### PR TITLE
fix(sdk/recall): Add() honours Subject/Predicate so slot supersede works for per-fact scope routing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,71 @@ with its own tag prefix (e.g. `sdk/vX.Y.Z`, `vessel/vX.Y.Z`,
 
 ### Added
 
+#### sdk
+
+- `sdk/engine`: capabilities / resume / revise lifecycle. New
+  `engine/depname` package centralises Dependencies keys (LLMClient,
+  ToolRegistry, ToolAllowedNames, …) so engine authors and host
+  wiring stop relying on stringly-typed map keys. New
+  `engine.WithCapabilities` helper + `engineWithCaps` adapter lets
+  any engine declare a `Describer` without re-implementing the round
+  driver, finally honouring the long-standing "engines may declare
+  capabilities / may be resumable / Decider may ask for a revise"
+  contract in the public godocs.
+- `sdk/engine` + `sdk/tool`: built-in `ask_user` tool with
+  host-on-context plumbing. New `engine.WithHost(ctx, host)` /
+  `engine.HostFromContext(ctx)` helpers let any tool reach
+  `engine.Host.AskUser` from inside `tool.Tool.Execute`. The
+  llmnode round driver now wraps the tool dispatch context with
+  the live `Host`. Contract is advisory: tools that truly require a
+  host must surface `errdefs.NotAvailable` when absent.
+- `sdk/agent`: `WithParentRunID(string) RunOption` threads a parent
+  run ID through `runConfig` and stamps it onto every
+  `engine.Run.ParentRunID` the revise loop dispatches. Closes the
+  contract-audit gap where `engine.Run.ParentRunID` had been a typed
+  field with zero writers since v0.1; multi-agent call-chain loop /
+  depth detection now has the data it always claimed to have.
+- `sdk/agent`: `WithArtifactChannels(channels ...string) RunOption`
+  harvests board channels into `Result.Artifacts` at the end of a
+  run. Closes the contract-audit gap where `Result.Artifacts` had
+  been documented since v0.1 but no `agent.Run` code path
+  populated it — hosts that wrote artifact channels previously saw
+  the data vanish at the agent boundary.
+- `sdk/agent`: `Agent.Tools` finally takes effect as a policy gate.
+  `agent.Run` now promotes the agent's tool list into
+  `engine.Run.Deps[depname.ToolAllowedNames]` once per run, and
+  `llmnode.Node.resolveTools` enforces it on each tool dispatch.
+  Allow-list semantics: empty list = no gate (back-compat); non-empty
+  list = tools outside the set return `errdefs.PermissionDenied`.
+- `sdk/agent` + `sdk/graph/node/scriptnode`: `agent.RunInfoFromAttributes`
+  reads the standard agent_id / run_id / task_id / context_id
+  attribute keys back into a fully-populated `agent.RunInfo`.
+  scriptnode now uses it, so scripts see the full run identity
+  instead of `RunInfo{RunID: ec.RunID}` with empty AgentID / TaskID /
+  ContextID.
+- `sdk/graph`: `ExecutionContext.Deps` (`*engine.Dependencies`) and
+  `ExecutionContext.Attributes` (`map[string]string`) propagate from
+  `engine.Run` down to every node. Tools and scriptnode can now
+  resolve host-supplied dependencies (LLM clients, tool registries,
+  retrievers, …) without closure-binding them at builder time.
+- `sdk/graph/node/llmnode`: tool registry + allow-list resolution
+  from `ExecutionContext.Deps`. Per-run `*tool.Registry` and
+  per-agent allow-list flow through the graph cleanly; constructor-
+  bound registry is still honoured when no run-scoped registry is
+  present.
+- `sdk/recall`: `Entry.Subject` and `Entry.Predicate` opt-in fields.
+  When both are non-empty and slot-eligible (neither contains `|`),
+  `Memory.Add` now writes `MetaSubject` / `MetaPredicate` /
+  `MetaSlotKey` and participates in the slot supersede channel,
+  matching `Memory.Save`'s built-in extractor path. Closes
+  [#100](https://github.com/GizClaw/flowcraft/issues/100): callers
+  that fan out facts to different scopes per-fact (and therefore
+  must drive `Add` instead of `Save`) can now combine per-fact scope
+  routing with slot dedup. Backwards-compatible: existing `Add`
+  callers that leave both fields zero are unchanged.
+
+#### eval / docs
+
 - Top-level `README.md`, `CHANGELOG.md`, and `SECURITY.md`.
 - `eval/cmd/eval`: unified Cobra CLI replaces the per-suite
   `eval/<suite>/cmd/eval` mains. Invoke as `eval <suite>`; LoCoMo +
@@ -74,6 +139,19 @@ compare/fetch/ingest`, `eval longmemeval convert`). Shell completion
   | `…/bench/locomo/runners…`     | `…/eval/locomo/runners…` |
   | `…/bench/history-compression` | `…/eval/history`         |
   | `…/tests/quality/knowledge`   | `…/eval/knowledge`       |
+
+### Deprecated
+
+#### sdk
+
+- `agent.Request.Extensions`. Agent never interpreted the field, no
+  engine ever read it, and the `map[string]any` →
+  `map[string]string` type mismatch with `engine.Run.Attributes`
+  meant any future forwarding would have needed ad-hoc per-host
+  serialisation. Use `agent.WithAttributes(...)` instead — same
+  wire format, same codepath, no serialisation guesswork. The
+  field is retained for source compatibility but ignored on every
+  write path.
 
 ---
 

--- a/sdk/recall/codec.go
+++ b/sdk/recall/codec.go
@@ -1,6 +1,7 @@
 package recall
 
 import (
+	"strings"
 	"time"
 
 	"github.com/GizClaw/flowcraft/sdk/retrieval"
@@ -19,10 +20,25 @@ import (
 //	expires_at   int64 (unix-millis), only when ExpiresAt != nil
 //	category     string (legacy single-value mirror)
 //	runtime_id   string
+//	subject      string (slot, only when both Subject and Predicate set
+//	                     and neither contains the slot delimiter '|')
+//	predicate    string (same conditions as subject)
+//	slot_key     string (subject + "|" + predicate, same conditions)
 //
 // Note: session_id was removed in v0.2.0 (see Scope godoc). Old rows
 // that still carry session_id metadata are read back with the field
 // silently dropped, since [DocToEntry] no longer looks for it.
+//
+// Slot fields are written only when BOTH Subject and Predicate are
+// present and neither contains the slot delimiter '|'. Subjects or
+// predicates containing '|' would produce ambiguous slot_keys (e.g.
+// subject="user|alt"+predicate="lives_in" would collide with
+// subject="user"+predicate="alt|lives_in") and are silently dropped
+// from the slot channel; the entry still persists, just without
+// slot supersede support. This matches the contract that Save's
+// internal upsertFacts uses, so an Entry promoted from
+// [ExtractedFact] keeps identical storage semantics across the two
+// write paths.
 func EntryToDoc(e Entry) retrieval.Doc {
 	md := map[string]any{
 		"user_id":  e.Scope.UserID,
@@ -50,6 +66,14 @@ func EntryToDoc(e Entry) retrieval.Doc {
 	}
 	if e.ExpiresAt != nil && !e.ExpiresAt.IsZero() {
 		md["expires_at"] = e.ExpiresAt.UnixMilli()
+	}
+	// Slot fields share the eligibility rules with upsertFacts so any
+	// entry that gets a slot_key here is exactly the entry that
+	// supersedeBySlot will later be able to look up.
+	if entrySlotEligible(e.Subject, e.Predicate) {
+		md[MetaSubject] = e.Subject
+		md[MetaPredicate] = e.Predicate
+		md[MetaSlotKey] = e.Subject + slotDelimiter + e.Predicate
 	}
 	ts := e.UpdatedAt
 	if ts.IsZero() {
@@ -103,10 +127,33 @@ func DocToEntry(d retrieval.Doc) Entry {
 			e.ExpiresAt = &t
 		}
 	}
+	if v, ok := d.Metadata[MetaSubject].(string); ok {
+		e.Subject = v
+	}
+	if v, ok := d.Metadata[MetaPredicate].(string); ok {
+		e.Predicate = v
+	}
 	if e.Category == "" && len(e.Categories) > 0 {
 		e.Category = Category(e.Categories[0])
 	}
 	return e
+}
+
+// entrySlotEligible mirrors slotEligible's contract but works off a
+// plain (subject, predicate) pair so it can be called from EntryToDoc
+// without constructing an [ExtractedFact]. The rules MUST stay in sync
+// with [slotEligible].
+func entrySlotEligible(subject, predicate string) bool {
+	if subject == "" || predicate == "" {
+		return false
+	}
+	if strings.Contains(subject, slotDelimiter) {
+		return false
+	}
+	if strings.Contains(predicate, slotDelimiter) {
+		return false
+	}
+	return true
 }
 
 func stringSlice(v any) []string {

--- a/sdk/recall/entry.go
+++ b/sdk/recall/entry.go
@@ -156,6 +156,21 @@ type Entry struct {
 	Entities   []string   `json:"entities,omitempty"`   // linked entities
 	Confidence float64    `json:"confidence,omitempty"` // LLM-reported [0,1]
 	ExpiresAt  *time.Time `json:"expires_at,omitempty"` // soft TTL; nil = never
+
+	// Subject and Predicate, when both are non-empty and slot-eligible
+	// (neither contains the '|' slot delimiter), opt this entry into the
+	// slot supersede / SlotCollapse machinery. With these set, [Memory.Add]
+	// writes slot metadata identical to what [Memory.Save]'s built-in
+	// extractor produces and (when slot-merge is enabled via the default
+	// config or explicitly retained) marks older entries sharing the same
+	// (Subject, Predicate) tuple as superseded_by the new entry.
+	//
+	// Use case: callers that run their own extractor and fan out facts to
+	// different scopes per-fact (which Save's single-scope contract cannot
+	// model). Leaving both empty preserves the historical Add behaviour —
+	// no slot metadata, no supersede, no breakage of existing callers.
+	Subject   string `json:"subject,omitempty"`
+	Predicate string `json:"predicate,omitempty"`
 }
 
 // Source records the origin of a memory entry.

--- a/sdk/recall/memory_test.go
+++ b/sdk/recall/memory_test.go
@@ -301,6 +301,144 @@ func TestHistoryAndRollback(t *testing.T) {
 	}
 }
 
+// TestAddSlotMetadataAndSupersede pins the contract that Add, given a
+// slot-eligible (Subject, Predicate) tuple, writes slot metadata and
+// participates in the slot supersede channel identically to Save's
+// upsertFacts path. Regression test for issue #100: per-fact scope
+// routing callers (which must drive Add instead of Save) were
+// previously locked out of slot dedup even with WithSlotMerge on and
+// SlotCollapse wired on the read side.
+func TestAddSlotMetadataAndSupersede(t *testing.T) {
+	ctx := context.Background()
+	idx := memidx.New()
+	m, err := recall.New(idx, recall.WithRequireUserID())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer m.Close()
+	scope := newScope()
+	ns := recall.NamespaceFor(scope)
+
+	id1, err := m.Add(ctx, scope, recall.Entry{
+		Content:    "user lives in Tokyo",
+		Categories: []string{"profile"},
+		Subject:    "user",
+		Predicate:  "lives_in",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	doc1, ok, _ := idx.Get(ctx, ns, id1)
+	if !ok {
+		t.Fatalf("doc1 missing in index")
+	}
+	if got, _ := doc1.Metadata[recall.MetaSlotKey].(string); got != "user|lives_in" {
+		t.Fatalf("slot_key not written by Add: metadata=%+v", doc1.Metadata)
+	}
+	if got, _ := doc1.Metadata[recall.MetaSubject].(string); got != "user" {
+		t.Fatalf("MetaSubject missing/wrong: %v", doc1.Metadata[recall.MetaSubject])
+	}
+	if got, _ := doc1.Metadata[recall.MetaPredicate].(string); got != "lives_in" {
+		t.Fatalf("MetaPredicate missing/wrong: %v", doc1.Metadata[recall.MetaPredicate])
+	}
+
+	id2, err := m.Add(ctx, scope, recall.Entry{
+		Content:    "user lives in Osaka",
+		Categories: []string{"profile"},
+		Subject:    "user",
+		Predicate:  "lives_in",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if id2 == id1 {
+		t.Fatalf("expected distinct IDs, got %q twice", id1)
+	}
+	doc1After, _, _ := idx.Get(ctx, ns, id1)
+	sup, _ := doc1After.Metadata[recall.MetaSupersededBy].(string)
+	if sup != id2 {
+		t.Fatalf("expected doc1.superseded_by=%q, got %q (metadata=%+v)",
+			id2, sup, doc1After.Metadata)
+	}
+}
+
+// TestAddSlotIneligibleSilentlyDegrades pins the contract from
+// upsertFacts: subjects or predicates containing the slot delimiter
+// '|' produce ambiguous slot_keys and are silently dropped from the
+// slot channel. The entry still persists, just without slot metadata.
+func TestAddSlotIneligibleSilentlyDegrades(t *testing.T) {
+	ctx := context.Background()
+	idx := memidx.New()
+	m, _ := recall.New(idx, recall.WithRequireUserID())
+	defer m.Close()
+	scope := newScope()
+	ns := recall.NamespaceFor(scope)
+
+	cases := []struct {
+		name               string
+		subject, predicate string
+	}{
+		{"empty subject", "", "lives_in"},
+		{"empty predicate", "user", ""},
+		{"delimiter in subject", "user|alt", "lives_in"},
+		{"delimiter in predicate", "user", "alt|lives_in"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			id, err := m.Add(ctx, scope, recall.Entry{
+				Content:    "fact " + tc.name,
+				Categories: []string{"profile"},
+				Subject:    tc.subject,
+				Predicate:  tc.predicate,
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			doc, ok, _ := idx.Get(ctx, ns, id)
+			if !ok {
+				t.Fatalf("doc missing")
+			}
+			if _, has := doc.Metadata[recall.MetaSlotKey]; has {
+				t.Fatalf("ineligible tuple wrote slot_key: %+v", doc.Metadata)
+			}
+		})
+	}
+}
+
+// TestAddWithoutSlotChannelSkipsSupersede confirms that opting out of
+// the slot channel via WithoutSlotChannel disables Add-side supersede
+// even when the entry is slot-eligible. Parity with how Save honours
+// the same option.
+func TestAddWithoutSlotChannelSkipsSupersede(t *testing.T) {
+	ctx := context.Background()
+	idx := memidx.New()
+	m, _ := recall.New(idx,
+		recall.WithRequireUserID(),
+		recall.WithoutSlotChannel(),
+	)
+	defer m.Close()
+	scope := newScope()
+	ns := recall.NamespaceFor(scope)
+
+	id1, _ := m.Add(ctx, scope, recall.Entry{
+		Content: "a", Categories: []string{"profile"},
+		Subject: "user", Predicate: "lives_in",
+	})
+	_, _ = m.Add(ctx, scope, recall.Entry{
+		Content: "b", Categories: []string{"profile"},
+		Subject: "user", Predicate: "lives_in",
+	})
+	doc1, _, _ := idx.Get(ctx, ns, id1)
+	if _, has := doc1.Metadata[recall.MetaSupersededBy]; has {
+		t.Fatalf("WithoutSlotChannel should suppress supersede; doc1 metadata=%+v", doc1.Metadata)
+	}
+	// Slot metadata is still written so future opt-ins can collapse
+	// historical rows.
+	if got, _ := doc1.Metadata[recall.MetaSlotKey].(string); got != "user|lives_in" {
+		t.Fatalf("slot_key should still be written even with slot-merge off: %+v", doc1.Metadata)
+	}
+}
+
 // TestAddEmptyContentFailsFast pins the contract that recall.Add
 // validates Content before doing any derived work (ID hash, timestamps,
 // embedding). Regression test for the previous order which generated a

--- a/sdk/recall/save.go
+++ b/sdk/recall/save.go
@@ -211,6 +211,16 @@ func (m *lt) Add(ctx context.Context, scope Scope, e Entry) (string, error) {
 	d := EntryToDoc(e)
 	ns := NamespaceFor(scope)
 	m.rememberNamespace(ctx, ns)
+	// Slot supersede runs before the new doc lands so the new entry is
+	// never returned by supersedeBySlot's List(). The defensive
+	// "d.ID == newID" guard inside supersedeBySlot covers the race-free
+	// case where the new doc has already been inserted (eg async
+	// retry), but running before Upsert avoids it entirely in the
+	// happy path. Matches the ordering in upsertFacts.
+	if m.cfg.slotMerge && entrySlotEligible(e.Subject, e.Predicate) {
+		m.supersedeBySlot(ctx, scope, e.ID,
+			ExtractedFact{Subject: e.Subject, Predicate: e.Predicate}, now)
+	}
 	if err := m.idx.Upsert(ctx, ns, []retrieval.Doc{d}); err != nil {
 		span.RecordError(err)
 		addTotal.Add(ctx, 1, metric.WithAttributes(attribute.String("outcome", "fail"), attribute.String("reason", "upsert")))
@@ -302,6 +312,14 @@ func (m *lt) upsertFacts(
 				RuntimeID: scope.RuntimeID,
 				Timestamp: now,
 			},
+			// Subject / Predicate flow through Entry so EntryToDoc is the
+			// single source of truth for slot metadata writes. Eligibility
+			// (both fields set, neither containing '|') is enforced inside
+			// EntryToDoc; ineligible tuples silently degrade and the fact
+			// falls back to the vector / resolver supersede channels —
+			// same contract the slot writer had before this refactor.
+			Subject:   f.Subject,
+			Predicate: f.Predicate,
 		}
 		if len(entry.Categories) > 0 {
 			entry.Category = Category(entry.Categories[0])
@@ -319,22 +337,6 @@ func (m *lt) upsertFacts(
 		d.Metadata[MetaContentHash] = hashes[i]
 		if f.Source != "" {
 			d.Metadata[MetaSourceLabel] = f.Source
-		}
-		// Slot fields are written only when BOTH Subject and Predicate are
-		// present so that the slot supersede channel and the SlotCollapse
-		// retrieval stage can rely on slot_key being unambiguous.
-		//
-		// Subjects/predicates that contain the slot delimiter '|' would
-		// produce ambiguous slot_keys (e.g. subject="user|alt"+
-		// predicate="lives_in" would collide with subject="user"+
-		// predicate="alt|lives_in"). The Save path drops the slot
-		// fields entirely in that case so the fact degrades to the
-		// vector / resolver supersede channels — slot writers stay
-		// strict, the rest of the pipeline keeps working.
-		if slotEligible(f) {
-			d.Metadata[MetaSubject] = f.Subject
-			d.Metadata[MetaPredicate] = f.Predicate
-			d.Metadata[MetaSlotKey] = f.Subject + slotDelimiter + f.Predicate
 		}
 		plans = append(plans, plan{entry: entry, doc: d, fact: f})
 		returnedIDs = append(returnedIDs, entry.ID)


### PR DESCRIPTION
Closes #100.

## Root cause

`Memory.Add` was a silent slot dead-end:

| component | `Save` path | `Add` path (before this PR) |
| --- | --- | --- |
| writes `MetaSlotKey` / `MetaSubject` / `MetaPredicate` | yes (inline in `upsertFacts`) | **no** |
| invokes `supersedeBySlot` | yes (via `supersedeNeighbours`) | **no** |
| visible to `WithSlotMerge(true)` | yes | **no** |
| visible to `pipeline.WithSlotCollapse(true)` | yes | **no** |

This silently locks out advanced callers — including ones who explicitly opt into both `WithSlotMerge` and `WithSlotCollapse` — because they need `Add` to fan out facts to different scopes per-fact (a flow `Save`'s single-scope contract cannot model).

Verified against every claim in the issue:

- `recall.Entry` has no `Subject` / `Predicate` fields → `sdk/recall/entry.go:145-159` ✓
- `Add` only does `EntryToDoc(e) + Upsert(...)` → `sdk/recall/save.go:168-226` ✓
- `EntryToDoc` writes `user_id` / `agent_id` / `category` / etc., never slot keys → `sdk/recall/codec.go:26-67` ✓
- Slot metadata is written in exactly one place, `upsertFacts:334-338` → confirmed; only `Save` / `SaveAsync` reach `upsertFacts` ✓
- `supersedeBySlot` / `supersedeNeighbours` only called from `upsertFacts:372`, never from `Add` ✓

This is a real SDK bug, not a misuse.

## Fix

Per the reporter's Option 1 (extend `Entry`):

1. **`sdk/recall/entry.go`** — add optional `Subject string` / `Predicate string` to `Entry` with the same eligibility contract `Save` uses (both non-empty, neither contains `|`). Zero values preserve historical `Add` behaviour exactly.
2. **`sdk/recall/codec.go`** — `EntryToDoc` writes `MetaSubject` / `MetaPredicate` / `MetaSlotKey` when both fields are slot-eligible. `DocToEntry` reads them back. Becomes the **single source of truth** for slot metadata serialisation; `upsertFacts` no longer needs its inline write.
3. **`sdk/recall/save.go`**
   - `Add` invokes `supersedeBySlot(scope, e.ID, ...)` when `cfg.slotMerge && entrySlotEligible(...)`, **before** the new doc is upserted (so the supersede `List()` never returns the new doc — matches `upsertFacts` ordering).
   - `upsertFacts` now copies `f.Subject` / `f.Predicate` onto the `Entry` and lets `EntryToDoc` handle the slot triplet, removing the duplicate inline block.

## Tests (`sdk/recall/memory_test.go`)

- `TestAddSlotMetadataAndSupersede` — Add writes the slot triplet; a second Add for the same `(Subject, Predicate)` tags the first row with `superseded_by`.
- `TestAddSlotIneligibleSilentlyDegrades` — empty / delimiter-bearing tuples persist the entry but skip slot metadata, matching the `Save` contract.
- `TestAddWithoutSlotChannelSkipsSupersede` — `WithoutSlotChannel` disables Add-side supersede; `slot_key` is still written so a future opt-in can collapse historical rows.

Full SDK suite green (`go test ./sdk/...`); recall package green with `-race`.

## Changelog backfill

Also backfills `[Unreleased]` with the eight other sdk contract-audit changes that landed since `sdk/v0.3.3` (capabilities / resume / revise lifecycle, ask_user tool, `WithParentRunID`, `WithArtifactChannels`, `Agent.Tools` policy gate, `RunInfoFromAttributes`, `ExecutionContext.Deps` + `Attributes` propagation, llmnode tool registry / allow-list resolution, `agent.Request.Extensions` deprecation) so the next sdk patch release ships a complete release note instead of just this fix.

## Compat

- Public API: additive only. `Entry.Subject` / `Entry.Predicate` are new optional fields. `EntryToDoc` / `DocToEntry` gained two metadata keys that older readers either honour or ignore.
- Existing callers: any `Add` call that leaves both fields zero is byte-identical to the previous behaviour (verified via the `EntryToDoc` "ineligible silently degrades" test).

## Test plan

- [x] `go test ./sdk/recall/...` green (incl. new tests)
- [x] `go test -race ./sdk/recall/...` green
- [x] `go test ./sdk/...` full sweep green
- [ ] Reporter verifies on their per-fact scope routing path

## Autotag

Only the `sdk` module is touched in this PR; the commit body carries `[skip-tag:sdkx][skip-tag:voice][skip-tag:vessel]` so autotag only bumps `sdk`.


Made with [Cursor](https://cursor.com)