### PR TITLE
fix(adapter): inject default variable resolver in graphRunnable.Execute

### DIFF
--- a/sdk/graph/adapter/strategy.go
+++ b/sdk/graph/adapter/strategy.go
@@ -9,6 +9,7 @@ import (
 	"github.com/GizClaw/flowcraft/sdk/graph/compiler"
 	"github.com/GizClaw/flowcraft/sdk/graph/executor"
 	"github.com/GizClaw/flowcraft/sdk/graph/node"
+	"github.com/GizClaw/flowcraft/sdk/graph/variable"
 	"github.com/GizClaw/flowcraft/sdk/workflow"
 )
 
@@ -108,7 +109,9 @@ func (r *graphRunnable) Execute(ctx context.Context, board *workflow.Board, req 
 	if err != nil {
 		return board, err
 	}
-	var execOpts []executor.RunOption
+	execOpts := []executor.RunOption{
+		executor.WithResolver(variable.NewResolver()),
+	}
 	if req != nil && req.Extensions != nil {
 		if raw, ok := req.Extensions[ExtExecutorRunOpts]; ok {
 			if sl, ok := raw.([]executor.RunOption); ok {


### PR DESCRIPTION
## Summary

- **Bug**: `adapter.graphRunnable.Execute()` did not inject a default `variable.NewResolver()` like `executor.Runner.Run()` does, causing `${board.xxx}` variable references in node configs to go unresolved when graphs are executed through the workflow adapter.
- **Fix**: Pre-populate `execOpts` with `executor.WithResolver(variable.NewResolver())` in `graphRunnable.Execute()`, matching the behavior of `Runner.Run()`.
- Callers can still override the resolver via `ExtExecutorRunOpts`.

## Test plan

- [x] `go build ./graph/adapter/...` compiles successfully
- [x] `go test ./graph/adapter/...` all tests pass
- [ ] Verify that a GraphDefinition containing `${board.xxx}` references resolves variables correctly when executed through the adapter path