### PR TITLE
fix(retrieval): close P0-P2 backend contract gaps

### DIFF
--- a/memory/retrieval/bbh/index.go
+++ b/memory/retrieval/bbh/index.go
@@ -580,10 +580,12 @@ func (idx *Index) Search(ctx context.Context, namespace string, req retrieval.Se
 		if err != nil {
 			return nil, err
 		}
+		textHits = positiveLaneHits(textHits)
 		vectorHits, err := idx.searchVectorLocked(sh, laneReq)
 		if err != nil {
 			return nil, err
 		}
+		vectorHits = positiveLaneHits(vectorHits)
 		hits = scoring.RRF([][]retrieval.Hit{textHits, vectorHits}, scoring.DefaultRRFK)
 	case hasText:
 		hits, err = idx.searchTextLocked(ctx, sh, req)
@@ -719,6 +721,16 @@ func (idx *Index) searchVectorFilteredScan(namespace string, req retrieval.Searc
 		out = out[:req.TopK]
 	}
 	return out, nil
+}
+
+func positiveLaneHits(hits []retrieval.Hit) []retrieval.Hit {
+	out := hits[:0]
+	for _, h := range hits {
+		if h.Score > 0 {
+			out = append(out, h)
+		}
+	}
+	return out
 }
 
 func filterIsZero(f retrieval.Filter) bool {

--- a/memory/retrieval/capabilities.go
+++ b/memory/retrieval/capabilities.go
@@ -58,7 +58,7 @@ func DefaultMemoryCapabilities() Capabilities {
 	return Capabilities{
 		BM25:   true,
 		Vector: true,
-		Sparse: false,
+		Sparse: true,
 		Hybrid: true,
 
 		FilterPushdown: true,

--- a/memory/retrieval/contract/contract.go
+++ b/memory/retrieval/contract/contract.go
@@ -27,6 +27,10 @@ func Run(t *testing.T, f Factory) {
 	t.Run("FilterEqAndIn", func(t *testing.T) { testFilterEqIn(t, f) })
 	t.Run("FilterRangeAndExists", func(t *testing.T) { testFilterRangeExists(t, f) })
 	t.Run("FilterNotComposes", func(t *testing.T) { testFilterNotComposes(t, f) })
+	t.Run("HybridIgnoresSearchMinScore", func(t *testing.T) { testHybridIgnoresSearchMinScore(t, f) })
+	t.Run("HybridDropsZeroEvidenceDocs", func(t *testing.T) { testHybridDropsZeroEvidenceDocs(t, f) })
+	t.Run("SparseCapabilityMatchesSearch", func(t *testing.T) { testSparseCapabilityMatchesSearch(t, f) })
+	t.Run("ListWithVectorFalseDropsAllVectors", func(t *testing.T) { testListWithVectorFalseDropsAllVectors(t, f) })
 	t.Run("DeleteByFilterValidation", func(t *testing.T) { testDeleteByFilterValidation(t, f) })
 	t.Run("CapabilitiesShape", func(t *testing.T) { testCapabilitiesShape(t, f) })
 	t.Run("SearchDebugIncludeLanesPopulatesExecution", func(t *testing.T) { testSearchDebugIncludeLanesPopulatesExecution(t, f) })
@@ -281,6 +285,120 @@ func testFilterNotComposes(t *testing.T, f Factory) {
 	}
 }
 
+func testHybridIgnoresSearchMinScore(t *testing.T, f Factory) {
+	idx, cleanup := f(t)
+	defer cleanup()
+	defer idx.Close()
+	ctx := context.Background()
+	ns := "ns_hybrid_minscore"
+	mustUpsert(t, idx, ns, []retrieval.Doc{
+		{ID: "a", Content: "alpha", Vector: []float32{1, 0}, Timestamp: time.Now()},
+	})
+	resp, err := idx.Search(ctx, ns, retrieval.SearchRequest{
+		QueryText:   "alpha",
+		QueryVector: []float32{1, 0},
+		TopK:        1,
+		MinScore:    1e9,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(resp.Hits) != 1 || resp.Hits[0].Doc.ID != "a" {
+		t.Fatalf("hybrid search must ignore SearchRequest.MinScore, hits=%+v", resp.Hits)
+	}
+}
+
+func testHybridDropsZeroEvidenceDocs(t *testing.T, f Factory) {
+	idx, cleanup := f(t)
+	defer cleanup()
+	defer idx.Close()
+	ctx := context.Background()
+	ns := "ns_hybrid_zero"
+	mustUpsert(t, idx, ns, []retrieval.Doc{
+		{ID: "text-only", Content: "alpha", Vector: []float32{0, 1}, Timestamp: time.Now()},
+		{ID: "vector-only", Content: "zzz", Vector: []float32{1, 0}, Timestamp: time.Now().Add(time.Second)},
+		{ID: "zero-evidence", Content: "zzz", Vector: []float32{0, 1}, Timestamp: time.Now().Add(2 * time.Second)},
+	})
+	resp, err := idx.Search(ctx, ns, retrieval.SearchRequest{
+		QueryText:   "alpha",
+		QueryVector: []float32{1, 0},
+		TopK:        3,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	ids := idsOf(resp.Hits)
+	if !containsID(ids, "text-only") {
+		t.Fatalf("hybrid search dropped text-lane positive doc: hits=%+v", resp.Hits)
+	}
+	if idx.Capabilities().Hybrid && !containsID(ids, "vector-only") {
+		t.Fatalf("native hybrid search dropped vector-lane positive doc: hits=%+v", resp.Hits)
+	}
+	for _, h := range resp.Hits {
+		if h.Doc.ID == "zero-evidence" {
+			t.Fatalf("hybrid search returned zero-evidence doc: hits=%+v", resp.Hits)
+		}
+	}
+}
+
+func testSparseCapabilityMatchesSearch(t *testing.T, f Factory) {
+	idx, cleanup := f(t)
+	defer cleanup()
+	defer idx.Close()
+	ctx := context.Background()
+	ns := "ns_sparse"
+	mustUpsert(t, idx, ns, []retrieval.Doc{
+		{ID: "sparse", Content: "x", SparseVector: map[string]float32{"needle": 2}, Timestamp: time.Now()},
+		{ID: "other", Content: "x", SparseVector: map[string]float32{"other": 2}, Timestamp: time.Now().Add(time.Second)},
+	})
+	resp, err := idx.Search(ctx, ns, retrieval.SearchRequest{
+		SparseVec: map[string]float32{"needle": 0.5},
+		TopK:      2,
+	})
+	if retrieval.CapabilitiesOf(idx).Sparse {
+		if err != nil {
+			t.Fatalf("Sparse=true backend rejected sparse search: %v", err)
+		}
+		if len(resp.Hits) == 0 || resp.Hits[0].Doc.ID != "sparse" || resp.Hits[0].Scores["sparse"] <= 0 {
+			t.Fatalf("sparse search returned wrong hits: %+v", resp.Hits)
+		}
+		return
+	}
+	if err == nil {
+		t.Fatalf("Sparse=false backend must reject sparse-only search, got response %+v", resp)
+	}
+	if !errdefs.IsValidation(err) && !errdefs.IsNotAvailable(err) && !errors.Is(err, retrieval.ErrNoQuery) {
+		t.Fatalf("Sparse=false backend returned unexpected error: %v", err)
+	}
+}
+
+func testListWithVectorFalseDropsAllVectors(t *testing.T, f Factory) {
+	idx, cleanup := f(t)
+	defer cleanup()
+	defer idx.Close()
+	ctx := context.Background()
+	ns := "ns_projection_vectors"
+	mustUpsert(t, idx, ns, []retrieval.Doc{
+		{
+			ID:           "a",
+			Content:      "alpha",
+			Vector:       []float32{1, 0},
+			SparseVector: map[string]float32{"alpha": 1},
+			Timestamp:    time.Now(),
+		},
+	})
+	resp, err := idx.List(ctx, ns, retrieval.ListRequest{PageSize: 1, WithVector: false})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(resp.Items) != 1 {
+		t.Fatalf("items=%+v", resp.Items)
+	}
+	if resp.Items[0].Vector != nil || resp.Items[0].SparseVector != nil {
+		t.Fatalf("WithVector=false leaked vector payloads: %+v", resp.Items[0])
+	}
+}
+
 func testDeleteByFilterValidation(t *testing.T, f Factory) {
 	idx, cleanup := f(t)
 	defer cleanup()
@@ -366,4 +484,13 @@ func idsOf(hits []retrieval.Hit) []string {
 		out = append(out, h.Doc.ID)
 	}
 	return out
+}
+
+func containsID(ids []string, want string) bool {
+	for _, id := range ids {
+		if id == want {
+			return true
+		}
+	}
+	return false
 }

--- a/memory/retrieval/journal/wrap.go
+++ b/memory/retrieval/journal/wrap.go
@@ -264,22 +264,30 @@ func (w *journaledIndex) supportsFilter(f retrieval.Filter) bool {
 }
 
 func (w *journaledIndex) deleteByFilter(ctx context.Context, namespace string, f retrieval.Filter) (int64, error) {
-	d, ok := w.inner.(retrieval.DeletableByFilter)
-	if !ok {
+	if _, ok := w.inner.(retrieval.DeletableByFilter); !ok {
 		return 0, nil
+	}
+	if isEmptyFilter(f) {
+		return 0, retrieval.ErrEmptyDeleteFilter
 	}
 	docs, err := w.snapshotForFilter(ctx, namespace, f)
 	if err != nil {
 		return 0, err
 	}
-	n, err := d.DeleteByFilter(ctx, namespace, f)
-	if err != nil {
-		return n, err
+	if len(docs) == 0 {
+		return 0, nil
+	}
+	ids := make([]string, 0, len(docs))
+	for _, d := range docs {
+		ids = append(ids, d.ID)
+	}
+	if err := w.inner.Delete(ctx, namespace, ids); err != nil {
+		return 0, err
 	}
 	if err := w.recordDocEvents(ctx, namespace, docs); err != nil {
-		return n, err
+		return int64(len(docs)), err
 	}
-	return n, nil
+	return int64(len(docs)), nil
 }
 
 func (w *journaledIndex) drop(ctx context.Context, namespace string) error {
@@ -468,3 +476,10 @@ var (
 	_ retrieval.Countable         = (*wrappedAuditableCount)(nil)
 	_ retrieval.Countable         = (*wrappedReadableCount)(nil)
 )
+
+func isEmptyFilter(f retrieval.Filter) bool {
+	return len(f.And) == 0 && len(f.Or) == 0 && f.Not == nil &&
+		len(f.Eq) == 0 && len(f.Neq) == 0 && len(f.In) == 0 && len(f.NotIn) == 0 &&
+		len(f.Range) == 0 && len(f.Exists) == 0 && len(f.Missing) == 0 && len(f.Match) == 0 &&
+		len(f.Contains) == 0 && len(f.IContains) == 0 && len(f.ContainsAny) == 0 && len(f.ContainsAll) == 0
+}

--- a/memory/retrieval/journal/wrap_test.go
+++ b/memory/retrieval/journal/wrap_test.go
@@ -2,6 +2,7 @@ package journal
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"time"
 
@@ -73,6 +74,75 @@ func TestWrapDeleteByFilterRecordsAuditEvents(t *testing.T) {
 	}
 }
 
+func TestWrapDeleteByFilterDeletesSnapshottedIDs(t *testing.T) {
+	ctx := context.Background()
+	ns := "ns-racy-delete"
+	inner := &mutatingFilterIndex{docs: map[string]retrieval.Doc{
+		"x1": {ID: "x1", Content: "foo", Metadata: map[string]any{"keep": false}, Timestamp: time.Now()},
+	}}
+	j := NewMemoryJournal()
+	idx := Wrap(inner, j).(retrieval.DeletableByFilter)
+
+	n, err := idx.DeleteByFilter(ctx, ns, retrieval.Filter{Eq: map[string]any{"keep": false}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if n != 1 {
+		t.Fatalf("deleted=%d want 1", n)
+	}
+	if inner.deleteByFilterCalled {
+		t.Fatal("wrapper should delete snapshotted IDs directly, not re-run DeleteByFilter")
+	}
+	if len(inner.deleted) != 1 || inner.deleted[0] != "x1" {
+		t.Fatalf("deleted IDs = %v, want [x1]", inner.deleted)
+	}
+	if _, ok := inner.docs["x2"]; !ok {
+		t.Fatal("x2 was added after snapshot and should not be deleted")
+	}
+	h, err := j.History(ctx, ns, "x1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(h) != 1 || h[0].Op != OpDelete || h[0].Before == nil || h[0].Before.ID != "x1" {
+		t.Fatalf("history for x1 = %+v", h)
+	}
+	if h2, _ := j.History(ctx, ns, "x2"); len(h2) != 0 {
+		t.Fatalf("x2 should not have journal events, got %+v", h2)
+	}
+}
+
+func TestWrapDeleteByFilterRejectsEmptyFilter(t *testing.T) {
+	ctx := context.Background()
+	inner := memory.New()
+	j := NewMemoryJournal()
+	idx := Wrap(inner, j)
+	ns := "ns-empty-delete"
+	if err := idx.Upsert(ctx, ns, []retrieval.Doc{{ID: "x", Content: "foo", Timestamp: time.Now()}}); err != nil {
+		t.Fatal(err)
+	}
+
+	df := idx.(retrieval.DeletableByFilter)
+	n, err := df.DeleteByFilter(ctx, ns, retrieval.Filter{})
+	if !errors.Is(err, retrieval.ErrEmptyDeleteFilter) {
+		t.Fatalf("err=%v, want ErrEmptyDeleteFilter", err)
+	}
+	if n != 0 {
+		t.Fatalf("deleted=%d want 0", n)
+	}
+	if _, found, err := idx.(retrieval.DocGetter).Get(ctx, ns, "x"); err != nil || !found {
+		t.Fatalf("doc should survive empty DeleteByFilter: found=%v err=%v", found, err)
+	}
+	h, err := j.History(ctx, ns, "x")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, ev := range h {
+		if ev.Op == OpDelete {
+			t.Fatalf("empty DeleteByFilter should not record delete event: %+v", h)
+		}
+	}
+}
+
 func TestWrapDropRecordsAuditEvents(t *testing.T) {
 	ctx := context.Background()
 	inner := memory.New()
@@ -101,6 +171,88 @@ func TestWrapDropRecordsAuditEvents(t *testing.T) {
 			t.Fatalf("expected delete event for %s after Drop, got %+v", id, h)
 		}
 	}
+}
+
+type mutatingFilterIndex struct {
+	docs                 map[string]retrieval.Doc
+	deleted              []string
+	iterated             bool
+	deleteByFilterCalled bool
+}
+
+func (m *mutatingFilterIndex) Upsert(_ context.Context, _ string, docs []retrieval.Doc) error {
+	if m.docs == nil {
+		m.docs = make(map[string]retrieval.Doc)
+	}
+	for _, d := range docs {
+		m.docs[d.ID] = d
+	}
+	return nil
+}
+
+func (m *mutatingFilterIndex) Delete(_ context.Context, _ string, ids []string) error {
+	for _, id := range ids {
+		m.deleted = append(m.deleted, id)
+		delete(m.docs, id)
+	}
+	return nil
+}
+
+func (m *mutatingFilterIndex) Search(context.Context, string, retrieval.SearchRequest) (*retrieval.SearchResponse, error) {
+	return &retrieval.SearchResponse{}, nil
+}
+
+func (m *mutatingFilterIndex) List(_ context.Context, _ string, req retrieval.ListRequest) (*retrieval.ListResponse, error) {
+	var out []retrieval.Doc
+	for _, d := range m.docs {
+		if retrieval.DocMatchesFilter(d, req.Filter) {
+			out = append(out, d)
+		}
+	}
+	return &retrieval.ListResponse{Items: out, Total: int64(len(out))}, nil
+}
+
+func (m *mutatingFilterIndex) Capabilities() retrieval.Capabilities {
+	return retrieval.DefaultMemoryCapabilities()
+}
+
+func (m *mutatingFilterIndex) Close() error { return nil }
+
+func (m *mutatingFilterIndex) Get(_ context.Context, _, id string) (retrieval.Doc, bool, error) {
+	d, ok := m.docs[id]
+	return d, ok, nil
+}
+
+func (m *mutatingFilterIndex) SupportsFilter(retrieval.Filter) bool { return true }
+
+func (m *mutatingFilterIndex) DeleteByFilter(_ context.Context, _ string, f retrieval.Filter) (int64, error) {
+	m.deleteByFilterCalled = true
+	var ids []string
+	for id, d := range m.docs {
+		if retrieval.DocMatchesFilter(d, f) {
+			ids = append(ids, id)
+		}
+	}
+	_ = m.Delete(context.Background(), "", ids)
+	return int64(len(ids)), nil
+}
+
+func (m *mutatingFilterIndex) Iterate(_ context.Context, _ string, cursor string, _ int) ([]retrieval.Doc, string, error) {
+	if cursor != "" {
+		return nil, "", nil
+	}
+	var out []retrieval.Doc
+	for _, d := range m.docs {
+		out = append(out, d)
+	}
+	if !m.iterated {
+		m.iterated = true
+		d := m.docs["x1"]
+		d.Metadata = map[string]any{"keep": true}
+		m.docs["x1"] = d
+		m.docs["x2"] = retrieval.Doc{ID: "x2", Content: "bar", Metadata: map[string]any{"keep": false}, Timestamp: time.Now()}
+	}
+	return out, "", nil
 }
 
 func TestWrapJournalUpsertBefore(t *testing.T) {

--- a/memory/retrieval/memory/index.go
+++ b/memory/retrieval/memory/index.go
@@ -210,55 +210,45 @@ func (m *Index) Search(_ context.Context, namespace string, req retrieval.Search
 	m.mu.RUnlock()
 
 	if hasText && hasVec {
-		bmOrder := append([]scored(nil), out...)
-		sort.SliceStable(bmOrder, func(i, j int) bool {
-			if bmOrder[i].bm25 == bmOrder[j].bm25 {
-				if bmOrder[i].cos == bmOrder[j].cos {
-					return bmOrder[i].d.ID < bmOrder[j].d.ID
+		buildLane := func(score func(scored) float64) []retrieval.Hit {
+			hits := make([]retrieval.Hit, 0, len(out))
+			for _, s := range out {
+				v := score(s)
+				if v <= 0 {
+					continue
 				}
-				return bmOrder[i].cos > bmOrder[j].cos
+				hits = append(hits, retrieval.Hit{Doc: cloneDoc(s.d), Score: v})
 			}
-			return bmOrder[i].bm25 > bmOrder[j].bm25
-		})
-		bmRank := make(map[string]int, len(bmOrder))
-		for i, s := range bmOrder {
-			bmRank[s.d.ID] = i + 1
-		}
-		vecOrder := append([]scored(nil), out...)
-		sort.SliceStable(vecOrder, func(i, j int) bool {
-			if vecOrder[i].cos == vecOrder[j].cos {
-				if vecOrder[i].bm25 == vecOrder[j].bm25 {
-					return vecOrder[i].d.ID < vecOrder[j].d.ID
+			sort.SliceStable(hits, func(i, j int) bool {
+				if hits[i].Score == hits[j].Score {
+					return hits[i].Doc.ID < hits[j].Doc.ID
 				}
-				return vecOrder[i].bm25 > vecOrder[j].bm25
-			}
-			return vecOrder[i].cos > vecOrder[j].cos
-		})
-		vecRank := make(map[string]int, len(vecOrder))
-		for i, s := range vecOrder {
-			vecRank[s.d.ID] = i + 1
-		}
-		const k = 60.0
-		var hits []retrieval.Hit
-		for _, s := range out {
-			rrf := 1.0/(k+float64(bmRank[s.d.ID])) + 1.0/(k+float64(vecRank[s.d.ID]))
-			// SearchRequest.MinScore is intentionally NOT consulted on the
-			// hybrid path: RRF scores live on a different scale (~1/k) than
-			// raw BM25/cosine, and applying the same threshold here would
-			// silently change meaning depending on which modes were
-			// supplied. Use pipeline.ScoreThreshold for hybrid filtering.
-			hits = append(hits, retrieval.Hit{
-				Doc:    cloneDoc(s.d),
-				Score:  rrf,
-				Scores: map[string]float64{"bm25": s.bm25, "cos": s.cos, "rrf": rrf},
+				return hits[i].Score > hits[j].Score
 			})
+			return hits
 		}
-		sort.SliceStable(hits, func(i, j int) bool {
-			if hits[i].Score == hits[j].Score {
-				return hits[i].Doc.ID < hits[j].Doc.ID
+		bmHits := buildLane(func(s scored) float64 { return s.bm25 })
+		vecHits := buildLane(func(s scored) float64 { return s.cos })
+		hits := scoring.RRF([][]retrieval.Hit{bmHits, vecHits}, scoring.DefaultRRFK)
+		bmByID := make(map[string]float64, len(out))
+		cosByID := make(map[string]float64, len(out))
+		for _, s := range out {
+			bmByID[s.d.ID] = s.bm25
+			cosByID[s.d.ID] = s.cos
+		}
+		for i := range hits {
+			rrf := hits[i].Score
+			hits[i].Scores = map[string]float64{
+				"bm25": bmByID[hits[i].Doc.ID],
+				"cos":  cosByID[hits[i].Doc.ID],
+				"rrf":  rrf,
 			}
-			return hits[i].Score > hits[j].Score
-		})
+		}
+		// SearchRequest.MinScore is intentionally NOT consulted on the
+		// hybrid path: RRF scores live on a different scale (~1/k) than
+		// raw BM25/cosine, and applying the same threshold here would
+		// silently change meaning depending on which modes were supplied.
+		// Use pipeline.ScoreThreshold for hybrid filtering.
 		if len(hits) > req.TopK {
 			hits = hits[:req.TopK]
 		}

--- a/memory/retrieval/pipeline/stages_boost.go
+++ b/memory/retrieval/pipeline/stages_boost.go
@@ -6,6 +6,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/GizClaw/flowcraft/memory/text/bm25"
 	"github.com/GizClaw/flowcraft/memory/text/tokenize"
 )
 
@@ -41,61 +42,21 @@ func (s BM25Boost) Run(_ context.Context, st *State) error {
 		w = 0.3
 	}
 	tok := tokenize.Detect(st.Request.QueryText)
-	qTerms := tok.Tokenize(st.Request.QueryText)
+	qTerms := bm25.ExtractKeywords(st.Request.QueryText, tok)
 	if len(qTerms) == 0 {
 		return nil
 	}
 	docTokens := make([][]string, len(hits))
-	totalLen := 0
+	corpus := bm25.NewCorpus()
 	for i, h := range hits {
 		docTokens[i] = tok.Tokenize(h.Doc.Content)
-		totalLen += len(docTokens[i])
+		corpus.AddDocument(docTokens[i])
 	}
-	avgLen := 0.0
-	if len(hits) > 0 {
-		avgLen = float64(totalLen) / float64(len(hits))
-	}
-	const k1, b = 1.5, 0.75
-	df := map[string]int{}
-	for _, terms := range docTokens {
-		seen := map[string]struct{}{}
-		for _, t := range terms {
-			seen[t] = struct{}{}
-		}
-		for t := range seen {
-			df[t]++
-		}
-	}
-	N := float64(len(hits))
 	scoresBM25 := make([]float64, len(hits))
 	maxBM25 := math.Inf(-1)
 	minBM25 := math.Inf(+1)
 	for i, terms := range docTokens {
-		tf := map[string]int{}
-		for _, t := range terms {
-			tf[t]++
-		}
-		dl := float64(len(terms))
-		denomNorm := 1.0
-		if avgLen > 0 {
-			denomNorm = 1 - b + b*dl/avgLen
-		}
-		var s float64
-		for _, q := range qTerms {
-			n := float64(df[q])
-			if n == 0 {
-				continue
-			}
-			idf := safeLog((N - n + 0.5) / (n + 0.5))
-			if idf < 0 {
-				idf = 0
-			}
-			f := float64(tf[q])
-			if f == 0 {
-				continue
-			}
-			s += idf * (f * (k1 + 1)) / (f + k1*denomNorm)
-		}
+		s := bm25.Score(terms, qTerms, corpus, bm25.WithK1(1.5))
 		scoresBM25[i] = s
 		if s > maxBM25 {
 			maxBM25 = s
@@ -205,11 +166,4 @@ func (s SupersededDecay) Run(_ context.Context, st *State) error {
 	sort.SliceStable(hits, func(i, j int) bool { return hits[i].Score > hits[j].Score })
 	st.Final = hits
 	return nil
-}
-
-func safeLog(x float64) float64 {
-	if x <= 0 {
-		return 0
-	}
-	return math.Log(x)
 }

--- a/memory/retrieval/pipeline/stages_boost_test.go
+++ b/memory/retrieval/pipeline/stages_boost_test.go
@@ -6,6 +6,8 @@ import (
 	"testing"
 
 	"github.com/GizClaw/flowcraft/memory/retrieval"
+	"github.com/GizClaw/flowcraft/memory/text/bm25"
+	"github.com/GizClaw/flowcraft/memory/text/tokenize"
 )
 
 func TestBM25Boost_AllEqualScoresIsStable(t *testing.T) {
@@ -46,5 +48,53 @@ func TestBM25Boost_NoQueryTermPresentIsNoOp(t *testing.T) {
 	}
 	if st.Final[0].Score != in[0].Score || st.Final[1].Score != in[1].Score {
 		t.Fatalf("unexpected score change: %+v -> %+v", in, st.Final)
+	}
+}
+
+func TestBM25Boost_UsesCanonicalBM25ForCommonTerms(t *testing.T) {
+	hits := []retrieval.Hit{
+		{Doc: retrieval.Doc{ID: "short", Content: "coffee"}, Score: 0},
+		{Doc: retrieval.Doc{ID: "repeat", Content: "coffee coffee"}, Score: 0},
+		{Doc: retrieval.Doc{ID: "long", Content: "coffee with lots of unrelated filler words"}, Score: 0},
+	}
+	st := &State{
+		Request: &retrieval.SearchRequest{QueryText: "coffee"},
+		Final:   append([]retrieval.Hit(nil), hits...),
+	}
+	if err := (BM25Boost{Weight: 1}).Run(context.Background(), st); err != nil {
+		t.Fatal(err)
+	}
+
+	tok := tokenize.Detect("coffee")
+	keywords := bm25.ExtractKeywords("coffee", tok)
+	corpus := bm25.NewCorpus()
+	docTokens := make(map[string][]string, len(hits))
+	for _, h := range hits {
+		tokens := tok.Tokenize(h.Doc.Content)
+		docTokens[h.Doc.ID] = tokens
+		corpus.AddDocument(tokens)
+	}
+	raw := make(map[string]float64, len(hits))
+	minScore, maxScore := math.Inf(1), math.Inf(-1)
+	for _, h := range hits {
+		s := bm25.Score(docTokens[h.Doc.ID], keywords, corpus, bm25.WithK1(1.5))
+		raw[h.Doc.ID] = s
+		if s < minScore {
+			minScore = s
+		}
+		if s > maxScore {
+			maxScore = s
+		}
+	}
+	if maxScore <= 0 || maxScore == minScore {
+		t.Fatalf("fixture must produce positive differentiated BM25 scores: min=%v max=%v raw=%+v", minScore, maxScore, raw)
+	}
+
+	for _, h := range st.Final {
+		want := (raw[h.Doc.ID] - minScore) / (maxScore - minScore)
+		got := h.Scores["bm25_boost"]
+		if math.Abs(got-want) > 1e-12 {
+			t.Fatalf("%s bm25_boost=%v want %v (raw=%+v)", h.Doc.ID, got, want, raw)
+		}
 	}
 }

--- a/memory/retrieval/postgres/index.go
+++ b/memory/retrieval/postgres/index.go
@@ -46,7 +46,7 @@ func (s *Index) Capabilities() retrieval.Capabilities {
 	return retrieval.Capabilities{
 		BM25:   true,
 		Vector: false,
-		Sparse: false,
+		Sparse: true,
 		Hybrid: false,
 
 		FilterPushdown: false,
@@ -244,6 +244,9 @@ func (s *Index) Search(ctx context.Context, ns string, req retrieval.SearchReque
 	if !hasText && !hasVec && !hasSparse {
 		return nil, retrieval.ErrNoQuery
 	}
+	if hasVec && !hasText {
+		return nil, errdefs.NotAvailablef("postgres: vector-only search is not supported")
+	}
 	topK := req.TopK
 	if topK <= 0 {
 		topK = 10
@@ -251,9 +254,10 @@ func (s *Index) Search(ctx context.Context, ns string, req retrieval.SearchReque
 	start := time.Now()
 
 	type cand struct {
-		d    retrieval.Doc
-		bm25 float64
-		cos  float64
+		d      retrieval.Doc
+		bm25   float64
+		cos    float64
+		sparse float64
 	}
 	var rows []cand
 	if hasText {
@@ -266,11 +270,7 @@ func (s *Index) Search(ctx context.Context, ns string, req retrieval.SearchReque
 		if pageSize < 100 {
 			pageSize = 100
 		}
-		maxScan := topK * 256
-		if maxScan < 1000 {
-			maxScan = 1000
-		}
-		for offset := 0; offset < maxScan; offset += pageSize {
+		for offset := 0; ; offset += pageSize {
 			rs, err := s.pool.Query(ctx, query, q, pageSize, offset)
 			if err != nil {
 				return nil, err
@@ -311,7 +311,7 @@ func (s *Index) Search(ctx context.Context, ns string, req retrieval.SearchReque
 			}
 		}
 	} else {
-		all, err := s.scanAll(ctx, ns, req.Filter, 4*topK)
+		all, err := s.scanAll(ctx, ns, req.Filter, 0)
 		if err != nil {
 			return nil, err
 		}
@@ -326,12 +326,20 @@ func (s *Index) Search(ctx context.Context, ns string, req retrieval.SearchReque
 			}
 		}
 	}
+	if hasSparse {
+		for i := range rows {
+			rows[i].sparse = sparseDot(rows[i].d.SparseVector, req.SparseVec)
+		}
+	}
 	sort.SliceStable(rows, func(i, j int) bool {
 		if hasText && hasVec {
 			return rows[i].bm25+rows[i].cos > rows[j].bm25+rows[j].cos
 		}
 		if hasVec {
 			return rows[i].cos > rows[j].cos
+		}
+		if hasSparse && !hasText {
+			return rows[i].sparse > rows[j].sparse
 		}
 		return rows[i].bm25 > rows[j].bm25
 	})
@@ -342,11 +350,13 @@ func (s *Index) Search(ctx context.Context, ns string, req retrieval.SearchReque
 			score = c.bm25 + c.cos
 		} else if hasVec && !hasText {
 			score = c.cos
+		} else if hasSparse && !hasText {
+			score = c.sparse
 		}
-		if score < req.MinScore {
+		if !(hasText && hasVec) && score < req.MinScore {
 			continue
 		}
-		out = append(out, retrieval.Hit{Doc: c.d, Score: score, Scores: map[string]float64{"bm25": c.bm25, "cos": c.cos}})
+		out = append(out, retrieval.Hit{Doc: c.d, Score: score, Scores: map[string]float64{"bm25": c.bm25, "cos": c.cos, "sparse": c.sparse}})
 		if len(out) >= topK {
 			break
 		}
@@ -355,10 +365,13 @@ func (s *Index) Search(ctx context.Context, ns string, req retrieval.SearchReque
 }
 
 func (s *Index) scanAll(ctx context.Context, ns string, f retrieval.Filter, limit int) ([]retrieval.Doc, error) {
-	if limit <= 0 {
-		limit = 1000
+	query := fmt.Sprintf(`SELECT id,content,metadata::text,vector,sparse::text,ts FROM %q ORDER BY ts DESC`, tableName(ns))
+	args := []any{}
+	if limit > 0 {
+		query += " LIMIT $1"
+		args = append(args, limit)
 	}
-	rs, err := s.pool.Query(ctx, fmt.Sprintf(`SELECT id,content,metadata::text,vector,sparse::text,ts FROM %q ORDER BY ts DESC LIMIT $1`, tableName(ns)), limit)
+	rs, err := s.pool.Query(ctx, query, args...)
 	if err != nil {
 		return nil, err
 	}
@@ -861,6 +874,19 @@ func cosineSim(a, b []float32) float64 {
 		return 0
 	}
 	return dot / (math.Sqrt(na) * math.Sqrt(nb))
+}
+
+func sparseDot(doc, q map[string]float32) float64 {
+	if len(doc) == 0 || len(q) == 0 {
+		return 0
+	}
+	var out float64
+	for k, qv := range q {
+		if dv, ok := doc[k]; ok {
+			out += float64(dv * qv)
+		}
+	}
+	return out
 }
 
 func isEmptyFilter(f retrieval.Filter) bool {

--- a/memory/retrieval/postgres/index_test.go
+++ b/memory/retrieval/postgres/index_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/GizClaw/flowcraft/memory/retrieval"
 	"github.com/GizClaw/flowcraft/memory/retrieval/contract"
+	"github.com/GizClaw/flowcraft/sdk/errdefs"
 
 	pgx "github.com/GizClaw/flowcraft/memory/retrieval/postgres"
 )
@@ -29,7 +30,11 @@ func TestContract(t *testing.T) {
 		}
 		return idx, func() {
 			ctx := context.Background()
-			for _, ns := range []string{"ns_a", "ns_idem", "ns_raw", "ns_x", "ns_y", "ns_list", "ns_filt", "ns_rng"} {
+			for _, ns := range []string{
+				"ns_a", "ns_idem", "ns_raw", "ns_x", "ns_y", "ns_list", "ns_list_stale",
+				"ns_filt", "ns_rng", "ns_not", "ns_hybrid_minscore", "ns_hybrid_zero",
+				"ns_sparse", "ns_projection_vectors", "ns_debug",
+			} {
 				_ = idx.Drop(ctx, ns)
 			}
 		}
@@ -50,8 +55,8 @@ func TestSearchSelectiveFilterBeyondInitialWindow(t *testing.T) {
 	const ns = "ns_selective_pg"
 	_ = idx.Drop(ctx, ns)
 	t.Cleanup(func() { _ = idx.Drop(context.Background(), ns) })
-	docs := make([]retrieval.Doc, 0, 80)
-	for i := 0; i < 79; i++ {
+	docs := make([]retrieval.Doc, 0, 1001)
+	for i := 0; i < 1000; i++ {
 		docs = append(docs, retrieval.Doc{
 			ID:       "common-" + strconv.Itoa(i),
 			Content:  "alpha alpha alpha common",
@@ -76,5 +81,33 @@ func TestSearchSelectiveFilterBeyondInitialWindow(t *testing.T) {
 	}
 	if len(resp.Hits) != 1 || resp.Hits[0].Doc.ID != "rare" {
 		t.Fatalf("hits = %+v, want rare", resp.Hits)
+	}
+}
+
+func TestSearchVectorOnlyNotAvailable(t *testing.T) {
+	dsn := os.Getenv("FC_PG_DSN")
+	if dsn == "" {
+		t.Skip("FC_PG_DSN not set; skipping postgres integration test")
+	}
+	ctx := context.Background()
+	idx, err := pgx.Open(ctx, dsn)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer idx.Close()
+	const ns = "ns_vector_disabled_pg"
+	_ = idx.Drop(ctx, ns)
+	t.Cleanup(func() { _ = idx.Drop(context.Background(), ns) })
+	if err := idx.Upsert(ctx, ns, []retrieval.Doc{
+		{ID: "a", Content: "alpha", Vector: []float32{1, 0}},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	_, err = idx.Search(ctx, ns, retrieval.SearchRequest{
+		QueryVector: []float32{1, 0},
+		TopK:        1,
+	})
+	if !errdefs.IsNotAvailable(err) {
+		t.Fatalf("vector-only search err=%v, want NotAvailable", err)
 	}
 }

--- a/memory/retrieval/sqlite/index.go
+++ b/memory/retrieval/sqlite/index.go
@@ -62,7 +62,7 @@ func (s *Index) Capabilities() retrieval.Capabilities {
 	return retrieval.Capabilities{
 		BM25:   true,
 		Vector: false,
-		Sparse: false,
+		Sparse: true,
 		Hybrid: false,
 
 		FilterPushdown: false,
@@ -301,6 +301,9 @@ func (s *Index) Search(ctx context.Context, ns string, req retrieval.SearchReque
 	if !hasText && !hasVec && !hasSparse {
 		return nil, retrieval.ErrNoQuery
 	}
+	if hasVec && !hasText {
+		return nil, errdefs.NotAvailablef("sqlite: vector-only search is not supported")
+	}
 	topK := req.TopK
 	if topK <= 0 {
 		topK = 10
@@ -308,9 +311,10 @@ func (s *Index) Search(ctx context.Context, ns string, req retrieval.SearchReque
 	start := time.Now()
 
 	type cand struct {
-		d    retrieval.Doc
-		bm25 float64
-		cos  float64
+		d      retrieval.Doc
+		bm25   float64
+		cos    float64
+		sparse float64
 	}
 	var rows []cand
 
@@ -326,11 +330,7 @@ func (s *Index) Search(ctx context.Context, ns string, req retrieval.SearchReque
 		if pageSize < 100 {
 			pageSize = 100
 		}
-		maxScan := topK * 256
-		if maxScan < 1000 {
-			maxScan = 1000
-		}
-		for offset := 0; offset < maxScan; offset += pageSize {
+		for offset := 0; ; offset += pageSize {
 			r, err := s.db.QueryContext(ctx, query, q, pageSize, offset)
 			if err != nil {
 				return nil, err
@@ -373,7 +373,7 @@ func (s *Index) Search(ctx context.Context, ns string, req retrieval.SearchReque
 			}
 		}
 	} else {
-		all, err := s.scanAll(ctx, ns, req.Filter, 4*topK)
+		all, err := s.scanAll(ctx, ns, req.Filter, 0)
 		if err != nil {
 			return nil, err
 		}
@@ -389,6 +389,11 @@ func (s *Index) Search(ctx context.Context, ns string, req retrieval.SearchReque
 			}
 		}
 	}
+	if hasSparse {
+		for i := range rows {
+			rows[i].sparse = sparseDot(rows[i].d.SparseVector, req.SparseVec)
+		}
+	}
 
 	sort.SliceStable(rows, func(i, j int) bool {
 		if hasText && hasVec {
@@ -398,6 +403,9 @@ func (s *Index) Search(ctx context.Context, ns string, req retrieval.SearchReque
 		}
 		if hasVec {
 			return rows[i].cos > rows[j].cos
+		}
+		if hasSparse && !hasText {
+			return rows[i].sparse > rows[j].sparse
 		}
 		return rows[i].bm25 > rows[j].bm25
 	})
@@ -409,14 +417,16 @@ func (s *Index) Search(ctx context.Context, ns string, req retrieval.SearchReque
 			score = c.bm25 + c.cos
 		} else if hasVec && !hasText {
 			score = c.cos
+		} else if hasSparse && !hasText {
+			score = c.sparse
 		}
-		if score < req.MinScore {
+		if !(hasText && hasVec) && score < req.MinScore {
 			continue
 		}
 		out = append(out, retrieval.Hit{
 			Doc:    c.d,
 			Score:  score,
-			Scores: map[string]float64{"bm25": c.bm25, "cos": c.cos},
+			Scores: map[string]float64{"bm25": c.bm25, "cos": c.cos, "sparse": c.sparse},
 		})
 		if len(out) >= topK {
 			break
@@ -426,11 +436,16 @@ func (s *Index) Search(ctx context.Context, ns string, req retrieval.SearchReque
 }
 
 func (s *Index) scanAll(ctx context.Context, ns string, f retrieval.Filter, limit int) ([]retrieval.Doc, error) {
-	if limit <= 0 {
-		limit = 1000
+	query := fmt.Sprintf(`SELECT id,content,metadata,vector,sparse,ts FROM "docs_%s" ORDER BY ts DESC`, ns)
+	var (
+		rows *sql.Rows
+		err  error
+	)
+	if limit > 0 {
+		rows, err = s.db.QueryContext(ctx, query+` LIMIT ?`, limit)
+	} else {
+		rows, err = s.db.QueryContext(ctx, query)
 	}
-	rows, err := s.db.QueryContext(ctx,
-		fmt.Sprintf(`SELECT id,content,metadata,vector,sparse,ts FROM "docs_%s" ORDER BY ts DESC LIMIT ?`, ns), limit)
 	if err != nil {
 		return nil, err
 	}
@@ -981,6 +996,19 @@ func cosineSim(a, b []float32) float64 {
 		return 0
 	}
 	return dot / (math.Sqrt(na) * math.Sqrt(nb))
+}
+
+func sparseDot(doc, q map[string]float32) float64 {
+	if len(doc) == 0 || len(q) == 0 {
+		return 0
+	}
+	var out float64
+	for k, qv := range q {
+		if dv, ok := doc[k]; ok {
+			out += float64(dv * qv)
+		}
+	}
+	return out
 }
 
 func isEmptyFilter(f retrieval.Filter) bool {

--- a/memory/retrieval/sqlite/index_test.go
+++ b/memory/retrieval/sqlite/index_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/GizClaw/flowcraft/memory/retrieval"
 	"github.com/GizClaw/flowcraft/memory/retrieval/contract"
+	"github.com/GizClaw/flowcraft/sdk/errdefs"
 
 	sqlx "github.com/GizClaw/flowcraft/memory/retrieval/sqlite"
 )
@@ -29,8 +30,8 @@ func TestSearchSelectiveFilterBeyondInitialWindow(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer idx.Close()
-	docs := make([]retrieval.Doc, 0, 80)
-	for i := 0; i < 79; i++ {
+	docs := make([]retrieval.Doc, 0, 1001)
+	for i := 0; i < 1000; i++ {
 		docs = append(docs, retrieval.Doc{
 			ID:       "common-" + strconv.Itoa(i),
 			Content:  "alpha alpha alpha common",
@@ -74,17 +75,38 @@ func TestSearchHybridUsesConsistentScore(t *testing.T) {
 		QueryText:   "alpha",
 		QueryVector: []float32{1, 0},
 		TopK:        1,
-		MinScore:    0.9,
+		MinScore:    1e9,
 	})
 	if err != nil {
 		t.Fatal(err)
 	}
 	if len(resp.Hits) != 1 {
-		t.Fatalf("hybrid final score should satisfy MinScore, hits=%+v", resp.Hits)
+		t.Fatalf("hybrid search should ignore SearchRequest.MinScore, hits=%+v", resp.Hits)
 	}
 	got := resp.Hits[0]
 	if got.Score != got.Scores["bm25"]+got.Scores["cos"] {
 		t.Fatalf("Hit.Score=%v, bm25+cos=%v", got.Score, got.Scores["bm25"]+got.Scores["cos"])
+	}
+}
+
+func TestSearchVectorOnlyNotAvailable(t *testing.T) {
+	dir := t.TempDir()
+	idx, err := sqlx.Open(filepath.Join(dir, "fc.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer idx.Close()
+	if err := idx.Upsert(t.Context(), "ns_vector_disabled", []retrieval.Doc{
+		{ID: "a", Content: "alpha", Vector: []float32{1, 0}},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	_, err = idx.Search(t.Context(), "ns_vector_disabled", retrieval.SearchRequest{
+		QueryVector: []float32{1, 0},
+		TopK:        1,
+	})
+	if !errdefs.IsNotAvailable(err) {
+		t.Fatalf("vector-only search err=%v, want NotAvailable", err)
 	}
 }
 

--- a/memory/retrieval/workspace/doc.go
+++ b/memory/retrieval/workspace/doc.go
@@ -44,8 +44,6 @@
 //	segments/<id>/meta.json         doc count, vector dim, build time, checksums
 //	segments/<id>/docs.jsonl        one Doc per line, immutable
 //	segments/<id>/docs.offsets.bin  uint64 line→byte offsets (point lookup)
-//	segments/<id>/bm25.bin          serialized term→postings + per-doc length
-//	segments/<id>/vector.bin        flat float32 + id index
 //	segments/<id>/tombstones.bin    doc IDs deleted during this segment's life
 //
 // Write path: every Upsert / Delete is appended to the current WAL
@@ -63,10 +61,12 @@
 // without a fsck-style rebuild.
 //
 // Read path: a query consults the memtable plus every live segment
-// listed in the manifest. Per-segment BM25 and vector lanes produce
-// independent ranked lists; results are merged with tombstones
-// filtered out and the final ranking is performed by
-// [scoring.RRF] (the default fusion shipped with sdk/retrieval).
+// listed in the manifest. Segment docs are loaded from docs.jsonl;
+// BM25 token streams are derived from content on first use and cached
+// in the segment reader. Search builds one global corpus across all
+// live docs for each request so IDF does not depend on which segment a
+// doc landed in. Hybrid text+vector queries are fused with
+// [scoring.RRF].
 //
 // Compaction: a background goroutine selects size-tiered groups of
 // small segments, reads them, drops tombstoned IDs, and writes a
@@ -77,11 +77,11 @@
 // # Crash recovery
 //
 // On New() / re-open the index reads the manifest (if any), loads
-// every live segment's metadata into memory (postings and vectors
-// stay on disk and are paged in at search time), then replays each
-// outstanding wal/<seq>.log into the memtable. After a successful
-// replay the index is open for reads and writes; the next flush
-// will atomically retire those WAL files.
+// every live segment's metadata into memory, then replays each
+// outstanding wal/<seq>.log into the memtable. Docs and derived BM25
+// tokens are loaded lazily by segment readers. After a successful
+// replay the index is open for reads and writes; the next flush will
+// atomically retire those WAL files.
 //
 // # Concurrency
 //

--- a/memory/retrieval/workspace/memtable.go
+++ b/memory/retrieval/workspace/memtable.go
@@ -55,7 +55,7 @@ func newMemtable() *memtable {
 func (m *memtable) upsert(d retrieval.Doc, sizeHint int) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	clone := d
+	clone := cloneDoc(d)
 	item := memtableItem{op: walOpUpsert, id: d.ID, doc: &clone}
 	if i, ok := m.index[d.ID]; ok {
 		// Overwriting an existing entry; bytes ≈ replace, not add.
@@ -127,16 +127,34 @@ func (m *memtable) approxByteCount() int {
 func (m *memtable) snapshot() *memtableSnapshot {
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	snap := &memtableSnapshot{items: m.items}
+	snap := &memtableSnapshot{items: m.items, approxBytes: m.approxBytes}
 	m.items = nil
 	m.index = make(map[string]int)
 	m.approxBytes = 0
 	return snap
 }
 
+// restoreSnapshot puts a failed flush snapshot back into the live
+// memtable. Caller holds the namespace write lock, so no newer writes
+// can have been staged since snapshot() emptied the memtable.
+func (m *memtable) restoreSnapshot(snap *memtableSnapshot) {
+	if snap == nil || snap.empty() {
+		return
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.items = append([]memtableItem(nil), snap.items...)
+	m.index = make(map[string]int, len(m.items))
+	m.approxBytes = snap.approxBytes
+	for i, it := range m.items {
+		m.index[it.id] = i
+	}
+}
+
 // memtableSnapshot is the sealed view returned by [memtable.snapshot].
 type memtableSnapshot struct {
-	items []memtableItem
+	items       []memtableItem
+	approxBytes int
 }
 
 // upserts iterates docs that should be persisted to the new segment

--- a/memory/retrieval/workspace/namespace.go
+++ b/memory/retrieval/workspace/namespace.go
@@ -135,6 +135,7 @@ func (idx *Index) flushLocked(ctx context.Context, st *namespaceState) error {
 	segID := st.manifest.LastSegmentID + 1
 	build, err := writeSegment(ctx, idx.ws, st.paths, segID, snap, idx.cfg.now())
 	if err != nil {
+		st.memtable.restoreSnapshot(snap)
 		return fmt.Errorf("flush: write segment: %w", err)
 	}
 
@@ -156,6 +157,7 @@ func (idx *Index) flushLocked(ctx context.Context, st *namespaceState) error {
 	}
 
 	if err := writeManifest(ctx, idx.ws, st.paths, &newMan); err != nil {
+		st.memtable.restoreSnapshot(snap)
 		return fmt.Errorf("flush: write manifest: %w", err)
 	}
 	st.manifest = &newMan

--- a/memory/retrieval/workspace/read.go
+++ b/memory/retrieval/workspace/read.go
@@ -2,6 +2,7 @@ package workspace
 
 import (
 	"context"
+	"reflect"
 	"sort"
 
 	"github.com/GizClaw/flowcraft/memory/retrieval"
@@ -321,7 +322,7 @@ func cloneDoc(d retrieval.Doc) retrieval.Doc {
 	if d.Metadata != nil {
 		out.Metadata = make(map[string]any, len(d.Metadata))
 		for k, v := range d.Metadata {
-			out.Metadata[k] = v
+			out.Metadata[k] = cloneMetadataValue(v)
 		}
 	}
 	if d.SparseVector != nil {
@@ -331,6 +332,87 @@ func cloneDoc(d retrieval.Doc) retrieval.Doc {
 		}
 	}
 	return out
+}
+
+func cloneMetadataValue(v any) any {
+	if v == nil {
+		return v
+	}
+	return cloneMetadataReflect(reflect.ValueOf(v)).Interface()
+}
+
+func cloneMetadataReflect(v reflect.Value) reflect.Value {
+	if !v.IsValid() {
+		return v
+	}
+	switch v.Kind() {
+	case reflect.Interface:
+		if v.IsNil() {
+			return v
+		}
+		return cloneMetadataReflect(v.Elem())
+	case reflect.Map:
+		if v.IsNil() {
+			return v
+		}
+		out := reflect.MakeMapWithSize(v.Type(), v.Len())
+		iter := v.MapRange()
+		for iter.Next() {
+			out.SetMapIndex(iter.Key(), cloneMetadataAssignable(cloneMetadataReflect(iter.Value()), v.Type().Elem()))
+		}
+		return out
+	case reflect.Slice:
+		if v.IsNil() {
+			return v
+		}
+		out := reflect.MakeSlice(v.Type(), v.Len(), v.Cap())
+		for i := 0; i < v.Len(); i++ {
+			out.Index(i).Set(cloneMetadataAssignable(cloneMetadataReflect(v.Index(i)), v.Type().Elem()))
+		}
+		return out
+	case reflect.Array:
+		out := reflect.New(v.Type()).Elem()
+		for i := 0; i < v.Len(); i++ {
+			out.Index(i).Set(cloneMetadataAssignable(cloneMetadataReflect(v.Index(i)), v.Type().Elem()))
+		}
+		return out
+	case reflect.Struct:
+		out := reflect.New(v.Type()).Elem()
+		out.Set(v)
+		for i := 0; i < v.NumField(); i++ {
+			dst := out.Field(i)
+			if !dst.CanSet() {
+				continue
+			}
+			dst.Set(cloneMetadataAssignable(cloneMetadataReflect(v.Field(i)), dst.Type()))
+		}
+		return out
+	case reflect.Pointer:
+		if v.IsNil() {
+			return v
+		}
+		out := reflect.New(v.Type().Elem())
+		out.Elem().Set(cloneMetadataAssignable(cloneMetadataReflect(v.Elem()), v.Type().Elem()))
+		return out
+	default:
+		return v
+	}
+}
+
+func cloneMetadataAssignable(v reflect.Value, typ reflect.Type) reflect.Value {
+	if !v.IsValid() {
+		return reflect.Zero(typ)
+	}
+	if v.Type().AssignableTo(typ) {
+		return v
+	}
+	if v.Type().ConvertibleTo(typ) {
+		return v.Convert(typ)
+	}
+	if typ.Kind() == reflect.Interface && v.Type().Implements(typ) {
+		return v
+	}
+	return reflect.Zero(typ)
 }
 
 // List walks every segment + the memtable, applies the filter,
@@ -611,6 +693,7 @@ func (idx *Index) Get(ctx context.Context, namespace, id string) (retrieval.Doc,
 func projectDoc(d retrieval.Doc, fields []string, withVector bool) retrieval.Doc {
 	if !withVector {
 		d.Vector = nil
+		d.SparseVector = nil
 	}
 	if len(fields) == 0 {
 		return d

--- a/memory/retrieval/workspace/types.go
+++ b/memory/retrieval/workspace/types.go
@@ -162,8 +162,8 @@ type segmentRef struct {
 	VectorDim int `json:"vector_dim"`
 
 	// SizeBytes is the total bytes occupied by the segment files
-	// (docs.jsonl + offsets + bm25 + vector + tombstones + meta),
-	// used by the size-tiered compactor to pick merge candidates.
+	// (docs.jsonl + offsets + tombstones + meta), used by the
+	// size-tiered compactor to pick merge candidates.
 	SizeBytes int64 `json:"size_bytes"`
 
 	// BuildAt is the writer's local clock at flush completion.
@@ -184,21 +184,19 @@ type segmentMeta struct {
 	DocCount  int `json:"doc_count"`
 	VectorDim int `json:"vector_dim"`
 
-	// AvgDocLength is the BM25 average term count per doc captured
-	// at build time. Used by per-segment scoring (BM25 is corpus-
-	// local; the per-segment value gives stable scores even when
-	// other segments come and go).
+	// AvgDocLength is retained for v1 metadata compatibility. It is
+	// currently the average marshaled-doc byte length at segment build
+	// time; Search does not use it for BM25 scoring.
 	AvgDocLength float64 `json:"avg_doc_length"`
 
 	// BuildAt is the flush completion time.
 	BuildAt time.Time `json:"build_at"`
 
-	// FileChecksums maps "docs.jsonl", "docs.offsets.bin",
-	// "bm25.bin", "vector.bin", "tombstones.bin" to their crc32
-	// (IEEE) of the file contents at build time. Reads verify the
-	// checksum on first load and refuse to use a corrupt file
-	// rather than silently feed garbled data into BM25 / vector
-	// scoring.
+	// FileChecksums maps "docs.jsonl", "docs.offsets.bin", and
+	// "tombstones.bin" to their crc32 (IEEE) of the file contents at
+	// build time. Reads verify the checksum on first load and refuse
+	// to use a corrupt file rather than silently feed garbled data
+	// into scoring.
 	FileChecksums map[string]uint32 `json:"file_checksums"`
 }
 

--- a/memory/retrieval/workspace/write.go
+++ b/memory/retrieval/workspace/write.go
@@ -50,11 +50,12 @@ func (idx *Index) Upsert(ctx context.Context, namespace string, docs []retrieval
 		if err != nil {
 			return fmt.Errorf("Upsert: marshal %s: %w", d.ID, err)
 		}
-		rec := walRecord{Op: walOpUpsert, DocID: d.ID, Doc: &d}
+		doc := cloneDoc(d)
+		rec := walRecord{Op: walOpUpsert, DocID: doc.ID, Doc: &doc}
 		if err := st.wal.Append(ctx, rec); err != nil {
 			return err
 		}
-		st.memtable.upsert(d, len(raw))
+		st.memtable.upsert(doc, len(raw))
 	}
 
 	return idx.maybeFlushLocked(ctx, st)

--- a/memory/retrieval/workspace/write_test.go
+++ b/memory/retrieval/workspace/write_test.go
@@ -39,11 +39,372 @@ func newIdx(t *testing.T, opts ...wsindex.Option) (*wsindex.Index, sdkworkspace.
 	return idx, ws
 }
 
+type failingWriteWorkspace struct {
+	sdkworkspace.Workspace
+	enabled bool
+	suffix  string
+}
+
+func (w *failingWriteWorkspace) Write(ctx context.Context, path string, data []byte) error {
+	if w.enabled && strings.HasSuffix(path, w.suffix) {
+		return errors.New("injected workspace write failure")
+	}
+	return w.Workspace.Write(ctx, path, data)
+}
+
 func TestNew_NilWorkspace(t *testing.T) {
 	if _, err := wsindex.New(nil); err == nil {
 		t.Fatal("expected error for nil workspace")
 	} else if !errdefs.IsValidation(err) {
 		t.Errorf("err = %v, want validation", err)
+	}
+}
+
+func TestFlushFailureRestoresMemtableAndCanRetry(t *testing.T) {
+	ctx := context.Background()
+	ws := &failingWriteWorkspace{
+		Workspace: sdkworkspace.NewMemWorkspace(),
+		suffix:    "manifest.json.tmp",
+	}
+	idx, err := wsindex.New(ws, wsindex.WithClock(fixedClock(1700000000)), wsindex.WithAutoCompact(false))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer idx.Close()
+
+	if err := idx.Upsert(ctx, "ns", []retrieval.Doc{{ID: "a", Content: "alpha"}}); err != nil {
+		t.Fatal(err)
+	}
+	ws.enabled = true
+	if err := idx.Flush(ctx, "ns"); err == nil {
+		t.Fatal("expected injected flush failure")
+	}
+	resp, err := idx.Search(ctx, "ns", retrieval.SearchRequest{QueryText: "alpha", TopK: 1})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(resp.Hits) != 1 || resp.Hits[0].Doc.ID != "a" {
+		t.Fatalf("acknowledged write disappeared after failed flush: %+v", resp.Hits)
+	}
+
+	ws.enabled = false
+	if err := idx.Flush(ctx, "ns"); err != nil {
+		t.Fatalf("retry flush: %v", err)
+	}
+	if err := idx.Close(); err != nil {
+		t.Fatal(err)
+	}
+	reopened, err := wsindex.New(ws, wsindex.WithClock(fixedClock(1700001000)), wsindex.WithAutoCompact(false))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer reopened.Close()
+	resp, err = reopened.Search(ctx, "ns", retrieval.SearchRequest{QueryText: "alpha", TopK: 1})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(resp.Hits) != 1 || resp.Hits[0].Doc.ID != "a" {
+		t.Fatalf("reopened index lost retried flush doc: %+v", resp.Hits)
+	}
+}
+
+func TestSegmentWriteFailureRestoresMemtableAndCanRetry(t *testing.T) {
+	ctx := context.Background()
+	ws := &failingWriteWorkspace{
+		Workspace: sdkworkspace.NewMemWorkspace(),
+		suffix:    "docs.jsonl",
+	}
+	idx, err := wsindex.New(ws, wsindex.WithClock(fixedClock(1700000000)), wsindex.WithAutoCompact(false))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer idx.Close()
+
+	if err := idx.Upsert(ctx, "ns", []retrieval.Doc{{ID: "a", Content: "alpha"}}); err != nil {
+		t.Fatal(err)
+	}
+	ws.enabled = true
+	if err := idx.Flush(ctx, "ns"); err == nil {
+		t.Fatal("expected injected segment write failure")
+	}
+	resp, err := idx.Search(ctx, "ns", retrieval.SearchRequest{QueryText: "alpha", TopK: 1})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(resp.Hits) != 1 || resp.Hits[0].Doc.ID != "a" {
+		t.Fatalf("acknowledged write disappeared after failed segment write: %+v", resp.Hits)
+	}
+
+	ws.enabled = false
+	if err := idx.Flush(ctx, "ns"); err != nil {
+		t.Fatalf("retry flush: %v", err)
+	}
+	if err := idx.Close(); err != nil {
+		t.Fatal(err)
+	}
+	reopened, err := wsindex.New(ws, wsindex.WithClock(fixedClock(1700001000)), wsindex.WithAutoCompact(false))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer reopened.Close()
+	resp, err = reopened.Search(ctx, "ns", retrieval.SearchRequest{QueryText: "alpha", TopK: 1})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(resp.Hits) != 1 || resp.Hits[0].Doc.ID != "a" {
+		t.Fatalf("reopened index lost retried segment doc: %+v", resp.Hits)
+	}
+}
+
+func TestFlushFailureRestoresTombstoneAndCanRetry(t *testing.T) {
+	ctx := context.Background()
+	ws := &failingWriteWorkspace{
+		Workspace: sdkworkspace.NewMemWorkspace(),
+		suffix:    "manifest.json.tmp",
+	}
+	idx, err := wsindex.New(ws, wsindex.WithClock(fixedClock(1700000000)), wsindex.WithAutoCompact(false))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer idx.Close()
+
+	if err := idx.Upsert(ctx, "ns", []retrieval.Doc{{ID: "a", Content: "alpha"}}); err != nil {
+		t.Fatal(err)
+	}
+	if err := idx.Flush(ctx, "ns"); err != nil {
+		t.Fatal(err)
+	}
+	if err := idx.Delete(ctx, "ns", []string{"a"}); err != nil {
+		t.Fatal(err)
+	}
+	ws.enabled = true
+	if err := idx.Flush(ctx, "ns"); err == nil {
+		t.Fatal("expected injected flush failure")
+	}
+	resp, err := idx.Search(ctx, "ns", retrieval.SearchRequest{QueryText: "alpha", TopK: 1})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(resp.Hits) != 0 {
+		t.Fatalf("deleted doc resurfaced after failed tombstone flush: %+v", resp.Hits)
+	}
+
+	ws.enabled = false
+	if err := idx.Flush(ctx, "ns"); err != nil {
+		t.Fatalf("retry flush: %v", err)
+	}
+	if err := idx.Close(); err != nil {
+		t.Fatal(err)
+	}
+	reopened, err := wsindex.New(ws, wsindex.WithClock(fixedClock(1700001000)), wsindex.WithAutoCompact(false))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer reopened.Close()
+	resp, err = reopened.Search(ctx, "ns", retrieval.SearchRequest{QueryText: "alpha", TopK: 1})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(resp.Hits) != 0 {
+		t.Fatalf("deleted doc resurfaced after retry/reopen: %+v", resp.Hits)
+	}
+}
+
+func TestSegmentWriteFailureRestoresTombstoneAndCanRetry(t *testing.T) {
+	ctx := context.Background()
+	ws := &failingWriteWorkspace{
+		Workspace: sdkworkspace.NewMemWorkspace(),
+		suffix:    "tombstones.bin",
+	}
+	idx, err := wsindex.New(ws, wsindex.WithClock(fixedClock(1700000000)), wsindex.WithAutoCompact(false))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer idx.Close()
+
+	ws.enabled = false
+	if err := idx.Upsert(ctx, "ns", []retrieval.Doc{{ID: "a", Content: "alpha"}}); err != nil {
+		t.Fatal(err)
+	}
+	if err := idx.Flush(ctx, "ns"); err != nil {
+		t.Fatal(err)
+	}
+	if err := idx.Delete(ctx, "ns", []string{"a"}); err != nil {
+		t.Fatal(err)
+	}
+	ws.enabled = true
+	if err := idx.Flush(ctx, "ns"); err == nil {
+		t.Fatal("expected injected tombstone segment write failure")
+	}
+	resp, err := idx.Search(ctx, "ns", retrieval.SearchRequest{QueryText: "alpha", TopK: 1})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(resp.Hits) != 0 {
+		t.Fatalf("deleted doc resurfaced after failed tombstone segment write: %+v", resp.Hits)
+	}
+
+	ws.enabled = false
+	if err := idx.Flush(ctx, "ns"); err != nil {
+		t.Fatalf("retry flush: %v", err)
+	}
+	if err := idx.Close(); err != nil {
+		t.Fatal(err)
+	}
+	reopened, err := wsindex.New(ws, wsindex.WithClock(fixedClock(1700001000)), wsindex.WithAutoCompact(false))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer reopened.Close()
+	resp, err = reopened.Search(ctx, "ns", retrieval.SearchRequest{QueryText: "alpha", TopK: 1})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(resp.Hits) != 0 {
+		t.Fatalf("deleted doc resurfaced after retried tombstone segment write: %+v", resp.Hits)
+	}
+}
+
+func TestFailedByteTriggeredFlushRestoresPressure(t *testing.T) {
+	ctx := context.Background()
+	ws := &failingWriteWorkspace{
+		Workspace: sdkworkspace.NewMemWorkspace(),
+		suffix:    "manifest.json.tmp",
+	}
+	idx, err := wsindex.New(ws,
+		wsindex.WithClock(fixedClock(1700000000)),
+		wsindex.WithAutoCompact(false),
+		wsindex.WithMemtableMaxDocs(100),
+		wsindex.WithMemtableMaxBytes(100),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer idx.Close()
+
+	ws.enabled = true
+	if err := idx.Upsert(ctx, "ns", []retrieval.Doc{{ID: "big", Content: strings.Repeat("alpha ", 30)}}); err == nil {
+		t.Fatal("expected byte-triggered flush failure")
+	}
+	ws.enabled = false
+	if err := idx.Upsert(ctx, "ns", []retrieval.Doc{{ID: "small", Content: "bravo"}}); err != nil {
+		t.Fatal(err)
+	}
+	if exists, _ := ws.Exists(ctx, "ns/manifest.json"); !exists {
+		t.Fatal("restored byte pressure did not trigger a successful manifest publish")
+	}
+	if err := idx.Close(); err != nil {
+		t.Fatal(err)
+	}
+	reopened, err := wsindex.New(ws, wsindex.WithClock(fixedClock(1700001000)), wsindex.WithAutoCompact(false))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer reopened.Close()
+	for _, q := range []struct {
+		text string
+		id   string
+	}{
+		{text: "alpha", id: "big"},
+		{text: "bravo", id: "small"},
+	} {
+		resp, err := reopened.Search(ctx, "ns", retrieval.SearchRequest{QueryText: q.text, TopK: 1})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(resp.Hits) != 1 || resp.Hits[0].Doc.ID != q.id {
+			t.Fatalf("reopened hits for %q = %+v, want %s", q.text, resp.Hits, q.id)
+		}
+	}
+}
+
+func TestUpsertDeepCopiesStagedDoc(t *testing.T) {
+	idx, _ := newIdx(t, wsindex.WithAutoCompact(false))
+	ctx := context.Background()
+	nestedTags := []any{"before"}
+	nestedMap := map[string]any{"tags": nestedTags}
+	typedMap := map[string][]string{"labels": {"before"}}
+	typedSlice := []map[string]string{{"state": "before"}}
+	structValue := struct {
+		Tags   []string
+		Nested map[string]string
+	}{
+		Tags:   []string{"before"},
+		Nested: map[string]string{"state": "before"},
+	}
+	docs := []retrieval.Doc{{
+		ID:           "a",
+		Content:      "alpha",
+		Vector:       []float32{1, 0},
+		Metadata:     map[string]any{"state": "before", "nested": nestedMap, "typed_map": typedMap, "typed_slice": typedSlice, "struct": structValue},
+		SparseVector: map[string]float32{"alpha": 1},
+	}}
+	if err := idx.Upsert(ctx, "ns", docs); err != nil {
+		t.Fatal(err)
+	}
+	docs[0].Vector[0] = 0
+	docs[0].Vector[1] = 1
+	docs[0].Metadata["state"] = "after"
+	docs[0].SparseVector["alpha"] = 99
+	nestedTags[0] = "after"
+	nestedMap["new"] = "after"
+	typedMap["labels"][0] = "after"
+	typedMap["labels"] = append(typedMap["labels"], "new")
+	typedSlice[0]["state"] = "after"
+	typedSlice = append(typedSlice, map[string]string{"state": "new"})
+	structValue.Tags[0] = "after"
+	structValue.Nested["state"] = "after"
+
+	resp, err := idx.List(ctx, "ns", retrieval.ListRequest{PageSize: 1, WithVector: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(resp.Items) != 1 {
+		t.Fatalf("items=%+v", resp.Items)
+	}
+	got := resp.Items[0]
+	if got.Vector[0] != 1 || got.Metadata["state"] != "before" || got.SparseVector["alpha"] != 1 {
+		t.Fatalf("staged doc aliases caller-owned data: %+v", got)
+	}
+	gotNested, ok := got.Metadata["nested"].(map[string]any)
+	if !ok {
+		t.Fatalf("nested metadata has unexpected type: %+v", got.Metadata["nested"])
+	}
+	gotTags, ok := gotNested["tags"].([]any)
+	if !ok || len(gotTags) != 1 || gotTags[0] != "before" {
+		t.Fatalf("nested metadata slice aliases caller-owned data: %+v", got.Metadata)
+	}
+	if _, ok := gotNested["new"]; ok {
+		t.Fatalf("nested metadata map aliases caller-owned data: %+v", got.Metadata)
+	}
+	gotTypedMap, ok := got.Metadata["typed_map"].(map[string][]string)
+	if !ok || len(gotTypedMap["labels"]) != 1 || gotTypedMap["labels"][0] != "before" {
+		t.Fatalf("typed nested metadata map aliases caller-owned data: %+v", got.Metadata)
+	}
+	gotTypedSlice, ok := got.Metadata["typed_slice"].([]map[string]string)
+	if !ok || len(gotTypedSlice) != 1 || gotTypedSlice[0]["state"] != "before" {
+		t.Fatalf("typed nested metadata slice aliases caller-owned data: %+v", got.Metadata)
+	}
+	gotStruct, ok := got.Metadata["struct"].(struct {
+		Tags   []string
+		Nested map[string]string
+	})
+	if !ok || len(gotStruct.Tags) != 1 || gotStruct.Tags[0] != "before" || gotStruct.Nested["state"] != "before" {
+		t.Fatalf("struct metadata aliases caller-owned data: %+v", got.Metadata)
+	}
+}
+
+func TestUpsertRejectsCyclicMetadata(t *testing.T) {
+	idx, _ := newIdx(t, wsindex.WithAutoCompact(false))
+	cyclic := map[string]any{}
+	cyclic["self"] = cyclic
+	err := idx.Upsert(context.Background(), "ns", []retrieval.Doc{{
+		ID:       "cyclic",
+		Content:  "alpha",
+		Metadata: map[string]any{"cyclic": cyclic},
+	}})
+	if err == nil {
+		t.Fatal("expected cyclic metadata marshal error")
 	}
 }
 


### PR DESCRIPTION
## Summary
Retrieval backends now enforce the same contract for hybrid thresholds, sparse search, projection, and zero-evidence fusion. The workspace backend now preserves acknowledged writes and tombstones across failed flushes, including segment and manifest write failures, and isolates staged docs from caller-owned mutations.

This also aligns SQL and memory backends with the declared capability surface: SQLite/Postgres reject standalone vector-only search, implement sparse-only scoring, and avoid hybrid MinScore filtering; memory and BBH hybrid paths no longer fuse zero-evidence candidates. BM25Boost now reuses the canonical `memory/text/bm25` scorer instead of carrying a separate formula.

## Key Decisions
- `SearchRequest.MinScore` remains single-modality only; hybrid/fused scores are left for pipeline-level thresholding.
- SQLite/Postgres no longer pretend to be vector-only backends; text-anchored hybrid remains available.
- Sparse scoring is exact for memory/SQLite/Postgres, with SQL backends favoring correctness over silent truncation.
- `journal.DeleteByFilter` deletes and records the snapshotted ID set so audit events match the actual mutation.

## Test Plan
- `go test ./memory/retrieval/... ./memory/text/...`
- `go test -race ./memory/retrieval/workspace`

## Notes
- Live Postgres integration still requires `FC_PG_DSN`; without it, the Postgres package compiles and skips the integration path as before.
