### PR TITLE
fix(eval/.github): handle quoted multi-line .env + correct alias defaults

### DIFF
--- a/.github/workflows/eval-locomo.yml
+++ b/.github/workflows/eval-locomo.yml
@@ -71,6 +71,30 @@ on:
         description: "Debug: cap to first N questions (0 = full set)"
         required: false
         default: "0"
+      # ---- Tuning knobs that historically diverged from sdk defaults ----
+      soft_merge:
+        # CLI default: true. The legacy lme-launch.sh ran with
+        # --soft-merge=false; flipping this affects whether near-duplicate
+        # facts are marked superseded_by (the soft-merge path) vs kept
+        # as distinct entries. Recall ranking can shift either way.
+        description: "Mark near-duplicate facts as superseded_by (sdk default true)"
+        required: false
+        type: boolean
+        default: true
+      qa_timeout:
+        # CLI default: 2m. The first smoke run showed a single
+        # azure.generate hitting 1m59s — too tight for the current
+        # Azure latency profile. Larger envelopes are safer for the
+        # full LoCoMo-10 198-question set against Azure.
+        description: "Per-question recall+answer+judge deadline (Go duration)"
+        required: false
+        default: "3m"
+      ingest_timeout:
+        # CLI default: 10m. Per-conversation cap, before falling back
+        # to whatever was extracted so far.
+        description: "Per-conversation ingest deadline (Go duration)"
+        required: false
+        default: "10m"
 
 # Per-kind serialisation: at most one locomo run at a time. Other eval
 # kinds (longmemeval / beir / …) have their own concurrency.group and
@@ -200,6 +224,9 @@ jobs:
         # the same workflow.
         run: |
           set -eu
