### PR TITLE
feat(sdk/engine,sdk/event,sdk/model): engine host extensibility, event sampling, and token usage enrichment

### DIFF
--- a/sdk/agent/run_test.go
+++ b/sdk/agent/run_test.go
@@ -606,11 +606,17 @@ func TestRun_AgentScopedDecidersFireBeforeCallScoped(t *testing.T) {
 	}
 }
 
-// usageReporterEngine reports a fixed delta then completes.
+// usageReporterEngine reports a fixed delta then completes. Any
+// budget error from the host is propagated so the agent layer sees
+// the same termination shape it would observe in a real sandbox host.
 func usageReporterEngine(u model.TokenUsage) engine.Engine {
 	return engine.EngineFunc(func(ctx context.Context, _ engine.Run, h engine.Host, b *engine.Board) (*engine.Board, error) {
-		h.ReportUsage(ctx, u)
-		h.ReportUsage(ctx, u)
+		if err := h.ReportUsage(ctx, u); err != nil {
+			return b, err
+		}
+		if err := h.ReportUsage(ctx, u); err != nil {
+			return b, err
+		}
 		return b, nil
 	})
 }
@@ -625,10 +631,11 @@ type usageHost struct {
 	total model.TokenUsage
 }
 
-func (h *usageHost) ReportUsage(_ context.Context, u model.TokenUsage) {
+func (h *usageHost) ReportUsage(_ context.Context, u model.TokenUsage) error {
 	h.mu.Lock()
 	h.total = h.total.Add(u)
 	h.mu.Unlock()
+	return nil
 }
 
 func (h *usageHost) Total() model.TokenUsage {

--- a/sdk/engine/board.go
+++ b/sdk/engine/board.go
@@ -1,11 +1,11 @@
 package engine
 
 import (
-	"fmt"
 	"maps"
 	"reflect"
 	"sync"
 
+	"github.com/GizClaw/flowcraft/sdk/errdefs"
 	"github.com/GizClaw/flowcraft/sdk/model"
 )
 
@@ -124,7 +124,7 @@ func (b *Board) AppendSliceVar(key string, value any) error {
 	}
 	slice, ok := existing.([]any)
 	if !ok {
-		return fmt.Errorf("engine.Board: var %q is %T, not []any", key, existing)
+		return errdefs.Validationf("engine.Board: var %q is %T, not []any", key, existing)
 	}
 	b.vars[key] = append(slice, value)
 	return nil

--- a/sdk/engine/capabilities.go
+++ b/sdk/engine/capabilities.go
@@ -1,0 +1,111 @@
+package engine
+
+// Capabilities describes the optional features an Engine implementation
+// declares to its host. The pod / agent layer reads these to:
+//
+//   - validate a PodSpec at Apply time (e.g. RestartPolicy=Always
+//     requires SupportsResume=true, otherwise the spec is rejected
+//     before any work starts);
+//   - decide which hooks to wire (configure CheckpointStore only when
+//     EmitsCheckpoint is true);
+//   - refuse to run an engine that needs user prompts in a headless
+//     deployment (EmitsUserPrompt=true on a host without an interactive
+//     channel becomes a fail-fast).
+//
+// All fields default to "do not claim the capability" (zero value).
+// Engines that do not satisfy the [Describer] interface are treated as
+// the zero Capabilities — the most conservative assumption.
+type Capabilities struct {
+	// SupportsResume reports whether Execute can honour
+	// Run.ResumeFrom. Engines that always return errdefs.NotAvailable
+	// for a non-nil ResumeFrom MUST leave this false; pods enforcing
+	// RestartPolicy=Always need the true case to recover mid-run state
+	// without losing partial work.
+	SupportsResume bool
+
+	// EmitsUserPrompt reports whether the engine may call
+	// Host.AskUser during Execute. Pods deploying in headless / batch
+	// mode use this to refuse engines that would block waiting for a
+	// reply that nobody can supply.
+	EmitsUserPrompt bool
+
+	// EmitsCheckpoint reports whether the engine writes Checkpoints
+	// during Execute (independently of SupportsResume — an engine
+	// can write checkpoints that only an external tool can replay).
+	// Pods use this to decide whether to attach a CheckpointStore.
+	EmitsCheckpoint bool
+
+	// RequiredDepNames lists the named dependencies the engine
+	// expects in Run.Deps. Names are conventional strings agreed
+	// between the engine and its host (e.g. "llm.resolver",
+	// "tool.registry"). Pods iterate this list at Apply time and
+	// reject the spec when a required dep is absent. Empty when the
+	// engine has no required deps.
+	//
+	// This is a *named* declaration deliberately — the underlying
+	// Dependencies map keys are `any`, so the engine cannot
+	// meaningfully expose its concrete typed keys to a generic pod
+	// controller. The host populates Dependencies under the same
+	// names the engine declares here.
+	RequiredDepNames []string
+}
+
+// Describer is the optional interface an Engine implementation
+// satisfies to advertise its [Capabilities]. Hosts that need to
+// gate behaviour on capabilities type-assert on Engine; engines that
+// do not implement Describer are treated as having the zero
+// Capabilities (no features claimed) — the safe default.
+//
+// Kept as a separate optional interface (not folded into Engine)
+// because most engines need only Execute and the SDK contract
+// MUST stay easy to satisfy with a one-method type.
+type Describer interface {
+	Capabilities() Capabilities
+}
+
+// CapabilitiesOf returns the engine's declared capabilities, or the
+// zero value when the engine does not implement [Describer]. Hosts
+// SHOULD use this helper rather than ad-hoc type assertions so the
+// "missing = zero" convention stays uniform.
+func CapabilitiesOf(e Engine) Capabilities {
+	if d, ok := e.(Describer); ok {
+		return d.Capabilities()
+	}
+	return Capabilities{}
+}
+
+// CheckpointSuggester is the optional engine-side interface a host
+// uses to ask the engine to write a Checkpoint at the next safe
+// boundary — typically before a voluntary restart, scale-down, or pod
+// reschedule.
+//
+// Semantics (advisory, not synchronous):
+//
+//   - The engine SHOULD call its host's Checkpointer at the next
+//     point in execution where Checkpoint.Step is well-defined. It is
+//     NOT obligated to interrupt itself; SuggestCheckpoint returns
+//     immediately with no guarantee that the checkpoint has been
+//     written by the time it returns.
+//   - The host typically pairs SuggestCheckpoint with a follow-up
+//     Interrupt after a grace period: "save what you can, then stop".
+//   - Engines that have no notion of a step boundary (purely
+//     memory-resident, sub-second runs) MAY treat this as a no-op.
+//   - Calling SuggestCheckpoint on an engine that does not implement
+//     this interface is impossible by the type system; hosts use
+//     [SuggestCheckpoint] (the helper below) which type-asserts and
+//     no-ops on engines that do not satisfy the interface.
+type CheckpointSuggester interface {
+	SuggestCheckpoint() error
+}
+
+// SuggestCheckpoint asks the engine for a voluntary checkpoint when
+// the engine implements [CheckpointSuggester]; otherwise it is a
+// no-op. Returns the engine's error directly so the host can log /
+// retry; nil is returned both for "engine does not support
+// suggestion" and for "engine accepted the suggestion".
+func SuggestCheckpoint(e Engine) error {
+	if s, ok := e.(CheckpointSuggester); ok {
+		return s.SuggestCheckpoint()
+	}
+	return nil
+}

--- a/sdk/engine/capabilities_test.go
+++ b/sdk/engine/capabilities_test.go
@@ -1,0 +1,78 @@
+package engine_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/GizClaw/flowcraft/sdk/engine"
+)
+
+type describingEngine struct {
+	caps engine.Capabilities
+}
+
+func (describingEngine) Execute(_ context.Context, _ engine.Run, _ engine.Host, b *engine.Board) (*engine.Board, error) {
+	return b, nil
+}
+
+func (e describingEngine) Capabilities() engine.Capabilities { return e.caps }
+
+func TestCapabilitiesOf_DefaultsToZeroForPlainEngine(t *testing.T) {
+	plain := engine.EngineFunc(func(_ context.Context, _ engine.Run, _ engine.Host, b *engine.Board) (*engine.Board, error) {
+		return b, nil
+	})
+	got := engine.CapabilitiesOf(plain)
+	if got.SupportsResume || got.EmitsUserPrompt || got.EmitsCheckpoint || len(got.RequiredDepNames) != 0 {
+		t.Fatalf("plain engine must report zero Capabilities; got %+v", got)
+	}
+}
+
+func TestCapabilitiesOf_ReadsDescriber(t *testing.T) {
+	want := engine.Capabilities{
+		SupportsResume:   true,
+		EmitsUserPrompt:  true,
+		EmitsCheckpoint:  true,
+		RequiredDepNames: []string{"llm.resolver", "tool.registry"},
+	}
+	got := engine.CapabilitiesOf(describingEngine{caps: want})
+	if got.SupportsResume != true ||
+		got.EmitsUserPrompt != true ||
+		got.EmitsCheckpoint != true ||
+		len(got.RequiredDepNames) != 2 ||
+		got.RequiredDepNames[0] != "llm.resolver" ||
+		got.RequiredDepNames[1] != "tool.registry" {
+		t.Fatalf("CapabilitiesOf = %+v, want %+v", got, want)
+	}
+}
+
+type suggestingEngine struct {
+	describingEngine
+	calls int
+	err   error
+}
+
+func (s *suggestingEngine) SuggestCheckpoint() error {
+	s.calls++
+	return s.err
+}
+
+func TestSuggestCheckpoint_NoOpForEnginesWithoutInterface(t *testing.T) {
+	plain := engine.EngineFunc(func(_ context.Context, _ engine.Run, _ engine.Host, b *engine.Board) (*engine.Board, error) {
+		return b, nil
+	})
+	if err := engine.SuggestCheckpoint(plain); err != nil {
+		t.Fatalf("SuggestCheckpoint on a plain engine must be a nil-returning no-op; got %v", err)
+	}
+}
+
+func TestSuggestCheckpoint_DelegatesToImplementation(t *testing.T) {
+	se := &suggestingEngine{err: errors.New("snapshot failed")}
+	got := engine.SuggestCheckpoint(se)
+	if se.calls != 1 {
+		t.Fatalf("SuggestCheckpoint must call the engine once; got %d", se.calls)
+	}
+	if got == nil || got.Error() != "snapshot failed" {
+		t.Fatalf("SuggestCheckpoint must surface the engine error; got %v", got)
+	}
+}

--- a/sdk/engine/deps.go
+++ b/sdk/engine/deps.go
@@ -1,8 +1,9 @@
 package engine
 
 import (
-	"fmt"
 	"sync"
+
+	"github.com/GizClaw/flowcraft/sdk/errdefs"
 )
 
 // Dependencies is a typed dependency-injection container that an engine
@@ -75,15 +76,20 @@ func (d *Dependencies) Has(key any) bool {
 func GetDep[T any](d *Dependencies, key any) (T, error) {
 	var zero T
 	if d == nil {
-		return zero, fmt.Errorf("engine.GetDep: nil dependencies (looking up %v)", key)
+		// nil container is a host-side wiring bug — the run was
+		// started without the dependencies it needs. Classify as
+		// Internal so callers / observability can distinguish "you
+		// forgot to wire deps" from "this specific dep is missing"
+		// (NotFound, below).
+		return zero, errdefs.Internalf("engine.GetDep: nil dependencies (looking up %v)", key)
 	}
 	raw, ok := d.Get(key)
 	if !ok {
-		return zero, fmt.Errorf("engine.GetDep: dependency %v not found", key)
+		return zero, errdefs.NotFoundf("engine.GetDep: dependency %v not found", key)
 	}
 	v, ok := raw.(T)
 	if !ok {
-		return zero, fmt.Errorf("engine.GetDep: dependency %v has type %T, want %T", key, raw, zero)
+		return zero, errdefs.Validationf("engine.GetDep: dependency %v has type %T, want %T", key, raw, zero)
 	}
 	return v, nil
 }

--- a/sdk/engine/enginetest/mock_host.go
+++ b/sdk/engine/enginetest/mock_host.go
@@ -159,10 +159,11 @@ func (h *MockHost) Checkpoints() []engine.Checkpoint {
 // ReportUsage records the usage delta. Multiple calls are kept in
 // order so tests can assert per-call totals; sum them with
 // [MockHost.TotalUsage] when only the total matters.
-func (h *MockHost) ReportUsage(_ context.Context, usage model.TokenUsage) {
+func (h *MockHost) ReportUsage(_ context.Context, usage model.TokenUsage) error {
 	h.mu.Lock()
 	h.usages = append(h.usages, usage)
 	h.mu.Unlock()
+	return nil
 }
 
 // Usages returns a copy of every usage report.

--- a/sdk/engine/host.go
+++ b/sdk/engine/host.go
@@ -97,13 +97,25 @@ type Checkpointer interface {
 // Engines should call ReportUsage once per LLM invocation that
 // returns usage metadata (typical: streaming nodes call it on
 // completion with the per-call totals). Reports SHOULD be best-effort
-// — engines must not let a slow or failing reporter block forward
-// progress, and must not return an error to the run because of usage
-// reporting.
+// for *observability* failures — a slow exporter must not block forward
+// progress.
 //
-// Hosts without billing or token tracking should make this a no-op.
+// Budget enforcement contract:
+//
+//   - The host MAY return errdefs.BudgetExceeded (or any error
+//     classified by errdefs.IsBudgetExceeded) to signal that the
+//     accumulated usage has crossed a configured budget and the next
+//     LLM call would not be authorised.
+//   - Engines that observe such an error MUST stop performing further
+//     LLM-cost-incurring work in this run and return the error from
+//     Execute (typically wrapped). Continuing would defeat the budget.
+//   - Any other non-nil error is observability-only — engines SHOULD
+//     log/swallow and continue, matching the pre-budget contract.
+//
+// Hosts without billing or budget enforcement return nil
+// unconditionally (see [NoopHost.ReportUsage]).
 type UsageReporter interface {
-	ReportUsage(ctx context.Context, usage model.TokenUsage)
+	ReportUsage(ctx context.Context, usage model.TokenUsage) error
 }
 
 // NoopHost is a zero-cost Host implementation that discards events,
@@ -128,5 +140,6 @@ func (NoopHost) AskUser(context.Context, UserPrompt) (UserReply, error) {
 // Checkpoint discards the checkpoint.
 func (NoopHost) Checkpoint(context.Context, Checkpoint) error { return nil }
 
-// ReportUsage discards the usage report.
-func (NoopHost) ReportUsage(context.Context, model.TokenUsage) {}
+// ReportUsage discards the usage report. NoopHost has no budget so
+// always returns nil — engines never see BudgetExceeded under it.
+func (NoopHost) ReportUsage(context.Context, model.TokenUsage) error { return nil }

--- a/sdk/engine/host_test.go
+++ b/sdk/engine/host_test.go
@@ -44,10 +44,13 @@ func TestNoopHost_CheckpointDrops(t *testing.T) {
 	}
 }
 
-func TestNoopHost_ReportUsageDrops(t *testing.T) {
-	// Just verify it doesn't panic; nothing observable beyond that.
-	(engine.NoopHost{}).ReportUsage(context.Background(),
-		model.TokenUsage{InputTokens: 1, OutputTokens: 1, TotalTokens: 2})
+func TestNoopHost_ReportUsageDropsAndReturnsNil(t *testing.T) {
+	// NoopHost has no budget so it MUST return nil — engines that
+	// branch on errdefs.IsBudgetExceeded never see it under noop.
+	if err := (engine.NoopHost{}).ReportUsage(context.Background(),
+		model.TokenUsage{InputTokens: 1, OutputTokens: 1, TotalTokens: 2}); err != nil {
+		t.Errorf("NoopHost.ReportUsage must return nil; got %v", err)
+	}
 }
 
 func TestEngineFunc_NilSafe(t *testing.T) {

--- a/sdk/engine/interrupt.go
+++ b/sdk/engine/interrupt.go
@@ -1,5 +1,10 @@
 package engine
 
+import (
+	"context"
+	"sync"
+)
+
 // Cause classifies why a run was asked to stop. The agent layer maps
 // these onto its higher-level commit/discard policy (e.g. discard the
 // partial output on user_input, commit it on host_shutdown).
@@ -105,3 +110,88 @@ func (interruptedErr) Interrupted() {}
 // uses errors.As against this exact shape, so this assertion guarantees
 // classification works.
 var _ interface{ Interrupted() } = interruptedErr{}
+
+// MergeInterrupts fans-in N independent interrupt channels into a
+// single output channel — the natural shape sandbox / pod hosts need
+// to combine "user cancel", "SIGTERM", "budget exceeded", "graceful
+// stop", … into the one channel an Engine reads from
+// [Host.Interrupts].
+//
+// Behaviour:
+//
+//   - The returned channel is closed once ctx is cancelled OR every
+//     non-nil source channel has been closed. Engines reading from it
+//     therefore see EOF when "everyone is done", matching how a single
+//     cooperative-interrupt channel behaves today.
+//   - Nil source channels are skipped silently — matches the documented
+//     "nil means never fires" semantic in [Interrupter.Interrupts] and
+//     keeps callers from having to filter their slice.
+//   - When zero non-nil sources are supplied the returned channel is
+//     a never-fires channel that is closed when ctx is cancelled. This
+//     keeps the helper total — engines selecting on it stay correct
+//     even in the trivial case.
+//   - Order of forwarded interrupts is the natural runtime arrival
+//     order across the source channels. No de-duplication: a host that
+//     fires "shutdown" through two distinct sources will surface both.
+//
+// Forwarding goroutines exit promptly when ctx is cancelled, so the
+// helper is safe to use in long-lived hosts that get re-created across
+// reloads.
+func MergeInterrupts(ctx context.Context, sources ...<-chan Interrupt) <-chan Interrupt {
+	out := make(chan Interrupt)
+
+	// Filter nil sources up front so the WaitGroup count matches the
+	// number of goroutines actually launched. With ctx cancellation we
+	// also need a separate sentinel to wake a parked send when ctx
+	// fires before any source produces; a single fan-out goroutine
+	// owns that responsibility.
+	var live []<-chan Interrupt
+	for _, ch := range sources {
+		if ch != nil {
+			live = append(live, ch)
+		}
+	}
+
+	var wg sync.WaitGroup
+	wg.Add(len(live))
+	for _, ch := range live {
+		go func(in <-chan Interrupt) {
+			defer wg.Done()
+			for {
+				select {
+				case <-ctx.Done():
+					return
+				case intr, ok := <-in:
+					if !ok {
+						return
+					}
+					select {
+					case <-ctx.Done():
+						return
+					case out <- intr:
+					}
+				}
+			}
+		}(ch)
+	}
+
+	// Closer: every forwarder exits on ctx.Done OR source close, then
+	// wg.Wait unblocks and we close out exactly once with no pending
+	// senders. The zero-source case still works: wg starts at 0 and
+	// out closes as soon as ctx is cancelled (because the goroutine
+	// blocks on wg.Wait, which returns immediately, so we then need a
+	// ctx select to keep the channel alive until cancellation). Handle
+	// that case explicitly so a 0-source merge doesn't return an
+	// already-closed channel.
+	go func() {
+		if len(live) == 0 {
+			<-ctx.Done()
+			close(out)
+			return
+		}
+		wg.Wait()
+		close(out)
+	}()
+
+	return out
+}

--- a/sdk/engine/interrupt_test.go
+++ b/sdk/engine/interrupt_test.go
@@ -1,9 +1,12 @@
 package engine_test
 
 import (
+	"context"
 	"errors"
 	"fmt"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/GizClaw/flowcraft/sdk/engine"
 	"github.com/GizClaw/flowcraft/sdk/errdefs"
@@ -84,6 +87,146 @@ func TestInterruptedError_MarkerInvoked(t *testing.T) {
 	}
 	// Calling the marker must not panic.
 	marker.Interrupted()
+}
+
+func TestMergeInterrupts_FansInFromMultipleSources(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	a := make(chan engine.Interrupt, 1)
+	b := make(chan engine.Interrupt, 1)
+	out := engine.MergeInterrupts(ctx, a, b)
+
+	a <- engine.Interrupt{Cause: engine.CauseUserCancel, Detail: "from-a"}
+	b <- engine.Interrupt{Cause: engine.CauseHostShutdown, Detail: "from-b"}
+
+	got := make(map[engine.Cause]string)
+	for i := 0; i < 2; i++ {
+		select {
+		case intr := <-out:
+			got[intr.Cause] = intr.Detail
+		case <-time.After(time.Second):
+			t.Fatalf("merged channel timed out at %d/2", i+1)
+		}
+	}
+	if got[engine.CauseUserCancel] != "from-a" || got[engine.CauseHostShutdown] != "from-b" {
+		t.Fatalf("merged values = %+v, want both detail strings", got)
+	}
+}
+
+func TestMergeInterrupts_NilSourcesIgnored(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	live := make(chan engine.Interrupt, 1)
+	out := engine.MergeInterrupts(ctx, nil, live, nil)
+
+	live <- engine.Interrupt{Cause: engine.CauseCustom, Detail: "go"}
+	select {
+	case intr := <-out:
+		if intr.Cause != engine.CauseCustom {
+			t.Fatalf("Cause = %q, want %q", intr.Cause, engine.CauseCustom)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("nil sources must be skipped, not crash; live source produced no value")
+	}
+}
+
+func TestMergeInterrupts_ClosesWhenEverySourceCloses(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	a := make(chan engine.Interrupt)
+	b := make(chan engine.Interrupt)
+	out := engine.MergeInterrupts(ctx, a, b)
+
+	close(a)
+	close(b)
+
+	select {
+	case _, ok := <-out:
+		if ok {
+			t.Fatal("merged channel should be closed after every source closed")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("merged channel did not close within deadline")
+	}
+}
+
+func TestMergeInterrupts_ClosesOnCtxCancel(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	a := make(chan engine.Interrupt)
+	out := engine.MergeInterrupts(ctx, a)
+
+	cancel()
+
+	select {
+	case _, ok := <-out:
+		if ok {
+			t.Fatal("merged channel should be closed after ctx cancel")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("ctx cancel did not propagate to merged channel within deadline")
+	}
+}
+
+func TestMergeInterrupts_ZeroSources(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	out := engine.MergeInterrupts(ctx)
+
+	// Channel is alive (no source closed it) until ctx fires.
+	select {
+	case <-out:
+		t.Fatal("zero-source merge must not yield values before ctx cancel")
+	default:
+	}
+	cancel()
+	select {
+	case _, ok := <-out:
+		if ok {
+			t.Fatal("zero-source merge must close on ctx cancel")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("zero-source merge did not close after ctx cancel")
+	}
+}
+
+func TestMergeInterrupts_NoGoroutineLeakAfterCancel(t *testing.T) {
+	// Defensive: spin up several merges, cancel them, ensure every
+	// source-side forwarder has exited (i.e. each source channel can
+	// be re-used / GC'd) by counting WaitGroup completions through a
+	// proxy: re-sending into an already-cancelled merge must not
+	// block indefinitely because no forwarder is parked on receive.
+	ctx, cancel := context.WithCancel(context.Background())
+	a := make(chan engine.Interrupt, 1)
+	out := engine.MergeInterrupts(ctx, a)
+
+	cancel()
+	// Drain out so the closer goroutine sees both ctx.Done and an
+	// emptied channel state.
+	<-out
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		// After cancel + drain, sending into the source channel must
+		// not park forever — no forwarder remains. Buffered cap=1
+		// absorbs the send; unblocked goroutine returns immediately.
+		a <- engine.Interrupt{}
+	}()
+	done := make(chan struct{})
+	go func() {
+		wg.Wait()
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("source channel send blocked — forwarder goroutine leaked")
+	}
 }
 
 func TestCauseConstants_StableValues(t *testing.T) {

--- a/sdk/engine/middleware.go
+++ b/sdk/engine/middleware.go
@@ -1,0 +1,130 @@
+package engine
+
+import (
+	"context"
+
+	"github.com/GizClaw/flowcraft/sdk/event"
+	"github.com/GizClaw/flowcraft/sdk/model"
+)
+
+// HostMiddleware decorates a Host with policy / observability /
+// resource-management behaviour. The pod / agent layer typically
+// stacks several middlewares (audit → rate-limit → budget →
+// secret-resolve) around a base Host built from a PodSpec; this
+// type and the [ComposeHost] helper exist so the stack can be
+// declared as a slice instead of N levels of struct embedding.
+//
+// Convention:
+//
+//   - Middleware ordering matches the slice order: ComposeHost(base,
+//     A, B, C) returns C(B(A(base))). The first middleware in the
+//     slice is the OUTERMOST wrapper and therefore runs first when an
+//     engine calls a Host method. This matches how HTTP middleware
+//     stacks are normally declared.
+//   - Each middleware MUST return a Host value that delegates
+//     unchanged for any sub-interface it does not specifically
+//     decorate. The [HostFuncs] adapter is provided to make this
+//     easy: zero-value func fields delegate to the wrapped Host.
+//   - Middlewares are invoked from any goroutine — implementations
+//     must be safe for concurrent use, mirroring the Host contract.
+type HostMiddleware func(Host) Host
+
+// ComposeHost returns base wrapped by every middleware in mws, in
+// declaration order (first = outermost). Returns base unchanged when
+// mws is empty.
+func ComposeHost(base Host, mws ...HostMiddleware) Host {
+	// Apply in reverse so the first slice entry ends up as the
+	// outermost wrapper. ComposeHost(base, A, B) ≡ A(B(base)) so a
+	// caller reading the slice top-down sees "A first, then B".
+	h := base
+	for i := len(mws) - 1; i >= 0; i-- {
+		if mws[i] == nil {
+			continue
+		}
+		h = mws[i](h)
+		if h == nil {
+			// A middleware that returns nil would silently break the
+			// chain at the next call. Refuse the whole compose so the
+			// programming bug surfaces immediately at assembly time.
+			panic("engine.ComposeHost: middleware returned nil Host")
+		}
+	}
+	return h
+}
+
+// HostFuncs is the func-field adapter that lets a middleware decorate
+// just the Host methods it cares about while delegating the rest to
+// an underlying Host. Construct one with the inner host as Inner and
+// override only the func fields you need:
+//
+//	wrapped := engine.HostFuncs{
+//	    Inner: base,
+//	    ReportUsageFn: func(ctx context.Context, u model.TokenUsage) error {
+//	        // budget enforcement here
+//	        return base.ReportUsage(ctx, u)
+//	    },
+//	}
+//
+// Every nil func field falls through to Inner so partial decorators
+// stay short. Inner MUST be non-nil; a nil Inner is a programming
+// bug and triggers a panic at the first delegated call.
+type HostFuncs struct {
+	Inner Host
+
+	PublishFn     func(ctx context.Context, env event.Envelope) error
+	InterruptsFn  func() <-chan Interrupt
+	AskUserFn     func(ctx context.Context, prompt UserPrompt) (UserReply, error)
+	CheckpointFn  func(ctx context.Context, cp Checkpoint) error
+	ReportUsageFn func(ctx context.Context, usage model.TokenUsage) error
+}
+
+// Publish routes through PublishFn or Inner.
+func (h HostFuncs) Publish(ctx context.Context, env event.Envelope) error {
+	if h.PublishFn != nil {
+		return h.PublishFn(ctx, env)
+	}
+	return h.requireInner().Publish(ctx, env)
+}
+
+// Interrupts routes through InterruptsFn or Inner.
+func (h HostFuncs) Interrupts() <-chan Interrupt {
+	if h.InterruptsFn != nil {
+		return h.InterruptsFn()
+	}
+	return h.requireInner().Interrupts()
+}
+
+// AskUser routes through AskUserFn or Inner.
+func (h HostFuncs) AskUser(ctx context.Context, prompt UserPrompt) (UserReply, error) {
+	if h.AskUserFn != nil {
+		return h.AskUserFn(ctx, prompt)
+	}
+	return h.requireInner().AskUser(ctx, prompt)
+}
+
+// Checkpoint routes through CheckpointFn or Inner.
+func (h HostFuncs) Checkpoint(ctx context.Context, cp Checkpoint) error {
+	if h.CheckpointFn != nil {
+		return h.CheckpointFn(ctx, cp)
+	}
+	return h.requireInner().Checkpoint(ctx, cp)
+}
+
+// ReportUsage routes through ReportUsageFn or Inner.
+func (h HostFuncs) ReportUsage(ctx context.Context, usage model.TokenUsage) error {
+	if h.ReportUsageFn != nil {
+		return h.ReportUsageFn(ctx, usage)
+	}
+	return h.requireInner().ReportUsage(ctx, usage)
+}
+
+// requireInner panics with a clear message when a delegated method
+// is invoked without an Inner host configured. Caught at the first
+// call rather than producing a confusing nil-pointer trace several
+// frames in.
+func (h HostFuncs) requireInner() Host {
+	if h.Inner == nil {
+		panic("engine.HostFuncs: Inner is nil; cannot delegate")
+	}
+	return h.Inner
+}

--- a/sdk/engine/middleware_test.go
+++ b/sdk/engine/middleware_test.go
@@ -1,0 +1,126 @@
+package engine_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/GizClaw/flowcraft/sdk/engine"
+	"github.com/GizClaw/flowcraft/sdk/errdefs"
+	"github.com/GizClaw/flowcraft/sdk/event"
+	"github.com/GizClaw/flowcraft/sdk/model"
+)
+
+func TestComposeHost_OrdersFirstSliceEntryAsOutermost(t *testing.T) {
+	var seen []string
+
+	mw := func(name string) engine.HostMiddleware {
+		return func(inner engine.Host) engine.Host {
+			return engine.HostFuncs{
+				Inner: inner,
+				ReportUsageFn: func(ctx context.Context, u model.TokenUsage) error {
+					seen = append(seen, name)
+					return inner.ReportUsage(ctx, u)
+				},
+			}
+		}
+	}
+
+	composed := engine.ComposeHost(engine.NoopHost{}, mw("A"), mw("B"), mw("C"))
+	if err := composed.ReportUsage(context.Background(), model.TokenUsage{}); err != nil {
+		t.Fatalf("ReportUsage: %v", err)
+	}
+	want := []string{"A", "B", "C"}
+	if len(seen) != 3 || seen[0] != want[0] || seen[1] != want[1] || seen[2] != want[2] {
+		t.Fatalf("call order = %v, want %v (declaration order)", seen, want)
+	}
+}
+
+func TestComposeHost_NoMiddlewaresEchoesBase(t *testing.T) {
+	base := engine.NoopHost{}
+	got := engine.ComposeHost(base)
+	if _, ok := got.(engine.NoopHost); !ok {
+		t.Fatalf("ComposeHost(base) with no middlewares must return base unchanged; got %T", got)
+	}
+}
+
+func TestComposeHost_PanicsOnNilReturn(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Fatal("expected panic on middleware returning nil Host")
+		}
+	}()
+	_ = engine.ComposeHost(engine.NoopHost{}, func(engine.Host) engine.Host { return nil })
+}
+
+func TestHostFuncs_DelegatesUntouchedMethods(t *testing.T) {
+	// Override only ReportUsage; every other method must fall through
+	// to Inner. Verify by exercising each delegated method against
+	// NoopHost and checking it gives NoopHost's documented behaviour.
+	called := false
+	wrapped := engine.HostFuncs{
+		Inner: engine.NoopHost{},
+		ReportUsageFn: func(_ context.Context, _ model.TokenUsage) error {
+			called = true
+			return nil
+		},
+	}
+
+	if err := wrapped.Publish(context.Background(), event.Envelope{Subject: "x"}); err != nil {
+		t.Errorf("Publish should delegate to NoopHost (returns nil); got %v", err)
+	}
+	if wrapped.Interrupts() != nil {
+		t.Error("Interrupts should delegate to NoopHost (returns nil)")
+	}
+	if _, err := wrapped.AskUser(context.Background(), engine.UserPrompt{}); !errdefs.IsNotAvailable(err) {
+		t.Errorf("AskUser should delegate to NoopHost (NotAvailable); got %v", err)
+	}
+	if err := wrapped.Checkpoint(context.Background(), engine.Checkpoint{}); err != nil {
+		t.Errorf("Checkpoint should delegate to NoopHost (returns nil); got %v", err)
+	}
+	if err := wrapped.ReportUsage(context.Background(), model.TokenUsage{}); err != nil {
+		t.Errorf("ReportUsage override returned %v, want nil", err)
+	}
+	if !called {
+		t.Error("ReportUsageFn override was never invoked")
+	}
+}
+
+func TestHostFuncs_BudgetGateRefusesNextCall(t *testing.T) {
+	// Worked example: the canonical sandbox host wraps base so
+	// ReportUsage returns BudgetExceeded once a quota hits. Engines
+	// observing the error must propagate; we assert the wire-level
+	// classification here so a refactor that loses the marker breaks
+	// loudly.
+	var totalTokens int64
+	const quota = int64(100)
+
+	gated := engine.HostFuncs{
+		Inner: engine.NoopHost{},
+		ReportUsageFn: func(_ context.Context, u model.TokenUsage) error {
+			totalTokens += u.TotalTokens
+			if totalTokens > quota {
+				return errdefs.BudgetExceededf("token budget exceeded: %d/%d", totalTokens, quota)
+			}
+			return nil
+		},
+	}
+
+	if err := gated.ReportUsage(context.Background(), model.TokenUsage{TotalTokens: 60}); err != nil {
+		t.Fatalf("first call within budget; got %v", err)
+	}
+	err := gated.ReportUsage(context.Background(), model.TokenUsage{TotalTokens: 60})
+	if !errdefs.IsBudgetExceeded(err) {
+		t.Fatalf("second call must trip BudgetExceeded; got %v", err)
+	}
+}
+
+func TestHostFuncs_NilInnerPanicsClearly(t *testing.T) {
+	defer func() {
+		r := recover()
+		if r == nil {
+			t.Fatal("expected panic when Inner is nil and method is delegated")
+		}
+	}()
+	h := engine.HostFuncs{} // no overrides, no Inner
+	_ = h.Publish(context.Background(), event.Envelope{Subject: "x"})
+}

--- a/sdk/engine/run.go
+++ b/sdk/engine/run.go
@@ -17,16 +17,26 @@ type Run struct {
 	// across resume / checkpoint cycles.
 	ID string
 
+	// ParentRunID identifies the parent engine.Run when this Run was
+	// dispatched by another agent (multi-agent call chains). Empty
+	// for top-level runs. Promoted to a typed field — separate from
+	// Attributes — so loop / depth detection at the pod layer can
+	// rely on the contract rather than hoping every engine remembers
+	// to populate the same string attribute key.
+	ParentRunID string
+
 	// Attributes carries arbitrary host-supplied metadata that should
-	// flow into telemetry spans and event headers (run id at the
-	// agent layer, tenant id, parent span links, engine kind for
-	// observability, …).
+	// flow into telemetry spans and event headers (tenant id, agent
+	// id, parent span links, engine kind, …).
 	//
-	// There is intentionally no dedicated field for "engine kind",
-	// "run id (agent layer)" or similar: those are observability
-	// concerns whose key conventions the host owns. If the consumer
-	// side wants to filter by engine kind, the host sets
-	// Attributes["engine_kind"] (or whatever key it agreed on).
+	// Convention: keys MUST use the constants in sdk/telemetry
+	// (`telemetry.AttrTenantID`, `telemetry.AttrAgentID`,
+	// `telemetry.AttrEngineKind`, …) so cross-package consumers
+	// (dashboards, log queries) can filter without per-package
+	// translation rules. There is intentionally no dedicated typed
+	// field for those values — the typed slot is reserved for fields
+	// the engine contract itself depends on (currently ParentRunID
+	// for loop detection, ResumeFrom for recovery).
 	Attributes map[string]string
 
 	// Deps is the typed dependency container the host has populated

--- a/sdk/event/bus.go
+++ b/sdk/event/bus.go
@@ -68,6 +68,7 @@ type subOptions struct {
 	bufferSize   int
 	backpressure BackpressurePolicy
 	predicate    func(Envelope) bool
+	sampleRate   float64
 }
 
 // WithBufferSize sets the buffered channel capacity. Values <= 0 fall back
@@ -90,6 +91,56 @@ func WithBackpressure(p BackpressurePolicy) SubOption {
 // (e.g. multi-tenant header checks).
 func WithPredicate(fn func(Envelope) bool) SubOption {
 	return func(o *subOptions) { o.predicate = fn }
+}
+
+// WithSampleRate configures the per-envelope keep probability when the
+// subscription uses BackpressurePolicy Sample. Values are clamped to
+// [0.0, 1.0]; values <= 0 reject every envelope (DropReasonSampled),
+// values >= 1 pass every envelope through to the buffer-full check.
+//
+// Has no effect on subscriptions whose policy is not Sample, so it is
+// safe to set unconditionally on a shared option set.
+func WithSampleRate(rate float64) SubOption {
+	return func(o *subOptions) {
+		switch {
+		case rate <= 0:
+			o.sampleRate = 0
+		case rate >= 1:
+			o.sampleRate = 1
+		default:
+			o.sampleRate = rate
+		}
+	}
+}
+
+// AckSubscription is the optional capability a Subscription may expose
+// when its parent Bus implements at-least-once delivery (typically
+// cross-process buses backed by NATS / Redis Streams / Kafka). In-process
+// implementations such as MemoryBus do not implement this interface;
+// consumers should type-assert and treat the absence as "auto-ack".
+//
+// Semantics (v1, intentionally minimal):
+//
+//   - Ack confirms successful processing of the envelope identified by
+//     envelopeID. Implementations MUST tolerate duplicate Ack calls and
+//     return nil on the second invocation.
+//   - Ack on an unknown envelopeID returns nil (defensive — replays and
+//     restarts can legitimately surface envelopes outside the current
+//     subscription's tracked window).
+//   - Negative-acknowledge / explicit redelivery is intentionally NOT
+//     part of v1. Implementations that need it should expose an
+//     additional, named interface (e.g. NackSubscription) so callers can
+//     opt in without breaking the minimal contract.
+//
+// Bus implementations without persistent delivery (MemoryBus,
+// NoopBus) MUST NOT implement this interface; their consumers therefore
+// take the auto-ack branch automatically.
+type AckSubscription interface {
+	Subscription
+
+	// Ack acknowledges that envelopeID has been successfully processed.
+	// See the AckSubscription doc comment for the per-call contract.
+	Ack(envelopeID string) error
 }
 
 // NoopBus is a Bus that discards every Publish and yields a closed channel

--- a/sdk/event/envelope.go
+++ b/sdk/event/envelope.go
@@ -42,6 +42,15 @@ const (
 	HeaderActorID = "actor_id"
 	HeaderGraphID = "graph_id"
 	HeaderTenant  = "tenant"
+
+	// HeaderKanbanScopeID identifies the sdk/kanban Board scope
+	// (Board.ScopeID) that produced an envelope. Distinct from
+	// HeaderRunID — kanban events do not happen inside an engine run
+	// — so consumers that want to fan-in by board need a dedicated
+	// dimension. Stored as a typed header (mirroring HeaderRunID /
+	// HeaderGraphID) rather than crammed into Envelope.Source so it
+	// composes with the existing well-known-header convention.
+	HeaderKanbanScopeID = "kanban_scope_id"
 )
 
 // NewEnvelope constructs an Envelope with ID and Time populated.
@@ -164,3 +173,10 @@ func (e *Envelope) SetTenant(id string) { e.SetHeader(HeaderTenant, id) }
 
 // Tenant returns the value of the well-known tenant header.
 func (e Envelope) Tenant() string { return e.Header(HeaderTenant) }
+
+// SetKanbanScopeID is a typed shorthand for
+// SetHeader(HeaderKanbanScopeID, id).
+func (e *Envelope) SetKanbanScopeID(id string) { e.SetHeader(HeaderKanbanScopeID, id) }
+
+// KanbanScopeID returns the value of the well-known kanban_scope_id header.
+func (e Envelope) KanbanScopeID() string { return e.Header(HeaderKanbanScopeID) }

--- a/sdk/event/envelope_test.go
+++ b/sdk/event/envelope_test.go
@@ -74,13 +74,21 @@ func TestEnvelope_HeadersHelpers(t *testing.T) {
 	env.SetActorID("a1")
 	env.SetGraphID("g1")
 	env.SetTenant("t1")
+	env.SetKanbanScopeID("k1")
 
-	if env.RunID() != "r1" || env.NodeID() != "n1" || env.ActorID() != "a1" || env.GraphID() != "g1" || env.Tenant() != "t1" {
+	if env.RunID() != "r1" || env.NodeID() != "n1" || env.ActorID() != "a1" || env.GraphID() != "g1" || env.Tenant() != "t1" || env.KanbanScopeID() != "k1" {
 		t.Fatalf("typed accessors disagree: %+v", env.Headers)
+	}
+	// The KanbanScopeID accessor must read from the documented header
+	// key so external consumers (e.g. cross-process bus adapters) that
+	// inspect the raw header map see the same value the typed accessor
+	// returns.
+	if got := env.Header(HeaderKanbanScopeID); got != "k1" {
+		t.Fatalf("Header[%s] = %q, want k1", HeaderKanbanScopeID, got)
 	}
 	// Zero envelope returns "" without panic.
 	var zero Envelope
-	if zero.RunID() != "" || zero.NodeID() != "" {
+	if zero.RunID() != "" || zero.NodeID() != "" || zero.KanbanScopeID() != "" {
 		t.Fatal("zero envelope should return empty strings")
 	}
 }

--- a/sdk/event/memory.go
+++ b/sdk/event/memory.go
@@ -3,6 +3,7 @@ package event
 import (
 	"context"
 	"fmt"
+	"math/rand/v2"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -172,6 +173,7 @@ type memSub struct {
 	patternSegs  []string // pre-split pattern; never mutated after Subscribe.
 	predicate    func(Envelope) bool
 	backpressure BackpressurePolicy
+	sampleRate   float64
 	ch           chan Envelope
 	done         chan struct{}
 	bus          *MemoryBus
@@ -398,6 +400,27 @@ func (b *MemoryBus) Publish(ctx context.Context, env Envelope) error {
 				}
 			}
 
+		case Sample:
+			// Sampling decision happens BEFORE the buffer-full check so
+			// the keep ratio is independent of subscriber speed: a fast
+			// consumer and a slow one both see ~rate fraction of events.
+			// Rate is clamped at construction time (WithSampleRate), so
+			// rate==1 short-circuits to a plain non-blocking send and
+			// rate==0 drops every envelope.
+			keep := sub.sampleRate >= 1 || (sub.sampleRate > 0 && rand.Float64() < sub.sampleRate)
+			if !keep {
+				b.dropped.Add(1)
+				drops = append(drops, dropCb{sub.id, DropReasonSampled})
+				continue
+			}
+			select {
+			case sub.ch <- env:
+				delivers = append(delivers, deliverCb{sub.id})
+			default:
+				b.dropped.Add(1)
+				drops = append(drops, dropCb{sub.id, DropReasonBufferFull})
+			}
+
 		default: // DropNewest
 			select {
 			case sub.ch <- env:
@@ -438,6 +461,7 @@ func (b *MemoryBus) Subscribe(ctx context.Context, pattern Pattern, opts ...SubO
 	o := subOptions{
 		bufferSize:   defaultMemoryBufferSize,
 		backpressure: DropNewest,
+		sampleRate:   1.0,
 	}
 	for _, fn := range opts {
 		fn(&o)
@@ -461,6 +485,7 @@ func (b *MemoryBus) Subscribe(ctx context.Context, pattern Pattern, opts ...SubO
 		patternSegs:  splitSubject(string(pattern)),
 		predicate:    o.predicate,
 		backpressure: o.backpressure,
+		sampleRate:   o.sampleRate,
 		ch:           make(chan Envelope, o.bufferSize),
 		done:         make(chan struct{}),
 		bus:          b,

--- a/sdk/event/memory_test.go
+++ b/sdk/event/memory_test.go
@@ -484,3 +484,197 @@ func drain(t *testing.T, ch <-chan Envelope, n int, timeout time.Duration) []Env
 	}
 	return out
 }
+
+// countingObserver counts OnDeliver / OnDrop per reason. Safe for
+// concurrent use because every counter is an atomic.
+type countingObserver struct {
+	delivered atomic.Int64
+	dropFull  atomic.Int64
+	dropClose atomic.Int64
+	dropSampl atomic.Int64
+}
+
+func (o *countingObserver) OnPublish(Envelope) {}
+func (o *countingObserver) OnDeliver(SubscriptionID, Envelope) {
+	o.delivered.Add(1)
+}
+func (o *countingObserver) OnDrop(_ SubscriptionID, _ Envelope, r DropReason) {
+	switch r {
+	case DropReasonBufferFull:
+		o.dropFull.Add(1)
+	case DropReasonClosed:
+		o.dropClose.Add(1)
+	case DropReasonSampled:
+		o.dropSampl.Add(1)
+	}
+}
+
+func TestWithSampleRate_ClampsToValidRange(t *testing.T) {
+	cases := []struct {
+		name string
+		in   float64
+		want float64
+	}{
+		{"negative clamps to zero", -0.5, 0},
+		{"zero stays zero", 0, 0},
+		{"mid passes through", 0.3, 0.3},
+		{"one stays one", 1, 1},
+		{"above one clamps to one", 2.5, 1},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var o subOptions
+			WithSampleRate(tc.in)(&o)
+			if o.sampleRate != tc.want {
+				t.Fatalf("sampleRate = %v, want %v", o.sampleRate, tc.want)
+			}
+		})
+	}
+}
+
+func TestMemoryBus_BackpressureSample_RateZeroDropsEverything(t *testing.T) {
+	obs := &countingObserver{}
+	bus := NewMemoryBus(WithObserver(obs))
+	t.Cleanup(func() { _ = bus.Close() })
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	if _, err := bus.Subscribe(ctx, "drop.>",
+		WithBackpressure(Sample),
+		WithSampleRate(0),
+	); err != nil {
+		t.Fatalf("Subscribe: %v", err)
+	}
+
+	for i := 0; i < 50; i++ {
+		if err := bus.Publish(ctx, mustEnv(t, "drop.zero", nil)); err != nil {
+			t.Fatalf("Publish: %v", err)
+		}
+	}
+
+	if obs.delivered.Load() != 0 {
+		t.Errorf("delivered = %d, want 0", obs.delivered.Load())
+	}
+	if obs.dropSampl.Load() != 50 {
+		t.Errorf("dropped(sampled) = %d, want 50", obs.dropSampl.Load())
+	}
+	if obs.dropFull.Load() != 0 {
+		t.Errorf("dropped(buffer_full) = %d, want 0 (sampling decision must precede buffer check)", obs.dropFull.Load())
+	}
+}
+
+func TestMemoryBus_BackpressureSample_RateOneDeliversEverything(t *testing.T) {
+	obs := &countingObserver{}
+	bus := NewMemoryBus(WithObserver(obs))
+	t.Cleanup(func() { _ = bus.Close() })
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	sub, err := bus.Subscribe(ctx, "pass.>",
+		WithBackpressure(Sample),
+		WithSampleRate(1.0),
+		WithBufferSize(128),
+	)
+	if err != nil {
+		t.Fatalf("Subscribe: %v", err)
+	}
+
+	const n = 50
+	for i := 0; i < n; i++ {
+		if err := bus.Publish(ctx, mustEnv(t, "pass.evt", nil)); err != nil {
+			t.Fatalf("Publish: %v", err)
+		}
+	}
+
+	deadline := time.After(time.Second)
+	got := 0
+	for got < n {
+		select {
+		case _, ok := <-sub.C():
+			if !ok {
+				t.Fatalf("subscription channel closed early at %d/%d", got, n)
+			}
+			got++
+		case <-deadline:
+			t.Fatalf("only received %d/%d before deadline", got, n)
+		}
+	}
+	if obs.dropSampl.Load() != 0 {
+		t.Errorf("dropped(sampled) = %d, want 0 with rate=1.0", obs.dropSampl.Load())
+	}
+}
+
+func TestMemoryBus_BackpressureSample_PartialRateDeliversWithinBand(t *testing.T) {
+	// Keep the test deterministic by checking only a wide statistical
+	// band (rate 0.5 over 2000 publishes ⇒ expect 1000 ± 200 with very
+	// high confidence). A tighter band would be flaky on slow CI.
+	obs := &countingObserver{}
+	bus := NewMemoryBus(WithObserver(obs))
+	t.Cleanup(func() { _ = bus.Close() })
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	sub, err := bus.Subscribe(ctx, "half.>",
+		WithBackpressure(Sample),
+		WithSampleRate(0.5),
+		WithBufferSize(4096),
+	)
+	if err != nil {
+		t.Fatalf("Subscribe: %v", err)
+	}
+
+	const n = 2000
+	for i := 0; i < n; i++ {
+		if err := bus.Publish(ctx, mustEnv(t, "half.evt", nil)); err != nil {
+			t.Fatalf("Publish: %v", err)
+		}
+	}
+
+	// Drain whatever is buffered without blocking forever.
+	delivered := 0
+drain:
+	for {
+		select {
+		case _, ok := <-sub.C():
+			if !ok {
+				break drain
+			}
+			delivered++
+		case <-time.After(50 * time.Millisecond):
+			break drain
+		}
+	}
+
+	dropped := int(obs.dropSampl.Load())
+	if delivered+dropped != n {
+		t.Fatalf("delivered+sampled-dropped = %d+%d = %d, want %d",
+			delivered, dropped, delivered+dropped, n)
+	}
+	if delivered < 800 || delivered > 1200 {
+		t.Errorf("delivered = %d, expected ~1000 (band 800..1200) with rate=0.5", delivered)
+	}
+}
+
+func TestMemoryBus_AckSubscription_NotImplemented(t *testing.T) {
+	// MemoryBus subscriptions intentionally do not implement
+	// AckSubscription — auto-ack is the documented in-process behaviour.
+	// This test pins that contract so a future change cannot silently
+	// promote the subscription type and surprise consumers that branch
+	// on the type assertion.
+	bus := NewMemoryBus()
+	t.Cleanup(func() { _ = bus.Close() })
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	sub, err := bus.Subscribe(ctx, "noack.>")
+	if err != nil {
+		t.Fatalf("Subscribe: %v", err)
+	}
+	if _, ok := sub.(AckSubscription); ok {
+		t.Fatal("MemoryBus subscription unexpectedly implements AckSubscription")
+	}
+}

--- a/sdk/event/observer.go
+++ b/sdk/event/observer.go
@@ -22,6 +22,24 @@ const (
 	// publishing context is cancelled. Use sparingly: a slow subscriber
 	// will back-pressure every publisher.
 	Block
+
+	// Sample probabilistically forwards each envelope according to the
+	// per-subscription rate set with WithSampleRate (default 1.0 =
+	// pass-through). Envelopes that pass the sampling gate are then
+	// enqueued non-blockingly; if the buffer is full at that point the
+	// envelope is dropped with reason DropReasonBufferFull. Envelopes
+	// rejected by the sampling gate itself are dropped with reason
+	// DropReasonSampled.
+	//
+	// Use this for high-volume streams (token deltas, voice frames,
+	// progress beacons) where exact delivery is unnecessary and the
+	// alternatives have undesirable side effects: DropNewest /
+	// DropOldest only kick in once the buffer fills (so a fast
+	// subscriber sees every event and a slow one loses bursts at
+	// random), while Block back-pressures the producer. Sample yields
+	// a bounded, predictable delivery ratio independent of subscriber
+	// speed.
+	Sample
 )
 
 // String returns a stable label for diagnostics.
@@ -33,6 +51,8 @@ func (p BackpressurePolicy) String() string {
 		return "drop_oldest"
 	case Block:
 		return "block"
+	case Sample:
+		return "sample"
 	default:
 		return "unknown"
 	}
@@ -50,6 +70,13 @@ const (
 	// DropReasonClosed indicates Publish raced with subscription close;
 	// the envelope was not delivered.
 	DropReasonClosed
+
+	// DropReasonSampled indicates the subscription's Sample
+	// backpressure policy probabilistically rejected this envelope.
+	// Distinct from DropReasonBufferFull so dashboards can
+	// differentiate "we voluntarily threw it away" from "the consumer
+	// could not keep up".
+	DropReasonSampled
 )
 
 // String returns a stable label for diagnostics.
@@ -59,6 +86,8 @@ func (r DropReason) String() string {
 		return "buffer_full"
 	case DropReasonClosed:
 		return "closed"
+	case DropReasonSampled:
+		return "sampled"
 	default:
 		return "unknown"
 	}

--- a/sdk/event/observer_test.go
+++ b/sdk/event/observer_test.go
@@ -10,6 +10,7 @@ func TestBackpressurePolicy_String(t *testing.T) {
 		{DropNewest, "drop_newest"},
 		{DropOldest, "drop_oldest"},
 		{Block, "block"},
+		{Sample, "sample"},
 		{BackpressurePolicy(99), "unknown"},
 	}
 	for _, c := range cases {
@@ -26,6 +27,7 @@ func TestDropReason_String(t *testing.T) {
 	}{
 		{DropReasonBufferFull, "buffer_full"},
 		{DropReasonClosed, "closed"},
+		{DropReasonSampled, "sampled"},
 		{DropReason(99), "unknown"},
 	}
 	for _, c := range cases {
@@ -47,4 +49,5 @@ func TestNoopObserver_Methods(t *testing.T) {
 	o.OnDeliver("sub-id", env)
 	o.OnDrop("sub-id", env, DropReasonBufferFull)
 	o.OnDrop("sub-id", env, DropReasonClosed)
+	o.OnDrop("sub-id", env, DropReasonSampled)
 }

--- a/sdk/event/subject.go
+++ b/sdk/event/subject.go
@@ -140,6 +140,28 @@ func splitSubject(s string) []string {
 	return strings.Split(s, subjectSep)
 }
 
+// ProducerKind returns the leading segment of subj — by SDK convention
+// this identifies the producer ("engine", "kanban", and future "pod" /
+// "agent" / "history"). Returns "" when subj is empty or has no
+// separator.
+//
+// This is the canonical way to discriminate producer kind in a
+// fan-out subscription that matches multiple producers (e.g. ">"). It
+// avoids inventing a parallel naming system on Envelope.Source: the
+// Subject already encodes the producer, and pattern matching
+// (`engine.>` / `kanban.>`) already does the corresponding subscribe-
+// time filter without any helper.
+func ProducerKind(subj Subject) string {
+	s := string(subj)
+	if s == "" {
+		return ""
+	}
+	if i := strings.IndexByte(s, '.'); i > 0 {
+		return s[:i]
+	}
+	return ""
+}
+
 // matchSegs is the segment-level matcher shared by Pattern.Matches and the
 // MemoryBus hot path. Both inputs are non-empty.
 //

--- a/sdk/event/subject_test.go
+++ b/sdk/event/subject_test.go
@@ -107,3 +107,25 @@ func TestPattern_Matches(t *testing.T) {
 		})
 	}
 }
+
+func TestProducerKind(t *testing.T) {
+	cases := []struct {
+		name string
+		in   Subject
+		want string
+	}{
+		{"engine run", "engine.run.r1.start", "engine"},
+		{"engine stream", "engine.run.r1.stream.s1.delta", "engine"},
+		{"kanban card", "kanban.card.c1.task.submitted", "kanban"},
+		{"kanban cron", "kanban.cron.s1.fired", "kanban"},
+		{"single segment has no producer", "standalone", ""},
+		{"empty subject", "", ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := ProducerKind(tc.in); got != tc.want {
+				t.Fatalf("ProducerKind(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}

--- a/sdk/graph/node/llmnode/host_test.go
+++ b/sdk/graph/node/llmnode/host_test.go
@@ -20,10 +20,11 @@ type usageRecorderHost struct {
 	deltas []model.TokenUsage
 }
 
-func (h *usageRecorderHost) ReportUsage(_ context.Context, u model.TokenUsage) {
+func (h *usageRecorderHost) ReportUsage(_ context.Context, u model.TokenUsage) error {
 	h.mu.Lock()
 	h.deltas = append(h.deltas, u)
 	h.mu.Unlock()
+	return nil
 }
 
 // TestNode_ReportsDeltaUsageToHost guarantees the contract documented

--- a/sdk/graph/node/llmnode/llmnode.go
+++ b/sdk/graph/node/llmnode/llmnode.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 
 	"github.com/GizClaw/flowcraft/sdk/engine"
+	"github.com/GizClaw/flowcraft/sdk/errdefs"
 	"github.com/GizClaw/flowcraft/sdk/graph"
 	"github.com/GizClaw/flowcraft/sdk/llm"
 	"github.com/GizClaw/flowcraft/sdk/model"
@@ -128,7 +129,14 @@ func (n *Node) ExecuteBoard(ctx graph.ExecutionContext, board *graph.Board) erro
 	// what materialises the partial assistant message + cancelled
 	// tool_results onto the board so the agent layer / memory writer
 	// can read them after the resume / discard decision.
-	n.writeResults(ctx, board, cfg, result, messagesKey, chName)
+	if werr := n.writeResults(ctx, board, cfg, result, messagesKey, chName); werr != nil {
+		// writeResults only ever surfaces errors from the host's
+		// budget / quota gate (UsageReporter). Propagate so the
+		// run terminates rather than silently exceeding the budget,
+		// but only after the partial state has been written above.
+		span.RecordError(werr)
+		return werr
+	}
 
 	span.SetAttributes(
 		attribute.Int64("llm.input_tokens", result.Usage.InputTokens),
@@ -209,7 +217,7 @@ func (n *Node) buildMessages(cfg Config, board *graph.Board, chName, messagesKey
 func (n *Node) writeResults(
 	ctx graph.ExecutionContext, board *graph.Board, cfg Config,
 	result *roundResult, messagesKey, chName string,
-) {
+) error {
 	if cfg.TrackSteps {
 		steps, _ := board.GetVar("agent_steps")
 		stepList, _ := steps.([]map[string]any)
@@ -273,11 +281,25 @@ func (n *Node) writeResults(
 	// call adds delta usage" so we hand off result.Usage, NOT the
 	// accumulated total. Interrupt path also flows through here so
 	// partial usage is still attributed.
+	//
+	// An error from ReportUsage is only meaningful when it carries
+	// the BudgetExceeded classification (sandbox / pod budget); per
+	// the engine.UsageReporter contract any other error is
+	// observability-only and SHOULD be swallowed so a flaky exporter
+	// cannot kill the run.
 	if ctx.Host != nil && (result.Usage.InputTokens > 0 ||
 		result.Usage.OutputTokens > 0 ||
 		result.Usage.TotalTokens > 0) {
-		ctx.Host.ReportUsage(ctx.Context, result.Usage)
+		if err := ctx.Host.ReportUsage(ctx.Context, result.Usage); err != nil {
+			if errdefs.IsBudgetExceeded(err) {
+				return err
+			}
+			telemetry.Warn(ctx.Context, "llm: ReportUsage returned a non-budget error; ignoring",
+				otellog.String(telemetry.AttrNodeID, n.id),
+				otellog.String(telemetry.AttrErrorMessage, err.Error()))
+		}
 	}
+	return nil
 }
 
 func truncate(s string, n int) string {

--- a/sdk/graph/runner/internal/executor/subjects.go
+++ b/sdk/graph/runner/internal/executor/subjects.go
@@ -85,6 +85,10 @@ func publishGraphEvent(ctx context.Context, pub engine.Publisher, subject event.
 	if actorKey != "" {
 		env.SetActorID(actorKey)
 	}
+	// Producer kind ("engine") is encoded in the leading Subject
+	// segment by SubjectPrefix; the run id is also carried via
+	// HeaderRunID. No separate Envelope.Source is needed — see
+	// event.ProducerKind.
 	_ = pub.Publish(ctx, env)
 }
 

--- a/sdk/kanban/events.go
+++ b/sdk/kanban/events.go
@@ -190,8 +190,14 @@ func publishCardEvent(ctx context.Context, bus event.Bus, kind, cardID, scopeID 
 	if cardID != "" {
 		env.SetHeader(HeaderCardID, cardID)
 	}
+	// scopeID identifies the producing Board; carry it on the
+	// well-known event.HeaderKanbanScopeID dimension (consistent with
+	// HeaderRunID / HeaderGraphID) so cross-module consumers can
+	// fan-in by board without inventing a parallel naming scheme on
+	// Envelope.Source. Producer kind ("kanban") is already encoded as
+	// the leading Subject segment — see event.ProducerKind.
 	if scopeID != "" {
-		env.Source = scopeID
+		env.SetKanbanScopeID(scopeID)
 	}
 	_ = bus.Publish(ctx, env)
 }
@@ -211,7 +217,7 @@ func publishCronEvent(ctx context.Context, bus event.Bus, kind, scheduleID, scop
 		env.SetHeader(HeaderScheduleID, scheduleID)
 	}
 	if scopeID != "" {
-		env.Source = scopeID
+		env.SetKanbanScopeID(scopeID)
 	}
 	_ = bus.Publish(ctx, env)
 }

--- a/sdk/kanban/events_test.go
+++ b/sdk/kanban/events_test.go
@@ -145,8 +145,8 @@ func TestBus_SubjectAndHeadersForTaskSubmitted(t *testing.T) {
 		if got := e.Header(HeaderKanbanKind); got != EventTaskSubmitted {
 			t.Errorf("Header[kanban_kind] = %q, want %q", got, EventTaskSubmitted)
 		}
-		if e.Source != sb.ScopeID() {
-			t.Errorf("Source = %q, want %q", e.Source, sb.ScopeID())
+		if got := e.KanbanScopeID(); got != sb.ScopeID() {
+			t.Errorf("Header[kanban_scope_id] = %q, want %q", got, sb.ScopeID())
 		}
 		return
 	}

--- a/sdk/model/message.go
+++ b/sdk/model/message.go
@@ -237,18 +237,59 @@ type Usage struct {
 }
 
 // TokenUsage tracks cumulative token consumption (includes TotalTokens).
+//
+// The Model / LatencyMs / CostMicros fields enrich the basic token
+// counts so a sandbox host (typically the planned sdk/pod controller)
+// can enforce dollar-denominated budgets and per-model rate limits
+// without a separate sidecar accumulator. All three are optional: a
+// reporter that only knows token counts leaves them zero / empty.
 type TokenUsage struct {
 	InputTokens  int64 `json:"input_tokens"`
 	OutputTokens int64 `json:"output_tokens"`
 	TotalTokens  int64 `json:"total_tokens"`
+
+	// Model is the resolved LLM model name this usage came from
+	// (e.g. "gpt-4o", "claude-3-7-sonnet-20250219"). Empty when the
+	// reporter does not know which model produced the call (test
+	// engines, aggregate reports). Hosts that bucket usage by model
+	// for budgeting / quota enforcement consume this field.
+	Model string `json:"model,omitempty"`
+
+	// LatencyMs is the wall-clock latency of the producing call in
+	// milliseconds. Zero when not measured. Used by sandbox hosts to
+	// surface per-call timing on the same dimension as token counts
+	// (avoids a parallel timing channel).
+	LatencyMs int64 `json:"latency_ms,omitempty"`
+
+	// CostMicros is the cost of the producing call in micro-units of
+	// the host's configured currency (micro-USD = USD * 1_000_000).
+	// Integer math is used so cumulative budgets do not drift.
+	// Zero when no pricing catalog is configured. Hosts enforcing $
+	// budgets accumulate this field.
+	CostMicros int64 `json:"cost_micros,omitempty"`
 }
 
 // Add returns a new TokenUsage that is the sum of u and other.
+//
+// Numeric fields (token counts, latency, cost) are summed. Model is
+// preserved from u when both are non-empty and disagree (the
+// accumulator's identity wins); when one side is empty the other
+// fills it in. Adding a per-call delta into a running total therefore
+// keeps the running total's model label intact even if the delta
+// reports a different model — callers that need per-model breakdowns
+// SHOULD bucket by Model before summing.
 func (u TokenUsage) Add(other TokenUsage) TokenUsage {
+	model := u.Model
+	if model == "" {
+		model = other.Model
+	}
 	return TokenUsage{
 		InputTokens:  u.InputTokens + other.InputTokens,
 		OutputTokens: u.OutputTokens + other.OutputTokens,
 		TotalTokens:  u.TotalTokens + other.TotalTokens,
+		Model:        model,
+		LatencyMs:    u.LatencyMs + other.LatencyMs,
+		CostMicros:   u.CostMicros + other.CostMicros,
 	}
 }
 

--- a/sdk/model/message_test.go
+++ b/sdk/model/message_test.go
@@ -126,6 +126,29 @@ func TestTokenUsage_Add(t *testing.T) {
 	}
 }
 
+func TestTokenUsage_Add_Enriched(t *testing.T) {
+	t.Run("sums latency and cost; preserves model label from accumulator", func(t *testing.T) {
+		acc := TokenUsage{InputTokens: 10, Model: "gpt-4o", LatencyMs: 100, CostMicros: 250}
+		delta := TokenUsage{OutputTokens: 5, Model: "claude", LatencyMs: 30, CostMicros: 80}
+		sum := acc.Add(delta)
+		if sum.Model != "gpt-4o" {
+			t.Errorf("Model = %q, want gpt-4o (accumulator wins on conflict)", sum.Model)
+		}
+		if sum.LatencyMs != 130 || sum.CostMicros != 330 {
+			t.Errorf("Latency=%d Cost=%d, want 130 / 330", sum.LatencyMs, sum.CostMicros)
+		}
+	})
+
+	t.Run("empty accumulator inherits delta's model", func(t *testing.T) {
+		acc := TokenUsage{}
+		delta := TokenUsage{Model: "claude", CostMicros: 80}
+		sum := acc.Add(delta)
+		if sum.Model != "claude" || sum.CostMicros != 80 {
+			t.Errorf("got %+v, want Model=claude Cost=80", sum)
+		}
+	})
+}
+
 func TestMessage_NoToolCalls(t *testing.T) {
 	msg := NewTextMessage(RoleAssistant, "just text")
 	if msg.HasToolCalls() {

--- a/sdk/script/bindings/bridge_host.go
+++ b/sdk/script/bindings/bridge_host.go
@@ -86,7 +86,12 @@ func NewHostBridge(host engine.Host, source string) BindingFunc {
 			"publish": func(subject string, payload any) error {
 				env, err := event.NewEnvelope(callCtx, event.Subject(subject), payload)
 				if err != nil {
-					return fmt.Errorf("host.publish: %w", err)
+					// Bad subject / unmarshallable payload — this is
+					// invalid input from the script side. Classify
+					// so consumers (script runtime / pod audit log)
+					// can react with the same Validation handling
+					// they use for other malformed bridge calls.
+					return errdefs.Validationf("host.publish: %s", err.Error())
 				}
 				return host.Publish(callCtx, env)
 			},
@@ -117,9 +122,22 @@ func NewHostBridge(host engine.Host, source string) BindingFunc {
 			"reportUsage": func(raw any) error {
 				usage, err := parseUsage(raw)
 				if err != nil {
+					// parseUsage rejects malformed scripts inputs; a
+					// Validation classification lets the runtime
+					// surface a typed error rather than a generic
+					// "host.reportUsage: ..." string.
+					return errdefs.Validationf("host.reportUsage: %s", err.Error())
+				}
+				// Surface budget errors back to the script runtime
+				// so a sandboxed script aborts instead of running on
+				// past its quota; other errors are observability-only
+				// per the engine.UsageReporter contract. The %w wrap
+				// preserves any classification (e.g. BudgetExceeded)
+				// the host attached, so errdefs.IsBudgetExceeded
+				// still reports true on the returned error.
+				if err := host.ReportUsage(callCtx, usage); err != nil {
 					return fmt.Errorf("host.reportUsage: %w", err)
 				}
-				host.ReportUsage(callCtx, usage)
 				return nil
 			},
 		}

--- a/sdk/script/bindings/bridge_host_test.go
+++ b/sdk/script/bindings/bridge_host_test.go
@@ -46,8 +46,9 @@ func (h *recordingHost) Checkpoint(_ context.Context, cp engine.Checkpoint) erro
 	h.checkpts = append(h.checkpts, cp)
 	return h.checkpErr
 }
-func (h *recordingHost) ReportUsage(_ context.Context, u model.TokenUsage) {
+func (h *recordingHost) ReportUsage(_ context.Context, u model.TokenUsage) error {
 	h.usages = append(h.usages, u)
+	return nil
 }
 
 // invoke is a tiny convenience that materialises the bridge's API map


### PR DESCRIPTION
## Summary

- **Engine layer**: Adds `Capabilities` struct + `Describer` interface so engines can advertise `SupportsResume`, `EmitsUserPrompt`, `EmitsCheckpoint`, and `RequiredDepNames`. Pod/agent layer reads these to validate PodSpecs and gate behaviour at apply time.
- **HostMiddleware**: New decorator type + `ComposeHost` helper for stacking policy layers (audit → rate-limit → budget → secret-resolve) around a base `Host`. `HostFuncs` adapter makes partial decoration easy without struct embedding.
- **`MergeInterrupts`**: New helper that fans N interrupt channels into one — the shape sandbox/pod hosts need for combining user cancel, SIGTERM, budget exceeded, graceful stop, etc.
- **`UsageReporter.ReportUsage`**: Changed from `void` to `error` return. Hosts may now return `errdefs.BudgetExceeded` to signal accumulated usage has crossed a budget; engines MUST stop LLM-cost-incurring work on seeing it.
- **Event layer**: Adds `BackpressurePolicy.Sample` for probabilistic envelope delivery with `WithSampleRate` option — useful for high-volume streams (token deltas, voice frames) where exact delivery is unnecessary. Also adds `AckSubscription` interface for at-least-once delivery semantics in cross-process buses.
- **Model layer**: `TokenUsage` enriched with `Model`, `LatencyMs`, `CostMicros` fields so sandbox hosts can enforce dollar-denominated budgets without a separate sidecar.

## Test plan

- [x] `make ci` passes on all in-tree modules
- [x] New `capabilities_test.go`, `middleware_test.go`, `interrupt_test.go` cover the new helpers
- [x] Updated `host_test.go` covers the new `UsageReporter` contract

🤖 Generated with [Claude Code](https://claude.ai/code)