### PR TITLE
docs: restore RRF mention in recall highlights

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ Layered bottom-up. Each layer only depends on layers below it; siblings on the s
 
 ### Hybrid memory that actually recalls (`sdk/recall`)
 
-- BM25 lexical + vector semantic search with entity boost and TTL filtering — not just embedding similarity.
+- Three-lane retrieval (BM25 + vector + entity), fused via **Reciprocal Rank Fusion** (K=60), then re-weighted by entity-overlap boost, supersede decay, and time decay.
 - Predicate alias normalisation so "favourite color" and "favorite colour" hit the same memory.
 - Pluggable `retrieval.Index` backend — bring your own vector store; the in-tree implementation is in-memory.
 

--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ Layered bottom-up. Each layer only depends on layers below it; siblings on the s
 
 - Three-lane retrieval (BM25 + vector + entity), fused via **Reciprocal Rank Fusion** (K=60), then re-weighted by entity-overlap boost, supersede decay, and time decay.
 - Predicate alias normalisation so "favourite color" and "favorite colour" hit the same memory.
-- Pluggable `retrieval.Index` backend — bring your own vector store; the in-tree implementation is in-memory.
+- Pluggable `retrieval.Index` backend — `sdk/retrieval/memory` (in-memory), `sdkx/retrieval/sqlite` (SQLite), and `sdkx/retrieval/postgres` (Postgres + pgvector) ship in-tree; bring your own by implementing `retrieval.Index`.
 
 ### Streaming, durable, resumable (`sdk/engine`)
 


### PR DESCRIPTION
## Summary

Follow-up correction to PR #67. After deeper code review, the previous \"RRF was an exaggeration\" rewrite was itself wrong.

## What I missed

\`sdk/recall.New()\` constructs its retrieval pipeline via \`sdk/retrieval/pipeline.LTM()\`, which canonically uses:

\`\`\`go
// sdk/retrieval/pipeline/factory.go
MultiRetrieve{ BM25, Vector, Entity },
RRFFusion{K: 60},               // ← this IS Reciprocal Rank Fusion
EntityBoost{Boost: 0.4},
ScoreThreshold{...},
SupersededDecay{...},
TimeDecay{...},
Limit{...},
\`\`\`

\`RRFFusion\` (defined in \`sdk/retrieval/pipeline/stages_fusion.go\`) is the standard \`1 / (k + rank)\` fusion. EntityBoost is a **post-fusion re-rank signal**, not a replacement for RRF.

## Fix

Restored the RRF mention and made it more precise: three-lane retrieval (BM25 + vector + entity) → RRF → entity boost / supersede decay / time decay → limit.

## Test plan

- [x] \`grep -n RRFFusion sdk/retrieval/pipeline/factory.go\` confirms it sits in both \`Default()\` and \`LTM()\`
- [x] Re-read README highlights section in rendered form

Made with [Cursor](https://cursor.com)