### PR TITLE
feat(sdk/script): classify signal.error/interrupt against errdefs and engine.Cause

### DIFF
--- a/sdk/graph/node/scriptnode/builtins_test.go
+++ b/sdk/graph/node/scriptnode/builtins_test.go
@@ -2,9 +2,11 @@ package scriptnode
 
 import (
 	"context"
+	"errors"
 	"strings"
 	"testing"
 
+	"github.com/GizClaw/flowcraft/sdk/engine"
 	"github.com/GizClaw/flowcraft/sdk/engine/enginetest"
 	"github.com/GizClaw/flowcraft/sdk/errdefs"
 	"github.com/GizClaw/flowcraft/sdk/graph"
@@ -253,6 +255,67 @@ func TestBuiltin_Approval_DecisionRecorded(t *testing.T) {
 	}
 	if v, _ := board.GetVar("approval_status"); v != "approved" {
 		t.Fatalf("approval_status = %v", v)
+	}
+}
+
+// ---------- signal classification (cross-cuts every script) ----------
+
+// signal.error({ kind: "validation", ... }) at the script level must
+// emerge from ScriptNode.ExecuteBoard as an errdefs.IsValidation error
+// — without callers needing to know about the script-layer mapping.
+// This is the contract scriptnode + future scriptengine hosts share.
+func TestScriptNode_SignalErrorKindFlowsToErrdefs(t *testing.T) {
+	rt := jsrt.New(jsrt.WithPoolSize(1))
+	n := New("validate1", "template", `
+		signal.error({
+			kind: "validation",
+			message: "model field is required",
+			detail: { field: "model" }
+		});
+	`, nil, rt)
+	board := graph.NewBoard()
+	err := n.ExecuteBoard(graph.ExecutionContext{
+		Context: context.Background(),
+		RunID:   runIDForTests,
+	}, board)
+	if err == nil {
+		t.Fatal("expected error from signal.error, got nil")
+	}
+	if !errdefs.IsValidation(err) {
+		t.Fatalf("expected IsValidation, got %v (kind classification lost in the chain?)", err)
+	}
+	if !strings.Contains(err.Error(), "model field is required") {
+		t.Errorf("error string missing message: %q", err.Error())
+	}
+	if !strings.Contains(err.Error(), "validate1") {
+		t.Errorf("error string missing node id: %q", err.Error())
+	}
+}
+
+// signal.interrupt({ kind: "user_input", ... }) must map to
+// engine.Cause=user_input, not collapse to CauseCustom.
+func TestScriptNode_SignalInterruptCauseFlowsThrough(t *testing.T) {
+	rt := jsrt.New(jsrt.WithPoolSize(1))
+	n := New("pause1", "template", `
+		signal.interrupt({ kind: "user_input", message: "barge" });
+	`, nil, rt)
+	board := graph.NewBoard()
+	err := n.ExecuteBoard(graph.ExecutionContext{
+		Context: context.Background(),
+		RunID:   runIDForTests,
+	}, board)
+	if !errdefs.IsInterrupted(err) {
+		t.Fatalf("expected IsInterrupted, got %v", err)
+	}
+	var ie engine.InterruptedError
+	if !errors.As(err, &ie) {
+		t.Fatalf("expected engine.InterruptedError in chain, got %v", err)
+	}
+	if ie.Cause != engine.CauseUserInput {
+		t.Errorf("Cause = %q, want %q", ie.Cause, engine.CauseUserInput)
+	}
+	if ie.Detail != "barge" {
+		t.Errorf("Detail = %q", ie.Detail)
 	}
 }
 

--- a/sdk/graph/node/scriptnode/jsnode.go
+++ b/sdk/graph/node/scriptnode/jsnode.go
@@ -4,12 +4,15 @@ import (
 	"fmt"
 
 	"github.com/GizClaw/flowcraft/sdk/agent"
-	"github.com/GizClaw/flowcraft/sdk/engine"
 	"github.com/GizClaw/flowcraft/sdk/graph"
 	"github.com/GizClaw/flowcraft/sdk/graph/node"
 	"github.com/GizClaw/flowcraft/sdk/script"
 	"github.com/GizClaw/flowcraft/sdk/script/bindings"
 )
