### PR TITLE
chore(sdkx): bump sdk to v0.3.12 to pick up Usage.CachedInputTokens (#136)

### DIFF
--- a/sdkx/go.mod
+++ b/sdkx/go.mod
@@ -2,7 +2,7 @@ module github.com/GizClaw/flowcraft/sdkx
 
 go 1.25.0
 
-require github.com/GizClaw/flowcraft/sdk v0.3.7
+require github.com/GizClaw/flowcraft/sdk v0.3.12
 
 require (
 	github.com/PuerkitoBio/goquery v1.11.0

--- a/sdkx/go.sum
+++ b/sdkx/go.sum
@@ -8,8 +8,8 @@ github.com/Azure/azure-sdk-for-go/sdk/internal v1.10.0/go.mod h1:iZDifYGJTIgIIkY
 github.com/AzureAD/microsoft-authentication-library-for-go v1.2.2 h1:XHOnouVk1mxXfQidrMEnLlPk9UMeRtyBTnEFtxkV0kU=
 github.com/AzureAD/microsoft-authentication-library-for-go v1.2.2/go.mod h1:wP83P5OoQ5p6ip3ScPr0BAq0BvuPAvacpEuSzyouqAI=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
-github.com/GizClaw/flowcraft/sdk v0.3.7 h1:kp7Vqdetbl58YhGcPp+ExGTpabDDFJAYuhtaWqVK2bM=
-github.com/GizClaw/flowcraft/sdk v0.3.7/go.mod h1:VeMqVBxnMGHtFO9ypHhsA591XoLCWxucXR+gqpxQt5s=
+github.com/GizClaw/flowcraft/sdk v0.3.12 h1:7aySuWD8BJBgfYEtTF7PF5tnZv84AxbzkSDR8T3IpfA=
+github.com/GizClaw/flowcraft/sdk v0.3.12/go.mod h1:VeMqVBxnMGHtFO9ypHhsA591XoLCWxucXR+gqpxQt5s=
 github.com/PuerkitoBio/goquery v1.11.0 h1:jZ7pwMQXIITcUXNH83LLk+txlaEy6NVOfTuP43xxfqw=
 github.com/PuerkitoBio/goquery v1.11.0/go.mod h1:wQHgxUOU3JGuj3oD/QFfxUdlzW6xPHfqyHre6VMY4DQ=
 github.com/andybalholm/cascadia v1.3.3 h1:AG2YHrzJIm4BZ19iwJ/DAua6Btl3IwJX+VI4kktS1LM=


### PR DESCRIPTION
## Summary

Follow-up to #138 (closes the deferred half of #136).

#138 widened `model.Usage` with `CachedInputTokens` and updated the sdkx stream adapters (openai / anthropic / bytedance) to write directly onto `s.usage.CachedInputTokens`. That PR carried `[skip-tag:sdkx]` (see `.github/workflows/auto-tag.yml`) so the sdkx tag could be deferred until its `go.mod` actually points at the sdk version exposing the new field — otherwise downstreams upgrading sdkx alone would resolve to a sdk without `Usage.CachedInputTokens` and silently keep dropping the cache subset on the host-side / board-side observers.

This PR lifts the deferred half:

- `sdkx/go.mod`: `github.com/GizClaw/flowcraft/sdk` v0.3.7 -> v0.3.12 (the auto-tagged release of #138).
- `sdkx/go.sum`: regenerated via \`go mod tidy\`.

No source changes. On merge, auto-tag picks up the sdkx push and (per the workflow's documented "skip == defer" semantics) publishes a single sdkx tag that carries both this go.mod bump and the adapter-side diff from #138 in one release.

## Verification

Tested under `GOWORK=off` to ensure resolution actually goes through the module proxy (the workspace `go.work` would have masked the version pin with the local `sdk/` directory):

- [x] `GOWORK=off go mod tidy` clean inside `sdkx/`; resolved to `sdk v0.3.12`.
- [x] `GOWORK=off go build ./...` clean in `sdkx/`.
- [x] `GOWORK=off go vet ./...` clean in `sdkx/`.
- [x] `GOWORK=off go test ./...` green across every sdkx subpackage (anthropic, openai, bytedance, qwen, deepseek, minimax, azure, ollama, mock, plus the non-llm packages — extract, retrieval, sandbox, tool, workspace, etc.).

## Out of scope

- `tests/quality/vessel/go.mod` (pinned to `sdk v0.2.7`) and `tests/conformance/go.mod` (pinned to `sdk v0.3.6`) carry the same `Usage` narrow-conversion pattern in their test harnesses (e.g. `tests/quality/vessel/fakellm/stream.go`). Bumping those is a much larger jump that risks breaking unrelated test fixtures; handled separately when those modules are next refreshed.

Refs #136, #138.

Made with [Cursor](https://cursor.com)