### PR TITLE
[skip-tag] chore(eval): bump sdk pin v0.3.16 -> v0.3.17

### DIFF
--- a/eval/go.mod
+++ b/eval/go.mod
@@ -9,7 +9,7 @@ go 1.25.0
 // development the workspace overlay is authoritative.
 
 require (
-	github.com/GizClaw/flowcraft/sdk v0.3.16
+	github.com/GizClaw/flowcraft/sdk v0.3.17
 	github.com/GizClaw/flowcraft/sdkx v0.3.9
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/pflag v1.0.9

--- a/eval/go.sum
+++ b/eval/go.sum
@@ -8,9 +8,8 @@ github.com/Azure/azure-sdk-for-go/sdk/internal v1.10.0/go.mod h1:iZDifYGJTIgIIkY
 github.com/AzureAD/microsoft-authentication-library-for-go v1.2.2 h1:XHOnouVk1mxXfQidrMEnLlPk9UMeRtyBTnEFtxkV0kU=
 github.com/AzureAD/microsoft-authentication-library-for-go v1.2.2/go.mod h1:wP83P5OoQ5p6ip3ScPr0BAq0BvuPAvacpEuSzyouqAI=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
-github.com/GizClaw/flowcraft/sdk v0.3.14 h1:Pc3UeHGKgbmip3ExTyB6Gd+XUMpjxJ29z4NkrIf7dXM=
-github.com/GizClaw/flowcraft/sdk v0.3.16 h1:K9u9u9eptm6+Xay6MMmWDVG9x45CPN9yee9LhSz3/A4=
-github.com/GizClaw/flowcraft/sdk v0.3.16/go.mod h1:VeMqVBxnMGHtFO9ypHhsA591XoLCWxucXR+gqpxQt5s=
+github.com/GizClaw/flowcraft/sdk v0.3.17 h1:HgafC/ENNktR6sVIbdgXW0eunPIiZRLg6BgmK5EJD8U=
+github.com/GizClaw/flowcraft/sdk v0.3.17/go.mod h1:VeMqVBxnMGHtFO9ypHhsA591XoLCWxucXR+gqpxQt5s=
 github.com/GizClaw/flowcraft/sdkx v0.3.9 h1:VIKCEz7H2ohRXXQthWd+6IGEnAIvPCXXhUZeQ/qAbHM=
 github.com/GizClaw/flowcraft/sdkx v0.3.9/go.mod h1:lLRzJth7GxSLmdb5iaq3CdVCfj13ZWcybzlIudAxfJg=
 github.com/anthropics/anthropic-sdk-go v1.26.0 h1:oUTzFaUpAevfuELAP1sjL6CQJ9HHAfT7CoSYSac11PY=


### PR DESCRIPTION
## Summary

\`v0.3.17\` is main HEAD after PR #180 merge — the post-architectural consistency cleanup (#179.1 / #179.2 / #179.3 + \`WithEntityStore\` safe-default). Workspace mode picks up the in-tree code automatically, but the require pin still matters for \`GOWORK=off\` builds (occasional CI lints, external consumers, reproducibility documentation).

\`sdkx\` unchanged at \`v0.3.9\` — PR #180 did not touch sdkx.

## Test plan

- [x] \`cd eval && GOWORK=off go build ./...\`
- [x] \`go build ./eval/...\` (workspace overlay)
- [x] \`go test ./eval/... -timeout 180s\`
- [ ] CI green

Made with [Cursor](https://cursor.com)