### PR TITLE
feat(sdk/knowledge): implement DocLevelSearcher on retrieval backend; deprecate fs chunk/layer + factory.NewLocal [skip-tag:sdkx]

### DIFF
--- a/eval/beir/beir.go
+++ b/eval/beir/beir.go
@@ -39,7 +39,9 @@ import (
 	"time"
 
 	"github.com/GizClaw/flowcraft/sdk/knowledge"
+	"github.com/GizClaw/flowcraft/sdk/knowledge/backend/fs"
 	"github.com/GizClaw/flowcraft/sdk/knowledge/factory"
+	"github.com/GizClaw/flowcraft/sdk/retrieval/memory"
 	"github.com/GizClaw/flowcraft/sdk/workspace"
 )
 
@@ -447,13 +449,23 @@ func Run(ctx context.Context, ds *Dataset, opts Options) (*Report, error) {
 	return rep, nil
 }
 
+// buildService assembles a knowledge.Service backed by the retrieval
+// backend (chunks/layers in an in-memory retrieval.Index, documents in
+// the workspace filesystem). We avoid factory.NewLocal here because
+// FSChunkRepo's Replace rewrites the entire dataset chunks file on
+// every doc ingest (O(N) per call) → at scifact's N=5183 this
+// dominates wall-clock by an order of magnitude. The retrieval +
+// memidx pair has the same in-process / no-external-deps property
+// while doing only O(1) work per doc. See #134.
 func buildService(opts Options) *knowledge.Service {
 	ws := workspace.NewMemWorkspace()
-	var localOpts []factory.LocalOption
+	docs := fs.NewDocumentRepo(ws, fs.DefaultPrefix)
+	idx := memory.New()
+	var retOpts []factory.RetrievalOption
 	if opts.Embedder != nil {
-		localOpts = append(localOpts, factory.WithLocalEmbedder(opts.Embedder, opts.DatasetID))
+		retOpts = append(retOpts, factory.WithRetrievalEmbedder(opts.Embedder, opts.DatasetID))
 	}
-	return factory.NewLocal(ws, localOpts...)
+	return factory.NewRetrieval(docs, idx, retOpts...)
 }
 
 // ingest puts every dataset document through PutDocument. BEIR corpora

--- a/eval/knowledge/knowledge.go
+++ b/eval/knowledge/knowledge.go
@@ -28,7 +28,9 @@ import (
 	"time"
 
 	"github.com/GizClaw/flowcraft/sdk/knowledge"
+	"github.com/GizClaw/flowcraft/sdk/knowledge/backend/fs"
 	"github.com/GizClaw/flowcraft/sdk/knowledge/factory"
+	"github.com/GizClaw/flowcraft/sdk/retrieval/memory"
 	"github.com/GizClaw/flowcraft/sdk/workspace"
 )
 
@@ -359,18 +361,27 @@ func Run(ctx context.Context, ds *Dataset, opts Options) (*Report, error) {
 	return rep, nil
 }
 
-// buildService spins up a fresh in-memory workspace + Service. The
+// buildService spins up a fresh in-memory workspace + Service backed
+// by the retrieval backend (chunks/layers in sdk/retrieval/memory,
+// documents in FSDocumentRepo on a workspace.MemWorkspace). The
 // embedder is wired only when non-nil — a nil embedder produces a
 // BM25-only Service that still answers ModeBM25 queries correctly but
 // returns empty results for ModeVector / ModeHybrid (we surface those
 // as Skipped lanes upstream rather than crashing).
+//
+// We avoid factory.NewLocal here: FSChunkRepo's O(N) per-ingest cost
+// (see #134) is not visible at this corpus size (~100 docs) but using
+// the same backend choice across eval suites keeps regressions
+// detected by either suite reproducible on the same code path.
 func buildService(opts Options) (*knowledge.Service, error) {
 	ws := workspace.NewMemWorkspace()
-	var localOpts []factory.LocalOption
+	docs := fs.NewDocumentRepo(ws, fs.DefaultPrefix)
+	idx := memory.New()
+	var retOpts []factory.RetrievalOption
 	if opts.Embedder != nil {
-		localOpts = append(localOpts, factory.WithLocalEmbedder(opts.Embedder, opts.DatasetID))
+		retOpts = append(retOpts, factory.WithRetrievalEmbedder(opts.Embedder, opts.DatasetID))
 	}
-	return factory.NewLocal(ws, localOpts...), nil
+	return factory.NewRetrieval(docs, idx, retOpts...), nil
 }
 
 // ingest puts every dataset document into svc under datasetID.

--- a/sdk/graph/node/knowledgenode/knowledgenode_test.go
+++ b/sdk/graph/node/knowledgenode/knowledgenode_test.go
@@ -8,13 +8,16 @@ import (
 	"github.com/GizClaw/flowcraft/sdk/graph/node"
 	"github.com/GizClaw/flowcraft/sdk/graph/node/knowledgenode"
 	"github.com/GizClaw/flowcraft/sdk/knowledge"
+	"github.com/GizClaw/flowcraft/sdk/knowledge/backend/fs"
 	"github.com/GizClaw/flowcraft/sdk/knowledge/factory"
+	"github.com/GizClaw/flowcraft/sdk/retrieval/memory"
 	"github.com/GizClaw/flowcraft/sdk/workspace"
 )
 
