### PR TITLE
feat(llm): add image/audio output caps, ImageGenOptions, public OneChunkStream

### DIFF
--- a/sdk/llm/capability.go
+++ b/sdk/llm/capability.go
@@ -45,6 +45,17 @@ const (
 	CapVision Capability = "vision"
 	CapAudio  Capability = "audio"
 	CapFile   Capability = "file"
+
+	// Output modality caps — these advertise non-text *response*
+	// modalities. Disabled is the conservative default for chat
+	// completion models; image-generation / audio-generation
+	// providers enable them. The caps middleware does not currently
+	// enforce these on the response side (providers populate the
+	// response Parts directly), but [LLMResolver] uses them when
+	// matching policy requirements such as "this slot needs an
+	// image-output model" via [WithPolicyCaps].
+	CapImageOutput Capability = "image_output"
+	CapAudioOutput Capability = "audio_output"
 )
 
 // ModelCaps declares which capabilities a model does not support.

--- a/sdk/llm/onechunk.go
+++ b/sdk/llm/onechunk.go
@@ -1,0 +1,57 @@
+package llm
+
+import "github.com/GizClaw/flowcraft/sdk/model"
+
+// NewOneChunkStream wraps a completed Generate result as a
+// [StreamMessage] that yields exactly one chunk and then ends. It is
+// the canonical adapter helper for synchronous-only providers (image
+// generation, audio generation, providers without native streaming)
+// that still need to satisfy the [LLM.GenerateStream] contract.
+//
+// It is also the downgrade target used by [WithCaps] when CapStreaming
+// is disabled — see (*capsLLM).GenerateStream.
+//
+// Semantics:
+//   - First Next() returns true; Current() yields a [model.StreamChunk]
+//     synthesised from the message (Role + concatenated text +
+//     ToolCalls + FinishReason="stop"). Non-text Parts (image / audio /
+//     file) are NOT replayed in the chunk because [model.StreamChunk]
+//     is text-oriented; callers needing the full multimodal payload
+//     read [StreamMessage.Message] after iteration completes.
+//   - Second Next() returns false. Err() returns nil.
+//   - Close() is a no-op and idempotent.
+//   - Message() returns the original message; Usage() returns the
+//     captured usage.
+func NewOneChunkStream(msg Message, usage TokenUsage) StreamMessage {
+	return &oneChunkStream{
+		msg:   msg,
+		usage: model.Usage{InputTokens: usage.InputTokens, OutputTokens: usage.OutputTokens},
+	}
+}
+
+type oneChunkStream struct {
+	msg     Message
+	usage   model.Usage
+	emitted bool
+	cur     model.StreamChunk
+}
+
+func (s *oneChunkStream) Next() bool {
+	if s.emitted {
+		return false
+	}
+	s.cur = model.StreamChunk{
+		Role:         s.msg.Role,
+		Content:      s.msg.Content(),
+		ToolCalls:    s.msg.ToolCalls(),
+		FinishReason: "stop",
+	}
+	s.emitted = true
+	return true
+}
+
+func (s *oneChunkStream) Current() model.StreamChunk { return s.cur }
+func (s *oneChunkStream) Err() error                 { return nil }
+func (s *oneChunkStream) Close() error               { return nil }
+func (s *oneChunkStream) Message() Message           { return s.msg }
+func (s *oneChunkStream) Usage() model.Usage         { return s.usage }

