### PR TITLE
chore(sdkx): bump pinned sdk version to v0.2.6

### DIFF
--- a/sdkx/go.mod
+++ b/sdkx/go.mod
@@ -2,7 +2,7 @@ module github.com/GizClaw/flowcraft/sdkx
 
 go 1.25.0
 
-require github.com/GizClaw/flowcraft/sdk v0.2.4
+require github.com/GizClaw/flowcraft/sdk v0.2.6
 
 require (
 	github.com/PuerkitoBio/goquery v1.11.0

--- a/sdkx/go.sum
+++ b/sdkx/go.sum
@@ -8,8 +8,8 @@ github.com/Azure/azure-sdk-for-go/sdk/internal v1.10.0/go.mod h1:iZDifYGJTIgIIkY
 github.com/AzureAD/microsoft-authentication-library-for-go v1.2.2 h1:XHOnouVk1mxXfQidrMEnLlPk9UMeRtyBTnEFtxkV0kU=
 github.com/AzureAD/microsoft-authentication-library-for-go v1.2.2/go.mod h1:wP83P5OoQ5p6ip3ScPr0BAq0BvuPAvacpEuSzyouqAI=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
-github.com/GizClaw/flowcraft/sdk v0.2.4 h1:xUD4PFOB1maQjf5yP3wKEmcGWPhsUt97DMdF0xuThko=
-github.com/GizClaw/flowcraft/sdk v0.2.4/go.mod h1:ESQWkg/xVCc+2RIO7Lxkdp9lwW9U+u2q+lojvnRzK3Y=
+github.com/GizClaw/flowcraft/sdk v0.2.6 h1:ApKV3jsh/7YOLLugpLIw5eB0atSZFdujdmbVziJ4Qq4=
+github.com/GizClaw/flowcraft/sdk v0.2.6/go.mod h1:ESQWkg/xVCc+2RIO7Lxkdp9lwW9U+u2q+lojvnRzK3Y=
 github.com/PuerkitoBio/goquery v1.11.0 h1:jZ7pwMQXIITcUXNH83LLk+txlaEy6NVOfTuP43xxfqw=
 github.com/PuerkitoBio/goquery v1.11.0/go.mod h1:wQHgxUOU3JGuj3oD/QFfxUdlzW6xPHfqyHre6VMY4DQ=
 github.com/andybalholm/cascadia v1.3.3 h1:AG2YHrzJIm4BZ19iwJ/DAua6Btl3IwJX+VI4kktS1LM=


### PR DESCRIPTION
## Summary

Bumps `sdkx`'s pinned `sdk` dependency from `v0.2.4` → `v0.2.6` so callers building `sdkx` outside the go.work workspace (`GOWORK=off`) pick up the APIs already used by `sdkx`.

The matching SDK changes shipped via #52 (merged as `sdk/v0.2.6`):
- `ModelSpec` / `ModelDeprecation` / `RegisterParallelToolExtraKey` — required by the catalog refresh and the parallel-tool `Extra` bridging in `sdkx/llm/{openai,anthropic,bytedance,...}`.
- `sdk/tool` middleware + `sdk/script` resource caps ship in the same patch (inert from `sdkx`'s perspective).

## Why this is a separate PR

PR #52 set `[skip-tag:sdkx]` in its title so the auto-tag workflow correctly bumped `sdk` only. This PR closes that loop manually — once merged, the auto-tag workflow will tag `sdkx/v0.2.4` (next patch).

## Test plan

- [x] `cd sdkx && GOWORK=off go vet ./...`
- [x] `cd sdkx && GOWORK=off go test ./... -count=1` (all green)
- [ ] CI: confirm `Test sdkx (Go 1.25 / 1.26)` jobs pass


Made with [Cursor](https://cursor.com)