### PR TITLE
test(adapter): add variable resolution regression test

### DIFF
--- a/sdk/graph/adapter/strategy_test.go
+++ b/sdk/graph/adapter/strategy_test.go
@@ -133,6 +133,51 @@ func TestNewGraphRunnable_WithCustomExecutor(t *testing.T) {
 	}
 }
 
+func TestGraphRunnable_ResolvesVariableReferences(t *testing.T) {
+	def := &graph.GraphDefinition{
+		Name:  "var-resolve",
+		Entry: "s1",
+		Nodes: []graph.NodeDefinition{
+			{
+				ID:   "s1",
+				Type: "script",
+				Config: map[string]any{
+					"source":   `board.setVar("resolved_greeting", config.greeting);`,
+					"greeting": "${board.greeting}",
+				},
+			},
+		},
+	}
+
+	cg, err := compiler.NewCompiler().Compile(def)
+	if err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+
+	deps := workflow.NewDependencies()
+	fac := node.NewFactory(node.WithScriptRuntime(jsrt.New()))
+	workflow.SetDep(deps, DepNodeFactory, fac)
+
+	s := FromCompiled(cg)
+	runnable, err := s.Build(context.Background(), deps)
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+
+	board := workflow.NewBoard()
+	board.SetVar("greeting", "hello from board")
+
+	result, err := runnable.Execute(context.Background(), board, nil)
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+
+	got := result.GetVarString("resolved_greeting")
+	if got != "hello from board" {
+		t.Fatalf("expected resolved_greeting=%q, got %q (variable reference was not resolved)", "hello from board", got)
+	}
+}
+
 func TestFromDefinition_CompiledCacheHit(t *testing.T) {
 	def := &graph.GraphDefinition{
 		Name:  "cache-test",

--- a/sdkx/go.mod
+++ b/sdkx/go.mod
@@ -2,7 +2,7 @@ module github.com/GizClaw/flowcraft/sdkx
 
 go 1.25.0
 
-require github.com/GizClaw/flowcraft/sdk v0.1.2
+require github.com/GizClaw/flowcraft/sdk v0.1.1
 
 require (
 	github.com/PuerkitoBio/goquery v1.11.0

--- a/sdkx/go.mod
+++ b/sdkx/go.mod
@@ -2,7 +2,7 @@ module github.com/GizClaw/flowcraft/sdkx
 
 go 1.25.0
 
-require github.com/GizClaw/flowcraft/sdk v0.1.1
+require github.com/GizClaw/flowcraft/sdk v0.1.2
 
 require (
 	github.com/PuerkitoBio/goquery v1.11.0


### PR DESCRIPTION
## Summary

- Add regression test `TestGraphRunnable_ResolvesVariableReferences` to verify that `${board.xxx}` references in node configs are correctly resolved when executed through the adapter path (covers the fix in #4).

## After merge

1. Tag `sdk/v0.1.2` on the merge commit
2. Follow-up PR: bump sdkx dependency to `sdk v0.1.2`, then tag `sdkx/v0.1.2`

## Test plan

- [x] `go test ./graph/adapter/...` — all 11 tests pass
- [x] Verified the new test fails without the #4 fix (resolver not injected → variable stays as raw `${board.greeting}`)