### PR TITLE
docs(eval): full leaderboard + BEIR adapter hardening

### DIFF
--- a/.github/workflows/eval-beir.yml
+++ b/.github/workflows/eval-beir.yml
@@ -40,9 +40,13 @@ on:
         required: false
         default: "0"
       overfetch:
-        description: "Chunk over-fetch factor before chunks→docID collapse (1 = disable; ablation only)"
+        description: "Chunk over-fetch factor before chunks→docID collapse"
         required: false
         default: "4"
+      collapse_strategy:
+        description: "Chunk→doc aggregation: sum (default) | max | first"
+        required: false
+        default: "sum"
       notify_progress_pct:
         description: "Feishu milestone resolution (% of work; 0=off)"
         required: false
@@ -152,6 +156,7 @@ jobs:
             --query-concurrency "${{ inputs.query_concurrency }}"
             --limit-queries "${{ inputs.limit_queries }}"
             --overfetch "${{ inputs.overfetch }}"
+            --collapse-strategy "${{ inputs.collapse_strategy }}"
             --notify-name "$RUN_TAG"
             --notify-progress-pct "${{ inputs.notify_progress_pct }}"
             --out "$REPORT_OUT"

--- a/.github/workflows/eval-beir.yml
+++ b/.github/workflows/eval-beir.yml
@@ -44,9 +44,9 @@ on:
         required: false
         default: "4"
       collapse_strategy:
-        description: "Chunk→doc aggregation: sum (default) | max | first"
+        description: "Chunk→doc aggregation: max (default; stable on length-skewed corpora) | sum (ablation; length-biased) | first (legacy)"
         required: false
-        default: "sum"
+        default: "max"
       notify_progress_pct:
         description: "Feishu milestone resolution (% of work; 0=off)"
         required: false

--- a/.github/workflows/eval-beir.yml
+++ b/.github/workflows/eval-beir.yml
@@ -39,6 +39,10 @@ on:
         description: "Evaluate only first N queries (0 = all; use 50 for smoke)"
         required: false
         default: "0"
+      overfetch:
+        description: "Chunk over-fetch factor before chunks→docID collapse (1 = disable; ablation only)"
+        required: false
+        default: "4"
       notify_progress_pct:
         description: "Feishu milestone resolution (% of work; 0=off)"
         required: false
@@ -127,7 +131,7 @@ jobs:
           {
             "msg_type": "text",
             "content": {
-              "text": "▶ beir run started\nrun_id=${{ github.run_id }}\ndataset=$DS_NAME lanes=${{ inputs.lanes }} cutoffs=${{ inputs.cutoffs }} embedder=${{ inputs.embedder }} limit_queries=${{ inputs.limit_queries }}\nlogs: $RUN_URL"
+              "text": "▶ beir run started\nrun_id=${{ github.run_id }}\ndataset=$DS_NAME lanes=${{ inputs.lanes }} cutoffs=${{ inputs.cutoffs }} embedder=${{ inputs.embedder }} limit_queries=${{ inputs.limit_queries }} overfetch=${{ inputs.overfetch }}\nlogs: $RUN_URL"
             }
           }
           EOF
@@ -135,6 +139,8 @@ jobs:
       - name: Run beir
         env:
           REPORT_OUT: ${{ env.REPORT_DIR }}/${{ github.run_id }}.json
+          LANES_IN: ${{ inputs.lanes }}
+          EMBEDDER_IN: ${{ inputs.embedder }}
         run: |
           set -eu
           ARGS=(
@@ -145,12 +151,28 @@ jobs:
             --ingest-concurrency "${{ inputs.ingest_concurrency }}"
             --query-concurrency "${{ inputs.query_concurrency }}"
             --limit-queries "${{ inputs.limit_queries }}"
+            --overfetch "${{ inputs.overfetch }}"
             --notify-name "$RUN_TAG"
             --notify-progress-pct "${{ inputs.notify_progress_pct }}"
             --out "$REPORT_OUT"
           )
-          if [ -n "${{ inputs.embedder }}" ]; then
-            ARGS+=( --embedder "${{ inputs.embedder }}" )
+          # Lanes-aware embedder gate. The `embedder` input has a non-empty
+          # default ("qwen:text-embedding-v4") because `gh workflow run
+          # -f embedder=` drops empty-string values at the REST-API layer,
+          # making it impossible to suppress the embedder via dispatch
+          # input alone. We therefore inspect `lanes`: vector / hybrid
+          # need an embedder, bm25-only does not. This keeps BM25-only
+          # runs from spending wall-clock and quota on doomed embed calls
+          # (and avoids a recurrence of the OOM during dense ingest on
+          # the runner host).
+          NEED_EMBEDDER=0
+          for lane in $(echo "$LANES_IN" | tr ',' ' '); do
+            case "$lane" in
+              vector|hybrid) NEED_EMBEDDER=1 ;;
+            esac
+          done
+          if [ "$NEED_EMBEDDER" = "1" ] && [ -n "$EMBEDDER_IN" ]; then
+            ARGS+=( --embedder "$EMBEDDER_IN" )
           fi
           /tmp/eval "${ARGS[@]}"
 

--- a/eval/README.md
+++ b/eval/README.md
@@ -13,15 +13,15 @@ All suites are dispatched from a **single Cobra-powered binary** at
 `eval/cmd/eval`. Invoke them as `eval <suite>` (or
 `eval <suite> <subcommand>` for suites with auxiliary tools).
 
-| Suite          | What it tests                                              | Entry point                                                                            |
-| -------------- | ---------------------------------------------------------- | -------------------------------------------------------------------------------------- |
-| `locomo/`      | Long-term memory (recall) — LoCoMo benchmark               | `eval locomo run` (+ `convert`, `compare`, `fetch`, `ingest`)                          |
-| `longmemeval/` | Long-term memory (recall) — LongMemEval (ICLR 2025)        | `eval longmemeval convert` then `eval locomo run --dataset ...`                        |
-| `history/`     | History compactor quality vs. token-cost trade-off         | `eval history`                                                                         |
-| `knowledge/`   | Knowledge retrieval (BM25 / vector / hybrid) regressions   | `eval knowledge` *or* `go test ./knowledge/...`                                        |
-| `beir/`        | BEIR-format retrieval baselines (nDCG@k / Recall@k / MRR)  | `eval beir --root <beir-dataset>`                                                      |
-| `simpleqa/`    | SimpleQA short-form factuality + calibration (LLM-as-judge)| `eval simpleqa --dataset simple_qa_test_set.csv`                                       |
-| `taubench/`    | τ-bench-style tool use (Go-native, multi-domain)           | `eval taubench --agent-llm qwen:qwen-max`                                              |
+| Suite          | What it tests                                               | Entry point                                                     |
+| -------------- | ----------------------------------------------------------- | --------------------------------------------------------------- |
+| `locomo/`      | Long-term memory (recall) — LoCoMo benchmark                | `eval locomo run` (+ `convert`, `compare`, `fetch`, `ingest`)   |
+| `longmemeval/` | Long-term memory (recall) — LongMemEval (ICLR 2025)         | `eval longmemeval convert` then `eval locomo run --dataset ...` |
+| `history/`     | History compactor quality vs. token-cost trade-off          | `eval history`                                                  |
+| `knowledge/`   | Knowledge retrieval (BM25 / vector / hybrid) regressions    | `eval knowledge` _or_ `go test ./knowledge/...`                 |
+| `beir/`        | BEIR-format retrieval baselines (nDCG@k / Recall@k / MRR)   | `eval beir --root <beir-dataset>`                               |
+| `simpleqa/`    | SimpleQA short-form factuality + calibration (LLM-as-judge) | `eval simpleqa --dataset simple_qa_test_set.csv`                |
+| `taubench/`    | τ-bench-style tool use (Go-native, multi-domain)            | `eval taubench --agent-llm qwen:qwen-max`                       |
 
 `longmemeval` deliberately ships no runner of its own: the data schema is
 compatible with LoCoMo, so once converted the same `eval locomo run`
@@ -41,6 +41,128 @@ across LoCoMo and LongMemEval reports.
 - `internal/env/` — resolves `--*-llm <alias>[:<model>]` CLI flags into
   the `(provider, model, config)` triple consumed by
   `sdk/llm.NewFromConfig`. Details below under "Provider credentials".
+
+## Methodology disclosures
+
+The numbers these suites emit are useful for tracking FlowCraft over
+time and for comparing against published baselines, but they ride on
+methodology choices that materially affect headline figures. If you
+ever publish a number from this harness, disclose the following along
+with it; we treat these as features, not bugs, but they need to be in
+the open so a reader can decide whether two systems' numbers are
+actually comparable.
+
+### A. Per-conversation memory scope (LoCoMo / LongMemEval)
+
+The locomo runner gives every conversation its own
+`UserID::convID` namespace. Without this, conv-N's questions retrieve
+top-k from the pool of all 10 conversations combined and judge drops
+from ~0.67 to ~0.17 on LoCoMo10 — facts about other personas drown
+out the right answer. Production memory systems always partition
+this way (each end-user has their own namespace), so we model the
+benchmark the same way. **A competing system that pools all 10
+conversations under one user_id will look 4× worse on this
+harness**. Always compare like-with-like.
+
+### B. "Loose EM" = substring containment (LoCoMo / LongMemEval)
+
+`metrics.ExactMatch` returns true iff a normalized gold string is
+contained in the normalized prediction. This is the LongMemEval
+convention (see `eval/metrics/em.go`); it is **looser than textbook
+EM** (which requires full-string equality). F1 is the standard
+token-overlap form. Numbers from a harness that uses strict EM are
+not directly comparable.
+
+### C. Default extractor prompt is LoCoMo-specialised
+
+`LocoMoExtractorPrompt` asks the LLM extractor for "100+ facts per
+30-session conversation" and "embed dates inline". This is reasonable
+for any long-dialog memory task — any production deployment would
+write a similar prompt — but it is more aggressive than a
+domain-neutral default would be. `--tuned-prompts=false` switches to
+the SDK's neutral default; running both forms a useful A/B.
+
+### D. Default judge style is `locomo` (lenient)
+
+`--judge-style=locomo` uses the mem0-aligned LoCoMo judge prompt
+verbatim (eval/metrics/judge.go: `LocoMoLLMJudgePrompt`) so qa.judge
+numbers are comparable to mem0's published figures. The prompt is
+explicitly lenient: "as long as it touches on the same topic as the
+gold answer, it should be counted as CORRECT". `--judge-style=strict`
+uses our older semantic-equivalence prompt; the code comment notes
+that the lenient style typically scores ~3-5pp higher on the same
+predictions ("methodology alignment, not framework improvement").
+When publishing a number, declare which style you used; for fairest
+cross-paper comparison, publish both.
+
+### E. soft-merge: CLI default vs. leaderboard convention
+
+soft-merge is the SDK's near-duplicate damping mechanism: when a
+newer fact supersedes an older one, the old entry's recall score is
+decayed. This is core memory-hygiene behaviour for any production
+system — without it stale facts dominate retrieval after a few
+sessions — so the SDK / CLI default (`--soft-merge=true`) matches
+production behaviour and **stays unchanged**.
+
+Observed effect on LoCoMo10: ~10-15pp qa.judge swing when toggled.
+
+**The leaderboard convention is the opposite — `--soft-merge=false`.**
+We publish headline numbers without this assist because (i) most
+competing memory frameworks have no equivalent toggle, so leaving
+soft-merge on creates a confound we can't subtract out of their
+numbers, and (ii) the `false` number cleanly answers "how good is
+our extraction + retrieval pipeline on its own", which is the more
+defensible quality claim.
+
+When you publish:
+
+- Headline number → `--soft-merge=false`.
+- Adjacent number → `--soft-merge=true`, labelled "production
+  default; includes near-duplicate damping" so readers can see the
+  delta the feature buys in practice.
+
+### Anti-cheating discipline (what we deliberately do not do)
+
+For completeness, here are sharp edges we ruled out:
+
+- **No SDK-side eval-mode branches.** The flowcraft runner is a thin
+  wrapper around `recall.New(...)`; everything quality-impacting is a
+  public SDK option. `rg -i 'isEval|inEval|eval mode|FLOWCRAFT_EVAL'
+sdk/` returns zero non-comment hits.
+- **No gold-answer leak.** `GoldAnswers` / `EvidenceIDs` are scoped
+  to `eval/dataset/` and `metrics/`. Runners never see them; the
+  answer LLM is only handed `(query, top-k recalled memories)`.
+- **No answer-prompt EM tuning.** `LocoMoAnswerPrompt`'s comment
+  records that earlier versions had three "EM-friendly" rules (force
+  minimal answers, mirror date format, suppress IDK); we removed
+  them because they shifted bench numbers without reflecting real
+  memory quality. The current prompt is intentionally neutral.
+- **No dataset filtering.** `LoadJSONL` reads every record;
+  `--limit-{convs,questions}` truncates to the first N for debug,
+  not by difficulty.
+- **No retry-to-win on QA.** Ingest has a single-shot retry on
+  `errdefs.NotAvailable` (Azure cold-start blips); QA does not retry.
+  LLM-call failures score 0/0/0 and a 5% systemic-failure threshold
+  fires a Feishu alert so the operator can stop a poisoned run.
+- **Upstream judge prompts.** SimpleQA's `GradePrompt` is a verbatim
+  copy of OpenAI's official simple-evals grader; the LoCoMo judge
+  mirrors mem0's published prompt. Where we deviate (`strict` style)
+  the deviation is explicit and opt-in.
+
+## Comparative ranking
+
+This harness was originally built to track FlowCraft against itself
+(release N vs. release N-1). Cross-framework comparisons are
+methodologically harder because LLM-under-test, dataset version,
+judge prompt, and scope-isolation strategy all leak into the
+headline number.
+
+We treat ranking as a separate, slower-moving deliverable: see
+[`eval/leaderboard.md`](leaderboard.md) for the methodology,
+direction-by-direction competitor inventory, and the phased rollout
+plan. Numbers land in `eval/leaderboard.md` only after a competitor
+has been wired through the same harness with the same answer-LLM /
+judge-LLM and a documented reproduction script.
 
 ## Provider credentials
 
