### PR TITLE
feat(sdkx): tool migration wrappers + Anthropic Memory Tool

### DIFF
--- a/docs/migrations/v0.3.0.md
+++ b/docs/migrations/v0.3.0.md
@@ -46,15 +46,15 @@ agent-orchestration primitive, not an external service adapter.
 
 The function/struct shapes are preserved; only the import path changes.
 
-| Today (`sdk` v0.2.x)                              | After (`sdk/v0.3.0` + `sdkx/v0.3.0`)             |
-| ------------------------------------------------- | ------------------------------------------------ |
-| `sdk/knowledge.NewSearchServiceTool`              | `sdkx/tool/knowledge.NewSearchServiceTool`       |
-| `sdk/knowledge.NewPutServiceTool`                 | `sdkx/tool/knowledge.NewPutServiceTool`          |
-| `sdk/kanban.SubmitTool`                           | `sdkx/tool/kanban.SubmitTool`                    |
-| `sdk/kanban.TaskContextTool`                      | `sdkx/tool/kanban.TaskContextTool`               |
-| `sdk/kanban.WithKanban` / `sdk/kanban.KanbanFrom` | `sdkx/tool/kanban.WithKanban` / `KanbanFrom`     |
-| `sdk/history.ToolDeps`                            | `sdkx/tool/history.ToolDeps`                     |
-| `sdk/history.RegisterTools`                       | `sdkx/tool/history.RegisterTools`                |
+| Today (`sdk` v0.2.x)                              | After (`sdk/v0.3.0` + `sdkx/v0.3.0`)         |
+| ------------------------------------------------- | -------------------------------------------- |
+| `sdk/knowledge.NewSearchServiceTool`              | `sdkx/tool/knowledge.NewSearchServiceTool`   |
+| `sdk/knowledge.NewPutServiceTool`                 | `sdkx/tool/knowledge.NewPutServiceTool`      |
+| `sdk/kanban.SubmitTool`                           | `sdkx/tool/kanban.SubmitTool`                |
+| `sdk/kanban.TaskContextTool`                      | `sdkx/tool/kanban.TaskContextTool`           |
+| `sdk/kanban.WithKanban` / `sdk/kanban.KanbanFrom` | `sdkx/tool/kanban.WithKanban` / `KanbanFrom` |
+| `sdk/history.ToolDeps`                            | `sdkx/tool/history.ToolDeps`                 |
+| `sdk/history.RegisterTools`                       | `sdkx/tool/history.RegisterTools`            |
 
 **New `sdkx/tool/...` packages landing alongside (no removal pressure):**
 
@@ -75,8 +75,29 @@ Mechanical import-path swap:
 + search := knowledgetool.NewSearchServiceTool(svc)
 ```
 
-A migration script (`scripts/migrate-tools-v0.3.go`) will be shipped
-that rewrites these imports in-place.
+#### Release coordination with `sdkx`
+
+`sdk` and `sdkx` are independent Go modules with independent version
+streams, but the tool migration straddles both. The schedule is:
+
+| Phase      | sdk                                                | sdkx                                                                                                                                                                                                                                                                                                       |
+| ---------- | -------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| v0.2.x     | tools live in `sdk` (deprecated), still functional | `sdkx/tool/{knowledge,kanban,history,memory}` published as forward-compatible wrappers. `history` is a Go type alias + delegation; `kanban` reuses the sdk-side context key                                                                                                                                |
+| v0.3.0 cut | tools deleted from `sdk`                           | `sdkx` ships a coordinated release that takes ownership: `sdkx/tool/history` inlines the relocated archive helpers; `sdkx/tool/kanban` hosts its own context key. Public **signatures stay identical** — for downstream code the cut is a `go get -u` away, no source changes after the v0.2.x import swap |
+
+Recommended user upgrade path:
+
+1. **During v0.2.x**: change imports from `sdk/{knowledge,kanban,history}`
+   to `sdkx/tool/{knowledge,kanban,history}` (mechanical text swap, see
+   the diff above). Tag boundaries are not crossed.
+2. **At v0.3.0**: `go get -u github.com/GizClaw/flowcraft/sdk@v0.3.0
+github.com/GizClaw/flowcraft/sdkx@v0.3.0` and rebuild. No source
+   edits needed.
+
+This is exactly why the v0.2.x sdkx wrappers are deliberately a thin
+forwarding layer rather than a re-implementation: it lets the
+"change imports" event and the "change underlying implementation"
+event happen at separate, low-risk moments for users.
 
 ### `sdk/llm` — round helpers and capability shims removed
 
@@ -226,8 +247,6 @@ To soften the impact:
 
 ## See also
 
-- [`CLAUDE.md`](../../CLAUDE.md) — repository conventions, including
-  the `sdk` ↔ `sdkx` layering rule
 - Per-package `deprecated.go` files, the source of truth:
   - [`sdk/llm/deprecated.go`](../../sdk/llm/deprecated.go)
   - [`sdk/graph/deprecated.go`](../../sdk/graph/deprecated.go)

--- a/sdkx/tool/history/doc.go
+++ b/sdkx/tool/history/doc.go
@@ -1,0 +1,34 @@
+// Package history ships the LLM-callable tool wrappers around
+// sdk/history.Coordinator. It is the v0.3.0 home of [ToolDeps]
+// and [RegisterTools], which currently live in sdk/history with
+// // Deprecated: markers pointing here.
+//
+// # Why sdkx
+//
+// sdk defines interfaces and primitives; sdkx ships concrete adapters
+// that integrate with external systems or external protocol specs.
+// LLM tool implementations are concrete adapters — they bridge the
+// generic [tool.Tool] interface to one specific service — and
+// therefore belong here, mirroring the existing sdk/llm → sdkx/llm/...
+// layout. See docs/migrations/v0.3.0.md.
+//
+// # Surface
+//
+// During the v0.2.x → v0.3.0 transition this package is a thin
+// re-export layer over sdk/history because the underlying tool
+// implementation depends on package-private archive helpers
+// (loadManifestImpl, archiveImpl, ...) that cannot be reached from
+// outside sdk/history. ToolDeps is a Go type alias to
+// [sdkhistory.ToolDeps] so the structures are interchangeable; the
+// migration is a pure import-path swap:
+//
+//	-import "github.com/GizClaw/flowcraft/sdk/history"
+//	+import historytool "github.com/GizClaw/flowcraft/sdkx/tool/history"
+//
+//	- history.RegisterTools(reg, history.ToolDeps{...})
+//	+ historytool.RegisterTools(reg, historytool.ToolDeps{...})
+//
+// At sdk/v0.3.0 the sdk-side helpers and their private dependencies
+// relocate into this package, and the alias is replaced with a
+// first-class type definition.
+package history

--- a/sdkx/tool/history/tools.go
+++ b/sdkx/tool/history/tools.go
@@ -1,0 +1,29 @@
+package history
+
+import (
+	sdkhistory "github.com/GizClaw/flowcraft/sdk/history"
+	"github.com/GizClaw/flowcraft/sdk/tool"
+)
+
+// ToolDeps bundles everything the history_expand / history_compact
+// tools need at registration time. Pass it to [RegisterTools].
+//
+// This is a Go type alias to [sdkhistory.ToolDeps] — instances of
+// either type are interchangeable. At sdk/v0.3.0 this becomes a
+// first-class type definition once the sdk-side helpers are deleted.
+//
+// See [sdkhistory.ToolDeps] for field semantics.
+type ToolDeps = sdkhistory.ToolDeps
+
+// RegisterTools registers history_expand and history_compact against
+// the supplied [tool.Registry]. The summary index is auto-injected
+// into the LLM system prompt via the workflow.VarSummaryIndex board
+// variable, so a separate history_search tool is not needed.
+//
+// During the v0.2.x → v0.3.0 transition this delegates to
+// [sdkhistory.RegisterTools] because the tool implementation
+// reaches into package-private archive helpers in sdk/history. At
+// sdk/v0.3.0 the implementation relocates into this package.
+func RegisterTools(registry *tool.Registry, deps ToolDeps) {
+	sdkhistory.RegisterTools(registry, deps)
+}

--- a/sdkx/tool/history/tools_test.go
+++ b/sdkx/tool/history/tools_test.go
@@ -1,0 +1,35 @@
+package history_test
+
+import (
+	"testing"
+
+	sdkhistory "github.com/GizClaw/flowcraft/sdk/history"
+	"github.com/GizClaw/flowcraft/sdk/tool"
+	historytool "github.com/GizClaw/flowcraft/sdkx/tool/history"
+)
+
+func TestRegisterTools_RegistersBothNames(t *testing.T) {
+	reg := tool.NewRegistry()
+	historytool.RegisterTools(reg, historytool.ToolDeps{})
+
+	for _, name := range []string{"history_expand", "history_compact"} {
+		if _, ok := reg.Get(name); !ok {
+			t.Errorf("registry missing tool %q after RegisterTools", name)
+		}
+	}
+}
+
+// TypeAliasInterop verifies the Go type alias contract: a value of
+// the sdkx ToolDeps must be assignable to sdkhistory.ToolDeps without
+// conversion (and vice-versa). This guards against an accidental
+// future switch from `type Foo = sdkhistory.Foo` to `type Foo
+// sdkhistory.Foo`, which would silently break user code.
+func TestTypeAliasInterop(t *testing.T) {
+	var sdkx historytool.ToolDeps
+	var sdk sdkhistory.ToolDeps = sdkx
+	_ = sdk
+
+	var sdk2 sdkhistory.ToolDeps
+	var sdkx2 historytool.ToolDeps = sdk2
+	_ = sdkx2
+}

