### PR TITLE
[skip-tag] chore(eval): bump sdk pin v0.3.14 -> v0.3.16

### DIFF
--- a/eval/go.mod
+++ b/eval/go.mod
@@ -9,7 +9,7 @@ go 1.25.0
 // development the workspace overlay is authoritative.
 
 require (
-	github.com/GizClaw/flowcraft/sdk v0.3.14
+	github.com/GizClaw/flowcraft/sdk v0.3.16
 	github.com/GizClaw/flowcraft/sdkx v0.3.9
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/pflag v1.0.9

--- a/eval/go.sum
+++ b/eval/go.sum
@@ -9,7 +9,10 @@ github.com/AzureAD/microsoft-authentication-library-for-go v1.2.2 h1:XHOnouVk1mx
 github.com/AzureAD/microsoft-authentication-library-for-go v1.2.2/go.mod h1:wP83P5OoQ5p6ip3ScPr0BAq0BvuPAvacpEuSzyouqAI=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/GizClaw/flowcraft/sdk v0.3.14 h1:Pc3UeHGKgbmip3ExTyB6Gd+XUMpjxJ29z4NkrIf7dXM=
+github.com/GizClaw/flowcraft/sdk v0.3.16 h1:K9u9u9eptm6+Xay6MMmWDVG9x45CPN9yee9LhSz3/A4=
+github.com/GizClaw/flowcraft/sdk v0.3.16/go.mod h1:VeMqVBxnMGHtFO9ypHhsA591XoLCWxucXR+gqpxQt5s=
 github.com/GizClaw/flowcraft/sdkx v0.3.9 h1:VIKCEz7H2ohRXXQthWd+6IGEnAIvPCXXhUZeQ/qAbHM=
+github.com/GizClaw/flowcraft/sdkx v0.3.9/go.mod h1:lLRzJth7GxSLmdb5iaq3CdVCfj13ZWcybzlIudAxfJg=
 github.com/anthropics/anthropic-sdk-go v1.26.0 h1:oUTzFaUpAevfuELAP1sjL6CQJ9HHAfT7CoSYSac11PY=
 github.com/anthropics/anthropic-sdk-go v1.26.0/go.mod h1:qUKmaW+uuPB64iy1l+4kOSvaLqPXnHTTBKH6RVZ7q5Q=
 github.com/avast/retry-go v3.0.0+incompatible/go.mod h1:XtSnn+n/sHqQIpZ10K1qAevBhOOCWBLXXy3hyiqqBrY=


### PR DESCRIPTION
## Summary

eval is a go.work member (#168) so the require pin is only a
`GOWORK=off` / `go mod tidy` fallback — CI and local development
already resolve sdk/sdkx to monorepo HEAD via the workspace
overlay. Align the offline-tidy pin with the freshly-tagged
\`sdk/v0.3.16\` so a clean \`cd eval && go mod tidy\` no longer
downgrades the cache below the recent architectural fixes.

## Coverage

\`sdk/v0.3.16\` spans (since v0.3.14):

| Tag | PR | Highlights |
|---|---|---|
| v0.3.15 | #166 | entity-recall lane + extractor sprint (LoCoMo baseline boost); P0 fixes #163 / #156 / #149 / #148 |
| v0.3.16 | #173 – #177 | Projection + Reconciler (#151/#158/#164/#167/#169/#171); WritePipeline (#165); KeyedMutex (#154/#162/#170); capability assertions (#145/#157/#161); godoc-vs-impl real fixes (#150/#152/#153/#155/#159/#160/#172) |

## eval impact

No eval-side API surface changed. The full grep over the eval
tree shows:

- \`mem.Add\` (no ID) — \`SaveRaw\`: now content-addressable, so
  retries are idempotent. The LoCoMo entrypoint uses
  \`SaveRawTurns\` which passes EvidenceID, taking the
  caller-supplied-ID branch (dedup probe skipped) → unchanged.
- \`mem.Save\` / \`Recall\` / \`Close\` — internally refactored but
  externally compatible.
- \`knowledge.ModeBM25/Vector/Hybrid\` — eval/beir + eval/knowledge
  already explicitly check the embedder, matching PR-4's
  capability-assertion contract.
- \`Scope.Partitions\`, \`Service.Rebuild\`, \`Service.DeleteDocument\`,
  \`SweepOnce\`, \`EventReloader\` — not referenced from eval.

sdkx stays at v0.3.9 (no new tag since).

## Test plan

- [x] \`cd eval && go test ./...\` (workspace HEAD) — all green.
- [x] \`cd eval && GOWORK=off go build ./...\` — all green.

\`[skip-tag]\` in the title because this PR is metadata-only;
sdk/sdkx tags are cut at the sdk-mutating PRs themselves, not
when downstream modules bump their pins.

Made with [Cursor](https://cursor.com)