### PR TITLE
test(tests/conformance/llm): live prompt-cache hit-rate probe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -140,6 +140,27 @@ compare/fetch/ingest`, `eval longmemeval convert`). Shell completion
   JSON loader with shadow-run scoring. NOT a PR gate (LLM-call-heavy;
   weekly/release-time use only).
 
+#### tests/conformance
+
+- `tests/conformance/llm/cached_tokens_test.go`: live double-call
+  prompt-cache hit-rate probe. Issues two back-to-back Generate
+  calls with a ≥ 22 KB (~4000-token) byte-identical system prefix
+  and asserts `CachedInputTokens > 0` on the second call for
+  providers where caching is contractually expected (anthropic /
+  minimax via adapter `cache_control`, bytedance Doubao
+  transparent prefix caching) and warns when implicit caching
+  providers (azure / deepseek / qwen) return zero. Validates the
+  full chain: sdkx-side `cache_control` / `prompt_cache_key`
+  injection → provider honours it → adapter populates
+  `TokenUsage.CachedInputTokens` correctly. Measured against live
+  providers from the repo `.env`: azure 96.6%, deepseek 98.0%,
+  minimax (anthropic-family) 99.5% — providing concrete evidence
+  that the prompt-cache optimisation work shipped over PR #109 and
+  the cached-tokens plumbing shipped over the sdkx v0.3.3 follow-up
+  is rewarded with the expected cheaper billing. Self-skips per
+  provider when its FLOWCRAFT_TEST_* env var is missing, matching
+  the existing conformance suite convention.
+
 ### Fixed
 
 #### sdkx

--- a/tests/conformance/go.mod
+++ b/tests/conformance/go.mod
@@ -3,8 +3,8 @@ module github.com/GizClaw/flowcraft/tests/conformance
 go 1.25.0
 
 require (
-	github.com/GizClaw/flowcraft/sdk v0.3.4
-	github.com/GizClaw/flowcraft/sdkx v0.3.1
+	github.com/GizClaw/flowcraft/sdk v0.3.5
+	github.com/GizClaw/flowcraft/sdkx v0.3.3
 )
 
 require (

--- a/tests/conformance/go.sum
+++ b/tests/conformance/go.sum
@@ -8,10 +8,10 @@ github.com/Azure/azure-sdk-for-go/sdk/internal v1.10.0/go.mod h1:iZDifYGJTIgIIkY
 github.com/AzureAD/microsoft-authentication-library-for-go v1.2.2 h1:XHOnouVk1mxXfQidrMEnLlPk9UMeRtyBTnEFtxkV0kU=
 github.com/AzureAD/microsoft-authentication-library-for-go v1.2.2/go.mod h1:wP83P5OoQ5p6ip3ScPr0BAq0BvuPAvacpEuSzyouqAI=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
-github.com/GizClaw/flowcraft/sdk v0.3.4 h1:Bma2skumOsm4Mrts8/or03iIugSQz3P/rinKIuaRBsQ=
-github.com/GizClaw/flowcraft/sdk v0.3.4/go.mod h1:VeMqVBxnMGHtFO9ypHhsA591XoLCWxucXR+gqpxQt5s=
-github.com/GizClaw/flowcraft/sdkx v0.3.1 h1:2HzXK+FmOGlnJ01m4NbUR+N7bx2O4SXHz5flvN+yizY=
-github.com/GizClaw/flowcraft/sdkx v0.3.1/go.mod h1:AuzpJHWVDNZKD8J8frY5qjmYU2IoEg4X3Rs0q232pnY=
+github.com/GizClaw/flowcraft/sdk v0.3.5 h1:Fmoon2bs36FwV85pDaF/5s86qVyvq5gAq3UkeUcHJD4=
+github.com/GizClaw/flowcraft/sdk v0.3.5/go.mod h1:VeMqVBxnMGHtFO9ypHhsA591XoLCWxucXR+gqpxQt5s=
+github.com/GizClaw/flowcraft/sdkx v0.3.3 h1:QxvS0k0aNUCGsjB3s2JESe/p4wjCNUE5B5XjqZH5ly4=
+github.com/GizClaw/flowcraft/sdkx v0.3.3/go.mod h1:aJO/NiSnBzhFAQSXe4e2E3nIOBuNGy0MjX5ADG7xP44=
 github.com/anthropics/anthropic-sdk-go v1.26.0 h1:oUTzFaUpAevfuELAP1sjL6CQJ9HHAfT7CoSYSac11PY=
 github.com/anthropics/anthropic-sdk-go v1.26.0/go.mod h1:qUKmaW+uuPB64iy1l+4kOSvaLqPXnHTTBKH6RVZ7q5Q=
 github.com/avast/retry-go v3.0.0+incompatible/go.mod h1:XtSnn+n/sHqQIpZ10K1qAevBhOOCWBLXXy3hyiqqBrY=

--- a/tests/conformance/llm/cached_tokens_test.go
+++ b/tests/conformance/llm/cached_tokens_test.go
@@ -1,0 +1,197 @@
+package llm_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/GizClaw/flowcraft/sdk/llm"
+)
+
+// cachedTokensProviders is the subset of conformance providers we
+// exercise for prompt-cache hit-rate. Each entry must point at a
+// model SKU that actually supports prefix caching on the relevant
+// platform:
+//
+//   - Anthropic / Minimax → explicit cache_control set by the
+//     adapter (sdkx/llm/anthropic/cache.go).
+//   - Azure OpenAI / OpenAI / DeepSeek / Qwen-flash → implicit
+//     automatic prefix caching once the prompt exceeds the
+//     provider's minimum (≥ 1024 tokens on all four).
+//   - ByteDance Doubao → transparent prefix caching, no opt-in.
+//
+// We deliberately leave Anthropic out of the main `providers`
+// list in provider_test.go (it is gated behind FLOWCRAFT_TEST_ANTHROPIC
+// and most CI hosts do not have an Anthropic key) but include it
+// here because the cache normalisation (three-bucket → gross/cached)
+// is unique to that family and worth covering end-to-end whenever
+// the key is present.
+var cachedTokensProviders = []providerSpec{
+	{Provider: "anthropic", Env: "FLOWCRAFT_TEST_ANTHROPIC"},
+	{Provider: "minimax", Env: "FLOWCRAFT_TEST_MINIMAX"},
+	{Provider: "qwen", Env: "FLOWCRAFT_TEST_QWEN"},
+	{Provider: "bytedance", Env: "FLOWCRAFT_TEST_BYTEDANCE"},
+	{Provider: "azure", Env: "FLOWCRAFT_TEST_AZURE"},
+	{Provider: "deepseek", Env: "FLOWCRAFT_TEST_DEEPSEEK"},
+}
+
+// buildStableSystemPrompt returns a deterministic ~22 KB string that
+// safely clears every supported provider's minimum-cacheable-prompt
+// threshold:
+//
+//   - Anthropic / Minimax: 1024-token minimum cache breakpoint (see
+//     https://docs.anthropic.com/en/docs/build-with-claude/prompt-caching#cache-limitations).
+//     Below this the API silently refuses to honour `cache_control`.
+//   - OpenAI / Azure OpenAI: prompt caching kicks in at 1024 prompt
+//     tokens (https://platform.openai.com/docs/guides/prompt-caching).
+//   - DeepSeek: hard 1024-token minimum.
+//   - Qwen-flash: no documented floor but quieter regions need
+//     long prompts to reliably populate the cache index.
+//   - ByteDance Doubao: transparent prefix caching, no documented
+//     floor; generous length still helps.
+//
+// We aim for ≥ 3000 tokens (≈ 22 KB English) to clear every floor
+// with comfortable margin. The seed is a literal block (no random
+// padding, no timestamps) so the prefix is byte-identical across
+// calls — providers compute cache keys by exact-prefix hashing, so
+// a single shifting byte would tank the hit rate to 0%.
+func buildStableSystemPrompt() string {
+	const seed = "You are a calm, precise assistant. Reply concisely and avoid speculation. " +
+		"Treat every user message as a self-contained task with no implicit shared history. " +
+		"Quote facts only when the supplied context contains them verbatim. " +
+		"If the user request is ambiguous, ask exactly one short clarifying question and stop. " +
+		"Do not invent tool names, file paths, URLs, dates, version numbers, or quantities. "
+	return strings.Repeat(seed, 50) // ≈ 22 KB ≈ 4000+ tokens, comfortably above every provider's 1024 floor.
+}
+
+// TestProviders_PromptCacheHitRate verifies end-to-end that the
+// prompt-cache plumbing introduced in sdkx/llm/{anthropic,openai,
+// bytedance}/cache.go + the CachedInputTokens normalisation in the
+// adapter Generate paths actually produces a non-zero cache hit
+// rate on a second back-to-back call with an identical stable
+// prefix.
+//
+// Why this lives in conformance (not adapter httptest): the value
+// the user cares about is "did our cache_control / prompt_cache_key
+// / multi-segment system convention land on the wire in a way the
+// real provider actually rewarded with cheaper billing?". Replaying
+// a hand-rolled JSON payload through httptest can only tell us the
+// adapter *reads* `cached_tokens` correctly — it cannot tell us the
+// upstream cache machinery decided we deserved a hit. Only a live
+// double-call can.
+//
+// Skip semantics: each provider's sub-test calls t.Skip() when its
+// env var is missing, so a credential-less `make conformance` run
+// becomes a no-op for this file. This matches the existing
+// conformance suite's convention.
+func TestProviders_PromptCacheHitRate(t *testing.T) {
+	stableSystem := buildStableSystemPrompt()
+
+	for _, spec := range cachedTokensProviders {
+		t.Run(spec.Provider, func(t *testing.T) {
+			provider := createProvider(t, spec)
+
+			// Use a single generous timeout that covers both calls:
+			// warm-up writes the cache (no observable saving), the
+			// follow-up reads it. We sequence them under one ctx so
+			// a hang on call #1 does not let call #2 leak past.
+			ctx, cancel := context.WithTimeout(context.Background(), 90*time.Second)
+			defer cancel()
+
+			baseMsgs := []llm.Message{
+				llm.NewTextMessage(llm.RoleSystem, stableSystem),
+				llm.NewTextMessage(llm.RoleUser, "Step 1 of 2: respond with the literal word OK."),
+			}
+
+			// Warm-up call. Most providers will report
+			// CachedInputTokens=0 here (cold cache). Anthropic +
+			// ByteDance may already report a low non-zero value when
+			// another recent run primed the same prefix — that's
+			// fine; we treat this as advisory only.
+			_, u1, err := provider.Generate(ctx, baseMsgs, llm.WithMaxTokens(20), llm.WithTemperature(0.1))
+			if err != nil {
+				t.Fatalf("warm-up call failed: %v", err)
+			}
+			t.Logf("warm-up: input=%d cached=%d output=%d (hit-rate=%.1f%%)",
+				u1.InputTokens, u1.CachedInputTokens, u1.OutputTokens,
+				ratePct(u1.CachedInputTokens, u1.InputTokens))
+
+			// Follow-up call: identical system + tools, only the
+			// trailing user message changes. The fresh user tokens
+			// are short (<50 tokens) compared with the multi-KB
+			// system prefix, so the cache hit rate must dominate.
+			hitMsgs := []llm.Message{
+				llm.NewTextMessage(llm.RoleSystem, stableSystem),
+				llm.NewTextMessage(llm.RoleUser, "Step 2 of 2: respond with the literal word DONE."),
+			}
+			_, u2, err := provider.Generate(ctx, hitMsgs, llm.WithMaxTokens(20), llm.WithTemperature(0.1))
+			if err != nil {
+				t.Fatalf("follow-up call failed: %v", err)
+			}
+			t.Logf("follow-up: input=%d cached=%d output=%d (hit-rate=%.1f%%)",
+				u2.InputTokens, u2.CachedInputTokens, u2.OutputTokens,
+				ratePct(u2.CachedInputTokens, u2.InputTokens))
+
+			// Hard contract: input must be reported and dominate
+			// output. Without this the rest of the assertions are
+			// meaningless (a zero-input call cannot have a cache
+			// breakdown).
+			if u2.InputTokens == 0 {
+				t.Fatalf("InputTokens=0 on follow-up: provider didn't report prompt usage")
+			}
+
+			// Soft contract: most providers honour the cache. We
+			// only enforce a STRICT non-zero requirement on the
+			// adapters where we either explicitly drive caching
+			// (anthropic / minimax via cache_control) or where
+			// transparent caching is documented to be reliable for
+			// the model SKU (bytedance Doubao). For OpenAI-family
+			// implicit caching the threshold can be flaky on
+			// quieter regions / smaller SKUs, so we only warn.
+			strictHit := spec.Provider == "anthropic" || spec.Provider == "minimax" || spec.Provider == "bytedance"
+			if strictHit && u2.CachedInputTokens == 0 {
+				t.Errorf("expected CachedInputTokens>0 on follow-up for %s (cache writes via adapter cache_control / transparent prefix), got 0",
+					spec.Provider)
+			}
+			if !strictHit && u2.CachedInputTokens == 0 {
+				t.Logf("WARN: provider %s reported CachedInputTokens=0 on follow-up. Could be (a) cold region, (b) prompt below provider minimum, or (c) adapter regression. Investigate before claiming optimisation works.",
+					spec.Provider)
+			}
+
+			// Invariant — same as the unit test, but enforced
+			// against live wire numbers so an adapter regression
+			// that decodes the wrong field would be caught here.
+			if u2.CachedInputTokens > u2.InputTokens {
+				t.Errorf("invariant violated: cached %d > input %d", u2.CachedInputTokens, u2.InputTokens)
+			}
+
+			// Anthropic-specific assertion: validate the
+			// three-bucket → gross normalisation end-to-end. After
+			// a warm follow-up the gross InputTokens must exceed
+			// the new-tokens-only count (which would be small —
+			// just the changed user line). We approximate this by
+			// requiring InputTokens to be at least 200 tokens; on
+			// any model SKU emitting only `input_tokens` (the
+			// legacy bug the adapter fixed) this would collapse
+			// to <100 tokens and fail.
+			if spec.Provider == "anthropic" || spec.Provider == "minimax" {
+				if u2.InputTokens < 200 {
+					t.Errorf("anthropic-family InputTokens=%d on warm follow-up looks too small — normalizeAnthropicUsage may be summing only the non-cached bucket. Expected gross prompt size (system + user) ≥ 200 tokens.",
+						u2.InputTokens)
+				}
+			}
+		})
+	}
+}
+
+// ratePct safely computes a percentage for logging without
+// divide-by-zero noise. Returns 0 instead of NaN when denominator
+// is zero (the "no prompt usage reported" case the assertions catch
+// separately).
+func ratePct(num, denom int64) float64 {
+	if denom == 0 {
+		return 0
+	}
+	return float64(num) / float64(denom) * 100
+}


### PR DESCRIPTION
## Summary

Adds an end-to-end conformance test that validates the full prompt-cache chain shipped over PR #109 (`cache_control` / `prompt_cache_key` injection in sdkx) and the cached-tokens plumbing shipped over sdkx v0.3.3 (`TokenUsage.CachedInputTokens` populated across openai / anthropic / bytedance Generate paths).

## How it works

Issues two back-to-back \`Generate\` calls with a **byte-identical ~22 KB system prefix** (~4000 tokens — comfortably above every provider's 1024-token minimum). Only the trailing user message changes on call #2, so fresh user tokens stay short relative to the cached prefix.

## Assertions

- **Strict** (test fails on miss):
  - \`anthropic\` / \`minimax\` (adapter writes \`cache_control\`)
  - \`bytedance\` (Doubao transparent prefix caching)
- **Soft** (logs warning on miss):
  - \`azure\` / \`deepseek\` / \`qwen\` (implicit caching, region-dependent)
- **Invariants**:
  - \`cached <= input\` (catches adapter decoding the wrong field)
  - Anthropic family: \`InputTokens >= 200\` (verifies three-bucket → gross normalisation lands)

## Measured hit-rates (live run)

| Provider | Warm-up | Follow-up | Hit rate |
|---|---|---|---|
| minimax (anthropic) | 0 | 3809 / 3828 | **99.5%** |
| azure | 3840 / 3975 | 3840 / 3975 | **96.6%** (sticky across runs) |
| deepseek | 3840 / 3919 | 3840 / 3920 | **98.0%** (sticky) |
| qwen | 0 | 0 | n/a (region limitation, warns) |

## Wiring

- Bumps \`tests/conformance/go.mod\`:
  - \`sdk\` v0.3.4 → v0.3.5 (CachedInputTokens field)
  - \`sdkx\` v0.3.1 → v0.3.3 (adapter-side populate)
- Self-skips per provider when its \`FLOWCRAFT_TEST_*\` env var is missing, so \`make conformance\` without \`.env\` remains a no-op.

## Test plan

- [x] \`GOWORK=off go test ./llm/ -run TestProviders_PromptCacheHitRate -v\` (live, repo \`.env\`)
- [x] \`GOWORK=off go build ./...\` (compile check)
- [ ] CI green

Made with [Cursor](https://cursor.com)