### PR TITLE
chore(sdkx): bump sdk dependency to v0.2.0 [skip-tag]

### DIFF
--- a/sdkx/go.mod
+++ b/sdkx/go.mod
@@ -2,7 +2,7 @@ module github.com/GizClaw/flowcraft/sdkx
 
 go 1.25.0
 
-require github.com/GizClaw/flowcraft/sdk v0.1.12
+require github.com/GizClaw/flowcraft/sdk v0.2.0
 
 require (
 	github.com/PuerkitoBio/goquery v1.11.0

--- a/sdkx/go.sum
+++ b/sdkx/go.sum
@@ -8,8 +8,8 @@ github.com/Azure/azure-sdk-for-go/sdk/internal v1.10.0/go.mod h1:iZDifYGJTIgIIkY
 github.com/AzureAD/microsoft-authentication-library-for-go v1.2.2 h1:XHOnouVk1mxXfQidrMEnLlPk9UMeRtyBTnEFtxkV0kU=
 github.com/AzureAD/microsoft-authentication-library-for-go v1.2.2/go.mod h1:wP83P5OoQ5p6ip3ScPr0BAq0BvuPAvacpEuSzyouqAI=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
-github.com/GizClaw/flowcraft/sdk v0.1.12 h1:wVUh3DSndZUEbUDNIzLCYbPoBAMGONeNxPSHFAJqCuU=
-github.com/GizClaw/flowcraft/sdk v0.1.12/go.mod h1:ANQvC68Ue7IL474d8XcJTyHd19jV8HdG4tDHBMEzM+4=
+github.com/GizClaw/flowcraft/sdk v0.2.0 h1:K+hs86rxDg6gup8SUIJEfuMJ+3z0V3KOWwLtLWIUl90=
+github.com/GizClaw/flowcraft/sdk v0.2.0/go.mod h1:ESQWkg/xVCc+2RIO7Lxkdp9lwW9U+u2q+lojvnRzK3Y=
 github.com/PuerkitoBio/goquery v1.11.0 h1:jZ7pwMQXIITcUXNH83LLk+txlaEy6NVOfTuP43xxfqw=
 github.com/PuerkitoBio/goquery v1.11.0/go.mod h1:wQHgxUOU3JGuj3oD/QFfxUdlzW6xPHfqyHre6VMY4DQ=
 github.com/andybalholm/cascadia v1.3.3 h1:AG2YHrzJIm4BZ19iwJ/DAua6Btl3IwJX+VI4kktS1LM=


### PR DESCRIPTION
## Summary

Pin sdkx to the freshly published `sdk/v0.2.0`. That release extracted
`sdk/speech/*` (and the pion/webrtc dep tree) into the new `voice`
module — sdkx's source already does not import any of the relocated
packages, so this is purely a pin bump.

## Test plan

- [x] `cd sdkx && GOWORK=off go vet ./...` green
- [x] `cd sdkx && GOWORK=off go test ./... -count=1` green
- [x] CI green

After merge: tag `sdkx/v0.2.0`.

Made with [Cursor](https://cursor.com)