### PR TITLE
feat(vessel): per-run workspace via SessionStore + WithSessionStore

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -216,6 +216,30 @@ compare/fetch/ingest`, `eval longmemeval convert`). Shell completion
   mount integration is gated on the RFC that needs to align with
   `sdk/workspace`'s ScopedWorkspace contract.
 
+#### vessel
+
+- `vessel.SessionStore` + `WithSessionStore` option: per-run
+  filesystem boundary for every dispatched `agent.Run`. The
+  Captain calls `store.Open(runCtx, runID)` at the start of
+  Submit / Resume, stashes the returned `workspace.Workspace` on
+  runCtx, and invokes `store.Close(baseCtx, runID)` when the run
+  terminates (baseCtx so cleanup survives a runCtx cancellation).
+  Engines / tools reach the per-run workspace via the new
+  `vessel.WorkspaceFromContext(ctx)` helper, which falls back to
+  `(nil, false)` when no store was wired so call sites can degrade
+  gracefully. Ships with two implementations: `MemorySessionStore`
+  (in-process `MemWorkspace` per run, data discarded on Close —
+  for tests and ephemeral demos) and `FilesystemSessionStore`
+  (`<root>/<runID>/` directory tree, data preserved on Close so a
+  CheckpointStore-backed Resume can reach the on-disk state an
+  interrupted run left behind). The exported `ValidateRunID`
+  helper enforces a strict `[A-Za-z0-9_-]+` allow-list on runIDs
+  before they reach the filesystem path component, rejecting `.`,
+  `..`, `/`, and `\` so a hostile runID cannot escape the store
+  root. There is no default SessionStore: the Captain only opens a
+  session when one is wired, because the choice between in-memory
+  and on-disk is workload-dependent.
+
 ### Fixed
 
 #### sdkx

--- a/vessel/captain.go
+++ b/vessel/captain.go
@@ -50,6 +50,12 @@ type Captain struct {
 	// promise the API is built on is missing.
 	checkpointStore engine.CheckpointStore
 
+	// sessionStore provisions a per-run workspace.Workspace view
+	// for every Submit / Resume dispatch. nil when no store was
+	// wired via [WithSessionStore]; in that case WorkspaceFromContext
+	// returns (nil, false) inside every run.
+	sessionStore SessionStore
+
 	// kanban is the Kanban subsystem when spec.Kanban is non-nil;
 	// otherwise nil (no agent-as-tool dispatch). The runtime owns
 	// the board, kanban instance, and the cardID→dispatcher map
@@ -216,6 +222,7 @@ func New(vs spec.Spec, opts ...Option) (*Captain, error) {
 		gate:            gate,
 		budget:          budget,
 		checkpointStore: cfg.checkpointStore,
+		sessionStore:    cfg.sessionStore,
 		kanban:          kbRuntime,
 		globalObservers: cfg.observers,
 		globalDeciders:  cfg.deciders,
@@ -470,6 +477,23 @@ func (c *Captain) submit(ctx context.Context, agentName string, req agent.Reques
 		if ru != nil {
 			runCtx = context.WithValue(runCtx, budgetCtxKey{}, ru)
 			defer c.budget.end(req.RunID)
+		}
+
+		// Provision the per-run workspace BEFORE dispatch so engines
+		// / tools see it via WorkspaceFromContext from the very first
+		// node. Close runs on baseCtx (not runCtx) so cleanup
+		// survives a runCtx cancellation — the Open path is what
+		// reserved the resource, the Close path must always run.
+		if c.sessionStore != nil {
+			ws, err := c.sessionStore.Open(runCtx, req.RunID)
+			if err != nil {
+				h.deliver(nil, errdefs.Internalf("vessel: open session for run %q: %v", req.RunID, err))
+				return
+			}
+			runCtx = context.WithValue(runCtx, sessionCtxKey{}, ws)
+			defer func() {
+				_ = c.sessionStore.Close(c.baseCtx, req.RunID)
+			}()
 		}
 
 		res, runErr := c.dispatch(runCtx, entry, req, extraOpts...)

--- a/vessel/option.go
+++ b/vessel/option.go
@@ -194,6 +194,25 @@ func WithCheckpointStore(store engine.CheckpointStore) Option {
 	return func(c *config) { c.checkpointStore = store }
 }
 
+// WithSessionStore wires the [SessionStore] used to provision a
+// per-run [workspace.Workspace] for every dispatched agent.Run.
+//
+// When set, the Captain calls store.Open(runCtx, runID) at the start
+// of Submit and stashes the returned Workspace onto runCtx so engines
+// / tools can reach it via [WorkspaceFromContext]; store.Close is
+// invoked on the vessel baseCtx when the run terminates so cleanup
+// survives a runCtx cancellation.
+//
+// When omitted, [WorkspaceFromContext] returns (nil, false) inside
+// every run — tools that need a workspace must fall back to their
+// own wiring. There is intentionally no default SessionStore: making
+// every Captain own a temporary directory would surprise callers who
+// never asked for one, and the choice between in-memory vs. on-disk
+// is workload-dependent.
+func WithSessionStore(store SessionStore) Option {
+	return func(c *config) { c.sessionStore = store }
+}
+
 // WithBaseContext sets the parent context every Submit / Call
 // inherits from. The default is context.Background(); supplying a
 // scoped parent lets the caller propagate a tenant / request id
@@ -225,6 +244,7 @@ type config struct {
 	llmResolver     llm.LLMResolver
 	historyOverride history.History
 	checkpointStore engine.CheckpointStore
+	sessionStore    SessionStore
 
 	baseCtx context.Context
 }

--- a/vessel/session.go
+++ b/vessel/session.go
@@ -1,0 +1,265 @@
+package vessel
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+
+	"github.com/GizClaw/flowcraft/sdk/errdefs"
+	"github.com/GizClaw/flowcraft/sdk/workspace"
+)
+
+// SessionStore provisions a per-run [workspace.Workspace] view so
+// every agent.Run dispatched by a Captain gets its own filesystem
+// boundary that lives for the duration of the run.
+//
+// Lifecycle contract:
+//
+//   - Open is called once per run by Captain.submit, right after the
+//     admission gate has issued runCtx. Implementations MUST return
+//     the same Workspace for repeated Open(runID) calls within a
+//     process — that is what lets a checkpoint resume reach the same
+//     view it left, and lets in-flight retries through the same runID
+//     observe their own prior writes.
+//   - Close is called once when the run terminates (success or error).
+//     The data underneath the Workspace MAY persist or be discarded;
+//     each implementation documents its own retention policy. The
+//     Captain uses the *vessel* baseCtx (not the run's ctx) for Close
+//     so cleanup survives a runCtx cancellation.
+//
+// Engines / tools running inside a vessel-dispatched run reach their
+// per-run Workspace via [WorkspaceFromContext]. Code outside a
+// vessel run (or vessels constructed without [WithSessionStore]) sees
+// a nil Workspace + false from that helper, and should fall back to
+// caller-supplied workspaces or error out depending on the use case.
+type SessionStore interface {
+	// Open returns the per-run workspace for runID. Implementations
+	// must return the same instance for the same runID within their
+	// process lifetime; this is what makes resume / retry idempotent.
+	Open(ctx context.Context, runID string) (workspace.Workspace, error)
+
+	// Close releases bookkeeping resources for runID. Whether the
+	// underlying data is also deleted is implementation-defined:
+	// MemorySessionStore drops the in-memory map entry (so its data
+	// is gone), while FilesystemSessionStore preserves the directory
+	// on disk (deletion is an operator concern — see its docs).
+	// Calling Close on an unknown runID is a no-op.
+	Close(ctx context.Context, runID string) error
+}
+
+// WorkspaceFromContext extracts the per-run [workspace.Workspace] a
+// Captain associated with the current agent.Run. Returns (nil, false)
+// when ctx is not a vessel run context or when the Captain was built
+// without [WithSessionStore].
+//
+// The standard pattern for tools / engines that want to be
+// session-aware without hard-coding the dependency is:
+//
+//	if ws, ok := vessel.WorkspaceFromContext(ctx); ok {
+//	    // use ws — it lives until the run terminates
+//	} else {
+//	    // fall back to the tool's own workspace (or refuse)
+//	}
+//
+// This avoids a circular dependency between sdk/tool packages and
+// vessel: the helper lives in vessel, callers in sdk import it as a
+// downstream dependency.
+func WorkspaceFromContext(ctx context.Context) (workspace.Workspace, bool) {
+	ws, ok := ctx.Value(sessionCtxKey{}).(workspace.Workspace)
+	if !ok || ws == nil {
+		return nil, false
+	}
+	return ws, true
+}
+
+// sessionCtxKey is the ctx value-key Captain.submit stashes the
+// per-run Workspace under. Private so external code cannot inject a
+// counterfeit value — the only way a Workspace reaches the ctx is
+// through SessionStore.Open, which is what the security model relies
+// on (Open is where path-traversal validation and root scoping
+// happen).
+type sessionCtxKey struct{}
+
+// MemorySessionStore is the in-process, non-persistent SessionStore:
+// every run gets a freshly minted [workspace.MemWorkspace] that lives
+// in heap. Close drops the entry; the data goes with it.
+//
+// Suitable for tests, ephemeral demos, and vessels whose
+// CheckpointStore is also in-memory (so a Resume across the loss
+// boundary is impossible anyway). For production deployments with a
+// persistent CheckpointStore, pair it with FilesystemSessionStore
+// instead so Resume can reach the on-disk state the prior run left.
+//
+// Safe for concurrent Open / Close from multiple Captain goroutines.
+type MemorySessionStore struct {
+	mu       sync.Mutex
+	sessions map[string]workspace.Workspace
+}
+
+// NewMemorySessionStore constructs an empty in-memory session store.
+func NewMemorySessionStore() *MemorySessionStore {
+	return &MemorySessionStore{sessions: make(map[string]workspace.Workspace)}
+}
+
+// Open returns (or creates) the in-memory workspace for runID. The
+// runID is treated as an opaque key — no path validation is applied
+// because no filesystem path is constructed from it.
+func (s *MemorySessionStore) Open(_ context.Context, runID string) (workspace.Workspace, error) {
+	if runID == "" {
+		return nil, errdefs.Validationf("vessel: SessionStore.Open requires a non-empty runID")
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if ws, ok := s.sessions[runID]; ok {
+		return ws, nil
+	}
+	ws := workspace.NewMemWorkspace()
+	s.sessions[runID] = ws
+	return ws, nil
+}
+
+// Close drops the workspace bookkeeping for runID. Because
+// MemWorkspace data lives entirely inside the released map entry, the
+// data is discarded as soon as the last reference (typically the
+// caller's ctx-stashed pointer) goes out of scope. Calling Close on
+// an unknown runID is a no-op so retries / double-Close are safe.
+func (s *MemorySessionStore) Close(_ context.Context, runID string) error {
+	if runID == "" {
+		return nil
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	delete(s.sessions, runID)
+	return nil
+}
+
+// FilesystemSessionStore lays each run's workspace out as a
+// subdirectory of a root directory:
+//
+//	<root>/<runID>/
+//
+// A fresh runID provisions a new subdirectory; reopening the same
+// runID returns the same [workspace.LocalWorkspace] view onto it.
+// Data is preserved across Close (and across process restarts) so a
+// downstream CheckpointStore.Resume can reach the files an
+// interrupted run left behind.
+//
+// runIDs must match [ValidateRunID] so a malicious caller cannot
+// escape the root with "../etc/passwd" or "/tmp/foo". The validator
+// is intentionally narrower than the engine's runID generator emits
+// (`run-<hex>`), so the same allow-list passes for both
+// Captain-minted and caller-supplied runIDs while rejecting anything
+// that looks like a path operator.
+//
+// Disk reclamation is OUT of scope for this type. Operators decide
+// when to GC the root (cron, retention policy, manual prune). The
+// store does not delete data on Close because doing so would defeat
+// the Resume use case the persistence layer exists for; callers that
+// want ephemeral semantics should pick MemorySessionStore instead.
+//
+// Safe for concurrent Open / Close from multiple Captain goroutines.
+type FilesystemSessionStore struct {
+	root     string
+	mu       sync.Mutex
+	sessions map[string]workspace.Workspace
+}
+
+// NewFilesystemSessionStore constructs a FilesystemSessionStore
+// rooted at root, creating the directory tree when missing.
+//
+// The root is resolved through filepath.EvalSymlinks (when the path
+// already exists) so a later symlink swap on the root cannot be used
+// to escape — same defence LocalWorkspace and sandbox.LocalRunner
+// already apply to their own roots.
+func NewFilesystemSessionStore(root string) (*FilesystemSessionStore, error) {
+	if root == "" {
+		return nil, errdefs.Validationf("vessel: FilesystemSessionStore requires a non-empty root")
+	}
+	abs, err := filepath.Abs(root)
+	if err != nil {
+		return nil, fmt.Errorf("vessel: resolve session root: %w", err)
+	}
+	if err := os.MkdirAll(abs, 0o755); err != nil {
+		return nil, fmt.Errorf("vessel: create session root: %w", err)
+	}
+	if resolved, evalErr := filepath.EvalSymlinks(abs); evalErr == nil {
+		abs = resolved
+	}
+	return &FilesystemSessionStore{
+		root:     abs,
+		sessions: make(map[string]workspace.Workspace),
+	}, nil
+}
+
+// Root reports the absolute, symlink-resolved path the store is
+// rooted at. Useful for tests that want to assert layout, and for
+// operators wiring retention / GC.
+func (s *FilesystemSessionStore) Root() string { return s.root }
+
+// Open returns (or creates) the on-disk workspace for runID. The
+// runID is validated by [ValidateRunID] before being used as a path
+// component.
+func (s *FilesystemSessionStore) Open(_ context.Context, runID string) (workspace.Workspace, error) {
+	if err := ValidateRunID(runID); err != nil {
+		return nil, err
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if ws, ok := s.sessions[runID]; ok {
+		return ws, nil
+	}
+	dir := filepath.Join(s.root, runID)
+	ws, err := workspace.NewLocalWorkspace(dir)
+	if err != nil {
+		return nil, fmt.Errorf("vessel: open session %q: %w", runID, err)
+	}
+	s.sessions[runID] = ws
+	return ws, nil
+}
+
+// Close drops the in-memory bookkeeping for runID. The on-disk
+// directory is preserved — see the type-level doc for the rationale.
+// Calling Close on an unknown runID is a no-op so retries /
+// double-Close are safe.
+func (s *FilesystemSessionStore) Close(_ context.Context, runID string) error {
+	if runID == "" {
+		return nil
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	delete(s.sessions, runID)
+	return nil
+}
+
+// ValidateRunID rejects runIDs that could be abused as path operators
+// or escape the FilesystemSessionStore root. Allowed characters are
+// ASCII letters, digits, dash, and underscore — a strict subset of
+// what filesystems accept, deliberately narrower than RFC 3986 path
+// segments to avoid surprises across Linux / macOS / Windows.
+//
+// Exported so callers building custom SessionStore implementations
+// can reuse the same allow-list and stay consistent with the
+// filesystem store's contract.
+func ValidateRunID(runID string) error {
+	if runID == "" {
+		return errdefs.Validationf("vessel: SessionStore.Open requires a non-empty runID")
+	}
+	if runID == "." || runID == ".." {
+		return errdefs.Validationf("vessel: runID %q is a reserved path component", runID)
+	}
+	for _, r := range runID {
+		switch {
+		case 'a' <= r && r <= 'z':
+		case 'A' <= r && r <= 'Z':
+		case '0' <= r && r <= '9':
+		case r == '-' || r == '_':
+		default:
+			return errdefs.Validationf(
+				"vessel: runID %q contains disallowed character %q (allowed: [A-Za-z0-9_-])",
+				runID, r)
+		}
+	}
+	return nil
+}

--- a/vessel/session_test.go
+++ b/vessel/session_test.go
@@ -1,0 +1,494 @@
+package vessel
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/GizClaw/flowcraft/sdk/agent"
+	"github.com/GizClaw/flowcraft/sdk/engine"
+	"github.com/GizClaw/flowcraft/sdk/errdefs"
+	"github.com/GizClaw/flowcraft/sdk/model"
+	"github.com/GizClaw/flowcraft/sdk/workspace"
+	"github.com/GizClaw/flowcraft/vessel/spec"
+)
+
+// ---------------------------------------------------------------------------
+// ValidateRunID
+// ---------------------------------------------------------------------------
+
+func TestValidateRunID(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name    string
+		in      string
+		wantErr bool
+	}{
+		{"happy_hex", "run-a1b2c3d4", false},
+		{"happy_uuid_like", "01HZA9F-9KQ_PVTM", false},
+		{"alnum_only", "abc123", false},
+		{"empty", "", true},
+		{"single_dot", ".", true},
+		{"double_dot", "..", true},
+		{"contains_slash", "run/abc", true},
+		{"contains_backslash", `run\abc`, true},
+		{"contains_dotdot_seq", "..foo", true},
+		{"contains_space", "run abc", true},
+		{"contains_unicode", "run-übung", true},
+		{"contains_colon", "run:abc", true},
+		{"contains_tilde", "run~abc", true},
+		{"leading_dash_ok", "-abc", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := ValidateRunID(tc.in)
+			if tc.wantErr {
+				if err == nil {
+					t.Errorf("expected error for %q", tc.in)
+				} else if !errdefs.IsValidation(err) {
+					t.Errorf("expected Validation, got %v", err)
+				}
+				return
+			}
+			if err != nil {
+				t.Errorf("unexpected error for %q: %v", tc.in, err)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// MemorySessionStore
+// ---------------------------------------------------------------------------
+
+func TestMemorySessionStore_OpenReturnsSameInstance(t *testing.T) {
+	t.Parallel()
+	s := NewMemorySessionStore()
+	ctx := context.Background()
+
+	a, err := s.Open(ctx, "run-1")
+	if err != nil {
+		t.Fatalf("Open#1: %v", err)
+	}
+	b, err := s.Open(ctx, "run-1")
+	if err != nil {
+		t.Fatalf("Open#2: %v", err)
+	}
+	if a != b {
+		t.Errorf("expected the same workspace for the same runID; got two different instances")
+	}
+
+	c, err := s.Open(ctx, "run-2")
+	if err != nil {
+		t.Fatalf("Open#3: %v", err)
+	}
+	if a == c {
+		t.Errorf("expected distinct workspaces for distinct runIDs")
+	}
+}
+
+func TestMemorySessionStore_CloseDropsState(t *testing.T) {
+	t.Parallel()
+	s := NewMemorySessionStore()
+	ctx := context.Background()
+
+	first, err := s.Open(ctx, "run-1")
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	if err := first.Write(ctx, "k", []byte("v")); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+
+	if err := s.Close(ctx, "run-1"); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	// Re-Open after Close: must mint a fresh workspace (no data
+	// carry-over). MemorySessionStore is explicitly the ephemeral
+	// variant, so dropping state is the documented contract.
+	second, err := s.Open(ctx, "run-1")
+	if err != nil {
+		t.Fatalf("Open after Close: %v", err)
+	}
+	if first == second {
+		t.Errorf("expected fresh workspace after Close, got same instance")
+	}
+	if got, err := second.Exists(ctx, "k"); err != nil {
+		t.Fatalf("Exists: %v", err)
+	} else if got {
+		t.Errorf("expected dropped state, key %q still visible", "k")
+	}
+}
+
+func TestMemorySessionStore_RejectsEmptyRunID(t *testing.T) {
+	t.Parallel()
+	s := NewMemorySessionStore()
+	_, err := s.Open(context.Background(), "")
+	if err == nil || !errdefs.IsValidation(err) {
+		t.Errorf("expected Validation for empty runID, got %v", err)
+	}
+}
+
+func TestMemorySessionStore_CloseUnknownIsNoop(t *testing.T) {
+	t.Parallel()
+	s := NewMemorySessionStore()
+	if err := s.Close(context.Background(), "never-opened"); err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if err := s.Close(context.Background(), ""); err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestMemorySessionStore_ConcurrentOpen(t *testing.T) {
+	t.Parallel()
+	s := NewMemorySessionStore()
+	ctx := context.Background()
+
+	var wg sync.WaitGroup
+	const n = 50
+	got := make([]workspace.Workspace, n)
+	for i := 0; i < n; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			ws, err := s.Open(ctx, "shared")
+			if err != nil {
+				t.Errorf("Open: %v", err)
+				return
+			}
+			got[i] = ws
+		}(i)
+	}
+	wg.Wait()
+	for i := 1; i < n; i++ {
+		if got[i] != got[0] {
+			t.Errorf("concurrent Open returned different instances for the same runID")
+			break
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// FilesystemSessionStore
+// ---------------------------------------------------------------------------
+
+func TestFilesystemSessionStore_Provisioning(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	s, err := NewFilesystemSessionStore(root)
+	if err != nil {
+		t.Fatalf("NewFilesystemSessionStore: %v", err)
+	}
+
+	ctx := context.Background()
+	ws, err := s.Open(ctx, "run-abc")
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	if err := ws.Write(ctx, "hello.txt", []byte("world")); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+
+	// File MUST exist under <root>/<runID>/.
+	want := filepath.Join(s.Root(), "run-abc", "hello.txt")
+	if data, err := os.ReadFile(want); err != nil {
+		t.Fatalf("expected on-disk file at %s: %v", want, err)
+	} else if string(data) != "world" {
+		t.Errorf("unexpected contents %q", data)
+	}
+}
+
+func TestFilesystemSessionStore_DataSurvivesClose(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	s, err := NewFilesystemSessionStore(root)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	ctx := context.Background()
+
+	ws, _ := s.Open(ctx, "run-x")
+	if err := ws.Write(ctx, "state.json", []byte(`{"ok":true}`)); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	if err := s.Close(ctx, "run-x"); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	// Re-Open returns the same data — this is the Resume contract
+	// that distinguishes FilesystemSessionStore from MemorySessionStore.
+	again, err := s.Open(ctx, "run-x")
+	if err != nil {
+		t.Fatalf("Open after Close: %v", err)
+	}
+	data, err := again.Read(ctx, "state.json")
+	if err != nil {
+		t.Fatalf("Read after Close: %v", err)
+	}
+	if string(data) != `{"ok":true}` {
+		t.Errorf("unexpected contents %q", data)
+	}
+}
+
+func TestFilesystemSessionStore_RejectsRunIDEscape(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	s, err := NewFilesystemSessionStore(root)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	ctx := context.Background()
+
+	for _, bad := range []string{"..", "../escape", "run/sub", "run\\sub", ""} {
+		_, err := s.Open(ctx, bad)
+		if err == nil || !errdefs.IsValidation(err) {
+			t.Errorf("expected Validation for %q, got %v", bad, err)
+		}
+	}
+
+	// Confirm no escape attempts created anything outside root.
+	if entries, err := os.ReadDir(filepath.Dir(root)); err == nil {
+		for _, e := range entries {
+			if e.Name() == "escape" {
+				t.Errorf("escape directory created outside root: %s", e.Name())
+			}
+		}
+	}
+}
+
+func TestFilesystemSessionStore_OpenReturnsSameInstance(t *testing.T) {
+	t.Parallel()
+	s, err := NewFilesystemSessionStore(t.TempDir())
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	ctx := context.Background()
+	a, _ := s.Open(ctx, "run-y")
+	b, _ := s.Open(ctx, "run-y")
+	if a != b {
+		t.Errorf("expected same instance across repeated Open calls")
+	}
+}
+
+func TestNewFilesystemSessionStore_EmptyRoot(t *testing.T) {
+	t.Parallel()
+	_, err := NewFilesystemSessionStore("")
+	if err == nil || !errdefs.IsValidation(err) {
+		t.Errorf("expected Validation for empty root, got %v", err)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// WorkspaceFromContext
+// ---------------------------------------------------------------------------
+
+func TestWorkspaceFromContext_AbsentReturnsFalse(t *testing.T) {
+	t.Parallel()
+	if ws, ok := WorkspaceFromContext(context.Background()); ok {
+		t.Errorf("expected (nil, false), got (%v, %v)", ws, ok)
+	}
+}
+
+func TestWorkspaceFromContext_NilStashReturnsFalse(t *testing.T) {
+	t.Parallel()
+	// A nil workspace in the value slot must surface as "no
+	// session" rather than panicking the caller.
+	ctx := context.WithValue(context.Background(), sessionCtxKey{}, workspace.Workspace(nil))
+	if ws, ok := WorkspaceFromContext(ctx); ok || ws != nil {
+		t.Errorf("expected (nil, false) for nil stash, got (%v, %v)", ws, ok)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Captain integration
+// ---------------------------------------------------------------------------
+
+func newSessionTestCaptain(t *testing.T, eng engine.Engine, opts ...Option) *Captain {
+	t.Helper()
+	vs := spec.Spec{Agents: []spec.Agent{{Name: "p"}}}
+	c, err := New(vs, append([]Option{WithEngine(eng)}, opts...)...)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	if err := c.Launch(context.Background()); err != nil {
+		t.Fatalf("Launch: %v", err)
+	}
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+		_ = c.Stop(ctx)
+	})
+	return c
+}
+
+// TestCaptain_SessionStoreExposesWorkspaceToEngine asserts that an
+// engine running inside a vessel with WithSessionStore sees a
+// non-nil workspace via WorkspaceFromContext, and that writes
+// through that workspace land on the SessionStore-managed view.
+func TestCaptain_SessionStoreExposesWorkspaceToEngine(t *testing.T) {
+	t.Parallel()
+	store := NewMemorySessionStore()
+
+	var (
+		mu        sync.Mutex
+		seenWS    workspace.Workspace
+		seenOK    bool
+		seenRunID string
+	)
+	eng := engine.EngineFunc(func(ctx context.Context, run engine.Run, _ engine.Host, b *engine.Board) (*engine.Board, error) {
+		ws, ok := WorkspaceFromContext(ctx)
+		mu.Lock()
+		seenWS = ws
+		seenOK = ok
+		seenRunID = run.ID
+		mu.Unlock()
+		if ok {
+			if err := ws.Write(ctx, "out.txt", []byte("from-engine")); err != nil {
+				return b, err
+			}
+		}
+		b.AppendChannelMessage(engine.MainChannel, model.NewTextMessage(model.RoleAssistant, "done"))
+		return b, nil
+	})
+
+	c := newSessionTestCaptain(t, eng, WithSessionStore(store))
+
+	h, err := c.Submit(context.Background(), "p", agent.Request{
+		RunID:   "run-cap-1",
+		Message: model.NewTextMessage(model.RoleUser, "go"),
+	})
+	if err != nil {
+		t.Fatalf("Submit: %v", err)
+	}
+	if _, err := h.Wait(context.Background()); err != nil {
+		t.Fatalf("Wait: %v", err)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if !seenOK {
+		t.Fatalf("engine did not observe a workspace via WorkspaceFromContext")
+	}
+	if seenWS == nil {
+		t.Fatalf("workspace was nil despite ok=true")
+	}
+	if seenRunID != "run-cap-1" {
+		t.Errorf("unexpected runID seen by engine: %q", seenRunID)
+	}
+
+	// After the run terminates, store.Close drops bookkeeping.
+	// Re-Open returns a fresh workspace (Memory variant) — so the
+	// "out.txt" the engine wrote is intentionally gone, demonstrating
+	// the ephemeral semantic. Other tests cover the persistent variant.
+	ws, err := store.Open(context.Background(), "run-cap-1")
+	if err != nil {
+		t.Fatalf("post-run Open: %v", err)
+	}
+	if got, _ := ws.Exists(context.Background(), "out.txt"); got {
+		t.Errorf("expected Close to drop in-memory state, but out.txt still visible")
+	}
+}
+
+// TestCaptain_WithoutSessionStoreLeavesContextEmpty asserts the
+// opposite default: with no WithSessionStore, runs see no workspace.
+func TestCaptain_WithoutSessionStoreLeavesContextEmpty(t *testing.T) {
+	t.Parallel()
+	var saw bool
+	eng := engine.EngineFunc(func(ctx context.Context, _ engine.Run, _ engine.Host, b *engine.Board) (*engine.Board, error) {
+		_, saw = WorkspaceFromContext(ctx)
+		b.AppendChannelMessage(engine.MainChannel, model.NewTextMessage(model.RoleAssistant, "done"))
+		return b, nil
+	})
+
+	c := newSessionTestCaptain(t, eng)
+	h, err := c.Submit(context.Background(), "p", agent.Request{Message: model.NewTextMessage(model.RoleUser, "go")})
+	if err != nil {
+		t.Fatalf("Submit: %v", err)
+	}
+	if _, err := h.Wait(context.Background()); err != nil {
+		t.Fatalf("Wait: %v", err)
+	}
+	if saw {
+		t.Errorf("engine should NOT see a workspace when no SessionStore is wired")
+	}
+}
+
+// TestCaptain_SessionStoreOpenFailureSurfaces asserts that a Store
+// that refuses to provision (e.g. quota exhausted, disk full) fails
+// the run cleanly with an Internal error instead of silently
+// proceeding without a workspace.
+func TestCaptain_SessionStoreOpenFailureSurfaces(t *testing.T) {
+	t.Parallel()
+	store := &failingStore{}
+	eng := engine.EngineFunc(func(_ context.Context, _ engine.Run, _ engine.Host, b *engine.Board) (*engine.Board, error) {
+		t.Errorf("engine should not run when SessionStore.Open fails")
+		return b, nil
+	})
+
+	c := newSessionTestCaptain(t, eng, WithSessionStore(store))
+	h, err := c.Submit(context.Background(), "p", agent.Request{
+		RunID:   "run-fail",
+		Message: model.NewTextMessage(model.RoleUser, "go"),
+	})
+	if err != nil {
+		t.Fatalf("Submit: %v", err)
+	}
+	_, err = h.Wait(context.Background())
+	if err == nil {
+		t.Fatalf("expected error from failing SessionStore, got nil")
+	}
+	if !errdefs.IsInternal(err) {
+		t.Errorf("expected Internal classification, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "open session") {
+		t.Errorf("error should mention 'open session', got: %v", err)
+	}
+}
+
+// TestCaptain_SessionStoreCloseAfterTerminate asserts the Captain
+// drops the session bookkeeping after the run terminates. We verify
+// it by observing that the store's per-run map is empty post-Wait.
+func TestCaptain_SessionStoreCloseAfterTerminate(t *testing.T) {
+	t.Parallel()
+	store := NewMemorySessionStore()
+	eng := engine.EngineFunc(func(_ context.Context, _ engine.Run, _ engine.Host, b *engine.Board) (*engine.Board, error) {
+		b.AppendChannelMessage(engine.MainChannel, model.NewTextMessage(model.RoleAssistant, "done"))
+		return b, nil
+	})
+	c := newSessionTestCaptain(t, eng, WithSessionStore(store))
+
+	h, err := c.Submit(context.Background(), "p", agent.Request{
+		RunID:   "run-close",
+		Message: model.NewTextMessage(model.RoleUser, "go"),
+	})
+	if err != nil {
+		t.Fatalf("Submit: %v", err)
+	}
+	if _, err := h.Wait(context.Background()); err != nil {
+		t.Fatalf("Wait: %v", err)
+	}
+
+	store.mu.Lock()
+	defer store.mu.Unlock()
+	if _, exists := store.sessions["run-close"]; exists {
+		t.Errorf("expected store bookkeeping for run-close to be dropped after run terminated")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// helpers
+// ---------------------------------------------------------------------------
+
+type failingStore struct{}
+
+func (f *failingStore) Open(_ context.Context, _ string) (workspace.Workspace, error) {
+	return nil, errdefs.Internalf("test: open denied")
+}
+
+func (f *failingStore) Close(_ context.Context, _ string) error { return nil }


### PR DESCRIPTION
## Summary

Wires the per-run filesystem boundary every vessel-dispatched `agent.Run` needs. Adds `vessel.SessionStore` (interface), `vessel.WithSessionStore` (Captain option), and two shipped implementations:

- **`MemorySessionStore`** — one `workspace.MemWorkspace` per run; data discarded on Close. For tests / ephemeral demos / vessels paired with `NoopCheckpointStore`.
- **`FilesystemSessionStore`** — `<root>/<runID>/` directory tree per run; data preserved on Close so a `CheckpointStore`-backed `Resume` can reach the state an interrupted run left behind.

Tools / engines reach the per-run workspace from inside a run via the new helper:

```go
if ws, ok := vessel.WorkspaceFromContext(ctx); ok {
    // use ws — it lives until the run terminates
}
```

`(nil, false)` is the documented fallback when no store was wired, so call sites can degrade gracefully.

## Captain integration

`Captain.submit` reaches into the new code path only when `WithSessionStore` is set:

1. `store.Open(runCtx, runID)` immediately after the admission gate
2. stash the returned `workspace.Workspace` onto `runCtx` under a package-private key
3. `defer store.Close(baseCtx, runID)` — baseCtx, not runCtx; Close must survive a runCtx cancellation because the Open path is what reserved the resource
4. `Open` failure → `errdefs.Internal` on the Handle; the engine never runs. A session is a prerequisite invariant of the run, not a best-effort capability.

There is intentionally **no default SessionStore**. Making every Captain own a tempdir would surprise callers who never asked for one, and the in-memory-vs-on-disk choice is workload-dependent.

## Security: runID validation

`FilesystemSessionStore` runs every runID through the exported `ValidateRunID` before constructing a path component. The allow-list is a strict `[A-Za-z0-9_-]+` (no `.`, `..`, `/`, `\`, spaces, unicode, control chars). That is narrower than Captain's own run-id minter emits (`run-<hex>`), so caller-supplied runIDs are held to the same filesystem-safe contract as auto-minted ones.

## Test plan

All tests pass under `go test -count=1 -race ./vessel/...` on Go 1.25 + Go 1.26.

### `ValidateRunID` (14 cases)
- [x] hex / uuid-like / alnum / leading-dash → accepted
- [x] empty / `.` / `..` / `/` / `\` / spaces / unicode / `:`  / `~` / `..foo` → rejected with `errdefs.Validation`

### `MemorySessionStore`
- [x] Same runID returns the same `Workspace` instance (idempotence)
- [x] Distinct runIDs return distinct instances
- [x] Close drops data; re-Open returns a fresh workspace with no carry-over
- [x] Empty runID rejected with `Validation`
- [x] Close on unknown / empty runID is a no-op
- [x] 50-goroutine concurrent `Open(\"shared\")` returns the same instance to every caller (race-free)

### `FilesystemSessionStore`
- [x] On-disk layout is `<root>/<runID>/<file>`
- [x] Data survives Close → re-Open reaches the same bytes (Resume contract)
- [x] Five malicious runIDs rejected (`..`, `../escape`, `run/sub`, `run\\sub`, empty) and no stray directories created outside root
- [x] Same instance returned across repeated `Open(runID)` calls
- [x] Empty root path rejected with `Validation`

### `WorkspaceFromContext`
- [x] No SessionStore wired → returns `(nil, false)`
- [x] Explicit nil `Workspace` stashed in ctx → returns `(nil, false)` without panic

### Captain integration
- [x] Engine inside a `WithSessionStore` vessel reads its workspace via `WorkspaceFromContext` and writes through it
- [x] Engine inside a vessel WITHOUT `WithSessionStore` sees `(nil, false)`
- [x] `SessionStore.Open` failure surfaces as `errdefs.Internal` on the Handle AND the engine never executes
- [x] After run termination the store's per-run bookkeeping is dropped

## Dependency layering

**No `sdk` dependency bump.** Consumes only `sdk/workspace.{Workspace, MemWorkspace, LocalWorkspace, NewLocalWorkspace}` and `sdk/errdefs` APIs that have been present since vessel's current pin of `sdk v0.3.4`. Bumping vessel's sdk dep is an independent chore — its own PR, not bundled here.

## Files

```
vessel/session.go       (+265)  interface, two impls, ctx helpers, runID validator
vessel/session_test.go  (+494)  unit + integration tests
vessel/option.go        (+20)   WithSessionStore option
vessel/captain.go       (+24)   submit-path integration
CHANGELOG.md            (+24)   [Unreleased] entry
```

Made with [Cursor](https://cursor.com)