### PR TITLE
feat(sdk/workspace): Capabilities + CapabilityReporter

### DIFF
--- a/sdk/workspace/capabilities.go
+++ b/sdk/workspace/capabilities.go
@@ -1,0 +1,68 @@
+package workspace
+
+// Capabilities describes the storage characteristics of a Workspace
+// implementation. Higher-layer adapters that need accurate semantics
+// (e.g. an LSM-style retrieval index that relies on atomic Rename, or
+// a multi-process coordinator that needs to know whether the workspace
+// is shareable) read these via [CapabilityReporter] instead of
+// hard-coding per-implementation assumptions.
+//
+// All fields default to false, which is the conservative
+// interpretation: adapters that do not bother to type-assert
+// CapabilityReporter — or that handle a workspace whose author has
+// not yet implemented the interface — see "no guarantees" and pick
+// the safe path. Adding a new field is therefore additive.
+type Capabilities struct {
+	// AtomicRename is true when [Workspace.Rename] succeeds or
+	// fails as a single observable operation; readers never see a
+	// half-renamed state. POSIX rename(2) on the same filesystem
+	// satisfies this. Object stores that emulate Rename as
+	// copy+delete do not.
+	AtomicRename bool
+
+	// ReadAfterWrite is true when a successful [Workspace.Write]
+	// or [Workspace.Append] is immediately observable to a
+	// subsequent [Workspace.Read] / [Workspace.List] /
+	// [Workspace.Exists] / [Workspace.Stat] from the same client.
+	// Strongly-consistent stores (local filesystem, sufficiently
+	// recent S3) are true; eventually-consistent stores are false.
+	ReadAfterWrite bool
+
+	// DurableOnWrite is true when a successful Write hits stable
+	// storage before returning. Implementations that only buffer
+	// in user-space (in-memory mocks, write-back caches) report
+	// false. Adapters that own crash-recovery logic (WAL replay,
+	// manifest swap) read this to decide whether to perform extra
+	// flush operations themselves.
+	DurableOnWrite bool
+
+	// Distributed is true when more than one process or host can
+	// be opened against the same workspace concurrently. Single-
+	// process backends (in-memory map, exclusive local directory)
+	// report false; cluster file systems and object stores report
+	// true. Coordinators use this to choose between a process-
+	// local mutex and a distributed lock primitive.
+	Distributed bool
+}
+
+// CapabilityReporter is an optional interface that [Workspace]
+// implementations may satisfy to publish their [Capabilities].
+// Adapters that need the information should type-assert; an
+// implementation that does not satisfy the interface should be
+// treated as a conservative all-false [Capabilities].
+//
+// Convenience: see [CapabilitiesOf] which performs the type-assert
+// + zero-value fallback in one call.
+type CapabilityReporter interface {
+	Capabilities() Capabilities
+}
+
+// CapabilitiesOf returns ws.Capabilities() when ws implements
+// [CapabilityReporter], or a zero-value [Capabilities] otherwise.
+// nil ws also returns the zero value.
+func CapabilitiesOf(ws Workspace) Capabilities {
+	if r, ok := ws.(CapabilityReporter); ok {
+		return r.Capabilities()
+	}
+	return Capabilities{}
+}

