### PR TITLE
refactor(sdk): externalize template ref detection from CoerceMapForStruct

### DIFF
--- a/sdk/graph/executor/executor_test.go
+++ b/sdk/graph/executor/executor_test.go
@@ -620,3 +620,169 @@ func TestLocalExecutor_TypedResolution_UnresolvedFallback(t *testing.T) {
 		t.Fatalf("unresolved prompt: got %T %v", capturedConfig["prompt"], capturedConfig["prompt"])
 	}
 }
+
+func TestLocalExecutor_TemplateRef_BuildThenExecute(t *testing.T) {
+	var capturedConfig map[string]any
+
+	node := &configurableTestNode{
+		id: "llm1",
+		config: map[string]any{
+			"system_prompt": "${board.system_prompt}",
+			"temperature":   "${board.temperature}",
+			"max_tokens":    "${board.max_tokens}",
+			"json_mode":     "${board.json_mode}",
+			"model":         "openai/gpt-4o",
+		},
+		execFn: func(_ graph.ExecutionContext, b *graph.Board, cfg map[string]any) error {
+			capturedConfig = copyMap(cfg)
+			b.SetVar("done", true)
+			return nil
+		},
+	}
+
+	origConfig := copyMap(node.config)
+
+	g := graph.NewGraph(&graph.RawGraph{
+		Name:  "test",
+		Entry: "llm1",
+		Nodes: map[string]graph.Node{"llm1": node},
+		Edges: map[string][]graph.Edge{
+			"llm1": {{From: "llm1", To: graph.END}},
+		},
+		Reverse:        map[string][]string{graph.END: {"llm1"}},
+		SkipConditions: make(map[string]*graph.CompiledCondition),
+	}, graph.GraphMeta{})
+
+	board := graph.NewBoard()
+	board.SetVar("system_prompt", "You are a translator.")
+	board.SetVar("temperature", 0.3)
+	board.SetVar("max_tokens", 2048)
+	board.SetVar("json_mode", true)
+
+	exec := NewLocalExecutor()
+	_, err := exec.Execute(context.Background(), g, board, WithResolver(variable.NewResolver()))
+	if err != nil {
+		t.Fatalf("execute failed: %v", err)
+	}
+
+	// Verify resolved values reached the node during execution.
+	if s, ok := capturedConfig["system_prompt"].(string); !ok || s != "You are a translator." {
+		t.Fatalf("system_prompt: got %T %v", capturedConfig["system_prompt"], capturedConfig["system_prompt"])
+	}
+	if temp, ok := capturedConfig["temperature"].(float64); !ok || temp != 0.3 {
+		t.Fatalf("temperature: got %T %v", capturedConfig["temperature"], capturedConfig["temperature"])
+	}
+	if mt, ok := capturedConfig["max_tokens"].(int); !ok || mt != 2048 {
+		t.Fatalf("max_tokens: got %T %v", capturedConfig["max_tokens"], capturedConfig["max_tokens"])
+	}
+	if jm, ok := capturedConfig["json_mode"].(bool); !ok || !jm {
+		t.Fatalf("json_mode: got %T %v", capturedConfig["json_mode"], capturedConfig["json_mode"])
+	}
+
+	// Verify original config is restored after execution.
+	for k, v := range origConfig {
+		if node.config[k] != v {
+			t.Fatalf("config[%q] not restored: got %v, want %v", k, node.config[k], v)
+		}
+	}
+}
+
+func TestLocalExecutor_TemplateRef_StringNumericBoardVars(t *testing.T) {
+	var capturedConfig map[string]any
+
+	node := &configurableTestNode{
+		id: "n1",
+		config: map[string]any{
+			"temperature": "${board.temperature}",
+			"max_tokens":  "${board.max_tokens}",
+			"json_mode":   "${board.json_mode}",
+		},
+		execFn: func(_ graph.ExecutionContext, b *graph.Board, cfg map[string]any) error {
+			capturedConfig = copyMap(cfg)
+			b.SetVar("done", true)
+			return nil
+		},
+	}
+
+	g := graph.NewGraph(&graph.RawGraph{
+		Name:  "test",
+		Entry: "n1",
+		Nodes: map[string]graph.Node{"n1": node},
+		Edges: map[string][]graph.Edge{
+			"n1": {{From: "n1", To: graph.END}},
+		},
+		Reverse:        map[string][]string{graph.END: {"n1"}},
+		SkipConditions: make(map[string]*graph.CompiledCondition),
+	}, graph.GraphMeta{})
+
+	board := graph.NewBoard()
+	board.SetVar("temperature", "0.7")
+	board.SetVar("max_tokens", "4096")
+	board.SetVar("json_mode", "true")
+
+	exec := NewLocalExecutor()
+	_, err := exec.Execute(context.Background(), g, board, WithResolver(variable.NewResolver()))
+	if err != nil {
+		t.Fatalf("execute failed: %v", err)
+	}
+
+	// When board vars are strings, resolveTyped returns the string value.
+	// The node's SetConfig → CoerceMapForStruct should still handle them.
+	if capturedConfig["temperature"] != "0.7" {
+		t.Fatalf("temperature: got %T %v", capturedConfig["temperature"], capturedConfig["temperature"])
+	}
+	if capturedConfig["max_tokens"] != "4096" {
+		t.Fatalf("max_tokens: got %T %v", capturedConfig["max_tokens"], capturedConfig["max_tokens"])
+	}
+	if capturedConfig["json_mode"] != "true" {
+		t.Fatalf("json_mode: got %T %v", capturedConfig["json_mode"], capturedConfig["json_mode"])
+	}
+}
+
+func TestLocalExecutor_PartialTemplateRef_PreservesLiteral(t *testing.T) {
+	var capturedConfig map[string]any
+
+	node := &configurableTestNode{
+		id: "n1",
+		config: map[string]any{
+			"system_prompt": "Translate: ${board.lang}",
+			"temperature":   float64(0.5),
+			"model":         "${board.model}",
+		},
+		execFn: func(_ graph.ExecutionContext, b *graph.Board, cfg map[string]any) error {
+			capturedConfig = copyMap(cfg)
+			return nil
+		},
+	}
+
+	g := graph.NewGraph(&graph.RawGraph{
+		Name:  "test",
+		Entry: "n1",
+		Nodes: map[string]graph.Node{"n1": node},
+		Edges: map[string][]graph.Edge{
+			"n1": {{From: "n1", To: graph.END}},
+		},
+		Reverse:        map[string][]string{graph.END: {"n1"}},
+		SkipConditions: make(map[string]*graph.CompiledCondition),
+	}, graph.GraphMeta{})
+
+	board := graph.NewBoard()
+	board.SetVar("lang", "Chinese")
+	board.SetVar("model", "openai/gpt-4o")
+
+	exec := NewLocalExecutor()
+	_, err := exec.Execute(context.Background(), g, board, WithResolver(variable.NewResolver()))
+	if err != nil {
+		t.Fatalf("execute failed: %v", err)
+	}
+
+	if s, ok := capturedConfig["system_prompt"].(string); !ok || s != "Translate: Chinese" {
+		t.Fatalf("system_prompt: got %T %v", capturedConfig["system_prompt"], capturedConfig["system_prompt"])
+	}
+	if temp, ok := capturedConfig["temperature"].(float64); !ok || temp != 0.5 {
+		t.Fatalf("temperature: got %T %v, want 0.5", capturedConfig["temperature"], capturedConfig["temperature"])
+	}
+	if s, ok := capturedConfig["model"].(string); !ok || s != "openai/gpt-4o" {
+		t.Fatalf("model: got %T %v", capturedConfig["model"], capturedConfig["model"])
+	}
+}

