### PR TITLE
fix(sdk/graph,llmnode): channel-aware ValidateOutputs for PortTypeMessages (#87)

### DIFF
--- a/sdk/graph/board_test.go
+++ b/sdk/graph/board_test.go
@@ -1,6 +1,10 @@
 package graph
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/GizClaw/flowcraft/sdk/model"
+)
 
 func TestBoard_ValidateInputs(t *testing.T) {
 	b := NewBoard()
@@ -20,6 +24,64 @@ func TestBoard_ValidateInputs(t *testing.T) {
 	node.inputs = append(node.inputs, Port{Name: "missing", Type: PortTypeString, Required: true})
 	if err := ValidateInputs(b, node); err == nil {
 		t.Fatal("should fail for missing required input")
+	}
+}
+
+// TestBoard_ValidateOutputs_VarBacked covers the historical contract:
+// a required output port resolves through a board variable of the same
+// name. This is what every PortTypeString / PortTypeBool / PortTypeUsage
+// output relies on.
+func TestBoard_ValidateOutputs_VarBacked(t *testing.T) {
+	b := NewBoard()
+	b.SetVar("response", "hi")
+
+	node := &testPortNode{
+		outputs: []Port{
+			{Name: "response", Type: PortTypeString, Required: true},
+			{Name: "optional", Type: PortTypeBool, Required: false},
+		},
+	}
+
+	if err := ValidateOutputs(b, node); err != nil {
+		t.Fatalf("should pass: %v", err)
+	}
+
+	node.outputs = append(node.outputs, Port{Name: "missing", Type: PortTypeString, Required: true})
+	if err := ValidateOutputs(b, node); err == nil {
+		t.Fatal("should fail for missing required output")
+	}
+}
+
+// TestBoard_ValidateOutputs_MessagesChannelFallback regression-guards
+// issue #87: under the v0.3 messages-only-on-channel contract, llmnode
+// writes the assistant reply via board.SetChannel and never SetVar. A
+// required PortTypeMessages output must therefore be satisfiable by a
+// non-empty channel of the same name, exactly like ValidateInputs.
+// Without the fallback, every llmnode round through graph/runner is
+// classified Status=failed despite producing the correct messages.
+func TestBoard_ValidateOutputs_MessagesChannelFallback(t *testing.T) {
+	b := NewBoard()
+	b.SetChannel(MainChannel, []model.Message{
+		model.NewTextMessage(model.RoleAssistant, "hi"),
+	})
+
+	node := &testPortNode{
+		outputs: []Port{
+			{Name: MainChannel, Type: PortTypeMessages, Required: true},
+		},
+	}
+
+	if err := ValidateOutputs(b, node); err != nil {
+		t.Fatalf("PortTypeMessages output should be satisfied by a non-empty channel: %v", err)
+	}
+
+	// Empty channel must still be treated as missing — the fallback is
+	// "non-empty", not "channel exists". Otherwise a node that
+	// declares a required messages output but writes nothing would
+	// silently pass validation.
+	b2 := NewBoard()
+	if err := ValidateOutputs(b2, node); err == nil {
+		t.Fatal("empty channel must not satisfy a required PortTypeMessages output")
 	}
 }
 

--- a/sdk/graph/node/llmnode/llmnode.go
+++ b/sdk/graph/node/llmnode/llmnode.go
@@ -93,7 +93,12 @@ func (n *Node) OutputPorts() []graph.Port {
 	}
 	return []graph.Port{
 		{Name: outputKey, Type: graph.PortTypeString, Required: true},
-		{Name: n.channelName(), Type: graph.PortTypeMessages, Required: true},
+		// Messages live on a typed channel (board.SetChannel), not on
+		// board vars. ValidateOutputs only inspects board vars unless
+		// the port is PortTypeMessages, so this port is intentionally
+		// not Required: doing otherwise short-circuits the executor
+		// after every successful llm round.
+		{Name: n.channelName(), Type: graph.PortTypeMessages, Required: false},
 		{Name: VarUsage, Type: graph.PortTypeUsage, Required: true},
 		{Name: VarToolPending, Type: graph.PortTypeBool, Required: true},
 	}

--- a/sdk/graph/port.go
+++ b/sdk/graph/port.go
@@ -71,13 +71,24 @@ func ValidateInputsWithConfig(b *Board, node PortDeclarable, config map[string]a
 }
 
 // ValidateOutputs checks that all required output ports have been written to the Board.
+//
+// Symmetric with ValidateInputsWithConfig: PortTypeMessages outputs may be
+// satisfied either by a board variable or by a non-empty channel of the
+// same name. Without this fallback, nodes that follow the v0.3 channels-
+// only messages contract (e.g. llmnode.writeResults' board.SetChannel)
+// would fail validation despite writing the data the port describes.
 func ValidateOutputs(b *Board, node PortDeclarable) error {
 	for _, p := range node.OutputPorts() {
-		if p.Required {
-			if _, ok := b.GetVar(p.Name); !ok {
-				return errdefs.Validationf("missing required output port %q from node", p.Name)
-			}
+		if !p.Required {
+			continue
 		}
+		if _, ok := b.GetVar(p.Name); ok {
+			continue
+		}
+		if p.Type == PortTypeMessages && len(b.Channel(p.Name)) > 0 {
+			continue
+		}
+		return errdefs.Validationf("missing required output port %q from node", p.Name)
 	}
 	return nil
 }

--- a/sdk/graph/runner/integration_test.go
+++ b/sdk/graph/runner/integration_test.go
@@ -221,6 +221,83 @@ func TestAgentRun_RunIDPropagates(t *testing.T) {
 	}
 }
 
+// channelMessagesNode is a minimal graph.Node that exercises the
+// v0.3 messages-only-on-channel contract end-to-end through
+// runner.Runner. It declares a Required PortTypeMessages output port
+// (just like llmnode), satisfies it solely via board.SetChannel (no
+// SetVar), and otherwise behaves like echoNode. The combination is
+// exactly the path issue #87 broke: executor.runNode invokes
+// graph.ValidateOutputs against a PortDeclarable node whose required
+// messages output lives on a channel, not a var.
+//
+// Defining the type here (rather than depending on llmnode) keeps the
+// regression structural — any future change to ValidateOutputs is
+// caught regardless of whether llmnode happens to be in the binary.
+type channelMessagesNode struct{ id string }
+
+func (n channelMessagesNode) ID() string   { return n.id }
+func (n channelMessagesNode) Type() string { return "chan-msg" }
+func (n channelMessagesNode) InputPorts() []graph.Port {
+	return []graph.Port{
+		{Name: graph.MainChannel, Type: graph.PortTypeMessages, Required: true},
+	}
+}
+func (n channelMessagesNode) OutputPorts() []graph.Port {
+	return []graph.Port{
+		{Name: graph.MainChannel, Type: graph.PortTypeMessages, Required: true},
+	}
+}
+func (n channelMessagesNode) ExecuteBoard(_ graph.ExecutionContext, b *graph.Board) error {
+	main := b.Channel(engine.MainChannel)
+	if len(main) == 0 {
+		return nil
+	}
+	last := main[len(main)-1]
+	reply := model.NewTextMessage(model.RoleAssistant, "echo: "+last.Content())
+	b.AppendChannelMessage(engine.MainChannel, reply)
+	return nil
+}
+
+// TestAgentRun_PortDeclarable_MessagesChannelOutput regression-guards
+// issue #87. Before the fix (sdk@v0.3.0), driving any PortDeclarable
+// node whose required PortTypeMessages output is written via
+// board.SetChannel — the exact shape llmnode adopted in v0.3 — through
+// runner.Runner produced Result.Status="failed" with
+// Result.Err = "missing required output port ... from node", because
+// graph.ValidateOutputs only consulted board vars. The existing
+// echoNode coverage in this file did not implement PortDeclarable, so
+// this code path had no e2e test.
+func TestAgentRun_PortDeclarable_MessagesChannelOutput(t *testing.T) {
+	factory := node.NewFactory()
+	factory.RegisterBuilder("chan-msg", func(def graph.NodeDefinition) (graph.Node, error) {
+		return channelMessagesNode{id: def.ID}, nil
+	})
+	def := &graph.GraphDefinition{
+		Name:  "chan-msg",
+		Entry: "n",
+		Nodes: []graph.NodeDefinition{{ID: "n", Type: "chan-msg"}},
+		Edges: []graph.EdgeDefinition{{From: "n", To: graph.END}},
+	}
+	r, err := runner.New(def, factory)
+	if err != nil {
+		t.Fatalf("runner.New: %v", err)
+	}
+
+	res, err := agent.Run(context.Background(),
+		agent.Agent{ID: "chan-msg-agent"}, r,
+		agent.Request{Message: model.NewTextMessage(model.RoleUser, "hello")},
+	)
+	if err != nil {
+		t.Fatalf("agent.Run: %v", err)
+	}
+	if res.Status != agent.StatusCompleted {
+		t.Fatalf("Status = %q (Err=%v), want completed — likely a regression of issue #87 (graph.ValidateOutputs not channel-aware for PortTypeMessages)", res.Status, res.Err)
+	}
+	if got := res.Text(); got != "echo: hello" {
+		t.Fatalf("Text = %q, want %q", got, "echo: hello")
+	}
+}
+
 // interruptObservingNode is a tiny graph.Node that does the same
 // "drain the host interrupt channel before doing any work" dance
 // LLMNode performs in production. Defining it here keeps the


### PR DESCRIPTION
## Summary

Fixes #87. After the v0.3.0 messages-only-on-channel migration, every `llmnode` round driven through `graph/runner.Runner` returned `Result.Status=failed` / `Err="missing required output port \"__main_channel\" from node"`, even though the assistant reply was correctly written to the channel. Downstream consumers gating on `StatusCompleted` therefore silently stopped working.

Two coordinated, minimal fixes:

- **`sdk/graph/port.go` — `ValidateOutputs`**: mirror `ValidateInputsWithConfig` so a required `PortTypeMessages` output may be satisfied either by a board var or a non-empty channel of the same name.
- **`sdk/graph/node/llmnode/llmnode.go` — `OutputPorts()`**: mark the messages port `Required: false`. It was always redundant (the executor only validates after a successful round, and `writeResults` unconditionally writes the channel on success) and now matches the v0.3 channel-as-source-of-truth contract.

## Why the regression slipped through

`graph/runner/integration_test.go` used an `echoNode` that did **not** implement `graph.PortDeclarable`, so the executor's `ValidateOutputs` path was never exercised against a real `PortDeclarable`-aware node in e2e tests. `llmnode`'s own unit tests bypass the runner. The combination "graph runner + `PortDeclarable` node + `ValidateOutputs` + `PortTypeMessages` written via channel" had zero coverage.

## Test plan

- [x] `go test ./sdk/graph/...` — all green
- [x] `go test ./sdk/...` — all green
- [x] New unit tests in `sdk/graph/board_test.go`:
  - `TestBoard_ValidateOutputs_VarBacked` — historical var-backed contract still enforced.
  - `TestBoard_ValidateOutputs_MessagesChannelFallback` — required `PortTypeMessages` satisfied by non-empty channel; empty channel still fails.
- [x] New e2e regression in `sdk/graph/runner/integration_test.go`:
  - `TestAgentRun_PortDeclarable_MessagesChannelOutput` — drives a `PortDeclarable` node (mirroring llmnode's contract) through `agent.Run` + `runner.Runner`; asserts `StatusCompleted`.
  - Verified to **fail** without the `port.go` change (`Status="failed", Err=missing required output port "__main_channel" from node`) and **pass** with it.

## Notes

- Fix is backwards-compatible: any existing node that wrote a `PortTypeMessages` output to board vars continues to validate exactly as before — the channel check is a fallback, not a replacement.
- Did not adopt the issue's alternative "re-introduce `SetVar` in `writeResults`" — that would undo the v0.3 channel contract.


Made with [Cursor](https://cursor.com)