### PR TITLE
fix(anthropic): wire thinking option

### DIFF
--- a/sdkx/llm/anthropic/anthropic.go
+++ b/sdkx/llm/anthropic/anthropic.go
@@ -21,8 +21,9 @@ import (
 )
 
 const (
-	defaultModel     = "claude-opus-4-6"
-	defaultMaxTokens = int64(4096)
+	defaultModel                = "claude-opus-4-6"
+	defaultMaxTokens            = int64(4096)
+	defaultThinkingBudgetTokens = int64(1024)
 )
 
 // normalizeAnthropicUsage maps Anthropic's three-bucket prompt-token
@@ -257,7 +258,9 @@ func (c *LLM) Generate(ctx context.Context, messages []llm.Message, opts ...llm.
 				},
 			},
 		}
-		applyBetaOptions(&p, options)
+		if err := applyBetaOptions(&p, options); err != nil {
+			return llm.Message{}, llm.TokenUsage{}, err
+		}
 		// Plan anchors against the stable params (planCacheAnchors
 		// reads only Text / content-length fields, which are
 		// identical across the stable / beta type pair) and then
@@ -313,7 +316,9 @@ func (c *LLM) Generate(ctx context.Context, messages []llm.Message, opts ...llm.
 		Messages:  msgParams,
 		System:    sys,
 	}
-	applyOptions(&p, options)
+	if err := applyOptions(&p, options); err != nil {
+		return llm.Message{}, llm.TokenUsage{}, err
+	}
 	// Cache-anchor planning must run *after* applyOptions has
 	// populated p.Tools — the plan's tools-end anchor needs the
 	// final tool slice to mutate in place. System / history
@@ -397,7 +402,10 @@ func (c *LLM) GenerateStream(ctx context.Context, messages []llm.Message, opts .
 				},
 			},
 		}
-		applyBetaOptions(&p, options)
+		if err := applyBetaOptions(&p, options); err != nil {
+			span.End()
+			return nil, err
+		}
 		// Same cache-anchor plumbing as the non-streaming Beta
 		// branch; see the comment there.
 		plan := planCacheAnchors(sys, msgParams, nil)
@@ -425,7 +433,10 @@ func (c *LLM) GenerateStream(ctx context.Context, messages []llm.Message, opts .
 		Messages:  msgParams,
 		System:    sys,
 	}
-	applyOptions(&p, options)
+	if err := applyOptions(&p, options); err != nil {
+		span.End()
+		return nil, err
+	}
 	plan := planCacheAnchors(p.System, p.Messages, p.Tools)
 	applyAnchorsToSystem(p.System, plan.systemBlocks)
 	applyAnchorToHistory(p.Messages, plan.historyMsgIdx)
