### PR TITLE
chore(eval,tests/conformance): bump sdk v0.3.5 -> v0.3.6 + sdkx v0.3.3 -> v0.3.4

### DIFF
--- a/eval/go.mod
+++ b/eval/go.mod
@@ -9,8 +9,8 @@ go 1.25.0
 // PR rather than coupling sdk's release cadence to this directory.
 
 require (
-	github.com/GizClaw/flowcraft/sdk v0.3.5
-	github.com/GizClaw/flowcraft/sdkx v0.3.3
+	github.com/GizClaw/flowcraft/sdk v0.3.6
+	github.com/GizClaw/flowcraft/sdkx v0.3.4
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/pflag v1.0.9
 )

--- a/eval/go.sum
+++ b/eval/go.sum
@@ -8,10 +8,10 @@ github.com/Azure/azure-sdk-for-go/sdk/internal v1.10.0/go.mod h1:iZDifYGJTIgIIkY
 github.com/AzureAD/microsoft-authentication-library-for-go v1.2.2 h1:XHOnouVk1mxXfQidrMEnLlPk9UMeRtyBTnEFtxkV0kU=
 github.com/AzureAD/microsoft-authentication-library-for-go v1.2.2/go.mod h1:wP83P5OoQ5p6ip3ScPr0BAq0BvuPAvacpEuSzyouqAI=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
-github.com/GizClaw/flowcraft/sdk v0.3.5 h1:Fmoon2bs36FwV85pDaF/5s86qVyvq5gAq3UkeUcHJD4=
-github.com/GizClaw/flowcraft/sdk v0.3.5/go.mod h1:VeMqVBxnMGHtFO9ypHhsA591XoLCWxucXR+gqpxQt5s=
-github.com/GizClaw/flowcraft/sdkx v0.3.3 h1:QxvS0k0aNUCGsjB3s2JESe/p4wjCNUE5B5XjqZH5ly4=
-github.com/GizClaw/flowcraft/sdkx v0.3.3/go.mod h1:aJO/NiSnBzhFAQSXe4e2E3nIOBuNGy0MjX5ADG7xP44=
+github.com/GizClaw/flowcraft/sdk v0.3.6 h1:fvSAWYvojdGuTI7vY84hMn6HZxG+fAO3qyTNq5WWLVk=
+github.com/GizClaw/flowcraft/sdk v0.3.6/go.mod h1:VeMqVBxnMGHtFO9ypHhsA591XoLCWxucXR+gqpxQt5s=
+github.com/GizClaw/flowcraft/sdkx v0.3.4 h1:GaBPP54vm+Z6gSAJNFlVAth6L8H4s4+mFhoJTqxb+M0=
+github.com/GizClaw/flowcraft/sdkx v0.3.4/go.mod h1:KyK7fS/DLwi9A2KULGrde3UW4Ms5iYX9VzPBaJh0ZeM=
 github.com/anthropics/anthropic-sdk-go v1.26.0 h1:oUTzFaUpAevfuELAP1sjL6CQJ9HHAfT7CoSYSac11PY=
 github.com/anthropics/anthropic-sdk-go v1.26.0/go.mod h1:qUKmaW+uuPB64iy1l+4kOSvaLqPXnHTTBKH6RVZ7q5Q=
 github.com/avast/retry-go v3.0.0+incompatible/go.mod h1:XtSnn+n/sHqQIpZ10K1qAevBhOOCWBLXXy3hyiqqBrY=

