### PR TITLE
fix(eval/notify): drop every *_progress kind from Feishu card history

### DIFF
--- a/eval/.gitignore
+++ b/eval/.gitignore
@@ -2,24 +2,28 @@
 #
 # - {locomo,longmemeval}/data/    upstream dumps + converted .jsonl
 #                                 (CC-BY but bulky; users fetch via
-#                                 each suite's cmd/ helpers)
-# - {locomo,longmemeval,history}/results/  per-run report JSON
-# - compiled binaries from `go build ./<suite>/cmd/...`
+#                                 each suite's converter subcommand)
+# - {locomo,longmemeval,history,knowledge,beir,simpleqa,taubench}/results/
+#                                 per-run report JSON. Headline
+#                                 baselines are summarised in each
+#                                 suite's README; the raw artefacts
+#                                 are intentionally excluded.
+# - compiled binaries from `go build ./cmd/eval` (the unified Cobra
+#   entry point) and any local-build leftovers.
 locomo/data/
 locomo/results/
 longmemeval/data/
 longmemeval/results/
 history/results/
-locomo/cmd/*/convert-locomo
-locomo/cmd/*/eval
-locomo/cmd/*/compare
-locomo/cmd/*/fetch
-locomo/cmd/*/ingest
-longmemeval/cmd/*/convert
-# `go build ./locomo/cmd/<x>` from eval/ drops the binary at eval/<x>.
-/compare
-/convert-locomo
+knowledge/results/
+beir/results/
+simpleqa/results/
+taubench/results/
+
+# Unified-CLI build product: `go build ./cmd/eval` from eval/ drops
+# the binary at eval/eval. The trailing slash-less form means "file
+# named eval at the eval/ root only" — it does NOT match any suite
+# subdirectory's content because `/eval` is rooted at this .gitignore
+# location (eval/) and there is no folder literally called `eval` here
+# (the suites are locomo/, longmemeval/, history/, …).
 /eval
-/fetch
-/ingest
-/results

