### PR TITLE
chore(sdkx): bump sdk to v0.2.3 + deprecate knowledge/watcher for v0.3.0

### DIFF
--- a/sdkx/go.mod
+++ b/sdkx/go.mod
@@ -2,7 +2,7 @@ module github.com/GizClaw/flowcraft/sdkx
 
 go 1.25.0
 
-require github.com/GizClaw/flowcraft/sdk v0.2.2
+require github.com/GizClaw/flowcraft/sdk v0.2.3
 
 require (
 	github.com/PuerkitoBio/goquery v1.11.0
@@ -31,7 +31,6 @@ require (
 	github.com/aymerick/douceur v0.2.0 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/dustin/go-humanize v1.0.1 // indirect
-	github.com/expr-lang/expr v1.17.8 // indirect
 	github.com/go-logr/logr v1.4.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/go-shiori/dom v0.0.0-20230515143342-73569d674e1c // indirect

--- a/sdkx/go.sum
+++ b/sdkx/go.sum
@@ -8,8 +8,8 @@ github.com/Azure/azure-sdk-for-go/sdk/internal v1.10.0/go.mod h1:iZDifYGJTIgIIkY
 github.com/AzureAD/microsoft-authentication-library-for-go v1.2.2 h1:XHOnouVk1mxXfQidrMEnLlPk9UMeRtyBTnEFtxkV0kU=
 github.com/AzureAD/microsoft-authentication-library-for-go v1.2.2/go.mod h1:wP83P5OoQ5p6ip3ScPr0BAq0BvuPAvacpEuSzyouqAI=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
-github.com/GizClaw/flowcraft/sdk v0.2.2 h1:smHhb1HcOG3/xlDFDQ1uO+aYMlLvx5AAaGcPsYQDHcY=
-github.com/GizClaw/flowcraft/sdk v0.2.2/go.mod h1:ESQWkg/xVCc+2RIO7Lxkdp9lwW9U+u2q+lojvnRzK3Y=
+github.com/GizClaw/flowcraft/sdk v0.2.3 h1:oGWJRRNOsaN8hOZ6loBsXqqLZFz6RPyunF964/79D+U=
+github.com/GizClaw/flowcraft/sdk v0.2.3/go.mod h1:ESQWkg/xVCc+2RIO7Lxkdp9lwW9U+u2q+lojvnRzK3Y=
 github.com/PuerkitoBio/goquery v1.11.0 h1:jZ7pwMQXIITcUXNH83LLk+txlaEy6NVOfTuP43xxfqw=
 github.com/PuerkitoBio/goquery v1.11.0/go.mod h1:wQHgxUOU3JGuj3oD/QFfxUdlzW6xPHfqyHre6VMY4DQ=
 github.com/andybalholm/cascadia v1.3.3 h1:AG2YHrzJIm4BZ19iwJ/DAua6Btl3IwJX+VI4kktS1LM=
@@ -34,8 +34,6 @@ github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkp
 github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
-github.com/expr-lang/expr v1.17.8 h1:W1loDTT+0PQf5YteHSTpju2qfUfNoBt4yw9+wOEU9VM=
-github.com/expr-lang/expr v1.17.8/go.mod h1:8/vRC7+7HBzESEqt5kKpYXxrxkr31SaO8r40VO/1IT4=
 github.com/fsnotify/fsnotify v1.9.0 h1:2Ml+OJNzbYCTzsxtv8vKSFD9PbJjmhYF14k/jKC7S9k=
 github.com/fsnotify/fsnotify v1.9.0/go.mod h1:8jBTzvmWwFyi3Pb8djgCCO5IBqzKJ/Jwo8TRcHyHii0=
 github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=

--- a/sdkx/knowledge/watcher/watcher.go
+++ b/sdkx/knowledge/watcher/watcher.go
@@ -4,9 +4,34 @@
 // Pure-fs notification was deliberately split from the sdk core to keep
 // sdk/knowledge dependency-free; reuse the SDK's Reloader to compose:
 //
-//	notifier, _ := watcher.New(store)
+//	notifier, _ := watcher.New(ctx, store)
 //	r := knowledge.NewReloader(store, notifier, knowledge.ReloaderOptions{})
 //	go r.Run(ctx)
+//
+// Deprecated: Removed in sdkx/v0.3.0 (the release that follows sdk/v0.3.0).
+//
+// Every type this package consumes from sdk/knowledge has already been
+// marked Deprecated and is scheduled for removal in sdk/v0.3.0:
+//
+//	*knowledge.FSStore         (use factory.NewLocal)
+//	knowledge.ChangeNotifier   (use EventNotifier — typed ChangeEvent stream)
+//	knowledge.NewReloader      (use NewEventReloader)
+//
+// Once those go away this adapter cannot compile against the new sdk,
+// so the package will be dropped entirely. The v0.3.0 replacement is
+// architecturally different — fsnotify events get *decoded* into typed
+// knowledge.ChangeEvent values (DatasetID / DocName / Kind) instead of
+// emitting opaque struct{} ticks — which means no in-place upgrade is
+// possible. Plan to rewrite call sites against:
+//
+//	svc := factory.NewLocal(ws, ...)            // sdk/knowledge/factory
+//	notifier := <a typed EventNotifier impl>    // sdk/knowledge or your own
+//	r := knowledge.NewEventReloader(svc, notifier, knowledge.ReloaderOptions{})
+//	go r.Run(ctx)
+//
+// A typed fsnotify-backed EventNotifier is on the roadmap for sdkx
+// post-v0.3.0; until it lands, this package keeps working against
+// sdk/v0.2.x consumers and is the recommended bridge for them.
 package watcher
 
 import (
@@ -24,6 +49,8 @@ import (
 )
 
 // Notifier wraps fsnotify.Watcher to satisfy knowledge.ChangeNotifier.
+//
+// Deprecated: see package-level deprecation note. Removed in sdkx/v0.3.0.
 type Notifier struct {
 	store     *knowledge.FSStore
 	watcher   *fsnotify.Watcher
@@ -37,6 +64,8 @@ type Notifier struct {
 // New constructs a Notifier for the given knowledge store. Returns nil
 // without error when the underlying workspace doesn't expose a filesystem
 // root (e.g. in-memory workspace).
+//
+// Deprecated: see package-level deprecation note. Removed in sdkx/v0.3.0.
 func New(ctx context.Context, store *knowledge.FSStore) (*Notifier, error) {
 	if store == nil {
 		return nil, errors.New("knowledge/watcher: store is nil")

--- a/sdkx/knowledge/watcher/watcher_test.go
+++ b/sdkx/knowledge/watcher/watcher_test.go
@@ -1,3 +1,8 @@
+//lint:file-ignore SA1019 watcher itself is Deprecated; the tests
+// intentionally exercise the deprecated New / Notifier / NewReloader /
+// FSStore surface to keep the v0.2.x compatibility window honest. A
+// fresh test suite ships alongside the v0.3.0 EventNotifier rewrite.
+
 package watcher_test
 
 import (


### PR DESCRIPTION
## Summary

Two small changes that belong in the same sdkx release window:

### 1. Bump `sdkx/go.mod` from `sdk v0.2.2` → `v0.2.3`

Atomic follow-up to PR #47: pick up the just-released `sdk/v0.2.3` (cut by auto-tag against the PR #47 merge commit). PR #47 deliberately suppressed sdkx's auto-tag via `[skip-tag:sdkx]` so that the dep bump and the corresponding sdkx tag could be cut as one self-contained chore — this commit is the dep-bump half. The sdkx code that adopted the new sdk APIs (`errdefs.ClassifyProviderError`, `telemetry.AttrXxx`, `errdefs.NotAvailable` wrapping in retrieval/recall storage paths, etc.) already shipped inside the PR #47 merge using the local module imports; this commit only switches the published dep coordinate.

Mechanics:

```
cd sdkx
go get github.com/GizClaw/flowcraft/sdk@v0.2.3
go mod tidy
```

`go.sum` side-effect: `github.com/expr-lang/expr v1.17.8` falls out of the indirect set. sdkx never directly imports `sdk/graph` (only `errdefs`, `llm`, `telemetry`, `retrieval`, `recall`, `embedding`), so `expr` — `sdk/graph`'s edge-condition compiler — was always a spurious transitive that earlier tidies happened to keep around. `sdk/v0.2.2..v0.2.3` contains zero changes to `sdk/go.mod`, so this is purely a re-tidy artefact, not a behaviour change.

### 2. Deprecate `sdkx/knowledge/watcher` for sdkx/v0.3.0

Every type this package consumes from `sdk/knowledge` — `*FSStore`, `ChangeNotifier`, `NewReloader` — has been marked `// Deprecated:` in `sdk/knowledge/deprecated.go` and is scheduled for removal in `sdk/v0.3.0`. Once those go away `sdkx/knowledge/watcher` cannot compile against the new sdk, so the package will be dropped entirely in `sdkx/v0.3.0`.

The replacement is *architecturally different*: sdk's v0.3.0 `EventNotifier` emits typed `knowledge.ChangeEvent` values (`DatasetID` / `DocName` / `Kind`) rather than opaque `struct{}` ticks, and pairs with `NewEventReloader` (scope-aware, serialised). No in-place upgrade is possible — call sites have to be rewritten against `factory.NewLocal` + a typed `EventNotifier` impl + the new `EventReloader`. The package doc spells out the migration shape so downstream callers have a release window to plan instead of being surprised by the v0.3.0 hard break.

Surface marked `// Deprecated:`:
- the package doc (full migration map + rationale)
- `type Notifier` (points to package doc)
- `func New(ctx, store)` (points to package doc)

Interface-method receivers (`Events`, `Close`) are not individually annotated — any caller already trips SA1019 on the constructor / type / the deprecated `knowledge.ChangeNotifier` interface they implement, so double-annotating adds noise without catching anything new.

`watcher_test.go` is the only in-tree caller of the deprecated surface and exists exactly to keep the v0.2.x compatibility window honest. Added `//lint:file-ignore SA1019` at the top so static analysis treats "tests of a deprecated package" as intended.

A typed fsnotify-backed `EventNotifier` replacement will ship inside sdkx itself post-v0.3.0; until then the deprecated package keeps working against `sdk/v0.2.x` and is the recommended bridge for them.

## Out of scope (intentional)

- **`sdkx/internal/testenv` is NOT deleted.** It is the active shared `.env` loader for `sdkx/llm/provider_integration_test.go` and `sdkx/embedding/embedding_integration_test.go` (mirrors `sdk/knowledge/e2e/internal/testenv` on the sdk side). `internal` here is the Go visibility boundary, not a code-smell flag; removing it would silently break those integration test binaries.
- **`voice/go.mod`** still pins `sdk v0.2.2`; **`bench/go.mod`** pins `v0.2.0`; **`examples/chatbot-with-recall`** uses a `replace` on the local sdk. They will be bumped on their own cadence — this round is sdkx-only by user scope.

## Auto-tag policy after merge

`.github/workflows/auto-tag.yml` will see only `sdkx/**` change in the merge commit, find no skip marker, and cut `sdkx/v0.2.2` (next patch after `sdkx/v0.2.1`) against the merge commit. `sdk/` and `voice/` will be untouched (no diff under those prefixes).

## Test plan

- [x] `go build ./...` green in `sdkx/` against `sdk@v0.2.3`.
- [x] `go vet ./knowledge/watcher/...` clean (file-level SA1019 ignore in the test file is the only suppression).
- [x] `go test ./...` green in `sdkx/` (no FAIL lines), watcher tests included.
- [ ] After merge: confirm auto-tag cut `sdkx/v0.2.2` and that no `sdk/` or `voice/` tag was created.