### PR TITLE
fix(sdk/knowledge): give RetrievalChunkRepo real doc-level BM25 corpus stats via __docs namespace

### DIFF
--- a/sdk/knowledge/backend/retrieval/chunk.go
+++ b/sdk/knowledge/backend/retrieval/chunk.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"sort"
+	"strings"
 
 	"github.com/GizClaw/flowcraft/sdk/errdefs"
 	"github.com/GizClaw/flowcraft/sdk/knowledge"
@@ -40,16 +41,23 @@ func NewChunkRepo(idx rt.Index) *RetrievalChunkRepo {
 	return &RetrievalChunkRepo{idx: idx}
 }
 
-// Replace atomically swaps every chunk for (datasetID, docName).
+// Replace atomically swaps every chunk for (datasetID, docName), and
+// keeps the doc-level virtual document in the __docs namespace in
+// sync so SearchDocs can answer doc-level BM25 from the underlying
+// retrieval.Index's native scorer (#134).
 //
 // Implementation: when the underlying Index satisfies DeletableByFilter
 // we issue a single bulk delete, then upsert the new chunks. Otherwise
 // we fall back to List + Delete by ID, which is O(N) in the document's
-// chunk count.
+// chunk count. The doc-level upsert is a single retrieval.Doc per
+// Replace call (O(1) in chunk count), so the doc-level update does
+// not change the asymptotic cost.
 //
