### PR TITLE
chore(deps): bump sdkx dependency to sdk v0.1.4

### DIFF
--- a/sdkx/go.mod
+++ b/sdkx/go.mod
@@ -2,7 +2,7 @@ module github.com/GizClaw/flowcraft/sdkx
 
 go 1.25.0
 
-require github.com/GizClaw/flowcraft/sdk v0.1.3
+require github.com/GizClaw/flowcraft/sdk v0.1.4
 
 require (
 	github.com/PuerkitoBio/goquery v1.11.0

--- a/sdkx/go.sum
+++ b/sdkx/go.sum
@@ -8,8 +8,8 @@ github.com/Azure/azure-sdk-for-go/sdk/internal v1.10.0/go.mod h1:iZDifYGJTIgIIkY
 github.com/AzureAD/microsoft-authentication-library-for-go v1.2.2 h1:XHOnouVk1mxXfQidrMEnLlPk9UMeRtyBTnEFtxkV0kU=
 github.com/AzureAD/microsoft-authentication-library-for-go v1.2.2/go.mod h1:wP83P5OoQ5p6ip3ScPr0BAq0BvuPAvacpEuSzyouqAI=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
-github.com/GizClaw/flowcraft/sdk v0.1.3 h1:7mbd0bZV99sp/3QvC8xHO9VvNg9lSWnL4Bv8YslKhYk=
-github.com/GizClaw/flowcraft/sdk v0.1.3/go.mod h1:6zJ5bEbbwHFrl9yioeNlF3Lf2HFcDKKeoE+0VMR4OQM=
+github.com/GizClaw/flowcraft/sdk v0.1.4 h1:Ff/eNSRMR+AwVHbvk32Iydfv+I1Cw9IZ3HiW7eCur3I=
+github.com/GizClaw/flowcraft/sdk v0.1.4/go.mod h1:npXXZur4RskX1Zx6tZTEua+c7sfGTHQGX6kfHnTCwP4=
 github.com/PuerkitoBio/goquery v1.11.0 h1:jZ7pwMQXIITcUXNH83LLk+txlaEy6NVOfTuP43xxfqw=
 github.com/PuerkitoBio/goquery v1.11.0/go.mod h1:wQHgxUOU3JGuj3oD/QFfxUdlzW6xPHfqyHre6VMY4DQ=
 github.com/andybalholm/cascadia v1.3.3 h1:AG2YHrzJIm4BZ19iwJ/DAua6Btl3IwJX+VI4kktS1LM=


### PR DESCRIPTION
## Summary

- Bump `sdkx` dependency from `sdk v0.1.3` to `sdk v0.1.4`

Follows `sdk/v0.1.4` tag which includes LLM round execution, script bindings, Lua runtime, hybrid memory, and related review fixes from PR #10.

After merge, `sdkx/v0.1.5` will be tagged.


Made with [Cursor](https://cursor.com)