### PR TITLE
feat(sdk/sandbox): extract execution boundary from sdk/workspace

### DIFF
--- a/sdk/graph/node/scriptnode/register.go
+++ b/sdk/graph/node/scriptnode/register.go
@@ -7,6 +7,7 @@ import (
 	"github.com/GizClaw/flowcraft/sdk/graph"
 	"github.com/GizClaw/flowcraft/sdk/graph/node"
 	"github.com/GizClaw/flowcraft/sdk/graph/node/scripts"
+	"github.com/GizClaw/flowcraft/sdk/sandbox"
 	"github.com/GizClaw/flowcraft/sdk/script"
 	"github.com/GizClaw/flowcraft/sdk/script/bindings"
 	"github.com/GizClaw/flowcraft/sdk/workspace"
@@ -14,11 +15,17 @@ import (
 
 // Deps captures the build-time dependencies needed to instantiate a
 // scriptnode. ScriptRuntime is required; the rest are optional.
+//
+// CommandRunner keeps its field name (rather than tracking the
+// sandbox.Runner rename) so existing wiring in callers like vesseld
+// does not have to chase the v0.2.0 rename. The field type is now
+// sandbox.Runner; workspace.CommandRunner remains a working alias until
+// v0.5.0.
 type Deps struct {
 	ScriptRuntime script.Runtime
 	ScriptFS      fs.FS
 	Workspace     workspace.Workspace
-	CommandRunner workspace.CommandRunner
+	CommandRunner sandbox.Runner
 }
 
 // needsShell lists built-in jsnode types that additionally require a

--- a/sdk/sandbox/decorator.go
+++ b/sdk/sandbox/decorator.go
@@ -1,0 +1,45 @@
+package sandbox
+
+import (
+	"context"
+	"fmt"
+)
+
+// AllowCommands returns a Runner that delegates to inner only when the
+// command's exact name appears in allowed; every other command is
+// rejected before reaching inner. It is the functional replacement for
+// the v0.1 ScopedCommandRunner type — a decorator rather than a struct
+// with exported fields. Matching is on the full command string passed to
+// Exec; callers that want to match base names (so "/usr/bin/echo"
+// matches "echo") should normalise before invoking Exec.
+func AllowCommands(inner Runner, allowed []string) Runner {
+	wl := make(map[string]bool, len(allowed))
+	for _, cmd := range allowed {
+		wl[cmd] = true
+	}
+	return &allowCommandsRunner{inner: inner, whitelist: wl}
+}
+
+type allowCommandsRunner struct {
+	inner     Runner
+	whitelist map[string]bool
+}
+
+func (r *allowCommandsRunner) Exec(ctx context.Context, cmd string, args []string, opts ExecOptions) (*ExecResult, error) {
+	if !r.whitelist[cmd] {
+		return nil, fmt.Errorf("sandbox: command %q is not in the whitelist", cmd)
+	}
+	return r.inner.Exec(ctx, cmd, args, opts)
+}
+
+// NoopRunner is a zero-policy Runner that always returns an empty
+// successful ExecResult. It is useful as a default in test wiring or as
+// the inner Runner for AllowCommands when the caller wants to assert
+// "the allow-list rejected the call" without actually running anything.
+type NoopRunner struct{}
+
+// Exec implements Runner. It ignores every argument and returns an empty
+// ExecResult with nil error.
+func (NoopRunner) Exec(_ context.Context, _ string, _ []string, _ ExecOptions) (*ExecResult, error) {
+	return &ExecResult{}, nil
+}

--- a/sdk/sandbox/decorator_test.go
+++ b/sdk/sandbox/decorator_test.go
@@ -1,0 +1,84 @@
+package sandbox_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/GizClaw/flowcraft/sdk/sandbox"
+)
+
+// recordingRunner records the most recent Exec call so AllowCommands
+// tests can prove that allowed calls do pass through to the inner Runner
+// (and blocked calls do not).
+type recordingRunner struct {
+	called bool
+	cmd    string
+}
+
+func (r *recordingRunner) Exec(_ context.Context, cmd string, _ []string, _ sandbox.ExecOptions) (*sandbox.ExecResult, error) {
+	r.called = true
+	r.cmd = cmd
+	return &sandbox.ExecResult{Stdout: "ok"}, nil
+}
+
+func TestAllowCommands_Pass(t *testing.T) {
+	inner := &recordingRunner{}
+	r := sandbox.AllowCommands(inner, []string{"ls", "cat", "echo"})
+
+	result, err := r.Exec(context.Background(), "ls", nil, sandbox.ExecOptions{})
+	if err != nil {
+		t.Fatalf("allowed command should succeed: %v", err)
+	}
+	if !inner.called {
+		t.Fatal("allowed command should reach inner runner")
+	}
+	if inner.cmd != "ls" {
+		t.Fatalf("inner.cmd = %q, want 'ls'", inner.cmd)
+	}
+	if result.Stdout != "ok" {
+		t.Fatalf("result not passed through, got Stdout = %q", result.Stdout)
+	}
+}
+
+func TestAllowCommands_Reject(t *testing.T) {
+	inner := &recordingRunner{}
+	r := sandbox.AllowCommands(inner, []string{"ls", "cat"})
+
+	_, err := r.Exec(context.Background(), "rm", []string{"-rf", "/"}, sandbox.ExecOptions{})
+	if err == nil {
+		t.Fatal("blocked command should fail")
+	}
+	if !strings.Contains(err.Error(), "whitelist") {
+		t.Fatalf("error should mention whitelist, got: %v", err)
+	}
+	if inner.called {
+		t.Fatal("blocked command must not reach inner runner")
+	}
+}
+
+func TestAllowCommands_EmptyWhitelist(t *testing.T) {
+	inner := &recordingRunner{}
+	r := sandbox.AllowCommands(inner, nil)
+
+	_, err := r.Exec(context.Background(), "ls", nil, sandbox.ExecOptions{})
+	if err == nil {
+		t.Fatal("empty whitelist should block all commands")
+	}
+	if inner.called {
+		t.Fatal("empty whitelist must not reach inner runner")
+	}
+}
+
+func TestNoopRunner(t *testing.T) {
+	result, err := sandbox.NoopRunner{}.Exec(context.Background(), "anything", []string{"arg"}, sandbox.ExecOptions{})
+	if err != nil {
+		t.Fatalf("NoopRunner should not error: %v", err)
+	}
+	if result == nil {
+		t.Fatal("NoopRunner should return non-nil ExecResult")
+	}
+	if result.ExitCode != 0 || result.Stdout != "" || result.Stderr != "" {
+		t.Fatalf("NoopRunner should return empty result, got: %+v", *result)
+	}
+}

--- a/sdk/sandbox/doc.go
+++ b/sdk/sandbox/doc.go
@@ -1,0 +1,29 @@
+// Package sandbox is the agent's execution boundary: where commands run,
+// what they can reach (net), what they can see (env), and how much they
+// can consume (resources). Sandbox is daemon-level shared policy; per-run
+// state lives in sdk/workspace.
+//
+// The package centres on the Runner interface, a single Exec call that
+// turns a command + arguments + ExecOptions into an ExecResult. Concrete
+// runners differ in *where* the work happens (local process, nsjail
+// namespace, container, microVM) but share the same policy surface so a
+// caller can be retargeted between backends without changing call sites.
+//
+// ExecOptions carries three policy groups beyond the obvious WorkDir /
+// Stdin / Timeout knobs:
+//
+//   - Env (EnvPolicy): explicit allow-list of host environment variables
+//     plus an Inject map. Replaces "inherit the entire daemon's env" which
+//     is unsafe in a multi-tenant agent harness.
+//   - Net (NetPolicy): mode + (future) allow-list / proxy URL. LocalRunner
+//     only accepts NetDefault; non-default modes require a sandboxing
+//     backend such as sdkx/sandbox/{nsjail,container,microvm} (planned).
+//   - Resources (ResourceLimits): CPU / memory / disk caps plus
+//     MaxOutputBytes. LocalRunner only enforces MaxOutputBytes today; the
+//     hard caps require kernel-level mechanisms shipped by sdkx backends.
+//
+// LocalRunner is the in-process, no-isolation backend used by tests and
+// single-tenant operators. Production deployments should compose it with
+// AllowCommands (whitelist) and eventually swap to a sandboxed Runner
+// when sdkx ships them.
+package sandbox

--- a/sdk/sandbox/local.go
+++ b/sdk/sandbox/local.go
@@ -1,0 +1,248 @@
+package sandbox
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"math"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"github.com/GizClaw/flowcraft/sdk/errdefs"
+)
+
+const defaultMaxOutputBytes int64 = 10 * 1024 * 1024
+
+// Option configures a LocalRunner at construction time.
+type Option func(*LocalRunner)
+
+// WithMaxOutputBytes sets the default per-call MaxOutputBytes used when
+// ExecOptions.Resources.MaxOutputBytes is zero. Pass a non-positive value
+// to disable truncation (i.e. allow up to math.MaxInt64 bytes).
+func WithMaxOutputBytes(n int64) Option {
+	return func(r *LocalRunner) {
+		if n <= 0 {
+			r.defaultMaxOutput = math.MaxInt64
+		} else {
+			r.defaultMaxOutput = n
+		}
+	}
+}
+
+// LocalRunner executes commands directly on the host using os/exec. It is
+// the no-isolation backend; production deployments that need real
+// boundaries should swap it for a sandboxed Runner from
+// sdkx/sandbox/{nsjail,container,microvm} (planned).
+//
+// Policy support matrix:
+//
+//   - ExecOptions.WorkDir / Stdin / Timeout: fully supported.
+//   - ExecOptions.Env: fully supported (see EnvPolicy doc).
+//   - ExecOptions.Net.Mode != NetDefault: returns errdefs.NotAvailable.
+//   - ExecOptions.Resources.{CPUMillicores,MemoryBytes,DiskBytes} != 0:
+//     returns errdefs.NotAvailable.
+//   - ExecOptions.Resources.MaxOutputBytes: enforced; per-call value
+//     overrides the runner's WithMaxOutputBytes default.
+type LocalRunner struct {
+	rootDir          string
+	defaultMaxOutput int64
+}
+
+// NewLocalRunner constructs a LocalRunner rooted at rootDir. The root is
+// resolved via filepath.Abs + EvalSymlinks so a later symlink swap on the
+// root itself cannot be used to escape.
+func NewLocalRunner(rootDir string, opts ...Option) *LocalRunner {
+	real, err := filepath.Abs(rootDir)
+	if err == nil {
+		if resolved, evalErr := filepath.EvalSymlinks(real); evalErr == nil {
+			real = resolved
+		}
+	}
+	r := &LocalRunner{rootDir: real, defaultMaxOutput: defaultMaxOutputBytes}
+	for _, o := range opts {
+		o(r)
+	}
+	return r
+}
+
+// Exec runs cmd with args under opts. See LocalRunner doc for which
+// policy fields are honoured vs. rejected with errdefs.NotAvailable.
+func (r *LocalRunner) Exec(ctx context.Context, cmd string, args []string, opts ExecOptions) (*ExecResult, error) {
+	if opts.Net.Mode != NetDefault {
+		return nil, errdefs.NotAvailablef(
+			"sandbox: net policy not supported by local runner; use sdkx/sandbox/{nsjail,container,microvm}")
+	}
+	if opts.Resources.CPUMillicores != 0 || opts.Resources.MemoryBytes != 0 || opts.Resources.DiskBytes != 0 {
+		return nil, errdefs.NotAvailablef(
+			"sandbox: resource limits not supported by local runner")
+	}
+
+	if opts.Timeout > 0 {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, opts.Timeout)
+		defer cancel()
+	}
+
+	c := exec.CommandContext(ctx, cmd, args...)
+	c.Dir = r.rootDir
+	if opts.WorkDir != "" {
+		resolved, err := r.resolveWorkDir(opts.WorkDir)
+		if err != nil {
+			return nil, err
+		}
+		c.Dir = resolved
+	}
+
+	c.Env = buildEnv(opts.Env)
+
+	if opts.Stdin != nil {
+		c.Stdin = bytes.NewReader(opts.Stdin)
+	}
+
+	maxOut := opts.Resources.MaxOutputBytes
+	if maxOut <= 0 {
+		maxOut = r.defaultMaxOutput
+	}
+	var stdout, stderr limitedBuffer
+	stdout.max = maxOut
+	stderr.max = maxOut
+	c.Stdout = &stdout
+	c.Stderr = &stderr
+
+	err := c.Run()
+	result := &ExecResult{
+		Stdout: stdout.buf.String(),
+		Stderr: stderr.buf.String(),
+	}
+	if err != nil {
+		if ctx.Err() != nil {
+			return result, errdefs.FromContext(fmt.Errorf("sandbox: exec %s: %w", cmd, ctx.Err()))
+		}
+		if exitErr, ok := err.(*exec.ExitError); ok {
+			result.ExitCode = exitErr.ExitCode()
+			return result, nil
+		}
+		return result, fmt.Errorf("sandbox: exec %s: %w", cmd, err)
+	}
+	return result, nil
+}
+
+// buildEnv translates an EnvPolicy into a flat []string suitable for
+// exec.Cmd.Env. The empty result is returned as nil so os/exec falls
+// back to its "no env at all" code path (which is what we want when the
+// caller asked for an empty allow-list with no Inject).
+func buildEnv(p EnvPolicy) []string {
+	var env []string
+
+	if p.Allow == nil {
+		env = append(env, os.Environ()...)
+	} else if len(p.Allow) > 0 {
+		allow := make(map[string]bool, len(p.Allow))
+		for _, name := range p.Allow {
+			allow[name] = true
+		}
+		for _, kv := range os.Environ() {
+			idx := strings.IndexByte(kv, '=')
+			if idx <= 0 {
+				continue
+			}
+			if allow[kv[:idx]] {
+				env = append(env, kv)
+			}
+		}
+	}
+
+	if len(p.Inject) > 0 {
+		injected := make(map[string]bool, len(p.Inject))
+		for k := range p.Inject {
+			injected[k] = true
+		}
+		filtered := env[:0]
+		for _, kv := range env {
+			idx := strings.IndexByte(kv, '=')
+			if idx <= 0 {
+				filtered = append(filtered, kv)
+				continue
+			}
+			if !injected[kv[:idx]] {
+				filtered = append(filtered, kv)
+			}
+		}
+		env = filtered
+		for k, v := range p.Inject {
+			env = append(env, fmt.Sprintf("%s=%s", k, v))
+		}
+	}
+
+	if p.Allow != nil && len(p.Allow) == 0 && len(p.Inject) == 0 {
+		// Distinguish "inherit nothing" from "inherit everything": return
+		// an empty (non-nil) slice so exec.Cmd.Env is set to no entries
+		// instead of falling back to os.Environ().
+		return []string{}
+	}
+	return env
+}
+
+func (r *LocalRunner) resolveWorkDir(dir string) (string, error) {
+	abs := dir
+	if !filepath.IsAbs(dir) {
+		abs = filepath.Join(r.rootDir, dir)
+	}
+	abs = filepath.Clean(abs)
+
+	real, err := evalExistingPrefix(abs)
+	if err != nil {
+		return "", fmt.Errorf("sandbox: resolve workdir: %w", err)
+	}
+	if real != r.rootDir && !strings.HasPrefix(real, r.rootDir+string(filepath.Separator)) {
+		return "", fmt.Errorf("%w: workdir %q escapes root", ErrPathTraversal, dir)
+	}
+	return abs, nil
+}
+
+// evalExistingPrefix resolves symlinks for the longest existing ancestor
+// of path, then appends the remaining non-existent tail. This catches
+// symlink escapes even when the final target does not exist yet.
+func evalExistingPrefix(path string) (string, error) {
+	real, err := filepath.EvalSymlinks(path)
+	if err == nil {
+		return real, nil
+	}
+	if !os.IsNotExist(err) {
+		return "", err
+	}
+	parent := filepath.Dir(path)
+	if parent == path {
+		return path, nil
+	}
+	realParent, err := evalExistingPrefix(parent)
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(realParent, filepath.Base(path)), nil
+}
+
+// limitedBuffer is a bytes.Buffer that silently discards writes past max
+// bytes. We pretend the write succeeded (return len(p), nil) so the
+// child process is not killed by a "short write" — truncation is meant
+// to be invisible to the program under test.
+type limitedBuffer struct {
+	buf bytes.Buffer
+	max int64
+}
+
+func (b *limitedBuffer) Write(p []byte) (int, error) {
+	if b.max <= 0 || int64(b.buf.Len()) >= b.max {
+		return len(p), nil
+	}
+	space := b.max - int64(b.buf.Len())
+	if int64(len(p)) <= space {
+		return b.buf.Write(p)
+	}
+	if _, err := b.buf.Write(p[:space]); err != nil {
+		return 0, err
+	}
+	return len(p), nil
+}

