### PR TITLE
fix(sdk/kanban): resolve 6 bugs from issue #28; unify event source on Board.Bus

### DIFF
--- a/sdk/kanban/board.go
+++ b/sdk/kanban/board.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"maps"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/GizClaw/flowcraft/sdk/event"
@@ -15,11 +16,69 @@ import (
 	otellog "go.opentelemetry.io/otel/log"
 )
 
+// watchBufSize is the initial capacity hint for a watcher's internal queue.
+// The queue grows on demand; events are never dropped.
 const watchBufSize = 32
 
+// watcher delivers card snapshots to a single subscriber via an unbounded
+// internal queue. notifyWatchers enqueues without blocking; a dedicated pump
+// goroutine forwards events to the consumer-visible channel `out`.
 type watcher struct {
 	filter CardFilter
-	ch     chan *Card
+	out    chan *Card
+
+	mu     sync.Mutex
+	queue  []*Card
+	notify chan struct{} // buffered(1); signal that queue has items or is closed
+	closed bool
+}
+
+// enqueue appends snap to the internal queue and wakes the pump goroutine.
+// It never blocks and never drops events.
+func (w *watcher) enqueue(snap *Card) {
+	w.mu.Lock()
+	if w.closed {
+		w.mu.Unlock()
+		return
+	}
+	w.queue = append(w.queue, snap)
+	w.mu.Unlock()
+	select {
+	case w.notify <- struct{}{}:
+	default:
+	}
+}
+
+// shutdown marks the watcher closed and wakes the pump so it can drain and exit.
+func (w *watcher) shutdown() {
+	w.mu.Lock()
+	w.closed = true
+	w.mu.Unlock()
+	select {
+	case w.notify <- struct{}{}:
+	default:
+	}
+}
+
+// pump runs in a goroutine, draining queue → out until shutdown.
+// On shutdown it flushes any remaining buffered events and closes out.
+func (w *watcher) pump() {
+	defer close(w.out)
+	for {
+		w.mu.Lock()
+		batch := w.queue
+		w.queue = nil
+		closed := w.closed
+		w.mu.Unlock()
+
+		for _, snap := range batch {
+			w.out <- snap
+		}
+		if closed {
+			return
+		}
+		<-w.notify
+	}
 }
 
 // Board is the kanban task board: card coordination + scope + EventBus.
@@ -40,6 +99,11 @@ type Board struct {
 	ctx       context.Context
 	cancel    context.CancelFunc
 	closeOnce sync.Once
+
+	// watcherDropped tracks notifications dropped because a watcher was
+	// already shut down. With the unbounded queue the value is informational
+	// only — live watchers never lose events.
+	watcherDropped atomic.Int64
 }
 
 // TaskBoard is a legacy alias for Board.
@@ -132,10 +196,41 @@ func (b *Board) Produce(cardType, producer string, payload any, opts ...CardOpti
 
 	snap := copyKanbanCard(card)
 	b.notifyWatchers(snap)
+	b.publishProduceEvent(snap)
 	return snap
 }
 
+// publishProduceEvent emits EventTaskSubmitted on Bus() for newly produced
+// task cards. Internal types and non-task cards are skipped.
+func (b *Board) publishProduceEvent(snap *Card) {
+	if b.bus == nil || snap == nil {
+		return
+	}
+	if snap.Type != "task" {
+		return
+	}
+	ctx := b.ctx
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	p := PayloadMap(snap.Payload)
+	target, _ := p["target_agent_id"].(string)
+	query, _ := p["query"].(string)
+	var inputs map[string]any
+	if v, ok := p["inputs"].(map[string]any); ok {
+		inputs = v
+	}
+	_ = b.bus.Publish(ctx, eventEnvelope(EventTaskSubmitted, TaskSubmittedPayload{
+		CardID:        snap.ID,
+		TargetAgentID: target,
+		Query:         query,
+		RuntimeID:     b.scopeID,
+		Inputs:        inputs,
+	}))
+}
+
 // Claim transitions a pending card to claimed status for the given consumer.
+// Publishes EventTaskClaimed to Bus() for task-typed cards.
 func (b *Board) Claim(cardID, consumer string) bool {
 	b.cardMu.Lock()
 	var snap *Card
@@ -152,12 +247,14 @@ func (b *Board) Claim(cardID, consumer string) bool {
 	b.cardMu.Unlock()
 	if snap != nil {
 		b.notifyWatchers(snap)
+		b.publishCardEvent(snap)
 		return true
 	}
 	return false
 }
 
 // Done transitions a claimed card to done status with a result payload.
+// Publishes EventTaskCompleted to Bus() for task-typed cards.
 func (b *Board) Done(cardID string, result any) bool {
 	b.cardMu.Lock()
 	var snap *Card
@@ -174,12 +271,14 @@ func (b *Board) Done(cardID string, result any) bool {
 	b.cardMu.Unlock()
 	if snap != nil {
 		b.notifyWatchers(snap)
+		b.publishCardEvent(snap)
 		return true
 	}
 	return false
 }
 
 // Fail transitions a pending or claimed card to failed status with an error message.
+// Publishes EventTaskFailed to Bus() for task-typed cards.
 func (b *Board) Fail(cardID string, errMsg string) bool {
 	b.cardMu.Lock()
 	var snap *Card
@@ -196,9 +295,61 @@ func (b *Board) Fail(cardID string, errMsg string) bool {
 	b.cardMu.Unlock()
 	if snap != nil {
 		b.notifyWatchers(snap)
+		b.publishCardEvent(snap)
 		return true
 	}
 	return false
+}
+
+// publishCardEvent maps a card transition snapshot to the matching Kanban event
+// type and publishes it on Board.Bus(). Internal card types (cron rules /
+// result rows) are skipped — they are not part of the public state machine.
+func (b *Board) publishCardEvent(snap *Card) {
+	if b.bus == nil || snap == nil {
+		return
+	}
+	if isInternalCardType(snap.Type) {
+		return
+	}
+	if snap.Type != "task" {
+		return
+	}
+	ctx := b.ctx
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	p := PayloadMap(snap.Payload)
+	target, _ := p["target_agent_id"].(string)
+	output, _ := p["output"].(string)
+	elapsedMs := int64(0)
+	if snap.UpdatedAt.After(snap.CreatedAt) {
+		elapsedMs = snap.UpdatedAt.Sub(snap.CreatedAt).Milliseconds()
+	}
+	switch snap.Status {
+	case CardClaimed:
+		_ = b.bus.Publish(ctx, eventEnvelope(EventTaskClaimed, TaskClaimedPayload{
+			CardID:        snap.ID,
+			TargetAgentID: target,
+			RuntimeID:     b.scopeID,
+			Consumer:      snap.Consumer,
+		}))
+	case CardDone:
+		_ = b.bus.Publish(ctx, eventEnvelope(EventTaskCompleted, TaskCompletedPayload{
+			CardID:        snap.ID,
+			TargetAgentID: target,
+			RuntimeID:     b.scopeID,
+			Output:        output,
+			ElapsedMs:     elapsedMs,
+		}))
+	case CardFailed:
+		_ = b.bus.Publish(ctx, eventEnvelope(EventTaskFailed, TaskFailedPayload{
+			CardID:        snap.ID,
+			TargetAgentID: target,
+			RuntimeID:     b.scopeID,
+			Error:         snap.Error,
+			ElapsedMs:     elapsedMs,
+		}))
+	}
 }
 
 // Query returns copies of all cards matching the filter.
@@ -314,16 +465,22 @@ func (b *Board) evictTerminalCardsLocked() {
 }
 
 // WatchFiltered returns a channel that receives newly produced cards matching the filter.
-// The channel is closed when ctx is cancelled.
+// The channel is closed when ctx is cancelled. The internal queue is unbounded:
+// notifications are never dropped while the watcher is alive, so slow consumers
+// can still observe every state transition.
 func (b *Board) WatchFiltered(ctx context.Context, filter CardFilter) <-chan *Card {
 	w := &watcher{
 		filter: filter,
-		ch:     make(chan *Card, watchBufSize),
+		out:    make(chan *Card),
+		queue:  make([]*Card, 0, watchBufSize),
+		notify: make(chan struct{}, 1),
 	}
 
 	b.wmu.Lock()
 	b.watchers = append(b.watchers, w)
 	b.wmu.Unlock()
+
+	go w.pump()
 
 	go func() {
 		<-ctx.Done()
@@ -335,10 +492,17 @@ func (b *Board) WatchFiltered(ctx context.Context, filter CardFilter) <-chan *Ca
 			}
 		}
 		b.wmu.Unlock()
-		close(w.ch)
+		w.shutdown()
 	}()
 
-	return w.ch
+	return w.out
+}
+
+// WatcherDropped returns the cumulative number of notifications dropped because
+// a watcher had already been shut down (i.e. its consumer disappeared but the
+// removal goroutine had not yet run). Live watchers never drop events.
+func (b *Board) WatcherDropped() int64 {
+	return b.watcherDropped.Load()
 }
 
 // Watch subscribes to all card changes. If ctx is nil, the subscription uses the board lifecycle context.
@@ -368,12 +532,20 @@ func (b *Board) RemapCardID(oldID, newID string) {
 	}
 }
 
