### PR TITLE
memory: add recall ops shutdown and bbh inspection

### DIFF
--- a/memory/recall/namespace.go
+++ b/memory/recall/namespace.go
@@ -1,0 +1,26 @@
+package recall
+
+import (
+	"strconv"
+	"strings"
+
+	retrievalns "github.com/GizClaw/flowcraft/memory/retrieval/namespace"
+)
+
+// NamespaceFor returns the v2 retrieval namespace for a memory scope.
+func NamespaceFor(s Scope) string {
+	rt := retrievalns.Sanitize(s.RuntimeID)
+	if s.UserID == "" {
+		return "recall_" + rt + "__global"
+	}
+	user := retrievalns.Sanitize(s.UserID)
+	var b strings.Builder
+	b.Grow(len("recall_") + len(rt) + len("__u") + 5 + 1 + len(user))
+	b.WriteString("recall_")
+	b.WriteString(rt)
+	b.WriteString("__u")
+	b.WriteString(strconv.Itoa(len(user)))
+	b.WriteByte('_')
+	b.WriteString(user)
+	return b.String()
+}

--- a/memory/recall/ops/runner.go
+++ b/memory/recall/ops/runner.go
@@ -60,7 +60,14 @@ func NewRunner(mem recall.Memory, opts ...Option) (*Runner, error) {
 
 // Run continuously drains the configured target until ctx is cancelled.
 func (r *Runner) Run(ctx context.Context, opts RunOptions) error {
+	return r.run(ctx, nil, opts)
+}
+
+func (r *Runner) run(ctx context.Context, stop <-chan struct{}, opts RunOptions) error {
 	for {
+		if stopped(stop) {
+			return nil
+		}
 		if err := ctx.Err(); err != nil {
 			return err
 		}
@@ -69,15 +76,18 @@ func (r *Runner) Run(ctx context.Context, opts RunOptions) error {
 			if errdefs.IsValidation(err) {
 				return err
 			}
-			if waitErr := sleepContext(ctx, r.cfg.ErrorBackoff); waitErr != nil {
+			if waitErr := sleepContext(ctx, stop, r.cfg.ErrorBackoff); waitErr != nil {
 				return waitErr
 			}
 			continue
 		}
+		if stopped(stop) {
+			return nil
+		}
 		if res.TotalClaimed() > 0 {
 			continue
 		}
-		if err := sleepContext(ctx, r.cfg.IdleInterval); err != nil {
+		if err := sleepContext(ctx, stop, r.cfg.IdleInterval); err != nil {
 			return err
 		}
 	}
@@ -152,13 +162,27 @@ func (r *Runner) emit(ctx context.Context, event Event) {
 	r.cfg.Metrics.ObserveRecallOps(ctx, event)
 }
 
-func sleepContext(ctx context.Context, d time.Duration) error {
+func stopped(stop <-chan struct{}) bool {
+	if stop == nil {
+		return false
+	}
+	select {
+	case <-stop:
+		return true
+	default:
+		return false
+	}
+}
+
+func sleepContext(ctx context.Context, stop <-chan struct{}, d time.Duration) error {
 	if d <= 0 {
 		return ctx.Err()
 	}
 	timer := time.NewTimer(d)
 	defer timer.Stop()
 	select {
+	case <-stop:
+		return nil
 	case <-ctx.Done():
 		return ctx.Err()
 	case <-timer.C:

--- a/memory/recall/ops/runner_test.go
+++ b/memory/recall/ops/runner_test.go
@@ -137,6 +137,58 @@ func TestSupervisorStartAndStop(t *testing.T) {
 	}
 }
 
+func TestSupervisorGracefulStopDoesNotCancelInflightDrain(t *testing.T) {
+	ctx := context.Background()
+	scope := recall.Scope{RuntimeID: "rt", UserID: "u1"}
+	started := make(chan struct{})
+	release := make(chan struct{})
+	done := make(chan struct{})
+	runner := &Runner{
+		side: blockingSideEffectProcessor{
+			started: started,
+			release: release,
+			done:    done,
+		},
+		cfg: Config{
+			WorkerID:           "test",
+			BatchSize:          1,
+			IdleInterval:       time.Hour,
+			ErrorBackoff:       time.Hour,
+			DrainSideEffects:   true,
+			DrainAsyncSemantic: false,
+			Now:                time.Now,
+		},
+	}
+	supervisor, err := Start(ctx, runner, Target{Scopes: []recall.Scope{scope}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	<-started
+	stopDone := make(chan error, 1)
+	go func() {
+		stopDone <- supervisor.GracefulStop(context.Background())
+	}()
+	select {
+	case err := <-stopDone:
+		t.Fatalf("GracefulStop returned before in-flight drain completed: %v", err)
+	case <-time.After(10 * time.Millisecond):
+	}
+	close(release)
+	select {
+	case err := <-stopDone:
+		if err != nil {
+			t.Fatalf("GracefulStop: %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("GracefulStop did not return after drain completed")
+	}
+	select {
+	case <-done:
+	default:
+		t.Fatal("processor did not finish")
+	}
+}
+
 func TestRunnerReadinessRuntimeUsesEnumerator(t *testing.T) {
 	ctx := context.Background()
 	mem, err := recall.New()
@@ -300,6 +352,23 @@ type durableParts struct {
 	store recall.TemporalStore
 	side  recall.SideEffectOutbox
 	async recall.AsyncSemanticQueue
+}
+
+type blockingSideEffectProcessor struct {
+	started chan<- struct{}
+	release <-chan struct{}
+	done    chan<- struct{}
+}
+
+func (p blockingSideEffectProcessor) ProcessSideEffects(ctx context.Context, opts recall.SideEffectProcessOptions) (recall.SideEffectProcessResult, error) {
+	close(p.started)
+	select {
+	case <-p.release:
+		close(p.done)
+		return recall.SideEffectProcessResult{Claimed: 1, Completed: 1}, nil
+	case <-ctx.Done():
+		return recall.SideEffectProcessResult{}, ctx.Err()
+	}
 }
 
 type staticEnumerator []recall.Scope

--- a/memory/recall/ops/supervisor.go
+++ b/memory/recall/ops/supervisor.go
@@ -10,6 +10,8 @@ import (
 // logging, and whether an error should restart the surrounding process.
 type Supervisor struct {
 	cancel context.CancelFunc
+	stop   chan struct{}
+	once   sync.Once
 	wg     sync.WaitGroup
 
 	mu   sync.Mutex
@@ -26,13 +28,13 @@ func Start(ctx context.Context, runner *Runner, targets ...Target) (*Supervisor,
 		return nil, validationf("at least one target is required")
 	}
 	ctx, cancel := context.WithCancel(ctx)
-	s := &Supervisor{cancel: cancel}
+	s := &Supervisor{cancel: cancel, stop: make(chan struct{})}
 	for _, target := range targets {
 		target := target
 		s.wg.Add(1)
 		go func() {
 			defer s.wg.Done()
-			if err := runner.Run(ctx, RunOptions{Target: target}); err != nil && ctx.Err() == nil {
+			if err := runner.run(ctx, s.stop, RunOptions{Target: target}); err != nil && ctx.Err() == nil {
 				s.addErr(err)
 				cancel()
 			}
@@ -47,8 +49,42 @@ func (s *Supervisor) Stop() error {
 	if s == nil {
 		return nil
 	}
+	s.once.Do(func() {
+		close(s.stop)
+	})
 	s.cancel()
 	s.wg.Wait()
+	return s.err()
+}
+
+// GracefulStop asks worker loops to stop before the next drain pass and waits
+// for any in-flight drain to finish without cancelling its context.
+func (s *Supervisor) GracefulStop(ctx context.Context) error {
+	if s == nil {
+		return nil
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	s.once.Do(func() {
+		close(s.stop)
+	})
+	done := make(chan struct{})
+	go func() {
+		s.wg.Wait()
+		close(done)
+	}()
+	select {
+	case <-done:
+		return s.err()
+	case <-ctx.Done():
+		s.cancel()
+		s.wg.Wait()
+		return ctx.Err()
+	}
+}
+
+func (s *Supervisor) err() error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	if len(s.errs) == 0 {

--- a/memory/retrieval/bbh/config.go
+++ b/memory/retrieval/bbh/config.go
@@ -58,6 +58,10 @@ type Duration struct {
 	time.Duration
 }
 
+func (d Duration) MarshalJSON() ([]byte, error) {
+	return json.Marshal(d.Duration.String())
+}
+
 func (d *Duration) UnmarshalJSON(raw []byte) error {
 	var s string
 	if err := json.Unmarshal(raw, &s); err == nil {
@@ -74,6 +78,10 @@ func (d *Duration) UnmarshalJSON(raw []byte) error {
 	}
 	d.Duration = time.Duration(n)
 	return nil
+}
+
+func (d Duration) MarshalYAML() (any, error) {
+	return d.Duration.String(), nil
 }
 
 func (d *Duration) UnmarshalYAML(value *yaml.Node) error {

--- a/memory/retrieval/bbh/doc.go
+++ b/memory/retrieval/bbh/doc.go
@@ -9,4 +9,7 @@
 // checkpointed by a per-namespace flush loop plus Close. It is intended as a
 // higher-performance local backend for recall's retrieval lens; the canonical
 // memory truth remains the recall TemporalStore.
+//
+// Inspector opens the same workspace read-only and reports discovered Badger,
+// Bleve, HNSW, and namespace statistics without constructing an Index.
 package bbh

--- a/memory/retrieval/bbh/index.go
+++ b/memory/retrieval/bbh/index.go
@@ -176,6 +176,15 @@ func (idx *Index) Capabilities() retrieval.Capabilities {
 // filter surface against Badger-loaded docs after candidate generation.
 func (idx *Index) SupportsFilter(retrieval.Filter) bool { return true }
 
+// WarmNamespace opens the path-backed Bleve and HNSW shard for namespace.
+func (idx *Index) WarmNamespace(ctx context.Context, namespace string) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	_, err := idx.ensureShard(namespace)
+	return err
+}
+
 func (idx *Index) ensureOpen() error {
 	if idx.closed.Load() {
 		return errdefs.NotAvailablef("retrieval/bbh: index is closed")

--- a/memory/retrieval/bbh/inspector.go
+++ b/memory/retrieval/bbh/inspector.go
@@ -1,0 +1,330 @@
+package bbh
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"sync/atomic"
+
+	"github.com/dgraph-io/badger/v4"
+
+	"github.com/GizClaw/flowcraft/memory/retrieval"
+	"github.com/GizClaw/flowcraft/sdk/errdefs"
+	sdkworkspace "github.com/GizClaw/flowcraft/sdk/workspace"
+)
+
+// Inspector provides read-only visibility into a BBH workspace.
+type Inspector struct {
+	root   string
+	db     *badger.DB
+	closed atomic.Bool
+}
+
+// Inspection is a point-in-time summary of the BBH workspace layout.
+type Inspection struct {
+	Root                   string                `json:"root"`
+	BadgerPath             string                `json:"badger_path"`
+	BlevePath              string                `json:"bleve_path"`
+	HNSWPath               string                `json:"hnsw_path"`
+	BadgerExists           bool                  `json:"badger_exists"`
+	BleveExists            bool                  `json:"bleve_exists"`
+	HNSWExists             bool                  `json:"hnsw_exists"`
+	BadgerSizeBytes        int64                 `json:"badger_size_bytes"`
+	BleveSizeBytes         int64                 `json:"bleve_size_bytes"`
+	HNSWSizeBytes          int64                 `json:"hnsw_size_bytes"`
+	PhysicalNamespaceCount int                   `json:"physical_namespace_count"`
+	DocNamespaceCount      int                   `json:"doc_namespace_count"`
+	TotalDocs              int64                 `json:"total_docs"`
+	TotalVectorDocs        int64                 `json:"total_vector_docs"`
+	Namespaces             []NamespaceInspection `json:"namespaces"`
+}
+
+// NamespaceInspection describes the physical index artifacts for one
+// namespace. Namespace is decoded from the BBH safe token when possible.
+type NamespaceInspection struct {
+	Namespace      string `json:"namespace"`
+	Token          string `json:"token"`
+	DecodeError    string `json:"decode_error,omitempty"`
+	DocCount       int64  `json:"doc_count"`
+	VectorDocCount int64  `json:"vector_doc_count"`
+	BadgerBytes    int64  `json:"badger_bytes"`
+	BlevePath      string `json:"bleve_path,omitempty"`
+	BleveExists    bool   `json:"bleve_exists"`
+	BleveSizeBytes int64  `json:"bleve_size_bytes"`
+	HNSWPath       string `json:"hnsw_path,omitempty"`
+	HNSWExists     bool   `json:"hnsw_exists"`
+	HNSWSizeBytes  int64  `json:"hnsw_size_bytes"`
+	Empty          bool   `json:"empty"`
+	SourceBadger   bool   `json:"source_badger"`
+	SourceBleve    bool   `json:"source_bleve"`
+	SourceHNSW     bool   `json:"source_hnsw"`
+}
+
+// NewInspector opens a read-only inspector rooted at a BBH workspace.
+func NewInspector(ws sdkworkspace.Workspace) (*Inspector, error) {
+	if ws == nil {
+		return nil, errdefs.Validationf("retrieval/bbh: workspace is nil")
+	}
+	lr, ok := ws.(localRoot)
+	if !ok {
+		return nil, errdefs.Validationf("retrieval/bbh: workspace must expose local Root()")
+	}
+	root := lr.Root()
+	in := &Inspector{root: root}
+	dbPath := filepath.Join(root, badgerDir)
+	info, err := os.Stat(dbPath)
+	switch {
+	case err == nil && !info.IsDir():
+		return nil, fmt.Errorf("retrieval/bbh: badger path is not a directory: %s", dbPath)
+	case err == nil:
+		db, err := badger.Open(badger.DefaultOptions(dbPath).WithLogger(nil).WithReadOnly(true))
+		if err != nil {
+			return nil, fmt.Errorf("retrieval/bbh: open badger inspector: %w", err)
+		}
+		in.db = db
+	case os.IsNotExist(err):
+	default:
+		return nil, fmt.Errorf("retrieval/bbh: stat badger path: %w", err)
+	}
+	return in, nil
+}
+
+// Close releases read-only resources held by the inspector.
+func (in *Inspector) Close() error {
+	if in == nil || !in.closed.CompareAndSwap(false, true) {
+		return nil
+	}
+	if in.db != nil {
+		return in.db.Close()
+	}
+	return nil
+}
+
+// Inspect returns a point-in-time summary of all discovered namespaces.
+func (in *Inspector) Inspect(ctx context.Context) (*Inspection, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	if err := in.ensureOpen(); err != nil {
+		return nil, err
+	}
+	out := &Inspection{
+		Root:       in.root,
+		BadgerPath: filepath.Join(in.root, badgerDir),
+		BlevePath:  filepath.Join(in.root, bleveDir),
+		HNSWPath:   filepath.Join(in.root, hnswDir),
+	}
+	out.BadgerExists, out.BadgerSizeBytes = pathSize(out.BadgerPath)
+	out.BleveExists, out.BleveSizeBytes = pathSize(out.BlevePath)
+	out.HNSWExists, out.HNSWSizeBytes = pathSize(out.HNSWPath)
+
+	namespaces := map[string]*NamespaceInspection{}
+	if err := in.inspectBadger(ctx, namespaces); err != nil {
+		return nil, err
+	}
+	if err := inspectBleveDirs(ctx, in.root, namespaces); err != nil {
+		return nil, err
+	}
+	if err := inspectHNSWFiles(ctx, in.root, namespaces); err != nil {
+		return nil, err
+	}
+
+	out.Namespaces = make([]NamespaceInspection, 0, len(namespaces))
+	for _, ns := range namespaces {
+		ns.Empty = ns.DocCount == 0 && ns.VectorDocCount == 0
+		out.TotalDocs += ns.DocCount
+		out.TotalVectorDocs += ns.VectorDocCount
+		if ns.DocCount > 0 {
+			out.DocNamespaceCount++
+		}
+		out.Namespaces = append(out.Namespaces, *ns)
+	}
+	out.PhysicalNamespaceCount = len(out.Namespaces)
+	sort.Slice(out.Namespaces, func(i, j int) bool {
+		if out.Namespaces[i].Namespace == out.Namespaces[j].Namespace {
+			return out.Namespaces[i].Token < out.Namespaces[j].Token
+		}
+		return out.Namespaces[i].Namespace < out.Namespaces[j].Namespace
+	})
+	return out, nil
+}
+
+// InspectNamespace returns inspection data for one namespace.
+func (in *Inspector) InspectNamespace(ctx context.Context, namespace string) (NamespaceInspection, error) {
+	if strings.TrimSpace(namespace) == "" {
+		return NamespaceInspection{}, errdefs.Validationf("retrieval/bbh: namespace is required")
+	}
+	inspection, err := in.Inspect(ctx)
+	if err != nil {
+		return NamespaceInspection{}, err
+	}
+	token := safeToken(namespace)
+	for _, ns := range inspection.Namespaces {
+		if ns.Token == token {
+			return ns, nil
+		}
+	}
+	return namespaceFromToken(token), nil
+}
+
+func (in *Inspector) ensureOpen() error {
+	if in == nil || in.closed.Load() {
+		return errdefs.NotAvailablef("retrieval/bbh: inspector is closed")
+	}
+	return nil
+}
+
+func (in *Inspector) inspectBadger(ctx context.Context, namespaces map[string]*NamespaceInspection) error {
+	if in.db == nil {
+		return nil
+	}
+	return in.db.View(func(txn *badger.Txn) error {
+		it := txn.NewIterator(badger.IteratorOptions{PrefetchValues: true})
+		defer it.Close()
+		prefix := []byte(badgerDocPrefix)
+		for it.Seek(prefix); it.ValidForPrefix(prefix); it.Next() {
+			if err := ctx.Err(); err != nil {
+				return err
+			}
+			key := string(it.Item().Key())
+			token, ok := namespaceTokenFromDocKey(key)
+			if !ok {
+				continue
+			}
+			ns := ensureNamespaceInspection(namespaces, token)
+			ns.SourceBadger = true
+			ns.DocCount++
+			ns.BadgerBytes += int64(len(key))
+			if err := it.Item().Value(func(v []byte) error {
+				ns.BadgerBytes += int64(len(v))
+				var d retrieval.Doc
+				if err := json.Unmarshal(v, &d); err != nil {
+					return err
+				}
+				if len(d.Vector) > 0 {
+					ns.VectorDocCount++
+				}
+				return nil
+			}); err != nil {
+				return err
+			}
+		}
+		return nil
+	})
+}
+
+func inspectBleveDirs(ctx context.Context, root string, namespaces map[string]*NamespaceInspection) error {
+	dir := filepath.Join(root, bleveDir)
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return fmt.Errorf("retrieval/bbh: read bleve dir: %w", err)
+	}
+	for _, entry := range entries {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		if !entry.IsDir() {
+			continue
+		}
+		token := entry.Name()
+		ns := ensureNamespaceInspection(namespaces, token)
+		ns.SourceBleve = true
+		ns.BleveExists = true
+		ns.BlevePath = filepath.Join(dir, token)
+		_, ns.BleveSizeBytes = pathSize(ns.BlevePath)
+	}
+	return nil
+}
+
+func inspectHNSWFiles(ctx context.Context, root string, namespaces map[string]*NamespaceInspection) error {
+	dir := filepath.Join(root, hnswDir)
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return fmt.Errorf("retrieval/bbh: read hnsw dir: %w", err)
+	}
+	for _, entry := range entries {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), hnswGraphExt) {
+			continue
+		}
+		token := strings.TrimSuffix(entry.Name(), hnswGraphExt)
+		ns := ensureNamespaceInspection(namespaces, token)
+		ns.SourceHNSW = true
+		ns.HNSWExists = true
+		ns.HNSWPath = filepath.Join(dir, entry.Name())
+		_, ns.HNSWSizeBytes = pathSize(ns.HNSWPath)
+	}
+	return nil
+}
+
+func ensureNamespaceInspection(namespaces map[string]*NamespaceInspection, token string) *NamespaceInspection {
+	if ns, ok := namespaces[token]; ok {
+		return ns
+	}
+	ns := namespaceFromToken(token)
+	namespaces[token] = &ns
+	return &ns
+}
+
+func namespaceFromToken(token string) NamespaceInspection {
+	raw, err := base64.RawURLEncoding.DecodeString(token)
+	if err != nil {
+		return NamespaceInspection{
+			Namespace:   token,
+			Token:       token,
+			DecodeError: err.Error(),
+		}
+	}
+	return NamespaceInspection{
+		Namespace: string(raw),
+		Token:     token,
+	}
+}
+
+func namespaceTokenFromDocKey(key string) (string, bool) {
+	if !strings.HasPrefix(key, badgerDocPrefix) {
+		return "", false
+	}
+	rest := strings.TrimPrefix(key, badgerDocPrefix)
+	token, _, ok := strings.Cut(rest, "/")
+	return token, ok && token != ""
+}
+
+func pathSize(path string) (bool, int64) {
+	var total int64
+	err := filepath.WalkDir(path, func(_ string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		info, err := d.Info()
+		if err != nil {
+			return err
+		}
+		if !info.IsDir() {
+			total += info.Size()
+		}
+		return nil
+	})
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) || os.IsNotExist(err) {
+			return false, 0
+		}
+		return true, total
+	}
+	return true, total
+}

--- a/memory/retrieval/bbh/inspector_test.go
+++ b/memory/retrieval/bbh/inspector_test.go
@@ -1,0 +1,158 @@
+package bbh
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/GizClaw/flowcraft/memory/retrieval"
+	sdkworkspace "github.com/GizClaw/flowcraft/sdk/workspace"
+)
+
+func TestInspectorValidationAndEmptyWorkspace(t *testing.T) {
+	if _, err := NewInspector(nil); err == nil {
+		t.Fatal("nil workspace should fail")
+	}
+	if _, err := NewInspector(sdkworkspace.NewMemWorkspace()); err == nil {
+		t.Fatal("workspace without Root should fail")
+	}
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, badgerDir), []byte("not a dir"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := NewInspector(rootedWorkspace(t, dir)); err == nil {
+		t.Fatal("badger file should fail")
+	}
+
+	empty := t.TempDir()
+	in, err := NewInspector(rootedWorkspace(t, empty))
+	if err != nil {
+		t.Fatalf("NewInspector empty: %v", err)
+	}
+	got, err := in.Inspect(context.Background())
+	if err != nil {
+		t.Fatalf("Inspect empty: %v", err)
+	}
+	if got.Root != empty || got.BadgerExists || got.BleveExists || got.HNSWExists {
+		t.Fatalf("unexpected empty inspection: %+v", got)
+	}
+	if len(got.Namespaces) != 0 || got.TotalDocs != 0 {
+		t.Fatalf("unexpected empty namespaces: %+v", got)
+	}
+	if err := in.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := in.Inspect(context.Background()); err == nil {
+		t.Fatal("inspect after close should fail")
+	}
+}
+
+func TestInspectorReportsNamespaces(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	idx := openInternalIndex(t, dir, WithConfig(Config{
+		HNSW: HNSWConfig{FlushInterval: Duration{Duration: time.Hour}},
+	}))
+	if err := idx.Upsert(ctx, "runtime/user/agent-a", []retrieval.Doc{
+		{ID: "a", Content: "alpha", Vector: []float32{1, 0}, Timestamp: time.Unix(1, 0).UTC()},
+		{ID: "b", Content: "beta", Timestamp: time.Unix(2, 0).UTC()},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := idx.Upsert(ctx, "runtime/user/agent-b", []retrieval.Doc{
+		{ID: "c", Content: "gamma", Vector: []float32{0, 1}, Timestamp: time.Unix(3, 0).UTC()},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := idx.Search(ctx, "empty/shard", retrieval.SearchRequest{QueryText: "nothing"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := idx.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	in, err := NewInspector(rootedWorkspace(t, dir))
+	if err != nil {
+		t.Fatalf("NewInspector: %v", err)
+	}
+	defer func() {
+		if err := in.Close(); err != nil {
+			t.Fatal(err)
+		}
+	}()
+	got, err := in.Inspect(ctx)
+	if err != nil {
+		t.Fatalf("Inspect: %v", err)
+	}
+	if !got.BadgerExists || !got.BleveExists || !got.HNSWExists {
+		t.Fatalf("expected all storage roots, got %+v", got)
+	}
+	if got.TotalDocs != 3 || got.TotalVectorDocs != 2 {
+		t.Fatalf("totals = docs %d vectors %d, want 3/2", got.TotalDocs, got.TotalVectorDocs)
+	}
+	if got.PhysicalNamespaceCount != 3 || got.DocNamespaceCount != 2 {
+		t.Fatalf("namespace counts = physical %d doc %d, want 3/2", got.PhysicalNamespaceCount, got.DocNamespaceCount)
+	}
+
+	a := mustInspectNamespace(t, in, "runtime/user/agent-a")
+	if a.DocCount != 2 || a.VectorDocCount != 1 {
+		t.Fatalf("agent-a counts = %+v", a)
+	}
+	if !a.SourceBadger || !a.SourceBleve || !a.SourceHNSW || !a.BleveExists || !a.HNSWExists {
+		t.Fatalf("agent-a sources = %+v", a)
+	}
+	if a.BadgerBytes <= 0 || a.BleveSizeBytes <= 0 || a.HNSWSizeBytes <= 0 {
+		t.Fatalf("agent-a sizes = %+v", a)
+	}
+
+	empty := mustInspectNamespace(t, in, "empty/shard")
+	if empty.DocCount != 0 || !empty.SourceBleve || !empty.Empty {
+		t.Fatalf("empty shard = %+v", empty)
+	}
+
+	missing, err := in.InspectNamespace(ctx, "missing")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if missing.Namespace != "missing" || missing.Token != safeToken("missing") || missing.DocCount != 0 {
+		t.Fatalf("missing namespace = %+v", missing)
+	}
+}
+
+func TestInspectorHandlesInvalidPhysicalToken(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dir, bleveDir, "not@base64"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	in, err := NewInspector(rootedWorkspace(t, dir))
+	if err != nil {
+		t.Fatalf("NewInspector: %v", err)
+	}
+	defer func() {
+		if err := in.Close(); err != nil {
+			t.Fatal(err)
+		}
+	}()
+	got, err := in.Inspect(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got.Namespaces) != 1 {
+		t.Fatalf("namespaces = %+v", got.Namespaces)
+	}
+	ns := got.Namespaces[0]
+	if ns.Namespace != "not@base64" || ns.DecodeError == "" || !ns.SourceBleve {
+		t.Fatalf("invalid token namespace = %+v", ns)
+	}
+}
+
+func mustInspectNamespace(t *testing.T, in *Inspector, namespace string) NamespaceInspection {
+	t.Helper()
+	got, err := in.InspectNamespace(context.Background(), namespace)
+	if err != nil {
+		t.Fatalf("InspectNamespace %s: %v", namespace, err)
+	}
+	return got
+}


### PR DESCRIPTION
## Summary
- add graceful recall ops supervisor shutdown without canceling in-flight drains
- add stable recall scope namespace helper
- add BBH namespace warmup and read-only inspection helpers

## Tests
- go test ./memory/recall/ops
- go test ./memory/retrieval/bbh
- go test ./memory/recall