### PR TITLE
retrieval/bbh: inspect persisted namespace shards

### DIFF
--- a/memory/retrieval/bbh/config.go
+++ b/memory/retrieval/bbh/config.go
@@ -58,6 +58,11 @@ type Duration struct {
 	time.Duration
 }
 
+// MarshalJSON encodes Duration using Go's duration string format.
+func (d Duration) MarshalJSON() ([]byte, error) {
+	return json.Marshal(d.Duration.String())
+}
+
 func (d *Duration) UnmarshalJSON(raw []byte) error {
 	var s string
 	if err := json.Unmarshal(raw, &s); err == nil {
@@ -74,6 +79,11 @@ func (d *Duration) UnmarshalJSON(raw []byte) error {
 	}
 	d.Duration = time.Duration(n)
 	return nil
+}
+
+// MarshalYAML encodes Duration using Go's duration string format.
+func (d Duration) MarshalYAML() (any, error) {
+	return d.Duration.String(), nil
 }
 
 func (d *Duration) UnmarshalYAML(value *yaml.Node) error {

--- a/memory/retrieval/bbh/config_test.go
+++ b/memory/retrieval/bbh/config_test.go
@@ -56,6 +56,26 @@ func TestDurationUnmarshalJSONAndYAML(t *testing.T) {
 	}
 }
 
+func TestDurationMarshalJSONAndYAML(t *testing.T) {
+	d := Duration{Duration: 1500 * time.Millisecond}
+	raw, err := json.Marshal(d)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(raw) != `"1.5s"` {
+		t.Fatalf("json marshal = %s, want %q", raw, `"1.5s"`)
+	}
+	yraw, err := yaml.Marshal(struct {
+		D Duration `yaml:"d"`
+	}{D: d})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(yraw) != "d: 1.5s\n" {
+		t.Fatalf("yaml marshal = %q, want %q", string(yraw), "d: 1.5s\n")
+	}
+}
+
 func TestConfigLoadErrors(t *testing.T) {
 	dir := t.TempDir()
 	if _, err := loadConfigFile(dir, "missing.yaml"); err == nil {

--- a/memory/retrieval/bbh/doc.go
+++ b/memory/retrieval/bbh/doc.go
@@ -9,4 +9,7 @@
 // checkpointed by a per-namespace flush loop plus Close. It is intended as a
 // higher-performance local backend for recall's retrieval lens; the canonical
 // memory truth remains the recall TemporalStore.
+//
+// Inspector opens the same workspace read-only and reports discovered Badger,
+// Bleve, HNSW, and namespace statistics without constructing an Index.
 package bbh

--- a/memory/retrieval/bbh/index.go
+++ b/memory/retrieval/bbh/index.go
@@ -168,6 +168,7 @@ func (idx *Index) Capabilities() retrieval.Capabilities {
 			Count:          true,
 			DeleteByFilter: true,
 			DropNamespace:  true,
+			NamespaceWarm:  true,
 		},
 	}
 }
@@ -175,6 +176,15 @@ func (idx *Index) Capabilities() retrieval.Capabilities {
 // SupportsFilter implements retrieval.Filterable. BBH evaluates the full
 // filter surface against Badger-loaded docs after candidate generation.
 func (idx *Index) SupportsFilter(retrieval.Filter) bool { return true }
+
+// WarmNamespace opens the path-backed Bleve and HNSW shard for namespace.
+func (idx *Index) WarmNamespace(ctx context.Context, namespace string) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	_, err := idx.ensureShard(namespace)
+	return err
+}
 
 func (idx *Index) ensureOpen() error {
 	if idx.closed.Load() {

--- a/memory/retrieval/bbh/index_test.go
+++ b/memory/retrieval/bbh/index_test.go
@@ -47,6 +47,9 @@ func TestNewValidationAndClosedIndexErrors(t *testing.T) {
 	if !caps.BM25 || !caps.Vector || !caps.Hybrid || !caps.NativeDeleteByFilter {
 		t.Fatalf("unexpected caps: %+v", caps)
 	}
+	if !retrieval.Supports(idx, retrieval.CapabilityNamespaceWarm) {
+		t.Fatal("BBH should advertise namespace warming")
+	}
 	if err := idx.Close(); err != nil {
 		t.Fatal(err)
 	}
@@ -58,6 +61,31 @@ func TestNewValidationAndClosedIndexErrors(t *testing.T) {
 	}
 	if _, err := idx.Search(context.Background(), "ns", retrieval.SearchRequest{QueryText: "x"}); err == nil {
 		t.Fatal("search after close should fail")
+	}
+}
+
+func TestWarmNamespace(t *testing.T) {
+	idx := openInternalIndex(t, t.TempDir())
+	warmer, ok := retrieval.AsNamespaceWarmer(idx)
+	if !ok {
+		t.Fatal("BBH should expose NamespaceWarmer")
+	}
+	if err := warmer.WarmNamespace(context.Background(), "warm/ns"); err != nil {
+		t.Fatalf("WarmNamespace: %v", err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if err := warmer.WarmNamespace(ctx, "cancelled"); !errors.Is(err, context.Canceled) {
+		t.Fatalf("cancelled WarmNamespace error = %v, want context.Canceled", err)
+	}
+	if err := warmer.WarmNamespace(context.Background(), " "); err == nil {
+		t.Fatal("blank WarmNamespace namespace should fail")
+	}
+	if err := idx.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := warmer.WarmNamespace(context.Background(), "closed"); err == nil {
+		t.Fatal("closed WarmNamespace should fail")
 	}
 }
 

--- a/memory/retrieval/bbh/inspector.go
+++ b/memory/retrieval/bbh/inspector.go
@@ -1,0 +1,431 @@
+package bbh
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"sync/atomic"
+
+	"github.com/dgraph-io/badger/v4"
+
+	"github.com/GizClaw/flowcraft/memory/retrieval"
+	"github.com/GizClaw/flowcraft/sdk/errdefs"
+	sdkworkspace "github.com/GizClaw/flowcraft/sdk/workspace"
+)
+
+// Inspector provides read-only visibility into a BBH workspace.
+type Inspector struct {
+	root   string
+	db     *badger.DB
+	closed atomic.Bool
+}
+
+// Inspection is a point-in-time summary of the BBH workspace layout.
+type Inspection struct {
+	Root                   string                `json:"root"`
+	BadgerPath             string                `json:"badger_path"`
+	BlevePath              string                `json:"bleve_path"`
+	HNSWPath               string                `json:"hnsw_path"`
+	BadgerExists           bool                  `json:"badger_exists"`
+	BleveExists            bool                  `json:"bleve_exists"`
+	HNSWExists             bool                  `json:"hnsw_exists"`
+	BadgerSizeBytes        int64                 `json:"badger_size_bytes"`
+	BleveSizeBytes         int64                 `json:"bleve_size_bytes"`
+	HNSWSizeBytes          int64                 `json:"hnsw_size_bytes"`
+	PhysicalNamespaceCount int                   `json:"physical_namespace_count"`
+	DocNamespaceCount      int                   `json:"doc_namespace_count"`
+	TotalDocs              int64                 `json:"total_docs"`
+	TotalVectorDocs        int64                 `json:"total_vector_docs"`
+	Namespaces             []NamespaceInspection `json:"namespaces"`
+}
+
+// NamespaceInspection describes the physical index artifacts for one
+// namespace. Namespace is decoded from the BBH safe token when possible.
+type NamespaceInspection struct {
+	Namespace      string `json:"namespace"`
+	Token          string `json:"token"`
+	DecodeError    string `json:"decode_error,omitempty"`
+	DocCount       int64  `json:"doc_count"`
+	VectorDocCount int64  `json:"vector_doc_count"`
+	BadgerBytes    int64  `json:"badger_bytes"`
+	BlevePath      string `json:"bleve_path,omitempty"`
+	BleveExists    bool   `json:"bleve_exists"`
+	BleveSizeBytes int64  `json:"bleve_size_bytes"`
+	HNSWPath       string `json:"hnsw_path,omitempty"`
+	HNSWExists     bool   `json:"hnsw_exists"`
+	HNSWSizeBytes  int64  `json:"hnsw_size_bytes"`
+	Empty          bool   `json:"empty"`
+	SourceBadger   bool   `json:"source_badger"`
+	SourceBleve    bool   `json:"source_bleve"`
+	SourceHNSW     bool   `json:"source_hnsw"`
+}
+
+// NewInspector opens an offline, read-only inspector rooted at a BBH workspace.
+// It opens Badger with a read-only lock, so it cannot inspect a workspace while
+// a writable Index is already open on the same path.
+func NewInspector(ws sdkworkspace.Workspace) (*Inspector, error) {
+	if ws == nil {
+		return nil, errdefs.Validationf("retrieval/bbh: workspace is nil")
+	}
+	lr, ok := ws.(localRoot)
+	if !ok {
+		return nil, errdefs.Validationf("retrieval/bbh: workspace must expose local Root()")
+	}
+	root := lr.Root()
+	in := &Inspector{root: root}
+	dbPath := filepath.Join(root, badgerDir)
+	info, err := os.Stat(dbPath)
+	switch {
+	case err == nil && !info.IsDir():
+		return nil, fmt.Errorf("retrieval/bbh: badger path is not a directory: %s", dbPath)
+	case err == nil:
+		db, err := badger.Open(badger.DefaultOptions(dbPath).WithLogger(nil).WithReadOnly(true))
+		if err != nil {
+			return nil, fmt.Errorf("retrieval/bbh: open badger inspector: %w", err)
+		}
+		in.db = db
+	case os.IsNotExist(err):
+	default:
+		return nil, fmt.Errorf("retrieval/bbh: stat badger path: %w", err)
+	}
+	return in, nil
+}
+
+// Close releases read-only resources held by the inspector.
+func (in *Inspector) Close() error {
+	if in == nil || !in.closed.CompareAndSwap(false, true) {
+		return nil
+	}
+	if in.db != nil {
+		return in.db.Close()
+	}
+	return nil
+}
+
+// Inspect returns a point-in-time summary of all discovered namespaces.
+func (in *Inspector) Inspect(ctx context.Context) (*Inspection, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	if err := in.ensureOpen(); err != nil {
+		return nil, err
+	}
+	out := &Inspection{
+		Root:       in.root,
+		BadgerPath: filepath.Join(in.root, badgerDir),
+		BlevePath:  filepath.Join(in.root, bleveDir),
+		HNSWPath:   filepath.Join(in.root, hnswDir),
+	}
+	var err error
+	out.BadgerExists, out.BadgerSizeBytes, err = pathSize(ctx, out.BadgerPath)
+	if err != nil {
+		return nil, err
+	}
+	out.BleveExists, out.BleveSizeBytes, err = pathSize(ctx, out.BlevePath)
+	if err != nil {
+		return nil, err
+	}
+	out.HNSWExists, out.HNSWSizeBytes, err = pathSize(ctx, out.HNSWPath)
+	if err != nil {
+		return nil, err
+	}
+
+	namespaces := map[string]*NamespaceInspection{}
+	if err := in.inspectBadger(ctx, namespaces); err != nil {
+		return nil, err
+	}
+	if err := inspectBleveDirs(ctx, in.root, namespaces); err != nil {
+		return nil, err
+	}
+	if err := inspectHNSWFiles(ctx, in.root, namespaces); err != nil {
+		return nil, err
+	}
+
+	out.Namespaces = make([]NamespaceInspection, 0, len(namespaces))
+	for _, ns := range namespaces {
+		ns.Empty = ns.DocCount == 0 && ns.VectorDocCount == 0
+		out.TotalDocs += ns.DocCount
+		out.TotalVectorDocs += ns.VectorDocCount
+		if ns.DocCount > 0 {
+			out.DocNamespaceCount++
+		}
+		out.Namespaces = append(out.Namespaces, *ns)
+	}
+	out.PhysicalNamespaceCount = len(out.Namespaces)
+	sort.Slice(out.Namespaces, func(i, j int) bool {
+		if out.Namespaces[i].Namespace == out.Namespaces[j].Namespace {
+			return out.Namespaces[i].Token < out.Namespaces[j].Token
+		}
+		return out.Namespaces[i].Namespace < out.Namespaces[j].Namespace
+	})
+	return out, nil
+}
+
+// InspectNamespace returns inspection data for one namespace.
+func (in *Inspector) InspectNamespace(ctx context.Context, namespace string) (NamespaceInspection, error) {
+	if strings.TrimSpace(namespace) == "" {
+		return NamespaceInspection{}, errdefs.Validationf("retrieval/bbh: namespace is required")
+	}
+	if err := ctx.Err(); err != nil {
+		return NamespaceInspection{}, err
+	}
+	if err := in.ensureOpen(); err != nil {
+		return NamespaceInspection{}, err
+	}
+	token := safeToken(namespace)
+	ns := namespaceFromToken(token)
+	if err := in.inspectBadgerNamespace(ctx, token, &ns); err != nil {
+		return NamespaceInspection{}, err
+	}
+	if err := inspectBleveNamespace(ctx, in.root, token, &ns); err != nil {
+		return NamespaceInspection{}, err
+	}
+	if err := inspectHNSWNamespace(ctx, in.root, token, &ns); err != nil {
+		return NamespaceInspection{}, err
+	}
+	ns.Empty = ns.DocCount == 0 && ns.VectorDocCount == 0
+	return ns, nil
+}
+
+func (in *Inspector) ensureOpen() error {
+	if in == nil || in.closed.Load() {
+		return errdefs.NotAvailablef("retrieval/bbh: inspector is closed")
+	}
+	return nil
+}
+
+func (in *Inspector) inspectBadgerNamespace(ctx context.Context, token string, ns *NamespaceInspection) error {
+	if in.db == nil {
+		return nil
+	}
+	return in.db.View(func(txn *badger.Txn) error {
+		it := txn.NewIterator(badger.IteratorOptions{PrefetchValues: true})
+		defer it.Close()
+		prefix := []byte(badgerDocPrefix + token + "/")
+		for it.Seek(prefix); it.ValidForPrefix(prefix); it.Next() {
+			if err := ctx.Err(); err != nil {
+				return err
+			}
+			key := string(it.Item().Key())
+			ns.SourceBadger = true
+			ns.DocCount++
+			ns.BadgerBytes += int64(len(key))
+			if err := it.Item().Value(func(v []byte) error {
+				ns.BadgerBytes += int64(len(v))
+				var d retrieval.Doc
+				if err := json.Unmarshal(v, &d); err != nil {
+					return err
+				}
+				if len(d.Vector) > 0 {
+					ns.VectorDocCount++
+				}
+				return nil
+			}); err != nil {
+				return err
+			}
+		}
+		return nil
+	})
+}
+
+func (in *Inspector) inspectBadger(ctx context.Context, namespaces map[string]*NamespaceInspection) error {
+	if in.db == nil {
+		return nil
+	}
+	return in.db.View(func(txn *badger.Txn) error {
+		it := txn.NewIterator(badger.IteratorOptions{PrefetchValues: true})
+		defer it.Close()
+		prefix := []byte(badgerDocPrefix)
+		for it.Seek(prefix); it.ValidForPrefix(prefix); it.Next() {
+			if err := ctx.Err(); err != nil {
+				return err
+			}
+			key := string(it.Item().Key())
+			token, ok := namespaceTokenFromDocKey(key)
+			if !ok {
+				continue
+			}
+			ns := ensureNamespaceInspection(namespaces, token)
+			ns.SourceBadger = true
+			ns.DocCount++
+			ns.BadgerBytes += int64(len(key))
+			if err := it.Item().Value(func(v []byte) error {
+				ns.BadgerBytes += int64(len(v))
+				var d retrieval.Doc
+				if err := json.Unmarshal(v, &d); err != nil {
+					return err
+				}
+				if len(d.Vector) > 0 {
+					ns.VectorDocCount++
+				}
+				return nil
+			}); err != nil {
+				return err
+			}
+		}
+		return nil
+	})
+}
+
+func inspectBleveDirs(ctx context.Context, root string, namespaces map[string]*NamespaceInspection) error {
+	dir := filepath.Join(root, bleveDir)
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return fmt.Errorf("retrieval/bbh: read bleve dir: %w", err)
+	}
+	for _, entry := range entries {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		if !entry.IsDir() {
+			continue
+		}
+		token := entry.Name()
+		ns := ensureNamespaceInspection(namespaces, token)
+		ns.SourceBleve = true
+		ns.BleveExists = true
+		ns.BlevePath = filepath.Join(dir, token)
+		var err error
+		_, ns.BleveSizeBytes, err = pathSize(ctx, ns.BlevePath)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func inspectBleveNamespace(ctx context.Context, root, token string, ns *NamespaceInspection) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	path := filepath.Join(root, bleveDir, token)
+	exists, size, err := pathSize(ctx, path)
+	if err != nil {
+		return err
+	}
+	if exists {
+		ns.SourceBleve = true
+		ns.BleveExists = true
+		ns.BlevePath = path
+		ns.BleveSizeBytes = size
+	}
+	return nil
+}
+
+func inspectHNSWFiles(ctx context.Context, root string, namespaces map[string]*NamespaceInspection) error {
+	dir := filepath.Join(root, hnswDir)
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return fmt.Errorf("retrieval/bbh: read hnsw dir: %w", err)
+	}
+	for _, entry := range entries {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), hnswGraphExt) {
+			continue
+		}
+		token := strings.TrimSuffix(entry.Name(), hnswGraphExt)
+		ns := ensureNamespaceInspection(namespaces, token)
+		ns.SourceHNSW = true
+		ns.HNSWExists = true
+		ns.HNSWPath = filepath.Join(dir, entry.Name())
+		var err error
+		_, ns.HNSWSizeBytes, err = pathSize(ctx, ns.HNSWPath)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func inspectHNSWNamespace(ctx context.Context, root, token string, ns *NamespaceInspection) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	path := filepath.Join(root, hnswDir, token+hnswGraphExt)
+	exists, size, err := pathSize(ctx, path)
+	if err != nil {
+		return err
+	}
+	if exists {
+		ns.SourceHNSW = true
+		ns.HNSWExists = true
+		ns.HNSWPath = path
+		ns.HNSWSizeBytes = size
+	}
+	return nil
+}
+
+func ensureNamespaceInspection(namespaces map[string]*NamespaceInspection, token string) *NamespaceInspection {
+	if ns, ok := namespaces[token]; ok {
+		return ns
+	}
+	ns := namespaceFromToken(token)
+	namespaces[token] = &ns
+	return &ns
+}
+
+func namespaceFromToken(token string) NamespaceInspection {
+	raw, err := base64.RawURLEncoding.DecodeString(token)
+	if err != nil {
+		return NamespaceInspection{
+			Namespace:   token,
+			Token:       token,
+			DecodeError: err.Error(),
+		}
+	}
+	return NamespaceInspection{
+		Namespace: string(raw),
+		Token:     token,
+	}
+}
+
+func namespaceTokenFromDocKey(key string) (string, bool) {
+	if !strings.HasPrefix(key, badgerDocPrefix) {
+		return "", false
+	}
+	rest := strings.TrimPrefix(key, badgerDocPrefix)
+	token, _, ok := strings.Cut(rest, "/")
+	return token, ok && token != ""
+}
+
+func pathSize(ctx context.Context, path string) (bool, int64, error) {
+	var total int64
+	err := filepath.WalkDir(path, func(_ string, d fs.DirEntry, err error) error {
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return ctxErr
+		}
+		if err != nil {
+			return err
+		}
+		info, err := d.Info()
+		if err != nil {
+			return err
+		}
+		if !info.IsDir() {
+			total += info.Size()
+		}
+		return nil
+	})
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) || os.IsNotExist(err) {
+			return false, 0, nil
+		}
+		return true, total, err
+	}
+	return true, total, nil
+}

