### PR TITLE
feat(cmd/vesseld): mTLS termination on the TCP control listener

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -242,6 +242,43 @@ compare/fetch/ingest`, `eval longmemeval convert`). Shell completion
 
 #### vesseld
 
+- `cmd/vesseld/apispec`: `Daemon.spec.control.auth.mtls` schema
+  carrying `cert`, `key`, `clientCA`, and an optional `minVersion`
+  (defaulting to `"1.3"`, `"1.2"` also accepted). Each ref accepts
+  the URL-keyed syntax the `secrets.Provider` already understands
+  (`env://NAME`, `file:///abs/path`, `vault://...`). The validator
+  treats mTLS as a first-class auth mode: `spec.control.listen`
+  now requires `tokenFile` OR `mtls` (was `tokenFile` only), and
+  any non-nil `mtls` block must specify all three refs — the
+  "thought we had mutual TLS, accepted any client" footgun is
+  caught at config-shape time.
+- `cmd/vesseld/tlsconfig`: new package that resolves the three
+  refs through a `secrets.Provider` and builds the
+  `*crypto/tls.Config` the TCP listener consumes. The package
+  pins `ClientAuth = RequireAndVerifyClientCert` and the
+  `MinVersion` mapping in one place so the path that crypto
+  reviewers care about lives in a single ~120-line file with
+  unit tests for happy-path, malformed PEM, key/cert mismatch,
+  unsupported `MinVersion`, and provider-error propagation.
+- `cmd/vesseld/api`: TCP listener now terminates mutual TLS when
+  `Config.TLS` is non-nil. `tls.NewListener` wraps the raw TCP
+  listener so a handshake without a valid client cert is refused
+  before the HTTP mux is ever consulted. Token-file remains
+  optional once mTLS is configured — the client certificate IS
+  the credential — though operators may keep `tokenFile` set for
+  defence in depth. The `Start` precondition is updated
+  accordingly: a TCP listener now requires `Token != ""` OR
+  `TLS != nil`. The unix-socket listener is unaffected
+  (filesystem permissions remain the auth boundary there).
+- `cmd/vesseld/cli`: `vesseld run` accepts `--cert`, `--key`, and
+  `--client-ca` flags that override the corresponding YAML
+  fields. The three follow an all-or-none contract — passing any
+  of them implies the operator wants mTLS, so the resulting plan
+  must end up with all three refs populated (either from
+  matching YAML fields or from sibling flags) or the daemon
+  refuses to start. Drop-in workflow: dev workstations swap
+  certs without editing the manifest, production deployments
+  keep everything in YAML.
 - `cmd/vesseld/secrets`: new URL-keyed `Provider` abstraction +
   `env://NAME`, `file:///abs/path`, and `vault://server/path?key=…`
   backends, plus a `Multi` router and a `Default()` constructor that

