### PR TITLE
feat(eval/.github): add workflows for history / knowledge / beir / simpleqa / taubench

### DIFF
--- a/.github/workflows/eval-beir.yml
+++ b/.github/workflows/eval-beir.yml
@@ -1,0 +1,207 @@
+name: eval / beir
+
+# ---------------------------------------------------------------------
+# Public BEIR-format retrieval benchmark (nDCG@k / Recall@k / MRR).
+# Requires the operator to stage a BEIR dataset on the runner host
+# under /var/lib/flowcraft-eval/datasets/<dataset>/ with the canonical
+# three-file layout (corpus.jsonl, queries.jsonl, qrels/test.tsv).
+# See internal-docs/eval-runbook.md §"Datasets".
+# ---------------------------------------------------------------------
+
+on:
+  workflow_dispatch:
+    inputs:
+      root:
+        description: "Path to BEIR dataset root (e.g. /var/lib/flowcraft-eval/datasets/scifact)"
+        required: true
+        default: "/var/lib/flowcraft-eval/datasets/scifact"
+      embedder:
+        description: "Embedder alias (empty restricts to BM25)"
+        required: false
+        default: "qwen:text-embedding-v4"
+      lanes:
+        description: "Comma-separated subset of {bm25,vector,hybrid}"
+        required: false
+        default: "bm25,vector,hybrid"
+      cutoffs:
+        description: "Comma-separated nDCG / Recall rank cutoffs"
+        required: false
+        default: "10,100"
+      ingest_concurrency:
+        description: "Concurrent PutDocument calls during ingest"
+        required: false
+        default: "8"
+      query_concurrency:
+        description: "Concurrent Search calls during scoring"
+        required: false
+        default: "8"
+      limit_queries:
+        description: "Evaluate only first N queries (0 = all; use 50 for smoke)"
+        required: false
+        default: "0"
+      notify_progress_pct:
+        description: "Feishu milestone resolution (% of work; 0=off)"
+        required: false
+        default: "10"
+
+concurrency:
+  group: eval-beir
+  cancel-in-progress: false
+
+env:
+  REPORT_DIR: /var/lib/flowcraft-eval/reports
+  RUN_TAG: beir-${{ github.run_id }}
+
+jobs:
+  run:
+    runs-on: [self-hosted, flowcraft-eval]
+    timeout-minutes: 360
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Load secrets from runner host
+        run: |
+          set -eu
+          test -f /etc/flowcraft-eval/.env
+          set -a
+          # shellcheck disable=SC1091
+          source /etc/flowcraft-eval/.env
+          set +a
+          while IFS= read -r key; do
+            [ -z "$key" ] && continue
+            value="${!key:-}"
+            [ -z "$value" ] && continue
+            while IFS= read -r line; do
+              [ -n "$line" ] && echo "::add-mask::$line"
+            done <<< "$value"
+            if [[ "$value" == *$'\n'* ]]; then
+              DELIM="EOF_${RANDOM}${RANDOM}"
+              {
+                echo "${key}<<${DELIM}"
+                echo "$value"
+                echo "$DELIM"
+              } >> "$GITHUB_ENV"
+            else
+              echo "${key}=${value}" >> "$GITHUB_ENV"
+            fi
+          done < <(grep -E '^[A-Z_][A-Z_0-9]*=' /etc/flowcraft-eval/.env | sed 's/=.*$//' | sort -u)
+          cp /etc/flowcraft-eval/.env .env
+          chmod 600 .env
+
+      - name: Ensure report dir
+        run: |
+          mkdir -p "$REPORT_DIR"
+          chmod 0750 "$REPORT_DIR" || true
+
+      - name: Verify dataset exists
+        # BEIR datasets are large (10s-100s MB) and aren't tracked in
+        # git. Fail loudly here rather than buried in `eval beir` logs.
+        run: |
+          set -eu
+          for f in corpus.jsonl queries.jsonl qrels/test.tsv; do
+            if [ ! -s "${{ inputs.root }}/$f" ]; then
+              echo "Missing or empty: ${{ inputs.root }}/$f"
+              echo "Stage a BEIR dataset under /var/lib/flowcraft-eval/datasets/ — see internal-docs/eval-runbook.md."
+              exit 1
+            fi
+          done
+
+      - name: Build eval binary
+        run: |
+          cd eval
+          GOWORK=off go build -trimpath -o /tmp/eval ./cmd/eval
+
+      - name: Notify Feishu — started
+        if: success()
+        run: |
+          set -eu
+          if [ -z "${FEISHU_WEBHOOK_URL:-}" ]; then
+            echo "FEISHU_WEBHOOK_URL not set; skipping started ping"
+            exit 0
+          fi
+          DS_NAME=$(basename "${{ inputs.root }}")
+          RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          curl -sS -X POST "$FEISHU_WEBHOOK_URL" \
+            -H 'Content-Type: application/json' \
+            -d @- <<EOF
+          {
+            "msg_type": "text",
+            "content": {
+              "text": "▶ beir run started\nrun_id=${{ github.run_id }}\ndataset=$DS_NAME lanes=${{ inputs.lanes }} cutoffs=${{ inputs.cutoffs }} embedder=${{ inputs.embedder }} limit_queries=${{ inputs.limit_queries }}\nlogs: $RUN_URL"
+            }
+          }
+          EOF
+
+      - name: Run beir
+        env:
+          REPORT_OUT: ${{ env.REPORT_DIR }}/${{ github.run_id }}.json
+        run: |
+          set -eu
+          ARGS=(
+            beir
+            --root "${{ inputs.root }}"
+            --lanes "${{ inputs.lanes }}"
+            --cutoffs "${{ inputs.cutoffs }}"
+            --ingest-concurrency "${{ inputs.ingest_concurrency }}"
+            --query-concurrency "${{ inputs.query_concurrency }}"
+            --limit-queries "${{ inputs.limit_queries }}"
+            --notify-name "$RUN_TAG"
+            --notify-progress-pct "${{ inputs.notify_progress_pct }}"
+            --out "$REPORT_OUT"
+          )
+          if [ -n "${{ inputs.embedder }}" ]; then
+            ARGS+=( --embedder "${{ inputs.embedder }}" )
+          fi
+          /tmp/eval "${ARGS[@]}"
+
+      - name: Upload report artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: beir-report-${{ github.run_id }}
+          path: ${{ env.REPORT_DIR }}/${{ github.run_id }}.json
+          if-no-files-found: warn
+          retention-days: 90
+
+      - name: Notify Feishu — final
+        if: always()
+        # BEIR Report shape:
+        #   .lanes[lane] = {ndcg: {<k>: f}, recall: {<k>: f}, mrr,
+        #                   n, errors, latency_p95(ns)}
+        # We surface one line per lane, flattening the ndcg/recall maps
+        # in lane key order so the message stays predictable across
+        # any --cutoffs the operator picked.
+        run: |
+          set +e
+          REPORT="$REPORT_DIR/${{ github.run_id }}.json"
+          STATUS="${{ job.status }}"
+          ICON="✅"
+          [ "$STATUS" != "success" ] && ICON="❌"
+          if [ -s "$REPORT" ]; then
+            METRICS=$(jq -r '
+              def ns2ms(x): if x == null then "n/a" else ((x/1000000)|tostring) + "ms" end;
+              .lanes | to_entries | map(
+                .key as $lane
+                | (.value.ndcg | to_entries | map("ndcg@\(.key)=\(.value)") | join(" ")) as $ndcg
+                | (.value.recall | to_entries | map("recall@\(.key)=\(.value)") | join(" ")) as $rec
+                | "[\($lane)] \($ndcg) \($rec) mrr=\(.value.mrr) errors=\(.value.errors) p95=" + ns2ms(.value.latency_p95)
+              ) | join("\n")
+            ' "$REPORT" 2>/dev/null)
+          else
+            METRICS="report not produced"
+          fi
+          RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          if [ -n "${FEISHU_WEBHOOK_URL:-}" ]; then
+            curl -sS -X POST "$FEISHU_WEBHOOK_URL" \
+              -H 'Content-Type: application/json' \
+              -d @- <<EOF
+          {
+            "msg_type": "text",
+            "content": {
+              "text": "$ICON beir run finished\nstatus=$STATUS\n$METRICS\nlogs: $RUN_URL"
+            }
+          }
+          EOF
+          else
+            echo "FEISHU_WEBHOOK_URL not set; skipping final ping"
+          fi

--- a/.github/workflows/eval-history.yml
+++ b/.github/workflows/eval-history.yml
@@ -1,0 +1,214 @@
+name: eval / history
+
+# ---------------------------------------------------------------------
+# History-compression regression. Replays a LoCoMo-style dataset
+# through {none, buffer, compacted} compactor strategies so we can
+# trade off prompt cost vs. answer quality. The default dataset
+# (eval/locomo/data/locomo10.jsonl) ships in-tree, so no host-side
+# staging is needed.
+# ---------------------------------------------------------------------
+
+on:
+  workflow_dispatch:
+    inputs:
+      dataset:
+        description: "Dataset path (.jsonl) or 'synthetic' (fastest smoke)"
+        required: true
+        default: "eval/locomo/data/locomo10.jsonl"
+      answer_llm:
+        description: "Answer LLM alias (required)"
+        required: true
+        default: "azure_gpt54"
+      summary_llm:
+        description: "Compactor summary LLM (empty skips 'compacted' strategy)"
+        required: false
+        default: "azure_gpt54"
+      judge_llm:
+        description: "Judge LLM alias (empty falls back to EM)"
+        required: false
+        default: "azure_gpt54"
+      strategies:
+        description: "Comma-separated subset of {none,buffer,compacted}"
+        required: false
+        default: "none,buffer,compacted"
+      buffer_max:
+        description: "StrategyBuffer window size"
+        required: false
+        default: "10"
+      compact_token_budget:
+        description: "Token budget per Load for compacted strategy"
+        required: false
+        default: "1500"
+      limit_convs:
+        description: "Evaluate first N conversations only (0 = all)"
+        required: false
+        default: "0"
+      limit_questions:
+        description: "Evaluate first N questions only (0 = all)"
+        required: false
+        default: "0"
+      concurrency:
+        description: "Parallel questions per strategy"
+        required: false
+        default: "1"
+      progress_every:
+        description: "Stderr progress every N questions (0=silent)"
+        required: false
+        default: "0"
+      notify_progress_pct:
+        description: "Feishu milestone resolution (% of work; 0=off)"
+        required: false
+        default: "25"
+
+concurrency:
+  group: eval-history
+  cancel-in-progress: false
+
+env:
+  REPORT_DIR: /var/lib/flowcraft-eval/reports
+  RUN_TAG: history-${{ github.run_id }}
+
+jobs:
+  run:
+    runs-on: [self-hosted, flowcraft-eval]
+    timeout-minutes: 180
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Load secrets from runner host
+        run: |
+          set -eu
+          test -f /etc/flowcraft-eval/.env
+          set -a
+          # shellcheck disable=SC1091
+          source /etc/flowcraft-eval/.env
+          set +a
+          while IFS= read -r key; do
+            [ -z "$key" ] && continue
+            value="${!key:-}"
+            [ -z "$value" ] && continue
+            while IFS= read -r line; do
+              [ -n "$line" ] && echo "::add-mask::$line"
+            done <<< "$value"
+            if [[ "$value" == *$'\n'* ]]; then
+              DELIM="EOF_${RANDOM}${RANDOM}"
+              {
+                echo "${key}<<${DELIM}"
+                echo "$value"
+                echo "$DELIM"
+              } >> "$GITHUB_ENV"
+            else
+              echo "${key}=${value}" >> "$GITHUB_ENV"
+            fi
+          done < <(grep -E '^[A-Z_][A-Z_0-9]*=' /etc/flowcraft-eval/.env | sed 's/=.*$//' | sort -u)
+          cp /etc/flowcraft-eval/.env .env
+          chmod 600 .env
+
+      - name: Ensure report dir
+        run: |
+          mkdir -p "$REPORT_DIR"
+          chmod 0750 "$REPORT_DIR" || true
+
+      - name: Build eval binary
+        run: |
+          cd eval
+          GOWORK=off go build -trimpath -o /tmp/eval ./cmd/eval
+
+      - name: Notify Feishu — started
+        if: success()
+        run: |
+          set -eu
+          if [ -z "${FEISHU_WEBHOOK_URL:-}" ]; then
+            echo "FEISHU_WEBHOOK_URL not set; skipping started ping"
+            exit 0
+          fi
+          RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          curl -sS -X POST "$FEISHU_WEBHOOK_URL" \
+            -H 'Content-Type: application/json' \
+            -d @- <<EOF
+          {
+            "msg_type": "text",
+            "content": {
+              "text": "▶ history run started\nrun_id=${{ github.run_id }}\nstrategies=${{ inputs.strategies }} answer=${{ inputs.answer_llm }} summary=${{ inputs.summary_llm }} judge=${{ inputs.judge_llm }}\ndataset=${{ inputs.dataset }}\nlogs: $RUN_URL"
+            }
+          }
+          EOF
+
+      - name: Run history
+        env:
+          REPORT_OUT: ${{ env.REPORT_DIR }}/${{ github.run_id }}.json
+        run: |
+          set -eu
+          ARGS=(
+            history
+            --dataset "${{ inputs.dataset }}"
+            --answer-llm "${{ inputs.answer_llm }}"
+            --strategies "${{ inputs.strategies }}"
+            --buffer-max "${{ inputs.buffer_max }}"
+            --compact-token-budget "${{ inputs.compact_token_budget }}"
+            --limit-convs "${{ inputs.limit_convs }}"
+            --limit-questions "${{ inputs.limit_questions }}"
+            --concurrency "${{ inputs.concurrency }}"
+            --progress-every "${{ inputs.progress_every }}"
+            --notify-name "$RUN_TAG"
+            --notify-progress-pct "${{ inputs.notify_progress_pct }}"
+            --out "$REPORT_OUT"
+          )
+          if [ -n "${{ inputs.summary_llm }}" ]; then
+            ARGS+=( --summary-llm "${{ inputs.summary_llm }}" )
+          fi
+          if [ -n "${{ inputs.judge_llm }}" ]; then
+            ARGS+=( --judge-llm "${{ inputs.judge_llm }}" )
+          fi
+          /tmp/eval "${ARGS[@]}"
+
+      - name: Upload report artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: history-report-${{ github.run_id }}
+          path: ${{ env.REPORT_DIR }}/${{ github.run_id }}.json
+          if-no-files-found: warn
+          retention-days: 90
+
+      - name: Notify Feishu — final
+        if: always()
+        # History Report shape:
+        #   .strategies[name] = {qa_judge, qa_em, qa_f1,
+        #                        prompt_tokens_p95, history_load_p95(ns),
+        #                        n, errors, skipped}
+        run: |
+          set +e
+          REPORT="$REPORT_DIR/${{ github.run_id }}.json"
+          STATUS="${{ job.status }}"
+          ICON="✅"
+          [ "$STATUS" != "success" ] && ICON="❌"
+          if [ -s "$REPORT" ]; then
+            METRICS=$(jq -r '
+              def ns2ms(x): if x == null then "n/a" else ((x/1000000)|tostring) + "ms" end;
+              .strategies | to_entries | map(
+                if (.value.skipped // "") != "" then
+                  "[\(.key)] SKIPPED (\(.value.skipped))"
+                else
+                  "[\(.key)] judge=\(.value.qa_judge) f1=\(.value.qa_f1) em=\(.value.qa_em) tokens.p95=\(.value.prompt_tokens_p95) load.p95=" + ns2ms(.value.history_load_p95)
+                end
+              ) | join("\n")
+            ' "$REPORT" 2>/dev/null)
+          else
+            METRICS="report not produced"
+          fi
+          RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          if [ -n "${FEISHU_WEBHOOK_URL:-}" ]; then
+            curl -sS -X POST "$FEISHU_WEBHOOK_URL" \
+              -H 'Content-Type: application/json' \
+              -d @- <<EOF
+          {
+            "msg_type": "text",
+            "content": {
+              "text": "$ICON history run finished\nstatus=$STATUS\n$METRICS\nlogs: $RUN_URL"
+            }
+          }
+          EOF
+          else
+            echo "FEISHU_WEBHOOK_URL not set; skipping final ping"
+          fi

--- a/.github/workflows/eval-knowledge.yml
+++ b/.github/workflows/eval-knowledge.yml
@@ -1,0 +1,189 @@
+name: eval / knowledge
+
+# ---------------------------------------------------------------------
+# FlowCraft hand-curated knowledge-retrieval regression. Smallest of
+# the retrieval suites (100 docs / 40 questions); the only one
+# checked into the repo, so no host-side dataset staging required.
+# Runs in 1-2 min, useful as a PR-gate fixture.
+# ---------------------------------------------------------------------
+
+on:
+  workflow_dispatch:
+    inputs:
+      corpus:
+        description: "Path to directory of .md documents to index"
+        required: false
+        default: "eval/knowledge/testdata/corpus"
+      golden:
+        description: "Path to JSONL golden question set"
+        required: false
+        default: "eval/knowledge/testdata/golden.jsonl"
+      embedder:
+        description: "Embedder alias (empty restricts to BM25 lane)"
+        required: false
+        default: "qwen:text-embedding-v4"
+      lanes:
+        description: "Comma-separated subset of {bm25,vector,hybrid}"
+        required: false
+        default: "bm25,vector,hybrid"
+      topk:
+        description: "Rank cutoff for Recall@K"
+        required: false
+        default: "10"
+      concurrency:
+        description: "In-flight searches per lane"
+        required: false
+        default: "4"
+      negative_score_ceiling:
+        description: "Negative-class top-1 score above this counts as breach (0 disables)"
+        required: false
+        default: "0"
+      notify_progress_pct:
+        description: "Feishu milestone resolution (% of work; 0=off)"
+        required: false
+        default: "25"
+
+concurrency:
+  group: eval-knowledge
+  cancel-in-progress: false
+
+env:
+  REPORT_DIR: /var/lib/flowcraft-eval/reports
+  RUN_TAG: knowledge-${{ github.run_id }}
+
+jobs:
+  run:
+    runs-on: [self-hosted, flowcraft-eval]
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Load secrets from runner host
+        # See eval-locomo.yml for the rationale (.env is shell-quoted
+        # dotenv with multi-line JSON; requires `set -a; source`).
+        run: |
+          set -eu
+          test -f /etc/flowcraft-eval/.env
+          set -a
+          # shellcheck disable=SC1091
+          source /etc/flowcraft-eval/.env
+          set +a
+          while IFS= read -r key; do
+            [ -z "$key" ] && continue
+            value="${!key:-}"
+            [ -z "$value" ] && continue
+            while IFS= read -r line; do
+              [ -n "$line" ] && echo "::add-mask::$line"
+            done <<< "$value"
+            if [[ "$value" == *$'\n'* ]]; then
+              DELIM="EOF_${RANDOM}${RANDOM}"
+              {
+                echo "${key}<<${DELIM}"
+                echo "$value"
+                echo "$DELIM"
+              } >> "$GITHUB_ENV"
+            else
+              echo "${key}=${value}" >> "$GITHUB_ENV"
+            fi
+          done < <(grep -E '^[A-Z_][A-Z_0-9]*=' /etc/flowcraft-eval/.env | sed 's/=.*$//' | sort -u)
+          cp /etc/flowcraft-eval/.env .env
+          chmod 600 .env
+
+      - name: Ensure report dir
+        run: |
+          mkdir -p "$REPORT_DIR"
+          chmod 0750 "$REPORT_DIR" || true
+
+      - name: Build eval binary
+        run: |
+          cd eval
+          GOWORK=off go build -trimpath -o /tmp/eval ./cmd/eval
+
+      - name: Notify Feishu — started
+        if: success()
+        run: |
+          set -eu
+          if [ -z "${FEISHU_WEBHOOK_URL:-}" ]; then
+            echo "FEISHU_WEBHOOK_URL not set; skipping started ping"
+            exit 0
+          fi
+          RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          curl -sS -X POST "$FEISHU_WEBHOOK_URL" \
+            -H 'Content-Type: application/json' \
+            -d @- <<EOF
+          {
+            "msg_type": "text",
+            "content": {
+              "text": "▶ knowledge run started\nrun_id=${{ github.run_id }}\nlanes=${{ inputs.lanes }} topk=${{ inputs.topk }} embedder=${{ inputs.embedder }}\nlogs: $RUN_URL"
+            }
+          }
+          EOF
+
+      - name: Run knowledge
+        env:
+          REPORT_OUT: ${{ env.REPORT_DIR }}/${{ github.run_id }}.json
+        run: |
+          set -eu
+          ARGS=(
+            knowledge
+            --corpus "${{ inputs.corpus }}"
+            --golden "${{ inputs.golden }}"
+            --lanes "${{ inputs.lanes }}"
+            --topk "${{ inputs.topk }}"
+            --concurrency "${{ inputs.concurrency }}"
+            --negative-score-ceiling "${{ inputs.negative_score_ceiling }}"
+            --notify-name "$RUN_TAG"
+            --notify-progress-pct "${{ inputs.notify_progress_pct }}"
+            --out "$REPORT_OUT"
+          )
+          if [ -n "${{ inputs.embedder }}" ]; then
+            ARGS+=( --embedder "${{ inputs.embedder }}" )
+          fi
+          /tmp/eval "${ARGS[@]}"
+
+      - name: Upload report artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: knowledge-report-${{ github.run_id }}
+          path: ${{ env.REPORT_DIR }}/${{ github.run_id }}.json
+          if-no-files-found: warn
+          retention-days: 90
+
+      - name: Notify Feishu — final
+        if: always()
+        # Knowledge Report shape:
+        #   .lanes[lane] = {recall_at_k, keyword_rate, negative_breach,
+        #                   n, errors, latency_p95(ns)}
+        # We surface one line per lane in the order bm25/vector/hybrid.
+        run: |
+          set +e
+          REPORT="$REPORT_DIR/${{ github.run_id }}.json"
+          STATUS="${{ job.status }}"
+          ICON="✅"
+          [ "$STATUS" != "success" ] && ICON="❌"
+          if [ -s "$REPORT" ]; then
+            METRICS=$(jq -r '
+              def ns2ms(x): if x == null then "n/a" else ((x/1000000)|tostring) + "ms" end;
+              .lanes | to_entries | map(
+                "[\(.key)] recall@k=\(.value.recall_at_k) keyword=\(.value.keyword_rate) neg_breach=\(.value.negative_breach) errors=\(.value.errors) p95=" + ns2ms(.value.latency_p95)
+              ) | join("\n")
+            ' "$REPORT" 2>/dev/null)
+          else
+            METRICS="report not produced"
+          fi
+          RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          if [ -n "${FEISHU_WEBHOOK_URL:-}" ]; then
+            curl -sS -X POST "$FEISHU_WEBHOOK_URL" \
+              -H 'Content-Type: application/json' \
+              -d @- <<EOF
+          {
+            "msg_type": "text",
+            "content": {
+              "text": "$ICON knowledge run finished\nstatus=$STATUS\n$METRICS\nlogs: $RUN_URL"
+            }
+          }
+          EOF
+          else
+            echo "FEISHU_WEBHOOK_URL not set; skipping final ping"
+          fi

--- a/.github/workflows/eval-simpleqa.yml
+++ b/.github/workflows/eval-simpleqa.yml
@@ -1,0 +1,204 @@
+name: eval / simpleqa
+
+# ---------------------------------------------------------------------
+# OpenAI's SimpleQA short-form factuality + calibration benchmark.
+# Requires the operator to stage simple_qa_test_set.csv on the runner
+# under /var/lib/flowcraft-eval/datasets/. A full run is ~4.3k
+# questions; use `limit` to smoke-test.
+#
+# Source CSV:
+#   curl -L https://openaipublic.blob.core.windows.net/simple-evals/simple_qa_test_set.csv \
+#     -o /var/lib/flowcraft-eval/datasets/simple_qa_test_set.csv
+# ---------------------------------------------------------------------
+
+on:
+  workflow_dispatch:
+    inputs:
+      dataset:
+        description: "Path to simple_qa_test_set.csv (or converted .jsonl)"
+        required: true
+        default: "/var/lib/flowcraft-eval/datasets/simple_qa_test_set.csv"
+      answer_llm:
+        description: "Model under test (required)"
+        required: true
+        default: "azure_gpt54"
+      judge_llm:
+        description: "Judge LLM (required)"
+        required: true
+        default: "azure_gpt54"
+      limit:
+        description: "Evaluate first N questions only (0 = all; use 50 for smoke)"
+        required: false
+        default: "0"
+      concurrency:
+        description: "Parallel (answer, judge) pairs"
+        required: false
+        default: "4"
+      per_question_timeout:
+        description: "Deadline for one answer+judge pair (Go duration; 0 disables)"
+        required: false
+        default: "90s"
+      max_samples:
+        description: "Cap on Report.Samples (debug detail rows)"
+        required: false
+        default: "200"
+      include_topic_breakdown:
+        description: "Populate Report.PerTopic"
+        required: false
+        type: boolean
+        default: true
+      notify_progress_pct:
+        description: "Feishu milestone resolution (% of work; 0=off)"
+        required: false
+        default: "10"
+
+concurrency:
+  group: eval-simpleqa
+  cancel-in-progress: false
+
+env:
+  REPORT_DIR: /var/lib/flowcraft-eval/reports
+  RUN_TAG: simpleqa-${{ github.run_id }}
+
+jobs:
+  run:
+    runs-on: [self-hosted, flowcraft-eval]
+    timeout-minutes: 360
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Load secrets from runner host
+        run: |
+          set -eu
+          test -f /etc/flowcraft-eval/.env
+          set -a
+          # shellcheck disable=SC1091
+          source /etc/flowcraft-eval/.env
+          set +a
+          while IFS= read -r key; do
+            [ -z "$key" ] && continue
+            value="${!key:-}"
+            [ -z "$value" ] && continue
+            while IFS= read -r line; do
+              [ -n "$line" ] && echo "::add-mask::$line"
+            done <<< "$value"
+            if [[ "$value" == *$'\n'* ]]; then
+              DELIM="EOF_${RANDOM}${RANDOM}"
+              {
+                echo "${key}<<${DELIM}"
+                echo "$value"
+                echo "$DELIM"
+              } >> "$GITHUB_ENV"
+            else
+              echo "${key}=${value}" >> "$GITHUB_ENV"
+            fi
+          done < <(grep -E '^[A-Z_][A-Z_0-9]*=' /etc/flowcraft-eval/.env | sed 's/=.*$//' | sort -u)
+          cp /etc/flowcraft-eval/.env .env
+          chmod 600 .env
+
+      - name: Ensure report dir
+        run: |
+          mkdir -p "$REPORT_DIR"
+          chmod 0750 "$REPORT_DIR" || true
+
+      - name: Verify dataset exists
+        run: |
+          set -eu
+          if [ ! -s "${{ inputs.dataset }}" ]; then
+            echo "Missing or empty: ${{ inputs.dataset }}"
+            echo "Stage the SimpleQA CSV under /var/lib/flowcraft-eval/datasets/ — see internal-docs/eval-runbook.md."
+            exit 1
+          fi
+
+      - name: Build eval binary
+        run: |
+          cd eval
+          GOWORK=off go build -trimpath -o /tmp/eval ./cmd/eval
+
+      - name: Notify Feishu — started
+        if: success()
+        run: |
+          set -eu
+          if [ -z "${FEISHU_WEBHOOK_URL:-}" ]; then
+            echo "FEISHU_WEBHOOK_URL not set; skipping started ping"
+            exit 0
+          fi
+          DS_NAME=$(basename "${{ inputs.dataset }}")
+          RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          curl -sS -X POST "$FEISHU_WEBHOOK_URL" \
+            -H 'Content-Type: application/json' \
+            -d @- <<EOF
+          {
+            "msg_type": "text",
+            "content": {
+              "text": "▶ simpleqa run started\nrun_id=${{ github.run_id }}\nanswer=${{ inputs.answer_llm }} judge=${{ inputs.judge_llm }} limit=${{ inputs.limit }} concurrency=${{ inputs.concurrency }}\ndataset=$DS_NAME\nlogs: $RUN_URL"
+            }
+          }
+          EOF
+
+      - name: Run simpleqa
+        env:
+          REPORT_OUT: ${{ env.REPORT_DIR }}/${{ github.run_id }}.json
+        run: |
+          set -eu
+          ARGS=(
+            simpleqa
+            --dataset "${{ inputs.dataset }}"
+            --answer-llm "${{ inputs.answer_llm }}"
+            --judge-llm "${{ inputs.judge_llm }}"
+            --limit "${{ inputs.limit }}"
+            --concurrency "${{ inputs.concurrency }}"
+            --per-question-timeout "${{ inputs.per_question_timeout }}"
+            --max-samples "${{ inputs.max_samples }}"
+            --include-topic-breakdown="${{ inputs.include_topic_breakdown }}"
+            --notify-name "$RUN_TAG"
+            --notify-progress-pct "${{ inputs.notify_progress_pct }}"
+            --out "$REPORT_OUT"
+          )
+          /tmp/eval "${ARGS[@]}"
+
+      - name: Upload report artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: simpleqa-report-${{ github.run_id }}
+          path: ${{ env.REPORT_DIR }}/${{ github.run_id }}.json
+          if-no-files-found: warn
+          retention-days: 90
+
+      - name: Notify Feishu — final
+        if: always()
+        # SimpleQA Report shape (flat):
+        #   {n, correct, incorrect, not_attempted, judge_failures,
+        #    accuracy, attempted_accuracy, abstention_rate,
+        #    hallucination_rate, duration_ms}
+        run: |
+          set +e
+          REPORT="$REPORT_DIR/${{ github.run_id }}.json"
+          STATUS="${{ job.status }}"
+          ICON="✅"
+          [ "$STATUS" != "success" ] && ICON="❌"
+          if [ -s "$REPORT" ]; then
+            METRICS=$(jq -r '
+              "n=\(.n) correct=\(.correct) incorrect=\(.incorrect) not_attempted=\(.not_attempted) judge_failures=\(.judge_failures)\n" +
+              "accuracy=\(.accuracy) attempted_accuracy=\(.attempted_accuracy)\n" +
+              "abstention=\(.abstention_rate) hallucination=\(.hallucination_rate)"
+            ' "$REPORT" 2>/dev/null)
+          else
+            METRICS="report not produced"
+          fi
+          RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          if [ -n "${FEISHU_WEBHOOK_URL:-}" ]; then
+            curl -sS -X POST "$FEISHU_WEBHOOK_URL" \
+              -H 'Content-Type: application/json' \
+              -d @- <<EOF
+          {
+            "msg_type": "text",
+            "content": {
+              "text": "$ICON simpleqa run finished\nstatus=$STATUS\n$METRICS\nlogs: $RUN_URL"
+            }
+          }
+          EOF
+          else
+            echo "FEISHU_WEBHOOK_URL not set; skipping final ping"
+          fi

--- a/.github/workflows/eval-taubench.yml
+++ b/.github/workflows/eval-taubench.yml
@@ -1,0 +1,232 @@
+name: eval / taubench
+
+# ---------------------------------------------------------------------
+# τ-bench tool-use benchmark (single-shot + multi-turn dialog). NOT a
+# PR gate — runs real LLM tool-call chains, expensive. The default
+# bundled mini-datasets (retail / airline / all) ship in-tree, so no
+# host-side staging is required unless --upstream-tasks is used.
+# ---------------------------------------------------------------------
+
+on:
+  workflow_dispatch:
+    inputs:
+      agent_llm:
+        description: "Agent LLM under test (required)"
+        required: true
+        default: "azure_gpt54"
+      customer_llm:
+        description: "Customer-role LLM (required iff dataset has multi-turn tasks)"
+        required: false
+        default: "azure_gpt54"
+      domain:
+        description: "Bundled domain pack: retail | airline | all"
+        required: false
+        default: "retail"
+      upstream_tasks:
+        description: "Path to upstream τ-bench tasks JSON (overrides bundled mini pack)"
+        required: false
+        default: ""
+      upstream_initial_state:
+        description: "Path to initial DB JSON paired with upstream_tasks"
+        required: false
+        default: ""
+      max_agent_turns:
+        description: "Ceiling on agent Generate calls per task"
+        required: false
+        default: "12"
+      max_conversation_turns:
+        description: "Ceiling on customer↔agent exchanges per multi-turn task"
+        required: false
+        default: "10"
+      stop_token:
+        description: "Substring the customer can emit to end a dialog cleanly"
+        required: false
+        default: "###STOP###"
+      concurrency:
+        description: "Parallel tasks"
+        required: false
+        default: "4"
+      limit:
+        description: "Run only the first N tasks (0 = all)"
+        required: false
+        default: "0"
+      per_task_timeout:
+        description: "Wall-clock cap per task (Go duration; 0 inherits ambient ctx)"
+        required: false
+        default: "5m"
+      include_transcript:
+        description: "Embed per-task agent transcript in the report"
+        required: false
+        type: boolean
+        default: false
+      notify_progress_pct:
+        description: "Feishu milestone resolution (% of work; 0=off)"
+        required: false
+        default: "25"
+
+concurrency:
+  group: eval-taubench
+  cancel-in-progress: false
+
+env:
+  REPORT_DIR: /var/lib/flowcraft-eval/reports
+  RUN_TAG: taubench-${{ github.run_id }}
+
+jobs:
+  run:
+    runs-on: [self-hosted, flowcraft-eval]
+    timeout-minutes: 240
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Load secrets from runner host
+        run: |
+          set -eu
+          test -f /etc/flowcraft-eval/.env
+          set -a
+          # shellcheck disable=SC1091
+          source /etc/flowcraft-eval/.env
+          set +a
+          while IFS= read -r key; do
+            [ -z "$key" ] && continue
+            value="${!key:-}"
+            [ -z "$value" ] && continue
+            while IFS= read -r line; do
+              [ -n "$line" ] && echo "::add-mask::$line"
+            done <<< "$value"
+            if [[ "$value" == *$'\n'* ]]; then
+              DELIM="EOF_${RANDOM}${RANDOM}"
+              {
+                echo "${key}<<${DELIM}"
+                echo "$value"
+                echo "$DELIM"
+              } >> "$GITHUB_ENV"
+            else
+              echo "${key}=${value}" >> "$GITHUB_ENV"
+            fi
+          done < <(grep -E '^[A-Z_][A-Z_0-9]*=' /etc/flowcraft-eval/.env | sed 's/=.*$//' | sort -u)
+          cp /etc/flowcraft-eval/.env .env
+          chmod 600 .env
+
+      - name: Ensure report dir
+        run: |
+          mkdir -p "$REPORT_DIR"
+          chmod 0750 "$REPORT_DIR" || true
+
+      - name: Verify upstream dataset (if provided)
+        if: ${{ inputs.upstream_tasks != '' }}
+        # Only validates the upstream-tasks pairing; bundled domain
+        # packs need no staging.
+        run: |
+          set -eu
+          if [ ! -s "${{ inputs.upstream_tasks }}" ]; then
+            echo "Missing or empty: ${{ inputs.upstream_tasks }}"
+            exit 1
+          fi
+          if [ -z "${{ inputs.upstream_initial_state }}" ] || [ ! -s "${{ inputs.upstream_initial_state }}" ]; then
+            echo "upstream_initial_state is required and must be non-empty when upstream_tasks is set"
+            exit 1
+          fi
+
+      - name: Build eval binary
+        run: |
+          cd eval
+          GOWORK=off go build -trimpath -o /tmp/eval ./cmd/eval
+
+      - name: Notify Feishu — started
+        if: success()
+        run: |
+          set -eu
+          if [ -z "${FEISHU_WEBHOOK_URL:-}" ]; then
+            echo "FEISHU_WEBHOOK_URL not set; skipping started ping"
+            exit 0
+          fi
+          RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          DS_DESC="bundled:${{ inputs.domain }}"
+          if [ -n "${{ inputs.upstream_tasks }}" ]; then
+            DS_DESC="upstream:$(basename "${{ inputs.upstream_tasks }}")"
+          fi
+          curl -sS -X POST "$FEISHU_WEBHOOK_URL" \
+            -H 'Content-Type: application/json' \
+            -d @- <<EOF
+          {
+            "msg_type": "text",
+            "content": {
+              "text": "▶ taubench run started\nrun_id=${{ github.run_id }}\nagent=${{ inputs.agent_llm }} customer=${{ inputs.customer_llm }} domain=${{ inputs.domain }} limit=${{ inputs.limit }}\ndataset=$DS_DESC\nlogs: $RUN_URL"
+            }
+          }
+          EOF
+
+      - name: Run taubench
+        env:
+          REPORT_OUT: ${{ env.REPORT_DIR }}/${{ github.run_id }}.json
+        run: |
+          set -eu
+          ARGS=(
+            taubench
+            --agent-llm "${{ inputs.agent_llm }}"
+            --domain "${{ inputs.domain }}"
+            --max-agent-turns "${{ inputs.max_agent_turns }}"
+            --max-conversation-turns "${{ inputs.max_conversation_turns }}"
+            --stop-token "${{ inputs.stop_token }}"
+            --concurrency "${{ inputs.concurrency }}"
+            --limit "${{ inputs.limit }}"
+            --per-task-timeout "${{ inputs.per_task_timeout }}"
+            --include-transcript="${{ inputs.include_transcript }}"
+            --notify-name "$RUN_TAG"
+            --notify-progress-pct "${{ inputs.notify_progress_pct }}"
+            --out "$REPORT_OUT"
+          )
+          if [ -n "${{ inputs.customer_llm }}" ]; then
+            ARGS+=( --customer-llm "${{ inputs.customer_llm }}" )
+          fi
+          if [ -n "${{ inputs.upstream_tasks }}" ]; then
+            ARGS+=( --upstream-tasks "${{ inputs.upstream_tasks }}" --upstream-initial-state "${{ inputs.upstream_initial_state }}" )
+          fi
+          /tmp/eval "${ARGS[@]}"
+
+      - name: Upload report artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: taubench-report-${{ github.run_id }}
+          path: ${{ env.REPORT_DIR }}/${{ github.run_id }}.json
+          if-no-files-found: warn
+          retention-days: 90
+
+      - name: Notify Feishu — final
+        if: always()
+        # τ-bench Report shape:
+        #   {n, passed, pass_rate, duration_ms,
+        #    per_domain: {<name>: {tasks, passed, pass_rate}}}
+        run: |
+          set +e
+          REPORT="$REPORT_DIR/${{ github.run_id }}.json"
+          STATUS="${{ job.status }}"
+          ICON="✅"
+          [ "$STATUS" != "success" ] && ICON="❌"
+          if [ -s "$REPORT" ]; then
+            METRICS=$(jq -r '
+              "n=\(.n) passed=\(.passed) pass_rate=\(.pass_rate) duration_ms=\(.duration_ms)\n" +
+              ((.per_domain // {}) | to_entries | map(
+                "[\(.key)] pass_rate=\(.value.pass_rate) (\(.value.passed)/\(.value.tasks))"
+              ) | join("\n"))
+            ' "$REPORT" 2>/dev/null)
+          else
+            METRICS="report not produced"
+          fi
+          RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          if [ -n "${FEISHU_WEBHOOK_URL:-}" ]; then
+            curl -sS -X POST "$FEISHU_WEBHOOK_URL" \
+              -H 'Content-Type: application/json' \
+              -d @- <<EOF
+          {
+            "msg_type": "text",
+            "content": {
+              "text": "$ICON taubench run finished\nstatus=$STATUS\n$METRICS\nlogs: $RUN_URL"
+            }
+          }
+          EOF
+          else
+            echo "FEISHU_WEBHOOK_URL not set; skipping final ping"
+          fi


### PR DESCRIPTION
## Summary

Round out the GitHub Actions migration: each remaining FlowCraft eval suite now has its own `workflow_dispatch` under `.github/workflows/`, matching the locomo + longmemeval template.

| Suite | Workflow | Needs host dataset? | Typical wall time |
|---|---|---|---|
| history | `eval-history.yml` | no (in-tree `locomo10.jsonl`) | 10 min – 1 h |
| knowledge | `eval-knowledge.yml` | no (in-tree `testdata/`) | 1 – 2 min |
| BEIR | `eval-beir.yml` | yes (per slice under `/var/lib/flowcraft-eval/datasets/`) | 10 min – 1 h |
| SimpleQA | `eval-simpleqa.yml` | yes (`simple_qa_test_set.csv`) | 1 h – 3 h |
| τ-bench | `eval-taubench.yml` | no (bundled retail/airline mini fixtures) | 5 – 30 min |

All five workflows:
- Reuse the loader pattern from #117 (`set -a; source /etc/flowcraft-eval/.env`) so quoted multi-line JSON values in the host `.env` load correctly.
- Each carries its own `concurrency.group` (e.g. `eval-history`) to serialise runs within a kind without blocking other kinds.
- Wire suite-specific CLI flags through `workflow_dispatch.inputs` verbatim — no surprise defaults relative to historical `*-launch.sh` invocations.
- Emit a started + final Feishu webhook ping; final ping `jq`s the suite-specific Report shape (lanes for knowledge/beir, strategies for history, flat for simpleqa, per_domain for taubench).
- Upload `${run_id}.json` as a 90-day GitHub artifact and to `/var/lib/flowcraft-eval/reports/`.

BEIR + SimpleQA include a `Verify dataset exists` step that fails fast if the host hasn't been staged; staging recipe is in the local runbook.

## Base

This PR is stacked on top of #117 (`fix/eval-actions-loader-quotes`). The loader logic these new workflows depend on lives in #117; once that lands and this rebases to `main`, the diff stays the 5 new YAML files only.

## Test plan

- [x] `python3 -c "yaml.safe_load(...)"` on all 7 eval workflow YAMLs.
- [x] `actionlint v1.7.12` on all 5 new workflows (whitelisted `flowcraft-eval` runner label via existing `.github/actionlint.yaml`).
- [ ] Trigger `eval-knowledge.yml` first — fastest smoke (1-2 min, in-tree data), exercises loader + Feishu pings + lane-based report jq.
- [ ] Trigger `eval-taubench.yml` with `domain=retail limit=2` — exercises the bundled-fixture path.
- [ ] Trigger `eval-history.yml` with `dataset=synthetic limit_questions=10` — exercises strategy-map report jq.
- [ ] Stage `scifact` on the host and trigger `eval-beir.yml` with `limit_queries=50` — exercises multi-cutoff report jq.
- [ ] Stage `simple_qa_test_set.csv` and trigger `eval-simpleqa.yml` with `limit=20` — exercises flat-report jq.

Made with [Cursor](https://cursor.com)