### PR TITLE
llm: add MiniMax OAI provider and DeepSeek thinking

### DIFF
--- a/sdkx/llm/anthropic/anthropic_test.go
+++ b/sdkx/llm/anthropic/anthropic_test.go
@@ -205,6 +205,28 @@ func TestGenerate_NilResp_NoPanic(t *testing.T) {
 	}
 }
 
+func TestGenerate_ThinkingFalseDisablesThinkingOnWire(t *testing.T) {
+	ts, cap := newCaptureServer(t)
+	c, err := New("claude-3-sonnet-20240229", "test-key", ts.URL, nil)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	_, _, err = c.Generate(
+		context.Background(),
+		[]llm.Message{llm.NewTextMessage(llm.RoleUser, "hi")},
+		llm.WithThinking(false),
+	)
+	if err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+
+	rb := decodeBody(t, cap.body)
+	if rb.Thinking["type"] != "disabled" {
+		t.Fatalf("thinking = %#v, want type=disabled; body=%s", rb.Thinking, cap.body)
+	}
+}
+
 // TestGenerateStream_TransportError verifies the streaming path
 // doesn't panic on a degraded server. The anthropic-sdk-go
 // NewStreaming always allocates the stream struct so a literal

--- a/sdkx/llm/anthropic/cache_integration_test.go
+++ b/sdkx/llm/anthropic/cache_integration_test.go
@@ -58,7 +58,8 @@ func newCaptureServer(t *testing.T) (*httptest.Server, *capturedRequest) {
 // SDK Marshal output is JSON-compatible with the public API shape, so
 // we decode straight into this; unknown fields are ignored.
 type requestBody struct {
-	System []struct {
+	Thinking map[string]interface{} `json:"thinking,omitempty"`
+	System   []struct {
 		Type         string                 `json:"type"`
 		Text         string                 `json:"text"`
 		CacheControl map[string]interface{} `json:"cache_control,omitempty"`

--- a/sdkx/llm/deepseek/deepseek.go
+++ b/sdkx/llm/deepseek/deepseek.go
@@ -53,6 +53,11 @@ func init() {
 		llm.CapJSONSchema, llm.CapVision, llm.CapAudio, llm.CapFile,
 		llm.CapImageOutput, llm.CapAudioOutput,
 	)
+	nonThinkingDefaults := llm.GenerateOptions{
+		Extra: map[string]any{
+			"thinking": map[string]any{"type": "disabled"},
+		},
+	}
 
 	llm.RegisterProviderModels("deepseek", []llm.ModelInfo{
 		// --- V4 series (current) -------------------------------------
@@ -63,7 +68,8 @@ func init() {
 			Label: "DeepSeek V4 Flash",
 			Name:  "deepseek-v4-flash",
 			Spec: llm.ModelSpec{
-				Caps: deepseekTextOnly,
+				Caps:     deepseekTextOnly,
+				Defaults: nonThinkingDefaults,
 				Limits: llm.ModelLimits{
 					MaxContextTokens: 1_000_000,
 					MaxOutputTokens:  384_000,
@@ -78,7 +84,8 @@ func init() {
 			Label: "DeepSeek V4 Pro",
 			Name:  "deepseek-v4-pro",
 			Spec: llm.ModelSpec{
-				Caps: deepseekTextOnly,
+				Caps:     deepseekTextOnly,
+				Defaults: nonThinkingDefaults,
 				Limits: llm.ModelLimits{
 					MaxContextTokens: 1_000_000,
 					MaxOutputTokens:  384_000,
@@ -170,5 +177,11 @@ func New(model, apiKey, baseURL string) (*openai.LLM, error) {
 	// is observable as its own bucket instead of getting silently
 	// aggregated under "openai" (the upstream HTTP transport). See
 	// sdkx/llm/openai/openai.go ▸ WithProviderName.
-	return inner.WithProviderName("deepseek"), nil
+	return inner.WithProviderName("deepseek").WithThinkingMapper(func(on bool) (string, any) {
+		typ := "disabled"
+		if on {
+			typ = "enabled"
+		}
+		return "thinking", map[string]any{"type": typ}
+	}), nil
 }

--- a/sdkx/llm/deepseek/provider_test.go
+++ b/sdkx/llm/deepseek/provider_test.go
@@ -1,16 +1,120 @@
 package deepseek
 
-import "testing"
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/GizClaw/flowcraft/sdk/llm"
+)
 
 // TestNewTagsProvider locks down the sub-provider plumbing: deepseek
 // must call openai.LLM.WithProviderName so traces/metrics from DeepSeek
 // traffic land under "deepseek" rather than the upstream "openai" tag.
 func TestNewTagsProvider(t *testing.T) {
-	c, err := New("deepseek-chat", "k", "")
+	c, err := New("deepseek-v4-flash", "k", "")
 	if err != nil {
 		t.Fatalf("New: %v", err)
 	}
 	if got := c.Provider(); got != "deepseek" {
 		t.Fatalf("Provider() = %q, want deepseek", got)
 	}
+}
+
+func TestCatalogDefaultsDisableThinking(t *testing.T) {
+	for _, model := range []string{"deepseek-v4-flash", "deepseek-v4-pro"} {
+		spec := llm.DefaultRegistry.LookupModelSpec("deepseek", model)
+		thinking, ok := spec.Defaults.Extra["thinking"].(map[string]any)
+		if !ok {
+			t.Fatalf("%s thinking default = %#v, want object", model, spec.Defaults.Extra["thinking"])
+		}
+		if got := thinking["type"]; got != "disabled" {
+			t.Fatalf("%s thinking.type = %#v, want disabled", model, got)
+		}
+	}
+}
+
+func TestGenerate_WithThinkingMapsToDeepSeekBody(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		opt  llm.GenerateOption
+		want string
+	}{
+		{name: "enabled", opt: llm.WithThinking(true), want: "enabled"},
+		{name: "disabled", opt: llm.WithThinking(false), want: "disabled"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			c, captured := newDeepSeekCaptureClient(t)
+			_, _, err := c.Generate(context.Background(), []llm.Message{
+				llm.NewTextMessage(llm.RoleUser, "hi"),
+			}, tc.opt)
+			if err != nil {
+				t.Fatalf("Generate: %v", err)
+			}
+			body := readDeepSeekCapturedBody(t, captured)
+			thinking, ok := body["thinking"].(map[string]any)
+			if !ok {
+				t.Fatalf("thinking body field = %#v, want object; body=%#v", body["thinking"], body)
+			}
+			if got := thinking["type"]; got != tc.want {
+				t.Fatalf("thinking.type = %#v, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestGenerate_CatalogDefaultDisablesDeepSeekThinkingOnWire(t *testing.T) {
+	c, captured := newDeepSeekCaptureClient(t)
+	spec := llm.DefaultRegistry.LookupModelSpec("deepseek", "deepseek-v4-flash")
+	wrapped := llm.WithDefaults(c, spec.Defaults)
+	_, _, err := wrapped.Generate(context.Background(), []llm.Message{
+		llm.NewTextMessage(llm.RoleUser, "hi"),
+	})
+	if err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+	body := readDeepSeekCapturedBody(t, captured)
+	thinking, ok := body["thinking"].(map[string]any)
+	if !ok {
+		t.Fatalf("thinking body field = %#v, want object; body=%#v", body["thinking"], body)
+	}
+	if got := thinking["type"]; got != "disabled" {
+		t.Fatalf("thinking.type = %#v, want disabled", got)
+	}
+}
+
+func newDeepSeekCaptureClient(t *testing.T) (llm.LLM, <-chan map[string]any) {
+	t.Helper()
+	captured := make(chan map[string]any, 1)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		raw, _ := io.ReadAll(r.Body)
+		var body map[string]any
+		if err := json.Unmarshal(raw, &body); err != nil {
+			t.Fatalf("decode request body: %v\nbody=%s", err, raw)
+		}
+		captured <- body
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"id":"chatcmpl-test","object":"chat.completion","choices":[{"index":0,"message":{"role":"assistant","content":"ok"},"finish_reason":"stop"}],"usage":{"prompt_tokens":1,"completion_tokens":1,"total_tokens":2}}`)
+	}))
+	t.Cleanup(srv.Close)
+	c, err := New("deepseek-v4-flash", "k", srv.URL)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	return c, captured
+}
+
+func readDeepSeekCapturedBody(t *testing.T, captured <-chan map[string]any) map[string]any {
+	t.Helper()
+	select {
+	case body := <-captured:
+		return body
+	case <-time.After(time.Second):
+		t.Fatal("server did not capture request body")
+	}
+	return nil
 }

--- a/sdkx/llm/minimax/openai.go
+++ b/sdkx/llm/minimax/openai.go
@@ -1,0 +1,109 @@
+// Package minimax registers MiniMax's Anthropic-compatible and
+// OpenAI-compatible LLM providers.
+package minimax
+
+import (
+	"github.com/GizClaw/flowcraft/sdk/llm"
+	openaiadapter "github.com/GizClaw/flowcraft/sdkx/llm/openai"
+)
+
+func init() {
+	llm.RegisterProvider("minimax-oai", func(model string, config map[string]any) (llm.LLM, error) {
+		apiKey, _ := config["api_key"].(string)
+		baseURL, _ := config["base_url"].(string)
+		return NewOpenAI(model, apiKey, baseURL)
+	})
+
+	// MiniMax's OpenAI-compatible endpoint works with openai-go for chat
+	// completions. Do not advertise JSON mode or default reasoning_split
+	// here: M2.x response_format support is unreliable, and
+	// reasoning_split requires preserving reasoning_details in history.
+	textOnlyOpenAIStyle := llm.DisabledCaps(
+		llm.CapVision, llm.CapAudio, llm.CapFile,
+		llm.CapJSONSchema, llm.CapJSONMode,
+		llm.CapImageOutput, llm.CapAudioOutput,
+	)
+
+	llm.RegisterProviderModels("minimax-oai", []llm.ModelInfo{
+		{
+			Label: "MiniMax-M2.7",
+			Name:  "MiniMax-M2.7",
+			Spec: llm.ModelSpec{
+				Caps: textOnlyOpenAIStyle,
+				Limits: llm.ModelLimits{
+					MaxContextTokens: 204_800,
+					MaxOutputTokens:  131_072,
+				},
+			},
+		},
+		{
+			Label: "MiniMax-M2.7 HighSpeed",
+			Name:  "MiniMax-M2.7-highspeed",
+			Spec: llm.ModelSpec{
+				Caps: textOnlyOpenAIStyle,
+				Limits: llm.ModelLimits{
+					MaxContextTokens: 204_800,
+					MaxOutputTokens:  131_072,
+				},
+			},
+		},
+		{
+			Label: "MiniMax-M2.5",
+			Name:  "MiniMax-M2.5",
+			Spec: llm.ModelSpec{
+				Caps:   textOnlyOpenAIStyle,
+				Limits: llm.ModelLimits{MaxContextTokens: 204_800},
+			},
+		},
+		{
+			Label: "MiniMax-M2.5 HighSpeed",
+			Name:  "MiniMax-M2.5-highspeed",
+			Spec: llm.ModelSpec{
+				Caps:   textOnlyOpenAIStyle,
+				Limits: llm.ModelLimits{MaxContextTokens: 204_800},
+			},
+		},
+		{
+			Label: "MiniMax-M2.1",
+			Name:  "MiniMax-M2.1",
+			Spec: llm.ModelSpec{
+				Caps:   textOnlyOpenAIStyle,
+				Limits: llm.ModelLimits{MaxContextTokens: 204_800},
+			},
+		},
+		{
+			Label: "MiniMax-M2.1 HighSpeed",
+			Name:  "MiniMax-M2.1-highspeed",
+			Spec: llm.ModelSpec{
+				Caps:   textOnlyOpenAIStyle,
+				Limits: llm.ModelLimits{MaxContextTokens: 204_800},
+			},
+		},
+		{
+			Label: "MiniMax-M2",
+			Name:  "MiniMax-M2",
+			Spec: llm.ModelSpec{
+				Caps:   textOnlyOpenAIStyle,
+				Limits: llm.ModelLimits{MaxContextTokens: 204_800},
+			},
+		},
+	})
+}
+
+const defaultOpenAIBaseURL = "https://api.minimax.io/v1"
+
+// NewOpenAI creates a MiniMax LLM instance through MiniMax's
+// OpenAI-compatible chat completions endpoint.
+func NewOpenAI(model, apiKey, baseURL string) (*openaiadapter.LLM, error) {
+	if baseURL == "" {
+		baseURL = defaultOpenAIBaseURL
+	}
+	if model == "" {
+		model = defaultModel
+	}
+	inner, err := openaiadapter.New(model, apiKey, baseURL)
+	if err != nil {
+		return nil, err
+	}
+	return inner.WithProviderName("minimax-oai"), nil
+}

--- a/sdkx/llm/minimax/provider_test.go
+++ b/sdkx/llm/minimax/provider_test.go
@@ -1,17 +1,64 @@
 package minimax
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/GizClaw/flowcraft/sdk/llm"
+)
 
 // TestNewTagsProvider locks down the sub-provider plumbing: minimax
 // must call anthropic.LLM.WithProviderName so traces/metrics from
 // MiniMax traffic land under "minimax" rather than the upstream
 // "anthropic" tag.
 func TestNewTagsProvider(t *testing.T) {
-	c, err := New("MiniMax-M2.5", "k", "")
+	c, err := New("MiniMax-M2.7-highspeed", "k", "")
 	if err != nil {
 		t.Fatalf("New: %v", err)
 	}
 	if got := c.Provider(); got != "minimax" {
 		t.Fatalf("Provider() = %q, want minimax", got)
+	}
+}
+
+func TestNewOpenAITagsProvider(t *testing.T) {
+	c, err := NewOpenAI("MiniMax-M2.7-highspeed", "k", "")
+	if err != nil {
+		t.Fatalf("NewOpenAI: %v", err)
+	}
+	if got := c.Provider(); got != "minimax-oai" {
+		t.Fatalf("Provider() = %q, want minimax-oai", got)
+	}
+}
+
+func TestOpenAICompatibleProviderRegistered(t *testing.T) {
+	c, err := llm.NewFromConfig("minimax-oai", "MiniMax-M2.7-highspeed", map[string]any{
+		"api_key": "k",
+	})
+	if err != nil {
+		t.Fatalf("NewFromConfig: %v", err)
+	}
+	tagged, ok := c.(interface{ Provider() string })
+	if !ok {
+		t.Fatalf("client does not expose Provider()")
+	}
+	if got := tagged.Provider(); got != "minimax-oai" {
+		t.Fatalf("Provider() = %q, want minimax-oai", got)
+	}
+}
+
+func TestOpenAICompatibleCatalogDisablesJSONFormatting(t *testing.T) {
+	spec := llm.DefaultRegistry.LookupModelSpec("minimax-oai", "MiniMax-M2.7-highspeed")
+	if spec.Caps.Supports(llm.CapJSONSchema) {
+		t.Fatal("minimax-oai M2.7 must not advertise JSON schema support")
+	}
+	if spec.Caps.Supports(llm.CapJSONMode) {
+		t.Fatal("minimax-oai M2.7 must not advertise JSON mode support")
+	}
+}
+
+func TestOpenAICompatibleCatalogDoesNotDefaultReasoningSplit(t *testing.T) {
+	spec := llm.DefaultRegistry.LookupModelSpec("minimax-oai", "MiniMax-M2.7-highspeed")
+	if _, ok := spec.Defaults.Extra["reasoning_split"]; ok {
+		t.Fatalf("reasoning_split default = %v, want absent", spec.Defaults.Extra["reasoning_split"])
 	}
 }

--- a/sdkx/llm/openai/openai.go
+++ b/sdkx/llm/openai/openai.go
@@ -277,6 +277,11 @@ type LLM struct {
 	// silently aggregated under "openai". Same story on the Anthropic
 	// side via sdkx/llm/minimax.
 	provider string
+
+	// thinkingMapper lets OpenAI-compatible sub-providers translate
+	// llm.WithThinking into their provider-specific JSON body field.
+	// Direct OpenAI calls leave this nil.
+	thinkingMapper func(bool) (string, any)
 }
 
 var _ llm.LLM = (*LLM)(nil)
@@ -316,6 +321,15 @@ func (c *LLM) WithProviderName(name string) *LLM {
 	return c
 }
 
+// WithThinkingMapper installs a provider-specific mapper for llm.WithThinking.
+// The mapper returns the JSON body key and value to add through Extra.
+func (c *LLM) WithThinkingMapper(mapper func(bool) (string, any)) *LLM {
+	if c != nil {
+		c.thinkingMapper = mapper
+	}
+	return c
+}
+
 // Provider returns the OTel / metrics tag used by this instance. Mostly
 // a debugging aid; exported so eval drivers and observability dashboards
 // can introspect what name they'll see in traces.
@@ -334,6 +348,7 @@ func (c *LLM) Generate(ctx context.Context, messages []llm.Message, opts ...llm.
 	))
 	defer span.End()
 
+	opts = c.injectProviderOptions(opts)
 	options := llm.ApplyOptions(opts...)
 	params := c.buildParams(messages, options)
 
@@ -345,7 +360,7 @@ func (c *LLM) Generate(ctx context.Context, messages []llm.Message, opts ...llm.
 		span.SetStatus(codes.Error, err.Error())
 		llm.RecordLLMMetrics(ctx, provider, c.model, "error", dur, llm.TokenUsage{})
 		if ctx.Err() != nil {
-			return llm.Message{}, llm.TokenUsage{}, errdefs.Timeoutf("%s.generate: %s", provider, dur.String())
+			return llm.Message{}, llm.TokenUsage{}, errdefs.FromContext(fmt.Errorf("%s.generate: %s: %w", provider, dur.String(), err))
 		}
 		return llm.Message{}, llm.TokenUsage{}, c.classifyAPIError(err)
 	}
@@ -401,6 +416,7 @@ func (c *LLM) GenerateStream(ctx context.Context, messages []llm.Message, opts .
 		attribute.String(telemetry.AttrLLMModel, c.model),
 	))
 
+	opts = c.injectProviderOptions(opts)
 	options := llm.ApplyOptions(opts...)
 	params := c.buildParams(messages, options)
 	params.StreamOptions = oai.ChatCompletionStreamOptionsParam{
@@ -442,6 +458,21 @@ func (c *LLM) GenerateStream(ctx context.Context, messages []llm.Message, opts .
 	}
 
 	return newStreamMessage(ctx, span, provider, c.model, stream), nil
+}
+
+func (c *LLM) injectProviderOptions(opts []llm.GenerateOption) []llm.GenerateOption {
+	if c == nil || c.thinkingMapper == nil {
+		return opts
+	}
+	o := llm.ApplyOptions(opts...)
+	if o.Thinking == nil {
+		return opts
+	}
+	key, value := c.thinkingMapper(*o.Thinking)
+	if key == "" {
+		return opts
+	}
+	return append(opts, llm.WithExtra(key, value))
 }
 
 // extraRequestOpts converts GenerateOptions.Extra into per-request

--- a/sdkx/llm/openai/openai.go
+++ b/sdkx/llm/openai/openai.go
@@ -424,6 +424,7 @@ func (c *LLM) GenerateStream(ctx context.Context, messages []llm.Message, opts .
 	}
 
 	reqOpts := extraRequestOpts(options)
+	start := time.Now()
 	stream := c.client.Chat.Completions.NewStreaming(ctx, params, reqOpts...)
 	// NewStreaming may return nil if the SDK fails before allocating the
 	// SSE handle (HTTP transport dial failure, panic recovery, etc.).
@@ -439,6 +440,13 @@ func (c *LLM) GenerateStream(ctx context.Context, messages []llm.Message, opts .
 		return nil, err
 	}
 	if err := stream.Err(); err != nil {
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			err = errdefs.FromContext(fmt.Errorf("%s.stream: %s: %w: %w", provider, time.Since(start).String(), err, ctxErr))
+			span.RecordError(err)
+			span.SetStatus(codes.Error, err.Error())
+			span.End()
+			return nil, err
+		}
 		// Some OpenAI-compatible providers don't support stream_options; retry without it.
 		params.StreamOptions = oai.ChatCompletionStreamOptionsParam{}
 		stream = c.client.Chat.Completions.NewStreaming(ctx, params, reqOpts...)
@@ -450,6 +458,13 @@ func (c *LLM) GenerateStream(ctx context.Context, messages []llm.Message, opts .
 			return nil, err
 		}
 		if err2 := stream.Err(); err2 != nil {
+			if ctxErr := ctx.Err(); ctxErr != nil {
+				err2 = errdefs.FromContext(fmt.Errorf("%s.stream: %s: %w: %w", provider, time.Since(start).String(), err2, ctxErr))
+				span.RecordError(err2)
+				span.SetStatus(codes.Error, err2.Error())
+				span.End()
+				return nil, err2
+			}
 			span.RecordError(err2)
 			span.SetStatus(codes.Error, err2.Error())
 			span.End()

--- a/sdkx/llm/openai/openai_test.go
+++ b/sdkx/llm/openai/openai_test.go
@@ -2,11 +2,13 @@ package openai
 
 import (
 	"context"
+	"errors"
 	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/GizClaw/flowcraft/sdk/errdefs"
 	"github.com/GizClaw/flowcraft/sdk/llm"
@@ -81,6 +83,48 @@ func TestGenerate_EmptyChoices(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "no choices") {
 		t.Errorf("error message should mention choices, got %q", err.Error())
+	}
+}
+
+func TestGenerate_ContextCanceledPreservesAbortedClassification(t *testing.T) {
+	c, err := New("test-model", "test-key", "http://127.0.0.1:1", option.WithMaxRetries(0))
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, _, err = c.Generate(ctx, []llm.Message{llm.NewTextMessage(llm.RoleUser, "hi")})
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !errdefs.IsAborted(err) {
+		t.Fatalf("expected Aborted kind, got %v", err)
+	}
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("error lost context.Canceled identity: %v", err)
+	}
+}
+
+func TestGenerate_ContextDeadlinePreservesTimeoutClassification(t *testing.T) {
+	c, err := New("test-model", "test-key", "http://127.0.0.1:1", option.WithMaxRetries(0))
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(-time.Second))
+	defer cancel()
+
+	_, _, err = c.Generate(ctx, []llm.Message{llm.NewTextMessage(llm.RoleUser, "hi")})
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !errdefs.IsTimeout(err) {
+		t.Fatalf("expected Timeout kind, got %v", err)
+	}
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("error lost context.DeadlineExceeded identity: %v", err)
 	}
 }
 

--- a/sdkx/llm/openai/openai_test.go
+++ b/sdkx/llm/openai/openai_test.go
@@ -128,6 +128,48 @@ func TestGenerate_ContextDeadlinePreservesTimeoutClassification(t *testing.T) {
 	}
 }
 
+func TestGenerateStream_ContextCanceledPreservesAbortedClassification(t *testing.T) {
+	c, err := New("test-model", "test-key", "http://127.0.0.1:1", option.WithMaxRetries(0))
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err = c.GenerateStream(ctx, []llm.Message{llm.NewTextMessage(llm.RoleUser, "hi")})
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !errdefs.IsAborted(err) {
+		t.Fatalf("expected Aborted kind, got %v", err)
+	}
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("error lost context.Canceled identity: %v", err)
+	}
+}
+
+func TestGenerateStream_ContextDeadlinePreservesTimeoutClassification(t *testing.T) {
+	c, err := New("test-model", "test-key", "http://127.0.0.1:1", option.WithMaxRetries(0))
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(-time.Second))
+	defer cancel()
+
+	_, err = c.GenerateStream(ctx, []llm.Message{llm.NewTextMessage(llm.RoleUser, "hi")})
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !errdefs.IsTimeout(err) {
+		t.Fatalf("expected Timeout kind, got %v", err)
+	}
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("error lost context.DeadlineExceeded identity: %v", err)
+	}
+}
+
 // TestGenerateStream_NilStream covers the streaming sibling of the
 // nil-resp guard. We simulate a transport-level dial failure by
 // pointing the client at a closed socket so NewStreaming gives back

--- a/sdkx/llm/openai/stream.go
+++ b/sdkx/llm/openai/stream.go
@@ -2,6 +2,7 @@ package openai
 
 import (
 	"context"
+	"fmt"
 	"sort"
 	"strings"
 	"sync"
@@ -68,7 +69,11 @@ func (s *openaiStreamMessage) Next() bool {
 		if !s.stream.Next() {
 			err := s.stream.Err()
 			if err != nil {
-				err = classifyAPIErrorWithProvider(s.provider, err)
+				if ctxErr := s.baseCtx.Err(); ctxErr != nil {
+					err = errdefs.FromContext(fmt.Errorf("%s.stream: %s: %w: %w", s.provider, time.Since(s.start).String(), err, ctxErr))
+				} else {
+					err = classifyAPIErrorWithProvider(s.provider, err)
+				}
 			}
 			s.mu.Lock()
 			s.err = err


### PR DESCRIPTION
## Summary
- register MiniMax OpenAI-compatible minimax-oai provider for chat-completions workloads
- keep MiniMax OAI conservative: no default reasoning_split and no advertised JSON mode/schema support
- wrap DeepSeek OpenAI-compatible client so llm.WithThinking maps to the provider thinking body field
- preserve OpenAI context cancellation/deadline classification via errdefs.FromContext

## Tests
- go test ./sdk/llm ./sdkx/llm/...