### PR TITLE
feat(sdk/engine): public subject contract for cross-engine event routing [skip-tag:sdk]

### DIFF
--- a/sdk/engine/doc.go
+++ b/sdk/engine/doc.go
@@ -83,6 +83,14 @@
 //  8. NoopHost / NoopCheckpointStore — zero-cost stand-ins for tests
 //     and embedded scenarios.
 //
+//  9. Subject schema (subjects.go) — the cross-engine event-routing
+//     convention every implementation MUST follow when publishing
+//     run lifecycle, step lifecycle, and stream-delta envelopes.
+//     Public Subject* / Pattern* builders, the StreamDeltaPayload
+//     decode contract, and SanitiseID live here so consumers (voice,
+//     SSE bridges, dashboards) can route on subject without
+//     importing any concrete engine.
+//
 // # What does NOT live here
 //
 //   - StreamCallback / StreamEvent — replaced by Publisher +
@@ -94,9 +102,9 @@
 //     sdk/agent/strategy.
 //   - VarMessages / VarQuery / VarAnswer — chat conventions that
 //     belong to sdk/agent.
-//   - Subject schema / engine kind enumeration — the host owns the
-//     event-routing convention; engine does not reserve a namespace
-//     or enumerate which engines exist.
+//   - Engine kind enumeration — engine does not reserve a "type"
+//     namespace or list which engines exist; routing on subject is
+//     the only cross-engine identification mechanism.
 //
 // See docs/agent-runtime-redesign.md for the full layering rationale.
 package engine

