### PR TITLE
feat(cmd/vesseld): kind: Sandbox + Agent.spec.sandbox declarative wiring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -242,6 +242,30 @@ compare/fetch/ingest`, `eval longmemeval convert`). Shell completion
 
 #### vesseld
 
+- `cmd/vesseld/apispec` + resolver + fleet: `kind: Sandbox` resource
+  type + `Agent.spec.sandbox: <name>` reference exposing
+  `sdk/sandbox.Runner` and `sdkx/sandbox/nsjail` as a declarative
+  primitive. One Sandbox document materialises one runner via the
+  spec's `backend` (`local | nsjail`), `rootDir`, and optional
+  `env / net / resources / nsjail` policy fields; the resolver
+  layers `sandbox.WithDefaults` so the YAML policy acts as a floor
+  per-call ExecOptions cannot widen. Agents that declare
+  `spec.sandbox` auto-gain an `exec` tool (sdkx/tool/exec) wired to
+  the referenced runner, registered into a per-Captain registry
+  overlay so different vessels can hold different `exec` bindings
+  without name collision. The new `resolver.RuntimeDeps.ToolRegistry`
+  seam threads that overlay into the engine factory's
+  `catalog.Deps.ToolRegistry` so the engine sees the same registry
+  the LLM tool-call dispatcher consults. The resolver enforces
+  "at most one Sandbox per Vessel" at validation time — multi-
+  sandbox-per-vessel would need an LLM-visible disambiguation
+  scheme that is out of scope for v0.2.0; until then the constraint
+  keeps the registry overlay unambiguous. nsjail-on-non-Linux
+  surfaces as `errdefs.NotAvailable` at resolve time (matching the
+  runner constructor's own classification) so operators developing
+  on macOS get the verdict at boot instead of first run. Consumes
+  `sdk v0.3.13` and `sdkx v0.3.9` (bumped in a separate commit on
+  this PR).
 - `cmd/vesseld/apispec` + resolver + fleet: `Daemon.spec.sessionStore`
   YAML schema (`backend: memory|filesystem`, `root` required for
   filesystem) that wires `vessel.WithSessionStore` onto every

--- a/cmd/vesseld/apispec/decode.go
+++ b/cmd/vesseld/apispec/decode.go
@@ -172,6 +172,12 @@ func decodeV1Alpha1(node *yaml.Node, kind string) (Object, error) {
 			return nil, errdefs.Validationf("vesseld: decode Secret: %v", err)
 		}
 		return s, nil
+	case v1alpha1.KindSandbox:
+		var sb v1alpha1.Sandbox
+		if err := node.Decode(&sb); err != nil {
+			return nil, errdefs.Validationf("vesseld: decode Sandbox: %v", err)
+		}
+		return sb, nil
 	default:
 		return nil, errdefs.Validationf("vesseld: unsupported kind %q under %s (known: %v)", kind, v1alpha1.APIVersion, v1alpha1.AllKinds())
 	}

--- a/cmd/vesseld/apispec/v1alpha1/agent.go
+++ b/cmd/vesseld/apispec/v1alpha1/agent.go
@@ -52,6 +52,17 @@ type AgentSpec struct {
 	// Engine selects the EngineFactory and supplies its config.
 	// Required: every agent needs a runnable engine.
 	Engine AgentEngine `json:"engine" yaml:"engine"`
+
+	// Sandbox is the metadata.name of a [Sandbox] document the
+	// resolver wires into the agent. When set, the agent
+	// automatically gains a sandbox-backed exec tool whose
+	// sandbox.Runner is fixed by the referenced Sandbox's spec
+	// (per-call ExecOptions cannot widen the configured policy).
+	// Empty means no shell tool is auto-injected — the agent's
+	// engine and its declared Tools list run with whatever
+	// capabilities they already have. The resolver rejects
+	// references to unknown Sandbox names.
+	Sandbox string `json:"sandbox,omitempty" yaml:"sandbox,omitempty"`
 }
 
 // AgentCard mirrors the agent.AgentCard wire fields the resolver

--- a/cmd/vesseld/apispec/v1alpha1/meta.go
+++ b/cmd/vesseld/apispec/v1alpha1/meta.go
@@ -23,6 +23,7 @@ const (
 	KindToolPack     = "ToolPack"
 	KindHistoryStore = "HistoryStore"
 	KindSecret       = "Secret"
+	KindSandbox      = "Sandbox"
 )
 
 // AllKinds returns every well-known kind registered for this
@@ -32,6 +33,7 @@ func AllKinds() []string {
 	return []string{
 		KindDaemon, KindVessel, KindAgent, KindLLMProfile,
 		KindProbe, KindToolPack, KindHistoryStore, KindSecret,
+		KindSandbox,
 	}
 }
 

--- a/cmd/vesseld/apispec/v1alpha1/sandbox.go
+++ b/cmd/vesseld/apispec/v1alpha1/sandbox.go
@@ -1,0 +1,172 @@
+package v1alpha1
+
+import (
+	"github.com/GizClaw/flowcraft/sdk/errdefs"
+)
+
+// Sandbox is the wire form of a sandbox.Runner template. One
+// Sandbox document materialises one daemon-wide [sandbox.Runner]
+// that Agents reference by name via Agent.spec.sandbox; the
+// resolver layers a [sandbox.WithDefaults] decorator over the
+// chosen backend so the policy fields below act as the floor that
+// per-call ExecOptions cannot widen.
+//
+// # Mental model
+//
+// Sandbox stands to Agents the way kubernetes NetworkPolicy stands
+// to Pods: it is a standalone resource that any number of agents
+// may reference. Keeping it independent of Agent means a single
+// operator-managed "production-sandbox" can serve N agents
+// without each agent re-declaring the same env / net / resource
+// floor.
+type Sandbox struct {
+	TypeMeta   `json:",inline" yaml:",inline"`
+	ObjectMeta `json:"metadata" yaml:"metadata"`
+	Spec       SandboxSpec `json:"spec" yaml:"spec"`
+}
+
+// SandboxSpec configures the runner. v0.2.0 ships two backends:
+//
+//   - "local"  — [sandbox.LocalRunner]. No isolation; the policy
+//     fields are advisory. Suitable for dev / trusted code.
+//   - "nsjail" — sdkx-side nsjail.Runner (Linux only). Honours
+//     EnvPolicy and NetPolicy.Mode = deny-all; richer modes
+//     surface NotAvailable at exec time.
+//
+// Future backends (container, microVM) will slot in here additively.
+type SandboxSpec struct {
+	// Backend selects the runner implementation. Required.
+	// "local" | "nsjail".
+	Backend string `json:"backend" yaml:"backend"`
+
+	// RootDir is the physical confinement root the runner uses
+	// when resolving per-call WorkDir. Required: both
+	// sandbox.LocalRunner and the nsjail runner take rootDir at
+	// construction time and refuse Exec paths that escape it.
+	// Relative paths in tool-level WorkDir resolve against this
+	// root; absolute paths and `..` escapes are rejected.
+	RootDir string `json:"rootDir" yaml:"rootDir"`
+
+	// Env is the default EnvPolicy layered in. The fields map
+	// 1:1 to sandbox.EnvPolicy.
+	Env *SandboxEnv `json:"env,omitempty" yaml:"env,omitempty"`
+
+	// Net is the default NetPolicy layered in.
+	Net *SandboxNet `json:"net,omitempty" yaml:"net,omitempty"`
+
+	// Resources is the default ResourceLimits layered in.
+	Resources *SandboxResources `json:"resources,omitempty" yaml:"resources,omitempty"`
+
+	// Nsjail collects backend-specific knobs that only apply when
+	// Backend == "nsjail". Setting any field here while Backend
+	// != "nsjail" is a validation error so a misconfigured switch
+	// of backend never silently drops settings.
+	Nsjail *SandboxNsjail `json:"nsjail,omitempty" yaml:"nsjail,omitempty"`
+}
+
+// SandboxEnv mirrors sandbox.EnvPolicy. A nil Allow slice means
+// "no allow-list configured" (default — inherit nothing from
+// the host); an empty non-nil slice means "explicitly allow no
+// host env vars" which is the same outcome but documented in
+// YAML as the operator's intent.
+type SandboxEnv struct {
+	Allow  []string          `json:"allow,omitempty" yaml:"allow,omitempty"`
+	Inject map[string]string `json:"inject,omitempty" yaml:"inject,omitempty"`
+}
+
+// SandboxNet mirrors sandbox.NetPolicy.
+//
+// Mode values:
+//
+//	"default"    — inherit host networking.
+//	"deny-all"   — block egress entirely.
+//	"allow-list" — allow only entries in Allow (backend-dependent).
+//	"proxy"      — route through Proxy.
+//
+// "" defaults to "default" at resolve time.
+type SandboxNet struct {
+	Mode  string   `json:"mode,omitempty" yaml:"mode,omitempty"`
+	Allow []string `json:"allow,omitempty" yaml:"allow,omitempty"`
+	Proxy string   `json:"proxy,omitempty" yaml:"proxy,omitempty"`
+}
+
+// SandboxResources mirrors sandbox.ResourceLimits. All fields are
+// advisory on the "local" backend; "nsjail" enforces CPUMillicores
+// and MemoryBytes via cgroups, with the rest surfaced as
+// NotAvailable at exec time.
+type SandboxResources struct {
+	CPUMillicores  int   `json:"cpuMillicores,omitempty" yaml:"cpuMillicores,omitempty"`
+	MemoryBytes    int64 `json:"memoryBytes,omitempty" yaml:"memoryBytes,omitempty"`
+	DiskBytes      int64 `json:"diskBytes,omitempty" yaml:"diskBytes,omitempty"`
+	MaxOutputBytes int64 `json:"maxOutputBytes,omitempty" yaml:"maxOutputBytes,omitempty"`
+}
+
+// SandboxNsjail collects optional knobs that only the nsjail
+// backend reads. Keeping them in a typed sub-struct (rather than a
+// free-form map[string]any) means the validator can reject typos
+// at boot.
+type SandboxNsjail struct {
+	// Binary overrides the nsjail executable path. Empty falls
+	// back to $PATH lookup at runner-construction time.
+	Binary string `json:"binary,omitempty" yaml:"binary,omitempty"`
+
+	// ExtraFlags are appended verbatim to every nsjail invocation.
+	// Useful for ops-specific quirks (e.g. --rlimit_as on hosts
+	// where the cgroup mem cap is unreliable) without bloating
+	// the generic Spec.
+	ExtraFlags []string `json:"extraFlags,omitempty" yaml:"extraFlags,omitempty"`
+}
+
+// GetTypeMeta / GetObjectMeta satisfy [Object].
+func (s Sandbox) GetTypeMeta() TypeMeta     { return s.TypeMeta }
+func (s Sandbox) GetObjectMeta() ObjectMeta { return s.ObjectMeta }
+
+// Validate is shape-only — IO (e.g. confirming Nsjail.Binary
+// exists) lives in the resolver because the apispec layer must
+// stay side-effect free.
+func (s Sandbox) Validate() error {
+	if err := s.ObjectMeta.Validate(KindSandbox); err != nil {
+		return err
+	}
+	if s.TypeMeta.APIVersion != APIVersion {
+		return errdefs.Validationf("vesseld Sandbox %q: apiVersion %q != %q", s.Name, s.TypeMeta.APIVersion, APIVersion)
+	}
+	if s.TypeMeta.Kind != KindSandbox {
+		return errdefs.Validationf("vesseld Sandbox %q: kind %q != %q", s.Name, s.TypeMeta.Kind, KindSandbox)
+	}
+	switch s.Spec.Backend {
+	case "":
+		return errdefs.Validationf("vesseld Sandbox %q: spec.backend is required (local|nsjail)", s.Name)
+	case "local", "nsjail":
+	default:
+		return errdefs.Validationf("vesseld Sandbox %q: spec.backend %q invalid (want local|nsjail)", s.Name, s.Spec.Backend)
+	}
+	if s.Spec.RootDir == "" {
+		return errdefs.Validationf("vesseld Sandbox %q: spec.rootDir is required (the runner's filesystem confinement root)", s.Name)
+	}
+	if s.Spec.Nsjail != nil && s.Spec.Backend != "nsjail" {
+		return errdefs.Validationf("vesseld Sandbox %q: spec.nsjail is only valid when spec.backend=nsjail", s.Name)
+	}
+	if n := s.Spec.Net; n != nil {
+		switch n.Mode {
+		case "", "default", "deny-all", "allow-list", "proxy":
+		default:
+			return errdefs.Validationf("vesseld Sandbox %q: spec.net.mode %q invalid (want default|deny-all|allow-list|proxy)", s.Name, n.Mode)
+		}
+		// We do NOT enforce "allow-list requires Allow non-empty"
+		// here: an empty allow-list with mode=allow-list is a
+		// legitimate "block all" posture and the runner backend
+		// should be the one to reject Mode/Allow shapes it
+		// cannot honour (different backends support different
+		// subsets — that authority belongs at exec time).
+	}
+	if r := s.Spec.Resources; r != nil {
+		if r.CPUMillicores < 0 {
+			return errdefs.Validationf("vesseld Sandbox %q: spec.resources.cpuMillicores must be >= 0", s.Name)
+		}
+		if r.MemoryBytes < 0 || r.DiskBytes < 0 || r.MaxOutputBytes < 0 {
+			return errdefs.Validationf("vesseld Sandbox %q: spec.resources byte caps must be >= 0", s.Name)
+		}
+	}
+	return nil
+}

--- a/cmd/vesseld/apispec/v1alpha1/validate_test.go
+++ b/cmd/vesseld/apispec/v1alpha1/validate_test.go
@@ -194,6 +194,90 @@ func TestDaemon_SessionStore_RejectsInvalid(t *testing.T) {
 	}
 }
 
+func tmSandbox() TypeMeta { return TypeMeta{APIVersion: APIVersion, Kind: KindSandbox} }
+
+func TestSandbox_ValidateOK(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		name string
+		s    Sandbox
+	}{
+		{
+			"local-minimal",
+			Sandbox{
+				TypeMeta:   tmSandbox(),
+				ObjectMeta: ObjectMeta{Name: "dev"},
+				Spec:       SandboxSpec{Backend: "local", RootDir: "/tmp/dev"},
+			},
+		},
+		{
+			"nsjail-with-knobs",
+			Sandbox{
+				TypeMeta:   tmSandbox(),
+				ObjectMeta: ObjectMeta{Name: "prod"},
+				Spec: SandboxSpec{
+					Backend: "nsjail",
+					RootDir: "/var/lib/vesseld/prod",
+					Env: &SandboxEnv{
+						Allow:  []string{"PATH", "HOME"},
+						Inject: map[string]string{"X": "1"},
+					},
+					Net:       &SandboxNet{Mode: "deny-all"},
+					Resources: &SandboxResources{CPUMillicores: 1000, MemoryBytes: 1 << 30},
+					Nsjail:    &SandboxNsjail{Binary: "/usr/local/bin/nsjail"},
+				},
+			},
+		},
+	} {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if err := tc.s.Validate(); err != nil {
+				t.Fatalf("Validate: %v", err)
+			}
+		})
+	}
+}
+
+func TestSandbox_ValidateRejections(t *testing.T) {
+	t.Parallel()
+	base := Sandbox{
+		TypeMeta:   tmSandbox(),
+		ObjectMeta: ObjectMeta{Name: "s"},
+		Spec:       SandboxSpec{Backend: "local", RootDir: "/tmp/s"},
+	}
+	for _, tc := range []struct {
+		name string
+		mut  func(*Sandbox)
+	}{
+		{"empty-backend", func(s *Sandbox) { s.Spec.Backend = "" }},
+		{"unknown-backend", func(s *Sandbox) { s.Spec.Backend = "docker" }},
+		{"empty-rootDir", func(s *Sandbox) { s.Spec.RootDir = "" }},
+		{"nsjail-on-local", func(s *Sandbox) {
+			s.Spec.Nsjail = &SandboxNsjail{Binary: "/x"}
+		}},
+		{"bad-net-mode", func(s *Sandbox) {
+			s.Spec.Net = &SandboxNet{Mode: "passthrough"}
+		}},
+		{"negative-cpu", func(s *Sandbox) {
+			s.Spec.Resources = &SandboxResources{CPUMillicores: -1}
+		}},
+		{"negative-mem", func(s *Sandbox) {
+			s.Spec.Resources = &SandboxResources{MemoryBytes: -1}
+		}},
+	} {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			s := base
+			tc.mut(&s)
+			if err := s.Validate(); !errdefs.IsValidation(err) {
+				t.Fatalf("expected Validation, got %v", err)
+			}
+		})
+	}
+}
+
 func TestVessel_RequiresAgents(t *testing.T) {
 	t.Parallel()
 	v := Vessel{TypeMeta: tmVessel(), ObjectMeta: ObjectMeta{Name: "x"}}

--- a/cmd/vesseld/fleet/fleet.go
+++ b/cmd/vesseld/fleet/fleet.go
@@ -17,6 +17,8 @@ import (
 	"github.com/GizClaw/flowcraft/sdk/errdefs"
 	"github.com/GizClaw/flowcraft/sdk/event"
 	"github.com/GizClaw/flowcraft/sdk/model"
+	"github.com/GizClaw/flowcraft/sdk/tool"
+	exectool "github.com/GizClaw/flowcraft/sdkx/tool/exec"
 	"github.com/GizClaw/flowcraft/vessel"
 	"github.com/GizClaw/flowcraft/vessel/spec"
 )
@@ -555,14 +557,34 @@ func (f *Fleet) teardownAll() {
 // + history + tool registry through vessel.Deps.
 func (f *Fleet) buildCaptain(vp resolver.VesselPlan) (*captainEntry, error) {
 	bus := event.NewMemoryBus()
+	toolReg, err := f.buildCaptainToolRegistry(vp)
+	if err != nil {
+		return nil, err
+	}
+	sandboxAgents := make(map[string]struct{}, len(vp.SandboxAgents))
+	for _, name := range vp.SandboxAgents {
+		sandboxAgents[name] = struct{}{}
+	}
 	options := []vessel.Option{
 		vessel.WithBus(bus),
-		vessel.WithToolRegistry(f.plan.SharedToolRegistry),
+		vessel.WithToolRegistry(toolReg),
 		vessel.WithLLMResolver(f.plan.SharedLLMResolver),
 		vessel.WithEngineFactory(func(aspec spec.Agent, deps vessel.Deps) (engine.Engine, error) {
 			builder, ok := vp.EngineFactoriesByAgent[aspec.Name]
 			if !ok {
 				return nil, errdefs.NotFoundf("vesseld fleet: no engine builder for %s/%s", vp.Name, aspec.Name)
+			}
+			tools := aspec.Tools
+			// Inject the auto-wired exec tool's name into the
+			// allow-list of every agent that declared
+			// spec.sandbox. The tool itself was registered into
+			// toolReg above under exectool.Name; appending the
+			// name here ensures the engine's per-agent tool
+			// resolution actually sees it. Idempotent — if the
+			// user already listed "exec" explicitly we do not
+			// duplicate.
+			if _, ok := sandboxAgents[aspec.Name]; ok && !containsString(tools, exectool.Name) {
+				tools = append(append([]string(nil), tools...), exectool.Name)
 			}
 			// aspec.Tools at this layer already carries the
 			// vessel-runtime kanban auto-injection for Dispatcher
@@ -570,9 +592,19 @@ func (f *Fleet) buildCaptain(vp resolver.VesselPlan) (*captainEntry, error) {
 			// it straight through so the engine factory honours
 			// the same allow-list the agent.Agent will be built
 			// with.
+			// Hand the per-Captain registry through so the
+			// engine factory's catalog.Deps.ToolRegistry sees
+			// the sandbox-derived overlay (if any). Nil for
+			// vanilla vessels keeps the resolver-time shared
+			// registry in play.
+			var perCaptainReg *tool.Registry
+			if toolReg != f.plan.SharedToolRegistry {
+				perCaptainReg = toolReg
+			}
 			res, err := builder(resolver.RuntimeDeps{
-				AgentTools:  aspec.Tools,
-				LLMLimiters: f.limitersAsCatalog(),
+				AgentTools:   tools,
+				LLMLimiters:  f.limitersAsCatalog(),
+				ToolRegistry: perCaptainReg,
 			})
 			if err != nil {
 				return nil, err
@@ -606,6 +638,58 @@ func (f *Fleet) buildCaptain(vp resolver.VesselPlan) (*captainEntry, error) {
 		return nil, err
 	}
 	return &captainEntry{cap: cap, bus: bus}, nil
+}
+
+// buildCaptainToolRegistry returns the *tool.Registry the captain
+// for vp should consume. When vp does not reference a Sandbox the
+// daemon-shared registry is returned verbatim (zero allocation,
+// historical behaviour). When vp.SandboxName is set we shallow-
+// copy the shared entries and overlay an auto-generated `exec`
+// tool wired to the per-Vessel sandbox.Runner. Per-Captain
+// isolation is the reason for the copy: another vessel using a
+// different Sandbox needs a different `exec` binding, and a
+// single daemon-wide registry cannot hold two tools with the
+// same Definition().Name.
+func (f *Fleet) buildCaptainToolRegistry(vp resolver.VesselPlan) (*tool.Registry, error) {
+	if vp.SandboxName == "" {
+		return f.plan.SharedToolRegistry, nil
+	}
+	runner, ok := f.plan.SharedSandboxes[vp.SandboxName]
+	if !ok {
+		// resolver should already have caught this; defensive
+		// surface so a Plan stitched together by hand (e.g. in
+		// a test) gets a structured error rather than a nil
+		// dereference.
+		return nil, errdefs.NotFoundf("vesseld fleet: vessel %q references Sandbox %q but no runner was resolved",
+			vp.Name, vp.SandboxName)
+	}
+	t, err := exectool.New(runner)
+	if err != nil {
+		return nil, fmt.Errorf("vesseld fleet: build exec tool for vessel %q: %w", vp.Name, err)
+	}
+	reg := tool.NewRegistry()
+	for _, name := range f.plan.SharedToolRegistry.Names() {
+		got, ok := f.plan.SharedToolRegistry.Get(name)
+		if !ok {
+			continue
+		}
+		reg.RegisterWithScope(got, f.plan.SharedToolRegistry.ScopeOf(name))
+	}
+	reg.Register(t)
+	return reg, nil
+}
+
+// containsString is a small "is name already present" check used
+// when deciding whether to append the auto-injected exec tool to
+// an agent's allow-list. Kept here rather than in a general utils
+// file because it is the only caller in the fleet package.
+func containsString(haystack []string, needle string) bool {
+	for _, s := range haystack {
+		if s == needle {
+			return true
+		}
+	}
+	return false
 }
 
 // Sorted returns a sorted copy of the vessel-name list. Helpful

--- a/cmd/vesseld/fleet/sandbox_test.go
+++ b/cmd/vesseld/fleet/sandbox_test.go
@@ -1,0 +1,156 @@
+package fleet
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/GizClaw/flowcraft/cmd/vesseld/apispec"
+	"github.com/GizClaw/flowcraft/cmd/vesseld/catalog"
+	"github.com/GizClaw/flowcraft/cmd/vesseld/resolver"
+	"github.com/GizClaw/flowcraft/sdk/agent"
+	"github.com/GizClaw/flowcraft/sdk/engine"
+	"github.com/GizClaw/flowcraft/sdk/model"
+	exectool "github.com/GizClaw/flowcraft/sdkx/tool/exec"
+)
+
+const sandboxConfigTmpl = `
+apiVersion: vessel.flowcraft.io/v1alpha1
+kind: Daemon
+metadata: {name: vesseld-default}
+spec:
+  control: {socket: /tmp/vsbx.sock}
+---
+apiVersion: vessel.flowcraft.io/v1alpha1
+kind: Sandbox
+metadata: {name: dev-shell}
+spec:
+  backend: local
+  rootDir: %s
+---
+apiVersion: vessel.flowcraft.io/v1alpha1
+kind: Vessel
+metadata: {name: support}
+spec: {agents: [helper]}
+---
+apiVersion: vessel.flowcraft.io/v1alpha1
+kind: Agent
+metadata: {name: helper}
+spec:
+  engine: {ref: probe-tools}
+  sandbox: dev-shell
+`
+
+// TestFleet_Sandbox_ExecToolReachableFromEngine is the end-to-end
+// assertion for kind: Sandbox. The engine reads its tool registry
+// via Deps.ToolRegistry, looks up the auto-injected `exec` tool,
+// confirms its Definition().Name, and the test asserts the tool
+// landed there. Any break in the chain (resolver did not build a
+// runner, fleet did not overlay it onto the per-Captain registry,
+// or the agent's Tools allow-list missed the auto-injection) shows
+// up here as either a missing tool or a missing allow-list entry.
+func TestFleet_Sandbox_ExecToolReachableFromEngine(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	objs, err := apispec.DecodeAll(strings.NewReader(fmt.Sprintf(sandboxConfigTmpl, root)), "<test>")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var sawExec atomic.Bool
+	var sawToolInAllowList atomic.Bool
+	cat := catalog.New()
+	cat.RegisterEngine("probe-tools", func(_ string, _ map[string]any, deps catalog.Deps) (engine.Engine, error) {
+		// The fleet hands the auto-injected exec tool name into
+		// aspec.Tools at captain-build time; the engine builder
+		// surfaces it through deps.AgentTools. We capture both
+		// observations so a future regression that breaks only
+		// one half (e.g. registry overlay missing, but allow-
+		// list present) is still caught.
+		for _, name := range deps.AgentTools {
+			if name == exectool.Name {
+				sawToolInAllowList.Store(true)
+			}
+		}
+		if _, ok := deps.ToolRegistry.Get(exectool.Name); ok {
+			sawExec.Store(true)
+		}
+		return engine.EngineFunc(func(_ context.Context, _ engine.Run, _ engine.Host, b *engine.Board) (*engine.Board, error) {
+			b.AppendChannelMessage(engine.MainChannel, model.NewTextMessage(model.RoleAssistant, "ok"))
+			return b, nil
+		}), nil
+	})
+
+	plan, errs := resolver.Resolve(objs, cat, resolver.ResolveOptions{})
+	if errs.Len() != 0 {
+		t.Fatalf("resolve: %v", errs)
+	}
+	if _, ok := plan.SharedSandboxes["dev-shell"]; !ok {
+		t.Fatal("plan.SharedSandboxes missing dev-shell")
+	}
+
+	f, err := Build(*plan)
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	if err := f.Launch(context.Background()); err != nil {
+		t.Fatalf("Launch: %v", err)
+	}
+	defer func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+		_ = f.Stop(ctx)
+	}()
+	h, err := f.Submit(context.Background(), "support", "helper", agent.Request{})
+	if err != nil {
+		t.Fatalf("Submit: %v", err)
+	}
+	if _, err := h.Wait(context.Background()); err != nil {
+		t.Fatalf("Wait: %v", err)
+	}
+	if !sawExec.Load() {
+		t.Fatal("engine never saw `exec` tool in deps.ToolRegistry (sandbox overlay missing)")
+	}
+	if !sawToolInAllowList.Load() {
+		t.Fatal("engine never saw `exec` in deps.AgentTools (auto-injection missing)")
+	}
+}
+
+// TestFleet_NoSandbox_SharedRegistryReused covers the cheap path:
+// a vessel without any sandbox-using agent must keep using the
+// daemon-shared registry verbatim. A regression that always
+// allocates a per-Captain registry would still pass other tests
+// but waste memory on every vessel; this pin keeps that quiet
+// regression visible.
+func TestFleet_NoSandbox_SharedRegistryReused(t *testing.T) {
+	t.Parallel()
+	objs, err := apispec.DecodeAll(strings.NewReader(fleetConfig), "<test>")
+	if err != nil {
+		t.Fatal(err)
+	}
+	cat := catalog.New()
+	cat.RegisterEngine("noop", func(_ string, _ map[string]any, _ catalog.Deps) (engine.Engine, error) {
+		return engine.EngineFunc(func(_ context.Context, _ engine.Run, _ engine.Host, b *engine.Board) (*engine.Board, error) {
+			b.AppendChannelMessage(engine.MainChannel, model.NewTextMessage(model.RoleAssistant, "ok"))
+			return b, nil
+		}), nil
+	})
+	plan, errs := resolver.Resolve(objs, cat, resolver.ResolveOptions{})
+	if errs.Len() != 0 {
+		t.Fatalf("resolve: %v", errs)
+	}
+	f, err := Build(*plan)
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	reg, err := f.buildCaptainToolRegistry(plan.Vessels[0])
+	if err != nil {
+		t.Fatalf("buildCaptainToolRegistry: %v", err)
+	}
+	if reg != plan.SharedToolRegistry {
+		t.Fatal("buildCaptainToolRegistry returned a fresh registry for a non-sandbox vessel; expected the shared instance")
+	}
+}

--- a/cmd/vesseld/go.mod
+++ b/cmd/vesseld/go.mod
@@ -3,8 +3,8 @@ module github.com/GizClaw/flowcraft/cmd/vesseld
 go 1.25.0
 
 require (
-	github.com/GizClaw/flowcraft/sdk v0.3.4
-	github.com/GizClaw/flowcraft/sdkx v0.3.1
+	github.com/GizClaw/flowcraft/sdk v0.3.13
+	github.com/GizClaw/flowcraft/sdkx v0.3.9
 	github.com/GizClaw/flowcraft/vessel v0.2.0
 	go.opentelemetry.io/otel/log v0.16.0
 	gopkg.in/yaml.v3 v3.0.1

--- a/cmd/vesseld/go.sum
+++ b/cmd/vesseld/go.sum
@@ -1,9 +1,9 @@
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
-github.com/GizClaw/flowcraft/sdk v0.3.4 h1:Bma2skumOsm4Mrts8/or03iIugSQz3P/rinKIuaRBsQ=
-github.com/GizClaw/flowcraft/sdk v0.3.4/go.mod h1:VeMqVBxnMGHtFO9ypHhsA591XoLCWxucXR+gqpxQt5s=
-github.com/GizClaw/flowcraft/sdkx v0.3.1 h1:2HzXK+FmOGlnJ01m4NbUR+N7bx2O4SXHz5flvN+yizY=
-github.com/GizClaw/flowcraft/sdkx v0.3.1/go.mod h1:AuzpJHWVDNZKD8J8frY5qjmYU2IoEg4X3Rs0q232pnY=
+github.com/GizClaw/flowcraft/sdk v0.3.13 h1:cobv3ovBjrgNAstRiq1K7n405Ch7B81MtXNUOyHkAdk=
+github.com/GizClaw/flowcraft/sdk v0.3.13/go.mod h1:VeMqVBxnMGHtFO9ypHhsA591XoLCWxucXR+gqpxQt5s=
+github.com/GizClaw/flowcraft/sdkx v0.3.9 h1:VIKCEz7H2ohRXXQthWd+6IGEnAIvPCXXhUZeQ/qAbHM=
+github.com/GizClaw/flowcraft/sdkx v0.3.9/go.mod h1:lLRzJth7GxSLmdb5iaq3CdVCfj13ZWcybzlIudAxfJg=
 github.com/GizClaw/flowcraft/vessel v0.2.0 h1:Qmc9K3i5xjnbSVmHlNMdCtIzv8NxZkxf+sjBUPeQM3E=
 github.com/GizClaw/flowcraft/vessel v0.2.0/go.mod h1:iG2UBuoipcCTy4GgLDyBReqphtEDoneDJxxsHBt1Tf8=
 github.com/anthropics/anthropic-sdk-go v1.26.0 h1:oUTzFaUpAevfuELAP1sjL6CQJ9HHAfT7CoSYSac11PY=

--- a/cmd/vesseld/resolver/inventory.go
+++ b/cmd/vesseld/resolver/inventory.go
@@ -24,6 +24,7 @@ type Inventory struct {
 	ToolPacks     map[string]v1alpha1.ToolPack
 	HistoryStores map[string]v1alpha1.HistoryStore
 	Secrets       []v1alpha1.Secret
+	Sandboxes     map[string]v1alpha1.Sandbox
 }
 
 // buildInventory partitions the loader output into the per-kind
@@ -41,6 +42,7 @@ func buildInventory(objs []apispec.Object) (Inventory, *Errors) {
 		Probes:        map[string]v1alpha1.Probe{},
 		ToolPacks:     map[string]v1alpha1.ToolPack{},
 		HistoryStores: map[string]v1alpha1.HistoryStore{},
+		Sandboxes:     map[string]v1alpha1.Sandbox{},
 	}
 	errs := &Errors{}
 	seen := map[string]struct{}{} // "kind/name" → {}
@@ -92,6 +94,10 @@ func buildInventory(objs []apispec.Object) (Inventory, *Errors) {
 		case v1alpha1.Secret:
 			if dedupe(v1alpha1.KindSecret, o.Name) {
 				inv.Secrets = append(inv.Secrets, o)
+			}
+		case v1alpha1.Sandbox:
+			if dedupe(v1alpha1.KindSandbox, o.Name) {
+				inv.Sandboxes[o.Name] = o
 			}
 		default:
 			errs.add(errdefs.Validationf("vesseld resolver: unhandled object type %T", obj))

--- a/cmd/vesseld/resolver/plan.go
+++ b/cmd/vesseld/resolver/plan.go
@@ -7,6 +7,7 @@ import (
 	"github.com/GizClaw/flowcraft/cmd/vesseld/catalog"
 	"github.com/GizClaw/flowcraft/sdk/history"
 	"github.com/GizClaw/flowcraft/sdk/llm"
+	"github.com/GizClaw/flowcraft/sdk/sandbox"
 	"github.com/GizClaw/flowcraft/sdk/tool"
 	"github.com/GizClaw/flowcraft/vessel"
 	"github.com/GizClaw/flowcraft/vessel/spec"
@@ -48,6 +49,12 @@ type Plan struct {
 	// history.History instance. Fleet looks the right one up by
 	// name when constructing each Captain.
 	SharedHistories map[string]history.History
+
+	// SharedSandboxes is the resolved map of Sandbox.metadata.name
+	// → sandbox.Runner. Empty when no kind: Sandbox documents are
+	// declared. The fleet consults this to build per-Agent exec
+	// tools when Agent.spec.sandbox names an entry here.
+	SharedSandboxes map[string]sandbox.Runner
 
 	// SharedSessionStore is the daemon-wide vessel.SessionStore
 	// instance built from Daemon.spec.sessionStore. Nil when
@@ -135,6 +142,25 @@ type VesselPlan struct {
 	// DispatcherAgents lists agent names with Dispatcher=true.
 	// Cached so the fleet does not repeatedly walk the spec.
 	DispatcherAgents []string
+
+	// SandboxName is the metadata.name of the [Sandbox] every
+	// sandbox-using agent in this vessel references. Empty when
+	// no agent in the vessel has spec.sandbox set. v0.2.0
+	// enforces "at most one Sandbox per Vessel": two agents in
+	// the same vessel referencing different Sandbox documents
+	// would collide on the per-Captain tool registry's "exec"
+	// key, and untangling that demands an LLM-visible naming
+	// scheme nobody has signed off on yet. Multi-sandbox-per-
+	// vessel is a future RFC; until then the resolver enforces
+	// the constraint at validation time.
+	SandboxName string
+
+	// SandboxAgents lists which agents in this vessel actually
+	// reference SandboxName (subset of vp.Spec.Agents). The
+	// fleet uses this to know which agents to inject the
+	// auto-generated "exec" tool into via aspec.Tools at
+	// captain build time.
+	SandboxAgents []string
 }
 
 // RuntimeDeps carries the per-call inputs the fleet hands to an
@@ -154,6 +180,15 @@ type VesselPlan struct {
 type RuntimeDeps struct {
 	AgentTools  []string
 	LLMLimiters map[string]catalog.Limiter
+
+	// ToolRegistry, when non-nil, replaces the daemon-shared
+	// registry the resolveAgent closure captured at resolve
+	// time. The fleet uses this seam to hand each Captain its
+	// per-Vessel registry overlay (today: the sandbox-derived
+	// exec tool). Nil falls back to the resolver-time
+	// registry, preserving zero-overhead behaviour for vessels
+	// with no sandbox-using agent.
+	ToolRegistry *tool.Registry
 }
 
 // EngineBuilder is the resolved engine factory closure, already

--- a/cmd/vesseld/resolver/resolve.go
+++ b/cmd/vesseld/resolver/resolve.go
@@ -70,10 +70,14 @@ func Resolve(objs []apispec.Object, cat *catalog.Catalog, opts ResolveOptions) (
 	histories, histErrs := resolveHistories(cat, inv.HistoryStores, sharedToolReg, llmClients)
 	errs.addAll(histErrs)
 
+	sandboxes, sbErrs := resolveSandboxes(inv.Sandboxes)
+	errs.addAll(sbErrs)
+
 	plan := &Plan{
 		SharedToolRegistry: sharedToolReg,
 		SharedLLMResolver:  llmResolver,
 		SharedHistories:    histories,
+		SharedSandboxes:    sandboxes,
 	}
 
 	if len(inv.Daemons) >= 1 {
@@ -241,6 +245,26 @@ func resolveVessel(
 		if specAgent.Dispatcher {
 			vp.DispatcherAgents = append(vp.DispatcherAgents, agent.Name)
 		}
+		// Sandbox reference handling. The agent's spec.sandbox
+		// must name a known Sandbox document; v0.2.0 also
+		// enforces "at most one Sandbox per Vessel" so the
+		// per-Captain tool registry can register the auto-
+		// generated `exec` tool under its canonical name
+		// without disambiguation.
+		if ref := agent.Spec.Sandbox; ref != "" {
+			if _, ok := inv.Sandboxes[ref]; !ok {
+				errs.add(errdefs.NotFoundf("vesseld Agent %q: spec.sandbox %q not found in loaded Sandbox docs", agent.Name, ref))
+			} else {
+				if vp.SandboxName == "" {
+					vp.SandboxName = ref
+				} else if vp.SandboxName != ref {
+					errs.add(errdefs.Validationf(
+						"vesseld Vessel %q: agents reference %d distinct Sandboxes (%q and %q); v0.2.0 supports at most one Sandbox per Vessel",
+						v.Name, 2, vp.SandboxName, ref))
+				}
+				vp.SandboxAgents = append(vp.SandboxAgents, agent.Name)
+			}
+		}
 		vs.Agents = append(vs.Agents, specAgent)
 	}
 
@@ -371,13 +395,17 @@ func resolveAgent(
 	}
 
 	builder := EngineBuilder(func(rd RuntimeDeps) (engineBuildResult, error) {
+		reg := toolReg
+		if rd.ToolRegistry != nil {
+			reg = rd.ToolRegistry
+		}
 		eng, err := fn(a.Spec.Engine.Ref, a.Spec.Engine.Config, catalog.Deps{
 			VesselID:     v.Name,
 			AgentName:    a.Name,
 			AgentTools:   rd.AgentTools,
 			Bus:          nil, // fleet injects per-Captain bus before invoking
 			History:      hist,
-			ToolRegistry: toolReg,
+			ToolRegistry: reg,
 			LLMClients:   clients,
 			LLMLimiters:  rd.LLMLimiters,
 		})

--- a/cmd/vesseld/resolver/sandbox.go
+++ b/cmd/vesseld/resolver/sandbox.go
@@ -1,0 +1,164 @@
+package resolver
+
+import (
+	"github.com/GizClaw/flowcraft/cmd/vesseld/apispec/v1alpha1"
+	"github.com/GizClaw/flowcraft/sdk/errdefs"
+	"github.com/GizClaw/flowcraft/sdk/sandbox"
+	nsjailrunner "github.com/GizClaw/flowcraft/sdkx/sandbox/nsjail"
+)
+
+// resolveSandboxes materialises one [sandbox.Runner] per Sandbox
+// document, wrapped in [sandbox.WithDefaults] so the spec's
+// EnvPolicy / NetPolicy / ResourceLimits become the floor that
+// per-call ExecOptions cannot widen. Returns a name → Runner map
+// plus an Errors aggregate so the resolver pattern (surface every
+// per-document failure in one pass) is preserved.
+//
+// One Runner per Sandbox is sufficient at v0.2.0 because every
+// backend in scope (local, nsjail) is goroutine-safe — the same
+// instance handles concurrent Exec calls from multiple Captains.
+// If a future backend turns out to be single-flight, this is the
+// layer that knows about the constraint and can fan out to a
+// per-Captain instance there.
+func resolveSandboxes(sandboxes map[string]v1alpha1.Sandbox) (map[string]sandbox.Runner, *Errors) {
+	errs := &Errors{}
+	out := make(map[string]sandbox.Runner, len(sandboxes))
+	for name, s := range sandboxes {
+		runner, err := buildSandboxRunner(s)
+		if err != nil {
+			errs.add(err)
+			continue
+		}
+		out[name] = runner
+	}
+	return out, errs
+}
+
+// buildSandboxRunner selects the backend and layers WithDefaults
+// on top. The defaults snapshot here is taken from the spec
+// verbatim; any future "interpolate secrets / inject runtime vars"
+// step would land between the snapshot and the WithDefaults call.
+func buildSandboxRunner(s v1alpha1.Sandbox) (sandbox.Runner, error) {
+	base, err := buildSandboxBackend(s)
+	if err != nil {
+		return nil, err
+	}
+	defaults := sandboxDefaultsFromSpec(s.Spec)
+	if isZeroExecOptions(defaults) {
+		// No daemon-level policy → return the base runner
+		// directly. Avoids the WithDefaults wrapper allocation
+		// and surfaces a clearer call stack in the error path
+		// when nothing here is actually decorating the runner.
+		return base, nil
+	}
+	return sandbox.WithDefaults(base, defaults), nil
+}
+
+// buildSandboxBackend instantiates the raw runner. Linux-only
+// backends (nsjail) surface errdefs.NotAvailable on non-Linux
+// hosts via the runner's own New constructor; we propagate that
+// faithfully so an operator developing on macOS sees a clear "this
+// backend is Linux-only" message at boot rather than at first exec.
+func buildSandboxBackend(s v1alpha1.Sandbox) (sandbox.Runner, error) {
+	switch s.Spec.Backend {
+	case "local":
+		return sandbox.NewLocalRunner(s.Spec.RootDir), nil
+	case "nsjail":
+		opts := []nsjailrunner.RunnerOption{}
+		if s.Spec.Nsjail != nil {
+			if s.Spec.Nsjail.Binary != "" {
+				opts = append(opts, nsjailrunner.WithBinary(s.Spec.Nsjail.Binary))
+			}
+			if len(s.Spec.Nsjail.ExtraFlags) > 0 {
+				opts = append(opts, nsjailrunner.WithExtraFlags(s.Spec.Nsjail.ExtraFlags...))
+			}
+		}
+		r, err := nsjailrunner.New(s.Spec.RootDir, opts...)
+		if err != nil {
+			// nsjail.New surfaces errdefs.NotAvailable on
+			// non-Linux hosts (and when the binary is missing);
+			// propagate the wrapped error so the operator sees
+			// the original classification.
+			return nil, err
+		}
+		return r, nil
+	default:
+		// apispec.Validate already covers this — defensive only.
+		return nil, errdefs.Validationf("vesseld Sandbox %q: unknown backend %q", s.Name, s.Spec.Backend)
+	}
+}
+
+// sandboxDefaultsFromSpec projects the YAML SandboxSpec onto the
+// sandbox.ExecOptions shape WithDefaults consumes. The projection
+// is purely structural — every field maps 1:1 — so the SandboxSpec
+// is essentially a wire-formatted ExecOptions with backend
+// discrimination on top.
+func sandboxDefaultsFromSpec(spec v1alpha1.SandboxSpec) sandbox.ExecOptions {
+	// RootDir is consumed by the runner constructor itself, not
+	// by ExecOptions.WorkDir — so it does NOT belong in defaults.
+	// Per-call ExecOptions.WorkDir resolves relative to that
+	// rootDir at exec time.
+	opts := sandbox.ExecOptions{}
+	if spec.Env != nil {
+		opts.Env = sandbox.EnvPolicy{
+			Allow:  spec.Env.Allow,
+			Inject: spec.Env.Inject,
+		}
+	}
+	if spec.Net != nil {
+		opts.Net = sandbox.NetPolicy{
+			Mode:       mapNetMode(spec.Net.Mode),
+			AllowHosts: spec.Net.Allow,
+			Proxy:      spec.Net.Proxy,
+		}
+	}
+	if spec.Resources != nil {
+		opts.Resources = sandbox.ResourceLimits{
+			CPUMillicores:  spec.Resources.CPUMillicores,
+			MemoryBytes:    spec.Resources.MemoryBytes,
+			DiskBytes:      spec.Resources.DiskBytes,
+			MaxOutputBytes: spec.Resources.MaxOutputBytes,
+		}
+	}
+	return opts
+}
+
+// mapNetMode translates the YAML mode string into the sandbox
+// constant. Empty → NetDefault, which mirrors the apispec
+// convention "unset means the implementation's default".
+func mapNetMode(mode string) sandbox.NetMode {
+	switch mode {
+	case "", "default":
+		return sandbox.NetDefault
+	case "deny-all":
+		return sandbox.NetDenyAll
+	case "allow-list":
+		return sandbox.NetAllowList
+	case "proxy":
+		return sandbox.NetProxy
+	default:
+		// apispec validator catches this before resolver runs.
+		return sandbox.NetDefault
+	}
+}
+
+// isZeroExecOptions returns true when no policy field would change
+// the runner's behaviour. Skipping WithDefaults in that case keeps
+// the call stack shallow for the "Sandbox declared backend only"
+// case (which is the common path for dev / local).
+func isZeroExecOptions(o sandbox.ExecOptions) bool {
+	if o.WorkDir != "" {
+		return false
+	}
+	if len(o.Env.Allow) > 0 || len(o.Env.Inject) > 0 {
+		return false
+	}
+	if o.Net.Mode != sandbox.NetDefault || len(o.Net.AllowHosts) > 0 || o.Net.Proxy != "" {
+		return false
+	}
+	r := o.Resources
+	if r.CPUMillicores != 0 || r.MemoryBytes != 0 || r.DiskBytes != 0 || r.MaxOutputBytes != 0 {
+		return false
+	}
+	return true
+}

--- a/cmd/vesseld/resolver/sandbox_test.go
+++ b/cmd/vesseld/resolver/sandbox_test.go
@@ -1,0 +1,320 @@
+package resolver
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/GizClaw/flowcraft/cmd/vesseld/apispec"
+	"github.com/GizClaw/flowcraft/cmd/vesseld/apispec/v1alpha1"
+	"github.com/GizClaw/flowcraft/cmd/vesseld/catalog"
+	"github.com/GizClaw/flowcraft/sdk/engine"
+	"github.com/GizClaw/flowcraft/sdk/errdefs"
+	"github.com/GizClaw/flowcraft/sdk/sandbox"
+)
+
+// TestResolveSandboxes_LocalBackend exercises the happy path for
+// the local backend. Side-effect verification (a real Exec inside
+// the resolved runner) lives here rather than in a fleet-level
+// test so a regression in the resolver's WithDefaults wiring is
+// not hidden behind cross-package failures.
+func TestResolveSandboxes_LocalBackend(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	in := map[string]v1alpha1.Sandbox{
+		"dev": {
+			TypeMeta:   v1alpha1.TypeMeta{APIVersion: v1alpha1.APIVersion, Kind: v1alpha1.KindSandbox},
+			ObjectMeta: v1alpha1.ObjectMeta{Name: "dev"},
+			Spec: v1alpha1.SandboxSpec{
+				Backend: "local",
+				RootDir: root,
+				Env: &v1alpha1.SandboxEnv{
+					Inject: map[string]string{"VESSEL_X": "yes"},
+				},
+			},
+		},
+	}
+	got, errs := resolveSandboxes(in)
+	if errs.Aggregate() != nil {
+		t.Fatalf("resolveSandboxes: %v", errs.Aggregate())
+	}
+	runner, ok := got["dev"]
+	if !ok {
+		t.Fatalf("missing runner for %q", "dev")
+	}
+	// echo the injected env var to prove WithDefaults layered
+	// the EnvPolicy on top of the LocalRunner. We use sh -c
+	// because the resolver does not set $PATH manipulation; the
+	// runner inherits the host PATH on LocalRunner.
+	out, err := runner.Exec(context.Background(), "sh", []string{"-c", "echo $VESSEL_X"}, sandbox.ExecOptions{})
+	if err != nil {
+		t.Fatalf("Exec: %v", err)
+	}
+	if got := strings.TrimSpace(string(out.Stdout)); got != "yes" {
+		t.Fatalf("VESSEL_X = %q; want %q", got, "yes")
+	}
+}
+
+// TestResolveSandboxes_LocalRootDirConfines pins the rootDir →
+// runner confinement contract: the LocalRunner returned for a
+// Sandbox with rootDir=X must reject a per-call WorkDir that
+// escapes X. If this regresses, the YAML "rootDir is the
+// confinement boundary" promise silently weakens.
+func TestResolveSandboxes_LocalRootDirConfines(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	outside := t.TempDir() // sibling, not inside root
+	if !filepath.IsAbs(outside) || strings.HasPrefix(outside, root) {
+		t.Fatalf("test setup: outside %q must not be under root %q", outside, root)
+	}
+	in := map[string]v1alpha1.Sandbox{
+		"dev": {
+			TypeMeta:   v1alpha1.TypeMeta{APIVersion: v1alpha1.APIVersion, Kind: v1alpha1.KindSandbox},
+			ObjectMeta: v1alpha1.ObjectMeta{Name: "dev"},
+			Spec:       v1alpha1.SandboxSpec{Backend: "local", RootDir: root},
+		},
+	}
+	got, errs := resolveSandboxes(in)
+	if errs.Aggregate() != nil {
+		t.Fatalf("resolveSandboxes: %v", errs.Aggregate())
+	}
+	if _, err := got["dev"].Exec(context.Background(), "true", nil, sandbox.ExecOptions{WorkDir: outside}); err == nil {
+		t.Fatalf("Exec into %q outside root %q unexpectedly succeeded", outside, root)
+	}
+}
+
+// TestResolveSandboxes_NsjailOnNonLinux confirms the resolver
+// faithfully propagates the runner's "Linux-only" verdict instead
+// of converting it into a generic Validation error. Operators on
+// macOS should see the original classification.
+func TestResolveSandboxes_NsjailOnNonLinux(t *testing.T) {
+	if runtime.GOOS == "linux" {
+		t.Skip("non-linux only: this asserts the platform-gating path")
+	}
+	t.Parallel()
+	in := map[string]v1alpha1.Sandbox{
+		"prod": {
+			TypeMeta:   v1alpha1.TypeMeta{APIVersion: v1alpha1.APIVersion, Kind: v1alpha1.KindSandbox},
+			ObjectMeta: v1alpha1.ObjectMeta{Name: "prod"},
+			Spec:       v1alpha1.SandboxSpec{Backend: "nsjail", RootDir: t.TempDir()},
+		},
+	}
+	_, errs := resolveSandboxes(in)
+	if !errdefs.IsNotAvailable(errs.Aggregate()) {
+		t.Fatalf("expected NotAvailable on non-linux; got %v", errs.Aggregate())
+	}
+}
+
+// TestResolveSandboxes_EmptyInput is the contract for "no
+// sandboxes declared" — an empty map, never a nil. Downstream
+// callers iterate the map without nil-guarding so a regression
+// to nil would crash the fleet at startup.
+func TestResolveSandboxes_EmptyInput(t *testing.T) {
+	t.Parallel()
+	got, errs := resolveSandboxes(nil)
+	if errs.Aggregate() != nil {
+		t.Fatalf("resolveSandboxes: %v", errs.Aggregate())
+	}
+	if got == nil {
+		t.Fatalf("resolveSandboxes returned nil map; want empty non-nil")
+	}
+	if len(got) != 0 {
+		t.Fatalf("len(got) = %d; want 0", len(got))
+	}
+}
+
+// TestSandboxRunner_HonoursDefaultsFloor pins the WithDefaults
+// integration: a per-call ExecOptions cannot widen the daemon-
+// level Env policy. The decorator is meant as a security floor;
+// if a regression makes per-call EnvPolicy *replace* the daemon
+// floor we'd silently lose the sandbox's env discipline.
+func TestSandboxRunner_HonoursDefaultsFloor(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	// Pre-populate a file the child should be able to read.
+	if err := os.WriteFile(filepath.Join(root, "marker"), []byte("ok"), 0o600); err != nil {
+		t.Fatalf("write marker: %v", err)
+	}
+	in := map[string]v1alpha1.Sandbox{
+		"dev": {
+			TypeMeta:   v1alpha1.TypeMeta{APIVersion: v1alpha1.APIVersion, Kind: v1alpha1.KindSandbox},
+			ObjectMeta: v1alpha1.ObjectMeta{Name: "dev"},
+			Spec: v1alpha1.SandboxSpec{
+				Backend: "local",
+				RootDir: root,
+				Env:     &v1alpha1.SandboxEnv{Inject: map[string]string{"FLOOR": "1"}},
+			},
+		},
+	}
+	got, errs := resolveSandboxes(in)
+	if errs.Aggregate() != nil {
+		t.Fatalf("resolveSandboxes: %v", errs.Aggregate())
+	}
+	// Per-call ExecOptions sets a different env var; FLOOR
+	// must still survive because the daemon-level Inject is a
+	// floor, not a default-with-override.
+	out, err := got["dev"].Exec(context.Background(), "sh",
+		[]string{"-c", "echo $FLOOR-$EXTRA"},
+		sandbox.ExecOptions{Env: sandbox.EnvPolicy{Inject: map[string]string{"EXTRA": "two"}}})
+	if err != nil {
+		t.Fatalf("Exec: %v", err)
+	}
+	if got := strings.TrimSpace(string(out.Stdout)); got != "1-two" {
+		t.Fatalf("env merge = %q; want %q (FLOOR must survive)", got, "1-two")
+	}
+}
+
+func sandboxFixtureConfig(t *testing.T, body string) []apispec.Object {
+	t.Helper()
+	objs, err := apispec.DecodeAll(strings.NewReader(body), "<sandbox_test>")
+	if err != nil {
+		t.Fatalf("DecodeAll: %v", err)
+	}
+	return objs
+}
+
+func sandboxFixtureCatalog() *catalog.Catalog {
+	cat := catalog.New()
+	cat.RegisterEngine("noop-test", func(ref string, cfg map[string]any, deps catalog.Deps) (engine.Engine, error) {
+		return engine.EngineFunc(func(_ context.Context, _ engine.Run, _ engine.Host, b *engine.Board) (*engine.Board, error) {
+			return b, nil
+		}), nil
+	})
+	return cat
+}
+
+// TestResolve_AgentSandboxRef pins the end-to-end happy path:
+// an Agent.spec.sandbox naming a Sandbox doc populates the
+// resolved VesselPlan fields the fleet later reads.
+func TestResolve_AgentSandboxRef(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	cfg := fmt.Sprintf(`
+apiVersion: vessel.flowcraft.io/v1alpha1
+kind: Daemon
+metadata: {name: vesseld-default}
+spec:
+  control: {socket: /tmp/vesseld.sock}
+---
+apiVersion: vessel.flowcraft.io/v1alpha1
+kind: Sandbox
+metadata: {name: dev-shell}
+spec:
+  backend: local
+  rootDir: %s
+---
+apiVersion: vessel.flowcraft.io/v1alpha1
+kind: Vessel
+metadata: {name: support}
+spec:
+  agents: [helper]
+---
+apiVersion: vessel.flowcraft.io/v1alpha1
+kind: Agent
+metadata: {name: helper}
+spec:
+  engine: {ref: noop-test}
+  sandbox: dev-shell
+`, root)
+	plan, errs := Resolve(sandboxFixtureConfig(t, cfg), sandboxFixtureCatalog(), ResolveOptions{})
+	if errs.Len() != 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if _, ok := plan.SharedSandboxes["dev-shell"]; !ok {
+		t.Fatalf("SharedSandboxes missing dev-shell; got %v", plan.SharedSandboxes)
+	}
+	if vp := plan.Vessels[0]; vp.SandboxName != "dev-shell" ||
+		len(vp.SandboxAgents) != 1 || vp.SandboxAgents[0] != "helper" {
+		t.Fatalf("VesselPlan sandbox fields = (%q, %v); want (dev-shell, [helper])",
+			vp.SandboxName, vp.SandboxAgents)
+	}
+}
+
+// TestResolve_RejectsUnknownSandboxRef confirms the NotFound
+// classification for a dangling reference. Catching this at
+// resolve time means the operator sees the failure at boot,
+// not at first agent run.
+func TestResolve_RejectsUnknownSandboxRef(t *testing.T) {
+	t.Parallel()
+	cfg := `
+apiVersion: vessel.flowcraft.io/v1alpha1
+kind: Daemon
+metadata: {name: vesseld-default}
+spec:
+  control: {socket: /tmp/vesseld.sock}
+---
+apiVersion: vessel.flowcraft.io/v1alpha1
+kind: Vessel
+metadata: {name: support}
+spec:
+  agents: [helper]
+---
+apiVersion: vessel.flowcraft.io/v1alpha1
+kind: Agent
+metadata: {name: helper}
+spec:
+  engine: {ref: noop-test}
+  sandbox: ghost
+`
+	_, errs := Resolve(sandboxFixtureConfig(t, cfg), sandboxFixtureCatalog(), ResolveOptions{})
+	if errs.Len() == 0 {
+		t.Fatal("expected NotFound for unknown sandbox ref")
+	}
+	if !errdefs.IsNotFound(errs.Aggregate()) {
+		t.Fatalf("expected NotFound; got %v", errs.Aggregate())
+	}
+}
+
+// TestResolve_RejectsMultiSandboxPerVessel pins the v0.2.0
+// invariant. When two agents in the same Vessel reference two
+// distinct Sandbox documents the resolver emits a Validation
+// error so the fleet never has to disambiguate `exec` tool keys.
+func TestResolve_RejectsMultiSandboxPerVessel(t *testing.T) {
+	t.Parallel()
+	root1 := t.TempDir()
+	root2 := t.TempDir()
+	cfg := fmt.Sprintf(`
+apiVersion: vessel.flowcraft.io/v1alpha1
+kind: Daemon
+metadata: {name: vesseld-default}
+spec:
+  control: {socket: /tmp/vesseld.sock}
+---
+apiVersion: vessel.flowcraft.io/v1alpha1
+kind: Sandbox
+metadata: {name: dev}
+spec: {backend: local, rootDir: %s}
+---
+apiVersion: vessel.flowcraft.io/v1alpha1
+kind: Sandbox
+metadata: {name: prod}
+spec: {backend: local, rootDir: %s}
+---
+apiVersion: vessel.flowcraft.io/v1alpha1
+kind: Vessel
+metadata: {name: support}
+spec:
+  agents: [a, b]
+---
+apiVersion: vessel.flowcraft.io/v1alpha1
+kind: Agent
+metadata: {name: a}
+spec: {engine: {ref: noop-test}, sandbox: dev}
+---
+apiVersion: vessel.flowcraft.io/v1alpha1
+kind: Agent
+metadata: {name: b}
+spec: {engine: {ref: noop-test}, sandbox: prod}
+`, root1, root2)
+	_, errs := Resolve(sandboxFixtureConfig(t, cfg), sandboxFixtureCatalog(), ResolveOptions{})
+	if !errdefs.IsValidation(errs.Aggregate()) {
+		t.Fatalf("expected Validation error; got %v", errs.Aggregate())
+	}
+	if !strings.Contains(errs.Aggregate().Error(), "at most one Sandbox per Vessel") {
+		t.Fatalf("error %q does not mention the v0.2.0 invariant", errs.Aggregate())
+	}
+}

--- a/tests/e2e/vesseld/go.mod
+++ b/tests/e2e/vesseld/go.mod
@@ -5,8 +5,8 @@ go 1.25.0
 require github.com/GizClaw/flowcraft/cmd/vesseld v0.0.0
 
 require (
-	github.com/GizClaw/flowcraft/sdk v0.3.4 // indirect
-	github.com/GizClaw/flowcraft/sdkx v0.3.1 // indirect
+	github.com/GizClaw/flowcraft/sdk v0.3.13 // indirect
+	github.com/GizClaw/flowcraft/sdkx v0.3.9 // indirect
 	github.com/GizClaw/flowcraft/vessel v0.2.0 // indirect
 	github.com/anthropics/anthropic-sdk-go v1.26.0 // indirect
 	github.com/cenkalti/backoff/v5 v5.0.3 // indirect

--- a/tests/e2e/vesseld/go.sum
+++ b/tests/e2e/vesseld/go.sum
@@ -1,9 +1,9 @@
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
-github.com/GizClaw/flowcraft/sdk v0.3.4 h1:Bma2skumOsm4Mrts8/or03iIugSQz3P/rinKIuaRBsQ=
-github.com/GizClaw/flowcraft/sdk v0.3.4/go.mod h1:VeMqVBxnMGHtFO9ypHhsA591XoLCWxucXR+gqpxQt5s=
-github.com/GizClaw/flowcraft/sdkx v0.3.1 h1:2HzXK+FmOGlnJ01m4NbUR+N7bx2O4SXHz5flvN+yizY=
-github.com/GizClaw/flowcraft/sdkx v0.3.1/go.mod h1:AuzpJHWVDNZKD8J8frY5qjmYU2IoEg4X3Rs0q232pnY=
+github.com/GizClaw/flowcraft/sdk v0.3.13 h1:cobv3ovBjrgNAstRiq1K7n405Ch7B81MtXNUOyHkAdk=
+github.com/GizClaw/flowcraft/sdk v0.3.13/go.mod h1:VeMqVBxnMGHtFO9ypHhsA591XoLCWxucXR+gqpxQt5s=
+github.com/GizClaw/flowcraft/sdkx v0.3.9 h1:VIKCEz7H2ohRXXQthWd+6IGEnAIvPCXXhUZeQ/qAbHM=
+github.com/GizClaw/flowcraft/sdkx v0.3.9/go.mod h1:lLRzJth7GxSLmdb5iaq3CdVCfj13ZWcybzlIudAxfJg=
 github.com/GizClaw/flowcraft/vessel v0.2.0 h1:Qmc9K3i5xjnbSVmHlNMdCtIzv8NxZkxf+sjBUPeQM3E=
 github.com/GizClaw/flowcraft/vessel v0.2.0/go.mod h1:iG2UBuoipcCTy4GgLDyBReqphtEDoneDJxxsHBt1Tf8=
 github.com/anthropics/anthropic-sdk-go v1.26.0 h1:oUTzFaUpAevfuELAP1sjL6CQJ9HHAfT7CoSYSac11PY=


### PR DESCRIPTION
## Summary

Exposes `sdk/sandbox` and `sdkx/sandbox/nsjail` as a first-class YAML resource so operators can pin their shell-tool boundary declaratively, the same way they pin `LLMProfile` / `HistoryStore`.

```yaml
apiVersion: vessel.flowcraft.io/v1alpha1
kind: Sandbox
metadata: {name: dev-shell}
spec:
  backend: local           # or "nsjail" (Linux)
  rootDir: /var/lib/vesseld/dev
  env:    {allow: [PATH, HOME], inject: {VESSEL_RUNTIME: "1"}}
  net:    {mode: deny-all}
  resources: {cpuMillicores: 1000, memoryBytes: 1073741824}
