### PR TITLE
docs: prep vesseld v0.1.0 GA (Status, TCP quickstart, vesseld-with-history demo)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -184,6 +184,61 @@ for the full removed-symbol table and upgrade recipe.
 
 ---
 
+## `vesseld/v0.1.0` — 2026-05-11
+
+General availability of the `vesseld` orchestration daemon. Composes
+the `v0.1.0` vessel runtime with declarative YAML, multi-vessel fleet
+supervision, and a Prometheus-instrumented HTTP control plane into a
+single static binary suitable for production single-node deployments.
+
+This is a documentation / coordination release on top of the RC series;
+no API-level changes between `vesseld/v0.1.0-rc.2` and GA.
+
+### Highlights
+
+- Vessel lifecycle (`/v1/vessels/{id}/call`, `/submit`, `/drain`,
+  `/phase`) wired through unix socket **and** TCP + bearer-token auth.
+  The TCP listener refuses to start without a `tokenFile`; mTLS is on
+  the `v0.2` track.
+- Per-vessel concurrency gate, shared LLM clients with cross-vessel
+  rate limiting, and the seven catalog-registered probes
+  (`TokenBudgetProbe`, `ToolReachableProbe`, `PromptResponseProbe`,
+  …) all on by default.
+- End-to-end `tests/e2e/vesseld` (25+ test files: allowlist, auth,
+  chaos, concurrency, drain, restart, sidecar reject, …) gates the
+  release.
+- Cross-platform binaries (linux/amd64, linux/arm64, darwin/amd64,
+  darwin/arm64, windows/amd64) with SHA-256 checksums via
+  `.github/workflows/release-vesseld.yml`.
+
+### Examples
+
+- [`examples/vesseld-multi-vessel/`](examples/vesseld-multi-vessel/) —
+  the canonical multi-agent demo with Kanban-style delegation.
+- [`examples/vesseld-with-history/`](examples/vesseld-with-history/) —
+  single-vessel demo wiring a shared `HistoryStore` so the agent
+  remembers earlier turns of the same `context_id` conversation.
+  (Cross-restart persistence ships in `v0.2`.)
+
+### Known limitations (tracked for `v0.2`)
+
+- No per-run filesystem session storage (`vessel.WithSessionStore` is
+  not yet wired).
+- mTLS / SecretProvider / `vesseld migrate` subcommand are not yet
+  shipped — runbook recommends fronting the TCP listener with a
+  TLS-terminating proxy in the meantime.
+
+## `vesseld/v0.1.0-rc.2` — 2026-05-11
+
+### Changed
+
+- Bump `vessel` dependency to `v0.1.0-rc.2`, picking up the
+  `Handle.OnTerminate` lifecycle hook. The fleet supervisor now uses
+  this hook to release concurrency gate entries and prune the run
+  registry in deterministic order on vessel termination, eliminating
+  a class of latent races in the rc.1 supervisor that surfaced under
+  rapid drain-restart cycles in chaos tests.
+
 ## `vesseld/v0.1.0-rc.1` — 2026-05-07
 
 First release candidate of the `vesseld` orchestration daemon.
@@ -196,6 +251,33 @@ First release candidate of the `vesseld` orchestration daemon.
   `/v1/runs` (paginated), `/metrics` (Prometheus text exposition).
 - Multi-vessel fleet supervision with per-vessel concurrency gates.
 - Cross-platform release artifacts via `release-vesseld.yml`.
+
+## `vessel/v0.1.0` — 2026-05-11
+
+General availability of the in-process `vessel` runtime. No API-level
+changes between `vessel/v0.1.0-rc.2` and GA — this is a stability /
+documentation coordination release that pairs with `vesseld/v0.1.0`.
+
+### Highlights
+
+- Captain lifecycle (`Submit` / `Drain` / `Stop` / `Restart`) with
+  per-vessel concurrency gates and deterministic termination via
+  `Handle.OnTerminate`.
+- `Spec.Resources.MaxTokensPerTurn` / `MaxTokensPerHour` budget caps
+  enforced end-to-end through `vessel/budget.go` + `vessel/sandbox.go`.
+- Built-in probes (`TokenBudgetProbe`, `ToolReachableProbe`,
+  `PromptResponseProbe`) for liveness / readiness signals; custom
+  probes register via `Probe` interface.
+- Multi-agent routing, Kanban agent-as-tool delegation, sidecar
+  agents, and shared history across the agent roster.
+- Decoupled from `sdk/workflow` (removed in `sdk/v0.3.0`); composes
+  cleanly on `sdk/engine` + `sdk/agent`.
+
+### Known limitations (tracked for `v0.2`)
+
+- `WithSessionStore` (per-run isolated filesystem workspace) is not
+  yet wired; long-running agents that need disk state should use a
+  Captain-scoped workspace today and migrate when `v0.2` lands.
 
 ## `vessel/v0.1.0-rc.2` — 2026-05-07
 

