### PR TITLE
docs: update release status for memory split

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,784 +1,195 @@
 # Changelog
 
-All notable changes to this repository are documented here. The format is based
-on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and the project
-loosely follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html) on a
-per-module basis.
+All notable changes to this repository are documented here. FlowCraft is a
+multi-module monorepo; each Go module is released independently with its own tag
+prefix, for example `sdk/vX.Y.Z`, `memory/vX.Y.Z`, `sdkx/vX.Y.Z`, and
+`vessel/vX.Y.Z`.
 
-FlowCraft is a multi-module monorepo. Each module is released independently
-with its own tag prefix (e.g. `sdk/vX.Y.Z`, `vessel/vX.Y.Z`,
-`vesseld/vX.Y.Z`). Per-release artifacts and notes also live on the
+Per-release artifacts and generated notes also live on the
 [GitHub Releases](https://github.com/GizClaw/flowcraft/releases) page.
+
+## Current Published State
+
+| Module | Latest tag | Notes |
+| --- | --- | --- |
+| `sdk` | `sdk/v0.4.0` | Core agent, engine, graph, LLM, tool, workspace, event, and telemetry primitives. |
+| `memory` | `memory/v0.1.0` | First standalone memory-domain release: recall v2, history, knowledge, retrieval, text, and stores. |
+| `sdkx` | `sdkx/v0.4.0` | Provider/adaptor release pinned to `sdk v0.4.0` and `memory v0.1.0`. |
+| `vessel` | `vessel/v0.3.0` | Runtime release pinned to `sdk v0.4.0` and `memory v0.1.0`; includes assembly helpers. |
+| `voice` | `voice/v0.2.0` | Voice pipeline module. |
+| `cmd/vesseld` | `vesseld/v0.1.0` | Daemon binary release line. |
 
 ## [Unreleased]
 
-### Added
+No unreleased user-facing changes yet.
 
-#### sdk
+## `sdk/v0.4.0` - 2026-05-30
 
-- `sdk/model`: `TokenUsage.CachedInputTokens` field for prompt-cache
-  observability. All three families of cache-aware providers expose
-  cached input tokens under different wire names —
-  OpenAI / Azure / DeepSeek / Qwen-flash report
-  `usage.prompt_tokens_details.cached_tokens`,
-  Anthropic / Minimax report `usage.cache_read_input_tokens`,
-  ByteDance Doubao reports
-  `usage.prompt_tokens_details.cached_tokens`. The new field lets
-  sdkx adapters normalise these into a single observable so callers
-  can compute a uniform `CachedInputTokens / InputTokens` hit-rate
-  without provider-specific branching. The field is additive,
-  `omitempty`-tagged (zero value vanishes from the wire format),
-  participates in `TokenUsage.Add` so cumulative reporters
-  aggregate cached counts the same way they aggregate input /
-  output tokens, and stays zero on providers (or model SKUs) that
-  do not surface a cache breakdown — wire-format back-compatible
-  with v0.3.4 readers. A follow-up sdkx release wires the three
-  cache-aware adapters to populate the field.
-- `sdk/llm`: `tokens.input.cached.total` OTel counter +
-  `UsageSpanAttrs(TokenUsage)` helper close the cached-tokens
-  telemetry gap that the v0.3.5 `TokenUsage.CachedInputTokens`
-  field left half-wired. Even though sdkx v0.3.3 adapters were
-  already populating the field on every Generate / stream call,
-  `RecordLLMMetrics` previously only emitted `tokens.input.total`
-  and `tokens.output.total`, so dashboards could not compute a
-  cache hit-rate from the metric stream. The new counter accumulates
-  the cached subset under the same `provider` / `model` label set
-  as the existing token counters and is omitted entirely when
-  `CachedInputTokens == 0` (cache-unaware provider call) so a
-  hit-rate panel divides the two counters directly without per-row
-  sanity checks. `UsageSpanAttrs` returns the canonical attribute
-  slice for both the input/output pair and the cached attribute
-  (omitted when zero), keeping per-call spans and per-call metrics
-  on the same shape via a single helper that adapters call.
-- `sdk/telemetry`: `AttrLLMCachedInputTokens` constant
-  (`llm.tokens.input.cached`) + `RunSummary.CachedInputTokens`
-  field. The attribute key mirrors the existing
-  `AttrLLMInputTokens` family so per-call spans and per-run
-  `engine.run.summary` spans use the same canonical name; the
-  new RunSummary field is only emitted when > 0 (back-compat with
-  callers that never aggregated cached counts).
-- `sdk/engine`: capabilities / resume / revise lifecycle. New
-  `engine/depname` package centralises Dependencies keys (LLMClient,
-  ToolRegistry, ToolAllowedNames, …) so engine authors and host
-  wiring stop relying on stringly-typed map keys. New
-  `engine.WithCapabilities` helper + `engineWithCaps` adapter lets
-  any engine declare a `Describer` without re-implementing the round
-  driver, finally honouring the long-standing "engines may declare
-  capabilities / may be resumable / Decider may ask for a revise"
-  contract in the public godocs.
-- `sdk/engine` + `sdk/tool`: built-in `ask_user` tool with
-  host-on-context plumbing. New `engine.WithHost(ctx, host)` /
-  `engine.HostFromContext(ctx)` helpers let any tool reach
-  `engine.Host.AskUser` from inside `tool.Tool.Execute`. The
-  llmnode round driver now wraps the tool dispatch context with
-  the live `Host`. Contract is advisory: tools that truly require a
-  host must surface `errdefs.NotAvailable` when absent.
-- `sdk/agent`: `WithParentRunID(string) RunOption` threads a parent
-  run ID through `runConfig` and stamps it onto every
-  `engine.Run.ParentRunID` the revise loop dispatches. Closes the
-  contract-audit gap where `engine.Run.ParentRunID` had been a typed
-  field with zero writers since v0.1; multi-agent call-chain loop /
-  depth detection now has the data it always claimed to have.
-- `sdk/agent`: `WithArtifactChannels(channels ...string) RunOption`
-  harvests board channels into `Result.Artifacts` at the end of a
-  run. Closes the contract-audit gap where `Result.Artifacts` had
-  been documented since v0.1 but no `agent.Run` code path
-  populated it — hosts that wrote artifact channels previously saw
-  the data vanish at the agent boundary.
-- `sdk/agent`: `Agent.Tools` finally takes effect as a policy gate.
-  `agent.Run` now promotes the agent's tool list into
-  `engine.Run.Deps[depname.ToolAllowedNames]` once per run, and
-  `llmnode.Node.resolveTools` enforces it on each tool dispatch.
-  Allow-list semantics: empty list = no gate (back-compat); non-empty
-  list = tools outside the set return `errdefs.PermissionDenied`.
-- `sdk/agent` + `sdk/graph/node/scriptnode`: `agent.RunInfoFromAttributes`
-  reads the standard agent_id / run_id / task_id / context_id
-  attribute keys back into a fully-populated `agent.RunInfo`.
-  scriptnode now uses it, so scripts see the full run identity
-  instead of `RunInfo{RunID: ec.RunID}` with empty AgentID / TaskID /
-  ContextID.
-- `sdk/graph`: `ExecutionContext.Deps` (`*engine.Dependencies`) and
-  `ExecutionContext.Attributes` (`map[string]string`) propagate from
-  `engine.Run` down to every node. Tools and scriptnode can now
-  resolve host-supplied dependencies (LLM clients, tool registries,
-  retrievers, …) without closure-binding them at builder time.
-- `sdk/graph/node/llmnode`: tool registry + allow-list resolution
-  from `ExecutionContext.Deps`. Per-run `*tool.Registry` and
-  per-agent allow-list flow through the graph cleanly; constructor-
-  bound registry is still honoured when no run-scoped registry is
-  present.
-- `sdk/recall`: `Entry.Subject` and `Entry.Predicate` opt-in fields.
-  When both are non-empty and slot-eligible (neither contains `|`),
-  `Memory.Add` now writes `MetaSubject` / `MetaPredicate` /
-  `MetaSlotKey` and participates in the slot supersede channel,
-  matching `Memory.Save`'s built-in extractor path. Closes
-  [#100](https://github.com/GizClaw/flowcraft/issues/100): callers
-  that fan out facts to different scopes per-fact (and therefore
-  must drive `Add` instead of `Save`) can now combine per-fact scope
-  routing with slot dedup. Backwards-compatible: existing `Add`
-  callers that leave both fields zero are unchanged.
-
-#### eval / docs
-
-- Top-level `README.md`, `CHANGELOG.md`, and `SECURITY.md`.
-- `eval/cmd/eval`: unified Cobra CLI replaces the per-suite
-  `eval/<suite>/cmd/eval` mains. Invoke as `eval <suite>`; LoCoMo +
-  LongMemEval expose sub-subcommands (`eval locomo run/convert/
-compare/fetch/ingest`, `eval longmemeval convert`). Shell completion
-  and uniform `--help` come for free.
-- `eval/internal/env`: JSON-encoded `FLOWCRAFT_<ALIAS>` provider
-  credentials with alias-to-factory decoupling and capability-aware
-  `llm.WithCaps` wrapping. Replaces ad-hoc per-CLI env handling.
-- `eval/internal/notify` + `eval/scripts/run-eval.sh`: Feishu CardKit
-  notifications (one live-updated card per run; webhook backend
-  intentionally unsupported) plus a process supervisor with PID lock,
-  disk check, log tee, and idle watchdog. Lifecycle events
-  (`ingest_done` / `done` / `error`) post a threaded text reply so
-  operators get a phone-buzz at phase boundaries; intra-phase
-  `*_progress` milestones stay as silent card edits.
-- `eval/locomo`: `--judge-style {locomo|strict}` and
-  `--judge-temperature` flags; mem0-aligned LoCoMo judge prompt at
-  `metrics.LocoMoLLMJudgePrompt`. Per-batch ingest heartbeats so slow
-  extractors don't look frozen.
-- `eval/longmemeval`: [LongMemEval](https://arxiv.org/abs/2410.10813)
-  (ICLR 2025) converter. Ships no runner of its own — the LoCoMo
-  runner drives it, keeping LoCoMo / LongMemEval numbers directly
-  comparable across all three official flavours (`oracle` / `_s` /
-  `_m`).
-- `eval/knowledge`: standardised on the `Run(ctx, ds, opts) → Report`
-  shape with a CLI binary and Feishu events. Embedder selection
-  collapses onto a single `KNOWLEDGE_EVAL_EMBEDDER` env var via the
-  shared `eval/internal/env` loader.
-- `eval/beir`: [BEIR](https://arxiv.org/abs/2104.08663)-format
-  retrieval suite (graded nDCG@k, binary Recall@k, MRR). Loads the
-  canonical 3-file layout directly; reuses `sdk/knowledge`'s embedder
-  pipeline.
-- `eval/simpleqa`: [SimpleQA](https://openai.com/index/introducing-simpleqa/)
-  short-form factuality suite with OpenAI's LLM-as-judge rubric.
-  Headline metric is _attempted accuracy_ (rewards calibration over
-  hallucination); per-topic breakdown on by default.
-- `eval/taubench`: Go-native [τ-bench](https://arxiv.org/abs/2406.12045)
-  tool-use suite — single-shot and multi-turn (LLM-as-customer) modes,
-  retail + airline domains with bundled mini-datasets, upstream task
-  JSON loader with shadow-run scoring. NOT a PR gate (LLM-call-heavy;
-  weekly/release-time use only).
-
-#### tests/conformance
-
-- `tests/conformance/llm/cached_tokens_test.go`: live double-call
-  prompt-cache hit-rate probe. Issues two back-to-back Generate
-  calls with a ≥ 22 KB (~4000-token) byte-identical system prefix
-  and asserts `CachedInputTokens > 0` on the second call for
-  providers where caching is contractually expected (anthropic /
-  minimax via adapter `cache_control`, bytedance Doubao
-  transparent prefix caching) and warns when implicit caching
-  providers (azure / deepseek / qwen) return zero. Validates the
-  full chain: sdkx-side `cache_control` / `prompt_cache_key`
-  injection → provider honours it → adapter populates
-  `TokenUsage.CachedInputTokens` correctly. Measured against live
-  providers from the repo `.env`: azure 96.6%, deepseek 98.0%,
-  minimax (anthropic-family) 99.5% — providing concrete evidence
-  that the prompt-cache optimisation work shipped over PR #109 and
-  the cached-tokens plumbing shipped over the sdkx v0.3.3 follow-up
-  is rewarded with the expected cheaper billing. Self-skips per
-  provider when its FLOWCRAFT_TEST_* env var is missing, matching
-  the existing conformance suite convention.
-
-#### sdkx
-
-- `sdkx/sandbox/nsjail`: new isolation backend that implements
-  `sandbox.Runner` on top of the [nsjail](https://github.com/google/nsjail)
-  binary. First backend that actually enforces
-  `sandbox.NetPolicy{Mode: NetDenyAll}` (fresh net namespace) and
-  `sandbox.ResourceLimits{CPUMillicores, MemoryBytes}` (cgroup v2
-  caps); `LocalRunner` returns `errdefs.NotAvailable` for both, so
-  the runtime had no production path for these policy fields before
-  this package landed. Translation of `ExecOptions` to nsjail CLI
-  flags is a pure function (`buildFlags`) so the policy contract is
-  unit-testable on every platform without nsjail installed; the
-  Linux-only `Runner` then shells out to the resolved binary,
-  honouring `Stdin`, `Timeout` (--time_limit + Go-side context
-  deadline as a belt-and-braces fallback), `WorkDir` (same root-
-  confinement rules as `LocalRunner`), `Env.Allow` / `Env.Inject`
-  (host env is snapshotted on the Go side and re-injected as
-  --env KEY=VALUE so the policy semantics match `LocalRunner.buildEnv`
-  one-for-one), and `Resources.MaxOutputBytes` (in-process truncation
-  identical to `LocalRunner`). Unsupported policy fields
-  (`NetAllowList`, `NetProxy`, `ResourceLimits.DiskBytes`) fail with
-  `errdefs.NotAvailable` rather than silently downgrading. `New`
-  returns `errdefs.NotAvailable` when the nsjail binary is missing
-  (with `WithBinary` as the escape hatch for vendored builds), or on
-  non-Linux platforms (a `runner_other.go` stub keeps the package
-  importable on macOS / Windows for type references and translation
-  tests). Filesystem isolation is deliberately not part of this
-  drop — `--disable_clone_newns` keeps the host filesystem visible
-  and `WorkDir` confinement is handled in Go; full chroot / bind-
-  mount integration is gated on the RFC that needs to align with
-  `sdk/workspace`'s ScopedWorkspace contract.
-
-#### vessel
-
-- `vessel.SessionStore` + `WithSessionStore` option: per-run
-  filesystem boundary for every dispatched `agent.Run`. The
-  Captain calls `store.Open(runCtx, runID)` at the start of
-  Submit / Resume, stashes the returned `workspace.Workspace` on
-  runCtx, and invokes `store.Close(baseCtx, runID)` when the run
-  terminates (baseCtx so cleanup survives a runCtx cancellation).
-  Engines / tools reach the per-run workspace via the new
-  `vessel.WorkspaceFromContext(ctx)` helper, which falls back to
-  `(nil, false)` when no store was wired so call sites can degrade
-  gracefully. Ships with two implementations: `MemorySessionStore`
-  (in-process `MemWorkspace` per run, data discarded on Close —
-  for tests and ephemeral demos) and `FilesystemSessionStore`
-  (`<root>/<runID>/` directory tree, data preserved on Close so a
-  CheckpointStore-backed Resume can reach the on-disk state an
-  interrupted run left behind). The exported `ValidateRunID`
-  helper enforces a strict `[A-Za-z0-9_-]+` allow-list on runIDs
-  before they reach the filesystem path component, rejecting `.`,
-  `..`, `/`, and `\` so a hostile runID cannot escape the store
-  root. There is no default SessionStore: the Captain only opens a
-  session when one is wired, because the choice between in-memory
-  and on-disk is workload-dependent.
-
-#### vesseld
-
-- `cmd/vesseld/apispec` + resolver + fleet: `kind: Sandbox` resource
-  type + `Agent.spec.sandbox: <name>` reference exposing
-  `sdk/sandbox.Runner` and `sdkx/sandbox/nsjail` as a declarative
-  primitive. One Sandbox document materialises one runner via the
-  spec's `backend` (`local | nsjail`), `rootDir`, and optional
-  `env / net / resources / nsjail` policy fields; the resolver
-  layers `sandbox.WithDefaults` so the YAML policy acts as a floor
-  per-call ExecOptions cannot widen. Agents that declare
-  `spec.sandbox` auto-gain an `exec` tool (sdkx/tool/exec) wired to
-  the referenced runner, registered into a per-Captain registry
-  overlay so different vessels can hold different `exec` bindings
-  without name collision. The new `resolver.RuntimeDeps.ToolRegistry`
-  seam threads that overlay into the engine factory's
-  `catalog.Deps.ToolRegistry` so the engine sees the same registry
-  the LLM tool-call dispatcher consults. The resolver enforces
-  "at most one Sandbox per Vessel" at validation time — multi-
-  sandbox-per-vessel would need an LLM-visible disambiguation
-  scheme that is out of scope for v0.2.0; until then the constraint
-  keeps the registry overlay unambiguous. nsjail-on-non-Linux
-  surfaces as `errdefs.NotAvailable` at resolve time (matching the
-  runner constructor's own classification) so operators developing
-  on macOS get the verdict at boot instead of first run. Consumes
-  `sdk v0.3.13` and `sdkx v0.3.9` (bumped in a separate commit on
-  this PR).
-- `cmd/vesseld/apispec` + resolver + fleet: `Daemon.spec.sessionStore`
-  YAML schema (`backend: memory|filesystem`, `root` required for
-  filesystem) that wires `vessel.WithSessionStore` onto every
-  Captain in the daemon. One store instance is built at resolve
-  time and shared across all captains — run IDs are globally
-  unique within a daemon lifetime so concurrent Open/Close on the
-  same store is race-free. Engines / tools reach the per-run
-  workspace via `vessel.WorkspaceFromContext`. Backend selection
-  is intentionally a fixed enum rather than a catalog factory ref:
-  v0.2.0 ships exactly two backends and a third (Redis,
-  object-storage) is a future RFC, so the catalog-factory
-  indirection costs more than it earns today. The schema field is
-  additive (omitting it preserves the v0.1.0 behaviour where
-  `WorkspaceFromContext` returns `(nil, false)`); the validator
-  rejects `backend: memory` with a non-empty `root` and
-  `backend: filesystem` with an empty `root` so misconfiguration
-  fails at boot instead of silently picking a different backend.
-  Consumes `vessel/v0.2.0` (bumped in a separate commit on this PR).
-- `cmd/vesseld/apispec`: `Daemon.spec.control.auth.mtls` schema
-  carrying `cert`, `key`, `clientCA`, and an optional `minVersion`
-  (defaulting to `"1.3"`, `"1.2"` also accepted). Each ref accepts
-  the URL-keyed syntax the `secrets.Provider` already understands
-  (`env://NAME`, `file:///abs/path`, `vault://...`). The validator
-  treats mTLS as a first-class auth mode: `spec.control.listen`
-  now requires `tokenFile` OR `mtls` (was `tokenFile` only), and
-  any non-nil `mtls` block must specify all three refs — the
-  "thought we had mutual TLS, accepted any client" footgun is
-  caught at config-shape time.
-- `cmd/vesseld/tlsconfig`: new package that resolves the three
-  refs through a `secrets.Provider` and builds the
-  `*crypto/tls.Config` the TCP listener consumes. The package
-  pins `ClientAuth = RequireAndVerifyClientCert` and the
-  `MinVersion` mapping in one place so the path that crypto
-  reviewers care about lives in a single ~120-line file with
-  unit tests for happy-path, malformed PEM, key/cert mismatch,
-  unsupported `MinVersion`, and provider-error propagation.
-- `cmd/vesseld/api`: TCP listener now terminates mutual TLS when
-  `Config.TLS` is non-nil. `tls.NewListener` wraps the raw TCP
-  listener so a handshake without a valid client cert is refused
-  before the HTTP mux is ever consulted. Token-file remains
-  optional once mTLS is configured — the client certificate IS
-  the credential — though operators may keep `tokenFile` set for
-  defence in depth. The `Start` precondition is updated
-  accordingly: a TCP listener now requires `Token != ""` OR
-  `TLS != nil`. The unix-socket listener is unaffected
-  (filesystem permissions remain the auth boundary there).
-- `cmd/vesseld/cli`: `vesseld run` accepts `--cert`, `--key`, and
-  `--client-ca` flags that override the corresponding YAML
-  fields. The three follow an all-or-none contract — passing any
-  of them implies the operator wants mTLS, so the resulting plan
-  must end up with all three refs populated (either from
-  matching YAML fields or from sibling flags) or the daemon
-  refuses to start. Drop-in workflow: dev workstations swap
-  certs without editing the manifest, production deployments
-  keep everything in YAML.
-- `cmd/vesseld/secrets`: new URL-keyed `Provider` abstraction +
-  `env://NAME`, `file:///abs/path`, and `vault://server/path?key=…`
-  backends, plus a `Multi` router and a `Default()` constructor that
-  registers all three. The forward-looking surface every upcoming
-  daemon subsystem (mTLS, `kind: Sandbox` env injection, future
-  `kind: Secret` resolver) will consume so a credential's storage
-  backend is a registration concern, not call-site branching. The
-  package intentionally does NOT touch `cmd/vesseld/resolver/secret.go`
-  yet — the apispec `ValueRef` path (typed `valueFrom.env / file /
-  secretRef`) is BC-pinned and handles a different syntactic shape;
-  consolidation between the two systems is a future RFC, this PR ships
-  the new surface only. Backends classify failures distinctly:
-  `errdefs.Validation` for malformed refs / unknown schemes,
-  `errdefs.NotFound` for unset env vars / missing files,
-  `errdefs.Forbidden` for files whose mode allows group/other read
-  (caught by default; opt out with `FileProvider{EnforceMode:false}`)
-  or for OS-level EACCES, and `errdefs.NotAvailable` for `vault://`
-  (the stub returns this for every well-formed ref so callers can
-  wire vault references today and pick up real reads when the Vault
-  client implementation lands). `FileProvider` trims a single
-  trailing LF / CRLF so editor-appended newlines do not silently
-  change a copy-pasted credential, preserves internal newlines for
-  PEM-shaped payloads, and on Windows skips the POSIX permission
-  check (the synthesised mode bits are unreliable there) instead of
-  surfacing false positives.
-
-### Fixed
-
-#### sdkx
-
-- `sdkx/llm/bytedance`: streaming `finish` path now calls
-  `llm.RecordLLMMetrics` symmetrically with the sync path. Earlier
-  revisions silently ended the span without emitting a request /
-  duration / token / error metric, so `bytedance` stream traffic
-  was invisible to error-rate and token-cost dashboards even though
-  the sync path was instrumented correctly. The streaming path now
-  also threads `cachedInputTokens` into the success-path
-  `TokenUsage` so the new `tokens.input.cached.total` counter and
-  the `llm.tokens.input.cached` span attribute land for stream
-  responses too — matching the openai / anthropic stream adapters.
-
-- `sdkx/llm/{openai,anthropic,bytedance}`: status-code-aware error
-  classification. The generic `errdefs.ClassifyProvider` regex
-  (`\b(?:http|status)\s*(\d{3})\b`) misses the SDK error format used
-  by openai-go, anthropic-sdk-go, and volcengine arkruntime — all
-  three format their `Error.Error()` as `<METHOD> "<URL>": <code>
-  <status>` (or `"Error code: <code>"` for arkruntime), and the
-  `"https://"` URL prefix or the literal `"code:"` keyword defeat
-  the heuristic. Result: real 400 / 404 / 422 client errors fell
-  through to the `ProviderTransient` default → `NotAvailable`,
-  which the locomo runner's new retry-once would then quietly
-  retry instead of fail-fast. Per-provider `classifyAPIError` now
-  routes by `StatusCode` (401/403→Unauthorized, 402→Forbidden,
-  429→RateLimit, 400/405/422→Validation, 408/409/≥500→NotAvailable).
-  The openai variant additionally splits 404 by `error.code` body
-  field so Azure AI Foundry's bare-body "capacity blip" 404s stay
-  `NotAvailable` (transient, retryable) while structured
-  `DeploymentNotFound` 404s become `Validation` (fail-fast, no
-  retry storm on a wrong deployment name). `ollama` and the image
-  generators already drive `ClassifyHTTPStatus` / explicit
-  `switch resp.StatusCode` so they're unaffected.
-
-- `sdkx/llm/{openai,anthropic,bytedance,ollama,*/image}`: guard every
-  chat-completion / image-generation entry point against `(nil, nil)`
-  return tuples from upstream SDKs. The openai-go family does in
-  fact return `(nil, nil)` when an OpenAI-compatible backend answers
-  with literal JSON `null` — a real-world DeepSeek failure mode that
-  crashed the LongMemEval `_s` eval runner at ~9% ingest with a
-  `nil pointer dereference` at `sdkx/llm/openai/openai.go:314`. The
-  anthropic-sdk-go family shares the same pointer-return shape and
-  the same latent bug. The pointer-return convention `err==nil ⇒
-  resp!=nil` is not a Go language guarantee — guard symmetrically
-  across every provider so a flaky upstream is surfaced as a clean
-  `errdefs.NotAvailable` instead of taking down the calling
-  goroutine. Streaming variants get the matching `nil stream handle`
-  check. Regression tests use `httptest` with `body=null` for the
-  openai/anthropic families (which reproduces the live failure
-  exactly) and a misbehaving `RoundTripper` for ollama.
+Coordinated release boundary for the recall v2 architecture and memory-module
+split.
 
 ### Changed
 
-#### sdkx
+- Kept `sdk` as the foundation module for agent execution, graph runtime, LLM
+  contracts, tools, events, telemetry, and workspace primitives.
+- Established the dependency floor consumed by `memory/v0.1.0`,
+  `sdkx/v0.4.0`, and `vessel/v0.3.0`.
+- Preserved deprecated compatibility surfaces that point users toward the new
+  `memory` module where appropriate; the compatibility removal remains a later
+  minor-release decision.
 
-- `sdkx/llm/{anthropic,openai,bytedance}`: automatic prompt-caching
-  optimisation across all three families, sharing a single caller
-  convention: emit multiple `llm.Message{Role:System}` entries to
-  declare independent system-prompt segments (stable / persona /
-  rules first, volatile / now / fresh-context last). Each provider
-  adapter applies its own best-fit strategy on top of that
-  convention:
-  - `anthropic`: convertMessages stops joining system messages —
-    each segment becomes its own `TextBlockParam`. The new
-    `cache.go` heuristic auto-places `cache_control:
-    {type: ephemeral}` breakpoints on long-enough segments (≥4096
-    chars) plus the last tool definition and the second-to-last
-    history message, sharing Anthropic's hard 4-breakpoint global
-    budget by priority (tools → history → system-latest → earlier
-    system). 5-min ephemeral TTL. Caller-facing API unchanged.
-  - `openai`: `buildParams` now auto-injects `prompt_cache_key`
-    (16-hex-char SHA-256 of canonicalised system + tools) so
-    requests with identical stable prefixes land on the same
-    backend node deterministically instead of round-robin —
-    flipping implicit prompt-cache hit-rate from "lottery" to
-    "deterministic hit when the prefix is identical". Message
-    history is excluded from the hash so multi-turn calls don't
-    rotate off the cached node. Canonical JSON serialisation
-    absorbs Go map iteration nondeterminism.
-  - `bytedance`: no code change (the ArkRuntime SDK exposes no
-    routing-hint field analogous to `prompt_cache_key` and no
-    explicit cache_control breakpoint surface). `convertMessages`
-    already preserved multi-segment system messages, so Doubao's
-    automatic prefix caching benefits from the shared convention
-    transparently. Package godoc updated to document the
-    contract.
+## `memory/v0.1.0` - 2026-05-30
 
-  End-to-end tests use `httptest` to capture the actual wire body
-  and assert the expected `cache_control` placements / non-empty
-  `prompt_cache_key` field for representative scenarios (long
-  stable + short volatile, history anchor on multi-turn, budget
-  trimming with 5 long segments, no-marker emission when nothing
-  qualifies, deterministic key under reordered map iteration).
-
-- `sdkx/llm/{anthropic,openai,bytedance}`: populate
-  `TokenUsage.CachedInputTokens` on every Generate / streaming
-  finish path so callers can read cache hit-rate uniformly across
-  providers. Anthropic / Minimax additionally normalise
-  Anthropic's three-bucket prompt-token wire format
-  (`input_tokens` + `cache_read_input_tokens` +
-  `cache_creation_input_tokens`) into a single gross
-  `InputTokens` (matching OpenAI's `prompt_tokens` semantics) so
-  `CachedInputTokens / InputTokens` is a provider-agnostic
-  hit-rate ratio. The three-bucket arithmetic is factored into
-  `normalizeAnthropicUsage` and pinned by a dedicated unit test so
-  a future refactor cannot silently under-count InputTokens for
-  Anthropic-family providers — that bug had hidden in the adapter
-  for the entire pre-cache history of the project. A follow-up
-  conformance suite under `tests/conformance/llm/` exercises this
-  end-to-end against live providers (double-call with ≥ 1024-token
-  stable prefix, asserts CachedInputTokens > 0 on the second call);
-  measured hit-rates 96–99% on azure / deepseek / minimax against
-  the live APIs.
-
-- `sdkx/llm/{openai,anthropic}`: configurable OTel / metrics provider
-  tag via new `LLM.WithProviderName(name)` + `LLM.Provider()`. Wrapping
-  adapters (`sdkx/llm/{azure,deepseek,qwen,minimax}`) now stamp their
-  own name on every span (`llm.<provider>.generate.<model>`),
-  attribute (`telemetry.AttrLLMProvider`), and metric label produced
-  by the upstream base provider. Previously, traffic from every
-  OpenAI-compatible sub-provider was silently aggregated under
-  `"openai"` in traces and dashboards (and MiniMax under
-  `"anthropic"`), because the base implementations hardcoded the
-  provider label deep in their hot path. Sub-providers had no way to
-  override it without re-implementing the whole `Generate` /
-  `GenerateStream` / streaming-finalize path. The same plumbing
-  routes through `classifyAPIError`'s fallback, so wrapped
-  network-shaped errors now surface under the right sub-provider
-  name. Direct callers of `openai.New` / `anthropic.New` are
-  unaffected (the historical "openai" / "anthropic" tags remain the
-  defaults). The image generators and `ollama` are already direct
-  providers and report their own names; not touched.
-
-#### eval
-
-- `eval/go.mod`: bump `sdk` v0.3.0 → v0.3.4 and `sdkx` v0.3.0 → v0.3.1.
-  Picks up the `sdk/recall.Add` slot-metadata fix (issue #100) and the
-  `sdkx/llm` nil-response guards (PR #103) so the LongMemEval `_s`
-  runner no longer panics at `sdkx/llm/openai/openai.go:314` when
-  DeepSeek's OpenAI-compatible backend answers a queued request with
-  literal JSON `null` — failures now surface as clean
-  `errdefs.NotAvailable` errors that the per-question scorer reports
-  as `error` instead of crashing the whole run.
-
-- **Breaking (internal)**: evaluation code consolidated under `eval/`,
-  freeing the word `bench` for Go's `Benchmark*` performance
-  benchmarks. Shared `dataset/` and `metrics/` packages were promoted
-  to `eval/`'s top level; all suites now share a single off-workspace
-  module `github.com/GizClaw/flowcraft/eval`. External consumers
-  update imports per the table below:
-
-  | Old                           | New                      |
-  | ----------------------------- | ------------------------ |
-  | `…/bench/locomo`              | `…/eval/locomo`          |
-  | `…/bench/locomo/dataset`      | `…/eval/dataset`         |
-  | `…/bench/locomo/metrics`      | `…/eval/metrics`         |
-  | `…/bench/locomo/runners…`     | `…/eval/locomo/runners…` |
-  | `…/bench/history-compression` | `…/eval/history`         |
-  | `…/tests/quality/knowledge`   | `…/eval/knowledge`       |
-
-### Deprecated
-
-#### sdk
-
-- `agent.Request.Extensions`. Agent never interpreted the field, no
-  engine ever read it, and the `map[string]any` →
-  `map[string]string` type mismatch with `engine.Run.Attributes`
-  meant any future forwarding would have needed ad-hoc per-host
-  serialisation. Use `agent.WithAttributes(...)` instead — same
-  wire format, same codepath, no serialisation guesswork. The
-  field is retained for source compatibility but ignored on every
-  write path.
-
----
-
-## `sdk/v0.3.3` — 2026-05-11
+First standalone release of FlowCraft's memory-domain module.
 
 ### Added
 
-- `sdk/script`: `signal.error` / `signal.interrupt` are now natively
-  typed — `Signal` carries an errdefs `Kind` (errors) or `engine.Cause`
-  (interrupts) plus a freeform `Detail`. `script.SignalToError` is the
-  single mapping point; jsrt / luart accept both the bare-string form
-  (back-compat) and `{kind, message, detail}`. `scriptnode` delegates
-  to it so `errdefs.Is*` and `engine.Interrupted{Cause}` work through
-  the chain. `iteration.js` forwards Kind/Detail when re-raising
-  child signals.
-
-## `sdk/v0.3.2` — 2026-05-11
-
-### Fixed
-
-- `sdk/graph/scriptnode`: repaired built-in JS scripts against v0.3
-  bindings — `answer.js` now routes through the canonical per-node
-  publisher (the v0.2 `stream` global was retired); `approval.js`
-  fills `node.id` from a new `scriptnode/bridge_node.go` instead of a
-  never-injected `config.__node_id`; `iteration.js` clears
-  `__iteration_result` between iterations, checks child signals
-  before pushing results, and propagates `signal.{error,interrupt,done}`
-  to the parent loop. `builtins_test.go` covers each script through
-  the real ScriptNode wiring so future binding renames trip the suite
-  instead of breaking silently at runtime.
-
-## `sdk/v0.3.1` — 2026-05-11
-
-### Fixed
-
-- `sdk/graph` + `sdk/graph/node/llmnode`: `graph.ValidateOutputs` now
-  accepts a required `PortTypeMessages` output satisfied either via a
-  board var (historical) or a non-empty channel of the same name
-  (the v0.3 reality). `llmnode.OutputPorts` drops `Required: true`
-  for the messages port — redundant with the executor's
-  run-then-validate sequence. Without this fix every llmnode round
-  driven through `graph/runner.Runner` came back with
-  `Status=failed` / `"missing required output port"`, silently
-  breaking observers, persistence, and memory-extract pipelines that
-  gate on `StatusCompleted`.
-
-## `sdk/v0.3.0` — 2026-05-09
-
-The v0.2.x deprecation window closes in a single coordinated cut.
-Every symbol that lived in a per-package `deprecated.go` shim during
-v0.2.x is removed. See [`docs/migrations/v0.3.0.md`](docs/migrations/v0.3.0.md)
-for the full removed-symbol table and upgrade recipe.
-
-### Removed (breaking)
-
-- `sdk/workflow` and `sdk/graph/adapter` (workflow ↔ graph bridge).
-- `sdk/llm`: `RoundResult` / `RunRound` / `StreamRound` /
-  `RoundConfig` family, `CapsMiddleware` / `WithExtraCaps` /
-  `LookupModelCaps` shims, `ModelInfo.Caps` auto-promotion.
-- `sdk/graph`: internal `Executor` interface, `ErrInterrupt`,
-  `WithEventBus` / `WithStreamCallback` / `WithCheckpointStore`
-  options, `busOnlyHost` shim, `VarMessages` / `VarQuery` /
-  `VarAnswer`. Runner collapses onto `engine.Engine`.
-- `sdk/knowledge`: legacy v0.1 surface (`Document` / `Chunk` /
-  `SearchResult` / `SearchOptions` / `DocInput`, `Store` family,
-  `ChunkDocument` / `ScoreChunk` / `RankResults` / `RRFMerge`,
-  `ChangeNotifier` / `Reloader`, `KnowledgeConfig` / `Node`).
-  Everything routes through `*Service` now.
-- `sdk/history`: `Closer` / `Compactor.Close`, `SummaryCacheStore`,
-  `RecoverArchive` / `SaveManifest` top-level helpers; tool
-  implementations + `ToolDeps` / `RegisterTools` relocate to
-  `sdkx/tool/history`.
-- `sdk/retrieval`: `SearchRequest.ReturnRaw` and
-  `SearchResponse.RawByRetriever`.
-- `sdk/script/bindings`: `NewStreamBridge`, `NewRunBridge`,
-  `AgentStepBindings`, `BuildEnv` preset. `NewRunInfoBridge` is the
-  surviving run-metadata bridge.
+- `memory/recall`: recall v2 write/read pipeline with temporal facts,
+  projection materialization, multi-lane retrieval, reranking, repair/triage
+  hooks, and evaluation diagnostics.
+- `memory/history`: transcript buffers, compacted history, summary stores, and
+  related persistence contracts.
+- `memory/knowledge`: knowledge service, local/retrieval-backed stores, and
+  factory helpers.
+- `memory/retrieval`: in-memory, SQLite, Postgres, workspace, scoring, journal,
+  namespace, and pipeline packages.
+- `memory/text`: tokenization, normalization, BM25, phrase, stemming, stopword,
+  quote, and timex helpers.
 
 ### Changed
 
-- `sdk/engine`: `MainChannel` renamed from `""` to `"__main_channel"`
-  with a `RestoreBoard` migration shim for old checkpoints. The `__`
-  prefix is now reserved for engine-owned board keys.
-- `sdk/graph/node/llmnode`: `MessagesKey` →
-  `MessagesChannel` (typed channel name); `QueryFallback` removed.
-- `sdk/graph/node/knowledgenode`: gains `Config.QueryKey`.
-- `sdk/knowledge`: `ContextLayer` ↔ `Layer` flip
-  (`ContextLayer` kept as alias); `ModeSemantic` removed.
+- Pins `github.com/GizClaw/flowcraft/sdk` to `v0.4.0`.
+- Promotes recall/history/knowledge/retrieval/text APIs from "SDK subdomain" to
+  a first-class, independently versioned module.
+
+## `sdkx/v0.4.0` - 2026-05-30
+
+Provider and adapter release coordinated with `sdk/v0.4.0` and
+`memory/v0.1.0`.
+
+### Changed
+
+- Pins `github.com/GizClaw/flowcraft/sdk` to `v0.4.0`.
+- Adds an explicit `github.com/GizClaw/flowcraft/memory v0.1.0` dependency for
+  deprecated retrieval wrappers that forward to `memory/retrieval/...`.
+- Refreshes provider dependency sums after the memory split.
+
+### Included From The v0.3.x Line
+
+- Prompt-cache token accounting across OpenAI-compatible, Anthropic-family, and
+  ByteDance adapters, including `TokenUsage.CachedInputTokens` population and
+  cache-aware telemetry.
+- Provider-specific error classification for OpenAI, Anthropic, ByteDance,
+  Azure/OpenAI-compatible wrappers, and related image/streaming paths.
+- Nil-response guards for upstream SDKs that can return `(nil, nil)`.
+- `sdkx/sandbox/nsjail` as the first sandbox backend that enforces network and
+  cgroup resource policy on Linux.
+
+## `vessel/v0.3.0` - 2026-05-30
+
+Runtime release coordinated with the published `sdk` and `memory` modules.
 
 ### Added
 
-- `sdk/model.LastByRole` helper for role-scoped reverse scans.
-
-## `sdkx/v0.3.0` — 2026-05-09
+- `vessel/assembly`: helpers for assembling runtime components around memory
+  recall, knowledge, tool catalogs, manifests, and workspace-backed backends.
 
 ### Changed
 
-- Bump `sdk` dependency to `v0.3.0`. Tool implementations and
-  context keys for `sdkx/tool/history` and `sdkx/tool/kanban` take
-  ownership of the symbols relocated out of `sdk/` — signatures stay
-  identical for downstream callers that swapped imports during the
-  v0.2.x deprecation window. See
-  [`docs/migrations/v0.3.0.md`](docs/migrations/v0.3.0.md) for the
-  full mapping.
+- Pins `github.com/GizClaw/flowcraft/sdk` to `v0.4.0`.
+- Pins `github.com/GizClaw/flowcraft/memory` to `v0.1.0`.
+- Removes local `replace` directives from the published module.
+- Refreshes `vessel/go.sum` against the published `sdk` and `memory` tags.
 
-### Removed
+## `vessel/v0.2.0` - 2026-05-14
 
-- `sdkx/knowledge/watcher` (alongside the deprecated
-  `knowledge.ChangeNotifier`). Durable watchers must emit
-  `ChangeEvent` for `EventReloader` directly.
+Runtime hardening release.
 
----
+### Added
 
-## `vesseld/v0.1.0` — 2026-05-11
+- `SessionStore` plus `WithSessionStore` for per-run workspace isolation.
+- `MemorySessionStore` and `FilesystemSessionStore`.
+- `Captain.Resume`, fleet resume support, and daemon `/resume` endpoint.
 
-General availability of the `vesseld` orchestration daemon. Composes
-the `v0.1.0` vessel runtime with declarative YAML, multi-vessel fleet
-supervision, and a Prometheus-instrumented HTTP control plane into a
-single static binary suitable for production single-node deployments.
+### Changed
 
-The cut goes directly from `vesseld/v0.1.0-rc.1` to GA — no `rc.2`
-tag was published. The `vessel` dependency bump to `v0.1.0-rc.2`
-landed in `main` shortly after the vessel tag (consumed
-`Handle.OnTerminate` so the fleet supervisor can release the
-concurrency gate + prune the run registry deterministically on
-termination, eliminating a class of latent races surfaced by chaos
-tests), and shipped as part of this GA.
+- Actor terminology converged on agent/run fields in lifecycle envelopes.
+- Expanded contract, honesty, and end-to-end lifecycle coverage for tools,
+  hosts, deciders, observers, resume, ask-user, revise, and HTTP flows.
+
+## `vesseld/v0.1.0` - 2026-05-11
+
+General availability of the standalone daemon.
+
+### Added
+
+- Declarative YAML for vessels, agents, LLM profiles, history stores, probes,
+  sidecars, resources, and fleet-level runtime configuration.
+- HTTP/SSE control plane over Unix sockets and authenticated TCP.
+- Prometheus metrics, run registry, drain/phase endpoints, and e2e tests.
+- Cross-platform binary release artifacts.
+
+### Later Mainline Additions
+
+- Declarative sandbox resources, shared session store config, mTLS config,
+  secret providers, and TLS resolver helpers landed after `vesseld/v0.1.0`.
+  These are documented in current README/examples and will be captured by the
+  next daemon binary release tag.
+
+## `sdk/v0.3.x` - 2026-05-09 to 2026-05-17
+
+The v0.3 line closed the v0.2 deprecation window and cleaned up the SDK runtime
+surface. See [`docs/migrations/v0.3.0.md`](docs/migrations/v0.3.0.md) for the
+full removed-symbol table and migration recipe.
 
 ### Highlights
 
-- Vessel lifecycle (`/v1/vessels/{id}/call`, `/submit`, `/drain`,
-  `/phase`) wired through unix socket **and** TCP + bearer-token auth.
-  The TCP listener refuses to start without a `tokenFile`; mTLS is on
-  the `v0.2` track.
-- Per-vessel concurrency gate, shared LLM clients with cross-vessel
-  rate limiting, and the seven catalog-registered probes
-  (`TokenBudgetProbe`, `ToolReachableProbe`, `PromptResponseProbe`,
-  …) all on by default.
-- Fleet supervisor uses `vessel.Handle.OnTerminate` for deterministic
-  concurrency-gate release + run-registry pruning on termination
-  (chaos-test hardened).
-- End-to-end `tests/e2e/vesseld` (25+ test files: allowlist, auth,
-  chaos, concurrency, drain, restart, sidecar reject, …) gates the
-  release.
-- Cross-platform binaries (linux/amd64, linux/arm64, darwin/amd64,
-  darwin/arm64, windows/amd64) with SHA-256 checksums via
-  `.github/workflows/release-vesseld.yml`.
+- Removed `sdk/workflow`, workflow/graph adapters, round helper families, and
+  legacy graph/runtime shims.
+- Converged graph execution on `engine.Engine`, typed message channels, and
+  explicit board channel names.
+- Removed legacy `sdk/knowledge`, `sdk/history`, and `sdk/retrieval`
+  compatibility surfaces that had been deprecated through v0.2.
+- Added runtime metadata, host dependencies, tool registry/allow-list plumbing,
+  cached-token usage fields, and telemetry attributes/counters.
+- Fixed scriptnode bindings, required message-output validation, provider error
+  classification, nil upstream responses, and eval module dependency drift.
 
-### Examples
+## `sdkx/v0.3.x` - 2026-05-09 to 2026-05-17
 
-- [`examples/vesseld-multi-vessel/`](examples/vesseld-multi-vessel/) —
-  the canonical multi-agent demo with Kanban-style delegation.
-- [`examples/vesseld-with-history/`](examples/vesseld-with-history/) —
-  single-vessel demo wiring a shared `HistoryStore` so the agent
-  remembers earlier turns of the same `context_id` conversation.
-  (Cross-restart persistence ships in `v0.2`.)
-
-### Known limitations (tracked for `v0.2`)
-
-- No per-run filesystem session storage (`vessel.WithSessionStore` is
-  not yet wired).
-- mTLS / SecretProvider / `vesseld migrate` subcommand are not yet
-  shipped — runbook recommends fronting the TCP listener with a
-  TLS-terminating proxy in the meantime.
-
-## `vesseld/v0.1.0-rc.1` — 2026-05-07
-
-First release candidate of the `vesseld` orchestration daemon.
-
-### Added
-
-- Declarative YAML configuration for vessels, agents, LLM clients, and rate
-  limiters.
-- HTTP control plane: `/v1/vessels/{id}/call`, `/submit`, `/logs` (SSE),
-  `/v1/runs` (paginated), `/metrics` (Prometheus text exposition).
-- Multi-vessel fleet supervision with per-vessel concurrency gates.
-- Cross-platform release artifacts via `release-vesseld.yml`.
-
-## `vessel/v0.1.0` — 2026-05-11
-
-General availability of the in-process `vessel` runtime. No API-level
-changes between `vessel/v0.1.0-rc.2` and GA — this is a stability /
-documentation coordination release that pairs with `vesseld/v0.1.0`.
+Provider-adapter line paired with `sdk/v0.3.x`.
 
 ### Highlights
 
-- Captain lifecycle (`Submit` / `Drain` / `Stop` / `Restart`) with
-  per-vessel concurrency gates and deterministic termination via
+- Moved tool implementations for history, knowledge, and kanban into
+  `sdkx/tool/...` while keeping public signatures stable for migrated callers.
+- Added prompt-cache routing/markers and cache-token normalization for supported
+  providers.
+- Added nsjail sandbox backend and provider-name telemetry overrides.
+- Removed `sdkx/knowledge/watcher` alongside the SDK knowledge watcher cleanup.
+
+## `vessel/v0.1.0` - 2026-05-11
+
+General availability of the in-process `vessel` runtime.
+
+### Highlights
+
+- Captain lifecycle: `Submit`, `Drain`, `Stop`, `Restart`, and
   `Handle.OnTerminate`.
-- `Spec.Resources.MaxTokensPerTurn` / `MaxTokensPerHour` budget caps
-  enforced end-to-end through `vessel/budget.go` + `vessel/sandbox.go`.
-- Built-in probes (`TokenBudgetProbe`, `ToolReachableProbe`,
-  `PromptResponseProbe`) for liveness / readiness signals; custom
-  probes register via `Probe` interface.
-- Multi-agent routing, Kanban agent-as-tool delegation, sidecar
-  agents, and shared history across the agent roster.
-- Decoupled from `sdk/workflow` (removed in `sdk/v0.3.0`); composes
-  cleanly on `sdk/engine` + `sdk/agent`.
+- Per-vessel concurrency gates, token budgets, probes, sidecars, multi-agent
+  routing, Kanban agent-as-tool delegation, and shared history.
+- Decoupled from the removed `sdk/workflow` package and composed on
+  `sdk/engine` plus `sdk/agent`.
 
-### Known limitations (tracked for `v0.2`)
+## `sdk/v0.2.x` and `sdkx/v0.2.x`
 
-- `WithSessionStore` (per-run isolated filesystem workspace) is not
-  yet wired; long-running agents that need disk state should use a
-  Captain-scoped workspace today and migrate when `v0.2` lands.
+The v0.2 line introduced the agent/engine/graph runtime, knowledge/history
+redesigns, image-output capabilities, handoff primitives, retrieval scoring,
+workspace capabilities, and the first wave of `sdkx/tool/...` migration
+wrappers.
 
-## `vessel/v0.1.0-rc.2` — 2026-05-07
+## Earlier Releases
 
-### Added
-
-- `Handle.OnTerminate` synchronous lifecycle hook for ordered termination
-  side-effects (run registry, concurrency gate release, etc.).
-
-## `vessel/v0.1.0-rc.1` — 2026-05-07
-
-First release candidate of the `vessel` runtime: in-process Captain managing
-agents, shared memory, engines, supervision, and probes (token-budget,
-tool-reachable, custom).
-
-## `sdk/v0.2.8` … `sdk/v0.2.11` — 2026-05-07 … 2026-05-08
-
-Incremental v0.2 releases between the v0.2.7 anchor and the v0.3.0
-cutover. See individual tags for full detail; headline changes:
-
-- `sdk/v0.2.8` — `sdk/llm` image-output caps (PR #71).
-- `sdk/v0.2.9` — handoff primitives + the first round of v0.3
-  deprecation shims (PR #77).
-- `sdk/v0.2.10` — `sdk/retrieval` scoring refinements (PR #80).
-- `sdk/v0.2.11` — `sdk/retrieval` workspace capabilities (PR #81).
-
-## `sdk/v0.2.7` and earlier
-
-See git history under `sdk/v*` tags. Highlights:
-
-- `sdk/agent` — agent orchestration with observers and deciders.
-- `sdk/graph` — declarative DAG executor.
-- `sdk/engine` — execution primitives (Board, Run, Host, Interrupt,
-  Checkpoint, Subject).
-- `sdk/recall` — long-term memory with hybrid BM25 + vector + entity
-  retrieval, RRF fusion, and entity-boost / time-decay reranking.
-- `sdk/history`, `sdk/knowledge`, `sdk/llm`, `sdk/event`, `sdk/model`,
-  `sdk/tool`, `sdk/kanban`.
-
-## `sdkx/v0.2.6` … `sdkx/v0.2.9` — 2026-05-07 … 2026-05-08
-
-Incremental v0.2 releases tracking `sdk` v0.2.8–v0.2.11. Headline
-changes:
-
-- `sdkx/v0.2.6` — image-modality adapters (PR #72).
-- `sdkx/v0.2.7` — Phase-1 checkpoint + OTel (PR #78).
-- `sdkx/v0.2.8` — tool migrations from `sdk/{history,kanban}` →
-  `sdkx/tool/{history,kanban}` (PR #79).
-- `sdkx/v0.2.9` — `retrieval` workspace (PR #82).
-
-## `sdkx/v0.2.5` and earlier
-
-Provider implementations: OpenAI, Anthropic, Google, OpenAI-compatible
-runtimes; SQLite and Postgres+pgvector backends for `sdk/retrieval`.
-
-## `voice/v0.2.0`
-
-Voice pipeline: STT → LLM → TTS with VAD and WebRTC transport.
+See git tags for full detail. The early release line established the core SDK,
+provider adapters, retrieval and history primitives, the voice pipeline, and the
+first vessel/vesseld release candidates.

--- a/README.md
+++ b/README.md
@@ -16,9 +16,10 @@
 
 FlowCraft is a layered, **batteries-included** toolkit for shipping LLM applications in Go. Pick the layer you need:
 
-- **`sdk`** — Composable primitives: agents, DAG executor, conversation history, hybrid retrieval, knowledge bases, kanban-style multi-agent delegation.
-- **`sdkx`** — Drop-in providers: OpenAI, Anthropic, DeepSeek, MiniMax, ByteDance / Volcengine, plus embedding + reranker backends.
-- **`vessel`** — In-process runtime that hosts your agents with proper lifecycle (Submit / Drain / Stop), restart policies, probes, sidecars, and shared history.
+- **`sdk`** — Composable primitives: agents, DAG executor, LLM contracts, tools, telemetry, workspaces, and kanban-style multi-agent delegation.
+- **`memory`** — Long-term recall, conversation history, knowledge retrieval, text processing, and memory-backed stores.
+- **`sdkx`** — Drop-in providers: OpenAI, Anthropic, DeepSeek, MiniMax, ByteDance / Volcengine, plus embedding, reranker, sandbox, and compatibility adapters.
+- **`vessel`** — In-process runtime that hosts your agents with lifecycle management, restart policies, probes, sidecars, per-run workspaces, and assembly helpers.
 - **`vesseld`** — A standalone daemon that runs `vessel` instances from declarative YAML, exposes an HTTP + SSE control plane, and shares LLM clients & rate limits across many vessels.
 - **`voice`** — Real-time STT → LLM → TTS pipeline with VAD, barge-in, and WebRTC.
 
@@ -31,7 +32,7 @@ Everything ships as Go modules with semantic versioning — depend on what you n
 | You want…                                                    | FlowCraft gives you…                                                                                                      |
 | ------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------- |
 | Strict separation between **engine** and **agent**           | `sdk/engine` is a leaf package; `sdk/agent` orchestrates above it. No "framework is the runtime" coupling.                |
-| **Long-term memory** that actually retrieves what's relevant | `sdk/recall` ships hybrid BM25 + vector retrieval with predicate-alias normalisation, not just embedding similarity.      |
+| **Long-term memory** that actually retrieves what's relevant | `memory/recall` ships hybrid BM25 + vector retrieval with predicate-alias normalisation, not just embedding similarity.   |
 | **Multi-agent collaboration** without a graph DSL            | `sdk/kanban` exposes any agent as a tool to any other agent — composition is just function calls.                         |
 | **A daemon you can deploy**                                  | `vesseld` is a single static binary: `vesseld run --config ./config -R`. No runtime, no Python, no Docker required.       |
 | **Voice agents** that don't reinvent VAD                     | `voice/` ships VAD, endpointing, barge-in, WebRTC — wire it to any STT/TTS provider in `sdkx`.                            |
@@ -87,13 +88,13 @@ curl -H "Authorization: Bearer $TOKEN" http://localhost:8443/v1/vessels/support/
   -d '{"agent":"support-agent","query":"hello"}'
 ```
 
-mTLS support is on the `v0.2` track; until then keep the listener behind a TLS-terminating proxy or restrict it to a trusted network.
+mTLS support is available through the daemon TLS config; bearer-token TCP auth remains the lightest remote-access path for simple deployments.
 
 See [`examples/vesseld-multi-vessel/`](examples/vesseld-multi-vessel/) for the multi-agent + Kanban delegation walkthrough, and [`examples/vesseld-with-history/`](examples/vesseld-with-history/) for an agent that remembers earlier turns of the same conversation.
 
 ### Library — programmatic SDK usage
 
-For embedding agents directly into a Go service (no daemon), use `sdk` + `sdkx` directly. The minimum viable wiring is a graph DAG (`graph.GraphDefinition` + `node.Factory` with `llmnode.Register`) driven by `agent.Run`. See:
+For embedding agents directly into a Go service (no daemon), use `sdk` directly and add `memory` / `sdkx` when you need recall, history, knowledge, or provider adapters. The minimum viable wiring is a graph DAG (`graph.GraphDefinition` + `node.Factory` with `llmnode.Register`) driven by `agent.Run`. See:
 
 - [`sdk/agent/run_test.go`](sdk/agent/run_test.go) — minimal `agent.Run` patterns
 - [`tests/quality/vessel/`](tests/quality/vessel/) — full integration examples (history, sidecars, kanban)
@@ -118,7 +119,7 @@ End-to-end: [`examples/voice-pipeline/`](examples/voice-pipeline/) — a runnabl
 
 ## Architecture
 
-Layered bottom-up. Each layer only depends on layers below it; siblings on the same row are independent of each other.
+Layered bottom-up. `sdk` is the foundation; `memory` builds on it, and upper layers compose the published `sdk` + `memory` surfaces.
 
 ```
    ┌──────────────────────────────────────────────────────────────┐
@@ -133,27 +134,26 @@ Layered bottom-up. Each layer only depends on layers below it; siblings on the s
    ┌────────────┼─────────────────┐          ┌──────▼─────┐
    │     ┌──────▼───────┐  ┌──────▼──────┐   │   voice/   │  WebRTC
    │     │   vessel/    │  │    sdkx/    │   │ (pipeline) │
-   │     │  (runtime)   │  │ (providers) │   └─────┬──────┘
-   │     │ Captain ▸    │  │ openai ·    │         │
-   │     │ Probe · Re-  │  │ anthropic · │         │
-   │     │ start ·      │  │ deepseek ·  │         │
-   │     │ Sidecar ·    │  │ minimax ·   │         │
-   │     │ Kanban       │  │ volcengine  │         │
+   │     │ runtime +    │  │ providers + │   └─────┬──────┘
+   │     │ assembly     │  │ sandbox     │         │
    │     └──────┬───────┘  └──────┬──────┘         │
    │            │                 │                │
-   │            └─────────┬───────┴────────────────┘
-   │                      │ all sit on sdk
-   │             ┌────────▼───────────────────────┐
-   └────────────►│             sdk/               │
-                 │ agent · engine · graph         │
-                 │ recall · history · knowledge   │
-                 │ kanban · tool · model · llm    │
-                 │ event · telemetry · workspace  │
-                 └────────────────────────────────┘
-                  Foundation — depends on no other in-tree module.
+   │            ├─────────┬───────┴────────────────┘
+   │            │         │
+   │     ┌──────▼──────┐  │        ┌────────────────┐
+   │     │   memory/   │  └───────►│      sdk/      │
+   │     │ recall ·    │           │ agent · engine │
+   │     │ history ·   │           │ graph · llm ·  │
+   │     │ knowledge · │           │ tool · event · │
+   │     │ retrieval   │           │ telemetry      │
+   │     └──────┬──────┘           └────────────────┘
+   │            │                         ▲
+   └────────────┴─────────────────────────┘
+        sdk is the foundation. memory depends on sdk; sdkx and vessel
+        consume the published sdk + memory surfaces.
 ```
 
-**Layering rule**: `sdk/engine` is a leaf inside `sdk/` — it does NOT import `agent`, `graph`, `history`, `recall`, `llm`, `tool`, or `workflow`. New execution engines plug in by implementing `engine.Engine` against the `Host` capability interface, which keeps the runtime contract narrow.
+**Layering rule**: `sdk/engine` is a leaf inside `sdk/` — it does NOT import `agent`, `graph`, `llm`, `tool`, or `workflow`. New execution engines plug in by implementing `engine.Engine` against the `Host` capability interface, which keeps the runtime contract narrow. Memory services live in the separate `memory` module and depend on the SDK contracts rather than the other way around.
 
 ---
 
@@ -164,8 +164,8 @@ Layered bottom-up. Each layer only depends on layers below it; siblings on the s
 | [`sdk`](sdk/)                              | Core primitives — agent, graph DAG, kanban, model, llm, telemetry                                          | yes           |
 | [`memory`](memory/)                        | Memory domain — recall v2, history, knowledge, retrieval, text, and memory adapters                        | yes           |
 | [`sdkx`](sdkx/)                            | Provider implementations (OpenAI, Anthropic, DeepSeek, MiniMax, Volcengine) + non-memory extensions        | yes           |
-| [`vessel`](vessel/)                        | In-process agent runtime — Captain, restart, probes, sidecars                                              | `v0.1.0-rc.2` |
-| [`cmd/vesseld`](cmd/vesseld/)              | Standalone daemon binary — declarative YAML, HTTP/SSE control plane                                        | `v0.1.0-rc.1` |
+| [`vessel`](vessel/)                        | In-process agent runtime — Captain, restart, probes, sidecars, per-run workspaces, assembly helpers        | yes           |
+| [`cmd/vesseld`](cmd/vesseld/)              | Standalone daemon binary — declarative YAML, HTTP/SSE control plane                                        | yes           |
 | [`voice`](voice/)                          | Real-time voice pipeline (VAD / STT / LLM / TTS / WebRTC)                                                  | yes           |
 | [`examples/`](examples/)                   | Worked end-to-end examples (voice pipeline, multi-vessel daemon, …)                                        | —             |
 | [`tests/quality/`](tests/quality/)         | Quality / regression suites (knowledge retrieval, vessel runtime)                                          | —             |
@@ -207,7 +207,8 @@ Layered bottom-up. Each layer only depends on layers below it; siblings on the s
 
 The canonical reference is the per-package `doc.go` files, browsable on pkg.go.dev:
 
-- [pkg.go.dev/github.com/GizClaw/flowcraft/sdk](https://pkg.go.dev/github.com/GizClaw/flowcraft/sdk) — core primitives (agent, engine, recall, history, knowledge, …)
+- [pkg.go.dev/github.com/GizClaw/flowcraft/sdk](https://pkg.go.dev/github.com/GizClaw/flowcraft/sdk) — core primitives (agent, engine, graph, llm, tool, telemetry, …)
+- [pkg.go.dev/github.com/GizClaw/flowcraft/memory](https://pkg.go.dev/github.com/GizClaw/flowcraft/memory) — recall, history, knowledge, retrieval, and text packages
 - [pkg.go.dev/github.com/GizClaw/flowcraft/sdkx](https://pkg.go.dev/github.com/GizClaw/flowcraft/sdkx) — provider implementations
 - [pkg.go.dev/github.com/GizClaw/flowcraft/vessel](https://pkg.go.dev/github.com/GizClaw/flowcraft/vessel) — runtime layer
 - [pkg.go.dev/github.com/GizClaw/flowcraft/voice](https://pkg.go.dev/github.com/GizClaw/flowcraft/voice) — voice pipeline
@@ -220,9 +221,9 @@ For the daemon specifically, run `vesseld --help` for CLI sub-commands and suppo
 
 ## Status
 
-`sdk` and `sdkx` are stable and released continuously. `vessel` and `cmd/vesseld` have shipped `v0.1.0` and are production-ready for single-node deployments. Durable execution (Postgres + SQLite checkpoint stores), OTel exporters, Prometheus `/metrics`, the seven-suite `eval/` harness, and end-to-end `tests/e2e/vesseld` conformance are all in place.
+`sdk` and `sdkx` are stable and released continuously. `memory` is published as its own module for recall, history, knowledge, retrieval, and text. `vessel` has shipped `v0.3.0` with per-run session workspaces and assembly helpers, and `cmd/vesseld` is production-ready for single-node deployments. Durable execution (Postgres + SQLite checkpoint stores), OTel exporters, Prometheus `/metrics`, the seven-suite `eval/` harness, and end-to-end `tests/e2e/vesseld` conformance are all in place.
 
-The next milestone (`v0.2`) hardens vesseld for "comfortable to operate": per-run session storage, mTLS, a `SecretProvider` interface, and a `vesseld migrate` subcommand. `v0.3` brings the protocol trio — MCP, Agent Skills (SKILL.md), and A2A — plus agent-writable memory Slots.
+The next milestone is the assertion-graph memory model: first-class observations, assertions, and links with provenance, so recall can retrieve linked evidence packets instead of isolated facts.
 
 API surface is governed by SemVer per module. Breaking changes ship as minor bumps until each module reaches `v1.0.0`.
 
@@ -239,7 +240,7 @@ make ci            # vet + test for all in-tree modules
 make test-e2e      # black-box vesseld suite (no API key required)
 ```
 
-This repo is a Go workspace (`go.work`). The in-tree modules are `sdk`, `sdkx`, `vessel`, `voice`, `cmd/vesseld`, and `tests/quality/vessel`. The off-workspace modules (`bench`, `examples/voice-pipeline`, `tests/conformance`, `tests/quality/knowledge`, `tests/e2e/vesseld`) pin released versions and run with `GOWORK=off`.
+This repo is a Go workspace (`go.work`). The in-tree modules are `sdk`, `memory`, `sdkx`, `vessel`, `voice`, `cmd/vesseld`, and `eval`. Off-workspace examples and test harnesses pin released versions and run with `GOWORK=off`.
 
 ---
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -8,9 +8,10 @@ Security fixes are issued against the latest release of each module.
 | Module     | Supported tag stream |
 | ---------- | -------------------- |
 | `sdk`      | latest `sdk/v0.x`    |
+| `memory`   | latest `memory/v0.x` |
 | `sdkx`     | latest `sdkx/v0.x`   |
-| `vessel`   | latest `vessel/v0.1.0-rc.x` |
-| `vesseld`  | latest `vesseld/v0.1.0-rc.x` |
+| `vessel`   | latest `vessel/v0.x` |
+| `vesseld`  | latest `vesseld/v0.x` |
 | `voice`    | latest `voice/v0.x`  |
 
 Older minor versions are not patched; please upgrade before reporting issues
@@ -29,7 +30,7 @@ Use one of the following private channels:
 
 Please include:
 
-- Affected module(s) and version/tag (e.g. `vesseld/v0.1.0-rc.1`).
+- Affected module(s) and version/tag (e.g. `vessel/v0.3.0`).
 - A minimal reproduction (config, command, request, or code snippet).
 - Impact assessment (what a malicious actor could do).
 - Any suggested mitigation, if you have one.
@@ -47,8 +48,8 @@ Please include:
 
 In scope:
 
-- Code in this repository (`sdk/`, `sdkx/`, `vessel/`, `cmd/vesseld/`,
-  `voice/`, `examples/`, `tests/`).
+- Code in this repository (`sdk/`, `memory/`, `sdkx/`, `vessel/`,
+  `cmd/vesseld/`, `voice/`, `examples/`, `tests/`).
 - Default configurations shipped with `vesseld` and the example deployments.
 
 Out of scope:

--- a/docs/index.md
+++ b/docs/index.md
@@ -6,43 +6,50 @@ title: FlowCraft Documentation
 # FlowCraft
 
 Go SDK for building AI agents with long-term memory, knowledge
-retrieval, and voice. Source on
+retrieval, runtime orchestration, and voice. Source on
 [github.com/GizClaw/flowcraft](https://github.com/GizClaw/flowcraft).
 
 ## Migrations
 
+- [`sdk/v0.4.0` + `memory/v0.1.0`](migrations/v0.4.0-memory-split.md) —
+  memory-domain packages split into the standalone `memory` module.
 - [`sdk/v0.3.0`](migrations/v0.3.0.md) — breaking-change cutover
   closing the v0.2.x deprecation window.
 
 ## Layered architecture
 
-The SDK is organised top-down from execution primitives to agent
-orchestration:
+The repository is organised as independently released Go modules:
 
 | Layer | Package | Responsibility |
 | --- | --- | --- |
 | Primitives | `sdk/engine` | Board / Run / Host / Interrupt / Checkpoint contracts |
 | DAG executor | `sdk/graph` | Declarative graph runtime (`runner.Runner` implements `engine.Engine`) |
 | Orchestration | `sdk/agent` | Agents, observers, deciders, board seeders, handoff DSL |
-| Services | `sdk/{recall,history,knowledge,llm,retrieval,workspace}` | Memory, conversation transcripts, knowledge base, LLM factory, hybrid retrieval, workspace abstraction |
-| Adapters | `sdkx/...` | Concrete provider / protocol bindings layered on the SDK contracts |
+| Memory services | `memory/{recall,history,knowledge,retrieval,text}` | Long-term recall, transcripts, knowledge base, retrieval indexes, text processing |
+| Adapters | `sdkx/...` | Concrete provider / protocol bindings layered on the SDK and memory contracts |
+| Runtime | `vessel/...`, `cmd/vesseld` | In-process runtime and deployable daemon |
 
 ## Repository layout
 
 ```
-sdk/      Core SDK (interfaces + primitives)
-sdkx/     Extended SDK (concrete adapters with their own go.mod)
-voice/    Voice pipeline: STT → LLM → TTS
-bench/    Benchmarks (GOWORK=off)
-examples/ Reference assemblies
-tests/    Conformance / quality / e2e suites
+sdk/         Core SDK (interfaces + primitives)
+memory/      Recall, history, knowledge, retrieval, text
+sdkx/        Provider and protocol adapters
+vessel/      Runtime and assembly helpers
+cmd/vesseld/ Daemon binary
+voice/       Voice pipeline: STT → LLM → TTS
+eval/        Quality-evaluation harnesses
+examples/    Reference assemblies
+tests/       Conformance / quality / e2e suites
 ```
 
 ## Getting started
 
 ```bash
 go get github.com/GizClaw/flowcraft/sdk@latest
+go get github.com/GizClaw/flowcraft/memory@latest
 ```
 
 See the package-level `doc.go` files for runnable usage snippets:
-`sdk/agent/doc.go`, `sdk/engine/doc.go`, `sdk/graph/doc.go`.
+`sdk/agent/doc.go`, `sdk/engine/doc.go`, `sdk/graph/doc.go`, and
+the focused packages under `memory/`.

--- a/docs/migrations/v0.4.0-memory-split.md
+++ b/docs/migrations/v0.4.0-memory-split.md
@@ -1,0 +1,102 @@
+# Migrating to the `sdk/v0.4.0` + `memory/v0.1.0` split
+
+> Status: `sdk/v0.4.0`, `memory/v0.1.0`, `sdkx/v0.4.0`, and
+> `vessel/v0.3.0` are published.
+
+This release makes the memory domain a first-class Go module. The important
+change is the release boundary, not a broad source-breaking API cleanup like
+`sdk/v0.3.0`.
+
+## Release order
+
+The modules were tagged in dependency order:
+
+1. `sdk/v0.4.0`
+2. `memory/v0.1.0`
+3. `sdkx/v0.4.0`
+4. `vessel/v0.3.0`
+
+The resulting dependency graph is:
+
+```text
+sdk/v0.4.0
+└── memory/v0.1.0
+    ├── sdkx/v0.4.0
+    └── vessel/v0.3.0
+```
+
+`sdkx` depends on `memory` because its deprecated retrieval wrappers forward to
+`memory/retrieval/...`. `vessel` depends on `memory` for assembly helpers and
+memory-backed runtime integrations.
+
+## New module boundary
+
+Use `github.com/GizClaw/flowcraft/memory` for memory-domain packages:
+
+| Domain | Module/package family |
+| --- | --- |
+| Long-term recall | `memory/recall` |
+| Conversation transcripts | `memory/history` |
+| Knowledge retrieval | `memory/knowledge` |
+| Retrieval indexes and scoring | `memory/retrieval` |
+| Text/tokenization utilities | `memory/text` |
+
+`sdk` remains the foundation for agent execution, graph runtime, LLM contracts,
+tools, events, telemetry, and workspace primitives.
+
+## Upgrade paths
+
+### SDK-only users
+
+If you only use agent / engine / graph / LLM / tool primitives:
+
+```bash
+go get github.com/GizClaw/flowcraft/sdk@v0.4.0
+go mod tidy
+```
+
+### Memory users
+
+If you use recall, history, knowledge, retrieval, or text helpers:
+
+```bash
+go get github.com/GizClaw/flowcraft/sdk@v0.4.0
+go get github.com/GizClaw/flowcraft/memory@v0.1.0
+go mod tidy
+```
+
+New code should import memory-domain packages from the `memory` module.
+
+### SDKX users
+
+If you use provider adapters or compatibility wrappers:
+
+```bash
+go get github.com/GizClaw/flowcraft/sdkx@v0.4.0
+go mod tidy
+```
+
+`sdkx/v0.4.0` pins `sdk v0.4.0` and explicitly depends on `memory v0.1.0`.
+
+### Vessel users
+
+If you use the in-process runtime:
+
+```bash
+go get github.com/GizClaw/flowcraft/vessel@v0.3.0
+go mod tidy
+```
+
+`vessel/v0.3.0` pins `sdk v0.4.0` and `memory v0.1.0`, and publishes the
+`vessel/assembly` helpers.
+
+## Compatibility notes
+
+- This is mainly a module-boundary and dependency-pin release.
+- The v0.3 migration remains the source of truth for the large SDK API cleanup:
+  see [`sdk/v0.3.0`](v0.3.0.md).
+- Compatibility wrappers may still exist in older SDK/SDKX package families;
+  prefer the `memory/...` import paths for new work.
+- The example programs have not all been rewritten to the new import paths yet.
+  Their README files intentionally continue to describe the code that is
+  currently checked in.

--- a/eval/README.md
+++ b/eval/README.md
@@ -76,7 +76,7 @@ not directly comparable.
 ### C. Extractor prompt is the SDK default (no LoCoMo overlay)
 
 The LoCoMo runner intentionally does NOT override
-`sdk/recall.DefaultExtractPrompt`. The SDK default already encodes
+`memory/recall.DefaultExtractPrompt`. The memory default already encodes
 every architectural rule a long-term memory extractor needs
 (self-containedness, atomic entities, composite-fact rule for
 multi-hop, inference-evidence rule for preferences, canonical

--- a/eval/history/README.md
+++ b/eval/history/README.md
@@ -1,13 +1,13 @@
 # eval/history
 
-Quality + token-cost evaluation of `sdk/history` compactor strategies.
+Quality + token-cost evaluation of `memory/history` compactor strategies.
 
 Where `eval/locomo` answers _"did recall surface the right fact?"_, this
 suite answers _"given a long transcript and no recall layer, can the model
 still answer correctly with a compressed history?"_. The two questions
 stress orthogonal subsystems — locomo evaluates the long-term-memory
-pipeline (`sdk/recall`), this one evaluates the short-term-memory
-compactor (`sdk/history`) in isolation.
+pipeline (`memory/recall`), this one evaluates the short-term-memory
+compactor (`memory/history`) in isolation.
 
 ## Strategies
 

--- a/eval/leaderboard.md
+++ b/eval/leaderboard.md
@@ -881,7 +881,7 @@ work-ticket:
 1. **Entity-index retrieval layer** — auto-extract entities
    (proper nouns, quoted strings, compound noun phrases) into a
    dedicated index alongside chunk/dense; have `pipeline.LTM`
-   query all three with rank-fusion. Today `sdk/recall` carries
+   query all three with rank-fusion. Today `memory/recall` carries
    an `entities` field on every fact but does **not** maintain a
    separate retrieval channel keyed by them. Expected
    contribution: +10~15 pp on multi-hop / open-domain — upper

--- a/eval/locomo/README.md
+++ b/eval/locomo/README.md
@@ -1,6 +1,6 @@
 # eval/locomo
 
-Evaluation scaffold for `sdk/memory/ltm` against the LoCoMo / LongMemEval benchmarks.
+Evaluation scaffold for `memory/recall` against the LoCoMo / LongMemEval benchmarks.
 
 ## Quick start
 

--- a/eval/simpleqa/README.md
+++ b/eval/simpleqa/README.md
@@ -67,7 +67,7 @@ the dataset.
 
 The current eval treats the model as a closed-book oracle: just the
 question goes in, an answer comes out. Future variants will plug
-`sdk/knowledge` (RAG over a corpus) or `sdk/agent` + search tools in
+`memory/knowledge` (RAG over a corpus) or `sdk/agent` + search tools in
 front of the answer LLM. The same `Run` function is reused; only the
 prompt-building lambda changes. Numbers from the closed-book run
 provide the "no augmentation" baseline against which the augmented


### PR DESCRIPTION
## Summary
- Compress `CHANGELOG.md` and add the current published module state after the memory split.
- Add a `sdk/v0.4.0` + `memory/v0.1.0` migration note with release order, dependency graph, and upgrade paths.
- Refresh top-level docs, security policy, and eval READMEs to use the current `memory` module boundary.

## Test plan
- `git diff --check`


Made with [Cursor](https://cursor.com)