### PR TITLE
[skip-tag] feat(agent,graph): plumb engine.Run.Deps + Attributes; enforce Agent.Tools policy gate

### DIFF
--- a/sdk/agent/promote_tools_test.go
+++ b/sdk/agent/promote_tools_test.go
@@ -1,0 +1,129 @@
+package agent
+
+import (
+	"reflect"
+	"sort"
+	"testing"
+
+	"github.com/GizClaw/flowcraft/sdk/engine"
+	"github.com/GizClaw/flowcraft/sdk/engine/depname"
+)
+
+// TestPromoteAgentTools_NilCallerDepsAllocates documents the
+// "no caller-deps, agent has tools" path: Run must hand the engine
+// a Dependencies container even when the caller never registered
+// one — otherwise engines that look up depname.ToolAllowedNames
+// would never find the gate and Agent.Tools would silently leak
+// back into the audit's #1 contract gap.
+func TestPromoteAgentTools_NilCallerDepsAllocates(t *testing.T) {
+	got := promoteAgentTools(nil, []string{"search", "fetch"})
+	if got == nil {
+		t.Fatal("expected an allocated Dependencies, got nil")
+	}
+	v, err := engine.GetDep[[]string](got, depname.ToolAllowedNames)
+	if err != nil {
+		t.Fatalf("ToolAllowedNames missing: %v", err)
+	}
+	want := []string{"search", "fetch"}
+	if !reflect.DeepEqual(v, want) {
+		t.Errorf("ToolAllowedNames = %v, want %v", v, want)
+	}
+}
+
+// TestPromoteAgentTools_NoToolsIsNoop documents the back-compat
+// path: agents that do not opt into the policy gate (Tools nil or
+// empty) get the caller's deps back unchanged. Forward-compatible
+// for codebases that haven't started populating agent.Tools yet.
+func TestPromoteAgentTools_NoToolsIsNoop(t *testing.T) {
+	deps := engine.NewDependencies()
+	deps.Set("user-key", "preserved")
+
+	if got := promoteAgentTools(deps, nil); got != deps {
+		t.Errorf("nil Tools should return caller deps verbatim, got fresh container")
+	}
+	if got := promoteAgentTools(deps, []string{}); got != deps {
+		t.Errorf("empty Tools should return caller deps verbatim, got fresh container")
+	}
+
+	if got := promoteAgentTools(nil, nil); got != nil {
+		t.Errorf("nil + nil should stay nil; got %v", got)
+	}
+}
+
+// TestPromoteAgentTools_CallerSuppliedWins is the symmetric rule
+// to mergeAttributes' "caller wins" policy: a power user that has
+// already set depname.ToolAllowedNames on their Dependencies (e.g.
+// to override the agent's claim for a single call) should NOT have
+// the agent.Tools value overwrite it.
+func TestPromoteAgentTools_CallerSuppliedWins(t *testing.T) {
+	deps := engine.NewDependencies()
+	deps.Set(depname.ToolAllowedNames, []string{"caller-override"})
+
+	got := promoteAgentTools(deps, []string{"agent-tools"})
+	if got != deps {
+		t.Fatalf("caller-supplied container should be returned unchanged, got fresh container")
+	}
+	v, err := engine.GetDep[[]string](deps, depname.ToolAllowedNames)
+	if err != nil {
+		t.Fatalf("post-call lookup: %v", err)
+	}
+	if !reflect.DeepEqual(v, []string{"caller-override"}) {
+		t.Errorf("caller value mutated: got %v want [caller-override]", v)
+	}
+}
+
+// TestPromoteAgentTools_ClonesToAvoidPollution is the most
+// important regression: the same Dependencies container reused
+// across runs of different agents must not accumulate one agent's
+// allow-list and surface it to another.
+func TestPromoteAgentTools_ClonesToAvoidPollution(t *testing.T) {
+	shared := engine.NewDependencies()
+	shared.Set("user-key", "preserved")
+
+	depsA := promoteAgentTools(shared, []string{"agent_a_tool"})
+	depsB := promoteAgentTools(shared, []string{"agent_b_tool"})
+
+	if depsA == shared || depsB == shared {
+		t.Fatal("promoteAgentTools must clone, not mutate the caller's container")
+	}
+	if shared.Has(depname.ToolAllowedNames) {
+		t.Error("shared (caller) container must NOT carry the promoted key")
+	}
+
+	a, _ := engine.GetDep[[]string](depsA, depname.ToolAllowedNames)
+	b, _ := engine.GetDep[[]string](depsB, depname.ToolAllowedNames)
+	if !reflect.DeepEqual(a, []string{"agent_a_tool"}) {
+		t.Errorf("depsA leaked: got %v", a)
+	}
+	if !reflect.DeepEqual(b, []string{"agent_b_tool"}) {
+		t.Errorf("depsB leaked: got %v", b)
+	}
+
+	// Pre-existing keys are preserved on the clones.
+	for _, d := range []*engine.Dependencies{depsA, depsB} {
+		v, _ := d.Get("user-key")
+		if v != "preserved" {
+			t.Errorf("pre-existing user key dropped from clone: got %v", v)
+		}
+	}
+}
+
+// TestPromoteAgentTools_DefensiveSliceCopy asserts the helper
+// detaches from the caller's []string so mutating ag.Tools after
+// Run returns (next call to applyOptions, etc.) cannot retroactively
+// alter the gate the engine already saw.
+func TestPromoteAgentTools_DefensiveSliceCopy(t *testing.T) {
+	original := []string{"search", "fetch"}
+	deps := promoteAgentTools(nil, original)
+
+	// Caller mutates the slice the agent owns.
+	original[0] = "tampered"
+
+	got, _ := engine.GetDep[[]string](deps, depname.ToolAllowedNames)
+	want := []string{"search", "fetch"}
+	sort.Strings(got)
+	sort.Strings(want)
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("snapshot drift: got %v want %v (helper must defensively copy ag.Tools)", got, want)
+	}
+}

--- a/sdk/agent/run.go
+++ b/sdk/agent/run.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/GizClaw/flowcraft/sdk/engine"
+	"github.com/GizClaw/flowcraft/sdk/engine/depname"
 	"github.com/GizClaw/flowcraft/sdk/errdefs"
 	"github.com/GizClaw/flowcraft/sdk/model"
 )
@@ -109,6 +110,13 @@ func Run(
 	}
 
 	attrs := mergeAttributes(rc.attributes, req, ag, runID)
+	// Promote agent.Agent.Tools into engine.Run.Deps under
+	// depname.ToolAllowedNames so engines that honour the
+	// allow-list (graph runner llmnode today; vessel inline engine
+	// after Epic D) finally see the policy gate. Caller-supplied
+	// rc.deps[ToolAllowedNames] wins so tests / power users can
+	// override the agent-level claim per call.
+	runDeps := promoteAgentTools(rc.deps, ag.Tools)
 	obs := composeObservers(rc.observers)
 
 	// Revise loop: each iteration is one engine.Execute attempt
