### PR TITLE
fix(sdk/model): surface CachedInputTokens through llm.Usage (closes #136) [skip-tag:sdkx]

### DIFF
--- a/sdk/graph/node/llmnode/round.go
+++ b/sdk/graph/node/llmnode/round.go
@@ -219,9 +219,10 @@ streamLoop:
 
 	rawUsage := inner.Usage()
 	usage := model.TokenUsage{
-		InputTokens:  rawUsage.InputTokens,
-		OutputTokens: rawUsage.OutputTokens,
-		TotalTokens:  rawUsage.InputTokens + rawUsage.OutputTokens,
+		InputTokens:       rawUsage.InputTokens,
+		CachedInputTokens: rawUsage.CachedInputTokens,
+		OutputTokens:      rawUsage.OutputTokens,
+		TotalTokens:       rawUsage.InputTokens + rawUsage.OutputTokens,
 	}
 
 	assistant := inner.Message()

--- a/sdk/llm/onechunk.go
+++ b/sdk/llm/onechunk.go
@@ -24,8 +24,12 @@ import "github.com/GizClaw/flowcraft/sdk/model"
 //     captured usage.
 func NewOneChunkStream(msg Message, usage TokenUsage) StreamMessage {
 	return &oneChunkStream{
-		msg:   msg,
-		usage: model.Usage{InputTokens: usage.InputTokens, OutputTokens: usage.OutputTokens},
+		msg: msg,
+		usage: model.Usage{
+			InputTokens:       usage.InputTokens,
+			CachedInputTokens: usage.CachedInputTokens,
+			OutputTokens:      usage.OutputTokens,
+		},
 	}
 }
 

--- a/sdk/llm/onechunk_test.go
+++ b/sdk/llm/onechunk_test.go
@@ -66,6 +66,23 @@ func TestOneChunkStream_ToolCallsReplayed(t *testing.T) {
 	}
 }
 