--- a/cmd/vesseld/api/server.go
+++ b/cmd/vesseld/api/server.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"context"
+	"crypto/tls"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -35,10 +36,24 @@ type Config struct {
 	Listen string
 
 	// Token is the bearer token TCP requests must present in the
-	// Authorization header. Required when Listen is non-empty;
-	// the runtime layer reads the token-file and passes its
-	// contents here.
+	// Authorization header. Required when Listen is non-empty and
+	// TLS is nil (no mTLS); the runtime layer reads the token-file
+	// and passes its contents here. Optional when TLS is non-nil:
+	// the client certificate IS the credential, though operators
+	// may still configure a token for defence in depth.
 	Token string
+
+	// TLS, when non-nil, terminates mutual TLS on the TCP
+	// listener. The Config must have a non-empty Certificates
+	// slice, a ClientCAs pool, and ClientAuth set to
+	// RequireAndVerifyClientCert; the tlsconfig package builds
+	// such a Config from the resolver DaemonMTLSPlan.
+	//
+	// The unix-socket listener is unaffected by this field —
+	// filesystem permissions are the auth boundary there and
+	// wrapping it in TLS would surprise local clients without
+	// any security gain.
+	TLS *tls.Config
 
 	// Version is the daemon version string returned by /v1/version.
 	Version string
@@ -101,12 +116,21 @@ func (s *Server) Start(ctx context.Context) error {
 		go s.serveListener("unix", l)
 	}
 	if s.cfg.Listen != "" {
-		if s.cfg.Token == "" {
-			return fmt.Errorf("vesseld api: TCP listener requires a non-empty token")
+		if s.cfg.Token == "" && s.cfg.TLS == nil {
+			return fmt.Errorf("vesseld api: TCP listener requires a non-empty token or a non-nil TLS config")
 		}
 		l, err := net.Listen("tcp", s.cfg.Listen)
 		if err != nil {
 			return fmt.Errorf("vesseld api: bind tcp %s: %w", s.cfg.Listen, err)
+		}
+		if s.cfg.TLS != nil {
+			// tls.NewListener wraps the underlying TCP listener so
+			// every accepted connection is handshake-terminated
+			// before the HTTP server ever sees it. A handshake
+			// without a valid client cert (per ClientAuth =
+			// RequireAndVerifyClientCert in tlsconfig) fails at
+			// this layer and the request never reaches the mux.
+			l = tls.NewListener(l, s.cfg.TLS)
 		}
 		s.listeners = append(s.listeners, l)
 		go s.serveListener("tcp", l)

--- a/cmd/vesseld/api/server_mtls_test.go
+++ b/cmd/vesseld/api/server_mtls_test.go
@@ -1,0 +1,241 @@
+package api
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"io"
+	"math/big"
+	"net"
+	"net/http"
+	"testing"
+	"time"
+)
+
+// keyPair is a self-signed cert + private key bundle used by the
+// mTLS round-trip test. We mint everything in-process so the test
+// has no filesystem dependencies and no risk of stale fixtures.
+type keyPair struct {
+	cert     *x509.Certificate
+	certDER  []byte
+	tlsCert  tls.Certificate
+	privKey  *ecdsa.PrivateKey
+	template *x509.Certificate
+}
+
+func mintCA(t *testing.T, cn string) *keyPair {
+	t.Helper()
+	priv, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("GenerateKey: %v", err)
+	}
+	tmpl := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: cn},
+		NotBefore:             time.Now().Add(-time.Minute),
+		NotAfter:              time.Now().Add(time.Hour),
+		IsCA:                  true,
+		BasicConstraintsValid: true,
+		KeyUsage:              x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &priv.PublicKey, priv)
+	if err != nil {
+		t.Fatalf("CreateCertificate (CA): %v", err)
+	}
+	parsed, err := x509.ParseCertificate(der)
+	if err != nil {
+		t.Fatalf("ParseCertificate: %v", err)
+	}
+	return &keyPair{cert: parsed, certDER: der, privKey: priv, template: tmpl}
+}
+
+// signLeaf issues a leaf cert chained to ca. The serverDNS list,
+// when non-empty, populates SANs so the test client can verify the
+// server certificate with the standard hostname check.
+func signLeaf(t *testing.T, ca *keyPair, cn string, eku []x509.ExtKeyUsage, serverDNS []string) tls.Certificate {
+	t.Helper()
+	leafPriv, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("GenerateKey: %v", err)
+	}
+	tmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(2),
+		Subject:      pkix.Name{CommonName: cn},
+		NotBefore:    time.Now().Add(-time.Minute),
+		NotAfter:     time.Now().Add(time.Hour),
+		KeyUsage:     x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment,
+		ExtKeyUsage:  eku,
+		DNSNames:     serverDNS,
+	}
+	// Stamp loopback IPs as SANs when the leaf is meant to serve
+	// requests — the test client dials 127.0.0.1, and the stdlib
+	// hostname verifier matches the connect target against IPAddresses
+	// (not DNSNames) when the target is a literal IP. Without this,
+	// the verifier returns "doesn't contain any IP SANs".
+	for _, name := range serverDNS {
+		if ip := net.ParseIP(name); ip != nil {
+			tmpl.IPAddresses = append(tmpl.IPAddresses, ip)
+		}
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, ca.cert, &leafPriv.PublicKey, ca.privKey)
+	if err != nil {
+		t.Fatalf("CreateCertificate (leaf): %v", err)
+	}
+	return tls.Certificate{
+		Certificate: [][]byte{der},
+		PrivateKey:  leafPriv,
+		Leaf:        mustParse(t, der),
+	}
+}
+
+func mustParse(t *testing.T, der []byte) *x509.Certificate {
+	t.Helper()
+	c, err := x509.ParseCertificate(der)
+	if err != nil {
+		t.Fatalf("ParseCertificate: %v", err)
+	}
+	return c
+}
+
+// TestAPI_TCPMTLSHandshake spins up a real TCP listener wrapped in
+// tls.Config{ClientAuth: RequireAndVerifyClientCert}, then exercises
+// three cases:
+//
+//  1. Client presents a cert signed by the expected CA → 200.
+//  2. Client presents NO cert                          → handshake error.
+//  3. Client presents cert from an unknown CA          → handshake error.
+//
+// Together they pin the contract that mTLS is the auth boundary —
+// not "we accepted a TLS connection and then checked tokens", but
+// "we refused to accept a connection without a valid client cert".
+func TestAPI_TCPMTLSHandshake(t *testing.T) {
+	t.Parallel()
+
+	serverCA := mintCA(t, "server-ca")
+	clientCA := mintCA(t, "client-ca")
+	otherCA := mintCA(t, "other-ca")
+
+	serverCert := signLeaf(t, serverCA, "localhost",
+		[]x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		[]string{"localhost", "127.0.0.1"})
+	goodClientCert := signLeaf(t, clientCA, "good-client",
+		[]x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth}, nil)
+	rogueClientCert := signLeaf(t, otherCA, "rogue-client",
+		[]x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth}, nil)
+
+	// Trust pool the server uses to verify clients.
+	clientCAs := x509.NewCertPool()
+	clientCAs.AddCert(clientCA.cert)
+	// Trust pool the client uses to verify the server.
+	rootCAs := x509.NewCertPool()
+	rootCAs.AddCert(serverCA.cert)
+
+	serverTLS := &tls.Config{
+		Certificates: []tls.Certificate{serverCert},
+		ClientCAs:    clientCAs,
+		ClientAuth:   tls.RequireAndVerifyClientCert,
+		MinVersion:   tls.VersionTLS13,
+	}
+
+	// Bind to localhost:0 so the kernel picks a free port. Setting
+	// cfg.Listen to the returned address completes the wiring of
+	// Server.Start → net.Listen("tcp", cfg.Listen) →
+	// tls.NewListener(rawL, cfg.TLS). We can't reuse newTestServer
+	// because it would call MarkReady on a stale config.
+	s := newTestServer(t)
+	s.cfg.Listen = "127.0.0.1:0"
+	s.cfg.TLS = serverTLS
+	// Token MUST be left empty here: the test exercises the "mTLS
+	// alone is sufficient auth" branch in Server.Start. If Token
+	// were non-empty, authn would also require a Bearer header.
+	s.cfg.Token = ""
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	if err := s.Start(ctx); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	t.Cleanup(func() {
+		stopCtx, stopCancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer stopCancel()
+		_ = s.Stop(stopCtx)
+	})
+
+	// Resolve the kernel-assigned port off the listener. The TCP
+	// listener is the SECOND entry when both socket and listen are
+	// configured (socket is registered first in Start); the test
+	// config above does not set Socket, so listeners[0] is the TLS
+	// listener directly.
+	if len(s.listeners) != 1 {
+		t.Fatalf("expected 1 listener, got %d", len(s.listeners))
+	}
+	addr := s.listeners[0].Addr().String()
+	url := "https://" + addr + "/healthz"
+
+	// Case 1: valid client cert → 200 ok.
+	clientGood := &http.Client{
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{
+				RootCAs:      rootCAs,
+				Certificates: []tls.Certificate{goodClientCert},
+			},
+		},
+		Timeout: 5 * time.Second,
+	}
+	resp, err := clientGood.Get(url)
+	if err != nil {
+		t.Fatalf("good client GET: %v", err)
+	}
+	body, _ := io.ReadAll(resp.Body)
+	_ = resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("good client status=%d body=%s", resp.StatusCode, body)
+	}
+
+	// Case 2: no client cert → handshake fails. Different Go
+	// versions surface this as different error strings; we just
+	// assert any error.
+	clientNone := &http.Client{
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{RootCAs: rootCAs},
+		},
+		Timeout: 5 * time.Second,
+	}
+	if _, err := clientNone.Get(url); err == nil {
+		t.Fatal("expected handshake error without client cert, got nil")
+	}
+
+	// Case 3: rogue client cert → handshake fails.
+	clientRogue := &http.Client{
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{
+				RootCAs:      rootCAs,
+				Certificates: []tls.Certificate{rogueClientCert},
+			},
+		},
+		Timeout: 5 * time.Second,
+	}
+	if _, err := clientRogue.Get(url); err == nil {
+		t.Fatal("expected handshake error with rogue client cert, got nil")
+	}
+}
+
+// TestAPI_StartRequiresAuthOnTCP pins the auth-boundary check: a
+// Server with Listen set but neither Token nor TLS must refuse to
+// Start. The error string travels back to runtime where it surfaces
+// as a startup failure with a 1 exit code — losing this check would
+// silently start an open TCP port.
+func TestAPI_StartRequiresAuthOnTCP(t *testing.T) {
+	t.Parallel()
+	s := newTestServer(t)
+	s.cfg.Listen = "127.0.0.1:0"
+	s.cfg.Token = ""
+	s.cfg.TLS = nil
+	if err := s.Start(context.Background()); err == nil {
+		t.Fatal("expected error, got nil")
+	}
+}