--- a/sdk/sandbox/local_test.go
+++ b/sdk/sandbox/local_test.go
@@ -1,0 +1,313 @@
+package sandbox_test
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/GizClaw/flowcraft/sdk/errdefs"
+	"github.com/GizClaw/flowcraft/sdk/sandbox"
+)
+
+func TestLocalRunner_Exec_HappyPath(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("skipping on windows")
+	}
+	runner := sandbox.NewLocalRunner(t.TempDir())
+
+	result, err := runner.Exec(context.Background(), "echo", []string{"hello"}, sandbox.ExecOptions{})
+	if err != nil {
+		t.Fatalf("Exec: %v", err)
+	}
+	if result.ExitCode != 0 {
+		t.Fatalf("ExitCode = %d, want 0", result.ExitCode)
+	}
+	if !strings.Contains(result.Stdout, "hello") {
+		t.Fatalf("Stdout = %q, want substring 'hello'", result.Stdout)
+	}
+}
+
+func TestLocalRunner_Exec_NonZeroExitCode(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("skipping on windows")
+	}
+	runner := sandbox.NewLocalRunner(t.TempDir())
+
+	result, err := runner.Exec(context.Background(), "sh", []string{"-c", "exit 42"}, sandbox.ExecOptions{})
+	if err != nil {
+		t.Fatalf("non-zero exit should not return Go error, got: %v", err)
+	}
+	if result.ExitCode != 42 {
+		t.Fatalf("ExitCode = %d, want 42", result.ExitCode)
+	}
+}
+
+func TestLocalRunner_Exec_Timeout(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("skipping on windows")
+	}
+	runner := sandbox.NewLocalRunner(t.TempDir())
+
+	_, err := runner.Exec(context.Background(), "sleep", []string{"1"}, sandbox.ExecOptions{
+		Timeout: 10 * time.Millisecond,
+	})
+	if err == nil {
+		t.Fatal("expected timeout error")
+	}
+	if !errdefs.IsTimeout(err) {
+		t.Fatalf("expected errdefs.IsTimeout, got: %v", err)
+	}
+}
+
+func TestLocalRunner_Exec_WorkDirEscape(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("skipping on windows")
+	}
+	root := t.TempDir()
+	runner := sandbox.NewLocalRunner(root)
+
+	_, err := runner.Exec(context.Background(), "pwd", nil, sandbox.ExecOptions{
+		WorkDir: "/tmp",
+	})
+	if err == nil {
+		t.Fatal("absolute WorkDir outside root should be rejected")
+	}
+	if !errors.Is(err, sandbox.ErrPathTraversal) {
+		t.Fatalf("expected sandbox.ErrPathTraversal, got: %v", err)
+	}
+
+	_, err = runner.Exec(context.Background(), "pwd", nil, sandbox.ExecOptions{
+		WorkDir: "../../../tmp",
+	})
+	if err == nil {
+		t.Fatal("relative WorkDir escaping root should be rejected")
+	}
+	if !errors.Is(err, sandbox.ErrPathTraversal) {
+		t.Fatalf("expected sandbox.ErrPathTraversal, got: %v", err)
+	}
+}
+
+func TestLocalRunner_MaxOutputBytes_Truncates(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("skipping on windows")
+	}
+	runner := sandbox.NewLocalRunner(t.TempDir())
+
+	t.Run("per-call override", func(t *testing.T) {
+		result, err := runner.Exec(context.Background(), "sh", []string{"-c", "yes | head -c 500"}, sandbox.ExecOptions{
+			Resources: sandbox.ResourceLimits{MaxOutputBytes: 100},
+		})
+		if err != nil {
+			t.Fatalf("Exec: %v", err)
+		}
+		if len(result.Stdout) != 100 {
+			t.Fatalf("len(Stdout) = %d, want 100", len(result.Stdout))
+		}
+	})
+
+	t.Run("runner default", func(t *testing.T) {
+		r := sandbox.NewLocalRunner(t.TempDir(), sandbox.WithMaxOutputBytes(50))
+		result, err := r.Exec(context.Background(), "sh", []string{"-c", "yes | head -c 500"}, sandbox.ExecOptions{})
+		if err != nil {
+			t.Fatalf("Exec: %v", err)
+		}
+		if len(result.Stdout) != 50 {
+			t.Fatalf("len(Stdout) = %d, want 50", len(result.Stdout))
+		}
+	})
+
+	t.Run("per-call overrides default", func(t *testing.T) {
+		r := sandbox.NewLocalRunner(t.TempDir(), sandbox.WithMaxOutputBytes(50))
+		result, err := r.Exec(context.Background(), "sh", []string{"-c", "yes | head -c 500"}, sandbox.ExecOptions{
+			Resources: sandbox.ResourceLimits{MaxOutputBytes: 200},
+		})
+		if err != nil {
+			t.Fatalf("Exec: %v", err)
+		}
+		if len(result.Stdout) != 200 {
+			t.Fatalf("len(Stdout) = %d, want 200 (per-call override)", len(result.Stdout))
+		}
+	})
+}
+
+func TestLocalRunner_Env_NilAllow_InheritsAll(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("skipping on windows")
+	}
+	t.Setenv("SANDBOX_TEST_PARENT", "from-host")
+	runner := sandbox.NewLocalRunner(t.TempDir())
+
+	result, err := runner.Exec(context.Background(), "sh", []string{"-c", "echo $SANDBOX_TEST_PARENT"}, sandbox.ExecOptions{})
+	if err != nil {
+		t.Fatalf("Exec: %v", err)
+	}
+	if strings.TrimSpace(result.Stdout) != "from-host" {
+		t.Fatalf("nil Allow should inherit host env, got Stdout = %q", result.Stdout)
+	}
+}
+
+func TestLocalRunner_Env_EmptyAllow_InheritsNone(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("skipping on windows")
+	}
+	t.Setenv("SANDBOX_TEST_PARENT", "from-host")
+	runner := sandbox.NewLocalRunner(t.TempDir())
+
+	result, err := runner.Exec(context.Background(), "/bin/sh", []string{"-c", "echo \"<$SANDBOX_TEST_PARENT>\""}, sandbox.ExecOptions{
+		Env: sandbox.EnvPolicy{Allow: []string{}},
+	})
+	if err != nil {
+		t.Fatalf("Exec: %v", err)
+	}
+	if strings.TrimSpace(result.Stdout) != "<>" {
+		t.Fatalf("empty Allow should hide host env, got Stdout = %q", result.Stdout)
+	}
+}
+
+func TestLocalRunner_Env_Allow_Filters(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("skipping on windows")
+	}
+	t.Setenv("SANDBOX_KEEP", "yes")
+	t.Setenv("SANDBOX_DROP", "no")
+	runner := sandbox.NewLocalRunner(t.TempDir())
+
+	result, err := runner.Exec(context.Background(), "/bin/sh", []string{"-c", "echo \"keep=$SANDBOX_KEEP drop=$SANDBOX_DROP path_set=${PATH:+yes}\""}, sandbox.ExecOptions{
+		Env: sandbox.EnvPolicy{Allow: []string{"PATH", "SANDBOX_KEEP"}},
+	})
+	if err != nil {
+		t.Fatalf("Exec: %v", err)
+	}
+	out := strings.TrimSpace(result.Stdout)
+	if !strings.Contains(out, "keep=yes") {
+		t.Fatalf("SANDBOX_KEEP should be present, got: %q", out)
+	}
+	if !strings.Contains(out, "drop=") || strings.Contains(out, "drop=no") {
+		t.Fatalf("SANDBOX_DROP should be filtered, got: %q", out)
+	}
+	if !strings.Contains(out, "path_set=yes") {
+		t.Fatalf("PATH should be inherited via allow list, got: %q", out)
+	}
+}
+
+func TestLocalRunner_Env_Inject_OverridesHost(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("skipping on windows")
+	}
+	t.Setenv("SANDBOX_FOO", "from-host")
+	runner := sandbox.NewLocalRunner(t.TempDir())
+
+	result, err := runner.Exec(context.Background(), "/bin/sh", []string{"-c", "echo $SANDBOX_FOO"}, sandbox.ExecOptions{
+		Env: sandbox.EnvPolicy{Inject: map[string]string{"SANDBOX_FOO": "from-inject"}},
+	})
+	if err != nil {
+		t.Fatalf("Exec: %v", err)
+	}
+	if strings.TrimSpace(result.Stdout) != "from-inject" {
+		t.Fatalf("Inject should override host SANDBOX_FOO, got: %q", result.Stdout)
+	}
+}
+
+func TestLocalRunner_Net_NonDefault_NotAvailable(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("skipping on windows")
+	}
+	runner := sandbox.NewLocalRunner(t.TempDir())
+
+	_, err := runner.Exec(context.Background(), "echo", nil, sandbox.ExecOptions{
+		Net: sandbox.NetPolicy{Mode: sandbox.NetDenyAll},
+	})
+	if err == nil {
+		t.Fatal("expected NotAvailable error for NetDenyAll on LocalRunner")
+	}
+	if !errdefs.IsNotAvailable(err) {
+		t.Fatalf("expected errdefs.IsNotAvailable, got: %v", err)
+	}
+}
+
+func TestLocalRunner_Resources_NonZero_NotAvailable(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("skipping on windows")
+	}
+	runner := sandbox.NewLocalRunner(t.TempDir())
+
+	for name, opts := range map[string]sandbox.ExecOptions{
+		"cpu":  {Resources: sandbox.ResourceLimits{CPUMillicores: 100}},
+		"mem":  {Resources: sandbox.ResourceLimits{MemoryBytes: 1 << 20}},
+		"disk": {Resources: sandbox.ResourceLimits{DiskBytes: 1 << 20}},
+	} {
+		t.Run(name, func(t *testing.T) {
+			_, err := runner.Exec(context.Background(), "echo", nil, opts)
+			if err == nil {
+				t.Fatalf("%s limit should return NotAvailable on LocalRunner", name)
+			}
+			if !errdefs.IsNotAvailable(err) {
+				t.Fatalf("%s: expected errdefs.IsNotAvailable, got: %v", name, err)
+			}
+		})
+	}
+}
+
+func TestLocalRunner_WorkDirValidSubdir(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("skipping on windows")
+	}
+	root := t.TempDir()
+	sub := filepath.Join(root, "child")
+	if err := os.MkdirAll(sub, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	runner := sandbox.NewLocalRunner(root)
+
+	result, err := runner.Exec(context.Background(), "pwd", nil, sandbox.ExecOptions{WorkDir: "child"})
+	if err != nil {
+		t.Fatalf("valid subdir should be allowed: %v", err)
+	}
+	if !strings.Contains(result.Stdout, "child") {
+		t.Fatalf("pwd should show child, got: %q", result.Stdout)
+	}
+}
+
+func TestLocalRunner_WorkDirSymlinkEscape(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("skipping on windows")
+	}
+	root := t.TempDir()
+	outside := t.TempDir()
+	if err := os.Symlink(outside, filepath.Join(root, "link")); err != nil {
+		t.Fatal(err)
+	}
+	runner := sandbox.NewLocalRunner(root)
+
+	_, err := runner.Exec(context.Background(), "pwd", nil, sandbox.ExecOptions{
+		WorkDir: filepath.Join(root, "link"),
+	})
+	if err == nil {
+		t.Fatal("symlink escape should be rejected")
+	}
+	if !errors.Is(err, sandbox.ErrPathTraversal) {
+		t.Fatalf("expected sandbox.ErrPathTraversal, got: %v", err)
+	}
+}
+
+func TestLocalRunner_Stdin(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("skipping on windows")
+	}
+	runner := sandbox.NewLocalRunner(t.TempDir())
+
+	result, err := runner.Exec(context.Background(), "cat", nil, sandbox.ExecOptions{
+		Stdin: []byte("hello from stdin"),
+	})
+	if err != nil {
+		t.Fatalf("Exec: %v", err)
+	}
+	if result.Stdout != "hello from stdin" {
+		t.Fatalf("Stdout = %q", result.Stdout)
+	}
+}

