### PR TITLE
[skip-tag] chore(workflows): align eval-longmemeval inputs with eval-locomo

### DIFF
--- a/.github/workflows/eval-longmemeval.yml
+++ b/.github/workflows/eval-longmemeval.yml
@@ -64,7 +64,13 @@ on:
         description: "Debug: cap to first N questions (0 = full set)"
         required: false
         default: "0"
-      # ---- Tuning knobs that historically diverged from sdk defaults ----
+      # ---- Tuning knobs (mirrors eval-locomo.yml so the same
+      # architectural ablation can be dispatched on both benchmarks
+      # without per-workflow drift). LLM aliases and concurrency are
+      # intentionally NOT mirrored — those are dataset-shape tuned:
+      # LongMemEval's _s split has 500-session haystacks and 100k+
+      # token contexts, which calls for stronger judges (azure_gpt54)
+      # and lower concurrency (Azure rate limits).
       soft_merge:
         # Legacy lme-launch.sh ran with --soft-merge=false; sdk default
         # is true. Behaviour delta: near-duplicate fact merging (older
@@ -73,6 +79,100 @@ on:
         required: false
         type: boolean
         default: true
+      multi_recall:
+        # CLI default: false (keeps legacy single-lane vector recall + BM25/entity
+        # boost behaviour). The LoCoMo validated baseline runs with true,
+        # which switches LTM to 3-lane recall (vector + bm25 + entity)
+        # + RRFFusion. See sdk/retrieval/pipeline/factory.go
+        # WithMultiRecall for the exact stage topology.
+        description: "Use 3-lane recall (vector+bm25+entity) + RRFFusion (LoCoMo validated baseline: true)"
+        required: false
+        type: boolean
+        default: true
+      update_resolver:
+        # Enables mem0 v3-style ADD/UPDATE/DELETE/NOOP memory linker.
+        # See sdk/recall/resolver_llm.go LLMUpdateResolver. Each Save
+        # batch issues one extra LLM call (resolver decision) plus
+        # N×Recall (one per new fact, top-K=20). Cost is non-trivial
+        # but offers cleaner long-term memory (no stale facts) for
+        # multi-session benches. Empty alias disables.
+        description: "LLM alias for the memory update resolver (empty = disabled)"
+        required: false
+        default: ""
+      recent_turns:
+        # Cross-batch reference-resolution context window. When >0,
+        # the extractor receives the previous K messages from prior
+        # Save batches on the same scope as RECENT TURNS — used to
+        # resolve pronouns, anaphora, short references, and
+        # chronology hints that were established earlier but absent
+        # from the current batch. The buffer lives in-process; see
+        # sdk/recall/message_buffer.go for the persistent-backend
+        # contract. Cost is one extra prompt section per Save (no
+        # extra LLM call). 0 disables.
+        description: "Inject previous K messages from prior batches into extractor (0 = disabled)"
+        required: false
+        default: "0"
+      save_with_context:
+        # Before extraction, recall existing facts for the current scope
+        # and inject them into the extractor prompt as EXISTING MEMORIES.
+        # This is mem0 v3's actual "memory linking" path: a single LLM
+        # call sees prior facts and self-dedups / skips semantic
+        # duplicates, without a destructive UPDATE/DELETE second call.
+        # Far cheaper than --update-resolver and architecturally suited
+        # to episodic-heavy datasets where old facts must never be
+        # tombstoned. LongMemEval _s has long episodic histories so
+        # this is expected to behave similarly to LoCoMo.
+        description: "Inject existing facts into extractor prompt (mem0 v3-style inline dedup)"
+        required: false
+        type: boolean
+        default: false
+      entity_store:
+        # Enables the entity-link inverted index lane (4th lane in
+        # MultiRetrieve, fed by EntityStore.Lookup on the entities the
+        # query extractor surfaces). Auto-enables --multi-recall. Adds
+        # a sibling namespace per Scope (ltm_<rt>__u_<user>__entities)
+        # with one row per normalised entity name; row writes happen
+        # synchronously after every Save batch.
+        description: "Enable entity-link inverted-index lane (architectural ablation)"
+        required: false
+        type: boolean
+        default: false
+      entity_store_max_linked:
+        # Common-noun pollution gate. SDK semantics post-#179.4:
+        # 0 = SDK safe default (defaultEntityMaxLinkedCount = 100,
+        # the value that gives back ~9pp on LoCoMo run 25980251192
+        # where the gate was OFF); >0 = exact threshold honoured
+        # verbatim; <0 = explicit audited opt-out (gate off, with a
+        # one-time warning emitted at Memory.New). No-op when
+        # entity_store=false.
+        description: "Skip entity rows with > N linked entries at Lookup (0 = SDK safe default 100; <0 = audited opt-out)"
+        required: false
+        default: "0"
+      entity_link_boost:
+        # Post-fusion entity-link integration mode. When > 0, the
+        # ModeEntityLink lane is REMOVED from MultiRetrieve and instead
+        # an EntityLinkBoost stage multiplies the score of every fused
+        # hit whose Doc.ID appears in CandidateEntityIDs by (1 + boost).
+        # Vector + BM25 keep ownership of candidate generation so
+        # multi-hop questions don't starve, and entity-link only acts
+        # as a re-ranking nudge. 0 keeps legacy 4-lane RRF integration.
+        # No-op when entity_store=false.
+        description: "Switch entity-link integration from RRF lane to post-fusion boost (0 = lane, 0.2-0.5 = boost)"
+        required: false
+        default: "0"
+      query_entity_extractor:
+        # Closes the entity-vocabulary asymmetry: write-side uses the
+        # LLM-based AdditiveExtractor (multi-word noun phrases like
+        # "LGBTQ support group"), query-side defaults to a rule-based
+        # capitalized-token splitter ("lgbtq" only). When true, we
+        # reuse the --extractor-llm to extract query entities with the
+        # same vocabulary as the EntityStore keys. Adds 1 LLM call per
+        # recall (cheap; same model + JSON mode). No-op when
+        # entity_store=false.
+        description: "Use LLM-backed query-side entity extractor (reuses --extractor-llm)"
+        required: false
+        type: boolean
+        default: false
       qa_timeout:
         # Default 3m (vs CLI default 2m) because Azure azure.generate
         # observed at ~2m in the loomo smoke; LME questions have longer
