### PR TITLE
[skip-tag] feat(recall): Projection + Reconciler for derived side-stores; fix supersede order + dedup tombstone filter

### DIFF
--- a/sdk/recall/entity_projection.go
+++ b/sdk/recall/entity_projection.go
@@ -1,0 +1,142 @@
+package recall
+
+import (
+	"context"
+	"sort"
+	"strings"
+
+	"github.com/GizClaw/flowcraft/sdk/retrieval"
+)
+
+// entityStoreProjection wraps an [EntityStore] so the [Reconciler]
+// can drive it as a generic [Projection].
+//
+// The adapter is intentionally thin: it expresses the contract that
+// "the entity-link inverted index is a derived view of the entry
+// namespace" in code rather than in a comment. Implementation notes:
+//
+//   - Project rebuilds the (entity → entry-id list) edge set from
+//     entry.Entities for the supplied entries and pushes it via
+//     [EntityStore.Link]. Link is idempotent on (entity, id), so
+//     this can be replayed safely (the Reconciler does so every
+//     tick).
+//   - Forget loops [EntityStore.Forget] over the stale ids. Most
+//     backends scan the entity namespace per call; for typical
+//     LoCoMo-shaped scopes (tens of stale ids per reconcile after a
+//     TTL sweep or rollback) the cost is negligible. Optimise via a
+//     batch interface if production telemetry shows the loop is
+//     hot.
+//   - AllEntryIDs scans the entity namespace via the wrapped index
+//     and unions every row's MetaEntityLinked list. The Reconciler
+//     uses this to compute (retained - alive) and Forget the diff.
+//     Bounded by total stored entity-rows under the scope.
+type entityStoreProjection struct {
+	store EntityStore
+	idx   retrieval.Index // same backing index the EntityStore lives in; used by AllEntryIDs
+}
+
+// newEntityStoreProjection returns nil when store is nil or the
+// backing index doesn't expose List — callers degrade gracefully
+// to "feature disabled" (same posture as NewIndexEntityStore).
+func newEntityStoreProjection(store EntityStore, idx retrieval.Index) *entityStoreProjection {
+	if store == nil || idx == nil {
+		return nil
+	}
+	return &entityStoreProjection{store: store, idx: idx}
+}
+
+// Name implements Projection.
+func (p *entityStoreProjection) Name() string { return "entity_store" }
+
+// Project implements Projection.
+//
+// Builds the edge set from entries[*].Entities — the same field
+// upsertFacts' eager linkEntities path consumes — and replays it
+// into the EntityStore. Idempotent because EntityStore.Link dedups
+// (entity, id) pairs and FIFO-evicts only when the row exceeds the
+// configured cap. Empty entry slices and entries without entities
+// are no-ops.
+func (p *entityStoreProjection) Project(ctx context.Context, scope Scope, entries []Entry) error {
+	if p == nil || p.store == nil || len(entries) == 0 {
+		return nil
+	}
+	edges := make(map[string][]string, len(entries))
+	for _, e := range entries {
+		for _, ent := range e.Entities {
+			ent = strings.TrimSpace(ent)
+			if ent == "" {
+				continue
+			}
+			edges[ent] = append(edges[ent], e.ID)
+		}
+	}
+	if len(edges) == 0 {
+		return nil
+	}
+	return p.store.Link(ctx, scope, edges)
+}
+
+// Forget implements Projection. EntityStore.Forget is per-id, so
+// we loop. The first error short-circuits — partial Forgets leave
+// the projection consistent enough (other ids may remain stale
+// until the next reconcile) but the Reconciler logs the failure so
+// operators can investigate.
+func (p *entityStoreProjection) Forget(ctx context.Context, scope Scope, entryIDs []string) error {
+	if p == nil || p.store == nil || len(entryIDs) == 0 {
+		return nil
+	}
+	for _, id := range entryIDs {
+		if id == "" {
+			continue
+		}
+		if err := p.store.Forget(ctx, scope, id); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// AllEntryIDs implements ProjectionInspector. Walks every row under
+// the entity namespace and unions the MetaEntityLinked lists.
+// Result order is unspecified (deduped by caller). Returns nil for
+// scopes the EntityStore has never seen.
+func (p *entityStoreProjection) AllEntryIDs(ctx context.Context, scope Scope) ([]string, error) {
+	if p == nil || p.idx == nil {
+		return nil, nil
+	}
+	ns := EntityNamespaceFor(scope)
+	seen := make(map[string]struct{})
+	var page string
+	for {
+		resp, err := p.idx.List(ctx, ns, retrieval.ListRequest{
+			PageSize:  500,
+			PageToken: page,
+		})
+		if err != nil || resp == nil {
+			return nil, err
+		}
+		for _, d := range resp.Items {
+			for _, id := range entityLinkedSlice(d) {
+				if id != "" {
+					seen[id] = struct{}{}
+				}
+			}
+		}
+		if resp.NextPageToken == "" {
+			break
+		}
+		page = resp.NextPageToken
+	}
+	out := make([]string, 0, len(seen))
+	for id := range seen {
+		out = append(out, id)
+	}
+	sort.Strings(out)
+	return out, nil
+}
+
+// Compile-time interface checks.
+var (
+	_ Projection          = (*entityStoreProjection)(nil)
+	_ ProjectionInspector = (*entityStoreProjection)(nil)
+)

--- a/sdk/recall/memory.go
+++ b/sdk/recall/memory.go
@@ -72,6 +72,21 @@ type JobController interface {
 	AwaitJob(ctx context.Context, id JobID, timeout time.Duration) (JobStatus, error)
 }
 
+// SideStoreSyncer is implemented by [Memory] flavours that register
+// one or more [Projection]s. Calling SyncSideStores runs one
+// synchronous reconcile pass for the given scope, bringing every
+// registered projection to the alive state of the primary index as
+// of now.
+//
+// Use this from tests and from callers that just performed a write
+// outside the eager hot path (Add, Auditable.Rollback, Memory.Forget,
+// TTL sweep, resolver OpDelete) and want 0-lag entity-lane recall
+// before the next background tick. Returns nil immediately when no
+// projection is registered.
+type SideStoreSyncer interface {
+	SyncSideStores(ctx context.Context, scope Scope) error
+}
+
 // RecallExplainer is implemented by [Memory] flavours whose underlying
 // retrieval pipeline can produce a structured [retrieval.SearchExecution]
 // (lanes, stages, …) alongside the ranked hits.
@@ -168,6 +183,15 @@ type config struct {
 	sweeperInterval time.Duration
 	sweeperBatchMax int
 	nsRegistry      NamespaceRegistry
+
+	// reconcileInterval controls the cadence of the background
+	// [Reconciler] that brings side-store projections (currently
+	// the EntityStore) into eventual consistency with the primary
+	// index. Zero falls back to [defaultReconcileInterval] (5 min)
+	// whenever any projection is active; negative disables the
+	// background tick (synchronous [Memory.SyncSideStores] still
+	// works). See [WithReconcileInterval].
+	reconcileInterval time.Duration
 
 	now    func() time.Time
 	logger func(string, ...any)
@@ -358,6 +382,26 @@ func WithEntityStoreMaxLinkedCount(n int) Option {
 			c.entityStoreMaxLinkedCnt = n
 		}
 	}
+}
+
+// WithReconcileInterval sets the cadence of the background
+// [Reconciler] that keeps side-store [Projection]s eventually
+// consistent with the primary index.
+//
+//   - d > 0: the Reconciler ticks every d. Smaller d = fresher
+//     projections at the cost of more namespace scans.
+//   - d == 0: the recall package uses [defaultReconcileInterval]
+//     (5 min) whenever any projection is registered.
+//   - d  < 0: the background loop is disabled. Synchronous
+//     [Memory.SyncSideStores] still works — useful in tests and
+//     in deployments that drive reconciliation from their own
+//     scheduler.
+//
+// This option has no effect when no projection is configured
+// ([WithEntityStore] is the only projection source today; future
+// graph / analytics views will register through the same channel).
+func WithReconcileInterval(d time.Duration) Option {
+	return func(c *config) { c.reconcileInterval = d }
 }
 
 // WithQueryEntityExtractor installs an LLM-backed extractor for the
@@ -639,13 +683,32 @@ type lt struct {
 
 	workerCtx    context.Context
 	workerCancel context.CancelFunc
+
+	// reconciler keeps registered side-store [Projection]s
+	// eventually consistent with idx. Nil when no projection was
+	// registered. Lifecycle is tied to (start in [New], stop in
+	// [Close]).
+	reconciler *Reconciler
 }
 
 var (
-	_ Memory        = (*lt)(nil)
-	_ Auditable     = (*lt)(nil)
-	_ JobController = (*lt)(nil)
+	_ Memory          = (*lt)(nil)
+	_ Auditable       = (*lt)(nil)
+	_ JobController   = (*lt)(nil)
+	_ SideStoreSyncer = (*lt)(nil)
 )
+
+// SyncSideStores implements [SideStoreSyncer]. No-op when no
+// projection is registered (the EntityStore was not enabled).
+func (m *lt) SyncSideStores(ctx context.Context, scope Scope) error {
+	if m.reconciler == nil {
+		return nil
+	}
+	if err := m.validateScope(scope); err != nil {
+		return err
+	}
+	return m.reconciler.SyncScope(ctx, scope)
+}
 
 // New constructs a Memory backed by idx. Caller must Close() on
 // shutdown. idx is a positional parameter because it is the only
@@ -769,6 +832,41 @@ func New(idx retrieval.Index, opts ...Option) (Memory, error) {
 		workerCtx:    workerCtx,
 		workerCancel: workerCancel,
 	}
+	// Wire side-store projections. The EntityStore — when enabled
+	// via [WithEntityStore] — is the only projection today. New
+	// projections (GraphStore, SearchAnalytics, …) plug in by
+	// adding an [entityStoreProjection]-style adapter here. The
+	// [Reconciler] takes ownership of keeping them in sync with
+	// the primary index; write paths stay uninstrumented.
+	var projections []Projection
+	if cfg.entityStore != nil {
+		if pr := newEntityStoreProjection(cfg.entityStore, idx); pr != nil {
+			projections = append(projections, pr)
+		}
+	}
+	// Reconciler needs the namespace registry to know which scopes
+	// to walk. Construct one on demand if no other component (TTL
+	// sweeper) already required it — the registry is cheap and
+	// projections without a registry would be unable to find
+	// scopes to reconcile.
+	if len(projections) > 0 && cfg.nsRegistry == nil {
+		cfg.nsRegistry = NewMemoryNamespaceRegistry()
+	}
+	if len(projections) > 0 {
+		// The reconciler is created whenever a projection exists so
+		// the synchronous [Memory.SyncSideStores] path works in all
+		// modes — including [WithReconcileInterval](-1), which only
+		// disables the BACKGROUND ticker (see reconciler.start()
+		// below).
+		m.reconciler = newReconciler(
+			wrapped,
+			projections,
+			cfg.nsRegistry,
+			cfg.reconcileInterval,
+			cfg.now,
+			cfg.logger,
+		)
+	}
 	for i := 0; i < cfg.asyncWorkers; i++ {
 		m.wgWorkers.Add(1)
 		go m.worker()
@@ -776,6 +874,12 @@ func New(idx retrieval.Index, opts ...Option) (Memory, error) {
 	if cfg.sweeperEnabled && cfg.ttlPolicy != nil {
 		m.wgWorkers.Add(1)
 		go m.sweeperLoop()
+	}
+	if m.reconciler != nil && cfg.reconcileInterval >= 0 {
+		// Negative interval disables the background loop; the
+		// synchronous [Memory.SyncSideStores] entry point keeps
+		// working (e.g. for tests, deterministic schedulers).
+		m.reconciler.start()
 	}
 	return m, nil
 }
@@ -833,6 +937,13 @@ func (m *lt) Close() error {
 		close(m.stopCh)
 	}
 	m.workerCancel()
+	// Stop the background reconciler before draining other workers
+	// so a long namespace scan does not extend Close beyond its
+	// expected budget. The reconciler's loop honours its own stop
+	// channel and the per-tick context derived from the loop body.
+	if m.reconciler != nil {
+		m.reconciler.stop()
+	}
 	m.wgWorkers.Wait()
 	var nsErr error
 	if m.cfg.nsRegistry != nil {

--- a/sdk/recall/merger.go
+++ b/sdk/recall/merger.go
@@ -26,6 +26,12 @@ func contentHash(scope Scope, content string) string {
 // dedupHashes returns hash → existingDocID for content hashes already present
 // in the namespace. Implemented via Index.List with an In filter; backends
 // without native filter pushdown fall back to client-side scans.
+//
+// The query composes the In-filter with [TombstoneFilter] so a hash that
+// belongs ONLY to tombstoned (logically deleted) docs does not count as
+// "already present" (issue #158). Without the filter, Save would see the
+// dead hash and skip re-writing the fact — leaving the namespace with no
+// live copy of an entry the user just asked to save.
 func (m *lt) dedupHashes(ctx context.Context, scope Scope, hashes []string) (map[string]string, error) {
 	out := make(map[string]string, len(hashes))
 	if len(hashes) == 0 {
@@ -37,7 +43,10 @@ func (m *lt) dedupHashes(ctx context.Context, scope Scope, hashes []string) (map
 		in = append(in, h)
 	}
 	resp, err := m.idx.List(ctx, ns, retrieval.ListRequest{
-		Filter:   retrieval.Filter{In: map[string][]any{MetaContentHash: in}},
+		Filter: MergeFilters(
+			retrieval.Filter{In: map[string][]any{MetaContentHash: in}},
+			TombstoneFilter(),
+		),
 		PageSize: len(hashes),
 	})
 	if err != nil || resp == nil {

--- a/sdk/recall/projection.go
+++ b/sdk/recall/projection.go
@@ -1,0 +1,322 @@
+package recall
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/GizClaw/flowcraft/sdk/retrieval"
+)
+
+// Projection is a derived view of the primary recall index.
+//
+// Side stores (EntityStore today; GraphStore / SearchAnalytics
+// tomorrow) implement Projection so the [Reconciler] can keep them
+// eventually consistent with the primary index. The architectural
+// contract is:
+//
+//   - The primary recall index is the SOURCE OF TRUTH for entries.
+//     A fact exists iff its retrieval.Doc is alive (not tombstoned,
+//     not expired) under the entry namespace.
+//   - A Projection is a DERIVED VIEW. It accelerates one query
+//     pattern (the entity-link inverted index is the canonical
+//     example). It MAY lag, it MAY be missing entries, it MAY
+//     retain stale entries — but reads must validate against the
+//     primary and the [Reconciler] eventually converges the view.
+//   - Write paths (Save, Add, Rollback, TTL sweeper, resolver
+//     OpDelete, …) DO NOT instrument Projection updates. Only the
+//     Reconciler does. This is the durable form of "the entity
+//     sibling namespace can be rebuilt offline by replaying the
+//     entries"; every Reconciler pass IS such a replay.
+//
+// Implementations MUST be idempotent: Project called twice with the
+// same scope + entries produces the same view state as once. Forget
+// called for an ID that the view never had is a no-op.
+//
+// Concurrency: Projection methods must be safe for concurrent use
+// by the Reconciler loop and by ad-hoc [Memory.SyncSideStores]
+// callers.
+type Projection interface {
+	// Name is used for logs / metrics and to distinguish multiple
+	// projections registered against the same Memory.
+	Name() string
+
+	// Project conveys "these entries currently exist (alive, not
+	// tombstoned/expired) in the primary index, under scope". The
+	// projection MUST treat this as the current truth for the
+	// scope: it may upsert new edges, refresh existing ones, and
+	// — when paired with [ProjectionInspector.AllEntryIDs] — drop
+	// references the projection retains but that are absent from
+	// the provided entries. Idempotent.
+	Project(ctx context.Context, scope Scope, entries []Entry) error
+
+	// Forget conveys "these entry IDs are no longer alive in
+	// primary (deleted, expired, or rolled back to before they
+	// existed)". The projection MUST drop any references to these
+	// IDs. Idempotent on (scope, id) — calling Forget for an ID
+	// the projection never knew about is a no-op.
+	Forget(ctx context.Context, scope Scope, entryIDs []string) error
+}
+
+// ProjectionInspector is an optional extension to [Projection]. The
+// Reconciler calls AllEntryIDs to learn which entry IDs the view
+// currently retains, so it can compute the set difference against
+// the primary's alive set and call [Projection.Forget] on the
+// stale IDs.
+//
+// Projections that do not implement this interface only get
+// additive sync from the Reconciler (Project on alive entries);
+// stale references in the view will not be cleaned up
+// automatically — those projections must invoke Forget themselves
+// from the write paths they care about.
+type ProjectionInspector interface {
+	// AllEntryIDs returns the union of entry IDs the projection
+	// currently references under scope. Ordering is unspecified.
+	// Duplicates are tolerated (the Reconciler dedupes).
+	AllEntryIDs(ctx context.Context, scope Scope) ([]string, error)
+}
+
+// Reconciler is the background loop that brings each registered
+// [Projection] into eventual consistency with the primary recall
+// index. It owns the contract spelled out in the Projection godoc:
+// projections lag, but the lag is bounded by the reconcile
+// interval, and reads remain correct because the read path filters
+// against the primary independently.
+//
+// Reconcile is per-namespace: the loop walks every namespace known
+// to the configured [NamespaceRegistry], collects the alive
+// entries under each, and asks every projection to (1) accept the
+// alive set via Project and (2) drop any retained IDs that are not
+// in the alive set via Forget.
+//
+// The Reconciler is constructed and owned by [Memory]; user code
+// interacts with it only through [Memory.SyncSideStores], which
+// runs one synchronous tick (used by tests and by callers who need
+// 0-lag after a known write).
+type Reconciler struct {
+	primary     retrieval.Index
+	projections []Projection
+	registry    NamespaceRegistry
+	interval    time.Duration
+	batchSize   int
+	now         func() time.Time
+	log         func(format string, args ...any)
+
+	stopCh chan struct{}
+	wg     sync.WaitGroup
+}
+
+// newReconciler is the package-internal constructor. Callers go
+// through [Memory] (recall.New); the Reconciler is wired into the
+// Memory worker pool and shares its lifecycle.
+func newReconciler(
+	primary retrieval.Index,
+	projections []Projection,
+	registry NamespaceRegistry,
+	interval time.Duration,
+	now func() time.Time,
+	log func(format string, args ...any),
+) *Reconciler {
+	if log == nil {
+		log = func(string, ...any) {}
+	}
+	if now == nil {
+		now = time.Now
+	}
+	if interval <= 0 {
+		interval = defaultReconcileInterval
+	}
+	return &Reconciler{
+		primary:     primary,
+		projections: projections,
+		registry:    registry,
+		interval:    interval,
+		batchSize:   defaultReconcileBatch,
+		now:         now,
+		log:         log,
+		stopCh:      make(chan struct{}),
+	}
+}
+
+// defaultReconcileInterval is the gap between background ticks
+// when WithReconcileInterval is not set. 5 minutes is a compromise
+// between freshness (#171 Add-then-Recall sees the new entry
+// within 5 min) and cost (one full namespace scan per tick).
+// Operators with large active scope counts should raise this.
+const defaultReconcileInterval = 5 * time.Minute
+
+// defaultReconcileBatch caps how many entries the Reconciler holds
+// in memory per scope while computing the diff. Set high enough
+// that LoCoMo-shaped (~250 entries/scope) scopes fit in one pass
+// while still bounding RSS for production-scale namespaces.
+const defaultReconcileBatch = 2000
+
+// start launches the background tick goroutine. Memory.Close stops
+// the loop via the shared stop channel.
+func (r *Reconciler) start() {
+	if r == nil || len(r.projections) == 0 {
+		return
+	}
+	r.wg.Add(1)
+	go r.loop()
+}
+
+// stop cancels the tick goroutine and waits for it to drain.
+func (r *Reconciler) stop() {
+	if r == nil {
+		return
+	}
+	select {
+	case <-r.stopCh:
+		// already stopped
+	default:
+		close(r.stopCh)
+	}
+	r.wg.Wait()
+}
+
+func (r *Reconciler) loop() {
+	defer r.wg.Done()
+	t := time.NewTicker(r.interval)
+	defer t.Stop()
+	for {
+		select {
+		case <-r.stopCh:
+			return
+		case <-t.C:
+			ctx, cancel := context.WithTimeout(context.Background(), r.interval)
+			r.tick(ctx)
+			cancel()
+		}
+	}
+}
+
+// tick runs one full reconcile pass across every registered
+// namespace. Errors per-scope are logged but do not abort the
+// pass — a single misbehaving scope must not stall the others.
+func (r *Reconciler) tick(ctx context.Context) {
+	if r == nil || r.registry == nil || len(r.projections) == 0 {
+		return
+	}
+	nss, err := r.registry.List(ctx)
+	if err != nil {
+		r.log("recall: reconcile namespaces list: %v", err)
+		return
+	}
+	for _, ns := range nss {
+		scope, ok := ScopeFromNamespace(ns)
+		if !ok {
+			// Sibling / unknown namespace (e.g. "..__entities");
+			// skip — the entry namespace's reconcile will cover it.
+			continue
+		}
+		if err := r.reconcileScope(ctx, scope); err != nil {
+			r.log("recall: reconcile scope %q: %v", ns, err)
+		}
+	}
+}
+
+// SyncScope runs one synchronous reconcile pass for a single
+// scope. Exposed via [Memory.SyncSideStores] so callers that just
+// performed a write outside the eager hot path (Add, Rollback,
+// Forget, TTL sweep, resolver OpDelete) can flush side stores to
+// 0-lag instead of waiting for the next background tick.
+func (r *Reconciler) SyncScope(ctx context.Context, scope Scope) error {
+	if r == nil || len(r.projections) == 0 {
+		return nil
+	}
+	return r.reconcileScope(ctx, scope)
+}
+
+func (r *Reconciler) reconcileScope(ctx context.Context, scope Scope) error {
+	ns := NamespaceFor(scope)
+	// 1. Pull alive entries from primary. "Alive" = not tombstoned
+	// AND not expired-as-of-now. Reconciler MUST use the same
+	// filter Recall uses (TombstoneFilter + ExpireFilter); a
+	// projection that thinks an expired doc is still alive would
+	// be more wrong than a projection that thinks an alive doc is
+	// stale.
+	now := r.now()
+	filter := MergeFilters(TombstoneFilter(), ExpireFilter(now))
+	aliveDocs, err := listAll(ctx, r.primary, ns, filter, r.batchSize)
+	if err != nil {
+		return err
+	}
+	aliveEntries := make([]Entry, 0, len(aliveDocs))
+	aliveIDs := make(map[string]struct{}, len(aliveDocs))
+	for _, d := range aliveDocs {
+		e := DocToEntry(d)
+		aliveEntries = append(aliveEntries, e)
+		aliveIDs[e.ID] = struct{}{}
+	}
+	// 2. Fan out to projections.
+	for _, p := range r.projections {
+		if err := p.Project(ctx, scope, aliveEntries); err != nil {
+			r.log("recall: projection %s Project: %v", p.Name(), err)
+		}
+		// 3. Diff against the projection's retained IDs and Forget
+		// anything the projection has that primary does not.
+		insp, ok := p.(ProjectionInspector)
+		if !ok {
+			continue
+		}
+		retained, err := insp.AllEntryIDs(ctx, scope)
+		if err != nil {
+			r.log("recall: projection %s AllEntryIDs: %v", p.Name(), err)
+			continue
+		}
+		var stale []string
+		seen := make(map[string]struct{}, len(retained))
+		for _, id := range retained {
+			if _, ok := seen[id]; ok {
+				continue
+			}
+			seen[id] = struct{}{}
+			if _, alive := aliveIDs[id]; !alive {
+				stale = append(stale, id)
+			}
+		}
+		if len(stale) > 0 {
+			if err := p.Forget(ctx, scope, stale); err != nil {
+				r.log("recall: projection %s Forget: %v", p.Name(), err)
+			}
+		}
+	}
+	return nil
+}
+
+// listAll pages through retrieval.Index.List collecting every doc
+// matching the filter. Used by the Reconciler — its caller bounds
+// memory implicitly by the per-scope alive-entry count, which for
+// LoCoMo-shaped workloads is ~250 per scope. Production deployments
+// with >batchSize entries per scope should consider raising
+// WithReconcileBatch (currently unexposed; revisit when needed).
+func listAll(
+	ctx context.Context,
+	idx retrieval.Index,
+	ns string,
+	filter retrieval.Filter,
+	batchSize int,
+) ([]retrieval.Doc, error) {
+	var out []retrieval.Doc
+	var page string
+	for {
+		resp, err := idx.List(ctx, ns, retrieval.ListRequest{
+			Filter:    filter,
+			PageSize:  batchSize,
+			PageToken: page,
+		})
+		if err != nil {
+			return nil, err
+		}
+		if resp == nil {
+			break
+		}
+		out = append(out, resp.Items...)
+		if resp.NextPageToken == "" {
+			break
+		}
+		page = resp.NextPageToken
+	}
+	return out, nil
+}

--- a/sdk/recall/projection_test.go
+++ b/sdk/recall/projection_test.go
@@ -1,0 +1,455 @@
+package recall_test
+
+import (
+	"context"
+	"sort"
+	"testing"
+	"time"
+
+	"github.com/GizClaw/flowcraft/sdk/llm"
+	"github.com/GizClaw/flowcraft/sdk/model"
+	"github.com/GizClaw/flowcraft/sdk/recall"
+	"github.com/GizClaw/flowcraft/sdk/retrieval"
+	"github.com/GizClaw/flowcraft/sdk/retrieval/journal"
+	memidx "github.com/GizClaw/flowcraft/sdk/retrieval/memory"
+)
+
+// TestReconciler_AddBackfillsEntityStore pins issue #171: a
+// Memory.Add invocation has no eager linkEntities pass — only
+// upsertFacts does. The Reconciler must therefore make the new
+// entry visible to the entity-link inverted index after one
+// synchronous SyncSideStores tick.
+func TestReconciler_AddBackfillsEntityStore(t *testing.T) {
+	ctx := context.Background()
+	idx := memidx.New()
+	m, err := recall.New(idx,
+		recall.WithRequireUserID(),
+		recall.WithEntityStore(0),
+		// Disable the background loop so the test deterministically
+		// owns when reconciliation happens.
+		recall.WithReconcileInterval(-1),
+	)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	defer m.Close()
+
+	scope := recall.Scope{RuntimeID: "rt1", UserID: "u1"}
+	id, err := m.Add(ctx, scope, recall.Entry{
+		Content:  "Alice met Bob at the library",
+		Entities: []string{"alice", "bob"},
+	})
+	if err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+
+	// Before reconcile the entity store has no link — Add is not
+	// eager-instrumented (issue #171's pre-fix complaint).
+	store := recall.NewIndexEntityStore(idx, recall.IndexEntityStoreOptions{})
+	if store == nil {
+		t.Skip("memidx does not satisfy DocGetter on this build")
+	}
+	got, _ := store.Lookup(ctx, scope, []string{"alice"}, 0)
+	if len(got) != 0 {
+		t.Fatalf("entity store unexpectedly populated before reconcile; got %v", got)
+	}
+
+	// One synchronous reconcile pass must converge the projection.
+	syncer, ok := m.(recall.SideStoreSyncer)
+	if !ok {
+		t.Fatalf("Memory does not implement SideStoreSyncer")
+	}
+	if err := syncer.SyncSideStores(ctx, scope); err != nil {
+		t.Fatalf("SyncSideStores: %v", err)
+	}
+	got, _ = store.Lookup(ctx, scope, []string{"alice"}, 0)
+	if len(got) != 1 || got[0] != id {
+		t.Fatalf("alice link missing post-reconcile; got %v want [%q]", got, id)
+	}
+	gotBob, _ := store.Lookup(ctx, scope, []string{"bob"}, 0)
+	if len(gotBob) != 1 || gotBob[0] != id {
+		t.Fatalf("bob link missing post-reconcile; got %v want [%q]", gotBob, id)
+	}
+}
+
+// TestReconciler_RollbackPrunesEntityStore pins issue #164: an
+// Auditable.Rollback that removes an entry from the primary index
+// leaves the entity-link inverted index pointing at the now-dead
+// id. The Reconciler must drop those references during a sync.
+func TestReconciler_RollbackPrunesEntityStore(t *testing.T) {
+	ctx := context.Background()
+	idx := memidx.New()
+	resp := `[{"content":"Alice loves jazz","entities":["Alice","jazz"]}]`
+	m, err := recall.New(idx,
+		recall.WithRequireUserID(),
+		recall.WithLLM(&stubLLM{resp: resp}),
+		recall.WithEntityStore(0),
+		recall.WithJournal(journal.NewMemoryJournal()),
+		recall.WithReconcileInterval(-1),
+	)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	defer m.Close()
+
+	scope := recall.Scope{RuntimeID: "rt1", UserID: "u1"}
+	res, err := m.Save(ctx, scope, []llm.Message{
+		{Role: model.RoleUser, Parts: []model.Part{{Type: model.PartText, Text: "Alice loves jazz"}}},
+	})
+	if err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	if len(res.EntryIDs) == 0 {
+		t.Fatalf("Save returned no entries")
+	}
+	id := res.EntryIDs[0]
+
+	// Pre-rollback: store has the link.
+	store := recall.NewIndexEntityStore(idx, recall.IndexEntityStoreOptions{})
+	if store == nil {
+		t.Skip("memidx does not satisfy DocGetter on this build")
+	}
+	got, _ := store.Lookup(ctx, scope, []string{"alice"}, 0)
+	if len(got) != 1 {
+		t.Fatalf("pre-rollback alice link missing; got %v", got)
+	}
+
+	// Roll back to a time before the entry existed — Auditable
+	// removes it from primary but does NOT touch the entity store
+	// today (issue #164).
+	aud := m.(recall.Auditable)
+	if err := aud.Rollback(ctx, scope, id, time.Time{}); err != nil {
+		t.Fatalf("Rollback: %v", err)
+	}
+	// Direct probe: pre-fix #164 leaves the link pointing at the
+	// dead id. We don't assert on that state — only that the
+	// post-reconcile state is clean.
+
+	if err := m.(recall.SideStoreSyncer).SyncSideStores(ctx, scope); err != nil {
+		t.Fatalf("SyncSideStores: %v", err)
+	}
+	got, _ = store.Lookup(ctx, scope, []string{"alice"}, 0)
+	for _, gid := range got {
+		if gid == id {
+			t.Fatalf("rolled-back id %q still referenced by entity store", id)
+		}
+	}
+}
+
+// TestReconciler_TombstonedEntryPrunedFromEntityStore pins issue
+// #169: the resolver OpDelete branch writes MetaTombstone to the
+// old entry but does not call EntityStore.Forget. After one
+// reconcile pass the projection must drop the tombstoned id.
+func TestReconciler_TombstonedEntryPrunedFromEntityStore(t *testing.T) {
+	ctx := context.Background()
+	idx := memidx.New()
+	ex := &scriptedExtractor{
+		facts: [][]recall.ExtractedFact{
+			{{Content: "user has a cat named Mittens", Entities: []string{"mittens", "cat"}}},
+			{{Content: "user does NOT have a cat", Entities: []string{"cat"}}},
+		},
+	}
+	var firstID string
+	resolver := &fakeResolver{}
+	m, err := recall.New(idx,
+		recall.WithRequireUserID(),
+		recall.WithExtractor(ex),
+		recall.WithUpdateResolver(resolver, 5),
+		recall.WithEntityStore(0),
+		recall.WithReconcileInterval(-1),
+	)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	defer m.Close()
+
+	scope := newScope()
+	firstIDs := saveText(t, m, scope, "I have a cat named Mittens")
+	firstID = firstIDs[0]
+	// Wire the second Save to fire OpDelete against firstID.
+	resolver.fn = func(batch recall.ResolveBatch) ([]recall.ResolveAction, error) {
+		return []recall.ResolveAction{{
+			Op:       recall.OpDelete,
+			SourceID: firstSourceID(t, batch),
+			TargetID: firstID,
+		}}, nil
+	}
+	saveText(t, m, scope, "I do not have a cat anymore")
+
+	store := recall.NewIndexEntityStore(idx, recall.IndexEntityStoreOptions{})
+	if store == nil {
+		t.Skip("memidx does not satisfy DocGetter on this build")
+	}
+	if err := m.(recall.SideStoreSyncer).SyncSideStores(ctx, scope); err != nil {
+		t.Fatalf("SyncSideStores: %v", err)
+	}
+	got, _ := store.Lookup(ctx, scope, []string{"mittens"}, 0)
+	for _, gid := range got {
+		if gid == firstID {
+			t.Fatalf("tombstoned id %q still referenced by entity store", firstID)
+		}
+	}
+}
+
+// TestDedupHashes_IgnoresTombstoned pins issue #158: a content
+// hash that exists ONLY on tombstoned (logically deleted) docs
+// must not block re-Save of the same content. The fix composes
+// TombstoneFilter into dedupHashes' List filter.
+func TestDedupHashes_IgnoresTombstoned(t *testing.T) {
+	ctx := context.Background()
+	idx := memidx.New()
+	resp := `[{"content":"user owns a labrador named Lucky","entities":["lucky"]}]`
+	m, err := recall.New(idx,
+		recall.WithRequireUserID(),
+		recall.WithLLM(&stubLLM{resp: resp}),
+	)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	defer m.Close()
+
+	scope := recall.Scope{RuntimeID: "rt1", UserID: "u1"}
+	first, err := m.Save(ctx, scope, []llm.Message{
+		{Role: model.RoleUser, Parts: []model.Part{{Type: model.PartText, Text: "I own a labrador named Lucky"}}},
+	})
+	if err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	if len(first.EntryIDs) == 0 {
+		t.Fatalf("Save returned no entries")
+	}
+	firstID := first.EntryIDs[0]
+	// Tombstone the entry directly (the OpDelete resolver path
+	// achieves the same metadata state).
+	ns := recall.NamespaceFor(scope)
+	doc, ok, err := idx.Get(ctx, ns, firstID)
+	if err != nil || !ok {
+		t.Fatalf("Get: ok=%v err=%v", ok, err)
+	}
+	if doc.Metadata == nil {
+		doc.Metadata = map[string]any{}
+	}
+	doc.Metadata[recall.MetaTombstone] = true
+	if err := idx.Upsert(ctx, ns, []retrieval.Doc{doc}); err != nil {
+		t.Fatalf("Upsert: %v", err)
+	}
+	// Save the same fact again — pre-fix, dedupHashes sees the
+	// tombstoned hash and returns its ID, so the second Save
+	// short-circuits and writes nothing. The row stays tombstoned
+	// (invisible to Recall) even though the user just asked to
+	// save it.
+	//
+	// With #158's fix, dedupHashes ignores tombstoned rows, the
+	// upsertFacts path proceeds, and the deterministic entry ID
+	// (which is content-derived) collides on the same row — the
+	// Upsert REPLACES the tombstoned doc with a fresh one whose
+	// metadata no longer carries MetaTombstone. Recall sees the
+	// fact again.
+	second, err := m.Save(ctx, scope, []llm.Message{
+		{Role: model.RoleUser, Parts: []model.Part{{Type: model.PartText, Text: "I own a labrador named Lucky"}}},
+	})
+	if err != nil {
+		t.Fatalf("Save #2: %v", err)
+	}
+	if len(second.EntryIDs) == 0 {
+		t.Fatalf("second Save returned no IDs; dedup may still be tombstone-blind")
+	}
+	revived, ok, err := idx.Get(ctx, ns, firstID)
+	if err != nil || !ok {
+		t.Fatalf("post-Save row missing: ok=%v err=%v", ok, err)
+	}
+	if v, _ := revived.Metadata[recall.MetaTombstone].(bool); v {
+		t.Fatalf("post-Save row is still tombstoned; #158 fix is not effective. metadata=%v", revived.Metadata)
+	}
+}
+
+// TestSupersedeOrder_NewDocUpsertedFirst pins issue #167: the
+// supersede tagging step must run AFTER the new doc lands so an
+// Upsert failure can never leave older entries pointing at an id
+// that does not exist.
+//
+// We assert the *order* indirectly: after a successful Save the
+// new entry IS in the index (older slot-mate's MetaSupersededBy
+// references a live id, not a dangling one). Coupled with the
+// existing TestResolver_UpdateMarksSuperseded assertion that the
+// supersede tag still lands, this proves the reorder preserves
+// the correctness invariant.
+func TestSupersedeOrder_NewDocUpsertedFirst(t *testing.T) {
+	ctx := context.Background()
+	idx := memidx.New()
+	ex := &scriptedExtractor{
+		facts: [][]recall.ExtractedFact{
+			{{Subject: "user", Predicate: "pet_name", Content: "user's pet is named Lucky", Entities: []string{"lucky"}}},
+			{{Subject: "user", Predicate: "pet_name", Content: "user's pet is named Max", Entities: []string{"max"}}},
+		},
+	}
+	m, err := recall.New(idx,
+		recall.WithRequireUserID(),
+		recall.WithExtractor(ex),
+	)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	defer m.Close()
+
+	scope := newScope()
+	firstIDs := saveText(t, m, scope, "I named my pet Lucky")
+	if len(firstIDs) == 0 {
+		t.Fatalf("first Save: no entries")
+	}
+	secondIDs := saveText(t, m, scope, "Actually I named my pet Max")
+	if len(secondIDs) == 0 {
+		t.Fatalf("second Save: no entries")
+	}
+	newID := secondIDs[0]
+	// The new doc MUST be alive in the index — proves Upsert
+	// happened before supersede tagged the old doc.
+	if _, ok, err := idx.Get(ctx, recall.NamespaceFor(scope), newID); err != nil || !ok {
+		t.Fatalf("new doc %q missing from index; ok=%v err=%v", newID, ok, err)
+	}
+	// The old doc points at the new id.
+	old, ok, err := idx.Get(ctx, recall.NamespaceFor(scope), firstIDs[0])
+	if err != nil || !ok {
+		t.Fatalf("old doc missing; ok=%v err=%v", ok, err)
+	}
+	got, _ := old.Metadata[recall.MetaSupersededBy].(string)
+	if got != newID {
+		t.Fatalf("old doc superseded_by = %q; want %q", got, newID)
+	}
+}
+
+// TestReconciler_NoBackgroundLoopWhenIntervalNegative checks that
+// WithReconcileInterval(-1) really disables the background ticker
+// so tests can drive reconciliation deterministically and the
+// option behaves the way its godoc claims.
+func TestReconciler_NoBackgroundLoopWhenIntervalNegative(t *testing.T) {
+	idx := memidx.New()
+	m, err := recall.New(idx,
+		recall.WithRequireUserID(),
+		recall.WithEntityStore(0),
+		recall.WithReconcileInterval(-1),
+	)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	// Just close — the absence of a hanging background goroutine
+	// is asserted by Close completing without timing out. (The
+	// recall package's Close already Wait()s on reconciler.wg, so
+	// any leaked goroutine would block the test forever.)
+	if err := m.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+}
+
+// TestReconciler_TTLSweepPrunesEntityStore pins issue #151: the
+// TTL sweeper hard-deletes expired entries from the primary index
+// without notifying the entity store; the Reconciler must drop
+// the dead refs on the next sync pass.
+func TestReconciler_TTLSweepPrunesEntityStore(t *testing.T) {
+	ctx := context.Background()
+	idx := memidx.New()
+	m, err := recall.New(idx,
+		recall.WithRequireUserID(),
+		recall.WithEntityStore(0),
+		recall.WithReconcileInterval(-1),
+	)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	defer m.Close()
+
+	scope := recall.Scope{RuntimeID: "rt1", UserID: "u1"}
+	past := time.Now().Add(-time.Hour)
+	id, err := m.Add(ctx, scope, recall.Entry{
+		Content:   "Alice met Bob",
+		Entities:  []string{"alice"},
+		ExpiresAt: &past, // already expired
+	})
+	if err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+	// Seed the entity store via a sync (Add does not eager-link;
+	// the reconciler is what populates it).
+	if err := m.(recall.SideStoreSyncer).SyncSideStores(ctx, scope); err != nil {
+		t.Fatalf("SyncSideStores #1: %v", err)
+	}
+	// Sweep deletes the expired doc from primary directly.
+	if sw, ok := m.(interface {
+		SweepNamespace(context.Context, string) error
+	}); ok {
+		if err := sw.SweepNamespace(ctx, recall.NamespaceFor(scope)); err != nil {
+			t.Fatalf("Sweep: %v", err)
+		}
+	} else {
+		t.Skip("Memory does not expose SweepNamespace on this build")
+	}
+	// Verify primary index dropped the entry.
+	if _, ok, _ := idx.Get(ctx, recall.NamespaceFor(scope), id); ok {
+		t.Fatalf("primary still has expired entry %q", id)
+	}
+	// Second sync — the inspector diff must Forget the dead id.
+	if err := m.(recall.SideStoreSyncer).SyncSideStores(ctx, scope); err != nil {
+		t.Fatalf("SyncSideStores #2: %v", err)
+	}
+	store := recall.NewIndexEntityStore(idx, recall.IndexEntityStoreOptions{})
+	if store == nil {
+		t.Skip("memidx does not satisfy DocGetter on this build")
+	}
+	got, _ := store.Lookup(ctx, scope, []string{"alice"}, 0)
+	for _, gid := range got {
+		if gid == id {
+			t.Fatalf("expired id %q still referenced by entity store post-sweep", id)
+		}
+	}
+}
+
+// TestEntityStoreProjection_AllEntryIDsScansNamespace asserts the
+// inspector returns the union of every entity row's linked ids
+// for the scope. Used by the Reconciler to compute the stale set
+// (retained - alive).
+func TestEntityStoreProjection_AllEntryIDsScansNamespace(t *testing.T) {
+	ctx := context.Background()
+	idx := memidx.New()
+	resp := `[{"content":"Alice likes coffee","entities":["alice","coffee"]}]`
+	m, err := recall.New(idx,
+		recall.WithRequireUserID(),
+		recall.WithLLM(&stubLLM{resp: resp}),
+		recall.WithEntityStore(0),
+		recall.WithReconcileInterval(-1),
+	)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	defer m.Close()
+
+	scope := recall.Scope{RuntimeID: "rt1", UserID: "u1"}
+	res, err := m.Save(ctx, scope, []llm.Message{
+		{Role: model.RoleUser, Parts: []model.Part{{Type: model.PartText, Text: "I like Alice"}}},
+	})
+	if err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	if len(res.EntryIDs) == 0 {
+		t.Fatalf("no entries")
+	}
+	if err := m.(recall.SideStoreSyncer).SyncSideStores(ctx, scope); err != nil {
+		t.Fatalf("SyncSideStores: %v", err)
+	}
+	// After a sync the projection must retain every alive id.
+	store := recall.NewIndexEntityStore(idx, recall.IndexEntityStoreOptions{})
+	if store == nil {
+		t.Skip("memidx does not satisfy DocGetter on this build")
+	}
+	got, _ := store.Lookup(ctx, scope, []string{"alice"}, 0)
+	sort.Strings(got)
+	want := append([]string(nil), res.EntryIDs...)
+	sort.Strings(want)
+	if len(got) != len(want) {
+		t.Fatalf("alice retained ids = %v; want %v", got, want)
+	}
+	for i := range got {
+		if got[i] != want[i] {
+			t.Fatalf("alice retained ids = %v; want %v", got, want)
+		}
+	}
+}

--- a/sdk/recall/resolver.go
+++ b/sdk/recall/resolver.go
@@ -147,9 +147,22 @@ func (m *lt) runResolverBatch(
 // (per-fact ranking is preserved on first occurrence). Recall errors
 // are logged but do not abort the batch — the resolver still runs on
 // whatever candidates were collected.
+//
+// The new-fact entries (already written to the primary index by the
+// upstream upsertFacts step — see issue #167 reorder) are filtered
+// out so the resolver does not see them as candidates of themselves.
+// Without this filter, every Save's resolver call would consume the
+// newly-written facts as its own contradiction targets and produce
+// self-supersede actions on each new entry.
 func (m *lt) gatherResolverCandidates(
 	ctx context.Context, scope Scope, newFacts []ResolveNewFact,
 ) []Hit {
+	newIDs := make(map[string]struct{}, len(newFacts))
+	for _, nf := range newFacts {
+		if nf.EntryID != "" {
+			newIDs[nf.EntryID] = struct{}{}
+		}
+	}
 	seen := make(map[string]struct{})
 	var out []Hit
 	for _, nf := range newFacts {
@@ -162,6 +175,9 @@ func (m *lt) gatherResolverCandidates(
 			continue
 		}
 		for _, h := range hits {
+			if _, isNew := newIDs[h.Entry.ID]; isNew {
+				continue
+			}
 			if _, dup := seen[h.Entry.ID]; dup {
 				continue
 			}

--- a/sdk/recall/save.go
+++ b/sdk/recall/save.go
@@ -319,20 +319,19 @@ func (m *lt) Add(ctx context.Context, scope Scope, e Entry) (string, error) {
 	d.Metadata[MetaContentHash] = contentHash(scope, e.Content)
 	ns := NamespaceFor(scope)
 	m.rememberNamespace(ctx, ns)
-	// Slot supersede runs before the new doc lands so the new entry is
-	// never returned by supersedeBySlot's List(). The defensive
-	// "d.ID == newID" guard inside supersedeBySlot covers the race-free
-	// case where the new doc has already been inserted (eg async
-	// retry), but running before Upsert avoids it entirely in the
-	// happy path. Matches the ordering in upsertFacts.
-	if m.cfg.slotMerge && entrySlotEligible(e.Subject, e.Predicate) {
-		m.supersedeBySlot(ctx, scope, e.ID,
-			ExtractedFact{Subject: e.Subject, Predicate: e.Predicate}, now)
-	}
 	if err := m.idx.Upsert(ctx, ns, []retrieval.Doc{d}); err != nil {
 		span.RecordError(err)
 		addTotal.Add(ctx, 1, metric.WithAttributes(attribute.String("outcome", "fail"), attribute.String("reason", "upsert")))
 		return "", err
+	}
+	// Slot supersede runs AFTER the new doc lands (issue #167). The
+	// "d.ID == newID" guard inside supersedeBySlot keeps the new
+	// entry from super-seding itself when the post-upsert List sees
+	// it. Running after Upsert means an Upsert failure can never
+	// leave orphan MetaSupersededBy pointers on older slot-mates.
+	if m.cfg.slotMerge && entrySlotEligible(e.Subject, e.Predicate) {
+		m.supersedeBySlot(ctx, scope, e.ID,
+			ExtractedFact{Subject: e.Subject, Predicate: e.Predicate}, now)
 	}
 	span.SetAttributes(
 		attribute.String("runtime_id", scope.RuntimeID),
@@ -475,15 +474,41 @@ func (m *lt) upsertFacts(
 		}
 	}
 
-	// 3. Supersede channels (slot + vector) -------------------------------
+	// 3. Upsert new docs FIRST (issue #167) -------------------------------
+	// Supersede channels and the LLM update resolver write
+	// MetaSupersededBy / MetaTombstone metadata on OLD docs that
+	// reference the NEW entry IDs we are about to write. Running
+	// those steps BEFORE Upsert would leave dangling pointers on
+	// the index if the Upsert below fails: old docs already point
+	// at entry IDs that never existed.
+	//
+	// Reordering: write the new doc batch first, THEN run the
+	// supersede + resolver passes. The self-skip guards inside
+	// supersedeBySlot / supersedeNeighbours / runResolverBatch
+	// (each checks d.ID == newID) guarantee the new entries are
+	// not super-seded by themselves on the post-upsert scan, so
+	// correctness is preserved while #167's "Upsert-fail leaves
+	// orphan supersede tags" hazard goes away.
+	docs := make([]retrieval.Doc, len(plans))
+	for i, p := range plans {
+		docs[i] = p.doc
+	}
+	if err := m.idx.Upsert(ctx, ns, docs); err != nil {
+		return nil, err
+	}
+
+	// 4. Supersede channels (slot + vector) -------------------------------
 	// supersedeNeighbours dispatches between the two channels and
 	// honours WithoutSlotChannel / WithoutSoftMerge independently;
-	// always call it and let the dispatcher decide.
+	// always call it and let the dispatcher decide. Failures here
+	// leave the new entries written and the older entries
+	// un-superseded — the worst case is recall returning a near-
+	// duplicate, which is preferable to a dangling pointer.
 	for _, p := range plans {
 		m.supersedeNeighbours(ctx, scope, p.entry.ID, p.fact, p.vec, now)
 	}
 
-	// 4. LLM update resolver (opt-in fallback) -----------------------------
+	// 5. LLM update resolver (opt-in fallback) -----------------------------
 	// The resolver runs at most once per Save with the full batch of
 	// non-slot facts so it can reason about combined contradictions
 	// (e.g. divorce + remarriage in the same turn). Slot-eligible facts
@@ -500,15 +525,6 @@ func (m *lt) upsertFacts(
 		if len(batch) > 0 {
 			m.runResolverBatch(ctx, scope, batch, now)
 		}
-	}
-
-	// 5. Upsert new docs ---------------------------------------------------
-	docs := make([]retrieval.Doc, len(plans))
-	for i, p := range plans {
-		docs[i] = p.doc
-	}
-	if err := m.idx.Upsert(ctx, ns, docs); err != nil {
-		return nil, err
 	}
 
 	// 6. Entity-link inverted index ---------------------------------------


### PR DESCRIPTION
## Summary

First PR of the architectural-debt plan in `internal-docs/recall-architectural-debt-2026-05-15.md` (Cluster A + the two specific write-path fixes). Frames the EntityStore as a derived view of the primary recall index and adds a `Projection` / `Reconciler` pair that keeps it (and future graph / analytics views) eventually consistent — new write paths no longer need to remember to instrument side-store writes.

- **Pattern 1: Projection + Reconciler.** `sdk/recall/projection.go` defines the interface and the per-namespace tick loop; `sdk/recall/entity_projection.go` wraps the existing `EntityStore` (including the new `AllEntryIDs` inspector) as a `Projection`. The Reconciler diffs alive-from-primary vs retained-by-projection and fans out `Project` / `Forget` accordingly. Background interval is configurable via `WithReconcileInterval` (default 5min; negative disables the loop but keeps the synchronous `Memory.SyncSideStores` entry point alive for tests and ad-hoc flushes).
- **#167 fix:** `upsertFacts` and `Memory.Add` now run supersede tagging + resolver actions **after** `idx.Upsert` succeeds. `gatherResolverCandidates` additionally filters `newFacts` ids so the resolver does not contradict its own write. Self-skip guards on the supersede paths were already in place.
- **#158 fix:** `dedupHashes` composes `TombstoneFilter` into its `List` query so a hash that lives only on a tombstoned doc no longer short-circuits a re-Save.

The eager `linkEntities` call inside `upsertFacts` and the eager `entityStore.Forget` inside `Memory.Forget` are retained as hot-path optimisations; `Link` / `Forget` are idempotent so they compose cleanly with the Reconciler's replay. Pure reconciler covers everything else (`Add`, `Rollback`, `Sweeper`, resolver `OpDelete`, …).

Closes #151
Closes #158
Closes #164
Closes #167
Closes #169
Closes #171

## Test plan

- [x] `go test ./sdk/... ./sdkx/...` — green
- [x] `go vet ./sdk/... ./sdkx/... ./eval/...` — clean
- [x] New regression tests pinned in `sdk/recall/projection_test.go`:
  - `TestReconciler_AddBackfillsEntityStore` (#171)
  - `TestReconciler_RollbackPrunesEntityStore` (#164)
  - `TestReconciler_TombstonedEntryPrunedFromEntityStore` (#169)
  - `TestReconciler_TTLSweepPrunesEntityStore` (#151)
  - `TestDedupHashes_IgnoresTombstoned` (#158)
  - `TestSupersedeOrder_NewDocUpsertedFirst` (#167)
  - `TestReconciler_NoBackgroundLoopWhenIntervalNegative`
  - `TestEntityStoreProjection_AllEntryIDsScansNamespace`

Made with [Cursor](https://cursor.com)