--- a/sdk/sandbox/sandbox.go
+++ b/sdk/sandbox/sandbox.go
@@ -1,0 +1,124 @@
+package sandbox
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/GizClaw/flowcraft/sdk/errdefs"
+)
+
+// Runner executes a command under the sandbox's policy. Implementations
+// MUST honour ExecOptions.Timeout, surface non-zero exits as ExitCode on
+// ExecResult (returning err == nil for that case), and reject any policy
+// they cannot enforce with an errdefs.NotAvailable error rather than
+// silently downgrading the request.
+type Runner interface {
+	Exec(ctx context.Context, cmd string, args []string, opts ExecOptions) (*ExecResult, error)
+}
+
+// ExecOptions configures one Runner.Exec call.
+//
+// Field semantics:
+//
+//   - WorkDir: directory the command runs in. Relative paths are resolved
+//     against the runner's root (e.g. LocalRunner.rootDir); absolute paths
+//     must stay inside the root or the call is rejected with
+//     ErrPathTraversal. Empty means "use the runner's root".
+//   - Stdin: bytes piped to the command's stdin. nil means no stdin.
+//   - Timeout: per-call deadline. Zero means "no sandbox-imposed timeout"
+//     (the caller's ctx still applies).
+//   - Env: see EnvPolicy. Replaces the historical "inherit everything"
+//     behaviour while staying back-compat when EnvPolicy.Allow is nil.
+//   - Net: see NetPolicy. LocalRunner only accepts NetDefault.
+//   - Resources: see ResourceLimits. LocalRunner only enforces
+//     MaxOutputBytes.
+type ExecOptions struct {
+	WorkDir   string
+	Stdin     []byte
+	Timeout   time.Duration
+	Env       EnvPolicy
+	Net       NetPolicy
+	Resources ResourceLimits
+}
+
+// ExecResult captures the outcome of a Runner.Exec call. ExitCode is the
+// command's exit status (0 on success, non-zero on failure that the OS
+// surfaced via *exec.ExitError or equivalent). Stdout / Stderr are the
+// captured output, possibly truncated to Resources.MaxOutputBytes.
+type ExecResult struct {
+	ExitCode int    `json:"exit_code"`
+	Stdout   string `json:"stdout"`
+	Stderr   string `json:"stderr"`
+}
+
+// EnvPolicy controls which host environment variables a child process
+// can observe, and lets the caller inject extra variables on top.
+//
+//   - Allow == nil: inherit the full host environment (back-compat with
+//     the pre-sandbox behaviour of LocalCommandRunner).
+//   - Allow == []string{} (non-nil empty slice): inherit nothing; the
+//     child only sees the names listed in Inject.
+//   - Allow == []string{"PATH", "HOME", ...}: only those names are
+//     forwarded from the host; everything else is dropped.
+//
+// Inject is applied on top of the allow-list. Names in Inject win over
+// host values of the same name.
+type EnvPolicy struct {
+	Allow  []string
+	Inject map[string]string
+}
+
+// NetMode names the network access posture the sandbox should enforce.
+type NetMode int
+
+const (
+	// NetDefault leaves networking to the host. LocalRunner accepts this
+	// mode; sandboxed backends interpret it as "no policy applied".
+	NetDefault NetMode = iota
+	// NetDenyAll forbids any outbound connection. Requires a sandboxing
+	// backend (nsjail / container / microvm) to enforce.
+	NetDenyAll
+	// NetAllowList permits only destinations listed in AllowHosts.
+	// Requires a sandboxing backend.
+	NetAllowList
+	// NetProxy routes all traffic through Proxy. Requires a sandboxing
+	// backend.
+	NetProxy
+)
+
+// NetPolicy controls outbound networking for the child process.
+// LocalRunner only honours NetDefault; any other mode is rejected with
+// errdefs.NotAvailable until a sandboxed backend (sdkx/sandbox/{nsjail,
+// container,microvm}) is wired up.
+type NetPolicy struct {
+	Mode       NetMode
+	AllowHosts []string
+	Proxy      string
+}
+
+// ResourceLimits caps how much the child process may consume.
+//
+// CPUMillicores / MemoryBytes / DiskBytes are *hard* limits that need
+// kernel-level enforcement (cgroups, rlimits, VM caps). LocalRunner
+// returns errdefs.NotAvailable when any of them is non-zero.
+//
+// MaxOutputBytes caps the bytes captured into ExecResult.Stdout and
+// ExecResult.Stderr independently; excess output is dropped silently
+// (the child process is not killed). LocalRunner enforces this directly.
+// When zero, the runner's default applies (see LocalRunner's
+// WithMaxOutputBytes option).
+type ResourceLimits struct {
+	CPUMillicores  int
+	MemoryBytes    int64
+	DiskBytes      int64
+	MaxOutputBytes int64
+}
+
+// ErrPathTraversal is returned when a WorkDir resolves outside the
+// runner's root, including via symlinks. sandbox owns its own
+// ErrPathTraversal so this package does not depend on sdk/workspace
+// (which would create an import cycle through the deprecation aliases).
+// sdk/workspace keeps a separate ErrPathTraversal for its filesystem
+// API.
+var ErrPathTraversal = errdefs.Forbidden(errors.New("sandbox: path traversal denied"))

