### PR TITLE
fix(sdk): coerce string board vars to numeric types before JSON config parsing

### DIFF
--- a/sdk/graph/node/llm.go
+++ b/sdk/graph/node/llm.go
@@ -265,6 +265,7 @@ func ConfigFromMap(m map[string]any) (LLMConfig, error) {
 	if m == nil {
 		return cfg, nil
 	}
+	m = llm.CoerceMapForStruct[LLMConfig](m)
 	data, err := json.Marshal(m)
 	if err != nil {
 		return cfg, fmt.Errorf("node: marshal config map: %w", err)

--- a/sdk/graph/node/llm_test.go
+++ b/sdk/graph/node/llm_test.go
@@ -102,6 +102,40 @@ func TestConfigFromMap_TemperatureFloat(t *testing.T) {
 	}
 }
 
+func TestConfigFromMap_TemperatureString(t *testing.T) {
+	m := map[string]any{"temperature": "0.8"}
+	cfg := mustConfigFromMap(t, m)
+	if cfg.Temperature == nil || *cfg.Temperature != 0.8 {
+		t.Fatalf("Temperature = %v, want 0.8", cfg.Temperature)
+	}
+	if _, ok := m["temperature"].(string); !ok {
+		t.Fatalf("input map should not be mutated, got %T", m["temperature"])
+	}
+}
+
+func TestConfigFromMap_MaxTokensString(t *testing.T) {
+	cfg := mustConfigFromMap(t, map[string]any{"max_tokens": "2048"})
+	if cfg.MaxTokens != 2048 {
+		t.Fatalf("MaxTokens = %d, want 2048", cfg.MaxTokens)
+	}
+}
+
+func TestConfigFromMap_JSONModeString(t *testing.T) {
+	cfg := mustConfigFromMap(t, map[string]any{"json_mode": "true"})
+	if !cfg.JSONMode {
+		t.Fatal("JSONMode should be true")
+	}
+}
+
+func TestConfigFromMap_UnresolvedRef(t *testing.T) {
+	_, err := ConfigFromMap(map[string]any{
+		"temperature": "${board.missing}",
+	})
+	if err == nil {
+		t.Fatal("unresolved ref should produce an error")
+	}
+}
+
 func TestLLMNode_SummaryIndexInjection(t *testing.T) {
 	board := newTestBoard()
 	board.SetVar("messages", []model.Message{

--- a/sdk/llm/round_config.go
+++ b/sdk/llm/round_config.go
@@ -3,6 +3,10 @@ package llm
 import (
 	"encoding/json"
 	"fmt"
+	"maps"
+	"reflect"
+	"strconv"
+	"strings"
 )
 
 // RoundConfig configures the LLM call parameters for one round.
@@ -16,12 +20,101 @@ type RoundConfig struct {
 	ToolNames   []string `json:"tool_names,omitempty" yaml:"tool_names,omitempty"`
 }
 
+// CoerceMapForStruct uses reflection on T's json tags to coerce string values
+// in m to the numeric/bool types expected by the target struct fields. This
+// allows JSON round-trip (Marshal → Unmarshal) to succeed when map values
+// arrive as strings (e.g. from ${board.temperature} template resolution).
+//
+// The input map is not modified; a shallow clone is returned.
+func CoerceMapForStruct[T any](m map[string]any) map[string]any {
+	if m == nil {
+		return nil
+	}
+	var zero T
+	t := reflect.TypeOf(zero)
+	if t.Kind() == reflect.Ptr {
+		t = t.Elem()
+	}
+	if t.Kind() != reflect.Struct {
+		return m
+	}
+
+	result := maps.Clone(m)
+	for i := range t.NumField() {
+		field := t.Field(i)
+		tag := field.Tag.Get("json")
+		if tag == "" || tag == "-" {
+			continue
+		}
+		key, _, _ := strings.Cut(tag, ",")
+		if key == "" {
+			continue
+		}
+		val, ok := result[key]
+		if !ok {
+			continue
+		}
+		str, ok := val.(string)
+		if !ok {
+			continue
+		}
+
+		target := field.Type
+		if target.Kind() == reflect.Ptr {
+			target = target.Elem()
+		}
+		if target.Kind() == reflect.String {
+			continue
+		}
+		if coerced, ok := coerceString(str, target.Kind()); ok {
+			result[key] = coerced
+		}
+	}
+	return result
+}
+
+func coerceString(s string, kind reflect.Kind) (any, bool) {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return nil, false
+	}
+	switch kind {
+	case reflect.Float32, reflect.Float64:
+		f, err := strconv.ParseFloat(s, 64)
+		if err != nil {
+			return nil, false
+		}
+		return f, true
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		i, err := strconv.ParseInt(s, 10, 64)
+		if err != nil {
+			return nil, false
+		}
+		return i, true
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+		u, err := strconv.ParseUint(s, 10, 64)
+		if err != nil {
+			return nil, false
+		}
+		return u, true
+	case reflect.Bool:
+		b, err := strconv.ParseBool(s)
+		if err != nil {
+			return nil, false
+		}
+		return b, true
+	default:
+		return nil, false
+	}
+}
+
 // RoundConfigFromMap parses RoundConfig from a generic map via JSON round-trip.
 func RoundConfigFromMap(m map[string]any) (RoundConfig, error) {
 	var cfg RoundConfig
 	if m == nil {
 		return cfg, nil
 	}
+	m = CoerceMapForStruct[RoundConfig](m)
 	data, err := json.Marshal(m)
 	if err != nil {
 		return cfg, fmt.Errorf("llm: marshal config map: %w", err)

--- a/sdk/llm/round_test.go
+++ b/sdk/llm/round_test.go
@@ -302,3 +302,154 @@ func TestRoundConfigFromMap_TemperatureZero(t *testing.T) {
 		t.Fatalf("Temperature = %v, want 0", *cfg.Temperature)
 	}
 }
+
+func TestRoundConfigFromMap_TemperatureString(t *testing.T) {
+	m := map[string]any{"temperature": "0.75"}
+	cfg, err := RoundConfigFromMap(m)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.Temperature == nil || *cfg.Temperature != 0.75 {
+		t.Fatalf("Temperature = %v", cfg.Temperature)
+	}
+	if _, ok := m["temperature"].(string); !ok {
+		t.Fatalf("RoundConfigFromMap must not mutate the input map, got %T", m["temperature"])
+	}
+}
+
+func TestRoundConfigFromMap_MaxTokensString(t *testing.T) {
+	cfg, err := RoundConfigFromMap(map[string]any{"max_tokens": "4096"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.MaxTokens != 4096 {
+		t.Fatalf("MaxTokens = %d, want 4096", cfg.MaxTokens)
+	}
+}
+
+func TestRoundConfigFromMap_JSONModeString(t *testing.T) {
+	cfg, err := RoundConfigFromMap(map[string]any{"json_mode": "true"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !cfg.JSONMode {
+		t.Fatal("JSONMode should be true")
+	}
+}
+
+func TestRoundConfigFromMap_UnresolvedRef(t *testing.T) {
+	_, err := RoundConfigFromMap(map[string]any{"temperature": "${board.missing}"})
+	if err == nil {
+		t.Fatal("unresolved ref should produce an error")
+	}
+}
+
+// ── CoerceMapForStruct tests ──
+
+type coerceTestStruct struct {
+	F64    float64  `json:"f64"`
+	PtrF64 *float64 `json:"ptr_f64"`
+	I64    int64    `json:"i64"`
+	B      bool     `json:"b"`
+	S      string   `json:"s"`
+	U      uint32   `json:"u"`
+}
+
+func TestCoerceMapForStruct_Nil(t *testing.T) {
+	got := CoerceMapForStruct[coerceTestStruct](nil)
+	if got != nil {
+		t.Fatalf("expected nil, got %v", got)
+	}
+}
+
+func TestCoerceMapForStruct_StringToFloat(t *testing.T) {
+	m := map[string]any{"f64": "1.5", "ptr_f64": "0.3"}
+	got := CoerceMapForStruct[coerceTestStruct](m)
+	if v, ok := got["f64"].(float64); !ok || v != 1.5 {
+		t.Fatalf("f64: got %T %v", got["f64"], got["f64"])
+	}
+	if v, ok := got["ptr_f64"].(float64); !ok || v != 0.3 {
+		t.Fatalf("ptr_f64: got %T %v", got["ptr_f64"], got["ptr_f64"])
+	}
+}
+
+func TestCoerceMapForStruct_StringToInt(t *testing.T) {
+	m := map[string]any{"i64": "42"}
+	got := CoerceMapForStruct[coerceTestStruct](m)
+	if v, ok := got["i64"].(int64); !ok || v != 42 {
+		t.Fatalf("i64: got %T %v", got["i64"], got["i64"])
+	}
+}
+
+func TestCoerceMapForStruct_StringToUint(t *testing.T) {
+	m := map[string]any{"u": "100"}
+	got := CoerceMapForStruct[coerceTestStruct](m)
+	if v, ok := got["u"].(uint64); !ok || v != 100 {
+		t.Fatalf("u: got %T %v", got["u"], got["u"])
+	}
+}
+
+func TestCoerceMapForStruct_StringToBool(t *testing.T) {
+	m := map[string]any{"b": "true"}
+	got := CoerceMapForStruct[coerceTestStruct](m)
+	if v, ok := got["b"].(bool); !ok || !v {
+		t.Fatalf("b: got %T %v", got["b"], got["b"])
+	}
+}
+
+func TestCoerceMapForStruct_NonStringUntouched(t *testing.T) {
+	m := map[string]any{"f64": 2.5, "i64": int64(10), "b": false, "s": "hello"}
+	got := CoerceMapForStruct[coerceTestStruct](m)
+	if got["f64"] != 2.5 || got["i64"] != int64(10) || got["b"] != false || got["s"] != "hello" {
+		t.Fatalf("non-string values should pass through: %v", got)
+	}
+}
+
+func TestCoerceMapForStruct_InvalidStringKept(t *testing.T) {
+	m := map[string]any{"f64": "not-a-number", "i64": "abc", "b": "nope"}
+	got := CoerceMapForStruct[coerceTestStruct](m)
+	if got["f64"] != "not-a-number" {
+		t.Fatalf("invalid float string should be kept, got %v", got["f64"])
+	}
+	if got["i64"] != "abc" {
+		t.Fatalf("invalid int string should be kept, got %v", got["i64"])
+	}
+	if got["b"] != "nope" {
+		t.Fatalf("invalid bool string should be kept, got %v", got["b"])
+	}
+}
+
+func TestCoerceMapForStruct_EmptyStringKept(t *testing.T) {
+	m := map[string]any{"f64": "", "i64": "  "}
+	got := CoerceMapForStruct[coerceTestStruct](m)
+	if got["f64"] != "" {
+		t.Fatalf("empty string should be kept, got %v", got["f64"])
+	}
+	if got["i64"] != "  " {
+		t.Fatalf("whitespace string should be kept, got %v", got["i64"])
+	}
+}
+
+func TestCoerceMapForStruct_StringFieldUntouched(t *testing.T) {
+	m := map[string]any{"s": "hello world"}
+	got := CoerceMapForStruct[coerceTestStruct](m)
+	if got["s"] != "hello world" {
+		t.Fatalf("string field should be untouched, got %v", got["s"])
+	}
+}
+
+func TestCoerceMapForStruct_DoesNotMutateInput(t *testing.T) {
+	m := map[string]any{"f64": "1.0", "s": "keep"}
+	_ = CoerceMapForStruct[coerceTestStruct](m)
+	if _, ok := m["f64"].(string); !ok {
+		t.Fatalf("input map was mutated: f64 is %T", m["f64"])
+	}
+}
+
+func TestCoerceMapForStruct_ExtraKeysPassThrough(t *testing.T) {
+	m := map[string]any{"f64": "1.0", "unknown_key": "whatever"}
+	got := CoerceMapForStruct[coerceTestStruct](m)
+	if got["unknown_key"] != "whatever" {
+		t.Fatalf("extra keys should pass through, got %v", got["unknown_key"])
+	}
+}

--- a/sdk/script/bindings/bridge_llm.go
+++ b/sdk/script/bindings/bridge_llm.go
@@ -133,6 +133,7 @@ func mergeRoundConfig(base llm.RoundConfig, overrides map[string]any) llm.RoundC
 	for k, v := range overrides {
 		m[k] = v
 	}
+	m = llm.CoerceMapForStruct[llm.RoundConfig](m)
 	merged, err := json.Marshal(m)
 	if err != nil {
 		return base

--- a/sdk/script/bindings/bridge_llm_test.go
+++ b/sdk/script/bindings/bridge_llm_test.go
@@ -56,3 +56,21 @@ func TestNormalizeLLMOverrides_NonMap(t *testing.T) {
 		t.Fatalf("expected nil for non-map, got %v", got)
 	}
 }
+
+func TestMergeRoundConfig_StringOverrides(t *testing.T) {
+	base := llm.RoundConfig{Model: "m1", MaxTokens: 100}
+	out := mergeRoundConfig(base, map[string]any{
+		"temperature": "0.3",
+		"max_tokens":  "2048",
+		"json_mode":   "true",
+	})
+	if out.Temperature == nil || *out.Temperature != 0.3 {
+		t.Fatalf("temperature = %v, want 0.3", out.Temperature)
+	}
+	if out.MaxTokens != 2048 {
+		t.Fatalf("max_tokens = %d, want 2048", out.MaxTokens)
+	}
+	if !out.JSONMode {
+		t.Fatal("json_mode should be true")
+	}
+}


### PR DESCRIPTION
## Summary

- Board template variables like `${board.temperature}` can resolve to Go strings (e.g. `"0.5"`) when the board var is stored as a string or goes through the `Resolve` string-interpolation path. The JSON round-trip (`json.Marshal` → `json.Unmarshal`) in `ConfigFromMap` / `RoundConfigFromMap` then fails because `encoding/json` cannot unmarshal a JSON string into `*float64` or `int64`.
- Add `CoerceMapForStruct[T]`, a generic reflection-based helper that reads `T`'s json tags to convert parseable string values to the expected field types (`float64`, `int64`, `bool`, etc.) before marshaling. Unparseable strings (e.g. unresolved `${board.missing}` refs) are left untouched so downstream `json.Unmarshal` correctly surfaces the error.
- Applied to all three JSON round-trip call sites: `llm.RoundConfigFromMap`, `node.ConfigFromMap`, and `bindings.mergeRoundConfig`.

## Test plan

- [x] `CoerceMapForStruct` unit tests: nil input, string→float/int/uint/bool, pointer fields, non-string passthrough, invalid/empty strings kept, string fields untouched, input map immutability, extra keys passthrough
- [x] `RoundConfigFromMap`: string temperature/max_tokens/json_mode parsed correctly, unresolved ref returns error, input map not mutated
- [x] `node.ConfigFromMap`: same string coercion coverage + unresolved ref error
- [x] `mergeRoundConfig`: string overrides from script layer merged correctly
- [x] Full `go test ./...` passes (sdk + internal)


Made with [Cursor](https://cursor.com)