### PR TITLE
[skip-tag] feat(recall): unify Save and handleJob write paths via executeWrite pipeline

### DIFF
--- a/sdk/recall/jobs.go
+++ b/sdk/recall/jobs.go
@@ -294,14 +294,27 @@ func (m *lt) worker() {
 }
 
 // handleJob runs one leased job under a per-job context derived from
-// workerCtx with the configured timeout. Two failure modes share the
-// retry path:
+// workerCtx with the configured timeout. The durable validate →
+// extract → upsert portion goes through the shared [executeWrite]
+// pipeline so the async path cannot drift from the sync ([Save]) one.
 //
-//  1. extractor / upsert returned an error → failOrRetry as before.
-//  2. ctx was canceled (timeout or Close) → ctx.Err() flows through
-//     extractor's return value and lands in failOrRetry too. The job
-//     is rescheduled with a short backoff so a transient cancel does
-//     not advance attempts beyond the cap on shutdown.
+// Failure routing has three modes:
+//
+//  1. [writeStageError.Permanent] (validate stage today) → the
+//     payload will never succeed under the current policy. Mark Fail
+//     immediately so the queue does not waste retries on a payload
+//     that was, e.g., enqueued before requireUserID was tightened
+//     (issue #165) or originated from a direct queue Enqueue that
+//     bypassed SaveAsync.
+//  2. extractor / upsert returned a transient error → failOrRetry as
+//     before. Includes ctx.Err() flowing through extractor on timeout
+//     / Close, which is rescheduled with a short backoff so a
+//     transient cancel does not advance attempts beyond the cap.
+//  3. success → append history on a fresh bookkeeping ctx, then
+//     Complete. Both bookkeeping calls deliberately run on a fresh
+//     ctx (not jobCtx) so a workerCtx cancel during this last-mile
+//     window does not skip the history append (issue #149) or orphan
+//     the job in 'running'.
 func (m *lt) handleJob(rec *JobRecord) {
 	jobCtx, cancel := context.WithTimeout(m.workerCtx, m.cfg.jobTimeout)
 	defer cancel()
@@ -311,24 +324,24 @@ func (m *lt) handleJob(rec *JobRecord) {
 		jobDuration.Record(jobCtx, time.Since(t0).Seconds())
 	}()
 
+	ids, _, err := m.executeWrite(jobCtx, rec.Payload.Scope, rec.Payload.Messages, m.cfg.now())
+	if err != nil {
+		stage := classifyWriteStage(err)
+		m.recordJobFailure(jobCtx, rec, err, stage)
+		if isPermanentWriteError(err) {
+			// Skip retry — a permanent stage failure (validate)
+			// will never succeed under the current policy.
+			bookCtx, bookCancel := context.WithTimeout(context.Background(), bookkeepingTimeout)
+			defer bookCancel()
+			if ferr := m.cfg.jobQueue.Fail(bookCtx, rec.ID, err.Error()); ferr != nil {
+				m.log("ltm.worker.fail: %v", ferr)
+			}
+			return
+		}
+		m.failOrRetry(rec, err)
+		return
+	}
 	ns := NamespaceFor(rec.Payload.Scope)
-	// Shared with the sync Save path: pulls WithRecentMessages from
-	// the history store and WithExistingFacts from saveWithCtx, so
-	// the async ingest path produces the same extractor prompts the
-	// sync path does (issue #149).
-	extractOpts := m.buildExtractOpts(jobCtx, rec.Payload.Scope, ns, rec.Payload.Messages)
-	facts, err := m.cfg.extractor.Extract(jobCtx, rec.Payload.Scope, rec.Payload.Messages, extractOpts...)
-	if err != nil {
-		m.recordJobFailure(jobCtx, rec, err, "extract")
-		m.failOrRetry(rec, err)
-		return
-	}
-	ids, err := m.upsertFacts(jobCtx, rec.Payload.Scope, rec.Payload.Messages, facts, m.cfg.now())
-	if err != nil {
-		m.recordJobFailure(jobCtx, rec, err, "upsert")
-		m.failOrRetry(rec, err)
-		return
-	}
 	// Append history AFTER persistence and BEFORE Complete. Uses an
 	// independent short-timeout bookkeeping ctx so a workerCtx cancel
 	// during this last-mile write does not skip the append, and the
@@ -355,6 +368,30 @@ func (m *lt) handleJob(rec *JobRecord) {
 		attribute.String("outcome", "succeeded"),
 		attribute.Int("attempts", rec.Attempts),
 	))