--- a/sdk/sandbox/sandbox_test.go
+++ b/sdk/sandbox/sandbox_test.go
@@ -1,0 +1,31 @@
+package sandbox_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/GizClaw/flowcraft/sdk/errdefs"
+	"github.com/GizClaw/flowcraft/sdk/sandbox"
+)
+
+// TestErrPathTraversal_IsForbidden ensures the package-level error is
+// classified as Forbidden by errdefs so HTTP / RPC layers map it to 403
+// without runtime-specific shims. This is the contract the deprecation
+// shim in sdk/workspace/command.go relies on.
+func TestErrPathTraversal_IsForbidden(t *testing.T) {
+	if !errdefs.IsForbidden(sandbox.ErrPathTraversal) {
+		t.Fatal("sandbox.ErrPathTraversal should be classified as Forbidden")
+	}
+}
+
+// TestErrPathTraversal_Independence guards against accidentally aliasing
+// sandbox.ErrPathTraversal to workspace.ErrPathTraversal. sandbox MUST
+// not import workspace (the dependency runs the other way through the
+// deprecation shim), so the two sentinels are intentionally separate
+// values even if they convey the same concept.
+func TestErrPathTraversal_Independence(t *testing.T) {
+	wrapped := errors.New("wrapped")
+	if errors.Is(wrapped, sandbox.ErrPathTraversal) {
+		t.Fatal("unrelated error should not be sandbox.ErrPathTraversal")
+	}
+}