@@ -263,6 +363,14 @@ jobs:
           REPORT_OUT: ${{ env.REPORT_DIR }}/${{ github.run_id }}.json
         run: |
           set -eu
+          # Argument plumbing mirrors eval-locomo.yml so dispatching
+          # the same architectural ablation (e.g. entity_store +
+          # save_with_context + query_entity_extractor) on both
+          # benchmarks is mechanical. The optional flags below
+          # (reranker, embedder, update_resolver, limit_questions,
+          # recent_turns) are only appended when set so unspecified
+          # inputs do not surface as empty-string CLI flags the
+          # parser would mistake for explicit zero values.
           ARGS=(
             locomo run
             --dataset "${{ inputs.dataset }}"
@@ -274,6 +382,12 @@ jobs:
             --concurrency "${{ inputs.concurrency }}"
             --ingest-concurrency "${{ inputs.ingest_concurrency }}"
             --soft-merge=${{ inputs.soft_merge }}
+            --multi-recall=${{ inputs.multi_recall }}
+            --save-with-context=${{ inputs.save_with_context }}
+            --entity-store=${{ inputs.entity_store }}
+            --entity-store-max-linked=${{ inputs.entity_store_max_linked }}
+            --entity-link-boost=${{ inputs.entity_link_boost }}
+            --query-entity-extractor=${{ inputs.query_entity_extractor }}
             --qa-timeout "${{ inputs.qa_timeout }}"
             --ingest-timeout "${{ inputs.ingest_timeout }}"
             --notify-name "$RUN_TAG"
@@ -286,8 +400,14 @@ jobs:
           if [ -n "${{ inputs.embedder }}" ]; then
             ARGS+=( --embedder "${{ inputs.embedder }}" )
           fi
+          if [ -n "${{ inputs.update_resolver }}" ]; then
+            ARGS+=( --update-resolver "${{ inputs.update_resolver }}" )
+          fi
           if [ "${{ inputs.limit_questions }}" != "0" ]; then
             ARGS+=( --limit-questions "${{ inputs.limit_questions }}" )
+          fi
+          if [ "${{ inputs.recent_turns }}" != "0" ]; then
+            ARGS+=( --recent-turns "${{ inputs.recent_turns }}" )
           fi
           /tmp/eval "${ARGS[@]}"
 


### PR DESCRIPTION
## Summary

Mirror the architectural ablation knobs from \`eval-locomo.yml\` into \`eval-longmemeval.yml\` so the same configuration can be dispatched on both benchmarks. Pre-fix LongMemEval only exposed \`soft_merge\`, \`qa_timeout\`, \`ingest_timeout\` — every architectural experiment was single-benchmark and we could not tell whether a delta was LoCoMo-specific or generalisable.

### Inputs added

| Input | Default | LoCoMo parity |
|---|---|---|
| \`multi_recall\` | \`true\` | ✓ |
| \`save_with_context\` | \`false\` | ✓ |
| \`update_resolver\` | \`\"\"\` | ✓ |
| \`recent_turns\` | \`0\` | ✓ |
| \`entity_store\` | \`false\` | ✓ |
| \`entity_store_max_linked\` | \`0\` (SDK safe default = 100, per #179.4) | ✓ |
| \`entity_link_boost\` | \`0\` | ✓ |
| \`query_entity_extractor\` | \`false\` | ✓ |

### Intentionally NOT mirrored

LLM aliases and concurrency stay LongMemEval-tuned:

- \`_s\` split has 500-session haystacks + 100k+ token contexts → stronger judge (\`azure_gpt54\`) and lower concurrency (\`8\`) for Azure rate limits.
- LoCoMo's \`azure_4o_mini\` baseline is intentional methodology alignment with mem0 / Zep / memobase, not a generic recommendation.

### Behind the workflow

\`eval locomo run\` (LongMemEval also uses this CLI) already supports every flag added here — this PR is workflow plumbing only, no SDK / eval code changes.

## Test plan

- [x] \`yaml.safe_load\` parses the workflow
- [ ] CI green
- [ ] Smoke dispatch on the new inputs (e.g. \`entity_store=true\` to verify the flag actually surfaces in the rendered CLI)

Made with [Cursor](https://cursor.com)