### PR TITLE
docs(migrations/v0.3.0): drop incorrect sdkx/tool/mcp reference [skip-tag]

### DIFF
--- a/docs/migrations/v0.3.0.md
+++ b/docs/migrations/v0.3.0.md
@@ -80,8 +80,6 @@ The function/struct shapes are preserved; only the import path changes.
 
 - `sdkx/tool/memory` — Anthropic Memory Tool spec-compatible wrapper
   over `sdk/workspace.Workspace`.
-- `sdkx/tool/mcp` — MCP client primitive that exposes external MCP
-  servers as `tool.Tool` instances.
 
 #### Migration
 


### PR DESCRIPTION
## Summary

The v0.3.0 migration guide listed \`sdkx/tool/mcp\` under \"New
\`sdkx/tool/...\` packages landing alongside\", but no such package
was ever shipped. \`sdkx/tool/\` contains only \`history\`, \`kanban\`,
\`knowledge\`, and \`memory\`.

MCP client / server support is queued as a follow-up workstream
(separate from the v0.3.0 cutover); the doc shouldn't claim it landed.

## Tagging

\`[skip-tag]\` (whole-workflow skip): docs-only change, no module
should pick up a new tag.

## Test plan

- [x] No code changes; just deletes 2 lines from
      \`docs/migrations/v0.3.0.md\`.

Made with [Cursor](https://cursor.com)