--- a/sdk/script/bindings/bridge_shell.go
+++ b/sdk/script/bindings/bridge_shell.go
@@ -5,7 +5,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/GizClaw/flowcraft/sdk/workspace"
+	"github.com/GizClaw/flowcraft/sdk/sandbox"
 )
 
 // ShellOption configures a shell bridge.
@@ -27,7 +27,7 @@ func WithAllowedCommands(cmds ...string) ShellOption {
 }
 
 // NewShellBridge exposes shell execution as global "shell".
-func NewShellBridge(runner workspace.CommandRunner, opts ...ShellOption) BindingFunc {
+func NewShellBridge(runner sandbox.Runner, opts ...ShellOption) BindingFunc {
 	cfg := &shellConfig{}
 	for _, opt := range opts {
 		opt(cfg)
@@ -49,7 +49,7 @@ func NewShellBridge(runner workspace.CommandRunner, opts ...ShellOption) Binding
 				}
 				args := parts[1:]
 				args = append(args, argsRaw...)
-				result, err := runner.Exec(ctx, cmdName, args, workspace.ExecOptions{})
+				result, err := runner.Exec(ctx, cmdName, args, sandbox.ExecOptions{})
 				if err != nil {
 					return map[string]any{"exit_code": -1, "stdout": "", "stderr": err.Error()}, nil
 				}

--- a/sdk/script/bindings/bridge_shell_test.go
+++ b/sdk/script/bindings/bridge_shell_test.go
@@ -5,12 +5,12 @@ import (
 	"testing"
 
 	"github.com/GizClaw/flowcraft/sdk/engine"
+	"github.com/GizClaw/flowcraft/sdk/sandbox"
 	"github.com/GizClaw/flowcraft/sdk/script/bindings"
 	"github.com/GizClaw/flowcraft/sdk/script/jsrt"
-	"github.com/GizClaw/flowcraft/sdk/workspace"
 )
 
-// fakeCommandRunner is a CommandRunner stub that returns canned output
+// fakeCommandRunner is a sandbox.Runner stub that returns canned output
 // without actually shelling out — keeps these tests hermetic and fast.
 type fakeCommandRunner struct {
 	stdout   string
@@ -18,15 +18,15 @@ type fakeCommandRunner struct {
 	exitCode int
 }
 
-func (f *fakeCommandRunner) Exec(_ context.Context, _ string, _ []string, _ workspace.ExecOptions) (*workspace.ExecResult, error) {
-	return &workspace.ExecResult{Stdout: f.stdout, Stderr: f.stderr, ExitCode: f.exitCode}, nil
+func (f *fakeCommandRunner) Exec(_ context.Context, _ string, _ []string, _ sandbox.ExecOptions) (*sandbox.ExecResult, error) {
+	return &sandbox.ExecResult{Stdout: f.stdout, Stderr: f.stderr, ExitCode: f.exitCode}, nil
 }
 
 // errorCommandRunner always fails — used to verify the bridge's error
 // translation branch (Go err → exit_code -1 + stderr).
 type errorCommandRunner struct{ err error }
 
-func (e *errorCommandRunner) Exec(_ context.Context, _ string, _ []string, _ workspace.ExecOptions) (*workspace.ExecResult, error) {
+func (e *errorCommandRunner) Exec(_ context.Context, _ string, _ []string, _ sandbox.ExecOptions) (*sandbox.ExecResult, error) {
 	return nil, e.err
 }
 

--- a/sdk/workspace/command.go
+++ b/sdk/workspace/command.go
@@ -1,186 +1,98 @@
 package workspace
 
 import (
-	"bytes"
 	"context"
-	"fmt"
-	"math"
-	"os"
-	"os/exec"
-	"path/filepath"
-	"strings"
-	"time"
 
-	"github.com/GizClaw/flowcraft/sdk/errdefs"
+	"github.com/GizClaw/flowcraft/sdk/sandbox"
 )
 
-const defaultMaxCommandOutput int64 = 10 * 1024 * 1024
+// This file is a deprecation shim. The execution-boundary types
+// (CommandRunner, LocalCommandRunner, ScopedCommandRunner,
+// NoopCommandRunner, ExecOptions, ExecResult, CommandOption,
+// WithMaxOutput, NewLocalCommandRunner, NewScopedCommandRunner) all
+// moved to sdk/sandbox in v0.2.0. The aliases and wrappers below keep
+// existing imports compiling without behaviour change.
+// Will be removed in v0.5.0 — same window as catalog.Deps.AgentTools
+// and runner.WithActorKey.
 
-type CommandOption func(*LocalCommandRunner)
+// CommandRunner is an alias for sandbox.Runner.
+//
+// Deprecated: moved to sdk/sandbox.Runner.
+// Will be removed in v0.5.0 (same window as catalog.Deps.AgentTools and runner.WithActorKey).
+type CommandRunner = sandbox.Runner
 
+// ExecOptions is an alias for sandbox.ExecOptions. The new type adds
+// Env / Net / Resources policy fields; callers that used the legacy
+// Env map[string]string knob should move to ExecOptions.Env.Inject.
+//
+// Deprecated: moved to sdk/sandbox.ExecOptions.
+// Will be removed in v0.5.0 (same window as catalog.Deps.AgentTools and runner.WithActorKey).
+type ExecOptions = sandbox.ExecOptions
+
+// ExecResult is an alias for sandbox.ExecResult.
+//
+// Deprecated: moved to sdk/sandbox.ExecResult.
+// Will be removed in v0.5.0 (same window as catalog.Deps.AgentTools and runner.WithActorKey).
+type ExecResult = sandbox.ExecResult
+
+// CommandOption is an alias for sandbox.Option.
+//
+// Deprecated: moved to sdk/sandbox.Option.
+// Will be removed in v0.5.0 (same window as catalog.Deps.AgentTools and runner.WithActorKey).
+type CommandOption = sandbox.Option
+
+// LocalCommandRunner is an alias for sandbox.LocalRunner.
+//
+// Deprecated: moved to sdk/sandbox.LocalRunner.
+// Will be removed in v0.5.0 (same window as catalog.Deps.AgentTools and runner.WithActorKey).
+type LocalCommandRunner = sandbox.LocalRunner
+
+// NoopCommandRunner is an alias for sandbox.NoopRunner.
+//
+// Deprecated: moved to sdk/sandbox.NoopRunner.
+// Will be removed in v0.5.0 (same window as catalog.Deps.AgentTools and runner.WithActorKey).
+type NoopCommandRunner = sandbox.NoopRunner
+
+// WithMaxOutput is a thin wrapper around sandbox.WithMaxOutputBytes.
+//
+// Deprecated: moved to sdk/sandbox.WithMaxOutputBytes.
+// Will be removed in v0.5.0 (same window as catalog.Deps.AgentTools and runner.WithActorKey).
 func WithMaxOutput(n int64) CommandOption {
-	return func(r *LocalCommandRunner) {
-		if n <= 0 {
-			r.maxOutput = math.MaxInt64
-		} else {
-			r.maxOutput = n
-		}
-	}
+	return sandbox.WithMaxOutputBytes(n)
 }
 
-type limitedBuffer struct {
-	buf bytes.Buffer
-	max int64
-}
-
-func (b *limitedBuffer) Write(p []byte) (int, error) {
-	if b.max <= 0 || int64(b.buf.Len()) >= b.max {
-		return len(p), nil
-	}
-	space := b.max - int64(b.buf.Len())
-	if int64(len(p)) <= space {
-		return b.buf.Write(p)
-	}
-	_, err := b.buf.Write(p[:space])
-	if err != nil {
-		return 0, err
-	}
-	return len(p), nil
-}
-
-// CommandRunner executes shell commands within or relative to a workspace.
-type CommandRunner interface {
-	Exec(ctx context.Context, cmd string, args []string, opts ExecOptions) (*ExecResult, error)
-}
-
-// ExecOptions configures a command execution.
-type ExecOptions struct {
-	WorkDir string
-	Env     map[string]string
-	Stdin   []byte
-	Timeout time.Duration
-}
-
-// ExecResult captures command output.
-type ExecResult struct {
-	ExitCode int    `json:"exit_code"`
-	Stdout   string `json:"stdout"`
-	Stderr   string `json:"stderr"`
-}
-
-// LocalCommandRunner executes commands on the local OS.
-type LocalCommandRunner struct {
-	rootDir   string
-	maxOutput int64
-}
-
+// NewLocalCommandRunner is a thin wrapper around sandbox.NewLocalRunner.
+//
+// Deprecated: moved to sdk/sandbox.NewLocalRunner.
+// Will be removed in v0.5.0 (same window as catalog.Deps.AgentTools and runner.WithActorKey).
 func NewLocalCommandRunner(rootDir string, opts ...CommandOption) *LocalCommandRunner {
-	real, err := filepath.Abs(rootDir)
-	if err == nil {
-		if resolved, evalErr := filepath.EvalSymlinks(real); evalErr == nil {
-			real = resolved
-		}
-	}
-	r := &LocalCommandRunner{rootDir: real, maxOutput: defaultMaxCommandOutput}
-	for _, o := range opts {
-		o(r)
-	}
-	return r
+	return sandbox.NewLocalRunner(rootDir, opts...)
 }
 
-func (r *LocalCommandRunner) Exec(ctx context.Context, cmd string, args []string, opts ExecOptions) (*ExecResult, error) {
-	if opts.Timeout > 0 {
-		var cancel context.CancelFunc
-		ctx, cancel = context.WithTimeout(ctx, opts.Timeout)
-		defer cancel()
-	}
-
-	c := exec.CommandContext(ctx, cmd, args...)
-	c.Dir = r.rootDir
-	if opts.WorkDir != "" {
-		resolved, err := r.resolveWorkDir(opts.WorkDir)
-		if err != nil {
-			return nil, err
-		}
-		c.Dir = resolved
-	}
-	if len(opts.Env) > 0 {
-		c.Env = os.Environ()
-		for k, v := range opts.Env {
-			c.Env = append(c.Env, fmt.Sprintf("%s=%s", k, v))
-		}
-	}
-	if opts.Stdin != nil {
-		c.Stdin = bytes.NewReader(opts.Stdin)
-	}
-
-	var stdout, stderr limitedBuffer
-	stdout.max = r.maxOutput
-	stderr.max = r.maxOutput
-	c.Stdout = &stdout
-	c.Stderr = &stderr
-
-	err := c.Run()
-	result := &ExecResult{
-		Stdout: stdout.buf.String(),
-		Stderr: stderr.buf.String(),
-	}
-	if err != nil {
-		if ctx.Err() != nil {
-			return result, errdefs.FromContext(fmt.Errorf("workspace: exec %s: %w", cmd, ctx.Err()))
-		}
-		if exitErr, ok := err.(*exec.ExitError); ok {
-			result.ExitCode = exitErr.ExitCode()
-			return result, nil
-		}
-		return result, fmt.Errorf("workspace: exec %s: %w", cmd, err)
-	}
-	return result, nil
-}
-
-func (r *LocalCommandRunner) resolveWorkDir(dir string) (string, error) {
-	abs := dir
-	if !filepath.IsAbs(dir) {
-		abs = filepath.Join(r.rootDir, dir)
-	}
-	abs = filepath.Clean(abs)
-
-	real, err := evalExistingPrefix(abs)
-	if err != nil {
-		return "", fmt.Errorf("workspace: resolve workdir: %w", err)
-	}
-	if real != r.rootDir && !strings.HasPrefix(real, r.rootDir+string(filepath.Separator)) {
-		return "", fmt.Errorf("%w: workdir %q escapes root", ErrPathTraversal, dir)
-	}
-	return abs, nil
-}
-
-// NoopCommandRunner always returns an empty successful result.
-type NoopCommandRunner struct{}
-
-func (NoopCommandRunner) Exec(_ context.Context, _ string, _ []string, _ ExecOptions) (*ExecResult, error) {
-	return &ExecResult{}, nil
-}
-
-// ScopedCommandRunner wraps a CommandRunner with a command whitelist.
-// Only commands whose base name appears in the whitelist are permitted.
+// ScopedCommandRunner is the legacy struct-shaped whitelist runner. It
+// is kept as a thin wrapper around sandbox.AllowCommands so existing
+// callers continue to compile.
+//
+// Deprecated: replaced by the functional sandbox.AllowCommands(inner, allowed) decorator.
+// Will be removed in v0.5.0 (same window as catalog.Deps.AgentTools and runner.WithActorKey).
 type ScopedCommandRunner struct {
-	inner     CommandRunner
-	whitelist map[string]bool
+	inner sandbox.Runner
 }
 
-// NewScopedCommandRunner creates a runner that only allows listed commands.
-func NewScopedCommandRunner(inner CommandRunner, allowed []string) *ScopedCommandRunner {
-	wl := make(map[string]bool, len(allowed))
-	for _, cmd := range allowed {
-		wl[cmd] = true
-	}
-	return &ScopedCommandRunner{inner: inner, whitelist: wl}
-}
-
+// Exec implements sandbox.Runner via the underlying AllowCommands
+// decorator built in NewScopedCommandRunner.
+//
+// Deprecated: see ScopedCommandRunner.
+// Will be removed in v0.5.0 (same window as catalog.Deps.AgentTools and runner.WithActorKey).
 func (r *ScopedCommandRunner) Exec(ctx context.Context, cmd string, args []string, opts ExecOptions) (*ExecResult, error) {
-	if !r.whitelist[cmd] {
-		return nil, fmt.Errorf("workspace: command %q is not in the whitelist", cmd)
-	}
 	return r.inner.Exec(ctx, cmd, args, opts)
+}
+
+// NewScopedCommandRunner wraps inner with the given whitelist. Builds a
+// sandbox.AllowCommands decorator under the hood.
+//
+// Deprecated: use sandbox.AllowCommands directly.
+// Will be removed in v0.5.0 (same window as catalog.Deps.AgentTools and runner.WithActorKey).
+func NewScopedCommandRunner(inner CommandRunner, allowed []string) *ScopedCommandRunner {
+	return &ScopedCommandRunner{inner: sandbox.AllowCommands(inner, allowed)}
 }

--- a/sdk/workspace/command_test.go
+++ b/sdk/workspace/command_test.go
@@ -1,263 +1,54 @@
-package workspace
+package workspace_test
 
 import (
 	"context"
-	"os"
-	"path/filepath"
 	"runtime"
 	"strings"
 	"testing"
-	"time"
+
+	"github.com/GizClaw/flowcraft/sdk/sandbox"
+	"github.com/GizClaw/flowcraft/sdk/workspace"
 )
 
-func TestLocalCommandRunner_BasicExec(t *testing.T) {
+// TestCommandRunner_DeprecationAliases is a sanity check that the
+// workspace shim (CommandRunner / LocalCommandRunner / NoopCommandRunner
+// / ScopedCommandRunner / WithMaxOutput / NewLocalCommandRunner /
+// NewScopedCommandRunner) still lets callers Exec successfully through
+// the alias chain to sdk/sandbox. Substantive coverage lives in the
+// sdk/sandbox package tests; this only proves the alias chain compiles
+// and dispatches.
+func TestCommandRunner_DeprecationAliases(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("skipping on windows")
 	}
-	dir := t.TempDir()
-	runner := NewLocalCommandRunner(dir)
 
-	result, err := runner.Exec(context.Background(), "echo", []string{"hello"}, ExecOptions{})
+	var runner workspace.CommandRunner = workspace.NewLocalCommandRunner(t.TempDir(), workspace.WithMaxOutput(1024))
+
+	result, err := runner.Exec(context.Background(), "echo", []string{"hello"}, workspace.ExecOptions{})
 	if err != nil {
-		t.Fatalf("Exec: %v", err)
+		t.Fatalf("alias chain Exec failed: %v", err)
 	}
-	if strings.TrimSpace(result.Stdout) != "hello" {
-		t.Fatalf("Stdout = %q", result.Stdout)
-	}
-	if result.ExitCode != 0 {
-		t.Fatalf("ExitCode = %d", result.ExitCode)
-	}
-}
-
-func TestLocalCommandRunner_NonZeroExit(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("skipping on windows")
-	}
-	dir := t.TempDir()
-	runner := NewLocalCommandRunner(dir)
-
-	result, err := runner.Exec(context.Background(), "sh", []string{"-c", "exit 42"}, ExecOptions{})
-	if err != nil {
-		t.Fatalf("non-zero exit should not return error: %v", err)
-	}
-	if result.ExitCode != 42 {
-		t.Fatalf("ExitCode = %d, want 42", result.ExitCode)
-	}
-}
-
-func TestLocalCommandRunner_EnvInheritance(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("skipping on windows")
-	}
-	dir := t.TempDir()
-	runner := NewLocalCommandRunner(dir)
-
-	result, err := runner.Exec(context.Background(), "sh", []string{"-c", "echo $HOME"}, ExecOptions{
-		Env: map[string]string{"CUSTOM_VAR": "custom_value"},
-	})
-	if err != nil {
-		t.Fatalf("Exec: %v", err)
-	}
-	if strings.TrimSpace(result.Stdout) == "" {
-		t.Fatal("$HOME should be inherited from parent environment")
+	if !strings.Contains(result.Stdout, "hello") {
+		t.Fatalf("Stdout = %q, want substring 'hello'", result.Stdout)
 	}
 
-	result, err = runner.Exec(context.Background(), "sh", []string{"-c", "echo $CUSTOM_VAR"}, ExecOptions{
-		Env: map[string]string{"CUSTOM_VAR": "hello_world"},
-	})
-	if err != nil {
-		t.Fatalf("Exec: %v", err)
-	}
-	if strings.TrimSpace(result.Stdout) != "hello_world" {
-		t.Fatalf("CUSTOM_VAR = %q, want 'hello_world'", strings.TrimSpace(result.Stdout))
-	}
-}
-
-func TestLocalCommandRunner_Timeout(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("skipping on windows")
-	}
-	dir := t.TempDir()
-	runner := NewLocalCommandRunner(dir)
-
-	_, err := runner.Exec(context.Background(), "sleep", []string{"10"}, ExecOptions{
-		Timeout: 50 * time.Millisecond,
-	})
-	if err == nil {
-		t.Fatal("expected error when command is killed by timeout")
-	}
-}
-
-func TestLocalCommandRunner_Stdin(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("skipping on windows")
-	}
-	dir := t.TempDir()
-	runner := NewLocalCommandRunner(dir)
-
-	result, err := runner.Exec(context.Background(), "cat", nil, ExecOptions{
-		Stdin: []byte("hello from stdin"),
-	})
-	if err != nil {
-		t.Fatalf("Exec: %v", err)
-	}
-	if result.Stdout != "hello from stdin" {
-		t.Fatalf("Stdout = %q", result.Stdout)
-	}
-}
-
-func TestLocalCommandRunner_MaxOutput(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("skipping on windows")
-	}
-	dir := t.TempDir()
-	runner := NewLocalCommandRunner(dir, WithMaxOutput(100))
-
-	result, err := runner.Exec(context.Background(), "sh", []string{"-c", "yes | head -c 500"}, ExecOptions{})
-	if err != nil {
-		t.Fatalf("Exec: %v", err)
-	}
-	if len(result.Stdout) != 100 {
-		t.Fatalf("len(Stdout) = %d, want 100", len(result.Stdout))
-	}
-}
-
-func TestNoopCommandRunner(t *testing.T) {
-	runner := NoopCommandRunner{}
-	result, err := runner.Exec(context.Background(), "anything", nil, ExecOptions{})
-	if err != nil {
-		t.Fatalf("Exec: %v", err)
-	}
-	if result.ExitCode != 0 {
-		t.Fatalf("ExitCode = %d", result.ExitCode)
-	}
-}
-
-func TestLocalCommandRunner_WorkDirAbsoluteEscape(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("skipping on windows")
-	}
-	dir := t.TempDir()
-	runner := NewLocalCommandRunner(dir)
-
-	_, err := runner.Exec(context.Background(), "pwd", nil, ExecOptions{
-		WorkDir: "/tmp",
-	})
-	if err == nil {
-		t.Fatal("absolute WorkDir outside rootDir should be rejected")
-	}
-	if !strings.Contains(err.Error(), "escapes root") {
-		t.Fatalf("error should mention escape: %v", err)
-	}
-}
-
-func TestLocalCommandRunner_WorkDirRelativeEscape(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("skipping on windows")
-	}
-	dir := t.TempDir()
-	runner := NewLocalCommandRunner(dir)
-
-	_, err := runner.Exec(context.Background(), "pwd", nil, ExecOptions{
-		WorkDir: "../../../tmp",
-	})
-	if err == nil {
-		t.Fatal("relative WorkDir escaping rootDir should be rejected")
-	}
-}
-
-func TestLocalCommandRunner_WorkDirSymlinkEscape(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("skipping on windows")
-	}
-	root := t.TempDir()
-	outside := t.TempDir()
-	if err := os.Symlink(outside, filepath.Join(root, "link")); err != nil {
-		t.Fatal(err)
+	// Noop alias still satisfies the interface and returns empty result.
+	var noop workspace.CommandRunner = workspace.NoopCommandRunner{}
+	if res, err := noop.Exec(context.Background(), "anything", nil, workspace.ExecOptions{}); err != nil || res.ExitCode != 0 {
+		t.Fatalf("NoopCommandRunner alias broken: res=%+v err=%v", res, err)
 	}
 
-	runner := NewLocalCommandRunner(root)
-	_, err := runner.Exec(context.Background(), "pwd", nil, ExecOptions{
-		WorkDir: filepath.Join(root, "link"),
-	})
-	if err == nil {
-		t.Fatal("symlink WorkDir escaping rootDir should be rejected")
+	// Scoped alias wraps sandbox.AllowCommands and rejects unknown commands.
+	scoped := workspace.NewScopedCommandRunner(workspace.NoopCommandRunner{}, []string{"echo"})
+	if _, err := scoped.Exec(context.Background(), "rm", nil, workspace.ExecOptions{}); err == nil {
+		t.Fatal("scoped alias should block command outside whitelist")
 	}
-}
-
-func TestLocalCommandRunner_WorkDirValidSubdir(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("skipping on windows")
-	}
-	root := t.TempDir()
-	sub := filepath.Join(root, "subdir")
-	if err := os.MkdirAll(sub, 0o755); err != nil {
-		t.Fatal(err)
+	if _, err := scoped.Exec(context.Background(), "echo", nil, workspace.ExecOptions{}); err != nil {
+		t.Fatalf("scoped alias should allow whitelisted command: %v", err)
 	}
 
-	runner := NewLocalCommandRunner(root)
-	result, err := runner.Exec(context.Background(), "pwd", nil, ExecOptions{
-		WorkDir: sub,
-	})
-	if err != nil {
-		t.Fatalf("valid subdir should be allowed: %v", err)
-	}
-	if !strings.Contains(result.Stdout, "subdir") {
-		t.Fatalf("expected pwd to show subdir, got %q", result.Stdout)
-	}
-}
-
-func TestLocalCommandRunner_WorkDirRelativeValid(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("skipping on windows")
-	}
-	root := t.TempDir()
-	sub := filepath.Join(root, "child")
-	if err := os.MkdirAll(sub, 0o755); err != nil {
-		t.Fatal(err)
-	}
-
-	runner := NewLocalCommandRunner(root)
-	result, err := runner.Exec(context.Background(), "pwd", nil, ExecOptions{
-		WorkDir: "child",
-	})
-	if err != nil {
-		t.Fatalf("relative valid subdir should be allowed: %v", err)
-	}
-	if !strings.Contains(result.Stdout, "child") {
-		t.Fatalf("expected pwd to show child, got %q", result.Stdout)
-	}
-}
-
-func TestScopedCommandRunner_AllowedCommand(t *testing.T) {
-	inner := NoopCommandRunner{}
-	runner := NewScopedCommandRunner(inner, []string{"ls", "cat", "echo"})
-
-	_, err := runner.Exec(context.Background(), "ls", nil, ExecOptions{})
-	if err != nil {
-		t.Fatalf("allowed command should succeed: %v", err)
-	}
-}
-
-func TestScopedCommandRunner_BlockedCommand(t *testing.T) {
-	inner := NoopCommandRunner{}
-	runner := NewScopedCommandRunner(inner, []string{"ls", "cat"})
-
-	_, err := runner.Exec(context.Background(), "rm", []string{"-rf", "/"}, ExecOptions{})
-	if err == nil {
-		t.Fatal("blocked command should fail")
-	}
-	if !strings.Contains(err.Error(), "whitelist") {
-		t.Fatalf("error should mention whitelist: %v", err)
-	}
-}
-
-func TestScopedCommandRunner_EmptyWhitelist(t *testing.T) {
-	inner := NoopCommandRunner{}
-	runner := NewScopedCommandRunner(inner, nil)
-
-	_, err := runner.Exec(context.Background(), "ls", nil, ExecOptions{})
-	if err == nil {
-		t.Fatal("empty whitelist should block all commands")
-	}
+	// ExecOptions and ExecResult are aliases to sandbox types — verify
+	// they're interchangeable at the type level.
+	var _ sandbox.ExecOptions = workspace.ExecOptions{}
+	var _ sandbox.ExecResult = workspace.ExecResult{}
 }

