### PR TITLE
chore(voice): bump sdk dependency to v0.2.0 [skip-tag]

### DIFF
--- a/voice/go.mod
+++ b/voice/go.mod
@@ -3,7 +3,7 @@ module github.com/GizClaw/flowcraft/voice
 go 1.25.0
 
 require (
-	github.com/GizClaw/flowcraft/sdk v0.1.12
+	github.com/GizClaw/flowcraft/sdk v0.2.0
 	github.com/coder/websocket v1.8.14
 	github.com/pion/webrtc/v4 v4.2.9
 	github.com/rs/xid v1.6.0

--- a/voice/go.sum
+++ b/voice/go.sum
@@ -1,5 +1,5 @@
-github.com/GizClaw/flowcraft/sdk v0.1.12 h1:wVUh3DSndZUEbUDNIzLCYbPoBAMGONeNxPSHFAJqCuU=
-github.com/GizClaw/flowcraft/sdk v0.1.12/go.mod h1:ANQvC68Ue7IL474d8XcJTyHd19jV8HdG4tDHBMEzM+4=
+github.com/GizClaw/flowcraft/sdk v0.2.0 h1:K+hs86rxDg6gup8SUIJEfuMJ+3z0V3KOWwLtLWIUl90=
+github.com/GizClaw/flowcraft/sdk v0.2.0/go.mod h1:ESQWkg/xVCc+2RIO7Lxkdp9lwW9U+u2q+lojvnRzK3Y=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/coder/websocket v1.8.14 h1:9L0p0iKiNOibykf283eHkKUHHrpG7f65OE3BhhO7v9g=


### PR DESCRIPTION
## Summary

Pin voice to the freshly published `sdk/v0.2.0`. With this in place the
published voice artifact can be built without the workspace fallback,
clearing the way for the initial `voice/v0.1.0` tag.

## Test plan

- [x] `cd voice && GOWORK=off go vet ./...` green
- [x] `cd voice && GOWORK=off go test ./... -count=1` green
- [x] CI green

After merge: tag `voice/v0.1.0` (initial release of the standalone module).

Made with [Cursor](https://cursor.com)