### PR TITLE
feat(eval/taubench): port Sierra τ-bench official retail+airline tools and tasks

### DIFF
--- a/.github/workflows/eval-taubench.yml
+++ b/.github/workflows/eval-taubench.yml
@@ -19,7 +19,7 @@ on:
         required: false
         default: "azure_gpt54"
       domain:
-        description: "Bundled domain pack: retail | airline | all"
+        description: "Domain: retail | airline | all (bundled mini packs) OR sierra-retail | sierra-airline (Sierra official 115/50 task set; requires upstream_tasks + upstream_initial_state)"
         required: false
         default: "retail"
       upstream_tasks:

--- a/eval/leaderboard.md
+++ b/eval/leaderboard.md
@@ -202,11 +202,15 @@ harnesses make different turn-budget / planning decisions.
 - **AgentBench**, **ToolBench**, **AutoGen** — too divergent in
   tool definitions to compare; out of scope for citation.
 
-**Caveat**: τ-bench scores are tied to a specific tool-call schema.
-Our `eval taubench` uses the same retail / airline mini-fixtures
-Sierra ships, so retail numbers are at least nominally comparable.
-The `all` domain is our merge; no direct upstream equivalent —
-declare the merge per row.
+**Caveat**: τ-bench scores are tied to a specific tool-call schema
+**and** the exact task set. The leaderboard rows below cite Sierra's
+115-task retail / 50-task airline test sets, so the only fair
+FlowCraft baseline is `eval-taubench.yml --domain sierra-retail` /
+`--domain sierra-airline`, which loads Sierra's official `tasks_test.py`
+and `data/*.json` (see `eval/taubench/sierra/README.md` for the
+one-time staging on the runner). The `--domain retail | airline`
+mini packs (5+7 hand-curated tasks) are harness smoke checks only —
+their pass-rate is **not** the leaderboard number.
 
 ## Reproduction protocol
 
