### PR TITLE
Refactor stateful SDK module lifecycles

### DIFF
--- a/sdk/history/archive.go
+++ b/sdk/history/archive.go
@@ -444,7 +444,7 @@ func LoadArchivedMessages(ctx context.Context, ws workspace.Workspace, prefix, a
 		for scanner.More() {
 			var msg model.Message
 			if err := scanner.Decode(&msg); err != nil {
-				break
+				return nil, fmt.Errorf("archive: decode %q at seq %d: %w", path, seq, err)
 			}
 			if seq >= startSeq && seq <= endSeq {
 				result = append(result, msg)

--- a/sdk/history/archive.go
+++ b/sdk/history/archive.go
@@ -90,6 +90,12 @@ func intentPath(prefix, archivePrefix, convID string) string {
 	return archiveDir(prefix, archivePrefix, convID) + "/intent.json"
 }
 
+const (
+	archivePhaseGzipPending    = "gzip_pending"
+	archivePhaseGzipWritten    = "gzip_written"
+	archivePhaseManifestUpdate = "manifest_updated"
+)
+
 // archiveIntent records the in-progress archive operation for crash recovery.
 type archiveIntent struct {
 	ConvID      string `json:"conv_id"`
@@ -97,7 +103,7 @@ type archiveIntent struct {
 	EndSeq      int    `json:"end_seq"`
 	BatchSize   int    `json:"batch_size"`
 	ArchiveFile string `json:"archive_file"`
-	Phase       string `json:"phase"` // "gzip_written" | "manifest_updated"
+	Phase       string `json:"phase"` // gzip_pending | gzip_written | manifest_updated
 }
 
 // writeIntent records the in-progress archive operation atomically.
@@ -154,59 +160,98 @@ func recoverArchiveImpl(ctx context.Context, ws workspace.Workspace, store Store
 		otellog.String("phase", intent.Phase))
 
 	switch intent.Phase {
-	case "manifest_updated":
+	case archivePhaseManifestUpdate:
 		// Gzip + manifest done, just need to trim messages.
-		msgs, err := store.GetMessages(ctx, convID)
-		if err != nil {
-			return fmt.Errorf("archive: recovery get messages: %w", err)
+		if err := trimRecoveredHotLog(ctx, store, convID, intent.BatchSize); err != nil {
+			return err
 		}
-		if len(msgs) > intent.BatchSize {
-			remaining := msgs[intent.BatchSize:]
-			if err := store.SaveMessages(ctx, convID, remaining); err != nil {
-				return fmt.Errorf("archive: recovery rewrite messages: %w", err)
+	case archivePhaseGzipPending:
+		archivePath := archiveDir(prefix, archivePrefix, convID) + "/" + intent.ArchiveFile
+		exists, err := ws.Exists(ctx, archivePath)
+		if err != nil {
+			return fmt.Errorf("archive: recovery check gzip: %w", err)
+		}
+		if !exists {
+			msgs, err := store.GetMessages(ctx, convID)
+			if err != nil {
+				return fmt.Errorf("archive: recovery get messages: %w", err)
+			}
+			if len(msgs) < intent.BatchSize {
+				return fmt.Errorf("archive: recovery gzip pending with only %d hot messages, need %d", len(msgs), intent.BatchSize)
+			}
+			data, err := encodeArchiveGzip(msgs[:intent.BatchSize])
+			if err != nil {
+				return err
+			}
+			if err := ws.Write(ctx, archivePath, data); err != nil {
+				return fmt.Errorf("archive: recovery write gzip: %w", err)
 			}
 		}
-	case "gzip_written":
+		intent.Phase = archivePhaseGzipWritten
+		if err := writeIntent(ctx, ws, prefix, archivePrefix, convID, intent); err != nil {
+			return fmt.Errorf("archive: recovery update intent: %w", err)
+		}
+		if err := recoverGzipWritten(ctx, ws, store, prefix, archivePrefix, convID, intent); err != nil {
+			return err
+		}
+	case archivePhaseGzipWritten:
 		// Gzip done but manifest not updated — update manifest then trim.
-		manifest, err := LoadManifest(ctx, ws, prefix, archivePrefix, convID)
-		if err != nil {
-			return fmt.Errorf("archive: recovery load manifest: %w", err)
+		if err := recoverGzipWritten(ctx, ws, store, prefix, archivePrefix, convID, intent); err != nil {
+			return err
 		}
-		// Check idempotency: skip if segment already in manifest.
-		alreadyDone := false
-		for _, seg := range manifest.Segments {
-			if seg.File == intent.ArchiveFile {
-				alreadyDone = true
-				break
-			}
-		}
-		if !alreadyDone {
-			manifest.Segments = append(manifest.Segments, ArchiveSegment{
-				File:      intent.ArchiveFile,
-				StartSeq:  intent.StartSeq,
-				EndSeq:    intent.EndSeq,
-				Count:     intent.BatchSize,
-				CreatedAt: time.Now(),
-			})
-			manifest.HotStartSeq = intent.EndSeq + 1
-			if err := saveManifestImpl(ctx, ws, prefix, archivePrefix, convID, manifest); err != nil {
-				return fmt.Errorf("archive: recovery save manifest: %w", err)
-			}
-		}
-		msgs, err := store.GetMessages(ctx, convID)
-		if err != nil {
-			return fmt.Errorf("archive: recovery get messages: %w", err)
-		}
-		if len(msgs) > intent.BatchSize {
-			remaining := msgs[intent.BatchSize:]
-			if err := store.SaveMessages(ctx, convID, remaining); err != nil {
-				return fmt.Errorf("archive: recovery rewrite messages: %w", err)
-			}
-		}
+	default:
+		return fmt.Errorf("archive: unknown recovery phase %q", intent.Phase)
 	}
 
 	deleteIntent(ctx, ws, prefix, archivePrefix, convID)
 	telemetry.Info(ctx, "archive: recovery completed", otellog.String(telemetry.AttrConversationID, convID))
+	return nil
+}
+
+func recoverGzipWritten(ctx context.Context, ws workspace.Workspace, store Store, prefix, archivePrefix, convID string, intent *archiveIntent) error {
+	manifest, err := LoadManifest(ctx, ws, prefix, archivePrefix, convID)
+	if err != nil {
+		return fmt.Errorf("archive: recovery load manifest: %w", err)
+	}
+	// Check idempotency: skip if segment already in manifest.
+	alreadyDone := false
+	for _, seg := range manifest.Segments {
+		if seg.File == intent.ArchiveFile {
+			alreadyDone = true
+			break
+		}
+	}
+	if !alreadyDone {
+		manifest.Segments = append(manifest.Segments, ArchiveSegment{
+			File:      intent.ArchiveFile,
+			StartSeq:  intent.StartSeq,
+			EndSeq:    intent.EndSeq,
+			Count:     intent.BatchSize,
+			CreatedAt: time.Now(),
+		})
+		manifest.HotStartSeq = intent.EndSeq + 1
+		if err := saveManifestImpl(ctx, ws, prefix, archivePrefix, convID, manifest); err != nil {
+			return fmt.Errorf("archive: recovery save manifest: %w", err)
+		}
+	}
+	intent.Phase = archivePhaseManifestUpdate
+	if err := writeIntent(ctx, ws, prefix, archivePrefix, convID, intent); err != nil {
+		return fmt.Errorf("archive: recovery update intent: %w", err)
+	}
+	return trimRecoveredHotLog(ctx, store, convID, intent.BatchSize)
+}
+
+func trimRecoveredHotLog(ctx context.Context, store Store, convID string, batchSize int) error {
+	msgs, err := store.GetMessages(ctx, convID)
+	if err != nil {
+		return fmt.Errorf("archive: recovery get messages: %w", err)
+	}
+	if len(msgs) >= batchSize {
+		remaining := msgs[batchSize:]
+		if err := store.SaveMessages(ctx, convID, remaining); err != nil {
+			return fmt.Errorf("archive: recovery rewrite messages: %w", err)
+		}
+	}
 	return nil
 }
 
@@ -273,32 +318,28 @@ func Archive(ctx context.Context, ws workspace.Workspace, store Store, prefix, c
 	endSeq := startSeq + batchSize - 1
 	archiveFile := fmt.Sprintf("messages_%d_%d.jsonl.gz", startSeq, endSeq)
 
-	// Phase 1: compress and write gzip.
-	var buf bytes.Buffer
-	gw := gzip.NewWriter(&buf)
-	enc := json.NewEncoder(gw)
-	enc.SetEscapeHTML(false)
-	for _, msg := range toArchive {
-		if err := enc.Encode(msg); err != nil {
-			_ = gw.Close()
-			return result, fmt.Errorf("archive: encode message: %w", err)
-		}
-	}
-	if err := gw.Close(); err != nil {
-		return result, fmt.Errorf("archive: gzip close: %w", err)
-	}
-
-	archivePath := archiveDir(prefix, archivePrefix, convID) + "/" + archiveFile
-	if err := ws.Write(ctx, archivePath, buf.Bytes()); err != nil {
-		return result, fmt.Errorf("archive: write gzip: %w", err)
-	}
-
 	intent := &archiveIntent{
 		ConvID: convID, StartSeq: startSeq, EndSeq: endSeq,
-		BatchSize: batchSize, ArchiveFile: archiveFile, Phase: "gzip_written",
+		BatchSize: batchSize, ArchiveFile: archiveFile, Phase: archivePhaseGzipPending,
 	}
 	if err := writeIntent(ctx, ws, prefix, archivePrefix, convID, intent); err != nil {
 		return result, fmt.Errorf("archive: write intent: %w", err)
+	}
+
+	// Phase 1: compress and write gzip.
+	data, err := encodeArchiveGzip(toArchive)
+	if err != nil {
+		return result, err
+	}
+
+	archivePath := archiveDir(prefix, archivePrefix, convID) + "/" + archiveFile
+	if err := ws.Write(ctx, archivePath, data); err != nil {
+		return result, fmt.Errorf("archive: write gzip: %w", err)
+	}
+
+	intent.Phase = archivePhaseGzipWritten
+	if err := writeIntent(ctx, ws, prefix, archivePrefix, convID, intent); err != nil {
+		return result, fmt.Errorf("archive: update intent: %w", err)
 	}
 
 	// Phase 2: update manifest.
@@ -315,7 +356,7 @@ func Archive(ctx context.Context, ws workspace.Workspace, store Store, prefix, c
 		return result, fmt.Errorf("archive: save manifest: %w", err)
 	}
 
-	intent.Phase = "manifest_updated"
+	intent.Phase = archivePhaseManifestUpdate
 	if err := writeIntent(ctx, ws, prefix, archivePrefix, convID, intent); err != nil {
 		return result, fmt.Errorf("archive: update intent: %w", err)
 	}
@@ -337,6 +378,23 @@ func Archive(ctx context.Context, ws workspace.Workspace, store Store, prefix, c
 		otellog.String("file", archiveFile))
 
 	return result, nil
+}
+
+func encodeArchiveGzip(messages []model.Message) ([]byte, error) {
+	var buf bytes.Buffer
+	gw := gzip.NewWriter(&buf)
+	enc := json.NewEncoder(gw)
+	enc.SetEscapeHTML(false)
+	for _, msg := range messages {
+		if err := enc.Encode(msg); err != nil {
+			_ = gw.Close()
+			return nil, fmt.Errorf("archive: encode message: %w", err)
+		}
+	}
+	if err := gw.Close(); err != nil {
+		return nil, fmt.Errorf("archive: gzip close: %w", err)
+	}
+	return buf.Bytes(), nil
 }
 
 func archiveDir(prefix, archivePrefix, convID string) string {

--- a/sdk/history/archive_test.go
+++ b/sdk/history/archive_test.go
@@ -1,7 +1,10 @@
 package history
 
 import (
+	"bytes"
+	"compress/gzip"
 	"context"
+	"strings"
 	"testing"
 	"time"
 
@@ -111,6 +114,41 @@ func TestLoadArchivedMessages(t *testing.T) {
 	}
 	if len(archived) != 15 {
 		t.Fatalf("expected 15 archived msgs, got %d", len(archived))
+	}
+}
+
+func TestLoadArchivedMessages_ReturnsDecodeError(t *testing.T) {
+	ws, err := workspace.NewLocalWorkspace(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx := context.Background()
+	convID := "archive-decode-error"
+	path := "memory/" + convID + "/archive/bad.jsonl.gz"
+
+	var buf bytes.Buffer
+	gw := gzip.NewWriter(&buf)
+	if _, err := gw.Write([]byte("{bad-json\n")); err != nil {
+		t.Fatal(err)
+	}
+	if err := gw.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := ws.Write(ctx, path, buf.Bytes()); err != nil {
+		t.Fatal(err)
+	}
+	if err := saveManifestImpl(ctx, ws, "memory", "archive", convID, &ArchiveManifest{
+		HotStartSeq: 1,
+		Segments: []ArchiveSegment{{
+			File: "bad.jsonl.gz", StartSeq: 0, EndSeq: 0, Count: 1, CreatedAt: time.Now(),
+		}},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = LoadArchivedMessages(ctx, ws, "memory", "archive", convID, 0, 0)
+	if err == nil || !strings.Contains(err.Error(), "decode") {
+		t.Fatalf("expected decode error, got %v", err)
 	}
 }
 

--- a/sdk/history/archive_test.go
+++ b/sdk/history/archive_test.go
@@ -189,6 +189,49 @@ func TestRecoverArchive_GzipWrittenPhase(t *testing.T) {
 	}
 }
 
+func TestRecoverArchive_GzipPendingPhaseWritesGzip(t *testing.T) {
+	ws, err := workspace.NewLocalWorkspace(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	store := NewFileStore(ws, "memory")
+	ctx := context.Background()
+	convID := "recover-pending"
+
+	msgs := make([]model.Message, 20)
+	for i := range msgs {
+		msgs[i] = model.NewTextMessage(model.RoleUser, "pending")
+	}
+	_ = store.SaveMessages(ctx, convID, msgs)
+
+	intent := &archiveIntent{
+		ConvID: convID, StartSeq: 0, EndSeq: 9,
+		BatchSize: 10, ArchiveFile: "messages_0_9.jsonl.gz", Phase: archivePhaseGzipPending,
+	}
+	if err := writeIntent(ctx, ws, "memory", "archive", convID, intent); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := recoverArchiveImpl(ctx, ws, store, "memory", "archive", convID); err != nil {
+		t.Fatal(err)
+	}
+
+	archived, err := LoadArchivedMessages(ctx, ws, "memory", "archive", convID, 0, 9)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(archived) != 10 {
+		t.Fatalf("expected 10 archived messages, got %d", len(archived))
+	}
+	remaining, err := store.GetMessages(ctx, convID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(remaining) != 10 {
+		t.Fatalf("expected 10 remaining after recovery, got %d", len(remaining))
+	}
+}
+
 func TestRecoverArchive_ManifestUpdatedPhase(t *testing.T) {
 	ws, err := workspace.NewLocalWorkspace(t.TempDir())
 	if err != nil {

--- a/sdk/history/buffer.go
+++ b/sdk/history/buffer.go
@@ -15,7 +15,12 @@ type buffer struct {
 	maxMessages int
 
 	mu    sync.Mutex
-	locks map[string]*sync.Mutex
+	locks map[string]*bufferLock
+}
+
+type bufferLock struct {
+	mu   sync.Mutex
+	refs int
 }
 
 // BufferOption customizes a [History] built by [NewBuffer].
@@ -44,7 +49,7 @@ func NewBuffer(store Store, opts ...BufferOption) History {
 	b := &buffer{
 		store:       store,
 		maxMessages: 50,
-		locks:       make(map[string]*sync.Mutex),
+		locks:       make(map[string]*bufferLock),
 	}
 	for _, opt := range opts {
 		opt(b)
@@ -89,9 +94,8 @@ func (m *buffer) Append(ctx context.Context, conversationID string, newMessages 
 	if len(newMessages) == 0 {
 		return nil
 	}
-	mu := m.convMu(conversationID)
-	mu.Lock()
-	defer mu.Unlock()
+	unlock := m.lockConv(conversationID)
+	defer unlock()
 
 	if appender, ok := m.store.(MessageAppender); ok {
 		return appender.AppendMessages(ctx, conversationID, newMessages)
@@ -110,19 +114,33 @@ func (m *buffer) Append(ctx context.Context, conversationID string, newMessages 
 }
 
 func (m *buffer) Clear(ctx context.Context, conversationID string) error {
-	mu := m.convMu(conversationID)
-	mu.Lock()
-	defer mu.Unlock()
-	return m.store.DeleteMessages(ctx, conversationID)
+	unlock := m.lockConv(conversationID)
+	defer unlock()
+	if err := m.store.DeleteMessages(ctx, conversationID); err != nil {
+		return err
+	}
+	return nil
 }
 
-func (m *buffer) convMu(convID string) *sync.Mutex {
+func (m *buffer) lockConv(convID string) func() {
 	m.mu.Lock()
-	defer m.mu.Unlock()
-	mu, ok := m.locks[convID]
+	entry, ok := m.locks[convID]
 	if !ok {
-		mu = &sync.Mutex{}
-		m.locks[convID] = mu
+		entry = &bufferLock{}
+		m.locks[convID] = entry
 	}
-	return mu
+	entry.refs++
+	m.mu.Unlock()
+
+	entry.mu.Lock()
+	return func() {
+		entry.mu.Unlock()
+
+		m.mu.Lock()
+		entry.refs--
+		if entry.refs == 0 {
+			delete(m.locks, convID)
+		}
+		m.mu.Unlock()
+	}
 }

--- a/sdk/history/buffer_test.go
+++ b/sdk/history/buffer_test.go
@@ -37,7 +37,7 @@ func TestBuffer_DefaultMaxMessages(t *testing.T) {
 func TestBuffer_SaveAndClear(t *testing.T) {
 	store := NewInMemoryStore()
 	ctx := context.Background()
-	buf := NewBuffer(store, WithBufferMax(10))
+	buf := NewBuffer(store, WithBufferMax(10)).(*buffer)
 
 	_ = buf.Append(ctx, "c1", []model.Message{model.NewTextMessage(model.RoleUser, "hi")})
 	loaded, _ := buf.Load(ctx, "c1", Budget{})
@@ -46,6 +46,12 @@ func TestBuffer_SaveAndClear(t *testing.T) {
 	}
 
 	_ = buf.Clear(ctx, "c1")
+	buf.mu.Lock()
+	_, lockPresent := buf.locks["c1"]
+	buf.mu.Unlock()
+	if lockPresent {
+		t.Fatal("expected Clear to remove per-conversation lock")
+	}
 	loaded, _ = buf.Load(ctx, "c1", Budget{})
 	if len(loaded) != 0 {
 		t.Fatal("expected 0 after clear")

--- a/sdk/history/compactor.go
+++ b/sdk/history/compactor.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/GizClaw/flowcraft/sdk/errdefs"
+	"github.com/GizClaw/flowcraft/sdk/internal/background"
 	"github.com/GizClaw/flowcraft/sdk/internal/syncx"
 	"github.com/GizClaw/flowcraft/sdk/llm"
 	"github.com/GizClaw/flowcraft/sdk/model"
@@ -58,6 +59,7 @@ type compactor struct {
 	queues  map[string]*convQueue
 	state   atomic.Int32 // open(0) → closing(1) → closed(2)
 	closeWg sync.WaitGroup
+	bg      *background.Group
 
 	// persistMu serialises Append per conversation across two
 	// critical sections that must be one:
@@ -167,6 +169,7 @@ func newCompactor(store Store, dag *SummaryDAG, config DAGConfig, ws workspace.W
 		ws:           ws,
 		prefix:       prefix,
 		queues:       make(map[string]*convQueue),
+		bg:           background.NewGroup(context.Background()),
 		shutdownDone: make(chan struct{}),
 	}
 	c.kickoffStartupRecovery()
@@ -247,9 +250,9 @@ func (m *compactor) Append(ctx context.Context, conversationID string, newMessag
 	// the worker could see a later task (startSeq=N) ahead of the
 	// earlier task (startSeq=0) that produced N — corrupting DAG
 	// summary parent/child wiring because ingest is positional on
-	// startSeq. enqueueAsync only does a bounded channel handoff
-	// and never re-enters persistMu, so the extended critical
-	// section cannot deadlock. See issue #179.2.
+	// startSeq. enqueueAsync now uses a bounded, context-aware channel
+	// handoff, so this critical section preserves ordering without
+	// waiting indefinitely on queue backpressure. See issue #179.2.
 	m.persistMu.Lock(conversationID)
 	defer m.persistMu.Unlock(conversationID)
 
@@ -258,14 +261,14 @@ func (m *compactor) Append(ctx context.Context, conversationID string, newMessag
 		return err
 	}
 
-	if err := m.enqueueAsync(conversationID, convTask{
+	if err := m.enqueueAsync(ctx, conversationID, convTask{
 		kind:     taskIngest,
 		msgs:     newMessages,
 		startSeq: startSeq,
 	}); err != nil {
-		// On Shutdown race the messages are already durable; lose only
-		// the async DAG ingest, which would have been best-effort anyway.
-		telemetry.Warn(ctx, "history: async ingest dropped during shutdown",
+		// The messages are already durable; lose only the async DAG ingest,
+		// which is best-effort when shutdown or backpressure intervenes.
+		telemetry.Warn(ctx, "history: async ingest dropped",
 			otellog.String(telemetry.AttrConversationID, conversationID),
 			otellog.String(telemetry.AttrErrorMessage, err.Error()))
 	}
@@ -401,6 +404,7 @@ func (m *compactor) Shutdown(ctx context.Context) error {
 		m.mu.Unlock()
 
 		go func() {
+			m.bg.Close()
 			m.closeWg.Wait()
 			m.state.Store(stateClosed)
 			close(m.shutdownDone)
@@ -419,37 +423,51 @@ func (m *compactor) Shutdown(ctx context.Context) error {
 var _ Coordinator = (*compactor)(nil)
 
 // enqueueAsync routes a fire-and-forget task (ingest) to the conv queue.
-// Returns ErrClosed if Shutdown has started in the meantime; never
-// returns a backpressure error because Append falls back to telemetry
-// rather than failing user writes.
-func (m *compactor) enqueueAsync(convID string, task convTask) error {
+// Returns ErrClosed if Shutdown has started in the meantime. Queue
+// backpressure is bounded by ctx/defaultIngestTimeout because Append already
+// holds the hot-log owner to preserve persist->enqueue ordering.
+func (m *compactor) enqueueAsync(ctx context.Context, convID string, task convTask) (err error) {
 	q, err := m.queueFor(convID)
 	if err != nil {
 		return err
 	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	enqueueCtx, cancel := context.WithTimeout(ctx, defaultIngestTimeout)
+	defer cancel()
 	defer func() {
 		// Recover from a "send on closed channel" panic that can occur
-		// only if Shutdown closes the channel between our state-check
-		// and the send below. Treat it as ErrClosed.
-		_ = recover()
+		// only if Shutdown/Clear closes the channel between our state-check
+		// and the send below. Treat it as ErrClosed so callers do not wait
+		// on a reply that can never arrive.
+		if recover() != nil {
+			err = ErrClosed
+		}
 	}()
 	if m.state.Load() != stateOpen {
 		return ErrClosed
 	}
-	q.tasks <- task
-	return nil
+	select {
+	case q.tasks <- task:
+		return nil
+	case <-enqueueCtx.Done():
+		return errdefs.FromContext(enqueueCtx.Err())
+	}
 }
 
 // enqueueSync routes a request/reply task and waits for the worker to
 // pick it up. Synchronous callers (Compact/Archive/Clear) handle their
 // own reply channel + ctx wait.
-func (m *compactor) enqueueSync(convID string, task convTask) error {
+func (m *compactor) enqueueSync(convID string, task convTask) (err error) {
 	q, err := m.queueFor(convID)
 	if err != nil {
 		return err
 	}
 	defer func() {
-		_ = recover()
+		if recover() != nil {
+			err = ErrClosed
+		}
 	}()
 	if m.state.Load() != stateOpen {
 		return ErrClosed
@@ -493,17 +511,19 @@ func (m *compactor) lazyRecover(convID string, q *convQueue) {
 	if m.ws == nil {
 		return
 	}
-	if !q.recovered.CompareAndSwap(false, true) {
+	if q.recovered.Load() {
 		return
 	}
 	archivePrefix := m.archivePrefix()
 	ctx, cancel := context.WithTimeout(context.Background(), defaultArchiveTimeout)
 	defer cancel()
-	if err := recoverArchiveImpl(ctx, m.ws, m.store, m.prefix, archivePrefix, convID); err != nil {
+	if err := m.recoverArchive(ctx, archivePrefix, convID); err != nil {
 		telemetry.Warn(ctx, "history: lazy archive recovery failed",
 			otellog.String(telemetry.AttrConversationID, convID),
 			otellog.String(telemetry.AttrErrorMessage, err.Error()))
+		return
 	}
+	q.recovered.Store(true)
 }
 
 func (m *compactor) runTask(convID string, task convTask) {
@@ -521,7 +541,7 @@ func (m *compactor) runTask(convID string, task convTask) {
 			return
 		}
 		archiveCtx, cancelArchive := context.WithTimeout(context.Background(), defaultArchiveTimeout)
-		if _, err := Archive(archiveCtx, m.ws, m.store, m.prefix, convID, m.config.Archive); err != nil {
+		if _, err := m.archive(archiveCtx, convID); err != nil {
 			telemetry.Warn(archiveCtx, "history: async archive failed",
 				otellog.String(telemetry.AttrConversationID, convID),
 				otellog.String(telemetry.AttrErrorMessage, err.Error()))
@@ -530,7 +550,7 @@ func (m *compactor) runTask(convID string, task convTask) {
 
 	case taskArchive:
 		ctx, cancel := context.WithTimeout(context.Background(), defaultArchiveTimeout)
-		res, err := Archive(ctx, m.ws, m.store, m.prefix, convID, m.config.Archive)
+		res, err := m.archive(ctx, convID)
 		cancel()
 		task.replyArchive <- archiveReply{res: res, err: err}
 
@@ -562,10 +582,24 @@ func (m *compactor) runTask(convID string, task convTask) {
 }
 
 func (m *compactor) runClear(ctx context.Context, convID string) error {
+	m.persistMu.Lock(convID)
+	defer m.persistMu.Unlock(convID)
 	if err := m.store.DeleteMessages(ctx, convID); err != nil {
 		return err
 	}
 	return m.dag.store.Rewrite(ctx, convID, nil)
+}
+
+func (m *compactor) archive(ctx context.Context, convID string) (ArchiveResult, error) {
+	m.persistMu.Lock(convID)
+	defer m.persistMu.Unlock(convID)
+	return Archive(ctx, m.ws, m.store, m.prefix, convID, m.config.Archive)
+}
+
+func (m *compactor) recoverArchive(ctx context.Context, archivePrefix, convID string) error {
+	m.persistMu.Lock(convID)
+	defer m.persistMu.Unlock(convID)
+	return recoverArchiveImpl(ctx, m.ws, m.store, m.prefix, archivePrefix, convID)
 }
 
 // removeQueue closes and removes a per-conversation queue. Safe to call
@@ -603,10 +637,8 @@ func (m *compactor) kickoffStartupRecovery() {
 	archivePrefix := m.archivePrefix()
 	prefix := m.prefix
 
-	m.closeWg.Add(1)
-	go func() {
-		defer m.closeWg.Done()
-		ctx, cancel := context.WithTimeout(context.Background(), defaultArchiveTimeout)
+	m.bg.Start(func(groupCtx context.Context) {
+		ctx, cancel := context.WithTimeout(groupCtx, defaultArchiveTimeout)
 		defer cancel()
 		entries, err := m.ws.List(ctx, prefix)
 		if err != nil {
@@ -618,7 +650,7 @@ func (m *compactor) kickoffStartupRecovery() {
 				continue
 			}
 			convID := e.Name()
-			if err := recoverArchiveImpl(ctx, m.ws, m.store, prefix, archivePrefix, convID); err != nil {
+			if err := m.recoverArchive(ctx, archivePrefix, convID); err != nil {
 				telemetry.Warn(ctx, "history: startup archive recovery failed",
 					otellog.String(telemetry.AttrConversationID, convID),
 					otellog.String(telemetry.AttrErrorMessage, err.Error()))
@@ -640,7 +672,7 @@ func (m *compactor) kickoffStartupRecovery() {
 			}
 			m.mu.Unlock()
 		}
-	}()
+	})
 }
 
 // CompactOption customizes a [History] built by [NewCompacted].

--- a/sdk/history/compactor.go
+++ b/sdk/history/compactor.go
@@ -515,7 +515,7 @@ func (m *compactor) lazyRecover(convID string, q *convQueue) {
 		return
 	}
 	archivePrefix := m.archivePrefix()
-	ctx, cancel := context.WithTimeout(context.Background(), defaultArchiveTimeout)
+	ctx, cancel := context.WithTimeout(m.bg.Context(), defaultArchiveTimeout)
 	defer cancel()
 	if err := m.recoverArchive(ctx, archivePrefix, convID); err != nil {
 		telemetry.Warn(ctx, "history: lazy archive recovery failed",

--- a/sdk/history/compactor.go
+++ b/sdk/history/compactor.go
@@ -208,8 +208,9 @@ func (m *compactor) LoadFiltered(ctx context.Context, conversationID string, opt
 	return ApplyLoadOptions(msgs, opts), nil
 }
 
-// clampPreservingSystem keeps the leading system message (if any) when
-// trimming from the head to satisfy MaxMessages.
+// clampPreservingSystem keeps the leading system message (if any) when there is
+// room for both system and conversation content. With maxMsgs==1 the most recent
+// non-system message is more useful than a system-only prompt.
 func clampPreservingSystem(msgs []model.Message, maxMsgs int) []model.Message {
 	if maxMsgs <= 0 || len(msgs) <= maxMsgs {
 		return msgs
@@ -217,6 +218,11 @@ func clampPreservingSystem(msgs []model.Message, maxMsgs int) []model.Message {
 	if len(msgs) > 0 && msgs[0].Role == model.RoleSystem {
 		head := msgs[0]
 		if maxMsgs == 1 {
+			for i := len(msgs) - 1; i >= 1; i-- {
+				if msgs[i].Role != model.RoleSystem {
+					return []model.Message{msgs[i]}
+				}
+			}
 			return []model.Message{head}
 		}
 		tail := msgs[1:]
@@ -1161,9 +1167,13 @@ func (d *SummaryDAG) Assemble(ctx context.Context, convID string, tokenBudget in
 		availableBudget = tokenBudget / 2
 	}
 
-	recentBudget := int(float64(availableBudget) * d.config.RecentRatio)
-	midBudget := int(float64(availableBudget) * d.config.MidRatio)
+	recentRatio, midRatio := normalizedHistoryRatios(d.config.RecentRatio, d.config.MidRatio)
+	recentBudget := int(float64(availableBudget) * recentRatio)
+	midBudget := int(float64(availableBudget) * midRatio)
 	farBudget := availableBudget - recentBudget - midBudget
+	if farBudget < 0 {
+		farBudget = 0
+	}
 
 	// Recent messages (from tail).
 	var recentMsgs []llm.Message
@@ -1181,6 +1191,11 @@ func (d *SummaryDAG) Assemble(ctx context.Context, convID string, tokenBudget in
 		}
 	}
 	recentMsgs = nonSystemMsgs[recentCutoff:]
+	if len(recentMsgs) == 0 && len(nonSystemMsgs) > 0 {
+		recentMsgs = nonSystemMsgs[len(nonSystemMsgs)-1:]
+		recentCutoff = len(nonSystemMsgs) - 1
+		recentTokens = d.countMsg(recentMsgs[0])
+	}
 
 	// Get summaries for earlier messages.
 	allSummaries, _ := d.store.List(ctx, convID, SummaryListOptions{})
@@ -1241,6 +1256,20 @@ func (d *SummaryDAG) Assemble(ctx context.Context, convID string, tokenBudget in
 
 	result = append(result, recentMsgs...)
 	return sanitizeToolPairs(result), nil
+}
+
+func normalizedHistoryRatios(recent, mid float64) (float64, float64) {
+	if recent < 0 {
+		recent = 0
+	}
+	if mid < 0 {
+		mid = 0
+	}
+	sum := recent + mid
+	if sum <= 1 {
+		return recent, mid
+	}
+	return recent / sum, mid / sum
 }
 
 // Compact removes deleted nodes and prunes leaf content.

--- a/sdk/history/coordinator_test.go
+++ b/sdk/history/coordinator_test.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io/fs"
 	"runtime"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -150,6 +152,225 @@ func TestCoordinator_AppendArchiveSerialized(t *testing.T) {
 	if store.maxConcurrent.Load() > 1 {
 		t.Fatalf("SaveMessages observed concurrency on the same conversation: max=%d",
 			store.maxConcurrent.Load())
+	}
+}
+
+func TestCoordinator_HotLogOwnerSerializesArchiveRecoverClearWithAppend(t *testing.T) {
+	t.Run("Archive", func(t *testing.T) {
+		ws := workspace.NewMemWorkspace()
+		store := newBlockingHotLogStore()
+		convID := "archive-append-owner"
+		seedMessages(t, store.inner, convID, 10)
+
+		cfg := DefaultDAGConfig()
+		cfg.Archive.ArchiveThreshold = 5
+		cfg.Archive.ArchiveBatchSize = 5
+		c := newCompactor(store, newNoopDAG(store, cfg), cfg, ws, "memory")
+		defer func() { _ = c.Shutdown(context.Background()) }()
+
+		entered := make(chan struct{})
+		release := make(chan struct{})
+		var once sync.Once
+		store.saveHook = func(id string, msgs []model.Message) {
+			if id == convID && len(msgs) == 5 {
+				once.Do(func() { close(entered) })
+				<-release
+			}
+		}
+
+		archiveDone := make(chan error, 1)
+		go func() {
+			_, err := c.Archive(context.Background(), convID)
+			archiveDone <- err
+		}()
+		waitForSignal(t, entered, "archive trim")
+
+		appendDone := make(chan error, 1)
+		go func() {
+			appendDone <- c.Append(context.Background(), convID, []model.Message{
+				model.NewTextMessage(model.RoleUser, "after-archive"),
+			})
+		}()
+		assertStillBlocked(t, appendDone, "Append while Archive owns hot log")
+
+		close(release)
+		if err := <-archiveDone; err != nil {
+			t.Fatalf("Archive: %v", err)
+		}
+		if err := <-appendDone; err != nil {
+			t.Fatalf("Append: %v", err)
+		}
+		got, err := store.GetMessages(context.Background(), convID)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(got) != 6 {
+			t.Fatalf("expected archived remainder plus append, got %d messages", len(got))
+		}
+	})
+
+	t.Run("RecoverArchive", func(t *testing.T) {
+		ws := workspace.NewMemWorkspace()
+		store := newBlockingHotLogStore()
+		convID := "recover-append-owner"
+		seedMessages(t, store.inner, convID, 10)
+		if err := writeIntent(context.Background(), ws, "memory", "archive", convID, &archiveIntent{
+			ConvID: convID, StartSeq: 0, EndSeq: 4, BatchSize: 5,
+			ArchiveFile: "messages_0_4.jsonl.gz", Phase: archivePhaseManifestUpdate,
+		}); err != nil {
+			t.Fatal(err)
+		}
+
+		entered := make(chan struct{})
+		release := make(chan struct{})
+		var once sync.Once
+		store.saveHook = func(id string, msgs []model.Message) {
+			if id == convID && len(msgs) == 5 {
+				once.Do(func() { close(entered) })
+				<-release
+			}
+		}
+
+		c := newCompactor(store, newNoopDAG(store, DefaultDAGConfig()), DefaultDAGConfig(), ws, "memory")
+		defer func() { _ = c.Shutdown(context.Background()) }()
+		waitForSignal(t, entered, "startup recovery trim")
+
+		appendDone := make(chan error, 1)
+		go func() {
+			appendDone <- c.Append(context.Background(), convID, []model.Message{
+				model.NewTextMessage(model.RoleUser, "after-recover"),
+			})
+		}()
+		assertStillBlocked(t, appendDone, "Append while recovery owns hot log")
+
+		close(release)
+		if err := <-appendDone; err != nil {
+			t.Fatalf("Append: %v", err)
+		}
+		got, err := store.GetMessages(context.Background(), convID)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(got) != 6 {
+			t.Fatalf("expected recovered remainder plus append, got %d messages", len(got))
+		}
+	})
+
+	t.Run("Clear", func(t *testing.T) {
+		store := newBlockingHotLogStore()
+		convID := "clear-append-owner"
+		seedMessages(t, store.inner, convID, 3)
+		c := newCompactor(store, newNoopDAG(store, DefaultDAGConfig()), DefaultDAGConfig(), nil, "memory")
+		defer func() { _ = c.Shutdown(context.Background()) }()
+
+		entered := make(chan struct{})
+		release := make(chan struct{})
+		store.deleteHook = func(id string) {
+			if id == convID {
+				close(entered)
+				<-release
+			}
+		}
+
+		clearDone := make(chan error, 1)
+		go func() { clearDone <- c.Clear(context.Background(), convID) }()
+		waitForSignal(t, entered, "clear")
+
+		appendDone := make(chan error, 1)
+		go func() {
+			appendDone <- c.Append(context.Background(), convID, []model.Message{
+				model.NewTextMessage(model.RoleUser, "after-clear"),
+			})
+		}()
+		assertStillBlocked(t, appendDone, "Append while Clear owns hot log")
+
+		close(release)
+		if err := <-clearDone; err != nil {
+			t.Fatalf("Clear: %v", err)
+		}
+		if err := <-appendDone; err != nil {
+			t.Fatalf("Append: %v", err)
+		}
+		got, err := store.GetMessages(context.Background(), convID)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(got) != 1 {
+			t.Fatalf("expected only post-clear append, got %d messages", len(got))
+		}
+	})
+}
+
+func TestCoordinator_EnqueueClosedRaceReturnsErrClosed(t *testing.T) {
+	c := &compactor{
+		queues:       map[string]*convQueue{"race": {tasks: make(chan convTask)}},
+		shutdownDone: make(chan struct{}),
+	}
+	close(c.queues["race"].tasks)
+
+	if err := c.enqueueAsync(context.Background(), "race", convTask{kind: taskIngest}); !errors.Is(err, ErrClosed) {
+		t.Fatalf("enqueueAsync expected ErrClosed, got %v", err)
+	}
+	if err := c.enqueueSync("race", convTask{kind: taskCompact, replyCompact: make(chan compactReply, 1)}); !errors.Is(err, ErrClosed) {
+		t.Fatalf("enqueueSync expected ErrClosed, got %v", err)
+	}
+}
+
+func TestCoordinator_StartupRecoveryShutdownCancelsScan(t *testing.T) {
+	ws := &cancelAwareListWorkspace{
+		MemWorkspace: workspace.NewMemWorkspace(),
+		entered:      make(chan struct{}),
+	}
+	store := NewInMemoryStore()
+	c := newCompactor(store, newNoopDAG(store, DefaultDAGConfig()), DefaultDAGConfig(), ws, "memory")
+	waitForSignal(t, ws.entered, "startup recovery List")
+
+	start := time.Now()
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	if err := c.Shutdown(ctx); err != nil {
+		t.Fatalf("Shutdown: %v", err)
+	}
+	if elapsed := time.Since(start); elapsed > 250*time.Millisecond {
+		t.Fatalf("Shutdown waited too long for startup recovery: %s", elapsed)
+	}
+}
+
+func TestCoordinator_LazyRecoveryFailureCanRetry(t *testing.T) {
+	ws := &lazyRetryWorkspace{MemWorkspace: workspace.NewMemWorkspace()}
+	store := NewInMemoryStore()
+	convID := "lazy-retry"
+	seedMessages(t, store, convID, 10)
+	if err := writeIntent(context.Background(), ws, "memory", "archive", convID, &archiveIntent{
+		ConvID: convID, StartSeq: 0, EndSeq: 4, BatchSize: 5,
+		ArchiveFile: "messages_0_4.jsonl.gz", Phase: archivePhaseManifestUpdate,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	c := newCompactor(store, newNoopDAG(store, DefaultDAGConfig()), DefaultDAGConfig(), ws, "memory")
+	defer func() { _ = c.Shutdown(context.Background()) }()
+
+	if _, err := c.Compact(context.Background(), convID); err != nil {
+		t.Fatalf("first Compact: %v", err)
+	}
+	intent, err := loadIntent(context.Background(), ws.MemWorkspace, "memory", "archive", convID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if intent == nil {
+		t.Fatal("first failed lazy recovery should leave intent for retry")
+	}
+
+	if _, err := c.Compact(context.Background(), convID); err != nil {
+		t.Fatalf("second Compact: %v", err)
+	}
+	intent, err = loadIntent(context.Background(), ws.MemWorkspace, "memory", "archive", convID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if intent != nil {
+		t.Fatal("second lazy recovery should clear intent")
 	}
 }
 
@@ -434,6 +655,100 @@ func (s *concurrencyAssertingStore) DeleteMessages(ctx context.Context, convID s
 // Ensure the wrapper participates as a plain Store (no MessageAppender)
 // so persistAppend goes through the SaveMessages path the test asserts.
 var _ Store = (*concurrencyAssertingStore)(nil)
+
+type cancelAwareListWorkspace struct {
+	*workspace.MemWorkspace
+	entered chan struct{}
+	once    sync.Once
+}
+
+func (w *cancelAwareListWorkspace) List(ctx context.Context, dir string) ([]fs.DirEntry, error) {
+	w.once.Do(func() { close(w.entered) })
+	<-ctx.Done()
+	return nil, ctx.Err()
+}
+
+type lazyRetryWorkspace struct {
+	*workspace.MemWorkspace
+	failReadOnce sync.Once
+}
+
+func (w *lazyRetryWorkspace) List(ctx context.Context, dir string) ([]fs.DirEntry, error) {
+	return nil, workspace.ErrNotFound
+}
+
+func (w *lazyRetryWorkspace) Read(ctx context.Context, path string) ([]byte, error) {
+	var fail bool
+	if strings.HasSuffix(path, "/intent.json") {
+		w.failReadOnce.Do(func() { fail = true })
+	}
+	if fail {
+		return nil, errors.New("injected intent read failure")
+	}
+	return w.MemWorkspace.Read(ctx, path)
+}
+
+type blockingHotLogStore struct {
+	inner      *InMemoryStore
+	saveHook   func(string, []model.Message)
+	deleteHook func(string)
+}
+
+func newBlockingHotLogStore() *blockingHotLogStore {
+	return &blockingHotLogStore{inner: NewInMemoryStore()}
+}
+
+func (s *blockingHotLogStore) GetMessages(ctx context.Context, convID string) ([]model.Message, error) {
+	return s.inner.GetMessages(ctx, convID)
+}
+
+func (s *blockingHotLogStore) SaveMessages(ctx context.Context, convID string, msgs []model.Message) error {
+	if s.saveHook != nil {
+		s.saveHook(convID, msgs)
+	}
+	return s.inner.SaveMessages(ctx, convID, msgs)
+}
+
+func (s *blockingHotLogStore) DeleteMessages(ctx context.Context, convID string) error {
+	if s.deleteHook != nil {
+		s.deleteHook(convID)
+	}
+	return s.inner.DeleteMessages(ctx, convID)
+}
+
+func seedMessages(t *testing.T, store *InMemoryStore, convID string, n int) {
+	t.Helper()
+	msgs := make([]model.Message, n)
+	for i := range msgs {
+		msgs[i] = model.NewTextMessage(model.RoleUser, fmt.Sprintf("seed-%d", i))
+	}
+	if err := store.SaveMessages(context.Background(), convID, msgs); err != nil {
+		t.Fatalf("seed messages: %v", err)
+	}
+}
+
+func newNoopDAG(store Store, cfg DAGConfig) *SummaryDAG {
+	summaryStore := &inMemSummaryStore{data: make(map[string][]*SummaryNode)}
+	return NewSummaryDAG(summaryStore, store, &mockSummaryLLM{}, cfg, &EstimateCounter{})
+}
+
+func waitForSignal(t *testing.T, ch <-chan struct{}, name string) {
+	t.Helper()
+	select {
+	case <-ch:
+	case <-time.After(time.Second):
+		t.Fatalf("timed out waiting for %s", name)
+	}
+}
+
+func assertStillBlocked(t *testing.T, ch <-chan error, name string) {
+	t.Helper()
+	select {
+	case err := <-ch:
+		t.Fatalf("%s returned before owner released: %v", name, err)
+	case <-time.After(25 * time.Millisecond):
+	}
+}
 
 // noopMessage placeholder helper used by the deadline test to avoid
 // importing llm in places that already have model.

--- a/sdk/history/coordinator_test.go
+++ b/sdk/history/coordinator_test.go
@@ -429,6 +429,65 @@ func TestLoad_PreservesSystemMessage(t *testing.T) {
 	}
 }
 
+func TestLoad_MaxMessagesOnePrefersConversationContent(t *testing.T) {
+	store := NewInMemoryStore()
+	summaryStore := &inMemSummaryStore{data: make(map[string][]*SummaryNode)}
+	dag := NewSummaryDAG(summaryStore, store, &mockSummaryLLM{}, DefaultDAGConfig(), &EstimateCounter{})
+	c := newCompactor(store, dag, DefaultDAGConfig(), nil, "memory")
+	defer func() { _ = c.Shutdown(context.Background()) }()
+
+	ctx := context.Background()
+	convID := "max-one-prefers-tail"
+	_ = store.SaveMessages(ctx, convID, []model.Message{
+		model.NewTextMessage(model.RoleSystem, "you are an assistant"),
+		model.NewTextMessage(model.RoleUser, "question"),
+		model.NewTextMessage(model.RoleAssistant, "answer"),
+	})
+
+	got, err := c.Load(ctx, convID, Budget{MaxMessages: 1})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("expected 1 msg, got %d", len(got))
+	}
+	if got[0].Role != model.RoleAssistant || got[0].Content() != "answer" {
+		t.Fatalf("MaxMessages=1 should keep latest non-system message, got role=%s content=%q", got[0].Role, got[0].Content())
+	}
+}
+
+func TestLoad_TinyTokenBudgetStillKeepsRecentMessage(t *testing.T) {
+	store := NewInMemoryStore()
+	summaryStore := &inMemSummaryStore{data: make(map[string][]*SummaryNode)}
+	cfg := DefaultDAGConfig()
+	cfg.TokenBudget = 1
+	cfg.RecentRatio = 0.9
+	cfg.MidRatio = 0.9 // deliberately invalid; Assemble should normalize.
+	dag := NewSummaryDAG(summaryStore, store, &mockSummaryLLM{}, cfg, &EstimateCounter{})
+	c := newCompactor(store, dag, cfg, nil, "memory")
+	defer func() { _ = c.Shutdown(context.Background()) }()
+
+	ctx := context.Background()
+	convID := "tiny-token-keeps-tail"
+	_ = store.SaveMessages(ctx, convID, []model.Message{
+		model.NewTextMessage(model.RoleSystem, "very long system prompt that exceeds tiny budget"),
+		model.NewTextMessage(model.RoleUser, "first user turn with enough text to exceed budget"),
+		model.NewTextMessage(model.RoleAssistant, "latest answer must survive"),
+	})
+
+	got, err := c.Load(ctx, convID, Budget{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) == 0 {
+		t.Fatal("expected at least one message")
+	}
+	last := got[len(got)-1]
+	if last.Role != model.RoleAssistant || last.Content() != "latest answer must survive" {
+		t.Fatalf("tiny budget should preserve latest non-system message, got role=%s content=%q", last.Role, last.Content())
+	}
+}
+
 // TestCoordinator_LazyArchiveRecovery checks D-R3: a stranded intent file
 // from a prior crash is recovered the first time the conversation is
 // touched after restart.

--- a/sdk/history/filestore_savemessages_test.go
+++ b/sdk/history/filestore_savemessages_test.go
@@ -57,6 +57,43 @@ func TestFileStore_SaveMessages_RewritesOnEqualLength(t *testing.T) {
 	}
 }
 
+func TestFileStore_SaveMessages_RewritesWhenExistingIsNotPrefix(t *testing.T) {
+	ws := workspace.NewMemWorkspace()
+	store := history.NewFileStore(ws, "memory")
+	ctx := context.Background()
+	conv := "conv-stale-prefix"
+
+	orig := []model.Message{
+		{Role: model.RoleUser, Parts: []model.Part{{Type: model.PartText, Text: "stale-A"}}},
+		{Role: model.RoleAssistant, Parts: []model.Part{{Type: model.PartText, Text: "stale-B"}}},
+	}
+	if err := store.SaveMessages(ctx, conv, orig); err != nil {
+		t.Fatalf("initial SaveMessages: %v", err)
+	}
+
+	replacement := []model.Message{
+		{Role: model.RoleUser, Parts: []model.Part{{Type: model.PartText, Text: "fresh-A"}}},
+		{Role: model.RoleAssistant, Parts: []model.Part{{Type: model.PartText, Text: "fresh-B"}}},
+		{Role: model.RoleUser, Parts: []model.Part{{Type: model.PartText, Text: "fresh-C"}}},
+	}
+	if err := store.SaveMessages(ctx, conv, replacement); err != nil {
+		t.Fatalf("replacement SaveMessages: %v", err)
+	}
+
+	got, err := store.GetMessages(ctx, conv)
+	if err != nil {
+		t.Fatalf("GetMessages: %v", err)
+	}
+	if len(got) != len(replacement) {
+		t.Fatalf("len = %d, want %d", len(got), len(replacement))
+	}
+	for i := range replacement {
+		if got[i].Parts[0].Text != replacement[i].Parts[0].Text {
+			t.Fatalf("msg[%d] = %q, want %q", i, got[i].Parts[0].Text, replacement[i].Parts[0].Text)
+		}
+	}
+}
+
 // Use llm package once to avoid unused-import warning in alternate
 // build configurations. The history.Store contract uses model.Message
 // directly; the llm symbol below is only retained as a sanity probe.

--- a/sdk/history/store.go
+++ b/sdk/history/store.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"reflect"
 	"sync"
 	"time"
 
@@ -334,6 +335,9 @@ func (s *FileStore) SaveMessages(ctx context.Context, conversationID string, mes
 	if len(messages) <= len(existing) {
 		return s.writeAll(ctx, path, messages)
 	}
+	if !messagesPrefixEqual(messages, existing) {
+		return s.writeAll(ctx, path, messages)
+	}
 
 	newMsgs := messages[len(existing):]
 	var buf bytes.Buffer
@@ -348,6 +352,18 @@ func (s *FileStore) SaveMessages(ctx context.Context, conversationID string, mes
 		return fmt.Errorf("memory: append %q: %w", path, err)
 	}
 	return nil
+}
+
+func messagesPrefixEqual(messages, prefix []model.Message) bool {
+	if len(prefix) > len(messages) {
+		return false
+	}
+	for i := range prefix {
+		if !reflect.DeepEqual(messages[i], prefix[i]) {
+			return false
+		}
+	}
+	return true
 }
 
 func (s *FileStore) DeleteMessages(ctx context.Context, conversationID string) error {

--- a/sdk/history/summary_store.go
+++ b/sdk/history/summary_store.go
@@ -243,8 +243,11 @@ func (s *FileSummaryStore) Save(ctx context.Context, node *SummaryNode) error {
 		node.CreatedAt = time.Now()
 	}
 
-	// Warm cache before disk write so the new node isn't double-counted.
-	if _, err := s.loadCached(ctx, node.ConversationID); err != nil {
+	// Warm cache before disk write so the new node isn't double-counted. Keep a
+	// snapshot locally because the global LRU may evict this entry while the
+	// workspace append is in flight.
+	nodes, err := s.loadCached(ctx, node.ConversationID)
+	if err != nil {
 		return err
 	}
 
@@ -259,7 +262,10 @@ func (s *FileSummaryStore) Save(ctx context.Context, node *SummaryNode) error {
 		return fmt.Errorf("summary_store: append %q: %w", path, err)
 	}
 
-	s.appendCache(node.ConversationID, node)
+	updated := make([]*SummaryNode, 0, len(nodes)+1)
+	updated = append(updated, nodes...)
+	updated = append(updated, node)
+	s.setCache(node.ConversationID, updated)
 	return nil
 }
 

--- a/sdk/history/summary_store_test.go
+++ b/sdk/history/summary_store_test.go
@@ -3,6 +3,7 @@ package history
 import (
 	"context"
 	"encoding/json"
+	"strings"
 	"testing"
 
 	"github.com/GizClaw/flowcraft/sdk/workspace"
@@ -188,6 +189,54 @@ func TestFileSummaryStore_CacheUpdatedOnSave(t *testing.T) {
 	if len(cached) != 2 {
 		t.Fatalf("expected 2 in cache, got %d", len(cached))
 	}
+}
+
+func TestFileSummaryStore_SaveRestoresCacheAfterLRUEviction(t *testing.T) {
+	base := workspace.NewMemWorkspace()
+	ctx := context.Background()
+	var store *FileSummaryStore
+	ws := &appendHookWorkspace{Workspace: base}
+	ws.onAppend = func(path string) {
+		if !strings.Contains(path, "mem/c/summaries.jsonl") {
+			return
+		}
+		ws.onAppend = nil
+		_ = store.Save(ctx, &SummaryNode{ConversationID: "other", Content: "evicting node"})
+	}
+	store = NewFileSummaryStore(ws, "mem", WithSummaryStoreCapacity(1))
+
+	if err := store.Save(ctx, &SummaryNode{ConversationID: "c", Content: "first"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.Save(ctx, &SummaryNode{ConversationID: "c", Content: "second"}); err != nil {
+		t.Fatal(err)
+	}
+
+	cached, ok := cacheSnapshot(store, "c")
+	if !ok {
+		t.Fatal("expected c cache to be restored after save")
+	}
+	if len(cached) != 2 {
+		t.Fatalf("expected restored cache to contain both nodes, got %d", len(cached))
+	}
+	if cached[0].Content != "first" || cached[1].Content != "second" {
+		t.Fatalf("unexpected cache contents: %+v", cached)
+	}
+}
+
+type appendHookWorkspace struct {
+	workspace.Workspace
+	onAppend func(path string)
+}
+
+func (w *appendHookWorkspace) Append(ctx context.Context, path string, data []byte) error {
+	if err := w.Workspace.Append(ctx, path, data); err != nil {
+		return err
+	}
+	if w.onAppend != nil {
+		w.onAppend(path)
+	}
+	return nil
 }
 
 func TestFileSummaryStore_CacheUpdatedOnRewrite(t *testing.T) {

--- a/sdk/internal/background/debouncer.go
+++ b/sdk/internal/background/debouncer.go
@@ -1,0 +1,104 @@
+package background
+
+import (
+	"sync"
+	"time"
+)
+
+// Debouncer emits one signal after a quiet period.
+//
+// Reset arms or re-arms the timer. The timer callback only attempts to send on
+// C; long-running work should happen in the owner loop that receives the signal.
+// C has capacity 1, so signals coalesce when the owner is busy.
+type Debouncer struct {
+	delay time.Duration
+	c     chan struct{}
+
+	mu      sync.Mutex
+	timer   *time.Timer
+	gen     uint64
+	stopped bool
+}
+
+// NewDebouncer creates a Debouncer. Non-positive delays are normalized to 1ns
+// so Reset still schedules work asynchronously through the timer path.
+func NewDebouncer(delay time.Duration) *Debouncer {
+	if delay <= 0 {
+		delay = time.Nanosecond
+	}
+	return &Debouncer{
+		delay: delay,
+		c:     make(chan struct{}, 1),
+	}
+}
+
+// C returns the signal channel consumed by the owner loop.
+func (d *Debouncer) C() <-chan struct{} {
+	if d == nil {
+		ch := make(chan struct{})
+		close(ch)
+		return ch
+	}
+	return d.c
+}
+
+// Reset schedules a signal after the quiet period. It returns false after Stop.
+func (d *Debouncer) Reset() bool {
+	if d == nil {
+		return false
+	}
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	if d.stopped {
+		return false
+	}
+	d.gen++
+	if d.timer != nil {
+		d.timer.Stop()
+	}
+	d.drainLocked()
+	gen := d.gen
+	d.timer = time.AfterFunc(d.delay, func() { d.fire(gen) })
+	return true
+}
+
+// Stop cancels future signals and drains any pending signal.
+func (d *Debouncer) Stop() {
+	if d == nil {
+		return
+	}
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	if d.stopped {
+		return
+	}
+	d.stopped = true
+	d.gen++
+	if d.timer != nil {
+		d.timer.Stop()
+		d.timer = nil
+	}
+	d.drainLocked()
+}
+
+func (d *Debouncer) fire(gen uint64) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	if d.stopped || gen != d.gen {
+		return
+	}
+	select {
+	case d.c <- struct{}{}:
+	default:
+	}
+}
+
+func (d *Debouncer) drainLocked() {
+	for {
+		select {
+		case <-d.c:
+		default:
+			return
+		}
+	}
+}

--- a/sdk/internal/background/debouncer_test.go
+++ b/sdk/internal/background/debouncer_test.go
@@ -1,0 +1,99 @@
+package background
+
+import (
+	"testing"
+	"time"
+)
+
+func TestDebouncerCoalescesResets(t *testing.T) {
+	d := NewDebouncer(50 * time.Millisecond)
+	defer d.Stop()
+
+	if !d.Reset() {
+		t.Fatal("first Reset returned false")
+	}
+	time.Sleep(10 * time.Millisecond)
+	if !d.Reset() {
+		t.Fatal("second Reset returned false")
+	}
+
+	select {
+	case <-d.C():
+		t.Fatal("debouncer fired before quiet period elapsed")
+	case <-time.After(20 * time.Millisecond):
+	}
+
+	select {
+	case <-d.C():
+	case <-time.After(200 * time.Millisecond):
+		t.Fatal("debouncer did not fire after quiet period")
+	}
+
+	select {
+	case <-d.C():
+		t.Fatal("debouncer emitted more than one signal for coalesced resets")
+	case <-time.After(20 * time.Millisecond):
+	}
+}
+
+func TestDebouncerResetDrainsPendingSignal(t *testing.T) {
+	d := NewDebouncer(40 * time.Millisecond)
+	defer d.Stop()
+
+	if !d.Reset() {
+		t.Fatal("first Reset returned false")
+	}
+	waitForPendingSignal(t, d)
+
+	if !d.Reset() {
+		t.Fatal("second Reset returned false")
+	}
+	select {
+	case <-d.C():
+		t.Fatal("Reset did not drain stale pending signal")
+	case <-time.After(10 * time.Millisecond):
+	}
+
+	select {
+	case <-d.C():
+	case <-time.After(200 * time.Millisecond):
+		t.Fatal("debouncer did not fire after reset")
+	}
+}
+
+func TestDebouncerStopPreventsSignals(t *testing.T) {
+	d := NewDebouncer(10 * time.Millisecond)
+	if !d.Reset() {
+		t.Fatal("Reset returned false")
+	}
+	d.Stop()
+	if d.Reset() {
+		t.Fatal("Reset succeeded after Stop")
+	}
+
+	select {
+	case <-d.C():
+		t.Fatal("debouncer emitted after Stop")
+	case <-time.After(30 * time.Millisecond):
+	}
+}
+
+func waitForPendingSignal(t *testing.T, d *Debouncer) {
+	t.Helper()
+	deadline := time.After(200 * time.Millisecond)
+	tick := time.NewTicker(time.Millisecond)
+	defer tick.Stop()
+	for {
+		select {
+		case <-deadline:
+			t.Fatal("timed out waiting for pending signal")
+		case <-tick.C:
+			d.mu.Lock()
+			n := len(d.c)
+			d.mu.Unlock()
+			if n > 0 {
+				return
+			}
+		}
+	}
+}

--- a/sdk/internal/background/doc.go
+++ b/sdk/internal/background/doc.go
@@ -1,0 +1,9 @@
+// Package background provides sdk-internal lifecycle primitives for long-lived
+// background work.
+//
+// The package intentionally knows nothing about history, knowledge, recall, or
+// telemetry backends. It only fixes the cross-cutting concurrency contract:
+// owners create a cancellable context, start goroutines with Add-before-go
+// ordering, debounce work through owner-loop signals, and classify work item
+// outcomes consistently.
+package background

--- a/sdk/internal/background/group.go
+++ b/sdk/internal/background/group.go
@@ -1,0 +1,94 @@
+package background
+
+import (
+	"context"
+	"sync"
+)
+
+// Group owns a lifecycle-bound context and a set of goroutines derived from it.
+//
+// Close is idempotent. It cancels the group context, waits for every accepted
+// goroutine to return, and then closes Done. Start synchronizes wg.Add before
+// launching the goroutine, so callers cannot race Close's Wait with a late Add.
+type Group struct {
+	mu      sync.Mutex
+	ctx     context.Context
+	cancel  context.CancelFunc
+	wg      sync.WaitGroup
+	closing bool
+
+	closeOnce sync.Once
+	done      chan struct{}
+}
+
+// NewGroup returns a fresh lifecycle group. A nil parent is treated as
+// context.Background().
+func NewGroup(parent context.Context) *Group {
+	if parent == nil {
+		parent = context.Background()
+	}
+	ctx, cancel := context.WithCancel(parent)
+	return &Group{
+		ctx:    ctx,
+		cancel: cancel,
+		done:   make(chan struct{}),
+	}
+}
+
+// Context returns the owner context shared by all accepted work.
+func (g *Group) Context() context.Context {
+	if g == nil {
+		return context.Background()
+	}
+	return g.ctx
+}
+
+// Done is closed after Close has canceled the context and all accepted work has
+// returned.
+func (g *Group) Done() <-chan struct{} {
+	if g == nil {
+		ch := make(chan struct{})
+		close(ch)
+		return ch
+	}
+	return g.done
+}
+
+// Start launches fn in a goroutine bound to the group context. It returns false
+// when Close has already started or fn is nil.
+func (g *Group) Start(fn func(context.Context)) bool {
+	if g == nil || fn == nil {
+		return false
+	}
+	g.mu.Lock()
+	if g.closing {
+		g.mu.Unlock()
+		return false
+	}
+	g.wg.Add(1)
+	ctx := g.ctx
+	g.mu.Unlock()
+
+	go func() {
+		defer g.wg.Done()
+		fn(ctx)
+	}()
+	return true
+}
+
+// Close cancels the group context and waits for all accepted work to drain.
+func (g *Group) Close() {
+	if g == nil {
+		return
+	}
+	g.closeOnce.Do(func() {
+		g.mu.Lock()
+		g.closing = true
+		g.cancel()
+		g.mu.Unlock()
+
+		g.wg.Wait()
+		close(g.done)
+	})
+	<-g.done
+}

--- a/sdk/internal/background/group_test.go
+++ b/sdk/internal/background/group_test.go
@@ -1,0 +1,70 @@
+package background
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+func TestGroupCloseCancelsAndWaits(t *testing.T) {
+	g := NewGroup(context.Background())
+	workerDone := make(chan struct{})
+	if !g.Start(func(ctx context.Context) {
+		<-ctx.Done()
+		close(workerDone)
+	}) {
+		t.Fatal("Start returned false")
+	}
+
+	closeDone := make(chan struct{})
+	go func() {
+		g.Close()
+		close(closeDone)
+	}()
+
+	select {
+	case <-workerDone:
+	case <-time.After(time.Second):
+		t.Fatal("worker did not observe group cancellation")
+	}
+	select {
+	case <-closeDone:
+	case <-time.After(time.Second):
+		t.Fatal("Close did not wait for worker to drain")
+	}
+	select {
+	case <-g.Done():
+	default:
+		t.Fatal("Done channel is not closed after Close")
+	}
+}
+
+func TestGroupRejectsStartAfterClose(t *testing.T) {
+	g := NewGroup(context.Background())
+	g.Close()
+
+	if g.Start(func(context.Context) {}) {
+		t.Fatal("Start succeeded after Close")
+	}
+	g.Close()
+}
+
+func TestGroupParentCancellationPropagates(t *testing.T) {
+	parent, cancel := context.WithCancel(context.Background())
+	g := NewGroup(parent)
+	workerDone := make(chan struct{})
+	if !g.Start(func(ctx context.Context) {
+		<-ctx.Done()
+		close(workerDone)
+	}) {
+		t.Fatal("Start returned false")
+	}
+
+	cancel()
+	select {
+	case <-workerDone:
+	case <-time.After(time.Second):
+		t.Fatal("worker did not observe parent cancellation")
+	}
+	g.Close()
+}

--- a/sdk/internal/background/outcome.go
+++ b/sdk/internal/background/outcome.go
@@ -1,0 +1,33 @@
+package background
+
+import (
+	"context"
+	"errors"
+)
+
+// Outcome is the normalized result label for a background work item.
+type Outcome string
+
+const (
+	OutcomeSucceeded Outcome = "succeeded"
+	OutcomeCanceled  Outcome = "canceled"
+	OutcomeTimeout   Outcome = "timeout"
+	OutcomeFailed    Outcome = "failed"
+)
+
+// String returns the stable telemetry label for o.
+func (o Outcome) String() string { return string(o) }
+
+// Classify returns the normalized outcome for err.
+func Classify(err error) Outcome {
+	switch {
+	case err == nil:
+		return OutcomeSucceeded
+	case errors.Is(err, context.DeadlineExceeded):
+		return OutcomeTimeout
+	case errors.Is(err, context.Canceled):
+		return OutcomeCanceled
+	default:
+		return OutcomeFailed
+	}
+}

--- a/sdk/internal/background/outcome_test.go
+++ b/sdk/internal/background/outcome_test.go
@@ -1,0 +1,34 @@
+package background
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+)
+
+func TestClassify(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want Outcome
+	}{
+		{name: "nil", err: nil, want: OutcomeSucceeded},
+		{name: "timeout", err: context.DeadlineExceeded, want: OutcomeTimeout},
+		{name: "wrapped timeout", err: fmt.Errorf("work: %w", context.DeadlineExceeded), want: OutcomeTimeout},
+		{name: "canceled", err: context.Canceled, want: OutcomeCanceled},
+		{name: "wrapped canceled", err: fmt.Errorf("work: %w", context.Canceled), want: OutcomeCanceled},
+		{name: "failed", err: errors.New("boom"), want: OutcomeFailed},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := Classify(tt.err); got != tt.want {
+				t.Fatalf("Classify() = %q, want %q", got, tt.want)
+			}
+			if tt.want.String() == "" {
+				t.Fatal("Outcome.String returned empty label")
+			}
+		})
+	}
+}

--- a/sdk/knowledge/backend/fs/chunk.go
+++ b/sdk/knowledge/backend/fs/chunk.go
@@ -206,6 +206,12 @@ func (r *FSChunkRepo) Replace(ctx context.Context, datasetID, docName string, ch
 	if !ok {
 		state = newDatasetState()
 	}
+	if len(chunks) > 0 {
+		wantSourceVer := chunksSourceVer(chunks)
+		if existing, present := docSigFromState(state, docName); present && existing.SourceVer > wantSourceVer {
+			return nil
+		}
+	}
 	merged := make([]knowledge.DerivedChunk, 0, len(state.chunks)+len(chunks))
 	for _, c := range state.chunks {
 		if c.DocName == docName {
@@ -226,7 +232,8 @@ func (r *FSChunkRepo) Replace(ctx context.Context, datasetID, docName string, ch
 	return nil
 }
 
-// DeleteByDoc removes every chunk for (datasetID, docName).
+// DeleteByDoc removes every chunk for (datasetID, docName). Missing
+// target documents are idempotent success and do not return NotFound.
 //
 // Same locking discipline as Replace: read-mutate-persist-install runs
 // under the write lock so concurrent Delete + Replace cannot lose
@@ -253,6 +260,37 @@ func (r *FSChunkRepo) DeleteByDoc(ctx context.Context, datasetID, docName string
 	}
 	r.states[datasetID] = r.buildState(merged)
 	return nil
+}
+
+// GetDocSig satisfies knowledge.ChunkSigReader for the filesystem backend.
+// Missing datasets or documents return (DerivedSig{}, false, nil).
+func (r *FSChunkRepo) GetDocSig(ctx context.Context, datasetID, docName string) (knowledge.DerivedSig, bool, error) {
+	if datasetID == "" || docName == "" {
+		return knowledge.DerivedSig{}, false, errdefs.Validationf("knowledge/fs: dataset_id and doc_name are required")
+	}
+	if err := ctx.Err(); err != nil {
+		return knowledge.DerivedSig{}, false, errdefs.FromContext(err)
+	}
+	r.mu.RLock()
+	state, ok := r.states[datasetID]
+	if ok {
+		if sig, present := docSigFromState(state, docName); present {
+			r.mu.RUnlock()
+			return sig, true, nil
+		}
+	}
+	r.mu.RUnlock()
+	if err := r.loadDataset(ctx, datasetID); err != nil {
+		return knowledge.DerivedSig{}, false, err
+	}
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	state, ok = r.states[datasetID]
+	if !ok {
+		return knowledge.DerivedSig{}, false, nil
+	}
+	sig, present := docSigFromState(state, docName)
+	return sig, present, nil
 }
 
 // DeleteByDataset removes every chunk for the dataset and the chunks.json file.
@@ -338,6 +376,28 @@ func (r *FSChunkRepo) buildState(chunks []knowledge.DerivedChunk) *datasetState 
 		state.docStats.AvgLength = totalDL / float64(state.docStats.DocCount)
 	}
 	return state
+}
+
+func chunksSourceVer(chunks []knowledge.DerivedChunk) uint64 {
+	var out uint64
+	for _, c := range chunks {
+		if c.Sig.SourceVer > out {
+			out = c.Sig.SourceVer
+		}
+	}
+	return out
+}
+
+func docSigFromState(state *datasetState, docName string) (knowledge.DerivedSig, bool) {
+	if state == nil {
+		return knowledge.DerivedSig{}, false
+	}
+	for _, c := range state.chunks {
+		if c.DocName == docName {
+			return c.Sig, true
+		}
+	}
+	return knowledge.DerivedSig{}, false
 }
 
 // Search runs the requested mode against the in-memory index. Vector
@@ -605,4 +665,7 @@ func scoreVector(datasetID string, state *datasetState, qvec []float32) []knowle
 }
 
 // Compile-time interface assertion.
-var _ knowledge.ChunkRepo = (*FSChunkRepo)(nil)
+var (
+	_ knowledge.ChunkRepo      = (*FSChunkRepo)(nil)
+	_ knowledge.ChunkSigReader = (*FSChunkRepo)(nil)
+)

--- a/sdk/knowledge/backend/fs/document.go
+++ b/sdk/knowledge/backend/fs/document.go
@@ -69,11 +69,12 @@ type metaSidecar struct {
 }
 
 // Put atomically increments SourceDocument.Version, writes the raw
-// content, and updates the .meta.json sidecar. Doc.Version supplied by
-// the caller is ignored; the repo is the source of truth for versions.
-func (r *FSDocumentRepo) Put(ctx context.Context, doc knowledge.SourceDocument) error {
+// content, updates the .meta.json sidecar, and returns the authoritative
+// stored SourceDocument. Doc.Version / UpdatedAt supplied by the caller
+// are ignored; the repo is the source of truth for both fields.
+func (r *FSDocumentRepo) Put(ctx context.Context, doc knowledge.SourceDocument) (*knowledge.SourceDocument, error) {
 	if doc.DatasetID == "" || doc.Name == "" {
-		return errdefs.Validationf("knowledge/fs: dataset_id and name are required")
+		return nil, errdefs.Validationf("knowledge/fs: dataset_id and name are required")
 	}
 	mu := r.lockFor(doc.DatasetID, doc.Name)
 	mu.Lock()
@@ -88,7 +89,7 @@ func (r *FSDocumentRepo) Put(ctx context.Context, doc knowledge.SourceDocument) 
 	now := r.now().UTC()
 
 	if err := atomicWrite(ctx, r.ws, r.paths.documentPath(doc.DatasetID, doc.Name), []byte(doc.Content)); err != nil {
-		return err
+		return nil, err
 	}
 
 	side := metaSidecar{
@@ -98,12 +99,19 @@ func (r *FSDocumentRepo) Put(ctx context.Context, doc knowledge.SourceDocument) 
 	}
 	payload, err := json.Marshal(side)
 	if err != nil {
-		return fmt.Errorf("knowledge/fs: marshal meta: %w", err)
+		return nil, fmt.Errorf("knowledge/fs: marshal meta: %w", err)
 	}
 	if err := atomicWrite(ctx, r.ws, r.paths.metaPath(doc.DatasetID, doc.Name), payload); err != nil {
-		return err
+		return nil, err
 	}
-	return nil
+	return &knowledge.SourceDocument{
+		DatasetID: doc.DatasetID,
+		Name:      doc.Name,
+		Content:   doc.Content,
+		Metadata:  copyMetadata(doc.Metadata),
+		Version:   nextVersion,
+		UpdatedAt: now,
+	}, nil
 }
 
 // Get returns the SourceDocument with Content losslessly preserved.

--- a/sdk/knowledge/backend/fs/document_test.go
+++ b/sdk/knowledge/backend/fs/document_test.go
@@ -25,8 +25,12 @@ func TestDocumentRepo_PutIncrementsVersion(t *testing.T) {
 	ctx := context.Background()
 	doc := knowledge.SourceDocument{DatasetID: "ds1", Name: "a.md", Content: "hello"}
 
-	if err := repo.Put(ctx, doc); err != nil {
+	stored, err := repo.Put(ctx, doc)
+	if err != nil {
 		t.Fatalf("first put: %v", err)
+	}
+	if stored.Version != 1 {
+		t.Fatalf("stored first version = %d, want 1", stored.Version)
 	}
 	got, err := repo.Get(ctx, "ds1", "a.md")
 	if err != nil {
@@ -37,8 +41,12 @@ func TestDocumentRepo_PutIncrementsVersion(t *testing.T) {
 	}
 
 	doc.Content = "hello v2"
-	if err := repo.Put(ctx, doc); err != nil {
+	stored, err = repo.Put(ctx, doc)
+	if err != nil {
 		t.Fatalf("second put: %v", err)
+	}
+	if stored.Version != 2 {
+		t.Fatalf("stored second version = %d, want 2", stored.Version)
 	}
 	got, err = repo.Get(ctx, "ds1", "a.md")
 	if err != nil {
@@ -56,7 +64,7 @@ func TestDocumentRepo_GetLosslessContent(t *testing.T) {
 	repo, _ := newRepo(t)
 	ctx := context.Background()
 	raw := "---\ntitle: Demo\n---\nbody line one\nbody line two\n"
-	if err := repo.Put(ctx, knowledge.SourceDocument{DatasetID: "ds", Name: "doc.md", Content: raw}); err != nil {
+	if _, err := repo.Put(ctx, knowledge.SourceDocument{DatasetID: "ds", Name: "doc.md", Content: raw}); err != nil {
 		t.Fatalf("put: %v", err)
 	}
 	got, err := repo.Get(ctx, "ds", "doc.md")
@@ -79,7 +87,7 @@ func TestDocumentRepo_GetMissingReturnsNotFound(t *testing.T) {
 func TestDocumentRepo_DeleteRemovesSidecars(t *testing.T) {
 	repo, ws := newRepo(t)
 	ctx := context.Background()
-	if err := repo.Put(ctx, knowledge.SourceDocument{DatasetID: "ds", Name: "a.md", Content: "x"}); err != nil {
+	if _, err := repo.Put(ctx, knowledge.SourceDocument{DatasetID: "ds", Name: "a.md", Content: "x"}); err != nil {
 		t.Fatalf("put: %v", err)
 	}
 	// Drop a sidecar to verify Delete cleans it up.
@@ -111,7 +119,7 @@ func TestDocumentRepo_ListSortedByName(t *testing.T) {
 	repo, _ := newRepo(t)
 	ctx := context.Background()
 	for _, n := range []string{"c.md", "a.md", "b.md"} {
-		if err := repo.Put(ctx, knowledge.SourceDocument{DatasetID: "ds", Name: n, Content: n}); err != nil {
+		if _, err := repo.Put(ctx, knowledge.SourceDocument{DatasetID: "ds", Name: n, Content: n}); err != nil {
 			t.Fatalf("put %s: %v", n, err)
 		}
 	}
@@ -134,7 +142,7 @@ func TestDocumentRepo_ListDatasets(t *testing.T) {
 	repo, _ := newRepo(t)
 	ctx := context.Background()
 	for _, ds := range []string{"alpha", "beta", "gamma"} {
-		if err := repo.Put(ctx, knowledge.SourceDocument{DatasetID: ds, Name: "x.md", Content: "x"}); err != nil {
+		if _, err := repo.Put(ctx, knowledge.SourceDocument{DatasetID: ds, Name: "x.md", Content: "x"}); err != nil {
 			t.Fatalf("put %s: %v", ds, err)
 		}
 	}
@@ -149,10 +157,10 @@ func TestDocumentRepo_ListDatasets(t *testing.T) {
 
 func TestDocumentRepo_PutValidatesInputs(t *testing.T) {
 	repo, _ := newRepo(t)
-	if err := repo.Put(context.Background(), knowledge.SourceDocument{DatasetID: "", Name: "x", Content: "y"}); !errdefs.IsValidation(err) {
+	if _, err := repo.Put(context.Background(), knowledge.SourceDocument{DatasetID: "", Name: "x", Content: "y"}); !errdefs.IsValidation(err) {
 		t.Fatalf("missing dataset: got %v, want Validation", err)
 	}
-	if err := repo.Put(context.Background(), knowledge.SourceDocument{DatasetID: "ds", Name: "", Content: "y"}); !errdefs.IsValidation(err) {
+	if _, err := repo.Put(context.Background(), knowledge.SourceDocument{DatasetID: "ds", Name: "", Content: "y"}); !errdefs.IsValidation(err) {
 		t.Fatalf("missing name: got %v, want Validation", err)
 	}
 }

--- a/sdk/knowledge/backend/retrieval/chunk.go
+++ b/sdk/knowledge/backend/retrieval/chunk.go
@@ -64,6 +64,13 @@ func (r *RetrievalChunkRepo) Replace(ctx context.Context, datasetID, docName str
 		return errdefs.Validationf("knowledge/retrieval: dataset_id and doc_name are required")
 	}
 	ns := chunksNamespace(datasetID)
+	if len(chunks) > 0 {
+		if existing, present, err := r.GetDocSig(ctx, datasetID, docName); err != nil {
+			return err
+		} else if present && existing.SourceVer > chunksSourceVer(chunks) {
+			return nil
+		}
+	}
 
 	if err := r.deleteByDoc(ctx, ns, docName); err != nil {
 		return err
@@ -152,7 +159,8 @@ func (r *RetrievalChunkRepo) deleteDocLevel(ctx context.Context, datasetID, docN
 }
 
 // DeleteByDoc removes every chunk for (datasetID, docName) and the
-// matching doc-level entry from the __docs namespace.
+// matching doc-level entry from the __docs namespace. Missing target
+// documents are idempotent success and do not return NotFound.
 func (r *RetrievalChunkRepo) DeleteByDoc(ctx context.Context, datasetID, docName string) error {
 	if datasetID == "" || docName == "" {
 		return errdefs.Validationf("knowledge/retrieval: dataset_id and doc_name are required")
@@ -431,6 +439,16 @@ func (r *RetrievalChunkRepo) searchOne(ctx context.Context, ns string, q knowled
 		return nil, nil
 	}
 	return resp.Hits, nil
+}
+
+func chunksSourceVer(chunks []knowledge.DerivedChunk) uint64 {
+	var out uint64
+	for _, c := range chunks {
+		if c.Sig.SourceVer > out {
+			out = c.Sig.SourceVer
+		}
+	}
+	return out
 }
 
 // SearchDocs runs a doc-level BM25 query directly against the

--- a/sdk/knowledge/backend/retrieval/layer.go
+++ b/sdk/knowledge/backend/retrieval/layer.go
@@ -110,7 +110,8 @@ func (r *RetrievalLayerRepo) Get(ctx context.Context, datasetID, docName string,
 	return docToLayer(datasetID, docName, layer, page.Items[0]), nil
 }
 
-// DeleteByDoc removes both layers for a single document.
+// DeleteByDoc removes both layers for a single document. Missing target
+// documents are idempotent success and do not return NotFound.
 func (r *RetrievalLayerRepo) DeleteByDoc(ctx context.Context, datasetID, docName string) error {
 	if datasetID == "" || docName == "" {
 		return errdefs.Validationf("knowledge/retrieval: dataset_id and doc_name are required")

--- a/sdk/knowledge/model.go
+++ b/sdk/knowledge/model.go
@@ -55,7 +55,8 @@ type DerivedSig struct {
 // IsStale returns true when sig was produced for an earlier source version
 // or with a different chunker / prompt / embed configuration than want.
 //
-// A zero EmbedSig in want is treated as "don't care".
+// EmbedSig is compared strictly, including the empty string. This makes
+// vectors stale when an embedder is removed so a rebuild can clear them.
 func (sig DerivedSig) IsStale(want DerivedSig) bool {
 	if sig.SourceVer != want.SourceVer {
 		return true
@@ -66,7 +67,7 @@ func (sig DerivedSig) IsStale(want DerivedSig) bool {
 	if want.PromptSig != "" && sig.PromptSig != want.PromptSig {
 		return true
 	}
-	if want.EmbedSig != "" && sig.EmbedSig != want.EmbedSig {
+	if sig.EmbedSig != want.EmbedSig {
 		return true
 	}
 	return false

--- a/sdk/knowledge/reloader.go
+++ b/sdk/knowledge/reloader.go
@@ -6,6 +6,9 @@ import (
 	"time"
 
 	"github.com/GizClaw/flowcraft/sdk/errdefs"
+	"github.com/GizClaw/flowcraft/sdk/internal/background"
+	"github.com/GizClaw/flowcraft/sdk/telemetry"
+	otellog "go.opentelemetry.io/otel/log"
 )
 
 // EventNotifier is the producer side of the reload pipeline. Events
@@ -24,14 +27,18 @@ type EventNotifier interface {
 //
 //   - Debounce       controls the trailing-edge window.
 //   - RebuildTimeout caps each rebuild call.
+//   - RetryBackoff   is the initial retry delay after a rebuild error.
+//   - MaxRetryBackoff caps exponential retry delay.
 type ReloaderOptions struct {
-	Debounce       time.Duration
-	RebuildTimeout time.Duration
+	Debounce        time.Duration
+	RebuildTimeout  time.Duration
+	RetryBackoff    time.Duration
+	MaxRetryBackoff time.Duration
 }
 
 // EventReloader debounces ChangeEvents and triggers Rebuild on the
-// trailing edge. Rebuilds are serialised: a new rebuild waits for the
-// previous one to finish.
+// trailing edge from one owner loop. Rebuilds are serialised: a new
+// rebuild waits for the previous one to finish.
 //
 // Targeted vs global rebuilds: when the debounce window contains
 // events for a single (dataset, doc) pair, the rebuild is scoped to
@@ -43,13 +50,18 @@ type EventReloader struct {
 	notifier EventNotifier
 	debounce time.Duration
 	timeout  time.Duration
+	retry    time.Duration
+	maxRetry time.Duration
 
-	mu      sync.Mutex
-	pending map[scopeKey]struct{} // events accumulated within the window
-	timer   *time.Timer
-	wg      sync.WaitGroup
-	stop    chan struct{}
-	stopped bool
+	debouncer *background.Debouncer
+
+	mu        sync.Mutex
+	pending   map[scopeKey]struct{} // events accumulated within the window
+	stop      chan struct{}
+	done      chan struct{}
+	started   bool
+	stopped   bool
+	runCancel context.CancelFunc
 }
 
 // scopeKey collapses a ChangeEvent into a comparable scope so the
@@ -62,6 +74,7 @@ type scopeKey struct {
 // NewEventReloader wires a Rebuilder to an EventNotifier.
 //
 // opts.Debounce defaults to 500ms; opts.RebuildTimeout defaults to 30s.
+// RetryBackoff defaults to 200ms and MaxRetryBackoff defaults to 5s.
 //
 // When target or notifier is nil, Run becomes a no-op (returns
 // immediately) and Close is also a no-op for the background loop, so
@@ -70,17 +83,11 @@ type scopeKey struct {
 //
 // In the normal (non-nil) configuration the contract is:
 //
-//   - Run MUST be invoked at most once before Close;
+//   - Run MUST be invoked at most once;
 //   - Close blocks until Run has actually exited AND the notifier has
 //     been closed, so callers observing a successful Close are
-//     guaranteed no further Rebuild / timer callback can fire.
-//
-// To uphold the second guarantee even when Close races with the
-// goroutine that is about to call Run, wg.Add(1) is performed here
-// (synchronously, before the constructor returns) rather than inside
-// Run. This way wg.Add strictly happens-before any wg.Wait in Close,
-// which is what sync.WaitGroup requires when its counter starts at
-// zero.
+//     guaranteed no further Rebuild can fire. Close also cancels an
+//     in-flight rebuild through the Run context.
 func NewEventReloader(target Rebuilder, notifier EventNotifier, opts ReloaderOptions) *EventReloader {
 	debounce := opts.Debounce
 	if debounce <= 0 {
@@ -90,16 +97,28 @@ func NewEventReloader(target Rebuilder, notifier EventNotifier, opts ReloaderOpt
 	if timeout <= 0 {
 		timeout = 30 * time.Second
 	}
-	r := &EventReloader{
-		target:   target,
-		notifier: notifier,
-		debounce: debounce,
-		timeout:  timeout,
-		pending:  make(map[scopeKey]struct{}),
-		stop:     make(chan struct{}),
+	retry := opts.RetryBackoff
+	if retry <= 0 {
+		retry = 200 * time.Millisecond
 	}
-	if target != nil && notifier != nil {
-		r.wg.Add(1)
+	maxRetry := opts.MaxRetryBackoff
+	if maxRetry <= 0 {
+		maxRetry = 5 * time.Second
+	}
+	if maxRetry < retry {
+		maxRetry = retry
+	}
+	r := &EventReloader{
+		target:    target,
+		notifier:  notifier,
+		debounce:  debounce,
+		timeout:   timeout,
+		retry:     retry,
+		maxRetry:  maxRetry,
+		debouncer: background.NewDebouncer(debounce),
+		pending:   make(map[scopeKey]struct{}),
+		stop:      make(chan struct{}),
+		done:      make(chan struct{}),
 	}
 	return r
 }
@@ -111,20 +130,101 @@ func (r *EventReloader) Run(ctx context.Context) error {
 	if r == nil || r.target == nil || r.notifier == nil {
 		return nil
 	}
-	defer r.wg.Done()
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	runCtx, cancel := context.WithCancel(ctx)
+	r.mu.Lock()
+	if r.started {
+		r.mu.Unlock()
+		cancel()
+		return errdefs.Validationf("knowledge: EventReloader.Run called more than once")
+	}
+	if r.stopped {
+		r.mu.Unlock()
+		cancel()
+		return nil
+	}
+	r.started = true
+	r.runCancel = cancel
+	r.mu.Unlock()
+
+	defer func() {
+		r.debouncer.Stop()
+		cancel()
+		r.mu.Lock()
+		r.runCancel = nil
+		r.mu.Unlock()
+		close(r.done)
+	}()
+	return r.loop(runCtx)
+}
+
+func (r *EventReloader) loop(ctx context.Context) error {
+	var (
+		retryTimer *time.Timer
+		retryC     <-chan time.Time
+		nextRetry  = r.retry
+	)
+	stopRetry := func() {
+		if retryTimer == nil {
+			return
+		}
+		if !retryTimer.Stop() {
+			select {
+			case <-retryTimer.C:
+			default:
+			}
+		}
+		retryTimer = nil
+		retryC = nil
+	}
+	defer stopRetry()
+
+	scheduleRetry := func() {
+		if !r.hasPending() {
+			return
+		}
+		if retryTimer != nil {
+			retryTimer.Reset(nextRetry)
+		} else {
+			retryTimer = time.NewTimer(nextRetry)
+		}
+		retryC = retryTimer.C
+		if nextRetry < r.maxRetry {
+			nextRetry *= 2
+			if nextRetry > r.maxRetry {
+				nextRetry = r.maxRetry
+			}
+		}
+	}
+
 	for {
 		select {
 		case <-ctx.Done():
-			r.cancelTimer()
 			return errdefs.FromContext(ctx.Err())
 		case <-r.stop:
-			r.cancelTimer()
 			return nil
 		case ev, ok := <-r.notifier.Events():
 			if !ok {
 				return nil
 			}
-			r.enqueue(ctx, ev)
+			r.enqueue(ev)
+		case <-r.debouncer.C():
+			stopRetry()
+			if r.rebuildPending(ctx) {
+				nextRetry = r.retry
+			} else {
+				scheduleRetry()
+			}
+		case <-retryC:
+			retryTimer = nil
+			retryC = nil
+			if r.rebuildPending(ctx) {
+				nextRetry = r.retry
+			} else {
+				scheduleRetry()
+			}
 		}
 	}
 }
@@ -133,84 +233,103 @@ func (r *EventReloader) Run(ctx context.Context) error {
 //
 // In the normal (non-nil target & notifier) configuration Close blocks
 // until Run has actually returned, so on success the caller is
-// guaranteed that no further Rebuild call or timer-driven flush can
-// happen. Calling Close before Run was started would deadlock, so
-// callers MUST start Run first; this matches the EventReloader
-// lifecycle documented on Run / NewEventReloader.
+// guaranteed that no further Rebuild call can happen. Calling Close
+// before Run is safe; a later Run returns immediately.
 //
 // When target or notifier is nil, Close is a no-op and may be called
 // at any time.
 func (r *EventReloader) Close() error {
-	r.mu.Lock()
-	if r.stopped {
-		r.mu.Unlock()
+	if r == nil {
 		return nil
 	}
-	r.stopped = true
-	close(r.stop)
-	r.mu.Unlock()
-	r.wg.Wait()
-	if r.notifier != nil {
-		return r.notifier.Close()
+	var (
+		cancel context.CancelFunc
+		wait   bool
+	)
+	r.mu.Lock()
+	if !r.stopped {
+		r.stopped = true
+		close(r.stop)
+		cancel = r.runCancel
 	}
-	return nil
+	wait = r.started
+	r.mu.Unlock()
+	if cancel != nil {
+		cancel()
+	}
+	if r.debouncer != nil {
+		r.debouncer.Stop()
+	}
+	var err error
+	if r.notifier != nil {
+		err = r.notifier.Close()
+	}
+	if wait {
+		<-r.done
+	}
+	return err
 }
 
 // enqueue is the body of the debouncer: it stamps the event into the
 // pending set and (re)arms the trailing-edge timer.
-func (r *EventReloader) enqueue(ctx context.Context, ev ChangeEvent) {
+func (r *EventReloader) enqueue(ev ChangeEvent) {
 	key := scopeKey{datasetID: ev.DatasetID}
 	if ev.Kind != EventBulk {
 		key.docName = ev.DocName
 	}
 	r.mu.Lock()
 	r.pending[key] = struct{}{}
-	if r.timer != nil {
-		r.timer.Stop()
-	}
-	r.timer = time.AfterFunc(r.debounce, func() { r.flush(ctx) })
 	r.mu.Unlock()
+	r.debouncer.Reset()
 }
 
-// flush executes the rebuild for the accumulated pending set.
+// rebuildPending executes the rebuild for the accumulated pending set.
 //
 // Scope reduction:
 //   - one (datasetID, docName)            -> RebuildScope{datasetID, docName}
 //   - one datasetID, multiple docs/bulk   -> RebuildScope{datasetID}
 //   - multiple datasetIDs                 -> RebuildScope{} (everything)
 //
-// Concurrency: flush registers itself with the same waitgroup that
-// Run uses BEFORE checking stopped, so [Close] (which calls
-// wg.Wait) blocks until any in-flight Rebuild returns. Pre-fix
-// (#159) the rebuild happened on a time.AfterFunc goroutine that
-// was untracked, letting Close return while Rebuild was still
-// running — the godoc claim "no further Rebuild call or
-// timer-driven flush can happen after Close" was broken.
-func (r *EventReloader) flush(ctx context.Context) {
-	r.wg.Add(1)
-	defer r.wg.Done()
-
+// On error, the contributing events remain pending so the owner loop can
+// retry with backoff; successful rebuilds remove only the snapshot they
+// consumed.
+func (r *EventReloader) rebuildPending(ctx context.Context) bool {
 	r.mu.Lock()
-	if r.stopped {
+	if len(r.pending) == 0 {
 		r.mu.Unlock()
-		return
+		return true
 	}
-	scope := reducePending(r.pending)
-	r.pending = make(map[scopeKey]struct{})
+	snapshot := make(map[scopeKey]struct{}, len(r.pending))
+	for k := range r.pending {
+		snapshot[k] = struct{}{}
+	}
+	scope := reducePending(snapshot)
 	r.mu.Unlock()
 
 	rebuildCtx, cancel := context.WithTimeout(ctx, r.timeout)
 	defer cancel()
-	_ = r.target.Rebuild(rebuildCtx, scope)
+	err := r.target.Rebuild(rebuildCtx, scope)
+	if err != nil {
+		outcome := background.Classify(err)
+		telemetry.Error(ctx, "knowledge reloader rebuild failed",
+			otellog.String("outcome", outcome.String()),
+			otellog.String("dataset_id", scope.DatasetID),
+			otellog.String("doc_name", scope.DocName),
+			otellog.String("error", err.Error()))
+		return false
+	}
+	r.mu.Lock()
+	for k := range snapshot {
+		delete(r.pending, k)
+	}
+	r.mu.Unlock()
+	return true
 }
 
-func (r *EventReloader) cancelTimer() {
+func (r *EventReloader) hasPending() bool {
 	r.mu.Lock()
 	defer r.mu.Unlock()
-	if r.timer != nil {
-		r.timer.Stop()
-		r.timer = nil
-	}
+	return len(r.pending) > 0
 }
 
 // reducePending collapses the pending set into a single RebuildScope

--- a/sdk/knowledge/reloader_test.go
+++ b/sdk/knowledge/reloader_test.go
@@ -2,6 +2,7 @@ package knowledge
 
 import (
 	"context"
+	"errors"
 	"sync"
 	"testing"
 	"time"
@@ -158,5 +159,91 @@ func TestEventReloader_SerialisesRebuilds(t *testing.T) {
 	_ = r.Close()
 	if len(rb.scopes) < 2 {
 		t.Fatalf("expected >= 2 rebuilds, got %d", len(rb.scopes))
+	}
+}
+
+type retryRebuilder struct {
+	mu        sync.Mutex
+	calls     int
+	scopes    []RebuildScope
+	succeeded chan struct{}
+}
+
+func (r *retryRebuilder) Rebuild(_ context.Context, scope RebuildScope) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.calls++
+	r.scopes = append(r.scopes, scope)
+	if r.calls == 1 {
+		return errors.New("transient")
+	}
+	select {
+	case <-r.succeeded:
+	default:
+		close(r.succeeded)
+	}
+	return nil
+}
+
+func TestEventReloader_RetriesAndKeepsPendingAfterError(t *testing.T) {
+	rb := &retryRebuilder{succeeded: make(chan struct{})}
+	notif := newFakeNotifier()
+	r := NewEventReloader(rb, notif, ReloaderOptions{
+		Debounce:        5 * time.Millisecond,
+		RetryBackoff:    5 * time.Millisecond,
+		MaxRetryBackoff: 10 * time.Millisecond,
+	})
+	go func() { _ = r.Run(context.Background()) }()
+	notif.out <- ChangeEvent{DatasetID: "ds", DocName: "a.md", Kind: EventPut}
+	select {
+	case <-rb.succeeded:
+	case <-time.After(time.Second):
+		t.Fatalf("rebuild did not retry after transient error")
+	}
+	_ = r.Close()
+	rb.mu.Lock()
+	defer rb.mu.Unlock()
+	if rb.calls != 2 {
+		t.Fatalf("calls = %d, want 2", rb.calls)
+	}
+	want := RebuildScope{DatasetID: "ds", DocName: "a.md"}
+	if rb.scopes[0] != want || rb.scopes[1] != want {
+		t.Fatalf("pending scope was not preserved across retry: %+v", rb.scopes)
+	}
+}
+
+type cancelAwareRebuilder struct {
+	started  chan struct{}
+	canceled chan struct{}
+}
+
+func (r *cancelAwareRebuilder) Rebuild(ctx context.Context, scope RebuildScope) error {
+	close(r.started)
+	<-ctx.Done()
+	close(r.canceled)
+	return ctx.Err()
+}
+
+func TestEventReloader_CloseCancelsInFlightRebuild(t *testing.T) {
+	rb := &cancelAwareRebuilder{started: make(chan struct{}), canceled: make(chan struct{})}
+	notif := newFakeNotifier()
+	r := NewEventReloader(rb, notif, ReloaderOptions{
+		Debounce:       5 * time.Millisecond,
+		RebuildTimeout: time.Minute,
+	})
+	go func() { _ = r.Run(context.Background()) }()
+	notif.out <- ChangeEvent{DatasetID: "ds", DocName: "a.md", Kind: EventPut}
+	select {
+	case <-rb.started:
+	case <-time.After(time.Second):
+		t.Fatalf("rebuild did not start")
+	}
+	if err := r.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+	select {
+	case <-rb.canceled:
+	case <-time.After(time.Second):
+		t.Fatalf("Close did not cancel in-flight rebuild")
 	}
 }

--- a/sdk/knowledge/repo.go
+++ b/sdk/knowledge/repo.go
@@ -3,14 +3,20 @@ package knowledge
 import "context"
 
 // DocumentRepo persists SourceDocuments. Implementations MUST guarantee:
-//   - Put atomically increments SourceDocument.Version.
+//   - Put atomically assigns SourceDocument.Version / UpdatedAt and
+//     returns the authoritative stored document.
 //   - Get returns the most recent Put with Content losslessly preserved
 //     (contract guarantee #4).
 //   - Delete is idempotent.
 //
+// Put used to return only error, leaving Service to predict the final
+// SourceDocument.Version. That contract is deprecated in favour of the
+// repository-authoritative return value and will be removed entirely in
+// v0.5.0.
+//
 // Implementations live in sdk/knowledge/backend/*.
 type DocumentRepo interface {
-	Put(ctx context.Context, doc SourceDocument) error
+	Put(ctx context.Context, doc SourceDocument) (*SourceDocument, error)
 	Get(ctx context.Context, datasetID, name string) (*SourceDocument, error)
 	Delete(ctx context.Context, datasetID, name string) error
 	List(ctx context.Context, datasetID string) ([]SourceDocument, error)
@@ -36,6 +42,8 @@ type ChunkQuery struct {
 // when a SourceDocument is updated (contract guarantee #5).
 type ChunkRepo interface {
 	Replace(ctx context.Context, datasetID, docName string, chunks []DerivedChunk) error
+	// DeleteByDoc removes all chunks for a document. Missing target
+	// documents are idempotent success and MUST NOT return NotFound.
 	DeleteByDoc(ctx context.Context, datasetID, docName string) error
 	DeleteByDataset(ctx context.Context, datasetID string) error
 	Search(ctx context.Context, q ChunkQuery) ([]Candidate, error)
@@ -118,6 +126,9 @@ type LayerQuery struct {
 type LayerRepo interface {
 	Put(ctx context.Context, layer DerivedLayer) error
 	Get(ctx context.Context, datasetID, docName string, layer Layer) (*DerivedLayer, error)
+	// DeleteByDoc removes all document-level layers for a document.
+	// Missing target documents are idempotent success and MUST NOT
+	// return NotFound.
 	DeleteByDoc(ctx context.Context, datasetID, docName string) error
 	DeleteByDataset(ctx context.Context, datasetID string) error
 	Search(ctx context.Context, q LayerQuery) ([]Candidate, error)

--- a/sdk/knowledge/retriever.go
+++ b/sdk/knowledge/retriever.go
@@ -2,7 +2,11 @@ package knowledge
 
 import (
 	"context"
+	"errors"
 	"fmt"
+
+	"github.com/GizClaw/flowcraft/sdk/telemetry"
+	otellog "go.opentelemetry.io/otel/log"
 )
 
 // BM25Retriever queries ChunkRepo with Mode=ModeBM25. It is layered:
@@ -136,19 +140,43 @@ func (r *LayerRetriever) Recall(ctx context.Context, q Query) ([]Candidate, erro
 		vec = v
 	}
 
-	lq := LayerQuery{
+	base := LayerQuery{
 		DatasetIDs: q.datasetIDs(),
 		Layer:      q.Layer,
 		Text:       q.Text,
 		Vector:     vec,
 		TopK:       q.TopK,
 	}
-	switch {
-	case wantVector && wantBM25:
-		lq.Mode = ModeHybrid
-	case wantVector:
+	if wantVector && wantBM25 {
+		var (
+			out       []Candidate
+			errs      []error
+			successes int
+		)
+		for _, mode := range []Mode{ModeBM25, ModeVector} {
+			lq := base
+			lq.Mode = mode
+			cands, err := r.Layers.Search(ctx, lq)
+			if err != nil {
+				errs = append(errs, err)
+				telemetry.Warn(ctx, "knowledge hybrid layer lane failed",
+					otellog.String("mode", string(mode)),
+					otellog.String("layer", string(q.Layer)),
+					otellog.String("error", err.Error()))
+				continue
+			}
+			successes++
+			out = append(out, cands...)
+		}
+		if len(errs) > 0 && successes == 0 {
+			return nil, errors.Join(errs...)
+		}
+		return out, nil
+	}
+	lq := base
+	if wantVector {
 		lq.Mode = ModeVector
-	default:
+	} else {
 		lq.Mode = ModeBM25
 	}
 	return r.Layers.Search(ctx, lq)

--- a/sdk/knowledge/retriever_test.go
+++ b/sdk/knowledge/retriever_test.go
@@ -211,11 +211,14 @@ func TestLayerRetriever_HybridUsesBoth(t *testing.T) {
 	if _, err := r.Recall(context.Background(), q); err != nil {
 		t.Fatalf("recall: %v", err)
 	}
-	if repo.calls[0].Mode != ModeHybrid {
-		t.Fatalf("mode = %q, want hybrid", repo.calls[0].Mode)
+	if len(repo.calls) != 2 {
+		t.Fatalf("calls = %d, want BM25 and vector lanes", len(repo.calls))
 	}
-	if len(repo.calls[0].Vector) != 2 {
-		t.Fatalf("vector not pushed: %+v", repo.calls[0].Vector)
+	if repo.calls[0].Mode != ModeBM25 || repo.calls[1].Mode != ModeVector {
+		t.Fatalf("modes = [%q %q], want [bm25 vector]", repo.calls[0].Mode, repo.calls[1].Mode)
+	}
+	if len(repo.calls[1].Vector) != 2 {
+		t.Fatalf("vector not pushed: %+v", repo.calls[1].Vector)
 	}
 }
 
@@ -231,6 +234,40 @@ func TestRRFRanker_FusesMultipleSources(t *testing.T) {
 	}
 	if out[0].DocName != "a.md" {
 		t.Fatalf("a.md should rank first, got %+v", out)
+	}
+}
+
+type namedRetriever struct {
+	name string
+	hits []Candidate
+	err  error
+}
+
+func (r namedRetriever) Name() string { return r.name }
+func (r namedRetriever) Recall(context.Context, Query) ([]Candidate, error) {
+	return r.hits, r.err
+}
+
+func TestSearchEngine_HybridSoftFailsSingleLaneError(t *testing.T) {
+	engine := NewSearchEngine([]Retriever{
+		namedRetriever{name: "bm25", hits: []Candidate{{Source: "bm25", Hit: Hit{DocName: "a.md", Score: 1}}}},
+		namedRetriever{name: "vector", err: errors.New("vector down")},
+	}, nil, nil)
+	res, err := engine.Search(context.Background(), Query{Layer: LayerDetail, Mode: ModeHybrid, TopK: 5})
+	if err != nil {
+		t.Fatalf("hybrid search returned error despite a successful lane: %v", err)
+	}
+	if len(res.Hits) != 1 || res.Hits[0].DocName != "a.md" {
+		t.Fatalf("hits = %+v, want successful lane result", res.Hits)
+	}
+}
+
+func TestSearchEngine_PureModeHardFailsLaneError(t *testing.T) {
+	engine := NewSearchEngine([]Retriever{
+		namedRetriever{name: "bm25", err: errors.New("bm25 down")},
+	}, nil, nil)
+	if _, err := engine.Search(context.Background(), Query{Layer: LayerDetail, Mode: ModeBM25, TopK: 5}); err == nil {
+		t.Fatalf("expected pure BM25 lane error to hard-fail")
 	}
 }
 

--- a/sdk/knowledge/searcher.go
+++ b/sdk/knowledge/searcher.go
@@ -1,6 +1,12 @@
 package knowledge
 
-import "context"
+import (
+	"context"
+	"errors"
+
+	"github.com/GizClaw/flowcraft/sdk/telemetry"
+	otellog "go.opentelemetry.io/otel/log"
+)
 
 // Retriever produces a candidate set for a Query. Implementations are
 // stateless with respect to the Query; all state lives in the underlying
@@ -50,15 +56,30 @@ func (e *SearchEngine) Search(ctx context.Context, q Query) (*Result, error) {
 		retrievers = e.Layer
 	}
 	var all []Candidate
+	var laneErrs []error
+	var successfulLanes int
 	for _, r := range retrievers {
 		if r == nil {
 			continue
 		}
 		cands, err := r.Recall(ctx, q)
 		if err != nil {
-			return nil, err
+			if ResolveMode(q.Mode) != ModeHybrid {
+				return nil, err
+			}
+			laneErrs = append(laneErrs, err)
+			telemetry.Warn(ctx, "knowledge hybrid recall lane failed",
+				otellog.String("retriever", r.Name()),
+				otellog.String("mode", string(q.Mode)),
+				otellog.String("layer", string(q.Layer)),
+				otellog.String("error", err.Error()))
+			continue
 		}
+		successfulLanes++
 		all = append(all, cands...)
+	}
+	if len(laneErrs) > 0 && successfulLanes == 0 {
+		return nil, errors.Join(laneErrs...)
 	}
 	hits := e.Rank.Rank(all, q)
 	return &Result{Hits: hits}, nil

--- a/sdk/knowledge/service.go
+++ b/sdk/knowledge/service.go
@@ -7,6 +7,8 @@ import (
 	"time"
 
 	"github.com/GizClaw/flowcraft/sdk/errdefs"
+	"github.com/GizClaw/flowcraft/sdk/telemetry"
+	otellog "go.opentelemetry.io/otel/log"
 )
 
 // Service orchestrates document lifecycle, derived-data persistence and
@@ -41,7 +43,11 @@ type ServiceOptions struct {
 	// freshness checks within a single binary but not stable across
 	// processes — production wiring should set it explicitly.
 	EmbedSig string
-	// Now overrides the clock; nil means time.Now (unit-test hook).
+	// Now overrides the legacy Service clock.
+	//
+	// Deprecated: DocumentRepo.Put is authoritative for UpdatedAt as of
+	// the final stateful-modules architecture. This hook no longer
+	// affects document timestamps and will be removed in v0.5.0.
 	Now func() time.Time
 }
 
@@ -86,7 +92,8 @@ func NewService(
 // PutDocument writes raw content under (datasetID, name).
 //
 // Behaviour:
-//   - SourceDocument.Version is incremented atomically by DocumentRepo.
+//   - SourceDocument.Version / UpdatedAt are assigned atomically by
+//     DocumentRepo.Put and the returned SourceDocument is authoritative.
 //   - DerivedChunks are recomputed and ChunkRepo.Replace is called.
 //   - DerivedLayers are NOT touched (layer generation is explicit; see
 //     PutDocumentLayer / PutDatasetLayer).
@@ -107,24 +114,22 @@ func (s *Service) PutDocument(ctx context.Context, datasetID, name, raw string) 
 	if err != nil && !errdefs.IsNotFound(err) {
 		return err
 	}
-	version := uint64(1)
-	if prev != nil {
-		version = prev.Version + 1
-	}
 	doc := SourceDocument{
 		DatasetID: datasetID,
 		Name:      name,
 		Content:   raw,
-		Version:   version,
-		UpdatedAt: s.now(),
 	}
 	if prev != nil {
 		doc.Metadata = copyStringMetadata(prev.Metadata)
 	}
-	if err := s.docs.Put(ctx, doc); err != nil {
+	stored, err := s.docs.Put(ctx, doc)
+	if err != nil {
 		return err
 	}
-	return s.replaceChunks(ctx, doc)
+	if stored == nil {
+		return errdefs.Validationf("knowledge: document repo returned nil SourceDocument")
+	}
+	return s.replaceChunks(ctx, *stored)
 }
 
 // DeleteDocument removes the document and all its derived data
@@ -430,6 +435,9 @@ func (s *Service) replaceChunks(ctx context.Context, doc SourceDocument) error {
 		if err != nil {
 			return fmt.Errorf("knowledge: GetDocSig: %w", err)
 		}
+		if present && existing.SourceVer > sig.SourceVer {
+			return nil
+		}
 		if present && !existing.IsStale(sig) {
 			return nil
 		}
@@ -448,11 +456,28 @@ func (s *Service) replaceChunks(ctx context.Context, doc SourceDocument) error {
 		if s.embedder != nil {
 			vec, err := s.embedder.Embed(ctx, sp.Content)
 			if err != nil {
+				telemetry.Error(ctx, "knowledge chunk embed failed",
+					otellog.String("dataset_id", doc.DatasetID),
+					otellog.String("doc_name", doc.Name),
+					otellog.Int("chunk_index", sp.Index),
+					otellog.String("error", err.Error()))
 				return fmt.Errorf("knowledge: embed chunk %d: %w", sp.Index, err)
 			}
 			c.Vector = vec
 		}
 		chunks[i] = c
+	}
+	if reader, ok := s.chunks.(ChunkSigReader); ok {
+		existing, present, err := reader.GetDocSig(ctx, doc.DatasetID, doc.Name)
+		if err != nil {
+			return fmt.Errorf("knowledge: GetDocSig: %w", err)
+		}
+		if present && existing.SourceVer > sig.SourceVer {
+			return nil
+		}
+		if present && !existing.IsStale(sig) {
+			return nil
+		}
 	}
 	return s.chunks.Replace(ctx, doc.DatasetID, doc.Name, chunks)
 }
@@ -494,18 +519,21 @@ func (s *Service) putLayer(ctx context.Context, datasetID, docName string, layer
 // document-level layers borrow the source's Version; dataset-level
 // layers use 0 (no single source).
 func (s *Service) layerSource(ctx context.Context, datasetID, docName string) (uint64, error) {
-	if docName == "" || s.docs == nil {
+	if docName == "" {
 		return 0, nil
+	}
+	if s.docs == nil {
+		return 0, errdefs.Validationf("knowledge: document store is required for document-level layers")
 	}
 	doc, err := s.docs.Get(ctx, datasetID, docName)
 	if err != nil {
 		if errdefs.IsNotFound(err) {
-			return 0, nil
+			return 0, err
 		}
 		return 0, err
 	}
 	if doc == nil {
-		return 0, nil
+		return 0, errdefs.NotFoundf("knowledge: source document %s/%s", datasetID, docName)
 	}
 	return doc.Version, nil
 }
@@ -548,7 +576,30 @@ func (s *Service) rebuildDocuments(ctx context.Context, datasetID string, scope 
 		}
 		return []SourceDocument{*doc}, nil
 	}
-	return s.docs.List(ctx, datasetID)
+	listed, err := s.docs.List(ctx, datasetID)
+	if err != nil {
+		return nil, err
+	}
+	docs := make([]SourceDocument, 0, len(listed))
+	for _, d := range listed {
+		if err := ctx.Err(); err != nil {
+			return nil, errdefs.FromContext(err)
+		}
+		if d.Name == "" {
+			continue
+		}
+		doc, err := s.docs.Get(ctx, datasetID, d.Name)
+		if err != nil {
+			if errdefs.IsNotFound(err) {
+				continue
+			}
+			return nil, err
+		}
+		if doc != nil {
+			docs = append(docs, *doc)
+		}
+	}
+	return docs, nil
 }
 
 // layerPromptSig stamps a deterministic prompt identifier onto layers.

--- a/sdk/knowledge/service_arch_test.go
+++ b/sdk/knowledge/service_arch_test.go
@@ -1,0 +1,290 @@
+package knowledge_test
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/GizClaw/flowcraft/sdk/errdefs"
+	"github.com/GizClaw/flowcraft/sdk/knowledge"
+	"github.com/GizClaw/flowcraft/sdk/knowledge/backend/fs"
+	kretrieval "github.com/GizClaw/flowcraft/sdk/knowledge/backend/retrieval"
+	"github.com/GizClaw/flowcraft/sdk/knowledge/factory"
+	"github.com/GizClaw/flowcraft/sdk/retrieval/memory"
+	"github.com/GizClaw/flowcraft/sdk/workspace"
+)
+
+type listWithoutContentRepo struct {
+	knowledge.DocumentRepo
+}
+
+func (r *listWithoutContentRepo) List(ctx context.Context, datasetID string) ([]knowledge.SourceDocument, error) {
+	docs, err := r.DocumentRepo.List(ctx, datasetID)
+	if err != nil {
+		return nil, err
+	}
+	for i := range docs {
+		docs[i].Content = ""
+	}
+	return docs, nil
+}
+
+func TestService_RebuildFetchesContentAfterList(t *testing.T) {
+	ctx := context.Background()
+	base := fs.NewDocumentRepo(workspace.NewMemWorkspace(), fs.DefaultPrefix)
+	if _, err := base.Put(ctx, knowledge.SourceDocument{DatasetID: "ds", Name: "a.md", Content: "alpha body"}); err != nil {
+		t.Fatalf("seed doc: %v", err)
+	}
+	docs := &listWithoutContentRepo{DocumentRepo: base}
+	idx := memory.New()
+	chunks := kretrieval.NewChunkRepo(idx)
+	layers := kretrieval.NewLayerRepo(idx)
+	engine := knowledge.NewSearchEngine([]knowledge.Retriever{knowledge.NewBM25Retriever(chunks)}, nil, nil)
+	svc := knowledge.NewService(docs, chunks, layers, engine, knowledge.ServiceOptions{})
+
+	if err := svc.Rebuild(ctx, knowledge.RebuildScope{DatasetID: "ds"}); err != nil {
+		t.Fatalf("rebuild: %v", err)
+	}
+	res, err := svc.Search(ctx, knowledge.Query{
+		Scope: knowledge.ScopeSingleDataset, DatasetID: "ds",
+		Text: "alpha", Mode: knowledge.ModeBM25, TopK: 5,
+	})
+	if err != nil {
+		t.Fatalf("search: %v", err)
+	}
+	if len(res.Hits) == 0 || res.Hits[0].Content == "" {
+		t.Fatalf("rebuild used List's empty Content instead of Get: %+v", res.Hits)
+	}
+}
+
+type blockingDocRepo struct {
+	mu      sync.Mutex
+	doc     knowledge.SourceDocument
+	block   bool
+	started chan struct{}
+	release chan struct{}
+}
+
+func newBlockingDocRepo() *blockingDocRepo {
+	return &blockingDocRepo{
+		doc: knowledge.SourceDocument{
+			DatasetID: "ds",
+			Name:      "a.md",
+			Content:   "old apple",
+			Version:   1,
+		},
+	}
+}
+
+func (r *blockingDocRepo) armNextGet() (<-chan struct{}, chan<- struct{}) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.block = true
+	r.started = make(chan struct{})
+	r.release = make(chan struct{})
+	return r.started, r.release
+}
+
+func (r *blockingDocRepo) Put(_ context.Context, doc knowledge.SourceDocument) (*knowledge.SourceDocument, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.doc.Content = doc.Content
+	r.doc.Metadata = doc.Metadata
+	r.doc.Version++
+	return cloneSourceDocument(r.doc), nil
+}
+
+func (r *blockingDocRepo) Get(_ context.Context, datasetID, name string) (*knowledge.SourceDocument, error) {
+	r.mu.Lock()
+	if datasetID != r.doc.DatasetID || name != r.doc.Name {
+		r.mu.Unlock()
+		return nil, errdefs.NotFoundf("test doc %s/%s", datasetID, name)
+	}
+	doc := r.doc
+	var started chan struct{}
+	var release chan struct{}
+	if r.block {
+		r.block = false
+		started = r.started
+		release = r.release
+	}
+	r.mu.Unlock()
+	if started != nil {
+		close(started)
+		<-release
+	}
+	return cloneSourceDocument(doc), nil
+}
+
+func (r *blockingDocRepo) Delete(_ context.Context, datasetID, name string) error {
+	return nil
+}
+
+func (r *blockingDocRepo) List(_ context.Context, datasetID string) ([]knowledge.SourceDocument, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if datasetID != r.doc.DatasetID {
+		return nil, nil
+	}
+	return []knowledge.SourceDocument{{DatasetID: r.doc.DatasetID, Name: r.doc.Name}}, nil
+}
+
+func (r *blockingDocRepo) ListDatasets(context.Context) ([]string, error) {
+	return []string{"ds"}, nil
+}
+
+func cloneSourceDocument(doc knowledge.SourceDocument) *knowledge.SourceDocument {
+	cp := doc
+	if len(doc.Metadata) > 0 {
+		cp.Metadata = make(map[string]string, len(doc.Metadata))
+		for k, v := range doc.Metadata {
+			cp.Metadata[k] = v
+		}
+	}
+	return &cp
+}
+
+type sigChunkRepo struct {
+	mu       sync.Mutex
+	chunks   []knowledge.DerivedChunk
+	replaced []uint64
+}
+
+func newSigChunkRepo() *sigChunkRepo {
+	return &sigChunkRepo{
+		chunks: []knowledge.DerivedChunk{{
+			DatasetID: "ds",
+			DocName:   "a.md",
+			Index:     0,
+			Content:   "old apple",
+			Sig:       knowledge.DerivedSig{SourceVer: 1},
+		}},
+	}
+}
+
+func (r *sigChunkRepo) Replace(_ context.Context, datasetID, docName string, chunks []knowledge.DerivedChunk) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	var ver uint64
+	if len(chunks) > 0 {
+		ver = chunks[0].Sig.SourceVer
+	}
+	r.replaced = append(r.replaced, ver)
+	r.chunks = append([]knowledge.DerivedChunk(nil), chunks...)
+	return nil
+}
+
+func (r *sigChunkRepo) GetDocSig(_ context.Context, datasetID, docName string) (knowledge.DerivedSig, bool, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	for _, c := range r.chunks {
+		if c.DatasetID == datasetID && c.DocName == docName {
+			return c.Sig, true, nil
+		}
+	}
+	return knowledge.DerivedSig{}, false, nil
+}
+
+func (r *sigChunkRepo) DeleteByDoc(context.Context, string, string) error { return nil }
+func (r *sigChunkRepo) DeleteByDataset(context.Context, string) error     { return nil }
+func (r *sigChunkRepo) Search(context.Context, knowledge.ChunkQuery) ([]knowledge.Candidate, error) {
+	return nil, nil
+}
+
+func TestService_ConcurrentPutBeatsStaleRebuild(t *testing.T) {
+	ctx := context.Background()
+	docs := newBlockingDocRepo()
+	chunks := newSigChunkRepo()
+	svc := knowledge.NewService(docs, chunks, nil, nil, knowledge.ServiceOptions{})
+
+	rebuildGetStarted, releaseRebuildGet := docs.armNextGet()
+	rebuildDone := make(chan error, 1)
+	go func() {
+		rebuildDone <- svc.Rebuild(ctx, knowledge.RebuildScope{DatasetID: "ds", DocName: "a.md"})
+	}()
+	select {
+	case <-rebuildGetStarted:
+	case <-time.After(time.Second):
+		t.Fatalf("rebuild did not reach blocked Get")
+	}
+
+	if err := svc.PutDocument(ctx, "ds", "a.md", "new banana"); err != nil {
+		t.Fatalf("concurrent put: %v", err)
+	}
+	close(releaseRebuildGet)
+	select {
+	case err := <-rebuildDone:
+		if err != nil {
+			t.Fatalf("rebuild: %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatalf("rebuild did not finish")
+	}
+
+	chunks.mu.Lock()
+	defer chunks.mu.Unlock()
+	if len(chunks.chunks) == 0 || chunks.chunks[0].Sig.SourceVer != 2 || chunks.chunks[0].Content != "new banana" {
+		t.Fatalf("stale rebuild overwrote newer chunks: %+v", chunks.chunks)
+	}
+	for _, ver := range chunks.replaced {
+		if ver == 1 {
+			t.Fatalf("stale rebuild performed Replace with source version 1: %v", chunks.replaced)
+		}
+	}
+}
+
+func TestService_PutDocumentLayerMissingSourceReturnsNotFound(t *testing.T) {
+	svc := newService(t)
+	err := svc.PutDocumentLayer(context.Background(), "ds", "missing.md", knowledge.LayerAbstract, "abstract")
+	if !errdefs.IsNotFound(err) {
+		t.Fatalf("got %v, want NotFound", err)
+	}
+}
+
+type failSecondEmbedder struct {
+	inner stubEmbedder
+	calls int
+}
+
+func (e *failSecondEmbedder) Embed(ctx context.Context, text string) ([]float32, error) {
+	e.calls++
+	if e.calls >= 2 {
+		return nil, errors.New("embed failed")
+	}
+	return e.inner.Embed(ctx, text)
+}
+
+func (e *failSecondEmbedder) EmbedBatch(ctx context.Context, texts []string) ([][]float32, error) {
+	out := make([][]float32, len(texts))
+	for i, text := range texts {
+		vec, err := e.Embed(ctx, text)
+		if err != nil {
+			return nil, err
+		}
+		out[i] = vec
+	}
+	return out, nil
+}
+
+func TestService_PutDocumentEmbedFailureKeepsOldChunks(t *testing.T) {
+	ctx := context.Background()
+	svc := newService(t, factory.WithRetrievalEmbedder(&failSecondEmbedder{inner: stubEmbedder{dim: 4}}, "flaky:v1"))
+	if err := svc.PutDocument(ctx, "ds", "a.md", "alpha"); err != nil {
+		t.Fatalf("first put: %v", err)
+	}
+	if err := svc.PutDocument(ctx, "ds", "a.md", "beta"); err == nil {
+		t.Fatalf("expected second put to fail during embedding")
+	}
+	res, err := svc.Search(ctx, knowledge.Query{
+		Scope: knowledge.ScopeSingleDataset, DatasetID: "ds",
+		Text: "alpha", Mode: knowledge.ModeBM25, TopK: 5,
+	})
+	if err != nil {
+		t.Fatalf("search: %v", err)
+	}
+	if len(res.Hits) == 0 || res.Hits[0].Content != "alpha" {
+		t.Fatalf("old chunks were not preserved after embed failure: %+v", res.Hits)
+	}
+}

--- a/sdk/knowledge/types_test.go
+++ b/sdk/knowledge/types_test.go
@@ -23,3 +23,14 @@ func TestContextLayers(t *testing.T) {
 		t.Fatalf("expected L2, got %s", LayerDetail)
 	}
 }
+
+func TestDerivedSigIsStaleComparesEmbedSigStrictly(t *testing.T) {
+	got := DerivedSig{SourceVer: 1, ChunkerSig: "chunker:v1", EmbedSig: "embed:v1"}
+	want := DerivedSig{SourceVer: 1, ChunkerSig: "chunker:v1"}
+	if !got.IsStale(want) {
+		t.Fatalf("expected vectors to be stale when desired EmbedSig is empty")
+	}
+	if !want.IsStale(got) {
+		t.Fatalf("expected missing vectors to be stale when desired EmbedSig is set")
+	}
+}

--- a/sdk/recall/architecture_regression_test.go
+++ b/sdk/recall/architecture_regression_test.go
@@ -1,0 +1,315 @@
+package recall_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/GizClaw/flowcraft/sdk/llm"
+	"github.com/GizClaw/flowcraft/sdk/model"
+	"github.com/GizClaw/flowcraft/sdk/recall"
+	"github.com/GizClaw/flowcraft/sdk/retrieval"
+	"github.com/GizClaw/flowcraft/sdk/retrieval/journal"
+	memidx "github.com/GizClaw/flowcraft/sdk/retrieval/memory"
+)
+
+func TestScopeGuardAppliesToAuditAndForget(t *testing.T) {
+	ctx := context.Background()
+	idx := memidx.New()
+	m, err := recall.New(idx, recall.WithRequireUserID(), recall.WithJournal(journal.NewMemoryJournal()))
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	defer m.Close()
+
+	aud := m.(recall.Auditable)
+	bad := recall.Scope{RuntimeID: "rt1"}
+	if _, err := aud.History(ctx, bad, "id"); !errors.Is(err, recall.ErrMissingUserID) {
+		t.Fatalf("History missing-user error = %v; want %v", err, recall.ErrMissingUserID)
+	}
+	if err := aud.Rollback(ctx, bad, "id", time.Now()); !errors.Is(err, recall.ErrMissingUserID) {
+		t.Fatalf("Rollback missing-user error = %v; want %v", err, recall.ErrMissingUserID)
+	}
+	if err := m.Forget(ctx, bad, "id", "test"); !errors.Is(err, recall.ErrMissingUserID) {
+		t.Fatalf("Forget missing-user error = %v; want %v", err, recall.ErrMissingUserID)
+	}
+}
+
+func TestScopeFromNamespaceRejectsEntitySiblings(t *testing.T) {
+	scope := recall.Scope{RuntimeID: "rt1", UserID: "alice"}
+	if got, ok := recall.ScopeFromNamespace(recall.EntityNamespaceFor(scope)); ok {
+		t.Fatalf("V2 entity namespace decoded as entry scope: %+v", got)
+	}
+	if got, ok := recall.ScopeFromNamespace("ltm_rt1__u_alice__entities"); ok {
+		t.Fatalf("legacy V1 entity namespace decoded as entry scope: %+v", got)
+	}
+	if got, ok := recall.ScopeFromNamespace("ltm_rt1__u_alice"); !ok || got.RuntimeID != "rt1" || got.UserID != "alice" {
+		t.Fatalf("legacy V1 entry namespace decode = %+v ok=%v", got, ok)
+	}
+}
+
+func TestProjectionReplacementPrunesStaleEntityEdges(t *testing.T) {
+	ctx := context.Background()
+	idx := memidx.New()
+	m, err := recall.New(idx,
+		recall.WithRequireUserID(),
+		recall.WithEntityStore(0),
+		recall.WithReconcileInterval(-1),
+	)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	defer m.Close()
+
+	scope := newScope()
+	id := "stable-entry-id"
+	if got, err := m.Add(ctx, scope, recall.Entry{ID: id, Content: "Alice note", Entities: []string{"alice"}}); err != nil || got != id {
+		t.Fatalf("Add #1 id=%q err=%v", got, err)
+	}
+	if got, err := m.Add(ctx, scope, recall.Entry{ID: id, Content: "Bob note", Entities: []string{"bob"}}); err != nil || got != id {
+		t.Fatalf("Add #2 id=%q err=%v", got, err)
+	}
+
+	store := recall.NewIndexEntityStore(idx, recall.IndexEntityStoreOptions{})
+	alice, _ := store.Lookup(ctx, scope, []string{"alice"}, 0)
+	for _, got := range alice {
+		if got == id {
+			t.Fatalf("stale alice edge still references %q after replacement; lookup=%v", id, alice)
+		}
+	}
+	bob, _ := store.Lookup(ctx, scope, []string{"bob"}, 0)
+	if len(bob) != 1 || bob[0] != id {
+		t.Fatalf("bob edge missing after replacement: got %v want [%q]", bob, id)
+	}
+}
+
+func TestDedupHitRepairsProjectionEagerly(t *testing.T) {
+	ctx := context.Background()
+	idx := memidx.New()
+	m, err := recall.New(idx,
+		recall.WithRequireUserID(),
+		recall.WithEntityStore(0),
+		recall.WithReconcileInterval(-1),
+	)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	defer m.Close()
+
+	scope := newScope()
+	id, err := m.Add(ctx, scope, recall.Entry{Content: "Alice likes tea", Entities: []string{"alice"}})
+	if err != nil {
+		t.Fatalf("Add #1: %v", err)
+	}
+	store := recall.NewIndexEntityStore(idx, recall.IndexEntityStoreOptions{})
+	if err := store.Forget(ctx, scope, id); err != nil {
+		t.Fatalf("manual projection prune: %v", err)
+	}
+	if got, _ := store.Lookup(ctx, scope, []string{"alice"}, 0); len(got) != 0 {
+		t.Fatalf("test setup failed, alice edge still present: %v", got)
+	}
+
+	gotID, err := m.Add(ctx, scope, recall.Entry{Content: "Alice likes tea", Entities: []string{"alice"}})
+	if err != nil {
+		t.Fatalf("Add dedup hit: %v", err)
+	}
+	if gotID != id {
+		t.Fatalf("dedup returned id %q; want existing %q", gotID, id)
+	}
+	got, _ := store.Lookup(ctx, scope, []string{"alice"}, 0)
+	if len(got) != 1 || got[0] != id {
+		t.Fatalf("dedup hit did not eagerly repair projection: got %v want [%q]", got, id)
+	}
+}
+
+func TestMemoryJobQueueAttemptStartsOnBusinessStart(t *testing.T) {
+	ctx := context.Background()
+	q := recall.NewMemoryJobQueue()
+	id, err := q.Enqueue(ctx, "ns", recall.JobPayload{Scope: newScope()})
+	if err != nil {
+		t.Fatalf("Enqueue: %v", err)
+	}
+	rec, ok, err := q.Lease(ctx, time.Now())
+	if err != nil || !ok || rec.ID != id {
+		t.Fatalf("Lease rec=%+v ok=%v err=%v", rec, ok, err)
+	}
+	if rec.State != recall.JobLeased || rec.Attempts != 0 {
+		t.Fatalf("leased rec state/attempts = %s/%d; want leased/0", rec.State, rec.Attempts)
+	}
+	if err := q.Reschedule(ctx, id, time.Now(), ""); err != nil {
+		t.Fatalf("Reschedule leased: %v", err)
+	}
+	rec, err = q.Get(ctx, id)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if rec.State != recall.JobPending || rec.Attempts != 0 {
+		t.Fatalf("pre-start cancel consumed attempt or changed state wrongly: %+v", rec)
+	}
+
+	rec, ok, err = q.Lease(ctx, time.Now())
+	if err != nil || !ok {
+		t.Fatalf("Lease #2 ok=%v err=%v", ok, err)
+	}
+	started, err := q.Start(ctx, rec.ID, time.Now())
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	if started.State != recall.JobRunning || started.Attempts != 1 {
+		t.Fatalf("started rec state/attempts = %s/%d; want running/1", started.State, started.Attempts)
+	}
+}
+
+func TestAwaitJobUsesWallClockTimeout(t *testing.T) {
+	ctx := context.Background()
+	frozen := time.Date(2026, 5, 18, 1, 2, 3, 0, time.UTC)
+	m, err := recall.New(memidx.New(),
+		recall.WithRequireUserID(),
+		recall.WithAsyncWorkers(0),
+		recall.WithClock(func() time.Time { return frozen }),
+	)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	defer m.Close()
+
+	id, err := m.SaveAsync(ctx, newScope(), []llm.Message{
+		{Role: model.RoleUser, Parts: []model.Part{{Type: model.PartText, Text: "pending forever"}}},
+	})
+	if err != nil {
+		t.Fatalf("SaveAsync: %v", err)
+	}
+	start := time.Now()
+	_, err = m.(recall.JobController).AwaitJob(ctx, id, 25*time.Millisecond)
+	if !errors.Is(err, recall.ErrAwaitTimeout) {
+		t.Fatalf("AwaitJob err = %v; want timeout", err)
+	}
+	if elapsed := time.Since(start); elapsed > time.Second {
+		t.Fatalf("AwaitJob ignored wall clock timeout; elapsed=%s", elapsed)
+	}
+}
+
+func TestSweeperFallbackRestartsAfterMutation(t *testing.T) {
+	ctx := context.Background()
+	inner := memidx.New()
+	idx := &noNativeDeleteIndex{inner: inner}
+	now := time.Now()
+	m, err := recall.New(idx,
+		recall.WithRequireUserID(),
+		recall.WithClock(func() time.Time { return now }),
+		recall.WithSweeper(time.Hour, 2),
+	)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	defer m.Close()
+
+	scope := newScope()
+	past := now.Add(-time.Hour)
+	var ids []string
+	for i := 0; i < 5; i++ {
+		id, err := m.Add(ctx, scope, recall.Entry{
+			Content:   fmt.Sprintf("expired %d", i),
+			ExpiresAt: &past,
+		})
+		if err != nil {
+			t.Fatalf("Add %d: %v", i, err)
+		}
+		ids = append(ids, id)
+	}
+	if err := m.(interface {
+		SweepNamespace(context.Context, string) error
+	}).SweepNamespace(ctx, recall.NamespaceFor(scope)); err != nil {
+		t.Fatalf("SweepNamespace: %v", err)
+	}
+	for _, id := range ids {
+		if _, ok, _ := inner.Get(ctx, recall.NamespaceFor(scope), id); ok {
+			t.Fatalf("expired id %q survived fallback sweep; ids=%v", id, ids)
+		}
+	}
+}
+
+func TestIndexEntityStoreForgetBuffersBeforeMutation(t *testing.T) {
+	ctx := context.Background()
+	idx := &recordingIndex{inner: memidx.New()}
+	store := recall.NewIndexEntityStore(idx, recall.IndexEntityStoreOptions{LinkedCap: 1000, MaxLinkedCount: -1})
+	scope := newScope()
+
+	edges := make(map[string][]string, 501)
+	for i := 0; i < 501; i++ {
+		edges[fmt.Sprintf("entity-%03d", i)] = []string{"entry-1"}
+	}
+	if err := store.Link(ctx, scope, edges); err != nil {
+		t.Fatalf("Link: %v", err)
+	}
+	idx.reset()
+	if err := store.Forget(ctx, scope, "entry-1"); err != nil {
+		t.Fatalf("Forget: %v", err)
+	}
+	if idx.listCalls < 2 {
+		t.Fatalf("test did not exercise pagination; listCalls=%d", idx.listCalls)
+	}
+	if idx.firstUpsertAt != idx.listCalls {
+		t.Fatalf("Forget mutated before completing pagination: firstUpsertAt=%d listCalls=%d", idx.firstUpsertAt, idx.listCalls)
+	}
+}
+
+type noNativeDeleteIndex struct {
+	inner *memidx.Index
+}
+
+func (i *noNativeDeleteIndex) Upsert(ctx context.Context, ns string, docs []retrieval.Doc) error {
+	return i.inner.Upsert(ctx, ns, docs)
+}
+func (i *noNativeDeleteIndex) Delete(ctx context.Context, ns string, ids []string) error {
+	return i.inner.Delete(ctx, ns, ids)
+}
+func (i *noNativeDeleteIndex) Search(ctx context.Context, ns string, req retrieval.SearchRequest) (*retrieval.SearchResponse, error) {
+	return i.inner.Search(ctx, ns, req)
+}
+func (i *noNativeDeleteIndex) List(ctx context.Context, ns string, req retrieval.ListRequest) (*retrieval.ListResponse, error) {
+	return i.inner.List(ctx, ns, req)
+}
+func (i *noNativeDeleteIndex) Capabilities() retrieval.Capabilities {
+	c := i.inner.Capabilities()
+	c.NativeDeleteByFilter = false
+	c.Extensions.DeleteByFilter = false
+	return c
+}
+func (i *noNativeDeleteIndex) Close() error { return i.inner.Close() }
+
+type recordingIndex struct {
+	inner         *memidx.Index
+	listCalls     int
+	firstUpsertAt int
+}
+
+func (i *recordingIndex) reset() {
+	i.listCalls = 0
+	i.firstUpsertAt = 0
+}
+func (i *recordingIndex) Upsert(ctx context.Context, ns string, docs []retrieval.Doc) error {
+	if i.listCalls > 0 && i.firstUpsertAt == 0 {
+		i.firstUpsertAt = i.listCalls
+	}
+	return i.inner.Upsert(ctx, ns, docs)
+}
+func (i *recordingIndex) Delete(ctx context.Context, ns string, ids []string) error {
+	return i.inner.Delete(ctx, ns, ids)
+}
+func (i *recordingIndex) Search(ctx context.Context, ns string, req retrieval.SearchRequest) (*retrieval.SearchResponse, error) {
+	return i.inner.Search(ctx, ns, req)
+}
+func (i *recordingIndex) List(ctx context.Context, ns string, req retrieval.ListRequest) (*retrieval.ListResponse, error) {
+	i.listCalls++
+	return i.inner.List(ctx, ns, req)
+}
+func (i *recordingIndex) Capabilities() retrieval.Capabilities {
+	return i.inner.Capabilities()
+}
+func (i *recordingIndex) Close() error { return i.inner.Close() }
+func (i *recordingIndex) Get(ctx context.Context, ns, id string) (retrieval.Doc, bool, error) {
+	return i.inner.Get(ctx, ns, id)
+}

--- a/sdk/recall/entity_projection.go
+++ b/sdk/recall/entity_projection.go
@@ -18,8 +18,11 @@ import (
 //   - Project rebuilds the (entity → entry-id list) edge set from
 //     entry.Entities for the supplied entries and pushes it via
 //     [EntityStore.Link]. Link is idempotent on (entity, id), so
-//     this can be replayed safely (the Reconciler does so every
-//     tick).
+//     this can be replayed safely.
+//   - Replace first prunes every supplied entry ID from all entity
+//     rows, then Projects the entries' current entity set. That
+//     expresses "this entry's projection equals Entry.Entities" and
+//     removes stale edges when an alive entry changes entities.
 //   - Forget loops [EntityStore.Forget] over the stale ids. Most
 //     backends scan the entity namespace per call; for typical
 //     LoCoMo-shaped scopes (tens of stale ids per reconcile after a
@@ -74,6 +77,32 @@ func (p *entityStoreProjection) Project(ctx context.Context, scope Scope, entrie
 		return nil
 	}
 	return p.store.Link(ctx, scope, edges)
+}
+
+// Replace implements ProjectionReplacer.
+func (p *entityStoreProjection) Replace(ctx context.Context, scope Scope, entries []Entry) error {
+	if p == nil || p.store == nil || len(entries) == 0 {
+		return nil
+	}
+	ids := make([]string, 0, len(entries))
+	seen := make(map[string]struct{}, len(entries))
+	for _, e := range entries {
+		id := strings.TrimSpace(e.ID)
+		if id == "" {
+			continue
+		}
+		if _, ok := seen[id]; ok {
+			continue
+		}
+		seen[id] = struct{}{}
+		ids = append(ids, id)
+	}
+	if len(ids) > 0 {
+		if err := p.Forget(ctx, scope, ids); err != nil {
+			return err
+		}
+	}
+	return p.Project(ctx, scope, entries)
 }
 
 // Forget implements Projection. EntityStore.Forget is per-id, so
@@ -138,5 +167,6 @@ func (p *entityStoreProjection) AllEntryIDs(ctx context.Context, scope Scope) ([
 // Compile-time interface checks.
 var (
 	_ Projection          = (*entityStoreProjection)(nil)
+	_ ProjectionReplacer  = (*entityStoreProjection)(nil)
 	_ ProjectionInspector = (*entityStoreProjection)(nil)
 )

--- a/sdk/recall/entity_store.go
+++ b/sdk/recall/entity_store.go
@@ -143,6 +143,9 @@ func entityKeyPrefix(s Scope) string {
 // resolver is invoked with the ENTRY namespace and looks up its
 // sibling itself via [EntityNamespaceFor].
 func ScopeFromNamespace(ns string) (Scope, bool) {
+	if strings.HasSuffix(ns, "__entities") {
+		return Scope{}, false
+	}
 	rt, user, isUser, ok := recallNamespace.DecodeScope(ns)
 	if !ok {
 		return Scope{}, false
@@ -509,13 +512,13 @@ func (s *IndexEntityStore) Forget(ctx context.Context, scope Scope, memEntryID s
 	// rewrite the ones that match. Forget is rare relative to Link,
 	// so the O(N) scan is acceptable.
 	var page string
+	var toUpsert []retrieval.Doc
 	for {
 		req := retrieval.ListRequest{PageSize: 500, PageToken: page}
 		resp, err := s.idx.List(ctx, ns, req)
 		if err != nil || resp == nil {
 			return err
 		}
-		var toUpsert []retrieval.Doc
 		for _, d := range resp.Items {
 			linked := entityLinkedSlice(d)
 			pruned := make([]string, 0, len(linked))
@@ -538,16 +541,17 @@ func (s *IndexEntityStore) Forget(ctx context.Context, scope Scope, memEntryID s
 			d.Metadata[MetaEntityLast] = now
 			toUpsert = append(toUpsert, d)
 		}
-		if len(toUpsert) > 0 {
-			if err := s.idx.Upsert(ctx, ns, toUpsert); err != nil {
-				return fmt.Errorf("entity_store: forget rewrite: %w", err)
-			}
-		}
 		if resp.NextPageToken == "" {
-			return nil
+			break
 		}
 		page = resp.NextPageToken
 	}
+	if len(toUpsert) > 0 {
+		if err := s.idx.Upsert(ctx, ns, toUpsert); err != nil {
+			return fmt.Errorf("entity_store: forget rewrite: %w", err)
+		}
+	}
+	return nil
 }
 
 // entityLinkedSlice extracts MetaEntityLinked from a Doc, tolerating

--- a/sdk/recall/jobs.go
+++ b/sdk/recall/jobs.go
@@ -7,6 +7,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/GizClaw/flowcraft/sdk/internal/background"
 	"github.com/GizClaw/flowcraft/sdk/llm"
 	"github.com/GizClaw/flowcraft/sdk/telemetry"
 	"go.opentelemetry.io/otel/attribute"
@@ -27,6 +28,7 @@ type JobState string
 
 const (
 	JobPending   JobState = "pending"
+	JobLeased    JobState = "leased"
 	JobRunning   JobState = "running"
 	JobSucceeded JobState = "succeeded"
 	JobFailed    JobState = "failed"
@@ -74,6 +76,7 @@ type JobRecord struct {
 type JobQueue interface {
 	Enqueue(ctx context.Context, namespace string, payload JobPayload) (JobID, error)
 	Lease(ctx context.Context, now time.Time) (*JobRecord, bool, error)
+	Start(ctx context.Context, id JobID, now time.Time) (*JobRecord, error)
 	Reschedule(ctx context.Context, id JobID, nextRun time.Time, lastErr string) error
 	Complete(ctx context.Context, id JobID, entryIDs []string) error
 	Fail(ctx context.Context, id JobID, lastErr string) error
@@ -149,12 +152,34 @@ func (q *MemoryJobQueue) Lease(_ context.Context, now time.Time) (*JobRecord, bo
 	if best == nil {
 		return nil, false, nil
 	}
-	best.State = JobRunning
-	best.Attempts++
+	best.State = JobLeased
 	best.UpdatedAt = now
 	q.leased[best.ID] = struct{}{}
 	cp := *best
 	return &cp, true, nil
+}
+
+// Start marks a leased job as running and consumes one attempt.
+func (q *MemoryJobQueue) Start(ctx context.Context, id JobID, now time.Time) (*JobRecord, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	j, ok := q.jobs[id]
+	if !ok {
+		return nil, ErrJobNotFound
+	}
+	if j.State != JobLeased && j.State != JobRunning {
+		return nil, errors.New("ltm: job is not leased")
+	}
+	if j.State == JobLeased {
+		j.State = JobRunning
+		j.Attempts++
+		j.UpdatedAt = now
+	}
+	cp := *j
+	return &cp, nil
 }
 
 // Reschedule pushes a leased job back to pending with a new NextRunAt.
@@ -289,7 +314,46 @@ func (m *lt) worker() {
 			}
 			continue
 		}
-		m.handleJob(rec)
+		if m.workerCtx.Err() != nil || m.stopping() {
+			m.releaseLeasedJob(rec)
+			return
+		}
+		started, err := m.cfg.jobQueue.Start(m.workerCtx, rec.ID, m.cfg.now())
+		if err != nil {
+			if m.workerCtx.Err() != nil || m.stopping() {
+				m.releaseLeasedJob(rec)
+				return
+			}
+			m.log("ltm.worker.start: %v", err)
+			m.releaseLeasedJob(rec)
+			select {
+			case <-m.stopCh:
+				return
+			case <-time.After(100 * time.Millisecond):
+			}
+			continue
+		}
+		m.handleJob(started)
+	}
+}
+
+func (m *lt) stopping() bool {
+	select {
+	case <-m.stopCh:
+		return true
+	default:
+		return false
+	}
+}
+
+func (m *lt) releaseLeasedJob(rec *JobRecord) {
+	if rec == nil {
+		return
+	}
+	bookCtx, cancel := context.WithTimeout(context.Background(), bookkeepingTimeout)
+	defer cancel()
+	if err := m.cfg.jobQueue.Reschedule(bookCtx, rec.ID, m.cfg.now(), rec.LastError); err != nil {
+		m.log("ltm.worker.release: %v", err)
 	}
 }
 
@@ -400,10 +464,7 @@ func isPermanentWriteError(err error) bool {
 // transitions are still owned by failOrRetry; this only annotates the
 // observation.
 func (m *lt) recordJobFailure(ctx context.Context, rec *JobRecord, err error, stage string) {
-	outcome := "failed"
-	if errors.Is(err, context.DeadlineExceeded) {
-		outcome = "timeout"
-	}
+	outcome := jobFailureOutcome(err)
 	jobTotal.Add(ctx, 1, metric.WithAttributes(
 		attribute.String("outcome", outcome),
 		attribute.String("stage", stage),
@@ -415,6 +476,10 @@ func (m *lt) recordJobFailure(ctx context.Context, rec *JobRecord, err error, st
 		otellog.String("outcome", outcome),
 		otellog.Int("attempts", rec.Attempts),
 		otellog.String(telemetry.AttrErrorMessage, err.Error()))
+}
+
+func jobFailureOutcome(err error) string {
+	return background.Classify(err).String()
 }
 
 func (m *lt) failOrRetry(rec *JobRecord, err error) {

--- a/sdk/recall/memory.go
+++ b/sdk/recall/memory.go
@@ -1016,7 +1016,17 @@ func (m *lt) JobStatus(ctx context.Context, id JobID) (JobStatus, error) {
 
 // AwaitJob polls JobQueue until terminal state or timeout.
 func (m *lt) AwaitJob(ctx context.Context, id JobID, timeout time.Duration) (JobStatus, error) {
-	deadline := m.cfg.now().Add(timeout)
+	if timeout <= 0 {
+		s, err := m.JobStatus(ctx, id)
+		if err != nil {
+			return JobStatus{}, err
+		}
+		return s, ErrAwaitTimeout
+	}
+	timer := time.NewTimer(timeout)
+	defer timer.Stop()
+	ticker := time.NewTicker(50 * time.Millisecond)
+	defer ticker.Stop()
 	for {
 		s, err := m.JobStatus(ctx, id)
 		if err != nil {
@@ -1026,13 +1036,12 @@ func (m *lt) AwaitJob(ctx context.Context, id JobID, timeout time.Duration) (Job
 		case JobSucceeded, JobFailed, JobDead:
 			return s, nil
 		}
-		if !m.cfg.now().Before(deadline) {
-			return s, ErrAwaitTimeout
-		}
 		select {
 		case <-ctx.Done():
 			return s, errdefs.FromContext(ctx.Err())
-		case <-time.After(50 * time.Millisecond):
+		case <-timer.C:
+			return s, ErrAwaitTimeout
+		case <-ticker.C:
 		}
 	}
 }

--- a/sdk/recall/projection.go
+++ b/sdk/recall/projection.go
@@ -2,9 +2,9 @@ package recall
 
 import (
 	"context"
-	"sync"
 	"time"
 
+	"github.com/GizClaw/flowcraft/sdk/internal/background"
 	"github.com/GizClaw/flowcraft/sdk/retrieval"
 )
 
@@ -24,21 +24,19 @@ import (
 //     retain stale entries — but reads must validate against the
 //     primary and the [Reconciler] eventually converges the view.
 //   - Eager write paths ([Memory.Save] via upsertFacts and
-//     [Memory.Add]) call [Projection.Project] inline AFTER the
-//     durable Upsert so the caller observes 0-lag recall against
-//     their own writes. The exact same Project method the
-//     [Reconciler] drives is used — there is ONE entry point,
-//     additive semantics — so the projection can never see two
-//     contracts. This was unified in #179.1; pre-fix the eager
-//     paths talked directly to the projection's backing
-//     primitives (e.g. [EntityStore.Link]) and Save/Add could
-//     drift independently of each other and of Reconciler.
-//   - Non-eager write paths (Rollback, TTL sweeper, resolver
-//     OpDelete, …) DO NOT instrument Projection updates. They
-//     rely entirely on the [Reconciler]'s tick to drop stale
-//     references via [Projection.Forget]. The contract guarantee
-//     is "every Reconciler pass IS a replay sufficient to rebuild
-//     the view offline".
+//     [Memory.Add]) call the replacement-capable projection path
+//     inline AFTER the durable Upsert so the caller observes
+//     0-lag recall against their own writes. If a projection
+//     implements [ProjectionReplacer], the entry's derived state
+//     is replaced with exactly what Entry currently says; otherwise
+//     the legacy additive [Projection.Project] contract is used.
+//   - [Memory.Forget] fans out through every registered Projection's
+//     Forget method after the primary delete succeeds. Other
+//     non-eager mutation paths (Rollback, TTL sweeper, resolver
+//     OpDelete, …) rely on the [Reconciler]'s tick. A reconciler
+//     pass is a full replay over alive primary entries, using
+//     [ProjectionReplacer] when available and [Projection.Forget]
+//     for IDs absent from primary.
 //
 // Implementations MUST be idempotent: Project called twice with the
 // same scope + entries produces the same view state as once. Forget
@@ -75,6 +73,23 @@ type Projection interface {
 	// IDs. Idempotent on (scope, id) — calling Forget for an ID
 	// the projection never knew about is a no-op.
 	Forget(ctx context.Context, scope Scope, entryIDs []string) error
+}
+
+// ProjectionReplacer is an optional extension to [Projection] for
+// per-entry replacement.
+//
+// Replace conveys "for each supplied entry, the projection state owned
+// by that entry ID must now equal the state implied by Entry". For the
+// entity-link projection, that means the entry ID appears under exactly
+// Entry.Entities: old entity rows that still referenced the alive entry
+// are pruned, and current rows are linked. This is stronger than
+// additive [Projection.Project] and is what lets eager writes and
+// Reconciler repair stale edges when an existing entry's Entities change.
+//
+// Idempotent on (scope, entry.ID). Empty entries and entries with no
+// projected fields remove that entry's old projection edges.
+type ProjectionReplacer interface {
+	Replace(ctx context.Context, scope Scope, entries []Entry) error
 }
 
 // ProjectionInspector is an optional extension to [Projection]. The
@@ -121,8 +136,7 @@ type Reconciler struct {
 	now         func() time.Time
 	log         func(format string, args ...any)
 
-	stopCh chan struct{}
-	wg     sync.WaitGroup
+	group *background.Group
 }
 
 // newReconciler is the package-internal constructor. Callers go
@@ -153,7 +167,7 @@ func newReconciler(
 		batchSize:   defaultReconcileBatch,
 		now:         now,
 		log:         log,
-		stopCh:      make(chan struct{}),
+		group:       background.NewGroup(context.Background()),
 	}
 }
 
@@ -176,8 +190,7 @@ func (r *Reconciler) start() {
 	if r == nil || len(r.projections) == 0 {
 		return
 	}
-	r.wg.Add(1)
-	go r.loop()
+	r.group.Start(r.loop)
 }
 
 // stop cancels the tick goroutine and waits for it to drain.
@@ -185,27 +198,18 @@ func (r *Reconciler) stop() {
 	if r == nil {
 		return
 	}
-	select {
-	case <-r.stopCh:
-		// already stopped
-	default:
-		close(r.stopCh)
-	}
-	r.wg.Wait()
+	r.group.Close()
 }
 
-func (r *Reconciler) loop() {
-	defer r.wg.Done()
+func (r *Reconciler) loop(ctx context.Context) {
 	t := time.NewTicker(r.interval)
 	defer t.Stop()
 	for {
 		select {
-		case <-r.stopCh:
+		case <-ctx.Done():
 			return
 		case <-t.C:
-			ctx, cancel := context.WithTimeout(context.Background(), r.interval)
 			r.tick(ctx)
-			cancel()
 		}
 	}
 }
@@ -223,13 +227,19 @@ func (r *Reconciler) tick(ctx context.Context) {
 		return
 	}
 	for _, ns := range nss {
+		if err := ctx.Err(); err != nil {
+			return
+		}
 		scope, ok := ScopeFromNamespace(ns)
 		if !ok {
 			// Sibling / unknown namespace (e.g. "..__entities");
 			// skip — the entry namespace's reconcile will cover it.
 			continue
 		}
-		if err := r.reconcileScope(ctx, scope); err != nil {
+		scopeCtx, cancel := context.WithTimeout(ctx, r.interval)
+		err := r.reconcileScope(scopeCtx, scope)
+		cancel()
+		if err != nil {
 			r.log("recall: reconcile scope %q: %v", ns, err)
 		}
 	}
@@ -270,8 +280,8 @@ func (r *Reconciler) reconcileScope(ctx context.Context, scope Scope) error {
 	}
 	// 2. Fan out to projections.
 	for _, p := range r.projections {
-		if err := p.Project(ctx, scope, aliveEntries); err != nil {
-			r.log("recall: projection %s Project: %v", p.Name(), err)
+		if err := projectReplaceOrAdd(ctx, p, scope, aliveEntries); err != nil {
+			r.log("recall: projection %s sync: %v", p.Name(), err)
 		}
 		// 3. Diff against the projection's retained IDs and Forget
 		// anything the projection has that primary does not.
@@ -302,6 +312,16 @@ func (r *Reconciler) reconcileScope(ctx context.Context, scope Scope) error {
 		}
 	}
 	return nil
+}
+
+func projectReplaceOrAdd(ctx context.Context, p Projection, scope Scope, entries []Entry) error {
+	if p == nil || len(entries) == 0 {
+		return nil
+	}
+	if replacer, ok := p.(ProjectionReplacer); ok {
+		return replacer.Replace(ctx, scope, entries)
+	}
+	return p.Project(ctx, scope, entries)
 }
 
 // listAll pages through retrieval.Index.List collecting every doc

--- a/sdk/recall/recall.go
+++ b/sdk/recall/recall.go
@@ -88,15 +88,10 @@ func (m *lt) runRecall(ctx context.Context, scope Scope, req Request) ([]Hit, *r
 		recallDuration.Record(ctx, time.Since(t0).Seconds())
 	}()
 
-	if scope.RuntimeID == "" {
-		span.RecordError(ErrMissingRuntimeID)
+	if err := m.validateScope(scope); err != nil {
+		span.RecordError(err)
 		recallTotal.Add(ctx, 1, metric.WithAttributes(attribute.String("outcome", "fail"), attribute.String("reason", "scope")))
-		return nil, nil, ErrMissingRuntimeID
-	}
-	if m.cfg.requireUserID && scope.UserID == "" && !m.cfg.allowGlobal {
-		span.RecordError(ErrMissingUserID)
-		recallTotal.Add(ctx, 1, metric.WithAttributes(attribute.String("outcome", "fail"), attribute.String("reason", "scope")))
-		return nil, nil, ErrMissingUserID
+		return nil, nil, err
 	}
 	now := req.Now
 	if now.IsZero() {
@@ -311,6 +306,9 @@ func (m *lt) History(ctx context.Context, scope Scope, id string) ([]journal.Eve
 	if m.cfg.journal == nil {
 		return nil, ErrJournalRequired
 	}
+	if err := m.validateScope(scope); err != nil {
+		return nil, err
+	}
 	ns := NamespaceFor(scope)
 	m.rememberNamespace(ctx, ns)
 	return m.cfg.journal.History(ctx, ns, id)
@@ -321,6 +319,9 @@ func (m *lt) History(ctx context.Context, scope Scope, id string) ([]journal.Eve
 func (m *lt) Rollback(ctx context.Context, scope Scope, id string, before time.Time) error {
 	if m.cfg.journal == nil {
 		return ErrJournalRequired
+	}
+	if err := m.validateScope(scope); err != nil {
+		return err
 	}
 	ns := NamespaceFor(scope)
 	m.rememberNamespace(ctx, ns)
@@ -352,20 +353,14 @@ func (m *lt) Rollback(ctx context.Context, scope Scope, id string, before time.T
 // Forget hard-deletes one entry; Journal records OpDelete{reason}.
 func (m *lt) Forget(ctx context.Context, scope Scope, id, reason string) error {
 	_ = reason // reason is captured by Journal actor (caller can WithActor)
+	if err := m.validateScope(scope); err != nil {
+		return err
+	}
 	ns := NamespaceFor(scope)
 	m.rememberNamespace(ctx, ns)
 	if err := m.idx.Delete(ctx, ns, []string{id}); err != nil {
 		return err
 	}
-	// Prune the entity-link inverted index AFTER the entry deletion
-	// so a Forget that fails to land never advances the entity row's
-	// MetaEntityLast. Failures are non-fatal — the entry is gone;
-	// the orphan id in the inverted index merely points to a tombstone
-	// and the read path's standard tombstone filter will drop it.
-	if m.cfg.entityStore != nil {
-		if err := m.cfg.entityStore.Forget(ctx, scope, id); err != nil {
-			m.log("ltm: entity_store Forget failed for %q: %v", id, err)
-		}
-	}
+	m.forgetProjections(ctx, scope, []string{id})
 	return nil
 }

--- a/sdk/recall/reconciler_internal_test.go
+++ b/sdk/recall/reconciler_internal_test.go
@@ -1,0 +1,148 @@
+package recall
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/GizClaw/flowcraft/sdk/retrieval"
+	memidx "github.com/GizClaw/flowcraft/sdk/retrieval/memory"
+)
+
+func TestReconcilerStopCancelsInFlightTick(t *testing.T) {
+	ctx := context.Background()
+	idx := memidx.New()
+	reg := NewMemoryNamespaceRegistry()
+	scope := Scope{RuntimeID: "rt1", UserID: "u1"}
+	ns := NamespaceFor(scope)
+	if err := reg.Remember(ctx, ns); err != nil {
+		t.Fatalf("Remember: %v", err)
+	}
+	if err := idx.Upsert(ctx, ns, []retrieval.Doc{EntryToDoc(Entry{
+		ID:       "entry-1",
+		Scope:    scope,
+		Content:  "Alice",
+		Entities: []string{"alice"},
+	})}); err != nil {
+		t.Fatalf("Upsert: %v", err)
+	}
+
+	proj := &blockingProjection{entered: make(chan struct{}), canceled: make(chan struct{})}
+	r := newReconciler(idx, []Projection{proj}, reg, time.Millisecond, time.Now, nil)
+	r.start()
+	select {
+	case <-proj.entered:
+	case <-time.After(time.Second):
+		t.Fatal("reconciler did not enter projection")
+	}
+
+	done := make(chan struct{})
+	go func() {
+		r.stop()
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("reconciler stop did not cancel in-flight projection")
+	}
+	select {
+	case <-proj.canceled:
+	default:
+		t.Fatal("projection did not observe canceled context")
+	}
+}
+
+func TestReconcilerPerScopeBudgetContinuesAfterSlowScope(t *testing.T) {
+	ctx := context.Background()
+	idx := memidx.New()
+	reg := NewMemoryNamespaceRegistry()
+	scopeA := Scope{RuntimeID: "rt1", UserID: "u1"}
+	scopeB := Scope{RuntimeID: "rt1", UserID: "u2"}
+	for _, scope := range []Scope{scopeA, scopeB} {
+		ns := NamespaceFor(scope)
+		if err := reg.Remember(ctx, ns); err != nil {
+			t.Fatalf("Remember: %v", err)
+		}
+		if err := idx.Upsert(ctx, ns, []retrieval.Doc{EntryToDoc(Entry{
+			ID:       "entry-" + scope.UserID,
+			Scope:    scope,
+			Content:  "fact",
+			Entities: []string{"entity"},
+		})}); err != nil {
+			t.Fatalf("Upsert %s: %v", scope.UserID, err)
+		}
+	}
+
+	proj := &slowFirstScopeProjection{slowUserID: "u1", sawSecond: make(chan struct{})}
+	r := newReconciler(idx, []Projection{proj}, reg, 20*time.Millisecond, time.Now, nil)
+	r.tick(context.Background())
+
+	select {
+	case <-proj.sawSecond:
+	default:
+		t.Fatal("reconciler did not continue to the next scope after the first scope exhausted its budget")
+	}
+}
+
+func TestJobFailureOutcomeClassifiesCanceled(t *testing.T) {
+	if got := jobFailureOutcome(context.Canceled); got != "canceled" {
+		t.Fatalf("context.Canceled outcome = %q; want canceled", got)
+	}
+	if got := jobFailureOutcome(context.DeadlineExceeded); got != "timeout" {
+		t.Fatalf("context.DeadlineExceeded outcome = %q; want timeout", got)
+	}
+	if got := jobFailureOutcome(errors.New("boom")); got != "failed" {
+		t.Fatalf("generic error outcome = %q; want failed", got)
+	}
+}
+
+type blockingProjection struct {
+	entered  chan struct{}
+	canceled chan struct{}
+	once     chan struct{}
+}
+
+func (p *blockingProjection) Name() string { return "blocking" }
+func (p *blockingProjection) Project(ctx context.Context, _ Scope, _ []Entry) error {
+	return p.Replace(ctx, Scope{}, nil)
+}
+func (p *blockingProjection) Replace(ctx context.Context, _ Scope, _ []Entry) error {
+	select {
+	case <-p.entered:
+	default:
+		close(p.entered)
+	}
+	<-ctx.Done()
+	select {
+	case <-p.canceled:
+	default:
+		close(p.canceled)
+	}
+	return ctx.Err()
+}
+func (p *blockingProjection) Forget(context.Context, Scope, []string) error { return nil }
+
+type slowFirstScopeProjection struct {
+	slowUserID string
+	sawSecond  chan struct{}
+}
+
+func (p *slowFirstScopeProjection) Name() string { return "slow_first_scope" }
+func (p *slowFirstScopeProjection) Project(ctx context.Context, scope Scope, entries []Entry) error {
+	return p.Replace(ctx, scope, entries)
+}
+func (p *slowFirstScopeProjection) Replace(ctx context.Context, scope Scope, _ []Entry) error {
+	if scope.UserID == p.slowUserID {
+		<-ctx.Done()
+		return ctx.Err()
+	}
+	select {
+	case <-p.sawSecond:
+	default:
+		close(p.sawSecond)
+	}
+	return nil
+}
+func (p *slowFirstScopeProjection) Forget(context.Context, Scope, []string) error { return nil }

--- a/sdk/recall/save.go
+++ b/sdk/recall/save.go
@@ -323,6 +323,7 @@ func (m *lt) Add(ctx context.Context, scope Scope, e Entry) (string, error) {
 		if derr == nil {
 			if existingID, ok := existing[hash]; ok {
 				m.rememberNamespace(ctx, ns)
+				m.repairProjectionForIDs(ctx, scope, []string{existingID})
 				addTotal.Add(ctx, 1, metric.WithAttributes(attribute.String("outcome", "success"), attribute.String("reason", "dedup_hit")))
 				return existingID, nil
 			}
@@ -435,10 +436,12 @@ func (m *lt) upsertFacts(
 	// returnedIDs tracks the ID we report back per fact, including those
 	// short-circuited by MD5 dedup so callers see idempotent behaviour.
 	returnedIDs := make([]string, 0, len(facts))
+	var dedupIDs []string
 	for i, f := range facts {
 		if existing != nil {
 			if existingID, ok := existing[hashes[i]]; ok {
 				returnedIDs = append(returnedIDs, existingID)
+				dedupIDs = append(dedupIDs, existingID)
 				continue
 			}
 		}
@@ -490,6 +493,10 @@ func (m *lt) upsertFacts(
 		}
 		plans = append(plans, plan{entry: entry, doc: d, fact: f})
 		returnedIDs = append(returnedIDs, entry.ID)
+	}
+
+	if len(dedupIDs) > 0 {
+		m.repairProjectionForIDs(ctx, scope, dedupIDs)
 	}
 
 	if len(plans) == 0 {
@@ -594,12 +601,12 @@ func (m *lt) upsertFacts(
 // drift from each other again: the moment we add a new eager
 // write path, it just needs to call [lt.projectEager] after Upsert.
 //
-// Semantics match [Projection.Project]'s additive contract:
-// projections incorporate the supplied entries' edges idempotently.
-// The Reconciler's full-replay + Forget cleanup is a separate path
-// and is NOT triggered from here. Errors are logged but do not
-// fail the Upsert — Projections are derived views; the primary
-// index is already durable.
+// Semantics prefer [ProjectionReplacer] when the projection supports
+// it, so an entry's derived edges are replaced with exactly the
+// current Entry state. Legacy projections fall back to additive
+// [Projection.Project]. Errors are logged but do not fail the Upsert
+// — Projections are derived views; the primary index is already
+// durable.
 //
 // No-op when len(entries) == 0 or no projection is registered.
 // Replaces the pre-#179.1 [lt.linkEntities] helper that talked
@@ -610,8 +617,51 @@ func (m *lt) projectEager(ctx context.Context, scope Scope, entries []Entry) {
 		return
 	}
 	for _, p := range m.projections {
-		if err := p.Project(ctx, scope, entries); err != nil {
-			m.log("ltm: projection %s Project (eager): %v", p.Name(), err)
+		if err := projectReplaceOrAdd(ctx, p, scope, entries); err != nil {
+			m.log("ltm: projection %s sync (eager): %v", p.Name(), err)
+		}
+	}
+}
+
+func (m *lt) repairProjectionForIDs(ctx context.Context, scope Scope, ids []string) {
+	if len(ids) == 0 || len(m.projections) == 0 {
+		return
+	}
+	getter, ok := retrieval.AsDocGetter(m.idx)
+	if !ok {
+		return
+	}
+	ns := NamespaceFor(scope)
+	seen := make(map[string]struct{}, len(ids))
+	entries := make([]Entry, 0, len(ids))
+	for _, id := range ids {
+		if id == "" {
+			continue
+		}
+		if _, ok := seen[id]; ok {
+			continue
+		}
+		seen[id] = struct{}{}
+		doc, ok, err := getter.Get(ctx, ns, id)
+		if err != nil {
+			m.log("ltm: projection dedup repair Get %q: %v", id, err)
+			continue
+		}
+		if !ok {
+			continue
+		}
+		entries = append(entries, DocToEntry(doc))
+	}
+	m.projectEager(ctx, scope, entries)
+}
+
+func (m *lt) forgetProjections(ctx context.Context, scope Scope, ids []string) {
+	if len(ids) == 0 || len(m.projections) == 0 {
+		return
+	}
+	for _, p := range m.projections {
+		if err := p.Forget(ctx, scope, ids); err != nil {
+			m.log("ltm: projection %s Forget: %v", p.Name(), err)
 		}
 	}
 }

--- a/sdk/recall/sweeper.go
+++ b/sdk/recall/sweeper.go
@@ -117,12 +117,10 @@ func (m *lt) sweepNamespace(ctx context.Context, ns string, filter retrieval.Fil
 		_, err := d.DeleteByFilter(ctx, ns, filter)
 		return err
 	}
-	tok := ""
 	for {
 		page, err := m.idx.List(ctx, ns, retrieval.ListRequest{
-			Filter:    filter,
-			PageSize:  m.cfg.sweeperBatchMax,
-			PageToken: tok,
+			Filter:   filter,
+			PageSize: m.cfg.sweeperBatchMax,
 		})
 		if err != nil {
 			return err
@@ -137,9 +135,8 @@ func (m *lt) sweepNamespace(ctx context.Context, ns string, filter retrieval.Fil
 		if err := m.idx.Delete(ctx, ns, ids); err != nil {
 			return err
 		}
-		if page.NextPageToken == "" {
-			return nil
-		}
-		tok = page.NextPageToken
+		// The delete mutates the ordered result set behind offset-style
+		// page tokens. Restart from the first page so backends do not
+		// skip rows that shifted into an already-consumed offset.
 	}
 }

--- a/sdkx/recall/jobqueue/sqlite/queue.go
+++ b/sdkx/recall/jobqueue/sqlite/queue.go
@@ -82,11 +82,11 @@ func (q *SQLiteJobQueue) migrate() error {
 	return nil
 }
 
-// recoverRunning resets stranded running jobs to pending.
+// recoverRunning resets stranded leased/running jobs to pending.
 func (q *SQLiteJobQueue) recoverRunning() error {
 	now := time.Now().UnixMilli()
 	_, err := q.db.Exec(
-		`UPDATE recall_jobs SET state='pending', next_run_at=?, updated_at=? WHERE state='running'`,
+		`UPDATE recall_jobs SET state='pending', next_run_at=?, updated_at=? WHERE state IN ('leased','running')`,
 		now, now,
 	)
 	return err
@@ -134,7 +134,7 @@ func (q *SQLiteJobQueue) Lease(ctx context.Context, now time.Time) (*recall.JobR
 		return nil, false, err
 	}
 	if _, err := tx.ExecContext(ctx,
-		`UPDATE recall_jobs SET state='running', attempts=attempts+1, updated_at=? WHERE id=?`,
+		`UPDATE recall_jobs SET state='leased', updated_at=? WHERE id=?`,
 		now.UnixMilli(), string(rec.ID),
 	); err != nil {
 		return nil, false, err
@@ -142,10 +142,30 @@ func (q *SQLiteJobQueue) Lease(ctx context.Context, now time.Time) (*recall.JobR
 	if err := tx.Commit(); err != nil {
 		return nil, false, err
 	}
-	rec.State = recall.JobRunning
-	rec.Attempts++
+	rec.State = recall.JobLeased
 	rec.UpdatedAt = now
 	return rec, true, nil
+}
+
+// Start marks a leased job as running and consumes one attempt.
+func (q *SQLiteJobQueue) Start(ctx context.Context, id recall.JobID, now time.Time) (*recall.JobRecord, error) {
+	res, err := q.db.ExecContext(ctx,
+		`UPDATE recall_jobs
+		    SET state='running', attempts=attempts+1, updated_at=?
+		  WHERE id=? AND state IN ('leased','running')`,
+		now.UnixMilli(), string(id),
+	)
+	if err != nil {
+		return nil, err
+	}
+	n, err := res.RowsAffected()
+	if err != nil {
+		return nil, err
+	}
+	if n == 0 {
+		return nil, recall.ErrJobNotFound
+	}
+	return q.Get(ctx, id)
 }
 
 // Reschedule implements recall.JobQueue.


### PR DESCRIPTION
## Summary
- Add `sdk/internal/background` lifecycle primitives for cancellable owner loops, debounce signals, and normalized background outcomes.
- Refactor `history` archive/recovery/clear paths to share the append conversation owner and harden archive intent recovery.
- Make `knowledge` source documents authoritative for derived chunks/layers, retry reloader failures, and soft-fail hybrid lane errors.
- Centralize `recall` scope guards, add replace-by-entry projection repair, and tighten reconciler/job queue lifecycle semantics.

## Audit status
- Fixes the Critical/High history, knowledge, and recall findings from `internal-docs/sdk-audit-findings-2026-05-18.md` that map to owner serialization, source/derived version safety, background lifecycle, scope isolation, projection replacement, and job attempts.
- Leaves only documented low-risk follow-ups in ignored internal docs, mostly history tiny-budget/load/archive/cache cleanup items.

## Test plan
- `go test ./...` in `sdk`
- `go test ./...` in `sdkx`
- `git diff --check`

## Notes
- `DocumentRepo.Put` now returns the authoritative `SourceDocument`; out-of-tree knowledge backends need to update this interface.
- `recall.JobQueue` now includes `Start`; out-of-tree durable job queue adapters need to update this interface.


Made with [Cursor](https://cursor.com)