### PR TITLE
ci(auto-tag): scope tagging to modules touched by this push

### DIFF
--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -24,6 +24,12 @@ jobs:
   #
   # Per-module skip is below: `[skip-tag:sdk]` keeps the workflow
   # running but bypasses the sdk module specifically.
+  #
+  # Scoping rule (since 2026-05): auto-tag will ONLY consider modules
+  # whose files were modified in the current push (event.before..
+  # event.after). Earlier `[skip-tag:X]` accumulated diff is no longer
+  # charged to the next unrelated PR — the next PR that touches X
+  # will pick it up instead. See workflow body for details.
   guard:
     name: Check skip-tag marker
     runs-on: ubuntu-latest
@@ -78,6 +84,48 @@ jobs:
             fi
           done
 
+      - name: Detect modules touched by THIS push
+        id: touched
+        env:
+          BEFORE_SHA: ${{ github.event.before }}
+          AFTER_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          # We only consider modules whose files were modified between
+          # the previous main tip (event.before) and the new tip
+          # (event.after / github.sha). This is what stops auto-tag
+          # from charging unrelated modules for diff that accumulated
+          # across earlier `[skip-tag:X]` PRs — the canonical bug fix
+          # behind this rewrite.
+          #
+          # Edge case: when this is the very first push that creates
+          # main (or after a force-push that rewrote history),
+          # event.before is the all-zeros SHA. In that case we fall
+          # back to "module has any tracked file" which is a safe
+          # superset and reproduces the pre-fix behaviour.
+          zeros="0000000000000000000000000000000000000000"
+          if [ -z "${BEFORE_SHA}" ] || [ "${BEFORE_SHA}" = "${zeros}" ]; then
+            echo "no usable BEFORE_SHA, treating every module as touched"
+            for mod in sdk sdkx voice; do
+              key="MODULE_TOUCHED_$(echo "$mod" | tr '[:lower:]' '[:upper:]')"
+              echo "${key}=1" >> "$GITHUB_ENV"
+            done
+            exit 0
+          fi
+          # Make sure the before SHA is actually fetched. checkout@v4
+          # with fetch-depth: 0 already pulls full history, but a defensive
+          # fetch keeps the workflow robust against shallow-clone tweaks.
+          git fetch --no-tags origin "${BEFORE_SHA}" >/dev/null 2>&1 || true
+          for mod in sdk sdkx voice; do
+            if [ -n "$(git diff --name-only "${BEFORE_SHA}".."${AFTER_SHA}" -- "$mod/")" ]; then
+              key="MODULE_TOUCHED_$(echo "$mod" | tr '[:lower:]' '[:upper:]')"
+              echo "${key}=1" >> "$GITHUB_ENV"
+              echo "$mod: touched by this push"
+            else
+              echo "$mod: not touched by this push"
+            fi
+          done
+
       - name: Detect changes and tag
         run: |
           set -euo pipefail
@@ -99,20 +147,39 @@ jobs:
             [ -n "$(git diff --name-only "$latest"..HEAD -- "$mod/")" ]
           }
 
-          # tag_module tags a module if it has changes since its last tag.
-          # Honours the per-module skip marker captured by the previous
-          # step (MODULE_SKIP_<MOD>=1 from `[skip-tag:<mod>]`).
+          # tag_module tags a module if both:
           #