@@ -576,7 +580,7 @@ artefact.
 | TC + claude-3-5-sonnet-20240620     |       0.626 |       0.387 | [Sierra README](https://github.com/sierra-research/tau-bench)             |
 | TC + gpt-4o                         |       0.604 |       0.383 | [Sierra README](https://github.com/sierra-research/tau-bench)             |
 | TC + claude-3-5-sonnet-20241022     |   **0.692** |   **0.462** | [Sierra README](https://github.com/sierra-research/tau-bench)             |
-| **FlowCraft (TC + same agent-LLM)** | `[pending]` | `[pending]` | our `eval-taubench.yml --domain retail`                                   |
+| **FlowCraft (TC + same agent-LLM)** | `[pending]` | `[pending]` | our `eval-taubench.yml --domain sierra-retail` (Sierra's 115-task `tasks_test.py`; staging in `eval/taubench/sierra/README.md`) |
 
 ### τ-bench — airline (Pass@1)
 
@@ -588,7 +592,7 @@ artefact.
 | TC + claude-3-5-sonnet-20241022     |   **0.460** |   **0.225** | [Sierra README](https://github.com/sierra-research/tau-bench) |
 | Act (gpt-4o)                        |       0.365 |       0.140 | [Sierra README](https://github.com/sierra-research/tau-bench) |
 | ReAct (gpt-4o)                      |       0.325 |       0.160 | [Sierra README](https://github.com/sierra-research/tau-bench) |
-| **FlowCraft (TC + same agent-LLM)** | `[pending]` | `[pending]` | our `eval-taubench.yml --domain airline`                      |
+| **FlowCraft (TC + same agent-LLM)** | `[pending]` | `[pending]` | our `eval-taubench.yml --domain sierra-airline` (Sierra's 50-task `tasks_test.py`; staging in `eval/taubench/sierra/README.md`) |
 
 **Caveat**: Sierra's main README warns that the original retail /
 airline task definitions are outdated; they recommend

--- a/eval/taubench/cli.go
+++ b/eval/taubench/cli.go
@@ -94,8 +94,12 @@ Example:
 				tools = NewAirlineTools()
 			case "all":
 				tools = mergeToolMaps(NewRetailTools(), NewAirlineTools())
+			case "sierra-retail":
+				tools = NewSierraRetailTools()
+			case "sierra-airline":
+				tools = NewSierraAirlineTools()
 			default:
-				return fmt.Errorf("--domain: unknown domain %q (want retail | airline | all)", domain)
+				return fmt.Errorf("--domain: unknown domain %q (want retail | airline | all | sierra-retail | sierra-airline)", domain)
 			}
 			if upstreamTasks != "" {
 				if upstreamState == "" {
@@ -118,6 +122,8 @@ Example:
 					ds = NewAirlineMiniDataset()
 				case "all":
 					ds = MergeDatasets("retail+airline", NewRetailMiniDataset(), NewAirlineMiniDataset())
+				case "sierra-retail", "sierra-airline":
+					return fmt.Errorf("--domain %s requires --upstream-tasks and --upstream-initial-state (stage Sierra fixtures via eval/taubench/sierra/prep.py)", domain)
 				}
 			}
 

--- a/eval/taubench/sierra/README.md
+++ b/eval/taubench/sierra/README.md
@@ -1,0 +1,99 @@
+# Sierra τ-bench fixtures
+
+This directory bridges between the published
+[`sierra-research/tau-bench`](https://github.com/sierra-research/tau-bench)
+test set (Python `Task(...)` literals + per-domain `data/*.json`) and
+the JSON shape `eval/taubench` consumes.
+
+Sierra's data is CC-BY licensed but bulky (~210k lines of JSON for the
+retail + airline test sets, ~165 gold task traces). It is **not**
+committed to this repo; an operator stages it once per Sierra release
+on the runner host before dispatching `eval-taubench.yml` with
+`--domain sierra-retail` or `--domain sierra-airline`.
+
+## One-time staging
+
+```bash
+# 1. clone Sierra at the commit you want to evaluate against. Record
+#    the commit hash in the leaderboard so the comparison is
+#    reproducible.
+cd /tmp && git clone https://github.com/sierra-research/tau-bench.git
+cd tau-bench && git rev-parse HEAD       # write this to leaderboard.md
+
+# 2. install pydantic (Sierra's Task / Action live in tau_bench/types.py
+#    and need pydantic to import). Nothing else from Sierra's Python
+#    stack is needed — prep.py bypasses the top-level __init__
+#    chain that pulls in litellm.
+pip3 install --user pydantic
+
+# 3. run prep.py from a flowcraft checkout. It writes per-domain
+#    initial_state.json (Sierra data/*.json merged under top-level
+#    keys) + tasks_test.json (the UpstreamTask wire shape consumed
+#    by eval/taubench/upstream.go LoadUpstreamTasks).
+cd /path/to/flowcraft
+python3 eval/taubench/sierra/prep.py \
+    --sierra /tmp/tau-bench \
+    --out    /var/lib/flowcraft-eval/datasets/taubench
+
+# 4. verify on the runner host (ssh flowcraft-eval):
+ls /var/lib/flowcraft-eval/datasets/taubench/{retail,airline}/
+# retail/initial_state.json  retail/tasks_test.json   (~3.6 MB, 115 tasks)
+# airline/initial_state.json airline/tasks_test.json  (~5.0 MB, 50 tasks)
+```
+
+## Dispatching the workflow
+
+```bash
+gh workflow run eval-taubench.yml --ref main \
+    -f domain=sierra-retail \
+    -f agent_llm=azure_4o \
+    -f customer_llm=azure_4o \
+    -f upstream_tasks=/var/lib/flowcraft-eval/datasets/taubench/retail/tasks_test.json \
+    -f upstream_initial_state=/var/lib/flowcraft-eval/datasets/taubench/retail/initial_state.json \
+    -f concurrency=4 \
+    -f per_task_timeout=5m
+```
+
+Same flags for airline; substitute `sierra-airline` and the airline
+dataset paths.
+
+## What this is comparable to
+
+The `eval/taubench` Go harness's metrics
+([pass@1, per-domain pass-rate](../../leaderboard.md)) on
+`--domain sierra-retail` / `--domain sierra-airline` runs are the
+**right** baselines to cite against the Sierra leaderboard rows
+("TC + gpt-4o" 0.604 / 0.420, "TC + claude-3-5-sonnet-20241022"
+0.692 / 0.460). The bundled mini-pack runs
+(`--domain retail | airline`, 5+7 hand-curated tasks) are not — they
+are first-cut harness smoke checks, useful only to assert the LLM
+wiring + the Tool / Handler contracts work end-to-end.
+
+## Smoke test (no LLM cost)
+
+`go test -run TestSierraRetailShadowRun_AllTasks ./eval/taubench/...`
+loads every staged task and shadow-runs its gold action trace against
+a clone of `initial_state.json`. A failure here means the Go port of
+some Sierra tool drifted (wrong kwargs handling, wrong state
+mutation, wrong error string) — every gold trace in the published
+Sierra fixtures executes deterministically against Sierra's own
+harness by construction, so any divergence is the Go side's bug.
+
+The test is gated on `FLOWCRAFT_TAUBENCH_SIERRA_DATA` pointing at the
+staged root (e.g. `/var/lib/flowcraft-eval/datasets/taubench`); set
+it locally to verify after re-staging.
+
+## Pinning Sierra revisions
+
+`tau-bench` evolves — task wordings change, state schemas drift. If
+this directory's tools diverge from the staged fixtures (smoke test
+errors out), pick one of:
+
+- Re-pin to the same Sierra commit recorded last in
+  `eval/leaderboard.md` (preferred when comparing to published numbers).
+- Re-run `prep.py` against the new Sierra HEAD, fix the affected tool
+  in `sierra_retail.go` / `sierra_airline.go`, and bump the leaderboard
+  Sierra-commit footnote.
+
+`prep.py` does not validate Sierra's shape against our tool set; the
+smoke test does. Run it after every restage.

--- a/eval/taubench/sierra/prep.py
+++ b/eval/taubench/sierra/prep.py
@@ -1,0 +1,151 @@
+#!/usr/bin/env python3
+# prep.py — one-shot converter from Sierra τ-bench's Python fixtures to
+# the JSON shapes eval/taubench expects.
+#
+# Why a Python script (and not Go): Sierra ships `tasks_test.py` as
+# Python `Task(...)` literals defined via pydantic models. Re-typing
+# 165 tasks (each with ~5-15 actions, each action with arbitrary
+# kwargs) by hand in Go is bug-bait. Loading the .py files via
+# importlib gives us the canonical bytes at Sierra commit precision
+# and serialises them via pydantic's own json.
+#
+# Usage:
+#   python3 eval/taubench/sierra/prep.py \
+#       --sierra /tmp/tau-bench \
+#       --out    /var/lib/flowcraft-eval/datasets/taubench
+#
+# Outputs (per domain in retail|airline):
+#   <out>/<domain>/initial_state.json   merged Sierra data/*.json
+#   <out>/<domain>/tasks_test.json      Sierra TASKS_TEST exported as
+#                                       the UpstreamTask wire shape
+#                                       (eval/taubench/upstream.go).
+#
+# The script intentionally bypasses tau_bench's top-level __init__
+# (which imports litellm). Only pydantic is required at runtime.
+
+import argparse
+import importlib.util
+import json
+import sys
+import types as _t
+from pathlib import Path
+
+
+def _bypass_tau_bench_init(sierra_root: Path) -> None:
+    """Make tau_bench.types importable without triggering the
+    litellm-pulling __init__ chain. We register synthetic empty
+    parents in sys.modules and then load tau_bench/types.py directly.
+    Without this Sierra's package import path crashes on a missing
+    `litellm` (see tau_bench/envs/user.py)."""
+    for name in (
+        "tau_bench",
+        "tau_bench.envs",
+        "tau_bench.envs.retail",
+        "tau_bench.envs.airline",
+    ):
+        sys.modules[name] = _t.ModuleType(name)
+
+    types_path = sierra_root / "tau_bench" / "types.py"
+    spec = importlib.util.spec_from_file_location("tau_bench.types", types_path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"could not load {types_path}")
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules["tau_bench.types"] = mod
+    spec.loader.exec_module(mod)
+
+
+def _load_tasks_module(sierra_root: Path, domain: str) -> object:
+    """Load tau_bench/envs/<domain>/tasks_test.py and return the loaded
+    module. The variable name holding the task list differs between
+    domains (retail=TASKS_TEST, airline=TASKS); the caller picks."""
+    path = sierra_root / "tau_bench" / "envs" / domain / "tasks_test.py"
+    spec = importlib.util.spec_from_file_location(f"tasks_{domain}", path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"could not load {path}")
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _export_tasks(mod: object, candidate_attrs: list) -> list:
+    """Pick the first non-empty list-of-Task attribute from `mod` and
+    return [Task.model_dump()] for each. The dump drops pydantic
+    private state but keeps every documented field on Task and
+    Action — i.e. exactly the UpstreamTask wire shape consumed by
+    eval/taubench/upstream.go LoadUpstreamTasks."""
+    for attr in candidate_attrs:
+        if not hasattr(mod, attr):
+            continue
+        tasks = getattr(mod, attr)
+        if not tasks:
+            continue
+        return [t.model_dump() for t in tasks]
+    raise RuntimeError(
+        f"none of {candidate_attrs} found / non-empty in {mod.__name__}"
+    )
+
+
+def _merge_data(sierra_root: Path, domain: str) -> dict:
+    """Sierra's per-domain data/ folder holds N top-level JSON files
+    (users.json, orders.json, products.json for retail; users.json,
+    flights.json, reservations.json for airline). The Python tools
+    access them as data["users"], data["orders"], etc. — i.e. a
+    single merged map. Construct it here so initial_state.json is one
+    file that LoadInitialState (eval/taubench/upstream.go) can read
+    in one os.ReadFile + json.Unmarshal."""
+    data_dir = sierra_root / "tau_bench" / "envs" / domain / "data"
+    merged: dict = {}
+    for json_path in sorted(data_dir.glob("*.json")):
+        key = json_path.stem  # users, orders, products, flights, reservations
+        with json_path.open() as f:
+            merged[key] = json.load(f)
+    if not merged:
+        raise RuntimeError(f"no JSON files under {data_dir}")
+    return merged
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--sierra", required=True, type=Path,
+                        help="Path to a sierra-research/tau-bench clone")
+    parser.add_argument("--out", required=True, type=Path,
+                        help="Output root (will create <domain>/ subdirs)")
+    parser.add_argument("--domains", nargs="+", default=["retail", "airline"],
+                        choices=["retail", "airline"])
+    args = parser.parse_args()
+
+    if not args.sierra.is_dir():
+        raise SystemExit(f"--sierra {args.sierra} is not a directory")
+
+    _bypass_tau_bench_init(args.sierra)
+
+    # Sierra uses TASKS_TEST for retail, TASKS for airline; tolerate
+    # either so future Sierra revisions that rename do not break us.
+    candidate_attrs = ["TASKS_TEST", "TASKS", "tasks"]
+
+    args.out.mkdir(parents=True, exist_ok=True)
+
+    for domain in args.domains:
+        out_dir = args.out / domain
+        out_dir.mkdir(parents=True, exist_ok=True)
+
+        initial_state = _merge_data(args.sierra, domain)
+        (out_dir / "initial_state.json").write_text(
+            json.dumps(initial_state, indent=2, sort_keys=True) + "\n"
+        )
+
+        mod = _load_tasks_module(args.sierra, domain)
+        tasks = _export_tasks(mod, candidate_attrs)
+        (out_dir / "tasks_test.json").write_text(
+            json.dumps(tasks, indent=2, sort_keys=False) + "\n"
+        )
+
+        print(
+            f"{domain}: state-keys={list(initial_state)}, tasks={len(tasks)}, "
+            f"out={out_dir}",
+            file=sys.stderr,
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/eval/taubench/sierra_airline.go
+++ b/eval/taubench/sierra_airline.go
@@ -1,0 +1,803 @@
+package taubench
+
+import (
+	"fmt"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+// NewSierraAirlineTools returns the canonical 14-tool airline-domain
+// registry ported from sierra-research/tau-bench
+// tau_bench/envs/airline/tools/ at commit 59a200c6 (2026-03-18).
+//
+// Airline state shape (top-level keys): "flights", "reservations",
+// "users". The contract differs from retail in two important
+// places worth knowing if you maintain both:
+//
+//   - Payment-method records use `amount` instead of `balance`.
+//     (Yes, this is Sierra's naming, not ours; preserved verbatim
+//     so the gold ExpectedFinalState comparison stays tight.)
+//   - `payment_history` entries carry `payment_id` + `amount` only;
+//     no `transaction_type`. Cancellation records refunds as
+//     entries with negative amounts.
+func NewSierraAirlineTools() map[string]Tool {
+	return map[string]Tool{
+		// --- read tools ---
+		"get_reservation_details": {
+			Name:        "get_reservation_details",
+			Description: "Get the details of a reservation.",
+			InputSchema: schemaObject(map[string]any{
+				"reservation_id": schemaString("The reservation id, such as '8JX2WO'."),
+			}, []string{"reservation_id"}),
+			Handler: airGetReservationDetails,
+		},
+		"get_user_details": {
+			Name:        "get_user_details",
+			Description: "Get the details of an user, including their reservations.",
+			InputSchema: schemaObject(map[string]any{
+				"user_id": schemaString("The user id, such as 'sara_doe_496'."),
+			}, []string{"user_id"}),
+			Handler: airGetUserDetails,
+		},
+		"list_all_airports": {
+			Name:        "list_all_airports",
+			Description: "List all airports and their cities.",
+			InputSchema: schemaObject(nil, nil),
+			Handler:     airListAllAirports,
+		},
+		"search_direct_flight": {
+			Name:        "search_direct_flight",
+			Description: "Search direct flights between two cities on a specific date.",
+			InputSchema: schemaObject(map[string]any{
+				"origin":      schemaString("The origin city airport in three letters, such as 'JFK'."),
+				"destination": schemaString("The destination city airport in three letters, such as 'LAX'."),
+				"date":        schemaString("The date of the flight in the format 'YYYY-MM-DD', such as '2024-01-01'."),
+			}, []string{"origin", "destination", "date"}),
+			Handler: airSearchDirectFlight,
+		},
+		"search_onestop_flight": {
+			Name:        "search_onestop_flight",
+			Description: "Search direct flights between two cities on a specific date.",
+			InputSchema: schemaObject(map[string]any{
+				"origin":      schemaString("The origin city airport in three letters, such as 'JFK'."),
+				"destination": schemaString("The destination city airport in three letters, such as 'LAX'."),
+				"date":        schemaString("The date of the flight in the format 'YYYY-MM-DD', such as '2024-05-01'."),
+			}, []string{"origin", "destination", "date"}),
+			Handler: airSearchOnestopFlight,
+		},
+		// --- mutating tools ---
+		"book_reservation": {
+			Name:        "book_reservation",
+			Description: "Book a reservation.",
+			InputSchema: airBookReservationSchema(),
+			Handler:     airBookReservation,
+		},
+		"cancel_reservation": {
+			Name:        "cancel_reservation",
+			Description: "Cancel the whole reservation.",
+			InputSchema: schemaObject(map[string]any{
+				"reservation_id": schemaString("The reservation ID, such as 'ZFA04Y'."),
+			}, []string{"reservation_id"}),
+			Handler: airCancelReservation,
+		},
+		"send_certificate": {
+			Name:        "send_certificate",
+			Description: "Send a certificate to a user. Be careful!",
+			InputSchema: schemaObject(map[string]any{
+				"user_id": schemaString("The ID of the user to book the reservation, such as 'sara_doe_496'."),
+				"amount":  map[string]any{"type": "number", "description": "Certificate amount to send."},
+			}, []string{"user_id", "amount"}),
+			Handler: airSendCertificate,
+		},
+		"update_reservation_baggages": {
+			Name:        "update_reservation_baggages",
+			Description: "Update the baggage information of a reservation.",
+			InputSchema: schemaObject(map[string]any{
+				"reservation_id":   schemaString("The reservation ID, such as 'ZFA04Y'."),
+				"total_baggages":   map[string]any{"type": "integer", "description": "The updated total number of baggage items included in the reservation."},
+				"nonfree_baggages": map[string]any{"type": "integer", "description": "The updated number of non-free baggage items included in the reservation."},
+				"payment_id":       schemaString("The payment id stored in user profile, such as 'credit_card_7815826', 'gift_card_7815826', 'certificate_7815826'."),
+			}, []string{"reservation_id", "total_baggages", "nonfree_baggages", "payment_id"}),
+			Handler: airUpdateReservationBaggages,
+		},
+		"update_reservation_flights": {
+			Name:        "update_reservation_flights",
+			Description: "Update the flight information of a reservation.",
+			InputSchema: airUpdateReservationFlightsSchema(),
+			Handler:     airUpdateReservationFlights,
+		},
+		"update_reservation_passengers": {
+			Name:        "update_reservation_passengers",
+			Description: "Update the passenger information of a reservation.",
+			InputSchema: airUpdateReservationPassengersSchema(),
+			Handler:     airUpdateReservationPassengers,
+		},
+		// --- aux tools ---
+		"calculate": {
+			Name:        "calculate",
+			Description: "Calculate the result of a mathematical expression.",
+			InputSchema: schemaObject(map[string]any{
+				"expression": schemaString("The mathematical expression to calculate, such as '2 + 2'. The expression can contain numbers, operators (+, -, *, /), parentheses, and spaces."),
+			}, []string{"expression"}),
+			Handler: sierraCalculate,
+		},
+		"think": {
+			Name:        "think",
+			Description: "Use the tool to think about something. It will not obtain new information or change the database, but just append the thought to the log. Use it when complex reasoning or some cache memory is needed.",
+			InputSchema: schemaObject(map[string]any{
+				"thought": schemaString("A thought to think about."),
+			}, []string{"thought"}),
+			Handler: sierraThink,
+		},
+		"transfer_to_human_agents": {
+			Name:        "transfer_to_human_agents",
+			Description: "Transfer the user to a human agent, with a summary of the user's issue. Only transfer if the user explicitly asks for a human agent, or if the user's issue cannot be resolved by the agent with the available tools.",
+			InputSchema: schemaObject(map[string]any{
+				"summary": schemaString("A summary of the user's issue."),
+			}, []string{"summary"}),
+			Handler: sierraTransferToHumanRetail,
+		},
+	}
+}
+
+// --- read handlers ---
+
+func airGetReservationDetails(state State, args map[string]any) (any, error) {
+	rid, err := argString(args, "reservation_id")
+	if err != nil {
+		return nil, err
+	}
+	res := asMap(state["reservations"])
+	r, ok := res[rid]
+	if !ok {
+		return "Error: user not found", nil // verbatim from Sierra (yes, "user")
+	}
+	return jsonString(r)
+}
+
+func airGetUserDetails(state State, args map[string]any) (any, error) {
+	uid, err := argString(args, "user_id")
+	if err != nil {
+		return nil, err
+	}
+	users := asMap(state["users"])
+	u, ok := users[uid]
+	if !ok {
+		return "Error: user not found", nil
+	}
+	return jsonString(u)
+}
+
+func airListAllAirports(_ State, _ map[string]any) (any, error) {
+	airports := []string{"SFO", "JFK", "LAX", "ORD", "DFW", "DEN", "SEA", "ATL", "MIA", "BOS",
+		"PHX", "IAH", "LAS", "MCO", "EWR", "CLT", "MSP", "DTW", "PHL", "LGA"}
+	cities := []string{"San Francisco", "New York", "Los Angeles", "Chicago", "Dallas",
+		"Denver", "Seattle", "Atlanta", "Miami", "Boston", "Phoenix", "Houston", "Las Vegas",
+		"Orlando", "Newark", "Charlotte", "Minneapolis", "Detroit", "Philadelphia", "LaGuardia"}
+	out := make(map[string]string, len(airports))
+	for i, a := range airports {
+		out[a] = cities[i]
+	}
+	return jsonString(out)
+}
+
+func airSearchDirectFlight(state State, args map[string]any) (any, error) {
+	origin, err := argString(args, "origin")
+	if err != nil {
+		return nil, err
+	}
+	destination, err := argString(args, "destination")
+	if err != nil {
+		return nil, err
+	}
+	date, err := argString(args, "date")
+	if err != nil {
+		return nil, err
+	}
+	flights := asMap(state["flights"])
+	keys := sortedKeys(flights)
+	results := make([]any, 0)
+	for _, k := range keys {
+		flight := asMap(flights[k])
+		if flight["origin"] != origin || flight["destination"] != destination {
+			continue
+		}
+		dates := asMap(flight["dates"])
+		dateData := asMap(dates[date])
+		if dateData == nil || dateData["status"] != "available" {
+			continue
+		}
+		entry := copyMapExcept(flight, "dates")
+		for ek, ev := range dateData {
+			entry[ek] = ev
+		}
+		results = append(results, entry)
+	}
+	return jsonString(results)
+}
+
+func airSearchOnestopFlight(state State, args map[string]any) (any, error) {
+	origin, err := argString(args, "origin")
+	if err != nil {
+		return nil, err
+	}
+	destination, err := argString(args, "destination")
+	if err != nil {
+		return nil, err
+	}
+	date, err := argString(args, "date")
+	if err != nil {
+		return nil, err
+	}
+	flights := asMap(state["flights"])
+	keys := sortedKeys(flights)
+	results := make([]any, 0)
+	for _, k1 := range keys {
+		f1 := asMap(flights[k1])
+		if f1["origin"] != origin {
+			continue
+		}
+		for _, k2 := range keys {
+			f2 := asMap(flights[k2])
+			if f2["destination"] != destination {
+				continue
+			}
+			if f1["destination"] != f2["origin"] {
+				continue
+			}
+			arrivalStr, _ := f1["scheduled_arrival_time_est"].(string)
+			deptStr, _ := f2["scheduled_departure_time_est"].(string)
+			date2 := date
+			if strings.Contains(arrivalStr, "+1") {
+				lastTwo := date[len(date)-2:]
+				dd, err := strconv.Atoi(lastTwo)
+				if err == nil {
+					date2 = fmt.Sprintf("2024-05-%d", dd+1)
+				}
+			}
+			if arrivalStr > deptStr {
+				continue
+			}
+			d1 := asMap(asMap(f1["dates"])[date])
+			d2 := asMap(asMap(f2["dates"])[date2])
+			if d1 == nil || d2 == nil {
+				continue
+			}
+			if d1["status"] != "available" || d2["status"] != "available" {
+				continue
+			}
+			r1 := copyMapExcept(f1, "dates")
+			for k, v := range d1 {
+				r1[k] = v
+			}
+			r1["date"] = date
+			r2 := copyMapExcept(f2, "dates")
+			for k, v := range d2 {
+				r2[k] = v
+			}
+			r2["date"] = date2
+			results = append(results, []any{r1, r2})
+		}
+	}
+	return jsonString(results)
+}
+
+// --- mutating handlers ---
+
+func airBookReservation(state State, args map[string]any) (any, error) {
+	userID, err := argString(args, "user_id")
+	if err != nil {
+		return nil, err
+	}
+	origin, _ := argString(args, "origin")
+	destination, _ := argString(args, "destination")
+	flightType, _ := argString(args, "flight_type")
+	cabin, _ := argString(args, "cabin")
+	insurance, _ := argString(args, "insurance")
+	flightsArg := asSlice(args["flights"])
+	passengersArg := asSlice(args["passengers"])
+	paymentsArg := asSlice(args["payment_methods"])
+	totalBaggages := int(asFloat(args["total_baggages"]))
+	nonfreeBaggages := int(asFloat(args["nonfree_baggages"]))
+
+	reservations := asMap(state["reservations"])
+	users := asMap(state["users"])
+	user, ok := users[userID]
+	if !ok {
+		return "Error: user not found", nil
+	}
+	userMap := asMap(user)
+
+	// Sierra: assume each task makes at most 3 reservations.
+	rid := "HATHAT"
+	if _, exists := reservations[rid]; exists {
+		rid = "HATHAU"
+		if _, exists2 := reservations[rid]; exists2 {
+			rid = "HATHAV"
+		}
+	}
+
+	// deepcopy the flights array so subsequent mutations don't
+	// alias the caller-provided slice.
+	flightsCopy := make([]any, len(flightsArg))
+	for i, f := range flightsArg {
+		flightsCopy[i] = deepCopyAny(f)
+	}
+
+	reservation := map[string]any{
+		"reservation_id":   rid,
+		"user_id":          userID,
+		"origin":           origin,
+		"destination":      destination,
+		"flight_type":      flightType,
+		"cabin":            cabin,
+		"flights":          flightsCopy,
+		"passengers":       passengersArg,
+		"payment_history":  paymentsArg,
+		"created_at":       "2024-05-15T15:00:00",
+		"total_baggages":   totalBaggages,
+		"nonfree_baggages": nonfreeBaggages,
+		"insurance":        insurance,
+	}
+
+	flightsDB := asMap(state["flights"])
+	totalPrice := 0.0
+	for _, fAny := range flightsCopy {
+		flight := asMap(fAny)
+		flightNumber, _ := flight["flight_number"].(string)
+		flightDate, _ := flight["date"].(string)
+		flightDataAny, ok := flightsDB[flightNumber]
+		if !ok {
+			return fmt.Sprintf("Error: flight %s not found", flightNumber), nil
+		}
+		flightData := asMap(flightDataAny)
+		dates := asMap(flightData["dates"])
+		dateData, ok := dates[flightDate]
+		if !ok {
+			return fmt.Sprintf("Error: flight %s not found on date %s", flightNumber, flightDate), nil
+		}
+		flightDateData := asMap(dateData)
+		if flightDateData["status"] != "available" {
+			return fmt.Sprintf("Error: flight %s not available on date %s", flightNumber, flightDate), nil
+		}
+		availableSeats := asMap(flightDateData["available_seats"])
+		if int(asFloat(availableSeats[cabin])) < len(passengersArg) {
+			return fmt.Sprintf("Error: not enough seats on flight %s", flightNumber), nil
+		}
+		prices := asMap(flightDateData["prices"])
+		price := asFloat(prices[cabin])
+		flight["price"] = price
+		flight["origin"] = flightData["origin"]
+		flight["destination"] = flightData["destination"]
+		totalPrice += price * float64(len(passengersArg))
+	}
+
+	if insurance == "yes" {
+		totalPrice += 30 * float64(len(passengersArg))
+	}
+	totalPrice += 50 * float64(nonfreeBaggages)
+
+	pms := asMap(userMap["payment_methods"])
+	for _, pAny := range paymentsArg {
+		payment := asMap(pAny)
+		paymentID, _ := payment["payment_id"].(string)
+		amt := asFloat(payment["amount"])
+		pm, ok := pms[paymentID]
+		if !ok {
+			return fmt.Sprintf("Error: payment method %s not found", paymentID), nil
+		}
+		pmMap := asMap(pm)
+		src, _ := pmMap["source"].(string)
+		if src == "gift_card" || src == "certificate" {
+			if asFloat(pmMap["amount"]) < amt {
+				return fmt.Sprintf("Error: not enough balance in payment method %s", paymentID), nil
+			}
+		}
+	}
+	var paidTotal float64
+	for _, pAny := range paymentsArg {
+		paidTotal += asFloat(asMap(pAny)["amount"])
+	}
+	if paidTotal != totalPrice {
+		return fmt.Sprintf("Error: payment amount does not add up, total price is %s, but paid %s",
+			formatNumber(totalPrice), formatNumber(paidTotal)), nil
+	}
+
+	for _, pAny := range paymentsArg {
+		payment := asMap(pAny)
+		paymentID, _ := payment["payment_id"].(string)
+		amt := asFloat(payment["amount"])
+		pm := asMap(pms[paymentID])
+		src, _ := pm["source"].(string)
+		switch src {
+		case "gift_card":
+			pm["amount"] = asFloat(pm["amount"]) - amt
+		case "certificate":
+			delete(pms, paymentID)
+		}
+	}
+
+	reservations[rid] = reservation
+	userReservations := asSlice(userMap["reservations"])
+	userReservations = append(userReservations, rid)
+	userMap["reservations"] = userReservations
+	return jsonString(reservation)
+}
+
+func airCancelReservation(state State, args map[string]any) (any, error) {
+	rid, err := argString(args, "reservation_id")
+	if err != nil {
+		return nil, err
+	}
+	reservations := asMap(state["reservations"])
+	r, ok := reservations[rid]
+	if !ok {
+		return "Error: reservation not found", nil
+	}
+	res := asMap(r)
+	history := asSlice(res["payment_history"])
+	refunds := make([]any, 0, len(history))
+	for _, pAny := range history {
+		p := asMap(pAny)
+		refunds = append(refunds, map[string]any{
+			"payment_id": p["payment_id"],
+			"amount":     -asFloat(p["amount"]),
+		})
+	}
+	res["payment_history"] = append(history, refunds...)
+	res["status"] = "cancelled"
+	return jsonString(res)
+}
+
+func airSendCertificate(state State, args map[string]any) (any, error) {
+	userID, err := argString(args, "user_id")
+	if err != nil {
+		return nil, err
+	}
+	amount := asFloat(args["amount"])
+	users := asMap(state["users"])
+	u, ok := users[userID]
+	if !ok {
+		return "Error: user not found", nil
+	}
+	user := asMap(u)
+	pms := asMap(user["payment_methods"])
+	for _, id := range []string{"certificate_3221322", "certificate_3221323", "certificate_3221324"} {
+		if _, exists := pms[id]; exists {
+			continue
+		}
+		pms[id] = map[string]any{
+			"source": "certificate",
+			"amount": amount,
+			"id":     id,
+		}
+		return fmt.Sprintf("Certificate %s added to user %s with amount %s.", id, userID, formatNumber(amount)), nil
+	}
+	// Sierra's Python returns None implicitly when all 3 slots are taken;
+	// we surface a plain string so the harness doesn't see a nil.
+	return "", nil
+}
+
+func airUpdateReservationBaggages(state State, args map[string]any) (any, error) {
+	rid, err := argString(args, "reservation_id")
+	if err != nil {
+		return nil, err
+	}
+	totalBaggages := int(asFloat(args["total_baggages"]))
+	nonfreeBaggages := int(asFloat(args["nonfree_baggages"]))
+	paymentID, err := argString(args, "payment_id")
+	if err != nil {
+		return nil, err
+	}
+	users := asMap(state["users"])
+	reservations := asMap(state["reservations"])
+	r, ok := reservations[rid]
+	if !ok {
+		return "Error: reservation not found", nil
+	}
+	res := asMap(r)
+	delta := nonfreeBaggages - int(asFloat(res["nonfree_baggages"]))
+	if delta < 0 {
+		delta = 0
+	}
+	totalPrice := float64(50 * delta)
+
+	userID, _ := res["user_id"].(string)
+	pms := asMap(asMap(users[userID])["payment_methods"])
+	pm, ok := pms[paymentID]
+	if !ok {
+		return "Error: payment method not found", nil
+	}
+	pmMap := asMap(pm)
+	src, _ := pmMap["source"].(string)
+	if src == "certificate" {
+		return "Error: certificate cannot be used to update reservation", nil
+	}
+	if src == "gift_card" && asFloat(pmMap["amount"]) < totalPrice {
+		return "Error: gift card balance is not enough", nil
+	}
+
+	res["total_baggages"] = totalBaggages
+	res["nonfree_baggages"] = nonfreeBaggages
+	if src == "gift_card" {
+		pmMap["amount"] = asFloat(pmMap["amount"]) - totalPrice
+	}
+	if totalPrice != 0 {
+		history := asSlice(res["payment_history"])
+		history = append(history, map[string]any{
+			"payment_id": paymentID,
+			"amount":     totalPrice,
+		})
+		res["payment_history"] = history
+	}
+	return jsonString(res)
+}
+
+func airUpdateReservationFlights(state State, args map[string]any) (any, error) {
+	rid, err := argString(args, "reservation_id")
+	if err != nil {
+		return nil, err
+	}
+	cabin, err := argString(args, "cabin")
+	if err != nil {
+		return nil, err
+	}
+	paymentID, err := argString(args, "payment_id")
+	if err != nil {
+		return nil, err
+	}
+	flightsArg := asSlice(args["flights"])
+	users := asMap(state["users"])
+	reservations := asMap(state["reservations"])
+	r, ok := reservations[rid]
+	if !ok {
+		return "Error: reservation not found", nil
+	}
+	res := asMap(r)
+
+	// deepcopy
+	flightsCopy := make([]any, len(flightsArg))
+	for i, f := range flightsArg {
+		flightsCopy[i] = deepCopyAny(f)
+	}
+
+	existingFlights := asSlice(res["flights"])
+	flightsDB := asMap(state["flights"])
+	totalPrice := 0.0
+	resCabin, _ := res["cabin"].(string)
+	passengerN := len(asSlice(res["passengers"]))
+	for _, fAny := range flightsCopy {
+		flight := asMap(fAny)
+		fn, _ := flight["flight_number"].(string)
+		fd, _ := flight["date"].(string)
+		// existing flight pass-through
+		var existing map[string]any
+		for _, ex := range existingFlights {
+			exMap := asMap(ex)
+			if exMap["flight_number"] == fn && exMap["date"] == fd && cabin == resCabin {
+				existing = exMap
+				break
+			}
+		}
+		if existing != nil {
+			price := asFloat(existing["price"])
+			totalPrice += price * float64(passengerN)
+			flight["price"] = price
+			flight["origin"] = existing["origin"]
+			flight["destination"] = existing["destination"]
+			continue
+		}
+		flightDataAny, ok := flightsDB[fn]
+		if !ok {
+			return fmt.Sprintf("Error: flight %s not found", fn), nil
+		}
+		flightData := asMap(flightDataAny)
+		dates := asMap(flightData["dates"])
+		dateData, ok := dates[fd]
+		if !ok {
+			return fmt.Sprintf("Error: flight %s not found on date %s", fn, fd), nil
+		}
+		fdd := asMap(dateData)
+		if fdd["status"] != "available" {
+			return fmt.Sprintf("Error: flight %s not available on date %s", fn, fd), nil
+		}
+		seats := asMap(fdd["available_seats"])
+		if int(asFloat(seats[cabin])) < passengerN {
+			return fmt.Sprintf("Error: not enough seats on flight %s", fn), nil
+		}
+		prices := asMap(fdd["prices"])
+		price := asFloat(prices[cabin])
+		flight["price"] = price
+		flight["origin"] = flightData["origin"]
+		flight["destination"] = flightData["destination"]
+		totalPrice += price * float64(passengerN)
+	}
+	var prevTotal float64
+	for _, ex := range existingFlights {
+		prevTotal += asFloat(asMap(ex)["price"])
+	}
+	totalPrice -= prevTotal * float64(passengerN)
+
+	userID, _ := res["user_id"].(string)
+	pms := asMap(asMap(users[userID])["payment_methods"])
+	pm, ok := pms[paymentID]
+	if !ok {
+		return "Error: payment method not found", nil
+	}
+	pmMap := asMap(pm)
+	src, _ := pmMap["source"].(string)
+	if src == "certificate" {
+		return "Error: certificate cannot be used to update reservation", nil
+	}
+	if src == "gift_card" && asFloat(pmMap["amount"]) < totalPrice {
+		return "Error: gift card balance is not enough", nil
+	}
+	if src == "gift_card" {
+		pmMap["amount"] = asFloat(pmMap["amount"]) - totalPrice
+	}
+	res["flights"] = flightsCopy
+	if totalPrice != 0 {
+		history := asSlice(res["payment_history"])
+		history = append(history, map[string]any{
+			"payment_id": paymentID,
+			"amount":     totalPrice,
+		})
+		res["payment_history"] = history
+	}
+	return jsonString(res)
+}
+
+func airUpdateReservationPassengers(state State, args map[string]any) (any, error) {
+	rid, err := argString(args, "reservation_id")
+	if err != nil {
+		return nil, err
+	}
+	passengersArg := asSlice(args["passengers"])
+	reservations := asMap(state["reservations"])
+	r, ok := reservations[rid]
+	if !ok {
+		return "Error: reservation not found", nil
+	}
+	res := asMap(r)
+	if len(passengersArg) != len(asSlice(res["passengers"])) {
+		return "Error: number of passengers does not match", nil
+	}
+	res["passengers"] = passengersArg
+	return jsonString(res)
+}
+
+// --- schema helpers for the more complex airline tools ---
+
+func airBookReservationSchema() map[string]any {
+	return schemaObject(map[string]any{
+		"user_id":     schemaString("The ID of the user to book the reservation, such as 'sara_doe_496'."),
+		"origin":      schemaString("The IATA code for the origin city, such as 'SFO'."),
+		"destination": schemaString("The IATA code for the destination city, such as 'JFK'."),
+		"flight_type": map[string]any{"type": "string", "enum": []any{"one_way", "round_trip"}},
+		"cabin":       map[string]any{"type": "string", "enum": []any{"basic_economy", "economy", "business"}},
+		"flights": map[string]any{
+			"type":        "array",
+			"description": "An array of objects containing details about each piece of flight.",
+			"items": map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"flight_number": schemaString("Flight number, such as 'HAT001'."),
+					"date":          schemaString("The date for the flight in the format 'YYYY-MM-DD', such as '2024-05-01'."),
+				},
+				"required": []any{"flight_number", "date"},
+			},
+		},
+		"passengers":       airPassengersSchema("An array of objects containing details about each passenger."),
+		"payment_methods":  airPaymentMethodsSchema(),
+		"total_baggages":   map[string]any{"type": "integer", "description": "The total number of baggage items included in the reservation."},
+		"nonfree_baggages": map[string]any{"type": "integer", "description": "The number of non-free baggage items included in the reservation."},
+		"insurance":        map[string]any{"type": "string", "enum": []any{"yes", "no"}},
+	}, []string{"user_id", "origin", "destination", "flight_type", "cabin", "flights", "passengers", "payment_methods", "total_baggages", "nonfree_baggages", "insurance"})
+}
+
+func airUpdateReservationFlightsSchema() map[string]any {
+	return schemaObject(map[string]any{
+		"reservation_id": schemaString("The reservation ID, such as 'ZFA04Y'."),
+		"cabin":          map[string]any{"type": "string", "enum": []any{"basic_economy", "economy", "business"}},
+		"flights": map[string]any{
+			"type":        "array",
+			"description": "An array of objects containing details about each piece of flight in the ENTIRE new reservation. Even if the a flight segment is not changed, it should still be included in the array.",
+			"items": map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"flight_number": schemaString("Flight number, such as 'HAT001'."),
+					"date":          schemaString("The date for the flight in the format 'YYYY-MM-DD', such as '2024-05-01'."),
+				},
+				"required": []any{"flight_number", "date"},
+			},
+		},
+		"payment_id": schemaString("The payment id stored in user profile, such as 'credit_card_7815826', 'gift_card_7815826', 'certificate_7815826'."),
+	}, []string{"reservation_id", "cabin", "flights", "payment_id"})
+}
+
+func airUpdateReservationPassengersSchema() map[string]any {
+	return schemaObject(map[string]any{
+		"reservation_id": schemaString("The reservation ID, such as 'ZFA04Y'."),
+		"passengers":     airPassengersSchema("An array of objects containing details about each passenger."),
+	}, []string{"reservation_id", "passengers"})
+}
+
+func airPassengersSchema(desc string) map[string]any {
+	return map[string]any{
+		"type":        "array",
+		"description": desc,
+		"items": map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"first_name": schemaString("The first name of the passenger, such as 'Noah'."),
+				"last_name":  schemaString("The last name of the passenger, such as 'Brown'."),
+				"dob":        schemaString("The date of birth of the passenger in the format 'YYYY-MM-DD', such as '1990-01-01'."),
+			},
+			"required": []any{"first_name", "last_name", "dob"},
+		},
+	}
+}
+
+func airPaymentMethodsSchema() map[string]any {
+	return map[string]any{
+		"type":        "array",
+		"description": "An array of objects containing details about each payment method.",
+		"items": map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"payment_id": schemaString("The payment id stored in user profile, such as 'credit_card_7815826', 'gift_card_7815826', 'certificate_7815826'."),
+				"amount":     map[string]any{"type": "number", "description": "The amount to be paid."},
+			},
+			"required": []any{"payment_id", "amount"},
+		},
+	}
+}
+
+// --- tiny helpers (airline-private) ---
+
+func sortedKeys(m map[string]any) []string {
+	ks := make([]string, 0, len(m))
+	for k := range m {
+		ks = append(ks, k)
+	}
+	sort.Strings(ks)
+	return ks
+}
+
+func copyMapExcept(m map[string]any, skip string) map[string]any {
+	out := make(map[string]any, len(m))
+	for k, v := range m {
+		if k == skip {
+			continue
+		}
+		out[k] = v
+	}
+	return out
+}
+
+func deepCopyAny(v any) any {
+	switch x := v.(type) {
+	case map[string]any:
+		out := make(map[string]any, len(x))
+		for k, vv := range x {
+			out[k] = deepCopyAny(vv)
+		}
+		return out
+	case []any:
+		out := make([]any, len(x))
+		for i, vv := range x {
+			out[i] = deepCopyAny(vv)
+		}
+		return out
+	}
+	return v
+}
+
+func formatNumber(v float64) string {
+	// Sierra interpolates Python's number stringification; for an
+	// integer-valued float that's "123.0" -> "123" via `int(...)`
+	// in some places and full repr in others. The error message
+	// path uses Python's default repr which is "%g"-equivalent.
+	return strconv.FormatFloat(v, 'g', -1, 64)
+}

