### PR TITLE
feat(sdk/workflow): add WithBoard RunOption for resume-from-snapshot

### DIFF
--- a/sdk/workflow/option.go
+++ b/sdk/workflow/option.go
@@ -42,6 +42,7 @@ type RunOption func(*RunConfig)
 // implementations (e.g. flowgraph) can read stream callback, max iterations, etc.
 type RunConfig struct {
 	History        []model.Message
+	Board          *Board
 	StreamCallback StreamCallback
 	MaxIterations  int
 }
@@ -69,4 +70,10 @@ func WithStreamCallback(cb StreamCallback) RunOption {
 // WithMaxIterations caps the number of graph execution steps.
 func WithMaxIterations(n int) RunOption {
 	return func(c *RunConfig) { c.MaxIterations = n }
+}
+
+// WithBoard injects a pre-built Board, skipping the normal prepareBoard phase.
+// Used for resume-from-snapshot flows.
+func WithBoard(b *Board) RunOption {
+	return func(c *RunConfig) { c.Board = b }
 }

--- a/sdk/workflow/request.go
+++ b/sdk/workflow/request.go
@@ -9,13 +9,12 @@ type RequestConfig struct {
 
 // Request is one agent turn: user message plus optional inputs and metadata.
 type Request struct {
-	TaskID    string
-	ContextID string
-	RuntimeID string
-	RunID     string
-	Message   model.Message
-	Inputs    map[string]any
-	Config    *RequestConfig
-	// Extensions carries platform-specific data (e.g. executor options for flowgraph).
-	Extensions map[string]any
+	TaskID     string         `json:"task_id,omitempty"`
+	ContextID  string         `json:"context_id,omitempty"`
+	RuntimeID  string         `json:"runtime_id,omitempty"`
+	RunID      string         `json:"run_id,omitempty"`
+	Message    model.Message  `json:"message"`
+	Inputs     map[string]any `json:"inputs,omitempty"`
+	Config     *RequestConfig `json:"config,omitempty"`
+	Extensions map[string]any `json:"extensions,omitempty"`
 }

--- a/sdk/workflow/result.go
+++ b/sdk/workflow/result.go
@@ -23,15 +23,14 @@ type Artifact struct {
 
 // Result is returned by Runtime.Run after execution and finish logic.
 type Result struct {
-	TaskID    string
-	Status    TaskStatus
-	Messages  []model.Message
-	Artifacts []Artifact
-	Usage     model.TokenUsage
-	State     map[string]any
-	Err       error
-	// LastBoard is the board after Execute (for platform persistence hooks). Not serialized.
-	LastBoard *Board `json:"-"`
+	TaskID    string           `json:"task_id,omitempty"`
+	Status    TaskStatus       `json:"status"`
+	Messages  []model.Message  `json:"messages,omitempty"`
+	Artifacts []Artifact       `json:"artifacts,omitempty"`
+	Usage     model.TokenUsage `json:"usage"`
+	State     map[string]any   `json:"state,omitempty"`
+	Err       error            `json:"-"`
+	LastBoard *Board           `json:"-"`
 }
 
 // Text returns the last assistant text message in Messages, or "".

--- a/sdk/workflow/run.go
+++ b/sdk/workflow/run.go
@@ -30,8 +30,12 @@ func (rt *runtime) run(ctx context.Context, agent Agent, req *Request, opts []Ru
 		}()
 	}
 
+	rc := ApplyRunOpts(opts)
+
 	var board *Board
-	if rt.prepareBoardFn != nil {
+	if rc.Board != nil {
+		board = rc.Board
+	} else if rt.prepareBoardFn != nil {
 		board, err = rt.prepareBoardFn(ctx, agent, req, session, opts)
 	} else {
 		board, err = prepareBoard(ctx, req, session, opts)

--- a/sdk/workflow/run_test.go
+++ b/sdk/workflow/run_test.go
@@ -306,3 +306,112 @@ func (r usageRunnable) Execute(_ context.Context, board *Board, _ *Request, _ ..
 	board.SetVar(VarAnswer, "done")
 	return board, nil
 }
+
+// --- WithBoard (resume) ---
+
+func TestRuntime_WithBoard_SkipsPrepareBoard(t *testing.T) {
+	board := NewBoard()
+	board.SetVar(VarRunID, "resumed-run")
+	board.SetVar(VarPrevMessageCount, 0)
+	board.AppendChannelMessage(MainChannel, model.NewTextMessage(model.RoleUser, "original"))
+
+	rt := NewRuntime()
+	req := NewTextRequest("resume-input")
+	res, err := rt.Run(context.Background(), noopAgent{str: noopStrategy{}}, req, WithBoard(board))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.Status != StatusCompleted {
+		t.Fatalf("status=%s", res.Status)
+	}
+	if res.State["run_id"] != "resumed-run" {
+		t.Fatalf("run_id=%v, want resumed-run", res.State["run_id"])
+	}
+}
+
+func TestRuntime_WithBoard_OverridesCustomPrepareBoard(t *testing.T) {
+	prepareCalled := false
+	rt := NewRuntime(WithPrepareBoard(func(_ context.Context, _ Agent, _ *Request, _ MemorySession, _ []RunOption) (*Board, error) {
+		prepareCalled = true
+		return NewBoard(), nil
+	}))
+
+	board := NewBoard()
+	board.SetVar(VarRunID, "injected")
+	board.SetVar(VarPrevMessageCount, 0)
+
+	req := NewTextRequest("hi")
+	res, err := rt.Run(context.Background(), noopAgent{str: noopStrategy{}}, req, WithBoard(board))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if prepareCalled {
+		t.Fatal("prepareBoardFn should be skipped when WithBoard is used")
+	}
+	if res.State["run_id"] != "injected" {
+		t.Fatalf("run_id=%v, want injected", res.State["run_id"])
+	}
+}
+
+func TestRuntime_WithBoard_PreservesExistingChannelMessages(t *testing.T) {
+	board := NewBoard()
+	board.SetVar(VarRunID, "r1")
+	board.SetVar(VarPrevMessageCount, 2)
+	board.SetChannel(MainChannel, []model.Message{
+		model.NewTextMessage(model.RoleUser, "turn1"),
+		model.NewTextMessage(model.RoleAssistant, "reply1"),
+	})
+
+	rt := NewRuntime()
+	req := NewTextRequest("turn2")
+	res, err := rt.Run(context.Background(), noopAgent{str: echoStrategy2{answer: "reply2"}}, req, WithBoard(board))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.Status != StatusCompleted {
+		t.Fatalf("status=%s", res.Status)
+	}
+	if len(res.Messages) != 1 {
+		t.Fatalf("expected 1 new message, got %d", len(res.Messages))
+	}
+	if res.Messages[0].Content() != "reply2" {
+		t.Fatalf("message=%q, want reply2", res.Messages[0].Content())
+	}
+}
+
+func TestRuntime_WithBoard_MemorySessionStillSaves(t *testing.T) {
+	saved := false
+	sess := &trackingSaveSession{onSave: func() { saved = true }}
+	factory := func(_ context.Context, _ Agent) (Memory, error) {
+		return &staticMem{session: sess}, nil
+	}
+	rt := NewRuntime(WithMemoryFactory(factory))
+
+	board := NewBoard()
+	board.SetVar(VarRunID, "resume")
+	board.SetVar(VarPrevMessageCount, 0)
+	board.SetChannel(MainChannel, []model.Message{})
+
+	req := NewTextRequest("hi")
+	req.ContextID = "c1"
+	_, err := rt.Run(context.Background(), noopAgent{str: echoStrategy2{answer: "ok"}}, req, WithBoard(board))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !saved {
+		t.Fatal("memory session should still save after WithBoard resume")
+	}
+}
+
+type trackingSaveSession struct {
+	BaseSession
+	onSave func()
+}
+
+func (s *trackingSaveSession) Load(context.Context) ([]model.Message, error) { return nil, nil }
+func (s *trackingSaveSession) Vars(context.Context) (map[string]any, error)  { return nil, nil }
+func (s *trackingSaveSession) Save(_ context.Context, _ []model.Message) error {
+	s.onSave()
+	return nil
+}
+func (s *trackingSaveSession) Close(_ context.Context, _ error) error { return nil }


### PR DESCRIPTION
## Summary

- Add `WithBoard(b *Board) RunOption` that injects a pre-built Board into `Runtime.Run`, skipping `prepareBoard`. This enables resume-from-snapshot flows to reuse the standard `finishRun` pipeline (status/message/usage assembly) instead of reimplementing it on the platform side.
- Add `Board *Board` field to `RunConfig` so that `WithBoard` takes priority over both the default `prepareBoard` and any custom `prepareBoardFn`.
- Add `json` struct tags to `Request` and `Result` for direct API serialization.

## Test plan

- [x] `TestRuntime_WithBoard_SkipsPrepareBoard` — verifies injected board is used and default prepareBoard is skipped
- [x] `TestRuntime_WithBoard_OverridesCustomPrepareBoard` — verifies WithBoard takes priority over WithPrepareBoard
- [x] `TestRuntime_WithBoard_PreservesExistingChannelMessages` — verifies finishRun correctly extracts only new messages from a restored board
- [x] `TestRuntime_WithBoard_MemorySessionStillSaves` — verifies memory session save still works in resume path
- [x] All existing sdk/workflow tests pass with no regressions


Made with [Cursor](https://cursor.com)