### PR TITLE
fix(sdk/recall): harden supersede counters, slot key contract, and resolver path

### DIFF
--- a/sdk/recall/aliases.go
+++ b/sdk/recall/aliases.go
@@ -1,0 +1,204 @@
+package recall
+
+import "strings"
+
+// PredicateAliases maps locale-specific or model-drift predicate strings
+// to the canonical entry from DefaultPredicates. Lookup is performed
+// after lowercase + trim. Without aliases, an extractor that emits
+// "lives in" / "居住地" / "lives-in" for what is semantically
+// `lives_in` would scatter across distinct slot keys and the slot
+// supersede channel would never collapse them.
+//
+// The default table covers the high-frequency EN/CN surface forms
+// observed in production extractor outputs (CN: "住"/"住所"/"老家"
+// /"故乡" → lives_in, "供职"/"就职" → works_at, "出生" → birthday,
+// "爱人"/"伴侣" → spouse, …; EN: "based_in" → lives_in,
+// "married_to" → spouse, "born_on" → birthday, …). It is NOT
+// exhaustive — domain-specific synonyms (e.g. medical
+// "primary_care_physician" → doctor) should be layered on via
+// [WithPredicateAlias] which takes precedence over this table.
+// Keys MUST already be lowercased and trimmed; values SHOULD match
+// a canonical predicate listed in [DefaultPredicates].
+var PredicateAliases = map[string]string{
+	// lives_in
+	"lives in":   "lives_in",
+	"lives-in":   "lives_in",
+	"livesin":    "lives_in",
+	"resides_in": "lives_in",
+	"resides in": "lives_in",
+	"resides":    "lives_in",
+	"based in":   "lives_in",
+	"based_in":   "lives_in",
+	"location":   "lives_in",
+	"city":       "lives_in",
+	"hometown":   "lives_in",
+	"住":          "lives_in",
+	"在":          "lives_in",
+	"住址":         "lives_in",
+	"住所":         "lives_in",
+	"居住地":        "lives_in",
+	"居住":         "lives_in",
+	"住在":         "lives_in",
+	"现居":         "lives_in",
+	"老家":         "lives_in",
+	"故乡":         "lives_in",
+	"家乡":         "lives_in",
+	"所在地":        "lives_in",
+	"所在城市":       "lives_in",
+
+	// works_at
+	"works at":  "works_at",
+	"works-at":  "works_at",
+	"works for": "works_at",
+	"works_for": "works_at",
+	"employed":  "works_at",
+	"employer":  "works_at",
+	"company":   "works_at",
+	"工作单位":      "works_at",
+	"工作":        "works_at",
+	"在职":        "works_at",
+	"任职":        "works_at",
+	"任职于":       "works_at",
+	"供职":        "works_at",
+	"供职于":       "works_at",
+	"就职":        "works_at",
+	"就职于":       "works_at",
+	"单位":        "works_at",
+	"公司":        "works_at",
+
+	// occupation
+	"job":        "occupation",
+	"profession": "occupation",
+	"role":       "occupation",
+	"title":      "occupation",
+	"职业":         "occupation",
+	"职位":         "occupation",
+	"工种":         "occupation",
+	"岗位":         "occupation",
+
+	// birthday
+	"dob":           "birthday",
+	"date_of_birth": "birthday",
+	"date of birth": "birthday",
+	"birth_date":    "birthday",
+	"birth date":    "birthday",
+	"birthdate":     "birthday",
+	"born":          "birthday",
+	"born_on":       "birthday",
+	"生日":            "birthday",
+	"出生":            "birthday",
+	"出生日期":          "birthday",
+	"生辰":            "birthday",
+
+	// language
+	"languages":       "language",
+	"native_language": "language",
+	"native language": "language",
+	"speaks":          "language",
+	"语言":              "language",
+	"母语":              "language",
+	"使用语言":            "language",
+
+	// spouse
+	"wife":              "spouse",
+	"husband":           "spouse",
+	"partner":           "spouse",
+	"married_to":        "spouse",
+	"married to":        "spouse",
+	"significant other": "spouse",
+	"配偶":                "spouse",
+	"老婆":                "spouse",
+	"老公":                "spouse",
+	"妻子":                "spouse",
+	"丈夫":                "spouse",
+	"爱人":                "spouse",
+	"对象":                "spouse",
+	"伴侣":                "spouse",
+
+	// child / parent / pet
+	"children": "child",
+	"kid":      "child",
+	"kids":     "child",
+	"son":      "child",
+	"daughter": "child",
+	"孩子":       "child",
+	"小孩":       "child",
+	"儿子":       "child",
+	"女儿":       "child",
+	"父母":       "parent",
+	"father":   "parent",
+	"mother":   "parent",
+	"mom":      "parent",
+	"dad":      "parent",
+	"妈妈":       "parent",
+	"爸爸":       "parent",
+	"母亲":       "parent",
+	"父亲":       "parent",
+	"宠物":       "pet",
+	"pets":     "pet",
+	"猫":        "pet",
+	"狗":        "pet",
+}
+
+// SubjectAliases normalizes the most common subject surface forms
+// extractors emit in mixed-language conversations. As with
+// PredicateAliases, keys are pre-trimmed lowercase strings; values are
+// the canonical subject form. Composite subjects (e.g. "pet:Lucky")
+// pass through unchanged.
+var SubjectAliases = map[string]string{
+	"i":        "user",
+	"me":       "user",
+	"the user": "user",
+	"用户":       "user",
+	"我":        "user",
+}
+
+// normalizePredicate applies PredicateAliases (after lowercase + trim)
+// followed by per-instance overrides supplied via WithPredicateAlias.
+// Returns "" when the input is empty so the caller can short-circuit
+// and skip slot metadata writing.
+func normalizePredicate(p string, overrides map[string]string) string {
+	p = strings.ToLower(strings.TrimSpace(p))
+	if p == "" {
+		return ""
+	}
+	if v, ok := overrides[p]; ok {
+		return v
+	}
+	if v, ok := PredicateAliases[p]; ok {
+		return v
+	}
+	return p
+}
+
+// normalizeSubject mirrors normalizePredicate for the subject field.
+// Composite subjects (containing ':' or '.') are passed through as-is
+// — only the bare token is rewritten — so "pet:Lucky" remains
+// distinguishable from "pet:Max".
+//
+// As with normalizePredicate, the bare-token branch returns the
+// LOWERCASE form even when no alias matches, so that two extractor
+// outputs differing only in case ("Alice" vs "alice", "Pet" vs
+// "pet") collapse onto the same slot_key. This trades proper-noun
+// casing in metadata for slot supersede stability — the slot channel
+// is exact-string and would otherwise treat the two as separate
+// slots. The original surface form is still preserved on
+// ExtractedFact.Content; only the slot metadata sees the
+// canonicalised value.
+func normalizeSubject(s string, overrides map[string]string) string {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return ""
+	}
+	low := strings.ToLower(s)
+	if strings.ContainsAny(low, ":.") {
+		return s
+	}
+	if v, ok := overrides[low]; ok {
+		return v
+	}
+	if v, ok := SubjectAliases[low]; ok {
+		return v
+	}
+	return low
+}