--- a/sdk/graph/node/llm.go
+++ b/sdk/graph/node/llm.go
@@ -55,6 +55,7 @@ type LLMNode struct {
 	toolRegistry *tool.Registry
 	config       LLMConfig
 	rawConfig    map[string]any
+	isDeferred   func(string) bool
 }
 
 // NewLLMNode creates a new LLM node.
@@ -72,7 +73,7 @@ func (n *LLMNode) Config() map[string]any { return n.rawConfig }
 // resolved ${board.xxx} variables take effect (e.g. system_prompt).
 func (n *LLMNode) SetConfig(c map[string]any) {
 	n.rawConfig = c
-	cfg, err := ConfigFromMap(c)
+	cfg, err := ConfigFromMap(c, n.isDeferred)
 	if err != nil {
 		telemetry.Warn(context.Background(), "llm node: invalid config map",
 			otellog.String("node_id", n.id),
@@ -260,12 +261,13 @@ func (n *LLMNode) writeResults(
 }
 
 // ConfigFromMap parses an LLMConfig from a generic map via JSON round-trip.
-func ConfigFromMap(m map[string]any) (LLMConfig, error) {
+// isDeferred is passed through to CoerceMapForStruct; see its documentation.
+func ConfigFromMap(m map[string]any, isDeferred func(string) bool) (LLMConfig, error) {
 	var cfg LLMConfig
 	if m == nil {
 		return cfg, nil
 	}
-	m = llm.CoerceMapForStruct[LLMConfig](m)
+	m = llm.CoerceMapForStruct[LLMConfig](m, isDeferred)
 	data, err := json.Marshal(m)
 	if err != nil {
 		return cfg, fmt.Errorf("node: marshal config map: %w", err)

--- a/sdk/graph/node/llm_test.go
+++ b/sdk/graph/node/llm_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/GizClaw/flowcraft/sdk/graph"
+	"github.com/GizClaw/flowcraft/sdk/graph/variable"
 	"github.com/GizClaw/flowcraft/sdk/model"
 	"github.com/GizClaw/flowcraft/sdk/workflow"
 )
@@ -17,7 +18,7 @@ func pf64(v float64) *float64 { return &v }
 
 func mustConfigFromMap(t *testing.T, m map[string]any) LLMConfig {
 	t.Helper()
-	cfg, err := ConfigFromMap(m)
+	cfg, err := ConfigFromMap(m, nil)
 	if err != nil {
 		t.Fatalf("ConfigFromMap: %v", err)
 	}
@@ -127,12 +128,36 @@ func TestConfigFromMap_JSONModeString(t *testing.T) {
 	}
 }
 
-func TestConfigFromMap_UnresolvedRef(t *testing.T) {
+func TestConfigFromMap_TemplateRef(t *testing.T) {
+	cfg, err := ConfigFromMap(map[string]any{
+		"temperature":   "${board.temperature}",
+		"max_tokens":    "${board.max_tokens}",
+		"json_mode":     "${board.json_mode}",
+		"system_prompt": "${board.system_prompt}",
+	}, variable.ContainsRef)
+	if err != nil {
+		t.Fatalf("template ref should not error at build time: %v", err)
+	}
+	if cfg.Temperature != nil {
+		t.Fatalf("template ref should leave Temperature nil, got %v", *cfg.Temperature)
+	}
+	if cfg.MaxTokens != 0 {
+		t.Fatalf("template ref should leave MaxTokens 0, got %d", cfg.MaxTokens)
+	}
+	if cfg.JSONMode {
+		t.Fatal("template ref should leave JSONMode false")
+	}
+	if cfg.SystemPrompt != "${board.system_prompt}" {
+		t.Fatalf("template ref in string field should be kept, got %q", cfg.SystemPrompt)
+	}
+}
+
+func TestConfigFromMap_InvalidString(t *testing.T) {
 	_, err := ConfigFromMap(map[string]any{
-		"temperature": "${board.missing}",
-	})
+		"temperature": "not-a-number",
+	}, nil)
 	if err == nil {
-		t.Fatal("unresolved ref should produce an error")
+		t.Fatal("invalid string should produce an error")
 	}
 }
 
@@ -299,6 +324,78 @@ func TestLLMNode_SetConfig(t *testing.T) {
 	}
 	if n.config.Temperature == nil || *n.config.Temperature != 0.8 {
 		t.Fatalf("Temperature after SetConfig = %v", n.config.Temperature)
+	}
+}
+
+func TestLLMNode_SetConfig_TemplateRefThenResolved(t *testing.T) {
+	cfg, err := ConfigFromMap(map[string]any{
+		"system_prompt": "${board.system_prompt}",
+		"temperature":   "${board.temperature}",
+		"max_tokens":    "${board.max_tokens}",
+		"json_mode":     "${board.json_mode}",
+		"model":         "openai/gpt-4o",
+	}, variable.ContainsRef)
+	if err != nil {
+		t.Fatalf("ConfigFromMap: %v", err)
+	}
+
+	n := NewLLMNode("llm1", nil, nil, cfg)
+	n.rawConfig = map[string]any{
+		"system_prompt": "${board.system_prompt}",
+		"temperature":   "${board.temperature}",
+		"max_tokens":    "${board.max_tokens}",
+		"json_mode":     "${board.json_mode}",
+		"model":         "openai/gpt-4o",
+	}
+
+	if n.config.Temperature != nil {
+		t.Fatalf("Build phase: Temperature should be nil, got %v", *n.config.Temperature)
+	}
+	if n.config.MaxTokens != 0 {
+		t.Fatalf("Build phase: MaxTokens should be 0, got %d", n.config.MaxTokens)
+	}
+	if n.config.Model != "openai/gpt-4o" {
+		t.Fatalf("Build phase: Model should be preserved, got %q", n.config.Model)
+	}
+
+	n.SetConfig(map[string]any{
+		"system_prompt": "You are a translator.",
+		"temperature":   0.3,
+		"max_tokens":    float64(2048),
+		"json_mode":     true,
+		"model":         "openai/gpt-4o",
+	})
+
+	if n.config.SystemPrompt != "You are a translator." {
+		t.Fatalf("Execute phase: SystemPrompt = %q", n.config.SystemPrompt)
+	}
+	if n.config.Temperature == nil || *n.config.Temperature != 0.3 {
+		t.Fatalf("Execute phase: Temperature = %v", n.config.Temperature)
+	}
+	if n.config.MaxTokens != 2048 {
+		t.Fatalf("Execute phase: MaxTokens = %d", n.config.MaxTokens)
+	}
+	if !n.config.JSONMode {
+		t.Fatal("Execute phase: JSONMode should be true")
+	}
+}
+
+func TestLLMNode_SetConfig_StringNumericValues(t *testing.T) {
+	n := NewLLMNode("llm1", nil, nil, LLMConfig{})
+	n.SetConfig(map[string]any{
+		"temperature": "0.7",
+		"max_tokens":  "4096",
+		"json_mode":   "true",
+	})
+
+	if n.config.Temperature == nil || *n.config.Temperature != 0.7 {
+		t.Fatalf("Temperature = %v, want 0.7", n.config.Temperature)
+	}
+	if n.config.MaxTokens != 4096 {
+		t.Fatalf("MaxTokens = %d, want 4096", n.config.MaxTokens)
+	}
+	if !n.config.JSONMode {
+		t.Fatal("JSONMode should be true")
 	}
 }
 

--- a/sdk/graph/node/register.go
+++ b/sdk/graph/node/register.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/GizClaw/flowcraft/sdk/graph"
+	"github.com/GizClaw/flowcraft/sdk/graph/variable"
 )
 
 func init() {
@@ -14,11 +15,12 @@ func buildLLMNode(def graph.NodeDefinition, bctx *BuildContext) (graph.Node, err
 	if bctx.LLMResolver == nil {
 		return nil, fmt.Errorf("build node %q: LLMResolver is required for llm nodes", def.ID)
 	}
-	cfg, err := ConfigFromMap(def.Config)
+	cfg, err := ConfigFromMap(def.Config, variable.ContainsRef)
 	if err != nil {
 		return nil, fmt.Errorf("build node %q: invalid config: %w", def.ID, err)
 	}
 	n := NewLLMNode(def.ID, bctx.LLMResolver, bctx.ToolRegistry, cfg)
 	n.rawConfig = def.Config
+	n.isDeferred = variable.ContainsRef
 	return n, nil
 }

--- a/sdk/graph/variable/resolver.go
+++ b/sdk/graph/variable/resolver.go
@@ -162,6 +162,19 @@ func resolveNested(m map[string]any, path string) any {
 	return current
 }
 
+// ContainsRef reports whether s contains at least one resolvable
+// ${scope.name} reference (i.e. the content inside braces must have a
+// dot-separated scope and name, matching what lookup actually resolves).
+func ContainsRef(s string) bool {
+	for _, match := range refPattern.FindAllStringSubmatch(s, -1) {
+		ref := strings.TrimSpace(match[1])
+		if i := strings.IndexByte(ref, '.'); i > 0 && i < len(ref)-1 {
+			return true
+		}
+	}
+	return false
+}
+
 // ExtractRefs returns all ${scope.name} references found in a string.
 func ExtractRefs(text string) []string {
 	matches := refPattern.FindAllStringSubmatch(text, -1)

--- a/sdk/llm/round_config.go
+++ b/sdk/llm/round_config.go
@@ -25,8 +25,14 @@ type RoundConfig struct {
 // allows JSON round-trip (Marshal → Unmarshal) to succeed when map values
 // arrive as strings (e.g. from ${board.temperature} template resolution).
 //
+// isDeferred, when non-nil, reports whether a string value is a deferred
+// reference (e.g. a template variable) that will be resolved later. Such
+// values are removed from non-string fields so that json.Unmarshal sees the
+// zero value instead of an invalid string. The caller should supply the
+// resolver's own ContainsRef function to keep detection in sync.
+//
 // The input map is not modified; a shallow clone is returned.
-func CoerceMapForStruct[T any](m map[string]any) map[string]any {
+func CoerceMapForStruct[T any](m map[string]any, isDeferred func(string) bool) map[string]any {
 	if m == nil {
 		return nil
 	}
@@ -68,6 +74,8 @@ func CoerceMapForStruct[T any](m map[string]any) map[string]any {
 		}
 		if coerced, ok := coerceString(str, target.Kind()); ok {
 			result[key] = coerced
+		} else if isDeferred != nil && isDeferred(str) {
+			delete(result, key)
 		}
 	}
 	return result
@@ -109,12 +117,13 @@ func coerceString(s string, kind reflect.Kind) (any, bool) {
 }
 
 // RoundConfigFromMap parses RoundConfig from a generic map via JSON round-trip.
-func RoundConfigFromMap(m map[string]any) (RoundConfig, error) {
+// isDeferred is passed through to CoerceMapForStruct; see its documentation.
+func RoundConfigFromMap(m map[string]any, isDeferred func(string) bool) (RoundConfig, error) {
 	var cfg RoundConfig
 	if m == nil {
 		return cfg, nil
 	}
-	m = CoerceMapForStruct[RoundConfig](m)
+	m = CoerceMapForStruct[RoundConfig](m, isDeferred)
 	data, err := json.Marshal(m)
 	if err != nil {
 		return cfg, fmt.Errorf("llm: marshal config map: %w", err)

--- a/sdk/llm/round_test.go
+++ b/sdk/llm/round_test.go
@@ -3,6 +3,8 @@ package llm
 import (
 	"context"
 	"fmt"
+	"regexp"
+	"strings"
 	"sync/atomic"
 	"testing"
 
@@ -10,6 +12,18 @@ import (
 	"github.com/GizClaw/flowcraft/sdk/tool"
 	"github.com/GizClaw/flowcraft/sdk/workflow"
 )
+
+var testRefPattern = regexp.MustCompile(`\$\{([^}]+)\}`)
+
+func testContainsRef(s string) bool {
+	for _, match := range testRefPattern.FindAllStringSubmatch(s, -1) {
+		ref := strings.TrimSpace(match[1])
+		if i := strings.IndexByte(ref, '.'); i > 0 && i < len(ref)-1 {
+			return true
+		}
+	}
+	return false
+}
 
 // ── mocks for RunRound / StreamRound ──
 
@@ -265,7 +279,7 @@ func TestRoundConfigFromMap_Valid(t *testing.T) {
 		"model":       "gpt-4",
 		"temperature": 0.5,
 		"max_tokens":  float64(100),
-	})
+	}, nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -281,7 +295,7 @@ func TestRoundConfigFromMap_Valid(t *testing.T) {
 }
 
 func TestRoundConfigFromMap_Nil(t *testing.T) {
-	cfg, err := RoundConfigFromMap(nil)
+	cfg, err := RoundConfigFromMap(nil, nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -291,7 +305,7 @@ func TestRoundConfigFromMap_Nil(t *testing.T) {
 }
 
 func TestRoundConfigFromMap_TemperatureZero(t *testing.T) {
-	cfg, err := RoundConfigFromMap(map[string]any{"temperature": 0.0})
+	cfg, err := RoundConfigFromMap(map[string]any{"temperature": 0.0}, nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -305,7 +319,7 @@ func TestRoundConfigFromMap_TemperatureZero(t *testing.T) {
 
 func TestRoundConfigFromMap_TemperatureString(t *testing.T) {
 	m := map[string]any{"temperature": "0.75"}
-	cfg, err := RoundConfigFromMap(m)
+	cfg, err := RoundConfigFromMap(m, nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -318,7 +332,7 @@ func TestRoundConfigFromMap_TemperatureString(t *testing.T) {
 }
 
 func TestRoundConfigFromMap_MaxTokensString(t *testing.T) {
-	cfg, err := RoundConfigFromMap(map[string]any{"max_tokens": "4096"})
+	cfg, err := RoundConfigFromMap(map[string]any{"max_tokens": "4096"}, nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -328,7 +342,7 @@ func TestRoundConfigFromMap_MaxTokensString(t *testing.T) {
 }
 
 func TestRoundConfigFromMap_JSONModeString(t *testing.T) {
-	cfg, err := RoundConfigFromMap(map[string]any{"json_mode": "true"})
+	cfg, err := RoundConfigFromMap(map[string]any{"json_mode": "true"}, nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -337,10 +351,20 @@ func TestRoundConfigFromMap_JSONModeString(t *testing.T) {
 	}
 }
 
-func TestRoundConfigFromMap_UnresolvedRef(t *testing.T) {
-	_, err := RoundConfigFromMap(map[string]any{"temperature": "${board.missing}"})
+func TestRoundConfigFromMap_TemplateRef(t *testing.T) {
+	cfg, err := RoundConfigFromMap(map[string]any{"temperature": "${board.temperature}"}, testContainsRef)
+	if err != nil {
+		t.Fatalf("template ref should not error at build time: %v", err)
+	}
+	if cfg.Temperature != nil {
+		t.Fatalf("template ref should leave Temperature nil, got %v", *cfg.Temperature)
+	}
+}
+
+func TestRoundConfigFromMap_InvalidString(t *testing.T) {
+	_, err := RoundConfigFromMap(map[string]any{"temperature": "not-a-number"}, nil)
 	if err == nil {
-		t.Fatal("unresolved ref should produce an error")
+		t.Fatal("invalid string should produce an error")
 	}
 }
 
@@ -356,7 +380,7 @@ type coerceTestStruct struct {
 }
 
 func TestCoerceMapForStruct_Nil(t *testing.T) {
-	got := CoerceMapForStruct[coerceTestStruct](nil)
+	got := CoerceMapForStruct[coerceTestStruct](nil, nil)
 	if got != nil {
 		t.Fatalf("expected nil, got %v", got)
 	}
@@ -364,7 +388,7 @@ func TestCoerceMapForStruct_Nil(t *testing.T) {
 
 func TestCoerceMapForStruct_StringToFloat(t *testing.T) {
 	m := map[string]any{"f64": "1.5", "ptr_f64": "0.3"}
-	got := CoerceMapForStruct[coerceTestStruct](m)
+	got := CoerceMapForStruct[coerceTestStruct](m, nil)
 	if v, ok := got["f64"].(float64); !ok || v != 1.5 {
 		t.Fatalf("f64: got %T %v", got["f64"], got["f64"])
 	}
@@ -375,7 +399,7 @@ func TestCoerceMapForStruct_StringToFloat(t *testing.T) {
 
 func TestCoerceMapForStruct_StringToInt(t *testing.T) {
 	m := map[string]any{"i64": "42"}
-	got := CoerceMapForStruct[coerceTestStruct](m)
+	got := CoerceMapForStruct[coerceTestStruct](m, nil)
 	if v, ok := got["i64"].(int64); !ok || v != 42 {
 		t.Fatalf("i64: got %T %v", got["i64"], got["i64"])
 	}
@@ -383,7 +407,7 @@ func TestCoerceMapForStruct_StringToInt(t *testing.T) {
 
 func TestCoerceMapForStruct_StringToUint(t *testing.T) {
 	m := map[string]any{"u": "100"}
-	got := CoerceMapForStruct[coerceTestStruct](m)
+	got := CoerceMapForStruct[coerceTestStruct](m, nil)
 	if v, ok := got["u"].(uint64); !ok || v != 100 {
 		t.Fatalf("u: got %T %v", got["u"], got["u"])
 	}
@@ -391,7 +415,7 @@ func TestCoerceMapForStruct_StringToUint(t *testing.T) {
 
 func TestCoerceMapForStruct_StringToBool(t *testing.T) {
 	m := map[string]any{"b": "true"}
-	got := CoerceMapForStruct[coerceTestStruct](m)
+	got := CoerceMapForStruct[coerceTestStruct](m, nil)
 	if v, ok := got["b"].(bool); !ok || !v {
 		t.Fatalf("b: got %T %v", got["b"], got["b"])
 	}
@@ -399,7 +423,7 @@ func TestCoerceMapForStruct_StringToBool(t *testing.T) {
 
 func TestCoerceMapForStruct_NonStringUntouched(t *testing.T) {
 	m := map[string]any{"f64": 2.5, "i64": int64(10), "b": false, "s": "hello"}
-	got := CoerceMapForStruct[coerceTestStruct](m)
+	got := CoerceMapForStruct[coerceTestStruct](m, nil)
 	if got["f64"] != 2.5 || got["i64"] != int64(10) || got["b"] != false || got["s"] != "hello" {
 		t.Fatalf("non-string values should pass through: %v", got)
 	}
@@ -407,7 +431,7 @@ func TestCoerceMapForStruct_NonStringUntouched(t *testing.T) {
 
 func TestCoerceMapForStruct_InvalidStringKept(t *testing.T) {
 	m := map[string]any{"f64": "not-a-number", "i64": "abc", "b": "nope"}
-	got := CoerceMapForStruct[coerceTestStruct](m)
+	got := CoerceMapForStruct[coerceTestStruct](m, nil)
 	if got["f64"] != "not-a-number" {
 		t.Fatalf("invalid float string should be kept, got %v", got["f64"])
 	}
@@ -419,9 +443,53 @@ func TestCoerceMapForStruct_InvalidStringKept(t *testing.T) {
 	}
 }
 
+func TestCoerceMapForStruct_TemplateRefRemoved(t *testing.T) {
+	m := map[string]any{
+		"f64":     "${board.temperature}",
+		"i64":     "${board.max_tokens}",
+		"b":       "${board.json_mode}",
+		"s":       "${board.system_prompt}",
+		"ptr_f64": "prefix ${board.temp}",
+	}
+	got := CoerceMapForStruct[coerceTestStruct](m, testContainsRef)
+	if _, ok := got["f64"]; ok {
+		t.Fatalf("template ref in float field should be removed, got %v", got["f64"])
+	}
+	if _, ok := got["i64"]; ok {
+		t.Fatalf("template ref in int field should be removed, got %v", got["i64"])
+	}
+	if _, ok := got["b"]; ok {
+		t.Fatalf("template ref in bool field should be removed, got %v", got["b"])
+	}
+	if got["s"] != "${board.system_prompt}" {
+		t.Fatalf("template ref in string field should be kept, got %v", got["s"])
+	}
+	if _, ok := got["ptr_f64"]; ok {
+		t.Fatalf("mixed template ref in float field should be removed, got %v", got["ptr_f64"])
+	}
+}
+
+func TestCoerceMapForStruct_MalformedRefKept(t *testing.T) {
+	m := map[string]any{
+		"f64": "price is ${",
+		"i64": "${}",
+		"b":   "${ }",
+	}
+	got := CoerceMapForStruct[coerceTestStruct](m, testContainsRef)
+	if got["f64"] != "price is ${" {
+		t.Fatalf("malformed ref (no closing brace) should be kept, got %v", got["f64"])
+	}
+	if got["i64"] != "${}" {
+		t.Fatalf("empty ref should be kept, got %v", got["i64"])
+	}
+	if got["b"] != "${ }" {
+		t.Fatalf("whitespace-only ref should be kept, got %v", got["b"])
+	}
+}
+
 func TestCoerceMapForStruct_EmptyStringKept(t *testing.T) {
 	m := map[string]any{"f64": "", "i64": "  "}
-	got := CoerceMapForStruct[coerceTestStruct](m)
+	got := CoerceMapForStruct[coerceTestStruct](m, nil)
 	if got["f64"] != "" {
 		t.Fatalf("empty string should be kept, got %v", got["f64"])
 	}
@@ -432,7 +500,7 @@ func TestCoerceMapForStruct_EmptyStringKept(t *testing.T) {
 
 func TestCoerceMapForStruct_StringFieldUntouched(t *testing.T) {
 	m := map[string]any{"s": "hello world"}
-	got := CoerceMapForStruct[coerceTestStruct](m)
+	got := CoerceMapForStruct[coerceTestStruct](m, nil)
 	if got["s"] != "hello world" {
 		t.Fatalf("string field should be untouched, got %v", got["s"])
 	}
@@ -440,7 +508,7 @@ func TestCoerceMapForStruct_StringFieldUntouched(t *testing.T) {
 
 func TestCoerceMapForStruct_DoesNotMutateInput(t *testing.T) {
 	m := map[string]any{"f64": "1.0", "s": "keep"}
-	_ = CoerceMapForStruct[coerceTestStruct](m)
+	_ = CoerceMapForStruct[coerceTestStruct](m, nil)
 	if _, ok := m["f64"].(string); !ok {
 		t.Fatalf("input map was mutated: f64 is %T", m["f64"])
 	}
@@ -448,7 +516,7 @@ func TestCoerceMapForStruct_DoesNotMutateInput(t *testing.T) {
 
 func TestCoerceMapForStruct_ExtraKeysPassThrough(t *testing.T) {
 	m := map[string]any{"f64": "1.0", "unknown_key": "whatever"}
-	got := CoerceMapForStruct[coerceTestStruct](m)
+	got := CoerceMapForStruct[coerceTestStruct](m, nil)
 	if got["unknown_key"] != "whatever" {
 		t.Fatalf("extra keys should pass through, got %v", got["unknown_key"])
 	}

--- a/sdk/script/bindings/bridge_llm.go
+++ b/sdk/script/bindings/bridge_llm.go
@@ -3,6 +3,7 @@ package bindings
 import (
 	"context"
 	"encoding/json"
+	"maps"
 
 	"github.com/GizClaw/flowcraft/sdk/llm"
 	"github.com/GizClaw/flowcraft/sdk/model"
@@ -130,10 +131,8 @@ func mergeRoundConfig(base llm.RoundConfig, overrides map[string]any) llm.RoundC
 	if err := json.Unmarshal(raw, &m); err != nil {
 		return base
 	}
-	for k, v := range overrides {
-		m[k] = v
-	}
-	m = llm.CoerceMapForStruct[llm.RoundConfig](m)
+	maps.Copy(m, overrides)
+	m = llm.CoerceMapForStruct[llm.RoundConfig](m, nil)
 	merged, err := json.Marshal(m)
 	if err != nil {
 		return base


### PR DESCRIPTION
## Summary

- **Externalize template ref detection**: `CoerceMapForStruct` and `RoundConfigFromMap` now accept an `isDeferred func(string) bool` predicate instead of using a hardcoded regex. This eliminates the risk of divergence between the coercion layer and the resolver's actual `${scope.name}` parsing logic.
- **Export `variable.ContainsRef`**: a single source of truth for detecting resolvable references, reusing `refPattern` and mirroring `lookup`'s dot-separated path requirement.
- **Store `isDeferred` on `LLMNode`**: injected at build time via `register.go`, reused by `SetConfig` at execute time, so both phases handle unresolved template refs consistently.
- **Add comprehensive test coverage**: end-to-end executor tests (build → resolve → execute → restore), string-typed board vars, partial template interpolation, and malformed ref edge cases (`${}`, `${ }`, truncated `${`).

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./sdk/...` passes (all packages)
- [x] New tests cover: template ref build+execute cycle, string numeric board vars, partial refs, malformed refs kept, config restoration after execution


Made with [Cursor](https://cursor.com)