-// Cards returns a snapshot of task cards on the board (excludes "result" cards).
+// isInternalCardType reports whether c is an internal card type that must not
+// leak into user-facing views (Cards / Timeline). Currently this covers the
+// scheduler's persisted cron rule cards and the legacy "result" cards.
+func isInternalCardType(t string) bool {
+	return t == "result" || t == cardTypeCronRule
+}
+
+// Cards returns a snapshot of task cards on the board, excluding internal
+// bookkeeping cards (result rows and cron rule definitions).
 func (b *Board) Cards() []CardInfo {
 	raw := b.RawCards()
 	out := make([]CardInfo, 0, len(raw))
 	for _, c := range raw {
-		if c.Type == "result" {
+		if isInternalCardType(c.Type) {
 			continue
 		}
 		ci := CardInfo{
@@ -398,11 +570,12 @@ func (b *Board) Cards() []CardInfo {
 }
 
 // Timeline returns card state history suitable for Gantt chart rendering.
+// Internal bookkeeping cards (result rows, cron rule definitions) are excluded.
 func (b *Board) Timeline() []TimelineEntry {
 	raw := b.RawCards()
 	out := make([]TimelineEntry, 0, len(raw))
 	for _, c := range raw {
-		if c.Type == "result" {
+		if isInternalCardType(c.Type) {
 			continue
 		}
 		te := TimelineEntry{
@@ -452,7 +625,9 @@ func (b *Board) Topology() Topology {
 	return Topology{Nodes: nodes, Edges: edges}
 }
 
-// RestoreTaskBoard reconstructs a Board from persisted KanbanCards.
+// RestoreTaskBoard reconstructs a Board from persisted KanbanCards. Each
+// card's persisted CreatedAt / UpdatedAt is honoured so timeline views and
+// elapsed-time metrics stay correct across a process restart.
 func RestoreTaskBoard(scopeID string, cards []*KanbanCardModel) *Board {
 	b := NewBoard(scopeID)
 	for _, c := range cards {
@@ -460,7 +635,10 @@ func RestoreTaskBoard(scopeID string, cards []*KanbanCardModel) *Board {
 			"query":           c.Query,
 			"target_agent_id": c.TargetAgentID,
 		}
-		card := b.Produce(c.Type, c.Producer, payload, WithConsumer(c.Consumer))
+		// Stamp the persisted CreatedAt; UpdatedAt is set per terminal state below.
+		card := b.Produce(c.Type, c.Producer, payload,
+			WithConsumer(c.Consumer),
+			WithTimestamps(c.CreatedAt, c.CreatedAt))
 
 		remapKanbanCardID(b, card.ID, c.ID)
 
@@ -480,8 +658,29 @@ func RestoreTaskBoard(scopeID string, cards []*KanbanCardModel) *Board {
 			b.Claim(c.ID, c.Consumer)
 			b.Fail(c.ID, c.Error)
 		}
+		// Claim/Done/Fail re-stamped UpdatedAt to time.Now(). Force it back to
+		// the persisted value so external timeline / SLA metrics remain accurate.
+		b.restoreTimestamps(c.ID, c.CreatedAt, c.UpdatedAt)
 	}
 	return b
+}
+
+// restoreTimestamps overwrites CreatedAt / UpdatedAt on an existing card to the
+// persisted values. Internal helper for RestoreTaskBoard; must not be exposed
+// because regular state transitions are responsible for stamping UpdatedAt.
+func (b *Board) restoreTimestamps(cardID string, created, updated time.Time) {
+	b.cardMu.Lock()
+	defer b.cardMu.Unlock()
+	c, ok := b.cardIndex[cardID]
+	if !ok {
+		return
+	}
+	if !created.IsZero() {
+		c.CreatedAt = created
+	}
+	if !updated.IsZero() {
+		c.UpdatedAt = updated
+	}
 }
 
 func remapKanbanCardID(b *Board, oldID, newID string) {
@@ -513,17 +712,26 @@ func matchKanbanCard(c *Card, f CardFilter) bool {
 
 func (b *Board) notifyWatchers(snap *Card) {
 	b.wmu.Lock()
-	defer b.wmu.Unlock()
+	matched := make([]*watcher, 0, len(b.watchers))
 	for _, w := range b.watchers {
 		if notifyKanbanMatch(snap, w.filter) {
-			select {
-			case w.ch <- snap:
-			default:
-				telemetry.Warn(b.ctx, "kanban: watcher channel full, card notification dropped",
-					otellog.String("card_id", snap.ID),
-					otellog.String("status", string(snap.Status)))
-			}
+			matched = append(matched, w)
 		}
+	}
+	b.wmu.Unlock()
+
+	for _, w := range matched {
+		w.mu.Lock()
+		closed := w.closed
+		w.mu.Unlock()
+		if closed {
+			b.watcherDropped.Add(1)
+			telemetry.Warn(b.ctx, "kanban: watcher already shut down, card notification dropped",
+				otellog.String("card_id", snap.ID),
+				otellog.String("status", string(snap.Status)))
+			continue
+		}
+		w.enqueue(snap)
 	}
 }
 

--- a/sdk/kanban/board_concurrency_test.go
+++ b/sdk/kanban/board_concurrency_test.go
@@ -1,0 +1,198 @@
+package kanban
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/GizClaw/flowcraft/sdk/event"
+)
+
+// ---------------------------------------------------------------------------
+// Board concurrency — race / deadlock guards.
+//
+// Always run with -race. None of these tests assert ordering; they assert
+// invariants that must hold under any interleaving (no panics, all events
+// delivered, indexes stay consistent).
+// ---------------------------------------------------------------------------
+
+func TestBoard_Concurrent_ProduceAndQuery(t *testing.T) {
+	t.Parallel()
+	b := newBoard(t)
+	const n = 50
+
+	var wg sync.WaitGroup
+	for i := 0; i < n; i++ {
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			b.Produce("task", "p", nil)
+		}()
+		go func() {
+			defer wg.Done()
+			_ = b.Query(CardFilter{Type: "task"})
+		}()
+	}
+	wg.Wait()
+
+	if got := b.Len(); got != n {
+		t.Fatalf("Len()=%d, want %d", got, n)
+	}
+}
+
+func TestBoard_Concurrent_FullLifecycle(t *testing.T) {
+	t.Parallel()
+	b := newBoard(t)
+	const n = 100
+
+	cardIDs := make([]string, n)
+	var wg sync.WaitGroup
+
+	for i := 0; i < n; i++ {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			c := b.Produce("task", fmt.Sprintf("p-%d", idx), map[string]any{"idx": idx})
+			cardIDs[idx] = c.ID
+		}(i)
+	}
+	wg.Wait()
+	if got := b.Len(); got != n {
+		t.Fatalf("after Produce: Len()=%d, want %d", got, n)
+	}
+
+	for i := 0; i < n; i++ {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			if !b.Claim(cardIDs[idx], fmt.Sprintf("c-%d", idx)) {
+				t.Errorf("claim %d failed", idx)
+			}
+		}(i)
+	}
+	wg.Wait()
+
+	for i := 0; i < n; i++ {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			b.Done(cardIDs[idx], fmt.Sprintf("result-%d", idx))
+		}(i)
+	}
+	wg.Wait()
+
+	if got := len(b.Query(CardFilter{Status: CardDone})); got != n {
+		t.Fatalf("done cards = %d, want %d", got, n)
+	}
+}
+
+func TestBoard_Concurrent_WatchAndProduce(t *testing.T) {
+	t.Parallel()
+	b := newBoard(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	const watchers = 5
+	const produces = 20
+
+	channels := make([]<-chan *Card, watchers)
+	for i := 0; i < watchers; i++ {
+		channels[i] = b.WatchFiltered(ctx, CardFilter{})
+	}
+
+	var wg sync.WaitGroup
+	for i := 0; i < produces; i++ {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			b.Produce("task", "p", map[string]any{"i": idx})
+		}(i)
+	}
+	wg.Wait()
+
+	for wi, ch := range channels {
+		count := 0
+		timeout := time.After(time.Second)
+	drain:
+		for {
+			select {
+			case <-ch:
+				count++
+				if count == produces {
+					break drain
+				}
+			case <-timeout:
+				break drain
+			}
+		}
+		if count != produces {
+			t.Fatalf("watcher %d: got %d events, want %d", wi, count, produces)
+		}
+	}
+}
+
+func TestBoard_Concurrent_BusSubscribe(t *testing.T) {
+	t.Parallel()
+	b := newBoard(t)
+
+	ctx := context.Background()
+	const subs = 20
+
+	var wg sync.WaitGroup
+	errs := make(chan error, subs)
+	for i := 0; i < subs; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			if _, err := b.Bus().Subscribe(ctx, event.EventFilter{}); err != nil {
+				errs <- err
+			}
+		}()
+	}
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		t.Fatalf("concurrent Subscribe failed: %v", err)
+	}
+}
+
+// CountByStatus must remain consistent with Query() under concurrent
+// state transitions — guards the cardIndex / statusIndex pair.
+func TestBoard_Concurrent_IndexConsistency(t *testing.T) {
+	t.Parallel()
+	b := newBoard(t)
+	const n = 50
+
+	ids := make([]string, n)
+	for i := 0; i < n; i++ {
+		ids[i] = b.Produce("task", "p", nil).ID
+	}
+
+	if got := b.CountByStatus(CardPending, ""); got != n {
+		t.Fatalf("initial pending=%d, want %d", got, n)
+	}
+
+	done := make(chan struct{})
+	for i := 0; i < n; i++ {
+		go func(id string) {
+			b.Claim(id, "a")
+			b.Done(id, "r")
+			done <- struct{}{}
+		}(ids[i])
+	}
+	for i := 0; i < n; i++ {
+		<-done
+	}
+
+	for status, want := range map[CardStatus]int{
+		CardDone:    n,
+		CardPending: 0,
+		CardClaimed: 0,
+	} {
+		if got := b.CountByStatus(status, ""); got != want {
+			t.Errorf("CountByStatus(%s)=%d, want %d", status, got, want)
+		}
+	}
+}

--- a/sdk/kanban/board_restore_test.go
+++ b/sdk/kanban/board_restore_test.go
@@ -1,0 +1,158 @@
+package kanban
+
+import (
+	"testing"
+	"time"
+)
+
+// ---------------------------------------------------------------------------
+// RestoreTaskBoard — rebuild a board from persisted KanbanCardModel rows.
+//
+// Bug 5 (issue #28): historical CreatedAt/UpdatedAt must survive restore so
+// timeline/SLA metrics keep reporting accurate elapsed times.
+// ---------------------------------------------------------------------------
+
+func TestRestoreTaskBoard_AllStates(t *testing.T) {
+	t.Parallel()
+	now := time.Now()
+	cards := []*KanbanCardModel{
+		{
+			ID: "c1", RuntimeID: "s1", Type: "task", Status: "pending",
+			Producer: "copilot", Consumer: "*",
+			Query: "q1", TargetAgentID: "agent-1",
+			CreatedAt: now, UpdatedAt: now,
+		},
+		{
+			ID: "c2", RuntimeID: "s1", Type: "task", Status: "claimed",
+			Producer: "copilot", Consumer: "agent-2",
+			Query: "q2", TargetAgentID: "agent-2",
+			CreatedAt: now, UpdatedAt: now,
+		},
+		{
+			ID: "c3", RuntimeID: "s1", Type: "task", Status: "done",
+			Producer: "copilot", Consumer: "agent-3",
+			Query: "q3", TargetAgentID: "agent-3", Output: "result", RunID: "run-1",
+			CreatedAt: now, UpdatedAt: now,
+		},
+		{
+			ID: "c4", RuntimeID: "s1", Type: "task", Status: "failed",
+			Producer: "copilot", Consumer: "agent-4",
+			Query: "q4", TargetAgentID: "agent-4", Error: "timeout",
+			CreatedAt: now, UpdatedAt: now,
+		},
+	}
+
+	tb := RestoreTaskBoard("s1", cards)
+	t.Cleanup(tb.Close)
+
+	if tb.ScopeID() != "s1" {
+		t.Fatalf("ScopeID = %q, want s1", tb.ScopeID())
+	}
+
+	got := make(map[string]string)
+	for _, c := range tb.Cards() {
+		got[c.ID] = c.Status
+	}
+	want := map[string]string{
+		"c1": "pending", "c2": "claimed", "c3": "done", "c4": "failed",
+	}
+	if len(got) != len(want) {
+		t.Fatalf("Cards()=%d, want %d", len(got), len(want))
+	}
+	for id, status := range want {
+		if got[id] != status {
+			t.Errorf("card %s: status=%q, want %q", id, got[id], status)
+		}
+	}
+
+	// Done card retains output / run_id during restore.
+	for _, c := range tb.Cards() {
+		if c.ID != "c3" {
+			continue
+		}
+		if c.RunID != "run-1" || c.Output != "result" {
+			t.Errorf("c3 lost done-state fields: %+v", c)
+		}
+	}
+}
+
+func TestRestoreTaskBoard_Empty(t *testing.T) {
+	t.Parallel()
+	tb := RestoreTaskBoard("s-empty", nil)
+	t.Cleanup(tb.Close)
+
+	if tb.ScopeID() != "s-empty" {
+		t.Fatalf("ScopeID = %q, want s-empty", tb.ScopeID())
+	}
+	if got := len(tb.Cards()); got != 0 {
+		t.Fatalf("Cards()=%d, want 0", got)
+	}
+}
+
+// Bug 5: historical timestamps must not be replaced by time.Now() during
+// the synthetic Claim/Done/Fail calls RestoreTaskBoard makes internally.
+func TestRestoreTaskBoard_PreservesTimestamps(t *testing.T) {
+	t.Parallel()
+	created := time.Date(2024, 1, 2, 10, 0, 0, 0, time.UTC)
+	updated := time.Date(2024, 1, 2, 10, 5, 30, 0, time.UTC)
+
+	tb := RestoreTaskBoard("s1", []*KanbanCardModel{{
+		ID: "c-old", RuntimeID: "s1", Type: "task", Status: "done",
+		Producer: "copilot", Consumer: "agent-1",
+		Query: "q", TargetAgentID: "agent-1", Output: "ok",
+		CreatedAt: created, UpdatedAt: updated,
+	}})
+	t.Cleanup(tb.Close)
+
+	got, ok := tb.GetCardByID("c-old")
+	if !ok {
+		t.Fatal("restored card not found")
+	}
+	if !got.CreatedAt.Equal(created) {
+		t.Errorf("CreatedAt overwritten: got %v, want %v", got.CreatedAt, created)
+	}
+	if !got.UpdatedAt.Equal(updated) {
+		t.Errorf("UpdatedAt overwritten: got %v, want %v", got.UpdatedAt, updated)
+	}
+
+	// Derived fields (e.g. ElapsedMs) must reflect the restored stamps.
+	infos := tb.Cards()
+	if len(infos) != 1 {
+		t.Fatalf("Cards()=%d, want 1", len(infos))
+	}
+	wantElapsed := updated.Sub(created).Milliseconds()
+	if infos[0].ElapsedMs != wantElapsed {
+		t.Errorf("ElapsedMs = %d, want %d", infos[0].ElapsedMs, wantElapsed)
+	}
+}
+
+// WithTimestamps is the public hook RestoreTaskBoard now uses internally.
+// Verify it overrides Produce's default time.Now() but does not break the
+// default path when not supplied.
+func TestBoard_WithTimestamps(t *testing.T) {
+	t.Parallel()
+	b := newBoard(t)
+
+	created := time.Date(2023, 6, 1, 12, 0, 0, 0, time.UTC)
+	updated := time.Date(2023, 6, 1, 12, 30, 0, 0, time.UTC)
+
+	t.Run("override", func(t *testing.T) {
+		card := b.Produce("task", "p", nil, WithTimestamps(created, updated))
+		if !card.CreatedAt.Equal(created) {
+			t.Errorf("CreatedAt = %v, want %v", card.CreatedAt, created)
+		}
+		if !card.UpdatedAt.Equal(updated) {
+			t.Errorf("UpdatedAt = %v, want %v", card.UpdatedAt, updated)
+		}
+	})
+
+	t.Run("default_still_now", func(t *testing.T) {
+		card := b.Produce("task", "p", nil)
+		if card.CreatedAt.IsZero() {
+			t.Fatal("default Produce must stamp CreatedAt")
+		}
+		if time.Since(card.CreatedAt) > time.Second {
+			t.Fatalf("default CreatedAt should be ~now, got %v ago", time.Since(card.CreatedAt))
+		}
+	})
+}

--- a/sdk/kanban/board_test.go
+++ b/sdk/kanban/board_test.go
@@ -2,8 +2,6 @@ package kanban
 
 import (
 	"context"
-	"fmt"
-	"sync"
 	"testing"
 	"time"
 
@@ -11,137 +9,197 @@ import (
 )
 
 // ---------------------------------------------------------------------------
-// Produce / deep copy
+// Construction
 // ---------------------------------------------------------------------------
 
-func TestBoard_Produce_ReturnsDeepCopy(t *testing.T) {
-	b := NewBoard("scope-dc1")
-	defer b.Close()
-	card := b.Produce("task", "p", map[string]any{"key": "val"}, WithMeta("m", "v"))
-
-	card.Status = CardDone
-	card.Meta["m"] = "mutated"
-
-	internal := b.Last(CardFilter{Type: "task"})
-	if internal.Status != CardPending {
-		t.Fatalf("internal card should still be Pending, got %s", internal.Status)
-	}
-	if internal.Meta["m"] != "v" {
-		t.Fatalf("internal meta should be 'v', got %s", internal.Meta["m"])
-	}
-}
-
-func TestBoard_Query_ReturnsDeepCopies(t *testing.T) {
-	b := NewBoard("scope-dc2")
-	defer b.Close()
-	b.Produce("task", "p", nil)
-	b.Produce("task", "p", nil)
-
-	cards := b.Query(CardFilter{Type: "task"})
-	for _, c := range cards {
-		c.Status = CardDone
-	}
-
-	internal := b.Query(CardFilter{Type: "task"})
-	for _, c := range internal {
-		if c.Status != CardPending {
-			t.Fatalf("mutation through Query should not affect internal state, got %s", c.Status)
-		}
+func TestBoard_New(t *testing.T) {
+	t.Parallel()
+	for _, ctor := range []struct {
+		name string
+		make func(scope string) *Board
+	}{
+		{"NewBoard", func(s string) *Board { return NewBoard(s) }},
+		{"NewTaskBoard", func(s string) *Board { return NewTaskBoard(s) }},
+	} {
+		ctor := ctor
+		t.Run(ctor.name, func(t *testing.T) {
+			t.Parallel()
+			b := ctor.make(scopeID(t))
+			t.Cleanup(b.Close)
+			if b.ScopeID() == "" {
+				t.Fatal("ScopeID empty")
+			}
+		})
 	}
 }
 
-func TestBoard_Last_ReturnsDeepCopy(t *testing.T) {
-	b := NewBoard("scope-dc3")
-	defer b.Close()
-	b.Produce("task", "p", "payload")
-
-	last := b.Last(CardFilter{Type: "task"})
-	last.Producer = "mutated"
-
-	check := b.Last(CardFilter{Type: "task"})
-	if check.Producer == "mutated" {
-		t.Fatal("Last() should return a copy; mutation should not affect internal state")
-	}
-}
-
-func TestBoard_RawCards_ReturnsDeepCopies(t *testing.T) {
-	b := NewBoard("scope-dc4")
-	defer b.Close()
-	b.Produce("task", "p", nil)
-
-	cards := b.RawCards()
-	cards[0].Type = "mutated"
-
-	check := b.RawCards()
-	if check[0].Type == "mutated" {
-		t.Fatal("RawCards() should return copies; mutation should not affect internal state")
-	}
+func TestBoard_Close_Idempotent(t *testing.T) {
+	t.Parallel()
+	b := NewBoard(scopeID(t))
+	b.Close()
+	b.Close() // second close must not panic
 }
 
 // ---------------------------------------------------------------------------
-// Claim / Done / Fail state transitions
+// Deep-copy isolation: callers must not be able to mutate Board state
+// through any returned Card. Covers Produce / Query / Last / RawCards /
+// GetCardByID — they all use the same deepCopy path.
 // ---------------------------------------------------------------------------
 
-func TestBoard_DoubleClaimFails(t *testing.T) {
-	b := NewBoard("scope-dcf")
-	defer b.Close()
-	card := b.Produce("task", "p", nil)
+func TestBoard_ReturnsDeepCopies(t *testing.T) {
+	t.Parallel()
 
-	if !b.Claim(card.ID, "a1") {
-		t.Fatal("first claim should succeed")
+	cases := []struct {
+		name   string
+		mutate func(b *Board, original *Card)
+		check  func(t *testing.T, b *Board, original *Card)
+	}{
+		{
+			name: "Produce_then_Last",
+			mutate: func(b *Board, c *Card) {
+				c.Status = CardDone
+				c.Meta["m"] = "mutated"
+			},
+			check: func(t *testing.T, b *Board, _ *Card) {
+				got := b.Last(CardFilter{Type: "task"})
+				if got.Status != CardPending || got.Meta["m"] != "v" {
+					t.Fatalf("internal state leaked: status=%s meta=%q", got.Status, got.Meta["m"])
+				}
+			},
+		},
+		{
+			name: "Query",
+			mutate: func(b *Board, _ *Card) {
+				for _, c := range b.Query(CardFilter{Type: "task"}) {
+					c.Status = CardDone
+				}
+			},
+			check: func(t *testing.T, b *Board, _ *Card) {
+				for _, c := range b.Query(CardFilter{Type: "task"}) {
+					if c.Status != CardPending {
+						t.Fatalf("Query mutation leaked into board")
+					}
+				}
+			},
+		},
+		{
+			name: "Last",
+			mutate: func(b *Board, _ *Card) {
+				b.Last(CardFilter{Type: "task"}).Producer = "mutated"
+			},
+			check: func(t *testing.T, b *Board, _ *Card) {
+				if got := b.Last(CardFilter{Type: "task"}).Producer; got == "mutated" {
+					t.Fatalf("Last mutation leaked: producer=%q", got)
+				}
+			},
+		},
+		{
+			name: "RawCards",
+			mutate: func(b *Board, _ *Card) {
+				b.RawCards()[0].Type = "mutated"
+			},
+			check: func(t *testing.T, b *Board, _ *Card) {
+				if got := b.RawCards()[0].Type; got == "mutated" {
+					t.Fatalf("RawCards mutation leaked: type=%q", got)
+				}
+			},
+		},
+		{
+			name: "GetCardByID",
+			mutate: func(b *Board, original *Card) {
+				got, _ := b.GetCardByID(original.ID)
+				got.Status = CardDone
+			},
+			check: func(t *testing.T, b *Board, original *Card) {
+				got, _ := b.GetCardByID(original.ID)
+				if got.Status != CardPending {
+					t.Fatalf("GetCardByID mutation leaked: status=%s", got.Status)
+				}
+			},
+		},
 	}
-	if b.Claim(card.ID, "a2") {
-		t.Fatal("second claim should fail (already claimed)")
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			b := newBoard(t)
+			card := b.Produce("task", "p", map[string]any{"k": "v"}, WithMeta("m", "v"))
+			tc.mutate(b, card)
+			tc.check(t, b, card)
+		})
 	}
 }
 
-func TestBoard_DoneOnPendingFails(t *testing.T) {
-	b := NewBoard("scope-dop")
-	defer b.Close()
-	card := b.Produce("task", "p", nil)
+// ---------------------------------------------------------------------------
+// State machine: Claim / Done / Fail transitions and validity rules.
+// ---------------------------------------------------------------------------
 
-	if b.Done(card.ID, "result") {
-		t.Fatal("Done on pending card should fail")
+func TestBoard_StateTransitions(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name    string
+		setup   func(b *Board) string
+		action  func(b *Board, id string) bool
+		wantOK  bool
+		wantEnd CardStatus
+	}{
+		{"DoubleClaim_fails", func(b *Board) string {
+			c := b.Produce("task", "p", nil)
+			b.Claim(c.ID, "a1")
+			return c.ID
+		}, func(b *Board, id string) bool { return b.Claim(id, "a2") }, false, CardClaimed},
+
+		{"DoneOnPending_fails", func(b *Board) string {
+			return b.Produce("task", "p", nil).ID
+		}, func(b *Board, id string) bool { return b.Done(id, "r") }, false, CardPending},
+
+		{"DoneAfterDone_fails", func(b *Board) string {
+			c := b.Produce("task", "p", nil)
+			b.Claim(c.ID, "a")
+			b.Done(c.ID, "r1")
+			return c.ID
+		}, func(b *Board, id string) bool { return b.Done(id, "r2") }, false, CardDone},
+
+		{"FailOnPending_succeeds", func(b *Board) string {
+			return b.Produce("task", "p", nil).ID
+		}, func(b *Board, id string) bool { return b.Fail(id, "boom") }, true, CardFailed},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			b := newBoard(t)
+			id := tc.setup(b)
+			if got := tc.action(b, id); got != tc.wantOK {
+				t.Fatalf("action returned %v, want %v", got, tc.wantOK)
+			}
+			got, _ := b.GetCardByID(id)
+			if got.Status != tc.wantEnd {
+				t.Fatalf("end state %s, want %s", got.Status, tc.wantEnd)
+			}
+		})
 	}
 }
 
-func TestBoard_DoneAfterDoneFails(t *testing.T) {
-	b := NewBoard("scope-dad")
-	defer b.Close()
-	card := b.Produce("task", "p", nil)
-	b.Claim(card.ID, "a")
-	b.Done(card.ID, "r1")
-
-	if b.Done(card.ID, "r2") {
-		t.Fatal("double Done should fail")
-	}
-}
-
-func TestBoard_FailOnPendingSucceeds(t *testing.T) {
-	b := NewBoard("scope-fop")
-	defer b.Close()
-	card := b.Produce("task", "p", nil)
-
-	if !b.Fail(card.ID, "error") {
+func TestBoard_FailFromPending_RecordsError(t *testing.T) {
+	t.Parallel()
+	b := newBoard(t)
+	c := b.Produce("task", "p", nil)
+	if !b.Fail(c.ID, "error") {
 		t.Fatal("Fail on pending card should succeed")
 	}
-	for _, c := range b.Cards() {
-		if c.ID == card.ID {
-			if c.Status != string(CardFailed) {
-				t.Fatalf("expected CardFailed, got %s", c.Status)
-			}
-			if c.Error != "error" {
-				t.Fatalf("expected error message, got %q", c.Error)
-			}
-			return
-		}
+	got, _ := b.GetCardByID(c.ID)
+	if got.Error != "error" {
+		t.Fatalf("Error = %q, want %q", got.Error, "error")
 	}
-	t.Fatal("card not found")
 }
 
-func TestBoard_QueryDoneFailedPendingCounts(t *testing.T) {
-	b := NewBoard("scope-qcounts")
-	defer b.Close()
+func TestBoard_QueryByStatus_Counts(t *testing.T) {
+	t.Parallel()
+	b := newBoard(t)
 
 	c1 := b.Produce("task", "p1", "payload1")
 	b.Claim(c1.ID, "a1")
@@ -151,74 +209,16 @@ func TestBoard_QueryDoneFailedPendingCounts(t *testing.T) {
 	b.Claim(c2.ID, "a2")
 	b.Fail(c2.ID, "oops")
 
-	b.Produce("task", "p3", "payload3")
+	b.Produce("task", "p3", "payload3") // pending
 
-	if len(b.Query(CardFilter{Status: CardDone})) != 1 {
-		t.Fatalf("done: %d", len(b.Query(CardFilter{Status: CardDone})))
-	}
-	if len(b.Query(CardFilter{Status: CardFailed})) != 1 {
-		t.Fatalf("failed: %d", len(b.Query(CardFilter{Status: CardFailed})))
-	}
-	if len(b.Query(CardFilter{Status: CardPending})) != 1 {
-		t.Fatalf("pending: %d", len(b.Query(CardFilter{Status: CardPending})))
-	}
-}
-
-// ---------------------------------------------------------------------------
-// GetCardByID
-// ---------------------------------------------------------------------------
-
-func TestBoard_GetCardByID(t *testing.T) {
-	b := NewBoard("scope-k4")
-	defer b.Close()
-
-	card := b.Produce("task", "p", map[string]any{"k": "v"})
-
-	got, ok := b.GetCardByID(card.ID)
-	if !ok {
-		t.Fatal("expected card to be found")
-	}
-	if got.ID != card.ID {
-		t.Fatalf("expected ID %q, got %q", card.ID, got.ID)
-	}
-
-	got.Status = CardDone
-	check, _ := b.GetCardByID(card.ID)
-	if check.Status != CardPending {
-		t.Fatal("GetCardByID should return a deep copy; mutation must not affect internal state")
-	}
-}
-
-func TestBoard_GetCardByID_NotFound(t *testing.T) {
-	b := NewBoard("scope-k4-nf")
-	defer b.Close()
-
-	_, ok := b.GetCardByID("nonexistent")
-	if ok {
-		t.Fatal("expected ok=false for nonexistent card")
-	}
-}
-
-func TestBoard_GetCardByID_AfterRemap(t *testing.T) {
-	b := NewBoard("scope-k4-remap")
-	defer b.Close()
-
-	card := b.Produce("task", "p", nil)
-	oldID := card.ID
-	newID := "remapped-id"
-	b.RemapCardID(oldID, newID)
-
-	_, ok := b.GetCardByID(oldID)
-	if ok {
-		t.Fatal("old ID should no longer be found after remap")
-	}
-
-	got, ok := b.GetCardByID(newID)
-	if !ok {
-		t.Fatal("new ID should be found after remap")
-	}
-	if got.ID != newID {
-		t.Fatalf("expected ID %q, got %q", newID, got.ID)
+	for status, want := range map[CardStatus]int{
+		CardDone:    1,
+		CardFailed:  1,
+		CardPending: 1,
+	} {
+		if got := len(b.Query(CardFilter{Status: status})); got != want {
+			t.Errorf("Query(%s)=%d, want %d", status, got, want)
+		}
 	}
 }
 
@@ -227,42 +227,76 @@ func TestBoard_GetCardByID_AfterRemap(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestBoard_CountByStatus(t *testing.T) {
-	b := NewBoard("scope-k3")
-	defer b.Close()
+	t.Parallel()
+	b := newBoard(t)
 
 	c1 := b.Produce("task", "p", nil)
 	c2 := b.Produce("task", "p", nil)
 	b.Produce("signal", "p", nil)
 
-	if got := b.CountByStatus(CardPending, ""); got != 3 {
-		t.Fatalf("all pending: expected 3, got %d", got)
-	}
-	if got := b.CountByStatus(CardPending, "task"); got != 2 {
-		t.Fatalf("pending tasks: expected 2, got %d", got)
-	}
-	if got := b.CountByStatus(CardPending, "signal"); got != 1 {
-		t.Fatalf("pending signals: expected 1, got %d", got)
+	for _, c := range []struct {
+		status   CardStatus
+		typeName string
+		want     int
+		label    string
+	}{
+		{CardPending, "", 3, "all pending"},
+		{CardPending, "task", 2, "pending tasks"},
+		{CardPending, "signal", 1, "pending signals"},
+	} {
+		if got := b.CountByStatus(c.status, c.typeName); got != c.want {
+			t.Errorf("%s: got %d, want %d", c.label, got, c.want)
+		}
 	}
 
 	b.Claim(c1.ID, "a1")
-	if got := b.CountByStatus(CardPending, "task"); got != 1 {
-		t.Fatalf("after claim: expected 1 pending task, got %d", got)
-	}
-	if got := b.CountByStatus(CardClaimed, ""); got != 1 {
-		t.Fatalf("after claim: expected 1 claimed, got %d", got)
-	}
-
 	b.Done(c1.ID, "result")
-	if got := b.CountByStatus(CardDone, ""); got != 1 {
-		t.Fatalf("after done: expected 1 done, got %d", got)
-	}
-
 	b.Fail(c2.ID, "oops")
-	if got := b.CountByStatus(CardFailed, ""); got != 1 {
-		t.Fatalf("after fail: expected 1 failed, got %d", got)
+
+	for _, c := range []struct {
+		status   CardStatus
+		typeName string
+		want     int
+		label    string
+	}{
+		{CardDone, "", 1, "after done"},
+		{CardFailed, "", 1, "after fail"},
+		{CardPending, "", 1, "remaining pending (signal)"},
+	} {
+		if got := b.CountByStatus(c.status, c.typeName); got != c.want {
+			t.Errorf("%s: got %d, want %d", c.label, got, c.want)
+		}
 	}
-	if got := b.CountByStatus(CardPending, ""); got != 1 {
-		t.Fatalf("remaining pending: expected 1 (signal), got %d", got)
+}
+
+// ---------------------------------------------------------------------------
+// GetCardByID
+// ---------------------------------------------------------------------------
+
+func TestBoard_GetCardByID_NotFound(t *testing.T) {
+	t.Parallel()
+	b := newBoard(t)
+	if _, ok := b.GetCardByID("nonexistent"); ok {
+		t.Fatal("expected ok=false")
+	}
+}
+
+func TestBoard_GetCardByID_AfterRemap(t *testing.T) {
+	t.Parallel()
+	b := newBoard(t)
+	c := b.Produce("task", "p", nil)
+	const newID = "remapped-id"
+	b.RemapCardID(c.ID, newID)
+
+	if _, ok := b.GetCardByID(c.ID); ok {
+		t.Fatal("old ID should not be findable after remap")
+	}
+	got, ok := b.GetCardByID(newID)
+	if !ok {
+		t.Fatal("new ID should be findable after remap")
+	}
+	if got.ID != newID {
+		t.Fatalf("ID = %q, want %q", got.ID, newID)
 	}
 }
 
@@ -270,100 +304,64 @@ func TestBoard_CountByStatus(t *testing.T) {
 // Watch / WatchFiltered
 // ---------------------------------------------------------------------------
 
-func waitBoardCard(t *testing.T, ch <-chan *Card, desc string) *Card {
-	t.Helper()
-	select {
-	case c := <-ch:
-		return c
-	case <-time.After(2 * time.Second):
-		t.Fatalf("timeout waiting for %s", desc)
-		return nil
-	}
-}
-
-func TestBoard_WatcherSeesClaimDoneFail(t *testing.T) {
-	b := NewBoard("scope-watcher")
-	defer b.Close()
+func TestBoard_Watch_FullLifecycle(t *testing.T) {
+	t.Parallel()
+	b := newBoard(t)
 	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	t.Cleanup(cancel)
 
 	ch := b.WatchFiltered(ctx, CardFilter{Type: "task"})
 
-	card1 := b.Produce("task", "orch", map[string]any{"n": 1})
-
-	recv := waitBoardCard(t, ch, "produce")
-	if recv.ID != card1.ID || recv.Status != CardPending {
-		t.Fatalf("expected pending card1, got status=%s", recv.Status)
+	c := b.Produce("task", "orch", map[string]any{"n": 1})
+	if got := waitCard(t, ch, "produce"); got.ID != c.ID || got.Status != CardPending {
+		t.Fatalf("produce: ID=%q status=%s", got.ID, got.Status)
 	}
 
-	b.Claim(card1.ID, "agent-1")
-	recv = waitBoardCard(t, ch, "claim")
-	if recv.Status != CardClaimed {
-		t.Fatalf("expected claimed, got %s", recv.Status)
-	}
-	if recv.Consumer != "agent-1" {
-		t.Fatalf("expected agent-1, got %s", recv.Consumer)
+	b.Claim(c.ID, "agent-1")
+	if got := waitCard(t, ch, "claim"); got.Status != CardClaimed || got.Consumer != "agent-1" {
+		t.Fatalf("claim: status=%s consumer=%q", got.Status, got.Consumer)
 	}
 
-	b.Done(card1.ID, "result-data")
-	recv = waitBoardCard(t, ch, "done")
-	if recv.Status != CardDone {
-		t.Fatalf("expected done, got %s", recv.Status)
+	b.Done(c.ID, "result-data")
+	if got := waitCard(t, ch, "done"); got.Status != CardDone {
+		t.Fatalf("done: status=%s", got.Status)
 	}
 
-	card2 := b.Produce("task", "orch", map[string]any{"n": 2})
-	recv = waitBoardCard(t, ch, "produce card2")
-	if recv.ID != card2.ID {
-		t.Fatal("expected card2")
-	}
-
-	b.Claim(card2.ID, "agent-2")
-	recv = waitBoardCard(t, ch, "claim card2")
-	if recv.Status != CardClaimed {
-		t.Fatalf("expected claimed, got %s", recv.Status)
-	}
-
-	b.Fail(card2.ID, "agent error")
-	recv = waitBoardCard(t, ch, "fail")
-	if recv.Status != CardFailed {
-		t.Fatalf("expected failed, got %s", recv.Status)
-	}
-	if recv.Error != "agent error" {
-		t.Fatalf("expected error 'agent error', got %q", recv.Error)
+	c2 := b.Produce("task", "orch", map[string]any{"n": 2})
+	waitCard(t, ch, "produce c2")
+	b.Claim(c2.ID, "agent-2")
+	waitCard(t, ch, "claim c2")
+	b.Fail(c2.ID, "agent error")
+	if got := waitCard(t, ch, "fail"); got.Status != CardFailed || got.Error != "agent error" {
+		t.Fatalf("fail: status=%s err=%q", got.Status, got.Error)
 	}
 }
 
-func TestBoard_WatcherReceivesSnapshot(t *testing.T) {
-	b := NewBoard("scope-snap")
-	defer b.Close()
+func TestBoard_Watch_DeliversSnapshotsNotLivePointers(t *testing.T) {
+	t.Parallel()
+	b := newBoard(t)
 	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	t.Cleanup(cancel)
 
 	ch := b.WatchFiltered(ctx, CardFilter{})
 
-	card := b.Produce("task", "p", map[string]any{"v": 1}, WithMeta("key", "val"))
+	c := b.Produce("task", "p", map[string]any{"v": 1}, WithMeta("key", "val"))
+	got := waitCard(t, ch, "produce")
+	b.Claim(c.ID, "agent")
 
-	recv := waitBoardCard(t, ch, "produce")
-	if recv.ID != card.ID {
-		t.Fatal("wrong card")
+	if got.Status != CardPending {
+		t.Fatal("snapshot must remain Pending after the source card is Claimed")
 	}
-
-	b.Claim(card.ID, "agent")
-
-	if recv.Status != CardPending {
-		t.Fatal("received snapshot should remain Pending even after source card was claimed")
-	}
-
-	if recv.Meta["key"] != "val" {
-		t.Fatal("meta should be copied to snapshot")
+	if got.Meta["key"] != "val" {
+		t.Fatal("Meta must be deep-copied into snapshot")
 	}
 }
 
-func TestBoard_MultipleWatchersFiltered(t *testing.T) {
-	b := NewBoard("scope-multi-watch")
-	defer b.Close()
+func TestBoard_Watch_FilteringByType(t *testing.T) {
+	t.Parallel()
+	b := newBoard(t)
 	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	t.Cleanup(cancel)
 
 	taskCh := b.WatchFiltered(ctx, CardFilter{Type: "task"})
 	resultCh := b.WatchFiltered(ctx, CardFilter{Type: "result"})
@@ -373,319 +371,282 @@ func TestBoard_MultipleWatchersFiltered(t *testing.T) {
 	b.Produce("result", "p", nil)
 	b.Produce("signal", "p", nil)
 
-	recv := waitBoardCard(t, taskCh, "task")
-	if recv.Type != "task" {
-		t.Fatalf("taskCh: expected task, got %s", recv.Type)
+	if got := waitCard(t, taskCh, "task"); got.Type != "task" {
+		t.Fatalf("taskCh got %s", got.Type)
+	}
+	if got := waitCard(t, resultCh, "result"); got.Type != "result" {
+		t.Fatalf("resultCh got %s", got.Type)
 	}
 
-	recv = waitBoardCard(t, resultCh, "result")
-	if recv.Type != "result" {
-		t.Fatalf("resultCh: expected result, got %s", recv.Type)
-	}
-
-	received := 0
+	count := 0
 	timeout := time.After(time.Second)
 drain:
-	for {
+	for count < 3 {
 		select {
 		case <-allCh:
-			received++
-			if received == 3 {
-				break drain
-			}
+			count++
 		case <-timeout:
 			break drain
 		}
 	}
-	if received != 3 {
-		t.Fatalf("allCh: expected 3 events, got %d", received)
+	if count != 3 {
+		t.Fatalf("allCh got %d, want 3", count)
 	}
 }
 
-func TestBoard_WatcherCleanupOnCancel(t *testing.T) {
-	b := NewBoard("scope-cleanup")
-	defer b.Close()
+func TestBoard_Watch_CleanupOnContextCancel(t *testing.T) {
+	t.Parallel()
+	b := newBoard(t)
 	ctx, cancel := context.WithCancel(context.Background())
-
 	ch := b.WatchFiltered(ctx, CardFilter{})
 	cancel()
-
-	time.Sleep(50 * time.Millisecond)
 
 	select {
 	case _, ok := <-ch:
 		if ok {
-			t.Fatal("expected channel to be closed after context cancel")
+			t.Fatal("expected channel close after context cancel")
 		}
 	case <-time.After(time.Second):
-		t.Fatal("channel should be closed")
+		t.Fatal("channel was not closed after cancel")
 	}
 
+	// Producing after the watcher is gone must not panic.
 	b.Produce("task", "p", nil)
 }
 
-func TestBoard_WatcherChannelFull_DoesNotPanic(t *testing.T) {
-	b := NewBoard("scope-k5")
-	defer b.Close()
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
-	ch := b.WatchFiltered(ctx, CardFilter{})
-
-	for i := 0; i < watchBufSize+10; i++ {
-		b.Produce("task", "p", nil)
-	}
-
-	drained := 0
-	for {
-		select {
-		case <-ch:
-			drained++
-		default:
-			goto done
-		}
-	}
-done:
-	if drained != watchBufSize {
-		t.Fatalf("expected to receive exactly %d buffered cards, got %d", watchBufSize, drained)
-	}
-}
-
 func TestBoard_Watch_ClosesOnBoardClose(t *testing.T) {
-	b := NewBoard("scope-watch-close")
+	t.Parallel()
+	b := NewBoard(scopeID(t))
 	ch := b.Watch(context.Background())
 	b.Close()
 
 	select {
 	case _, ok := <-ch:
 		if ok {
-			t.Fatal("expected watch channel to be closed after Board.Close")
+			t.Fatal("expected channel close after Board.Close")
 		}
 	case <-time.After(time.Second):
-		t.Fatal("timed out waiting for watch channel to close")
+		t.Fatal("channel did not close after Board.Close")
+	}
+}
+
+// Bug 1 (P0): unbounded watcher queue must deliver every event regardless of
+// consumer pace.
+func TestBoard_Watch_SlowConsumer_NoEventLoss(t *testing.T) {
+	t.Parallel()
+	b := newBoard(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	ch := b.WatchFiltered(ctx, CardFilter{})
+
+	const total = watchBufSize * 4 // intentionally larger than the legacy bound
+	for i := 0; i < total; i++ {
+		b.Produce("task", "p", nil)
+	}
+
+	drained := 0
+	timeout := time.After(2 * time.Second)
+drain:
+	for drained < total {
+		select {
+		case <-ch:
+			drained++
+		case <-timeout:
+			break drain
+		}
+	}
+	if drained != total {
+		t.Fatalf("got %d/%d events; queue dropped events", drained, total)
+	}
+	if got := b.WatcherDropped(); got != 0 {
+		t.Fatalf("WatcherDropped should be 0 for a live watcher, got %d", got)
 	}
 }
 
 // ---------------------------------------------------------------------------
-// Cards / Timeline / Topology (view methods)
+// Cards / Timeline / Topology view methods.
+//
+// These views must filter internal-only card types ("result", "cron_rule")
+// out of the public API. Bug 2 (issue #28) was a regression here.
 // ---------------------------------------------------------------------------
 
-func TestBoard_Cards_FiltersResultCards(t *testing.T) {
-	b := NewBoard("scope-filter")
-	defer b.Close()
+func TestBoard_Cards_FiltersInternalTypes(t *testing.T) {
+	t.Parallel()
 
-	b.Produce("task", "agent-main", TaskPayload{Query: "q1", TargetAgentID: "t1"})
-	b.Produce("result", "agent-1", ResultPayload{Output: "r1"},
-		WithConsumer("agent-main"), WithMeta("task_card_id", "c1"))
-	b.Produce("task", "agent-main", TaskPayload{Query: "q2", TargetAgentID: "t2"})
-
-	cards := b.Cards()
-	if len(cards) != 2 {
-		t.Fatalf("expected 2 cards (result filtered), got %d", len(cards))
+	cases := []struct {
+		name   string
+		seed   func(b *Board)
+		hidden string
+	}{
+		{
+			name: "result cards hidden",
+			seed: func(b *Board) {
+				b.Produce("task", "agent-main", TaskPayload{Query: "q1", TargetAgentID: "t1"})
+				b.Produce("result", "agent-1", ResultPayload{Output: "r1"},
+					WithConsumer("agent-main"), WithMeta("task_card_id", "c1"))
+				b.Produce("task", "agent-main", TaskPayload{Query: "q2", TargetAgentID: "t2"})
+			},
+			hidden: "result",
+		},
+		{
+			name: "cron_rule cards hidden",
+			seed: func(b *Board) {
+				b.Produce("task", "agent-main", TaskPayload{Query: "real task", TargetAgentID: "t1"})
+				b.Produce(cardTypeCronRule, "scheduler", cronRulePayload{
+					AgentID: "agent-main", ScheduleID: "sched-1",
+					Cron: "0 9 * * *", Query: "daily",
+				}, WithMeta("schedule_id", "sched-1"))
+			},
+			hidden: cardTypeCronRule,
+		},
 	}
-	for _, c := range cards {
-		if c.Type == "result" {
-			t.Fatal("result card should be filtered from Cards()")
-		}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			b := newBoard(t)
+			tc.seed(b)
+			for _, c := range b.Cards() {
+				if c.Type == tc.hidden {
+					t.Fatalf("%s should be filtered out of Cards()", tc.hidden)
+				}
+			}
+		})
 	}
 }
 
 func TestBoard_Cards_ExtractsPayloadFields(t *testing.T) {
-	b := NewBoard("scope-payload")
-	defer b.Close()
+	t.Parallel()
+	b := newBoard(t)
 
-	card := b.Produce("task", "orch", TaskPayload{Query: "the query", TargetAgentID: "the_tpl"})
-	b.Claim(card.ID, "agent-1")
-	b.Done(card.ID, map[string]any{
+	c := b.Produce("task", "orch", TaskPayload{Query: "the query", TargetAgentID: "the_tpl"})
+	b.Claim(c.ID, "agent-1")
+	b.Done(c.ID, map[string]any{
 		"query":           "the query",
 		"target_agent_id": "the_tpl",
 		"output":          "the output",
-	})
-
-	cards := b.Cards()
-	if len(cards) != 1 {
-		t.Fatalf("expected 1 card, got %d", len(cards))
-	}
-	c := cards[0]
-	if c.Query != "the query" {
-		t.Fatalf("expected query 'the query', got %q", c.Query)
-	}
-	if c.TargetAgentID != "the_tpl" {
-		t.Fatalf("expected target_agent_id 'the_tpl', got %q", c.TargetAgentID)
-	}
-	if c.Output != "the output" {
-		t.Fatalf("expected output 'the output', got %q", c.Output)
-	}
-}
-
-func TestBoard_Cards_ExtractsRunID(t *testing.T) {
-	b := NewBoard("scope-runid")
-	defer b.Close()
-
-	card := b.Produce("task", "orch", TaskPayload{Query: "q1", TargetAgentID: "agent-1"})
-	b.Claim(card.ID, "agent-1")
-	b.Done(card.ID, map[string]any{
-		"query":           "q1",
-		"target_agent_id": "agent-1",
-		"output":          "done",
 		"run_id":          "run-abc",
 	})
 
 	cards := b.Cards()
 	if len(cards) != 1 {
-		t.Fatalf("expected 1 card, got %d", len(cards))
+		t.Fatalf("Cards()=%d, want 1", len(cards))
 	}
-	if cards[0].RunID != "run-abc" {
-		t.Fatalf("expected run_id 'run-abc', got %q", cards[0].RunID)
+	got := cards[0]
+	if got.Query != "the query" || got.TargetAgentID != "the_tpl" ||
+		got.Output != "the output" || got.RunID != "run-abc" {
+		t.Fatalf("unexpected extracted fields: %+v", got)
 	}
 }
 
-func TestBoard_Timeline_FiltersResultCards(t *testing.T) {
-	b := NewBoard("scope-tl-filter")
-	defer b.Close()
+func TestBoard_Timeline_FiltersInternalTypes(t *testing.T) {
+	t.Parallel()
 
-	b.Produce("task", "orch", TaskPayload{Query: "q1"})
-	b.Produce("result", "agent", ResultPayload{Output: "r1"})
-
-	timeline := b.Timeline()
-	if len(timeline) != 1 {
-		t.Fatalf("expected 1 timeline entry, got %d", len(timeline))
+	cases := []struct {
+		name string
+		seed func(b *Board)
+	}{
+		{
+			name: "result hidden",
+			seed: func(b *Board) {
+				b.Produce("task", "orch", TaskPayload{Query: "q1"})
+				b.Produce("result", "agent", ResultPayload{Output: "r1"})
+			},
+		},
+		{
+			name: "cron_rule hidden",
+			seed: func(b *Board) {
+				b.Produce("task", "orch", TaskPayload{Query: "q1"})
+				b.Produce(cardTypeCronRule, "scheduler", cronRulePayload{
+					AgentID: "orch", ScheduleID: "sched-1",
+					Cron: "0 9 * * *", Query: "daily",
+				}, WithMeta("schedule_id", "sched-1"))
+			},
+		},
 	}
-	if timeline[0].Type == "result" {
-		t.Fatal("result should not appear in timeline")
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			b := newBoard(t)
+			tc.seed(b)
+			tl := b.Timeline()
+			if len(tl) != 1 {
+				t.Fatalf("Timeline()=%d, want 1", len(tl))
+			}
+			if tl[0].Type == "result" || tl[0].Type == cardTypeCronRule {
+				t.Fatalf("Timeline leaked %s", tl[0].Type)
+			}
+		})
 	}
 }
 
 func TestBoard_Topology(t *testing.T) {
-	b := NewBoard("scope-topo")
-	defer b.Close()
+	t.Parallel()
+	b := newBoard(t)
 
 	b.Produce("task", "agent-main", TaskPayload{Query: "q1"}, WithConsumer("agent-1"))
 	b.Produce("task", "agent-main", TaskPayload{Query: "q2"}, WithConsumer("agent-2"))
 
 	topo := b.Topology()
 	if len(topo.Nodes) != 3 {
-		t.Fatalf("expected 3 nodes (producer + 2 consumers), got %d", len(topo.Nodes))
+		t.Fatalf("Nodes=%d, want 3 (producer + 2 consumers)", len(topo.Nodes))
 	}
 	if len(topo.Edges) != 2 {
-		t.Fatalf("expected 2 edges, got %d", len(topo.Edges))
+		t.Fatalf("Edges=%d, want 2", len(topo.Edges))
 	}
 }
 
 // ---------------------------------------------------------------------------
-// Payload extraction helpers
+// Payload extraction helpers (extractPayloadFields / extractRunID).
 // ---------------------------------------------------------------------------
 
 func TestExtractPayloadFieldsPublic(t *testing.T) {
-	q, tid, o := ExtractPayloadFieldsPublic(TaskPayload{Query: "q", TargetAgentID: "t"})
-	if q != "q" || tid != "t" || o != "" {
-		t.Fatalf("unexpected: q=%q tid=%q o=%q", q, tid, o)
+	t.Parallel()
+	cases := []struct {
+		name            string
+		in              any
+		query, tid, out string
+	}{
+		{"struct", TaskPayload{Query: "q", TargetAgentID: "t"}, "q", "t", ""},
+		{"map", map[string]any{"query": "q2", "output": "o2"}, "q2", "", "o2"},
 	}
-
-	q, _, o = ExtractPayloadFieldsPublic(map[string]any{"query": "q2", "output": "o2"})
-	if q != "q2" || o != "o2" {
-		t.Fatalf("unexpected map: q=%q o=%q", q, o)
+	for _, c := range cases {
+		c := c
+		t.Run(c.name, func(t *testing.T) {
+			t.Parallel()
+			q, tid, o := ExtractPayloadFieldsPublic(c.in)
+			if q != c.query || tid != c.tid || o != c.out {
+				t.Fatalf("got q=%q tid=%q o=%q; want q=%q tid=%q o=%q",
+					q, tid, o, c.query, c.tid, c.out)
+			}
+		})
 	}
 }
 
 func TestExtractRunID(t *testing.T) {
-	if id := extractRunID(map[string]any{"run_id": "r1"}); id != "r1" {
-		t.Fatalf("expected r1, got %q", id)
+	t.Parallel()
+	cases := []struct {
+		name string
+		in   any
+		want string
+	}{
+		{"map_with_run_id", map[string]any{"run_id": "r1"}, "r1"},
+		{"map_without_run_id", map[string]any{"other": "val"}, ""},
+		{"struct", TaskPayload{Query: "q"}, ""},
+		{"nil", nil, ""},
 	}
-	if id := extractRunID(map[string]any{"other": "val"}); id != "" {
-		t.Fatalf("expected empty, got %q", id)
-	}
-	if id := extractRunID(TaskPayload{Query: "q"}); id != "" {
-		t.Fatalf("expected empty for non-map, got %q", id)
-	}
-	if id := extractRunID(nil); id != "" {
-		t.Fatalf("expected empty for nil, got %q", id)
-	}
-}
-
-// ---------------------------------------------------------------------------
-// Restore
-// ---------------------------------------------------------------------------
-
-func TestRestoreTaskBoard_AllStates(t *testing.T) {
-	cards := []*KanbanCardModel{
-		{
-			ID: "c1", RuntimeID: "s1", Type: "task", Status: "pending",
-			Producer: "copilot", Consumer: "*",
-			Query: "q1", TargetAgentID: "agent-1",
-			CreatedAt: time.Now(), UpdatedAt: time.Now(),
-		},
-		{
-			ID: "c2", RuntimeID: "s1", Type: "task", Status: "claimed",
-			Producer: "copilot", Consumer: "agent-2",
-			Query: "q2", TargetAgentID: "agent-2",
-			CreatedAt: time.Now(), UpdatedAt: time.Now(),
-		},
-		{
-			ID: "c3", RuntimeID: "s1", Type: "task", Status: "done",
-			Producer: "copilot", Consumer: "agent-3",
-			Query: "q3", TargetAgentID: "agent-3", Output: "result", RunID: "run-1",
-			CreatedAt: time.Now(), UpdatedAt: time.Now(),
-		},
-		{
-			ID: "c4", RuntimeID: "s1", Type: "task", Status: "failed",
-			Producer: "copilot", Consumer: "agent-4",
-			Query: "q4", TargetAgentID: "agent-4", Error: "timeout",
-			CreatedAt: time.Now(), UpdatedAt: time.Now(),
-		},
-	}
-
-	tb := RestoreTaskBoard("s1", cards)
-	defer tb.Close()
-
-	if tb.ScopeID() != "s1" {
-		t.Fatalf("expected scope s1, got %q", tb.ScopeID())
-	}
-
-	infos := tb.Cards()
-	if len(infos) != 4 {
-		t.Fatalf("expected 4 cards, got %d", len(infos))
-	}
-
-	statusMap := make(map[string]string)
-	for _, c := range infos {
-		statusMap[c.ID] = c.Status
-	}
-
-	if statusMap["c1"] != "pending" {
-		t.Fatalf("c1: expected pending, got %s", statusMap["c1"])
-	}
-	if statusMap["c2"] != "claimed" {
-		t.Fatalf("c2: expected claimed, got %s", statusMap["c2"])
-	}
-	if statusMap["c3"] != "done" {
-		t.Fatalf("c3: expected done, got %s", statusMap["c3"])
-	}
-	if statusMap["c4"] != "failed" {
-		t.Fatalf("c4: expected failed, got %s", statusMap["c4"])
-	}
-
-	for _, c := range infos {
-		if c.ID == "c3" {
-			if c.RunID != "run-1" {
-				t.Fatalf("c3: expected run_id 'run-1', got %q", c.RunID)
+	for _, c := range cases {
+		c := c
+		t.Run(c.name, func(t *testing.T) {
+			t.Parallel()
+			if got := extractRunID(c.in); got != c.want {
+				t.Errorf("got %q, want %q", got, c.want)
 			}
-			if c.Output != "result" {
-				t.Fatalf("c3: expected output 'result', got %q", c.Output)
-			}
-		}
-	}
-}
-
-func TestRestoreTaskBoard_Empty(t *testing.T) {
-	tb := RestoreTaskBoard("s-empty", nil)
-	defer tb.Close()
-
-	if tb.ScopeID() != "s-empty" {
-		t.Fatalf("expected scope s-empty, got %q", tb.ScopeID())
-	}
-	if len(tb.Cards()) != 0 {
-		t.Fatalf("expected 0 cards, got %d", len(tb.Cards()))
+		})
 	}
 }
 
@@ -694,135 +655,135 @@ func TestRestoreTaskBoard_Empty(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestBoard_WithMaxCards_EvictsTerminal(t *testing.T) {
-	b := NewBoard("scope-k2-max", WithMaxCards(5))
-	defer b.Close()
+	t.Parallel()
+	b := NewBoard(scopeID(t), WithMaxCards(5))
+	t.Cleanup(b.Close)
 
 	for i := 0; i < 5; i++ {
 		c := b.Produce("task", "p", nil)
 		b.Claim(c.ID, "a")
 		b.Done(c.ID, "r")
 	}
-
 	if b.Len() != 5 {
-		t.Fatalf("expected 5 cards before eviction trigger, got %d", b.Len())
+		t.Fatalf("before extra produces: Len()=%d, want 5", b.Len())
 	}
 
 	b.Produce("task", "p", nil)
 	b.Produce("task", "p", nil)
 
 	if b.Len() > 7 {
-		t.Fatalf("expected cards to be evicted to stay near maxCards, got %d", b.Len())
+		t.Fatalf("eviction did not bound size: Len()=%d", b.Len())
 	}
-
-	pending := b.CountByStatus(CardPending, "")
-	if pending < 2 {
-		t.Fatalf("pending cards should not be evicted, got %d pending", pending)
+	if pending := b.CountByStatus(CardPending, ""); pending < 2 {
+		t.Fatalf("pending cards must not be evicted, got %d pending", pending)
 	}
 }
 
 func TestBoard_WithCardTTL_EvictsExpired(t *testing.T) {
-	b := NewBoard("scope-k2-ttl", WithCardTTL(50*time.Millisecond))
-	defer b.Close()
+	t.Parallel()
+	b := NewBoard(scopeID(t), WithCardTTL(50*time.Millisecond))
+	t.Cleanup(b.Close)
 
-	c1 := b.Produce("task", "p", nil)
-	b.Claim(c1.ID, "a")
-	b.Done(c1.ID, "r")
+	c := b.Produce("task", "p", nil)
+	b.Claim(c.ID, "a")
+	b.Done(c.ID, "r")
 
 	time.Sleep(80 * time.Millisecond)
+	b.Produce("task", "p", nil) // triggers eviction sweep
 
-	b.Produce("task", "p", nil)
-
-	done := b.CountByStatus(CardDone, "")
-	if done != 0 {
-		t.Fatalf("expected done card to be evicted after TTL, got %d done", done)
+	if got := b.CountByStatus(CardDone, ""); got != 0 {
+		t.Fatalf("done card not evicted after TTL: %d remain", got)
 	}
-	if b.CountByStatus(CardPending, "") != 1 {
-		t.Fatal("pending card should survive TTL eviction")
+	if got := b.CountByStatus(CardPending, ""); got != 1 {
+		t.Fatalf("pending must survive TTL eviction, got %d", got)
 	}
 }
 
 func TestBoard_WithMaxCards_PreservesActiveCards(t *testing.T) {
-	b := NewBoard("scope-k2-active", WithMaxCards(3))
-	defer b.Close()
+	t.Parallel()
+	b := NewBoard(scopeID(t), WithMaxCards(3))
+	t.Cleanup(b.Close)
 
 	for i := 0; i < 5; i++ {
 		b.Produce("task", "p", nil)
 	}
-
-	if b.CountByStatus(CardPending, "") != 5 {
-		t.Fatalf("active (pending) cards should never be evicted, got %d", b.CountByStatus(CardPending, ""))
+	if got := b.CountByStatus(CardPending, ""); got != 5 {
+		t.Fatalf("active (pending) cards must never be evicted, got %d", got)
 	}
 }
 
 // ---------------------------------------------------------------------------
-// normalizePayload
+// normalizePayload — Produce/Done normalize to map[string]any (or pass
+// through primitives) so downstream callers see one consistent shape.
 // ---------------------------------------------------------------------------
 
-func TestBoard_NormalizePayload_TypeConsistency(t *testing.T) {
-	b := NewBoard("scope-k6")
-	defer b.Close()
+func TestBoard_NormalizePayload(t *testing.T) {
+	t.Parallel()
 
-	card := b.Produce("task", "p", TaskPayload{
-		TargetAgentID: "agent-1",
-		Query:         "hello",
-	})
-
-	if _, ok := card.Payload.(map[string]any); !ok {
-		t.Fatalf("expected Payload to be map[string]any after Produce, got %T", card.Payload)
+	cases := []struct {
+		name    string
+		payload any
+		check   func(t *testing.T, got *Card)
+	}{
+		{
+			name:    "struct -> map",
+			payload: TaskPayload{TargetAgentID: "agent-1", Query: "hello"},
+			check: func(t *testing.T, c *Card) {
+				m, ok := c.Payload.(map[string]any)
+				if !ok {
+					t.Fatalf("Payload type = %T, want map[string]any", c.Payload)
+				}
+				if m["query"] != "hello" || m["target_agent_id"] != "agent-1" {
+					t.Fatalf("missing fields after normalize: %v", m)
+				}
+			},
+		},
+		{
+			name:    "map passthrough",
+			payload: map[string]any{"key": "val"},
+			check: func(t *testing.T, c *Card) {
+				if _, ok := c.Payload.(map[string]any); !ok {
+					t.Fatalf("map should pass through, got %T", c.Payload)
+				}
+			},
+		},
+		{
+			name:    "primitive passthrough",
+			payload: "hello string",
+			check: func(t *testing.T, c *Card) {
+				s, ok := c.Payload.(string)
+				if !ok || s != "hello string" {
+					t.Fatalf("string should pass through, got %T: %v", c.Payload, c.Payload)
+				}
+			},
+		},
 	}
 
-	got, _ := b.GetCardByID(card.ID)
-	if _, ok := got.Payload.(map[string]any); !ok {
-		t.Fatalf("expected internal Payload to be map[string]any, got %T", got.Payload)
-	}
-
-	p := PayloadMap(got.Payload)
-	if p["query"] != "hello" {
-		t.Fatalf("expected query='hello', got %v", p["query"])
-	}
-	if p["target_agent_id"] != "agent-1" {
-		t.Fatalf("expected target_agent_id='agent-1', got %v", p["target_agent_id"])
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			b := newBoard(t)
+			tc.check(t, b.Produce("task", "p", tc.payload))
+		})
 	}
 }
 
 func TestBoard_NormalizePayload_DoneAlsoNormalized(t *testing.T) {
-	b := NewBoard("scope-k6-done")
-	defer b.Close()
+	t.Parallel()
+	b := newBoard(t)
 
-	card := b.Produce("task", "p", nil)
-	b.Claim(card.ID, "a")
-	b.Done(card.ID, ResultPayload{Output: "result text", Error: ""})
+	c := b.Produce("task", "p", nil)
+	b.Claim(c.ID, "a")
+	b.Done(c.ID, ResultPayload{Output: "result text"})
 
-	got, _ := b.GetCardByID(card.ID)
-	if _, ok := got.Payload.(map[string]any); !ok {
-		t.Fatalf("expected Done Payload to be map[string]any, got %T", got.Payload)
+	got, _ := b.GetCardByID(c.ID)
+	m, ok := got.Payload.(map[string]any)
+	if !ok {
+		t.Fatalf("Done payload should normalize to map, got %T", got.Payload)
 	}
-
-	p := PayloadMap(got.Payload)
-	if p["output"] != "result text" {
-		t.Fatalf("expected output='result text', got %v", p["output"])
-	}
-}
-
-func TestBoard_NormalizePayload_MapPassthrough(t *testing.T) {
-	b := NewBoard("scope-k6-map")
-	defer b.Close()
-
-	original := map[string]any{"key": "val"}
-	card := b.Produce("task", "p", original)
-
-	if _, ok := card.Payload.(map[string]any); !ok {
-		t.Fatalf("map[string]any should pass through normalizePayload, got %T", card.Payload)
-	}
-}
-
-func TestBoard_NormalizePayload_PrimitivePassthrough(t *testing.T) {
-	b := NewBoard("scope-k6-prim")
-	defer b.Close()
-
-	card := b.Produce("task", "p", "hello string")
-	if s, ok := card.Payload.(string); !ok || s != "hello string" {
-		t.Fatalf("string payload should pass through, got %T: %v", card.Payload, card.Payload)
+	if m["output"] != "result text" {
+		t.Fatalf("output = %v, want 'result text'", m["output"])
 	}
 }
 
@@ -834,120 +795,109 @@ type unmarshalable struct {
 	Ch chan int
 }
 
-func TestDeepCopyJSONValue_Nil(t *testing.T) {
-	if deepCopyJSONValue(nil) != nil {
-		t.Fatal("expected nil")
+func TestDeepCopyJSONValue(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		in   any
+		want any
+	}{
+		{"nil", nil, nil},
+		{"string", "hello", "hello"},
+		{"int", 42, 42},
+		{"bool", true, true},
+		{"unmarshalable", unmarshalable{Ch: make(chan int)}, nil},
+	}
+	for _, c := range cases {
+		c := c
+		t.Run(c.name, func(t *testing.T) {
+			t.Parallel()
+			if got := deepCopyJSONValue(c.in); got != c.want {
+				t.Fatalf("got %v, want %v", got, c.want)
+			}
+		})
 	}
 }
 
-func TestDeepCopyJSONValue_Primitive(t *testing.T) {
-	if v := deepCopyJSONValue("hello"); v != "hello" {
-		t.Fatalf("expected 'hello', got %v", v)
-	}
-	if v := deepCopyJSONValue(42); v != 42 {
-		t.Fatalf("expected 42, got %v", v)
-	}
-	if v := deepCopyJSONValue(true); v != true {
-		t.Fatalf("expected true, got %v", v)
-	}
-}
-
-func TestDeepCopyJSONValue_Map(t *testing.T) {
+func TestDeepCopyJSONValue_MapIsIndependent(t *testing.T) {
+	t.Parallel()
 	original := map[string]any{"a": float64(1), "b": "two"}
-	cp := deepCopyJSONValue(original)
-	m, ok := cp.(map[string]any)
+	cp, ok := deepCopyJSONValue(original).(map[string]any)
 	if !ok {
-		t.Fatalf("expected map[string]any, got %T", cp)
+		t.Fatalf("copy is not a map")
 	}
-	if m["a"] != float64(1) || m["b"] != "two" {
-		t.Fatalf("unexpected copy: %v", m)
+	if cp["a"] != float64(1) || cp["b"] != "two" {
+		t.Fatalf("copy missing fields: %v", cp)
 	}
-
 	original["a"] = float64(999)
-	if m["a"] == float64(999) {
-		t.Fatal("copy should be independent of original")
-	}
-}
-
-func TestDeepCopyJSONValue_FailReturnsNil(t *testing.T) {
-	v := deepCopyJSONValue(unmarshalable{Ch: make(chan int)})
-	if v != nil {
-		t.Fatalf("expected nil when marshal fails, got %v", v)
+	if cp["a"] == float64(999) {
+		t.Fatal("mutation to original leaked into copy")
 	}
 }
 
 // ---------------------------------------------------------------------------
-// Index consistency across state transitions
+// Index consistency: cardIndex / statusIndex stay in sync with state.
+// (Concurrent variant lives in board_concurrency_test.go.)
 // ---------------------------------------------------------------------------
 
 func TestBoard_IndexConsistency_FullLifecycle(t *testing.T) {
-	b := NewBoard("scope-idx-lc")
-	defer b.Close()
+	t.Parallel()
+	b := newBoard(t)
 
-	card := b.Produce("task", "p", map[string]any{"v": 1})
-
-	if b.CountByStatus(CardPending, "") != 1 {
-		t.Fatal("pending count should be 1 after Produce")
-	}
-
-	b.Claim(card.ID, "agent")
-	if b.CountByStatus(CardPending, "") != 0 {
-		t.Fatal("pending count should be 0 after Claim")
-	}
-	if b.CountByStatus(CardClaimed, "") != 1 {
-		t.Fatal("claimed count should be 1 after Claim")
+	c := b.Produce("task", "p", map[string]any{"v": 1})
+	if got := b.CountByStatus(CardPending, ""); got != 1 {
+		t.Fatalf("pending after Produce = %d, want 1", got)
 	}
 
-	b.Done(card.ID, "result")
-	if b.CountByStatus(CardClaimed, "") != 0 {
-		t.Fatal("claimed count should be 0 after Done")
-	}
-	if b.CountByStatus(CardDone, "") != 1 {
-		t.Fatal("done count should be 1 after Done")
+	b.Claim(c.ID, "agent")
+	if b.CountByStatus(CardPending, "") != 0 || b.CountByStatus(CardClaimed, "") != 1 {
+		t.Fatal("pending/claimed indexes inconsistent after Claim")
 	}
 
-	got, ok := b.GetCardByID(card.ID)
-	if !ok {
-		t.Fatal("card should still be findable by ID after Done")
+	b.Done(c.ID, "result")
+	if b.CountByStatus(CardClaimed, "") != 0 || b.CountByStatus(CardDone, "") != 1 {
+		t.Fatal("claimed/done indexes inconsistent after Done")
 	}
-	if got.Status != CardDone {
-		t.Fatalf("expected Done status, got %s", got.Status)
+
+	got, ok := b.GetCardByID(c.ID)
+	if !ok || got.Status != CardDone {
+		t.Fatalf("post-Done lookup mismatch: ok=%v status=%s", ok, got.Status)
 	}
 }
 
 func TestBoard_IndexConsistency_FailFromPending(t *testing.T) {
-	b := NewBoard("scope-idx-fp")
-	defer b.Close()
-
-	card := b.Produce("task", "p", nil)
-	b.Fail(card.ID, "fail-from-pending")
+	t.Parallel()
+	b := newBoard(t)
+	c := b.Produce("task", "p", nil)
+	b.Fail(c.ID, "fail-from-pending")
 
 	if b.CountByStatus(CardPending, "") != 0 {
-		t.Fatal("pending should be 0 after Fail")
+		t.Fatal("pending must drop to 0 after Fail")
 	}
 	if b.CountByStatus(CardFailed, "") != 1 {
-		t.Fatal("failed should be 1 after Fail")
+		t.Fatal("failed must rise to 1 after Fail")
 	}
 }
 
 // ---------------------------------------------------------------------------
-// Bus
+// Bus — generic publish/subscribe wiring.
+// (Kanban-specific event payloads are tested in events_test.go.)
 // ---------------------------------------------------------------------------
 
-func TestBoard_Bus(t *testing.T) {
-	b := NewBoard("scope-bus")
-	defer b.Close()
-
-	bus := b.Bus()
-	if bus == nil {
+func TestBoard_Bus_PublishesToSubscriber(t *testing.T) {
+	t.Parallel()
+	b := newBoard(t)
+	if b.Bus() == nil {
 		t.Fatal("Bus() should not be nil")
 	}
 
 	ctx := context.Background()
-	sub, err := bus.Subscribe(ctx, event.EventFilter{})
+	sub, err := b.Bus().Subscribe(ctx, event.EventFilter{})
 	if err != nil {
 		t.Fatalf("Subscribe: %v", err)
 	}
+	t.Cleanup(func() { _ = sub.Close() })
 
 	ev := event.Event{
 		ID:        "ev-1",
@@ -955,23 +905,23 @@ func TestBoard_Bus(t *testing.T) {
 		Timestamp: time.Now(),
 		Payload:   map[string]any{"node_id": "n1"},
 	}
-	if err := bus.Publish(ctx, ev); err != nil {
+	if err := b.Bus().Publish(ctx, ev); err != nil {
 		t.Fatalf("Publish: %v", err)
 	}
 
 	select {
 	case got := <-sub.Events():
 		if got.ID != "ev-1" {
-			t.Fatalf("expected event ID 'ev-1', got %q", got.ID)
+			t.Fatalf("got ID=%q, want 'ev-1'", got.ID)
 		}
 	case <-time.After(time.Second):
 		t.Fatal("timed out waiting for event")
 	}
 }
 
-func TestBoard_Bus_MultipleSubscribers(t *testing.T) {
-	b := NewBoard("scope-multi")
-	defer b.Close()
+func TestBoard_Bus_FanOutsToMultipleSubscribers(t *testing.T) {
+	t.Parallel()
+	b := newBoard(t)
 
 	ctx := context.Background()
 	const n = 5
@@ -982,6 +932,7 @@ func TestBoard_Bus_MultipleSubscribers(t *testing.T) {
 			t.Fatalf("Subscribe[%d]: %v", i, err)
 		}
 		subs[i] = s
+		t.Cleanup(func() { _ = s.Close() })
 	}
 
 	ev := event.Event{ID: "ev-multi", Type: event.EventGraphStart, Timestamp: time.Now()}
@@ -993,228 +944,10 @@ func TestBoard_Bus_MultipleSubscribers(t *testing.T) {
 		select {
 		case got := <-sub.Events():
 			if got.ID != "ev-multi" {
-				t.Fatalf("sub[%d]: expected 'ev-multi', got %q", i, got.ID)
+				t.Errorf("sub[%d]: got ID=%q, want 'ev-multi'", i, got.ID)
 			}
 		case <-time.After(time.Second):
-			t.Fatalf("sub[%d]: timed out", i)
+			t.Errorf("sub[%d]: timed out", i)
 		}
-	}
-}
-
-func TestBoard_Close_Idempotent(t *testing.T) {
-	b := NewBoard("scope-close")
-	b.Close()
-	b.Close()
-}
-
-// ---------------------------------------------------------------------------
-// NewBoard / NewTaskBoard
-// ---------------------------------------------------------------------------
-
-func TestNewBoard(t *testing.T) {
-	b := NewBoard("scope-1")
-	defer b.Close()
-	if b.ScopeID() != "scope-1" {
-		t.Fatalf("expected scope ID 'scope-1', got %q", b.ScopeID())
-	}
-}
-
-func TestNewTaskBoard_Alias(t *testing.T) {
-	tb := NewTaskBoard("scope-alias")
-	defer tb.Close()
-	if tb.ScopeID() != "scope-alias" {
-		t.Fatalf("expected scope ID 'scope-alias', got %q", tb.ScopeID())
-	}
-}
-
-// ---------------------------------------------------------------------------
-// Concurrency
-// ---------------------------------------------------------------------------
-
-func TestBoard_ConcurrentProduceAndQuery(t *testing.T) {
-	b := NewBoard("scope-cpq")
-	defer b.Close()
-	const n = 50
-
-	var wg sync.WaitGroup
-
-	for i := 0; i < n; i++ {
-		wg.Add(2)
-		go func() {
-			defer wg.Done()
-			b.Produce("task", "p", nil)
-		}()
-		go func() {
-			defer wg.Done()
-			_ = b.Query(CardFilter{Type: "task"})
-		}()
-	}
-
-	wg.Wait()
-
-	if b.Len() != n {
-		t.Fatalf("expected %d cards, got %d", n, b.Len())
-	}
-}
-
-func TestBoard_ConcurrentProduceClaimDone(t *testing.T) {
-	b := NewBoard("scope-conc-pcd")
-	defer b.Close()
-	const n = 100
-
-	var wg sync.WaitGroup
-	cardIDs := make([]string, n)
-
-	for i := 0; i < n; i++ {
-		wg.Add(1)
-		go func(idx int) {
-			defer wg.Done()
-			card := b.Produce("task", fmt.Sprintf("p-%d", idx), map[string]any{"idx": idx})
-			cardIDs[idx] = card.ID
-		}(i)
-	}
-	wg.Wait()
-
-	if b.Len() != n {
-		t.Fatalf("expected %d cards, got %d", n, b.Len())
-	}
-
-	claimed := make([]bool, n)
-	for i := 0; i < n; i++ {
-		wg.Add(1)
-		go func(idx int) {
-			defer wg.Done()
-			claimed[idx] = b.Claim(cardIDs[idx], fmt.Sprintf("c-%d", idx))
-		}(i)
-	}
-	wg.Wait()
-
-	for i, ok := range claimed {
-		if !ok {
-			t.Fatalf("claim %d failed", i)
-		}
-	}
-
-	for i := 0; i < n; i++ {
-		wg.Add(1)
-		go func(idx int) {
-			defer wg.Done()
-			b.Done(cardIDs[idx], fmt.Sprintf("result-%d", idx))
-		}(i)
-	}
-	wg.Wait()
-
-	doneCards := b.Query(CardFilter{Status: CardDone})
-	if len(doneCards) != n {
-		t.Fatalf("expected %d done cards, got %d", n, len(doneCards))
-	}
-}
-
-func TestBoard_ConcurrentWatchAndProduce(t *testing.T) {
-	b := NewBoard("scope-cwp")
-	defer b.Close()
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
-	const watchers = 5
-	const produces = 20
-
-	channels := make([]<-chan *Card, watchers)
-	for i := 0; i < watchers; i++ {
-		channels[i] = b.WatchFiltered(ctx, CardFilter{})
-	}
-
-	var wg sync.WaitGroup
-	for i := 0; i < produces; i++ {
-		wg.Add(1)
-		go func(idx int) {
-			defer wg.Done()
-			b.Produce("task", "p", map[string]any{"i": idx})
-		}(i)
-	}
-	wg.Wait()
-
-	for wi, ch := range channels {
-		count := 0
-		timeout := time.After(time.Second)
-	drain:
-		for {
-			select {
-			case <-ch:
-				count++
-				if count == produces {
-					break drain
-				}
-			case <-timeout:
-				break drain
-			}
-		}
-		if count != produces {
-			t.Fatalf("watcher %d: expected %d events, got %d", wi, produces, count)
-		}
-	}
-}
-
-func TestBoard_ConcurrentBusSubscribe(t *testing.T) {
-	b := NewBoard("scope-conc-bus")
-	defer b.Close()
-
-	ctx := context.Background()
-	var wg sync.WaitGroup
-	errs := make(chan error, 20)
-
-	for i := 0; i < 20; i++ {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
-			_, err := b.Bus().Subscribe(ctx, event.EventFilter{})
-			if err != nil {
-				errs <- err
-			}
-		}()
-	}
-
-	wg.Wait()
-	close(errs)
-	for err := range errs {
-		t.Fatalf("concurrent Subscribe failed: %v", err)
-	}
-}
-
-func TestBoard_IndexConsistency_ConcurrentTransitions(t *testing.T) {
-	b := NewBoard("scope-idx-conc")
-	defer b.Close()
-	const n = 50
-
-	ids := make([]string, n)
-	for i := 0; i < n; i++ {
-		c := b.Produce("task", "p", nil)
-		ids[i] = c.ID
-	}
-
-	if b.CountByStatus(CardPending, "") != n {
-		t.Fatalf("expected %d pending, got %d", n, b.CountByStatus(CardPending, ""))
-	}
-
-	done := make(chan struct{})
-	for i := 0; i < n; i++ {
-		go func(id string) {
-			b.Claim(id, "a")
-			b.Done(id, "r")
-			done <- struct{}{}
-		}(ids[i])
-	}
-	for i := 0; i < n; i++ {
-		<-done
-	}
-
-	if b.CountByStatus(CardDone, "") != n {
-		t.Fatalf("expected %d done, got %d", n, b.CountByStatus(CardDone, ""))
-	}
-	if b.CountByStatus(CardPending, "") != 0 {
-		t.Fatalf("expected 0 pending, got %d", b.CountByStatus(CardPending, ""))
-	}
-	if b.CountByStatus(CardClaimed, "") != 0 {
-		t.Fatalf("expected 0 claimed, got %d", b.CountByStatus(CardClaimed, ""))
 	}
 }

--- a/sdk/kanban/card.go
+++ b/sdk/kanban/card.go
@@ -51,3 +51,21 @@ func WithMeta(k, v string) CardOption {
 		card.Meta[k] = v
 	}
 }
+
+// WithTimestamps overrides the CreatedAt / UpdatedAt fields that Produce would
+// otherwise stamp with time.Now(). Pass the zero time on either argument to
+// keep the default (current time) for that field.
+//
+// Primary use case: RestoreTaskBoard, which must preserve the historical
+// creation / update timestamps captured in persistence so timeline / Gantt
+// views and SLA metrics survive a process restart.
+func WithTimestamps(created, updated time.Time) CardOption {
+	return func(card *Card) {
+		if !created.IsZero() {
+			card.CreatedAt = created
+		}
+		if !updated.IsZero() {
+			card.UpdatedAt = updated
+		}
+	}
+}

--- a/sdk/kanban/events.go
+++ b/sdk/kanban/events.go
@@ -1,17 +1,38 @@
 package kanban
 
-// EventBus event types for Kanban operations.
-const (
-	EventTaskSubmitted = "kanban.task.submitted"
-	EventTaskClaimed   = "kanban.task.claimed"
-	EventTaskCompleted = "kanban.task.completed"
-	EventTaskFailed    = "kanban.task.failed"
-	EventCallbackStart = "kanban.callback.start"
-	EventCallbackDone  = "kanban.callback.done"
+import (
+	"time"
+
+	"github.com/GizClaw/flowcraft/sdk/event"
 )
+
+// EventBus event types for Kanban operations. The catalogue below is the
+// complete set of business actions an external observer can subscribe to via
+// Board.Bus(); subscribing alone is sufficient to reconstruct every state
+// transition the SDK exposes through Cards().
+//
+// When a new public action is added, it MUST add (1) a constant here, (2) a
+// Publish call in the same critical section as the state change, and (3) a
+// unit test under sdk/kanban/...
+const (
+	EventTaskSubmitted    = "kanban.task.submitted"
+	EventTaskClaimed      = "kanban.task.claimed"
+	EventTaskCompleted    = "kanban.task.completed"
+	EventTaskFailed       = "kanban.task.failed"
+	EventCallbackStart    = "kanban.callback.start"
+	EventCallbackDone     = "kanban.callback.done"
+	EventCronRuleCreated  = "kanban.cron.rule.created"
+	EventCronRuleFired    = "kanban.cron.rule.fired"
+	EventCronRuleDisabled = "kanban.cron.rule.disabled"
+)
+
+// payloadVersion is the schema version stamped onto every Kanban event payload.
+// Future fields are additive; consumers that pin Version=1 keep working.
+const payloadVersion = 1
 
 // TaskSubmittedPayload is published when a task is submitted.
 type TaskSubmittedPayload struct {
+	Version       int            `json:"version"`
 	CardID        string         `json:"card_id"`
 	TargetAgentID string         `json:"target_agent_id"`
 	Query         string         `json:"query"`
@@ -21,13 +42,16 @@ type TaskSubmittedPayload struct {
 
 // TaskClaimedPayload is published when an agent claims a task.
 type TaskClaimedPayload struct {
+	Version       int    `json:"version"`
 	CardID        string `json:"card_id"`
 	TargetAgentID string `json:"target_agent_id"`
 	RuntimeID     string `json:"runtime_id"`
+	Consumer      string `json:"consumer"`
 }
 
 // TaskCompletedPayload is published when a task is completed.
 type TaskCompletedPayload struct {
+	Version       int    `json:"version"`
 	CardID        string `json:"card_id"`
 	TargetAgentID string `json:"target_agent_id"`
 	RuntimeID     string `json:"runtime_id"`
@@ -37,6 +61,7 @@ type TaskCompletedPayload struct {
 
 // TaskFailedPayload is published when a task fails.
 type TaskFailedPayload struct {
+	Version       int    `json:"version"`
 	CardID        string `json:"card_id"`
 	TargetAgentID string `json:"target_agent_id"`
 	RuntimeID     string `json:"runtime_id"`
@@ -47,6 +72,7 @@ type TaskFailedPayload struct {
 // CallbackStartPayload is published just before the callback message is sent
 // to the Dispatcher Actor, so WS subscribers can start streaming.
 type CallbackStartPayload struct {
+	Version   int    `json:"version"`
 	CardID    string `json:"card_id"`
 	RuntimeID string `json:"runtime_id"`
 	AgentID   string `json:"agent_id"`
@@ -57,8 +83,69 @@ type CallbackStartPayload struct {
 // a task callback, signaling the frontend to finalize the streamed message.
 // Error is set when the callback turn ended unsuccessfully.
 type CallbackDonePayload struct {
+	Version   int    `json:"version"`
 	CardID    string `json:"card_id"`
 	RuntimeID string `json:"runtime_id"`
 	AgentID   string `json:"agent_id"`
 	Error     string `json:"error,omitempty"`
+}
+
+// CronRuleCreatedPayload is published when a new dynamic cron rule is registered.
+type CronRuleCreatedPayload struct {
+	Version    int    `json:"version"`
+	ScheduleID string `json:"schedule_id"`
+	AgentID    string `json:"agent_id"`
+	Cron       string `json:"cron"`
+	Query      string `json:"query"`
+	Timezone   string `json:"timezone,omitempty"`
+}
+
+// CronRuleFiredPayload is published each time a cron rule fires and produces a task card.
+type CronRuleFiredPayload struct {
+	Version    int    `json:"version"`
+	ScheduleID string `json:"schedule_id"`
+	AgentID    string `json:"agent_id"`
+	CardID     string `json:"card_id"`
+	Query      string `json:"query"`
+}
+
+// CronRuleDisabledPayload is published when a cron rule is removed (e.g. via RemoveAgent).
+type CronRuleDisabledPayload struct {
+	Version    int    `json:"version"`
+	ScheduleID string `json:"schedule_id"`
+	AgentID    string `json:"agent_id"`
+}
+
+// eventEnvelope wraps a Kanban payload into an event.Event. It auto-stamps the
+// payload's Version field via reflection-free type switch, so call sites stay
+// terse.
+func eventEnvelope(eventType string, payload any) event.Event {
+	switch p := payload.(type) {
+	case TaskSubmittedPayload:
+		p.Version = payloadVersion
+		payload = p
+	case TaskClaimedPayload:
+		p.Version = payloadVersion
+		payload = p
+	case TaskCompletedPayload:
+		p.Version = payloadVersion
+		payload = p
+	case TaskFailedPayload:
+		p.Version = payloadVersion
+		payload = p
+	case CronRuleCreatedPayload:
+		p.Version = payloadVersion
+		payload = p
+	case CronRuleFiredPayload:
+		p.Version = payloadVersion
+		payload = p
+	case CronRuleDisabledPayload:
+		p.Version = payloadVersion
+		payload = p
+	}
+	return event.Event{
+		Type:      event.EventType(eventType),
+		Timestamp: time.Now(),
+		Payload:   payload,
+	}
 }

--- a/sdk/kanban/events_test.go
+++ b/sdk/kanban/events_test.go
@@ -1,0 +1,269 @@
+package kanban
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"math/rand"
+	"sort"
+	"testing"
+	"time"
+
+	"github.com/GizClaw/flowcraft/sdk/event"
+)
+
+// ---------------------------------------------------------------------------
+// Bus() emission — Submit / Claim / Done / Fail are published from Board
+// ---------------------------------------------------------------------------
+
+func TestBus_PublishesTaskSubmitted(t *testing.T) {
+	t.Parallel()
+	k, sb := newKanban(t, WithConfig(KanbanConfig{MaxPendingTasks: 100}))
+	sub := subscribeBus(t, sb)
+
+	if _, err := k.Submit(context.Background(), TaskOptions{Query: "test event"}); err != nil {
+		t.Fatalf("Submit: %v", err)
+	}
+
+	evs := drainEvents(sub, time.Second, 1, func(e event.Event) bool {
+		return string(e.Type) == EventTaskSubmitted
+	})
+	if !containsType(evs, EventTaskSubmitted) {
+		t.Fatalf("expected %q on Bus(), saw types: %v", EventTaskSubmitted, eventTypes(evs))
+	}
+}
+
+func TestBus_PublishesClaimAndDone(t *testing.T) {
+	t.Parallel()
+	sb := newBoard(t)
+	executor := &mockExecutor{
+		fn: func(_ context.Context, _, targetAgentID string, card *Card, _ string, _ map[string]any) error {
+			sb.Claim(card.ID, targetAgentID)
+			sb.Done(card.ID, map[string]any{
+				"output":          "agent output",
+				"target_agent_id": targetAgentID,
+			})
+			return nil
+		},
+	}
+	k := New(context.Background(), sb,
+		WithAgentExecutor(executor),
+		WithConfig(KanbanConfig{MaxPendingTasks: 100}),
+	)
+	t.Cleanup(k.Stop)
+
+	sub := subscribeBus(t, sb)
+
+	if _, err := k.Submit(context.Background(), TaskOptions{
+		TargetAgentID: "test-agent",
+		Query:         "hello agent",
+	}); err != nil {
+		t.Fatalf("Submit: %v", err)
+	}
+	k.Stop()
+
+	evs := drainEvents(sub, time.Second, 0, nil)
+	for _, want := range []string{EventTaskSubmitted, EventTaskClaimed, EventTaskCompleted} {
+		if !containsType(evs, want) {
+			t.Errorf("expected %q on Bus(), saw types: %v", want, eventTypes(evs))
+		}
+	}
+}
+
+func TestBus_PublishesTaskFailedFromExecutorError(t *testing.T) {
+	t.Parallel()
+	executor := &mockExecutor{
+		fn: func(_ context.Context, _, _ string, _ *Card, _ string, _ map[string]any) error {
+			return errors.New("agent down")
+		},
+	}
+	k, sb := newKanban(t,
+		WithAgentExecutor(executor),
+		WithConfig(KanbanConfig{MaxPendingTasks: 100}),
+	)
+	sub := subscribeBus(t, sb)
+
+	if _, err := k.Submit(context.Background(), TaskOptions{
+		TargetAgentID: "agent-fail",
+		Query:         "boom",
+	}); err != nil {
+		t.Fatalf("Submit: %v", err)
+	}
+	k.Stop()
+
+	evs := drainEvents(sub, 2*time.Second, 1, func(e event.Event) bool {
+		return string(e.Type) == EventTaskFailed
+	})
+	for _, e := range evs {
+		if string(e.Type) != EventTaskFailed {
+			continue
+		}
+		p, ok := e.Payload.(TaskFailedPayload)
+		if !ok {
+			t.Fatalf("payload type = %T, want TaskFailedPayload", e.Payload)
+		}
+		if p.Error != "agent down" {
+			t.Errorf("payload.Error = %q, want %q", p.Error, "agent down")
+		}
+		if p.TargetAgentID != "agent-fail" {
+			t.Errorf("payload.TargetAgentID = %q, want agent-fail", p.TargetAgentID)
+		}
+		return
+	}
+	t.Fatalf("expected EventTaskFailed on Bus(), saw types: %v", eventTypes(evs))
+}
+
+// ---------------------------------------------------------------------------
+// Bug 6 acceptance: Bus() can reconstruct Cards() over a random op sequence.
+// ---------------------------------------------------------------------------
+
+func TestBus_ReconstructsCardsFromEvents(t *testing.T) {
+	t.Parallel()
+	sb := newBoard(t)
+	sub := subscribeBus(t, sb)
+
+	rng := rand.New(rand.NewSource(42))
+	const ops = 80
+	type liveCard struct {
+		id     string
+		status CardStatus
+	}
+	var live []liveCard
+
+	for i := 0; i < ops; i++ {
+		switch {
+		case len(live) == 0 || rng.Intn(3) == 0:
+			c := sb.Produce("task", "producer-1",
+				TaskPayload{Query: fmt.Sprintf("q-%d", i), TargetAgentID: "agent-1"})
+			live = append(live, liveCard{id: c.ID, status: CardPending})
+		default:
+			idx := rng.Intn(len(live))
+			lc := &live[idx]
+			switch lc.status {
+			case CardPending:
+				if rng.Intn(2) == 0 {
+					sb.Claim(lc.id, "agent-1")
+					lc.status = CardClaimed
+				} else {
+					sb.Fail(lc.id, "boom")
+					lc.status = CardFailed
+				}
+			case CardClaimed:
+				if rng.Intn(2) == 0 {
+					sb.Done(lc.id, map[string]any{"output": "ok", "target_agent_id": "agent-1"})
+					lc.status = CardDone
+				} else {
+					sb.Fail(lc.id, "boom")
+					lc.status = CardFailed
+				}
+			}
+		}
+	}
+
+	// Cards() = ground truth, sorted by ID.
+	type stateRow struct {
+		id     string
+		status string
+	}
+	want := func() []stateRow {
+		raw := sb.Cards()
+		out := make([]stateRow, 0, len(raw))
+		for _, c := range raw {
+			out = append(out, stateRow{id: c.ID, status: c.Status})
+		}
+		sort.Slice(out, func(i, j int) bool { return out[i].id < out[j].id })
+		return out
+	}()
+
+	// Bus() = derived state by replaying event payloads.
+	got := func() []stateRow {
+		state := make(map[string]string)
+		for _, ev := range drainEvents(sub, time.Second, 0, nil) {
+			switch ev.Type {
+			case EventTaskSubmitted:
+				if p, ok := ev.Payload.(TaskSubmittedPayload); ok {
+					state[p.CardID] = string(CardPending)
+				}
+			case EventTaskClaimed:
+				if p, ok := ev.Payload.(TaskClaimedPayload); ok {
+					state[p.CardID] = string(CardClaimed)
+				}
+			case EventTaskCompleted:
+				if p, ok := ev.Payload.(TaskCompletedPayload); ok {
+					state[p.CardID] = string(CardDone)
+				}
+			case EventTaskFailed:
+				if p, ok := ev.Payload.(TaskFailedPayload); ok {
+					state[p.CardID] = string(CardFailed)
+				}
+			}
+		}
+		out := make([]stateRow, 0, len(state))
+		for id, st := range state {
+			out = append(out, stateRow{id: id, status: st})
+		}
+		sort.Slice(out, func(i, j int) bool { return out[i].id < out[j].id })
+		return out
+	}()
+
+	if len(want) != len(got) {
+		t.Fatalf("card count mismatch: Cards()=%d Bus()=%d\nwant=%v\n got=%v", len(want), len(got), want, got)
+	}
+	for i := range want {
+		if want[i] != got[i] {
+			t.Fatalf("state[%d] mismatch: want=%+v got=%+v", i, want[i], got[i])
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Envelope: every payload carries Version=payloadVersion regardless of input.
+// ---------------------------------------------------------------------------
+
+func TestEventEnvelope_StampsVersion(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name    string
+		payload any
+		version func(event.Event) int
+	}{
+		{"task.submitted", TaskSubmittedPayload{CardID: "c1"}, func(e event.Event) int { return e.Payload.(TaskSubmittedPayload).Version }},
+		{"task.claimed", TaskClaimedPayload{CardID: "c1"}, func(e event.Event) int { return e.Payload.(TaskClaimedPayload).Version }},
+		{"task.completed", TaskCompletedPayload{CardID: "c1"}, func(e event.Event) int { return e.Payload.(TaskCompletedPayload).Version }},
+		{"task.failed", TaskFailedPayload{CardID: "c1"}, func(e event.Event) int { return e.Payload.(TaskFailedPayload).Version }},
+		{"cron.created", CronRuleCreatedPayload{ScheduleID: "s1"}, func(e event.Event) int { return e.Payload.(CronRuleCreatedPayload).Version }},
+		{"cron.fired", CronRuleFiredPayload{ScheduleID: "s1"}, func(e event.Event) int { return e.Payload.(CronRuleFiredPayload).Version }},
+		{"cron.disabled", CronRuleDisabledPayload{ScheduleID: "s1"}, func(e event.Event) int { return e.Payload.(CronRuleDisabledPayload).Version }},
+	}
+	for _, c := range cases {
+		c := c
+		t.Run(c.name, func(t *testing.T) {
+			t.Parallel()
+			ev := eventEnvelope("kanban."+c.name, c.payload)
+			if v := c.version(ev); v != payloadVersion {
+				t.Fatalf("Version = %d, want %d", v, payloadVersion)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// helpers
+// ---------------------------------------------------------------------------
+
+func containsType(evs []event.Event, t string) bool {
+	for _, e := range evs {
+		if string(e.Type) == t {
+			return true
+		}
+	}
+	return false
+}
+
+func eventTypes(evs []event.Event) []string {
+	out := make([]string, len(evs))
+	for i, e := range evs {
+		out[i] = string(e.Type)
+	}
+	return out
+}

--- a/sdk/kanban/helpers_test.go
+++ b/sdk/kanban/helpers_test.go
@@ -1,0 +1,138 @@
+package kanban
+
+import (
+	"context"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/GizClaw/flowcraft/sdk/event"
+)
+
+// ---------------------------------------------------------------------------
+// Shared test helpers
+//
+// All kanban_test files use these helpers to avoid duplicating
+// mockExecutor / drain / scope-id boilerplate. Keep this file small and free
+// of test functions — tests live in their topic-specific files.
+// ---------------------------------------------------------------------------
+
+// scopeCounter generates unique scope IDs across parallel tests so that
+// resource leak diagnostics in failures point at the right test.
+var scopeCounter atomic.Uint64
+
+// scopeID returns a per-call unique scope identifier rooted at the test name.
+// Use this in any test that creates a Board so failures stay attributable.
+func scopeID(t *testing.T) string {
+	t.Helper()
+	name := strings.ReplaceAll(t.Name(), "/", "-")
+	return name + "-" + itoa(scopeCounter.Add(1))
+}
+
+func itoa(n uint64) string {
+	if n == 0 {
+		return "0"
+	}
+	var buf [20]byte
+	i := len(buf)
+	for n > 0 {
+		i--
+		buf[i] = byte('0' + n%10)
+		n /= 10
+	}
+	return string(buf[i:])
+}
+
+// newBoard returns a Board whose Close is registered with t.Cleanup, so tests
+// never leak the board lifecycle goroutine.
+func newBoard(t *testing.T, opts ...BoardOption) *Board {
+	t.Helper()
+	b := NewBoard(scopeID(t), opts...)
+	t.Cleanup(b.Close)
+	return b
+}
+
+// newKanban returns a Kanban + Board pair, both auto-stopped on test cleanup.
+func newKanban(t *testing.T, opts ...Option) (*Kanban, *Board) {
+	t.Helper()
+	b := newBoard(t)
+	k := New(context.Background(), b, opts...)
+	t.Cleanup(k.Stop)
+	return k, b
+}
+
+// ---------------------------------------------------------------------------
+// mockExecutor — shared across kanban / scheduler / events tests
+// ---------------------------------------------------------------------------
+
+type mockExecutor struct {
+	fn func(ctx context.Context, scopeID, targetAgentID string, card *Card, query string, inputs map[string]any) error
+}
+
+func (m *mockExecutor) ExecuteTask(ctx context.Context, scopeID, targetAgentID string, card *Card, query string, inputs map[string]any) error {
+	if m.fn != nil {
+		return m.fn(ctx, scopeID, targetAgentID, card, query, inputs)
+	}
+	return nil
+}
+
+// ---------------------------------------------------------------------------
+// Channel / event helpers
+// ---------------------------------------------------------------------------
+
+// waitCard blocks for one card from ch up to timeout, failing the test on
+// timeout with a labelled diagnostic. Use this instead of bare select+t.Fatal.
+func waitCard(t *testing.T, ch <-chan *Card, label string) *Card {
+	t.Helper()
+	select {
+	case c, ok := <-ch:
+		if !ok {
+			t.Fatalf("%s: channel closed unexpectedly", label)
+		}
+		return c
+	case <-time.After(2 * time.Second):
+		t.Fatalf("%s: timed out waiting for card", label)
+		return nil
+	}
+}
+
+// drainEvents collects every event emitted on sub until either matchCount
+// events satisfy match (returning early), or the deadline elapses.
+//
+// match may be nil to collect everything. The returned slice preserves
+// arrival order and includes all events seen, not just the matching ones.
+func drainEvents(sub event.Subscription, deadline time.Duration, matchCount int, match func(event.Event) bool) []event.Event {
+	var out []event.Event
+	matched := 0
+	timeout := time.After(deadline)
+	for {
+		select {
+		case ev, ok := <-sub.Events():
+			if !ok {
+				return out
+			}
+			out = append(out, ev)
+			if match != nil && match(ev) {
+				matched++
+				if matchCount > 0 && matched >= matchCount {
+					return out
+				}
+			}
+		case <-timeout:
+			return out
+		}
+	}
+}
+
+// subscribeBus subscribes to b.Bus() with a generous buffer and registers
+// the subscription's Close with t.Cleanup.
+func subscribeBus(t *testing.T, b *Board) event.Subscription {
+	t.Helper()
+	sub, err := b.Bus().Subscribe(context.Background(), event.EventFilter{}, event.WithBufferSize(1024))
+	if err != nil {
+		t.Fatalf("Bus().Subscribe: %v", err)
+	}
+	t.Cleanup(func() { _ = sub.Close() })
+	return sub
+}

--- a/sdk/kanban/kanban.go
+++ b/sdk/kanban/kanban.go
@@ -2,6 +2,7 @@ package kanban
 
 import (
 	"context"
+	"runtime"
 	"sync"
 	"time"
 
@@ -77,17 +78,28 @@ func DefaultConfig() KanbanConfig {
 	}
 }
 
+// DefaultStopTimeout bounds how long Kanban.Stop() waits for in-flight
+// executors before logging and returning. Override with WithStopTimeout(0)
+// for the legacy "wait forever" behaviour, or with a different positive
+// duration. Callers building integrations on top of Kanban (SIGTERM
+// handlers, test harnesses) rely on Stop terminating in bounded time.
+const DefaultStopTimeout = 10 * time.Second
+
 // Kanban coordinates multi-agent collaboration via a shared board.
+//
+// Kanban does not own an independent event bus: every state transition is
+// published on Board.Bus(), which is the single source of truth.
+// (k *Kanban).Bus() is a thin alias for board.Bus() kept for ergonomics.
 type Kanban struct {
-	board     *Board
-	executor  AgentExecutor
-	validator AgentValidator
-	bus       event.EventBus
-	cfg       KanbanConfig
-	metrics   *kanbanMetrics
-	scheduler *Scheduler
-	ctx       context.Context
-	cancel    context.CancelFunc
+	board       *Board
+	executor    AgentExecutor
+	validator   AgentValidator
+	cfg         KanbanConfig
+	metrics     *kanbanMetrics
+	scheduler   *Scheduler
+	stopTimeout time.Duration
+	ctx         context.Context
+	cancel      context.CancelFunc
 
 	mu       sync.RWMutex
 	closed   bool
@@ -102,12 +114,12 @@ func New(ctx context.Context, board *Board, opts ...Option) *Kanban {
 	}
 	runCtx, cancel := context.WithCancel(ctx)
 	k := &Kanban{
-		board:   board,
-		bus:     board.Bus(),
-		cfg:     DefaultConfig(),
-		metrics: newKanbanMetrics(ctx),
-		ctx:     runCtx,
-		cancel:  cancel,
+		board:       board,
+		cfg:         DefaultConfig(),
+		metrics:     newKanbanMetrics(ctx),
+		stopTimeout: DefaultStopTimeout,
+		ctx:         runCtx,
+		cancel:      cancel,
 	}
 	for _, opt := range opts {
 		opt(k)
@@ -135,9 +147,15 @@ func WithAgentValidator(v AgentValidator) Option {
 	return func(k *Kanban) { k.validator = v }
 }
 
-// WithEventBus sets the event bus for publishing Kanban events.
-func WithEventBus(bus event.EventBus) Option {
-	return func(k *Kanban) { k.bus = bus }
+// WithEventBus is retained for source compatibility only and has no effect.
+//
+// Deprecated: Board.Bus() is the single source of truth for every Kanban
+// state transition (task submitted / claimed / completed / failed + cron
+// rule created / fired / disabled). Pass your bus to the Board instead, or
+// subscribe to board.Bus() and forward as needed. This option will be
+// removed in v0.2.0.
+func WithEventBus(_ event.EventBus) Option {
+	return func(*Kanban) {}
 }
 
 // WithConfig sets the Kanban configuration.
@@ -150,10 +168,28 @@ func WithScheduler(s *Scheduler) Option {
 	return func(k *Kanban) { k.scheduler = s }
 }
 
+// WithStopTimeout bounds how long Stop will wait for in-flight executors.
+// The default is DefaultStopTimeout (10s); pass 0 or a negative value to
+// fall back to the legacy "wait forever" behaviour.
+//
+// On timeout, Stop logs the unfinished goroutine count captured at start
+// of Stop and returns; the executors keep running but no longer block
+// process exit. AgentExecutor implementations should always honour ctx
+// cancellation — using context.WithoutCancel inside an executor chain
+// defeats this safety net.
+func WithStopTimeout(d time.Duration) Option {
+	return func(k *Kanban) { k.stopTimeout = d }
+}
+
 // Scheduler returns the embedded scheduler, or nil.
 func (k *Kanban) Scheduler() *Scheduler { return k.scheduler }
 
-// Stop closes the Kanban admission path and waits for running executors to finish.
+// Stop closes the Kanban admission path and waits for in-flight executors.
+// The wait is bounded by the stop timeout (DefaultStopTimeout = 10s, or
+// the value passed to WithStopTimeout); set WithStopTimeout(0) to wait
+// forever. On timeout the alive-goroutine count captured at start of Stop
+// is logged and Stop returns without waiting for stuck executors. The
+// board is always closed before Stop returns.
 func (k *Kanban) Stop() {
 	k.stopOnce.Do(func() {
 		k.mu.Lock()
@@ -170,7 +206,30 @@ func (k *Kanban) Stop() {
 				k.board.Close()
 			}
 		}()
-		k.execWg.Wait()
+
+		if k.stopTimeout <= 0 {
+			k.execWg.Wait()
+			return
+		}
+
+		goroutinesAtStop := runtime.NumGoroutine()
+		done := make(chan struct{})
+		go func() {
+			k.execWg.Wait()
+			close(done)
+		}()
+		select {
+		case <-done:
+		case <-time.After(k.stopTimeout):
+			ctx := k.ctx
+			if ctx == nil {
+				ctx = context.Background()
+			}
+			telemetry.Warn(ctx, "kanban: Stop timed out waiting for executors; returning early",
+				otellog.String("stop_timeout", k.stopTimeout.String()),
+				otellog.Int("goroutines_at_stop", goroutinesAtStop),
+				otellog.Int("goroutines_now", runtime.NumGoroutine()))
+		}
 	})
 }
 
@@ -194,8 +253,9 @@ func (k *Kanban) executionContext(producer string) context.Context {
 // Board returns the owned task board.
 func (k *Kanban) Board() *Board { return k.board }
 
-// Bus returns the event bus used by Kanban.
-func (k *Kanban) Bus() event.EventBus { return k.bus }
+// Bus returns the event bus that publishes every Kanban state transition.
+// It is an alias for Board().Bus(); both return the same underlying bus.
+func (k *Kanban) Bus() event.EventBus { return k.board.Bus() }
 
 // Submit produces a task card on the board and executes via AgentExecutor.
 // All tasks are asynchronous; results are delivered via callback.
@@ -258,14 +318,8 @@ func (k *Kanban) Submit(ctx context.Context, opts TaskOptions) (string, error) {
 	k.mu.Unlock()
 
 	k.metrics.incTasksSubmitted(ctx, attribute.String("target_agent_id", opts.TargetAgentID))
-
-	k.publishEvent(ctx, EventTaskSubmitted, TaskSubmittedPayload{
-		CardID:        card.ID,
-		TargetAgentID: opts.TargetAgentID,
-		Query:         opts.Query,
-		RuntimeID:     k.board.ScopeID(),
-		Inputs:        opts.Inputs,
-	})
+	// EventTaskSubmitted is published by Board.Produce → publishProduceEvent.
+	// Do not re-publish here; Board.Bus() is the single source of truth.
 
 	if shouldExecute {
 		go func() {
@@ -282,14 +336,9 @@ func (k *Kanban) Submit(ctx context.Context, opts TaskOptions) (string, error) {
 					attribute.String("target_agent_id", opts.TargetAgentID),
 					attribute.String("status", "error"),
 				)
+				// Board.Fail publishes EventTaskFailed via publishCardEvent;
+				// no need to emit a second copy from here.
 				k.board.Fail(card.ID, err.Error())
-				k.publishEvent(execCtx, EventTaskFailed, TaskFailedPayload{
-					CardID:        card.ID,
-					TargetAgentID: opts.TargetAgentID,
-					RuntimeID:     k.board.ScopeID(),
-					Error:         err.Error(),
-					ElapsedMs:     elapsed.Milliseconds(),
-				})
 				telemetry.Warn(ctx, "kanban executor failed",
 					otellog.String("card", card.ID),
 					otellog.String("error", err.Error()))
@@ -326,14 +375,4 @@ func (k *Kanban) Broadcast(ctx context.Context, signalType string, payload any) 
 	}
 	producer := ProducerIDFrom(ctx)
 	k.board.Produce("signal", producer, payload, WithMeta("signal_type", signalType))
-}
-
-func (k *Kanban) publishEvent(ctx context.Context, eventType string, payload any) {
-	if k.bus == nil {
-		return
-	}
-	_ = k.bus.Publish(ctx, event.Event{
-		Type:    event.EventType(eventType),
-		Payload: payload,
-	})
 }

--- a/sdk/kanban/kanban_test.go
+++ b/sdk/kanban/kanban_test.go
@@ -2,6 +2,7 @@ package kanban
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 	"sync"
@@ -13,28 +14,12 @@ import (
 )
 
 // ---------------------------------------------------------------------------
-// Helpers
+// Submit — happy path & payload shaping
 // ---------------------------------------------------------------------------
 
-type mockExecutor struct {
-	fn func(ctx context.Context, scopeID, targetAgentID string, card *Card, query string, inputs map[string]any) error
-}
-
-func (m *mockExecutor) ExecuteTask(ctx context.Context, scopeID, targetAgentID string, card *Card, query string, inputs map[string]any) error {
-	if m.fn != nil {
-		return m.fn(ctx, scopeID, targetAgentID, card, query, inputs)
-	}
-	return nil
-}
-
-// ---------------------------------------------------------------------------
-// Submit
-// ---------------------------------------------------------------------------
-
-func TestKanban_Submit(t *testing.T) {
-	sb := NewBoard("scope-1")
-	k := New(context.Background(), sb, WithConfig(KanbanConfig{MaxPendingTasks: 100}))
-	defer k.Stop()
+func TestKanban_Submit_HappyPath(t *testing.T) {
+	t.Parallel()
+	k, _ := newKanban(t, WithConfig(KanbanConfig{MaxPendingTasks: 100}))
 
 	ctx := context.Background()
 	cardID, err := k.Submit(ctx, TaskOptions{
@@ -55,62 +40,86 @@ func TestKanban_Submit(t *testing.T) {
 		t.Fatalf("GetCard: %v", err)
 	}
 	p := PayloadMap(card.Payload)
-	if p["user_query"] != "帮我创建一个 RAG 应用" {
-		t.Fatalf("expected user_query in payload, got %v", p["user_query"])
-	}
-	if p["dispatch_note"] != "完成后告知用户" {
-		t.Fatalf("expected dispatch_note in payload, got %v", p["dispatch_note"])
-	}
-	if p["target_agent_id"] != "copilot_builder" {
-		t.Fatalf("expected target_agent_id in payload, got %v", p["target_agent_id"])
+	for key, want := range map[string]string{
+		"user_query":      "帮我创建一个 RAG 应用",
+		"dispatch_note":   "完成后告知用户",
+		"target_agent_id": "copilot_builder",
+	} {
+		if p[key] != want {
+			t.Fatalf("payload[%q] = %v, want %q", key, p[key], want)
+		}
 	}
 }
+
+// ---------------------------------------------------------------------------
+// Submit — guardrails (rate limit, validator, structured errors)
+// ---------------------------------------------------------------------------
 
 func TestKanban_Submit_PendingLimit(t *testing.T) {
-	sb := NewBoard("scope-2")
-	k := New(context.Background(), sb, WithConfig(KanbanConfig{MaxPendingTasks: 2}))
+	t.Parallel()
+	k, _ := newKanban(t, WithConfig(KanbanConfig{MaxPendingTasks: 2}))
 
-	ctx := context.Background()
-
-	_, err := k.Submit(ctx, TaskOptions{Query: "task 1"})
-	if err != nil {
-		t.Fatalf("submit 1: %v", err)
-	}
-	_, err = k.Submit(ctx, TaskOptions{Query: "task 2"})
-	if err != nil {
-		t.Fatalf("submit 2: %v", err)
+	for i, query := range []string{"task 1", "task 2"} {
+		if _, err := k.Submit(context.Background(), TaskOptions{Query: query}); err != nil {
+			t.Fatalf("submit %d: %v", i+1, err)
+		}
 	}
 
-	_, err = k.Submit(ctx, TaskOptions{Query: "task 3"})
+	_, err := k.Submit(context.Background(), TaskOptions{Query: "task 3"})
 	if err == nil {
-		t.Fatal("expected pending limit error")
-	}
-}
-
-func TestKanban_Submit_StructuredErrors(t *testing.T) {
-	sb := NewBoard("scope-err")
-
-	k := New(context.Background(), sb, WithConfig(KanbanConfig{MaxPendingTasks: 1}))
-	ctx := context.Background()
-	_, _ = k.Submit(ctx, TaskOptions{Query: "task 1"})
-	_, err := k.Submit(ctx, TaskOptions{Query: "task 2"})
-	if err == nil {
-		t.Fatal("expected rate limit error")
+		t.Fatal("expected pending-limit error on 3rd submit")
 	}
 	if !errdefs.IsRateLimit(err) {
 		t.Fatalf("expected RateLimit error, got %v", err)
 	}
 }
 
+func TestKanban_Submit_AgentValidatorRejects(t *testing.T) {
+	t.Parallel()
+	validAgents := map[string]bool{"copilot-builder": true, "copilot-runner": true}
+	validator := func(_ context.Context, agentID string) error {
+		if validAgents[agentID] {
+			return nil
+		}
+		return fmt.Errorf("agent %q not found; available agent IDs: [copilot-builder copilot-runner]", agentID)
+	}
+	k, _ := newKanban(t,
+		WithAgentValidator(validator),
+		WithConfig(KanbanConfig{MaxPendingTasks: 100}),
+	)
+
+	_, err := k.Submit(context.Background(), TaskOptions{
+		TargetAgentID: "agent-builder",
+		Query:         "build something",
+	})
+	if err == nil {
+		t.Fatal("expected validation error for unknown agent")
+	}
+	if !strings.Contains(err.Error(), "agent-builder") || !strings.Contains(err.Error(), "copilot-builder") {
+		t.Fatalf("error should name the bad ID and list valid IDs, got: %v", err)
+	}
+
+	if cards := k.QueryCards(CardFilter{Type: "task"}); len(cards) != 0 {
+		t.Fatalf("expected 0 cards after rejected submit, got %d", len(cards))
+	}
+
+	if _, err := k.Submit(context.Background(), TaskOptions{
+		TargetAgentID: "copilot-builder",
+		Query:         "build something",
+	}); err != nil {
+		t.Fatalf("expected valid agent to pass validation: %v", err)
+	}
+}
+
 // ---------------------------------------------------------------------------
-// GetCard / QueryCards
+// GetCard / QueryCards / Broadcast
 // ---------------------------------------------------------------------------
 
 func TestKanban_GetCard(t *testing.T) {
-	sb := NewBoard("scope-gc")
-	k := New(context.Background(), sb)
-
+	t.Parallel()
+	k, sb := newKanban(t)
 	card := sb.Produce("task", "orch", "payload1")
+
 	got, err := k.GetCard(context.Background(), card.ID)
 	if err != nil {
 		t.Fatalf("GetCard: %v", err)
@@ -128,53 +137,93 @@ func TestKanban_GetCard(t *testing.T) {
 	}
 }
 
-func TestKanban_QueryCards(t *testing.T) {
-	sb := NewBoard("scope-qc")
-	k := New(context.Background(), sb)
-
+func TestKanban_QueryCards_FiltersByType(t *testing.T) {
+	t.Parallel()
+	k, sb := newKanban(t)
 	sb.Produce("task", "orch", "payload1")
 	sb.Produce("task", "orch", "payload2")
 	sb.Produce("signal", "orch", "stop")
 
-	tasks := k.QueryCards(CardFilter{Type: "task"})
-	if len(tasks) != 2 {
-		t.Fatalf("expected 2 task cards, got %d", len(tasks))
+	cases := []struct {
+		filter CardFilter
+		want   int
+		label  string
+	}{
+		{CardFilter{Type: "task"}, 2, "task filter"},
+		{CardFilter{Type: "signal"}, 1, "signal filter"},
+		{CardFilter{}, 3, "no filter"},
 	}
-
-	signals := k.QueryCards(CardFilter{Type: "signal"})
-	if len(signals) != 1 {
-		t.Fatalf("expected 1 signal card, got %d", len(signals))
-	}
-
-	all := k.QueryCards(CardFilter{})
-	if len(all) != 3 {
-		t.Fatalf("expected 3 total cards, got %d", len(all))
+	for _, c := range cases {
+		if got := len(k.QueryCards(c.filter)); got != c.want {
+			t.Errorf("%s: got %d, want %d", c.label, got, c.want)
+		}
 	}
 }
 
-// ---------------------------------------------------------------------------
-// Broadcast
-// ---------------------------------------------------------------------------
+// TestKanban_Board_ReturnsUnderlyingBoard guards the Board() accessor.
+// Many callers (audit, persistence layers) rely on this.
+func TestKanban_Board_ReturnsUnderlyingBoard(t *testing.T) {
+	t.Parallel()
+	k, sb := newKanban(t)
+	if k.Board() != sb {
+		t.Fatal("Kanban.Board() should return the same Board passed to New()")
+	}
+}
 
-func TestKanban_Broadcast(t *testing.T) {
-	sb := NewBoard("scope-4")
-	k := New(context.Background(), sb)
+// TestKanban_WithEventBus_DeprecatedNoOp pins the v0.1.x contract:
+// WithEventBus is accepted for source compatibility but is a complete
+// no-op. Events must continue to land on board.Bus() — the injected bus
+// must remain silent. Will be removed together with WithEventBus in v0.2.0.
+func TestKanban_WithEventBus_DeprecatedNoOp(t *testing.T) {
+	t.Parallel()
+	external := event.NewMemoryBus()
+	t.Cleanup(func() { _ = external.Close() })
 
-	ctx := context.Background()
-	k.Broadcast(ctx, "stop_all", map[string]string{"reason": "test"})
+	extSub, err := external.Subscribe(context.Background(), event.EventFilter{})
+	if err != nil {
+		t.Fatalf("external.Subscribe: %v", err)
+	}
+	t.Cleanup(func() { _ = extSub.Close() })
 
-	cards := sb.Query(CardFilter{Type: "signal"})
-	if len(cards) != 1 {
+	k, sb := newKanban(t, WithEventBus(external))
+	if k.Bus() != sb.Bus() {
+		t.Fatal("Kanban.Bus() must alias board.Bus(); WithEventBus must not redirect it")
+	}
+
+	boardSub := subscribeBus(t, sb)
+
+	if _, err := k.Submit(context.Background(), TaskOptions{Query: "still works"}); err != nil {
+		t.Fatalf("Submit after WithEventBus: %v", err)
+	}
+
+	if got := drainEvents(boardSub, 200*time.Millisecond, 1, func(e event.Event) bool {
+		return string(e.Type) == EventTaskSubmitted
+	}); !containsType(got, EventTaskSubmitted) {
+		t.Fatalf("expected EventTaskSubmitted on board.Bus(), got types=%v", eventTypes(got))
+	}
+
+	if got := drainEvents(extSub, 100*time.Millisecond, 0, nil); len(got) != 0 {
+		t.Fatalf("WithEventBus must be a no-op; injected bus received %d events: %v",
+			len(got), eventTypes(got))
+	}
+}
+
+func TestKanban_Broadcast_ProducesSignalCard(t *testing.T) {
+	t.Parallel()
+	k, sb := newKanban(t)
+	k.Broadcast(context.Background(), "stop_all", map[string]string{"reason": "test"})
+
+	if cards := sb.Query(CardFilter{Type: "signal"}); len(cards) != 1 {
 		t.Fatalf("expected 1 signal card, got %d", len(cards))
 	}
 }
 
 // ---------------------------------------------------------------------------
-// Executor — success
+// Executor — invocation, success, failure
 // ---------------------------------------------------------------------------
 
-func TestKanban_Submit_WithExecutor(t *testing.T) {
-	sb := NewBoard("scope-exec")
+func TestKanban_Submit_InvokesExecutor(t *testing.T) {
+	t.Parallel()
 	executed := make(chan struct{})
 	executor := &mockExecutor{
 		fn: func(_ context.Context, _, _ string, _ *Card, _ string, _ map[string]any) error {
@@ -183,104 +232,30 @@ func TestKanban_Submit_WithExecutor(t *testing.T) {
 		},
 	}
 
-	k := New(context.Background(), sb, WithAgentExecutor(executor), WithConfig(KanbanConfig{MaxPendingTasks: 100}))
-	defer k.Stop()
-
-	_, err := k.Submit(context.Background(), TaskOptions{
+	k, _ := newKanban(t, WithAgentExecutor(executor), WithConfig(KanbanConfig{MaxPendingTasks: 100}))
+	if _, err := k.Submit(context.Background(), TaskOptions{
 		TargetAgentID: "builder",
 		Query:         "build something",
-	})
-	if err != nil {
+	}); err != nil {
 		t.Fatalf("Submit: %v", err)
 	}
 
 	select {
 	case <-executed:
 	case <-time.After(2 * time.Second):
-		t.Fatal("executor was not called")
+		t.Fatal("executor was not invoked")
 	}
 }
 
-func TestKanban_ExecutorClaimAndDone(t *testing.T) {
-	sb := NewBoard("scope-ev")
-	defer sb.Close()
-
-	executor := &mockExecutor{
-		fn: func(_ context.Context, _, targetAgentID string, card *Card, _ string, _ map[string]any) error {
-			sb.Claim(card.ID, targetAgentID)
-			sb.Done(card.ID, map[string]any{
-				"output":          "agent output",
-				"target_agent_id": targetAgentID,
-			})
-			return nil
-		},
-	}
-
-	k := New(context.Background(), sb,
-		WithAgentExecutor(executor),
-		WithConfig(KanbanConfig{MaxPendingTasks: 100}),
-		WithEventBus(sb.Bus()),
-	)
-
-	ctx := context.Background()
-	sub, err := sb.Bus().Subscribe(ctx, event.EventFilter{})
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer func() { _ = sub.Close() }()
-
-	_, err = k.Submit(ctx, TaskOptions{
-		TargetAgentID: "test-agent",
-		Query:         "hello agent",
-	})
-	if err != nil {
-		t.Fatalf("Submit: %v", err)
-	}
-
-	k.Stop()
-
-	var received []event.Event
-	drainTimeout := time.After(time.Second)
-drain:
-	for {
-		select {
-		case ev := <-sub.Events():
-			received = append(received, ev)
-		case <-drainTimeout:
-			break drain
-		}
-	}
-
-	hasSubmitted := false
-	for _, ev := range received {
-		if ev.Type == EventTaskSubmitted {
-			hasSubmitted = true
-		}
-	}
-	if !hasSubmitted {
-		t.Fatal("expected task.submitted event on Bus")
-	}
-}
-
-// ---------------------------------------------------------------------------
-// Executor — failure (K-1)
-// ---------------------------------------------------------------------------
-
-func TestKanban_ExecutorError_MarksCardFailed(t *testing.T) {
-	sb := NewBoard("scope-k1-fail")
-	defer sb.Close()
-
+func TestKanban_Executor_FailureMarksCardFailed(t *testing.T) {
+	t.Parallel()
 	executor := &mockExecutor{
 		fn: func(_ context.Context, _, _ string, _ *Card, _ string, _ map[string]any) error {
-			return fmt.Errorf("simulated executor crash")
+			return errors.New("simulated executor crash")
 		},
 	}
 
-	k := New(context.Background(), sb,
-		WithAgentExecutor(executor),
-		WithConfig(KanbanConfig{MaxPendingTasks: 100}),
-	)
-
+	k, _ := newKanban(t, WithAgentExecutor(executor), WithConfig(KanbanConfig{MaxPendingTasks: 100}))
 	cardID, err := k.Submit(context.Background(), TaskOptions{
 		TargetAgentID: "agent-x",
 		Query:         "do work",
@@ -288,7 +263,6 @@ func TestKanban_ExecutorError_MarksCardFailed(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Submit: %v", err)
 	}
-
 	k.Stop()
 
 	card, err := k.GetCard(context.Background(), cardID)
@@ -296,157 +270,39 @@ func TestKanban_ExecutorError_MarksCardFailed(t *testing.T) {
 		t.Fatalf("GetCard: %v", err)
 	}
 	if card.Status != CardFailed {
-		t.Fatalf("expected card status Failed, got %s", card.Status)
+		t.Fatalf("expected CardFailed, got %s", card.Status)
 	}
 	if card.Error != "simulated executor crash" {
 		t.Fatalf("expected error message on card, got %q", card.Error)
 	}
 }
 
-func TestKanban_ExecutorError_PublishesTaskFailedEvent(t *testing.T) {
-	sb := NewBoard("scope-k1-ev")
-	defer sb.Close()
-
-	bus := event.NewMemoryBus()
-	defer func() { _ = bus.Close() }()
-
-	executor := &mockExecutor{
-		fn: func(_ context.Context, _, _ string, _ *Card, _ string, _ map[string]any) error {
-			return fmt.Errorf("agent down")
-		},
-	}
-
-	k := New(context.Background(), sb,
-		WithAgentExecutor(executor),
-		WithEventBus(bus),
-		WithConfig(KanbanConfig{MaxPendingTasks: 100}),
-	)
-
-	sub, err := bus.Subscribe(context.Background(), event.EventFilter{})
-	if err != nil {
-		t.Fatalf("subscribe: %v", err)
-	}
-	defer func() { _ = sub.Close() }()
-
-	_, err = k.Submit(context.Background(), TaskOptions{
-		TargetAgentID: "agent-fail",
-		Query:         "boom",
-	})
-	if err != nil {
-		t.Fatalf("Submit: %v", err)
-	}
-
-	k.Stop()
-
-	var hasFailed bool
-	timeout := time.After(2 * time.Second)
-drainFailed:
-	for {
-		select {
-		case ev := <-sub.Events():
-			if string(ev.Type) == EventTaskFailed {
-				hasFailed = true
-				p, ok := ev.Payload.(TaskFailedPayload)
-				if !ok {
-					break drainFailed
-				}
-				if p.Error != "agent down" {
-					t.Fatalf("expected error='agent down', got %q", p.Error)
-				}
-				if p.TargetAgentID != "agent-fail" {
-					t.Fatalf("expected target_agent_id='agent-fail', got %q", p.TargetAgentID)
-				}
-				break drainFailed
-			}
-		case <-timeout:
-			break drainFailed
-		}
-	}
-	if !hasFailed {
-		t.Fatal("expected EventTaskFailed to be published when executor returns error")
-	}
-}
-
-func TestKanban_ExecutorCallsFailThenReturnsError(t *testing.T) {
-	sb := NewBoard("scope-fail-both")
-	defer sb.Close()
-
+// TestKanban_Executor_FailIsIdempotent guards the legacy contract that an
+// executor is allowed to call Fail itself and also return a non-nil error;
+// only one CardFailed transition must land on the board.
+func TestKanban_Executor_FailIsIdempotent(t *testing.T) {
+	t.Parallel()
+	sb := newBoard(t)
 	executor := &mockExecutor{
 		fn: func(_ context.Context, _, targetAgentID string, card *Card, _ string, _ map[string]any) error {
 			sb.Claim(card.ID, targetAgentID)
 			sb.Fail(card.ID, "execution failed")
-			return fmt.Errorf("execution failed")
+			return errors.New("execution failed")
 		},
 	}
+	k := New(context.Background(), sb, WithAgentExecutor(executor), WithConfig(KanbanConfig{MaxPendingTasks: 100}))
+	t.Cleanup(k.Stop)
 
-	k := New(context.Background(), sb,
-		WithAgentExecutor(executor),
-		WithConfig(KanbanConfig{MaxPendingTasks: 100}),
-	)
-
-	_, err := k.Submit(context.Background(), TaskOptions{
+	if _, err := k.Submit(context.Background(), TaskOptions{
 		TargetAgentID: "fail-agent",
 		Query:         "boom",
-	})
-	if err != nil {
+	}); err != nil {
 		t.Fatalf("Submit: %v", err)
 	}
-
 	k.Stop()
 
-	failed := sb.Query(CardFilter{Type: "task", Status: CardFailed})
-	if len(failed) == 0 {
-		t.Fatal("expected failed card after executor error")
-	}
-}
-
-// ---------------------------------------------------------------------------
-// Validator
-// ---------------------------------------------------------------------------
-
-func TestKanban_Submit_AgentValidatorRejects(t *testing.T) {
-	tb := NewBoard("scope-validate")
-	validAgents := map[string]bool{"copilot-builder": true, "copilot-runner": true}
-	validator := func(_ context.Context, agentID string) error {
-		if validAgents[agentID] {
-			return nil
-		}
-		return fmt.Errorf("agent %q not found; available agent IDs: [copilot-builder copilot-runner]", agentID)
-	}
-	k := New(context.Background(), tb,
-		WithAgentValidator(validator),
-		WithConfig(KanbanConfig{MaxPendingTasks: 100}),
-	)
-	defer k.Stop()
-
-	_, err := k.Submit(context.Background(), TaskOptions{
-		TargetAgentID: "agent-builder",
-		Query:         "build something",
-	})
-	if err == nil {
-		t.Fatal("expected validation error for unknown agent")
-	}
-	if !strings.Contains(err.Error(), "agent-builder") {
-		t.Fatalf("error should mention invalid ID, got: %v", err)
-	}
-	if !strings.Contains(err.Error(), "copilot-builder") {
-		t.Fatalf("error should list available IDs, got: %v", err)
-	}
-
-	cards := k.QueryCards(CardFilter{Type: "task"})
-	if len(cards) != 0 {
-		t.Fatalf("expected 0 cards after rejected submit, got %d", len(cards))
-	}
-
-	cardID, err := k.Submit(context.Background(), TaskOptions{
-		TargetAgentID: "copilot-builder",
-		Query:         "build something",
-	})
-	if err != nil {
-		t.Fatalf("expected valid agent to pass validation: %v", err)
-	}
-	if cardID == "" {
-		t.Fatal("expected non-empty card ID for valid agent")
+	if got := len(sb.Query(CardFilter{Type: "task", Status: CardFailed})); got != 1 {
+		t.Fatalf("expected exactly 1 failed card, got %d", got)
 	}
 }
 
@@ -454,25 +310,26 @@ func TestKanban_Submit_AgentValidatorRejects(t *testing.T) {
 // Stop / lifecycle
 // ---------------------------------------------------------------------------
 
-func TestKanban_StopRejectsNewSubmit(t *testing.T) {
-	tb := NewBoard("scope-stop")
-	k := New(context.Background(), tb)
-
+func TestKanban_Stop_RejectsNewSubmits(t *testing.T) {
+	t.Parallel()
+	k, _ := newKanban(t)
 	k.Stop()
+
 	_, err := k.Submit(context.Background(), TaskOptions{Query: "after-stop"})
 	if err == nil {
-		t.Fatal("expected submit to fail after stop")
+		t.Fatal("expected submit to fail after Stop")
 	}
 	if !errdefs.IsNotAvailable(err) {
 		t.Fatalf("expected NotAvailable error, got %v", err)
 	}
 }
 
-func TestKanban_StopWaitsInflightExecutor(t *testing.T) {
-	tb := NewBoard("scope-wait")
+func TestKanban_Stop_WaitsForInflightExecutor(t *testing.T) {
+	t.Parallel()
 	started := make(chan struct{})
 	release := make(chan struct{})
-	k := New(context.Background(), tb, WithAgentExecutor(&mockExecutor{
+
+	k, _ := newKanban(t, WithAgentExecutor(&mockExecutor{
 		fn: func(_ context.Context, _, _ string, _ *Card, _ string, _ map[string]any) error {
 			close(started)
 			<-release
@@ -496,7 +353,7 @@ func TestKanban_StopWaitsInflightExecutor(t *testing.T) {
 
 	select {
 	case <-stopped:
-		t.Fatal("Stop should wait for inflight executor")
+		t.Fatal("Stop returned before inflight executor finished")
 	case <-time.After(100 * time.Millisecond):
 	}
 
@@ -509,13 +366,13 @@ func TestKanban_StopWaitsInflightExecutor(t *testing.T) {
 	}
 }
 
-func TestKanban_StopCancelsExecutorContext(t *testing.T) {
-	tb := NewBoard("scope-cancel")
-	ctxCancelled := make(chan struct{})
-	k := New(context.Background(), tb, WithAgentExecutor(&mockExecutor{
+func TestKanban_Stop_CancelsExecutorContext(t *testing.T) {
+	t.Parallel()
+	cancelled := make(chan struct{})
+	k, _ := newKanban(t, WithAgentExecutor(&mockExecutor{
 		fn: func(ctx context.Context, _, _ string, _ *Card, _ string, _ map[string]any) error {
 			<-ctx.Done()
-			close(ctxCancelled)
+			close(cancelled)
 			return ctx.Err()
 		},
 	}))
@@ -530,49 +387,127 @@ func TestKanban_StopCancelsExecutorContext(t *testing.T) {
 	k.Stop()
 
 	select {
-	case <-ctxCancelled:
+	case <-cancelled:
 	case <-time.After(2 * time.Second):
 		t.Fatal("executor context was not cancelled by Stop")
 	}
 }
 
-// ---------------------------------------------------------------------------
-// Events
-// ---------------------------------------------------------------------------
+// Default stopTimeout is DefaultStopTimeout (10s), not "wait forever".
+// A fresh Kanban with no Option must therefore have a bounded Stop.
+func TestKanban_Stop_DefaultTimeoutIsTenSeconds(t *testing.T) {
+	t.Parallel()
+	k, _ := newKanban(t)
+	if got, want := k.stopTimeout, DefaultStopTimeout; got != want {
+		t.Fatalf("default stopTimeout = %v, want %v", got, want)
+	}
+	if DefaultStopTimeout != 10*time.Second {
+		t.Fatalf("DefaultStopTimeout = %v, want 10s", DefaultStopTimeout)
+	}
+}
 
-func TestKanban_EventBusPublish(t *testing.T) {
-	sb := NewBoard("scope-ev-pub")
-	bus := event.NewMemoryBus()
-	defer func() { _ = bus.Close() }()
+// WithStopTimeout(0) opts back into the legacy unbounded-wait behaviour.
+func TestKanban_Stop_ZeroTimeoutWaitsForever(t *testing.T) {
+	t.Parallel()
+	executorEntered := make(chan struct{})
+	releaseExecutor := make(chan struct{})
 
-	k := New(context.Background(), sb, WithEventBus(bus), WithConfig(KanbanConfig{MaxPendingTasks: 100}))
-
-	ctx := context.Background()
-	sub, err := bus.Subscribe(ctx, event.EventFilter{})
-	if err != nil {
-		t.Fatalf("subscribe: %v", err)
+	k, _ := newKanban(t,
+		WithAgentExecutor(&mockExecutor{
+			fn: func(_ context.Context, _, _ string, _ *Card, _ string, _ map[string]any) error {
+				close(executorEntered)
+				<-releaseExecutor
+				return nil
+			},
+		}),
+		WithStopTimeout(0),
+	)
+	if k.stopTimeout != 0 {
+		t.Fatalf("WithStopTimeout(0) did not set stopTimeout to 0, got %v", k.stopTimeout)
 	}
 
-	_, _ = k.Submit(ctx, TaskOptions{Query: "test event"})
+	if _, err := k.Submit(context.Background(), TaskOptions{
+		TargetAgentID: "builder",
+		Query:         "build something",
+	}); err != nil {
+		t.Fatalf("Submit: %v", err)
+	}
+	<-executorEntered
+
+	stopped := make(chan struct{})
+	go func() {
+		k.Stop()
+		close(stopped)
+	}()
+
+	// With zero timeout, Stop must NOT return while the executor is still
+	// running, even after a window much larger than DefaultStopTimeout would
+	// have allowed if it had silently leaked through.
+	select {
+	case <-stopped:
+		t.Fatal("Stop with WithStopTimeout(0) returned before executor finished")
+	case <-time.After(200 * time.Millisecond):
+	}
+
+	close(releaseExecutor)
 
 	select {
-	case ev := <-sub.Events():
-		if string(ev.Type) != EventTaskSubmitted {
-			t.Fatalf("expected %q, got %q", EventTaskSubmitted, ev.Type)
-		}
+	case <-stopped:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Stop did not return after executor finished")
+	}
+}
+
+// Bug 4 (P2): Stop must respect WithStopTimeout and not hang on stuck executors.
+func TestKanban_Stop_RespectsStopTimeout(t *testing.T) {
+	t.Parallel()
+	executorEntered := make(chan struct{})
+	releaseExecutor := make(chan struct{})
+	defer close(releaseExecutor)
+
+	k, _ := newKanban(t,
+		WithAgentExecutor(&mockExecutor{
+			fn: func(_ context.Context, _, _ string, _ *Card, _ string, _ map[string]any) error {
+				close(executorEntered)
+				<-releaseExecutor
+				return nil
+			},
+		}),
+		WithStopTimeout(100*time.Millisecond),
+	)
+
+	if _, err := k.Submit(context.Background(), TaskOptions{
+		TargetAgentID: "stuck",
+		Query:         "ignore cancel",
+	}); err != nil {
+		t.Fatalf("Submit: %v", err)
+	}
+	<-executorEntered
+
+	stopped := make(chan struct{})
+	start := time.Now()
+	go func() {
+		k.Stop()
+		close(stopped)
+	}()
+
+	select {
+	case <-stopped:
 	case <-time.After(time.Second):
-		t.Fatal("no event received")
+		t.Fatal("Stop with WithStopTimeout did not return within budget")
+	}
+	if elapsed := time.Since(start); elapsed > 500*time.Millisecond {
+		t.Fatalf("Stop returned but took %v, expected ~100ms", elapsed)
 	}
 }
 
 // ---------------------------------------------------------------------------
-// Concurrency
+// Concurrency — Submit racing under load and against Stop
 // ---------------------------------------------------------------------------
 
-func TestKanban_SubmitConcurrent(t *testing.T) {
-	sb := NewBoard("scope-conc")
-	defer sb.Close()
-
+func TestKanban_Submit_Concurrent(t *testing.T) {
+	t.Parallel()
+	sb := newBoard(t)
 	executor := &mockExecutor{
 		fn: func(_ context.Context, _, targetAgentID string, card *Card, _ string, _ map[string]any) error {
 			time.Sleep(10 * time.Millisecond)
@@ -581,8 +516,8 @@ func TestKanban_SubmitConcurrent(t *testing.T) {
 			return nil
 		},
 	}
-
 	k := New(context.Background(), sb, WithAgentExecutor(executor), WithConfig(KanbanConfig{MaxPendingTasks: 100}))
+	t.Cleanup(k.Stop)
 
 	const n = 10
 	var wg sync.WaitGroup
@@ -592,28 +527,24 @@ func TestKanban_SubmitConcurrent(t *testing.T) {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			_, err := k.Submit(context.Background(), TaskOptions{
+			if _, err := k.Submit(context.Background(), TaskOptions{
 				TargetAgentID: "tpl",
 				Query:         "concurrent-task",
-			})
-			if err != nil {
+			}); err != nil {
 				errs <- err
 			}
 		}()
 	}
-
 	wg.Wait()
 	close(errs)
 	for err := range errs {
 		t.Fatalf("concurrent Submit error: %v", err)
 	}
-
-	k.Stop()
 }
 
-func TestKanban_SubmitConcurrentWithStop(t *testing.T) {
-	tb := NewBoard("scope-race")
-	k := New(context.Background(), tb, WithAgentExecutor(&mockExecutor{
+func TestKanban_Submit_RacesWithStop(t *testing.T) {
+	t.Parallel()
+	k, _ := newKanban(t, WithAgentExecutor(&mockExecutor{
 		fn: func(ctx context.Context, _, _ string, _ *Card, _ string, _ map[string]any) error {
 			select {
 			case <-ctx.Done():
@@ -645,6 +576,6 @@ func TestKanban_SubmitConcurrentWithStop(t *testing.T) {
 	close(errs)
 
 	for err := range errs {
-		t.Fatalf("unexpected submit error: %v", err)
+		t.Fatalf("unexpected submit error during Submit/Stop race: %v", err)
 	}
 }

--- a/sdk/kanban/scheduler.go
+++ b/sdk/kanban/scheduler.go
@@ -11,7 +11,9 @@ import (
 	"github.com/GizClaw/flowcraft/sdk/telemetry"
 
 	"github.com/robfig/cron/v3"
+	"go.opentelemetry.io/otel/attribute"
 	otellog "go.opentelemetry.io/otel/log"
+	"go.opentelemetry.io/otel/trace"
 )
 
 const cardTypeCronRule = "cron_rule"
@@ -143,14 +145,32 @@ func (s *Scheduler) SyncAgent(agentID string, jobs []CronJob) {
 	}
 }
 
-// RemoveAgent clears all cron rules for an agent.
+// RemoveAgent clears all cron rules for an agent. An EventCronRuleDisabled
+// event is published for each removed schedule so external observers can keep
+// in sync without polling.
 func (s *Scheduler) RemoveAgent(agentID string) {
 	s.mu.Lock()
-	defer s.mu.Unlock()
+	removed := make([]string, 0, len(s.entries[agentID]))
 	for _, rec := range s.entries[agentID] {
 		s.cron.Remove(rec.cronID)
+		removed = append(removed, rec.scheduleID)
 	}
 	delete(s.entries, agentID)
+	s.mu.Unlock()
+
+	if s.kanban != nil {
+		ctx := context.Background()
+		if s.kanban.ctx != nil {
+			ctx = s.kanban.ctx
+		}
+		bus := s.kanban.board.Bus()
+		for _, scheduleID := range removed {
+			_ = bus.Publish(ctx, eventEnvelope(EventCronRuleDisabled, CronRuleDisabledPayload{
+				ScheduleID: scheduleID,
+				AgentID:    agentID,
+			}))
+		}
+	}
 }
 
 // LoadFromBoard scans the board for active cron_rule cards and registers them.
@@ -213,16 +233,49 @@ func (s *Scheduler) SyncAgentAppend(agentID string, job CronJob) {
 	s.mu.Unlock()
 }
 
+// schedulerCtx returns the base context used for all scheduler-originated
+// submissions. Trace span + producer ID are attached so downstream telemetry
+// can correlate cron / delayed tasks back to the scheduler that fired them.
+func (s *Scheduler) schedulerCtx(parent context.Context, agentID, scheduleID, kind string) (context.Context, trace.Span) {
+	if parent == nil {
+		parent = context.Background()
+	}
+	if s.kanban != nil && s.kanban.ctx != nil {
+		// Use the Kanban lifecycle ctx so a Kanban.Stop() also cancels in-flight
+		// scheduler submits. We keep the parent's trace baggage by deriving the
+		// span from the parent ctx if it had one.
+		if sc := trace.SpanFromContext(parent).SpanContext(); sc.IsValid() {
+			parent = trace.ContextWithSpanContext(s.kanban.ctx, sc)
+		} else {
+			parent = s.kanban.ctx
+		}
+	}
+	ctx, span := telemetry.Tracer().Start(parent, "kanban.scheduler."+kind,
+		trace.WithAttributes(
+			attribute.String("kanban.scheduler.agent_id", agentID),
+			attribute.String("kanban.scheduler.schedule_id", scheduleID),
+		),
+	)
+	ctx = WithProducerID(ctx, "scheduler")
+	return ctx, span
+}
+
 // fire submits a scheduled task card, skipping if a previous card is still active.
+// It propagates a fresh scheduler-rooted trace span so submitted tasks correlate
+// back to the cron rule that triggered them, instead of starting from a bare
+// context.Background().
 func (s *Scheduler) fire(agentID, scheduleID, query string) {
 	if s.isClosed() || s.kanban == nil {
 		return
 	}
 
+	ctx, span := s.schedulerCtx(nil, agentID, scheduleID, "fire")
+	defer span.End()
+
 	for _, card := range s.kanban.QueryCards(CardFilter{Type: "task"}) {
 		if card.Meta["schedule_id"] == scheduleID &&
 			(card.Status == CardPending || card.Status == CardClaimed) {
-			telemetry.Info(context.Background(), "kanban.scheduler: skipping, previous task still active",
+			telemetry.Info(ctx, "kanban.scheduler: skipping, previous task still active",
 				otellog.String("agent_id", agentID),
 				otellog.String("schedule_id", scheduleID),
 				otellog.String("card_id", card.ID))
@@ -230,7 +283,6 @@ func (s *Scheduler) fire(agentID, scheduleID, query string) {
 		}
 	}
 
-	ctx := WithProducerID(context.Background(), "scheduler")
 	cardID, err := s.kanban.Submit(ctx, TaskOptions{
 		TargetAgentID: agentID,
 		Query:         query,
@@ -238,13 +290,23 @@ func (s *Scheduler) fire(agentID, scheduleID, query string) {
 		Meta:          map[string]string{"schedule_id": scheduleID},
 	})
 	if err != nil {
-		telemetry.Warn(context.Background(), "kanban.scheduler: submit failed",
+		span.RecordError(err)
+		telemetry.Warn(ctx, "kanban.scheduler: submit failed",
 			otellog.String("agent_id", agentID),
 			otellog.String("schedule_id", scheduleID),
 			otellog.String("error", err.Error()))
 		return
 	}
-	telemetry.Info(context.Background(), "kanban.scheduler: task submitted",
+	span.SetAttributes(attribute.String("kanban.scheduler.card_id", cardID))
+
+	_ = s.kanban.board.Bus().Publish(ctx, eventEnvelope(EventCronRuleFired, CronRuleFiredPayload{
+		ScheduleID: scheduleID,
+		AgentID:    agentID,
+		CardID:     cardID,
+		Query:      query,
+	}))
+
+	telemetry.Info(ctx, "kanban.scheduler: task submitted",
 		otellog.String("agent_id", agentID),
 		otellog.String("schedule_id", scheduleID),
 		otellog.String("card_id", cardID))
@@ -270,13 +332,23 @@ func (s *Scheduler) scheduleSubmit(ctx context.Context, opts TaskOptions) (strin
 	return s.kanban.Submit(ctx, opts)
 }
 
-func (s *Scheduler) submitWithDelay(_ context.Context, opts TaskOptions, delayStr string) (string, error) {
+// submitWithDelay registers a one-shot timer that fires opts after delayStr.
+// The original caller's producer ID and trace span context are captured at
+// submit time and re-attached when the timer fires, so rate-limit accounting
+// and trace correlation behave the same as a synchronous Submit.
+func (s *Scheduler) submitWithDelay(ctx context.Context, opts TaskOptions, delayStr string) (string, error) {
 	d, err := time.ParseDuration(delayStr)
 	if err != nil {
 		return "", fmt.Errorf("kanban.scheduler: invalid delay %q: %w", delayStr, err)
 	}
 
 	placeholderID := schedGenID()
+
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	originalProducer := ProducerIDFrom(ctx)
+	originalSpanCtx := trace.SpanFromContext(ctx).SpanContext()
 
 	s.mu.Lock()
 	if s.closed {
@@ -287,9 +359,36 @@ func (s *Scheduler) submitWithDelay(_ context.Context, opts TaskOptions, delaySt
 		s.mu.Lock()
 		delete(s.timers, placeholderID)
 		s.mu.Unlock()
-		if !s.isClosed() && s.kanban != nil {
-			_, _ = s.kanban.Submit(context.Background(), opts)
+		if s.isClosed() || s.kanban == nil {
+			return
 		}
+
+		base := s.kanban.ctx
+		if base == nil {
+			base = context.Background()
+		}
+		if originalSpanCtx.IsValid() {
+			base = trace.ContextWithSpanContext(base, originalSpanCtx)
+		}
+		producer := originalProducer
+		if producer == "" {
+			producer = "scheduler"
+		}
+		fireCtx, span := telemetry.Tracer().Start(base, "kanban.scheduler.delay.fire",
+			trace.WithAttributes(
+				attribute.String("kanban.scheduler.placeholder_id", placeholderID),
+				attribute.String("kanban.scheduler.original_producer", originalProducer),
+			),
+		)
+		fireCtx = WithProducerID(fireCtx, producer)
+		_, err := s.kanban.Submit(fireCtx, opts)
+		if err != nil {
+			span.RecordError(err)
+			telemetry.Warn(fireCtx, "kanban.scheduler: delayed submit failed",
+				otellog.String("placeholder_id", placeholderID),
+				otellog.String("error", err.Error()))
+		}
+		span.End()
 	})
 	s.timers[placeholderID] = timer
 	s.mu.Unlock()
@@ -304,7 +403,13 @@ func schedGenID() string {
 }
 
 // submitWithCron registers a dynamic cron job and persists it as a cron_rule card.
-func (s *Scheduler) submitWithCron(_ context.Context, opts TaskOptions, cronExpr, tz string) (string, error) {
+// The caller's ctx (producer ID + trace span) is preserved on the
+// EventCronRuleCreated event so external observers can correlate the rule
+// back to the user request that created it.
+func (s *Scheduler) submitWithCron(ctx context.Context, opts TaskOptions, cronExpr, tz string) (string, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
 	scheduleID := schedGenID()
 	agentID := opts.TargetAgentID
 	query := opts.Query
@@ -329,6 +434,14 @@ func (s *Scheduler) submitWithCron(_ context.Context, opts TaskOptions, cronExpr
 			Query:      query,
 			Timezone:   tz,
 		}, WithMeta("schedule_id", scheduleID), WithMeta("agent_id", agentID))
+
+		_ = s.kanban.board.Bus().Publish(ctx, eventEnvelope(EventCronRuleCreated, CronRuleCreatedPayload{
+			ScheduleID: scheduleID,
+			AgentID:    agentID,
+			Cron:       rawCron,
+			Query:      query,
+			Timezone:   tz,
+		}))
 	}
 
 	s.mu.Lock()

--- a/sdk/kanban/scheduler_test.go
+++ b/sdk/kanban/scheduler_test.go
@@ -2,157 +2,200 @@ package kanban
 
 import (
 	"context"
-	"sync"
 	"testing"
 	"time"
+
+	"github.com/GizClaw/flowcraft/sdk/event"
 )
 
-func newTestKanbanForScheduler(t *testing.T) *Kanban {
+// ---------------------------------------------------------------------------
+// Helpers — schedulers are typically wired through Kanban.New(WithScheduler).
+// Provide a single helper so individual tests stop building boilerplate.
+// ---------------------------------------------------------------------------
+
+func newScheduler(t *testing.T, opts ...Option) (*Scheduler, *Kanban, *Board) {
 	t.Helper()
-	board := NewBoard("test-scheduler")
-	return New(context.Background(), board)
+	sched := NewScheduler()
+	allOpts := append([]Option{WithScheduler(sched), WithConfig(KanbanConfig{MaxPendingTasks: 100})}, opts...)
+	k, b := newKanban(t, allOpts...)
+	return sched, k, b
 }
 
-func TestScheduler_SyncAndFire(t *testing.T) {
-	k := newTestKanbanForScheduler(t)
-	s := NewScheduler()
-	s.SetKanban(k)
+func boolPtr(v bool) *bool { return &v }
 
-	enabled := true
+// ---------------------------------------------------------------------------
+// SyncAgent / RemoveAgent — static schedule registration
+// ---------------------------------------------------------------------------
+
+func TestScheduler_SyncAgent_RegistersEnabledJobs(t *testing.T) {
+	t.Parallel()
+	s, k, _ := newScheduler(t)
+
 	s.SyncAgent("agent-1", []CronJob{
-		{ID: "sched-1", Cron: "* * * * *", Query: "do something", Enabled: &enabled},
+		{ID: "sched-1", Cron: "* * * * *", Query: "do something", Enabled: boolPtr(true)},
 	})
 
 	s.fire("agent-1", "sched-1", "do something")
 
 	cards := k.QueryCards(CardFilter{Type: "task"})
 	if len(cards) != 1 {
-		t.Fatalf("expected 1 card, got %d", len(cards))
+		t.Fatalf("Cards()=%d, want 1", len(cards))
 	}
 	if cards[0].Meta["schedule_id"] != "sched-1" {
-		t.Errorf("expected meta schedule_id=sched-1, got %v", cards[0].Meta)
+		t.Errorf("meta schedule_id = %v, want sched-1", cards[0].Meta["schedule_id"])
 	}
 }
 
-func TestScheduler_FireIdempotency(t *testing.T) {
-	k := newTestKanbanForScheduler(t)
-	s := NewScheduler()
-	s.SetKanban(k)
+func TestScheduler_SyncAgent_SkipsDisabledOrInvalid(t *testing.T) {
+	t.Parallel()
 
-	s.fire("agent-1", "sched-1", "task query")
-	s.fire("agent-1", "sched-1", "task query")
-
-	cards := k.QueryCards(CardFilter{Type: "task"})
-	if len(cards) != 1 {
-		t.Fatalf("expected 1 card (idempotency), got %d", len(cards))
+	cases := []struct {
+		name string
+		jobs []CronJob
+	}{
+		{"disabled", []CronJob{{ID: "x", Cron: "* * * * *", Query: "q", Enabled: boolPtr(false)}}},
+		{"invalid_cron", []CronJob{{ID: "y", Cron: "not-a-cron", Query: "q", Enabled: boolPtr(true)}}},
 	}
-}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			s, _, _ := newScheduler(t)
+			s.SyncAgent("agent-1", tc.jobs)
 
-func TestScheduler_DisabledJobSkipped(t *testing.T) {
-	k := newTestKanbanForScheduler(t)
-	s := NewScheduler()
-	s.SetKanban(k)
-
-	disabled := false
-	s.SyncAgent("agent-1", []CronJob{
-		{ID: "sched-disabled", Cron: "* * * * *", Query: "should not run", Enabled: &disabled},
-	})
-
-	s.mu.RLock()
-	entries := s.entries["agent-1"]
-	s.mu.RUnlock()
-	if len(entries) != 0 {
-		t.Errorf("expected 0 entries for disabled job, got %d", len(entries))
+			s.mu.RLock()
+			defer s.mu.RUnlock()
+			if got := len(s.entries["agent-1"]); got != 0 {
+				t.Errorf("entries=%d, want 0", got)
+			}
+		})
 	}
 }
 
 func TestScheduler_RemoveAgent(t *testing.T) {
-	k := newTestKanbanForScheduler(t)
-	s := NewScheduler()
-	s.SetKanban(k)
+	t.Parallel()
+	s, _, _ := newScheduler(t)
 
-	enabled := true
 	s.SyncAgent("agent-1", []CronJob{
-		{ID: "sched-1", Cron: "* * * * *", Query: "q", Enabled: &enabled},
+		{ID: "sched-1", Cron: "* * * * *", Query: "q", Enabled: boolPtr(true)},
 	})
 	s.RemoveAgent("agent-1")
 
 	s.mu.RLock()
-	entries := s.entries["agent-1"]
-	s.mu.RUnlock()
-	if len(entries) != 0 {
-		t.Errorf("expected 0 entries after remove, got %d", len(entries))
+	defer s.mu.RUnlock()
+	if got := len(s.entries["agent-1"]); got != 0 {
+		t.Errorf("entries after Remove=%d, want 0", got)
 	}
 }
 
-func TestScheduler_SyncAgentReplacesStaticOnly(t *testing.T) {
-	k := newTestKanbanForScheduler(t)
-	s := NewScheduler()
-	s.SetKanban(k)
+func TestScheduler_SyncAgent_PreservesDynamicEntries(t *testing.T) {
+	t.Parallel()
+	s, _, _ := newScheduler(t)
 	s.Start()
-	defer s.Stop()
+	t.Cleanup(s.Stop)
 
-	enabled := true
 	s.SyncAgent("agent-1", []CronJob{
-		{ID: "static-1", Cron: "0 0 1 1 *", Query: "old query", Enabled: &enabled, Source: "static"},
+		{ID: "static-1", Cron: "0 0 1 1 *", Query: "old", Enabled: boolPtr(true), Source: "static"},
 	})
-
-	// Add a dynamic entry via submitWithCron
-	_, err := s.submitWithCron(context.Background(), TaskOptions{
-		TargetAgentID: "agent-1",
-		Query:         "dynamic task",
-	}, "0 0 1 1 *", "")
-	if err != nil {
-		t.Fatal(err)
+	if _, err := s.submitWithCron(context.Background(), TaskOptions{
+		TargetAgentID: "agent-1", Query: "dynamic task",
+	}, "0 0 1 1 *", ""); err != nil {
+		t.Fatalf("submitWithCron: %v", err)
 	}
 
 	s.mu.RLock()
 	beforeCount := len(s.entries["agent-1"])
 	s.mu.RUnlock()
 	if beforeCount != 2 {
-		t.Fatalf("expected 2 entries (1 static + 1 dynamic), got %d", beforeCount)
+		t.Fatalf("setup: entries=%d, want 2", beforeCount)
 	}
 
-	// Re-sync static schedules — dynamic should survive
 	s.SyncAgent("agent-1", []CronJob{
-		{ID: "static-2", Cron: "0 0 1 1 *", Query: "new query", Enabled: &enabled, Source: "static"},
+		{ID: "static-2", Cron: "0 0 1 1 *", Query: "new", Enabled: boolPtr(true), Source: "static"},
 	})
 
 	s.mu.RLock()
+	defer s.mu.RUnlock()
 	entries := s.entries["agent-1"]
-	s.mu.RUnlock()
 	if len(entries) != 2 {
-		t.Fatalf("expected 2 entries (1 new static + 1 dynamic), got %d", len(entries))
+		t.Fatalf("after re-sync: entries=%d, want 2 (1 new static + 1 dynamic)", len(entries))
 	}
 
 	sources := map[string]int{}
 	for _, e := range entries {
 		sources[e.source]++
 	}
-	if sources["dynamic"] != 1 {
-		t.Errorf("expected 1 dynamic entry, got %d", sources["dynamic"])
-	}
-	if sources["static"] != 1 {
-		t.Errorf("expected 1 static entry, got %d", sources["static"])
+	if sources["dynamic"] != 1 || sources["static"] != 1 {
+		t.Errorf("source breakdown = %v, want 1 each", sources)
 	}
 }
 
-func TestScheduler_SubmitWithDelay(t *testing.T) {
-	k := newTestKanbanForScheduler(t)
+// ---------------------------------------------------------------------------
+// fire — cron tick handler. Must be idempotent and tolerant of nil Kanban.
+// ---------------------------------------------------------------------------
+
+func TestScheduler_Fire_Idempotent(t *testing.T) {
+	t.Parallel()
+	s, k, _ := newScheduler(t)
+
+	s.fire("agent-1", "sched-1", "task query")
+	s.fire("agent-1", "sched-1", "task query") // same schedule_id — must dedup
+
+	if got := len(k.QueryCards(CardFilter{Type: "task"})); got != 1 {
+		t.Fatalf("Cards()=%d, want 1 (idempotent fire)", got)
+	}
+}
+
+func TestScheduler_Fire_NilKanbanDoesNotPanic(t *testing.T) {
+	t.Parallel()
 	s := NewScheduler()
-	s.SetKanban(k)
+	t.Cleanup(s.Stop)
+	s.fire("agent-1", "sched-1", "test") // must not panic
+}
+
+// Bug 3 (P2): scheduler-fired cards must be tagged Producer="scheduler".
+func TestScheduler_Fire_TagsProducerAsScheduler(t *testing.T) {
+	t.Parallel()
+	s, k, _ := newScheduler(t)
+	s.fire("agent-1", "sched-1", "cron task")
+
+	cards := k.QueryCards(CardFilter{Type: "task"})
+	if len(cards) != 1 {
+		t.Fatalf("Cards()=%d, want 1", len(cards))
+	}
+	if got := cards[0].Producer; got != "scheduler" {
+		t.Fatalf("Producer=%q, want scheduler", got)
+	}
+}
+
+// Bug 3 (P2): fire must respect Kanban's MaxPendingTasks rate limit.
+func TestScheduler_Fire_RespectsMaxPendingTasks(t *testing.T) {
+	t.Parallel()
+	sched := NewScheduler()
+	sb := newBoard(t)
+	k := New(context.Background(), sb, WithScheduler(sched), WithConfig(KanbanConfig{MaxPendingTasks: 1}))
+	t.Cleanup(k.Stop)
+
+	sched.fire("agent-1", "sched-A", "task1")
+	sched.fire("agent-2", "sched-B", "task2") // different schedule_id avoids dedup
+
+	if got := len(k.QueryCards(CardFilter{Type: "task", Status: CardPending})); got > 1 {
+		t.Fatalf("MaxPendingTasks=1 not enforced for fire: %d pending", got)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// submitWithDelay — schedules a one-shot task after a duration.
+// ---------------------------------------------------------------------------
+
+func TestScheduler_SubmitWithDelay_FiresAfterDelay(t *testing.T) {
+	t.Parallel()
+	s, k, _ := newScheduler(t)
 	s.Start()
-	defer s.Stop()
-
-	var wg sync.WaitGroup
-	wg.Add(1)
-
-	origSubmit := k.QueryCards
-	_ = origSubmit
+	t.Cleanup(s.Stop)
 
 	id, err := s.submitWithDelay(context.Background(), TaskOptions{
-		TargetAgentID: "agent-1",
-		Query:         "delayed task",
+		TargetAgentID: "agent-1", Query: "delayed task",
 	}, "50ms")
 	if err != nil {
 		t.Fatalf("submitWithDelay: %v", err)
@@ -161,357 +204,405 @@ func TestScheduler_SubmitWithDelay(t *testing.T) {
 		t.Fatal("expected non-empty placeholder ID")
 	}
 
-	time.Sleep(150 * time.Millisecond)
-
-	cards := k.QueryCards(CardFilter{Type: "task"})
-	if len(cards) != 1 {
-		t.Fatalf("expected 1 card after delay, got %d", len(cards))
+	deadline := time.Now().Add(time.Second)
+	for time.Now().Before(deadline) {
+		if len(k.QueryCards(CardFilter{Type: "task"})) == 1 {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
 	}
+	t.Fatal("delayed task did not appear within deadline")
 }
 
-func TestScheduler_SubmitWithInvalidDelay(t *testing.T) {
-	k := newTestKanbanForScheduler(t)
-	s := NewScheduler()
-	s.SetKanban(k)
+func TestScheduler_SubmitWithDelay_RejectsInvalidDuration(t *testing.T) {
+	t.Parallel()
+	s, _, _ := newScheduler(t)
 
 	_, err := s.submitWithDelay(context.Background(), TaskOptions{
-		TargetAgentID: "agent-1",
-		Query:         "bad",
+		TargetAgentID: "agent-1", Query: "bad",
 	}, "invalid")
 	if err == nil {
 		t.Fatal("expected error for invalid delay")
 	}
 }
 
-func TestScheduler_SubmitWithCron(t *testing.T) {
-	k := newTestKanbanForScheduler(t)
+func TestScheduler_SubmitWithDelay_NilKanbanSafe(t *testing.T) {
+	t.Parallel()
 	s := NewScheduler()
-	s.SetKanban(k)
 	s.Start()
-	defer s.Stop()
+	t.Cleanup(s.Stop)
 
-	schedID, err := s.submitWithCron(context.Background(), TaskOptions{
-		TargetAgentID: "agent-1",
-		Query:         "cron task",
-	}, "0 0 1 1 *", "")
-	if err != nil {
-		t.Fatalf("submitWithCron: %v", err)
+	if _, err := s.submitWithDelay(context.Background(), TaskOptions{
+		TargetAgentID: "agent-1", Query: "delayed",
+	}, "10ms"); err != nil {
+		t.Fatalf("submitWithDelay: %v", err)
 	}
-	if schedID == "" {
-		t.Fatal("expected non-empty schedule ID")
-	}
-
-	s.mu.RLock()
-	entries := s.entries["agent-1"]
-	s.mu.RUnlock()
-	if len(entries) != 1 {
-		t.Fatalf("expected 1 cron entry, got %d", len(entries))
-	}
-	if entries[0].source != "dynamic" {
-		t.Errorf("expected source=dynamic, got %q", entries[0].source)
-	}
+	time.Sleep(50 * time.Millisecond) // let timer fire against nil Kanban
 }
 
-func TestScheduler_SubmitWithCron_ProducesCronRuleCard(t *testing.T) {
-	k := newTestKanbanForScheduler(t)
-	s := NewScheduler()
-	s.SetKanban(k)
+// Bug 3 (P2): submitWithDelay must preserve ProducerID across the delay.
+func TestScheduler_SubmitWithDelay_PreservesProducerID(t *testing.T) {
+	t.Parallel()
+	s, k, _ := newScheduler(t)
 	s.Start()
-	defer s.Stop()
+	t.Cleanup(s.Stop)
 
-	schedID, err := s.submitWithCron(context.Background(), TaskOptions{
-		TargetAgentID: "agent-1",
-		Query:         "daily report",
-	}, "0 9 * * *", "Asia/Shanghai")
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	cards := k.QueryCards(CardFilter{Type: cardTypeCronRule})
-	if len(cards) != 1 {
-		t.Fatalf("expected 1 cron_rule card, got %d", len(cards))
-	}
-	card := cards[0]
-	if card.Status != CardPending {
-		t.Errorf("expected status=pending, got %s", card.Status)
-	}
-	if card.Meta["schedule_id"] != schedID {
-		t.Errorf("expected meta schedule_id=%s, got %s", schedID, card.Meta["schedule_id"])
-	}
-	if card.Meta["agent_id"] != "agent-1" {
-		t.Errorf("expected meta agent_id=agent-1, got %s", card.Meta["agent_id"])
+	ctx := WithProducerID(context.Background(), "user-42")
+	if _, err := s.submitWithDelay(ctx, TaskOptions{
+		TargetAgentID: "agent-1", Query: "delayed",
+	}, "30ms"); err != nil {
+		t.Fatalf("submitWithDelay: %v", err)
 	}
 
-	p, ok := parseCronRulePayload(card.Payload)
-	if !ok {
-		t.Fatal("failed to parse cron_rule payload")
+	deadline := time.Now().Add(time.Second)
+	for time.Now().Before(deadline) {
+		cards := k.QueryCards(CardFilter{Type: "task"})
+		if len(cards) == 1 {
+			if cards[0].Producer != "user-42" {
+				t.Fatalf("delayed task lost producer ID: got %q, want user-42", cards[0].Producer)
+			}
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
 	}
-	if p.AgentID != "agent-1" {
-		t.Errorf("payload agent_id = %q, want agent-1", p.AgentID)
-	}
-	if p.Cron != "0 9 * * *" {
-		t.Errorf("payload cron = %q, want raw expression", p.Cron)
-	}
-	if p.Timezone != "Asia/Shanghai" {
-		t.Errorf("payload timezone = %q, want Asia/Shanghai", p.Timezone)
-	}
-	if p.Query != "daily report" {
-		t.Errorf("payload query = %q, want daily report", p.Query)
-	}
-}
-
-func TestScheduler_LoadFromBoard(t *testing.T) {
-	k := newTestKanbanForScheduler(t)
-	s := NewScheduler()
-	s.SetKanban(k)
-
-	// Produce some cron_rule cards on the board (simulating restored state)
-	board := k.Board()
-	board.Produce(cardTypeCronRule, "scheduler", cronRulePayload{
-		AgentID:    "agent-1",
-		ScheduleID: "dyn-1",
-		Cron:       "0 9 * * *",
-		Query:      "morning report",
-		Timezone:   "Asia/Shanghai",
-	}, WithMeta("schedule_id", "dyn-1"), WithMeta("agent_id", "agent-1"))
-
-	board.Produce(cardTypeCronRule, "scheduler", cronRulePayload{
-		AgentID:    "agent-2",
-		ScheduleID: "dyn-2",
-		Cron:       "0 18 * * *",
-		Query:      "evening summary",
-	}, WithMeta("schedule_id", "dyn-2"), WithMeta("agent_id", "agent-2"))
-
-	n := s.LoadFromBoard()
-	if n != 2 {
-		t.Fatalf("expected 2 loaded, got %d", n)
-	}
-
-	s.mu.RLock()
-	agent1 := s.entries["agent-1"]
-	agent2 := s.entries["agent-2"]
-	s.mu.RUnlock()
-
-	if len(agent1) != 1 || agent1[0].scheduleID != "dyn-1" {
-		t.Errorf("agent-1 entries: %+v", agent1)
-	}
-	if len(agent2) != 1 || agent2[0].scheduleID != "dyn-2" {
-		t.Errorf("agent-2 entries: %+v", agent2)
-	}
-}
-
-func TestScheduler_LoadFromBoard_SkipsDoneCards(t *testing.T) {
-	k := newTestKanbanForScheduler(t)
-	s := NewScheduler()
-	s.SetKanban(k)
-
-	board := k.Board()
-	card := board.Produce(cardTypeCronRule, "scheduler", cronRulePayload{
-		AgentID:    "agent-1",
-		ScheduleID: "dyn-done",
-		Cron:       "0 9 * * *",
-		Query:      "done task",
-	}, WithMeta("schedule_id", "dyn-done"), WithMeta("agent_id", "agent-1"))
-
-	board.Claim(card.ID, "system")
-	board.Done(card.ID, nil)
-
-	n := s.LoadFromBoard()
-	if n != 0 {
-		t.Fatalf("expected 0 loaded (done card), got %d", n)
-	}
+	t.Fatal("delayed task did not appear within deadline")
 }
 
 func TestScheduler_StopCancelsDelayTimer(t *testing.T) {
-	k := newTestKanbanForScheduler(t)
-	s := NewScheduler()
-	s.SetKanban(k)
+	t.Parallel()
+	s, k, _ := newScheduler(t)
 	s.Start()
 
-	_, err := s.submitWithDelay(context.Background(), TaskOptions{
-		TargetAgentID: "agent-1",
-		Query:         "should not fire",
-	}, "1s")
-	if err != nil {
-		t.Fatal(err)
+	if _, err := s.submitWithDelay(context.Background(), TaskOptions{
+		TargetAgentID: "agent-1", Query: "should not fire",
+	}, "1s"); err != nil {
+		t.Fatalf("submitWithDelay: %v", err)
 	}
 
 	s.Stop()
 	time.Sleep(1500 * time.Millisecond)
 
-	cards := k.QueryCards(CardFilter{Type: "task"})
-	if len(cards) != 0 {
-		t.Fatalf("expected 0 cards after stop, got %d", len(cards))
+	if got := len(k.QueryCards(CardFilter{Type: "task"})); got != 0 {
+		t.Fatalf("Cards()=%d after Stop, want 0", got)
 	}
 }
 
-func TestScheduler_CronJobIsEnabled(t *testing.T) {
-	enabled := true
-	disabled := false
+// ---------------------------------------------------------------------------
+// submitWithCron — dynamic cron rule + cron_rule card persistence
+// ---------------------------------------------------------------------------
 
-	tests := []struct {
-		name string
-		job  CronJob
-		want bool
-	}{
-		{"nil = enabled", CronJob{Enabled: nil}, true},
-		{"true = enabled", CronJob{Enabled: &enabled}, true},
-		{"false = disabled", CronJob{Enabled: &disabled}, false},
+func TestScheduler_SubmitWithCron_RegistersDynamicEntry(t *testing.T) {
+	t.Parallel()
+	s, _, _ := newScheduler(t)
+	s.Start()
+	t.Cleanup(s.Stop)
+
+	id, err := s.submitWithCron(context.Background(), TaskOptions{
+		TargetAgentID: "agent-1", Query: "cron task",
+	}, "0 0 1 1 *", "")
+	if err != nil {
+		t.Fatalf("submitWithCron: %v", err)
 	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if got := tt.job.isEnabled(); got != tt.want {
-				t.Errorf("isEnabled() = %v, want %v", got, tt.want)
-			}
-		})
+	if id == "" {
+		t.Fatal("expected non-empty schedule ID")
 	}
-}
-
-func TestScheduler_InvalidCronExpressionSkipped(t *testing.T) {
-	k := newTestKanbanForScheduler(t)
-	s := NewScheduler()
-	s.SetKanban(k)
-
-	enabled := true
-	s.SyncAgent("agent-1", []CronJob{
-		{ID: "bad", Cron: "not-a-cron", Query: "q", Enabled: &enabled},
-	})
 
 	s.mu.RLock()
+	defer s.mu.RUnlock()
 	entries := s.entries["agent-1"]
-	s.mu.RUnlock()
-	if len(entries) != 0 {
-		t.Errorf("expected 0 entries for invalid cron, got %d", len(entries))
+	if len(entries) != 1 {
+		t.Fatalf("entries=%d, want 1", len(entries))
+	}
+	if entries[0].source != "dynamic" {
+		t.Errorf("source=%q, want dynamic", entries[0].source)
 	}
 }
 
-func TestScheduler_FireWithNilKanban(t *testing.T) {
-	s := NewScheduler()
-	s.fire("agent-1", "sched-1", "test")
+func TestScheduler_SubmitWithCron_ProducesCronRuleCard(t *testing.T) {
+	t.Parallel()
+	s, k, _ := newScheduler(t)
+	s.Start()
+	t.Cleanup(s.Stop)
+
+	id, err := s.submitWithCron(context.Background(), TaskOptions{
+		TargetAgentID: "agent-1", Query: "daily report",
+	}, "0 9 * * *", "Asia/Shanghai")
+	if err != nil {
+		t.Fatalf("submitWithCron: %v", err)
+	}
+
+	cards := k.QueryCards(CardFilter{Type: cardTypeCronRule})
+	if len(cards) != 1 {
+		t.Fatalf("cron_rule cards=%d, want 1", len(cards))
+	}
+	c := cards[0]
+	if c.Status != CardPending || c.Meta["schedule_id"] != id || c.Meta["agent_id"] != "agent-1" {
+		t.Errorf("unexpected card: status=%s meta=%v", c.Status, c.Meta)
+	}
+
+	p, ok := parseCronRulePayload(c.Payload)
+	if !ok {
+		t.Fatal("parseCronRulePayload: ok=false")
+	}
+	if p.AgentID != "agent-1" || p.Cron != "0 9 * * *" || p.Timezone != "Asia/Shanghai" || p.Query != "daily report" {
+		t.Errorf("payload mismatch: %+v", p)
+	}
 }
 
-func TestScheduler_TimezoneInCronExpr(t *testing.T) {
-	k := newTestKanbanForScheduler(t)
-	s := NewScheduler()
-	s.SetKanban(k)
+func TestScheduler_SubmitWithCron_TimezoneAccepted(t *testing.T) {
+	t.Parallel()
+	s, _, _ := newScheduler(t)
 	s.Start()
-	defer s.Stop()
+	t.Cleanup(s.Stop)
 
-	schedID, err := s.submitWithCron(context.Background(), TaskOptions{
-		TargetAgentID: "agent-1",
-		Query:         "tz task",
+	id, err := s.submitWithCron(context.Background(), TaskOptions{
+		TargetAgentID: "agent-1", Query: "tz task",
 	}, "0 9 * * MON-FRI", "Asia/Shanghai")
 	if err != nil {
-		t.Fatalf("submitWithCron with timezone: %v", err)
+		t.Fatalf("submitWithCron: %v", err)
 	}
-	if schedID == "" {
+	if id == "" {
 		t.Fatal("expected non-empty schedule ID")
 	}
 }
 
-func TestScheduler_MultipleDynamicCrons_AllProduceCards(t *testing.T) {
-	k := newTestKanbanForScheduler(t)
-	s := NewScheduler()
-	s.SetKanban(k)
+func TestScheduler_SubmitWithCron_MultipleEntriesAllPersisted(t *testing.T) {
+	t.Parallel()
+	s, k, _ := newScheduler(t)
 	s.Start()
-	defer s.Stop()
+	t.Cleanup(s.Stop)
 
 	for i := 0; i < 3; i++ {
-		_, err := s.submitWithCron(context.Background(), TaskOptions{
-			TargetAgentID: "agent-1",
-			Query:         "task",
-		}, "0 * * * *", "")
-		if err != nil {
-			t.Fatal(err)
+		if _, err := s.submitWithCron(context.Background(), TaskOptions{
+			TargetAgentID: "agent-1", Query: "task",
+		}, "0 * * * *", ""); err != nil {
+			t.Fatalf("submitWithCron[%d]: %v", i, err)
 		}
 	}
 
 	cards := k.QueryCards(CardFilter{Type: cardTypeCronRule})
 	if len(cards) != 3 {
-		t.Fatalf("expected 3 cron_rule cards, got %d", len(cards))
+		t.Fatalf("cron_rule cards=%d, want 3", len(cards))
 	}
-
 	ids := make(map[string]bool)
 	for _, c := range cards {
 		ids[c.Meta["schedule_id"]] = true
 	}
 	if len(ids) != 3 {
-		t.Fatal("expected 3 unique schedule IDs in cards")
-	}
-}
-
-func TestScheduler_ParseCronRulePayload(t *testing.T) {
-	valid := map[string]any{
-		"agent_id":    "a1",
-		"schedule_id": "s1",
-		"cron":        "0 9 * * *",
-		"query":       "q",
-		"timezone":    "UTC",
-	}
-	p, ok := parseCronRulePayload(valid)
-	if !ok {
-		t.Fatal("expected ok=true for valid payload")
-	}
-	if p.AgentID != "a1" || p.ScheduleID != "s1" || p.Cron != "0 9 * * *" || p.Query != "q" || p.Timezone != "UTC" {
-		t.Errorf("unexpected parsed payload: %+v", p)
-	}
-
-	_, ok = parseCronRulePayload("not a map")
-	if ok {
-		t.Error("expected ok=false for string payload")
-	}
-
-	_, ok = parseCronRulePayload(map[string]any{"foo": "bar"})
-	if ok {
-		t.Error("expected ok=false for payload missing agent_id/schedule_id")
+		t.Fatalf("schedule_id uniqueness lost: %d unique", len(ids))
 	}
 }
 
 // ---------------------------------------------------------------------------
-// WithScheduler auto-wiring (K-7)
+// LoadFromBoard — restore dynamic schedules from persisted cron_rule cards
+// ---------------------------------------------------------------------------
+
+func TestScheduler_LoadFromBoard_LoadsPendingRules(t *testing.T) {
+	t.Parallel()
+	s, _, sb := newScheduler(t)
+
+	sb.Produce(cardTypeCronRule, "scheduler", cronRulePayload{
+		AgentID: "agent-1", ScheduleID: "dyn-1",
+		Cron: "0 9 * * *", Query: "morning report", Timezone: "Asia/Shanghai",
+	}, WithMeta("schedule_id", "dyn-1"), WithMeta("agent_id", "agent-1"))
+
+	sb.Produce(cardTypeCronRule, "scheduler", cronRulePayload{
+		AgentID: "agent-2", ScheduleID: "dyn-2",
+		Cron: "0 18 * * *", Query: "evening summary",
+	}, WithMeta("schedule_id", "dyn-2"), WithMeta("agent_id", "agent-2"))
+
+	if n := s.LoadFromBoard(); n != 2 {
+		t.Fatalf("LoadFromBoard()=%d, want 2", n)
+	}
+
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	if got := s.entries["agent-1"]; len(got) != 1 || got[0].scheduleID != "dyn-1" {
+		t.Errorf("agent-1: %+v", got)
+	}
+	if got := s.entries["agent-2"]; len(got) != 1 || got[0].scheduleID != "dyn-2" {
+		t.Errorf("agent-2: %+v", got)
+	}
+}
+
+func TestScheduler_LoadFromBoard_SkipsDoneRules(t *testing.T) {
+	t.Parallel()
+	s, _, sb := newScheduler(t)
+
+	c := sb.Produce(cardTypeCronRule, "scheduler", cronRulePayload{
+		AgentID: "agent-1", ScheduleID: "dyn-done",
+		Cron: "0 9 * * *", Query: "done task",
+	}, WithMeta("schedule_id", "dyn-done"), WithMeta("agent_id", "agent-1"))
+	sb.Claim(c.ID, "system")
+	sb.Done(c.ID, nil)
+
+	if n := s.LoadFromBoard(); n != 0 {
+		t.Fatalf("LoadFromBoard()=%d, want 0 (done card skipped)", n)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Auto-wiring (K-7): WithScheduler must register Kanban back-reference.
 // ---------------------------------------------------------------------------
 
 func TestScheduler_AutoWiredByKanbanNew(t *testing.T) {
-	sb := NewBoard("scope-k7")
-	defer sb.Close()
-
-	sched := NewScheduler()
-	k := New(context.Background(), sb, WithScheduler(sched))
-	defer k.Stop()
-
+	t.Parallel()
+	sched, k, _ := newScheduler(t)
 	if sched.kanban != k {
-		t.Fatal("expected scheduler.kanban to be auto-wired by New()")
+		t.Fatal("scheduler.kanban not auto-wired by New()")
 	}
 }
 
 func TestScheduler_AutoWired_CanFire(t *testing.T) {
-	sb := NewBoard("scope-k7-fire")
-	defer sb.Close()
-
-	sched := NewScheduler()
-	k := New(context.Background(), sb, WithScheduler(sched))
-	defer k.Stop()
-
+	t.Parallel()
+	sched, k, _ := newScheduler(t)
 	sched.fire("agent-1", "sched-1", "auto-wired task")
 
-	cards := k.QueryCards(CardFilter{Type: "task"})
-	if len(cards) != 1 {
-		t.Fatalf("expected 1 card after fire, got %d", len(cards))
+	if got := len(k.QueryCards(CardFilter{Type: "task"})); got != 1 {
+		t.Fatalf("Cards()=%d, want 1", got)
 	}
 }
 
-func TestScheduler_SubmitWithDelay_NilKanbanSafe(t *testing.T) {
-	s := NewScheduler()
-	s.Start()
+// ---------------------------------------------------------------------------
+// CronJob.isEnabled / parseCronRulePayload — table-driven leaf helpers
+// ---------------------------------------------------------------------------
 
-	_, err := s.submitWithDelay(context.Background(), TaskOptions{
-		TargetAgentID: "agent-1",
-		Query:         "delayed",
-	}, "10ms")
+func TestCronJob_IsEnabled(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name string
+		job  CronJob
+		want bool
+	}{
+		{"nil_means_enabled", CronJob{Enabled: nil}, true},
+		{"true", CronJob{Enabled: boolPtr(true)}, true},
+		{"false", CronJob{Enabled: boolPtr(false)}, false},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := tc.job.isEnabled(); got != tc.want {
+				t.Errorf("isEnabled()=%v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestParseCronRulePayload(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name  string
+		in    any
+		ok    bool
+		check func(t *testing.T, p cronRulePayload)
+	}{
+		{
+			name: "valid_map",
+			in: map[string]any{
+				"agent_id": "a1", "schedule_id": "s1",
+				"cron": "0 9 * * *", "query": "q", "timezone": "UTC",
+			},
+			ok: true,
+			check: func(t *testing.T, p cronRulePayload) {
+				if p.AgentID != "a1" || p.ScheduleID != "s1" || p.Cron != "0 9 * * *" ||
+					p.Query != "q" || p.Timezone != "UTC" {
+					t.Errorf("unexpected: %+v", p)
+				}
+			},
+		},
+		{name: "wrong_type", in: "not a map", ok: false},
+		{name: "missing_keys", in: map[string]any{"foo": "bar"}, ok: false},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			p, ok := parseCronRulePayload(tc.in)
+			if ok != tc.ok {
+				t.Fatalf("ok=%v, want %v", ok, tc.ok)
+			}
+			if ok && tc.check != nil {
+				tc.check(t, p)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Bug 6 (P3): scheduler emits cron-rule lifecycle events on the Board's bus.
+// ---------------------------------------------------------------------------
+
+func TestScheduler_Bus_PublishesCronRuleCreatedAndDisabled(t *testing.T) {
+	t.Parallel()
+	s, _, sb := newScheduler(t)
+	s.Start()
+	t.Cleanup(s.Stop)
+
+	sub := subscribeBus(t, sb)
+
+	id, err := s.submitWithCron(context.Background(), TaskOptions{
+		TargetAgentID: "agent-1", Query: "daily",
+	}, "0 9 * * *", "")
 	if err != nil {
-		t.Fatalf("submitWithDelay: %v", err)
+		t.Fatalf("submitWithCron: %v", err)
 	}
 
-	time.Sleep(50 * time.Millisecond)
-	s.Stop()
+	createdSeen := false
+	for _, ev := range drainEvents(sub, 500*time.Millisecond, 1, func(e event.Event) bool {
+		return string(e.Type) == EventCronRuleCreated
+	}) {
+		if string(ev.Type) != EventCronRuleCreated {
+			continue
+		}
+		p, ok := ev.Payload.(CronRuleCreatedPayload)
+		if !ok || p.ScheduleID != id || p.AgentID != "agent-1" {
+			t.Fatalf("CronRuleCreated payload mismatch: %+v", ev.Payload)
+		}
+		createdSeen = true
+	}
+	if !createdSeen {
+		t.Fatal("EventCronRuleCreated not observed")
+	}
+
+	s.RemoveAgent("agent-1")
+
+	disabledSeen := false
+	for _, ev := range drainEvents(sub, 500*time.Millisecond, 1, func(e event.Event) bool {
+		return string(e.Type) == EventCronRuleDisabled
+	}) {
+		if string(ev.Type) != EventCronRuleDisabled {
+			continue
+		}
+		p, ok := ev.Payload.(CronRuleDisabledPayload)
+		if !ok || p.AgentID != "agent-1" {
+			t.Fatalf("CronRuleDisabled payload mismatch: %+v", ev.Payload)
+		}
+		disabledSeen = true
+	}
+	if !disabledSeen {
+		t.Fatal("EventCronRuleDisabled not observed")
+	}
+}
+
+func TestScheduler_Bus_PublishesCronRuleFiredOnFire(t *testing.T) {
+	t.Parallel()
+	s, _, sb := newScheduler(t)
+	sub := subscribeBus(t, sb)
+
+	s.fire("agent-1", "sched-fire", "cron task")
+
+	for _, ev := range drainEvents(sub, 500*time.Millisecond, 1, func(e event.Event) bool {
+		return string(e.Type) == EventCronRuleFired
+	}) {
+		if string(ev.Type) != EventCronRuleFired {
+			continue
+		}
+		p, ok := ev.Payload.(CronRuleFiredPayload)
+		if !ok || p.ScheduleID != "sched-fire" || p.AgentID != "agent-1" {
+			t.Fatalf("CronRuleFired payload mismatch: %+v", ev.Payload)
+		}
+		return
+	}
+	t.Fatal("EventCronRuleFired not observed")
 }


### PR DESCRIPTION
Closes #28.

## Summary

Fixes the six bugs reported in #28 across `sdk/kanban` and consolidates the event surface so `Board.Bus()` is the single source of truth.

| # | Sev | Bug | Fix |
|---|-----|-----|-----|
| 1 | P0 | Watcher event drop on bounded chan | Unbounded queue + pump goroutine; `watcherDropped` only counts post-shutdown |
| 2 | P1 | Cron-rule / result cards leak into `Cards()` & `Timeline()` | `isInternalCardType` filter |
| 3 | P1 | Trace span / `ProducerID` lost across delayed/cron submits | Capture from initial ctx, re-inject at fire; cron opens scheduler-rooted span |
| 4 | P2 | `Stop()` hangs forever on stuck executor | `DefaultStopTimeout = 10s`; `WithStopTimeout(0)` opts back to legacy |
| 5 | P2 | Restored `CreatedAt`/`UpdatedAt` overwritten by replay | `WithTimestamps` + `Board.restoreTimestamps` |
| 6 | P3 | Event coverage gaps + dual-bus drift via `WithEventBus` | `Kanban.bus` removed, `Kanban.Bus()` aliases `board.Bus()`; `WithEventBus` is a no-op (scheduled to be removed in v0.2.0); cron events emitted on the same bus; payloads carry `Version` via `eventEnvelope` |

## Behaviour change (worth flagging in v0.2 release notes)

- `kanban.New(...)` now defaults to `WithStopTimeout(10s)`. Callers that relied on `Stop()` blocking until every executor finished must opt back in with `WithStopTimeout(0)`.
- `WithEventBus` no longer redirects events. It is retained as a source-compat no-op until v0.2.0.

## Test plan

- [x] `go test -race -cover ./sdk/kanban/` — pass, coverage **92.5%**
- [x] Per-bug acceptance tests added (event drop, cron filter, producer-id propagation, stop-timeout default + zero, restore-timestamps, event reconstruction)
- [x] Kanban test suite reorganised: `board_test.go` / `board_restore_test.go` / `board_concurrency_test.go` / `events_test.go` / `kanban_test.go` / `scheduler_test.go`, with `helpers_test.go` for shared fixtures, `t.Parallel()` everywhere it's safe
- [ ] Downstream smoke (sdkx / runtimes) — please verify CI


Made with [Cursor](https://cursor.com)