### PR TITLE
voice: drop workflow dependency, drive turns via agent.Run + engine.Engine [skip-tag:voice]

### DIFF
--- a/voice/go.mod
+++ b/voice/go.mod
@@ -3,7 +3,7 @@ module github.com/GizClaw/flowcraft/voice
 go 1.25.0
 
 require (
-	github.com/GizClaw/flowcraft/sdk v0.2.2
+	github.com/GizClaw/flowcraft/sdk v0.2.7
 	github.com/coder/websocket v1.8.14
 	github.com/pion/webrtc/v4 v4.2.9
 	github.com/rs/xid v1.6.0

--- a/voice/go.sum
+++ b/voice/go.sum
@@ -1,5 +1,5 @@
-github.com/GizClaw/flowcraft/sdk v0.2.2 h1:smHhb1HcOG3/xlDFDQ1uO+aYMlLvx5AAaGcPsYQDHcY=
-github.com/GizClaw/flowcraft/sdk v0.2.2/go.mod h1:ESQWkg/xVCc+2RIO7Lxkdp9lwW9U+u2q+lojvnRzK3Y=
+github.com/GizClaw/flowcraft/sdk v0.2.7 h1:J9nA8JPwR+gbDPSOVh1vas8/YT2bFvoJXd0dUGYoWiY=
+github.com/GizClaw/flowcraft/sdk v0.2.7/go.mod h1:ESQWkg/xVCc+2RIO7Lxkdp9lwW9U+u2q+lojvnRzK3Y=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/coder/websocket v1.8.14 h1:9L0p0iKiNOibykf283eHkKUHHrpG7f65OE3BhhO7v9g=

--- a/voice/pipeline.go
+++ b/voice/pipeline.go
@@ -8,8 +8,10 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/GizClaw/flowcraft/sdk/agent"
+	"github.com/GizClaw/flowcraft/sdk/engine"
+	"github.com/GizClaw/flowcraft/sdk/event"
 	"github.com/GizClaw/flowcraft/sdk/model"
-	"github.com/GizClaw/flowcraft/sdk/workflow"
 	"github.com/GizClaw/flowcraft/voice/audio"
 	"github.com/GizClaw/flowcraft/voice/provider"
 	"github.com/GizClaw/flowcraft/voice/stt"
@@ -100,13 +102,29 @@ func WithTimeouts(timeouts PipelineTimeouts) PipelineOption {
 	return func(p *Pipeline) { p.timeouts = timeouts }
 }
 
-// Pipeline orchestrates STT → Runtime.Run → TTS into a stream of
+// Pipeline orchestrates STT → agent.Run → TTS into a stream of
 // voice events using a linear pipeline architecture.
+//
+// Execution is delegated to an [engine.Engine] driven by [agent.Run].
+// The pipeline owns its own internal [engine.Host] so it can capture
+// the engine's stream-delta envelopes (assistant tokens, tool calls,
+// tool results) and turn them into voice events. Callers that want
+// their own host capabilities (event bus fan-out, OTel, checkpointing,
+// interrupts, …) can layer one in via [WithEngineHost]; the pipeline
+// will fan every envelope to both sinks.
+//
+// History loading and conversation memory are NOT a pipeline concern.
+// Callers who need them register an [agent.BoardSeeder] /
+// [agent.Observer] via [WithRunOptions]; the pipeline forwards those
+// options unchanged to [agent.Run].
 type Pipeline struct {
-	stt   stt.STT
-	tts   tts.TTS
-	rt    workflow.Runtime
-	agent workflow.Agent
+	stt stt.STT
+	tts tts.TTS
+	eng engine.Engine
+	ag  agent.Agent
+
+	externalHost engine.Host
+	extraRunOpts []agent.RunOption
 
 	turnMu     sync.Mutex
 	turnCancel context.CancelFunc
@@ -117,8 +135,6 @@ type Pipeline struct {
 
 	dynamicTTSOpts []func() []tts.TTSOption
 	timeouts       PipelineTimeouts
-	history        []model.Message
-	contextID      string
 	skipWarmup     bool
 }
 
@@ -142,20 +158,32 @@ func (p *Pipeline) currentTTSOpts() []tts.TTSOption {
 	return merged
 }
 
-// WithTurnHistory sets message history for the current turn.
-// Only effective when the Runtime has no MemoryFactory configured;
-// when a MemoryFactory is present, use WithContextID instead.
-func WithTurnHistory(msgs []model.Message) PipelineOption {
-	return func(p *Pipeline) {
-		p.history = append([]model.Message(nil), msgs...)
-	}
+// WithEngineHost installs an [engine.Host] that the pipeline will
+// fan engine envelopes to in addition to its internal sink.
+//
+// The internal sink (which captures stream-delta envelopes to drive
+// TTS) is always present and cannot be removed. The external host
+// receives a copy of every envelope the engine publishes — including
+// stream deltas — so callers can wire OTel exporters, an event.Bus,
+// kanban dashboards, etc. without affecting voice output.
+//
+// The external host's Interrupter / UserPrompter / Checkpointer /
+// UsageReporter methods are also surfaced to the engine (the internal
+// host falls back to [engine.NoopHost] for those).
+func WithEngineHost(h engine.Host) PipelineOption {
+	return func(p *Pipeline) { p.externalHost = h }
 }
 
-// WithContextID sets the memory context identifier passed to Runtime.Run.
-// When the Runtime is configured with a MemoryFactory, this enables
-// automatic history load/save across turns.
-func WithContextID(id string) PipelineOption {
-	return func(p *Pipeline) { p.contextID = id }
+// WithRunOptions appends [agent.RunOption] values that are forwarded
+// unchanged to every [agent.Run] invocation the pipeline makes. Use
+// this to install a [agent.BoardSeeder] (for history / RAG injection),
+// observers, deciders, dependencies, or extra attributes.
+//
+// The internal host installed for stream capture is appended AFTER
+// these options, so a caller-supplied host via this option would be
+// overridden — use [WithEngineHost] for hosts.
+func WithRunOptions(opts ...agent.RunOption) PipelineOption {
+	return func(p *Pipeline) { p.extraRunOpts = append(p.extraRunOpts, opts...) }
 }
 
 func (p *Pipeline) clone() *Pipeline {
@@ -163,22 +191,22 @@ func (p *Pipeline) clone() *Pipeline {
 		return nil
 	}
 	cp := Pipeline{
-		stt:        p.stt,
-		tts:        p.tts,
-		rt:         p.rt,
-		agent:      p.agent,
-		timeouts:   p.timeouts,
-		contextID:  p.contextID,
-		skipWarmup: p.skipWarmup,
-		segOpts:    append([]tts.SegmenterOption(nil), p.segOpts...),
-		sttOpts:    append([]stt.STTOption(nil), p.sttOpts...),
-		ttsOpts:    append([]tts.TTSOption(nil), p.ttsOpts...),
+		stt:          p.stt,
+		tts:          p.tts,
+		eng:          p.eng,
+		ag:           p.ag,
+		externalHost: p.externalHost,
+		timeouts:     p.timeouts,
+		skipWarmup:   p.skipWarmup,
+		segOpts:      append([]tts.SegmenterOption(nil), p.segOpts...),
+		sttOpts:      append([]stt.STTOption(nil), p.sttOpts...),
+		ttsOpts:      append([]tts.TTSOption(nil), p.ttsOpts...),
 	}
 	if len(p.dynamicTTSOpts) > 0 {
 		cp.dynamicTTSOpts = append([]func() []tts.TTSOption(nil), p.dynamicTTSOpts...)
 	}
-	if len(p.history) > 0 {
-		cp.history = append([]model.Message(nil), p.history...)
+	if len(p.extraRunOpts) > 0 {
+		cp.extraRunOpts = append([]agent.RunOption(nil), p.extraRunOpts...)
 	}
 	return &cp
 }
@@ -191,9 +219,17 @@ func (p *Pipeline) addDynamicTTSOptionsProvider(fn func() []tts.TTSOption) {
 }
 
 // NewPipeline creates a new voice pipeline.
-// The stt parameter may be nil if only text input (RunText) is used.
-func NewPipeline(s stt.STT, t tts.TTS, rt workflow.Runtime, agent workflow.Agent, opts ...PipelineOption) *Pipeline {
-	p := &Pipeline{stt: s, tts: t, rt: rt, agent: agent}
+//
+// stt may be nil when only text input (RunText) is used. eng + ag are
+// the execution stack: the pipeline calls [agent.Run] with them on
+// every turn. Pass an [engine.Engine] from sdk/graph/runner (or any
+// custom one) and an [agent.Agent] describing identity / tools /
+// agent-level observers.
+//
+// History loading and conversation memory are not handled here — wire
+// them through [WithRunOptions] (typically a [agent.BoardSeeder]).
+func NewPipeline(s stt.STT, t tts.TTS, eng engine.Engine, ag agent.Agent, opts ...PipelineOption) *Pipeline {
+	p := &Pipeline{stt: s, tts: t, eng: eng, ag: ag}
 	for _, o := range opts {
 		o(p)
 	}
@@ -568,7 +604,7 @@ func (p *Pipeline) startFlow(ctx context.Context, transcript string) *flowRun {
 	sentences := make(chan string, 32)
 	done := make(chan struct{})
 
-	eventCh := make(chan workflow.StreamEvent, 256)
+	eventCh := make(chan engine.StreamDeltaPayload, 256)
 	runCtx, runCancel := context.WithCancel(ctx)
 
 	p.turnMu.Lock()
@@ -577,31 +613,35 @@ func (p *Pipeline) startFlow(ctx context.Context, transcript string) *flowRun {
 
 	var runErr error
 
+	host := newVoiceHost(p.externalHost, runID, eventCh, &overflow)
+
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
 		defer close(eventCh)
 
-		req := &workflow.Request{
-			RunID:     runID,
-			ContextID: p.contextID,
-			Message:   model.NewTextMessage(model.RoleUser, transcript),
+		req := agent.Request{
+			RunID:   runID,
+			Message: model.NewTextMessage(model.RoleUser, transcript),
 		}
-		var runOpts []workflow.RunOption
-		runOpts = append(runOpts, workflow.WithStreamCallback(func(ev workflow.StreamEvent) {
-			select {
-			case eventCh <- ev:
-			default:
-				overflow.Add(1)
-			}
-		}))
-		if len(p.history) > 0 {
-			runOpts = append(runOpts, workflow.WithHistory(p.history))
-		}
+		runOpts := make([]agent.RunOption, 0, len(p.extraRunOpts)+1)
+		runOpts = append(runOpts, p.extraRunOpts...)
+		runOpts = append(runOpts, agent.WithEngineHost(host))
 
-		_, err := p.rt.Run(runCtx, p.agent, req, runOpts...)
-		if err != nil && runCtx.Err() == nil {
+		res, err := agent.Run(runCtx, p.ag, p.eng, req, runOpts...)
+		// agent.Run returns (nil, err) only for infrastructure
+		// failures; engine-side failures land on Result.Err with a
+		// non-completed Status. Surface both back to the pipeline so
+		// the consumer goroutine can publish a EventError downstream.
+		// runCtx.Err() filters out the race where agent.Run reports
+		// the cancellation we triggered ourselves (Abort, ctx
+		// cancel) — those should not turn into user-visible errors.
+		switch {
+		case err != nil && runCtx.Err() == nil:
 			runErr = err
+		case res != nil && res.Err != nil && runCtx.Err() == nil &&
+			res.Status != agent.StatusCanceled && res.Status != agent.StatusInterrupted:
+			runErr = res.Err
 		}
 	}()
 
@@ -643,24 +683,18 @@ func (p *Pipeline) startFlow(ctx context.Context, transcript string) *flowRun {
 					return
 				}
 
-				payload, ok := ev.Payload.(map[string]any)
-				if !ok {
-					continue
-				}
-
 				switch ev.Type {
-				case "token":
-					content, _ := payload["content"].(string)
-					if content == "" {
+				case engine.StreamDeltaToken:
+					if ev.Content == "" {
 						continue
 					}
 					select {
-					case events <- withRunID(Event{Type: EventTextDelta, Text: content}, runID):
+					case events <- withRunID(Event{Type: EventTextDelta, Text: ev.Content}, runID):
 					case <-ctx.Done():
 						runCancel()
 						return
 					}
-					if sentence, segOK := seg.Feed(content); segOK && sentence != "" {
+					if sentence, segOK := seg.Feed(ev.Content); segOK && sentence != "" {
 						select {
 						case sentences <- sentence:
 						case <-ctx.Done():
@@ -668,18 +702,16 @@ func (p *Pipeline) startFlow(ctx context.Context, transcript string) *flowRun {
 							return
 						}
 					}
-				case "tool_call":
-					name, _ := payload["name"].(string)
+				case engine.StreamDeltaToolCall:
 					select {
-					case events <- withRunID(Event{Type: EventToolCall, Text: name, Data: payload}, runID):
+					case events <- withRunID(Event{Type: EventToolCall, Text: ev.Name, Data: streamDeltaToData(ev)}, runID):
 					case <-ctx.Done():
 						runCancel()
 						return
 					}
-				case "tool_result":
-					content, _ := payload["content"].(string)
+				case engine.StreamDeltaToolResult:
 					select {
-					case events <- withRunID(Event{Type: EventToolResult, Text: content, Data: payload}, runID):
+					case events <- withRunID(Event{Type: EventToolResult, Text: ev.Content, Data: streamDeltaToData(ev)}, runID):
 					case <-ctx.Done():
 						runCancel()
 						return
@@ -970,6 +1002,122 @@ func drainStream[T any](s audio.Stream[T]) {
 			return
 		}
 	}
+}
+
+// voiceHost is the [engine.Host] the pipeline installs on every
+// agent.Run call. It captures stream-delta envelopes whose subject
+// matches the active runID and forwards the decoded payload to a
+// buffered channel the pipeline consumes; everything else is either
+// dropped (when no external host is configured) or fanned out to the
+// caller-supplied host (set via [WithEngineHost]).
+//
+// Non-Publisher Host methods (Interrupts / AskUser / Checkpoint /
+// ReportUsage) delegate to the external host when present, falling
+// back to [engine.NoopHost] semantics when nil.
+type voiceHost struct {
+	external engine.Host
+	runID    string
+	events   chan<- engine.StreamDeltaPayload
+	overflow *atomic.Int64
+}
+
+func newVoiceHost(external engine.Host, runID string, events chan<- engine.StreamDeltaPayload, overflow *atomic.Int64) *voiceHost {
+	return &voiceHost{external: external, runID: runID, events: events, overflow: overflow}
+}
+
+// runIDSegment is the dot-delimited segment that "engine.run.<id>." sits
+// around in a [event.Subject]. We do a cheap string match instead of
+// re-parsing the subject because we already paid the SanitiseID cost on
+// the engine side; runID never contains '.' here.
+func (h *voiceHost) belongsToRun(s event.Subject) bool {
+	const prefix = engine.SubjectPrefix
+	str := string(s)
+	if len(str) <= len(prefix)+len(h.runID)+1 {
+		return false
+	}
+	if str[:len(prefix)] != prefix {
+		return false
+	}
+	return str[len(prefix):len(prefix)+len(h.runID)] == h.runID && str[len(prefix)+len(h.runID)] == '.'
+}
+
+func (h *voiceHost) Publish(ctx context.Context, env event.Envelope) error {
+	if h.external != nil {
+		_ = h.external.Publish(ctx, env)
+	}
+	if !engine.IsStreamDelta(env.Subject) || !h.belongsToRun(env.Subject) {
+		return nil
+	}
+	payload, err := engine.DecodeStreamDelta(env)
+	if err != nil {
+		return nil
+	}
+	select {
+	case h.events <- payload:
+	default:
+		h.overflow.Add(1)
+	}
+	return nil
+}
+
+func (h *voiceHost) Interrupts() <-chan engine.Interrupt {
+	if h.external != nil {
+		return h.external.Interrupts()
+	}
+	return nil
+}
+
+func (h *voiceHost) AskUser(ctx context.Context, prompt engine.UserPrompt) (engine.UserReply, error) {
+	if h.external != nil {
+		return h.external.AskUser(ctx, prompt)
+	}
+	return engine.NoopHost{}.AskUser(ctx, prompt)
+}
+
+func (h *voiceHost) Checkpoint(ctx context.Context, cp engine.Checkpoint) error {
+	if h.external != nil {
+		return h.external.Checkpoint(ctx, cp)
+	}
+	return nil
+}
+
+func (h *voiceHost) ReportUsage(ctx context.Context, usage model.TokenUsage) error {
+	if h.external != nil {
+		return h.external.ReportUsage(ctx, usage)
+	}
+	return nil
+}
+
+// streamDeltaToData re-projects a [engine.StreamDeltaPayload] into the
+// untyped map[string]any shape that voice [Event].Data has historically
+// carried, so downstream consumers (TUI, dashboards, tests) keep
+// working without churn. Empty fields are omitted to keep the map
+// compact.
+func streamDeltaToData(p engine.StreamDeltaPayload) map[string]any {
+	d := make(map[string]any, 6)
+	d["type"] = string(p.Type)
+	if p.Content != "" {
+		d["content"] = p.Content
+	}
+	if p.ID != "" {
+		d["id"] = p.ID
+	}
+	if p.Name != "" {
+		d["name"] = p.Name
+	}
+	if p.Arguments != nil {
+		d["arguments"] = p.Arguments
+	}
+	if p.ToolCallID != "" {
+		d["tool_call_id"] = p.ToolCallID
+	}
+	if p.IsError {
+		d["is_error"] = true
+	}
+	if p.Cancelled {
+		d["cancelled"] = true
+	}
+	return d
 }
 
 func bindPipeToContext[T any](ctx context.Context, pipe *audio.Pipe[T]) func() bool {

--- a/voice/pipeline_test.go
+++ b/voice/pipeline_test.go
@@ -10,7 +10,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/GizClaw/flowcraft/sdk/workflow"
+	"github.com/GizClaw/flowcraft/sdk/agent"
+	"github.com/GizClaw/flowcraft/sdk/engine"
 	"github.com/GizClaw/flowcraft/voice"
 	"github.com/GizClaw/flowcraft/voice/audio"
 	"github.com/GizClaw/flowcraft/voice/provider"
@@ -256,52 +257,75 @@ func (s *slowSTT) Recognize(ctx context.Context, input audio.Frame, opts ...stt.
 }
 
 // ---------------------------------------------------------------------------
-// Fake workflow.Runtime / workflow.Agent
+// Fake engine.Engine / agent.Agent
 // ---------------------------------------------------------------------------
 
-type fakeAgent struct{}
+// fakeAgent is the agent value the tests pass to voice.NewPipeline.
+// agent.Agent is a plain data struct in the new SDK, so a single
+// package-level value is enough — no per-test variation needed.
+var fakeAgent = agent.Agent{ID: "test"}
 
-func (fakeAgent) ID() string                  { return "test" }
-func (fakeAgent) Card() workflow.AgentCard    { return workflow.AgentCard{} }
-func (fakeAgent) Strategy() workflow.Strategy { return nil }
-func (fakeAgent) Tools() []string             { return nil }
+// nodeID is the actor id every fake engine uses when emitting stream
+// deltas. It is arbitrary; voice does not care about the value, only
+// that the deltas decode into the canonical [engine.StreamDeltaPayload].
+const fakeNodeID = "fake-llm"
 
-// fakeRuntime emits StreamEvents via the StreamCallback then returns.
-type fakeRuntime struct {
-	tokens     []string
-	toolEvents []map[string]any
+// streamToolEvent is a small DSL the fake engines use to describe tool
+// stream-deltas without re-typing the StreamDeltaPayload boilerplate.
+// Type is "tool_call" or "tool_result"; Name / Content / ID
+// correspond to the canonical fields.
+type streamToolEvent struct {
+	Type    string
+	Name    string
+	Content string
+	ID      string
 }
 
-func (r *fakeRuntime) Run(ctx context.Context, agent workflow.Agent, req *workflow.Request, opts ...workflow.RunOption) (*workflow.Result, error) {
-	rc := workflow.ApplyRunOpts(opts)
+func emitToolDelta(ctx context.Context, host engine.Host, runID string, e streamToolEvent) {
+	switch e.Type {
+	case "tool_call":
+		id := e.ID
+		if id == "" {
+			id = "call-" + e.Name
+		}
+		_ = engine.EmitStreamToolCall(ctx, host, runID, fakeNodeID, id, e.Name, nil)
+	case "tool_result":
+		id := e.ID
+		if id == "" {
+			id = "call-" + e.Name
+		}
+		_ = engine.EmitStreamToolResult(ctx, host, runID, fakeNodeID, id, e.Name, e.Content, false, false)
+	}
+}
 
+// fakeRuntime emits assistant tokens via the host's stream-delta
+// channel, then optional tool-call / tool-result deltas, then returns.
+// Default tokens reproduce a minimal two-chunk completion so most
+// tests can omit the field.
+type fakeRuntime struct {
+	tokens     []string
+	toolEvents []streamToolEvent
+}
+
+func (r *fakeRuntime) Execute(ctx context.Context, run engine.Run, host engine.Host, board *engine.Board) (*engine.Board, error) {
 	tokens := r.tokens
 	if len(tokens) == 0 {
 		tokens = []string{"Hello ", "world."}
 	}
-	if rc.StreamCallback != nil {
-		for _, tok := range tokens {
-			rc.StreamCallback(workflow.StreamEvent{
-				Type:    "token",
-				Payload: map[string]any{"content": tok},
-			})
-		}
-		for _, p := range r.toolEvents {
-			evType, _ := p["type"].(string)
-			rc.StreamCallback(workflow.StreamEvent{
-				Type:    evType,
-				Payload: p,
-			})
-		}
+	for _, tok := range tokens {
+		_ = engine.EmitStreamToken(ctx, host, run.ID, fakeNodeID, tok)
 	}
-	return &workflow.Result{}, nil
+	for _, e := range r.toolEvents {
+		emitToolDelta(ctx, host, run.ID, e)
+	}
+	return board, nil
 }
 
 // errRuntime always returns an error.
 type errRuntime struct{ err error }
 
-func (r *errRuntime) Run(ctx context.Context, _ workflow.Agent, _ *workflow.Request, opts ...workflow.RunOption) (*workflow.Result, error) {
-	return nil, r.err
+func (r *errRuntime) Execute(ctx context.Context, _ engine.Run, _ engine.Host, board *engine.Board) (*engine.Board, error) {
+	return board, r.err
 }
 
 // blockingRuntime blocks until ctx is cancelled (for Abort testing).
@@ -309,10 +333,10 @@ type blockingRuntime struct {
 	running atomic.Bool
 }
 
-func (r *blockingRuntime) Run(ctx context.Context, _ workflow.Agent, _ *workflow.Request, opts ...workflow.RunOption) (*workflow.Result, error) {
+func (r *blockingRuntime) Execute(ctx context.Context, _ engine.Run, _ engine.Host, board *engine.Board) (*engine.Board, error) {
 	r.running.Store(true)
 	<-ctx.Done()
-	return nil, ctx.Err()
+	return board, ctx.Err()
 }
 
 // slowRuntime does not emit any tokens for the given delay, for timeout testing.
@@ -320,12 +344,12 @@ type slowRuntime struct {
 	delay time.Duration
 }
 
-func (r *slowRuntime) Run(ctx context.Context, _ workflow.Agent, _ *workflow.Request, opts ...workflow.RunOption) (*workflow.Result, error) {
+func (r *slowRuntime) Execute(ctx context.Context, _ engine.Run, _ engine.Host, board *engine.Board) (*engine.Board, error) {
 	select {
 	case <-time.After(r.delay):
-		return &workflow.Result{}, nil
+		return board, nil
 	case <-ctx.Done():
-		return nil, ctx.Err()
+		return board, ctx.Err()
 	}
 }
 
@@ -338,7 +362,7 @@ func TestPipeline_RunAudio_Basic(t *testing.T) {
 		&fakeSTT{preset: "hello"},
 		&fakeTTS{},
 		&fakeRuntime{},
-		fakeAgent{},
+		fakeAgent,
 		voice.WithSegmenterOptions(tts.WithMinChars(1)),
 	)
 
@@ -389,7 +413,7 @@ func TestPipeline_RunAudio_EmptyTranscript(t *testing.T) {
 		&fakeSTT{preset: ""},
 		&fakeTTS{},
 		&fakeRuntime{},
-		fakeAgent{},
+		fakeAgent,
 	)
 
 	ctx := context.Background()
@@ -432,7 +456,7 @@ func TestPipeline_RunAudioStream_WithStreamSTT(t *testing.T) {
 		&fakeStreamSTT{preset: "hello"},
 		&fakeTTS{},
 		&fakeRuntime{},
-		fakeAgent{},
+		fakeAgent,
 		voice.WithSegmenterOptions(tts.WithMinChars(1)),
 	)
 
@@ -481,7 +505,7 @@ func TestPipeline_RunAudioStream_PreservesSTTTailAfterFirstFinal(t *testing.T) {
 		tailingStreamSTT{},
 		&fakeTTS{},
 		&fakeRuntime{},
-		fakeAgent{},
+		fakeAgent,
 		voice.WithSegmenterOptions(tts.WithMinChars(1)),
 	)
 
@@ -515,7 +539,7 @@ func TestPipeline_RunAudioStream_WithNonStreamSTT(t *testing.T) {
 		&fakeSTT{preset: "hello"},
 		&fakeTTS{},
 		&fakeRuntime{},
-		fakeAgent{},
+		fakeAgent,
 		voice.WithSegmenterOptions(tts.WithMinChars(1)),
 	)
 
@@ -559,7 +583,7 @@ func TestPipeline_RunAudioStream_WithStreamTTS(t *testing.T) {
 		&fakeSTT{preset: "hello"},
 		&fakeStreamTTS{fakeTTS: &fakeTTS{}},
 		&fakeRuntime{},
-		fakeAgent{},
+		fakeAgent,
 		voice.WithSegmenterOptions(tts.WithMinChars(1)),
 	)
 
@@ -591,7 +615,7 @@ func TestPipeline_RunnerError(t *testing.T) {
 		&fakeSTT{preset: "hello"},
 		&fakeTTS{},
 		&errRuntime{err: io.ErrClosedPipe},
-		fakeAgent{},
+		fakeAgent,
 		voice.WithSegmenterOptions(tts.WithMinChars(1)),
 	)
 
@@ -626,7 +650,7 @@ func TestPipeline_RunAudio_STTFinalTimeout(t *testing.T) {
 		},
 		&fakeTTS{},
 		&fakeRuntime{},
-		fakeAgent{},
+		fakeAgent,
 		voice.WithTimeouts(voice.PipelineTimeouts{
 			STTFinal: 20 * time.Millisecond,
 		}),
@@ -657,7 +681,7 @@ func TestPipeline_RunText_RunnerFirstTokenTimeout(t *testing.T) {
 		nil,
 		&fakeTTS{},
 		&slowRuntime{delay: 2 * time.Second},
-		fakeAgent{},
+		fakeAgent,
 		voice.WithTimeouts(voice.PipelineTimeouts{
 			RunnerFirstToken: 20 * time.Millisecond,
 		}),
@@ -692,7 +716,7 @@ func TestPipeline_RunAudio_AttachesSTTProviderReport(t *testing.T) {
 		fallbackSTT,
 		&fakeTTS{},
 		&fakeRuntime{},
-		fakeAgent{},
+		fakeAgent,
 		voice.WithSegmenterOptions(tts.WithMinChars(1)),
 	)
 
@@ -730,7 +754,7 @@ func TestPipeline_RunAudio_AttachesTTSProviderReport(t *testing.T) {
 		&fakeSTT{preset: "hello"},
 		fallbackTTS,
 		&fakeRuntime{},
-		fakeAgent{},
+		fakeAgent,
 		voice.WithSegmenterOptions(tts.WithMinChars(1)),
 	)
 
@@ -764,7 +788,7 @@ func TestPipeline_RunAudio_TranscriptMetadata(t *testing.T) {
 		metadataSTT{},
 		&fakeTTS{},
 		&fakeRuntime{},
-		fakeAgent{},
+		fakeAgent,
 	)
 
 	stream, err := p.RunAudio(context.Background(), audio.Frame{Data: []byte("wav")})
@@ -795,7 +819,7 @@ func TestPipeline_RunAudioStream_TranscriptRevisionIncrements(t *testing.T) {
 		metadataStreamSTT{},
 		&fakeTTS{},
 		&fakeRuntime{},
-		fakeAgent{},
+		fakeAgent,
 		voice.WithSegmenterOptions(tts.WithMinChars(1)),
 	)
 
@@ -844,7 +868,7 @@ func TestPipeline_TranscriptAudio(t *testing.T) {
 		&fakeSTT{preset: "hello"},
 		&fakeTTS{},
 		&fakeRuntime{},
-		fakeAgent{},
+		fakeAgent,
 		voice.WithSegmenterOptions(tts.WithMinChars(1)),
 	)
 
@@ -870,9 +894,9 @@ func TestPipeline_TranscriptAudio(t *testing.T) {
 func TestPipeline_ToolCallEvents(t *testing.T) {
 	toolRuntime := &fakeRuntime{
 		tokens: []string{"Use ", "the ", "tool."},
-		toolEvents: []map[string]any{
-			{"type": "tool_call", "name": "get_weather"},
-			{"type": "tool_result", "content": "sunny"},
+		toolEvents: []streamToolEvent{
+			{Type: "tool_call", Name: "get_weather"},
+			{Type: "tool_result", Name: "get_weather", Content: "sunny"},
 		},
 	}
 
@@ -880,7 +904,7 @@ func TestPipeline_ToolCallEvents(t *testing.T) {
 		&fakeSTT{preset: "hello"},
 		&fakeTTS{},
 		toolRuntime,
-		fakeAgent{},
+		fakeAgent,
 		voice.WithSegmenterOptions(tts.WithMinChars(1)),
 	)
 
@@ -921,7 +945,7 @@ func TestPipeline_Abort(t *testing.T) {
 		nil,
 		&fakeTTS{},
 		rt,
-		fakeAgent{},
+		fakeAgent,
 	)
 
 	ctx := context.Background()
@@ -954,7 +978,7 @@ func TestPipeline_NonStreamTTS(t *testing.T) {
 		&fakeSTT{preset: "hello"},
 		&fakeTTS{},
 		&fakeRuntime{},
-		fakeAgent{},
+		fakeAgent,
 		voice.WithSegmenterOptions(tts.WithMinChars(1)),
 	)
 
@@ -986,7 +1010,7 @@ func TestPipeline_RunText_Basic(t *testing.T) {
 		nil,
 		&fakeTTS{},
 		&fakeRuntime{},
-		fakeAgent{},
+		fakeAgent,
 		voice.WithSegmenterOptions(tts.WithMinChars(1)),
 	)
 
@@ -1033,7 +1057,7 @@ func TestPipeline_RunText_Basic(t *testing.T) {
 }
 
 func TestPipeline_RunText_EmptyText(t *testing.T) {
-	p := voice.NewPipeline(nil, &fakeTTS{}, &fakeRuntime{}, fakeAgent{})
+	p := voice.NewPipeline(nil, &fakeTTS{}, &fakeRuntime{}, fakeAgent)
 
 	ctx := context.Background()
 	stream, err := p.RunText(ctx, "")
@@ -1067,7 +1091,7 @@ func TestPipeline_RunText_EmptyText(t *testing.T) {
 }
 
 func TestPipeline_RunAudio_NilSTT(t *testing.T) {
-	p := voice.NewPipeline(nil, &fakeTTS{}, &fakeRuntime{}, fakeAgent{})
+	p := voice.NewPipeline(nil, &fakeTTS{}, &fakeRuntime{}, fakeAgent)
 
 	_, err := p.RunAudio(context.Background(), audio.Frame{Data: []byte("wav")})
 	if err == nil {
@@ -1076,7 +1100,7 @@ func TestPipeline_RunAudio_NilSTT(t *testing.T) {
 }
 
 func TestPipeline_RunAudioStream_NilSTT(t *testing.T) {
-	p := voice.NewPipeline(nil, &fakeTTS{}, &fakeRuntime{}, fakeAgent{})
+	p := voice.NewPipeline(nil, &fakeTTS{}, &fakeRuntime{}, fakeAgent)
 
 	input := audio.NewPipe[audio.Frame](8)
 	input.Close()
@@ -1095,7 +1119,7 @@ func TestPipeline_InputInterruptClosesOutput(t *testing.T) {
 		&fakeStreamSTT{preset: "hello"},
 		&fakeTTS{},
 		&fakeRuntime{},
-		fakeAgent{},
+		fakeAgent,
 	)
 
 	ctx := context.Background()
@@ -1126,7 +1150,7 @@ func TestPipeline_RunText_NonStreamTTS_SynthesizeError_EmitsErrorEvent(t *testin
 		nil,
 		failingTTSAdapter{err: synthErr},
 		&fakeRuntime{tokens: []string{"Hello."}},
-		fakeAgent{},
+		fakeAgent,
 		voice.WithSegmenterOptions(tts.WithMinChars(1)),
 	)
 
@@ -1165,22 +1189,17 @@ func collectTextDeltas(events []voice.Event) string {
 // eventCh overflow (S-4)
 // ---------------------------------------------------------------------------
 
-// overflowRuntime emits a burst of tokens synchronously.
+// overflowRuntime emits a burst of tokens synchronously to exercise
+// the voice pipeline's bounded eventCh + overflow counter.
 type overflowRuntime struct {
 	count int
 }
 
-func (r *overflowRuntime) Run(ctx context.Context, _ workflow.Agent, _ *workflow.Request, opts ...workflow.RunOption) (*workflow.Result, error) {
-	rc := workflow.ApplyRunOpts(opts)
-	if rc.StreamCallback != nil {
-		for i := 0; i < r.count; i++ {
-			rc.StreamCallback(workflow.StreamEvent{
-				Type:    "token",
-				Payload: map[string]any{"content": "x"},
-			})
-		}
+func (r *overflowRuntime) Execute(ctx context.Context, run engine.Run, host engine.Host, board *engine.Board) (*engine.Board, error) {
+	for i := 0; i < r.count; i++ {
+		_ = engine.EmitStreamToken(ctx, host, run.ID, fakeNodeID, "x")
 	}
-	return &workflow.Result{}, nil
+	return board, nil
 }
 
 func TestPipeline_RunText_EventOverflowWarning(t *testing.T) {
@@ -1188,7 +1207,7 @@ func TestPipeline_RunText_EventOverflowWarning(t *testing.T) {
 		nil,
 		&fakeTTS{},
 		&overflowRuntime{count: 2000},
-		fakeAgent{},
+		fakeAgent,
 	)
 
 	stream, err := p.RunText(context.Background(), "hello")
@@ -1242,7 +1261,7 @@ func TestPipeline_RunText_WarmupLifecycle(t *testing.T) {
 		nil,
 		wt,
 		&fakeRuntime{},
-		fakeAgent{},
+		fakeAgent,
 		voice.WithSegmenterOptions(tts.WithMinChars(1)),
 	)
 
@@ -1272,7 +1291,7 @@ func TestPipeline_EventOrdering_Strict(t *testing.T) {
 		&fakeSTT{preset: "hello"},
 		&fakeTTS{},
 		&fakeRuntime{},
-		fakeAgent{},
+		fakeAgent,
 		voice.WithSegmenterOptions(tts.WithMinChars(1)),
 	)
 
@@ -1332,7 +1351,7 @@ func TestPipeline_RunText_AllEventsShareRunID(t *testing.T) {
 		nil,
 		&fakeTTS{},
 		&fakeRuntime{},
-		fakeAgent{},
+		fakeAgent,
 		voice.WithSegmenterOptions(tts.WithMinChars(1)),
 	)
 
@@ -1364,7 +1383,7 @@ func TestPipeline_ContextCancel_TerminatesCleanly(t *testing.T) {
 		nil,
 		&fakeTTS{},
 		rt,
-		fakeAgent{},
+		fakeAgent,
 	)
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -1403,7 +1422,7 @@ func TestPipeline_RunAudioStream_ContextCancel_NoHang(t *testing.T) {
 		&fakeStreamSTT{preset: "hello"},
 		&fakeTTS{},
 		&blockingRuntime{},
-		fakeAgent{},
+		fakeAgent,
 	)
 
 	input := audio.NewPipe[audio.Frame](8)
@@ -1437,7 +1456,7 @@ func TestPipeline_RunText_MultipleSentences(t *testing.T) {
 		nil,
 		&fakeTTS{},
 		&fakeRuntime{tokens: []string{"First sentence.", " Second sentence."}},
-		fakeAgent{},
+		fakeAgent,
 		voice.WithSegmenterOptions(tts.WithMinChars(1)),
 	)
 
@@ -1464,7 +1483,7 @@ func TestPipeline_Abort_EmitsLifecycleEvents(t *testing.T) {
 		nil,
 		&fakeTTS{},
 		rt,
-		fakeAgent{},
+		fakeAgent,
 	)
 
 	stream, err := p.RunText(context.Background(), "hello")
@@ -1537,7 +1556,7 @@ func TestPipeline_RunText_TTSFirstAudioTimeout(t *testing.T) {
 		nil,
 		slowStreamTTS{},
 		&fakeRuntime{tokens: []string{"Hello."}},
-		fakeAgent{},
+		fakeAgent,
 		voice.WithTimeouts(voice.PipelineTimeouts{
 			TTSFirstAudio: 50 * time.Millisecond,
 		}),
@@ -1570,7 +1589,7 @@ func TestPipeline_EventOrdering_StreamTTS(t *testing.T) {
 		&fakeSTT{preset: "hello"},
 		&fakeStreamTTS{fakeTTS: &fakeTTS{}},
 		&fakeRuntime{},
-		fakeAgent{},
+		fakeAgent,
 		voice.WithSegmenterOptions(tts.WithMinChars(1)),
 	)
 
@@ -1615,7 +1634,7 @@ func TestPipeline_RunText_StreamTTS_EventOrdering(t *testing.T) {
 		nil,
 		&fakeStreamTTS{fakeTTS: &fakeTTS{}},
 		&fakeRuntime{tokens: []string{"One.", " Two."}},
-		fakeAgent{},
+		fakeAgent,
 		voice.WithSegmenterOptions(tts.WithMinChars(1)),
 	)
 
@@ -1663,7 +1682,7 @@ func TestPipeline_RunAudio_WarmupLifecycle(t *testing.T) {
 		&fakeSTT{preset: "hello"},
 		wt,
 		&fakeRuntime{},
-		fakeAgent{},
+		fakeAgent,
 		voice.WithSegmenterOptions(tts.WithMinChars(1)),
 	)
 

--- a/voice/session.go
+++ b/voice/session.go
@@ -235,9 +235,6 @@ func (s *Session) pipelineForTurn() *Pipeline {
 	}
 	p := s.pipeline.clone()
 	p.skipWarmup = true
-	if p.contextID == "" {
-		p.contextID = s.sessionID
-	}
 	if s.cfg.voiceProfileSet {
 		profile := s.cfg.voiceProfile
 		p.addDynamicTTSOptionsProvider(func() []tts.TTSOption {

--- a/voice/session_test.go
+++ b/voice/session_test.go
@@ -10,7 +10,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/GizClaw/flowcraft/sdk/workflow"
+	"github.com/GizClaw/flowcraft/sdk/engine"
 	"github.com/GizClaw/flowcraft/voice"
 	"github.com/GizClaw/flowcraft/voice/audio"
 	"github.com/GizClaw/flowcraft/voice/detect"
@@ -197,26 +197,19 @@ func newDelayedRuntime(tokens []string, delay time.Duration) *delayedRuntime {
 	return &delayedRuntime{tokens: tokens, delay: delay}
 }
 
-func (r *delayedRuntime) Run(ctx context.Context, _ workflow.Agent, _ *workflow.Request, opts ...workflow.RunOption) (*workflow.Result, error) {
-	rc := workflow.ApplyRunOpts(opts)
-
+func (r *delayedRuntime) Execute(ctx context.Context, run engine.Run, host engine.Host, board *engine.Board) (*engine.Board, error) {
 	tokens := r.tokens
 	if len(tokens) == 0 {
 		tokens = []string{"Hello "}
 	}
-	if rc.StreamCallback != nil {
-		for _, tok := range tokens {
-			rc.StreamCallback(workflow.StreamEvent{
-				Type:    "token",
-				Payload: map[string]any{"content": tok},
-			})
-		}
+	for _, tok := range tokens {
+		_ = engine.EmitStreamToken(ctx, host, run.ID, fakeNodeID, tok)
 	}
 	select {
 	case <-time.After(r.delay):
-		return &workflow.Result{}, nil
+		return board, nil
 	case <-ctx.Done():
-		return nil, ctx.Err()
+		return board, ctx.Err()
 	}
 }
 
@@ -228,35 +221,23 @@ type staleTokenRuntime struct {
 	startCnt atomic.Int32
 }
 
-func (r *staleTokenRuntime) Run(ctx context.Context, _ workflow.Agent, _ *workflow.Request, opts ...workflow.RunOption) (*workflow.Result, error) {
-	rc := workflow.ApplyRunOpts(opts)
+func (r *staleTokenRuntime) Execute(ctx context.Context, run engine.Run, host engine.Host, board *engine.Board) (*engine.Board, error) {
 	turn := r.startCnt.Add(1)
 
-	if rc.StreamCallback != nil {
-		switch turn {
-		case 1:
-			rc.StreamCallback(workflow.StreamEvent{
-				Type:    "token",
-				Payload: map[string]any{"content": "old-early "},
-			})
-			select {
-			case <-time.After(200 * time.Millisecond):
-			case <-ctx.Done():
-				return nil, ctx.Err()
-			}
-			rc.StreamCallback(workflow.StreamEvent{
-				Type:    "token",
-				Payload: map[string]any{"content": "old-late "},
-			})
-		default:
-			time.Sleep(30 * time.Millisecond)
-			rc.StreamCallback(workflow.StreamEvent{
-				Type:    "token",
-				Payload: map[string]any{"content": "new-turn "},
-			})
+	switch turn {
+	case 1:
+		_ = engine.EmitStreamToken(ctx, host, run.ID, fakeNodeID, "old-early ")
+		select {
+		case <-time.After(200 * time.Millisecond):
+		case <-ctx.Done():
+			return board, ctx.Err()
 		}
+		_ = engine.EmitStreamToken(ctx, host, run.ID, fakeNodeID, "old-late ")
+	default:
+		time.Sleep(30 * time.Millisecond)
+		_ = engine.EmitStreamToken(ctx, host, run.ID, fakeNodeID, "new-turn ")
 	}
-	return &workflow.Result{}, nil
+	return board, nil
 }
 
 func newSessionPipeline(transcript string) *voice.Pipeline {
@@ -268,7 +249,7 @@ func newSessionPipeline(transcript string) *voice.Pipeline {
 		&fakeStreamSTT{preset: transcript},
 		&fakeStreamTTS{fakeTTS: &fakeTTS{}},
 		&fakeRuntime{tokens: tokens},
-		fakeAgent{},
+		fakeAgent,
 		voice.WithSegmenterOptions(tts.WithMinChars(1)),
 	)
 }
@@ -279,7 +260,7 @@ func newTextOnlyPipeline() *voice.Pipeline {
 		nil,
 		&fakeStreamTTS{fakeTTS: &fakeTTS{}},
 		&fakeRuntime{tokens: []string{"reply"}},
-		fakeAgent{},
+		fakeAgent,
 		voice.WithSegmenterOptions(tts.WithMinChars(1)),
 	)
 }
@@ -294,7 +275,7 @@ func newSessionPipelineForBargeIn(transcript string) (*voice.Pipeline, *delayedR
 		&fakeStreamSTT{preset: transcript},
 		&fakeStreamTTS{fakeTTS: &fakeTTS{}},
 		rt,
-		fakeAgent{},
+		fakeAgent,
 		voice.WithSegmenterOptions(tts.WithMinChars(1)),
 	)
 	return pipeline, rt
@@ -508,7 +489,7 @@ func TestSession_VoiceProfileAppliesDynamicTTSOptions(t *testing.T) {
 		nil,
 		ttsCapture,
 		&fakeRuntime{tokens: []string{"reply"}},
-		fakeAgent{},
+		fakeAgent,
 		voice.WithSegmenterOptions(tts.WithMinChars(1)),
 	)
 	session := voice.NewSession(pipeline, nil, &fakeAudioSink{},
@@ -959,7 +940,7 @@ func TestSession_TextInterruptsResponding(t *testing.T) {
 		nil,
 		&fakeStreamTTS{fakeTTS: &fakeTTS{}},
 		rt,
-		fakeAgent{},
+		fakeAgent,
 		voice.WithSegmenterOptions(tts.WithMinChars(1)),
 	)
 
@@ -998,7 +979,7 @@ func TestSession_TextInterruptStopsOldTurnEvents(t *testing.T) {
 		nil,
 		&fakeStreamTTS{fakeTTS: &fakeTTS{}},
 		rt,
-		fakeAgent{},
+		fakeAgent,
 		voice.WithSegmenterOptions(tts.WithMinChars(1)),
 	)
 
@@ -1326,7 +1307,7 @@ func TestSession_TurnMetricsIncludeProviderReports(t *testing.T) {
 			okStreamTTSAdapter{payload: "audio"},
 		),
 		&fakeRuntime{tokens: []string{"reply"}},
-		fakeAgent{},
+		fakeAgent,
 		voice.WithSegmenterOptions(tts.WithMinChars(1)),
 	)
 	source := newFakeAudioSource([]audio.Frame{


### PR DESCRIPTION
## Summary

- `voice.Pipeline` no longer imports `sdk/workflow`. Turns are now driven by `agent.Run` against any `engine.Engine`; the pipeline installs an internal `voiceHost` to capture stream-delta envelopes for the active runID and translate them into `voice.Event`s.
- New options: `WithEngineHost(engine.Host)` (fan-out for OTel / event bus / interrupts / checkpointer) and `WithRunOptions(...agent.RunOption)` (escape hatch for `agent.BoardSeeder`, observers, deciders, attributes — including history loading, which is no longer a pipeline concern).
- Removed: `WithTurnHistory`, `WithContextID`. `Session.pipelineForTurn` no longer copies sessionID into a pipeline-level context field.
- `voice/go.mod`: `sdk v0.2.2` → `v0.2.7` (needed for `agent.Run` and `engine.StreamDeltaPayload`).

## Why `[skip-tag:voice]`

This is a **breaking change** to voice's public `NewPipeline` signature and option surface. Auto-tag's patch-only bump would label it incorrectly. The release coordinator should hand-tag `voice/v0.2.0` after merge.

## Migration

Old:
\`\`\`go
voice.NewPipeline(s, t, workflowRuntime, workflowAgent,
    voice.WithTurnHistory(msgs),
    voice.WithContextID(\"sess-1\"),
)
\`\`\`

New:
\`\`\`go
voice.NewPipeline(s, t, engineImpl, agent.Agent{ID: \"voice\"},
    voice.WithRunOptions(
        agent.WithBoardSeed(historySeeder(msgs)),
        agent.WithAttributes(map[string]string{\"context_id\": \"sess-1\"}),
    ),
)
\`\`\`

For graph-based agents, the engine is `runner.New(def, factory)` from `sdk/graph/runner` (it satisfies `engine.Engine` directly).

## Verification

| Check | Result |
|---|---|
| \`go vet ./voice/...\` | ✅ |
| \`rg workflow voice/\` | ✅ 0 hits |
| \`go list -deps ./voice/... \| grep workflow\` (feat) | ✅ 0 hits |
| \`go list -deps ./voice/... \| grep workflow\` (main) | exists, confirms removal works |
| \`go test ./voice/... -race -count=1\` | ✅ 13/13 packages |
| \`go test ./voice/. -count=20\` | ✅ no flake |
| Test function names diff (main vs feat) | ✅ identical — no coverage loss |
| \`go test ./sdk/...\` | ✅ unaffected |
| \`GOWORK=off go test ./voice/... -count=1\` (against released sdk v0.2.7) | ✅ |

## Bug found & fixed during refactor

\`agent.Run\` returns \`(res, nil)\` for engine-side failures (errors land on \`res.Err\` + non-completed \`res.Status\`), unlike the old \`workflow.Runtime.Run\` which returned the error directly. The naive port lost \`EventError\` emission for runner failures; \`TestPipeline_RunnerError\` caught it and \`startFlow\` now reads both \`err\` and \`res.Err\`, while filtering out cancelled/interrupted statuses to preserve Abort behaviour.

## Out of scope (intentional)

- \`examples/voice-pipeline/\` is pinned to released \`voice v0.1.0\` and \`sdk v0.2.0\`; updating it would touch unrelated API drift (\`llm.ProviderConfigStore\`, \`node.NewFactory\` …). It will be migrated in a follow-up PR after \`voice/v0.2.0\` is published.

## Test plan

- [ ] CI green
- [ ] Manual review of \`voiceHost\` Publisher fan-out logic in \`voice/pipeline.go\`
- [ ] Manual review of error-classification switch in \`startFlow\`
- [ ] Confirm \`[skip-tag:voice]\` is honoured by \`auto-tag\` workflow on merge

Made with [Cursor](https://cursor.com)