--- a/sdk/workspace/capabilities_test.go
+++ b/sdk/workspace/capabilities_test.go
@@ -1,0 +1,79 @@
+package workspace
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+)
+
+func TestMemWorkspace_Capabilities(t *testing.T) {
+	ws := NewMemWorkspace()
+	c := ws.Capabilities()
+	if !c.AtomicRename {
+		t.Error("MemWorkspace must report AtomicRename")
+	}
+	if !c.ReadAfterWrite {
+		t.Error("MemWorkspace must report ReadAfterWrite")
+	}
+	if c.DurableOnWrite {
+		t.Error("MemWorkspace must not claim DurableOnWrite")
+	}
+	if c.Distributed {
+		t.Error("MemWorkspace must not claim Distributed")
+	}
+}
+
+func TestLocalWorkspace_Capabilities(t *testing.T) {
+	dir := t.TempDir()
+	ws, err := NewLocalWorkspace(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	c := ws.Capabilities()
+	if !c.AtomicRename || !c.ReadAfterWrite || !c.DurableOnWrite {
+		t.Errorf("LocalWorkspace unexpectedly missing caps: %+v", c)
+	}
+	if c.Distributed {
+		t.Error("LocalWorkspace must not claim Distributed")
+	}
+}
+
+func TestScopedWorkspace_Capabilities_ForwardsInner(t *testing.T) {
+	inner := NewMemWorkspace()
+	scoped := NewScopedWorkspace(inner)
+	if scoped.Capabilities() != inner.Capabilities() {
+		t.Errorf("ScopedWorkspace caps %+v != inner %+v",
+			scoped.Capabilities(), inner.Capabilities())
+	}
+}
+
+// minimalWorkspace is a Workspace that intentionally does NOT
+// implement CapabilityReporter. It guards CapabilitiesOf's safe
+// default path for third-party impls that pre-date the interface.
+type minimalWorkspace struct{ Workspace }
+
+func TestCapabilitiesOf_FallsBackToZeroValue(t *testing.T) {
+	ws := minimalWorkspace{Workspace: NewMemWorkspace()}
+	got := CapabilitiesOf(ws)
+	if got != (Capabilities{}) {
+		t.Errorf("non-reporter should yield zero-value, got %+v", got)
+	}
+}
+
+func TestCapabilitiesOf_NilWorkspace(t *testing.T) {
+	if CapabilitiesOf(nil) != (Capabilities{}) {
+		t.Error("nil workspace should yield zero-value")
+	}
+}
+
+func TestScopedWorkspace_Capabilities_OverNonReporter(t *testing.T) {
+	inner := minimalWorkspace{Workspace: NewMemWorkspace()}
+	scoped := NewScopedWorkspace(inner)
+	if scoped.Capabilities() != (Capabilities{}) {
+		t.Errorf("scoped over non-reporter should yield zero-value")
+	}
+	// Sanity: scoped reads still work end-to-end.
+	if err := inner.Write(context.Background(), filepath.Join("a"), []byte("x")); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/sdk/workspace/local.go
+++ b/sdk/workspace/local.go
@@ -38,6 +38,21 @@ func NewLocalWorkspace(root string) (*LocalWorkspace, error) {
 // Root returns the absolute path of the workspace root.
 func (w *LocalWorkspace) Root() string { return w.root }
 
+// Capabilities reports LocalWorkspace's storage characteristics:
+// backed by the host filesystem, so Rename is atomic on the same
+// device, writes are read-after-write consistent, and durability
+// matches the underlying filesystem's default flush behaviour.
+// Distributed is false because LocalWorkspace assumes exclusive
+// access to its directory tree.
+func (w *LocalWorkspace) Capabilities() Capabilities {
+	return Capabilities{
+		AtomicRename:   true,
+		ReadAfterWrite: true,
+		DurableOnWrite: true,
+		Distributed:    false,
+	}
+}
+
 func (w *LocalWorkspace) Read(_ context.Context, path string) ([]byte, error) {
 	full, err := w.resolve(path)
 	if err != nil {

--- a/sdk/workspace/mem.go
+++ b/sdk/workspace/mem.go
@@ -228,6 +228,19 @@ func (m *MemWorkspace) Stat(_ context.Context, path string) (fs.FileInfo, error)
 	return nil, fmt.Errorf("%w: %s", ErrNotFound, path)
 }
 
+// Capabilities reports MemWorkspace's storage characteristics:
+// in-memory map under a single mutex, so writes are immediately
+// observable, Rename is atomic, but nothing reaches stable storage
+// and the workspace is single-process by construction.
+func (m *MemWorkspace) Capabilities() Capabilities {
+	return Capabilities{
+		AtomicRename:   true,
+		ReadAfterWrite: true,
+		DurableOnWrite: false,
+		Distributed:    false,
+	}
+}
+
 // MustWrite panics on error — intended for tests.
 func (m *MemWorkspace) MustWrite(path string, data []byte) {
 	if err := m.Write(context.Background(), path, data); err != nil {

--- a/sdk/workspace/scoped.go
+++ b/sdk/workspace/scoped.go
@@ -51,6 +51,18 @@ func NewScopedWorkspace(inner Workspace, opts ...ScopedOption) *ScopedWorkspace 
 	return sw
 }
 
+// Capabilities forwards to the wrapped Workspace, since scoping
+// is a security boundary that does not change durability /
+// atomicity / consistency / distribution semantics. A wrapped
+// Workspace that does not implement [CapabilityReporter] yields a
+// zero-value (all-false) [Capabilities] via [CapabilitiesOf].
+//
+// ScopedGitWorkspace embeds ScopedWorkspace and therefore inherits
+// this method.
+func (s *ScopedWorkspace) Capabilities() Capabilities {
+	return CapabilitiesOf(s.inner)
+}
+
 func (s *ScopedWorkspace) Read(ctx context.Context, path string) ([]byte, error) {
 	if err := s.checkRead(ctx, path); err != nil {
 		return nil, err


### PR DESCRIPTION
## Summary

Prep for **P4 — sdkx/retrieval/workspace**.

Adds an optional interface that \`Workspace\` implementations satisfy to publish their storage characteristics (atomic rename, read-after-write, write durability, distributed access). Higher-layer adapters that need accurate semantics — e.g. the upcoming LSM-style retrieval Index that relies on atomic Rename for manifest swaps — read these via \`CapabilitiesOf\` instead of hard-coding per-impl assumptions.

| Impl | AtomicRename | RaW | Durable | Distributed |
| --- | --- | --- | --- | --- |
| \`MemWorkspace\` | ✅ | ✅ | ❌ | ❌ |
| \`LocalWorkspace\` | ✅ | ✅ | ✅ | ❌ |
| \`ScopedWorkspace\` | (forwards inner) | (forwards inner) | (forwards inner) | (forwards inner) |
| \`ScopedGitWorkspace\` | inherits via embedding | | | |

Contract: **zero value = no guarantees**. Adapters that don't bother to type-assert \`CapabilityReporter\`, or that handle a workspace whose author hasn't implemented it, get the safe path. Adding a new field is therefore additive.

The sdkx-side \`objstore.objectWorkspace\` will land its \`Capabilities()\` method on the follow-up sdkx PR that pins the resulting sdk tag.

## Test plan

- [x] \`go test ./workspace/... -count=1\` passes
- [x] Cases: each impl reports the documented caps; \`Scoped\` forwards a reporter inner; \`Scoped\` over a non-reporter inner yields zero value; \`CapabilitiesOf(nil)\` yields zero value; non-reporter \`Workspace\` yields zero value
- [x] No behavioural changes for existing callers — purely additive interface

## Notes

- No \`[skip-tag:sdk]\`. The follow-up sdkx PR will pin this tag immediately, so accumulating with another sdk change would block downstream.
- Capabilities axis kept deliberately small (4 booleans). Future feature-bearing capabilities (Watch / Snapshot / PresignURL) should be added as sub-interfaces (the same pattern \`CapabilityReporter\` itself follows), not as bool flags here.

Made with [Cursor](https://cursor.com)