### PR TITLE
feat(sdkx/tool/askuser): canonical home for ask_user tool

### DIFF
--- a/sdk/engine/doc.go
+++ b/sdk/engine/doc.go
@@ -123,9 +123,9 @@
 //  14. Host-on-context plumbing (host_ctx.go) — [WithHost] /
 //     [HostFromContext] let engines hand the Host to extension
 //     points whose signatures don't carry it (canonically:
-//     sdk/tool's Tool.Execute). Built-in tools that need host
-//     capabilities (e.g. sdk/tool/builtin/askuser) recover the host
-//     this way without each engine inventing its own ctx-key
+//     sdk/tool's Tool.Execute). Tools that need host capabilities
+//     (the ask_user tool is the canonical example) recover the
+//     host this way without each engine inventing its own ctx-key
 //     convention.
 //
 // # What does NOT live here

--- a/sdk/sandbox/doc.go
+++ b/sdk/sandbox/doc.go
@@ -17,13 +17,14 @@
 //     is unsafe in a multi-tenant agent harness.
 //   - Net (NetPolicy): mode + (future) allow-list / proxy URL. LocalRunner
 //     only accepts NetDefault; non-default modes require a sandboxing
-//     backend such as sdkx/sandbox/{nsjail,container,microvm} (planned).
+//     backend (namespace-based, container-based, or microVM-based) that
+//     can actually enforce the policy at the kernel level.
 //   - Resources (ResourceLimits): CPU / memory / disk caps plus
 //     MaxOutputBytes. LocalRunner only enforces MaxOutputBytes today; the
-//     hard caps require kernel-level mechanisms shipped by sdkx backends.
+//     hard caps require the same kernel-level enforcement as Net.
 //
 // LocalRunner is the in-process, no-isolation backend used by tests and
 // single-tenant operators. Production deployments should compose it with
 // AllowCommands (whitelist) and eventually swap to a sandboxed Runner
-// when sdkx ships them.
+// once a real isolation backend is available.
 package sandbox

