### PR TITLE
feat(sdkx/tool/exec): generic shell tool over sandbox.Runner

### DIFF
--- a/sdkx/go.mod
+++ b/sdkx/go.mod
@@ -2,7 +2,7 @@ module github.com/GizClaw/flowcraft/sdkx
 
 go 1.25.0
 
-require github.com/GizClaw/flowcraft/sdk v0.3.6
+require github.com/GizClaw/flowcraft/sdk v0.3.7
 
 require (
 	github.com/PuerkitoBio/goquery v1.11.0

--- a/sdkx/go.sum
+++ b/sdkx/go.sum
@@ -8,8 +8,8 @@ github.com/Azure/azure-sdk-for-go/sdk/internal v1.10.0/go.mod h1:iZDifYGJTIgIIkY
 github.com/AzureAD/microsoft-authentication-library-for-go v1.2.2 h1:XHOnouVk1mxXfQidrMEnLlPk9UMeRtyBTnEFtxkV0kU=
 github.com/AzureAD/microsoft-authentication-library-for-go v1.2.2/go.mod h1:wP83P5OoQ5p6ip3ScPr0BAq0BvuPAvacpEuSzyouqAI=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
-github.com/GizClaw/flowcraft/sdk v0.3.6 h1:fvSAWYvojdGuTI7vY84hMn6HZxG+fAO3qyTNq5WWLVk=
-github.com/GizClaw/flowcraft/sdk v0.3.6/go.mod h1:VeMqVBxnMGHtFO9ypHhsA591XoLCWxucXR+gqpxQt5s=
+github.com/GizClaw/flowcraft/sdk v0.3.7 h1:kp7Vqdetbl58YhGcPp+ExGTpabDDFJAYuhtaWqVK2bM=
+github.com/GizClaw/flowcraft/sdk v0.3.7/go.mod h1:VeMqVBxnMGHtFO9ypHhsA591XoLCWxucXR+gqpxQt5s=
 github.com/PuerkitoBio/goquery v1.11.0 h1:jZ7pwMQXIITcUXNH83LLk+txlaEy6NVOfTuP43xxfqw=
 github.com/PuerkitoBio/goquery v1.11.0/go.mod h1:wQHgxUOU3JGuj3oD/QFfxUdlzW6xPHfqyHre6VMY4DQ=
 github.com/andybalholm/cascadia v1.3.3 h1:AG2YHrzJIm4BZ19iwJ/DAua6Btl3IwJX+VI4kktS1LM=

--- a/sdkx/tool/exec/doc.go
+++ b/sdkx/tool/exec/doc.go
@@ -1,0 +1,72 @@
+// Package exec ships the LLM-callable "exec" tool: a generic shell
+// command runner over [sandbox.Runner]. It is the missing piece that
+// turns coding-agent style harnesses (SWE-bench, Terminal-Bench)
+// into something the model can drive end-to-end — the model emits
+// `exec(command, args...)`, the tool delegates to a sandboxed
+// runner, and the captured stdout/stderr/exit_code surfaces back as
+// the tool result.
+//
+// # Why sdkx
+//
+// sdk defines interfaces and primitives; sdkx ships concrete
+// adapters. tool.Tool implementations are concrete adapters — they
+// bridge the generic tool.Tool interface to one specific service —
+// and therefore belong here, mirroring the existing
+// sdk/llm → sdkx/llm/*, sdk/workspace → sdkx/tool/memory layouts.
+// See sdkx/tool/history/doc.go for the same rationale applied to
+// the history coordinator.
+//
+// # Deny-by-default
+//
+// [New] requires a non-nil [sandbox.Runner]. Callers cannot
+// construct an exec tool that "falls back to host shell" by leaving
+// the runner empty; that bypass would defeat the whole point of
+// sdk/sandbox. The mistake is caught at wiring time
+// (errdefs.Validation), not at the first LLM call. If you genuinely
+// want a no-op for tests, pass [sandbox.NoopRunner]{} or build a
+// runner with [sandbox.AllowCommands] around an empty whitelist.
+//
+// # Wire shape
+//
+// Arguments (JSON object):
+//
+//	{
+//	  "command":         "string, the program to run (required)",
+//	  "args":            ["string", ...],
+//	  "workdir":         "string, relative to the sandbox root",
+//	  "stdin":           "string, bytes piped to the program stdin",
+//	  "timeout_seconds": 30
+//	}
+//
+// Result (JSON object, returned as the tool result string):
+//
+//	{
+//	  "exit_code": 0,
+//	  "stdout":    "...",
+//	  "stderr":    "..."
+//	}
+//
+// A non-zero exit code is NOT a tool error — it is reported via
+// exit_code so the LLM can reason about it. The tool only returns
+// an errdefs-categorised Go error when the call cannot be made at
+// all (validation failure, sandbox policy rejection, timeout, IO
+// error from the runner).
+//
+// # Relationship to sandbox policy
+//
+// The tool itself carries zero policy; everything (env allow-list,
+// network mode, resource caps, output truncation, command
+// whitelist) lives in the injected [sandbox.Runner]. To restrict
+// what the LLM can run, compose the runner before passing it in:
+//
+//	rn := sandbox.AllowCommands(
+//	    sandbox.NewLocalRunner(workdir, sandbox.WithMaxOutputBytes(1<<20)),
+//	    []string{"ls", "cat", "git", "go"},
+//	)
+//	t, err := exec.New(rn)
+//
+// The same sandbox can be shared with the script-engine shell
+// bridge, vesseld Sandbox resources (planned, v0.2.0), and any
+// future sdkx/sandbox/{nsjail,container,microvm} backend without
+// changing this tool's call site.
+package exec

--- a/sdkx/tool/exec/tool.go
+++ b/sdkx/tool/exec/tool.go
@@ -1,0 +1,197 @@
+package exec
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"time"
+
+	"github.com/GizClaw/flowcraft/sdk/errdefs"
+	"github.com/GizClaw/flowcraft/sdk/model"
+	"github.com/GizClaw/flowcraft/sdk/sandbox"
+	"github.com/GizClaw/flowcraft/sdk/tool"
+)
+
+// Name is the canonical tool id callers register and LLMs invoke.
+// Stable across versions so prompts referring to the tool by name
+// keep working.
+const Name = "exec"
+
+// Tool is the LLM-callable shell command runner. It is stateless
+// apart from its injected dependencies; safe to register once and
+// share across runs.
+type Tool struct {
+	rn             sandbox.Runner
+	defaultTimeout time.Duration
+}
+
+// Option configures a [Tool] at construction time.
+type Option func(*Tool)
+
+// WithDefaultTimeout sets the per-call timeout used when the LLM
+// does not supply timeout_seconds. Zero means "no tool-imposed
+// default" — the caller's ctx still applies. Negative values are
+// treated as zero.
+func WithDefaultTimeout(d time.Duration) Option {
+	return func(t *Tool) {
+		if d > 0 {
+			t.defaultTimeout = d
+		}
+	}
+}
+
+// New constructs the exec tool. rn MUST be non-nil — there is no
+// host-shell fallback. Callers that want a literal "always
+// succeed" stub for tests should pass [sandbox.NoopRunner]{}
+// explicitly; callers that want "always reject" should wrap with
+// [sandbox.AllowCommands] over an empty whitelist.
+func New(rn sandbox.Runner, opts ...Option) (*Tool, error) {
+	if rn == nil {
+		return nil, errdefs.Validationf(
+			"exec: sandbox.Runner is required (deny-by-default); pass sandbox.NoopRunner{} explicitly if you really want a no-op")
+	}
+	t := &Tool{rn: rn}
+	for _, o := range opts {
+		o(t)
+	}
+	return t, nil
+}
+
+// MustNew is the panic-on-error variant of [New] for static wiring
+// where the runner is known to be non-nil at compile time.
+func MustNew(rn sandbox.Runner, opts ...Option) *Tool {
+	t, err := New(rn, opts...)
+	if err != nil {
+		panic(err)
+	}
+	return t
+}
+
+// Definition implements [tool.Tool]. The description is conservative
+// on purpose — the model should not treat exec as a free-form
+// scratchpad; explicit cwd / timeout knobs steer it toward
+// reproducible calls.
+func (t *Tool) Definition() model.ToolDefinition {
+	return model.ToolDefinition{
+		Name: Name,
+		Description: "Run a shell command inside the agent's sandbox. " +
+			"Returns exit_code, stdout, and stderr as JSON. A non-zero " +
+			"exit_code is reported in the result body, not as an error. " +
+			"Use this when you need to inspect files, run scripts, " +
+			"compile, or invoke CLIs the user expects you to drive.",
+		InputSchema: map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"command": map[string]any{
+					"type":        "string",
+					"description": "The program to run (required). Resolved against the sandbox's PATH policy.",
+				},
+				"args": map[string]any{
+					"type":        "array",
+					"items":       map[string]any{"type": "string"},
+					"description": "Arguments passed verbatim to the program.",
+				},
+				"workdir": map[string]any{
+					"type":        "string",
+					"description": "Working directory, relative to the sandbox root. Empty means the sandbox root itself. Absolute paths or .. escapes are rejected.",
+				},
+				"stdin": map[string]any{
+					"type":        "string",
+					"description": "Bytes piped to the program's stdin. Omit when the program does not read stdin.",
+				},
+				"timeout_seconds": map[string]any{
+					"type":        "number",
+					"description": "Per-call timeout in seconds. Falls back to the tool's default when omitted. Zero or negative disables the tool-level timeout (the caller's ctx still applies).",
+				},
+			},
+			"required":             []string{"command"},
+			"additionalProperties": false,
+		},
+	}
+}
+
+// Metadata implements [tool.ToolMetadata]. The tool can mutate any
+// state the sandbox grants the child process — file writes, network
+// calls, etc. — so we flag it as mutating without claiming a
+// specific RateLimit (real throttling belongs to the sandbox or the
+// caller's policy, not this adapter).
+func (t *Tool) Metadata() tool.ToolMeta {
+	return tool.ToolMeta{MutatesState: true}
+}
+
+// args is the wire-side input. Pointer types let us distinguish
+// "omitted" from "zero value" for the optional knobs.
+type args struct {
+	Command        string   `json:"command"`
+	Args           []string `json:"args"`
+	Workdir        string   `json:"workdir"`
+	Stdin          string   `json:"stdin"`
+	TimeoutSeconds *float64 `json:"timeout_seconds"`
+}
+
+// result is the wire-side output. JSON-encoded as the tool result
+// string so structured fields (exit_code) survive the round-trip to
+// the model without prose parsing.
+type result struct {
+	ExitCode int    `json:"exit_code"`
+	Stdout   string `json:"stdout"`
+	Stderr   string `json:"stderr"`
+}
+
+// Execute implements [tool.Tool]. It parses the LLM-supplied
+// arguments, builds a [sandbox.ExecOptions], delegates to the
+// injected runner, and JSON-encodes the result. Sandbox-level
+// errors (errdefs.NotAvailable / Forbidden / Timeout / ...) are
+// forwarded verbatim so callers can classify them via errdefs.Is*
+// without parsing strings.
+func (t *Tool) Execute(ctx context.Context, arguments string) (string, error) {
+	var a args
+	if err := json.Unmarshal([]byte(arguments), &a); err != nil {
+		return "", errdefs.Validationf("exec: parse arguments: %v", err)
+	}
+	if strings.TrimSpace(a.Command) == "" {
+		return "", errdefs.Validationf("exec: command must be non-empty")
+	}
+
+	opts := sandbox.ExecOptions{
+		WorkDir: a.Workdir,
+		Stdin:   nil,
+		Timeout: t.resolveTimeout(a.TimeoutSeconds),
+	}
+	if a.Stdin != "" {
+		opts.Stdin = []byte(a.Stdin)
+	}
+
+	res, err := t.rn.Exec(ctx, a.Command, a.Args, opts)
+	if err != nil {
+		return "", err
+	}
+
+	payload, err := json.Marshal(result{
+		ExitCode: res.ExitCode,
+		Stdout:   res.Stdout,
+		Stderr:   res.Stderr,
+	})
+	if err != nil {
+		return "", errdefs.Internalf("exec: encode result: %v", err)
+	}
+	return string(payload), nil
+}
+
+// resolveTimeout maps the optional timeout_seconds knob to a
+// time.Duration. Nil / negative / zero from the LLM falls back to
+// the tool's default; both layers off means "no tool-imposed
+// timeout" (ctx still bounds the call).
+func (t *Tool) resolveTimeout(s *float64) time.Duration {
+	if s == nil {
+		return t.defaultTimeout
+	}
+	if *s <= 0 {
+		return 0
+	}
+	return time.Duration(*s * float64(time.Second))
+}
+
+// Compile-time assertion the tool satisfies the contract. Keeps
+// signature drift in sdk/tool from silently breaking the adapter.
+var _ tool.Tool = (*Tool)(nil)

