### PR TITLE
[skip-tag] chore(release): prepare vessel v0.3.0

### DIFF
--- a/vessel/go.mod
+++ b/vessel/go.mod
@@ -3,22 +3,19 @@ module github.com/GizClaw/flowcraft/vessel
 go 1.25.0
 
 require (
-	github.com/GizClaw/flowcraft/sdk v0.3.12
+	github.com/GizClaw/flowcraft/sdk v0.4.0
 	go.opentelemetry.io/otel/log v0.16.0
 	gopkg.in/yaml.v3 v3.0.1
 )
 
 require (
-	github.com/AlekSi/pointer v1.0.0 // indirect
 	github.com/go-ego/gse v1.0.2 // indirect
 	github.com/kljensen/snowball v0.10.0 // indirect
-	github.com/olebedev/when v1.1.0 // indirect
-	github.com/pkg/errors v0.8.1 // indirect
 	github.com/vcaesar/cedar v0.30.0 // indirect
 )
 
 require (
-	github.com/GizClaw/flowcraft/memory v0.0.0
+	github.com/GizClaw/flowcraft/memory v0.1.0
 	github.com/cenkalti/backoff/v5 v5.0.3 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/dlclark/regexp2 v1.11.4 // indirect
@@ -52,8 +49,4 @@ require (
 	google.golang.org/protobuf v1.36.11 // indirect
 )
 
-replace github.com/GizClaw/flowcraft/memory => ../memory
-
 exclude google.golang.org/genproto v0.0.0-20200526211855-cb27e3aa2013
-
-replace github.com/GizClaw/flowcraft/sdk => ../sdk

--- a/vessel/go.sum
+++ b/vessel/go.sum
@@ -1,5 +1,7 @@
-github.com/AlekSi/pointer v1.0.0 h1:KWCWzsvFxNLcmM5XmiqHsGTTsuwZMsLFwWF9Y+//bNE=
-github.com/AlekSi/pointer v1.0.0/go.mod h1:1kjywbfcPFCmncIxtk6fIEub6LKrfMz3gc5QKVOSOA8=
+github.com/GizClaw/flowcraft/memory v0.1.0 h1:/bMi3yorT2ig3Syyq76dcr+laXtfEYeU68KUTQGsulI=
+github.com/GizClaw/flowcraft/memory v0.1.0/go.mod h1:ddcjEcyaxlXXOR4ktW9VXI4vRIf4NPsQjLzL7P6CJjQ=
+github.com/GizClaw/flowcraft/sdk v0.4.0 h1:L0wOTgjfizol33sgEJC/WzloB8O+vtNNHBqRXDo6/I8=
+github.com/GizClaw/flowcraft/sdk v0.4.0/go.mod h1:pMY9bxfdEOnj5gJndX9Yrrw3mpBvIbldBZ9Ug4b9Ltk=
 github.com/cenkalti/backoff/v5 v5.0.3 h1:ZN+IMa753KfX5hd8vVaMixjnqRZ3y8CuJKRKj1xcsSM=
 github.com/cenkalti/backoff/v5 v5.0.3/go.mod h1:rkhZdG3JZukswDf7f0cwqPNk4K0sa+F97BxZthm/crw=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
@@ -37,10 +39,6 @@ github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWE
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 github.com/ncruces/go-strftime v1.0.0 h1:HMFp8mLCTPp341M/ZnA4qaf7ZlsbTc+miZjCLOFAw7w=
 github.com/ncruces/go-strftime v1.0.0/go.mod h1:Fwc5htZGVVkseilnfgOVb9mKy6w1naJmn9CehxcKcls=
-github.com/olebedev/when v1.1.0 h1:dlpoRa7huImhNtEx4yl0WYfTHVEWmJmIWd7fEkTHayc=
-github.com/olebedev/when v1.1.0/go.mod h1:T0THb4kP9D3NNqlvCwIG4GyUioTAzEhB4RNVzig/43E=
-github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
-github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkoukk/tiktoken-go v0.1.8 h1:85ENo+3FpWgAACBaEUVp+lctuTcYUO7BtmfhlN/QTRo=
 github.com/pkoukk/tiktoken-go v0.1.8/go.mod h1:9NiV+i9mJKGj1rYOT+njbv+ZwA/zJxYdewGl6qVatpg=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=


### PR DESCRIPTION
## Summary
- Pin `vessel` to `sdk v0.4.0` and `memory v0.1.0`.
- Remove local `replace` directives from the published module.
- Refresh `vessel/go.sum` with the published module checksums.

## Test plan
- `GOWORK=off GONOSUMDB=github.com/GizClaw/flowcraft/* GOPROXY=direct go mod tidy` in `vessel`
- `GOWORK=off GONOSUMDB=github.com/GizClaw/flowcraft/* GOPROXY=direct go list ./...` in `vessel`


Made with [Cursor](https://cursor.com)