### PR TITLE
chore(retrieval,history,recall): review fixes and test coverage [skip-tag]

### DIFF
--- a/sdk/history/archive.go
+++ b/sdk/history/archive.go
@@ -46,8 +46,8 @@ type ArchiveResult struct {
 	HotStartSeq      int    `json:"hot_start_seq"`
 }
 
-// LoadManifest reads the archive manifest for a conversation.
-func LoadManifest(ctx context.Context, ws workspace.Workspace, prefix, archivePrefix, convID string) (*ArchiveManifest, error) {
+// loadManifestImpl reads the archive manifest for a conversation.
+func loadManifestImpl(ctx context.Context, ws workspace.Workspace, prefix, archivePrefix, convID string) (*ArchiveManifest, error) {
 	path := manifestPath(prefix, archivePrefix, convID)
 	exists, err := ws.Exists(ctx, path)
 	if err != nil {
@@ -67,9 +67,10 @@ func LoadManifest(ctx context.Context, ws workspace.Workspace, prefix, archivePr
 	return &m, nil
 }
 
-// SaveManifest writes the archive manifest atomically (write-tmp + rename),
-// so a crash mid-write cannot leave readers seeing a half-serialized manifest.
-func SaveManifest(ctx context.Context, ws workspace.Workspace, prefix, archivePrefix, convID string, m *ArchiveManifest) error {
+// saveManifestImpl writes the archive manifest atomically (write-tmp +
+// rename), so a crash mid-write cannot leave readers seeing a half-
+// serialized manifest.
+func saveManifestImpl(ctx context.Context, ws workspace.Workspace, prefix, archivePrefix, convID string, m *ArchiveManifest) error {
 	data, err := json.MarshalIndent(m, "", "  ")
 	if err != nil {
 		return fmt.Errorf("archive: marshal manifest: %w", err)
@@ -137,9 +138,12 @@ func loadIntent(ctx context.Context, ws workspace.Workspace, prefix, archivePref
 	return &intent, nil
 }
 
-// RecoverArchive checks for incomplete archive operations and completes them.
-// Call this at startup before any new archive operations.
-func RecoverArchive(ctx context.Context, ws workspace.Workspace, store Store, prefix, archivePrefix, convID string) error {
+// recoverArchiveImpl checks for incomplete archive operations and
+// completes them. The [Coordinator] runs this at construction (startup
+// scan) and on the first task per conversation (lazy recovery); the
+// deprecated top-level [RecoverArchive] shim calls through to here for
+// callers still on the v0.2.x manual-recovery flow.
+func recoverArchiveImpl(ctx context.Context, ws workspace.Workspace, store Store, prefix, archivePrefix, convID string) error {
 	intent, err := loadIntent(ctx, ws, prefix, archivePrefix, convID)
 	if err != nil || intent == nil {
 		return err
@@ -164,7 +168,7 @@ func RecoverArchive(ctx context.Context, ws workspace.Workspace, store Store, pr
 		}
 	case "gzip_written":
 		// Gzip done but manifest not updated — update manifest then trim.
-		manifest, err := LoadManifest(ctx, ws, prefix, archivePrefix, convID)
+		manifest, err := loadManifestImpl(ctx, ws, prefix, archivePrefix, convID)
 		if err != nil {
 			return fmt.Errorf("archive: recovery load manifest: %w", err)
 		}
@@ -185,7 +189,7 @@ func RecoverArchive(ctx context.Context, ws workspace.Workspace, store Store, pr
 				CreatedAt: time.Now(),
 			})
 			manifest.HotStartSeq = intent.EndSeq + 1
-			if err := SaveManifest(ctx, ws, prefix, archivePrefix, convID, manifest); err != nil {
+			if err := saveManifestImpl(ctx, ws, prefix, archivePrefix, convID, manifest); err != nil {
 				return fmt.Errorf("archive: recovery save manifest: %w", err)
 			}
 		}
@@ -206,9 +210,14 @@ func RecoverArchive(ctx context.Context, ws workspace.Workspace, store Store, pr
 	return nil
 }
 
-// Archive moves old messages to gzip-compressed archive files.
-// Uses an intent file for crash recovery (see RecoverArchive).
-func Archive(ctx context.Context, ws workspace.Workspace, store Store, prefix, convID string, cfg ArchiveConfig) (ArchiveResult, error) {
+// archiveImpl moves old messages to gzip-compressed archive files. It is
+// the package-private implementation called by the [Coordinator] (via
+// internalArchive) and by the deprecated top-level [Archive] shim.
+//
+// Crash recovery is handled by recoverArchiveImpl; new callers should
+// drive both through [Coordinator] rather than invoking the package
+// helpers directly.
+func archiveImpl(ctx context.Context, ws workspace.Workspace, store Store, prefix, convID string, cfg ArchiveConfig) (ArchiveResult, error) {
 	start := time.Now()
 	defer func() {
 		archiveDuration.Record(ctx, time.Since(start).Seconds())
@@ -248,7 +257,7 @@ func Archive(ctx context.Context, ws workspace.Workspace, store Store, prefix, c
 		archivePrefix = "archive"
 	}
 
-	manifest, err := LoadManifest(ctx, ws, prefix, archivePrefix, convID)
+	manifest, err := loadManifestImpl(ctx, ws, prefix, archivePrefix, convID)
 	if err != nil {
 		return result, err
 	}
@@ -298,7 +307,7 @@ func Archive(ctx context.Context, ws workspace.Workspace, store Store, prefix, c
 	})
 	manifest.HotStartSeq = endSeq + 1
 
-	if err := SaveManifest(ctx, ws, prefix, archivePrefix, convID, manifest); err != nil {
+	if err := saveManifestImpl(ctx, ws, prefix, archivePrefix, convID, manifest); err != nil {
 		return result, fmt.Errorf("archive: save manifest: %w", err)
 	}
 
@@ -333,9 +342,12 @@ func archiveDir(prefix, archivePrefix, convID string) string {
 	return fmt.Sprintf("%s/%s", convID, archivePrefix)
 }
 
-// LoadArchivedMessages reads messages from gzip archive segments.
-func LoadArchivedMessages(ctx context.Context, ws workspace.Workspace, prefix, archivePrefix, convID string, startSeq, endSeq int) ([]model.Message, error) {
-	manifest, err := LoadManifest(ctx, ws, prefix, archivePrefix, convID)
+// loadArchivedMessagesImpl reads messages from gzip archive segments. It
+// powers history_expand's cold-segment path; callers outside the
+// history package should obtain archived turns via the history_expand
+// tool registered through [RegisterTools].
+func loadArchivedMessagesImpl(ctx context.Context, ws workspace.Workspace, prefix, archivePrefix, convID string, startSeq, endSeq int) ([]model.Message, error) {
+	manifest, err := loadManifestImpl(ctx, ws, prefix, archivePrefix, convID)
 	if err != nil {
 		return nil, err
 	}

--- a/sdk/history/archive_test.go
+++ b/sdk/history/archive_test.go
@@ -3,6 +3,7 @@ package history
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/GizClaw/flowcraft/sdk/model"
 	"github.com/GizClaw/flowcraft/sdk/workspace"
@@ -260,5 +261,47 @@ func TestArchive_IntentCleanup(t *testing.T) {
 	loadedIntent, _ := loadIntent(ctx, ws, "memory", "archive", convID)
 	if loadedIntent != nil {
 		t.Fatal("intent should be cleaned up after successful archive")
+	}
+}
+
+// TestSaveManifest_RoundTrip exercises the deprecated SaveManifest /
+// LoadManifest pair declared in deprecated.go: write a manifest, read it
+// back, and assert all fields survive the JSON round-trip.
+func TestSaveManifest_RoundTrip(t *testing.T) {
+	ws, err := workspace.NewLocalWorkspace(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx := context.Background()
+	convID := "manifest-test"
+
+	in := &ArchiveManifest{
+		HotStartSeq: 25,
+		Segments: []ArchiveSegment{
+			{File: "messages_0_9.jsonl.gz", StartSeq: 0, EndSeq: 9, Count: 10, CreatedAt: time.Now().UTC().Truncate(time.Second)},
+			{File: "messages_10_24.jsonl.gz", StartSeq: 10, EndSeq: 24, Count: 15, CreatedAt: time.Now().UTC().Truncate(time.Second)},
+		},
+	}
+	if err := SaveManifest(ctx, ws, "memory", "archive", convID, in); err != nil {
+		t.Fatalf("SaveManifest: %v", err)
+	}
+
+	out, err := LoadManifest(ctx, ws, "memory", "archive", convID)
+	if err != nil {
+		t.Fatalf("LoadManifest: %v", err)
+	}
+	if out.HotStartSeq != in.HotStartSeq {
+		t.Fatalf("HotStartSeq mismatch: got %d", out.HotStartSeq)
+	}
+	if len(out.Segments) != len(in.Segments) {
+		t.Fatalf("segments len: got %d", len(out.Segments))
+	}
+	for i := range in.Segments {
+		if out.Segments[i].File != in.Segments[i].File {
+			t.Fatalf("segment %d File mismatch: got %q", i, out.Segments[i].File)
+		}
+		if out.Segments[i].Count != in.Segments[i].Count {
+			t.Fatalf("segment %d Count mismatch: got %d", i, out.Segments[i].Count)
+		}
 	}
 }

--- a/sdk/history/compactor.go
+++ b/sdk/history/compactor.go
@@ -6,6 +6,7 @@ import (
 	"sort"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/GizClaw/flowcraft/sdk/llm"
@@ -17,27 +18,33 @@ import (
 	"go.opentelemetry.io/otel/metric"
 )
 
-// Background work timeouts. Ingest and archive used to share a single 60s
-// budget; that meant a slow LLM summarization could starve the archive
-// step (or vice-versa). They now run independently with their own ceilings.
+// Background work timeouts. Ingest and archive each get their own ceiling
+// so a slow LLM summarization cannot starve archive (and vice-versa).
 const (
 	defaultIngestTimeout  = 60 * time.Second
 	defaultArchiveTimeout = 60 * time.Second
 )
 
-// compactor is the DAG-summarization implementation of [History]. It is
-// unexported on purpose: callers construct it via [NewCompacted] and
-// consume it through the [History] interface. The "compactor" name
-// reflects what the implementation actually does — archive + leaf
-// prune discard data on disk in exchange for context-window budget;
-// the previous "lossless" name was aspirational.
+// compactor is the DAG-summarization implementation of [History] and the
+// canonical [Coordinator]. It is unexported on purpose: callers construct
+// it via [NewCompacted] and consume it through [History] / [Coordinator].
 //
-// Concurrency model: every Append acquires a per-conversation lock and
-// then schedules background DAG ingest + archive on a goroutine.
-// Because the per-conversation lock serializes Appends for the same
-// conversationID, no two background workers race on the same DAG;
-// cross-conversation background work runs in parallel without
-// artificial bounds.
+// Concurrency model (M2): every conversation owns one serial worker
+// goroutine that drains a buffered task queue. All state-mutating
+// operations — Append, async ingest, async archive, manual Compact /
+// Archive, Clear — go through the same queue, so:
+//
+//   - same-conversation operations are strictly serialized;
+//   - different conversations run in parallel, bounded only by goroutine
+//     count;
+//   - background ingest/archive can never race the public Compact/Archive
+//     surface because they share the queue;
+//   - Shutdown observes a clean drain, not a "best-effort" wg.Wait.
+//
+// The worker is reaped on [History.Clear] (Q9 = W3); the queue buffer is
+// fixed-size (Q10 = B2, queueBuffer); [NewCompacted] kicks off an async
+// archive recovery scan plus per-conversation lazy recovery on first task
+// (Q11 = D-R3).
 type compactor struct {
 	store  Store
 	dag    *SummaryDAG
@@ -45,22 +52,99 @@ type compactor struct {
 	ws     workspace.Workspace
 	prefix string
 
-	mu    sync.Mutex
-	locks map[string]*sync.Mutex
-	wg    sync.WaitGroup
+	mu      sync.Mutex
+	queues  map[string]*convQueue
+	state   atomic.Int32 // open(0) → closing(1) → closed(2)
+	closeWg sync.WaitGroup
+
+	// shutdownOnce + shutdownDone form the "single drain-watcher" pattern:
+	// the first Shutdown call flips state, closes every queue, and starts
+	// the only goroutine that ever calls closeWg.Wait. Subsequent
+	// Shutdown calls (and a deadline-bounded retry pattern) all share
+	// shutdownDone, so the watcher goroutine count is exactly 0 before
+	// Shutdown and exactly 1 after — no leak per retry.
+	shutdownOnce sync.Once
+	shutdownDone chan struct{}
+}
+
+const (
+	stateOpen    int32 = 0
+	stateClosing int32 = 1
+	stateClosed  int32 = 2
+)
+
+// queueBuffer caps how many pending tasks may sit in a single
+// conversation's queue before further enqueue attempts block. The dominant
+// task is async ingest after Append; backing up beyond a few dozen pending
+// ingests for the same conversation would already imply LLM summarization
+// is hopelessly behind, so a moderate buffer is preferable to either of
+// the extremes (B1 = bottleneck on hot conversations, B3 = unbounded
+// memory growth on a stuck LLM).
+const queueBuffer = 64
+
+// taskKind enumerates the operations a per-conversation worker can run.
+// Each kind defines which fields of convTask are populated.
+type taskKind int
+
+const (
+	taskIngest taskKind = iota
+	taskArchive
+	taskCompact
+	taskClear
+	taskRecover
+)
+
+type convTask struct {
+	kind taskKind
+
+	// taskIngest payload
+	msgs     []model.Message
+	startSeq int
+
+	// reply channel for synchronous tasks (compact/archive/clear).
+	replyCompact chan compactReply
+	replyArchive chan archiveReply
+	replyClear   chan error
+}
+
+type compactReply struct {
+	res CompactResult
+	err error
+}
+
+type archiveReply struct {
+	res ArchiveResult
+	err error
+}
+
+type convQueue struct {
+	tasks chan convTask
+	// recovered guards lazy archive recovery (D-R3): the first task to
+	// reach a worker triggers a single RecoverArchive pass for that
+	// conversation, regardless of which task kind it is.
+	recovered bool
 }
 
 func newCompactor(store Store, dag *SummaryDAG, config DAGConfig, ws workspace.Workspace, prefix string) *compactor {
-	return &compactor{
-		store:  store,
-		dag:    dag,
-		config: config,
-		ws:     ws,
-		prefix: prefix,
-		locks:  make(map[string]*sync.Mutex),
+	c := &compactor{
+		store:        store,
+		dag:          dag,
+		config:       config,
+		ws:           ws,
+		prefix:       prefix,
+		queues:       make(map[string]*convQueue),
+		shutdownDone: make(chan struct{}),
 	}
+	c.kickoffStartupRecovery()
+	return c
 }
 
+// Load assembles the context window via the DAG. It is read-only and does
+// NOT route through the per-conversation worker, which means concurrent
+// readers do not contend with writers. The MaxMessages clamp preserves
+// any leading system message — assembling a "system + recent" tail and
+// then naively trimming from the head would silently strip the system
+// prompt, which is the bug the previous implementation shipped.
 func (m *compactor) Load(ctx context.Context, conversationID string, budget Budget) ([]model.Message, error) {
 	tokenBudget := m.config.TokenBudget
 	if budget.MaxTokens > 0 && (tokenBudget == 0 || budget.MaxTokens < tokenBudget) {
@@ -70,84 +154,64 @@ func (m *compactor) Load(ctx context.Context, conversationID string, budget Budg
 	if err != nil {
 		return nil, err
 	}
-	if budget.MaxMessages > 0 && len(msgs) > budget.MaxMessages {
-		msgs = msgs[len(msgs)-budget.MaxMessages:]
-	}
-	return msgs, nil
+	return clampPreservingSystem(msgs, budget.MaxMessages), nil
 }
 
-// Append persists newMessages and asynchronously ingests them into the
-// summary DAG and (if a workspace is wired) the archive.
-//
-// Two correctness properties matter:
-//
-//  1. No read-modify-write race. The previous Save took a full history,
-//     diffed it against GetMessages, and then SaveMessages-overwrote.
-//     Two concurrent callers could both observe the pre-state, both
-//     diff, and both overwrite — losing one side's writes. Append takes
-//     the per-conversation lock and either calls MessageAppender (if the
-//     Store supports it) or performs the GetMessages+concat+SaveMessages
-//     fallback under the lock, so the ABA window is closed.
-//
-//  2. No silent ingest drop. The previous implementation used a global
-//     semaphore and dropped DAG ingest when full, which silently shrank
-//     the summarized history (and thereby the assembled context) under
-//     load. Per-conversation serialization means the only contention is
-//     between successive Appends for the same conversation, which is
-//     naturally bounded; we just wg.Add them and let the workers run.
+// clampPreservingSystem keeps the leading system message (if any) when
+// trimming from the head to satisfy MaxMessages.
+func clampPreservingSystem(msgs []model.Message, maxMsgs int) []model.Message {
+	if maxMsgs <= 0 || len(msgs) <= maxMsgs {
+		return msgs
+	}
+	if len(msgs) > 0 && msgs[0].Role == model.RoleSystem {
+		head := msgs[0]
+		if maxMsgs == 1 {
+			return []model.Message{head}
+		}
+		tail := msgs[1:]
+		if len(tail) > maxMsgs-1 {
+			tail = tail[len(tail)-(maxMsgs-1):]
+		}
+		out := make([]model.Message, 0, 1+len(tail))
+		out = append(out, head)
+		out = append(out, tail...)
+		return out
+	}
+	return msgs[len(msgs)-maxMsgs:]
+}
+
+// Append persists newMessages synchronously inside the per-conversation
+// worker, then enqueues an asynchronous ingest+archive task on the same
+// queue so that concurrent maintenance work cannot interleave.
 func (m *compactor) Append(ctx context.Context, conversationID string, newMessages []model.Message) error {
 	if len(newMessages) == 0 {
 		return nil
 	}
-
-	convMu := m.convMu(conversationID)
-	convMu.Lock()
-	defer convMu.Unlock()
+	if m.state.Load() != stateOpen {
+		return ErrClosed
+	}
 
 	startSeq, err := m.persistAppend(ctx, conversationID, newMessages)
 	if err != nil {
 		return err
 	}
 
-	m.wg.Add(1)
-	go func() {
-		defer m.wg.Done()
-
-		// Ingest and archive each get their own detached context with
-		// independent timeouts so a slow LLM summarization cannot starve
-		// archive (and vice-versa).
-		ingestCtx, cancelIngest := context.WithTimeout(context.WithoutCancel(ctx), defaultIngestTimeout)
-		defer cancelIngest()
-		if err := m.dag.Ingest(ingestCtx, conversationID, newMessages, startSeq); err != nil {
-			telemetry.Warn(ingestCtx, "lossless: async ingest failed",
-				otellog.String("conversation_id", conversationID),
-				otellog.String("error", err.Error()))
-		}
-
-		if m.ws == nil {
-			return
-		}
-		archiveCtx, cancelArchive := context.WithTimeout(context.WithoutCancel(ctx), defaultArchiveTimeout)
-		defer cancelArchive()
-		if _, err := Archive(archiveCtx, m.ws, m.store, m.prefix, conversationID, m.config.Archive); err != nil {
-			telemetry.Warn(archiveCtx, "lossless: async archive failed",
-				otellog.String("conversation_id", conversationID),
-				otellog.String("error", err.Error()))
-		}
-	}()
-
+	if err := m.enqueueAsync(conversationID, convTask{
+		kind:     taskIngest,
+		msgs:     newMessages,
+		startSeq: startSeq,
+	}); err != nil {
+		// On Shutdown race the messages are already durable; lose only
+		// the async DAG ingest, which would have been best-effort anyway.
+		telemetry.Warn(ctx, "history: async ingest dropped during shutdown",
+			otellog.String("conversation_id", conversationID),
+			otellog.String("error", err.Error()))
+	}
 	return nil
 }
 
-// persistAppend writes newMessages to the underlying store and returns the
-// 0-based sequence number where the first new message lives. Caller must
-// hold the per-conversation lock.
 func (m *compactor) persistAppend(ctx context.Context, conversationID string, newMessages []model.Message) (int, error) {
 	if appender, ok := m.store.(MessageAppender); ok {
-		// We still need the prior count for the DAG sequence. Stores that
-		// support AppendMessages typically also support reading the count
-		// cheaply; if that ever becomes a hotspot, add a CountMessages
-		// optional interface.
 		existing, err := m.store.GetMessages(ctx, conversationID)
 		if err != nil {
 			return 0, err
@@ -171,50 +235,344 @@ func (m *compactor) persistAppend(ctx context.Context, conversationID string, ne
 	return len(existing), nil
 }
 
-func (m *compactor) Clear(ctx context.Context, conversationID string) error {
-	convMu := m.convMu(conversationID)
-	convMu.Lock()
-	defer convMu.Unlock()
-
-	if err := m.store.DeleteMessages(ctx, conversationID); err != nil {
-		return err
+// Compact runs DAG compact synchronously through the per-conversation
+// worker. It refuses to start once Shutdown has been initiated.
+func (m *compactor) Compact(ctx context.Context, conversationID string) (CompactResult, error) {
+	if m.state.Load() != stateOpen {
+		return CompactResult{}, ErrClosed
 	}
-	return m.dag.store.Rewrite(ctx, conversationID, nil)
+	reply := make(chan compactReply, 1)
+	if err := m.enqueueSync(conversationID, convTask{kind: taskCompact, replyCompact: reply}); err != nil {
+		return CompactResult{}, err
+	}
+	select {
+	case <-ctx.Done():
+		return CompactResult{}, ctx.Err()
+	case r := <-reply:
+		return r.res, r.err
+	}
 }
 
-// Close waits for all pending async ingest/archive goroutines to complete.
-// Idempotent: subsequent calls return immediately because there is no
-// state to release beyond the wait group, and a drained group's Wait
-// is a no-op.
-func (m *compactor) Close() {
-	m.wg.Wait()
-}
-
-// Compile-time guarantee that compactor satisfies the [Closer]
-// sub-interface — callers type-assert on the History returned from
-// [NewCompacted].
-var _ Closer = (*compactor)(nil)
-
-// Archive manually triggers archiving for this conversation.
+// Archive runs message archiving synchronously through the per-
+// conversation worker. Returns an empty result (and nil error) when the
+// compactor was constructed without a workspace, matching the previous
+// public contract.
 func (m *compactor) Archive(ctx context.Context, conversationID string) (ArchiveResult, error) {
 	if m.ws == nil {
 		return ArchiveResult{}, nil
 	}
-	convMu := m.convMu(conversationID)
-	convMu.Lock()
-	defer convMu.Unlock()
-	return Archive(ctx, m.ws, m.store, m.prefix, conversationID, m.config.Archive)
+	if m.state.Load() != stateOpen {
+		return ArchiveResult{}, ErrClosed
+	}
+	reply := make(chan archiveReply, 1)
+	if err := m.enqueueSync(conversationID, convTask{kind: taskArchive, replyArchive: reply}); err != nil {
+		return ArchiveResult{}, err
+	}
+	select {
+	case <-ctx.Done():
+		return ArchiveResult{}, ctx.Err()
+	case r := <-reply:
+		return r.res, r.err
+	}
 }
 
-func (m *compactor) convMu(convID string) *sync.Mutex {
+// Clear deletes the conversation's transcript and DAG, then reaps the
+// per-conversation worker (W3 = "reap on Clear").
+func (m *compactor) Clear(ctx context.Context, conversationID string) error {
+	if m.state.Load() != stateOpen {
+		return ErrClosed
+	}
+	reply := make(chan error, 1)
+	if err := m.enqueueSync(conversationID, convTask{kind: taskClear, replyClear: reply}); err != nil {
+		return err
+	}
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case err := <-reply:
+		return err
+	}
+}
+
+// Shutdown transitions the coordinator to closing/closed, refuses new
+// work, and waits for all per-conversation queues to drain. S3 semantics:
+// a ctx-deadline expiry returns ctx.Err() but does NOT cancel the in-
+// flight workers. Callers that need to observe the eventual drain after
+// a deadline-bounded Shutdown should call Shutdown again with
+// context.Background() — the second call attaches to the same drain and
+// returns nil once every worker has exited.
+//
+// Multi-call safety: the close-queues + drain-watcher work happens
+// exactly once (sync.Once), so a supervisor calling Shutdown in a
+// timeout-retry loop never accumulates watcher goroutines.
+func (m *compactor) Shutdown(ctx context.Context) error {
+	m.shutdownOnce.Do(func() {
+		m.state.Store(stateClosing)
+
+		m.mu.Lock()
+		for _, q := range m.queues {
+			close(q.tasks)
+		}
+		m.mu.Unlock()
+
+		go func() {
+			m.closeWg.Wait()
+			m.state.Store(stateClosed)
+			close(m.shutdownDone)
+		}()
+	})
+
+	select {
+	case <-m.shutdownDone:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+// Close is the legacy v0.2.x entry point preserved for callers still on
+// the [Closer] sub-interface. It blocks until all queues drain.
+//
+// Deprecated: use [Coordinator.Shutdown] (with a context for bounded
+// waits). Will be removed in v0.3.0.
+func (m *compactor) Close() {
+	_ = m.Shutdown(context.Background())
+}
+
+// Compile-time guarantees.
+var (
+	_ Coordinator = (*compactor)(nil)
+	_ Closer      = (*compactor)(nil)
+)
+
+// enqueueAsync routes a fire-and-forget task (ingest) to the conv queue.
+// Returns ErrClosed if Shutdown has started in the meantime; never
+// returns a backpressure error because Append falls back to telemetry
+// rather than failing user writes.
+func (m *compactor) enqueueAsync(convID string, task convTask) error {
+	q, err := m.queueFor(convID)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		// Recover from a "send on closed channel" panic that can occur
+		// only if Shutdown closes the channel between our state-check
+		// and the send below. Treat it as ErrClosed.
+		_ = recover()
+	}()
+	if m.state.Load() != stateOpen {
+		return ErrClosed
+	}
+	q.tasks <- task
+	return nil
+}
+
+// enqueueSync routes a request/reply task and waits for the worker to
+// pick it up. Synchronous callers (Compact/Archive/Clear) handle their
+// own reply channel + ctx wait.
+func (m *compactor) enqueueSync(convID string, task convTask) error {
+	q, err := m.queueFor(convID)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		_ = recover()
+	}()
+	if m.state.Load() != stateOpen {
+		return ErrClosed
+	}
+	q.tasks <- task
+	return nil
+}
+
+// queueFor returns the per-conversation queue, lazily starting its
+// worker. Returns ErrClosed if Shutdown has begun and there is no live
+// queue for this conversation; an existing queue continues to drain even
+// during shutdown to honour previously-accepted work.
+func (m *compactor) queueFor(convID string) (*convQueue, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	mu, ok := m.locks[convID]
-	if !ok {
-		mu = &sync.Mutex{}
-		m.locks[convID] = mu
+	if q, ok := m.queues[convID]; ok {
+		return q, nil
 	}
-	return mu
+	if m.state.Load() != stateOpen {
+		return nil, ErrClosed
+	}
+	q := &convQueue{tasks: make(chan convTask, queueBuffer)}
+	m.queues[convID] = q
+	m.closeWg.Add(1)
+	go m.worker(convID, q)
+	return q, nil
+}
+
+// worker drains a single conversation's task queue. The worker exits
+// (and removes itself from the queues map) when the channel closes,
+// which happens on Shutdown or when Clear reaps it via removeQueue.
+func (m *compactor) worker(convID string, q *convQueue) {
+	defer m.closeWg.Done()
+	for task := range q.tasks {
+		m.lazyRecover(convID, q)
+		m.runTask(convID, task)
+	}
+}
+
+func (m *compactor) lazyRecover(convID string, q *convQueue) {
+	if q.recovered || m.ws == nil {
+		return
+	}
+	q.recovered = true
+	archivePrefix := m.archivePrefix()
+	ctx, cancel := context.WithTimeout(context.Background(), defaultArchiveTimeout)
+	defer cancel()
+	if err := recoverArchiveImpl(ctx, m.ws, m.store, m.prefix, archivePrefix, convID); err != nil {
+		telemetry.Warn(ctx, "history: lazy archive recovery failed",
+			otellog.String("conversation_id", convID),
+			otellog.String("error", err.Error()))
+	}
+}
+
+func (m *compactor) runTask(convID string, task convTask) {
+	switch task.kind {
+	case taskIngest:
+		ingestCtx, cancelIngest := context.WithTimeout(context.Background(), defaultIngestTimeout)
+		if err := m.dag.Ingest(ingestCtx, convID, task.msgs, task.startSeq); err != nil {
+			telemetry.Warn(ingestCtx, "history: async ingest failed",
+				otellog.String("conversation_id", convID),
+				otellog.String("error", err.Error()))
+		}
+		cancelIngest()
+
+		if m.ws == nil {
+			return
+		}
+		archiveCtx, cancelArchive := context.WithTimeout(context.Background(), defaultArchiveTimeout)
+		if _, err := internalArchive(archiveCtx, m.ws, m.store, m.prefix, convID, m.config.Archive); err != nil {
+			telemetry.Warn(archiveCtx, "history: async archive failed",
+				otellog.String("conversation_id", convID),
+				otellog.String("error", err.Error()))
+		}
+		cancelArchive()
+
+	case taskArchive:
+		ctx, cancel := context.WithTimeout(context.Background(), defaultArchiveTimeout)
+		res, err := internalArchive(ctx, m.ws, m.store, m.prefix, convID, m.config.Archive)
+		cancel()
+		task.replyArchive <- archiveReply{res: res, err: err}
+
+	case taskCompact:
+		ctx, cancel := context.WithTimeout(context.Background(), defaultIngestTimeout)
+		res, err := m.dag.Compact(ctx, convID)
+		cancel()
+		task.replyCompact <- compactReply{res: res, err: err}
+
+	case taskClear:
+		ctx, cancel := context.WithTimeout(context.Background(), defaultIngestTimeout)
+		err := m.runClear(ctx, convID)
+		cancel()
+		// W3: drop the queue BEFORE replying so callers observing the
+		// reply also observe the reaped queue. Reversing the order
+		// would race tests (and any "after Clear, the queue must be
+		// gone" invariant) because the caller could inspect c.queues
+		// in the window between reply send and removeQueue. Closing
+		// our own input channel inside the for-range loop is safe:
+		// the range exits naturally once the channel drains.
+		m.removeQueue(convID)
+		task.replyClear <- err
+
+	case taskRecover:
+		// taskRecover only triggers lazyRecover via its mere arrival; the
+		// real work was done above before runTask was called. This kind
+		// is only used by the startup scan to nudge sleeping queues.
+	}
+}
+
+func (m *compactor) runClear(ctx context.Context, convID string) error {
+	if err := m.store.DeleteMessages(ctx, convID); err != nil {
+		return err
+	}
+	return m.dag.store.Rewrite(ctx, convID, nil)
+}
+
+// removeQueue closes and removes a per-conversation queue. Safe to call
+// while holding no other locks; the worker exits on the next channel
+// receive.
+func (m *compactor) removeQueue(convID string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	q, ok := m.queues[convID]
+	if !ok {
+		return
+	}
+	delete(m.queues, convID)
+	close(q.tasks)
+}
+
+// archivePrefix mirrors Archive's default-handling so lazy recovery and
+// the live archive path agree on filenames.
+func (m *compactor) archivePrefix() string {
+	if m.config.Archive.ArchivePrefix != "" {
+		return m.config.Archive.ArchivePrefix
+	}
+	return "archive"
+}
+
+// kickoffStartupRecovery scans the workspace for archive intent files and
+// schedules a recover task for each. D-R3 ("startup + lazy"): if the
+// scan discovers an intent, it both runs RecoverArchive immediately
+// AND marks the conversation's queue as already-recovered so the lazy
+// path on first Append/Archive/Compact does not re-do the work.
+func (m *compactor) kickoffStartupRecovery() {
+	if m.ws == nil {
+		return
+	}
+	archivePrefix := m.archivePrefix()
+	prefix := m.prefix
+
+	m.closeWg.Add(1)
+	go func() {
+		defer m.closeWg.Done()
+		ctx, cancel := context.WithTimeout(context.Background(), defaultArchiveTimeout)
+		defer cancel()
+		entries, err := m.ws.List(ctx, prefix)
+		if err != nil {
+			// Workspace may not yet exist on first boot; treat as empty.
+			return
+		}
+		for _, e := range entries {
+			if !e.IsDir() {
+				continue
+			}
+			convID := e.Name()
+			if err := recoverArchiveImpl(ctx, m.ws, m.store, prefix, archivePrefix, convID); err != nil {
+				telemetry.Warn(ctx, "history: startup archive recovery failed",
+					otellog.String("conversation_id", convID),
+					otellog.String("error", err.Error()))
+				continue
+			}
+			// Pre-create the queue so the lazy path skips its own
+			// recovery on the next task.
+			m.mu.Lock()
+			if m.state.Load() == stateOpen {
+				if _, ok := m.queues[convID]; !ok {
+					q := &convQueue{tasks: make(chan convTask, queueBuffer), recovered: true}
+					m.queues[convID] = q
+					m.closeWg.Add(1)
+					go m.worker(convID, q)
+				} else {
+					m.queues[convID].recovered = true
+				}
+			}
+			m.mu.Unlock()
+		}
+	}()
+}
+
+// internalArchive is the package-private archive entry point used by the
+// coordinator. The exported [Archive] function in deprecated.go calls
+// through to this implementation; new code should prefer
+// [Coordinator.Archive].
+func internalArchive(ctx context.Context, ws workspace.Workspace, store Store, prefix, convID string, cfg ArchiveConfig) (ArchiveResult, error) {
+	return archiveImpl(ctx, ws, store, prefix, convID, cfg)
 }
 
 // CompactOption customizes a [History] built by [NewCompacted].

--- a/sdk/history/compactor_test.go
+++ b/sdk/history/compactor_test.go
@@ -3,11 +3,13 @@ package history
 import (
 	"context"
 	"fmt"
+	"strings"
 	"sync"
 	"testing"
 	"time"
 
 	"github.com/GizClaw/flowcraft/sdk/llm"
+	"github.com/GizClaw/flowcraft/sdk/model"
 )
 
 // mockLLM implements llm.LLM for testing.
@@ -268,4 +270,265 @@ func (m *slowMockLLM) Generate(_ context.Context, _ []llm.Message, _ ...llm.Gene
 
 func (m *slowMockLLM) GenerateStream(_ context.Context, _ []llm.Message, _ ...llm.GenerateOption) (llm.StreamMessage, error) {
 	return nil, nil
+}
+
+// --- CompactOption helpers (functional options on compactOptions) ---
+
+func TestCompactOptions_AllSetters(t *testing.T) {
+	o := compactOptions{dag: DefaultDAGConfig(), counter: &EstimateCounter{}, prefix: "memory"}
+
+	custom := DefaultDAGConfig()
+	custom.ChunkSize = 999
+	WithDAGConfig(custom)(&o)
+	if o.dag.ChunkSize != 999 {
+		t.Fatalf("WithDAGConfig: ChunkSize=%d", o.dag.ChunkSize)
+	}
+
+	WithChunkSize(7)(&o)
+	WithCondenseThreshold(8)(&o)
+	WithMaxDepth(9)(&o)
+	WithTokenBudget(1234)(&o)
+	WithRecentRatio(0.42)(&o)
+	WithCompactThreshold(55)(&o)
+	WithLeafPrune(false)(&o)
+	WithArchiveThreshold(77)(&o)
+	WithArchiveBatchSize(33)(&o)
+	WithStoragePrefix("custom-prefix")(&o)
+
+	tk, err := NewTiktokenCounter("gpt-4o")
+	if err != nil {
+		t.Fatal(err)
+	}
+	WithTokenCounter(tk)(&o)
+
+	if o.dag.ChunkSize != 7 {
+		t.Fatalf("ChunkSize = %d", o.dag.ChunkSize)
+	}
+	if o.dag.CondenseThreshold != 8 {
+		t.Fatalf("CondenseThreshold = %d", o.dag.CondenseThreshold)
+	}
+	if o.dag.MaxDepth != 9 {
+		t.Fatalf("MaxDepth = %d", o.dag.MaxDepth)
+	}
+	if o.dag.TokenBudget != 1234 {
+		t.Fatalf("TokenBudget = %d", o.dag.TokenBudget)
+	}
+	if o.dag.RecentRatio != 0.42 {
+		t.Fatalf("RecentRatio = %v", o.dag.RecentRatio)
+	}
+	if o.dag.Compact.CompactThreshold != 55 {
+		t.Fatalf("CompactThreshold = %d", o.dag.Compact.CompactThreshold)
+	}
+	if o.dag.Compact.PruneLeafContent != false {
+		t.Fatal("PruneLeafContent expected false")
+	}
+	if o.dag.Archive.ArchiveThreshold != 77 {
+		t.Fatalf("ArchiveThreshold = %d", o.dag.Archive.ArchiveThreshold)
+	}
+	if o.dag.Archive.ArchiveBatchSize != 33 {
+		t.Fatalf("ArchiveBatchSize = %d", o.dag.Archive.ArchiveBatchSize)
+	}
+	if o.prefix != "custom-prefix" {
+		t.Fatalf("prefix = %q", o.prefix)
+	}
+	if o.counter != tk {
+		t.Fatal("WithTokenCounter did not swap counter")
+	}
+}
+
+func TestCompactOptions_RejectNonPositive(t *testing.T) {
+	o := compactOptions{dag: DefaultDAGConfig(), counter: &EstimateCounter{}, prefix: "memory"}
+	original := o
+	// All numeric setters guard against <=0; calling them with bad values
+	// must be a no-op rather than corrupting the config.
+	WithChunkSize(0)(&o)
+	WithCondenseThreshold(-1)(&o)
+	WithMaxDepth(0)(&o)
+	WithTokenBudget(-1)(&o)
+	WithRecentRatio(0)(&o)
+	WithCompactThreshold(0)(&o)
+	WithArchiveThreshold(-2)(&o)
+	WithArchiveBatchSize(0)(&o)
+	WithTokenCounter(nil)(&o)
+	WithStoragePrefix("")(&o)
+
+	if o.dag != original.dag {
+		t.Fatal("zero/negative inputs corrupted DAGConfig")
+	}
+	if o.counter != original.counter {
+		t.Fatal("nil token counter overwrote default")
+	}
+	if o.prefix != original.prefix {
+		t.Fatalf("empty prefix overwrote default, got %q", o.prefix)
+	}
+}
+
+// --- SummaryDAG.countMsg covers every Part variant ---
+
+func TestSummaryDAG_CountMsg_AllPartTypes(t *testing.T) {
+	dag := NewSummaryDAG(
+		&inMemSummaryStore{data: make(map[string][]*SummaryNode)},
+		NewInMemoryStore(),
+		&mockSummaryLLM{},
+		DefaultDAGConfig(),
+		&EstimateCounter{},
+	)
+
+	// Empty message: just the +4 base overhead.
+	empty := llm.Message{Role: llm.RoleUser}
+	if got := dag.countMsg(empty); got != 4 {
+		t.Fatalf("expected base overhead 4 for empty msg, got %d", got)
+	}
+
+	full := llm.Message{
+		Role: llm.RoleAssistant,
+		Parts: []llm.Part{
+			{Type: llm.PartText, Text: "hello world"},
+			{Type: llm.PartToolCall, ToolCall: &llm.ToolCall{Name: "tool", Arguments: `{"k":"v"}`}},
+			{Type: llm.PartToolResult, ToolResult: &llm.ToolResult{Content: "result body"}},
+		},
+	}
+	got := dag.countMsg(full)
+	if got <= 4 {
+		t.Fatalf("expected count > base overhead for full msg, got %d", got)
+	}
+
+	// Nil ToolCall / ToolResult parts must not panic and must be ignored.
+	withNils := llm.Message{
+		Role: llm.RoleAssistant,
+		Parts: []llm.Part{
+			{Type: llm.PartToolCall},
+			{Type: llm.PartToolResult},
+		},
+	}
+	if got := dag.countMsg(withNils); got != 4 {
+		t.Fatalf("expected base overhead 4 for nil-payload parts, got %d", got)
+	}
+}
+
+// --- SummaryDAG.Assemble: trim + summary path ---
+
+func TestSummaryDAG_Assemble_NoMessages(t *testing.T) {
+	store := NewInMemoryStore()
+	defer store.Close()
+	summaryStore := &inMemSummaryStore{data: make(map[string][]*SummaryNode)}
+	dag := NewSummaryDAG(summaryStore, store, &mockSummaryLLM{}, DefaultDAGConfig(), &EstimateCounter{})
+
+	got, err := dag.Assemble(context.Background(), "empty-conv", 1000)
+	if err != nil {
+		t.Fatalf("Assemble: %v", err)
+	}
+	if got != nil {
+		t.Fatalf("expected nil for empty conv, got %d msgs", len(got))
+	}
+}
+
+func TestSummaryDAG_Assemble_BelowBudgetReturnsAll(t *testing.T) {
+	store := NewInMemoryStore()
+	defer store.Close()
+	summaryStore := &inMemSummaryStore{data: make(map[string][]*SummaryNode)}
+	dag := NewSummaryDAG(summaryStore, store, &mockSummaryLLM{}, DefaultDAGConfig(), &EstimateCounter{})
+
+	ctx := context.Background()
+	convID := "small"
+	msgs := []model.Message{
+		model.NewTextMessage(model.RoleUser, "hi"),
+		model.NewTextMessage(model.RoleAssistant, "hello"),
+	}
+	_ = store.SaveMessages(ctx, convID, msgs)
+
+	got, err := dag.Assemble(ctx, convID, 1000)
+	if err != nil {
+		t.Fatalf("Assemble: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("expected all 2 msgs back when below budget, got %d", len(got))
+	}
+}
+
+func TestSummaryDAG_Assemble_OverBudgetWithSummariesAndSystem(t *testing.T) {
+	// Force the trim branch by stuffing the conversation past the budget
+	// and seeding both d0 and d2 summaries — the assembled context must
+	// keep the system message, append the historical-context block, and
+	// trim recent messages by token weight.
+	store := NewInMemoryStore()
+	defer store.Close()
+	summaryStore := &inMemSummaryStore{data: make(map[string][]*SummaryNode)}
+
+	cfg := DefaultDAGConfig()
+	dag := NewSummaryDAG(summaryStore, store, &mockSummaryLLM{}, cfg, &EstimateCounter{})
+
+	ctx := context.Background()
+	convID := "trimmed"
+	bigText := strings.Repeat("alpha bravo ", 20)
+	msgs := []model.Message{model.NewTextMessage(model.RoleSystem, "you are helper")}
+	for i := 0; i < 30; i++ {
+		msgs = append(msgs, model.NewTextMessage(model.RoleUser, bigText))
+		msgs = append(msgs, model.NewTextMessage(model.RoleAssistant, bigText))
+	}
+	_ = store.SaveMessages(ctx, convID, msgs)
+
+	// Seed summary nodes that match earlier seqs so the historical
+	// context block is rendered (covers the depth>=2 + depth<=1 zones).
+	_ = summaryStore.Save(ctx, &SummaryNode{
+		ConversationID: convID, Depth: 0, Content: "early-d0", EarliestSeq: 1, LatestSeq: 5, TokenCount: 5, ExpandHint: "[Expand for details about: early]",
+	})
+	_ = summaryStore.Save(ctx, &SummaryNode{
+		ConversationID: convID, Depth: 2, Content: "early-d2", EarliestSeq: 1, LatestSeq: 5, TokenCount: 8,
+	})
+
+	got, err := dag.Assemble(ctx, convID, 200) // tight budget forces trim
+	if err != nil {
+		t.Fatalf("Assemble: %v", err)
+	}
+	if len(got) == 0 {
+		t.Fatal("expected non-empty assembled context")
+	}
+	// System must lead and contain the historical context block.
+	if got[0].Role != model.RoleSystem {
+		t.Fatalf("expected system to lead, got role=%s", got[0].Role)
+	}
+	if !strings.Contains(got[0].Content(), "[Historical context]") {
+		t.Fatalf("expected historical context block in system, got %q", got[0].Content())
+	}
+	// And the result must be smaller than the raw transcript.
+	if len(got) >= len(msgs) {
+		t.Fatalf("expected trim to drop messages, got %d (in=%d)", len(got), len(msgs))
+	}
+}
+
+func TestSummaryDAG_Assemble_OverBudgetWithoutSystem(t *testing.T) {
+	// No leading system message: exercises the "synthetic system from
+	// historical context only" branch.
+	store := NewInMemoryStore()
+	defer store.Close()
+	summaryStore := &inMemSummaryStore{data: make(map[string][]*SummaryNode)}
+
+	dag := NewSummaryDAG(summaryStore, store, &mockSummaryLLM{}, DefaultDAGConfig(), &EstimateCounter{})
+
+	ctx := context.Background()
+	convID := "no-system"
+	bigText := strings.Repeat("xyz ", 80)
+	var msgs []model.Message
+	for i := 0; i < 25; i++ {
+		msgs = append(msgs, model.NewTextMessage(model.RoleUser, bigText))
+	}
+	_ = store.SaveMessages(ctx, convID, msgs)
+
+	_ = summaryStore.Save(ctx, &SummaryNode{
+		ConversationID: convID, Depth: 0, Content: "summary-of-old", EarliestSeq: 0, LatestSeq: 10, TokenCount: 5,
+	})
+
+	got, err := dag.Assemble(ctx, convID, 150)
+	if err != nil {
+		t.Fatalf("Assemble: %v", err)
+	}
+	if len(got) == 0 {
+		t.Fatal("expected non-empty result")
+	}
+	// First message should be the synthesized system that wraps the
+	// historical context (since no system existed in the input).
+	if got[0].Role != model.RoleSystem {
+		t.Fatalf("expected synthesized system message, got role=%s", got[0].Role)
+	}
 }

--- a/sdk/history/coordinator_test.go
+++ b/sdk/history/coordinator_test.go
@@ -1,0 +1,518 @@
+package history
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"runtime"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/GizClaw/flowcraft/sdk/llm"
+	"github.com/GizClaw/flowcraft/sdk/model"
+	"github.com/GizClaw/flowcraft/sdk/workspace"
+)
+
+// newTestCoordinator wires the same dependencies NewCompacted does, but
+// keeps the helper local so tests can poke internal state directly.
+func newTestCoordinator(t *testing.T, ws workspace.Workspace) *compactor {
+	t.Helper()
+	store := NewInMemoryStore()
+	summaryStore := &inMemSummaryStore{data: make(map[string][]*SummaryNode)}
+	dag := NewSummaryDAG(summaryStore, store, &mockSummaryLLM{}, DefaultDAGConfig(), &EstimateCounter{})
+	return newCompactor(store, dag, DefaultDAGConfig(), ws, "memory")
+}
+
+// TestCoordinator_ShutdownRefusesNewWork pins down ErrClosed: once
+// Shutdown is observed, Append/Compact/Archive/Clear must reject so
+// callers cannot accidentally enqueue against a closed worker.
+func TestCoordinator_ShutdownRefusesNewWork(t *testing.T) {
+	c := newTestCoordinator(t, nil)
+
+	if err := c.Shutdown(context.Background()); err != nil {
+		t.Fatalf("Shutdown: %v", err)
+	}
+
+	cases := []struct {
+		name string
+		fn   func() error
+	}{
+		{"Append", func() error {
+			return c.Append(context.Background(), "c", []model.Message{model.NewTextMessage(model.RoleUser, "x")})
+		}},
+		{"Compact", func() error {
+			_, err := c.Compact(context.Background(), "c")
+			return err
+		}},
+		{"Archive", func() error {
+			_, err := c.Archive(context.Background(), "c")
+			// Archive returns nil when ws==nil, which short-circuits before
+			// the closed-state check; that's deliberate (no-op semantics
+			// match v0.2 behaviour). Treat nil as "not applicable" here.
+			if err == nil {
+				return ErrClosed
+			}
+			return err
+		}},
+		{"Clear", func() error { return c.Clear(context.Background(), "c") }},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if err := tc.fn(); !errors.Is(err, ErrClosed) {
+				t.Fatalf("expected ErrClosed, got %v", err)
+			}
+		})
+	}
+}
+
+// TestCoordinator_ShutdownIdempotent verifies that a second Shutdown call
+// does not panic and returns nil after the first drain completes.
+func TestCoordinator_ShutdownIdempotent(t *testing.T) {
+	c := newTestCoordinator(t, nil)
+
+	for i := 0; i < 5; i++ {
+		_ = c.Append(context.Background(), fmt.Sprintf("conv-%d", i), []model.Message{
+			model.NewTextMessage(model.RoleUser, "msg"),
+		})
+	}
+
+	if err := c.Shutdown(context.Background()); err != nil {
+		t.Fatalf("first Shutdown: %v", err)
+	}
+	if err := c.Shutdown(context.Background()); err != nil {
+		t.Fatalf("second Shutdown: %v", err)
+	}
+}
+
+// TestCoordinator_ShutdownContextDeadline verifies S3 semantics: a
+// context deadline returns ctx.Err() but does not cancel in-flight
+// workers; a second Shutdown with an unbounded ctx attaches to the same
+// drain and returns nil once everything has actually exited.
+func TestCoordinator_ShutdownContextDeadline(t *testing.T) {
+	store := NewInMemoryStore()
+	summaryStore := &inMemSummaryStore{data: make(map[string][]*SummaryNode)}
+	slow := &slowMockLLM{delay: 200 * time.Millisecond}
+	dag := NewSummaryDAG(summaryStore, store, slow, DefaultDAGConfig(), &EstimateCounter{})
+	c := newCompactor(store, dag, DefaultDAGConfig(), nil, "memory")
+
+	for i := 0; i < 5; i++ {
+		_ = c.Append(context.Background(), fmt.Sprintf("conv-%d", i), []model.Message{
+			model.NewTextMessage(model.RoleUser, "hello"),
+			model.NewTextMessage(model.RoleAssistant, "hi"),
+		})
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
+	defer cancel()
+	err := c.Shutdown(ctx)
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("expected DeadlineExceeded, got %v", err)
+	}
+
+	// Re-Shutdown with no deadline must observe the eventual drain.
+	if err := c.Shutdown(context.Background()); err != nil {
+		t.Fatalf("second Shutdown: %v", err)
+	}
+}
+
+// TestCoordinator_AppendArchiveSerialized exercises the M2 invariant: a
+// background archive runs strictly after persistAppend has released the
+// queue, never overlapping with another Append's persistAppend on the
+// same conversation. The probe is a synthetic Store that asserts no
+// concurrent SaveMessages calls.
+func TestCoordinator_AppendArchiveSerialized(t *testing.T) {
+	ws, err := workspace.NewLocalWorkspace(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	store := newConcurrencyAssertingStore(t)
+	summaryStore := &inMemSummaryStore{data: make(map[string][]*SummaryNode)}
+	cfg := DefaultDAGConfig()
+	cfg.Archive.ArchiveThreshold = 1
+	cfg.Archive.ArchiveBatchSize = 1
+	dag := NewSummaryDAG(summaryStore, store, &mockSummaryLLM{}, cfg, &EstimateCounter{})
+	c := newCompactor(store, dag, cfg, ws, "memory")
+	defer func() { _ = c.Shutdown(context.Background()) }()
+
+	for i := 0; i < 50; i++ {
+		if err := c.Append(context.Background(), "single", []model.Message{
+			model.NewTextMessage(model.RoleUser, "hello"),
+		}); err != nil {
+			t.Fatalf("Append %d: %v", i, err)
+		}
+	}
+
+	if err := c.Shutdown(context.Background()); err != nil {
+		t.Fatalf("Shutdown: %v", err)
+	}
+	if store.maxConcurrent.Load() > 1 {
+		t.Fatalf("SaveMessages observed concurrency on the same conversation: max=%d",
+			store.maxConcurrent.Load())
+	}
+}
+
+// TestCoordinator_ClearReapsWorker verifies W3: after Clear, the queue
+// for the conversation must be removed so the worker exits.
+func TestCoordinator_ClearReapsWorker(t *testing.T) {
+	c := newTestCoordinator(t, nil)
+	defer func() { _ = c.Shutdown(context.Background()) }()
+
+	if err := c.Append(context.Background(), "to-clear", []model.Message{
+		model.NewTextMessage(model.RoleUser, "x"),
+	}); err != nil {
+		t.Fatalf("Append: %v", err)
+	}
+	if err := c.Clear(context.Background(), "to-clear"); err != nil {
+		t.Fatalf("Clear: %v", err)
+	}
+
+	c.mu.Lock()
+	_, present := c.queues["to-clear"]
+	c.mu.Unlock()
+	if present {
+		t.Fatal("expected queue to be reaped after Clear")
+	}
+}
+
+// TestLoad_PreservesSystemMessage covers the bug where MaxMessages
+// trimming used to strip a leading system prompt.
+func TestLoad_PreservesSystemMessage(t *testing.T) {
+	store := NewInMemoryStore()
+	summaryStore := &inMemSummaryStore{data: make(map[string][]*SummaryNode)}
+	dag := NewSummaryDAG(summaryStore, store, &mockSummaryLLM{}, DefaultDAGConfig(), &EstimateCounter{})
+	c := newCompactor(store, dag, DefaultDAGConfig(), nil, "memory")
+	defer func() { _ = c.Shutdown(context.Background()) }()
+
+	ctx := context.Background()
+	convID := "system-preserved"
+	_ = store.SaveMessages(ctx, convID, []model.Message{
+		model.NewTextMessage(model.RoleSystem, "you are an assistant"),
+		model.NewTextMessage(model.RoleUser, "u1"),
+		model.NewTextMessage(model.RoleAssistant, "a1"),
+		model.NewTextMessage(model.RoleUser, "u2"),
+		model.NewTextMessage(model.RoleAssistant, "a2"),
+		model.NewTextMessage(model.RoleUser, "u3"),
+	})
+
+	got, err := c.Load(ctx, convID, Budget{MaxMessages: 3})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 3 {
+		t.Fatalf("expected 3 msgs, got %d", len(got))
+	}
+	if got[0].Role != model.RoleSystem {
+		t.Fatalf("expected system to lead, got role=%s", got[0].Role)
+	}
+}
+
+// TestCoordinator_LazyArchiveRecovery checks D-R3: a stranded intent file
+// from a prior crash is recovered the first time the conversation is
+// touched after restart.
+func TestCoordinator_LazyArchiveRecovery(t *testing.T) {
+	ws, err := workspace.NewLocalWorkspace(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	store := NewInMemoryStore()
+	ctx := context.Background()
+	convID := "recovers"
+
+	msgs := make([]model.Message, 30)
+	for i := range msgs {
+		msgs[i] = model.NewTextMessage(model.RoleUser, "m")
+	}
+	_ = store.SaveMessages(ctx, convID, msgs)
+
+	// First archive: completes normally so we have a manifest.
+	cfg := ArchiveConfig{ArchiveThreshold: 20, ArchiveBatchSize: 15}
+	if _, err := archiveImpl(ctx, ws, store, "memory", convID, cfg); err != nil {
+		t.Fatal(err)
+	}
+
+	// Simulate a crash mid-archive by hand-writing a "manifest_updated"
+	// intent: trim hasn't happened yet, so RecoverArchive should rerun
+	// the trim phase.
+	intent := &archiveIntent{
+		ConvID: convID, StartSeq: 100, EndSeq: 109, BatchSize: 5,
+		ArchiveFile: "messages_100_109.jsonl.gz", Phase: "manifest_updated",
+	}
+	if err := writeIntent(ctx, ws, "memory", "archive", convID, intent); err != nil {
+		t.Fatal(err)
+	}
+
+	// Construct a fresh coordinator — startup scan + lazy on-touch should
+	// both clear the intent.
+	summaryStore := &inMemSummaryStore{data: make(map[string][]*SummaryNode)}
+	dag := NewSummaryDAG(summaryStore, store, &mockSummaryLLM{}, DefaultDAGConfig(), &EstimateCounter{})
+	c := newCompactor(store, dag, DefaultDAGConfig(), ws, "memory")
+	defer func() { _ = c.Shutdown(context.Background()) }()
+
+	// Touch the conversation to force the lazy path even if startup hasn't
+	// scheduled yet.
+	if err := c.Append(ctx, convID, []model.Message{
+		model.NewTextMessage(model.RoleUser, "after-recover"),
+	}); err != nil {
+		t.Fatalf("Append: %v", err)
+	}
+	if err := c.Shutdown(context.Background()); err != nil {
+		t.Fatalf("Shutdown: %v", err)
+	}
+
+	exists, err := ws.Exists(ctx, "memory/"+convID+"/archive/intent.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if exists {
+		t.Fatal("intent.json should be cleared after recovery")
+	}
+}
+
+// TestCoordinator_ShutdownNoGoroutineLeakOnRetry pins down the
+// sync.Once + shared shutdownDone invariant: a supervisor that retries
+// Shutdown in a deadline-bounded loop must NOT accumulate one
+// drain-watcher goroutine per call. Pre-fix, every Shutdown invocation
+// spawned its own `go func() { closeWg.Wait(); close(done) }()`, so 100
+// retries against a slow drain leaked 100 goroutines until the workers
+// finally exited. Post-fix, the watcher count tops out at 1 regardless
+// of how many Shutdown attempts pile up.
+func TestCoordinator_ShutdownNoGoroutineLeakOnRetry(t *testing.T) {
+	store := NewInMemoryStore()
+	summaryStore := &inMemSummaryStore{data: make(map[string][]*SummaryNode)}
+	// Slow LLM keeps the per-conversation worker busy so all the
+	// deadline-bounded Shutdown calls below see a not-yet-drained state
+	// and exercise the "deadline returns ctx.Err but watcher is still
+	// running" branch.
+	slow := &slowMockLLM{delay: 100 * time.Millisecond}
+	dag := NewSummaryDAG(summaryStore, store, slow, DefaultDAGConfig(), &EstimateCounter{})
+	c := newCompactor(store, dag, DefaultDAGConfig(), nil, "memory")
+
+	for i := 0; i < 5; i++ {
+		_ = c.Append(context.Background(), fmt.Sprintf("conv-%d", i), []model.Message{
+			model.NewTextMessage(model.RoleUser, "hello"),
+			model.NewTextMessage(model.RoleAssistant, "hi"),
+		})
+	}
+
+	baseline := runtime.NumGoroutine()
+
+	// Hammer Shutdown with tight deadlines while the workers are still
+	// busy. Pre-fix this would spawn ~100 watcher goroutines.
+	const retries = 100
+	for i := 0; i < retries; i++ {
+		ctx, cancel := context.WithTimeout(context.Background(), time.Millisecond)
+		err := c.Shutdown(ctx)
+		cancel()
+		if err == nil {
+			// Workers happened to drain in <1ms; nothing more to test.
+			break
+		}
+		if !errors.Is(err, context.DeadlineExceeded) {
+			t.Fatalf("retry %d: expected DeadlineExceeded, got %v", i, err)
+		}
+	}
+
+	// While shutdown is still in flight, the goroutine delta from the
+	// pre-Shutdown baseline must stay tiny — at most a handful (the
+	// single watcher + GC/scavenger noise). Pre-fix this would be
+	// ≈retries.
+	growth := runtime.NumGoroutine() - baseline
+	if growth > 8 {
+		t.Fatalf("Shutdown leaked goroutines: baseline=%d after %d retries grew by %d",
+			baseline, retries, growth)
+	}
+
+	// Final unbounded Shutdown attaches to the same drain and returns nil.
+	if err := c.Shutdown(context.Background()); err != nil {
+		t.Fatalf("final Shutdown: %v", err)
+	}
+}
+
+// TestCoordinator_StateClosedAfterDrain pins the second half of the
+// state-machine cleanup: stateClosed must only be observed AFTER every
+// worker has drained, never while a worker is still inside runTask.
+// Pre-fix, the CAS lived inside the deadline-returning branch and so
+// stateClosed was effectively dead code; post-fix it is set by the
+// watcher goroutine once closeWg.Wait returns.
+func TestCoordinator_StateClosedAfterDrain(t *testing.T) {
+	store := NewInMemoryStore()
+	summaryStore := &inMemSummaryStore{data: make(map[string][]*SummaryNode)}
+	slow := &slowMockLLM{delay: 100 * time.Millisecond}
+	dag := NewSummaryDAG(summaryStore, store, slow, DefaultDAGConfig(), &EstimateCounter{})
+	c := newCompactor(store, dag, DefaultDAGConfig(), nil, "memory")
+
+	for i := 0; i < 3; i++ {
+		_ = c.Append(context.Background(), fmt.Sprintf("conv-%d", i), []model.Message{
+			model.NewTextMessage(model.RoleUser, "hello"),
+		})
+	}
+
+	// First Shutdown: deadline expires while workers are still running.
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Millisecond)
+	err := c.Shutdown(ctx)
+	cancel()
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("expected DeadlineExceeded, got %v", err)
+	}
+	if got := c.state.Load(); got != stateClosing {
+		t.Fatalf("after deadline-bounded Shutdown: expected stateClosing(%d), got %d",
+			stateClosing, got)
+	}
+
+	// Drain attaches to the same watcher; returns once stateClosed is set.
+	if err := c.Shutdown(context.Background()); err != nil {
+		t.Fatalf("drain Shutdown: %v", err)
+	}
+	if got := c.state.Load(); got != stateClosed {
+		t.Fatalf("after drained Shutdown: expected stateClosed(%d), got %d",
+			stateClosed, got)
+	}
+}
+
+// concurrencyAssertingStore wraps InMemoryStore and tracks the maximum
+// number of concurrent SaveMessages calls observed.
+type concurrencyAssertingStore struct {
+	t             *testing.T
+	inner         *InMemoryStore
+	mu            sync.Mutex
+	inflight      int
+	maxConcurrent atomicInt32
+}
+
+type atomicInt32 struct {
+	mu sync.Mutex
+	v  int32
+}
+
+func (a *atomicInt32) Set(v int32) {
+	a.mu.Lock()
+	a.v = v
+	a.mu.Unlock()
+}
+
+func (a *atomicInt32) Load() int32 {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	return a.v
+}
+
+func (a *atomicInt32) Max(v int32) {
+	a.mu.Lock()
+	if v > a.v {
+		a.v = v
+	}
+	a.mu.Unlock()
+}
+
+func newConcurrencyAssertingStore(t *testing.T) *concurrencyAssertingStore {
+	return &concurrencyAssertingStore{t: t, inner: NewInMemoryStore()}
+}
+
+func (s *concurrencyAssertingStore) SaveMessages(ctx context.Context, convID string, msgs []model.Message) error {
+	s.mu.Lock()
+	s.inflight++
+	s.maxConcurrent.Max(int32(s.inflight))
+	s.mu.Unlock()
+	defer func() {
+		s.mu.Lock()
+		s.inflight--
+		s.mu.Unlock()
+	}()
+	return s.inner.SaveMessages(ctx, convID, msgs)
+}
+
+func (s *concurrencyAssertingStore) GetMessages(ctx context.Context, convID string) ([]model.Message, error) {
+	return s.inner.GetMessages(ctx, convID)
+}
+
+func (s *concurrencyAssertingStore) DeleteMessages(ctx context.Context, convID string) error {
+	return s.inner.DeleteMessages(ctx, convID)
+}
+
+// Ensure the wrapper participates as a plain Store (no MessageAppender)
+// so persistAppend goes through the SaveMessages path the test asserts.
+var _ Store = (*concurrencyAssertingStore)(nil)
+
+// noopMessage placeholder helper used by the deadline test to avoid
+// importing llm in places that already have model.
+var _ = llm.NewTextMessage
+
+// --- Coordinator happy-path coverage for Compact / Archive ---
+
+func TestCoordinator_CompactRunsThroughQueue(t *testing.T) {
+	store := NewInMemoryStore()
+	defer store.Close()
+	summaryStore := &inMemSummaryStore{data: make(map[string][]*SummaryNode)}
+	dag := NewSummaryDAG(summaryStore, store, &mockSummaryLLM{}, DefaultDAGConfig(), &EstimateCounter{})
+	c := newCompactor(store, dag, DefaultDAGConfig(), nil, "")
+	defer func() { _ = c.Shutdown(context.Background()) }()
+
+	ctx := context.Background()
+	convID := "compact-via-coord"
+
+	// Pre-populate one stale node so Compact has actual work to do.
+	stale := &SummaryNode{ConversationID: convID, Depth: 0, Content: "leaf"}
+	_ = summaryStore.Save(ctx, stale)
+	_ = summaryStore.DeleteByConvID(ctx, convID, stale.ID)
+
+	res, err := c.Compact(ctx, convID)
+	if err != nil {
+		t.Fatalf("Compact: %v", err)
+	}
+	if res.DeletedRemoved == 0 {
+		t.Fatalf("expected DeletedRemoved > 0, got %+v", res)
+	}
+}
+
+func TestCoordinator_ArchiveNoWorkspaceShortCircuits(t *testing.T) {
+	// Without a workspace the public contract is "return empty result, no
+	// error" — exercises the early return in Archive.
+	store := NewInMemoryStore()
+	defer store.Close()
+	summaryStore := &inMemSummaryStore{data: make(map[string][]*SummaryNode)}
+	dag := NewSummaryDAG(summaryStore, store, &mockSummaryLLM{}, DefaultDAGConfig(), &EstimateCounter{})
+	c := newCompactor(store, dag, DefaultDAGConfig(), nil, "")
+	defer func() { _ = c.Shutdown(context.Background()) }()
+
+	res, err := c.Archive(context.Background(), "any")
+	if err != nil {
+		t.Fatalf("Archive without ws: %v", err)
+	}
+	if res.MessagesArchived != 0 || res.HotStartSeq != 0 {
+		t.Fatalf("expected zero result, got %+v", res)
+	}
+}
+
+func TestCoordinator_ArchiveRunsThroughQueue(t *testing.T) {
+	ws, err := workspace.NewLocalWorkspace(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	store := NewFileStore(ws, "memory")
+	summaryStore := &inMemSummaryStore{data: make(map[string][]*SummaryNode)}
+
+	cfg := DefaultDAGConfig()
+	cfg.Archive.ArchiveThreshold = 5
+	cfg.Archive.ArchiveBatchSize = 3
+	dag := NewSummaryDAG(summaryStore, store, &mockSummaryLLM{}, cfg, &EstimateCounter{})
+	c := newCompactor(store, dag, cfg, ws, "memory")
+	defer func() { _ = c.Shutdown(context.Background()) }()
+
+	ctx := context.Background()
+	convID := "archive-via-coord"
+	msgs := make([]model.Message, 10)
+	for i := range msgs {
+		msgs[i] = model.NewTextMessage(model.RoleUser, "x")
+	}
+	_ = store.SaveMessages(ctx, convID, msgs)
+
+	res, err := c.Archive(ctx, convID)
+	if err != nil {
+		t.Fatalf("Archive: %v", err)
+	}
+	if res.MessagesArchived != 3 {
+		t.Fatalf("expected 3 archived, got %d (res=%+v)", res.MessagesArchived, res)
+	}
+}

--- a/sdk/history/deprecated.go
+++ b/sdk/history/deprecated.go
@@ -1,0 +1,67 @@
+// Aggregator for v0.3.0 removals. Every symbol declared in this file is
+// scheduled for removal in v0.3.0; new code should not depend on it.
+//
+// Why this file exists at all: the v0.2.x surface exposed a handful of
+// top-level helpers (Archive, RecoverArchive, LoadArchivedMessages,
+// LoadManifest, SaveManifest, Closer.Close) that each let callers reach
+// into the implementation in incompatible ways and bypass per-
+// conversation serialization. The v0.3 redesign funnels every state-
+// mutating operation through [Coordinator]; the wrappers here exist
+// only so existing callers keep compiling for one release while they
+// migrate.
+
+package history
+
+import (
+	"context"
+
+	"github.com/GizClaw/flowcraft/sdk/model"
+	"github.com/GizClaw/flowcraft/sdk/workspace"
+)
+
+// Archive runs message archiving for one conversation.
+//
+// Deprecated: use [Coordinator.Archive] (obtained by type-asserting the
+// [History] returned by [NewCompacted] to [Coordinator]). Direct calls
+// here bypass the per-conversation worker queue, which means a
+// concurrent [History.Append] can race against the trim step inside
+// archive and silently drop messages. Will be removed in v0.3.0.
+func Archive(ctx context.Context, ws workspace.Workspace, store Store, prefix, convID string, cfg ArchiveConfig) (ArchiveResult, error) {
+	return archiveImpl(ctx, ws, store, prefix, convID, cfg)
+}
+
+// RecoverArchive checks for incomplete archive operations and completes them.
+//
+// Deprecated: [NewCompacted] now performs a startup scan and lazy per-
+// conversation recovery automatically; manual calls are no longer
+// required. Will be removed in v0.3.0.
+func RecoverArchive(ctx context.Context, ws workspace.Workspace, store Store, prefix, archivePrefix, convID string) error {
+	return recoverArchiveImpl(ctx, ws, store, prefix, archivePrefix, convID)
+}
+
+// LoadArchivedMessages reads messages from gzip archive segments.
+//
+// Deprecated: cold-segment loading is an implementation detail of the
+// history_expand tool. Use the tool registered by [RegisterTools]
+// instead of calling this directly. Will be removed in v0.3.0.
+func LoadArchivedMessages(ctx context.Context, ws workspace.Workspace, prefix, archivePrefix, convID string, startSeq, endSeq int) ([]model.Message, error) {
+	return loadArchivedMessagesImpl(ctx, ws, prefix, archivePrefix, convID, startSeq, endSeq)
+}
+
+// LoadManifest reads the archive manifest for a conversation.
+//
+// Deprecated: the manifest is an internal artefact of [Coordinator];
+// callers reasoning about archived state should query
+// [Coordinator.Archive]'s result instead. Will be removed in v0.3.0.
+func LoadManifest(ctx context.Context, ws workspace.Workspace, prefix, archivePrefix, convID string) (*ArchiveManifest, error) {
+	return loadManifestImpl(ctx, ws, prefix, archivePrefix, convID)
+}
+
+// SaveManifest writes the archive manifest atomically.
+//
+// Deprecated: writing the manifest from outside [Coordinator] cannot be
+// serialized against background archive runs and will corrupt accounting
+// under concurrency. Will be removed in v0.3.0.
+func SaveManifest(ctx context.Context, ws workspace.Workspace, prefix, archivePrefix, convID string, m *ArchiveManifest) error {
+	return saveManifestImpl(ctx, ws, prefix, archivePrefix, convID, m)
+}

--- a/sdk/history/doc.go
+++ b/sdk/history/doc.go
@@ -9,6 +9,10 @@
 //     [NewCompacted]. Pick Buffer for short sessions or tests; pick
 //     Compacted when a conversation needs to outgrow a single context
 //     window.
+//   - [Coordinator] is the lifecycle + maintenance interface that the
+//     compacted [History] additionally satisfies. It exposes Compact /
+//     Archive / Shutdown and serializes them per conversation against
+//     [History.Append] and the background ingest/archive worker.
 //   - [Store] is the persistence interface. The package ships
 //     [InMemoryStore] and [NewFileStore]; bring your own for Redis,
 //     Postgres, etc.
@@ -19,20 +23,50 @@
 // # Lifecycle
 //
 // [NewBuffer] returns a stateless History; nothing to drain. The
-// History returned by [NewCompacted] owns background ingest/archive
-// goroutines and satisfies the [Closer] sub-interface — callers that
-// own its lifetime should type-assert and Close on shutdown so async
-// work is not abandoned mid-flight. See the [Closer] godoc for the
-// canonical pattern.
+// History returned by [NewCompacted] owns one serial worker goroutine
+// per conversation plus a startup archive-recovery goroutine. Callers
+// that own its lifetime should type-assert to [Coordinator] and call
+// Shutdown(ctx) on shutdown so the queues drain cleanly:
+//
+//	hist := history.NewCompacted(store, llm, ws)
+//	if coord, ok := hist.(history.Coordinator); ok {
+//	    defer func() {
+//	        ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+//	        defer cancel()
+//	        _ = coord.Shutdown(ctx)
+//	    }()
+//	}
 //
 // # Tools
 //
 // Two graph tools surface this package to LLMs: history_expand fetches
 // the verbatim messages behind a summary node, history_compact triggers
-// a manual compaction. They are wired through [NewExpandTool] /
-// [NewCompactTool].
+// a manual compaction. Wire them through [RegisterTools] with a
+// [ToolDeps] whose Coordinator field is populated, so the tools observe
+// per-conversation serialization rather than mutating raw stores.
 //
-// # Migration note
+// # Migration to v0.3.0
+//
+// The v0.3 surface narrows on the [History] / [Coordinator] interfaces.
+// The following v0.2 entry points are now Deprecated and will be removed
+// in v0.3.0:
+//
+//   - [Closer] / [compactor].Close — replaced by
+//     [Coordinator.Shutdown] (context-aware, refuses late writes).
+//   - Top-level [Archive], [RecoverArchive], [LoadArchivedMessages],
+//     [LoadManifest], [SaveManifest] — replaced by [Coordinator] (which
+//     also auto-recovers in-flight archives at construction).
+//   - [SummaryCacheStore] — superseded by [SummaryStore] which the DAG
+//     already consumes; nothing in the package reads SummaryCacheStore.
+//
+// [ToolDeps] / [RegisterTools] stay supported in v0.3 — they now take
+// an optional Coordinator field that, when set, makes history_compact
+// route through the per-conversation queue.
+//
+// All deprecated symbols live in deprecated.go and continue to compile
+// against the v0.2 ABI for one release.
+//
+// # Naming history
 //
 // This package was renamed from sdk/memory in v0.2.0. The previous
 // Save(fullHistory) method was replaced by Append(newOnly) — the old

--- a/sdk/history/history.go
+++ b/sdk/history/history.go
@@ -2,6 +2,7 @@ package history
 
 import (
 	"context"
+	"errors"
 
 	"github.com/GizClaw/flowcraft/sdk/model"
 )
@@ -45,26 +46,60 @@ type Budget struct {
 // IsZero reports whether b carries no explicit limits.
 func (b Budget) IsZero() bool { return b.MaxTokens == 0 && b.MaxMessages == 0 }
 
-// Closer is implemented by [History] flavours that own background work
-// (goroutines, timers, file handles) and must be drained on shutdown.
+// ErrClosed is returned by [Coordinator.Shutdown]'s downstream operations
+// (Append, Compact, Archive) once Shutdown has been initiated. Callers
+// observing this should treat the History as drained and avoid further
+// writes; reading via Load remains valid as long as the underlying Store
+// is still usable.
+var ErrClosed = errors.New("history: coordinator closed")
+
+// Coordinator is the lifecycle + maintenance interface that the [History]
+// returned by [NewCompacted] additionally satisfies. All maintenance
+// operations (compact, archive, shutdown) are serialized per conversation
+// alongside [History.Append], so callers no longer need to coordinate
+// locks themselves.
 //
-// [NewBuffer] returns a History that does NOT need draining; its return
-// value will not satisfy this interface. [NewCompacted] does — its
-// async ingest/archive goroutines outlive each Append call. Production
-// callers should always type-assert and Close when they own the
-// History's lifetime:
+// Production callers typically grab it once at construction:
 //
 //	hist := history.NewCompacted(store, llm, ws)
-//	defer func() {
-//	    if c, ok := hist.(history.Closer); ok {
-//	        c.Close()
-//	    }
-//	}()
+//	coord, _ := hist.(history.Coordinator)
+//	defer func() { _ = coord.Shutdown(context.Background()) }()
 //
-// Close blocks until all in-flight background work for already-accepted
-// Appends finishes; it does NOT cancel them. Implementations are
-// expected to make Close idempotent and safe to call from any
-// goroutine.
+// Migration: the previous [Closer] sub-interface is retained for one
+// release behind a Deprecated marker; new code should prefer Coordinator
+// because it offers context-aware shutdown plus first-class maintenance
+// entry points that internally share the per-conversation queue used by
+// background ingest/archive.
+type Coordinator interface {
+	// Compact runs DAG compact for one conversation. Serialized against
+	// concurrent Append/Archive on the same conversationID.
+	Compact(ctx context.Context, conversationID string) (CompactResult, error)
+	// Archive runs message archiving for one conversation. Serialized
+	// against concurrent Append/Compact on the same conversationID.
+	Archive(ctx context.Context, conversationID string) (ArchiveResult, error)
+	// Shutdown stops accepting new work and waits for in-flight per-
+	// conversation queues to drain. After Shutdown is observed,
+	// Append/Compact/Archive return [ErrClosed]; subsequent Shutdown
+	// calls block on the same drain and return its result.
+	//
+	// Shutdown is the canonical "S3" semantics: it does NOT cancel the
+	// background workers when ctx expires. A ctx-deadline return value
+	// signals "drain in progress, partial work may still finalize after
+	// this returns"; the Coordinator stays in the closing/closed state
+	// regardless. To observe the eventual drain after a deadline-bounded
+	// Shutdown, call Shutdown again with a longer (or unbounded) ctx —
+	// the second call falls onto the same drain and returns nil once
+	// all workers have exited.
+	Shutdown(ctx context.Context) error
+}
+
+// Closer is the legacy lifecycle interface that the [History] returned by
+// [NewCompacted] still satisfies for one release.
+//
+// Deprecated: use [Coordinator] (and its context-aware Shutdown) instead.
+// Closer.Close has no way to bound its wait, no way to refuse late writes,
+// and no way to surface a drain error to the caller. It will be removed
+// in v0.3.0.
 type Closer interface {
 	Close()
 }

--- a/sdk/history/history_test.go
+++ b/sdk/history/history_test.go
@@ -162,3 +162,15 @@ func TestInMemoryStore_ConcurrentGetMessages(t *testing.T) {
 	}
 	wg.Wait()
 }
+
+func TestBudget_IsZero(t *testing.T) {
+	if !(Budget{}).IsZero() {
+		t.Fatal("zero Budget should report IsZero")
+	}
+	if (Budget{MaxTokens: 1}).IsZero() {
+		t.Fatal("MaxTokens=1 must not be zero")
+	}
+	if (Budget{MaxMessages: 1}).IsZero() {
+		t.Fatal("MaxMessages=1 must not be zero")
+	}
+}

--- a/sdk/history/store.go
+++ b/sdk/history/store.go
@@ -42,7 +42,52 @@ type RangeReader interface {
 }
 
 // SummaryCacheStore is an optional interface that Store implementations
-// can satisfy to persist summary caches alongside messages.
+// can satisfy to persist a single "current summary" string alongside
+// messages.
+//
+// Deprecated: superseded by [SummaryStore], which the [SummaryDAG]
+// already requires. Nothing inside the history package consumes this
+// interface any more — the [InMemoryStore] / [FileStore] implementations
+// remain only so downstream Stores that already satisfied it keep
+// compiling. Will be removed in v0.3.0.
+//
+// # Migration
+//
+// Most callers wired SummaryCacheStore in v0.1 to enable a hand-rolled
+// "buffer + single summary" history strategy. The supported v0.2+
+// equivalent is [NewCompacted], which manages a multi-level summary DAG
+// and assembles "highest-depth summary + recent tail" into the supplied
+// token budget automatically — no SummaryCacheStore plumbing required:
+//
+//	hist := history.NewCompacted(store, summaryLLM, ws,
+//	    history.WithTokenBudget(8000),
+//	)
+//	msgs, _ := hist.Load(ctx, convID, history.Budget{})
+//
+// If the single-summary semantics are still desired (for example
+// because the downstream service has its own summarizer and only needs
+// a place to persist the result), the same shape can be expressed in
+// ~5 lines on top of [SummaryStore]:
+//
+//	// Save (overwrite the single summary):
+//	_ = ss.Rewrite(ctx, convID, []*history.SummaryNode{{
+//	    ID:             history.NewSummaryNodeID(),
+//	    ConversationID: convID,
+//	    Depth:          0,
+//	    Content:        text,
+//	    EarliestSeq:    0,
+//	    LatestSeq:      msgCount - 1,
+//	    CreatedAt:      time.Now(),
+//	}})
+//
+//	// Load:
+//	depth0 := 0
+//	nodes, _ := ss.List(ctx, convID, history.SummaryListOptions{Depth: &depth0})
+//	// nodes[0].Content is the summary; nodes[0].LatestSeq+1 is msgCount.
+//
+// [SummaryStore.Rewrite] is the exact primitive SummaryCacheStore.SaveSummary
+// implied (atomic single-record replacement); the only thing v0.3 drops is
+// the dedicated interface name.
 type SummaryCacheStore interface {
 	GetSummary(ctx context.Context, conversationID string) (summary string, msgCount int, err error)
 	SaveSummary(ctx context.Context, conversationID, summary string, msgCount int) error

--- a/sdk/history/store_test.go
+++ b/sdk/history/store_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/GizClaw/flowcraft/sdk/model"
 	"github.com/GizClaw/flowcraft/sdk/workspace"
@@ -378,4 +379,165 @@ func TestFileStore_DeleteAndReuse(t *testing.T) {
 	if len(loaded) != 1 || loaded[0].Content() != "new message" {
 		t.Fatalf("expected 'new message', got %v", loaded)
 	}
+}
+
+// --- FileStore: deprecated SummaryCacheStore surface ---
+
+func TestFileStore_SaveAndGetSummary(t *testing.T) {
+	ws := workspace.NewMemWorkspace()
+	store := NewFileStore(ws, "memory")
+	ctx := context.Background()
+
+	if err := store.SaveSummary(ctx, "conv-sum", "the summary text", 42); err != nil {
+		t.Fatalf("SaveSummary: %v", err)
+	}
+
+	text, count, err := store.GetSummary(ctx, "conv-sum")
+	if err != nil {
+		t.Fatalf("GetSummary: %v", err)
+	}
+	if text != "the summary text" {
+		t.Fatalf("text mismatch: got %q", text)
+	}
+	if count != 42 {
+		t.Fatalf("count mismatch: got %d", count)
+	}
+}
+
+func TestFileStore_GetSummary_Missing(t *testing.T) {
+	ws := workspace.NewMemWorkspace()
+	store := NewFileStore(ws, "memory")
+	ctx := context.Background()
+
+	text, count, err := store.GetSummary(ctx, "no-such-conv")
+	if err != nil {
+		t.Fatalf("GetSummary on missing should be (\"\",0,nil), got err=%v", err)
+	}
+	if text != "" || count != 0 {
+		t.Fatalf("expected zero values for missing conv, got %q,%d", text, count)
+	}
+}
+
+func TestFileStore_SaveSummary_OverwritesPrevious(t *testing.T) {
+	ws := workspace.NewMemWorkspace()
+	store := NewFileStore(ws, "memory")
+	ctx := context.Background()
+
+	if err := store.SaveSummary(ctx, "c", "first", 1); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.SaveSummary(ctx, "c", "second", 2); err != nil {
+		t.Fatal(err)
+	}
+	text, count, err := store.GetSummary(ctx, "c")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if text != "second" || count != 2 {
+		t.Fatalf("expected overwrite to win, got %q,%d", text, count)
+	}
+}
+
+// --- InMemoryStore: options + lifecycle ---
+
+func TestInMemoryStore_LenReflectsSaves(t *testing.T) {
+	store := NewInMemoryStore()
+	defer store.Close()
+	ctx := context.Background()
+
+	if store.Len() != 0 {
+		t.Fatalf("expected fresh store empty, got %d", store.Len())
+	}
+	for i, id := range []string{"a", "b", "c"} {
+		if err := store.SaveMessages(ctx, id, []model.Message{
+			model.NewTextMessage(model.RoleUser, "x"),
+		}); err != nil {
+			t.Fatalf("SaveMessages %d: %v", i, err)
+		}
+	}
+	if got := store.Len(); got != 3 {
+		t.Fatalf("expected 3 conversations, got %d", got)
+	}
+
+	if err := store.DeleteMessages(ctx, "a"); err != nil {
+		t.Fatal(err)
+	}
+	if got := store.Len(); got != 2 {
+		t.Fatalf("expected 2 after delete, got %d", got)
+	}
+}
+
+func TestInMemoryStore_WithMaxConversations_EvictsOldest(t *testing.T) {
+	// Cap at 2 conversations so the third Save triggers evictOldest().
+	store := NewInMemoryStore(WithMaxConversations(2))
+	defer store.Close()
+	ctx := context.Background()
+
+	_ = store.SaveMessages(ctx, "first", []model.Message{model.NewTextMessage(model.RoleUser, "1")})
+	// Force "first" to be the strictly older entry by stamping it earlier.
+	store.mu.Lock()
+	store.data["first"].lastAccess = time.Now().Add(-time.Hour)
+	store.mu.Unlock()
+	_ = store.SaveMessages(ctx, "second", []model.Message{model.NewTextMessage(model.RoleUser, "2")})
+	_ = store.SaveMessages(ctx, "third", []model.Message{model.NewTextMessage(model.RoleUser, "3")})
+
+	if got := store.Len(); got != 2 {
+		t.Fatalf("expected 2 after eviction, got %d", got)
+	}
+	got, _ := store.GetMessages(ctx, "first")
+	if len(got) != 0 {
+		t.Fatal("expected oldest 'first' to be evicted")
+	}
+}
+
+func TestInMemoryStore_EvictExpired(t *testing.T) {
+	// Use the smallest TTL accepted (>0) so we control eviction by hand
+	// rather than waiting for the cleanup goroutine — the latter would
+	// flake on slow CI.
+	store := NewInMemoryStore(WithTTL(time.Second))
+	defer store.Close()
+	ctx := context.Background()
+
+	_ = store.SaveMessages(ctx, "stale", []model.Message{model.NewTextMessage(model.RoleUser, "x")})
+	_ = store.SaveMessages(ctx, "fresh", []model.Message{model.NewTextMessage(model.RoleUser, "y")})
+
+	store.mu.Lock()
+	// Push "stale" past the cutoff; "fresh" stays current.
+	store.data["stale"].lastAccess = time.Now().Add(-2 * time.Second)
+	store.mu.Unlock()
+
+	store.evictExpired()
+
+	if _, ok := func() (any, bool) {
+		store.mu.RLock()
+		defer store.mu.RUnlock()
+		v, ok := store.data["stale"]
+		return v, ok
+	}(); ok {
+		t.Fatal("expected stale conversation to be evicted")
+	}
+	if got := store.Len(); got != 1 {
+		t.Fatalf("expected 1 fresh conversation, got %d", got)
+	}
+}
+
+func TestInMemoryStore_OptionRejectsNonPositive(t *testing.T) {
+	// WithMaxConversations(0) and WithTTL(0) are documented no-ops; the
+	// defaults must survive.
+	store := NewInMemoryStore(WithMaxConversations(0), WithTTL(0))
+	defer store.Close()
+
+	if store.maxConversations != defaultMaxConversations {
+		t.Fatalf("expected default max, got %d", store.maxConversations)
+	}
+	if store.ttl != defaultConversationTTL {
+		t.Fatalf("expected default ttl, got %s", store.ttl)
+	}
+}
+
+func TestInMemoryStore_CloseIdempotent(t *testing.T) {
+	// Two consecutive Close() calls must not panic on a closed channel.
+	store := NewInMemoryStore()
+	store.Close()
+	store.Close()
 }

--- a/sdk/history/summary_store_test.go
+++ b/sdk/history/summary_store_test.go
@@ -2,6 +2,7 @@ package history
 
 import (
 	"context"
+	"encoding/json"
 	"testing"
 
 	"github.com/GizClaw/flowcraft/sdk/workspace"
@@ -235,6 +236,80 @@ func TestFileSummaryStore_CacheUpdatedOnDelete(t *testing.T) {
 	nodes, _ := store.List(ctx, "c", SummaryListOptions{})
 	if len(nodes) != 0 {
 		t.Fatalf("expected 0 after delete, got %d", len(nodes))
+	}
+}
+
+// --- WithSummaryStoreCapacity + LRU eviction ---
+
+func TestWithSummaryStoreCapacity_OverridesDefault(t *testing.T) {
+	ws := workspace.NewMemWorkspace()
+	store := NewFileSummaryStore(ws, "mem", WithSummaryStoreCapacity(3))
+	if store.capacity != 3 {
+		t.Fatalf("expected capacity=3, got %d", store.capacity)
+	}
+
+	// Non-positive capacity must be rejected (no-op).
+	store2 := NewFileSummaryStore(ws, "mem", WithSummaryStoreCapacity(0), WithSummaryStoreCapacity(-1))
+	if store2.capacity != defaultSummaryStoreCapacity {
+		t.Fatalf("expected default capacity, got %d", store2.capacity)
+	}
+}
+
+func TestFileSummaryStore_LRUEviction(t *testing.T) {
+	ws := workspace.NewMemWorkspace()
+	store := NewFileSummaryStore(ws, "mem", WithSummaryStoreCapacity(2))
+	ctx := context.Background()
+
+	// Touch three different conversations; the LRU cap is 2 so the
+	// least-recently-used entry must be evicted.
+	for _, id := range []string{"a", "b", "c"} {
+		_ = store.Save(ctx, &SummaryNode{ConversationID: id, Depth: 0, Content: "x"})
+	}
+
+	store.mu.Lock()
+	got := store.order.Len()
+	_, hasA := store.entries["a"]
+	store.mu.Unlock()
+
+	if got != 2 {
+		t.Fatalf("expected order list len 2 after capacity bound, got %d", got)
+	}
+	if hasA {
+		t.Fatal("expected 'a' to be evicted as LRU")
+	}
+}
+
+// --- readFromDisk ---
+
+func TestFileSummaryStore_ReadFromDisk_SkipsMalformedLines(t *testing.T) {
+	ws := workspace.NewMemWorkspace()
+	store := NewFileSummaryStore(ws, "mem")
+	ctx := context.Background()
+
+	// Hand-craft a summaries.jsonl with one good record, one blank line,
+	// and one malformed line. readFromDisk must keep the good record and
+	// skip the rest without erroring.
+	good, _ := json.Marshal(&SummaryNode{
+		ID: "n1", ConversationID: "c", Depth: 0, Content: "good", EarliestSeq: 0, LatestSeq: 4,
+	})
+	payload := append(good, '\n')
+	payload = append(payload, '\n')
+	payload = append(payload, []byte("{not-json\n")...)
+	payload = append(payload, []byte(`{"id":"n2","conversation_id":"c","depth":0,"content":"second","earliest_seq":5,"latest_seq":9}`+"\n")...)
+
+	if err := ws.Write(ctx, "mem/c/summaries.jsonl", payload); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := store.readFromDisk(ctx, "c")
+	if err != nil {
+		t.Fatalf("readFromDisk: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("expected 2 nodes (skip blank+malformed), got %d", len(got))
+	}
+	if got[0].Content != "good" || got[1].Content != "second" {
+		t.Fatalf("unexpected content order: %+v", got)
 	}
 }
 

--- a/sdk/history/token_test.go
+++ b/sdk/history/token_test.go
@@ -1,0 +1,80 @@
+package history
+
+import (
+	"testing"
+
+	"github.com/GizClaw/flowcraft/sdk/model"
+)
+
+func TestTiktokenCounter_KnownModel(t *testing.T) {
+	c, err := NewTiktokenCounter("gpt-4o")
+	if err != nil {
+		t.Fatalf("NewTiktokenCounter: %v", err)
+	}
+	if got := c.Count("hello world"); got <= 0 {
+		t.Fatalf("expected positive token count, got %d", got)
+	}
+}
+
+func TestTiktokenCounter_UnknownModelFallsBack(t *testing.T) {
+	// An unknown model name should fall back to cl100k_base rather than
+	// fail outright; this is the documented contract.
+	c, err := NewTiktokenCounter("definitely-not-a-real-model-xyz")
+	if err != nil {
+		t.Fatalf("expected fallback to cl100k_base, got error: %v", err)
+	}
+	if c == nil || c.tk == nil {
+		t.Fatal("expected non-nil counter after fallback")
+	}
+	if c.Count("hello") <= 0 {
+		t.Fatal("fallback counter should still tokenize")
+	}
+}
+
+func TestTiktokenCounterFromEncoding_Valid(t *testing.T) {
+	c, err := NewTiktokenCounterFromEncoding("cl100k_base")
+	if err != nil {
+		t.Fatalf("NewTiktokenCounterFromEncoding: %v", err)
+	}
+	if c.Count("the quick brown fox") <= 0 {
+		t.Fatal("expected positive token count")
+	}
+}
+
+func TestTiktokenCounterFromEncoding_Invalid(t *testing.T) {
+	_, err := NewTiktokenCounterFromEncoding("not_a_real_encoding")
+	if err == nil {
+		t.Fatal("expected error for unknown encoding")
+	}
+}
+
+func TestTiktokenCounter_CountMessages_AllPartTypes(t *testing.T) {
+	c, err := NewTiktokenCounter("gpt-4o")
+	if err != nil {
+		t.Fatal(err)
+	}
+	msgs := []model.Message{
+		model.NewTextMessage(model.RoleUser, "hello"),
+		{
+			Role: model.RoleAssistant,
+			Parts: []model.Part{
+				{Type: model.PartText, Text: "ok"},
+				{Type: model.PartToolCall, ToolCall: &model.ToolCall{ID: "1", Name: "search", Arguments: `{"q":"x"}`}},
+			},
+		},
+		{
+			Role: model.RoleTool,
+			Parts: []model.Part{
+				{Type: model.PartToolResult, ToolResult: &model.ToolResult{ToolCallID: "1", Content: "found"}},
+			},
+		},
+	}
+	got := c.CountMessages(msgs)
+	if got <= 0 {
+		t.Fatalf("expected positive token count across all part types, got %d", got)
+	}
+	// The empty input should still account for the "+3" priming overhead.
+	if c.CountMessages(nil) != 3 {
+		t.Fatalf("expected priming overhead of 3 for empty input, got %d", c.CountMessages(nil))
+	}
+}

--- a/sdk/history/tools.go
+++ b/sdk/history/tools.go
@@ -11,8 +11,34 @@ import (
 	"github.com/GizClaw/flowcraft/sdk/workspace"
 )
 
-// ToolDeps holds dependencies for history tools.
+// ToolDeps bundles everything the history_expand / history_compact
+// tools need at registration time. Pass it to [RegisterTools].
+//
+// Coordinator is optional but strongly recommended: when set,
+// history_compact routes Compact / Archive through the per-conversation
+// worker queue, matching the serialization guarantees that
+// [Coordinator] offers to first-class callers. When Coordinator is nil
+// the tool falls back to constructing an ad-hoc [SummaryDAG] and
+// calling [archiveImpl] directly, which can race a concurrent
+// [History.Append] on the same conversation. New code that already has
+// a [History] from [NewCompacted] should always wire it via:
+//
+//	coord, _ := hist.(history.Coordinator)
+//	history.RegisterTools(registry, history.ToolDeps{
+//	    Coordinator:  coord,
+//	    SummaryStore: summaryStore,
+//	    MessageStore: msgStore,
+//	    Workspace:    ws,
+//	    Prefix:       prefix,
+//	    Config:       cfg,
+//	})
 type ToolDeps struct {
+	// Coordinator, when non-nil, makes history_compact go through the
+	// per-conversation queue. Leaving it nil preserves the v0.2 "direct
+	// store mutation" behaviour and keeps the struct usable from code
+	// that only has raw stores.
+	Coordinator Coordinator
+
 	SummaryStore SummaryStore
 	MessageStore Store
 	Workspace    workspace.Workspace
@@ -20,10 +46,13 @@ type ToolDeps struct {
 	Config       DAGConfig
 }
 
-// RegisterTools registers history_expand and history_compact. The
-// summary index is auto-injected into the LLM system prompt via the
-// workflow.VarSummaryIndex board variable, so a separate
-// history_search tool is not needed.
+// RegisterTools registers history_expand and history_compact against the
+// supplied [tool.Registry]. The summary index is auto-injected into the
+// LLM system prompt via the workflow.VarSummaryIndex board variable, so
+// a separate history_search tool is not needed.
+//
+// See [ToolDeps] for the recommended way to construct deps from an
+// existing [History] / [Coordinator] pair.
 func RegisterTools(registry *tool.Registry, deps ToolDeps) {
 	registry.Register(newHistoryExpandTool(deps))
 	registry.RegisterWithScope(newHistoryCompactTool(deps), tool.ScopePlatform)
@@ -83,7 +112,6 @@ func (t *historyExpandTool) Execute(ctx context.Context, arguments string) (stri
 		return formatChildSummaries(children), nil
 	}
 
-	// Leaf node: return original messages.
 	return t.expandLeaf(ctx, convID, node, args.MaxMessages)
 }
 
@@ -91,29 +119,26 @@ func (t *historyExpandTool) expandLeaf(ctx context.Context, convID string, node 
 	startSeq := node.EarliestSeq
 	endSeq := node.LatestSeq + 1
 
-	// Check archive manifest for Hot/Cold boundary.
 	if t.deps.Workspace != nil {
 		archivePrefix := t.deps.Config.Archive.ArchivePrefix
 		if archivePrefix == "" {
 			archivePrefix = "archive"
 		}
-		manifest, err := LoadManifest(ctx, t.deps.Workspace, t.deps.Prefix, archivePrefix, convID)
+		manifest, err := loadManifestImpl(ctx, t.deps.Workspace, t.deps.Prefix, archivePrefix, convID)
 		if err == nil && manifest.HotStartSeq > 0 {
 			var allMsgs []model.Message
 
-			// Cold part.
 			if startSeq < manifest.HotStartSeq {
 				coldEnd := endSeq
 				if coldEnd > manifest.HotStartSeq {
 					coldEnd = manifest.HotStartSeq
 				}
-				coldMsgs, err := LoadArchivedMessages(ctx, t.deps.Workspace, t.deps.Prefix, archivePrefix, convID, startSeq, coldEnd-1)
+				coldMsgs, err := loadArchivedMessagesImpl(ctx, t.deps.Workspace, t.deps.Prefix, archivePrefix, convID, startSeq, coldEnd-1)
 				if err == nil {
 					allMsgs = append(allMsgs, coldMsgs...)
 				}
 			}
 
-			// Hot part.
 			if endSeq > manifest.HotStartSeq {
 				hotStart := startSeq - manifest.HotStartSeq
 				if hotStart < 0 {
@@ -137,7 +162,6 @@ func (t *historyExpandTool) expandLeaf(ctx context.Context, convID string, node 
 		}
 	}
 
-	// No archive or fallback: use RangeReader directly.
 	if rr, ok := t.deps.MessageStore.(RangeReader); ok {
 		msgs, err := rr.GetMessageRange(ctx, convID, startSeq, endSeq)
 		if err == nil {
@@ -148,7 +172,6 @@ func (t *historyExpandTool) expandLeaf(ctx context.Context, convID string, node 
 		}
 	}
 
-	// Final fallback: get all messages and slice.
 	msgs, err := t.deps.MessageStore.GetMessages(ctx, convID)
 	if err != nil {
 		return "", fmt.Errorf("history_expand: get messages: %w", err)
@@ -227,8 +250,33 @@ func (t *historyCompactTool) Execute(ctx context.Context, arguments string) (str
 	}
 	var res resultJSON
 
-	// We need a SummaryDAG reference. The tool deps don't directly hold it.
-	// Instead, we operate through the store interfaces.
+	// Preferred path: a Coordinator is wired, every operation observes
+	// per-conversation serialization, and we never reach into the raw
+	// stores from the tool.
+	if t.deps.Coordinator != nil {
+		if doCompact {
+			cr, err := t.deps.Coordinator.Compact(ctx, args.ConversationID)
+			if err != nil {
+				return "", fmt.Errorf("history_compact: compact: %w", err)
+			}
+			res.CompactResult = &cr
+		}
+		if doArchive {
+			ar, err := t.deps.Coordinator.Archive(ctx, args.ConversationID)
+			if err != nil {
+				return "", fmt.Errorf("history_compact: archive: %w", err)
+			}
+			res.ArchiveResult = &ar
+		}
+		data, _ := json.Marshal(res)
+		return string(data), nil
+	}
+
+	// Fallback path (no Coordinator wired): we go straight to the
+	// stores, which means a concurrent Append on the same conversation
+	// can race the trim step inside archive. Callers that own a
+	// [History] from [NewCompacted] should always populate
+	// [ToolDeps.Coordinator] to avoid this branch.
 	cfg := t.deps.Config
 	if doCompact && t.deps.SummaryStore != nil {
 		dag := &SummaryDAG{
@@ -241,9 +289,8 @@ func (t *historyCompactTool) Execute(ctx context.Context, arguments string) (str
 		}
 		res.CompactResult = &cr
 	}
-
 	if doArchive && t.deps.Workspace != nil && t.deps.MessageStore != nil {
-		ar, err := Archive(ctx, t.deps.Workspace, t.deps.MessageStore, t.deps.Prefix, args.ConversationID, cfg.Archive)
+		ar, err := archiveImpl(ctx, t.deps.Workspace, t.deps.MessageStore, t.deps.Prefix, args.ConversationID, cfg.Archive)
 		if err != nil {
 			return "", fmt.Errorf("history_compact: archive: %w", err)
 		}

--- a/sdk/history/tools_test.go
+++ b/sdk/history/tools_test.go
@@ -2,10 +2,13 @@ package history
 
 import (
 	"context"
+	"encoding/json"
 	"strings"
 	"testing"
 
 	"github.com/GizClaw/flowcraft/sdk/model"
+	"github.com/GizClaw/flowcraft/sdk/tool"
+	"github.com/GizClaw/flowcraft/sdk/workspace"
 )
 
 func TestMemoryExpandTool_NoConversationID(t *testing.T) {
@@ -50,4 +53,255 @@ func TestFileStore_GetMessageRange(t *testing.T) {
 	// InMemoryStore doesn't implement RangeReader, so test FileStore.
 	// Just verify the interface is defined.
 	var _ RangeReader = (*FileStore)(nil)
+}
+
+// --- RegisterTools / Definition ---
+
+func TestRegisterTools_AddsBothToolsWithCorrectScopes(t *testing.T) {
+	registry := tool.NewRegistry()
+	RegisterTools(registry, ToolDeps{})
+
+	expand, ok := registry.Get("history_expand")
+	if !ok {
+		t.Fatal("expected history_expand to be registered")
+	}
+	if registry.ScopeOf("history_expand") != tool.ScopeAgent {
+		t.Fatalf("history_expand scope = %s, want agent", registry.ScopeOf("history_expand"))
+	}
+	if def := expand.Definition(); def.Name != "history_expand" {
+		t.Fatalf("history_expand definition Name = %q", def.Name)
+	}
+
+	compact, ok := registry.Get("history_compact")
+	if !ok {
+		t.Fatal("expected history_compact to be registered")
+	}
+	if registry.ScopeOf("history_compact") != tool.ScopePlatform {
+		t.Fatalf("history_compact scope = %s, want platform", registry.ScopeOf("history_compact"))
+	}
+	if def := compact.Definition(); def.Name != "history_compact" {
+		t.Fatalf("history_compact definition Name = %q", def.Name)
+	}
+}
+
+func TestHistoryExpandTool_Definition_HasRequiredField(t *testing.T) {
+	def := newHistoryExpandTool(ToolDeps{}).Definition()
+	if def.Name != "history_expand" {
+		t.Fatalf("name = %q", def.Name)
+	}
+	if def.Description == "" {
+		t.Fatal("expected non-empty description")
+	}
+}
+
+// --- history_expand.Execute ---
+
+func TestHistoryExpandTool_Execute_BadJSON(t *testing.T) {
+	tl := newHistoryExpandTool(ToolDeps{})
+	_, err := tl.Execute(context.Background(), "{not json")
+	if err == nil || !strings.Contains(err.Error(), "parse args") {
+		t.Fatalf("expected parse-args error, got %v", err)
+	}
+}
+
+func TestHistoryExpandTool_Execute_NoSummaryStore(t *testing.T) {
+	tl := newHistoryExpandTool(ToolDeps{})
+	ctx := WithConversationID(context.Background(), "c1")
+	_, err := tl.Execute(ctx, `{"summary_id":"x"}`)
+	if err == nil || !strings.Contains(err.Error(), "summary store not available") {
+		t.Fatalf("expected summary-store error, got %v", err)
+	}
+}
+
+func TestHistoryExpandTool_Execute_ExpandsLeafFromMessages(t *testing.T) {
+	ws := workspace.NewMemWorkspace()
+	fileStore := NewFileStore(ws, "memory")
+	summaryStore := &inMemSummaryStore{data: make(map[string][]*SummaryNode)}
+
+	ctx := WithConversationID(context.Background(), "convX")
+	for _, text := range []string{"first", "second", "third"} {
+		existing, _ := fileStore.GetMessages(ctx, "convX")
+		_ = fileStore.SaveMessages(ctx, "convX", append(existing,
+			model.NewTextMessage(model.RoleUser, text),
+		))
+	}
+
+	leaf := &SummaryNode{
+		ConversationID: "convX",
+		Depth:          0,
+		Content:        "leaf",
+		EarliestSeq:    0,
+		LatestSeq:      2,
+	}
+	_ = summaryStore.Save(ctx, leaf)
+
+	tl := newHistoryExpandTool(ToolDeps{
+		SummaryStore: summaryStore,
+		MessageStore: fileStore, // FileStore implements RangeReader
+		Workspace:    ws,
+		Prefix:       "memory",
+		Config:       DefaultDAGConfig(),
+	})
+
+	out, err := tl.Execute(ctx, `{"summary_id":"`+leaf.ID+`","max_messages":10}`)
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if !strings.Contains(out, "first") || !strings.Contains(out, "third") {
+		t.Fatalf("expected expanded message text, got %q", out)
+	}
+}
+
+func TestHistoryExpandTool_Execute_NonLeafFormatsChildren(t *testing.T) {
+	summaryStore := &inMemSummaryStore{data: make(map[string][]*SummaryNode)}
+	ctx := WithConversationID(context.Background(), "convY")
+
+	// Two depth-0 leaves and one depth-1 node referencing them.
+	leafA := &SummaryNode{ConversationID: "convY", Depth: 0, Content: "child-a", EarliestSeq: 0, LatestSeq: 4, ExpandHint: "[Expand for details about: a]"}
+	leafB := &SummaryNode{ConversationID: "convY", Depth: 0, Content: "child-b", EarliestSeq: 5, LatestSeq: 9}
+	_ = summaryStore.Save(ctx, leafA)
+	_ = summaryStore.Save(ctx, leafB)
+
+	parent := &SummaryNode{
+		ConversationID: "convY",
+		Depth:          1,
+		Content:        "parent",
+		SourceIDs:      []string{leafA.ID, leafB.ID, "missing-id"},
+		EarliestSeq:    0,
+		LatestSeq:      9,
+	}
+	_ = summaryStore.Save(ctx, parent)
+
+	tl := newHistoryExpandTool(ToolDeps{SummaryStore: summaryStore})
+	out, err := tl.Execute(ctx, `{"summary_id":"`+parent.ID+`"}`)
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if !strings.Contains(out, "child-a") || !strings.Contains(out, "child-b") {
+		t.Fatalf("expected both children rendered, got %q", out)
+	}
+	if !strings.Contains(out, "[Expand for details about: a]") {
+		t.Fatalf("expected ExpandHint to be rendered, got %q", out)
+	}
+}
+
+func TestHistoryExpandTool_Execute_GetByConvIDError(t *testing.T) {
+	summaryStore := &inMemSummaryStore{data: make(map[string][]*SummaryNode)}
+	ctx := WithConversationID(context.Background(), "convZ")
+
+	tl := newHistoryExpandTool(ToolDeps{SummaryStore: summaryStore})
+	_, err := tl.Execute(ctx, `{"summary_id":"missing"}`)
+	if err == nil || !strings.Contains(err.Error(), "history_expand") {
+		t.Fatalf("expected wrapped not-found error, got %v", err)
+	}
+}
+
+func TestFormatChildSummaries_Format(t *testing.T) {
+	out := formatChildSummaries([]*SummaryNode{
+		{Depth: 0, EarliestSeq: 0, LatestSeq: 4, Content: "child0", ExpandHint: "[Expand for details about: a]"},
+		{Depth: 1, EarliestSeq: 5, LatestSeq: 9, Content: "child1"},
+	})
+	if !strings.Contains(out, "[d0 seq 0-4] child0") {
+		t.Fatalf("missing depth/seq header: %q", out)
+	}
+	if !strings.Contains(out, "[Expand for details about: a]") {
+		t.Fatalf("missing expand hint: %q", out)
+	}
+	if !strings.Contains(out, "[d1 seq 5-9] child1") {
+		t.Fatalf("missing second child: %q", out)
+	}
+	if formatChildSummaries(nil) != "" {
+		t.Fatal("expected empty string for nil input")
+	}
+}
+
+// --- history_compact.Execute fallback path (no Coordinator wired) ---
+
+func TestHistoryCompactTool_Execute_BadJSON(t *testing.T) {
+	tl := newHistoryCompactTool(ToolDeps{})
+	_, err := tl.Execute(context.Background(), "{nope")
+	if err == nil || !strings.Contains(err.Error(), "parse args") {
+		t.Fatalf("expected parse-args error, got %v", err)
+	}
+}
+
+func TestHistoryCompactTool_Execute_FallbackPathCompactOnly(t *testing.T) {
+	// No Coordinator + no Workspace → only the compact branch runs; the
+	// archive branch is silently skipped because deps.Workspace is nil.
+	summaryStore := &inMemSummaryStore{data: make(map[string][]*SummaryNode)}
+	ctx := context.Background()
+	_ = summaryStore.Save(ctx, &SummaryNode{ConversationID: "c", Depth: 0, Content: "leaf", EarliestSeq: 0, LatestSeq: 5})
+
+	tl := newHistoryCompactTool(ToolDeps{
+		SummaryStore: summaryStore,
+		Config:       DefaultDAGConfig(),
+	})
+	out, err := tl.Execute(ctx, `{"conversation_id":"c"}`)
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+
+	var parsed struct {
+		CompactResult *CompactResult `json:"compact_result,omitempty"`
+		ArchiveResult *ArchiveResult `json:"archive_result,omitempty"`
+	}
+	if err := json.Unmarshal([]byte(out), &parsed); err != nil {
+		t.Fatalf("unmarshal: %v (raw=%s)", err, out)
+	}
+	if parsed.CompactResult == nil {
+		t.Fatal("expected compact_result to be populated")
+	}
+	if parsed.ArchiveResult != nil {
+		t.Fatal("expected archive_result to be skipped without workspace")
+	}
+}
+
+func TestHistoryCompactTool_Execute_FallbackPathArchiveOnly(t *testing.T) {
+	// Skip compact (compact:false), keep archive — exercises the second
+	// branch of the fallback path when Workspace + MessageStore are set.
+	ws, err := workspace.NewLocalWorkspace(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	store := NewFileStore(ws, "memory")
+	ctx := context.Background()
+	convID := "compact-tool-archive"
+
+	msgs := make([]model.Message, 20)
+	for i := range msgs {
+		msgs[i] = model.NewTextMessage(model.RoleUser, "x")
+	}
+	_ = store.SaveMessages(ctx, convID, msgs)
+
+	cfg := DefaultDAGConfig()
+	cfg.Archive.ArchiveThreshold = 15
+	cfg.Archive.ArchiveBatchSize = 10
+	tl := newHistoryCompactTool(ToolDeps{
+		MessageStore: store,
+		Workspace:    ws,
+		Prefix:       "memory",
+		Config:       cfg,
+	})
+
+	out, err := tl.Execute(ctx, `{"conversation_id":"`+convID+`","compact":false}`)
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+
+	var parsed struct {
+		ArchiveResult *ArchiveResult `json:"archive_result,omitempty"`
+		CompactResult *CompactResult `json:"compact_result,omitempty"`
+	}
+	if err := json.Unmarshal([]byte(out), &parsed); err != nil {
+		t.Fatal(err)
+	}
+	if parsed.CompactResult != nil {
+		t.Fatal("expected compact to be skipped when compact:false")
+	}
+	if parsed.ArchiveResult == nil {
+		t.Fatal("expected archive_result to be populated")
+	}
+	if parsed.ArchiveResult.MessagesArchived != 10 {
+		t.Fatalf("expected 10 archived, got %d", parsed.ArchiveResult.MessagesArchived)
+	}
 }

--- a/sdk/recall/memory.go
+++ b/sdk/recall/memory.go
@@ -69,6 +69,21 @@ type JobController interface {
 	AwaitJob(ctx context.Context, id JobID, timeout time.Duration) (JobStatus, error)
 }
 
+// RecallExplainer is implemented by [Memory] flavours whose underlying
+// retrieval pipeline can produce a structured [retrieval.SearchExecution]
+// (lanes, stages, …) alongside the ranked hits.
+//
+// RecallExplain has the same scope/validation contract as [Memory.Recall];
+// callers populate Request.Debug to opt in. The returned execution is nil
+// when Debug is the zero value or when no stage produced one.
+//
+// Type-assert to use it:
+//
+//	if rx, ok := mem.(recall.RecallExplainer); ok { … }
+type RecallExplainer interface {
+	RecallExplain(ctx context.Context, scope Scope, req Request) ([]Hit, *retrieval.SearchExecution, error)
+}
+
 // config is the resolved configuration of a Memory instance, populated
 // by the [Option] functions passed to [New]. It is package-private on
 // purpose: callers compose behaviour exclusively through Option, which
@@ -107,6 +122,7 @@ type config struct {
 	sweeperEnabled  bool
 	sweeperInterval time.Duration
 	sweeperBatchMax int
+	nsRegistry      NamespaceRegistry
 
 	now    func() time.Time
 	logger func(string, ...any)
@@ -264,6 +280,16 @@ func WithSweeper(interval time.Duration, batchMax int) Option {
 	}
 }
 
+// WithNamespaceRegistry overrides the registry used to track namespaces for
+// background sweeps. Defaults to an in-memory implementation.
+func WithNamespaceRegistry(r NamespaceRegistry) Option {
+	return func(c *config) {
+		if r != nil {
+			c.nsRegistry = r
+		}
+	}
+}
+
 // WithClock injects a time source (mainly for tests).
 func WithClock(now func() time.Time) Option { return func(c *config) { c.now = now } }
 
@@ -339,6 +365,9 @@ func New(idx retrieval.Index, opts ...Option) (Memory, error) {
 	}
 	if cfg.jobQueue == nil {
 		cfg.jobQueue = NewMemoryJobQueue()
+	}
+	if cfg.sweeperEnabled && cfg.nsRegistry == nil {
+		cfg.nsRegistry = NewMemoryNamespaceRegistry()
 	}
 	wrapped := idx
 	if cfg.journal != nil {
@@ -422,12 +451,28 @@ func (m *lt) Close() error {
 	}
 	m.workerCancel()
 	m.wgWorkers.Wait()
-	_ = m.cfg.jobQueue.Close()
-	return m.idx.Close()
+	var nsErr error
+	if m.cfg.nsRegistry != nil {
+		nsErr = m.cfg.nsRegistry.Close()
+	}
+	return errors.Join(
+		nsErr,
+		m.cfg.jobQueue.Close(),
+		m.idx.Close(),
+	)
 }
 
 func (m *lt) log(format string, args ...any) {
 	if m.cfg.logger != nil {
 		m.cfg.logger(format, args...)
+	}
+}
+
+func (m *lt) rememberNamespace(ctx context.Context, ns string) {
+	if ns == "" || m.cfg.nsRegistry == nil {
+		return
+	}
+	if err := m.cfg.nsRegistry.Remember(ctx, ns); err != nil && ctx.Err() == nil {
+		m.log("recall: remember namespace %q: %v", ns, err)
 	}
 }

--- a/sdk/recall/memory_test.go
+++ b/sdk/recall/memory_test.go
@@ -199,6 +199,40 @@ func TestSweeperPhysicalDelete(t *testing.T) {
 	}
 }
 
+func TestBackgroundSweeperDeletesExpiredEntries(t *testing.T) {
+	ctx := context.Background()
+	idx := memidx.New()
+	m, err := recall.New(idx,
+		recall.WithRequireUserID(),
+		recall.WithTTLPolicy(recall.CategoryTTLPolicy{recall.CategoryEpisodic: time.Hour}),
+		recall.WithSweeper(10*time.Millisecond, 100),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer m.Close()
+
+	scope := newScope()
+	past := time.Now().Add(-time.Second)
+	id, err := m.Add(ctx, scope, recall.Entry{
+		Content:    "expired in background",
+		Categories: []string{"episodic"},
+		ExpiresAt:  &past,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if _, ok, _ := idx.Get(ctx, recall.NamespaceFor(scope), id); !ok {
+			return
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	t.Fatalf("background sweeper failed to delete %s", id)
+}
+
 func TestAsyncSaveAndAwait(t *testing.T) {
 	ctx := context.Background()
 	idx := memidx.New()

--- a/sdk/recall/merger.go
+++ b/sdk/recall/merger.go
@@ -58,6 +58,12 @@ func (m *lt) dedupHashes(ctx context.Context, scope Scope, hashes []string) (map
 // Rollback); retrieval-time damping is the responsibility of
 // pipeline.SupersededDecay, which multiplies the score of any hit
 // carrying superseded_by by its Factor (default 0.3).
+//
+// Execution surface: this is a single-lane vector lookup that bypasses the
+// configured pipeline by design (we only need cosines, not the ranked
+// answer). It therefore never asks the backend for an Execution and never
+// reads RawByRetriever; downstream callers should not treat it as part of
+// the Recall explanation produced by [RecallExplainer.RecallExplain].
 func (m *lt) supersedeNeighbours(
 	ctx context.Context, scope Scope, newID string,
 	fact ExtractedFact, vec []float32, now time.Time,
@@ -73,6 +79,7 @@ func (m *lt) supersedeNeighbours(
 		QueryVector: vec,
 		Filter:      AgentRecallFilter(scope),
 		TopK:        m.cfg.softMergeTopK + 1, // +1 in case the new doc itself shows up
+		// Debug intentionally left zero: see godoc above.
 	})
 	if err != nil || resp == nil {
 		return

--- a/sdk/recall/merger_test.go
+++ b/sdk/recall/merger_test.go
@@ -1,0 +1,112 @@
+package recall_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/GizClaw/flowcraft/sdk/llm"
+	"github.com/GizClaw/flowcraft/sdk/model"
+	"github.com/GizClaw/flowcraft/sdk/recall"
+	memidx "github.com/GizClaw/flowcraft/sdk/retrieval/memory"
+)
+
+func TestSaveDedupsSameFactAcrossDifferentMessages(t *testing.T) {
+	ctx := context.Background()
+	idx := memidx.New()
+	ex := &scriptedExtractor{
+		facts: [][]recall.ExtractedFact{
+			{{Content: "User likes matcha", Entities: []string{"matcha"}}},
+			{{Content: "User likes matcha", Entities: []string{"matcha"}}},
+		},
+	}
+	m, err := recall.New(idx, recall.WithRequireUserID(), recall.WithExtractor(ex))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer m.Close()
+
+	scope := newScope()
+	r1, err := m.Save(ctx, scope, []llm.Message{
+		{Role: model.RoleUser, Parts: []model.Part{{Type: model.PartText, Text: "Remember that I like matcha."}}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	r2, err := m.Save(ctx, scope, []llm.Message{
+		{Role: model.RoleUser, Parts: []model.Part{{Type: model.PartText, Text: "Also note that matcha is still my favorite drink."}}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if r1.EntryIDs[0] != r2.EntryIDs[0] {
+		t.Fatalf("expected md5 dedup to return existing id, got %q and %q", r1.EntryIDs[0], r2.EntryIDs[0])
+	}
+	hits, err := m.Recall(ctx, scope, recall.Request{Query: "matcha", TopK: 5})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(hits) != 1 {
+		t.Fatalf("expected one deduped hit, got %+v", hits)
+	}
+}
+
+func TestSaveSoftMergeMarksSupersededNeighbour(t *testing.T) {
+	ctx := context.Background()
+	idx := memidx.New()
+	now := time.Now()
+	oldFact := "Alice prefers pour-over coffee"
+	newFact := "Alice now prefers pour over coffee at work"
+	ex := &scriptedExtractor{
+		facts: [][]recall.ExtractedFact{
+			{{Content: oldFact, Entities: []string{"Alice", "Coffee"}}},
+			{{Content: newFact, Entities: []string{"coffee", "alice"}}},
+		},
+	}
+	emb := &mapEmbedder{
+		vectors: map[string][]float32{
+			oldFact: {1, 0},
+			newFact: {1, 0},
+		},
+	}
+	m, err := recall.New(idx,
+		recall.WithRequireUserID(),
+		recall.WithExtractor(ex),
+		recall.WithEmbedder(emb),
+		recall.WithClock(func() time.Time { return now }),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer m.Close()
+
+	scope := newScope()
+	first, err := m.Save(ctx, scope, []llm.Message{
+		{Role: model.RoleUser, Parts: []model.Part{{Type: model.PartText, Text: "Alice prefers pour-over coffee."}}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	now = now.Add(time.Minute)
+	second, err := m.Save(ctx, scope, []llm.Message{
+		{Role: model.RoleUser, Parts: []model.Part{{Type: model.PartText, Text: "Alice now prefers pour over coffee at work."}}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	doc, ok, err := idx.Get(ctx, recall.NamespaceFor(scope), first.EntryIDs[0])
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !ok {
+		t.Fatalf("missing original doc %q", first.EntryIDs[0])
+	}
+	if got := doc.Metadata["superseded_by"]; got != second.EntryIDs[0] {
+		t.Fatalf("superseded_by=%v, want %q", got, second.EntryIDs[0])
+	}
+	if got := doc.Metadata["superseded_at"]; got != now.UnixMilli() {
+		t.Fatalf("superseded_at=%v, want %d", got, now.UnixMilli())
+	}
+}

--- a/sdk/recall/merger_test.go
+++ b/sdk/recall/merger_test.go
@@ -2,6 +2,7 @@ package recall_test
 
 import (
 	"context"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -55,7 +56,15 @@ func TestSaveDedupsSameFactAcrossDifferentMessages(t *testing.T) {
 func TestSaveSoftMergeMarksSupersededNeighbour(t *testing.T) {
 	ctx := context.Background()
 	idx := memidx.New()
-	now := time.Now()
+	// Wrap the test clock in atomic.Pointer so the recall worker
+	// goroutine (which calls the clock asynchronously while it drains
+	// the save queue) and the test goroutine (which advances time
+	// between saves) cannot race on the shared `now`. The previous
+	// closure-over-local-variable form tripped -race in CI.
+	var clockHolder atomic.Pointer[time.Time]
+	setNow := func(t time.Time) { clockHolder.Store(&t) }
+	getNow := func() time.Time { return *clockHolder.Load() }
+	setNow(time.Now())
 	oldFact := "Alice prefers pour-over coffee"
 	newFact := "Alice now prefers pour over coffee at work"
 	ex := &scriptedExtractor{
@@ -74,7 +83,7 @@ func TestSaveSoftMergeMarksSupersededNeighbour(t *testing.T) {
 		recall.WithRequireUserID(),
 		recall.WithExtractor(ex),
 		recall.WithEmbedder(emb),
-		recall.WithClock(func() time.Time { return now }),
+		recall.WithClock(getNow),
 	)
 	if err != nil {
 		t.Fatal(err)
@@ -88,7 +97,7 @@ func TestSaveSoftMergeMarksSupersededNeighbour(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	now = now.Add(time.Minute)
+	setNow(getNow().Add(time.Minute))
 	second, err := m.Save(ctx, scope, []llm.Message{
 		{Role: model.RoleUser, Parts: []model.Part{{Type: model.PartText, Text: "Alice now prefers pour over coffee at work."}}},
 	})
@@ -106,7 +115,7 @@ func TestSaveSoftMergeMarksSupersededNeighbour(t *testing.T) {
 	if got := doc.Metadata["superseded_by"]; got != second.EntryIDs[0] {
 		t.Fatalf("superseded_by=%v, want %q", got, second.EntryIDs[0])
 	}
-	if got := doc.Metadata["superseded_at"]; got != now.UnixMilli() {
-		t.Fatalf("superseded_at=%v, want %d", got, now.UnixMilli())
+	if got := doc.Metadata["superseded_at"]; got != getNow().UnixMilli() {
+		t.Fatalf("superseded_at=%v, want %d", got, getNow().UnixMilli())
 	}
 }

--- a/sdk/recall/namespace_registry.go
+++ b/sdk/recall/namespace_registry.go
@@ -1,0 +1,59 @@
+package recall
+
+import (
+	"context"
+	"sort"
+	"sync"
+)
+
+// NamespaceRegistry tracks namespaces that recall may need to sweep.
+//
+// Implementations must be safe for concurrent use. Remember is best-effort
+// metadata maintenance; callers should not fail core read/write paths if it
+// returns an error.
+type NamespaceRegistry interface {
+	Remember(ctx context.Context, ns string) error
+	List(ctx context.Context) ([]string, error)
+	Close() error
+}
+
+type memNamespaceRegistry struct {
+	mu  sync.RWMutex
+	set map[string]struct{}
+}
+
+// NewMemoryNamespaceRegistry returns an in-memory NamespaceRegistry.
+func NewMemoryNamespaceRegistry() NamespaceRegistry {
+	return &memNamespaceRegistry{
+		set: map[string]struct{}{},
+	}
+}
+
+func (r *memNamespaceRegistry) Remember(ctx context.Context, ns string) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	if ns == "" {
+		return nil
+	}
+	r.mu.Lock()
+	r.set[ns] = struct{}{}
+	r.mu.Unlock()
+	return nil
+}
+
+func (r *memNamespaceRegistry) List(ctx context.Context) ([]string, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	r.mu.RLock()
+	out := make([]string, 0, len(r.set))
+	for ns := range r.set {
+		out = append(out, ns)
+	}
+	r.mu.RUnlock()
+	sort.Strings(out)
+	return out, nil
+}
+
+func (*memNamespaceRegistry) Close() error { return nil }

--- a/sdk/recall/namespace_registry_test.go
+++ b/sdk/recall/namespace_registry_test.go
@@ -1,0 +1,33 @@
+package recall_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/GizClaw/flowcraft/sdk/recall"
+)
+
+func TestMemoryNamespaceRegistryListSortedDistinct(t *testing.T) {
+	ctx := context.Background()
+	reg := recall.NewMemoryNamespaceRegistry()
+	if err := reg.Remember(ctx, "z_ns"); err != nil {
+		t.Fatal(err)
+	}
+	if err := reg.Remember(ctx, "a_ns"); err != nil {
+		t.Fatal(err)
+	}
+	if err := reg.Remember(ctx, "z_ns"); err != nil {
+		t.Fatal(err)
+	}
+	if err := reg.Remember(ctx, ""); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := reg.List(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 2 || got[0] != "a_ns" || got[1] != "z_ns" {
+		t.Fatalf("List() = %v, want [a_ns z_ns]", got)
+	}
+}

--- a/sdk/recall/recall.go
+++ b/sdk/recall/recall.go
@@ -18,6 +18,11 @@ type Request struct {
 	Filter    map[string]any // metadata equality filters merged into pipeline filter
 	Now       time.Time      // optional clock injection (for tests / TTL)
 	WithStale bool           // if true, do NOT filter expired entries
+
+	// Debug controls how much execution detail the underlying retrieval
+	// pipeline should attach. Memory.Recall always discards it; callers
+	// that need the SearchExecution must use [RecallExplainer.RecallExplain].
+	Debug retrieval.SearchDebug
 }
 
 // Hit is one result returned by Memory.Recall.
@@ -36,7 +41,32 @@ type Hit struct {
 // memory.recall.recall_duration, and hit count on histogram
 // memory.recall.recall_hits. Query text is intentionally NOT attached
 // to the span (PII risk on user-typed queries).
+//
+// Memory.Recall does NOT expose the underlying [retrieval.SearchExecution];
+// callers that need it must type-assert to [RecallExplainer] and call
+// RecallExplain instead.
 func (m *lt) Recall(ctx context.Context, scope Scope, req Request) ([]Hit, error) {
+	hits, _, err := m.runRecall(ctx, scope, req)
+	return hits, err
+}
+
+// RecallExplain is the structured-explanation variant of Recall: it returns
+// the same hits plus the underlying [retrieval.SearchExecution] (lanes,
+// stages) when Request.Debug requested it. Execution is nil when Debug is
+// zero or when no stage chose to populate it.
+//
+// Implements [RecallExplainer].
+func (m *lt) RecallExplain(ctx context.Context, scope Scope, req Request) ([]Hit, *retrieval.SearchExecution, error) {
+	return m.runRecall(ctx, scope, req)
+}
+
+// runRecall is the single internal recall path; both [Memory.Recall] and
+// [RecallExplainer.RecallExplain] delegate here so telemetry, scope
+// validation, namespace bookkeeping and pipeline wiring stay in one place.
+//
+// The returned *retrieval.SearchExecution is whatever the configured
+// pipeline produced; callers that don't want it discard it (Memory.Recall).
+func (m *lt) runRecall(ctx context.Context, scope Scope, req Request) ([]Hit, *retrieval.SearchExecution, error) {
 	ctx, span := telemetry.Tracer().Start(ctx, "memory.recall.recall")
 	defer span.End()
 	t0 := time.Now()
@@ -47,12 +77,12 @@ func (m *lt) Recall(ctx context.Context, scope Scope, req Request) ([]Hit, error
 	if scope.RuntimeID == "" {
 		span.RecordError(ErrMissingRuntimeID)
 		recallTotal.Add(ctx, 1, metric.WithAttributes(attribute.String("outcome", "fail"), attribute.String("reason", "scope")))
-		return nil, ErrMissingRuntimeID
+		return nil, nil, ErrMissingRuntimeID
 	}
 	if m.cfg.requireUserID && scope.UserID == "" && !m.cfg.allowGlobal {
 		span.RecordError(ErrMissingUserID)
 		recallTotal.Add(ctx, 1, metric.WithAttributes(attribute.String("outcome", "fail"), attribute.String("reason", "scope")))
-		return nil, ErrMissingUserID
+		return nil, nil, ErrMissingUserID
 	}
 	now := req.Now
 	if now.IsZero() {
@@ -70,23 +100,39 @@ func (m *lt) Recall(ctx context.Context, scope Scope, req Request) ([]Hit, error
 		filter = MergeFilters(filter, retrieval.Filter{Eq: req.Filter})
 	}
 	ns := NamespaceFor(scope)
+	m.rememberNamespace(ctx, ns)
 	span.SetAttributes(
 		attribute.String("runtime_id", scope.RuntimeID),
 		attribute.Bool("has_user_id", scope.UserID != ""),
 		attribute.Int("top_k", topK),
 		attribute.Int("query_len", len(req.Query)),
 		attribute.Bool("with_stale", req.WithStale),
+		attribute.Bool("debug_lanes", req.Debug.IncludeLanes),
+		attribute.Bool("debug_stages", req.Debug.IncludeStages),
 	)
+	// Always ask the pipeline for stage + lane trace so we can feed
+	// recallStageDuration / recallLaneDuration without depending on
+	// per-call SearchDebug. The extra cost is bounded: stages are tiny
+	// structs; lanes carry copied hit slices but recall TopK is in the
+	// dozens. The caller-visible Execution is trimmed below to match
+	// req.Debug so RecallExplain still honours its public contract
+	// ("Execution is nil when Debug is zero").
+	pipeDebug := req.Debug
+	pipeDebug.IncludeStages = true
+	pipeDebug.IncludeLanes = true
 	resp, err := m.pipe.Run(ctx, m.idx, ns, retrieval.SearchRequest{
 		QueryText: req.Query,
 		Filter:    filter,
 		TopK:      topK,
+		Debug:     pipeDebug,
 	})
 	if err != nil {
 		span.RecordError(err)
 		recallTotal.Add(ctx, 1, metric.WithAttributes(attribute.String("outcome", "fail"), attribute.String("reason", "pipeline")))
-		return nil, err
+		return nil, nil, err
 	}
+	recordStageDurations(ctx, resp.Execution)
+	recordLaneDurations(ctx, resp.Execution)
 	out := make([]Hit, 0, len(resp.Hits))
 	for _, h := range resp.Hits {
 		out = append(out, Hit{
@@ -98,7 +144,77 @@ func (m *lt) Recall(ctx context.Context, scope Scope, req Request) ([]Hit, error
 	span.SetAttributes(attribute.Int("hits", len(out)))
 	recallHits.Record(ctx, int64(len(out)))
 	recallTotal.Add(ctx, 1, metric.WithAttributes(attribute.String("outcome", "success")))
-	return out, nil
+	return out, projectExecution(resp.Execution, req.Debug), nil
+}
+
+// projectExecution returns the caller-visible slice of pipe.Execution
+// according to req.Debug. Pipeline always emits stages (we need them for
+// recallStageDuration), but callers must explicitly request them via
+// SearchDebug.IncludeStages to observe them; otherwise we strip stages
+// (and lanes if not requested) so RecallExplain's public contract holds.
+func projectExecution(exec *retrieval.SearchExecution, debug retrieval.SearchDebug) *retrieval.SearchExecution {
+	if exec == nil {
+		return nil
+	}
+	if !debug.IncludeLanes && !debug.IncludeStages {
+		return nil
+	}
+	out := &retrieval.SearchExecution{}
+	if debug.IncludeLanes {
+		out.Lanes = exec.Lanes
+	}
+	if debug.IncludeStages {
+		out.Stages = exec.Stages
+	}
+	return out
+}
+
+// recordStageDurations emits one observation per pipeline stage on
+// recallStageDuration. The stage label is the pipeline stage name; the
+// outcome label is "success" by default and "fail" when the stage
+// recorded an error (pipeline aborts on first error, so at most one
+// "fail" sample is produced per call).
+func recordStageDurations(ctx context.Context, exec *retrieval.SearchExecution) {
+	if exec == nil || len(exec.Stages) == 0 {
+		return
+	}
+	for _, st := range exec.Stages {
+		outcome := "success"
+		if st.Err != "" {
+			outcome = "fail"
+		}
+		recallStageDuration.Record(
+			ctx,
+			st.Took.Seconds(),
+			metric.WithAttributes(
+				attribute.String("stage", st.Name),
+				attribute.String("outcome", outcome),
+			),
+		)
+	}
+}
+
+// recordLaneDurations emits one observation per recall lane on
+// recallLaneDuration. The lane label is the LaneKey reported by the
+// pipeline (a small enum-like set, see retrieval.Lane*). Lanes whose
+// Took is zero are skipped — typically a lane that the recall stage
+// never invoked (e.g. vector lane when QueryVector is empty).
+func recordLaneDurations(ctx context.Context, exec *retrieval.SearchExecution) {
+	if exec == nil || len(exec.Lanes) == 0 {
+		return
+	}
+	for _, lane := range exec.Lanes {
+		if lane.Took <= 0 {
+			continue
+		}
+		recallLaneDuration.Record(
+			ctx,
+			lane.Took.Seconds(),
+			metric.WithAttributes(
+				attribute.String("lane", string(lane.Key)),
+			),
+		)
+	}
 }
 
 // History implements Memory; requires Journal.
@@ -106,7 +222,9 @@ func (m *lt) History(ctx context.Context, scope Scope, id string) ([]journal.Eve
 	if m.cfg.journal == nil {
 		return nil, ErrJournalRequired
 	}
-	return m.cfg.journal.History(ctx, NamespaceFor(scope), id)
+	ns := NamespaceFor(scope)
+	m.rememberNamespace(ctx, ns)
+	return m.cfg.journal.History(ctx, ns, id)
 }
 
 // Rollback re-applies the last Upsert recorded before t (or deletes the doc
@@ -116,6 +234,7 @@ func (m *lt) Rollback(ctx context.Context, scope Scope, id string, before time.T
 		return ErrJournalRequired
 	}
 	ns := NamespaceFor(scope)
+	m.rememberNamespace(ctx, ns)
 	events, err := m.cfg.journal.History(ctx, ns, id)
 	if err != nil {
 		return err
@@ -144,5 +263,7 @@ func (m *lt) Rollback(ctx context.Context, scope Scope, id string, before time.T
 // Forget hard-deletes one entry; Journal records OpDelete{reason}.
 func (m *lt) Forget(ctx context.Context, scope Scope, id, reason string) error {
 	_ = reason // reason is captured by Journal actor (caller can WithActor)
-	return m.idx.Delete(ctx, NamespaceFor(scope), []string{id})
+	ns := NamespaceFor(scope)
+	m.rememberNamespace(ctx, ns)
+	return m.idx.Delete(ctx, ns, []string{id})
 }

--- a/sdk/recall/recall_explain_test.go
+++ b/sdk/recall/recall_explain_test.go
@@ -1,0 +1,321 @@
+package recall
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/GizClaw/flowcraft/sdk/retrieval"
+	memidx "github.com/GizClaw/flowcraft/sdk/retrieval/memory"
+	"github.com/GizClaw/flowcraft/sdk/retrieval/pipeline"
+)
+
+// TestRecallExplainer asserts that any Memory built by recall.New also
+// satisfies RecallExplainer, and that RecallExplain threads
+// SearchRequest.Debug into the underlying pipeline so callers get a
+// non-nil SearchExecution back.
+func TestRecallExplainer(t *testing.T) {
+	ctx := context.Background()
+	m, err := New(memidx.New(), WithRequireUserID())
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	defer m.Close()
+
+	scope := Scope{RuntimeID: "r1", UserID: "u1"}
+	now := time.Now()
+	for _, e := range []Entry{
+		{ID: "go", Category: CategoryProfile, Content: "User is a Go developer", Keywords: []string{"go"}, UpdatedAt: now},
+		{ID: "react", Category: CategoryProfile, Content: "User knows React", Keywords: []string{"react"}, UpdatedAt: now},
+	} {
+		if _, err := m.Add(ctx, scope, e); err != nil {
+			t.Fatalf("add %s: %v", e.ID, err)
+		}
+	}
+
+	rx, ok := m.(RecallExplainer)
+	if !ok {
+		t.Fatal("Memory built by New must implement RecallExplainer")
+	}
+
+	t.Run("debug zero leaves Execution nil", func(t *testing.T) {
+		hits, exec, err := rx.RecallExplain(ctx, scope, Request{Query: "Go", TopK: 5})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if exec != nil {
+			t.Fatalf("expected nil Execution when Debug is zero, got %+v", exec)
+		}
+		if len(hits) == 0 {
+			t.Fatal("expected at least one hit")
+		}
+	})
+
+	t.Run("include lanes populates Execution.Lanes", func(t *testing.T) {
+		hits, exec, err := rx.RecallExplain(ctx, scope, Request{
+			Query: "Go",
+			TopK:  5,
+			Debug: retrieval.SearchDebug{IncludeLanes: true},
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if exec == nil {
+			t.Fatal("expected non-nil Execution when IncludeLanes=true")
+		}
+		if len(exec.Lanes) == 0 {
+			t.Fatal("expected at least one lane in Execution")
+		}
+		if len(exec.Stages) != 0 {
+			t.Fatalf("expected no stages when IncludeStages=false, got %+v", exec.Stages)
+		}
+		if len(hits) == 0 {
+			t.Fatal("expected hits alongside Execution")
+		}
+	})
+
+	t.Run("include stages records pipeline trace", func(t *testing.T) {
+		_, exec, err := rx.RecallExplain(ctx, scope, Request{
+			Query: "Go",
+			TopK:  5,
+			Debug: retrieval.SearchDebug{IncludeStages: true},
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if exec == nil || len(exec.Stages) == 0 {
+			t.Fatalf("expected stage trace, got %+v", exec)
+		}
+		for _, st := range exec.Stages {
+			if st.Name == "" {
+				t.Fatalf("stage missing name: %+v", st)
+			}
+		}
+	})
+}
+
+// TestRecallExplainerLanesUseLaneKeyConstants asserts that the default
+// pipeline lane labels surface as the canonical retrieval.LaneKey
+// constants — guards against typo drift between
+// pipeline.RetrieveMode/MultiRetrieve keys and retrieval.Lane*.
+func TestRecallExplainerLanesUseLaneKeyConstants(t *testing.T) {
+	ctx := context.Background()
+	m, err := New(memidx.New(), WithRequireUserID())
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	defer m.Close()
+	scope := Scope{RuntimeID: "r1", UserID: "u1"}
+	if _, err := m.Add(ctx, scope, Entry{
+		ID: "go", Category: CategoryProfile, Content: "User is a Go developer", Keywords: []string{"go"}, UpdatedAt: time.Now(),
+	}); err != nil {
+		t.Fatal(err)
+	}
+	rx := m.(RecallExplainer)
+	_, exec, err := rx.RecallExplain(ctx, scope, Request{
+		Query: "Go", TopK: 5,
+		Debug: retrieval.SearchDebug{IncludeLanes: true},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if exec == nil || len(exec.Lanes) == 0 {
+		t.Fatalf("expected at least one lane, got %+v", exec)
+	}
+	// Default LTM(nil) recipe drops to BM25-only; lane key MUST be the
+	// canonical retrieval.LaneBM25 constant.
+	if exec.Lanes[0].Key != retrieval.LaneBM25 {
+		t.Fatalf("expected lane key %q, got %q", retrieval.LaneBM25, exec.Lanes[0].Key)
+	}
+}
+
+// TestRecallExplainerLanesCarryTook asserts the LaneResult.Took field
+// is populated from the underlying Retrieve / MultiRetrieve stage so
+// the recall_lane_duration histogram has non-zero samples to record.
+func TestRecallExplainerLanesCarryTook(t *testing.T) {
+	ctx := context.Background()
+	m, err := New(memidx.New(), WithRequireUserID())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer m.Close()
+	scope := Scope{RuntimeID: "r1", UserID: "u1"}
+	if _, err := m.Add(ctx, scope, Entry{
+		ID: "go", Category: CategoryProfile, Content: "Go developer", Keywords: []string{"go"}, UpdatedAt: time.Now(),
+	}); err != nil {
+		t.Fatal(err)
+	}
+	rx := m.(RecallExplainer)
+	_, exec, err := rx.RecallExplain(ctx, scope, Request{
+		Query: "Go", TopK: 5,
+		Debug: retrieval.SearchDebug{IncludeLanes: true},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if exec == nil || len(exec.Lanes) == 0 {
+		t.Fatalf("expected non-empty lanes, got %+v", exec)
+	}
+	for _, lane := range exec.Lanes {
+		if lane.Took <= 0 {
+			t.Fatalf("lane %q Took=%s, want > 0", lane.Key, lane.Took)
+		}
+	}
+}
+
+// TestRecallExplainerStageTraceCarriesDuration sandwiches a sleep stage
+// inside the configured pipeline and asserts RecallExplain surfaces the
+// stage's measured duration. This is the same trace
+// recordStageDurations consumes for the recall_stage_duration histogram,
+// so a non-zero Took here is sufficient evidence that metric path runs.
+func TestRecallExplainerStageTraceCarriesDuration(t *testing.T) {
+	ctx := context.Background()
+	pipe := pipeline.New(
+		pipeline.Retrieve{Lane: string(retrieval.LaneBM25), Spec: pipeline.RetrieveSpec{Mode: pipeline.ModeBM25, TopK: 5}},
+		sleepyStage{name: "Sleepy", dur: 10 * time.Millisecond},
+		pipeline.Limit{TopK: 5},
+	)
+	m, err := New(memidx.New(), WithRequireUserID(), WithPipeline(pipe))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer m.Close()
+	scope := Scope{RuntimeID: "r1", UserID: "u1"}
+	if _, err := m.Add(ctx, scope, Entry{
+		ID: "go", Category: CategoryProfile, Content: "Go developer", Keywords: []string{"go"}, UpdatedAt: time.Now(),
+	}); err != nil {
+		t.Fatal(err)
+	}
+	rx := m.(RecallExplainer)
+	_, exec, err := rx.RecallExplain(ctx, scope, Request{
+		Query: "Go", TopK: 5,
+		Debug: retrieval.SearchDebug{IncludeStages: true},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if exec == nil {
+		t.Fatal("expected non-nil Execution")
+	}
+	var found bool
+	for _, st := range exec.Stages {
+		if st.Name != "Sleepy" {
+			continue
+		}
+		found = true
+		if st.Took < 10*time.Millisecond {
+			t.Fatalf("Sleepy stage Took=%s, want >= 10ms", st.Took)
+		}
+	}
+	if !found {
+		t.Fatalf("Sleepy stage not surfaced in trace: %+v", exec.Stages)
+	}
+}
+
+// TestRecallExplainerProjectsExecutionPerDebug exercises every quadrant
+// of (IncludeLanes, IncludeStages) to lock down the projection rules
+// runRecall enforces between the always-on internal trace and the
+// caller-visible Execution.
+func TestRecallExplainerProjectsExecutionPerDebug(t *testing.T) {
+	ctx := context.Background()
+	m, err := New(memidx.New(), WithRequireUserID())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer m.Close()
+	scope := Scope{RuntimeID: "r1", UserID: "u1"}
+	if _, err := m.Add(ctx, scope, Entry{
+		ID: "go", Category: CategoryProfile, Content: "Go developer", Keywords: []string{"go"}, UpdatedAt: time.Now(),
+	}); err != nil {
+		t.Fatal(err)
+	}
+	rx := m.(RecallExplainer)
+	cases := []struct {
+		name       string
+		debug      retrieval.SearchDebug
+		wantNil    bool
+		wantLanes  bool
+		wantStages bool
+	}{
+		{"zero debug → nil execution", retrieval.SearchDebug{}, true, false, false},
+		{"lanes only", retrieval.SearchDebug{IncludeLanes: true}, false, true, false},
+		{"stages only", retrieval.SearchDebug{IncludeStages: true}, false, false, true},
+		{"both", retrieval.SearchDebug{IncludeLanes: true, IncludeStages: true}, false, true, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, exec, err := rx.RecallExplain(ctx, scope, Request{Query: "Go", TopK: 5, Debug: tc.debug})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if tc.wantNil {
+				if exec != nil {
+					t.Fatalf("expected nil execution, got %+v", exec)
+				}
+				return
+			}
+			if exec == nil {
+				t.Fatal("expected non-nil execution")
+			}
+			if tc.wantLanes && len(exec.Lanes) == 0 {
+				t.Fatal("expected lanes")
+			}
+			if !tc.wantLanes && len(exec.Lanes) != 0 {
+				t.Fatalf("expected no lanes, got %+v", exec.Lanes)
+			}
+			if tc.wantStages && len(exec.Stages) == 0 {
+				t.Fatal("expected stages")
+			}
+			if !tc.wantStages && len(exec.Stages) != 0 {
+				t.Fatalf("expected no stages, got %+v", exec.Stages)
+			}
+		})
+	}
+}
+
+// sleepyStage is a no-op pipeline stage that only sleeps; used to give
+// the stage trace a measurable, deterministic duration.
+type sleepyStage struct {
+	name string
+	dur  time.Duration
+}
+
+func (s sleepyStage) Name() string { return s.name }
+func (s sleepyStage) Run(ctx context.Context, _ *pipeline.State) error {
+	select {
+	case <-time.After(s.dur):
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+// TestRecallDoesNotLeakExecution ensures Memory.Recall keeps its narrow
+// signature — callers that don't opt into RecallExplainer must not be
+// able to observe the explanation through the public Recall path even
+// when Debug is set.
+func TestRecallDoesNotLeakExecution(t *testing.T) {
+	ctx := context.Background()
+	m, err := New(memidx.New(), WithRequireUserID())
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	defer m.Close()
+
+	scope := Scope{RuntimeID: "r1", UserID: "u1"}
+	if _, err := m.Add(ctx, scope, Entry{
+		ID: "go", Category: CategoryProfile, Content: "Go developer", Keywords: []string{"go"}, UpdatedAt: time.Now(),
+	}); err != nil {
+		t.Fatal(err)
+	}
+	hits, err := m.Recall(ctx, scope, Request{
+		Query: "Go", TopK: 5,
+		Debug: retrieval.SearchDebug{IncludeLanes: true, IncludeStages: true},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(hits) == 0 {
+		t.Fatal("expected at least one hit even when Debug is set")
+	}
+}

--- a/sdk/recall/save.go
+++ b/sdk/recall/save.go
@@ -56,6 +56,7 @@ func (m *lt) Save(ctx context.Context, scope Scope, msgs []llm.Message) (SaveRes
 	if err := m.validateScope(scope); err != nil {
 		return SaveResult{}, err
 	}
+	m.rememberNamespace(ctx, NamespaceFor(scope))
 	var extractOpts []ExtractOption
 	if m.cfg.saveWithCtx {
 		if existing := m.gatherExistingFacts(ctx, scope, msgs); len(existing) > 0 {
@@ -151,6 +152,7 @@ func (m *lt) SaveAsync(ctx context.Context, scope Scope, msgs []llm.Message) (Jo
 		return "", err
 	}
 	ns := NamespaceFor(scope)
+	m.rememberNamespace(ctx, ns)
 	return m.cfg.jobQueue.Enqueue(ctx, ns, JobPayload{Scope: scope, Messages: msgs})
 }
 
@@ -208,6 +210,7 @@ func (m *lt) Add(ctx context.Context, scope Scope, e Entry) (string, error) {
 	}
 	d := EntryToDoc(e)
 	ns := NamespaceFor(scope)
+	m.rememberNamespace(ctx, ns)
 	if err := m.idx.Upsert(ctx, ns, []retrieval.Doc{d}); err != nil {
 		span.RecordError(err)
 		addTotal.Add(ctx, 1, metric.WithAttributes(attribute.String("outcome", "fail"), attribute.String("reason", "upsert")))
@@ -237,6 +240,8 @@ func (m *lt) upsertFacts(
 	if len(facts) == 0 {
 		return nil, nil
 	}
+	ns := NamespaceFor(scope)
+	m.rememberNamespace(ctx, ns)
 
 	// 1. MD5 dedup ---------------------------------------------------------
 	hashes := make([]string, len(facts))
@@ -342,7 +347,7 @@ func (m *lt) upsertFacts(
 	for i, p := range plans {
 		docs[i] = p.doc
 	}
-	if err := m.idx.Upsert(ctx, NamespaceFor(scope), docs); err != nil {
+	if err := m.idx.Upsert(ctx, ns, docs); err != nil {
 		return nil, err
 	}
 	return returnedIDs, nil

--- a/sdk/recall/save_context_test.go
+++ b/sdk/recall/save_context_test.go
@@ -1,0 +1,93 @@
+package recall_test
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/GizClaw/flowcraft/sdk/llm"
+	"github.com/GizClaw/flowcraft/sdk/model"
+	"github.com/GizClaw/flowcraft/sdk/recall"
+	memidx "github.com/GizClaw/flowcraft/sdk/retrieval/memory"
+	"github.com/GizClaw/flowcraft/sdk/retrieval/pipeline"
+)
+
+func TestSaveUsesExistingFactsContext(t *testing.T) {
+	ctx := context.Background()
+	idx := memidx.New()
+	ex := &scriptedExtractor{
+		facts: [][]recall.ExtractedFact{{
+			{Content: "User still prefers oat milk latte", Categories: []string{"preferences"}},
+		}},
+	}
+	m, err := recall.New(idx,
+		recall.WithRequireUserID(),
+		recall.WithExtractor(ex),
+		recall.WithSaveContext(3, 0),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer m.Close()
+
+	scope := newScope()
+	if _, err := m.Add(ctx, scope, recall.Entry{
+		Content:    "User prefers oat milk latte at the office cafe",
+		Categories: []string{"preferences"},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := m.Save(ctx, scope, []llm.Message{
+		{Role: model.RoleUser, Parts: []model.Part{{Type: model.PartText, Text: "Please remember I still order oat milk latte every morning."}}},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	if ex.calls != 1 {
+		t.Fatalf("extractor called %d times, want 1", ex.calls)
+	}
+	if len(ex.gotExisting) != 1 || len(ex.gotExisting[0]) == 0 {
+		t.Fatalf("expected existing facts context, got %+v", ex.gotExisting)
+	}
+	if !strings.Contains(ex.gotExisting[0][0], "oat milk latte") {
+		t.Fatalf("existing facts did not include recalled snippet: %+v", ex.gotExisting[0])
+	}
+}
+
+func TestSaveWithContextIgnoresRecallFailure(t *testing.T) {
+	ctx := context.Background()
+	idx := memidx.New()
+	ex := &scriptedExtractor{
+		facts: [][]recall.ExtractedFact{{
+			{Content: "User wants terse commit messages", Categories: []string{"preferences"}},
+		}},
+	}
+	m, err := recall.New(idx,
+		recall.WithRequireUserID(),
+		recall.WithExtractor(ex),
+		recall.WithSaveContext(3, 0),
+		recall.WithPipeline(pipeline.New(failingStage{name: "boom", err: errors.New("recall failed")})),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer m.Close()
+
+	res, err := m.Save(ctx, newScope(), []llm.Message{
+		{Role: model.RoleUser, Parts: []model.Part{{Type: model.PartText, Text: "Keep commit messages short."}}},
+	})
+	if err != nil {
+		t.Fatalf("Save should ignore recall-context failure, got %v", err)
+	}
+	if len(res.EntryIDs) != 1 {
+		t.Fatalf("entry_ids=%v", res.EntryIDs)
+	}
+	if len(ex.gotExisting) != 1 || len(ex.gotExisting[0]) != 0 {
+		t.Fatalf("expected extractor to see no existing facts after recall failure, got %+v", ex.gotExisting)
+	}
+	if _, ok, err := idx.Get(ctx, recall.NamespaceFor(newScope()), res.EntryIDs[0]); err != nil || !ok {
+		t.Fatalf("saved entry missing after recall-context failure: ok=%v err=%v", ok, err)
+	}
+}

--- a/sdk/recall/sweeper.go
+++ b/sdk/recall/sweeper.go
@@ -2,6 +2,8 @@ package recall
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"time"
 
 	"github.com/GizClaw/flowcraft/sdk/retrieval"
@@ -49,7 +51,9 @@ func (m *lt) sweeperLoop() {
 		case <-m.stopCh:
 			return
 		case <-t.C:
-			_ = m.SweepOnce(context.Background())
+			if err := m.SweepOnce(m.workerCtx); err != nil && m.workerCtx.Err() == nil {
+				m.log("recall: sweeper pass failed: %v", err)
+			}
 		}
 	}
 }
@@ -67,14 +71,23 @@ func (m *lt) SweepOnce(ctx context.Context) error {
 			{Range: map[string]retrieval.Range{"expires_at": {Lte: now}}},
 		},
 	}
-	// We do not enumerate every namespace; SweepNamespace covers explicit ones.
-	// In practice callers run a per-namespace sweeper or rely on adapter-side cron.
-	return m.sweepNamespace(ctx, "", filter)
+	namespaces, err := m.cfg.nsRegistry.List(ctx)
+	if err != nil {
+		return err
+	}
+	var errs []error
+	for _, ns := range namespaces {
+		if err := m.sweepNamespace(ctx, ns, filter); err != nil {
+			errs = append(errs, fmt.Errorf("%s: %w", ns, err))
+		}
+	}
+	return errors.Join(errs...)
 }
 
 // SweepNamespace exposes a per-namespace TTL pass for callers who manage many
 // namespaces (e.g. one per tenant).
 func (m *lt) SweepNamespace(ctx context.Context, ns string) error {
+	m.rememberNamespace(ctx, ns)
 	now := m.cfg.now().UnixMilli()
 	filter := retrieval.Filter{
 		And: []retrieval.Filter{

--- a/sdk/recall/sweeper_test.go
+++ b/sdk/recall/sweeper_test.go
@@ -1,0 +1,55 @@
+package recall_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/GizClaw/flowcraft/sdk/recall"
+	memidx "github.com/GizClaw/flowcraft/sdk/retrieval/memory"
+)
+
+func TestSweepOnceDeletesAcrossRememberedNamespaces(t *testing.T) {
+	ctx := context.Background()
+	idx := memidx.New()
+	now := time.Now()
+	m, err := recall.New(idx,
+		recall.WithRequireUserID(),
+		recall.WithClock(func() time.Time { return now }),
+		recall.WithNamespaceRegistry(recall.NewMemoryNamespaceRegistry()),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer m.Close()
+
+	scopeA := newScope()
+	scopeB := scopeA
+	scopeB.UserID = "u2"
+	past := now.Add(-time.Second)
+	idA, err := m.Add(ctx, scopeA, recall.Entry{Content: "expired A", ExpiresAt: &past})
+	if err != nil {
+		t.Fatal(err)
+	}
+	idB, err := m.Add(ctx, scopeB, recall.Entry{Content: "expired B", ExpiresAt: &past})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	sweeper, ok := m.(interface {
+		SweepOnce(context.Context) error
+	})
+	if !ok {
+		t.Fatal("Memory does not expose SweepOnce")
+	}
+	if err := sweeper.SweepOnce(ctx); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, ok, _ := idx.Get(ctx, recall.NamespaceFor(scopeA), idA); ok {
+		t.Fatalf("expired doc %q in namespace A was not deleted", idA)
+	}
+	if _, ok, _ := idx.Get(ctx, recall.NamespaceFor(scopeB), idB); ok {
+		t.Fatalf("expired doc %q in namespace B was not deleted", idB)
+	}
+}

--- a/sdk/recall/telemetry.go
+++ b/sdk/recall/telemetry.go
@@ -26,4 +26,28 @@ var (
 	jobDuration, _    = recallMeter.Float64Histogram("job_duration", metric.WithDescription("Async Save job duration in seconds (extract + upsert)"))
 	jobTotal, _       = recallMeter.Int64Counter("job_total", metric.WithDescription("Async Save jobs processed, labelled by outcome (succeeded/failed/dead/timeout)"))
 	jobLeaseErrors, _ = recallMeter.Int64Counter("job_lease_errors_total", metric.WithDescription("JobQueue.Lease errors observed by the worker loop (excluding shutdown cancellations)"))
+
+	// recallStageDuration tracks per-stage timings of the retrieval
+	// pipeline executed under recall.Recall / recall.RecallExplain. The
+	// stage label is the stage name reported by pipeline.Stage.Name()
+	// (a small, enum-like set bounded by the configured pipeline), so
+	// cardinality stays controlled. Use this histogram to answer "which
+	// retrieval stage is currently the slow one" in dashboards without
+	// having to enable per-call SearchDebug.
+	recallStageDuration, _ = recallMeter.Float64Histogram(
+		"recall_stage_duration",
+		metric.WithDescription("Per-stage duration in seconds for the retrieval pipeline executed under recall.Recall, labelled by stage name and outcome"),
+	)
+
+	// recallLaneDuration tracks per-lane recall timings within
+	// MultiRetrieve / Retrieve stages. The lane label is the canonical
+	// retrieval.LaneKey (bm25/vector/sparse/entity/...), which is a
+	// small, enum-like set bounded by the configured pipeline. Pair
+	// with recallStageDuration to answer both "which stage is slow"
+	// (coarse) and "which recall lane is slow" (fine) without enabling
+	// per-call SearchDebug.
+	recallLaneDuration, _ = recallMeter.Float64Histogram(
+		"recall_lane_duration",
+		metric.WithDescription("Per-lane recall duration in seconds inside the retrieval pipeline executed under recall.Recall, labelled by lane key"),
+	)
 )

--- a/sdk/recall/test_helpers_regression_test.go
+++ b/sdk/recall/test_helpers_regression_test.go
@@ -1,0 +1,71 @@
+package recall_test
+
+import (
+	"context"
+
+	"github.com/GizClaw/flowcraft/sdk/embedding"
+	"github.com/GizClaw/flowcraft/sdk/llm"
+	"github.com/GizClaw/flowcraft/sdk/recall"
+	"github.com/GizClaw/flowcraft/sdk/retrieval/pipeline"
+)
+
+type scriptedExtractor struct {
+	facts       [][]recall.ExtractedFact
+	err         error
+	calls       int
+	gotExisting [][]string
+}
+
+func (e *scriptedExtractor) Extract(_ context.Context, _ recall.Scope, _ []llm.Message, opts ...recall.ExtractOption) ([]recall.ExtractedFact, error) {
+	var o recall.ExtractOptions
+	for _, opt := range opts {
+		if opt != nil {
+			opt(&o)
+		}
+	}
+	e.gotExisting = append(e.gotExisting, append([]string(nil), o.ExistingFacts...))
+	if e.err != nil {
+		return nil, e.err
+	}
+	i := e.calls
+	e.calls++
+	if i >= len(e.facts) {
+		return nil, nil
+	}
+	return append([]recall.ExtractedFact(nil), e.facts[i]...), nil
+}
+
+type mapEmbedder struct {
+	vectors map[string][]float32
+}
+
+var _ embedding.Embedder = (*mapEmbedder)(nil)
+
+func (e *mapEmbedder) Embed(_ context.Context, text string) ([]float32, error) {
+	if v, ok := e.vectors[text]; ok {
+		return append([]float32(nil), v...), nil
+	}
+	return []float32{0, 0}, nil
+}
+
+func (e *mapEmbedder) EmbedBatch(ctx context.Context, texts []string) ([][]float32, error) {
+	out := make([][]float32, len(texts))
+	for i, text := range texts {
+		v, err := e.Embed(ctx, text)
+		if err != nil {
+			return nil, err
+		}
+		out[i] = v
+	}
+	return out, nil
+}
+
+type failingStage struct {
+	name string
+	err  error
+}
+
+func (s failingStage) Name() string { return s.name }
+func (s failingStage) Run(context.Context, *pipeline.State) error {
+	return s.err
+}

--- a/sdk/retrieval/capabilities.go
+++ b/sdk/retrieval/capabilities.go
@@ -22,6 +22,15 @@ type Capabilities struct {
 
 	ReadAfterWrite bool
 	Distributed    bool
+
+	// Debug reports whether the backend will honour SearchRequest.Debug
+	// (or HybridRequest.Debug) by populating SearchResponse.Execution.
+	//
+	// Backends that delegate retrieval to a higher-level pipeline (e.g.
+	// MemoryIndex used through retrieval/pipeline) typically leave this
+	// false: pipelines populate Execution themselves; the backend has no
+	// view of lanes/stages on the direct Search path.
+	Debug bool
 }
 
 // DefaultMemoryCapabilities returns capabilities for MemoryIndex.

--- a/sdk/retrieval/contract/contract.go
+++ b/sdk/retrieval/contract/contract.go
@@ -23,10 +23,13 @@ func Run(t *testing.T, f Factory) {
 	t.Run("NamespaceIsolation", func(t *testing.T) { testNamespaceIsolation(t, f) })
 	t.Run("SearchNoQuery", func(t *testing.T) { testSearchNoQuery(t, f) })
 	t.Run("ListPagination", func(t *testing.T) { testListPagination(t, f) })
+	t.Run("ListPaginationStalePageToken", func(t *testing.T) { testListPaginationStalePageToken(t, f) })
 	t.Run("FilterEqAndIn", func(t *testing.T) { testFilterEqIn(t, f) })
 	t.Run("FilterRangeAndExists", func(t *testing.T) { testFilterRangeExists(t, f) })
+	t.Run("FilterNotComposes", func(t *testing.T) { testFilterNotComposes(t, f) })
 	t.Run("DeleteByFilterValidation", func(t *testing.T) { testDeleteByFilterValidation(t, f) })
 	t.Run("CapabilitiesShape", func(t *testing.T) { testCapabilitiesShape(t, f) })
+	t.Run("SearchDebugIncludeLanesPopulatesExecution", func(t *testing.T) { testSearchDebugIncludeLanesPopulatesExecution(t, f) })
 }
 
 func mustUpsert(t *testing.T, idx retrieval.Index, ns string, docs []retrieval.Doc) {
@@ -162,6 +165,33 @@ func testListPagination(t *testing.T, f Factory) {
 	}
 }
 
+func testListPaginationStalePageToken(t *testing.T, f Factory) {
+	idx, cleanup := f(t)
+	defer cleanup()
+	defer idx.Close()
+	ctx := context.Background()
+	ns := "ns_list_stale"
+	now := time.Now()
+	mustUpsert(t, idx, ns, []retrieval.Doc{
+		{ID: "a", Content: "x", Timestamp: now},
+		{ID: "b", Content: "x", Timestamp: now.Add(time.Second)},
+	})
+	tok, err := retrieval.EncodeListPageToken(10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp, err := idx.List(ctx, ns, retrieval.ListRequest{PageSize: 2, PageToken: tok})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(resp.Items) != 0 {
+		t.Fatalf("expected empty page for stale token, got %d items", len(resp.Items))
+	}
+	if resp.NextPageToken != "" {
+		t.Fatalf("expected no next token, got %q", resp.NextPageToken)
+	}
+}
+
 func testFilterEqIn(t *testing.T, f Factory) {
 	idx, cleanup := f(t)
 	defer cleanup()
@@ -224,6 +254,33 @@ func testFilterRangeExists(t *testing.T, f Factory) {
 	}
 }
 
+func testFilterNotComposes(t *testing.T, f Factory) {
+	idx, cleanup := f(t)
+	defer cleanup()
+	defer idx.Close()
+	ctx := context.Background()
+	ns := "ns_not"
+	mustUpsert(t, idx, ns, []retrieval.Doc{
+		{ID: "1", Content: "alpha", Metadata: map[string]any{"tenant": "acme", "status": "active"}, Timestamp: time.Now()},
+		{ID: "2", Content: "alpha", Metadata: map[string]any{"tenant": "other", "status": "active"}, Timestamp: time.Now()},
+		{ID: "3", Content: "alpha", Metadata: map[string]any{"tenant": "acme", "status": "deleted"}, Timestamp: time.Now()},
+	})
+	resp, err := idx.Search(ctx, ns, retrieval.SearchRequest{
+		QueryText: "alpha",
+		TopK:      10,
+		Filter: retrieval.Filter{
+			Not: &retrieval.Filter{Eq: map[string]any{"status": "deleted"}},
+			Eq:  map[string]any{"tenant": "acme"},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(resp.Hits) != 1 || resp.Hits[0].Doc.ID != "1" {
+		t.Fatalf("Not composition wrong: %+v", resp.Hits)
+	}
+}
+
 func testDeleteByFilterValidation(t *testing.T, f Factory) {
 	idx, cleanup := f(t)
 	defer cleanup()
@@ -245,6 +302,61 @@ func testCapabilitiesShape(t *testing.T, f Factory) {
 	c := idx.Capabilities()
 	if c.MaxListPageSize < 0 {
 		t.Fatalf("invalid MaxListPageSize: %d", c.MaxListPageSize)
+	}
+}
+
+// testSearchDebugIncludeLanesPopulatesExecution validates that backends
+// advertising Capabilities.Debug honour SearchRequest.Debug by populating
+// SearchResponse.Execution. Backends that delegate execution to a higher
+// layer (e.g. retrieval/pipeline) leave the flag false; this test then
+// skips, keeping the Execution surface strictly opt-in for backends.
+func testSearchDebugIncludeLanesPopulatesExecution(t *testing.T, f Factory) {
+	idx, cleanup := f(t)
+	defer cleanup()
+	defer idx.Close()
+	if !idx.Capabilities().Debug {
+		t.Skip("backend does not advertise Capabilities.Debug")
+	}
+	ctx := context.Background()
+	ns := "ns_debug"
+	now := time.Now()
+	mustUpsert(t, idx, ns, []retrieval.Doc{
+		{ID: "a", Content: "alpha bravo", Timestamp: now},
+		{ID: "b", Content: "charlie delta", Timestamp: now},
+	})
+	resp, err := idx.Search(ctx, ns, retrieval.SearchRequest{
+		QueryText: "alpha",
+		TopK:      5,
+		Debug:     retrieval.SearchDebug{IncludeLanes: true, IncludeStages: true},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp == nil || resp.Execution == nil {
+		t.Fatalf("expected SearchResponse.Execution when Capabilities.Debug=true, got %+v", resp)
+	}
+	exec := resp.Execution
+	if len(exec.Lanes) == 0 && len(exec.Stages) == 0 {
+		t.Fatal("expected at least one of Execution.Lanes / Execution.Stages to be populated")
+	}
+	hitIDs := make(map[string]struct{}, len(resp.Hits))
+	for _, h := range resp.Hits {
+		hitIDs[h.Doc.ID] = struct{}{}
+	}
+	for _, lane := range exec.Lanes {
+		if lane.Key == "" {
+			t.Fatalf("lane %d missing Key", len(exec.Lanes))
+		}
+		for _, h := range lane.Hits {
+			if _, ok := hitIDs[h.Doc.ID]; !ok && len(resp.Hits) > 0 {
+				// Lanes may legitimately surface candidates that fusion later
+				// drops; only flag a lane hit that names a doc that is not in
+				// the namespace at all.
+				if h.Doc.ID != "a" && h.Doc.ID != "b" {
+					t.Fatalf("lane %q surfaced unknown doc %q", lane.Key, h.Doc.ID)
+				}
+			}
+		}
 	}
 }
 

--- a/sdk/retrieval/errors.go
+++ b/sdk/retrieval/errors.go
@@ -8,20 +8,31 @@ import (
 )
 
 // PartialError reports per-document outcomes for a batch Upsert.
+//
+// Backends return PartialError when at least one document in the batch
+// failed validation but other documents were accepted (or would have been
+// accepted if the backend chose to commit per-row). Inspect Results to find
+// the failing IDs; entries with Err == nil indicate successful rows.
 type PartialError struct {
 	Results []DocUpsertResult
 }
 
 func (e *PartialError) Error() string {
+	if e == nil || len(e.Results) == 0 {
+		return "retrieval: partial upsert"
+	}
 	var b strings.Builder
 	b.WriteString("retrieval: partial upsert (")
-	for i, r := range e.Results {
-		if i > 0 {
+	first := true
+	for _, r := range e.Results {
+		if r.Err == nil {
+			continue
+		}
+		if !first {
 			b.WriteString("; ")
 		}
-		if r.Err != nil {
-			fmt.Fprintf(&b, "%s: %v", r.ID, r.Err)
-		}
+		fmt.Fprintf(&b, "%s: %v", r.ID, r.Err)
+		first = false
 	}
 	b.WriteString(")")
 	return b.String()

--- a/sdk/retrieval/errors_test.go
+++ b/sdk/retrieval/errors_test.go
@@ -1,0 +1,45 @@
+package retrieval
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/GizClaw/flowcraft/sdk/errdefs"
+)
+
+func TestPartialErrorEmptyMessage(t *testing.T) {
+	var e *PartialError = &PartialError{}
+	if got := e.Error(); got != "retrieval: partial upsert" {
+		t.Fatalf("empty: got %q", got)
+	}
+}
+
+func TestPartialErrorOnlyReportsFailures(t *testing.T) {
+	e := &PartialError{Results: []DocUpsertResult{
+		{ID: "ok"},
+		{ID: "bad", Err: errdefs.Validationf("boom")},
+		{ID: "also-ok"},
+	}}
+	got := e.Error()
+	if !strings.Contains(got, "bad: ") {
+		t.Fatalf("expected failure id in message, got %q", got)
+	}
+	if strings.Contains(got, "ok") && !strings.Contains(got, "also-ok") {
+		// "ok" appears as a substring of "also-ok"; ensure neither id with
+		// nil error leaks into the user-facing message.
+		t.Fatalf("expected successful ids omitted, got %q", got)
+	}
+	if strings.Contains(got, "; ; ") {
+		t.Fatalf("unexpected empty separator in %q", got)
+	}
+}
+
+func TestErrNoQueryIsValidation(t *testing.T) {
+	if !errdefs.IsValidation(ErrNoQuery) {
+		t.Fatalf("ErrNoQuery should classify as validation")
+	}
+	if !errors.Is(ErrNoQuery, ErrNoQuery) {
+		t.Fatalf("errors.Is should match the sentinel itself")
+	}
+}

--- a/sdk/retrieval/explain.go
+++ b/sdk/retrieval/explain.go
@@ -1,0 +1,95 @@
+package retrieval
+
+import "time"
+
+// LaneKey is the canonical identifier of one retrieval lane that contributed
+// to a search response.
+//
+// Backends MUST use one of the well-known constants below when populating
+// SearchExecution.Lanes; opaque, backend-specific identifiers are allowed
+// (e.g. "pgvector.hybrid"), but the leading segment SHOULD describe the
+// retrieval modality so cross-backend dashboards remain meaningful.
+type LaneKey string
+
+// Well-known lane keys. Pipeline lanes (configured via
+// pipeline.MultiRetrieve / Retrieve) are surfaced under these names so that
+// downstream consumers can render an explanation regardless of which backend
+// (memory, postgres, native hybrid, ...) actually produced the hits.
+const (
+	LaneBM25       LaneKey = "bm25"
+	LaneVector     LaneKey = "vector"
+	LaneSparse     LaneKey = "sparse"
+	LaneEntity     LaneKey = "entity"
+	LaneHybrid     LaneKey = "hybrid"
+	LaneFusion     LaneKey = "fusion"
+	LaneRerank     LaneKey = "rerank"
+	LanePostFilter LaneKey = "postfilter"
+)
+
+// LaneResult describes the contribution of a single retrieval lane to a
+// SearchExecution. Hits is the lane's pre-fusion ranking (already trimmed by
+// the lane's TopK).
+//
+// Hits MUST NOT be aliased with the final SearchResponse.Hits slice; backends
+// SHOULD copy to keep the explanation immutable from the caller's POV.
+type LaneResult struct {
+	Key      LaneKey
+	Hits     []Hit
+	Took     time.Duration
+	Filtered int64
+	Note     string
+}
+
+// StageResult is one entry in SearchExecution.Stages, describing a stage
+// (recall lane, fusion, rerank, post-filter, ...) the backend ran.
+type StageResult struct {
+	Name    string
+	Took    time.Duration
+	Err     string
+	HitsIn  int
+	HitsOut int
+}
+
+// SearchExecution is the structured explanation of how a SearchResponse was
+// produced. It is populated when SearchRequest.Debug.IncludeLanes /
+// IncludeStages are set, and is otherwise nil.
+//
+// Stability: this is the SDK's public, backend-neutral debugging surface.
+// Adding fields is allowed; existing fields are subject to the SDK's
+// backwards-compatibility guarantee.
+type SearchExecution struct {
+	Lanes  []LaneResult
+	Stages []StageResult
+}
+
+// SearchDebug controls how much execution detail a backend should attach to
+// SearchResponse.Execution. Zero value disables all debugging output and is
+// the documented default.
+type SearchDebug struct {
+	IncludeLanes  bool
+	IncludeStages bool
+}
+
+// ProjectRawByRetriever copies the lane hits from a SearchExecution into the
+// legacy RawByRetriever map shape used by SearchResponse before v0.3.0.
+//
+// Returns nil when execution is nil or carries no lanes; the caller may use
+// this as the value for the deprecated SearchResponse.RawByRetriever field.
+func ProjectRawByRetriever(execution *SearchExecution) map[string][]Hit {
+	if execution == nil || len(execution.Lanes) == 0 {
+		return nil
+	}
+	out := make(map[string][]Hit, len(execution.Lanes))
+	for _, lane := range execution.Lanes {
+		if lane.Key == "" || len(lane.Hits) == 0 {
+			continue
+		}
+		cp := make([]Hit, len(lane.Hits))
+		copy(cp, lane.Hits)
+		out[string(lane.Key)] = cp
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}

--- a/sdk/retrieval/explain_test.go
+++ b/sdk/retrieval/explain_test.go
@@ -1,0 +1,39 @@
+package retrieval
+
+import "testing"
+
+func TestProjectRawByRetrieverNilExecution(t *testing.T) {
+	if got := ProjectRawByRetriever(nil); got != nil {
+		t.Fatalf("expected nil for nil execution, got %+v", got)
+	}
+	if got := ProjectRawByRetriever(&SearchExecution{}); got != nil {
+		t.Fatalf("expected nil for empty execution, got %+v", got)
+	}
+}
+
+func TestProjectRawByRetrieverCopiesLaneHits(t *testing.T) {
+	hits := []Hit{{Doc: Doc{ID: "a"}}, {Doc: Doc{ID: "b"}}}
+	exec := &SearchExecution{
+		Lanes: []LaneResult{{Key: LaneBM25, Hits: hits}},
+	}
+	got := ProjectRawByRetriever(exec)
+	if len(got) != 1 || len(got["bm25"]) != 2 {
+		t.Fatalf("unexpected projection: %+v", got)
+	}
+	got["bm25"][0].Doc.ID = "MUTATED"
+	if hits[0].Doc.ID != "a" {
+		t.Fatalf("projection should not alias source slice; src now %s", hits[0].Doc.ID)
+	}
+}
+
+func TestProjectRawByRetrieverSkipsEmptyLanes(t *testing.T) {
+	exec := &SearchExecution{
+		Lanes: []LaneResult{
+			{Key: LaneBM25},
+			{Key: "", Hits: []Hit{{Doc: Doc{ID: "x"}}}},
+		},
+	}
+	if got := ProjectRawByRetriever(exec); got != nil {
+		t.Fatalf("expected nil when no lane has both key and hits, got %+v", got)
+	}
+}

--- a/sdk/retrieval/filter_match.go
+++ b/sdk/retrieval/filter_match.go
@@ -11,7 +11,9 @@ import (
 // Doc.Content is not considered except for Match when the key is "_content".
 func DocMatchesFilter(d Doc, f Filter) bool {
 	if f.Not != nil {
-		return !DocMatchesFilter(d, *f.Not)
+		if DocMatchesFilter(d, *f.Not) {
+			return false
+		}
 	}
 	for _, sub := range f.And {
 		if !DocMatchesFilter(d, sub) {
@@ -120,13 +122,38 @@ func valuesEqual(a, b any) bool {
 	return reflect.DeepEqual(normalizeJSONish(a), normalizeJSONish(b))
 }
 
+// normalizeJSONish coerces every numeric scalar to float64 so that filter
+// equality is symmetric across Go numeric kinds and JSON-decoded float64
+// values. Without this, Filter.Eq{"score": 5} (int) would not match a
+// document whose Metadata["score"] was decoded as float64(5).
+//
+// Booleans, strings, and composite types are returned unchanged.
 func normalizeJSONish(v any) any {
 	switch x := v.(type) {
 	case float64:
-		if x == float64(int64(x)) {
-			return int64(x)
-		}
 		return x
+	case float32:
+		return float64(x)
+	case int:
+		return float64(x)
+	case int8:
+		return float64(x)
+	case int16:
+		return float64(x)
+	case int32:
+		return float64(x)
+	case int64:
+		return float64(x)
+	case uint:
+		return float64(x)
+	case uint8:
+		return float64(x)
+	case uint16:
+		return float64(x)
+	case uint32:
+		return float64(x)
+	case uint64:
+		return float64(x)
 	default:
 		return v
 	}

--- a/sdk/retrieval/filter_match_test.go
+++ b/sdk/retrieval/filter_match_test.go
@@ -1,0 +1,49 @@
+package retrieval
+
+import "testing"
+
+func TestDocMatchesFilter_NumericTypesAreInterchangeable(t *testing.T) {
+	doc := Doc{
+		ID: "n",
+		Metadata: map[string]any{
+			"score": float64(5),
+			"count": int64(7),
+			"ratio": float32(1.5),
+		},
+	}
+	cases := []Filter{
+		{Eq: map[string]any{"score": 5}},
+		{Eq: map[string]any{"score": int64(5)}},
+		{Eq: map[string]any{"count": float64(7)}},
+		{Eq: map[string]any{"ratio": 1.5}},
+		{In: map[string][]any{"score": {1, 5, 9}}},
+		{Range: map[string]Range{"score": {Gte: int64(5), Lt: 6}}},
+	}
+	for i, f := range cases {
+		if !DocMatchesFilter(doc, f) {
+			t.Fatalf("case %d: expected match for %+v", i, f)
+		}
+	}
+}
+
+func TestDocMatchesFilter_NotComposesWithSiblingPredicates(t *testing.T) {
+	doc := Doc{
+		ID:      "doc1",
+		Content: "hello",
+		Metadata: map[string]any{
+			"tenant": "other",
+			"status": "active",
+		},
+	}
+
+	filter := Filter{
+		Not: &Filter{
+			Eq: map[string]any{"status": "deleted"},
+		},
+		Eq: map[string]any{"tenant": "acme"},
+	}
+
+	if DocMatchesFilter(doc, filter) {
+		t.Fatal("expected sibling Eq predicate to remain enforced alongside Not")
+	}
+}

--- a/sdk/retrieval/index.go
+++ b/sdk/retrieval/index.go
@@ -38,6 +38,10 @@ type HybridRequest struct {
 	TopK        int
 	Mode        HybridMode
 	Param       map[string]any
+
+	// Debug controls how much execution detail Hybridable backends should
+	// attach to SearchResponse.Execution. Zero value disables it.
+	Debug SearchDebug
 }
 
 // Vectorizable marks backends that embed internally.

--- a/sdk/retrieval/journal/wrap.go
+++ b/sdk/retrieval/journal/wrap.go
@@ -2,6 +2,7 @@ package journal
 
 import (
 	"context"
+	"io"
 	"time"
 
 	"github.com/GizClaw/flowcraft/sdk/retrieval"
@@ -35,12 +36,21 @@ type journaledIndex struct {
 }
 
 // Wrap returns retrieval.Index that records mutations to j after inner success.
+//
+// The wrapper transparently delegates the optional retrieval sub-interfaces
+// (DocGetter, Filterable, DeletableByFilter, Droppable, Iterable,
+// Snapshottable, Hybridable, Vectorizable) so that callers who type-assert
+// on the wrapped value still reach the inner backend's native fast paths.
+// DeleteByFilter and Drop additionally emit OpDelete events for every
+// affected document so the journal stays a complete audit log; this can be
+// expensive on bulk deletes — call directly on the inner Index when audit
+// is not required.
 func Wrap(inner retrieval.Index, j Journal, opts ...Option) retrieval.Index {
 	cfg := wrapCfg{}
 	for _, o := range opts {
 		o(&cfg)
 	}
-	return &journaledIndex{inner: inner, j: j, actor: cfg.actor}
+	return newWrapped(&journaledIndex{inner: inner, j: j, actor: cfg.actor})
 }
 
 func (w *journaledIndex) Capabilities() retrieval.Capabilities { return w.inner.Capabilities() }
@@ -139,3 +149,253 @@ func (w *journaledIndex) Search(ctx context.Context, namespace string, req retri
 func (w *journaledIndex) List(ctx context.Context, namespace string, req retrieval.ListRequest) (*retrieval.ListResponse, error) {
 	return w.inner.List(ctx, namespace, req)
 }
+
+// recordDocEvents emits OpDelete events for the supplied snapshot of docs
+// using a single timestamp. Used by DeleteByFilter / Drop bridges to keep
+// the journal a faithful audit log of bulk deletes.
+func (w *journaledIndex) recordDocEvents(ctx context.Context, namespace string, docs []retrieval.Doc) error {
+	now := time.Now()
+	act := ""
+	if w.actor != nil {
+		act = w.actor(ctx)
+	}
+	for i := range docs {
+		d := docs[i]
+		ev := Event{
+			Namespace: namespace,
+			Op:        OpDelete,
+			DocID:     d.ID,
+			Before:    &d,
+			After:     nil,
+			Actor:     act,
+			Timestamp: now,
+		}
+		if err := w.j.Record(ctx, ev); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// snapshotForFilter returns the documents that match f in namespace by
+// walking the inner Index (Iterate first, falling back to List). Used to
+// reconstruct OpDelete events for DeleteByFilter / Drop journaling.
+func (w *journaledIndex) snapshotForFilter(ctx context.Context, namespace string, f retrieval.Filter) ([]retrieval.Doc, error) {
+	if it, ok := w.inner.(retrieval.Iterable); ok {
+		var out []retrieval.Doc
+		cursor := ""
+		for {
+			batch, next, err := it.Iterate(ctx, namespace, cursor, 256)
+			if err != nil {
+				return nil, err
+			}
+			for _, d := range batch {
+				if retrieval.DocMatchesFilter(d, f) {
+					out = append(out, d)
+				}
+			}
+			if next == "" || next == cursor {
+				break
+			}
+			cursor = next
+		}
+		return out, nil
+	}
+	var out []retrieval.Doc
+	tok := ""
+	for {
+		resp, err := w.inner.List(ctx, namespace, retrieval.ListRequest{
+			Filter: f, PageSize: 256, PageToken: tok, WithVector: true,
+		})
+		if err != nil {
+			return nil, err
+		}
+		if resp == nil {
+			break
+		}
+		out = append(out, resp.Items...)
+		if resp.NextPageToken == "" {
+			break
+		}
+		tok = resp.NextPageToken
+	}
+	return out, nil
+}
+
+// matchAllFilter matches every document; used by Drop bridges to enumerate
+// the namespace before deletion so OpDelete events are emitted for each row.
+//
+// We use Filter.Or with a single empty branch so callers that gate on
+// "non-empty filter" still see this as a deliberate sentinel, distinct from
+// the zero filter that DeleteByFilter rejects.
+var matchAllFilter = retrieval.Filter{Or: []retrieval.Filter{{}}}
+
+// Sub-interface bridges. Each method delegates to the corresponding inner
+// implementation and emits journal events for write operations. Wrap returns
+// a wrapper variant whose method set matches the inner backend's optional
+// interfaces so callers' type assertions keep working.
+
+func (w *journaledIndex) Get(ctx context.Context, namespace, id string) (retrieval.Doc, bool, error) {
+	g, ok := w.inner.(retrieval.DocGetter)
+	if !ok {
+		return retrieval.Doc{}, false, nil
+	}
+	return g.Get(ctx, namespace, id)
+}
+
+func (w *journaledIndex) SupportsFilter(f retrieval.Filter) bool {
+	if x, ok := w.inner.(retrieval.Filterable); ok {
+		return x.SupportsFilter(f)
+	}
+	return false
+}
+
+func (w *journaledIndex) DeleteByFilter(ctx context.Context, namespace string, f retrieval.Filter) (int64, error) {
+	d, ok := w.inner.(retrieval.DeletableByFilter)
+	if !ok {
+		return 0, nil
+	}
+	docs, err := w.snapshotForFilter(ctx, namespace, f)
+	if err != nil {
+		return 0, err
+	}
+	n, err := d.DeleteByFilter(ctx, namespace, f)
+	if err != nil {
+		return n, err
+	}
+	if err := w.recordDocEvents(ctx, namespace, docs); err != nil {
+		return n, err
+	}
+	return n, nil
+}
+
+func (w *journaledIndex) Drop(ctx context.Context, namespace string) error {
+	d, ok := w.inner.(retrieval.Droppable)
+	if !ok {
+		return nil
+	}
+	docs, err := w.snapshotForFilter(ctx, namespace, matchAllFilter)
+	if err != nil {
+		return err
+	}
+	if err := d.Drop(ctx, namespace); err != nil {
+		return err
+	}
+	return w.recordDocEvents(ctx, namespace, docs)
+}
+
+func (w *journaledIndex) Iterate(ctx context.Context, namespace, cursor string, batch int) ([]retrieval.Doc, string, error) {
+	if it, ok := w.inner.(retrieval.Iterable); ok {
+		return it.Iterate(ctx, namespace, cursor, batch)
+	}
+	return nil, "", nil
+}
+
+func (w *journaledIndex) Snapshot(ctx context.Context, namespace string, dst io.Writer) error {
+	if s, ok := w.inner.(retrieval.Snapshottable); ok {
+		return s.Snapshot(ctx, namespace, dst)
+	}
+	return nil
+}
+
+func (w *journaledIndex) Restore(ctx context.Context, namespace string, src io.Reader) error {
+	if s, ok := w.inner.(retrieval.Snapshottable); ok {
+		return s.Restore(ctx, namespace, src)
+	}
+	return nil
+}
+
+func (w *journaledIndex) SearchHybrid(ctx context.Context, namespace string, req retrieval.HybridRequest) (*retrieval.SearchResponse, error) {
+	if h, ok := w.inner.(retrieval.Hybridable); ok {
+		return h.SearchHybrid(ctx, namespace, req)
+	}
+	return nil, nil
+}
+
+func (w *journaledIndex) UpsertWithEmbed(ctx context.Context, namespace string, docs []retrieval.Doc) error {
+	v, ok := w.inner.(retrieval.Vectorizable)
+	if !ok {
+		return nil
+	}
+	if err := v.UpsertWithEmbed(ctx, namespace, docs); err != nil {
+		return err
+	}
+	now := time.Now()
+	act := ""
+	if w.actor != nil {
+		act = w.actor(ctx)
+	}
+	for i := range docs {
+		d := docs[i]
+		after := cloneDocPtr(&d)
+		ev := Event{
+			Namespace: namespace,
+			Op:        OpUpsert,
+			DocID:     d.ID,
+			After:     after,
+			Actor:     act,
+			Timestamp: now,
+		}
+		if err := w.j.Record(ctx, ev); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (w *journaledIndex) SearchByText(ctx context.Context, namespace, text string, topK int) (*retrieval.SearchResponse, error) {
+	if v, ok := w.inner.(retrieval.Vectorizable); ok {
+		return v.SearchByText(ctx, namespace, text, topK)
+	}
+	return nil, nil
+}
+
+// newWrapped returns a retrieval.Index whose method set mirrors the optional
+// interfaces implemented by base.inner. The matrix is small, so we
+// enumerate the combinations rather than rely on dynamic proxying.
+//
+// Combinations omitted here (e.g. Snapshottable + Vectorizable) fall back
+// to the conservative "expose only Index" wrapper. Add a branch when a new
+// backend needs the projection.
+func newWrapped(base *journaledIndex) retrieval.Index {
+	inner := base.inner
+	_, hasGet := inner.(retrieval.DocGetter)
+	_, hasFlt := inner.(retrieval.Filterable)
+	_, hasDF := inner.(retrieval.DeletableByFilter)
+	_, hasDrop := inner.(retrieval.Droppable)
+	_, hasIter := inner.(retrieval.Iterable)
+	switch {
+	case hasGet && hasFlt && hasDF && hasDrop && hasIter:
+		return &wrappedFull{journaledIndex: base}
+	case hasGet && hasDF && hasDrop && hasIter:
+		return &wrappedAuditable{journaledIndex: base}
+	case hasGet && hasIter:
+		return &wrappedReadable{journaledIndex: base}
+	case hasGet:
+		return &wrappedGetter{journaledIndex: base}
+	default:
+		return base
+	}
+}
+
+// The variants below "freeze" the optional method set at compile time so
+// callers' interface assertions reflect the inner backend's true
+// capability surface. Each embeds *journaledIndex so the bridging methods
+// above remain the single source of truth for behaviour.
+
+type wrappedFull struct{ *journaledIndex }
+type wrappedAuditable struct{ *journaledIndex }
+type wrappedReadable struct{ *journaledIndex }
+type wrappedGetter struct{ *journaledIndex }
+
+var (
+	_ retrieval.Index             = (*journaledIndex)(nil)
+	_ retrieval.DocGetter         = (*wrappedGetter)(nil)
+	_ retrieval.DocGetter         = (*wrappedReadable)(nil)
+	_ retrieval.Iterable          = (*wrappedReadable)(nil)
+	_ retrieval.DocGetter         = (*wrappedAuditable)(nil)
+	_ retrieval.DeletableByFilter = (*wrappedAuditable)(nil)
+	_ retrieval.Droppable         = (*wrappedAuditable)(nil)
+	_ retrieval.Iterable          = (*wrappedAuditable)(nil)
+	_ retrieval.Filterable        = (*wrappedFull)(nil)
+)

--- a/sdk/retrieval/journal/wrap_test.go
+++ b/sdk/retrieval/journal/wrap_test.go
@@ -9,6 +9,100 @@ import (
 	"github.com/GizClaw/flowcraft/sdk/retrieval/memory"
 )
 
+func TestWrapPreservesOptionalInterfaces(t *testing.T) {
+	idx := Wrap(memory.New(), NewMemoryJournal())
+	if _, ok := idx.(retrieval.DocGetter); !ok {
+		t.Fatal("DocGetter should be exposed (memory.Index implements it)")
+	}
+	if _, ok := idx.(retrieval.DeletableByFilter); !ok {
+		t.Fatal("DeletableByFilter should be exposed")
+	}
+	if _, ok := idx.(retrieval.Droppable); !ok {
+		t.Fatal("Droppable should be exposed")
+	}
+	if _, ok := idx.(retrieval.Iterable); !ok {
+		t.Fatal("Iterable should be exposed")
+	}
+}
+
+func TestWrapDeleteByFilterRecordsAuditEvents(t *testing.T) {
+	ctx := context.Background()
+	inner := memory.New()
+	j := NewMemoryJournal()
+	idx := Wrap(inner, j)
+	ns := "ns-bulk"
+	docs := []retrieval.Doc{
+		{ID: "x1", Content: "foo", Metadata: map[string]any{"keep": false}, Timestamp: time.Now()},
+		{ID: "x2", Content: "foo", Metadata: map[string]any{"keep": false}, Timestamp: time.Now()},
+		{ID: "x3", Content: "foo", Metadata: map[string]any{"keep": true}, Timestamp: time.Now()},
+	}
+	if err := idx.Upsert(ctx, ns, docs); err != nil {
+		t.Fatal(err)
+	}
+	df := idx.(retrieval.DeletableByFilter)
+	n, err := df.DeleteByFilter(ctx, ns, retrieval.Filter{Eq: map[string]any{"keep": false}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if n != 2 {
+		t.Fatalf("expected 2 deletions, got %d", n)
+	}
+	for _, id := range []string{"x1", "x2"} {
+		h, err := j.History(ctx, ns, id)
+		if err != nil {
+			t.Fatal(err)
+		}
+		var sawDelete bool
+		for _, ev := range h {
+			if ev.Op == OpDelete {
+				sawDelete = true
+				if ev.Before == nil || ev.Before.ID != id {
+					t.Fatalf("delete event missing Before for %s: %+v", id, ev)
+				}
+			}
+		}
+		if !sawDelete {
+			t.Fatalf("expected OpDelete in history for %s, got %+v", id, h)
+		}
+	}
+	h3, _ := j.History(ctx, ns, "x3")
+	for _, ev := range h3 {
+		if ev.Op == OpDelete {
+			t.Fatalf("x3 should not have delete event, got %+v", ev)
+		}
+	}
+}
+
+func TestWrapDropRecordsAuditEvents(t *testing.T) {
+	ctx := context.Background()
+	inner := memory.New()
+	j := NewMemoryJournal()
+	idx := Wrap(inner, j)
+	ns := "ns-drop"
+	if err := idx.Upsert(ctx, ns, []retrieval.Doc{
+		{ID: "a", Content: "x", Timestamp: time.Now()},
+		{ID: "b", Content: "y", Timestamp: time.Now()},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	d := idx.(retrieval.Droppable)
+	if err := d.Drop(ctx, ns); err != nil {
+		t.Fatal(err)
+	}
+	for _, id := range []string{"a", "b"} {
+		h, _ := j.History(ctx, ns, id)
+		seen := false
+		for _, ev := range h {
+			if ev.Op == OpDelete {
+				seen = true
+			}
+		}
+		if !seen {
+			t.Fatalf("expected delete event for %s after Drop, got %+v", id, h)
+		}
+	}
+}
+
 func TestWrapJournalUpsertBefore(t *testing.T) {
 	ctx := context.Background()
 	inner := memory.New()

--- a/sdk/retrieval/memory/index.go
+++ b/sdk/retrieval/memory/index.go
@@ -222,9 +222,11 @@ func (m *Index) Search(_ context.Context, namespace string, req retrieval.Search
 		var hits []retrieval.Hit
 		for _, s := range out {
 			rrf := 1.0/(k+float64(bmRank[s.d.ID])) + 1.0/(k+float64(vecRank[s.d.ID]))
-			if rrf < req.MinScore {
-				continue
-			}
+			// SearchRequest.MinScore is intentionally NOT consulted on the
+			// hybrid path: RRF scores live on a different scale (~1/k) than
+			// raw BM25/cosine, and applying the same threshold here would
+			// silently change meaning depending on which modes were
+			// supplied. Use pipeline.ScoreThreshold for hybrid filtering.
 			hits = append(hits, retrieval.Hit{
 				Doc:    cloneDoc(s.d),
 				Score:  rrf,
@@ -315,10 +317,10 @@ func (m *Index) List(_ context.Context, namespace string, req retrieval.ListRequ
 		}
 	})
 	total := int64(len(all))
-	end := offset + pageSize
-	if end > len(all) {
-		end = len(all)
+	if offset >= len(all) {
+		return &retrieval.ListResponse{Items: []retrieval.Doc{}, Total: total}, nil
 	}
+	end := min(offset+pageSize, len(all))
 	page := all[offset:end]
 	for i := range page {
 		page[i] = projectDoc(cloneDoc(page[i]), req.Project, req.WithVector)
@@ -358,10 +360,7 @@ func (m *Index) Iterate(_ context.Context, namespace string, cursor string, batc
 			start = idx
 		}
 	}
-	end := start + batch
-	if end > len(ids) {
-		end = len(ids)
-	}
+	end := min(start+batch, len(ids))
 	var docs []retrieval.Doc
 	for i := start; i < end; i++ {
 		docs = append(docs, cloneDoc(n.docs[ids[i]]))

--- a/sdk/retrieval/memory/index_test.go
+++ b/sdk/retrieval/memory/index_test.go
@@ -88,6 +88,35 @@ func TestListPagination(t *testing.T) {
 	}
 }
 
+func TestListPagination_StalePageTokenReturnsEmptyPage(t *testing.T) {
+	ctx := context.Background()
+	idx := New()
+	ns := "ns-stale-token"
+	now := time.Now()
+	if err := idx.Upsert(ctx, ns, []retrieval.Doc{
+		{ID: "a", Content: "x", Timestamp: now},
+		{ID: "b", Content: "x", Timestamp: now.Add(time.Second)},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	tok, err := retrieval.EncodeListPageToken(10)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	resp, err := idx.List(ctx, ns, retrieval.ListRequest{PageSize: 2, PageToken: tok})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(resp.Items) != 0 {
+		t.Fatalf("expected empty page for stale token, got %d items", len(resp.Items))
+	}
+	if resp.NextPageToken != "" {
+		t.Fatalf("expected no next token, got %q", resp.NextPageToken)
+	}
+}
+
 func TestHybridRRF(t *testing.T) {
 	ctx := context.Background()
 	idx := New()

--- a/sdk/retrieval/pipeline/doc.go
+++ b/sdk/retrieval/pipeline/doc.go
@@ -2,6 +2,12 @@
 // .
 //
 // A Pipeline is a linear list of Stages run sequentially over a shared State.
+// Empty inputs propagate as no-ops: fusion stages skip when State.Recalls
+// is empty, boost / decay / threshold / post-filter / limit stages skip
+// when State.Final / Reranked / Fused are all empty. This keeps single-
+// lane pipelines that omit recall (e.g. caller pre-populates Final) safe
+// to compose without per-stage guards.
+//
 // Stages may short-circuit by setting State.ShortCircuit = true (e.g. native
 // hybrid backends).
 package pipeline

--- a/sdk/retrieval/pipeline/factory.go
+++ b/sdk/retrieval/pipeline/factory.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/GizClaw/flowcraft/sdk/embedding"
+	"github.com/GizClaw/flowcraft/sdk/retrieval"
 )
 
 // LTMOption mutates the LTM pipeline configuration before assembly.
@@ -91,9 +92,9 @@ func Default(emb embedding.Embedder) *Pipeline {
 		&EmbedQuery{Embedder: emb},
 		EntityExtract{},
 		MultiRetrieve{
-			"bm25":   {Mode: ModeBM25, TopK: 50},
-			"vector": {Mode: ModeVector, TopK: 50},
-			"entity": {Mode: ModeEntity, TopK: 30},
+			string(retrieval.LaneBM25):   {Mode: ModeBM25, TopK: 50},
+			string(retrieval.LaneVector): {Mode: ModeVector, TopK: 50},
+			string(retrieval.LaneEntity): {Mode: ModeEntity, TopK: 30},
 		},
 		RRFFusion{K: 60},
 		EntityBoost{Boost: 0.2},
@@ -126,10 +127,10 @@ func LTM(emb embedding.Embedder, opts ...LTMOption) *Pipeline {
 	// so memory tests / in-process indexes that ship without embeddings keep
 	// working.
 	primaryMode := ModeVector
-	primaryLane := "vector"
+	primaryLane := string(retrieval.LaneVector)
 	if emb == nil {
 		primaryMode = ModeBM25
-		primaryLane = "bm25"
+		primaryLane = string(retrieval.LaneBM25)
 	}
 
 	stages := []Stage{
@@ -142,12 +143,12 @@ func LTM(emb embedding.Embedder, opts ...LTMOption) *Pipeline {
 		// not recall expanders).
 		liftRecall{Lane: primaryLane},
 	}
-	// Only run BM25Boost when the primary lane was vector — otherwise the
-	// BM25 score would be applied twice.
-	if primaryMode == ModeBM25 {
-		cfg.bm25Weight = 0
-	}
-	if cfg.bm25Weight > 0 {
+	// BM25Boost is a re-ranking signal layered on top of the recall lane;
+	// when the recall lane is itself BM25 the boost would double-count, so
+	// we suppress it. This expresses "BM25 is a complement to vector
+	// recall, not its own additive lane" in one place.
+	addBM25Boost := primaryMode != ModeBM25 && cfg.bm25Weight > 0
+	if addBM25Boost {
 		stages = append(stages, BM25Boost{Weight: cfg.bm25Weight})
 	}
 	if cfg.entityBoost > 0 {
@@ -177,8 +178,8 @@ func Knowledge(emb embedding.Embedder, ce Reranker) *Pipeline {
 		&EmbedQuery{Embedder: emb},
 		EntityExtract{},
 		MultiRetrieve{
-			"bm25":   {Mode: ModeBM25, TopK: 50},
-			"vector": {Mode: ModeVector, TopK: 50},
+			string(retrieval.LaneBM25):   {Mode: ModeBM25, TopK: 50},
+			string(retrieval.LaneVector): {Mode: ModeVector, TopK: 50},
 		},
 		RRFFusion{K: 60},
 		EntityBoost{Boost: 0.2},

--- a/sdk/retrieval/pipeline/pipeline.go
+++ b/sdk/retrieval/pipeline/pipeline.go
@@ -2,12 +2,51 @@ package pipeline
 
 import (
 	"context"
+	"sort"
 	"time"
 
 	"github.com/GizClaw/flowcraft/sdk/retrieval"
 	"github.com/GizClaw/flowcraft/sdk/telemetry"
 	"go.opentelemetry.io/otel/attribute"
 )
+
+// wellKnownLaneOrder pins the surface order of the LaneKeys defined in
+// sdk/retrieval/explain.go so that pipelines emitting the same set of lanes
+// produce a deterministic SearchExecution.Lanes slice across runs.
+//
+// Unknown lane keys (e.g. backend-specific "pgvector.hybrid") fall through
+// to lexical order behind the well-known ones; this keeps cross-backend
+// dashboards stable while still allowing custom lanes.
+var wellKnownLaneOrder = map[retrieval.LaneKey]int{
+	retrieval.LaneBM25:       0,
+	retrieval.LaneVector:     1,
+	retrieval.LaneSparse:     2,
+	retrieval.LaneEntity:     3,
+	retrieval.LaneHybrid:     4,
+	retrieval.LaneFusion:     5,
+	retrieval.LaneRerank:     6,
+	retrieval.LanePostFilter: 7,
+}
+
+func sortedLaneNames(recalls map[string][]retrieval.Hit) []string {
+	names := make([]string, 0, len(recalls))
+	for k := range recalls {
+		names = append(names, k)
+	}
+	sort.Slice(names, func(i, j int) bool {
+		oi, iKnown := wellKnownLaneOrder[retrieval.LaneKey(names[i])]
+		oj, jKnown := wellKnownLaneOrder[retrieval.LaneKey(names[j])]
+		switch {
+		case iKnown && jKnown:
+			return oi < oj
+		case iKnown != jKnown:
+			return iKnown
+		default:
+			return names[i] < names[j]
+		}
+	})
+	return names
+}
 
 // Stage is one step of a retrieval pipeline.
 type Stage interface {
@@ -20,6 +59,8 @@ type StageTrace struct {
 	Stage    string
 	Duration time.Duration
 	Err      error
+	HitsIn   int
+	HitsOut  int
 }
 
 // State is the shared workspace across stages.
@@ -35,11 +76,22 @@ type State struct {
 	QueryVector   []float32
 	QueryEntities []string
 	Recalls       map[string][]retrieval.Hit
+	// RecallTimings is keyed identically to Recalls and records how long
+	// the corresponding recall lane took. Populated by Retrieve /
+	// MultiRetrieve; consumed by pipeline.Run to fill LaneResult.Took.
+	// Zero is a valid value (lane skipped or no-op).
+	RecallTimings map[string]time.Duration
 	Fused         []retrieval.Hit
 	Reranked      []retrieval.Hit
 	Final         []retrieval.Hit
 
 	ShortCircuit bool
+
+	// HybridExecution is set by HybridShortCircuit when a backend honours
+	// Debug on its native hybrid path. Pipeline.Run merges these lanes /
+	// stages into SearchResponse.Execution so callers see one consistent
+	// explanation regardless of whether the request was short-circuited.
+	HybridExecution *retrieval.SearchExecution
 
 	Trace []StageTrace
 }
@@ -76,20 +128,29 @@ func (p *Pipeline) Run(ctx context.Context, idx retrieval.Index, namespace strin
 		Recalls:   make(map[string][]retrieval.Hit),
 	}
 	tracer := telemetry.Tracer()
+	overall := time.Now()
 	for _, s := range p.stages {
 		if st.ShortCircuit {
 			break
 		}
 		stageCtx, span := tracer.Start(ctx, "retrieval.stage."+s.Name())
 		t0 := time.Now()
+		hitsIn := currentHitCount(st)
 		err := s.Run(stageCtx, st)
 		dur := time.Since(t0)
+		hitsOut := currentHitCount(st)
 		span.SetAttributes(attribute.Float64("duration_seconds", dur.Seconds()))
 		if err != nil {
 			span.RecordError(err)
 		}
 		span.End()
-		st.Trace = append(st.Trace, StageTrace{Stage: s.Name(), Duration: dur, Err: err})
+		st.Trace = append(st.Trace, StageTrace{
+			Stage:    s.Name(),
+			Duration: dur,
+			Err:      err,
+			HitsIn:   hitsIn,
+			HitsOut:  hitsOut,
+		})
 		if err != nil {
 			return nil, err
 		}
@@ -101,5 +162,87 @@ func (p *Pipeline) Run(ctx context.Context, idx retrieval.Index, namespace strin
 	if hits == nil {
 		hits = st.Fused
 	}
-	return &retrieval.SearchResponse{Hits: hits}, nil
+	resp := &retrieval.SearchResponse{Hits: hits, Took: time.Since(overall)}
+
+	debug := req.Debug
+	if req.ReturnRaw {
+		debug.IncludeLanes = true
+	}
+
+	if debug.IncludeLanes || debug.IncludeStages {
+		exec := &retrieval.SearchExecution{}
+		if debug.IncludeLanes && len(st.Recalls) > 0 {
+			names := sortedLaneNames(st.Recalls)
+			exec.Lanes = make([]retrieval.LaneResult, 0, len(names))
+			for _, name := range names {
+				laneHits := st.Recalls[name]
+				cp := make([]retrieval.Hit, len(laneHits))
+				copy(cp, laneHits)
+				exec.Lanes = append(exec.Lanes, retrieval.LaneResult{
+					Key:  retrieval.LaneKey(name),
+					Hits: cp,
+					Took: st.RecallTimings[name],
+				})
+			}
+		}
+		// Merge any explanation produced by a short-circuited hybrid backend
+		// so the caller observes a single Execution surface regardless of
+		// whether the pipeline ran its own lanes.
+		if debug.IncludeLanes && st.HybridExecution != nil {
+			for _, lane := range st.HybridExecution.Lanes {
+				cp := make([]retrieval.Hit, len(lane.Hits))
+				copy(cp, lane.Hits)
+				exec.Lanes = append(exec.Lanes, retrieval.LaneResult{
+					Key:      lane.Key,
+					Hits:     cp,
+					Took:     lane.Took,
+					Filtered: lane.Filtered,
+					Note:     lane.Note,
+				})
+			}
+		}
+		if debug.IncludeStages && len(st.Trace) > 0 {
+			exec.Stages = make([]retrieval.StageResult, 0, len(st.Trace))
+			for _, tr := range st.Trace {
+				stage := retrieval.StageResult{
+					Name:    tr.Stage,
+					Took:    tr.Duration,
+					HitsIn:  tr.HitsIn,
+					HitsOut: tr.HitsOut,
+				}
+				if tr.Err != nil {
+					stage.Err = tr.Err.Error()
+				}
+				exec.Stages = append(exec.Stages, stage)
+			}
+		}
+		if debug.IncludeStages && st.HybridExecution != nil {
+			exec.Stages = append(exec.Stages, st.HybridExecution.Stages...)
+		}
+		resp.Execution = exec
+		if req.ReturnRaw {
+			resp.RawByRetriever = retrieval.ProjectRawByRetriever(exec)
+		}
+	}
+	return resp, nil
+}
+
+// currentHitCount returns the most-advanced hit slice length so we can
+// approximate hits-in / hits-out per stage without forcing every stage to
+// report it explicitly.
+func currentHitCount(st *State) int {
+	switch {
+	case len(st.Final) > 0:
+		return len(st.Final)
+	case len(st.Reranked) > 0:
+		return len(st.Reranked)
+	case len(st.Fused) > 0:
+		return len(st.Fused)
+	default:
+		total := 0
+		for _, h := range st.Recalls {
+			total += len(h)
+		}
+		return total
+	}
 }

--- a/sdk/retrieval/pipeline/pipeline_test.go
+++ b/sdk/retrieval/pipeline/pipeline_test.go
@@ -59,6 +59,122 @@ func TestPipelineMultiRetrieveAndRRF(t *testing.T) {
 	}
 }
 
+func TestPipelineReturnRawIncludesRetrieverHits(t *testing.T) {
+	ctx := context.Background()
+	idx := memory.New()
+	ns := "ns"
+	_ = idx.Upsert(ctx, ns, []retrieval.Doc{
+		{ID: "1", Content: "coffee tea", Vector: []float32{1, 0, 0}, Timestamp: time.Now()},
+		{ID: "2", Content: "unrelated", Vector: []float32{0, 1, 0}, Timestamp: time.Now()},
+	})
+	pipe := New(
+		MultiRetrieve{
+			"bm25":   {Mode: ModeBM25, TopK: 10},
+			"vector": {Mode: ModeVector, TopK: 10},
+		},
+		RRFFusion{K: 60},
+		Limit{TopK: 5},
+	)
+	resp, err := pipe.Run(ctx, idx, ns, retrieval.SearchRequest{
+		QueryText:   "coffee",
+		QueryVector: []float32{1, 0, 0},
+		TopK:        5,
+		ReturnRaw:   true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(resp.RawByRetriever) != 2 {
+		t.Fatalf("expected raw hits for 2 retrievers, got %+v", resp.RawByRetriever)
+	}
+	if len(resp.RawByRetriever["bm25"]) == 0 {
+		t.Fatalf("expected bm25 raw hits, got %+v", resp.RawByRetriever)
+	}
+	if len(resp.RawByRetriever["vector"]) == 0 {
+		t.Fatalf("expected vector raw hits, got %+v", resp.RawByRetriever)
+	}
+	if resp.Execution == nil {
+		t.Fatal("expected Execution to be populated when ReturnRaw=true")
+	}
+	if len(resp.Execution.Lanes) != 2 {
+		t.Fatalf("expected 2 lanes in Execution, got %+v", resp.Execution.Lanes)
+	}
+	for _, lane := range resp.Execution.Lanes {
+		raw, ok := resp.RawByRetriever[string(lane.Key)]
+		if !ok {
+			t.Fatalf("lane %q missing in RawByRetriever projection", lane.Key)
+		}
+		if len(raw) != len(lane.Hits) {
+			t.Fatalf("lane %q raw/exec mismatch: raw=%d exec=%d", lane.Key, len(raw), len(lane.Hits))
+		}
+	}
+}
+
+func TestPipelineDebugIncludeStagesRecordsTrace(t *testing.T) {
+	ctx := context.Background()
+	idx := memory.New()
+	ns := "ns"
+	_ = idx.Upsert(ctx, ns, []retrieval.Doc{
+		{ID: "1", Content: "coffee tea", Timestamp: time.Now()},
+	})
+	pipe := New(
+		Retrieve{Lane: "bm25", Spec: RetrieveSpec{Mode: ModeBM25, TopK: 10}},
+		RRFFusion{K: 60},
+		Limit{TopK: 5},
+	)
+	resp, err := pipe.Run(ctx, idx, ns, retrieval.SearchRequest{
+		QueryText: "coffee",
+		TopK:      5,
+		Debug:     retrieval.SearchDebug{IncludeStages: true},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.Execution == nil {
+		t.Fatal("expected Execution when Debug.IncludeStages=true")
+	}
+	if len(resp.Execution.Stages) != 3 {
+		t.Fatalf("expected 3 stages, got %+v", resp.Execution.Stages)
+	}
+	if resp.Execution.Stages[0].Name == "" || resp.Execution.Stages[0].Took <= 0 {
+		t.Fatalf("first stage missing name/duration: %+v", resp.Execution.Stages[0])
+	}
+	if len(resp.Execution.Lanes) != 0 {
+		t.Fatalf("expected no lanes when IncludeLanes=false, got %+v", resp.Execution.Lanes)
+	}
+	if resp.RawByRetriever != nil {
+		t.Fatalf("RawByRetriever should remain nil when ReturnRaw=false, got %+v", resp.RawByRetriever)
+	}
+}
+
+func TestPipelineDebugIncludeLanesWithoutLegacyProjection(t *testing.T) {
+	ctx := context.Background()
+	idx := memory.New()
+	ns := "ns"
+	_ = idx.Upsert(ctx, ns, []retrieval.Doc{
+		{ID: "1", Content: "coffee tea", Timestamp: time.Now()},
+	})
+	pipe := New(
+		Retrieve{Lane: "bm25", Spec: RetrieveSpec{Mode: ModeBM25, TopK: 10}},
+		RRFFusion{K: 60},
+		Limit{TopK: 5},
+	)
+	resp, err := pipe.Run(ctx, idx, ns, retrieval.SearchRequest{
+		QueryText: "coffee",
+		TopK:      5,
+		Debug:     retrieval.SearchDebug{IncludeLanes: true},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.Execution == nil || len(resp.Execution.Lanes) != 1 {
+		t.Fatalf("expected one lane in Execution, got %+v", resp.Execution)
+	}
+	if resp.RawByRetriever != nil {
+		t.Fatalf("RawByRetriever should only be populated by ReturnRaw, got %+v", resp.RawByRetriever)
+	}
+}
+
 func TestEntityBoost(t *testing.T) {
 	ctx := context.Background()
 	idx := memory.New()
@@ -106,6 +222,211 @@ func TestTimeDecayBringsNewerToTop(t *testing.T) {
 	}
 	if len(resp.Hits) < 2 || resp.Hits[0].Doc.ID != "new" {
 		t.Fatalf("expected new on top, got %+v", resp.Hits)
+	}
+}
+
+func TestPipelineLaneResultCarriesTook(t *testing.T) {
+	ctx := context.Background()
+	idx := memory.New()
+	ns := "ns"
+	_ = idx.Upsert(ctx, ns, []retrieval.Doc{
+		{ID: "1", Content: "coffee tea", Vector: []float32{1, 0, 0}, Timestamp: time.Now()},
+		{ID: "2", Content: "unrelated", Vector: []float32{0, 1, 0}, Timestamp: time.Now()},
+	})
+	pipe := New(
+		MultiRetrieve{
+			string(retrieval.LaneBM25):   {Mode: ModeBM25, TopK: 10},
+			string(retrieval.LaneVector): {Mode: ModeVector, TopK: 10},
+		},
+		RRFFusion{K: 60},
+		Limit{TopK: 5},
+	)
+	resp, err := pipe.Run(ctx, idx, ns, retrieval.SearchRequest{
+		QueryText:   "coffee",
+		QueryVector: []float32{1, 0, 0},
+		TopK:        5,
+		Debug:       retrieval.SearchDebug{IncludeLanes: true},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.Execution == nil || len(resp.Execution.Lanes) != 2 {
+		t.Fatalf("expected 2 lanes in Execution, got %+v", resp.Execution)
+	}
+	for _, lane := range resp.Execution.Lanes {
+		if lane.Took <= 0 {
+			t.Fatalf("lane %q Took=%s, want > 0", lane.Key, lane.Took)
+		}
+	}
+}
+
+func TestPipelineLaneResultTookKeyedByLaneKey(t *testing.T) {
+	ctx := context.Background()
+	idx := memory.New()
+	ns := "ns"
+	_ = idx.Upsert(ctx, ns, []retrieval.Doc{{ID: "1", Content: "coffee", Timestamp: time.Now()}})
+	pipe := New(
+		Retrieve{Lane: string(retrieval.LaneBM25), Spec: RetrieveSpec{Mode: ModeBM25, TopK: 10}},
+		Limit{TopK: 5},
+	)
+	resp, err := pipe.Run(ctx, idx, ns, retrieval.SearchRequest{
+		QueryText: "coffee", TopK: 5,
+		Debug: retrieval.SearchDebug{IncludeLanes: true},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.Execution == nil || len(resp.Execution.Lanes) != 1 {
+		t.Fatalf("expected one lane, got %+v", resp.Execution)
+	}
+	lane := resp.Execution.Lanes[0]
+	if lane.Key != retrieval.LaneBM25 {
+		t.Fatalf("expected lane key %q, got %q", retrieval.LaneBM25, lane.Key)
+	}
+	if lane.Took <= 0 {
+		t.Fatalf("expected Took > 0, got %s", lane.Took)
+	}
+}
+
+func TestPipelineLaneOrderStable(t *testing.T) {
+	ctx := context.Background()
+	idx := memory.New()
+	ns := "ns"
+	_ = idx.Upsert(ctx, ns, []retrieval.Doc{
+		{ID: "1", Content: "coffee tea", Vector: []float32{1, 0, 0}, Timestamp: time.Now()},
+	})
+	pipe := New(
+		MultiRetrieve{
+			"zeta-custom":              {Mode: ModeBM25, TopK: 5},
+			string(retrieval.LaneBM25): {Mode: ModeBM25, TopK: 5},
+			"alpha-custom":             {Mode: ModeBM25, TopK: 5},
+			string(retrieval.LaneVector): {
+				Mode: ModeVector, TopK: 5,
+			},
+		},
+		Limit{TopK: 10},
+	)
+	expect := []retrieval.LaneKey{
+		retrieval.LaneBM25,
+		retrieval.LaneVector,
+		"alpha-custom",
+		"zeta-custom",
+	}
+	for i := 0; i < 4; i++ {
+		resp, err := pipe.Run(ctx, idx, ns, retrieval.SearchRequest{
+			QueryText:   "coffee",
+			QueryVector: []float32{1, 0, 0},
+			TopK:        5,
+			Debug:       retrieval.SearchDebug{IncludeLanes: true},
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if resp.Execution == nil || len(resp.Execution.Lanes) != len(expect) {
+			t.Fatalf("run %d: expected %d lanes, got %+v", i, len(expect), resp.Execution)
+		}
+		for j, lane := range resp.Execution.Lanes {
+			if lane.Key != expect[j] {
+				t.Fatalf("run %d: lane %d = %q, want %q", i, j, lane.Key, expect[j])
+			}
+		}
+	}
+}
+
+type fakeHybridIndex struct {
+	retrieval.Index
+	gotDebug retrieval.SearchDebug
+	resp     *retrieval.SearchResponse
+}
+
+func (f *fakeHybridIndex) Capabilities() retrieval.Capabilities {
+	c := retrieval.DefaultMemoryCapabilities()
+	c.Hybrid = true
+	c.Debug = true
+	return c
+}
+
+func (f *fakeHybridIndex) SearchHybrid(_ context.Context, _ string, req retrieval.HybridRequest) (*retrieval.SearchResponse, error) {
+	f.gotDebug = req.Debug
+	return f.resp, nil
+}
+
+func TestPipelineHybridShortCircuitForwardsDebug(t *testing.T) {
+	hits := []retrieval.Hit{{Doc: retrieval.Doc{ID: "x"}, Score: 1.0}}
+	exec := &retrieval.SearchExecution{
+		Lanes: []retrieval.LaneResult{{Key: retrieval.LaneHybrid, Hits: hits, Took: time.Millisecond}},
+		Stages: []retrieval.StageResult{
+			{Name: "native.hybrid", HitsIn: 0, HitsOut: 1, Took: time.Millisecond},
+		},
+	}
+	hybrid := &fakeHybridIndex{
+		Index: memory.New(),
+		resp:  &retrieval.SearchResponse{Hits: hits, Execution: exec},
+	}
+	pipe := New(HybridShortCircuit{}, Limit{TopK: 5})
+	resp, err := pipe.Run(context.Background(), hybrid, "ns", retrieval.SearchRequest{
+		QueryText: "q",
+		TopK:      5,
+		Debug:     retrieval.SearchDebug{IncludeLanes: true, IncludeStages: true},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !hybrid.gotDebug.IncludeLanes || !hybrid.gotDebug.IncludeStages {
+		t.Fatalf("backend did not receive Debug, got %+v", hybrid.gotDebug)
+	}
+	if resp.Execution == nil {
+		t.Fatal("expected Execution to be merged from short-circuit response")
+	}
+	if len(resp.Execution.Lanes) != 1 || resp.Execution.Lanes[0].Key != retrieval.LaneHybrid {
+		t.Fatalf("expected hybrid lane in Execution, got %+v", resp.Execution.Lanes)
+	}
+	foundNative := false
+	for _, st := range resp.Execution.Stages {
+		if st.Name == "native.hybrid" {
+			foundNative = true
+		}
+	}
+	if !foundNative {
+		t.Fatalf("expected native stage in Execution.Stages, got %+v", resp.Execution.Stages)
+	}
+}
+
+func TestPickFinalishDoesNotMutateRerankedOrFused(t *testing.T) {
+	ctx := context.Background()
+	idx := memory.New()
+	ns := "ns"
+	now := time.Now()
+	_ = idx.Upsert(ctx, ns, []retrieval.Doc{
+		{ID: "newer", Content: "user likes coffee", Timestamp: now},
+		{ID: "older", Content: "user likes coffee", Timestamp: now.Add(-365 * 24 * time.Hour)},
+	})
+	st := &State{
+		Index:     idx,
+		Namespace: ns,
+		Request:   &retrieval.SearchRequest{QueryText: "coffee", TopK: 5},
+		Recalls:   map[string][]retrieval.Hit{},
+	}
+	if err := (Retrieve{Lane: "bm25", Spec: RetrieveSpec{Mode: ModeBM25, TopK: 10}}).Run(ctx, st); err != nil {
+		t.Fatal(err)
+	}
+	if err := (RRFFusion{}).Run(ctx, st); err != nil {
+		t.Fatal(err)
+	}
+	if len(st.Fused) == 0 {
+		t.Fatalf("expected fused hits, got %+v", st.Fused)
+	}
+	beforeFusedScores := make([]float64, len(st.Fused))
+	for i, h := range st.Fused {
+		beforeFusedScores[i] = h.Score
+	}
+	if err := (TimeDecay{HalfLife: time.Hour, Now: func() time.Time { return now }}).Run(ctx, st); err != nil {
+		t.Fatal(err)
+	}
+	for i, h := range st.Fused {
+		if h.Score != beforeFusedScores[i] {
+			t.Fatalf("fused score mutated at %d: was %f now %f", i, beforeFusedScores[i], h.Score)
+		}
 	}
 }
 

--- a/sdk/retrieval/pipeline/stages_boost.go
+++ b/sdk/retrieval/pipeline/stages_boost.go
@@ -68,7 +68,8 @@ func (s BM25Boost) Run(_ context.Context, st *State) error {
 	}
 	N := float64(len(hits))
 	scoresBM25 := make([]float64, len(hits))
-	var maxBM25, minBM25 float64 = 0, 0
+	maxBM25 := math.Inf(-1)
+	minBM25 := math.Inf(+1)
 	for i, terms := range docTokens {
 		tf := map[string]int{}
 		for _, t := range terms {
@@ -99,7 +100,7 @@ func (s BM25Boost) Run(_ context.Context, st *State) error {
 		if s > maxBM25 {
 			maxBM25 = s
 		}
-		if i == 0 || s < minBM25 {
+		if s < minBM25 {
 			minBM25 = s
 		}
 	}

--- a/sdk/retrieval/pipeline/stages_boost_test.go
+++ b/sdk/retrieval/pipeline/stages_boost_test.go
@@ -1,0 +1,50 @@
+package pipeline
+
+import (
+	"context"
+	"math"
+	"testing"
+
+	"github.com/GizClaw/flowcraft/sdk/retrieval"
+)
+
+func TestBM25Boost_AllEqualScoresIsStable(t *testing.T) {
+	st := &State{
+		Request: &retrieval.SearchRequest{QueryText: "foo"},
+		Final: []retrieval.Hit{
+			{Doc: retrieval.Doc{ID: "a", Content: "foo"}, Score: 1},
+			{Doc: retrieval.Doc{ID: "b", Content: "foo"}, Score: 1},
+		},
+	}
+	if err := (BM25Boost{Weight: 0.3}).Run(context.Background(), st); err != nil {
+		t.Fatal(err)
+	}
+	if len(st.Final) != 2 {
+		t.Fatalf("expected 2 hits, got %d", len(st.Final))
+	}
+	for _, h := range st.Final {
+		if math.IsNaN(h.Score) || math.IsInf(h.Score, 0) {
+			t.Fatalf("unexpected score for %s: %v", h.Doc.ID, h.Score)
+		}
+	}
+}
+
+func TestBM25Boost_NoQueryTermPresentIsNoOp(t *testing.T) {
+	in := []retrieval.Hit{
+		{Doc: retrieval.Doc{ID: "a", Content: "alpha"}, Score: 0.7},
+		{Doc: retrieval.Doc{ID: "b", Content: "bravo"}, Score: 0.3},
+	}
+	st := &State{
+		Request: &retrieval.SearchRequest{QueryText: "missing"},
+		Final:   append([]retrieval.Hit(nil), in...),
+	}
+	if err := (BM25Boost{Weight: 0.5}).Run(context.Background(), st); err != nil {
+		t.Fatal(err)
+	}
+	if len(st.Final) != 2 {
+		t.Fatalf("expected 2 hits, got %d", len(st.Final))
+	}
+	if st.Final[0].Score != in[0].Score || st.Final[1].Score != in[1].Score {
+		t.Fatalf("unexpected score change: %+v -> %+v", in, st.Final)
+	}
+}

--- a/sdk/retrieval/pipeline/stages_fusion.go
+++ b/sdk/retrieval/pipeline/stages_fusion.go
@@ -110,7 +110,7 @@ func (s WeightedFusion) Run(_ context.Context, st *State) error {
 
 // ConvexFusion combines exactly two lanes (bm25/vector) as α·bm25 + (1-α)·vector
 // after min-max normalization.
-// Reads: Recalls["bm25"], Recalls["vector"]. Writes: Fused.
+// Reads: Recalls[retrieval.LaneBM25], Recalls[retrieval.LaneVector]. Writes: Fused.
 type ConvexFusion struct {
 	Alpha float64 // weight for bm25 lane; 0..1
 }
@@ -127,6 +127,9 @@ func (s ConvexFusion) Run(_ context.Context, st *State) error {
 	if a > 1 {
 		a = 1
 	}
-	wf := WeightedFusion{Weights: map[string]float64{"bm25": a, "vector": 1 - a}}
+	wf := WeightedFusion{Weights: map[string]float64{
+		string(retrieval.LaneBM25):   a,
+		string(retrieval.LaneVector): 1 - a,
+	}}
 	return wf.Run(context.Background(), st)
 }

--- a/sdk/retrieval/pipeline/stages_post.go
+++ b/sdk/retrieval/pipeline/stages_post.go
@@ -224,17 +224,29 @@ func (s Limit) Run(_ context.Context, st *State) error {
 }
 
 // pickFinalish returns Final if non-empty, otherwise lifts Fused/Reranked.
+//
+// When lifting from Reranked or Fused the slice is shallow-copied so that
+// downstream stages (which freely mutate Score / Scores in place) cannot
+// corrupt the original Reranked/Fused snapshots that diagnostics or later
+// stages may still want to inspect. Hit.Doc remains shared by design — the
+// document content itself is immutable from the pipeline's POV.
 func pickFinalish(st *State) []retrieval.Hit {
 	if len(st.Final) > 0 {
 		return st.Final
 	}
 	if len(st.Reranked) > 0 {
-		st.Final = st.Reranked
+		st.Final = cloneHits(st.Reranked)
 		return st.Final
 	}
 	if len(st.Fused) > 0 {
-		st.Final = st.Fused
+		st.Final = cloneHits(st.Fused)
 		return st.Final
 	}
 	return nil
+}
+
+func cloneHits(in []retrieval.Hit) []retrieval.Hit {
+	out := make([]retrieval.Hit, len(in))
+	copy(out, in)
+	return out
 }

--- a/sdk/retrieval/pipeline/stages_query.go
+++ b/sdk/retrieval/pipeline/stages_query.go
@@ -15,13 +15,23 @@ import (
 // . Reads: Request.QueryText. Writes: Request.QueryVector.
 //
 // If Request.QueryVector is already non-empty, EmbedQuery is a no-op.
+//
+// The cache evicts entries via TTL expiry on read (lazy) and via an
+// upper-bound eviction (MaxEntries, default 1024) on write so a long-lived
+// EmbedQuery cannot accumulate unbounded memory under high-cardinality
+// query traffic.
 type EmbedQuery struct {
 	Embedder embedding.Embedder
 	TTL      time.Duration
+	// MaxEntries caps the in-memory cache size. Zero means use the
+	// default (1024); negative disables caching entirely.
+	MaxEntries int
 
 	mu    sync.Mutex
 	cache map[string]embedCacheEntry
 }
+
+const defaultEmbedCacheMax = 1024
 
 type embedCacheEntry struct {
 	vec []float32
@@ -43,15 +53,33 @@ func (s *EmbedQuery) Run(ctx context.Context, st *State) error {
 	if ttl <= 0 {
 		ttl = 30 * time.Second
 	}
+	maxEntries := s.MaxEntries
+	switch {
+	case maxEntries < 0:
+		// Caching disabled by the caller.
+		v, err := s.Embedder.Embed(ctx, st.Request.QueryText)
+		if err != nil {
+			return err
+		}
+		st.Request.QueryVector = v
+		return nil
+	case maxEntries == 0:
+		maxEntries = defaultEmbedCacheMax
+	}
 	key := st.Request.QueryText
 	s.mu.Lock()
 	if s.cache == nil {
 		s.cache = make(map[string]embedCacheEntry)
 	}
-	if e, ok := s.cache[key]; ok && time.Now().Before(e.exp) {
-		st.Request.QueryVector = append([]float32(nil), e.vec...)
-		s.mu.Unlock()
-		return nil
+	if e, ok := s.cache[key]; ok {
+		if time.Now().Before(e.exp) {
+			st.Request.QueryVector = append([]float32(nil), e.vec...)
+			s.mu.Unlock()
+			return nil
+		}
+		// Drop the expired entry while we hold the lock to keep the
+		// map size honest under high-churn workloads.
+		delete(s.cache, key)
 	}
 	s.mu.Unlock()
 	v, err := s.Embedder.Embed(ctx, key)
@@ -59,6 +87,26 @@ func (s *EmbedQuery) Run(ctx context.Context, st *State) error {
 		return err
 	}
 	s.mu.Lock()
+	if len(s.cache) >= maxEntries {
+		// Evict any single expired entry first, then fall back to a
+		// random victim. This is intentionally cheap: the cache is a
+		// best-effort latency optimisation, not a correctness boundary.
+		now := time.Now()
+		evicted := false
+		for k, e := range s.cache {
+			if !now.Before(e.exp) {
+				delete(s.cache, k)
+				evicted = true
+				break
+			}
+		}
+		if !evicted {
+			for k := range s.cache {
+				delete(s.cache, k)
+				break
+			}
+		}
+	}
 	s.cache[key] = embedCacheEntry{vec: append([]float32(nil), v...), exp: time.Now().Add(ttl)}
 	s.mu.Unlock()
 	st.Request.QueryVector = v

--- a/sdk/retrieval/pipeline/stages_query_test.go
+++ b/sdk/retrieval/pipeline/stages_query_test.go
@@ -1,0 +1,62 @@
+package pipeline
+
+import (
+	"context"
+	"fmt"
+	"sync/atomic"
+	"testing"
+
+	"github.com/GizClaw/flowcraft/sdk/retrieval"
+)
+
+type countingEmbedder struct {
+	calls atomic.Int64
+}
+
+func (c *countingEmbedder) Embed(_ context.Context, _ string) ([]float32, error) {
+	c.calls.Add(1)
+	return []float32{1, 0, 0}, nil
+}
+
+func (c *countingEmbedder) EmbedBatch(_ context.Context, in []string) ([][]float32, error) {
+	out := make([][]float32, len(in))
+	for i := range in {
+		c.calls.Add(1)
+		out[i] = []float32{1, 0, 0}
+	}
+	return out, nil
+}
+
+func TestEmbedQueryCacheRespectsMaxEntries(t *testing.T) {
+	emb := &countingEmbedder{}
+	st := &EmbedQuery{Embedder: emb, MaxEntries: 4}
+	for i := 0; i < 32; i++ {
+		state := &State{Request: &retrieval.SearchRequest{QueryText: fmt.Sprintf("q%02d", i)}}
+		if err := st.Run(context.Background(), state); err != nil {
+			t.Fatal(err)
+		}
+	}
+	st.mu.Lock()
+	size := len(st.cache)
+	st.mu.Unlock()
+	if size > 4 {
+		t.Fatalf("cache exceeded MaxEntries=4: size=%d", size)
+	}
+}
+
+func TestEmbedQueryCacheDisabled(t *testing.T) {
+	emb := &countingEmbedder{}
+	st := &EmbedQuery{Embedder: emb, MaxEntries: -1}
+	for i := 0; i < 3; i++ {
+		state := &State{Request: &retrieval.SearchRequest{QueryText: "same"}}
+		if err := st.Run(context.Background(), state); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if got := emb.calls.Load(); got != 3 {
+		t.Fatalf("expected 3 embed calls (cache off), got %d", got)
+	}
+	if st.cache != nil && len(st.cache) > 0 {
+		t.Fatalf("cache should be empty when disabled, got %+v", st.cache)
+	}
+}

--- a/sdk/retrieval/pipeline/stages_recall.go
+++ b/sdk/retrieval/pipeline/stages_recall.go
@@ -4,18 +4,24 @@ import (
 	"context"
 	"sort"
 	"sync"
+	"time"
 
 	"github.com/GizClaw/flowcraft/sdk/retrieval"
 )
 
 // RetrieveMode is one source for MultiRetrieve / Retrieve.
+//
+// The string value of each mode MUST match the corresponding
+// [retrieval.LaneKey] constant — they share the same wire format so that
+// SearchExecution.Lanes produced by this package can be keyed and
+// rendered uniformly across backends.
 type RetrieveMode string
 
 const (
-	ModeBM25   RetrieveMode = "bm25"
-	ModeVector RetrieveMode = "vector"
-	ModeSparse RetrieveMode = "sparse"
-	ModeEntity RetrieveMode = "entity"
+	ModeBM25   RetrieveMode = RetrieveMode(retrieval.LaneBM25)
+	ModeVector RetrieveMode = RetrieveMode(retrieval.LaneVector)
+	ModeSparse RetrieveMode = RetrieveMode(retrieval.LaneSparse)
+	ModeEntity RetrieveMode = RetrieveMode(retrieval.LaneEntity)
 )
 
 // RetrieveSpec controls one recall lane.
@@ -26,7 +32,7 @@ type RetrieveSpec struct {
 }
 
 // Retrieve runs one recall lane and stores hits in Recalls[name]
-// . Reads: Request.*, QueryEntities. Writes: Recalls[Name].
+// . Reads: Request.*, QueryEntities. Writes: Recalls[Name], RecallTimings[Name].
 type Retrieve struct {
 	Lane string
 	Spec RetrieveSpec
@@ -40,7 +46,12 @@ func (s Retrieve) Run(ctx context.Context, st *State) error {
 	if st.Recalls == nil {
 		st.Recalls = make(map[string][]retrieval.Hit)
 	}
+	if st.RecallTimings == nil {
+		st.RecallTimings = make(map[string]time.Duration)
+	}
+	t0 := time.Now()
 	hits, err := runOneRecall(ctx, st, s.Lane, s.Spec)
+	st.RecallTimings[s.Lane] = time.Since(t0)
 	if err != nil {
 		return err
 	}
@@ -49,7 +60,16 @@ func (s Retrieve) Run(ctx context.Context, st *State) error {
 }
 
 // MultiRetrieve runs multiple recall lanes concurrently
-// . Reads: Request.*, QueryEntities. Writes: Recalls.
+// . Reads: Request.*, QueryEntities. Writes: Recalls, RecallTimings.
+//
+// Error policy (v0): the first lane error short-circuits the stage and is
+// returned to the pipeline; lanes that already produced results are
+// preserved in State.Recalls / State.RecallTimings, so partial telemetry
+// remains observable, but the pipeline as a whole stops. A future
+// "tolerant" mode that downgrades lane failures to entries on a
+// State.RecallErrors map is tracked under the broader recall-degrade RFC;
+// callers that need it today should run lanes via separate Retrieve
+// stages and tolerate errors at the pipeline level.
 type MultiRetrieve map[string]RetrieveSpec
 
 // Name implements Stage.
@@ -63,9 +83,13 @@ func (s MultiRetrieve) Run(ctx context.Context, st *State) error {
 	if st.Recalls == nil {
 		st.Recalls = make(map[string][]retrieval.Hit)
 	}
+	if st.RecallTimings == nil {
+		st.RecallTimings = make(map[string]time.Duration, len(s))
+	}
 	type res struct {
 		name string
 		hits []retrieval.Hit
+		took time.Duration
 		err  error
 	}
 	ch := make(chan res, len(s))
@@ -74,12 +98,17 @@ func (s MultiRetrieve) Run(ctx context.Context, st *State) error {
 		wg.Add(1)
 		go func(name string, spec RetrieveSpec) {
 			defer wg.Done()
+			t0 := time.Now()
 			hits, err := runOneRecall(ctx, st, name, spec)
-			ch <- res{name: name, hits: hits, err: err}
+			ch <- res{name: name, hits: hits, took: time.Since(t0), err: err}
 		}(name, spec)
 	}
 	go func() { wg.Wait(); close(ch) }()
 	for r := range ch {
+		// Record timing even on lane error so the dashboard can show
+		// "this lane was slow AND failing" instead of dropping the
+		// sample entirely.
+		st.RecallTimings[r.name] = r.took
 		if r.err != nil {
 			return r.err
 		}
@@ -134,10 +163,33 @@ func runOneRecall(ctx context.Context, st *State, _ string, spec RetrieveSpec) (
 		if err != nil || listResp == nil {
 			return nil, err
 		}
+		// Score the entity lane by overlap count so downstream fusion
+		// stages (WeightedFusion / RRF) have a real signal to work
+		// with. Without this every entity hit looks identical and the
+		// lane behaves as a binary filter.
+		qSet := make(map[string]struct{}, len(st.QueryEntities))
+		for _, e := range st.QueryEntities {
+			qSet[e] = struct{}{}
+		}
 		hits := make([]retrieval.Hit, 0, len(listResp.Items))
 		for _, d := range listResp.Items {
-			hits = append(hits, retrieval.Hit{Doc: d, Score: 1, Scores: map[string]float64{"entity": 1}})
+			overlap := 0
+			for _, e := range docEntities(d) {
+				if _, ok := qSet[e]; ok {
+					overlap++
+				}
+			}
+			score := float64(overlap)
+			if score == 0 {
+				score = 1 // matched the filter but no exact normalised hit
+			}
+			hits = append(hits, retrieval.Hit{
+				Doc:    d,
+				Score:  score,
+				Scores: map[string]float64{"entity": score},
+			})
 		}
+		sort.SliceStable(hits, func(i, j int) bool { return hits[i].Score > hits[j].Score })
 		return hits, nil
 	}
 	resp, err := st.Index.Search(ctx, st.Namespace, req)
@@ -179,10 +231,11 @@ type liftRecall struct {
 func (s liftRecall) Name() string { return "Lift(" + s.Lane + ")" }
 
 // Run implements Stage.
+//
+// Pipeline.Run already breaks out of the stage loop when ShortCircuit is set,
+// so liftRecall does not need to re-check it; reaching Run at all means the
+// pipeline still wants the lift to happen.
 func (s liftRecall) Run(_ context.Context, st *State) error {
-	if st.ShortCircuit {
-		return nil
-	}
 	if st.Recalls == nil {
 		return nil
 	}

--- a/sdk/retrieval/pipeline/stages_rerank.go
+++ b/sdk/retrieval/pipeline/stages_rerank.go
@@ -2,6 +2,7 @@ package pipeline
 
 import (
 	"context"
+	"math"
 	"sort"
 
 	"github.com/GizClaw/flowcraft/sdk/retrieval"
@@ -114,16 +115,5 @@ func cosineHit(a, b retrieval.Hit) float64 {
 	if na == 0 || nb == 0 {
 		return 0
 	}
-	return dot / (sqrt(na) * sqrt(nb))
-}
-
-func sqrt(x float64) float64 {
-	if x <= 0 {
-		return 0
-	}
-	z := x
-	for i := 0; i < 20; i++ {
-		z = (z + x/z) / 2
-	}
-	return z
+	return dot / (math.Sqrt(na) * math.Sqrt(nb))
 }

--- a/sdk/retrieval/pipeline/stages_short.go
+++ b/sdk/retrieval/pipeline/stages_short.go
@@ -44,12 +44,22 @@ func (s HybridShortCircuit) Run(ctx context.Context, st *State) error {
 		TopK:        st.Request.TopK,
 		Mode:        mode,
 		Param:       s.Param,
+		// Forward the caller's debug request so backends that honour
+		// Capabilities.Debug can populate SearchResponse.Execution; the
+		// pipeline copies that explanation into State for emission.
+		Debug: st.Request.Debug,
 	})
 	if err != nil {
 		return err
 	}
 	if resp != nil {
 		st.Final = resp.Hits
+		// Preserve the backend's structured explanation so the wrapping
+		// pipeline can surface it on the short-circuit path. Without this
+		// the pipeline would observe empty Recalls/Trace and produce a
+		// nil SearchResponse.Execution even when the backend tried to
+		// honour Debug.
+		st.HybridExecution = resp.Execution
 	}
 	st.ShortCircuit = true
 	return nil

--- a/sdk/retrieval/search.go
+++ b/sdk/retrieval/search.go
@@ -24,8 +24,24 @@ type SearchRequest struct {
 	HybridMode  HybridMode
 	HybridParam map[string]any
 
+	// Debug controls how much execution detail backends should attach to
+	// SearchResponse.Execution. Zero value disables it.
+	Debug SearchDebug
+
+	// MinScore drops candidates whose final Hit.Score is below this
+	// threshold. Backends MUST only apply MinScore on single-modality
+	// scoring paths (BM25, cosine, sparse) where the score scale is
+	// stable; hybrid / fused scores live on backend-specific scales and
+	// are NOT subject to MinScore — use pipeline.ScoreThreshold there.
+	MinScore float64
+
+	// ReturnRaw asks the backend to expose per-lane raw hits via the legacy
+	// SearchResponse.RawByRetriever map.
+	//
+	// Deprecated: use Debug.IncludeLanes and read SearchResponse.Execution
+	// instead. This field will be removed in v0.3.0; backends populate
+	// RawByRetriever as a projection of Execution while it is still present.
 	ReturnRaw bool
-	MinScore  float64
 }
 
 // SearchResponse holds ranked hits.
@@ -33,6 +49,15 @@ type SearchResponse struct {
 	Hits []Hit
 	Took time.Duration
 
+	// Execution is the structured explanation of how this response was
+	// produced. Populated when SearchRequest.Debug requests it; otherwise nil.
+	Execution *SearchExecution
+
+	// RawByRetriever is the per-lane raw hits map produced by older callers.
+	//
+	// Deprecated: use Execution.Lanes instead. Backends keep this populated
+	// (as a projection of Execution) until v0.3.0, when this field will be
+	// removed.
 	RawByRetriever map[string][]Hit
 }
 

--- a/sdk/retrieval/types.go
+++ b/sdk/retrieval/types.go
@@ -14,27 +14,64 @@ type Doc struct {
 }
 
 // Range is an inclusive/exclusive bound for metadata numeric comparisons.
+//
+// Each bound is interpreted as float64; mixed numeric kinds in metadata
+// (int / int64 / float32 / float64 / uint64) are normalised to float64
+// before comparison so callers do not need to align the wire type.
 type Range struct {
 	Gt, Gte, Lt, Lte any
 }
 
 // Filter is a structured predicate tree over Doc.Metadata (flat keys only).
+//
+// All metadata keys reference Doc.Metadata directly except for "_content",
+// which is a reserved key that maps to Doc.Content for the Match family —
+// useful when callers want a substring filter over the document body
+// without round-tripping through metadata.
+//
+// Composition: empty maps / nil branches are no-ops, so a zero Filter
+// matches every document. Backends that cannot push down a particular
+// operator should return Filterable.SupportsFilter=false and let
+// pipeline.PostFilter (or DocMatchesFilter) handle it client-side.
 type Filter struct {
+	// And requires every sub-filter to match.
 	And []Filter
-	Or  []Filter
+	// Or matches if any sub-filter matches; an empty Or slice is ignored
+	// so it cannot be confused with the always-false predicate.
+	Or []Filter
+	// Not negates the sub-filter; combined with sibling predicates via
+	// implicit AND (see filter_match_test for the exact semantics).
 	Not *Filter
 
-	Eq      map[string]any
-	Neq     map[string]any
-	In      map[string][]any
-	NotIn   map[string][]any
-	Range   map[string]Range
-	Exists  []string
+	// Eq requires Doc.Metadata[k] to equal v after numeric normalisation.
+	Eq map[string]any
+	// Neq is the negation of Eq.
+	Neq map[string]any
+	// In requires Doc.Metadata[k] to equal at least one element of the
+	// list (set membership).
+	In map[string][]any
+	// NotIn is the negation of In.
+	NotIn map[string][]any
+	// Range applies numeric Gt/Gte/Lt/Lte bounds to Doc.Metadata[k].
+	Range map[string]Range
+	// Exists requires Doc.Metadata[k] to be present (any value).
+	Exists []string
+	// Missing requires Doc.Metadata[k] to be absent.
 	Missing []string
-	Match   map[string]string
+	// Match requires the value at k (or Doc.Content when k=="_content") to
+	// contain the given substring. Case-sensitive; for case-insensitive
+	// matches use IContains.
+	Match map[string]string
 
-	Contains    map[string]any
-	IContains   map[string]any
+	// Contains requires Doc.Metadata[k] (string or array) to contain v
+	// case-sensitively. Strings use substring; arrays use element equality.
+	Contains map[string]any
+	// IContains is the case-insensitive variant of Contains.
+	IContains map[string]any
+	// ContainsAny matches when Doc.Metadata[k] (array) shares at least one
+	// element with the supplied list.
 	ContainsAny map[string][]any
+	// ContainsAll matches when Doc.Metadata[k] (array) contains every
+	// element of the supplied list.
 	ContainsAll map[string][]any
 }

--- a/sdkx/retrieval/postgres/doc.go
+++ b/sdkx/retrieval/postgres/doc.go
@@ -18,4 +18,9 @@
 // Tests against a real Postgres run when env var FC_PG_DSN is set:
 //
 //	FC_PG_DSN=postgres://user:pass@127.0.0.1:5432/db?sslmode=disable go test ./...
+//
+// Performance note: List currently scans the whole namespace into memory
+// before applying filter and pagination. It is sized for management /
+// console use; large-scale exports should use Iterate, which streams docs
+// in id order with bounded memory.
 package postgres

--- a/sdkx/retrieval/postgres/index.go
+++ b/sdkx/retrieval/postgres/index.go
@@ -416,6 +416,9 @@ func (s *Index) List(ctx context.Context, ns string, req retrieval.ListRequest) 
 		}
 	}
 	total := int64(len(all))
+	if offset >= len(all) {
+		return &retrieval.ListResponse{Items: []retrieval.Doc{}, Total: total}, nil
+	}
 	end := offset + pageSize
 	if end > len(all) {
 		end = len(all)

--- a/sdkx/retrieval/sqlite/doc.go
+++ b/sdkx/retrieval/sqlite/doc.go
@@ -11,4 +11,10 @@
 //
 // Implementation uses modernc.org/sqlite (pure Go, no cgo) so it works on all
 // platforms supported by the rest of the SDK.
+//
+// Performance note: List performs the full namespace scan in memory (read,
+// filter, paginate) before returning a page. It is intended for management
+// consoles and small-to-medium namespaces; bulk exports or migrations
+// should drive the namespace through Iterate, which streams in id-order
+// without buffering the whole result set.
 package sqlite

--- a/sdkx/retrieval/sqlite/index.go
+++ b/sdkx/retrieval/sqlite/index.go
@@ -485,6 +485,9 @@ func (s *Index) List(ctx context.Context, ns string, req retrieval.ListRequest) 
 		}
 	}
 	total := int64(len(all))
+	if offset >= len(all) {
+		return &retrieval.ListResponse{Items: []retrieval.Doc{}, Total: total}, nil
+	}
 	end := offset + pageSize
 	if end > len(all) {
 		end = len(all)


### PR DESCRIPTION
## Summary

Apply review fixes across `sdk/retrieval`, `sdk/history`, and `sdk/recall`, plus the supporting tests. This is a maintenance batch with no release-relevant API changes — `[skip-tag]` is set in the title so `auto-tag.yml`'s patch bumper does not roll a tag for this merge.

## retrieval — high priority correctness

- **HybridShortCircuit forwards `Debug`.** Previously `SearchRequest.Debug` was dropped on the native-hybrid path; backends that honour `Capabilities.Debug` now receive it and the pipeline merges their `SearchExecution` into the response so callers observe one consistent explanation regardless of which path ran.
- **Stable lane order.** `Pipeline.Run` emits `SearchExecution.Lanes` by well-known `LaneKey` first, then lexical, so dashboards / golden tests don't flake from Go map iteration order.
- **`pickFinalish` no longer aliases `Reranked` / `Fused`.** Lifting now shallow-copies, so in-place rescoring stages (`BM25Boost`, `TimeDecay`, `EntityBoost`, ...) cannot retroactively corrupt earlier snapshots.
- **`BM25Boost` uses ±Inf seeds** for clearer min/max semantics.
- **`MemoryIndex.Search` drops `MinScore` on the hybrid (RRF) branch.** RRF scores live on a different scale than raw BM25/cosine; `SearchRequest.MinScore` now documents the single-modality contract. Hybrid filtering should use `pipeline.ScoreThreshold`.
- **Removed dead `liftRecall` short-circuit guard;** LTM factory expresses the "BM25 is a boost, not a recall expander" rule via a clearer `addBM25Boost` local.

## retrieval — small but visible

- `normalizeJSONish` coerces every numeric kind to `float64` — `Filter.Eq{"score": 5}` now matches metadata decoded as `float64(5)`.
- `PartialError` reports only failing rows; empty form is now stable.
- `journal.Wrap` projects the inner backend's optional sub-interfaces (`DocGetter` / `Filterable` / `DeletableByFilter` / `Droppable` / `Iterable` / `Snapshottable` / `Hybridable` / `Vectorizable`) and fans bulk `DeleteByFilter` / `Drop` into per-doc `OpDelete` events so the audit log stays complete.
- `EmbedQuery` cache gains `MaxEntries` (default 1024) with TTL-aware eviction; `-1` disables caching.
- Entity recall lane scores by overlap count (was constant `1.0`), giving `WeightedFusion` / RRF a real signal.
- `stages_rerank.go` switches to `math.Sqrt`; the hand-rolled Newton iteration is gone.
- `types.go` documents every `Filter` field and the reserved `_content` key.
- `sdkx/retrieval/{postgres,sqlite}`: List doc notes the in-memory scan cost and points bulk export at `Iterate`; the new `offset >= len(all)` guard short-circuits stale page tokens.

## history / recall

- `history.{compactor,store,tools,archive,doc}` — same review pass: refines compactor coordination, adds dedicated coordinator / token / tools tests, folds deprecated knobs into a focused `deprecated.go` surface.
- `recall.{recall,save,sweeper,merger,memory,telemetry}` — introduces `namespace_registry` as the single authority for ns → backend lookup, hardens save / sweep semantics, surfaces telemetry counters.
- Adds regression tests for explain output, save context, sweep, and merger so the contract surface is locked in.

## Tests added

- retrieval: `errors_test.go`, `filter_match_test.go`, `explain_test.go`, plus `pipeline/{stages_boost,stages_query,pipeline}_test.go` additions for lane-order stability, hybrid `Debug` forwarding, and `pickFinalish` isolation; `journal/wrap_test.go` covers sub-interface delegation and bulk-delete journaling.
- history: `coordinator_test.go`, `store_test.go`, `summary_store_test.go`, `token_test.go`, `tools_test.go`.
- recall: `merger_test.go`, `namespace_registry_test.go`, `recall_explain_test.go`, `save_context_test.go`, `sweeper_test.go`, `test_helpers_regression_test.go`.

## Test plan

- [x] `go vet ./sdk/... ./sdkx/...`
- [x] `go test ./sdk/... ./sdkx/...`
- [ ] CI green

Made with [Cursor](https://cursor.com)