### PR TITLE
feat(sdk/model): TokenUsage.CachedInputTokens for prompt-cache observability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,24 @@ with its own tag prefix (e.g. `sdk/vX.Y.Z`, `vessel/vX.Y.Z`,
 
 #### sdk
 
+- `sdk/model`: `TokenUsage.CachedInputTokens` field for prompt-cache
+  observability. All three families of cache-aware providers expose
+  cached input tokens under different wire names —
+  OpenAI / Azure / DeepSeek / Qwen-flash report
+  `usage.prompt_tokens_details.cached_tokens`,
+  Anthropic / Minimax report `usage.cache_read_input_tokens`,
+  ByteDance Doubao reports
+  `usage.prompt_tokens_details.cached_tokens`. The new field lets
+  sdkx adapters normalise these into a single observable so callers
+  can compute a uniform `CachedInputTokens / InputTokens` hit-rate
+  without provider-specific branching. The field is additive,
+  `omitempty`-tagged (zero value vanishes from the wire format),
+  participates in `TokenUsage.Add` so cumulative reporters
+  aggregate cached counts the same way they aggregate input /
+  output tokens, and stays zero on providers (or model SKUs) that
+  do not surface a cache breakdown — wire-format back-compatible
+  with v0.3.4 readers. A follow-up sdkx release wires the three
+  cache-aware adapters to populate the field.
 - `sdk/engine`: capabilities / resume / revise lifecycle. New
   `engine/depname` package centralises Dependencies keys (LLMClient,
   ToolRegistry, ToolAllowedNames, …) so engine authors and host

--- a/sdk/model/message.go
+++ b/sdk/model/message.go
@@ -269,6 +269,25 @@ type TokenUsage struct {
 	OutputTokens int64 `json:"output_tokens"`
 	TotalTokens  int64 `json:"total_tokens"`
 
+	// CachedInputTokens is the subset of InputTokens that hit the
+	// provider's prompt cache and are therefore billed at a reduced
+	// rate (typically 10x cheaper). It is always <= InputTokens.
+	//
+	// Different providers expose this under different names but the
+	// semantics are aligned: OpenAI / DeepSeek / Azure / Qwen report
+	// `usage.prompt_tokens_details.cached_tokens`, Anthropic /
+	// Minimax report `usage.cache_read_input_tokens`, ByteDance
+	// Doubao reports `usage.prompt_tokens_details.cached_tokens`.
+	// The Generate / stream paths normalise these into this single
+	// field so callers can compute a cache hit-rate uniformly via
+	// CachedInputTokens / InputTokens without provider-specific
+	// branching.
+	//
+	// Zero means either the provider does not expose cache stats
+	// or no cache hit occurred on this call. omitempty keeps the
+	// wire format stable for providers that never set it.
+	CachedInputTokens int64 `json:"cached_input_tokens,omitempty"`
+
 	// Model is the resolved LLM model name this usage came from
 	// (e.g. "gpt-4o", "claude-3-7-sonnet-20250219"). Empty when the
 	// reporter does not know which model produced the call (test
@@ -305,12 +324,13 @@ func (u TokenUsage) Add(other TokenUsage) TokenUsage {
 		model = other.Model
 	}
 	return TokenUsage{
-		InputTokens:  u.InputTokens + other.InputTokens,
-		OutputTokens: u.OutputTokens + other.OutputTokens,
-		TotalTokens:  u.TotalTokens + other.TotalTokens,
-		Model:        model,
-		LatencyMs:    u.LatencyMs + other.LatencyMs,
-		CostMicros:   u.CostMicros + other.CostMicros,
+		InputTokens:       u.InputTokens + other.InputTokens,
+		CachedInputTokens: u.CachedInputTokens + other.CachedInputTokens,
+		OutputTokens:      u.OutputTokens + other.OutputTokens,
+		TotalTokens:       u.TotalTokens + other.TotalTokens,
+		Model:             model,
+		LatencyMs:         u.LatencyMs + other.LatencyMs,
+		CostMicros:        u.CostMicros + other.CostMicros,
 	}
 }
 

--- a/sdk/model/message_test.go
+++ b/sdk/model/message_test.go
@@ -1,6 +1,10 @@
 package model
 
-import "testing"
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+)
 
 func TestMessage_Content(t *testing.T) {
 	msg := Message{
@@ -145,6 +149,46 @@ func TestTokenUsage_Add_Enriched(t *testing.T) {
 		sum := acc.Add(delta)
 		if sum.Model != "claude" || sum.CostMicros != 80 {
 			t.Errorf("got %+v, want Model=claude Cost=80", sum)
+		}
+	})
+
+	t.Run("cached input tokens sum across deltas", func(t *testing.T) {
+		acc := TokenUsage{InputTokens: 100, CachedInputTokens: 60}
+		delta := TokenUsage{InputTokens: 80, CachedInputTokens: 50}
+		sum := acc.Add(delta)
+		if sum.InputTokens != 180 || sum.CachedInputTokens != 110 {
+			t.Errorf("Input=%d Cached=%d, want 180 / 110", sum.InputTokens, sum.CachedInputTokens)
+		}
+	})
+}
+
+func TestTokenUsage_CachedInputTokens_JSON(t *testing.T) {
+	t.Run("zero value omits cached_input_tokens (back-compat with v<=0.3.4)", func(t *testing.T) {
+		u := TokenUsage{InputTokens: 10, OutputTokens: 5, TotalTokens: 15}
+		b, err := json.Marshal(u)
+		if err != nil {
+			t.Fatalf("Marshal: %v", err)
+		}
+		if bytes.Contains(b, []byte("cached_input_tokens")) {
+			t.Errorf("zero value should omit cached_input_tokens, got %s", b)
+		}
+	})
+
+	t.Run("non-zero serialises and round-trips", func(t *testing.T) {
+		u := TokenUsage{InputTokens: 1000, CachedInputTokens: 800, OutputTokens: 50, TotalTokens: 1050}
+		b, err := json.Marshal(u)
+		if err != nil {
+			t.Fatalf("Marshal: %v", err)
+		}
+		if !bytes.Contains(b, []byte(`"cached_input_tokens":800`)) {
+			t.Errorf("expected cached_input_tokens in JSON, got %s", b)
+		}
+		var got TokenUsage
+		if err := json.Unmarshal(b, &got); err != nil {
+			t.Fatalf("Unmarshal: %v", err)
+		}
+		if got.CachedInputTokens != 800 {
+			t.Errorf("round-trip CachedInputTokens = %d, want 800", got.CachedInputTokens)
 		}
 	})
 }