--- a/eval/internal/notify/feishu_app.go
+++ b/eval/internal/notify/feishu_app.go
@@ -337,14 +337,23 @@ func (f *FeishuApp) renderMarkdown() string {
 		var historyLines []string
 		for i := 0; i < len(f.events)-1; i++ {
 			e := f.events[i]
-			// ingest_progress milestones are transient: they give live
-			// visibility while ingest is running but are superseded by
-			// ingest_done. Keeping them in History bloats the card on
-			// long runs (4 progress lines + ingest_done all saying
-			// essentially the same thing), so we drop them once a newer
-			// event arrives. The current ingest_progress is still
-			// rendered in the Latest block.
-			if e.Kind == "ingest_progress" {
+			// *_progress milestones are transient: they give live
+			// visibility while a phase is running but are superseded
+			// by the matching *_done. Keeping them in History bloats
+			// the card on long runs (many progress lines + one done
+			// line all saying essentially the same thing), so we drop
+			// them once a newer event arrives. The current progress
+			// event is still rendered in the Latest block.
+			//
+			// Covered kinds: ingest_progress, qa_progress, and the
+			// history-suite per-strategy progress events
+			// (strategy_progress, lane_progress). Hard-coded on
+			// purpose: future eval suites that add their own *_progress
+			// kind opt in by extending this list, which forces the
+			// author to think about History-vs-Latest semantics.
+			switch e.Kind {
+			case "ingest_progress", "qa_progress",
+				"strategy_progress", "lane_progress":
 				continue
 			}
 			since := e.At.Sub(first.At).Truncate(time.Second)

--- a/eval/internal/notify/feishu_app_test.go
+++ b/eval/internal/notify/feishu_app_test.go
@@ -168,9 +168,66 @@ func TestFeishuApp_SubsequentEventsPatch(t *testing.T) {
 	if _, ok := mock.lastPatchBody["sequence"]; !ok {
 		t.Errorf("patch body must include sequence for ordering: %v", mock.lastPatchBody)
 	}
-	for _, want := range []string{"begin", "25%", "complete", "qa.judge=0.612", "✅"} {
+	// The final patch (after `done`) MUST contain the done title +
+	// body and the start title (which lives in History). It MUST NOT
+	// contain the qa_progress title — _progress events are transient
+	// and are dropped from History once superseded by the next event,
+	// so the card doesn't bloat over a 50 h run with dozens of
+	// progress milestones.
+	for _, want := range []string{"begin", "complete", "qa.judge=0.612", "✅"} {
 		if !strings.Contains(elementStr, want) {
 			t.Errorf("patched element should contain %q\n--- element ---\n%s", want, elementStr)
+		}
+	}
+	if strings.Contains(elementStr, "25%") {
+		t.Errorf("patched element MUST NOT contain superseded qa_progress title %q\n--- element ---\n%s", "25%", elementStr)
+	}
+}
+
+// TestFeishuApp_ProgressEventsFilteredFromHistory pins the filter
+// rule end-to-end across every *_progress kind we know about:
+// ingest_progress (locomo/longmemeval), qa_progress (locomo /
+// longmemeval / simpleqa / beir / taubench), strategy_progress
+// (history), lane_progress (knowledge). All of them must be visible
+// in Latest while they're the most recent event, then dropped from
+// History the moment a non-progress event arrives.
+func TestFeishuApp_ProgressEventsFilteredFromHistory(t *testing.T) {
+	mock := &fakeFeishu{}
+	srv := httptest.NewServer(mock.handler(t))
+	defer srv.Close()
+
+	app := &FeishuApp{
+		AppID: "cli_test", AppSecret: "s", ChatID: "oc_test", Name: "smoke",
+		Base: srv.URL,
+		Now:  func() time.Time { return time.Date(2026, 5, 11, 13, 0, 0, 0, time.UTC) },
+	}
+	ctx := context.Background()
+	progressKinds := []string{"ingest_progress", "qa_progress", "strategy_progress", "lane_progress"}
+	if err := app.Notify(ctx, Event{Kind: "start", Title: "begin"}); err != nil {
+		t.Fatalf("start: %v", err)
+	}
+	for i, k := range progressKinds {
+		title := k + "-25%"
+		if err := app.Notify(ctx, Event{Kind: k, Title: title}); err != nil {
+			t.Fatalf("%d %s: %v", i, k, err)
+		}
+		// While this kind is Latest its title must be visible.
+		body, _ := mock.lastPatchBody["partial_element"].(string)
+		if !strings.Contains(body, title) {
+			t.Errorf("Latest must show current %s title %q; body=%s", k, title, body)
+		}
+	}
+	if err := app.Notify(ctx, Event{Kind: "done", Title: "complete"}); err != nil {
+		t.Fatalf("done: %v", err)
+	}
+	final, _ := mock.lastPatchBody["partial_element"].(string)
+	if !strings.Contains(final, "begin") || !strings.Contains(final, "complete") {
+		t.Errorf("final card must keep start (in History) + done (in Latest); body=%s", final)
+	}
+	for _, k := range progressKinds {
+		title := k + "-25%"
+		if strings.Contains(final, title) {
+			t.Errorf("%s title %q must be dropped from History once superseded; body=%s", k, title, final)
 		}
 	}
 }

--- a/eval/longmemeval/README.md
+++ b/eval/longmemeval/README.md
@@ -106,6 +106,26 @@ minimax answer + azure judge + deepseek reranker, k=30) `_s` takes
 roughly 4-5h end-to-end and `_m` is closer to 30-40h — gate the latter
 behind a manual nightly until ingest concurrency is tuned upward.
 
+## Baselines
+
+Headline `oracle` numbers from periodic full-sweep runs. Raw JSON
+reports are NOT committed (gitignored under `results/`); ask the
+on-call eval owner for the artefact if you need the per-question
+detail. Numbers are recorded here so the trend is visible at a
+glance from the repo.
+
+| Date       | Stack (extractor / answer / judge / reranker / embedder)                                                              | k  | n   | qa.judge | qa.em | qa.f1 | recall.p95 | save.p95 |
+| ---------- | --------------------------------------------------------------------------------------------------------------------- | -- | --- | -------- | ----- | ----- | ---------- | -------- |
+| 2026-05-11 | deepseek-v4-flash / minimax-m2.7-highspeed / azure-gpt-5 (locomo prompt) / qwen-flash / qwen text-embedding-v4         | 30 | 500 | **0.812**| 0.484 | 0.134 | 7.5 s      | 244 s    |
+
+The 2026-05-11 sweep was the first oracle baseline against
+`feat/eval-migration`'s unified runner — see PR #91 for the code
+under test. mem0's published LongMemEval oracle reference range is
+~0.70-0.80 on qa.judge, so flowcraft's 0.812 is a competitive
+starting point; gains from here are expected to come from per-type
+prompts (the `*_abs` abstention class still drags) rather than the
+core pipeline.
+
 ## Citation
 
 ```bibtex


### PR DESCRIPTION
## Summary

Two small follow-ups against PR #91:

1. **Feishu card bug fix** — drop every `*_progress` kind (`ingest_progress`, `qa_progress`, `strategy_progress`, `lane_progress`) from the History block. Previously only `ingest_progress` was filtered, so a long LongMemEval run on `--notify-progress-pct 1` accumulated ~100 redundant qa_progress lines in the card body before `done`.
2. **Record the first LongMemEval oracle baseline** — n=500, qa.judge=0.812, plus a Baselines table in `eval/longmemeval/README.md` so future runs append a row. Also tidies `eval/.gitignore` after the cobra migration deleted every per-suite `cmd/eval` package; only `/eval` (the unified binary build artefact) remains.

## Result this baseline pins

mem0's published LongMemEval oracle range is ~0.70-0.80 on qa.judge; flowcraft's 0.812 on the same dataset is the new headline number. Stack: deepseek-v4-flash extractor + minimax m2.7-highspeed answer + azure gpt-5 (locomo prompt) judge + qwen-flash reranker + qwen text-embedding-v4 embedder, topk=30, run on `feat/eval-migration`'s unified runner. The eval was executed on the remote eval server with this fix's predecessor; the card-bloat behaviour is what motivated this fix.

## Test plan

- [x] `go test ./eval/internal/notify/...` — green, including the new `TestFeishuApp_ProgressEventsFilteredFromHistory` end-to-end pin
- [x] manual review of the README table format
- [ ] next live LongMemEval run will visually confirm the card stops accumulating progress lines (covered by the unit test, no need to gate on this)

Made with [Cursor](https://cursor.com)