### PR TITLE
fix(memory): use ArchiveConfig.ArchivePrefix instead of hardcoded 'archive'

### DIFF
--- a/examples/voice-pipeline/go.mod
+++ b/examples/voice-pipeline/go.mod
@@ -3,7 +3,7 @@ module github.com/GizClaw/flowcraft/examples/voice-pipeline
 go 1.25.0
 
 require (
-	github.com/GizClaw/flowcraft/sdk v0.1.3
+	github.com/GizClaw/flowcraft/sdk v0.1.7
 	github.com/GizClaw/flowcraft/sdkx v0.0.0
 	github.com/charmbracelet/bubbles v0.20.0
 	github.com/charmbracelet/bubbletea v1.1.0

--- a/sdk/memory/archive.go
+++ b/sdk/memory/archive.go
@@ -47,8 +47,8 @@ type ArchiveResult struct {
 }
 
 // LoadManifest reads the archive manifest for a conversation.
-func LoadManifest(ctx context.Context, ws workspace.Workspace, prefix, convID string) (*ArchiveManifest, error) {
-	path := manifestPath(prefix, convID)
+func LoadManifest(ctx context.Context, ws workspace.Workspace, prefix, archivePrefix, convID string) (*ArchiveManifest, error) {
+	path := manifestPath(prefix, archivePrefix, convID)
 	exists, err := ws.Exists(ctx, path)
 	if err != nil {
 		return nil, fmt.Errorf("archive: check manifest: %w", err)
@@ -68,24 +68,24 @@ func LoadManifest(ctx context.Context, ws workspace.Workspace, prefix, convID st
 }
 
 // SaveManifest writes the archive manifest.
-func SaveManifest(ctx context.Context, ws workspace.Workspace, prefix, convID string, m *ArchiveManifest) error {
+func SaveManifest(ctx context.Context, ws workspace.Workspace, prefix, archivePrefix, convID string, m *ArchiveManifest) error {
 	data, err := json.MarshalIndent(m, "", "  ")
 	if err != nil {
 		return fmt.Errorf("archive: marshal manifest: %w", err)
 	}
-	path := manifestPath(prefix, convID)
+	path := manifestPath(prefix, archivePrefix, convID)
 	return ws.Write(ctx, path, data)
 }
 
-func manifestPath(prefix, convID string) string {
+func manifestPath(prefix, archivePrefix, convID string) string {
 	if prefix != "" {
-		return fmt.Sprintf("%s/%s/archive/manifest.json", prefix, convID)
+		return fmt.Sprintf("%s/%s/%s/manifest.json", prefix, convID, archivePrefix)
 	}
-	return fmt.Sprintf("%s/archive/manifest.json", convID)
+	return fmt.Sprintf("%s/%s/manifest.json", convID, archivePrefix)
 }
 
-func intentPath(prefix, convID string) string {
-	return archiveDir(prefix, convID) + "/intent.json"
+func intentPath(prefix, archivePrefix, convID string) string {
+	return archiveDir(prefix, archivePrefix, convID) + "/intent.json"
 }
 
 // archiveIntent records the in-progress archive operation for crash recovery.
@@ -98,21 +98,21 @@ type archiveIntent struct {
 	Phase       string `json:"phase"` // "gzip_written" | "manifest_updated"
 }
 
-func writeIntent(ctx context.Context, ws workspace.Workspace, prefix, convID string, intent *archiveIntent) error {
+func writeIntent(ctx context.Context, ws workspace.Workspace, prefix, archivePrefix, convID string, intent *archiveIntent) error {
 	data, err := json.Marshal(intent)
 	if err != nil {
 		return err
 	}
-	return ws.Write(ctx, intentPath(prefix, convID), data)
+	return ws.Write(ctx, intentPath(prefix, archivePrefix, convID), data)
 }
 
-func deleteIntent(ctx context.Context, ws workspace.Workspace, prefix, convID string) {
-	path := intentPath(prefix, convID)
+func deleteIntent(ctx context.Context, ws workspace.Workspace, prefix, archivePrefix, convID string) {
+	path := intentPath(prefix, archivePrefix, convID)
 	_ = ws.Write(ctx, path, nil)
 }
 
-func loadIntent(ctx context.Context, ws workspace.Workspace, prefix, convID string) (*archiveIntent, error) {
-	path := intentPath(prefix, convID)
+func loadIntent(ctx context.Context, ws workspace.Workspace, prefix, archivePrefix, convID string) (*archiveIntent, error) {
+	path := intentPath(prefix, archivePrefix, convID)
 	exists, err := ws.Exists(ctx, path)
 	if err != nil || !exists {
 		return nil, err
@@ -130,8 +130,8 @@ func loadIntent(ctx context.Context, ws workspace.Workspace, prefix, convID stri
 
 // RecoverArchive checks for incomplete archive operations and completes them.
 // Call this at startup before any new archive operations.
-func RecoverArchive(ctx context.Context, ws workspace.Workspace, store Store, prefix, convID string) error {
-	intent, err := loadIntent(ctx, ws, prefix, convID)
+func RecoverArchive(ctx context.Context, ws workspace.Workspace, store Store, prefix, archivePrefix, convID string) error {
+	intent, err := loadIntent(ctx, ws, prefix, archivePrefix, convID)
 	if err != nil || intent == nil {
 		return err
 	}
@@ -155,7 +155,7 @@ func RecoverArchive(ctx context.Context, ws workspace.Workspace, store Store, pr
 		}
 	case "gzip_written":
 		// Gzip done but manifest not updated — update manifest then trim.
-		manifest, err := LoadManifest(ctx, ws, prefix, convID)
+		manifest, err := LoadManifest(ctx, ws, prefix, archivePrefix, convID)
 		if err != nil {
 			return fmt.Errorf("archive: recovery load manifest: %w", err)
 		}
@@ -176,7 +176,7 @@ func RecoverArchive(ctx context.Context, ws workspace.Workspace, store Store, pr
 				CreatedAt: time.Now(),
 			})
 			manifest.HotStartSeq = intent.EndSeq + 1
-			if err := SaveManifest(ctx, ws, prefix, convID, manifest); err != nil {
+			if err := SaveManifest(ctx, ws, prefix, archivePrefix, convID, manifest); err != nil {
 				return fmt.Errorf("archive: recovery save manifest: %w", err)
 			}
 		}
@@ -192,7 +192,7 @@ func RecoverArchive(ctx context.Context, ws workspace.Workspace, store Store, pr
 		}
 	}
 
-	deleteIntent(ctx, ws, prefix, convID)
+	deleteIntent(ctx, ws, prefix, archivePrefix, convID)
 	telemetry.Info(ctx, "archive: recovery completed", otellog.String("conversation_id", convID))
 	return nil
 }
@@ -234,7 +234,12 @@ func Archive(ctx context.Context, ws workspace.Workspace, store Store, prefix, c
 		return result, nil
 	}
 
-	manifest, err := LoadManifest(ctx, ws, prefix, convID)
+	archivePrefix := cfg.ArchivePrefix
+	if archivePrefix == "" {
+		archivePrefix = "archive"
+	}
+
+	manifest, err := LoadManifest(ctx, ws, prefix, archivePrefix, convID)
 	if err != nil {
 		return result, err
 	}
@@ -261,7 +266,7 @@ func Archive(ctx context.Context, ws workspace.Workspace, store Store, prefix, c
 		return result, fmt.Errorf("archive: gzip close: %w", err)
 	}
 
-	archivePath := archiveDir(prefix, convID) + "/" + archiveFile
+	archivePath := archiveDir(prefix, archivePrefix, convID) + "/" + archiveFile
 	if err := ws.Write(ctx, archivePath, buf.Bytes()); err != nil {
 		return result, fmt.Errorf("archive: write gzip: %w", err)
 	}
@@ -270,7 +275,7 @@ func Archive(ctx context.Context, ws workspace.Workspace, store Store, prefix, c
 		ConvID: convID, StartSeq: startSeq, EndSeq: endSeq,
 		BatchSize: batchSize, ArchiveFile: archiveFile, Phase: "gzip_written",
 	}
-	if err := writeIntent(ctx, ws, prefix, convID, intent); err != nil {
+	if err := writeIntent(ctx, ws, prefix, archivePrefix, convID, intent); err != nil {
 		return result, fmt.Errorf("archive: write intent: %w", err)
 	}
 
@@ -284,12 +289,12 @@ func Archive(ctx context.Context, ws workspace.Workspace, store Store, prefix, c
 	})
 	manifest.HotStartSeq = endSeq + 1
 
-	if err := SaveManifest(ctx, ws, prefix, convID, manifest); err != nil {
+	if err := SaveManifest(ctx, ws, prefix, archivePrefix, convID, manifest); err != nil {
 		return result, fmt.Errorf("archive: save manifest: %w", err)
 	}
 
 	intent.Phase = "manifest_updated"
-	if err := writeIntent(ctx, ws, prefix, convID, intent); err != nil {
+	if err := writeIntent(ctx, ws, prefix, archivePrefix, convID, intent); err != nil {
 		return result, fmt.Errorf("archive: update intent: %w", err)
 	}
 
@@ -298,7 +303,7 @@ func Archive(ctx context.Context, ws workspace.Workspace, store Store, prefix, c
 		return result, fmt.Errorf("archive: rewrite messages: %w", err)
 	}
 
-	deleteIntent(ctx, ws, prefix, convID)
+	deleteIntent(ctx, ws, prefix, archivePrefix, convID)
 
 	result.MessagesArchived = batchSize
 	result.ArchiveFile = archiveFile
@@ -312,22 +317,22 @@ func Archive(ctx context.Context, ws workspace.Workspace, store Store, prefix, c
 	return result, nil
 }
 
-func archiveDir(prefix, convID string) string {
+func archiveDir(prefix, archivePrefix, convID string) string {
 	if prefix != "" {
-		return fmt.Sprintf("%s/%s/archive", prefix, convID)
+		return fmt.Sprintf("%s/%s/%s", prefix, convID, archivePrefix)
 	}
-	return fmt.Sprintf("%s/archive", convID)
+	return fmt.Sprintf("%s/%s", convID, archivePrefix)
 }
 
 // LoadArchivedMessages reads messages from gzip archive segments.
-func LoadArchivedMessages(ctx context.Context, ws workspace.Workspace, prefix, convID string, startSeq, endSeq int) ([]model.Message, error) {
-	manifest, err := LoadManifest(ctx, ws, prefix, convID)
+func LoadArchivedMessages(ctx context.Context, ws workspace.Workspace, prefix, archivePrefix, convID string, startSeq, endSeq int) ([]model.Message, error) {
+	manifest, err := LoadManifest(ctx, ws, prefix, archivePrefix, convID)
 	if err != nil {
 		return nil, err
 	}
 
 	var result []model.Message
-	dir := archiveDir(prefix, convID)
+	dir := archiveDir(prefix, archivePrefix, convID)
 
 	for _, seg := range manifest.Segments {
 		if seg.EndSeq < startSeq || seg.StartSeq > endSeq {

--- a/sdk/memory/archive_test.go
+++ b/sdk/memory/archive_test.go
@@ -70,7 +70,7 @@ func TestArchive_AboveThreshold(t *testing.T) {
 	}
 
 	// Check manifest.
-	manifest, err := LoadManifest(ctx, ws, "memory", convID)
+	manifest, err := LoadManifest(ctx, ws, "memory", "archive", convID)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -104,7 +104,7 @@ func TestLoadArchivedMessages(t *testing.T) {
 	}
 
 	// Load archived messages.
-	archived, err := LoadArchivedMessages(ctx, ws, "memory", convID, 0, 14)
+	archived, err := LoadArchivedMessages(ctx, ws, "memory", "archive", convID, 0, 14)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -122,7 +122,7 @@ func TestRecoverArchive_NoIntent(t *testing.T) {
 	ctx := context.Background()
 
 	// No pending intent — should be a no-op.
-	if err := RecoverArchive(ctx, ws, store, "memory", "no-intent-conv"); err != nil {
+	if err := RecoverArchive(ctx, ws, store, "memory", "archive", "no-intent-conv"); err != nil {
 		t.Fatal(err)
 	}
 }
@@ -168,10 +168,10 @@ func TestRecoverArchive_GzipWrittenPhase(t *testing.T) {
 		ConvID: convID, StartSeq: 10, EndSeq: 19,
 		BatchSize: 10, ArchiveFile: "messages_10_19.jsonl.gz", Phase: "gzip_written",
 	}
-	_ = writeIntent(ctx, ws, "memory", convID, intent)
+	_ = writeIntent(ctx, ws, "memory", "archive", convID, intent)
 
 	// Recovery should: update manifest, trim messages.
-	if err := RecoverArchive(ctx, ws, store, "memory", convID); err != nil {
+	if err := RecoverArchive(ctx, ws, store, "memory", "archive", convID); err != nil {
 		t.Fatal(err)
 	}
 
@@ -182,7 +182,7 @@ func TestRecoverArchive_GzipWrittenPhase(t *testing.T) {
 	}
 
 	// Verify intent cleaned up.
-	loadedIntent, _ := loadIntent(ctx, ws, "memory", convID)
+	loadedIntent, _ := loadIntent(ctx, ws, "memory", "archive", convID)
 	if loadedIntent != nil {
 		t.Fatal("intent should be cleaned up after recovery")
 	}
@@ -218,9 +218,9 @@ func TestRecoverArchive_ManifestUpdatedPhase(t *testing.T) {
 		ConvID: convID, StartSeq: 0, EndSeq: 9,
 		BatchSize: 10, ArchiveFile: "messages_0_9.jsonl.gz", Phase: "manifest_updated",
 	}
-	_ = writeIntent(ctx, ws, "memory", convID, intent)
+	_ = writeIntent(ctx, ws, "memory", "archive", convID, intent)
 
-	if err := RecoverArchive(ctx, ws, store, "memory", convID); err != nil {
+	if err := RecoverArchive(ctx, ws, store, "memory", "archive", convID); err != nil {
 		t.Fatal(err)
 	}
 
@@ -229,7 +229,7 @@ func TestRecoverArchive_ManifestUpdatedPhase(t *testing.T) {
 		t.Fatalf("expected 10 remaining after recovery, got %d", len(after))
 	}
 
-	loadedIntent, _ := loadIntent(ctx, ws, "memory", convID)
+	loadedIntent, _ := loadIntent(ctx, ws, "memory", "archive", convID)
 	if loadedIntent != nil {
 		t.Fatal("intent should be cleaned up")
 	}
@@ -257,7 +257,7 @@ func TestArchive_IntentCleanup(t *testing.T) {
 	}
 
 	// After successful archive, intent should not exist.
-	loadedIntent, _ := loadIntent(ctx, ws, "memory", convID)
+	loadedIntent, _ := loadIntent(ctx, ws, "memory", "archive", convID)
 	if loadedIntent != nil {
 		t.Fatal("intent should be cleaned up after successful archive")
 	}

--- a/sdk/memory/bench_test.go
+++ b/sdk/memory/bench_test.go
@@ -192,6 +192,6 @@ func BenchmarkExpandFromArchive_50Messages(b *testing.B) {
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		_, _ = LoadArchivedMessages(ctx, ws, "memory", convID, 10, 59)
+		_, _ = LoadArchivedMessages(ctx, ws, "memory", "archive", convID, 10, 59)
 	}
 }

--- a/sdk/memory/tools.go
+++ b/sdk/memory/tools.go
@@ -92,7 +92,11 @@ func (t *memoryExpandTool) expandLeaf(ctx context.Context, convID string, node *
 
 	// Check archive manifest for Hot/Cold boundary.
 	if t.deps.Workspace != nil {
-		manifest, err := LoadManifest(ctx, t.deps.Workspace, t.deps.Prefix, convID)
+		archivePrefix := t.deps.Config.Archive.ArchivePrefix
+		if archivePrefix == "" {
+			archivePrefix = "archive"
+		}
+		manifest, err := LoadManifest(ctx, t.deps.Workspace, t.deps.Prefix, archivePrefix, convID)
 		if err == nil && manifest.HotStartSeq > 0 {
 			var allMsgs []model.Message
 
@@ -102,7 +106,7 @@ func (t *memoryExpandTool) expandLeaf(ctx context.Context, convID string, node *
 				if coldEnd > manifest.HotStartSeq {
 					coldEnd = manifest.HotStartSeq
 				}
-				coldMsgs, err := LoadArchivedMessages(ctx, t.deps.Workspace, t.deps.Prefix, convID, startSeq, coldEnd-1)
+				coldMsgs, err := LoadArchivedMessages(ctx, t.deps.Workspace, t.deps.Prefix, archivePrefix, convID, startSeq, coldEnd-1)
 				if err == nil {
 					allMsgs = append(allMsgs, coldMsgs...)
 				}


### PR DESCRIPTION
## Summary

- Fix `ArchiveConfig.ArchivePrefix` which was defined but never actually used
- Replace hardcoded `"archive"` subdirectory name in `archiveDir()` and `manifestPath()` with `cfg.ArchivePrefix`
- The external `prefix` parameter (root directory) remains unchanged

## Changes

- **archive.go**: Pass `archivePrefix` (from `cfg.ArchivePrefix`) into `archiveDir()`, `manifestPath()`, `intentPath()`, `writeIntent()`, `deleteIntent()`, `loadIntent()`
- **tools.go**: `LoadManifest` / `LoadArchivedMessages` callers now read `t.deps.Config.Archive.ArchivePrefix`
- **Tests**: Updated to use new function signatures

## Directory layout (unchanged by default)

```
{prefix}/{convID}/{ArchivePrefix}/manifest.json
{prefix}/{convID}/{ArchivePrefix}/messages_0_499.jsonl.gz
{prefix}/{convID}/{ArchivePrefix}/intent.json
```

Default `ArchivePrefix = "archive"` preserves backward compatibility.

## Test plan

- [x] All memory package tests pass
- [x] All SDK tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)