--- a/sdkx/tool/kanban/doc.go
+++ b/sdkx/tool/kanban/doc.go
@@ -1,0 +1,35 @@
+// Package kanban ships the LLM-callable tool wrappers around
+// sdk/kanban.Kanban. It is the v0.3.0 home of [SubmitTool],
+// [TaskContextTool], [WithKanban] and [KanbanFrom], which currently
+// live in sdk/kanban with // Deprecated: markers pointing here.
+//
+// # Why sdkx
+//
+// sdk defines interfaces and primitives; sdkx ships concrete adapters
+// that integrate with external systems or external protocol specs.
+// LLM tool implementations are concrete adapters — they bridge the
+// generic [tool.Tool] interface to one specific service — and
+// therefore belong here, mirroring the existing sdk/llm → sdkx/llm/...
+// layout. See docs/migrations/v0.3.0.md.
+//
+// # Surface
+//
+// Mirrors the sdk/kanban versions verbatim. Tool names, JSON shapes,
+// behaviour, and error codes are preserved across the move; the
+// migration is a pure import-path swap:
+//
+//	-import "github.com/GizClaw/flowcraft/sdk/kanban"
+//	+import kanbantool "github.com/GizClaw/flowcraft/sdkx/tool/kanban"
+//
+//	- ctx = kanban.WithKanban(ctx, k)
+//	+ ctx = kanbantool.WithKanban(ctx, k)
+//
+// # Context-key compatibility
+//
+// During the v0.2.x → v0.3.0 transition both sdk/kanban.WithKanban
+// and this package's WithKanban interoperate: the sdkx versions are
+// thin re-exports of the sdk functions so a [SubmitTool] reading
+// from ctx finds a [*kanban.Kanban] that was installed via either
+// API. At sdk/v0.3.0 the sdk-side helpers are deleted; the sdkx
+// versions become the canonical implementation.
+package kanban

--- a/sdkx/tool/kanban/tools.go
+++ b/sdkx/tool/kanban/tools.go
@@ -1,0 +1,184 @@
+package kanban
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/GizClaw/flowcraft/sdk/errdefs"
+	sdkkanban "github.com/GizClaw/flowcraft/sdk/kanban"
+	"github.com/GizClaw/flowcraft/sdk/model"
+	"github.com/GizClaw/flowcraft/sdk/tool"
+)
+
+// SubmitTool allows LLM to submit tasks to the Kanban board.
+// Kanban is injected via struct field (when the instance is known
+// at construction) or resolved from context at execution time via
+// [KanbanFrom].
+//
+// This is the v0.3.0 location of the helper that lives at
+// [sdkkanban.SubmitTool] in v0.2.x. Behaviour is identical; only
+// the import path changes.
+type SubmitTool struct {
+	Kanban *sdkkanban.Kanban
+}
+
+// Definition implements [tool.Tool].
+func (t *SubmitTool) Definition() model.ToolDefinition {
+	return tool.DefineSchema(
+		"kanban_submit",
+		"Dispatch a task to another agent. Returns a card_id. The agent executes in the background and the system delivers the result via a [Task Callback] message when done. "+
+			"You can optionally schedule the task with a delay or cron expression.",
+		tool.Property("target_agent_id", "string", "Target agent ID to execute the task"),
+		tool.Property("query", "string", "Specific task instruction for the target agent"),
+		tool.Property("user_query", "string",
+			"The user's original request that triggered this task"),
+		tool.Property("dispatch_note", "string",
+			"Brief note about the task purpose and how to summarize the result for the user"),
+		tool.Property("delay", "string",
+			"Execute after a delay instead of immediately. Go duration format, e.g. \"30s\", \"5m\", \"2h\""),
+		tool.Property("cron", "string",
+			"Execute on a recurring cron schedule. 5-field cron expression (minute hour day month weekday). Examples: \"0 9 * * MON-FRI\" = weekdays 9AM, \"*/30 * * * *\" = every 30 minutes"),
+		tool.Property("timezone", "string",
+			"Timezone for cron schedule, IANA format. e.g. \"Asia/Shanghai\", \"America/New_York\". Defaults to UTC"),
+	).Required("target_agent_id", "query").Build()
+}
+
+// Execute implements [tool.Tool].
+func (t *SubmitTool) Execute(ctx context.Context, arguments string) (string, error) {
+	k := t.resolve(ctx)
+	if k == nil {
+		return "", errdefs.NotAvailablef("kanban_submit: no kanban instance available")
+	}
+
+	var args struct {
+		TargetAgentID string `json:"target_agent_id"`
+		Query         string `json:"query"`
+		UserQuery     string `json:"user_query"`
+		DispatchNote  string `json:"dispatch_note"`
+		Delay         string `json:"delay"`
+		Cron          string `json:"cron"`
+		Timezone      string `json:"timezone"`
+	}
+	if err := json.Unmarshal([]byte(arguments), &args); err != nil {
+		return "", fmt.Errorf("kanban_submit: invalid arguments: %w", err)
+	}
+
+	cardID, err := k.Submit(ctx, sdkkanban.TaskOptions{
+		TargetAgentID: args.TargetAgentID,
+		Query:         args.Query,
+		UserQuery:     args.UserQuery,
+		DispatchNote:  args.DispatchNote,
+		Delay:         args.Delay,
+		Cron:          args.Cron,
+		Timezone:      args.Timezone,
+	})
+	if err != nil {
+		return "", err
+	}
+
+	status := "submitted"
+	message := "Task submitted. The target agent is executing in the background. A [Task Callback] message will be delivered when done."
+	idLabel := "card_id"
+	if args.Cron != "" {
+		status = "scheduled"
+		message = fmt.Sprintf("Recurring task scheduled (cron: %s). The task will be submitted automatically on each trigger.", args.Cron)
+		idLabel = "schedule_id"
+	} else if args.Delay != "" {
+		status = "delayed"
+		message = fmt.Sprintf("Task will be submitted after %s delay.", args.Delay)
+		idLabel = "timer_id"
+	}
+
+	out, _ := json.Marshal(map[string]string{
+		idLabel:           cardID,
+		"status":          status,
+		"target_agent_id": args.TargetAgentID,
+		"message":         message,
+	})
+	return string(out), nil
+}
+
+func (t *SubmitTool) resolve(ctx context.Context) *sdkkanban.Kanban {
+	if t.Kanban != nil {
+		return t.Kanban
+	}
+	return KanbanFrom(ctx)
+}
+
+// TaskContextTool allows the Dispatcher to retrieve the full context
+// of a previously dispatched async task, including the original user
+// request, dispatch note, task instruction, and execution result.
+//
+// This is the v0.3.0 location of the helper that lives at
+// [sdkkanban.TaskContextTool] in v0.2.x. Behaviour is identical;
+// only the import path changes.
+type TaskContextTool struct {
+	Kanban *sdkkanban.Kanban
+}
+
+// Definition implements [tool.Tool].
+func (t *TaskContextTool) Definition() model.ToolDefinition {
+	return tool.DefineSchema(
+		"task_context",
+		"Retrieve the full context of a dispatched task, including original user request, "+
+			"your dispatch note, task instruction, and execution result. "+
+			"Use this when you receive a task callback and need to recall the original context.",
+		tool.Property("card_id", "string", "The card ID from the task callback message"),
+	).Required("card_id").Build()
+}
+
+// Execute implements [tool.Tool].
+func (t *TaskContextTool) Execute(ctx context.Context, arguments string) (string, error) {
+	k := t.resolve(ctx)
+	if k == nil {
+		return "", errdefs.NotAvailablef("task_context: no kanban instance available")
+	}
+
+	var args struct {
+		CardID string `json:"card_id"`
+	}
+	if err := json.Unmarshal([]byte(arguments), &args); err != nil {
+		return "", fmt.Errorf("task_context: invalid arguments: %w", err)
+	}
+
+	card, err := k.GetCard(ctx, args.CardID)
+	if err != nil {
+		return "", fmt.Errorf("task_context: %w", err)
+	}
+
+	return sdkkanban.BuildTaskContext(card), nil
+}
+
+func (t *TaskContextTool) resolve(ctx context.Context) *sdkkanban.Kanban {
+	if t.Kanban != nil {
+		return t.Kanban
+	}
+	return KanbanFrom(ctx)
+}
+
+// WithKanban attaches a [*sdkkanban.Kanban] instance to ctx so the
+// LLM-facing [SubmitTool] / [TaskContextTool] can resolve it without
+// a struct field. Used by hosts that wire tools into a registry
+// before the Kanban instance is constructed.
+//
+// The implementation re-exports [sdkkanban.WithKanban] so contexts
+// installed by either package interoperate during the v0.2.x →
+// v0.3.0 transition. After sdk/v0.3.0 the sdk-side helper is
+// deleted and this function will hold the canonical implementation.
+func WithKanban(ctx context.Context, k *sdkkanban.Kanban) context.Context {
+	return sdkkanban.WithKanban(ctx, k)
+}
+
+// KanbanFrom retrieves the [*sdkkanban.Kanban] instance previously
+// installed by [WithKanban] (or by [sdkkanban.WithKanban]), or nil
+// when absent.
+func KanbanFrom(ctx context.Context) *sdkkanban.Kanban {
+	return sdkkanban.KanbanFrom(ctx)
+}
+
+// Compile-time interface check.
+var (
+	_ tool.Tool = (*SubmitTool)(nil)
+	_ tool.Tool = (*TaskContextTool)(nil)
+)

