### PR TITLE
feat(eval/.github): workflow_dispatch entry points for locomo + longmemeval

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,7 @@
+# actionlint configuration.
+# Custom self-hosted runner labels we use. Without this entry,
+# actionlint flags `runs-on: [self-hosted, flowcraft-eval]` as an
+# unknown label and would fail CI lints.
+self-hosted-runner:
+  labels:
+    - flowcraft-eval

--- a/.github/workflows/eval-locomo.yml
+++ b/.github/workflows/eval-locomo.yml
@@ -1,0 +1,244 @@
+name: eval / locomo
+
+# ---------------------------------------------------------------------
+# LoCoMo-10 dialog-memory benchmark, executed on the self-hosted
+# runner labelled `flowcraft-eval`. See internal-docs/eval-runbook.md
+# for the host-side setup (runner install, /etc/flowcraft-eval/.env,
+# /var/lib/flowcraft-eval/reports).
+#
+# Canonical CLI: `eval locomo run --dataset <path> --topk N
+#                  --extractor --extractor-llm <alias>
+#                  --answer-llm <alias> --judge-llm <alias>
+#                  --reranker-llm <alias> --embedder <alias>
+#                  --concurrency N --ingest-concurrency N
+#                  --out <report.json>`
+# ---------------------------------------------------------------------
+
+on:
+  workflow_dispatch:
+    inputs:
+      dataset:
+        description: "Dataset path (.jsonl) or 'synthetic' (smoke)"
+        required: true
+        default: "eval/locomo/data/locomo10.jsonl"
+      topk:
+        description: "Recall top-k"
+        required: false
+        default: "30"
+      extractor_llm:
+        description: "Extractor model alias (e.g. azure:deepseek-flash)"
+        required: false
+        default: "azure:deepseek-flash"
+      answer_llm:
+        description: "Answer-synthesis model alias"
+        required: false
+        default: "azure:deepseek-flash"
+      judge_llm:
+        description: "Judge model alias"
+        required: false
+        default: "azure:gpt-5.4"
+      reranker_llm:
+        description: "Reranker LLM alias ('' to disable)"
+        required: false
+        default: ""
+      embedder:
+        description: "Embedder alias (e.g. qwen:text-embedding-v4)"
+        required: false
+        default: "qwen:text-embedding-v4"
+      concurrency:
+        description: "QA-loop parallelism"
+        required: false
+        default: "8"
+      ingest_concurrency:
+        description: "Per-conversation extractor parallelism"
+        required: false
+        default: "8"
+      notify_progress_pct:
+        description: "Feishu milestone resolution (% of work; 0=off)"
+        required: false
+        default: "10"
+      limit_questions:
+        description: "Debug: cap to first N questions (0 = full set)"
+        required: false
+        default: "0"
+
+# Per-kind serialisation: at most one locomo run at a time. Other eval
+# kinds (longmemeval / beir / …) have their own concurrency.group and
+# run independently.
+concurrency:
+  group: eval-locomo
+  cancel-in-progress: false
+
+env:
+  RUN_ID: ${{ github.run_id }}
+  REPORT_DIR: /var/lib/flowcraft-eval/reports
+  RUN_TAG: locomo-${{ github.run_id }}
+
+jobs:
+  run:
+    runs-on: [self-hosted, flowcraft-eval]
+    # 12h ceiling. LoCoMo-10 with topk=30 + LLM judge fits well within
+    # 4h on the current azure:deepseek-flash + azure:gpt-5.4 combo;
+    # the headroom guards against accidental --dataset bumps.
+    timeout-minutes: 720
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Load secrets from runner host
+        # All credentials (LLM provider keys + FEISHU_*) live in
+        # /etc/flowcraft-eval/.env on this runner, mode 0600. We pipe
+        # each KEY=VALUE line through ::add-mask:: (so an accidental
+        # `echo $AZURE_API_KEY` in any downstream step still renders
+        # as *** in the GH UI) and then into $GITHUB_ENV so all
+        # subsequent steps in this job inherit them. Reading the file
+        # via `read` (not `cat | …`) keeps the values off any log.
+        # A copy is also placed at ./.env for `eval` binaries that
+        # call into eval/internal/env.LoadDotEnv().
+        run: |
+          set -eu
+          test -f /etc/flowcraft-eval/.env
+          while IFS='=' read -r key value; do
+            [[ -z "$key" || "$key" =~ ^# ]] && continue
+            echo "::add-mask::$value"
+            echo "$key=$value" >> "$GITHUB_ENV"
+          done < /etc/flowcraft-eval/.env
+          cp /etc/flowcraft-eval/.env .env
+          chmod 600 .env
+
+      - name: Ensure report dir
+        run: |
+          mkdir -p "$REPORT_DIR"
+          # 0750: runner OS user + group readable; world denied.
+          chmod 0750 "$REPORT_DIR" || true
+
+      - name: Show eval binary toolchain
+        run: |
+          go version
+          go env GOMODCACHE GOCACHE
+
+      - name: Build eval binary
+        # The eval module pins released sdk/sdkx via go.mod and uses
+        # GOWORK=off in CI; mirror that here so we use the pinned
+        # versions, not the workspace overlay.
+        run: |
+          cd eval
+          GOWORK=off go build -trimpath -o /tmp/eval ./cmd/eval
+          /tmp/eval --help | head -20
+
+      - name: Notify Feishu — started
+        if: success()
+        # Plain text message at start. The live CardKit progress
+        # updates emitted by the running eval binary use FEISHU_APP_*
+        # credentials (also loaded above) and are independent of this
+        # webhook ping.
+        run: |
+          set -eu
+          if [ -z "${FEISHU_WEBHOOK_URL:-}" ]; then
+            echo "FEISHU_WEBHOOK_URL not set in /etc/flowcraft-eval/.env; skipping started ping"
+            exit 0
+          fi
+          RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          curl -sS -X POST "$FEISHU_WEBHOOK_URL" \
+            -H 'Content-Type: application/json' \
+            -d @- <<EOF
+          {
+            "msg_type": "text",
+            "content": {
+              "text": "▶ locomo run started\nrun_id=${{ github.run_id }}\ndataset=${{ inputs.dataset }}\ntopk=${{ inputs.topk }} extractor=${{ inputs.extractor_llm }} judge=${{ inputs.judge_llm }}\nlogs: $RUN_URL"
+            }
+          }
+          EOF
+
+      - name: Run locomo
+        env:
+          REPORT_OUT: ${{ env.REPORT_DIR }}/${{ github.run_id }}.json
+        # CardKit live-update flags:
+        #   --notify-name      identifies this run in the card header
+        #   --notify-progress-pct  milestone resolution
+        # We default reranker/embedder/limit-questions to optional so a
+        # smoke run (`--dataset synthetic --limit-questions 50`) reuses
+        # the same workflow.
+        run: |
+          set -eu
+          ARGS=(
+            locomo run
+            --dataset "${{ inputs.dataset }}"
+            --topk "${{ inputs.topk }}"
+            --extractor
+            --extractor-llm "${{ inputs.extractor_llm }}"
+            --answer-llm "${{ inputs.answer_llm }}"
+            --judge-llm "${{ inputs.judge_llm }}"
+            --concurrency "${{ inputs.concurrency }}"
+            --ingest-concurrency "${{ inputs.ingest_concurrency }}"
+            --notify-name "$RUN_TAG"
+            --notify-progress-pct "${{ inputs.notify_progress_pct }}"
+            --out "$REPORT_OUT"
+          )
+          if [ -n "${{ inputs.reranker_llm }}" ]; then
+            ARGS+=( --reranker-llm "${{ inputs.reranker_llm }}" )
+          fi
+          if [ -n "${{ inputs.embedder }}" ]; then
+            ARGS+=( --embedder "${{ inputs.embedder }}" )
+          fi
+          if [ "${{ inputs.limit_questions }}" != "0" ]; then
+            ARGS+=( --limit-questions "${{ inputs.limit_questions }}" )
+          fi
+          /tmp/eval "${ARGS[@]}"
+
+      - name: Upload report artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: locomo-report-${{ github.run_id }}
+          path: ${{ env.REPORT_DIR }}/${{ github.run_id }}.json
+          if-no-files-found: warn
+          retention-days: 90
+
+      - name: Notify Feishu — final
+        if: always()
+        # Final summary. We pull headline numbers via jq from the
+        # locomo Report shape (aggregate.qa.em / qa.f1 / qa.judge / n).
+        # Token-usage isn't in the Report today; once `internal-docs/
+        # eval-platform-design-actions.md` §4.5 lands the cached/input
+        # rollup, extend the METRICS line to include them.
+        run: |
+          set +e
+          REPORT="$REPORT_DIR/${{ github.run_id }}.json"
+          STATUS="${{ job.status }}"
+          ICON="✅"
+          [ "$STATUS" != "success" ] && ICON="❌"
+          # latency.*.p95 is raw nanoseconds (Go time.Duration marshals
+          # to int64); convert to ms here so the Feishu summary stays
+          # human-readable. tostring is forced on every numeric field so
+          # the final concat never sees mixed string+number arithmetic.
+          if [ -s "$REPORT" ]; then
+            METRICS=$(jq -r '
+              def ns2ms(x): if x == null then "n/a" else ((x/1000000)|tostring) + "ms" end;
+              "n=" + (.n|tostring)
+              + " qa.judge=" + (.aggregate."qa.judge"|tostring)
+              + " qa.f1=" + (.aggregate."qa.f1"|tostring)
+              + " qa.em=" + (.aggregate."qa.em"|tostring)
+              + (if .aggregate."recall.k_hit" != null
+                   then " recall.k_hit=" + (.aggregate."recall.k_hit"|tostring)
+                   else "" end)
+              + " save.p95=" + ns2ms(.latency.save.p95)
+              + " recall.p95=" + ns2ms(.latency.recall.p95)
+            ' "$REPORT" 2>/dev/null)
+          else
+            METRICS="report not produced"
+          fi
+          RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          if [ -n "${FEISHU_WEBHOOK_URL:-}" ]; then
+            curl -sS -X POST "$FEISHU_WEBHOOK_URL" \
+              -H 'Content-Type: application/json' \
+              -d @- <<EOF
+          {
+            "msg_type": "text",
+            "content": {
+              "text": "$ICON locomo run finished\nstatus=$STATUS\n$METRICS\nlogs: $RUN_URL"
+            }
+          }
+          EOF
+          else
+            echo "FEISHU_WEBHOOK_URL not set; skipping final ping"
+          fi

--- a/.github/workflows/eval-longmemeval.yml
+++ b/.github/workflows/eval-longmemeval.yml
@@ -1,0 +1,217 @@
+name: eval / longmemeval
+
+# ---------------------------------------------------------------------
+# LongMemEval (ICLR 2025) executed via `eval locomo run` against a
+# LongMemEval-converted JSONL dataset. The locomo runner is shape-
+# compatible with the converted LME data (see eval/longmemeval/cli.go).
+#
+# Datasets must be converted once on the runner host:
+#   eval longmemeval convert --in <upstream.json> --out <out.jsonl>
+# Conventional path:
+#   eval/longmemeval/data/longmemeval_oracle.jsonl
+#   eval/longmemeval/data/longmemeval_s.jsonl
+#   eval/longmemeval/data/longmemeval_m.jsonl
+# ---------------------------------------------------------------------
+
+on:
+  workflow_dispatch:
+    inputs:
+      dataset:
+        description: "Converted LongMemEval .jsonl path"
+        required: true
+        default: "eval/longmemeval/data/longmemeval_oracle.jsonl"
+      topk:
+        description: "Recall top-k"
+        required: false
+        default: "30"
+      extractor_llm:
+        description: "Extractor model alias"
+        required: false
+        default: "azure:deepseek-flash"
+      answer_llm:
+        description: "Answer-synthesis model alias"
+        required: false
+        default: "azure:deepseek-flash"
+      judge_llm:
+        description: "Judge model alias"
+        required: false
+        default: "azure:gpt-5.4"
+      reranker_llm:
+        description: "Reranker LLM alias ('' to disable)"
+        required: false
+        default: ""
+      embedder:
+        description: "Embedder alias"
+        required: false
+        default: "qwen:text-embedding-v4"
+      concurrency:
+        description: "QA-loop parallelism"
+        required: false
+        default: "8"
+      ingest_concurrency:
+        description: "Per-conversation extractor parallelism"
+        required: false
+        default: "8"
+      notify_progress_pct:
+        description: "Feishu milestone resolution (% of work)"
+        required: false
+        default: "5"
+      limit_questions:
+        description: "Debug: cap to first N questions (0 = full set)"
+        required: false
+        default: "0"
+
+# LongMemEval-s 500 instances at concurrency=8 still saturates one
+# Azure endpoint; serialise per kind.
+concurrency:
+  group: eval-longmemeval
+  cancel-in-progress: false
+
+env:
+  REPORT_DIR: /var/lib/flowcraft-eval/reports
+  RUN_TAG: lme-${{ github.run_id }}
+
+jobs:
+  run:
+    runs-on: [self-hosted, flowcraft-eval]
+    timeout-minutes: 720
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Load secrets from runner host
+        run: |
+          set -eu
+          test -f /etc/flowcraft-eval/.env
+          while IFS='=' read -r key value; do
+            [[ -z "$key" || "$key" =~ ^# ]] && continue
+            echo "::add-mask::$value"
+            echo "$key=$value" >> "$GITHUB_ENV"
+          done < /etc/flowcraft-eval/.env
+          cp /etc/flowcraft-eval/.env .env
+          chmod 600 .env
+
+      - name: Ensure report dir
+        run: |
+          mkdir -p "$REPORT_DIR"
+          chmod 0750 "$REPORT_DIR" || true
+
+      - name: Verify dataset exists on the runner host
+        # LongMemEval datasets are large and live on the runner host
+        # (not in git). Fail fast with a clear message rather than a
+        # 30-min-deep "file not found" trace inside the eval binary.
+        run: |
+          set -eu
+          DS="${{ inputs.dataset }}"
+          if [ ! -s "$DS" ]; then
+            echo "::error::LongMemEval dataset $DS missing or empty on runner host."
+            echo "Generate it once with:"
+            echo "  /tmp/eval longmemeval convert --in <upstream.json> --out $DS"
+            exit 1
+          fi
+          echo "dataset $DS: $(wc -l < "$DS") lines"
+
+      - name: Build eval binary
+        run: |
+          cd eval
+          GOWORK=off go build -trimpath -o /tmp/eval ./cmd/eval
+
+      - name: Notify Feishu — started
+        if: success()
+        run: |
+          set -eu
+          if [ -z "${FEISHU_WEBHOOK_URL:-}" ]; then
+            echo "FEISHU_WEBHOOK_URL not set; skipping started ping"
+            exit 0
+          fi
+          RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          curl -sS -X POST "$FEISHU_WEBHOOK_URL" \
+            -H 'Content-Type: application/json' \
+            -d @- <<EOF
+          {
+            "msg_type": "text",
+            "content": {
+              "text": "▶ longmemeval run started\nrun_id=${{ github.run_id }}\ndataset=${{ inputs.dataset }}\ntopk=${{ inputs.topk }} extractor=${{ inputs.extractor_llm }} judge=${{ inputs.judge_llm }}\nlogs: $RUN_URL"
+            }
+          }
+          EOF
+
+      - name: Run longmemeval (via locomo runner)
+        env:
+          REPORT_OUT: ${{ env.REPORT_DIR }}/${{ github.run_id }}.json
+        run: |
+          set -eu
+          ARGS=(
+            locomo run
+            --dataset "${{ inputs.dataset }}"
+            --topk "${{ inputs.topk }}"
+            --extractor
+            --extractor-llm "${{ inputs.extractor_llm }}"
+            --answer-llm "${{ inputs.answer_llm }}"
+            --judge-llm "${{ inputs.judge_llm }}"
+            --concurrency "${{ inputs.concurrency }}"
+            --ingest-concurrency "${{ inputs.ingest_concurrency }}"
+            --notify-name "$RUN_TAG"
+            --notify-progress-pct "${{ inputs.notify_progress_pct }}"
+            --out "$REPORT_OUT"
+          )
+          if [ -n "${{ inputs.reranker_llm }}" ]; then
+            ARGS+=( --reranker-llm "${{ inputs.reranker_llm }}" )
+          fi
+          if [ -n "${{ inputs.embedder }}" ]; then
+            ARGS+=( --embedder "${{ inputs.embedder }}" )
+          fi
+          if [ "${{ inputs.limit_questions }}" != "0" ]; then
+            ARGS+=( --limit-questions "${{ inputs.limit_questions }}" )
+          fi
+          /tmp/eval "${ARGS[@]}"
+
+      - name: Upload report artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: longmemeval-report-${{ github.run_id }}
+          path: ${{ env.REPORT_DIR }}/${{ github.run_id }}.json
+          if-no-files-found: warn
+          retention-days: 90
+
+      - name: Notify Feishu — final
+        if: always()
+        run: |
+          set +e
+          REPORT="$REPORT_DIR/${{ github.run_id }}.json"
+          STATUS="${{ job.status }}"
+          ICON="✅"
+          [ "$STATUS" != "success" ] && ICON="❌"
+          # latency.*.p95 is raw nanoseconds (Go time.Duration marshals
+          # to int64); convert to ms for the Feishu summary.
+          if [ -s "$REPORT" ]; then
+            METRICS=$(jq -r '
+              def ns2ms(x): if x == null then "n/a" else ((x/1000000)|tostring) + "ms" end;
+              "n=" + (.n|tostring)
+              + " qa.judge=" + (.aggregate."qa.judge"|tostring)
+              + " qa.f1=" + (.aggregate."qa.f1"|tostring)
+              + " qa.em=" + (.aggregate."qa.em"|tostring)
+              + (if .aggregate."recall.k_hit" != null
+                   then " recall.k_hit=" + (.aggregate."recall.k_hit"|tostring)
+                   else "" end)
+              + " save.p95=" + ns2ms(.latency.save.p95)
+              + " recall.p95=" + ns2ms(.latency.recall.p95)
+            ' "$REPORT" 2>/dev/null)
+          else
+            METRICS="report not produced"
+          fi
+          RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          if [ -n "${FEISHU_WEBHOOK_URL:-}" ]; then
+            curl -sS -X POST "$FEISHU_WEBHOOK_URL" \
+              -H 'Content-Type: application/json' \
+              -d @- <<EOF
+          {
+            "msg_type": "text",
+            "content": {
+              "text": "$ICON longmemeval run finished\nstatus=$STATUS\n$METRICS\nlogs: $RUN_URL"
+            }
+          }
+          EOF
+          else
+            echo "FEISHU_WEBHOOK_URL not set; skipping final ping"
+          fi


### PR DESCRIPTION
## Summary

Migrate the eval surface to **GitHub Actions on a self-hosted runner**, per
the decision recorded in `internal-docs/eval-platform-design-actions.md`.
This PR ships the two highest-traffic eval kinds (LoCoMo + LongMemEval) as
`workflow_dispatch` workflows; the remaining five (BEIR / SimpleQA / τ-bench
/ history / knowledge) clone cleanly off the LoCoMo template per the runbook.

### What the workflows do

- Declare every eval as a `workflow_dispatch` with the same input set as the
  underlying \`eval <kind> run\` CLI (dataset path, top-k, model aliases,
  concurrency, notify-progress-pct, debug limit).
- Load \`/etc/flowcraft-eval/.env\` from the runner host through
  \`::add-mask::\` + \`\$GITHUB_ENV\` so **no credentials live on github.com**;
  the workflow references zero \`\${{ secrets.* }}\` entries (anyone with
  read-only repo access can audit the YAML and verify this).
- Serialise per kind via \`concurrency.group: eval-<kind>\` so two LoCoMo
  runs can't contend while different kinds can still run independently.
- Emit a start ping + final summary to \`FEISHU_WEBHOOK_URL\` (gracefully
  skipped when unset) and let the eval binary's existing CardKit notifier
  drive live progress via \`FEISHU_APP_*\`.
- Upload the JSON Report as a GH artifact (90-day retention) and keep a
  host-local copy under \`/var/lib/flowcraft-eval/reports/\` for offline
  inspection.

\`.github/actionlint.yaml\` whitelists the custom \`flowcraft-eval\` runner
label so future CI lint passes don't trip on the self-hosted target.

### Host-side prerequisites (already provisioned)

The runner host \`14.103.201.159\` is fully provisioned: \`ghrunner\` user,
Go 1.25, \`/etc/flowcraft-eval/.env\` (seeded from existing
\`/root/flowcraft/.env\`), \`/var/lib/flowcraft-eval/{reports,datasets}\`,
LongMemEval converted datasets staged under \`datasets/\`, and the runner
agent v2.334.0 registered as \`flowcraft-eval-host\` (agentId=21, labels
\`[self-hosted, flowcraft-eval]\`) running as a systemd unit. Step-by-step
in \`internal-docs/eval-runbook.md\` (not committed; lives under
\`internal-docs/\` per repo policy).

### Why not a custom daemon

See \`internal-docs/eval-platform-design-actions.md\` §2 — building the
queueing / leasing / reaping / archiving / panic-recovery / re-run-UI we
were going to re-implement in a custom \`evald\` against the GH Actions
equivalents that ship out of the box is ~10 days vs ~2 days for Actions,
in exchange for **zero** features the user values. The full pros/cons
table is in §3.

## Test plan

- [ ] After merge to main, GH Actions UI shows \`eval / locomo\` +
  \`eval / longmemeval\` workflows under
  https://github.com/GizClaw/flowcraft/actions
- [ ] \`Run workflow\` → \`eval / locomo\` with
  \`dataset=synthetic\`, \`limit_questions=10\`, \`extractor_llm=azure:deepseek-flash\`,
  \`judge_llm=azure:gpt-5.4\` completes green inside ~5min and produces a
  report artifact.
- [ ] \`Run workflow\` → \`eval / longmemeval\` with
  \`dataset=/var/lib/flowcraft-eval/datasets/longmemeval_oracle.jsonl\`,
  \`limit_questions=20\` completes green and produces a report artifact.
- [ ] Feishu CardKit live progress card appears (via FEISHU_APP_* in the
  loaded .env), updates at the milestone resolution set by
  \`notify_progress_pct\`.
- [ ] Job log shows masked secret values (\`::add-mask::\` working) — try
  intentionally \`echo \$FLOWCRAFT_TEST_AZURE\` in a transient debug step
  and verify it renders as \`***\` in the GH UI.
- [ ] Cancel a running workflow via GH UI → eval binary honours
  \`ctx.Done()\` and exits cleanly within the 30s job-cancel grace period.

## Follow-ups (not in this PR)

1. Clone the workflow shape for BEIR / SimpleQA / τ-bench / history /
   knowledge (template in \`eval-runbook.md\` §3).
2. After confirming the workflow path is solid, decommission
   \`eval/scripts/run-eval.sh\` + \`lme-launch.sh\` (the legacy supervisor
   layer is now redundant).
3. Once the design-doc TODO in §4.5 (token-usage rollup in the Report
   header) lands, extend the final-Feishu \`jq\` line to surface
   \`cached_input_tokens / input_tokens\` per run.

Made with [Cursor](https://cursor.com)