--- a/sdk/llm/onechunk_test.go
+++ b/sdk/llm/onechunk_test.go
@@ -1,0 +1,94 @@
+package llm
+
+import (
+	"testing"
+
+	"github.com/GizClaw/flowcraft/sdk/model"
+)
+
+func TestOneChunkStream_TextMessage(t *testing.T) {
+	msg := NewTextMessage(RoleAssistant, "hello world")
+	usage := TokenUsage{InputTokens: 7, OutputTokens: 3}
+
+	stream := NewOneChunkStream(msg, usage)
+
+	if !stream.Next() {
+		t.Fatal("first Next() should return true")
+	}
+	cur := stream.Current()
+	if cur.Role != RoleAssistant {
+		t.Errorf("Current().Role = %q, want assistant", cur.Role)
+	}
+	if cur.Content != "hello world" {
+		t.Errorf("Current().Content = %q", cur.Content)
+	}
+	if cur.FinishReason != "stop" {
+		t.Errorf("Current().FinishReason = %q, want stop", cur.FinishReason)
+	}
+
+	if stream.Next() {
+		t.Fatal("second Next() should return false")
+	}
+	if err := stream.Err(); err != nil {
+		t.Errorf("Err() = %v", err)
+	}
+	if got := stream.Message(); got.Content() != "hello world" {
+		t.Errorf("Message().Content() = %q", got.Content())
+	}
+	if u := stream.Usage(); u.InputTokens != 7 || u.OutputTokens != 3 {
+		t.Errorf("Usage = %+v", u)
+	}
+	if err := stream.Close(); err != nil {
+		t.Errorf("Close() = %v", err)
+	}
+	// Close is idempotent.
+	if err := stream.Close(); err != nil {
+		t.Errorf("second Close() = %v", err)
+	}
+}
+
+func TestOneChunkStream_ToolCallsReplayed(t *testing.T) {
+	msg := NewToolCallMessage([]ToolCall{
+		{ID: "c1", Name: "search", Arguments: `{"q":"x"}`},
+		{ID: "c2", Name: "fetch", Arguments: `{}`},
+	})
+	stream := NewOneChunkStream(msg, TokenUsage{})
+
+	if !stream.Next() {
+		t.Fatal("Next() = false")
+	}
+	cur := stream.Current()
+	if len(cur.ToolCalls) != 2 {
+		t.Fatalf("ToolCalls = %d, want 2", len(cur.ToolCalls))
+	}
+	if cur.ToolCalls[0].Name != "search" || cur.ToolCalls[1].Name != "fetch" {
+		t.Errorf("tool call order/name lost: %+v", cur.ToolCalls)
+	}
+}
+
+func TestOneChunkStream_NonTextPartsAreInMessageNotChunk(t *testing.T) {
+	// Multimodal output: chunk only carries text concat (empty here);
+	// callers must read Message() for image parts.
+	msg := Message{
+		Role: RoleAssistant,
+		Parts: []model.Part{
+			{Type: model.PartImage, Image: &model.MediaRef{URL: "https://cdn/x.png"}},
+			{Type: model.PartText, Text: "caption"},
+		},
+	}
+	stream := NewOneChunkStream(msg, TokenUsage{})
+
+	stream.Next()
+	cur := stream.Current()
+	if cur.Content != "caption" {
+		t.Errorf("Current().Content = %q, want only the text part replayed", cur.Content)
+	}
+
+	finalMsg := stream.Message()
+	if len(finalMsg.Parts) != 2 {
+		t.Fatalf("Message().Parts = %d, want 2", len(finalMsg.Parts))
+	}
+	if finalMsg.Parts[0].Image == nil || finalMsg.Parts[0].Image.URL != "https://cdn/x.png" {
+		t.Errorf("image part not preserved in final Message: %+v", finalMsg.Parts[0])
+	}
+}

--- a/sdk/llm/option.go
+++ b/sdk/llm/option.go
@@ -30,9 +30,47 @@ type GenerateOptions struct {
 	// unsupported providers simply ignore the field.
 	Thinking *bool
 
+	// ImageGen carries image-generation-specific options. Only honored
+	// by providers that advertise [CapImageOutput]; chat-only
+	// providers ignore the field.
+	ImageGen *ImageGenOptions
+
 	// Extra carries provider-specific parameters as key-value pairs.
 	// Providers read the keys they care about and ignore the rest.
 	Extra map[string]any
+}
+
+// ResponseFormat selects how generated images are returned.
+type ResponseFormat string
+
+const (
+	// ResponseFormatURL returns short-lived asset URLs (default for
+	// most providers; URLs typically expire within 24h).
+	ResponseFormatURL ResponseFormat = "url"
+	// ResponseFormatBase64 inlines image bytes as base64. Useful for
+	// air-gapped pipelines that cannot reach the provider's CDN.
+	ResponseFormatBase64 ResponseFormat = "base64"
+)
+
+// ImageGenOptions configures image generation calls. All fields are
+// optional; providers fall back to their own defaults when a field is
+// the zero value. Provider-specific knobs go through [GenerateOptions.Extra].
+type ImageGenOptions struct {
+	// AspectRatio in "W:H" form, e.g. "1:1", "16:9". Mutually
+	// exclusive with Width/Height on most providers.
+	AspectRatio string
+	// Width / Height in pixels. Providers may quantise to their own
+	// step (MiniMax: divisible by 8, range [512, 2048]).
+	Width  int
+	Height int
+	// N is the number of images to generate. Zero means "provider
+	// default" (typically 1).
+	N int
+	// Seed makes generation reproducible when non-nil and supported.
+	Seed *int64
+	// ResponseFormat selects URL vs base64 delivery. Empty string
+	// means provider default.
+	ResponseFormat ResponseFormat
 }
 
 // ToolChoiceType specifies how the model selects tools.
