### PR TITLE
chore(sdkx,voice): bump sdk dependency to v0.2.2

### DIFF
--- a/sdkx/go.mod
+++ b/sdkx/go.mod
@@ -2,7 +2,7 @@ module github.com/GizClaw/flowcraft/sdkx
 
 go 1.25.0
 
-require github.com/GizClaw/flowcraft/sdk v0.2.0
+require github.com/GizClaw/flowcraft/sdk v0.2.2
 
 require (
 	github.com/PuerkitoBio/goquery v1.11.0

--- a/sdkx/go.sum
+++ b/sdkx/go.sum
@@ -8,8 +8,8 @@ github.com/Azure/azure-sdk-for-go/sdk/internal v1.10.0/go.mod h1:iZDifYGJTIgIIkY
 github.com/AzureAD/microsoft-authentication-library-for-go v1.2.2 h1:XHOnouVk1mxXfQidrMEnLlPk9UMeRtyBTnEFtxkV0kU=
 github.com/AzureAD/microsoft-authentication-library-for-go v1.2.2/go.mod h1:wP83P5OoQ5p6ip3ScPr0BAq0BvuPAvacpEuSzyouqAI=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
-github.com/GizClaw/flowcraft/sdk v0.2.0 h1:K+hs86rxDg6gup8SUIJEfuMJ+3z0V3KOWwLtLWIUl90=
-github.com/GizClaw/flowcraft/sdk v0.2.0/go.mod h1:ESQWkg/xVCc+2RIO7Lxkdp9lwW9U+u2q+lojvnRzK3Y=
+github.com/GizClaw/flowcraft/sdk v0.2.2 h1:smHhb1HcOG3/xlDFDQ1uO+aYMlLvx5AAaGcPsYQDHcY=
+github.com/GizClaw/flowcraft/sdk v0.2.2/go.mod h1:ESQWkg/xVCc+2RIO7Lxkdp9lwW9U+u2q+lojvnRzK3Y=
 github.com/PuerkitoBio/goquery v1.11.0 h1:jZ7pwMQXIITcUXNH83LLk+txlaEy6NVOfTuP43xxfqw=
 github.com/PuerkitoBio/goquery v1.11.0/go.mod h1:wQHgxUOU3JGuj3oD/QFfxUdlzW6xPHfqyHre6VMY4DQ=
 github.com/andybalholm/cascadia v1.3.3 h1:AG2YHrzJIm4BZ19iwJ/DAua6Btl3IwJX+VI4kktS1LM=

--- a/voice/go.mod
+++ b/voice/go.mod
@@ -3,7 +3,7 @@ module github.com/GizClaw/flowcraft/voice
 go 1.25.0
 
 require (
-	github.com/GizClaw/flowcraft/sdk v0.2.0
+	github.com/GizClaw/flowcraft/sdk v0.2.2
 	github.com/coder/websocket v1.8.14
 	github.com/pion/webrtc/v4 v4.2.9
 	github.com/rs/xid v1.6.0

--- a/voice/go.sum
+++ b/voice/go.sum
@@ -1,5 +1,5 @@
-github.com/GizClaw/flowcraft/sdk v0.2.0 h1:K+hs86rxDg6gup8SUIJEfuMJ+3z0V3KOWwLtLWIUl90=
-github.com/GizClaw/flowcraft/sdk v0.2.0/go.mod h1:ESQWkg/xVCc+2RIO7Lxkdp9lwW9U+u2q+lojvnRzK3Y=
+github.com/GizClaw/flowcraft/sdk v0.2.2 h1:smHhb1HcOG3/xlDFDQ1uO+aYMlLvx5AAaGcPsYQDHcY=
+github.com/GizClaw/flowcraft/sdk v0.2.2/go.mod h1:ESQWkg/xVCc+2RIO7Lxkdp9lwW9U+u2q+lojvnRzK3Y=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/coder/websocket v1.8.14 h1:9L0p0iKiNOibykf283eHkKUHHrpG7f65OE3BhhO7v9g=


### PR DESCRIPTION
## Summary

Lift `sdkx/go.mod` and `voice/go.mod`'s `require github.com/GizClaw/flowcraft/sdk` floor from `v0.2.0` to `v0.2.2`.

## Why

`sdk/v0.2.1` (PR#42, knowledge architecture refactor) and `sdk/v0.2.2` (PR#43, history compactor + knowledge reloader race fixes) added new API surface that `sdkx`'s and `voice`'s source already uses on `main`. Their `go.mod` still pinned the floor at `v0.2.0`. This is silently OK in our monorepo because `go.work` redirects to local code, and OK for downstream apps that themselves require `sdk >= v0.2.2`, but it is **not** OK for an app that only requires `sdkx`/`voice` and lets MVS pick `sdk@v0.2.0` — that app would compile `sdkx`/`voice` against a `sdk` predating the refactor and break.

Lifting the floor to `v0.2.2` makes Minimum Version Selection always pick a `sdk` that is known to satisfy `sdkx`/`voice`'s actual API usage.

## Tag implications

After merge, `auto-tag` will:

- skip `sdk` (no `sdk/` changes)
- bump `sdkx` (now `sdkx/v0.2.0` → `sdkx/v0.2.2`, since the next free patch slot is `v0.2.2`; `v0.2.1` was deleted earlier as it pointed to the same code state as the now-merged catch-up tag would have)
- bump `voice` (`voice/v0.2.0` → `voice/v0.2.1`)

This is the desired outcome — `sdkx`/`voice` consumers get pointers to versions whose `go.mod` correctly declares the sdk API they need.

## Test plan

- [x] `GOWORK=off go build ./...` in `sdkx/` and `voice/` against real `sdk@v0.2.2` module zip
- [x] `go test -race ./...` in `sdkx/` and `voice/` (workspace mode, fast feedback)
- [ ] CI green on this PR

Made with [Cursor](https://cursor.com)