--- a/sdkx/tool/exec/tool_test.go
+++ b/sdkx/tool/exec/tool_test.go
@@ -1,0 +1,312 @@
+package exec_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/GizClaw/flowcraft/sdk/errdefs"
+	"github.com/GizClaw/flowcraft/sdk/sandbox"
+	"github.com/GizClaw/flowcraft/sdkx/tool/exec"
+)
+
+// fakeRunner is a sandbox.Runner stub that captures the most recent
+// Exec call and returns canned output, so tests can prove the tool
+// translates args → sandbox.ExecOptions correctly without spawning
+// real processes. Use the real LocalRunner only for E2E-style
+// happy-path coverage at the end of this file.
+type fakeRunner struct {
+	gotCmd  string
+	gotArgs []string
+	gotOpts sandbox.ExecOptions
+
+	retResult *sandbox.ExecResult
+	retErr    error
+}
+
+func (f *fakeRunner) Exec(_ context.Context, cmd string, args []string, opts sandbox.ExecOptions) (*sandbox.ExecResult, error) {
+	f.gotCmd = cmd
+	f.gotArgs = args
+	f.gotOpts = opts
+	if f.retErr != nil {
+		return nil, f.retErr
+	}
+	if f.retResult != nil {
+		return f.retResult, nil
+	}
+	return &sandbox.ExecResult{}, nil
+}
+
+func TestNew_NilRunner_Rejected(t *testing.T) {
+	_, err := exec.New(nil)
+	if err == nil {
+		t.Fatal("New with nil runner should be rejected (deny-by-default)")
+	}
+	if !errdefs.IsValidation(err) {
+		t.Fatalf("expected errdefs.IsValidation, got: %v", err)
+	}
+}
+
+func TestMustNew_NilRunner_Panics(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Fatal("MustNew with nil runner should panic")
+		}
+	}()
+	_ = exec.MustNew(nil)
+}
+
+func TestNew_NoopRunner_OK(t *testing.T) {
+	// The explicit-noop bypass is the documented escape hatch from
+	// deny-by-default; make sure it actually compiles + constructs.
+	tl, err := exec.New(sandbox.NoopRunner{})
+	if err != nil {
+		t.Fatalf("New(NoopRunner) should succeed: %v", err)
+	}
+	if tl == nil {
+		t.Fatal("New returned nil tool")
+	}
+}
+
+func TestDefinition_Shape(t *testing.T) {
+	tl, err := exec.New(sandbox.NoopRunner{})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	def := tl.Definition()
+	if def.Name != exec.Name {
+		t.Fatalf("Definition.Name = %q, want %q", def.Name, exec.Name)
+	}
+	// Schema must require command — without it the LLM gets no
+	// hint that command is mandatory and we lose the validation
+	// fast-path.
+	schema := def.InputSchema
+	if schema == nil {
+		t.Fatal("InputSchema should not be nil")
+	}
+	required, _ := schema["required"].([]string)
+	if len(required) != 1 || required[0] != "command" {
+		t.Fatalf("required = %v, want [command]", required)
+	}
+}
+
+func TestExecute_HappyPath_ForwardsArgs(t *testing.T) {
+	rn := &fakeRunner{retResult: &sandbox.ExecResult{ExitCode: 0, Stdout: "hello\n", Stderr: ""}}
+	tl, err := exec.New(rn)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	out, err := tl.Execute(context.Background(), `{"command":"echo","args":["hello"]}`)
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+
+	// Verify the JSON result shape — exit_code is the structured
+	// field the model needs to distinguish "ran but failed" from
+	// "ran and succeeded".
+	var got map[string]any
+	if err := json.Unmarshal([]byte(out), &got); err != nil {
+		t.Fatalf("result not valid JSON: %v (out=%q)", err, out)
+	}
+	if got["exit_code"] != float64(0) {
+		t.Fatalf("exit_code = %v, want 0", got["exit_code"])
+	}
+	if got["stdout"] != "hello\n" {
+		t.Fatalf("stdout = %v, want 'hello\\n'", got["stdout"])
+	}
+
+	// Verify the args reached the runner unchanged.
+	if rn.gotCmd != "echo" {
+		t.Fatalf("runner saw cmd %q, want echo", rn.gotCmd)
+	}
+	if len(rn.gotArgs) != 1 || rn.gotArgs[0] != "hello" {
+		t.Fatalf("runner saw args %v, want [hello]", rn.gotArgs)
+	}
+}
+
+func TestExecute_NonZeroExit_NotAnError(t *testing.T) {
+	// Sandboxed sub-processes exit non-zero for legitimate reasons
+	// (test failures, grep miss, ...) — those must NOT bubble up
+	// as a Go error to the LLM round, otherwise the model can't
+	// reason about exit codes and the round will look like a
+	// tool-system failure to the agent harness.
+	rn := &fakeRunner{retResult: &sandbox.ExecResult{ExitCode: 1, Stdout: "", Stderr: "boom"}}
+	tl, _ := exec.New(rn)
+
+	out, err := tl.Execute(context.Background(), `{"command":"false"}`)
+	if err != nil {
+		t.Fatalf("non-zero exit must not be a Go error, got: %v", err)
+	}
+	var r map[string]any
+	_ = json.Unmarshal([]byte(out), &r)
+	if r["exit_code"] != float64(1) {
+		t.Fatalf("exit_code = %v, want 1", r["exit_code"])
+	}
+	if r["stderr"] != "boom" {
+		t.Fatalf("stderr = %v, want 'boom'", r["stderr"])
+	}
+}
+
+func TestExecute_BadJSON_Validation(t *testing.T) {
+	tl, _ := exec.New(sandbox.NoopRunner{})
+
+	_, err := tl.Execute(context.Background(), `{not json`)
+	if err == nil {
+		t.Fatal("malformed JSON should be rejected")
+	}
+	if !errdefs.IsValidation(err) {
+		t.Fatalf("expected errdefs.IsValidation, got: %v", err)
+	}
+}
+
+func TestExecute_EmptyCommand_Validation(t *testing.T) {
+	tl, _ := exec.New(sandbox.NoopRunner{})
+
+	for _, raw := range []string{
+		`{}`,
+		`{"command":""}`,
+		`{"command":"   "}`,
+	} {
+		_, err := tl.Execute(context.Background(), raw)
+		if err == nil {
+			t.Fatalf("empty/whitespace command must be rejected (input=%q)", raw)
+		}
+		if !errdefs.IsValidation(err) {
+			t.Fatalf("input=%q: expected errdefs.IsValidation, got: %v", raw, err)
+		}
+	}
+}
+
+func TestExecute_SandboxError_Forwarded(t *testing.T) {
+	// Sandbox-side errors (NotAvailable / Forbidden / Timeout /
+	// path-traversal) MUST be forwarded verbatim so callers can
+	// classify them with errdefs.Is*. The tool layer adds nothing
+	// of value to those errors — the sandbox already knows why it
+	// refused.
+	want := errdefs.NotAvailablef("sandbox: net policy not supported")
+	rn := &fakeRunner{retErr: want}
+	tl, _ := exec.New(rn)
+
+	_, err := tl.Execute(context.Background(), `{"command":"echo"}`)
+	if err == nil {
+		t.Fatal("sandbox error should not be swallowed")
+	}
+	if !errdefs.IsNotAvailable(err) {
+		t.Fatalf("expected errdefs.IsNotAvailable, got: %v", err)
+	}
+	if !errors.Is(err, want) {
+		t.Fatalf("err chain should preserve sandbox sentinel: %v", err)
+	}
+}
+
+func TestExecute_Stdin_PassedThrough(t *testing.T) {
+	rn := &fakeRunner{retResult: &sandbox.ExecResult{}}
+	tl, _ := exec.New(rn)
+
+	_, err := tl.Execute(context.Background(), `{"command":"cat","stdin":"piped input"}`)
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if string(rn.gotOpts.Stdin) != "piped input" {
+		t.Fatalf("stdin not forwarded: got %q", rn.gotOpts.Stdin)
+	}
+}
+
+func TestExecute_Workdir_PassedThrough(t *testing.T) {
+	rn := &fakeRunner{retResult: &sandbox.ExecResult{}}
+	tl, _ := exec.New(rn)
+
+	_, err := tl.Execute(context.Background(), `{"command":"ls","workdir":"subdir"}`)
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if rn.gotOpts.WorkDir != "subdir" {
+		t.Fatalf("workdir not forwarded: got %q", rn.gotOpts.WorkDir)
+	}
+}
+
+func TestExecute_Timeout_Precedence(t *testing.T) {
+	// per-call > tool-default > zero. Cover all three layers so a
+	// future refactor cannot silently reorder them.
+	tests := []struct {
+		name     string
+		toolOpt  []exec.Option
+		argsJSON string
+		want     time.Duration
+	}{
+		{
+			name:     "per-call wins over default",
+			toolOpt:  []exec.Option{exec.WithDefaultTimeout(5 * time.Second)},
+			argsJSON: `{"command":"echo","timeout_seconds":2}`,
+			want:     2 * time.Second,
+		},
+		{
+			name:     "default applies when omitted",
+			toolOpt:  []exec.Option{exec.WithDefaultTimeout(7 * time.Second)},
+			argsJSON: `{"command":"echo"}`,
+			want:     7 * time.Second,
+		},
+		{
+			name:     "zero per-call disables tool timeout",
+			toolOpt:  []exec.Option{exec.WithDefaultTimeout(5 * time.Second)},
+			argsJSON: `{"command":"echo","timeout_seconds":0}`,
+			want:     0,
+		},
+		{
+			name:     "no defaults, no per-call",
+			argsJSON: `{"command":"echo"}`,
+			want:     0,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			rn := &fakeRunner{retResult: &sandbox.ExecResult{}}
+			tl, err := exec.New(rn, tc.toolOpt...)
+			if err != nil {
+				t.Fatalf("New: %v", err)
+			}
+			if _, err := tl.Execute(context.Background(), tc.argsJSON); err != nil {
+				t.Fatalf("Execute: %v", err)
+			}
+			if rn.gotOpts.Timeout != tc.want {
+				t.Fatalf("Timeout = %v, want %v", rn.gotOpts.Timeout, tc.want)
+			}
+		})
+	}
+}
+
+func TestExecute_E2E_LocalRunner(t *testing.T) {
+	// One end-to-end test against the real LocalRunner so the
+	// JSON-args → sandbox.ExecOptions → os/exec chain is exercised
+	// at least once. Substantive sandbox coverage lives in
+	// sdk/sandbox; we just confirm wiring here.
+	if runtime.GOOS == "windows" {
+		t.Skip("skipping on windows")
+	}
+	rn := sandbox.NewLocalRunner(t.TempDir())
+	tl, err := exec.New(rn)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	out, err := tl.Execute(context.Background(), `{"command":"echo","args":["world"]}`)
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	var r map[string]any
+	if err := json.Unmarshal([]byte(out), &r); err != nil {
+		t.Fatalf("result not valid JSON: %v", err)
+	}
+	if r["exit_code"] != float64(0) {
+		t.Fatalf("exit_code = %v, want 0", r["exit_code"])
+	}
+	if s, _ := r["stdout"].(string); !strings.Contains(s, "world") {
+		t.Fatalf("stdout = %q, want substring 'world'", s)
+	}
+}


