### PR TITLE
feat(sdk/sandbox): WithDefaults decorator for fixed policy

### DIFF
--- a/sdk/sandbox/decorator.go
+++ b/sdk/sandbox/decorator.go
@@ -3,6 +3,7 @@ package sandbox
 import (
 	"context"
 	"fmt"
+	"time"
 )
 
 // AllowCommands returns a Runner that delegates to inner only when the
@@ -30,6 +31,134 @@ func (r *allowCommandsRunner) Exec(ctx context.Context, cmd string, args []strin
 		return nil, fmt.Errorf("sandbox: command %q is not in the whitelist", cmd)
 	}
 	return r.inner.Exec(ctx, cmd, args, opts)
+}
+
+// WithDefaults returns a Runner that merges defaults into every Exec
+// call's ExecOptions before delegating to inner. It is the
+// composition seam that lets a runtime owner (typically vesseld
+// Catalog instantiating a kind: Sandbox resource) fix the
+// daemon-level shared policy — env allow-list, network mode,
+// resource caps — onto a Runner that callers (tools, scripts) then
+// invoke with only behavioural knobs (cwd, stdin, per-call timeout).
+//
+// Merge semantics are deliberately security-biased: policy fields
+// belong to defaults, behavioural fields belong to the caller.
+// A tool cannot escape sandbox policy by passing wider ExecOptions
+// at call time.
+//
+//   - WorkDir: caller wins. Empty caller WorkDir falls back to
+//     defaults.WorkDir.
+//   - Stdin: caller wins. nil caller Stdin falls back to
+//     defaults.Stdin (rare in practice; here for symmetry).
+//   - Timeout: min(caller, defaults) when both > 0. A non-zero side
+//     overrides a zero side. Zero on both sides means "no
+//     sandbox-imposed timeout"; the caller's ctx still applies. The
+//     min rule lets defaults act as a ceiling — a tool can ask for
+//     a shorter window than the sandbox grants, never a longer one.
+//   - Env.Allow: defaults wins entirely. A non-nil caller Allow is
+//     ignored; widening the host-env allow-list at call time would
+//     defeat the sandbox. Callers that want a narrower view should
+//     not run as exec at all, or should be deployed against a
+//     differently-configured Sandbox resource.
+//   - Env.Inject: union; caller entries override defaults on key
+//     collision. This is the one place a tool can layer in
+//     per-call context (RUN_ID, REQUEST_ID, ...) on top of the
+//     sandbox's static injections.
+//   - Net: defaults wins entirely. Caller Net is ignored — the
+//     network posture is sandbox-level policy.
+//   - Resources: defaults wins entirely. Caller cannot raise caps;
+//     and narrowing CPU/Mem/Disk per call is not actionable for a
+//     LocalRunner today (those fields are advisory until a real
+//     isolation backend lands), so the simpler "defaults only"
+//     rule keeps the contract honest.
+//
+// Composition with the other decorators:
+//
+//	rn := sandbox.WithDefaults(
+//	    sandbox.AllowCommands(
+//	        sandbox.NewLocalRunner(spec.Root, sandbox.WithMaxOutputBytes(spec.MaxOutput)),
+//	        spec.AllowedCommands,
+//	    ),
+//	    sandbox.ExecOptions{
+//	        Env:       toEnvPolicy(spec.Env),
+//	        Net:       toNetPolicy(spec.Net),
+//	        Resources: toResourceLimits(spec.Resources),
+//	    },
+//	)
+//
+// The inner-to-outer ordering is: LocalRunner (actually runs the
+// command) → AllowCommands (gates the command name) → WithDefaults
+// (rewrites ExecOptions). Reversing the gate vs. defaults order
+// has no semantic difference today because neither decorator
+// observes the other's domain.
+func WithDefaults(inner Runner, defaults ExecOptions) Runner {
+	return &defaultsRunner{inner: inner, defaults: defaults}
+}
+
+type defaultsRunner struct {
+	inner    Runner
+	defaults ExecOptions
+}
+
+func (r *defaultsRunner) Exec(ctx context.Context, cmd string, args []string, opts ExecOptions) (*ExecResult, error) {
+	return r.inner.Exec(ctx, cmd, args, r.merge(opts))
+}
+
+// merge applies the rules documented on [WithDefaults]. Kept on a
+// pointer receiver so the defaults map is not copied on every call.
+func (r *defaultsRunner) merge(caller ExecOptions) ExecOptions {
+	merged := ExecOptions{
+		WorkDir:   caller.WorkDir,
+		Stdin:     caller.Stdin,
+		Timeout:   mergeTimeout(caller.Timeout, r.defaults.Timeout),
+		Env:       mergeEnv(caller.Env, r.defaults.Env),
+		Net:       r.defaults.Net,
+		Resources: r.defaults.Resources,
+	}
+	if merged.WorkDir == "" {
+		merged.WorkDir = r.defaults.WorkDir
+	}
+	if merged.Stdin == nil {
+		merged.Stdin = r.defaults.Stdin
+	}
+	return merged
+}
+
+// mergeTimeout takes the smaller of the two positive durations.
+// A zero side defers to the other side; both zero means no
+// sandbox-imposed timeout.
+func mergeTimeout(caller, def time.Duration) time.Duration {
+	if caller > 0 && def > 0 {
+		if caller < def {
+			return caller
+		}
+		return def
+	}
+	if caller > 0 {
+		return caller
+	}
+	return def
+}
+
+// mergeEnv enforces the asymmetric Env policy: defaults owns Allow,
+// caller can layer Inject. We never clone defaults.Inject directly
+// into the returned EnvPolicy when caller.Inject is empty — the
+// LocalRunner reads the map by value, and aliasing the defaults map
+// would let a buggy downstream mutate the shared policy.
+func mergeEnv(caller, def EnvPolicy) EnvPolicy {
+	out := EnvPolicy{Allow: def.Allow}
+	if len(def.Inject) == 0 && len(caller.Inject) == 0 {
+		return out
+	}
+	merged := make(map[string]string, len(def.Inject)+len(caller.Inject))
+	for k, v := range def.Inject {
+		merged[k] = v
+	}
+	for k, v := range caller.Inject {
+		merged[k] = v
+	}
+	out.Inject = merged
+	return out
 }
 
 // NoopRunner is a zero-policy Runner that always returns an empty

