### PR TITLE
chore(sdkx): bump sdk dependency to v0.1.8

### DIFF
--- a/sdkx/go.mod
+++ b/sdkx/go.mod
@@ -2,7 +2,7 @@ module github.com/GizClaw/flowcraft/sdkx
 
 go 1.25.0
 
-require github.com/GizClaw/flowcraft/sdk v0.1.7
+require github.com/GizClaw/flowcraft/sdk v0.1.8
 
 require (
 	github.com/PuerkitoBio/goquery v1.11.0

--- a/sdkx/go.sum
+++ b/sdkx/go.sum
@@ -8,8 +8,8 @@ github.com/Azure/azure-sdk-for-go/sdk/internal v1.10.0/go.mod h1:iZDifYGJTIgIIkY
 github.com/AzureAD/microsoft-authentication-library-for-go v1.2.2 h1:XHOnouVk1mxXfQidrMEnLlPk9UMeRtyBTnEFtxkV0kU=
 github.com/AzureAD/microsoft-authentication-library-for-go v1.2.2/go.mod h1:wP83P5OoQ5p6ip3ScPr0BAq0BvuPAvacpEuSzyouqAI=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
-github.com/GizClaw/flowcraft/sdk v0.1.7 h1:cWipVa4JmVILV7RZ+3+Flmw1opH+BkhaBR/bLrETELg=
-github.com/GizClaw/flowcraft/sdk v0.1.7/go.mod h1:npXXZur4RskX1Zx6tZTEua+c7sfGTHQGX6kfHnTCwP4=
+github.com/GizClaw/flowcraft/sdk v0.1.8 h1:dzLeVFowWeVbikmsdQCoeZ8b084AF8wxj1KyfUkn/mc=
+github.com/GizClaw/flowcraft/sdk v0.1.8/go.mod h1:npXXZur4RskX1Zx6tZTEua+c7sfGTHQGX6kfHnTCwP4=
 github.com/PuerkitoBio/goquery v1.11.0 h1:jZ7pwMQXIITcUXNH83LLk+txlaEy6NVOfTuP43xxfqw=
 github.com/PuerkitoBio/goquery v1.11.0/go.mod h1:wQHgxUOU3JGuj3oD/QFfxUdlzW6xPHfqyHre6VMY4DQ=
 github.com/andybalholm/cascadia v1.3.3 h1:AG2YHrzJIm4BZ19iwJ/DAua6Btl3IwJX+VI4kktS1LM=


### PR DESCRIPTION
## Summary

Bump sdkx's dependency on the core SDK from v0.1.7 to v0.1.8.

## Changes

- **sdkx/go.mod**: Update `github.com/GizClaw/flowcraft/sdk` from v0.1.7 to v0.1.8

## Test plan

- [x] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)