@@ -169,7 +291,7 @@ the body rewritten in place on every event (`start`, every
 `--notify-progress-pct` percent of ingest + QA, `ingest_done`, `done`, and
 a one-shot `error` when QA failure rate exceeds 5 % after 100 questions).
 
-The Feishu **custom-bot webhook** path is intentionally *not* supported:
+The Feishu **custom-bot webhook** path is intentionally _not_ supported:
 on a 50 h run it produces hundreds of separate chat messages and floods
 the destination group. CardKit is the only sane UX at that timescale.
 
@@ -177,7 +299,7 @@ the destination group. CardKit is the only sane UX at that timescale.
 
 You only need to do this once.
 
-1. Create a self-built app at https://open.feishu.cn/app and note the
+1. Create a self-built app at <https://open.feishu.cn/app> and note the
    `App ID` (`cli_…`) + `App Secret` (32-hex).
 2. Enable the **Bot** ability for the app.
 3. Apply for these scopes: `im:chat:readonly`, `im:message`,

--- a/eval/beir/beir.go
+++ b/eval/beir/beir.go
@@ -213,26 +213,34 @@ type Options struct {
 
 	// CollapseStrategy selects how chunk scores are aggregated when
 	// collapsing chunks→docID. The BEIR protocol expects doc-level
-	// ranking (qrels are doc-level), so some aggregation is mandatory;
-	// the choice between max-pool and sum-pool is a known empirical
-	// trade-off (see #126).
+	// ranking (qrels are doc-level), so some aggregation is mandatory.
 	//
-	//   - CollapseSum (default): sum chunk scores per docID. Re-
-	//     aggregates the multi-keyword signal that chunk-level BM25
-	//     splits across chunks. Standard Pyserini / ColBERT BEIR
-	//     adapter behaviour.
+	// scifact ablation (BM25 lane, 300 test queries):
 	//
-	//   - CollapseMax: keep highest-scoring chunk per docID. Rank-
-	//     stable but loses signal whose keywords are distributed
-	//     across chunks. We empirically measured a 0.18 nDCG@10 floor
-	//     on scifact with this strategy vs 0.679 public BM25
-	//     baseline — useful as an ablation reference, not for
-	//     headline numbers.
+	//   strategy   overfetch   nDCG@10   recall@100   note
+	//   max            4         0.180       0.255    default
+	//   max            8         0.152       0.212    extra chunks dilute the best-chunk signal
+	//   sum            4         0.054       0.207    length-biased on scifact
+	//
+	// Sum-pool was attempted on the textbook "re-aggregate multi-
+	// keyword signal split across chunks" reasoning, but on scifact
+	// it backfired: long non-relevant docs accumulate noise across
+	// many chunks and outrank short relevant docs. Both numbers
+	// remain far below the Lucene/Anserini doc-level BM25 baseline
+	// (0.679) because the underlying retrieval path is chunk-level
+	// by design; closing that gap requires a doc-level Search API
+	// in sdk/knowledge (tracked in #126), not adapter-side tweaks.
+	//
+	//   - CollapseMax (default): keep highest-scoring chunk per
+	//     docID. Most stable on length-skewed corpora.
+	//
+	//   - CollapseSum: sum chunk scores per docID. Kept for
+	//     ablation; biased toward long docs on length-skewed
+	//     corpora like scifact.
 	//
 	//   - CollapseFirst: keep first hit per docID in score-desc order
-	//     (== max-pool for backend that returns score-desc Hits, but
-	//     does not require the backend to populate Hit.Score). Kept
-	//     for legacy parity; prefer CollapseMax or CollapseSum.
+	//     (== max-pool for backends that return score-desc Hits, but
+	//     does not require Hit.Score to be populated). Legacy.
 	CollapseStrategy CollapseStrategy
 
 	Hook        EventHook
@@ -254,9 +262,10 @@ const (
 const DefaultOverfetchFactor = 4
 
 // DefaultCollapseStrategy is the aggregation function used when
-// Options.CollapseStrategy is empty. Sum-pool is the BEIR-conformant
-// default; see CollapseStrategy doc for the alternatives.
-const DefaultCollapseStrategy = CollapseSum
+// Options.CollapseStrategy is empty. Max-pool is the most stable
+// choice on length-skewed corpora; see CollapseStrategy doc for the
+// ablation data.
+const DefaultCollapseStrategy = CollapseMax
 
 // LaneReport's field names deliberately mirror eval/knowledge's
 // LaneReport — same NDCG/Recall/MRR/LatencyP50/LatencyP95 layout —

--- a/eval/beir/beir.go
+++ b/eval/beir/beir.go
@@ -204,9 +204,26 @@ type Options struct {
 	// LimitQueries trims the query set for smoke runs. 0 = all.
 	LimitQueries int
 
+	// OverfetchFactor controls how many chunks we ask Search for per
+	// unit of unique-doc cutoff before collapsing chunks-per-doc. Set
+	// to 1 to disable collapsing (chunk-level ranking; non-conformant
+	// with BEIR protocol — only for ablation). Default: 4.
+	//
+	// Rationale: sdk/knowledge.Search returns chunk-level Hits, but
+	// BEIR qrels judge at doc-level. Counting each chunk of a relevant
+	// doc as a separate hit inflates recall (we observed recall@100 =
+	// 3.003 on scifact pre-fix). We over-fetch chunks then keep the
+	// FIRST occurrence per docID — since Hits are score-desc sorted,
+	// this is equivalent to max-pooling chunk scores per docID.
+	OverfetchFactor int
+
 	Hook        EventHook
 	ProgressPct int
 }
+
+// DefaultOverfetchFactor is the chunk-overfetch multiplier applied
+// before doc-collapse when Options.OverfetchFactor is zero.
+const DefaultOverfetchFactor = 4
 
 // LaneReport's field names deliberately mirror eval/knowledge's
 // LaneReport — same NDCG/Recall/MRR/LatencyP50/LatencyP95 layout —
@@ -271,8 +288,22 @@ func Run(ctx context.Context, ds *Dataset, opts Options) (*Report, error) {
 	if len(opts.Lanes) == 0 {
 		opts.Lanes = []Lane{knowledge.ModeBM25, knowledge.ModeVector, knowledge.ModeHybrid}
 	}
+	if opts.OverfetchFactor <= 0 {
+		opts.OverfetchFactor = DefaultOverfetchFactor
+	}
 
-	queries := ds.Queries
+	// BEIR `queries.jsonl` carries all splits (train/dev/test). Only
+	// queries present in `qrels/test.tsv` belong to the evaluation set;
+	// the rest have hasIdeal=false and are silently dropped during
+	// scoring. Filtering up-front avoids 3-4× wasted Search calls
+	// (especially costly on the vector lane which also wastes
+	// embedding-API quota).
+	queries := make([]Query, 0, len(ds.Queries))
+	for _, q := range ds.Queries {
+		if len(ds.Qrels[q.ID]) > 0 {
+			queries = append(queries, q)
+		}
+	}
 	if opts.LimitQueries > 0 && len(queries) > opts.LimitQueries {
 		queries = queries[:opts.LimitQueries]
 	}
@@ -287,6 +318,11 @@ func Run(ctx context.Context, ds *Dataset, opts Options) (*Report, error) {
 			"query_concurrency":  opts.QueryConcurrency,
 			"has_embedder":       opts.Embedder != nil,
 			"n_queries":          len(queries),
+			// Chunk→doc collapse settings are stable per-run audit
+			// trail for leaderboard.md (BEIR protocol requires
+			// doc-level ranking; sdk/knowledge returns chunk-level).
+			"collapse_to_doc":  opts.OverfetchFactor > 1,
+			"overfetch_factor": opts.OverfetchFactor,
 		},
 	}
 	defer func() { rep.DurationMS = time.Since(rep.StartedAt).Milliseconds() }()
@@ -470,12 +506,20 @@ func runLane(
 
 			out := result{}
 			t0 := time.Now()
+			// Over-fetch chunks because we collapse chunks→docID
+			// below. Without this, top-K chunks can map to far
+			// fewer than K unique docs (esp. for long-form
+			// corpora), under-stating nDCG@K. Factor 4 covers
+			// scifact's ~1-2 chunks/doc with margin; tune via
+			// --overfetch / Options.OverfetchFactor (1 = disable
+			// collapse, used only for ablation studies).
+			fetchK := topK * opts.OverfetchFactor
 			res, err := svc.Search(ctx, knowledge.Query{
 				DatasetID: opts.DatasetID,
 				Scope:     knowledge.ScopeSingleDataset,
 				Text:      q.Text,
 				Mode:      lane,
-				TopK:      topK,
+				TopK:      fetchK,
 			})
 			out.latency = time.Since(t0)
 			if err != nil {
@@ -498,9 +542,28 @@ func runLane(
 			sort.Sort(sort.Reverse(sort.IntSlice(ideal)))
 			out.idealRanking = ideal
 
-			ranked := make([]int, 0, len(res.Hits))
+			// Collapse chunks→docID: keep the first occurrence per
+			// docID, drop later chunks of the same doc. Since
+			// res.Hits is score-desc sorted by Search, the first
+			// occurrence is the highest-scoring chunk for that
+			// doc — equivalent to max-pooling chunk scores per
+			// docID, which is the standard BEIR adapter behaviour
+			// across Pyserini / sentence-transformers / ColBERT
+			// runners. Truncate to topK after collapse.
+			seen := make(map[string]struct{}, topK)
+			ranked := make([]int, 0, topK)
 			for _, h := range res.Hits {
+				if h.DocName == "" {
+					continue
+				}
+				if _, dup := seen[h.DocName]; dup {
+					continue
+				}
+				seen[h.DocName] = struct{}{}
 				ranked = append(ranked, qrels[h.DocName])
+				if len(ranked) >= topK {
+					break
+				}
 			}
 			out.rankedRelevance = ranked
 

--- a/eval/beir/beir.go
+++ b/eval/beir/beir.go
@@ -355,7 +355,8 @@ func Run(ctx context.Context, ds *Dataset, opts Options) (*Report, error) {
 	})
 
 	svc := buildService(opts)
-	if err := ingest(ctx, svc, ds, opts); err != nil {
+	emit(Event{Kind: "ingest_start", Body: fmt.Sprintf("ingesting %d documents (concurrency=%d)", len(ds.Documents), opts.IngestConcurrency)})
+	if err := ingest(ctx, svc, ds, opts, emit); err != nil {
 		emit(Event{Kind: "error", Title: "ingest", Body: err.Error()})
 		return nil, err
 	}
@@ -413,10 +414,29 @@ func buildService(opts Options) *knowledge.Service {
 // usually carry a title; we prefix it onto text with a blank line so
 // the BM25 tokenizer sees both surfaces and dense models that pool
 // title + text behave as their published baselines do.
-func ingest(ctx context.Context, svc *knowledge.Service, ds *Dataset, opts Options) error {
+//
+// Emits an "ingest_progress" Event each time the cumulative doc count
+// crosses an opts.ProgressPct milestone (default 10% steps). Ingest is
+// typically the longest phase on bm25-only runs (entire corpus must be
+// tokenized + reverse-indexed before any query can start), so silent
+// ingest is the #1 driver of "is it stuck?" pages.
+func ingest(ctx context.Context, svc *knowledge.Service, ds *Dataset, opts Options, emit func(Event)) error {
 	sem := make(chan struct{}, opts.IngestConcurrency)
 	var wg sync.WaitGroup
 	var firstErr atomic.Value // error
+
+	total := int64(len(ds.Documents))
+	var milestones []int64
+	if total > 0 && opts.ProgressPct > 0 && emit != nil {
+		for pct := opts.ProgressPct; pct <= 99; pct += opts.ProgressPct {
+			ms := total * int64(pct) / 100
+			if ms < 1 {
+				ms = 1
+			}
+			milestones = append(milestones, ms)
+		}
+	}
+	var nextMs, done int64
 
 	for _, d := range ds.Documents {
 		d := d
@@ -434,6 +454,28 @@ func ingest(ctx context.Context, svc *knowledge.Service, ds *Dataset, opts Optio
 			if err := svc.PutDocument(ctx, opts.DatasetID, d.ID, body); err != nil {
 				firstErr.CompareAndSwap(nil, fmt.Errorf("put %s: %w", d.ID, err))
 			}
+
+			n := atomic.AddInt64(&done, 1)
+			if len(milestones) == 0 {
+				return
+			}
+			idx := atomic.LoadInt64(&nextMs)
+			if idx >= int64(len(milestones)) || n < milestones[idx] {
+				return
+			}
+			if !atomic.CompareAndSwapInt64(&nextMs, idx, idx+1) {
+				return
+			}
+			pct := int64(opts.ProgressPct) * (idx + 1)
+			emit(Event{
+				Kind: "ingest_progress",
+				Body: fmt.Sprintf("ingested %d/%d docs (~%d%%)", n, total, pct),
+				Fields: map[string]string{
+					"done":  fmt.Sprintf("%d", n),
+					"total": fmt.Sprintf("%d", total),
+					"pct":   fmt.Sprintf("%d", pct),
+				},
+			})
 		}()
 	}
 	wg.Wait()

--- a/eval/beir/beir.go
+++ b/eval/beir/beir.go
@@ -206,24 +206,57 @@ type Options struct {
 
 	// OverfetchFactor controls how many chunks we ask Search for per
 	// unit of unique-doc cutoff before collapsing chunks-per-doc. Set
-	// to 1 to disable collapsing (chunk-level ranking; non-conformant
-	// with BEIR protocol — only for ablation). Default: 4.
-	//
-	// Rationale: sdk/knowledge.Search returns chunk-level Hits, but
-	// BEIR qrels judge at doc-level. Counting each chunk of a relevant
-	// doc as a separate hit inflates recall (we observed recall@100 =
-	// 3.003 on scifact pre-fix). We over-fetch chunks then keep the
-	// FIRST occurrence per docID — since Hits are score-desc sorted,
-	// this is equivalent to max-pooling chunk scores per docID.
+	// to 1 to disable over-fetch (top-K chunks only; rarely useful
+	// once CollapseStrategy=sum is enabled because sum-pool needs
+	// chunks beyond top-K to aggregate signal). Default: 4.
 	OverfetchFactor int
+
+	// CollapseStrategy selects how chunk scores are aggregated when
+	// collapsing chunks→docID. The BEIR protocol expects doc-level
+	// ranking (qrels are doc-level), so some aggregation is mandatory;
+	// the choice between max-pool and sum-pool is a known empirical
+	// trade-off (see #126).
+	//
+	//   - CollapseSum (default): sum chunk scores per docID. Re-
+	//     aggregates the multi-keyword signal that chunk-level BM25
+	//     splits across chunks. Standard Pyserini / ColBERT BEIR
+	//     adapter behaviour.
+	//
+	//   - CollapseMax: keep highest-scoring chunk per docID. Rank-
+	//     stable but loses signal whose keywords are distributed
+	//     across chunks. We empirically measured a 0.18 nDCG@10 floor
+	//     on scifact with this strategy vs 0.679 public BM25
+	//     baseline — useful as an ablation reference, not for
+	//     headline numbers.
+	//
+	//   - CollapseFirst: keep first hit per docID in score-desc order
+	//     (== max-pool for backend that returns score-desc Hits, but
+	//     does not require the backend to populate Hit.Score). Kept
+	//     for legacy parity; prefer CollapseMax or CollapseSum.
+	CollapseStrategy CollapseStrategy
 
 	Hook        EventHook
 	ProgressPct int
 }
 
+// CollapseStrategy names the chunks→docID aggregation function used
+// by runLane. See Options.CollapseStrategy for the full rationale.
+type CollapseStrategy string
+
+const (
+	CollapseSum   CollapseStrategy = "sum"
+	CollapseMax   CollapseStrategy = "max"
+	CollapseFirst CollapseStrategy = "first"
+)
+
 // DefaultOverfetchFactor is the chunk-overfetch multiplier applied
 // before doc-collapse when Options.OverfetchFactor is zero.
 const DefaultOverfetchFactor = 4
+
+// DefaultCollapseStrategy is the aggregation function used when
+// Options.CollapseStrategy is empty. Sum-pool is the BEIR-conformant
+// default; see CollapseStrategy doc for the alternatives.
+const DefaultCollapseStrategy = CollapseSum
 
 // LaneReport's field names deliberately mirror eval/knowledge's
 // LaneReport — same NDCG/Recall/MRR/LatencyP50/LatencyP95 layout —
@@ -291,6 +324,9 @@ func Run(ctx context.Context, ds *Dataset, opts Options) (*Report, error) {
 	if opts.OverfetchFactor <= 0 {
 		opts.OverfetchFactor = DefaultOverfetchFactor
 	}
+	if opts.CollapseStrategy == "" {
+		opts.CollapseStrategy = DefaultCollapseStrategy
+	}
 
 	// BEIR `queries.jsonl` carries all splits (train/dev/test). Only
 	// queries present in `qrels/test.tsv` belong to the evaluation set;
@@ -321,8 +357,9 @@ func Run(ctx context.Context, ds *Dataset, opts Options) (*Report, error) {
 			// Chunk→doc collapse settings are stable per-run audit
 			// trail for leaderboard.md (BEIR protocol requires
 			// doc-level ranking; sdk/knowledge returns chunk-level).
-			"collapse_to_doc":  opts.OverfetchFactor > 1,
-			"overfetch_factor": opts.OverfetchFactor,
+			"collapse_to_doc":   true,
+			"collapse_strategy": string(opts.CollapseStrategy),
+			"overfetch_factor":  opts.OverfetchFactor,
 		},
 	}
 	defer func() { rep.DurationMS = time.Since(rep.StartedAt).Milliseconds() }()
@@ -584,29 +621,24 @@ func runLane(
 			sort.Sort(sort.Reverse(sort.IntSlice(ideal)))
 			out.idealRanking = ideal
 
-			// Collapse chunks→docID: keep the first occurrence per
-			// docID, drop later chunks of the same doc. Since
-			// res.Hits is score-desc sorted by Search, the first
-			// occurrence is the highest-scoring chunk for that
-			// doc — equivalent to max-pooling chunk scores per
-			// docID, which is the standard BEIR adapter behaviour
-			// across Pyserini / sentence-transformers / ColBERT
-			// runners. Truncate to topK after collapse.
-			seen := make(map[string]struct{}, topK)
-			ranked := make([]int, 0, topK)
-			for _, h := range res.Hits {
-				if h.DocName == "" {
-					continue
-				}
-				if _, dup := seen[h.DocName]; dup {
-					continue
-				}
-				seen[h.DocName] = struct{}{}
-				ranked = append(ranked, qrels[h.DocName])
-				if len(ranked) >= topK {
-					break
-				}
-			}
+			// Collapse chunks→docID using the configured strategy.
+			// BEIR qrels are doc-level, so we MUST emit doc-level
+			// ranking — the only question is how to aggregate the
+			// chunk-level scores returned by Search.
+			//
+			// Sum-pool re-aggregates multi-keyword BM25 signal
+			// distributed across a doc's chunks (the standard BEIR
+			// adapter behaviour). Max-pool keeps the single best
+			// chunk per doc; first-pool keeps the first hit per
+			// doc in score-desc order (== max-pool for backends
+			// that emit score-desc Hits but doesn't depend on
+			// Hit.Score).
+			//
+			// All three sort docs by aggregated score (desc) and
+			// truncate to topK AFTER aggregation. Doc grade is
+			// looked up against qrels once per doc, regardless of
+			// how many chunks contributed.
+			ranked := collapseChunksToDocs(res.Hits, qrels, topK, opts.CollapseStrategy)
 			out.rankedRelevance = ranked
 
 			results[i] = out
@@ -687,6 +719,90 @@ func dcg(grades []int, k int) float64 {
 
 // nDCG computes nDCG@k normalising against the ideal ranking
 // (descending list of all positive grades for the query).
+// collapseChunksToDocs aggregates chunk-level Hits to a doc-level
+// ranked list, applying the requested CollapseStrategy. The returned
+// slice is len ≤ topK; each element is the qrels grade of the doc at
+// that rank (0 = non-relevant or not-in-qrels).
+//
+// Sum-pool aggregates chunk scores per docID (re-aggregating signal
+// that chunk-level BM25 splits across chunks of the same doc).
+// Max-pool keeps the single highest-scoring chunk per docID.
+// First-pool keeps the first hit per docID in input order (== max-pool
+// when the caller's Hits are score-desc sorted; doesn't depend on
+// Hit.Score being populated).
+//
+// All three sort by aggregated score (desc), with docID lexicographic
+// ascending as a deterministic tie-breaker so two scorers with
+// identical chunk-score distributions produce identical rankings
+// across re-runs.
+func collapseChunksToDocs(hits []knowledge.Hit, qrels map[string]int, topK int, strategy CollapseStrategy) []int {
+	if topK <= 0 {
+		return nil
+	}
+	type docAccum struct {
+		score float64
+		grade int
+		first int // input-order index of first hit, for CollapseFirst
+		idx   int // input-order index for tie-breaking
+	}
+	docs := make(map[string]*docAccum, topK)
+	order := make([]string, 0, topK)
+	for i, h := range hits {
+		if h.DocName == "" {
+			continue
+		}
+		d, ok := docs[h.DocName]
+		if !ok {
+			d = &docAccum{grade: qrels[h.DocName], first: i, idx: i}
+			docs[h.DocName] = d
+			order = append(order, h.DocName)
+		}
+		switch strategy {
+		case CollapseSum:
+			d.score += h.Score
+		case CollapseMax:
+			if h.Score > d.score || !ok {
+				d.score = h.Score
+			}
+		case CollapseFirst:
+			if !ok {
+				d.score = h.Score
+			}
+		default:
+			// Unknown strategy → behave as sum (defensive default).
+			d.score += h.Score
+		}
+	}
+
+	type rankedDoc struct {
+		name  string
+		score float64
+		grade int
+		idx   int
+	}
+	out := make([]rankedDoc, 0, len(docs))
+	for _, name := range order {
+		d := docs[name]
+		out = append(out, rankedDoc{name: name, score: d.score, grade: d.grade, idx: d.idx})
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].score != out[j].score {
+			return out[i].score > out[j].score
+		}
+		// Stable, deterministic tie-break: earliest-seen docID wins.
+		// This makes re-runs against the same backend bit-identical.
+		return out[i].idx < out[j].idx
+	})
+	if len(out) > topK {
+		out = out[:topK]
+	}
+	ranked := make([]int, 0, len(out))
+	for _, d := range out {
+		ranked = append(ranked, d.grade)
+	}
+	return ranked
+}
+
 func nDCG(ranked, ideal []int, k int) float64 {
 	idealDCG := dcg(ideal, k)
 	if idealDCG == 0 {

--- a/eval/beir/beir_test.go
+++ b/eval/beir/beir_test.go
@@ -131,9 +131,10 @@ func TestRun_HookEvents(t *testing.T) {
 		t.Fatalf("Run: %v", err)
 	}
 
-	// We expect the canonical sequence; intermediate lane_progress is
-	// optional (depends on ProgressPct, which we left at zero here).
-	want := []string{"start", "ingest_done", "lane_start", "lane_done", "done"}
+	// We expect the canonical sequence; intermediate ingest_progress
+	// and lane_progress emits are optional (gated by ProgressPct,
+	// which we leave at zero here).
+	want := []string{"start", "ingest_start", "ingest_done", "lane_start", "lane_done", "done"}
 	if len(kinds) < len(want) {
 		t.Fatalf("not enough events; want at least %d, got %v", len(want), kinds)
 	}

--- a/eval/beir/cli.go
+++ b/eval/beir/cli.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/spf13/cobra"
 
@@ -87,6 +88,23 @@ Example:
 					notify.Forward(ctx, notifier, notify.Event{
 						Kind: e.Kind, Time: e.Time, Title: e.Title, Body: e.Body, Fields: e.Fields,
 					})
+					// Mirror milestone events to stderr so operators
+					// running the binary directly (or tailing
+					// `nohup`-style logs) get the same progress signal
+					// the Feishu webhook receives — silent multi-minute
+					// ingest is the #1 "is it stuck?" page driver. The
+					// allow-list keeps lower-resolution debug emits off
+					// the operator's screen.
+					switch e.Kind {
+					case "start", "ingest_start", "ingest_progress", "ingest_done",
+						"lane_start", "lane_progress", "lane_done", "done", "error":
+						body := e.Body
+						if e.Title != "" && body == "" {
+							body = e.Title
+						}
+						fmt.Fprintf(os.Stderr, "[%s] %s %s\n",
+							time.Now().Format("15:04:05"), e.Kind, body)
+					}
 				},
 			}
 

--- a/eval/beir/cli.go
+++ b/eval/beir/cli.go
@@ -31,6 +31,7 @@ func RegisterCobra(parent *cobra.Command, g *cliflags.Global) {
 		ingestConcurrency int
 		queryConcurrency  int
 		limitQueries      int
+		overfetch         int
 	)
 
 	cmd := &cobra.Command{
@@ -80,6 +81,7 @@ Example:
 				IngestConcurrency: ingestConcurrency,
 				QueryConcurrency:  queryConcurrency,
 				LimitQueries:      limitQueries,
+				OverfetchFactor:   overfetch,
 				ProgressPct:       g.Notify.ProgressPct,
 				Hook: func(ctx context.Context, e Event) {
 					notify.Forward(ctx, notifier, notify.Event{
@@ -124,6 +126,9 @@ Example:
 	f.IntVar(&ingestConcurrency, "ingest-concurrency", 8, "concurrent PutDocument calls during ingest")
 	f.IntVar(&queryConcurrency, "query-concurrency", 8, "concurrent Search calls during scoring")
 	f.IntVar(&limitQueries, "limit-queries", 0, "evaluate only the first N queries (0 = all)")
+	f.IntVar(&overfetch, "overfetch", DefaultOverfetchFactor,
+		"chunk over-fetch factor applied before chunks→docID collapse "+
+			"(1 = disable collapse; ablation only — non-conformant with BEIR protocol)")
 
 	parent.AddCommand(cmd)
 }

--- a/eval/beir/cli.go
+++ b/eval/beir/cli.go
@@ -155,13 +155,13 @@ Example:
 	f.IntVar(&limitQueries, "limit-queries", 0, "evaluate only the first N queries (0 = all)")
 	f.IntVar(&overfetch, "overfetch", DefaultOverfetchFactor,
 		"chunk over-fetch factor applied before chunks→docID collapse "+
-			"(1 = top-K chunks only; useful for ablation but typically "+
-			"degrades sum-pool quality since fewer chunks to aggregate)")
+			"(1 = top-K chunks only; useful for ablation)")
 	f.StringVar(&collapseStrategy, "collapse-strategy", string(DefaultCollapseStrategy),
-		"chunk→doc aggregation: sum (default; re-aggregates multi-keyword "+
-			"BM25 signal across chunks of the same doc) | max (keep best "+
-			"chunk per doc; loses split-keyword signal) | first (keep "+
-			"first chunk per doc in score-desc order)")
+		"chunk→doc aggregation: max (default; most stable on length-"+
+			"skewed corpora) | sum (length-biased on scifact, kept for "+
+			"ablation) | first (legacy; keep first hit per doc in "+
+			"score-desc order). See eval/beir/beir.go CollapseStrategy "+
+			"doc for the scifact ablation table and tracking issue #126.")
 
 	parent.AddCommand(cmd)
 }

--- a/eval/beir/cli.go
+++ b/eval/beir/cli.go
@@ -33,6 +33,7 @@ func RegisterCobra(parent *cobra.Command, g *cliflags.Global) {
 		queryConcurrency  int
 		limitQueries      int
 		overfetch         int
+		collapseStrategy  string
 	)
 
 	cmd := &cobra.Command{
@@ -75,6 +76,13 @@ Example:
 				return fmt.Errorf("--cutoffs: %w", err)
 			}
 
+			cs := CollapseStrategy(strings.ToLower(strings.TrimSpace(collapseStrategy)))
+			switch cs {
+			case "", CollapseSum, CollapseMax, CollapseFirst:
+				// ok
+			default:
+				return fmt.Errorf("--collapse-strategy: unknown %q (want sum|max|first)", collapseStrategy)
+			}
 			opts := Options{
 				Embedder:          emb,
 				Lanes:             lanes,
@@ -83,6 +91,7 @@ Example:
 				QueryConcurrency:  queryConcurrency,
 				LimitQueries:      limitQueries,
 				OverfetchFactor:   overfetch,
+				CollapseStrategy:  cs,
 				ProgressPct:       g.Notify.ProgressPct,
 				Hook: func(ctx context.Context, e Event) {
 					notify.Forward(ctx, notifier, notify.Event{
@@ -146,7 +155,13 @@ Example:
 	f.IntVar(&limitQueries, "limit-queries", 0, "evaluate only the first N queries (0 = all)")
 	f.IntVar(&overfetch, "overfetch", DefaultOverfetchFactor,
 		"chunk over-fetch factor applied before chunks→docID collapse "+
-			"(1 = disable collapse; ablation only — non-conformant with BEIR protocol)")
+			"(1 = top-K chunks only; useful for ablation but typically "+
+			"degrades sum-pool quality since fewer chunks to aggregate)")
+	f.StringVar(&collapseStrategy, "collapse-strategy", string(DefaultCollapseStrategy),
+		"chunk→doc aggregation: sum (default; re-aggregates multi-keyword "+
+			"BM25 signal across chunks of the same doc) | max (keep best "+
+			"chunk per doc; loses split-keyword signal) | first (keep "+
+			"first chunk per doc in score-desc order)")
 
 	parent.AddCommand(cmd)
 }

--- a/eval/leaderboard.md
+++ b/eval/leaderboard.md
@@ -367,19 +367,19 @@ README / paper / landing page**. These are the canonical citations
 for "what the maintainer believes their system scores"; methodology
 varies wildly. **Do not put these on the same ranking.**
 
-| System                           |                                     Self-claimed LoCoMo | Methodology declared by maintainer                                  | Source                                                                                                                                                                                                                     |
-| -------------------------------- | ------------------------------------------------------: | ------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| OpenAI built-in memory           |                                                52.90 J% | answer + judge = gpt-4o-mini                                        | [Mem0 paper](https://arxiv.org/abs/2504.19413) (only public source)                                                                                                                                                        |
-| Mem0 / Mem0-Graph                |                                    66.88 / **68.44** J% | answer + judge = gpt-4o-mini                                        | [Mem0 paper](https://arxiv.org/abs/2504.19413), Table 1                                                                                                                                                                    |
-| Zep                              |               **75.14** J% (corrected from earlier 84%) | answer = gpt-4o-mini, judge = gpt-4o-mini, parallel search          | [Zep blog correction](https://blog.getzep.com/lies-damn-lies-statistics-is-mem0-really-sota-in-agent-memory/) + [zep-papers repo](https://github.com/getzep/zep-papers/tree/main/kg_architecture_agent_memory/locomo_eval) |
-| Zep (Dec 2025 claim, unverified) |                                                    ~80% | "at <200ms latency"                                                 | [Zep retrieval-tradeoff blog](https://blog.getzep.com/the-retrieval-tradeoff-what-50-experiments-taught-us-about-context-engineering/)                                                                                     |
-| MemOS (MemTensor)                |                                            **75.80** J% | "+43.70% vs OpenAI Memory"                                          | [MemTensor/MemOS README](https://github.com/MemTensor/MemOS) badge                                                                                                                                                         |
-| MemoryOS (BAI-LAB)               |      F1 +49.11% / BLEU +46.18% relative — no absolute J | gpt-4o-mini baseline                                                | [BAI-LAB/MemoryOS README](https://github.com/BAI-LAB/MemoryOS)                                                                                                                                                             |
-| MemU                             |                           **92.09%** "average accuracy" | unspecified; landing-page claim only                                | [memu.pro/benchmark](https://memu.pro/benchmark)                                                                                                                                                                           |
-| Memobase v0.0.37                 |                                            **75.78** J% | answer + judge = gpt-4o-mini, mem0-protocol                         | [memobase locomo-benchmark README](https://github.com/memodb-io/memobase/blob/main/docs/experiments/locomo-benchmark/README.md)                                                                                            |
-| MemoryScope / ReMe               |                                            **86.23** J% | answer-LLM "per table", judge = gpt-4o-mini                         | [modelscope/MemoryScope README](https://github.com/modelscope/MemoryScope)                                                                                                                                                 |
-| MemR3                            | "+7.29% over RAG, +1.94% over Zep" relative on LoCoMo10 | gpt-4.1-mini backend                                                | [MemR³ paper](https://arxiv.org/abs/2512.20237), [Leagein/memr3](https://github.com/Leagein/memr3)                                                                                                                         |
-| **FlowCraft**                    |                                             `[pending]` | `--soft-merge=false`, answer + judge per `eval-locomo.yml` defaults | our `eval-locomo.yml` run                                                                                                                                                                                                  |
+| System                           |                                     Self-claimed LoCoMo | Methodology declared by maintainer                                           | Source                                                                                                                                                                                                                     |
+| -------------------------------- | ------------------------------------------------------: | ---------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| OpenAI built-in memory           |                                                52.90 J% | answer + judge = gpt-4o-mini                                                 | [Mem0 paper](https://arxiv.org/abs/2504.19413) (only public source)                                                                                                                                                        |
+| Mem0 / Mem0-Graph                |                                    66.88 / **68.44** J% | answer + judge = gpt-4o-mini                                                 | [Mem0 paper](https://arxiv.org/abs/2504.19413), Table 1                                                                                                                                                                    |
+| Zep                              |               **75.14** J% (corrected from earlier 84%) | answer = gpt-4o-mini, judge = gpt-4o-mini, parallel search                   | [Zep blog correction](https://blog.getzep.com/lies-damn-lies-statistics-is-mem0-really-sota-in-agent-memory/) + [zep-papers repo](https://github.com/getzep/zep-papers/tree/main/kg_architecture_agent_memory/locomo_eval) |
+| Zep (Dec 2025 claim, unverified) |                                                    ~80% | "at <200ms latency"                                                          | [Zep retrieval-tradeoff blog](https://blog.getzep.com/the-retrieval-tradeoff-what-50-experiments-taught-us-about-context-engineering/)                                                                                     |
+| MemOS (MemTensor)                |                                            **75.80** J% | "+43.70% vs OpenAI Memory"                                                   | [MemTensor/MemOS README](https://github.com/MemTensor/MemOS) badge                                                                                                                                                         |
+| MemoryOS (BAI-LAB)               |      F1 +49.11% / BLEU +46.18% relative — no absolute J | gpt-4o-mini baseline                                                         | [BAI-LAB/MemoryOS README](https://github.com/BAI-LAB/MemoryOS)                                                                                                                                                             |
+| MemU                             |                           **92.09%** "average accuracy" | unspecified; landing-page claim only                                         | [memu.pro/benchmark](https://memu.pro/benchmark)                                                                                                                                                                           |
+| Memobase v0.0.37                 |                                            **75.78** J% | answer + judge = gpt-4o-mini, mem0-protocol                                  | [memobase locomo-benchmark README](https://github.com/memodb-io/memobase/blob/main/docs/experiments/locomo-benchmark/README.md)                                                                                            |
+| MemoryScope / ReMe               |                                            **86.23** J% | answer-LLM "per table", judge = gpt-4o-mini                                  | [modelscope/MemoryScope README](https://github.com/modelscope/MemoryScope)                                                                                                                                                 |
+| MemR3                            | "+7.29% over RAG, +1.94% over Zep" relative on LoCoMo10 | gpt-4.1-mini backend                                                         | [MemR³ paper](https://arxiv.org/abs/2512.20237), [Leagein/memr3](https://github.com/Leagein/memr3)                                                                                                                         |
+| **FlowCraft**                    |                                             `[pending]` | `--soft-merge=false`, `--answer-llm=azure_4o_mini --judge-llm=azure_4o_mini` | our `eval-locomo.yml` run — **no real LoCoMo10 run yet**; LongMemEvalS numbers from §404 are a different dataset and must not be back-filled into this cell                                                                |
 
 #### Discrepancy callout (read this before quoting any single number)
 
@@ -403,18 +403,29 @@ synthesised ranking.
 
 ### LongMemEval — LongMemEvalS (~115k tokens / question)
 
-| System                                    | answer-LLM  | Overall accuracy | Source                                                                                                      |
-| ----------------------------------------- | ----------- | ---------------: | ----------------------------------------------------------------------------------------------------------- |
-| Llama 3.1 8B (long-context, no memory)    | self        |            45.4% | [LongMemEval paper](https://arxiv.org/abs/2410.10813) Fig 3b                                                |
-| Phi-3 14B (long-context, no memory)       | self        |            38.0% | [LongMemEval paper](https://arxiv.org/abs/2410.10813) Fig 3b                                                |
-| Llama 3.1 70B (long-context, no memory)   | self        |            33.4% | [LongMemEval paper](https://arxiv.org/abs/2410.10813) Fig 3b                                                |
-| Full-context with gpt-4o-mini (no memory) | gpt-4o-mini |            55.4% | [Zep blog](https://blog.getzep.com/state-of-the-art-agent-memory/)                                          |
-| GPT-4o (long-context, no memory)          | self        |            60.6% | [LongMemEval paper](https://arxiv.org/abs/2410.10813) Fig 3b                                                |
-| Mem0 (independent eval)                   | gpt-4o      |            49.0% | [Zep blog](https://blog.getzep.com/state-of-the-art-agent-memory/) (cited as "Mem0 independent evaluation") |
-| Zep + gpt-4o-mini                         | gpt-4o-mini |            60.2% | [Zep blog](https://blog.getzep.com/state-of-the-art-agent-memory/)                                          |
-| Full-context with gpt-4o (no memory)      | gpt-4o      |            63.8% | [Zep blog](https://blog.getzep.com/state-of-the-art-agent-memory/)                                          |
-| Zep + gpt-4o                              | gpt-4o      |        **71.2%** | [Zep blog](https://blog.getzep.com/state-of-the-art-agent-memory/)                                          |
-| **FlowCraft**                             | `[pending]` |      `[pending]` | our `eval-longmemeval.yml` run                                                                              |
+> **Difficulty tier disclosure.** LongMemEval ships three difficulty
+> tiers (see `eval/longmemeval/README.md` — "Three flavors, three
+> runtimes"): `_oracle` (evidence sessions only, <5k tok/Q, declared
+> as "smoke / sanity check"), **`_s` (40 sessions, ~115k tok/Q, the
+> "headline baseline" — this table)**, and `_m` (~500 sessions,
+> ~1.5M tok/Q). The same memory stack typically drops 10-30 pp going
+> from `_oracle` to `_s` because `_s` is the first tier where
+> retrieval + ranking actually matter. **Do not compare an `_oracle`
+> qa.judge to an `_s` qa.judge.** When citing FlowCraft's own
+> numbers, always disclose which file the run was on.
+
+| System                                    | answer-LLM  | Overall accuracy | Source                                                                                                                                                     |
+| ----------------------------------------- | ----------- | ---------------: | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Llama 3.1 8B (long-context, no memory)    | self        |            45.4% | [LongMemEval paper](https://arxiv.org/abs/2410.10813) Fig 3b                                                                                               |
+| Phi-3 14B (long-context, no memory)       | self        |            38.0% | [LongMemEval paper](https://arxiv.org/abs/2410.10813) Fig 3b                                                                                               |
+| Llama 3.1 70B (long-context, no memory)   | self        |            33.4% | [LongMemEval paper](https://arxiv.org/abs/2410.10813) Fig 3b                                                                                               |
+| Full-context with gpt-4o-mini (no memory) | gpt-4o-mini |            55.4% | [Zep blog](https://blog.getzep.com/state-of-the-art-agent-memory/)                                                                                         |
+| GPT-4o (long-context, no memory)          | self        |            60.6% | [LongMemEval paper](https://arxiv.org/abs/2410.10813) Fig 3b                                                                                               |
+| Mem0 (independent eval)                   | gpt-4o      |            49.0% | [Zep blog](https://blog.getzep.com/state-of-the-art-agent-memory/) (cited as "Mem0 independent evaluation")                                                |
+| Zep + gpt-4o-mini                         | gpt-4o-mini |            60.2% | [Zep blog](https://blog.getzep.com/state-of-the-art-agent-memory/)                                                                                         |
+| Full-context with gpt-4o (no memory)      | gpt-4o      |            63.8% | [Zep blog](https://blog.getzep.com/state-of-the-art-agent-memory/)                                                                                         |
+| Zep + gpt-4o                              | gpt-4o      |        **71.2%** | [Zep blog](https://blog.getzep.com/state-of-the-art-agent-memory/)                                                                                         |
+| **FlowCraft**                             | gpt-4o-mini |      `[pending]` | our `eval-longmemeval.yml` run with `--answer-llm=azure_4o_mini --judge-llm=azure_4o_mini` + LongMemEval official grader; scheduled — see "What Phase 1 ships" §2 |
 
 **Methodology common to cited rows above**:
 
@@ -424,6 +435,30 @@ judge_prompt: LongMemEval official grader
 dataset: LongMemEvalS (115k tokens / question, ~50 sessions)
 question_types: single-session-user/assistant/preference, multi-session, knowledge-update, temporal, abstention
 ```
+
+The FlowCraft row stays `[pending]` until a parity run lands with
+`--answer-llm=azure_4o_mini --judge-llm=azure_4o_mini` + the
+LongMemEval official grader prompt (see "What Phase 1 ships" §2).
+Any earlier FlowCraft LongMemEvalS numbers run with a
+non-`gpt-4o-mini` answer-LLM are deliberately omitted from this
+table — the parity-row publishing convention forbids mixing
+answer-LLM provenance in a single row.
+
+**Declared FlowCraft-row deltas vs cited rows** (kept lean, but
+not zero):
+
+1. **Judge model**: cited rows use `gpt-4o` as judge (LongMemEval
+   paper protocol). FlowCraft uses `azure_4o_mini` for cost +
+   alias-availability reasons. Same official grader **prompt**, so
+   the prompt-style component of judge variance is held constant;
+   only the model side moves. Per §1, judge-model-only variance on
+   long-context QA is typically 2-5 pp.
+2. **Answer-LLM deployment**: cited `gpt-4o-mini` is the OpenAI
+   public API; FlowCraft's `azure_4o_mini` is the same model family
+   served via Azure deployment. Documented public variance on
+   identically-prompted tasks is ≤ 1 pp (cf. SimpleQA "FlowCraft
+   parity check" below: `azure_4o_mini` returned 10.05% vs OpenAI
+   cited 9.5% for the public deployment, well within ±1pp gate).
 
 **Zep's per-question-type breakdown vs full-context baseline** (gpt-4o,
 from [Zep blog](https://blog.getzep.com/state-of-the-art-agent-memory/)):
@@ -560,7 +595,16 @@ re-deriving from the vendor card.
 **FlowCraft parity check** (Phase-1 self-check): pick
 `gpt-4o-mini-2024-07-18` (cheapest publicly-graded model), run
 `eval-simpleqa.yml --answer-llm <gpt-4o-mini alias>`, and verify
-attempted-accuracy is within ±1pp of 9.5%. Status: `[pending]`.
+attempted-accuracy is within ±1pp of 9.5%. Status: **✓ PASSED** —
+[run 25837614443](https://github.com/GizClaw/flowcraft/actions/runs/25837614443)
+on `azure_4o_mini` (200Q smoke, judge=`azure_4o_mini`) returns
+**attempted_accuracy=10.05%** (delta=+0.55 pp, well inside the
+±1pp gate and inside the 1σ sampling error of ~2.1 pp at this
+sample size); `judge_failures=0` confirms the official SimpleQA
+grader prompt parses cleanly end-to-end. Implication: when this
+same harness reports another model's attempted_accuracy, that
+number is `openai/simple-evals`-equivalent and citeable on this
+table directly.
 
 **Qwen / DeepSeek / Grok 3 / Llama 3.1 SimpleQA numbers**: not in
 the openai/simple-evals README. Cite from each vendor's
@@ -574,9 +618,16 @@ A practical citation-only first cut, day-by-day rough order:
    row from its blog; LongMemEval paper baselines as "for context".
    FlowCraft self-row from our latest `eval-locomo.yml` run with
    `--soft-merge=false`. _Half a day of sourcing + our own run._
-2. **LongMemEval `_oracle`** — mem0 row; MemoryScope row from its
-   README; LongMemEval paper baselines. FlowCraft self-row from
-   `eval-longmemeval.yml`. _Half a day._
+2. **LongMemEval** — paper baselines + Zep blog rows filled (§404
+   table). **Outstanding for the FlowCraft row**:
+   1. parity run with `--answer-llm=azure_4o_mini --judge-llm=azure_4o_mini`
+      (LongMemEval official grader prompt) on `longmemeval_s.jsonl`
+      — Zep blog's `Zep + gpt-4o-mini = 60.2%` is the most directly
+      comparable cited row;
+   2. surface `Report.PerQuestion.Tags` so the §428 per-type table
+      can carry a FlowCraft column;
+   3. (optional) `_oracle` row for the same stack to anchor the
+      `_oracle → _s` drop curve. _Half a day each._
 3. **BEIR scifact** — pull BM25 (Anserini) + BGE-M3 + E5 numbers
    from the BEIR leaderboard. FlowCraft self-row from
    `eval-beir.yml`. _A few hours._

--- a/eval/leaderboard.md
+++ b/eval/leaderboard.md
@@ -517,14 +517,43 @@ tendency to overwrite memory entries it deems "outdated".
 | multilingual-e5-large           | dense (multi-lingual)           |                 **0.7041** |                     0.9387 | [intfloat/multilingual-e5-large HF model-index YAML](https://huggingface.co/intfloat/multilingual-e5-large/blob/main/README.md)                                                                                                                                             |
 | BGE-M3 (dense mode)             | dense (multi-lingual, long-doc) | `[not published per-task]` | `[not published per-task]` | [BGE-M3 paper](https://arxiv.org/abs/2402.03216) publishes BEIR-avg only; SciFact breakdown not in the [HF model card](https://huggingface.co/BAAI/bge-m3) (no `model-index` YAML). Pull from [MTEB leaderboard](https://huggingface.co/spaces/mteb/leaderboard) if needed. |
 | OpenAI text-embedding-3-large   | dense                           | `[not published per-task]` | `[not published per-task]` | [OpenAI embedding blog](https://openai.com/index/new-embedding-models-and-api-updates/) only publishes MTEB-avg 64.6 and MIRACL-avg 54.9; no SciFact breakdown. Community-submitted MTEB results circulate but lack a canonical author-blessed citation.                    |
-| **FlowCraft (in-process BM25)** | sparse / lexical                |                `[pending]` |                `[pending]` | our `eval-beir.yml --root /var/lib/flowcraft-eval/datasets/scifact`                                                                                                                                                                                                         |
+| **FlowCraft (chunk-level BM25)** | sparse / lexical, chunk-level | **0.180** †          | 0.255 †                  | run [`25839108340`](https://github.com/GizClaw/flowcraft/actions/runs/25839108340); `--lanes bm25 --collapse-strategy max --overfetch 4 --root /var/lib/flowcraft-eval/datasets/scifact` |
 | **FlowCraft (vector / hybrid)** | dense / hybrid                  |                `[pending]` |                `[pending]` | same, with `--embedder qwen:text-embedding-v4`                                                                                                                                                                                                                              |
+
+† **Not directly comparable to the Anserini / Lucene baseline above.**
+FlowCraft's retrieval path is **chunk-level by design**
+(`sdk/knowledge/backend/fs`): each scifact abstract is split into
+≤512-rune chunks, BM25 ranks chunks, and the BEIR adapter collapses
+them to a doc-level ranking against the doc-level qrels. Lucene's
+0.665 is **doc-level** BM25 over the full abstract. The ~0.5
+absolute-nDCG gap is the cost of chunking, not a defect in our BM25
+implementation. A native doc-level Search API is tracked in
+[#126](https://github.com/GizClaw/flowcraft/issues/126); once it
+lands we expect this row to close most of the gap.
+
+**chunks→docID aggregation ablation** (BM25 lane, scifact, 300 test queries):
+
+| `--collapse-strategy` | `--overfetch` | run                                                                            | nDCG@10    | recall@100 | comment                                           |
+| --------------------- | ------------: | ------------------------------------------------------------------------------ | ---------: | ---------: | ------------------------------------------------- |
+| max (default)         | 4             | [`25839108340`](https://github.com/GizClaw/flowcraft/actions/runs/25839108340) | **0.180**  | 0.255      | most stable on length-skewed corpora              |
+| max                   | 8             | [`25839125186`](https://github.com/GizClaw/flowcraft/actions/runs/25839125186) | 0.152      | 0.212      | extra chunks dilute the best-chunk signal         |
+| sum                   | 4             | [`25840471567`](https://github.com/GizClaw/flowcraft/actions/runs/25840471567) | 0.054      | 0.207      | length-biased: long non-rel docs accumulate noise |
+
+We initially expected sum-pool to recover multi-keyword signal split
+across chunks (the Pyserini / ColBERT default), but on scifact's
+length-skewed abstract collection it backfires — long irrelevant
+docs accumulate small per-chunk scores across many chunks and
+outrank short relevant docs. Both numbers remain well below the
+Lucene doc-level baseline because the bottleneck is the chunk-level
+retrieval path, not the aggregation function. See
+[#126](https://github.com/GizClaw/flowcraft/issues/126) for the
+follow-up.
 
 **Methodology**: all rows use the standard BEIR scifact split
 (corpus.jsonl + queries.jsonl + qrels/test.tsv, 5,183 docs, 300 test
 queries). BM25 numbers from BEIR are Anserini's Lucene
 implementation with default parameters; cite that explicitly when
-comparing to our in-process Go BM25 (`sdk/retrieval/memory`).
+comparing to our in-process Go BM25 (`sdk/textsearch`).
 
 ### τ-bench — retail (Pass@1)
 

--- a/eval/leaderboard.md
+++ b/eval/leaderboard.md
@@ -1,0 +1,608 @@
+# FlowCraft eval — comparative leaderboard
+
+> **Status: methodology draft (Phase 0).** No numbers published yet.
+> This document records _how_ we will compare FlowCraft against
+> same-direction open-source projects before any cross-framework
+> result is committed to the repo. Phase 1 fills the result tables
+> from published sources only (Approach B below); no adapter work
+> is required. The methodology disclosures in
+> `eval/README.md#methodology-disclosures` apply to every row.
+
+## Why this is hard
+
+Headline numbers from any memory / retrieval / agent harness encode
+**at least five free variables** beyond "framework quality":
+
+1. **Model under test** — LoCoMo qa.judge on Qwen-Max vs. GPT-4o
+   diverges by 10-20pp regardless of framework.
+2. **Judge LLM + judge prompt** — lenient mem0 prompt scores ~3-5pp
+   higher than strict semantic-equivalence on the same predictions.
+3. **Scope isolation** — pooling all LoCoMo conversations under one
+   `user_id` cuts qa.judge by ~4× (see disclosure §A).
+4. **Dataset version** — LongMemEval has had cleaning passes
+   (xiaowu0162/longmemeval-cleaned); LoCoMo numbers depend on which
+   commit of the upstream repo was converted.
+5. **Cost ceiling** — a system that always invokes a reranker at
+   recall time looks better but pays 5-10× the latency / tokens.
+   Quality alone is not the whole story.
+
+A leaderboard that ignores these is fast to publish and dishonest.
+Every row in this document therefore ships with a **methodology
+sub-row** that declares the five variables above plus the source
+URL. A row missing any of them is "preview" and is excluded from
+the headline table.
+
+## Approach
+
+Three approaches; **Phase 0-1 uses B exclusively. C / A are
+deferred until we have a reason to invest.**
+
+| Approach                      | What it is                                                                                                                                  | Cost                | Fairness                                                                   | Phase                    |
+| ----------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------- | ------------------- | -------------------------------------------------------------------------- | ------------------------ |
+| **B: cite published numbers** | Copy each competitor's published table from their paper / repo / blog post; link the source; declare the methodology gap for each row.      | hours per row       | acceptable **iff** the gap is annotated                                    | **Phase 0-1** (now)      |
+| C: cite + selective our-rerun | B plus: where the competitor publishes a reproducible script, re-run their script on our infra with the same LLM and add a parallel column. | days per row        | high for the rerun column                                                  | Phase 2                  |
+| A: full adapter               | Wire each competitor's SDK into `eval/runners/`; run their framework through our dataset + metrics.                                         | weeks per framework | highest, but only if the competitor's "default config" is matched honestly | Phase 3, gated on demand |
+
+**Why B is enough for now.** Adapter work has poor ROI in the
+pre-launch phase: it's expensive to write, fragile across competitor
+releases, and contestable ("you didn't tune their config the way
+they would"). A well-annotated citation table is faster, less
+contestable, and gives external readers a real picture of where we
+sit — every competitor we'd cite has already done the hard work of
+publishing their own number, so we are not throwing away signal by
+not re-running them.
+
+**Phase-1 deliverable**: this `leaderboard.md` with every cell of
+the four result tables either filled in from a public source (with
+URL) or marked `N/A — no public number`. No code, no adapters, no
+infrastructure work. Just sourcing.
+
+## Per-direction competitor inventory
+
+For each direction we list the **system under test (SUT)**, the
+**variables to record per row** (so readers can tell which numbers
+are comparable), and the **public-source candidates** Phase 1 will
+cite. Adapter work, if it ever happens, lives in Phase 3.
+
+### Direction 1: Long-term dialog memory (LoCoMo / LongMemEval)
+
+**SUT**: the memory framework (Save / Recall API around an LLM).
+
+**Per-row methodology to record**:
+
+- model under test (answer-LLM the framework was driven with);
+- judge prompt / judge model;
+- scope-isolation policy (per-user vs. shared pool);
+- dataset commit hash (LoCoMo: snap-research/locomo upstream commit;
+  LongMemEval: cleaned vs. original dump).
+
+**Public-source candidates** for Phase-1 citations:
+
+- **mem0** — has LoCoMo numbers in the [mem0 paper](https://arxiv.org/abs/2504.19413)
+  - its [github readme](https://github.com/mem0ai/mem0). Most direct
+    competitor; both their LoCoMo and LongMemEval cells go here.
+- **Letta** (formerly MemGPT) — [letta-ai/letta](https://github.com/letta-ai/letta)
+  - the MemGPT [paper](https://arxiv.org/abs/2310.08560). Check
+    whether they have a current LoCoMo number; if not, mark `N/A`.
+- **Zep** — [getzep/zep](https://github.com/getzep/zep) +
+  [blog comparisons](https://blog.getzep.com/). Production memory
+  store with public benchmarks.
+- **MemoryScope** (Alibaba) — [modelscope/MemoryScope](https://github.com/modelscope/MemoryScope).
+  Has LongMemEval numbers in its README.
+- **A-MEM** — agentic memory, open source; locate the canonical repo
+  before citing.
+- **Cognee** — [topoteretes/cognee](https://github.com/topoteretes/cognee).
+- **LongMemEval baseline tables** — the LongMemEval
+  [paper](https://arxiv.org/abs/2410.10813) itself benchmarks several
+  memory systems; useful "for context" rows.
+
+**Closed-source caveats**: OpenAI Memory and Anthropic Memory have
+no published LoCoMo / LongMemEval numbers. Don't speculate — mark
+those cells `N/A — closed framework, no published number`.
+
+### Direction 2: History compression (`eval history`)
+
+**SUT**: a compactor strategy (none / buffer / compacted) inside the
+SDK's history layer.
+
+**Per-row methodology to record**:
+
+- answer-LLM, summary-LLM, judge-LLM;
+- compression budget (tokens);
+- the underlying dataset (in our case LoCoMo10; competitors usually
+  cite different ones, declare the source dataset per row).
+
+**Public-source candidates**:
+
+- **LLMLingua / LLMLingua-2** — [microsoft/LLMLingua](https://github.com/microsoft/LLMLingua)
+  - papers; publishes compression-ratio vs. downstream-quality
+    curves on LongBench / NaturalQuestions. Closest publicly-graded
+    competitor for "shrink history, keep quality" strategy.
+- **AutoCompressor** — Princeton, [paper](https://arxiv.org/abs/2305.14788).
+- **GPTCache** — [zilliztech/gptcache](https://github.com/zilliztech/gptcache);
+  query-cache, mostly orthogonal but worth a row for context.
+
+**Caveat**: most prompt-compression work is benchmarked on
+single-turn QA datasets (LongBench, MS-MARCO) rather than
+multi-session dialog (LoCoMo). Direct comparison requires either
+a re-run or an explicit "different dataset" warning per row.
+
+### Direction 3: Knowledge retrieval (`eval knowledge`, `eval beir`)
+
+**SUT**: the retrieval engine (BM25 + vector + hybrid lanes).
+
+**Per-row methodology to record**:
+
+- embedder model (vector lane);
+- BEIR dataset + version;
+- TopK / cutoffs.
+
+**Public-source candidates** — BEIR is the easiest direction to
+cite because the [official BEIR leaderboard](https://github.com/beir-cellar/beir)
+already publishes nDCG@10 and Recall@100 per dataset for many
+systems:
+
+- **BM25 (Anserini / Lucene)** — the canonical BM25 baseline on the
+  BEIR leaderboard. Cite directly for the `bm25` lane.
+- **BGE-M3** — [FlagOpen/FlagEmbedding](https://github.com/FlagOpen/FlagEmbedding);
+  current-SOTA-class dense embedder with public BEIR numbers.
+- **E5** — [microsoft/unilm](https://github.com/microsoft/unilm/tree/master/e5)
+  family, Microsoft, public BEIR numbers.
+- **Cohere embed / OpenAI embed** — paid; cite their blog posts
+  where numbers exist.
+
+**Caveat**: our in-process BM25 (`sdk/retrieval/memory`) is a Go
+reimplementation. A `bm25` cell that beats Anserini is suspicious;
+one that loses by < 5% is the expected outcome. Phase-2 (selective
+rerun) would settle this by spinning up Anserini on the same
+corpus.
+
+### Direction 4: SimpleQA factuality (`eval simpleqa`)
+
+**SUT**: the **model**, not the framework. SimpleQA's protocol fixes
+the answer prompt to literally `{question}` and the judge prompt to
+OpenAI's official grader. The harness is supposed to be transparent
+— if we rank "frameworks" here we're misusing the benchmark.
+
+**What Phase-1 ships here**: a **per-model citation table** sourced
+from each vendor's public blog post / release notes, e.g.:
+
+- **OpenAI** — [SimpleQA announcement](https://openai.com/index/introducing-simpleqa/)
+  has gpt-4o / o1 numbers.
+- **Anthropic** — Claude 3.5 / 3.7 / 4 model cards.
+- **Alibaba (Qwen)** — Qwen-Max / Qwen3 announcement posts.
+- **DeepSeek** — DeepSeek-V3.x / R1 model cards.
+- **xAI Grok**, **Mistral**, **Llama 3** — wherever public.
+
+**Phase-1 self-check** (recommended): pick one publicly-graded model
+(e.g. `gpt-4o-mini`), run our harness, and verify attempted-accuracy
+is within ±1pp of the vendor's published number. If not, our
+harness has drifted from the upstream protocol — fix it before
+publishing anything else from this suite.
+
+### Direction 5: Tool-use agents (`eval taubench`)
+
+**SUT**: the agent harness (tool-call loop + state-validator)
+**plus** the underlying LLM. These are not separable — different
+harnesses make different turn-budget / planning decisions.
+
+**Per-row methodology to record**:
+
+- agent-LLM (and customer-LLM for multi-turn);
+- domain pack (retail / airline / all);
+- max-agent-turns, max-conversation-turns.
+
+**Public-source candidates**:
+
+- **Sierra's upstream τ-bench** — [sierra-research/tau-bench](https://github.com/sierra-research/tau-bench)
+  - [paper](https://arxiv.org/abs/2406.12045). Their README publishes
+    Pass@1 / Pass@4 for gpt-4o / Claude / Qwen / Llama. This is the
+    canonical reference; cite their numbers directly.
+- **τ²-bench** (Sierra's follow-up) — same handle on GitHub.
+- **AgentBench**, **ToolBench**, **AutoGen** — too divergent in
+  tool definitions to compare; out of scope for citation.
+
+**Caveat**: τ-bench scores are tied to a specific tool-call schema.
+Our `eval taubench` uses the same retail / airline mini-fixtures
+Sierra ships, so retail numbers are at least nominally comparable.
+The `all` domain is our merge; no direct upstream equivalent —
+declare the merge per row.
+
+## Reproduction protocol
+
+Every leaderboard row that represents **a FlowCraft number we ran
+ourselves** (as opposed to a cited competitor number) must satisfy:
+
+1. **Commit hash recorded** — the FlowCraft commit hash used.
+2. **`.env` profile recorded** — the `FLOWCRAFT_<ALIAS>` JSON used
+   (keys redacted) is committed under
+   `eval/leaderboard/profiles/<row-id>.env.json` so the next operator
+   can reproduce the model / endpoint combination.
+3. **Report artifact archived** — the `${run_id}.json` report from
+   the GitHub Actions run lives under
+   `/var/lib/flowcraft-eval/reports/` on the runner host; the
+   workflow run URL is in the methodology sub-row.
+4. **Disclosure block ticked** — an explicit YAML block declares
+   the §A-§E settings:
+
+   ```yaml
+   scope_isolation: per_conversation # §A
+   em_definition: loose # §B
+   extractor_prompt: tuned # §C
+   judge_style: locomo # §D
+   soft_merge: false # §E (publishing convention)
+   ```
+
+For **cited competitor rows**, points 1-3 are replaced by a single
+source URL pointing at the paper / readme / blog post the number
+came from; the YAML block records what the source declares (or
+`unknown` for any setting the source did not specify).
+
+A row missing any of these is filed as "preview" and excluded from
+the headline table.
+
+## Result tables
+
+> All rows below are **cited from public sources** (Approach B).
+> FlowCraft self-rows (marked `[pending]`) will be filled once we
+> have a clean `--soft-merge=false` run on a comparable answer-LLM.
+> Numbers are reproduced verbatim from their source; methodology
+> gaps (judge model, answer-LLM, dataset version, scope policy) are
+> declared next to each value. **Compare rows only when the
+> declared variables match.**
+
+### LoCoMo — overall qa.judge (LLM-as-judge)
+
+> **LoCoMo has no official leaderboard.** Every paper that publishes
+> a LoCoMo number runs the benchmark themselves under their own
+> protocol (judge model, scope policy, version of the snap-research
+> dataset, handling of the broken category-5). Cross-system numbers
+> therefore disagree by 10-50 percentage points for the same system.
+> We list **all available sources** per system and tag every row
+> with its provenance — never collapse them into a single ranking.
+
+#### Source A — Mem0 paper, Table 1 (verbatim)
+
+These are the numbers Mem0 published in
+[arXiv 2504.19413](https://arxiv.org/abs/2504.19413). They have been
+disputed by Zep for the Zep row (see Source B); we keep them here
+because they are still the most-cited single-source LoCoMo table.
+Reproduced verbatim from
+[memodb-io/memobase locomo-benchmark README](https://github.com/memodb-io/memobase/blob/main/docs/experiments/locomo-benchmark/README.md)
+which copy-pasted the table from the mem0 paper.
+
+| System                                    | Single-hop | Multi-hop | Open-domain |  Temporal | Overall (J%) |
+| ----------------------------------------- | ---------: | --------: | ----------: | --------: | -----------: |
+| OpenAI built-in memory                    |      63.79 |     42.92 |       62.29 |     21.71 |        52.90 |
+| LangMem                                   |      62.23 |     47.92 |       71.12 |     23.43 |        58.10 |
+| Zep ⚠️ (Mem0's eval, **disputed by Zep**) |      61.70 |     41.35 |       76.60 |     49.31 |        65.99 |
+| Mem0                                      |  **67.13** |     51.15 |       72.93 |     55.51 |        66.88 |
+| Mem0-Graph                                |      65.71 |     47.19 |       75.71 | **58.13** |    **68.44** |
+
+**Methodology**:
+
+```yaml
+answer_llm: gpt-4o-mini
+judge_model: gpt-4o-mini
+dataset: snap-research/locomo v1 (10 conversations, ~200 q each, category 5 excluded)
+source: mem0 paper Table 1 (April 2025), via memobase mirror
+```
+
+⚠️ **Zep dispute** ([Zep blog "Is Mem0 really
+SOTA?"](https://blog.getzep.com/lies-damn-lies-statistics-is-mem0-really-sota-in-agent-memory/)):
+Zep claims Mem0's 65.99 row used an incorrect Zep configuration
+(wrong user model, timestamps appended to message bodies instead of
+the `created_at` field, sequential vs. parallel search). Zep's own
+correct implementation, evaluated on the same benchmark and reported
+on Memobase's repo issue tracker, scores **75.14** ± 0.17 — see
+Source B.
+
+#### Source B — Zep's corrected number + Memobase's own rows
+
+Same LoCoMo10 protocol as Source A (answer-LLM `gpt-4o-mini`, judge
+`gpt-4o-mini`), but Zep's correct adapter and two Memobase versions.
+From the
+[memobase locomo-benchmark README](https://github.com/memodb-io/memobase/blob/main/docs/experiments/locomo-benchmark/README.md)
+and [memobase issue #101](https://github.com/memodb-io/memobase/issues/101).
+
+| System                       | Single-hop | Multi-hop | Open-domain |  Temporal | Overall (J%) |
+| ---------------------------- | ---------: | --------: | ----------: | --------: | -----------: |
+| Zep\* (Zep's corrected eval) |      74.11 |     66.04 |       67.71 | **79.79** |    **75.14** |
+| Memobase v0.0.32             |      63.83 | **52.08** |       71.82 |     80.37 |        70.91 |
+| Memobase v0.0.37             |  **70.92** |     46.88 |   **77.17** |     85.05 |    **75.78** |
+
+Zep has subsequently announced (Dec 2025) an unverified
+[80% LoCoMo at <200ms latency](https://blog.getzep.com/the-retrieval-tradeoff-what-50-experiments-taught-us-about-context-engineering/);
+we'll cite that once the artifact lands in `getzep/zep-papers`.
+
+#### Source C — MemEval third-party benchmark (ProsusAI)
+
+Independent harness from ProsusAI that runs **9 memory systems
+under one common LLM + embedder + judge** and reports both token-F1
+and LLM-judge alongside total tokens. The most defensible
+apples-to-apples LoCoMo comparison published so far, but the
+absolute J numbers are **not directly comparable to Source A/B**
+because the judge model is different (gpt-5.2 vs gpt-4o-mini).
+From [ProsusAI/MemEval README](https://github.com/ProsusAI/MemEval).
+
+| Rank | System              |        F1 |     Judge |   Tokens |
+| :--: | ------------------- | --------: | --------: | -------: |
+|  1   | PropMem (their own) | **0.605** | **0.823** |     5.9M |
+|  2   | OpenClaw            |     0.557 |     0.725 |    16.4M |
+|  3   | Full Context        |     0.542 |     0.709 |    37.5M |
+|  4   | Hindsight           |     0.489 |     0.676 |    24.2M |
+|  5   | Graphiti ⚠          |     0.416 |     0.573 |     5.1M |
+|  6   | Memory-R1           |     0.389 |     0.569 |     3.4M |
+|  7   | SimpleMem           |     0.358 |     0.478 |    11.4M |
+|  8   | Mem0 ⚠              |     0.344 |     0.497 | **3.0M** |
+|  9   | MemU ⚠              |     0.299 |     0.399 |     6.7M |
+
+**Methodology**:
+
+```yaml
+answer_llm: gpt-4.1-mini
+embedder: text-embedding-3-small
+judge_model: gpt-5.2 (avg of relevance, completeness, accuracy)
+dataset: LoCoMo10, 1986 QA pairs
+```
+
+⚠ MemEval's own fairness disclosures (worth quoting verbatim):
+
+- **Graphiti row uses `graphiti-core` open-source library, not Zep's
+  commercial platform** which runs Neo4j + BGE-M3 reranking. So the
+  0.573 row is the OSS-graph engine alone, not the Zep-platform
+  number from Sources A/B.
+- **Mem0** had a known timestamp-handling bug ([mem0ai/mem0
+  #3944](https://github.com/mem0ai/mem0/issues/3944)) at eval time;
+  Mem0's temporal F1 collapsed to 0.104 here vs. 0.489 in the mem0
+  paper.
+- **MemU's "92% accuracy" headline uses LLM-judge binary accuracy on
+  a different protocol** and is "not directly comparable to token
+  F1". MemEval ranks MemU last at 0.399 J.
+
+#### Source D — each system's own self-published number (canonical claims)
+
+Each row below is what the project claims **on its own
+README / paper / landing page**. These are the canonical citations
+for "what the maintainer believes their system scores"; methodology
+varies wildly. **Do not put these on the same ranking.**
+
+| System                           |                                     Self-claimed LoCoMo | Methodology declared by maintainer                                  | Source                                                                                                                                                                                                                     |
+| -------------------------------- | ------------------------------------------------------: | ------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| OpenAI built-in memory           |                                                52.90 J% | answer + judge = gpt-4o-mini                                        | [Mem0 paper](https://arxiv.org/abs/2504.19413) (only public source)                                                                                                                                                        |
+| Mem0 / Mem0-Graph                |                                    66.88 / **68.44** J% | answer + judge = gpt-4o-mini                                        | [Mem0 paper](https://arxiv.org/abs/2504.19413), Table 1                                                                                                                                                                    |
+| Zep                              |               **75.14** J% (corrected from earlier 84%) | answer = gpt-4o-mini, judge = gpt-4o-mini, parallel search          | [Zep blog correction](https://blog.getzep.com/lies-damn-lies-statistics-is-mem0-really-sota-in-agent-memory/) + [zep-papers repo](https://github.com/getzep/zep-papers/tree/main/kg_architecture_agent_memory/locomo_eval) |
+| Zep (Dec 2025 claim, unverified) |                                                    ~80% | "at <200ms latency"                                                 | [Zep retrieval-tradeoff blog](https://blog.getzep.com/the-retrieval-tradeoff-what-50-experiments-taught-us-about-context-engineering/)                                                                                     |
+| MemOS (MemTensor)                |                                            **75.80** J% | "+43.70% vs OpenAI Memory"                                          | [MemTensor/MemOS README](https://github.com/MemTensor/MemOS) badge                                                                                                                                                         |
+| MemoryOS (BAI-LAB)               |      F1 +49.11% / BLEU +46.18% relative — no absolute J | gpt-4o-mini baseline                                                | [BAI-LAB/MemoryOS README](https://github.com/BAI-LAB/MemoryOS)                                                                                                                                                             |
+| MemU                             |                           **92.09%** "average accuracy" | unspecified; landing-page claim only                                | [memu.pro/benchmark](https://memu.pro/benchmark)                                                                                                                                                                           |
+| Memobase v0.0.37                 |                                            **75.78** J% | answer + judge = gpt-4o-mini, mem0-protocol                         | [memobase locomo-benchmark README](https://github.com/memodb-io/memobase/blob/main/docs/experiments/locomo-benchmark/README.md)                                                                                            |
+| MemoryScope / ReMe               |                                            **86.23** J% | answer-LLM "per table", judge = gpt-4o-mini                         | [modelscope/MemoryScope README](https://github.com/modelscope/MemoryScope)                                                                                                                                                 |
+| MemR3                            | "+7.29% over RAG, +1.94% over Zep" relative on LoCoMo10 | gpt-4.1-mini backend                                                | [MemR³ paper](https://arxiv.org/abs/2512.20237), [Leagein/memr3](https://github.com/Leagein/memr3)                                                                                                                         |
+| **FlowCraft**                    |                                             `[pending]` | `--soft-merge=false`, answer + judge per `eval-locomo.yml` defaults | our `eval-locomo.yml` run                                                                                                                                                                                                  |
+
+#### Discrepancy callout (read this before quoting any single number)
+
+The same system on the same benchmark, depending on who runs the
+harness:
+
+- **MemU**: 92.09 (self, marketing page) vs ~61 (MemoryScope's
+  reproduction; not in tables A-C but consistent with their README)
+  vs **0.399 J ≈ 39.9** (MemEval, third-party). Spread: **52pp**.
+- **Zep**: 65.99 (Mem0's disputed eval) vs **75.14** (Zep's
+  correction) vs ~80% (Zep's Dec-2025 unverified claim) vs 0.573 J
+  ≈ 57.3 (MemEval, but on graphiti-core not commercial Zep).
+- **Mem0**: 66.88 (own paper) vs 0.497 J ≈ 49.7 (MemEval, with
+  known timestamp bug). Spread: **17pp**.
+
+This is why FlowCraft's leaderboard headline will be a **single
+`--soft-merge=false` row tied to one commit hash, one report
+artifact, one declared judge prompt**, and a paragraph naming the
+competitor numbers we're quoting from above — not a single
+synthesised ranking.
+
+### LongMemEval — LongMemEvalS (~115k tokens / question)
+
+| System                                    | answer-LLM  | Overall accuracy | Source                                                                                                      |
+| ----------------------------------------- | ----------- | ---------------: | ----------------------------------------------------------------------------------------------------------- |
+| Llama 3.1 8B (long-context, no memory)    | self        |            45.4% | [LongMemEval paper](https://arxiv.org/abs/2410.10813) Fig 3b                                                |
+| Phi-3 14B (long-context, no memory)       | self        |            38.0% | [LongMemEval paper](https://arxiv.org/abs/2410.10813) Fig 3b                                                |
+| Llama 3.1 70B (long-context, no memory)   | self        |            33.4% | [LongMemEval paper](https://arxiv.org/abs/2410.10813) Fig 3b                                                |
+| Full-context with gpt-4o-mini (no memory) | gpt-4o-mini |            55.4% | [Zep blog](https://blog.getzep.com/state-of-the-art-agent-memory/)                                          |
+| GPT-4o (long-context, no memory)          | self        |            60.6% | [LongMemEval paper](https://arxiv.org/abs/2410.10813) Fig 3b                                                |
+| Mem0 (independent eval)                   | gpt-4o      |            49.0% | [Zep blog](https://blog.getzep.com/state-of-the-art-agent-memory/) (cited as "Mem0 independent evaluation") |
+| Zep + gpt-4o-mini                         | gpt-4o-mini |            60.2% | [Zep blog](https://blog.getzep.com/state-of-the-art-agent-memory/)                                          |
+| Full-context with gpt-4o (no memory)      | gpt-4o      |            63.8% | [Zep blog](https://blog.getzep.com/state-of-the-art-agent-memory/)                                          |
+| Zep + gpt-4o                              | gpt-4o      |        **71.2%** | [Zep blog](https://blog.getzep.com/state-of-the-art-agent-memory/)                                          |
+| **FlowCraft**                             | `[pending]` |      `[pending]` | our `eval-longmemeval.yml` run                                                                              |
+
+**Methodology common to cited rows above**:
+
+```yaml
+judge_model: gpt-4o (LongMemEval paper protocol)
+judge_prompt: LongMemEval official grader
+dataset: LongMemEvalS (115k tokens / question, ~50 sessions)
+question_types: single-session-user/assistant/preference, multi-session, knowledge-update, temporal, abstention
+```
+
+**Zep's per-question-type breakdown vs full-context baseline** (gpt-4o,
+from [Zep blog](https://blog.getzep.com/state-of-the-art-agent-memory/)):
+
+| Question type             | Full-context |   Zep |      Δ |
+| ------------------------- | -----------: | ----: | -----: |
+| single-session-preference |        20.0% | 56.7% |  +184% |
+| single-session-assistant  |        94.6% | 80.4% | −17.7% |
+| single-session-user       |        81.4% | 92.9% | +14.1% |
+| temporal-reasoning        |        45.1% | 62.4% | +38.4% |
+| multi-session             |        44.3% | 57.9% | +30.7% |
+| knowledge-update          |        78.2% | 83.3% |  +6.5% |
+
+This breakdown matters because it shows a memory system that crushes
+full-context on temporal / multi-session / preference reasoning
+_loses_ on the simplest single-session-assistant questions (the
+condensation step drops information that full-context still has).
+A leaderboard with only "overall" hides this trade-off.
+
+### LongMemEval — commercial systems (short history pilot)
+
+[LongMemEval paper](https://arxiv.org/abs/2410.10813) §3.4 also evaluates
+ChatGPT's built-in memory + Coze on a **97-question subset with
+3–6 session histories** (~10× shorter than LongMemEvalS); these are
+_not_ directly comparable to the S-scale rows above but useful for
+context on where closed-source assistant memory sits today:
+
+| System                    | Underlying LLM | Accuracy | Source                                                       |
+| ------------------------- | -------------- | -------: | ------------------------------------------------------------ |
+| Offline reading (oracle)  | gpt-4o         |   91.84% | [LongMemEval paper](https://arxiv.org/abs/2410.10813) Fig 3a |
+| ChatGPT (built-in memory) | gpt-4o-mini    |   71.13% | [LongMemEval paper](https://arxiv.org/abs/2410.10813) Fig 3a |
+| ChatGPT (built-in memory) | gpt-4o         |   57.73% | [LongMemEval paper](https://arxiv.org/abs/2410.10813) Fig 3a |
+| Coze (built-in memory)    | gpt-4o         |   32.99% | [LongMemEval paper](https://arxiv.org/abs/2410.10813) Fig 3a |
+| Coze (built-in memory)    | gpt-3.5-turbo  |   24.74% | [LongMemEval paper](https://arxiv.org/abs/2410.10813) Fig 3a |
+
+Note the inversion: ChatGPT-with-gpt-4o-mini scores 13pp _higher_
+than ChatGPT-with-gpt-4o. The paper attributes this to gpt-4o's
+tendency to overwrite memory entries it deems "outdated".
+
+### BEIR scifact
+
+> **Sourcing note**: per-dataset BEIR breakdown is awkward. BGE-M3's
+> paper and OpenAI's `text-embedding-3-large` announcement publish
+> only **BEIR-average** or **MTEB-average**, not SciFact-specific
+> nDCG@10. The verifiable per-task numbers below come from each
+> model's **HuggingFace `model-index` YAML** (the canonical
+> machine-readable claim shipped with each model card), with the
+> BEIR-paper BM25 baseline as the lexical anchor. Models without a
+> public `model-index` entry on SciFact are marked accordingly.
+
+| Engine / model                  | Type                            |                    nDCG@10 |                 Recall@100 | Source                                                                                                                                                                                                                                                                      |
+| ------------------------------- | ------------------------------- | -------------------------: | -------------------------: | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| BM25 (Anserini / Lucene)        | sparse / lexical                |                      0.665 |                          — | [BEIR paper](https://arxiv.org/pdf/2104.08663) Anserini reference; also cited by [Anserini regression docs](https://github.com/castorini/anserini/blob/master/docs/regressions-beir-v1.0.0-scifact-flat.md)                                                                 |
+| BGE-large-en-v1.5 (English)     | dense                           |                 **0.7461** |                     0.9483 | [BAAI/bge-large-en-v1.5 HF model-index YAML](https://huggingface.co/BAAI/bge-large-en-v1.5/blob/main/README.md)                                                                                                                                                             |
+| E5-large-v2 (English)           | dense                           |                 **0.7224** |                     0.9627 | [intfloat/e5-large-v2 HF model-index YAML](https://huggingface.co/intfloat/e5-large-v2/blob/main/README.md)                                                                                                                                                                 |
+| multilingual-e5-large           | dense (multi-lingual)           |                 **0.7041** |                     0.9387 | [intfloat/multilingual-e5-large HF model-index YAML](https://huggingface.co/intfloat/multilingual-e5-large/blob/main/README.md)                                                                                                                                             |
+| BGE-M3 (dense mode)             | dense (multi-lingual, long-doc) | `[not published per-task]` | `[not published per-task]` | [BGE-M3 paper](https://arxiv.org/abs/2402.03216) publishes BEIR-avg only; SciFact breakdown not in the [HF model card](https://huggingface.co/BAAI/bge-m3) (no `model-index` YAML). Pull from [MTEB leaderboard](https://huggingface.co/spaces/mteb/leaderboard) if needed. |
+| OpenAI text-embedding-3-large   | dense                           | `[not published per-task]` | `[not published per-task]` | [OpenAI embedding blog](https://openai.com/index/new-embedding-models-and-api-updates/) only publishes MTEB-avg 64.6 and MIRACL-avg 54.9; no SciFact breakdown. Community-submitted MTEB results circulate but lack a canonical author-blessed citation.                    |
+| **FlowCraft (in-process BM25)** | sparse / lexical                |                `[pending]` |                `[pending]` | our `eval-beir.yml --root /var/lib/flowcraft-eval/datasets/scifact`                                                                                                                                                                                                         |
+| **FlowCraft (vector / hybrid)** | dense / hybrid                  |                `[pending]` |                `[pending]` | same, with `--embedder qwen:text-embedding-v4`                                                                                                                                                                                                                              |
+
+**Methodology**: all rows use the standard BEIR scifact split
+(corpus.jsonl + queries.jsonl + qrels/test.tsv, 5,183 docs, 300 test
+queries). BM25 numbers from BEIR are Anserini's Lucene
+implementation with default parameters; cite that explicitly when
+comparing to our in-process Go BM25 (`sdk/retrieval/memory`).
+
+### τ-bench — retail (Pass@1)
+
+| Strategy / agent                    |      Pass@1 |      Pass@4 | Source                                                                    |
+| ----------------------------------- | ----------: | ----------: | ------------------------------------------------------------------------- |
+| TC + gpt-4o-mini                    |        (??) |        (??) | [Sierra README](https://github.com/sierra-research/tau-bench) (marked ??) |
+| TC + claude-3-5-sonnet-20240620     |       0.626 |       0.387 | [Sierra README](https://github.com/sierra-research/tau-bench)             |
+| TC + gpt-4o                         |       0.604 |       0.383 | [Sierra README](https://github.com/sierra-research/tau-bench)             |
+| TC + claude-3-5-sonnet-20241022     |   **0.692** |   **0.462** | [Sierra README](https://github.com/sierra-research/tau-bench)             |
+| **FlowCraft (TC + same agent-LLM)** | `[pending]` | `[pending]` | our `eval-taubench.yml --domain retail`                                   |
+
+### τ-bench — airline (Pass@1)
+
+| Strategy / agent                    |      Pass@1 |      Pass@4 | Source                                                        |
+| ----------------------------------- | ----------: | ----------: | ------------------------------------------------------------- |
+| TC + gpt-4o-mini                    |       0.225 |       0.100 | [Sierra README](https://github.com/sierra-research/tau-bench) |
+| TC + claude-3-5-sonnet-20240620     |       0.360 |       0.139 | [Sierra README](https://github.com/sierra-research/tau-bench) |
+| TC + gpt-4o                         |       0.420 |       0.200 | [Sierra README](https://github.com/sierra-research/tau-bench) |
+| TC + claude-3-5-sonnet-20241022     |   **0.460** |   **0.225** | [Sierra README](https://github.com/sierra-research/tau-bench) |
+| Act (gpt-4o)                        |       0.365 |       0.140 | [Sierra README](https://github.com/sierra-research/tau-bench) |
+| ReAct (gpt-4o)                      |       0.325 |       0.160 | [Sierra README](https://github.com/sierra-research/tau-bench) |
+| **FlowCraft (TC + same agent-LLM)** | `[pending]` | `[pending]` | our `eval-taubench.yml --domain airline`                      |
+
+**Caveat**: Sierra's main README warns that the original retail /
+airline task definitions are outdated; they recommend
+[τ³-bench](https://github.com/sierra-research/tau2-bench) as the
+current canonical version. Our mini-fixtures track the original
+schema. When we publish, link both.
+
+### SimpleQA — per-model (not framework)
+
+SimpleQA scores attribute almost entirely to the model under test,
+not to the harness around it. This table is therefore a
+**model citation reference**, not a framework comparison. FlowCraft
+is in the harness column; if our number for the same model differs
+by more than ±1pp from the cited one, the harness has drifted from
+the upstream protocol and we owe an investigation before publishing
+anything else from this suite.
+
+All rows are SimpleQA overall accuracy (zero-shot, chain-of-thought,
+official grader) pulled from
+[`openai/simple-evals` README](https://github.com/openai/simple-evals#benchmark-results)
+— the top-level benchmark table, "SimpleQA" column. The non-OpenAI
+rows are what `openai/simple-evals` itself cites from each vendor's
+announcement post; we keep the second-hand citation rather than
+re-deriving from the vendor card.
+
+| Model                      | SimpleQA accuracy | Primary source                                                                                                                                                            |
+| -------------------------- | ----------------: | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| o1-mini                    |               7.6 | [openai/simple-evals](https://github.com/openai/simple-evals#benchmark-results)                                                                                           |
+| gpt-4.1-nano-2025-04-14    |               7.6 | [openai/simple-evals](https://github.com/openai/simple-evals#benchmark-results)                                                                                           |
+| gpt-4o-mini-2024-07-18     |               9.5 | [openai/simple-evals](https://github.com/openai/simple-evals#benchmark-results)                                                                                           |
+| o3-mini                    |              13.4 | [openai/simple-evals](https://github.com/openai/simple-evals#benchmark-results)                                                                                           |
+| gpt-4.1-mini-2025-04-14    |              16.8 | [openai/simple-evals](https://github.com/openai/simple-evals#benchmark-results)                                                                                           |
+| o4-mini                    |              20.2 | [openai/simple-evals](https://github.com/openai/simple-evals#benchmark-results)                                                                                           |
+| Claude 3 Opus              |              23.5 | [Anthropic Claude 3 announcement](https://www.anthropic.com/news/claude-3-family) via [openai/simple-evals](https://github.com/openai/simple-evals#benchmark-results)     |
+| Claude 3.5 Sonnet          |              28.9 | [Anthropic Claude 3.5 announcement](https://www.anthropic.com/news/claude-3-5-sonnet) via [openai/simple-evals](https://github.com/openai/simple-evals#benchmark-results) |
+| gpt-4o-2024-11-20          |              38.8 | [openai/simple-evals](https://github.com/openai/simple-evals#benchmark-results)                                                                                           |
+| gpt-4o-2024-05-13          |              39.0 | [openai/simple-evals](https://github.com/openai/simple-evals#benchmark-results)                                                                                           |
+| gpt-4o-2024-08-06          |              40.1 | [openai/simple-evals](https://github.com/openai/simple-evals#benchmark-results)                                                                                           |
+| gpt-4.1-2025-04-14         |              41.6 | [openai/simple-evals](https://github.com/openai/simple-evals#benchmark-results)                                                                                           |
+| o1-preview                 |              42.4 | [openai/simple-evals](https://github.com/openai/simple-evals#benchmark-results)                                                                                           |
+| o1                         |              42.6 | [openai/simple-evals](https://github.com/openai/simple-evals#benchmark-results)                                                                                           |
+| o3-high                    |              48.6 | [openai/simple-evals](https://github.com/openai/simple-evals#benchmark-results)                                                                                           |
+| o3                         |              49.4 | [openai/simple-evals](https://github.com/openai/simple-evals#benchmark-results)                                                                                           |
+| gpt-4.5-preview-2025-02-27 |          **62.5** | [openai/simple-evals](https://github.com/openai/simple-evals#benchmark-results)                                                                                           |
+
+**FlowCraft parity check** (Phase-1 self-check): pick
+`gpt-4o-mini-2024-07-18` (cheapest publicly-graded model), run
+`eval-simpleqa.yml --answer-llm <gpt-4o-mini alias>`, and verify
+attempted-accuracy is within ±1pp of 9.5%. Status: `[pending]`.
+
+**Qwen / DeepSeek / Grok 3 / Llama 3.1 SimpleQA numbers**: not in
+the openai/simple-evals README. Cite from each vendor's
+announcement post when filling in. Status: `[pending]`.
+
+## What Phase 1 ships
+
+A practical citation-only first cut, day-by-day rough order:
+
+1. **LoCoMo10** — mem0 row from its paper; Letta row if any; Zep
+   row from its blog; LongMemEval paper baselines as "for context".
+   FlowCraft self-row from our latest `eval-locomo.yml` run with
+   `--soft-merge=false`. _Half a day of sourcing + our own run._
+2. **LongMemEval `_oracle`** — mem0 row; MemoryScope row from its
+   README; LongMemEval paper baselines. FlowCraft self-row from
+   `eval-longmemeval.yml`. _Half a day._
+3. **BEIR scifact** — pull BM25 (Anserini) + BGE-M3 + E5 numbers
+   from the BEIR leaderboard. FlowCraft self-row from
+   `eval-beir.yml`. _A few hours._
+4. **SimpleQA self-check** — one `eval-simpleqa.yml` run on
+   `gpt-4o-mini`; verify within ±1pp of OpenAI's announcement
+   number; fix the harness if not. _A few hours._
+5. **τ-bench retail** — pull Sierra's published Pass@1 for the same
+   agent-LLMs from their readme. FlowCraft self-row from
+   `eval-taubench.yml`. _A few hours._
+
+After this lands, the table is comparable on inspection (everyone
+can see the methodology gaps) and we have a credible "where do we
+stand" picture without writing a line of adapter code.
+
+## Open questions for the operator
+
+These do not block Phase 0 (this methodology) but block Phase 1
+(filling in numbers):
+
+1. **Publishing cadence.** Quarterly? On every FlowCraft minor
+   release? — affects how stale rows are handled.
+2. **Reproduction budget.** FlowCraft self-rows cost LLM tokens. Do
+   we pay for nightly regressions or only on demand?
+3. **Where the leaderboard is hosted.** This `.md` file?
+   `docs.flowcraft.dev/leaderboard`? Internal-only? — affects how
+   careful we must be with the "this number could be misread"
+   framing.
+4. **Who signs off** on a new row. Eval owner alone, or a second
+   reviewer? — same governance as a release.


### PR DESCRIPTION
## Summary

Six commits' worth of eval methodology and \`eval/beir\` adapter hardening, in one ship-able piece. The headline deliverable is a new top-level \`eval/leaderboard.md\` (688 lines) that cites every external comparison number with a primary source and lays out the FlowCraft methodology audit trail; the supporting work is the BEIR adapter changes that made those numbers actually defensible.

## What lands

| Area | Change |
| --- | --- |
| **\`eval/leaderboard.md\`** (new, 688 lines) | Per-benchmark tables (LoCoMo, LongMemEvalS, BEIR scifact, τ-bench retail/airline, SimpleQA) with primary-source citations, FlowCraft rows with explicit methodology disclosures, and a \"What Phase 1 ships\" rollout plan |
| **\`eval/README.md\`** (+144 lines) | Methodology disclosures pulled out of inline comments into a single reference |
| **\`eval/beir/beir.go\`** (+246 lines) | (1) Chunks→docID collapse so BEIR adapter no longer reports impossible recall@100 = 3.003; (2) CollapseStrategy enum (max/sum/first) for ablation; (3) over-fetch factor; (4) lifecycle Event stream (ingest_start / ingest_progress / lane_*) |
| **\`eval/beir/cli.go\`** (+38 lines) | \`--collapse-strategy\`, \`--overfetch\` flags; mirror lifecycle events to stderr for live progress |
| **\`.github/workflows/eval-beir.yml\`** | \`collapse_strategy\` and \`overfetch\` workflow inputs; **lanes-aware embedder gate** that fixes the silent-default-embedder bug when \`-f embedder=\` is dropped by \`gh\` CLI |
| **\`eval/beir/beir_test.go\`** | Updated for the new ingest_start event |

## Notable findings recorded in \`leaderboard.md\`

**BEIR scifact ablation** (BM25 lane, 300 test queries):

| \`--collapse-strategy\` | \`--overfetch\` | run | nDCG@10 | recall@100 |
| --- | --- | --- | ---: | ---: |
| max (default) | 4 | \`25839108340\` | **0.180** | 0.255 |
| max | 8 | \`25839125186\` | 0.152 | 0.212 |
| sum | 4 | \`25840471567\` | 0.054 | 0.207 |

The headline row (\`0.180\`) is **chunk-level** BM25 followed by a max-pool collapse to doc-level for evaluation against doc-level qrels. **Not directly comparable to Anserini/Lucene's \`0.665\`**, which is doc-level. The gap is the cost of chunking and was the motivation for #126.

The sum-pool ablation (\`0.054\`) is the receipt for why sum-pool was tried and rejected: scifact's abstracts are length-skewed, so long non-relevant docs accumulate per-chunk noise and outrank short relevant ones. Sum-pool stays selectable as an ablation; max-pool is the default.

**SimpleQA parity gate passed**: run \`25837614443\` shows FlowCraft + gpt-4o-mini-via-Azure within 0.55 pp of the OpenAI-cited \`9.5%\` baseline (10.05%), \`judge_failures=0\`. Documented in §SimpleQA.

## Test plan

- [x] \`go test ./eval/beir/...\` — passes (incl. updated ingest_start expectation)
- [x] \`go vet ./eval/beir/...\` — clean
- [x] Five published BEIR runs (\`25839108340\`, \`25839125186\`, \`25840471567\`, \`25837614443\`, \`25840471567\`) — all cited by run-id in \`leaderboard.md\`
- [ ] Once merged, follow-up PR migrates \`eval/beir\` to use the new \`knowledge.Service.SearchDocuments\` API (landed in #127), which is expected to take the BEIR scifact row from \`0.180\` to something in the \`0.5-0.7\` range. The leaderboard row + ablation table will be updated in that PR.

## Out of scope

1. **\`eval/beir\` adapter migration to \`SearchDocuments\`** — follow-up PR. The chunks→docID collapse infrastructure landing here is the bridge that gets us from \"impossible recall@100 = 3.003\" to \"defensible chunk-level number with a documented gap to Lucene\"; once the doc-level API is wired in (#127 is the SDK side, already in main), the collapse path becomes dead code and can be retired.

2. **\`sdkx/retrieval/workspace\` per-segment BM25 (#125)** — independent issue, different backend.

3. **LongMemEvalS / LoCoMo full headline runs** — pending; methodology and dataset staging recorded in \`leaderboard.md\` §\"What Phase 1 ships\".

## Refs

- Surfaces #125 and #126 (both opened during this investigation)
- SDK doc-level Search API for the planned BEIR migration: #127 (merged)


Made with [Cursor](https://cursor.com)