### PR TITLE
feat(graph): support cancelable parallel branches

### DIFF
--- a/sdk/engine/stream_emit.go
+++ b/sdk/engine/stream_emit.go
@@ -185,6 +185,14 @@ func validateStreamDelta(p StreamDeltaPayload) error {
 			return fmt.Errorf("engine: stream delta tool_result requires ToolCallID")
 		}
 		return nil
+	case StreamDeltaParallelBranchAccept, StreamDeltaParallelBranchCancel:
+		if p.ForkID == "" {
+			return fmt.Errorf("engine: stream delta %s requires ForkID", p.Type)
+		}
+		if p.BranchID == "" {
+			return fmt.Errorf("engine: stream delta %s requires BranchID", p.Type)
+		}
+		return nil
 	case "":
 		return fmt.Errorf("engine: stream delta requires Type")
 	default:

--- a/sdk/engine/stream_emit_test.go
+++ b/sdk/engine/stream_emit_test.go
@@ -135,6 +135,49 @@ func TestEmitStreamDelta_RejectsEmptyType(t *testing.T) {
 	}
 }
 
+func TestEmitStreamDelta_ParallelBranchControlRequiredFields(t *testing.T) {
+	t.Parallel()
+	pub := &capturePublisher{}
+
+	if err := EmitStreamDelta(context.Background(), pub, "r", "branch-a", StreamDeltaPayload{
+		Type:     StreamDeltaParallelBranchAccept,
+		BranchID: "branch-a",
+	}); err == nil {
+		t.Fatal("expected error for missing ForkID")
+	}
+	if err := EmitStreamDelta(context.Background(), pub, "r", "branch-a", StreamDeltaPayload{
+		Type:   StreamDeltaParallelBranchCancel,
+		ForkID: "r:start",
+		Reason: "intent rejected",
+	}); err == nil {
+		t.Fatal("expected error for missing BranchID")
+	}
+	if len(pub.got) != 0 {
+		t.Fatalf("malformed parallel control deltas leaked through: %d envelopes", len(pub.got))
+	}
+
+	if err := EmitStreamDelta(context.Background(), pub, "r", "branch-a", StreamDeltaPayload{
+		Type:        StreamDeltaParallelBranchCancel,
+		ForkID:      "r:start",
+		BranchID:    "branch-a",
+		Reason:      "intent rejected",
+		Speculative: true,
+	}); err != nil {
+		t.Fatalf("valid parallel control delta: %v", err)
+	}
+	got, err := DecodeStreamDelta(pub.got[0])
+	if err != nil {
+		t.Fatalf("DecodeStreamDelta: %v", err)
+	}
+	if got.Type != StreamDeltaParallelBranchCancel ||
+		got.ForkID != "r:start" ||
+		got.BranchID != "branch-a" ||
+		got.Reason != "intent rejected" ||
+		!got.Speculative {
+		t.Fatalf("payload = %+v", got)
+	}
+}
+
 func TestEmitStreamDelta_AcceptsForwardCompatibleType(t *testing.T) {
 	t.Parallel()
 	pub := &capturePublisher{}

--- a/sdk/engine/subjects.go
+++ b/sdk/engine/subjects.go
@@ -235,6 +235,16 @@ const (
 	// Required fields: ToolCallID, Content. Recommended: Name,
 	// IsError, Cancelled.
 	StreamDeltaToolResult StreamDeltaType = "tool_result"
+
+	// StreamDeltaParallelBranchAccept marks a speculative parallel
+	// branch's stream output as accepted by the graph runner.
+	// Required fields: ForkID, BranchID.
+	StreamDeltaParallelBranchAccept StreamDeltaType = "parallel_branch_accept"
+
+	// StreamDeltaParallelBranchCancel marks a speculative parallel
+	// branch's stream output as canceled/rolled back by the graph runner.
+	// Required fields: ForkID, BranchID. Recommended: Reason.
+	StreamDeltaParallelBranchCancel StreamDeltaType = "parallel_branch_cancel"
 )
 
 // StreamDeltaPayload is the canonical decoded shape of a
@@ -253,6 +263,8 @@ const (
 //	token          Content                —
 //	tool_call      ID, Name               Arguments
 //	tool_result    ToolCallID, Content    Name, IsError, Cancelled
+//	parallel_branch_accept ForkID, BranchID —
+//	parallel_branch_cancel ForkID, BranchID Reason
 type StreamDeltaPayload struct {
 	// Type discriminates the payload variant. See StreamDeltaType
 	// constants for the standard values.
@@ -288,6 +300,21 @@ type StreamDeltaPayload struct {
 	// cancellation (the call was never dispatched because the round
 	// was interrupted). Set on "tool_result" only.
 	Cancelled bool `json:"cancelled,omitempty"`
+
+	// Speculative reports whether the delta belongs to a parallel branch
+	// whose output has not yet been accepted into the parent board.
+	Speculative bool `json:"speculative,omitempty"`
+
+	// ForkID identifies the graph-runner parallel fork for speculative
+	// branch deltas and parallel_branch_* control deltas.
+	ForkID string `json:"fork_id,omitempty"`
+
+	// BranchID identifies the branch within ForkID for speculative
+	// branch deltas and parallel_branch_* control deltas.
+	BranchID string `json:"branch_id,omitempty"`
+
+	// Reason carries the rollback/abort reason for parallel_branch_cancel.
+	Reason string `json:"reason,omitempty"`
 }
 
 // DecodeStreamDelta extracts the payload of a stream-delta envelope.

--- a/sdk/engine/subjects_test.go
+++ b/sdk/engine/subjects_test.go
@@ -264,6 +264,48 @@ func TestDecodeStreamDelta_CancelledToolResult(t *testing.T) {
 	}
 }
 
+func TestDecodeStreamDelta_ParallelBranchControl(t *testing.T) {
+	acceptEnv := mustEnvelope(t,
+		engine.SubjectStreamDelta("r1", "branch-a"),
+		map[string]any{
+			"type":        "parallel_branch_accept",
+			"fork_id":     "r1:start",
+			"branch_id":   "branch-a",
+			"speculative": true,
+		},
+	)
+	accept, err := engine.DecodeStreamDelta(acceptEnv)
+	if err != nil {
+		t.Fatalf("decode accept: %v", err)
+	}
+	if accept.Type != engine.StreamDeltaParallelBranchAccept ||
+		accept.ForkID != "r1:start" ||
+		accept.BranchID != "branch-a" ||
+		!accept.Speculative {
+		t.Fatalf("accept payload = %+v", accept)
+	}
+
+	cancelEnv := mustEnvelope(t,
+		engine.SubjectStreamDelta("r1", "branch-b"),
+		map[string]any{
+			"type":      "parallel_branch_cancel",
+			"fork_id":   "r1:start",
+			"branch_id": "branch-b",
+			"reason":    "intent rejected",
+		},
+	)
+	cancel, err := engine.DecodeStreamDelta(cancelEnv)
+	if err != nil {
+		t.Fatalf("decode cancel: %v", err)
+	}
+	if cancel.Type != engine.StreamDeltaParallelBranchCancel ||
+		cancel.ForkID != "r1:start" ||
+		cancel.BranchID != "branch-b" ||
+		cancel.Reason != "intent rejected" {
+		t.Fatalf("cancel payload = %+v", cancel)
+	}
+}
+
 func TestDecodeStreamDelta_EmptyPayload(t *testing.T) {
 	env := event.Envelope{Subject: engine.SubjectStreamDelta("r1", "s1")}
 	if _, err := engine.DecodeStreamDelta(env); err == nil {

--- a/sdk/graph/node/scriptnode/bridge_parallel.go
+++ b/sdk/graph/node/scriptnode/bridge_parallel.go
@@ -1,0 +1,27 @@
+package scriptnode
+
+import (
+	"context"
+
+	"github.com/GizClaw/flowcraft/sdk/graph"
+	"github.com/GizClaw/flowcraft/sdk/script/bindings"
+)
+
+// newParallelBridge exposes graph parallel-fork controls to scripts.
+//
+// Script-facing API:
+//
+//	parallel.cancelNode(nodeID, reason) bool
+func newParallelBridge() bindings.BindingFunc {
+	return func(ctx context.Context) (string, any) {
+		return "parallel", map[string]any{
+			"cancelNode": func(nodeID, reason string) bool {
+				controller, ok := graph.ParallelControllerFromContext(ctx)
+				if !ok {
+					return false
+				}
+				return controller.CancelNode(nodeID, reason)
+			},
+		}
+	}
+}

--- a/sdk/graph/node/scriptnode/jsnode.go
+++ b/sdk/graph/node/scriptnode/jsnode.go
@@ -77,6 +77,7 @@ func (n *ScriptNode) ExecuteBoard(ctx graph.ExecutionContext, board *graph.Board
 		bindings.NewBoardBridge(board),
 		bindings.NewExprBridge(),
 		bindings.NewHostBridge(ctx.Host, n.id, ctx.Publisher),
+		newParallelBridge(),
 		// Reconstruct the full RunInfo from engine.Run.Attributes
 		// (promoted by agent.Run upstream) instead of the legacy
 		// RunInfo{RunID: ec.RunID} one-field bridge that left

--- a/sdk/graph/node/scriptnode/jsnode_test.go
+++ b/sdk/graph/node/scriptnode/jsnode_test.go
@@ -164,3 +164,56 @@ func TestScriptNode_RunInfo_AllFieldsPropagate(t *testing.T) {
 		}
 	}
 }
+
+func TestScriptNode_ParallelCancelNodeBridge(t *testing.T) {
+	rt := jsrt.New(jsrt.WithPoolSize(1))
+	src := `
+		var ok = parallel.cancelNode("draft_answer", "intent rejected");
+		board.setVar("cancel_ok", ok);
+	`
+	n := New("decide", "script", src, nil, rt)
+	controller := &stubParallelController{}
+
+	board := graph.NewBoard()
+	ctx := graph.ExecutionContext{
+		Context: graph.WithParallelController(context.Background(), controller),
+	}
+	if err := n.ExecuteBoard(ctx, board); err != nil {
+		t.Fatalf("ExecuteBoard: %v", err)
+	}
+
+	if v, _ := board.GetVar("cancel_ok"); v != true {
+		t.Fatalf("cancel_ok = %v", v)
+	}
+	if controller.nodeID != "draft_answer" {
+		t.Fatalf("nodeID = %q", controller.nodeID)
+	}
+	if controller.reason != "intent rejected" {
+		t.Fatalf("reason = %q", controller.reason)
+	}
+}
+
+func TestScriptNode_ParallelCancelNodeBridge_NoParallelContext(t *testing.T) {
+	rt := jsrt.New(jsrt.WithPoolSize(1))
+	src := `board.setVar("cancel_ok", parallel.cancelNode("draft_answer", "intent rejected"));`
+	n := New("decide", "script", src, nil, rt)
+
+	board := graph.NewBoard()
+	if err := n.ExecuteBoard(graph.ExecutionContext{Context: context.Background()}, board); err != nil {
+		t.Fatalf("ExecuteBoard: %v", err)
+	}
+	if v, _ := board.GetVar("cancel_ok"); v != false {
+		t.Fatalf("cancel_ok = %v, want false", v)
+	}
+}
+
+type stubParallelController struct {
+	nodeID string
+	reason string
+}
+
+func (s *stubParallelController) CancelNode(nodeID, reason string) bool {
+	s.nodeID = nodeID
+	s.reason = reason
+	return true
+}

--- a/sdk/graph/parallel.go
+++ b/sdk/graph/parallel.go
@@ -1,0 +1,29 @@
+package graph
+
+import "context"
+
+type parallelCtxKey string
+
+const (
+	parallelControllerKey parallelCtxKey = "graph.parallel.controller"
+)
+
+// ParallelController exposes limited control over the currently executing
+// parallel fork. It is intentionally context-scoped: outside a fork it is absent.
+type ParallelController interface {
+	CancelNode(nodeID, reason string) bool
+}
+
+// WithParallelController stores the current fork controller on ctx.
+func WithParallelController(ctx context.Context, c ParallelController) context.Context {
+	if c == nil {
+		return ctx
+	}
+	return context.WithValue(ctx, parallelControllerKey, c)
+}
+
+// ParallelControllerFromContext returns the current fork controller, if any.
+func ParallelControllerFromContext(ctx context.Context) (ParallelController, bool) {
+	c, ok := ctx.Value(parallelControllerKey).(ParallelController)
+	return c, ok
+}

--- a/sdk/graph/runner/internal/executor/executor.go
+++ b/sdk/graph/runner/internal/executor/executor.go
@@ -561,7 +561,7 @@ func (e *LocalExecutor) Execute(ctx context.Context, g *graph.Graph, board *grap
 			}
 
 			if cfg.parallel != nil && len(resolved) > 1 && allUnconditional(g.Edges(nodeID), resolved) {
-				joinBoard, err := executeForkJoin(ctx, g, board, resolved, cfg)
+				joinBoard, err := executeForkJoin(ctx, g, board, nodeID, resolved, cfg)
 				if err != nil {
 					return board, err
 				}

--- a/sdk/graph/runner/internal/executor/merge.go
+++ b/sdk/graph/runner/internal/executor/merge.go
@@ -50,7 +50,11 @@ func mergeLastWins(board *graph.Board, _ *graph.BoardSnapshot, results []branchR
 
 func mergeNamespace(board *graph.Board, _ *graph.BoardSnapshot, results []branchResult) error {
 	for i, r := range results {
-		prefix := fmt.Sprintf("__branch_%d.", i)
+		idx := i
+		if r.index > 0 {
+			idx = r.index
+		}
+		prefix := fmt.Sprintf("__branch_%d.", idx)
 		for k, v := range r.vars {
 			board.SetVar(prefix+k, v)
 		}

--- a/sdk/graph/runner/internal/executor/parallel.go
+++ b/sdk/graph/runner/internal/executor/parallel.go
@@ -5,28 +5,68 @@ import (
 	"fmt"
 	"sync"
 
+	"github.com/GizClaw/flowcraft/sdk/engine"
 	"github.com/GizClaw/flowcraft/sdk/errdefs"
 	"github.com/GizClaw/flowcraft/sdk/graph"
 	"github.com/GizClaw/flowcraft/sdk/model"
 )
 
 type branchResult struct {
+	index    int
+	branchID string
 	vars     map[string]any
 	channels map[string][]model.Message
 	err      error
 }
 
-func executeForkJoin(ctx context.Context, g *graph.Graph, board *graph.Board, branchStarts []string, cfg runConfig) (*graph.Board, error) {
+type branchParallelController struct {
+	parent    *parallelForkController
+	branchIdx int
+	ctx       context.Context
+}
+
+func (c *branchParallelController) CancelNode(nodeID, reason string) bool {
+	if c == nil || c.parent == nil || c.ctx.Err() != nil {
+		return false
+	}
+	if c.parent.branchTerminal(c.branchIdx) {
+		return false
+	}
+	return c.parent.cancelNodeFromBranch(c.branchIdx, nodeID, reason)
+}
+
+type parallelForkController struct {
+	ctx        context.Context
+	cfg        runConfig
+	graphName  string
+	agentID    string
+	forkID     string
+	forkNodeID string
+
+	mu           sync.Mutex
+	branchStarts []string
+	cancels      map[int]context.CancelCauseFunc
+	nodeBranches map[string][]int
+	canceled     map[int]string
+	accepted     map[int]struct{}
+	abortReason  string
+}
+
+func executeForkJoin(ctx context.Context, g *graph.Graph, board *graph.Board, forkNodeID string, branchStarts []string, cfg runConfig) (*graph.Board, error) {
 	if cfg.parallel != nil && len(branchStarts) > cfg.parallel.MaxBranches {
 		branchStarts = branchStarts[:cfg.parallel.MaxBranches]
 	}
 
 	agentID := agentIDFor(ctx, cfg)
 	joinNodeID := findJoinNode(g, branchStarts)
+	forkID := parallelForkID(cfg.runID, forkNodeID)
+	controller := newParallelForkController(ctx, cfg, g.Name(), agentID, forkID, forkNodeID, branchStarts, joinNodeID, g)
 
 	publishGraphEvent(ctx, cfg.publisher, subjParallelFork(cfg.runID),
 		cfg.runID, g.Name(), agentID,
 		map[string]any{
+			"fork_id":    forkID,
+			"fork_node":  forkNodeID,
 			"branch_ids": branchStarts,
 			"join_node":  joinNodeID,
 		})
@@ -34,14 +74,28 @@ func executeForkJoin(ctx context.Context, g *graph.Graph, board *graph.Board, br
 	results := make([]branchResult, len(branchStarts))
 	var wg sync.WaitGroup
 
-	branchCtx, cancelBranches := context.WithCancel(ctx)
-	defer cancelBranches()
-
 	snapshot := board.Snapshot()
+	branchCtxs := make([]context.Context, len(branchStarts))
+	for i, startID := range branchStarts {
+		branchCtx, cancelBranch := context.WithCancelCause(ctx)
+		controller.attachBranch(i, cancelBranch)
+		branchCtx = graph.WithParallelController(branchCtx, &branchParallelController{
+			parent:    controller,
+			branchIdx: i,
+			ctx:       branchCtx,
+		})
+		branchCtx = withParallelBranchInfo(branchCtx, parallelBranchInfo{
+			ForkID:      forkID,
+			BranchID:    startID,
+			Speculative: true,
+		})
+		branchCtxs[i] = branchCtx
+	}
+	defer controller.releaseBranchContexts()
 
 	for i, startID := range branchStarts {
 		wg.Add(1)
-		go func(idx int, sid string) {
+		go func(idx int, sid string, branchCtx context.Context) {
 			defer wg.Done()
 			branchBoard := graph.RestoreBoard(snapshot)
 			branchCfg := cfg
@@ -50,20 +104,34 @@ func executeForkJoin(ctx context.Context, g *graph.Graph, board *graph.Board, br
 			}
 			err := runBranch(branchCtx, g, branchBoard, sid, joinNodeID, branchCfg)
 			results[idx] = branchResult{
+				index:    idx,
+				branchID: sid,
 				vars:     branchBoard.Vars(),
 				channels: branchBoard.ChannelsCopy(),
 				err:      err,
 			}
-			if err != nil {
-				cancelBranches()
+			if err != nil && !controller.branchCanceled(idx) {
+				controller.abortUnaccepted(fmt.Sprintf("fork aborted: parallel branch %q failed: %v", sid, err))
 			}
-		}(i, startID)
+		}(i, startID, branchCtxs[i])
 	}
 
 	wg.Wait()
 
+	if reason, ok := controller.abortState(); ok {
+		primaryIdx := primaryErrorIndex(results)
+		if primaryIdx >= 0 {
+			return board, fmt.Errorf("parallel branch %q failed: %w",
+				branchStarts[primaryIdx], results[primaryIdx].err)
+		}
+		return board, errdefs.Abortedf("%s", reason)
+	}
+
 	primaryIdx := -1
 	for i, r := range results {
+		if controller.branchCanceled(i) {
+			continue
+		}
 		if r.err == nil {
 			continue
 		}
@@ -76,8 +144,19 @@ func executeForkJoin(ctx context.Context, g *graph.Graph, board *graph.Board, br
 		}
 	}
 	if primaryIdx >= 0 {
-		return board, fmt.Errorf("parallel branch %q failed: %w",
+		err := fmt.Errorf("parallel branch %q failed: %w",
 			branchStarts[primaryIdx], results[primaryIdx].err)
+		controller.cancelUnaccepted("fork aborted: " + err.Error())
+		return board, err
+	}
+
+	mergeResults := make([]branchResult, 0, len(results))
+	acceptedIdxs := make([]int, 0, len(results))
+	for i, r := range results {
+		if !controller.branchCanceled(i) {
+			mergeResults = append(mergeResults, r)
+			acceptedIdxs = append(acceptedIdxs, i)
+		}
 	}
 
 	strategy := MergeLastWins
@@ -85,18 +164,294 @@ func executeForkJoin(ctx context.Context, g *graph.Graph, board *graph.Board, br
 		strategy = cfg.parallel.MergeStrategy
 	}
 	mergeFn := lookupMerge(strategy)
-	if err := mergeFn(board, snapshot, results); err != nil {
+	if err := mergeFn(board, snapshot, mergeResults); err != nil {
+		controller.cancelUnaccepted("fork aborted: merge failed: " + err.Error())
 		return board, err
 	}
+
+	controller.acceptBranches(acceptedIdxs)
 
 	publishGraphEvent(ctx, cfg.publisher, subjParallelJoin(cfg.runID),
 		cfg.runID, g.Name(), agentID,
 		map[string]any{
+			"fork_id":    forkID,
 			"branch_ids": branchStarts,
 			"vars":       board.Vars(),
 		})
 
 	return board, nil
+}
+
+func parallelForkID(runID, forkNodeID string) string {
+	if runID == "" {
+		return forkNodeID
+	}
+	return runID + ":" + forkNodeID
+}
+
+func newParallelForkController(
+	ctx context.Context,
+	cfg runConfig,
+	graphName, agentID, forkID, forkNodeID string,
+	branchStarts []string,
+	joinNodeID string,
+	g *graph.Graph,
+) *parallelForkController {
+	return &parallelForkController{
+		ctx:          ctx,
+		cfg:          cfg,
+		graphName:    graphName,
+		agentID:      agentID,
+		forkID:       forkID,
+		forkNodeID:   forkNodeID,
+		branchStarts: append([]string(nil), branchStarts...),
+		cancels:      make(map[int]context.CancelCauseFunc, len(branchStarts)),
+		nodeBranches: branchNodeIndex(g, branchStarts, joinNodeID),
+		canceled:     make(map[int]string),
+		accepted:     make(map[int]struct{}),
+	}
+}
+
+func (c *parallelForkController) attachBranch(idx int, cancel context.CancelCauseFunc) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.cancels[idx] = cancel
+}
+
+func (c *parallelForkController) cancelNodeFromBranch(callerIdx int, nodeID, reason string) bool {
+	if reason == "" {
+		reason = "cancelled by parallel.cancelNode"
+	}
+
+	type cancellation struct {
+		branchID string
+		cancel   context.CancelCauseFunc
+	}
+
+	c.mu.Lock()
+	if _, ok := c.accepted[callerIdx]; ok {
+		c.mu.Unlock()
+		return false
+	}
+	if _, ok := c.canceled[callerIdx]; ok {
+		c.mu.Unlock()
+		return false
+	}
+	branchIdxs := append([]int(nil), c.nodeBranches[nodeID]...)
+	cancellations := make([]cancellation, 0, len(branchIdxs))
+	for _, idx := range branchIdxs {
+		if _, ok := c.accepted[idx]; ok {
+			continue
+		}
+		if _, ok := c.canceled[idx]; ok {
+			continue
+		}
+		c.canceled[idx] = reason
+		cancellations = append(cancellations, cancellation{
+			branchID: c.branchStarts[idx],
+			cancel:   c.cancels[idx],
+		})
+	}
+	c.mu.Unlock()
+
+	for _, item := range cancellations {
+		if item.cancel != nil {
+			item.cancel(fmt.Errorf("parallel branch %q canceled: %s", item.branchID, reason))
+		}
+		c.publishBranchCancel(item.branchID, nodeID, reason)
+	}
+	return len(cancellations) > 0
+}
+
+func (c *parallelForkController) branchTerminal(idx int) bool {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if _, ok := c.canceled[idx]; ok {
+		return true
+	}
+	_, ok := c.accepted[idx]
+	return ok
+}
+
+func (c *parallelForkController) branchCanceled(idx int) bool {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	_, ok := c.canceled[idx]
+	return ok
+}
+
+func (c *parallelForkController) cancelBranchContexts(cause error) {
+	c.mu.Lock()
+	cancels := make([]context.CancelCauseFunc, 0, len(c.cancels))
+	for _, cancel := range c.cancels {
+		cancels = append(cancels, cancel)
+	}
+	c.mu.Unlock()
+
+	for _, cancel := range cancels {
+		cancel(cause)
+	}
+}
+
+func (c *parallelForkController) releaseBranchContexts() {
+	c.cancelBranchContexts(nil)
+}
+
+func (c *parallelForkController) abortUnaccepted(reason string) {
+	c.mu.Lock()
+	if c.abortReason == "" {
+		c.abortReason = reason
+	}
+	reason = c.abortReason
+	c.mu.Unlock()
+	c.cancelUnaccepted(reason)
+}
+
+func (c *parallelForkController) abortState() (string, bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.abortReason, c.abortReason != ""
+}
+
+func (c *parallelForkController) cancelUnaccepted(reason string) {
+	type cancellation struct {
+		branchID string
+		cancel   context.CancelCauseFunc
+	}
+
+	c.mu.Lock()
+	cancellations := make([]cancellation, 0, len(c.branchStarts))
+	for idx, branchID := range c.branchStarts {
+		if _, ok := c.accepted[idx]; ok {
+			continue
+		}
+		if _, ok := c.canceled[idx]; ok {
+			continue
+		}
+		c.canceled[idx] = reason
+		cancellations = append(cancellations, cancellation{
+			branchID: branchID,
+			cancel:   c.cancels[idx],
+		})
+	}
+	c.mu.Unlock()
+
+	for _, item := range cancellations {
+		if item.cancel != nil {
+			item.cancel(fmt.Errorf("parallel branch %q canceled: %s", item.branchID, reason))
+		}
+		c.publishBranchCancel(item.branchID, "", reason)
+	}
+}
+
+func (c *parallelForkController) acceptBranches(idxs []int) {
+	branchIDs := make([]string, 0, len(idxs))
+
+	c.mu.Lock()
+	for _, idx := range idxs {
+		if _, ok := c.canceled[idx]; ok {
+			continue
+		}
+		if _, ok := c.accepted[idx]; ok {
+			continue
+		}
+		c.accepted[idx] = struct{}{}
+		branchIDs = append(branchIDs, c.branchStarts[idx])
+	}
+	c.mu.Unlock()
+
+	for _, branchID := range branchIDs {
+		c.publishBranchAccept(branchID)
+	}
+}
+
+func (c *parallelForkController) publishBranchAccept(branchID string) {
+	payload := map[string]any{
+		"fork_id":   c.forkID,
+		"branch_id": branchID,
+	}
+	publishGraphEvent(c.ctx, c.cfg.publisher, subjParallelBranchAccept(c.cfg.runID),
+		c.cfg.runID, c.graphName, c.agentID, payload)
+	c.publishBranchControlDelta(branchID, engine.StreamDeltaParallelBranchAccept, payload)
+}
+
+func (c *parallelForkController) publishBranchCancel(branchID, nodeID, reason string) {
+	payload := map[string]any{
+		"fork_id":   c.forkID,
+		"fork_node": c.forkNodeID,
+		"branch_id": branchID,
+		"reason":    reason,
+	}
+	if nodeID != "" {
+		payload["node_id"] = nodeID
+	}
+	publishGraphEvent(c.ctx, c.cfg.publisher, subjParallelBranchCancel(c.cfg.runID),
+		c.cfg.runID, c.graphName, c.agentID, payload)
+	c.publishBranchControlDelta(branchID, engine.StreamDeltaParallelBranchCancel, payload)
+}
+
+func (c *parallelForkController) publishBranchControlDelta(branchID string, eventType engine.StreamDeltaType, payload map[string]any) {
+	if c.cfg.publisher == nil {
+		return
+	}
+	delta := map[string]any{
+		"type":        eventType,
+		"fork_id":     c.forkID,
+		"branch_id":   branchID,
+		"speculative": true,
+	}
+	for k, v := range payload {
+		delta[k] = v
+	}
+	publishNodeEvent(c.ctx, c.cfg.publisher,
+		engine.SubjectStreamDelta(c.cfg.runID, stepActorFor(c.agentID, branchID)),
+		c.cfg.runID, c.graphName, c.agentID, branchID, delta)
+}
+
+func branchNodeIndex(g *graph.Graph, branchStartIDs []string, joinNodeID string) map[string][]int {
+	succs := make(map[string][]string)
+	for _, e := range g.AllEdges() {
+		succs[e.From] = append(succs[e.From], e.To)
+	}
+
+	out := make(map[string][]int)
+	for i, startID := range branchStartIDs {
+		for nodeID := range bfsReachableUntilJoin(succs, startID, joinNodeID) {
+			out[nodeID] = append(out[nodeID], i)
+		}
+	}
+	return out
+}
+
+func bfsReachableUntilJoin(succs map[string][]string, start, joinNodeID string) map[string]bool {
+	reached := make(map[string]bool)
+	queue := []string{start}
+	for len(queue) > 0 {
+		cur := queue[0]
+		queue = queue[1:]
+		if reached[cur] || cur == graph.END || (joinNodeID != "" && cur == joinNodeID) {
+			continue
+		}
+		reached[cur] = true
+		queue = append(queue, succs[cur]...)
+	}
+	return reached
+}
+
+func primaryErrorIndex(results []branchResult) int {
+	primaryIdx := -1
+	for i, r := range results {
+		if r.err == nil {
+			continue
+		}
+		if primaryIdx == -1 {
+			primaryIdx = i
+		}
+		if !errdefs.Is(r.err, context.Canceled) {
+			return i
+		}
+	}
+	return primaryIdx
 }
 
 func runBranch(ctx context.Context, g *graph.Graph, board *graph.Board, startID, joinID string, cfg runConfig) error {

--- a/sdk/graph/runner/internal/executor/parallel_test.go
+++ b/sdk/graph/runner/internal/executor/parallel_test.go
@@ -3,9 +3,14 @@ package executor
 import (
 	"context"
 	"fmt"
+	"strings"
+	"sync"
 	"sync/atomic"
 	"testing"
+	"time"
 
+	"github.com/GizClaw/flowcraft/sdk/engine"
+	"github.com/GizClaw/flowcraft/sdk/event"
 	"github.com/GizClaw/flowcraft/sdk/graph"
 	"github.com/GizClaw/flowcraft/sdk/graph/variable"
 )
@@ -315,4 +320,535 @@ func TestLocalExecutor_TypedResolution_ParallelBranches(t *testing.T) {
 	if nodeB.config["temperature"] != "${board.temperature}" {
 		t.Fatalf("branch_b config should be restored, got %v", nodeB.config["temperature"])
 	}
+}
+
+func TestLocalExecutor_ParallelCancelNode_DropsCanceledBranch(t *testing.T) {
+	draftStarted := make(chan struct{})
+	lateCancelResult := make(chan bool, 1)
+	host := &recordingParallelHost{}
+
+	g := buildGraph("test", "start",
+		map[string]graph.Node{
+			"start": graph.NewPassthroughNode("start", "passthrough"),
+			"decide": newTestNode("decide", func(ctx graph.ExecutionContext, b *graph.Board) error {
+				select {
+				case <-draftStarted:
+				case <-time.After(time.Second):
+					return fmt.Errorf("draft branch did not start")
+				}
+				controller, ok := graph.ParallelControllerFromContext(ctx.Context)
+				if !ok {
+					return fmt.Errorf("parallel controller missing")
+				}
+				if !controller.CancelNode("draft", "intent rejected draft") {
+					return fmt.Errorf("cancelNode returned false")
+				}
+				b.SetVar("decision_result", "keep_decision")
+				return nil
+			}),
+			"draft": newTestNode("draft", func(ctx graph.ExecutionContext, b *graph.Board) error {
+				controller, ok := graph.ParallelControllerFromContext(ctx.Context)
+				if !ok {
+					return fmt.Errorf("parallel controller missing")
+				}
+				close(draftStarted)
+				ctx.Publisher.Emit("token", map[string]any{"content": "draft partial"})
+				<-ctx.Context.Done()
+				ctx.Publisher.Emit("token", map[string]any{"content": "late after cancel"})
+				lateCancelResult <- controller.CancelNode("decide", "canceled branch should not cancel sibling")
+				b.SetVar("draft_result", "should_not_merge")
+				return ctx.Context.Err()
+			}),
+			"join": newTestNode("join", func(_ graph.ExecutionContext, b *graph.Board) error {
+				b.SetVar("joined", true)
+				return nil
+			}),
+		},
+		[]graph.Edge{
+			{From: "start", To: "decide"},
+			{From: "start", To: "draft"},
+			{From: "decide", To: "join"},
+			{From: "draft", To: "join"},
+			{From: "join", To: graph.END},
+		},
+	)
+
+	result, err := NewLocalExecutor().Execute(context.Background(), g, graph.NewBoard(),
+		WithRunID("run-cancel"),
+		WithHost(host),
+		WithParallel(ParallelConfig{Enabled: true, MaxBranches: 10}),
+	)
+	if err != nil {
+		t.Fatalf("execute failed: %v", err)
+	}
+	if v := result.GetVarString("decision_result"); v != "keep_decision" {
+		t.Fatalf("decision_result = %q", v)
+	}
+	if v := result.GetVarString("draft_result"); v != "" {
+		t.Fatalf("canceled draft branch merged result %q", v)
+	}
+	if v, _ := result.GetVar("joined"); v != true {
+		t.Fatal("expected joined=true")
+	}
+	select {
+	case got := <-lateCancelResult:
+		if got {
+			t.Fatal("canceled branch was allowed to cancel sibling")
+		}
+	default:
+		t.Fatal("canceled branch did not attempt late sibling cancel")
+	}
+
+	payload, ok := host.firstPayload(subjParallelBranchCancel("run-cancel"))
+	if !ok {
+		t.Fatal("expected parallel branch cancel event")
+	}
+	if payload["reason"] != "intent rejected draft" {
+		t.Fatalf("cancel reason = %v", payload["reason"])
+	}
+	if payload["node_id"] != "draft" || payload["branch_id"] != "draft" {
+		t.Fatalf("cancel payload = %+v", payload)
+	}
+	if payload["fork_id"] != "run-cancel:start" {
+		t.Fatalf("fork_id = %v", payload["fork_id"])
+	}
+	cancelDelta, ok := host.firstStreamPayload(engine.StreamDeltaParallelBranchCancel)
+	if !ok {
+		t.Fatal("expected stream control delta for branch cancel")
+	}
+	if cancelDelta.ForkID != "run-cancel:start" ||
+		cancelDelta.BranchID != "draft" ||
+		cancelDelta.Reason != "intent rejected draft" ||
+		!cancelDelta.Speculative {
+		t.Fatalf("cancel stream delta = %+v", cancelDelta)
+	}
+
+	var draftToken map[string]any
+	for _, env := range host.events() {
+		if env.NodeID() != "draft" {
+			continue
+		}
+		var payload map[string]any
+		if err := env.Decode(&payload); err != nil {
+			t.Fatalf("decode draft stream payload: %v", err)
+		}
+		if payload["type"] == "token" {
+			draftToken = payload
+			break
+		}
+	}
+	if draftToken == nil {
+		t.Fatal("expected speculative token from canceled draft branch")
+	}
+	if draftToken["speculative"] != true ||
+		draftToken["fork_id"] != "run-cancel:start" ||
+		draftToken["branch_id"] != "draft" {
+		t.Fatalf("draft token parallel metadata = %+v", draftToken)
+	}
+	for _, env := range host.events() {
+		if env.NodeID() != "draft" {
+			continue
+		}
+		var payload map[string]any
+		if err := env.Decode(&payload); err != nil {
+			t.Fatalf("decode draft stream payload: %v", err)
+		}
+		if payload["content"] == "late after cancel" {
+			t.Fatalf("stream delta emitted after branch cancel: %+v", payload)
+		}
+	}
+	for _, payload := range host.payloads(subjParallelBranchAccept("run-cancel")) {
+		if payload["branch_id"] == "draft" {
+			t.Fatalf("canceled draft branch was accepted: %+v", payload)
+		}
+	}
+}
+
+func TestLocalExecutor_ParallelNamespaceMerge_PreservesOriginalIndexAfterCancel(t *testing.T) {
+	dropDone := make(chan struct{})
+	g := buildGraph("test", "start",
+		map[string]graph.Node{
+			"start": graph.NewPassthroughNode("start", "passthrough"),
+			"drop": newTestNode("drop", func(_ graph.ExecutionContext, b *graph.Board) error {
+				b.SetVar("dropped", true)
+				close(dropDone)
+				return nil
+			}),
+			"keep": newTestNode("keep", func(ctx graph.ExecutionContext, b *graph.Board) error {
+				select {
+				case <-dropDone:
+				case <-time.After(time.Second):
+					return fmt.Errorf("drop branch did not complete")
+				}
+				controller, ok := graph.ParallelControllerFromContext(ctx.Context)
+				if !ok {
+					return fmt.Errorf("parallel controller missing")
+				}
+				if !controller.CancelNode("drop", "drop first branch output") {
+					return fmt.Errorf("cancelNode returned false")
+				}
+				b.SetVar("kept", true)
+				return nil
+			}),
+			"join": graph.NewPassthroughNode("join", "passthrough"),
+		},
+		[]graph.Edge{
+			{From: "start", To: "drop"},
+			{From: "start", To: "keep"},
+			{From: "drop", To: "join"},
+			{From: "keep", To: "join"},
+			{From: "join", To: graph.END},
+		},
+	)
+
+	result, err := NewLocalExecutor().Execute(context.Background(), g, graph.NewBoard(),
+		WithRunID("run-namespace-cancel"),
+		WithParallel(ParallelConfig{Enabled: true, MaxBranches: 10, MergeStrategy: MergeNamespace}),
+	)
+	if err != nil {
+		t.Fatalf("execute failed: %v", err)
+	}
+	if v, _ := result.GetVar("__branch_0.dropped"); v != nil {
+		t.Fatalf("canceled branch 0 should not merge, got %v", v)
+	}
+	if v, _ := result.GetVar("__branch_0.kept"); v != nil {
+		t.Fatalf("kept branch was renumbered to branch 0: %v", v)
+	}
+	if v, _ := result.GetVar("__branch_1.kept"); v != true {
+		t.Fatalf("kept branch should preserve original namespace __branch_1, got %v", v)
+	}
+}
+
+func TestLocalExecutor_ParallelCancelNode_CancelsCompletedOutput(t *testing.T) {
+	draftDone := make(chan struct{})
+	host := &recordingParallelHost{}
+
+	g := buildGraph("test", "start",
+		map[string]graph.Node{
+			"start": graph.NewPassthroughNode("start", "passthrough"),
+			"decide": newTestNode("decide", func(ctx graph.ExecutionContext, b *graph.Board) error {
+				select {
+				case <-draftDone:
+				case <-time.After(time.Second):
+					return fmt.Errorf("draft branch did not complete")
+				}
+				controller, ok := graph.ParallelControllerFromContext(ctx.Context)
+				if !ok {
+					return fmt.Errorf("parallel controller missing")
+				}
+				if !controller.CancelNode("draft", "completed output rejected") {
+					return fmt.Errorf("cancelNode returned false")
+				}
+				b.SetVar("decision_result", "done")
+				return nil
+			}),
+			"draft": newTestNode("draft", func(_ graph.ExecutionContext, b *graph.Board) error {
+				b.SetVar("draft_result", "completed_but_rejected")
+				close(draftDone)
+				return nil
+			}),
+			"join": graph.NewPassthroughNode("join", "passthrough"),
+		},
+		[]graph.Edge{
+			{From: "start", To: "decide"},
+			{From: "start", To: "draft"},
+			{From: "decide", To: "join"},
+			{From: "draft", To: "join"},
+			{From: "join", To: graph.END},
+		},
+	)
+
+	result, err := NewLocalExecutor().Execute(context.Background(), g, graph.NewBoard(),
+		WithRunID("run-completed-cancel"),
+		WithHost(host),
+		WithParallel(ParallelConfig{Enabled: true, MaxBranches: 10}),
+	)
+	if err != nil {
+		t.Fatalf("execute failed: %v", err)
+	}
+	if got := result.GetVarString("draft_result"); got != "" {
+		t.Fatalf("completed-but-canceled branch merged draft_result %q", got)
+	}
+	if got := result.GetVarString("decision_result"); got != "done" {
+		t.Fatalf("decision_result = %q", got)
+	}
+
+	cancelPayload, ok := host.firstPayload(subjParallelBranchCancel("run-completed-cancel"))
+	if !ok {
+		t.Fatal("expected cancel event for completed branch output")
+	}
+	if cancelPayload["reason"] != "completed output rejected" {
+		t.Fatalf("cancel reason = %v", cancelPayload["reason"])
+	}
+	for _, payload := range host.payloads(subjParallelBranchAccept("run-completed-cancel")) {
+		if payload["branch_id"] == "draft" {
+			t.Fatalf("completed-but-canceled draft branch was accepted: %+v", payload)
+		}
+	}
+}
+
+func TestLocalExecutor_ParallelBranchError_CancelsSpeculativeBranches(t *testing.T) {
+	slowStarted := make(chan struct{})
+	host := &recordingParallelHost{}
+
+	g := buildGraph("test", "start",
+		map[string]graph.Node{
+			"start": graph.NewPassthroughNode("start", "passthrough"),
+			"slow": newTestNode("slow", func(ctx graph.ExecutionContext, _ *graph.Board) error {
+				close(slowStarted)
+				ctx.Publisher.Emit("token", map[string]any{"content": "partial"})
+				<-ctx.Context.Done()
+				return ctx.Context.Err()
+			}),
+			"fail": newTestNode("fail", func(_ graph.ExecutionContext, _ *graph.Board) error {
+				select {
+				case <-slowStarted:
+				case <-time.After(time.Second):
+					return fmt.Errorf("slow branch did not start")
+				}
+				return fmt.Errorf("branch failed")
+			}),
+			"join": graph.NewPassthroughNode("join", "passthrough"),
+		},
+		[]graph.Edge{
+			{From: "start", To: "slow"},
+			{From: "start", To: "fail"},
+			{From: "slow", To: "join"},
+			{From: "fail", To: "join"},
+			{From: "join", To: graph.END},
+		},
+	)
+
+	_, err := NewLocalExecutor().Execute(context.Background(), g, graph.NewBoard(),
+		WithRunID("run-error-cancel"),
+		WithHost(host),
+		WithParallel(ParallelConfig{Enabled: true, MaxBranches: 10}),
+	)
+	if err == nil {
+		t.Fatal("expected branch failure")
+	}
+
+	cancelPayloads := host.payloads(subjParallelBranchCancel("run-error-cancel"))
+	if len(cancelPayloads) == 0 {
+		t.Fatal("expected cancel terminal events on branch failure")
+	}
+	cancelByBranch := make(map[string]map[string]any)
+	for _, payload := range cancelPayloads {
+		if branchID, _ := payload["branch_id"].(string); branchID != "" {
+			cancelByBranch[branchID] = payload
+		}
+	}
+	if _, ok := cancelByBranch["slow"]; !ok {
+		t.Fatalf("missing cancel event for slow branch: %+v", cancelPayloads)
+	}
+	if _, ok := cancelByBranch["fail"]; !ok {
+		t.Fatalf("missing cancel event for failed branch: %+v", cancelPayloads)
+	}
+	for branchID, payload := range cancelByBranch {
+		if reason, _ := payload["reason"].(string); reason == "" {
+			t.Fatalf("cancel reason missing for branch %s: %+v", branchID, payload)
+		}
+	}
+	if got := host.payloads(subjParallelBranchAccept("run-error-cancel")); len(got) != 0 {
+		t.Fatalf("erroring fork should not accept branches: %+v", got)
+	}
+}
+
+func TestLocalExecutor_ParallelStreamEvents_AreSpeculativeThenAccepted(t *testing.T) {
+	host := &recordingParallelHost{}
+	g := buildGraph("test", "start",
+		map[string]graph.Node{
+			"start": graph.NewPassthroughNode("start", "passthrough"),
+			"emitter": newTestNode("emitter", func(ctx graph.ExecutionContext, b *graph.Board) error {
+				ctx.Publisher.Emit("token", map[string]any{"content": "hello"})
+				b.SetVar("emitted", true)
+				return nil
+			}),
+			"other": newTestNode("other", func(_ graph.ExecutionContext, b *graph.Board) error {
+				b.SetVar("other_done", true)
+				return nil
+			}),
+			"join": graph.NewPassthroughNode("join", "passthrough"),
+		},
+		[]graph.Edge{
+			{From: "start", To: "emitter"},
+			{From: "start", To: "other"},
+			{From: "emitter", To: "join"},
+			{From: "other", To: "join"},
+			{From: "join", To: graph.END},
+		},
+	)
+
+	if _, err := NewLocalExecutor().Execute(context.Background(), g, graph.NewBoard(),
+		WithRunID("run-stream"),
+		WithHost(host),
+		WithParallel(ParallelConfig{Enabled: true, MaxBranches: 10}),
+	); err != nil {
+		t.Fatalf("execute failed: %v", err)
+	}
+
+	var tokenPayload map[string]any
+	for _, env := range host.events() {
+		if env.NodeID() != "emitter" {
+			continue
+		}
+		var payload map[string]any
+		if err := env.Decode(&payload); err != nil {
+			t.Fatalf("decode stream payload: %v", err)
+		}
+		if payload["type"] == "token" {
+			tokenPayload = payload
+			break
+		}
+	}
+	if tokenPayload == nil {
+		t.Fatal("expected token stream event from emitter")
+	}
+	if tokenPayload["speculative"] != true {
+		t.Fatalf("speculative = %v", tokenPayload["speculative"])
+	}
+	if tokenPayload["fork_id"] != "run-stream:start" || tokenPayload["branch_id"] != "emitter" {
+		t.Fatalf("parallel metadata = %+v", tokenPayload)
+	}
+
+	acceptPayload, ok := host.firstPayload(subjParallelBranchAccept("run-stream"))
+	if !ok {
+		t.Fatal("expected branch accept event")
+	}
+	if acceptPayload["fork_id"] != "run-stream:start" {
+		t.Fatalf("accept fork_id = %v", acceptPayload["fork_id"])
+	}
+	acceptDeltas := host.streamPayloads(engine.StreamDeltaParallelBranchAccept)
+	acceptedBranches := make(map[string]bool, len(acceptDeltas))
+	for _, delta := range acceptDeltas {
+		acceptedBranches[delta.BranchID] = true
+		if delta.ForkID != "run-stream:start" || !delta.Speculative {
+			t.Fatalf("accept stream delta = %+v", delta)
+		}
+	}
+	if !acceptedBranches["emitter"] {
+		t.Fatalf("expected emitter branch accept stream delta, got %+v", acceptDeltas)
+	}
+}
+
+func TestLocalExecutor_ParallelMergeConflict_CancelsUnacceptedBranches(t *testing.T) {
+	host := &recordingParallelHost{}
+	g := buildGraph("test", "start",
+		map[string]graph.Node{
+			"start": graph.NewPassthroughNode("start", "passthrough"),
+			"a": newTestNode("a", func(_ graph.ExecutionContext, b *graph.Board) error {
+				b.SetVar("shared", "from_a")
+				return nil
+			}),
+			"b": newTestNode("b", func(_ graph.ExecutionContext, b *graph.Board) error {
+				b.SetVar("shared", "from_b")
+				return nil
+			}),
+			"join": graph.NewPassthroughNode("join", "passthrough"),
+		},
+		[]graph.Edge{
+			{From: "start", To: "a"},
+			{From: "start", To: "b"},
+			{From: "a", To: "join"},
+			{From: "b", To: "join"},
+			{From: "join", To: graph.END},
+		},
+	)
+
+	_, err := NewLocalExecutor().Execute(context.Background(), g, graph.NewBoard(),
+		WithRunID("run-merge-conflict"),
+		WithHost(host),
+		WithParallel(ParallelConfig{Enabled: true, MaxBranches: 10, MergeStrategy: MergeErrorOnConflict}),
+	)
+	if err == nil {
+		t.Fatal("expected merge conflict")
+	}
+	cancelPayloads := host.payloads(subjParallelBranchCancel("run-merge-conflict"))
+	if len(cancelPayloads) != 2 {
+		t.Fatalf("cancel payload count = %d, want 2: %+v", len(cancelPayloads), cancelPayloads)
+	}
+	for _, payload := range cancelPayloads {
+		if reason, _ := payload["reason"].(string); !strings.Contains(reason, "merge failed") {
+			t.Fatalf("cancel reason should mention merge failure: %+v", payload)
+		}
+	}
+	if got := host.payloads(subjParallelBranchAccept("run-merge-conflict")); len(got) != 0 {
+		t.Fatalf("merge conflict should not accept branches: %+v", got)
+	}
+	cancelDeltas := host.streamPayloads(engine.StreamDeltaParallelBranchCancel)
+	cancelDeltaBranches := make(map[string]bool, len(cancelDeltas))
+	for _, delta := range cancelDeltas {
+		cancelDeltaBranches[delta.BranchID] = true
+	}
+	if len(cancelDeltaBranches) != 2 || !cancelDeltaBranches["a"] || !cancelDeltaBranches["b"] {
+		t.Fatalf("cancel stream delta branches = %+v, payloads=%+v", cancelDeltaBranches, cancelDeltas)
+	}
+}
+
+type recordingParallelHost struct {
+	engine.NoopHost
+
+	mu   sync.Mutex
+	envs []event.Envelope
+}
+
+func (h *recordingParallelHost) Publish(_ context.Context, env event.Envelope) error {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.envs = append(h.envs, env)
+	return nil
+}
+
+func (h *recordingParallelHost) events() []event.Envelope {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	out := make([]event.Envelope, len(h.envs))
+	copy(out, h.envs)
+	return out
+}
+
+func (h *recordingParallelHost) firstPayload(subject event.Subject) (map[string]any, bool) {
+	payloads := h.payloads(subject)
+	if len(payloads) == 0 {
+		return nil, false
+	}
+	return payloads[0], true
+}
+
+func (h *recordingParallelHost) firstStreamPayload(deltaType engine.StreamDeltaType) (engine.StreamDeltaPayload, bool) {
+	payloads := h.streamPayloads(deltaType)
+	if len(payloads) == 0 {
+		return engine.StreamDeltaPayload{}, false
+	}
+	return payloads[0], true
+}
+
+func (h *recordingParallelHost) streamPayloads(deltaType engine.StreamDeltaType) []engine.StreamDeltaPayload {
+	var out []engine.StreamDeltaPayload
+	for _, env := range h.events() {
+		if !engine.IsStreamDelta(env.Subject) {
+			continue
+		}
+		payload, err := engine.DecodeStreamDelta(env)
+		if err != nil || payload.Type != deltaType {
+			continue
+		}
+		out = append(out, payload)
+	}
+	return out
+}
+
+func (h *recordingParallelHost) payloads(subject event.Subject) []map[string]any {
+	var out []map[string]any
+	for _, env := range h.events() {
+		if env.Subject != subject {
+			continue
+		}
+		var payload map[string]any
+		if err := env.Decode(&payload); err != nil {
+			continue
+		}
+		out = append(out, payload)
+	}
+	return out
 }

--- a/sdk/graph/runner/internal/executor/publisher.go
+++ b/sdk/graph/runner/internal/executor/publisher.go
@@ -7,6 +7,26 @@ import (
 	"github.com/GizClaw/flowcraft/sdk/graph"
 )
 
+type parallelBranchInfoCtxKey struct{}
+
+type parallelBranchInfo struct {
+	ForkID      string
+	BranchID    string
+	Speculative bool
+}
+
+func withParallelBranchInfo(ctx context.Context, info parallelBranchInfo) context.Context {
+	if info.ForkID == "" && info.BranchID == "" && !info.Speculative {
+		return ctx
+	}
+	return context.WithValue(ctx, parallelBranchInfoCtxKey{}, info)
+}
+
+func parallelBranchInfoFromContext(ctx context.Context) (parallelBranchInfo, bool) {
+	info, ok := ctx.Value(parallelBranchInfoCtxKey{}).(parallelBranchInfo)
+	return info, ok
+}
+
 // newNodePublisher builds the StreamPublisher handed to a node. The
 // node speaks the simplified (eventType, payload) shape; this wrapper
 // translates each emit into a fully-formed engine event.Envelope and
@@ -26,12 +46,21 @@ func newNodePublisher(ctx context.Context, cfg runConfig, nodeID string) graph.S
 	stepActor := stepActorFor(agentID, nodeID)
 	graphName := cfg.graphName
 	pub := cfg.publisher
+	branchInfo, inParallelBranch := parallelBranchInfoFromContext(ctx)
 
 	return graph.StreamPublisherFunc(func(eventType string, payload any) {
 		if pub == nil {
 			return
 		}
+		if inParallelBranch && ctx.Err() != nil {
+			return
+		}
 		pl := normalisePayload(eventType, payload)
+		if inParallelBranch {
+			pl["speculative"] = branchInfo.Speculative
+			pl["fork_id"] = branchInfo.ForkID
+			pl["branch_id"] = branchInfo.BranchID
+		}
 		publishNodeEvent(ctx, pub, engine.SubjectStreamDelta(cfg.runID, stepActor),
 			cfg.runID, graphName, agentID, nodeID, pl)
 	})

--- a/sdk/graph/runner/internal/executor/subjects.go
+++ b/sdk/graph/runner/internal/executor/subjects.go
@@ -26,6 +26,8 @@ import (
 //
 //	engine.run.<runID>.parallel.fork
 //	engine.run.<runID>.parallel.join
+//	engine.run.<runID>.parallel.branch.accept
+//	engine.run.<runID>.parallel.branch.cancel
 //	engine.run.<runID>.step.<stepActor>.skipped
 //
 // stepActor follows the engine contract documented in
@@ -56,6 +58,24 @@ func subjParallelFork(runID string) event.Subject {
 // graph-private: see subjParallelFork.
 func subjParallelJoin(runID string) event.Subject {
 	return event.Subject(fmt.Sprintf("%s%s.parallel.join", engine.SubjectPrefix, engine.SanitiseID(runID)))
+}
+
+// subjParallelBranchAccept returns
+// "engine.run.<runID>.parallel.branch.accept".
+//
+// graph-private: signals that speculative events emitted by a parallel branch
+// should be treated as retained by observers.
+func subjParallelBranchAccept(runID string) event.Subject {
+	return event.Subject(fmt.Sprintf("%s%s.parallel.branch.accept", engine.SubjectPrefix, engine.SanitiseID(runID)))
+}
+
+// subjParallelBranchCancel returns
+// "engine.run.<runID>.parallel.branch.cancel".
+//
+// graph-private: signals that speculative events emitted by a parallel branch
+// should be discarded or visually rolled back by observers.
+func subjParallelBranchCancel(runID string) event.Subject {
+	return event.Subject(fmt.Sprintf("%s%s.parallel.branch.cancel", engine.SubjectPrefix, engine.SanitiseID(runID)))
 }
 
 // subjNodeSkipped returns "engine.run.<runID>.step.<nodeID>.skipped".


### PR DESCRIPTION
## Summary

Graph parallel forks can now be controlled at runtime: scripts may call `parallel.cancelNode(nodeID, reason)` to roll back a speculative branch before its output is accepted into the parent board.

Speculative branch stream output is now tagged with `speculative`, `fork_id`, and `branch_id`, and each branch emits an explicit accept or cancel terminal delta so consumers can retain or discard streamed output deterministically.

Canceled branches are excluded from final board merges even if they already completed, while fork aborts and merge conflicts now publish cancel signals for every unaccepted branch and preserve original namespace indexes.

## Test plan

- `go test ./sdk/engine ./sdk/graph/runner/internal/executor ./sdk/graph/node/scriptnode`
- `go test ./sdk/graph/... ./sdk/engine`
- `go test -race ./sdk/graph/runner/internal/executor`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
