### PR TITLE
feat(tests/conformance): add image-generation conformance suite

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,9 +44,6 @@
 !.github/**
 
 # ── Global excludes (override all allowed dirs) ──
-# Example: go build in examples/voice-pipeline produces ./voice-pipeline
-examples/voice-pipeline/voice-pipeline
-examples/chatbot-with-recall/chatbot-with-recall
 **/.DS_Store
 **/Thumbs.db
 **/*.exe

--- a/examples/.gitignore
+++ b/examples/.gitignore
@@ -1,0 +1,3 @@
+/voice-pipeline/voice-pipeline
+/chatbot-with-recall/chatbot-with-recall
+

--- a/tests/conformance/.gitignore
+++ b/tests/conformance/.gitignore
@@ -1,0 +1,4 @@
+# Conformance test artefacts: images downloaded by image_test.go when
+# SAVE_GENERATED_IMAGES=1. Never committed.
+/llm/_out/
+

--- a/tests/conformance/README.md
+++ b/tests/conformance/README.md
@@ -17,9 +17,11 @@ credential-less run is a no-op (useful as a compile check):
 make conformance
 ```
 
-To actually exercise the providers, populate a repo-root `.env` and
-re-run `make conformance`. The loader walks up from each test's CWD,
-so any of the candidates work.
+To actually exercise the providers, copy `.env.example` from the repo
+root to `.env`, fill in credentials, and re-run `make conformance`.
+The loader walks up from each test's CWD, so any of the candidates
+work. `.env` is git-ignored; `.env.example` is the source-of-truth
+template.
 
 ## Required env vars
 
@@ -35,6 +37,34 @@ unset provider are skipped.
 | `FLOWCRAFT_TEST_BYTEDANCE` | bytedance |
 | `FLOWCRAFT_TEST_AZURE` | azure |
 | `FLOWCRAFT_TEST_DEEPSEEK` | deepseek |
+
+### LLM image-generation providers (`tests/conformance/llm/image_test.go`)
+
+Same JSON shape as the chat providers, registered under separate
+provider keys so chat and image catalogs stay decoupled. See
+`.env.example` at the repo root for ready-to-paste templates.
+
+| Env var | Provider key | Default model |
+| --- | --- | --- |
+| `FLOWCRAFT_TEST_MINIMAX_IMAGE` | `minimax-image` | `image-01` |
+| `FLOWCRAFT_TEST_BYTEDANCE_IMAGE` | `bytedance-image` | `doubao-seedream-5-0-260128` |
+| `FLOWCRAFT_TEST_QWEN_IMAGE` | `qwen-image` | `qwen-image-2.0-pro` |
+
+Scenarios:
+
+- Basic text-to-image (all three).
+- Explicit `Width`/`Height` mapping (verifies `WxH` vs `W*H` size syntax).
+- Streaming via `NewOneChunkStream` (single chunk + final message).
+- Image-to-image with a reference URL (`minimax-image`, `bytedance-image`).
+- `qwen-image` rejection of `PartImage` inputs (the t2i-only contract).
+
+Generated image URLs are normally just logged. To download every
+returned image to `tests/conformance/llm/_out/` for offline visual
+review (the directory is git-ignored), set `SAVE_GENERATED_IMAGES=1`:
+
+```bash
+SAVE_GENERATED_IMAGES=1 make test-conformance
+```
 
 JSON shape:
 

--- a/tests/conformance/go.mod
+++ b/tests/conformance/go.mod
@@ -3,8 +3,8 @@ module github.com/GizClaw/flowcraft/tests/conformance
 go 1.25.0
 
 require (
-	github.com/GizClaw/flowcraft/sdk v0.2.4
-	github.com/GizClaw/flowcraft/sdkx v0.2.2
+	github.com/GizClaw/flowcraft/sdk v0.2.8
+	github.com/GizClaw/flowcraft/sdkx v0.2.6
 )
 
 require (

--- a/tests/conformance/go.sum
+++ b/tests/conformance/go.sum
@@ -8,10 +8,10 @@ github.com/Azure/azure-sdk-for-go/sdk/internal v1.10.0/go.mod h1:iZDifYGJTIgIIkY
 github.com/AzureAD/microsoft-authentication-library-for-go v1.2.2 h1:XHOnouVk1mxXfQidrMEnLlPk9UMeRtyBTnEFtxkV0kU=
 github.com/AzureAD/microsoft-authentication-library-for-go v1.2.2/go.mod h1:wP83P5OoQ5p6ip3ScPr0BAq0BvuPAvacpEuSzyouqAI=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
-github.com/GizClaw/flowcraft/sdk v0.2.4 h1:xUD4PFOB1maQjf5yP3wKEmcGWPhsUt97DMdF0xuThko=
-github.com/GizClaw/flowcraft/sdk v0.2.4/go.mod h1:ESQWkg/xVCc+2RIO7Lxkdp9lwW9U+u2q+lojvnRzK3Y=
-github.com/GizClaw/flowcraft/sdkx v0.2.2 h1:NtExFhnwNIi4Lu/7LAVA+ltdk1W8tYFXNvNufyUzfbI=
-github.com/GizClaw/flowcraft/sdkx v0.2.2/go.mod h1:Hp9Wn3d/cOPETZpQpcWWxkI15NIZWWL9ahoUdKOYXhQ=
+github.com/GizClaw/flowcraft/sdk v0.2.8 h1:8Xq0oYd396lMajj/k0EQ6mbqZNXsVht2/r2SqZ/C83k=
+github.com/GizClaw/flowcraft/sdk v0.2.8/go.mod h1:ESQWkg/xVCc+2RIO7Lxkdp9lwW9U+u2q+lojvnRzK3Y=
+github.com/GizClaw/flowcraft/sdkx v0.2.6 h1:zl5NrnDSZ8lHytvlbo+dFWgeyzLyoBqdaq0QDNbZIb4=
+github.com/GizClaw/flowcraft/sdkx v0.2.6/go.mod h1:OGwbJ9UJw1s88lTG89yCdiDMuudnWUlN6ODpbM+NXrw=
 github.com/anthropics/anthropic-sdk-go v1.26.0 h1:oUTzFaUpAevfuELAP1sjL6CQJ9HHAfT7CoSYSac11PY=
 github.com/anthropics/anthropic-sdk-go v1.26.0/go.mod h1:qUKmaW+uuPB64iy1l+4kOSvaLqPXnHTTBKH6RVZ7q5Q=
 github.com/avast/retry-go v3.0.0+incompatible/go.mod h1:XtSnn+n/sHqQIpZ10K1qAevBhOOCWBLXXy3hyiqqBrY=

--- a/tests/conformance/llm/image_test.go
+++ b/tests/conformance/llm/image_test.go
@@ -1,0 +1,389 @@
+package llm_test
+
+import (
+	"context"
+	"encoding/base64"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/GizClaw/flowcraft/sdk/llm"
+	"github.com/GizClaw/flowcraft/sdk/model"
+
+	// Trigger init() self-registration for the image-generation
+	// adapters. They live under separate provider keys so the chat
+	// imports above do NOT pull them in implicitly.
+	_ "github.com/GizClaw/flowcraft/sdkx/llm/bytedance/image"
+	_ "github.com/GizClaw/flowcraft/sdkx/llm/minimax/image"
+	_ "github.com/GizClaw/flowcraft/sdkx/llm/qwen/image"
+)
+
+// imageProviders enumerates the image-generation adapters under
+// test. Each entry self-skips when its env var is unset so a
+// credential-less run is a no-op (matches the chat-conformance
+// pattern). Provider keys here are deliberately distinct from the
+// chat provider keys ("minimax", "bytedance", "qwen") since image
+// catalogs are registered under separate keys to keep capability
+// matrices clean.
+var imageProviders = []providerSpec{
+	{Provider: "minimax-image", Env: "FLOWCRAFT_TEST_MINIMAX_IMAGE"},
+	{Provider: "bytedance-image", Env: "FLOWCRAFT_TEST_BYTEDANCE_IMAGE"},
+	{Provider: "qwen-image", Env: "FLOWCRAFT_TEST_QWEN_IMAGE"},
+}
+
+// countImageParts returns the number of [model.PartImage] parts in
+// msg, regardless of whether they're URL- or base64-backed.
+func countImageParts(msg llm.Message) int {
+	n := 0
+	for _, p := range msg.Parts {
+		if p.Type == llm.PartImage {
+			n++
+		}
+	}
+	return n
+}
+
+// firstImageDescriptor returns a short stable descriptor of the
+// first image part, useful for log output without dumping the full
+// payload.
+func firstImageDescriptor(msg llm.Message) string {
+	for _, p := range msg.Parts {
+		if p.Type != llm.PartImage || p.Image == nil {
+			continue
+		}
+		switch {
+		case p.Image.URL != "":
+			return "url=" + p.Image.URL
+		case p.Image.Base64 != "":
+			d := p.Image.Base64
+			if len(d) > 32 {
+				d = d[:32] + "…"
+			}
+			return "base64=" + d
+		}
+	}
+	return "<no image>"
+}
+
+// maybeSaveImages writes every [model.PartImage] in msg to
+// tests/conformance/llm/_out/ when SAVE_GENERATED_IMAGES is truthy.
+// Unset / "0" / "false" → no-op (default for CI and credential-less
+// runs). The directory is created on demand and listed in
+// .gitignore so accidental commits are prevented.
+//
+// Filenames are stable enough for human inspection but unique per
+// invocation: "{provider}_{test}_{nanos}_{idx}.{ext}". Failure to
+// download is logged with t.Errorf — the test still passes if the
+// API contract held; only the offline review fails.
+func maybeSaveImages(t *testing.T, provider string, msg llm.Message) {
+	t.Helper()
+	if !envTruthy(os.Getenv("SAVE_GENERATED_IMAGES")) {
+		return
+	}
+	dir := outputDir(t)
+	if dir == "" {
+		return
+	}
+	stamp := time.Now().UnixNano()
+	idx := 0
+	for _, p := range msg.Parts {
+		if p.Type != llm.PartImage || p.Image == nil {
+			continue
+		}
+		ext, data, err := fetchImageBytes(p.Image)
+		if err != nil {
+			t.Errorf("fetch image bytes for save: %v", err)
+			continue
+		}
+		name := fmt.Sprintf("%s_%s_%d_%d.%s",
+			sanitizeForFilename(provider),
+			sanitizeForFilename(t.Name()),
+			stamp, idx, ext)
+		path := filepath.Join(dir, name)
+		if err := os.WriteFile(path, data, 0o644); err != nil {
+			t.Errorf("write %s: %v", path, err)
+			continue
+		}
+		t.Logf("saved -> %s (%d bytes)", path, len(data))
+		idx++
+	}
+}
+
+func fetchImageBytes(ref *model.MediaRef) (ext string, data []byte, err error) {
+	switch {
+	case ref.URL != "":
+		client := &http.Client{Timeout: 30 * time.Second}
+		resp, err := client.Get(ref.URL)
+		if err != nil {
+			return "", nil, fmt.Errorf("GET %s: %w", ref.URL, err)
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode >= 400 {
+			return "", nil, fmt.Errorf("GET %s: status %d", ref.URL, resp.StatusCode)
+		}
+		body, err := io.ReadAll(resp.Body)
+		if err != nil {
+			return "", nil, err
+		}
+		return extFromMediaTypeOrURL(ref.MediaType, ref.URL), body, nil
+	case ref.Base64 != "":
+		body, err := base64.StdEncoding.DecodeString(ref.Base64)
+		if err != nil {
+			return "", nil, fmt.Errorf("decode base64: %w", err)
+		}
+		return extFromMediaTypeOrURL(ref.MediaType, ""), body, nil
+	default:
+		return "", nil, fmt.Errorf("MediaRef has neither URL nor Base64")
+	}
+}
+
+func extFromMediaTypeOrURL(mediaType, url string) string {
+	switch mediaType {
+	case "image/png":
+		return "png"
+	case "image/jpeg", "image/jpg":
+		return "jpg"
+	case "image/webp":
+		return "webp"
+	}
+	if i := strings.IndexByte(url, '?'); i >= 0 {
+		url = url[:i]
+	}
+	switch e := strings.ToLower(filepath.Ext(url)); e {
+	case ".png", ".jpg", ".jpeg", ".webp":
+		return strings.TrimPrefix(e, ".")
+	}
+	return "bin"
+}
+
+// outputDir returns the absolute path of the per-package output
+// directory, creating it on demand. It anchors at the test's CWD
+// (the conformance/llm/ package directory under `go test`).
+func outputDir(t *testing.T) string {
+	t.Helper()
+	wd, err := os.Getwd()
+	if err != nil {
+		t.Errorf("getwd: %v", err)
+		return ""
+	}
+	dir := filepath.Join(wd, "_out")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Errorf("mkdir %s: %v", dir, err)
+		return ""
+	}
+	return dir
+}
+
+func envTruthy(v string) bool {
+	switch strings.ToLower(strings.TrimSpace(v)) {
+	case "", "0", "false", "no", "off":
+		return false
+	}
+	return true
+}
+
+func sanitizeForFilename(s string) string {
+	r := strings.NewReplacer("/", "_", " ", "_", ":", "_", string(filepath.Separator), "_")
+	return r.Replace(s)
+}
+
+// ---------------------------------------------------------------------------
+// Scenario 1: basic text-to-image — minimal smoke test for every adapter
+// ---------------------------------------------------------------------------
+
+func TestImageProviders_BasicTextToImage(t *testing.T) {
+	for _, spec := range imageProviders {
+		t.Run(spec.Provider, func(t *testing.T) {
+			provider := createProvider(t, spec)
+			ctx, cancel := context.WithTimeout(context.Background(), 90*time.Second)
+			defer cancel()
+
+			msgs := []llm.Message{
+				llm.NewTextMessage(llm.RoleUser, "A photorealistic ginger kitten sitting on a wooden floor, soft natural light."),
+			}
+			resp, _, err := provider.Generate(ctx, msgs)
+			if err != nil {
+				t.Fatalf("Generate error: %v", err)
+			}
+			if got := countImageParts(resp); got == 0 {
+				t.Fatalf("expected at least 1 image part, got 0 (parts=%+v)", resp.Parts)
+			}
+			t.Logf("first=%s images=%d", firstImageDescriptor(resp), countImageParts(resp))
+			maybeSaveImages(t, spec.Provider, resp)
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Scenario 2: explicit Width/Height — every adapter must accept and route
+// the dimensions to its provider-native field. Adapters internally translate
+// to "WxH" (MiniMax/Seedream) or "W*H" (Qwen).
+//
+// Each family has very different valid ranges, so we use per-provider
+// sizes that are known to be accepted:
+//
+//   - minimax-image:   image-01 accepts 256–1536 per side (multiple of 8).
+//   - bytedance-image: Seedream 5.0 requires ≥1920² total pixels.
+//   - qwen-image:      2.0 series accepts 512–2048 total pixel range.
+// ---------------------------------------------------------------------------
+
+func TestImageProviders_ExplicitDimensions(t *testing.T) {
+	type sizeCase struct {
+		provider providerSpec
+		w, h     int
+	}
+	cases := []sizeCase{
+		{providerSpec{Provider: "minimax-image", Env: "FLOWCRAFT_TEST_MINIMAX_IMAGE"}, 1024, 1024},
+		{providerSpec{Provider: "bytedance-image", Env: "FLOWCRAFT_TEST_BYTEDANCE_IMAGE"}, 2048, 2048},
+		{providerSpec{Provider: "qwen-image", Env: "FLOWCRAFT_TEST_QWEN_IMAGE"}, 1024, 1024},
+	}
+	for _, tc := range cases {
+		t.Run(tc.provider.Provider, func(t *testing.T) {
+			provider := createProvider(t, tc.provider)
+			ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
+			defer cancel()
+
+			msgs := []llm.Message{
+				llm.NewTextMessage(llm.RoleUser, "A simple geometric pattern in pastel colors."),
+			}
+			resp, _, err := provider.Generate(ctx, msgs,
+				llm.WithImageGen(llm.ImageGenOptions{Width: tc.w, Height: tc.h}),
+			)
+			if err != nil {
+				t.Fatalf("Generate error (%dx%d): %v", tc.w, tc.h, err)
+			}
+			if got := countImageParts(resp); got == 0 {
+				t.Fatalf("expected at least 1 image part, got 0")
+			}
+			t.Logf("size=%dx%d first=%s", tc.w, tc.h, firstImageDescriptor(resp))
+			maybeSaveImages(t, tc.provider.Provider, resp)
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Scenario 3: streaming via NewOneChunkStream — every adapter wraps its
+// synchronous response in a single-chunk stream. Validates the
+// llm.StreamMessage contract: Next() once, Err() == nil, Message() carries
+// the image parts.
+// ---------------------------------------------------------------------------
+
+func TestImageProviders_Streaming(t *testing.T) {
+	for _, spec := range imageProviders {
+		t.Run(spec.Provider, func(t *testing.T) {
+			provider := createProvider(t, spec)
+			ctx, cancel := context.WithTimeout(context.Background(), 90*time.Second)
+			defer cancel()
+
+			msgs := []llm.Message{
+				llm.NewTextMessage(llm.RoleUser, "A red apple on a white background."),
+			}
+			stream, err := provider.GenerateStream(ctx, msgs)
+			if err != nil {
+				t.Fatalf("GenerateStream error: %v", err)
+			}
+			defer stream.Close()
+			chunks := 0
+			for stream.Next() {
+				chunks++
+			}
+			if err := stream.Err(); err != nil {
+				t.Fatalf("stream error: %v", err)
+			}
+			final := stream.Message()
+			if got := countImageParts(final); got == 0 {
+				t.Fatalf("expected at least 1 image part in final message, got 0")
+			}
+			t.Logf("chunks=%d first=%s", chunks, firstImageDescriptor(final))
+			maybeSaveImages(t, spec.Provider, final)
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Scenario 4: image-to-image with a reference URL.
+//
+// Only minimax-image and bytedance-image support reference-image input on
+// their generation endpoints. qwen-image rejects PartImage at the adapter
+// level (image editing is on the separate qwen-image-edit endpoint).
+// ---------------------------------------------------------------------------
+
+func TestImageProviders_ImageToImage(t *testing.T) {
+	// Reference image hosted on Aliyun help-static CDN. We deliberately
+	// avoid Wikipedia / GitHub-raw URLs because the upstream image
+	// generation servers (MiniMax in Shanghai, Volcengine Ark in
+	// Beijing) often cannot reach foreign CDNs and surface the result
+	// as cryptic "invalid params, img_url" / "Timeout while
+	// downloading url" errors. The chosen URL is one of Qwen's own
+	// example images and is reachable from both regions.
+	const refImageURL = "https://help-static-aliyun-doc.aliyuncs.com/assets/img/zh-CN/0552803771/p1005422.png"
+
+	specs := []providerSpec{
+		{Provider: "minimax-image", Env: "FLOWCRAFT_TEST_MINIMAX_IMAGE"},
+		{Provider: "bytedance-image", Env: "FLOWCRAFT_TEST_BYTEDANCE_IMAGE"},
+	}
+	for _, spec := range specs {
+		t.Run(spec.Provider, func(t *testing.T) {
+			provider := createProvider(t, spec)
+			ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
+			defer cancel()
+
+			msgs := []llm.Message{
+				{
+					Role: llm.RoleUser,
+					Parts: []model.Part{
+						{Type: llm.PartText, Text: "Re-imagine this cat in an oil-painting style."},
+						{Type: llm.PartImage, Image: &model.MediaRef{URL: refImageURL, MediaType: "image/jpeg"}},
+					},
+				},
+			}
+			resp, _, err := provider.Generate(ctx, msgs)
+			if err != nil {
+				t.Fatalf("Generate error: %v", err)
+			}
+			if got := countImageParts(resp); got == 0 {
+				t.Fatalf("expected at least 1 image part, got 0")
+			}
+			t.Logf("first=%s", firstImageDescriptor(resp))
+			maybeSaveImages(t, spec.Provider, resp)
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Scenario 5: qwen-image must REJECT image inputs (this endpoint is
+// text-to-image only; image editing lives on qwen-image-edit).
+// ---------------------------------------------------------------------------
+
+func TestImageProviders_QwenRejectsImageInput(t *testing.T) {
+	spec := providerSpec{Provider: "qwen-image", Env: "FLOWCRAFT_TEST_QWEN_IMAGE"}
+	provider := createProvider(t, spec)
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	msgs := []llm.Message{
+		{
+			Role: llm.RoleUser,
+			Parts: []model.Part{
+				{Type: llm.PartText, Text: "Edit this please."},
+				{Type: llm.PartImage, Image: &model.MediaRef{URL: "https://example.com/whatever.png"}},
+			},
+		},
+	}
+	_, _, err := provider.Generate(ctx, msgs)
+	if err == nil {
+		t.Fatal("expected validation error for image input on qwen-image, got nil")
+	}
+	// The error message should mention either qwen-image-edit or
+	// text-to-image so callers can tell why the request was refused.
+	msg := err.Error()
+	if !strings.Contains(msg, "text-to-image") && !strings.Contains(msg, "edit") {
+		t.Errorf("error %q does not mention t2i-only constraint", msg)
+	}
+	t.Logf("rejected as expected: %v", err)
+}


### PR DESCRIPTION
## Summary

Live-API conformance scenarios for the three image-generation
adapters that landed in `sdkx/v0.2.6` via #72:
`minimax-image` / `bytedance-image` / `qwen-image`.

Each test self-skips when its `FLOWCRAFT_TEST_*_IMAGE` env var is
unset, so credential-less runs (CI default) are a no-op. Same
pattern as the existing chat conformance suite.

## Scenarios

| # | Test | Coverage |
| --- | --- | --- |
| 1 | `BasicTextToImage` | Smoke for every adapter |
| 2 | `ExplicitDimensions` | `Width`/`Height` routing — `WxH` (MiniMax / Seedream) vs `W*H` (Qwen) |
| 3 | `Streaming` | `NewOneChunkStream` contract: single chunk + final message |
| 4 | `ImageToImage` | Reference-image input (minimax / bytedance only) |
| 5 | `QwenRejectsImageInput` | Pins the t2i-only contract |

## Optional offline review

`SAVE_GENERATED_IMAGES=1 make test-conformance` downloads every
returned image into `tests/conformance/llm/_out/` (git-ignored)
for visual inspection. Off by default, so CI / credential-less
runs stay disk-clean.

## Dependency / replace housekeeping

- `sdk` pin: `v0.2.6` → `v0.2.8` (consumes #71's
  `CapImageOutput` / `ImageGenOptions` / `NewOneChunkStream`).
- `sdkx` pin: `v0.2.2` → `v0.2.6` (consumes #72's three image
  adapters).
- Drops the local `replace` directives that were temporarily
  added while #71 / #72 were in flight. The module now
  exclusively tests against released versions, restoring the
  README's stated "isolate dependency graph from sdk/sdkx
  releases" property.

## Bonus housekeeping (separate commit)

`chore(.gitignore): relocate per-example binary ignores` — moves
`examples/voice-pipeline/voice-pipeline` and
`examples/chatbot-with-recall/chatbot-with-recall` from the
top-level `.gitignore` into a new `examples/.gitignore` so future
examples can manage their build artefacts in isolation. Net
behaviour identical.

## Test plan

- [x] `cd tests/conformance && GOWORK=off go vet ./...`
- [x] `cd tests/conformance && GOWORK=off go test -count=1 ./...`
      (creds-less, all skip cleanly)
- [x] Live run against my keys with all five scenarios green;
      `SAVE_GENERATED_IMAGES=1` produced and visually verified the
      11 sample images.

Made with [Cursor](https://cursor.com)