@@ -156,7 +164,7 @@ func Run(
 		engRun := engine.Run{
 			ID:         runID,
 			Attributes: attemptAttrs,
-			Deps:       rc.deps,
+			Deps:       runDeps,
 		}
 		if attempt == 1 {
 			engRun.ResumeFrom = rc.resumeFrom
@@ -322,6 +330,49 @@ func mintRunID() string {
 		return fmt.Sprintf("run-%d", time.Now().UnixNano())
 	}
 	return "run-" + hex.EncodeToString(b)
+}
+
+// promoteAgentTools is the agent-level policy gate hand-off. When
+// agent.Agent.Tools is set and the caller's Dependencies container
+// does NOT already define [depname.ToolAllowedNames], the helper
+// returns a CLONE of the caller's container with the agent's tool
+// list set under that key. Engines that honour the allow-list
+// (graph runner llmnode; vessel inline engine after Epic D) then
+// see it via engine.GetDep at run time.
+//
+// Cloning preserves Run's "callers' container is immutable from
+// our perspective" rule — a caller that reuses one Dependencies
+// across many runs (different agents) won't see this run's tool
+// list bleed into the next.
+//
+// Caller-supplied wins: if the caller already set
+// depname.ToolAllowedNames on the container (e.g. tests, or a
+// power user overriding the agent claim), the helper returns the
+// container unchanged and the agent's Tools field is silently
+// shadowed for this call. This matches the "caller-supplied wins"
+// rule mergeAttributes uses for the attribute bag.
+//
+// When agent.Tools is nil/empty the helper is a no-op; agents that
+// do not opt into the policy gate keep getting the caller's deps
+// verbatim (back-compat for code that hasn't yet started populating
+// agent.Tools).
+func promoteAgentTools(callerDeps *engine.Dependencies, agentTools []string) *engine.Dependencies {
+	if len(agentTools) == 0 {
+		return callerDeps
+	}
+	if callerDeps != nil && callerDeps.Has(depname.ToolAllowedNames) {
+		return callerDeps
+	}
+	cloned := callerDeps.Clone()
+	if cloned == nil {
+		cloned = engine.NewDependencies()
+	}
+	// Defensive copy of agentTools — agent owns ag.Tools and may
+	// mutate it after Run returns; the engine should see a stable
+	// snapshot for the duration of this call.
+	tools := append([]string(nil), agentTools...)
+	cloned.Set(depname.ToolAllowedNames, tools)
+	return cloned
 }
 
 // mergeAttributes combines RunOption-supplied attributes with the

--- a/sdk/agent/run.go
+++ b/sdk/agent/run.go
@@ -327,15 +327,19 @@ func mintRunID() string {
 // mergeAttributes combines RunOption-supplied attributes with the
 // well-known agent / task / context ids. Keys explicitly set by the
 // caller win — agent never overwrites.
+//
+// Key names live in runinfo_attrs.go and stay private to this
+// package; downstream readers go through [RunInfoFromAttributes] so
+// the wire format can be migrated without sweeping the codebase.
 func mergeAttributes(extra map[string]string, req Request, ag Agent, runID string) map[string]string {
 	out := make(map[string]string, len(extra)+4)
-	out["agent_id"] = ag.ID
-	out["run_id"] = runID
+	out[attrAgentID] = ag.ID
+	out[attrRunID] = runID
 	if req.TaskID != "" {
-		out["task_id"] = req.TaskID
+		out[attrTaskID] = req.TaskID
 	}
 	if req.ContextID != "" {
-		out["context_id"] = req.ContextID
+		out[attrContextID] = req.ContextID
 	}
 	for k, v := range extra {
 		out[k] = v

--- a/sdk/agent/run_test.go
+++ b/sdk/agent/run_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/GizClaw/flowcraft/sdk/agent"
 	"github.com/GizClaw/flowcraft/sdk/engine"
+	"github.com/GizClaw/flowcraft/sdk/engine/depname"
 	"github.com/GizClaw/flowcraft/sdk/errdefs"
 	"github.com/GizClaw/flowcraft/sdk/model"
 )
@@ -1040,5 +1041,72 @@ func TestRun_Revise_NotTriggeredOnNonCompleted(t *testing.T) {
 	}
 	if res.Attempts != 1 {
 		t.Errorf("Attempts = %d, want 1", res.Attempts)
+	}
+}
+
+// TestRun_PromotesAgentToolsIntoEngineRunDeps is the end-to-end
+// regression for contract-audit #1 ("Agent.Tools is silently
+// ignored"). After the run-context plumbing is wired (commits
+// 1–3 on this branch), agent.Run MUST surface ag.Tools to the
+// engine via engine.Run.Deps[depname.ToolAllowedNames] so the
+// llmnode policy gate can act on it.
+func TestRun_PromotesAgentToolsIntoEngineRunDeps(t *testing.T) {
+	var observed *engine.Dependencies
+	eng := engine.EngineFunc(func(_ context.Context, run engine.Run, _ engine.Host, b *engine.Board) (*engine.Board, error) {
+		observed = run.Deps
+		b.AppendChannelMessage(engine.MainChannel,
+			model.NewTextMessage(model.RoleAssistant, "ok"))
+		return b, nil
+	})
+
+	ag := agent.Agent{ID: "researcher", Tools: []string{"search", "fetch"}}
+	if _, err := agent.Run(context.Background(), ag, eng, newReq("hi")); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	if observed == nil {
+		t.Fatal("engine.Run.Deps was nil — Agent.Tools was not promoted")
+	}
+	got, gerr := engine.GetDep[[]string](observed, depname.ToolAllowedNames)
+	if gerr != nil {
+		t.Fatalf("ToolAllowedNames missing in engine.Run.Deps: %v", gerr)
+	}
+	want := []string{"search", "fetch"}
+	if len(got) != len(want) {
+		t.Fatalf("ToolAllowedNames len = %d, want %d (got %v)", len(got), len(want), got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("ToolAllowedNames[%d] = %q, want %q", i, got[i], want[i])
+		}
+	}
+}
+
+// TestRun_AgentToolsDoesNotOverwriteCallerSuppliedToolAllowedNames
+// asserts the same "caller-supplied wins" rule that mergeAttributes
+// uses for the attribute bag: a power user that overrode the
+// allow-list via WithDependencies must see their value reach the
+// engine, not the agent's claim.
+func TestRun_AgentToolsDoesNotOverwriteCallerSuppliedToolAllowedNames(t *testing.T) {
+	var observed *engine.Dependencies
+	eng := engine.EngineFunc(func(_ context.Context, run engine.Run, _ engine.Host, b *engine.Board) (*engine.Board, error) {
+		observed = run.Deps
+		b.AppendChannelMessage(engine.MainChannel,
+			model.NewTextMessage(model.RoleAssistant, "ok"))
+		return b, nil
+	})
+
+	deps := engine.NewDependencies()
+	deps.Set(depname.ToolAllowedNames, []string{"caller-pin"})
+
+	ag := agent.Agent{ID: "researcher", Tools: []string{"agent-claim"}}
+	if _, err := agent.Run(context.Background(), ag, eng, newReq("hi"),
+		agent.WithDependencies(deps)); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	got, _ := engine.GetDep[[]string](observed, depname.ToolAllowedNames)
+	if len(got) != 1 || got[0] != "caller-pin" {
+		t.Errorf("ToolAllowedNames = %v, want [caller-pin] (caller-supplied must win)", got)
 	}
 }

--- a/sdk/agent/runinfo_attrs.go
+++ b/sdk/agent/runinfo_attrs.go
@@ -1,0 +1,59 @@
+package agent
+
+// runinfo_attrs.go owns the contract between [Run] (which promotes
+// per-call identity into [engine.Run.Attributes]) and downstream
+// readers that need to reconstruct a [RunInfo] from those attributes.
+//
+// The string keys are deliberately kept private to the agent package:
+// callers never type the key strings themselves; they go through
+// [RunInfoFromAttributes] (read side) or rely on Run's promotion (write
+// side). That way migrating the wire format (e.g. switching to
+// telemetry.Attr* canonical dot-keys) is a one-edit change here, not a
+// codebase-wide grep-and-replace.
+const (
+	// attrAgentID — agent.Agent.ID promoted by Run into engine.Run.Attributes.
+	attrAgentID = "agent_id"
+
+	// attrRunID — the engine.Run.ID promoted by Run. Engines that key
+	// telemetry off engine.Run.ID directly do NOT need to read this;
+	// it exists so a node looking at engine.Run.Attributes alone can
+	// recover the full RunInfo without consulting engine.Run.
+	attrRunID = "run_id"
+
+	// attrTaskID / attrContextID — Request.TaskID / Request.ContextID
+	// (A2A-aligned identifiers) promoted by Run when non-empty.
+	attrTaskID    = "task_id"
+	attrContextID = "context_id"
+)
+
+// RunInfoFromAttributes reconstructs a [RunInfo] from the
+// engine.Run.Attributes map [Run] populates on every attempt. runID
+// is taken from the caller-supplied argument (typically
+// engine.Run.ID, the canonical source) rather than the attribute
+// copy, since some downstream contexts (e.g. graph.ExecutionContext)
+// expose RunID as a dedicated field separate from the attributes
+// bag.
+//
+// Missing keys yield empty strings — RunInfoFromAttributes never
+// errors. This matches Run's "promote when non-empty" write policy:
+// a missing key just means the upstream Request did not carry that
+// identifier, not that something went wrong.
+//
+// Typical caller (a graph node bridging RunInfo into a script
+// runtime):
+//
+//	info := agent.RunInfoFromAttributes(ec.RunID, ec.Attributes)
+//	bindings.NewRunInfoBridge(info)
+//
+// This closes contract-audit #12: nodes used to construct
+// RunInfo{RunID: ec.RunID} verbatim, leaving AgentID / TaskID /
+// ContextID empty even though Run had written them upstream into
+// engine.Run.Attributes.
+func RunInfoFromAttributes(runID string, attrs map[string]string) RunInfo {
+	return RunInfo{
+		AgentID:   attrs[attrAgentID],
+		RunID:     runID,
+		TaskID:    attrs[attrTaskID],
+		ContextID: attrs[attrContextID],
+	}
+}

--- a/sdk/agent/runinfo_attrs_test.go
+++ b/sdk/agent/runinfo_attrs_test.go
@@ -1,0 +1,70 @@
+package agent
+
+import (
+	"testing"
+)
+
+// TestRunInfoFromAttributes_RoundTrip asserts the
+// mergeAttributes write side and RunInfoFromAttributes read side
+// agree on the wire format. If anyone changes one half without the
+// other, this test turns red — closing the historical "scriptnode
+// reads ec.RunID and silently loses the other three identity
+// fields" gap (contract-audit #12) at the contract level rather
+// than the call-site level.
+func TestRunInfoFromAttributes_RoundTrip(t *testing.T) {
+	const (
+		agentID   = "researcher"
+		runID     = "run-77"
+		taskID    = "task-42"
+		contextID = "ctx-9"
+	)
+	attrs := mergeAttributes(nil,
+		Request{TaskID: taskID, ContextID: contextID},
+		Agent{ID: agentID}, runID)
+
+	got := RunInfoFromAttributes(runID, attrs)
+
+	want := RunInfo{
+		AgentID:   agentID,
+		RunID:     runID,
+		TaskID:    taskID,
+		ContextID: contextID,
+	}
+	if got != want {
+		t.Fatalf("round-trip mismatch:\n  got  %+v\n  want %+v", got, want)
+	}
+}
+
+// TestRunInfoFromAttributes_MissingKeys documents that absent
+// keys yield empty strings rather than errors — matching Run's
+// "promote when non-empty" write policy.
+func TestRunInfoFromAttributes_MissingKeys(t *testing.T) {
+	got := RunInfoFromAttributes("run-1", nil)
+	if got.RunID != "run-1" {
+		t.Errorf("RunID: got %q want %q", got.RunID, "run-1")
+	}
+	if got.AgentID != "" || got.TaskID != "" || got.ContextID != "" {
+		t.Errorf("missing keys should yield empty strings, got %+v", got)
+	}
+
+	got = RunInfoFromAttributes("run-2", map[string]string{"unrelated": "x"})
+	if got.AgentID != "" {
+		t.Errorf("unrelated key should not bleed into AgentID: got %+v", got)
+	}
+}
+
+// TestRunInfoFromAttributes_RunIDArgWinsOverAttribute asserts the
+// caller-supplied runID overrides any attribute copy. ExecutionContext
+// exposes RunID as a dedicated field separate from Attributes; the
+// helper trusts the dedicated field so a stale Attributes copy
+// (e.g. cloned across attempts) cannot poison observers.
+func TestRunInfoFromAttributes_RunIDArgWinsOverAttribute(t *testing.T) {
+	attrs := map[string]string{
+		attrAgentID: "a",
+		attrRunID:   "stale-run-id",
+	}
+	got := RunInfoFromAttributes("authoritative-run-id", attrs)
+	if got.RunID != "authoritative-run-id" {
+		t.Fatalf("RunID arg should win over attribute copy: got %q", got.RunID)
+	}
+}

--- a/sdk/engine/deps.go
+++ b/sdk/engine/deps.go
@@ -68,6 +68,33 @@ func (d *Dependencies) Has(key any) bool {
 	return ok
 }
 
+// Clone returns a new Dependencies with a shallow copy of d's items.
+// Stored values are NOT deep-copied — callers that mutate a stored
+// value via the clone WILL also mutate the original (this matches
+// the standard "container clone" semantics: shape is independent,
+// payload is shared).
+//
+// Cloning is the canonical way for callers that own a base
+// Dependencies (e.g. an agent.Agent's per-run wiring) to derive a
+// per-call container with extra entries (e.g. agent.Run promoting
+// agent.Agent.Tools into [depname.ToolAllowedNames]) without
+// poisoning the caller's container.
+//
+// Cloning a nil receiver returns nil so callers can chain Clone
+// without a guard. The returned container is independently lockable.
+func (d *Dependencies) Clone() *Dependencies {
+	if d == nil {
+		return nil
+	}
+	d.mu.RLock()
+	defer d.mu.RUnlock()
+	cloned := &Dependencies{items: make(map[any]any, len(d.items))}
+	for k, v := range d.items {
+		cloned.items[k] = v
+	}
+	return cloned
+}
+
 // GetDep is a generic helper that retrieves a typed dependency. It
 // returns an error when the key is missing or when the stored value is
 // not assignable to T, so callers can surface configuration mistakes

--- a/sdk/graph/core.go
+++ b/sdk/graph/core.go
@@ -77,11 +77,29 @@ type PortDeclarable interface {
 // Publisher is a thin wrapper around Host.Publish kept for backwards
 // compatibility and ergonomic event emission with (type, payload) pairs;
 // new code MAY call Host.Publish directly with a fully formed envelope.
+//
+// Deps is the typed dependency container the upstream agent.Run handed
+// to the engine via [engine.Run.Deps]. The graph runner propagates it
+// verbatim so nodes can recover host-supplied dependencies (LLM clients,
+// tool registries, retrievers, …) via [engine.GetDep] instead of
+// closure-binding them at builder time. May be nil when the engine was
+// invoked directly without [engine.Run.Deps]; nodes that need a dep MUST
+// handle the nil case (engine.GetDep does).
+//
+// Attributes is the read-only string-keyed bag that the upstream
+// agent.Run promoted from [agent.Request] / [agent.RunInfo]. Canonical
+// keys live under [github.com/GizClaw/flowcraft/sdk/telemetry] (e.g.
+// AttrAgentID / AttrTaskID / AttrContextID) so nodes that need
+// agent-scoped identity (scriptnode RunInfoBridge, telemetry hooks,
+// envelope actor_id) can read them without inventing a parallel
+// transport. May be nil when the engine was invoked without attributes.
 type ExecutionContext struct {
-	Context   context.Context
-	Host      engine.Host
-	Publisher StreamPublisher
-	RunID     string
+	Context    context.Context
+	Host       engine.Host
+	Publisher  StreamPublisher
+	RunID      string
+	Deps       *engine.Dependencies
+	Attributes map[string]string
 }
 
 // ---------------------------------------------------------------------------

--- a/sdk/graph/node/llmnode/llmnode.go
+++ b/sdk/graph/node/llmnode/llmnode.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 
 	"github.com/GizClaw/flowcraft/sdk/engine"
+	"github.com/GizClaw/flowcraft/sdk/engine/depname"
 	"github.com/GizClaw/flowcraft/sdk/errdefs"
 	"github.com/GizClaw/flowcraft/sdk/graph"
 	"github.com/GizClaw/flowcraft/sdk/llm"
@@ -49,17 +50,94 @@ type Config struct {
 // Node is a Go-native graph node that calls an LLM, dispatches tool calls,
 // and manages message history on the board.
 type Node struct {
-	id           string
-	resolver     llm.LLMResolver
+	id       string
+	resolver llm.LLMResolver
+
+	// toolRegistry is the legacy "builder closure" tool registry,
+	// retained as a fallback only. The runtime now prefers the
+	// engine.Run-scoped *tool.Registry exposed via
+	// graph.ExecutionContext.Deps[depname.ToolRegistry] (populated
+	// by agent.Run from agent.WithDependencies). Closure-binding
+	// here remains supported for callers that construct llmnode
+	// without an upstream agent.Run wiring deps (vessel inline
+	// engine, hand-built test graphs).
 	toolRegistry *tool.Registry
-	config       Config
-	rawConfig    map[string]any
-	isDeferred   func(string) bool
+
+	config     Config
+	rawConfig  map[string]any
+	isDeferred func(string) bool
 }
 
 // New creates a Node.
+//
+// toolReg is optional: pass nil when the surrounding engine.Run is
+// expected to supply the registry via [engine.Dependencies] under the
+// [depname.ToolRegistry] key. Pass a non-nil registry to keep the
+// legacy "builder closure" behaviour for callers driving the node
+// outside agent.Run (e.g. the vessel inline engine, unit tests).
+// At runtime the run-scoped registry wins when both are present.
 func New(id string, resolver llm.LLMResolver, toolReg *tool.Registry, config Config) *Node {
 	return &Node{id: id, resolver: resolver, toolRegistry: toolReg, config: config}
+}
+
+// resolveTools returns the tool registry and effective allow-list for
+// one round, applying contract-audit Epic A's policy:
+//
+//  1. Registry: graph.ExecutionContext.Deps[depname.ToolRegistry]
+//     wins when present and well-typed; falls back to the
+//     constructor-bound n.toolRegistry. This lets agent.Run swap a
+//     run-scoped registry in without touching the graph builder.
+//  2. Allow list: when ec.Deps carries [depname.ToolAllowedNames]
+//     it acts as the run-level CEILING. agent.Run populates that
+//     key from agent.Agent.Tools, so this is where the historically
+//     ignored policy gate finally takes effect.
+//     - ceiling absent → fall back to Config.ToolNames verbatim
+//     (preserves legacy behaviour for engines that don't wire
+//     deps).
+//     - ceiling present and empty → no tools permitted (fail
+//     closed).
+//     - ceiling present and non-empty → INTERSECT with
+//     Config.ToolNames so the node still controls which subset
+//     to expose to the LLM for this round.
+//
+// The returned slice is a fresh allocation; callers may pass it into
+// downstream Config copies without aliasing concerns.
+func (n *Node) resolveTools(ec graph.ExecutionContext) (*tool.Registry, []string) {
+	reg := n.toolRegistry
+	if r, err := engine.GetDep[*tool.Registry](ec.Deps, depname.ToolRegistry); err == nil && r != nil {
+		reg = r
+	}
+
+	requested := n.config.ToolNames
+	if ec.Deps == nil {
+		return reg, requested
+	}
+	ceiling, err := engine.GetDep[[]string](ec.Deps, depname.ToolAllowedNames)
+	if err != nil {
+		return reg, requested
+	}
+	return reg, intersectAllow(requested, ceiling)
+}
+
+// intersectAllow returns the names present in both requested and
+// ceiling. Either input being empty means "deny all" — empty
+// requested is the node opting out, empty ceiling is the run-level
+// gate closing everything.
+func intersectAllow(requested, ceiling []string) []string {
+	if len(requested) == 0 || len(ceiling) == 0 {
+		return nil
+	}
+	cset := make(map[string]struct{}, len(ceiling))
+	for _, name := range ceiling {
+		cset[name] = struct{}{}
+	}
+	out := make([]string, 0, len(requested))
+	for _, name := range requested {
+		if _, ok := cset[name]; ok {
+			out = append(out, name)
+		}
+	}
+	return out
 }
 
 func (n *Node) ID() string             { return n.id }
@@ -138,9 +216,17 @@ func (n *Node) ExecuteBoard(ctx graph.ExecutionContext, board *graph.Board) erro
 		board.SetVar(VarPrevMessageCount, len(messages))
 	}
 
+	// Resolve registry + allow-list at runtime so agent.Run-supplied
+	// dependencies (and Agent.Tools as the policy gate) actually
+	// reach the LLM call. cfg is a value-copied Config above; we
+	// overwrite ToolNames on the local copy without aliasing the
+	// node-level field.
+	reg, allowedNames := n.resolveTools(ctx)
+	cfg.ToolNames = allowedNames
+
 	result, err := runRound(
 		ctx.Context, ctx.Host, ctx.Publisher,
-		n.resolver, n.toolRegistry,
+		n.resolver, reg,
 		n.id, messages, cfg,
 	)
 	if err != nil {

--- a/sdk/graph/node/llmnode/resolve_test.go
+++ b/sdk/graph/node/llmnode/resolve_test.go
@@ -1,0 +1,135 @@
+package llmnode
+
+import (
+	"reflect"
+	"sort"
+	"testing"
+
+	"github.com/GizClaw/flowcraft/sdk/engine"
+	"github.com/GizClaw/flowcraft/sdk/engine/depname"
+	"github.com/GizClaw/flowcraft/sdk/graph"
+	"github.com/GizClaw/flowcraft/sdk/tool"
+)
+
+// TestNode_ResolveTools_RunDepsRegistryWinsOverConstructor closes
+// the agent.Run plumbing path: when the upstream wires a
+// *tool.Registry into engine.Run.Deps under depname.ToolRegistry,
+// llmnode MUST use it in preference to the constructor-bound
+// registry. Without this rule agent.Run could not swap the registry
+// per-run (the historical builder-closure bug — contract-audit #2
+// for tools).
+func TestNode_ResolveTools_RunDepsRegistryWinsOverConstructor(t *testing.T) {
+	ctorReg := tool.NewRegistry()
+	ctorReg.Register(&mockTool{name: "ctor_only"})
+	runReg := tool.NewRegistry()
+	runReg.Register(&mockTool{name: "run_only"})
+
+	deps := &engine.Dependencies{}
+	deps.Set(depname.ToolRegistry, runReg)
+
+	n := New("n1", nil, ctorReg, Config{ToolNames: []string{"run_only"}})
+	gotReg, gotAllow := n.resolveTools(graph.ExecutionContext{Deps: deps})
+
+	if gotReg != runReg {
+		t.Fatalf("registry: got %p want %p (run-scoped should win)", gotReg, runReg)
+	}
+	if !reflect.DeepEqual(gotAllow, []string{"run_only"}) {
+		t.Errorf("allow list: got %v want [run_only]", gotAllow)
+	}
+}
+
+// TestNode_ResolveTools_FallsBackToConstructorWhenNoDeps documents
+// the back-compat path: callers that build llmnode without any
+// agent.Run wiring (vessel inline engine, hand-built test graphs)
+// keep the legacy "registry comes from the constructor" behaviour.
+func TestNode_ResolveTools_FallsBackToConstructorWhenNoDeps(t *testing.T) {
+	ctorReg := tool.NewRegistry()
+	ctorReg.Register(&mockTool{name: "search"})
+
+	n := New("n1", nil, ctorReg, Config{ToolNames: []string{"search"}})
+	gotReg, gotAllow := n.resolveTools(graph.ExecutionContext{})
+
+	if gotReg != ctorReg {
+		t.Errorf("registry: expected constructor fallback, got %p want %p", gotReg, ctorReg)
+	}
+	if !reflect.DeepEqual(gotAllow, []string{"search"}) {
+		t.Errorf("allow list: got %v want [search]", gotAllow)
+	}
+}
+
+// TestNode_ResolveTools_AllowedNamesIntersection asserts the policy
+// gate: the run-level ceiling (agent.Agent.Tools, promoted by
+// agent.Run into depname.ToolAllowedNames) intersects with the
+// per-node Config.ToolNames. Tools the agent does not authorise
+// MUST NOT reach the LLM call even when the node config asks for
+// them.
+//
+// Closes contract-audit #1 ("Agent.Tools is silently ignored") at
+// the gate site: the helper is the only consumer of the allow-list
+// in the LLM round and the only place the gate can take effect.
+func TestNode_ResolveTools_AllowedNamesIntersection(t *testing.T) {
+	deps := &engine.Dependencies{}
+	deps.Set(depname.ToolAllowedNames, []string{"search", "fetch"})
+
+	n := New("n1", nil, tool.NewRegistry(), Config{
+		ToolNames: []string{"search", "delete_world", "fetch"},
+	})
+	_, gotAllow := n.resolveTools(graph.ExecutionContext{Deps: deps})
+
+	sort.Strings(gotAllow)
+	want := []string{"fetch", "search"}
+	if !reflect.DeepEqual(gotAllow, want) {
+		t.Errorf("intersection: got %v want %v (delete_world MUST be filtered out)", gotAllow, want)
+	}
+}
+
+// TestNode_ResolveTools_EmptyCeilingDeniesAll documents the
+// fail-closed semantics: an empty []string under ToolAllowedNames
+// is a deliberate "no tools permitted" signal (e.g. an agent the
+// operator restricted), distinct from "no key set" which falls
+// back to legacy behaviour.
+func TestNode_ResolveTools_EmptyCeilingDeniesAll(t *testing.T) {
+	deps := &engine.Dependencies{}
+	deps.Set(depname.ToolAllowedNames, []string{})
+
+	n := New("n1", nil, tool.NewRegistry(), Config{ToolNames: []string{"search"}})
+	_, gotAllow := n.resolveTools(graph.ExecutionContext{Deps: deps})
+
+	if len(gotAllow) != 0 {
+		t.Errorf("empty ceiling should deny all, got %v", gotAllow)
+	}
+}
+
+// TestNode_ResolveTools_AbsentCeilingFallsBackToConfig confirms the
+// legacy back-compat path. Engines that haven't been migrated to
+// declare ToolAllowedNames (vessel inline engine pre-Epic-D) MUST
+// keep working with the per-node ToolNames as the only filter.
+func TestNode_ResolveTools_AbsentCeilingFallsBackToConfig(t *testing.T) {
+	deps := &engine.Dependencies{}
+	// Deps container present but no ToolAllowedNames key set.
+
+	n := New("n1", nil, tool.NewRegistry(), Config{ToolNames: []string{"search", "fetch"}})
+	_, gotAllow := n.resolveTools(graph.ExecutionContext{Deps: deps})
+
+	want := []string{"search", "fetch"}
+	if !reflect.DeepEqual(gotAllow, want) {
+		t.Errorf("absent ceiling: got %v want %v (legacy fallback)", gotAllow, want)
+	}
+}
+
+// TestNode_ResolveTools_EmptyConfigToolNamesIsDenyAll is the
+// symmetric companion to EmptyCeilingDeniesAll: a node with no
+// ToolNames opts out of tools regardless of the run-level
+// ceiling. Prevents accidental tool exposure when a graph author
+// left ToolNames empty by mistake.
+func TestNode_ResolveTools_EmptyConfigToolNamesIsDenyAll(t *testing.T) {
+	deps := &engine.Dependencies{}
+	deps.Set(depname.ToolAllowedNames, []string{"search"})
+
+	n := New("n1", nil, tool.NewRegistry(), Config{ToolNames: nil})
+	_, gotAllow := n.resolveTools(graph.ExecutionContext{Deps: deps})
+
+	if len(gotAllow) != 0 {
+		t.Errorf("empty Config.ToolNames should deny all, got %v", gotAllow)
+	}
+}

--- a/sdk/graph/node/scriptnode/jsnode.go
+++ b/sdk/graph/node/scriptnode/jsnode.go
@@ -77,7 +77,14 @@ func (n *ScriptNode) ExecuteBoard(ctx graph.ExecutionContext, board *graph.Board
 		bindings.NewBoardBridge(board),
 		bindings.NewExprBridge(),
 		bindings.NewHostBridge(ctx.Host, n.id, ctx.Publisher),
-		bindings.NewRunInfoBridge(agent.RunInfo{RunID: ctx.RunID}),
+		// Reconstruct the full RunInfo from engine.Run.Attributes
+		// (promoted by agent.Run upstream) instead of the legacy
+		// RunInfo{RunID: ec.RunID} one-field bridge that left
+		// AgentID / TaskID / ContextID permanently empty —
+		// contract-audit #12. agent.RunInfoFromAttributes is the
+		// canonical reader so the key strings stay private to the
+		// agent package.
+		bindings.NewRunInfoBridge(agent.RunInfoFromAttributes(ctx.RunID, ctx.Attributes)),
 		newNodeBridge(n.id, n.nodeType),
 	}
 	allFns = append(allFns, n.extraBindFn...)

--- a/sdk/graph/node/scriptnode/jsnode_test.go
+++ b/sdk/graph/node/scriptnode/jsnode_test.go
@@ -113,3 +113,52 @@ func TestScriptNode_SignalInterrupt_CarriesCauseAndDetail(t *testing.T) {
 		t.Fatalf("Detail = %q, want %q", ie.Detail, "need approval")
 	}
 }
+
+// TestScriptNode_RunInfo_AllFieldsPropagate is the regression test
+// for contract-audit #12. Before this fix, the script bridge was
+// constructed with only RunID populated; agent_id() / task_id() /
+// context_id() always returned "" in scripts even when agent.Run
+// had written them upstream into engine.Run.Attributes.
+//
+// The fix wires ExecutionContext.Attributes (forwarded by the
+// runner from engine.Run.Attributes) into agent.RunInfoFromAttributes,
+// producing a fully populated RunInfo for the script binding.
+func TestScriptNode_RunInfo_AllFieldsPropagate(t *testing.T) {
+	rt := jsrt.New(jsrt.WithPoolSize(1))
+	src := `
+		board.setVar("agent_id", run.get_agent_id());
+		board.setVar("task_id", run.get_task_id());
+		board.setVar("context_id", run.get_context_id());
+		board.setVar("run_id", run.get_run_id());
+	`
+	n := New("rinfo", "template", src, nil, rt)
+
+	board := graph.NewBoard()
+	ctx := graph.ExecutionContext{
+		Context: context.Background(),
+		RunID:   "run-x",
+		Attributes: map[string]string{
+			"agent_id":   "researcher",
+			"task_id":    "task-7",
+			"context_id": "thread-3",
+			// run_id is intentionally absent: ExecutionContext.RunID
+			// is the dedicated source.
+		},
+	}
+	if err := n.ExecuteBoard(ctx, board); err != nil {
+		t.Fatalf("ExecuteBoard: %v", err)
+	}
+
+	checks := map[string]string{
+		"agent_id":   "researcher",
+		"task_id":    "task-7",
+		"context_id": "thread-3",
+		"run_id":     "run-x",
+	}
+	for k, want := range checks {
+		got, _ := board.GetVar(k)
+		if got != want {
+			t.Errorf("script-visible %s = %v, want %q", k, got, want)
+		}
+	}
+}

--- a/sdk/graph/runner/engine_test.go
+++ b/sdk/graph/runner/engine_test.go
@@ -121,6 +121,74 @@ func TestRunner_Execute_HostInjection(t *testing.T) {
 	}
 }
 
+// TestRunner_Execute_PropagatesRunDepsAndAttributes asserts that
+// engine.Run.Deps and engine.Run.Attributes flow from the runner
+// boundary all the way to ExecutionContext on the node side. This
+// closes contract-audit #2 ("engine.Run.Deps had zero readers") at
+// the Runner→executor seam: future regressions that drop the
+// propagation here would silently break every node that resolves
+// dependencies via engine.GetDep instead of builder closures.
+func TestRunner_Execute_PropagatesRunDepsAndAttributes(t *testing.T) {
+	type registryKey struct{}
+	deps := &engine.Dependencies{}
+	deps.Set(registryKey{}, "tool-registry-stub")
+	attrs := map[string]string{
+		"agent.id":   "researcher",
+		"task.id":    "task-9",
+		"context.id": "thread-3",
+	}
+
+	var (
+		gotDeps  *engine.Dependencies
+		gotAttrs map[string]string
+		gotVal   any
+		gotOK    bool
+	)
+	factory := node.NewFactory()
+	factory.RegisterBuilder("capture_runctx", func(def graph.NodeDefinition) (graph.Node, error) {
+		return testNodeFunc(def.ID, func(ctx graph.ExecutionContext, _ *graph.Board) error {
+			gotDeps = ctx.Deps
+			gotAttrs = ctx.Attributes
+			if ctx.Deps != nil {
+				gotVal, gotOK = ctx.Deps.Get(registryKey{})
+			}
+			return nil
+		}), nil
+	})
+
+	def := &graph.GraphDefinition{
+		Name:  "deps_attrs_propagation",
+		Entry: "cap",
+		Nodes: []graph.NodeDefinition{{ID: "cap", Type: "capture_runctx"}},
+		Edges: []graph.EdgeDefinition{{From: "cap", To: graph.END}},
+	}
+	r, err := runner.New(def, factory)
+	if err != nil {
+		t.Fatalf("runner.New: %v", err)
+	}
+
+	if _, err := r.Execute(context.Background(),
+		engine.Run{ID: "run-prop", Deps: deps, Attributes: attrs},
+		enginetest.NewMockHost(), engine.NewBoard()); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+
+	if gotDeps != deps {
+		t.Errorf("ExecutionContext.Deps: pointer differs from engine.Run.Deps; got %p want %p", gotDeps, deps)
+	}
+	if !gotOK || gotVal != "tool-registry-stub" {
+		t.Errorf("Deps payload missing through propagation: ok=%v val=%v", gotOK, gotVal)
+	}
+	if len(gotAttrs) != len(attrs) {
+		t.Fatalf("ExecutionContext.Attributes len = %d, want %d", len(gotAttrs), len(attrs))
+	}
+	for k, v := range attrs {
+		if gotAttrs[k] != v {
+			t.Errorf("Attributes[%q] = %q, want %q", k, gotAttrs[k], v)
+		}
+	}
+}
+
 // TestRunner_Execute_PublishesUnderRunID asserts that the run.ID
 // parameter (and only that — no executor.WithRunID needed) drives
 // the executor's lifecycle subjects. Confirms agent.Run's mintRunID

--- a/sdk/graph/runner/integration_test.go
+++ b/sdk/graph/runner/integration_test.go
@@ -13,18 +13,24 @@ package runner_test
 
 import (
 	"context"
+	"reflect"
+	"sort"
 	"strings"
 	"sync"
 	"testing"
 
 	"github.com/GizClaw/flowcraft/sdk/agent"
 	"github.com/GizClaw/flowcraft/sdk/engine"
+	"github.com/GizClaw/flowcraft/sdk/engine/depname"
 	"github.com/GizClaw/flowcraft/sdk/engine/enginetest"
 	"github.com/GizClaw/flowcraft/sdk/errdefs"
 	"github.com/GizClaw/flowcraft/sdk/graph"
 	"github.com/GizClaw/flowcraft/sdk/graph/node"
+	"github.com/GizClaw/flowcraft/sdk/graph/node/llmnode"
 	"github.com/GizClaw/flowcraft/sdk/graph/runner"
+	"github.com/GizClaw/flowcraft/sdk/llm"
 	"github.com/GizClaw/flowcraft/sdk/model"
+	"github.com/GizClaw/flowcraft/sdk/tool"
 )
 
 // echoNode appends an assistant reply to MainChannel quoting the last
@@ -485,4 +491,205 @@ func (o *reviseRecordingObserver) lastNextAttempt() int {
 		return -1
 	}
 	return o.events[len(o.events)-1].nextAttempt
+}
+
+// ============================================================================
+// Vertical E2E: Agent.Tools → agent.Run → graph runner → llmnode
+// ----------------------------------------------------------------------------
+// These tests wire the full chain landed in this PR (run-context-deps-plumbing):
+// agent.Agent.Tools is promoted into engine.Run.Deps[depname.ToolAllowedNames];
+// the graph runner forwards Deps into ExecutionContext.Deps; and llmnode
+// resolves its tool registry + allow-list from there. If ANY seam in that
+// chain regresses, these tests fail before any PR ships.
+
+// captureLLM records the GenerateOptions every llm.Generate{,Stream} call
+// receives so the test can extract the tool definitions the model was
+// offered. Because GenerateOption is an opaque func(*GenerateOptions),
+// extraction works by applying the recorded slice to a fresh
+// GenerateOptions and reading back .Tools.
+type captureLLM struct {
+	mu          sync.Mutex
+	lastOptions []llm.GenerateOption
+}
+
+func (c *captureLLM) record(opts []llm.GenerateOption) {
+	c.mu.Lock()
+	c.lastOptions = opts
+	c.mu.Unlock()
+}
+
+func (c *captureLLM) toolsSeen() []string {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	var resolved llm.GenerateOptions
+	for _, opt := range c.lastOptions {
+		opt(&resolved)
+	}
+	out := make([]string, 0, len(resolved.Tools))
+	for _, t := range resolved.Tools {
+		out = append(out, t.Name)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func (c *captureLLM) Generate(_ context.Context, _ []model.Message, opts ...llm.GenerateOption) (model.Message, model.TokenUsage, error) {
+	c.record(opts)
+	return model.NewTextMessage(model.RoleAssistant, "ok"), model.TokenUsage{}, nil
+}
+
+func (c *captureLLM) GenerateStream(_ context.Context, _ []model.Message, opts ...llm.GenerateOption) (llm.StreamMessage, error) {
+	c.record(opts)
+	return &capturedStream{final: model.NewTextMessage(model.RoleAssistant, "ok")}, nil
+}
+
+type capturedStream struct {
+	final model.Message
+	done  bool
+}
+
+func (s *capturedStream) Next() bool                 { return false }
+func (s *capturedStream) Current() model.StreamChunk { return model.StreamChunk{} }
+func (s *capturedStream) Err() error                 { return nil }
+func (s *capturedStream) Close() error               { s.done = true; return nil }
+func (s *capturedStream) Message() model.Message     { return s.final }
+func (s *capturedStream) Usage() model.Usage         { return model.Usage{} }
+
+type fixedResolver struct{ inst llm.LLM }
+
+func (r *fixedResolver) Resolve(_ context.Context, _ string) (llm.LLM, error) { return r.inst, nil }
+func (r *fixedResolver) InvalidateCache(_ ...llm.InvalidateOption)            {}
+
+// noopTool is a tool.Tool the registry can hold but which the LLM never
+// actually executes in these tests (the captureLLM returns no tool calls).
+// Only the tool's Definition().Name reaches the assertion site.
+type noopTool struct{ name string }
+
+func (t *noopTool) Definition() model.ToolDefinition {
+	return model.ToolDefinition{Name: t.name, Description: "noop"}
+}
+
+func (t *noopTool) Execute(_ context.Context, _ string) (string, error) {
+	return "", nil
+}
+
+// buildLLMRunner registers a single llm node that pulls its registry +
+// allow-list from ExecutionContext.Deps (Register's toolReg is nil). The
+// node config requests three tools — the test then varies agent.Tools to
+// see which subset the LLM actually receives.
+func buildLLMRunner(t *testing.T, resolver llm.LLMResolver, requestedToolNames []string) *runner.Runner {
+	t.Helper()
+	factory := node.NewFactory()
+	llmnode.Register(factory, resolver, nil) // nil toolReg → resolved from Deps at runtime
+
+	def := &graph.GraphDefinition{
+		Name:  "llm_only",
+		Entry: "llm",
+		Nodes: []graph.NodeDefinition{
+			{ID: "llm", Type: "llm", Config: map[string]any{
+				"system_prompt": "you are a test",
+				"tool_names":    sliceAsAny(requestedToolNames),
+			}},
+		},
+		Edges: []graph.EdgeDefinition{{From: "llm", To: graph.END}},
+	}
+	r, err := runner.New(def, factory)
+	if err != nil {
+		t.Fatalf("runner.New: %v", err)
+	}
+	return r
+}
+
+func sliceAsAny(in []string) []any {
+	out := make([]any, len(in))
+	for i, v := range in {
+		out[i] = v
+	}
+	return out
+}
+
+// TestAgentRun_AgentToolsActsAsPolicyGate is the vertical E2E that
+// verifies the entire chain from contract-audit Epics A+B:
+//
+//	agent.Agent.Tools                                        (PR commit 4 write)
+//	  → agent.Run promotes into engine.Run.Deps[...AllowedNames]
+//	  → graph runner forwards Deps into ExecutionContext.Deps   (commit 1)
+//	  → llmnode.resolveTools intersects with Config.ToolNames   (commit 3)
+//	  → llm.GenerateStream receives only the intersected defs
+//
+// The node asks for [search, fetch, delete_world] but the agent only
+// allows [search, fetch]. delete_world MUST be filtered before the
+// model call — proving Agent.Tools is now a real, enforced policy gate
+// rather than the cosmetic field the audit flagged (#1).
+func TestAgentRun_AgentToolsActsAsPolicyGate(t *testing.T) {
+	cap := &captureLLM{}
+	resolver := &fixedResolver{inst: cap}
+
+	reg := tool.NewRegistry()
+	reg.Register(&noopTool{name: "search"})
+	reg.Register(&noopTool{name: "fetch"})
+	reg.Register(&noopTool{name: "delete_world"})
+
+	deps := engine.NewDependencies()
+	deps.Set(depname.ToolRegistry, reg)
+
+	r := buildLLMRunner(t, resolver,
+		[]string{"search", "fetch", "delete_world"})
+
+	ag := agent.Agent{ID: "researcher", Tools: []string{"search", "fetch"}}
+	res, err := agent.Run(context.Background(), ag, r,
+		agent.Request{Message: model.NewTextMessage(model.RoleUser, "go")},
+		agent.WithDependencies(deps),
+	)
+	if err != nil {
+		t.Fatalf("agent.Run: %v", err)
+	}
+	if res.Status != agent.StatusCompleted {
+		t.Fatalf("Status = %q, want completed", res.Status)
+	}
+
+	got := cap.toolsSeen()
+	want := []string{"fetch", "search"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("LLM tool defs = %v, want %v\n"+
+			"This means Agent.Tools failed to act as the run-level\n"+
+			"ceiling somewhere on the chain agent → engine.Run.Deps\n"+
+			"→ ExecutionContext.Deps → llmnode.resolveTools.",
+			got, want)
+	}
+}
+
+// TestAgentRun_NoAgentToolsKeepsLegacyBehaviour is the back-compat
+// guard: agents that haven't opted into Agent.Tools (the vast
+// majority of pre-Epic-A code) MUST continue to see the per-node
+// Config.ToolNames as the only filter. Without this guard the new
+// "deny-by-default" semantics could quietly break every existing
+// graph that relies on node-level tool config.
+func TestAgentRun_NoAgentToolsKeepsLegacyBehaviour(t *testing.T) {
+	cap := &captureLLM{}
+	resolver := &fixedResolver{inst: cap}
+
+	reg := tool.NewRegistry()
+	reg.Register(&noopTool{name: "search"})
+	reg.Register(&noopTool{name: "fetch"})
+
+	deps := engine.NewDependencies()
+	deps.Set(depname.ToolRegistry, reg)
+
+	r := buildLLMRunner(t, resolver, []string{"search", "fetch"})
+
+	ag := agent.Agent{ID: "noop"} // no Tools → no policy gate
+	if _, err := agent.Run(context.Background(), ag, r,
+		agent.Request{Message: model.NewTextMessage(model.RoleUser, "go")},
+		agent.WithDependencies(deps),
+	); err != nil {
+		t.Fatalf("agent.Run: %v", err)
+	}
+
+	got := cap.toolsSeen()
+	want := []string{"fetch", "search"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("legacy back-compat broken: got %v want %v "+
+			"(agent without Tools should not constrain Config.ToolNames)", got, want)
+	}
 }

--- a/sdk/graph/runner/internal/executor/executor.go
+++ b/sdk/graph/runner/internal/executor/executor.go
@@ -103,6 +103,25 @@ type runConfig struct {
 	// going forward; defaulted to engine.NoopHost{} in Execute when
 	// the caller doesn't supply WithHost.
 	host engine.Host
+
+	// deps carries the engine.Dependencies the upstream caller
+	// (agent.Run / engine host) populated for this run. The
+	// executor forwards it verbatim into [graph.ExecutionContext]
+	// so nodes can recover host-supplied dependencies (LLM clients,
+	// tool registries, …) via [engine.GetDep] instead of being
+	// builder-closure-bound. nil is allowed; nodes that need a dep
+	// must tolerate it (engine.GetDep does).
+	deps *engine.Dependencies
+
+	// attributes carries the string-keyed bag agent.Run promoted
+	// from agent.Request / agent.RunInfo (canonical keys under
+	// sdk/telemetry — AttrAgentID, AttrTaskID, AttrContextID, …).
+	// Forwarded into ExecutionContext.Attributes so nodes that
+	// need agent-scoped identity (scriptnode RunInfoBridge,
+	// telemetry hooks) can read them without a parallel ctx-key
+	// transport. nil = no attributes.
+	attributes map[string]string
+
 	// --- derived (set by Execute) ---
 
 	// publisher is the single event sink consumed by every
@@ -146,6 +165,29 @@ func WithParallel(cfg ParallelConfig) RunOption {
 // engine.NoopHost{} so nodes can call ctx.Host methods unconditionally.
 func WithHost(h engine.Host) RunOption {
 	return func(c *runConfig) { c.host = h }
+}
+
+// WithDeps installs the engine.Dependencies the executor will forward
+// into [graph.ExecutionContext.Deps] so nodes can recover host-supplied
+// dependencies (LLM clients, tool registries, …) via [engine.GetDep].
+// nil is allowed and means "no deps for this run"; nodes that need a
+// dep must tolerate the nil case.
+//
+// runner.Runner.Execute populates this from engine.Run.Deps, so callers
+// that drive the executor through the Engine surface get the wiring
+// for free.
+func WithDeps(d *engine.Dependencies) RunOption {
+	return func(c *runConfig) { c.deps = d }
+}
+
+// WithAttributes installs the string-keyed attribute bag the executor
+// will forward into [graph.ExecutionContext.Attributes]. Used for
+// canonical agent-scoped identity (sdk/telemetry.AttrAgentID,
+// AttrTaskID, AttrContextID) and any caller-supplied tags. nil clears.
+//
+// runner.Runner.Execute populates this from engine.Run.Attributes.
+func WithAttributes(m map[string]string) RunOption {
+	return func(c *runConfig) { c.attributes = m }
 }
 
 func WithResolver(r VariableResolver) RunOption {

--- a/sdk/graph/runner/internal/executor/executor_test.go
+++ b/sdk/graph/runner/internal/executor/executor_test.go
@@ -734,3 +734,96 @@ func TestLocalExecutor_PartialTemplateRef_PreservesLiteral(t *testing.T) {
 		t.Fatalf("model: got %T %v", capturedConfig["model"], capturedConfig["model"])
 	}
 }
+
+// TestLocalExecutor_PropagatesDepsAndAttributes asserts the
+// engine.Run.Deps + engine.Run.Attributes channel reaches every
+// node via [graph.ExecutionContext]. Without this regression test
+// the runner could silently drop the propagation (which is exactly
+// the contract gap audit #2 identified — Deps was a zero-reader
+// channel for months because no executor populated it on the way
+// down).
+func TestLocalExecutor_PropagatesDepsAndAttributes(t *testing.T) {
+	type ctxAuditKey struct{}
+	deps := &engine.Dependencies{}
+	deps.Set(ctxAuditKey{}, "audit-token")
+	attrs := map[string]string{
+		"agent.id":   "researcher",
+		"task.id":    "task-42",
+		"context.id": "thread-7",
+	}
+
+	var (
+		gotDeps  *engine.Dependencies
+		gotAttrs map[string]string
+		gotVal   any
+		gotOK    bool
+	)
+	probe := newTestNode("probe", func(ec graph.ExecutionContext, _ *graph.Board) error {
+		gotDeps = ec.Deps
+		gotAttrs = ec.Attributes
+		if ec.Deps != nil {
+			gotVal, gotOK = ec.Deps.Get(ctxAuditKey{})
+		}
+		return nil
+	})
+
+	g := buildGraph("test", "probe",
+		map[string]graph.Node{"probe": probe},
+		[]graph.Edge{{From: "probe", To: graph.END}},
+	)
+
+	exec := NewLocalExecutor()
+	_, err := exec.Execute(context.Background(), g, graph.NewBoard(),
+		WithDeps(deps),
+		WithAttributes(attrs),
+	)
+	if err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+
+	if gotDeps != deps {
+		t.Errorf("ExecutionContext.Deps: pointer differs from WithDeps argument; got %p want %p", gotDeps, deps)
+	}
+	if !gotOK || gotVal != "audit-token" {
+		t.Errorf("Deps payload missing through propagation: ok=%v val=%v", gotOK, gotVal)
+	}
+	if len(gotAttrs) != len(attrs) {
+		t.Fatalf("ExecutionContext.Attributes: len mismatch; got %d want %d (%v)", len(gotAttrs), len(attrs), gotAttrs)
+	}
+	for k, v := range attrs {
+		if gotAttrs[k] != v {
+			t.Errorf("Attributes[%q] = %q, want %q", k, gotAttrs[k], v)
+		}
+	}
+}
+
+// TestLocalExecutor_NilDepsAndAttributesAreTolerated documents that
+// engines invoked without WithDeps / WithAttributes still work — the
+// executor MUST surface nil maps / pointers verbatim instead of
+// inventing default values nodes might mistake for real state.
+func TestLocalExecutor_NilDepsAndAttributesAreTolerated(t *testing.T) {
+	var (
+		gotDeps  *engine.Dependencies
+		gotAttrs map[string]string
+	)
+	probe := newTestNode("probe", func(ec graph.ExecutionContext, _ *graph.Board) error {
+		gotDeps = ec.Deps
+		gotAttrs = ec.Attributes
+		return nil
+	})
+
+	g := buildGraph("test", "probe",
+		map[string]graph.Node{"probe": probe},
+		[]graph.Edge{{From: "probe", To: graph.END}},
+	)
+
+	if _, err := NewLocalExecutor().Execute(context.Background(), g, graph.NewBoard()); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	if gotDeps != nil {
+		t.Errorf("ExecutionContext.Deps: expected nil when WithDeps absent, got %v", gotDeps)
+	}
+	if gotAttrs != nil {
+		t.Errorf("ExecutionContext.Attributes: expected nil when WithAttributes absent, got %v", gotAttrs)
+	}
+}

--- a/sdk/graph/runner/internal/executor/retry.go
+++ b/sdk/graph/runner/internal/executor/retry.go
@@ -31,10 +31,12 @@ func executeWithRetry(ctx context.Context, node graph.Node, board *graph.Board, 
 
 		snapshot := board.Snapshot()
 		execCtx := graph.ExecutionContext{
-			Context:   ctx,
-			Host:      cfg.host,
-			Publisher: wrappedPublisher,
-			RunID:     cfg.runID,
+			Context:    ctx,
+			Host:       cfg.host,
+			Publisher:  wrappedPublisher,
+			RunID:      cfg.runID,
+			Deps:       cfg.deps,
+			Attributes: cfg.attributes,
 		}
 
 		lastErr = node.ExecuteBoard(execCtx, board)

--- a/sdk/graph/runner/runner.go
+++ b/sdk/graph/runner/runner.go
@@ -165,10 +165,22 @@ func (r *Runner) executeBound(
 		}
 	}
 
-	opts := make([]executor.RunOption, 0, 4+len(r.runOpts)+len(extra))
+	opts := make([]executor.RunOption, 0, 6+len(r.runOpts)+len(extra))
 	opts = append(opts, executor.WithHost(host))
 	if run.ID != "" {
 		opts = append(opts, executor.WithRunID(run.ID))
+	}
+	// Forward engine.Run.Deps + Attributes verbatim so nodes can
+	// recover host-supplied dependencies via engine.GetDep
+	// (ToolRegistry, LLMClient, …) and read agent-scoped identity
+	// attributes (telemetry.AttrAgentID, …) without inventing a
+	// parallel ctx-key channel. nil values are no-ops at the
+	// executor layer.
+	if run.Deps != nil {
+		opts = append(opts, executor.WithDeps(run.Deps))
+	}
+	if len(run.Attributes) > 0 {
+		opts = append(opts, executor.WithAttributes(run.Attributes))
 	}
 	// Default resolver is harmless if the caller already supplied one
 	// via runner.WithResolver — executor.runConfig is last-write-wins.


### PR DESCRIPTION
## Summary

Closes contract-audit Epics A + B by wiring the previously-disconnected
chain `agent.Agent.Tools` → `agent.Run` → `engine.Run.Deps` → graph
runner → `ExecutionContext.Deps` → `llmnode.resolveTools` end-to-end.
Two long-standing audit gaps disappear:

- **#1 Agent.Tools is silently ignored** — the field used to be a spec
  ornament; it is now a real, enforced policy gate intersected with
  per-node `Config.ToolNames` inside the LLM round driver.
- **#12 scriptnode RunInfo getters return empty** — `agent_id()` /
  `task_id()` / `context_id()` used to always return `""` because
  scriptnode constructed `RunInfo{RunID: ec.RunID}` and dropped the
  three other fields `agent.Run` had already promoted upstream.

The `[skip-tag]` marker keeps auto-tag from publishing partial
intermediate releases — sdk + vessel will be tagged together by the
release coordinator once Epic D/G follow-ups land.

## What ships, by commit

1. `feat(graph): propagate engine.Run.Deps + Attributes through ExecutionContext`
   Adds `Deps *engine.Dependencies` + `Attributes map[string]string`
   to `graph.ExecutionContext`; runner / executor forward `engine.Run`'s
   values verbatim. Pure infrastructure — every later commit consumes it.

2. `feat(agent,scriptnode): expose RunInfoFromAttributes; fill scriptnode RunInfo`
   New helper `agent.RunInfoFromAttributes(runID, attrs)` becomes the
   canonical reader for the attributes `agent.Run` writes; key names
   stay private to the agent package so the wire format can be
   migrated to `sdk/telemetry.Attr*` later in one edit. scriptnode
   switches to it and finally surfaces all four `RunInfo` fields.

3. `feat(llmnode): resolve tool registry + allow-list from ExecutionContext.Deps`
   `llmnode.Node.resolveTools` reads `*tool.Registry` and the allow-list
   from `ec.Deps[depname.ToolRegistry]` / `[depname.ToolAllowedNames]`
   with a documented precedence table (run-scoped wins; ceiling
   intersects with `Config.ToolNames`; absent ceiling falls back to
   legacy behaviour; empty ceiling is fail-closed).

4. `feat(agent): promote Agent.Tools into engine.Run.Deps as policy gate`
   `promoteAgentTools` clones the caller's `Dependencies` and writes
   `depname.ToolAllowedNames = ag.Tools` (defensive slice copy)
   unless the caller already pinned the key. Adds
   `engine.Dependencies.Clone()` for the cloning. Closes the writer
   side of audit #1.

5. `test(integration): vertical E2E for Agent.Tools policy gate`
   Drives a real `agent.Run` against a real `runner.Runner` with a
   real `*tool.Registry` and a `captureLLM` that records the
   `GenerateOption` slice. Asserts the LLM only sees the
   intersection of `Agent.Tools` + `Config.ToolNames`. The single
   regression test that would have caught the entire historical
   gap; complemented by a back-compat test for agents that never
   set `Tools`.

## Test plan

- [x] `go test ./sdk/... ./vessel/... ./cmd/vesseld/...` (all green)
- [x] `gofmt -l sdk vessel cmd` (clean)
- [x] Per-seam unit tests:
  - executor: `TestLocalExecutor_PropagatesDepsAndAttributes`,
    `TestLocalExecutor_NilDepsAndAttributesAreTolerated`
  - runner: `TestRunner_Execute_PropagatesRunDepsAndAttributes`
  - agent: `TestRunInfoFromAttributes_RoundTrip` /
    `TestPromoteAgentTools_*` /
    `TestRun_PromotesAgentToolsIntoEngineRunDeps`
  - llmnode: `TestNode_ResolveTools_*` (intersection, fail-closed,
    back-compat, fallback)
  - scriptnode: `TestScriptNode_RunInfo_AllFieldsPropagate`
- [x] Vertical E2E (most important):
  - `TestAgentRun_AgentToolsActsAsPolicyGate` — `delete_world`
    requested by node config but unauthorised by agent MUST be
    filtered before the model call.
  - `TestAgentRun_NoAgentToolsKeepsLegacyBehaviour` — agent without
    `Tools` keeps full per-node `ToolNames` reach (no accidental
    deny-by-default escalation).

## Follow-ups (deliberately out of scope)

- Migrate `agent.run.mergeAttributes` snake_case keys to canonical
  `sdk/telemetry.Attr*` dot-keys (one-edit change behind the new
  `RunInfoFromAttributes` helper).
- Epic D: vessel inline engine + `cmd/vesseld` honour
  `depname.ToolAllowedNames` (today they use the legacy
  `catalog.Deps.AgentTools` path; the gate still works because the
  graph runner llmnode is the only enforcement site, but the
  vessel inline engine should also read the canonical key).
- Epic G: `runner.WithActorKey` transformation to
  `executor.WithAttributes` so node-level actor keys participate
  in the same canonical attribute bag.


Made with [Cursor](https://cursor.com)