--- a/README.md
+++ b/README.md
@@ -69,7 +69,27 @@ RUN=$(curl -s --unix-socket $SOCK -X POST http://vesseld/v1/vessels/triage/submi
 curl --unix-socket $SOCK "http://vesseld/v1/vessels/triage/logs?run_id=$RUN"
 ```
 
-See [`examples/vesseld-multi-vessel/`](examples/vesseld-multi-vessel/) for the full walkthrough.
+**Remote access via TCP + bearer token.** Set `spec.control.listen` and a `tokenFile` in `daemon.yaml`; validation refuses to start a TCP listener without auth:
+
+```yaml
+spec:
+  control:
+    socket: /tmp/vesseld-multi-vessel.sock   # local debugging stays available
+    listen: 0.0.0.0:8443                     # remote access
+    auth:
+      tokenFile: /etc/vesseld/token           # one line: the bearer token
+```
+
+```bash
+TOKEN=$(cat /etc/vesseld/token)
+curl -H "Authorization: Bearer $TOKEN" http://localhost:8443/v1/vessels/support/call \
+  -H 'content-type: application/json' \
+  -d '{"agent":"support-agent","query":"hello"}'
+```
+
+mTLS support is on the `v0.2` track; until then keep the listener behind a TLS-terminating proxy or restrict it to a trusted network.
+
+See [`examples/vesseld-multi-vessel/`](examples/vesseld-multi-vessel/) for the multi-agent + Kanban delegation walkthrough, and [`examples/vesseld-with-history/`](examples/vesseld-with-history/) for an agent that remembers earlier turns of the same conversation.
 
 ### Library — programmatic SDK usage
 
@@ -193,11 +213,15 @@ The canonical reference is the per-package `doc.go` files, browsable on pkg.go.d
 
 Worked examples live under [`examples/`](examples/) — each one is runnable end-to-end with a single command.
 
+For the daemon specifically, see [`internal-docs/vesseld-cli.md`](internal-docs/vesseld-cli.md) — CLI sub-commands, HTTP control-plane endpoints, and the supported YAML kinds for `vesseld/v0.1.0`.
+
 ---
 
 ## Status
 
-`sdk` and `sdkx` are stable and released continuously. `vessel` and `cmd/vesseld` are at `v0.1.0-rc.*` and stabilising. The next milestone (`v0.2`) covers durable execution, MCP support, OTel exporters, and an evaluation harness.
+`sdk` and `sdkx` are stable and released continuously. `vessel` and `cmd/vesseld` have shipped `v0.1.0` and are production-ready for single-node deployments. Durable execution (Postgres + SQLite checkpoint stores), OTel exporters, Prometheus `/metrics`, the seven-suite `eval/` harness, and end-to-end `tests/e2e/vesseld` conformance are all in place.
+
+The next milestone (`v0.2`) hardens vesseld for "comfortable to operate": per-run session storage, mTLS, a `SecretProvider` interface, and a `vesseld migrate` subcommand. `v0.3` brings the protocol trio — MCP, Agent Skills (SKILL.md), and A2A — plus agent-writable memory Slots.
 
 API surface is governed by SemVer per module. Breaking changes ship as minor bumps until each module reaches `v1.0.0`.
 

--- a/examples/vesseld-multi-vessel/README.md
+++ b/examples/vesseld-multi-vessel/README.md
@@ -7,12 +7,12 @@ for the YAML schema.
 
 ## What it shows
 
-| File | Concept |
-|---|---|
-| `daemon.yaml` | Daemon-wide config: control socket, drain timeout, LLM rate-limit bucket. |
-| `shared/openai.yaml` | One `LLMProfile` referenced by every vessel — the daemon shares the underlying client + limiter across them. |
-| `vessels/triage/vessel.yaml` | A multi-agent vessel with **dispatcher + worker** + `Kanban` agent-as-tool delegation. |
-| `vessels/support/vessel.yaml` | A simple single-agent vessel for plain Q&A. |
+| File                          | Concept                                                                                                      |
+| ----------------------------- | ------------------------------------------------------------------------------------------------------------ |
+| `daemon.yaml`                 | Daemon-wide config: control socket, drain timeout, LLM rate-limit bucket.                                    |
+| `shared/openai.yaml`          | One `LLMProfile` referenced by every vessel — the daemon shares the underlying client + limiter across them. |
+| `vessels/triage/vessel.yaml`  | A multi-agent vessel with **dispatcher + worker** + `Kanban` agent-as-tool delegation.                       |
+| `vessels/support/vessel.yaml` | A simple single-agent vessel for plain Q&A.                                                                  |
 
 The two vessels live in the same daemon, share the LLM profile, but have independent agent rosters, history, and `Resources` caps.
 
@@ -84,9 +84,39 @@ curl --unix-socket /tmp/vesseld-multi-vessel.sock \
 
 `SIGTERM` to the daemon also runs drain semantics, bounded by `daemon.spec.shutdown.drainTimeout`.
 
+## Remote access via TCP + bearer token
+
+The default `daemon.yaml` only exposes the unix socket. To reach the daemon over the network, set `spec.control.listen` and a `tokenFile`. The validator refuses to start a TCP listener without a token — it's an explicit "no open ports without auth" guarantee:
+
+```yaml
+# daemon.yaml
+spec:
+  control:
+    socket: /tmp/vesseld-multi-vessel.sock # keep the unix socket for local debugging
+    listen: 0.0.0.0:8443 # remote endpoint
+    auth:
+      tokenFile: ./token # one-line file: the bearer secret
+```
+
+```bash
+echo "$(openssl rand -hex 32)" > ./token
+chmod 600 ./token
+./vesseld run --config examples/vesseld-multi-vessel -R
+
+# In another shell:
+TOKEN=$(cat examples/vesseld-multi-vessel/token)
+curl -H "Authorization: Bearer $TOKEN" http://localhost:8443/v1/vessels/support/call \
+  -H 'content-type: application/json' \
+  -d '{"agent":"support-agent","query":"hello"}'
+```
+
+The unix-socket path and TCP path are equivalent — they hit the same handler. Keep the unix socket for in-host operator access (no TLS overhead) and TCP for cross-host.
+
+> **mTLS / OIDC** are on the `v0.2` track. Until then, place the TCP listener behind a TLS-terminating proxy (nginx / envoy / Caddy) or restrict it to a trusted network.
+
 ## Going further
 
 - Swap `provider: openai` → `provider: deepseek` / `anthropic` / `bytedance` / `minimax`. The same YAML works.
 - Add a sidecar agent (`sidecar: true` + `subscribeTo: agent.run.completed`) to the triage vessel to log every completed turn.
-- Set `auth.token: <string>` on the daemon and a `Listen: :8443` to expose the API over TCP with bearer-token auth.
+- For an agent that remembers across turns of the same conversation, see [`examples/vesseld-with-history/`](../vesseld-with-history/) — wires a shared `HistoryStore` and a `context_id`-keyed transcript.
 - For the smaller single-vessel "hello world", strip this directory down to one `Vessel` + one `Agent` + one `LLMProfile` document — the daemon will validate and run with as few as four `kind:` blocks.

--- a/examples/vesseld-with-history/README.md
+++ b/examples/vesseld-with-history/README.md
@@ -1,0 +1,63 @@
+# vesseld with conversational history
+
+Single-vessel, single-agent demo that wires a shared `HistoryStore` so the agent remembers what was said earlier in the conversation. Pair this with [`vesseld-multi-vessel`](../vesseld-multi-vessel/) — that one shows multi-agent + Kanban delegation; this one shows how a Vessel preserves transcript state across turns.
+
+## What it shows
+
+| File | Concept |
+|---|---|
+| `daemon.yaml` | Daemon-wide config: control socket, drain timeout, shared LLM rate-limit bucket. |
+| `shared/openai.yaml` | One `LLMProfile`. |
+| `shared/history.yaml` | A `HistoryStore` with `ref: buffer` and a per-conversation cap of 500 messages. |
+| `vessels/assistant/vessel.yaml` | `Vessel` references the HistoryStore; the `Agent` opts into `historyAccess: read_write`. |
+
+Multiple Vessels can reference the **same** `HistoryStore` — useful when a "human" vessel and a "supervisor sidecar" vessel need to see one another's turns.
+
+## Prerequisites
+
+```bash
+export OPENAI_API_KEY=sk-...
+go build -o ./vesseld ./cmd/vesseld
+```
+
+## Run
+
+```bash
+./vesseld validate --config examples/vesseld-with-history -R
+./vesseld run      --config examples/vesseld-with-history -R
+```
+
+## Drive a multi-turn conversation
+
+The key is **a stable `context_id`** in each request. Different `context_id`s give independent transcripts; the same one continues a thread.
+
+```bash
+SOCK=/tmp/vesseld-with-history.sock
+CONV=demo-alice                     # any stable string; treat it as the conversation key
+
+# Turn 1: tell the agent something.
+curl --unix-socket $SOCK -X POST http://vesseld/v1/vessels/assistant/call \
+  -H 'content-type: application/json' \
+  -d "{\"agent\":\"assistant-agent\",\"context_id\":\"$CONV\",\"query\":\"My name is Alice and I prefer coffee over tea.\"}"
+
+# Turn 2: ask a follow-up — the agent recalls from the buffer.
+curl --unix-socket $SOCK -X POST http://vesseld/v1/vessels/assistant/call \
+  -H 'content-type: application/json' \
+  -d "{\"agent\":\"assistant-agent\",\"context_id\":\"$CONV\",\"query\":\"What should I drink this morning?\"}"
+```
+
+The second response should reference coffee. Change `CONV` to a new value and ask the same question — the agent will (correctly) admit it doesn't know.
+
+## Caveats — what this is NOT
+
+> **The buffer history lives in the daemon's memory.** Restart `vesseld` and every conversation is gone.
+>
+> Persistent transcripts across daemon restarts arrive in `v0.2.0` via the `Compacted` history flavor (hierarchical SummaryDAG + SQLite/Postgres-backed `Store`). The declarative YAML schema and the `vessel.WithSessionStore` option are tracked under [`internal-docs/roadmap.md`](../../internal-docs/roadmap.md) §4 v0.2.0.
+>
+> If you need cross-restart memory **today**, embed `vessel` as a library and pass `history.NewCompacted(store, llm, ws)` directly — see `examples/chatbot-with-recall/` for the in-process pattern.
+
+## Going further
+
+- Set `maxMessages` lower (e.g. 20) and observe the agent "forgetting" once eviction kicks in.
+- Add a second agent to the same vessel with `historyAccess: read_only` to model a supervisor that watches without writing.
+- Combine with `examples/vesseld-multi-vessel/` patterns: point both demo daemons at the same `HistoryStore` document and they'll share transcripts.

--- a/examples/vesseld-with-history/daemon.yaml
+++ b/examples/vesseld-with-history/daemon.yaml
@@ -1,0 +1,20 @@
+apiVersion: vessel.flowcraft.io/v1alpha1
+kind: Daemon
+metadata:
+  name: history-demo
+spec:
+  control:
+    # Local control plane only — for a TCP listener + bearer token
+    # config, see examples/vesseld-multi-vessel/README.md.
+    socket: /tmp/vesseld-with-history.sock
+  resources:
+    maxConcurrentRuns: 8
+  llmRateLimits:
+    - llmProfile: shared-openai
+      requestsPerMinute: 300
+      perVesselFairshare: true
+  logging:
+    format: text
+    level: info
+  shutdown:
+    drainTimeout: 5s

--- a/examples/vesseld-with-history/shared/history.yaml
+++ b/examples/vesseld-with-history/shared/history.yaml
@@ -1,0 +1,14 @@
+apiVersion: vessel.flowcraft.io/v1alpha1
+kind: HistoryStore
+metadata:
+  name: assistant-history
+spec:
+  # v0.1.0 ships a single factory ("buffer") backed by an
+  # in-memory store. Hierarchical SummaryDAG ("compacted") and
+  # persistent backends (sqlite / postgres / redis) are on the
+  # v0.2 track — see internal-docs/roadmap.md.
+  ref: buffer
+  config:
+    # Per-conversation cap. The buffer evicts oldest turns when
+    # exceeded; tune to balance context window vs. recall depth.
+    maxMessages: 500

--- a/examples/vesseld-with-history/shared/openai.yaml
+++ b/examples/vesseld-with-history/shared/openai.yaml
@@ -1,0 +1,12 @@
+apiVersion: vessel.flowcraft.io/v1alpha1
+kind: LLMProfile
+metadata:
+  name: shared-openai
+spec:
+  provider: openai
+  config:
+    defaultModel: gpt-4o-mini
+  auth:
+    apiKey:
+      valueFrom:
+        env: OPENAI_API_KEY

--- a/examples/vesseld-with-history/vessels/assistant/vessel.yaml
+++ b/examples/vesseld-with-history/vessels/assistant/vessel.yaml
@@ -1,0 +1,41 @@
+apiVersion: vessel.flowcraft.io/v1alpha1
+kind: Vessel
+metadata:
+  name: assistant
+spec:
+  agents:
+    - assistant-agent
+  # Wire the vessel onto the shared HistoryStore. Every agent in
+  # this vessel that opts into history access sees the same
+  # conversation transcript, keyed by the request's context_id.
+  history:
+    ref: assistant-history
+  resources:
+    maxConcurrentRuns: 4
+    turnTimeout: 60s
+---
+apiVersion: vessel.flowcraft.io/v1alpha1
+kind: Agent
+metadata:
+  name: assistant-agent
+spec:
+  card:
+    name: Memory-Aware Assistant
+    description: |
+      Single-agent vessel that remembers the user across turns of
+      the same context_id, demonstrating buffer-history wiring.
+  # read_write = the agent's BoardSeeder loads prior turns AND
+  # the post-run Observer appends the new turn to the transcript.
+  # Use read_only for sidecars / monitors that should see history
+  # without writing.
+  historyAccess: read_write
+  engine:
+    ref: graph-llm
+    config:
+      llmProfile: shared-openai
+      systemPrompt: |
+        You are a helpful assistant with conversational memory.
+        Refer back to facts the user told you earlier in the
+        conversation when relevant. If asked something you have
+        not been told, say so plainly — don't fabricate.
+      maxIterations: 4


### PR DESCRIPTION
## Summary

Three doc-only changes to clear the runway for cutting `vessel/v0.1.0` and `vesseld/v0.1.0` GA tags. No Go code touched.

- **`README.md`** — rewrite Status section against shipped reality (Postgres/SQLite checkpointers, OTel, Prometheus `/metrics`, seven-suite `eval/` harness all in place); refresh the v0.2 / v0.3 milestone descriptions; add a TCP + bearer-token snippet to the Quickstart so remote access is documented before users hit it.
- **`examples/vesseld-multi-vessel/README.md`** — add a "Remote access via TCP + bearer token" section with the `tokenFile` YAML and a `curl -H "Authorization: Bearer …"` example; mTLS explicitly tagged as `v0.2` scope.
- **`examples/vesseld-with-history/`** *(new)* — single-vessel demo that wires a shared `HistoryStore` (`ref: buffer`) so the agent remembers earlier turns of the same `context_id` conversation. README is explicit that v0.1.0 only ships in-memory buffer history; cross-restart persistence is deferred to v0.2's `Compacted` flavor + `SessionStore`.
- **`CHANGELOG.md`** — add `vessel/v0.1.0`, `vesseld/v0.1.0-rc.2` (vessel rc.2 dep bump + supervisor race fix), and `vesseld/v0.1.0` GA entries with known-limitations callouts.

## Test plan

- [x] `make vet` — clean across all modules
- [x] `make test-e2e` — `tests/e2e/vesseld` (29.5s) + `tests/e2e/retrieval` (0.5s) both green
- [x] `tests/quality/vessel` — 1.3s green
- [x] `vesseld validate -R` on both `vesseld-multi-vessel` and `vesseld-with-history` → `ok`
- [x] `vesseld plan -R` on `vesseld-with-history` confirms `HistoryStore` ref resolution
- [ ] Wait for required CI status check to pass on the PR

> **Note**: `make test` locally trips a known live-LLM hang in `tests/conformance/llm` after 601s (HTTP/2 TLS read stuck) because a populated `.env` defeats the suite's self-skip path. Not a regression — this PR touches zero Go.

## Follow-up

Once this merges, the planned tag sequence is:

```bash
git tag -a vessel/v0.1.0       -m "vessel v0.1.0 — runtime GA"
git tag -a vesseld/v0.1.0-rc.2 -m "vesseld v0.1.0-rc.2 — vessel rc.2 dep bump"
git tag -a vesseld/v0.1.0      -m "vesseld v0.1.0 — daemon GA"
git push origin vessel/v0.1.0 vesseld/v0.1.0-rc.2 vesseld/v0.1.0
```

`release-vesseld.yml` then auto-builds the 5-arch matrix + SHA-256s. `auto-tag.yml` is a no-op for this PR (filters on `sdk|sdkx|voice|vessel/**` paths, none of which we touched).

Made with [Cursor](https://cursor.com)