-          # Each module is tagged independently: bumping sdk does NOT
-          # trigger any automated PR to refresh sdkx/voice's `require
-          # github.com/GizClaw/flowcraft/sdk` directive. Downstream
-          # modules are bumped by hand (or by a follow-up PR), and on
-          # the next push of that PR they get tagged on their own.
+          #   1. THIS push touched files inside the module directory
+          #      (MODULE_TOUCHED_<MOD>=1 from the previous step), AND
+          #   2. there are diffs in the module directory since the
+          #      latest module tag (so we capture any prior commits
+          #      that were left untagged due to `[skip-tag:<mod>]`).
+          #
+          # Rule 1 is the fix for the cross-module bleed bug: a PR
+          # that only modifies voice/ no longer wakes up sdk's tag
+          # logic just because some earlier sdk-only PR carried
+          # `[skip-tag:sdk]`. That earlier PR's accumulated diff will
+          # only be released the next time someone actually pushes
+          # an sdk/ change.
+          #
+          # Rule 2 is preserved so that a single PR that touches a
+          # module gets credited for the full untagged window — e.g.
+          # if PR#56 carried [skip-tag:sdk] and PR#60 (our hypothetical
+          # next sdk PR) does not, PR#60 patches up to v0.x.(N+2) in
+          # one go, which is the documented "skip == defer" semantics.
+          #
+          # Per-module SKIP marker still wins over both rules so a
+          # release coordinator can hand-tag a SemVer-major bump.
           tag_module() {
             local mod=$1
             local skip_var="MODULE_SKIP_$(echo "$mod" | tr '[:lower:]' '[:upper:]')"
             if [ "${!skip_var:-}" = "1" ]; then
               echo "$mod: skipped via [skip-tag:${mod}]"
+              return
+            fi
+            local touched_var="MODULE_TOUCHED_$(echo "$mod" | tr '[:lower:]' '[:upper:]')"
+            if [ "${!touched_var:-}" != "1" ]; then
+              echo "$mod: not touched by this push, skipping"
               return
             fi
             local latest


### PR DESCRIPTION
## Summary

Auto-tag's current design re-evaluates every module on every push to main, regardless of which paths the push actually modified. Combined with the stateless `[skip-tag:X]` semantics, that means **diff a previous PR opted out of gets silently charged to the next unrelated PR**.

Concrete recent example: [PR #58](https://github.com/GizClaw/flowcraft/pull/58) only modified `voice/`, but on merge the workflow created `sdk/v0.2.8` because PR #56 and PR #57 had each used `[skip-tag:sdk]` and the accumulated `sdk/` diff was waiting in the `latest_tag..HEAD` window. The bogus tag had to be deleted by hand.

## What changed

A new step **\"Detect modules touched by THIS push\"** computes the set of touched module roots from `github.event.before..github.sha`, and `tag_module` now requires *both*:

1. THIS push touched files inside the module directory, AND
2. There are diffs in the module since the latest module tag.

Rule (1) stops the cross-module bleed. Rule (2) is preserved so that a PR which *does* touch the module still picks up any prior untagged window in one go — the documented \"skip == defer\" semantics. Per-module `[skip-tag:<mod>]` still wins over both rules so a release coordinator can hand-tag breaking changes.

## Edge cases handled

- **Initial push / force-push**: `event.before` is the all-zeros SHA. The step falls back to pre-fix behaviour (every module marked as touched) so the workflow stays safe on a fresh `main`.
- **Shallow clones**: defensive `git fetch --no-tags origin $BEFORE_SHA` so the diff resolves even if checkout depth is ever tightened.

## Behaviour matrix

| Scenario | Before | After |
|---|---|---|
| PR touches voice/ only, no debt | tag voice ✅ | tag voice ✅ |
| PR touches voice/ only, sdk/ has accumulated `[skip-tag:sdk]` debt | tag voice ✅ + tag sdk ❌ (bug) | tag voice ✅, sdk untouched ✅ |
| PR touches sdk/ only, sdk/ has accumulated `[skip-tag:sdk]` debt | tag sdk (rolling up debt) ✅ | tag sdk (rolling up debt) ✅ — same |
| PR touches sdk/ + voice/ | tag both ✅ | tag both ✅ |
| PR carries `[skip-tag]` (whole) | skip everything ✅ | skip everything ✅ |
| PR carries `[skip-tag:sdk]` and touches sdk/+voice/ | skip sdk, tag voice ✅ | skip sdk, tag voice ✅ |

The only behavioural change is the buggy row.

## Doc updates

The job-level comment now records the new scoping rule (with date) and the inline comment in `tag_module` explains why both gates exist.

## Test plan

- [ ] Wait for CI green on the PR (workflow itself is not exercised by PR validation, only on merge to main)
- [ ] After merge, watch the next sdk-only PR confirm sdk gets bumped (rolling up earlier debt)
- [ ] Watch the next voice-only PR confirm sdk is left untouched
- [ ] Verify `[skip-tag]` and `[skip-tag:<mod>]` markers still behave as before (manual scan of merge run logs)

Made with [Cursor](https://cursor.com)