### PR TITLE
[skip-tag] feat(retrieval,knowledge): capabilities via interface assertion

### DIFF
--- a/sdk/knowledge/backend/retrieval/chunk.go
+++ b/sdk/knowledge/backend/retrieval/chunk.go
@@ -412,13 +412,14 @@ func (r *RetrievalChunkRepo) searchOne(ctx context.Context, ns string, q knowled
 //
 // Mode handling:
 //   - ModeBM25:   primary path. Hits land at doc-level granularity.
-//   - ModeVector / ModeHybrid: returns errdefs.NotAvailable. The
-//     __docs namespace holds no per-doc vector (chunk vectors do
-//     not compose into a doc vector without a model choice);
-//     building doc-level vectors via mean-pool / late-chunking is
-//     tracked as a follow-up. BEIR / MS-MARCO / TREC doc-level eval
-//     suites are BM25-only, so this limitation does not affect
-//     #134's acceptance criteria.
+//   - ModeVector / ModeHybrid: BM25-only repo. The __docs namespace
+//     holds no per-doc vector (chunk vectors do not compose into a
+//     doc vector without a model choice). Use [Service.SearchDocuments]
+//     with q.Mode == ModeVector instead — it routes via the explicit
+//     [knowledge.DocVectorSearcher] capability assertion (issue #145).
+//     If called directly with a non-BM25 mode this method still
+//     surfaces errdefs.NotAvailable so external direct callers get
+//     the migration hint.
 //
 // Returned Hits have ChunkIndex = -1 and Layer = "" (doc-level
 // results have no specific chunk); Content / Sig / Metadata are
@@ -436,8 +437,10 @@ func (r *RetrievalChunkRepo) SearchDocs(ctx context.Context, q knowledge.ChunkQu
 	mode := knowledge.ResolveMode(q.Mode)
 	if mode != knowledge.ModeBM25 {
 		return nil, errdefs.NotAvailablef(
-			"knowledge/retrieval: SearchDocs supports ModeBM25 only in v1 (got %q); "+
-				"doc-level vector/hybrid is tracked as a follow-up of #134",
+			"knowledge/retrieval: SearchDocs is BM25-only (got %q); "+
+				"implement DocVectorSearcher on this repo or call "+
+				"Service.SearchDocuments which routes Vector/Hybrid via "+
+				"the explicit capability interface (#145)",
 			mode)
 	}
 	topK := q.TopK

--- a/sdk/knowledge/doc_vector_capability_test.go
+++ b/sdk/knowledge/doc_vector_capability_test.go
@@ -1,0 +1,61 @@
+package knowledge_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/GizClaw/flowcraft/sdk/errdefs"
+	"github.com/GizClaw/flowcraft/sdk/knowledge"
+)
+
+// TestService_SearchDocuments_VectorWithoutCapabilityReturnsNotAvailable
+// pins issue #145. Pre-fix, requesting ModeVector / ModeHybrid against
+// a chunk repo that only supports doc-level BM25 surfaced a
+// NotAvailable error from deep inside SearchDocs. The architectural
+// fix lifts the capability check to the service layer via type
+// assertion against the new [knowledge.DocVectorSearcher] interface,
+// so the error is clear and discoverable BEFORE any backend call.
+func TestService_SearchDocuments_VectorWithoutCapabilityReturnsNotAvailable(t *testing.T) {
+	svc := newService(t)
+	ctx := context.Background()
+	if err := svc.PutDocument(ctx, "ds", "a.md", "alpha beta gamma"); err != nil {
+		t.Fatalf("put: %v", err)
+	}
+
+	for _, mode := range []knowledge.Mode{knowledge.ModeVector, knowledge.ModeHybrid} {
+		_, err := svc.SearchDocuments(ctx, knowledge.Query{
+			Scope:     knowledge.ScopeSingleDataset,
+			DatasetID: "ds",
+			Text:      "alpha",
+			Mode:      mode,
+			TopK:      5,
+		})
+		if err == nil {
+			t.Fatalf("mode=%q expected NotAvailable; got nil", mode)
+		}
+		if !errdefs.IsNotAvailable(err) {
+			t.Fatalf("mode=%q expected NotAvailable, got %v (kind=%v)", mode, err, errors.Unwrap(err))
+		}
+	}
+}
+
+// TestDocVectorSearcher_InterfaceShape pins the capability surface
+// declared by #145 — implementers must expose SearchDocsByVector with
+// the same query shape as DocLevelSearcher.SearchDocs. Asserts the
+// interface compiles and is satisfiable.
+func TestDocVectorSearcher_InterfaceShape(t *testing.T) {
+	var (
+		_ knowledge.DocLevelSearcher  = (*stubDocSearcher)(nil)
+		_ knowledge.DocVectorSearcher = (*stubDocSearcher)(nil)
+	)
+}
+
+type stubDocSearcher struct{}
+
+func (stubDocSearcher) SearchDocs(context.Context, knowledge.ChunkQuery) ([]knowledge.Candidate, error) {
+	return nil, nil
+}
+func (stubDocSearcher) SearchDocsByVector(context.Context, knowledge.ChunkQuery) ([]knowledge.Candidate, error) {
+	return nil, nil
+}

--- a/sdk/knowledge/repo.go
+++ b/sdk/knowledge/repo.go
@@ -48,13 +48,41 @@ type ChunkRepo interface {
 // chunks→docID collapse that callers (e.g. eval/beir) would otherwise
 // have to implement themselves.
 //
-// Service.SearchDocuments type-asserts the configured ChunkRepo to this
-// interface; backends that do not implement it will surface a clear
-// error from SearchDocuments rather than silently fall back to a
-// chunk-level + collapse strategy (which is exactly what landing this
-// interface was meant to retire). See #126 for the rationale.
+// SCOPE: BM25 only. Doc-level vector / hybrid retrieval is a separate
+// capability — see [DocVectorSearcher]. Service.SearchDocuments routes
+// q.Mode == ModeBM25 here and ModeVector / ModeHybrid to
+// DocVectorSearcher; backends that do not implement the requested
+// capability surface a clear error rather than silently degrading.
+// See #126 for the BM25 rationale, #145 for the vector rationale.
 type DocLevelSearcher interface {
 	SearchDocs(ctx context.Context, q ChunkQuery) ([]Candidate, error)
+}
+
+// DocVectorSearcher is an OPTIONAL extension declaring doc-level vector
+// (and hybrid) retrieval as an explicit capability (issue #145).
+//
+// Pre-fix, ChunkRepo.SearchDocs accepted q.Mode and returned
+// errdefs.NotAvailable mid-call when the requested mode was anything
+// other than ModeBM25. That mixed two unrelated concerns — "what
+// granularity is supported" (DocLevelSearcher) and "what scoring
+// modes are supported" — into a runtime error that callers had to
+// pattern-match on. This interface separates them: the capability is
+// declared at compile time and probed via type assertion in
+// [Service.SearchDocuments]. Backends that do not implement it
+// surface a clear NotAvailable up front, not a buried mid-search
+// error.
+//
+// Hybrid handling is the implementer's responsibility (BM25 + cosine
+// fusion, late-chunking, etc.). The interface accepts the same
+// [ChunkQuery] as DocLevelSearcher and is expected to honour
+// q.Mode == ModeVector or ModeHybrid.
+//
+// No in-tree implementation yet — both [FSChunkRepo] and
+// [RetrievalChunkRepo] hold per-chunk vectors but no per-doc
+// representation. Mean-pool / late-chunking will land via a
+// follow-up that adds SearchDocsByVector to one or both repos.
+type DocVectorSearcher interface {
+	SearchDocsByVector(ctx context.Context, q ChunkQuery) ([]Candidate, error)
 }
 
 // LayerQuery is the recall input for layer-tier searches.

--- a/sdk/knowledge/service.go
+++ b/sdk/knowledge/service.go
@@ -314,12 +314,31 @@ func (s *Service) SearchDocuments(ctx context.Context, q Query) (*Result, error)
 		return &Result{}, nil
 	}
 
-	cands, err := searcher.SearchDocs(ctx, ChunkQuery{
+	// Capability-routing (#145): SearchDocs is the BM25 doc-level
+	// path; doc-level vector / hybrid is opted into by implementing
+	// [DocVectorSearcher]. We probe via type assertion so the failure
+	// mode for backends without doc-level vectors is a clear up-front
+	// NotAvailable, not a partial-execution error buried inside the
+	// chosen ChunkQuery.
+	chunkQ := ChunkQuery{
 		DatasetIDs: ids,
 		Text:       q.Text,
 		Mode:       q.Mode,
 		TopK:       q.TopK,
-	})
+	}
+	var cands []Candidate
+	switch q.Mode {
+	case ModeVector, ModeHybrid:
+		dvs, hasVec := s.chunks.(DocVectorSearcher)
+		if !hasVec {
+			return nil, errdefs.NotAvailablef(
+				"knowledge: doc-level mode %q not supported by chunk repo %T (implement DocVectorSearcher; #145)",
+				q.Mode, s.chunks)
+		}
+		cands, err = dvs.SearchDocsByVector(ctx, chunkQ)
+	default: // ModeBM25
+		cands, err = searcher.SearchDocs(ctx, chunkQ)
+	}
 	if err != nil {
 		return nil, err
 	}

--- a/sdk/retrieval/journal/wrap.go
+++ b/sdk/retrieval/journal/wrap.go
@@ -2,7 +2,6 @@ package journal
 
 import (
 	"context"
-	"io"
 	"time"
 
 	"github.com/GizClaw/flowcraft/sdk/retrieval"
@@ -37,10 +36,24 @@ type journaledIndex struct {
 
 // Wrap returns retrieval.Index that records mutations to j after inner success.
 //
-// The wrapper transparently delegates the optional retrieval sub-interfaces
-// (DocGetter, Filterable, DeletableByFilter, Droppable, Iterable,
-// Snapshottable, Hybridable, Vectorizable) so that callers who type-assert
-// on the wrapped value still reach the inner backend's native fast paths.
+// Capability projection (issue #157): the wrapper exposes ONLY the optional
+// sub-interfaces the inner actually implements. Pre-fix, the base type
+// embedded bridge methods for every optional sub-interface, so a wrapped
+// index always satisfied `idx.(retrieval.Hybridable)` even when the inner
+// did not — and the bridge silently returned (nil, nil), which collapsed
+// the recall pipeline through [pipeline.HybridShortCircuit] to zero hits.
+//
+// Currently transparently delegates: [retrieval.DocGetter],
+// [retrieval.Filterable], [retrieval.DeletableByFilter],
+// [retrieval.Droppable], [retrieval.Iterable]. These have in-tree
+// implementations and the bridge logic on `*journaledIndex` is correct.
+// [retrieval.Hybridable], [retrieval.Snapshottable], and
+// [retrieval.Vectorizable] are NOT delegated by the base wrapper today —
+// no in-tree backend implements them. When a future backend does, add a
+// specialised variant type that explicitly defines the corresponding
+// methods (the same pattern as [wrappedFull] / [wrappedAuditable] below)
+// rather than restoring the leaky base-type bridge.
+//
 // DeleteByFilter and Drop additionally emit OpDelete events for every
 // affected document so the journal stays a complete audit log; this can be
 // expensive on bulk deletes — call directly on the inner Index when audit
@@ -291,65 +304,25 @@ func (w *journaledIndex) Iterate(ctx context.Context, namespace, cursor string, 
 	return nil, "", nil
 }
 
-func (w *journaledIndex) Snapshot(ctx context.Context, namespace string, dst io.Writer) error {
-	if s, ok := w.inner.(retrieval.Snapshottable); ok {
-		return s.Snapshot(ctx, namespace, dst)
-	}
-	return nil
-}
-
-func (w *journaledIndex) Restore(ctx context.Context, namespace string, src io.Reader) error {
-	if s, ok := w.inner.(retrieval.Snapshottable); ok {
-		return s.Restore(ctx, namespace, src)
-	}
-	return nil
-}
-
-func (w *journaledIndex) SearchHybrid(ctx context.Context, namespace string, req retrieval.HybridRequest) (*retrieval.SearchResponse, error) {
-	if h, ok := w.inner.(retrieval.Hybridable); ok {
-		return h.SearchHybrid(ctx, namespace, req)
-	}
-	return nil, nil
-}
-
-func (w *journaledIndex) UpsertWithEmbed(ctx context.Context, namespace string, docs []retrieval.Doc) error {
-	v, ok := w.inner.(retrieval.Vectorizable)
-	if !ok {
-		return nil
-	}
-	if err := v.UpsertWithEmbed(ctx, namespace, docs); err != nil {
-		return err
-	}
-	now := time.Now()
-	act := ""
-	if w.actor != nil {
-		act = w.actor(ctx)
-	}
-	for i := range docs {
-		d := docs[i]
-		after := cloneDocPtr(&d)
-		ev := Event{
-			Namespace: namespace,
-			Op:        OpUpsert,
-			DocID:     d.ID,
-			After:     after,
-			Actor:     act,
-			Timestamp: now,
-		}
-		if err := w.j.Record(ctx, ev); err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
-func (w *journaledIndex) SearchByText(ctx context.Context, namespace, text string, topK int) (*retrieval.SearchResponse, error) {
-	if v, ok := w.inner.(retrieval.Vectorizable); ok {
-		return v.SearchByText(ctx, namespace, text, topK)
-	}
-	return nil, nil
-}
-
+// REMOVED in PR-4 (issue #157):
+//   - Snapshot / Restore
+//   - SearchHybrid
+//   - UpsertWithEmbed / SearchByText
+//
+// Pre-fix, these existed on *journaledIndex as 'return (nil, nil)' bridges
+// that fell through to the inner only when it implemented the corresponding
+// optional sub-interface. Embedding *journaledIndex into every variant type
+// then made every wrapped value satisfy [retrieval.Hybridable] etc. via
+// method-set promotion, regardless of the inner's real capabilities. The
+// downstream [pipeline.HybridShortCircuit] then short-circuited recall to
+// zero hits.
+//
+// Reintroducing them — even gated by type assertions — requires committing
+// to specialised variant types (see newWrapped's matrix) that ONLY embed
+// the relevant bridge when the inner truly implements it. No in-tree
+// backend implements these today, so they have been deleted rather than
+// kept as a foot-gun.
+//
 // newWrapped returns a retrieval.Index whose method set mirrors the optional
 // interfaces implemented by base.inner. The matrix is small, so we
 // enumerate the combinations rather than rely on dynamic proxying.

--- a/sdk/retrieval/journal/wrap_capability_test.go
+++ b/sdk/retrieval/journal/wrap_capability_test.go
@@ -1,0 +1,70 @@
+package journal_test
+
+import (
+	"context"
+	"iter"
+	"testing"
+	"time"
+
+	"github.com/GizClaw/flowcraft/sdk/retrieval"
+	"github.com/GizClaw/flowcraft/sdk/retrieval/journal"
+)
+
+// hybridClaimingIndex is a minimal retrieval.Index that advertises
+// Capabilities.Hybrid == true but DOES NOT implement
+// retrieval.Hybridable — exactly the in-tree workspace.Index profile
+// that triggered #157.
+type hybridClaimingIndex struct{}
+
+func (hybridClaimingIndex) Capabilities() retrieval.Capabilities {
+	return retrieval.Capabilities{Hybrid: true}
+}
+func (hybridClaimingIndex) Close() error { return nil }
+func (hybridClaimingIndex) Upsert(context.Context, string, []retrieval.Doc) error {
+	return nil
+}
+func (hybridClaimingIndex) Delete(context.Context, string, []string) error { return nil }
+func (hybridClaimingIndex) Search(context.Context, string, retrieval.SearchRequest) (*retrieval.SearchResponse, error) {
+	return &retrieval.SearchResponse{}, nil
+}
+func (hybridClaimingIndex) List(context.Context, string, retrieval.ListRequest) (*retrieval.ListResponse, error) {
+	return &retrieval.ListResponse{}, nil
+}
+
+// nullJournal absorbs Record / Close calls so Wrap can return a
+// useful value without spinning up a real journal backend.
+type nullJournal struct{}
+
+func (nullJournal) Record(context.Context, journal.Event) error { return nil }
+func (nullJournal) History(context.Context, string, string) ([]journal.Event, error) {
+	return nil, nil
+}
+func (nullJournal) Replay(context.Context, string, uint64) iter.Seq2[journal.Event, error] {
+	return func(func(journal.Event, error) bool) {}
+}
+func (nullJournal) Compact(context.Context, time.Time) error { return nil }
+func (nullJournal) Close() error                             { return nil }
+
+// TestWrap_DoesNotFalselyAdvertiseHybridable is the regression guard
+// for issue #157. Pre-fix, journal.Wrap embedded a SearchHybrid
+// bridge on every variant via *journaledIndex, so the type
+// assertion to retrieval.Hybridable always succeeded — and the
+// bridge returned (nil, nil), which downstream
+// pipeline.HybridShortCircuit treated as a successful empty
+// short-circuit.
+//
+// The fix removes the bridge methods from the base wrapper type so
+// no wrapped value falsely advertises Hybridable / Snapshottable /
+// Vectorizable when the inner index does not implement them.
+func TestWrap_DoesNotFalselyAdvertiseHybridable(t *testing.T) {
+	wrapped := journal.Wrap(hybridClaimingIndex{}, nullJournal{})
+	if _, ok := wrapped.(retrieval.Hybridable); ok {
+		t.Fatalf("#157 regression: journal.Wrap of a non-Hybridable inner must NOT satisfy retrieval.Hybridable")
+	}
+	if _, ok := wrapped.(retrieval.Snapshottable); ok {
+		t.Fatalf("#157 regression: journal.Wrap of a non-Snapshottable inner must NOT satisfy retrieval.Snapshottable")
+	}
+	if _, ok := wrapped.(retrieval.Vectorizable); ok {
+		t.Fatalf("#157 regression: journal.Wrap of a non-Vectorizable inner must NOT satisfy retrieval.Vectorizable")
+	}
+}

--- a/sdk/retrieval/pipeline/stages_short.go
+++ b/sdk/retrieval/pipeline/stages_short.go
@@ -52,15 +52,23 @@ func (s HybridShortCircuit) Run(ctx context.Context, st *State) error {
 	if err != nil {
 		return err
 	}
-	if resp != nil {
-		st.Final = resp.Hits
-		// Preserve the backend's structured explanation so the wrapping
-		// pipeline can surface it on the short-circuit path. Without this
-		// the pipeline would observe empty Recalls/Trace and produce a
-		// nil SearchResponse.Execution even when the backend tried to
-		// honour Debug.
-		st.HybridExecution = resp.Execution
+	// Only short-circuit when the backend actually returned a response.
+	// A nil resp means the backend is a "type-assertion-positive but
+	// no-op" bridge (the historic shape of [journal.Wrap]'s false
+	// Hybridable advertisement, issue #157). Treating that as a
+	// successful short-circuit silently empties Recall (issue #161);
+	// the remaining LTM stages — SupersededDecay, SlotCollapse,
+	// TimeDecay, EntityBoost / EntityLinkBoost — must run instead.
+	if resp == nil {
+		return nil
 	}
+	st.Final = resp.Hits
+	// Preserve the backend's structured explanation so the wrapping
+	// pipeline can surface it on the short-circuit path. Without this
+	// the pipeline would observe empty Recalls/Trace and produce a
+	// nil SearchResponse.Execution even when the backend tried to
+	// honour Debug.
+	st.HybridExecution = resp.Execution
 	st.ShortCircuit = true
 	return nil
 }

--- a/sdk/retrieval/pipeline/stages_short_test.go
+++ b/sdk/retrieval/pipeline/stages_short_test.go
@@ -1,0 +1,55 @@
+package pipeline
+
+import (
+	"context"
+	"testing"
+
+	"github.com/GizClaw/flowcraft/sdk/retrieval"
+	"github.com/GizClaw/flowcraft/sdk/retrieval/memory"
+)
+
+// nilHybridIndex advertises Capabilities.Hybrid = true and implements
+// retrieval.Hybridable but returns (nil, nil) — emulating the pre-fix
+// journal.Wrap bridge that #157 exposed. The short-circuit stage must
+// NOT mark ShortCircuit=true in this case (issue #161), because the
+// remaining LTM stages (SupersededDecay, SlotCollapse, TimeDecay,
+// EntityBoost / EntityLinkBoost) carry the actual recall semantics
+// for the in-memory backend.
+type nilHybridIndex struct{ *memory.Index }
+
+func (i *nilHybridIndex) Capabilities() retrieval.Capabilities {
+	c := i.Index.Capabilities()
+	c.Hybrid = true
+	return c
+}
+
+func (i *nilHybridIndex) SearchHybrid(context.Context, string, retrieval.HybridRequest) (*retrieval.SearchResponse, error) {
+	return nil, nil
+}
+
+// TestHybridShortCircuit_DoesNotShortCircuitOnNilResponse pins
+// issue #161: when SearchHybrid returns (nil, nil) — historically
+// the journal.Wrap bridge for non-Hybridable inners — the stage
+// must leave ShortCircuit=false so the rest of the LTM pipeline
+// still runs. Pre-fix the stage unconditionally set ShortCircuit
+// even on nil resp, silently emptying Recall.
+func TestHybridShortCircuit_DoesNotShortCircuitOnNilResponse(t *testing.T) {
+	idx := &nilHybridIndex{Index: memory.New()}
+	st := &State{
+		Index:     idx,
+		Namespace: "ns",
+		Request: &retrieval.SearchRequest{
+			QueryText: "q",
+			TopK:      5,
+		},
+	}
+	if err := (HybridShortCircuit{}).Run(context.Background(), st); err != nil {
+		t.Fatalf("HybridShortCircuit.Run: %v", err)
+	}
+	if st.ShortCircuit {
+		t.Fatalf("#161 regression: HybridShortCircuit must NOT short-circuit when SearchHybrid returns (nil, nil)")
+	}
+	if st.Final != nil {
+		t.Fatalf("Final should be untouched on nil response; got %+v", st.Final)
+	}
+}


### PR DESCRIPTION
## Summary

Cluster D of the recall-architectural-debt plan: PR-4, **capabilities must be discoverable via interface assertion**, not implicitly granted by embedding or accepting a Mode parameter that the implementation will refuse mid-call.

Closes #145
Closes #157
Closes #161

## Root cause

Three issues, one anti-pattern: callers can't reliably tell which optional capability a backend supports.

| Issue | Site | Symptom |
|---|---|---|
| #157 | \`journal.Wrap\` embeds bridge methods for \`Hybridable\` / \`Snapshottable\` / \`Vectorizable\` on the base \`*journaledIndex\` type | Every wrapped index falsely satisfies these interfaces → \`HybridShortCircuit\` collapses recall to zero hits when wrapping workspace.Index (caps.Hybrid=true but no Hybridable impl). |
| #161 | \`HybridShortCircuit\` sets \`ShortCircuit=true\` unconditionally on success | Latent foot-gun: any future \"type-assertion-positive but no-op\" Hybridable bridge silently empties Recall AND skips the rest of the LTM pipeline. |
| #145 | \`knowledge.ChunkRepo.SearchDocs\` accepts \`q.Mode\` but returns \`NotAvailable\` mid-call for ModeVector/ModeHybrid | Capability is implied by a Mode parameter, rejected at runtime instead of declared at compile time. BEIR vector / hybrid leaderboard rows blocked. |

## Design

### #157 fix — remove the foot-gun bridges

Pre-fix \`*journaledIndex\` defined bridge methods for every optional sub-interface; embedding it into every variant type promoted those methods into every wrapped value's method set. Even though the bridges fell through to \`(nil, nil)\` when the inner did not implement the interface, the type assertion \`idx.(retrieval.Hybridable)\` always succeeded.

Removed: \`SearchHybrid\`, \`Snapshot\`, \`Restore\`, \`UpsertWithEmbed\`, \`SearchByText\`. No in-tree backend implements these; the methods existed purely as a leaky bridge. When a future backend lands with one of these capabilities, the fix is to add a specialised variant type that explicitly declares the methods (the same pattern as \`wrappedFull\` / \`wrappedAuditable\` already use for the DocGetter / Iterable / etc. cluster).

### #161 fix — guard against nil short-circuit response

\`HybridShortCircuit\` now gates \`st.ShortCircuit = true\` on \`resp != nil\`. After #157's bridge removal this code path is unreachable from in-tree backends, but the unconditional flag was a latent regression generator. A nil response now falls through so the rest of the LTM pipeline (SupersededDecay, SlotCollapse, TimeDecay, EntityBoost / EntityLinkBoost) still runs.

### #145 fix — capability via interface, not Mode rejection

Introduced \`knowledge.DocVectorSearcher\`:

\`\`\`go
type DocVectorSearcher interface {
    SearchDocsByVector(ctx context.Context, q ChunkQuery) ([]Candidate, error)
}
\`\`\`

\`Service.SearchDocuments\` now type-asserts on this interface for ModeVector / ModeHybrid and routes there explicitly. ModeBM25 still goes through the existing \`DocLevelSearcher.SearchDocs\`. Backends that do not implement \`DocVectorSearcher\` surface a clear up-front NotAvailable instead of a buried mid-search error.

No backend implements \`DocVectorSearcher\` today — the actual mean-pool / late-chunking implementation lands via a follow-up PR that adds \`SearchDocsByVector\` to \`RetrievalChunkRepo\`. At that point BEIR vector / hybrid leaderboard rows are unblocked; \`leaderboard.md\` line 521 stops being \`[pending]\`.

## Test plan

- [x] \`sdk/retrieval/journal/wrap_capability_test.go\` — #157: a Hybrid-claiming index wrapped by \`journal.Wrap\` MUST NOT satisfy \`Hybridable\` / \`Snapshottable\` / \`Vectorizable\`.
- [x] \`sdk/retrieval/pipeline/stages_short_test.go\` — #161: nil \`SearchHybrid\` response must not set \`ShortCircuit=true\`; the existing \`TestPipelineHybridShortCircuitForwardsDebug\` still passes (real Hybridable backend short-circuits correctly).
- [x] \`sdk/knowledge/doc_vector_capability_test.go\` — #145: pins the \`DocVectorSearcher\` interface shape AND asserts the Service routes NotAvailable for Vector / Hybrid without the capability.
- [x] \`go vet ./sdk/... ./sdkx/...\` clean.
- [x] Full SDK / sdkx suite passes.

## Skip-tag rationale

\`[skip-tag]\` keeps this off the auto-tag pipeline; PR-4 is intermediate. PR-5 (TestGodoc executable contracts) lands without the marker as the final PR in the architectural-debt series.

Made with [Cursor](https://cursor.com)