### PR TITLE
feat(vessel): add Handle.OnTerminate lifecycle hook

### DIFF
--- a/vessel/handle.go
+++ b/vessel/handle.go
@@ -45,6 +45,15 @@ type Handle struct {
 	// inside Do — the close acts as the release barrier.
 	result *agent.Result
 	err    error
+
+	// hookMu guards onTerminate. It is held while appending hooks
+	// (OnTerminate) and while draining them (deliver). Because
+	// deliver runs the hooks INSIDE the lock and only THEN closes
+	// done, any later OnTerminate caller sees terminated == true
+	// and synchronously runs the hook itself.
+	hookMu      sync.Mutex
+	onTerminate []func(*agent.Result, error)
+	terminated  bool
 }
 
 // newHandle is the internal constructor.
@@ -89,11 +98,17 @@ func (h *Handle) Done() <-chan struct{} {
 	return h.done
 }
 
-// deliver is the producer-side helper. It publishes the result and
-// closes the done channel so every concurrent Wait observes the
-// terminal state. Called exactly once by [Captain.Submit]'s dispatch
-// goroutine; the once guard makes a second call a no-op rather than
-// a double-close panic.
+// deliver is the producer-side helper. It publishes the result,
+// runs every registered OnTerminate hook synchronously (in
+// registration order), and only THEN closes the done channel.
+// This is the lifecycle-event ordering guarantee that callers
+// rely on: when Wait returns or <-Done() unblocks, every hook has
+// already executed.
+//
+// Called exactly once by [Captain.Submit]'s dispatch goroutine;
+// the once guard makes a second call a no-op rather than a
+// double-close panic. Hooks panicking are isolated by recover —
+// one buggy hook MUST NOT block others or leave the run hanging.
 func (h *Handle) deliver(res *agent.Result, err error) {
 	if h == nil {
 		return
@@ -101,6 +116,56 @@ func (h *Handle) deliver(res *agent.Result, err error) {
 	h.once.Do(func() {
 		h.result = res
 		h.err = err
+		h.hookMu.Lock()
+		hooks := h.onTerminate
+		h.onTerminate = nil
+		h.terminated = true
+		h.hookMu.Unlock()
+		for _, fn := range hooks {
+			runHookSafely(fn, res, err)
+		}
 		close(h.done)
 	})
+}
+
+// OnTerminate registers a hook that runs synchronously when the
+// underlying run reaches a terminal state, BEFORE Wait returns
+// and BEFORE Done is closed. Hooks observe the same (result, err)
+// pair that Wait will return. Use this to plug in bookkeeping
+// (registry updates, span closure, metrics, checkpoint flush)
+// without inventing a separate goroutine that races against the
+// done channel.
+//
+// Contract:
+//
+//   - Hooks MUST NOT block. They run in the dispatch goroutine
+//     and delay every Wait caller by their wall-clock cost.
+//   - Hooks MAY panic; the panic is recovered and ignored. Don't
+//     rely on it for control flow.
+//   - Late registration is safe: if the run has already
+//     terminated, OnTerminate invokes fn synchronously with the
+//     cached result before returning.
+//   - Hooks fire in registration order.
+//
+// OnTerminate is safe to call from any goroutine and any number
+// of times.
+func (h *Handle) OnTerminate(fn func(*agent.Result, error)) {
+	if h == nil || fn == nil {
+		return
+	}
+	h.hookMu.Lock()
+	if !h.terminated {
+		h.onTerminate = append(h.onTerminate, fn)
+		h.hookMu.Unlock()
+		return
+	}
+	res, err := h.result, h.err
+	h.hookMu.Unlock()
+	runHookSafely(fn, res, err)
+}
+
+// runHookSafely invokes a single hook with panic isolation.
+func runHookSafely(fn func(*agent.Result, error), res *agent.Result, err error) {
+	defer func() { _ = recover() }()
+	fn(res, err)
 }

--- a/vessel/handle_test.go
+++ b/vessel/handle_test.go
@@ -1,0 +1,213 @@
+package vessel
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/GizClaw/flowcraft/sdk/agent"
+)
+
+// TestHandle_OnTerminate_RunsBeforeWaitReturns is the central
+// contract: every Wait caller MUST observe a state where the
+// hook has already executed. We register a hook that flips a
+// flag, then assert the flag is true the moment Wait returns.
+func TestHandle_OnTerminate_RunsBeforeWaitReturns(t *testing.T) {
+	t.Parallel()
+	h := newHandle("run-1", "alpha")
+
+	var hookRan atomic.Bool
+	h.OnTerminate(func(_ *agent.Result, _ error) {
+		hookRan.Store(true)
+	})
+
+	// Drive deliver from a separate goroutine so Wait actually
+	// blocks. Otherwise we'd be testing the late-register path.
+	go func() {
+		time.Sleep(5 * time.Millisecond)
+		h.deliver(&agent.Result{}, nil)
+	}()
+
+	if _, err := h.Wait(context.Background()); err != nil {
+		t.Fatalf("Wait: %v", err)
+	}
+	if !hookRan.Load() {
+		t.Fatalf("hook did not run before Wait returned")
+	}
+}
+
+// TestHandle_OnTerminate_RunsBeforeDoneCloses asserts the same
+// ordering for the <-h.Done() consumer path. After the channel
+// fires, every registered hook must already be done.
+func TestHandle_OnTerminate_RunsBeforeDoneCloses(t *testing.T) {
+	t.Parallel()
+	h := newHandle("run-2", "alpha")
+
+	var hookRan atomic.Bool
+	h.OnTerminate(func(_ *agent.Result, _ error) {
+		hookRan.Store(true)
+	})
+
+	go h.deliver(&agent.Result{}, nil)
+
+	<-h.Done()
+	if !hookRan.Load() {
+		t.Fatalf("hook did not run before Done closed")
+	}
+}
+
+// TestHandle_OnTerminate_FiresInRegistrationOrder pins the
+// ordering guarantee so consumers can layer (e.g. close OTel
+// span before recording metrics that may reference it).
+func TestHandle_OnTerminate_FiresInRegistrationOrder(t *testing.T) {
+	t.Parallel()
+	h := newHandle("run-3", "alpha")
+
+	var (
+		mu  sync.Mutex
+		got []int
+	)
+	for i := 0; i < 5; i++ {
+		i := i
+		h.OnTerminate(func(_ *agent.Result, _ error) {
+			mu.Lock()
+			got = append(got, i)
+			mu.Unlock()
+		})
+	}
+
+	h.deliver(&agent.Result{}, nil)
+
+	for idx, want := range []int{0, 1, 2, 3, 4} {
+		if got[idx] != want {
+			t.Fatalf("hook order = %v, want [0 1 2 3 4]", got)
+		}
+	}
+}
+
+// TestHandle_OnTerminate_ReceivesResultAndErr verifies hooks
+// observe the exact same (result, err) pair Wait returns —
+// otherwise hooks couldn't make decisions based on terminal
+// state (e.g. only flush checkpoints on success).
+func TestHandle_OnTerminate_ReceivesResultAndErr(t *testing.T) {
+	t.Parallel()
+	h := newHandle("run-4", "alpha")
+
+	wantRes := &agent.Result{}
+	wantErr := errors.New("boom")
+
+	var (
+		gotRes *agent.Result
+		gotErr error
+	)
+	h.OnTerminate(func(res *agent.Result, err error) {
+		gotRes = res
+		gotErr = err
+	})
+
+	h.deliver(wantRes, wantErr)
+
+	if gotRes != wantRes {
+		t.Fatalf("hook got result %p, want %p", gotRes, wantRes)
+	}
+	if !errors.Is(gotErr, wantErr) {
+		t.Fatalf("hook got err %v, want %v", gotErr, wantErr)
+	}
+}
+
+// TestHandle_OnTerminate_PanicIsIsolated ensures one buggy hook
+// can't block subsequent hooks or leave Wait hanging. Critical
+// for the "any subsystem can register" contract.
+func TestHandle_OnTerminate_PanicIsIsolated(t *testing.T) {
+	t.Parallel()
+	h := newHandle("run-5", "alpha")
+
+	var laterRan atomic.Bool
+	h.OnTerminate(func(_ *agent.Result, _ error) {
+		panic("hook 1 explodes")
+	})
+	h.OnTerminate(func(_ *agent.Result, _ error) {
+		laterRan.Store(true)
+	})
+
+	h.deliver(&agent.Result{}, nil)
+
+	if !laterRan.Load() {
+		t.Fatalf("later hook did not run after earlier hook panicked")
+	}
+	// Wait must still return cleanly.
+	if _, err := h.Wait(context.Background()); err != nil {
+		t.Fatalf("Wait: %v", err)
+	}
+}
+
+// TestHandle_OnTerminate_LateRegisterFastPath verifies hooks
+// registered AFTER the run has already terminated are invoked
+// synchronously with the cached terminal state. Otherwise late
+// registration would silently drop bookkeeping.
+func TestHandle_OnTerminate_LateRegisterFastPath(t *testing.T) {
+	t.Parallel()
+	h := newHandle("run-6", "alpha")
+
+	wantErr := errors.New("post-mortem")
+	h.deliver(&agent.Result{}, wantErr)
+
+	var gotErr error
+	h.OnTerminate(func(_ *agent.Result, err error) {
+		gotErr = err
+	})
+
+	if !errors.Is(gotErr, wantErr) {
+		t.Fatalf("late hook got err %v, want %v", gotErr, wantErr)
+	}
+}
+
+// TestHandle_OnTerminate_NilFnIsNoop guards against nil-fn
+// crashes — registering nil should be a silent no-op rather
+// than a panic at deliver time.
+func TestHandle_OnTerminate_NilFnIsNoop(t *testing.T) {
+	t.Parallel()
+	h := newHandle("run-7", "alpha")
+	h.OnTerminate(nil)
+	h.deliver(&agent.Result{}, nil)
+	// Reaching here without panic is the assertion.
+}
+
+// TestHandle_OnTerminate_ConcurrentRegistration stresses the
+// registration path against deliver to confirm no hook is lost
+// AND no hook runs twice. Race detector is the primary check.
+func TestHandle_OnTerminate_ConcurrentRegistration(t *testing.T) {
+	t.Parallel()
+	h := newHandle("run-8", "alpha")
+
+	const N = 32
+	var ran atomic.Int32
+	var wg sync.WaitGroup
+	wg.Add(N)
+	for i := 0; i < N; i++ {
+		go func() {
+			defer wg.Done()
+			h.OnTerminate(func(_ *agent.Result, _ error) {
+				ran.Add(1)
+			})
+		}()
+	}
+
+	go func() {
+		// Race deliver against the registration storm.
+		time.Sleep(time.Microsecond)
+		h.deliver(&agent.Result{}, nil)
+	}()
+
+	wg.Wait()
+	// wg.Wait covers OnTerminate returns; deliver may still be
+	// mid-loop iterating queued hooks. Done is closed only after
+	// every queued hook has executed, so it's the right barrier.
+	<-h.Done()
+	if got := ran.Load(); got != N {
+		t.Fatalf("ran = %d, want %d (each hook must fire exactly once)", got, N)
+	}
+}


### PR DESCRIPTION
## Summary

Adds a synchronous completion-hook API on \`vessel.Handle\` so multiple consumers can observe run termination with deterministic ordering — no more racy \`<-h.Done()\` watcher goroutines per consumer.

## Why

PR #62 surfaced a real ordering gap on \`/v1/vessels/{id}/call\`: \`/call\` returned when \`h.Wait\` resolved, but \`runRegistry\`'s background goroutine watching \`h.Done()\` had no ordering guarantee against \`Wait\`. Result: \`/metrics\` and \`/v1/runs\` could miss a just-completed run, breaking the scrape contract.

The architectural fix is to give \`Handle\` a proper lifecycle-event hook API instead of patching one consumer at a time.

## Contract

- Hooks fire **synchronously**, in registration order, **BEFORE** \`Wait\` returns and **BEFORE** \`Done\` is closed.
- Any consumer of \`Wait\`/\`Done\` is guaranteed to see a state where every hook has executed.
- Hooks **must be fast and non-blocking** — they delay every \`Wait\` caller.
- Hooks may panic; isolated per-hook via \`recover\` so one buggy hook can't block siblings.
- **Late registration** is safe: registering after termination invokes \`fn\` synchronously with the cached terminal state.

## Scope

- \`vessel/handle.go\`: \`Handle.OnTerminate(fn)\` + \`hookMu\`/\`onTerminate\`/\`terminated\` fields; \`deliver\` runs hooks under panic isolation before \`close(done)\`.
- \`vessel/handle_test.go\`: 8 tests covering ordering, fan-out, panic isolation, late-register fast path, nil-fn no-op, concurrent registration race.

Backwards compatible — pure addition.

## Follow-up

PR #62 will pick up \`vessel v0.1.0-rc.2\` (this PR + tag) and migrate \`runRegistry\` off its own goroutine, then revert the test-side polling hack added as a stopgap.

## Test plan

- [x] \`go test -race -count=10 -run TestHandle ./vessel/\` green
- [x] \`go test -race -count=1 ./vessel/...\` green
- [ ] CI green

Made with [Cursor](https://cursor.com)