### PR TITLE
ci: add auto-tag workflow for multi-module releases

### DIFF
--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -1,0 +1,120 @@
+name: Auto-tag modules
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "sdk/**"
+      - "sdkx/**"
+      - "plugin/**"
+
+permissions:
+  contents: write
+
+concurrency:
+  group: auto-tag
+  cancel-in-progress: false
+
+jobs:
+  tag:
+    name: Tag changed modules
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version: "1.25.x"
+
+      - name: Configure git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Detect changes and tag
+        run: |
+          set -euo pipefail
+
+          bump_patch() {
+            local tag=$1
+            local version=${tag##*/v}
+            local major minor patch
+            IFS='.' read -r major minor patch <<< "$version"
+            echo "${major}.${minor}.$((patch + 1))"
+          }
+
+          latest_tag() {
+            git tag -l "$1/v*" --sort=-v:refname | head -1
+          }
+
+          has_changes() {
+            local mod=$1 latest=$2
+            [ -n "$(git diff --name-only "$latest"..HEAD -- "$mod/")" ]
+          }
+
+          # tag_module tags a module if it has changes since its last tag.
+          # On success, writes the new version to $TAGGED_<MOD> env var.
+          tag_module() {
+            local mod=$1
+            local latest
+            latest=$(latest_tag "$mod")
+            if [ -z "$latest" ]; then
+              echo "::warning::No existing tag for $mod, skipping"
+              return
+            fi
+            if ! has_changes "$mod" "$latest"; then
+              echo "$mod: no changes since $latest"
+              return
+            fi
+            local new_version
+            new_version=$(bump_patch "$latest")
+            local new_tag="${mod}/v${new_version}"
+            echo "$mod: $latest -> $new_tag"
+            git tag "$new_tag"
+            git push origin "$new_tag"
+
+            local env_key
+            env_key="TAGGED_$(echo "$mod" | tr '[:lower:]' '[:upper:]')"
+            echo "${env_key}=${new_version}" >> "$GITHUB_ENV"
+          }
+
+          # Phase 1: tag leaf modules (plugin, sdk)
+          tag_module "plugin"
+          tag_module "sdk"
+
+      - name: Cascade sdk bump to sdkx
+        if: env.TAGGED_SDK != ''
+        run: |
+          set -euo pipefail
+          echo "sdkx: updating sdk dependency to v${TAGGED_SDK}"
+          cd sdkx
+          go get "github.com/GizClaw/flowcraft/sdk@v${TAGGED_SDK}"
+          go mod tidy
+          cd ..
+          git add sdkx/go.mod sdkx/go.sum
+          git commit -m "chore(sdkx): bump sdk dependency to v${TAGGED_SDK}"
+          git push origin main
+
+      - name: Tag sdkx
+        if: env.TAGGED_SDK != '' || success()
+        run: |
+          set -euo pipefail
+
+          latest=$(git tag -l "sdkx/v*" --sort=-v:refname | head -1)
+          if [ -z "$latest" ]; then
+            echo "::warning::No existing tag for sdkx, skipping"
+            exit 0
+          fi
+          if [ -z "$(git diff --name-only "$latest"..HEAD -- sdkx/)" ]; then
+            echo "sdkx: no changes since $latest"
+            exit 0
+          fi
+
+          version=${latest##*/v}
+          IFS='.' read -r major minor patch <<< "$version"
+          new_tag="sdkx/v${major}.${minor}.$((patch + 1))"
+          echo "sdkx: $latest -> $new_tag"
+          git tag "$new_tag"
+          git push origin "$new_tag"

--- a/sdkx/go.mod
+++ b/sdkx/go.mod
@@ -2,7 +2,7 @@ module github.com/GizClaw/flowcraft/sdkx
 
 go 1.25.0
 
-require github.com/GizClaw/flowcraft/sdk v0.1.4
+require github.com/GizClaw/flowcraft/sdk v0.1.5
 
 require (
 	github.com/PuerkitoBio/goquery v1.11.0

--- a/sdkx/go.sum
+++ b/sdkx/go.sum
@@ -8,8 +8,8 @@ github.com/Azure/azure-sdk-for-go/sdk/internal v1.10.0/go.mod h1:iZDifYGJTIgIIkY
 github.com/AzureAD/microsoft-authentication-library-for-go v1.2.2 h1:XHOnouVk1mxXfQidrMEnLlPk9UMeRtyBTnEFtxkV0kU=
 github.com/AzureAD/microsoft-authentication-library-for-go v1.2.2/go.mod h1:wP83P5OoQ5p6ip3ScPr0BAq0BvuPAvacpEuSzyouqAI=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
-github.com/GizClaw/flowcraft/sdk v0.1.4 h1:Ff/eNSRMR+AwVHbvk32Iydfv+I1Cw9IZ3HiW7eCur3I=
-github.com/GizClaw/flowcraft/sdk v0.1.4/go.mod h1:npXXZur4RskX1Zx6tZTEua+c7sfGTHQGX6kfHnTCwP4=
+github.com/GizClaw/flowcraft/sdk v0.1.5 h1:LsF4Cucz6bfkGnXkQoeUU+ca7uwE1RJJICfhpCOjasY=
+github.com/GizClaw/flowcraft/sdk v0.1.5/go.mod h1:npXXZur4RskX1Zx6tZTEua+c7sfGTHQGX6kfHnTCwP4=
 github.com/PuerkitoBio/goquery v1.11.0 h1:jZ7pwMQXIITcUXNH83LLk+txlaEy6NVOfTuP43xxfqw=
 github.com/PuerkitoBio/goquery v1.11.0/go.mod h1:wQHgxUOU3JGuj3oD/QFfxUdlzW6xPHfqyHre6VMY4DQ=
 github.com/andybalholm/cascadia v1.3.3 h1:AG2YHrzJIm4BZ19iwJ/DAua6Btl3IwJX+VI4kktS1LM=


### PR DESCRIPTION
## Summary

- Add `.github/workflows/auto-tag.yml` that automatically tags changed modules (`plugin`, `sdk`, `sdkx`) when PRs are merged to main. Tags are created in topological order (leaf modules first), and when `sdk` is tagged, `sdkx/go.mod` is automatically updated to the new version before tagging `sdkx`.
- Bump `sdkx` sdk dependency from `v0.1.4` to `v0.1.5` (corresponding to the fix in #12).

## Workflow behavior

```
merge to main (paths: sdk/**, sdkx/**, plugin/**)
  │
  ├─ Phase 1: tag leaf modules (plugin, sdk) if changed
  │
  ├─ Phase 2: if sdk was tagged, update sdkx/go.mod → commit → push
  │
  └─ Phase 3: tag sdkx if changed (own changes or cascaded go.mod bump)
```

- Only bumps patch version automatically; minor/major releases remain manual.
- `concurrency: cancel-in-progress: false` prevents tag races on rapid merges.
- Root module (`go.mod`) is intentionally excluded from auto-updates.

## Test plan

- [x] Verify workflow YAML syntax is valid
- [ ] Merge and confirm auto-tag runs correctly on next `sdk/` or `sdkx/` change


Made with [Cursor](https://cursor.com)