### PR TITLE
fix(memory): separate context from extraction target in extractCandidates

### DIFF
--- a/sdk/memory/extractor.go
+++ b/sdk/memory/extractor.go
@@ -205,16 +205,11 @@ func (e *MemoryExtractor) Extract(ctx context.Context, input ExtractInput) error
 }
 
 func extractCandidates(ctx context.Context, l llm.LLM, input ExtractInput, ecfg ExtractorConfig) ([]CandidateMemory, error) {
-	messages := input.Messages
-	if len(input.ContextMessages) > 0 {
-		messages = input.ContextMessages
-	}
-
 	var convText string
 	if ecfg.FormatMessages != nil {
-		convText = ecfg.FormatMessages(messages, input.Source)
+		convText = ecfg.FormatMessages(input.Messages, input.Source)
 	} else {
-		convText = defaultFormatMessages(messages)
+		convText = defaultFormatMessages(input.Messages)
 	}
 
 	if convText == "" {
@@ -235,10 +230,29 @@ func extractCandidates(ctx context.Context, l llm.LLM, input ExtractInput, ecfg 
 	}
 
 	prompt := fmt.Sprintf(promptTpl, convText)
+
+	var msgs []llm.Message
+	if len(input.ContextMessages) > 0 {
+		var ctxText string
+		if ecfg.FormatMessages != nil {
+			ctxText = ecfg.FormatMessages(input.ContextMessages, input.Source)
+		} else {
+			ctxText = defaultFormatMessages(input.ContextMessages)
+		}
+		ctxBudget := maxRunes * 3 / 10
+		if r := []rune(ctxText); len(r) > ctxBudget {
+			ctxText = string(r[len(r)-ctxBudget:])
+		}
+		if ctxText != "" {
+			msgs = append(msgs, llm.NewTextMessage(llm.RoleSystem,
+				"Earlier conversation for reference only. "+
+					"Do NOT extract memories from this section.\n\n"+ctxText))
+		}
+	}
+	msgs = append(msgs, llm.NewTextMessage(llm.RoleUser, prompt))
+
 	jsonOpt := jsonOutputOption(l, extractionSchema())
-	resp, _, err := l.Generate(ctx, []llm.Message{
-		llm.NewTextMessage(llm.RoleUser, prompt),
-	}, jsonOpt)
+	resp, _, err := l.Generate(ctx, msgs, jsonOpt)
 	if err != nil {
 		return nil, err
 	}

--- a/sdk/memory/extractor_test.go
+++ b/sdk/memory/extractor_test.go
@@ -473,14 +473,12 @@ func TestExtractWithPostProcess_FilterAll(t *testing.T) {
 }
 
 func TestExtractWithContextMessages(t *testing.T) {
-	var receivedPrompt string
+	var receivedMessages []llm.Message
 
 	store := &mergeFallbackStore{}
 	resolver := &mergeFallbackResolver{
 		generate: func(_ context.Context, msgs []llm.Message, _ ...llm.GenerateOption) (llm.Message, llm.TokenUsage, error) {
-			if len(msgs) > 0 {
-				receivedPrompt = msgs[0].Content()
-			}
+			receivedMessages = msgs
 			return llm.Message{
 				Role:  llm.RoleAssistant,
 				Parts: []llm.Part{{Type: llm.PartText, Text: `[]`}},
@@ -502,8 +500,53 @@ func TestExtractWithContextMessages(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !strings.Contains(receivedPrompt, "earlier context") {
-		t.Fatal("expected ContextMessages to be used instead of Messages")
+	if len(receivedMessages) != 2 {
+		t.Fatalf("expected 2 messages (system + user), got %d", len(receivedMessages))
+	}
+	if receivedMessages[0].Role != llm.RoleSystem {
+		t.Fatalf("expected first message to be system, got %s", receivedMessages[0].Role)
+	}
+	sysContent := receivedMessages[0].Content()
+	if !strings.Contains(sysContent, "earlier context") {
+		t.Fatal("expected system message to contain ContextMessages content")
+	}
+	if !strings.Contains(sysContent, "Do NOT extract") {
+		t.Fatal("expected system message to contain extraction restriction")
+	}
+	userContent := receivedMessages[1].Content()
+	if !strings.Contains(userContent, "incremental only") {
+		t.Fatal("expected user message to contain Messages content")
+	}
+}
+
+func TestExtractWithoutContextMessages(t *testing.T) {
+	var receivedMessages []llm.Message
+
+	store := &mergeFallbackStore{}
+	resolver := &mergeFallbackResolver{
+		generate: func(_ context.Context, msgs []llm.Message, _ ...llm.GenerateOption) (llm.Message, llm.TokenUsage, error) {
+			receivedMessages = msgs
+			return llm.Message{
+				Role:  llm.RoleAssistant,
+				Parts: []llm.Part{{Type: llm.PartText, Text: `[]`}},
+			}, llm.TokenUsage{}, nil
+		},
+	}
+
+	extractor := NewMemoryExtractor(resolver, store, LongTermConfig{}, ExtractorConfig{})
+	err := extractor.Extract(context.Background(), ExtractInput{
+		RuntimeID: "agent1",
+		Messages:  []llm.Message{llm.NewTextMessage(llm.RoleUser, "hello world")},
+		Source:    MemorySource{RuntimeID: "owner"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(receivedMessages) != 1 {
+		t.Fatalf("expected 1 message (user only) when no ContextMessages, got %d", len(receivedMessages))
+	}
+	if receivedMessages[0].Role != llm.RoleUser {
+		t.Fatalf("expected user message, got %s", receivedMessages[0].Role)
 	}
 }
 


### PR DESCRIPTION
## Summary

- **Previously**, `extractCandidates` replaced `Messages` with `ContextMessages` when the latter was non-empty, causing the LLM to extract memories from the entire context window (including already-processed old messages), leading to duplicate extractions and wasted tokens.
- **Now**, `ContextMessages` is delivered as a **system message** with a "Do NOT extract" instruction, while `Messages` remains the sole extraction target in the user message. This leverages the LLM's native role-based message separation — a much stronger signal than in-text markers.
- Context text is independently truncated to 30% of `MaxConversationRunes` to prevent it from crowding out the extraction target.
- When `ContextMessages` is nil, behavior is entirely unchanged (backward compatible).

## Test plan

- [x] Updated `TestExtractWithContextMessages` to verify the two-message structure (system + user), system message contains context content and restriction, user message contains only new messages.
- [x] Added `TestExtractWithoutContextMessages` to verify backward-compatible single user message when no context is provided.
- [x] All 120+ existing memory package tests pass.


Made with [Cursor](https://cursor.com)