### PR TITLE
chore(eval): join go.work and drop sdk/sdkx replace directives

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,7 +62,9 @@ jobs:
           go-version: "1.25"
       - name: go vet
         run: |
-          for m in sdk sdkx voice vessel cmd/vesseld; do
+          # Workspace members (go.work) — vetted with the workspace
+          # overlay so cross-module symbols at monorepo HEAD resolve.
+          for m in sdk sdkx voice vessel cmd/vesseld eval; do
             echo "==> vet $m"
             (cd "$m" && go vet ./...)
           done
@@ -70,7 +72,7 @@ jobs:
           # directives — vet them with GOWORK=off so the pinned
           # versions are honoured. The e2e suites are also build-
           # tagged (//go:build e2e) so we pass -tags=e2e.
-          for m in eval tests/quality/vessel; do
+          for m in tests/quality/vessel; do
             echo "==> vet $m (GOWORK=off)"
             (cd "$m" && GOWORK=off go vet ./...)
           done

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -290,16 +290,14 @@ jobs:
   test-eval:
     name: Test eval (Go ${{ matrix.go-version }})
     needs: detect
-    # eval pins released sdk/sdkx via go.mod and runs with GOWORK=off, so
-    # rerun whenever sdk/sdkx changes (the pin may need a bump) or the
-    # suites themselves move.
+    # eval is a workspace member (see go.work) — sdk/sdkx resolve to
+    # monorepo HEAD via the workspace overlay, so rerun whenever sdk,
+    # sdkx, or eval source changes.
     if: needs.detect.outputs.sdk == 'true' || needs.detect.outputs.sdkx == 'true' || needs.detect.outputs.eval == 'true' || needs.detect.outputs.ci == 'true'
     runs-on: ubuntu-latest
     strategy:
       matrix:
         go-version: ["1.25", "1.26"]
-    env:
-      GOWORK: "off"
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v6

--- a/.github/workflows/eval-beir.yml
+++ b/.github/workflows/eval-beir.yml
@@ -114,9 +114,12 @@ jobs:
           done
 
       - name: Build eval binary
+        # `eval` is a workspace member (see ../go.work) — build with
+        # the workspace overlay so sdk/sdkx resolve to monorepo HEAD
+        # rather than the v0.3.x require pins.
         run: |
           cd eval
-          GOWORK=off go build -trimpath -o /tmp/eval ./cmd/eval
+          go build -trimpath -o /tmp/eval ./cmd/eval
 
       - name: Notify Feishu — started
         if: success()

--- a/.github/workflows/eval-history.yml
+++ b/.github/workflows/eval-history.yml
@@ -110,9 +110,12 @@ jobs:
           chmod 0750 "$REPORT_DIR" || true
 
       - name: Build eval binary
+        # `eval` is a workspace member (see ../go.work) — build with
+        # the workspace overlay so sdk/sdkx resolve to monorepo HEAD
+        # rather than the v0.3.x require pins.
         run: |
           cd eval
-          GOWORK=off go build -trimpath -o /tmp/eval ./cmd/eval
+          go build -trimpath -o /tmp/eval ./cmd/eval
 
       - name: Notify Feishu — started
         if: success()

--- a/.github/workflows/eval-knowledge.yml
+++ b/.github/workflows/eval-knowledge.yml
@@ -95,9 +95,12 @@ jobs:
           chmod 0750 "$REPORT_DIR" || true
 
       - name: Build eval binary
+        # `eval` is a workspace member (see ../go.work) — build with
+        # the workspace overlay so sdk/sdkx resolve to monorepo HEAD
+        # rather than the v0.3.x require pins.
         run: |
           cd eval
-          GOWORK=off go build -trimpath -o /tmp/eval ./cmd/eval
+          go build -trimpath -o /tmp/eval ./cmd/eval
 
       - name: Notify Feishu — started
         if: success()

--- a/.github/workflows/eval-locomo.yml
+++ b/.github/workflows/eval-locomo.yml
@@ -297,12 +297,13 @@ jobs:
           go env GOMODCACHE GOCACHE
 
       - name: Build eval binary