@@ -122,6 +160,12 @@ func WithToolChoiceSpecific(name string) GenerateOption {
 
 func WithThinking(on bool) GenerateOption {
 	return func(o *GenerateOptions) { o.Thinking = &on }
+}
+
+// WithImageGen attaches image-generation options. Providers that do
+// not advertise [CapImageOutput] ignore the field.
+func WithImageGen(opts ImageGenOptions) GenerateOption {
+	return func(o *GenerateOptions) { o.ImageGen = &opts }
 }
 
 func WithExtra(key string, value any) GenerateOption {

--- a/sdk/llm/with_caps.go
+++ b/sdk/llm/with_caps.go
@@ -55,7 +55,7 @@ func (c *capsLLM) GenerateStream(ctx context.Context, msgs []Message, opts ...Ge
 		if err != nil {
 			return nil, err
 		}
-		return newOneChunkStream(msg, usage), nil
+		return NewOneChunkStream(msg, usage), nil
 	}
 	return c.inner.GenerateStream(ctx, msgs, c.filtered(ctx, opts)...)
 }
@@ -313,54 +313,3 @@ func stripParallelToolExtras(ctx context.Context, o *GenerateOptions) {
 		"llm: dropping parallel-tool extras — model does not support parallel tool calls",
 		otellog.String("dropped_keys", strings.Join(keys, ",")))
 }
-
-// ---------------------------------------------------------------------------
-// oneChunkStream — streaming downgrade target used by WithCaps when
-// CapStreaming is disabled. Wraps a single completed Generate result
-// as a StreamMessage that yields exactly one chunk and then ends, so
-// the caller's GenerateStream loop still gets a uniform iterator
-// interface.
-//
-// Semantics:
-//   - First Next() returns true; Current() yields a StreamChunk
-//     synthesised from the message (Role + concatenated text +
-//     ToolCalls + FinishReason="stop").
-//   - Second Next() returns false. Err() returns nil.
-//   - Message() returns the original message; Usage() returns the
-//     captured usage.
-//   - Close() is a no-op and idempotent.
-// ---------------------------------------------------------------------------
-
-func newOneChunkStream(msg Message, usage TokenUsage) *oneChunkStream {
-	return &oneChunkStream{
-		msg:   msg,
-		usage: model.Usage{InputTokens: usage.InputTokens, OutputTokens: usage.OutputTokens},
-	}
-}
-
-type oneChunkStream struct {
-	msg     Message
-	usage   model.Usage
-	emitted bool
-	cur     model.StreamChunk
-}
-
-func (s *oneChunkStream) Next() bool {
-	if s.emitted {
-		return false
-	}
-	s.cur = model.StreamChunk{
-		Role:         s.msg.Role,
-		Content:      s.msg.Content(),
-		ToolCalls:    s.msg.ToolCalls(),
-		FinishReason: "stop",
-	}
-	s.emitted = true
-	return true
-}
-
-func (s *oneChunkStream) Current() model.StreamChunk { return s.cur }
-func (s *oneChunkStream) Err() error                 { return nil }
-func (s *oneChunkStream) Close() error               { return nil }
-func (s *oneChunkStream) Message() Message           { return s.msg }
-func (s *oneChunkStream) Usage() model.Usage         { return s.usage }


### PR DESCRIPTION
## Summary

Extends `sdk/llm` with the primitives needed by upcoming
image-generation adapters in `sdkx` (MiniMax / Seedream /
Qwen-Image), without coupling `sdk/llm` to any specific provider.

- **New capabilities** `CapImageOutput` / `CapAudioOutput` so output
  modalities are declarable in the blacklist-based `ModelCaps`
  matrix. Existing chat-only catalogs will get these disabled in a
  follow-up `sdkx` PR.
- **`ImageGenOptions` + `WithImageGen()`** carry size / aspect ratio
  / N / seed / response-format knobs through
  `llm.GenerateOptions`.
- **`NewOneChunkStream`** extracts the previously-private
  `oneChunkStream` helper from `with_caps.go` so synchronous-only
  adapters can satisfy `llm.StreamMessage` with a single shared
  implementation. `with_caps.go` now delegates to the public
  helper.

## Why this PR exists

Three image-generation providers are about to land in `sdkx`. They
all need:

1. A way to declare image-output capability without inventing a
   parallel `sdk/image` interface.
2. A typed channel for image-specific knobs (size etc.) that the
   text-oriented `LLM` interface lacks.
3. A canonical wrapper to expose synchronous image APIs as a
   single-chunk stream so `llm.StreamMessage` callers don't break.

Keeping these in `sdk/llm` (rather than copy-pasting per adapter)
makes the matrix consistent and unblocks sdkx.

## Test plan

- [x] `go test ./sdk/llm/... -count=1 -race` — covers the new
      `onechunk_test.go` (text, tool calls, multimodal parts) and
      the existing `with_caps_test.go` which now exercises the
      public helper via the streaming-downgrade path.
- [x] `go vet ./sdk/...`

## Follow-ups

- `sdkx`: catalog updates (disable new caps on chat models) + the
  three image adapters that consume `ImageGenOptions` and
  `NewOneChunkStream`.
- `tests/conformance`: live API integration tests for the image
  providers (gated on env vars).

Made with [Cursor](https://cursor.com)