### PR TITLE
[skip-tag] sdk,vessel,cmd/vesseld: rename actor_id -> agent_id end-to-end

### DIFF
--- a/cmd/vesseld/catalog/engine_graph_llm.go
+++ b/cmd/vesseld/catalog/engine_graph_llm.go
@@ -18,7 +18,17 @@ import (
 // hand-rolls run-level subjects. Centralising the construction
 // keeps run.start and run.end identical in shape so consumers
 // (vessel.Logs, /v1/vessels/{id}/logs) can treat them as a pair.
-func publishLifecycle(ctx context.Context, pub engine.Publisher, subject event.Subject, runID string, payload any) {
+// publishLifecycle stamps a run/step lifecycle envelope. agentID is
+// the executor identity (= deps.AgentName); it goes onto
+// HeaderAgentID so observers can fan-in by agent. The optional
+// stepKey carries the engine-private "what sub-unit inside this
+// agent run" suffix the inline engine builds (e.g. "iter5" for the
+// 6th iteration); it is ONLY used by the caller to assemble the
+// step subject segment via stepActor — it does not need a separate
+// envelope header because vessel inline does not have a graph node
+// dimension to surface. Empty agentID is allowed (degraded run-level
+// publish before the agent identity is known).
+func publishLifecycle(ctx context.Context, pub engine.Publisher, subject event.Subject, runID, agentID string, payload any) {
 	if pub == nil {
 		return
 	}
@@ -29,7 +39,28 @@ func publishLifecycle(ctx context.Context, pub engine.Publisher, subject event.S
 	if runID != "" {
 		env.SetRunID(runID)
 	}
+	if agentID != "" {
+		env.SetAgentID(agentID)
+	}
 	_ = pub.Publish(ctx, env)
+}
+
+// stepActor builds the engine.SubjectStep* segment for the inline
+// engine. Per the engine contract (sdk/engine/subjects.go), the
+// segment MUST start with the executing agent.id; vessel inline
+// appends ".iter<N>" as its engine-private sub-unit suffix. The
+// literal "." is collapsed to "_" by SubjectStep*'s SanitiseID, so
+// the resulting NATS segment is one flat token (e.g.
+// "researcher_iter3") — matching graph runner's "<agent>_node_<id>"
+// shape.
+func stepActor(agentID, stepKey string) string {
+	if stepKey == "" {
+		return agentID
+	}
+	if agentID == "" {
+		return stepKey
+	}
+	return agentID + "." + stepKey
 }
 
 // graphLLMEngineFactory builds the v0.1.0 default engine: a small
@@ -103,14 +134,14 @@ func graphLLMEngineFactory(ref string, cfg map[string]any, deps Deps) (engine.En
 	//     turns this into a fully run-deps-driven engine.
 	return engine.WithCapabilities(engine.EngineFunc(func(ctx context.Context, run engine.Run, host engine.Host, board *engine.Board) (*engine.Board, error) {
 		allowSet := resolveAllowSet(run, deps)
-		// actorID is the engine "actor" key used in step-level
-		// subjects. We use the agent name so SSE consumers can
-		// see "agent X started step Y" without having to consult
-		// a separate registry for an opaque node id. For the
-		// engine-contract subjects this maps to the
-		// engine.run.<runID>.step.<actorID>.{start,complete,error}
-		// shape (see sdk/engine/subjects.go).
-		actorID := deps.AgentName
+		// agentID is the executor identity (engine.HeaderAgentID
+		// on every envelope) and the prefix of every step subject
+		// segment (engine.SubjectStep*). We use the agent name so
+		// SSE consumers can see "agent X started step Y" without
+		// consulting a registry for an opaque id, matching the
+		// graph runner's behaviour where agent.Run promotes
+		// Agent.ID into engine.Run.Attributes.
+		agentID := deps.AgentName
 
 		// Lifecycle: run.started fires exactly once at entry,
 		// run.ended fires exactly once on exit (defer), regardless
@@ -119,9 +150,9 @@ func graphLLMEngineFactory(ref string, cfg map[string]any, deps Deps) (engine.En
 		// consumers can rely on the start/end pair existing for
 		// every Submit, mirroring sdk/graph/runner's behaviour
 		// even though we are an in-line executor.
-		publishLifecycle(ctx, host, engine.SubjectRunStart(run.ID), run.ID, map[string]any{
-			"vessel": deps.VesselID,
-			"agent":  deps.AgentName,
+		publishLifecycle(ctx, host, engine.SubjectRunStart(run.ID), run.ID, agentID, map[string]any{
+			"vessel":   deps.VesselID,
+			"agent_id": agentID,
 		})
 		var runErr error
 		defer func() {
@@ -133,7 +164,7 @@ func graphLLMEngineFactory(ref string, cfg map[string]any, deps Deps) (engine.En
 			if runErr != nil {
 				payload["error"] = runErr.Error()
 			}
-			publishLifecycle(ctx, host, engine.SubjectRunEnd(run.ID), run.ID, payload)
+			publishLifecycle(ctx, host, engine.SubjectRunEnd(run.ID), run.ID, agentID, payload)
 		}()
 
 		// Pull the current message stream from MainChannel; the
@@ -159,12 +190,28 @@ func graphLLMEngineFactory(ref string, cfg map[string]any, deps Deps) (engine.En
 			// inside the SAME step; that keeps the step.start /
 			// step.complete pair anchored to "one model turn"
 			// rather than fragmenting across each tool call.
-			stepActor := fmt.Sprintf("%s.iter%d", actorID, iter)
-			publishLifecycle(ctx, host, engine.SubjectStepStart(run.ID, stepActor), run.ID, map[string]any{
-				"actor_id":  stepActor,
-				"iteration": iter,
-				"kind":      "llm",
-			})
+			stepKey := fmt.Sprintf("iter%d", iter)
+			step := stepActor(agentID, stepKey)
+			// step_actor is duplicated in payload because the
+			// stepActor segment is collapsed into one NATS token
+			// by SanitiseID — payload subscribers that only see
+			// envelope.Subject can still recover the original
+			// "<agent>.<stepKey>" form.
+			stepPayload := func(extra map[string]any) map[string]any {
+				out := map[string]any{
+					"agent_id":   agentID,
+					"step_actor": step,
+					"step_key":   stepKey,
+					"iteration":  iter,
+				}
+				for k, v := range extra {
+					out[k] = v
+				}
+				return out
+			}
+			publishLifecycle(ctx, host, engine.SubjectStepStart(run.ID, step), run.ID, agentID, stepPayload(map[string]any{
+				"kind": "llm",
+			}))
 
 			// Honour the daemon-wide LLM rate limit before each
 			// Generate call. v0.1.0 only enforces the requests-
@@ -174,9 +221,9 @@ func graphLLMEngineFactory(ref string, cfg map[string]any, deps Deps) (engine.En
 			if limiter != nil {
 				if err := limiter.Acquire(ctx, deps.VesselID, 0); err != nil {
 					runErr = fmt.Errorf("graph-llm[%s/%s]: rate limit acquire iter=%d: %w", deps.VesselID, deps.AgentName, iter, err)
-					publishLifecycle(ctx, host, engine.SubjectStepError(run.ID, stepActor), run.ID, map[string]any{
-						"actor_id": stepActor, "error": runErr.Error(),
-					})
+					publishLifecycle(ctx, host, engine.SubjectStepError(run.ID, step), run.ID, agentID, stepPayload(map[string]any{
+						"error": runErr.Error(),
+					}))
 					return board, runErr
 				}
 			}
@@ -184,21 +231,21 @@ func graphLLMEngineFactory(ref string, cfg map[string]any, deps Deps) (engine.En
 			if len(toolDefs) > 0 {
 				opts = append(opts, llm.WithTools(toolDefs...))
 			}
-			reply, err := streamLLMRound(ctx, host, run.ID, stepActor, client, msgs, opts)
+			reply, err := streamLLMRound(ctx, host, run.ID, step, client, msgs, opts)
 			if err != nil {
 				runErr = fmt.Errorf("graph-llm[%s/%s]: generate iter=%d: %w", deps.VesselID, deps.AgentName, iter, err)
-				publishLifecycle(ctx, host, engine.SubjectStepError(run.ID, stepActor), run.ID, map[string]any{
-					"actor_id": stepActor, "error": runErr.Error(),
-				})
+				publishLifecycle(ctx, host, engine.SubjectStepError(run.ID, step), run.ID, agentID, stepPayload(map[string]any{
+					"error": runErr.Error(),
+				}))
 				return board, runErr
 			}
 			msgs = append(msgs, reply)
 			board.AppendChannelMessage(engine.MainChannel, reply)
 
 			if !reply.HasToolCalls() {
-				publishLifecycle(ctx, host, engine.SubjectStepComplete(run.ID, stepActor), run.ID, map[string]any{
-					"actor_id": stepActor, "final": true,
-				})
+				publishLifecycle(ctx, host, engine.SubjectStepComplete(run.ID, step), run.ID, agentID, stepPayload(map[string]any{
+					"final": true,
+				}))
 				return board, nil
 			}
 
@@ -208,7 +255,7 @@ func graphLLMEngineFactory(ref string, cfg map[string]any, deps Deps) (engine.En
 			results := make([]model.ToolResult, 0, len(reply.ToolCalls()))
 			for _, call := range reply.ToolCalls() {
 				out, terr := executeToolCall(ctx, deps, allowSet, call)
-				_ = engine.EmitStreamToolResult(ctx, host, run.ID, stepActor, call.ID, call.Name, out, terr != nil, false)
+				_ = engine.EmitStreamToolResult(ctx, host, run.ID, step, call.ID, call.Name, out, terr != nil, false)
 				results = append(results, model.ToolResult{
 					ToolCallID: call.ID,
 					Content:    out,
@@ -218,10 +265,9 @@ func graphLLMEngineFactory(ref string, cfg map[string]any, deps Deps) (engine.En
 			toolMsg := model.NewToolResultMessage(results)
 			msgs = append(msgs, toolMsg)
 			board.AppendChannelMessage(engine.MainChannel, toolMsg)
-			publishLifecycle(ctx, host, engine.SubjectStepComplete(run.ID, stepActor), run.ID, map[string]any{
-				"actor_id":   stepActor,
+			publishLifecycle(ctx, host, engine.SubjectStepComplete(run.ID, step), run.ID, agentID, stepPayload(map[string]any{
 				"tool_calls": len(reply.ToolCalls()),
-			})
+			}))
 		}
 		runErr = errdefs.Conflictf("graph-llm[%s/%s]: max iterations (%d) reached without final answer", deps.VesselID, deps.AgentName, maxIter)
 		return board, runErr
@@ -246,7 +292,7 @@ func graphLLMEngineFactory(ref string, cfg map[string]any, deps Deps) (engine.En
 func streamLLMRound(
 	ctx context.Context,
 	host engine.Host,
-	runID, actorID string,
+	runID, stepActor string,
 	client llm.LLM,
 	msgs []model.Message,
 	opts []llm.GenerateOption,
@@ -263,7 +309,7 @@ func streamLLMRound(
 		if gerr != nil {
 			return reply, gerr
 		}
-		_ = engine.EmitStreamToken(ctx, host, runID, actorID, reply.Content())
+		_ = engine.EmitStreamToken(ctx, host, runID, stepActor, reply.Content())
 		return reply, nil
 	}
 	defer stream.Close()
@@ -271,10 +317,10 @@ func streamLLMRound(
 	for stream.Next() {
 		chunk := stream.Current()
 		if chunk.Content != "" {
-			_ = engine.EmitStreamToken(ctx, host, runID, actorID, chunk.Content)
+			_ = engine.EmitStreamToken(ctx, host, runID, stepActor, chunk.Content)
 		}
 		for _, tc := range chunk.ToolCalls {
-			_ = engine.EmitStreamToolCall(ctx, host, runID, actorID, tc.ID, tc.Name, tc.Arguments)
+			_ = engine.EmitStreamToolCall(ctx, host, runID, stepActor, tc.ID, tc.Name, tc.Arguments)
 		}
 	}
 	if serr := stream.Err(); serr != nil {

--- a/sdk/agent/run.go
+++ b/sdk/agent/run.go
@@ -13,6 +13,7 @@ import (
 	"github.com/GizClaw/flowcraft/sdk/engine/depname"
 	"github.com/GizClaw/flowcraft/sdk/errdefs"
 	"github.com/GizClaw/flowcraft/sdk/model"
+	"github.com/GizClaw/flowcraft/sdk/telemetry"
 )
 
 // Run executes one turn of ag against eng with the given req.
@@ -419,21 +420,25 @@ func promoteAgentTools(callerDeps *engine.Dependencies, agentTools []string) *en
 }
 
 // mergeAttributes combines RunOption-supplied attributes with the
-// well-known agent / task / context ids. Keys explicitly set by the
-// caller win — agent never overwrites.
+// well-known agent / run / task / conversation ids. Keys explicitly
+// set by the caller win — agent never overwrites.
 //
-// Key names live in runinfo_attrs.go and stay private to this
-// package; downstream readers go through [RunInfoFromAttributes] so
-// the wire format can be migrated without sweeping the codebase.
+// The wire format is the canonical OpenTelemetry-style dot-key set
+// defined in sdk/telemetry/attrs.go. Downstream readers go through
+// [RunInfoFromAttributes] (RunInfo recovery) or read
+// telemetry.Attr* directly (executor actor_id resolution,
+// observers, dashboards) — there is one canonical key set, so the
+// agent → engine → executor → envelope hand-off does not need a
+// per-layer translation table.
 func mergeAttributes(extra map[string]string, req Request, ag Agent, runID string) map[string]string {
 	out := make(map[string]string, len(extra)+4)
-	out[attrAgentID] = ag.ID
-	out[attrRunID] = runID
+	out[telemetry.AttrAgentID] = ag.ID
+	out[telemetry.AttrRunID] = runID
 	if req.TaskID != "" {
-		out[attrTaskID] = req.TaskID
+		out[telemetry.AttrTaskID] = req.TaskID
 	}
 	if req.ContextID != "" {
-		out[attrContextID] = req.ContextID
+		out[telemetry.AttrConversationID] = req.ContextID
 	}
 	for k, v := range extra {
 		out[k] = v

--- a/sdk/agent/run.go
+++ b/sdk/agent/run.go
@@ -426,7 +426,7 @@ func promoteAgentTools(callerDeps *engine.Dependencies, agentTools []string) *en
 // The wire format is the canonical OpenTelemetry-style dot-key set
 // defined in sdk/telemetry/attrs.go. Downstream readers go through
 // [RunInfoFromAttributes] (RunInfo recovery) or read
-// telemetry.Attr* directly (executor actor_id resolution,
+// telemetry.Attr* directly (executor agent_id resolution,
 // observers, dashboards) — there is one canonical key set, so the
 // agent → engine → executor → envelope hand-off does not need a
 // per-layer translation table.

--- a/sdk/agent/run_test.go
+++ b/sdk/agent/run_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/GizClaw/flowcraft/sdk/engine/depname"
 	"github.com/GizClaw/flowcraft/sdk/errdefs"
 	"github.com/GizClaw/flowcraft/sdk/model"
+	"github.com/GizClaw/flowcraft/sdk/telemetry"
 )
 
 // completedEngine appends a single assistant reply and returns nil.
@@ -110,7 +111,7 @@ func TestRun_AttributesContainWellKnownKeys(t *testing.T) {
 	req.RunID = "run-1"
 
 	_, err := agent.Run(context.Background(), agent.Agent{ID: "agent-x"}, eng, req,
-		agent.WithAttributes(map[string]string{"tenant": "acme", "agent_id": "caller-overrides"}),
+		agent.WithAttributes(map[string]string{"tenant": "acme", telemetry.AttrAgentID: "caller-overrides"}),
 	)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -118,13 +119,16 @@ func TestRun_AttributesContainWellKnownKeys(t *testing.T) {
 
 	// Caller-supplied keys win on conflict — that's the documented
 	// rule on mergeAttributes ("agent never overwrites" = the
-	// well-known seed never overwrites caller intent).
+	// well-known seed never overwrites caller intent). Keys are the
+	// canonical sdk/telemetry dot-key format so executor /
+	// dashboards can resolve them without an agent-private lookup
+	// table.
 	want := map[string]string{
-		"agent_id":   "caller-overrides",
-		"run_id":     "run-1",
-		"task_id":    "task-1",
-		"context_id": "ctx-1",
-		"tenant":     "acme",
+		telemetry.AttrAgentID:        "caller-overrides",
+		telemetry.AttrRunID:          "run-1",
+		telemetry.AttrTaskID:         "task-1",
+		telemetry.AttrConversationID: "ctx-1",
+		"tenant":                     "acme",
 	}
 	for k, v := range want {
 		if got[k] != v {

--- a/sdk/agent/runinfo_attrs.go
+++ b/sdk/agent/runinfo_attrs.go
@@ -1,30 +1,24 @@
 package agent
 
+import "github.com/GizClaw/flowcraft/sdk/telemetry"
+
 // runinfo_attrs.go owns the contract between [Run] (which promotes
 // per-call identity into [engine.Run.Attributes]) and downstream
 // readers that need to reconstruct a [RunInfo] from those attributes.
 //
-// The string keys are deliberately kept private to the agent package:
-// callers never type the key strings themselves; they go through
-// [RunInfoFromAttributes] (read side) or rely on Run's promotion (write
-// side). That way migrating the wire format (e.g. switching to
-// telemetry.Attr* canonical dot-keys) is a one-edit change here, not a
-// codebase-wide grep-and-replace.
-const (
-	// attrAgentID — agent.Agent.ID promoted by Run into engine.Run.Attributes.
-	attrAgentID = "agent_id"
-
-	// attrRunID — the engine.Run.ID promoted by Run. Engines that key
-	// telemetry off engine.Run.ID directly do NOT need to read this;
-	// it exists so a node looking at engine.Run.Attributes alone can
-	// recover the full RunInfo without consulting engine.Run.
-	attrRunID = "run_id"
-
-	// attrTaskID / attrContextID — Request.TaskID / Request.ContextID
-	// (A2A-aligned identifiers) promoted by Run when non-empty.
-	attrTaskID    = "task_id"
-	attrContextID = "context_id"
-)
+// The wire format is the canonical OpenTelemetry-style dot-key set
+// defined in sdk/telemetry/attrs.go (AttrAgentID, AttrRunID,
+// AttrTaskID, AttrConversationID). Routing identity through the
+// telemetry catalog instead of agent-private snake_case constants
+// gives downstream consumers (executor actor_id resolver, dashboards,
+// future sdk/pod controller) one canonical key set to filter on,
+// closing the contract-audit #15 gap where the executor had no
+// process-portable channel for agent.id.
+//
+// The mapping ContextID → AttrConversationID reflects A2A semantics:
+// "context" / "conversation" name the same thread-of-interaction
+// scope; collapsing onto one canonical key avoids dashboard joins
+// having to know about both spellings.
 
 // RunInfoFromAttributes reconstructs a [RunInfo] from the
 // engine.Run.Attributes map [Run] populates on every attempt. runID
@@ -51,9 +45,9 @@ const (
 // engine.Run.Attributes.
 func RunInfoFromAttributes(runID string, attrs map[string]string) RunInfo {
 	return RunInfo{
-		AgentID:   attrs[attrAgentID],
+		AgentID:   attrs[telemetry.AttrAgentID],
 		RunID:     runID,
-		TaskID:    attrs[attrTaskID],
-		ContextID: attrs[attrContextID],
+		TaskID:    attrs[telemetry.AttrTaskID],
+		ContextID: attrs[telemetry.AttrConversationID],
 	}
 }

--- a/sdk/agent/runinfo_attrs.go
+++ b/sdk/agent/runinfo_attrs.go
@@ -10,7 +10,7 @@ import "github.com/GizClaw/flowcraft/sdk/telemetry"
 // defined in sdk/telemetry/attrs.go (AttrAgentID, AttrRunID,
 // AttrTaskID, AttrConversationID). Routing identity through the
 // telemetry catalog instead of agent-private snake_case constants
-// gives downstream consumers (executor actor_id resolver, dashboards,
+// gives downstream consumers (executor agent_id resolver, dashboards,
 // future sdk/pod controller) one canonical key set to filter on,
 // closing the contract-audit #15 gap where the executor had no
 // process-portable channel for agent.id.

--- a/sdk/agent/runinfo_attrs_test.go
+++ b/sdk/agent/runinfo_attrs_test.go
@@ -58,7 +58,7 @@ func TestRunInfoFromAttributes_MissingKeys(t *testing.T) {
 // TestMergeAttributes_WriteSideUsesTelemetryDotKeys pins the wire
 // format on the write side. Migrating off snake_case "agent_id" /
 // "run_id" / "task_id" / "context_id" was the precondition for the
-// executor reading actor_id from engine.Run.Attributes (contract-
+// executor reading agent_id from engine.Run.Attributes (contract-
 // audit #15): the executor — across module boundaries — has no
 // access to agent-private constants, so the keys MUST live in
 // sdk/telemetry where every layer can reference them.

--- a/sdk/agent/runinfo_attrs_test.go
+++ b/sdk/agent/runinfo_attrs_test.go
@@ -2,6 +2,8 @@ package agent
 
 import (
 	"testing"
+
+	"github.com/GizClaw/flowcraft/sdk/telemetry"
 )
 
 // TestRunInfoFromAttributes_RoundTrip asserts the
@@ -53,6 +55,43 @@ func TestRunInfoFromAttributes_MissingKeys(t *testing.T) {
 	}
 }
 
+// TestMergeAttributes_WriteSideUsesTelemetryDotKeys pins the wire
+// format on the write side. Migrating off snake_case "agent_id" /
+// "run_id" / "task_id" / "context_id" was the precondition for the
+// executor reading actor_id from engine.Run.Attributes (contract-
+// audit #15): the executor — across module boundaries — has no
+// access to agent-private constants, so the keys MUST live in
+// sdk/telemetry where every layer can reference them.
+//
+// If anyone reverts to snake_case in mergeAttributes, this test
+// turns red and the executor's actorIDFor lookup silently breaks.
+func TestMergeAttributes_WriteSideUsesTelemetryDotKeys(t *testing.T) {
+	attrs := mergeAttributes(nil,
+		Request{TaskID: "task-1", ContextID: "conv-1"},
+		Agent{ID: "agent-x"}, "run-1")
+
+	wantKeys := map[string]string{
+		telemetry.AttrAgentID:        "agent-x",
+		telemetry.AttrRunID:          "run-1",
+		telemetry.AttrTaskID:         "task-1",
+		telemetry.AttrConversationID: "conv-1",
+	}
+	for k, want := range wantKeys {
+		if got := attrs[k]; got != want {
+			t.Errorf("Attributes[%q] = %q, want %q", k, got, want)
+		}
+	}
+
+	// Snake_case legacy keys MUST NOT leak — they would dilute the
+	// canonical-key dashboard joins and re-introduce the dual-format
+	// trap the migration was designed to remove.
+	for _, legacy := range []string{"agent_id", "run_id", "task_id", "context_id"} {
+		if _, ok := attrs[legacy]; ok {
+			t.Errorf("legacy snake_case key %q must not be set after migration; got %v", legacy, attrs)
+		}
+	}
+}
+
 // TestRunInfoFromAttributes_RunIDArgWinsOverAttribute asserts the
 // caller-supplied runID overrides any attribute copy. ExecutionContext
 // exposes RunID as a dedicated field separate from Attributes; the
@@ -60,8 +99,8 @@ func TestRunInfoFromAttributes_MissingKeys(t *testing.T) {
 // (e.g. cloned across attempts) cannot poison observers.
 func TestRunInfoFromAttributes_RunIDArgWinsOverAttribute(t *testing.T) {
 	attrs := map[string]string{
-		attrAgentID: "a",
-		attrRunID:   "stale-run-id",
+		telemetry.AttrAgentID: "a",
+		telemetry.AttrRunID:   "stale-run-id",
 	}
 	got := RunInfoFromAttributes("authoritative-run-id", attrs)
 	if got.RunID != "authoritative-run-id" {

--- a/sdk/engine/stream_emit.go
+++ b/sdk/engine/stream_emit.go
@@ -28,10 +28,8 @@ import (
 // host built with NoopHost{}) keeps running.
 
 // EmitStreamToken publishes one assistant-token delta on the canonical
-// stream subject. The payload is a [StreamDeltaPayload] of type
-// [StreamDeltaToken] with Content set; runID and actorID feed the
-// subject builder so any consumer subscribed via [PatternRunStream]
-// observes it.
+// stream subject. See [EmitStreamDelta] for the stepActor format
+// requirement.
 //
 // Use this from any node that produces incremental textual output —
 // for example a custom RAG retriever streaming its working notes, or a
@@ -39,8 +37,8 @@ import (
 // be empty (callers that want "still alive" heartbeats should typically
 // mark them differently); empty content is published as-is so the
 // helper stays predictable.
-func EmitStreamToken(ctx context.Context, pub Publisher, runID, actorID, content string) error {
-	return EmitStreamDelta(ctx, pub, runID, actorID, StreamDeltaPayload{
+func EmitStreamToken(ctx context.Context, pub Publisher, runID, stepActor, content string) error {
+	return EmitStreamDelta(ctx, pub, runID, stepActor, StreamDeltaPayload{
 		Type:    StreamDeltaToken,
 		Content: content,
 	})
@@ -50,19 +48,20 @@ func EmitStreamToken(ctx context.Context, pub Publisher, runID, actorID, content
 // required (consumers correlate the eventual tool_result by ID); args
 // is the tool input the model produced and may be either a JSON string
 // or an already-decoded map / slice — both are valid per the
-// [StreamDeltaPayload] contract.
+// [StreamDeltaPayload] contract. See [EmitStreamDelta] for the
+// stepActor format requirement.
 //
 // The helper validates the required fields up-front and returns a
 // descriptive error instead of publishing a malformed envelope; callers
 // that already validated upstream can ignore the error safely.
-func EmitStreamToolCall(ctx context.Context, pub Publisher, runID, actorID, id, name string, args any) error {
+func EmitStreamToolCall(ctx context.Context, pub Publisher, runID, stepActor, id, name string, args any) error {
 	if id == "" {
 		return fmt.Errorf("engine: EmitStreamToolCall: id is required")
 	}
 	if name == "" {
 		return fmt.Errorf("engine: EmitStreamToolCall: name is required")
 	}
-	return EmitStreamDelta(ctx, pub, runID, actorID, StreamDeltaPayload{
+	return EmitStreamDelta(ctx, pub, runID, stepActor, StreamDeltaPayload{
 		Type:      StreamDeltaToolCall,
 		ID:        id,
 		Name:      name,
@@ -75,12 +74,13 @@ func EmitStreamToolCall(ctx context.Context, pub Publisher, runID, actorID, id, 
 // tool_call); name is recommended so consumers can render the result
 // without a separate dispatch table. isError marks unsuccessful
 // results; cancelled marks synthesised cancellations emitted when the
-// round was interrupted before the call dispatched.
-func EmitStreamToolResult(ctx context.Context, pub Publisher, runID, actorID, toolCallID, name, content string, isError, cancelled bool) error {
+// round was interrupted before the call dispatched. See
+// [EmitStreamDelta] for the stepActor format requirement.
+func EmitStreamToolResult(ctx context.Context, pub Publisher, runID, stepActor, toolCallID, name, content string, isError, cancelled bool) error {
 	if toolCallID == "" {
 		return fmt.Errorf("engine: EmitStreamToolResult: toolCallID is required")
 	}
-	return EmitStreamDelta(ctx, pub, runID, actorID, StreamDeltaPayload{
+	return EmitStreamDelta(ctx, pub, runID, stepActor, StreamDeltaPayload{
 		Type:       StreamDeltaToolResult,
 		ToolCallID: toolCallID,
 		Name:       name,
@@ -98,25 +98,34 @@ func EmitStreamToolResult(ctx context.Context, pub Publisher, runID, actorID, to
 // [DecodeStreamDelta] on the consumer side, so a malformed delta is
 // caught at publish time instead of silently flowing to subscribers.
 //
-// runID and actorID feed the subject builder; both are sanitised by
-// [SanitiseID] so caller-supplied IDs cannot fragment the resulting
-// subject. The envelope is stamped with HeaderRunID, HeaderActorID and
-// (for parity with the executor) HeaderNodeID = actorID so subscribers
-// that filter on headers behave identically whether the delta came
-// from a built-in node or a custom emitter.
+// stepActor follows the contract documented at the top of subjects.go:
+// it MUST start with the executing agent.id (so [PatternRunAgentStream]
+// can fan-in by agent) and MAY append an engine-private suffix
+// (graph runner: ".node.<nodeID>"; vessel inline: ".iter<N>"). Both
+// runID and stepActor are sanitised by [SanitiseID] so caller-supplied
+// values cannot fragment the resulting subject.
+//
+// The envelope is stamped with HeaderRunID. The agent identifier is
+// derived from the stepActor segment ahead of any optional ".node." /
+// ".iter" suffix — it goes onto HeaderAgentID (and the legacy
+// HeaderActorID via [event.Envelope.SetAgentID] dual-write). For
+// header-routed subscribers that key off the node id, the
+// HeaderNodeID is populated whenever stepActor carries the
+// graph runner's "<agent>.node.<nodeID>" form so the two transports
+// stay aligned.
 //
 // Publish errors are returned to the caller (unlike the executor's
 // fire-and-forget convention) so node authors can decide whether to
 // retry or surface the failure; in practice most callers just discard
 // the error because stream deltas are observability, not control flow.
-func EmitStreamDelta(ctx context.Context, pub Publisher, runID, actorID string, payload StreamDeltaPayload) error {
+func EmitStreamDelta(ctx context.Context, pub Publisher, runID, stepActor string, payload StreamDeltaPayload) error {
 	if pub == nil {
 		return nil
 	}
 	if err := validateStreamDelta(payload); err != nil {
 		return err
 	}
-	subject := SubjectStreamDelta(runID, actorID)
+	subject := SubjectStreamDelta(runID, stepActor)
 	env, err := event.NewEnvelope(ctx, subject, payload)
 	if err != nil {
 		return err
@@ -124,16 +133,33 @@ func EmitStreamDelta(ctx context.Context, pub Publisher, runID, actorID string, 
 	if runID != "" {
 		env.SetRunID(runID)
 	}
-	if actorID != "" {
-		env.SetActorID(actorID)
-		// HeaderNodeID is set in addition to HeaderActorID for
-		// header-routed subscribers that key off the node. Inside the
-		// graph runner the two values coincide; custom emitters MAY
-		// pass a distinct nodeID by populating Headers themselves
-		// before publishing.
-		env.SetNodeID(actorID)
+	agentID, nodeID := splitStepActor(stepActor)
+	if agentID != "" {
+		env.SetAgentID(agentID)
+	}
+	if nodeID != "" {
+		env.SetNodeID(nodeID)
 	}
 	return pub.Publish(ctx, env)
+}
+
+// splitStepActor extracts the agent.id prefix and the optional graph
+// runner ".node.<nodeID>" suffix from a stepActor string. Returns
+// (stepActor, "") when no recognised suffix is present, so engines
+// that use a different suffix scheme (e.g. vessel inline's ".iter<N>")
+// only get the agent.id projected onto HeaderAgentID and rely on
+// other facilities for the rest.
+//
+// Kept private because the suffix vocabulary is not part of any
+// consumer-facing contract — only the agent.id prefix is.
+func splitStepActor(stepActor string) (agentID, nodeID string) {
+	const nodeSep = ".node."
+	for i := 0; i+len(nodeSep) <= len(stepActor); i++ {
+		if stepActor[i:i+len(nodeSep)] == nodeSep {
+			return stepActor[:i], stepActor[i+len(nodeSep):]
+		}
+	}
+	return stepActor, ""
 }
 
 // validateStreamDelta mirrors the per-Type field requirements

--- a/sdk/engine/stream_emit_test.go
+++ b/sdk/engine/stream_emit_test.go
@@ -22,21 +22,32 @@ func (c *capturePublisher) Publish(_ context.Context, env event.Envelope) error 
 func TestEmitStreamToken_HappyPath(t *testing.T) {
 	t.Parallel()
 	pub := &capturePublisher{}
-	if err := EmitStreamToken(context.Background(), pub, "run-1", "node-A", "hello"); err != nil {
+	const stepActor = "agent-A.node.node-1"
+	if err := EmitStreamToken(context.Background(), pub, "run-1", stepActor, "hello"); err != nil {
 		t.Fatalf("EmitStreamToken: %v", err)
 	}
 	if len(pub.got) != 1 {
 		t.Fatalf("publish count = %d, want 1", len(pub.got))
 	}
 	env := pub.got[0]
-	if env.Subject != SubjectStreamDelta("run-1", "node-A") {
+	if env.Subject != SubjectStreamDelta("run-1", stepActor) {
 		t.Fatalf("subject = %s", env.Subject)
 	}
 	if env.Headers[event.HeaderRunID] != "run-1" {
 		t.Fatalf("HeaderRunID missing: %v", env.Headers)
 	}
-	if env.Headers[event.HeaderActorID] != "node-A" || env.Headers[event.HeaderNodeID] != "node-A" {
-		t.Fatalf("Actor / Node header mismatch: %v", env.Headers)
+	// stepActor is split into the agent.id prefix + the optional
+	// ".node.<nodeID>" suffix; the helper projects them onto
+	// HeaderAgentID / HeaderNodeID respectively. HeaderActorID is the
+	// legacy mirror written by SetAgentID's dual-write.
+	if got := env.Headers[event.HeaderAgentID]; got != "agent-A" {
+		t.Errorf("HeaderAgentID = %q, want agent-A", got)
+	}
+	if got := env.Headers[event.HeaderNodeID]; got != "node-1" {
+		t.Errorf("HeaderNodeID = %q, want node-1", got)
+	}
+	if got := env.Headers[event.HeaderActorID]; got != "agent-A" {
+		t.Errorf("HeaderActorID (legacy mirror) = %q, want agent-A", got)
 	}
 	p, err := DecodeStreamDelta(env)
 	if err != nil {
@@ -44,6 +55,29 @@ func TestEmitStreamToken_HappyPath(t *testing.T) {
 	}
 	if p.Type != StreamDeltaToken || p.Content != "hello" {
 		t.Fatalf("payload = %+v", p)
+	}
+}
+
+// TestEmitStreamDelta_StepActorWithoutNodeSuffix documents that
+// engines whose step convention is NOT graph-runner-shaped (e.g.
+// vessel inline's "<agent>.iter<N>") still get HeaderAgentID
+// populated correctly — splitStepActor returns the whole stepActor
+// as the agent.id prefix when no ".node." marker is present, and
+// leaves HeaderNodeID unset so the header doesn't accidentally
+// claim a node id that does not exist.
+func TestEmitStreamDelta_StepActorWithoutNodeSuffix(t *testing.T) {
+	t.Parallel()
+	pub := &capturePublisher{}
+	if err := EmitStreamDelta(context.Background(), pub, "r", "agent-A.iter3",
+		StreamDeltaPayload{Type: StreamDeltaToken, Content: "x"}); err != nil {
+		t.Fatalf("EmitStreamDelta: %v", err)
+	}
+	env := pub.got[0]
+	if got := env.Headers[event.HeaderAgentID]; got != "agent-A.iter3" {
+		t.Errorf("HeaderAgentID = %q, want agent-A.iter3 (no .node. suffix → whole stepActor is prefix)", got)
+	}
+	if _, ok := env.Headers[event.HeaderNodeID]; ok {
+		t.Errorf("HeaderNodeID should be unset when stepActor has no .node. suffix, got %q", env.Headers[event.HeaderNodeID])
 	}
 }
 

--- a/sdk/engine/subjects.go
+++ b/sdk/engine/subjects.go
@@ -44,24 +44,25 @@ import (
 //
 // "step" is the engine-neutral name for one unit of work in a run.
 // "stepActor" identifies one such unit; it MUST start with the
-// agent.id of the executing agent so observers can fan-in by agent
-// using the [PatternRunAgentSteps] / [PatternRunAgentStream]
-// wildcards. An engine implementation MAY append an engine-private
+// agent.id of the executing agent and MAY append an engine-private
 // suffix to disambiguate units within the same agent run:
 //
 //   - graph runner: "<agent.id>.node.<node id>"
 //   - vessel inline: "<agent.id>.iter<N>"
 //   - script engine (future): "<agent.id>.stmt<N>"
 //
-// The agent.id prefix is the contract; the suffix is the engine's
-// own dimension and not standardised here. Engines are responsible
-// for keeping the value dot/wildcard-free (use [SanitiseID]).
-//
-// stepActor is distinct from the envelope's [event.HeaderAgentID]
-// header (= the bare agent.id, no suffix). The header is the routing
-// key for "which agent produced this"; the subject segment is the
-// routing key for "which step of that agent". Both ride on the same
-// envelope.
+// Engines are responsible for keeping the value dot/wildcard-free
+// (use [SanitiseID]); SanitiseID also collapses any literal '.'
+// inside the suffix into '_', so the resulting NATS segment is one
+// flat token (e.g. "<agent>_node_<node>") rather than separate
+// segments. This means agent-level fan-in via NATS subject
+// wildcards is NOT supported on the bare segment — it would require
+// schema-revising "step" into multiple segments, which the engine
+// contract avoids to keep the wildcard surface stable. Consumers
+// that want "show me only agent X's events" filter on the
+// [event.HeaderAgentID] envelope header instead — that header is
+// stamped by every engine alongside the subject and survives the
+// segment collapse.
 //
 // "stream" is intentionally a sibling of "step" rather than a child:
 // consumers that only care about LLM token / tool deltas (voice TTS,
@@ -94,10 +95,12 @@ func SubjectRunEnd(runID string) event.Subject {
 
 // SubjectStepStart returns the subject every engine MUST publish when
 // it begins executing one step. stepActor identifies the unit of
-// work; it MUST start with the executing agent.id so the
-// [PatternRunAgentSteps] wildcard fans-in cleanly. See the file
-// header for the per-engine suffix conventions (graph: ".node.<id>";
-// vessel inline: ".iter<N>").
+// work; it MUST start with the executing agent.id (so consumers can
+// reconstruct the agent identity from the subject when the envelope
+// header is unavailable). See the file header for the per-engine
+// suffix conventions (graph: ".node.<id>"; vessel inline:
+// ".iter<N>") and for why agent-level NATS wildcard fan-in goes
+// through the [event.HeaderAgentID] header instead of the subject.
 //
 //	engine.run.<runID>.step.<stepActor>.start
 func SubjectStepStart(runID, stepActor string) event.Subject {
@@ -168,36 +171,16 @@ func PatternRunSteps(runID string) event.Pattern {
 // delta of one run. Use this when you want LLM token / tool deltas but
 // not the step lifecycle events.
 //
+// Agent-level fan-in ("only agent X's events in this run") is NOT
+// available as a NATS wildcard because the stepActor segment is
+// collapsed into one token by [SanitiseID] (see the file header).
+// Consumers route by agent through the [event.HeaderAgentID]
+// envelope header instead — subscribe with PatternRun(runID) and
+// filter on env.AgentID() in the consumer.
+//
 //	engine.run.<runID>.stream.>
 func PatternRunStream(runID string) event.Pattern {
 	return event.Pattern(fmt.Sprintf("%s%s.stream.>", SubjectPrefix, SanitiseID(runID)))
-}
-
-// PatternRunAgentSteps returns the wildcard pattern matching every
-// step lifecycle event produced by one agent inside one run. Relies
-// on the stepActor convention documented in this file's header: the
-// segment MUST start with agent.id, so the wildcard
-// engine.run.<runID>.step.<agentID>.> picks up every per-engine
-// suffix (graph "<agentID>.node.<id>", vessel "<agentID>.iter<N>",
-// …).
-//
-//	engine.run.<runID>.step.<agentID>.>
-//
-// In multi-agent vessel mode this is the canonical "show me only
-// agent X's events in run R" subscription — it complements the
-// envelope-header path (filter by HeaderAgentID) for subscribers
-// that route on subject alone.
-func PatternRunAgentSteps(runID, agentID string) event.Pattern {
-	return event.Pattern(fmt.Sprintf("%s%s.step.%s.>", SubjectPrefix, SanitiseID(runID), SanitiseID(agentID)))
-}
-
-// PatternRunAgentStream is the stream-side counterpart of
-// [PatternRunAgentSteps]: every stream delta produced by one agent
-// inside one run.
-//
-//	engine.run.<runID>.stream.<agentID>.>
-func PatternRunAgentStream(runID, agentID string) event.Pattern {
-	return event.Pattern(fmt.Sprintf("%s%s.stream.%s.>", SubjectPrefix, SanitiseID(runID), SanitiseID(agentID)))
 }
 
 // ---------- Classification helpers ----------

--- a/sdk/engine/subjects.go
+++ b/sdk/engine/subjects.go
@@ -37,17 +37,31 @@ import (
 //
 //	engine.run.<runID>.start
 //	engine.run.<runID>.end
-//	engine.run.<runID>.step.<actorID>.start
-//	engine.run.<runID>.step.<actorID>.complete
-//	engine.run.<runID>.step.<actorID>.error
-//	engine.run.<runID>.stream.<actorID>.delta
+//	engine.run.<runID>.step.<stepActor>.start
+//	engine.run.<runID>.step.<stepActor>.complete
+//	engine.run.<runID>.step.<stepActor>.error
+//	engine.run.<runID>.stream.<stepActor>.delta
 //
-// "step" is the engine-neutral name for one unit of work in a run; an
-// engine implementation MAY map it onto its own concept (graph runner
-// maps "step" → "node", a future script engine might map it onto a
-// statement). "actorID" is whatever stable identifier the engine uses
-// for that unit; engines are responsible for keeping the value
-// dot/wildcard-free (use [SanitiseID]).
+// "step" is the engine-neutral name for one unit of work in a run.
+// "stepActor" identifies one such unit; it MUST start with the
+// agent.id of the executing agent so observers can fan-in by agent
+// using the [PatternRunAgentSteps] / [PatternRunAgentStream]
+// wildcards. An engine implementation MAY append an engine-private
+// suffix to disambiguate units within the same agent run:
+//
+//   - graph runner: "<agent.id>.node.<node id>"
+//   - vessel inline: "<agent.id>.iter<N>"
+//   - script engine (future): "<agent.id>.stmt<N>"
+//
+// The agent.id prefix is the contract; the suffix is the engine's
+// own dimension and not standardised here. Engines are responsible
+// for keeping the value dot/wildcard-free (use [SanitiseID]).
+//
+// stepActor is distinct from the envelope's [event.HeaderAgentID]
+// header (= the bare agent.id, no suffix). The header is the routing
+// key for "which agent produced this"; the subject segment is the
+// routing key for "which step of that agent". Both ride on the same
+// envelope.
 //
 // "stream" is intentionally a sibling of "step" rather than a child:
 // consumers that only care about LLM token / tool deltas (voice TTS,
@@ -79,42 +93,48 @@ func SubjectRunEnd(runID string) event.Subject {
 }
 
 // SubjectStepStart returns the subject every engine MUST publish when
-// it begins executing one step. actorID identifies the unit of work
-// (graph runner: node id; script engine: statement id; etc.).
+// it begins executing one step. stepActor identifies the unit of
+// work; it MUST start with the executing agent.id so the
+// [PatternRunAgentSteps] wildcard fans-in cleanly. See the file
+// header for the per-engine suffix conventions (graph: ".node.<id>";
+// vessel inline: ".iter<N>").
 //
-//	engine.run.<runID>.step.<actorID>.start
-func SubjectStepStart(runID, actorID string) event.Subject {
-	return event.Subject(fmt.Sprintf("%s%s.step.%s.start", SubjectPrefix, SanitiseID(runID), SanitiseID(actorID)))
+//	engine.run.<runID>.step.<stepActor>.start
+func SubjectStepStart(runID, stepActor string) event.Subject {
+	return event.Subject(fmt.Sprintf("%s%s.step.%s.start", SubjectPrefix, SanitiseID(runID), SanitiseID(stepActor)))
 }
 
 // SubjectStepComplete returns the subject every engine MUST publish
-// when one step finishes successfully.
+// when one step finishes successfully. See [SubjectStepStart] for
+// the stepActor format.
 //
-//	engine.run.<runID>.step.<actorID>.complete
-func SubjectStepComplete(runID, actorID string) event.Subject {
-	return event.Subject(fmt.Sprintf("%s%s.step.%s.complete", SubjectPrefix, SanitiseID(runID), SanitiseID(actorID)))
+//	engine.run.<runID>.step.<stepActor>.complete
+func SubjectStepComplete(runID, stepActor string) event.Subject {
+	return event.Subject(fmt.Sprintf("%s%s.step.%s.complete", SubjectPrefix, SanitiseID(runID), SanitiseID(stepActor)))
 }
 
 // SubjectStepError returns the subject every engine MUST publish when
 // one step fails (i.e. when it would normally cause Execute to return
-// a non-nil non-interrupt error).
+// a non-nil non-interrupt error). See [SubjectStepStart] for the
+// stepActor format.
 //
-//	engine.run.<runID>.step.<actorID>.error
-func SubjectStepError(runID, actorID string) event.Subject {
-	return event.Subject(fmt.Sprintf("%s%s.step.%s.error", SubjectPrefix, SanitiseID(runID), SanitiseID(actorID)))
+//	engine.run.<runID>.step.<stepActor>.error
+func SubjectStepError(runID, stepActor string) event.Subject {
+	return event.Subject(fmt.Sprintf("%s%s.step.%s.error", SubjectPrefix, SanitiseID(runID), SanitiseID(stepActor)))
 }
 
 // SubjectStreamDelta returns the subject every engine MUST use when
 // emitting an in-flight increment from the step identified by
-// actorID — the canonical example is one LLM token, one dispatched
-// tool call, or one tool result.
+// stepActor — the canonical example is one LLM token, one dispatched
+// tool call, or one tool result. See [SubjectStepStart] for the
+// stepActor format.
 //
 // Payload MUST decode to a [StreamDeltaPayload]; see its docs for the
 // per-Type field requirements.
 //
-//	engine.run.<runID>.stream.<actorID>.delta
-func SubjectStreamDelta(runID, actorID string) event.Subject {
-	return event.Subject(fmt.Sprintf("%s%s.stream.%s.delta", SubjectPrefix, SanitiseID(runID), SanitiseID(actorID)))
+//	engine.run.<runID>.stream.<stepActor>.delta
+func SubjectStreamDelta(runID, stepActor string) event.Subject {
+	return event.Subject(fmt.Sprintf("%s%s.stream.%s.delta", SubjectPrefix, SanitiseID(runID), SanitiseID(stepActor)))
 }
 
 // ---------- Patterns ----------
@@ -153,6 +173,33 @@ func PatternRunStream(runID string) event.Pattern {
 	return event.Pattern(fmt.Sprintf("%s%s.stream.>", SubjectPrefix, SanitiseID(runID)))
 }
 
+// PatternRunAgentSteps returns the wildcard pattern matching every
+// step lifecycle event produced by one agent inside one run. Relies
+// on the stepActor convention documented in this file's header: the
+// segment MUST start with agent.id, so the wildcard
+// engine.run.<runID>.step.<agentID>.> picks up every per-engine
+// suffix (graph "<agentID>.node.<id>", vessel "<agentID>.iter<N>",
+// …).
+//
+//	engine.run.<runID>.step.<agentID>.>
+//
+// In multi-agent vessel mode this is the canonical "show me only
+// agent X's events in run R" subscription — it complements the
+// envelope-header path (filter by HeaderAgentID) for subscribers
+// that route on subject alone.
+func PatternRunAgentSteps(runID, agentID string) event.Pattern {
+	return event.Pattern(fmt.Sprintf("%s%s.step.%s.>", SubjectPrefix, SanitiseID(runID), SanitiseID(agentID)))
+}
+
+// PatternRunAgentStream is the stream-side counterpart of
+// [PatternRunAgentSteps]: every stream delta produced by one agent
+// inside one run.
+//
+//	engine.run.<runID>.stream.<agentID>.>
+func PatternRunAgentStream(runID, agentID string) event.Pattern {
+	return event.Pattern(fmt.Sprintf("%s%s.stream.%s.>", SubjectPrefix, SanitiseID(runID), SanitiseID(agentID)))
+}
+
 // ---------- Classification helpers ----------
 
 // IsStreamDelta reports whether s is a stream-delta subject. Cheap
@@ -160,8 +207,8 @@ func PatternRunStream(runID string) event.Pattern {
 // expensive payload decode.
 //
 // Implementation note: matches subjects shaped like
-// "engine.run.<runID>.stream.<actorID>.delta" — i.e. the prefix is
-// SubjectPrefix, contains ".stream." and ends with ".delta".
+// "engine.run.<runID>.stream.<stepActor>.delta" — i.e. the prefix
+// is SubjectPrefix, contains ".stream." and ends with ".delta".
 func IsStreamDelta(s event.Subject) bool {
 	str := string(s)
 	if len(str) < len(SubjectPrefix) || str[:len(SubjectPrefix)] != SubjectPrefix {
@@ -172,7 +219,7 @@ func IsStreamDelta(s event.Subject) bool {
 		return false
 	}
 	// Cheap "contains .stream." check without splitting; subjects with
-	// a literal ".stream." in an actor id are rejected by SanitiseID
+	// a literal ".stream." in a stepActor are rejected by SanitiseID
 	// before they reach this point.
 	for i := len(SubjectPrefix); i+len(".stream.") <= len(str)-len(tail); i++ {
 		if str[i:i+len(".stream.")] == ".stream." {
@@ -281,7 +328,7 @@ func DecodeStreamDelta(env event.Envelope) (StreamDeltaPayload, error) {
 // SanitiseID escapes characters that would corrupt an event.Subject
 // when the input is concatenated into one. event.Subject segments are
 // separated by '.', and '*' / '>' are reserved by event.Pattern for
-// wildcards; any of these in a runID / actorID would either fragment
+// wildcards; any of these in a runID / stepActor would either fragment
 // the subject or turn it into an unintended pattern. SanitiseID
 // replaces each occurrence with '_'.
 //

--- a/sdk/event/envelope.go
+++ b/sdk/event/envelope.go
@@ -37,9 +37,28 @@ type Envelope struct {
 // Well-known header keys. Consumers may add arbitrary headers; these
 // constants exist to prevent key drift across producers.
 const (
-	HeaderRunID   = "run_id"
-	HeaderNodeID  = "node_id"
+	HeaderRunID  = "run_id"
+	HeaderNodeID = "node_id"
+
+	// HeaderAgentID identifies the agent (sdk/agent.Agent.ID) that
+	// produced this envelope — i.e. the executor identity in
+	// engine-neutral terms. The producer end is sdk/agent.Run, which
+	// promotes Agent.ID into engine.Run.Attributes under
+	// telemetry.AttrAgentID; engines forward that into the envelope
+	// header via SetAgentID. Consumers that need to fan-in / filter
+	// by "which agent did this" subscribe on this dimension.
+	HeaderAgentID = "agent_id"
+
+	// HeaderActorID is the legacy spelling of HeaderAgentID. It
+	// exists for back-compat with envelopes produced by pre-v0.4
+	// SDK consumers; SetAgentID dual-writes both header keys until
+	// v0.5.0 so existing observers keep working without a coordinated
+	// flag day.
+	//
+	// Deprecated: use HeaderAgentID. This constant and the matching
+	// SetActorID / ActorID accessors are removed in v0.5.0.
 	HeaderActorID = "actor_id"
+
 	HeaderGraphID = "graph_id"
 	HeaderTenant  = "tenant"
 
@@ -156,11 +175,44 @@ func (e *Envelope) SetNodeID(id string) { e.SetHeader(HeaderNodeID, id) }
 // NodeID returns the value of the well-known node_id header.
 func (e Envelope) NodeID() string { return e.Header(HeaderNodeID) }
 
-// SetActorID is a typed shorthand for SetHeader(HeaderActorID, id).
-func (e *Envelope) SetActorID(id string) { e.SetHeader(HeaderActorID, id) }
+// SetAgentID stamps the agent identifier (sdk/agent.Agent.ID) of the
+// producer onto the envelope.
+//
+// The call is dual-write: it sets both HeaderAgentID (the canonical
+// post-v0.4 key) AND HeaderActorID (the legacy spelling) so observers
+// that have not yet migrated keep working unchanged. The legacy
+// header is removed in v0.5.0; producers should call SetAgentID and
+// stop relying on SetActorID.
+func (e *Envelope) SetAgentID(id string) {
+	e.SetHeader(HeaderAgentID, id)
+	e.SetHeader(HeaderActorID, id) // legacy mirror; removed in v0.5.0
+}
 
-// ActorID returns the value of the well-known actor_id header.
-func (e Envelope) ActorID() string { return e.Header(HeaderActorID) }
+// AgentID returns the producer's agent identifier. It prefers
+// HeaderAgentID (the post-v0.4 canonical key) and falls back to the
+// legacy HeaderActorID so envelopes produced by older SDK versions
+// still resolve correctly. After v0.5.0 only HeaderAgentID is read.
+func (e Envelope) AgentID() string {
+	if v := e.Header(HeaderAgentID); v != "" {
+		return v
+	}
+	return e.Header(HeaderActorID)
+}
+
+// SetActorID is the legacy spelling of SetAgentID.
+//
+// Deprecated: use [Envelope.SetAgentID]. The "actor" terminology
+// pre-dates the agent / step-actor distinction settled in v0.4
+// (envelope header "actor_id" is the producer agent identity;
+// the per-step "actor" segment in engine.SubjectStep* subjects is
+// a separate dimension, see sdk/engine/subjects.go). Removed in
+// v0.5.0.
+func (e *Envelope) SetActorID(id string) { e.SetAgentID(id) }
+
+// ActorID is the legacy spelling of [Envelope.AgentID].
+//
+// Deprecated: use [Envelope.AgentID]. Removed in v0.5.0.
+func (e Envelope) ActorID() string { return e.AgentID() }
 
 // SetGraphID is a typed shorthand for SetHeader(HeaderGraphID, id).
 func (e *Envelope) SetGraphID(id string) { e.SetHeader(HeaderGraphID, id) }

--- a/sdk/event/envelope_test.go
+++ b/sdk/event/envelope_test.go
@@ -71,12 +71,12 @@ func TestEnvelope_HeadersHelpers(t *testing.T) {
 	var env Envelope
 	env.SetRunID("r1")
 	env.SetNodeID("n1")
-	env.SetActorID("a1")
+	env.SetAgentID("a1")
 	env.SetGraphID("g1")
 	env.SetTenant("t1")
 	env.SetKanbanScopeID("k1")
 
-	if env.RunID() != "r1" || env.NodeID() != "n1" || env.ActorID() != "a1" || env.GraphID() != "g1" || env.Tenant() != "t1" || env.KanbanScopeID() != "k1" {
+	if env.RunID() != "r1" || env.NodeID() != "n1" || env.AgentID() != "a1" || env.GraphID() != "g1" || env.Tenant() != "t1" || env.KanbanScopeID() != "k1" {
 		t.Fatalf("typed accessors disagree: %+v", env.Headers)
 	}
 	// The KanbanScopeID accessor must read from the documented header
@@ -90,6 +90,63 @@ func TestEnvelope_HeadersHelpers(t *testing.T) {
 	var zero Envelope
 	if zero.RunID() != "" || zero.NodeID() != "" || zero.KanbanScopeID() != "" {
 		t.Fatal("zero envelope should return empty strings")
+	}
+}
+
+// TestEnvelope_AgentIDDualWrite pins the migration contract:
+// SetAgentID MUST stamp both HeaderAgentID (canonical) and
+// HeaderActorID (legacy) so observers that haven't migrated
+// off the actor_id header keep working until v0.5.0 when the
+// legacy spelling is removed. Without this guard a producer-side
+// rename would silently break every cross-process consumer that
+// inspects raw envelope.Headers["actor_id"].
+func TestEnvelope_AgentIDDualWrite(t *testing.T) {
+	var env Envelope
+	env.SetAgentID("alice")
+
+	if got := env.Headers[HeaderAgentID]; got != "alice" {
+		t.Errorf("HeaderAgentID = %q, want alice", got)
+	}
+	// Legacy mirror — removed in v0.5.0.
+	if got := env.Headers[HeaderActorID]; got != "alice" {
+		t.Errorf("HeaderActorID dual-write = %q, want alice (back-compat broken)", got)
+	}
+	// Both accessors agree.
+	if env.AgentID() != "alice" || env.ActorID() != "alice" {
+		t.Errorf("accessors disagree: AgentID=%q ActorID=%q", env.AgentID(), env.ActorID())
+	}
+}
+
+// TestEnvelope_AgentIDReadFallsBackToLegacyHeader documents the
+// consumer-side back-compat path: an envelope produced by a
+// pre-v0.4 SDK (only sets HeaderActorID, not HeaderAgentID) MUST
+// still resolve via env.AgentID(). After v0.5.0 producers will
+// only set HeaderAgentID and this fallback becomes dead code,
+// but until then it is the bridge that lets new consumers run
+// against old producers.
+func TestEnvelope_AgentIDReadFallsBackToLegacyHeader(t *testing.T) {
+	var env Envelope
+	env.SetHeader(HeaderActorID, "legacy-producer")
+
+	if got := env.AgentID(); got != "legacy-producer" {
+		t.Errorf("AgentID() should fall back to HeaderActorID; got %q", got)
+	}
+}
+
+// TestEnvelope_SetActorIDDelegatesToSetAgentID documents the
+// inverse migration path: existing producers calling the
+// Deprecated SetActorID still get both headers populated so the
+// transitional period does not require a coordinated flag day
+// where producers and consumers all upgrade together.
+func TestEnvelope_SetActorIDDelegatesToSetAgentID(t *testing.T) {
+	var env Envelope
+	env.SetActorID("bob") //nolint:staticcheck // intentional Deprecated path
+
+	if got := env.Headers[HeaderAgentID]; got != "bob" {
+		t.Errorf("legacy SetActorID must populate HeaderAgentID; got %q", got)
+	}
+	if got := env.Headers[HeaderActorID]; got != "bob" {
+		t.Errorf("legacy SetActorID must keep populating HeaderActorID; got %q", got)
 	}
 }
 

--- a/sdk/graph/core.go
+++ b/sdk/graph/core.go
@@ -91,7 +91,7 @@ type PortDeclarable interface {
 // keys live under [github.com/GizClaw/flowcraft/sdk/telemetry] (e.g.
 // AttrAgentID / AttrTaskID / AttrContextID) so nodes that need
 // agent-scoped identity (scriptnode RunInfoBridge, telemetry hooks,
-// envelope actor_id) can read them without inventing a parallel
+// envelope agent_id) can read them without inventing a parallel
 // transport. May be nil when the engine was invoked without attributes.
 type ExecutionContext struct {
 	Context    context.Context

--- a/sdk/graph/node/scriptnode/jsnode_test.go
+++ b/sdk/graph/node/scriptnode/jsnode_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/GizClaw/flowcraft/sdk/errdefs"
 	"github.com/GizClaw/flowcraft/sdk/graph"
 	"github.com/GizClaw/flowcraft/sdk/script/jsrt"
+	"github.com/GizClaw/flowcraft/sdk/telemetry"
 )
 
 func TestScriptNode_IDAndType(t *testing.T) {
@@ -138,11 +139,12 @@ func TestScriptNode_RunInfo_AllFieldsPropagate(t *testing.T) {
 		Context: context.Background(),
 		RunID:   "run-x",
 		Attributes: map[string]string{
-			"agent_id":   "researcher",
-			"task_id":    "task-7",
-			"context_id": "thread-3",
-			// run_id is intentionally absent: ExecutionContext.RunID
-			// is the dedicated source.
+			telemetry.AttrAgentID:        "researcher",
+			telemetry.AttrTaskID:         "task-7",
+			telemetry.AttrConversationID: "thread-3",
+			// AttrRunID is intentionally absent: ExecutionContext.RunID
+			// is the dedicated source agent.RunInfoFromAttributes
+			// trusts over any attribute copy.
 		},
 	}
 	if err := n.ExecuteBoard(ctx, board); err != nil {

--- a/sdk/graph/runner/aliases.go
+++ b/sdk/graph/runner/aliases.go
@@ -66,9 +66,19 @@ type CloneableResolver = executor.CloneableResolver
 
 // --- context helpers ---------------------------------------------------------
 
-// WithActorKey stamps an actor identifier onto ctx. The runner reads
-// it and forwards it onto every envelope header so multi-tenant
-// observers can filter by tenant without inspecting payload.
+// WithActorKey stamps an agent identifier onto ctx so the runner
+// forwards it onto every envelope header (HeaderAgentID) and uses
+// it as the prefix of the step subject segment.
+//
+// Deprecated: as of v0.4 the runner resolves the agent id from the
+// canonical [engine.Run.Attributes][telemetry.AttrAgentID] key first
+// (populated automatically by [agent.Run]) and only falls back to
+// this ctx-key when the attribute is absent. Prefer driving the
+// runner through [agent.Run] (or stamp the attribute directly on
+// engine.Run.Attributes) — that path survives cross-process
+// hand-offs (HTTP, vessel inline, A2A) where context values are
+// dropped at the wire boundary. WithActorKey will be removed in
+// v0.5.0.
 func WithActorKey(ctx context.Context, key string) context.Context {
 	return executor.WithActorKey(ctx, key)
 }

--- a/sdk/graph/runner/doc.go
+++ b/sdk/graph/runner/doc.go
@@ -28,13 +28,13 @@
 //     engine package — [engine.EmitStreamToken],
 //     [engine.EmitStreamToolCall], [engine.EmitStreamToolResult] or
 //     the lower-level [engine.EmitStreamDelta]. These build the
-//     envelope, attach HeaderRunID / HeaderActorID / HeaderNodeID,
+//     envelope, attach HeaderRunID / HeaderAgentID / HeaderNodeID,
 //     and validate per-Type required fields before publishing, so a
 //     malformed delta is caught at emit time instead of silently
 //     flowing to subscribers.
 //
 // Both paths land on the same Subject (engine.run.<runID>.stream.
-// <actorID>.delta), so consumers subscribing via
+// <stepActor>.delta), so consumers subscribing via
 // [engine.PatternRunStream] observe LLM-emitted and node-emitted
 // deltas through one subscription.
 package runner

--- a/sdk/graph/runner/integration_test.go
+++ b/sdk/graph/runner/integration_test.go
@@ -24,12 +24,14 @@ import (
 	"github.com/GizClaw/flowcraft/sdk/engine/depname"
 	"github.com/GizClaw/flowcraft/sdk/engine/enginetest"
 	"github.com/GizClaw/flowcraft/sdk/errdefs"
+	"github.com/GizClaw/flowcraft/sdk/event"
 	"github.com/GizClaw/flowcraft/sdk/graph"
 	"github.com/GizClaw/flowcraft/sdk/graph/node"
 	"github.com/GizClaw/flowcraft/sdk/graph/node/llmnode"
 	"github.com/GizClaw/flowcraft/sdk/graph/runner"
 	"github.com/GizClaw/flowcraft/sdk/llm"
 	"github.com/GizClaw/flowcraft/sdk/model"
+	"github.com/GizClaw/flowcraft/sdk/telemetry"
 	"github.com/GizClaw/flowcraft/sdk/tool"
 )
 
@@ -691,5 +693,175 @@ func TestAgentRun_NoAgentToolsKeepsLegacyBehaviour(t *testing.T) {
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("legacy back-compat broken: got %v want %v "+
 			"(agent without Tools should not constrain Config.ToolNames)", got, want)
+	}
+}
+
+// TestAgentRun_EnvelopeAgentIDIsAgentID is the vertical E2E that
+// closes contract-audit #15. The chain under test:
+//
+//	agent.Run -> mergeAttributes writes telemetry.AttrAgentID into
+//	             engine.Run.Attributes
+//	          -> runner.Runner.Execute forwards Attributes into
+//	             executor.WithAttributes
+//	          -> agentIDFor reads cfg.attributes[AttrAgentID]
+//	          -> publishGraphEvent / publishNodeEvent /
+//	             newNodePublisher stamp env.SetAgentID
+//	          -> host observes envelope.AgentID() == ag.ID
+//
+// Before the fix the executor only consulted runner.WithActorKey
+// (a ctx-key), which agent.Run never set; envelopes published
+// through agent.Run therefore carried empty agent_id headers,
+// breaking multi-agent observability in vessel mode (multiple
+// agents publishing to the same NATS topic could not be split by
+// producer).
+func TestAgentRun_EnvelopeAgentIDIsAgentID(t *testing.T) {
+	r := buildEchoRunner(t)
+	host := enginetest.NewMockHost()
+
+	const agentID = "researcher"
+	res, err := agent.Run(context.Background(),
+		agent.Agent{ID: agentID},
+		r,
+		agent.Request{
+			RunID:   "run-actor",
+			Message: model.NewTextMessage(model.RoleUser, "hi"),
+		},
+		agent.WithEngineHost(host),
+	)
+	if err != nil {
+		t.Fatalf("agent.Run: %v", err)
+	}
+	if res.Status != agent.StatusCompleted {
+		t.Fatalf("Status = %q, want completed", res.Status)
+	}
+
+	envs := host.Envelopes()
+	if len(envs) == 0 {
+		t.Fatal("host received no envelopes — runner is not publishing through the agent-supplied host")
+	}
+
+	missing := 0
+	for _, e := range envs {
+		// Every envelope (run.start, step.*, run.end, parallel.*, …)
+		// MUST carry agent_id == ag.ID. Tolerating "some envelopes
+		// missing" would let a regression in any single publish
+		// call site (publisher.go / parallel.go / executor.go) slip
+		// through unnoticed.
+		if got := e.AgentID(); got != agentID {
+			missing++
+			t.Errorf("envelope %q: AgentID = %q, want %q",
+				string(e.Subject), got, agentID)
+		}
+	}
+	if missing > 0 {
+		t.Fatalf("%d / %d envelopes missing agent_id (agent.Run -> executor seam regression)",
+			missing, len(envs))
+	}
+}
+
+// TestAgentRun_LegacyActorIDHeaderStillSet pins the dual-write
+// migration contract at the integration boundary: even after
+// agent.Run/runner moved to SetAgentID semantics, the legacy
+// envelope header HeaderActorID must keep being populated so
+// pre-v0.4 consumers (vessel/logs, dashboards inspecting raw
+// Headers["actor_id"]) keep working unchanged until v0.5.0
+// removes the mirror.
+func TestAgentRun_LegacyActorIDHeaderStillSet(t *testing.T) {
+	r := buildEchoRunner(t)
+	host := enginetest.NewMockHost()
+
+	_, err := agent.Run(context.Background(),
+		agent.Agent{ID: "researcher"},
+		r,
+		agent.Request{Message: model.NewTextMessage(model.RoleUser, "hi")},
+		agent.WithEngineHost(host),
+	)
+	if err != nil {
+		t.Fatalf("agent.Run: %v", err)
+	}
+
+	for _, e := range host.Envelopes() {
+		// HeaderActorID is the legacy spelling; SetAgentID's
+		// dual-write keeps it populated until v0.5.0.
+		if got := e.Headers[event.HeaderActorID]; got != "researcher" {
+			t.Errorf("envelope %q: legacy actor_id mirror = %q, want %q",
+				string(e.Subject), got, "researcher")
+		}
+	}
+}
+
+// TestAgentRun_StepSubjectsCarryAgentPrefix asserts every per-step
+// subject ends up with the stepActor segment shaped as
+// "<agent>_node_<nodeID>" (the SanitiseID-collapsed form of
+// "<agent>.node.<nodeID>"). This pins the contract documented at
+// sdk/engine/subjects.go: the segment MUST start with the agent.id
+// for human-readable debugging, even though agent-level NATS
+// wildcard fan-in goes through HeaderAgentID rather than the
+// subject.
+func TestAgentRun_StepSubjectsCarryAgentPrefix(t *testing.T) {
+	r := buildEchoRunner(t)
+	host := enginetest.NewMockHost()
+
+	_, err := agent.Run(context.Background(),
+		agent.Agent{ID: "researcher"},
+		r,
+		agent.Request{
+			RunID:   "run-step",
+			Message: model.NewTextMessage(model.RoleUser, "hi"),
+		},
+		agent.WithEngineHost(host),
+	)
+	if err != nil {
+		t.Fatalf("agent.Run: %v", err)
+	}
+
+	const wantSegment = ".step.researcher_node_echo."
+	var sawStep bool
+	for _, e := range host.Envelopes() {
+		s := string(e.Subject)
+		if strings.Contains(s, ".step.") {
+			sawStep = true
+			if !strings.Contains(s, wantSegment) {
+				t.Errorf("step subject = %q, must contain %q", s, wantSegment)
+			}
+		}
+	}
+	if !sawStep {
+		t.Fatal("no step subject published — graph never executed the echo node?")
+	}
+}
+
+// TestAgentRun_CallerSuppliedAgentIDOverridesAgentField asserts the
+// "caller-supplied wins" rule documented on agent.WithAttributes
+// extends to envelope agent_id: a caller that explicitly stamps
+// telemetry.AttrAgentID via WithAttributes should see that value
+// on the wire, not Agent.ID. This matters for impersonation /
+// shadow-run debugging where the operator wants envelopes
+// attributed to the impersonated identity.
+func TestAgentRun_CallerSuppliedAgentIDOverridesAgentField(t *testing.T) {
+	r := buildEchoRunner(t)
+	host := enginetest.NewMockHost()
+
+	_, err := agent.Run(context.Background(),
+		agent.Agent{ID: "default-agent"},
+		r,
+		agent.Request{
+			RunID:   "run-override",
+			Message: model.NewTextMessage(model.RoleUser, "hi"),
+		},
+		agent.WithEngineHost(host),
+		agent.WithAttributes(map[string]string{
+			telemetry.AttrAgentID: "impersonated",
+		}),
+	)
+	if err != nil {
+		t.Fatalf("agent.Run: %v", err)
+	}
+
+	for _, e := range host.Envelopes() {
+		if got := e.AgentID(); got != "impersonated" {
+			t.Errorf("envelope %q: AgentID = %q, want %q (caller WithAttributes should win)",
+				string(e.Subject), got, "impersonated")
+		}
 	}
 }

--- a/sdk/graph/runner/internal/executor/agent_id_test.go
+++ b/sdk/graph/runner/internal/executor/agent_id_test.go
@@ -1,0 +1,195 @@
+package executor
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/GizClaw/flowcraft/sdk/engine"
+	"github.com/GizClaw/flowcraft/sdk/engine/enginetest"
+	"github.com/GizClaw/flowcraft/sdk/event"
+	"github.com/GizClaw/flowcraft/sdk/graph"
+	"github.com/GizClaw/flowcraft/sdk/telemetry"
+)
+
+// TestAgentIDFor_AttributesWinOverCtxKey pins the precedence
+// documented on agentIDFor: the canonical wire key
+// (cfg.attributes[telemetry.AttrAgentID], populated upstream by
+// agent.Run.mergeAttributes) takes priority over the legacy
+// WithActorKey ctx-key. This is the rule that lets agent.Run
+// stamp the envelope agent id without callers having to manually
+// thread WithActorKey through the executor entry point.
+func TestAgentIDFor_AttributesWinOverCtxKey(t *testing.T) {
+	ctx := WithActorKey(context.Background(), "ctx-actor")
+	cfg := runConfig{attributes: map[string]string{
+		telemetry.AttrAgentID: "attr-agent",
+	}}
+	if got := agentIDFor(ctx, cfg); got != "attr-agent" {
+		t.Fatalf("attributes should win: got %q want %q", got, "attr-agent")
+	}
+}
+
+// TestAgentIDFor_FallsBackToCtxKeyWhenAttributesEmpty asserts the
+// back-compat path: legacy callers that drove the executor with
+// WithActorKey (no agent.Run on top) still see their identifier on
+// the envelope after the migration. Without this the migration
+// would silently strip agent_id from existing pipelines until
+// they switched to the attribute-based seed.
+func TestAgentIDFor_FallsBackToCtxKeyWhenAttributesEmpty(t *testing.T) {
+	ctx := WithActorKey(context.Background(), "ctx-actor")
+
+	if got := agentIDFor(ctx, runConfig{}); got != "ctx-actor" {
+		t.Errorf("nil attributes: got %q want %q", got, "ctx-actor")
+	}
+	cfg := runConfig{attributes: map[string]string{"unrelated": "x"}}
+	if got := agentIDFor(ctx, cfg); got != "ctx-actor" {
+		t.Errorf("missing AttrAgentID: got %q want %q", got, "ctx-actor")
+	}
+	cfg = runConfig{attributes: map[string]string{telemetry.AttrAgentID: ""}}
+	if got := agentIDFor(ctx, cfg); got != "ctx-actor" {
+		t.Errorf("empty AttrAgentID should not suppress fallback: got %q", got)
+	}
+}
+
+// TestAgentIDFor_EmptyWhenBothMissing documents the no-agent case:
+// publish helpers skip SetAgentID when the resolved id is empty so
+// envelope headers stay clean (no "agent_id":"" pollution) and
+// step subjects degrade to the bare nodeID rather than an
+// "<empty>.node.<id>" form.
+func TestAgentIDFor_EmptyWhenBothMissing(t *testing.T) {
+	if got := agentIDFor(context.Background(), runConfig{}); got != "" {
+		t.Fatalf("expected empty agent id, got %q", got)
+	}
+}
+
+// TestStepActorFor pins the contract documented at
+// sdk/engine/subjects.go: the stepActor subject segment MUST start
+// with the executing agent.id so PatternRunAgentSteps fans-in
+// cleanly, and graph runner uses ".node.<nodeID>" as its
+// engine-private suffix to disambiguate per-node sub-units.
+func TestStepActorFor(t *testing.T) {
+	cases := []struct {
+		name    string
+		agentID string
+		nodeID  string
+		want    string
+	}{
+		{"both", "researcher", "n1", "researcher.node.n1"},
+		{"agent only (run-level)", "researcher", "", "researcher"},
+		{"node only (legacy ctx-key absent)", "", "n1", "n1"},
+		{"both empty", "", "", ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := stepActorFor(tc.agentID, tc.nodeID); got != tc.want {
+				t.Errorf("stepActorFor(%q, %q) = %q, want %q", tc.agentID, tc.nodeID, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestExecute_StampsAgentIDFromAttributes is the integration-level
+// counterpart to the agentIDFor unit test: it drives Execute end-to-
+// end and asserts the envelopes published by the executor carry
+// HeaderAgentID sourced from cfg.attributes[telemetry.AttrAgentID]
+// AND the step subject segment is the compound stepActor
+// (= agentID.node.nodeID). Closes contract-audit #15 at the publish
+// boundary (where unit-testing agentIDFor alone is not enough — any
+// of the four publishGraph/Node call sites could still drop one of
+// the dimensions before reaching the wire).
+func TestExecute_StampsAgentIDFromAttributes(t *testing.T) {
+	host := enginetest.NewMockHost()
+
+	probe := newTestNode("probe", func(_ graph.ExecutionContext, _ *graph.Board) error {
+		return nil
+	})
+	g := buildGraph("agent-test", "probe",
+		map[string]graph.Node{"probe": probe},
+		[]graph.Edge{{From: "probe", To: graph.END}},
+	)
+
+	_, err := NewLocalExecutor().Execute(context.Background(), g, graph.NewBoard(),
+		WithRunID("run-agent"),
+		WithHost(host),
+		WithAttributes(map[string]string{telemetry.AttrAgentID: "researcher"}),
+	)
+	if err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+
+	envs := host.Envelopes()
+	if len(envs) == 0 {
+		t.Fatal("host received no envelopes")
+	}
+
+	var sawStep bool
+	for _, env := range envs {
+		// Every envelope MUST carry HeaderAgentID = "researcher".
+		// Tolerating "some envelopes missing" would let a regression
+		// in any single publish call site slip through.
+		if got := env.AgentID(); got != "researcher" {
+			t.Errorf("envelope %s: AgentID = %q, want %q",
+				env.Subject, got, "researcher")
+		}
+		// Legacy mirror also populated by SetAgentID dual-write —
+		// observers that haven't migrated still see actor_id.
+		if got := env.Headers[event.HeaderActorID]; got != "researcher" {
+			t.Errorf("envelope %s: legacy actor_id mirror = %q, want %q",
+				env.Subject, got, "researcher")
+		}
+		// Step subjects MUST carry the compound stepActor segment.
+		// Run-level subjects (.start / .end) do not — they have no
+		// step actor. SanitiseID collapses the literal "." inside
+		// the stepActor (".node.") into "_" so the segment stays
+		// one NATS token; agent-level fan-in goes through
+		// HeaderAgentID, not subject wildcards (see
+		// sdk/engine/subjects.go file header).
+		s := string(env.Subject)
+		if strings.Contains(s, ".step.") {
+			sawStep = true
+			if !strings.Contains(s, ".step.researcher_node_probe.") {
+				t.Errorf("step subject must contain .step.<agent>_node_<node>.; got %q", s)
+			}
+		}
+	}
+	if !sawStep {
+		t.Fatal("no step subject published — graph never executed the probe node?")
+	}
+}
+
+// TestExecute_StampsAgentIDFromCtxKeyFallback exercises the legacy
+// path. With the attribute bag empty the executor MUST still honour
+// WithActorKey-supplied ids until v0.5.0 removal; otherwise existing
+// direct-executor callers (tests, embedded users) would silently
+// lose envelope agent_id at this version bump.
+func TestExecute_StampsAgentIDFromCtxKeyFallback(t *testing.T) {
+	host := enginetest.NewMockHost()
+
+	probe := newTestNode("probe", func(_ graph.ExecutionContext, _ *graph.Board) error {
+		return nil
+	})
+	g := buildGraph("agent-fallback", "probe",
+		map[string]graph.Node{"probe": probe},
+		[]graph.Edge{{From: "probe", To: graph.END}},
+	)
+
+	ctx := WithActorKey(context.Background(), "legacy-agent")
+	_, err := NewLocalExecutor().Execute(ctx, g, graph.NewBoard(),
+		WithRunID("run-fallback"),
+		WithHost(host),
+	)
+	if err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+
+	for _, env := range host.Envelopes() {
+		if got := env.AgentID(); got != "legacy-agent" {
+			t.Errorf("envelope %s: AgentID = %q, want %q",
+				env.Subject, got, "legacy-agent")
+		}
+	}
+}
+
+// Compile-time check that enginetest.MockHost satisfies engine.Host
+// (used by the integration tests above).
+var _ engine.Host = (*enginetest.MockHost)(nil)

--- a/sdk/graph/runner/internal/executor/executor.go
+++ b/sdk/graph/runner/internal/executor/executor.go
@@ -24,6 +24,16 @@ type ctxKey int
 
 const ctxKeyActorKey ctxKey = iota
 
+// WithActorKey stamps an agent identifier onto ctx for legacy
+// callers that drive the executor directly (no agent.Run wrapper).
+//
+// Deprecated: prefer populating engine.Run.Attributes with the
+// canonical telemetry.AttrAgentID key — agent.Run already does
+// this, and unlike a context value the attribute survives
+// cross-process hand-offs (HTTP, A2A, vessel inline engines). The
+// executor's agentIDFor resolver still honours this ctx-key as a
+// fallback when no attribute is set, so existing callers keep
+// working until the v0.5.0 removal.
 func WithActorKey(ctx context.Context, key string) context.Context {
 	return context.WithValue(ctx, ctxKeyActorKey, key)
 }
@@ -33,6 +43,58 @@ func actorKeyFrom(ctx context.Context) string {
 		return v
 	}
 	return ""
+}
+
+// agentIDFor resolves the agent.id the executor stamps onto every
+// published envelope (HeaderAgentID) and uses as the prefix of the
+// step subject segment (engine.SubjectStep* / SubjectStreamDelta).
+//
+// Precedence:
+//
+//  1. cfg.attributes[telemetry.AttrAgentID] — the canonical wire
+//     key. agent.Run promotes Agent.ID into engine.Run.Attributes
+//     under this key (sdk/agent.mergeAttributes), and runner.Runner
+//     forwards engine.Run.Attributes into cfg.attributes via
+//     executor.WithAttributes. This path survives cross-process
+//     hand-offs (HTTP, vessel inline, A2A) because the attribute
+//     bag is part of the engine.Run contract.
+//  2. actorKeyFrom(ctx) — legacy WithActorKey ctx-key. Kept until
+//     v0.5.0 so direct executor callers (tests, embedded users)
+//     keep working without code change. The "actor" naming is
+//     historical; the value is treated as an agent identifier.
+//
+// Returns "" when neither source has a value; envelope publishers
+// then skip the SetAgentID call and the step subject degrades to
+// the bare nodeID (no agent prefix).
+func agentIDFor(ctx context.Context, cfg runConfig) string {
+	if id := cfg.attributes[telemetry.AttrAgentID]; id != "" {
+		return id
+	}
+	return actorKeyFrom(ctx)
+}
+
+// stepActorFor builds the engine.SubjectStep* "stepActor" segment
+// for a graph runner step. The contract documented at
+// sdk/engine/subjects.go demands the segment start with agent.id so
+// the engine.PatternRunAgentSteps wildcard fans-in cleanly across
+// runs of the same agent; graph runner appends ".node.<nodeID>" as
+// its engine-private suffix to disambiguate the per-node sub-units.
+//
+// Empty agentID degrades to a bare nodeID (legacy path for direct
+// executor callers that do not populate engine.Run.Attributes);
+// empty nodeID degrades to a bare agentID (run-level events have
+// no node dimension).
+func stepActorFor(agentID, nodeID string) string {
+	switch {
+	case agentID == "" && nodeID == "":
+		return ""
+	case agentID == "":
+		return nodeID
+	case nodeID == "":
+		return agentID
+	default:
+		return agentID + ".node." + nodeID
+	}
 }
 
 var (
@@ -242,7 +304,7 @@ func (e *LocalExecutor) Execute(ctx context.Context, g *graph.Graph, board *grap
 	}
 	cfg.publisher = cfg.host
 
-	actorKey := actorKeyFrom(ctx)
+	agentID := agentIDFor(ctx, cfg)
 
 	if cfg.timeout > 0 {
 		var cancel context.CancelFunc
@@ -325,9 +387,9 @@ func (e *LocalExecutor) Execute(ctx context.Context, g *graph.Graph, board *grap
 		}
 		if len(live) == 0 {
 			publishGraphEvent(ctx, cfg.publisher, engine.SubjectRunStart(cfg.runID),
-				cfg.runID, g.Name(), actorKey, board.Vars())
+				cfg.runID, g.Name(), agentID, board.Vars())
 			publishGraphEvent(ctx, cfg.publisher, engine.SubjectRunEnd(cfg.runID),
-				cfg.runID, g.Name(), actorKey,
+				cfg.runID, g.Name(), agentID,
 				map[string]any{"iteration": cfg.resumeFrom.Iteration, "vars": board.Vars(), "resumed": true})
 			return board, nil
 		}
@@ -336,7 +398,7 @@ func (e *LocalExecutor) Execute(ctx context.Context, g *graph.Graph, board *grap
 	}
 
 	publishGraphEvent(ctx, cfg.publisher, engine.SubjectRunStart(cfg.runID),
-		cfg.runID, g.Name(), actorKey, board.Vars())
+		cfg.runID, g.Name(), agentID, board.Vars())
 
 	graphStatus := "success"
 	for len(currentNodes) > 0 && iteration < cfg.maxIterations {
@@ -356,8 +418,8 @@ func (e *LocalExecutor) Execute(ctx context.Context, g *graph.Graph, board *grap
 			if skip, err := shouldSkip(g, node, board); err != nil {
 				return board, err
 			} else if skip {
-				publishNodeEvent(ctx, cfg.publisher, subjNodeSkipped(cfg.runID, nodeID),
-					cfg.runID, g.Name(), actorKey, nodeID, nil)
+				publishNodeEvent(ctx, cfg.publisher, subjNodeSkipped(cfg.runID, stepActorFor(agentID, nodeID)),
+					cfg.runID, g.Name(), agentID, nodeID, nil)
 				resolved, err := resolveNextNodes(g, node, board)
 				if err != nil {
 					return board, err
@@ -389,8 +451,8 @@ func (e *LocalExecutor) Execute(ctx context.Context, g *graph.Graph, board *grap
 				}
 			}
 
-			publishNodeEvent(ctx, cfg.publisher, engine.SubjectStepStart(cfg.runID, nodeID),
-				cfg.runID, g.Name(), actorKey, nodeID, nil)
+			publishNodeEvent(ctx, cfg.publisher, engine.SubjectStepStart(cfg.runID, stepActorFor(agentID, nodeID)),
+				cfg.runID, g.Name(), agentID, nodeID, nil)
 
 			nodeStart := time.Now()
 			_, nodeSpan := telemetry.Tracer().Start(ctx, "node."+node.Type()+".execute",
@@ -426,7 +488,7 @@ func (e *LocalExecutor) Execute(ctx context.Context, g *graph.Graph, board *grap
 				if errdefs.IsInterrupted(err) {
 					board.SetVar(graph.VarInterruptedNode, nodeID)
 					publishGraphEvent(ctx, cfg.publisher, engine.SubjectRunEnd(cfg.runID),
-						cfg.runID, g.Name(), actorKey, nil)
+						cfg.runID, g.Name(), agentID, nil)
 					graphSpan.SetAttributes(attribute.String("graph.status", "interrupted"))
 					graphExecCount.Add(ctx, 1,
 						metric.WithAttributes(
@@ -449,8 +511,8 @@ func (e *LocalExecutor) Execute(ctx context.Context, g *graph.Graph, board *grap
 					otellog.String(telemetry.AttrNodeID, nodeID),
 					otellog.String(telemetry.AttrErrorMessage, err.Error()))
 
-				publishNodeEvent(ctx, cfg.publisher, engine.SubjectStepError(cfg.runID, nodeID),
-					cfg.runID, g.Name(), actorKey, nodeID,
+				publishNodeEvent(ctx, cfg.publisher, engine.SubjectStepError(cfg.runID, stepActorFor(agentID, nodeID)),
+					cfg.runID, g.Name(), agentID, nodeID,
 					map[string]any{"error": err.Error()})
 				return board, err
 			}
@@ -470,8 +532,8 @@ func (e *LocalExecutor) Execute(ctx context.Context, g *graph.Graph, board *grap
 				}
 			}
 
-			publishNodeEvent(ctx, cfg.publisher, engine.SubjectStepComplete(cfg.runID, nodeID),
-				cfg.runID, g.Name(), actorKey, nodeID,
+			publishNodeEvent(ctx, cfg.publisher, engine.SubjectStepComplete(cfg.runID, stepActorFor(agentID, nodeID)),
+				cfg.runID, g.Name(), agentID, nodeID,
 				map[string]any{"iteration": iteration, "vars": board.Vars()})
 
 			// Checkpoint through the host. host is always non-nil
@@ -537,7 +599,7 @@ func (e *LocalExecutor) Execute(ctx context.Context, g *graph.Graph, board *grap
 	}
 
 	publishGraphEvent(ctx, cfg.publisher, engine.SubjectRunEnd(cfg.runID),
-		cfg.runID, g.Name(), actorKey,
+		cfg.runID, g.Name(), agentID,
 		map[string]any{"iteration": iteration, "vars": board.Vars()})
 
 	graphSpan.SetAttributes(

--- a/sdk/graph/runner/internal/executor/parallel.go
+++ b/sdk/graph/runner/internal/executor/parallel.go
@@ -21,11 +21,11 @@ func executeForkJoin(ctx context.Context, g *graph.Graph, board *graph.Board, br
 		branchStarts = branchStarts[:cfg.parallel.MaxBranches]
 	}
 
-	actorKey := actorKeyFrom(ctx)
+	agentID := agentIDFor(ctx, cfg)
 	joinNodeID := findJoinNode(g, branchStarts)
 
 	publishGraphEvent(ctx, cfg.publisher, subjParallelFork(cfg.runID),
-		cfg.runID, g.Name(), actorKey,
+		cfg.runID, g.Name(), agentID,
 		map[string]any{
 			"branch_ids": branchStarts,
 			"join_node":  joinNodeID,
@@ -90,7 +90,7 @@ func executeForkJoin(ctx context.Context, g *graph.Graph, board *graph.Board, br
 	}
 
 	publishGraphEvent(ctx, cfg.publisher, subjParallelJoin(cfg.runID),
-		cfg.runID, g.Name(), actorKey,
+		cfg.runID, g.Name(), agentID,
 		map[string]any{
 			"branch_ids": branchStarts,
 			"vars":       board.Vars(),

--- a/sdk/graph/runner/internal/executor/publisher.go
+++ b/sdk/graph/runner/internal/executor/publisher.go
@@ -12,10 +12,18 @@ import (
 // translates each emit into a fully-formed engine event.Envelope and
 // pushes it through the executor's host publisher.
 //
+// agentID is resolved once (from engine.Run.Attributes /
+// WithActorKey ctx-key fallback) so every emit pays a constant cost
+// rather than re-walking ctx for each payload. The stepActor segment
+// stamped onto the subject is "<agentID>.node.<nodeID>" — the
+// envelope.HeaderAgentID and HeaderNodeID transports carry the two
+// dimensions separately for header-routed subscribers.
+//
 // The wrapper is always non-nil so nodes can call ctx.Publisher.Emit
 // without nil-checks.
 func newNodePublisher(ctx context.Context, cfg runConfig, nodeID string) graph.StreamPublisher {
-	actorKey := actorKeyFrom(ctx)
+	agentID := agentIDFor(ctx, cfg)
+	stepActor := stepActorFor(agentID, nodeID)
 	graphName := cfg.graphName
 	pub := cfg.publisher
 
@@ -24,8 +32,8 @@ func newNodePublisher(ctx context.Context, cfg runConfig, nodeID string) graph.S
 			return
 		}
 		pl := normalisePayload(eventType, payload)
-		publishNodeEvent(ctx, pub, engine.SubjectStreamDelta(cfg.runID, nodeID),
-			cfg.runID, graphName, actorKey, nodeID, pl)
+		publishNodeEvent(ctx, pub, engine.SubjectStreamDelta(cfg.runID, stepActor),
+			cfg.runID, graphName, agentID, nodeID, pl)
 	})
 }
 

--- a/sdk/graph/runner/internal/executor/subjects.go
+++ b/sdk/graph/runner/internal/executor/subjects.go
@@ -13,12 +13,12 @@ import (
 // Engine-contract subjects (constructed via sdk/engine builders so the
 // names stay aligned with every other engine implementation):
 //
-//	engine.run.<runID>.start                       — engine.SubjectRunStart
-//	engine.run.<runID>.end                         — engine.SubjectRunEnd
-//	engine.run.<runID>.step.<nodeID>.start         — engine.SubjectStepStart
-//	engine.run.<runID>.step.<nodeID>.complete      — engine.SubjectStepComplete
-//	engine.run.<runID>.step.<nodeID>.error         — engine.SubjectStepError
-//	engine.run.<runID>.stream.<nodeID>.delta       — engine.SubjectStreamDelta
+//	engine.run.<runID>.start                          — engine.SubjectRunStart
+//	engine.run.<runID>.end                            — engine.SubjectRunEnd
+//	engine.run.<runID>.step.<stepActor>.start         — engine.SubjectStepStart
+//	engine.run.<runID>.step.<stepActor>.complete      — engine.SubjectStepComplete
+//	engine.run.<runID>.step.<stepActor>.error         — engine.SubjectStepError
+//	engine.run.<runID>.stream.<stepActor>.delta       — engine.SubjectStreamDelta
 //
 // graph-private extensions (still under engine.run.<runID>. so a single
 // engine.PatternRun subscription captures them; their shape is NOT part
@@ -26,12 +26,21 @@ import (
 //
 //	engine.run.<runID>.parallel.fork
 //	engine.run.<runID>.parallel.join
-//	engine.run.<runID>.step.<nodeID>.skipped
+//	engine.run.<runID>.step.<stepActor>.skipped
 //
-// graph runner uses node id as the engine "actor" id. Both go through
-// engine.SanitiseID inside the builders so a runID / nodeID containing
-// '.' / '*' / '>' degrades to '_'-substituted segments rather than
-// corrupting the resulting Subject.
+// stepActor follows the engine contract documented in
+// sdk/engine/subjects.go: it MUST start with the executing agent.id
+// so engine.PatternRunAgentSteps wildcards fan-in cleanly. Graph
+// runner appends ".node.<nodeID>" as its engine-private suffix
+// (built by stepActorFor in executor.go); that suffix is invisible
+// to the engine contract — pure-engine consumers route on the
+// agent.id prefix, graph-aware consumers split on ".node." or read
+// the parallel envelope.HeaderNodeID.
+//
+// Both runID and stepActor go through engine.SanitiseID inside the
+// builders so a value containing '.' / '*' / '>' degrades to
+// '_'-substituted segments rather than corrupting the resulting
+// Subject.
 
 // subjParallelFork returns "engine.run.<runID>.parallel.fork".
 //
@@ -62,13 +71,17 @@ func subjNodeSkipped(runID, nodeID string) event.Subject {
 // publishGraphEvent fires-and-forgets a run-level envelope. Headers
 // carry the well-known IDs that callers may need for predicate filtering
 // when subject routing alone is insufficient (e.g. cross-run
-// aggregations).
+// aggregations). agentID — the executor identity, sourced from
+// engine.Run.Attributes[telemetry.AttrAgentID] via agentIDFor — is
+// stamped onto HeaderAgentID (and the legacy HeaderActorID via the
+// SetAgentID dual-write) so observers can filter by agent without
+// inspecting the subject.
 //
 // Errors from publisher.Publish are intentionally swallowed to preserve
 // the historical behaviour: the executor must not stop graph execution
 // because an observer is overloaded. The publisher is the executor's
 // composed sink (host + optional legacy bus), built once in Execute.
-func publishGraphEvent(ctx context.Context, pub engine.Publisher, subject event.Subject, runID, graphName, actorKey string, payload any) {
+func publishGraphEvent(ctx context.Context, pub engine.Publisher, subject event.Subject, runID, graphName, agentID string, payload any) {
 	if pub == nil {
 		return
 	}
@@ -82,8 +95,8 @@ func publishGraphEvent(ctx context.Context, pub engine.Publisher, subject event.
 	if graphName != "" {
 		env.SetGraphID(graphName)
 	}
-	if actorKey != "" {
-		env.SetActorID(actorKey)
+	if agentID != "" {
+		env.SetAgentID(agentID)
 	}
 	// Producer kind ("engine") is encoded in the leading Subject
 	// segment by SubjectPrefix; the run id is also carried via
@@ -92,8 +105,12 @@ func publishGraphEvent(ctx context.Context, pub engine.Publisher, subject event.
 	_ = pub.Publish(ctx, env)
 }
 
-// publishNodeEvent is publishGraphEvent + node_id header.
-func publishNodeEvent(ctx context.Context, pub engine.Publisher, subject event.Subject, runID, graphName, actorKey, nodeID string, payload any) {
+// publishNodeEvent is publishGraphEvent + node_id header. The caller
+// passes agent id and node id as two separate dimensions (envelope
+// header level); the matching subject built by the caller carries
+// the compound stepActor (= agentID.node.nodeID) so subject-routed
+// and header-routed subscribers see the same picture.
+func publishNodeEvent(ctx context.Context, pub engine.Publisher, subject event.Subject, runID, graphName, agentID, nodeID string, payload any) {
 	if pub == nil {
 		return
 	}
@@ -107,8 +124,8 @@ func publishNodeEvent(ctx context.Context, pub engine.Publisher, subject event.S
 	if graphName != "" {
 		env.SetGraphID(graphName)
 	}
-	if actorKey != "" {
-		env.SetActorID(actorKey)
+	if agentID != "" {
+		env.SetAgentID(agentID)
 	}
 	if nodeID != "" {
 		env.SetNodeID(nodeID)

--- a/sdk/telemetry/attrs.go
+++ b/sdk/telemetry/attrs.go
@@ -52,6 +52,15 @@ const (
 	// top-level runs.
 	AttrParentRunID = "parent.run.id"
 
+	// AttrTaskID identifies the A2A-aligned task an operation
+	// belongs to (sdk/agent.Request.TaskID, mirrored into
+	// sdk/agent.Result.TaskID). Promoted by sdk/agent.Run into
+	// engine.Run.Attributes so engines / nodes / observers can
+	// recover it without reaching back through agent state.
+	// Optional: empty when the upstream Request did not carry a
+	// task identifier.
+	AttrTaskID = "task.id"
+
 	// AttrEngineKind identifies the concrete engine.Engine
 	// implementation (graph runner, future script engine, remote
 	// A2A bridge, ...). Producers SHOULD use a stable short token

--- a/sdk/telemetry/attrs.go
+++ b/sdk/telemetry/attrs.go
@@ -87,11 +87,15 @@ const (
 
 	// ----- Generic actor (engine-neutral) -----
 
-	// AttrActorID is the engine-neutral identifier of the unit of
-	// work that produced an event. Mirrors the engine.SubjectStep* /
-	// engine.SubjectStreamDelta `actor_id` segment. Graph runner
-	// sets it to the node id; script/other engines use their own
-	// stable id.
+	// AttrActorID is the legacy spelling of AttrAgentID. The "actor"
+	// terminology pre-dates the agent / step-actor distinction
+	// settled in v0.4: the producer identity (envelope agent_id /
+	// span attribute) and the engine.SubjectStep* "actor" segment
+	// (graph runner: agent.id + ".node." + node id) are two
+	// different dimensions, and the single "actor" name conflated
+	// them.
+	//
+	// Deprecated: use [AttrAgentID]. Removed in v0.5.0.
 	AttrActorID = "actor.id"
 
 	// ----- Tools -----

--- a/tests/e2e/vesseld/conformance_test.go
+++ b/tests/e2e/vesseld/conformance_test.go
@@ -30,8 +30,10 @@ import (
 //     i.e. the SSE stream and the registry are two consistent views
 //     of the same fact.
 //  5. The decoded JSON envelope on the wire has the exact field
-//     names documented (type / run_id / actor_id / subject / seq /
-//     ts / payload).
+//     names documented (type / run_id / agent_id / subject / seq /
+//     ts / payload). agent_id replaces the legacy "actor_id"
+//     spelling; the legacy header is still mirrored on the wire
+//     until v0.5.0 — see sdk/event/envelope.go SetAgentID dual-write.
 func TestE2E_Conformance_LifecycleEnvelope(t *testing.T) {
 	if testing.Short() {
 		t.Skip("e2e: skipped in -short mode")

--- a/vessel/logs.go
+++ b/vessel/logs.go
@@ -45,7 +45,13 @@ const (
 	LogEntryRunEnded LogEntryType = "run.ended"
 
 	// LogEntryStepStarted maps to engine.SubjectStepStart. ActorID
-	// is set to the engine's actor identifier (graph: node id).
+	// is set to the stepActor segment of the subject — which per
+	// the engine contract starts with the executing agent.id and
+	// MAY be followed by an engine-private suffix (graph runner:
+	// "<agent>_node_<nodeID>"; vessel inline: "<agent>_iter<N>").
+	// Consumers that want only the agent.id portion should read
+	// the envelope's HeaderAgentID instead, which is stamped by
+	// every engine and never carries the suffix.
 	LogEntryStepStarted LogEntryType = "step.started"
 
 	// LogEntryStepEnded maps to engine.SubjectStepComplete (success


### PR DESCRIPTION
## Summary

Closes the last open contract-audit item (#15: graph runner did not propagate `agent.id` onto envelopes). The audit revealed the broader issue: the historical "actor_id" name conflated **two distinct dimensions** that the post-v0.4 codebase needed to keep separate, and the conflation made the `engine.SubjectStep*` "actor" segment, `event.HeaderActorID`, and `telemetry.AttrActorID` look interchangeable when they were not. This PR settles the contract:

- **agent.id** = executor identity. The producer of an envelope. Goes onto the new `event.HeaderAgentID` ("agent_id"), the canonical `telemetry.AttrAgentID` span attribute, and the prefix of the `stepActor` subject segment.
- **stepActor** = engine-private locator for one unit of work inside one agent run (`<agent>.node.<nodeID>` for graph runner; `<agent>.iter<N>` for vessel inline). Lives only in the subject segment.

The migration is **dual-write to avoid a flag day**: producers stamp both `agent_id` (canonical) and `actor_id` (legacy mirror), consumers read `agent_id` first and fall back to `actor_id`. The legacy spelling is marked Deprecated v0.5.0 across `event.HeaderActorID`, `event.SetActorID`, `event.ActorID()`, `telemetry.AttrActorID`, and `runner.WithActorKey`.

Per-commit breakdown:

- **`d40092f` sdk/agent**: migrate run attribute keys to canonical `sdk/telemetry` dot-keys (`AttrAgentID` / `AttrTaskID` / `AttrConversationID`).
- **`b061c7e` sdk/event,sdk/telemetry**: introduce `HeaderAgentID` + `SetAgentID` (dual-write) + `AgentID()` (with legacy fallback). Deprecate `HeaderActorID`/`SetActorID`/`ActorID`/`AttrActorID` v0.5.0.
- **`0a85ae4` sdk/engine**: rename `SubjectStep*` `actorID` arg to `stepActor`; `EmitStreamDelta` splits `stepActor` into `agent.id` prefix + `.node.<nodeID>` suffix and projects them onto `HeaderAgentID` / `HeaderNodeID`. File-header godoc rewritten with the new contract.
- **`ed5b2d7` sdk/graph/runner**: introduce `agentIDFor(ctx, cfg)` (attributes win over ctx-key fallback) + `stepActorFor(agent, node)`. All four publish call sites (executor + parallel + node stream publisher) refactored to thread `agentID` + `nodeID` separately. Newly-added unit + Execute-level integration tests.
- **`05d2017` cmd/vesseld,vessel**: vessel inline engine `actorID -> agentID` rename + `publishLifecycle` takes `agentID` argument + payload split into `agent_id` / `step_actor` / `step_key` (Q3).
- **`156d646` sdk/graph/runner integration_test**: vertical E2E pinning the agent.Run -> envelope chain (every envelope MUST carry `agent_id`; legacy `actor_id` mirror MUST stay populated; step subjects MUST contain `<agent>_node_<nodeID>`; caller `WithAttributes` overrides `Agent.ID`).

`[skip-tag]` because this is the breaking-change wave for the `actor_id -> agent_id` rename — release coordinator should hand-tag if/when bumping, not the per-commit auto-tagger.

Refs: `internal-docs/contract-audit.md` #15.

## Test plan

- [x] `go test ./...` green across all 5 modules (sdk, sdkx, vessel, cmd/vesseld, voice)
- [x] `gofmt -l` clean
- [ ] CI green
- [ ] Verify no auto-tag fires (skip-tag honoured)


Made with [Cursor](https://cursor.com)