### PR TITLE
workspace: add sub workspace prefix views

### DIFF
--- a/memory/recall/store/workspace/backend.go
+++ b/memory/recall/store/workspace/backend.go
@@ -3,7 +3,6 @@ package workspace
 import (
 	"context"
 	"errors"
-	"path"
 	"sync"
 
 	"github.com/GizClaw/flowcraft/memory/recall"
@@ -14,9 +13,8 @@ import (
 )
 
 const (
-	defaultRoot = "recall"
-	stateFile   = "state.json"
-	stateTmp    = "state.json.tmp"
+	stateFile = "state.json"
+	stateTmp  = "state.json.tmp"
 )
 
 // Store is the durable canonical ledger plus its optional scope enumerator.
@@ -27,22 +25,12 @@ type Store interface {
 
 // Backend owns the workspace subtree shared by recall's durable adapters.
 type Backend struct {
-	mu   sync.Mutex
-	ws   sdkworkspace.Workspace
-	root string
+	mu sync.Mutex
+	ws sdkworkspace.Workspace
 }
 
 // Option configures a workspace backend.
 type Option func(*Backend)
-
-// WithRoot nests recall state under root inside the workspace.
-func WithRoot(root string) Option {
-	return func(b *Backend) {
-		if root != "" {
-			b.root = root
-		}
-	}
-}
 
 // Open creates a LocalWorkspace-backed recall durable backend at dir.
 func Open(dir string, opts ...Option) (*Backend, error) {
@@ -58,7 +46,7 @@ func New(ws sdkworkspace.Workspace, opts ...Option) (*Backend, error) {
 	if ws == nil {
 		return nil, errdefs.Validationf("recall workspace: nil workspace")
 	}
-	b := &Backend{ws: ws, root: defaultRoot}
+	b := &Backend{ws: ws}
 	for _, opt := range opts {
 		opt(b)
 	}
@@ -82,22 +70,8 @@ func (b *Backend) AsyncSemanticQueue() recall.AsyncSemanticQueue {
 // EvidenceStore returns the secondary evidence lookup adapter.
 func (b *Backend) EvidenceStore() recall.EvidenceStore { return &evidenceStore{b: b} }
 
-func (b *Backend) statePath() string {
-	if b.root == "" {
-		return stateFile
-	}
-	return path.Join(b.root, stateFile)
-}
-
-func (b *Backend) stateTmpPath() string {
-	if b.root == "" {
-		return stateTmp
-	}
-	return path.Join(b.root, stateTmp)
-}
-
 func (b *Backend) load(ctx context.Context) (state, error) {
-	raw, err := b.ws.Read(ctx, b.statePath())
+	raw, err := b.ws.Read(ctx, stateFile)
 	if err != nil {
 		if errors.Is(err, sdkworkspace.ErrNotFound) {
 			return newState(), nil
@@ -112,10 +86,10 @@ func (b *Backend) save(ctx context.Context, st state) error {
 	if err != nil {
 		return err
 	}
-	if err := b.ws.Write(ctx, b.stateTmpPath(), raw); err != nil {
+	if err := b.ws.Write(ctx, stateTmp, raw); err != nil {
 		return err
 	}
-	return b.ws.Rename(ctx, b.stateTmpPath(), b.statePath())
+	return b.ws.Rename(ctx, stateTmp, stateFile)
 }
 
 func samePartition(a, b domain.Scope) bool {

--- a/memory/retrieval/workspace/index.go
+++ b/memory/retrieval/workspace/index.go
@@ -16,10 +16,6 @@ import (
 // callers with very different shapes (mostly-read, very-write-heavy,
 // large vectors) should pass explicit options.
 const (
-	// DefaultRoot is the empty string, which means "use workspace
-	// root". Set [WithRoot] to nest the index under a sub-path.
-	DefaultRoot = ""
-
 	// DefaultMemtableMaxDocs is the doc-count threshold that
 	// triggers a memtable flush. Mid-thousands keeps each segment
 	// readable in a single Workspace.Read call.
@@ -65,7 +61,6 @@ const (
 // produced from a slice of [Option] values; callers do not
 // instantiate Config directly.
 type Config struct {
-	root             string
 	memtableMaxDocs  int
 	memtableMaxBytes int
 	walMaxBytes      int
@@ -81,7 +76,6 @@ type Config struct {
 
 func defaultConfig() Config {
 	return Config{
-		root:             DefaultRoot,
 		memtableMaxDocs:  DefaultMemtableMaxDocs,
 		memtableMaxBytes: DefaultMemtableMaxBytes,
 		walMaxBytes:      DefaultWALMaxBytes,
@@ -102,12 +96,6 @@ func defaultConfig() Config {
 
 // Option configures an [Index] at construction time.
 type Option func(*Config)
-
-// WithRoot nests the index under a sub-path of the workspace, which
-// lets a single Workspace host the index next to recall/, knowledge/,
-// memories/, history/ subtrees without name collisions. The default
-// is "" (workspace root).
-func WithRoot(p string) Option { return func(c *Config) { c.root = p } }
 
 // WithMemtableMaxDocs overrides the doc-count flush threshold.
 func WithMemtableMaxDocs(n int) Option {

--- a/memory/retrieval/workspace/namespace.go
+++ b/memory/retrieval/workspace/namespace.go
@@ -59,7 +59,7 @@ func (idx *Index) ensureNamespace(ctx context.Context, name string) (*namespaceS
 // memtable, (5) wire up the WAL writer, (6) start the heartbeat
 // goroutine that keeps our lock alive.
 func (idx *Index) openNamespaceLocked(ctx context.Context, st *namespaceState) error {
-	st.paths = newPathHelper(idx.cfg.root, st.name)
+	st.paths = newPathHelper(st.name)
 
 	lock, err := acquireLock(ctx, idx.ws, st.paths, idx.cfg.lockHeartbeat, idx.cfg.now())
 	if err != nil {

--- a/memory/retrieval/workspace/paths.go
+++ b/memory/retrieval/workspace/paths.go
@@ -6,29 +6,21 @@ import (
 )
 
 // pathHelper centralises the on-disk layout for one namespace.
-// Keeping all path math in a single struct lets the writer, reader,
-// flush, and compaction code stay agnostic of the workspace root or
-// namespace name they happen to be operating on, and makes it easy
-// to validate the layout in tests.
+// Keeping all path math behind one small type lets the writer, reader,
+// flush, and compaction code stay agnostic of the concrete workspace layout.
 type pathHelper struct {
-	root string // Index-level root within the workspace
-	ns   string // namespace name as supplied by the caller
+	ns string
 }
 
-// newPathHelper composes the per-namespace base path. An empty
-// Index root collapses to ns/...; a non-empty root nests as
-// root/ns/... so a single Workspace can host the index next to
-// recall/, knowledge/, history/, memories/ subtrees.
-func newPathHelper(root, ns string) pathHelper {
-	return pathHelper{root: root, ns: ns}
+// newPathHelper composes the per-namespace base path. Workspace-level
+// nesting is handled by sdk/workspace.Sub before the index is constructed.
+func newPathHelper(ns string) pathHelper {
+	return pathHelper{ns: ns}
 }
 
 // nsDir returns the namespace base directory.
 func (p pathHelper) nsDir() string {
-	if p.root == "" {
-		return p.ns
-	}
-	return path.Join(p.root, p.ns)
+	return p.ns
 }
 
 // manifestPath / manifestTmpPath are the canonical and staging

--- a/sdk/workspace/sub.go
+++ b/sdk/workspace/sub.go
@@ -1,0 +1,159 @@
+package workspace
+
+import (
+	"context"
+	"fmt"
+	"io/fs"
+	"path/filepath"
+	"strings"
+
+	"github.com/GizClaw/flowcraft/sdk/errdefs"
+)
+
+type subWorkspace struct {
+	inner   Workspace
+	prefix  string
+	initErr error
+}
+
+var _ Workspace = (*subWorkspace)(nil)
+
+// Sub returns a Workspace view rooted under prefix.
+//
+// All operations are forwarded to the parent workspace after prefixing the
+// caller's path. For local workspaces, the returned value also exposes Root()
+// so path-backed embedded stores can open files inside the subdirectory.
+func Sub(inner Workspace, prefix string) Workspace {
+	if inner == nil {
+		return nil
+	}
+	cleaned, err := cleanPath(prefix)
+	if err != nil {
+		return &subWorkspace{inner: inner, initErr: fmt.Errorf("workspace sub: invalid prefix %q: %w", prefix, err)}
+	}
+	if cleaned == "" {
+		return inner
+	}
+	switch current := inner.(type) {
+	case *subWorkspace:
+		if current.initErr != nil {
+			return &subWorkspace{inner: current.inner, initErr: current.initErr}
+		}
+		inner = current.inner
+		cleaned = filepath.Join(current.prefix, cleaned)
+	}
+	sw := &subWorkspace{inner: inner, prefix: cleaned}
+	switch typed := inner.(type) {
+	case *LocalWorkspace:
+		local, err := NewLocalWorkspace(filepath.Join(typed.Root(), cleaned))
+		if err != nil {
+			return &subWorkspace{inner: inner, initErr: fmt.Errorf("workspace sub: open local root %q: %w", cleaned, err)}
+		}
+		root := local.Root()
+		if root != typed.Root() && !strings.HasPrefix(root, typed.Root()+string(filepath.Separator)) {
+			err := fmt.Errorf("%w: %s (symlink escape)", ErrPathTraversal, cleaned)
+			return &subWorkspace{inner: inner, initErr: fmt.Errorf("workspace sub: open local root %q: %w", cleaned, err)}
+		}
+		return local
+	}
+	return sw
+}
+
+func (s *subWorkspace) Capabilities() Capabilities {
+	return CapabilitiesOf(s.inner)
+}
+
+func (s *subWorkspace) Read(ctx context.Context, path string) ([]byte, error) {
+	p, err := s.join(path)
+	if err != nil {
+		return nil, err
+	}
+	return s.inner.Read(ctx, p)
+}
+
+func (s *subWorkspace) Write(ctx context.Context, path string, data []byte) error {
+	p, err := s.join(path)
+	if err != nil {
+		return err
+	}
+	return s.inner.Write(ctx, p, data)
+}
+
+func (s *subWorkspace) Append(ctx context.Context, path string, data []byte) error {
+	p, err := s.join(path)
+	if err != nil {
+		return err
+	}
+	return s.inner.Append(ctx, p, data)
+}
+
+func (s *subWorkspace) Rename(ctx context.Context, src, dst string) error {
+	srcPath, err := s.join(src)
+	if err != nil {
+		return err
+	}
+	dstPath, err := s.join(dst)
+	if err != nil {
+		return err
+	}
+	return s.inner.Rename(ctx, srcPath, dstPath)
+}
+
+func (s *subWorkspace) Delete(ctx context.Context, path string) error {
+	p, err := s.join(path)
+	if err != nil {
+		return err
+	}
+	return s.inner.Delete(ctx, p)
+}
+
+func (s *subWorkspace) RemoveAll(ctx context.Context, path string) error {
+	if p, err := cleanPath(path); err != nil {
+		return err
+	} else if p == "" {
+		return errdefs.Forbiddenf("workspace: refusing to remove root")
+	}
+	p, err := s.join(path)
+	if err != nil {
+		return err
+	}
+	return s.inner.RemoveAll(ctx, p)
+}
+
+func (s *subWorkspace) List(ctx context.Context, dir string) ([]fs.DirEntry, error) {
+	p, err := s.join(dir)
+	if err != nil {
+		return nil, err
+	}
+	return s.inner.List(ctx, p)
+}
+
+func (s *subWorkspace) Exists(ctx context.Context, path string) (bool, error) {
+	p, err := s.join(path)
+	if err != nil {
+		return false, err
+	}
+	return s.inner.Exists(ctx, p)
+}
+
+func (s *subWorkspace) Stat(ctx context.Context, path string) (fs.FileInfo, error) {
+	p, err := s.join(path)
+	if err != nil {
+		return nil, err
+	}
+	return s.inner.Stat(ctx, p)
+}
+
+func (s *subWorkspace) join(path string) (string, error) {
+	if s.initErr != nil {
+		return "", s.initErr
+	}
+	cleaned, err := cleanPath(path)
+	if err != nil {
+		return "", err
+	}
+	if cleaned == "" {
+		return s.prefix, nil
+	}
+	return filepath.Join(s.prefix, cleaned), nil
+}

--- a/sdk/workspace/sub_test.go
+++ b/sdk/workspace/sub_test.go
@@ -1,0 +1,194 @@
+package workspace
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+func TestSubWorkspace_PrefixesOperations(t *testing.T) {
+	ctx := context.Background()
+	base := NewMemWorkspace()
+	sub := Sub(base, "runtime-a")
+	if err := sub.Write(ctx, "docs/a.txt", []byte("hello")); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	got, err := base.Read(ctx, "runtime-a/docs/a.txt")
+	if err != nil {
+		t.Fatalf("base Read: %v", err)
+	}
+	if string(got) != "hello" {
+		t.Fatalf("got %q, want hello", got)
+	}
+	if err := sub.Append(ctx, "docs/a.txt", []byte(" world")); err != nil {
+		t.Fatalf("Append: %v", err)
+	}
+	if err := sub.Rename(ctx, "docs/a.txt", "docs/b.txt"); err != nil {
+		t.Fatalf("Rename: %v", err)
+	}
+	if ok, err := base.Exists(ctx, "runtime-a/docs/b.txt"); err != nil || !ok {
+		t.Fatalf("base Exists = %v, %v; want true, nil", ok, err)
+	}
+	entries, err := sub.List(ctx, "docs")
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	found := false
+	for _, entry := range entries {
+		if entry.Name() == "b.txt" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("entries = %+v, want b.txt", entries)
+	}
+	if _, err := sub.Stat(ctx, "docs/b.txt"); err != nil {
+		t.Fatalf("Stat: %v", err)
+	}
+	if err := sub.Delete(ctx, "docs/b.txt"); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+	if ok, err := base.Exists(ctx, "runtime-a/docs/b.txt"); err != nil || ok {
+		t.Fatalf("base Exists after delete = %v, %v; want false, nil", ok, err)
+	}
+}
+
+func TestSubWorkspace_RejectsTraversal(t *testing.T) {
+	ctx := context.Background()
+	base := NewMemWorkspace()
+	bad := Sub(base, "../runtime-a")
+	if err := bad.Write(ctx, "x.txt", []byte("x")); !errors.Is(err, ErrPathTraversal) {
+		t.Fatalf("bad sub Write err = %v, want ErrPathTraversal", err)
+	}
+	sub := Sub(base, "runtime-a")
+	if err := sub.Write(ctx, "../escape.txt", []byte("x")); !errors.Is(err, ErrPathTraversal) {
+		t.Fatalf("Write traversal err = %v, want ErrPathTraversal", err)
+	}
+	if ok, err := base.Exists(ctx, "escape.txt"); err != nil || ok {
+		t.Fatalf("escape Exists = %v, %v; want false, nil", ok, err)
+	}
+}
+
+func TestSubWorkspace_RemoveAllRootRefused(t *testing.T) {
+	ctx := context.Background()
+	base := NewMemWorkspace()
+	base.MustWrite("runtime-a/child/file.txt", []byte("x"))
+	sub := Sub(base, "runtime-a")
+	if err := sub.RemoveAll(ctx, "."); err == nil {
+		t.Fatal("RemoveAll root should fail")
+	}
+	if err := sub.RemoveAll(ctx, "child"); err != nil {
+		t.Fatalf("RemoveAll child: %v", err)
+	}
+	if ok, err := base.Exists(ctx, "runtime-a/child/file.txt"); err != nil || ok {
+		t.Fatalf("child Exists = %v, %v; want false, nil", ok, err)
+	}
+}
+
+func TestSubWorkspace_Capabilities(t *testing.T) {
+	base := NewMemWorkspace()
+	sub := Sub(base, "runtime-a")
+	got := CapabilitiesOf(sub)
+	if !got.AtomicRename || !got.ReadAfterWrite || got.DurableOnWrite || got.Distributed {
+		t.Fatalf("CapabilitiesOf(sub) = %+v", got)
+	}
+}
+
+func TestSubWorkspace_MergesNestedSubPrefixes(t *testing.T) {
+	ctx := context.Background()
+	base := NewMemWorkspace()
+	sub := Sub(Sub(base, "runtime-a"), "memory")
+	if err := sub.Write(ctx, "state.json", []byte("x")); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	if ok, err := base.Exists(ctx, "runtime-a/memory/state.json"); err != nil || !ok {
+		t.Fatalf("merged path Exists = %v, %v; want true, nil", ok, err)
+	}
+}
+
+func TestSubWorkspace_LocalRoot(t *testing.T) {
+	base, err := NewLocalWorkspace(t.TempDir())
+	if err != nil {
+		t.Fatalf("NewLocalWorkspace: %v", err)
+	}
+	sub := Sub(base, filepath.Join("runtime-a", "memory"))
+	rooted, ok := sub.(*LocalWorkspace)
+	if !ok {
+		t.Fatalf("sub = %T, want *LocalWorkspace", sub)
+	}
+	want := filepath.Join(base.Root(), "runtime-a", "memory")
+	if rooted.Root() != want {
+		t.Fatalf("Root() = %q, want %q", rooted.Root(), want)
+	}
+	if info, err := os.Stat(rooted.Root()); err != nil || !info.IsDir() {
+		t.Fatalf("sub root stat = %v, %v; want dir", info, err)
+	}
+}
+
+func TestSubWorkspace_LocalRootRejectsSymlinkEscape(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink setup is platform-sensitive on windows")
+	}
+	base, err := NewLocalWorkspace(t.TempDir())
+	if err != nil {
+		t.Fatalf("NewLocalWorkspace: %v", err)
+	}
+	outside := t.TempDir()
+	if err := os.Symlink(outside, filepath.Join(base.Root(), "escape")); err != nil {
+		t.Fatalf("Symlink: %v", err)
+	}
+	sub := Sub(base, "escape")
+	if err := sub.Write(context.Background(), "file.txt", []byte("x")); !errors.Is(err, ErrPathTraversal) {
+		t.Fatalf("sub Write through symlink err = %v, want ErrPathTraversal", err)
+	}
+}
+
+func TestSubWorkspace_LocalSubPreservesGitWorkspace(t *testing.T) {
+	base, err := NewLocalWorkspace(t.TempDir())
+	if err != nil {
+		t.Fatalf("NewLocalWorkspace: %v", err)
+	}
+	sub := Sub(base, "runtime-a")
+	_, ok := sub.(GitWorkspace)
+	if !ok {
+		t.Fatalf("local sub does not implement GitWorkspace: %T", sub)
+	}
+}
+
+func TestSubWorkspace_GenericGitWorkspaceIsPlainWorkspace(t *testing.T) {
+	ctx := context.Background()
+	git := &recordingGitWorkspace{Workspace: NewMemWorkspace()}
+	sub := Sub(git, "runtime-a")
+	if _, ok := sub.(GitWorkspace); ok {
+		t.Fatalf("generic sub unexpectedly implements GitWorkspace: %T", sub)
+	}
+	if err := sub.Write(ctx, "file.txt", []byte("x")); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	if ok, err := git.Exists(ctx, "runtime-a/file.txt"); err != nil || !ok {
+		t.Fatalf("prefixed file Exists = %v, %v; want true, nil", ok, err)
+	}
+}
+
+type recordingGitWorkspace struct {
+	Workspace
+	calls []string
+}
+
+func (r *recordingGitWorkspace) GitClone(_ context.Context, _, dest string) error {
+	r.calls = append(r.calls, "clone:"+dest)
+	return nil
+}
+
+func (r *recordingGitWorkspace) GitPull(_ context.Context, dir string) error {
+	r.calls = append(r.calls, "pull:"+dir)
+	return nil
+}
+
+func (r *recordingGitWorkspace) GitHead(_ context.Context, dir string) (string, error) {
+	r.calls = append(r.calls, "head:"+dir)
+	return "abc123", nil
+}

--- a/sdkx/retrieval/workspace/deprecated.go
+++ b/sdkx/retrieval/workspace/deprecated.go
@@ -21,7 +21,6 @@ const (
 	DefaultCompactionMinSegments = target.DefaultCompactionMinSegments
 	DefaultMemtableMaxBytes      = target.DefaultMemtableMaxBytes
 	DefaultMemtableMaxDocs       = target.DefaultMemtableMaxDocs
-	DefaultRoot                  = target.DefaultRoot
 	DefaultWALMaxBytes           = target.DefaultWALMaxBytes
 )
 
@@ -41,7 +40,6 @@ var (
 	WithLockHeartbeat                       = target.WithLockHeartbeat
 	WithMemtableMaxBytes                    = target.WithMemtableMaxBytes
 	WithMemtableMaxDocs                     = target.WithMemtableMaxDocs
-	WithRoot                                = target.WithRoot
 	WithTokenizer                           = target.WithTokenizer
 	WithWALMaxBytes                         = target.WithWALMaxBytes
 )

--- a/tools/retrieval-namespace-migrate/main.go
+++ b/tools/retrieval-namespace-migrate/main.go
@@ -128,15 +128,15 @@ func openIndex(ctx context.Context, cfg config) (retrieval.Index, error) {
 		if cfg.workspaceRoot == "" {
 			return nil, fmt.Errorf("-workspace-root is required for workspace backend")
 		}
-		ws, err := sdkworkspace.NewLocalWorkspace(cfg.workspaceRoot)
+		local, err := sdkworkspace.NewLocalWorkspace(cfg.workspaceRoot)
 		if err != nil {
 			return nil, err
 		}
-		var opts []wsretrieval.Option
+		var ws sdkworkspace.Workspace = local
 		if cfg.workspaceIndexRoot != "" {
-			opts = append(opts, wsretrieval.WithRoot(cfg.workspaceIndexRoot))
+			ws = sdkworkspace.Sub(ws, cfg.workspaceIndexRoot)
 		}
-		return wsretrieval.New(ws, opts...)
+		return wsretrieval.New(ws)
 	default:
 		return nil, fmt.Errorf("-backend must be sqlite, postgres, or workspace")
 	}

--- a/vessel/assembly/assembly_test.go
+++ b/vessel/assembly/assembly_test.go
@@ -3,6 +3,8 @@ package assembly_test
 import (
 	"context"
 	"encoding/json"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -118,6 +120,43 @@ agents:
 		if _, ok := a.Tools.Get(name); !ok {
 			t.Fatalf("tool %q not registered", name)
 		}
+	}
+}
+
+func TestWorkspaceRecallBackendUsesRecallSubWorkspace(t *testing.T) {
+	root := t.TempDir()
+	defaults := assembly.Defaults{
+		Workspace: assembly.FilesystemWorkspaceBackend(),
+		Recall:    assembly.WorkspaceRecallBackend(),
+	}
+	manifest := `
+id: demo
+workspace:
+  root: ` + root + `
+recall: {}
+agents:
+  - name: primary
+    engine: test
+`
+	m, err := assembly.DecodeWithDefaults(strings.NewReader(manifest), defaults)
+	if err != nil {
+		t.Fatalf("DecodeWithDefaults: %v", err)
+	}
+	a, err := assembly.Build(context.Background(), m, assembly.WithCatalog(newTestCatalog(t)), assembly.WithDefaults(defaults))
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	t.Cleanup(func() { _ = a.Close() })
+	if _, err := a.Recall.Save(context.Background(), recall.Scope{RuntimeID: "rt", UserID: "u1"}, recall.SaveRequest{
+		Facts: []recall.TemporalFact{{Kind: recall.FactNote, Content: "alpha"}},
+	}); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(root, "recall", "state.json")); err != nil {
+		t.Fatalf("recall state path: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(root, "state.json")); !os.IsNotExist(err) {
+		t.Fatalf("root state path err = %v, want not exist", err)
 	}
 }
 

--- a/vessel/assembly/recall.go
+++ b/vessel/assembly/recall.go
@@ -7,6 +7,7 @@ import (
 	"github.com/GizClaw/flowcraft/memory/recall"
 	"github.com/GizClaw/flowcraft/memory/recall/ops"
 	recallworkspace "github.com/GizClaw/flowcraft/memory/recall/store/workspace"
+	sdkworkspace "github.com/GizClaw/flowcraft/sdk/workspace"
 )
 
 type recallBundle struct {
@@ -61,7 +62,7 @@ func (workspaceRecallBackend) BuildRecall(_ context.Context, spec RecallSpec, de
 	if deps.Workspace == nil {
 		return RecallResource{}, fmt.Errorf("vessel assembly: recall workspace backend requires workspace")
 	}
-	b, err := recallworkspace.New(deps.Workspace, recallworkspace.WithRoot(defaultString(spec.Prefix, "recall")))
+	b, err := recallworkspace.New(sdkworkspace.Sub(deps.Workspace, defaultString(spec.Prefix, "recall")))
 	if err != nil {
 		return RecallResource{}, err
 	}


### PR DESCRIPTION
## Summary
- Add `workspace.Sub` to expose a prefixed workspace view over an existing workspace.
- Return a real `LocalWorkspace` for local sub paths so path-backed stores and local Git methods work without an extra wrapper.
- Rework recall and retrieval workspace `WithRoot` handling to use the shared sub workspace helper.

## Validation
- `go test -count=1 ./sdk/workspace ./memory/recall/store/workspace ./memory/retrieval/workspace`
- `go test -count=1 ./vessel/assembly`
- `go test -count=1 ./memory/retrieval/bbh ./sdk/retrieval/bbh`
- `git diff --check`