### PR TITLE
chore(examples/chatbot-with-recall): bump sdk to v0.2.7, drop replace

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,7 @@
 # ── Global excludes (override all allowed dirs) ──
 # Example: go build in examples/voice-pipeline produces ./voice-pipeline
 examples/voice-pipeline/voice-pipeline
+examples/chatbot-with-recall/chatbot-with-recall
 **/.DS_Store
 **/Thumbs.db
 **/*.exe

--- a/examples/chatbot-with-recall/go.mod
+++ b/examples/chatbot-with-recall/go.mod
@@ -2,7 +2,7 @@ module github.com/GizClaw/flowcraft/examples/chatbot-with-recall
 
 go 1.25.0
 
-require github.com/GizClaw/flowcraft/sdk v0.1.11
+require github.com/GizClaw/flowcraft/sdk v0.2.7
 
 require (
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
@@ -24,5 +24,3 @@ require (
 	golang.org/x/sync v0.19.0 // indirect
 	golang.org/x/sys v0.41.0 // indirect
 )
-
-replace github.com/GizClaw/flowcraft/sdk => ../../sdk

--- a/examples/chatbot-with-recall/go.sum
+++ b/examples/chatbot-with-recall/go.sum
@@ -1,3 +1,5 @@
+github.com/GizClaw/flowcraft/sdk v0.2.7 h1:J9nA8JPwR+gbDPSOVh1vas8/YT2bFvoJXd0dUGYoWiY=
+github.com/GizClaw/flowcraft/sdk v0.2.7/go.mod h1:ESQWkg/xVCc+2RIO7Lxkdp9lwW9U+u2q+lojvnRzK3Y=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=

--- a/tests/quality/knowledge/doc.go
+++ b/tests/quality/knowledge/doc.go
@@ -20,13 +20,14 @@
 //
 // Test layout:
 //
-//   - bm25_test.go        no external dependency; runs by default
-//   - helper_test.go      service builder + corpus loader
-//   - integration_test.go //go:build integration; requires
-//                         EMBEDDING_PROVIDER / EMBEDDING_API_KEY /
-//                         EMBEDDING_MODEL env vars to exercise the
-//                         vector + hybrid lanes against a live
-//                         embedding provider
+//   - bm25_test.go — no external dependency; runs by default.
+//   - helper_test.go — service builder + corpus loader.
+//   - integration_test.go — gated by //go:build integration.
+//
+// The integration suite exercises the vector + hybrid lanes against a
+// live embedding provider and therefore requires the EMBEDDING_PROVIDER,
+// EMBEDDING_API_KEY, and EMBEDDING_MODEL env vars (typically loaded from
+// a .env file at the repo root).
 //
 // Invocation:
 //


### PR DESCRIPTION
## Summary

- Bump `github.com/GizClaw/flowcraft/sdk` in `examples/chatbot-with-recall` from `v0.1.11` to `v0.2.7` and remove the local `replace` directive so the example mirrors a downstream consumer.
- Add the locally built `chatbot-with-recall` binary to `.gitignore`.
- Restructure `tests/quality/knowledge/doc.go` package comment so it survives `gofmt` without losing semantic grouping (column-aligned multi-line bullets were being normalised to a flat 4-space continuation).

No source changes were necessary in the example: `model.NewTextMessage` is unchanged across these SDK versions.

## Test plan

- [x] `GOWORK=off go mod tidy` in `examples/chatbot-with-recall/`
- [x] `GOWORK=off go build ./...`
- [x] `GOWORK=off go vet ./...`
- [x] `GOWORK=off go run .` — all 4 scripted turns produce the expected output (incl. cross-turn recall of the "dark mode" preference)
- [x] `gofmt -w tests/quality/knowledge/doc.go` is idempotent on the new wording

Made with [Cursor](https://cursor.com)