--- a/sdkx/tool/kanban/tools_test.go
+++ b/sdkx/tool/kanban/tools_test.go
@@ -1,0 +1,90 @@
+package kanban_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	sdkkanban "github.com/GizClaw/flowcraft/sdk/kanban"
+	tool "github.com/GizClaw/flowcraft/sdkx/tool/kanban"
+)
+
+func newKanban(t *testing.T) *sdkkanban.Kanban {
+	t.Helper()
+	sb := sdkkanban.NewBoard("scope-test")
+	k := sdkkanban.New(context.Background(), sb,
+		sdkkanban.WithConfig(sdkkanban.KanbanConfig{MaxPendingTasks: 100}))
+	t.Cleanup(k.Stop)
+	return k
+}
+
+func TestSubmitTool_Definition(t *testing.T) {
+	x := &tool.SubmitTool{}
+	def := x.Definition()
+	if def.Name != "kanban_submit" {
+		t.Fatalf("name = %q, want kanban_submit", def.Name)
+	}
+}
+
+func TestSubmitTool_Execute(t *testing.T) {
+	k := newKanban(t)
+	x := &tool.SubmitTool{Kanban: k}
+	out, err := x.Execute(context.Background(),
+		`{"query":"create app","target_agent_id":"copilot_builder","user_query":"创建应用","dispatch_note":"完成后通知"}`)
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	for _, want := range []string{`"card_id"`, `"status":"submitted"`, `"target_agent_id":"copilot_builder"`} {
+		if !strings.Contains(out, want) {
+			t.Errorf("missing %q in result: %s", want, out)
+		}
+	}
+}
+
+func TestSubmitTool_NilKanban(t *testing.T) {
+	x := &tool.SubmitTool{}
+	_, err := x.Execute(context.Background(), `{"query":"q","target_agent_id":"a"}`)
+	if err == nil {
+		t.Fatal("want error when no kanban available")
+	}
+}
+
+func TestSubmitTool_FromContext(t *testing.T) {
+	k := newKanban(t)
+	ctx := tool.WithKanban(context.Background(), k)
+	x := &tool.SubmitTool{}
+	out, err := x.Execute(ctx, `{"query":"q","target_agent_id":"a"}`)
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if !strings.Contains(out, `"card_id"`) {
+		t.Errorf("missing card_id: %s", out)
+	}
+}
+
+// Round-trip with sdk-side WithKanban: contexts installed via the
+// deprecated sdk helper must be readable by the sdkx KanbanFrom and
+// vice-versa during the v0.2.x → v0.3.0 transition.
+func TestContextInterop(t *testing.T) {
+	k := newKanban(t)
+
+	// sdk-installed → sdkx readable
+	ctx := sdkkanban.WithKanban(context.Background(), k)
+	if got := tool.KanbanFrom(ctx); got != k {
+		t.Errorf("sdk install / sdkx read: got %v want %v", got, k)
+	}
+
+	// sdkx-installed → sdk readable
+	ctx2 := tool.WithKanban(context.Background(), k)
+	if got := sdkkanban.KanbanFrom(ctx2); got != k {
+		t.Errorf("sdkx install / sdk read: got %v want %v", got, k)
+	}
+}
+
+func TestTaskContextTool_NilKanban(t *testing.T) {
+	x := &tool.TaskContextTool{}
+	_, err := x.Execute(context.Background(), `{"card_id":"x"}`)
+	if err == nil {
+		t.Fatal("want error when no kanban available")
+	}
+}

--- a/sdkx/tool/knowledge/doc.go
+++ b/sdkx/tool/knowledge/doc.go
@@ -1,0 +1,27 @@
+// Package knowledge ships the LLM-callable tool wrappers around
+// sdk/knowledge.Service. It is the v0.3.0 home of NewSearchServiceTool
+// and NewPutServiceTool, which currently live in sdk/knowledge with a
+// // Deprecated: marker pointing here.
+//
+// # Why sdkx
+//
+// sdk defines interfaces and primitives; sdkx ships concrete adapters
+// that integrate with external systems or external protocol specs.
+// LLM tool implementations are concrete adapters — they bridge the
+// generic [tool.Tool] interface to one specific service — and
+// therefore belong here, mirroring the existing sdk/llm → sdkx/llm/...
+// layout. See docs/migrations/v0.3.0.md.
+//
+// # Surface
+//
+// Both helpers mirror the sdk/knowledge versions verbatim. Function
+// signatures, tool names, JSON shapes, default values, and error
+// codes are preserved across the move; the migration is a pure
+// import-path swap:
+//
+//	-import "github.com/GizClaw/flowcraft/sdk/knowledge"
+//	+import knowledgetool "github.com/GizClaw/flowcraft/sdkx/tool/knowledge"
+//
+//	- search := knowledge.NewSearchServiceTool(svc)
+//	+ search := knowledgetool.NewSearchServiceTool(svc)
+package knowledge

--- a/sdkx/tool/knowledge/tool.go
+++ b/sdkx/tool/knowledge/tool.go
@@ -1,0 +1,163 @@
+package knowledge
+
+import (
+	"context"
+	"encoding/json"
+
+	"github.com/GizClaw/flowcraft/sdk/errdefs"
+	"github.com/GizClaw/flowcraft/sdk/knowledge"
+	"github.com/GizClaw/flowcraft/sdk/tool"
+)
+
+// defaultDatasetID is the implicit dataset for tools that omit dataset_id.
+const defaultDatasetID = "default"
+
+// NewSearchServiceTool exposes [knowledge.Service.Search] to LLMs.
+//
+// Tool name:  "knowledge_search"
+// Input JSON:
+//
+//	{
+//	  "query":      string,                       // required
+//	  "scope":      "single"|"all",               // default "all"
+//	  "dataset_id": string,                       // required when scope=single
+//	  "mode":       "bm25"|"vector"|"hybrid",     // default "bm25"
+//	  "layer":      "L0"|"L1"|"L2",               // default "L2"
+//	  "top_k":      integer,                      // default 5
+//	  "threshold":  number                        // default 0
+//	}
+//
+// Output: JSON-encoded []knowledge.Hit.
+//
+// This is the v0.3.0 location of the helper that lives at
+// [knowledge.NewSearchServiceTool] in v0.2.x. Behaviour is
+// identical; only the import path changes.
+func NewSearchServiceTool(svc *knowledge.Service) tool.Tool {
+	return tool.FuncTool(
+		tool.DefineSchema(
+			"knowledge_search",
+			"Search the knowledge base. Supports BM25 / vector / hybrid modes "+
+				"and three layers (L0 abstract, L1 overview, L2 detail). "+
+				"Use specific keywords for best results.",
+			tool.Property("query", "string", "Search query"),
+			tool.Property("scope", "string", `"single" or "all" (default "all")`),
+			tool.Property("dataset_id", "string", "Required when scope=single"),
+			tool.Property("mode", "string", `"bm25" | "vector" | "hybrid" (default "bm25")`),
+			tool.Property("layer", "string", `"L0" | "L1" | "L2" (default "L2")`),
+			tool.Property("top_k", "integer", "Number of results (default 5)"),
+			tool.Property("threshold", "number", "Minimum fused score (default 0)"),
+		).Required("query").Build(),
+		func(ctx context.Context, args string) (string, error) {
+			if svc == nil {
+				return "", errdefs.NotAvailablef("knowledge service not available")
+			}
+			var p struct {
+				Query     string  `json:"query"`
+				Scope     string  `json:"scope"`
+				DatasetID string  `json:"dataset_id"`
+				Mode      string  `json:"mode"`
+				Layer     string  `json:"layer"`
+				TopK      int     `json:"top_k"`
+				Threshold float64 `json:"threshold"`
+			}
+			if err := json.Unmarshal([]byte(args), &p); err != nil {
+				return "", err
+			}
+			q := knowledge.Query{
+				Text:      p.Query,
+				DatasetID: p.DatasetID,
+				Mode:      knowledge.Mode(p.Mode),
+				Layer:     knowledge.Layer(p.Layer),
+				TopK:      p.TopK,
+				Threshold: p.Threshold,
+			}
+			switch p.Scope {
+			case "single":
+				q.Scope = knowledge.ScopeSingleDataset
+			case "all", "":
+				q.Scope = knowledge.ScopeAllDatasets
+			default:
+				return "", errdefs.Validationf("knowledge: invalid scope %q", p.Scope)
+			}
+			res, err := svc.Search(ctx, q)
+			if err != nil {
+				return "", err
+			}
+			hits := []knowledge.Hit{}
+			if res != nil {
+				hits = res.Hits
+			}
+			data, err := json.Marshal(hits)
+			if err != nil {
+				return "", err
+			}
+			return string(data), nil
+		},
+	)
+}
+
+// NewPutServiceTool exposes [knowledge.Service.PutDocument] to LLMs.
+//
+// Tool name:  "knowledge_put"
+// Input JSON:
+//
+//	{
+//	  "dataset_id": string,   // default "default"
+//	  "name":       string,   // required
+//	  "content":    string    // required
+//	}
+//
+// Output:
+//
+//	{"status": "ok", "dataset_id": ..., "name": ..., "version": uint}
+//
+// This is the v0.3.0 location of the helper that lives at
+// [knowledge.NewPutServiceTool] in v0.2.x. Behaviour is identical;
+// only the import path changes.
+func NewPutServiceTool(svc *knowledge.Service) tool.Tool {
+	return tool.FuncTool(
+		tool.DefineSchema(
+			"knowledge_put",
+			"Persist a document into the knowledge base. Use this for "+
+				"durable knowledge (troubleshooting conclusions, design notes); "+
+				"avoid temporary scratchpads.",
+			tool.Property("dataset_id", "string", `Target dataset (default "default")`),
+			tool.Property("name", "string", "Document name (include extension, e.g. .md)"),
+			tool.Property("content", "string", "Document body"),
+		).Required("name", "content").Build(),
+		func(ctx context.Context, args string) (string, error) {
+			if svc == nil {
+				return "", errdefs.NotAvailablef("knowledge service not available")
+			}
+			var p struct {
+				DatasetID string `json:"dataset_id"`
+				Name      string `json:"name"`
+				Content   string `json:"content"`
+			}
+			if err := json.Unmarshal([]byte(args), &p); err != nil {
+				return "", err
+			}
+			if p.DatasetID == "" {
+				p.DatasetID = defaultDatasetID
+			}
+			if err := svc.PutDocument(ctx, p.DatasetID, p.Name, p.Content); err != nil {
+				return "", err
+			}
+			doc, err := svc.GetDocument(ctx, p.DatasetID, p.Name)
+			if err != nil {
+				return "", err
+			}
+			version := uint64(0)
+			if doc != nil {
+				version = doc.Version
+			}
+			resp, _ := json.Marshal(map[string]any{
+				"status":     "ok",
+				"dataset_id": p.DatasetID,
+				"name":       p.Name,
+				"version":    version,
+			})
+			return string(resp), nil
+		},
+	)
+}