--- a/sdk/sandbox/local.go
+++ b/sdk/sandbox/local.go
@@ -33,8 +33,8 @@ func WithMaxOutputBytes(n int64) Option {
 
 // LocalRunner executes commands directly on the host using os/exec. It is
 // the no-isolation backend; production deployments that need real
-// boundaries should swap it for a sandboxed Runner from
-// sdkx/sandbox/{nsjail,container,microvm} (planned).
+// boundaries should swap it for a sandboxed Runner with kernel-level
+// enforcement (namespace / container / microVM).
 //
 // Policy support matrix:
 //
@@ -72,7 +72,7 @@ func NewLocalRunner(rootDir string, opts ...Option) *LocalRunner {
 func (r *LocalRunner) Exec(ctx context.Context, cmd string, args []string, opts ExecOptions) (*ExecResult, error) {
 	if opts.Net.Mode != NetDefault {
 		return nil, errdefs.NotAvailablef(
-			"sandbox: net policy not supported by local runner; use sdkx/sandbox/{nsjail,container,microvm}")
+			"sandbox: net policy not supported by local runner; requires a kernel-level isolation backend")
 	}
 	if opts.Resources.CPUMillicores != 0 || opts.Resources.MemoryBytes != 0 || opts.Resources.DiskBytes != 0 {
 		return nil, errdefs.NotAvailablef(

--- a/sdk/sandbox/sandbox.go
+++ b/sdk/sandbox/sandbox.go
@@ -89,8 +89,8 @@ const (
 
 // NetPolicy controls outbound networking for the child process.
 // LocalRunner only honours NetDefault; any other mode is rejected with
-// errdefs.NotAvailable until a sandboxed backend (sdkx/sandbox/{nsjail,
-// container,microvm}) is wired up.
+// errdefs.NotAvailable until a sandboxed backend with kernel-level
+// enforcement is wired up.
 type NetPolicy struct {
 	Mode       NetMode
 	AllowHosts []string

--- a/sdk/tool/builtin/askuser/askuser.go
+++ b/sdk/tool/builtin/askuser/askuser.go
@@ -2,6 +2,18 @@
 // human-in-the-loop bridge that lets the model explicitly hand a
 // question back to the operator via [engine.Host.AskUser].
 //
+// Deprecated: moved to sdkx/tool/askuser. The new canonical import
+// path is "github.com/GizClaw/flowcraft/sdkx/tool/askuser". This
+// package continues to host the implementation only because sdk
+// cannot import sdkx (the dependency runs one-way); the sdkx path
+// is a thin forwarder during the migration window. Will be removed
+// in v0.5.0 — same window as catalog.Deps.AgentTools,
+// runner.WithActorKey, and workspace.CommandRunner. Migrate via a
+// pure import-path swap:
+//
+//	-import "github.com/GizClaw/flowcraft/sdk/tool/builtin/askuser"
+//	+import "github.com/GizClaw/flowcraft/sdkx/tool/askuser"
+//
 // Without a real consumer, host.AskUser is a dead capability: the
 // engine.NoopHost rejects it, scriptnode forwards a script-side
 // API to it, but no model-driven path ever called it. ask_user
@@ -66,6 +78,11 @@ import (
 // Name is the canonical tool id callers register and LLMs invoke.
 // Stable across versions so prompts referring to the tool by name
 // keep working.
+//
+// Deprecated: use sdkx/tool/askuser.Name. Will be removed in v0.5.0
+// (same window as catalog.Deps.AgentTools, runner.WithActorKey, and
+// workspace.CommandRunner). The value is preserved verbatim across
+// both paths so prompts / registry lookups keep working.
 const Name = "ask_user"
 
 // args is the wire-side argument struct. JSON-only; no positional
@@ -80,6 +97,11 @@ type askUserTool struct{}
 
 // New constructs the built-in ask_user tool. The returned value
 // satisfies tool.Tool and can be passed to Registry.Register.
+//
+// Deprecated: use sdkx/tool/askuser.New. Will be removed in v0.5.0
+// (same window as catalog.Deps.AgentTools, runner.WithActorKey, and
+// workspace.CommandRunner). The sdkx forwarder returns the exact
+// same tool implementation, so a pure import-path swap is enough.
 func New() tool.Tool { return askUserTool{} }
 
 // Definition returns the model-facing schema. Description is the

--- a/sdkx/tool/askuser/askuser.go
+++ b/sdkx/tool/askuser/askuser.go
@@ -1,0 +1,26 @@
+package askuser
+
+import (
+	"github.com/GizClaw/flowcraft/sdk/tool"
+	sdkbuiltin "github.com/GizClaw/flowcraft/sdk/tool/builtin/askuser"
+)
+
+// Name is the canonical tool id callers register and LLMs invoke.
+// Stable across versions so prompts referring to the tool by name
+// keep working. Re-exported from sdk/tool/builtin/askuser during
+// the v0.2.0 → v0.5.0 transition; the constant value is identical
+// across both paths.
+const Name = sdkbuiltin.Name
+
+// New constructs the ask_user tool. The returned value satisfies
+// tool.Tool and can be passed to Registry.Register.
+//
+// During the v0.2.0 → v0.5.0 transition this is a thin forwarder
+// to sdk/tool/builtin/askuser.New; sdk cannot import sdkx (the
+// dependency runs one-way), so the implementation has to stay in
+// sdk for now. At v0.5.0 the implementation moves here verbatim
+// and the sdk path is removed — call-site signature does not
+// change.
+func New() tool.Tool {
+	return sdkbuiltin.New()
+}

--- a/sdkx/tool/askuser/askuser_test.go
+++ b/sdkx/tool/askuser/askuser_test.go
@@ -1,0 +1,92 @@
+package askuser_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/GizClaw/flowcraft/sdk/engine"
+	"github.com/GizClaw/flowcraft/sdk/errdefs"
+	"github.com/GizClaw/flowcraft/sdk/model"
+	sdkbuiltin "github.com/GizClaw/flowcraft/sdk/tool/builtin/askuser"
+	"github.com/GizClaw/flowcraft/sdkx/tool/askuser"
+)
+
+// TestForwarder_NameMatchesSDK asserts the sdkx Name constant is
+// exactly the value the sdk/tool/builtin/askuser package exports,
+// so prompts / registry lookups keyed on either path resolve to
+// the same tool. If this drifts, callers migrating their import
+// path would silently get a different tool id.
+func TestForwarder_NameMatchesSDK(t *testing.T) {
+	if askuser.Name != sdkbuiltin.Name {
+		t.Fatalf("Name = %q, want %q (sdkx forwarder must re-export the sdk constant verbatim)",
+			askuser.Name, sdkbuiltin.Name)
+	}
+}
+
+// TestForwarder_Definition_Identity confirms the tool produced
+// through the sdkx path has the same Name in its Definition as
+// the underlying sdk implementation. We do not lock the entire
+// schema down here because that is the sdk-side tool's contract;
+// duplicating it would just create a second source of truth.
+func TestForwarder_Definition_Identity(t *testing.T) {
+	def := askuser.New().Definition()
+	if def.Name != sdkbuiltin.Name {
+		t.Fatalf("Definition.Name = %q, want %q", def.Name, sdkbuiltin.Name)
+	}
+}
+
+// TestForwarder_Execute_NoHost_NotAvailable proves the forwarder
+// does not break the contract documented on the sdk side: an
+// ask_user call on a ctx that does not carry an engine.Host must
+// surface errdefs.NotAvailable. This is the smoke test that a
+// no-op forwarder change would still trip if someone accidentally
+// reimplemented New() to return a different impl.
+func TestForwarder_Execute_NoHost_NotAvailable(t *testing.T) {
+	_, err := askuser.New().Execute(context.Background(), `{"prompt":"hi"}`)
+	if err == nil {
+		t.Fatal("expected error on bare ctx (no engine.Host)")
+	}
+	if !errdefs.IsNotAvailable(err) {
+		t.Fatalf("err category = %v, want NotAvailable", err)
+	}
+}
+
+// TestForwarder_Execute_HappyPath threads a fake host through
+// engine.WithHost and confirms the sdkx-constructed tool reaches
+// it. This is the single end-to-end check that the forwarder
+// pipes the host-on-ctx mechanism through unchanged; substantive
+// host-side behaviour is covered in sdk/tool/builtin/askuser.
+func TestForwarder_Execute_HappyPath(t *testing.T) {
+	host := &replyingHost{reply: "you should ship"}
+	tl := askuser.New()
+
+	ctx := engine.WithHost(context.Background(), host)
+	out, err := tl.Execute(ctx, `{"prompt":"should I ship?"}`)
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if !strings.Contains(out, "you should ship") {
+		t.Fatalf("result = %q, want host reply substring", out)
+	}
+	if host.gotPrompt.Source != askuser.Name {
+		t.Errorf("UserPrompt.Source = %q, want %q (Execute must stamp the source)",
+			host.gotPrompt.Source, askuser.Name)
+	}
+}
+
+// replyingHost embeds NoopHost so it satisfies the full
+// engine.Host surface, then overrides AskUser to return a
+// scripted reply and capture the inbound prompt for assertion.
+type replyingHost struct {
+	engine.NoopHost
+	gotPrompt engine.UserPrompt
+	reply     string
+}
+
+func (h *replyingHost) AskUser(_ context.Context, p engine.UserPrompt) (engine.UserReply, error) {
+	h.gotPrompt = p
+	return engine.UserReply{
+		Parts: []model.Part{{Type: model.PartText, Text: h.reply}},
+	}, nil
+}

--- a/sdkx/tool/askuser/doc.go
+++ b/sdkx/tool/askuser/doc.go
@@ -1,0 +1,77 @@
+// Package askuser is the v0.2.0+ canonical home for the
+// `ask_user` LLM tool — a human-in-the-loop bridge that lets the
+// model explicitly hand a question back to the operator via
+// [engine.Host.AskUser].
+//
+// # Why sdkx
+//
+// sdk defines interfaces and primitives; sdkx ships concrete
+// adapters that integrate with external systems or external
+// protocol specs. tool.Tool implementations are concrete adapters
+// — they bridge the generic tool.Tool interface to one specific
+// service — and therefore belong here, mirroring the existing
+// sdk/llm → sdkx/llm/*, sdk/workspace → sdkx/tool/memory, and now
+// sdk/sandbox → sdkx/tool/exec layouts. See
+// sdkx/tool/history/doc.go for the same rationale applied to the
+// history coordinator.
+//
+// # Migration shape
+//
+// During v0.2.x → v0.5.0 this package is a thin re-export layer
+// over sdk/tool/builtin/askuser because sdk cannot import sdkx
+// (the dependency runs one-way: sdkx imports sdk). [Name] is a
+// re-exported constant and [New] forwards to the underlying
+// builtin constructor — the two paths are interchangeable at the
+// Go type level for as long as the deprecation window stays open.
+// Callers should migrate to this import path now:
+//
+//	-import "github.com/GizClaw/flowcraft/sdk/tool/builtin/askuser"
+//	+import "github.com/GizClaw/flowcraft/sdkx/tool/askuser"
+//
+// At v0.5.0 the implementation relocates into this package, the
+// thin wrappers go away, and sdk/tool/builtin/askuser is removed
+// — same window as catalog.Deps.AgentTools, runner.WithActorKey,
+// and workspace.CommandRunner.
+//
+// # Wiring
+//
+// Register the tool into the same tool.Registry the LLM node
+// already consults:
+//
+//	reg := tool.NewRegistry()
+//	reg.Register(askuser.New())
+//
+// At round time, llmnode stashes the engine.Host on ctx via
+// engine.WithHost before invoking reg.ExecuteAll. The tool's
+// Execute recovers it via engine.HostFromContext and forwards the
+// LLM-supplied prompt to host.AskUser. The host's UserPrompter
+// implementation (typically a UI controller, a queued kanban
+// card, or a terminal prompt) returns the human's reply, which
+// surfaces back to the LLM as the tool result body.
+//
+// # Capability gating
+//
+// Engines that include this tool in their advertised registry
+// implicitly emit user prompts. Hosts SHOULD declare
+// engine.Capabilities.EmitsUserPrompt = true so the runtime can
+// route those prompts to a real user-facing surface; an embedded
+// fire-and-forget batch run that wires only NoopHost will see
+// every ask_user call surface as errdefs.NotAvailable — that is
+// honest behaviour: the model asked a question nobody can answer,
+// and the surface error tells the LLM exactly that.
+//
+// # Wire shape
+//
+// Arguments (JSON object):
+//
+//	{
+//	  "prompt": "string, the question to ask the user (required)"
+//	}
+//
+// Result: the human's reply as a plain string. Errors:
+//
+//   - errdefs.Validation: arguments did not parse / prompt empty.
+//   - errdefs.NotAvailable: no engine.Host on ctx, or the host
+//     refused the prompt (UserPrompter returned the same).
+//   - any other error: forwarded verbatim from host.AskUser.
+package askuser


### PR DESCRIPTION
## Summary

Third slice of roadmap §2 v0.2.0: relocate the `ask_user` LLM tool to its canonical sdkx home, finishing the `sdk/tool/builtin/` retirement story that began with the sandbox split. Together with PR #120 (sandbox primitives) and PR #121 (`sdkx/tool/exec`), this aligns the tool layer with the established \`sdk/llm → sdkx/llm/*\` and \`sdk/workspace → sdkx/tool/memory\` layout: \`tool.Tool\` implementations live in sdkx, sdk stays primitive-only.

- **New `sdkx/tool/askuser` package** — thin re-export layer over `sdk/tool/builtin/askuser`. Same shape as \`sdkx/tool/history\` during its v0.2.x → v0.3.0 transition: sdk cannot import sdkx (the dependency runs one-way), so the implementation has to stay in sdk for now; the sdkx path becomes the canonical one immediately and the implementation relocates at v0.5.0. \`Name\` is a const alias, \`New()\` forwards verbatim, so a pure import-path swap migrates any caller.
- **`sdk/tool/builtin/askuser` flagged Deprecated** at the package, \`Name\`, and \`New\` levels. **Will be removed in v0.5.0** — same window as \`catalog.Deps.AgentTools\`, \`runner.WithActorKey\`, and \`workspace.CommandRunner\`.
- **Four forwarder smoke tests** on the sdkx side: \`Name\` identity, \`Definition.Name\`, no-host \`NotAvailable\`, happy-path host round-trip. Substantive contract coverage stays on the sdk side (the full 178-line test file is untouched); duplicating it would create a second source of truth.
- **`sdk/engine/doc.go`**: stop naming sdkx as the example consumer of \`HostFromContext\`. sdk-level godoc must not point forward at sdkx; generic phrasing ("the ask_user tool is the canonical example") preserves the doc value without breaking the layering rule.
- **`sdk/sandbox` godoc / error strings cleanup** (second commit): the package was leaking \`sdkx/sandbox/{nsjail,container,microvm}\` references into godoc and the \`errdefs.NotAvailable\` message it returns for non-default \`Net\` policy. Replaced with intent-level phrasing ("requires a kernel-level isolation backend", "namespace / container / microVM enforcement"). Same layering rule as the engine.go cleanup; closes the gaps that PR #120 introduced.

The \`// Deprecated:\` notice in \`sdk/tool/builtin/askuser/askuser.go\` is the **documented exception** — Go's godoc convention requires \`Deprecated\` comments to name their replacement, and that is the one place sdk-side godoc is allowed to mention an sdkx path.

## What is NOT in this PR

- **vessel/lifecycle_askuser_e2e_test.go import path migration.** \`vessel\` does not depend on sdkx (intentional module boundary) and the deprecated path remains functional. It will migrate when \`vessel\` adopts sdkx elsewhere or at the v0.5.0 cleanup, whichever lands first.
- **\`sdk/telemetry/{run_summary,attrs}.go\` + \`sdk/llm/metrics.go\` sdkx references** — older code, predates this PR's scope, deserves its own focused chore PR.
- **\`sdk/tool/tooltest/suite.go\` doc example** — does not name an import path, so the example is currently ambiguous between both routes. Left untouched.

## Test plan

- [x] \`go vet ./sdk/sandbox/... ./sdk/engine/... ./sdk/tool/builtin/askuser/... ./sdkx/tool/askuser/...\` — clean
- [x] \`go test ./sdk/sandbox/... ./sdk/tool/builtin/askuser/... ./sdkx/tool/askuser/...\` — all green
- [x] Full module build: \`sdk\`, \`sdkx\`, \`vessel\`, \`voice\`, \`cmd/vesseld\` all clean
- [x] \`vessel\` AskUser e2e test passes unchanged on the deprecated sdk import path — proves the back-compat guarantee
- [x] No \`sdkx\` references remain in \`sdk/sandbox/\` or \`sdk/engine/\`; only \`sdk/tool/builtin/askuser/\` retains them, exclusively inside \`Deprecated:\` notices

## Follow-ups

- Independent chore PR to scrub \`sdk/telemetry/\` and \`sdk/llm/metrics.go\` of \`sdkx/llm\` references.
- v0.5.0 cleanup window: delete \`sdk/tool/builtin/\` entirely, move ask_user implementation into \`sdkx/tool/askuser\`, drop the forwarder.

Refs: \`internal-docs/roadmap.md\` §2 v0.2.0

Made with [Cursor](https://cursor.com)