--- a/sdk/recall/aliases_test.go
+++ b/sdk/recall/aliases_test.go
@@ -1,0 +1,187 @@
+package recall_test
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/GizClaw/flowcraft/sdk/llm"
+	"github.com/GizClaw/flowcraft/sdk/model"
+	"github.com/GizClaw/flowcraft/sdk/recall"
+	memidx "github.com/GizClaw/flowcraft/sdk/retrieval/memory"
+)
+
+// TestAlias_PredicateNormalizationAcrossLocales asserts that two
+// extractor outputs using locale-divergent predicates ("居住地" vs
+// "lives_in") collapse onto the same slot_key, so the slot supersede
+// channel correctly tags the older entry as superseded.
+func TestAlias_PredicateNormalizationAcrossLocales(t *testing.T) {
+	ctx := context.Background()
+	idx := memidx.New()
+	var clockHolder atomic.Pointer[time.Time]
+	setNow := func(t time.Time) { clockHolder.Store(&t) }
+	getNow := func() time.Time { return *clockHolder.Load() }
+	setNow(time.Now())
+	ex := &scriptedExtractor{
+		facts: [][]recall.ExtractedFact{
+			// Chinese locale predicate — must alias to lives_in.
+			{{Content: "user lives in Guangzhou", Subject: "用户", Predicate: "居住地"}},
+			// English canonical form on the second save.
+			{{Content: "user lives in Shanghai", Subject: "user", Predicate: "lives_in"}},
+		},
+	}
+	m, err := recall.New(idx,
+		recall.WithRequireUserID(),
+		recall.WithExtractor(ex),
+		recall.WithClock(getNow),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer m.Close()
+
+	scope := newScope()
+	first, err := m.Save(ctx, scope, []llm.Message{
+		{Role: model.RoleUser, Parts: []model.Part{{Type: model.PartText, Text: "我住在广州"}}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	setNow(getNow().Add(time.Hour))
+	second, err := m.Save(ctx, scope, []llm.Message{
+		{Role: model.RoleUser, Parts: []model.Part{{Type: model.PartText, Text: "I moved to Shanghai"}}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	doc, ok, err := idx.Get(ctx, recall.NamespaceFor(scope), first.EntryIDs[0])
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !ok {
+		t.Fatalf("missing original doc %q", first.EntryIDs[0])
+	}
+	if got := doc.Metadata["superseded_by"]; got != second.EntryIDs[0] {
+		t.Fatalf("alias normalization broken: superseded_by=%v, want %q", got, second.EntryIDs[0])
+	}
+	if got := doc.Metadata["slot_key"]; got != "user|lives_in" {
+		t.Fatalf("slot_key=%v, want canonical %q", got, "user|lives_in")
+	}
+}
+
+// TestAlias_PerInstanceOverrideWins asserts that
+// WithPredicateAlias-supplied entries take precedence over the
+// built-in PredicateAliases table — so callers can introduce
+// namespace-specific synonyms without forking the package.
+func TestAlias_PerInstanceOverrideWins(t *testing.T) {
+	ctx := context.Background()
+	idx := memidx.New()
+	ex := &scriptedExtractor{
+		facts: [][]recall.ExtractedFact{
+			{{Content: "patient sees Dr. Smith", Subject: "patient", Predicate: "primary_care"}},
+			{{Content: "patient sees Dr. Johnson", Subject: "patient", Predicate: "primary_care"}},
+		},
+	}
+	m, err := recall.New(idx,
+		recall.WithRequireUserID(),
+		recall.WithExtractor(ex),
+		recall.WithPredicateAlias(map[string]string{"primary_care": "doctor"}),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer m.Close()
+	scope := newScope()
+	first, _ := m.Save(ctx, scope, []llm.Message{
+		{Role: model.RoleUser, Parts: []model.Part{{Type: model.PartText, Text: "1"}}},
+	})
+	second, _ := m.Save(ctx, scope, []llm.Message{
+		{Role: model.RoleUser, Parts: []model.Part{{Type: model.PartText, Text: "2"}}},
+	})
+	doc, _, _ := idx.Get(ctx, recall.NamespaceFor(scope), first.EntryIDs[0])
+	if got := doc.Metadata["slot_key"]; got != "patient|doctor" {
+		t.Fatalf("override missed: slot_key=%v, want %q", got, "patient|doctor")
+	}
+	if got := doc.Metadata["superseded_by"]; got != second.EntryIDs[0] {
+		t.Fatalf("supersede did not fire after alias rewrite: superseded_by=%v", got)
+	}
+}
+
+// TestAlias_CompositeSubjectPassThrough asserts that subjects
+// containing ':' or '.' (used to address specific instances like
+// "pet:Lucky") are NOT aliased — only the bare token is rewritten.
+func TestAlias_CompositeSubjectPassThrough(t *testing.T) {
+	ctx := context.Background()
+	idx := memidx.New()
+	ex := &scriptedExtractor{
+		facts: [][]recall.ExtractedFact{
+			{{Content: "Lucky is a labrador", Subject: "pet:Lucky", Predicate: "breed"}},
+		},
+	}
+	m, err := recall.New(idx,
+		recall.WithRequireUserID(),
+		recall.WithExtractor(ex),
+		recall.WithSubjectAlias(map[string]string{"pet:lucky": "should_not_apply"}),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer m.Close()
+	res, _ := m.Save(ctx, newScope(), []llm.Message{
+		{Role: model.RoleUser, Parts: []model.Part{{Type: model.PartText, Text: "Lucky is my dog"}}},
+	})
+	doc, _, _ := idx.Get(ctx, recall.NamespaceFor(newScope()), res.EntryIDs[0])
+	if got := doc.Metadata["subject"]; got != "pet:Lucky" {
+		t.Fatalf("composite subject was aliased: subject=%v, want %q", got, "pet:Lucky")
+	}
+	if got := doc.Metadata["slot_key"]; got != "pet:Lucky|breed" {
+		t.Fatalf("slot_key=%v, want %q", got, "pet:Lucky|breed")
+	}
+}
+
+// TestNormalizeSubject_LowercasesUnknownTokens locks in the B2 fix:
+// when a subject is not in the alias table, the slot metadata MUST
+// still be lowercased so two extractor outputs differing only in
+// case ("Alice"/"alice") collapse onto the same slot_key. Without
+// this, the second Save would write to a different slot and the
+// first entry would never be superseded.
+func TestNormalizeSubject_LowercasesUnknownTokens(t *testing.T) {
+	ctx := context.Background()
+	idx := memidx.New()
+	var clockHolder atomic.Pointer[time.Time]
+	setNow := func(t time.Time) { clockHolder.Store(&t) }
+	getNow := func() time.Time { return *clockHolder.Load() }
+	setNow(time.Now())
+	ex := &scriptedExtractor{
+		facts: [][]recall.ExtractedFact{
+			{{Content: "Alice prefers tea", Subject: "Alice", Predicate: "preference.drink"}},
+			{{Content: "Alice prefers coffee", Subject: "alice", Predicate: "preference.drink"}},
+		},
+	}
+	m, err := recall.New(idx,
+		recall.WithRequireUserID(),
+		recall.WithExtractor(ex),
+		recall.WithClock(getNow),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer m.Close()
+	scope := newScope()
+	first, _ := m.Save(ctx, scope, []llm.Message{
+		{Role: model.RoleUser, Parts: []model.Part{{Type: model.PartText, Text: "1"}}},
+	})
+	setNow(getNow().Add(time.Hour))
+	second, _ := m.Save(ctx, scope, []llm.Message{
+		{Role: model.RoleUser, Parts: []model.Part{{Type: model.PartText, Text: "2"}}},
+	})
+	doc, _, _ := idx.Get(ctx, recall.NamespaceFor(scope), first.EntryIDs[0])
+	if got := doc.Metadata[recall.MetaSlotKey]; got != "alice|preference.drink" {
+		t.Fatalf("subject case must be canonicalised; slot_key=%v, want %q", got, "alice|preference.drink")
+	}
+	if got := doc.Metadata[recall.MetaSupersededBy]; got != second.EntryIDs[0] {
+		t.Fatalf("supersede must fire across case-only differences; superseded_by=%v", got)
+	}
+}

--- a/sdk/recall/extractor.go
+++ b/sdk/recall/extractor.go
@@ -32,12 +32,39 @@ const (
 )
 
 // ExtractedFact is one LLM-extracted memory candidate.
+//
+// Subject and Predicate are optional slot fields; when BOTH are non-empty
+// (and neither contains the slot delimiter '|') the Save path
+// activates the deterministic "slot supersede" channel (see
+// merger.supersedeBySlot) which marks any older entry sharing the
+// same (Subject, Predicate) tuple as superseded_by the new entry.
+// Leave them empty for episodic / non-slot facts; behaviour is
+// unchanged.
+//
+// The recommended v1 predicate vocabulary is enumerated in
+// [DefaultPredicates]; locale variants and common synonyms are mapped
+// to canonical entries by [PredicateAliases] (extend per-namespace
+// via [WithPredicateAlias]).
 type ExtractedFact struct {
 	Content    string   `json:"content"`
 	Categories []string `json:"categories,omitempty"`
 	Entities   []string `json:"entities,omitempty"`
 	Source     string   `json:"source,omitempty"`
 	Confidence float64  `json:"confidence,omitempty"`
+
+	Subject   string `json:"subject,omitempty"`
+	Predicate string `json:"predicate,omitempty"`
+}
+
+// DefaultPredicates is the v1 controlled predicate vocabulary rendered
+// into DefaultExtractPrompt. Predicates outside this list are still
+// honoured by the slot supersede channel (matching is exact-string), but
+// extending the prompt vocabulary should go through this slice so the
+// guidance stays consistent.
+var DefaultPredicates = []string{
+	"lives_in", "works_at", "occupation", "birthday", "language",
+	"spouse", "child", "parent", "pet",
+	"preference.<topic>", "status.<topic>",
 }
 
 // ExtractOptions carries optional context handed to an Extractor invocation.
@@ -107,6 +134,27 @@ OUTPUT FORMAT — strict JSON object with a single "facts" array, no prose:
 
 Categories (multi-label allowed): preferences | profile | episodic | procedural | semantic | events | facts | patterns | cases | entities
 Entities: people, places, organizations, products, quoted strings, compound nouns. Keep original surface form.
+
+SLOT FIELDS (optional but encouraged for STABLE attributes that can change
+over time — profile, preferences, relationships):
+  "subject":   what the fact is about ("user", "user.spouse", "pet:<name>")
+  "predicate": snake_case key from the controlled list:
+               lives_in, works_at, occupation, birthday, language,
+               spouse, child, parent, pet,
+               preference.<topic>, status.<topic>
+               If NONE fits, leave both as empty strings.
+
+Episodic events ("I went to Tokyo last week", "booked a flight on Mar 3")
+MUST leave subject and predicate empty — they are append-only timeline
+data, not slot replacements.
+
+Slot examples:
+  "I moved to Shanghai" →
+    {"content":"user lives in Shanghai","subject":"user",
+     "predicate":"lives_in","entities":["Shanghai"], ...}
+  "I love lattes" →
+    {"content":"user prefers lattes","subject":"user",
+     "predicate":"preference.coffee","entities":["latte"], ...}
 
 If no facts: return {"facts": []}.
 
@@ -265,6 +313,8 @@ func normalizeFacts(in []ExtractedFact) []ExtractedFact {
 		}
 		f.Categories = normStrings(f.Categories)
 		f.Entities = normStrings(f.Entities)
+		f.Subject = strings.TrimSpace(f.Subject)
+		f.Predicate = strings.TrimSpace(f.Predicate)
 		out = append(out, f)
 	}
 	return out
@@ -328,13 +378,15 @@ var extractedFactsSchema = llm.JSONSchemaParam{
 					// every key in `properties` must also appear in `required`.
 					// Models can still emit empty arrays / "" / 0.0 to signal
 					// "no value" — parseFactsJSON tolerates them.
-					"required": []string{"content", "categories", "entities", "source", "confidence"},
+					"required": []string{"content", "categories", "entities", "source", "confidence", "subject", "predicate"},
 					"properties": map[string]any{
 						"content":    map[string]any{"type": "string"},
 						"categories": map[string]any{"type": "array", "items": map[string]any{"type": "string"}},
 						"entities":   map[string]any{"type": "array", "items": map[string]any{"type": "string"}},
 						"source":     map[string]any{"type": "string"},
 						"confidence": map[string]any{"type": "number"},
+						"subject":    map[string]any{"type": "string"},
+						"predicate":  map[string]any{"type": "string"},
 					},
 				},
 			},

--- a/sdk/recall/memory.go
+++ b/sdk/recall/memory.go
@@ -3,6 +3,7 @@ package recall
 import (
 	"context"
 	"errors"
+	"maps"
 	"sync"
 	"time"
 
@@ -106,8 +107,15 @@ type config struct {
 
 	md5Dedup           bool
 	softMerge          bool
+	slotMerge          bool
 	softMergeCosineMin float64
 	softMergeTopK      int
+
+	updateResolver UpdateResolver
+	resolverTopK   int
+
+	predicateAliases map[string]string
+	subjectAliases   map[string]string
 
 	jobQueue       JobQueue
 	asyncWorkers   int
@@ -187,11 +195,99 @@ func WithSaveContext(topK int, threshold float64) Option {
 // upserts across re-extractions.
 func WithoutMD5Dedup() Option { return func(c *config) { c.md5Dedup = false } }
 
-// WithoutSoftMerge disables soft-merging of near-duplicate older
-// entries (default ON). Soft-merge marks neighbours with metadata
-// `superseded_by=<new_id>`; pair with [pipeline.SupersededDecay] for
-// retrieval-time damping.
+// WithoutSoftMerge disables the VECTOR + entity-set supersede channel
+// (default ON). The vector channel marks near-duplicate older
+// neighbours with metadata `superseded_by=<new_id>` based on cosine
+// similarity and entity overlap; pair with [pipeline.SupersededDecay]
+// for retrieval-time damping.
+//
+// This option does NOT affect the deterministic SLOT supersede
+// channel — facts that carry both Subject and Predicate continue to
+// supersede same-slot neighbours regardless. Use [WithoutSlotChannel]
+// to disable the slot channel as well. The two channels are
+// orthogonal so callers can keep the deterministic path while
+// silencing the noisier vector path (e.g. when entity extraction is
+// unreliable on their corpus).
 func WithoutSoftMerge() Option { return func(c *config) { c.softMerge = false } }
+
+// WithoutSlotChannel disables the deterministic (subject, predicate)
+// supersede channel that runs whenever an extractor populates both
+// slot fields (default ON). Use this when you want to keep the
+// vector soft-merge path but disable the slot path — for example
+// when migrating an existing namespace whose historical entries were
+// written without slot metadata, and you want the read-side
+// SupersededDecay to depend exclusively on vector-channel decisions
+// for a controlled rollout window.
+func WithoutSlotChannel() Option { return func(c *config) { c.slotMerge = false } }
+
+// WithUpdateResolver installs an opt-in LLM-driven resolver that is
+// consulted on Save for facts the slot supersede channel cannot handle
+// (i.e. ExtractedFact.Subject or Predicate is empty). The resolver
+// receives the new fact plus its top-K nearest existing memories and
+// returns a list of [ResolveAction] (ADD / UPDATE / DELETE / NOOP).
+//
+// FlowCraft applies UPDATE and DELETE non-destructively: targeted
+// entries gain superseded_by metadata (DELETE additionally sets
+// tombstone=true), preserving Auditable.History and Rollback. ADD and
+// NOOP require no action since the new entry is always written.
+//
+// topK <= 0 falls back to 5. Passing a nil resolver disables the path
+// (the default).
+//
+// Ordering note: the resolver runs AFTER the slot and vector
+// supersede channels. Candidates whose older versions were already
+// tagged by those channels will appear with damped scores (or be
+// missing from the top-K entirely) thanks to SupersededDecay; this
+// is intentional — the resolver should not re-decide what the
+// deterministic channels already handled. Operators reading the
+// resolver_actions_total counter should expect candidate counts to
+// shrink when slot vocabulary coverage improves.
+func WithUpdateResolver(r UpdateResolver, topK int) Option {
+	return func(c *config) {
+		c.updateResolver = r
+		if topK > 0 {
+			c.resolverTopK = topK
+		} else {
+			c.resolverTopK = 5
+		}
+	}
+}
+
+// WithPredicateAlias merges additional predicate aliases on top of the
+// built-in [PredicateAliases] table. Use this to teach the slot
+// supersede channel about namespace-specific synonyms (e.g. medical
+// SaaS adding "primary_care_physician" → "doctor"). Keys MUST be
+// lowercase + trimmed; values SHOULD match a canonical predicate.
+//
+// Per-instance overrides win over the global table so callers can
+// remap a built-in entry if needed without forking the source.
+func WithPredicateAlias(aliases map[string]string) Option {
+	return func(c *config) {
+		if len(aliases) == 0 {
+			return
+		}
+		if c.predicateAliases == nil {
+			c.predicateAliases = make(map[string]string, len(aliases))
+		}
+		maps.Copy(c.predicateAliases, aliases)
+	}
+}
+
+// WithSubjectAlias mirrors [WithPredicateAlias] for ExtractedFact.Subject.
+// Composite subjects (those containing ':' or '.') are passed through
+// without aliasing so per-instance subjects like "pet:Lucky" remain
+// distinguishable.
+func WithSubjectAlias(aliases map[string]string) Option {
+	return func(c *config) {
+		if len(aliases) == 0 {
+			return
+		}
+		if c.subjectAliases == nil {
+			c.subjectAliases = make(map[string]string, len(aliases))
+		}
+		maps.Copy(c.subjectAliases, aliases)
+	}
+}
 
 // WithSoftMergeThreshold tunes the cosine threshold (default 0.92) and
 // neighbour-fanout (default 3) for soft-merge. Values <= 0 keep the
@@ -339,6 +435,7 @@ func New(idx retrieval.Index, opts ...Option) (Memory, error) {
 		mode:               ModeAdditive,
 		md5Dedup:           true,
 		softMerge:          true,
+		slotMerge:          true,
 		softMergeCosineMin: 0.92,
 		softMergeTopK:      3,
 		saveCtxTopK:        10,

--- a/sdk/recall/memory_test.go
+++ b/sdk/recall/memory_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/GizClaw/flowcraft/sdk/llm"
 	"github.com/GizClaw/flowcraft/sdk/model"
 	"github.com/GizClaw/flowcraft/sdk/recall"
+	"github.com/GizClaw/flowcraft/sdk/retrieval"
 	"github.com/GizClaw/flowcraft/sdk/retrieval/journal"
 	memidx "github.com/GizClaw/flowcraft/sdk/retrieval/memory"
 )
@@ -376,5 +377,63 @@ func TestForget(t *testing.T) {
 	hits, _ := m.Recall(ctx, scope, recall.Request{Query: "forget", TopK: 5})
 	if len(hits) != 0 {
 		t.Fatalf("expected forgotten, got %+v", hits)
+	}
+}
+
+// TestTombstoneFilter_HidesByDefault_OptInReveals exercises Recall's
+// public contract for tombstoned entries (the B3 escape hatch):
+//   - With default Request, an entry whose metadata carries
+//     `tombstone=true` MUST NOT appear among the hits.
+//   - With Request.WithTombstoned=true, the same entry MUST be
+//     returned so callers can debug the resolver / stage an
+//     Auditable.Rollback.
+func TestTombstoneFilter_HidesByDefault_OptInReveals(t *testing.T) {
+	ctx := context.Background()
+	idx := memidx.New()
+	m, err := recall.New(idx, recall.WithRequireUserID())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer m.Close()
+	scope := newScope()
+	// Add the entry through the public API so all the scope-derived
+	// metadata (user_id, agent_id, runtime_id) is populated correctly,
+	// then re-Upsert with MetaTombstone toggled on. This mirrors what
+	// the LLM update resolver's OpDelete branch does internally.
+	id, err := m.Add(ctx, scope, recall.Entry{Content: "user said something then deleted it"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	ns := recall.NamespaceFor(scope)
+	doc, _, _ := idx.Get(ctx, ns, id)
+	if doc.Metadata == nil {
+		doc.Metadata = map[string]any{}
+	}
+	doc.Metadata[recall.MetaTombstone] = true
+	if err := idx.Upsert(ctx, ns, []retrieval.Doc{doc}); err != nil {
+		t.Fatal(err)
+	}
+	hits, err := m.Recall(ctx, scope, recall.Request{Query: "deleted", TopK: 10})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, h := range hits {
+		if h.Entry.ID == id {
+			t.Fatalf("default Recall must hide tombstoned entry %q", id)
+		}
+	}
+	hits, err = m.Recall(ctx, scope, recall.Request{Query: "deleted", TopK: 10, WithTombstoned: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var found bool
+	for _, h := range hits {
+		if h.Entry.ID == id {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("WithTombstoned=true must surface tombstoned entry %q (hits=%+v)", id, hits)
 	}
 }

--- a/sdk/recall/merger.go
+++ b/sdk/recall/merger.go
@@ -8,6 +8,8 @@ import (
 	"time"
 
 	"github.com/GizClaw/flowcraft/sdk/retrieval"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
 )
 
 // contentHash returns an MD5 hex digest scoped by user, used by the byte-level
@@ -35,7 +37,7 @@ func (m *lt) dedupHashes(ctx context.Context, scope Scope, hashes []string) (map
 		in = append(in, h)
 	}
 	resp, err := m.idx.List(ctx, ns, retrieval.ListRequest{
-		Filter:   retrieval.Filter{In: map[string][]any{"content_hash": in}},
+		Filter:   retrieval.Filter{In: map[string][]any{MetaContentHash: in}},
 		PageSize: len(hashes),
 	})
 	if err != nil || resp == nil {
@@ -45,30 +47,57 @@ func (m *lt) dedupHashes(ctx context.Context, scope Scope, hashes []string) (map
 		if d.Metadata == nil {
 			continue
 		}
-		if v, ok := d.Metadata["content_hash"].(string); ok {
+		if v, ok := d.Metadata[MetaContentHash].(string); ok {
 			out[v] = d.ID
 		}
 	}
 	return out, nil
 }
 
-// supersedeNeighbours marks older entries whose entity set matches the new
-// fact AND whose vector cosine ≥ SoftMergeCosineMin with metadata.superseded_by.
-// Old entries are NOT deleted (history preserved for Auditable.History /
-// Rollback); retrieval-time damping is the responsibility of
-// pipeline.SupersededDecay, which multiplies the score of any hit
-// carrying superseded_by by its Factor (default 0.3).
+// supersedeNeighbours dispatches to one of two deterministic supersede
+// channels:
 //
-// Execution surface: this is a single-lane vector lookup that bypasses the
-// configured pipeline by design (we only need cosines, not the ranked
-// answer). It therefore never asks the backend for an Execution and never
-// reads RawByRetriever; downstream callers should not treat it as part of
-// the Recall explanation produced by [RecallExplainer.RecallExplain].
+//   - slot channel (supersedeBySlot): runs when the extractor populated
+//     ExtractedFact.Subject AND Predicate. Independent of the embedder
+//     and the vector; controlled by [WithoutSlotChannel].
+//   - vector+entity channel (the body below): runs only when slot fields
+//     are absent. Requires an embedder and a non-empty vector; matches
+//     candidates by entity-set equality AND cosine ≥ SoftMergeCosineMin.
+//     Controlled by [WithoutSoftMerge].
+//
+// The two channels are intentionally orthogonal so callers can disable
+// the noisier vector path while keeping the deterministic slot path
+// (or vice versa). Old entries are NEVER deleted — history stays in
+// the journal and Auditable.Rollback continues to work; retrieval-time
+// damping is the responsibility of pipeline.SupersededDecay, which
+// multiplies the score of any hit carrying MetaSupersededBy by its
+// Factor (default 0.3).
+//
+// Execution surface: the vector path is a single-lane vector lookup
+// that bypasses the configured pipeline by design (we only need
+// cosines, not the ranked answer). It therefore never asks the
+// backend for an Execution and never reads RawByRetriever; downstream
+// callers should not treat it as part of the Recall explanation
+// produced by [RecallExplainer.RecallExplain].
 func (m *lt) supersedeNeighbours(
 	ctx context.Context, scope Scope, newID string,
 	fact ExtractedFact, vec []float32, now time.Time,
 ) {
-	if !m.cfg.softMerge || m.cfg.embedder == nil || len(vec) == 0 {
+	// Slot channel takes priority and is deterministic: it does not need
+	// the embedder, the vector, or matching entities. When the extractor
+	// declared a (subject, predicate) tuple AND neither side contains
+	// the slot delimiter '|' the conflict signal is the tuple itself.
+	// Tuples that contain '|' would produce ambiguous slot_keys
+	// (see upsertFacts) and fall through to the vector / resolver
+	// channels instead.
+	if m.cfg.slotMerge && slotEligible(fact) {
+		m.supersedeBySlot(ctx, scope, newID, fact, now)
+		return
+	}
+	if !m.cfg.softMerge {
+		return
+	}
+	if m.cfg.embedder == nil || len(vec) == 0 {
 		return
 	}
 	if len(fact.Entities) == 0 {
@@ -106,7 +135,7 @@ func (m *lt) supersedeNeighbours(
 		}
 		// Avoid re-superseding entries already pointing somewhere.
 		if h.Doc.Metadata != nil {
-			if v, ok := h.Doc.Metadata["superseded_by"].(string); ok && v != "" {
+			if v, ok := h.Doc.Metadata[MetaSupersededBy].(string); ok && v != "" {
 				continue
 			}
 		}
@@ -114,9 +143,14 @@ func (m *lt) supersedeNeighbours(
 		if updated.Metadata == nil {
 			updated.Metadata = map[string]any{}
 		}
-		updated.Metadata["superseded_by"] = newID
-		updated.Metadata["superseded_at"] = now.UnixMilli()
-		_ = m.idx.Upsert(ctx, ns, []retrieval.Doc{updated})
+		updated.Metadata[MetaSupersededBy] = newID
+		updated.Metadata[MetaSupersededAt] = now.UnixMilli()
+		if err := m.idx.Upsert(ctx, ns, []retrieval.Doc{updated}); err != nil {
+			m.log("ltm: vector supersede upsert failed for %q: %v", h.Doc.ID, err)
+			continue
+		}
+		supersedeTotal.Add(ctx, 1,
+			metric.WithAttributes(attribute.String("channel", "vector")))
 	}
 }
 
@@ -124,7 +158,7 @@ func docEntities(d retrieval.Doc) []string {
 	if d.Metadata == nil {
 		return nil
 	}
-	v, ok := d.Metadata["entities"]
+	v, ok := d.Metadata[MetaEntities]
 	if !ok {
 		return nil
 	}
@@ -153,6 +187,86 @@ func lowerSet(in []string) map[string]struct{} {
 		out[s] = struct{}{}
 	}
 	return out
+}
+
+// supersedeBySlot is the deterministic supersede channel used when the
+// extractor populates ExtractedFact.Subject and Predicate AND neither
+// contains the slot delimiter '|'. It tags every older entry sharing
+// the same slot_key with MetaSupersededBy=newID so that
+// pipeline.SupersededDecay damps them at recall time. Old entries are
+// kept in the index — Auditable.History / Rollback continue to work.
+//
+// Unlike the vector path in supersedeNeighbours, this channel does
+// not require an embedder or a vector; matching is exact-string on
+// the MetaSlotKey metadata field. Backends without composite filter
+// pushdown still hit a single equality predicate which all in-tree
+// backends support.
+//
+// supersede counter accounting: the metric is incremented inside the
+// Upsert-success branch only, so callers reading
+// supersede_total{channel="slot"} get the count of entries actually
+// re-tagged (not the count of candidates returned by List, which
+// includes the new entry itself plus any candidates already pointing
+// at a previous superseder).
+func (m *lt) supersedeBySlot(
+	ctx context.Context, scope Scope, newID string,
+	fact ExtractedFact, now time.Time,
+) {
+	ns := NamespaceFor(scope)
+	slotKey := fact.Subject + slotDelimiter + fact.Predicate
+	resp, err := m.idx.List(ctx, ns, retrieval.ListRequest{
+		Filter: MergeFilters(
+			AgentRecallFilter(scope),
+			retrieval.Filter{Eq: map[string]any{MetaSlotKey: slotKey}},
+		),
+		PageSize: 64,
+	})
+	if err != nil || resp == nil {
+		if err != nil {
+			m.log("ltm: slot supersede list failed: %v", err)
+		}
+		return
+	}
+	for _, d := range resp.Items {
+		if d.ID == newID {
+			continue
+		}
+		if d.Metadata != nil {
+			if v, ok := d.Metadata[MetaSupersededBy].(string); ok && v != "" {
+				continue
+			}
+		}
+		updated := d
+		if updated.Metadata == nil {
+			updated.Metadata = map[string]any{}
+		}
+		updated.Metadata[MetaSupersededBy] = newID
+		updated.Metadata[MetaSupersededAt] = now.UnixMilli()
+		if err := m.idx.Upsert(ctx, ns, []retrieval.Doc{updated}); err != nil {
+			m.log("ltm: slot supersede upsert failed for %q: %v", d.ID, err)
+			continue
+		}
+		supersedeTotal.Add(ctx, 1,
+			metric.WithAttributes(attribute.String("channel", "slot")))
+	}
+}
+
+// slotEligible reports whether a fact qualifies for the deterministic
+// slot supersede channel. The contract MUST stay in sync with the
+// metadata-writing branch in upsertFacts so a fact that gets a
+// slot_key written is exactly the fact that supersedeBySlot will
+// later look up.
+func slotEligible(f ExtractedFact) bool {
+	if f.Subject == "" || f.Predicate == "" {
+		return false
+	}
+	if strings.Contains(f.Subject, slotDelimiter) {
+		return false
+	}
+	if strings.Contains(f.Predicate, slotDelimiter) {
+		return false
+	}
+	return true
 }
 
 func setEqual(a, b map[string]struct{}) bool {

--- a/sdk/recall/merger_test.go
+++ b/sdk/recall/merger_test.go
@@ -9,7 +9,9 @@ import (
 	"github.com/GizClaw/flowcraft/sdk/llm"
 	"github.com/GizClaw/flowcraft/sdk/model"
 	"github.com/GizClaw/flowcraft/sdk/recall"
+	"github.com/GizClaw/flowcraft/sdk/retrieval"
 	memidx "github.com/GizClaw/flowcraft/sdk/retrieval/memory"
+	"github.com/GizClaw/flowcraft/sdk/retrieval/pipeline"
 )
 
 func TestSaveDedupsSameFactAcrossDifferentMessages(t *testing.T) {
@@ -117,5 +119,412 @@ func TestSaveSoftMergeMarksSupersededNeighbour(t *testing.T) {
 	}
 	if got := doc.Metadata["superseded_at"]; got != getNow().UnixMilli() {
 		t.Fatalf("superseded_at=%v, want %d", got, getNow().UnixMilli())
+	}
+}
+
+// TestSlotSupersede_CityChange asserts the deterministic slot channel
+// tags an older lives_in entry as superseded when the new fact carries
+// the same (subject, predicate) tuple, even though the entities differ
+// ("Guangzhou" vs "Shanghai") — the case the legacy vector+entity
+// channel cannot handle.
+func TestSlotSupersede_CityChange(t *testing.T) {
+	ctx := context.Background()
+	idx := memidx.New()
+	var clockHolder atomic.Pointer[time.Time]
+	setNow := func(t time.Time) { clockHolder.Store(&t) }
+	getNow := func() time.Time { return *clockHolder.Load() }
+	setNow(time.Now())
+	ex := &scriptedExtractor{
+		facts: [][]recall.ExtractedFact{
+			{{Content: "user lives in Guangzhou", Subject: "user", Predicate: "lives_in", Entities: []string{"Guangzhou"}}},
+			{{Content: "user lives in Shanghai", Subject: "user", Predicate: "lives_in", Entities: []string{"Shanghai"}}},
+		},
+	}
+	m, err := recall.New(idx,
+		recall.WithRequireUserID(),
+		recall.WithExtractor(ex),
+		recall.WithClock(getNow),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer m.Close()
+
+	scope := newScope()
+	first, err := m.Save(ctx, scope, []llm.Message{
+		{Role: model.RoleUser, Parts: []model.Part{{Type: model.PartText, Text: "我住在广州"}}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	setNow(getNow().Add(time.Hour))
+	second, err := m.Save(ctx, scope, []llm.Message{
+		{Role: model.RoleUser, Parts: []model.Part{{Type: model.PartText, Text: "我搬到上海了"}}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	doc, ok, err := idx.Get(ctx, recall.NamespaceFor(scope), first.EntryIDs[0])
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !ok {
+		t.Fatalf("missing original doc %q", first.EntryIDs[0])
+	}
+	if got := doc.Metadata["superseded_by"]; got != second.EntryIDs[0] {
+		t.Fatalf("superseded_by=%v, want %q", got, second.EntryIDs[0])
+	}
+	// Slot key was recorded so SlotCollapse / future writes can target it.
+	if got := doc.Metadata["slot_key"]; got != "user|lives_in" {
+		t.Fatalf("slot_key=%v, want %q", got, "user|lives_in")
+	}
+	newDoc, _, err := idx.Get(ctx, recall.NamespaceFor(scope), second.EntryIDs[0])
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := newDoc.Metadata["slot_key"]; got != "user|lives_in" {
+		t.Fatalf("new doc slot_key=%v, want %q", got, "user|lives_in")
+	}
+	if _, has := newDoc.Metadata["superseded_by"]; has {
+		t.Fatalf("new doc should not be superseded; got %v", newDoc.Metadata["superseded_by"])
+	}
+}
+
+// TestSlotSupersede_ChainedUpdates walks three sequential updates on
+// the same slot and checks every prior entry points at the latest one.
+// The middle entry must NOT be re-superseded once the third write
+// arrives — supersedeBySlot intentionally skips entries that already
+// carry superseded_by so chains stay sparse.
+func TestSlotSupersede_ChainedUpdates(t *testing.T) {
+	ctx := context.Background()
+	idx := memidx.New()
+	var clockHolder atomic.Pointer[time.Time]
+	setNow := func(t time.Time) { clockHolder.Store(&t) }
+	getNow := func() time.Time { return *clockHolder.Load() }
+	setNow(time.Now())
+	ex := &scriptedExtractor{
+		facts: [][]recall.ExtractedFact{
+			{{Content: "user lives in Guangzhou", Subject: "user", Predicate: "lives_in"}},
+			{{Content: "user lives in Shanghai", Subject: "user", Predicate: "lives_in"}},
+			{{Content: "user lives in Beijing", Subject: "user", Predicate: "lives_in"}},
+		},
+	}
+	m, err := recall.New(idx,
+		recall.WithRequireUserID(),
+		recall.WithExtractor(ex),
+		recall.WithClock(getNow),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer m.Close()
+
+	scope := newScope()
+	mkSave := func(text string) string {
+		res, err := m.Save(ctx, scope, []llm.Message{
+			{Role: model.RoleUser, Parts: []model.Part{{Type: model.PartText, Text: text}}},
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		setNow(getNow().Add(time.Hour))
+		return res.EntryIDs[0]
+	}
+	idGZ := mkSave("我住在广州")
+	idSH := mkSave("我搬到上海了")
+	idBJ := mkSave("我又搬到北京了")
+
+	gz, _, _ := idx.Get(ctx, recall.NamespaceFor(scope), idGZ)
+	sh, _, _ := idx.Get(ctx, recall.NamespaceFor(scope), idSH)
+	bj, _, _ := idx.Get(ctx, recall.NamespaceFor(scope), idBJ)
+
+	// Guangzhou was superseded by the FIRST update (Shanghai) and is
+	// then skipped by Beijing's pass because it already carries
+	// superseded_by — see supersedeBySlot's "already pointed somewhere"
+	// short-circuit.
+	if got := gz.Metadata["superseded_by"]; got != idSH {
+		t.Fatalf("Guangzhou.superseded_by=%v, want %q", got, idSH)
+	}
+	if got := sh.Metadata["superseded_by"]; got != idBJ {
+		t.Fatalf("Shanghai.superseded_by=%v, want %q", got, idBJ)
+	}
+	if _, has := bj.Metadata["superseded_by"]; has {
+		t.Fatalf("Beijing should be the active entry; got superseded_by=%v", bj.Metadata["superseded_by"])
+	}
+}
+
+// TestSlotSupersede_NoSlotFallsBackToVectorEntity asserts the dispatch
+// in supersedeNeighbours: if Subject/Predicate are empty the legacy
+// vector+entity path still runs (and behaves as before), and if they
+// are present the vector path is bypassed entirely (no embedder call
+// is required).
+func TestSlotSupersede_NoSlotFallsBackToVectorEntity(t *testing.T) {
+	ctx := context.Background()
+	idx := memidx.New()
+	ex := &scriptedExtractor{
+		facts: [][]recall.ExtractedFact{
+			// Slot fact, no embedder configured — must still supersede.
+			{{Content: "user lives in Guangzhou", Subject: "user", Predicate: "lives_in"}},
+			{{Content: "user lives in Shanghai", Subject: "user", Predicate: "lives_in"}},
+		},
+	}
+	m, err := recall.New(idx,
+		recall.WithRequireUserID(),
+		recall.WithExtractor(ex),
+		// Note: no WithEmbedder — slot channel must work without one.
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer m.Close()
+	scope := newScope()
+	first, err := m.Save(ctx, scope, []llm.Message{
+		{Role: model.RoleUser, Parts: []model.Part{{Type: model.PartText, Text: "我住广州"}}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	second, err := m.Save(ctx, scope, []llm.Message{
+		{Role: model.RoleUser, Parts: []model.Part{{Type: model.PartText, Text: "我搬上海"}}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	doc, _, _ := idx.Get(ctx, recall.NamespaceFor(scope), first.EntryIDs[0])
+	if got := doc.Metadata["superseded_by"]; got != second.EntryIDs[0] {
+		t.Fatalf("superseded_by=%v, want %q (slot channel must run without embedder)", got, second.EntryIDs[0])
+	}
+}
+
+// TestSlotChannel_KeptWhenWithoutSoftMerge asserts the M3 fix:
+// WithoutSoftMerge silences the VECTOR + entity supersede channel
+// only — the deterministic SLOT channel keeps running for facts
+// that carry both Subject and Predicate. This is the user-visible
+// contract change separating "noisy soft merge" from "deterministic
+// slot rewrite".
+func TestSlotChannel_KeptWhenWithoutSoftMerge(t *testing.T) {
+	ctx := context.Background()
+	idx := memidx.New()
+	ex := &scriptedExtractor{
+		facts: [][]recall.ExtractedFact{
+			{{Content: "user lives in Guangzhou", Subject: "user", Predicate: "lives_in"}},
+			{{Content: "user lives in Shanghai", Subject: "user", Predicate: "lives_in"}},
+		},
+	}
+	m, err := recall.New(idx,
+		recall.WithRequireUserID(),
+		recall.WithExtractor(ex),
+		recall.WithoutSoftMerge(), // vector channel off, slot channel still on.
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer m.Close()
+	scope := newScope()
+	first, _ := m.Save(ctx, scope, []llm.Message{
+		{Role: model.RoleUser, Parts: []model.Part{{Type: model.PartText, Text: "我住广州"}}},
+	})
+	second, _ := m.Save(ctx, scope, []llm.Message{
+		{Role: model.RoleUser, Parts: []model.Part{{Type: model.PartText, Text: "搬上海"}}},
+	})
+	doc, _, _ := idx.Get(ctx, recall.NamespaceFor(scope), first.EntryIDs[0])
+	if got := doc.Metadata[recall.MetaSupersededBy]; got != second.EntryIDs[0] {
+		t.Fatalf("WithoutSoftMerge must NOT disable slot channel; superseded_by=%v, want %q", got, second.EntryIDs[0])
+	}
+}
+
+// TestSlotChannel_DisabledByWithoutSlotChannel exercises the new
+// orthogonal knob: WithoutSlotChannel suppresses the deterministic
+// path even though the vector channel is still ON. With no embedder
+// configured, the vector path also no-ops, so the older entry must
+// be left untagged — proving the slot path was the only thing
+// touching it before.
+func TestSlotChannel_DisabledByWithoutSlotChannel(t *testing.T) {
+	ctx := context.Background()
+	idx := memidx.New()
+	ex := &scriptedExtractor{
+		facts: [][]recall.ExtractedFact{
+			{{Content: "user lives in Guangzhou", Subject: "user", Predicate: "lives_in"}},
+			{{Content: "user lives in Shanghai", Subject: "user", Predicate: "lives_in"}},
+		},
+	}
+	m, err := recall.New(idx,
+		recall.WithRequireUserID(),
+		recall.WithExtractor(ex),
+		recall.WithoutSlotChannel(),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer m.Close()
+	scope := newScope()
+	first, _ := m.Save(ctx, scope, []llm.Message{
+		{Role: model.RoleUser, Parts: []model.Part{{Type: model.PartText, Text: "我住广州"}}},
+	})
+	_, _ = m.Save(ctx, scope, []llm.Message{
+		{Role: model.RoleUser, Parts: []model.Part{{Type: model.PartText, Text: "搬上海"}}},
+	})
+	doc, _, _ := idx.Get(ctx, recall.NamespaceFor(scope), first.EntryIDs[0])
+	if v, has := doc.Metadata[recall.MetaSupersededBy]; has {
+		t.Fatalf("WithoutSlotChannel must suppress slot tagging; got superseded_by=%v", v)
+	}
+}
+
+// TestSlotSupersede_MultipleStaleEntriesInOneSlot covers the
+// rarely-hit but important case the original review flagged: a slot
+// already contains MORE THAN ONE untagged stale entry (e.g. a backfill
+// that replayed history out of order, or an external importer that
+// bypassed the slot channel). The newest write must tag every
+// previously-untagged entry, not just one.
+func TestSlotSupersede_MultipleStaleEntriesInOneSlot(t *testing.T) {
+	ctx := context.Background()
+	idx := memidx.New()
+	// Drop AgentID so the seeded raw docs (which have no agent_id
+	// metadata) survive AgentRecallFilter — the test exercises the
+	// supersede channel, not the agent-isolation filter.
+	scope := recall.Scope{RuntimeID: "rt1", UserID: "u1"}
+	ns := recall.NamespaceFor(scope)
+	// Pre-seed two untagged entries sharing the same slot_key — this
+	// is the kind of state the slot channel itself never produces
+	// (it always skips already-tagged entries) but a backfill does.
+	_ = idx.Upsert(ctx, ns, []retrieval.Doc{
+		{
+			ID: "stale-1", Content: "user lives in Guangzhou",
+			Metadata: map[string]any{
+				recall.MetaSubject:   "user",
+				recall.MetaPredicate: "lives_in",
+				recall.MetaSlotKey:   "user|lives_in",
+			},
+			Timestamp: time.Now().Add(-2 * time.Hour),
+		},
+		{
+			ID: "stale-2", Content: "user lives in Shenzhen",
+			Metadata: map[string]any{
+				recall.MetaSubject:   "user",
+				recall.MetaPredicate: "lives_in",
+				recall.MetaSlotKey:   "user|lives_in",
+			},
+			Timestamp: time.Now().Add(-time.Hour),
+		},
+	})
+
+	ex := &scriptedExtractor{
+		facts: [][]recall.ExtractedFact{
+			{{Content: "user lives in Beijing", Subject: "user", Predicate: "lives_in"}},
+		},
+	}
+	m, err := recall.New(idx,
+		recall.WithRequireUserID(),
+		recall.WithExtractor(ex),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer m.Close()
+	res, _ := m.Save(ctx, scope, []llm.Message{
+		{Role: model.RoleUser, Parts: []model.Part{{Type: model.PartText, Text: "搬北京"}}},
+	})
+	if len(res.EntryIDs) != 1 {
+		t.Fatalf("expected one new entry, got %+v", res.EntryIDs)
+	}
+	newID := res.EntryIDs[0]
+	for _, oldID := range []string{"stale-1", "stale-2"} {
+		d, _, _ := idx.Get(ctx, ns, oldID)
+		if got := d.Metadata[recall.MetaSupersededBy]; got != newID {
+			t.Fatalf("%s.superseded_by=%v, want %q (slot channel must tag every untagged stale entry)", oldID, got, newID)
+		}
+	}
+}
+
+// TestSlotEligibility_RejectsDelimiterInSubject verifies the M2 fix:
+// a fact whose subject contains the slot delimiter '|' MUST NOT
+// produce a slot_key (otherwise it would collide with another
+// fact's legitimate slot). The fact still gets written, just
+// without slot metadata, and falls back to the resolver / vector
+// channels.
+func TestSlotEligibility_RejectsDelimiterInSubject(t *testing.T) {
+	ctx := context.Background()
+	idx := memidx.New()
+	ex := &scriptedExtractor{
+		facts: [][]recall.ExtractedFact{
+			{{Content: "ambiguous fact", Subject: "user|alt", Predicate: "lives_in"}},
+		},
+	}
+	m, err := recall.New(idx, recall.WithRequireUserID(), recall.WithExtractor(ex))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer m.Close()
+	scope := newScope()
+	res, _ := m.Save(ctx, scope, []llm.Message{
+		{Role: model.RoleUser, Parts: []model.Part{{Type: model.PartText, Text: "x"}}},
+	})
+	doc, _, _ := idx.Get(ctx, recall.NamespaceFor(scope), res.EntryIDs[0])
+	if v, has := doc.Metadata[recall.MetaSlotKey]; has {
+		t.Fatalf("subject with delimiter must NOT produce slot_key; got %v", v)
+	}
+	if v, has := doc.Metadata[recall.MetaSubject]; has {
+		t.Fatalf("subject metadata must be skipped together with slot_key; got %v", v)
+	}
+}
+
+// TestSlotCollapse_EndToEnd_OnLegacyData wires WithSlotCollapse into
+// the LTM pipeline and asserts that even when both old and new
+// entries are returned by the recall lane (the older one was never
+// tagged with superseded_by — i.e. legacy data), only the newest
+// per slot survives. Without WithSlotCollapse the older entry would
+// remain visible in the hits, defeating the point of the stage.
+//
+// This is the read-side counterpart to the slot supersede tests
+// above: it lives next to them in merger_test.go because the
+// collapse stage is the safety net for whatever the supersede
+// channel could not tag (legacy / out-of-band writes).
+func TestSlotCollapse_EndToEnd_OnLegacyData(t *testing.T) {
+	ctx := context.Background()
+	idx := memidx.New()
+	scope := recall.Scope{RuntimeID: "rt1", UserID: "u1"}
+	ns := recall.NamespaceFor(scope)
+	now := time.Now()
+	// Two entries, same slot, neither tagged with superseded_by — the
+	// "untouched legacy data" case WithSlotCollapse exists for.
+	_ = idx.Upsert(ctx, ns, []retrieval.Doc{
+		{
+			ID: "old", Content: "user lives in Guangzhou",
+			Metadata:  map[string]any{recall.MetaSlotKey: "user|lives_in"},
+			Timestamp: now.Add(-time.Hour),
+		},
+		{
+			ID: "new", Content: "user lives in Shanghai",
+			Metadata:  map[string]any{recall.MetaSlotKey: "user|lives_in"},
+			Timestamp: now,
+		},
+	})
+
+	m, err := recall.New(idx,
+		recall.WithRequireUserID(),
+		recall.WithPipeline(pipeline.LTM(nil, pipeline.WithSlotCollapse(true))),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer m.Close()
+	hits, err := m.Recall(ctx, scope, recall.Request{Query: "lives", TopK: 10})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, h := range hits {
+		if h.Entry.ID == "old" {
+			t.Fatalf("WithSlotCollapse must drop legacy older entry; hits=%+v", hits)
+		}
+	}
+	var sawNew bool
+	for _, h := range hits {
+		if h.Entry.ID == "new" {
+			sawNew = true
+		}
+	}
+	if !sawNew {
+		t.Fatalf("expected newest entry to survive collapse, hits=%+v", hits)
 	}
 }

--- a/sdk/recall/metadata.go
+++ b/sdk/recall/metadata.go
@@ -1,0 +1,69 @@
+package recall
+
+import "github.com/GizClaw/flowcraft/sdk/retrieval"
+
+// Reserved metadata keys written by the recall package and read by
+// both the recall package itself and the retrieval pipeline stages
+// (e.g. SupersededDecay reads MetaSupersededBy).
+//
+// External callers SHOULD treat these keys as reserved: setting them
+// via Entry.Metadata or a custom extractor will be silently
+// overwritten by the Save path, and any pre-existing user data stored
+// under MetaTombstone will be hidden from Recall (use
+// Request.WithTombstoned to opt out, see [Request]).
+//
+// The slot key constant lives in the retrieval package
+// ([retrieval.MetaSlotKey]) so SlotCollapse and SlotKeyOf can read it
+// without importing recall and creating a cycle.
+const (
+	// MetaSubject stores the canonical subject of a slot fact (after
+	// alias normalisation). Written only when both Subject and
+	// Predicate are non-empty AND neither contains the slot delimiter
+	// '|'. See upsertFacts.
+	MetaSubject = "subject"
+
+	// MetaPredicate stores the canonical predicate of a slot fact.
+	// Same write conditions as MetaSubject.
+	MetaPredicate = "predicate"
+
+	// MetaSupersededBy is the entry ID that replaced this entry. Set
+	// by all three supersede channels (slot / vector / resolver).
+	// Pipeline.SupersededDecay damps any hit carrying this key at
+	// recall time.
+	MetaSupersededBy = "superseded_by"
+
+	// MetaSupersededAt is the unix-millis timestamp of the supersede
+	// action; co-written with MetaSupersededBy.
+	MetaSupersededAt = "superseded_at"
+
+	// MetaTombstone is set to bool(true) by the OpDelete branch of
+	// the LLM update resolver. Recall composes [TombstoneFilter]
+	// unconditionally to hide tombstoned entries; callers that need
+	// to see them must pass Request.WithTombstoned = true.
+	MetaTombstone = "tombstone"
+
+	// MetaContentHash is the per-namespace MD5 of the entry content,
+	// scoped by UserID. Used by the dedup probe at Save time.
+	MetaContentHash = "content_hash"
+
+	// MetaSourceLabel mirrors ExtractedFact.Source so post-hoc
+	// analytics can group entries by extractor provenance.
+	MetaSourceLabel = "source_label"
+
+	// MetaEntities is the list of named entities (people, places,
+	// products, …) the extractor attached to the fact. Stored as
+	// []string but tolerated as []any for adapter round-trips.
+	MetaEntities = "entities"
+)
+
+// MetaSlotKey is re-exported from the retrieval package so recall
+// callers can stay within one import. See [retrieval.MetaSlotKey] for
+// the underlying contract.
+const MetaSlotKey = retrieval.MetaSlotKey
+
+// slotDelimiter separates subject and predicate inside MetaSlotKey.
+// Subjects/predicates that contain this byte are NOT eligible for the
+// slot supersede channel (they would create ambiguous keys); the Save
+// path drops the slot fields entirely in that case so the fact
+// degrades to the vector / resolver supersede channels instead.
+const slotDelimiter = "|"

--- a/sdk/recall/recall.go
+++ b/sdk/recall/recall.go
@@ -13,11 +13,24 @@ import (
 
 // Request is the input to Memory.Recall ( + §6.2).
 type Request struct {
-	Query     string
-	TopK      int
-	Filter    map[string]any // metadata equality filters merged into pipeline filter
-	Now       time.Time      // optional clock injection (for tests / TTL)
-	WithStale bool           // if true, do NOT filter expired entries
+	Query  string
+	TopK   int
+	Filter map[string]any // metadata equality filters merged into pipeline filter
+	Now    time.Time      // optional clock injection (for tests / TTL)
+
+	// WithStale, if true, disables the default ExpireFilter so expired
+	// entries are returned alongside live ones.
+	WithStale bool
+
+	// WithTombstoned, if true, disables the default TombstoneFilter so
+	// entries the LLM update resolver marked with metadata.tombstone =
+	// true are returned alongside live ones. Use this to debug
+	// resolver behaviour or to re-surface entries before
+	// Auditable.Rollback. Note that MetaTombstone is a RESERVED
+	// metadata key written by recall internals — pre-existing user
+	// data accidentally stored under "tombstone" will be hidden by
+	// default until WithTombstoned is set.
+	WithTombstoned bool
 
 	// Debug controls how much execution detail the underlying retrieval
 	// pipeline should attach. Memory.Recall always discards it; callers
@@ -96,6 +109,14 @@ func (m *lt) runRecall(ctx context.Context, scope Scope, req Request) ([]Hit, *r
 	if !req.WithStale {
 		filter = MergeFilters(filter, ExpireFilter(now))
 	}
+	// Tombstones (set by the LLM update resolver's DELETE action) are
+	// hidden from Recall by default. Callers can opt out via
+	// Request.WithTombstoned to debug resolver behaviour or to
+	// re-surface entries before Auditable.Rollback. Forget remains
+	// the way to hard-delete them.
+	if !req.WithTombstoned {
+		filter = MergeFilters(filter, TombstoneFilter())
+	}
 	if len(req.Filter) > 0 {
 		filter = MergeFilters(filter, retrieval.Filter{Eq: req.Filter})
 	}
@@ -107,6 +128,7 @@ func (m *lt) runRecall(ctx context.Context, scope Scope, req Request) ([]Hit, *r
 		attribute.Int("top_k", topK),
 		attribute.Int("query_len", len(req.Query)),
 		attribute.Bool("with_stale", req.WithStale),
+		attribute.Bool("with_tombstoned", req.WithTombstoned),
 		attribute.Bool("debug_lanes", req.Debug.IncludeLanes),
 		attribute.Bool("debug_stages", req.Debug.IncludeStages),
 	)

--- a/sdk/recall/resolver.go
+++ b/sdk/recall/resolver.go
@@ -1,0 +1,249 @@
+package recall
+
+import (
+	"context"
+	"time"
+
+	"github.com/GizClaw/flowcraft/sdk/retrieval"
+	"github.com/GizClaw/flowcraft/sdk/telemetry"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
+)
+
+// ResolveOp is the action an [UpdateResolver] requests for one
+// existing memory in response to a new fact.
+type ResolveOp string
+
+const (
+	// OpAdd is the default: keep the candidate untouched and accept the
+	// new fact as a fresh entry. Resolvers MAY omit ADD actions; the
+	// new entry is written regardless.
+	OpAdd ResolveOp = "ADD"
+	// OpUpdate marks the candidate as superseded by the new fact.
+	// FlowCraft tags the candidate with superseded_by=<newID>, NOT
+	// overwriting the candidate's content (preserves audit history).
+	OpUpdate ResolveOp = "UPDATE"
+	// OpDelete marks the candidate as contradicted by the new fact.
+	// FlowCraft tags the candidate with superseded_by=<newID> AND
+	// tombstone=true so the default Recall filter excludes it. History
+	// is still recoverable via Auditable.
+	OpDelete ResolveOp = "DELETE"
+	// OpNoop performs no action. Use when the new fact equals or is
+	// subsumed by the candidate.
+	OpNoop ResolveOp = "NOOP"
+)
+
+// ResolveAction is one entry of an [UpdateResolver] decision.
+//
+// SourceID names the new fact (entry ID) that triggered the action.
+//
+//   - UPDATE / DELETE: SourceID is REQUIRED and MUST be one of the
+//     IDs in [ResolveBatch.NewFacts]. FlowCraft drops actions that
+//     reference an unknown source so a hallucinated ID cannot mark
+//     the wrong entry as superseded. The candidate's MetaSupersededBy
+//     is set to SourceID.
+//   - ADD / NOOP: SourceID is OPTIONAL (informational only). The new
+//     entry is written by the caller regardless of whether ADD is
+//     emitted, and NOOP by definition triggers no mutation, so
+//     FlowCraft does not read SourceID for these ops. Resolvers MAY
+//     leave it empty.
+//
+// TargetID names the existing memory the action applies to and is
+// required for UPDATE and DELETE; it is ignored for ADD and NOOP.
+type ResolveAction struct {
+	Op       ResolveOp
+	SourceID string // new fact entry ID; required for UPDATE/DELETE, optional for ADD/NOOP
+	TargetID string // existing memory ID; required for UPDATE/DELETE, ignored for ADD/NOOP
+}
+
+// ResolveNewFact pairs an extracted fact with the entry ID FlowCraft
+// will write for it. The resolver MUST NOT mutate Fact.
+type ResolveNewFact struct {
+	EntryID string
+	Fact    ExtractedFact
+}
+
+// ResolveBatch is the input to [UpdateResolver.Resolve]. All non-slot
+// facts produced by a single Save call are passed together so the
+// resolver can reason about combined contradictions ("user divorced X"
+// + "user married Y" → DELETE the X-spouse memory AND UPDATE other
+// X-related memories in one go).
+type ResolveBatch struct {
+	// NewFacts are the just-extracted facts for which the slot supersede
+	// channel did not fire (Subject or Predicate empty). The order is
+	// stable across calls so resolver implementations can rely on it
+	// when correlating with their own logs.
+	NewFacts []ResolveNewFact
+
+	// Candidates is the union of top-K Recall hits across all NewFacts,
+	// deduplicated by Doc.ID, ordered by descending Score. The resolver
+	// is free to ignore any candidate whose action is ADD (the default).
+	Candidates []Hit
+}
+
+// UpdateResolver is the contract for opt-in LLM-driven memory
+// reconciliation. Implementations receive the full per-Save batch (not
+// individual facts) so they can reason about combined updates that no
+// single-fact decision could resolve.
+//
+// The interface intentionally takes a batch even when only one new
+// fact qualifies for the resolver path. Single-fact resolvers can
+// simply iterate batch.NewFacts and apply per-fact logic.
+type UpdateResolver interface {
+	Resolve(ctx context.Context, batch ResolveBatch) ([]ResolveAction, error)
+}
+
+// runResolverBatch is the single resolver invocation per Save. It
+// gathers candidates for every non-slot new fact, unions/deduplicates
+// them, calls the resolver once, and applies the returned actions.
+// Errors are swallowed (logged) so a flaky resolver never blocks Save.
+//
+// Cost model: gatherResolverCandidates issues N×Recall (one per new
+// fact) before the single LLM call. The span attached here records
+// n_facts and n_candidates so dashboards can correlate Save latency
+// spikes with resolver fan-out without enabling SearchDebug. Future
+// work may expose a custom-candidate hook to let callers replace the
+// per-fact Recall with a batched embed + single vector lookup.
+func (m *lt) runResolverBatch(
+	ctx context.Context, scope Scope,
+	newFacts []ResolveNewFact, now time.Time,
+) {
+	if len(newFacts) == 0 {
+		return
+	}
+	ctx, span := telemetry.Tracer().Start(ctx, "memory.recall.resolver_batch")
+	defer span.End()
+	t0 := time.Now()
+	defer func() {
+		resolverDuration.Record(ctx, time.Since(t0).Seconds())
+	}()
+
+	candidates := m.gatherResolverCandidates(ctx, scope, newFacts)
+	span.SetAttributes(
+		attribute.Int("n_facts", len(newFacts)),
+		attribute.Int("n_candidates", len(candidates)),
+	)
+	if len(candidates) == 0 {
+		return
+	}
+	actions, err := m.cfg.updateResolver.Resolve(ctx, ResolveBatch{
+		NewFacts:   newFacts,
+		Candidates: candidates,
+	})
+	if err != nil {
+		m.log("ltm: resolver Resolve failed: %v", err)
+		resolverActionsTotal.Add(ctx, 1, metric.WithAttributes(attribute.String("op", "error")))
+		return
+	}
+	if len(actions) == 0 {
+		resolverActionsTotal.Add(ctx, 1, metric.WithAttributes(attribute.String("op", "noop")))
+		return
+	}
+	m.applyResolverActions(ctx, scope, newFacts, actions, now)
+}
+
+// gatherResolverCandidates issues one Recall per new fact and returns
+// the union, deduplicated by entry ID and ordered by descending score
+// (per-fact ranking is preserved on first occurrence). Recall errors
+// are logged but do not abort the batch — the resolver still runs on
+// whatever candidates were collected.
+func (m *lt) gatherResolverCandidates(
+	ctx context.Context, scope Scope, newFacts []ResolveNewFact,
+) []Hit {
+	seen := make(map[string]struct{})
+	var out []Hit
+	for _, nf := range newFacts {
+		hits, err := m.Recall(ctx, scope, Request{
+			Query: nf.Fact.Content,
+			TopK:  m.cfg.resolverTopK,
+		})
+		if err != nil {
+			m.log("ltm: resolver candidate Recall failed for %q: %v", nf.EntryID, err)
+			continue
+		}
+		for _, h := range hits {
+			if _, dup := seen[h.Entry.ID]; dup {
+				continue
+			}
+			seen[h.Entry.ID] = struct{}{}
+			out = append(out, h)
+		}
+	}
+	return out
+}
+
+// applyResolverActions writes the supersede / tombstone metadata
+// implied by the resolver's actions. Unknown SourceIDs are skipped
+// (defensive against LLM hallucination); unknown TargetIDs trigger a
+// no-op since they don't exist in the index.
+func (m *lt) applyResolverActions(
+	ctx context.Context, scope Scope,
+	newFacts []ResolveNewFact, actions []ResolveAction, now time.Time,
+) {
+	knownSources := make(map[string]struct{}, len(newFacts))
+	for _, nf := range newFacts {
+		knownSources[nf.EntryID] = struct{}{}
+	}
+	ns := NamespaceFor(scope)
+	for _, a := range actions {
+		op := string(a.Op)
+		switch a.Op {
+		case OpUpdate, OpDelete:
+			if a.TargetID == "" {
+				continue
+			}
+			if _, ok := knownSources[a.SourceID]; !ok {
+				resolverActionsTotal.Add(ctx, 1, metric.WithAttributes(attribute.String("op", "error")))
+				m.log("ltm: resolver action references unknown source_id %q", a.SourceID)
+				continue
+			}
+			if a.TargetID == a.SourceID {
+				continue
+			}
+			doc, ok := m.fetchDoc(ctx, ns, a.TargetID)
+			if !ok {
+				continue
+			}
+			if doc.Metadata == nil {
+				doc.Metadata = map[string]any{}
+			}
+			doc.Metadata[MetaSupersededBy] = a.SourceID
+			doc.Metadata[MetaSupersededAt] = now.UnixMilli()
+			if a.Op == OpDelete {
+				doc.Metadata[MetaTombstone] = true
+			}
+			if err := m.idx.Upsert(ctx, ns, []retrieval.Doc{doc}); err != nil {
+				m.log("ltm: resolver upsert failed for %q: %v", doc.ID, err)
+				op = "error"
+			} else {
+				supersedeTotal.Add(ctx, 1,
+					metric.WithAttributes(attribute.String("channel", "resolver")))
+			}
+		case OpAdd, OpNoop:
+			// nothing to do — the new entry is written by the caller
+		default:
+			op = "error"
+		}
+		resolverActionsTotal.Add(ctx, 1, metric.WithAttributes(attribute.String("op", op)))
+	}
+}
+
+// fetchDoc returns the doc with the given id from the namespace. The
+// retrieval interface exposes Get only via the optional [DocGetter]
+// sub-interface; when the backend does not implement it the resolver
+// gracefully no-ops (the new entry is still written, only the
+// supersede tagging is skipped). All in-tree backends (memory,
+// postgres, qdrant adapter, journal wrapper) implement DocGetter so
+// this fallback is rarely exercised in practice.
+func (m *lt) fetchDoc(ctx context.Context, ns, id string) (retrieval.Doc, bool) {
+	g, ok := m.idx.(retrieval.DocGetter)
+	if !ok {
+		return retrieval.Doc{}, false
+	}
+	d, found, err := g.Get(ctx, ns, id)
+	if err != nil {
+		m.log("ltm: resolver Get %q failed: %v", id, err)
+		return retrieval.Doc{}, false
+	}
+	return d, found
+}

--- a/sdk/recall/resolver_llm.go
+++ b/sdk/recall/resolver_llm.go
@@ -1,0 +1,209 @@
+package recall
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/GizClaw/flowcraft/sdk/llm"
+	"github.com/GizClaw/flowcraft/sdk/model"
+)
+
+// LLMUpdateResolver is the reference [UpdateResolver] implementation.
+// It asks an LLM to produce per-(new_fact, candidate) decisions in
+// strict JSON form, then projects them onto [ResolveAction].
+//
+// The prompt is batch-aware: every Save's non-slot facts are presented
+// together so the model can resolve combined contradictions a
+// per-fact loop would miss (e.g. divorce + remarriage in one turn).
+//
+// A malformed response is propagated as an error so the Save path
+// reports it on memory.recall.resolver_actions_total{op="error"} and
+// the Save itself still succeeds (errors are logged, not returned).
+type LLMUpdateResolver struct {
+	LLM            llm.LLM
+	PromptTemplate string  // optional override; defaults to DefaultResolverPrompt
+	MaxCandidates  int     // truncate candidates passed to the LLM (default 20)
+	ConfidenceMin  float64 // skip actions whose JSON "confidence" is below this (0 = accept all)
+}
+
+// DefaultResolverPrompt is the prompt template used by
+// [LLMUpdateResolver] when no override is configured. It expects two
+// %s arguments: the NEW FACTS slate (JSON array, each element has
+// id+content+optional source) and the CANDIDATES slate (JSON array,
+// id+content). The template intentionally encourages combined
+// reasoning across all new facts.
+const DefaultResolverPrompt = `You are Flowcraft's memory update resolver. A NEW SAVE just produced one or more NEW FACTS at the same time. For each CANDIDATE memory below, decide whether ANY of the new facts implies an action on it. Consider the new facts JOINTLY — a candidate may be invalidated by one fact and reinforced by another.
+
+For each (candidate, triggering new fact) pair where action != ADD, return one row.
+
+Allowed ops:
+- ADD:    candidate is unrelated to all new facts; no action needed (omit from output).
+- UPDATE: candidate is superseded by a new fact (e.g. profile change, preference change, relationship change).
+- DELETE: candidate is contradicted or negated by a new fact (e.g. "my dog passed away" vs "I have a dog").
+- NOOP:   candidate is equivalent to or already contains the relevant new fact.
+
+Rules:
+1. Each non-ADD action MUST cite "source_id" — the id of the new fact that triggered it. Hallucinated source_ids are dropped.
+2. UPDATE when topic stays but value changes; DELETE only on explicit negation; ambiguous cases fall back to ADD (omit).
+3. Episodic events (one-off past actions) almost always resolve to ADD.
+4. When two new facts both imply an action on the same candidate, emit BOTH rows; FlowCraft de-duplicates downstream.
+5. Output strict JSON in the exact shape below — no prose, no markdown.
+
+OUTPUT JSON:
+{
+  "actions": [
+    {"source_id": "<new fact id>", "target_id": "<candidate id>", "op": "UPDATE", "confidence": 0.0-1.0}
+  ]
+}
+
+NEW FACTS (JSON):
+%s
+
+CANDIDATES (JSON):
+%s
+`
+
+// resolverActionsSchema is the structured-output schema sent alongside
+// the resolver prompt. Mirrors extractedFactsSchema's strict shape so
+// providers that enforce strict JSON-schema (Azure OpenAI, etc.)
+// accept the call. The schema permits all four ops on the wire even
+// though ADD is normally omitted from output — the LLM may still emit
+// ADD rows defensively, and the parser keeps them as informational
+// no-ops.
+var resolverActionsSchema = llm.JSONSchemaParam{
+	Name:        "resolver_actions",
+	Description: "Memory update resolver decisions for one Save batch",
+	Strict:      true,
+	Schema: map[string]any{
+		"type":                 "object",
+		"additionalProperties": false,
+		"required":             []string{"actions"},
+		"properties": map[string]any{
+			"actions": map[string]any{
+				"type": "array",
+				"items": map[string]any{
+					"type":                 "object",
+					"additionalProperties": false,
+					"required":             []string{"source_id", "target_id", "op", "confidence"},
+					"properties": map[string]any{
+						"source_id":  map[string]any{"type": "string"},
+						"target_id":  map[string]any{"type": "string"},
+						"op":         map[string]any{"type": "string", "enum": []string{"ADD", "UPDATE", "DELETE", "NOOP"}},
+						"confidence": map[string]any{"type": "number"},
+					},
+				},
+			},
+		},
+	},
+}
+
+type resolverEnvelope struct {
+	Actions []resolverAction `json:"actions"`
+}
+
+type resolverAction struct {
+	SourceID   string  `json:"source_id"`
+	TargetID   string  `json:"target_id"`
+	Op         string  `json:"op"`
+	Confidence float64 `json:"confidence,omitempty"`
+}
+
+type resolverNewFactJSON struct {
+	ID        string `json:"id"`
+	Content   string `json:"content"`
+	Subject   string `json:"subject,omitempty"`
+	Predicate string `json:"predicate,omitempty"`
+}
+
+type resolverCandidate struct {
+	ID      string `json:"id"`
+	Content string `json:"content"`
+}
+
+// Resolve implements [UpdateResolver].
+func (r LLMUpdateResolver) Resolve(ctx context.Context, batch ResolveBatch) ([]ResolveAction, error) {
+	if r.LLM == nil || len(batch.NewFacts) == 0 || len(batch.Candidates) == 0 {
+		return nil, nil
+	}
+	max := r.MaxCandidates
+	if max <= 0 {
+		max = 20
+	}
+	candidates := batch.Candidates
+	if len(candidates) > max {
+		candidates = candidates[:max]
+	}
+
+	newFactsJSON := make([]resolverNewFactJSON, 0, len(batch.NewFacts))
+	for _, nf := range batch.NewFacts {
+		newFactsJSON = append(newFactsJSON, resolverNewFactJSON{
+			ID:        nf.EntryID,
+			Content:   nf.Fact.Content,
+			Subject:   nf.Fact.Subject,
+			Predicate: nf.Fact.Predicate,
+		})
+	}
+	newFactsRaw, err := json.Marshal(newFactsJSON)
+	if err != nil {
+		return nil, fmt.Errorf("recall: resolver: marshal new facts: %w", err)
+	}
+	candJSON := make([]resolverCandidate, 0, len(candidates))
+	for _, c := range candidates {
+		candJSON = append(candJSON, resolverCandidate{
+			ID:      c.Entry.ID,
+			Content: c.Entry.Content,
+		})
+	}
+	candRaw, err := json.Marshal(candJSON)
+	if err != nil {
+		return nil, fmt.Errorf("recall: resolver: marshal candidates: %w", err)
+	}
+	tmpl := r.PromptTemplate
+	if tmpl == "" {
+		tmpl = DefaultResolverPrompt
+	}
+	prompt := fmt.Sprintf(tmpl, string(newFactsRaw), string(candRaw))
+
+	resp, _, err := r.LLM.Generate(ctx, []llm.Message{{
+		Role:  model.RoleUser,
+		Parts: []model.Part{{Type: model.PartText, Text: prompt}},
+	}},
+		llm.WithJSONSchema(resolverActionsSchema),
+		llm.WithJSONMode(true),
+	)
+	if err != nil {
+		return nil, err
+	}
+	raw := resp.Content()
+	if strings.TrimSpace(raw) == "" {
+		return nil, nil
+	}
+	payload, _, err := llm.ExtractJSON(raw)
+	if err != nil {
+		return nil, fmt.Errorf("recall: resolver: %w", err)
+	}
+	var env resolverEnvelope
+	if err := json.Unmarshal(payload, &env); err != nil {
+		return nil, fmt.Errorf("recall: resolver: parse: %w", err)
+	}
+	out := make([]ResolveAction, 0, len(env.Actions))
+	for _, a := range env.Actions {
+		if r.ConfidenceMin > 0 && a.Confidence > 0 && a.Confidence < r.ConfidenceMin {
+			continue
+		}
+		op := ResolveOp(strings.ToUpper(strings.TrimSpace(a.Op)))
+		switch op {
+		case OpAdd, OpUpdate, OpDelete, OpNoop:
+		default:
+			continue
+		}
+		out = append(out, ResolveAction{
+			Op:       op,
+			SourceID: strings.TrimSpace(a.SourceID),
+			TargetID: strings.TrimSpace(a.TargetID),
+		})
+	}
+	return out, nil
+}

--- a/sdk/recall/resolver_test.go
+++ b/sdk/recall/resolver_test.go
@@ -1,0 +1,333 @@
+package recall_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/GizClaw/flowcraft/sdk/llm"
+	"github.com/GizClaw/flowcraft/sdk/model"
+	"github.com/GizClaw/flowcraft/sdk/recall"
+	memidx "github.com/GizClaw/flowcraft/sdk/retrieval/memory"
+)
+
+// fakeResolver is a deterministic [recall.UpdateResolver] used to test
+// the Save -> resolver -> apply path without an LLM. It either runs a
+// caller-provided function (for batch-aware tests) or returns a static
+// canned set of actions.
+type fakeResolver struct {
+	fn      func(batch recall.ResolveBatch) ([]recall.ResolveAction, error)
+	actions []recall.ResolveAction
+	err     error
+
+	calls      int
+	lastBatch  recall.ResolveBatch
+	gotBatches []recall.ResolveBatch
+}
+
+func (r *fakeResolver) Resolve(_ context.Context, batch recall.ResolveBatch) ([]recall.ResolveAction, error) {
+	r.calls++
+	r.lastBatch = batch
+	r.gotBatches = append(r.gotBatches, batch)
+	if r.err != nil {
+		return nil, r.err
+	}
+	if r.fn != nil {
+		return r.fn(batch)
+	}
+	return r.actions, nil
+}
+
+// saveText is a tiny helper that runs Save with a single user message
+// and returns the resulting entry IDs in order.
+func saveText(t *testing.T, m recall.Memory, scope recall.Scope, text string) []string {
+	t.Helper()
+	res, err := m.Save(context.Background(), scope, []llm.Message{
+		{Role: model.RoleUser, Parts: []model.Part{{Type: model.PartText, Text: text}}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return res.EntryIDs
+}
+
+// firstSourceID returns the EntryID of the first new fact the resolver
+// saw — handy when wiring resolver actions that must reference a real
+// new fact, otherwise the action is rejected as a hallucinated
+// source_id.
+func firstSourceID(t *testing.T, batch recall.ResolveBatch) string {
+	t.Helper()
+	if len(batch.NewFacts) == 0 {
+		t.Fatalf("expected resolver batch to contain at least one new fact")
+	}
+	return batch.NewFacts[0].EntryID
+}
+
+func TestResolver_UpdateMarksSuperseded(t *testing.T) {
+	ctx := context.Background()
+	idx := memidx.New()
+	ex := &scriptedExtractor{
+		facts: [][]recall.ExtractedFact{
+			{{Content: "user owns a labrador named Lucky"}},
+			{{Content: "user has a poodle named Max"}},
+		},
+	}
+	resolver := &fakeResolver{}
+	m, err := recall.New(idx,
+		recall.WithRequireUserID(),
+		recall.WithExtractor(ex),
+		recall.WithUpdateResolver(resolver, 5),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer m.Close()
+
+	scope := newScope()
+	firstIDs := saveText(t, m, scope, "I have a labrador named Lucky")
+	// Wire the resolver to UPDATE the first entry; SourceID is filled
+	// from the batch so the action survives the hallucination guard.
+	resolver.fn = func(batch recall.ResolveBatch) ([]recall.ResolveAction, error) {
+		return []recall.ResolveAction{{
+			Op:       recall.OpUpdate,
+			SourceID: firstSourceID(t, batch),
+			TargetID: firstIDs[0],
+		}}, nil
+	}
+
+	saveText(t, m, scope, "Actually it's a poodle named Max")
+	if resolver.calls != 1 {
+		t.Fatalf("resolver should be called once (second Save); got %d", resolver.calls)
+	}
+	doc, ok, _ := idx.Get(ctx, recall.NamespaceFor(scope), firstIDs[0])
+	if !ok {
+		t.Fatalf("first entry vanished")
+	}
+	if _, has := doc.Metadata["superseded_by"]; !has {
+		t.Fatalf("first entry should be tagged superseded_by, metadata=%v", doc.Metadata)
+	}
+	if got, _ := doc.Metadata["tombstone"]; got == true {
+		t.Fatalf("UPDATE must not set tombstone; got %v", got)
+	}
+}
+
+func TestResolver_DeleteSetsTombstoneAndHidesFromRecall(t *testing.T) {
+	ctx := context.Background()
+	idx := memidx.New()
+	ex := &scriptedExtractor{
+		facts: [][]recall.ExtractedFact{
+			{{Content: "user has a dog called Lucky"}},
+			{{Content: "user no longer has a pet"}},
+		},
+	}
+	resolver := &fakeResolver{}
+	m, err := recall.New(idx,
+		recall.WithRequireUserID(),
+		recall.WithExtractor(ex),
+		recall.WithUpdateResolver(resolver, 5),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer m.Close()
+
+	scope := newScope()
+	firstIDs := saveText(t, m, scope, "I have a dog called Lucky")
+	resolver.fn = func(batch recall.ResolveBatch) ([]recall.ResolveAction, error) {
+		return []recall.ResolveAction{{
+			Op:       recall.OpDelete,
+			SourceID: firstSourceID(t, batch),
+			TargetID: firstIDs[0],
+		}}, nil
+	}
+	saveText(t, m, scope, "Lucky passed away last week")
+
+	doc, ok, _ := idx.Get(ctx, recall.NamespaceFor(scope), firstIDs[0])
+	if !ok {
+		t.Fatalf("DELETE must be soft (tombstone); doc was hard-removed")
+	}
+	if got := doc.Metadata["tombstone"]; got != true {
+		t.Fatalf("tombstone=%v, want true", got)
+	}
+	hits, err := m.Recall(ctx, scope, recall.Request{Query: "Lucky", TopK: 5})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, h := range hits {
+		if h.Entry.ID == firstIDs[0] {
+			t.Fatalf("Recall must hide tombstoned entry %q", firstIDs[0])
+		}
+	}
+}
+
+func TestResolver_NoopAndAddDoNotMutateStore(t *testing.T) {
+	ctx := context.Background()
+	idx := memidx.New()
+	ex := &scriptedExtractor{
+		facts: [][]recall.ExtractedFact{
+			{{Content: "user likes hiking"}},
+			{{Content: "user enjoys cycling on weekends"}},
+		},
+	}
+	resolver := &fakeResolver{}
+	m, err := recall.New(idx,
+		recall.WithRequireUserID(),
+		recall.WithExtractor(ex),
+		recall.WithUpdateResolver(resolver, 5),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer m.Close()
+	scope := newScope()
+	firstIDs := saveText(t, m, scope, "I like hiking")
+	resolver.fn = func(batch recall.ResolveBatch) ([]recall.ResolveAction, error) {
+		// Mix of NOOP and ADD — neither should touch existing docs.
+		return []recall.ResolveAction{
+			{Op: recall.OpNoop, SourceID: firstSourceID(t, batch), TargetID: "irrelevant"},
+			{Op: recall.OpAdd, SourceID: firstSourceID(t, batch)},
+		}, nil
+	}
+	saveText(t, m, scope, "I also enjoy cycling on weekends")
+
+	doc, _, _ := idx.Get(ctx, recall.NamespaceFor(scope), firstIDs[0])
+	if _, has := doc.Metadata["superseded_by"]; has {
+		t.Fatalf("NOOP/ADD must not set superseded_by; got %v", doc.Metadata["superseded_by"])
+	}
+}
+
+func TestResolver_SkipsFactsWithSlotFields(t *testing.T) {
+	ex := &scriptedExtractor{
+		facts: [][]recall.ExtractedFact{
+			{{Content: "user lives in Guangzhou", Subject: "user", Predicate: "lives_in"}},
+		},
+	}
+	resolver := &fakeResolver{}
+	m, err := recall.New(memidx.New(),
+		recall.WithRequireUserID(),
+		recall.WithExtractor(ex),
+		recall.WithUpdateResolver(resolver, 5),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer m.Close()
+	saveText(t, m, newScope(), "我住在广州")
+	if resolver.calls != 0 {
+		t.Fatalf("resolver must NOT be called for slot facts; got %d calls", resolver.calls)
+	}
+}
+
+func TestResolver_ErrorIsSwallowed(t *testing.T) {
+	ex := &scriptedExtractor{
+		facts: [][]recall.ExtractedFact{
+			{{Content: "user said something interesting"}},
+			{{Content: "user said something else"}},
+		},
+	}
+	resolver := &fakeResolver{err: errors.New("boom")}
+	m, err := recall.New(memidx.New(),
+		recall.WithRequireUserID(),
+		recall.WithExtractor(ex),
+		recall.WithUpdateResolver(resolver, 5),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer m.Close()
+	scope := newScope()
+	saveText(t, m, scope, "first")
+	// Resolver fails — Save must still succeed.
+	if _, err := m.Save(context.Background(), scope, []llm.Message{
+		{Role: model.RoleUser, Parts: []model.Part{{Type: model.PartText, Text: "second"}}},
+	}); err != nil {
+		t.Fatalf("Save must succeed even when resolver fails; got %v", err)
+	}
+}
+
+// TestResolver_BatchSeesAllNewFacts asserts that when a single Save
+// produces multiple non-slot facts the resolver receives ONE batch
+// containing all of them — not one call per fact. This is the core
+// behaviour change vs the per-fact resolver of the previous design.
+func TestResolver_BatchSeesAllNewFacts(t *testing.T) {
+	idx := memidx.New()
+	// Seed an existing entry the second Save's resolver will see as a
+	// candidate.
+	ex := &scriptedExtractor{
+		facts: [][]recall.ExtractedFact{
+			{{Content: "user used to be married to Alice"}},
+			// Second Save extracts TWO related facts in one batch.
+			{
+				{Content: "user divorced Alice"},
+				{Content: "user is now married to Beth"},
+			},
+		},
+	}
+	resolver := &fakeResolver{}
+	m, err := recall.New(idx,
+		recall.WithRequireUserID(),
+		recall.WithExtractor(ex),
+		recall.WithUpdateResolver(resolver, 5),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer m.Close()
+	scope := newScope()
+	saveText(t, m, scope, "I was married to Alice")
+
+	resolver.fn = func(batch recall.ResolveBatch) ([]recall.ResolveAction, error) {
+		// Sanity-check: the resolver sees BOTH new facts together.
+		if len(batch.NewFacts) != 2 {
+			t.Errorf("expected batch with 2 new facts, got %d", len(batch.NewFacts))
+		}
+		return nil, nil
+	}
+	saveText(t, m, scope, "I divorced Alice. I'm now married to Beth.")
+
+	if resolver.calls != 1 {
+		t.Fatalf("resolver must be called exactly once per Save; got %d", resolver.calls)
+	}
+	if got := len(resolver.lastBatch.NewFacts); got != 2 {
+		t.Fatalf("last batch new fact count = %d, want 2", got)
+	}
+}
+
+// TestResolver_HallucinatedSourceIDIsRejected verifies the defensive
+// guard in applyResolverActions: actions whose source_id does not
+// match any new fact in the batch are dropped with no side effect on
+// the store.
+func TestResolver_HallucinatedSourceIDIsRejected(t *testing.T) {
+	ctx := context.Background()
+	idx := memidx.New()
+	ex := &scriptedExtractor{
+		facts: [][]recall.ExtractedFact{
+			{{Content: "user enjoys reading"}},
+			{{Content: "user enjoys writing"}},
+		},
+	}
+	resolver := &fakeResolver{}
+	m, err := recall.New(idx,
+		recall.WithRequireUserID(),
+		recall.WithExtractor(ex),
+		recall.WithUpdateResolver(resolver, 5),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer m.Close()
+	scope := newScope()
+	firstIDs := saveText(t, m, scope, "I enjoy reading")
+	resolver.fn = func(batch recall.ResolveBatch) ([]recall.ResolveAction, error) {
+		return []recall.ResolveAction{{
+			Op:       recall.OpUpdate,
+			SourceID: "fabricated-id-not-in-batch",
+			TargetID: firstIDs[0],
+		}}, nil
+	}
+	saveText(t, m, scope, "I also enjoy writing")
+	doc, _, _ := idx.Get(ctx, recall.NamespaceFor(scope), firstIDs[0])
+	if _, has := doc.Metadata["superseded_by"]; has {
+		t.Fatalf("hallucinated source_id must not be applied; metadata=%v", doc.Metadata)
+	}
+}

--- a/sdk/recall/save.go
+++ b/sdk/recall/save.go
@@ -243,6 +243,19 @@ func (m *lt) upsertFacts(
 	ns := NamespaceFor(scope)
 	m.rememberNamespace(ctx, ns)
 
+	// 0. Normalize slot fields --------------------------------------------
+	// Predicate / Subject aliases are applied here (not in the extractor)
+	// so per-instance overrides reach every fact regardless of which
+	// extractor produced it. Running normalisation at the very top of
+	// upsertFacts also means every downstream step (MD5 dedup, slot
+	// metadata writing, slot supersede, resolver candidate gathering)
+	// observes the same canonical (subject, predicate) tuple — there
+	// is exactly one source of truth for what a fact "is about".
+	for i := range facts {
+		facts[i].Subject = normalizeSubject(facts[i].Subject, m.cfg.subjectAliases)
+		facts[i].Predicate = normalizePredicate(facts[i].Predicate, m.cfg.predicateAliases)
+	}
+
 	// 1. MD5 dedup ---------------------------------------------------------
 	hashes := make([]string, len(facts))
 	for i, f := range facts {
@@ -303,9 +316,25 @@ func (m *lt) upsertFacts(
 		if d.Metadata == nil {
 			d.Metadata = map[string]any{}
 		}
-		d.Metadata["content_hash"] = hashes[i]
+		d.Metadata[MetaContentHash] = hashes[i]
 		if f.Source != "" {
-			d.Metadata["source_label"] = f.Source
+			d.Metadata[MetaSourceLabel] = f.Source
+		}
+		// Slot fields are written only when BOTH Subject and Predicate are
+		// present so that the slot supersede channel and the SlotCollapse
+		// retrieval stage can rely on slot_key being unambiguous.
+		//
+		// Subjects/predicates that contain the slot delimiter '|' would
+		// produce ambiguous slot_keys (e.g. subject="user|alt"+
+		// predicate="lives_in" would collide with subject="user"+
+		// predicate="alt|lives_in"). The Save path drops the slot
+		// fields entirely in that case so the fact degrades to the
+		// vector / resolver supersede channels — slot writers stay
+		// strict, the rest of the pipeline keeps working.
+		if slotEligible(f) {
+			d.Metadata[MetaSubject] = f.Subject
+			d.Metadata[MetaPredicate] = f.Predicate
+			d.Metadata[MetaSlotKey] = f.Subject + slotDelimiter + f.Predicate
 		}
 		plans = append(plans, plan{entry: entry, doc: d, fact: f})
 		returnedIDs = append(returnedIDs, entry.ID)
@@ -335,14 +364,34 @@ func (m *lt) upsertFacts(
 		}
 	}
 
-	// 3. Soft-merge --------------------------------------------------------
-	if m.cfg.softMerge {
+	// 3. Supersede channels (slot + vector) -------------------------------
+	// supersedeNeighbours dispatches between the two channels and
+	// honours WithoutSlotChannel / WithoutSoftMerge independently;
+	// always call it and let the dispatcher decide.
+	for _, p := range plans {
+		m.supersedeNeighbours(ctx, scope, p.entry.ID, p.fact, p.vec, now)
+	}
+
+	// 4. LLM update resolver (opt-in fallback) -----------------------------
+	// The resolver runs at most once per Save with the full batch of
+	// non-slot facts so it can reason about combined contradictions
+	// (e.g. divorce + remarriage in the same turn). Slot-eligible facts
+	// were already handled by supersedeBySlot above and are excluded
+	// from the batch.
+	if m.cfg.updateResolver != nil {
+		batch := make([]ResolveNewFact, 0, len(plans))
 		for _, p := range plans {
-			m.supersedeNeighbours(ctx, scope, p.entry.ID, p.fact, p.vec, now)
+			if slotEligible(p.fact) {
+				continue
+			}
+			batch = append(batch, ResolveNewFact{EntryID: p.entry.ID, Fact: p.fact})
+		}
+		if len(batch) > 0 {
+			m.runResolverBatch(ctx, scope, batch, now)
 		}
 	}
 
-	// 4. Upsert new docs ---------------------------------------------------
+	// 5. Upsert new docs ---------------------------------------------------
 	docs := make([]retrieval.Doc, len(plans))
 	for i, p := range plans {
 		docs[i] = p.doc

--- a/sdk/recall/scope.go
+++ b/sdk/recall/scope.go
@@ -65,6 +65,26 @@ func AgentRecallFilter(s Scope) retrieval.Filter {
 	}}
 }
 
+// TombstoneFilter returns the default filter that excludes entries
+// the LLM update resolver has marked for deletion via
+// metadata[MetaTombstone] = true. The filter accepts entries where
+// the field is missing or any value other than the boolean true.
+//
+// Recall composes this filter by default; callers that want to
+// surface tombstoned entries (debugging the resolver, or staging an
+// Auditable.Rollback) MUST set Request.WithTombstoned = true.
+//
+// MetaTombstone is a RESERVED metadata key owned by the recall
+// package — pre-existing user data accidentally stored under
+// "tombstone" will be hidden by Recall until the caller passes
+// WithTombstoned.
+func TombstoneFilter() retrieval.Filter {
+	return retrieval.Filter{Or: []retrieval.Filter{
+		{Missing: []string{MetaTombstone}},
+		{Neq: map[string]any{MetaTombstone: true}},
+	}}
+}
+
 // ExpireFilter returns the default filter that excludes expired entries
 // . Pass current time via now (use time.Now() at call site).
 func ExpireFilter(now time.Time) retrieval.Filter {

--- a/sdk/recall/telemetry.go
+++ b/sdk/recall/telemetry.go
@@ -50,4 +50,36 @@ var (
 		"recall_lane_duration",
 		metric.WithDescription("Per-lane recall duration in seconds inside the retrieval pipeline executed under recall.Recall, labelled by lane key"),
 	)
+
+	// supersedeTotal counts entries marked superseded_by during a Save,
+	// labelled by the channel that made the decision: "slot" for the
+	// deterministic (subject, predicate) supersede path, "vector" for
+	// the existing entity+cosine soft-merge path, "resolver" for an
+	// LLM-driven UpdateResolver action. Use this to measure the relative
+	// contribution of each channel and decide when slot vocabulary or
+	// resolver coverage should be extended.
+	supersedeTotal, _ = recallMeter.Int64Counter(
+		"supersede_total",
+		metric.WithDescription("Older entries marked superseded_by during a Save, labelled by channel (slot/vector/resolver)"),
+	)
+
+	// resolverActionsTotal counts the actions an UpdateResolver returned
+	// during Save, labelled by op (add/update/delete/noop/error). The
+	// "error" bucket includes Recall failures, Resolve() errors and
+	// downstream Upsert failures so dashboards can alert on a single
+	// counter regardless of where the failure originated.
+	resolverActionsTotal, _ = recallMeter.Int64Counter(
+		"resolver_actions_total",
+		metric.WithDescription("LLM update resolver actions returned during Save, labelled by op (add/update/delete/noop/error)"),
+	)
+
+	// resolverDuration tracks end-to-end latency of a single resolver
+	// invocation (Recall candidate fetch + LLM call + Upsert apply). One
+	// observation per fact that entered the resolver path, regardless of
+	// outcome, so the histogram reflects user-visible Save overhead when
+	// the resolver is enabled.
+	resolverDuration, _ = recallMeter.Float64Histogram(
+		"resolver_duration",
+		metric.WithDescription("Per-fact LLM update resolver duration in seconds (Recall + Resolve + apply)"),
+	)
 )

--- a/sdk/retrieval/metadata.go
+++ b/sdk/retrieval/metadata.go
@@ -1,0 +1,37 @@
+package retrieval
+
+import "strings"
+
+// Reserved metadata keys that are part of the public retrieval / recall
+// protocol. Stages, writers and external integrations MUST use these
+// constants rather than hard-coded string literals so a typo is caught
+// at compile time and a future rename only touches one place.
+//
+// The recall package defines additional reserved keys (subject,
+// predicate, superseded_by, tombstone, …) that are documented in
+// sdk/recall/metadata.go; they live there because they are semantically
+// owned by the recall package, not the generic retrieval substrate.
+const (
+	// MetaSlotKey is the canonical metadata key under which a writer
+	// stores the slot supersede tuple ("subject|predicate"). The
+	// SlotCollapse retrieval stage reads it; the recall save path
+	// writes it. Kept on the retrieval side so both packages can
+	// reference one source of truth without an import cycle.
+	MetaSlotKey = "slot_key"
+)
+
+// SlotKeyOf returns the trimmed slot_key metadata value, or "" when
+// absent / non-string. Centralised so every reader (retrieval stages,
+// recall package helpers, future tooling) agrees on the lookup
+// contract — including the trim-on-read rule that tolerates writers
+// that forgot to canonicalise on write.
+func SlotKeyOf(d Doc) string {
+	if d.Metadata == nil {
+		return ""
+	}
+	v, ok := d.Metadata[MetaSlotKey].(string)
+	if !ok {
+		return ""
+	}
+	return strings.TrimSpace(v)
+}

--- a/sdk/retrieval/pipeline/factory.go
+++ b/sdk/retrieval/pipeline/factory.go
@@ -27,6 +27,7 @@ type ltmConfig struct {
 	limit            int
 	reranker         Reranker
 	entityExtract    EntityExtract
+	slotCollapse     bool
 }
 
 // WithRecallTopK overrides the vector recall fan-out (default 60).
@@ -80,6 +81,16 @@ func WithEntityExtractor(extract func(ctx context.Context, text string) ([]strin
 // WithLimit overrides the final TopK truncation (default 10).
 func WithLimit(k int) LTMOption {
 	return func(c *ltmConfig) { c.limit = k }
+}
+
+// WithSlotCollapse inserts a [SlotCollapse] stage after
+// [SupersededDecay] so legacy entries that were never tagged with
+// superseded_by still get collapsed to the newest hit per
+// (subject, predicate) tuple at recall time. Defaults to false; enable
+// when running on data written before the slot supersede channel
+// shipped or when the underlying writer cannot guarantee tagging.
+func WithSlotCollapse(on bool) LTMOption {
+	return func(c *ltmConfig) { c.slotCollapse = on }
 }
 
 // Default returns the general-purpose hybrid pipeline.
@@ -159,6 +170,9 @@ func LTM(emb embedding.Embedder, opts ...LTMOption) *Pipeline {
 	}
 	if cfg.supersededFactor > 0 && cfg.supersededFactor < 1 {
 		stages = append(stages, SupersededDecay{Factor: cfg.supersededFactor})
+	}
+	if cfg.slotCollapse {
+		stages = append(stages, SlotCollapse{})
 	}
 	if cfg.halfLife > 0 {
 		stages = append(stages, TimeDecay{HalfLife: cfg.halfLife})

--- a/sdk/retrieval/pipeline/pipeline_test.go
+++ b/sdk/retrieval/pipeline/pipeline_test.go
@@ -461,3 +461,58 @@ func TestDedupAndPostFilter(t *testing.T) {
 		t.Fatalf("hits=%+v", resp.Hits)
 	}
 }
+
+// TestSlotCollapse_KeepsNewest verifies that SlotCollapse drops the
+// older entry sharing the same slot_key while leaving entries without a
+// slot_key alone (legacy / episodic data must pass through).
+func TestSlotCollapse_KeepsNewest(t *testing.T) {
+	st := &State{Final: []retrieval.Hit{
+		{
+			Doc: retrieval.Doc{
+				ID: "old", Timestamp: time.Now().Add(-time.Hour),
+				Metadata: map[string]any{"slot_key": "user|lives_in"},
+			},
+			Score: 0.9,
+		},
+		{
+			Doc: retrieval.Doc{
+				ID: "new", Timestamp: time.Now(),
+				Metadata: map[string]any{"slot_key": "user|lives_in"},
+			},
+			Score: 0.5, // lower score, but newer — must win.
+		},
+		{
+			Doc:   retrieval.Doc{ID: "episodic", Timestamp: time.Now()},
+			Score: 0.7,
+		},
+	}}
+	if err := (SlotCollapse{}).Run(context.Background(), st); err != nil {
+		t.Fatal(err)
+	}
+	if len(st.Final) != 2 {
+		t.Fatalf("expected 2 hits, got %d: %+v", len(st.Final), st.Final)
+	}
+	ids := map[string]bool{}
+	for _, h := range st.Final {
+		ids[h.Doc.ID] = true
+	}
+	if !ids["new"] || !ids["episodic"] || ids["old"] {
+		t.Fatalf("expected {new, episodic}, got %v", ids)
+	}
+}
+
+// TestSlotCollapse_NoSlotPassThrough is the no-op fast path: when no
+// hit carries a slot_key the stage must not allocate or mutate Final.
+func TestSlotCollapse_NoSlotPassThrough(t *testing.T) {
+	hits := []retrieval.Hit{
+		{Doc: retrieval.Doc{ID: "a"}, Score: 1},
+		{Doc: retrieval.Doc{ID: "b"}, Score: 2},
+	}
+	st := &State{Final: hits}
+	if err := (SlotCollapse{}).Run(context.Background(), st); err != nil {
+		t.Fatal(err)
+	}
+	if len(st.Final) != 2 || st.Final[0].Doc.ID != "a" || st.Final[1].Doc.ID != "b" {
+		t.Fatalf("pass-through expected, got %+v", st.Final)
+	}
+}

--- a/sdk/retrieval/pipeline/stages_post.go
+++ b/sdk/retrieval/pipeline/stages_post.go
@@ -191,6 +191,79 @@ func (s Dedup) Run(_ context.Context, st *State) error {
 	return nil
 }
 
+// SlotCollapse keeps only the most recent hit per
+// metadata.slot_key value. Hits without a slot_key are passed through
+// untouched (legacy / episodic data). When two hits share the same slot
+// key the one with the larger Doc.Timestamp wins; ties are broken by
+// the higher score so deterministic recall ordering is preserved.
+//
+// SlotCollapse is the read-side counterpart to recall's slot supersede
+// channel: when a writer correctly tagged the older entry with
+// superseded_by SupersededDecay alone is sufficient and SlotCollapse is
+// a no-op. SlotCollapse exists for legacy data written before slot_key
+// was introduced — it ensures the LLM only ever sees the newest entry
+// for a given (subject, predicate) tuple even when the historical doc
+// was never tagged.
+//
+// Reads/Writes: Final.
+type SlotCollapse struct{}
+
+// Name implements Stage.
+func (s SlotCollapse) Name() string { return "SlotCollapse" }
+
+// Run implements Stage.
+func (s SlotCollapse) Run(_ context.Context, st *State) error {
+	hits := pickFinalish(st)
+	if len(hits) < 2 {
+		return nil
+	}
+	type keep struct {
+		idx   int
+		ts    time.Time
+		score float64
+	}
+	bySlot := make(map[string]keep)
+	drop := make(map[int]bool)
+	for i, h := range hits {
+		slot := retrieval.SlotKeyOf(h.Doc)
+		if slot == "" {
+			continue
+		}
+		cur, ok := bySlot[slot]
+		if !ok {
+			bySlot[slot] = keep{idx: i, ts: h.Doc.Timestamp, score: h.Score}
+			continue
+		}
+		// Newer timestamp wins; on ties (or zero timestamps) keep the
+		// higher-scoring hit so collapsed ordering matches the rest of
+		// the pipeline.
+		var newer bool
+		switch {
+		case h.Doc.Timestamp.After(cur.ts):
+			newer = true
+		case h.Doc.Timestamp.Equal(cur.ts) && h.Score > cur.score:
+			newer = true
+		}
+		if newer {
+			drop[cur.idx] = true
+			bySlot[slot] = keep{idx: i, ts: h.Doc.Timestamp, score: h.Score}
+		} else {
+			drop[i] = true
+		}
+	}
+	if len(drop) == 0 {
+		return nil
+	}
+	out := hits[:0]
+	for i, h := range hits {
+		if !drop[i] {
+			out = append(out, h)
+		}
+	}
+	st.Final = out
+	return nil
+}
+
 // Limit truncates Final to TopK and drops hits below MinScore
 // . MUST be the last stage. Reads/Writes: Final.
 type Limit struct {


### PR DESCRIPTION
## Summary

Hardens the slot supersede + LLM update resolver feature in `sdk/recall` after a code review that surfaced counter accounting bugs, a missing escape hatch, and several maintainability issues.

### Bugs (correctness)

- **B1** — `supersedeBySlot` only increments `supersede_total{channel="slot"}` after a successful `Upsert`, matching the vector / resolver channels. Previously the metric was bumped by `len(resp.Items)` before the loop's skip-list ran, over-reporting in dashboards.
- **B2** — `normalizeSubject` lowercases unknown tokens so case-only differences (`"Alice"` vs `"alice"`) collapse onto the same `slot_key`. The behaviour now mirrors `normalizePredicate` and is documented in godoc.
- **B3** — Add `Request.WithTombstoned` so callers can surface tombstoned entries (debug resolver, stage `Auditable.Rollback`). `MetaTombstone` is now documented as a reserved metadata key.

### Design / maintainability

- **M1 / N6** — Centralise reserved metadata keys: new `sdk/recall/metadata.go` (`MetaSubject`, `MetaPredicate`, `MetaSupersededBy`, `MetaSupersededAt`, `MetaTombstone`, `MetaContentHash`, `MetaSourceLabel`, `MetaEntities`) plus `sdk/retrieval/metadata.go` (`MetaSlotKey`, `SlotKeyOf`). Pipeline's `SlotCollapse` and the recall package now share one lookup helper instead of duplicating it.
- **M2** — `slotEligible(fact)` rejects subject/predicate values containing the slot delimiter `|` so ambiguous `slot_key`s are never written; such facts gracefully degrade to the vector / resolver channels.
- **M3** — New `WithoutSlotChannel()` option separates the deterministic slot path from the noisy vector soft-merge. `WithoutSoftMerge()` now affects the vector channel only and the godoc spells the difference out.
- **M4** — Resolver invocation opens its own span `memory.recall.resolver_batch` with `n_facts` / `n_candidates` attributes for cost attribution without enabling `SearchDebug`.
- **M5** — `WithUpdateResolver` godoc explains the ordering relationship with the slot/vector supersede channels and the resulting candidate-count behaviour.

### Polish

- **N1** — Drop misleading "future-proofs" comment in `save.go`; replaced with a "single source of truth" rationale that actually matches the code.
- **N2** — `ResolveAction` godoc clarifies that `SourceID` / `TargetID` are required for `UPDATE` / `DELETE` and informational/optional for `ADD` / `NOOP`.
- **N4** — Expand `PredicateAliases` coverage for high-frequency CN/EN surface forms across all v1 predicates (`住`/`住所`/`老家`/`故乡`/`供职`/`就职`/`出生`/`爱人`/`伴侣`, `based_in`/`married_to`/`born_on`/`son`/`daughter`, …); table is now documented as curated rather than exhaustive, with `WithPredicateAlias` overrides retained as the per-namespace extension point.
- **N5** — `LLMUpdateResolver` sends a strict `resolverActionsSchema` alongside `WithJSONMode` so providers that enforce JSON-schema (Azure OpenAI strict) accept the call.
- **N7** — Drop now-stale references to `docs/recall-update-resolution.md` (file does not exist in tree); link to in-code symbols instead.

### New tests

| Test | File | Covers |
| --- | --- | --- |
| `TestTombstoneFilter_HidesByDefault_OptInReveals` | `memory_test.go` | B3 |
| `TestSlotChannel_KeptWhenWithoutSoftMerge` | `merger_test.go` | M3 |
| `TestSlotChannel_DisabledByWithoutSlotChannel` | `merger_test.go` | M3 (new option) |
| `TestSlotSupersede_MultipleStaleEntriesInOneSlot` | `merger_test.go` | N3 (multiple stale entries) |
| `TestSlotEligibility_RejectsDelimiterInSubject` | `merger_test.go` | M2 |
| `TestSlotCollapse_EndToEnd_OnLegacyData` | `merger_test.go` | N3 (end-to-end) |
| `TestNormalizeSubject_LowercasesUnknownTokens` | `aliases_test.go` | B2 |

## Test plan

- [x] `go build ./sdk/...`
- [x] `go vet ./sdk/...`
- [x] `go test ./sdk/recall/...`
- [x] `go test ./sdk/... ./sdkx/... ./voice/...`

Made with [Cursor](https://cursor.com)