--- a/sdkx/tool/knowledge/tool_test.go
+++ b/sdkx/tool/knowledge/tool_test.go
@@ -1,0 +1,94 @@
+package knowledge_test
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	sdkknowledge "github.com/GizClaw/flowcraft/sdk/knowledge"
+	"github.com/GizClaw/flowcraft/sdk/knowledge/factory"
+	"github.com/GizClaw/flowcraft/sdk/workspace"
+	tool "github.com/GizClaw/flowcraft/sdkx/tool/knowledge"
+)
+
+func newLocalService(t *testing.T) *sdkknowledge.Service {
+	t.Helper()
+	return factory.NewLocal(workspace.NewMemWorkspace())
+}
+
+func TestSearchServiceTool_BasicSearch(t *testing.T) {
+	svc := newLocalService(t)
+	ctx := context.Background()
+	if err := svc.PutDocument(ctx, "ds", "go.md", "Go is a compiled programming language"); err != nil {
+		t.Fatalf("put: %v", err)
+	}
+	x := tool.NewSearchServiceTool(svc)
+	if got := x.Definition().Name; got != "knowledge_search" {
+		t.Fatalf("tool name = %q, want knowledge_search", got)
+	}
+
+	out, err := x.Execute(ctx, `{"query":"Go programming"}`)
+	if err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+
+	var hits []sdkknowledge.Hit
+	if err := json.Unmarshal([]byte(out), &hits); err != nil {
+		t.Fatalf("unmarshal hits: %v (raw=%s)", err, out)
+	}
+}
+
+func TestSearchServiceTool_NilService(t *testing.T) {
+	x := tool.NewSearchServiceTool(nil)
+	_, err := x.Execute(context.Background(), `{"query":"x"}`)
+	if err == nil || !strings.Contains(err.Error(), "not available") {
+		t.Fatalf("nil service: want NotAvailable, got %v", err)
+	}
+}
+
+func TestSearchServiceTool_InvalidScope(t *testing.T) {
+	svc := newLocalService(t)
+	x := tool.NewSearchServiceTool(svc)
+	_, err := x.Execute(context.Background(), `{"query":"q","scope":"weird"}`)
+	if err == nil || !strings.Contains(err.Error(), "invalid scope") {
+		t.Fatalf("invalid scope: want validation error, got %v", err)
+	}
+}
+
+func TestPutServiceTool_RoundTrip(t *testing.T) {
+	svc := newLocalService(t)
+	ctx := context.Background()
+	x := tool.NewPutServiceTool(svc)
+	if got := x.Definition().Name; got != "knowledge_put" {
+		t.Fatalf("tool name = %q, want knowledge_put", got)
+	}
+
+	out, err := x.Execute(ctx, `{"name":"a.md","content":"alpha"}`)
+	if err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	var resp struct {
+		Status    string `json:"status"`
+		DatasetID string `json:"dataset_id"`
+		Name      string `json:"name"`
+		Version   uint64 `json:"version"`
+	}
+	if err := json.Unmarshal([]byte(out), &resp); err != nil {
+		t.Fatalf("unmarshal: %v (raw=%s)", err, out)
+	}
+	if resp.Status != "ok" || resp.DatasetID != "default" || resp.Name != "a.md" {
+		t.Errorf("response shape: %+v", resp)
+	}
+	if resp.Version == 0 {
+		t.Errorf("version should be > 0 after put, got 0")
+	}
+}
+
+func TestPutServiceTool_NilService(t *testing.T) {
+	x := tool.NewPutServiceTool(nil)
+	_, err := x.Execute(context.Background(), `{"name":"x","content":"y"}`)
+	if err == nil || !strings.Contains(err.Error(), "not available") {
+		t.Fatalf("nil service: want NotAvailable, got %v", err)
+	}
+}

--- a/sdkx/tool/memory/doc.go
+++ b/sdkx/tool/memory/doc.go
@@ -9,8 +9,26 @@
 // rename and the client (this package) executes them against a
 // sandboxed file store, then returns the result back to the model.
 // All paths the model produces are required to begin with the
-// "/memories" prefix; this package strips that prefix and routes
-// the operation against the workspace root.
+// "/memories" prefix.
+//
+// # Path layout inside the workspace
+//
+// The "memories" segment is *preserved* when forwarding to the
+// underlying [workspace.Workspace]: the model's "/memories/foo.md"
+// becomes the workspace-relative path "memories/foo.md". The Memory
+// Tool therefore lives in a dedicated subtree at
+// <workspace>/memories/, peer to the other workspace consumers:
+//
+//	<workspace>/
+//	├── memories/   <-- written by Memory Tool
+//	├── recall/     <-- managed by recall.Service (when fs-backed)
+//	├── knowledge/  <-- managed by knowledge.Service (when fs-backed)
+//	└── history/    <-- managed by history.Coordinator
+//
+// This isolation is what lets a single Workspace be shared across
+// every memory subsystem without their writes colliding. Hosts can
+// optionally wrap the workspace with [workspace.NewScopedWorkspace]
+// to enforce the boundary defensively.
 //
 // # Why sdkx
 //

--- a/sdkx/tool/memory/doc.go
+++ b/sdkx/tool/memory/doc.go
@@ -1,0 +1,36 @@
+// Package memory implements the Anthropic Memory Tool client-side
+// contract (memory_20250818) on top of a [workspace.Workspace].
+//
+// # What is the Memory Tool
+//
+// Anthropic's Memory Tool is a client-executed tool the model uses
+// to maintain a persistent file tree across turns. The model emits
+// commands such as view / create / str_replace / insert / delete /
+// rename and the client (this package) executes them against a
+// sandboxed file store, then returns the result back to the model.
+// All paths the model produces are required to begin with the
+// "/memories" prefix; this package strips that prefix and routes
+// the operation against the workspace root.
+//
+// # Why sdkx
+//
+// Memory Tool is a concrete protocol adapter (specific spec, fixed
+// command set, fixed path prefix) — exactly the layer where sdkx
+// lives. The underlying primitive ([workspace.Workspace]) stays in
+// sdk; this package is the wire-level binding.
+//
+// # Composition with the memory hierarchy
+//
+// FlowCraft already exposes a four-tier memory architecture:
+//
+//	sdk/history    - per-conversation transcript (hot)
+//	sdk/recall     - long-term facts (BM25 + vector)
+//	sdk/knowledge  - retrieval over corpora (chunk + rerank)
+//	sdk/workspace  - persistent file tree (Memory Tool target)
+//
+// This package wires the file-tree tier to the Anthropic spec so
+// agents using Anthropic's client-tool calling protocol see a
+// drop-in compatible "memory" surface, while internally the same
+// workspace can be shared with knowledge ingestion, skills, and any
+// other workspace consumer.
+package memory