+
+// (intentionally no direct dependency on engine / errdefs here:
+// script.SignalToError owns the classification mapping so the
+// translation lives in one place.)
 
 // ScriptNode is a script-based graph node that delegates execution to a
 // language-agnostic script.Runtime.
@@ -96,21 +99,18 @@ func (n *ScriptNode) ExecuteBoard(ctx graph.ExecutionContext, board *graph.Board
 		return fmt.Errorf("script node %s execution failed: %w", n.id, err)
 	}
 
-	if sig != nil {
-		switch sig.Type {
-		case "error":
-			return fmt.Errorf("script node %s: %s", n.id, sig.Message)
-		case "interrupt":
-			// signal.interrupt(msg) is the script's "I want to pause,
-			// the agent will resume me later". We surface it as a
-			// CauseCustom interrupt so the agent layer can both detect
-			// the pause (via errdefs.IsInterrupted) and read the
-			// script-supplied detail.
-			return engine.Interrupted(engine.Interrupt{
-				Cause:  engine.CauseCustom,
-				Detail: sig.Message,
-			})
-		}
+	// script.SignalToError centralises the {interrupt, error, done}
+	// → {engine.Interrupted, errdefs.<Kind>, nil} mapping. Scripts
+	// classify failures via signal.error({ kind, message }) and pauses
+	// via signal.interrupt({ cause, detail }); unknown kinds degrade
+	// inside the helper rather than here so every host (scriptnode,
+	// future scriptengine, …) interprets signals identically.
+	//
+	// %w-wrap preserves the errdefs / engine.InterruptedError
+	// classification so callers can still use errdefs.Is… and
+	// errors.As without losing the "script node X" provenance.
+	if mapped := script.SignalToError(sig); mapped != nil {
+		return fmt.Errorf("script node %s: %w", n.id, mapped)
 	}
 
 	return nil

--- a/sdk/graph/node/scripts/iteration.js
+++ b/sdk/graph/node/scripts/iteration.js
@@ -14,10 +14,21 @@
       if (sig) {
           if (sig.Type === "interrupt") {
               board.setVar("iteration_results", results);
-              signal.interrupt(sig.Message);
+              // Forward kind (engine.Cause) / detail through so the
+              // child's classification reaches the host instead of
+              // collapsing to a bare-message CauseCustom interrupt.
+              signal.interrupt({
+                  kind: sig.Kind,
+                  message: sig.Message,
+                  detail: sig.Detail
+              });
               return;
           } else if (sig.Type === "error") {
-              signal.error(sig.Message);
+              signal.error({
+                  kind: sig.Kind,
+                  message: sig.Message,
+                  detail: sig.Detail
+              });
               return;
           } else if (sig.Type === "done") {
               break;

--- a/sdk/script/jsrt/jsrt.go
+++ b/sdk/script/jsrt/jsrt.go
@@ -162,13 +162,22 @@ func (r *Runtime) Exec(ctx context.Context, name, source string, env *script.Env
 	}
 
 	var sig *script.Signal
+	// signal.interrupt and signal.error accept either:
+	//   - a bare string (back-compat): used as Message; Kind stays empty
+	//     (engine.CauseCustom / errdefs.Internal under SignalToError).
+	//   - an object { kind, message, detail }: Kind classifies the
+	//     signal per script.ErrorKind (errors) or engine.Cause
+	//     (interrupts). Unknown Kind values degrade safely host-side
+	//     rather than aborting the script.
 	signalObj := map[string]any{
-		"interrupt": func(message string) {
-			sig = &script.Signal{Type: "interrupt", Message: message}
+		"interrupt": func(arg any) {
+			kind, msg, detail := parseSignalArg(arg)
+			sig = &script.Signal{Type: "interrupt", Kind: kind, Message: msg, Detail: detail}
 			vm.Interrupt("interrupt")
 		},
-		"error": func(message string) {
-			sig = &script.Signal{Type: "error", Message: message}
+		"error": func(arg any) {
+			kind, msg, detail := parseSignalArg(arg)
+			sig = &script.Signal{Type: "error", Kind: kind, Message: msg, Detail: detail}
 			vm.Interrupt("error")
 		},
 		"done": func() {
@@ -229,6 +238,36 @@ func wrapIIFE(source string) string {
 		return source
 	}
 	return "(function(){\n" + source + "\n})();"
+}
+
+// parseSignalArg decodes the polymorphic argument to signal.interrupt
+// / signal.error. Strings populate Message only; objects may supply
+// kind / message / detail keys. Anything else is silently coerced to
+// an empty message — invalid shapes do not abort the VM; the host's
+// SignalToError translation handles unknown Kind values safely.
+func parseSignalArg(arg any) (kind, message string, detail map[string]any) {
+	switch v := arg.(type) {
+	case nil:
+		return "", "", nil
+	case string:
+		return "", v, nil
+	case map[string]any:
+		if k, ok := v["kind"].(string); ok {
+			kind = k
+		}
+		if m, ok := v["message"].(string); ok {
+			message = m
+		}
+		if d, ok := v["detail"].(map[string]any); ok {
+			detail = d
+		}
+		return kind, message, detail
+	default:
+		// goja widens unrecognised JS values into interface{}; falling
+		// through with a stringified form keeps the surface safe while
+		// still leaving a trail for the script author to spot.
+		return "", fmt.Sprintf("%v", v), nil
+	}
 }
 
 func enrichError(scriptName string, err error) error {

--- a/sdk/script/jsrt/jsrt_test.go
+++ b/sdk/script/jsrt/jsrt_test.go
@@ -72,6 +72,63 @@ func TestRuntime_SignalError(t *testing.T) {
 	if sig == nil || sig.Type != "error" {
 		t.Fatalf("signal = %+v, want error type", sig)
 	}
+	// Bare-string form keeps Kind empty so SignalToError can degrade
+	// it to errdefs.Internal — exercised by the script-level helper
+	// tests in sdk/script/signal_test.go.
+	if sig.Kind != "" {
+		t.Errorf("bare-string error should leave Kind empty, got %q", sig.Kind)
+	}
+	if sig.Message != "bad input" {
+		t.Errorf("Message = %q", sig.Message)
+	}
+}
+
+func TestRuntime_SignalError_ObjectFormCarriesKind(t *testing.T) {
+	rt := New(WithPoolSize(1))
+	sig, err := rt.Exec(context.Background(), "sig-err-obj", `
+		signal.error({
+			kind: "validation",
+			message: "model is required",
+			detail: { field: "model" }
+		});
+	`, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if sig == nil {
+		t.Fatal("expected signal")
+	}
+	if sig.Type != "error" {
+		t.Errorf("Type = %q, want %q", sig.Type, "error")
+	}
+	if sig.Kind != "validation" {
+		t.Errorf("Kind = %q, want %q", sig.Kind, "validation")
+	}
+	if sig.Message != "model is required" {
+		t.Errorf("Message = %q", sig.Message)
+	}
+	if sig.Detail["field"] != "model" {
+		t.Errorf("Detail[field] = %v, want %q", sig.Detail["field"], "model")
+	}
+}
+
+func TestRuntime_SignalInterrupt_ObjectFormCarriesCause(t *testing.T) {
+	rt := New(WithPoolSize(1))
+	sig, err := rt.Exec(context.Background(), "sig-int-obj", `
+		signal.interrupt({ kind: "user_input", message: "barge" });
+	`, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if sig == nil || sig.Type != "interrupt" {
+		t.Fatalf("signal = %+v, want interrupt", sig)
+	}
+	if sig.Kind != "user_input" {
+		t.Errorf("Kind = %q, want %q", sig.Kind, "user_input")
+	}
+	if sig.Message != "barge" {
+		t.Errorf("Message = %q", sig.Message)
+	}
 }
 
 func TestRuntime_SignalDone(t *testing.T) {

--- a/sdk/script/luart/luart.go
+++ b/sdk/script/luart/luart.go
@@ -192,13 +192,22 @@ func (r *Runtime) Exec(ctx context.Context, name, source string, env *script.Env
 	}
 
 	var sig *script.Signal
+	// signal.interrupt and signal.error accept either:
+	//   - a bare string (back-compat): used as Message; Kind stays empty
+	//     (engine.CauseCustom / errdefs.Internal under SignalToError).
+	//   - a table { kind, message, detail }: Kind classifies the signal
+	//     per script.ErrorKind (errors) or engine.Cause (interrupts).
+	//     Unknown Kind values degrade safely host-side rather than
+	//     aborting the script.
 	setGlobal("signal", pushGoValue(L, map[string]any{
-		"interrupt": func(message string) {
-			sig = &script.Signal{Type: "interrupt", Message: message}
+		"interrupt": func(arg any) {
+			kind, msg, detail := parseSignalArg(arg)
+			sig = &script.Signal{Type: "interrupt", Kind: kind, Message: msg, Detail: detail}
 			L.RaiseError(signalRaiseMarker)
 		},
-		"error": func(message string) {
-			sig = &script.Signal{Type: "error", Message: message}
+		"error": func(arg any) {
+			kind, msg, detail := parseSignalArg(arg)
+			sig = &script.Signal{Type: "error", Kind: kind, Message: msg, Detail: detail}
 			L.RaiseError(signalRaiseMarker)
 		},
 		"done": func() {
@@ -226,6 +235,33 @@ func (r *Runtime) Exec(ctx context.Context, name, source string, env *script.Env
 	}
 
 	return nil, nil
+}
+
+// parseSignalArg decodes the polymorphic argument to signal.interrupt
+// / signal.error. Strings populate Message only; tables may supply
+// kind / message / detail keys. See jsrt.parseSignalArg for the JS
+// twin — keeping the two implementations textually parallel is
+// deliberate so a behavioural drift between runtimes is easy to spot.
+func parseSignalArg(arg any) (kind, message string, detail map[string]any) {
+	switch v := arg.(type) {
+	case nil:
+		return "", "", nil
+	case string:
+		return "", v, nil
+	case map[string]any:
+		if k, ok := v["kind"].(string); ok {
+			kind = k
+		}
+		if m, ok := v["message"].(string); ok {
+			message = m
+		}
+		if d, ok := v["detail"].(map[string]any); ok {
+			detail = d
+		}
+		return kind, message, detail
+	default:
+		return "", fmt.Sprintf("%v", v), nil
+	}
 }
 
 func wrapChunk(source string) string {

--- a/sdk/script/luart/luart_test.go
+++ b/sdk/script/luart/luart_test.go
@@ -61,6 +61,55 @@ func TestRuntime_SignalInterrupt(t *testing.T) {
 	if sig.Message != "need approval" {
 		t.Fatalf("signal.Message = %q", sig.Message)
 	}
+	// Bare-string form keeps Kind empty.
+	if sig.Kind != "" {
+		t.Errorf("bare-string interrupt should leave Kind empty, got %q", sig.Kind)
+	}
+}
+
+func TestRuntime_SignalError_TableFormCarriesKind(t *testing.T) {
+	rt := New(WithPoolSize(1))
+	sig, err := rt.Exec(context.Background(), "sig-err-tbl", `
+		signal.error({
+			kind = "validation",
+			message = "model is required",
+			detail = { field = "model" }
+		})
+	`, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if sig == nil || sig.Type != "error" {
+		t.Fatalf("signal = %+v, want error", sig)
+	}
+	if sig.Kind != "validation" {
+		t.Errorf("Kind = %q, want %q", sig.Kind, "validation")
+	}
+	if sig.Message != "model is required" {
+		t.Errorf("Message = %q", sig.Message)
+	}
+	if sig.Detail["field"] != "model" {
+		t.Errorf("Detail[field] = %v, want %q", sig.Detail["field"], "model")
+	}
+}
+
+func TestRuntime_SignalInterrupt_TableFormCarriesCause(t *testing.T) {
+	rt := New(WithPoolSize(1))
+	sig, err := rt.Exec(context.Background(), "sig-int-tbl", `
+		signal.interrupt({ kind = "user_input", message = "barge" })
+	`, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if sig == nil || sig.Type != "interrupt" {
+		t.Fatalf("signal = %+v, want interrupt", sig)
+	}
+	if sig.Kind != "user_input" {
+		t.Errorf("Kind = %q, want %q", sig.Kind, "user_input")
+	}
+	if sig.Message != "barge" {
+		t.Errorf("Message = %q", sig.Message)
+	}
 }
 
 func TestRuntime_PoolReuse(t *testing.T) {

--- a/sdk/script/luart/push.go
+++ b/sdk/script/luart/push.go
@@ -82,7 +82,11 @@ func pushGoValue(L *lua.LState, v any) lua.LValue {
 		}
 		t := L.NewTable()
 		L.SetField(t, "type", lua.LString(x.Type))
+		L.SetField(t, "kind", lua.LString(x.Kind))
 		L.SetField(t, "message", lua.LString(x.Message))
+		if x.Detail != nil {
+			L.SetField(t, "detail", pushGoValue(L, x.Detail))
+		}
 		return t
 	}
 

--- a/sdk/script/script.go
+++ b/sdk/script/script.go
@@ -7,9 +7,28 @@ package script
 import "context"
 
 // Signal represents a control signal from a script back to the host.
+//
+// Type is always one of "interrupt" / "error" / "done" — the three
+// outcomes a script can choose to surface besides "ran to completion".
+//
+// Kind is a per-Type sub-classifier:
+//
+//   - For Type "error" it carries an errdefs category name (see
+//     [ErrorKind]). [SignalToError] maps it onto the matching errdefs
+//     wrapper; unknown values degrade to [ErrorKindInternal] so a
+//     typo in script land cannot escape as an unclassified error.
+//   - For Type "interrupt" it carries an [engine.Cause] string. Unknown
+//     values degrade to [engine.CauseCustom] for the same reason.
+//   - For Type "done" Kind is unused.
+//
+// Message is the human-readable detail. Detail is freeform structured
+// metadata scripts may attach; it is preserved across host translation
+// but is not inspected by [SignalToError] today.
 type Signal struct {
-	Type    string `json:"type"`
-	Message string `json:"message,omitempty"`
+	Type    string         `json:"type"`
+	Kind    string         `json:"kind,omitempty"`
+	Message string         `json:"message,omitempty"`
+	Detail  map[string]any `json:"detail,omitempty"`
 }
 
 // Runtime executes scripts with injected host bindings.

--- a/sdk/script/script_test.go
+++ b/sdk/script/script_test.go
@@ -7,12 +7,23 @@ import (
 )
 
 func TestSignal_Fields(t *testing.T) {
-	s := Signal{Type: "abort", Message: "something went wrong"}
-	if s.Type != "abort" {
-		t.Errorf("Type = %q, want %q", s.Type, "abort")
+	s := Signal{
+		Type:    "error",
+		Kind:    "validation",
+		Message: "something went wrong",
+		Detail:  map[string]any{"field": "model"},
+	}
+	if s.Type != "error" {
+		t.Errorf("Type = %q, want %q", s.Type, "error")
+	}
+	if s.Kind != "validation" {
+		t.Errorf("Kind = %q, want %q", s.Kind, "validation")
 	}
 	if s.Message != "something went wrong" {
 		t.Errorf("Message = %q, want %q", s.Message, "something went wrong")
+	}
+	if s.Detail["field"] != "model" {
+		t.Errorf("Detail[field] = %v, want %q", s.Detail["field"], "model")
 	}
 }
 
@@ -21,8 +32,14 @@ func TestSignal_ZeroValue(t *testing.T) {
 	if s.Type != "" {
 		t.Errorf("zero Type = %q, want empty", s.Type)
 	}
+	if s.Kind != "" {
+		t.Errorf("zero Kind = %q, want empty", s.Kind)
+	}
 	if s.Message != "" {
 		t.Errorf("zero Message = %q, want empty", s.Message)
+	}
+	if s.Detail != nil {
+		t.Errorf("zero Detail = %v, want nil", s.Detail)
 	}
 }
 

--- a/sdk/script/signal.go
+++ b/sdk/script/signal.go
@@ -1,0 +1,123 @@
+package script
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/GizClaw/flowcraft/sdk/engine"
+	"github.com/GizClaw/flowcraft/sdk/errdefs"
+)
+
+// ErrorKind enumerates the errdefs categories scripts may set on
+// signal.error({ kind, message }). Only categories that can plausibly
+// originate from script logic are exposed — auth, rate-limit, timeout
+// and similar wire-level classifications stay in the Go layer where
+// they are produced.
+//
+// Unknown kinds passed by a script degrade to [ErrorKindInternal] in
+// [SignalToError] so a typo in script land cannot escape as an
+// unclassified error.
+type ErrorKind string
+
+const (
+	// ErrorKindValidation marks user-input / config validation
+	// failures. Maps to [errdefs.Validation] (HTTP 400).
+	ErrorKindValidation ErrorKind = "validation"
+
+	// ErrorKindNotFound marks a lookup the script performed that
+	// returned nothing. Maps to [errdefs.NotFound] (HTTP 404).
+	ErrorKindNotFound ErrorKind = "not_found"
+
+	// ErrorKindBudgetExceeded marks a per-run / per-tenant budget
+	// (token, cost, iteration count) the script self-detected.
+	// Maps to [errdefs.BudgetExceeded] (HTTP 429).
+	ErrorKindBudgetExceeded ErrorKind = "budget_exceeded"
+
+	// ErrorKindPolicyDenied marks a policy-layer refusal raised from
+	// inside the script (tool allow-list, role check, …). Maps to
+	// [errdefs.PolicyDenied] (HTTP 403).
+	ErrorKindPolicyDenied ErrorKind = "policy_denied"
+
+	// ErrorKindNotAvailable marks a transient unavailability of a
+	// dependency the script needed (e.g. a knowledge store down).
+	// Maps to [errdefs.NotAvailable] (HTTP 503).
+	ErrorKindNotAvailable ErrorKind = "not_available"
+
+	// ErrorKindInternal is the default fallback for uncategorised
+	// script-side errors. Maps to [errdefs.Internal] (HTTP 500).
+	ErrorKindInternal ErrorKind = "internal"
+)
+
+// SignalToError maps a script control signal into a Go error that
+// fulfils the appropriate errdefs / engine classification, so host
+// code (scriptnode, future scriptengine, …) can share one consistent
+// translation step instead of branching on sig.Type by hand.
+//
+// Mapping rules:
+//
+//   - nil signal, Type "done", or unrecognised Type return nil.
+//   - Type "error": [errdefs] wrapper chosen by Kind; unknown / empty
+//     Kind degrades to [errdefs.Internal] (the value is preserved in
+//     the wrapped message so observability surfaces the typo).
+//   - Type "interrupt": [engine.Interrupted] with Cause taken from
+//     Kind (unknown values fall through to [engine.CauseCustom]) and
+//     Detail taken from Message.
+//
+// Returning nil for an unknown Type matches the existing scriptnode
+// behaviour — only "error" / "interrupt" are observable side-effects.
+func SignalToError(sig *Signal) error {
+	if sig == nil {
+		return nil
+	}
+	switch sig.Type {
+	case "", "done":
+		return nil
+	case "error":
+		return signalErrorToErrdefs(sig)
+	case "interrupt":
+		return engine.Interrupted(engine.Interrupt{
+			Cause:  signalKindToCause(sig.Kind),
+			Detail: sig.Message,
+		})
+	default:
+		return nil
+	}
+}
+
+func signalErrorToErrdefs(sig *Signal) error {
+	msg := sig.Message
+	if msg == "" {
+		msg = "script error"
+	}
+	base := errors.New(msg)
+	switch ErrorKind(sig.Kind) {
+	case ErrorKindValidation:
+		return errdefs.Validation(base)
+	case ErrorKindNotFound:
+		return errdefs.NotFound(base)
+	case ErrorKindBudgetExceeded:
+		return errdefs.BudgetExceeded(base)
+	case ErrorKindPolicyDenied:
+		return errdefs.PolicyDenied(base)
+	case ErrorKindNotAvailable:
+		return errdefs.NotAvailable(base)
+	case ErrorKindInternal, "":
+		return errdefs.Internal(base)
+	default:
+		// Unknown kind: preserve the raw value in the chain for
+		// observability, but classification stays internal so we
+		// never lie about category.
+		return errdefs.Internal(fmt.Errorf("kind=%q: %w", sig.Kind, base))
+	}
+}
+
+func signalKindToCause(kind string) engine.Cause {
+	switch engine.Cause(kind) {
+	case engine.CauseUserCancel,
+		engine.CauseUserInput,
+		engine.CauseHostShutdown,
+		engine.CauseCustom:
+		return engine.Cause(kind)
+	}
+	return engine.CauseCustom
+}

--- a/sdk/script/signal_test.go
+++ b/sdk/script/signal_test.go
@@ -1,0 +1,154 @@
+package script_test
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/GizClaw/flowcraft/sdk/engine"
+	"github.com/GizClaw/flowcraft/sdk/errdefs"
+	"github.com/GizClaw/flowcraft/sdk/script"
+)
+
+// SignalToError is the single point of truth that host code (scriptnode,
+// scriptengine, …) uses to translate script-side signals into Go errors.
+// These tests cover the full classification matrix so a regression in
+// the mapping is impossible to merge silently.
+
+func TestSignalToError_NilAndDone(t *testing.T) {
+	cases := []*script.Signal{
+		nil,
+		{Type: ""},
+		{Type: "done"},
+		{Type: "done", Kind: "ignored", Message: "ignored"},
+		// Unknown types intentionally return nil — only "error" and
+		// "interrupt" cross the host boundary as observable failures.
+		{Type: "weird"},
+	}
+	for _, sig := range cases {
+		if err := script.SignalToError(sig); err != nil {
+			t.Errorf("SignalToError(%+v) = %v, want nil", sig, err)
+		}
+	}
+}
+
+func TestSignalToError_ErrorKinds(t *testing.T) {
+	tests := []struct {
+		name    string
+		kind    string
+		check   func(error) bool
+		wantMsg string
+	}{
+		{"validation", "validation", errdefs.IsValidation, "bad input"},
+		{"not_found", "not_found", errdefs.IsNotFound, "no such thing"},
+		{"budget_exceeded", "budget_exceeded", errdefs.IsBudgetExceeded, "out of tokens"},
+		{"policy_denied", "policy_denied", errdefs.IsPolicyDenied, "tool blocked"},
+		{"not_available", "not_available", errdefs.IsNotAvailable, "knowledge down"},
+		{"internal_explicit", "internal", errdefs.IsInternal, "boom"},
+		{"internal_default_empty_kind", "", errdefs.IsInternal, "boom"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := script.SignalToError(&script.Signal{
+				Type:    "error",
+				Kind:    tt.kind,
+				Message: tt.wantMsg,
+			})
+			if err == nil {
+				t.Fatal("expected error, got nil")
+			}
+			if !tt.check(err) {
+				t.Errorf("classification check failed for %q: %v", tt.kind, err)
+			}
+			if !strings.Contains(err.Error(), tt.wantMsg) {
+				t.Errorf("error message %q missing %q", err.Error(), tt.wantMsg)
+			}
+		})
+	}
+}
+
+func TestSignalToError_UnknownKindDegradesToInternal(t *testing.T) {
+	err := script.SignalToError(&script.Signal{
+		Type:    "error",
+		Kind:    "typo-from-script",
+		Message: "oops",
+	})
+	if !errdefs.IsInternal(err) {
+		t.Fatalf("expected internal classification, got %v", err)
+	}
+	// The raw kind value must survive in the chain so observability
+	// surfaces the typo instead of swallowing it.
+	if !strings.Contains(err.Error(), "typo-from-script") {
+		t.Errorf("error message should preserve unknown kind, got %q", err.Error())
+	}
+}
+
+func TestSignalToError_ErrorEmptyMessage(t *testing.T) {
+	// A script that does signal.error({kind: "validation"}) without a
+	// message still classifies — we just substitute a placeholder so
+	// the error string is non-empty.
+	err := script.SignalToError(&script.Signal{Type: "error", Kind: "validation"})
+	if !errdefs.IsValidation(err) {
+		t.Fatalf("expected validation, got %v", err)
+	}
+	if err.Error() == "" {
+		t.Error("error string should never be empty")
+	}
+}
+
+func TestSignalToError_InterruptCauseMapping(t *testing.T) {
+	tests := []struct {
+		kind      string
+		wantCause engine.Cause
+	}{
+		{"user_cancel", engine.CauseUserCancel},
+		{"user_input", engine.CauseUserInput},
+		{"host_shutdown", engine.CauseHostShutdown},
+		{"custom", engine.CauseCustom},
+		{"", engine.CauseCustom},        // empty → custom
+		{"unknown", engine.CauseCustom}, // unknown → custom (no synthetic causes)
+	}
+	for _, tt := range tests {
+		t.Run(tt.kind, func(t *testing.T) {
+			err := script.SignalToError(&script.Signal{
+				Type:    "interrupt",
+				Kind:    tt.kind,
+				Message: "pausing",
+			})
+			if !errdefs.IsInterrupted(err) {
+				t.Fatalf("expected IsInterrupted, got %v", err)
+			}
+			var ie engine.InterruptedError
+			if !errors.As(err, &ie) {
+				t.Fatalf("expected to extract InterruptedError from %v", err)
+			}
+			if ie.Cause != tt.wantCause {
+				t.Errorf("Cause = %q, want %q", ie.Cause, tt.wantCause)
+			}
+			if ie.Detail != "pausing" {
+				t.Errorf("Detail = %q, want %q", ie.Detail, "pausing")
+			}
+		})
+	}
+}
+
+func TestSignalToError_BackCompatBareMessage(t *testing.T) {
+	// Pre-PR scripts that called signal.error("boom") with no kind
+	// must still produce a classifiable error (Internal) so existing
+	// callers keep working without source changes.
+	err := script.SignalToError(&script.Signal{Type: "error", Message: "boom"})
+	if !errdefs.IsInternal(err) {
+		t.Fatalf("expected internal for empty-kind error, got %v", err)
+	}
+
+	// And signal.interrupt("...") must keep producing an Interrupted
+	// engine error with CauseCustom.
+	err = script.SignalToError(&script.Signal{Type: "interrupt", Message: "pause"})
+	var ie engine.InterruptedError
+	if !errors.As(err, &ie) {
+		t.Fatalf("expected interrupted, got %v", err)
+	}
+	if ie.Cause != engine.CauseCustom {
+		t.Errorf("Cause = %q, want %q", ie.Cause, engine.CauseCustom)
+	}
+}


### PR DESCRIPTION
## Summary

Script `signal.error(msg)` returned a flat string, leaving hosts (scriptnode and any future script-based engine) unable to tell a validation failure apart from a budget refusal or an internal crash without parsing the message. `signal.interrupt(msg)` had the same gap, always collapsing to `engine.CauseCustom`.

This PR makes the signal protocol natively typed and aligns it with `errdefs` / `engine.Cause`:

- `script.Signal` gains `Kind` (errdefs category for errors, `engine.Cause` for interrupts) and `Detail` (freeform structured metadata).
- New `script.SignalToError` is the single point of truth that maps a signal into either `errdefs.<Kind>(message)` or `engine.Interrupted({Cause, Detail})`. Unknown kinds degrade safely (`Internal` / `CauseCustom`) and preserve the raw value in the error chain so observability surfaces the typo.
- `jsrt` and `luart` accept either a bare string (back-compat, kind stays empty) or an object/table ``{ kind, message, detail }`` for both `signal.error` and `signal.interrupt`. The two implementations stay textually parallel so behaviour cannot drift.
- `sdk/graph/node/scriptnode/jsnode.go` drops its inline `switch sig.Type` and delegates to `script.SignalToError`, `%w`-wrapping with the node id so `errdefs.Is…` and `errors.As(InterruptedError)` still work through the chain.
- `iteration.js` forwards `Kind` / `Detail` when re-raising a child signal so the child's classification reaches the host instead of being flattened.

### Script-facing API (no breaking changes)

\`\`\`javascript
// Back-compat: bare string → Internal / CauseCustom
signal.error(\"boom\");
signal.interrupt(\"pause\");

// New: typed
signal.error({ kind: \"validation\", message: \"model is required\", detail: { field: \"model\" } });
signal.interrupt({ kind: \"user_input\", message: \"barge\" });
\`\`\`

### Exposed `ErrorKind` allowlist (deliberate subset of errdefs)

\`validation\`, \`not_found\`, \`budget_exceeded\`, \`policy_denied\`, \`not_available\`, \`internal\`.

Auth / rate-limit / timeout / conflict are intentionally NOT script-raisable — they are wire-level classifications that belong in the Go layer.

## Test plan

- [x] \`go vet ./sdk/...\`
- [x] \`go test ./sdk/...\` — all packages pass (script, script/jsrt, script/luart, script/bindings, graph/node/scriptnode, etc.)
- [x] \`go test ./sdkx/... ./vessel/... ./voice/... ./cmd/vesseld/...\` — no consumers broke
- [x] New \`sdk/script/signal_test.go\` covers every errdefs kind, every \`engine.Cause\`, empty-kind defaults, unknown-kind degradation, back-compat bare strings
- [x] \`jsrt\` / \`luart\` tests cover the object/table form for both signal.error and signal.interrupt and assert Kind / Detail flow through
- [x] scriptnode integration tests assert a kinded \`signal.error\` reaches the host as \`errdefs.IsValidation\` and a kinded \`signal.interrupt\` preserves \`engine.Cause=user_input\`

Made with [Cursor](https://cursor.com)