--- a/cmd/vesseld/apispec/v1alpha1/daemon.go
+++ b/cmd/vesseld/apispec/v1alpha1/daemon.go
@@ -74,10 +74,57 @@ type DaemonControl struct {
 	Auth DaemonAuth `json:"auth,omitempty" yaml:"auth,omitempty"`
 }
 
-// DaemonAuth holds authentication configuration. Token-file is the
-// only mode in v0.1.0; mTLS / OIDC are explicitly v0.2.0+ scope.
+// DaemonAuth holds authentication configuration. Two modes are
+// supported and may be combined (defence in depth):
+//
+//   - TokenFile: shared bearer token in the Authorization header.
+//     v0.1.0 default.
+//   - MTLS:      mutual TLS — server presents Cert/Key, clients
+//     present a cert signed by ClientCA. v0.2.0 addition.
+//
+// When TCP is enabled (Control.Listen != ""), at least one of the
+// two MUST be configured; Validate enforces this so an open TCP
+// port without any auth can never start.
 type DaemonAuth struct {
-	TokenFile string `json:"tokenFile,omitempty" yaml:"tokenFile,omitempty"`
+	TokenFile string      `json:"tokenFile,omitempty" yaml:"tokenFile,omitempty"`
+	MTLS      *DaemonMTLS `json:"mtls,omitempty" yaml:"mtls,omitempty"`
+}
+
+// DaemonMTLS pins the server certificate, server key, and the
+// trusted client-CA bundle that the TCP listener uses to terminate
+// mutual TLS. All three reference fields use the secrets package's
+// URL-keyed syntax (env://NAME, file:///abs/path, vault://...) so
+// the same indirection that resolves bearer-token files extends to
+// cryptographic material.
+//
+// Setting MTLS is sufficient to authenticate TCP requests — the
+// client cert IS the credential. Operators may still configure
+// TokenFile alongside it for defence in depth (Authorization header
+// is checked after the TLS handshake completes); without an
+// MTLS-only mode option, the auth filter stays unchanged.
+//
+// MinVersion is optional and defaults to TLS 1.3. Operators stuck
+// with legacy clients can drop to "1.2" explicitly; older versions
+// are intentionally not supported.
+type DaemonMTLS struct {
+	// Cert is the secret reference to the PEM-encoded server
+	// certificate. Required.
+	Cert string `json:"cert" yaml:"cert"`
+
+	// Key is the secret reference to the PEM-encoded server
+	// private key. Required.
+	Key string `json:"key" yaml:"key"`
+
+	// ClientCA is the secret reference to the PEM-encoded trusted
+	// client CA bundle. Required — without it the listener would
+	// accept any client, which is plain TLS, not mutual TLS.
+	ClientCA string `json:"clientCA" yaml:"clientCA"`
+
+	// MinVersion clamps the TLS version negotiated with clients.
+	// Empty defaults to "1.3"; "1.2" is the only other accepted
+	// value. Anything older is rejected because the protocol
+	// itself is no longer considered secure.
+	MinVersion string `json:"minVersion,omitempty" yaml:"minVersion,omitempty"`
 }
 
 // DaemonResources holds daemon-wide resource caps.
@@ -132,8 +179,29 @@ func (d Daemon) Validate() error {
 		// "" + resolver default, or any explicit value. The
 		// strict check is "do not allow listen without auth".
 	}
-	if d.Spec.Control.Listen != "" && d.Spec.Control.Auth.TokenFile == "" {
-		return errdefs.Validationf("vesseld Daemon %q: spec.control.listen requires spec.control.auth.tokenFile", d.Name)
+	if d.Spec.Control.Listen != "" {
+		auth := d.Spec.Control.Auth
+		if auth.TokenFile == "" && auth.MTLS == nil {
+			return errdefs.Validationf(
+				"vesseld Daemon %q: spec.control.listen requires at least one of spec.control.auth.tokenFile or spec.control.auth.mtls",
+				d.Name)
+		}
+	}
+	if mtls := d.Spec.Control.Auth.MTLS; mtls != nil {
+		if mtls.Cert == "" {
+			return errdefs.Validationf("vesseld Daemon %q: spec.control.auth.mtls.cert is required", d.Name)
+		}
+		if mtls.Key == "" {
+			return errdefs.Validationf("vesseld Daemon %q: spec.control.auth.mtls.key is required", d.Name)
+		}
+		if mtls.ClientCA == "" {
+			return errdefs.Validationf("vesseld Daemon %q: spec.control.auth.mtls.clientCA is required (without it the listener accepts any client → not mutual TLS)", d.Name)
+		}
+		switch mtls.MinVersion {
+		case "", "1.2", "1.3":
+		default:
+			return errdefs.Validationf("vesseld Daemon %q: spec.control.auth.mtls.minVersion %q invalid (want 1.2|1.3)", d.Name, mtls.MinVersion)
+		}
 	}
 	if d.Spec.Resources.MaxConcurrentRuns < 0 {
 		return errdefs.Validationf("vesseld Daemon %q: spec.resources.maxConcurrentRuns must be >= 0", d.Name)

--- a/cmd/vesseld/apispec/v1alpha1/validate_test.go
+++ b/cmd/vesseld/apispec/v1alpha1/validate_test.go
@@ -70,7 +70,7 @@ func TestDaemon_ValidateOK(t *testing.T) {
 	}
 }
 
-func TestDaemon_TCPRequiresToken(t *testing.T) {
+func TestDaemon_TCPRequiresAuth(t *testing.T) {
 	t.Parallel()
 	d := Daemon{
 		TypeMeta:   tmDaemon(),
@@ -79,6 +79,62 @@ func TestDaemon_TCPRequiresToken(t *testing.T) {
 	}
 	if err := d.Validate(); !errdefs.IsValidation(err) {
 		t.Fatalf("expected Validation, got %v", err)
+	}
+}
+
+func TestDaemon_TCPMTLSSatisfiesAuth(t *testing.T) {
+	t.Parallel()
+	// mTLS alone (no tokenFile) is a valid auth posture: the
+	// client cert IS the credential.
+	d := Daemon{
+		TypeMeta:   tmDaemon(),
+		ObjectMeta: ObjectMeta{Name: "d"},
+		Spec: DaemonSpec{
+			Control: DaemonControl{
+				Listen: "0.0.0.0:8080",
+				Auth: DaemonAuth{
+					MTLS: &DaemonMTLS{
+						Cert:     "file:///tmp/cert.pem",
+						Key:      "file:///tmp/key.pem",
+						ClientCA: "file:///tmp/ca.pem",
+					},
+				},
+			},
+		},
+	}
+	if err := d.Validate(); err != nil {
+		t.Fatalf("Validate: %v", err)
+	}
+}
+
+func TestDaemon_MTLSFieldsRequired(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		name string
+		m    DaemonMTLS
+	}{
+		{"missing-cert", DaemonMTLS{Key: "file:///k", ClientCA: "file:///ca"}},
+		{"missing-key", DaemonMTLS{Cert: "file:///c", ClientCA: "file:///ca"}},
+		{"missing-clientCA", DaemonMTLS{Cert: "file:///c", Key: "file:///k"}},
+		{"bad-minVersion", DaemonMTLS{Cert: "file:///c", Key: "file:///k", ClientCA: "file:///ca", MinVersion: "1.1"}},
+	} {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			d := Daemon{
+				TypeMeta:   tmDaemon(),
+				ObjectMeta: ObjectMeta{Name: "d"},
+				Spec: DaemonSpec{
+					Control: DaemonControl{
+						Listen: "0.0.0.0:8080",
+						Auth:   DaemonAuth{TokenFile: "/tmp/t", MTLS: &tc.m},
+					},
+				},
+			}
+			if err := d.Validate(); !errdefs.IsValidation(err) {
+				t.Fatalf("expected Validation, got %v", err)
+			}
+		})
 	}
 }
 