--- a/sdkx/tool/memory/tool.go
+++ b/sdkx/tool/memory/tool.go
@@ -3,6 +3,7 @@ package memory
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"sort"
 	"strings"
@@ -132,47 +133,63 @@ func (t *Tool) Execute(ctx context.Context, arguments string) (string, error) {
 	}
 }
 
-// stripPrefix validates and strips PathPrefix, returning the
-// workspace-relative path. An empty result is the workspace root.
-func stripPrefix(p string) (string, error) {
+// toWorkspacePath validates the LLM-emitted path and returns the
+// equivalent workspace-relative path. The "memories" segment is
+// preserved so the tool stays sandboxed inside <workspace>/memories/,
+// peer to other workspace consumers (recall/, knowledge/, history/).
+//
+// Examples (with default PathPrefix "/memories"):
+//
+//	"/memories"            -> "memories"          (the memories root)
+//	"/memories/notes.md"   -> "memories/notes.md"
+//	"/memories/sub/a.txt"  -> "memories/sub/a.txt"
+//	"/etc/passwd"          -> error (missing prefix)
+//	"/memories/../escape"  -> error (traversal denied)
+func toWorkspacePath(p string) (string, error) {
 	if p == "" {
 		return "", errdefs.Validationf("memory: path is required")
 	}
-	if !strings.HasPrefix(p, PathPrefix) {
+	if p != PathPrefix && !strings.HasPrefix(p, PathPrefix+"/") {
 		return "", errdefs.Validationf("memory: path %q must begin with %s", p, PathPrefix)
 	}
-	rel := strings.TrimPrefix(p, PathPrefix)
-	rel = strings.TrimPrefix(rel, "/")
+	rel := strings.TrimPrefix(p, "/")
 	if strings.Contains(rel, "..") {
 		return "", errdefs.Validationf("memory: path traversal denied")
 	}
 	return rel, nil
 }
 
+// memoriesRoot is the workspace-relative path to the memories
+// subtree (i.e. PathPrefix without the leading slash).
+var memoriesRoot = strings.TrimPrefix(PathPrefix, "/")
+
 func (t *Tool) view(ctx context.Context, a args) (string, error) {
-	rel, err := stripPrefix(a.Path)
+	rel, err := toWorkspacePath(a.Path)
 	if err != nil {
 		return "", err
 	}
 
-	// Empty rel == list workspace root; otherwise probe Stat to
-	// distinguish file from directory.
-	if rel == "" {
-		return t.viewDir(ctx, "")
+	// rel == memoriesRoot means "list /memories". Probe Stat for
+	// anything deeper to distinguish file from directory. If the
+	// memories root has never been written to, Stat fails with
+	// NotFound — return an empty directory listing instead so the
+	// LLM can bootstrap.
+	if rel == memoriesRoot {
+		return t.viewDir(ctx, rel, true)
 	}
 	info, err := t.ws.Stat(ctx, rel)
 	if err != nil {
 		return "", fmt.Errorf("memory.view: %w", err)
 	}
 	if info.IsDir() {
-		return t.viewDir(ctx, rel)
+		return t.viewDir(ctx, rel, false)
 	}
 	return t.viewFile(ctx, rel, a.ViewRange)
 }
 
-func (t *Tool) viewDir(ctx context.Context, rel string) (string, error) {
+func (t *Tool) viewDir(ctx context.Context, rel string, tolerateMissing bool) (string, error) {
 	entries, err := t.ws.List(ctx, rel)
-	if err != nil {
+	if err != nil && !(tolerateMissing && errors.Is(err, workspace.ErrNotFound)) {
 		return "", fmt.Errorf("memory.view: %w", err)
 	}
 	names := make([]string, 0, len(entries))
@@ -185,15 +202,8 @@ func (t *Tool) viewDir(ctx context.Context, rel string) (string, error) {
 	}
 	sort.Strings(names)
 
-	display := PathPrefix + "/" + rel
-	display = strings.TrimSuffix(display, "/")
-	if rel == "" {
-		display = PathPrefix + "/"
-	} else {
-		display += "/"
-	}
 	out := map[string]any{
-		"path":    display,
+		"path":    "/" + rel + "/",
 		"entries": names,
 	}
 	return marshal(out), nil
@@ -230,7 +240,7 @@ func (t *Tool) viewFile(ctx context.Context, rel string, viewRange []int) (strin
 		fmt.Fprintf(&b, "%6d\t%s\n", i+1, lines[i])
 	}
 	out := map[string]any{
-		"path":      PathPrefix + "/" + rel,
+		"path":      "/" + rel,
 		"content":   b.String(),
 		"truncated": truncated,
 	}
@@ -238,12 +248,12 @@ func (t *Tool) viewFile(ctx context.Context, rel string, viewRange []int) (strin
 }
 
 func (t *Tool) create(ctx context.Context, a args) (string, error) {
-	rel, err := stripPrefix(a.Path)
+	rel, err := toWorkspacePath(a.Path)
 	if err != nil {
 		return "", err
 	}
-	if rel == "" {
-		return "", errdefs.Validationf("memory.create: cannot create at root")
+	if rel == memoriesRoot {
+		return "", errdefs.Validationf("memory.create: cannot create at %s", PathPrefix)
 	}
 	if err := t.ws.Write(ctx, rel, []byte(a.FileText)); err != nil {
 		return "", fmt.Errorf("memory.create: %w", err)
@@ -255,7 +265,7 @@ func (t *Tool) create(ctx context.Context, a args) (string, error) {
 }
 
 func (t *Tool) strReplace(ctx context.Context, a args) (string, error) {
-	rel, err := stripPrefix(a.Path)
+	rel, err := toWorkspacePath(a.Path)
 	if err != nil {
 		return "", err
 	}
@@ -282,7 +292,7 @@ func (t *Tool) strReplace(ctx context.Context, a args) (string, error) {
 }
 
 func (t *Tool) insert(ctx context.Context, a args) (string, error) {
-	rel, err := stripPrefix(a.Path)
+	rel, err := toWorkspacePath(a.Path)
 	if err != nil {
 		return "", err
 	}
@@ -314,12 +324,12 @@ func (t *Tool) insert(ctx context.Context, a args) (string, error) {
 }
 
 func (t *Tool) del(ctx context.Context, a args) (string, error) {
-	rel, err := stripPrefix(a.Path)
+	rel, err := toWorkspacePath(a.Path)
 	if err != nil {
 		return "", err
 	}
-	if rel == "" {
-		return "", errdefs.Validationf("memory.delete: refusing to delete root")
+	if rel == memoriesRoot {
+		return "", errdefs.Validationf("memory.delete: refusing to delete %s root", PathPrefix)
 	}
 	info, err := t.ws.Stat(ctx, rel)
 	if err != nil {
@@ -338,16 +348,16 @@ func (t *Tool) del(ctx context.Context, a args) (string, error) {
 }
 
 func (t *Tool) rename(ctx context.Context, a args) (string, error) {
-	src, err := stripPrefix(a.OldPath)
+	src, err := toWorkspacePath(a.OldPath)
 	if err != nil {
 		return "", fmt.Errorf("memory.rename old_path: %w", err)
 	}
-	dst, err := stripPrefix(a.NewPath)
+	dst, err := toWorkspacePath(a.NewPath)
 	if err != nil {
 		return "", fmt.Errorf("memory.rename new_path: %w", err)
 	}
-	if src == "" || dst == "" {
-		return "", errdefs.Validationf("memory.rename: cannot rename root")
+	if src == memoriesRoot || dst == memoriesRoot {
+		return "", errdefs.Validationf("memory.rename: cannot rename %s root", PathPrefix)
 	}
 	if err := t.ws.Rename(ctx, src, dst); err != nil {
 		return "", fmt.Errorf("memory.rename: %w", err)

--- a/sdkx/tool/memory/tool.go
+++ b/sdkx/tool/memory/tool.go
@@ -1,0 +1,370 @@
+package memory
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/GizClaw/flowcraft/sdk/errdefs"
+	"github.com/GizClaw/flowcraft/sdk/model"
+	"github.com/GizClaw/flowcraft/sdk/tool"
+	"github.com/GizClaw/flowcraft/sdk/workspace"
+)
+
+// PathPrefix is the mandatory path prefix every Anthropic Memory
+// Tool path must carry. The runtime strips it before delegating to
+// the underlying [workspace.Workspace], whose paths are relative to
+// its root.
+const PathPrefix = "/memories"
+
+// MaxViewBytes caps the bytes returned by a single view of a file.
+// Anthropic's reference client truncates large files; we apply the
+// same guard to keep tool output bounded. Configure via [Option].
+const MaxViewBytes = 64 * 1024
+
+// Tool is the single Anthropic Memory Tool exposed to LLMs. The
+// command verb is dispatched on the "command" argument; see
+// [https://docs.anthropic.com/en/docs/agents-and-tools/tool-use/memory-tool]
+// for the upstream spec.
+type Tool struct {
+	ws       workspace.Workspace
+	maxBytes int64
+}
+
+// Option configures [Tool].
+type Option func(*Tool)
+
+// WithMaxViewBytes overrides the default truncation cap for view.
+func WithMaxViewBytes(n int64) Option {
+	return func(t *Tool) {
+		if n > 0 {
+			t.maxBytes = n
+		}
+	}
+}
+
+// New returns a Memory Tool backed by ws. Paths emitted by the
+// model must begin with [PathPrefix]; the prefix is stripped
+// before forwarding to ws.
+func New(ws workspace.Workspace, opts ...Option) *Tool {
+	t := &Tool{ws: ws, maxBytes: MaxViewBytes}
+	for _, o := range opts {
+		o(t)
+	}
+	return t
+}
+
+// Definition implements [tool.Tool].
+func (t *Tool) Definition() model.ToolDefinition {
+	return tool.DefineSchema(
+		"memory",
+		"Persistent file-tree memory. Issue commands to read and edit files under "+PathPrefix+"/. "+
+			"Use 'view' to inspect, 'create' to write, 'str_replace' to edit, 'insert' to splice, 'delete' to remove, 'rename' to move.",
+		tool.EnumProperty("command", "string",
+			"The memory operation to perform.",
+			"view", "create", "str_replace", "insert", "delete", "rename"),
+		tool.Property("path", "string",
+			"Target path. Must begin with "+PathPrefix+"/. Required for view, create, str_replace, insert, delete."),
+		tool.Property("file_text", "string",
+			"Full file contents (create only)."),
+		tool.Property("old_str", "string",
+			"Substring to replace (str_replace only). Must match exactly once."),
+		tool.Property("new_str", "string",
+			"Replacement string (str_replace only)."),
+		tool.Property("insert_line", "integer",
+			"0-based line index after which insert_text is spliced (insert only). 0 inserts before the first line."),
+		tool.Property("insert_text", "string",
+			"Text to splice into the file (insert only). A trailing newline is appended if missing."),
+		tool.Property("old_path", "string",
+			"Source path for rename. Must begin with "+PathPrefix+"/."),
+		tool.Property("new_path", "string",
+			"Destination path for rename. Must begin with "+PathPrefix+"/."),
+		tool.ArrayProperty("view_range",
+			"Optional 2-element [start, end] 1-based inclusive line range for view. Use -1 for end-of-file.",
+			map[string]any{"type": "integer"}),
+	).Required("command").Build()
+}
+
+// Metadata implements [tool.ToolMetadata]. Every command except
+// view mutates the underlying store, and bandwidth is dominated
+// by file size rather than call rate, so we declare side-effects
+// without claiming a specific RateLimit.
+func (t *Tool) Metadata() tool.ToolMeta {
+	return tool.ToolMeta{MutatesState: true}
+}
+
+type args struct {
+	Command    string `json:"command"`
+	Path       string `json:"path"`
+	FileText   string `json:"file_text"`
+	OldStr     string `json:"old_str"`
+	NewStr     string `json:"new_str"`
+	InsertLine *int   `json:"insert_line"`
+	InsertText string `json:"insert_text"`
+	OldPath    string `json:"old_path"`
+	NewPath    string `json:"new_path"`
+	ViewRange  []int  `json:"view_range"`
+}
+
+// Execute implements [tool.Tool].
+func (t *Tool) Execute(ctx context.Context, arguments string) (string, error) {
+	var a args
+	if err := json.Unmarshal([]byte(arguments), &a); err != nil {
+		return "", errdefs.Validationf("memory: parse args: %v", err)
+	}
+	switch a.Command {
+	case "view":
+		return t.view(ctx, a)
+	case "create":
+		return t.create(ctx, a)
+	case "str_replace":
+		return t.strReplace(ctx, a)
+	case "insert":
+		return t.insert(ctx, a)
+	case "delete":
+		return t.del(ctx, a)
+	case "rename":
+		return t.rename(ctx, a)
+	default:
+		return "", errdefs.Validationf("memory: unknown command %q", a.Command)
+	}
+}
+
+// stripPrefix validates and strips PathPrefix, returning the
+// workspace-relative path. An empty result is the workspace root.
+func stripPrefix(p string) (string, error) {
+	if p == "" {
+		return "", errdefs.Validationf("memory: path is required")
+	}
+	if !strings.HasPrefix(p, PathPrefix) {
+		return "", errdefs.Validationf("memory: path %q must begin with %s", p, PathPrefix)
+	}
+	rel := strings.TrimPrefix(p, PathPrefix)
+	rel = strings.TrimPrefix(rel, "/")
+	if strings.Contains(rel, "..") {
+		return "", errdefs.Validationf("memory: path traversal denied")
+	}
+	return rel, nil
+}
+
+func (t *Tool) view(ctx context.Context, a args) (string, error) {
+	rel, err := stripPrefix(a.Path)
+	if err != nil {
+		return "", err
+	}
+
+	// Empty rel == list workspace root; otherwise probe Stat to
+	// distinguish file from directory.
+	if rel == "" {
+		return t.viewDir(ctx, "")
+	}
+	info, err := t.ws.Stat(ctx, rel)
+	if err != nil {
+		return "", fmt.Errorf("memory.view: %w", err)
+	}
+	if info.IsDir() {
+		return t.viewDir(ctx, rel)
+	}
+	return t.viewFile(ctx, rel, a.ViewRange)
+}
+
+func (t *Tool) viewDir(ctx context.Context, rel string) (string, error) {
+	entries, err := t.ws.List(ctx, rel)
+	if err != nil {
+		return "", fmt.Errorf("memory.view: %w", err)
+	}
+	names := make([]string, 0, len(entries))
+	for _, e := range entries {
+		name := e.Name()
+		if e.IsDir() {
+			name += "/"
+		}
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	display := PathPrefix + "/" + rel
+	display = strings.TrimSuffix(display, "/")
+	if rel == "" {
+		display = PathPrefix + "/"
+	} else {
+		display += "/"
+	}
+	out := map[string]any{
+		"path":    display,
+		"entries": names,
+	}
+	return marshal(out), nil
+}
+
+func (t *Tool) viewFile(ctx context.Context, rel string, viewRange []int) (string, error) {
+	data, err := t.ws.Read(ctx, rel)
+	if err != nil {
+		return "", fmt.Errorf("memory.view: %w", err)
+	}
+	truncated := false
+	if int64(len(data)) > t.maxBytes {
+		data = data[:t.maxBytes]
+		truncated = true
+	}
+	lines := strings.Split(string(data), "\n")
+	start, end := 1, len(lines)
+	if len(viewRange) == 2 {
+		start = viewRange[0]
+		end = viewRange[1]
+		if start < 1 {
+			start = 1
+		}
+		if end == -1 || end > len(lines) {
+			end = len(lines)
+		}
+		if start > end {
+			return "", errdefs.Validationf("memory.view: invalid view_range %v", viewRange)
+		}
+	}
+
+	var b strings.Builder
+	for i := start - 1; i < end; i++ {
+		fmt.Fprintf(&b, "%6d\t%s\n", i+1, lines[i])
+	}
+	out := map[string]any{
+		"path":      PathPrefix + "/" + rel,
+		"content":   b.String(),
+		"truncated": truncated,
+	}
+	return marshal(out), nil
+}
+
+func (t *Tool) create(ctx context.Context, a args) (string, error) {
+	rel, err := stripPrefix(a.Path)
+	if err != nil {
+		return "", err
+	}
+	if rel == "" {
+		return "", errdefs.Validationf("memory.create: cannot create at root")
+	}
+	if err := t.ws.Write(ctx, rel, []byte(a.FileText)); err != nil {
+		return "", fmt.Errorf("memory.create: %w", err)
+	}
+	return marshal(map[string]any{
+		"path":  a.Path,
+		"bytes": len(a.FileText),
+	}), nil
+}
+
+func (t *Tool) strReplace(ctx context.Context, a args) (string, error) {
+	rel, err := stripPrefix(a.Path)
+	if err != nil {
+		return "", err
+	}
+	if a.OldStr == "" {
+		return "", errdefs.Validationf("memory.str_replace: old_str is required")
+	}
+	data, err := t.ws.Read(ctx, rel)
+	if err != nil {
+		return "", fmt.Errorf("memory.str_replace: %w", err)
+	}
+	body := string(data)
+	count := strings.Count(body, a.OldStr)
+	if count == 0 {
+		return "", errdefs.NotFoundf("memory.str_replace: old_str not found in %s", a.Path)
+	}
+	if count > 1 {
+		return "", errdefs.Conflictf("memory.str_replace: old_str matches %d times in %s; tighten the snippet", count, a.Path)
+	}
+	updated := strings.Replace(body, a.OldStr, a.NewStr, 1)
+	if err := t.ws.Write(ctx, rel, []byte(updated)); err != nil {
+		return "", fmt.Errorf("memory.str_replace: %w", err)
+	}
+	return marshal(map[string]any{"path": a.Path, "replaced": 1}), nil
+}
+
+func (t *Tool) insert(ctx context.Context, a args) (string, error) {
+	rel, err := stripPrefix(a.Path)
+	if err != nil {
+		return "", err
+	}
+	if a.InsertLine == nil {
+		return "", errdefs.Validationf("memory.insert: insert_line is required")
+	}
+	at := *a.InsertLine
+	data, err := t.ws.Read(ctx, rel)
+	if err != nil {
+		return "", fmt.Errorf("memory.insert: %w", err)
+	}
+	lines := strings.Split(string(data), "\n")
+	if at < 0 || at > len(lines) {
+		return "", errdefs.Validationf("memory.insert: insert_line %d out of range [0,%d]", at, len(lines))
+	}
+	insertText := a.InsertText
+	if !strings.HasSuffix(insertText, "\n") {
+		insertText += "\n"
+	}
+	newLines := strings.Split(strings.TrimSuffix(insertText, "\n"), "\n")
+	out := make([]string, 0, len(lines)+len(newLines))
+	out = append(out, lines[:at]...)
+	out = append(out, newLines...)
+	out = append(out, lines[at:]...)
+	if err := t.ws.Write(ctx, rel, []byte(strings.Join(out, "\n"))); err != nil {
+		return "", fmt.Errorf("memory.insert: %w", err)
+	}
+	return marshal(map[string]any{"path": a.Path, "inserted": len(newLines)}), nil
+}
+
+func (t *Tool) del(ctx context.Context, a args) (string, error) {
+	rel, err := stripPrefix(a.Path)
+	if err != nil {
+		return "", err
+	}
+	if rel == "" {
+		return "", errdefs.Validationf("memory.delete: refusing to delete root")
+	}
+	info, err := t.ws.Stat(ctx, rel)
+	if err != nil {
+		return "", fmt.Errorf("memory.delete: %w", err)
+	}
+	if info.IsDir() {
+		if err := t.ws.RemoveAll(ctx, rel); err != nil {
+			return "", fmt.Errorf("memory.delete: %w", err)
+		}
+	} else {
+		if err := t.ws.Delete(ctx, rel); err != nil {
+			return "", fmt.Errorf("memory.delete: %w", err)
+		}
+	}
+	return marshal(map[string]any{"path": a.Path, "deleted": true}), nil
+}
+
+func (t *Tool) rename(ctx context.Context, a args) (string, error) {
+	src, err := stripPrefix(a.OldPath)
+	if err != nil {
+		return "", fmt.Errorf("memory.rename old_path: %w", err)
+	}
+	dst, err := stripPrefix(a.NewPath)
+	if err != nil {
+		return "", fmt.Errorf("memory.rename new_path: %w", err)
+	}
+	if src == "" || dst == "" {
+		return "", errdefs.Validationf("memory.rename: cannot rename root")
+	}
+	if err := t.ws.Rename(ctx, src, dst); err != nil {
+		return "", fmt.Errorf("memory.rename: %w", err)
+	}
+	return marshal(map[string]any{
+		"old_path": a.OldPath,
+		"new_path": a.NewPath,
+	}), nil
+}
+
+func marshal(v any) string {
+	out, _ := json.Marshal(v)
+	return string(out)
+}
+
+// Compile-time interface checks.
+var (
+	_ tool.Tool         = (*Tool)(nil)
+	_ tool.ToolMetadata = (*Tool)(nil)
+)

--- a/sdkx/tool/memory/tool_test.go
+++ b/sdkx/tool/memory/tool_test.go
@@ -1,0 +1,235 @@
+package memory_test
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/GizClaw/flowcraft/sdk/workspace"
+	memorytool "github.com/GizClaw/flowcraft/sdkx/tool/memory"
+)
+
+func newTool(t *testing.T) (*memorytool.Tool, *workspace.MemWorkspace) {
+	t.Helper()
+	ws := workspace.NewMemWorkspace()
+	return memorytool.New(ws), ws
+}
+
+func exec(t *testing.T, tool *memorytool.Tool, args map[string]any) string {
+	t.Helper()
+	raw, err := json.Marshal(args)
+	if err != nil {
+		t.Fatal(err)
+	}
+	out, err := tool.Execute(context.Background(), string(raw))
+	if err != nil {
+		t.Fatalf("Execute(%v): %v", args, err)
+	}
+	return out
+}
+
+func execErr(t *testing.T, tool *memorytool.Tool, args map[string]any) error {
+	t.Helper()
+	raw, _ := json.Marshal(args)
+	_, err := tool.Execute(context.Background(), string(raw))
+	if err == nil {
+		t.Fatalf("Execute(%v): want error, got nil", args)
+	}
+	return err
+}
+
+func TestDefinition(t *testing.T) {
+	tool, _ := newTool(t)
+	def := tool.Definition()
+	if def.Name != "memory" {
+		t.Fatalf("name = %q, want memory", def.Name)
+	}
+}
+
+func TestPathPrefixEnforced(t *testing.T) {
+	tool, _ := newTool(t)
+	err := execErr(t, tool, map[string]any{"command": "view", "path": "/etc/passwd"})
+	if !strings.Contains(err.Error(), memorytool.PathPrefix) {
+		t.Errorf("err = %v, want PathPrefix mention", err)
+	}
+}
+
+func TestCreateAndView(t *testing.T) {
+	tool, _ := newTool(t)
+	exec(t, tool, map[string]any{
+		"command":   "create",
+		"path":      "/memories/notes/a.txt",
+		"file_text": "hello\nworld\n",
+	})
+
+	out := exec(t, tool, map[string]any{
+		"command": "view",
+		"path":    "/memories/notes/a.txt",
+	})
+	if !strings.Contains(out, "hello") || !strings.Contains(out, "world") {
+		t.Errorf("view output missing content: %s", out)
+	}
+}
+
+func TestViewWithRange(t *testing.T) {
+	tool, _ := newTool(t)
+	exec(t, tool, map[string]any{
+		"command":   "create",
+		"path":      "/memories/a.txt",
+		"file_text": "l1\nl2\nl3\nl4\nl5\n",
+	})
+	out := exec(t, tool, map[string]any{
+		"command":    "view",
+		"path":       "/memories/a.txt",
+		"view_range": []int{2, 4},
+	})
+	if !strings.Contains(out, "l2") || !strings.Contains(out, "l4") {
+		t.Errorf("range view missing l2/l4: %s", out)
+	}
+	if strings.Contains(out, "l1") || strings.Contains(out, "l5") {
+		t.Errorf("range view leaked outside range: %s", out)
+	}
+}
+
+func TestViewDir(t *testing.T) {
+	tool, _ := newTool(t)
+	exec(t, tool, map[string]any{"command": "create", "path": "/memories/a.txt", "file_text": "a"})
+	exec(t, tool, map[string]any{"command": "create", "path": "/memories/sub/b.txt", "file_text": "b"})
+
+	out := exec(t, tool, map[string]any{"command": "view", "path": "/memories"})
+	if !strings.Contains(out, "a.txt") || !strings.Contains(out, "sub/") {
+		t.Errorf("dir view missing entries: %s", out)
+	}
+}
+
+func TestStrReplace(t *testing.T) {
+	tool, _ := newTool(t)
+	exec(t, tool, map[string]any{"command": "create", "path": "/memories/x.txt", "file_text": "hello world"})
+
+	exec(t, tool, map[string]any{
+		"command": "str_replace",
+		"path":    "/memories/x.txt",
+		"old_str": "world",
+		"new_str": "anthropic",
+	})
+	out := exec(t, tool, map[string]any{"command": "view", "path": "/memories/x.txt"})
+	if !strings.Contains(out, "anthropic") {
+		t.Errorf("str_replace not applied: %s", out)
+	}
+}
+
+func TestStrReplaceMultipleMatches(t *testing.T) {
+	tool, _ := newTool(t)
+	exec(t, tool, map[string]any{"command": "create", "path": "/memories/x.txt", "file_text": "a a a"})
+	err := execErr(t, tool, map[string]any{
+		"command": "str_replace",
+		"path":    "/memories/x.txt",
+		"old_str": "a",
+		"new_str": "b",
+	})
+	if !strings.Contains(err.Error(), "matches 3 times") {
+		t.Errorf("expected ambiguity error, got: %v", err)
+	}
+}
+
+func TestStrReplaceNotFound(t *testing.T) {
+	tool, _ := newTool(t)
+	exec(t, tool, map[string]any{"command": "create", "path": "/memories/x.txt", "file_text": "abc"})
+	err := execErr(t, tool, map[string]any{
+		"command": "str_replace",
+		"path":    "/memories/x.txt",
+		"old_str": "xyz",
+		"new_str": "q",
+	})
+	if !strings.Contains(err.Error(), "not found") {
+		t.Errorf("err = %v, want 'not found'", err)
+	}
+}
+
+func TestInsert(t *testing.T) {
+	tool, _ := newTool(t)
+	exec(t, tool, map[string]any{
+		"command":   "create",
+		"path":      "/memories/x.txt",
+		"file_text": "l1\nl2\nl3\n",
+	})
+	exec(t, tool, map[string]any{
+		"command":     "insert",
+		"path":        "/memories/x.txt",
+		"insert_line": 1,
+		"insert_text": "INJECTED",
+	})
+	out := exec(t, tool, map[string]any{"command": "view", "path": "/memories/x.txt"})
+	idxL1 := strings.Index(out, "l1")
+	idxInj := strings.Index(out, "INJECTED")
+	idxL2 := strings.Index(out, "l2")
+	if !(idxL1 < idxInj && idxInj < idxL2) {
+		t.Errorf("insert order wrong: %s", out)
+	}
+}
+
+func TestDelete(t *testing.T) {
+	tool, _ := newTool(t)
+	exec(t, tool, map[string]any{"command": "create", "path": "/memories/x.txt", "file_text": "a"})
+	exec(t, tool, map[string]any{"command": "delete", "path": "/memories/x.txt"})
+	err := execErr(t, tool, map[string]any{"command": "view", "path": "/memories/x.txt"})
+	if err == nil {
+		t.Errorf("expected view error after delete")
+	}
+}
+
+func TestDeleteRoot(t *testing.T) {
+	tool, _ := newTool(t)
+	err := execErr(t, tool, map[string]any{"command": "delete", "path": "/memories"})
+	if !strings.Contains(err.Error(), "root") {
+		t.Errorf("err = %v, want refuse-to-delete-root", err)
+	}
+}
+
+func TestRename(t *testing.T) {
+	tool, _ := newTool(t)
+	exec(t, tool, map[string]any{"command": "create", "path": "/memories/a.txt", "file_text": "X"})
+	exec(t, tool, map[string]any{
+		"command":  "rename",
+		"old_path": "/memories/a.txt",
+		"new_path": "/memories/b.txt",
+	})
+	out := exec(t, tool, map[string]any{"command": "view", "path": "/memories/b.txt"})
+	if !strings.Contains(out, "X") {
+		t.Errorf("rename target missing content: %s", out)
+	}
+}
+
+func TestUnknownCommand(t *testing.T) {
+	tool, _ := newTool(t)
+	err := execErr(t, tool, map[string]any{"command": "nope", "path": "/memories/x"})
+	if !strings.Contains(err.Error(), "unknown command") {
+		t.Errorf("err = %v, want unknown command", err)
+	}
+}
+
+func TestMaxViewBytesTruncates(t *testing.T) {
+	ws := workspace.NewMemWorkspace()
+	tool := memorytool.New(ws, memorytool.WithMaxViewBytes(8))
+	exec(t, tool, map[string]any{
+		"command":   "create",
+		"path":      "/memories/big.txt",
+		"file_text": "0123456789ABCDEF",
+	})
+	out := exec(t, tool, map[string]any{"command": "view", "path": "/memories/big.txt"})
+	if !strings.Contains(out, `"truncated":true`) {
+		t.Errorf("expected truncated=true, got: %s", out)
+	}
+}
+
+func TestPathTraversalDenied(t *testing.T) {
+	tool, _ := newTool(t)
+	err := execErr(t, tool, map[string]any{
+		"command": "view",
+		"path":    "/memories/../etc/passwd",
+	})
+	if !strings.Contains(err.Error(), "traversal") {
+		t.Errorf("err = %v, want traversal denied", err)
+	}
+}

--- a/sdkx/tool/memory/tool_test.go
+++ b/sdkx/tool/memory/tool_test.go
@@ -56,12 +56,22 @@ func TestPathPrefixEnforced(t *testing.T) {
 }
 
 func TestCreateAndView(t *testing.T) {
-	tool, _ := newTool(t)
+	tool, ws := newTool(t)
 	exec(t, tool, map[string]any{
 		"command":   "create",
 		"path":      "/memories/notes/a.txt",
 		"file_text": "hello\nworld\n",
 	})
+
+	// Verify the write landed under memories/ (not at workspace root)
+	// so the Memory Tool subtree coexists with recall/knowledge/...
+	data, err := ws.Read(context.Background(), "memories/notes/a.txt")
+	if err != nil {
+		t.Fatalf("expected file at memories/notes/a.txt: %v", err)
+	}
+	if string(data) != "hello\nworld\n" {
+		t.Errorf("workspace content = %q", data)
+	}
 
 	out := exec(t, tool, map[string]any{
 		"command": "view",
@@ -69,6 +79,44 @@ func TestCreateAndView(t *testing.T) {
 	})
 	if !strings.Contains(out, "hello") || !strings.Contains(out, "world") {
 		t.Errorf("view output missing content: %s", out)
+	}
+}
+
+func TestSubtreeIsolation(t *testing.T) {
+	tool, ws := newTool(t)
+
+	// Pre-seed peer subtrees that another subsystem (recall, etc.)
+	// would own; the Memory Tool must not see or touch them.
+	if err := ws.Write(context.Background(), "recall/facts.json", []byte(`{}`)); err != nil {
+		t.Fatal(err)
+	}
+	if err := ws.Write(context.Background(), "knowledge/chunks.bin", []byte("x")); err != nil {
+		t.Fatal(err)
+	}
+
+	exec(t, tool, map[string]any{"command": "create", "path": "/memories/note.md", "file_text": "hi"})
+
+	out := exec(t, tool, map[string]any{"command": "view", "path": "/memories"})
+	if strings.Contains(out, "recall") || strings.Contains(out, "knowledge") {
+		t.Errorf("memory view leaked sibling subtree: %s", out)
+	}
+	if !strings.Contains(out, "note.md") {
+		t.Errorf("memory view missing own file: %s", out)
+	}
+
+	// Peer subtree must remain untouched.
+	if exists, _ := ws.Exists(context.Background(), "recall/facts.json"); !exists {
+		t.Error("peer subtree recall/facts.json was disturbed")
+	}
+}
+
+func TestViewMemoriesRoot(t *testing.T) {
+	tool, _ := newTool(t)
+	// Empty memories/ root should still be viewable; List on a
+	// non-existent dir is tolerated and returns empty entries.
+	out := exec(t, tool, map[string]any{"command": "view", "path": "/memories"})
+	if !strings.Contains(out, `"entries":[]`) {
+		t.Errorf("empty memories root view = %s", out)
 	}
 }
 


### PR DESCRIPTION
## Summary

Phase 3 of the sdkx track: lands `sdkx/tool/{knowledge,kanban,history,memory}` so users can switch their imports **before** sdk/v0.3.0 deletes the corresponding helpers from `sdk/{knowledge,kanban,history}`. Public signatures stay identical, so the v0.3.0 cut becomes a pure `go get -u` for callers — no source edits after the import swap.

| Package                  | Strategy                                                                                                                    |
| ------------------------ | --------------------------------------------------------------------------------------------------------------------------- |
| `sdkx/tool/knowledge`    | Full mirror (only depends on public `sdk/knowledge` API).                                                                   |
| `sdkx/tool/kanban`       | Full mirror; `WithKanban`/`KanbanFrom` forward to `sdk/kanban` so contexts installed on either side interoperate.           |
| `sdkx/tool/history`      | Go type alias + delegation. The underlying tools reach into package-private helpers (`archiveImpl`, `loadManifestImpl`, `SummaryDAG{store,config}`) that can't be exported without growing sdk's stable surface. The alias pins the API shape now; the implementation relocates at the sdk/v0.3.0 cut. |
| `sdkx/tool/memory`       | Net-new Anthropic Memory Tool (`memory_20250818`) wrapper over `workspace.Workspace`. Single tool, command enum, mandatory `/memories` prefix, view-byte cap, str_replace ambiguity errors, path-traversal guard. |

Each package ships a `doc.go` explaining the sdkx layering rationale and migration path. Tests cover:
- mechanical contracts (definition names, registry registration);
- kanban context-key interop (sdk-installed ↔ sdkx-readable, both directions);
- history type-alias interop (`var sdk Hist.ToolDeps = sdkx.ToolDeps{}`);
- all 6 memory commands incl. truncation, prefix enforcement, and traversal denial.

`docs/migrations/v0.3.0.md`: documents sdk↔sdkx release coordination — users do a one-line import swap during v0.2.x, then a paired `go get -u` at v0.3.0 cut, no other source edits.

## Test plan

- [x] `make fmt` clean across the workspace
- [x] `cd sdkx && go vet ./...`
- [x] `cd sdkx && go test ./tool/... -count=1` — all four packages pass
- [x] kanban context-key interop test exercises both directions
- [x] history type-alias interop test guards against future `type Foo X` regression
- [x] memory tool: 15/15 cases incl. truncation, traversal denial, str_replace ambiguity

## Notes

- Pure additive in **sdk** (zero changes); no `[skip-tag:sdk]` needed.
- The `history` package is intentionally a thin forwarding layer in v0.2.x — see commit message and the package `doc.go` for why path D (alias + delegation) was preferred over exporting private helpers or duplicating archive logic.

Made with [Cursor](https://cursor.com)