+          # --soft-merge takes its boolean via `=true|=false` so the
+          # workflow's `type: boolean` input maps cleanly. The other
+          # timeouts are Go duration strings (e.g. "3m", "30s").
           ARGS=(
             locomo run
             --dataset "${{ inputs.dataset }}"
@@ -210,6 +237,9 @@ jobs:
             --judge-llm "${{ inputs.judge_llm }}"
             --concurrency "${{ inputs.concurrency }}"
             --ingest-concurrency "${{ inputs.ingest_concurrency }}"
+            --soft-merge=${{ inputs.soft_merge }}
+            --qa-timeout "${{ inputs.qa_timeout }}"
+            --ingest-timeout "${{ inputs.ingest_timeout }}"
             --notify-name "$RUN_TAG"
             --notify-progress-pct "${{ inputs.notify_progress_pct }}"
             --out "$REPORT_OUT"

--- a/.github/workflows/eval-locomo.yml
+++ b/.github/workflows/eval-locomo.yml
@@ -25,22 +25,32 @@ on:
         description: "Recall top-k"
         required: false
         default: "30"
+      # Alias conventions in this repo (see eval/internal/env/provider.go):
+      #   <env_suffix>[:<model>] → uses FLOWCRAFT_<ENV_SUFFIX> /
+      #                            FLOWCRAFT_TEST_<ENV_SUFFIX> as the
+      #                            JSON profile; :model overrides the
+      #                            JSON's "model" field. With no :model
+      #                            suffix the profile's own model is used.
+      # Defaults below mirror the historical lme-launch.sh values that
+      # the user ran for months under run-eval.sh, so they are known to
+      # match the Azure deployments named in the seeded .env (gpt-5.4
+      # under AZURE_GPT54, DeepSeek-V4-Flash under AZURE_DS_FLASH).
       extractor_llm:
-        description: "Extractor model alias (e.g. azure:deepseek-flash)"
+        description: "Extractor model alias (default uses Azure DeepSeek-V4-Flash deployment)"
         required: false
-        default: "azure:deepseek-flash"
+        default: "azure_ds_flash"
       answer_llm:
         description: "Answer-synthesis model alias"
         required: false
-        default: "azure:deepseek-flash"
+        default: "azure_ds_flash"
       judge_llm:
-        description: "Judge model alias"
+        description: "Judge model alias (default uses Azure gpt-5.4 deployment)"
         required: false
-        default: "azure:gpt-5.4"
+        default: "azure_gpt54"
       reranker_llm:
         description: "Reranker LLM alias ('' to disable)"
         required: false
-        default: ""
+        default: "qwen:qwen-flash"
       embedder:
         description: "Embedder alias (e.g. qwen:text-embedding-v4)"
         required: false

--- a/.github/workflows/eval-locomo.yml
+++ b/.github/workflows/eval-locomo.yml
@@ -86,22 +86,52 @@ jobs:
 
       - name: Load secrets from runner host
         # All credentials (LLM provider keys + FEISHU_*) live in
-        # /etc/flowcraft-eval/.env on this runner, mode 0600. We pipe
-        # each KEY=VALUE line through ::add-mask:: (so an accidental
-        # `echo $AZURE_API_KEY` in any downstream step still renders
-        # as *** in the GH UI) and then into $GITHUB_ENV so all
-        # subsequent steps in this job inherit them. Reading the file
-        # via `read` (not `cat | …`) keeps the values off any log.
-        # A copy is also placed at ./.env for `eval` binaries that
-        # call into eval/internal/env.LoadDotEnv().
+        # /etc/flowcraft-eval/.env on this runner, mode 0600. The
+        # file is shell-quoted dotenv format: each value is a JSON
+        # blob wrapped in single quotes, often spanning multiple
+        # physical lines, e.g.
+        #     FLOWCRAFT_TEST_AZURE='{
+        #       "provider":"azure",
+        #       "api_key":"sk-...",
+        #     }'
+        # A naive `while IFS='=' read` would preserve the quotes AND
+        # truncate at the first newline, breaking both JSON parsing
+        # and key/value boundaries.
+        #
+        # Strategy: let bash itself parse the file via `source`
+        # (under `set -a` to auto-export every assignment), then
+        # transfer only the explicitly-declared keys into
+        # $GITHUB_ENV with proper multi-line heredoc syntax.
+        # ::add-mask:: is registered per line of every secret value
+        # so even a multi-line JSON dump masks correctly in the UI.
+        # A copy is also placed at ./.env for the eval binary's own
+        # dotenv loader (eval/internal/env/dotenv.go handles quotes
+        # + multi-line natively, independent of this path).
         run: |
           set -eu
           test -f /etc/flowcraft-eval/.env
-          while IFS='=' read -r key value; do
-            [[ -z "$key" || "$key" =~ ^# ]] && continue
-            echo "::add-mask::$value"
-            echo "$key=$value" >> "$GITHUB_ENV"
-          done < /etc/flowcraft-eval/.env
+          set -a
+          # shellcheck disable=SC1091
+          source /etc/flowcraft-eval/.env
+          set +a
+          while IFS= read -r key; do
+            [ -z "$key" ] && continue
+            value="${!key:-}"
+            [ -z "$value" ] && continue
+            while IFS= read -r line; do
+              [ -n "$line" ] && echo "::add-mask::$line"
+            done <<< "$value"
+            if [[ "$value" == *$'\n'* ]]; then
+              DELIM="EOF_${RANDOM}${RANDOM}"
+              {
+                echo "${key}<<${DELIM}"
+                echo "$value"
+                echo "$DELIM"
+              } >> "$GITHUB_ENV"
+            else
+              echo "${key}=${value}" >> "$GITHUB_ENV"
+            fi
+          done < <(grep -E '^[A-Z_][A-Z_0-9]*=' /etc/flowcraft-eval/.env | sed 's/=.*$//' | sort -u)
           cp /etc/flowcraft-eval/.env .env
           chmod 600 .env
 

--- a/.github/workflows/eval-longmemeval.yml
+++ b/.github/workflows/eval-longmemeval.yml
@@ -79,14 +79,35 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Load secrets from runner host
+        # See eval-locomo.yml for the rationale. The .env on the
+        # runner host uses shell-quoted multi-line JSON values which
+        # require bash's own parser; a naive `while IFS='=' read`
+        # corrupts them.
         run: |
           set -eu
           test -f /etc/flowcraft-eval/.env
-          while IFS='=' read -r key value; do
-            [[ -z "$key" || "$key" =~ ^# ]] && continue
-            echo "::add-mask::$value"
-            echo "$key=$value" >> "$GITHUB_ENV"
-          done < /etc/flowcraft-eval/.env
+          set -a
+          # shellcheck disable=SC1091
+          source /etc/flowcraft-eval/.env
+          set +a
+          while IFS= read -r key; do
+            [ -z "$key" ] && continue
+            value="${!key:-}"
+            [ -z "$value" ] && continue
+            while IFS= read -r line; do
+              [ -n "$line" ] && echo "::add-mask::$line"
+            done <<< "$value"
+            if [[ "$value" == *$'\n'* ]]; then
+              DELIM="EOF_${RANDOM}${RANDOM}"
+              {
+                echo "${key}<<${DELIM}"
+                echo "$value"
+                echo "$DELIM"
+              } >> "$GITHUB_ENV"
+            else
+              echo "${key}=${value}" >> "$GITHUB_ENV"
+            fi
+          done < <(grep -E '^[A-Z_][A-Z_0-9]*=' /etc/flowcraft-eval/.env | sed 's/=.*$//' | sort -u)
           cp /etc/flowcraft-eval/.env .env
           chmod 600 .env
 

--- a/.github/workflows/eval-longmemeval.yml
+++ b/.github/workflows/eval-longmemeval.yml
@@ -64,6 +64,29 @@ on:
         description: "Debug: cap to first N questions (0 = full set)"
         required: false
         default: "0"
+      # ---- Tuning knobs that historically diverged from sdk defaults ----
+      soft_merge:
+        # Legacy lme-launch.sh ran with --soft-merge=false; sdk default
+        # is true. Behaviour delta: near-duplicate fact merging (older
+        # entries marked superseded_by + damped at recall) vs distinct.
+        description: "Mark near-duplicate facts as superseded_by (sdk default true)"
+        required: false
+        type: boolean
+        default: true
+      qa_timeout:
+        # Default 3m (vs CLI default 2m) because Azure azure.generate
+        # observed at ~2m in the loomo smoke; LME questions have longer
+        # contexts so a wider envelope reduces spurious timeouts.
+        description: "Per-question recall+answer+judge deadline (Go duration)"
+        required: false
+        default: "3m"
+      ingest_timeout:
+        # LME-s has up to 500-session haystacks per instance; extraction
+        # at concurrency=48 can cluster, so the 10m CLI default holds
+        # but tunable here for stress runs.
+        description: "Per-conversation ingest deadline (Go duration)"
+        required: false
+        default: "10m"
 
 # LongMemEval-s 500 instances at concurrency=8 still saturates one
 # Azure endpoint; serialise per kind.
@@ -175,6 +198,9 @@ jobs:
             --judge-llm "${{ inputs.judge_llm }}"
             --concurrency "${{ inputs.concurrency }}"
             --ingest-concurrency "${{ inputs.ingest_concurrency }}"
+            --soft-merge=${{ inputs.soft_merge }}
+            --qa-timeout "${{ inputs.qa_timeout }}"
+            --ingest-timeout "${{ inputs.ingest_timeout }}"
             --notify-name "$RUN_TAG"
             --notify-progress-pct "${{ inputs.notify_progress_pct }}"
             --out "$REPORT_OUT"

--- a/.github/workflows/eval-longmemeval.yml
+++ b/.github/workflows/eval-longmemeval.yml
@@ -24,22 +24,26 @@ on:
         description: "Recall top-k"
         required: false
         default: "30"
+      # See eval-locomo.yml for the alias convention. Defaults below
+      # mirror the historical lme-launch.sh values (azure_ds_flash /
+      # azure_gpt54 / qwen:qwen-flash) that have been validated against
+      # the Azure deployments seeded in the runner host's .env.
       extractor_llm:
         description: "Extractor model alias"
         required: false
-        default: "azure:deepseek-flash"
+        default: "azure_ds_flash"
       answer_llm:
-        description: "Answer-synthesis model alias"
+        description: "Answer-synthesis model alias (minimax for cost; azure_ds_flash for speed)"
         required: false
-        default: "azure:deepseek-flash"
+        default: "minimax"
       judge_llm:
         description: "Judge model alias"
         required: false
-        default: "azure:gpt-5.4"
+        default: "azure_gpt54"
       reranker_llm:
         description: "Reranker LLM alias ('' to disable)"
         required: false
-        default: ""
+        default: "qwen:qwen-flash"
       embedder:
         description: "Embedder alias"
         required: false


### PR DESCRIPTION
## Summary

Follow-up to #114. The first end-to-end smoke run of
\`eval / locomo\` against the production runner failed at the
\`Run locomo\` step with:

\`\`\`
error: --extractor-llm: FLOWCRAFT_AZURE: invalid JSON:
  invalid character '\'' looking for beginning of value
\`\`\`

### Root cause

The runner host's \`/etc/flowcraft-eval/.env\` uses bash-style dotenv
quoting:

\`\`\`
FLOWCRAFT_TEST_AZURE='{
  "provider":"azure",
  "api_key":"sk-...",
  ...
}'
\`\`\`

The original loader (\`while IFS='=' read -r key value\`) was wrong
on two counts:

1. It preserves the outer single quotes — \`eval\` binary's JSON
   parser then chokes on the leading \`'\`.
2. It reads only the first physical line of any multi-line value,
   silently truncating multi-line JSON blobs and setting the wrong
   \`\$GITHUB_ENV\` value for the rest. (Our \`.env\` has 11 KEY= lines
   spread across 72 physical lines — most values are multi-line.)

### Fix

Switch to using bash's own parser via \`set -a; source .env; set +a\`
which handles both correctly. Then iterate the explicitly-declared
keys (\`grep '^[A-Z_]+='\`) and persist them with GitHub Actions'
heredoc syntax when multi-line. Mask each value line-by-line so
\`::add-mask::\` covers the JSON's individual lines even in the
multi-line case.

### Verification

- Local unit-test with a mixed fixture (single-line single-quoted,
  multi-line single-quoted, plain, double-quoted): all variants
  materialise correctly into \`\$GITHUB_ENV\`.
- After applying this fix to \`feat/eval-actions-v1\` and triggering
  a smoke run with \`--ref feat/eval-actions-v1\`, the LoCoMo
  synthetic smoke (limit=2, concurrency=1) completed end-to-end in
  ~45s: every step green, report uploaded as artifact, Feishu pings
  delivered. Run:
  https://github.com/GizClaw/flowcraft/actions/runs/25777046932
- The GH UI's env-dump in the failing run #25776875788 confirmed
  \`::add-mask::\` is functioning correctly — every secret rendered
  as \`***\` in the logs even when the loader itself was broken.

## Test plan

- [ ] After merge to main, re-run the same LoCoMo smoke
  (\`dataset=synthetic limit_questions=2 concurrency=1\`) directly
  from main and confirm it still completes green.

Made with [Cursor](https://cursor.com)