### PR TITLE
chore(eval): bump sdk v0.3.4 + sdkx v0.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -145,6 +145,17 @@ compare/fetch/ingest`, `eval longmemeval convert`). Shell completion
 
 ### Changed
 
+#### eval
+
+- `eval/go.mod`: bump `sdk` v0.3.0 → v0.3.4 and `sdkx` v0.3.0 → v0.3.1.
+  Picks up the `sdk/recall.Add` slot-metadata fix (issue #100) and the
+  `sdkx/llm` nil-response guards (PR #103) so the LongMemEval `_s`
+  runner no longer panics at `sdkx/llm/openai/openai.go:314` when
+  DeepSeek's OpenAI-compatible backend answers a queued request with
+  literal JSON `null` — failures now surface as clean
+  `errdefs.NotAvailable` errors that the per-question scorer reports
+  as `error` instead of crashing the whole run.
+
 - **Breaking (internal)**: evaluation code consolidated under `eval/`,
   freeing the word `bench` for Go's `Benchmark*` performance
   benchmarks. Shared `dataset/` and `metrics/` packages were promoted

--- a/eval/go.mod
+++ b/eval/go.mod
@@ -9,8 +9,8 @@ go 1.25.0
 // PR rather than coupling sdk's release cadence to this directory.
 
 require (
-	github.com/GizClaw/flowcraft/sdk v0.3.0
-	github.com/GizClaw/flowcraft/sdkx v0.3.0
+	github.com/GizClaw/flowcraft/sdk v0.3.4
+	github.com/GizClaw/flowcraft/sdkx v0.3.1
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/pflag v1.0.9
 )

--- a/eval/go.sum
+++ b/eval/go.sum
@@ -8,10 +8,10 @@ github.com/Azure/azure-sdk-for-go/sdk/internal v1.10.0/go.mod h1:iZDifYGJTIgIIkY
 github.com/AzureAD/microsoft-authentication-library-for-go v1.2.2 h1:XHOnouVk1mxXfQidrMEnLlPk9UMeRtyBTnEFtxkV0kU=
 github.com/AzureAD/microsoft-authentication-library-for-go v1.2.2/go.mod h1:wP83P5OoQ5p6ip3ScPr0BAq0BvuPAvacpEuSzyouqAI=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
-github.com/GizClaw/flowcraft/sdk v0.3.0 h1:7l5S4LoWPLvFHlJ0jhU5Sgq5tIRfAw29LO5fTDiRe8g=
-github.com/GizClaw/flowcraft/sdk v0.3.0/go.mod h1:VeMqVBxnMGHtFO9ypHhsA591XoLCWxucXR+gqpxQt5s=
-github.com/GizClaw/flowcraft/sdkx v0.3.0 h1:uGDtp+dVX8lxP8sPSqqdemqeDPKwk/AWOs/5IQ/FG8M=
-github.com/GizClaw/flowcraft/sdkx v0.3.0/go.mod h1:jTqH/OQD6OsehOKk7wSn1b0fg+bmMlVLIc4YjQFCgoA=
+github.com/GizClaw/flowcraft/sdk v0.3.4 h1:Bma2skumOsm4Mrts8/or03iIugSQz3P/rinKIuaRBsQ=
+github.com/GizClaw/flowcraft/sdk v0.3.4/go.mod h1:VeMqVBxnMGHtFO9ypHhsA591XoLCWxucXR+gqpxQt5s=
+github.com/GizClaw/flowcraft/sdkx v0.3.1 h1:2HzXK+FmOGlnJ01m4NbUR+N7bx2O4SXHz5flvN+yizY=
+github.com/GizClaw/flowcraft/sdkx v0.3.1/go.mod h1:AuzpJHWVDNZKD8J8frY5qjmYU2IoEg4X3Rs0q232pnY=
 github.com/anthropics/anthropic-sdk-go v1.26.0 h1:oUTzFaUpAevfuELAP1sjL6CQJ9HHAfT7CoSYSac11PY=
 github.com/anthropics/anthropic-sdk-go v1.26.0/go.mod h1:qUKmaW+uuPB64iy1l+4kOSvaLqPXnHTTBKH6RVZ7q5Q=
 github.com/avast/retry-go v3.0.0+incompatible/go.mod h1:XtSnn+n/sHqQIpZ10K1qAevBhOOCWBLXXy3hyiqqBrY=


### PR DESCRIPTION
## Summary

- `eval/go.mod`: `sdk` v0.3.0 → **v0.3.4**, `sdkx` v0.3.0 → **v0.3.1**.
- No source changes in `eval/`; only `go.mod` / `go.sum` and a CHANGELOG note.
- Deliberately **defers** RateLimit / NotAvailable backoff-retry in eval (per request) — that lands in a follow-up.

## Why

Picks up two fixes that the in-flight LongMemEval `_s` run needs:

1. **`sdk` v0.3.4** — `recall.Memory.Add` now persists `Subject` /
   `Predicate` / `slot_key` metadata and participates in slot supersede
   (issue [#100](https://github.com/GizClaw/flowcraft/issues/100)).
   Brings `Add` to parity with `Save` for callers that fan out facts to
   per-fact scopes.

2. **`sdkx` v0.3.1** — nil-response guards across
   `openai` / `anthropic` / `bytedance` / `ollama` and the image
   variants ([#103](https://github.com/GizClaw/flowcraft/pull/103)).
   Closes the real `_s` crash where DeepSeek's OpenAI-compatible
   backend answered a 10-minute queued request with literal JSON
   `null` and the runner panicked at
   `sdkx/llm/openai/openai.go:314`. Failures now surface as clean
   `errdefs.NotAvailable` errors that the per-question scorer reports
   as `error` instead of crashing the whole run.

## Test plan

- [x] `GOWORK=off go build ./...` from `eval/` passes.
- [x] `GOWORK=off go test -count=1 -short ./...` from `eval/` passes (all suites green).
- [ ] After merge: rebuild eval binary on the remote server, restart `lme-s-full`, verify the previous panic site no longer trips.

Made with [Cursor](https://cursor.com)