### PR TITLE
feat(sdkx/llm): add image-generation adapters + align chat caps

### DIFF
--- a/sdkx/go.mod
+++ b/sdkx/go.mod
@@ -2,7 +2,7 @@ module github.com/GizClaw/flowcraft/sdkx
 
 go 1.25.0
 
-require github.com/GizClaw/flowcraft/sdk v0.2.6
+require github.com/GizClaw/flowcraft/sdk v0.2.8
 
 require (
 	github.com/PuerkitoBio/goquery v1.11.0

--- a/sdkx/go.sum
+++ b/sdkx/go.sum
@@ -8,8 +8,8 @@ github.com/Azure/azure-sdk-for-go/sdk/internal v1.10.0/go.mod h1:iZDifYGJTIgIIkY
 github.com/AzureAD/microsoft-authentication-library-for-go v1.2.2 h1:XHOnouVk1mxXfQidrMEnLlPk9UMeRtyBTnEFtxkV0kU=
 github.com/AzureAD/microsoft-authentication-library-for-go v1.2.2/go.mod h1:wP83P5OoQ5p6ip3ScPr0BAq0BvuPAvacpEuSzyouqAI=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
-github.com/GizClaw/flowcraft/sdk v0.2.6 h1:ApKV3jsh/7YOLLugpLIw5eB0atSZFdujdmbVziJ4Qq4=
-github.com/GizClaw/flowcraft/sdk v0.2.6/go.mod h1:ESQWkg/xVCc+2RIO7Lxkdp9lwW9U+u2q+lojvnRzK3Y=
+github.com/GizClaw/flowcraft/sdk v0.2.8 h1:8Xq0oYd396lMajj/k0EQ6mbqZNXsVht2/r2SqZ/C83k=
+github.com/GizClaw/flowcraft/sdk v0.2.8/go.mod h1:ESQWkg/xVCc+2RIO7Lxkdp9lwW9U+u2q+lojvnRzK3Y=
 github.com/PuerkitoBio/goquery v1.11.0 h1:jZ7pwMQXIITcUXNH83LLk+txlaEy6NVOfTuP43xxfqw=
 github.com/PuerkitoBio/goquery v1.11.0/go.mod h1:wQHgxUOU3JGuj3oD/QFfxUdlzW6xPHfqyHre6VMY4DQ=
 github.com/andybalholm/cascadia v1.3.3 h1:AG2YHrzJIm4BZ19iwJ/DAua6Btl3IwJX+VI4kktS1LM=

--- a/sdkx/llm/anthropic/anthropic.go
+++ b/sdkx/llm/anthropic/anthropic.go
@@ -58,7 +58,16 @@ func init() {
 	// Per platform.claude.com/docs/en/about-claude/models/overview
 	// (read 2026-04-30) every current Claude SKU supports vision and
 	// tool use, so only CapJSONSchema is disabled per family.
-	noJSONSchema := llm.DisabledCaps(llm.CapJSONSchema)
+	//
+	// Output modality: text only. Claude has no native image or
+	// audio output across the 4.x family — vision is input-only per
+	// docs.anthropic.com/en/docs/vision (analyse / understand,
+	// not generate). Disable both output modality caps so policy
+	// matching does not route image-output slots here.
+	textOnlyOutput := llm.DisabledCaps(
+		llm.CapJSONSchema,
+		llm.CapImageOutput, llm.CapAudioOutput,
+	)
 
 	llm.RegisterProviderModels("anthropic", []llm.ModelInfo{
 		{
@@ -67,7 +76,7 @@ func init() {
 			Label: "Claude Opus 4.7",
 			Name:  "claude-opus-4-7",
 			Spec: llm.ModelSpec{
-				Caps: noJSONSchema,
+				Caps: textOnlyOutput,
 				Limits: llm.ModelLimits{
 					MaxContextTokens: 1_000_000,
 					MaxOutputTokens:  128_000,
@@ -80,7 +89,7 @@ func init() {
 			Label: "Claude Opus 4.6",
 			Name:  "claude-opus-4-6",
 			Spec: llm.ModelSpec{
-				Caps: noJSONSchema,
+				Caps: textOnlyOutput,
 				Limits: llm.ModelLimits{
 					MaxContextTokens: 1_000_000,
 					MaxOutputTokens:  128_000,
@@ -93,7 +102,7 @@ func init() {
 			Label: "Claude Sonnet 4.6",
 			Name:  "claude-sonnet-4-6",
 			Spec: llm.ModelSpec{
-				Caps: noJSONSchema,
+				Caps: textOnlyOutput,
 				Limits: llm.ModelLimits{
 					MaxContextTokens: 1_000_000,
 					MaxOutputTokens:  64_000,
@@ -109,7 +118,7 @@ func init() {
 			Label: "Claude Haiku 4.5",
 			Name:  "claude-haiku-4-5-20251001",
 			Spec: llm.ModelSpec{
-				Caps: noJSONSchema,
+				Caps: textOnlyOutput,
 				Limits: llm.ModelLimits{
 					MaxContextTokens: 200_000,
 					MaxOutputTokens:  64_000,

--- a/sdkx/llm/bytedance/bytedance.go
+++ b/sdkx/llm/bytedance/bytedance.go
@@ -47,12 +47,23 @@ func init() {
 	// 32K max output cap per the unified family doc. Vision and tool
 	// use are first-class. The Volcengine Ark API is OpenAI-style and
 	// supports streaming + structured output natively, so no
-	// negative caps need declaring there.
+	// negative input/protocol caps need declaring.
+	//
+	// Output modality: text only. Image generation lives in
+	// dedicated Doubao image SKUs and audio/video in Seedance 2.0 —
+	// separate adapters not catalogued here. Disable the matching
+	// output modality caps so policy matching does not route
+	// image-output / audio-output slots onto these chat models.
+	chatTextOutputOnly := llm.DisabledCaps(
+		llm.CapImageOutput, llm.CapAudioOutput,
+	)
+
 	llm.RegisterProviderModels("bytedance", []llm.ModelInfo{
 		{
 			Label: "Doubao Seed 2.0 Pro",
 			Name:  "doubao-seed-2-0-pro-260215",
 			Spec: llm.ModelSpec{
+				Caps: chatTextOutputOnly,
 				Limits: llm.ModelLimits{
 					MaxContextTokens: 256_000,
 					MaxOutputTokens:  32_000,
@@ -63,6 +74,7 @@ func init() {
 			Label: "Doubao Seed 2.0 Lite",
 			Name:  "doubao-seed-2-0-lite-260215",
 			Spec: llm.ModelSpec{
+				Caps: chatTextOutputOnly,
 				Limits: llm.ModelLimits{
 					MaxContextTokens: 256_000,
 					MaxOutputTokens:  32_000,
@@ -73,6 +85,7 @@ func init() {
 			Label: "Doubao Seed 2.0 Mini",
 			Name:  "doubao-seed-2-0-mini-260215",
 			Spec: llm.ModelSpec{
+				Caps: chatTextOutputOnly,
 				Limits: llm.ModelLimits{
 					MaxContextTokens: 256_000,
 					MaxOutputTokens:  32_000,
@@ -85,6 +98,9 @@ func init() {
 			// material we have on file; left unset.
 			Label: "Doubao Seed 1.8",
 			Name:  "doubao-seed-1-8-251228",
+			Spec: llm.ModelSpec{
+				Caps: chatTextOutputOnly,
+			},
 		},
 	})
 }

--- a/sdkx/llm/bytedance/image/doc.go
+++ b/sdkx/llm/bytedance/image/doc.go
@@ -1,0 +1,67 @@
+// Package image is the ByteDance Doubao-Seedream image-generation
+// adapter. It targets Volcengine Ark's POST /api/v3/images/generations
+// endpoint (see https://www.volcengine.com/docs/82379/1824121) and
+// exposes it through the standard sdk/llm.LLM interface so callers
+// can route image generation through the same resolver, fallback,
+// and credential-profile machinery as chat models.
+//
+// # Input mapping
+//
+// The adapter translates a [model.Message] list into a single
+// Seedream request:
+//
+//   - The last user message's text parts are concatenated into the prompt field.
+//   - All [model.PartImage] entries across user messages are forwarded as the image field.
+//   - System and assistant messages are dropped.
+//
+// Seedream recommends prompts ≤300 Chinese chars / 600 English words
+// but does not hard-fail on longer prompts. The image field is
+// serialized as a JSON string when there is exactly one reference
+// and as a JSON array when there are multiple; with zero references
+// the call degrades to text-to-image (still served by the same
+// endpoint).
+//
+// # Image options
+//
+// Image-specific knobs flow through [llm.GenerateOptions.ImageGen]:
+//
+//   - Width + Height map to size in "WxH" form.
+//   - N > 1 maps to sequential_image_generation = "auto" plus sequential_image_generation_options.max_images = N.
+//   - ResponseFormat maps to response_format ("url" or "b64_json").
+//
+// AspectRatio and Seed are ignored by the Seedream surface.
+//
+// # Provider extras
+//
+// Callers needing the "2K" / "3K" / "4K" preset path or the
+// watermark / optimize / web_search / output_format knobs pass them
+// via [llm.WithExtra]:
+//
+//   - "size" (string) overrides Width/Height-derived size.
+//   - "watermark" (bool) toggles the "AI生成" watermark.
+//   - "output_format" (string) "png" or "jpeg" (5.0-lite only).
+//   - "optimize_prompt_mode" (string) "standard" or "fast" (4.0 only).
+//   - "web_search" (bool) wraps {tools: [{type: "web_search"}]} (5.0-lite only).
+//
+// # Output mapping
+//
+// The response is parsed into a single assistant [model.Message]
+// whose Parts are [model.PartImage] entries (one per generated
+// image), preserving the URL or b64_json delivery format.
+//
+// # Streaming
+//
+// Seedream supports native server-side streaming via SSE, but the
+// stream chunks carry image payloads which the text-oriented
+// [llm.StreamChunk] cannot express. This adapter therefore wraps
+// Generate via [llm.NewOneChunkStream] — the call is still
+// synchronous from the caller's perspective. Native streaming can
+// be added later by extending the StreamChunk envelope.
+//
+// # Authentication
+//
+// Bearer token in the Authorization header. The provider key is
+// "bytedance-image" so existing "bytedance" chat credentials remain
+// independent (the Volc Ark account is the same but the rate-limit
+// pools are tracked separately upstream).
+package image

--- a/sdkx/llm/bytedance/image/image.go
+++ b/sdkx/llm/bytedance/image/image.go
@@ -1,0 +1,445 @@
+package image
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/GizClaw/flowcraft/sdk/errdefs"
+	"github.com/GizClaw/flowcraft/sdk/llm"
+	"github.com/GizClaw/flowcraft/sdk/model"
+)
+
+const (
+	defaultBaseURL = "https://ark.cn-beijing.volces.com"
+	imageGenPath   = "/api/v3/images/generations"
+	defaultModel   = "doubao-seedream-5-0-260128"
+	defaultTimeout = 120 * time.Second
+
+	// providerKey is the registry key. Kept distinct from the
+	// "bytedance" chat provider so credentials and rate-limit
+	// pools can be configured independently — even when both use
+	// the same Volc Ark API key, they hit different SKUs.
+	providerKey = "bytedance-image"
+
+	// maxRefsPlusOutputs caps refs+outputs at 15 per Seedream's
+	// documented limit ("输入的参考图数量 + 最终生成的图片数量 ≤ 15").
+	maxRefsPlusOutputs = 15
+)
+
+func init() {
+	llm.RegisterProvider(providerKey, func(model string, config map[string]any) (llm.LLM, error) {
+		apiKey, _ := config["api_key"].(string)
+		baseURL, _ := config["base_url"].(string)
+		return New(model, apiKey, baseURL)
+	})
+
+	// Catalog reflects Seedream's image-generation lineup as of
+	// 2026-04-30. Sources:
+	//   - https://www.volcengine.com/docs/82379/1824121
+	//   - https://console.volcengine.com/ark/region:ark+cn-beijing/model/detail
+	//
+	// Caps: every chat-completion knob is disabled (Seedream is a
+	// dedicated image-gen surface that does not honour temperature,
+	// tools-from-LLM, JSON mode, system prompts, etc.). Streaming
+	// IS supported natively by the endpoint, but the StreamMessage
+	// contract (text-oriented StreamChunk) cannot express image
+	// payloads, so we disable CapStreaming and rely on the caps
+	// middleware's Generate→one-chunk downgrade — same trade-off
+	// as the minimax-image adapter.
+	imageOnly := llm.DisabledCaps(
+		llm.CapTemperature, llm.CapTopP, llm.CapTopK, llm.CapMaxTokens,
+		llm.CapStopWords, llm.CapFrequencyPenalty, llm.CapPresencePenalty,
+		llm.CapThinking,
+		llm.CapJSONMode, llm.CapJSONSchema,
+		llm.CapTools, llm.CapToolChoice, llm.CapParallelTools,
+		llm.CapStreaming, llm.CapSystemPrompt,
+		llm.CapAudio, llm.CapFile,
+		llm.CapAudioOutput,
+		// CapVision and CapImageOutput remain ENABLED.
+	)
+
+	llm.RegisterProviderModels(providerKey, []llm.ModelInfo{
+		// --- Seedream 5.0 lite (current default) ---------------------
+		// Two model IDs route to the same SKU per the upstream doc:
+		// "doubao-seedream-5-0-260128 (同时支持：doubao-seedream-5-0-lite-260128)".
+		// Both are registered so callers can pin either.
+		{
+			Label: "Doubao Seedream 5.0 lite",
+			Name:  "doubao-seedream-5-0-260128",
+			Spec:  llm.ModelSpec{Caps: imageOnly},
+		},
+		{
+			Label: "Doubao Seedream 5.0 lite (alias)",
+			Name:  "doubao-seedream-5-0-lite-260128",
+			Spec:  llm.ModelSpec{Caps: imageOnly},
+		},
+		// --- Seedream 4.5 -------------------------------------------
+		{
+			Label: "Doubao Seedream 4.5",
+			Name:  "doubao-seedream-4-5-251128",
+			Spec:  llm.ModelSpec{Caps: imageOnly},
+		},
+		// --- Seedream 4.0 -------------------------------------------
+		// Only SKU that supports the optimize_prompt_options.mode=fast
+		// fast-path; expose via llm.WithExtra("optimize_prompt_mode",
+		// "fast") on a per-call basis.
+		{
+			Label: "Doubao Seedream 4.0",
+			Name:  "doubao-seedream-4-0-250828",
+			Spec:  llm.ModelSpec{Caps: imageOnly},
+		},
+	})
+}
+
+// LLM is the Seedream image-generation adapter. It implements
+// [llm.LLM] so callers can route image generation through the same
+// resolver and fallback machinery as chat models.
+type LLM struct {
+	model   string
+	apiKey  string
+	baseURL string
+	client  *http.Client
+}
+
+// Option configures the adapter at construction time.
+type Option func(*LLM)
+
+// WithHTTPClient overrides the default *http.Client (120s timeout).
+// Useful for tests and for plugging in OTel/transport middleware.
+func WithHTTPClient(c *http.Client) Option {
+	return func(l *LLM) {
+		if c != nil {
+			l.client = c
+		}
+	}
+}
+
+// New builds an adapter pointing at the Seedream endpoint. An empty
+// model defaults to "doubao-seedream-5-0-260128"; an empty baseURL
+// defaults to https://ark.cn-beijing.volces.com.
+func New(modelName, apiKey, baseURL string, opts ...Option) (*LLM, error) {
+	if apiKey == "" {
+		return nil, errdefs.Validation(errdefs.New("bytedance-image: api_key required"))
+	}
+	if modelName == "" {
+		modelName = defaultModel
+	}
+	if baseURL == "" {
+		baseURL = defaultBaseURL
+	}
+	l := &LLM{
+		model:   modelName,
+		apiKey:  apiKey,
+		baseURL: strings.TrimRight(baseURL, "/"),
+		client:  &http.Client{Timeout: defaultTimeout},
+	}
+	for _, opt := range opts {
+		opt(l)
+	}
+	return l, nil
+}
+
+// --- llm.LLM ----------------------------------------------------------
+
+// Generate calls Seedream /api/v3/images/generations and returns an
+// assistant message whose Parts are PartImage entries (one per
+// generated image). TokenUsage is populated from the response when
+// present; Seedream reports image-count usage rather than token
+// counts.
+func (l *LLM) Generate(ctx context.Context, messages []llm.Message, opts ...llm.GenerateOption) (llm.Message, llm.TokenUsage, error) {
+	o := llm.ApplyOptions(opts...)
+	prompt, refs := extractPromptAndRefs(messages)
+	if prompt == "" {
+		return llm.Message{}, llm.TokenUsage{}, errdefs.Validation(errdefs.New("bytedance-image: empty prompt (no text parts in user messages)"))
+	}
+
+	body, err := buildRequest(l.model, prompt, refs, o.ImageGen, o.Extra)
+	if err != nil {
+		return llm.Message{}, llm.TokenUsage{}, err
+	}
+	resp, err := l.do(ctx, body)
+	if err != nil {
+		return llm.Message{}, llm.TokenUsage{}, err
+	}
+	parts, err := imagesToParts(resp.Data, body.OutputFormat)
+	if err != nil {
+		return llm.Message{}, llm.TokenUsage{}, err
+	}
+	if len(parts) == 0 {
+		return llm.Message{}, llm.TokenUsage{}, errdefs.Internal(errdefs.New("bytedance-image: provider returned zero images"))
+	}
+	usage := llm.TokenUsage{Model: l.model}
+	if resp.Usage != nil {
+		usage.OutputTokens = int64(resp.Usage.GeneratedImages)
+	}
+	return llm.Message{Role: model.RoleAssistant, Parts: parts}, usage, nil
+}
+
+// GenerateStream wraps Generate via [llm.NewOneChunkStream]. Native
+// streaming on this endpoint emits image-bearing events that the
+// text-oriented [llm.StreamChunk] envelope cannot represent; see
+// package doc for rationale.
+func (l *LLM) GenerateStream(ctx context.Context, messages []llm.Message, opts ...llm.GenerateOption) (llm.StreamMessage, error) {
+	msg, usage, err := l.Generate(ctx, messages, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return llm.NewOneChunkStream(msg, usage), nil
+}
+
+// --- request / response wire shape -----------------------------------
+
+type apiRequest struct {
+	Model                            string        `json:"model"`
+	Prompt                           string        `json:"prompt"`
+	Image                            any           `json:"image,omitempty"` // string for 1, []string for >1
+	Size                             string        `json:"size,omitempty"`
+	OutputFormat                     string        `json:"output_format,omitempty"`
+	ResponseFormat                   string        `json:"response_format,omitempty"`
+	Watermark                        *bool         `json:"watermark,omitempty"`
+	SequentialImageGeneration        string        `json:"sequential_image_generation,omitempty"`
+	SequentialImageGenerationOptions *seqOpts      `json:"sequential_image_generation_options,omitempty"`
+	OptimizePromptOptions            *optimizeOpts `json:"optimize_prompt_options,omitempty"`
+	Tools                            []toolSpec    `json:"tools,omitempty"`
+}
+
+type seqOpts struct {
+	MaxImages int `json:"max_images"`
+}
+
+type optimizeOpts struct {
+	Mode string `json:"mode"`
+}
+
+type toolSpec struct {
+	Type string `json:"type"`
+}
+
+type apiResponse struct {
+	Model string         `json:"model,omitempty"`
+	Data  []responseItem `json:"data"`
+	Usage *apiUsage      `json:"usage,omitempty"`
+	Error *apiError      `json:"error,omitempty"`
+}
+
+type responseItem struct {
+	URL     string `json:"url,omitempty"`
+	B64JSON string `json:"b64_json,omitempty"`
+	Size    string `json:"size,omitempty"`
+}
+
+type apiUsage struct {
+	GeneratedImages int `json:"generated_images,omitempty"`
+}
+
+type apiError struct {
+	Code    string `json:"code,omitempty"`
+	Message string `json:"message,omitempty"`
+}
+
+func buildRequest(modelName, prompt string, refs []string, ig *llm.ImageGenOptions, extra map[string]any) (apiRequest, error) {
+	req := apiRequest{Model: modelName, Prompt: prompt}
+
+	switch len(refs) {
+	case 0:
+		// text-to-image
+	case 1:
+		req.Image = refs[0]
+	default:
+		req.Image = refs
+	}
+
+	if ig != nil {
+		// Size: pixel form takes priority. AspectRatio and Seed have
+		// no native Seedream knob; document and ignore.
+		if ig.Width > 0 && ig.Height > 0 {
+			req.Size = fmt.Sprintf("%dx%d", ig.Width, ig.Height)
+		}
+		switch ig.ResponseFormat {
+		case llm.ResponseFormatURL:
+			req.ResponseFormat = "url"
+		case llm.ResponseFormatBase64:
+			req.ResponseFormat = "b64_json"
+		}
+		if ig.N > 1 {
+			if ig.N+len(refs) > maxRefsPlusOutputs {
+				return req, errdefs.Validation(errdefs.Fmt("bytedance-image: refs(%d) + N(%d) exceeds Seedream cap of %d", len(refs), ig.N, maxRefsPlusOutputs))
+			}
+			req.SequentialImageGeneration = "auto"
+			req.SequentialImageGenerationOptions = &seqOpts{MaxImages: ig.N}
+		}
+	}
+
+	// Extra escape hatches for provider-specific knobs that don't
+	// belong on the public ImageGenOptions surface.
+	if v, ok := stringExtra(extra, "size"); ok && v != "" {
+		req.Size = v // overrides W/H-derived size
+	}
+	if v, ok := stringExtra(extra, "output_format"); ok && v != "" {
+		req.OutputFormat = v
+	}
+	if v, ok := boolExtra(extra, "watermark"); ok {
+		req.Watermark = &v
+	}
+	if v, ok := stringExtra(extra, "optimize_prompt_mode"); ok && v != "" {
+		req.OptimizePromptOptions = &optimizeOpts{Mode: v}
+	}
+	if v, ok := boolExtra(extra, "web_search"); ok && v {
+		req.Tools = append(req.Tools, toolSpec{Type: "web_search"})
+	}
+
+	return req, nil
+}
+
+func extractPromptAndRefs(messages []llm.Message) (prompt string, refs []string) {
+	var lastUserText strings.Builder
+	for _, m := range messages {
+		if m.Role != model.RoleUser {
+			continue
+		}
+		for _, p := range m.Parts {
+			switch p.Type {
+			case model.PartImage:
+				if p.Image != nil && p.Image.URL != "" {
+					refs = append(refs, p.Image.URL)
+				}
+			case model.PartText:
+				if lastUserText.Len() > 0 {
+					lastUserText.WriteString("\n")
+				}
+				lastUserText.WriteString(p.Text)
+			}
+		}
+	}
+	return strings.TrimSpace(lastUserText.String()), refs
+}
+
+func imagesToParts(items []responseItem, outputFormat string) ([]model.Part, error) {
+	mediaType := "image/jpeg" // Seedream default for 4.0 / 4.5
+	if strings.EqualFold(outputFormat, "png") {
+		mediaType = "image/png"
+	}
+	parts := make([]model.Part, 0, len(items))
+	for _, it := range items {
+		if it.URL != "" {
+			parts = append(parts, model.Part{Type: model.PartImage, Image: &model.MediaRef{URL: it.URL, MediaType: mediaType}})
+			continue
+		}
+		if it.B64JSON != "" {
+			parts = append(parts, model.Part{Type: model.PartImage, Image: &model.MediaRef{Base64: it.B64JSON, MediaType: mediaType}})
+		}
+	}
+	return parts, nil
+}
+
+func (l *LLM) do(ctx context.Context, req apiRequest) (*apiResponse, error) {
+	body, err := json.Marshal(req)
+	if err != nil {
+		return nil, errdefs.Internal(errdefs.Fmt("bytedance-image: marshal request: %w", err))
+	}
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, l.baseURL+imageGenPath, bytes.NewReader(body))
+	if err != nil {
+		return nil, errdefs.Internal(errdefs.Fmt("bytedance-image: build request: %w", err))
+	}
+	httpReq.Header.Set("Content-Type", "application/json")
+	httpReq.Header.Set("Authorization", "Bearer "+l.apiKey)
+
+	resp, err := l.client.Do(httpReq)
+	if err != nil {
+		return nil, errdefs.NotAvailable(errdefs.Fmt("bytedance-image: http call: %w", err))
+	}
+	defer resp.Body.Close()
+
+	raw, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, errdefs.Internal(errdefs.Fmt("bytedance-image: read body: %w", err))
+	}
+
+	switch {
+	case resp.StatusCode == http.StatusUnauthorized:
+		return nil, errdefs.Unauthorized(errdefs.Fmt("bytedance-image: 401: %s", truncate(string(raw), 200)))
+	case resp.StatusCode == http.StatusTooManyRequests:
+		return nil, errdefs.RateLimit(errdefs.Fmt("bytedance-image: 429: %s", truncate(string(raw), 200)))
+	case resp.StatusCode >= 500:
+		return nil, errdefs.NotAvailable(errdefs.Fmt("bytedance-image: %d: %s", resp.StatusCode, truncate(string(raw), 200)))
+	case resp.StatusCode >= 400:
+		return nil, errdefs.Validation(errdefs.Fmt("bytedance-image: %d: %s", resp.StatusCode, truncate(string(raw), 200)))
+	}
+
+	var out apiResponse
+	if err := json.Unmarshal(raw, &out); err != nil {
+		return nil, errdefs.Internal(errdefs.Fmt("bytedance-image: decode body: %w (raw=%s)", err, truncate(string(raw), 200)))
+	}
+	if out.Error != nil && out.Error.Code != "" {
+		return nil, mapAPIError(out.Error)
+	}
+	return &out, nil
+}
+
+// mapAPIError maps Volc Ark error codes to errdefs categories. The
+// Ark error envelope reuses the Volcengine "TopErrorCode" naming
+// convention; the cases below cover the documented ImageGenerations
+// failures (see /docs/82379/1330310 — model list and limits).
+func mapAPIError(e *apiError) error {
+	msg := fmt.Sprintf("bytedance-image: %s %s", e.Code, e.Message)
+	switch {
+	case strings.HasPrefix(e.Code, "AuthenticationError"),
+		strings.HasPrefix(e.Code, "InvalidAccessKey"),
+		strings.HasPrefix(e.Code, "MissingAuthHeader"):
+		return errdefs.Unauthorized(errdefs.New(msg))
+	case strings.HasPrefix(e.Code, "RateLimitExceeded"),
+		strings.HasPrefix(e.Code, "QuotaExceeded"):
+		return errdefs.RateLimit(errdefs.New(msg))
+	case strings.HasPrefix(e.Code, "InsufficientBalance"),
+		strings.HasPrefix(e.Code, "AccessDenied"):
+		return errdefs.Forbidden(errdefs.New(msg))
+	case strings.HasPrefix(e.Code, "InvalidParameter"),
+		strings.HasPrefix(e.Code, "InvalidRequest"),
+		strings.HasPrefix(e.Code, "ResourceNotFound"):
+		return errdefs.Validation(errdefs.New(msg))
+	case strings.HasPrefix(e.Code, "InternalServiceError"),
+		strings.HasPrefix(e.Code, "ServiceUnavailable"):
+		return errdefs.NotAvailable(errdefs.New(msg))
+	default:
+		return errdefs.Internal(errdefs.New(msg))
+	}
+}
+
+// --- helpers ---------------------------------------------------------
+
+func stringExtra(extra map[string]any, key string) (string, bool) {
+	if extra == nil {
+		return "", false
+	}
+	v, ok := extra[key]
+	if !ok {
+		return "", false
+	}
+	s, ok := v.(string)
+	return s, ok
+}
+
+func boolExtra(extra map[string]any, key string) (bool, bool) {
+	if extra == nil {
+		return false, false
+	}
+	v, ok := extra[key]
+	if !ok {
+		return false, false
+	}
+	b, ok := v.(bool)
+	return b, ok
+}
+
+func truncate(s string, n int) string {
+	if len(s) <= n {
+		return s
+	}
+	return s[:n] + "…"
+}

--- a/sdkx/llm/bytedance/image/image_test.go
+++ b/sdkx/llm/bytedance/image/image_test.go
@@ -1,0 +1,409 @@
+package image
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/GizClaw/flowcraft/sdk/errdefs"
+	"github.com/GizClaw/flowcraft/sdk/llm"
+	"github.com/GizClaw/flowcraft/sdk/model"
+)
+
+func newMockServer(t *testing.T, status int, body []byte, capture *apiRequest) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != imageGenPath {
+			t.Errorf("unexpected path %q", r.URL.Path)
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer test-key" {
+			t.Errorf("missing/incorrect Authorization header: %q", got)
+		}
+		if capture != nil {
+			raw, err := io.ReadAll(r.Body)
+			if err != nil {
+				t.Fatalf("read body: %v", err)
+			}
+			if err := json.Unmarshal(raw, capture); err != nil {
+				t.Fatalf("decode body: %v (raw=%s)", err, raw)
+			}
+		}
+		w.WriteHeader(status)
+		_, _ = w.Write(body)
+	}))
+}
+
+func TestNew_RequiresAPIKey(t *testing.T) {
+	_, err := New("doubao-seedream-5-0-260128", "", "")
+	if err == nil || !errdefs.IsValidation(err) {
+		t.Fatalf("expected validation error, got %v", err)
+	}
+}
+
+func TestGenerate_TextToImage_DefaultPath(t *testing.T) {
+	resp := apiResponse{
+		Data: []responseItem{{URL: "https://cdn/x.png", Size: "2048x2048"}},
+	}
+	body, _ := json.Marshal(resp)
+
+	var captured apiRequest
+	srv := newMockServer(t, http.StatusOK, body, &captured)
+	defer srv.Close()
+
+	l, err := New("doubao-seedream-5-0-260128", "test-key", srv.URL)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	out, _, err := l.Generate(context.Background(), []llm.Message{
+		llm.NewTextMessage(llm.RoleUser, "a fox in the snow"),
+	})
+	if err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+
+	if captured.Model != "doubao-seedream-5-0-260128" {
+		t.Errorf("model: %q", captured.Model)
+	}
+	if captured.Prompt != "a fox in the snow" {
+		t.Errorf("prompt: %q", captured.Prompt)
+	}
+	if captured.Image != nil {
+		t.Errorf("expected no image refs, got %+v", captured.Image)
+	}
+	if len(out.Parts) != 1 || out.Parts[0].Image == nil || out.Parts[0].Image.URL != "https://cdn/x.png" {
+		t.Fatalf("unexpected parts: %+v", out.Parts)
+	}
+}
+
+func TestGenerate_SingleReference_StringForm(t *testing.T) {
+	resp := apiResponse{Data: []responseItem{{URL: "https://cdn/out.png"}}}
+	body, _ := json.Marshal(resp)
+	var captured apiRequest
+	srv := newMockServer(t, http.StatusOK, body, &captured)
+	defer srv.Close()
+
+	l, _ := New("doubao-seedream-4-5-251128", "test-key", srv.URL)
+
+	msg := model.Message{
+		Role: model.RoleUser,
+		Parts: []model.Part{
+			{Type: model.PartImage, Image: &model.MediaRef{URL: "https://ref/a.png"}},
+			{Type: model.PartText, Text: "swap outfit"},
+		},
+	}
+	if _, _, err := l.Generate(context.Background(), []llm.Message{msg}); err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+
+	// Single ref → string form per upstream docs.
+	s, ok := captured.Image.(string)
+	if !ok {
+		t.Fatalf("expected string image, got %T (%+v)", captured.Image, captured.Image)
+	}
+	if s != "https://ref/a.png" {
+		t.Errorf("image: %q", s)
+	}
+}
+
+func TestGenerate_MultiReference_ArrayForm(t *testing.T) {
+	resp := apiResponse{Data: []responseItem{{URL: "https://cdn/out.png"}}}
+	body, _ := json.Marshal(resp)
+	var captured apiRequest
+	srv := newMockServer(t, http.StatusOK, body, &captured)
+	defer srv.Close()
+
+	l, _ := New("doubao-seedream-4-5-251128", "test-key", srv.URL)
+
+	msg := model.Message{
+		Role: model.RoleUser,
+		Parts: []model.Part{
+			{Type: model.PartImage, Image: &model.MediaRef{URL: "https://ref/a.png"}},
+			{Type: model.PartImage, Image: &model.MediaRef{URL: "https://ref/b.png"}},
+			{Type: model.PartText, Text: "merge them"},
+		},
+	}
+	if _, _, err := l.Generate(context.Background(), []llm.Message{msg}); err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+
+	arr, ok := captured.Image.([]any)
+	if !ok {
+		t.Fatalf("expected []any image, got %T (%+v)", captured.Image, captured.Image)
+	}
+	if len(arr) != 2 {
+		t.Fatalf("expected 2 refs, got %d", len(arr))
+	}
+}
+
+func TestGenerate_SequentialOptionsForN(t *testing.T) {
+	resp := apiResponse{
+		Data: []responseItem{
+			{URL: "https://cdn/1.png"},
+			{URL: "https://cdn/2.png"},
+			{URL: "https://cdn/3.png"},
+		},
+		Usage: &apiUsage{GeneratedImages: 3},
+	}
+	body, _ := json.Marshal(resp)
+	var captured apiRequest
+	srv := newMockServer(t, http.StatusOK, body, &captured)
+	defer srv.Close()
+
+	l, _ := New("doubao-seedream-5-0-260128", "test-key", srv.URL)
+
+	out, usage, err := l.Generate(context.Background(),
+		[]llm.Message{llm.NewTextMessage(llm.RoleUser, "story panels")},
+		llm.WithImageGen(llm.ImageGenOptions{N: 3, Width: 2048, Height: 2048}))
+	if err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+	if captured.SequentialImageGeneration != "auto" {
+		t.Errorf("sequential_image_generation: %q", captured.SequentialImageGeneration)
+	}
+	if captured.SequentialImageGenerationOptions == nil || captured.SequentialImageGenerationOptions.MaxImages != 3 {
+		t.Errorf("sequential options: %+v", captured.SequentialImageGenerationOptions)
+	}
+	if captured.Size != "2048x2048" {
+		t.Errorf("size: %q", captured.Size)
+	}
+	if len(out.Parts) != 3 {
+		t.Errorf("expected 3 parts, got %d", len(out.Parts))
+	}
+	if usage.OutputTokens != 3 || usage.Model == "" {
+		t.Errorf("usage: %+v", usage)
+	}
+}
+
+func TestGenerate_NCapEnforced(t *testing.T) {
+	l, _ := New("doubao-seedream-5-0-260128", "test-key", "https://invalid")
+	msgs := []llm.Message{{
+		Role: model.RoleUser,
+		Parts: []model.Part{
+			{Type: model.PartImage, Image: &model.MediaRef{URL: "https://ref/1.png"}},
+			{Type: model.PartImage, Image: &model.MediaRef{URL: "https://ref/2.png"}},
+			{Type: model.PartText, Text: "boom"},
+		},
+	}}
+	_, _, err := l.Generate(context.Background(), msgs,
+		llm.WithImageGen(llm.ImageGenOptions{N: 14}))
+	if err == nil || !errdefs.IsValidation(err) {
+		t.Fatalf("expected validation error for refs+N>15, got %v", err)
+	}
+}
+
+func TestGenerate_ResponseFormatBase64(t *testing.T) {
+	resp := apiResponse{Data: []responseItem{{B64JSON: "aGVsbG8="}}}
+	body, _ := json.Marshal(resp)
+	var captured apiRequest
+	srv := newMockServer(t, http.StatusOK, body, &captured)
+	defer srv.Close()
+
+	l, _ := New("doubao-seedream-5-0-260128", "test-key", srv.URL)
+	out, _, err := l.Generate(context.Background(),
+		[]llm.Message{llm.NewTextMessage(llm.RoleUser, "x")},
+		llm.WithImageGen(llm.ImageGenOptions{ResponseFormat: llm.ResponseFormatBase64}))
+	if err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+	if captured.ResponseFormat != "b64_json" {
+		t.Errorf("response_format: %q", captured.ResponseFormat)
+	}
+	if len(out.Parts) != 1 || out.Parts[0].Image.Base64 != "aGVsbG8=" {
+		t.Fatalf("parts: %+v", out.Parts)
+	}
+}
+
+func TestGenerate_ExtraEscapeHatches(t *testing.T) {
+	resp := apiResponse{Data: []responseItem{{URL: "https://cdn/x.png"}}}
+	body, _ := json.Marshal(resp)
+	var captured apiRequest
+	srv := newMockServer(t, http.StatusOK, body, &captured)
+	defer srv.Close()
+
+	l, _ := New("doubao-seedream-4-0-250828", "test-key", srv.URL)
+	_, _, err := l.Generate(context.Background(),
+		[]llm.Message{llm.NewTextMessage(llm.RoleUser, "garden")},
+		llm.WithExtra("size", "2K"),
+		llm.WithExtra("output_format", "png"),
+		llm.WithExtra("watermark", false),
+		llm.WithExtra("optimize_prompt_mode", "fast"),
+		llm.WithExtra("web_search", true),
+	)
+	if err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+	if captured.Size != "2K" {
+		t.Errorf("size: %q", captured.Size)
+	}
+	if captured.OutputFormat != "png" {
+		t.Errorf("output_format: %q", captured.OutputFormat)
+	}
+	if captured.Watermark == nil || *captured.Watermark != false {
+		t.Errorf("watermark: %+v", captured.Watermark)
+	}
+	if captured.OptimizePromptOptions == nil || captured.OptimizePromptOptions.Mode != "fast" {
+		t.Errorf("optimize: %+v", captured.OptimizePromptOptions)
+	}
+	if len(captured.Tools) != 1 || captured.Tools[0].Type != "web_search" {
+		t.Errorf("tools: %+v", captured.Tools)
+	}
+}
+
+func TestGenerate_ExtraSizeOverridesPixelSize(t *testing.T) {
+	resp := apiResponse{Data: []responseItem{{URL: "https://cdn/x.png"}}}
+	body, _ := json.Marshal(resp)
+	var captured apiRequest
+	srv := newMockServer(t, http.StatusOK, body, &captured)
+	defer srv.Close()
+
+	l, _ := New("doubao-seedream-5-0-260128", "test-key", srv.URL)
+	_, _, err := l.Generate(context.Background(),
+		[]llm.Message{llm.NewTextMessage(llm.RoleUser, "x")},
+		llm.WithImageGen(llm.ImageGenOptions{Width: 1024, Height: 1024}),
+		llm.WithExtra("size", "4K"),
+	)
+	if err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+	if captured.Size != "4K" {
+		t.Errorf("Extra size should override W/H, got %q", captured.Size)
+	}
+}
+
+func TestGenerate_EmptyPromptRejected(t *testing.T) {
+	l, _ := New("doubao-seedream-5-0-260128", "test-key", "https://invalid")
+	_, _, err := l.Generate(context.Background(), []llm.Message{
+		{Role: model.RoleUser, Parts: []model.Part{
+			{Type: model.PartImage, Image: &model.MediaRef{URL: "https://ref/a.png"}},
+		}},
+	})
+	if err == nil || !errdefs.IsValidation(err) {
+		t.Fatalf("expected validation error, got %v", err)
+	}
+}
+
+func TestGenerate_HTTPErrorMapping(t *testing.T) {
+	cases := []struct {
+		name   string
+		status int
+		check  func(error) bool
+	}{
+		{"401 → unauthorized", http.StatusUnauthorized, errdefs.IsUnauthorized},
+		{"429 → rate limit", http.StatusTooManyRequests, errdefs.IsRateLimit},
+		{"500 → not available", http.StatusInternalServerError, errdefs.IsNotAvailable},
+		{"400 → validation", http.StatusBadRequest, errdefs.IsValidation},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := newMockServer(t, tc.status, []byte(`{"error":{"code":"X"}}`), nil)
+			defer srv.Close()
+			l, _ := New("doubao-seedream-5-0-260128", "test-key", srv.URL)
+			_, _, err := l.Generate(context.Background(),
+				[]llm.Message{llm.NewTextMessage(llm.RoleUser, "hi")})
+			if err == nil || !tc.check(err) {
+				t.Fatalf("expected categorised error, got %v", err)
+			}
+		})
+	}
+}
+
+func TestGenerate_APIErrorEnvelope(t *testing.T) {
+	cases := []struct {
+		name  string
+		code  string
+		check func(error) bool
+	}{
+		{"AuthenticationError → unauthorized", "AuthenticationError", errdefs.IsUnauthorized},
+		{"RateLimitExceeded → rate limit", "RateLimitExceeded.Resource", errdefs.IsRateLimit},
+		{"InsufficientBalance → forbidden", "InsufficientBalance", errdefs.IsForbidden},
+		{"InvalidParameter → validation", "InvalidParameter.Prompt", errdefs.IsValidation},
+		{"InternalServiceError → not available", "InternalServiceError", errdefs.IsNotAvailable},
+		{"unknown → internal", "WhoKnows", errdefs.IsInternal},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			body, _ := json.Marshal(apiResponse{Error: &apiError{Code: tc.code, Message: "boom"}})
+			srv := newMockServer(t, http.StatusOK, body, nil)
+			defer srv.Close()
+			l, _ := New("doubao-seedream-5-0-260128", "test-key", srv.URL)
+			_, _, err := l.Generate(context.Background(),
+				[]llm.Message{llm.NewTextMessage(llm.RoleUser, "hi")})
+			if err == nil || !tc.check(err) {
+				t.Fatalf("expected categorised error, got %v", err)
+			}
+		})
+	}
+}
+
+func TestGenerate_ZeroImagesIsInternal(t *testing.T) {
+	body, _ := json.Marshal(apiResponse{Data: []responseItem{}})
+	srv := newMockServer(t, http.StatusOK, body, nil)
+	defer srv.Close()
+	l, _ := New("doubao-seedream-5-0-260128", "test-key", srv.URL)
+	_, _, err := l.Generate(context.Background(),
+		[]llm.Message{llm.NewTextMessage(llm.RoleUser, "x")})
+	if err == nil || !errdefs.IsInternal(err) {
+		t.Fatalf("expected internal error, got %v", err)
+	}
+}
+
+func TestGenerate_TransportErrorIsNotAvailable(t *testing.T) {
+	l, _ := New("doubao-seedream-5-0-260128", "test-key", "http://127.0.0.1:1")
+	_, _, err := l.Generate(context.Background(),
+		[]llm.Message{llm.NewTextMessage(llm.RoleUser, "x")})
+	if err == nil || !errdefs.IsNotAvailable(err) {
+		t.Fatalf("expected NotAvailable, got %v", err)
+	}
+}
+
+func TestGenerateStream_OneShot(t *testing.T) {
+	resp := apiResponse{Data: []responseItem{{URL: "https://cdn/x.png"}}}
+	body, _ := json.Marshal(resp)
+	srv := newMockServer(t, http.StatusOK, body, nil)
+	defer srv.Close()
+
+	l, _ := New("doubao-seedream-5-0-260128", "test-key", srv.URL)
+	stream, err := l.GenerateStream(context.Background(),
+		[]llm.Message{llm.NewTextMessage(llm.RoleUser, "a frog")})
+	if err != nil {
+		t.Fatalf("GenerateStream: %v", err)
+	}
+	if !stream.Next() {
+		t.Fatal("expected first Next() to be true")
+	}
+	if stream.Next() {
+		t.Fatal("expected second Next() to be false")
+	}
+	finalMsg := stream.Message()
+	if len(finalMsg.Parts) != 1 || finalMsg.Parts[0].Image == nil {
+		t.Fatalf("Message() did not carry image: %+v", finalMsg)
+	}
+}
+
+func TestProviderRegistration(t *testing.T) {
+	wantModels := []string{
+		"doubao-seedream-5-0-260128",
+		"doubao-seedream-5-0-lite-260128",
+		"doubao-seedream-4-5-251128",
+		"doubao-seedream-4-0-250828",
+	}
+	for _, m := range wantModels {
+		if _, ok := llm.DefaultRegistry.LookupModel(providerKey, m); !ok {
+			t.Errorf("model %q not registered under %q", m, providerKey)
+		}
+	}
+	spec := llm.DefaultRegistry.LookupModelSpec(providerKey, "doubao-seedream-5-0-260128")
+	if spec.Caps.Supports(llm.CapTools) {
+		t.Error("expected CapTools to be disabled")
+	}
+	if !spec.Caps.Supports(llm.CapImageOutput) {
+		t.Error("expected CapImageOutput to be ENABLED")
+	}
+	if spec.Caps.Supports(llm.CapAudioOutput) {
+		t.Error("expected CapAudioOutput to be disabled")
+	}
+}

--- a/sdkx/llm/deepseek/deepseek.go
+++ b/sdkx/llm/deepseek/deepseek.go
@@ -46,8 +46,12 @@ func init() {
 	// (free-form JSON), not schema-constrained structured output.
 	// CapVision / CapAudio / CapFile are disabled because the V4
 	// series is text-only per artificialanalysis.ai/articles/...-v4-pro-and-v4-flash.
+	// Output is text-only as well (no native image / audio
+	// generation in the DeepSeek API), so disable the matching
+	// output modality caps too.
 	deepseekTextOnly := llm.DisabledCaps(
 		llm.CapJSONSchema, llm.CapVision, llm.CapAudio, llm.CapFile,
+		llm.CapImageOutput, llm.CapAudioOutput,
 	)
 
 	llm.RegisterProviderModels("deepseek", []llm.ModelInfo{
@@ -128,6 +132,8 @@ func init() {
 					llm.CapVision,
 					llm.CapAudio,
 					llm.CapFile,
+					llm.CapImageOutput,
+					llm.CapAudioOutput,
 				),
 				Limits: llm.ModelLimits{
 					MaxContextTokens: 1_000_000,

--- a/sdkx/llm/minimax/image/doc.go
+++ b/sdkx/llm/minimax/image/doc.go
@@ -1,0 +1,38 @@
+// Package image is the MiniMax image-generation adapter. It targets
+// MiniMax's POST /v1/image_generation endpoint
+// (https://platform.minimax.io/docs/api-reference/image-generation-i2i)
+// and exposes it through the standard sdk/llm.LLM interface so callers
+// can route image generation through the same resolver, fallback, and
+// credential-profile machinery as chat models.
+//
+// # Input mapping
+//
+// The adapter translates a [model.Message] list into a single
+// MiniMax request:
+//
+//   - The last user message's text parts are concatenated into the prompt field (max 1500 chars per upstream).
+//   - All [model.PartImage] parts across user messages are forwarded as subject_reference[].image_file URLs.
+//   - System and assistant messages are dropped.
+//
+// When zero reference images are present the call degrades to
+// text-to-image (still served by the same endpoint).
+//
+// # Image options
+//
+// Image-specific knobs (size, aspect ratio, n, seed, response
+// format) flow through [llm.GenerateOptions.ImageGen]. The response
+// is parsed into a single assistant [model.Message] whose Parts are
+// [model.PartImage] entries (one per generated image).
+//
+// # Streaming
+//
+// The endpoint is synchronous; GenerateStream wraps Generate via
+// [llm.NewOneChunkStream] so the [llm.StreamMessage] contract holds.
+//
+// # Authentication
+//
+// Bearer token in the Authorization header. The provider key is
+// "minimax-image" so existing "minimax" chat credentials remain
+// independent (deployments often use the same API key but different
+// rate-limit pools).
+package image

--- a/sdkx/llm/minimax/image/image.go
+++ b/sdkx/llm/minimax/image/image.go
@@ -1,0 +1,335 @@
+package image
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/GizClaw/flowcraft/sdk/errdefs"
+	"github.com/GizClaw/flowcraft/sdk/llm"
+	"github.com/GizClaw/flowcraft/sdk/model"
+)
+
+const (
+	defaultBaseURL = "https://api.minimaxi.com"
+	imageGenPath   = "/v1/image_generation"
+	defaultModel   = "image-01"
+	maxPromptChars = 1500
+	defaultTimeout = 90 * time.Second
+)
+
+const providerKey = "minimax-image"
+
+func init() {
+	llm.RegisterProvider(providerKey, func(model string, config map[string]any) (llm.LLM, error) {
+		apiKey, _ := config["api_key"].(string)
+		baseURL, _ := config["base_url"].(string)
+		return New(model, apiKey, baseURL)
+	})
+
+	// Catalog reflects MiniMax's image-gen lineup as of 2026-04-30.
+	// Sources:
+	//   - https://platform.minimax.io/docs/api-reference/image-generation-i2i
+	//   - https://platform.minimax.io/docs/guides/image-generation
+	//
+	// Both image-01 SKUs are dedicated image-generation models served
+	// out of /v1/image_generation; they do not honour any of the
+	// chat-completion knobs (temperature, tools, JSON mode, …) and
+	// cannot stream natively. Caps below disable everything that does
+	// not apply so the caps middleware fails fast at the SDK edge.
+	imageOnly := llm.DisabledCaps(
+		// Generation params (chat-only).
+		llm.CapTemperature, llm.CapTopP, llm.CapTopK, llm.CapMaxTokens,
+		llm.CapStopWords, llm.CapFrequencyPenalty, llm.CapPresencePenalty,
+		llm.CapThinking,
+		// Output controls (chat-only).
+		llm.CapJSONMode, llm.CapJSONSchema,
+		// Protocol features (chat-only).
+		llm.CapTools, llm.CapToolChoice, llm.CapParallelTools,
+		llm.CapStreaming, llm.CapSystemPrompt,
+		// Input modalities not accepted by /v1/image_generation.
+		llm.CapAudio, llm.CapFile,
+		// Output modalities — the model emits images, not audio.
+		llm.CapAudioOutput,
+		// CapVision and CapImageOutput remain ENABLED so the resolver
+		// can route image-output policy slots to this adapter while
+		// the caps middleware permits image input parts.
+	)
+
+	llm.RegisterProviderModels(providerKey, []llm.ModelInfo{
+		{
+			Label: "MiniMax Image-01",
+			Name:  "image-01",
+			Spec:  llm.ModelSpec{Caps: imageOnly},
+		},
+		{
+			Label: "MiniMax Image-01 Live",
+			Name:  "image-01-live",
+			Spec:  llm.ModelSpec{Caps: imageOnly},
+		},
+	})
+}
+
+// LLM is the MiniMax image-generation adapter. It implements
+// [llm.LLM] so callers can route image generation through the same
+// resolver and fallback machinery as chat models.
+type LLM struct {
+	model   string
+	apiKey  string
+	baseURL string
+	client  *http.Client
+}
+
+// Option configures the adapter at construction time.
+type Option func(*LLM)
+
+// WithHTTPClient overrides the default *http.Client (90s timeout).
+// Useful for tests and for plugging in OTel/transport middleware.
+func WithHTTPClient(c *http.Client) Option {
+	return func(l *LLM) {
+		if c != nil {
+			l.client = c
+		}
+	}
+}
+
+// New builds an adapter pointing at MiniMax's image-generation
+// endpoint. An empty model defaults to "image-01"; an empty baseURL
+// defaults to https://api.minimaxi.com.
+func New(modelName, apiKey, baseURL string, opts ...Option) (*LLM, error) {
+	if apiKey == "" {
+		return nil, errdefs.Validation(errdefs.New("minimax-image: api_key required"))
+	}
+	if modelName == "" {
+		modelName = defaultModel
+	}
+	if baseURL == "" {
+		baseURL = defaultBaseURL
+	}
+	l := &LLM{
+		model:   modelName,
+		apiKey:  apiKey,
+		baseURL: strings.TrimRight(baseURL, "/"),
+		client:  &http.Client{Timeout: defaultTimeout},
+	}
+	for _, opt := range opts {
+		opt(l)
+	}
+	return l, nil
+}
+
+// --- llm.LLM ----------------------------------------------------------
+
+// Generate calls MiniMax /v1/image_generation and returns an assistant
+// message whose Parts are PartImage entries (one per generated image).
+// The TokenUsage is always zero — the endpoint does not report usage.
+func (l *LLM) Generate(ctx context.Context, messages []llm.Message, opts ...llm.GenerateOption) (llm.Message, llm.TokenUsage, error) {
+	o := llm.ApplyOptions(opts...)
+	prompt, refs := extractPromptAndRefs(messages)
+	if prompt == "" {
+		return llm.Message{}, llm.TokenUsage{}, errdefs.Validation(errdefs.New("minimax-image: empty prompt (no text parts in user messages)"))
+	}
+	if cnt := len([]rune(prompt)); cnt > maxPromptChars {
+		return llm.Message{}, llm.TokenUsage{}, errdefs.Validation(errdefs.Fmt("minimax-image: prompt is %d chars (max %d)", cnt, maxPromptChars))
+	}
+
+	body := buildRequest(l.model, prompt, refs, o.ImageGen, o.Extra)
+	resp, err := l.do(ctx, body)
+	if err != nil {
+		return llm.Message{}, llm.TokenUsage{}, err
+	}
+	if resp.BaseResp.StatusCode != 0 {
+		return llm.Message{}, llm.TokenUsage{}, mapAPIError(resp.BaseResp)
+	}
+	parts, err := imagesToParts(resp.Data)
+	if err != nil {
+		return llm.Message{}, llm.TokenUsage{}, err
+	}
+	if len(parts) == 0 {
+		return llm.Message{}, llm.TokenUsage{}, errdefs.Internal(errdefs.New("minimax-image: provider returned zero images"))
+	}
+	return llm.Message{Role: model.RoleAssistant, Parts: parts}, llm.TokenUsage{}, nil
+}
+
+// GenerateStream wraps Generate via [llm.NewOneChunkStream] because
+// /v1/image_generation is synchronous. The returned stream emits a
+// single chunk carrying the assistant role and "stop" finish reason;
+// callers retrieve the full multimodal payload (image Parts) from
+// Message() after iteration completes — [llm.StreamChunk] is text-
+// oriented and has no Parts field.
+func (l *LLM) GenerateStream(ctx context.Context, messages []llm.Message, opts ...llm.GenerateOption) (llm.StreamMessage, error) {
+	msg, usage, err := l.Generate(ctx, messages, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return llm.NewOneChunkStream(msg, usage), nil
+}
+
+// --- request / response wire shape -----------------------------------
+
+type apiRequest struct {
+	Model            string             `json:"model"`
+	Prompt           string             `json:"prompt"`
+	SubjectReference []subjectReference `json:"subject_reference,omitempty"`
+	AspectRatio      string             `json:"aspect_ratio,omitempty"`
+	Width            int                `json:"width,omitempty"`
+	Height           int                `json:"height,omitempty"`
+	N                int                `json:"n,omitempty"`
+	Seed             *int64             `json:"seed,omitempty"`
+	ResponseFormat   string             `json:"response_format,omitempty"`
+}
+
+type subjectReference struct {
+	Type      string `json:"type"`
+	ImageFile string `json:"image_file"`
+}
+
+type apiResponse struct {
+	ID       string       `json:"id,omitempty"`
+	Data     responseData `json:"data"`
+	Metadata any          `json:"metadata,omitempty"`
+	BaseResp baseResp     `json:"base_resp"`
+}
+
+type responseData struct {
+	ImageURLs    []string `json:"image_urls,omitempty"`
+	ImageBase64s []string `json:"image_base64,omitempty"`
+}
+
+type baseResp struct {
+	StatusCode int    `json:"status_code"`
+	StatusMsg  string `json:"status_msg"`
+}
+
+func buildRequest(modelName, prompt string, refs []string, opts *llm.ImageGenOptions, extra map[string]any) apiRequest {
+	req := apiRequest{Model: modelName, Prompt: prompt}
+	for _, url := range refs {
+		req.SubjectReference = append(req.SubjectReference, subjectReference{
+			Type:      "character",
+			ImageFile: url,
+		})
+	}
+	if opts != nil {
+		req.AspectRatio = opts.AspectRatio
+		req.Width = opts.Width
+		req.Height = opts.Height
+		req.N = opts.N
+		req.Seed = opts.Seed
+		switch opts.ResponseFormat {
+		case llm.ResponseFormatBase64:
+			req.ResponseFormat = "base64"
+		case llm.ResponseFormatURL:
+			req.ResponseFormat = "url"
+		}
+	}
+	_ = extra // reserved for future provider-specific overrides
+	return req
+}
+
+func extractPromptAndRefs(messages []llm.Message) (prompt string, refs []string) {
+	var lastUserText strings.Builder
+	for _, m := range messages {
+		if m.Role != model.RoleUser {
+			continue
+		}
+		for _, p := range m.Parts {
+			switch p.Type {
+			case model.PartImage:
+				if p.Image != nil && p.Image.URL != "" {
+					refs = append(refs, p.Image.URL)
+				}
+			case model.PartText:
+				if lastUserText.Len() > 0 {
+					lastUserText.WriteString("\n")
+				}
+				lastUserText.WriteString(p.Text)
+			}
+		}
+	}
+	return strings.TrimSpace(lastUserText.String()), refs
+}
+
+func imagesToParts(d responseData) ([]model.Part, error) {
+	parts := make([]model.Part, 0, len(d.ImageURLs)+len(d.ImageBase64s))
+	for _, u := range d.ImageURLs {
+		parts = append(parts, model.Part{Type: model.PartImage, Image: &model.MediaRef{URL: u, MediaType: "image/png"}})
+	}
+	for _, b := range d.ImageBase64s {
+		parts = append(parts, model.Part{Type: model.PartImage, Image: &model.MediaRef{Base64: b, MediaType: "image/png"}})
+	}
+	return parts, nil
+}
+
+func (l *LLM) do(ctx context.Context, req apiRequest) (*apiResponse, error) {
+	body, err := json.Marshal(req)
+	if err != nil {
+		return nil, errdefs.Internal(errdefs.Fmt("minimax-image: marshal request: %w", err))
+	}
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, l.baseURL+imageGenPath, bytes.NewReader(body))
+	if err != nil {
+		return nil, errdefs.Internal(errdefs.Fmt("minimax-image: build request: %w", err))
+	}
+	httpReq.Header.Set("Content-Type", "application/json")
+	httpReq.Header.Set("Authorization", "Bearer "+l.apiKey)
+
+	resp, err := l.client.Do(httpReq)
+	if err != nil {
+		return nil, errdefs.NotAvailable(errdefs.Fmt("minimax-image: http call: %w", err))
+	}
+	defer resp.Body.Close()
+
+	raw, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, errdefs.Internal(errdefs.Fmt("minimax-image: read body: %w", err))
+	}
+	if resp.StatusCode == http.StatusUnauthorized {
+		return nil, errdefs.Unauthorized(errdefs.Fmt("minimax-image: 401: %s", truncate(string(raw), 200)))
+	}
+	if resp.StatusCode == http.StatusTooManyRequests {
+		return nil, errdefs.RateLimit(errdefs.Fmt("minimax-image: 429: %s", truncate(string(raw), 200)))
+	}
+	if resp.StatusCode >= 500 {
+		return nil, errdefs.NotAvailable(errdefs.Fmt("minimax-image: %d: %s", resp.StatusCode, truncate(string(raw), 200)))
+	}
+	if resp.StatusCode >= 400 {
+		return nil, errdefs.Validation(errdefs.Fmt("minimax-image: %d: %s", resp.StatusCode, truncate(string(raw), 200)))
+	}
+	var out apiResponse
+	if err := json.Unmarshal(raw, &out); err != nil {
+		return nil, errdefs.Internal(errdefs.Fmt("minimax-image: decode body: %w (raw=%s)", err, truncate(string(raw), 200)))
+	}
+	return &out, nil
+}
+
+// mapAPIError maps MiniMax base_resp non-zero codes to errdefs categories.
+// Documented codes: 1000-series (auth/quota), 1004 (rate-limit), 1008
+// (insufficient balance), 2013 (invalid params), etc.
+func mapAPIError(b baseResp) error {
+	msg := fmt.Sprintf("minimax-image: %d %s", b.StatusCode, b.StatusMsg)
+	switch b.StatusCode {
+	case 1000, 1001, 1002, 1004:
+		return errdefs.RateLimit(errdefs.New(msg))
+	case 1008, 1013:
+		return errdefs.Forbidden(errdefs.New(msg))
+	case 1003, 1005, 1006:
+		return errdefs.Unauthorized(errdefs.New(msg))
+	case 2013, 2049:
+		return errdefs.Validation(errdefs.New(msg))
+	default:
+		return errdefs.Internal(errdefs.New(msg))
+	}
+}
+
+// --- helpers ---------------------------------------------------------
+
+func truncate(s string, n int) string {
+	if len(s) <= n {
+		return s
+	}
+	return s[:n] + "…"
+}

--- a/sdkx/llm/minimax/image/image_test.go
+++ b/sdkx/llm/minimax/image/image_test.go
@@ -1,0 +1,327 @@
+package image
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/GizClaw/flowcraft/sdk/errdefs"
+	"github.com/GizClaw/flowcraft/sdk/llm"
+	"github.com/GizClaw/flowcraft/sdk/model"
+)
+
+// newMockServer returns a httptest server that decodes the inbound
+// request, hands it to handler for inspection, and writes back the
+// supplied raw response body with the supplied status code.
+func newMockServer(t *testing.T, status int, body []byte, capture *apiRequest) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != imageGenPath {
+			t.Errorf("unexpected path %q", r.URL.Path)
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer test-key" {
+			t.Errorf("missing/incorrect Authorization header: %q", got)
+		}
+		if capture != nil {
+			raw, err := io.ReadAll(r.Body)
+			if err != nil {
+				t.Fatalf("read body: %v", err)
+			}
+			if err := json.Unmarshal(raw, capture); err != nil {
+				t.Fatalf("decode body: %v", err)
+			}
+		}
+		w.WriteHeader(status)
+		_, _ = w.Write(body)
+	}))
+}
+
+func TestNew_RequiresAPIKey(t *testing.T) {
+	_, err := New("image-01", "", "")
+	if err == nil || !errdefs.IsValidation(err) {
+		t.Fatalf("expected validation error, got %v", err)
+	}
+}
+
+func TestGenerate_TextToImage_URL(t *testing.T) {
+	resp := apiResponse{
+		ID:   "img-1",
+		Data: responseData{ImageURLs: []string{"https://cdn/x.png", "https://cdn/y.png"}},
+	}
+	body, _ := json.Marshal(resp)
+
+	var captured apiRequest
+	srv := newMockServer(t, http.StatusOK, body, &captured)
+	defer srv.Close()
+
+	l, err := New("image-01", "test-key", srv.URL)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	out, _, err := l.Generate(context.Background(), []llm.Message{
+		llm.NewTextMessage(llm.RoleUser, "a cat in space"),
+	}, llm.WithImageGen(llm.ImageGenOptions{
+		AspectRatio:    "16:9",
+		N:              2,
+		ResponseFormat: llm.ResponseFormatURL,
+	}))
+	if err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+
+	if captured.Model != "image-01" {
+		t.Errorf("model: %q", captured.Model)
+	}
+	if captured.Prompt != "a cat in space" {
+		t.Errorf("prompt: %q", captured.Prompt)
+	}
+	if captured.AspectRatio != "16:9" || captured.N != 2 || captured.ResponseFormat != "url" {
+		t.Errorf("opts not forwarded: %+v", captured)
+	}
+	if len(captured.SubjectReference) != 0 {
+		t.Errorf("expected no subject_reference for t2i, got %d", len(captured.SubjectReference))
+	}
+
+	if len(out.Parts) != 2 {
+		t.Fatalf("expected 2 image parts, got %d", len(out.Parts))
+	}
+	for i, p := range out.Parts {
+		if p.Type != model.PartImage || p.Image == nil {
+			t.Fatalf("part %d not an image: %+v", i, p)
+		}
+		if p.Image.URL == "" {
+			t.Errorf("part %d missing URL", i)
+		}
+	}
+}
+
+func TestGenerate_ImageToImage_PassesReferences(t *testing.T) {
+	resp := apiResponse{Data: responseData{ImageURLs: []string{"https://cdn/out.png"}}}
+	body, _ := json.Marshal(resp)
+
+	var captured apiRequest
+	srv := newMockServer(t, http.StatusOK, body, &captured)
+	defer srv.Close()
+
+	l, _ := New("image-01", "test-key", srv.URL)
+
+	msg := model.Message{
+		Role: model.RoleUser,
+		Parts: []model.Part{
+			{Type: model.PartImage, Image: &model.MediaRef{URL: "https://ref/a.png"}},
+			{Type: model.PartImage, Image: &model.MediaRef{URL: "https://ref/b.png"}},
+			{Type: model.PartText, Text: "make it cyberpunk"},
+		},
+	}
+	if _, _, err := l.Generate(context.Background(), []llm.Message{msg}); err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+
+	if got := len(captured.SubjectReference); got != 2 {
+		t.Fatalf("expected 2 subject_reference entries, got %d", got)
+	}
+	for i, ref := range captured.SubjectReference {
+		if ref.Type != "character" {
+			t.Errorf("ref[%d].type = %q", i, ref.Type)
+		}
+	}
+	if captured.Prompt != "make it cyberpunk" {
+		t.Errorf("prompt: %q", captured.Prompt)
+	}
+}
+
+func TestGenerate_Base64Response(t *testing.T) {
+	resp := apiResponse{Data: responseData{ImageBase64s: []string{"aGVsbG8="}}}
+	body, _ := json.Marshal(resp)
+	srv := newMockServer(t, http.StatusOK, body, nil)
+	defer srv.Close()
+
+	l, _ := New("image-01", "test-key", srv.URL)
+	out, _, err := l.Generate(context.Background(), []llm.Message{
+		llm.NewTextMessage(llm.RoleUser, "x"),
+	}, llm.WithImageGen(llm.ImageGenOptions{ResponseFormat: llm.ResponseFormatBase64}))
+	if err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+	if len(out.Parts) != 1 || out.Parts[0].Image.Base64 != "aGVsbG8=" {
+		t.Fatalf("unexpected parts: %+v", out.Parts)
+	}
+}
+
+func TestGenerate_EmptyPromptRejected(t *testing.T) {
+	l, _ := New("image-01", "test-key", "https://invalid")
+	_, _, err := l.Generate(context.Background(), []llm.Message{
+		// no text parts at all
+		{Role: model.RoleUser, Parts: []model.Part{
+			{Type: model.PartImage, Image: &model.MediaRef{URL: "https://ref/a.png"}},
+		}},
+	})
+	if err == nil || !errdefs.IsValidation(err) {
+		t.Fatalf("expected validation error, got %v", err)
+	}
+}
+
+func TestGenerate_PromptTooLong(t *testing.T) {
+	l, _ := New("image-01", "test-key", "https://invalid")
+	long := strings.Repeat("a", maxPromptChars+1)
+	_, _, err := l.Generate(context.Background(), []llm.Message{
+		llm.NewTextMessage(llm.RoleUser, long),
+	})
+	if err == nil || !errdefs.IsValidation(err) {
+		t.Fatalf("expected validation error, got %v", err)
+	}
+}
+
+func TestGenerate_HTTPErrorMapping(t *testing.T) {
+	cases := []struct {
+		name   string
+		status int
+		check  func(error) bool
+	}{
+		{"401 → unauthorized", http.StatusUnauthorized, errdefs.IsUnauthorized},
+		{"429 → rate limit", http.StatusTooManyRequests, errdefs.IsRateLimit},
+		{"500 → not available", http.StatusInternalServerError, errdefs.IsNotAvailable},
+		{"400 → validation", http.StatusBadRequest, errdefs.IsValidation},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := newMockServer(t, tc.status, []byte(`{"error":"boom"}`), nil)
+			defer srv.Close()
+			l, _ := New("image-01", "test-key", srv.URL)
+			_, _, err := l.Generate(context.Background(), []llm.Message{
+				llm.NewTextMessage(llm.RoleUser, "hi"),
+			})
+			if err == nil || !tc.check(err) {
+				t.Fatalf("expected categorised error, got %v", err)
+			}
+		})
+	}
+}
+
+func TestGenerate_BaseRespErrorMapping(t *testing.T) {
+	cases := []struct {
+		name  string
+		code  int
+		check func(error) bool
+	}{
+		{"1004 → rate limit", 1004, errdefs.IsRateLimit},
+		{"1008 → forbidden (insufficient balance)", 1008, errdefs.IsForbidden},
+		{"1003 → unauthorized", 1003, errdefs.IsUnauthorized},
+		{"2013 → validation", 2013, errdefs.IsValidation},
+		{"9999 → internal", 9999, errdefs.IsInternal},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			body, _ := json.Marshal(apiResponse{
+				BaseResp: baseResp{StatusCode: tc.code, StatusMsg: "err"},
+			})
+			srv := newMockServer(t, http.StatusOK, body, nil)
+			defer srv.Close()
+			l, _ := New("image-01", "test-key", srv.URL)
+			_, _, err := l.Generate(context.Background(), []llm.Message{
+				llm.NewTextMessage(llm.RoleUser, "hi"),
+			})
+			if err == nil || !tc.check(err) {
+				t.Fatalf("expected categorised error, got %v", err)
+			}
+		})
+	}
+}
+
+func TestGenerate_ZeroImagesIsInternal(t *testing.T) {
+	body, _ := json.Marshal(apiResponse{Data: responseData{}})
+	srv := newMockServer(t, http.StatusOK, body, nil)
+	defer srv.Close()
+	l, _ := New("image-01", "test-key", srv.URL)
+	_, _, err := l.Generate(context.Background(), []llm.Message{
+		llm.NewTextMessage(llm.RoleUser, "x"),
+	})
+	if err == nil || !errdefs.IsInternal(err) {
+		t.Fatalf("expected internal error, got %v", err)
+	}
+}
+
+func TestGenerate_TransportErrorIsNotAvailable(t *testing.T) {
+	l, _ := New("image-01", "test-key", "http://127.0.0.1:1") // closed port
+	_, _, err := l.Generate(context.Background(), []llm.Message{
+		llm.NewTextMessage(llm.RoleUser, "x"),
+	})
+	if err == nil || !errdefs.IsNotAvailable(err) {
+		t.Fatalf("expected NotAvailable, got %v", err)
+	}
+}
+
+func TestGenerateStream_OneShot(t *testing.T) {
+	resp := apiResponse{Data: responseData{ImageURLs: []string{"https://cdn/x.png"}}}
+	body, _ := json.Marshal(resp)
+	srv := newMockServer(t, http.StatusOK, body, nil)
+	defer srv.Close()
+
+	l, _ := New("image-01", "test-key", srv.URL)
+	stream, err := l.GenerateStream(context.Background(), []llm.Message{
+		llm.NewTextMessage(llm.RoleUser, "a frog"),
+	})
+	if err != nil {
+		t.Fatalf("GenerateStream: %v", err)
+	}
+	if !stream.Next() {
+		t.Fatal("expected first Next() to be true")
+	}
+	if stream.Next() {
+		t.Fatal("expected second Next() to be false")
+	}
+	if stream.Err() != nil {
+		t.Fatalf("Err: %v", stream.Err())
+	}
+	finalMsg := stream.Message()
+	if len(finalMsg.Parts) != 1 || finalMsg.Parts[0].Image == nil {
+		t.Fatalf("Message() did not carry image: %+v", finalMsg)
+	}
+	if err := stream.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+}
+
+func TestExtractPromptAndRefs_MergesUserTextAndDropsOtherRoles(t *testing.T) {
+	msgs := []llm.Message{
+		{Role: model.RoleSystem, Parts: []model.Part{{Type: model.PartText, Text: "ignored"}}},
+		{Role: model.RoleUser, Parts: []model.Part{
+			{Type: model.PartText, Text: "first"},
+			{Type: model.PartImage, Image: &model.MediaRef{URL: "https://ref/a.png"}},
+		}},
+		{Role: model.RoleAssistant, Parts: []model.Part{{Type: model.PartText, Text: "ignored too"}}},
+		{Role: model.RoleUser, Parts: []model.Part{
+			{Type: model.PartText, Text: "second"},
+		}},
+	}
+	prompt, refs := extractPromptAndRefs(msgs)
+	if prompt != "first\nsecond" {
+		t.Errorf("prompt: %q", prompt)
+	}
+	if len(refs) != 1 || refs[0] != "https://ref/a.png" {
+		t.Errorf("refs: %+v", refs)
+	}
+}
+
+func TestProviderRegistration(t *testing.T) {
+	// init() registered the catalog entry for "minimax-image" /
+	// "image-01"; the resolver should be able to look it up.
+	if _, ok := llm.DefaultRegistry.LookupModel(providerKey, "image-01"); !ok {
+		t.Fatal("image-01 not registered under minimax-image provider")
+	}
+	if _, ok := llm.DefaultRegistry.LookupModel(providerKey, "image-01-live"); !ok {
+		t.Fatal("image-01-live not registered under minimax-image provider")
+	}
+	spec := llm.DefaultRegistry.LookupModelSpec(providerKey, "image-01")
+	if spec.Caps.Supports(llm.CapTools) {
+		t.Error("expected CapTools to be disabled for image-01")
+	}
+	if !spec.Caps.Supports(llm.CapImageOutput) {
+		t.Error("expected CapImageOutput to be ENABLED for image-01")
+	}
+}

--- a/sdkx/llm/minimax/minimax.go
+++ b/sdkx/llm/minimax/minimax.go
@@ -51,6 +51,10 @@ func init() {
 	textOnlyAnthropicStyle := llm.DisabledCaps(
 		llm.CapVision, llm.CapAudio, llm.CapFile,
 		llm.CapJSONMode, llm.CapJSONSchema,
+		// Output: text only. Image generation lives in the
+		// minimax-image adapter (sdkx/llm/minimax/image); audio
+		// generation has no in-tree adapter today.
+		llm.CapImageOutput, llm.CapAudioOutput,
 	)
 
 	llm.RegisterProviderModels("minimax", []llm.ModelInfo{

--- a/sdkx/llm/openai/openai.go
+++ b/sdkx/llm/openai/openai.go
@@ -45,11 +45,21 @@ func init() {
 	//   - https://openai.com/gpt-5/
 	//
 	// Across the gpt-5 / gpt-5.4 family the chat-completions surface
-	// is text+image only — audio and file modalities go through
-	// separate APIs (gpt-4o-audio-preview / Files endpoint), so
-	// CapAudio and CapFile are disabled here to fail-fast at the
+	// is text+image *input* only — audio and file modalities go
+	// through separate APIs (gpt-4o-audio-preview / Files endpoint),
+	// so CapAudio and CapFile are disabled here to fail-fast at the
 	// caps middleware rather than at the OpenAI API edge.
-	openaiTextImageOnly := llm.DisabledCaps(llm.CapAudio, llm.CapFile)
+	//
+	// Output modality: text only. Image generation goes through the
+	// dedicated gpt-image-1 / Images API surface (separate adapter),
+	// and audio output goes through gpt-realtime-* / TTS endpoints.
+	// Verified against developers.openai.com/api/docs/models/gpt-5
+	// and developers.openai.com/docs/guides/audio (Chat Completions
+	// audio path covers gpt-realtime-* SKUs only) as of 2026-04-30.
+	openaiTextImageOnly := llm.DisabledCaps(
+		llm.CapAudio, llm.CapFile,
+		llm.CapImageOutput, llm.CapAudioOutput,
+	)
 
 	llm.RegisterProviderModels("openai", []llm.ModelInfo{
 		// --- GPT-5.5 (current flagship, released 2026-04-23) -------
@@ -175,7 +185,10 @@ func init() {
 			Label: "GPT-5.4 Nano",
 			Name:  "gpt-5.4-nano",
 			Spec: llm.ModelSpec{
-				Caps: llm.DisabledCaps(llm.CapVision, llm.CapAudio, llm.CapFile),
+				Caps: llm.DisabledCaps(
+					llm.CapVision, llm.CapAudio, llm.CapFile,
+					llm.CapImageOutput, llm.CapAudioOutput,
+				),
 			},
 		},
 
@@ -199,6 +212,7 @@ func init() {
 					llm.CapFrequencyPenalty, llm.CapPresencePenalty,
 					llm.CapStopWords,
 					llm.CapAudio, llm.CapFile,
+					llm.CapImageOutput, llm.CapAudioOutput,
 				),
 				Limits: llm.ModelLimits{MaxContextTokens: 200_000},
 			},
@@ -212,6 +226,7 @@ func init() {
 					llm.CapFrequencyPenalty, llm.CapPresencePenalty,
 					llm.CapStopWords,
 					llm.CapAudio, llm.CapFile,
+					llm.CapImageOutput, llm.CapAudioOutput,
 				),
 				Limits: llm.ModelLimits{
 					MaxContextTokens: 200_000,
@@ -236,6 +251,7 @@ func init() {
 					llm.CapFrequencyPenalty, llm.CapPresencePenalty,
 					llm.CapStopWords,
 					llm.CapAudio, llm.CapFile,
+					llm.CapImageOutput, llm.CapAudioOutput,
 				),
 			},
 			Deprecation: llm.ModelDeprecation{

--- a/sdkx/llm/qwen/image/doc.go
+++ b/sdkx/llm/qwen/image/doc.go
@@ -1,0 +1,71 @@
+// Package image is the Alibaba DashScope Qwen-Image text-to-image
+// adapter. It targets the synchronous multimodal-generation endpoint
+// (POST /api/v1/services/aigc/multimodal-generation/generation, see
+// https://help.aliyun.com/zh/model-studio/qwen-image-api) and exposes
+// it through the standard sdk/llm.LLM interface so callers can route
+// image generation through the same resolver, fallback, and
+// credential-profile machinery as chat models.
+//
+// # Input mapping
+//
+// The endpoint is text-to-image only and accepts exactly one user
+// message with one text content part per the upstream contract
+// ("当前仅支持单轮对话" / "仅支持传入一个text"). The adapter therefore:
+//
+//   - Concatenates all user-message text parts into a single text.
+//   - Drops system and assistant messages.
+//   - Rejects [model.PartImage] inputs with a validation error.
+//
+// Image editing is served by a separate qwen-image-edit endpoint not
+// handled by this adapter; rejecting reference images keeps callers
+// from silently getting a t2i result that ignored their references.
+//
+// # Image options
+//
+// Image-specific knobs flow through [llm.GenerateOptions.ImageGen]:
+//
+//   - Width + Height map to parameters.size in "W*H" form.
+//   - N maps to parameters.n.
+//   - Seed maps to parameters.seed.
+//
+// Note the unusual "*" separator: Qwen uses "W*H", not the "WxH"
+// convention shared by OpenAI / Seedream / MiniMax. AspectRatio and
+// ResponseFormat are silently ignored: this endpoint has no
+// aspect-ratio knob (use Width/Height) and only returns URL.
+//
+// Per-model n limits are enforced server-side: 2.0 series accept 1-6,
+// max / plus / qwen-image are fixed at 1.
+//
+// # Provider extras
+//
+// Provider-specific knobs are passed through [llm.WithExtra]:
+//
+//   - "negative_prompt" (string) discouraged content guidance.
+//   - "prompt_extend" (bool) toggles the model's auto rewrite, default true upstream.
+//   - "watermark" (bool) adds the "Qwen-Image" watermark.
+//   - "size" (string) overrides Width/Height-derived size, useful for the max / plus fixed-size SKUs.
+//
+// # Output mapping
+//
+// The response (output.choices[0].message.content[].image) is parsed
+// into a single assistant [model.Message] whose Parts are
+// [model.PartImage] entries, one per generated image. Token usage is
+// left zero — this endpoint reports image_count and dimensions
+// rather than token counts.
+//
+// # Streaming
+//
+// The endpoint is synchronous; GenerateStream wraps Generate via
+// [llm.NewOneChunkStream] so the [llm.StreamMessage] contract holds.
+//
+// # Authentication and regions
+//
+// Bearer token in the Authorization header. The default base URL is
+// the Beijing endpoint https://dashscope.aliyuncs.com; deployments
+// routing through the international (Singapore) region should set
+// base_url to https://dashscope-intl.aliyuncs.com. Beijing and
+// Singapore have independent API keys and are NOT cross-callable.
+//
+// The provider key is "qwen-image" so existing "qwen" chat
+// credentials remain independent.
+package image

--- a/sdkx/llm/qwen/image/image.go
+++ b/sdkx/llm/qwen/image/image.go
@@ -1,0 +1,458 @@
+package image
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/GizClaw/flowcraft/sdk/errdefs"
+	"github.com/GizClaw/flowcraft/sdk/llm"
+	"github.com/GizClaw/flowcraft/sdk/model"
+)
+
+const (
+	// defaultBaseURL is the Beijing endpoint. The international
+	// (Singapore) endpoint (https://dashscope-intl.aliyuncs.com) is
+	// reachable by overriding base_url at config time. Beijing and
+	// Singapore have independent API keys and are not cross-callable.
+	defaultBaseURL = "https://dashscope.aliyuncs.com"
+	imageGenPath   = "/api/v1/services/aigc/multimodal-generation/generation"
+	defaultModel   = "qwen-image-2.0-pro"
+	defaultTimeout = 120 * time.Second
+
+	providerKey = "qwen-image"
+)
+
+func init() {
+	llm.RegisterProvider(providerKey, func(model string, config map[string]any) (llm.LLM, error) {
+		apiKey, _ := config["api_key"].(string)
+		baseURL, _ := config["base_url"].(string)
+		return New(model, apiKey, baseURL)
+	})
+
+	// Catalog reflects DashScope's Qwen-Image lineup as of
+	// 2026-04-30. Sources:
+	//   - https://help.aliyun.com/zh/model-studio/qwen-image-api
+	//   - https://help.aliyun.com/zh/model-studio/text-to-image
+	//
+	// Caps: every chat-completion knob is disabled. CapVision stays
+	// disabled because this endpoint is text-to-image ONLY — image
+	// editing is on a separate qwen-image-edit endpoint and would be
+	// served by a future adapter. Audio output stays disabled
+	// because Qwen-Image emits images only.
+	imageOnly := llm.DisabledCaps(
+		llm.CapTemperature, llm.CapTopP, llm.CapTopK, llm.CapMaxTokens,
+		llm.CapStopWords, llm.CapFrequencyPenalty, llm.CapPresencePenalty,
+		llm.CapThinking,
+		llm.CapJSONMode, llm.CapJSONSchema,
+		llm.CapTools, llm.CapToolChoice, llm.CapParallelTools,
+		llm.CapStreaming, llm.CapSystemPrompt,
+		// Input modalities: this endpoint is text-only.
+		llm.CapVision, llm.CapAudio, llm.CapFile,
+		// Output modalities: image only.
+		llm.CapAudioOutput,
+		// CapImageOutput remains ENABLED.
+	)
+
+	llm.RegisterProviderModels(providerKey, []llm.ModelInfo{
+		// --- 2.0 Pro series (current recommended flagship) -----------
+		// Total pixels in [512*512, 2048*2048], default 2048*2048.
+		// n: 1-6.
+		{Label: "Qwen-Image 2.0 Pro", Name: "qwen-image-2.0-pro", Spec: llm.ModelSpec{Caps: imageOnly}},
+		{Label: "Qwen-Image 2.0 Pro (2026-04-22)", Name: "qwen-image-2.0-pro-2026-04-22", Spec: llm.ModelSpec{Caps: imageOnly}},
+		{Label: "Qwen-Image 2.0 Pro (2026-03-03)", Name: "qwen-image-2.0-pro-2026-03-03", Spec: llm.ModelSpec{Caps: imageOnly}},
+
+		// --- 2.0 series (accelerated, recommended) ------------------
+		{Label: "Qwen-Image 2.0", Name: "qwen-image-2.0", Spec: llm.ModelSpec{Caps: imageOnly}},
+		{Label: "Qwen-Image 2.0 (2026-03-03)", Name: "qwen-image-2.0-2026-03-03", Spec: llm.ModelSpec{Caps: imageOnly}},
+
+		// --- Max / Plus series --------------------------------------
+		// Default 1664*928 (16:9). n: fixed at 1; server errors on
+		// other values.
+		{Label: "Qwen-Image Max", Name: "qwen-image-max", Spec: llm.ModelSpec{Caps: imageOnly}},
+		{Label: "Qwen-Image Max (2025-12-30)", Name: "qwen-image-max-2025-12-30", Spec: llm.ModelSpec{Caps: imageOnly}},
+		{Label: "Qwen-Image Plus", Name: "qwen-image-plus", Spec: llm.ModelSpec{Caps: imageOnly}},
+		{Label: "Qwen-Image Plus (2026-01-09)", Name: "qwen-image-plus-2026-01-09", Spec: llm.ModelSpec{Caps: imageOnly}},
+		{Label: "Qwen-Image", Name: "qwen-image", Spec: llm.ModelSpec{Caps: imageOnly}},
+	})
+}
+
+// LLM is the Qwen-Image text-to-image adapter. It implements
+// [llm.LLM] so callers can route image generation through the same
+// resolver and fallback machinery as chat models.
+type LLM struct {
+	model   string
+	apiKey  string
+	baseURL string
+	client  *http.Client
+}
+
+// Option configures the adapter at construction time.
+type Option func(*LLM)
+
+// WithHTTPClient overrides the default *http.Client (120s timeout).
+// Useful for tests and for plugging in OTel/transport middleware.
+func WithHTTPClient(c *http.Client) Option {
+	return func(l *LLM) {
+		if c != nil {
+			l.client = c
+		}
+	}
+}
+
+// New builds an adapter pointing at the DashScope Qwen-Image
+// endpoint. An empty model defaults to "qwen-image-2.0-pro"; an
+// empty baseURL defaults to https://dashscope.aliyuncs.com (Beijing).
+// Set baseURL to "https://dashscope-intl.aliyuncs.com" for the
+// international (Singapore) region.
+func New(modelName, apiKey, baseURL string, opts ...Option) (*LLM, error) {
+	if apiKey == "" {
+		return nil, errdefs.Validation(errdefs.New("qwen-image: api_key required"))
+	}
+	if modelName == "" {
+		modelName = defaultModel
+	}
+	if baseURL == "" {
+		baseURL = defaultBaseURL
+	}
+	l := &LLM{
+		model:   modelName,
+		apiKey:  apiKey,
+		baseURL: strings.TrimRight(baseURL, "/"),
+		client:  &http.Client{Timeout: defaultTimeout},
+	}
+	for _, opt := range opts {
+		opt(l)
+	}
+	return l, nil
+}
+
+// --- llm.LLM ----------------------------------------------------------
+
+// Generate calls the Qwen-Image multimodal-generation endpoint and
+// returns an assistant message whose Parts are PartImage entries
+// (one per generated image). TokenUsage is left zero — the endpoint
+// reports image_count rather than token counts.
+func (l *LLM) Generate(ctx context.Context, messages []llm.Message, opts ...llm.GenerateOption) (llm.Message, llm.TokenUsage, error) {
+	o := llm.ApplyOptions(opts...)
+	prompt, refsCount := extractPrompt(messages)
+	if prompt == "" {
+		return llm.Message{}, llm.TokenUsage{}, errdefs.Validation(errdefs.New("qwen-image: empty prompt (no text parts in user messages)"))
+	}
+	if refsCount > 0 {
+		return llm.Message{}, llm.TokenUsage{}, errdefs.Validation(errdefs.New("qwen-image: this endpoint is text-to-image only; image editing is on the separate qwen-image-edit endpoint (not yet adapted)"))
+	}
+
+	body := buildRequest(l.model, prompt, o.ImageGen, o.Extra)
+	resp, err := l.do(ctx, body)
+	if err != nil {
+		return llm.Message{}, llm.TokenUsage{}, err
+	}
+	parts, err := imagesToParts(resp)
+	if err != nil {
+		return llm.Message{}, llm.TokenUsage{}, err
+	}
+	if len(parts) == 0 {
+		return llm.Message{}, llm.TokenUsage{}, errdefs.Internal(errdefs.New("qwen-image: provider returned zero images"))
+	}
+	usage := llm.TokenUsage{Model: l.model}
+	if resp.Usage != nil {
+		usage.OutputTokens = int64(resp.Usage.ImageCount)
+	}
+	return llm.Message{Role: model.RoleAssistant, Parts: parts}, usage, nil
+}
+
+// GenerateStream wraps Generate via [llm.NewOneChunkStream]; the
+// endpoint is synchronous.
+func (l *LLM) GenerateStream(ctx context.Context, messages []llm.Message, opts ...llm.GenerateOption) (llm.StreamMessage, error) {
+	msg, usage, err := l.Generate(ctx, messages, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return llm.NewOneChunkStream(msg, usage), nil
+}
+
+// --- request / response wire shape -----------------------------------
+
+type apiRequest struct {
+	Model      string        `json:"model"`
+	Input      apiInput      `json:"input"`
+	Parameters apiParameters `json:"parameters,omitempty"`
+}
+
+type apiInput struct {
+	Messages []apiMessage `json:"messages"`
+}
+
+type apiMessage struct {
+	Role    string       `json:"role"`
+	Content []apiContent `json:"content"`
+}
+
+type apiContent struct {
+	Text string `json:"text"`
+}
+
+type apiParameters struct {
+	NegativePrompt string `json:"negative_prompt,omitempty"`
+	Size           string `json:"size,omitempty"`
+	N              int    `json:"n,omitempty"`
+	PromptExtend   *bool  `json:"prompt_extend,omitempty"`
+	Watermark      *bool  `json:"watermark,omitempty"`
+	Seed           *int64 `json:"seed,omitempty"`
+}
+
+type apiResponse struct {
+	RequestID string     `json:"request_id,omitempty"`
+	Code      string     `json:"code,omitempty"`
+	Message   string     `json:"message,omitempty"`
+	Output    *apiOutput `json:"output,omitempty"`
+	Usage     *apiUsage  `json:"usage,omitempty"`
+}
+
+type apiOutput struct {
+	Choices []apiChoice `json:"choices,omitempty"`
+}
+
+type apiChoice struct {
+	FinishReason string         `json:"finish_reason,omitempty"`
+	Message      *apiOutMessage `json:"message,omitempty"`
+}
+
+type apiOutMessage struct {
+	Role    string              `json:"role,omitempty"`
+	Content []apiOutContentItem `json:"content,omitempty"`
+}
+
+type apiOutContentItem struct {
+	Image string `json:"image,omitempty"`
+	Text  string `json:"text,omitempty"`
+}
+
+type apiUsage struct {
+	ImageCount int `json:"image_count,omitempty"`
+	Width      int `json:"width,omitempty"`
+	Height     int `json:"height,omitempty"`
+}
+
+func buildRequest(modelName, prompt string, ig *llm.ImageGenOptions, extra map[string]any) apiRequest {
+	req := apiRequest{
+		Model: modelName,
+		Input: apiInput{Messages: []apiMessage{{
+			Role:    "user",
+			Content: []apiContent{{Text: prompt}},
+		}}},
+	}
+
+	if ig != nil {
+		// Note the unusual "*" separator: Qwen uses "W*H", not the
+		// "WxH" common to OpenAI / Seedream / MiniMax.
+		if ig.Width > 0 && ig.Height > 0 {
+			req.Parameters.Size = fmt.Sprintf("%d*%d", ig.Width, ig.Height)
+		}
+		if ig.N > 0 {
+			req.Parameters.N = ig.N
+		}
+		if ig.Seed != nil {
+			s := *ig.Seed
+			req.Parameters.Seed = &s
+		}
+		// AspectRatio and ResponseFormat have no native knob on this
+		// endpoint and are silently ignored — see package doc.
+	}
+
+	// Provider-specific overrides via Extra.
+	if v, ok := stringExtra(extra, "negative_prompt"); ok {
+		req.Parameters.NegativePrompt = v
+	}
+	if v, ok := stringExtra(extra, "size"); ok && v != "" {
+		req.Parameters.Size = v // overrides W*H-derived size
+	}
+	if v, ok := boolExtra(extra, "prompt_extend"); ok {
+		req.Parameters.PromptExtend = &v
+	}
+	if v, ok := boolExtra(extra, "watermark"); ok {
+		req.Parameters.Watermark = &v
+	}
+
+	return req
+}
+
+// extractPrompt collects all user-message text into one prompt and
+// reports the count of [model.PartImage] inputs so the caller can
+// fail-fast on an attempt to use this t2i-only endpoint with image
+// references.
+func extractPrompt(messages []llm.Message) (prompt string, imageRefs int) {
+	var b strings.Builder
+	for _, m := range messages {
+		if m.Role != model.RoleUser {
+			continue
+		}
+		for _, p := range m.Parts {
+			switch p.Type {
+			case model.PartText:
+				if b.Len() > 0 {
+					b.WriteString("\n")
+				}
+				b.WriteString(p.Text)
+			case model.PartImage:
+				imageRefs++
+			}
+		}
+	}
+	return strings.TrimSpace(b.String()), imageRefs
+}
+
+func imagesToParts(resp *apiResponse) ([]model.Part, error) {
+	if resp.Output == nil || len(resp.Output.Choices) == 0 {
+		return nil, nil
+	}
+	choice := resp.Output.Choices[0]
+	if choice.Message == nil {
+		return nil, nil
+	}
+	parts := make([]model.Part, 0, len(choice.Message.Content))
+	for _, c := range choice.Message.Content {
+		if c.Image == "" {
+			continue
+		}
+		parts = append(parts, model.Part{
+			Type:  model.PartImage,
+			Image: &model.MediaRef{URL: c.Image, MediaType: "image/png"},
+		})
+	}
+	return parts, nil
+}
+
+func (l *LLM) do(ctx context.Context, req apiRequest) (*apiResponse, error) {
+	body, err := json.Marshal(req)
+	if err != nil {
+		return nil, errdefs.Internal(errdefs.Fmt("qwen-image: marshal request: %w", err))
+	}
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, l.baseURL+imageGenPath, bytes.NewReader(body))
+	if err != nil {
+		return nil, errdefs.Internal(errdefs.Fmt("qwen-image: build request: %w", err))
+	}
+	httpReq.Header.Set("Content-Type", "application/json")
+	httpReq.Header.Set("Authorization", "Bearer "+l.apiKey)
+
+	resp, err := l.client.Do(httpReq)
+	if err != nil {
+		return nil, errdefs.NotAvailable(errdefs.Fmt("qwen-image: http call: %w", err))
+	}
+	defer resp.Body.Close()
+
+	raw, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, errdefs.Internal(errdefs.Fmt("qwen-image: read body: %w", err))
+	}
+
+	switch {
+	case resp.StatusCode == http.StatusUnauthorized:
+		return nil, errdefs.Unauthorized(errdefs.Fmt("qwen-image: 401: %s", truncate(string(raw), 200)))
+	case resp.StatusCode == http.StatusTooManyRequests:
+		return nil, errdefs.RateLimit(errdefs.Fmt("qwen-image: 429: %s", truncate(string(raw), 200)))
+	case resp.StatusCode >= 500:
+		return nil, errdefs.NotAvailable(errdefs.Fmt("qwen-image: %d: %s", resp.StatusCode, truncate(string(raw), 200)))
+	case resp.StatusCode >= 400:
+		// 400 may carry a structured error envelope — try to decode
+		// it for a more helpful category.
+		if err := tryDecodeError(raw); err != nil {
+			return nil, err
+		}
+		return nil, errdefs.Validation(errdefs.Fmt("qwen-image: %d: %s", resp.StatusCode, truncate(string(raw), 200)))
+	}
+
+	var out apiResponse
+	if err := json.Unmarshal(raw, &out); err != nil {
+		return nil, errdefs.Internal(errdefs.Fmt("qwen-image: decode body: %w (raw=%s)", err, truncate(string(raw), 200)))
+	}
+	// 200-but-business-error: code is set on top-level when the
+	// model rejects the request (e.g. "InvalidParameter").
+	if out.Code != "" {
+		return nil, mapAPIError(out.Code, out.Message)
+	}
+	return &out, nil
+}
+
+func tryDecodeError(raw []byte) error {
+	var env struct {
+		Code    string `json:"code,omitempty"`
+		Message string `json:"message,omitempty"`
+	}
+	if err := json.Unmarshal(raw, &env); err != nil || env.Code == "" {
+		return nil
+	}
+	return mapAPIError(env.Code, env.Message)
+}
+
+// mapAPIError maps DashScope error codes to errdefs categories. The
+// DashScope error envelope follows the Aliyun convention; the cases
+// below cover documented Qwen-Image failures (see
+// help.aliyun.com/zh/model-studio/error-code).
+func mapAPIError(code, message string) error {
+	msg := fmt.Sprintf("qwen-image: %s %s", code, message)
+	switch {
+	case strings.HasPrefix(code, "InvalidApiKey"),
+		strings.HasPrefix(code, "AuthenticationError"),
+		strings.HasPrefix(code, "Unauthorized"):
+		return errdefs.Unauthorized(errdefs.New(msg))
+	case strings.HasPrefix(code, "Throttling"),
+		strings.HasPrefix(code, "RateLimit"),
+		strings.HasPrefix(code, "RequestLimitExceeded"):
+		return errdefs.RateLimit(errdefs.New(msg))
+	case strings.HasPrefix(code, "AccessDenied"),
+		strings.HasPrefix(code, "ArrearagedAccount"),
+		strings.HasPrefix(code, "InsufficientBalance"):
+		return errdefs.Forbidden(errdefs.New(msg))
+	case strings.HasPrefix(code, "InvalidParameter"),
+		strings.HasPrefix(code, "InvalidRequest"),
+		strings.HasPrefix(code, "ResourceNotFound"),
+		strings.HasPrefix(code, "ContentFiltered"),
+		strings.HasPrefix(code, "DataInspection"):
+		return errdefs.Validation(errdefs.New(msg))
+	case strings.HasPrefix(code, "InternalError"),
+		strings.HasPrefix(code, "ServiceUnavailable"):
+		return errdefs.NotAvailable(errdefs.New(msg))
+	default:
+		return errdefs.Internal(errdefs.New(msg))
+	}
+}
+
+// --- helpers ---------------------------------------------------------
+
+func stringExtra(extra map[string]any, key string) (string, bool) {
+	if extra == nil {
+		return "", false
+	}
+	v, ok := extra[key]
+	if !ok {
+		return "", false
+	}
+	s, ok := v.(string)
+	return s, ok
+}
+
+func boolExtra(extra map[string]any, key string) (bool, bool) {
+	if extra == nil {
+		return false, false
+	}
+	v, ok := extra[key]
+	if !ok {
+		return false, false
+	}
+	b, ok := v.(bool)
+	return b, ok
+}
+
+func truncate(s string, n int) string {
+	if len(s) <= n {
+		return s
+	}
+	return s[:n] + "…"
+}

--- a/sdkx/llm/qwen/image/image_test.go
+++ b/sdkx/llm/qwen/image/image_test.go
@@ -1,0 +1,363 @@
+package image
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/GizClaw/flowcraft/sdk/errdefs"
+	"github.com/GizClaw/flowcraft/sdk/llm"
+	"github.com/GizClaw/flowcraft/sdk/model"
+)
+
+func newMockServer(t *testing.T, status int, body []byte, capture *apiRequest) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != imageGenPath {
+			t.Errorf("unexpected path %q", r.URL.Path)
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer test-key" {
+			t.Errorf("missing/incorrect Authorization header: %q", got)
+		}
+		if capture != nil {
+			raw, err := io.ReadAll(r.Body)
+			if err != nil {
+				t.Fatalf("read body: %v", err)
+			}
+			if err := json.Unmarshal(raw, capture); err != nil {
+				t.Fatalf("decode body: %v (raw=%s)", err, raw)
+			}
+		}
+		w.WriteHeader(status)
+		_, _ = w.Write(body)
+	}))
+}
+
+func successBody(images ...string) []byte {
+	content := make([]apiOutContentItem, 0, len(images))
+	for _, u := range images {
+		content = append(content, apiOutContentItem{Image: u})
+	}
+	resp := apiResponse{
+		RequestID: "req-1",
+		Output: &apiOutput{Choices: []apiChoice{{
+			FinishReason: "stop",
+			Message:      &apiOutMessage{Role: "assistant", Content: content},
+		}}},
+		Usage: &apiUsage{ImageCount: len(images), Width: 2048, Height: 2048},
+	}
+	b, _ := json.Marshal(resp)
+	return b
+}
+
+func TestNew_RequiresAPIKey(t *testing.T) {
+	_, err := New("qwen-image-2.0-pro", "", "")
+	if err == nil || !errdefs.IsValidation(err) {
+		t.Fatalf("expected validation error, got %v", err)
+	}
+}
+
+func TestNew_DefaultModelAndBaseURL(t *testing.T) {
+	l, err := New("", "k", "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if l.model != defaultModel {
+		t.Errorf("default model = %q, want %q", l.model, defaultModel)
+	}
+	if l.baseURL != defaultBaseURL {
+		t.Errorf("default base URL = %q, want %q", l.baseURL, defaultBaseURL)
+	}
+}
+
+func TestGenerate_TextToImage_DefaultPath(t *testing.T) {
+	var captured apiRequest
+	srv := newMockServer(t, http.StatusOK, successBody("https://cdn/x.png"), &captured)
+	defer srv.Close()
+
+	l, err := New("qwen-image-2.0-pro", "test-key", srv.URL, WithHTTPClient(srv.Client()))
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	msg, usage, err := l.Generate(context.Background(), []llm.Message{
+		{Role: model.RoleUser, Parts: []model.Part{{Type: model.PartText, Text: "a kitten"}}},
+	})
+	if err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+	if msg.Role != model.RoleAssistant {
+		t.Errorf("role = %q, want assistant", msg.Role)
+	}
+	if len(msg.Parts) != 1 || msg.Parts[0].Type != model.PartImage || msg.Parts[0].Image == nil || msg.Parts[0].Image.URL != "https://cdn/x.png" {
+		t.Errorf("unexpected parts: %+v", msg.Parts)
+	}
+	if usage.OutputTokens != 1 {
+		t.Errorf("usage.OutputTokens = %d, want 1 (mapped from image_count)", usage.OutputTokens)
+	}
+	if captured.Model != "qwen-image-2.0-pro" {
+		t.Errorf("captured model = %q", captured.Model)
+	}
+	if len(captured.Input.Messages) != 1 || len(captured.Input.Messages[0].Content) != 1 || captured.Input.Messages[0].Content[0].Text != "a kitten" {
+		t.Errorf("unexpected request body: %+v", captured)
+	}
+}
+
+func TestGenerate_ImageGenOptionsMapping(t *testing.T) {
+	var captured apiRequest
+	srv := newMockServer(t, http.StatusOK, successBody("https://cdn/x.png", "https://cdn/y.png"), &captured)
+	defer srv.Close()
+
+	l, _ := New("qwen-image-2.0-pro", "test-key", srv.URL, WithHTTPClient(srv.Client()))
+	seed := int64(42)
+	_, _, err := l.Generate(context.Background(), []llm.Message{
+		{Role: model.RoleUser, Parts: []model.Part{{Type: model.PartText, Text: "two cats"}}},
+	}, llm.WithImageGen(llm.ImageGenOptions{Width: 2048, Height: 2048, N: 2, Seed: &seed}))
+	if err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+	// Note the "*" separator (Qwen uses "W*H", not "WxH").
+	if got := captured.Parameters.Size; got != "2048*2048" {
+		t.Errorf("size = %q, want 2048*2048", got)
+	}
+	if got := captured.Parameters.N; got != 2 {
+		t.Errorf("n = %d, want 2", got)
+	}
+	if captured.Parameters.Seed == nil || *captured.Parameters.Seed != 42 {
+		t.Errorf("seed = %v, want 42", captured.Parameters.Seed)
+	}
+}
+
+func TestGenerate_ExtraOverrides(t *testing.T) {
+	var captured apiRequest
+	srv := newMockServer(t, http.StatusOK, successBody("https://cdn/x.png"), &captured)
+	defer srv.Close()
+
+	l, _ := New("qwen-image-max", "test-key", srv.URL, WithHTTPClient(srv.Client()))
+	_, _, err := l.Generate(context.Background(), []llm.Message{
+		{Role: model.RoleUser, Parts: []model.Part{{Type: model.PartText, Text: "hello"}}},
+	},
+		// W/H first; Extra "size" should override.
+		llm.WithImageGen(llm.ImageGenOptions{Width: 2048, Height: 2048}),
+		llm.WithExtra("size", "1664*928"),
+		llm.WithExtra("negative_prompt", "low quality"),
+		llm.WithExtra("prompt_extend", false),
+		llm.WithExtra("watermark", true),
+	)
+	if err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+	if captured.Parameters.Size != "1664*928" {
+		t.Errorf("size = %q, want 1664*928 (extra override)", captured.Parameters.Size)
+	}
+	if captured.Parameters.NegativePrompt != "low quality" {
+		t.Errorf("negative_prompt = %q", captured.Parameters.NegativePrompt)
+	}
+	if captured.Parameters.PromptExtend == nil || *captured.Parameters.PromptExtend != false {
+		t.Errorf("prompt_extend = %v, want false", captured.Parameters.PromptExtend)
+	}
+	if captured.Parameters.Watermark == nil || *captured.Parameters.Watermark != true {
+		t.Errorf("watermark = %v, want true", captured.Parameters.Watermark)
+	}
+}
+
+func TestGenerate_RejectsImageReferences(t *testing.T) {
+	srv := newMockServer(t, http.StatusOK, successBody("https://cdn/x.png"), nil)
+	defer srv.Close()
+
+	l, _ := New("qwen-image-2.0-pro", "test-key", srv.URL, WithHTTPClient(srv.Client()))
+	_, _, err := l.Generate(context.Background(), []llm.Message{
+		{Role: model.RoleUser, Parts: []model.Part{
+			{Type: model.PartText, Text: "edit this"},
+			{Type: model.PartImage, Image: &model.MediaRef{URL: "https://cdn/in.png"}},
+		}},
+	})
+	if err == nil || !errdefs.IsValidation(err) {
+		t.Fatalf("expected validation error for image-reference input, got %v", err)
+	}
+}
+
+func TestGenerate_EmptyPrompt(t *testing.T) {
+	srv := newMockServer(t, http.StatusOK, successBody("https://cdn/x.png"), nil)
+	defer srv.Close()
+
+	l, _ := New("qwen-image-2.0-pro", "test-key", srv.URL, WithHTTPClient(srv.Client()))
+	_, _, err := l.Generate(context.Background(), []llm.Message{
+		{Role: model.RoleUser, Parts: []model.Part{{Type: model.PartText, Text: "   "}}},
+	})
+	if err == nil || !errdefs.IsValidation(err) {
+		t.Fatalf("expected validation error, got %v", err)
+	}
+}
+
+func TestGenerate_HTTPErrorMapping(t *testing.T) {
+	tests := []struct {
+		name   string
+		status int
+		check  func(error) bool
+	}{
+		{"401", http.StatusUnauthorized, errdefs.IsUnauthorized},
+		{"429", http.StatusTooManyRequests, errdefs.IsRateLimit},
+		{"500", http.StatusInternalServerError, errdefs.IsNotAvailable},
+		{"400 (no envelope)", http.StatusBadRequest, errdefs.IsValidation},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := newMockServer(t, tc.status, []byte(`oops`), nil)
+			defer srv.Close()
+			l, _ := New("qwen-image-2.0-pro", "test-key", srv.URL, WithHTTPClient(srv.Client()))
+			_, _, err := l.Generate(context.Background(), []llm.Message{
+				{Role: model.RoleUser, Parts: []model.Part{{Type: model.PartText, Text: "hi"}}},
+			})
+			if err == nil || !tc.check(err) {
+				t.Fatalf("status %d: expected matching errdef, got %v", tc.status, err)
+			}
+		})
+	}
+}
+
+func TestGenerate_APIErrorEnvelope(t *testing.T) {
+	tests := []struct {
+		code  string
+		check func(error) bool
+	}{
+		{"InvalidApiKey", errdefs.IsUnauthorized},
+		{"Throttling.User", errdefs.IsRateLimit},
+		{"AccessDenied.Unpurchased", errdefs.IsForbidden},
+		{"InvalidParameter", errdefs.IsValidation},
+		{"DataInspectionFailed", errdefs.IsValidation},
+		{"InternalError.Algo", errdefs.IsNotAvailable},
+		{"SomethingElse", errdefs.IsInternal},
+	}
+	for _, tc := range tests {
+		t.Run(tc.code, func(t *testing.T) {
+			// 200 + top-level code is the typical Qwen-Image business
+			// failure shape.
+			body, _ := json.Marshal(apiResponse{Code: tc.code, Message: "boom", RequestID: "req-x"})
+			srv := newMockServer(t, http.StatusOK, body, nil)
+			defer srv.Close()
+			l, _ := New("qwen-image-2.0-pro", "test-key", srv.URL, WithHTTPClient(srv.Client()))
+			_, _, err := l.Generate(context.Background(), []llm.Message{
+				{Role: model.RoleUser, Parts: []model.Part{{Type: model.PartText, Text: "hi"}}},
+			})
+			if err == nil || !tc.check(err) {
+				t.Fatalf("code %s: expected matching errdef, got %v", tc.code, err)
+			}
+		})
+	}
+}
+
+func TestGenerate_400WithEnvelope(t *testing.T) {
+	body := []byte(`{"code":"InvalidParameter","message":"num_images_per_prompt must be 1","request_id":"req-x"}`)
+	srv := newMockServer(t, http.StatusBadRequest, body, nil)
+	defer srv.Close()
+	l, _ := New("qwen-image-max", "test-key", srv.URL, WithHTTPClient(srv.Client()))
+	_, _, err := l.Generate(context.Background(), []llm.Message{
+		{Role: model.RoleUser, Parts: []model.Part{{Type: model.PartText, Text: "hi"}}},
+	})
+	if err == nil || !errdefs.IsValidation(err) {
+		t.Fatalf("expected validation error, got %v", err)
+	}
+}
+
+func TestGenerate_ZeroImages(t *testing.T) {
+	body, _ := json.Marshal(apiResponse{Output: &apiOutput{Choices: []apiChoice{{Message: &apiOutMessage{}}}}})
+	srv := newMockServer(t, http.StatusOK, body, nil)
+	defer srv.Close()
+	l, _ := New("qwen-image-2.0-pro", "test-key", srv.URL, WithHTTPClient(srv.Client()))
+	_, _, err := l.Generate(context.Background(), []llm.Message{
+		{Role: model.RoleUser, Parts: []model.Part{{Type: model.PartText, Text: "hi"}}},
+	})
+	if err == nil || !errdefs.IsInternal(err) {
+		t.Fatalf("expected internal error for zero images, got %v", err)
+	}
+}
+
+func TestGenerate_TransportError(t *testing.T) {
+	srv := newMockServer(t, http.StatusOK, successBody("https://cdn/x.png"), nil)
+	srv.Close() // induce a transport error
+	l, _ := New("qwen-image-2.0-pro", "test-key", srv.URL, WithHTTPClient(srv.Client()))
+	_, _, err := l.Generate(context.Background(), []llm.Message{
+		{Role: model.RoleUser, Parts: []model.Part{{Type: model.PartText, Text: "hi"}}},
+	})
+	if err == nil || !errdefs.IsNotAvailable(err) {
+		t.Fatalf("expected not-available error, got %v", err)
+	}
+}
+
+func TestGenerateStream_OneShot(t *testing.T) {
+	srv := newMockServer(t, http.StatusOK, successBody("https://cdn/x.png"), nil)
+	defer srv.Close()
+	l, _ := New("qwen-image-2.0-pro", "test-key", srv.URL, WithHTTPClient(srv.Client()))
+	stream, err := l.GenerateStream(context.Background(), []llm.Message{
+		{Role: model.RoleUser, Parts: []model.Part{{Type: model.PartText, Text: "hi"}}},
+	})
+	if err != nil {
+		t.Fatalf("GenerateStream: %v", err)
+	}
+	// One chunk; iterator-style API.
+	if !stream.Next() {
+		t.Fatalf("expected first Next() = true, err=%v", stream.Err())
+	}
+	if stream.Next() {
+		t.Fatalf("expected second Next() = false")
+	}
+	if err := stream.Err(); err != nil {
+		t.Fatalf("Err after exhaustion: %v", err)
+	}
+	final := stream.Message()
+	if len(final.Parts) != 1 || final.Parts[0].Type != model.PartImage {
+		t.Errorf("unexpected message after stream: %+v", final)
+	}
+}
+
+func TestExtractPrompt(t *testing.T) {
+	prompt, refs := extractPrompt([]llm.Message{
+		{Role: model.RoleSystem, Parts: []model.Part{{Type: model.PartText, Text: "ignored"}}},
+		{Role: model.RoleUser, Parts: []model.Part{
+			{Type: model.PartText, Text: "first"},
+			{Type: model.PartImage, Image: &model.MediaRef{URL: "https://cdn/in.png"}},
+		}},
+		{Role: model.RoleUser, Parts: []model.Part{{Type: model.PartText, Text: "second"}}},
+	})
+	if prompt != "first\nsecond" {
+		t.Errorf("prompt = %q, want %q", prompt, "first\nsecond")
+	}
+	if refs != 1 {
+		t.Errorf("refs = %d, want 1", refs)
+	}
+}
+
+func TestProviderRegistration(t *testing.T) {
+	// All catalog entries must be retrievable.
+	models := []string{
+		"qwen-image-2.0-pro",
+		"qwen-image-2.0-pro-2026-04-22",
+		"qwen-image-2.0-pro-2026-03-03",
+		"qwen-image-2.0",
+		"qwen-image-2.0-2026-03-03",
+		"qwen-image-max",
+		"qwen-image-max-2025-12-30",
+		"qwen-image-plus",
+		"qwen-image-plus-2026-01-09",
+		"qwen-image",
+	}
+	for _, m := range models {
+		if _, ok := llm.DefaultRegistry.LookupModel(providerKey, m); !ok {
+			t.Errorf("model %q not registered under provider %q", m, providerKey)
+			continue
+		}
+		spec := llm.DefaultRegistry.LookupModelSpec(providerKey, m)
+		if !spec.Caps.Supports(llm.CapImageOutput) {
+			t.Errorf("model %q should support CapImageOutput", m)
+		}
+		if spec.Caps.Supports(llm.CapTools) {
+			t.Errorf("model %q should NOT support CapTools", m)
+		}
+		if spec.Caps.Supports(llm.CapAudioOutput) {
+			t.Errorf("model %q should NOT support CapAudioOutput", m)
+		}
+	}
+}

--- a/sdkx/llm/qwen/qwen.go
+++ b/sdkx/llm/qwen/qwen.go
@@ -33,7 +33,16 @@ func init() {
 	// for these chat-completions models so callers get a fail-fast
 	// rather than a backend error. Vision is supported across the
 	// commercial chat models (qwen-max et al.) per Model Studio docs.
-	qwenChatCaps := llm.DisabledCaps(llm.CapAudio, llm.CapFile)
+	//
+	// Output modality: text only. Image generation lives in the
+	// dedicated Qwen-Image SKU and audio output in Qwen3-Omni /
+	// Qwen3.5-Omni — separate adapters not catalogued here. Disable
+	// the matching output caps so policy matching does not route
+	// image-output / audio-output slots onto these chat models.
+	qwenChatCaps := llm.DisabledCaps(
+		llm.CapAudio, llm.CapFile,
+		llm.CapImageOutput, llm.CapAudioOutput,
+	)
 
 	llm.RegisterProviderModels("qwen", []llm.ModelInfo{
 		{

--- a/tests/e2e/vesseld/go.mod
+++ b/tests/e2e/vesseld/go.mod
@@ -5,7 +5,7 @@ go 1.25.0
 require github.com/GizClaw/flowcraft/cmd/vesseld v0.0.0
 
 require (
-	github.com/GizClaw/flowcraft/sdk v0.2.7 // indirect
+	github.com/GizClaw/flowcraft/sdk v0.2.8 // indirect
 	github.com/GizClaw/flowcraft/sdkx v0.2.5 // indirect
 	github.com/GizClaw/flowcraft/vessel v0.1.0-rc.2 // indirect
 	github.com/anthropics/anthropic-sdk-go v1.26.0 // indirect

--- a/tests/e2e/vesseld/go.mod
+++ b/tests/e2e/vesseld/go.mod
@@ -5,7 +5,7 @@ go 1.25.0
 require github.com/GizClaw/flowcraft/cmd/vesseld v0.0.0
 
 require (
-	github.com/GizClaw/flowcraft/sdk v0.2.8 // indirect
+	github.com/GizClaw/flowcraft/sdk v0.2.7 // indirect
 	github.com/GizClaw/flowcraft/sdkx v0.2.5 // indirect
 	github.com/GizClaw/flowcraft/vessel v0.1.0-rc.2 // indirect
 	github.com/anthropics/anthropic-sdk-go v1.26.0 // indirect
@@ -40,9 +40,14 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
-replace (
-	github.com/GizClaw/flowcraft/cmd/vesseld => ../../../cmd/vesseld
-	github.com/GizClaw/flowcraft/sdk => ../../../sdk
-	github.com/GizClaw/flowcraft/sdkx => ../../../sdkx
-	github.com/GizClaw/flowcraft/vessel => ../../../vessel
-)
+// Only replace modules that have no published version we can pin
+// against. sdk / sdkx / vessel ARE published so they stay
+// version-pinned — this isolates the e2e suite from in-flight
+// library PRs and keeps a downstream PR's CI from breaking just
+// because it bumps an indirect dep here.
+//
+// cmd/vesseld is the lone exception: it is intentionally never
+// tagged as a Go module (it ships as a binary release artifact —
+// see .github/workflows/auto-tag.yml), so the local-tree replace
+// is mandatory.
+replace github.com/GizClaw/flowcraft/cmd/vesseld => ../../../cmd/vesseld

--- a/tests/e2e/vesseld/go.sum
+++ b/tests/e2e/vesseld/go.sum
@@ -1,5 +1,11 @@
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
+github.com/GizClaw/flowcraft/sdk v0.2.7 h1:J9nA8JPwR+gbDPSOVh1vas8/YT2bFvoJXd0dUGYoWiY=
+github.com/GizClaw/flowcraft/sdk v0.2.7/go.mod h1:ESQWkg/xVCc+2RIO7Lxkdp9lwW9U+u2q+lojvnRzK3Y=
+github.com/GizClaw/flowcraft/sdkx v0.2.5 h1:n5astpfg5UuKS6DrG0As2awjeWFlpyAsV2eNAoIgNEw=
+github.com/GizClaw/flowcraft/sdkx v0.2.5/go.mod h1:KnamFfKt1q/8v6ArviMBePE0eIUeMpNtrovcLvO18hE=
+github.com/GizClaw/flowcraft/vessel v0.1.0-rc.2 h1:tXvxaEhy0aQK1yjet8yE1kbQp3UBrEbQ1aSN1HCeyKY=
+github.com/GizClaw/flowcraft/vessel v0.1.0-rc.2/go.mod h1:Zv7w5uTFQtBYKhE7911YNJ8w1cBsTmR6n7VEajvYFQY=
 github.com/anthropics/anthropic-sdk-go v1.26.0 h1:oUTzFaUpAevfuELAP1sjL6CQJ9HHAfT7CoSYSac11PY=
 github.com/anthropics/anthropic-sdk-go v1.26.0/go.mod h1:qUKmaW+uuPB64iy1l+4kOSvaLqPXnHTTBKH6RVZ7q5Q=
 github.com/avast/retry-go v3.0.0+incompatible/go.mod h1:XtSnn+n/sHqQIpZ10K1qAevBhOOCWBLXXy3hyiqqBrY=


### PR DESCRIPTION
## Summary

Builds on the new sdk/llm primitives shipped in `sdk/v0.2.8` (#71)
to deliver three production image-generation adapters and align
existing chat catalogs with the new output-modality capabilities.

### Catalog alignment (chat models, text-only output)

`openai` / `anthropic` / `deepseek` / `qwen` / `minimax` (M2 chat)
/ `bytedance` (Doubao Seed chat) — `DisabledCaps` now also
disables `CapImageOutput` and `CapAudioOutput`. Without this, the
blacklist semantics would silently advertise image / audio output
on every chat-only catalog. Verified against each provider's
current public model list (2026-04-30).

### New image-generation adapters

| Provider key | Path | Endpoint | Notable |
| --- | --- | --- | --- |
| `minimax-image` | `sdkx/llm/minimax/image` | `/v1/image_generation` | `image-01` / `image-01-live`; subject_reference for i2i |
| `bytedance-image` | `sdkx/llm/bytedance/image` | `/api/v3/images/generations` | Seedream 5.0 / 5.0-lite / 4.5 / 4.0; multi-ref + sequential generation; web_search / optimize_prompt_mode escape hatches |
| `qwen-image` | `sdkx/llm/qwen/image` | `/api/v1/services/aigc/multimodal-generation/generation` | Qwen-Image 2.0 Pro / 2.0 / Max / Plus; default Beijing region; rejects `PartImage` inputs (t2i-only contract) |

Each adapter:

- Implements the standard `llm.LLM` interface.
- Wraps synchronous responses via the public
  `llm.NewOneChunkStream` helper to satisfy `llm.StreamMessage`.
- Has its own `DisabledCaps` profile (CapVision + CapImageOutput
  on, every chat-completion knob off).
- Maps provider-specific error codes to typed `errdefs` categories.
- Ships with a gofmt-stable `doc.go` and a self-contained unit
  test suite using `httptest`.

### Provider keys are deliberately distinct from chat keys

`minimax-image` (vs `minimax`), `bytedance-image` (vs `bytedance`),
`qwen-image` (vs `qwen`). This keeps the capability matrix clean —
chat catalogs advertise text-only output, image catalogs advertise
`CapImageOutput`. Same upstream API key works for both pools but
they are tracked independently for routing / rate-limit purposes.

## Dependency bump

`sdkx/go.mod`: `github.com/GizClaw/flowcraft/sdk` → `v0.2.8`

Pulls in the new `CapImageOutput` / `CapAudioOutput` /
`ImageGenOptions` / `NewOneChunkStream` surface that this PR
consumes.

## Test plan

- [x] `cd sdkx && GOWORK=off go vet ./...`
- [x] `cd sdkx && GOWORK=off go test ./llm/... -count=1 -race`
- [x] Live API smoke run via `tests/conformance/llm/image_test.go`
      (5 scenarios × 3 providers, all green; saved sample images
      verified visually).

## Follow-ups

- `tests/conformance`: bump sdkx pin to the upcoming sdkx tag and
  drop the local `replace` directives. Will land once auto-tag
  publishes the sdkx version produced by this PR's merge.

Made with [Cursor](https://cursor.com)