--- a/sdk/engine/subjects.go
+++ b/sdk/engine/subjects.go
@@ -1,0 +1,309 @@
+package engine
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/GizClaw/flowcraft/sdk/event"
+)
+
+// This file defines the cross-engine event subject convention.
+//
+// Why subjects live in sdk/engine
+//
+// engine is the smallest layer every concrete execution engine must
+// import (to satisfy [Engine.Execute]). Putting the subject convention
+// here means:
+//
+//   - engine implementations have a single source of truth for "how to
+//     name an event"; they MUST construct envelopes via the builders
+//     below rather than fmt.Sprintf-ing their own strings;
+//   - engine consumers (voice, SSE bridges, dashboards, kanban hooks)
+//     can route on subject without knowing which engine produced the
+//     event — they import sdk/engine, not the engine implementation.
+//
+// What this file does NOT lock down
+//
+// engine reserves only the subject prefixes documented below. A
+// concrete engine MAY publish additional subjects under
+// "engine.run.<runID>.<engine-private-segment>...". Examples in
+// graph runner: ".parallel.fork", ".step.<id>.skipped". These extensions
+// share the engine.run.<runID>. prefix so a single PatternRun
+// subscription captures both the contract events and the engine's own
+// extras, but the engine package does not standardise their shape.
+//
+// Subject schema (REQUIRED for every engine implementation):
+//
+//	engine.run.<runID>.start
+//	engine.run.<runID>.end
+//	engine.run.<runID>.step.<actorID>.start
+//	engine.run.<runID>.step.<actorID>.complete
+//	engine.run.<runID>.step.<actorID>.error
+//	engine.run.<runID>.stream.<actorID>.delta
+//
+// "step" is the engine-neutral name for one unit of work in a run; an
+// engine implementation MAY map it onto its own concept (graph runner
+// maps "step" → "node", a future script engine might map it onto a
+// statement). "actorID" is whatever stable identifier the engine uses
+// for that unit; engines are responsible for keeping the value
+// dot/wildcard-free (use [SanitiseID]).
+//
+// "stream" is intentionally a sibling of "step" rather than a child:
+// consumers that only care about LLM token / tool deltas (voice TTS,
+// SSE token typewriter) can subscribe with [PatternRunStream] without
+// also matching every step lifecycle event.
+
+// SubjectPrefix is the fixed root every engine envelope subject MUST
+// start with. Exposed as a constant so consumers can check
+// strings.HasPrefix without re-deriving it.
+const SubjectPrefix = "engine.run."
+
+// ---------- Builders ----------
+
+// SubjectRunStart returns the subject every engine MUST publish exactly
+// once when [Engine.Execute] begins.
+//
+//	engine.run.<runID>.start
+func SubjectRunStart(runID string) event.Subject {
+	return event.Subject(fmt.Sprintf("%s%s.start", SubjectPrefix, SanitiseID(runID)))
+}
+
+// SubjectRunEnd returns the subject every engine MUST publish exactly
+// once when [Engine.Execute] returns, regardless of outcome (clean
+// completion, interrupt, cancel, failure).
+//
+//	engine.run.<runID>.end
+func SubjectRunEnd(runID string) event.Subject {
+	return event.Subject(fmt.Sprintf("%s%s.end", SubjectPrefix, SanitiseID(runID)))
+}
+
+// SubjectStepStart returns the subject every engine MUST publish when
+// it begins executing one step. actorID identifies the unit of work
+// (graph runner: node id; script engine: statement id; etc.).
+//
+//	engine.run.<runID>.step.<actorID>.start
+func SubjectStepStart(runID, actorID string) event.Subject {
+	return event.Subject(fmt.Sprintf("%s%s.step.%s.start", SubjectPrefix, SanitiseID(runID), SanitiseID(actorID)))
+}
+
+// SubjectStepComplete returns the subject every engine MUST publish
+// when one step finishes successfully.
+//
+//	engine.run.<runID>.step.<actorID>.complete
+func SubjectStepComplete(runID, actorID string) event.Subject {
+	return event.Subject(fmt.Sprintf("%s%s.step.%s.complete", SubjectPrefix, SanitiseID(runID), SanitiseID(actorID)))
+}
+
+// SubjectStepError returns the subject every engine MUST publish when
+// one step fails (i.e. when it would normally cause Execute to return
+// a non-nil non-interrupt error).
+//
+//	engine.run.<runID>.step.<actorID>.error
+func SubjectStepError(runID, actorID string) event.Subject {
+	return event.Subject(fmt.Sprintf("%s%s.step.%s.error", SubjectPrefix, SanitiseID(runID), SanitiseID(actorID)))
+}
+
+// SubjectStreamDelta returns the subject every engine MUST use when
+// emitting an in-flight increment from the step identified by
+// actorID — the canonical example is one LLM token, one dispatched
+// tool call, or one tool result.
+//
+// Payload MUST decode to a [StreamDeltaPayload]; see its docs for the
+// per-Type field requirements.
+//
+//	engine.run.<runID>.stream.<actorID>.delta
+func SubjectStreamDelta(runID, actorID string) event.Subject {
+	return event.Subject(fmt.Sprintf("%s%s.stream.%s.delta", SubjectPrefix, SanitiseID(runID), SanitiseID(actorID)))
+}
+
+// ---------- Patterns ----------
+
+// PatternRun returns the wildcard pattern matching every event of one
+// run, regardless of engine implementation or engine-private extension.
+//
+//	engine.run.<runID>.>
+func PatternRun(runID string) event.Pattern {
+	return event.Pattern(fmt.Sprintf("%s%s.>", SubjectPrefix, SanitiseID(runID)))
+}
+
+// PatternAllRuns returns the wildcard pattern matching every event from
+// every run.
+//
+//	engine.run.>
+func PatternAllRuns() event.Pattern {
+	return event.Pattern(SubjectPrefix + ">")
+}
+
+// PatternRunSteps returns the wildcard pattern matching every step
+// lifecycle event (start / complete / error and any engine-private
+// step.* extension such as graph runner's "skipped") of one run.
+//
+//	engine.run.<runID>.step.>
+func PatternRunSteps(runID string) event.Pattern {
+	return event.Pattern(fmt.Sprintf("%s%s.step.>", SubjectPrefix, SanitiseID(runID)))
+}
+
+// PatternRunStream returns the wildcard pattern matching every stream
+// delta of one run. Use this when you want LLM token / tool deltas but
+// not the step lifecycle events.
+//
+//	engine.run.<runID>.stream.>
+func PatternRunStream(runID string) event.Pattern {
+	return event.Pattern(fmt.Sprintf("%s%s.stream.>", SubjectPrefix, SanitiseID(runID)))
+}
+
+// ---------- Classification helpers ----------
+
+// IsStreamDelta reports whether s is a stream-delta subject. Cheap
+// (string-only) so consumers can filter envelopes before the more
+// expensive payload decode.
+//
+// Implementation note: matches subjects shaped like
+// "engine.run.<runID>.stream.<actorID>.delta" — i.e. the prefix is
+// SubjectPrefix, contains ".stream." and ends with ".delta".
+func IsStreamDelta(s event.Subject) bool {
+	str := string(s)
+	if len(str) < len(SubjectPrefix) || str[:len(SubjectPrefix)] != SubjectPrefix {
+		return false
+	}
+	const tail = ".delta"
+	if len(str) <= len(tail) || str[len(str)-len(tail):] != tail {
+		return false
+	}
+	// Cheap "contains .stream." check without splitting; subjects with
+	// a literal ".stream." in an actor id are rejected by SanitiseID
+	// before they reach this point.
+	for i := len(SubjectPrefix); i+len(".stream.") <= len(str)-len(tail); i++ {
+		if str[i:i+len(".stream.")] == ".stream." {
+			return true
+		}
+	}
+	return false
+}
+
+// ---------- Stream delta payload schema ----------
+
+// StreamDeltaType enumerates the kinds of in-flight increments a stream
+// envelope can carry. Engines MUST set [StreamDeltaPayload.Type] to one
+// of these values; consumers SHOULD treat unknown values as forward-
+// compatible additions and skip them.
+type StreamDeltaType string
+
+const (
+	// StreamDeltaToken is one piece of generated assistant text.
+	// Required field: Content.
+	StreamDeltaToken StreamDeltaType = "token"
+
+	// StreamDeltaToolCall is one tool invocation the model just
+	// requested. Required fields: ID, Name. Recommended: Arguments.
+	StreamDeltaToolCall StreamDeltaType = "tool_call"
+
+	// StreamDeltaToolResult is the outcome of one tool invocation —
+	// either the actual result, or a synthesised cancellation when
+	// the round was interrupted before the call dispatched.
+	// Required fields: ToolCallID, Content. Recommended: Name,
+	// IsError, Cancelled.
+	StreamDeltaToolResult StreamDeltaType = "tool_result"
+)
+
+// StreamDeltaPayload is the canonical decoded shape of a
+// [SubjectStreamDelta] envelope's payload.
+//
+// Engines MUST emit payloads that JSON-decode into this struct; the
+// runtime constraint is checked by [DecodeStreamDelta]. Engines MAY
+// add fields beyond what this struct lists — the JSON decoder is
+// permissive on unknowns — but consumers SHOULD only rely on the
+// fields documented here.
+//
+// Per-Type field requirements:
+//
+//	Type           Required               Recommended
+//	------------   --------------------   --------------------
+//	token          Content                —
+//	tool_call      ID, Name               Arguments
+//	tool_result    ToolCallID, Content    Name, IsError, Cancelled
+type StreamDeltaPayload struct {
+	// Type discriminates the payload variant. See StreamDeltaType
+	// constants for the standard values.
+	Type StreamDeltaType `json:"type"`
+
+	// Content carries the assistant text for "token" and the tool
+	// output (typically already serialised) for "tool_result".
+	Content string `json:"content,omitempty"`
+
+	// ID is the tool-call identifier the model assigned. Set on
+	// "tool_call" only; for "tool_result" use ToolCallID instead.
+	ID string `json:"id,omitempty"`
+
+	// Name is the tool name. Set on "tool_call"; recommended on
+	// "tool_result" so consumers can correlate without a separate
+	// dispatch table.
+	Name string `json:"name,omitempty"`
+
+	// Arguments is the tool input the model produced. Engines MAY
+	// pass it as either a string (raw JSON) or an already-decoded
+	// map / slice — consumers should accept both.
+	Arguments any `json:"arguments,omitempty"`
+
+	// ToolCallID pairs a "tool_result" with the originating
+	// "tool_call". Required on tool_result.
+	ToolCallID string `json:"tool_call_id,omitempty"`
+
+	// IsError reports whether the tool dispatch returned an error
+	// payload (vs. a successful result). Set on "tool_result".
+	IsError bool `json:"is_error,omitempty"`
+
+	// Cancelled reports whether this tool_result is a synthesised
+	// cancellation (the call was never dispatched because the round
+	// was interrupted). Set on "tool_result" only.
+	Cancelled bool `json:"cancelled,omitempty"`
+}
+
+// DecodeStreamDelta extracts the payload of a stream-delta envelope.
+// It returns an error when the envelope payload is empty or does not
+// JSON-decode into [StreamDeltaPayload]. It does NOT verify the
+// subject; callers may pre-filter with [IsStreamDelta] when iterating
+// a mixed stream.
+func DecodeStreamDelta(env event.Envelope) (StreamDeltaPayload, error) {
+	var p StreamDeltaPayload
+	if len(env.Payload) == 0 {
+		return p, fmt.Errorf("engine: stream delta envelope %q has empty payload", env.Subject)
+	}
+	if err := json.Unmarshal(env.Payload, &p); err != nil {
+		return p, fmt.Errorf("engine: decode stream delta payload for %q: %w", env.Subject, err)
+	}
+	return p, nil
+}
+
+// ---------- Subject helpers ----------
+
+// SanitiseID escapes characters that would corrupt an event.Subject
+// when the input is concatenated into one. event.Subject segments are
+// separated by '.', and '*' / '>' are reserved by event.Pattern for
+// wildcards; any of these in a runID / actorID would either fragment
+// the subject or turn it into an unintended pattern. SanitiseID
+// replaces each occurrence with '_'.
+//
+// Empty input becomes "_" so the resulting subject keeps a constant
+// segment count even when the engine forgot to mint an id.
+//
+// Engines are expected to call SanitiseID on every user-supplied
+// fragment they splice into a subject. The Subject* / Pattern*
+// builders in this file already do so for their parameters; engine
+// implementations only need it when constructing private extensions
+// of their own.
+func SanitiseID(id string) string {
+	if id == "" {
+		return "_"
+	}
+	out := make([]byte, 0, len(id))
+	for i := 0; i < len(id); i++ {
+		switch id[i] {
+		case '.', '*', '>':
+			out = append(out, '_')
+		default:
+			out = append(out, id[i])
+		}
+	}
+	return string(out)
+}