--- a/cmd/vesseld/cli/run.go
+++ b/cmd/vesseld/cli/run.go
@@ -14,12 +14,24 @@ func cmdRun(args []string) error {
 	fs := flag.NewFlagSet("run", flag.ContinueOnError)
 	configs := newRepeatedFlag(fs, "config", "path to a config file or directory (repeatable)")
 	recursive := fs.Bool("R", false, "descend into subdirectories of --config dirs")
+	// mTLS overrides. Each accepts the same URL-keyed reference
+	// the YAML field would (env://NAME, file:///abs/path,
+	// vault://...). Empty (the default) leaves the YAML value
+	// untouched; non-empty replaces it. Operators set these for
+	// "drop a different cert in dev without editing the manifest"
+	// workflows; production deployments keep everything in YAML.
+	cert := fs.String("cert", "", "mTLS server cert ref (overrides spec.control.auth.mtls.cert)")
+	key := fs.String("key", "", "mTLS server key ref (overrides spec.control.auth.mtls.key)")
+	clientCA := fs.String("client-ca", "", "mTLS client CA bundle ref (overrides spec.control.auth.mtls.clientCA)")
 	if err := fs.Parse(args); err != nil {
 		return err
 	}
 	return runtime.Run(context.Background(), runtime.RunOptions{
-		Config:    *configs,
-		Recursive: *recursive,
-		Version:   Version,
+		Config:       *configs,
+		Recursive:    *recursive,
+		Version:      Version,
+		MTLSCert:     *cert,
+		MTLSKey:      *key,
+		MTLSClientCA: *clientCA,
 	})
 }

--- a/cmd/vesseld/resolver/plan.go
+++ b/cmd/vesseld/resolver/plan.go
@@ -55,11 +55,26 @@ type DaemonPlan struct {
 	Socket            string
 	Listen            string
 	TokenFile         string
+	MTLS              *DaemonMTLSPlan
 	MaxConcurrentRuns int
 	LLMRateLimits     []v1alpha1.LLMRateLimit
 	LoggingFormat     string
 	LoggingLevel      string
 	DrainTimeout      time.Duration
+}
+
+// DaemonMTLSPlan is the resolved mTLS configuration. The Ref
+// fields use the secrets.Provider URL-keyed syntax (env://...,
+// file:///..., vault://...); the runtime layer is responsible for
+// fetching the actual PEM bytes via the daemon-wide Provider when
+// constructing the tls.Config.
+type DaemonMTLSPlan struct {
+	CertRef     string
+	KeyRef      string
+	ClientCARef string
+	// MinVersion is "1.2" or "1.3" (defaulted to "1.3" by Resolve
+	// if the apispec field was empty).
+	MinVersion string
 }
 
 // VesselPlan is one resolved Vessel: enough information for the

--- a/cmd/vesseld/resolver/resolve.go
+++ b/cmd/vesseld/resolver/resolve.go
@@ -113,6 +113,18 @@ func buildDaemonPlan(d v1alpha1.Daemon) DaemonPlan {
 	if dp.LoggingLevel == "" {
 		dp.LoggingLevel = "info"
 	}
+	if mtls := d.Spec.Control.Auth.MTLS; mtls != nil {
+		minVer := mtls.MinVersion
+		if minVer == "" {
+			minVer = "1.3"
+		}
+		dp.MTLS = &DaemonMTLSPlan{
+			CertRef:     mtls.Cert,
+			KeyRef:      mtls.Key,
+			ClientCARef: mtls.ClientCA,
+			MinVersion:  minVer,
+		}
+	}
 	return dp
 }
 