### PR DESCRIPTION
## Summary

Adds `CachedInputTokens int64` to `model.TokenUsage` (re-exported as `llm.TokenUsage`) so the cached subset of prompt tokens is observable through the public SDK surface.

This is the **first half** of validating the prompt-cache PR (#109). Without this field there is no provider-agnostic way to read whether a call hit the prompt cache: each provider exposes the count under its own wire name and sdkx today discards all of them in the `Generate` / streaming finish paths.

## Field semantics

| Provider family            | SDK response field                                  |
| -------------------------- | --------------------------------------------------- |
| OpenAI / Azure / DeepSeek / Qwen-flash | \`usage.prompt_tokens_details.cached_tokens\` |
| Anthropic / Minimax        | \`usage.cache_read_input_tokens\`                    |
| ByteDance Doubao           | \`usage.prompt_tokens_details.cached_tokens\`        |

All three are normalised into `TokenUsage.CachedInputTokens`. Callers compute hit-rate uniformly via `CachedInputTokens / InputTokens` with no provider branching.

## Wire compatibility

- New field is `omitempty`-tagged — zero value vanishes from JSON, so v0.3.4 readers see identical bytes for non-cached calls.
- Participates in `TokenUsage.Add` so cumulative reporters aggregate cached counts the same way they aggregate input/output tokens.

## Follow-up

Next PR (sdkx side) wires:

- \`sdkx/llm/openai\`: read \`resp.Usage.PromptTokensDetails.CachedTokens\` in Generate + streaming finish.
- \`sdkx/llm/anthropic\`: read \`resp.Usage.CacheReadInputTokens\` in Generate + streaming finish (stable + Beta API).
- \`sdkx/llm/bytedance\`: read \`resp.Usage.PromptTokensDetails.CachedTokens\`.
- httptest-based unit tests for each adapter asserting the field is populated.
- conformance-suite cache test that issues two back-to-back calls with stable system prefix and asserts \`CachedInputTokens > 0\` on the second call.

## Test plan

- [x] \`go test ./sdk/...\` (sdk module — local)
- [ ] CI green
- [ ] Tag \`sdk/v0.3.5\` once merged so sdkx follow-up can pin it

Made with [Cursor](https://cursor.com)