### PR TITLE
chore(deps): bump sdkx dependency to sdk v0.1.2

### DIFF
--- a/sdkx/go.mod
+++ b/sdkx/go.mod
@@ -2,7 +2,7 @@ module github.com/GizClaw/flowcraft/sdkx
 
 go 1.25.0
 
-require github.com/GizClaw/flowcraft/sdk v0.1.1
+require github.com/GizClaw/flowcraft/sdk v0.1.2
 
 require (
 	github.com/PuerkitoBio/goquery v1.11.0

--- a/sdkx/go.sum
+++ b/sdkx/go.sum
@@ -8,8 +8,8 @@ github.com/Azure/azure-sdk-for-go/sdk/internal v1.10.0/go.mod h1:iZDifYGJTIgIIkY
 github.com/AzureAD/microsoft-authentication-library-for-go v1.2.2 h1:XHOnouVk1mxXfQidrMEnLlPk9UMeRtyBTnEFtxkV0kU=
 github.com/AzureAD/microsoft-authentication-library-for-go v1.2.2/go.mod h1:wP83P5OoQ5p6ip3ScPr0BAq0BvuPAvacpEuSzyouqAI=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
-github.com/GizClaw/flowcraft/sdk v0.1.1 h1:qQvaW+lR9NEEOF9NuPRPTsxefKJxYnbLpPJJfmAWfI4=
-github.com/GizClaw/flowcraft/sdk v0.1.1/go.mod h1:6zJ5bEbbwHFrl9yioeNlF3Lf2HFcDKKeoE+0VMR4OQM=
+github.com/GizClaw/flowcraft/sdk v0.1.2 h1:11YjQn3Vpbi99W+6RakiV9Nm5ZB23DgtbVnwQdnmN8o=
+github.com/GizClaw/flowcraft/sdk v0.1.2/go.mod h1:6zJ5bEbbwHFrl9yioeNlF3Lf2HFcDKKeoE+0VMR4OQM=
 github.com/PuerkitoBio/goquery v1.11.0 h1:jZ7pwMQXIITcUXNH83LLk+txlaEy6NVOfTuP43xxfqw=
 github.com/PuerkitoBio/goquery v1.11.0/go.mod h1:wQHgxUOU3JGuj3oD/QFfxUdlzW6xPHfqyHre6VMY4DQ=
 github.com/andybalholm/cascadia v1.3.3 h1:AG2YHrzJIm4BZ19iwJ/DAua6Btl3IwJX+VI4kktS1LM=


### PR DESCRIPTION
## Summary

- Bump `sdkx/go.mod` dependency from `sdk v0.1.1` to `sdk v0.1.2`.
- `sdk v0.1.2` includes the adapter variable resolver fix (#4) and its regression test (#5).

## After merge

Tag `sdkx/v0.1.2` on the merge commit.

## Test plan

- [x] `go mod tidy` succeeds with the new version
- [ ] CI passes (lint + tests for sdk and sdkx)


Made with [Cursor](https://cursor.com)