### PR TITLE
[skip-tag] feat(agent,vesseld): complete agent.Run funnel; migrate vessel allow-list to engine.Run.Deps

### DIFF
--- a/cmd/vesseld/catalog/catalog.go
+++ b/cmd/vesseld/catalog/catalog.go
@@ -59,6 +59,20 @@ type Deps struct {
 	// spec.Agent.Tools (with kanban auto-injection already
 	// applied by the vessel runtime when the agent is a
 	// Dispatcher).
+	//
+	// Deprecated: this field is the legacy "build-time closure"
+	// transport for the policy gate. The canonical SDK path is
+	// engine.Run.Deps[depname.ToolAllowedNames] (populated by
+	// agent.Run from agent.Agent.Tools — see contract-audit
+	// Epic A + D). The vessel inline engine still falls back to
+	// this field when the engine is invoked outside agent.Run
+	// (custom drivers, legacy tests), but new engine factories
+	// MUST resolve the allow-list from engine.Run.Deps via
+	// engine.GetDep[[]string](run.Deps, depname.ToolAllowedNames).
+	//
+	// Scheduled for removal in v0.5.0 once all in-tree call sites
+	// drive vessel through agent.Run. The field will then become
+	// fully redundant with the run-deps path.
 	AgentTools []string
 
 	// Bus is the vessel's event bus. Factories MAY publish onto

--- a/cmd/vesseld/catalog/engine_graph_llm.go
+++ b/cmd/vesseld/catalog/engine_graph_llm.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/GizClaw/flowcraft/sdk/engine"
+	"github.com/GizClaw/flowcraft/sdk/engine/depname"
 	"github.com/GizClaw/flowcraft/sdk/errdefs"
 	"github.com/GizClaw/flowcraft/sdk/event"
 	"github.com/GizClaw/flowcraft/sdk/llm"
@@ -72,7 +73,13 @@ func graphLLMEngineFactory(ref string, cfg map[string]any, deps Deps) (engine.En
 	}
 
 	limiter := deps.LLMLimiters[profile]
-	allowSet := buildAllowSet(deps.AgentTools)
+	// Allow-list resolution moved INTO the EngineFunc closure
+	// (contract-audit Epic D / #11): the inline engine now reads
+	// the per-run agent.Agent.Tools snapshot agent.Run promotes
+	// into engine.Run.Deps[depname.ToolAllowedNames] and falls
+	// back to the legacy factory-time deps.AgentTools for callers
+	// that still wire vessel without driving it through agent.Run.
+	// See resolveAllowSet for the precedence rules.
 
 	// Wrap the inline executor with the engine's declared
 	// capabilities so hosts (agent.Run preflight, dashboards, the
@@ -87,11 +94,15 @@ func graphLLMEngineFactory(ref string, cfg map[string]any, deps Deps) (engine.En
 	//   - EmitsCheckpoint = false: the inline loop never invokes
 	//     host.Checkpoint (graph runner is the engine that does, but
 	//     this factory does not delegate to it).
-	//   - RequiredDepNames = nil: the inline engine takes its
-	//     dependencies from catalog.Deps (LLMClients / ToolRegistry /
-	//     AgentTools) at factory time, not from engine.Run.Deps —
-	//     declaring run-deps requirements here would be misleading.
+	//   - RequiredDepNames = []string{depname.ToolAllowedNames}:
+	//     declares the only dep this engine resolves at run time
+	//     (the policy gate). LLMClient / ToolRegistry are still
+	//     wired through factory-time catalog.Deps for v0.1.0 so
+	//     they're not declared here; teaching the inline engine
+	//     to resolve those from run.Deps too is a follow-up that
+	//     turns this into a fully run-deps-driven engine.
 	return engine.WithCapabilities(engine.EngineFunc(func(ctx context.Context, run engine.Run, host engine.Host, board *engine.Board) (*engine.Board, error) {
+		allowSet := resolveAllowSet(run, deps)
 		// actorID is the engine "actor" key used in step-level
 		// subjects. We use the agent name so SSE consumers can
 		// see "agent X started step Y" without having to consult
@@ -218,7 +229,7 @@ func graphLLMEngineFactory(ref string, cfg map[string]any, deps Deps) (engine.En
 		SupportsResume:   false,
 		EmitsUserPrompt:  false,
 		EmitsCheckpoint:  false,
-		RequiredDepNames: nil,
+		RequiredDepNames: []string{depname.ToolAllowedNames},
 	}), nil
 }
 
@@ -276,6 +287,32 @@ func streamLLMRound(
 // the per-iteration filter and the per-call execution gate run in
 // O(1). nil / empty input yields an empty set that buildToolDefinitions
 // and executeToolCall interpret as "deny all".
+// resolveAllowSet returns the per-run tool allow-set the inline
+// engine should enforce. Precedence (contract-audit Epic D):
+//
+//  1. engine.Run.Deps[depname.ToolAllowedNames] when present and
+//     well-typed. agent.Run promotes agent.Agent.Tools into this
+//     key (see sdk/agent/run.go::promoteAgentTools), so this is
+//     the canonical SDK-wide path: the same allow-list reaches
+//     this engine, sdk/graph/node/llmnode, and any future engine
+//     that honours the contract.
+//  2. Factory-time catalog.Deps.AgentTools fallback. Preserves
+//     back-compat for hosts that build vessel without going
+//     through agent.Run (custom drivers, legacy tests). Marked
+//     Deprecated on the catalog struct; scheduled for removal in
+//     v0.5.0.
+//
+// An empty / absent allow-set yields an empty map (the strict
+// default — buildToolDefinitions and executeToolCall both
+// interpret empty as "deny all", a misconfigured agent gets a
+// safe failure instead of a silent permission escalation).
+func resolveAllowSet(run engine.Run, deps Deps) map[string]struct{} {
+	if names, err := engine.GetDep[[]string](run.Deps, depname.ToolAllowedNames); err == nil {
+		return buildAllowSet(names)
+	}
+	return buildAllowSet(deps.AgentTools)
+}
+
 func buildAllowSet(tools []string) map[string]struct{} {
 	if len(tools) == 0 {
 		return map[string]struct{}{}

--- a/cmd/vesseld/catalog/engine_graph_llm_test.go
+++ b/cmd/vesseld/catalog/engine_graph_llm_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/GizClaw/flowcraft/sdk/engine"
+	"github.com/GizClaw/flowcraft/sdk/engine/depname"
 	"github.com/GizClaw/flowcraft/sdk/errdefs"
 	"github.com/GizClaw/flowcraft/sdk/llm"
 	"github.com/GizClaw/flowcraft/sdk/model"
@@ -170,5 +171,159 @@ func TestGraphLLM_AllowlistEnforcedAtExecution(t *testing.T) {
 	}
 	if out != "ok" {
 		t.Fatalf("calc returned %q, want \"ok\"", out)
+	}
+}
+
+// TestGraphLLM_RunDepsAllowedNamesOverridesAgentTools is the
+// regression for contract-audit Epic D / #11. Once the inline
+// engine resolves the allow-list from engine.Run.Deps, the
+// per-run policy gate (which agent.Run populates from
+// agent.Agent.Tools) MUST take precedence over the legacy
+// factory-time catalog.Deps.AgentTools closure.
+//
+// Setup: factory wires the LEGACY closure with [calc, shell]; the
+// run carries Run.Deps[ToolAllowedNames] = [calc] only. Without
+// the resolution change, the LLM would see both calc + shell
+// because allowSet was computed at factory time. With the change,
+// the LLM sees only calc.
+func TestGraphLLM_RunDepsAllowedNamesOverridesAgentTools(t *testing.T) {
+	t.Parallel()
+
+	reg := tool.NewRegistry()
+	reg.Register(fakeTool("calc"))
+	reg.Register(fakeTool("shell"))
+
+	stub := &stubLLM{}
+	deps := Deps{
+		VesselID:     "v",
+		AgentName:    "primary",
+		AgentTools:   []string{"calc", "shell"}, // legacy claim — superset
+		ToolRegistry: reg,
+		LLMClients:   map[string]llm.LLM{"openai-default": stub},
+	}
+	eng, err := graphLLMEngineFactory("graph-llm", map[string]any{
+		"llmProfile":    "openai-default",
+		"maxIterations": 1,
+	}, deps)
+	if err != nil {
+		t.Fatalf("graphLLMEngineFactory: %v", err)
+	}
+
+	// Per-run override: the agent.Run-promoted allow-list permits
+	// only calc. The inline engine MUST honour this over the
+	// closure.
+	runDeps := engine.NewDependencies()
+	runDeps.Set(depname.ToolAllowedNames, []string{"calc"})
+
+	board := engine.NewBoard()
+	board.AppendChannelMessage(engine.MainChannel, model.NewTextMessage(model.RoleUser, "hi"))
+	if _, err := eng.Execute(context.Background(),
+		engine.Run{ID: "r1", Deps: runDeps},
+		engine.NoopHost{}, board); err != nil {
+		t.Fatalf("engine.Execute: %v", err)
+	}
+
+	got := map[string]bool{}
+	for _, td := range stub.gotTools {
+		got[td.Name] = true
+	}
+	if !got["calc"] {
+		t.Errorf("LLM did not see calc (run.Deps allow-list dropped a permitted tool)")
+	}
+	if got["shell"] {
+		t.Errorf("LLM saw shell — run.Deps allow-list did NOT override factory closure")
+	}
+}
+
+// TestGraphLLM_RunDepsEmptyAllowedNamesDeniesAll asserts the
+// fail-closed semantics at the new resolution path: an explicit
+// empty []string under depname.ToolAllowedNames is a deliberate
+// "no tools permitted" signal — even when the factory closure
+// permits some. Without this rule a deployment that wants to
+// strip tools per-run could not do so without rebuilding the
+// factory.
+func TestGraphLLM_RunDepsEmptyAllowedNamesDeniesAll(t *testing.T) {
+	t.Parallel()
+
+	reg := tool.NewRegistry()
+	reg.Register(fakeTool("calc"))
+
+	stub := &stubLLM{}
+	deps := Deps{
+		VesselID:     "v",
+		AgentName:    "primary",
+		AgentTools:   []string{"calc"}, // legacy: would permit calc
+		ToolRegistry: reg,
+		LLMClients:   map[string]llm.LLM{"openai-default": stub},
+	}
+	eng, err := graphLLMEngineFactory("graph-llm", map[string]any{
+		"llmProfile":    "openai-default",
+		"maxIterations": 1,
+	}, deps)
+	if err != nil {
+		t.Fatalf("graphLLMEngineFactory: %v", err)
+	}
+
+	runDeps := engine.NewDependencies()
+	runDeps.Set(depname.ToolAllowedNames, []string{}) // explicit deny-all
+
+	board := engine.NewBoard()
+	board.AppendChannelMessage(engine.MainChannel, model.NewTextMessage(model.RoleUser, "hi"))
+	if _, err := eng.Execute(context.Background(),
+		engine.Run{ID: "r1", Deps: runDeps},
+		engine.NoopHost{}, board); err != nil {
+		t.Fatalf("engine.Execute: %v", err)
+	}
+	if len(stub.gotTools) != 0 {
+		t.Fatalf("LLM saw %d tools, want 0 (explicit empty allow-list MUST deny all)",
+			len(stub.gotTools))
+	}
+}
+
+// TestGraphLLM_AbsentRunDepsKeyFallsBackToAgentTools is the
+// back-compat guard: callers (custom drivers, legacy tests) that
+// build vessel without driving it through agent.Run won't
+// populate engine.Run.Deps[ToolAllowedNames]. The inline engine
+// MUST keep honouring the factory-time closure for them.
+func TestGraphLLM_AbsentRunDepsKeyFallsBackToAgentTools(t *testing.T) {
+	t.Parallel()
+
+	reg := tool.NewRegistry()
+	reg.Register(fakeTool("calc"))
+	reg.Register(fakeTool("shell"))
+
+	stub := &stubLLM{}
+	deps := Deps{
+		VesselID:     "v",
+		AgentName:    "primary",
+		AgentTools:   []string{"calc"}, // factory closure permits calc only
+		ToolRegistry: reg,
+		LLMClients:   map[string]llm.LLM{"openai-default": stub},
+	}
+	eng, err := graphLLMEngineFactory("graph-llm", map[string]any{
+		"llmProfile":    "openai-default",
+		"maxIterations": 1,
+	}, deps)
+	if err != nil {
+		t.Fatalf("graphLLMEngineFactory: %v", err)
+	}
+
+	board := engine.NewBoard()
+	board.AppendChannelMessage(engine.MainChannel, model.NewTextMessage(model.RoleUser, "hi"))
+	// Note: engine.Run.Deps is nil — no run-deps key set.
+	if _, err := eng.Execute(context.Background(),
+		engine.Run{ID: "r1"}, engine.NoopHost{}, board); err != nil {
+		t.Fatalf("engine.Execute: %v", err)
+	}
+
+	got := map[string]bool{}
+	for _, td := range stub.gotTools {
+		got[td.Name] = true
+	}
+	if !got["calc"] {
+		t.Error("legacy fallback broken: calc missing from LLM-visible defs")
+	}
+	if got["shell"] {
+		t.Error("legacy fallback broken: shell leaked through (closure permitted only calc)")
 	}
 }

--- a/sdk/agent/request.go
+++ b/sdk/agent/request.go
@@ -41,9 +41,27 @@ type Request struct {
 	// Maps to A2A's "configuration".
 	Config *RequestConfig `json:"configuration,omitempty"`
 
-	// Extensions is host-passed-through metadata. agent does NOT
-	// interpret it; engines may read it from Run.Attributes if the
-	// host chose to forward it.
+	// Extensions is host-passed-through metadata.
+	//
+	// Deprecated: agent has never interpreted this field — the
+	// previous godoc only documented "engines may read it from
+	// Run.Attributes if the host chose to forward it", and no
+	// such forwarding was ever implemented (contract-audit #8).
+	// The map[string]any → map[string]string type mismatch with
+	// engine.Run.Attributes also forces an ad-hoc serialisation
+	// strategy on every host that wants to forward.
+	//
+	// Use [WithAttributes] instead: it is a typed map[string]string
+	// the caller controls, the wire format is uniform with the
+	// canonical attribute bag (sdk/telemetry.Attr* dot-keys), and
+	// engines find it under engine.Run.Attributes via the same
+	// codepath as agent_id / run_id / task_id / context_id.
+	//
+	// This field is scheduled for removal in sdk v0.5.0. Migrate
+	// callers by serialising any non-string values at the call
+	// site and passing them through agent.WithAttributes(...) on
+	// the agent.Run option list. Engines that need to introspect
+	// caller-supplied metadata read engine.Run.Attributes today.
 	Extensions map[string]any `json:"extensions,omitempty"`
 }
 

--- a/sdk/agent/run.go
+++ b/sdk/agent/run.go
@@ -162,9 +162,10 @@ func Run(
 		}
 		attemptAttrs["agent.attempt"] = itoa(attempt)
 		engRun := engine.Run{
-			ID:         runID,
-			Attributes: attemptAttrs,
-			Deps:       runDeps,
+			ID:          runID,
+			ParentRunID: rc.parentRunID,
+			Attributes:  attemptAttrs,
+			Deps:        runDeps,
 		}
 		if attempt == 1 {
 			engRun.ResumeFrom = rc.resumeFrom
@@ -405,15 +406,16 @@ func mergeAttributes(extra map[string]string, req Request, ag Agent, runID strin
 type RunOption func(*runConfig)
 
 type runConfig struct {
-	seeder     BoardSeeder
-	deps       *engine.Dependencies
-	host       engine.Host
-	attributes map[string]string
-	observers  []Observer
-	deciders   []Decider
-	resumeFrom *engine.Checkpoint
-	runID      string
-	maxRevise  int
+	seeder      BoardSeeder
+	deps        *engine.Dependencies
+	host        engine.Host
+	attributes  map[string]string
+	observers   []Observer
+	deciders    []Decider
+	resumeFrom  *engine.Checkpoint
+	runID       string
+	parentRunID string
+	maxRevise   int
 }
 
 // applyOptions threads ag through so we can apply Agent-scoped
@@ -548,6 +550,27 @@ func WithMaxRevise(n int) RunOption {
 		}
 		rc.maxRevise = n
 	}
+}
+
+// WithParentRunID stamps every engine.Run this call dispatches with
+// the supplied parent run id (engine.Run.ParentRunID). Use it when
+// one agent.Run is spawned by another (multi-agent call chain,
+// handoff, sub-agent dispatch) so dashboards / pod controllers can
+// reconstruct the call tree and apply loop-detection / depth budgets
+// against a stable correlation key.
+//
+// The empty string is a no-op; passing the parent's runID
+// (typically obtained from agent.RunInfo.RunID inside an Observer
+// / Decider on the parent run) is the canonical use. agent.Run does
+// NOT auto-derive ParentRunID from any ambient context — explicit
+// is the only contract that survives ctx propagation rewrites and
+// cross-process dispatch (vessel, A2A bridge).
+//
+// Engines / hosts that don't read ParentRunID are unaffected. The
+// field is also surfaced under telemetry.AttrParentRunID by
+// observers that emit run-summary spans (sdk/telemetry/run_summary).
+func WithParentRunID(id string) RunOption {
+	return func(rc *runConfig) { rc.parentRunID = id }
 }
 
 // WithResumeFrom replays an interrupted run from a previously

--- a/sdk/agent/run.go
+++ b/sdk/agent/run.go
@@ -188,6 +188,7 @@ func Run(
 			Attempts:  attempt,
 		}
 		res.Messages = newAssistantMessages(finalBoard)
+		res.Artifacts = collectArtifacts(finalBoard, rc.artifactChannels)
 
 		switch {
 		case execErr == nil:
@@ -322,6 +323,47 @@ func newAssistantMessages(b *engine.Board) []model.Message {
 	return out
 }
 
+// collectArtifacts harvests the named board channels into Result.Artifacts
+// per the [WithArtifactChannels] contract. One Artifact per channel that
+// holds at least one Part after the run; Parts are flat-concatenated in
+// board-write order. Channels are processed in the order callers
+// registered them and de-duplicated so accumulating per-agent + per-call
+// lists never produces duplicate Artifact entries.
+//
+// Channels that hold messages but no Parts (e.g. role-only system
+// markers) produce no Artifact entry — empty Parts would be confusing
+// to consumers that expect "Artifact present means there is something
+// to render".
+//
+// nil channels list returns nil so the unaltered nil-Artifacts default
+// for callers that don't opt in is preserved.
+func collectArtifacts(b *engine.Board, channels []string) []Artifact {
+	if len(channels) == 0 {
+		return nil
+	}
+	seen := make(map[string]struct{}, len(channels))
+	var out []Artifact
+	for _, name := range channels {
+		if _, dup := seen[name]; dup {
+			continue
+		}
+		seen[name] = struct{}{}
+		msgs := b.Channel(name)
+		if len(msgs) == 0 {
+			continue
+		}
+		var parts []model.Part
+		for _, m := range msgs {
+			parts = append(parts, m.Parts...)
+		}
+		if len(parts) == 0 {
+			continue
+		}
+		out = append(out, Artifact{Name: name, Parts: parts})
+	}
+	return out
+}
+
 // mintRunID returns a fresh "run-<hex>" identifier. Falls back to a
 // nanos-suffixed string if crypto/rand is unavailable (extremely rare
 // — typically only sandboxes).
@@ -406,16 +448,17 @@ func mergeAttributes(extra map[string]string, req Request, ag Agent, runID strin
 type RunOption func(*runConfig)
 
 type runConfig struct {
-	seeder      BoardSeeder
-	deps        *engine.Dependencies
-	host        engine.Host
-	attributes  map[string]string
-	observers   []Observer
-	deciders    []Decider
-	resumeFrom  *engine.Checkpoint
-	runID       string
-	parentRunID string
-	maxRevise   int
+	seeder           BoardSeeder
+	deps             *engine.Dependencies
+	host             engine.Host
+	attributes       map[string]string
+	observers        []Observer
+	deciders         []Decider
+	resumeFrom       *engine.Checkpoint
+	runID            string
+	parentRunID      string
+	maxRevise        int
+	artifactChannels []string
 }
 
 // applyOptions threads ag through so we can apply Agent-scoped
@@ -557,6 +600,51 @@ func WithMaxRevise(n int) RunOption {
 			n = 0
 		}
 		rc.maxRevise = n
+	}
+}
+
+// WithArtifactChannels names the [engine.Board] channels [Run] should
+// harvest into [Result.Artifacts] on the way out. One Artifact per
+// listed channel: Artifact.Name = channel name; Artifact.Parts =
+// flat concatenation of every Part across every Message in the
+// channel (in board-write order). Channels that hold no messages
+// after the run produce no Artifact entry — empty channels do not
+// pollute the result with empty bundles.
+//
+// This is the writer side of the Result.Artifacts contract that
+// contract-audit #6 flagged: the godoc had been promising
+// "engines store them in a board channel; agent collects channel
+// contents into Artifacts on the way out" since v0.1, but no
+// agent.Run code path actually performed the collection so the
+// field was permanently nil for every caller.
+//
+// MUST NOT include [engine.MainChannel] — Run already promotes
+// that channel into [Result.Messages] and a duplicate harvest
+// would surface the same payload twice with confusing semantics
+// (Messages keeps role + tool metadata; Artifacts is the
+// modality-bundle view). Run silently skips MainChannel if the
+// caller mistakenly passes it.
+//
+// Example: an engine that writes a "summary" markdown blob and
+// an "audio" TTS clip to dedicated channels:
+//
+//	res, _ := agent.Run(ctx, ag, eng, req,
+//	    agent.WithArtifactChannels("summary", "audio"))
+//	for _, a := range res.Artifacts {
+//	    switch a.Name { ... }
+//	}
+//
+// Multiple WithArtifactChannels calls accumulate (deduped at
+// collection time) so per-agent and per-call lists compose. nil
+// / empty input is a no-op.
+func WithArtifactChannels(channels ...string) RunOption {
+	return func(rc *runConfig) {
+		for _, c := range channels {
+			if c == "" || c == engine.MainChannel {
+				continue
+			}
+			rc.artifactChannels = append(rc.artifactChannels, c)
+		}
 	}
 }
 

--- a/sdk/agent/run.go
+++ b/sdk/agent/run.go
@@ -500,6 +500,14 @@ func WithEngineHost(h engine.Host) RunOption {
 // WithAttributes adds extra attributes that flow into engine.Run.Attributes
 // alongside the well-known agent_id / run_id / task_id / context_id keys.
 // Caller-supplied keys win on conflict; agent does not overwrite.
+//
+// This is also the canonical replacement for the deprecated
+// [Request.Extensions] (contract-audit #8): engines that need
+// caller-supplied metadata read engine.Run.Attributes via the same
+// codepath as the well-known keys, with no map[string]any →
+// map[string]string serialisation guesswork. Hosts that previously
+// wrote into req.Extensions should serialise the values at the
+// call site and pass the resulting map[string]string here.
 func WithAttributes(extra map[string]string) RunOption {
 	return func(rc *runConfig) {
 		if rc.attributes == nil {

--- a/sdk/agent/run_test.go
+++ b/sdk/agent/run_test.go
@@ -1110,3 +1110,56 @@ func TestRun_AgentToolsDoesNotOverwriteCallerSuppliedToolAllowedNames(t *testing
 		t.Errorf("ToolAllowedNames = %v, want [caller-pin] (caller-supplied must win)", got)
 	}
 }
+
+// TestRun_WithParentRunID_PropagatesToEngineRun is the regression
+// test for contract-audit #3. engine.Run.ParentRunID was a typed
+// field with zero writers before this PR; agent.Run now promotes
+// the WithParentRunID value into every dispatched engine.Run so
+// the multi-agent call chain finally has a stable correlation
+// dimension dashboards / pod controllers can rely on.
+func TestRun_WithParentRunID_PropagatesToEngineRun(t *testing.T) {
+	var observed string
+	eng := engine.EngineFunc(func(_ context.Context, run engine.Run, _ engine.Host, b *engine.Board) (*engine.Board, error) {
+		observed = run.ParentRunID
+		b.AppendChannelMessage(engine.MainChannel,
+			model.NewTextMessage(model.RoleAssistant, "ok"))
+		return b, nil
+	})
+
+	if _, err := agent.Run(context.Background(),
+		agent.Agent{ID: "child"}, eng, newReq("hi"),
+		agent.WithParentRunID("run-parent-42"),
+	); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if observed != "run-parent-42" {
+		t.Fatalf("engine.Run.ParentRunID = %q, want %q", observed, "run-parent-42")
+	}
+}
+
+// TestRun_WithParentRunID_EmptyIsNoop documents the no-op contract:
+// callers (vessel, future pod controller) that don't have a parent
+// id MUST be able to omit the option without seeing an "empty
+// parent" appear downstream.
+func TestRun_WithParentRunID_EmptyIsNoop(t *testing.T) {
+	var observed string
+	var sawHookCall bool
+	eng := engine.EngineFunc(func(_ context.Context, run engine.Run, _ engine.Host, b *engine.Board) (*engine.Board, error) {
+		sawHookCall = true
+		observed = run.ParentRunID
+		b.AppendChannelMessage(engine.MainChannel,
+			model.NewTextMessage(model.RoleAssistant, "ok"))
+		return b, nil
+	})
+
+	if _, err := agent.Run(context.Background(),
+		agent.Agent{ID: "x"}, eng, newReq("hi")); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if !sawHookCall {
+		t.Fatal("engine never called")
+	}
+	if observed != "" {
+		t.Fatalf("ParentRunID should default to empty string, got %q", observed)
+	}
+}

--- a/sdk/agent/run_test.go
+++ b/sdk/agent/run_test.go
@@ -1163,3 +1163,159 @@ func TestRun_WithParentRunID_EmptyIsNoop(t *testing.T) {
 		t.Fatalf("ParentRunID should default to empty string, got %q", observed)
 	}
 }
+
+// TestRun_WithArtifactChannels_HarvestsRegisteredChannels is the
+// regression for contract-audit #6. Result.Artifacts had been
+// promised since v0.1 ("engines store them in a board channel;
+// agent collects channel contents into Artifacts on the way
+// out") but no agent.Run code path implemented the harvest, so
+// the field was permanently nil for every caller.
+func TestRun_WithArtifactChannels_HarvestsRegisteredChannels(t *testing.T) {
+	eng := engine.EngineFunc(func(_ context.Context, _ engine.Run, _ engine.Host, b *engine.Board) (*engine.Board, error) {
+		// Engine writes artifacts onto two dedicated channels.
+		b.AppendChannelMessage("summary",
+			model.Message{Role: model.RoleAssistant, Parts: []model.Part{
+				{Type: model.PartText, Text: "tl;dr line 1"},
+			}})
+		b.AppendChannelMessage("summary",
+			model.Message{Role: model.RoleAssistant, Parts: []model.Part{
+				{Type: model.PartText, Text: "tl;dr line 2"},
+			}})
+		b.AppendChannelMessage("audio",
+			model.Message{Role: model.RoleAssistant, Parts: []model.Part{
+				{Type: model.PartText, Text: "<wav-blob>"},
+			}})
+		// MainChannel reply still happens (Result.Messages path).
+		b.AppendChannelMessage(engine.MainChannel,
+			model.NewTextMessage(model.RoleAssistant, "ok"))
+		return b, nil
+	})
+
+	res, err := agent.Run(context.Background(),
+		agent.Agent{ID: "x"}, eng, newReq("hi"),
+		agent.WithArtifactChannels("summary", "audio"),
+	)
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	if len(res.Artifacts) != 2 {
+		t.Fatalf("len(Artifacts) = %d, want 2 (got %+v)", len(res.Artifacts), res.Artifacts)
+	}
+	if res.Artifacts[0].Name != "summary" || res.Artifacts[1].Name != "audio" {
+		t.Errorf("artifacts not in registration order: got %q / %q",
+			res.Artifacts[0].Name, res.Artifacts[1].Name)
+	}
+	if len(res.Artifacts[0].Parts) != 2 {
+		t.Errorf("summary.Parts len = %d, want 2 (one Part per Message)",
+			len(res.Artifacts[0].Parts))
+	}
+	if res.Artifacts[0].Parts[0].Text != "tl;dr line 1" ||
+		res.Artifacts[0].Parts[1].Text != "tl;dr line 2" {
+		t.Errorf("summary parts not in board-write order: %+v", res.Artifacts[0].Parts)
+	}
+}
+
+// TestRun_WithArtifactChannels_DefaultIsNilArtifacts asserts the
+// back-compat invariant: callers that don't opt in must keep
+// seeing nil Artifacts. Without this guard a future "auto-harvest
+// every non-Main channel" refactor could surface unrelated
+// internal channels and break consumers that switch on
+// len(res.Artifacts) == 0.
+func TestRun_WithArtifactChannels_DefaultIsNilArtifacts(t *testing.T) {
+	eng := engine.EngineFunc(func(_ context.Context, _ engine.Run, _ engine.Host, b *engine.Board) (*engine.Board, error) {
+		b.AppendChannelMessage("internal",
+			model.NewTextMessage(model.RoleAssistant, "noise"))
+		b.AppendChannelMessage(engine.MainChannel,
+			model.NewTextMessage(model.RoleAssistant, "ok"))
+		return b, nil
+	})
+	res, err := agent.Run(context.Background(),
+		agent.Agent{ID: "x"}, eng, newReq("hi"))
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if res.Artifacts != nil {
+		t.Errorf("Artifacts = %+v, want nil (no opt-in)", res.Artifacts)
+	}
+}
+
+// TestRun_WithArtifactChannels_EmptyChannelDropped documents the
+// "no empty bundles" rule: channels that exist but hold zero
+// messages (or zero Parts across all messages) are silently
+// skipped so consumers can rely on `for _, a := range Artifacts`
+// always yielding renderable payload.
+func TestRun_WithArtifactChannels_EmptyChannelDropped(t *testing.T) {
+	eng := engine.EngineFunc(func(_ context.Context, _ engine.Run, _ engine.Host, b *engine.Board) (*engine.Board, error) {
+		b.AppendChannelMessage("populated",
+			model.NewTextMessage(model.RoleAssistant, "hello"))
+		b.AppendChannelMessage(engine.MainChannel,
+			model.NewTextMessage(model.RoleAssistant, "ok"))
+		return b, nil
+	})
+
+	res, err := agent.Run(context.Background(),
+		agent.Agent{ID: "x"}, eng, newReq("hi"),
+		agent.WithArtifactChannels("populated", "missing-channel"),
+	)
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if len(res.Artifacts) != 1 || res.Artifacts[0].Name != "populated" {
+		t.Fatalf("missing-channel should have been dropped, got %+v", res.Artifacts)
+	}
+}
+
+// TestRun_WithArtifactChannels_MainChannelSilentlySkipped documents
+// the explicit "MainChannel is not an artifact channel" rule. Run
+// already promotes MainChannel into Result.Messages; harvesting it
+// again would duplicate the same payload across two semantically
+// different fields (Messages keeps role + tool metadata; Artifacts
+// is the modality-bundle view).
+func TestRun_WithArtifactChannels_MainChannelSilentlySkipped(t *testing.T) {
+	eng := engine.EngineFunc(func(_ context.Context, _ engine.Run, _ engine.Host, b *engine.Board) (*engine.Board, error) {
+		b.AppendChannelMessage(engine.MainChannel,
+			model.NewTextMessage(model.RoleAssistant, "would-duplicate"))
+		return b, nil
+	})
+
+	res, err := agent.Run(context.Background(),
+		agent.Agent{ID: "x"}, eng, newReq("hi"),
+		agent.WithArtifactChannels(engine.MainChannel, ""),
+	)
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if res.Artifacts != nil {
+		t.Errorf("MainChannel + empty must be filtered out, got %+v", res.Artifacts)
+	}
+}
+
+// TestRun_WithArtifactChannels_AccumulatesAndDedupes confirms
+// per-agent / per-call composition: multiple WithArtifactChannels
+// calls accumulate so an Agent can declare the standard channels
+// once and individual callers can extend the list.
+func TestRun_WithArtifactChannels_AccumulatesAndDedupes(t *testing.T) {
+	eng := engine.EngineFunc(func(_ context.Context, _ engine.Run, _ engine.Host, b *engine.Board) (*engine.Board, error) {
+		b.AppendChannelMessage("a", model.NewTextMessage(model.RoleAssistant, "a-msg"))
+		b.AppendChannelMessage("b", model.NewTextMessage(model.RoleAssistant, "b-msg"))
+		b.AppendChannelMessage(engine.MainChannel,
+			model.NewTextMessage(model.RoleAssistant, "ok"))
+		return b, nil
+	})
+
+	res, err := agent.Run(context.Background(),
+		agent.Agent{ID: "x"}, eng, newReq("hi"),
+		agent.WithArtifactChannels("a"),
+		agent.WithArtifactChannels("a", "b"), // dup "a" must not double-emit
+	)
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if len(res.Artifacts) != 2 {
+		t.Fatalf("dedup failed: got %d artifacts (%+v)", len(res.Artifacts), res.Artifacts)
+	}
+	if res.Artifacts[0].Name != "a" || res.Artifacts[1].Name != "b" {
+		t.Errorf("registration-order broken: %+v", res.Artifacts)
+	}
+}

--- a/tests/e2e/vesseld/go.mod
+++ b/tests/e2e/vesseld/go.mod
@@ -64,17 +64,26 @@ require (
 // is mandatory.
 replace github.com/GizClaw/flowcraft/cmd/vesseld => ../../../cmd/vesseld
 
-// TEMPORARY (PR #96 — feat/engine-lifecycle-contracts): this PR
-// introduces new sdk + vessel APIs (engine.WithCapabilities,
-// vessel.Captain.Resume, …) that cmd/vesseld immediately consumes.
-// Because cmd/vesseld is replace-pinned to the local tree but
-// sdk + vessel are version-pinned, the e2e module would otherwise
+// TEMPORARY (rolling — last extended by feat/agent-run-funnel-and-
+// vessel-deps): each in-flight PR that introduces new sdk + vessel
+// APIs immediately consumed by cmd/vesseld carries this same
+// workaround. The pattern is necessary because cmd/vesseld is
+// replace-pinned to the local tree but sdk + vessel are
+// version-pinned — without these replaces the e2e module would
 // fail to build against the unreleased symbols.
 //
-// These two replaces relax the isolation policy for ONE PR; they
-// MUST be removed in a follow-up after sdk + vessel auto-tag
-// publishes the new versions and the `require` lines above are
-// bumped accordingly. Tracking removal: TODO(post-tag).
+// Currently active for:
+//   - sdk: depname.ToolAllowedNames (PR #98) and the new
+//     engine.Run.Deps reader path (this PR's vessel inline
+//     engine refactor).
+//   - vessel: vessel.Captain.Resume + Captain.* surface
+//     introduced in PR #96.
+//
+// These two replaces MUST be removed in the FIRST follow-up PR
+// that does NOT carry [skip-tag], so an sdk + vessel auto-tag
+// run can publish the accumulated changes and the `require`
+// lines above can be bumped accordingly. Tracking removal:
+// TODO(post-tag).
 replace github.com/GizClaw/flowcraft/sdk => ../../../sdk
 
 replace github.com/GizClaw/flowcraft/vessel => ../../../vessel


### PR DESCRIPTION
## Summary

Closes contract-audit Epics **C** (agent.Run 完整出口) and **D**
(vessel 字段迁移到 SDK 契约) — six issues in total:

| Issue | Status | Path |
|---|---|---|
| #3 ParentRunID never written | fixed | `WithParentRunID` promotes into `engine.Run.ParentRunID` |
| #6 Result.Artifacts always nil | fixed | `WithArtifactChannels` harvests at agent.Run exit |
| #8 Request.Extensions noise | deprecated | `// Deprecated`; v0.5.0 removal; migrate to `WithAttributes` |
| #9 ResumeFrom user entry | already fixed in #98 | (no-op here) |
| #11 vessel reads `catalog.Deps.AgentTools` instead of `engine.Run.Deps` | fixed | inline engine resolves from `engine.Run.Deps[depname.ToolAllowedNames]` with deprecated closure fallback |

`[skip-tag]` keeps auto-tag from publishing partial intermediate
sdk + vessel releases — same convention as PR #98. The
`tests/e2e/vesseld/go.mod` temporary `replace` directives carried
over from #98 stay (with refreshed comment) for the same reason.

## What ships, by commit

1. **`feat(agent): add WithParentRunID; promote into engine.Run.ParentRunID`**
   `engine.Run.ParentRunID` had zero writers since v0.1 — multi-agent
   call-chain loop / depth detection was advertised but unwirable.
   Adds the option, threads through `runConfig`, stamps onto every
   `engine.Run` the revise loop dispatches.

2. **`deprecate(agent): Request.Extensions; document WithAttributes as replacement`**
   `Request.Extensions` was `map[string]any` with no in-tree readers
   and an unresolvable type mismatch with `engine.Run.Attributes`
   (`map[string]string`). Marks it `Deprecated` with a v0.5.0
   removal target and points at the existing `WithAttributes`
   RunOption as the canonical replacement (uniform wire format,
   no per-host serialiser invention). Behaviour unchanged.

3. **`feat(agent): WithArtifactChannels harvests board channels into Result.Artifacts`**
   `Result.Artifacts` had been nil for every caller despite a v0.1
   godoc that promised harvesting. Adds the explicit
   `WithArtifactChannels(...string)` opt-in (auto-collect would
   leak engine-internal channels), `MainChannel`-skipping (already
   feeds `Result.Messages`), empty-bundle dropping, and per-Agent /
   per-call accumulation with dedup.

4. **`feat(vesseld): inline engine reads tool allow-list from engine.Run.Deps`**
   Moves `allowSet` resolution INTO the `EngineFunc` closure so it
   can read `engine.Run.Deps[depname.ToolAllowedNames]` (populated
   by agent.Run from `agent.Agent.Tools` — the canonical SDK path
   landed in #98). Falls back to the legacy
   `catalog.Deps.AgentTools` closure for callers that build vessel
   without driving through agent.Run. `RequiredDepNames` now
   declares `ToolAllowedNames` so agent.Run preflight /
   dashboards see the contract. `catalog.Deps.AgentTools` itself is
   marked `Deprecated` with a v0.5.0 removal target.

5. **`chore(tests/e2e/vesseld): refresh temp replace TODO for run-funnel PR`**
   Updates the rolling `replace` block comment so future readers see
   the currently-active in-flight symbols (was stuck on PR #96
   reference) and the explicit removal trigger ("first follow-up PR
   that does NOT carry `[skip-tag]`").

## Test plan

- [x] `go test ./sdk/... ./vessel/... ./cmd/vesseld/...` — all green
- [x] `cd tests/e2e/vesseld && GOWORK=off go test ./...` — all green
- [x] `gofmt -l sdk vessel cmd` — clean
- [x] **agent layer** new tests:
  - `TestRun_WithParentRunID_PropagatesToEngineRun` + `EmptyIsNoop`
  - `TestRun_WithArtifactChannels_HarvestsRegisteredChannels` /
    `DefaultIsNilArtifacts` / `EmptyChannelDropped` /
    `MainChannelSilentlySkipped` / `AccumulatesAndDedupes`
- [x] **vesseld inline engine** new tests:
  - `TestGraphLLM_RunDepsAllowedNamesOverridesAgentTools` — happy path
  - `TestGraphLLM_RunDepsEmptyAllowedNamesDeniesAll` — fail-closed
  - `TestGraphLLM_AbsentRunDepsKeyFallsBackToAgentTools` — back-compat
- [x] Existing `TestGraphLLM_AllowlistFiltersToolDefinitions` /
  `EmptyAllowlistDeniesAll` / `AllowlistEnforcedAtExecution` and the
  `tests/e2e/vesseld/allowlist_test.go` E2E still pass — proves the
  legacy closure path is intact.

## Out of scope (deliberate)

- **Cross-process ParentRunID propagation** (vessel / A2A bridge
  reading `agent.RunInfo.RunID` and stamping it as the next agent's
  parent). The field is now writable; producer wiring is a future
  PR blocked on the pod controller / dispatcher refactor.
- **Vessel-level vertical E2E exercising the new run.Deps path**
  end-to-end through the daemon. Vessel doesn't currently drive
  agent.Run — adding that integration is a larger architectural
  change (Epic G shape). Unit tests in `cmd/vesseld/catalog`
  fully cover the new code path; the legacy closure path E2E
  already proves no regression for the path daemon callers
  exercise today.
- **`Request.Extensions` removal** — deferred to v0.5.0 to give
  any external consumers one minor-version upgrade window.


Made with [Cursor](https://cursor.com)