--- a/sdk/sandbox/decorator_test.go
+++ b/sdk/sandbox/decorator_test.go
@@ -2,23 +2,27 @@ package sandbox_test
 
 import (
 	"context"
+	"reflect"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/GizClaw/flowcraft/sdk/sandbox"
 )
 
-// recordingRunner records the most recent Exec call so AllowCommands
-// tests can prove that allowed calls do pass through to the inner Runner
-// (and blocked calls do not).
+// recordingRunner records the most recent Exec call so decorator
+// tests can prove that delegated calls reach the inner Runner with
+// the expected (post-merge) ExecOptions.
 type recordingRunner struct {
-	called bool
-	cmd    string
+	called  bool
+	cmd     string
+	gotOpts sandbox.ExecOptions
 }
 
-func (r *recordingRunner) Exec(_ context.Context, cmd string, _ []string, _ sandbox.ExecOptions) (*sandbox.ExecResult, error) {
+func (r *recordingRunner) Exec(_ context.Context, cmd string, _ []string, opts sandbox.ExecOptions) (*sandbox.ExecResult, error) {
 	r.called = true
 	r.cmd = cmd
+	r.gotOpts = opts
 	return &sandbox.ExecResult{Stdout: "ok"}, nil
 }
 
@@ -67,6 +71,309 @@ func TestAllowCommands_EmptyWhitelist(t *testing.T) {
 	}
 	if inner.called {
 		t.Fatal("empty whitelist must not reach inner runner")
+	}
+}
+
+// -- WithDefaults --
+
+func TestWithDefaults_WorkDir_CallerWins(t *testing.T) {
+	inner := &recordingRunner{}
+	r := sandbox.WithDefaults(inner, sandbox.ExecOptions{WorkDir: "from-defaults"})
+
+	_, err := r.Exec(context.Background(), "echo", nil, sandbox.ExecOptions{WorkDir: "from-caller"})
+	if err != nil {
+		t.Fatalf("Exec: %v", err)
+	}
+	if inner.gotOpts.WorkDir != "from-caller" {
+		t.Fatalf("WorkDir = %q, want 'from-caller' (caller should win)", inner.gotOpts.WorkDir)
+	}
+}
+
+func TestWithDefaults_WorkDir_FallsBackToDefault(t *testing.T) {
+	inner := &recordingRunner{}
+	r := sandbox.WithDefaults(inner, sandbox.ExecOptions{WorkDir: "from-defaults"})
+
+	_, err := r.Exec(context.Background(), "echo", nil, sandbox.ExecOptions{})
+	if err != nil {
+		t.Fatalf("Exec: %v", err)
+	}
+	if inner.gotOpts.WorkDir != "from-defaults" {
+		t.Fatalf("WorkDir = %q, want 'from-defaults' (empty caller should fall back)", inner.gotOpts.WorkDir)
+	}
+}
+
+func TestWithDefaults_Stdin_CallerWinsAndFallback(t *testing.T) {
+	t.Run("caller wins", func(t *testing.T) {
+		inner := &recordingRunner{}
+		r := sandbox.WithDefaults(inner, sandbox.ExecOptions{Stdin: []byte("default-stdin")})
+
+		_, _ = r.Exec(context.Background(), "echo", nil, sandbox.ExecOptions{Stdin: []byte("caller-stdin")})
+		if string(inner.gotOpts.Stdin) != "caller-stdin" {
+			t.Fatalf("Stdin = %q, want 'caller-stdin'", inner.gotOpts.Stdin)
+		}
+	})
+	t.Run("nil falls back", func(t *testing.T) {
+		inner := &recordingRunner{}
+		r := sandbox.WithDefaults(inner, sandbox.ExecOptions{Stdin: []byte("default-stdin")})
+
+		_, _ = r.Exec(context.Background(), "echo", nil, sandbox.ExecOptions{})
+		if string(inner.gotOpts.Stdin) != "default-stdin" {
+			t.Fatalf("Stdin = %q, want 'default-stdin'", inner.gotOpts.Stdin)
+		}
+	})
+}
+
+func TestWithDefaults_Timeout_MinRule(t *testing.T) {
+	// The four corners of (caller, default) × (zero, positive) plus
+	// the actual narrowing case. Locked down because timeout is the
+	// one place defaults act as a ceiling — any future refactor that
+	// flips min() to max() would silently let tools escape the
+	// sandbox-imposed window.
+	tests := []struct {
+		name       string
+		callerTO   time.Duration
+		defaultTO  time.Duration
+		wantMerged time.Duration
+	}{
+		{"both zero", 0, 0, 0},
+		{"caller zero, default non-zero", 0, 5 * time.Second, 5 * time.Second},
+		{"caller non-zero, default zero", 3 * time.Second, 0, 3 * time.Second},
+		{"caller narrows", 2 * time.Second, 5 * time.Second, 2 * time.Second},
+		{"caller would broaden — default wins (ceiling)", 10 * time.Second, 4 * time.Second, 4 * time.Second},
+		{"equal", 5 * time.Second, 5 * time.Second, 5 * time.Second},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			inner := &recordingRunner{}
+			r := sandbox.WithDefaults(inner, sandbox.ExecOptions{Timeout: tc.defaultTO})
+
+			_, _ = r.Exec(context.Background(), "echo", nil, sandbox.ExecOptions{Timeout: tc.callerTO})
+			if inner.gotOpts.Timeout != tc.wantMerged {
+				t.Fatalf("Timeout = %v, want %v", inner.gotOpts.Timeout, tc.wantMerged)
+			}
+		})
+	}
+}
+
+func TestWithDefaults_Env_AllowDefaultsAlwaysWins(t *testing.T) {
+	// Allow-list narrowing at call time is not actionable for this
+	// MVP (defaults owns the list); the contract is that the inner
+	// Runner sees defaults.Allow regardless of what the caller
+	// supplied. This protects against a buggy / malicious tool
+	// trying to widen the host-env view by passing
+	// Env.Allow=[..., "SECRET_KEY"].
+	defaults := sandbox.EnvPolicy{Allow: []string{"PATH", "HOME"}}
+
+	tests := []struct {
+		name        string
+		callerAllow []string
+		want        []string
+	}{
+		{"nil caller", nil, []string{"PATH", "HOME"}},
+		{"empty caller", []string{}, []string{"PATH", "HOME"}},
+		{"caller tries to widen", []string{"PATH", "HOME", "SECRET_KEY"}, []string{"PATH", "HOME"}},
+		{"caller tries to narrow", []string{"PATH"}, []string{"PATH", "HOME"}},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			inner := &recordingRunner{}
+			r := sandbox.WithDefaults(inner, sandbox.ExecOptions{Env: defaults})
+
+			_, _ = r.Exec(context.Background(), "echo", nil, sandbox.ExecOptions{
+				Env: sandbox.EnvPolicy{Allow: tc.callerAllow},
+			})
+			if !reflect.DeepEqual(inner.gotOpts.Env.Allow, tc.want) {
+				t.Fatalf("Env.Allow = %v, want %v", inner.gotOpts.Env.Allow, tc.want)
+			}
+		})
+	}
+}
+
+func TestWithDefaults_Env_InjectUnion_CallerWinsOnConflict(t *testing.T) {
+	defaults := sandbox.EnvPolicy{
+		Inject: map[string]string{
+			"SANDBOX_ID": "default-id",
+			"REGION":     "us-east",
+		},
+	}
+	inner := &recordingRunner{}
+	r := sandbox.WithDefaults(inner, sandbox.ExecOptions{Env: defaults})
+
+	_, _ = r.Exec(context.Background(), "echo", nil, sandbox.ExecOptions{
+		Env: sandbox.EnvPolicy{
+			Inject: map[string]string{
+				"SANDBOX_ID": "caller-id", // collision — caller wins
+				"RUN_ID":     "abc123",    // new key — appended
+			},
+		},
+	})
+
+	got := inner.gotOpts.Env.Inject
+	want := map[string]string{
+		"SANDBOX_ID": "caller-id",
+		"REGION":     "us-east",
+		"RUN_ID":     "abc123",
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("Env.Inject = %v, want %v", got, want)
+	}
+}
+
+func TestWithDefaults_Env_InjectBothEmpty_StaysEmpty(t *testing.T) {
+	// Guard against a regression where we always allocate a map
+	// for the merged Inject (would surface as Env.Inject == empty
+	// non-nil map vs. nil — the LocalRunner treats both the same,
+	// but downstream observers / serialisers may not).
+	inner := &recordingRunner{}
+	r := sandbox.WithDefaults(inner, sandbox.ExecOptions{})
+
+	_, _ = r.Exec(context.Background(), "echo", nil, sandbox.ExecOptions{})
+	if inner.gotOpts.Env.Inject != nil {
+		t.Fatalf("Env.Inject = %v, want nil when both sides are empty", inner.gotOpts.Env.Inject)
+	}
+}
+
+func TestWithDefaults_Net_DefaultsOnly(t *testing.T) {
+	// NetPolicy is sandbox-level policy: the caller cannot weaken
+	// (e.g. switch DenyAll → Default) or strengthen (Default →
+	// DenyAll only to escape an AllowList). Tools that want a
+	// different posture run against a different Sandbox resource.
+	defaults := sandbox.NetPolicy{Mode: sandbox.NetDenyAll}
+	inner := &recordingRunner{}
+	r := sandbox.WithDefaults(inner, sandbox.ExecOptions{Net: defaults})
+
+	_, _ = r.Exec(context.Background(), "echo", nil, sandbox.ExecOptions{
+		Net: sandbox.NetPolicy{Mode: sandbox.NetDefault, AllowHosts: []string{"any.host"}},
+	})
+	if inner.gotOpts.Net.Mode != sandbox.NetDenyAll {
+		t.Fatalf("Net.Mode = %v, want NetDenyAll (defaults must win)", inner.gotOpts.Net.Mode)
+	}
+	if len(inner.gotOpts.Net.AllowHosts) != 0 {
+		t.Fatalf("Net.AllowHosts = %v, want empty (caller AllowHosts should be ignored)", inner.gotOpts.Net.AllowHosts)
+	}
+}
+
+func TestWithDefaults_Resources_DefaultsOnly(t *testing.T) {
+	defaults := sandbox.ResourceLimits{
+		CPUMillicores:  500,
+		MemoryBytes:    256 << 20,
+		DiskBytes:      1 << 30,
+		MaxOutputBytes: 1 << 20,
+	}
+	inner := &recordingRunner{}
+	r := sandbox.WithDefaults(inner, sandbox.ExecOptions{Resources: defaults})
+
+	_, _ = r.Exec(context.Background(), "echo", nil, sandbox.ExecOptions{
+		Resources: sandbox.ResourceLimits{
+			CPUMillicores:  8000,      // tool would never get to raise CPU
+			MemoryBytes:    16 << 30,  // ... or memory
+			MaxOutputBytes: 100 << 20, // ... or output cap
+		},
+	})
+	if !reflect.DeepEqual(inner.gotOpts.Resources, defaults) {
+		t.Fatalf("Resources = %+v, want defaults %+v (caller must not raise caps)", inner.gotOpts.Resources, defaults)
+	}
+}
+
+func TestWithDefaults_DefaultsNotMutated(t *testing.T) {
+	// Multiple Exec calls must not see each other through shared
+	// state. The merge path allocates a fresh map for Env.Inject
+	// rather than mutating defaults.Inject — this test pins that
+	// guarantee.
+	defaults := sandbox.ExecOptions{
+		Env: sandbox.EnvPolicy{
+			Inject: map[string]string{"REGION": "us-east"},
+		},
+	}
+	inner := &recordingRunner{}
+	r := sandbox.WithDefaults(inner, defaults)
+
+	_, _ = r.Exec(context.Background(), "echo", nil, sandbox.ExecOptions{
+		Env: sandbox.EnvPolicy{Inject: map[string]string{"RUN_ID": "first"}},
+	})
+	_, _ = r.Exec(context.Background(), "echo", nil, sandbox.ExecOptions{
+		Env: sandbox.EnvPolicy{Inject: map[string]string{"RUN_ID": "second"}},
+	})
+
+	// defaults.Env.Inject must still be exactly what we passed in.
+	if !reflect.DeepEqual(defaults.Env.Inject, map[string]string{"REGION": "us-east"}) {
+		t.Fatalf("defaults.Env.Inject mutated: got %v", defaults.Env.Inject)
+	}
+	// The second call's inner.gotOpts must NOT carry the first
+	// call's RUN_ID — proves the merged map is per-call.
+	if inner.gotOpts.Env.Inject["RUN_ID"] != "second" {
+		t.Fatalf("second call RUN_ID = %q, want 'second' (cross-call leak suspected)", inner.gotOpts.Env.Inject["RUN_ID"])
+	}
+}
+
+func TestWithDefaults_EmptyCallerOpts(t *testing.T) {
+	// The "all-defaults" path: caller passes a bare ExecOptions{}.
+	// Every field on the merged result must come from defaults.
+	// Guards the "this is what a Tool that knows nothing about
+	// sandbox policy will pass" call shape.
+	defaults := sandbox.ExecOptions{
+		WorkDir: "/work",
+		Stdin:   []byte("default-stdin"),
+		Timeout: 7 * time.Second,
+		Env: sandbox.EnvPolicy{
+			Allow:  []string{"PATH"},
+			Inject: map[string]string{"REGION": "us-east"},
+		},
+		Net:       sandbox.NetPolicy{Mode: sandbox.NetDenyAll},
+		Resources: sandbox.ResourceLimits{MaxOutputBytes: 1 << 20},
+	}
+	inner := &recordingRunner{}
+	r := sandbox.WithDefaults(inner, defaults)
+
+	_, _ = r.Exec(context.Background(), "echo", nil, sandbox.ExecOptions{})
+
+	if inner.gotOpts.WorkDir != defaults.WorkDir {
+		t.Errorf("WorkDir = %q, want %q", inner.gotOpts.WorkDir, defaults.WorkDir)
+	}
+	if string(inner.gotOpts.Stdin) != string(defaults.Stdin) {
+		t.Errorf("Stdin = %q, want %q", inner.gotOpts.Stdin, defaults.Stdin)
+	}
+	if inner.gotOpts.Timeout != defaults.Timeout {
+		t.Errorf("Timeout = %v, want %v", inner.gotOpts.Timeout, defaults.Timeout)
+	}
+	if !reflect.DeepEqual(inner.gotOpts.Env.Allow, defaults.Env.Allow) {
+		t.Errorf("Env.Allow = %v, want %v", inner.gotOpts.Env.Allow, defaults.Env.Allow)
+	}
+	if !reflect.DeepEqual(inner.gotOpts.Env.Inject, defaults.Env.Inject) {
+		t.Errorf("Env.Inject = %v, want %v", inner.gotOpts.Env.Inject, defaults.Env.Inject)
+	}
+	if inner.gotOpts.Net.Mode != defaults.Net.Mode {
+		t.Errorf("Net.Mode = %v, want %v", inner.gotOpts.Net.Mode, defaults.Net.Mode)
+	}
+	if inner.gotOpts.Resources != defaults.Resources {
+		t.Errorf("Resources = %+v, want %+v", inner.gotOpts.Resources, defaults.Resources)
+	}
+}
+
+func TestWithDefaults_ComposesWithAllowCommands(t *testing.T) {
+	// The documented inner-to-outer composition: LocalRunner →
+	// AllowCommands → WithDefaults. The whitelist gate fires before
+	// the inner Runner is reached, regardless of how rich the
+	// defaults are — so a blocked command never gets its
+	// ExecOptions merged at all.
+	inner := &recordingRunner{}
+	gated := sandbox.AllowCommands(inner, []string{"echo"})
+	r := sandbox.WithDefaults(gated, sandbox.ExecOptions{Timeout: 5 * time.Second})
+
+	if _, err := r.Exec(context.Background(), "rm", nil, sandbox.ExecOptions{}); err == nil {
+		t.Fatal("blocked command should still be rejected through the WithDefaults wrapper")
+	}
+	if inner.called {
+		t.Fatal("blocked command must not reach the inner runner")
+	}
+
+	if _, err := r.Exec(context.Background(), "echo", nil, sandbox.ExecOptions{}); err != nil {
+		t.Fatalf("allowed command should pass: %v", err)
+	}
+	if inner.gotOpts.Timeout != 5*time.Second {
+		t.Fatalf("Timeout = %v, want 5s (defaults should have been merged)", inner.gotOpts.Timeout)
 	}
 }
 