-        # The eval module pins released sdk/sdkx via go.mod and uses
-        # GOWORK=off in CI; mirror that here so we use the pinned
-        # versions, not the workspace overlay.
+        # `eval` is a workspace member (see ../go.work) — build with
+        # the workspace overlay so sdk/sdkx resolve to monorepo HEAD
+        # rather than the v0.3.x require pins (which are only a
+        # GOWORK=off / `go mod tidy` fallback).
         run: |
           cd eval
-          GOWORK=off go build -trimpath -o /tmp/eval ./cmd/eval
+          go build -trimpath -o /tmp/eval ./cmd/eval
           /tmp/eval --help | head -20
 
       - name: Refresh dataset from upstream

--- a/.github/workflows/eval-longmemeval.yml
+++ b/.github/workflows/eval-longmemeval.yml
@@ -152,9 +152,12 @@ jobs:
           chmod 0750 "$REPORT_DIR" || true
 
       - name: Build eval binary
+        # `eval` is a workspace member (see ../go.work) — build with
+        # the workspace overlay so sdk/sdkx resolve to monorepo HEAD
+        # rather than the v0.3.x require pins.
         run: |
           cd eval
-          GOWORK=off go build -trimpath -o /tmp/eval ./cmd/eval
+          go build -trimpath -o /tmp/eval ./cmd/eval
 
       - name: Refresh dataset from upstream
         # LongMemEval datasets are published on HuggingFace under

--- a/.github/workflows/eval-simpleqa.yml
+++ b/.github/workflows/eval-simpleqa.yml
@@ -111,9 +111,12 @@ jobs:
           fi
 
       - name: Build eval binary
+        # `eval` is a workspace member (see ../go.work) — build with
+        # the workspace overlay so sdk/sdkx resolve to monorepo HEAD
+        # rather than the v0.3.x require pins.
         run: |
           cd eval
-          GOWORK=off go build -trimpath -o /tmp/eval ./cmd/eval
+          go build -trimpath -o /tmp/eval ./cmd/eval
 
       - name: Notify Feishu — started
         if: success()

--- a/.github/workflows/eval-taubench.yml
+++ b/.github/workflows/eval-taubench.yml
@@ -129,9 +129,12 @@ jobs:
           fi
 
       - name: Build eval binary
+        # `eval` is a workspace member (see ../go.work) — build with
+        # the workspace overlay so sdk/sdkx resolve to monorepo HEAD
+        # rather than the v0.3.x require pins.
         run: |
           cd eval
-          GOWORK=off go build -trimpath -o /tmp/eval ./cmd/eval
+          go build -trimpath -o /tmp/eval ./cmd/eval
 
       - name: Notify Feishu — started
         if: success()

--- a/eval/go.mod
+++ b/eval/go.mod
@@ -2,28 +2,17 @@ module github.com/GizClaw/flowcraft/eval
 
 go 1.25.0
 