--- a/eval/taubench/sierra_common.go
+++ b/eval/taubench/sierra_common.go
@@ -1,0 +1,229 @@
+package taubench
+
+import (
+	"encoding/json"
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"math"
+)
+
+// Sierra τ-bench tool ports — common helpers
+//
+// Sierra's Python tools (sierra-research/tau-bench, commit
+// 59a200c6, dated 2026-03-18) all follow the same wire contract:
+//
+//   - State is a single map (initial state from data/*.json merged
+//     under top-level keys like "orders" / "users" / "products").
+//   - Each tool takes typed kwargs from the LLM.
+//   - Each tool returns a STRING — either json.dumps(<some object>)
+//     on success, or "Error: ..." on a domain-rule violation (note:
+//     not a Python exception; the LLM agent reads this and retries).
+//   - State mutations are in-place on `data` (we pass our State map
+//     by reference, same).
+//
+// We deliberately keep these helpers tight: typed arg extraction,
+// JSON-string return helper, a safe arithmetic evaluator (Sierra's
+// retail/calculate.py uses Python's `eval` with a tiny char-allowlist;
+// we use go/parser to walk the AST instead — same semantics, no
+// eval, no recursion-depth risk).
+
+// argString reads args[name] as a string. Sierra invariably sends
+// string keys; if the LLM serialised a number as JSON we surface a
+// typed error so the harness fails loud instead of silently
+// stringifying nonsense.
+func argString(args map[string]any, name string) (string, error) {
+	v, ok := args[name]
+	if !ok {
+		return "", fmt.Errorf("missing argument %q", name)
+	}
+	s, ok := v.(string)
+	if !ok {
+		return "", fmt.Errorf("argument %q: expected string, got %T", name, v)
+	}
+	return s, nil
+}
+
+// argStringList reads args[name] as []string. Accepts a Go []string
+// (rare; only from native test fixtures) or a JSON-shaped []any
+// where every element is a string (the normal LLM path).
+func argStringList(args map[string]any, name string) ([]string, error) {
+	v, ok := args[name]
+	if !ok {
+		return nil, fmt.Errorf("missing argument %q", name)
+	}
+	switch xs := v.(type) {
+	case []string:
+		return xs, nil
+	case []any:
+		out := make([]string, len(xs))
+		for i, x := range xs {
+			s, ok := x.(string)
+			if !ok {
+				return nil, fmt.Errorf("argument %q[%d]: expected string, got %T", name, i, x)
+			}
+			out[i] = s
+		}
+		return out, nil
+	default:
+		return nil, fmt.Errorf("argument %q: expected []string, got %T", name, v)
+	}
+}
+
+// asMap is the unchecked downcast we apply when State is structured
+// (Sierra's initial_state.json is rigorously typed; this helper
+// exists only to keep call sites readable). Missing key → nil map.
+func asMap(v any) map[string]any {
+	m, _ := v.(map[string]any)
+	return m
+}
+
+// asSlice mirrors asMap for arrays.
+func asSlice(v any) []any {
+	s, _ := v.([]any)
+	return s
+}
+
+// asFloat returns the underlying numeric value for a JSON-decoded
+// `any`. encoding/json decodes JSON numbers as float64; some
+// fixtures hand-write int literals — we accept both.
+func asFloat(v any) float64 {
+	switch x := v.(type) {
+	case float64:
+		return x
+	case int:
+		return float64(x)
+	case int64:
+		return float64(x)
+	case json.Number:
+		f, _ := x.Float64()
+		return f
+	}
+	return 0
+}
+
+// round2 mirrors Python's round(x, 2). Sierra rounds every
+// gift-card / price-difference computation this way; deviating
+// produces an off-by-one-cent state delta that fails the
+// ExpectedFinalState DeepEqual.
+func round2(x float64) float64 {
+	return math.Round(x*100) / 100
+}
+
+// jsonString is the Go analogue of Python's json.dumps. Tools
+// return this on the success path so the Hits string mirrors what
+// Sierra emits at the equivalent action.
+func jsonString(v any) (any, error) {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return nil, err
+	}
+	return string(b), nil
+}
+
+// safeEval evaluates a Sierra `calculate(...)` expression. Sierra's
+// own implementation passes the string to Python's `eval()` after a
+// char-allowlist check ("0123456789+-*/(). "). We replicate the
+// semantics by parsing the expression with go/parser (which handles
+// precedence + parens identically to Python for +,-,*,/) and walking
+// the BasicLit / BinaryExpr / ParenExpr / UnaryExpr nodes.
+//
+// Anything outside this grammar (function calls, identifiers, octal
+// literals starting with 0o, etc.) returns an error mirroring
+// Sierra's "Error: invalid characters in expression" branch.
+func safeEval(expr string) (float64, error) {
+	for _, r := range expr {
+		switch {
+		case r >= '0' && r <= '9':
+		case r == '+' || r == '-' || r == '*' || r == '/':
+		case r == '(' || r == ')' || r == '.' || r == ' ':
+		default:
+			return 0, fmt.Errorf("invalid characters in expression")
+		}
+	}
+	tree, err := parser.ParseExpr(expr)
+	if err != nil {
+		return 0, err
+	}
+	return evalNode(tree)
+}
+
+func evalNode(n ast.Node) (float64, error) {
+	switch x := n.(type) {
+	case *ast.BasicLit:
+		if x.Kind != token.INT && x.Kind != token.FLOAT {
+			return 0, fmt.Errorf("invalid literal kind %v", x.Kind)
+		}
+		f, err := strParseFloat(x.Value)
+		if err != nil {
+			return 0, err
+		}
+		return f, nil
+	case *ast.ParenExpr:
+		return evalNode(x.X)
+	case *ast.UnaryExpr:
+		v, err := evalNode(x.X)
+		if err != nil {
+			return 0, err
+		}
+		switch x.Op {
+		case token.ADD:
+			return v, nil
+		case token.SUB:
+			return -v, nil
+		}
+		return 0, fmt.Errorf("unsupported unary op %s", x.Op)
+	case *ast.BinaryExpr:
+		l, err := evalNode(x.X)
+		if err != nil {
+			return 0, err
+		}
+		r, err := evalNode(x.Y)
+		if err != nil {
+			return 0, err
+		}
+		switch x.Op {
+		case token.ADD:
+			return l + r, nil
+		case token.SUB:
+			return l - r, nil
+		case token.MUL:
+			return l * r, nil
+		case token.QUO:
+			if r == 0 {
+				return 0, fmt.Errorf("division by zero")
+			}
+			return l / r, nil
+		}
+		return 0, fmt.Errorf("unsupported binary op %s", x.Op)
+	}
+	return 0, fmt.Errorf("unsupported expression node %T", n)
+}
+
+func strParseFloat(s string) (float64, error) {
+	// strconv to avoid pulling in "strconv" via a top-level import
+	// when only this helper uses it — but go fmt prefers an import.
+	// Just import strconv at top; this isolated helper keeps the
+	// node-walk readable.
+	var f float64
+	_, err := fmt.Sscanf(s, "%g", &f)
+	if err != nil {
+		return 0, err
+	}
+	return f, nil
+}
+
+// countString returns the number of occurrences of s in xs. Sierra
+// uses list.count() in several tools to validate that duplicate
+// item ids in the action's item_ids list don't exceed the
+// duplicate count in the order; we mirror it bit-for-bit.
+func countString(xs []string, s string) int {
+	n := 0
+	for _, x := range xs {
+		if x == s {
+			n++
+		}
+	}
+	return n
+}