---
apiVersion: vessel.flowcraft.io/v1alpha1
kind: Agent
metadata: {name: coder}
spec:
  engine: {ref: graph-llm}
  sandbox: dev-shell        # auto-injects sdkx/tool/exec wired to dev-shell
```

### What lands

- **apispec**: new `kind: Sandbox` doc + `Agent.spec.sandbox: <name>` reference. Backend is a closed enum (`local | nsjail`); `rootDir` mandatory; `nsjail` knobs gated to `backend: nsjail`.
- **resolver**: one `sandbox.Runner` per Sandbox doc, decorated with `sandbox.WithDefaults` so the YAML policy is a floor per-call `ExecOptions` cannot widen. Dangling refs → `errdefs.NotFound`. Two distinct Sandboxes within one Vessel → `errdefs.Validation` (see "Why" below).
- **fleet**: per-Captain registry overlay registers `sdkx/tool/exec` wired to the per-Vessel runner. New `resolver.RuntimeDeps.ToolRegistry` seam threads the overlay into the engine factory's `catalog.Deps.ToolRegistry`. Vessels without any sandbox-using agent reuse the shared registry pointer (zero alloc).
- **Auto-injection**: agents with `spec.sandbox` set automatically gain `exec` in their tool allow-list. Idempotent — explicit `tools: [exec]` works the same.

### Why split as two commits, not two PRs

The two commits in this PR are:

1. `chore(cmd/vesseld)`: bump `sdk v0.3.4 → v0.3.13`, `sdkx v0.3.1 → v0.3.9` — picks up `sandbox.Runner`, `sandbox.WithDefaults`, `sdkx/tool/exec`, `sdkx/sandbox/nsjail`. The intermediate patches are additive so cmd/vesseld code compiles unchanged; `tests/e2e/vesseld` go.mod is bumped in lockstep.
2. `feat(cmd/vesseld)`: the actual schema + resolver + fleet wiring.

Per-request, kept as one PR. The chore commit is mechanical and reviewable in isolation if needed.

### Why one-Sandbox-per-Vessel for now

Two Sandboxes in the same Vessel would collide on the per-Captain registry's `exec` key. Disambiguating (e.g. `exec-<name>`) leaks sandbox identity into the LLM-visible tool surface — a UX choice nobody has signed off on. The constraint keeps wiring unambiguous while the YAML schema stays additive: a future RFC can lift it without breaking any v0.2.0 config.

### Why backend is a closed enum, not a catalog factory ref

The backend taxonomy is small (`local`, `nsjail` today; `container` / `microvm` later), the resolver already owns the construction quirks (`nsjail` returns `NotAvailable` on non-Linux), and catalog indirection costs more to navigate than it saves at this scale. If the taxonomy opens up we promote to a factory map.

## Test plan

- [x] `go test ./...` across `cmd/vesseld` — green
- [x] `go test ./...` across `tests/e2e/vesseld` — green
- [x] `resolver/sandbox_test.go`: per-backend resolution, `rootDir` confinement, `WithDefaults` floor (per-call `EnvPolicy.Inject` cannot erase YAML inject), `NotAvailable` on non-Linux for `nsjail`
- [x] `resolver/sandbox_test.go`: vessel-level happy path, dangling-ref `NotFound`, multi-sandbox-per-vessel `Validation`
- [x] `fleet/sandbox_test.go`: engine observes `exec` in both `deps.ToolRegistry` and `deps.AgentTools`; vanilla vessel still gets shared-registry pointer back from `buildCaptainToolRegistry`
- [x] `apispec/v1alpha1/validate_test.go`: schema accepts well-formed Sandbox docs, rejects each malformed shape (`empty-backend`, `empty-rootDir`, `nsjail-on-local`, bad net mode, negative resource caps)

Made with [Cursor](https://cursor.com)