### PR TITLE
vessel: fix Submit teardown race

### DIFF
--- a/vessel/captain.go
+++ b/vessel/captain.go
@@ -96,6 +96,11 @@ type Captain struct {
 	// this WaitGroup so a Drain waits for the bus subscription to
 	// fully close.
 	inflight sync.WaitGroup
+	// submitMu serializes foreground admission against Drain/Stop's
+	// transition to a non-accepting phase. That keeps inflight.Add
+	// from racing with inflight.Wait without making callback paths
+	// contend with the broader lifecycle lock.
+	submitMu sync.Mutex
 
 	// mu guards phase transitions to keep them monotonic per the
 	// state diagram in [Phase]. Reads happen via Phase() which
@@ -428,24 +433,24 @@ func (c *Captain) Resume(ctx context.Context, runID string) (*Handle, error) {
 // extraOpts lets Resume inject agent.WithResumeFrom without
 // duplicating the admission / handle / goroutine plumbing.
 func (c *Captain) submit(ctx context.Context, agentName string, req agent.Request, extraOpts []agent.RunOption) (*Handle, error) {
-	c.mu.Lock()
+	c.submitMu.Lock()
 	phase := c.Phase()
 	if !phase.AcceptsRequests() {
-		c.mu.Unlock()
+		c.submitMu.Unlock()
 		return nil, errdefs.NotAvailablef("vessel: not accepting requests in phase %q", phase)
 	}
 	entry, ok := c.entries[agentName]
 	if !ok {
-		c.mu.Unlock()
+		c.submitMu.Unlock()
 		return nil, errdefs.NotFoundf("vessel: no agent named %q", agentName)
 	}
 	if entry.spec.Sidecar {
-		c.mu.Unlock()
+		c.submitMu.Unlock()
 		return nil, errdefs.Conflictf("vessel: agent %q is a sidecar; trigger via bus, not Submit", agentName)
 	}
 
 	if c.budget.hourExhausted() {
-		c.mu.Unlock()
+		c.submitMu.Unlock()
 		return nil, errdefs.RateLimitf("vessel: hourly token budget exhausted")
 	}
 
@@ -454,11 +459,11 @@ func (c *Captain) submit(ctx context.Context, agentName string, req agent.Reques
 	}
 	h := newHandle(req.RunID, agentName)
 	rootCtx := c.rootCtx
-	// Keep Add under the lifecycle lock. Drain/Stop transition out of
-	// PhaseRunning while holding the same lock and only call Wait after
+	// Keep Add in the admission critical section. Drain/Stop transition
+	// out of PhaseRunning while holding submitMu and only call Wait after
 	// releasing it, so no new Submit can race Add against Wait.
 	c.inflight.Add(1)
-	c.mu.Unlock()
+	c.submitMu.Unlock()
 
 	// runCtx merges caller ctx with the Captain's root so Stop
 	// cancels in-flight runs even when the caller never cancels
@@ -550,12 +555,14 @@ func (c *Captain) Call(ctx context.Context, agentName string, req agent.Request)
 // After Drain returns successfully the phase advances to
 // PhaseStopped and the bus (if owned) is closed.
 func (c *Captain) Drain(ctx context.Context) error {
+	c.submitMu.Lock()
 	c.mu.Lock()
 	switch c.Phase() {
 	case PhasePending:
 		c.transitionPhaseLocked(PhaseStopped, "drain on pending")
 		c.closeOwnedBus()
 		c.mu.Unlock()
+		c.submitMu.Unlock()
 		return nil
 	case PhaseRunning:
 		c.transitionPhaseLocked(PhaseDraining, "")
@@ -563,9 +570,11 @@ func (c *Captain) Drain(ctx context.Context) error {
 		// Already in teardown.
 	case PhaseStopped, PhaseFailed:
 		c.mu.Unlock()
+		c.submitMu.Unlock()
 		return nil
 	default:
 		c.mu.Unlock()
+		c.submitMu.Unlock()
 		return errdefs.Conflictf("vessel: cannot Drain from phase %q", c.Phase())
 	}
 	// Sidecars stop accepting new envelopes by closing their
@@ -573,6 +582,7 @@ func (c *Captain) Drain(ctx context.Context) error {
 	// by the inflight WG below.
 	c.stopSidecars()
 	c.mu.Unlock()
+	c.submitMu.Unlock()
 
 	done := make(chan struct{})
 	go func() {
@@ -603,18 +613,21 @@ func (c *Captain) Drain(ctx context.Context) error {
 // will exit shortly after on their own (assuming the agent honours
 // ctx, which the engine.Engine contract requires).
 func (c *Captain) Stop(ctx context.Context) error {
+	c.submitMu.Lock()
 	c.mu.Lock()
 	switch c.Phase() {
 	case PhasePending:
 		c.transitionPhaseLocked(PhaseStopped, "stop on pending")
 		c.closeOwnedBus()
 		c.mu.Unlock()
+		c.submitMu.Unlock()
 		return nil
 	case PhaseRunning, PhaseDraining, PhaseFailed:
 		c.transitionPhaseLocked(PhaseStopping, "")
 	case PhaseStopping:
 	case PhaseStopped:
 		c.mu.Unlock()
+		c.submitMu.Unlock()
 		return nil
 	}
 	if c.rootCancel != nil {
@@ -624,6 +637,7 @@ func (c *Captain) Stop(ctx context.Context) error {
 	c.probes.stop()
 	c.stopSidecars()
 	c.mu.Unlock()
+	c.submitMu.Unlock()
 
 	done := make(chan struct{})
 	go func() {

--- a/vessel/captain.go
+++ b/vessel/captain.go
@@ -96,10 +96,10 @@ type Captain struct {
 	// this WaitGroup so a Drain waits for the bus subscription to
 	// fully close.
 	inflight sync.WaitGroup
-	// submitMu serializes foreground admission against Drain/Stop's
-	// transition to a non-accepting phase. That keeps inflight.Add
-	// from racing with inflight.Wait without making callback paths
-	// contend with the broader lifecycle lock.
+	// submitMu serializes foreground admission against transitions out
+	// of PhaseRunning. For Drain/Stop this keeps inflight.Add from
+	// racing with inflight.Wait; for failure transitions it keeps the
+	// root context snapshot coherent with the accepted phase.
 	submitMu sync.Mutex
 
 	// mu guards phase transitions to keep them monotonic per the
@@ -679,9 +679,11 @@ func (c *Captain) Stop(ctx context.Context) error {
 // and closing owned resources — instead of leaving a zombie
 // PhaseFailed Captain that the operator might miss.
 func (c *Captain) transitionToFailed(reason string) {
+	c.submitMu.Lock()
 	c.mu.Lock()
 	if c.Phase() != PhaseRunning {
 		c.mu.Unlock()
+		c.submitMu.Unlock()
 		return
 	}
 	c.transitionPhaseLocked(PhaseFailed, reason)
@@ -707,6 +709,7 @@ func (c *Captain) transitionToFailed(reason string) {
 		maxRestarts > 0 &&
 		c.restartAttempts >= maxRestarts
 	c.mu.Unlock()
+	c.submitMu.Unlock()
 
 	if exhausted {
 		c.finalize("restart attempts exhausted: " + reason)

--- a/vessel/captain.go
+++ b/vessel/captain.go
@@ -428,18 +428,24 @@ func (c *Captain) Resume(ctx context.Context, runID string) (*Handle, error) {
 // extraOpts lets Resume inject agent.WithResumeFrom without
 // duplicating the admission / handle / goroutine plumbing.
 func (c *Captain) submit(ctx context.Context, agentName string, req agent.Request, extraOpts []agent.RunOption) (*Handle, error) {
-	if !c.Phase().AcceptsRequests() {
-		return nil, errdefs.NotAvailablef("vessel: not accepting requests in phase %q", c.Phase())
+	c.mu.Lock()
+	phase := c.Phase()
+	if !phase.AcceptsRequests() {
+		c.mu.Unlock()
+		return nil, errdefs.NotAvailablef("vessel: not accepting requests in phase %q", phase)
 	}
 	entry, ok := c.entries[agentName]
 	if !ok {
+		c.mu.Unlock()
 		return nil, errdefs.NotFoundf("vessel: no agent named %q", agentName)
 	}
 	if entry.spec.Sidecar {
+		c.mu.Unlock()
 		return nil, errdefs.Conflictf("vessel: agent %q is a sidecar; trigger via bus, not Submit", agentName)
 	}
 
 	if c.budget.hourExhausted() {
+		c.mu.Unlock()
 		return nil, errdefs.RateLimitf("vessel: hourly token budget exhausted")
 	}
 
@@ -447,13 +453,18 @@ func (c *Captain) submit(ctx context.Context, agentName string, req agent.Reques
 		req.RunID = mintRunID()
 	}
 	h := newHandle(req.RunID, agentName)
+	rootCtx := c.rootCtx
+	// Keep Add under the lifecycle lock. Drain/Stop transition out of
+	// PhaseRunning while holding the same lock and only call Wait after
+	// releasing it, so no new Submit can race Add against Wait.
+	c.inflight.Add(1)
+	c.mu.Unlock()
 
 	// runCtx merges caller ctx with the Captain's root so Stop
 	// cancels in-flight runs even when the caller never cancels
 	// its own ctx.
-	parent, cancelParent := mergeContexts(ctx, c.rootCtx)
+	parent, cancelParent := mergeContexts(ctx, rootCtx)
 
-	c.inflight.Add(1)
 	go func() {
 		defer c.inflight.Done()
 		defer cancelParent()

--- a/vessel/captain_test.go
+++ b/vessel/captain_test.go
@@ -136,6 +136,57 @@ func TestCaptain_Submit_HandleWaitDelivers(t *testing.T) {
 	}
 }
 
+func TestCaptain_SubmitRejectedWhileStopWaiting(t *testing.T) {
+	started := make(chan struct{})
+	release := make(chan struct{})
+	var startedOnce sync.Once
+	blocking := engine.EngineFunc(func(_ context.Context, _ engine.Run, _ engine.Host, b *engine.Board) (*engine.Board, error) {
+		startedOnce.Do(func() { close(started) })
+		<-release
+		return b, nil
+	})
+	c, err := New(basicSpec("primary"), WithEngine(blocking))
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	if err := c.Launch(context.Background()); err != nil {
+		t.Fatalf("Launch: %v", err)
+	}
+
+	h, err := c.Submit(context.Background(), "primary", agent.Request{
+		Message: model.NewTextMessage(model.RoleUser, "block"),
+	})
+	if err != nil {
+		t.Fatalf("Submit first: %v", err)
+	}
+	<-started
+
+	stopCtx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	stopped := make(chan error, 1)
+	go func() { stopped <- c.Stop(stopCtx) }()
+
+	deadline := time.Now().Add(2 * time.Second)
+	for c.Phase() != PhaseStopping {
+		if time.Now().After(deadline) {
+			t.Fatalf("phase = %s, want %s", c.Phase(), PhaseStopping)
+		}
+		time.Sleep(time.Millisecond)
+	}
+	if _, err := c.Submit(context.Background(), "primary", agent.Request{
+		Message: model.NewTextMessage(model.RoleUser, "late"),
+	}); !errdefs.IsNotAvailable(err) {
+		t.Fatalf("late Submit err = %v, want NotAvailable", err)
+	}
+	close(release)
+	if err := <-stopped; err != nil {
+		t.Fatalf("Stop: %v", err)
+	}
+	if _, err := h.Wait(context.Background()); err != nil {
+		t.Fatalf("first run Wait: %v", err)
+	}
+}
+
 func TestCaptain_Submit_UnknownAgentReturnsNotFound(t *testing.T) {
 	t.Parallel()
 	c := newTestCaptain(t)


### PR DESCRIPTION
## Summary
- Synchronize `Submit` admission with `Drain`/`Stop` phase transitions so `inflight.Add` cannot race with teardown `Wait`.
- Use a dedicated submit admission mutex to avoid callback bridge deadlocks during Kanban teardown.
- Add a regression test that rejects late `Submit` calls while `Stop` is waiting.

Fixes #196.

## Test plan
- `go test -count=1 ./vessel -run TestCaptain_SubmitRejectedWhileStopWaiting`
- `go test -race -count=20 ./vessel -run 'TestKanban_DrainWaitsForKanbanWorker|TestKanban_FailedTask_DeliversCallback|TestCaptain_SubmitRejectedWhileStopWaiting'`
- `go test -race -count=1 ./vessel`

Made with [Cursor](https://cursor.com)