--- a/eval/taubench/sierra_retail.go
+++ b/eval/taubench/sierra_retail.go
@@ -1,0 +1,881 @@
+package taubench
+
+import (
+	"fmt"
+	"math"
+	"sort"
+	"strings"
+)
+
+// NewSierraRetailTools returns the canonical 16-tool retail-domain
+// registry ported from sierra-research/tau-bench
+// tau_bench/envs/retail/tools/ at commit 59a200c6 (2026-03-18).
+// Used in conjunction with the staged initial_state.json + tasks_test.json
+// produced by eval/taubench/sierra/prep.py; the shadow runner in
+// upstream.go executes each task's gold action sequence against a
+// clone of the initial state and snapshots the resulting State as
+// the ExpectedFinalState.
+//
+// Differences from NewRetailTools (the hand-curated mini pack):
+//
+//   - Tool names, kwargs, and state shapes follow Sierra verbatim
+//     (e.g. "cancel_pending_order" requires `reason ∈ {"no longer
+//     needed", "ordered by mistake"}`, our mini "cancel_order"
+//     accepts any reason). Mini and Sierra tool registries must
+//     not be merged — they read incompatible state shapes.
+//   - State is read as nested maps keyed by string ids; every
+//     mutation is in-place on the supplied State map so shadowRun
+//     captures the final state by snapshotting the same reference.
+//   - Error returns are *strings*, not Go errors. Sierra's contract
+//     is that a tool returning "Error: ..." represents a domain-rule
+//     violation the agent should reason about; only a Go-level
+//     panic (malformed kwargs, missing state subtree) is surfaced
+//     as an error from Handler.
+func NewSierraRetailTools() map[string]Tool {
+	return map[string]Tool{
+		// --- read tools ---
+		"get_order_details": {
+			Name:        "get_order_details",
+			Description: "Get the status and details of an order.",
+			InputSchema: schemaObject(map[string]any{
+				"order_id": schemaString("The order id, such as '#W0000000'. Be careful there is a '#' symbol at the beginning of the order id."),
+			}, []string{"order_id"}),
+			Handler: sierraGetOrderDetails,
+		},
+		"get_product_details": {
+			Name:        "get_product_details",
+			Description: "Get the inventory details of a product.",
+			InputSchema: schemaObject(map[string]any{
+				"product_id": schemaString("The product id, such as '6086499569'. Be careful the product id is different from the item id."),
+			}, []string{"product_id"}),
+			Handler: sierraGetProductDetails,
+		},
+		"get_user_details": {
+			Name:        "get_user_details",
+			Description: "Get the details of a user, including their orders.",
+			InputSchema: schemaObject(map[string]any{
+				"user_id": schemaString("The user id, such as 'sara_doe_496'."),
+			}, []string{"user_id"}),
+			Handler: sierraGetUserDetails,
+		},
+		"find_user_id_by_email": {
+			Name:        "find_user_id_by_email",
+			Description: "Find user id by email. If the user is not found, the function will return an error message.",
+			InputSchema: schemaObject(map[string]any{
+				"email": schemaString("The email of the user, such as 'something@example.com'."),
+			}, []string{"email"}),
+			Handler: sierraFindUserByEmail,
+		},
+		"find_user_id_by_name_zip": {
+			Name: "find_user_id_by_name_zip",
+			Description: "Find user id by first name, last name, and zip code. If the user is not found, the function " +
+				"will return an error message. By default, find user id by email, and only call this function if the " +
+				"user is not found by email or cannot remember email.",
+			InputSchema: schemaObject(map[string]any{
+				"first_name": schemaString("The first name of the customer, such as 'John'."),
+				"last_name":  schemaString("The last name of the customer, such as 'Doe'."),
+				"zip":        schemaString("The zip code of the customer, such as '12345'."),
+			}, []string{"first_name", "last_name", "zip"}),
+			Handler: sierraFindUserByNameZip,
+		},
+		"list_all_product_types": {
+			Name:        "list_all_product_types",
+			Description: "List the name and product id of all product types. Each product type has a variety of different items with unique item ids and options. There are only 50 product types in the store.",
+			InputSchema: schemaObject(nil, nil),
+			Handler:     sierraListProductTypes,
+		},
+		// --- mutating tools ---
+		"cancel_pending_order": {
+			Name: "cancel_pending_order",
+			Description: "Cancel a pending order. If the order is already processed or delivered, it cannot be cancelled. " +
+				"The agent needs to explain the cancellation detail and ask for explicit user confirmation (yes/no) to proceed. " +
+				"If the user confirms, the order status will be changed to 'cancelled' and the payment will be refunded. " +
+				"The refund will be added to the user's gift card balance immediately if the payment was made using a gift card, " +
+				"otherwise the refund would take 5-7 business days to process. The function returns the order details after the cancellation.",
+			InputSchema: schemaObject(map[string]any{
+				"order_id": schemaString("The order id, such as '#W0000000'. Be careful there is a '#' symbol at the beginning of the order id."),
+				"reason":   schemaEnum([]string{"no longer needed", "ordered by mistake"}, "The reason for cancellation, which should be either 'no longer needed' or 'ordered by mistake'."),
+			}, []string{"order_id", "reason"}),
+			Handler: sierraCancelPendingOrder,
+		},
+		"exchange_delivered_order_items": {
+			Name: "exchange_delivered_order_items",
+			Description: "Exchange items in a delivered order to new items of the same product type. For a delivered order, " +
+				"return or exchange can be only done once by the agent. The agent needs to explain the exchange detail and ask " +
+				"for explicit user confirmation (yes/no) to proceed.",
+			InputSchema: schemaObject(map[string]any{
+				"order_id":          schemaString("The order id, such as '#W0000000'. Be careful there is a '#' symbol at the beginning of the order id."),
+				"item_ids":          schemaStringList("The item ids to be exchanged, each such as '1008292230'. There could be duplicate items in the list."),
+				"new_item_ids":      schemaStringList("The item ids to be exchanged for, each such as '1008292230'. There could be duplicate items in the list. Each new item id should match the item id in the same position and be of the same product."),
+				"payment_method_id": schemaString("The payment method id to pay or receive refund for the item price difference, such as 'gift_card_0000000' or 'credit_card_0000000'. These can be looked up from the user or order details."),
+			}, []string{"order_id", "item_ids", "new_item_ids", "payment_method_id"}),
+			Handler: sierraExchangeDeliveredOrderItems,
+		},
+		"modify_pending_order_address": {
+			Name:        "modify_pending_order_address",
+			Description: "Modify the shipping address of a pending order. The agent needs to explain the modification detail and ask for explicit user confirmation (yes/no) to proceed.",
+			InputSchema: schemaObject(map[string]any{
+				"order_id": schemaString("The order id, such as '#W0000000'. Be careful there is a '#' symbol at the beginning of the order id."),
+				"address1": schemaString("The first line of the address, such as '123 Main St'."),
+				"address2": schemaString("The second line of the address, such as 'Apt 1' or ''."),
+				"city":     schemaString("The city, such as 'San Francisco'."),
+				"state":    schemaString("The state, such as 'CA'."),
+				"country":  schemaString("The country, such as 'USA'."),
+				"zip":      schemaString("The zip code, such as '12345'."),
+			}, []string{"order_id", "address1", "address2", "city", "state", "country", "zip"}),
+			Handler: sierraModifyPendingOrderAddress,
+		},
+		"modify_pending_order_items": {
+			Name:        "modify_pending_order_items",
+			Description: "Modify items in a pending order to new items of the same product type. For a pending order, this function can only be called once. The agent needs to explain the exchange detail and ask for explicit user confirmation (yes/no) to proceed.",
+			InputSchema: schemaObject(map[string]any{
+				"order_id":          schemaString("The order id, such as '#W0000000'. Be careful there is a '#' symbol at the beginning of the order id."),
+				"item_ids":          schemaStringList("The item ids to be modified, each such as '1008292230'. There could be duplicate items in the list."),
+				"new_item_ids":      schemaStringList("The item ids to be modified for, each such as '1008292230'. There could be duplicate items in the list. Each new item id should match the item id in the same position and be of the same product."),
+				"payment_method_id": schemaString("The payment method id to pay or receive refund for the item price difference, such as 'gift_card_0000000' or 'credit_card_0000000'. These can be looked up from the user or order details."),
+			}, []string{"order_id", "item_ids", "new_item_ids", "payment_method_id"}),
+			Handler: sierraModifyPendingOrderItems,
+		},
+		"modify_pending_order_payment": {
+			Name:        "modify_pending_order_payment",
+			Description: "Modify the payment method of a pending order. The agent needs to explain the modification detail and ask for explicit user confirmation (yes/no) to proceed.",
+			InputSchema: schemaObject(map[string]any{
+				"order_id":          schemaString("The order id, such as '#W0000000'. Be careful there is a '#' symbol at the beginning of the order id."),
+				"payment_method_id": schemaString("The payment method id to pay or receive refund for the item price difference, such as 'gift_card_0000000' or 'credit_card_0000000'. These can be looked up from the user or order details."),
+			}, []string{"order_id", "payment_method_id"}),
+			Handler: sierraModifyPendingOrderPayment,
+		},
+		"modify_user_address": {
+			Name:        "modify_user_address",
+			Description: "Modify the default address of a user. The agent needs to explain the modification detail and ask for explicit user confirmation (yes/no) to proceed.",
+			InputSchema: schemaObject(map[string]any{
+				"user_id":  schemaString("The user id, such as 'sara_doe_496'."),
+				"address1": schemaString("The first line of the address, such as '123 Main St'."),
+				"address2": schemaString("The second line of the address, such as 'Apt 1' or ''."),
+				"city":     schemaString("The city, such as 'San Francisco'."),
+				"state":    schemaString("The state, such as 'CA'."),
+				"country":  schemaString("The country, such as 'USA'."),
+				"zip":      schemaString("The zip code, such as '12345'."),
+			}, []string{"user_id", "address1", "address2", "city", "state", "country", "zip"}),
+			Handler: sierraModifyUserAddress,
+		},
+		"return_delivered_order_items": {
+			Name:        "return_delivered_order_items",
+			Description: "Return some items of a delivered order. The order status will be changed to 'return requested'. The agent needs to explain the return detail and ask for explicit user confirmation (yes/no) to proceed. The user will receive follow-up email for how and where to return the item.",
+			InputSchema: schemaObject(map[string]any{
+				"order_id":          schemaString("The order id, such as '#W0000000'. Be careful there is a '#' symbol at the beginning of the order id."),
+				"item_ids":          schemaStringList("The item ids to be returned, each such as '1008292230'. There could be duplicate items in the list."),
+				"payment_method_id": schemaString("The payment method id to pay or receive refund for the item price difference, such as 'gift_card_0000000' or 'credit_card_0000000'. These can be looked up from the user or order details."),
+			}, []string{"order_id", "item_ids", "payment_method_id"}),
+			Handler: sierraReturnDeliveredOrderItems,
+		},
+		// --- aux tools ---
+		"calculate": {
+			Name:        "calculate",
+			Description: "Calculate the result of a mathematical expression.",
+			InputSchema: schemaObject(map[string]any{
+				"expression": schemaString("The mathematical expression to calculate, such as '2 + 2'. The expression can contain numbers, operators (+, -, *, /), parentheses, and spaces."),
+			}, []string{"expression"}),
+			Handler: sierraCalculate,
+		},
+		"think": {
+			Name: "think",
+			Description: "Use the tool to think about something. It will not obtain new information or change the database, " +
+				"but just append the thought to the log. Use it when complex reasoning or some cache memory is needed.",
+			InputSchema: schemaObject(map[string]any{
+				"thought": schemaString("A thought to think about."),
+			}, []string{"thought"}),
+			Handler: sierraThink,
+		},
+		"transfer_to_human_agents": {
+			Name: "transfer_to_human_agents",
+			Description: "Transfer the user to a human agent, with a summary of the user's issue. " +
+				"Only transfer if the user explicitly asks for a human agent, or if the user's issue cannot be resolved by the agent with the available tools.",
+			InputSchema: schemaObject(map[string]any{
+				"summary": schemaString("A summary of the user's issue."),
+			}, []string{"summary"}),
+			Handler: sierraTransferToHumanRetail,
+		},
+	}
+}
+
+// --- read handlers ---
+
+func sierraGetOrderDetails(state State, args map[string]any) (any, error) {
+	orderID, err := argString(args, "order_id")
+	if err != nil {
+		return nil, err
+	}
+	orders := asMap(state["orders"])
+	o, ok := orders[orderID]
+	if !ok {
+		return "Error: order not found", nil
+	}
+	return jsonString(o)
+}
+
+func sierraGetProductDetails(state State, args map[string]any) (any, error) {
+	productID, err := argString(args, "product_id")
+	if err != nil {
+		return nil, err
+	}
+	products := asMap(state["products"])
+	p, ok := products[productID]
+	if !ok {
+		return "Error: product not found", nil
+	}
+	return jsonString(p)
+}
+
+func sierraGetUserDetails(state State, args map[string]any) (any, error) {
+	userID, err := argString(args, "user_id")
+	if err != nil {
+		return nil, err
+	}
+	users := asMap(state["users"])
+	u, ok := users[userID]
+	if !ok {
+		return "Error: user not found", nil
+	}
+	return jsonString(u)
+}
+
+func sierraFindUserByEmail(state State, args map[string]any) (any, error) {
+	email, err := argString(args, "email")
+	if err != nil {
+		return nil, err
+	}
+	target := strings.ToLower(email)
+	users := asMap(state["users"])
+	// Sort keys for deterministic iteration; Python dict iteration
+	// order matches insertion order, but in Sierra's data file the
+	// order is also alphabetical so this matches.
+	keys := make([]string, 0, len(users))
+	for k := range users {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	for _, uid := range keys {
+		profile := asMap(users[uid])
+		profEmail, _ := profile["email"].(string)
+		if strings.ToLower(profEmail) == target {
+			return uid, nil
+		}
+	}
+	return "Error: user not found", nil
+}
+
+func sierraFindUserByNameZip(state State, args map[string]any) (any, error) {
+	first, err := argString(args, "first_name")
+	if err != nil {
+		return nil, err
+	}
+	last, err := argString(args, "last_name")
+	if err != nil {
+		return nil, err
+	}
+	zip, err := argString(args, "zip")
+	if err != nil {
+		return nil, err
+	}
+	fLow := strings.ToLower(first)
+	lLow := strings.ToLower(last)
+	users := asMap(state["users"])
+	keys := make([]string, 0, len(users))
+	for k := range users {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	for _, uid := range keys {
+		profile := asMap(users[uid])
+		name := asMap(profile["name"])
+		addr := asMap(profile["address"])
+		pf, _ := name["first_name"].(string)
+		pl, _ := name["last_name"].(string)
+		pz, _ := addr["zip"].(string)
+		if strings.ToLower(pf) == fLow && strings.ToLower(pl) == lLow && pz == zip {
+			return uid, nil
+		}
+	}
+	return "Error: user not found", nil
+}
+
+func sierraListProductTypes(state State, _ map[string]any) (any, error) {
+	products := asMap(state["products"])
+	// Sierra builds {product["name"]: product["product_id"]} then
+	// sorts alphabetically. Multiple products with the same name
+	// would collide in Python's dict — we mirror that, last write
+	// wins, then sort.
+	nameToID := make(map[string]string, len(products))
+	for _, v := range products {
+		p := asMap(v)
+		name, _ := p["name"].(string)
+		pid, _ := p["product_id"].(string)
+		nameToID[name] = pid
+	}
+	names := make([]string, 0, len(nameToID))
+	for k := range nameToID {
+		names = append(names, k)
+	}
+	sort.Strings(names)
+	// Marshal as an ordered JSON object: encoding/json emits keys
+	// sorted by ASCII; that matches Sierra's `dict(sorted(...))`
+	// for the alphanumeric names in the fixture.
+	out := make(map[string]string, len(nameToID))
+	for _, k := range names {
+		out[k] = nameToID[k]
+	}
+	return jsonString(out)
+}
+
+// --- mutating handlers ---
+
+func sierraCancelPendingOrder(state State, args map[string]any) (any, error) {
+	orderID, err := argString(args, "order_id")
+	if err != nil {
+		return nil, err
+	}
+	reason, err := argString(args, "reason")
+	if err != nil {
+		return nil, err
+	}
+	orders := asMap(state["orders"])
+	o, ok := orders[orderID]
+	if !ok {
+		return "Error: order not found", nil
+	}
+	order := asMap(o)
+	if order["status"] != "pending" {
+		return "Error: non-pending order cannot be cancelled", nil
+	}
+	if reason != "no longer needed" && reason != "ordered by mistake" {
+		return "Error: invalid reason", nil
+	}
+	users := asMap(state["users"])
+	userID, _ := order["user_id"].(string)
+	user := asMap(users[userID])
+	pms := asMap(user["payment_methods"])
+
+	history := asSlice(order["payment_history"])
+	var refunds []any
+	for _, pAny := range history {
+		p := asMap(pAny)
+		pmID, _ := p["payment_method_id"].(string)
+		amt := asFloat(p["amount"])
+		refund := map[string]any{
+			"transaction_type":  "refund",
+			"amount":            amt,
+			"payment_method_id": pmID,
+		}
+		refunds = append(refunds, refund)
+		if strings.Contains(pmID, "gift_card") {
+			pm := asMap(pms[pmID])
+			pm["balance"] = round2(asFloat(pm["balance"]) + amt)
+		}
+	}
+	order["status"] = "cancelled"
+	order["cancel_reason"] = reason
+	order["payment_history"] = append(history, refunds...)
+	return jsonString(order)
+}
+
+func sierraExchangeDeliveredOrderItems(state State, args map[string]any) (any, error) {
+	orderID, err := argString(args, "order_id")
+	if err != nil {
+		return nil, err
+	}
+	itemIDs, err := argStringList(args, "item_ids")
+	if err != nil {
+		return nil, err
+	}
+	newItemIDs, err := argStringList(args, "new_item_ids")
+	if err != nil {
+		return nil, err
+	}
+	paymentMethodID, err := argString(args, "payment_method_id")
+	if err != nil {
+		return nil, err
+	}
+	products := asMap(state["products"])
+	orders := asMap(state["orders"])
+	users := asMap(state["users"])
+
+	o, ok := orders[orderID]
+	if !ok {
+		return "Error: order not found", nil
+	}
+	order := asMap(o)
+	if order["status"] != "delivered" {
+		return "Error: non-delivered order cannot be exchanged", nil
+	}
+
+	items := asSlice(order["items"])
+	allItemIDs := make([]string, 0, len(items))
+	for _, it := range items {
+		s, _ := asMap(it)["item_id"].(string)
+		allItemIDs = append(allItemIDs, s)
+	}
+	for _, id := range itemIDs {
+		if countString(itemIDs, id) > countString(allItemIDs, id) {
+			return fmt.Sprintf("Error: %s not found", id), nil
+		}
+	}
+	if len(itemIDs) != len(newItemIDs) {
+		return "Error: the number of items to be exchanged should match", nil
+	}
+
+	var diffPrice float64
+	for i := range itemIDs {
+		var matched map[string]any
+		for _, it := range items {
+			m := asMap(it)
+			if id, _ := m["item_id"].(string); id == itemIDs[i] {
+				matched = m
+				break
+			}
+		}
+		if matched == nil {
+			return fmt.Sprintf("Error: %s not found", itemIDs[i]), nil
+		}
+		productID, _ := matched["product_id"].(string)
+		variants := asMap(asMap(products[productID])["variants"])
+		variant := asMap(variants[newItemIDs[i]])
+		if variant == nil {
+			return fmt.Sprintf("Error: new item %s not found or available", newItemIDs[i]), nil
+		}
+		avail, _ := variant["available"].(bool)
+		if !avail {
+			return fmt.Sprintf("Error: new item %s not found or available", newItemIDs[i]), nil
+		}
+		diffPrice += asFloat(variant["price"]) - asFloat(matched["price"])
+	}
+	diffPrice = round2(diffPrice)
+
+	userID, _ := order["user_id"].(string)
+	pms := asMap(asMap(users[userID])["payment_methods"])
+	pm, ok := pms[paymentMethodID]
+	if !ok {
+		return "Error: payment method not found", nil
+	}
+	pmMap := asMap(pm)
+	if src, _ := pmMap["source"].(string); src == "gift_card" {
+		if asFloat(pmMap["balance"]) < diffPrice {
+			return "Error: insufficient gift card balance to pay for the price difference", nil
+		}
+	}
+
+	sortedItem := append([]string(nil), itemIDs...)
+	sort.Strings(sortedItem)
+	sortedNew := append([]string(nil), newItemIDs...)
+	sort.Strings(sortedNew)
+	order["status"] = "exchange requested"
+	order["exchange_items"] = stringsToAnys(sortedItem)
+	order["exchange_new_items"] = stringsToAnys(sortedNew)
+	order["exchange_payment_method_id"] = paymentMethodID
+	order["exchange_price_difference"] = diffPrice
+	return jsonString(order)
+}
+
+func sierraModifyPendingOrderAddress(state State, args map[string]any) (any, error) {
+	orderID, err := argString(args, "order_id")
+	if err != nil {
+		return nil, err
+	}
+	addr1, err := argString(args, "address1")
+	if err != nil {
+		return nil, err
+	}
+	addr2, err := argString(args, "address2")
+	if err != nil {
+		return nil, err
+	}
+	city, err := argString(args, "city")
+	if err != nil {
+		return nil, err
+	}
+	st, err := argString(args, "state")
+	if err != nil {
+		return nil, err
+	}
+	country, err := argString(args, "country")
+	if err != nil {
+		return nil, err
+	}
+	zip, err := argString(args, "zip")
+	if err != nil {
+		return nil, err
+	}
+	orders := asMap(state["orders"])
+	o, ok := orders[orderID]
+	if !ok {
+		return "Error: order not found", nil
+	}
+	order := asMap(o)
+	if order["status"] != "pending" {
+		return "Error: non-pending order cannot be modified", nil
+	}
+	order["address"] = map[string]any{
+		"address1": addr1,
+		"address2": addr2,
+		"city":     city,
+		"state":    st,
+		"country":  country,
+		"zip":      zip,
+	}
+	return jsonString(order)
+}
+
+func sierraModifyPendingOrderItems(state State, args map[string]any) (any, error) {
+	orderID, err := argString(args, "order_id")
+	if err != nil {
+		return nil, err
+	}
+	itemIDs, err := argStringList(args, "item_ids")
+	if err != nil {
+		return nil, err
+	}
+	newItemIDs, err := argStringList(args, "new_item_ids")
+	if err != nil {
+		return nil, err
+	}
+	paymentMethodID, err := argString(args, "payment_method_id")
+	if err != nil {
+		return nil, err
+	}
+	products := asMap(state["products"])
+	orders := asMap(state["orders"])
+	users := asMap(state["users"])
+
+	o, ok := orders[orderID]
+	if !ok {
+		return "Error: order not found", nil
+	}
+	order := asMap(o)
+	if order["status"] != "pending" {
+		return "Error: non-pending order cannot be modified", nil
+	}
+	items := asSlice(order["items"])
+	allItemIDs := make([]string, 0, len(items))
+	for _, it := range items {
+		s, _ := asMap(it)["item_id"].(string)
+		allItemIDs = append(allItemIDs, s)
+	}
+	for _, id := range itemIDs {
+		if countString(itemIDs, id) > countString(allItemIDs, id) {
+			return fmt.Sprintf("Error: %s not found", id), nil
+		}
+	}
+	if len(itemIDs) != len(newItemIDs) {
+		return "Error: the number of items to be exchanged should match", nil
+	}
+	var diffPrice float64
+	for i := range itemIDs {
+		var matched map[string]any
+		for _, it := range items {
+			m := asMap(it)
+			if id, _ := m["item_id"].(string); id == itemIDs[i] {
+				matched = m
+				break
+			}
+		}
+		if matched == nil {
+			return fmt.Sprintf("Error: %s not found", itemIDs[i]), nil
+		}
+		productID, _ := matched["product_id"].(string)
+		variants := asMap(asMap(products[productID])["variants"])
+		variant := asMap(variants[newItemIDs[i]])
+		if variant == nil {
+			return fmt.Sprintf("Error: new item %s not found or available", newItemIDs[i]), nil
+		}
+		avail, _ := variant["available"].(bool)
+		if !avail {
+			return fmt.Sprintf("Error: new item %s not found or available", newItemIDs[i]), nil
+		}
+		diffPrice += asFloat(variant["price"]) - asFloat(matched["price"])
+	}
+
+	userID, _ := order["user_id"].(string)
+	pms := asMap(asMap(users[userID])["payment_methods"])
+	pm, ok := pms[paymentMethodID]
+	if !ok {
+		return "Error: payment method not found", nil
+	}
+	pmMap := asMap(pm)
+	if src, _ := pmMap["source"].(string); src == "gift_card" && asFloat(pmMap["balance"]) < diffPrice {
+		return "Error: insufficient gift card balance to pay for the new item", nil
+	}
+
+	history := asSlice(order["payment_history"])
+	txType := "payment"
+	if diffPrice < 0 {
+		txType = "refund"
+	}
+	history = append(history, map[string]any{
+		"transaction_type":  txType,
+		"amount":            math.Abs(diffPrice),
+		"payment_method_id": paymentMethodID,
+	})
+	order["payment_history"] = history
+	if src, _ := pmMap["source"].(string); src == "gift_card" {
+		pmMap["balance"] = round2(asFloat(pmMap["balance"]) - diffPrice)
+	}
+
+	for i := range itemIDs {
+		var matched map[string]any
+		for _, it := range items {
+			m := asMap(it)
+			if id, _ := m["item_id"].(string); id == itemIDs[i] {
+				matched = m
+				break
+			}
+		}
+		if matched == nil {
+			continue
+		}
+		productID, _ := matched["product_id"].(string)
+		variants := asMap(asMap(products[productID])["variants"])
+		variant := asMap(variants[newItemIDs[i]])
+		matched["item_id"] = newItemIDs[i]
+		matched["price"] = variant["price"]
+		matched["options"] = variant["options"]
+	}
+	order["status"] = "pending (item modified)"
+	return jsonString(order)
+}
+
+func sierraModifyPendingOrderPayment(state State, args map[string]any) (any, error) {
+	orderID, err := argString(args, "order_id")
+	if err != nil {
+		return nil, err
+	}
+	paymentMethodID, err := argString(args, "payment_method_id")
+	if err != nil {
+		return nil, err
+	}
+	orders := asMap(state["orders"])
+	o, ok := orders[orderID]
+	if !ok {
+		return "Error: order not found", nil
+	}
+	order := asMap(o)
+	if order["status"] != "pending" {
+		return "Error: non-pending order cannot be modified", nil
+	}
+	users := asMap(state["users"])
+	userID, _ := order["user_id"].(string)
+	pms := asMap(asMap(users[userID])["payment_methods"])
+	if _, ok := pms[paymentMethodID]; !ok {
+		return "Error: payment method not found", nil
+	}
+	history := asSlice(order["payment_history"])
+	if len(history) > 1 {
+		return "Error: there should be exactly one payment for a pending order", nil
+	}
+	if len(history) == 0 {
+		return "Error: there should be exactly one payment for a pending order", nil
+	}
+	first := asMap(history[0])
+	if tt, _ := first["transaction_type"].(string); tt != "payment" {
+		return "Error: there should be exactly one payment for a pending order", nil
+	}
+	oldPMID, _ := first["payment_method_id"].(string)
+	if oldPMID == paymentMethodID {
+		return "Error: the new payment method should be different from the current one", nil
+	}
+	amount := asFloat(first["amount"])
+	newPM := asMap(pms[paymentMethodID])
+	if src, _ := newPM["source"].(string); src == "gift_card" && asFloat(newPM["balance"]) < amount {
+		return "Error: insufficient gift card balance to pay for the order", nil
+	}
+	history = append(history,
+		map[string]any{"transaction_type": "payment", "amount": amount, "payment_method_id": paymentMethodID},
+		map[string]any{"transaction_type": "refund", "amount": amount, "payment_method_id": oldPMID},
+	)
+	order["payment_history"] = history
+	if src, _ := newPM["source"].(string); src == "gift_card" {
+		newPM["balance"] = round2(asFloat(newPM["balance"]) - amount)
+	}
+	if strings.Contains(oldPMID, "gift_card") {
+		oldPM := asMap(pms[oldPMID])
+		oldPM["balance"] = round2(asFloat(oldPM["balance"]) + amount)
+	}
+	return jsonString(order)
+}
+
+func sierraModifyUserAddress(state State, args map[string]any) (any, error) {
+	userID, err := argString(args, "user_id")
+	if err != nil {
+		return nil, err
+	}
+	addr1, err := argString(args, "address1")
+	if err != nil {
+		return nil, err
+	}
+	addr2, err := argString(args, "address2")
+	if err != nil {
+		return nil, err
+	}
+	city, err := argString(args, "city")
+	if err != nil {
+		return nil, err
+	}
+	st, err := argString(args, "state")
+	if err != nil {
+		return nil, err
+	}
+	country, err := argString(args, "country")
+	if err != nil {
+		return nil, err
+	}
+	zip, err := argString(args, "zip")
+	if err != nil {
+		return nil, err
+	}
+	users := asMap(state["users"])
+	u, ok := users[userID]
+	if !ok {
+		return "Error: user not found", nil
+	}
+	user := asMap(u)
+	user["address"] = map[string]any{
+		"address1": addr1,
+		"address2": addr2,
+		"city":     city,
+		"state":    st,
+		"country":  country,
+		"zip":      zip,
+	}
+	return jsonString(user)
+}
+
+func sierraReturnDeliveredOrderItems(state State, args map[string]any) (any, error) {
+	orderID, err := argString(args, "order_id")
+	if err != nil {
+		return nil, err
+	}
+	itemIDs, err := argStringList(args, "item_ids")
+	if err != nil {
+		return nil, err
+	}
+	paymentMethodID, err := argString(args, "payment_method_id")
+	if err != nil {
+		return nil, err
+	}
+	orders := asMap(state["orders"])
+	o, ok := orders[orderID]
+	if !ok {
+		return "Error: order not found", nil
+	}
+	order := asMap(o)
+	if order["status"] != "delivered" {
+		return "Error: non-delivered order cannot be returned", nil
+	}
+	users := asMap(state["users"])
+	userID, _ := order["user_id"].(string)
+	pms := asMap(asMap(users[userID])["payment_methods"])
+	if _, ok := pms[paymentMethodID]; !ok {
+		return "Error: payment method not found", nil
+	}
+	history := asSlice(order["payment_history"])
+	originalPMID, _ := asMap(history[0])["payment_method_id"].(string)
+	if !strings.Contains(paymentMethodID, "gift_card") && paymentMethodID != originalPMID {
+		return "Error: payment method should be either the original payment method or a gift card", nil
+	}
+	items := asSlice(order["items"])
+	allItemIDs := make([]string, 0, len(items))
+	for _, it := range items {
+		s, _ := asMap(it)["item_id"].(string)
+		allItemIDs = append(allItemIDs, s)
+	}
+	for _, id := range itemIDs {
+		if countString(itemIDs, id) > countString(allItemIDs, id) {
+			return "Error: some item not found", nil
+		}
+	}
+	sortedItems := append([]string(nil), itemIDs...)
+	sort.Strings(sortedItems)
+	order["status"] = "return requested"
+	order["return_items"] = stringsToAnys(sortedItems)
+	order["return_payment_method_id"] = paymentMethodID
+	return jsonString(order)
+}
+
+// --- aux handlers ---
+
+func sierraCalculate(_ State, args map[string]any) (any, error) {
+	expr, err := argString(args, "expression")
+	if err != nil {
+		return nil, err
+	}
+	v, err := safeEval(expr)
+	if err != nil {
+		return fmt.Sprintf("Error: %s", err.Error()), nil
+	}
+	// Sierra returns `str(round(..., 2))`; Python prints "44.08"
+	// (trailing zero stripped only if integral). We match that.
+	return fmt.Sprintf("%g", round2(v)), nil
+}
+
+func sierraThink(_ State, _ map[string]any) (any, error) {
+	return "", nil
+}
+
+func sierraTransferToHumanRetail(_ State, _ map[string]any) (any, error) {
+	return "Transfer successful", nil
+}
+
+// --- tiny schema helpers ---
+//
+// These return JSON-Schema fragments. They live here (not
+// sierra_common.go) so each tool's registration call stays
+// readable in one place.
+
+func schemaString(desc string) map[string]any {
+	return map[string]any{"type": "string", "description": desc}
+}
+
+func schemaStringList(desc string) map[string]any {
+	return map[string]any{
+		"type":        "array",
+		"items":       map[string]any{"type": "string"},
+		"description": desc,
+	}
+}
+
+func schemaEnum(values []string, desc string) map[string]any {
+	enum := make([]any, len(values))
+	for i, v := range values {
+		enum[i] = v
+	}
+	return map[string]any{"type": "string", "enum": enum, "description": desc}
+}
+
+func schemaObject(props map[string]any, required []string) map[string]any {
+	if props == nil {
+		props = map[string]any{}
+	}
+	if required == nil {
+		required = []string{}
+	}
+	return map[string]any{
+		"type":       "object",
+		"properties": props,
+		"required":   anySlice(required),
+	}
+}
+
+func anySlice(ss []string) []any {
+	out := make([]any, len(ss))
+	for i, s := range ss {
+		out[i] = s
+	}
+	return out
+}
+
+func stringsToAnys(ss []string) []any {
+	out := make([]any, len(ss))
+	for i, s := range ss {
+		out[i] = s
+	}
+	return out
+}

--- a/eval/taubench/sierra_smoke_test.go
+++ b/eval/taubench/sierra_smoke_test.go
@@ -1,0 +1,68 @@
+package taubench
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestSierraRetailShadowRun_AllTasks loads the full 115-task
+// retail test set produced by eval/taubench/sierra/prep.py and
+// shadow-runs every task's gold action sequence. A task whose
+// gold trace fails to execute against a fresh clone of the initial
+// state is almost always a tool-port bug (missing tool, wrong
+// kwargs handling, wrong state mutation) and is the cheapest gate
+// against drift between Sierra's Python harness and our Go port.
+//
+// The test is gated on FLOWCRAFT_TAUBENCH_SIERRA_DATA pointing at a
+// directory laid out as:
+//
+//	<root>/retail/initial_state.json
+//	<root>/retail/tasks_test.json
+//	<root>/airline/initial_state.json
+//	<root>/airline/tasks_test.json
+//
+// (the canonical output of prep.py). Without the env var the test
+// is skipped — Sierra data is not committed to the repo (210k lines
+// of JSON, CC-BY) and is staged on the runner host.
+func TestSierraRetailShadowRun_AllTasks(t *testing.T) {
+	root := os.Getenv("FLOWCRAFT_TAUBENCH_SIERRA_DATA")
+	if root == "" {
+		t.Skip("FLOWCRAFT_TAUBENCH_SIERRA_DATA not set; stage Sierra data and re-run")
+	}
+	t.Run("retail", func(t *testing.T) {
+		runShadowSmoke(t, root, "retail", NewSierraRetailTools())
+	})
+	t.Run("airline", func(t *testing.T) {
+		if _, err := os.Stat(filepath.Join(root, "airline", "tasks_test.json")); err != nil {
+			t.Skip("airline tools not yet ported")
+		}
+		runShadowSmoke(t, root, "airline", NewSierraAirlineTools())
+	})
+}
+
+func runShadowSmoke(t *testing.T, root, domain string, tools map[string]Tool) {
+	t.Helper()
+	stateRaw, err := os.ReadFile(filepath.Join(root, domain, "initial_state.json"))
+	if err != nil {
+		t.Fatalf("read initial state: %v", err)
+	}
+	var initial State
+	if err := json.Unmarshal(stateRaw, &initial); err != nil {
+		t.Fatalf("parse initial state: %v", err)
+	}
+	tasks, err := LoadUpstreamTasks(filepath.Join(root, domain, "tasks_test.json"), initial, tools, domain)
+	if err != nil {
+		t.Fatalf("load + shadow run: %v", err)
+	}
+	if len(tasks) == 0 {
+		t.Fatalf("expected > 0 tasks, got 0")
+	}
+	for _, task := range tasks {
+		if len(task.Expected.ExpectedFinalState) == 0 && len(task.Expected.ExpectedTextFragments) == 0 {
+			t.Errorf("task %s: ExpectedFinalState and ExpectedTextFragments both empty (shadow run produced no signal)", task.ID)
+		}
+	}
+	t.Logf("%s: shadow-ran %d tasks, no errors", domain, len(tasks))
+}


### PR DESCRIPTION
## Summary

Port [sierra-research/tau-bench](https://github.com/sierra-research/tau-bench)'s 30 official tools (16 retail + 14 airline) and load its 165 gold tasks (115 retail + 50 airline) so `eval/taubench` runs nominally comparable to the Sierra-published Pass@1 / Pass@4 leaderboard rows. Two new `--domain` values (`sierra-retail`, `sierra-airline`) route through the new tool registries; the existing bundled mini packs (`retail` / `airline`, 5+7 hand-curated tasks) keep their role as cheap harness smoke checks.

Pinned Sierra revision: `59a200c6` (2026-03-18).

### Components

- `eval/taubench/sierra_retail.go` (16 tools, ~600 LOC) and `eval/taubench/sierra_airline.go` (14 tools, ~700 LOC) port `tau_bench/envs/{retail,airline}/tools/*.py` kwargs + state mutations + error strings verbatim against the merged \`data/*.json\` shape.
- \`eval/taubench/sierra_common.go\` factors out shared helpers (\`argString\`, \`asMap\`, \`round2\`, \`safeEval\`). Sierra's retail \`calculate\` uses Python's \`eval()\` with a char allowlist; we replicate via \`go/parser\` walk.
- \`eval/taubench/sierra/prep.py\` exports Sierra's pydantic \`Task\` literals to the UpstreamTask JSON shape \`upstream.go\` consumes (bypasses \`tau_bench\`'s litellm-pulling \`__init__\`) and merges per-domain \`data/*.json\` into one \`initial_state.json\`.
- \`TestSierraRetailShadowRun_AllTasks\` (gated on \`FLOWCRAFT_TAUBENCH_SIERRA_DATA\`) shadow-runs every gold trace against a fresh clone of the initial state — every divergence surfaces a port bug. Local run: **115/115 retail + 50/50 airline** PASS against Sierra commit \`59a200c6\`.

### Wiring

- \`eval/taubench/cli.go\`: \`--domain sierra-retail|sierra-airline\` routes through the new \`NewSierra{Retail,Airline}Tools()\`. Sierra domains require \`--upstream-tasks\` + \`--upstream-initial-state\` (no bundled mini-pack fallback).
- \`.github/workflows/eval-taubench.yml\`: \`domain\` input description documents the new values.
- \`eval/leaderboard.md\`: τ-bench retail / airline rows now point operators at \`--domain sierra-retail\` / \`--domain sierra-airline\` (1:1 with cited Sierra rows). Methodology caveat clarified to call out that mini-pack runs are **not** the leaderboard number.

### Data fixtures

Sierra's \`data/*.json\` totals ~210k lines (CC-BY). Not committed; \`eval/taubench/sierra/README.md\` documents the one-time runner staging:

\`\`\`
/var/lib/flowcraft-eval/datasets/taubench/retail/initial_state.json   (~2.0 MB)
/var/lib/flowcraft-eval/datasets/taubench/retail/tasks_test.json      (115 tasks)
/var/lib/flowcraft-eval/datasets/taubench/airline/initial_state.json  (~5.2 MB)
/var/lib/flowcraft-eval/datasets/taubench/airline/tasks_test.json     (50 tasks)
\`\`\`

Staged on the \`flowcraft-eval\` host as part of this PR's preparation.

## Test plan

- [x] \`go vet ./eval/taubench/...\` clean
- [x] \`go test ./eval/taubench/...\` (existing mini-pack tests still pass)
- [x] \`FLOWCRAFT_TAUBENCH_SIERRA_DATA=/tmp/sierra-data go test -run TestSierraRetailShadowRun_AllTasks ./eval/taubench/...\` → 115/115 retail + 50/50 airline shadow-run cleanly in ~10s
- [ ] After merge, dispatch \`eval-taubench.yml --domain sierra-retail --agent_llm azure_4o --customer_llm azure_4o\` and update leaderboard with Pass@1.
- [ ] Same for \`sierra-airline\`.

## Out of scope

- Pass@4 numbers (Sierra runs each task 4× with different seeds; we'd need to extend the harness with explicit \`--repeats\` + cross-trial aggregation, separate PR).
- Pinning Sierra revisions automatically (the README documents the manual re-stage flow; if the smoke test errors out after a Sierra HEAD bump, that's the signal to either re-pin or update the affected tool).

Made with [Cursor](https://cursor.com)