### PR TITLE
chore(deps): bump sdk dependency to v0.1.1 in sdkx and examples

### DIFF
--- a/examples/voice-pipeline/go.mod
+++ b/examples/voice-pipeline/go.mod
@@ -3,7 +3,7 @@ module github.com/GizClaw/flowcraft/examples/voice-pipeline
 go 1.25.0
 
 require (
-	github.com/GizClaw/flowcraft/sdk v0.1.0
+	github.com/GizClaw/flowcraft/sdk v0.1.1
 	github.com/GizClaw/flowcraft/sdkx v0.1.0
 	github.com/charmbracelet/bubbles v0.20.0
 	github.com/charmbracelet/bubbletea v1.1.0

--- a/examples/voice-pipeline/go.sum
+++ b/examples/voice-pipeline/go.sum
@@ -1,5 +1,5 @@
-github.com/GizClaw/flowcraft/sdk v0.1.0 h1:b3DQPAz1U/isF8Gf1eapeWUhe2zO3v2gKEB03B1eGi4=
-github.com/GizClaw/flowcraft/sdk v0.1.0/go.mod h1:6zJ5bEbbwHFrl9yioeNlF3Lf2HFcDKKeoE+0VMR4OQM=
+github.com/GizClaw/flowcraft/sdk v0.1.1 h1:qQvaW+lR9NEEOF9NuPRPTsxefKJxYnbLpPJJfmAWfI4=
+github.com/GizClaw/flowcraft/sdk v0.1.1/go.mod h1:6zJ5bEbbwHFrl9yioeNlF3Lf2HFcDKKeoE+0VMR4OQM=
 github.com/GizClaw/flowcraft/sdkx v0.1.0 h1:uClkTdHT/0PxbvgAAIYfubvhCUlkh4nRoYv1TyL+JSo=
 github.com/GizClaw/flowcraft/sdkx v0.1.0/go.mod h1:TnCHQoY0Ta4ulm4j9D9JnQjq840h5cM3ScTEmQMj3Ec=
 github.com/Masterminds/semver/v3 v3.2.1 h1:RN9w6+7QoMeJVGyfmbcgs28Br8cvmnucEXnY0rYXWg0=

--- a/sdkx/go.mod
+++ b/sdkx/go.mod
@@ -2,7 +2,7 @@ module github.com/GizClaw/flowcraft/sdkx
 
 go 1.25.0
 
-require github.com/GizClaw/flowcraft/sdk v0.1.0
+require github.com/GizClaw/flowcraft/sdk v0.1.1
 
 require (
 	github.com/PuerkitoBio/goquery v1.11.0

--- a/sdkx/go.sum
+++ b/sdkx/go.sum
@@ -8,8 +8,8 @@ github.com/Azure/azure-sdk-for-go/sdk/internal v1.10.0/go.mod h1:iZDifYGJTIgIIkY
 github.com/AzureAD/microsoft-authentication-library-for-go v1.2.2 h1:XHOnouVk1mxXfQidrMEnLlPk9UMeRtyBTnEFtxkV0kU=
 github.com/AzureAD/microsoft-authentication-library-for-go v1.2.2/go.mod h1:wP83P5OoQ5p6ip3ScPr0BAq0BvuPAvacpEuSzyouqAI=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
-github.com/GizClaw/flowcraft/sdk v0.1.0 h1:b3DQPAz1U/isF8Gf1eapeWUhe2zO3v2gKEB03B1eGi4=
-github.com/GizClaw/flowcraft/sdk v0.1.0/go.mod h1:6zJ5bEbbwHFrl9yioeNlF3Lf2HFcDKKeoE+0VMR4OQM=
+github.com/GizClaw/flowcraft/sdk v0.1.1 h1:qQvaW+lR9NEEOF9NuPRPTsxefKJxYnbLpPJJfmAWfI4=
+github.com/GizClaw/flowcraft/sdk v0.1.1/go.mod h1:6zJ5bEbbwHFrl9yioeNlF3Lf2HFcDKKeoE+0VMR4OQM=
 github.com/PuerkitoBio/goquery v1.11.0 h1:jZ7pwMQXIITcUXNH83LLk+txlaEy6NVOfTuP43xxfqw=
 github.com/PuerkitoBio/goquery v1.11.0/go.mod h1:wQHgxUOU3JGuj3oD/QFfxUdlzW6xPHfqyHre6VMY4DQ=
 github.com/andybalholm/cascadia v1.3.3 h1:AG2YHrzJIm4BZ19iwJ/DAua6Btl3IwJX+VI4kktS1LM=


### PR DESCRIPTION
## Summary

- Bump `github.com/GizClaw/flowcraft/sdk` from `v0.1.0` to `v0.1.1` in `sdkx/go.mod` and `examples/voice-pipeline/go.mod`.
- Ensures a consistent and CI-verified dependency set when external projects reference `sdk v0.1.1` alongside `sdkx`.

## Changed files

| File | Change |
|------|--------|
| `sdkx/go.mod` | `sdk v0.1.0` → `v0.1.1` |
| `sdkx/go.sum` | Updated checksums |
| `examples/voice-pipeline/go.mod` | `sdk v0.1.0` → `v0.1.1` |
| `examples/voice-pipeline/go.sum` | Updated checksums |

## Test plan

- [x] CI passes (all existing sdkx and examples tests)
- [x] No code changes, dependency bump only


Made with [Cursor](https://cursor.com)