--- a/sdk/workspace/workspace.go
+++ b/sdk/workspace/workspace.go
@@ -1,6 +1,7 @@
-// Package workspace provides a file-system sandbox abstraction.
-// Knowledge, Skills, and Memory subsystems share a single Workspace
-// to manage persistent state as a unified file tree.
+// Package workspace provides a persistent filesystem abstraction for
+// agent state. Knowledge, Skills, and Memory subsystems share a single
+// Workspace. Execution-boundary concerns (command runners, network
+// policy, resource limits) live in sibling package sdk/sandbox.
 package workspace
 
 import (


### PR DESCRIPTION
## Summary

First slice of roadmap §2 v0.2.0 P0 for `sdk/sandbox`: lift the "execution boundary" out of `sdk/workspace` into its own subpackage so the follow-up work (`sdk/tool/builtin/exec`, `vesseld kind: Sandbox`, `sdkx/sandbox/{nsjail,container,microvm}`) has a stable home.

- **New `sdk/sandbox` package.** `Runner` interface; `ExecOptions` adds three policy groups — `Env` (allow-list + Inject), `Net` (Default / DenyAll / AllowList / Proxy), `Resources` (CPU / Mem / Disk / MaxOutputBytes). `LocalRunner` honours WorkDir / Stdin / Timeout / Env / MaxOutputBytes; non-default `Net` modes and the CPU / Mem / Disk hard limits return `errdefs.NotAvailable` until the `sdkx/sandbox/*` backends land — no silent downgrade. `AllowCommands` is the functional replacement for the legacy `ScopedCommandRunner`; `NoopRunner` covers test wiring.
- **`sdk/workspace` narrowed to "persistent filesystem abstraction".** `command.go` is now a deprecation shim: 11 types / constructors stay as type aliases or thin wrappers, each carrying a `// Deprecated:` godoc and a **"will be removed in v0.5.0"** marker (same window as `catalog.Deps.AgentTools` and `runner.WithActorKey`). Package doc updated to match the narrowed scope.
- **Three in-tree call sites migrated**: `sdk/script/bindings/bridge_shell.go`, `sdk/script/bindings/bridge_shell_test.go`, `sdk/graph/node/scriptnode/register.go`. `scriptnode.Deps.CommandRunner` keeps its field name (type is now `sandbox.Runner`) so external wiring does not have to chase the rename.
- **No behaviour change for existing callers.** A nil `EnvPolicy.Allow` still inherits the host env (back-compat with the old `LocalCommandRunner`). Policies the local runner cannot enforce are rejected explicitly rather than ignored.

## Test plan

- [x] `go test ./sdk/sandbox/... ./sdk/workspace/... ./sdk/script/... ./sdk/graph/...` — all green
- [x] `go vet ./sdk/sandbox/... ./sdk/workspace/...` — clean
- [x] Downstream modules `sdkx`, `vessel`, `cmd/vesseld` all `go build ./...` cleanly — no external regression
- [x] `sdk/workspace/command.go` carries "Will be removed in v0.5.0" 12 times, covering every exported symbol in the shim
- [x] New tests cover: `EnvPolicy` nil / empty / allow-list / Inject branches; non-`NetDefault` modes and CPU/Mem/Disk limits all return `errdefs.IsNotAvailable`; absolute / relative / symlink WorkDir escapes all surface as `sandbox.ErrPathTraversal`; `MaxOutputBytes` per-call / runner-default / per-call-overrides-default precedence
- [ ] (follow-up PRs) wire `sdk/tool/builtin/exec` (deny-by-default), `vesseld kind: Sandbox` apispec, `sdkx/sandbox/nsjail`

Refs: \`internal-docs/roadmap.md\` §2 v0.2.0