### PR DESCRIPTION
## Summary

Second slice of roadmap §2 v0.2.0: ship the LLM-callable counterpart to `sdk/sandbox.Runner`. Together with PR #120 (which delivered the sandbox primitives) this is the wiring that lets a model emit `exec(command, args...)` and have it land in a sandboxed runner — the missing piece for coding-agent style harnesses (SWE-bench, Terminal-Bench).

- **New `sdkx/tool/exec` package.** JSON args (`command` / `args` / `workdir` / `stdin` / `timeout_seconds`) → `sandbox.ExecOptions` → `sandbox.ExecResult`, encoded back as JSON so the model sees structured `exit_code` / `stdout` / `stderr` fields. The tool carries zero policy; everything (env allow-list, net mode, resource caps, output truncation, command whitelist) lives in the injected runner. To restrict what the LLM can run, compose the runner before construction:

  \`\`\`go
  rn := sandbox.AllowCommands(
      sandbox.NewLocalRunner(workdir, sandbox.WithMaxOutputBytes(1<<20)),
      []string{\"ls\", \"cat\", \"git\", \"go\"},
  )
  t, err := exec.New(rn)
  \`\`\`

- **Deny-by-default.** `New` rejects a nil `sandbox.Runner` with `errdefs.Validation` so the wiring mistake is caught at build time, not at the first LLM call. The documented escape hatch is `sandbox.NoopRunner{}` (always succeeds, always empty) — callers who really want a no-op have to type it out.
- **Non-zero exit is not a Go error.** Sub-processes exit non-zero for legitimate reasons (test failures, grep miss). Surfacing those as Go errors would make every \"ran but failed\" outcome look like a tool-system failure to the agent harness; instead the result body carries `exit_code` and the LLM can reason about it. Sandbox-level errors (`errdefs.NotAvailable` / `Forbidden` / `Timeout`) are forwarded verbatim so callers classify them via `errdefs.Is*` without parsing strings.
- **Lives in sdkx, not sdk.** Following the rule already documented in `sdkx/tool/history/doc.go`: `tool.Tool` implementations are concrete adapters; `sdk/llm` → `sdkx/llm/*`, `sdk/workspace` → `sdkx/tool/memory`, and now `sdk/sandbox` → `sdkx/tool/exec`. The sdk side stays primitive-only.

## What is NOT in this PR

- `sdk/tool/builtin/askuser` → `sdkx/tool/askuser` migration. Mentioned in the same roadmap row, but it requires its own deprecation-shim work on the sdk side and belongs to a separate review focus.
- `vesseld kind: Sandbox` apispec — independent PR, can land in parallel.
- `sdkx/sandbox/nsjail` (the first real isolation backend that would make `NetPolicy.DenyAll/AllowList` and CPU/mem/disk limits truly enforced) — independent PR after this one.

## Test plan

- [x] `go test ./sdkx/tool/exec/...` — all green; 11 test cases cover nil-runner rejection, MustNew panic path, NoopRunner happy path, definition shape (required field), JSON arg → sandbox.ExecOptions forwarding (command/args/workdir/stdin), non-zero exit as result-not-error, malformed-JSON / empty-command validation, sandbox-side error forwarding via `errors.Is`, three-layer timeout precedence (per-call / tool-default / zero), and a single end-to-end against the real `LocalRunner`
- [x] `go vet ./sdkx/tool/exec/...` — clean
- [x] Full `sdkx` package test sweep — every existing package still green, no behaviour regression
- [x] `sdk`, `sdkx`, `vessel`, `voice`, `cmd/vesseld` all `go build` cleanly — no downstream module regression
- [ ] (follow-up PR) wire `exec.MustNew` into `examples/coding-agent` so the SWE-bench mini target in roadmap §2 v0.2.0 KPI #3 has a real runtime to evaluate

Refs: \`internal-docs/roadmap.md\` §2 v0.2.0; depends on PR #120 (merged).

Made with [Cursor](https://cursor.com)