--- a/memory/retrieval/bbh/inspector_test.go
+++ b/memory/retrieval/bbh/inspector_test.go
@@ -1,0 +1,226 @@
+package bbh
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/GizClaw/flowcraft/memory/retrieval"
+	sdkworkspace "github.com/GizClaw/flowcraft/sdk/workspace"
+	"github.com/dgraph-io/badger/v4"
+)
+
+func TestInspectorValidationAndEmptyWorkspace(t *testing.T) {
+	if _, err := NewInspector(nil); err == nil {
+		t.Fatal("nil workspace should fail")
+	}
+	if _, err := NewInspector(sdkworkspace.NewMemWorkspace()); err == nil {
+		t.Fatal("workspace without Root should fail")
+	}
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, badgerDir), []byte("not a dir"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := NewInspector(rootedWorkspace(t, dir)); err == nil {
+		t.Fatal("badger file should fail")
+	}
+
+	empty := t.TempDir()
+	in, err := NewInspector(rootedWorkspace(t, empty))
+	if err != nil {
+		t.Fatalf("NewInspector empty: %v", err)
+	}
+	got, err := in.Inspect(context.Background())
+	if err != nil {
+		t.Fatalf("Inspect empty: %v", err)
+	}
+	if got.Root != empty || got.BadgerExists || got.BleveExists || got.HNSWExists {
+		t.Fatalf("unexpected empty inspection: %+v", got)
+	}
+	if len(got.Namespaces) != 0 || got.TotalDocs != 0 {
+		t.Fatalf("unexpected empty namespaces: %+v", got)
+	}
+	cancelled, cancel := context.WithCancel(context.Background())
+	cancel()
+	if _, err := in.Inspect(cancelled); err == nil {
+		t.Fatal("Inspect with cancelled context should fail")
+	}
+	if _, err := in.InspectNamespace(cancelled, "ns"); err == nil {
+		t.Fatal("InspectNamespace with cancelled context should fail")
+	}
+	if err := in.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := in.Inspect(context.Background()); err == nil {
+		t.Fatal("inspect after close should fail")
+	}
+}
+
+func TestInspectorReportsNamespaces(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	idx := openInternalIndex(t, dir, WithConfig(Config{
+		HNSW: HNSWConfig{FlushInterval: Duration{Duration: time.Hour}},
+	}))
+	if err := idx.Upsert(ctx, "runtime/user/agent-a", []retrieval.Doc{
+		{ID: "a", Content: "alpha", Vector: []float32{1, 0}, Timestamp: time.Unix(1, 0).UTC()},
+		{ID: "b", Content: "beta", Timestamp: time.Unix(2, 0).UTC()},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := idx.Upsert(ctx, "runtime/user/agent-b", []retrieval.Doc{
+		{ID: "c", Content: "gamma", Vector: []float32{0, 1}, Timestamp: time.Unix(3, 0).UTC()},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := idx.Search(ctx, "empty/shard", retrieval.SearchRequest{QueryText: "nothing"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := idx.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	in, err := NewInspector(rootedWorkspace(t, dir))
+	if err != nil {
+		t.Fatalf("NewInspector: %v", err)
+	}
+	defer func() {
+		if err := in.Close(); err != nil {
+			t.Fatal(err)
+		}
+	}()
+	got, err := in.Inspect(ctx)
+	if err != nil {
+		t.Fatalf("Inspect: %v", err)
+	}
+	if !got.BadgerExists || !got.BleveExists || !got.HNSWExists {
+		t.Fatalf("expected all storage roots, got %+v", got)
+	}
+	if got.TotalDocs != 3 || got.TotalVectorDocs != 2 {
+		t.Fatalf("totals = docs %d vectors %d, want 3/2", got.TotalDocs, got.TotalVectorDocs)
+	}
+	if got.PhysicalNamespaceCount != 3 || got.DocNamespaceCount != 2 {
+		t.Fatalf("namespace counts = physical %d doc %d, want 3/2", got.PhysicalNamespaceCount, got.DocNamespaceCount)
+	}
+
+	a := mustInspectNamespace(t, in, "runtime/user/agent-a")
+	if a.DocCount != 2 || a.VectorDocCount != 1 {
+		t.Fatalf("agent-a counts = %+v", a)
+	}
+	if !a.SourceBadger || !a.SourceBleve || !a.SourceHNSW || !a.BleveExists || !a.HNSWExists {
+		t.Fatalf("agent-a sources = %+v", a)
+	}
+	if a.BadgerBytes <= 0 || a.BleveSizeBytes <= 0 || a.HNSWSizeBytes <= 0 {
+		t.Fatalf("agent-a sizes = %+v", a)
+	}
+
+	empty := mustInspectNamespace(t, in, "empty/shard")
+	if empty.DocCount != 0 || !empty.SourceBleve || !empty.Empty {
+		t.Fatalf("empty shard = %+v", empty)
+	}
+
+	missing, err := in.InspectNamespace(ctx, "missing")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if missing.Namespace != "missing" || missing.Token != safeToken("missing") || missing.DocCount != 0 {
+		t.Fatalf("missing namespace = %+v", missing)
+	}
+	if !missing.Empty {
+		t.Fatalf("missing namespace Empty = false, want true: %+v", missing)
+	}
+}
+
+func TestInspectorDocumentsOfflineOnlyContract(t *testing.T) {
+	idx := openInternalIndex(t, t.TempDir(), WithConfig(Config{
+		HNSW: HNSWConfig{FlushInterval: Duration{Duration: time.Hour}},
+	}))
+	defer idx.Close()
+	if _, err := NewInspector(rootedWorkspace(t, idx.root)); err == nil {
+		t.Fatal("NewInspector should fail while writable Index has Badger open")
+	}
+}
+
+func TestInspectNamespaceIsScoped(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	idx := openInternalIndex(t, dir, WithConfig(Config{
+		HNSW: HNSWConfig{FlushInterval: Duration{Duration: time.Hour}},
+	}))
+	if err := idx.Upsert(ctx, "target", []retrieval.Doc{
+		{ID: "ok", Content: "alpha", Vector: []float32{1}, Timestamp: time.Unix(1, 0).UTC()},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := idx.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	db, err := badger.Open(badger.DefaultOptions(filepath.Join(dir, badgerDir)).WithLogger(nil))
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = db.Update(func(txn *badger.Txn) error {
+		return txn.Set(docKey("broken", "bad-json"), []byte("{"))
+	})
+	if closeErr := db.Close(); closeErr != nil {
+		t.Fatal(closeErr)
+	}
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	in, err := NewInspector(rootedWorkspace(t, dir))
+	if err != nil {
+		t.Fatalf("NewInspector: %v", err)
+	}
+	defer in.Close()
+	got, err := in.InspectNamespace(ctx, "target")
+	if err != nil {
+		t.Fatalf("InspectNamespace target: %v", err)
+	}
+	if got.DocCount != 1 || got.VectorDocCount != 1 {
+		t.Fatalf("target namespace = %+v, want one vector doc", got)
+	}
+	if _, err := in.Inspect(ctx); err == nil {
+		t.Fatal("full Inspect should still report unrelated corrupt doc")
+	}
+}
+
+func TestInspectorHandlesInvalidPhysicalToken(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dir, bleveDir, "not@base64"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	in, err := NewInspector(rootedWorkspace(t, dir))
+	if err != nil {
+		t.Fatalf("NewInspector: %v", err)
+	}
+	defer func() {
+		if err := in.Close(); err != nil {
+			t.Fatal(err)
+		}
+	}()
+	got, err := in.Inspect(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got.Namespaces) != 1 {
+		t.Fatalf("namespaces = %+v", got.Namespaces)
+	}
+	ns := got.Namespaces[0]
+	if ns.Namespace != "not@base64" || ns.DecodeError == "" || !ns.SourceBleve {
+		t.Fatalf("invalid token namespace = %+v", ns)
+	}
+}
+
+func mustInspectNamespace(t *testing.T, in *Inspector, namespace string) NamespaceInspection {
+	t.Helper()
+	got, err := in.InspectNamespace(context.Background(), namespace)
+	if err != nil {
+		t.Fatalf("InspectNamespace %s: %v", namespace, err)
+	}
+	return got
+}

--- a/memory/retrieval/capabilities.go
+++ b/memory/retrieval/capabilities.go
@@ -51,6 +51,7 @@ type ExtensionCapabilities struct {
 	Count          bool
 	DeleteByFilter bool
 	DropNamespace  bool
+	NamespaceWarm  bool
 }
 
 // DefaultMemoryCapabilities returns capabilities for MemoryIndex.
@@ -134,6 +135,9 @@ func extensionCapabilitiesOf(idx Index, declared ExtensionCapabilities) Extensio
 	}
 	if _, ok := idx.(Droppable); ok {
 		declared.DropNamespace = true
+	}
+	if _, ok := idx.(NamespaceWarmer); ok {
+		declared.NamespaceWarm = true
 	}
 	return declared
 }

--- a/memory/retrieval/capabilities.go
+++ b/memory/retrieval/capabilities.go
@@ -98,7 +98,7 @@ func CapabilitiesOf(idx Index) Capabilities {
 		return Capabilities{}
 	}
 	c := idx.Capabilities()
-	c.Extensions = extensionCapabilitiesOf(idx, c.Extensions)
+	c.Extensions = extensionCapabilitiesOf(idx)
 	if c.Hybrid && !c.Extensions.HybridSearch {
 		c.Hybrid = false
 	}
@@ -108,36 +108,37 @@ func CapabilitiesOf(idx Index) Capabilities {
 	return c
 }
 
-func extensionCapabilitiesOf(idx Index, declared ExtensionCapabilities) ExtensionCapabilities {
+func extensionCapabilitiesOf(idx Index) ExtensionCapabilities {
+	var projected ExtensionCapabilities
 	if _, ok := idx.(DocGetter); ok {
-		declared.DocGetter = true
+		projected.DocGetter = true
 	}
 	if _, ok := idx.(Filterable); ok {
-		declared.Filterable = true
+		projected.Filterable = true
 	}
 	if _, ok := idx.(Hybridable); ok {
-		declared.HybridSearch = true
+		projected.HybridSearch = true
 	}
 	if _, ok := idx.(Vectorizable); ok {
-		declared.Vectorizable = true
+		projected.Vectorizable = true
 	}
 	if _, ok := idx.(Snapshottable); ok {
-		declared.Snapshottable = true
+		projected.Snapshottable = true
 	}
 	if _, ok := idx.(Iterable); ok {
-		declared.Iterable = true
+		projected.Iterable = true
 	}
 	if _, ok := idx.(Countable); ok {
-		declared.Count = true
+		projected.Count = true
 	}
 	if _, ok := idx.(DeletableByFilter); ok {
-		declared.DeleteByFilter = true
+		projected.DeleteByFilter = true
 	}
 	if _, ok := idx.(Droppable); ok {
-		declared.DropNamespace = true
+		projected.DropNamespace = true
 	}
 	if _, ok := idx.(NamespaceWarmer); ok {
-		declared.NamespaceWarm = true
+		projected.NamespaceWarm = true
 	}
-	return declared
+	return projected
 }

--- a/memory/retrieval/capability_helpers.go
+++ b/memory/retrieval/capability_helpers.go
@@ -18,6 +18,7 @@ const (
 	CapabilitySnapshot             Capability = "snapshot"
 	CapabilityVectorizable         Capability = "vectorizable"
 	CapabilityNativeDeleteByFilter Capability = "native_delete_by_filter"
+	CapabilityNamespaceWarm        Capability = "namespace_warm"
 )
 
 // Supports centralises capability checks so callers do not spread
@@ -56,6 +57,8 @@ func Supports(idx Index, cap Capability) bool {
 		return c.Extensions.Snapshottable
 	case CapabilityVectorizable:
 		return c.Extensions.Vectorizable
+	case CapabilityNamespaceWarm:
+		return c.Extensions.NamespaceWarm
 	default:
 		return false
 	}
@@ -107,4 +110,14 @@ func AsDroppable(idx Index) (Droppable, bool) {
 	}
 	d, ok := idx.(Droppable)
 	return d, ok
+}
+
+// AsNamespaceWarmer returns idx as a NamespaceWarmer when it advertises and
+// implements namespace warming.
+func AsNamespaceWarmer(idx Index) (NamespaceWarmer, bool) {
+	if !Supports(idx, CapabilityNamespaceWarm) {
+		return nil, false
+	}
+	w, ok := idx.(NamespaceWarmer)
+	return w, ok
 }

--- a/memory/retrieval/index.go
+++ b/memory/retrieval/index.go
@@ -79,3 +79,9 @@ type DeletableByFilter interface {
 type Droppable interface {
 	Drop(ctx context.Context, namespace string) error
 }
+
+// NamespaceWarmer supports explicitly opening backend resources for a
+// namespace before the first read or write path needs them.
+type NamespaceWarmer interface {
+	WarmNamespace(ctx context.Context, namespace string) error
+}

--- a/memory/retrieval/journal/wrap.go
+++ b/memory/retrieval/journal/wrap.go
@@ -45,8 +45,9 @@ type journaledIndex struct {
 //
 // Currently transparently delegates: [retrieval.DocGetter],
 // [retrieval.Filterable], [retrieval.DeletableByFilter],
-// [retrieval.Droppable], [retrieval.Iterable]. These have in-tree
-// implementations and the bridge logic on `*journaledIndex` is correct.
+// [retrieval.Droppable], [retrieval.Iterable], [retrieval.Countable], and
+// [retrieval.NamespaceWarmer]. These have in-tree implementations and the
+// bridge logic on `*journaledIndex` is correct.
 // [retrieval.Hybridable], [retrieval.Snapshottable], and
 // [retrieval.Vectorizable] are NOT delegated by the base wrapper today —
 // no in-tree backend implements them. When a future backend does, add a
@@ -319,6 +320,13 @@ func (w *journaledIndex) count(ctx context.Context, namespace string, f retrieva
 	return 0, nil
 }
 
+func (w *journaledIndex) warmNamespace(ctx context.Context, namespace string) error {
+	if x, ok := w.inner.(retrieval.NamespaceWarmer); ok {
+		return x.WarmNamespace(ctx, namespace)
+	}
+	return nil
+}
+
 // REMOVED in PR-4 (issue #157):
 //   - Snapshot / Restore
 //   - SearchHybrid
@@ -353,6 +361,10 @@ func newWrapped(base *journaledIndex) retrieval.Index {
 	_, hasDrop := inner.(retrieval.Droppable)
 	_, hasIter := inner.(retrieval.Iterable)
 	_, hasCount := inner.(retrieval.Countable)
+	_, hasWarm := inner.(retrieval.NamespaceWarmer)
+	if hasWarm {
+		return newWrappedWarm(base, hasGet, hasFlt, hasDF, hasDrop, hasIter, hasCount)
+	}
 	switch {
 	case hasGet && hasFlt && hasDF && hasDrop && hasIter && hasCount:
 		return &wrappedFullCount{wrappedFull: &wrappedFull{journaledIndex: base}}
@@ -377,6 +389,31 @@ func newWrapped(base *journaledIndex) retrieval.Index {
 	}
 }
 
+func newWrappedWarm(base *journaledIndex, hasGet, hasFlt, hasDF, hasDrop, hasIter, hasCount bool) retrieval.Index {
+	switch {
+	case hasGet && hasFlt && hasDF && hasDrop && hasIter && hasCount:
+		return &wrappedFullCountWarm{wrappedFullCount: &wrappedFullCount{wrappedFull: &wrappedFull{journaledIndex: base}}}
+	case hasGet && hasFlt && hasDF && hasDrop && hasIter:
+		return &wrappedFullWarm{wrappedFull: &wrappedFull{journaledIndex: base}}
+	case hasGet && hasFlt && hasDF && hasIter && hasCount:
+		return &wrappedFilterAuditableCountWarm{wrappedFilterAuditableCount: &wrappedFilterAuditableCount{wrappedFilterAuditable: &wrappedFilterAuditable{journaledIndex: base}}}
+	case hasGet && hasFlt && hasDF && hasIter:
+		return &wrappedFilterAuditableWarm{wrappedFilterAuditable: &wrappedFilterAuditable{journaledIndex: base}}
+	case hasGet && hasDF && hasDrop && hasIter && hasCount:
+		return &wrappedAuditableCountWarm{wrappedAuditableCount: &wrappedAuditableCount{wrappedAuditable: &wrappedAuditable{journaledIndex: base}}}
+	case hasGet && hasDF && hasDrop && hasIter:
+		return &wrappedAuditableWarm{wrappedAuditable: &wrappedAuditable{journaledIndex: base}}
+	case hasGet && hasIter && hasCount:
+		return &wrappedReadableCountWarm{wrappedReadableCount: &wrappedReadableCount{wrappedReadable: &wrappedReadable{journaledIndex: base}}}
+	case hasGet && hasIter:
+		return &wrappedReadableWarm{wrappedReadable: &wrappedReadable{journaledIndex: base}}
+	case hasGet:
+		return &wrappedGetterWarm{wrappedGetter: &wrappedGetter{journaledIndex: base}}
+	default:
+		return &wrappedWarm{journaledIndex: base}
+	}
+}
+
 // The variants below "freeze" the optional method set at compile time so
 // callers' interface assertions reflect the inner backend's true
 // capability surface. Each embeds *journaledIndex so the bridging methods
@@ -391,6 +428,16 @@ type wrappedFullCount struct{ *wrappedFull }
 type wrappedFilterAuditableCount struct{ *wrappedFilterAuditable }
 type wrappedAuditableCount struct{ *wrappedAuditable }
 type wrappedReadableCount struct{ *wrappedReadable }
+type wrappedWarm struct{ *journaledIndex }
+type wrappedFullWarm struct{ *wrappedFull }
+type wrappedFilterAuditableWarm struct{ *wrappedFilterAuditable }
+type wrappedAuditableWarm struct{ *wrappedAuditable }
+type wrappedReadableWarm struct{ *wrappedReadable }
+type wrappedGetterWarm struct{ *wrappedGetter }
+type wrappedFullCountWarm struct{ *wrappedFullCount }
+type wrappedFilterAuditableCountWarm struct{ *wrappedFilterAuditableCount }
+type wrappedAuditableCountWarm struct{ *wrappedAuditableCount }
+type wrappedReadableCountWarm struct{ *wrappedReadableCount }
 
 func (w *wrappedFull) Get(ctx context.Context, namespace, id string) (retrieval.Doc, bool, error) {
 	return w.get(ctx, namespace, id)
@@ -454,6 +501,37 @@ func (w *wrappedReadableCount) Count(ctx context.Context, namespace string, f re
 	return w.count(ctx, namespace, f)
 }
 
+func (w *wrappedWarm) WarmNamespace(ctx context.Context, namespace string) error {
+	return w.warmNamespace(ctx, namespace)
+}
+func (w *wrappedFullWarm) WarmNamespace(ctx context.Context, namespace string) error {
+	return w.warmNamespace(ctx, namespace)
+}
+func (w *wrappedFilterAuditableWarm) WarmNamespace(ctx context.Context, namespace string) error {
+	return w.warmNamespace(ctx, namespace)
+}
+func (w *wrappedAuditableWarm) WarmNamespace(ctx context.Context, namespace string) error {
+	return w.warmNamespace(ctx, namespace)
+}
+func (w *wrappedReadableWarm) WarmNamespace(ctx context.Context, namespace string) error {
+	return w.warmNamespace(ctx, namespace)
+}
+func (w *wrappedGetterWarm) WarmNamespace(ctx context.Context, namespace string) error {
+	return w.warmNamespace(ctx, namespace)
+}
+func (w *wrappedFullCountWarm) WarmNamespace(ctx context.Context, namespace string) error {
+	return w.warmNamespace(ctx, namespace)
+}
+func (w *wrappedFilterAuditableCountWarm) WarmNamespace(ctx context.Context, namespace string) error {
+	return w.warmNamespace(ctx, namespace)
+}
+func (w *wrappedAuditableCountWarm) WarmNamespace(ctx context.Context, namespace string) error {
+	return w.warmNamespace(ctx, namespace)
+}
+func (w *wrappedReadableCountWarm) WarmNamespace(ctx context.Context, namespace string) error {
+	return w.warmNamespace(ctx, namespace)
+}
+
 var (
 	_ retrieval.Index             = (*journaledIndex)(nil)
 	_ retrieval.DocGetter         = (*wrappedGetter)(nil)
@@ -475,6 +553,16 @@ var (
 	_ retrieval.Countable         = (*wrappedFilterAuditableCount)(nil)
 	_ retrieval.Countable         = (*wrappedAuditableCount)(nil)
 	_ retrieval.Countable         = (*wrappedReadableCount)(nil)
+	_ retrieval.NamespaceWarmer   = (*wrappedWarm)(nil)
+	_ retrieval.NamespaceWarmer   = (*wrappedFullWarm)(nil)
+	_ retrieval.NamespaceWarmer   = (*wrappedFilterAuditableWarm)(nil)
+	_ retrieval.NamespaceWarmer   = (*wrappedAuditableWarm)(nil)
+	_ retrieval.NamespaceWarmer   = (*wrappedReadableWarm)(nil)
+	_ retrieval.NamespaceWarmer   = (*wrappedGetterWarm)(nil)
+	_ retrieval.NamespaceWarmer   = (*wrappedFullCountWarm)(nil)
+	_ retrieval.NamespaceWarmer   = (*wrappedFilterAuditableCountWarm)(nil)
+	_ retrieval.NamespaceWarmer   = (*wrappedAuditableCountWarm)(nil)
+	_ retrieval.NamespaceWarmer   = (*wrappedReadableCountWarm)(nil)
 )
 
 func isEmptyFilter(f retrieval.Filter) bool {

--- a/memory/retrieval/journal/wrap_capability_test.go
+++ b/memory/retrieval/journal/wrap_capability_test.go
@@ -32,6 +32,20 @@ func (hybridClaimingIndex) List(context.Context, string, retrieval.ListRequest) 
 	return &retrieval.ListResponse{}, nil
 }
 
+type namespaceWarmIndex struct {
+	hybridClaimingIndex
+	warmed string
+}
+
+func (idx *namespaceWarmIndex) Capabilities() retrieval.Capabilities {
+	return retrieval.Capabilities{}
+}
+
+func (idx *namespaceWarmIndex) WarmNamespace(_ context.Context, namespace string) error {
+	idx.warmed = namespace
+	return nil
+}
+
 // nullJournal absorbs Record / Close calls so Wrap can return a
 // useful value without spinning up a real journal backend.
 type nullJournal struct{}
@@ -92,6 +106,9 @@ func TestWrap_DoesNotFalselyAdvertiseHybridable(t *testing.T) {
 	if _, ok := wrapped.(retrieval.Countable); ok {
 		t.Fatalf("#157 regression: non-Countable inner must not satisfy Countable")
 	}
+	if _, ok := wrapped.(retrieval.NamespaceWarmer); ok {
+		t.Fatalf("#157 regression: non-NamespaceWarmer inner must not satisfy NamespaceWarmer")
+	}
 }
 
 func TestWrap_ProjectsImplementedOptionalInterfaces(t *testing.T) {
@@ -120,5 +137,23 @@ func TestWrap_ProjectsImplementedOptionalInterfaces(t *testing.T) {
 	}
 	if caps.Extensions.Filterable {
 		t.Fatalf("CapabilitiesOf falsely projected Filterable: %+v", caps.Extensions)
+	}
+}
+
+func TestWrap_ProjectsNamespaceWarmer(t *testing.T) {
+	inner := &namespaceWarmIndex{}
+	wrapped := journal.Wrap(inner, nullJournal{})
+	warmer, ok := retrieval.AsNamespaceWarmer(wrapped)
+	if !ok {
+		t.Fatal("wrapped namespace warmer should expose NamespaceWarmer")
+	}
+	if err := warmer.WarmNamespace(context.Background(), "warm/ns"); err != nil {
+		t.Fatal(err)
+	}
+	if inner.warmed != "warm/ns" {
+		t.Fatalf("inner warmed namespace = %q, want warm/ns", inner.warmed)
+	}
+	if _, ok := wrapped.(retrieval.DocGetter); ok {
+		t.Fatal("warm-only wrapper should not expose unrelated DocGetter")
 	}
 }

--- a/memory/retrieval/journal/wrap_capability_test.go
+++ b/memory/retrieval/journal/wrap_capability_test.go
@@ -46,6 +46,27 @@ func (idx *namespaceWarmIndex) WarmNamespace(_ context.Context, namespace string
 	return nil
 }
 
+type namespaceWarmCountIndex struct {
+	hybridClaimingIndex
+	warmed string
+}
+
+func (idx *namespaceWarmCountIndex) Capabilities() retrieval.Capabilities {
+	return retrieval.Capabilities{Extensions: retrieval.ExtensionCapabilities{
+		Count:         true,
+		NamespaceWarm: true,
+	}}
+}
+
+func (idx *namespaceWarmCountIndex) Count(context.Context, string, retrieval.Filter) (int64, error) {
+	return 0, nil
+}
+
+func (idx *namespaceWarmCountIndex) WarmNamespace(_ context.Context, namespace string) error {
+	idx.warmed = namespace
+	return nil
+}
+
 // nullJournal absorbs Record / Close calls so Wrap can return a
 // useful value without spinning up a real journal backend.
 type nullJournal struct{}
@@ -155,5 +176,30 @@ func TestWrap_ProjectsNamespaceWarmer(t *testing.T) {
 	}
 	if _, ok := wrapped.(retrieval.DocGetter); ok {
 		t.Fatal("warm-only wrapper should not expose unrelated DocGetter")
+	}
+}
+
+func TestWrap_WarmFallbackDoesNotAdvertiseDroppedCount(t *testing.T) {
+	inner := &namespaceWarmCountIndex{}
+	wrapped := journal.Wrap(inner, nullJournal{})
+
+	if _, ok := wrapped.(retrieval.NamespaceWarmer); !ok {
+		t.Fatal("wrapped warm+count fallback should expose NamespaceWarmer")
+	}
+	if _, ok := wrapped.(retrieval.Countable); ok {
+		t.Fatal("wrapped warm+count fallback should not expose Countable")
+	}
+	if retrieval.Supports(wrapped, retrieval.CapabilityCount) {
+		t.Fatal("wrapped warm+count fallback should not advertise Count capability")
+	}
+	caps := retrieval.CapabilitiesOf(wrapped)
+	if caps.Extensions.Count {
+		t.Fatalf("CapabilitiesOf falsely projected Count: %+v", caps.Extensions)
+	}
+	if !caps.Extensions.NamespaceWarm {
+		t.Fatalf("CapabilitiesOf did not project NamespaceWarm: %+v", caps.Extensions)
+	}
+	if !retrieval.Supports(wrapped, retrieval.CapabilityNamespaceWarm) {
+		t.Fatal("wrapped warm+count fallback should advertise NamespaceWarm capability")
 	}
 }


### PR DESCRIPTION
## Summary
- add offline read-only inspection for persisted BBH namespace shards
- make InspectNamespace scan only the requested namespace and report missing namespaces as empty
- thread context/errors through artifact size walks instead of returning partial silent results
- expose NamespaceWarmer capability for WarmNamespace and add Duration marshal coverage

## Tests
- go test ./memory/retrieval/bbh
- go test ./memory/retrieval/...