### PR TITLE
fix(sdkx/retrieval/workspace): aggregate BM25 corpus across segments (closes #125)

### DIFF
--- a/sdkx/retrieval/workspace/read.go
+++ b/sdkx/retrieval/workspace/read.go
@@ -20,10 +20,16 @@ import (
 //     The memtable wins over any segment for an ID it stages, and
 //     a newer segment's tombstone wins over an older segment's
 //     content.
-//  3. Per-segment scoring: BM25 for QueryText is computed by
-//     [textsearch.BM25] against the segment-local
-//     [textsearch.CorpusStats] (rebuilt on first load by
-//     [segmentReader.loadBM25]); cosine for QueryVector is
+//  3. BM25 scoring uses a per-Search GLOBAL corpus aggregated from
+//     every live (non-tombstoned, not-overridden) segment +
+//     memtable doc. Each segment caches its [textsearch.Tokenizer]
+//     output via [segmentReader.loadBM25]; Search folds those
+//     tokens (plus freshly-tokenized memtable docs) into a single
+//     [textsearch.CorpusStats] before scoring. This matches the
+//     reference [sdk/retrieval/memory.Index] behaviour and the
+//     BM25 protocol — IDF is corpus-relative, so a per-segment
+//     corpus would make a doc's rank depend on which segment it
+//     happens to live in. Cosine for QueryVector is
 //     [scoring.CosineSim] over the doc's Vector field. Hybrid
 //     fuses the per-modality rankings via [scoring.RRF].
 //  4. Filter pushdown: the workspace backend evaluates the full
@@ -74,38 +80,32 @@ func (idx *Index) Search(
 	keywords := textsearch.ExtractKeywords(req.QueryText, idx.cfg.tokenizer)
 	queryVec := req.QueryVector
 
-	// merged tracks the best score per ID across segments + memtable.
-	// Newest writer wins on ID collisions; the search loop only
-	// records a doc the first time it sees the ID and skips later
-	// (older) copies.
-	merged := make(map[string]*partial)
+	// Phase 1: walk the snapshot newest-first, collecting one
+	// liveDoc per surviving ID. Filter is NOT applied here — the
+	// global BM25 corpus must reflect every live doc in the
+	// namespace (Lucene/`sdk/retrieval/memory.Index` behaviour);
+	// applying the filter pre-scoring would bake the filtered
+	// subset into IDF and break ranking when the same query is
+	// run with different filters.
+	live := make(map[string]*liveDoc)
 	deleted := make(map[string]struct{})
 
-	// Memtable first: it is the freshest writer.
 	for _, it := range memSnap {
 		if it.op == walOpDelete {
 			deleted[it.id] = struct{}{}
-			delete(merged, it.id)
+			delete(live, it.id)
 			continue
 		}
 		if it.doc == nil {
 			continue
 		}
-		if !retrieval.DocMatchesFilter(*it.doc, req.Filter) {
-			continue
+		ld := &liveDoc{doc: cloneDoc(*it.doc)}
+		if hasText {
+			ld.tokens = idx.cfg.tokenizer.Tokenize(it.doc.Content)
 		}
-		p := &partial{doc: cloneDoc(*it.doc)}
-		if hasText && len(keywords) > 0 {
-			p.bm = scoreMemtableBM25(it.doc.Content, keywords, idx.cfg.tokenizer)
-		}
-		if hasVec && len(it.doc.Vector) == len(queryVec) {
-			p.cos = scoring.CosineSim(queryVec, it.doc.Vector)
-		}
-		merged[it.id] = p
+		live[it.id] = ld
 	}
 
-	// Newest segment first so a fresh tombstone overrides an old
-	// content row.
 	segs := append([]segmentRef(nil), manifestSnap.Segments...)
 	sort.Slice(segs, func(i, j int) bool { return segs[i].ID > segs[j].ID })
 
@@ -114,13 +114,12 @@ func (idx *Index) Search(
 		if err != nil {
 			return nil, err
 		}
-		// Apply this segment's tombstones to the cumulative set
-		// FIRST: a segment's tombstone for ID X means X was deleted
+		// A segment's tombstone for ID X means X was deleted
 		// at the time of this segment's flush, so any older
 		// segment must not surface X.
 		for id := range seg.tombSet {
-			if _, ok := merged[id]; ok {
-				delete(merged, id)
+			if _, ok := live[id]; ok {
+				delete(live, id)
 			}
 			deleted[id] = struct{}{}
 		}
@@ -138,31 +137,49 @@ func (idx *Index) Search(
 			if _, ok := deleted[d.ID]; ok {
 				continue
 			}
-			if _, ok := merged[d.ID]; ok {
-				// A fresher copy already ranks the doc; segments
-				// can't override the freshest writer.
+			if _, ok := live[d.ID]; ok {
+				// A fresher writer already claimed this ID; older
+				// segments can't override the freshest copy.
 				continue
 			}
-			if !retrieval.DocMatchesFilter(d, req.Filter) {
-				continue
+			ld := &liveDoc{doc: cloneDoc(d)}
+			if hasText && seg.docTokens != nil {
+				ld.tokens = seg.docTokens[i]
 			}
-			p := &partial{doc: cloneDoc(d)}
-			if hasText && seg.corpus != nil && len(keywords) > 0 {
-				p.bm = textsearch.BM25(seg.docTokens[i], keywords, seg.corpus)
-			}
-			if hasVec && len(d.Vector) == len(queryVec) {
-				p.cos = scoring.CosineSim(queryVec, d.Vector)
-			}
-			// We deliberately keep zero-score docs in the result
-			// set: the [retrieval.Index] contract (matched by the
-			// in-memory backend) is "every filter-passing doc is
-			// a candidate; the caller decides via MinScore /
-			// TopK". Search would otherwise diverge on the
-			// degenerate "QueryText='x' (one-char, tokenizes to
-			// nothing) + Filter only" pattern that the contract
-			// suite exercises.
-			merged[d.ID] = p
+			live[d.ID] = ld
 		}
+	}
+
+	// Phase 2: build the per-Search global corpus. Memtable docs
+	// and segment docs go through the same path (AddDocument), so
+	// pre-flush ranks match post-flush ranks for the same doc set.
+	var globalCorpus *textsearch.CorpusStats
+	if hasText {
+		globalCorpus = textsearch.NewCorpusStats()
+		for _, ld := range live {
+			if len(ld.tokens) > 0 {
+				globalCorpus.AddDocument(ld.tokens)
+			}
+		}
+	}
+
+	// Phase 3: score against the global corpus and apply the
+	// filter as a post-step. Zero-score docs are deliberately kept
+	// (matches the in-memory backend contract — every filter-
+	// passing doc is a candidate; MinScore / TopK trims later).
+	merged := make(map[string]*partial, len(live))
+	for id, ld := range live {
+		if !retrieval.DocMatchesFilter(ld.doc, req.Filter) {
+			continue
+		}
+		p := &partial{doc: ld.doc}
+		if hasText && globalCorpus != nil && globalCorpus.DocCount > 0 && len(keywords) > 0 {
+			p.bm = textsearch.BM25(ld.tokens, keywords, globalCorpus)
+		}
+		if hasVec && len(ld.doc.Vector) == len(queryVec) {
+			p.cos = scoring.CosineSim(queryVec, ld.doc.Vector)
+		}
+		merged[id] = p
 	}
 
 	scoreds := make([]partial, 0, len(merged))
@@ -174,32 +191,21 @@ func (idx *Index) Search(
 	return &retrieval.SearchResponse{Hits: hits, Took: idx.cfg.now().Sub(start)}, nil
 }
 
+// liveDoc is the per-Search snapshot of one doc that survived the
+// memtable / segment / tombstone merge. tokens is non-nil only on
+// the BM25 path; an empty tokens slice (content tokenizes to
+// nothing) is preserved so the doc is still ranked as a zero-score
+// candidate.
+type liveDoc struct {
+	doc    retrieval.Doc
+	tokens []string
+}
+
 // partial holds the per-doc accumulated lane scores during a Search.
 type partial struct {
 	doc retrieval.Doc
 	bm  float64
 	cos float64
-}
-
-// scoreMemtableBM25 scores a single memtable doc against the query
-// keywords using a synthetic 1-doc corpus. Numerically inferior to
-// a "real" segment hit (because the corpus stats are tiny) but
-// keeps memtable docs from being absent from results pre-flush;
-// post-flush the segment-local scores dominate the ranking.
-func scoreMemtableBM25(content string, keywords []string, tok textsearch.Tokenizer) float64 {
-	tokens := tok.Tokenize(content)
-	if len(tokens) == 0 {
-		return 0
-	}
-	corpus := &textsearch.CorpusStats{
-		DocCount:  1,
-		AvgLength: float64(len(tokens)),
-		DocFreq:   make(map[string]int, len(keywords)),
-	}
-	for _, k := range keywords {
-		corpus.DocFreq[k] = 1
-	}
-	return textsearch.BM25(tokens, keywords, corpus)
 }
 
 // rankAndProject sorts scoreds, applies MinScore on single-modality

--- a/sdkx/retrieval/workspace/read_test.go
+++ b/sdkx/retrieval/workspace/read_test.go
@@ -375,6 +375,147 @@ func TestDeleteByFilter_EmptyFilterRejected(t *testing.T) {
 	}
 }
 
+// TestSearch_BM25_ScoreIsSegmentationInvariant guards the
+// regression in issue #125: BM25 IDF must be computed against a
+// global corpus, so each doc's score must NOT depend on how the
+// corpus is split across segments.
+//
+// We construct the same corpus twice — once flushed as a single
+// segment, once forced into many small segments via a tight
+// MemtableMaxDocs — and assert per-doc BM25 scores match. Under
+// per-segment corpus stats the IDF differs across segments and
+// this test fails by tens of percent on terms with skewed df.
+func TestSearch_BM25_ScoreIsSegmentationInvariant(t *testing.T) {
+	docs := bm25CorpusForRanking()
+
+	scoreSingle := bm25Scores(t, buildAndFlushAll(t, docs, 1024 /* one segment */),
+		"machine learning")
+	scoreSplit := bm25Scores(t, buildAndFlushAll(t, docs, 3 /* ~7 segments */),
+		"machine learning")
+
+	if len(scoreSingle) != len(docs) {
+		t.Fatalf("expected %d hits in single-segment search, got %d", len(docs), len(scoreSingle))
+	}
+	if len(scoreSingle) != len(scoreSplit) {
+		t.Fatalf("hit count diverges: single=%d split=%d", len(scoreSingle), len(scoreSplit))
+	}
+	for id, single := range scoreSingle {
+		split, ok := scoreSplit[id]
+		if !ok {
+			t.Errorf("doc %q present in single but missing from split", id)
+			continue
+		}
+		// Floating point is exact here because both paths sum the
+		// same terms in the same order against an identical
+		// corpus; a tolerance would mask a real regression.
+		if single != split {
+			t.Errorf("BM25 score for %q diverges: single=%g split=%g", id, single, split)
+		}
+	}
+}
+
+// TestSearch_BM25_MemtableMatchesSegmentScore guards the second
+// half of the issue #125 fix: a doc's BM25 score must not jump
+// when its host writer transitions from memtable to segment, given
+// the same surrounding corpus. Pre-fix this failed because
+// memtable docs scored against a synthetic 1-doc corpus while
+// segment docs scored against the segment-local corpus.
+func TestSearch_BM25_MemtableMatchesSegmentScore(t *testing.T) {
+	docs := bm25CorpusForRanking()
+
+	preIdx, _ := newIdx(t, wsindex.WithMemtableMaxDocs(1024))
+	if err := preIdx.Upsert(context.Background(), "ns", docs); err != nil {
+		t.Fatal(err)
+	}
+	pre := bm25Scores(t, preIdx, "machine learning")
+
+	post := bm25Scores(t, buildAndFlushAll(t, docs, 1024), "machine learning")
+
+	if len(pre) != len(post) {
+		t.Fatalf("hit count diverges memtable=%d segment=%d", len(pre), len(post))
+	}
+	for id, pv := range pre {
+		ppv, ok := post[id]
+		if !ok {
+			t.Errorf("doc %q present in memtable result but missing from segment result", id)
+			continue
+		}
+		if pv != ppv {
+			t.Errorf("BM25 score for %q diverges: memtable=%g segment=%g", id, pv, ppv)
+		}
+	}
+}
+
+// bm25CorpusForRanking returns a small but rank-meaningful corpus.
+// Every doc shares some vocab so DocFreq is non-trivial and the
+// per-segment-vs-global IDF gap is observable.
+func bm25CorpusForRanking() []retrieval.Doc {
+	return []retrieval.Doc{
+		{ID: "d01", Content: "machine learning models learn patterns from data"},
+		{ID: "d02", Content: "deep learning networks recognize patterns in images"},
+		{ID: "d03", Content: "machine machine learning learning is everywhere now"},
+		{ID: "d04", Content: "data data data pipelines feed learning systems"},
+		{ID: "d05", Content: "fox jumps over lazy dog under bright sun"},
+		{ID: "d06", Content: "machine vision detects objects in real time scenes"},
+		{ID: "d07", Content: "graph models capture structural patterns in networks"},
+		{ID: "d08", Content: "statistical learning theory underpins many machine methods"},
+		{ID: "d09", Content: "the lazy fox does not chase any dog at all"},
+		{ID: "d10", Content: "patterns in data inform learning rates and choices"},
+		{ID: "d11", Content: "robotics combines machine vision and machine learning"},
+		{ID: "d12", Content: "lemma the proof relies on continuity not convergence"},
+		{ID: "d13", Content: "music music music notes drift across the lazy river"},
+		{ID: "d14", Content: "machine code differs from machine learning programs"},
+		{ID: "d15", Content: "dataset shift breaks learning guarantees in practice"},
+		{ID: "d16", Content: "kernel methods are a venerable learning approach"},
+		{ID: "d17", Content: "feature engineering still matters for many learning tasks"},
+		{ID: "d18", Content: "embedding learning surfaces latent semantic structure"},
+		{ID: "d19", Content: "online learning adapts as new examples arrive"},
+		{ID: "d20", Content: "machine learning at scale demands careful engineering"},
+	}
+}
+
+// buildAndFlushAll ingests docs in flushPer-sized batches, flushing
+// after each batch so the resulting index has roughly len(docs)/flushPer
+// segments. flushPer >= len(docs) yields a single segment.
+func buildAndFlushAll(t *testing.T, docs []retrieval.Doc, flushPer int) *wsindex.Index {
+	t.Helper()
+	idx, _ := newIdx(t, wsindex.WithMemtableMaxDocs(flushPer), wsindex.WithAutoCompact(false))
+	ctx := context.Background()
+	for start := 0; start < len(docs); start += flushPer {
+		end := start + flushPer
+		if end > len(docs) {
+			end = len(docs)
+		}
+		if err := idx.Upsert(ctx, "ns", docs[start:end]); err != nil {
+			t.Fatal(err)
+		}
+		if err := idx.Flush(ctx, "ns"); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return idx
+}
+
+// bm25Scores runs a Search and returns the per-doc BM25 lane
+// score keyed by doc ID. Compares cleanly even when ties make rank
+// order nondeterministic — the score itself is the BM25 protocol
+// guarantee, not the rank tiebreaker.
+func bm25Scores(t *testing.T, idx *wsindex.Index, query string) map[string]float64 {
+	t.Helper()
+	resp, err := idx.Search(context.Background(), "ns", retrieval.SearchRequest{
+		QueryText: query,
+		TopK:      1000,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	out := make(map[string]float64, len(resp.Hits))
+	for _, h := range resp.Hits {
+		out[h.Doc.ID] = h.Score
+	}
+	return out
+}
+
 func TestSearch_ChecksumDetectsCorruption(t *testing.T) {
 	idx, ws := newIdx(t)
 	ctx := context.Background()

--- a/sdkx/retrieval/workspace/segment_reader.go
+++ b/sdkx/retrieval/workspace/segment_reader.go
@@ -53,13 +53,19 @@ type segmentReader struct {
 
 	bm25Once sync.Once
 	bm25Err  error
-	// corpus is the segment-local BM25 corpus statistics. Set
-	// alongside docTokens by [loadBM25]; nil for tombstone-only
-	// segments.
-	corpus *textsearch.CorpusStats
 	// docTokens parallels docs: docTokens[i] is the tokenizer
-	// output for docs[i].Content. Held so search can call
-	// [textsearch.BM25] without re-tokenizing on every keyword.
+	// output for docs[i].Content. Held so [Index.Search] can both
+	// fold this segment's docs into a per-Search global corpus and
+	// score against that corpus without re-tokenizing.
+	//
+	// Note: BM25 corpus stats themselves are NOT cached on the
+	// segment. A segment-local corpus would let segments answer
+	// scoring requests in isolation, but BM25 IDF is corpus-
+	// relative and merging per-segment scores at the top of Search
+	// produces ranks that depend on which segment a doc landed in
+	// rather than its global frequency. Search rebuilds the corpus
+	// across all live (non-tombstoned) segment + memtable docs
+	// each call; tokens are the only segment-cacheable piece.
 	docTokens [][]string
 }
 
@@ -185,14 +191,13 @@ func (r *segmentReader) loadDocs(ctx context.Context) error {
 	return r.docsErr
 }
 
-// loadBM25 lazily tokenizes every doc and accumulates them into a
-// segment-local [textsearch.CorpusStats]. The corpus is segment-
-// local on purpose: BM25 is a corpus-relative score, and a per-
-// segment corpus gives stable scores across compactions (a doc's
-// score doesn't shift when a sibling segment is merged away).
+// loadBM25 lazily tokenizes every doc into r.docTokens. It does NOT
+// build a segment-local corpus: see the comment on docTokens for
+// why. Search aggregates tokens across segments + memtable into a
+// single per-call corpus before scoring.
 //
-// loadBM25 is a no-op for tombstone-only segments — the corpus
-// stays nil, which scoring code treats as "no contribution".
+// loadBM25 is a no-op for tombstone-only segments — docTokens stays
+// nil, which the search loop treats as "no contribution".
 func (r *segmentReader) loadBM25(ctx context.Context, tok textsearch.Tokenizer) error {
 	if err := r.loadDocs(ctx); err != nil {
 		return err
@@ -201,13 +206,10 @@ func (r *segmentReader) loadBM25(ctx context.Context, tok textsearch.Tokenizer) 
 		if len(r.docs) == 0 {
 			return
 		}
-		corpus := textsearch.NewCorpusStats()
 		docTokens := make([][]string, len(r.docs))
 		for i, d := range r.docs {
 			docTokens[i] = tok.Tokenize(d.Content)
-			corpus.AddDocument(docTokens[i])
 		}
-		r.corpus = corpus
 		r.docTokens = docTokens
 	})
 	return r.bm25Err


### PR DESCRIPTION
## Summary

Fixes #125. The workspace backend computed BM25 corpus stats per-segment in `segmentReader.loadBM25` and merged scores from different segments unchanged at Search time, while memtable docs were scored against a synthetic 1-doc corpus. BM25 IDF is corpus-relative, so a doc's rank depended on which segment it landed in rather than its global frequency — violating the BM25 protocol and diverging from the reference `sdk/retrieval/memory.Index`.

`Search` now runs in three phases:

1. **Collect live docs**: walk memtable + segments newest-first, keep one `liveDoc` per surviving ID, honoring tombstones and override semantics. Tokens are reused from the existing `segmentReader.docTokens` cache; memtable content is tokenized once.
2. **Build global corpus**: fold every live doc's tokens into a single per-Search `textsearch.CorpusStats` so IDF reflects the whole namespace.
3. **Score + filter**: score against the global corpus, then apply `req.Filter` as a post-step. The filter must not perturb IDF — applying it pre-scoring would make the same query produce different scores under different filters.

`segmentReader` no longer caches a per-segment `CorpusStats`; only `docTokens` survives, since Search is now the only place that builds corpus stats. The obsolete `scoreMemtableBM25` helper is removed — memtable and segment docs now go through the same path, so a doc's score is unchanged when it transitions from memtable to segment.

## Why this is the Option A from the issue

The issue weighed three options. This PR implements Option A (aggregate at Search time) because:

- Doesn't disturb the write/compact path or the on-disk segment layout.
- Reuses already-cached `docTokens` so the marginal cost is one map-merge per Search.
- Matches `sdk/retrieval/memory.Index` exactly, which is the reference cited by every BEIR baseline.

Option B (rebuild on every compaction) was rejected by the reporter as too expensive. Option C (document as experimental) walks back the workspace stabilisation path documented in `tests/e2e/retrieval/doc.go`.

## Test plan

Two new regression tests in `sdkx/retrieval/workspace/read_test.go`:

- `TestSearch_BM25_ScoreIsSegmentationInvariant`: ingests the same 20-doc corpus twice — once flushed as a single segment, once split into ~7 segments via `WithMemtableMaxDocs(3)` — and asserts per-doc BM25 scores match bit-exactly. Under per-segment corpus stats this fails by tens of percent on terms with skewed df.
- `TestSearch_BM25_MemtableMatchesSegmentScore`: scores the same corpus while it lives in the memtable, then again after a flush, and asserts each doc's score is unchanged. Under the old synthetic 1-doc memtable corpus this fails on every doc.

Both tests fail on `main` and pass on this branch.

- [x] `go test ./...` in both `sdk/` and `sdkx/` (all suites pass, including the existing 30+ workspace tests)
- [x] `go vet ./...` clean
- [x] New tests stable under `-count=10`
- [x] Rebased on latest `origin/main`

## Out of scope

- The latent rank-tiebreak nondeterminism (Go map iteration into `sort.SliceStable`) is unrelated to the BM25 corpus issue and affects `sdk/retrieval/memory.Index` too — left alone here. The new tests compare per-doc scores rather than rank order to avoid coupling to that.
- Sibling issue #126 (knowledge.Service Search granularity) is a different layer; already addressed by #127.

Made with [Cursor](https://cursor.com)