--- a/sdk/engine/subjects_test.go
+++ b/sdk/engine/subjects_test.go
@@ -1,0 +1,293 @@
+package engine_test
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/GizClaw/flowcraft/sdk/engine"
+	"github.com/GizClaw/flowcraft/sdk/event"
+)
+
+func TestSubjects_Format(t *testing.T) {
+	cases := []struct {
+		name string
+		got  event.Subject
+		want event.Subject
+	}{
+		{"run start", engine.SubjectRunStart("r1"), "engine.run.r1.start"},
+		{"run end", engine.SubjectRunEnd("r1"), "engine.run.r1.end"},
+		{"step start", engine.SubjectStepStart("r1", "s1"), "engine.run.r1.step.s1.start"},
+		{"step complete", engine.SubjectStepComplete("r1", "s1"), "engine.run.r1.step.s1.complete"},
+		{"step error", engine.SubjectStepError("r1", "s1"), "engine.run.r1.step.s1.error"},
+		{"stream delta", engine.SubjectStreamDelta("r1", "s1"), "engine.run.r1.stream.s1.delta"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.got != tc.want {
+				t.Fatalf("want %q, got %q", tc.want, tc.got)
+			}
+			if err := tc.got.Validate(); err != nil {
+				t.Fatalf("subject must be a valid event.Subject, got %v", err)
+			}
+		})
+	}
+}
+
+func TestSubjects_DotsInIDsAreSanitised(t *testing.T) {
+	// runID / actorID containing characters that are reserved in
+	// event.Subject MUST be replaced so the resulting subject still
+	// validates and routes predictably.
+	subj := engine.SubjectStepStart("run.with.dots", "step*id")
+	if err := subj.Validate(); err != nil {
+		t.Fatalf("Validate: %v", err)
+	}
+	if subj != "engine.run.run_with_dots.step.step_id.start" {
+		t.Fatalf("unexpected sanitised subject: %s", subj)
+	}
+}
+
+func TestPatterns_Validate(t *testing.T) {
+	patterns := []event.Pattern{
+		engine.PatternRun("r1"),
+		engine.PatternAllRuns(),
+		engine.PatternRunSteps("r1"),
+		engine.PatternRunStream("r1"),
+	}
+	for _, p := range patterns {
+		if err := p.Validate(); err != nil {
+			t.Fatalf("pattern %q invalid: %v", p, err)
+		}
+	}
+}
+
+func TestPatterns_Matches(t *testing.T) {
+	t.Run("PatternRun matches every event of one run", func(t *testing.T) {
+		p := engine.PatternRun("r1")
+		matches := []event.Subject{
+			engine.SubjectRunStart("r1"),
+			engine.SubjectRunEnd("r1"),
+			engine.SubjectStepStart("r1", "s1"),
+			engine.SubjectStreamDelta("r1", "s1"),
+			// engine-private extension under the same prefix
+			"engine.run.r1.parallel.fork",
+		}
+		for _, s := range matches {
+			if !p.Matches(s) {
+				t.Errorf("PatternRun(r1) should match %q", s)
+			}
+		}
+		if p.Matches(engine.SubjectRunStart("r2")) {
+			t.Errorf("PatternRun(r1) must not match other run")
+		}
+	})
+
+	t.Run("PatternRunSteps matches step events only", func(t *testing.T) {
+		p := engine.PatternRunSteps("r1")
+		if !p.Matches(engine.SubjectStepStart("r1", "s1")) {
+			t.Errorf("should match step.start")
+		}
+		if !p.Matches("engine.run.r1.step.s1.skipped") {
+			t.Errorf("should match engine-private step.* extension")
+		}
+		if p.Matches(engine.SubjectRunStart("r1")) {
+			t.Errorf("must not match run.start")
+		}
+		if p.Matches(engine.SubjectStreamDelta("r1", "s1")) {
+			t.Errorf("must not match stream delta")
+		}
+	})
+
+	t.Run("PatternRunStream matches stream deltas only", func(t *testing.T) {
+		p := engine.PatternRunStream("r1")
+		if !p.Matches(engine.SubjectStreamDelta("r1", "s1")) {
+			t.Errorf("should match stream.delta")
+		}
+		if p.Matches(engine.SubjectStepStart("r1", "s1")) {
+			t.Errorf("must not match step.start")
+		}
+	})
+
+	t.Run("PatternAllRuns matches every run", func(t *testing.T) {
+		p := engine.PatternAllRuns()
+		if !p.Matches(engine.SubjectRunStart("r1")) {
+			t.Errorf("should match r1")
+		}
+		if !p.Matches(engine.SubjectRunStart("r2")) {
+			t.Errorf("should match r2")
+		}
+	})
+}
+
+func TestIsStreamDelta(t *testing.T) {
+	yes := []event.Subject{
+		engine.SubjectStreamDelta("r1", "s1"),
+		engine.SubjectStreamDelta("run-with-hyphens", "actor_id"),
+	}
+	for _, s := range yes {
+		if !engine.IsStreamDelta(s) {
+			t.Errorf("expected IsStreamDelta(%q) = true", s)
+		}
+	}
+
+	no := []event.Subject{
+		engine.SubjectRunStart("r1"),
+		engine.SubjectRunEnd("r1"),
+		engine.SubjectStepStart("r1", "s1"),
+		engine.SubjectStepComplete("r1", "s1"),
+		engine.SubjectStepError("r1", "s1"),
+		"engine.run.r1.parallel.fork", // graph-private, looks similar but not stream
+		"foo.bar.delta",               // wrong prefix
+		"",                            // empty
+	}
+	for _, s := range no {
+		if engine.IsStreamDelta(s) {
+			t.Errorf("expected IsStreamDelta(%q) = false", s)
+		}
+	}
+}
+
+func TestSubjectPrefix_Constant(t *testing.T) {
+	if !strings.HasPrefix(string(engine.SubjectRunStart("r1")), engine.SubjectPrefix) {
+		t.Fatalf("SubjectRunStart should start with SubjectPrefix")
+	}
+}
+
+func TestSanitiseID(t *testing.T) {
+	cases := []struct {
+		in, want string
+	}{
+		{"", "_"},
+		{"r1", "r1"},
+		{"a.b", "a_b"},
+		{"a*b", "a_b"},
+		{"a>b", "a_b"},
+		{"a.b*c>d", "a_b_c_d"},
+		{"normal-id_123", "normal-id_123"},
+	}
+	for _, tc := range cases {
+		if got := engine.SanitiseID(tc.in); got != tc.want {
+			t.Errorf("SanitiseID(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+// ---------- StreamDeltaPayload ----------
+
+func TestDecodeStreamDelta_Token(t *testing.T) {
+	env := mustEnvelope(t,
+		engine.SubjectStreamDelta("r1", "s1"),
+		map[string]any{"type": "token", "content": "你好"},
+	)
+	got, err := engine.DecodeStreamDelta(env)
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if got.Type != engine.StreamDeltaToken {
+		t.Errorf("Type = %q, want token", got.Type)
+	}
+	if got.Content != "你好" {
+		t.Errorf("Content = %q, want 你好", got.Content)
+	}
+}
+
+func TestDecodeStreamDelta_ToolCall(t *testing.T) {
+	env := mustEnvelope(t,
+		engine.SubjectStreamDelta("r1", "s1"),
+		map[string]any{
+			"type":      "tool_call",
+			"id":        "call_1",
+			"name":      "search",
+			"arguments": map[string]any{"q": "weather"},
+		},
+	)
+	got, err := engine.DecodeStreamDelta(env)
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if got.Type != engine.StreamDeltaToolCall {
+		t.Errorf("Type = %q, want tool_call", got.Type)
+	}
+	if got.ID != "call_1" || got.Name != "search" {
+		t.Errorf("ID/Name = %q/%q, want call_1/search", got.ID, got.Name)
+	}
+	args, ok := got.Arguments.(map[string]any)
+	if !ok || args["q"] != "weather" {
+		t.Errorf("Arguments = %#v, want map with q=weather", got.Arguments)
+	}
+}
+
+func TestDecodeStreamDelta_ToolResult(t *testing.T) {
+	env := mustEnvelope(t,
+		engine.SubjectStreamDelta("r1", "s1"),
+		map[string]any{
+			"type":         "tool_result",
+			"tool_call_id": "call_1",
+			"name":         "search",
+			"content":      "sunny",
+			"is_error":     false,
+		},
+	)
+	got, err := engine.DecodeStreamDelta(env)
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if got.Type != engine.StreamDeltaToolResult {
+		t.Errorf("Type = %q, want tool_result", got.Type)
+	}
+	if got.ToolCallID != "call_1" || got.Content != "sunny" {
+		t.Errorf("got %#v", got)
+	}
+	if got.IsError {
+		t.Errorf("IsError = true, want false")
+	}
+}
+
+func TestDecodeStreamDelta_CancelledToolResult(t *testing.T) {
+	env := mustEnvelope(t,
+		engine.SubjectStreamDelta("r1", "s1"),
+		map[string]any{
+			"type":         "tool_result",
+			"tool_call_id": "call_1",
+			"content":      "[cancelled by interrupt]",
+			"is_error":     true,
+			"cancelled":    true,
+		},
+	)
+	got, err := engine.DecodeStreamDelta(env)
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if !got.Cancelled || !got.IsError {
+		t.Errorf("expected Cancelled and IsError both true, got %#v", got)
+	}
+}
+
+func TestDecodeStreamDelta_EmptyPayload(t *testing.T) {
+	env := event.Envelope{Subject: engine.SubjectStreamDelta("r1", "s1")}
+	if _, err := engine.DecodeStreamDelta(env); err == nil {
+		t.Fatal("expected error for empty payload, got nil")
+	}
+}
+
+func TestDecodeStreamDelta_BadJSON(t *testing.T) {
+	env := event.Envelope{
+		Subject: engine.SubjectStreamDelta("r1", "s1"),
+		Payload: json.RawMessage(`{not json`),
+	}
+	if _, err := engine.DecodeStreamDelta(env); err == nil {
+		t.Fatal("expected error for malformed JSON, got nil")
+	}
+}
+
+// ---------- helpers ----------
+
+func mustEnvelope(t *testing.T, subject event.Subject, payload any) event.Envelope {
+	t.Helper()
+	env, err := event.NewEnvelope(context.Background(), subject, payload)
+	if err != nil {
+		t.Fatalf("NewEnvelope: %v", err)
+	}
+	return env
+}

--- a/sdk/graph/runner/aliases.go
+++ b/sdk/graph/runner/aliases.go
@@ -3,39 +3,26 @@ package runner
 import (
 	"context"
 
-	"github.com/GizClaw/flowcraft/sdk/event"
 	"github.com/GizClaw/flowcraft/sdk/graph/runner/internal/executor"
 )
 
 // This file re-exports the small subset of the (internal) executor
-// package that legitimate callers need to interact with: subject
-// patterns for subscribing to envelopes, parallel-execution policy
-// types for runner.WithParallel, the pluggable variable resolver
-// contract, the pluggable merge function contract, and the
-// actor-key context helper. Anything not re-exported here is an
-// implementation detail of the engine that lives entirely behind
+// package that legitimate callers need to interact with: parallel
+// execution policy types for runner.WithParallel, the pluggable
+// variable resolver contract, the pluggable merge function contract,
+// and the actor-key context helper. Anything not re-exported here is
+// an implementation detail of the engine that lives entirely behind
 // runner.Runner.
+//
+// Subject helpers are NOT re-exported. Subscribers should import
+// sdk/engine and use engine.PatternRun / engine.PatternAllRuns /
+// engine.PatternRunSteps / engine.PatternRunStream — the runner
+// publishes envelopes under the engine-contract subject convention,
+// so engine's helpers are the canonical entry point.
 //
 // Each alias names a single concept the executor owns; the runner
 // package never grows its own definition for these so there is one
 // canonical type the user can satisfy / pass around.
-
-// --- event subject helpers ---------------------------------------------------
-
-// PatternRun returns "graph.run.<runID>.>" — every event emitted by
-// the runner for the given run.
-//
-// Use it as the pattern argument to event.Bus.Subscribe when the
-// host implementation routes envelopes through a bus.
-func PatternRun(runID string) event.Pattern { return executor.PatternRun(runID) }
-
-// PatternAllRuns returns "graph.run.>" — every runner event from
-// any run.
-func PatternAllRuns() event.Pattern { return executor.PatternAllRuns() }
-
-// PatternRunNodes returns "graph.run.<runID>.node.>" — every node-level
-// event for the given run.
-func PatternRunNodes(runID string) event.Pattern { return executor.PatternRunNodes(runID) }
 
 // --- parallel execution ------------------------------------------------------
 

--- a/sdk/graph/runner/engine_test.go
+++ b/sdk/graph/runner/engine_test.go
@@ -147,7 +147,7 @@ func TestRunner_Execute_PublishesUnderRunID(t *testing.T) {
 	if len(envs) == 0 {
 		t.Fatal("host received no envelopes")
 	}
-	wantPrefix := "graph.run." + runID + "."
+	wantPrefix := string(engine.SubjectPrefix) + runID + "."
 	for _, e := range envs {
 		if !strings.HasPrefix(string(e.Subject), wantPrefix) {
 			t.Fatalf("envelope subject %q does not carry run.ID prefix %q",

--- a/sdk/graph/runner/integration_test.go
+++ b/sdk/graph/runner/integration_test.go
@@ -126,7 +126,7 @@ func TestAgentRun_HostReceivesEnvelopes(t *testing.T) {
 	if len(envs) == 0 {
 		t.Fatal("host received no envelopes — runner is not publishing through the agent-supplied host")
 	}
-	wantPrefix := "graph.run.run-explicit."
+	wantPrefix := string(engine.SubjectPrefix) + "run-explicit."
 	sawStart, sawEnd := false, false
 	for _, e := range envs {
 		if !strings.HasPrefix(string(e.Subject), wantPrefix) {

--- a/sdk/graph/runner/internal/executor/executor.go
+++ b/sdk/graph/runner/internal/executor/executor.go
@@ -291,7 +291,7 @@ func (e *LocalExecutor) Execute(ctx context.Context, g *graph.Graph, board *grap
 		currentNodes = []string{cfg.startNode}
 	}
 
-	publishGraphEvent(ctx, cfg.publisher, subjGraphStart(cfg.runID),
+	publishGraphEvent(ctx, cfg.publisher, engine.SubjectRunStart(cfg.runID),
 		cfg.runID, g.Name(), actorKey, board.Vars())
 
 	iteration := 0
@@ -346,7 +346,7 @@ func (e *LocalExecutor) Execute(ctx context.Context, g *graph.Graph, board *grap
 				}
 			}
 
-			publishNodeEvent(ctx, cfg.publisher, subjNodeStart(cfg.runID, nodeID),
+			publishNodeEvent(ctx, cfg.publisher, engine.SubjectStepStart(cfg.runID, nodeID),
 				cfg.runID, g.Name(), actorKey, nodeID, nil)
 
 			nodeStart := time.Now()
@@ -382,7 +382,7 @@ func (e *LocalExecutor) Execute(ctx context.Context, g *graph.Graph, board *grap
 
 				if errdefs.IsInterrupted(err) {
 					board.SetVar(graph.VarInterruptedNode, nodeID)
-					publishGraphEvent(ctx, cfg.publisher, subjGraphEnd(cfg.runID),
+					publishGraphEvent(ctx, cfg.publisher, engine.SubjectRunEnd(cfg.runID),
 						cfg.runID, g.Name(), actorKey, nil)
 					graphSpan.SetAttributes(attribute.String("graph.status", "interrupted"))
 					graphExecCount.Add(ctx, 1,
@@ -406,7 +406,7 @@ func (e *LocalExecutor) Execute(ctx context.Context, g *graph.Graph, board *grap
 					otellog.String("node.id", nodeID),
 					otellog.String("error", err.Error()))
 
-				publishNodeEvent(ctx, cfg.publisher, subjNodeError(cfg.runID, nodeID),
+				publishNodeEvent(ctx, cfg.publisher, engine.SubjectStepError(cfg.runID, nodeID),
 					cfg.runID, g.Name(), actorKey, nodeID,
 					map[string]any{"error": err.Error()})
 				return board, err
@@ -427,7 +427,7 @@ func (e *LocalExecutor) Execute(ctx context.Context, g *graph.Graph, board *grap
 				}
 			}
 
-			publishNodeEvent(ctx, cfg.publisher, subjNodeComplete(cfg.runID, nodeID),
+			publishNodeEvent(ctx, cfg.publisher, engine.SubjectStepComplete(cfg.runID, nodeID),
 				cfg.runID, g.Name(), actorKey, nodeID,
 				map[string]any{"iteration": iteration, "vars": board.Vars()})
 
@@ -494,7 +494,7 @@ func (e *LocalExecutor) Execute(ctx context.Context, g *graph.Graph, board *grap
 		return board, fmt.Errorf("graph execution exceeded max iterations (%d)", cfg.maxIterations)
 	}
 
-	publishGraphEvent(ctx, cfg.publisher, subjGraphEnd(cfg.runID),
+	publishGraphEvent(ctx, cfg.publisher, engine.SubjectRunEnd(cfg.runID),
 		cfg.runID, g.Name(), actorKey,
 		map[string]any{"iteration": iteration, "vars": board.Vars()})
 

--- a/sdk/graph/runner/internal/executor/executor_test.go
+++ b/sdk/graph/runner/internal/executor/executor_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/GizClaw/flowcraft/sdk/engine"
 	"github.com/GizClaw/flowcraft/sdk/errdefs"
 	"github.com/GizClaw/flowcraft/sdk/event"
 	"github.com/GizClaw/flowcraft/sdk/graph"
@@ -393,7 +394,7 @@ func TestLocalExecutor_EventBus_Integration(t *testing.T) {
 
 	ctx := context.Background()
 	const runID = "rint-1"
-	sub, err := bus.Subscribe(ctx, PatternRun(runID))
+	sub, err := bus.Subscribe(ctx, engine.PatternRun(runID))
 	if err != nil {
 		t.Fatalf("subscribe: %v", err)
 	}
@@ -414,8 +415,8 @@ func TestLocalExecutor_EventBus_Integration(t *testing.T) {
 		t.Fatalf("execute failed: %v", err)
 	}
 
-	wantStart := subjGraphStart(runID)
-	wantEnd := subjGraphEnd(runID)
+	wantStart := engine.SubjectRunStart(runID)
+	wantEnd := engine.SubjectRunEnd(runID)
 
 	var envelopes []event.Envelope
 	timeout := time.After(time.Second)

--- a/sdk/graph/runner/internal/executor/publisher.go
+++ b/sdk/graph/runner/internal/executor/publisher.go
@@ -94,7 +94,7 @@ func newNodePublisher(ctx context.Context, cfg runConfig, nodeID string) graph.S
 			return
 		}
 		pl := normalisePayload(eventType, payload)
-		publishNodeEvent(ctx, pub, subjNodeStreamDelta(cfg.runID, nodeID),
+		publishNodeEvent(ctx, pub, engine.SubjectStreamDelta(cfg.runID, nodeID),
 			cfg.runID, graphName, actorKey, nodeID, pl)
 	})
 }

--- a/sdk/graph/runner/internal/executor/subjects.go
+++ b/sdk/graph/runner/internal/executor/subjects.go
@@ -10,116 +10,56 @@ import (
 
 // Subject convention emitted by this executor:
 //
-//	graph.run.<runID>.start
-//	graph.run.<runID>.end
-//	graph.run.<runID>.parallel.fork
-//	graph.run.<runID>.parallel.join
-//	graph.run.<runID>.node.<nodeID>.start
-//	graph.run.<runID>.node.<nodeID>.complete
-//	graph.run.<runID>.node.<nodeID>.error
-//	graph.run.<runID>.node.<nodeID>.skipped
-//	graph.run.<runID>.node.<nodeID>.stream.delta
+// Engine-contract subjects (constructed via sdk/engine builders so the
+// names stay aligned with every other engine implementation):
 //
-// runID and nodeID values are inserted verbatim. Callers must keep them
-// dot-free (validateID below); IDs containing '.', '*' or '>' would
-// corrupt the resulting Subject. The executor enforces this by passing
-// every id through sanitiseID before constructing a Subject.
+//	engine.run.<runID>.start                       — engine.SubjectRunStart
+//	engine.run.<runID>.end                         — engine.SubjectRunEnd
+//	engine.run.<runID>.step.<nodeID>.start         — engine.SubjectStepStart
+//	engine.run.<runID>.step.<nodeID>.complete      — engine.SubjectStepComplete
+//	engine.run.<runID>.step.<nodeID>.error         — engine.SubjectStepError
+//	engine.run.<runID>.stream.<nodeID>.delta       — engine.SubjectStreamDelta
+//
+// graph-private extensions (still under engine.run.<runID>. so a single
+// engine.PatternRun subscription captures them; their shape is NOT part
+// of the engine contract):
+//
+//	engine.run.<runID>.parallel.fork
+//	engine.run.<runID>.parallel.join
+//	engine.run.<runID>.step.<nodeID>.skipped
+//
+// graph runner uses node id as the engine "actor" id. Both go through
+// engine.SanitiseID inside the builders so a runID / nodeID containing
+// '.' / '*' / '>' degrades to '_'-substituted segments rather than
+// corrupting the resulting Subject.
 
-const (
-	graphSubjectPrefix = "graph.run."
-)
-
-// subjGraphStart returns "graph.run.<runID>.start".
-func subjGraphStart(runID string) event.Subject {
-	return event.Subject(fmt.Sprintf("%s%s.start", graphSubjectPrefix, sanitiseID(runID)))
-}
-
-// subjGraphEnd returns "graph.run.<runID>.end".
-func subjGraphEnd(runID string) event.Subject {
-	return event.Subject(fmt.Sprintf("%s%s.end", graphSubjectPrefix, sanitiseID(runID)))
-}
-
-// subjParallelFork returns "graph.run.<runID>.parallel.fork".
+// subjParallelFork returns "engine.run.<runID>.parallel.fork".
+//
+// graph-private: declared here because engine does not standardise
+// fan-out semantics. The shared engine.run.<runID>. prefix means
+// engine.PatternRun(runID) still picks it up.
 func subjParallelFork(runID string) event.Subject {
-	return event.Subject(fmt.Sprintf("%s%s.parallel.fork", graphSubjectPrefix, sanitiseID(runID)))
+	return event.Subject(fmt.Sprintf("%s%s.parallel.fork", engine.SubjectPrefix, engine.SanitiseID(runID)))
 }
 
-// subjParallelJoin returns "graph.run.<runID>.parallel.join".
+// subjParallelJoin returns "engine.run.<runID>.parallel.join".
+//
+// graph-private: see subjParallelFork.
 func subjParallelJoin(runID string) event.Subject {
-	return event.Subject(fmt.Sprintf("%s%s.parallel.join", graphSubjectPrefix, sanitiseID(runID)))
+	return event.Subject(fmt.Sprintf("%s%s.parallel.join", engine.SubjectPrefix, engine.SanitiseID(runID)))
 }
 
-// subjNodeStart returns "graph.run.<runID>.node.<nodeID>.start".
-func subjNodeStart(runID, nodeID string) event.Subject {
-	return event.Subject(fmt.Sprintf("%s%s.node.%s.start", graphSubjectPrefix, sanitiseID(runID), sanitiseID(nodeID)))
-}
-
-// subjNodeComplete returns "graph.run.<runID>.node.<nodeID>.complete".
-func subjNodeComplete(runID, nodeID string) event.Subject {
-	return event.Subject(fmt.Sprintf("%s%s.node.%s.complete", graphSubjectPrefix, sanitiseID(runID), sanitiseID(nodeID)))
-}
-
-// subjNodeError returns "graph.run.<runID>.node.<nodeID>.error".
-func subjNodeError(runID, nodeID string) event.Subject {
-	return event.Subject(fmt.Sprintf("%s%s.node.%s.error", graphSubjectPrefix, sanitiseID(runID), sanitiseID(nodeID)))
-}
-
-// subjNodeSkipped returns "graph.run.<runID>.node.<nodeID>.skipped".
+// subjNodeSkipped returns "engine.run.<runID>.step.<nodeID>.skipped".
+//
+// graph-private: declared here because engine does not standardise
+// skip semantics. Sits under the engine "step" namespace so
+// engine.PatternRunSteps(runID) picks it up alongside the contract's
+// step.start / step.complete / step.error events.
 func subjNodeSkipped(runID, nodeID string) event.Subject {
-	return event.Subject(fmt.Sprintf("%s%s.node.%s.skipped", graphSubjectPrefix, sanitiseID(runID), sanitiseID(nodeID)))
+	return event.Subject(fmt.Sprintf("%s%s.step.%s.skipped", engine.SubjectPrefix, engine.SanitiseID(runID), engine.SanitiseID(nodeID)))
 }
 
-// subjNodeStreamDelta returns "graph.run.<runID>.node.<nodeID>.stream.delta".
-func subjNodeStreamDelta(runID, nodeID string) event.Subject {
-	return event.Subject(fmt.Sprintf("%s%s.node.%s.stream.delta", graphSubjectPrefix, sanitiseID(runID), sanitiseID(nodeID)))
-}
-
-// sanitiseID escapes characters that would corrupt a Subject. Subject
-// segments are separated by '.', and '*' / '>' are reserved for Pattern
-// wildcards. We replace each occurrence with '_' rather than rejecting
-// the input so that a misformed user-supplied runID / nodeID degrades to
-// a still-routable subject (over-broad subscriptions still match) instead
-// of silently dropping events.
-//
-// Empty IDs become "_" so the subject keeps a constant segment count.
-func sanitiseID(id string) string {
-	if id == "" {
-		return "_"
-	}
-	out := make([]byte, 0, len(id))
-	for i := 0; i < len(id); i++ {
-		switch id[i] {
-		case '.', '*', '>':
-			out = append(out, '_')
-		default:
-			out = append(out, id[i])
-		}
-	}
-	return string(out)
-}
-
-// PatternRun returns "graph.run.<runID>.>" — a Pattern that matches every
-// event emitted by the executor for the given run.
-//
-// Exposed for callers that want to subscribe to a specific run without
-// hard-coding the subject convention.
-func PatternRun(runID string) event.Pattern {
-	return event.Pattern(fmt.Sprintf("%s%s.>", graphSubjectPrefix, sanitiseID(runID)))
-}
-
-// PatternAllRuns returns "graph.run.>" — every executor event from any
-// run.
-func PatternAllRuns() event.Pattern {
-	return event.Pattern("graph.run.>")
-}
-
-// PatternRunNodes returns "graph.run.<runID>.node.>" — every node-level
-// event for the given run.
-func PatternRunNodes(runID string) event.Pattern {
-	return event.Pattern(fmt.Sprintf("%s%s.node.>", graphSubjectPrefix, sanitiseID(runID)))
-}
-
-// publishGraphEvent fires-and-forgets a graph-level envelope. Headers
+// publishGraphEvent fires-and-forgets a run-level envelope. Headers
 // carry the well-known IDs that callers may need for predicate filtering
 // when subject routing alone is insufficient (e.g. cross-run
 // aggregations).

--- a/sdk/graph/runner/internal/executor/subjects_test.go
+++ b/sdk/graph/runner/internal/executor/subjects_test.go
@@ -6,21 +6,21 @@ import (
 	"github.com/GizClaw/flowcraft/sdk/event"
 )
 
-func TestSubjects_Format(t *testing.T) {
+// These tests pin the graph-private subject extensions only. The
+// engine-contract subjects (run.start / run.end / step.* / stream)
+// are tested in sdk/engine — graph runner builds them via the engine
+// builders, so re-asserting their format here would just duplicate
+// the engine-side assertions.
+
+func TestGraphPrivateSubjects_Format(t *testing.T) {
 	cases := []struct {
 		name string
 		got  event.Subject
 		want event.Subject
 	}{
-		{"graph start", subjGraphStart("r1"), "graph.run.r1.start"},
-		{"graph end", subjGraphEnd("r1"), "graph.run.r1.end"},
-		{"parallel fork", subjParallelFork("r1"), "graph.run.r1.parallel.fork"},
-		{"parallel join", subjParallelJoin("r1"), "graph.run.r1.parallel.join"},
-		{"node start", subjNodeStart("r1", "n1"), "graph.run.r1.node.n1.start"},
-		{"node complete", subjNodeComplete("r1", "n1"), "graph.run.r1.node.n1.complete"},
-		{"node error", subjNodeError("r1", "n1"), "graph.run.r1.node.n1.error"},
-		{"node skipped", subjNodeSkipped("r1", "n1"), "graph.run.r1.node.n1.skipped"},
-		{"stream delta", subjNodeStreamDelta("r1", "n1"), "graph.run.r1.node.n1.stream.delta"},
+		{"parallel fork", subjParallelFork("r1"), "engine.run.r1.parallel.fork"},
+		{"parallel join", subjParallelJoin("r1"), "engine.run.r1.parallel.join"},
+		{"node skipped", subjNodeSkipped("r1", "n1"), "engine.run.r1.step.n1.skipped"},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -34,62 +34,14 @@ func TestSubjects_Format(t *testing.T) {
 	}
 }
 
-func TestSubjects_PatternsValidate(t *testing.T) {
-	patterns := []event.Pattern{
-		PatternRun("r1"),
-		PatternAllRuns(),
-		PatternRunNodes("r1"),
-	}
-	for _, p := range patterns {
-		if err := p.Validate(); err != nil {
-			t.Fatalf("pattern %q invalid: %v", p, err)
-		}
-	}
-
-	// Cross-check Matches against a couple of subjects.
-	if !PatternRun("r1").Matches("graph.run.r1.start") {
-		t.Fatal("PatternRun should match start")
-	}
-	if !PatternRun("r1").Matches("graph.run.r1.node.n1.complete") {
-		t.Fatal("PatternRun should match node events")
-	}
-	if PatternRun("r1").Matches("graph.run.r2.start") {
-		t.Fatal("PatternRun must not cross runs")
-	}
-	if !PatternRunNodes("r1").Matches("graph.run.r1.node.n1.start") {
-		t.Fatal("PatternRunNodes should match")
-	}
-	if PatternRunNodes("r1").Matches("graph.run.r1.start") {
-		t.Fatal("PatternRunNodes must not match graph-level events")
-	}
-}
-
-func TestSanitiseID(t *testing.T) {
-	cases := []struct {
-		in, want string
-	}{
-		{"", "_"},
-		{"r1", "r1"},
-		{"a.b", "a_b"},
-		{"a*b", "a_b"},
-		{"a>b", "a_b"},
-		{"a.b*c>d", "a_b_c_d"},
-		{"normal-id_123", "normal-id_123"},
-	}
-	for _, tc := range cases {
-		if got := sanitiseID(tc.in); got != tc.want {
-			t.Errorf("sanitiseID(%q) = %q, want %q", tc.in, got, tc.want)
-		}
-	}
-}
-
-func TestSubjects_DotInIDDoesNotBreakSubject(t *testing.T) {
-	// runID containing '.' would otherwise fragment the subject.
-	subj := subjNodeStart("run.with.dots", "node.id")
+func TestGraphPrivateSubjects_DotInIDDoesNotBreakSubject(t *testing.T) {
+	// runID containing '.' would otherwise fragment the subject;
+	// engine.SanitiseID (called by the builders) substitutes '_'.
+	subj := subjNodeSkipped("run.with.dots", "node.id")
 	if err := subj.Validate(); err != nil {
 		t.Fatalf("Validate: %v", err)
 	}
-	if subj != "graph.run.run_with_dots.node.node_id.start" {
+	if subj != "engine.run.run_with_dots.step.node_id.skipped" {
 		t.Fatalf("unexpected sanitised subject: %s", subj)
 	}
 }

--- a/sdk/graph/runner/runner_test.go
+++ b/sdk/graph/runner/runner_test.go
@@ -248,7 +248,7 @@ func TestRunner_WithEventBus(t *testing.T) {
 	}
 
 	const runID = "rb-1"
-	sub, err := bus.Subscribe(context.Background(), runner.PatternRun(runID), event.WithBufferSize(16))
+	sub, err := bus.Subscribe(context.Background(), engine.PatternRun(runID), event.WithBufferSize(16))
 	if err != nil {
 		t.Fatalf("subscribe: %v", err)
 	}
@@ -259,7 +259,7 @@ func TestRunner_WithEventBus(t *testing.T) {
 		t.Fatalf("Execute: %v", err)
 	}
 
-	wantPrefix := "graph.run." + runID + "."
+	wantPrefix := string(engine.SubjectPrefix) + runID + "."
 	sawStart, sawEnd := false, false
 	timeout := time.After(time.Second)
 	for !(sawStart && sawEnd) {
@@ -320,7 +320,7 @@ func TestRunner_WithHost(t *testing.T) {
 	if len(envs) == 0 {
 		t.Fatal("expected host to receive envelopes")
 	}
-	wantPrefix := "graph.run." + runID + "."
+	wantPrefix := string(engine.SubjectPrefix) + runID + "."
 	sawStart, sawEnd := false, false
 	for _, env := range envs {
 		s := string(env.Subject)


### PR DESCRIPTION
## Summary

Lifts the event-subject convention from graph runner's `internal/executor` package up into `sdk/engine`, making it the cross-engine contract every implementation must follow when publishing run / step / stream envelopes.

- **New**: `sdk/engine/subjects.go` defines `SubjectPrefix` (`engine.run.`), all `Subject*` / `Pattern*` builders, `IsStreamDelta`, `StreamDeltaPayload` + `DecodeStreamDelta`, and `SanitiseID`.
- **Refactor**: graph runner now constructs subjects through the engine builders. The graph-private extensions it owns (`parallel.fork/join`, `step.<id>.skipped`) remain in `internal/executor/subjects.go` but anchor on `engine.SubjectPrefix` so a single `engine.PatternRun(runID)` subscription still captures them.
- **Drop**: `runner.PatternRun` / `PatternAllRuns` / `PatternRunNodes` re-exports — subscribers should import `sdk/engine` for the canonical patterns.

### Why

The voice package wants to be driven by `sdk/engine` + `sdk/agent` (off `sdk/workflow`) so it can plug into any engine implementation. To do that, voice needs a stable subject contract to recognise "this envelope is an LLM token / tool delta" without hard-coding the graph runner's private layout. Owning the convention in `sdk/engine` turns it from "graph runner's internal habit" into "engine implementations' obligation".

### Subject changes

| Before | After |
|---|---|
| `graph.run.<r>.start` | `engine.run.<r>.start` |
| `graph.run.<r>.end` | `engine.run.<r>.end` |
| `graph.run.<r>.node.<n>.start` | `engine.run.<r>.step.<n>.start` |
| `graph.run.<r>.node.<n>.complete` | `engine.run.<r>.step.<n>.complete` |
| `graph.run.<r>.node.<n>.error` | `engine.run.<r>.step.<n>.error` |
| `graph.run.<r>.node.<n>.stream.delta` | `engine.run.<r>.stream.<n>.delta` |
| `graph.run.<r>.parallel.fork/join` (graph-private) | `engine.run.<r>.parallel.fork/join` |
| `graph.run.<r>.node.<n>.skipped` (graph-private) | `engine.run.<r>.step.<n>.skipped` |

Two intentional design tweaks vs. the old layout:

1. **`node` → `step`**: at the engine layer, the unit of work is generic; "node" is graph-specific.
2. **`stream` is now a sibling of `step`** rather than nested under it. Consumers that only want LLM token / tool deltas can subscribe with `engine.PatternRunStream(runID)` without also matching every step lifecycle event — voice's TTS feeder is the headline use case.

### BREAKING CHANGE

Subject prefix and node→step rename are wire-incompatible with the previous shape. **Released sdk versions are unaffected** because `sdk/v0.2.3` was deleted before this PR landed. External subscribers using `runner.PatternRun` / `PatternAllRuns` / `PatternRunNodes` must switch to the equivalents in `sdk/engine`.

### Auto-tag

Commit message carries `[skip-tag:sdk]` so the auto-tag workflow skips this commit's sdk module bump. The next sdk release should be cut by hand at the appropriate semver level (likely `v0.3.0`, since this is breaking).

## Test plan

- [x] `go test ./...` in `sdk/` (all green, including `engine`'s 14 new test cases)
- [x] `go test ./...` in `voice/` (still green; voice unchanged in this PR but verified the rename did not break its build path)
- [x] graph runner `runner_test.go` / `engine_test.go` / `integration_test.go` updated to assert against `engine.SubjectPrefix`
- [ ] After merge: voice migration off `sdk/workflow` lands in a follow-up PR using `engine.PatternRunStream` + `DecodeStreamDelta`

Made with [Cursor](https://cursor.com)