### PR TITLE
feat(scriptnode): subscribe to node stream events

### DIFF
--- a/sdk/graph/node/scriptnode/bridge_stream.go
+++ b/sdk/graph/node/scriptnode/bridge_stream.go
@@ -3,6 +3,7 @@ package scriptnode
 import (
 	"context"
 	"encoding/json"
+	"strings"
 	"sync"
 	"time"
 
@@ -14,7 +15,7 @@ import (
 
 const defaultStreamSubBufferSize = 256
 
-// newStreamBridge exposes graph stream-delta subscriptions to scripts as
+// newStreamBridge exposes graph node stream subscriptions to scripts as
 // the global "stream".
 //
 // Script-facing API:
@@ -41,11 +42,12 @@ func newStreamBridge(defaultRunID string, bus event.Bus) bindings.BindingFunc {
 				subCtx, cancel := context.WithCancel(callCtx)
 				sub, err := bus.Subscribe(
 					subCtx,
-					engine.PatternRunStream(opts.runID),
+					engine.PatternRun(opts.runID),
 					event.WithBufferSize(opts.bufferSize),
 					// Keep the publisher path non-blocking when scripts are slow:
-					// a full subscription buffer drops the incoming newest delta.
-					event.WithBackpressure(event.DropNewest),
+					// a full subscription buffer drops older events so terminal
+					// lifecycle events still reach slow subscribers.
+					event.WithBackpressure(event.DropOldest),
 					event.WithPredicate(func(env event.Envelope) bool {
 						return env.NodeID() == opts.nodeID
 					}),
@@ -55,7 +57,7 @@ func newStreamBridge(defaultRunID string, bus event.Bus) bindings.BindingFunc {
 					return nil, err
 				}
 
-				iter := &streamDeltaIterator{
+				iter := &streamNodeIterator{
 					ctx:    subCtx,
 					cancel: cancel,
 					sub:    sub,
@@ -151,7 +153,7 @@ func streamBufferSize(v any) (int, error) {
 	return 0, errdefs.Validationf("stream.subscribe_node: buffer_size must be positive")
 }
 
-type streamDeltaIterator struct {
+type streamNodeIterator struct {
 	ctx    context.Context
 	cancel context.CancelFunc
 	sub    event.Subscription
@@ -161,27 +163,36 @@ type streamDeltaIterator struct {
 	once    sync.Once
 }
 
-// Next blocks until the next matching delta arrives. It returns false when
+// Next blocks until the next matching node stream event arrives. It returns false when
 // the subscription or parent execution context is closed.
-func (i *streamDeltaIterator) Next() bool {
+func (i *streamNodeIterator) Next() bool {
 	if i == nil || i.sub == nil {
 		return false
 	}
-	select {
-	case env, ok := <-i.sub.C():
-		if !ok {
+	for {
+		select {
+		case env, ok := <-i.sub.C():
+			if !ok {
+				return false
+			}
+			cur, terminal, ok := streamNodeEnvelopeToMap(env)
+			if !ok {
+				continue
+			}
+			i.mu.Lock()
+			i.current = cur
+			i.mu.Unlock()
+			if terminal {
+				_ = i.Close()
+			}
+			return true
+		case <-i.ctx.Done():
 			return false
 		}
-		i.mu.Lock()
-		i.current = streamDeltaEnvelopeToMap(env)
-		i.mu.Unlock()
-		return true
-	case <-i.ctx.Done():
-		return false
 	}
 }
 
-func (i *streamDeltaIterator) Current() map[string]any {
+func (i *streamNodeIterator) Current() map[string]any {
 	if i == nil {
 		return nil
 	}
@@ -197,7 +208,7 @@ func (i *streamDeltaIterator) Current() map[string]any {
 	return out
 }
 
-func (i *streamDeltaIterator) Close() error {
+func (i *streamNodeIterator) Close() error {
 	if i == nil {
 		return nil
 	}
@@ -211,12 +222,56 @@ func (i *streamDeltaIterator) Close() error {
 	return err
 }
 
+func streamNodeEnvelopeToMap(env event.Envelope) (map[string]any, bool, bool) {
+	if engine.IsStreamDelta(env.Subject) {
+		return streamDeltaEnvelopeToMap(env), false, true
+	}
+
+	str := string(env.Subject)
+	if !strings.Contains(str, ".step.") {
+		return nil, false, false
+	}
+	switch {
+	case strings.HasSuffix(str, ".start"):
+		return streamLifecycleEnvelopeToMap(env, "step.started", ""), false, true
+	case strings.HasSuffix(str, ".complete"):
+		return streamLifecycleEnvelopeToMap(env, "step.ended", "success"), true, true
+	case strings.HasSuffix(str, ".error"):
+		return streamLifecycleEnvelopeToMap(env, "step.ended", "error"), true, true
+	case strings.HasSuffix(str, ".skipped"):
+		return streamLifecycleEnvelopeToMap(env, "step.skipped", "skipped"), true, true
+	}
+	return nil, false, false
+}
+
 func streamDeltaEnvelopeToMap(env event.Envelope) map[string]any {
 	out := decodeStreamDeltaPayloadMap(env)
 	if out == nil {
 		out = make(map[string]any, 8)
 	}
+	out["event"] = "stream.delta"
 
+	addStreamEnvelopeMetadata(out, env)
+	return out
+}
+
+func streamLifecycleEnvelopeToMap(env event.Envelope, eventName, status string) map[string]any {
+	out := decodeEnvelopePayloadMap(env)
+	if out == nil {
+		out = make(map[string]any, 8)
+	}
+	out["event"] = eventName
+	if status != "" {
+		if _, ok := out["status"]; !ok {
+			out["status"] = status
+		}
+	}
+
+	addStreamEnvelopeMetadata(out, env)
+	return out
+}
+
+func addStreamEnvelopeMetadata(out map[string]any, env event.Envelope) {
 	// Preserve payload "id" for tool_call deltas; envelope id is always
 	// available under envelope_id and also under id when payload.id is absent.
 	if _, ok := out["id"]; !ok {
@@ -237,7 +292,6 @@ func streamDeltaEnvelopeToMap(env event.Envelope) map[string]any {
 	if env.SpanID != "" {
 		out["span_id"] = env.SpanID
 	}
-	return out
 }
 
 func decodeStreamDeltaPayloadMap(env event.Envelope) map[string]any {
@@ -251,6 +305,21 @@ func decodeStreamDeltaPayloadMap(env event.Envelope) map[string]any {
 	p, err := engine.DecodeStreamDelta(env)
 	if err == nil {
 		return streamDeltaPayloadToMap(p)
+	}
+	return map[string]any{"raw": string(env.Payload)}
+}
+
+func decodeEnvelopePayloadMap(env event.Envelope) map[string]any {
+	if len(env.Payload) == 0 {
+		return nil
+	}
+	var asMap map[string]any
+	if err := json.Unmarshal(env.Payload, &asMap); err == nil && asMap != nil {
+		return asMap
+	}
+	var generic any
+	if err := json.Unmarshal(env.Payload, &generic); err == nil {
+		return map[string]any{"value": generic}
 	}
 	return map[string]any{"raw": string(env.Payload)}
 }

--- a/sdk/graph/node/scriptnode/bridge_stream.go
+++ b/sdk/graph/node/scriptnode/bridge_stream.go
@@ -1,0 +1,301 @@
+package scriptnode
+
+import (
+	"context"
+	"encoding/json"
+	"sync"
+	"time"
+
+	"github.com/GizClaw/flowcraft/sdk/engine"
+	"github.com/GizClaw/flowcraft/sdk/errdefs"
+	"github.com/GizClaw/flowcraft/sdk/event"
+	"github.com/GizClaw/flowcraft/sdk/script/bindings"
+)
+
+const defaultStreamSubBufferSize = 256
+
+// newStreamBridge exposes graph stream-delta subscriptions to scripts as
+// the global "stream".
+//
+// Script-facing API:
+//
+//	stream.subscribe_node({ node_id: "planner", run_id: "...", buffer_size: 256 })
+//	    -> { next, current, close }
+func newStreamBridge(defaultRunID string, bus event.Bus) bindings.BindingFunc {
+	return func(callCtx context.Context) (string, any) {
+		if callCtx == nil {
+			callCtx = context.Background()
+		}
+
+		return "stream", map[string]any{
+			"subscribe_node": func(raw any) (map[string]any, error) {
+				if bus == nil {
+					return nil, errdefs.NotAvailablef("stream.subscribe_node: event bus not configured")
+				}
+
+				opts, err := parseStreamSubscribeOptions(raw, defaultRunID)
+				if err != nil {
+					return nil, err
+				}
+
+				subCtx, cancel := context.WithCancel(callCtx)
+				sub, err := bus.Subscribe(
+					subCtx,
+					engine.PatternRunStream(opts.runID),
+					event.WithBufferSize(opts.bufferSize),
+					// Keep the publisher path non-blocking when scripts are slow:
+					// a full subscription buffer drops the incoming newest delta.
+					event.WithBackpressure(event.DropNewest),
+					event.WithPredicate(func(env event.Envelope) bool {
+						return env.NodeID() == opts.nodeID
+					}),
+				)
+				if err != nil {
+					cancel()
+					return nil, err
+				}
+
+				iter := &streamDeltaIterator{
+					ctx:    subCtx,
+					cancel: cancel,
+					sub:    sub,
+				}
+				return map[string]any{
+					"next":    iter.Next,
+					"current": iter.Current,
+					"close":   iter.Close,
+				}, nil
+			},
+		}
+	}
+}
+
+type streamSubscribeOptions struct {
+	nodeID     string
+	runID      string
+	bufferSize int
+}
+
+func parseStreamSubscribeOptions(raw any, defaultRunID string) (streamSubscribeOptions, error) {
+	opts := streamSubscribeOptions{
+		runID:      defaultRunID,
+		bufferSize: defaultStreamSubBufferSize,
+	}
+	m, ok := raw.(map[string]any)
+	if !ok {
+		return opts, errdefs.Validationf("stream.subscribe_node: options must be an object, got %T", raw)
+	}
+	if v, ok := m["node_id"].(string); ok {
+		opts.nodeID = v
+	}
+	if opts.nodeID == "" {
+		return opts, errdefs.Validationf("stream.subscribe_node: node_id is required")
+	}
+	if v, ok := m["run_id"]; ok && v != nil {
+		s, ok := v.(string)
+		if !ok {
+			return opts, errdefs.Validationf("stream.subscribe_node: run_id must be a string, got %T", v)
+		}
+		opts.runID = s
+	}
+	if opts.runID == "" {
+		return opts, errdefs.Validationf("stream.subscribe_node: run_id is required")
+	}
+	if v, ok := m["buffer_size"]; ok && v != nil {
+		n, err := streamBufferSize(v)
+		if err != nil {
+			return opts, err
+		}
+		opts.bufferSize = n
+	}
+	return opts, nil
+}
+
+func streamBufferSize(v any) (int, error) {
+	switch n := v.(type) {
+	case int:
+		if n > 0 {
+			return n, nil
+		}
+	case int32:
+		if n > 0 {
+			return int(n), nil
+		}
+	case int64:
+		if n > 0 {
+			return int(n), nil
+		}
+	case uint:
+		if n > 0 {
+			return int(n), nil
+		}
+	case uint32:
+		if n > 0 {
+			return int(n), nil
+		}
+	case uint64:
+		if n > 0 {
+			return int(n), nil
+		}
+	case float32:
+		if n > 0 {
+			return int(n), nil
+		}
+	case float64:
+		if n > 0 {
+			return int(n), nil
+		}
+	default:
+		return 0, errdefs.Validationf("stream.subscribe_node: buffer_size must be a positive number, got %T", v)
+	}
+	return 0, errdefs.Validationf("stream.subscribe_node: buffer_size must be positive")
+}
+
+type streamDeltaIterator struct {
+	ctx    context.Context
+	cancel context.CancelFunc
+	sub    event.Subscription
+
+	mu      sync.Mutex
+	current map[string]any
+	once    sync.Once
+}
+
+// Next blocks until the next matching delta arrives. It returns false when
+// the subscription or parent execution context is closed.
+func (i *streamDeltaIterator) Next() bool {
+	if i == nil || i.sub == nil {
+		return false
+	}
+	select {
+	case env, ok := <-i.sub.C():
+		if !ok {
+			return false
+		}
+		i.mu.Lock()
+		i.current = streamDeltaEnvelopeToMap(env)
+		i.mu.Unlock()
+		return true
+	case <-i.ctx.Done():
+		return false
+	}
+}
+
+func (i *streamDeltaIterator) Current() map[string]any {
+	if i == nil {
+		return nil
+	}
+	i.mu.Lock()
+	defer i.mu.Unlock()
+	if i.current == nil {
+		return nil
+	}
+	out := make(map[string]any, len(i.current))
+	for k, v := range i.current {
+		out[k] = v
+	}
+	return out
+}
+
+func (i *streamDeltaIterator) Close() error {
+	if i == nil {
+		return nil
+	}
+	var err error
+	i.once.Do(func() {
+		i.cancel()
+		if i.sub != nil {
+			err = i.sub.Close()
+		}
+	})
+	return err
+}
+
+func streamDeltaEnvelopeToMap(env event.Envelope) map[string]any {
+	out := decodeStreamDeltaPayloadMap(env)
+	if out == nil {
+		out = make(map[string]any, 8)
+	}
+
+	// Preserve payload "id" for tool_call deltas; envelope id is always
+	// available under envelope_id and also under id when payload.id is absent.
+	if _, ok := out["id"]; !ok {
+		out["id"] = env.ID
+	}
+	out["envelope_id"] = env.ID
+	out["subject"] = string(env.Subject)
+	out["time"] = formatEnvelopeTime(env.Time)
+	out["run_id"] = env.RunID()
+	out["node_id"] = env.NodeID()
+	out["agent_id"] = env.AgentID()
+	if env.Source != "" {
+		out["source"] = env.Source
+	}
+	if env.TraceID != "" {
+		out["trace_id"] = env.TraceID
+	}
+	if env.SpanID != "" {
+		out["span_id"] = env.SpanID
+	}
+	return out
+}
+
+func decodeStreamDeltaPayloadMap(env event.Envelope) map[string]any {
+	if len(env.Payload) == 0 {
+		return nil
+	}
+	var asMap map[string]any
+	if err := json.Unmarshal(env.Payload, &asMap); err == nil && asMap != nil {
+		return asMap
+	}
+	p, err := engine.DecodeStreamDelta(env)
+	if err == nil {
+		return streamDeltaPayloadToMap(p)
+	}
+	return map[string]any{"raw": string(env.Payload)}
+}
+
+func streamDeltaPayloadToMap(p engine.StreamDeltaPayload) map[string]any {
+	out := map[string]any{"type": string(p.Type)}
+	if p.Content != "" {
+		out["content"] = p.Content
+	}
+	if p.ID != "" {
+		out["id"] = p.ID
+	}
+	if p.Name != "" {
+		out["name"] = p.Name
+	}
+	if p.Arguments != nil {
+		out["arguments"] = p.Arguments
+	}
+	if p.ToolCallID != "" {
+		out["tool_call_id"] = p.ToolCallID
+	}
+	if p.IsError {
+		out["is_error"] = true
+	}
+	if p.Cancelled {
+		out["cancelled"] = true
+	}
+	if p.Speculative {
+		out["speculative"] = true
+	}
+	if p.ForkID != "" {
+		out["fork_id"] = p.ForkID
+	}
+	if p.BranchID != "" {
+		out["branch_id"] = p.BranchID
+	}
+	if p.Reason != "" {
+		out["reason"] = p.Reason
+	}
+	return out
+}
+
+func formatEnvelopeTime(t time.Time) string {
+	if t.IsZero() {
+		return ""
+	}
+	return t.Format(time.RFC3339Nano)
+}

--- a/sdk/graph/node/scriptnode/bridge_stream_test.go
+++ b/sdk/graph/node/scriptnode/bridge_stream_test.go
@@ -1,0 +1,396 @@
+package scriptnode
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/GizClaw/flowcraft/sdk/engine"
+	"github.com/GizClaw/flowcraft/sdk/errdefs"
+	"github.com/GizClaw/flowcraft/sdk/event"
+	"github.com/GizClaw/flowcraft/sdk/graph"
+	nodepkg "github.com/GizClaw/flowcraft/sdk/graph/node"
+	"github.com/GizClaw/flowcraft/sdk/script/jsrt"
+)
+
+func TestStreamBridge_SubscribeNode_NoEventBusIsNotAvailable(t *testing.T) {
+	subscribe := streamSubscribeFunc(t, "run-1", nil)
+
+	_, err := subscribe(map[string]any{"node_id": "planner"})
+	if !errdefs.IsNotAvailable(err) {
+		t.Fatalf("subscribe_node error = %v, want NotAvailable", err)
+	}
+}
+
+func TestStreamBridge_SubscribeNode_FiltersNodeAndProjectsCurrent(t *testing.T) {
+	bus := event.NewMemoryBus()
+	t.Cleanup(func() { _ = bus.Close() })
+
+	subscribe := streamSubscribeFunc(t, "run-1", bus)
+	iter, err := subscribe(map[string]any{"node_id": "planner"})
+	if err != nil {
+		t.Fatalf("subscribe_node: %v", err)
+	}
+	defer iter["close"].(func() error)()
+
+	publishStreamDelta(t, bus, "run-1", "other", "agent-a", "ignore me")
+	publishStreamDelta(t, bus, "run-1", "planner", "agent-a", "keep me")
+
+	if !iter["next"].(func() bool)() {
+		t.Fatal("next() = false, want matching delta")
+	}
+	cur := iter["current"].(func() map[string]any)()
+	checkCurrentDelta(t, cur, map[string]any{
+		"type":     "token",
+		"content":  "keep me",
+		"run_id":   "run-1",
+		"node_id":  "planner",
+		"agent_id": "agent-a",
+	})
+	if cur["subject"] == "" {
+		t.Fatalf("current.subject missing: %+v", cur)
+	}
+	if cur["id"] == "" || cur["envelope_id"] == "" {
+		t.Fatalf("current envelope id missing: %+v", cur)
+	}
+	if cur["time"] == "" {
+		t.Fatalf("current.time missing: %+v", cur)
+	}
+}
+
+func TestStreamBridge_SubscribeNode_RunIDOverrideFiltersDefaultRun(t *testing.T) {
+	bus := event.NewMemoryBus()
+	t.Cleanup(func() { _ = bus.Close() })
+
+	subscribe := streamSubscribeFunc(t, "run-default", bus)
+	iter, err := subscribe(map[string]any{"run_id": "run-override", "node_id": "planner"})
+	if err != nil {
+		t.Fatalf("subscribe_node: %v", err)
+	}
+	defer iter["close"].(func() error)()
+
+	publishStreamDelta(t, bus, "run-default", "planner", "agent-a", "default run")
+	publishStreamDelta(t, bus, "run-override", "planner", "agent-a", "override run")
+
+	if !iter["next"].(func() bool)() {
+		t.Fatal("next() = false, want override run delta")
+	}
+	cur := iter["current"].(func() map[string]any)()
+	checkCurrentDelta(t, cur, map[string]any{
+		"content": "override run",
+		"run_id":  "run-override",
+		"node_id": "planner",
+	})
+}
+
+func TestStreamBridge_SubscribeNode_CurrentPreservesPayloadObjectFields(t *testing.T) {
+	tests := []struct {
+		name    string
+		payload map[string]any
+		want    map[string]any
+	}{
+		{
+			name:    "custom progress field",
+			payload: map[string]any{"type": "progress", "pct": 0.5},
+			want:    map[string]any{"type": "progress", "pct": 0.5},
+		},
+		{
+			name:    "bare emit payload field",
+			payload: map[string]any{"type": "token", "payload": "x"},
+			want:    map[string]any{"type": "token", "payload": "x"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			bus := event.NewMemoryBus()
+			t.Cleanup(func() { _ = bus.Close() })
+
+			subscribe := streamSubscribeFunc(t, "run-1", bus)
+			iter, err := subscribe(map[string]any{"node_id": "planner"})
+			if err != nil {
+				t.Fatalf("subscribe_node: %v", err)
+			}
+			defer iter["close"].(func() error)()
+
+			publishStreamDeltaPayload(t, bus, "run-1", "planner", "agent-a", tt.payload)
+			if !iter["next"].(func() bool)() {
+				t.Fatal("next() = false, want matching delta")
+			}
+			cur := iter["current"].(func() map[string]any)()
+			checkCurrentDelta(t, cur, tt.want)
+		})
+	}
+}
+
+func TestStreamBridge_SubscribeNode_NextReturnsFalseWhenCallContextCanceled(t *testing.T) {
+	bus := event.NewMemoryBus()
+	t.Cleanup(func() { _ = bus.Close() })
+
+	ctx, cancel := context.WithCancel(context.Background())
+	subscribe := streamSubscribeFuncWithContext(t, ctx, "run-1", bus)
+	iter, err := subscribe(map[string]any{"node_id": "planner"})
+	if err != nil {
+		t.Fatalf("subscribe_node: %v", err)
+	}
+	defer iter["close"].(func() error)()
+
+	started := make(chan struct{})
+	done := make(chan bool, 1)
+	go func() {
+		close(started)
+		done <- iter["next"].(func() bool)()
+	}()
+
+	<-started
+	cancel()
+
+	select {
+	case got := <-done:
+		if got {
+			t.Fatal("next() after call context cancel = true, want false")
+		}
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("next() did not unblock after call context cancel")
+	}
+}
+
+func TestStreamBridge_SubscribeNode_CloseMakesNextFalse(t *testing.T) {
+	bus := event.NewMemoryBus()
+	t.Cleanup(func() { _ = bus.Close() })
+
+	subscribe := streamSubscribeFunc(t, "run-1", bus)
+	iter, err := subscribe(map[string]any{"node_id": "planner"})
+	if err != nil {
+		t.Fatalf("subscribe_node: %v", err)
+	}
+	if err := iter["close"].(func() error)(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+	if iter["next"].(func() bool)() {
+		t.Fatal("next() after close = true, want false")
+	}
+}
+
+func TestStreamBridge_SubscribeNode_DropNewestPublishIsNonBlocking(t *testing.T) {
+	bus := event.NewMemoryBus()
+	t.Cleanup(func() { _ = bus.Close() })
+
+	subscribe := streamSubscribeFunc(t, "run-1", bus)
+	iter, err := subscribe(map[string]any{"node_id": "planner", "buffer_size": 1})
+	if err != nil {
+		t.Fatalf("subscribe_node: %v", err)
+	}
+	defer iter["close"].(func() error)()
+
+	envs := []event.Envelope{
+		newStreamDeltaEnvelope(t, "run-1", "planner", "agent-a", "first"),
+		newStreamDeltaEnvelope(t, "run-1", "planner", "agent-a", "second"),
+		newStreamDeltaEnvelope(t, "run-1", "planner", "agent-a", "third"),
+	}
+	done := make(chan error, 1)
+	go func() {
+		for _, env := range envs {
+			if err := bus.Publish(context.Background(), env); err != nil {
+				done <- err
+				return
+			}
+		}
+		done <- nil
+	}()
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("publish: %v", err)
+		}
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("publish blocked with full stream subscription buffer")
+	}
+
+	if !iter["next"].(func() bool)() {
+		t.Fatal("next() = false, want buffered first delta")
+	}
+	cur := iter["current"].(func() map[string]any)()
+	checkCurrentDelta(t, cur, map[string]any{"content": "first"})
+}
+
+func TestStreamBridge_SubscribeNode_InvalidBufferSize(t *testing.T) {
+	bus := event.NewMemoryBus()
+	t.Cleanup(func() { _ = bus.Close() })
+
+	subscribe := streamSubscribeFunc(t, "run-1", bus)
+	tests := []struct {
+		name  string
+		value any
+	}{
+		{name: "zero", value: 0},
+		{name: "negative", value: -1},
+		{name: "non number", value: "1"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := subscribe(map[string]any{"node_id": "planner", "buffer_size": tt.value})
+			if !errdefs.IsValidation(err) {
+				t.Fatalf("subscribe_node error = %v, want Validation", err)
+			}
+		})
+	}
+}
+
+func TestScriptNode_StreamBridge_SubscribeNodeFromScript(t *testing.T) {
+	mem := event.NewMemoryBus()
+	t.Cleanup(func() { _ = mem.Close() })
+	bus := &subscribeNotifyBus{
+		Bus:        mem,
+		subscribed: make(chan struct{}),
+	}
+
+	rt := jsrt.New(jsrt.WithPoolSize(1))
+	factory := nodepkg.NewFactory()
+	Register(factory, Deps{ScriptRuntime: rt, EventBus: bus})
+	n, err := factory.Build(graph.NodeDefinition{
+		ID:   "listener",
+		Type: "script",
+		Config: map[string]any{
+			"source": `
+				var sub = stream.subscribe_node({ node_id: "planner" });
+				if (!sub.next()) throw new Error("expected a stream delta");
+				var d = sub.current();
+				board.setVar("stream_content", d.content);
+				board.setVar("stream_run_id", d.run_id);
+				board.setVar("stream_node_id", d.node_id);
+				board.setVar("stream_agent_id", d.agent_id);
+				board.setVar("stream_subject", d.subject);
+				board.setVar("stream_has_envelope_id", !!d.envelope_id);
+				sub.close();
+			`,
+		},
+	})
+	if err != nil {
+		t.Fatalf("build script node: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	board := graph.NewBoard()
+	done := make(chan error, 1)
+	go func() {
+		done <- n.ExecuteBoard(graph.ExecutionContext{Context: ctx, RunID: "run-js"}, board)
+	}()
+
+	select {
+	case <-bus.subscribed:
+	case <-ctx.Done():
+		t.Fatalf("script did not subscribe: %v", ctx.Err())
+	}
+
+	publishStreamDelta(t, mem, "run-js", "other", "agent-js", "ignore me")
+	publishStreamDelta(t, mem, "run-js", "planner", "agent-js", "hello script")
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("ExecuteBoard: %v", err)
+		}
+	case <-ctx.Done():
+		t.Fatalf("ExecuteBoard did not finish: %v", ctx.Err())
+	}
+
+	boardChecks := map[string]any{
+		"stream_content":         "hello script",
+		"stream_run_id":          "run-js",
+		"stream_node_id":         "planner",
+		"stream_agent_id":        "agent-js",
+		"stream_has_envelope_id": true,
+	}
+	for key, want := range boardChecks {
+		got, _ := board.GetVar(key)
+		if got != want {
+			t.Fatalf("%s = %v, want %v", key, got, want)
+		}
+	}
+	if got, _ := board.GetVar("stream_subject"); got == "" {
+		t.Fatal("stream_subject missing")
+	}
+}
+
+func streamSubscribeFunc(t *testing.T, runID string, bus event.Bus) func(any) (map[string]any, error) {
+	t.Helper()
+	return streamSubscribeFuncWithContext(t, context.Background(), runID, bus)
+}
+
+func streamSubscribeFuncWithContext(t *testing.T, ctx context.Context, runID string, bus event.Bus) func(any) (map[string]any, error) {
+	t.Helper()
+	_, raw := newStreamBridge(runID, bus)(ctx)
+	api, ok := raw.(map[string]any)
+	if !ok {
+		t.Fatalf("stream bridge shape = %T", raw)
+	}
+	subscribe, ok := api["subscribe_node"].(func(any) (map[string]any, error))
+	if !ok {
+		t.Fatalf("subscribe_node shape = %T", api["subscribe_node"])
+	}
+	return subscribe
+}
+
+func publishStreamDelta(t *testing.T, bus event.Bus, runID, nodeID, agentID, content string) {
+	t.Helper()
+	publishStreamDeltaPayload(t, bus, runID, nodeID, agentID, engine.StreamDeltaPayload{
+		Type:    engine.StreamDeltaToken,
+		Content: content,
+	})
+}
+
+func publishStreamDeltaPayload(t *testing.T, bus event.Bus, runID, nodeID, agentID string, payload any) {
+	t.Helper()
+	env := newStreamDeltaPayloadEnvelope(t, runID, nodeID, agentID, payload)
+	if err := bus.Publish(context.Background(), env); err != nil {
+		t.Fatalf("publish %s: %v", nodeID, err)
+	}
+}
+
+func newStreamDeltaEnvelope(t *testing.T, runID, nodeID, agentID, content string) event.Envelope {
+	t.Helper()
+	return newStreamDeltaPayloadEnvelope(t, runID, nodeID, agentID, engine.StreamDeltaPayload{
+		Type:    engine.StreamDeltaToken,
+		Content: content,
+	})
+}
+
+func newStreamDeltaPayloadEnvelope(t *testing.T, runID, nodeID, agentID string, payload any) event.Envelope {
+	t.Helper()
+	subject := engine.SubjectStreamDelta(runID, agentID+".node."+nodeID)
+	env, err := event.NewEnvelope(context.Background(), subject, payload)
+	if err != nil {
+		t.Fatalf("new envelope: %v", err)
+	}
+	env.SetRunID(runID)
+	env.SetNodeID(nodeID)
+	env.SetAgentID(agentID)
+	return env
+}
+
+func checkCurrentDelta(t *testing.T, cur map[string]any, want map[string]any) {
+	t.Helper()
+	for key, expected := range want {
+		if got := cur[key]; got != expected {
+			t.Fatalf("current.%s = %v, want %v (current=%+v)", key, got, expected, cur)
+		}
+	}
+}
+
+type subscribeNotifyBus struct {
+	event.Bus
+	subscribed chan struct{}
+	once       sync.Once
+}
+
+func (b *subscribeNotifyBus) Subscribe(ctx context.Context, pattern event.Pattern, opts ...event.SubOption) (event.Subscription, error) {
+	sub, err := b.Bus.Subscribe(ctx, pattern, opts...)
+	if err == nil {
+		b.once.Do(func() { close(b.subscribed) })
+	}
+	return sub, err
+}

--- a/sdk/graph/node/scriptnode/bridge_stream_test.go
+++ b/sdk/graph/node/scriptnode/bridge_stream_test.go
@@ -124,6 +124,137 @@ func TestStreamBridge_SubscribeNode_CurrentPreservesPayloadObjectFields(t *testi
 	}
 }
 
+func TestStreamBridge_SubscribeNode_SeesLifecycleDeltaEndedInOrder(t *testing.T) {
+	bus := event.NewMemoryBus()
+	t.Cleanup(func() { _ = bus.Close() })
+
+	subscribe := streamSubscribeFunc(t, "run-1", bus)
+	iter, err := subscribe(map[string]any{"node_id": "planner"})
+	if err != nil {
+		t.Fatalf("subscribe_node: %v", err)
+	}
+	defer iter["close"].(func() error)()
+
+	publishStepLifecycle(t, bus, "run-1", "planner", "agent-a", "start", nil)
+	publishStreamDelta(t, bus, "run-1", "planner", "agent-a", "hello")
+	publishStepLifecycle(t, bus, "run-1", "planner", "agent-a", "complete", map[string]any{
+		"iteration": 1,
+	})
+
+	if !iter["next"].(func() bool)() {
+		t.Fatal("next() = false, want step.started")
+	}
+	checkCurrentEvent(t, iter["current"].(func() map[string]any)(), map[string]any{
+		"event":    "step.started",
+		"run_id":   "run-1",
+		"node_id":  "planner",
+		"agent_id": "agent-a",
+	})
+
+	if !iter["next"].(func() bool)() {
+		t.Fatal("next() = false, want stream.delta")
+	}
+	checkCurrentDelta(t, iter["current"].(func() map[string]any)(), map[string]any{
+		"type":    "token",
+		"content": "hello",
+	})
+
+	if !iter["next"].(func() bool)() {
+		t.Fatal("next() = false, want step.ended")
+	}
+	cur := iter["current"].(func() map[string]any)()
+	checkCurrentEvent(t, cur, map[string]any{
+		"event":     "step.ended",
+		"status":    "success",
+		"iteration": float64(1),
+		"run_id":    "run-1",
+		"node_id":   "planner",
+		"agent_id":  "agent-a",
+	})
+	if iter["next"].(func() bool)() {
+		t.Fatal("next() after step.ended = true, want false")
+	}
+}
+
+func TestStreamBridge_SubscribeNode_StepErrorFoldsToEndedAndCloses(t *testing.T) {
+	bus := event.NewMemoryBus()
+	t.Cleanup(func() { _ = bus.Close() })
+
+	subscribe := streamSubscribeFunc(t, "run-1", bus)
+	iter, err := subscribe(map[string]any{"node_id": "planner"})
+	if err != nil {
+		t.Fatalf("subscribe_node: %v", err)
+	}
+	defer iter["close"].(func() error)()
+
+	publishStepLifecycle(t, bus, "run-1", "planner", "agent-a", "error", map[string]any{
+		"error": "boom",
+	})
+
+	if !iter["next"].(func() bool)() {
+		t.Fatal("next() = false, want step.error as step.ended")
+	}
+	checkCurrentEvent(t, iter["current"].(func() map[string]any)(), map[string]any{
+		"event":  "step.ended",
+		"status": "error",
+		"error":  "boom",
+	})
+	if iter["next"].(func() bool)() {
+		t.Fatal("next() after step.error = true, want false")
+	}
+}
+
+func TestStreamBridge_SubscribeNode_StepSkippedIsTerminal(t *testing.T) {
+	bus := event.NewMemoryBus()
+	t.Cleanup(func() { _ = bus.Close() })
+
+	subscribe := streamSubscribeFunc(t, "run-1", bus)
+	iter, err := subscribe(map[string]any{"node_id": "planner"})
+	if err != nil {
+		t.Fatalf("subscribe_node: %v", err)
+	}
+	defer iter["close"].(func() error)()
+
+	publishStepLifecycle(t, bus, "run-1", "planner", "agent-a", "skipped", nil)
+
+	if !iter["next"].(func() bool)() {
+		t.Fatal("next() = false, want step.skipped")
+	}
+	checkCurrentEvent(t, iter["current"].(func() map[string]any)(), map[string]any{
+		"event":    "step.skipped",
+		"status":   "skipped",
+		"run_id":   "run-1",
+		"node_id":  "planner",
+		"agent_id": "agent-a",
+	})
+	if iter["next"].(func() bool)() {
+		t.Fatal("next() after step.skipped = true, want false")
+	}
+}
+
+func TestStreamBridge_SubscribeNode_FiltersOtherNodeLifecycleEvents(t *testing.T) {
+	bus := event.NewMemoryBus()
+	t.Cleanup(func() { _ = bus.Close() })
+
+	subscribe := streamSubscribeFunc(t, "run-1", bus)
+	iter, err := subscribe(map[string]any{"node_id": "planner"})
+	if err != nil {
+		t.Fatalf("subscribe_node: %v", err)
+	}
+	defer iter["close"].(func() error)()
+
+	publishStepLifecycle(t, bus, "run-1", "other", "agent-a", "skipped", nil)
+	publishStepLifecycle(t, bus, "run-1", "planner", "agent-a", "start", nil)
+
+	if !iter["next"].(func() bool)() {
+		t.Fatal("next() = false, want target node step.started")
+	}
+	checkCurrentEvent(t, iter["current"].(func() map[string]any)(), map[string]any{
+		"event":   "step.started",
+		"node_id": "planner",
+	})
+}
+
 func TestStreamBridge_SubscribeNode_NextReturnsFalseWhenCallContextCanceled(t *testing.T) {
 	bus := event.NewMemoryBus()
 	t.Cleanup(func() { _ = bus.Close() })
@@ -173,7 +304,7 @@ func TestStreamBridge_SubscribeNode_CloseMakesNextFalse(t *testing.T) {
 	}
 }
 
-func TestStreamBridge_SubscribeNode_DropNewestPublishIsNonBlocking(t *testing.T) {
+func TestStreamBridge_SubscribeNode_FullBufferPreservesTerminalEvent(t *testing.T) {
 	bus := event.NewMemoryBus()
 	t.Cleanup(func() { _ = bus.Close() })
 
@@ -187,7 +318,7 @@ func TestStreamBridge_SubscribeNode_DropNewestPublishIsNonBlocking(t *testing.T)
 	envs := []event.Envelope{
 		newStreamDeltaEnvelope(t, "run-1", "planner", "agent-a", "first"),
 		newStreamDeltaEnvelope(t, "run-1", "planner", "agent-a", "second"),
-		newStreamDeltaEnvelope(t, "run-1", "planner", "agent-a", "third"),
+		newStepLifecycleEnvelope(t, "run-1", "planner", "agent-a", "complete", nil),
 	}
 	done := make(chan error, 1)
 	go func() {
@@ -206,14 +337,20 @@ func TestStreamBridge_SubscribeNode_DropNewestPublishIsNonBlocking(t *testing.T)
 			t.Fatalf("publish: %v", err)
 		}
 	case <-time.After(500 * time.Millisecond):
-		t.Fatal("publish blocked with full stream subscription buffer")
+		t.Fatal("publish blocked with full node subscription buffer")
 	}
 
 	if !iter["next"].(func() bool)() {
-		t.Fatal("next() = false, want buffered first delta")
+		t.Fatal("next() = false, want terminal event preserved")
 	}
 	cur := iter["current"].(func() map[string]any)()
-	checkCurrentDelta(t, cur, map[string]any{"content": "first"})
+	checkCurrentEvent(t, cur, map[string]any{
+		"event":  "step.ended",
+		"status": "success",
+	})
+	if iter["next"].(func() bool)() {
+		t.Fatal("next() after preserved terminal event = true, want false")
+	}
 }
 
 func TestStreamBridge_SubscribeNode_InvalidBufferSize(t *testing.T) {
@@ -372,11 +509,66 @@ func newStreamDeltaPayloadEnvelope(t *testing.T, runID, nodeID, agentID string, 
 	return env
 }
 
+func publishStepLifecycle(t *testing.T, bus event.Bus, runID, nodeID, agentID, kind string, payload any) {
+	t.Helper()
+	env := newStepLifecycleEnvelope(t, runID, nodeID, agentID, kind, payload)
+	if err := bus.Publish(context.Background(), env); err != nil {
+		t.Fatalf("publish %s %s: %v", nodeID, kind, err)
+	}
+}
+
+func newStepLifecycleEnvelope(t *testing.T, runID, nodeID, agentID, kind string, payload any) event.Envelope {
+	t.Helper()
+	stepActor := agentID + ".node." + nodeID
+	var subject event.Subject
+	switch kind {
+	case "start":
+		subject = engine.SubjectStepStart(runID, stepActor)
+	case "complete":
+		subject = engine.SubjectStepComplete(runID, stepActor)
+	case "error":
+		subject = engine.SubjectStepError(runID, stepActor)
+	case "skipped":
+		subject = event.Subject(engine.SubjectPrefix + engine.SanitiseID(runID) + ".step." + engine.SanitiseID(stepActor) + ".skipped")
+	default:
+		t.Fatalf("unknown lifecycle kind %q", kind)
+	}
+	env, err := event.NewEnvelope(context.Background(), subject, payload)
+	if err != nil {
+		t.Fatalf("new lifecycle envelope: %v", err)
+	}
+	env.SetRunID(runID)
+	env.SetNodeID(nodeID)
+	env.SetAgentID(agentID)
+	return env
+}
+
 func checkCurrentDelta(t *testing.T, cur map[string]any, want map[string]any) {
 	t.Helper()
+	checkCurrentEvent(t, cur, map[string]any{"event": "stream.delta"})
 	for key, expected := range want {
 		if got := cur[key]; got != expected {
 			t.Fatalf("current.%s = %v, want %v (current=%+v)", key, got, expected, cur)
+		}
+	}
+}
+
+func checkCurrentEvent(t *testing.T, cur map[string]any, want map[string]any) {
+	t.Helper()
+	checkCurrentMetadata(t, cur)
+	for key, expected := range want {
+		if got := cur[key]; got != expected {
+			t.Fatalf("current.%s = %v, want %v (current=%+v)", key, got, expected, cur)
+		}
+	}
+}
+
+func checkCurrentMetadata(t *testing.T, cur map[string]any) {
+	t.Helper()
+	for _, key := range []string{"event", "run_id", "node_id", "agent_id", "subject", "envelope_id", "time"} {
+		v, ok := cur[key]
+		if !ok || v == "" {
+			t.Fatalf("current.%s missing: %+v", key, cur)
 		}
 	}
 }

--- a/sdk/graph/node/scriptnode/jsnode.go
+++ b/sdk/graph/node/scriptnode/jsnode.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/GizClaw/flowcraft/sdk/agent"
+	"github.com/GizClaw/flowcraft/sdk/event"
 	"github.com/GizClaw/flowcraft/sdk/graph"
 	"github.com/GizClaw/flowcraft/sdk/graph/node"
 	"github.com/GizClaw/flowcraft/sdk/script"
@@ -22,6 +23,7 @@ type ScriptNode struct {
 	script      string
 	config      map[string]any
 	runtime     script.Runtime
+	eventBus    event.Bus
 	extraBindFn []bindings.BindingFunc
 	inputPorts  []graph.Port
 	outputPorts []graph.Port
@@ -77,6 +79,7 @@ func (n *ScriptNode) ExecuteBoard(ctx graph.ExecutionContext, board *graph.Board
 		bindings.NewBoardBridge(board),
 		bindings.NewExprBridge(),
 		bindings.NewHostBridge(ctx.Host, n.id, ctx.Publisher),
+		newStreamBridge(ctx.RunID, n.eventBus),
 		newParallelBridge(),
 		// Reconstruct the full RunInfo from engine.Run.Attributes
 		// (promoted by agent.Run upstream) instead of the legacy

--- a/sdk/graph/node/scriptnode/register.go
+++ b/sdk/graph/node/scriptnode/register.go
@@ -4,6 +4,7 @@ import (
 	"io/fs"
 
 	"github.com/GizClaw/flowcraft/sdk/errdefs"
+	"github.com/GizClaw/flowcraft/sdk/event"
 	"github.com/GizClaw/flowcraft/sdk/graph"
 	"github.com/GizClaw/flowcraft/sdk/graph/node"
 	"github.com/GizClaw/flowcraft/sdk/graph/node/scripts"
@@ -26,6 +27,7 @@ type Deps struct {
 	ScriptFS      fs.FS
 	Workspace     workspace.Workspace
 	CommandRunner sandbox.Runner
+	EventBus      event.Bus
 }
 
 // needsShell lists built-in jsnode types that additionally require a
@@ -46,6 +48,12 @@ var needsShell = map[string]bool{
 // require deps.CommandRunner. Missing deps are reported as a build-time
 // validation error from Factory.Build.
 func Register(factory *node.Factory, deps Deps) {
+	newNode := func(id, nodeType, src string, config map[string]any, extras ...bindings.BindingFunc) *ScriptNode {
+		n := New(id, nodeType, src, config, deps.ScriptRuntime, extras...)
+		n.eventBus = deps.EventBus
+		return n
+	}
+
 	for _, name := range scripts.BuiltinTypes() {
 		n := name
 		factory.RegisterBuilder(n, func(def graph.NodeDefinition) (graph.Node, error) {
@@ -59,7 +67,7 @@ func Register(factory *node.Factory, deps Deps) {
 				extras = append(extras, bindings.NewShellBridge(deps.CommandRunner))
 			}
 			extras = append(extras, bindings.NewFSBridge(deps.Workspace))
-			return New(def.ID, n, src, def.Config, deps.ScriptRuntime, extras...), nil
+			return newNode(def.ID, n, src, def.Config, extras...), nil
 		})
 	}
 
@@ -73,7 +81,7 @@ func Register(factory *node.Factory, deps Deps) {
 			return nil, errdefs.Validationf(
 				"node %q (type script): config.source is required", def.ID)
 		}
-		return New(def.ID, "script", source, def.Config, deps.ScriptRuntime, bindings.NewFSBridge(deps.Workspace)), nil
+		return newNode(def.ID, "script", source, def.Config, bindings.NewFSBridge(deps.Workspace)), nil
 	})
 
 	factory.SetFallback(func(def graph.NodeDefinition) (graph.Node, error) {
@@ -84,7 +92,7 @@ func Register(factory *node.Factory, deps Deps) {
 					return nil, errdefs.Validationf(
 						"node %q (type %s): script runtime not configured", def.ID, def.Type)
 				}
-				return New(def.ID, def.Type, string(data), def.Config, deps.ScriptRuntime, bindings.NewFSBridge(deps.Workspace)), nil
+				return newNode(def.ID, def.Type, string(data), def.Config, bindings.NewFSBridge(deps.Workspace)), nil
 			}
 		}
 		return nil, errdefs.Validationf(


### PR DESCRIPTION
## Summary

Script nodes can now observe another node's live node event stream from inside their script without widening the engine host contract. The `stream.subscribe_node` binding exposes a pull iterator over the run's event bus, filters by the stable `node_id` envelope header, and returns both lifecycle boundaries and in-flight stream deltas.

Each `current()` result now includes an `event` field such as `step.started`, `stream.delta`, `step.ended`, or `step.skipped`. Terminal lifecycle events are delivered to the script before the iterator closes, so scripts can distinguish "the node has not emitted yet" from "the node is finished" without hanging forever. The subscription remains non-blocking for publishers by dropping older buffered events when scripts fall behind, which preserves the latest terminal boundary.

The API keeps raw payload object fields visible to scripts while adding envelope metadata such as run, node, agent, subject, envelope id, and timestamp. Scriptnode registration now accepts an optional `EventBus`; callers that do not wire one get a typed NotAvailable error instead of a partially working subscription.

## Test plan

- `go test ./sdk/graph/node/scriptnode ./sdk/event ./sdk/engine`

