### PR TITLE
fix(recall): bound two-pass extractor stages

### DIFF
--- a/memory/recall/internal/ingest/extractor_llm.go
+++ b/memory/recall/internal/ingest/extractor_llm.go
@@ -615,7 +615,7 @@ func (e *LLMExtractor) triageCoverageRepairInput(ctx context.Context, input port
 	if schemaName == "" {
 		schemaName = "recall_coverage_repair_triage"
 	}
-	return triageCoverageRepairInput(ctx, e.Client, system, schemaName, e.Temperature, e.ExtraOptions, input, facts)
+	return triageCoverageRepairInput(ctx, e.Client, system, schemaName, e.Temperature, e.ExtraOptions, 0, input, facts)
 }
 
 // normaliseExtractedKind maps the LLM's "kind" field to a canonical

--- a/memory/recall/internal/ingest/extractor_llm_two_pass.go
+++ b/memory/recall/internal/ingest/extractor_llm_two_pass.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/GizClaw/flowcraft/memory/recall/internal/domain"
 	"github.com/GizClaw/flowcraft/memory/recall/internal/port"
@@ -683,6 +684,7 @@ type TwoPassLLMExtractor struct {
 
 	Temperature  float64
 	ExtraOptions []llm.GenerateOption
+	StageTimeout time.Duration
 
 	mu        sync.Mutex
 	lastStats TwoPassExtractionStats
@@ -900,7 +902,9 @@ func (e *TwoPassLLMExtractor) extractFactsWithSchema(ctx context.Context, userMe
 	if schemaName == "" {
 		schemaName = defaultSchemaName
 	}
-	reply, usage, err := e.Client.Generate(ctx, []llm.Message{
+	stageCtx, cancel := e.stageContext(ctx)
+	defer cancel()
+	reply, usage, err := e.Client.Generate(stageCtx, []llm.Message{
 		llm.NewTextMessage(llm.RoleSystem, system),
 		llm.NewTextMessage(llm.RoleUser, userMessage),
 	}, e.generateOptions(schemaName, schema)...)
@@ -1252,7 +1256,9 @@ func (e *TwoPassLLMExtractor) groundEvidence(ctx context.Context, turnsJSONL str
 	if err != nil {
 		return nil, err
 	}
-	reply, usage, err := e.Client.Generate(ctx, []llm.Message{
+	stageCtx, cancel := e.stageContext(ctx)
+	defer cancel()
+	reply, usage, err := e.Client.Generate(stageCtx, []llm.Message{
 		llm.NewTextMessage(llm.RoleSystem, system),
 		llm.NewTextMessage(llm.RoleUser, userMessage),
 	}, e.generateOptions(schemaName, TwoPassEvidenceGroundingSchema)...)
@@ -1314,7 +1320,9 @@ func (e *TwoPassLLMExtractor) extractAssertionAnnotations(ctx context.Context, m
 	if userMessage == "" {
 		return nil, nil
 	}
-	reply, usage, err := e.Client.Generate(ctx, []llm.Message{
+	stageCtx, cancel := e.stageContext(ctx)
+	defer cancel()
+	reply, usage, err := e.Client.Generate(stageCtx, []llm.Message{
 		llm.NewTextMessage(llm.RoleSystem, system),
 		llm.NewTextMessage(llm.RoleUser, userMessage),
 	}, e.generateOptions(schemaName, TwoPassAssertionExtractionSchema)...)
@@ -1351,6 +1359,13 @@ func (e *TwoPassLLMExtractor) generateOptions(schemaName string, schema string) 
 	}
 	opts = append(opts, e.ExtraOptions...)
 	return opts
+}
+
+func (e *TwoPassLLMExtractor) stageContext(ctx context.Context) (context.Context, context.CancelFunc) {
+	if e == nil || e.StageTimeout <= 0 {
+		return ctx, func() {}
+	}
+	return context.WithTimeout(ctx, e.StageTimeout)
 }
 
 func cleanSourceIDs(ids []string) []string {
@@ -1628,7 +1643,7 @@ func (e *TwoPassLLMExtractor) triageCoverageRepairInput(ctx context.Context, inp
 	if schemaName == "" {
 		schemaName = "recall_coverage_repair_triage"
 	}
-	return triageCoverageRepairInput(ctx, e.Client, system, schemaName, e.Temperature, e.ExtraOptions, input, facts)
+	return triageCoverageRepairInput(ctx, e.Client, system, schemaName, e.Temperature, e.ExtraOptions, e.StageTimeout, input, facts)
 }
 
 type coverageRepairTriageTurn struct {
@@ -1654,7 +1669,7 @@ type coverageRepairTriageResponse struct {
 	Turns []coverageRepairTriageDecision `json:"turns"`
 }
 
-func triageCoverageRepairInput(ctx context.Context, client llm.LLM, system, schemaName string, temperature float64, extraOptions []llm.GenerateOption, input port.IngestInput, facts []domain.TemporalFact) (port.IngestInput, bool, error) {
+func triageCoverageRepairInput(ctx context.Context, client llm.LLM, system, schemaName string, temperature float64, extraOptions []llm.GenerateOption, stageTimeout time.Duration, input port.IngestInput, facts []domain.TemporalFact) (port.IngestInput, bool, error) {
 	if client == nil || len(input.Turns) == 0 {
 		return input, false, nil
 	}
@@ -1679,7 +1694,13 @@ func triageCoverageRepairInput(ctx context.Context, client llm.LLM, system, sche
 	}
 	opts = append(opts, extraOptions...)
 
-	reply, usage, err := client.Generate(ctx, messages, opts...)
+	stageCtx := ctx
+	cancel := func() {}
+	if stageTimeout > 0 {
+		stageCtx, cancel = context.WithTimeout(ctx, stageTimeout)
+	}
+	defer cancel()
+	reply, usage, err := client.Generate(stageCtx, messages, opts...)
 	recordExtractorTokenUsage(ctx, "repair_triage", usage)
 	if err != nil {
 		return input, false, fmt.Errorf("recall extractor: repair triage llm: %w", err)

--- a/memory/recall/internal/ingest/extractor_test.go
+++ b/memory/recall/internal/ingest/extractor_test.go
@@ -155,6 +155,22 @@ func (f *fakeLLM) GenerateStream(context.Context, []llm.Message, ...llm.Generate
 	return nil, errors.New("fakeLLM: streaming not implemented")
 }
 
+type blockingStageLLM struct {
+	stage string
+}
+
+func (b blockingStageLLM) Generate(ctx context.Context, msgs []llm.Message, _ ...llm.GenerateOption) (llm.Message, llm.TokenUsage, error) {
+	if len(msgs) > 0 && msgs[0].Content() == b.stage {
+		<-ctx.Done()
+		return llm.Message{}, llm.TokenUsage{}, ctx.Err()
+	}
+	return llm.NewTextMessage(llm.RoleAssistant, `{"facts":[]}`), llm.TokenUsage{}, nil
+}
+
+func (b blockingStageLLM) GenerateStream(context.Context, []llm.Message, ...llm.GenerateOption) (llm.StreamMessage, error) {
+	return nil, errors.New("blockingStageLLM: streaming not implemented")
+}
+
 func fakeTwoPassLLM(content, kind, relation, entity, evidence []string) *fakeLLM {
 	return &fakeLLM{ResponsesBySystem: map[string][]string{
 		TwoPassFactExtractionPrompt:     content,
@@ -1383,6 +1399,31 @@ func TestTwoPassLLMExtractor_ContentPassFailureFailsExtraction(t *testing.T) {
 	}
 }
 
+func TestTwoPassLLMExtractor_StageTimeoutCancelsBlockedGenerate(t *testing.T) {
+	ex := NewTwoPassLLMExtractor(blockingStageLLM{stage: TwoPassFactExtractionPrompt})
+	ex.StageTimeout = 20 * time.Millisecond
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	start := time.Now()
+	_, err := ex.Extract(ctx, port.IngestInput{
+		Scope: domain.Scope{RuntimeID: "rt"},
+		Turns: []port.TurnContext{{ID: "D1:3", Role: "user", Speaker: "Avery", Text: "Avery likes Riverton."}},
+	})
+	if err == nil {
+		t.Fatal("blocked content stage should return an error")
+	}
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("blocked content stage error = %v, want context deadline exceeded", err)
+	}
+	if ctx.Err() != nil {
+		t.Fatalf("outer context should still be live, got %v", ctx.Err())
+	}
+	if elapsed := time.Since(start); elapsed >= time.Second {
+		t.Fatalf("stage timeout should cancel promptly, elapsed=%s", elapsed)
+	}
+}
+
 func TestTwoPassLLMExtractor_MergePrefersStrongSubject(t *testing.T) {
 	client := fakeTwoPassLLM(
 		[]string{`{"facts":[{"text":"Avery likes Riverton.","subject":"they","source_ids":["D1:3"],"quote":"Avery likes Riverton."}]}`},
@@ -1760,7 +1801,7 @@ func TestCoverageRepairTriageFiltersSelectedTurns(t *testing.T) {
 	}}
 	acc := newExtractorUsageAccumulator()
 	ctx := withExtractorUsageAccumulator(context.Background(), acc)
-	filtered, ok, err := triageCoverageRepairInput(ctx, client, CoverageRepairTriagePrompt, "triage", 0, nil, input, nil)
+	filtered, ok, err := triageCoverageRepairInput(ctx, client, CoverageRepairTriagePrompt, "triage", 0, nil, 0, input, nil)
 	if err != nil {
 		t.Fatalf("triage: %v", err)
 	}
@@ -1777,6 +1818,29 @@ func TestCoverageRepairTriageFiltersSelectedTurns(t *testing.T) {
 	usage := acc.snapshot()
 	if len(usage.Stages) != 1 || usage.Stages[0].Stage != "repair_triage" || usage.Stages[0].Calls != 1 {
 		t.Fatalf("usage stages = %+v, want one repair_triage call", usage.Stages)
+	}
+}
+
+func TestCoverageRepairTriageUsesStageTimeout(t *testing.T) {
+	client := blockingStageLLM{stage: CoverageRepairTriagePrompt}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	start := time.Now()
+	_, _, err := triageCoverageRepairInput(ctx, client, CoverageRepairTriagePrompt, "triage", 0, nil, 20*time.Millisecond, port.IngestInput{
+		Turns: []port.TurnContext{{ID: "D1:2", Role: "user", Speaker: "Avery", Text: "Avery bought a blue mug."}},
+	}, nil)
+	if err == nil {
+		t.Fatal("blocked repair triage should return an error")
+	}
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("repair triage error = %v, want context deadline exceeded", err)
+	}
+	if ctx.Err() != nil {
+		t.Fatalf("outer context should still be live, got %v", ctx.Err())
+	}
+	if elapsed := time.Since(start); elapsed >= time.Second {
+		t.Fatalf("stage timeout should cancel repair triage promptly, elapsed=%s", elapsed)
 	}
 }
 

--- a/memory/recall/memory_llm_extractor_test.go
+++ b/memory/recall/memory_llm_extractor_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/GizClaw/flowcraft/memory/recall/internal/ingest"
 	temporalstore "github.com/GizClaw/flowcraft/memory/recall/internal/store/temporal"
@@ -51,6 +52,22 @@ func (s *scriptedLLM) Generate(_ context.Context, _ []llm.Message, opts ...llm.G
 
 func (s *scriptedLLM) GenerateStream(context.Context, []llm.Message, ...llm.GenerateOption) (llm.StreamMessage, error) {
 	return nil, errors.New("scriptedLLM: streaming not implemented")
+}
+
+type publicBlockingStageLLM struct {
+	stage string
+}
+
+func (b publicBlockingStageLLM) Generate(ctx context.Context, msgs []llm.Message, _ ...llm.GenerateOption) (llm.Message, llm.TokenUsage, error) {
+	if len(msgs) > 0 && msgs[0].Content() == b.stage {
+		<-ctx.Done()
+		return llm.Message{}, llm.TokenUsage{}, ctx.Err()
+	}
+	return llm.NewTextMessage(llm.RoleAssistant, `{"facts":[]}`), llm.TokenUsage{}, nil
+}
+
+func (b publicBlockingStageLLM) GenerateStream(context.Context, []llm.Message, ...llm.GenerateOption) (llm.StreamMessage, error) {
+	return nil, errors.New("publicBlockingStageLLM: streaming not implemented")
 }
 
 func TestWithLLMExtractor_WiresExtractorIntoSavePath(t *testing.T) {
@@ -187,6 +204,42 @@ func TestWithLLMExtractor_TwoPassModeWiresTwoStepExtractor(t *testing.T) {
 	}
 	if len(fact.EvidenceRefs) != 1 || fact.EvidenceRefs[0].ID != "D1:3" {
 		t.Fatalf("two-pass evidence refs not persisted: %+v", fact.EvidenceRefs)
+	}
+}
+
+func TestWithLLMExtractor_TwoPassStageTimeoutOption(t *testing.T) {
+	store := temporalstore.NewMemoryStore()
+	client := publicBlockingStageLLM{stage: ingest.TwoPassFactExtractionPrompt}
+	mem, err := New(
+		WithTemporalStore(store),
+		WithLLMExtractor(
+			client,
+			WithLLMExtractionMode(LLMExtractionTwoPass),
+			WithLLMExtractorStageTimeout(20*time.Millisecond),
+		),
+	)
+	if err != nil {
+		t.Fatalf("new: %v", err)
+	}
+	defer mem.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	start := time.Now()
+	_, err = mem.Save(ctx, Scope{RuntimeID: "rt", UserID: "u1"}, SaveRequest{
+		Turns: []TurnContext{{ID: "D1:3", Role: "user", Text: "Alice likes Paris."}},
+	})
+	if err == nil {
+		t.Fatal("blocked two-pass content stage should fail save")
+	}
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("save error = %v, want context deadline exceeded", err)
+	}
+	if ctx.Err() != nil {
+		t.Fatalf("outer context should still be live, got %v", ctx.Err())
+	}
+	if elapsed := time.Since(start); elapsed >= time.Second {
+		t.Fatalf("stage timeout should cancel promptly, elapsed=%s", elapsed)
 	}
 }
 

--- a/memory/recall/options.go
+++ b/memory/recall/options.go
@@ -1,6 +1,8 @@
 package recall
 
 import (
+	"time"
+
 	"github.com/GizClaw/flowcraft/memory/recall/internal/governance"
 	"github.com/GizClaw/flowcraft/memory/recall/internal/ingest"
 	"github.com/GizClaw/flowcraft/memory/recall/internal/port"
@@ -76,6 +78,7 @@ type llmExtractorConfig struct {
 	schemaName   string
 	temperature  float64
 	extraOptions []llm.GenerateOption
+	stageTimeout time.Duration
 }
 
 func (c *llmExtractorConfig) build() port.Extractor {
@@ -97,6 +100,7 @@ func (c *llmExtractorConfig) build() port.Extractor {
 		}
 		ex.Temperature = c.temperature
 		ex.ExtraOptions = append(ex.ExtraOptions, c.extraOptions...)
+		ex.StageTimeout = c.stageTimeout
 		return ex
 	}
 	ex := ingest.NewLLMExtractor(c.client)
@@ -246,6 +250,17 @@ func WithLLMExtractorSchemaName(name string) LLMExtractorOption {
 func WithLLMExtractorExtraOptions(opts ...llm.GenerateOption) LLMExtractorOption {
 	return newLLMExtractorOption(func(c *llmExtractorConfig) {
 		c.extraOptions = append(c.extraOptions, opts...)
+	})
+}
+
+// WithLLMExtractorStageTimeout bounds each LLM Generate call made by the
+// two-pass extractor. Values <= 0 keep the historical caller-context-only
+// behaviour. Single-pass extraction is intentionally unchanged.
+func WithLLMExtractorStageTimeout(d time.Duration) LLMExtractorOption {
+	return newLLMExtractorOption(func(c *llmExtractorConfig) {
+		if d > 0 {
+			c.stageTimeout = d
+		}
 	})
 }
 


### PR DESCRIPTION
## Summary
Two-pass recall extraction can now give each structured LLM stage its own deadline, so one slow content, relation, evidence, assertion, or repair-triage call cannot consume the whole async semantic worker budget.

This adds a public `WithLLMExtractorStageTimeout` option for two-pass mode, applies it around every two-pass `Generate` call, and leaves single-pass extraction on its existing caller-context behavior.

Fixes #204

## Test Plan
- `go test ./memory/recall ./memory/recall/internal/ingest -run 'TestWithLLMExtractor_TwoPassStageTimeoutOption|TestTwoPassLLMExtractor_StageTimeoutCancelsBlockedGenerate|TestCoverageRepairTriageUsesStageTimeout|TestCoverageRepairTriageFiltersSelectedTurns'`
- `go test ./memory/recall/...`
