### PR TITLE
feat(eval/notify): thread-reply on lifecycle events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,10 @@ compare/fetch/ingest`, `eval longmemeval convert`). Shell completion
 - `eval/internal/notify` + `eval/scripts/run-eval.sh`: Feishu CardKit
   notifications (one live-updated card per run; webhook backend
   intentionally unsupported) plus a process supervisor with PID lock,
-  disk check, log tee, and idle watchdog.
+  disk check, log tee, and idle watchdog. Lifecycle events
+  (`ingest_done` / `done` / `error`) post a threaded text reply so
+  operators get a phone-buzz at phase boundaries; intra-phase
+  `*_progress` milestones stay as silent card edits.
 - `eval/locomo`: `--judge-style {locomo|strict}` and
   `--judge-temperature` flags; mem0-aligned LoCoMo judge prompt at
   `metrics.LocoMoLLMJudgePrompt`. Per-batch ingest heartbeats so slow

--- a/eval/internal/notify/feishu_app.go
+++ b/eval/internal/notify/feishu_app.go
@@ -289,9 +289,18 @@ func (f *FeishuApp) replyLifecycle(ctx context.Context, e Event) error {
 	}
 
 	contentJSON, _ := json.Marshal(map[string]string{"text": text})
-	body, _ := json.Marshal(map[string]string{
-		"msg_type": "text",
-		"content":  string(contentJSON),
+	// `reply_in_thread: true` confines the reply to the card's thread —
+	// it does NOT bubble up into the main chat-list as a fresh message.
+	// Without this flag Feishu treats `/reply` as a "quote-reply" that
+	// also lands in the main timeline, which defeats the whole
+	// silent-card design (the chat list still gets one new bullet per
+	// lifecycle event). Threaded replies still fire the normal
+	// per-device notification, so operators get pinged exactly once
+	// per phase boundary without screen real-estate cost.
+	body, _ := json.Marshal(map[string]any{
+		"msg_type":        "text",
+		"content":         string(contentJSON),
+		"reply_in_thread": true,
 	})
 	url := fmt.Sprintf("/open-apis/im/v1/messages/%s/reply", f.messageID)
 	var resp struct {

--- a/eval/internal/notify/feishu_app.go
+++ b/eval/internal/notify/feishu_app.go
@@ -34,6 +34,21 @@ import (
 //   - POST /open-apis/cardkit/v1/cards
 //   - POST /open-apis/im/v1/messages?receive_id_type=chat_id
 //   - PATCH /open-apis/cardkit/v1/cards/{card_id}/elements/{element_id}
+//   - POST /open-apis/im/v1/messages/{message_id}/reply
+//
+// Notification model:
+//
+//   - The initial `interactive` card send triggers a normal chat
+//     notification (mobile + desktop), so operators see the run begin.
+//   - Every subsequent CardKit PATCH updates the body silently — Feishu
+//     does NOT notify on card edits and there is no "edited" badge. This
+//     is by design: a 100-milestone run does not spam the chat.
+//   - For lifecycle kinds {ingest_done, done, error} we additionally
+//     post a one-line TEXT reply threaded to the card. Replies DO fire
+//     normal notifications, so the operator gets pinged exactly at the
+//     handful of moments they actually need to look (phase boundaries,
+//     final scores, failures) while progress milestones remain silent
+//     edits on the same card.
 type FeishuApp struct {
 	AppID     string
 	AppSecret string
@@ -46,6 +61,7 @@ type FeishuApp struct {
 
 	mu          sync.Mutex
 	cardID      string
+	messageID   string // chat message that hosts the card; reply target for lifecycle pings
 	events      []renderedEvent
 	token       string
 	tokenExpiry time.Time
@@ -83,9 +99,41 @@ func (f *FeishuApp) Notify(ctx context.Context, e Event) error {
 	}
 
 	if f.cardID == "" {
+		// First event always creates the card. The interactive message
+		// send fires its own chat notification, so we don't double-ping
+		// with a thread reply on `start`.
 		return f.createAndSendCard(ctx)
 	}
-	return f.updateLogElement(ctx)
+	if err := f.updateLogElement(ctx); err != nil {
+		return err
+	}
+	// Silent patches above keep progress noise off the chat list.
+	// Lifecycle events get a thread reply so the operator's device
+	// actually buzzes when the phase boundary lands.
+	if isLifecycleNotify(e.Kind) && f.messageID != "" {
+		if err := f.replyLifecycle(ctx, e); err != nil {
+			return fmt.Errorf("feishu reply: %w", err)
+		}
+	}
+	return nil
+}
+
+// isLifecycleNotify returns true for the small set of event kinds we
+// surface as threaded chat replies (in addition to the silent card
+// patch). The list is hard-coded — every suite that adds a new lifecycle
+// kind makes a conscious decision whether it warrants a phone-buzz, and
+// progress milestones intentionally stay silent.
+//
+// Excluded: "start" (the card's own creation notification covers it),
+// every *_progress kind (transient, would defeat the whole point of
+// CardKit consolidation), and the heartbeat-style events some suites
+// may add later.
+func isLifecycleNotify(kind string) bool {
+	switch kind {
+	case "ingest_done", "done", "error":
+		return true
+	}
+	return false
 }
 
 func (f *FeishuApp) now() time.Time {
@@ -184,6 +232,9 @@ func (f *FeishuApp) createAndSendCard(ctx context.Context) error {
 	var sendResp struct {
 		Code int    `json:"code"`
 		Msg  string `json:"msg"`
+		Data struct {
+			MessageID string `json:"message_id"`
+		} `json:"data"`
 	}
 	if err := f.doJSON(ctx, "POST", "/open-apis/im/v1/messages?receive_id_type=chat_id", sendBody, f.token, &sendResp); err != nil {
 		return fmt.Errorf("feishu send card: %w", err)
@@ -193,6 +244,66 @@ func (f *FeishuApp) createAndSendCard(ctx context.Context) error {
 	}
 
 	f.cardID = cardID
+	// message_id is the parent for lifecycle replies; we tolerate an
+	// empty value (older Feishu API shapes) and just degrade to silent
+	// patches in that case rather than failing the whole run.
+	f.messageID = sendResp.Data.MessageID
+	return nil
+}
+
+// replyLifecycle posts a one-line TEXT reply threaded to the card
+// message. Unlike CardKit PATCHes (silent edits), replies trigger the
+// normal Feishu chat notification path, so operators get pinged on
+// phase boundaries / final scores / failures without subscribing to
+// every milestone.
+//
+// Endpoint: `POST /open-apis/im/v1/messages/{message_id}/reply`
+//
+// Body fields:
+//
+//   - msg_type:  "text" — keeps the reply lightweight; nested cards
+//     would re-render unnecessary chrome under the parent
+//   - content:   JSON string with a single "text" field, capped at
+//     ~300 chars so a long error body doesn't blow past
+//     Feishu's per-message limit
+func (f *FeishuApp) replyLifecycle(ctx context.Context, e Event) error {
+	icon := iconFor(e.Kind)
+	text := strings.TrimSpace(fmt.Sprintf("%s [%s] %s", icon, e.Kind, firstLine(e.Title)))
+	// Compact body summary onto a second line when present so the
+	// notification preview surfaces the headline number (qa.judge, p95,
+	// error message). Trim aggressively — the full body lives on the
+	// card; replies are just notification bait.
+	if e.Body != "" {
+		body := firstLine(e.Body)
+		if len(text)+len(body)+1 > 300 {
+			cut := 300 - len(text) - 4
+			if cut < 0 {
+				cut = 0
+			}
+			body = body[:cut] + "…"
+		}
+		text = text + "\n" + body
+	}
+	if len(text) > 300 {
+		text = text[:297] + "…"
+	}
+
+	contentJSON, _ := json.Marshal(map[string]string{"text": text})
+	body, _ := json.Marshal(map[string]string{
+		"msg_type": "text",
+		"content":  string(contentJSON),
+	})
+	url := fmt.Sprintf("/open-apis/im/v1/messages/%s/reply", f.messageID)
+	var resp struct {
+		Code int    `json:"code"`
+		Msg  string `json:"msg"`
+	}
+	if err := f.doJSON(ctx, "POST", url, body, f.token, &resp); err != nil {
+		return err
+	}
+	if resp.Code != 0 {
+		return fmt.Errorf("code=%d msg=%q", resp.Code, resp.Msg)
+	}
 	return nil
 }
 

--- a/eval/internal/notify/feishu_app_test.go
+++ b/eval/internal/notify/feishu_app_test.go
@@ -287,9 +287,15 @@ func TestFeishuApp_LifecycleReply(t *testing.T) {
 	if !strings.HasPrefix(mock.lastReplyPath, "/open-apis/im/v1/messages/om_fake/reply") {
 		t.Errorf("reply path must embed parent message_id; got %s", mock.lastReplyPath)
 	}
-	// Reply payload is {msg_type: text, content: JSON-string-with-text}
+	// Reply payload is {msg_type: text, content: JSON-string-with-text,
+	// reply_in_thread: true}. The thread flag is the difference between
+	// "tidy thread under the card" and "flooding the main chat list" —
+	// see the doc on replyLifecycle for the rationale.
 	if got := mock.lastReplyBody["msg_type"]; got != "text" {
 		t.Errorf("reply msg_type: got %v want text", got)
+	}
+	if got := mock.lastReplyBody["reply_in_thread"]; got != true {
+		t.Errorf("reply MUST set reply_in_thread=true so the reply stays inside the card's thread; got %v", got)
 	}
 	contentRaw, _ := mock.lastReplyBody["content"].(string)
 	var content map[string]string

--- a/eval/internal/notify/feishu_app_test.go
+++ b/eval/internal/notify/feishu_app_test.go
@@ -21,10 +21,13 @@ type fakeFeishu struct {
 	createCalls    int
 	sendCalls      int
 	patchCalls     int
+	replyCalls     int
 	lastCreateBody map[string]any
 	lastSendBody   map[string]any
 	lastPatchBody  map[string]any
 	lastPatchPath  string
+	lastReplyBody  map[string]any
+	lastReplyPath  string
 	cardID         string
 }
 
@@ -46,6 +49,12 @@ func (s *fakeFeishu) handler(t *testing.T) http.HandlerFunc {
 			s.lastCreateBody = parsed
 			s.cardID = "AAqcardfake"
 			_, _ = w.Write([]byte(`{"code":0,"msg":"ok","data":{"card_id":"AAqcardfake"}}`))
+
+		case strings.HasPrefix(r.URL.Path, "/open-apis/im/v1/messages/") && strings.HasSuffix(r.URL.Path, "/reply"):
+			s.replyCalls++
+			s.lastReplyBody = parsed
+			s.lastReplyPath = r.URL.Path
+			_, _ = w.Write([]byte(`{"code":0,"msg":"ok"}`))
 
 		case strings.HasPrefix(r.URL.Path, "/open-apis/im/v1/messages"):
 			s.sendCalls++
@@ -229,6 +238,89 @@ func TestFeishuApp_ProgressEventsFilteredFromHistory(t *testing.T) {
 		if strings.Contains(final, title) {
 			t.Errorf("%s title %q must be dropped from History once superseded; body=%s", k, title, final)
 		}
+	}
+}
+
+// TestFeishuApp_LifecycleReply verifies that lifecycle events
+// (ingest_done / done / error) additionally post a threaded text reply
+// to the parent card message, while progress and start events do not.
+// The reply path embeds the message_id captured from the initial card
+// send, so this also indirectly checks the message_id wire-up.
+func TestFeishuApp_LifecycleReply(t *testing.T) {
+	mock := &fakeFeishu{}
+	srv := httptest.NewServer(mock.handler(t))
+	defer srv.Close()
+
+	app := &FeishuApp{
+		AppID: "cli", AppSecret: "s", ChatID: "oc",
+		Name: "lme-s", Base: srv.URL,
+	}
+	ctx := context.Background()
+
+	// 1. start: creates card, sends to chat — no reply expected.
+	if err := app.Notify(ctx, Event{Kind: "start", Title: "begin"}); err != nil {
+		t.Fatalf("start: %v", err)
+	}
+	if mock.replyCalls != 0 {
+		t.Errorf("start must NOT trigger reply; got %d reply calls", mock.replyCalls)
+	}
+
+	// 2. ingest_progress (any *_progress): silent patch only.
+	if err := app.Notify(ctx, Event{Kind: "ingest_progress", Title: "ingest 5%"}); err != nil {
+		t.Fatalf("ingest_progress: %v", err)
+	}
+	if mock.replyCalls != 0 {
+		t.Errorf("ingest_progress must NOT trigger reply; got %d reply calls", mock.replyCalls)
+	}
+
+	// 3. ingest_done: lifecycle — reply expected.
+	if err := app.Notify(ctx, Event{
+		Kind:  "ingest_done",
+		Title: "ingest done in 2h48m (2436 Save calls)",
+		Body:  "save.p50=42s save.p95=2m18s",
+	}); err != nil {
+		t.Fatalf("ingest_done: %v", err)
+	}
+	if mock.replyCalls != 1 {
+		t.Fatalf("ingest_done must trigger 1 reply; got %d", mock.replyCalls)
+	}
+	if !strings.HasPrefix(mock.lastReplyPath, "/open-apis/im/v1/messages/om_fake/reply") {
+		t.Errorf("reply path must embed parent message_id; got %s", mock.lastReplyPath)
+	}
+	// Reply payload is {msg_type: text, content: JSON-string-with-text}
+	if got := mock.lastReplyBody["msg_type"]; got != "text" {
+		t.Errorf("reply msg_type: got %v want text", got)
+	}
+	contentRaw, _ := mock.lastReplyBody["content"].(string)
+	var content map[string]string
+	_ = json.Unmarshal([]byte(contentRaw), &content)
+	if !strings.Contains(content["text"], "ingest_done") || !strings.Contains(content["text"], "2436 Save calls") {
+		t.Errorf("reply text should surface kind + headline title; got %q", content["text"])
+	}
+	if !strings.Contains(content["text"], "save.p95=2m18s") {
+		t.Errorf("reply text should append first line of Body for the notification preview; got %q", content["text"])
+	}
+
+	// 4. done: lifecycle — second reply.
+	if err := app.Notify(ctx, Event{Kind: "done", Title: "eval done in 2h50m", Body: "qa.judge=0.960"}); err != nil {
+		t.Fatalf("done: %v", err)
+	}
+	if mock.replyCalls != 2 {
+		t.Errorf("done must trigger 1 additional reply; got total %d", mock.replyCalls)
+	}
+
+	// 5. error: lifecycle — third reply.
+	if err := app.Notify(ctx, Event{Kind: "error", Title: "extractor blew up"}); err != nil {
+		t.Fatalf("error: %v", err)
+	}
+	if mock.replyCalls != 3 {
+		t.Errorf("error must trigger 1 additional reply; got total %d", mock.replyCalls)
+	}
+
+	// Sanity: silent patches kept growing across every non-start event
+	// (start used inline content, no patch yet).
+	if mock.patchCalls != 4 {
+		t.Errorf("expected 4 patches (progress + ingest_done + done + error); got %d", mock.patchCalls)
 	}
 }
 


### PR DESCRIPTION
## Summary

- CardKit silent patches were perfect for `*_progress` (avoids chat
  flood) but also hid `ingest_done` / `done` / `error` — the moments
  operators actually need to be pinged for. After 3 h of "card not
  updating" head-scratching on the lme-s run, the verdict was that
  the patches landed fine; Feishu simply doesn't notify on card edits.
- Keep silent patches as-is; *additionally* fire a one-line threaded
  text reply on the lifecycle event set `{ingest_done, done, error}`.
  `start` is deliberately skipped (the interactive card send already
  notifies).
- Reply payload: `<icon> [<kind>] <Title>` + first line of `Body`,
  hard-capped at 300 chars so a long error body can't blow Feishu's
  per-message limit. Captured `message_id` from `/im/v1/messages`
  POST response so we can target `/messages/{id}/reply`.

## Test plan

- [x] `eval/internal/notify` unit tests pass (`go test ./internal/notify/...`)
- [x] New `TestFeishuApp_LifecycleReply` asserts: no reply on `start`
      or `*_progress`; one reply each on `ingest_done` / `done` /
      `error`; reply path embeds the captured message_id; payload
      surfaces kind + Title + first line of Body.
- [x] Existing tests still cover silent patches + History filtering.
- [ ] Live verification on the remote `lme-s-full` run after rebuild.


Made with [Cursor](https://cursor.com)