--- a/cmd/vesseld/runtime/mtls_test.go
+++ b/cmd/vesseld/runtime/mtls_test.go
@@ -1,0 +1,82 @@
+package runtime
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/GizClaw/flowcraft/cmd/vesseld/resolver"
+)
+
+func TestApplyMTLSOverrides_NoFlags_NoOp(t *testing.T) {
+	t.Parallel()
+	plan := &resolver.Plan{}
+	if err := applyMTLSOverrides(plan, RunOptions{}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if plan.Daemon.MTLS != nil {
+		t.Fatalf("MTLS unexpectedly populated: %+v", plan.Daemon.MTLS)
+	}
+}
+
+func TestApplyMTLSOverrides_AllFromCLI(t *testing.T) {
+	t.Parallel()
+	plan := &resolver.Plan{}
+	err := applyMTLSOverrides(plan, RunOptions{
+		MTLSCert:     "file:///cert",
+		MTLSKey:      "file:///key",
+		MTLSClientCA: "file:///ca",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	m := plan.Daemon.MTLS
+	if m == nil {
+		t.Fatal("MTLS not populated")
+	}
+	if m.CertRef != "file:///cert" || m.KeyRef != "file:///key" || m.ClientCARef != "file:///ca" {
+		t.Fatalf("refs not propagated: %+v", m)
+	}
+	if m.MinVersion != "1.3" {
+		t.Fatalf("default MinVersion = %q, want 1.3", m.MinVersion)
+	}
+}
+
+func TestApplyMTLSOverrides_PartialCLI_FailsWhenNoYAML(t *testing.T) {
+	t.Parallel()
+	plan := &resolver.Plan{}
+	err := applyMTLSOverrides(plan, RunOptions{MTLSCert: "file:///cert"})
+	if err == nil || !strings.Contains(err.Error(), "all of --cert") {
+		t.Fatalf("expected partial-input error, got %v", err)
+	}
+}
+
+func TestApplyMTLSOverrides_PartialCLI_MergesWithYAML(t *testing.T) {
+	t.Parallel()
+	plan := &resolver.Plan{
+		Daemon: resolver.DaemonPlan{
+			MTLS: &resolver.DaemonMTLSPlan{
+				CertRef:     "file:///yaml-cert",
+				KeyRef:      "file:///yaml-key",
+				ClientCARef: "file:///yaml-ca",
+				MinVersion:  "1.3",
+			},
+		},
+	}
+	err := applyMTLSOverrides(plan, RunOptions{MTLSCert: "file:///cli-cert"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	m := plan.Daemon.MTLS
+	if m.CertRef != "file:///cli-cert" {
+		t.Fatalf("CertRef override missed: %q", m.CertRef)
+	}
+	if m.KeyRef != "file:///yaml-key" {
+		t.Fatalf("KeyRef should retain yaml value, got %q", m.KeyRef)
+	}
+	if m.ClientCARef != "file:///yaml-ca" {
+		t.Fatalf("ClientCARef should retain yaml value, got %q", m.ClientCARef)
+	}
+	if m.MinVersion != "1.3" {
+		t.Fatalf("MinVersion clobbered: %q", m.MinVersion)
+	}
+}

--- a/cmd/vesseld/runtime/runtime.go
+++ b/cmd/vesseld/runtime/runtime.go
@@ -23,6 +23,8 @@ import (
 	"github.com/GizClaw/flowcraft/cmd/vesseld/fleet"
 	"github.com/GizClaw/flowcraft/cmd/vesseld/loader"
 	"github.com/GizClaw/flowcraft/cmd/vesseld/resolver"
+	"github.com/GizClaw/flowcraft/cmd/vesseld/secrets"
+	"github.com/GizClaw/flowcraft/cmd/vesseld/tlsconfig"
 )
 
 // RunOptions bundles the inputs `vesseld run` collects from CLI
@@ -38,6 +40,19 @@ type RunOptions struct {
 	// Version is the daemon version string surfaced via /v1/version.
 	// Defaults to "dev" when empty.
 	Version string
+
+	// MTLSCert / MTLSKey / MTLSClientCA, when non-empty, override
+	// the corresponding spec.control.auth.mtls fields on the
+	// resolved DaemonPlan. They accept the same URL-keyed
+	// reference syntax as the YAML (env://NAME,
+	// file:///abs/path, vault://...). The override applies even
+	// when the YAML did not declare mtls at all — supplying any
+	// of the three on the CLI implies operators want mTLS, so
+	// runtime constructs a MTLSPlan from them and rejects
+	// partial inputs.
+	MTLSCert     string
+	MTLSKey      string
+	MTLSClientCA string
 }
 
 // Run performs the full daemon lifecycle and returns when the
@@ -53,6 +68,10 @@ func Run(parent context.Context, opts RunOptions) error {
 	plan, errs := resolver.Resolve(objs, cat, resolver.DefaultResolveOptions())
 	if errs.Len() > 0 {
 		return fmt.Errorf("vesseld run: %w", errs.Aggregate())
+	}
+
+	if err := applyMTLSOverrides(plan, opts); err != nil {
+		return fmt.Errorf("vesseld run: %w", err)
 	}
 
 	logger := buildLogger(plan.Daemon.LoggingFormat, plan.Daemon.LoggingLevel)
@@ -131,9 +150,42 @@ func Run(parent context.Context, opts RunOptions) error {
 	return nil
 }
 
-// startAPI builds + starts the API server. Token-file content is
-// read here (the only filesystem touch outside loader/secret) so
-// the api package stays IO-light and testable.
+// applyMTLSOverrides merges --cert / --key / --client-ca onto the
+// resolved DaemonPlan. The three CLI flags follow an "all-or-none"
+// contract: passing any of them implies the operator wants mTLS,
+// so the remaining values come from the YAML (when MTLSPlan
+// already exists) or are required on the command line. Mixing
+// "yaml has Key, CLI overrides Cert" works — each flag overrides
+// its own field independently — but starting from a manifest
+// without mtls and passing only `--cert` is rejected because the
+// resulting Plan would have an incomplete cert pair.
+func applyMTLSOverrides(plan *resolver.Plan, opts RunOptions) error {
+	if opts.MTLSCert == "" && opts.MTLSKey == "" && opts.MTLSClientCA == "" {
+		return nil
+	}
+	if plan.Daemon.MTLS == nil {
+		plan.Daemon.MTLS = &resolver.DaemonMTLSPlan{MinVersion: "1.3"}
+	}
+	if opts.MTLSCert != "" {
+		plan.Daemon.MTLS.CertRef = opts.MTLSCert
+	}
+	if opts.MTLSKey != "" {
+		plan.Daemon.MTLS.KeyRef = opts.MTLSKey
+	}
+	if opts.MTLSClientCA != "" {
+		plan.Daemon.MTLS.ClientCARef = opts.MTLSClientCA
+	}
+	m := plan.Daemon.MTLS
+	if m.CertRef == "" || m.KeyRef == "" || m.ClientCARef == "" {
+		return fmt.Errorf("mTLS overrides require all of --cert/--key/--client-ca (or matching YAML fields); got cert=%q key=%q clientCA=%q",
+			m.CertRef, m.KeyRef, m.ClientCARef)
+	}
+	return nil
+}
+
+// startAPI builds + starts the API server. Token-file content
+// (when present) and any mTLS material are resolved here so the
+// api package stays IO-light and testable.
 func startAPI(ctx context.Context, plan *resolver.Plan, f *fleet.Fleet, version string) (*api.Server, error) {
 	cfg := api.Config{
 		Socket:  plan.Daemon.Socket,
@@ -141,13 +193,36 @@ func startAPI(ctx context.Context, plan *resolver.Plan, f *fleet.Fleet, version 
 		Version: version,
 	}
 	if cfg.Listen != "" {
-		raw, err := os.ReadFile(plan.Daemon.TokenFile)
-		if err != nil {
-			return nil, fmt.Errorf("token file %q: %w", plan.Daemon.TokenFile, err)
+		// Token-file remains optional once mTLS is configured.
+		// The apispec validator guarantees at least one of the
+		// two is set, so the "no auth at all" footgun is caught
+		// before we get here.
+		if plan.Daemon.TokenFile != "" {
+			raw, err := os.ReadFile(plan.Daemon.TokenFile)
+			if err != nil {
+				return nil, fmt.Errorf("token file %q: %w", plan.Daemon.TokenFile, err)
+			}
+			cfg.Token = strings.TrimRight(string(raw), "\r\n")
+			if cfg.Token == "" {
+				return nil, fmt.Errorf("token file %q is empty", plan.Daemon.TokenFile)
+			}
 		}
-		cfg.Token = strings.TrimRight(string(raw), "\r\n")
-		if cfg.Token == "" {
-			return nil, fmt.Errorf("token file %q is empty", plan.Daemon.TokenFile)
+		if plan.Daemon.MTLS != nil {
+			// secrets.Default() registers the env://, file://,
+			// and vault:// providers; the URL scheme on each ref
+			// selects the backend. A future PR may surface a
+			// customisation hook here (Daemon.spec.secrets), but
+			// the default set is sufficient for v0.2.0.
+			tlsCfg, err := tlsconfig.Build(ctx, secrets.Default(), tlsconfig.Config{
+				CertRef:     plan.Daemon.MTLS.CertRef,
+				KeyRef:      plan.Daemon.MTLS.KeyRef,
+				ClientCARef: plan.Daemon.MTLS.ClientCARef,
+				MinVersion:  plan.Daemon.MTLS.MinVersion,
+			})
+			if err != nil {
+				return nil, fmt.Errorf("build mTLS config: %w", err)
+			}
+			cfg.TLS = tlsCfg
 		}
 	}
 	srv := api.New(cfg, f)

--- a/cmd/vesseld/tlsconfig/doc.go
+++ b/cmd/vesseld/tlsconfig/doc.go
@@ -1,0 +1,36 @@
+// Package tlsconfig builds the *crypto/tls.Config that vesseld's
+// TCP listener uses to terminate mutual TLS. It is the bridge
+// between the resolver-side DaemonMTLSPlan (URL-keyed reference
+// strings) and the api-side listener (raw key material).
+//
+// # Scope
+//
+// The package owns three responsibilities:
+//
+//  1. Resolve the Cert / Key / ClientCA references through a
+//     [secrets.Provider]. Every reference goes through the same
+//     daemon-wide provider so a vault://, file://, or env://
+//     reference is honoured uniformly across the daemon.
+//  2. Parse the returned bytes as PEM, build the X.509 server
+//     certificate and the client-CA pool, and assemble a
+//     [crypto/tls.Config] with ClientAuth = RequireAndVerifyClientCert.
+//  3. Map the resolver's "1.2" / "1.3" minVersion string into the
+//     stdlib's tls.VersionTLS{12,13} constants, defaulting to TLS
+//     1.3 when unspecified.
+//
+// # Why a separate package
+//
+// The crypto-material handling is mechanical but easy to get
+// subtly wrong (forgetting RequireAndVerifyClientCert is the
+// canonical "we thought we had mTLS, we didn't" bug). Carving it
+// out of cmd/vesseld/runtime keeps that codepath single-purpose
+// and unit-testable without spinning up a full daemon.
+//
+// # Non-scope
+//
+// The package does NOT itself listen, accept connections, or
+// renegotiate certificates. It also does NOT watch the underlying
+// secret references for rotation — Build is a one-shot snapshot
+// taken at startup, mirroring how the token-file path reads its
+// content once. Live rotation is a future RFC.
+package tlsconfig

--- a/cmd/vesseld/tlsconfig/tlsconfig.go
+++ b/cmd/vesseld/tlsconfig/tlsconfig.go
@@ -1,0 +1,121 @@
+package tlsconfig
+
+import (
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+
+	"github.com/GizClaw/flowcraft/cmd/vesseld/secrets"
+	"github.com/GizClaw/flowcraft/sdk/errdefs"
+)
+
+// Config bundles the references that point at the PEM material
+// the daemon will load. The strings are passed through to the
+// [secrets.Provider] verbatim; format follows whatever schemes the
+// provider supports (env://, file:///abs/path, vault://...).
+type Config struct {
+	// CertRef points at the server certificate (PEM). Required.
+	CertRef string
+
+	// KeyRef points at the server private key (PEM). Required.
+	KeyRef string
+
+	// ClientCARef points at the trusted client CA bundle (PEM).
+	// Required — without it the listener would accept any client,
+	// defeating the purpose of mutual TLS.
+	ClientCARef string
+
+	// MinVersion is "1.2" or "1.3". Empty defaults to "1.3".
+	MinVersion string
+}
+
+// Build resolves every reference through provider and assembles a
+// [crypto/tls.Config] suitable for an mTLS HTTP listener. The
+// returned config has ClientAuth = RequireAndVerifyClientCert so a
+// handshake without a client cert (or with one not chained to
+// ClientCARef) is rejected at the TLS layer — the request never
+// reaches the HTTP mux.
+//
+// Errors are classified:
+//
+//   - errdefs.Validation: cfg is incomplete (missing ref, unsupported
+//     MinVersion) or the resolved bytes are not parseable as PEM.
+//   - errdefs.NotFound / errdefs.NotAvailable / errdefs.Forbidden:
+//     surfaced from the underlying provider; Build preserves the
+//     classification so the daemon's startup path can map them to
+//     the same exit codes as plain secret resolution.
+func Build(ctx context.Context, provider secrets.Provider, cfg Config) (*tls.Config, error) {
+	if provider == nil {
+		return nil, errdefs.Validationf("tlsconfig: provider is required")
+	}
+	if cfg.CertRef == "" {
+		return nil, errdefs.Validationf("tlsconfig: CertRef is required")
+	}
+	if cfg.KeyRef == "" {
+		return nil, errdefs.Validationf("tlsconfig: KeyRef is required")
+	}
+	if cfg.ClientCARef == "" {
+		return nil, errdefs.Validationf("tlsconfig: ClientCARef is required")
+	}
+
+	minVersion, err := mapMinVersion(cfg.MinVersion)
+	if err != nil {
+		return nil, err
+	}
+
+	certPEM, err := provider.Get(ctx, cfg.CertRef)
+	if err != nil {
+		return nil, fmt.Errorf("tlsconfig: resolve cert %q: %w", cfg.CertRef, err)
+	}
+	keyPEM, err := provider.Get(ctx, cfg.KeyRef)
+	if err != nil {
+		return nil, fmt.Errorf("tlsconfig: resolve key %q: %w", cfg.KeyRef, err)
+	}
+	caPEM, err := provider.Get(ctx, cfg.ClientCARef)
+	if err != nil {
+		return nil, fmt.Errorf("tlsconfig: resolve clientCA %q: %w", cfg.ClientCARef, err)
+	}
+
+	cert, err := tls.X509KeyPair(certPEM, keyPEM)
+	if err != nil {
+		// X509KeyPair surfaces "PEM block not parseable" /
+		// "key does not match cert" as generic errors. Either
+		// case is a config-shape problem and the operator must
+		// fix it before the daemon can start, so Validation is
+		// the right classification.
+		return nil, errdefs.Validationf("tlsconfig: load X509 key pair: %v", err)
+	}
+
+	pool := x509.NewCertPool()
+	if !pool.AppendCertsFromPEM(caPEM) {
+		return nil, errdefs.Validationf("tlsconfig: clientCA %q contains no parseable PEM blocks", cfg.ClientCARef)
+	}
+
+	return &tls.Config{
+		Certificates: []tls.Certificate{cert},
+		ClientCAs:    pool,
+		// RequireAndVerifyClientCert is the whole point of this
+		// package. RequestClientCert / VerifyClientCertIfGiven
+		// would silently accept anonymous clients on a TLS
+		// listener and that is the exact "thought we had mTLS,
+		// didn't" footgun this package exists to prevent.
+		ClientAuth: tls.RequireAndVerifyClientCert,
+		MinVersion: minVersion,
+	}, nil
+}
+
+// mapMinVersion translates the human-readable string accepted by
+// the apispec into the tls.VersionTLS{12,13} constants. Anything
+// outside that allow-list is rejected — older protocols are no
+// longer considered secure and we refuse to start the listener.
+func mapMinVersion(s string) (uint16, error) {
+	switch s {
+	case "", "1.3":
+		return tls.VersionTLS13, nil
+	case "1.2":
+		return tls.VersionTLS12, nil
+	default:
+		return 0, errdefs.Validationf("tlsconfig: MinVersion %q invalid (want 1.2|1.3)", s)
+	}
+}

--- a/cmd/vesseld/tlsconfig/tlsconfig_test.go
+++ b/cmd/vesseld/tlsconfig/tlsconfig_test.go
@@ -1,0 +1,218 @@
+package tlsconfig
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"testing"
+	"time"
+
+	"github.com/GizClaw/flowcraft/sdk/errdefs"
+)
+
+// fakeProvider implements secrets.Provider for tests. The map is
+// ref → bytes; an unknown ref returns errdefs.NotFound so we can
+// exercise both the happy path and the surfacing of provider
+// errors.
+type fakeProvider struct {
+	data map[string][]byte
+}
+
+func (f *fakeProvider) Get(_ context.Context, ref string) ([]byte, error) {
+	v, ok := f.data[ref]
+	if !ok {
+		return nil, errdefs.NotFoundf("test: ref %q not registered", ref)
+	}
+	return v, nil
+}
+
+// genPair returns a freshly minted self-signed cert + private key
+// (PEM-encoded) suitable for both server and CA roles in unit
+// tests. The cert is valid for one hour starting now — long enough
+// to outlive any reasonable test run, short enough that a leaked
+// cert is meaningless an hour later.
+func genPair(t *testing.T, cn string) (certPEM, keyPEM []byte) {
+	t.Helper()
+	priv, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("GenerateKey: %v", err)
+	}
+	tmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject:      pkix.Name{CommonName: cn},
+		NotBefore:    time.Now().Add(-1 * time.Minute),
+		NotAfter:     time.Now().Add(1 * time.Hour),
+		KeyUsage:     x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
+		ExtKeyUsage: []x509.ExtKeyUsage{
+			x509.ExtKeyUsageServerAuth,
+			x509.ExtKeyUsageClientAuth,
+		},
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &priv.PublicKey, priv)
+	if err != nil {
+		t.Fatalf("CreateCertificate: %v", err)
+	}
+	certPEM = pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})
+	keyDER, err := x509.MarshalECPrivateKey(priv)
+	if err != nil {
+		t.Fatalf("MarshalECPrivateKey: %v", err)
+	}
+	keyPEM = pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: keyDER})
+	return certPEM, keyPEM
+}
+
+func TestBuild_HappyPath(t *testing.T) {
+	t.Parallel()
+	certPEM, keyPEM := genPair(t, "vesseld-test")
+	caPEM, _ := genPair(t, "client-ca")
+
+	p := &fakeProvider{data: map[string][]byte{
+		"file:///cert": certPEM,
+		"file:///key":  keyPEM,
+		"file:///ca":   caPEM,
+	}}
+	out, err := Build(context.Background(), p, Config{
+		CertRef:     "file:///cert",
+		KeyRef:      "file:///key",
+		ClientCARef: "file:///ca",
+	})
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	if got := out.MinVersion; got != tls.VersionTLS13 {
+		t.Fatalf("MinVersion = %d, want %d (TLS 1.3)", got, tls.VersionTLS13)
+	}
+	if out.ClientAuth != tls.RequireAndVerifyClientCert {
+		t.Fatalf("ClientAuth = %v, want RequireAndVerifyClientCert", out.ClientAuth)
+	}
+	if len(out.Certificates) != 1 {
+		t.Fatalf("Certificates len = %d, want 1", len(out.Certificates))
+	}
+	if out.ClientCAs == nil {
+		t.Fatal("ClientCAs is nil")
+	}
+}
+
+func TestBuild_MinVersion12Honoured(t *testing.T) {
+	t.Parallel()
+	certPEM, keyPEM := genPair(t, "vesseld-test")
+	caPEM, _ := genPair(t, "client-ca")
+	p := &fakeProvider{data: map[string][]byte{
+		"c": certPEM, "k": keyPEM, "a": caPEM,
+	}}
+	out, err := Build(context.Background(), p, Config{
+		CertRef: "c", KeyRef: "k", ClientCARef: "a", MinVersion: "1.2",
+	})
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	if out.MinVersion != tls.VersionTLS12 {
+		t.Fatalf("MinVersion = %d, want %d", out.MinVersion, tls.VersionTLS12)
+	}
+}
+
+func TestBuild_RejectsInvalidMinVersion(t *testing.T) {
+	t.Parallel()
+	p := &fakeProvider{data: map[string][]byte{}}
+	_, err := Build(context.Background(), p, Config{
+		CertRef: "c", KeyRef: "k", ClientCARef: "a", MinVersion: "1.1",
+	})
+	if !errdefs.IsValidation(err) {
+		t.Fatalf("expected Validation, got %v", err)
+	}
+}
+
+func TestBuild_RejectsMissingFields(t *testing.T) {
+	t.Parallel()
+	p := &fakeProvider{}
+	for _, tc := range []struct {
+		name string
+		cfg  Config
+	}{
+		{"no-cert", Config{KeyRef: "k", ClientCARef: "a"}},
+		{"no-key", Config{CertRef: "c", ClientCARef: "a"}},
+		{"no-ca", Config{CertRef: "c", KeyRef: "k"}},
+	} {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if _, err := Build(context.Background(), p, tc.cfg); !errdefs.IsValidation(err) {
+				t.Fatalf("expected Validation, got %v", err)
+			}
+		})
+	}
+}
+
+func TestBuild_RejectsNilProvider(t *testing.T) {
+	t.Parallel()
+	if _, err := Build(context.Background(), nil, Config{CertRef: "c", KeyRef: "k", ClientCARef: "a"}); !errdefs.IsValidation(err) {
+		t.Fatalf("expected Validation, got %v", err)
+	}
+}
+
+func TestBuild_PropagatesProviderError(t *testing.T) {
+	t.Parallel()
+	p := &fakeProvider{data: map[string][]byte{}}
+	_, err := Build(context.Background(), p, Config{
+		CertRef: "missing", KeyRef: "k", ClientCARef: "a",
+	})
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !errdefs.IsNotFound(err) {
+		t.Fatalf("expected wrapped NotFound, got %v", err)
+	}
+}
+
+func TestBuild_RejectsBadCertPEM(t *testing.T) {
+	t.Parallel()
+	_, keyPEM := genPair(t, "vesseld-test")
+	caPEM, _ := genPair(t, "ca")
+	p := &fakeProvider{data: map[string][]byte{
+		"c": []byte("not pem"), "k": keyPEM, "a": caPEM,
+	}}
+	_, err := Build(context.Background(), p, Config{
+		CertRef: "c", KeyRef: "k", ClientCARef: "a",
+	})
+	if !errdefs.IsValidation(err) {
+		t.Fatalf("expected Validation, got %v", err)
+	}
+}
+
+func TestBuild_RejectsBadCAPEM(t *testing.T) {
+	t.Parallel()
+	certPEM, keyPEM := genPair(t, "vesseld-test")
+	p := &fakeProvider{data: map[string][]byte{
+		"c": certPEM, "k": keyPEM, "a": []byte("not pem"),
+	}}
+	_, err := Build(context.Background(), p, Config{
+		CertRef: "c", KeyRef: "k", ClientCARef: "a",
+	})
+	if !errdefs.IsValidation(err) {
+		t.Fatalf("expected Validation, got %v", err)
+	}
+}
+
+func TestBuild_RejectsKeyCertMismatch(t *testing.T) {
+	t.Parallel()
+	certPEM, _ := genPair(t, "vesseld-test")
+	_, otherKeyPEM := genPair(t, "other")
+	caPEM, _ := genPair(t, "ca")
+	p := &fakeProvider{data: map[string][]byte{
+		"c": certPEM, "k": otherKeyPEM, "a": caPEM,
+	}}
+	_, err := Build(context.Background(), p, Config{
+		CertRef: "c", KeyRef: "k", ClientCARef: "a",
+	})
+	if !errdefs.IsValidation(err) {
+		t.Fatalf("expected Validation, got %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

Adds mutual TLS as a first-class auth mode for vesseld's TCP API
listener, unblocking the v0.2.0 roadmap item `vesseld mTLS` and
giving `cmd/vesseld/secrets` its first real consumer.

Listener config (YAML):

```yaml
apiVersion: vessel.flowcraft.io/v1alpha1
kind: Daemon
metadata:
  name: vesseld-default
spec:
  control:
    listen: 0.0.0.0:8443
    auth:
      mtls:
        cert:     file:///etc/vesseld/server.pem
        key:      file:///etc/vesseld/server.key
        clientCA: file:///etc/vesseld/clients-ca.pem
        # minVersion: \"1.3\"  # default
```

Cert / key / clientCA refs accept the same URL-keyed syntax
`secrets.Provider` already understands (`env://`, `file:///`,
`vault://`). CLI overrides via `--cert / --key / --client-ca`.

## Design notes

* **mTLS is first-class auth**, not an add-on. The TCP listener
  precondition is now \"tokenFile OR mtls\", so an mtls-only
  posture (no token at all) is valid — the client certificate IS
  the credential. Operators may still set `tokenFile` alongside
  mtls for defence in depth.
* **`tls.NewListener` wraps the TCP listener** so handshakes
  without a valid client cert are refused before the HTTP mux is
  consulted. The unix-socket listener is unaffected (filesystem
  permissions remain the auth boundary there).
* **`tlsconfig.Build` pins `ClientAuth = RequireAndVerifyClientCert`
  in one place** so the \"thought we had mutual TLS, accepted any
  client\" footgun lives in a single ~120-line file with
  exhaustive unit coverage (malformed PEM, key/cert mismatch,
  unsupported MinVersion, provider-error propagation).
* **CLI flags follow an all-or-none contract** — partial input is
  accepted only when matching YAML fields fill the gap; the
  daemon refuses to start otherwise so a half-configured mTLS
  posture never silently degrades to "open TCP port".

## Layer breakdown

| Layer | Files | Role |
|---|---|---|
| apispec | `daemon.go`, `validate_test.go` | `DaemonMTLS` schema + validator; TCP requires `tokenFile OR mtls` |
| resolver | `plan.go`, `resolve.go` | `DaemonMTLSPlan` flat fields; `minVersion` defaulted to `\"1.3\"` |
| tlsconfig (new) | `doc.go`, `tlsconfig.go`, `tlsconfig_test.go` | `Build(ctx, secrets.Provider, Config) → *tls.Config` |
| api | `server.go`, `server_mtls_test.go` | `Config.TLS`; `tls.NewListener` wrap; in-process CA + leaves end-to-end handshake test |
| runtime + cli | `runtime.go`, `mtls_test.go`, `run.go` | `applyMTLSOverrides` merges CLI onto plan; `--cert/--key/--client-ca` flags |

## Out of scope (covered separately)

* **Live cert rotation** — `Build` takes a startup snapshot today,
  mirroring the existing token-file path. Live rotation is a
  future RFC.
* **OIDC bearer token validation** — different scope, blocked on
  an \"identity-only vs. identity + RBAC\" RFC, and the typical
  vesseld caller today is machine-to-machine where mTLS is the
  better fit. Layered on top of mTLS once a web console or
  `vesseldctl login` flow lands.

## Dependency posture

Pure `cmd/vesseld` change. No `sdk` / `sdkx` / `vessel` deltas, so
no module dependency bump is required.

## Test plan

- [x] `go vet ./...` clean
- [x] `go test -race -count=1 ./cmd/vesseld/...` green (all packages)
- [x] new `TestAPI_TCPMTLSHandshake` exercises valid / no-cert / rogue-CA paths against a real TCP+TLS listener
- [x] new `TestAPI_StartRequiresAuthOnTCP` pins the \"Listen without auth\" footgun
- [x] new `tlsconfig` package covers happy path, malformed PEM, key/cert mismatch, invalid MinVersion, missing fields, provider-error propagation
- [x] new `runtime.applyMTLSOverrides` tests cover no-op, all-from-CLI, partial-CLI-rejection, partial-CLI + YAML merge
- [x] `apispec.Daemon.Validate` tests cover mTLS-satisfies-auth, missing each required field, bad minVersion

Made with [Cursor](https://cursor.com)