### PR TITLE
revert(eval/beir): restore factory.NewLocal until #134 reworks doc-level BM25 corpus stats

### DIFF
--- a/eval/beir/beir.go
+++ b/eval/beir/beir.go
@@ -39,9 +39,7 @@ import (
 	"time"
 
 	"github.com/GizClaw/flowcraft/sdk/knowledge"
-	"github.com/GizClaw/flowcraft/sdk/knowledge/backend/fs"
 	"github.com/GizClaw/flowcraft/sdk/knowledge/factory"
-	"github.com/GizClaw/flowcraft/sdk/retrieval/memory"
 	"github.com/GizClaw/flowcraft/sdk/workspace"
 )
 
@@ -449,23 +447,39 @@ func Run(ctx context.Context, ds *Dataset, opts Options) (*Report, error) {
 	return rep, nil
 }
 
-// buildService assembles a knowledge.Service backed by the retrieval
-// backend (chunks/layers in an in-memory retrieval.Index, documents in
-// the workspace filesystem). We avoid factory.NewLocal here because
-// FSChunkRepo's Replace rewrites the entire dataset chunks file on
-// every doc ingest (O(N) per call) → at scifact's N=5183 this
-// dominates wall-clock by an order of magnitude. The retrieval +
-// memidx pair has the same in-process / no-external-deps property
-// while doing only O(1) work per doc. See #134.
+// buildService assembles a knowledge.Service for the BEIR adapter.
+//
+// We stay on factory.NewLocal (FSChunkRepo + DocLevelSearcher) despite
+// FSChunkRepo's known O(N) per-doc-ingest cost because the retrieval
+// backend's RetrievalChunkRepo.SearchDocs (#137) scores against
+// chunk-level corpus stats (DocCount inflated by chunker fan-out,
+// AvgLength = avg chunk length) and then sum-pools chunk-level BM25
+// scores. BM25 is nonlinear in TF and DocLength, so chunk-level scores
+// cannot be re-aggregated into doc-level BM25 scores. On scifact
+// (N=5183) this produced nDCG@10 = 0.133 vs FSChunkRepo's native
+// doc-level index at 0.672 (run 25848699992 vs 25844184454, a 5x
+// degradation). FSChunkRepo's SearchDocs maintains a parallel
+// doc-level inverted index (#127) so it scores against the right
+// corpus stats; that is what published BEIR baselines (Anserini,
+// Lucene field_collapse over doc-level Lucene) actually do.
+//
+// This restores main's BEIR baseline. The retrieval backend keeps its
+// SearchDocs implementation for non-eval doc-level callers but is not
+// suitable for IR benchmarking until #134 is reworked with native
+// doc-level corpus stats (or a per-Index doc-level inverted index).
+// Tracked in #134.
 func buildService(opts Options) *knowledge.Service {
 	ws := workspace.NewMemWorkspace()
-	docs := fs.NewDocumentRepo(ws, fs.DefaultPrefix)
-	idx := memory.New()
-	var retOpts []factory.RetrievalOption
+	var localOpts []factory.LocalOption
 	if opts.Embedder != nil {
-		retOpts = append(retOpts, factory.WithRetrievalEmbedder(opts.Embedder, opts.DatasetID))
+		localOpts = append(localOpts, factory.WithLocalEmbedder(opts.Embedder, opts.DatasetID))
 	}
-	return factory.NewRetrieval(docs, idx, retOpts...)
+	//nolint:staticcheck // factory.NewLocal is deprecated for v0.5.0 removal
+	// (see #137 commit 38512b85), but its FSChunkRepo's doc-level BM25
+	// is the only in-tree implementation that produces correct BEIR
+	// numbers today. Re-evaluate after #134 reworks
+	// RetrievalChunkRepo.SearchDocs to use doc-level corpus stats.
+	return factory.NewLocal(ws, localOpts...)
 }
 
 // ingest puts every dataset document through PutDocument. BEIR corpora


### PR DESCRIPTION
Reverts the BEIR adapter's `buildService` from `factory.NewRetrieval` back to `factory.NewLocal`. Restores the working BEIR baseline on main while #134 is reworked.

## Why

Post-#137 validation run on the retrieval backend produced a 5× nDCG@10 degradation vs. the fs-backend baseline. The perf target was met; the correctness target was missed by three orders of magnitude over budget:

| Backend | Run | nDCG@10 | Recall@100 | MRR | Ingest |
|---|---|---|---|---|---|
| fs (post-#130) | [`25844184454`](https://github.com/GizClaw/flowcraft/actions/runs/25844184454) | **0.6725** | 0.9076 | 0.6352 | ~30 min |
| retrieval (#137) | [`25848699992`](https://github.com/GizClaw/flowcraft/actions/runs/25848699992) | **0.1325** | 0.7266 | 0.1437 | 14 min |

#134 acceptance:
- ✅ ingest wall-clock < 5 min — met
- ❌ nDCG@10 within ±0.005 of fs — delta 0.540

## Root cause (in one paragraph)

Both backends use the same BM25 formula (k1=1.2, b=0.75 from `sdk/textsearch`), but `RetrievalChunkRepo.SearchDocs` scores against `memory.Index`'s **chunk-level** corpus stats (`DocCount` inflated by chunker fan-out, `AvgLength` = avg chunk length) and then sum-pools chunk-level BM25 scores per doc. BM25's TF saturation is nonlinear in TF and DocLength, so chunk-level scores cannot be re-aggregated into doc-level BM25 scores. `FSChunkRepo.SearchDocs` (#127) maintains a parallel doc-level inverted index with real doc-level corpus stats, which is what Anserini / Lucene `field_collapse`-over-doc-level-index actually do. Detailed math + design alternatives in the [#134 follow-up comment](https://github.com/GizClaw/flowcraft/issues/134#issuecomment-4448919273).

## Scope (revert is minimal)

Only `eval/beir/beir.go buildService` changes. The sdk-side #137 work — `RetrievalChunkRepo.SearchDocs`, `DocLevelSearcher` interface, deprecation markers, eval/knowledge migration, all test-fixture migrations — stays on main. When #134 reworks the retrieval-side scoring to use doc-level corpus stats (or a per-Index doc-level inverted index), this revert flips back.

## Caveat

Re-introduces one SA1019 warning at the single `factory.NewLocal` call-site; covered with `//nolint:staticcheck` + a comment pointing at #134. eval is a separate go.mod so this does not propagate to sdk/sdkx CI staticcheck.

## Test plan

- [x] `GOWORK=off go build ./...` in eval module
- [x] `GOWORK=off go test ./beir/... -count=1` — all pass
- [x] `GOWORK=off go vet ./beir/...` — clean
- [ ] Reviewer: confirm intent — the right call here is to restore BEIR correctness on main even at the cost of re-introducing the deprecation warning, because main producing a wrong number is worse than main producing a slow number.
- [ ] After merge, dispatch one BEIR scifact run against main to re-confirm the 0.6725 baseline returns. Will post the run ID here once dispatched.

Refs #134