+}
+
+// classifyWriteStage extracts the phase tag from a writeStageError
+// for telemetry attribution. Returns "unknown" when the failure did
+// not originate from executeWrite — defensive default so the metric
+// dimension stays well-typed.
+func classifyWriteStage(err error) string {
+	var werr *writeStageError
+	if errors.As(err, &werr) {
+		return werr.Stage()
+	}
+	return "unknown"
+}
+
+// isPermanentWriteError reports whether the failure is a permanent
+// stage failure (currently only the validate stage). Permanent
+// failures must skip the retry loop — repeating the same JobPayload
+// through the same gate produces the same rejection.
+func isPermanentWriteError(err error) bool {
+	var werr *writeStageError
+	if errors.As(err, &werr) {
+		return werr.Permanent()
+	}
+	return false
 }
 
 // recordJobFailure emits the OTel signal for a failed handleJob attempt.

--- a/sdk/recall/save.go
+++ b/sdk/recall/save.go
@@ -64,18 +64,16 @@ func (m *lt) validateScope(s Scope) error {
 }
 
 // Save (sync) extracts then upserts; returns generated entry IDs.
+//
+// The durable portion (validate → extract → upsert) runs through
+// the shared [executeWrite] pipeline so the sync and async
+// (handleJob) paths cannot diverge on validation, extractor
+// options, or upsert ordering. The post-success history append
+// remains here because its ctx-lifecycle differs from the async
+// caller's (sync reuses the user ctx; async uses a fresh
+// bookkeeping ctx — see handleJob for rationale).
 func (m *lt) Save(ctx context.Context, scope Scope, msgs []llm.Message) (SaveResult, error) {
-	if err := m.validateScope(scope); err != nil {
-		return SaveResult{}, err
-	}
-	ns := NamespaceFor(scope)
-	m.rememberNamespace(ctx, ns)
-	extractOpts := m.buildExtractOpts(ctx, scope, ns, msgs)
-	facts, err := m.cfg.extractor.Extract(ctx, scope, msgs, extractOpts...)
-	if err != nil {
-		return SaveResult{}, err
-	}
-	ids, err := m.upsertFacts(ctx, scope, msgs, facts, m.cfg.now())
+	ids, facts, err := m.executeWrite(ctx, scope, msgs, m.cfg.now())
 	if err != nil {
 		return SaveResult{}, err
 	}
@@ -84,7 +82,7 @@ func (m *lt) Save(ctx context.Context, scope Scope, msgs []llm.Message) (SaveRes
 	// non-fatal — the history store is a quality booster, not part
 	// of the durability contract.
 	if m.cfg.historyStore != nil {
-		m.appendHistory(ctx, ns, msgs)
+		m.appendHistory(ctx, NamespaceFor(scope), msgs)
 	}
 	return SaveResult{EntryIDs: ids, Facts: facts}, nil
 }

--- a/sdk/recall/write_pipeline.go
+++ b/sdk/recall/write_pipeline.go
@@ -1,0 +1,128 @@
+package recall
+
+import (
+	"context"
+	"time"
+
+	"github.com/GizClaw/flowcraft/sdk/llm"
+)
+
+// executeWrite is the single shared body of the sync ([Memory.Save])
+// and async ([handleJob]) ingest paths. Both callers funnel the
+// durable "validate scope → extract facts → upsert facts → append
+// history" portion through this method so any new step (a new
+// validation gate, a new pre-extract hook, a new metric attribute,
+// …) lands on BOTH surfaces by construction.
+//
+// Historical context: the two callers used to maintain parallel
+// copies of this logic. The drift surfaced as a class of bugs whose
+// canonical examples were #149 (the async path missed the
+// WithHistoryStore append) and #165 (the async path skipped
+// validateScope on consumption — a durable JobQueue adapter or a
+// post-Enqueue policy change could feed handleJob a payload the
+// configured policy now rejects).
+//
+// Error stage: failures are wrapped in [writeStageError] so callers
+// can route them to stage-specific telemetry / retry decisions
+// without re-deriving the stage from the underlying error message.
+// "validate" failures are permanent — see [writeStageError.Permanent].
+//
+// Bookkeeping ctx: executeWrite does NOT own the post-success
+// bookkeeping that follows a successful write (JobQueue.Complete,
+// success metrics, etc.). Those steps have ctx-lifecycle constraints
+// that differ between the sync and async callers — sync caller
+// reuses the user ctx; async caller uses a fresh bookkeeping ctx so
+// a workerCtx cancel does not orphan a successful job in 'running'.
+// Each caller handles its own post-success path; the durable write
+// itself uses the supplied ctx end-to-end.
+func (m *lt) executeWrite(
+	ctx context.Context,
+	scope Scope,
+	msgs []llm.Message,
+	now time.Time,
+) ([]string, []ExtractedFact, error) {
+	// 1. Validation gate — runs on BOTH paths. SaveAsync already
+	// validates at Enqueue time, but a payload that survived a
+	// durable adapter (re-decoded JobPayload), a post-Enqueue
+	// policy tighten (requireUserID flipped on), or a direct
+	// JobQueue.Enqueue call by an advanced caller would otherwise
+	// bypass the gate here at Lease time. Issue #165.
+	if err := m.validateScope(scope); err != nil {
+		return nil, nil, &writeStageError{stage: writeStageValidate, err: err}
+	}
+	ns := NamespaceFor(scope)
+	m.rememberNamespace(ctx, ns)
+	// 2. Extractor options — pulls WithRecentMessages from the
+	// history store and WithExistingFacts from saveWithCtx. Both
+	// are best-effort quality boosters; a failure inside
+	// buildExtractOpts degrades extraction but doesn't fail the
+	// write.
+	extractOpts := m.buildExtractOpts(ctx, scope, ns, msgs)
+	facts, err := m.cfg.extractor.Extract(ctx, scope, msgs, extractOpts...)
+	if err != nil {
+		return nil, nil, &writeStageError{stage: writeStageExtract, err: err}
+	}
+	// 3. Durable write — content hashing, embed batch, supersede,
+	// resolver, entity-link Link all happen inside upsertFacts.
+	ids, err := m.upsertFacts(ctx, scope, msgs, facts, now)
+	if err != nil {
+		return nil, nil, &writeStageError{stage: writeStageUpsert, err: err}
+	}
+	return ids, facts, nil
+}
+
+// writeStage enumerates the phases of [executeWrite] so callers can
+// route failures to phase-specific telemetry / retry decisions.
+type writeStage string
+
+const (
+	writeStageValidate writeStage = "validate"
+	writeStageExtract  writeStage = "extract"
+	writeStageUpsert   writeStage = "upsert"
+)
+
+// writeStageError wraps the failure of one [executeWrite] phase so
+// callers can recover the phase tag via [errors.As] without
+// pattern-matching the error message.
+//
+// Use [writeStageError.Permanent] to ask whether the failure is
+// retry-eligible — currently only "validate" failures are permanent,
+// because re-running the same JobPayload through the same gate will
+// produce the same rejection.
+type writeStageError struct {
+	stage writeStage
+	err   error
+}
+
+func (e *writeStageError) Error() string {
+	if e == nil || e.err == nil {
+		return ""
+	}
+	return e.err.Error()
+}
+
+func (e *writeStageError) Unwrap() error {
+	if e == nil {
+		return nil
+	}
+	return e.err
+}
+
+// Stage returns the phase that failed.
+func (e *writeStageError) Stage() string {
+	if e == nil {
+		return ""
+	}
+	return string(e.stage)
+}
+
+// Permanent reports whether re-running [executeWrite] with the same
+// inputs is guaranteed to fail with the same error class. Only
+// "validate" qualifies today; "extract" and "upsert" are typically
+// transient (network, content filter, index hiccup).
+func (e *writeStageError) Permanent() bool {
+	if e == nil {
+		return false
+	}
+	return e.stage == writeStageValidate
+}

--- a/sdk/recall/write_pipeline_test.go
+++ b/sdk/recall/write_pipeline_test.go
@@ -1,0 +1,153 @@
+package recall_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/GizClaw/flowcraft/sdk/llm"
+	"github.com/GizClaw/flowcraft/sdk/model"
+	"github.com/GizClaw/flowcraft/sdk/recall"
+	memidx "github.com/GizClaw/flowcraft/sdk/retrieval/memory"
+)
+
+// TestSaveAsync_HandleJobRevalidatesScope pins issue #165: a payload
+// that survives a durable JobQueue adapter or a direct queue
+// Enqueue (bypassing SaveAsync) must still go through validateScope
+// at consumption time. The unified [executeWrite] pipeline runs the
+// gate; handleJob treats a validate-stage failure as permanent and
+// dead-letters the job without retrying.
+func TestSaveAsync_HandleJobRevalidatesScope(t *testing.T) {
+	idx := memidx.New()
+	queue := recall.NewMemoryJobQueue()
+	m, err := recall.New(idx,
+		recall.WithRequireUserID(),
+		recall.WithJobQueue(queue),
+		recall.WithJobRetry(3, 10*time.Millisecond, 100*time.Millisecond),
+	)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	defer m.Close()
+
+	// Bypass SaveAsync: enqueue a payload directly into the queue
+	// with an empty UserID. SaveAsync would reject this at Enqueue;
+	// a durable adapter that snapshots an older payload, or an
+	// advanced caller talking to JobQueue directly, would not.
+	badPayload := recall.JobPayload{
+		Scope: recall.Scope{RuntimeID: "rt1"}, // missing UserID
+		Messages: []llm.Message{{
+			Role:  model.RoleUser,
+			Parts: []model.Part{{Type: model.PartText, Text: "ignored"}},
+		}},
+	}
+	id, err := queue.Enqueue(context.Background(), "ltm_rt1__global", badPayload)
+	if err != nil {
+		t.Fatalf("Enqueue: %v", err)
+	}
+
+	// Poll for the worker to consume + dead-letter the job.
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		rec, err := queue.Get(context.Background(), id)
+		if err != nil {
+			t.Fatalf("Get: %v", err)
+		}
+		if rec.State == recall.JobDead {
+			// Attempts should be 1 — the permanent-failure path
+			// skipped the retry loop entirely.
+			if rec.Attempts != 1 {
+				t.Fatalf("job dead-lettered after %d attempts; want 1 (permanent fail skips retries)", rec.Attempts)
+			}
+			if rec.LastError == "" {
+				t.Fatalf("dead job has no LastError; expected validateScope rejection")
+			}
+			return
+		}
+		if rec.State == recall.JobFailed {
+			// Earlier behaviour would land the job in Failed
+			// after maxAttempts retries. Acceptable as a less-
+			// precise signal that the gate fires — but verify it
+			// did not waste retries.
+			if rec.Attempts > 1 {
+				t.Fatalf("validate-stage failure burned %d retries; expected permanent fail-no-retry", rec.Attempts)
+			}
+			return
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	t.Fatalf("job did not dead-letter within 3s; final state never reached")
+}
+
+// TestExecuteWrite_SyncAsyncProduceSameIDs is a parity guard: the
+// sync ([Memory.Save]) and async ([Memory.SaveAsync]) paths feed the
+// SAME (scope, msgs) through the same [executeWrite] pipeline, so
+// the deterministic entry IDs they assign must be byte-identical.
+// Any future divergence — a pre-extract hook added to Save but not
+// handleJob, an extractor option dropped on one side, …  — flips
+// this assertion before it ships.
+func TestExecuteWrite_SyncAsyncProduceSameIDs(t *testing.T) {
+	ctx := context.Background()
+	resp := `[{"content":"user owns a labrador named Lucky","entities":["lucky"]}]`
+
+	// Sync path.
+	idxSync := memidx.New()
+	mSync, err := recall.New(idxSync,
+		recall.WithRequireUserID(),
+		recall.WithLLM(&stubLLM{resp: resp}),
+	)
+	if err != nil {
+		t.Fatalf("New sync: %v", err)
+	}
+	defer mSync.Close()
+
+	scope := recall.Scope{RuntimeID: "rt1", UserID: "u1"}
+	msgs := []llm.Message{{
+		Role:  model.RoleUser,
+		Parts: []model.Part{{Type: model.PartText, Text: "I own a labrador named Lucky"}},
+	}}
+	syncRes, err := mSync.Save(ctx, scope, msgs)
+	if err != nil {
+		t.Fatalf("Save sync: %v", err)
+	}
+	if len(syncRes.EntryIDs) == 0 {
+		t.Fatalf("sync Save returned no entry ids")
+	}
+
+	// Async path — fresh index and Memory so we compare ID
+	// determinism, not row collision.
+	idxAsync := memidx.New()
+	mAsync, err := recall.New(idxAsync,
+		recall.WithRequireUserID(),
+		recall.WithLLM(&stubLLM{resp: resp}),
+	)
+	if err != nil {
+		t.Fatalf("New async: %v", err)
+	}
+	defer mAsync.Close()
+
+	jobID, err := mAsync.SaveAsync(ctx, scope, msgs)
+	if err != nil {
+		t.Fatalf("SaveAsync: %v", err)
+	}
+	jc, ok := mAsync.(recall.JobController)
+	if !ok {
+		t.Fatalf("Memory does not implement JobController")
+	}
+	st, err := jc.AwaitJob(ctx, jobID, 3*time.Second)
+	if err != nil {
+		t.Fatalf("AwaitJob: %v", err)
+	}
+	if st.State != recall.JobSucceeded {
+		t.Fatalf("async job state = %s; LastError=%q", st.State, st.LastError)
+	}
+	if len(st.EntryIDs) != len(syncRes.EntryIDs) {
+		t.Fatalf("async EntryIDs len %d != sync len %d", len(st.EntryIDs), len(syncRes.EntryIDs))
+	}
+	for i := range st.EntryIDs {
+		if st.EntryIDs[i] != syncRes.EntryIDs[i] {
+			t.Fatalf("entry id divergence at [%d]: sync=%s async=%s",
+				i, syncRes.EntryIDs[i], st.EntryIDs[i])
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Second PR of the architectural-debt plan (Cluster B / Pattern 2: WritePipeline). Consolidates the durable `validate → extract → upsert` portion of `Memory.Save` (sync) and `handleJob` (async) into a single `executeWrite` method on `*lt`. Both callers funnel through the same pipeline so any new step lands on BOTH surfaces by construction — the structural fix for the class of bug whose canonical examples were #149 and #165.

- **`executeWrite` in `sdk/recall/write_pipeline.go`**: runs `validateScope → buildExtractOpts → Extract → upsertFacts` and returns `(ids, facts, error)`.
- **Stage-tagged errors**: phase failures wrap into `writeStageError` (validate / extract / upsert). `Permanent()` reports whether retry is futile (today: only validate).
- **`handleJob` retry routing**: permanent (validate) → Fail-not-Reschedule (#165); transient → existing `failOrRetry` path. Stage tag flows into the existing `recordJobFailure` telemetry attribute.
- **Post-success bookkeeping stays per-caller**: sync reuses user ctx; async handleJob uses fresh bookkeeping ctx (preserves the #149 fix).

Closes #165

## Test plan

- [x] `go test ./sdk/... ./sdkx/...` — green
- [x] `go vet ./sdk/... ./sdkx/... ./eval/...` — clean
- [x] New regression tests:
  - `TestSaveAsync_HandleJobRevalidatesScope` (#165): direct-queue Enqueue bypassing SaveAsync still gets rejected at handleJob with Fail-not-Reschedule (Attempts=1)
  - `TestExecuteWrite_SyncAsyncProduceSameIDs`: parity guard — same (scope, msgs) through Save and SaveAsync produce byte-identical deterministic entry IDs; flips on any future drift

Made with [Cursor](https://cursor.com)