+func TestOneChunkStream_PropagatesCachedInputTokens(t *testing.T) {
+	// Regression for #136: model.Usage now carries CachedInputTokens
+	// so the synchronous-only Generate → NewOneChunkStream adapter
+	// must surface it to callers that observe via Usage() (e.g.
+	// llmnode → host.ReportUsage).
+	msg := NewTextMessage(RoleAssistant, "hi")
+	usage := TokenUsage{InputTokens: 100, CachedInputTokens: 80, OutputTokens: 5, TotalTokens: 105}
+	stream := NewOneChunkStream(msg, usage)
+	if !stream.Next() {
+		t.Fatal("Next() = false")
+	}
+	got := stream.Usage()
+	if got.InputTokens != 100 || got.CachedInputTokens != 80 || got.OutputTokens != 5 {
+		t.Errorf("Usage = %+v, want {Input:100 Cached:80 Output:5}", got)
+	}
+}
+
 func TestOneChunkStream_NonTextPartsAreInMessageNotChunk(t *testing.T) {
 	// Multimodal output: chunk only carries text concat (empty here);
 	// callers must read Message() for image parts.

--- a/sdk/model/message.go
+++ b/sdk/model/message.go
@@ -252,9 +252,21 @@ func NewImageMessage(role Role, text, imageURL string) Message {
 }
 
 // Usage represents raw token usage from a single LLM call (Provider layer).
+//
+// CachedInputTokens carries the same semantics as
+// TokenUsage.CachedInputTokens: it is the subset of InputTokens that
+// hit the provider's prompt cache and is billed at a reduced rate
+// (typically ~10x cheaper). Always <= InputTokens. Zero means either
+// the provider does not expose cache stats or no cache hit occurred
+// on this call.
+//
+// omitempty keeps the wire format stable for providers (e.g. ollama)
+// that never set it — pre-existing JSON consumers of Usage continue
+// to observe the historical {input_tokens, output_tokens} shape.
 type Usage struct {
-	InputTokens  int64 `json:"input_tokens"`
-	OutputTokens int64 `json:"output_tokens"`
+	InputTokens       int64 `json:"input_tokens"`
+	CachedInputTokens int64 `json:"cached_input_tokens,omitempty"`
+	OutputTokens      int64 `json:"output_tokens"`
 }
 
 // TokenUsage tracks cumulative token consumption (includes TotalTokens).

--- a/sdkx/llm/anthropic/stream.go
+++ b/sdkx/llm/anthropic/stream.go
@@ -34,11 +34,6 @@ type anthropicBetaStreamMessage struct {
 
 	mu    sync.Mutex
 	usage llm.Usage
-	// cachedInputTokens shadows usage so the finish path can plumb
-	// the cache-read subset (which llm.Usage intentionally omits)
-	// into TokenUsage. See sdkx/llm/openai/stream.go for the same
-	// pattern.
-	cachedInputTokens int64
 	// grossInputTokens is the sum of new + cache_read +
 	// cache_creation input tokens. Anthropic's wire `input_tokens`
 	// is the *non-cached new* portion only; we recombine it with
@@ -170,8 +165,8 @@ func (s *anthropicBetaStreamMessage) betaUpdateUsage(ev asdk.BetaRawMessageStrea
 		gross, cached := normalizeAnthropicUsage(u.InputTokens, u.CacheReadInputTokens, u.CacheCreationInputTokens)
 		s.mu.Lock()
 		s.usage.InputTokens = gross
+		s.usage.CachedInputTokens = cached
 		s.usage.OutputTokens = u.OutputTokens
-		s.cachedInputTokens = cached
 		s.grossInputTokens = gross
 		s.mu.Unlock()
 	case "message_delta":
@@ -222,7 +217,6 @@ func (s *anthropicBetaStreamMessage) betaFinish(err error) {
 		dur := time.Since(s.start)
 		s.mu.Lock()
 		usage := s.usage
-		cached := s.cachedInputTokens
 		s.mu.Unlock()
 		if err != nil {
 			s.span.RecordError(err)
@@ -233,7 +227,7 @@ func (s *anthropicBetaStreamMessage) betaFinish(err error) {
 		} else {
 			final := llm.TokenUsage{
 				InputTokens:       usage.InputTokens,
-				CachedInputTokens: cached,
+				CachedInputTokens: usage.CachedInputTokens,
 				OutputTokens:      usage.OutputTokens,
 				TotalTokens:       usage.InputTokens + usage.OutputTokens,
 			}
@@ -259,11 +253,10 @@ type anthropicStreamMessage struct {
 
 	mu    sync.Mutex
 	usage llm.Usage
-	// cachedInputTokens / grossInputTokens — see anthropicBetaStreamMessage.
-	cachedInputTokens int64
-	grossInputTokens  int64
-	closeOnce         sync.Once
-	finishOnce        sync.Once
+	// grossInputTokens — see anthropicBetaStreamMessage.
+	grossInputTokens int64
+	closeOnce        sync.Once
+	finishOnce       sync.Once
 
 	blockTypes map[int64]string
 
@@ -399,8 +392,8 @@ func (s *anthropicStreamMessage) updateUsage(ev asdk.MessageStreamEventUnion) {
 		gross, cached := normalizeAnthropicUsage(u.InputTokens, u.CacheReadInputTokens, u.CacheCreationInputTokens)
 		s.mu.Lock()
 		s.usage.InputTokens = gross
+		s.usage.CachedInputTokens = cached
 		s.usage.OutputTokens = u.OutputTokens
-		s.cachedInputTokens = cached
 		s.grossInputTokens = gross
 		s.mu.Unlock()
 	case "message_delta":
@@ -475,7 +468,6 @@ func (s *anthropicStreamMessage) finish(err error) {
 		dur := time.Since(s.start)
 		s.mu.Lock()
 		usage := s.usage
-		cached := s.cachedInputTokens
 		s.mu.Unlock()
 
 		if err != nil {
@@ -487,7 +479,7 @@ func (s *anthropicStreamMessage) finish(err error) {
 		} else {
 			final := llm.TokenUsage{
 				InputTokens:       usage.InputTokens,
-				CachedInputTokens: cached,
+				CachedInputTokens: usage.CachedInputTokens,
 				OutputTokens:      usage.OutputTokens,
 				TotalTokens:       usage.InputTokens + usage.OutputTokens,
 			}

--- a/sdkx/llm/bytedance/stream.go
+++ b/sdkx/llm/bytedance/stream.go
@@ -31,17 +31,12 @@ type streamMessage struct {
 	// openai/anthropic stream adapters.
 	start time.Time
 
-	mu    sync.Mutex
-	usage llm.Usage
-	// cachedInputTokens shadows usage so the finish path can surface
-	// Doubao's transparent prefix-cache hit count (which llm.Usage
-	// intentionally omits to stay minimal). Mirrors the openai/anthropic
-	// stream adapters.
-	cachedInputTokens int64
-	content           string
-	toolCalls         map[int]llm.ToolCall
-	closeOnce         sync.Once
-	spanEnded         bool
+	mu        sync.Mutex
+	usage     llm.Usage
+	content   string
+	toolCalls map[int]llm.ToolCall
+	closeOnce sync.Once
+	spanEnded bool
 
 	cur llm.StreamChunk
 	err error
@@ -209,7 +204,7 @@ func (s *streamMessage) updateUsage(resp model.ChatCompletionStreamResponse) {
 	s.mu.Lock()
 	s.usage.InputTokens = int64(resp.Usage.PromptTokens)
 	s.usage.OutputTokens = int64(resp.Usage.CompletionTokens)
-	s.cachedInputTokens = int64(resp.Usage.PromptTokensDetails.CachedTokens)
+	s.usage.CachedInputTokens = int64(resp.Usage.PromptTokensDetails.CachedTokens)
 	s.mu.Unlock()
 }
 
@@ -221,7 +216,6 @@ func (s *streamMessage) finish(err error) {
 	}
 	s.spanEnded = true
 	usage := s.usage
-	cached := s.cachedInputTokens
 	s.mu.Unlock()
 
 	dur := time.Since(s.start)
@@ -241,7 +235,7 @@ func (s *streamMessage) finish(err error) {
 	} else {
 		final := llm.TokenUsage{
 			InputTokens:       usage.InputTokens,
-			CachedInputTokens: cached,
+			CachedInputTokens: usage.CachedInputTokens,
 			OutputTokens:      usage.OutputTokens,
 			TotalTokens:       usage.InputTokens + usage.OutputTokens,
 		}

--- a/sdkx/llm/mock/mock.go
+++ b/sdkx/llm/mock/mock.go
@@ -66,9 +66,13 @@ func (m *MockLLM) GenerateStream(ctx context.Context, messages []llm.Message, op
 		return nil, err
 	}
 	return &mockStream{
-		msg:   msg,
-		text:  msg.Content(),
-		usage: llm.Usage{InputTokens: usage.InputTokens, OutputTokens: usage.OutputTokens},
+		msg:  msg,
+		text: msg.Content(),
+		usage: llm.Usage{
+			InputTokens:       usage.InputTokens,
+			CachedInputTokens: usage.CachedInputTokens,
+			OutputTokens:      usage.OutputTokens,
+		},
 	}, nil
 }
 

--- a/sdkx/llm/openai/stream.go
+++ b/sdkx/llm/openai/stream.go
@@ -28,17 +28,12 @@ type openaiStreamMessage struct {
 	start    time.Time
 	stream   *ssestream.Stream[oai.ChatCompletionChunk]
 
-	mu    sync.Mutex
-	usage llm.Usage
-	// cachedInputTokens shadows usage so we can plumb the cached
-	// subset (which llm.Usage intentionally omits to stay minimal
-	// at the Provider layer) into the finish-path TokenUsage
-	// without changing the Usage() return shape.
-	cachedInputTokens int64
-	content           strings.Builder
-	toolCalls         map[int]llm.ToolCall
-	closeOnce         sync.Once
-	spanEnded         bool
+	mu        sync.Mutex
+	usage     llm.Usage
+	content   strings.Builder
+	toolCalls map[int]llm.ToolCall
+	closeOnce sync.Once
+	spanEnded bool
 
 	cur llm.StreamChunk
 	err error
@@ -193,7 +188,7 @@ func (s *openaiStreamMessage) updateUsage(chunk oai.ChatCompletionChunk) {
 	s.mu.Lock()
 	s.usage.InputTokens = chunk.Usage.PromptTokens
 	s.usage.OutputTokens = chunk.Usage.CompletionTokens
-	s.cachedInputTokens = chunk.Usage.PromptTokensDetails.CachedTokens
+	s.usage.CachedInputTokens = chunk.Usage.PromptTokensDetails.CachedTokens
 	s.mu.Unlock()
 }
 
@@ -219,7 +214,6 @@ func (s *openaiStreamMessage) finish(err error) {
 	}
 	s.spanEnded = true
 	usage := s.usage
-	cached := s.cachedInputTokens
 	s.mu.Unlock()
 
 	dur := time.Since(s.start)
@@ -231,7 +225,7 @@ func (s *openaiStreamMessage) finish(err error) {
 	} else {
 		final := llm.TokenUsage{
 			InputTokens:       usage.InputTokens,
-			CachedInputTokens: cached,
+			CachedInputTokens: usage.CachedInputTokens,
 			OutputTokens:      usage.OutputTokens,
 			TotalTokens:       usage.InputTokens + usage.OutputTokens,
 		}

--- a/tests/conformance/llm/cached_tokens_stream_test.go
+++ b/tests/conformance/llm/cached_tokens_stream_test.go
@@ -16,14 +16,20 @@ import (
 )
 
 // pkgMetricReader is the package-level OTel ManualReader installed
-// once via TestMain. It exists for one reason: the streaming half of
-// the LLM API surface (sdkx/llm/{openai,anthropic,bytedance}/stream.go
-// → finish() → llm.RecordLLMMetrics) is the only public observable
-// for TokenUsage.CachedInputTokens on the stream path. The
-// llm.StreamMessage interface returns a minimal Usage{Input,Output}
-// (sdk/model/message.go:255) that does not surface the cache field —
-// asserting via stream.Usage() therefore cannot regress-protect the
-// stream finish path.
+// once via TestMain. It exists because this test asserts on
+// llm.RecordLLMMetrics counters as the regression surface for the
+// streaming half of the LLM API (sdkx/llm/{openai,anthropic,
+// bytedance}/stream.go → finish() → RecordLLMMetrics).
+//
+// Historical note: stream.Usage() used to return a minimal
+// Usage{Input,Output} that did not surface CachedInputTokens, so
+// the OTel counter was the only public observable for stream-path
+// cache stats. As of #136 the model.Usage struct carries
+// CachedInputTokens too, but this conformance module is pinned to
+// an older sdk version and still treats the counter as authoritative.
+// Once the module bumps sdk past #136, an additional
+// stream.Usage().CachedInputTokens assertion is straightforward to
+// add as a second, cheaper regression layer.
 //
 // The OTel global meter delegation rebinds package-level instruments
 // only on the FIRST SetMeterProvider call per process (see
@@ -89,21 +95,20 @@ func counterSumByProvider(t *testing.T, name, providerName string) int64 {
 // traffic in the framework's primary callers (sdk/agent, copilot
 // dispatcher, run-loop nodes) flows through GenerateStream. The
 // per-adapter stream finish() functions latch CachedInputTokens
-// through a SEPARATE code path (s.cachedInputTokens shadow field
-// + finish()-time TokenUsage construction) than the synchronous
-// adapter.Generate, so a regression in the stream-side latching
-// would not be caught by TestProviders_PromptCacheHitRate.
+// through a separate code path than the synchronous adapter.Generate,
+// so a regression in the stream-side latching would not be caught by
+// TestProviders_PromptCacheHitRate.
 //
-// Specifically, the gap users have hit in production:
+// Specifically, the gaps users have hit in production:
 //
-//   - sdkx/llm/openai/stream.go:196 latches
+//   - sdkx/llm/openai/stream.go latches
 //     chunk.Usage.PromptTokensDetails.CachedTokens onto
-//     s.cachedInputTokens, then stream.go:222→234 packages it into
+//     s.usage.CachedInputTokens, then finish() packages it into
 //     llm.TokenUsage.CachedInputTokens for RecordLLMMetrics. If any
-//     of these three steps regress (SDK rename, refactor drops the
-//     plumbing, finish() forgets to read the shadow), the
-//     synchronous Generate path remains unaffected — but the
-//     cached-tokens metric vanishes for every streaming caller.
+//     step regresses (SDK rename, refactor drops the plumbing,
+//     finish() forgets to read the field), the synchronous Generate
+//     path remains unaffected — but the cached-tokens metric
+//     vanishes for every streaming caller.
 //   - sdkx/llm/anthropic/stream.go has TWO finish paths (stable +
 //     beta JSON-mode) each with their own latching site, doubling
 //     the surface a sync-only test would miss.
@@ -112,16 +117,14 @@ func counterSumByProvider(t *testing.T, name, providerName string) int64 {
 //     PR added it back; that bug shipped to production undetected
 //     because no stream-path metric coverage existed.
 //
-// Why we observe via the OTel ManualReader rather than
-// stream.Usage(): the StreamMessage.Usage() return type is
-// model.Usage (sdk/model/message.go:255), a minimal pair
-// {InputTokens, OutputTokens}. The cache breakdown is intentionally
-// kept off the streaming-call hot path (avoiding mutex traffic for
-// callers that don't observe it), so the metric counter is the
-// *only* public observable for stream-path CachedInputTokens.
-// Asserting on the counter is what the user actually wants
-// regression-protected anyway — the bug report was "the metric
-// never prints", not "stream.Usage().Cached is wrong".
+// We observe via the OTel ManualReader (counter) because this
+// conformance module is pinned to an older sdk version whose
+// model.Usage did not expose CachedInputTokens — the metric was the
+// only public observable. Post-#136 the streaming Usage() also
+// carries the field, so once this module's sdk pin is bumped a
+// second assertion on stream.Usage().CachedInputTokens is a cheap
+// way to catch adapter-side regressions before they reach the
+// telemetry boundary.
 func TestProviders_PromptCacheHitRate_Stream(t *testing.T) {
 	stableSystem := buildStableSystemPrompt()
 


### PR DESCRIPTION
## Summary

Fix for #136. The streaming-side `llm.Usage` struct only carried `{InputTokens, OutputTokens}`, so even though sdkx adapters (openai / anthropic / bytedance) already tracked prompt-cache hit counts and emitted them to OTel via `RecordLLMMetrics` (the #113 path), the value could not flow through `StreamMessage.Usage()` → `llmnode/round.go` → `host.ReportUsage` / `VarInternalUsage` / `VarUsage`. Board-side dashboards, budget enforcers and per-turn audit logs always saw `CachedInputTokens=0` regardless of provider cache stats.

Option 1 from the issue (preferred): widen the narrow type so the streaming-side carrier aligns with the durable `model.TokenUsage`. Adapters drop the `s.cachedInputTokens` shadow and write directly onto `s.usage.CachedInputTokens`.

## Changes

- `sdk/model/message.go`: add `Usage.CachedInputTokens int64` with `omitempty` and the same semantics docstring as `TokenUsage.CachedInputTokens`. Pre-existing JSON consumers continue to observe the `{input_tokens, output_tokens}` shape for providers that don't set it.
- `sdkx/llm/{openai,anthropic,bytedance}/stream.go`: remove the `cachedInputTokens` shadow field; write the value directly onto `s.usage` in the per-event update path. Finish path now reads from `usage.CachedInputTokens` so `RecordLLMMetrics` and `stream.Usage()` agree byte-for-byte. Anthropic's two finish paths (stable + beta JSON-mode) are both updated.
- `sdk/graph/node/llmnode/round.go`: copy `CachedInputTokens` from the raw `Usage` into the `TokenUsage` handed to the host.
- `sdk/llm/onechunk.go` + `sdkx/llm/mock/mock.go`: propagate the field when constructing a synthetic `Usage` from a `TokenUsage` so the synchronous-only `Generate` adapter and the in-process mock both surface it.
- `sdk/llm/onechunk_test.go`: regression unit test for `NewOneChunkStream`.
- `tests/conformance/llm/cached_tokens_stream_test.go`: refresh the package and function docs that described `stream.Usage()` as a minimal `{Input,Output}` pair and pointed at the now-removed `s.cachedInputTokens` shadow. Pure documentation change — the assertions still observe via the OTel ManualReader because this conformance module is pinned to an older sdk version.

## Auto-tag note

The PR title carries `[skip-tag:sdkx]` (see `.github/workflows/auto-tag.yml`) because:

- This PR modifies both `sdk/` and `sdkx/`.
- On merge, sdk auto-tags correctly (the new field is consumed by sdkx code that ships with this PR).
- **But sdkx's `go.mod` still pins the pre-#136 sdk version.** If sdkx were auto-tagged in the same push, the new sdkx tag would advertise the CachedInputTokens plumbing while its module dependency still resolves to a sdk without `Usage.CachedInputTokens` — downstreams upgrading sdkx alone would either fail to compile (if the field is referenced) or silently keep dropping the cache subset.
- Correct sequence is: merge this PR → sdk auto-tags → follow-up PR bumps `sdkx/go.mod` to the new sdk tag → that merge auto-tags sdkx, which carries the accumulated sdkx diff per the "skip == defer" semantics documented in the workflow.

The follow-up dep-bump PR will be opened against `main` once the new sdk tag is published.

## Test plan

- [x] `go build ./...` clean in sdk, sdkx, vessel, voice modules.
- [x] `go test ./...` passes in sdk and sdkx (all subpackages cached green).
- [x] `go vet ./...` clean.
- [x] New unit test `TestOneChunkStream_PropagatesCachedInputTokens` in `sdk/llm/onechunk_test.go` covers the synchronous adapter path.
- [x] `tests/conformance` and `tests/quality/vessel` modules (separate go.mod, pinned to older sdk) still build under `GOWORK=off`.
- [ ] CI conformance suite against live providers (openai / anthropic / bytedance) — exercised by the existing `TestProviders_PromptCacheHitRate` + `TestProviders_PromptCacheHitRate_Stream`, no semantic changes.

## Out of scope

- `tests/quality/vessel/fakellm/stream.go` has the same `TokenUsage → llm.Usage` narrow-conversion pattern as `onechunk.go` / `mock.go` and currently drops `CachedInputTokens`. It lives in a separate `go.mod` pinned to the pre-#136 sdk, so the fix can't be applied until that module's sdk dependency is bumped. Will be addressed in the same follow-up PR as the sdkx dep-bump.

Closes #136.

Made with [Cursor](https://cursor.com)