### PR TITLE
[skip-tag] chore(release): prepare memory v0.1.0

### DIFF
--- a/memory/go.mod
+++ b/memory/go.mod
@@ -3,7 +3,7 @@ module github.com/GizClaw/flowcraft/memory
 go 1.25.0
 
 require (
-	github.com/GizClaw/flowcraft/sdk v0.3.12
+	github.com/GizClaw/flowcraft/sdk v0.4.0
 	github.com/go-ego/gse v1.0.2
 	github.com/jackc/pgx/v5 v5.9.2
 	github.com/kljensen/snowball v0.10.0

--- a/memory/go.sum
+++ b/memory/go.sum
@@ -1,5 +1,5 @@
-github.com/GizClaw/flowcraft/sdk v0.3.12 h1:7aySuWD8BJBgfYEtTF7PF5tnZv84AxbzkSDR8T3IpfA=
-github.com/GizClaw/flowcraft/sdk v0.3.12/go.mod h1:VeMqVBxnMGHtFO9ypHhsA591XoLCWxucXR+gqpxQt5s=
+github.com/GizClaw/flowcraft/sdk v0.4.0 h1:L0wOTgjfizol33sgEJC/WzloB8O+vtNNHBqRXDo6/I8=
+github.com/GizClaw/flowcraft/sdk v0.4.0/go.mod h1:pMY9bxfdEOnj5gJndX9Yrrw3mpBvIbldBZ9Ug4b9Ltk=
 github.com/cenkalti/backoff/v5 v5.0.3 h1:ZN+IMa753KfX5hd8vVaMixjnqRZ3y8CuJKRKj1xcsSM=
 github.com/cenkalti/backoff/v5 v5.0.3/go.mod h1:rkhZdG3JZukswDf7f0cwqPNk4K0sa+F97BxZthm/crw=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=


### PR DESCRIPTION
## Summary
- Pin `memory` to `sdk v0.4.0` for the manual `memory/v0.1.0` release.
- Refresh `memory/go.sum` after publishing `sdk/v0.4.0`.

## Test plan
- `GONOSUMDB=github.com/GizClaw/flowcraft/* GOPROXY=direct go mod tidy` in `memory`


Made with [Cursor](https://cursor.com)