### PR DESCRIPTION
## Summary

First slice of v0.2.0 P0 \`kind: Sandbox\` work, scoped strictly to the **sdk layer** so the cmd/vesseld catalog PR that follows can pin this version via \`go.mod\` rather than relying on \`go.work\` shadowing.

- **New `WithDefaults(inner, defaults)` decorator.** Every \`Exec\` call's \`ExecOptions\` is merged with the captured defaults before reaching \`inner\`. This is the composition seam that lets vesseld Catalog fix a \`kind: Sandbox\` resource's Env / Net / Resources policy onto a Runner; tools then invoke that Runner with only behavioural knobs (cwd, stdin, per-call timeout).
- **Security-biased merge.** Policy fields (\`Env.Allow\` / \`Net\` / \`Resources\`) belong to defaults — a caller cannot widen them at call time. Behavioural fields (\`WorkDir\` / \`Stdin\`) belong to the caller, falling back to defaults when empty. **Timeout uses `min(caller, defaults)`** so defaults acts as a ceiling: a tool can ask for a shorter window than the sandbox grants, never a longer one. **`Env.Inject` is the one union point**, where caller entries override defaults on key collision so tools can layer per-call context (\`RUN_ID\`, ...) on top of static sandbox injections.
- **No shared state across calls.** The merge path allocates a fresh \`Inject\` map per Exec rather than aliasing \`defaults.Env.Inject\`. Pinned by \`TestWithDefaults_DefaultsNotMutated\` (two consecutive calls with different \`RUN_ID\`, defaults untouched, no cross-call leak).
- **Composition rule documented and tested.** Inner-to-outer ordering is \`LocalRunner → AllowCommands → WithDefaults\`; \`TestWithDefaults_ComposesWithAllowCommands\` verifies that the whitelist gate fires before the merge so a blocked command never gets its ExecOptions touched.

## Why this isn't bundled with the cmd/vesseld catalog PR

Per the dependency-ordered PR rule we adopted: each PR touches exactly one module layer (\`sdk\`, then \`sdkx\` + \`vessel\`, then \`cmd/vesseld\`). The cmd/vesseld \`kind: Sandbox\` work needs \`WithDefaults\` to exist as a published API in \`sdk/sandbox\`, so this lands first and gets tagged (target: \`sdk/v0.3.8\`); cmd/vesseld then bumps its \`sdk\` dependency to pick it up — same shape as PR #121's \`chore(sdkx): bump sdk v0.3.6 -> v0.3.7\`.

## Test plan

- [x] \`go vet ./sdk/sandbox/...\` — clean
- [x] \`go test ./sdk/sandbox/... -v -run WithDefaults\` — **23 sub-tests** pass, covering:
  - \`WorkDir\` caller-wins / empty-fallback
  - \`Stdin\` caller-wins / nil-fallback
  - **\`Timeout\` matrix** (6 sub-cases): both zero, single-side zero, narrowing, broadening blocked by ceiling, equal
  - **\`Env.Allow\` defaults-only** (4 sub-cases): nil caller, empty caller, attempted widen, attempted narrow — all collapse to defaults
  - \`Env.Inject\` union with caller-wins-on-conflict
  - \`Env.Inject\` both-empty-stays-nil (guards the alloc-elision branch)
  - \`Net\` defaults-only (Mode + AllowHosts both come from defaults)
  - \`Resources\` defaults-only (caller cannot raise CPU/Mem/MaxOutputBytes caps)
  - Defaults not mutated across multiple Exec calls
  - Empty-caller path: every field falls back to defaults
  - Composes correctly with \`AllowCommands\` (whitelist gate fires before merge)
- [x] Full \`sdk\` test sweep — 41 packages green, no regression in adjacent areas
- [x] Downstream module builds (\`sdkx\`, \`vessel\`, \`voice\`, \`cmd/vesseld\`) all clean — no consumer impact yet because the API is purely additive

## Follow-ups (separate PRs per the dependency-ordered plan)

1. **cmd/vesseld \`kind: Sandbox\` apispec + catalog + resolver** (Layer 3) — pins \`sdk/v0.3.8\` and consumes \`WithDefaults\` from the Catalog
2. \`sdkx/sandbox/nsjail\` backend (Layer 2, independent) — lets non-\`NetDefault\` \`Net\` and CPU/mem/disk caps actually enforce
3. sdk doc cleanup follow-up (Layer 1, independent) — scrubs \`sdkx/llm\` references from \`sdk/telemetry/\` and \`sdk/llm/metrics.go\`

Refs: \`internal-docs/roadmap.md\` §2 v0.2.0

Made with [Cursor](https://cursor.com)