### PR TITLE
chore(sdkx): bump sdk v0.3.5 -> v0.3.6

### DIFF
--- a/sdkx/go.mod
+++ b/sdkx/go.mod
@@ -2,7 +2,7 @@ module github.com/GizClaw/flowcraft/sdkx
 
 go 1.25.0
 
-require github.com/GizClaw/flowcraft/sdk v0.3.5
+require github.com/GizClaw/flowcraft/sdk v0.3.6
 
 require (
 	github.com/PuerkitoBio/goquery v1.11.0

--- a/sdkx/go.sum
+++ b/sdkx/go.sum
@@ -8,8 +8,8 @@ github.com/Azure/azure-sdk-for-go/sdk/internal v1.10.0/go.mod h1:iZDifYGJTIgIIkY
 github.com/AzureAD/microsoft-authentication-library-for-go v1.2.2 h1:XHOnouVk1mxXfQidrMEnLlPk9UMeRtyBTnEFtxkV0kU=
 github.com/AzureAD/microsoft-authentication-library-for-go v1.2.2/go.mod h1:wP83P5OoQ5p6ip3ScPr0BAq0BvuPAvacpEuSzyouqAI=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
-github.com/GizClaw/flowcraft/sdk v0.3.5 h1:Fmoon2bs36FwV85pDaF/5s86qVyvq5gAq3UkeUcHJD4=
-github.com/GizClaw/flowcraft/sdk v0.3.5/go.mod h1:VeMqVBxnMGHtFO9ypHhsA591XoLCWxucXR+gqpxQt5s=
+github.com/GizClaw/flowcraft/sdk v0.3.6 h1:fvSAWYvojdGuTI7vY84hMn6HZxG+fAO3qyTNq5WWLVk=
+github.com/GizClaw/flowcraft/sdk v0.3.6/go.mod h1:VeMqVBxnMGHtFO9ypHhsA591XoLCWxucXR+gqpxQt5s=
 github.com/PuerkitoBio/goquery v1.11.0 h1:jZ7pwMQXIITcUXNH83LLk+txlaEy6NVOfTuP43xxfqw=
 github.com/PuerkitoBio/goquery v1.11.0/go.mod h1:wQHgxUOU3JGuj3oD/QFfxUdlzW6xPHfqyHre6VMY4DQ=
 github.com/andybalholm/cascadia v1.3.3 h1:AG2YHrzJIm4BZ19iwJ/DAua6Btl3IwJX+VI4kktS1LM=


### PR DESCRIPTION
Step 2 of the two-step cached-tokens telemetry release (step 1 was PR #115 which cut `sdk/v0.3.6`).

## Why

PR #115 landed adapter code in `sdkx/llm/{openai,anthropic,bytedance}` that calls `llm.UsageSpanAttrs` and references `telemetry.AttrLLMCachedInputTokens` — both only exist at `sdk v0.3.6`. That PR carried `[skip-tag:sdkx]` so auto-tag did not cut a broken `sdkx/v0.3.4` whose go.mod still pinned `sdk v0.3.5` (would have failed `go get` for any external consumer).

This PR bumps the pin and lets auto-tag cut `sdkx/v0.3.4` cleanly. Per the workflow's documented "skip == defer" semantics (`auto-tag.yml` lines 153–169), the new tag captures **both** PR #115's adapter changes and this PR's go.mod bump in a single patch jump from `sdkx/v0.3.3`.

## What's in `sdkx/v0.3.4` once auto-tag runs

| Source PR | Change |
|---|---|
| #115 | All 7 cache-aware adapter span sites route through `llm.UsageSpanAttrs` → cached attribute lands on per-call traces |
| #115 | `bytedance/stream.go` `finish()` now calls `llm.RecordLLMMetrics` symmetrically with sync path (was silently dropping every metric) |
| this PR | `sdkx/go.mod` pins `sdk v0.3.6` so the above code resolves without a workspace replace |

## Verification

```
$ GOWORK=off go test -count=1 ./llm/...
ok  	.../sdkx/llm/anthropic	3.304s
ok  	.../sdkx/llm/azure	2.613s
ok  	.../sdkx/llm/bytedance	6.615s
ok  	.../sdkx/llm/bytedance/image	4.319s
ok  	.../sdkx/llm/deepseek	8.009s
ok  	.../sdkx/llm/minimax	7.223s
ok  	.../sdkx/llm/minimax/image	5.047s
ok  	.../sdkx/llm/mock	6.488s
ok  	.../sdkx/llm/ollama	5.761s
ok  	.../sdkx/llm/openai	11.146s
ok  	.../sdkx/llm/qwen	9.469s
ok  	.../sdkx/llm/qwen/image	10.222s
```

`GOWORK=off` is the meaningful flag here — it bypasses the workspace replace so the test resolves `sdk` via the new `v0.3.6` pin, not via the local `./sdk` source. Without that, this PR could not distinguish "code works because pin is right" from "code works because workspace bypassed the pin".

## Test plan

- [x] `GOWORK=off go build ./...` — clean
- [x] `GOWORK=off go test -count=1 ./llm/...` — green (12 packages including all three cache-aware providers)
- [ ] CI matrix runs on PR open
- [ ] Auto-tag should cut `sdkx/v0.3.4` on merge (no `[skip-tag]` markers — opposite of #115)

## Follow-up (separate chore PRs)

- `eval/go.mod`: bump `sdk v0.3.5 → v0.3.6` + `sdkx v0.3.3 → v0.3.4`
- `tests/conformance/go.mod`: same bumps so `cached_tokens_test.go` exercises the new metric / span surfaces in CI

Made with [Cursor](https://cursor.com)