-func newLocalService(t *testing.T) *knowledge.Service {
+func newService(t *testing.T) *knowledge.Service {
 	t.Helper()
-	return factory.NewLocal(workspace.NewMemWorkspace())
+	ws := workspace.NewMemWorkspace()
+	return factory.NewRetrieval(fs.NewDocumentRepo(ws, fs.DefaultPrefix), memory.New())
 }
 
 func newNodeBoardCtx() (graph.ExecutionContext, *graph.Board) {
@@ -39,7 +42,7 @@ func TestNode_NilService_ReturnsEmpty(t *testing.T) {
 }
 
 func TestNode_AllScope_FansOut(t *testing.T) {
-	svc := newLocalService(t)
+	svc := newService(t)
 	ctx := context.Background()
 	if err := svc.PutDocument(ctx, "ds1", "a.md", "alpha banana"); err != nil {
 		t.Fatalf("put ds1: %v", err)
@@ -66,7 +69,7 @@ func TestNode_AllScope_FansOut(t *testing.T) {
 }
 
 func TestNode_SingleScope_PerDatasetStateKey(t *testing.T) {
-	svc := newLocalService(t)
+	svc := newService(t)
 	ctx := context.Background()
 	if err := svc.PutDocument(ctx, "docs", "a.md", "alpha banana"); err != nil {
 		t.Fatalf("put: %v", err)
@@ -98,7 +101,7 @@ func TestNode_SingleScope_PerDatasetStateKey(t *testing.T) {
 }
 
 func TestNode_SingleScope_FallsBackToBoardDataset(t *testing.T) {
-	svc := newLocalService(t)
+	svc := newService(t)
 	ctx := context.Background()
 	if err := svc.PutDocument(ctx, "docs", "a.md", "alpha banana"); err != nil {
 		t.Fatalf("put: %v", err)
@@ -163,7 +166,7 @@ func TestConfigFromMap_AllScopeAndDatasets(t *testing.T) {
 }
 
 func TestNode_CustomQueryKey(t *testing.T) {
-	svc := newLocalService(t)
+	svc := newService(t)
 	if err := svc.PutDocument(context.Background(), "ds1", "a.md", "alpha banana"); err != nil {
 		t.Fatalf("put: %v", err)
 	}

--- a/sdk/knowledge/backend/fs/chunk.go
+++ b/sdk/knowledge/backend/fs/chunk.go
@@ -95,6 +95,16 @@ func newDatasetState() *datasetState {
 //
 // Concurrency: every public method is safe for concurrent use; the
 // repo's RWMutex protects the state map and each datasetState.
+//
+// Deprecated: FSChunkRepo is a unit-test / demo-grade backend. Replace
+// rewrites the entire dataset .chunks.json on every per-doc ingest and
+// rebuilds both chunk-level and doc-level inverted indices from
+// scratch, all under a single write lock — making per-doc ingest O(N)
+// and total ingest O(N^2) in the dataset (see #134). For any
+// non-trivial dataset use factory.NewRetrieval with an in-process
+// sdk/retrieval/memory.Index or a production retrieval.Index from
+// sdkx/retrieval/{sqlite,postgres,workspace}. Slated for removal in
+// v0.5.0; see docs/migrations/v0.5.0.md.
 type FSChunkRepo struct {
 	ws        workspace.Workspace
 	paths     pathBuilder
@@ -106,6 +116,10 @@ type FSChunkRepo struct {
 
 // NewChunkRepo constructs an FSChunkRepo. Tokenizer is auto-detected from
 // the first content seen when nil; explicit override wins.
+//
+// Deprecated: see FSChunkRepo. Use factory.NewRetrieval with a
+// sdk/retrieval/memory.Index (or any production retrieval.Index)
+// instead. Slated for removal in v0.5.0.
 func NewChunkRepo(ws workspace.Workspace, prefix string, tok textsearch.Tokenizer) *FSChunkRepo {
 	return &FSChunkRepo{
 		ws:        ws,

--- a/sdk/knowledge/backend/fs/layer.go
+++ b/sdk/knowledge/backend/fs/layer.go
@@ -51,6 +51,14 @@ type datasetLayersFileSchema struct {
 // Detail (L2) layers are not persisted by this repo: detail content
 // already lives in chunks via FSChunkRepo. Put for LayerDetail returns a
 // validation error.
+//
+// Deprecated: FSLayerRepo is a unit-test / demo-grade backend. Like
+// FSChunkRepo it scales poorly on multi-doc datasets and is paired
+// exclusively with FSChunkRepo through factory.NewLocal — once that
+// pairing is retired in v0.5.0 there is no remaining caller. For
+// production wiring use factory.NewRetrieval, which stores layers
+// inside the retrieval.Index alongside chunks (see #134 and
+// docs/migrations/v0.5.0.md).
 type FSLayerRepo struct {
 	ws        workspace.Workspace
 	paths     pathBuilder
@@ -60,6 +68,9 @@ type FSLayerRepo struct {
 }
 
 // NewLayerRepo wires an FSLayerRepo to ws under prefix.
+//
+// Deprecated: see FSLayerRepo. Use factory.NewRetrieval instead;
+// slated for removal in v0.5.0.
 func NewLayerRepo(ws workspace.Workspace, prefix string, tok textsearch.Tokenizer) *FSLayerRepo {
 	return &FSLayerRepo{
 		ws:        ws,

--- a/sdk/knowledge/backend/retrieval/chunk.go
+++ b/sdk/knowledge/backend/retrieval/chunk.go
@@ -235,6 +235,13 @@ func (r *RetrievalChunkRepo) searchOne(ctx context.Context, ns string, q knowled
 // in the ~5-20 chunks-per-doc range.
 const docOverfetchFactor = 4
 
+// sumpoolSource is the Candidate.Source label used when SearchDocs
+// aggregates chunks from more than one lane (e.g. ModeHybrid mixing
+// bm25 + vector candidates for the same doc). When all aggregated
+// chunks share a single lane, that lane's original Source is kept so
+// downstream lane-aware code keeps working on the BM25-only path.
+const sumpoolSource = "sumpool"
+
 // SearchDocs runs a doc-level query by over-fetching chunk-level Hits
 // and collapsing them by docName via sum-pool aggregation.
 //
@@ -251,9 +258,37 @@ const docOverfetchFactor = 4
 // chunk-granularity path uses. For hybrid, both BM25 and vector
 // candidates for the same chunk contribute to the doc's aggregate.
 //
+// HYBRID CAVEAT: BM25 scores (range ~0–30+) and cosine similarities
+// (range 0–1) live on incomparable scales; sum-pooling them lets the
+// BM25 lane dominate the aggregate while the vector lane contributes
+// negligible weight. At the chunk level this is what
+// SearchEngine.Ranker exists to solve (RRF / rank-based fusion across
+// non-comparable scoring domains). SearchDocs intentionally bypasses
+// the Ranker today because it operates below the SearchEngine layer;
+// callers running production hybrid retrieval should prefer the
+// chunk-granularity Search path. A doc-level Ranker hook that
+// preserves hybrid fusion semantics is tracked as a follow-up.
+// BEIR / MS-MARCO / TREC doc-level eval suites run BM25-only so this
+// limitation does not affect #134 acceptance.
+//
+// OVER-FETCH ASSUMPTION: docOverfetchFactor (= 4) assumes
+// chunks-per-doc ≤ 4 in the typical case; corpora that produce many
+// chunks per doc (long PDFs, codebases) may see the top-K*4 chunk
+// page filled by a small number of strong docs and silently drop
+// other matching docs from the result set. Surfacing this as a
+// Query.OverfetchFactor knob, or refetching when the unique-doc
+// count falls short of TopK, is tracked as a follow-up.
+//
 // Returned Hits have ChunkIndex = -1 and Layer = "" (doc-level results
 // have no specific chunk); Content / Sig / Metadata are intentionally
 // dropped because they belong to a specific chunk, not the doc.
+//
+// Candidate.Source reflects the originating lane when every chunk
+// contributing to a doc came from the same lane (e.g. "bm25" or
+// "vector"); when a doc is aggregated across more than one lane
+// (hybrid), Source is set to sumpoolSource ("sumpool") so downstream
+// lane-aware code is not silently misled by the first-seen lane
+// label.
 //
 // Doc-level results are deterministically ordered: primary by score
 // (desc), tie-broken by (datasetID, docName) ascending so two scorers
@@ -279,6 +314,10 @@ func (r *RetrievalChunkRepo) SearchDocs(ctx context.Context, q knowledge.ChunkQu
 	// achieves the same by only emitting docs with a posting hit.
 	type key struct{ ds, doc string }
 	agg := make(map[key]*knowledge.Candidate, len(cands))
+	// sources tracks the distinct chunk-level Source values that
+	// contributed to each doc; promoted to sumpoolSource when more
+	// than one lane participated.
+	sources := make(map[key]string, len(cands))
 	order := make([]key, 0, len(cands))
 	for i := range cands {
 		c := cands[i]
@@ -288,6 +327,10 @@ func (r *RetrievalChunkRepo) SearchDocs(ctx context.Context, q knowledge.ChunkQu
 		k := key{c.Hit.DatasetID, c.Hit.DocName}
 		if existing, ok := agg[k]; ok {
 			existing.Hit.Score += c.Hit.Score
+			if sources[k] != "" && sources[k] != c.Source {
+				existing.Source = sumpoolSource
+				sources[k] = sumpoolSource
+			}
 			continue
 		}
 		agg[k] = &knowledge.Candidate{
@@ -299,6 +342,7 @@ func (r *RetrievalChunkRepo) SearchDocs(ctx context.Context, q knowledge.ChunkQu
 				ChunkIndex: -1,
 			},
 		}
+		sources[k] = c.Source
 		order = append(order, k)
 	}
 	out := make([]knowledge.Candidate, 0, len(order))

--- a/sdk/knowledge/backend/retrieval/chunk.go
+++ b/sdk/knowledge/backend/retrieval/chunk.go
@@ -226,6 +226,100 @@ func (r *RetrievalChunkRepo) searchOne(ctx context.Context, ns string, q knowled
 	return resp.Hits, nil
 }
 
+// docOverfetchFactor controls how many chunks SearchDocs pulls from the
+// chunk-level index per requested doc. The collapse below dedupes
+// chunks→docs, so we must over-fetch to guarantee that the top-K *docs*
+// are reachable even when one strong doc occupies the chunk-level top
+// hits with multiple chunks. 4x mirrors eval/beir's
+// DefaultOverfetchFactor and is empirically enough for chunker configs
+// in the ~5-20 chunks-per-doc range.
+const docOverfetchFactor = 4
+
+// SearchDocs runs a doc-level query by over-fetching chunk-level Hits
+// and collapsing them by docName via sum-pool aggregation.
+//
+// Score semantics: each doc's score is the sum of its matching chunks'
+// scores from the underlying retrieval.Index.Search response. This
+// re-aggregates BM25 signal that chunking split across passages —
+// closer to Anserini doc-level BM25 than max-pool, which only retains
+// the single strongest chunk. ChunkOverlap induces a small uniform
+// duplicate-count offset across every doc and therefore does not
+// affect intra-corpus ranking; see #126.
+//
+// Mode handling delegates to the chunk-level Search: BM25 / Vector /
+// Hybrid all flow through, with the same per-lane retrieval the
+// chunk-granularity path uses. For hybrid, both BM25 and vector
+// candidates for the same chunk contribute to the doc's aggregate.
+//
+// Returned Hits have ChunkIndex = -1 and Layer = "" (doc-level results
+// have no specific chunk); Content / Sig / Metadata are intentionally
+// dropped because they belong to a specific chunk, not the doc.
+//
+// Doc-level results are deterministically ordered: primary by score
+// (desc), tie-broken by (datasetID, docName) ascending so two scorers
+// with identical chunk-score distributions produce identical rankings
+// across re-runs.
+func (r *RetrievalChunkRepo) SearchDocs(ctx context.Context, q knowledge.ChunkQuery) ([]knowledge.Candidate, error) {
+	topK := q.TopK
+	if topK <= 0 {
+		topK = 5
+	}
+	chunkQ := q
+	chunkQ.TopK = topK * docOverfetchFactor
+	cands, err := r.Search(ctx, chunkQ)
+	if err != nil {
+		return nil, err
+	}
+
+	// Aggregate by (datasetID, docName). Zero-score chunk hits are
+	// dropped: some retrieval.Index implementations (notably
+	// sdk/retrieval/memory) surface every filter-matched doc with
+	// Score = 0 when no query term hit, which would otherwise leak
+	// into doc-level rankings and trash BEIR nDCG. FSChunkRepo
+	// achieves the same by only emitting docs with a posting hit.
+	type key struct{ ds, doc string }
+	agg := make(map[key]*knowledge.Candidate, len(cands))
+	order := make([]key, 0, len(cands))
+	for i := range cands {
+		c := cands[i]
+		if c.Hit.DocName == "" || c.Hit.Score <= 0 {
+			continue
+		}
+		k := key{c.Hit.DatasetID, c.Hit.DocName}
+		if existing, ok := agg[k]; ok {
+			existing.Hit.Score += c.Hit.Score
+			continue
+		}
+		agg[k] = &knowledge.Candidate{
+			Source: c.Source,
+			Hit: knowledge.Hit{
+				DatasetID:  c.Hit.DatasetID,
+				DocName:    c.Hit.DocName,
+				Score:      c.Hit.Score,
+				ChunkIndex: -1,
+			},
+		}
+		order = append(order, k)
+	}
+	out := make([]knowledge.Candidate, 0, len(order))
+	for _, k := range order {
+		out = append(out, *agg[k])
+	}
+	sort.SliceStable(out, func(i, j int) bool {
+		if out[i].Hit.Score != out[j].Hit.Score {
+			return out[i].Hit.Score > out[j].Hit.Score
+		}
+		if out[i].Hit.DatasetID != out[j].Hit.DatasetID {
+			return out[i].Hit.DatasetID < out[j].Hit.DatasetID
+		}
+		return out[i].Hit.DocName < out[j].Hit.DocName
+	})
+	if len(out) > topK {
+		out = out[:topK]
+	}
+	return out, nil
+}
+
 // hitToChunkCandidate projects a retrieval.Hit into a Candidate carrying
 // the chunk metadata back into the knowledge layer.
 func hitToChunkCandidate(datasetID, source string, h rt.Hit) knowledge.Candidate {
@@ -387,4 +481,7 @@ func copyAnyMetadata(m map[string]any) map[string]any {
 	return out
 }
 
-var _ knowledge.ChunkRepo = (*RetrievalChunkRepo)(nil)
+var (
+	_ knowledge.ChunkRepo        = (*RetrievalChunkRepo)(nil)
+	_ knowledge.DocLevelSearcher = (*RetrievalChunkRepo)(nil)
+)

--- a/sdk/knowledge/backend/retrieval/chunk_test.go
+++ b/sdk/knowledge/backend/retrieval/chunk_test.go
@@ -431,6 +431,69 @@ func TestRetrievalChunkRepo_SearchDocs_HybridContributesBothLanes(t *testing.T) 
 	}
 }
 
+func TestRetrievalChunkRepo_SearchDocs_SourceLabelsCrossLaneAggregateAsSumpool(t *testing.T) {
+	// When a doc's matching chunks span more than one lane
+	// (hybrid bm25 + vector for the same chunk → two candidates),
+	// the aggregated doc Candidate must carry sumpoolSource rather
+	// than whichever lane was encountered first. Downstream
+	// lane-aware code (fusion / labelling) would otherwise be
+	// silently misled by iteration order.
+	r := newChunkRepo(t)
+	ctx := context.Background()
+	c := chunk("a.md", 0, "apple")
+	c.Vector = []float32{1, 0, 0}
+	if err := r.Replace(ctx, "ds", "a.md", []knowledge.DerivedChunk{c}); err != nil {
+		t.Fatalf("replace: %v", err)
+	}
+	cands, err := r.SearchDocs(ctx, knowledge.ChunkQuery{
+		DatasetIDs: []string{"ds"},
+		Text:       "apple",
+		Vector:     []float32{1, 0, 0},
+		Mode:       knowledge.ModeHybrid,
+		TopK:       5,
+	})
+	if err != nil {
+		t.Fatalf("search docs: %v", err)
+	}
+	if len(cands) != 1 {
+		t.Fatalf("expected 1 doc-level hit, got %d", len(cands))
+	}
+	if got := cands[0].Source; got != "sumpool" {
+		t.Fatalf("cross-lane aggregate Source = %q, want \"sumpool\"", got)
+	}
+}
+
+func TestRetrievalChunkRepo_SearchDocs_SourceLabelsSingleLanePreserved(t *testing.T) {
+	// When every contributing chunk shares one lane (BM25-only),
+	// the aggregate must keep that lane's label rather than
+	// promoting to sumpoolSource. Lane-aware downstream code on the
+	// BM25-only eval path (e.g. BEIR scifact lanes=bm25) depends on
+	// this.
+	r := newChunkRepo(t)
+	ctx := context.Background()
+	if err := r.Replace(ctx, "ds", "a.md", []knowledge.DerivedChunk{
+		chunk("a.md", 0, "apple"),
+		chunk("a.md", 1, "apple banana"),
+	}); err != nil {
+		t.Fatalf("replace: %v", err)
+	}
+	cands, err := r.SearchDocs(ctx, knowledge.ChunkQuery{
+		DatasetIDs: []string{"ds"},
+		Text:       "apple",
+		Mode:       knowledge.ModeBM25,
+		TopK:       5,
+	})
+	if err != nil {
+		t.Fatalf("search docs: %v", err)
+	}
+	if len(cands) != 1 {
+		t.Fatalf("expected 1 doc-level hit, got %d", len(cands))
+	}
+	if got := cands[0].Source; got != "bm25" {
+		t.Fatalf("single-lane aggregate Source = %q, want \"bm25\"", got)
+	}
+}
+
 func TestRetrievalChunkRepo_SearchDocs_NoResults(t *testing.T) {
 	r := newChunkRepo(t)
 	ctx := context.Background()

--- a/sdk/knowledge/backend/retrieval/chunk_test.go
+++ b/sdk/knowledge/backend/retrieval/chunk_test.go
@@ -234,6 +234,223 @@ func TestRetrievalChunkRepo_NamespaceIsolation(t *testing.T) {
 	}
 }
 
+func TestRetrievalChunkRepo_SearchDocs_ImplementsDocLevelSearcher(t *testing.T) {
+	r := newChunkRepo(t)
+	if _, ok := any(r).(knowledge.DocLevelSearcher); !ok {
+		t.Fatalf("RetrievalChunkRepo must implement knowledge.DocLevelSearcher")
+	}
+}
+
+func TestRetrievalChunkRepo_SearchDocs_OneHitPerDoc(t *testing.T) {
+	// A query whose keyword appears in N chunks of the same doc must
+	// still produce exactly ONE doc-level hit for that doc — the
+	// whole point of doc-level collapse.
+	r := newChunkRepo(t)
+	ctx := context.Background()
+	if err := r.Replace(ctx, "ds", "a.md", []knowledge.DerivedChunk{
+		chunk("a.md", 0, "alpha"),
+		chunk("a.md", 1, "alpha"),
+		chunk("a.md", 2, "alpha"),
+	}); err != nil {
+		t.Fatalf("replace: %v", err)
+	}
+	cands, err := r.SearchDocs(ctx, knowledge.ChunkQuery{
+		DatasetIDs: []string{"ds"},
+		Text:       "alpha",
+		Mode:       knowledge.ModeBM25,
+		TopK:       5,
+	})
+	if err != nil {
+		t.Fatalf("search docs: %v", err)
+	}
+	if len(cands) != 1 {
+		t.Fatalf("expected 1 doc-level hit, got %d (cands=%+v)", len(cands), cands)
+	}
+	if cands[0].Hit.DocName != "a.md" {
+		t.Fatalf("docName = %q, want a.md", cands[0].Hit.DocName)
+	}
+	if cands[0].Hit.ChunkIndex != -1 {
+		t.Fatalf("doc-level hit has ChunkIndex %d, want -1", cands[0].Hit.ChunkIndex)
+	}
+	if cands[0].Hit.Layer != "" {
+		t.Fatalf("doc-level hit has Layer %q, want \"\"", cands[0].Hit.Layer)
+	}
+}
+
+func TestRetrievalChunkRepo_SearchDocs_SumPoolAggregatesAcrossChunks(t *testing.T) {
+	// A doc whose query keywords are SPLIT across two chunks must
+	// outrank a non-relevant doc that only matches one of those
+	// keywords (even repeatedly) in a single chunk. This is the exact
+	// failure mode of max-pool chunk-collapse documented in #126;
+	// sum-pool folds the per-chunk evidence into one doc score.
+	r := newChunkRepo(t)
+	ctx := context.Background()
+	if err := r.Replace(ctx, "ds", "rel.md", []knowledge.DerivedChunk{
+		chunk("rel.md", 0, "alpha bravo charlie"),
+		chunk("rel.md", 1, "delta echo foxtrot"),
+	}); err != nil {
+		t.Fatalf("replace rel: %v", err)
+	}
+	if err := r.Replace(ctx, "ds", "noise.md", []knowledge.DerivedChunk{
+		chunk("noise.md", 0, "alpha alpha alpha zulu"),
+	}); err != nil {
+		t.Fatalf("replace noise: %v", err)
+	}
+
+	cands, err := r.SearchDocs(ctx, knowledge.ChunkQuery{
+		DatasetIDs: []string{"ds"},
+		Text:       "alpha foxtrot",
+		Mode:       knowledge.ModeBM25,
+		TopK:       5,
+	})
+	if err != nil {
+		t.Fatalf("search docs: %v", err)
+	}
+	if len(cands) < 2 {
+		t.Fatalf("expected both docs, got %d", len(cands))
+	}
+	if cands[0].Hit.DocName != "rel.md" {
+		t.Fatalf("top doc = %q, want rel.md (sum-pool should let two-keyword coverage beat one-keyword repetition); ranking = %+v",
+			cands[0].Hit.DocName, cands)
+	}
+}
+
+func TestRetrievalChunkRepo_SearchDocs_RebuildsOnReplace(t *testing.T) {
+	// Doc-level results derive from the chunk index; a Replace that
+	// rewrites a doc's chunks must immediately surface the new tokens
+	// and stop surfacing the old ones — no stale cache layer.
+	r := newChunkRepo(t)
+	ctx := context.Background()
+	if err := r.Replace(ctx, "ds", "a.md", []knowledge.DerivedChunk{
+		chunk("a.md", 0, "alpha"),
+	}); err != nil {
+		t.Fatalf("replace v1: %v", err)
+	}
+	cands, _ := r.SearchDocs(ctx, knowledge.ChunkQuery{
+		DatasetIDs: []string{"ds"}, Text: "alpha", Mode: knowledge.ModeBM25, TopK: 5,
+	})
+	if len(cands) != 1 {
+		t.Fatalf("pre-replace: got %d, want 1", len(cands))
+	}
+	if err := r.Replace(ctx, "ds", "a.md", []knowledge.DerivedChunk{
+		chunk("a.md", 0, "epsilon"),
+	}); err != nil {
+		t.Fatalf("replace v2: %v", err)
+	}
+	cands, _ = r.SearchDocs(ctx, knowledge.ChunkQuery{
+		DatasetIDs: []string{"ds"}, Text: "alpha", Mode: knowledge.ModeBM25, TopK: 5,
+	})
+	if len(cands) != 0 {
+		t.Fatalf("post-replace stale: %+v", cands)
+	}
+	cands, _ = r.SearchDocs(ctx, knowledge.ChunkQuery{
+		DatasetIDs: []string{"ds"}, Text: "epsilon", Mode: knowledge.ModeBM25, TopK: 5,
+	})
+	if len(cands) != 1 {
+		t.Fatalf("post-replace new term not found: %+v", cands)
+	}
+}
+
+func TestRetrievalChunkRepo_SearchDocs_RespectsTopK(t *testing.T) {
+	r := newChunkRepo(t)
+	ctx := context.Background()
+	for i := 0; i < 8; i++ {
+		name := "doc" + itoa(i) + ".md"
+		if err := r.Replace(ctx, "ds", name, []knowledge.DerivedChunk{
+			chunk(name, 0, "shared keyword body "+name),
+		}); err != nil {
+			t.Fatalf("replace %s: %v", name, err)
+		}
+	}
+	cands, err := r.SearchDocs(ctx, knowledge.ChunkQuery{
+		DatasetIDs: []string{"ds"},
+		Text:       "shared",
+		Mode:       knowledge.ModeBM25,
+		TopK:       3,
+	})
+	if err != nil {
+		t.Fatalf("search docs: %v", err)
+	}
+	if len(cands) != 3 {
+		t.Fatalf("topK=3 returned %d hits", len(cands))
+	}
+}
+
+func TestRetrievalChunkRepo_SearchDocs_FanOutAcrossDatasets(t *testing.T) {
+	r := newChunkRepo(t)
+	ctx := context.Background()
+	if err := r.Replace(ctx, "ds1", "a.md", []knowledge.DerivedChunk{chunk("a.md", 0, "shared apple")}); err != nil {
+		t.Fatalf("replace ds1: %v", err)
+	}
+	if err := r.Replace(ctx, "ds2", "b.md", []knowledge.DerivedChunk{chunk("b.md", 0, "shared banana")}); err != nil {
+		t.Fatalf("replace ds2: %v", err)
+	}
+	cands, err := r.SearchDocs(ctx, knowledge.ChunkQuery{
+		DatasetIDs: []string{"ds1", "ds2"},
+		Text:       "shared",
+		Mode:       knowledge.ModeBM25,
+		TopK:       5,
+	})
+	if err != nil {
+		t.Fatalf("search docs: %v", err)
+	}
+	seen := map[string]bool{}
+	for _, c := range cands {
+		seen[c.Hit.DatasetID] = true
+	}
+	if !seen["ds1"] || !seen["ds2"] {
+		t.Fatalf("doc-level fan-out missed a dataset: seen=%v", seen)
+	}
+}
+
+func TestRetrievalChunkRepo_SearchDocs_HybridContributesBothLanes(t *testing.T) {
+	// Hybrid mode should let both BM25 and vector signal contribute
+	// to the doc's aggregate score.
+	r := newChunkRepo(t)
+	ctx := context.Background()
+	c := chunk("a.md", 0, "apple")
+	c.Vector = []float32{1, 0, 0}
+	if err := r.Replace(ctx, "ds", "a.md", []knowledge.DerivedChunk{c}); err != nil {
+		t.Fatalf("replace: %v", err)
+	}
+	cands, err := r.SearchDocs(ctx, knowledge.ChunkQuery{
+		DatasetIDs: []string{"ds"},
+		Text:       "apple",
+		Vector:     []float32{1, 0, 0},
+		Mode:       knowledge.ModeHybrid,
+		TopK:       5,
+	})
+	if err != nil {
+		t.Fatalf("search docs: %v", err)
+	}
+	if len(cands) != 1 {
+		t.Fatalf("expected 1 doc-level hit, got %d", len(cands))
+	}
+	if cands[0].Hit.Score <= 0 {
+		t.Fatalf("hybrid doc-level score = %v, expected > 0 (both lanes should contribute)", cands[0].Hit.Score)
+	}
+}
+
+func TestRetrievalChunkRepo_SearchDocs_NoResults(t *testing.T) {
+	r := newChunkRepo(t)
+	ctx := context.Background()
+	if err := r.Replace(ctx, "ds", "a.md", []knowledge.DerivedChunk{chunk("a.md", 0, "alpha")}); err != nil {
+		t.Fatalf("replace: %v", err)
+	}
+	cands, err := r.SearchDocs(ctx, knowledge.ChunkQuery{
+		DatasetIDs: []string{"ds"},
+		Text:       "no-such-term",
+		Mode:       knowledge.ModeBM25,
+		TopK:       5,
+	})
+	if err != nil {
+		t.Fatalf("search docs: %v", err)
+	}
+	if len(cands) != 0 {
+		t.Fatalf("expected 0 hits for non-matching query, got %+v", cands)
+	}
+}
+
 func TestRetrievalChunkRepo_SigRoundtrip(t *testing.T) {
 	r := newChunkRepo(t)
 	ctx := context.Background()

--- a/sdk/knowledge/factory/factory.go
+++ b/sdk/knowledge/factory/factory.go
@@ -20,6 +20,9 @@ import (
 )
 
 // LocalOption configures NewLocal.
+//
+// Deprecated: see NewLocal. Use RetrievalOption with NewRetrieval
+// instead; slated for removal in v0.5.0.
 type LocalOption func(*localConfig)
 
 type localConfig struct {
@@ -31,6 +34,9 @@ type localConfig struct {
 }
 
 // WithLocalChunker overrides the chunker used by the local service.
+//
+// Deprecated: use WithRetrievalChunker with NewRetrieval. Slated for
+// removal in v0.5.0.
 func WithLocalChunker(c knowledge.Chunker) LocalOption {
 	return func(cfg *localConfig) { cfg.chunker = c }
 }
@@ -38,6 +44,9 @@ func WithLocalChunker(c knowledge.Chunker) LocalOption {
 // WithLocalEmbedder enables vector-aware indexing on the local
 // backend. When sig is empty, the embedder's Go type name is used as
 // the EmbedSig; pass an explicit identifier for production wiring.
+//
+// Deprecated: use WithRetrievalEmbedder with NewRetrieval. Slated for
+// removal in v0.5.0.
 func WithLocalEmbedder(e knowledge.Embedder, sig string) LocalOption {
 	return func(cfg *localConfig) {
 		cfg.embedder = e
@@ -46,11 +55,22 @@ func WithLocalEmbedder(e knowledge.Embedder, sig string) LocalOption {
 }
 
 // WithLocalPrefix overrides the workspace prefix (default "knowledge").
+//
+// Deprecated: NewRetrieval has no equivalent — the retrieval.Index
+// owns chunk/layer storage and is independent of the workspace
+// filesystem prefix used by FSDocumentRepo. Slated for removal in
+// v0.5.0.
 func WithLocalPrefix(prefix string) LocalOption {
 	return func(cfg *localConfig) { cfg.prefix = prefix }
 }
 
 // WithLocalTokenizer overrides the BM25 tokenizer (default CJKTokenizer).
+//
+// Deprecated: the tokenizer used by NewRetrieval is owned by the
+// configured retrieval.Index (e.g. sdk/retrieval/memory.Index uses
+// CJKTokenizer; sdkx/retrieval/{sqlite,postgres} expose backend-native
+// analyzers). Configure tokenization at the Index constructor instead.
+// Slated for removal in v0.5.0.
 func WithLocalTokenizer(tok textsearch.Tokenizer) LocalOption {
 	return func(cfg *localConfig) { cfg.tok = tok }
 }
@@ -59,6 +79,16 @@ func WithLocalTokenizer(tok textsearch.Tokenizer) LocalOption {
 // workspace filesystem. ChunkRepo.Load is called eagerly so BM25
 // indexes rehydrate from disk before the first search; load errors
 // are swallowed (treated as "empty index").
+//
+// Deprecated: NewLocal wires FSChunkRepo + FSLayerRepo, both
+// demo-grade backends whose O(N) per-doc ingest does not scale beyond
+// unit-test / small-fixture sizes (see #134). Use NewRetrieval with
+// an in-process sdk/retrieval/memory.Index for tests and a production
+// retrieval.Index (sdkx/retrieval/{sqlite,postgres,workspace}) for
+// real workloads. FSDocumentRepo is NOT deprecated and remains the
+// canonical document store for both factories. Slated for removal in
+// v0.5.0; see docs/migrations/v0.5.0.md for the one-liner migration
+// recipe.
 func NewLocal(ws workspace.Workspace, opts ...LocalOption) *knowledge.Service {
 	cfg := localConfig{
 		prefix: fs.DefaultPrefix,

--- a/sdk/knowledge/service_test.go
+++ b/sdk/knowledge/service_test.go
@@ -7,7 +7,9 @@ import (
 	"testing"
 
 	"github.com/GizClaw/flowcraft/sdk/knowledge"
+	"github.com/GizClaw/flowcraft/sdk/knowledge/backend/fs"
 	"github.com/GizClaw/flowcraft/sdk/knowledge/factory"
+	"github.com/GizClaw/flowcraft/sdk/retrieval/memory"
 	"github.com/GizClaw/flowcraft/sdk/workspace"
 )
 
@@ -38,14 +40,20 @@ func (e *stubEmbedder) EmbedBatch(ctx context.Context, texts []string) ([][]floa
 	return out, nil
 }
 
-func newLocalService(t *testing.T, opts ...factory.LocalOption) *knowledge.Service {
+// newService spins up a Service backed by the retrieval backend
+// (RetrievalChunkRepo/LayerRepo on sdk/retrieval/memory; documents in
+// FSDocumentRepo on a workspace.MemWorkspace). factory.NewLocal is
+// deprecated as of v0.4 (#134) — new tests should reach for this
+// helper.
+func newService(t *testing.T, opts ...factory.RetrievalOption) *knowledge.Service {
 	t.Helper()
 	ws := workspace.NewMemWorkspace()
-	return factory.NewLocal(ws, opts...)
+	docs := fs.NewDocumentRepo(ws, fs.DefaultPrefix)
+	return factory.NewRetrieval(docs, memory.New(), opts...)
 }
 
 func TestService_PutDocumentIncrementsVersion(t *testing.T) {
-	svc := newLocalService(t)
+	svc := newService(t)
 	ctx := context.Background()
 	if err := svc.PutDocument(ctx, "ds", "a.md", "alpha"); err != nil {
 		t.Fatalf("first put: %v", err)
@@ -66,7 +74,7 @@ func TestService_PutDocumentIncrementsVersion(t *testing.T) {
 }
 
 func TestService_PutDocumentReplacesChunks(t *testing.T) {
-	svc := newLocalService(t)
+	svc := newService(t)
 	ctx := context.Background()
 	if err := svc.PutDocument(ctx, "ds", "a.md", "alpha banana"); err != nil {
 		t.Fatalf("put: %v", err)
@@ -93,7 +101,7 @@ func TestService_PutDocumentReplacesChunks(t *testing.T) {
 }
 
 func TestService_DeleteDocumentRemovesChunks(t *testing.T) {
-	svc := newLocalService(t)
+	svc := newService(t)
 	ctx := context.Background()
 	if err := svc.PutDocument(ctx, "ds", "a.md", "alpha"); err != nil {
 		t.Fatalf("put: %v", err)
@@ -122,7 +130,7 @@ func TestService_DeleteDocumentRemovesChunks(t *testing.T) {
 }
 
 func TestService_SearchSingleDatasetRequiresID(t *testing.T) {
-	svc := newLocalService(t)
+	svc := newService(t)
 	_, err := svc.Search(context.Background(), knowledge.Query{
 		Scope: knowledge.ScopeSingleDataset,
 		Text:  "x",
@@ -133,7 +141,7 @@ func TestService_SearchSingleDatasetRequiresID(t *testing.T) {
 }
 
 func TestService_SearchAllDatasetsFanOut(t *testing.T) {
-	svc := newLocalService(t)
+	svc := newService(t)
 	ctx := context.Background()
 	if err := svc.PutDocument(ctx, "ds1", "a.md", "shared apple"); err != nil {
 		t.Fatalf("put ds1: %v", err)
@@ -160,7 +168,7 @@ func TestService_SearchAllDatasetsFanOut(t *testing.T) {
 }
 
 func TestService_SearchInvalidLayer(t *testing.T) {
-	svc := newLocalService(t)
+	svc := newService(t)
 	_, err := svc.Search(context.Background(), knowledge.Query{
 		Scope: knowledge.ScopeAllDatasets,
 		Layer: knowledge.Layer("L99"),
@@ -172,7 +180,7 @@ func TestService_SearchInvalidLayer(t *testing.T) {
 }
 
 func TestService_PutDocumentLayerStoresBoth(t *testing.T) {
-	svc := newLocalService(t)
+	svc := newService(t)
 	ctx := context.Background()
 	if err := svc.PutDocument(ctx, "ds", "a.md", "alpha"); err != nil {
 		t.Fatalf("put doc: %v", err)
@@ -190,7 +198,7 @@ func TestService_PutDocumentLayerStoresBoth(t *testing.T) {
 }
 
 func TestService_PutDatasetLayer(t *testing.T) {
-	svc := newLocalService(t)
+	svc := newService(t)
 	ctx := context.Background()
 	if err := svc.PutDatasetLayer(context.Background(), "ds", knowledge.LayerOverview, "ds overview"); err != nil {
 		t.Fatalf("put: %v", err)
@@ -205,7 +213,7 @@ func TestService_PutDatasetLayer(t *testing.T) {
 }
 
 func TestService_PutLayerRejectsLayerDetail(t *testing.T) {
-	svc := newLocalService(t)
+	svc := newService(t)
 	err := svc.PutDocumentLayer(context.Background(), "ds", "a.md", knowledge.LayerDetail, "x")
 	if err == nil {
 		t.Fatalf("expected validation error for LayerDetail")
@@ -213,7 +221,7 @@ func TestService_PutLayerRejectsLayerDetail(t *testing.T) {
 }
 
 func TestService_RebuildScopedDocument(t *testing.T) {
-	svc := newLocalService(t)
+	svc := newService(t)
 	ctx := context.Background()
 	if err := svc.PutDocument(ctx, "ds", "a.md", "alpha"); err != nil {
 		t.Fatalf("put: %v", err)
@@ -234,7 +242,7 @@ func TestService_RebuildScopedDocument(t *testing.T) {
 }
 
 func TestService_RebuildWholeDataset(t *testing.T) {
-	svc := newLocalService(t)
+	svc := newService(t)
 	ctx := context.Background()
 	if err := svc.PutDocument(ctx, "ds", "a.md", "alpha"); err != nil {
 		t.Fatalf("put: %v", err)
@@ -246,8 +254,8 @@ func TestService_RebuildWholeDataset(t *testing.T) {
 
 func TestService_VectorEnabledStampsEmbedSig(t *testing.T) {
 	emb := &stubEmbedder{dim: 4}
-	svc := newLocalService(t,
-		factory.WithLocalEmbedder(emb, "stub:v1"),
+	svc := newService(t,
+		factory.WithRetrievalEmbedder(emb, "stub:v1"),
 	)
 	ctx := context.Background()
 	if err := svc.PutDocument(ctx, "ds", "a.md", "alpha"); err != nil {
@@ -271,7 +279,7 @@ func TestService_VectorEnabledStampsEmbedSig(t *testing.T) {
 }
 
 func TestService_HybridFallsBackToBM25WhenNoVector(t *testing.T) {
-	svc := newLocalService(t)
+	svc := newService(t)
 	ctx := context.Background()
 	if err := svc.PutDocument(ctx, "ds", "a.md", "alpha"); err != nil {
 		t.Fatalf("put: %v", err)
@@ -291,7 +299,7 @@ func TestService_HybridFallsBackToBM25WhenNoVector(t *testing.T) {
 }
 
 func TestService_NoDocsReturnsEmpty(t *testing.T) {
-	svc := newLocalService(t)
+	svc := newService(t)
 	res, err := svc.Search(context.Background(), knowledge.Query{
 		Scope: knowledge.ScopeAllDatasets,
 		Text:  "anything",
@@ -307,7 +315,7 @@ func TestService_NoDocsReturnsEmpty(t *testing.T) {
 }
 
 func TestService_DeleteUnknownDocumentNoError(t *testing.T) {
-	svc := newLocalService(t)
+	svc := newService(t)
 	if err := svc.DeleteDocument(context.Background(), "ds", "missing.md"); err != nil {
 		t.Fatalf("delete missing: %v", err)
 	}
@@ -324,8 +332,8 @@ func (e *errEmbedder) EmbedBatch(context.Context, []string) ([][]float32, error)
 }
 
 func TestService_PutDocumentSurfacesEmbedderError(t *testing.T) {
-	svc := newLocalService(t,
-		factory.WithLocalEmbedder(&errEmbedder{}, "err:v1"),
+	svc := newService(t,
+		factory.WithRetrievalEmbedder(&errEmbedder{}, "err:v1"),
 	)
 	err := svc.PutDocument(context.Background(), "ds", "a.md", "alpha")
 	if err == nil {
@@ -336,7 +344,7 @@ func TestService_PutDocumentSurfacesEmbedderError(t *testing.T) {
 // --- SearchDocuments (doc-level granularity, #126) --------------------------
 
 func TestService_SearchDocumentsReturnsOneHitPerDoc(t *testing.T) {
-	svc := newLocalService(t)
+	svc := newService(t)
 	ctx := context.Background()
 	if err := svc.PutDocument(ctx, "ds", "a.md", "alpha beta gamma alpha beta gamma"); err != nil {
 		t.Fatalf("put a: %v", err)
@@ -370,7 +378,7 @@ func TestService_SearchDocumentsRanksDocAcrossChunks(t *testing.T) {
 	// the chunks→doc aggregation path inside fs.SearchDocs. Doc "a"
 	// has the query keyword once in each of its two chunks (doc TF=2);
 	// doc "b" has the keyword only in its first chunk (doc TF=1).
-	svc := newLocalService(t, factory.WithLocalChunker(
+	svc := newService(t, factory.WithRetrievalChunker(
 		knowledge.NewDefaultChunker(knowledge.ChunkConfig{ChunkSize: 16, ChunkOverlap: 0}),
 	))
 	ctx := context.Background()
@@ -400,7 +408,7 @@ func TestService_SearchDocumentsRanksDocAcrossChunks(t *testing.T) {
 }
 
 func TestService_SearchDocumentsRespectsTopK(t *testing.T) {
-	svc := newLocalService(t)
+	svc := newService(t)
 	ctx := context.Background()
 	for _, name := range []string{"a.md", "b.md", "c.md", "d.md"} {
 		if err := svc.PutDocument(ctx, "ds", name, "alpha "+name); err != nil {
@@ -423,7 +431,7 @@ func TestService_SearchDocumentsRespectsTopK(t *testing.T) {
 }
 
 func TestService_SearchDocumentsScopeAllDatasets(t *testing.T) {
-	svc := newLocalService(t)
+	svc := newService(t)
 	ctx := context.Background()
 	if err := svc.PutDocument(ctx, "ds1", "a.md", "alpha"); err != nil {
 		t.Fatalf("put ds1: %v", err)
@@ -453,7 +461,7 @@ func TestService_SearchDocumentsScopeAllDatasets(t *testing.T) {
 }
 
 func TestService_SearchDocumentsRequiresDatasetIDForSingleScope(t *testing.T) {
-	svc := newLocalService(t)
+	svc := newService(t)
 	_, err := svc.SearchDocuments(context.Background(), knowledge.Query{
 		Scope: knowledge.ScopeSingleDataset,
 		Text:  "alpha",

--- a/sdk/knowledge/types.go
+++ b/sdk/knowledge/types.go
@@ -7,9 +7,10 @@
 //   - Service       (this package): orchestrates DocumentRepo / ChunkRepo /
 //     LayerRepo, normalises Query and stamps DerivedSig
 //     so callers see a single coherent contract.
-//   - factory       (sdk/knowledge/factory): wires Service against either
-//     filesystem-backed (factory.NewLocal) or
-//     retrieval.Index-backed (factory.NewRetrieval) repositories.
+//   - factory       (sdk/knowledge/factory): wires Service against a
+//     retrieval.Index (factory.NewRetrieval). The legacy filesystem
+//     wiring factory.NewLocal is deprecated as of v0.4 and slated for
+//     removal in v0.5.0; see #134 / docs/migrations/v0.5.0.md.
 //   - SearchEngine  (this package): runs Retrievers in parallel, fuses with
 //     a Ranker (RRF by default).
 //   - EventReloader (this package): debounces ChangeEvents and triggers

--- a/sdkx/tool/knowledge/tool_test.go
+++ b/sdkx/tool/knowledge/tool_test.go
@@ -7,18 +7,21 @@ import (
 	"testing"
 
 	sdkknowledge "github.com/GizClaw/flowcraft/sdk/knowledge"
+	"github.com/GizClaw/flowcraft/sdk/knowledge/backend/fs"
 	"github.com/GizClaw/flowcraft/sdk/knowledge/factory"
+	"github.com/GizClaw/flowcraft/sdk/retrieval/memory"
 	"github.com/GizClaw/flowcraft/sdk/workspace"
 	tool "github.com/GizClaw/flowcraft/sdkx/tool/knowledge"
 )
 
-func newLocalService(t *testing.T) *sdkknowledge.Service {
+func newService(t *testing.T) *sdkknowledge.Service {
 	t.Helper()
-	return factory.NewLocal(workspace.NewMemWorkspace())
+	ws := workspace.NewMemWorkspace()
+	return factory.NewRetrieval(fs.NewDocumentRepo(ws, fs.DefaultPrefix), memory.New())
 }
 
 func TestSearchServiceTool_BasicSearch(t *testing.T) {
-	svc := newLocalService(t)
+	svc := newService(t)
 	ctx := context.Background()
 	if err := svc.PutDocument(ctx, "ds", "go.md", "Go is a compiled programming language"); err != nil {
 		t.Fatalf("put: %v", err)
@@ -48,7 +51,7 @@ func TestSearchServiceTool_NilService(t *testing.T) {
 }
 
 func TestSearchServiceTool_InvalidScope(t *testing.T) {
-	svc := newLocalService(t)
+	svc := newService(t)
 	x := tool.NewSearchServiceTool(svc)
 	_, err := x.Execute(context.Background(), `{"query":"q","scope":"weird"}`)
 	if err == nil || !strings.Contains(err.Error(), "invalid scope") {
@@ -57,7 +60,7 @@ func TestSearchServiceTool_InvalidScope(t *testing.T) {
 }
 
 func TestPutServiceTool_RoundTrip(t *testing.T) {
-	svc := newLocalService(t)
+	svc := newService(t)
 	ctx := context.Background()
 	x := tool.NewPutServiceTool(svc)
 	if got := x.Definition().Name; got != "knowledge_put" {


### PR DESCRIPTION
Refs #134.

## Summary

- Implements `RetrievalChunkRepo.SearchDocs` so callers wired via `factory.NewRetrieval` can answer `knowledge.Service.SearchDocuments` instead of getting `errdefs.NotAvailable`. Uses query-time collapse (chunk over-fetch + sum-pool by docName), aligning with how Lucene / Elasticsearch / OpenSearch (`field_collapse`), Pinecone / Weaviate / Qdrant / Milvus (`parent_id` metadata aggregation) and ColBERT (max-passage scoring) solve the same problem in production.
- Migrates every in-tree `factory.NewLocal` call-site to `factory.NewRetrieval` + `sdk/retrieval/memory` (BEIR, knowledge-quality eval, three unit-test helpers). `FSDocumentRepo` is kept — it remains the canonical document store consumed by both factories.
- Deprecates `FSChunkRepo`, `FSLayerRepo`, `factory.NewLocal`, `LocalOption` and the four `WithLocal*` options for v0.5.0 removal. Full deprecation rationale and timeline live in the body of commit `38512b85`.

The five primary commits are independently reviewable and each leaves the tree green. The `// Deprecated:` markers in the final commit do not fire `SA1019` anywhere in-tree because the prior four commits removed every in-tree caller. Commit `2c457e13` addresses review feedback on hybrid `Source` labelling and adds docstring caveats for hybrid score additivity and overfetch assumptions.

## Why query-time collapse on a single chunk index

The alternative — maintaining a second native doc-level inverted index inside `retrieval.Index` — would force every backend implementation (memory, sqlite, postgres, workspace, third-party) to opt in, double the write amplification, and require backend-level transactional consistency between the chunk and doc indexes. Surveyed industry practice confirms this is rarely done outside engine-level systems like Vespa:

| System | Index granularity | Doc-level method | Maintains two indexes |
|---|---|---|---|
| Lucene / Elasticsearch / OpenSearch | Single, fixed at schema time | `field_collapse` at query time | No |
| Anserini (BEIR baseline) | Doc-level single index | Index granularity matches the qrels | No |
| Pinecone / Weaviate / Qdrant / Milvus | Chunk-level | `parent_id` metadata + KV lookup for parent body | No |
| Vespa | parent-child schema | Engine-level imported fields | Yes (parent doc replicated across all content nodes) |
| ColBERT / passage retrieval | Passage-level | max-passage scoring at query time | No |
| HRR / KohakuRAG (2025-26) | Chunk-level | Bottom-up embedding aggregation | No |
| Late Chunking (Jina, 2024) | Chunk-level | Long-context embed then slice | No |

`FSChunkRepo` maintains two inverted indexes because it is itself the indexing engine (an in-process Go map) and can synchronize both maps under a single `sync.RWMutex`. At the `retrieval.Index` abstraction level — which is meant to be pluggable against Pinecone-class engines and SQL-backed indexes — that pattern does not generalise. Keeping the `retrieval.Index` interface unchanged means every existing in-tree and out-of-tree backend gains doc-level search for free.

## Score semantics and BEIR parity

`SearchDocs` over-fetches `topK * 4` chunks (matching `eval/beir`'s `DefaultOverfetchFactor`) and sum-pools chunk scores per `(datasetID, docName)`. Zero-score chunks are dropped so `sdk/retrieval/memory`'s "return every filter-matched doc with `Score=0`" behaviour cannot leak into doc-level rankings and ruin nDCG. `FSChunkRepo` achieves the same by only emitting docs with a posting hit; this aligns the two backends' contracts.

Ranking is `Score` descending, with `(datasetID, docName)` ascending as a deterministic tie-break so two scorers with identical chunk-score distributions produce identical rankings across reruns.

The sum-pool semantics are mathematically adjacent to `FSChunkRepo.SearchDocs`, which derives doc-level postings by summing chunk token contributions per doc (see `#126` for the equivalence argument). When `feat/eval-beir-doc-granularity` rebases on this PR and bumps `eval/go.mod`'s sdk pin past the release containing commit 1, BEIR doc-granularity is expected to hit the `0.005` nDCG@10 reproducibility band in `#134`'s acceptance criteria.

Documented limitations (see `SearchDocs` docstring): hybrid mode sum-pools BM25 (~0-30+) and cosine similarity (0-1) without normalisation, letting BM25 dominate the aggregate; production hybrid retrieval should use the chunk-granularity `Search` path. `docOverfetchFactor=4` assumes chunks-per-doc ≤ 4; long-doc corpora may need a larger factor. Both are tracked as follow-ups and do not affect `#134`'s BM25-only acceptance.

## Why `Refs #134` not `Closes #134`

`#134` has five acceptance criteria. This PR ships three of them:

- [x] `RetrievalChunkRepo` implements `DocLevelSearcher`
- [x] `factory.NewRetrieval` callers can call `SearchDocuments` without `errdefs.NotAvailable`
- [x] `eval/beir` repointed from `factory.NewLocal` to `factory.NewRetrieval` (single-line `buildService` change)

Two remaining criteria require an eval-side rerun and will be verified after `feat/eval-beir-doc-granularity` rebases on this PR and bumps its `eval/go.mod`:

- [ ] BEIR scifact ingest wall-clock < 5 min at `ingest_concurrency=8`
- [ ] BEIR scifact nDCG@10 reproducible within ±0.005 of the fs-backend number

The eval team will close `#134` from their side once the post-merge BEIR rerun lands.

## What is intentionally NOT in this PR

By explicit user direction:

- `docs/migrations/v0.5.0.md` — to be written when v0.5.0 actually ships.
- `eval/go.mod` sdk version bump — per the comment in `eval/go.mod`, this is a manual follow-up so eval is not coupled to the sdk release cadence.
- Any change to the BEIR adapter beyond switching `buildService` to the retrieval backend.
- `sdkx/retrieval/{sqlite,postgres,workspace}` — since `retrieval.Index` is unchanged, these backends inherit doc-level search transparently through `RetrievalChunkRepo`.

## Test plan

- [x] `go build ./...` clean across sdk, sdkx, vessel, voice, cmd/vesseld, eval (with `GOWORK=off` for eval since it lives outside `go.work`).
- [x] `go test ./...` green across the same five modules — no skips, no flakes.
- [x] `go vet ./...` clean across all modules; `// Deprecated:` comments validate.
- [x] 10 new unit tests cover: `DocLevelSearcher` interface satisfaction, one-hit-per-doc under same-doc chunk repetition, sum-pool correctness (a split-keyword doc must outrank single-keyword-repeated noise — the exact failure mode `#126` documents for max-pool), `Replace`-driven rebuild, `topK` respect, multi-dataset fan-out, hybrid lane contribution, cross-lane `Source` promotion to `"sumpool"`, single-lane `Source` preservation, and empty-result behaviour.
- [ ] Reviewer to confirm `feat/eval-beir-doc-granularity` hits `#134` acceptance criteria once it rebases on this PR and bumps `eval/go.mod`.

## Commits

1. `feat(sdk/knowledge/backend/retrieval)`: implement DocLevelSearcher via chunk overfetch + sum-pool collapse
2. `refactor(eval/beir)`: switch buildService from factory.NewLocal to factory.NewRetrieval + memidx
3. `refactor(eval/knowledge)`: switch buildService from factory.NewLocal to factory.NewRetrieval + memidx
4. `test(sdk,sdkx)`: migrate Service test fixtures from factory.NewLocal to factory.NewRetrieval + memidx
5. `chore(sdk/knowledge)`: deprecate FSChunkRepo, FSLayerRepo, factory.NewLocal and Local* options for v0.5.0 removal
6. `fix(sdk/knowledge/backend/retrieval)`: label cross-lane SearchDocs aggregates as sumpool, document hybrid score and overfetch caveats