### PR TITLE
chore: repair PR 195 module tag dependencies

### DIFF
--- a/memory/go.mod
+++ b/memory/go.mod
@@ -3,7 +3,7 @@ module github.com/GizClaw/flowcraft/memory
 go 1.25.0
 
 require (
-	github.com/GizClaw/flowcraft/sdk v0.4.0
+	github.com/GizClaw/flowcraft/sdk v0.4.2
 	github.com/blevesearch/bleve/v2 v2.6.0
 	github.com/coder/hnsw v0.6.1
 	github.com/dgraph-io/badger/v4 v4.9.1

--- a/memory/go.sum
+++ b/memory/go.sum
@@ -1,5 +1,5 @@
-github.com/GizClaw/flowcraft/sdk v0.4.0 h1:L0wOTgjfizol33sgEJC/WzloB8O+vtNNHBqRXDo6/I8=
-github.com/GizClaw/flowcraft/sdk v0.4.0/go.mod h1:pMY9bxfdEOnj5gJndX9Yrrw3mpBvIbldBZ9Ug4b9Ltk=
+github.com/GizClaw/flowcraft/sdk v0.4.2 h1:xKQ9zhdK6C0ioJIrc4GOnog8TbAnEDJaGQqSbBXjaaQ=
+github.com/GizClaw/flowcraft/sdk v0.4.2/go.mod h1:CtWO/keRfKzfyTuKD3axf6QSpDB/vEqbBIRgvK9qpKw=
 github.com/RoaringBitmap/roaring/v2 v2.14.5 h1:ckd0o545JqDPeVJDgeFoaM21eBixUnlWfYgjE5VnyWw=
 github.com/RoaringBitmap/roaring/v2 v2.14.5/go.mod h1:eq4wdNXxtJIS/oikeCzdX1rBzek7ANzbth041hrU8Q4=
 github.com/bits-and-blooms/bitset v1.24.2 h1:M7/NzVbsytmtfHbumG+K2bremQPMJuqv1JD3vOaFxp0=

--- a/sdkx/go.mod
+++ b/sdkx/go.mod
@@ -2,10 +2,10 @@ module github.com/GizClaw/flowcraft/sdkx
 
 go 1.25.0
 
-require github.com/GizClaw/flowcraft/sdk v0.4.0
+require github.com/GizClaw/flowcraft/sdk v0.4.2
 
 require (
-	github.com/GizClaw/flowcraft/memory v0.1.0
+	github.com/GizClaw/flowcraft/memory v0.1.2
 	github.com/PuerkitoBio/goquery v1.11.0
 	github.com/anthropics/anthropic-sdk-go v1.26.0
 	github.com/go-shiori/go-readability v0.0.0-20251205110129-5db1dc9836f0

--- a/sdkx/go.sum
+++ b/sdkx/go.sum
@@ -8,10 +8,10 @@ github.com/Azure/azure-sdk-for-go/sdk/internal v1.10.0/go.mod h1:iZDifYGJTIgIIkY
 github.com/AzureAD/microsoft-authentication-library-for-go v1.2.2 h1:XHOnouVk1mxXfQidrMEnLlPk9UMeRtyBTnEFtxkV0kU=
 github.com/AzureAD/microsoft-authentication-library-for-go v1.2.2/go.mod h1:wP83P5OoQ5p6ip3ScPr0BAq0BvuPAvacpEuSzyouqAI=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
-github.com/GizClaw/flowcraft/memory v0.1.0 h1:/bMi3yorT2ig3Syyq76dcr+laXtfEYeU68KUTQGsulI=
-github.com/GizClaw/flowcraft/memory v0.1.0/go.mod h1:ddcjEcyaxlXXOR4ktW9VXI4vRIf4NPsQjLzL7P6CJjQ=
-github.com/GizClaw/flowcraft/sdk v0.4.0 h1:L0wOTgjfizol33sgEJC/WzloB8O+vtNNHBqRXDo6/I8=
-github.com/GizClaw/flowcraft/sdk v0.4.0/go.mod h1:pMY9bxfdEOnj5gJndX9Yrrw3mpBvIbldBZ9Ug4b9Ltk=
+github.com/GizClaw/flowcraft/memory v0.1.2 h1:0Dxj1uZVvf1J+aKzh8wuX8iwbDhu/eg9NL7QlaO0pIQ=
+github.com/GizClaw/flowcraft/memory v0.1.2/go.mod h1:FKrzqusZECJVKhsHVRBZZbZbbtwQ/DVKq0AnL+wUmuM=
+github.com/GizClaw/flowcraft/sdk v0.4.2 h1:xKQ9zhdK6C0ioJIrc4GOnog8TbAnEDJaGQqSbBXjaaQ=
+github.com/GizClaw/flowcraft/sdk v0.4.2/go.mod h1:CtWO/keRfKzfyTuKD3axf6QSpDB/vEqbBIRgvK9qpKw=
 github.com/PuerkitoBio/goquery v1.11.0 h1:jZ7pwMQXIITcUXNH83LLk+txlaEy6NVOfTuP43xxfqw=
 github.com/PuerkitoBio/goquery v1.11.0/go.mod h1:wQHgxUOU3JGuj3oD/QFfxUdlzW6xPHfqyHre6VMY4DQ=
 github.com/andybalholm/cascadia v1.3.3 h1:AG2YHrzJIm4BZ19iwJ/DAua6Btl3IwJX+VI4kktS1LM=

--- a/vessel/go.mod
+++ b/vessel/go.mod
@@ -3,7 +3,7 @@ module github.com/GizClaw/flowcraft/vessel
 go 1.25.0
 
 require (
-	github.com/GizClaw/flowcraft/sdk v0.4.0
+	github.com/GizClaw/flowcraft/sdk v0.4.2
 	go.opentelemetry.io/otel/log v0.16.0
 	gopkg.in/yaml.v3 v3.0.1
 )
@@ -15,7 +15,7 @@ require (
 )
 
 require (
-	github.com/GizClaw/flowcraft/memory v0.1.0
+	github.com/GizClaw/flowcraft/memory v0.1.2
 	github.com/cenkalti/backoff/v5 v5.0.3 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/dlclark/regexp2 v1.11.4 // indirect

--- a/vessel/go.sum
+++ b/vessel/go.sum
@@ -1,7 +1,7 @@
-github.com/GizClaw/flowcraft/memory v0.1.0 h1:/bMi3yorT2ig3Syyq76dcr+laXtfEYeU68KUTQGsulI=
-github.com/GizClaw/flowcraft/memory v0.1.0/go.mod h1:ddcjEcyaxlXXOR4ktW9VXI4vRIf4NPsQjLzL7P6CJjQ=
-github.com/GizClaw/flowcraft/sdk v0.4.0 h1:L0wOTgjfizol33sgEJC/WzloB8O+vtNNHBqRXDo6/I8=
-github.com/GizClaw/flowcraft/sdk v0.4.0/go.mod h1:pMY9bxfdEOnj5gJndX9Yrrw3mpBvIbldBZ9Ug4b9Ltk=
+github.com/GizClaw/flowcraft/memory v0.1.2 h1:0Dxj1uZVvf1J+aKzh8wuX8iwbDhu/eg9NL7QlaO0pIQ=
+github.com/GizClaw/flowcraft/memory v0.1.2/go.mod h1:FKrzqusZECJVKhsHVRBZZbZbbtwQ/DVKq0AnL+wUmuM=
+github.com/GizClaw/flowcraft/sdk v0.4.2 h1:xKQ9zhdK6C0ioJIrc4GOnog8TbAnEDJaGQqSbBXjaaQ=
+github.com/GizClaw/flowcraft/sdk v0.4.2/go.mod h1:CtWO/keRfKzfyTuKD3axf6QSpDB/vEqbBIRgvK9qpKw=
 github.com/cenkalti/backoff/v5 v5.0.3 h1:ZN+IMa753KfX5hd8vVaMixjnqRZ3y8CuJKRKj1xcsSM=
 github.com/cenkalti/backoff/v5 v5.0.3/go.mod h1:rkhZdG3JZukswDf7f0cwqPNk4K0sa+F97BxZthm/crw=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=


### PR DESCRIPTION
## Summary
- Update `memory` to require `sdk v0.4.2`, the tag created for PR #195's `workspace.Sub` changes.
- Update `sdkx` and `vessel` to require `sdk v0.4.2` and the repaired `memory v0.1.2` tag.
- Mark both commits with `[skip-tag]` so the auto-tag workflow does not create another patch release while repairing the existing tags.

## Tag repair notes
- `sdk/v0.4.2` remains on PR #195's merge commit.
- `memory/v0.1.2` has already been re-pointed to commit `4faea921` on this branch so downstream module tidy can resolve it.
- After this PR merges, re-point `memory/v0.1.2`, `sdkx/v0.4.1`, and `vessel/v0.3.2` to the merged commits on `main` as appropriate.

## Test plan
- `GOWORK=off go test -count=1 ./...` in `memory` passed.
- `GOWORK=off GOPROXY=direct GONOSUMDB=github.com/GizClaw/flowcraft/* go mod tidy` in `sdkx` and `vessel` passed.
- Full `sdkx` / `vessel` standalone tests were started but interrupted before completion.

Made with [Cursor](https://cursor.com)