-// Atomicity is best-effort: if the upsert fails after the delete the
-// document ends up empty rather than partially updated. Backends that
-// support transactions can override this by implementing both
+// Atomicity is best-effort: if any of the three writes (chunks
+// delete, chunks upsert, docs upsert) fails after a previous one
+// succeeds, the doc ends up partially updated. This matches the
+// existing fs and pre-#134 retrieval contract; backends that support
+// transactions can override this by implementing both
 // DeletableByFilter and an atomic Upsert.
 func (r *RetrievalChunkRepo) Replace(ctx context.Context, datasetID, docName string, chunks []knowledge.DerivedChunk) error {
 	if datasetID == "" || docName == "" {
@@ -61,7 +69,10 @@ func (r *RetrievalChunkRepo) Replace(ctx context.Context, datasetID, docName str
 		return err
 	}
 	if len(chunks) == 0 {
-		return nil
+		// Doc has no chunks anymore; drop it from the doc-level
+		// namespace too so SearchDocs does not surface a stale
+		// empty entry.
+		return r.deleteDocLevel(ctx, datasetID, docName)
 	}
 
 	docs := make([]rt.Doc, len(chunks))
@@ -84,24 +95,91 @@ func (r *RetrievalChunkRepo) Replace(ctx context.Context, datasetID, docName str
 	if err := r.idx.Upsert(ctx, ns, docs); err != nil {
 		return fmt.Errorf("knowledge/retrieval: upsert %s/%s: %w", datasetID, docName, err)
 	}
+	return r.replaceDocLevel(ctx, datasetID, docName, chunks)
+}
+
+// replaceDocLevel rewrites a single (datasetID, docName) entry in the
+// __docs namespace. The doc-level Content is the chunk Content
+// concatenated in chunk-index order (newline-delimited); this is
+// what feeds the retrieval.Index's BM25 scorer when SearchDocs hits
+// the namespace.
+//
+// CHUNK OVERLAP CAVEAT: when the chunker emits overlapping chunks
+// (ChunkOverlap > 0), the concatenated Content double-counts tokens
+// in the overlap region, slightly inflating that doc's TF for those
+// tokens. The inflation is uniform per overlap setting across every
+// doc in the corpus, so BM25 *ranking* is unaffected — only absolute
+// scores drift. Callers running doc-level eval against published
+// baselines (BEIR / MS-MARCO / TREC) should configure their chunker
+// with ChunkOverlap=0 to eliminate the offset entirely.
+func (r *RetrievalChunkRepo) replaceDocLevel(ctx context.Context, datasetID, docName string, chunks []knowledge.DerivedChunk) error {
+	sorted := make([]knowledge.DerivedChunk, len(chunks))
+	copy(sorted, chunks)
+	sort.SliceStable(sorted, func(i, j int) bool { return sorted[i].Index < sorted[j].Index })
+	var sb strings.Builder
+	for i, c := range sorted {
+		if i > 0 {
+			sb.WriteByte('\n')
+		}
+		sb.WriteString(c.Content)
+	}
+	doc := rt.Doc{
+		ID:      docName,
+		Content: sb.String(),
+		Metadata: map[string]any{
+			mdDatasetID: datasetID,
+			mdDocName:   docName,
+			mdLayer:     string(knowledge.LayerDetail),
+			mdSourceVer: sorted[0].Sig.SourceVer,
+		},
+	}
+	if err := r.idx.Upsert(ctx, docsNamespace(datasetID), []rt.Doc{doc}); err != nil {
+		return fmt.Errorf("knowledge/retrieval: upsert doc %s/%s: %w", datasetID, docName, err)
+	}
 	return nil
 }
 
-// DeleteByDoc removes every chunk for (datasetID, docName).
+// deleteDocLevel removes (datasetID, docName) from the __docs
+// namespace. Backends that return NotFound on missing IDs are
+// tolerated — this is also the path used when the doc never had a
+// doc-level entry to begin with (e.g. legacy data ingested before
+// #134, dropped via Replace([])).
+func (r *RetrievalChunkRepo) deleteDocLevel(ctx context.Context, datasetID, docName string) error {
+	if err := r.idx.Delete(ctx, docsNamespace(datasetID), []string{docName}); err != nil && !errdefs.IsNotFound(err) {
+		return fmt.Errorf("knowledge/retrieval: delete doc %s/%s: %w", datasetID, docName, err)
+	}
+	return nil
+}
+
+// DeleteByDoc removes every chunk for (datasetID, docName) and the
+// matching doc-level entry from the __docs namespace.
 func (r *RetrievalChunkRepo) DeleteByDoc(ctx context.Context, datasetID, docName string) error {
 	if datasetID == "" || docName == "" {
 		return errdefs.Validationf("knowledge/retrieval: dataset_id and doc_name are required")
 	}
-	return r.deleteByDoc(ctx, chunksNamespace(datasetID), docName)
+	if err := r.deleteByDoc(ctx, chunksNamespace(datasetID), docName); err != nil {
+		return err
+	}
+	return r.deleteDocLevel(ctx, datasetID, docName)
 }
 
-// DeleteByDataset drops the dataset's namespace when the backend
-// supports it; otherwise it falls back to filter-driven deletes.
+// DeleteByDataset drops the dataset's chunks AND doc-level namespaces
+// when the backend supports it; otherwise it falls back to
+// filter-driven deletes on both.
 func (r *RetrievalChunkRepo) DeleteByDataset(ctx context.Context, datasetID string) error {
 	if datasetID == "" {
 		return errdefs.Validationf("knowledge/retrieval: dataset_id is required")
 	}
-	ns := chunksNamespace(datasetID)
+	if err := r.deleteDatasetNamespace(ctx, datasetID, chunksNamespace(datasetID)); err != nil {
+		return err
+	}
+	return r.deleteDatasetNamespace(ctx, datasetID, docsNamespace(datasetID))
+}
+
+// deleteDatasetNamespace clears every doc carrying the dataset_id
+// from a single namespace using whichever capability the backend
+// advertises.
+func (r *RetrievalChunkRepo) deleteDatasetNamespace(ctx context.Context, datasetID, ns string) error {
 	if d, ok := r.idx.(rt.Droppable); ok {
 		if err := d.Drop(ctx, ns); err != nil && !errdefs.IsNotFound(err) {
 			return fmt.Errorf("knowledge/retrieval: drop %s: %w", ns, err)

--- a/sdk/knowledge/backend/retrieval/chunk.go
+++ b/sdk/knowledge/backend/retrieval/chunk.go
@@ -304,128 +304,106 @@ func (r *RetrievalChunkRepo) searchOne(ctx context.Context, ns string, q knowled
 	return resp.Hits, nil
 }
 
-// docOverfetchFactor controls how many chunks SearchDocs pulls from the
-// chunk-level index per requested doc. The collapse below dedupes
-// chunks→docs, so we must over-fetch to guarantee that the top-K *docs*
-// are reachable even when one strong doc occupies the chunk-level top
-// hits with multiple chunks. 4x mirrors eval/beir's
-// DefaultOverfetchFactor and is empirically enough for chunker configs
-// in the ~5-20 chunks-per-doc range.
-const docOverfetchFactor = 4
-
-// sumpoolSource is the Candidate.Source label used when SearchDocs
-// aggregates chunks from more than one lane (e.g. ModeHybrid mixing
-// bm25 + vector candidates for the same doc). When all aggregated
-// chunks share a single lane, that lane's original Source is kept so
-// downstream lane-aware code keeps working on the BM25-only path.
-const sumpoolSource = "sumpool"
-
-// SearchDocs runs a doc-level query by over-fetching chunk-level Hits
-// and collapsing them by docName via sum-pool aggregation.
+// SearchDocs runs a doc-level BM25 query directly against the
+// dataset's __docs namespace (see package doc and #134).
 //
-// Score semantics: each doc's score is the sum of its matching chunks'
-// scores from the underlying retrieval.Index.Search response. This
-// re-aggregates BM25 signal that chunking split across passages —
-// closer to Anserini doc-level BM25 than max-pool, which only retains
-// the single strongest chunk. ChunkOverlap induces a small uniform
-// duplicate-count offset across every doc and therefore does not
-// affect intra-corpus ranking; see #126.
+// Score semantics: scores come from the underlying retrieval.Index's
+// native BM25 scorer evaluated against the doc-level corpus stats
+// (N = number of documents in the dataset, avgdl = average doc
+// length, df = doc-level document frequency). This is the same
+// statistic regime Anserini uses for BEIR baselines and what
+// FSChunkRepo's bespoke doc-level inverted index produces; it
+// replaces the pre-#134 query-time chunk-level + sum-pool collapse,
+// which cannot recover doc-level BM25 from chunk-level statistics
+// (BM25 is nonlinear in TF / DocLength; see #134 for the math).
 //
-// Mode handling delegates to the chunk-level Search: BM25 / Vector /
-// Hybrid all flow through, with the same per-lane retrieval the
-// chunk-granularity path uses. For hybrid, both BM25 and vector
-// candidates for the same chunk contribute to the doc's aggregate.
+// Mode handling:
+//   - ModeBM25:   primary path. Hits land at doc-level granularity.
+//   - ModeVector / ModeHybrid: returns errdefs.NotAvailable. The
+//     __docs namespace holds no per-doc vector (chunk vectors do
+//     not compose into a doc vector without a model choice);
+//     building doc-level vectors via mean-pool / late-chunking is
+//     tracked as a follow-up. BEIR / MS-MARCO / TREC doc-level eval
+//     suites are BM25-only, so this limitation does not affect
+//     #134's acceptance criteria.
 //
-// HYBRID CAVEAT: BM25 scores (range ~0–30+) and cosine similarities
-// (range 0–1) live on incomparable scales; sum-pooling them lets the
-// BM25 lane dominate the aggregate while the vector lane contributes
-// negligible weight. At the chunk level this is what
-// SearchEngine.Ranker exists to solve (RRF / rank-based fusion across
-// non-comparable scoring domains). SearchDocs intentionally bypasses
-// the Ranker today because it operates below the SearchEngine layer;
-// callers running production hybrid retrieval should prefer the
-// chunk-granularity Search path. A doc-level Ranker hook that
-// preserves hybrid fusion semantics is tracked as a follow-up.
-// BEIR / MS-MARCO / TREC doc-level eval suites run BM25-only so this
-// limitation does not affect #134 acceptance.
+// Returned Hits have ChunkIndex = -1 and Layer = "" (doc-level
+// results have no specific chunk); Content / Sig / Metadata are
+// intentionally dropped — Content of the virtual doc is just the
+// chunk concatenation and would mislead consumers expecting either
+// the original source text or a specific chunk.
 //
-// OVER-FETCH ASSUMPTION: docOverfetchFactor (= 4) assumes
-// chunks-per-doc ≤ 4 in the typical case; corpora that produce many
-// chunks per doc (long PDFs, codebases) may see the top-K*4 chunk
-// page filled by a small number of strong docs and silently drop
-// other matching docs from the result set. Surfacing this as a
-// Query.OverfetchFactor knob, or refetching when the unique-doc
-// count falls short of TopK, is tracked as a follow-up.
-//
-// Returned Hits have ChunkIndex = -1 and Layer = "" (doc-level results
-// have no specific chunk); Content / Sig / Metadata are intentionally
-// dropped because they belong to a specific chunk, not the doc.
-//
-// Candidate.Source reflects the originating lane when every chunk
-// contributing to a doc came from the same lane (e.g. "bm25" or
-// "vector"); when a doc is aggregated across more than one lane
-// (hybrid), Source is set to sumpoolSource ("sumpool") so downstream
-// lane-aware code is not silently misled by the first-seen lane
-// label.
+// Candidate.Source is always "bm25" on the v1 path.
 //
 // Doc-level results are deterministically ordered: primary by score
-// (desc), tie-broken by (datasetID, docName) ascending so two scorers
-// with identical chunk-score distributions produce identical rankings
-// across re-runs.
+// (desc), tie-broken by (datasetID, docName) ascending so two
+// scorers with identical doc-score distributions produce identical
+// rankings across re-runs.
 func (r *RetrievalChunkRepo) SearchDocs(ctx context.Context, q knowledge.ChunkQuery) ([]knowledge.Candidate, error) {
+	mode := knowledge.ResolveMode(q.Mode)
+	if mode != knowledge.ModeBM25 {
+		return nil, errdefs.NotAvailablef(
+			"knowledge/retrieval: SearchDocs supports ModeBM25 only in v1 (got %q); "+
+				"doc-level vector/hybrid is tracked as a follow-up of #134",
+			mode)
+	}
 	topK := q.TopK
 	if topK <= 0 {
 		topK = 5
 	}
-	chunkQ := q
-	chunkQ.TopK = topK * docOverfetchFactor
-	cands, err := r.Search(ctx, chunkQ)
-	if err != nil {
-		return nil, err
+	if len(q.DatasetIDs) == 0 {
+		return nil, nil
+	}
+	if q.Text == "" {
+		return nil, nil
 	}
 
-	// Aggregate by (datasetID, docName). Zero-score chunk hits are
-	// dropped: some retrieval.Index implementations (notably
-	// sdk/retrieval/memory) surface every filter-matched doc with
-	// Score = 0 when no query term hit, which would otherwise leak
-	// into doc-level rankings and trash BEIR nDCG. FSChunkRepo
-	// achieves the same by only emitting docs with a posting hit.
-	type key struct{ ds, doc string }
-	agg := make(map[key]*knowledge.Candidate, len(cands))
-	// sources tracks the distinct chunk-level Source values that
-	// contributed to each doc; promoted to sumpoolSource when more
-	// than one lane participated.
-	sources := make(map[key]string, len(cands))
-	order := make([]key, 0, len(cands))
-	for i := range cands {
-		c := cands[i]
-		if c.Hit.DocName == "" || c.Hit.Score <= 0 {
+	var out []knowledge.Candidate
+	for _, ds := range q.DatasetIDs {
+		if ds == "" {
 			continue
 		}
-		k := key{c.Hit.DatasetID, c.Hit.DocName}
-		if existing, ok := agg[k]; ok {
-			existing.Hit.Score += c.Hit.Score
-			if sources[k] != "" && sources[k] != c.Source {
-				existing.Source = sumpoolSource
-				sources[k] = sumpoolSource
+		if err := ctx.Err(); err != nil {
+			return nil, errdefs.FromContext(err)
+		}
+		resp, err := r.idx.Search(ctx, docsNamespace(ds), rt.SearchRequest{
+			QueryText: q.Text,
+			TopK:      topK,
+		})
+		if err != nil {
+			if errdefs.IsNotFound(err) {
+				continue
 			}
+			return nil, fmt.Errorf("knowledge/retrieval: search docs %s: %w", ds, err)
+		}
+		if resp == nil {
 			continue
 		}
-		agg[k] = &knowledge.Candidate{
-			Source: c.Source,
-			Hit: knowledge.Hit{
-				DatasetID:  c.Hit.DatasetID,
-				DocName:    c.Hit.DocName,
-				Score:      c.Hit.Score,
-				ChunkIndex: -1,
-			},
+		for _, h := range resp.Hits {
+			// Zero-score hits leak through on some backends
+			// (notably sdk/retrieval/memory returns every
+			// filter-matched doc with Score=0 when no query
+			// term hit); dropping them keeps doc-level
+			// rankings honest. Mirrors what FSChunkRepo's
+			// SearchDocs achieves by only emitting docs with
+			// a posting hit.
+			if h.Score <= 0 {
+				continue
+			}
+			docName := metadataString(h.Doc.Metadata[mdDocName])
+			if docName == "" {
+				docName = h.Doc.ID
+			}
+			out = append(out, knowledge.Candidate{
+				Source: "bm25",
+				Hit: knowledge.Hit{
+					DatasetID:  ds,
+					DocName:    docName,
+					Score:      h.Score,
+					ChunkIndex: -1,
+				},
+			})
 		}
-		sources[k] = c.Source
-		order = append(order, k)
-	}
-	out := make([]knowledge.Candidate, 0, len(order))
-	for _, k := range order {
-		out = append(out, *agg[k])
 	}
 	sort.SliceStable(out, func(i, j int) bool {
 		if out[i].Hit.Score != out[j].Hit.Score {

--- a/sdk/knowledge/backend/retrieval/chunk.go
+++ b/sdk/knowledge/backend/retrieval/chunk.go
@@ -163,6 +163,99 @@ func (r *RetrievalChunkRepo) DeleteByDoc(ctx context.Context, datasetID, docName
 	return r.deleteDocLevel(ctx, datasetID, docName)
 }
 
+// RebuildDocIndex re-derives the __docs namespace for a dataset by
+// iterating every chunk currently held in the __chunks namespace,
+// grouping by doc_name, and re-running replaceDocLevel per doc.
+//
+// Intended for one-shot in-place upgrades from sdk versions that did
+// not maintain a doc-level namespace (pre-#134). Operators should
+// call it once per dataset after upgrading the binary, before
+// SearchDocs traffic kicks in; subsequent regular Replace / Delete
+// calls keep the namespace in sync automatically.
+//
+// Behaviour:
+//   - For each (datasetID, docName) cluster, the chunks are sorted
+//     by chunk_index and concatenated; the result is upserted into
+//     the __docs namespace. This is exactly what a fresh Replace
+//     would have produced.
+//   - The method does NOT pre-clean the __docs namespace; existing
+//     entries with the same docName are overwritten by Upsert, and
+//     stale entries for docs that no longer have chunks are NOT
+//     removed (call DeleteByDoc explicitly to clear them, or
+//     DeleteByDataset to wipe the dataset and re-ingest).
+//   - It is safe to call repeatedly: the operation is idempotent up
+//     to the contents of the __chunks namespace at call time.
+//
+// O(N) in the dataset's chunk count; one Index.Upsert per logical
+// doc plus one Index.List per page of chunks. No additional locks
+// are taken inside the repo — concurrent Replace calls during a
+// rebuild race in the usual best-effort sense and the last writer
+// wins per (ds, doc).
+func (r *RetrievalChunkRepo) RebuildDocIndex(ctx context.Context, datasetID string) error {
+	if datasetID == "" {
+		return errdefs.Validationf("knowledge/retrieval: dataset_id is required")
+	}
+	chunkNS := chunksNamespace(datasetID)
+	// Buckets keep insertion order of doc_names for deterministic
+	// rebuilds across calls and across backends.
+	clusters := make(map[string][]knowledge.DerivedChunk)
+	order := make([]string, 0)
+	pageToken := ""
+	for {
+		if err := ctx.Err(); err != nil {
+			return errdefs.FromContext(err)
+		}
+		page, err := r.idx.List(ctx, chunkNS, rt.ListRequest{
+			Filter:   rt.Filter{Eq: map[string]any{mdLayer: string(knowledge.LayerDetail)}},
+			PageSize: 200, PageToken: pageToken,
+		})
+		if err != nil {
+			if errdefs.IsNotFound(err) {
+				return nil
+			}
+			return fmt.Errorf("knowledge/retrieval: list %s: %w", chunkNS, err)
+		}
+		if page == nil {
+			return nil
+		}
+		for _, doc := range page.Items {
+			docName := metadataString(doc.Metadata[mdDocName])
+			if docName == "" {
+				continue
+			}
+			idx, _ := metadataInt(doc.Metadata[mdChunkIndex])
+			derived := knowledge.DerivedChunk{
+				DatasetID: datasetID,
+				DocName:   docName,
+				Index:     idx,
+				Content:   doc.Content,
+				Sig: knowledge.DerivedSig{
+					SourceVer:  metadataUint64(doc.Metadata[mdSourceVer]),
+					ChunkerSig: metadataString(doc.Metadata[mdChunkerSig]),
+					EmbedSig:   metadataString(doc.Metadata[mdEmbedSig]),
+				},
+			}
+			if _, seen := clusters[docName]; !seen {
+				order = append(order, docName)
+			}
+			clusters[docName] = append(clusters[docName], derived)
+		}
+		if page.NextPageToken == "" {
+			break
+		}
+		pageToken = page.NextPageToken
+	}
+	for _, docName := range order {
+		if err := ctx.Err(); err != nil {
+			return errdefs.FromContext(err)
+		}
+		if err := r.replaceDocLevel(ctx, datasetID, docName, clusters[docName]); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 // DeleteByDataset drops the dataset's chunks AND doc-level namespaces
 // when the backend supports it; otherwise it falls back to
 // filter-driven deletes on both.

--- a/sdk/knowledge/backend/retrieval/chunk_test.go
+++ b/sdk/knowledge/backend/retrieval/chunk_test.go
@@ -5,12 +5,37 @@ import (
 	"testing"
 
 	"github.com/GizClaw/flowcraft/sdk/knowledge"
+	rt "github.com/GizClaw/flowcraft/sdk/retrieval"
 	"github.com/GizClaw/flowcraft/sdk/retrieval/memory"
 )
 
 func newChunkRepo(t *testing.T) *RetrievalChunkRepo {
 	t.Helper()
 	return NewChunkRepo(memory.New())
+}
+
+// newChunkRepoWithIndex returns both the repo and the underlying
+// in-memory index so tests can inspect the doc-level namespace
+// directly without going through SearchDocs.
+func newChunkRepoWithIndex(t *testing.T) (*RetrievalChunkRepo, *memory.Index) {
+	t.Helper()
+	idx := memory.New()
+	return NewChunkRepo(idx), idx
+}
+
+// listDocsNamespace dumps every retrieval.Doc currently held in the
+// dataset's __docs namespace; used to assert doc-level write
+// behaviour independently of the SearchDocs query path.
+func listDocsNamespace(t *testing.T, idx *memory.Index, datasetID string) []rt.Doc {
+	t.Helper()
+	resp, err := idx.List(context.Background(), docsNamespace(datasetID), rt.ListRequest{PageSize: 100})
+	if err != nil {
+		t.Fatalf("list docs namespace: %v", err)
+	}
+	if resp == nil {
+		return nil
+	}
+	return resp.Items
 }
 
 func chunk(doc string, idx int, content string) knowledge.DerivedChunk {
@@ -511,6 +536,108 @@ func TestRetrievalChunkRepo_SearchDocs_NoResults(t *testing.T) {
 	}
 	if len(cands) != 0 {
 		t.Fatalf("expected 0 hits for non-matching query, got %+v", cands)
+	}
+}
+
+// --- __docs namespace cascade (#134) ---------------------------------------
+
+func TestRetrievalChunkRepo_Replace_PopulatesDocsNamespace(t *testing.T) {
+	// Replace must seed the doc-level namespace with one Doc per
+	// logical document, ID = docName, Content = concatenation of
+	// chunk contents in chunk-index order.
+	r, idx := newChunkRepoWithIndex(t)
+	ctx := context.Background()
+	if err := r.Replace(ctx, "ds", "a.md", []knowledge.DerivedChunk{
+		chunk("a.md", 1, "beta gamma"),
+		chunk("a.md", 0, "alpha"),
+	}); err != nil {
+		t.Fatalf("replace: %v", err)
+	}
+	docs := listDocsNamespace(t, idx, "ds")
+	if len(docs) != 1 {
+		t.Fatalf("expected 1 doc-level entry, got %d (%+v)", len(docs), docs)
+	}
+	if docs[0].ID != "a.md" {
+		t.Fatalf("doc.ID = %q, want a.md", docs[0].ID)
+	}
+	if want := "alpha\nbeta gamma"; docs[0].Content != want {
+		t.Fatalf("doc.Content = %q, want %q", docs[0].Content, want)
+	}
+}
+
+func TestRetrievalChunkRepo_Replace_RebuildsDocOnSubsequentCall(t *testing.T) {
+	// A second Replace for the same (ds, docName) must overwrite the
+	// doc-level Content with the new chunk concatenation, not leave
+	// the previous version lingering.
+	r, idx := newChunkRepoWithIndex(t)
+	ctx := context.Background()
+	if err := r.Replace(ctx, "ds", "a.md", []knowledge.DerivedChunk{chunk("a.md", 0, "old text")}); err != nil {
+		t.Fatalf("replace v1: %v", err)
+	}
+	if err := r.Replace(ctx, "ds", "a.md", []knowledge.DerivedChunk{chunk("a.md", 0, "new text")}); err != nil {
+		t.Fatalf("replace v2: %v", err)
+	}
+	docs := listDocsNamespace(t, idx, "ds")
+	if len(docs) != 1 {
+		t.Fatalf("expected 1 doc-level entry after rebuild, got %d", len(docs))
+	}
+	if docs[0].Content != "new text" {
+		t.Fatalf("doc.Content = %q, want %q", docs[0].Content, "new text")
+	}
+}
+
+func TestRetrievalChunkRepo_Replace_EmptyChunksClearsDocsNamespace(t *testing.T) {
+	// Replace with no chunks is the canonical "doc deleted" signal
+	// in the ChunkRepo contract; the doc-level namespace must
+	// observe the deletion too so SearchDocs cannot resurrect it.
+	r, idx := newChunkRepoWithIndex(t)
+	ctx := context.Background()
+	if err := r.Replace(ctx, "ds", "a.md", []knowledge.DerivedChunk{chunk("a.md", 0, "alpha")}); err != nil {
+		t.Fatalf("replace seed: %v", err)
+	}
+	if err := r.Replace(ctx, "ds", "a.md", nil); err != nil {
+		t.Fatalf("replace empty: %v", err)
+	}
+	if docs := listDocsNamespace(t, idx, "ds"); len(docs) != 0 {
+		t.Fatalf("expected docs namespace empty after empty replace, got %+v", docs)
+	}
+}
+
+func TestRetrievalChunkRepo_DeleteByDoc_CascadesToDocsNamespace(t *testing.T) {
+	r, idx := newChunkRepoWithIndex(t)
+	ctx := context.Background()
+	if err := r.Replace(ctx, "ds", "a.md", []knowledge.DerivedChunk{chunk("a.md", 0, "alpha")}); err != nil {
+		t.Fatalf("replace a: %v", err)
+	}
+	if err := r.Replace(ctx, "ds", "b.md", []knowledge.DerivedChunk{chunk("b.md", 0, "beta")}); err != nil {
+		t.Fatalf("replace b: %v", err)
+	}
+	if err := r.DeleteByDoc(ctx, "ds", "a.md"); err != nil {
+		t.Fatalf("delete: %v", err)
+	}
+	docs := listDocsNamespace(t, idx, "ds")
+	if len(docs) != 1 || docs[0].ID != "b.md" {
+		t.Fatalf("expected only b.md left in docs namespace, got %+v", docs)
+	}
+}
+
+func TestRetrievalChunkRepo_DeleteByDataset_CascadesToDocsNamespace(t *testing.T) {
+	r, idx := newChunkRepoWithIndex(t)
+	ctx := context.Background()
+	if err := r.Replace(ctx, "ds1", "a.md", []knowledge.DerivedChunk{chunk("a.md", 0, "alpha")}); err != nil {
+		t.Fatalf("replace ds1: %v", err)
+	}
+	if err := r.Replace(ctx, "ds2", "b.md", []knowledge.DerivedChunk{chunk("b.md", 0, "beta")}); err != nil {
+		t.Fatalf("replace ds2: %v", err)
+	}
+	if err := r.DeleteByDataset(ctx, "ds1"); err != nil {
+		t.Fatalf("delete ds1: %v", err)
+	}
+	if docs := listDocsNamespace(t, idx, "ds1"); len(docs) != 0 {
+		t.Fatalf("ds1 docs namespace not cleared: %+v", docs)
+	}
+	if docs := listDocsNamespace(t, idx, "ds2"); len(docs) != 1 {
+		t.Fatalf("ds2 docs namespace corrupted by ds1 drop: %+v", docs)
 	}
 }
 

--- a/sdk/knowledge/backend/retrieval/chunk_test.go
+++ b/sdk/knowledge/backend/retrieval/chunk_test.go
@@ -675,6 +675,98 @@ func TestRetrievalChunkRepo_DeleteByDataset_CascadesToDocsNamespace(t *testing.T
 	}
 }
 
+// --- RebuildDocIndex (#134 in-place upgrade path) --------------------------
+
+func TestRetrievalChunkRepo_RebuildDocIndex_RecoversFromChunksOnly(t *testing.T) {
+	// Simulate a pre-#134 deployment: chunks are present in the
+	// __chunks namespace but the __docs namespace was never seeded.
+	// RebuildDocIndex must reconstruct the doc-level entries from
+	// the chunks alone so SearchDocs immediately works.
+	r, idx := newChunkRepoWithIndex(t)
+	ctx := context.Background()
+	if err := r.Replace(ctx, "ds", "a.md", []knowledge.DerivedChunk{
+		chunk("a.md", 0, "alpha"),
+		chunk("a.md", 1, "beta"),
+	}); err != nil {
+		t.Fatalf("seed a: %v", err)
+	}
+	if err := r.Replace(ctx, "ds", "b.md", []knowledge.DerivedChunk{
+		chunk("b.md", 0, "gamma"),
+	}); err != nil {
+		t.Fatalf("seed b: %v", err)
+	}
+	// Wipe the __docs namespace to fake the pre-#134 state, leaving
+	// chunks untouched.
+	if err := idx.Delete(ctx, docsNamespace("ds"), []string{"a.md", "b.md"}); err != nil {
+		t.Fatalf("wipe docs ns: %v", err)
+	}
+	if docs := listDocsNamespace(t, idx, "ds"); len(docs) != 0 {
+		t.Fatalf("setup precondition: docs ns must be empty, got %+v", docs)
+	}
+	if err := r.RebuildDocIndex(ctx, "ds"); err != nil {
+		t.Fatalf("rebuild: %v", err)
+	}
+	docs := listDocsNamespace(t, idx, "ds")
+	if len(docs) != 2 {
+		t.Fatalf("expected 2 doc-level entries after rebuild, got %d (%+v)", len(docs), docs)
+	}
+	byID := map[string]string{}
+	for _, d := range docs {
+		byID[d.ID] = d.Content
+	}
+	if got, want := byID["a.md"], "alpha\nbeta"; got != want {
+		t.Fatalf("a.md content = %q, want %q (chunk_index-ordered concat)", got, want)
+	}
+	if got, want := byID["b.md"], "gamma"; got != want {
+		t.Fatalf("b.md content = %q, want %q", got, want)
+	}
+	// And SearchDocs must now answer.
+	cands, err := r.SearchDocs(ctx, knowledge.ChunkQuery{
+		DatasetIDs: []string{"ds"}, Text: "alpha", Mode: knowledge.ModeBM25, TopK: 5,
+	})
+	if err != nil {
+		t.Fatalf("search after rebuild: %v", err)
+	}
+	if len(cands) != 1 || cands[0].Hit.DocName != "a.md" {
+		t.Fatalf("post-rebuild SearchDocs returned %+v, want a.md", cands)
+	}
+}
+
+func TestRetrievalChunkRepo_RebuildDocIndex_IsIdempotent(t *testing.T) {
+	r, idx := newChunkRepoWithIndex(t)
+	ctx := context.Background()
+	if err := r.Replace(ctx, "ds", "a.md", []knowledge.DerivedChunk{chunk("a.md", 0, "alpha")}); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	for i := 0; i < 3; i++ {
+		if err := r.RebuildDocIndex(ctx, "ds"); err != nil {
+			t.Fatalf("rebuild %d: %v", i, err)
+		}
+	}
+	docs := listDocsNamespace(t, idx, "ds")
+	if len(docs) != 1 || docs[0].ID != "a.md" || docs[0].Content != "alpha" {
+		t.Fatalf("idempotent rebuild produced %+v", docs)
+	}
+}
+
+func TestRetrievalChunkRepo_RebuildDocIndex_EmptyDatasetIsNoop(t *testing.T) {
+	r, idx := newChunkRepoWithIndex(t)
+	ctx := context.Background()
+	if err := r.RebuildDocIndex(ctx, "ds-empty"); err != nil {
+		t.Fatalf("rebuild empty: %v", err)
+	}
+	if docs := listDocsNamespace(t, idx, "ds-empty"); len(docs) != 0 {
+		t.Fatalf("expected no doc entries, got %+v", docs)
+	}
+}
+
+func TestRetrievalChunkRepo_RebuildDocIndex_RequiresDatasetID(t *testing.T) {
+	r := newChunkRepo(t)
+	if err := r.RebuildDocIndex(context.Background(), ""); err == nil {
+		t.Fatalf("expected validation error for empty datasetID")
+	}
+}
+
 func TestRetrievalChunkRepo_SigRoundtrip(t *testing.T) {
 	r := newChunkRepo(t)
 	ctx := context.Background()

--- a/sdk/knowledge/backend/retrieval/chunk_test.go
+++ b/sdk/knowledge/backend/retrieval/chunk_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/GizClaw/flowcraft/sdk/errdefs"
 	"github.com/GizClaw/flowcraft/sdk/knowledge"
 	rt "github.com/GizClaw/flowcraft/sdk/retrieval"
 	"github.com/GizClaw/flowcraft/sdk/retrieval/memory"
@@ -302,12 +303,14 @@ func TestRetrievalChunkRepo_SearchDocs_OneHitPerDoc(t *testing.T) {
 	}
 }
 
-func TestRetrievalChunkRepo_SearchDocs_SumPoolAggregatesAcrossChunks(t *testing.T) {
+func TestRetrievalChunkRepo_SearchDocs_RanksDocAcrossSplitTerms(t *testing.T) {
 	// A doc whose query keywords are SPLIT across two chunks must
-	// outrank a non-relevant doc that only matches one of those
-	// keywords (even repeatedly) in a single chunk. This is the exact
-	// failure mode of max-pool chunk-collapse documented in #126;
-	// sum-pool folds the per-chunk evidence into one doc score.
+	// outrank a noise doc that only matches one of those keywords
+	// (even repeatedly) in a single chunk. This is the exact
+	// failure mode of max-pool chunk-collapse documented in #126.
+	// Under the doc-level namespace, the concatenated Content sees
+	// both keywords as one doc and BM25 scores it accordingly,
+	// without the sum-pool double-counting hazard #137 introduced.
 	r := newChunkRepo(t)
 	ctx := context.Background()
 	if err := r.Replace(ctx, "ds", "rel.md", []knowledge.DerivedChunk{
@@ -335,8 +338,100 @@ func TestRetrievalChunkRepo_SearchDocs_SumPoolAggregatesAcrossChunks(t *testing.
 		t.Fatalf("expected both docs, got %d", len(cands))
 	}
 	if cands[0].Hit.DocName != "rel.md" {
-		t.Fatalf("top doc = %q, want rel.md (sum-pool should let two-keyword coverage beat one-keyword repetition); ranking = %+v",
+		t.Fatalf("top doc = %q, want rel.md (split-term coverage should beat single-term repetition at doc-level); ranking = %+v",
 			cands[0].Hit.DocName, cands)
+	}
+}
+
+func TestRetrievalChunkRepo_SearchDocs_ModeVectorReturnsNotAvailable(t *testing.T) {
+	r := newChunkRepo(t)
+	ctx := context.Background()
+	if err := r.Replace(ctx, "ds", "a.md", []knowledge.DerivedChunk{chunk("a.md", 0, "alpha")}); err != nil {
+		t.Fatalf("replace: %v", err)
+	}
+	_, err := r.SearchDocs(ctx, knowledge.ChunkQuery{
+		DatasetIDs: []string{"ds"},
+		Vector:     []float32{1, 0, 0},
+		Mode:       knowledge.ModeVector,
+		TopK:       5,
+	})
+	if err == nil {
+		t.Fatalf("expected NotAvailable error for ModeVector, got nil")
+	}
+	if !errdefs.IsNotAvailable(err) {
+		t.Fatalf("expected NotAvailable, got %v", err)
+	}
+}
+
+func TestRetrievalChunkRepo_SearchDocs_ModeHybridReturnsNotAvailable(t *testing.T) {
+	r := newChunkRepo(t)
+	ctx := context.Background()
+	if err := r.Replace(ctx, "ds", "a.md", []knowledge.DerivedChunk{chunk("a.md", 0, "alpha")}); err != nil {
+		t.Fatalf("replace: %v", err)
+	}
+	_, err := r.SearchDocs(ctx, knowledge.ChunkQuery{
+		DatasetIDs: []string{"ds"},
+		Text:       "alpha",
+		Vector:     []float32{1, 0, 0},
+		Mode:       knowledge.ModeHybrid,
+		TopK:       5,
+	})
+	if !errdefs.IsNotAvailable(err) {
+		t.Fatalf("expected NotAvailable for ModeHybrid, got %v", err)
+	}
+}
+
+func TestRetrievalChunkRepo_SearchDocs_CorpusStatsAreDocLevel(t *testing.T) {
+	// Seed 100 docs where exactly ONE doc contains the term "rare"
+	// and EVERY doc contains the term "common". A doc-level BM25
+	// scorer working on doc-level N / df / avgdl will surface the
+	// rare-bearing doc at the top of a "rare" query and rank every
+	// other doc above zero only for "common" — but the rare doc's
+	// score for "rare" must be much higher than the common-only
+	// docs' score for "common" because rare has df=1 while common
+	// has df=100. This is the exact regime the chunk-level +
+	// sum-pool implementation cannot reproduce (#134 root cause:
+	// chunk-level N inflates and IDF collapses toward log(2)).
+	r := newChunkRepo(t)
+	ctx := context.Background()
+	const N = 100
+	for i := 0; i < N; i++ {
+		name := "doc" + itoa(i) + ".md"
+		content := "common token"
+		if i == 0 {
+			content = "rare common token"
+		}
+		if err := r.Replace(ctx, "ds", name, []knowledge.DerivedChunk{chunk(name, 0, content)}); err != nil {
+			t.Fatalf("seed %s: %v", name, err)
+		}
+	}
+	rare, err := r.SearchDocs(ctx, knowledge.ChunkQuery{
+		DatasetIDs: []string{"ds"}, Text: "rare", Mode: knowledge.ModeBM25, TopK: 5,
+	})
+	if err != nil {
+		t.Fatalf("rare search: %v", err)
+	}
+	if len(rare) != 1 || rare[0].Hit.DocName != "doc0.md" {
+		t.Fatalf("rare query: expected exactly doc0.md, got %+v", rare)
+	}
+	common, err := r.SearchDocs(ctx, knowledge.ChunkQuery{
+		DatasetIDs: []string{"ds"}, Text: "common", Mode: knowledge.ModeBM25, TopK: 5,
+	})
+	if err != nil {
+		t.Fatalf("common search: %v", err)
+	}
+	if len(common) == 0 {
+		t.Fatalf("common query returned nothing")
+	}
+	// The rare doc's score for "rare" (df=1, N=100) must be
+	// strictly greater than any common doc's score for "common"
+	// (df=100, N=100) — IDF saturates to ~0 when df==N. This is
+	// the smoking gun that the scorer is working on doc-level
+	// stats, not chunk-level.
+	if rare[0].Hit.Score <= common[0].Hit.Score {
+		t.Fatalf("doc-level IDF discrimination failed: rare.score=%v common.score=%v "+
+			"(rare term df=1/N=100 should dominate common term df=100/N=100)",
+			rare[0].Hit.Score, common[0].Hit.Score)
 	}
 }
 
@@ -428,72 +523,11 @@ func TestRetrievalChunkRepo_SearchDocs_FanOutAcrossDatasets(t *testing.T) {
 	}
 }
 
-func TestRetrievalChunkRepo_SearchDocs_HybridContributesBothLanes(t *testing.T) {
-	// Hybrid mode should let both BM25 and vector signal contribute
-	// to the doc's aggregate score.
-	r := newChunkRepo(t)
-	ctx := context.Background()
-	c := chunk("a.md", 0, "apple")
-	c.Vector = []float32{1, 0, 0}
-	if err := r.Replace(ctx, "ds", "a.md", []knowledge.DerivedChunk{c}); err != nil {
-		t.Fatalf("replace: %v", err)
-	}
-	cands, err := r.SearchDocs(ctx, knowledge.ChunkQuery{
-		DatasetIDs: []string{"ds"},
-		Text:       "apple",
-		Vector:     []float32{1, 0, 0},
-		Mode:       knowledge.ModeHybrid,
-		TopK:       5,
-	})
-	if err != nil {
-		t.Fatalf("search docs: %v", err)
-	}
-	if len(cands) != 1 {
-		t.Fatalf("expected 1 doc-level hit, got %d", len(cands))
-	}
-	if cands[0].Hit.Score <= 0 {
-		t.Fatalf("hybrid doc-level score = %v, expected > 0 (both lanes should contribute)", cands[0].Hit.Score)
-	}
-}
-
-func TestRetrievalChunkRepo_SearchDocs_SourceLabelsCrossLaneAggregateAsSumpool(t *testing.T) {
-	// When a doc's matching chunks span more than one lane
-	// (hybrid bm25 + vector for the same chunk → two candidates),
-	// the aggregated doc Candidate must carry sumpoolSource rather
-	// than whichever lane was encountered first. Downstream
-	// lane-aware code (fusion / labelling) would otherwise be
-	// silently misled by iteration order.
-	r := newChunkRepo(t)
-	ctx := context.Background()
-	c := chunk("a.md", 0, "apple")
-	c.Vector = []float32{1, 0, 0}
-	if err := r.Replace(ctx, "ds", "a.md", []knowledge.DerivedChunk{c}); err != nil {
-		t.Fatalf("replace: %v", err)
-	}
-	cands, err := r.SearchDocs(ctx, knowledge.ChunkQuery{
-		DatasetIDs: []string{"ds"},
-		Text:       "apple",
-		Vector:     []float32{1, 0, 0},
-		Mode:       knowledge.ModeHybrid,
-		TopK:       5,
-	})
-	if err != nil {
-		t.Fatalf("search docs: %v", err)
-	}
-	if len(cands) != 1 {
-		t.Fatalf("expected 1 doc-level hit, got %d", len(cands))
-	}
-	if got := cands[0].Source; got != "sumpool" {
-		t.Fatalf("cross-lane aggregate Source = %q, want \"sumpool\"", got)
-	}
-}
-
-func TestRetrievalChunkRepo_SearchDocs_SourceLabelsSingleLanePreserved(t *testing.T) {
-	// When every contributing chunk shares one lane (BM25-only),
-	// the aggregate must keep that lane's label rather than
-	// promoting to sumpoolSource. Lane-aware downstream code on the
-	// BM25-only eval path (e.g. BEIR scifact lanes=bm25) depends on
-	// this.
+func TestRetrievalChunkRepo_SearchDocs_BM25OnlySourceLabel(t *testing.T) {
+	// SearchDocs is BM25-only on the v1 path (vector/hybrid return
+	// NotAvailable). Every Candidate must carry Source="bm25" so
+	// downstream lane-aware code does not have to special-case
+	// doc-level output.
 	r := newChunkRepo(t)
 	ctx := context.Background()
 	if err := r.Replace(ctx, "ds", "a.md", []knowledge.DerivedChunk{
@@ -515,7 +549,7 @@ func TestRetrievalChunkRepo_SearchDocs_SourceLabelsSingleLanePreserved(t *testin
 		t.Fatalf("expected 1 doc-level hit, got %d", len(cands))
 	}
 	if got := cands[0].Source; got != "bm25" {
-		t.Fatalf("single-lane aggregate Source = %q, want \"bm25\"", got)
+		t.Fatalf("doc-level Source = %q, want \"bm25\"", got)
 	}
 }
 

--- a/sdk/knowledge/backend/retrieval/namespace.go
+++ b/sdk/knowledge/backend/retrieval/namespace.go
@@ -1,7 +1,7 @@
 // Package retrieval implements knowledge.ChunkRepo and
 // knowledge.LayerRepo on top of any retrieval.Index.
 //
-// Namespace strategy (Q7=A): each dataset gets its own pair of
+// Namespace strategy (Q7=A): each dataset gets its own triple of
 // namespaces, so backends with native namespace isolation (Postgres
 // partitions, SQLite per-namespace tables) can scale by dataset
 // without the knowledge layer doing scatter/gather inside one big
@@ -9,6 +9,15 @@
 //
 //	kb_<sane(dataset)>__chunks   // DerivedChunks for one dataset
 //	kb_<sane(dataset)>__layers   // DerivedLayers for one dataset
+//	kb_<sane(dataset)>__docs     // doc-level virtual documents (#134)
+//
+// The __docs namespace holds one retrieval.Doc per logical document;
+// its Content is the concatenation of the document's chunks. It
+// exists so SearchDocs can hit a doc-granular inverted index with
+// real doc-level corpus statistics (N = doc count, avgdl = average
+// doc length), rather than collapsing chunk-level BM25 scores at
+// query time — see #134 for the math reason the latter cannot meet
+// doc-level BEIR / MS-MARCO acceptance criteria.
 //
 // Cross-dataset Search (q.DatasetIDs == nil) is a fan-out across
 // every dataset id supplied by the caller. The Index interface does
@@ -41,6 +50,11 @@ const chunksSuffix = "__chunks"
 // layersSuffix is appended to dataset namespaces holding DerivedLayers.
 const layersSuffix = "__layers"
 
+// docsSuffix is appended to dataset namespaces holding the doc-level
+// virtual documents used by SearchDocs. See package doc for the
+// motivation (#134).
+const docsSuffix = "__docs"
+
 // chunksNamespace returns the namespace for the dataset's chunks.
 func chunksNamespace(datasetID string) string {
 	return namespacePrefix + sanitiseDatasetID(datasetID) + chunksSuffix
@@ -49,6 +63,14 @@ func chunksNamespace(datasetID string) string {
 // layersNamespace returns the namespace for the dataset's layers.
 func layersNamespace(datasetID string) string {
 	return namespacePrefix + sanitiseDatasetID(datasetID) + layersSuffix
+}
+
+// docsNamespace returns the namespace for the dataset's doc-level
+// virtual documents (#134). Kept package-private: callers must go
+// through SearchDocs / Replace; touching the namespace directly
+// would let stale doc-level data drift from the chunks namespace.
+func docsNamespace(datasetID string) string {
+	return namespacePrefix + sanitiseDatasetID(datasetID) + docsSuffix
 }
 
 // sanitiseDatasetID mirrors recall.saneNS so the namespaces produced


### PR DESCRIPTION
Closes #134 (sdk-side).

## Why

[`#134 validation`](https://github.com/GizClaw/flowcraft/issues/134#issuecomment-validation) on BEIR scifact showed the [`#137`](https://github.com/GizClaw/flowcraft/pull/137) chunk-overfetch + sum-pool implementation could not meet the issue's ±0.005 nDCG@10 acceptance band against the fs-backend baseline:

| Backend | nDCG@10 | Recall@100 | MRR |
|---|---|---|---|
| fs (post-#130) | **0.6725** | 0.9076 | 0.6352 |
| retrieval (#137 sum-pool) | 0.1325 | 0.7266 | 0.1437 |

Observed delta 0.540 — 100× over the 0.005 budget. The performance goal (ingest <5 min @ concurrency=8) was met (14 min total run), but correctness regressed by 5×.

**Root cause** (#134 evaluator analysis): BM25 is corpus-stats driven and nonlinear in TF / DocLength. `RetrievalChunkRepo` was scoring on chunk-level `N` (≈25K-30K chunks), `df`, and `avgdl` (~50-100 tok), then sum-pooling. Sum-pooling chunk-level scores mathematically cannot recover doc-level BM25; the IDF term `log((N − df + 0.5) / (df + 0.5) + 1)` collapses toward `log(2)` when `N` inflates 5×-6× by counting chunks, and rare/discriminative terms lose their weight against common ones. The length-normalization `b·dl/avgdl` also normalizes the wrong quantities.

This PR replaces query-time collapse with a **second per-dataset namespace** that holds one `retrieval.Doc` per logical document (Content = chunk-index-ordered concatenation). `SearchDocs` then queries that namespace and the underlying `retrieval.Index` BM25 scorer sees doc-level `N` / `df` / `avgdl` — the same regime Anserini uses for BEIR baselines, the same regime FSChunkRepo's bespoke doc-level inverted index already produces.

## What is in this PR

Three independently reviewable commits, each leaves the tree green:

1. **`feat: add __docs namespace cascade in Replace and Delete paths`** — introduces `kb_<ds>__docs` and threads it through `Replace` / `DeleteByDoc` / `DeleteByDataset`. `SearchDocs` continues on the pre-#134 sum-pool path so this commit is observable but behaviour-neutral.
2. **`fix: rewrite SearchDocs to query __docs namespace`** — routes `SearchDocs` at the new namespace; doc-level corpus stats become real. `ModeVector` / `ModeHybrid` return `errdefs.NotAvailable` (BM25-only on v1; doc-level vector via mean-pool / late-chunking is tracked as a follow-up — BEIR / MS-MARCO / TREC doc-level eval suites are BM25-only).
3. **`feat: add RebuildDocIndex for in-place upgrade from pre-#134 deployments`** — admin method that seeds `__docs` from existing `__chunks` data, for operators upgrading from sdk versions that did not maintain the namespace.

## Why this design vs the alternative considered in #134

#134's Proposal (1) listed two paths. This PR takes the simpler, lower-blast-radius shape of (b): doc-level statistics live in a second namespace inside the existing `retrieval.Index` contract, not below it.

| Aspect | This PR (b) | Alternative (a): doc-level inside `retrieval.Index` |
|---|---|---|
| `retrieval.Index` contract change | None | Required (new `DocLevelSearch` method or optional interface) |
| `sdk/retrieval/memory` work | None (transparent) | Add second `CorpusStats` + doc-level inverted index |
| `sdkx/retrieval/sqlite` work | None | Add `doc_postings` / `doc_stats` tables, schema migration |
| `sdkx/retrieval/postgres` work | None | Same as sqlite |
| `sdkx/retrieval/workspace` work | None | Add second LSM index alongside the existing one — new segment format, new compaction, new WAL protocol |
| Third-party backends (Pinecone / Qdrant / Weaviate) | Work transparently | Cannot implement without engine support |
| Silent-fallback hazard #134 objects to | None (`SearchDocs` is always satisfied) | Re-introduced via optional interface |

`FSChunkRepo` maintains two indexes because it *is* the indexing engine and can synchronize both maps under one `sync.RWMutex`. At the `retrieval.Index` abstraction level — meant to be pluggable against Pinecone-class engines and SQL-backed indexes — that pattern does not generalise; (b) keeps the dual-index pattern but lifts it one level above the engine.

Industry precedent for this shape: Pinecone / Weaviate / Qdrant "parent document retriever" stores chunks and parent docs in separate namespaces and serves each query at the granularity that matches the index. Anserini's BEIR baselines use a doc-level Lucene index by construction.

## What is NOT in this PR (intentional follow-ups)

- **Doc-level vector / hybrid `SearchDocs`** — needs a mean-pool / late-chunking aggregation step at `Replace` time; tracked separately. BEIR / MS-MARCO doc-level eval is BM25-only so this does not block #134.
- **Stronger atomicity** between the chunk and doc namespace writes — current contract is best-effort across the two upserts, matching the pre-existing chunks-delete-then-upsert contract.
- **`docs/migrations/v0.5.0.md`** — written when v0.5.0 actually ships, per existing convention.
- **`eval/go.mod` sdk version bump** — eval team manual step after this PR is merged and the next sdk tag is cut.

## Chunk overlap caveat

When the chunker emits overlapping chunks (`ChunkOverlap > 0`), the concatenated `Content` of a doc double-counts tokens in the overlap region, slightly inflating per-doc TF. The offset is **uniform across every doc** for a given chunker config, so BM25 *ranking* is unaffected — only absolute scores drift. Documented on `replaceDocLevel`. BEIR / MS-MARCO / TREC doc-level eval runs should configure `ChunkOverlap=0` to eliminate the offset entirely.

## Test plan

- [x] `go build ./...` clean on sdk and sdkx modules.
- [x] `go test ./...` green on sdk and sdkx; no skips, no flakes.
- [x] `go vet ./...` clean.
- [x] 13 new unit tests cover:
  - `__docs` namespace populated on Replace with chunk-index ordering
  - Replace rewrites the doc-level entry cleanly
  - Empty-chunks Replace clears the doc-level entry
  - `DeleteByDoc` cascades to `__docs`
  - `DeleteByDataset` cascades to `__docs` while leaving siblings intact
  - `SearchDocs` ranks split-term coverage doc above single-term repetition (#126 failure mode)
  - **`SearchDocs_CorpusStatsAreDocLevel`**: 100-doc fixture, rare term (df=1) strictly dominates universal term (df=100) — the smoking-gun assertion #137's chunk-level scorer mathematically could not satisfy
  - `ModeVector` and `ModeHybrid` return `NotAvailable`
  - `BM25OnlySourceLabel` on v1 path
  - `RebuildDocIndex` recovers from chunks-only state, is idempotent, no-op on empty datasets, rejects empty datasetID
- [ ] **Reviewer (eval team)**: validate against #134's BEIR scifact acceptance after merge + sdk tag — expected nDCG@10 within ±0.005 of the 0.6725 fs baseline, ingest ≤14 min wall-clock.

## Acceptance criteria (from #134)

This PR ships:
- [x] `RetrievalChunkRepo` implements `DocLevelSearcher` (already true via #137; semantics now correct)
- [x] `factory.NewRetrieval` callers can call `SearchDocuments` without `errdefs.NotAvailable` on `ModeBM25`
- [x] `eval/beir` repointable from `factory.NewLocal` to `factory.NewRetrieval` (already done by #137 commit `ecbdf714`; was reverted by #141 pending this fix — eval team will revert the revert after the next sdk tag)

Remaining post-merge validation:
- [ ] BEIR scifact ingest <5 min @ `ingest_concurrency=8` (expected from #137's 14-min run; this PR does not regress ingest)
- [ ] BEIR scifact nDCG@10 within ±0.005 of fs baseline (this PR's central claim)


Made with [Cursor](https://cursor.com)