--- a/tests/conformance/go.mod
+++ b/tests/conformance/go.mod
@@ -3,8 +3,8 @@ module github.com/GizClaw/flowcraft/tests/conformance
 go 1.25.0
 
 require (
-	github.com/GizClaw/flowcraft/sdk v0.3.5
-	github.com/GizClaw/flowcraft/sdkx v0.3.3
+	github.com/GizClaw/flowcraft/sdk v0.3.6
+	github.com/GizClaw/flowcraft/sdkx v0.3.4
 )
 
 require (

--- a/tests/conformance/go.sum
+++ b/tests/conformance/go.sum
@@ -8,10 +8,10 @@ github.com/Azure/azure-sdk-for-go/sdk/internal v1.10.0/go.mod h1:iZDifYGJTIgIIkY
 github.com/AzureAD/microsoft-authentication-library-for-go v1.2.2 h1:XHOnouVk1mxXfQidrMEnLlPk9UMeRtyBTnEFtxkV0kU=
 github.com/AzureAD/microsoft-authentication-library-for-go v1.2.2/go.mod h1:wP83P5OoQ5p6ip3ScPr0BAq0BvuPAvacpEuSzyouqAI=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
-github.com/GizClaw/flowcraft/sdk v0.3.5 h1:Fmoon2bs36FwV85pDaF/5s86qVyvq5gAq3UkeUcHJD4=
-github.com/GizClaw/flowcraft/sdk v0.3.5/go.mod h1:VeMqVBxnMGHtFO9ypHhsA591XoLCWxucXR+gqpxQt5s=
-github.com/GizClaw/flowcraft/sdkx v0.3.3 h1:QxvS0k0aNUCGsjB3s2JESe/p4wjCNUE5B5XjqZH5ly4=
-github.com/GizClaw/flowcraft/sdkx v0.3.3/go.mod h1:aJO/NiSnBzhFAQSXe4e2E3nIOBuNGy0MjX5ADG7xP44=
+github.com/GizClaw/flowcraft/sdk v0.3.6 h1:fvSAWYvojdGuTI7vY84hMn6HZxG+fAO3qyTNq5WWLVk=
+github.com/GizClaw/flowcraft/sdk v0.3.6/go.mod h1:VeMqVBxnMGHtFO9ypHhsA591XoLCWxucXR+gqpxQt5s=
+github.com/GizClaw/flowcraft/sdkx v0.3.4 h1:GaBPP54vm+Z6gSAJNFlVAth6L8H4s4+mFhoJTqxb+M0=
+github.com/GizClaw/flowcraft/sdkx v0.3.4/go.mod h1:KyK7fS/DLwi9A2KULGrde3UW4Ms5iYX9VzPBaJh0ZeM=
 github.com/anthropics/anthropic-sdk-go v1.26.0 h1:oUTzFaUpAevfuELAP1sjL6CQJ9HHAfT7CoSYSac11PY=
 github.com/anthropics/anthropic-sdk-go v1.26.0/go.mod h1:qUKmaW+uuPB64iy1l+4kOSvaLqPXnHTTBKH6RVZ7q5Q=
 github.com/avast/retry-go v3.0.0+incompatible/go.mod h1:XtSnn+n/sHqQIpZ10K1qAevBhOOCWBLXXy3hyiqqBrY=


### PR DESCRIPTION
Step 3 (final) of the cached-tokens telemetry release. Bumps the two pinned-version modules to pick up:

| Tag | Source | What it brings |
|---|---|---|
| `sdk/v0.3.6` | PR #115 | `tokens.input.cached.total` counter, `UsageSpanAttrs` helper, `AttrLLMCachedInputTokens` constant, `RunSummary.CachedInputTokens` field |
| `sdkx/v0.3.4` | PR #116 + deferred adapter changes from #115 | All 7 cache-aware adapter span sites route through `llm.UsageSpanAttrs`; bytedance stream `RecordLLMMetrics` bug fix |

## Why combine the two modules in one PR

- Same upstream tag pair — atomic bump avoids any intermediate state where one suite is on the new surface and the other isn't.
- Neither directory triggers `auto-tag` (path filter in `auto-tag.yml` is `sdk/sdkx/voice/vessel` only) — combining is safe and saves a review round.
- Past convention split them (`9ef9b7b9` for conformance, `4fa7fb9b` for eval) only because they happened to need different upstream versions at different times. Here the upstream pair is identical, so collapsing is a strict improvement.

## Verification

```
$ cd eval && GOWORK=off go test -count=1 ./...
ok  	.../eval/beir	5.156s
ok  	.../eval/history	6.641s
ok  	.../eval/internal/env	5.818s
ok  	.../eval/internal/notify	8.066s
ok  	.../eval/knowledge	7.902s
ok  	.../eval/locomo	10.818s
ok  	.../eval/simpleqa	9.602s
ok  	.../eval/taubench	10.391s

$ cd tests/conformance && GOWORK=off go build ./...
(clean)
```

`tests/conformance` itself is gated behind live-provider env vars (`FLOWCRAFT_TEST_*`) so the test command would self-skip locally; the build alone is enough to prove the new symbols resolve correctly through the pin.

## Net effect for the conformance suite

The existing `tests/conformance/llm/cached_tokens_test.go` already validated the `TokenUsage.CachedInputTokens` **field** end-to-end, but until this bump it could not also assert that the **metric counter** / **span attribute** actually surfaced — the new sdk surfaces only became reachable once this go.mod pin moved. A follow-up may extend that test to add a `metricstest` snapshot reader assertion against `tokens.input.cached.total`; this PR just unlocks the dependency.

## Test plan

- [x] `GOWORK=off go build ./...` in both modules — clean
- [x] `GOWORK=off go test -count=1 ./...` in eval — green
- [x] `GOWORK=off go build ./...` in tests/conformance — clean (live tests gated by `FLOWCRAFT_TEST_*` env vars)
- [ ] CI matrix runs on PR open

## Release plan complete

After this merges the cached-tokens telemetry work shipped over #113 / #115 / #116 / this PR is fully observable end-to-end:

```
sdk v0.3.5 (TokenUsage.CachedInputTokens field)
       │
       ├─→ sdkx v0.3.3 (adapters populate the field)
       │
       └─→ tests/conformance/llm/cached_tokens_test.go
              (proves wire-level cache hits — 96–99% on real providers)

[GAP closed by this release pair]

sdk v0.3.6 (counter + span attr + RunSummary)  ← #115
       │
       └─→ sdkx v0.3.4 (adapter spans + bytedance stream)  ← #116
              │
              └─→ eval + tests/conformance pinned to the new pair  ← this PR
```

Made with [Cursor](https://cursor.com)