### PR TITLE
chore(sdkx/llm/deepseek): annotate legacy aliases with ModelDeprecation

### DIFF
--- a/sdkx/llm/deepseek/deepseek.go
+++ b/sdkx/llm/deepseek/deepseek.go
@@ -1,9 +1,23 @@
 package deepseek
 
 import (
+	"time"
+
 	"github.com/GizClaw/flowcraft/sdk/llm"
 	"github.com/GizClaw/flowcraft/sdkx/llm/openai"
 )
+
+// legacyAliasRetiresAt is the announced shutdown moment for the
+// `deepseek-chat` and `deepseek-reasoner` aliases per
+// https://api-docs.deepseek.com/news/news260424:
+//
+//	"deepseek-chat & deepseek-reasoner will be fully retired and
+//	 inaccessible after Jul 24th, 2026, 15:59 (UTC Time)."
+//
+// ModelDeprecation.RetiresAt documents that the HH:MM:SS portion is
+// ignored by the telemetry warning formatter, but we keep the precise
+// minute here so the source mirrors the upstream announcement.
+var legacyAliasRetiresAt = time.Date(2026, 7, 24, 15, 59, 0, 0, time.UTC)
 
 func init() {
 	llm.RegisterProvider("deepseek", func(model string, config map[string]any) (llm.LLM, error) {
@@ -88,6 +102,11 @@ func init() {
 					MaxOutputTokens:  8_000,
 				},
 			},
+			Deprecation: llm.ModelDeprecation{
+				RetiresAt:   legacyAliasRetiresAt,
+				Replacement: "deepseek/deepseek-v4-flash",
+				Notes:       "https://api-docs.deepseek.com/news/news260424 (legacy alias → v4-flash non-thinking)",
+			},
 		},
 		{
 			// Routes to deepseek-v4-flash thinking mode. Per
@@ -114,6 +133,11 @@ func init() {
 					MaxContextTokens: 1_000_000,
 					MaxOutputTokens:  64_000,
 				},
+			},
+			Deprecation: llm.ModelDeprecation{
+				RetiresAt:   legacyAliasRetiresAt,
+				Replacement: "deepseek/deepseek-v4-flash",
+				Notes:       "https://api-docs.deepseek.com/news/news260424 (legacy alias → v4-flash thinking)",
 			},
 		},
 	})


### PR DESCRIPTION
## Summary

- `sdkx/llm/deepseek` previously described the upcoming retirement of the
  `deepseek-chat` and `deepseek-reasoner` aliases only in package comments,
  so `ModelInfo.Deprecation` was empty and the resolver could not emit the
  one-shot deprecation telemetry that other providers (e.g. `openai/o4-mini`)
  already produce.
- Populate `Deprecation` on both alias entries with the official shutdown
  moment (`2026-07-24 15:59 UTC`, shared via a new package-level
  `legacyAliasRetiresAt`), the official routing target
  (`deepseek/deepseek-v4-flash`), and a link to the upstream announcement.
- Source of truth: <https://api-docs.deepseek.com/news/news260424>:
  > deepseek-chat & deepseek-reasoner will be fully retired and inaccessible
  > after Jul 24th, 2026, 15:59 (UTC Time). (Currently routing to
  > deepseek-v4-flash non-thinking/thinking).
- Pinned-minute precision mirrors the upstream announcement; the warning
  formatter ignores `HH:MM:SS` per `ModelDeprecation` docs, so behaviour
  is unchanged for downstream telemetry.

## Test plan

- [x] `cd sdkx && go vet ./llm/deepseek/...`
- [x] `cd sdkx && go build ./llm/deepseek/...`
- [ ] Resolve `deepseek/deepseek-chat` (or `deepseek-reasoner`) once in a
      sandbox process and confirm the one-shot deprecation warning is logged.

Made with [Cursor](https://cursor.com)