@@ -605,7 +616,7 @@ func convertResponse(blocks []asdk.ContentBlockUnion) llm.Message {
 
 // --- Beta API helpers (JSON mode) ---
 
-func applyBetaOptions(p *asdk.BetaMessageNewParams, options *llm.GenerateOptions) {
+func applyBetaOptions(p *asdk.BetaMessageNewParams, options *llm.GenerateOptions) error {
 	if options.Temperature != nil {
 		p.Temperature = param.NewOpt(*options.Temperature)
 	}
@@ -618,6 +629,19 @@ func applyBetaOptions(p *asdk.BetaMessageNewParams, options *llm.GenerateOptions
 	if len(options.StopWords) > 0 {
 		p.StopSequences = options.StopWords
 	}
+	if options.Thinking != nil {
+		if *options.Thinking {
+			budget, err := thinkingBudgetTokens(p.MaxTokens)
+			if err != nil {
+				return err
+			}
+			p.Thinking = asdk.BetaThinkingConfigParamOfEnabled(budget)
+		} else {
+			disabled := asdk.NewBetaThinkingConfigDisabledParam()
+			p.Thinking = asdk.BetaThinkingConfigParamUnion{OfDisabled: &disabled}
+		}
+	}
+	return nil
 }
 
 func extractBetaText(blocks []asdk.BetaContentBlockUnion) string {
@@ -674,7 +698,7 @@ func convertToBetaSystemBlocks(sys []asdk.TextBlockParam) []asdk.BetaTextBlockPa
 
 // --- Stable API helpers ---
 
-func applyOptions(p *asdk.MessageNewParams, options *llm.GenerateOptions) {
+func applyOptions(p *asdk.MessageNewParams, options *llm.GenerateOptions) error {
 	if options.Temperature != nil {
 		p.Temperature = param.NewOpt(*options.Temperature)
 	}
@@ -686,6 +710,18 @@ func applyOptions(p *asdk.MessageNewParams, options *llm.GenerateOptions) {
 	}
 	if len(options.StopWords) > 0 {
 		p.StopSequences = options.StopWords
+	}
+	if options.Thinking != nil {
+		if *options.Thinking {
+			budget, err := thinkingBudgetTokens(p.MaxTokens)
+			if err != nil {
+				return err
+			}
+			p.Thinking = asdk.ThinkingConfigParamOfEnabled(budget)
+		} else {
+			disabled := asdk.NewThinkingConfigDisabledParam()
+			p.Thinking = asdk.ThinkingConfigParamUnion{OfDisabled: &disabled}
+		}
 	}
 
 	if len(options.Tools) > 0 {
@@ -758,6 +794,14 @@ func applyOptions(p *asdk.MessageNewParams, options *llm.GenerateOptions) {
 			DisableParallelToolUse: param.NewOpt(disableParallel),
 		}}
 	}
+	return nil
+}
+
+func thinkingBudgetTokens(maxTokens int64) (int64, error) {
+	if maxTokens <= defaultThinkingBudgetTokens {
+		return 0, errdefs.Validationf("anthropic: thinking requires max_tokens > %d", defaultThinkingBudgetTokens)
+	}
+	return defaultThinkingBudgetTokens, nil
 }
 
 func parseDataURL(s string) (mediaType, base64Data string, err error) {

--- a/sdkx/llm/anthropic/anthropic_test.go
+++ b/sdkx/llm/anthropic/anthropic_test.go
@@ -2,6 +2,7 @@ package anthropic
 
 import (
 	"context"
+	"encoding/json"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -11,6 +12,158 @@ import (
 	"github.com/GizClaw/flowcraft/sdk/errdefs"
 	"github.com/GizClaw/flowcraft/sdk/llm"
 )
+
+func TestGenerate_ThinkingFalseWritesDisabledRequestBody(t *testing.T) {
+	captured := make(chan map[string]any, 1)
+	srv := thinkingCaptureServer(t, captured)
+	defer srv.Close()
+
+	c, err := New("claude-3-sonnet-20240229", "test-key", srv.URL, nil)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	_, _, err = c.Generate(context.Background(), []llm.Message{
+		llm.NewTextMessage(llm.RoleUser, "hi"),
+	}, llm.WithThinking(false))
+	if err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+
+	body := readCapturedBody(t, captured)
+	assertThinking(t, body, "disabled", 0)
+}
+
+func TestGenerate_JSONModeThinkingFalseWritesBetaDisabledRequestBody(t *testing.T) {
+	captured := make(chan map[string]any, 1)
+	srv := thinkingCaptureServer(t, captured)
+	defer srv.Close()
+
+	c, err := New("claude-3-sonnet-20240229", "test-key", srv.URL, nil)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	_, _, err = c.Generate(context.Background(), []llm.Message{
+		llm.NewTextMessage(llm.RoleUser, "hi"),
+	}, llm.WithJSONMode(true), llm.WithThinking(false))
+	if err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+
+	body := readCapturedBody(t, captured)
+	if _, ok := body["output_format"]; !ok {
+		t.Fatalf("expected beta JSON-mode request body to include output_format, got %#v", body)
+	}
+	assertThinking(t, body, "disabled", 0)
+}
+
+func TestGenerate_ThinkingTrueWritesDefaultBudget(t *testing.T) {
+	captured := make(chan map[string]any, 1)
+	srv := thinkingCaptureServer(t, captured)
+	defer srv.Close()
+
+	c, err := New("claude-3-sonnet-20240229", "test-key", srv.URL, nil)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	_, _, err = c.Generate(context.Background(), []llm.Message{
+		llm.NewTextMessage(llm.RoleUser, "hi"),
+	}, llm.WithThinking(true))
+	if err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+
+	body := readCapturedBody(t, captured)
+	assertThinking(t, body, "enabled", defaultThinkingBudgetTokens)
+}
+
+func TestGenerate_ThinkingTrueRejectsTooSmallMaxTokens(t *testing.T) {
+	captured := make(chan map[string]any, 1)
+	srv := thinkingCaptureServer(t, captured)
+	defer srv.Close()
+
+	c, err := New("claude-3-sonnet-20240229", "test-key", srv.URL, nil)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	_, _, err = c.Generate(context.Background(), []llm.Message{
+		llm.NewTextMessage(llm.RoleUser, "hi"),
+	}, llm.WithMaxTokens(defaultThinkingBudgetTokens), llm.WithThinking(true))
+	if !errdefs.IsValidation(err) {
+		t.Fatalf("expected validation error, got %v", err)
+	}
+	select {
+	case body := <-captured:
+		t.Fatalf("request should not have reached server, got body %#v", body)
+	default:
+	}
+}
+
+func thinkingCaptureServer(t *testing.T, captured chan<- map[string]any) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		defer r.Body.Close()
+		var body map[string]any
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Errorf("decode request body: %v", err)
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		select {
+		case captured <- body:
+		default:
+			t.Errorf("unexpected additional request body: %#v", body)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{
+			"id": "msg_test",
+			"type": "message",
+			"role": "assistant",
+			"model": "claude-3-sonnet-20240229",
+			"content": [{"type": "text", "text": "ok"}],
+			"stop_reason": "end_turn",
+			"usage": {"input_tokens": 1, "output_tokens": 1}
+		}`)
+	}))
+}
+
+func readCapturedBody(t *testing.T, captured <-chan map[string]any) map[string]any {
+	t.Helper()
+	select {
+	case body := <-captured:
+		return body
+	default:
+		t.Fatal("server did not capture request body")
+		return nil
+	}
+}
+
+func assertThinking(t *testing.T, body map[string]any, wantType string, wantBudget int64) {
+	t.Helper()
+	raw, ok := body["thinking"]
+	if !ok {
+		t.Fatalf("request body missing thinking: %#v", body)
+	}
+	thinking, ok := raw.(map[string]any)
+	if !ok {
+		t.Fatalf("thinking has unexpected shape: %#v", raw)
+	}
+	if got := thinking["type"]; got != wantType {
+		t.Fatalf("thinking.type = %v, want %q (thinking=%#v)", got, wantType, thinking)
+	}
+	if wantBudget == 0 {
+		if _, ok := thinking["budget_tokens"]; ok {
+			t.Fatalf("disabled thinking should not include budget_tokens: %#v", thinking)
+		}
+		return
+	}
+	gotBudget, ok := thinking["budget_tokens"].(float64)
+	if !ok {
+		t.Fatalf("thinking.budget_tokens missing or non-numeric: %#v", thinking)
+	}
+	if int64(gotBudget) != wantBudget {
+		t.Fatalf("thinking.budget_tokens = %v, want %d", gotBudget, wantBudget)
+	}
+}
 
 // TestGenerate_NilResp_NoPanic regresses the same family of bug
 // fixed in sdkx/llm/openai: anthropic-sdk-go's MessageService.New


### PR DESCRIPTION
## Summary
- `llm.WithThinking(false)` now reaches Anthropic stable and beta Messages request bodies as `thinking.type=disabled`, which also covers Anthropic-compatible MiniMax calls.
- `llm.WithThinking(true)` now emits Anthropic's enabled thinking config with the minimum valid budget, and rejects too-small `max_tokens` before sending an invalid provider request.
- Adds request-body regressions for stable, beta JSON mode, enabled budget, and local validation.

## Test plan
- `go test ./sdkx/llm/anthropic`
- `go test ./sdkx/llm/minimax`

Refs GizClaw/flowcraft#200. The Claw config/defaults portion is tracked separately on PR #197.

Made with [Cursor](https://cursor.com)