### PR TITLE
fix(sdk/graph,scriptnode): repair built-in JS scripts against v0.3 bindings

### DIFF
--- a/sdk/graph/node/scriptnode/bridge_node.go
+++ b/sdk/graph/node/scriptnode/bridge_node.go
@@ -1,0 +1,44 @@
+package scriptnode
+
+import (
+	"context"
+
+	"github.com/GizClaw/flowcraft/sdk/script/bindings"
+)
+
+// newNodeBridge exposes the current graph node's identity to scripts as
+// the global "node". It is a deliberately graph-layer bridge — "node"
+// is a graph executor concept that does not exist at the engine /
+// agent / bindings layer, so the bridge lives next to ScriptNode
+// rather than in sdk/script/bindings.
+//
+// The split-of-concerns is:
+//
+//   - "run"  (NewRunInfoBridge in bindings, fed from agent.RunInfo) —
+//     per-run identity: run / task / agent / context ids. Immutable
+//     across all steps of a single run.
+//   - "node" (this bridge) — per-step identity of one graph node.
+//     Re-instantiated for every node the executor invokes; visible
+//     only to scripts running inside that node.
+//   - "host" (NewHostBridge in bindings) — control plane (publish /
+//     emit / askUser / ...) wired with the engine.Host and the
+//     executor's per-node stream publisher.
+//
+// Script-facing API:
+//
+//	node.id()    string  // the graph.NodeDefinition.ID being executed
+//	node.type()  string  // the registered node type (e.g. "answer",
+//	                       "approval", "iteration", or whatever
+//	                       graph.NodeDefinition.Type carried)
+//
+// Future fields (node.inputs(), node.outputs(), …) should land here
+// when scripts demonstrably need them; the bridge stays minimal until
+// then.
+func newNodeBridge(nodeID, nodeType string) bindings.BindingFunc {
+	return func(_ context.Context) (string, any) {
+		return "node", map[string]any{
+			"id":   func() string { return nodeID },
+			"type": func() string { return nodeType },
+		}
+	}
+}

