### PR TITLE
docs: add CHANGELOG and SECURITY policy, tweak README diagram

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,10 @@
 # ── Root documentation ──
 !README.md
 !LICENSE
+!CHANGELOG.md
+!SECURITY.md
+!CONTRIBUTING.md
+!CODE_OF_CONDUCT.md
 
 # ── Go source ──
 !go.mod

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,63 @@
+# Changelog
+
+All notable changes to this repository are documented here. The format is based
+on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and the project
+loosely follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html) on a
+per-module basis.
+
+FlowCraft is a multi-module monorepo. Each module is released independently
+with its own tag prefix (e.g. `sdk/vX.Y.Z`, `vessel/vX.Y.Z`,
+`vesseld/vX.Y.Z`). Per-release artifacts and notes also live on the
+[GitHub Releases](https://github.com/GizClaw/flowcraft/releases) page.
+
+## [Unreleased]
+
+### Added
+- Top-level `README.md`, `CHANGELOG.md`, and `SECURITY.md`.
+
+---
+
+## `vesseld/v0.1.0-rc.1` — 2026-05-07
+
+First release candidate of the `vesseld` orchestration daemon.
+
+### Added
+- Declarative YAML configuration for vessels, agents, LLM clients, and rate
+  limiters.
+- HTTP control plane: `/v1/vessels/{id}/call`, `/submit`, `/logs` (SSE),
+  `/v1/runs` (paginated), `/metrics` (Prometheus text exposition).
+- Multi-vessel fleet supervision with per-vessel concurrency gates.
+- Cross-platform release artifacts via `release-vesseld.yml`.
+
+## `vessel/v0.1.0-rc.2` — 2026-05-07
+
+### Added
+- `Handle.OnTerminate` synchronous lifecycle hook for ordered termination
+  side-effects (run registry, concurrency gate release, etc.).
+
+## `vessel/v0.1.0-rc.1` — 2026-05-07
+
+First release candidate of the `vessel` runtime: in-process Captain managing
+agents, shared memory, engines, supervision, and probes (token-budget,
+tool-reachable, custom).
+
+## `sdk/v0.2.7` and earlier
+
+See git history under `sdk/v*` tags. Highlights:
+- `sdk/agent` — agent orchestration with observers and deciders.
+- `sdk/graph` — declarative DAG executor.
+- `sdk/engine` — execution primitives (Board, Run, Host, Interrupt,
+  Checkpoint, Subject).
+- `sdk/recall` — long-term memory with hybrid BM25 + vector + entity
+  retrieval, RRF fusion, and entity-boost / time-decay reranking.
+- `sdk/history`, `sdk/knowledge`, `sdk/llm`, `sdk/event`, `sdk/model`,
+  `sdk/tool`, `sdk/kanban`.
+
+## `sdkx/v0.2.5` and earlier
+
+Provider implementations: OpenAI, Anthropic, Google, OpenAI-compatible
+runtimes; SQLite and Postgres+pgvector backends for `sdk/retrieval`.
+
+## `voice/v0.2.0`
+
+Voice pipeline: STT → LLM → TTS with VAD and WebRTC transport.

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ Layered bottom-up. Each layer only depends on layers below it; siblings on the s
          │   (daemon)  │                            │
          └──────┬──────┘                            │
                 │ composes vessel + sdkx            │
-   ┌────────────┼─────────────────┐          ┌─────▼──────┐
+   ┌────────────┼─────────────────┐          ┌──────▼─────┐
    │     ┌──────▼───────┐  ┌──────▼──────┐   │   voice/   │  WebRTC
    │     │   vessel/    │  │    sdkx/    │   │ (pipeline) │
    │     │  (runtime)   │  │ (providers) │   └─────┬──────┘

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,60 @@
+# Security Policy
+
+## Supported Versions
+
+FlowCraft is a multi-module monorepo and is currently in pre-1.0 development.
+Security fixes are issued against the latest release of each module.
+
+| Module     | Supported tag stream |
+| ---------- | -------------------- |
+| `sdk`      | latest `sdk/v0.x`    |
+| `sdkx`     | latest `sdkx/v0.x`   |
+| `vessel`   | latest `vessel/v0.1.0-rc.x` |
+| `vesseld`  | latest `vesseld/v0.1.0-rc.x` |
+| `voice`    | latest `voice/v0.x`  |
+
+Older minor versions are not patched; please upgrade before reporting issues
+that only reproduce on outdated tags.
+
+## Reporting a Vulnerability
+
+**Please do not file public GitHub issues for security problems.**
+
+Use one of the following private channels:
+
+1. **GitHub Security Advisories** — preferred. Open a draft advisory at
+   <https://github.com/GizClaw/flowcraft/security/advisories/new>. This keeps
+   the report private and lets us coordinate a fix and CVE assignment with you.
+2. **Email** — `security@gizclaw.dev` (PGP key on request).
+
+Please include:
+
+- Affected module(s) and version/tag (e.g. `vesseld/v0.1.0-rc.1`).
+- A minimal reproduction (config, command, request, or code snippet).
+- Impact assessment (what a malicious actor could do).
+- Any suggested mitigation, if you have one.
+
+## Response Process
+
+- We acknowledge new reports within **3 business days**.
+- We aim to provide a triage assessment (severity, affected versions, ETA)
+  within **7 business days**.
+- For confirmed high-severity issues we coordinate a fix, a CVE (when
+  applicable), and a coordinated release window with the reporter. Reporters
+  are credited in the advisory unless they request otherwise.
+
+## Scope
+
+In scope:
+
+- Code in this repository (`sdk/`, `sdkx/`, `vessel/`, `cmd/vesseld/`,
+  `voice/`, `examples/`, `tests/`).
+- Default configurations shipped with `vesseld` and the example deployments.
+
+Out of scope:
+
+- Third-party LLM, STT, or TTS providers — please report those upstream.
+- Vulnerabilities that require an attacker to already control the host
+  running `vesseld` or the operator's developer machine.
+- Best-practice hardening suggestions without a concrete attack — those are
+  welcome as regular GitHub issues or pull requests.


### PR DESCRIPTION
## Summary

Adds the next batch of standard open-source governance docs and a small README polish:

- **CHANGELOG.md** — per-module release history (Keep a Changelog format), covering `sdk`, `sdkx`, `vessel`, `vesseld`, `voice`.
- **SECURITY.md** — private disclosure flow (GHSA + email), supported version table, response SLAs, scope.
- **.gitignore** — whitelist root governance docs (`CHANGELOG.md`, `SECURITY.md`, plus future `CONTRIBUTING.md` / `CODE_OF_CONDUCT.md`).
- **README.md** — minor architecture diagram alignment fix (user edit).

Follow-ups (separate PRs): `CONTRIBUTING.md`, ISSUE/PR templates, `dependabot.yml`, `.golangci.yml`, `CODE_OF_CONDUCT.md`.

## Test plan

- [x] `git diff` reviewed
- [ ] CI green

Made with [Cursor](https://cursor.com)