-// Pin sdk + sdkx to released tags. Bumping is a manual step (not auto-tagged) —
-// the eval suites live outside the workspace precisely so heavy datasets and
-// LLM-judge corpora do not inflate every sdk patch release. When sdk drops a
-// new version that needs re-validating, bump these requires in a follow-up
-// PR rather than coupling sdk's release cadence to this directory.
+// `eval` is a workspace member (see ../go.work) — `github.com/GizClaw/
+// flowcraft/sdk` and `.../sdkx` resolve to ../sdk and ../sdkx at the
+// monorepo HEAD, not to the v0.3.x require pins below. The pins exist
+// only to satisfy `GOWORK=off` / `go mod tidy` runs; in CI and local
+// development the workspace overlay is authoritative.
 
 require (
 	github.com/GizClaw/flowcraft/sdk v0.3.14
 	github.com/GizClaw/flowcraft/sdkx v0.3.9
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/pflag v1.0.9
-)
-
-// TEMPORARY: point sdk + sdkx at the monorepo working copies so this
-// branch can build against pipeline.WithMultiRecall before sdk is
-// tagged. Remove these replace lines once an sdk release containing
-// WithMultiRecall is cut and bump the require above to that tag.
-// (CI honours `replace` even under GOWORK=off — actions/checkout
-// brings in ../sdk and ../sdkx from the same monorepo workspace.)
-replace (
-	github.com/GizClaw/flowcraft/sdk => ../sdk
-	github.com/GizClaw/flowcraft/sdkx => ../sdkx
 )
 
 require (

--- a/eval/go.sum
+++ b/eval/go.sum
@@ -8,6 +8,8 @@ github.com/Azure/azure-sdk-for-go/sdk/internal v1.10.0/go.mod h1:iZDifYGJTIgIIkY
 github.com/AzureAD/microsoft-authentication-library-for-go v1.2.2 h1:XHOnouVk1mxXfQidrMEnLlPk9UMeRtyBTnEFtxkV0kU=
 github.com/AzureAD/microsoft-authentication-library-for-go v1.2.2/go.mod h1:wP83P5OoQ5p6ip3ScPr0BAq0BvuPAvacpEuSzyouqAI=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
+github.com/GizClaw/flowcraft/sdk v0.3.14 h1:Pc3UeHGKgbmip3ExTyB6Gd+XUMpjxJ29z4NkrIf7dXM=
+github.com/GizClaw/flowcraft/sdkx v0.3.9 h1:VIKCEz7H2ohRXXQthWd+6IGEnAIvPCXXhUZeQ/qAbHM=
 github.com/anthropics/anthropic-sdk-go v1.26.0 h1:oUTzFaUpAevfuELAP1sjL6CQJ9HHAfT7CoSYSac11PY=
 github.com/anthropics/anthropic-sdk-go v1.26.0/go.mod h1:qUKmaW+uuPB64iy1l+4kOSvaLqPXnHTTBKH6RVZ7q5Q=
 github.com/avast/retry-go v3.0.0+incompatible/go.mod h1:XtSnn+n/sHqQIpZ10K1qAevBhOOCWBLXXy3hyiqqBrY=

--- a/go.work
+++ b/go.work
@@ -1,9 +1,10 @@
 go 1.25.0
 
 use (
+	./cmd/vesseld
+	./eval
 	./sdk
 	./sdkx
 	./vessel
 	./voice
-	./cmd/vesseld
 )


### PR DESCRIPTION
## Summary

- Add \`./eval\` to \`go.work\`'s \`use ( ... )\` block so the monorepo workspace overlay applies to the eval module.
- Drop the \`replace\` block in \`eval/go.mod\` that pointed \`github.com/GizClaw/flowcraft/sdk\` and \`.../sdkx\` at \`../sdk\` / \`../sdkx\`. The workspace overlay supersedes it; the v0.3.x \`require\` pins remain as a \`GOWORK=off\` / \`go mod tidy\` fallback.
- Update CI to match: \`eval\` moves from the \`GOWORK=off\` vet lane to the workspace vet lane, and the seven \`eval-*.yml\` workflows' "Build eval binary" steps drop \`GOWORK=off\` so they build against monorepo HEAD (required — the runner currently uses \`WithMultiRecall\`, \`WithEntityStore\`, \`WithRecentTurns\`, \`Lemmatize\` etc. which don't exist in sdk v0.3.14).

## Why

Every feature branch that landed an sdk symbol used by eval had to ship a TEMPORARY \`replace\` edit in \`eval/go.mod\` (most recently on \`feat/entity-recall-lane\`). Workspace membership is the durable form of that pattern.

## Test plan

- [x] \`gofmt -l eval\` clean
- [x] \`go vet ./sdk/... ./sdkx/... ./eval/...\` clean (workspace overlay)
- [x] \`go build -o /tmp/eval ./eval/cmd/eval\` succeeds
- [x] \`go test ./eval/...\` — all 7 packages with tests green (history / env / notify / knowledge / locomo / simpleqa / taubench)
- [ ] CI: full ci.yml lane plus a workflow_dispatch smoke of one eval-* workflow once merged (only \`workflow_dispatch\` jobs touch the eval binary build, so they will validate on the next manual run)

Made with [Cursor](https://cursor.com)