--- a/sdk/graph/node/scriptnode/builtins_test.go
+++ b/sdk/graph/node/scriptnode/builtins_test.go
@@ -1,0 +1,326 @@
+package scriptnode
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/GizClaw/flowcraft/sdk/engine/enginetest"
+	"github.com/GizClaw/flowcraft/sdk/errdefs"
+	"github.com/GizClaw/flowcraft/sdk/graph"
+	"github.com/GizClaw/flowcraft/sdk/graph/node/scripts"
+	"github.com/GizClaw/flowcraft/sdk/script/jsrt"
+)
+
+// These tests exercise the built-in JS node scripts end-to-end through
+// ScriptNode to guarantee the bindings each script depends on actually
+// exist. They are intentionally NOT unit tests of the .js bodies in
+// isolation: every regression we have seen so far (most recently the
+// answer.js -> stream.emit reference to a removed binding) involved a
+// script-level API drifting out of sync with the Go-side bindings, and
+// only an integration test would have caught it.
+
+const runIDForTests = "test-run"
+
+// streamEvent captures a single Emit call so tests can assert on the
+// (type, payload) pair that flowed through ctx.Publisher (and from
+// there into host.emit on the script side).
+type streamEvent struct {
+	Type    string
+	Payload any
+}
+
+// recordingPublisher implements graph.StreamPublisher and stashes
+// every Emit for later inspection. Mirrors the executor-side per-node
+// publisher wiring without pulling in the rest of executor.runConfig.
+func recordingPublisher() (graph.StreamPublisher, *[]streamEvent) {
+	events := &[]streamEvent{}
+	pub := graph.StreamPublisherFunc(func(eventType string, payload any) {
+		*events = append(*events, streamEvent{Type: eventType, Payload: payload})
+	})
+	return pub, events
+}
+
+// execBuiltin builds a ScriptNode from the named built-in script and
+// runs it once with a recording publisher attached so callers can
+// assert on host.emit events.
+func execBuiltin(t *testing.T, name, nodeID string, config map[string]any, setup func(*graph.Board)) (*[]streamEvent, *graph.Board, error) {
+	t.Helper()
+	rt := jsrt.New(jsrt.WithPoolSize(1))
+	src := scripts.MustGet(name)
+	n := New(nodeID, name, src, config, rt)
+	pub, events := recordingPublisher()
+	board := graph.NewBoard()
+	if setup != nil {
+		setup(board)
+	}
+	err := n.ExecuteBoard(graph.ExecutionContext{
+		Context:   context.Background(),
+		Host:      enginetest.NewMockHost(),
+		Publisher: pub,
+		RunID:     runIDForTests,
+	}, board)
+	return events, board, err
+}
+
+// ---------- answer.js ----------
+
+// answer.js must surface its rendered output as a stream-delta event
+// via host.emit. The previous stream.emit("answer", ...) call pointed
+// at a binding that no longer exists; this verifies the replacement
+// goes through ctx.Publisher (the per-node channel the executor
+// pre-bakes) so the wire format matches what engine.PatternRunStream
+// subscribers expect once the executor wraps it.
+func TestBuiltin_Answer_EmitsTokenViaHostEmit(t *testing.T) {
+	events, board, err := execBuiltin(t, "answer", "ans1", map[string]any{
+		"template": "hello {{.name}}",
+	}, func(b *graph.Board) {
+		b.SetVar("name", "world")
+	})
+	if err != nil {
+		t.Fatalf("answer.js execution failed: %v", err)
+	}
+	if v, _ := board.GetVar("answer"); v != "hello world" {
+		t.Fatalf("answer var = %q, want %q", v, "hello world")
+	}
+	if len(*events) != 1 {
+		t.Fatalf("expected 1 stream event, got %d (%+v)", len(*events), *events)
+	}
+	ev := (*events)[0]
+	if ev.Type != "token" {
+		t.Fatalf("event.Type = %q, want %q", ev.Type, "token")
+	}
+	m, ok := ev.Payload.(map[string]any)
+	if !ok {
+		t.Fatalf("payload shape = %T (%+v)", ev.Payload, ev.Payload)
+	}
+	if m["content"] != "hello world" {
+		t.Fatalf("payload.content = %v, want %q", m["content"], "hello world")
+	}
+}
+
+// stream:false suppresses the host.emit call but still sets board.answer
+// — the option opts out of streaming, not of producing the answer.
+func TestBuiltin_Answer_StreamFalseSkipsEmit(t *testing.T) {
+	events, board, err := execBuiltin(t, "answer", "ans2", map[string]any{
+		"template": "static",
+		"stream":   false,
+	}, nil)
+	if err != nil {
+		t.Fatalf("answer.js execution failed: %v", err)
+	}
+	if v, _ := board.GetVar("answer"); v != "static" {
+		t.Fatalf("answer var = %v", v)
+	}
+	if got := len(*events); got != 0 {
+		t.Fatalf("events = %d, want 0 when stream:false", got)
+	}
+}
+
+// Default keys mode (no template, pull from keys) covers the
+// non-template branch of answer.js.
+func TestBuiltin_Answer_KeysMode(t *testing.T) {
+	events, board, err := execBuiltin(t, "answer", "ans3", map[string]any{
+		"keys": []any{"a", "b"},
+	}, func(b *graph.Board) {
+		b.SetVar("a", "first")
+		b.SetVar("b", "second")
+	})
+	if err != nil {
+		t.Fatalf("answer.js execution failed: %v", err)
+	}
+	if v, _ := board.GetVar("answer"); v != "first\nsecond" {
+		t.Fatalf("answer var = %v", v)
+	}
+	if len(*events) != 1 {
+		t.Fatalf("events = %d, want 1", len(*events))
+	}
+	m, _ := (*events)[0].Payload.(map[string]any)
+	if m["content"] != "first\nsecond" {
+		t.Fatalf("payload.content = %v", m["content"])
+	}
+}
+
+// host.emit must be a documented no-op when ctx.Publisher was not
+// installed — test harnesses that omit the per-node publisher should
+// still be able to run scripts without crashes.
+func TestBuiltin_Answer_NilPublisherIsNoOp(t *testing.T) {
+	rt := jsrt.New(jsrt.WithPoolSize(1))
+	n := New("ans_no_pub", "answer", scripts.MustGet("answer"), map[string]any{
+		"template": "hi",
+	}, rt)
+	board := graph.NewBoard()
+	// ExecutionContext intentionally has no Publisher / Host wiring.
+	if err := n.ExecuteBoard(graph.ExecutionContext{
+		Context: context.Background(),
+		RunID:   runIDForTests,
+	}, board); err != nil {
+		t.Fatalf("exec: %v", err)
+	}
+	if v, _ := board.GetVar("answer"); v != "hi" {
+		t.Fatalf("answer var = %v", v)
+	}
+}
+
+// Scripts read the run id via the canonical NewRunInfoBridge "run"
+// global; scriptnode installs the bridge with whatever ctx.RunID
+// carries. The host bridge intentionally does NOT mirror runID — there
+// is one source of truth ("run") for run identity.
+func TestScriptNode_RunInfoBridge_RunIDVisibleToScript(t *testing.T) {
+	rt := jsrt.New(jsrt.WithPoolSize(1))
+	src := `board.setVar("seen_run_id", run.get_run_id());`
+	n := New("rn1", "template", src, nil, rt)
+	board := graph.NewBoard()
+	err := n.ExecuteBoard(graph.ExecutionContext{
+		Context: context.Background(),
+		RunID:   "rn-42",
+	}, board)
+	if err != nil {
+		t.Fatalf("exec: %v", err)
+	}
+	if v, _ := board.GetVar("seen_run_id"); v != "rn-42" {
+		t.Fatalf("seen_run_id = %v, want %q", v, "rn-42")
+	}
+}
+
+// Per-step identity lives on the graph-layer "node" global (defined in
+// scriptnode/bridge_node.go), not on host or run. Scripts read
+// node.id() / node.type() to discover the currently executing node;
+// the values reflect what scriptnode.New was constructed with.
+func TestScriptNode_NodeBridge_ExposesIDAndType(t *testing.T) {
+	rt := jsrt.New(jsrt.WithPoolSize(1))
+	src := `
+		board.setVar("seen_node_id", node.id());
+		board.setVar("seen_node_type", node.type());
+	`
+	n := New("approval-step-7", "approval", src, nil, rt)
+	board := graph.NewBoard()
+	err := n.ExecuteBoard(graph.ExecutionContext{
+		Context: context.Background(),
+	}, board)
+	if err != nil {
+		t.Fatalf("exec: %v", err)
+	}
+	if v, _ := board.GetVar("seen_node_id"); v != "approval-step-7" {
+		t.Fatalf("seen_node_id = %v, want %q", v, "approval-step-7")
+	}
+	if v, _ := board.GetVar("seen_node_type"); v != "approval" {
+		t.Fatalf("seen_node_type = %v, want %q", v, "approval")
+	}
+}
+
+// ---------- approval.js ----------
+
+// First entry into approval (no decision, no prior status) must:
+//   - set approval_status = "pending"
+//   - set approval_request.node_id to the actual node id (NOT undefined,
+//     which was the regression with config.__node_id)
+//   - surface signal.interrupt("waiting for approval") as
+//     errdefs.IsInterrupted so the agent layer pauses the run.
+func TestBuiltin_Approval_FirstPassInterruptsWithNodeID(t *testing.T) {
+	_, board, err := execBuiltin(t, "approval", "approval-step-7", map[string]any{
+		"prompt": "Approve change?",
+	}, nil)
+	if !errdefs.IsInterrupted(err) {
+		t.Fatalf("expected errdefs.IsInterrupted, got: %v", err)
+	}
+	if v, _ := board.GetVar("approval_status"); v != "pending" {
+		t.Fatalf("approval_status = %v", v)
+	}
+	raw, _ := board.GetVar("approval_request")
+	req, ok := raw.(map[string]any)
+	if !ok {
+		t.Fatalf("approval_request shape = %T", raw)
+	}
+	if req["node_id"] != "approval-step-7" {
+		t.Fatalf("approval_request.node_id = %v, want %q (was undefined under the config.__node_id regression)",
+			req["node_id"], "approval-step-7")
+	}
+	if req["prompt"] != "Approve change?" {
+		t.Fatalf("approval_request.prompt = %v", req["prompt"])
+	}
+}
+
+// When the agent resumes the node after the user replied,
+// approval_decision is set on the board; approval.js must record it as
+// the new status and NOT raise another interrupt.
+func TestBuiltin_Approval_DecisionRecorded(t *testing.T) {
+	_, board, err := execBuiltin(t, "approval", "ap1", nil, func(b *graph.Board) {
+		b.SetVar("approval_decision", "approved")
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if v, _ := board.GetVar("approval_status"); v != "approved" {
+		t.Fatalf("approval_status = %v", v)
+	}
+}
+
+// ---------- iteration.js ----------
+
+// The body script must run once per item with __iteration_item bound,
+// and __iteration_result values must accumulate into iteration_results.
+func TestBuiltin_Iteration_AccumulatesResults(t *testing.T) {
+	rt := jsrt.New(jsrt.WithPoolSize(2))
+	n := New("iter1", "iteration", scripts.MustGet("iteration"), map[string]any{
+		"input_key": "items",
+		"body_script": `
+			var x = board.getVar("__iteration_item");
+			board.setVar("__iteration_result", x * 2);
+		`,
+	}, rt)
+	board := graph.NewBoard()
+	board.SetVar("items", []any{int64(1), int64(2), int64(3)})
+	if err := n.ExecuteBoard(graph.ExecutionContext{
+		Context: context.Background(), RunID: runIDForTests,
+	}, board); err != nil {
+		t.Fatalf("exec: %v", err)
+	}
+	raw, _ := board.GetVar("iteration_results")
+	results, ok := raw.([]any)
+	if !ok {
+		t.Fatalf("iteration_results shape = %T", raw)
+	}
+	if len(results) != 3 {
+		t.Fatalf("results len = %d, want 3 (results=%v)", len(results), results)
+	}
+}
+
+// A signal.interrupt inside the body script must surface to the agent
+// layer as an Interrupted error (mirrors the same contract any direct
+// signal.interrupt on a ScriptNode upholds). Before the fix the parent
+// iteration script discarded the child's signal and kept iterating;
+// the body's stale __iteration_result also leaked into the parent's
+// results array. Both are covered here.
+func TestBuiltin_Iteration_BodyInterruptSurfaces(t *testing.T) {
+	rt := jsrt.New(jsrt.WithPoolSize(2))
+	n := New("iter2", "iteration", scripts.MustGet("iteration"), map[string]any{
+		"input_key": "items",
+		"body_script": `
+			var idx = board.getVar("__iteration_index");
+			if (idx === 1) {
+				signal.interrupt("need approval at " + idx);
+			}
+			board.setVar("__iteration_result", idx);
+		`,
+	}, rt)
+	board := graph.NewBoard()
+	board.SetVar("items", []any{int64(10), int64(20), int64(30)})
+
+	err := n.ExecuteBoard(graph.ExecutionContext{
+		Context: context.Background(), RunID: runIDForTests,
+	}, board)
+
+	if !errdefs.IsInterrupted(err) {
+		t.Fatalf("expected errdefs.IsInterrupted, got: %v", err)
+	}
+	if err == nil || !strings.Contains(err.Error(), "need approval at 1") {
+		t.Fatalf("error did not carry child message: %v", err)
+	}
+
+	raw, _ := board.GetVar("iteration_results")
+	results, _ := raw.([]any)
+	if len(results) != 1 {
+		t.Fatalf("results len = %d, want 1 (results=%v)", len(results), results)
+	}
+}

--- a/sdk/graph/node/scriptnode/jsnode.go
+++ b/sdk/graph/node/scriptnode/jsnode.go
@@ -3,6 +3,7 @@ package scriptnode
 import (
 	"fmt"
 
+	"github.com/GizClaw/flowcraft/sdk/agent"
 	"github.com/GizClaw/flowcraft/sdk/engine"
 	"github.com/GizClaw/flowcraft/sdk/graph"
 	"github.com/GizClaw/flowcraft/sdk/graph/node"
@@ -51,10 +52,30 @@ func (n *ScriptNode) SetConfig(c map[string]any) { n.config = c }
 // ExecuteBoard runs the script with board, expr, host, stream, and
 // runtime bindings.
 func (n *ScriptNode) ExecuteBoard(ctx graph.ExecutionContext, board *graph.Board) error {
+	// Bridge wiring rationale:
+	//
+	//   - host: engine.Host control plane (publish / askUser / ...) plus
+	//           the per-node stream channel via host.emit, fed by the
+	//           executor-installed ctx.Publisher. Carries no identity
+	//           accessors.
+	//   - run:  agent.RunInfo identification bundle (per-run, immutable).
+	//           Under direct graph execution only RunID is known, so
+	//           the agent-layer fields (task / agent / context) are
+	//           empty per bridge contract.
+	//   - node: graph-layer per-step identity (id, type). Lives in
+	//           scriptnode rather than in bindings because "node" is a
+	//           graph concept that bindings deliberately does not know
+	//           about (see sdk/script/bindings/doc.go).
+	//
+	// The node id passed to NewHostBridge is still used internally as
+	// the askUser default source and for error annotations, but is no
+	// longer surfaced as a script-readable accessor (use node.id()).
 	allFns := []bindings.BindingFunc{
 		bindings.NewBoardBridge(board),
 		bindings.NewExprBridge(),
-		bindings.NewHostBridge(ctx.Host, n.id),
+		bindings.NewHostBridge(ctx.Host, n.id, ctx.Publisher),
+		bindings.NewRunInfoBridge(agent.RunInfo{RunID: ctx.RunID}),
+		newNodeBridge(n.id, n.nodeType),
 	}
 	allFns = append(allFns, n.extraBindFn...)
 

--- a/sdk/graph/node/scriptnode/register.go
+++ b/sdk/graph/node/scriptnode/register.go
@@ -21,8 +21,11 @@ type Deps struct {
 	CommandRunner workspace.CommandRunner
 }
 
-// Built-in jsnode types that need a shell bridge in addition to fs/runtime.
-var needsShellFS = map[string]bool{
+// needsShell lists built-in jsnode types that additionally require a
+// shell bridge. Every built-in node already gets fs / board / expr /
+// host / runtime bridges unconditionally below; the entries here are
+// the *additional* shell bridge gate (driven by deps.CommandRunner).
+var needsShell = map[string]bool{
 	"gate":    true,
 	"context": true,
 }
@@ -45,7 +48,7 @@ func Register(factory *node.Factory, deps Deps) {
 			}
 			src := scripts.MustGet(n)
 			var extras []bindings.BindingFunc
-			if needsShellFS[n] {
+			if needsShell[n] {
 				extras = append(extras, bindings.NewShellBridge(deps.CommandRunner))
 			}
 			extras = append(extras, bindings.NewFSBridge(deps.Workspace))

--- a/sdk/graph/node/scripts/answer.js
+++ b/sdk/graph/node/scripts/answer.js
@@ -24,6 +24,6 @@
   board.setVar("answer", answer);
 
   if (config.stream !== false) {
-      stream.emit("answer", answer);
+      host.emit("token", { content: answer });
   }
 })();

--- a/sdk/graph/node/scripts/approval.js
+++ b/sdk/graph/node/scripts/approval.js
@@ -8,7 +8,7 @@
       board.setVar("approval_status", "pending");
       board.setVar("approval_request", {
           prompt: config.prompt || "Please approve or reject this action.",
-          node_id: config.__node_id,
+          node_id: node.id(),
       });
       signal.interrupt("waiting for approval");
   }

--- a/sdk/graph/node/scripts/iteration.js
+++ b/sdk/graph/node/scripts/iteration.js
@@ -7,8 +7,22 @@
   for (var i = 0; i < items.length; i++) {
       board.setVar("__iteration_item", items[i]);
       board.setVar("__iteration_index", i);
+      board.setVar("__iteration_result", undefined);
 
-      runtime.execScript(bodyScript, config, []);
+      var sig = runtime.execScript(bodyScript, config);
+
+      if (sig) {
+          if (sig.Type === "interrupt") {
+              board.setVar("iteration_results", results);
+              signal.interrupt(sig.Message);
+              return;
+          } else if (sig.Type === "error") {
+              signal.error(sig.Message);
+              return;
+          } else if (sig.Type === "done") {
+              break;
+          }
+      }
 
       var result = board.getVar("__iteration_result");
       if (result !== undefined) {

--- a/sdk/script/bindings/bridge_host.go
+++ b/sdk/script/bindings/bridge_host.go
@@ -11,20 +11,63 @@ import (
 	"github.com/GizClaw/flowcraft/sdk/model"
 )
 
+// StreamEmitter is the structural contract NewHostBridge accepts for
+// per-node delta emission, exposed to scripts via host.emit. The
+// executor's per-node publisher (built by executor.newNodePublisher)
+// satisfies it; the bridge takes the smaller shape so the bindings
+// package does not depend on sdk/graph.
+//
+// The Emit signature mirrors graph.StreamPublisher exactly so callers
+// can hand the bridge their existing publisher without an adapter.
+type StreamEmitter interface {
+	Emit(eventType string, payload any)
+}
+
 // NewHostBridge exposes the engine.Host control plane to scripts as the
 // global "host". It is the script-side mirror of the small interfaces
 // composed in engine.Host (Publisher, Interrupter, UserPrompter,
-// Checkpointer, UsageReporter).
+// Checkpointer, UsageReporter), with one extra method (host.emit)
+// surfacing the per-node stream publisher the executor pre-baked with
+// the right run / node identity.
 //
 // Script-facing API (every method returns nil / "" on a NoopHost so
 // scripts can call it unconditionally):
 //
 //	host.publish(subject, payload)         -> nil | error
+//	host.emit(type, payload)               -> void   (per-node stream
+//	                                          delta; subject is composed
+//	                                          by the executor from the
+//	                                          runID and nodeID it
+//	                                          installed at wire time)
 //	host.checkInterrupt()                  -> {cause, detail} | null
 //	host.askUser({ parts, schema, source, metadata })
 //	                                       -> { parts, metadata }
 //	host.reportUsage({ input, output, total })
 //	                                       -> nil
+//
+// Identity (which run / which node) is intentionally NOT exposed on
+// host: it lives on the canonical NewRunInfoBridge "run" global
+// (run.get_run_id() / run.get_node_id() / ...). There is one source of
+// truth for "where am I", separate from the host control plane.
+//
+// host.publish vs host.emit:
+//
+//   - host.publish is the low-level escape hatch. Scripts that need a
+//     specific Subject (kanban callbacks, custom analytics subjects,
+//     cross-run signalling) construct the subject themselves and pass
+//     a full envelope payload.
+//   - host.emit is the high-level node-stream channel. The executor
+//     installed a per-node publisher that already knows the runID and
+//     nodeID, so scripts only supply (type, payload) and the envelope
+//     fans out under the canonical
+//     engine.run.<runID>.stream.<nodeID>.delta subject. This is the
+//     same channel Go-side nodes write to via ctx.Publisher.Emit.
+//
+// Payload conventions for host.emit mirror the executor's
+// normalisePayload behaviour: passing an object literal merges in the
+// {type} field so a {content: "..."} payload for type "token" decodes
+// cleanly into engine.StreamDeltaPayload; passing a bare value is wrapped
+// as {type, payload: value} for legacy consumers.
 //
 // Checkpointing is intentionally NOT exposed: scripts have no access to
 // the executing engine's ExecID / Board snapshot / Step marker, so a
@@ -34,7 +77,13 @@ import (
 // than a generic bag.
 //
 // Source labels diagnostic strings (errors carry it, future tracing may
-// too); it mirrors the bridge_llm.LLMBridgeOptions.Source convention.
+// too) and supplies the default UserPrompt.Source for askUser when the
+// script does not override it. It mirrors the
+// bridge_llm.LLMBridgeOptions.Source convention. scriptnode passes the
+// node id as source so an askUser interruption is naturally attributed
+// to the calling node; scripts that want to read the node id should
+// use run.get_node_id() from NewRunInfoBridge, not infer it from this
+// label.
 //
 // Interrupt latching: the first interrupt the bridge observes is cached
 // inside the closure so subsequent host.checkInterrupt() calls keep
@@ -43,10 +92,12 @@ import (
 // "have I been told to stop?" — instead of forcing them to either save
 // the value at first sight or risk losing it on a re-poll.
 //
-// The bridge does NOT own the engine.Host; the caller (typically
-// scriptnode.ScriptNode) feeds it whatever ctx.Host the executor
-// installed and reuses the same Host instance for all bindings.
-func NewHostBridge(host engine.Host, source string) BindingFunc {
+// The bridge does NOT own the engine.Host nor the StreamEmitter; the
+// caller (typically scriptnode.ScriptNode) feeds it whatever
+// ctx.Host / ctx.Publisher the executor installed and reuses those
+// instances for all bindings. When emitter is nil host.emit silently
+// drops the call, matching graph.NoopPublisher on the Go side.
+func NewHostBridge(host engine.Host, source string, emitter StreamEmitter) BindingFunc {
 	return func(callCtx context.Context) (string, any) {
 		if host == nil {
 			host = engine.NoopHost{}
@@ -83,6 +134,13 @@ func NewHostBridge(host engine.Host, source string) BindingFunc {
 		}
 
 		return "host", map[string]any{
+			"emit": func(eventType string, payload any) {
+				if emitter == nil {
+					return
+				}
+				emitter.Emit(eventType, payload)
+			},
+
 			"publish": func(subject string, payload any) error {
 				env, err := event.NewEnvelope(callCtx, event.Subject(subject), payload)
 				if err != nil {

--- a/sdk/script/bindings/bridge_host_test.go
+++ b/sdk/script/bindings/bridge_host_test.go
@@ -54,9 +54,32 @@ func (h *recordingHost) ReportUsage(_ context.Context, u model.TokenUsage) error
 // invoke is a tiny convenience that materialises the bridge's API map
 // and returns it ready for assertions. The bridge name "host" is also
 // returned so tests can verify the canonical global name didn't drift.
+// emitter is nil for the existing test set; tests that exercise
+// host.emit use invokeWithEmitter below.
 func invoke(host engine.Host) (string, map[string]any) {
-	name, raw := NewHostBridge(host, "test-source")(context.Background())
+	name, raw := NewHostBridge(host, "test-source", nil)(context.Background())
 	return name, raw.(map[string]any)
+}
+
+func invokeWithEmitter(host engine.Host, emitter StreamEmitter) map[string]any {
+	_, raw := NewHostBridge(host, "test-source", emitter)(context.Background())
+	return raw.(map[string]any)
+}
+
+// recordingEmitter captures every Emit so host.emit tests can assert
+// the (type, payload) pair without simulating the executor's full
+// publishNodeEvent pipeline.
+type recordingEmitter struct {
+	events []recordedEmit
+}
+
+type recordedEmit struct {
+	Type    string
+	Payload any
+}
+
+func (e *recordingEmitter) Emit(eventType string, payload any) {
+	e.events = append(e.events, recordedEmit{Type: eventType, Payload: payload})
 }
 
 func TestHostBridge_Name(t *testing.T) {
@@ -244,10 +267,44 @@ func TestHostBridge_ReportUsage_RejectsNonNumber(t *testing.T) {
 	}
 }
 
+// host.emit forwards (type, payload) to the StreamEmitter installed at
+// wire time. The bridge does not interpret payload — that is the
+// executor's normalisePayload job downstream — so a script that hands
+// in a map gets the same map back at the publisher.
+func TestHostBridge_Emit_ForwardsToEmitter(t *testing.T) {
+	emitter := &recordingEmitter{}
+	api := invokeWithEmitter(newRecordingHost(), emitter)
+	emit := api["emit"].(func(string, any))
+
+	emit("token", map[string]any{"content": "hi"})
+	if len(emitter.events) != 1 {
+		t.Fatalf("emit calls = %d, want 1", len(emitter.events))
+	}
+	got := emitter.events[0]
+	if got.Type != "token" {
+		t.Fatalf("type = %q", got.Type)
+	}
+	m, ok := got.Payload.(map[string]any)
+	if !ok || m["content"] != "hi" {
+		t.Fatalf("payload = %v (%T)", got.Payload, got.Payload)
+	}
+}
+
+// host.emit must be a silent no-op when the bridge was built without a
+// StreamEmitter (test harnesses that don't wire ctx.Publisher) so
+// scripts stay callable.
+func TestHostBridge_Emit_NoEmitterIsNoOp(t *testing.T) {
+	api := invokeWithEmitter(newRecordingHost(), nil)
+	emit := api["emit"].(func(string, any))
+	// Must not panic. There is no observable side effect to assert
+	// beyond "did not crash" since the bridge silently drops.
+	emit("token", "anything")
+}
+
 func TestHostBridge_NilHost_FallsBackToNoop(t *testing.T) {
 	// NewHostBridge must accept a nil Host (callers that forgot to
 	// install one should still get callable, no-op-ish bindings).
-	name, raw := NewHostBridge(nil, "src")(context.Background())
+	name, raw := NewHostBridge(nil, "src", nil)(context.Background())
 	if name != "host" {
 		t.Fatalf("name = %q", name)
 	}


### PR DESCRIPTION
## Summary

Several built-in JS node scripts under `sdk/graph/node/scripts` had silently drifted out of sync with the v0.3 binding surface:

- **`answer.js`** referenced `stream.emit("answer", ...)` — the `stream` global was retired in v0.3 along with `workflow.StreamCallback`, so the node threw `ReferenceError` on every default invocation.
- **`approval.js`** read `config.__node_id` for `approval_request.node_id`, but nothing in scriptnode ever injected that reserved key. The field was permanently `undefined`.
- **`iteration.js`** passed a stale third argument to `runtime.execScript`, silently dropped child signals, and leaked the previous iteration's `__iteration_result` when the body skipped setting it.

## Approach

Restored emission through the executor's canonical per-node channel and added the missing identity bridge, while keeping each layer aware of only its own concepts:

| Concern | Layer | Where it lives now |
|---|---|---|
| Stream emit `host.emit(type, payload)` | engine | `bindings.NewHostBridge` (gains `StreamEmitter` parameter, backed by `ctx.Publisher`) |
| Per-run identity (`run.*`) | agent | `bindings.NewRunInfoBridge(agent.RunInfo{...})` — unchanged on the script side |
| Per-step identity (`node.id()`, `node.type()`) | **graph** | New `sdk/graph/node/scriptnode/bridge_node.go` (kept out of `bindings` per its no-graph-deps invariant) |
| Control plane (`host.publish`, `askUser`, `checkInterrupt`, `reportUsage`) | engine | `bindings.NewHostBridge` |

Key invariants preserved:
- `agent.RunInfo` stays per-run immutable — no per-step fields added.
- `sdk/script/bindings` remains zero-dependency on `sdk/graph` (see `bindings/doc.go`).
- `host.emit` uses a local `StreamEmitter` duck-typed interface that `graph.StreamPublisher` satisfies, so the executor's per-node publisher wiring carries the run/node identity inside the subject without leaking it back through host.

## Other fixes folded in

- `iteration.js`: clear `__iteration_result` per iteration, check child signal before pushing, propagate `signal.interrupt` / `error` / `done` to the parent loop.
- `scriptnode/register.go`: rename `needsShellFS` → `needsShell` and tighten the comment ("only shell is the extra bridge"; fs is unconditional).

## Test coverage

New `sdk/graph/node/scriptnode/builtins_test.go` drives `answer` / `approval` / `iteration` and the new `node` bridge through `ScriptNode` with a recording `graph.StreamPublisher` and an `enginetest.MockHost`, so future binding renames trip the suite at compile/test time instead of breaking silently in production. `bridge_host_test.go` gains coverage for `host.emit` forwarding and the nil-emitter no-op contract.

## Test plan

- [x] `cd sdk && go build ./...`
- [x] `cd sdk && go test ./...` — all packages green
- [ ] Smoke a downstream graph using the `answer` / `approval` / `iteration` nodes once merged

Made with [Cursor](https://cursor.com)