### PR TITLE
fix(scriptnode): harden script bridge boundaries

### DIFF
--- a/sdk/engine/board.go
+++ b/sdk/engine/board.go
@@ -81,6 +81,13 @@ func (b *Board) SetVar(key string, value any) {
 	b.mu.Unlock()
 }
 
+// DeleteVar removes a board-level variable. Concurrent-safe.
+func (b *Board) DeleteVar(key string) {
+	b.mu.Lock()
+	delete(b.vars, key)
+	b.mu.Unlock()
+}
+
 // GetVar retrieves a board-level variable.
 func (b *Board) GetVar(key string) (any, bool) {
 	b.mu.RLock()

--- a/sdk/graph/node/scriptnode/bridge_stream.go
+++ b/sdk/graph/node/scriptnode/bridge_stream.go
@@ -64,7 +64,8 @@ func (r *streamCleanupRegistry) Close() {
 // Script-facing API:
 //
 //	stream.subscribe_node({ node_id: "planner", run_id: "...", buffer_size: 256 })
-//	    -> { next, current, close }
+//	stream.subscribe_node({ node_ids: ["planner", "executor"] })
+//	    -> { next, next_timeout_ms, current, close }
 func newStreamBridge(defaultRunID string, bus event.Bus) bindings.BindingFunc {
 	return func(callCtx context.Context) (string, any) {
 		if callCtx == nil {
@@ -92,7 +93,8 @@ func newStreamBridge(defaultRunID string, bus event.Bus) bindings.BindingFunc {
 					// lifecycle events still reach slow subscribers.
 					event.WithBackpressure(event.DropOldest),
 					event.WithPredicate(func(env event.Envelope) bool {
-						return env.NodeID() == opts.nodeID
+						_, ok := opts.nodeIDSet[env.NodeID()]
+						return ok
 					}),
 				)
 				if err != nil {
@@ -104,14 +106,18 @@ func newStreamBridge(defaultRunID string, bus event.Bus) bindings.BindingFunc {
 					ctx:    subCtx,
 					cancel: cancel,
 					sub:    sub,
+
+					targetNodeCount: len(opts.nodeIDSet),
+					terminalNodes:   make(map[string]struct{}, len(opts.nodeIDSet)),
 				}
 				if reg := streamCleanupFromContext(callCtx); reg != nil {
 					reg.Add(iter.Close)
 				}
 				return map[string]any{
-					"next":    iter.Next,
-					"current": iter.Current,
-					"close":   iter.Close,
+					"next":            iter.Next,
+					"next_timeout_ms": iter.NextTimeoutMS,
+					"current":         iter.Current,
+					"close":           iter.Close,
 				}, nil
 			},
 		}
@@ -120,6 +126,8 @@ func newStreamBridge(defaultRunID string, bus event.Bus) bindings.BindingFunc {
 
 type streamSubscribeOptions struct {
 	nodeID     string
+	nodeIDs    []string
+	nodeIDSet  map[string]struct{}
 	runID      string
 	bufferSize int
 }
@@ -133,11 +141,34 @@ func parseStreamSubscribeOptions(raw any, defaultRunID string) (streamSubscribeO
 	if !ok {
 		return opts, errdefs.Validationf("stream.subscribe_node: options must be an object, got %T", raw)
 	}
-	if v, ok := m["node_id"].(string); ok {
-		opts.nodeID = v
+	nodeIDRaw, hasNodeID := m["node_id"]
+	nodeIDsRaw, hasNodeIDs := m["node_ids"]
+	if hasNodeID && hasNodeIDs {
+		return opts, errdefs.Validationf("stream.subscribe_node: node_id and node_ids are mutually exclusive")
 	}
-	if opts.nodeID == "" {
-		return opts, errdefs.Validationf("stream.subscribe_node: node_id is required")
+	switch {
+	case hasNodeID:
+		s, ok := nodeIDRaw.(string)
+		if !ok {
+			return opts, errdefs.Validationf("stream.subscribe_node: node_id must be a string, got %T", nodeIDRaw)
+		}
+		if s == "" {
+			return opts, errdefs.Validationf("stream.subscribe_node: node_id must be a non-empty string")
+		}
+		opts.nodeID = s
+		opts.nodeIDs = []string{s}
+	case hasNodeIDs:
+		ids, err := streamNodeIDs(nodeIDsRaw)
+		if err != nil {
+			return opts, err
+		}
+		opts.nodeIDs = ids
+	default:
+		return opts, errdefs.Validationf("stream.subscribe_node: node_id or node_ids is required")
+	}
+	opts.nodeIDSet = make(map[string]struct{}, len(opts.nodeIDs))
+	for _, nodeID := range opts.nodeIDs {
+		opts.nodeIDSet[nodeID] = struct{}{}
 	}
 	if v, ok := m["run_id"]; ok && v != nil {
 		s, ok := v.(string)
@@ -160,6 +191,43 @@ func parseStreamSubscribeOptions(raw any, defaultRunID string) (streamSubscribeO
 		opts.bufferSize = n
 	}
 	return opts, nil
+}
+
+func streamNodeIDs(v any) ([]string, error) {
+	var raw []any
+	switch ids := v.(type) {
+	case []string:
+		out := append([]string(nil), ids...)
+		return validateStreamNodeIDs(out)
+	case []any:
+		raw = ids
+	default:
+		return nil, errdefs.Validationf("stream.subscribe_node: node_ids must be an array of strings, got %T", v)
+	}
+	if len(raw) == 0 {
+		return nil, errdefs.Validationf("stream.subscribe_node: node_ids must not be empty")
+	}
+	out := make([]string, 0, len(raw))
+	for idx, item := range raw {
+		s, ok := item.(string)
+		if !ok {
+			return nil, errdefs.Validationf("stream.subscribe_node: node_ids[%d] must be a string, got %T", idx, item)
+		}
+		out = append(out, s)
+	}
+	return validateStreamNodeIDs(out)
+}
+
+func validateStreamNodeIDs(ids []string) ([]string, error) {
+	if len(ids) == 0 {
+		return nil, errdefs.Validationf("stream.subscribe_node: node_ids must not be empty")
+	}
+	for idx, nodeID := range ids {
+		if nodeID == "" {
+			return nil, errdefs.Validationf("stream.subscribe_node: node_ids[%d] must be a non-empty string", idx)
+		}
+	}
+	return ids, nil
 }
 
 func streamBufferSize(v any) (int, error) {
@@ -216,13 +284,40 @@ type streamNodeIterator struct {
 	mu      sync.Mutex
 	current map[string]any
 	once    sync.Once
+
+	targetNodeCount int
+	terminalNodes   map[string]struct{}
 }
 
 // Next blocks until the next matching node stream event arrives. It returns false when
 // the subscription or parent execution context is closed.
 func (i *streamNodeIterator) Next() bool {
+	return i.next(false, 0)
+}
+
+// NextTimeoutMS waits up to ms for the next matching node stream event. Timeout
+// returns false without closing the subscription so scripts can fail open.
+func (i *streamNodeIterator) NextTimeoutMS(raw any) (bool, error) {
+	timeout, err := streamNextTimeout(raw)
+	if err != nil {
+		return false, err
+	}
+	return i.next(true, timeout), nil
+}
+
+func (i *streamNodeIterator) next(useTimeout bool, timeout time.Duration) bool {
 	if i == nil || i.sub == nil {
 		return false
+	}
+	if useTimeout && timeout == 0 {
+		return i.poll()
+	}
+	var timer *time.Timer
+	var timeoutC <-chan time.Time
+	if useTimeout && timeout > 0 {
+		timer = time.NewTimer(timeout)
+		timeoutC = timer.C
+		defer timer.Stop()
 	}
 	for {
 		select {
@@ -230,21 +325,55 @@ func (i *streamNodeIterator) Next() bool {
 			if !ok {
 				return false
 			}
-			cur, terminal, ok := streamNodeEnvelopeToMap(env)
-			if !ok {
-				continue
+			if i.acceptEnvelope(env) {
+				return true
 			}
-			i.mu.Lock()
-			i.current = cur
-			i.mu.Unlock()
-			if terminal {
-				_ = i.Close()
-			}
-			return true
 		case <-i.ctx.Done():
+			return false
+		case <-timeoutC:
 			return false
 		}
 	}
+}
+
+func (i *streamNodeIterator) poll() bool {
+	for {
+		select {
+		case env, ok := <-i.sub.C():
+			if !ok {
+				return false
+			}
+			if i.acceptEnvelope(env) {
+				return true
+			}
+		case <-i.ctx.Done():
+			return false
+		default:
+			return false
+		}
+	}
+}
+
+func (i *streamNodeIterator) acceptEnvelope(env event.Envelope) bool {
+	cur, terminal, ok := streamNodeEnvelopeToMap(env)
+	if !ok {
+		return false
+	}
+	closeAfter := false
+	i.mu.Lock()
+	i.current = cur
+	if terminal {
+		if i.terminalNodes == nil {
+			i.terminalNodes = make(map[string]struct{}, i.targetNodeCount)
+		}
+		i.terminalNodes[env.NodeID()] = struct{}{}
+		closeAfter = len(i.terminalNodes) >= i.targetNodeCount
+	}
+	i.mu.Unlock()
+	if closeAfter {
+		_ = i.Close()
+	}
+	return true
 }
 
 func (i *streamNodeIterator) Current() map[string]any {
@@ -275,6 +404,72 @@ func (i *streamNodeIterator) Close() error {
 		}
 	})
 	return err
+}
+
+const maxStreamNextTimeoutMS = int64(1<<63-1) / int64(time.Millisecond)
+
+func streamNextTimeout(v any) (time.Duration, error) {
+	ms, err := streamNonNegativeIntegerMS(v)
+	if err != nil {
+		return 0, err
+	}
+	if ms > maxStreamNextTimeoutMS {
+		return 0, errdefs.Validationf("stream.subscribe_node.next_timeout_ms: ms is too large")
+	}
+	return time.Duration(ms) * time.Millisecond, nil
+}
+
+func streamNonNegativeIntegerMS(v any) (int64, error) {
+	switch n := v.(type) {
+	case int:
+		return streamSignedMS(int64(n))
+	case int32:
+		return streamSignedMS(int64(n))
+	case int64:
+		return streamSignedMS(n)
+	case uint:
+		return streamUnsignedMS(uint64(n))
+	case uint32:
+		return streamUnsignedMS(uint64(n))
+	case uint64:
+		return streamUnsignedMS(n)
+	case float32:
+		return streamFloatMS(float64(n))
+	case float64:
+		return streamFloatMS(n)
+	default:
+		return 0, errdefs.Validationf("stream.subscribe_node.next_timeout_ms: ms must be a non-negative integer, got %T", v)
+	}
+}
+
+func streamSignedMS(n int64) (int64, error) {
+	if n < 0 {
+		return 0, errdefs.Validationf("stream.subscribe_node.next_timeout_ms: ms must be non-negative")
+	}
+	return n, nil
+}
+
+func streamUnsignedMS(n uint64) (int64, error) {
+	if n > uint64(maxStreamNextTimeoutMS) {
+		return 0, errdefs.Validationf("stream.subscribe_node.next_timeout_ms: ms is too large")
+	}
+	return int64(n), nil
+}
+
+func streamFloatMS(n float64) (int64, error) {
+	if math.IsNaN(n) || math.IsInf(n, 0) {
+		return 0, errdefs.Validationf("stream.subscribe_node.next_timeout_ms: ms must be a finite number")
+	}
+	if math.Trunc(n) != n {
+		return 0, errdefs.Validationf("stream.subscribe_node.next_timeout_ms: ms must be an integer")
+	}
+	if n < 0 {
+		return 0, errdefs.Validationf("stream.subscribe_node.next_timeout_ms: ms must be non-negative")
+	}
+	if n > float64(maxStreamNextTimeoutMS) {
+		return 0, errdefs.Validationf("stream.subscribe_node.next_timeout_ms: ms is too large")
+	}
+	return int64(n), nil
 }
 
 func streamNodeEnvelopeToMap(env event.Envelope) (map[string]any, bool, bool) {

--- a/sdk/graph/node/scriptnode/bridge_stream.go
+++ b/sdk/graph/node/scriptnode/bridge_stream.go
@@ -3,6 +3,7 @@ package scriptnode
 import (
 	"context"
 	"encoding/json"
+	"math"
 	"strings"
 	"sync"
 	"time"
@@ -13,7 +14,49 @@ import (
 	"github.com/GizClaw/flowcraft/sdk/script/bindings"
 )
 
-const defaultStreamSubBufferSize = 256
+const (
+	defaultStreamSubBufferSize = 256
+	maxStreamSubBufferSize     = 4096
+)
+
+type streamCleanupKey struct{}
+
+type streamCleanupRegistry struct {
+	mu       sync.Mutex
+	cleanups []func() error
+}
+
+func withStreamCleanup(ctx context.Context) (context.Context, *streamCleanupRegistry) {
+	reg := &streamCleanupRegistry{}
+	return context.WithValue(ctx, streamCleanupKey{}, reg), reg
+}
+
+func streamCleanupFromContext(ctx context.Context) *streamCleanupRegistry {
+	reg, _ := ctx.Value(streamCleanupKey{}).(*streamCleanupRegistry)
+	return reg
+}
+
+func (r *streamCleanupRegistry) Add(fn func() error) {
+	if r == nil || fn == nil {
+		return
+	}
+	r.mu.Lock()
+	r.cleanups = append(r.cleanups, fn)
+	r.mu.Unlock()
+}
+
+func (r *streamCleanupRegistry) Close() {
+	if r == nil {
+		return
+	}
+	r.mu.Lock()
+	cleanups := append([]func() error(nil), r.cleanups...)
+	r.cleanups = nil
+	r.mu.Unlock()
+	for i := len(cleanups) - 1; i >= 0; i-- {
+		_ = cleanups[i]()
+	}
+}
 
 // newStreamBridge exposes graph node stream subscriptions to scripts as
 // the global "stream".
@@ -62,6 +105,9 @@ func newStreamBridge(defaultRunID string, bus event.Bus) bindings.BindingFunc {
 					cancel: cancel,
 					sub:    sub,
 				}
+				if reg := streamCleanupFromContext(callCtx); reg != nil {
+					reg.Add(iter.Close)
+				}
 				return map[string]any{
 					"next":    iter.Next,
 					"current": iter.Current,
@@ -98,6 +144,9 @@ func parseStreamSubscribeOptions(raw any, defaultRunID string) (streamSubscribeO
 		if !ok {
 			return opts, errdefs.Validationf("stream.subscribe_node: run_id must be a string, got %T", v)
 		}
+		if s != defaultRunID {
+			return opts, errdefs.Validationf("stream.subscribe_node: run_id override is not allowed")
+		}
 		opts.runID = s
 	}
 	if opts.runID == "" {
@@ -116,41 +165,47 @@ func parseStreamSubscribeOptions(raw any, defaultRunID string) (streamSubscribeO
 func streamBufferSize(v any) (int, error) {
 	switch n := v.(type) {
 	case int:
-		if n > 0 {
+		if n > 0 && n <= maxStreamSubBufferSize {
 			return n, nil
 		}
 	case int32:
-		if n > 0 {
+		if n > 0 && n <= maxStreamSubBufferSize {
 			return int(n), nil
 		}
 	case int64:
-		if n > 0 {
+		if n > 0 && n <= maxStreamSubBufferSize {
 			return int(n), nil
 		}
 	case uint:
-		if n > 0 {
+		if n > 0 && n <= maxStreamSubBufferSize {
 			return int(n), nil
 		}
 	case uint32:
-		if n > 0 {
+		if n > 0 && n <= maxStreamSubBufferSize {
 			return int(n), nil
 		}
 	case uint64:
-		if n > 0 {
+		if n > 0 && n <= maxStreamSubBufferSize {
 			return int(n), nil
 		}
 	case float32:
-		if n > 0 {
+		if math.Trunc(float64(n)) != float64(n) {
+			return 0, errdefs.Validationf("stream.subscribe_node: buffer_size must be an integer")
+		}
+		if n > 0 && n <= maxStreamSubBufferSize {
 			return int(n), nil
 		}
 	case float64:
-		if n > 0 {
+		if math.Trunc(n) != n {
+			return 0, errdefs.Validationf("stream.subscribe_node: buffer_size must be an integer")
+		}
+		if n > 0 && n <= maxStreamSubBufferSize {
 			return int(n), nil
 		}
 	default:
 		return 0, errdefs.Validationf("stream.subscribe_node: buffer_size must be a positive number, got %T", v)
 	}
-	return 0, errdefs.Validationf("stream.subscribe_node: buffer_size must be positive")
+	return 0, errdefs.Validationf("stream.subscribe_node: buffer_size must be between 1 and %d", maxStreamSubBufferSize)
 }
 
 type streamNodeIterator struct {

--- a/sdk/graph/node/scriptnode/bridge_stream_test.go
+++ b/sdk/graph/node/scriptnode/bridge_stream_test.go
@@ -2,6 +2,7 @@ package scriptnode
 
 import (
 	"context"
+	"math"
 	"sync"
 	"testing"
 	"time"
@@ -67,6 +68,77 @@ func TestStreamBridge_SubscribeNode_RunIDOverrideRejected(t *testing.T) {
 	_, err := subscribe(map[string]any{"run_id": "run-override", "node_id": "planner"})
 	if !errdefs.IsValidation(err) {
 		t.Fatalf("subscribe_node error = %v, want Validation", err)
+	}
+}
+
+func TestStreamBridge_SubscribeNode_NodeIDsFiltersMultipleTargets(t *testing.T) {
+	bus := event.NewMemoryBus()
+	t.Cleanup(func() { _ = bus.Close() })
+
+	subscribe := streamSubscribeFunc(t, "run-1", bus)
+	iter, err := subscribe(map[string]any{"node_ids": []string{"planner", "executor"}})
+	if err != nil {
+		t.Fatalf("subscribe_node: %v", err)
+	}
+	defer iter["close"].(func() error)()
+
+	publishStreamDelta(t, bus, "run-1", "other", "agent-a", "ignore me")
+	publishStreamDelta(t, bus, "run-1", "planner", "agent-a", "from planner")
+	publishStreamDelta(t, bus, "run-1", "executor", "agent-a", "from executor")
+
+	if !iter["next"].(func() bool)() {
+		t.Fatal("next() = false, want planner delta")
+	}
+	checkCurrentDelta(t, iter["current"].(func() map[string]any)(), map[string]any{
+		"content": "from planner",
+		"node_id": "planner",
+	})
+
+	if !iter["next"].(func() bool)() {
+		t.Fatal("next() = false, want executor delta")
+	}
+	checkCurrentDelta(t, iter["current"].(func() map[string]any)(), map[string]any{
+		"content": "from executor",
+		"node_id": "executor",
+	})
+}
+
+func TestStreamBridge_SubscribeNode_NodeIDAndNodeIDsMutuallyExclusive(t *testing.T) {
+	bus := event.NewMemoryBus()
+	t.Cleanup(func() { _ = bus.Close() })
+
+	subscribe := streamSubscribeFunc(t, "run-1", bus)
+	_, err := subscribe(map[string]any{
+		"node_id":  "planner",
+		"node_ids": []string{"executor"},
+	})
+	if !errdefs.IsValidation(err) {
+		t.Fatalf("subscribe_node error = %v, want Validation", err)
+	}
+}
+
+func TestStreamBridge_SubscribeNode_InvalidNodeIDs(t *testing.T) {
+	bus := event.NewMemoryBus()
+	t.Cleanup(func() { _ = bus.Close() })
+
+	subscribe := streamSubscribeFunc(t, "run-1", bus)
+	tests := []struct {
+		name string
+		raw  any
+	}{
+		{name: "empty string slice", raw: []string{}},
+		{name: "empty any slice", raw: []any{}},
+		{name: "non string element", raw: []any{"planner", 42}},
+		{name: "empty string element", raw: []string{"planner", ""}},
+		{name: "not an array", raw: "planner"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := subscribe(map[string]any{"node_ids": tt.raw})
+			if !errdefs.IsValidation(err) {
+				t.Fatalf("subscribe_node error = %v, want Validation", err)
+			}
+		})
 	}
 }
 
@@ -218,6 +290,74 @@ func TestStreamBridge_SubscribeNode_StepSkippedIsTerminal(t *testing.T) {
 	}
 }
 
+func TestStreamBridge_SubscribeNode_MultiNodeFirstTerminalDoesNotClose(t *testing.T) {
+	bus := event.NewMemoryBus()
+	t.Cleanup(func() { _ = bus.Close() })
+
+	subscribe := streamSubscribeFunc(t, "run-1", bus)
+	iter, err := subscribe(map[string]any{"node_ids": []string{"planner", "executor"}})
+	if err != nil {
+		t.Fatalf("subscribe_node: %v", err)
+	}
+	defer iter["close"].(func() error)()
+
+	publishStepLifecycle(t, bus, "run-1", "planner", "agent-a", "complete", nil)
+	publishStreamDelta(t, bus, "run-1", "executor", "agent-a", "still open")
+
+	if !iter["next"].(func() bool)() {
+		t.Fatal("next() = false, want planner terminal")
+	}
+	checkCurrentEvent(t, iter["current"].(func() map[string]any)(), map[string]any{
+		"event":   "step.ended",
+		"status":  "success",
+		"node_id": "planner",
+	})
+
+	if !iter["next"].(func() bool)() {
+		t.Fatal("next() = false, want executor delta after first terminal")
+	}
+	checkCurrentDelta(t, iter["current"].(func() map[string]any)(), map[string]any{
+		"content": "still open",
+		"node_id": "executor",
+	})
+}
+
+func TestStreamBridge_SubscribeNode_MultiNodeClosesAfterAllTargetsTerminal(t *testing.T) {
+	bus := event.NewMemoryBus()
+	t.Cleanup(func() { _ = bus.Close() })
+
+	subscribe := streamSubscribeFunc(t, "run-1", bus)
+	iter, err := subscribe(map[string]any{"node_ids": []string{"planner", "executor"}})
+	if err != nil {
+		t.Fatalf("subscribe_node: %v", err)
+	}
+	defer iter["close"].(func() error)()
+
+	publishStepLifecycle(t, bus, "run-1", "planner", "agent-a", "complete", nil)
+	publishStepLifecycle(t, bus, "run-1", "executor", "agent-a", "skipped", nil)
+
+	if !iter["next"].(func() bool)() {
+		t.Fatal("next() = false, want planner terminal")
+	}
+	checkCurrentEvent(t, iter["current"].(func() map[string]any)(), map[string]any{
+		"event":   "step.ended",
+		"node_id": "planner",
+	})
+
+	if !iter["next"].(func() bool)() {
+		t.Fatal("next() = false, want executor terminal")
+	}
+	checkCurrentEvent(t, iter["current"].(func() map[string]any)(), map[string]any{
+		"event":   "step.skipped",
+		"status":  "skipped",
+		"node_id": "executor",
+	})
+
+	if iter["next"].(func() bool)() {
+		t.Fatal("next() after all target terminals = true, want false")
+	}
+}
+
 func TestStreamBridge_SubscribeNode_FiltersOtherNodeLifecycleEvents(t *testing.T) {
 	bus := event.NewMemoryBus()
 	t.Cleanup(func() { _ = bus.Close() })
@@ -239,6 +379,106 @@ func TestStreamBridge_SubscribeNode_FiltersOtherNodeLifecycleEvents(t *testing.T
 		"event":   "step.started",
 		"node_id": "planner",
 	})
+}
+
+func TestStreamBridge_SubscribeNode_NextTimeoutReturnsFalseWithoutClosing(t *testing.T) {
+	bus := event.NewMemoryBus()
+	t.Cleanup(func() { _ = bus.Close() })
+
+	subscribe := streamSubscribeFunc(t, "run-1", bus)
+	iter, err := subscribe(map[string]any{"node_id": "planner"})
+	if err != nil {
+		t.Fatalf("subscribe_node: %v", err)
+	}
+	defer iter["close"].(func() error)()
+	nextTimeout := iter["next_timeout_ms"].(func(any) (bool, error))
+
+	got, err := nextTimeout(10)
+	if err != nil {
+		t.Fatalf("next_timeout_ms: %v", err)
+	}
+	if got {
+		t.Fatal("next_timeout_ms timeout = true, want false")
+	}
+
+	publishStreamDelta(t, bus, "run-1", "planner", "agent-a", "after timeout")
+	got, err = nextTimeout(100)
+	if err != nil {
+		t.Fatalf("next_timeout_ms after publish: %v", err)
+	}
+	if !got {
+		t.Fatal("next_timeout_ms after publish = false, want true")
+	}
+	checkCurrentDelta(t, iter["current"].(func() map[string]any)(), map[string]any{
+		"content": "after timeout",
+	})
+}
+
+func TestStreamBridge_SubscribeNode_NextTimeoutZeroPollsNonBlocking(t *testing.T) {
+	bus := event.NewMemoryBus()
+	t.Cleanup(func() { _ = bus.Close() })
+
+	subscribe := streamSubscribeFunc(t, "run-1", bus)
+	iter, err := subscribe(map[string]any{"node_id": "planner"})
+	if err != nil {
+		t.Fatalf("subscribe_node: %v", err)
+	}
+	defer iter["close"].(func() error)()
+	nextTimeout := iter["next_timeout_ms"].(func(any) (bool, error))
+
+	got, err := nextTimeout(0)
+	if err != nil {
+		t.Fatalf("next_timeout_ms(0): %v", err)
+	}
+	if got {
+		t.Fatal("next_timeout_ms(0) before publish = true, want false")
+	}
+
+	publishStreamDelta(t, bus, "run-1", "planner", "agent-a", "ready")
+	got, err = nextTimeout(0)
+	if err != nil {
+		t.Fatalf("next_timeout_ms(0) after publish: %v", err)
+	}
+	if !got {
+		t.Fatal("next_timeout_ms(0) after publish = false, want true")
+	}
+	checkCurrentDelta(t, iter["current"].(func() map[string]any)(), map[string]any{
+		"content": "ready",
+	})
+}
+
+func TestStreamBridge_SubscribeNode_InvalidNextTimeout(t *testing.T) {
+	bus := event.NewMemoryBus()
+	t.Cleanup(func() { _ = bus.Close() })
+
+	subscribe := streamSubscribeFunc(t, "run-1", bus)
+	iter, err := subscribe(map[string]any{"node_id": "planner"})
+	if err != nil {
+		t.Fatalf("subscribe_node: %v", err)
+	}
+	defer iter["close"].(func() error)()
+	nextTimeout := iter["next_timeout_ms"].(func(any) (bool, error))
+
+	tests := []struct {
+		name string
+		raw  any
+	}{
+		{name: "negative", raw: -1},
+		{name: "fractional", raw: 1.5},
+		{name: "non number", raw: "1"},
+		{name: "nan", raw: math.NaN()},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := nextTimeout(tt.raw)
+			if !errdefs.IsValidation(err) {
+				t.Fatalf("next_timeout_ms(%v) error = %v, want Validation", tt.raw, err)
+			}
+			if got {
+				t.Fatalf("next_timeout_ms(%v) = true, want false", tt.raw)
+			}
+		})
+	}
 }
 
 func TestStreamBridge_SubscribeNode_NextReturnsFalseWhenCallContextCanceled(t *testing.T) {
@@ -438,6 +678,41 @@ func TestScriptNode_StreamBridge_SubscribeNodeFromScript(t *testing.T) {
 	}
 	if got, _ := board.GetVar("stream_subject"); got == "" {
 		t.Fatal("stream_subject missing")
+	}
+}
+
+func TestScriptNode_StreamBridge_NextTimeoutFromScriptFailsOpen(t *testing.T) {
+	mem := event.NewMemoryBus()
+	t.Cleanup(func() { _ = mem.Close() })
+
+	rt := jsrt.New(jsrt.WithPoolSize(1))
+	factory := nodepkg.NewFactory()
+	Register(factory, Deps{ScriptRuntime: rt, EventBus: mem})
+	n, err := factory.Build(graph.NodeDefinition{
+		ID:   "listener",
+		Type: "script",
+		Config: map[string]any{
+			"source": `
+				var sub = stream.subscribe_node({ node_ids: ["planner", "executor"] });
+				if (sub.next_timeout_ms(0)) throw new Error("poll should not have an event");
+				if (sub.next_timeout_ms(10)) throw new Error("timeout should fail open");
+				board.setVar("stream_fail_open", true);
+				sub.close();
+			`,
+		},
+	})
+	if err != nil {
+		t.Fatalf("build script node: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	board := graph.NewBoard()
+	if err := n.ExecuteBoard(graph.ExecutionContext{Context: ctx, RunID: "run-js"}, board); err != nil {
+		t.Fatalf("ExecuteBoard: %v", err)
+	}
+	if got, _ := board.GetVar("stream_fail_open"); got != true {
+		t.Fatalf("stream_fail_open = %v, want true", got)
 	}
 }
 

--- a/sdk/graph/node/scriptnode/bridge_stream_test.go
+++ b/sdk/graph/node/scriptnode/bridge_stream_test.go
@@ -59,29 +59,15 @@ func TestStreamBridge_SubscribeNode_FiltersNodeAndProjectsCurrent(t *testing.T) 
 	}
 }
 
-func TestStreamBridge_SubscribeNode_RunIDOverrideFiltersDefaultRun(t *testing.T) {
+func TestStreamBridge_SubscribeNode_RunIDOverrideRejected(t *testing.T) {
 	bus := event.NewMemoryBus()
 	t.Cleanup(func() { _ = bus.Close() })
 
 	subscribe := streamSubscribeFunc(t, "run-default", bus)
-	iter, err := subscribe(map[string]any{"run_id": "run-override", "node_id": "planner"})
-	if err != nil {
-		t.Fatalf("subscribe_node: %v", err)
+	_, err := subscribe(map[string]any{"run_id": "run-override", "node_id": "planner"})
+	if !errdefs.IsValidation(err) {
+		t.Fatalf("subscribe_node error = %v, want Validation", err)
 	}
-	defer iter["close"].(func() error)()
-
-	publishStreamDelta(t, bus, "run-default", "planner", "agent-a", "default run")
-	publishStreamDelta(t, bus, "run-override", "planner", "agent-a", "override run")
-
-	if !iter["next"].(func() bool)() {
-		t.Fatal("next() = false, want override run delta")
-	}
-	cur := iter["current"].(func() map[string]any)()
-	checkCurrentDelta(t, cur, map[string]any{
-		"content": "override run",
-		"run_id":  "run-override",
-		"node_id": "planner",
-	})
 }
 
 func TestStreamBridge_SubscribeNode_CurrentPreservesPayloadObjectFields(t *testing.T) {
@@ -365,6 +351,8 @@ func TestStreamBridge_SubscribeNode_InvalidBufferSize(t *testing.T) {
 		{name: "zero", value: 0},
 		{name: "negative", value: -1},
 		{name: "non number", value: "1"},
+		{name: "fractional", value: 1.5},
+		{name: "too large", value: maxStreamSubBufferSize + 1},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -450,6 +438,50 @@ func TestScriptNode_StreamBridge_SubscribeNodeFromScript(t *testing.T) {
 	}
 	if got, _ := board.GetVar("stream_subject"); got == "" {
 		t.Fatal("stream_subject missing")
+	}
+}
+
+func TestScriptNode_StreamBridge_CleansUpUnclosedSubscriptions(t *testing.T) {
+	tests := []struct {
+		name    string
+		source  string
+		wantErr bool
+	}{
+		{
+			name:   "natural return",
+			source: `stream.subscribe_node({ node_id: "planner" });`,
+		},
+		{
+			name:    "throw",
+			source:  `stream.subscribe_node({ node_id: "planner" }); throw new Error("boom");`,
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mem := event.NewMemoryBus()
+			t.Cleanup(func() { _ = mem.Close() })
+			bus := &closeTrackingBus{Bus: mem}
+
+			rt := jsrt.New(jsrt.WithPoolSize(1))
+			n := New("listener", "script", tt.source, nil, rt)
+			n.eventBus = bus
+
+			err := n.ExecuteBoard(graph.ExecutionContext{
+				Context: context.Background(),
+				RunID:   "run-cleanup",
+			}, graph.NewBoard())
+			if tt.wantErr && err == nil {
+				t.Fatal("expected script error")
+			}
+			if !tt.wantErr && err != nil {
+				t.Fatalf("ExecuteBoard: %v", err)
+			}
+			if bus.closeCount() != 1 {
+				t.Fatalf("subscription close count = %d, want 1", bus.closeCount())
+			}
+		})
 	}
 }
 
@@ -585,4 +617,40 @@ func (b *subscribeNotifyBus) Subscribe(ctx context.Context, pattern event.Patter
 		b.once.Do(func() { close(b.subscribed) })
 	}
 	return sub, err
+}
+
+type closeTrackingBus struct {
+	event.Bus
+	mu     sync.Mutex
+	closed int
+}
+
+func (b *closeTrackingBus) Subscribe(ctx context.Context, pattern event.Pattern, opts ...event.SubOption) (event.Subscription, error) {
+	sub, err := b.Bus.Subscribe(ctx, pattern, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return &closeTrackingSubscription{Subscription: sub, bus: b}, nil
+}
+
+func (b *closeTrackingBus) closeCount() int {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.closed
+}
+
+type closeTrackingSubscription struct {
+	event.Subscription
+	bus  *closeTrackingBus
+	once sync.Once
+}
+
+func (s *closeTrackingSubscription) Close() error {
+	err := s.Subscription.Close()
+	s.once.Do(func() {
+		s.bus.mu.Lock()
+		s.bus.closed++
+		s.bus.mu.Unlock()
+	})
+	return err
 }

--- a/sdk/graph/node/scriptnode/builtins_test.go
+++ b/sdk/graph/node/scriptnode/builtins_test.go
@@ -217,8 +217,8 @@ func TestScriptNode_NodeBridge_ExposesIDAndType(t *testing.T) {
 //   - set approval_status = "pending"
 //   - set approval_request.node_id to the actual node id (NOT undefined,
 //     which was the regression with config.__node_id)
-//   - surface signal.interrupt("waiting for approval") as
-//     errdefs.IsInterrupted so the agent layer pauses the run.
+//   - surface signal.interrupt({kind:"user_input", ...}) as
+//     CauseUserInput so the agent layer pauses for user input.
 func TestBuiltin_Approval_FirstPassInterruptsWithNodeID(t *testing.T) {
 	_, board, err := execBuiltin(t, "approval", "approval-step-7", map[string]any{
 		"prompt": "Approve change?",
@@ -241,6 +241,13 @@ func TestBuiltin_Approval_FirstPassInterruptsWithNodeID(t *testing.T) {
 	if req["prompt"] != "Approve change?" {
 		t.Fatalf("approval_request.prompt = %v", req["prompt"])
 	}
+	var ie engine.InterruptedError
+	if !errors.As(err, &ie) {
+		t.Fatalf("expected engine.InterruptedError in chain, got %v", err)
+	}
+	if ie.Cause != engine.CauseUserInput {
+		t.Fatalf("Cause = %q, want %q", ie.Cause, engine.CauseUserInput)
+	}
 }
 
 // When the agent resumes the node after the user replied,
@@ -249,12 +256,106 @@ func TestBuiltin_Approval_FirstPassInterruptsWithNodeID(t *testing.T) {
 func TestBuiltin_Approval_DecisionRecorded(t *testing.T) {
 	_, board, err := execBuiltin(t, "approval", "ap1", nil, func(b *graph.Board) {
 		b.SetVar("approval_decision", "approved")
+		b.SetVar("approval_request", map[string]any{"node_id": "ap1"})
 	})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	if v, _ := board.GetVar("approval_status"); v != "approved" {
 		t.Fatalf("approval_status = %v", v)
+	}
+	for _, key := range []string{
+		"approval_decision",
+		"approval_request",
+		"__approval.ap1.decision",
+		"__approval.ap1.request",
+	} {
+		if v, ok := board.GetVar(key); ok {
+			t.Fatalf("%s should be cleared after consumption, got %v", key, v)
+		}
+	}
+}
+
+func TestBuiltin_Approval_LegacyGlobalDecisionWithoutRequestIsConsumed(t *testing.T) {
+	_, board, err := execBuiltin(t, "approval", "ap_legacy", nil, func(b *graph.Board) {
+		b.SetVar("approval_decision", "approved")
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if v, _ := board.GetVar("approval_status"); v != "approved" {
+		t.Fatalf("approval_status = %v", v)
+	}
+	if v, ok := board.GetVar("approval_decision"); ok {
+		t.Fatalf("approval_decision should be cleared after consumption, got %v", v)
+	}
+}
+
+func TestBuiltin_Approval_GlobalDecisionForOtherNodeDoesNotLeak(t *testing.T) {
+	_, board, err := execBuiltin(t, "approval", "ap2", nil, func(b *graph.Board) {
+		b.SetVar("approval_decision", "approved")
+		b.SetVar("approval_request", map[string]any{"node_id": "ap1"})
+	})
+	if !errdefs.IsInterrupted(err) {
+		t.Fatalf("expected fresh approval interrupt, got: %v", err)
+	}
+	if v, _ := board.GetVar("approval_status"); v != "pending" {
+		t.Fatalf("approval_status = %v, want pending", v)
+	}
+	raw, _ := board.GetVar("approval_request")
+	req, ok := raw.(map[string]any)
+	if !ok {
+		t.Fatalf("approval_request shape = %T", raw)
+	}
+	if req["node_id"] != "ap2" {
+		t.Fatalf("approval_request.node_id = %v, want ap2", req["node_id"])
+	}
+	if v, ok := board.GetVar("approval_decision"); ok {
+		t.Fatalf("stale approval_decision should be cleared, got %v", v)
+	}
+
+	n := New("ap2", "approval", scripts.MustGet("approval"), nil, jsrt.New(jsrt.WithPoolSize(1)))
+	if err := n.ExecuteBoard(graph.ExecutionContext{
+		Context: context.Background(),
+		RunID:   runIDForTests,
+	}, board); err != nil {
+		t.Fatalf("second execution with pending approval should not consume stale decision: %v", err)
+	}
+	if v, _ := board.GetVar("approval_status"); v != "pending" {
+		t.Fatalf("approval_status after second execution = %v, want pending", v)
+	}
+}
+
+func TestBuiltin_Approval_ConsumedDecisionDoesNotSatisfyNextExecution(t *testing.T) {
+	rt := jsrt.New(jsrt.WithPoolSize(1))
+	n := New("ap_repeat", "approval", scripts.MustGet("approval"), nil, rt)
+	board := graph.NewBoard()
+	board.SetVar("approval_decision", "approved")
+
+	if err := n.ExecuteBoard(graph.ExecutionContext{
+		Context: context.Background(),
+		RunID:   runIDForTests,
+	}, board); err != nil {
+		t.Fatalf("first execution should consume decision: %v", err)
+	}
+
+	err := n.ExecuteBoard(graph.ExecutionContext{
+		Context: context.Background(),
+		RunID:   runIDForTests,
+	}, board)
+	if !errdefs.IsInterrupted(err) {
+		t.Fatalf("second execution should request fresh approval, got: %v", err)
+	}
+	if v, _ := board.GetVar("approval_status"); v != "pending" {
+		t.Fatalf("approval_status = %v, want pending", v)
+	}
+	raw, _ := board.GetVar("approval_request")
+	req, ok := raw.(map[string]any)
+	if !ok {
+		t.Fatalf("approval_request shape = %T", raw)
+	}
+	if req["node_id"] != "ap_repeat" {
+		t.Fatalf("approval_request.node_id = %v, want ap_repeat", req["node_id"])
 	}
 }
 
@@ -346,6 +447,23 @@ func TestBuiltin_Iteration_AccumulatesResults(t *testing.T) {
 	}
 	if len(results) != 3 {
 		t.Fatalf("results len = %d, want 3 (results=%v)", len(results), results)
+	}
+}
+
+func TestBuiltin_Iteration_PoolSizeOneRejectsNestedExec(t *testing.T) {
+	rt := jsrt.New(jsrt.WithPoolSize(1))
+	n := New("iter_pool1", "iteration", scripts.MustGet("iteration"), map[string]any{
+		"input_key":   "items",
+		"body_script": `board.setVar("__iteration_result", "unreachable");`,
+	}, rt)
+	board := graph.NewBoard()
+	board.SetVar("items", []any{"one"})
+
+	err := n.ExecuteBoard(graph.ExecutionContext{
+		Context: context.Background(), RunID: runIDForTests,
+	}, board)
+	if !errdefs.IsNotAvailable(err) {
+		t.Fatalf("ExecuteBoard error = %v, want NotAvailable", err)
 	}
 }
 

--- a/sdk/graph/node/scriptnode/context_register_test.go
+++ b/sdk/graph/node/scriptnode/context_register_test.go
@@ -1,0 +1,121 @@
+package scriptnode
+
+import (
+	"context"
+	"testing"
+
+	"github.com/GizClaw/flowcraft/sdk/errdefs"
+	"github.com/GizClaw/flowcraft/sdk/graph"
+	nodepkg "github.com/GizClaw/flowcraft/sdk/graph/node"
+	"github.com/GizClaw/flowcraft/sdk/graph/node/scripts"
+	"github.com/GizClaw/flowcraft/sdk/sandbox"
+	"github.com/GizClaw/flowcraft/sdk/script/bindings"
+	"github.com/GizClaw/flowcraft/sdk/script/jsrt"
+)
+
+type contextCommandRunner struct {
+	stdout   string
+	stderr   string
+	exitCode int
+}
+
+func (r contextCommandRunner) Exec(context.Context, string, []string, sandbox.ExecOptions) (*sandbox.ExecResult, error) {
+	return &sandbox.ExecResult{
+		Stdout:   r.stdout,
+		Stderr:   r.stderr,
+		ExitCode: r.exitCode,
+	}, nil
+}
+
+func TestBuiltin_Context_CommandFailureSignalsTypedError(t *testing.T) {
+	rt := jsrt.New(jsrt.WithPoolSize(1))
+	runner := contextCommandRunner{stdout: "ignored", stderr: "command failed", exitCode: 2}
+	n := New("ctx1", "context", scripts.MustGet("context"), map[string]any{
+		"commands": []any{
+			map[string]any{"command": "false", "state_key": "cmd_out"},
+		},
+	}, rt, bindings.NewShellBridge(runner))
+
+	board := graph.NewBoard()
+	err := n.ExecuteBoard(graph.ExecutionContext{
+		Context: context.Background(),
+		RunID:   runIDForTests,
+	}, board)
+	if !errdefs.IsInternal(err) {
+		t.Fatalf("ExecuteBoard error = %v, want Internal", err)
+	}
+	if v, ok := board.GetVar("cmd_out"); ok && v != nil {
+		t.Fatalf("failed command stdout should not be written, got %v", v)
+	}
+}
+
+func TestBuiltin_Context_CommandUnavailableSignalsNotAvailable(t *testing.T) {
+	rt := jsrt.New(jsrt.WithPoolSize(1))
+	runner := contextCommandRunner{stderr: "runner offline", exitCode: -1}
+	n := New("ctx_unavailable", "context", scripts.MustGet("context"), map[string]any{
+		"commands": []any{
+			map[string]any{"command": "tool status", "state_key": "cmd_out"},
+		},
+	}, rt, bindings.NewShellBridge(runner))
+
+	err := n.ExecuteBoard(graph.ExecutionContext{
+		Context: context.Background(),
+		RunID:   runIDForTests,
+	}, graph.NewBoard())
+	if !errdefs.IsNotAvailable(err) {
+		t.Fatalf("ExecuteBoard error = %v, want NotAvailable", err)
+	}
+}
+
+func TestRegister_ContextFilesOnlyBuildsWithoutCommandRunner(t *testing.T) {
+	rt := jsrt.New(jsrt.WithPoolSize(1))
+	factory := nodepkg.NewFactory()
+	Register(factory, Deps{ScriptRuntime: rt})
+
+	_, err := factory.Build(graph.NodeDefinition{
+		ID:   "ctx_files",
+		Type: "context",
+		Config: map[string]any{
+			"files": []any{
+				map[string]any{"path": "README.md"},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Build files-only context without CommandRunner: %v", err)
+	}
+}
+
+func TestRegister_GateWithoutCommandsBuildsWithoutCommandRunner(t *testing.T) {
+	rt := jsrt.New(jsrt.WithPoolSize(1))
+	factory := nodepkg.NewFactory()
+	Register(factory, Deps{ScriptRuntime: rt})
+
+	_, err := factory.Build(graph.NodeDefinition{
+		ID:     "gate_empty",
+		Type:   "gate",
+		Config: map[string]any{"commands": []any{}},
+	})
+	if err != nil {
+		t.Fatalf("Build commandless gate without CommandRunner: %v", err)
+	}
+}
+
+func TestRegister_BuiltinCommandsRequireCommandRunner(t *testing.T) {
+	rt := jsrt.New(jsrt.WithPoolSize(1))
+	factory := nodepkg.NewFactory()
+	Register(factory, Deps{ScriptRuntime: rt})
+
+	for _, nodeType := range []string{"context", "gate"} {
+		t.Run(nodeType, func(t *testing.T) {
+			_, err := factory.Build(graph.NodeDefinition{
+				ID:     nodeType + "1",
+				Type:   nodeType,
+				Config: map[string]any{"commands": []any{"echo hi"}},
+			})
+			if !errdefs.IsValidation(err) {
+				t.Fatalf("Build error = %v, want Validation", err)
+			}
+		})
+	}
+}

--- a/sdk/graph/node/scriptnode/jsnode.go
+++ b/sdk/graph/node/scriptnode/jsnode.go
@@ -1,6 +1,7 @@
 package scriptnode
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/GizClaw/flowcraft/sdk/agent"
@@ -57,6 +58,13 @@ func (n *ScriptNode) SetConfig(c map[string]any) { n.config = c }
 // ExecuteBoard runs the script with board, expr, host, stream, and
 // runtime bindings.
 func (n *ScriptNode) ExecuteBoard(ctx graph.ExecutionContext, board *graph.Board) error {
+	callCtx := ctx.Context
+	if callCtx == nil {
+		callCtx = context.Background()
+	}
+	callCtx, cleanup := withStreamCleanup(callCtx)
+	defer cleanup.Close()
+
 	// Bridge wiring rationale:
 	//
 	//   - host: engine.Host control plane (publish / askUser / ...) plus
@@ -78,7 +86,7 @@ func (n *ScriptNode) ExecuteBoard(ctx graph.ExecutionContext, board *graph.Board
 	allFns := []bindings.BindingFunc{
 		bindings.NewBoardBridge(board),
 		bindings.NewExprBridge(),
-		bindings.NewHostBridge(ctx.Host, n.id, ctx.Publisher),
+		bindings.NewHostBridge(ctx.Host, n.id, ctx.Publisher, bindings.WithHostRunID(ctx.RunID)),
 		newStreamBridge(ctx.RunID, n.eventBus),
 		newParallelBridge(),
 		// Reconstruct the full RunInfo from engine.Run.Attributes
@@ -95,17 +103,17 @@ func (n *ScriptNode) ExecuteBoard(ctx graph.ExecutionContext, board *graph.Board
 
 	hostBindings := make(map[string]any, len(allFns)+1)
 	for _, fn := range allFns {
-		name, val := fn(ctx.Context)
+		name, val := fn(callCtx)
 		hostBindings[name] = val
 	}
-	hostBindings["runtime"] = bindings.RuntimeBinding(ctx.Context, n.runtime, hostBindings)
+	hostBindings["runtime"] = bindings.RuntimeBinding(callCtx, n.runtime, hostBindings)
 
 	env := &script.Env{
 		Config:   n.config,
 		Bindings: hostBindings,
 	}
 
-	sig, err := n.runtime.Exec(ctx.Context, n.id+".js", n.script, env)
+	sig, err := n.runtime.Exec(callCtx, n.id+".js", n.script, env)
 	if err != nil {
 		return fmt.Errorf("script node %s execution failed: %w", n.id, err)
 	}

--- a/sdk/graph/node/scriptnode/register.go
+++ b/sdk/graph/node/scriptnode/register.go
@@ -2,6 +2,7 @@ package scriptnode
 
 import (
 	"io/fs"
+	"reflect"
 
 	"github.com/GizClaw/flowcraft/sdk/errdefs"
 	"github.com/GizClaw/flowcraft/sdk/event"
@@ -28,15 +29,7 @@ type Deps struct {
 	Workspace     workspace.Workspace
 	CommandRunner sandbox.Runner
 	EventBus      event.Bus
-}
-
-// needsShell lists built-in jsnode types that additionally require a
-// shell bridge. Every built-in node already gets fs / board / expr /
-// host / runtime bridges unconditionally below; the entries here are
-// the *additional* shell bridge gate (driven by deps.CommandRunner).
-var needsShell = map[string]bool{
-	"gate":    true,
-	"context": true,
+	ExtraBridges  []bindings.BindingFunc
 }
 
 // Register binds the built-in script-backed node builders ("script", every
@@ -48,8 +41,12 @@ var needsShell = map[string]bool{
 // require deps.CommandRunner. Missing deps are reported as a build-time
 // validation error from Factory.Build.
 func Register(factory *node.Factory, deps Deps) {
+	extraBridges := append([]bindings.BindingFunc(nil), deps.ExtraBridges...)
 	newNode := func(id, nodeType, src string, config map[string]any, extras ...bindings.BindingFunc) *ScriptNode {
-		n := New(id, nodeType, src, config, deps.ScriptRuntime, extras...)
+		nodeExtras := make([]bindings.BindingFunc, 0, len(extras)+len(extraBridges))
+		nodeExtras = append(nodeExtras, extras...)
+		nodeExtras = append(nodeExtras, extraBridges...)
+		n := New(id, nodeType, src, config, deps.ScriptRuntime, nodeExtras...)
 		n.eventBus = deps.EventBus
 		return n
 	}
@@ -63,7 +60,11 @@ func Register(factory *node.Factory, deps Deps) {
 			}
 			src := scripts.MustGet(n)
 			var extras []bindings.BindingFunc
-			if needsShell[n] {
+			if needsShell(n, def.Config) {
+				if deps.CommandRunner == nil {
+					return nil, errdefs.Validationf(
+						"node %q (type %s): command runner not configured", def.ID, n)
+				}
 				extras = append(extras, bindings.NewShellBridge(deps.CommandRunner))
 			}
 			extras = append(extras, bindings.NewFSBridge(deps.Workspace))
@@ -98,4 +99,33 @@ func Register(factory *node.Factory, deps Deps) {
 		return nil, errdefs.Validationf(
 			"unknown node type %q for node %q", def.Type, def.ID)
 	})
+}
+
+// needsShell reports whether this built-in's current configuration will call
+// shell.exec. Files-only context nodes and commandless gates do not need a
+// command runner at build time.
+func needsShell(nodeType string, config map[string]any) bool {
+	switch nodeType {
+	case "context", "gate":
+		return configValueNonEmpty(config, "commands")
+	default:
+		return false
+	}
+}
+
+func configValueNonEmpty(config map[string]any, key string) bool {
+	if config == nil {
+		return false
+	}
+	v, ok := config[key]
+	if !ok || v == nil {
+		return false
+	}
+	rv := reflect.ValueOf(v)
+	switch rv.Kind() {
+	case reflect.Array, reflect.Chan, reflect.Map, reflect.Slice, reflect.String:
+		return rv.Len() > 0
+	default:
+		return true
+	}
 }

--- a/sdk/graph/node/scriptnode/register_extra_bridges_test.go
+++ b/sdk/graph/node/scriptnode/register_extra_bridges_test.go
@@ -1,0 +1,145 @@
+package scriptnode
+
+import (
+	"context"
+	"testing"
+	"testing/fstest"
+
+	"github.com/GizClaw/flowcraft/sdk/graph"
+	nodepkg "github.com/GizClaw/flowcraft/sdk/graph/node"
+	"github.com/GizClaw/flowcraft/sdk/script/bindings"
+	"github.com/GizClaw/flowcraft/sdk/script/jsrt"
+)
+
+func testValueBridge(value string) bindings.BindingFunc {
+	return func(context.Context) (string, any) {
+		return "extra", map[string]any{
+			"value": func() string { return value },
+		}
+	}
+}
+
+func TestRegister_ExtraBridgesAvailableToBuiltinScriptNode(t *testing.T) {
+	rt := jsrt.New(jsrt.WithPoolSize(2))
+	factory := nodepkg.NewFactory()
+	Register(factory, Deps{
+		ScriptRuntime: rt,
+		ExtraBridges:  []bindings.BindingFunc{testValueBridge("from-extra")},
+	})
+
+	n, err := factory.Build(graph.NodeDefinition{
+		ID:   "iter_extra",
+		Type: "iteration",
+		Config: map[string]any{
+			"input_key":   "items",
+			"body_script": `board.setVar("__iteration_result", extra.value());`,
+		},
+	})
+	if err != nil {
+		t.Fatalf("Build iteration: %v", err)
+	}
+
+	board := graph.NewBoard()
+	board.SetVar("items", []any{"one"})
+	if err := n.ExecuteBoard(graph.ExecutionContext{Context: context.Background()}, board); err != nil {
+		t.Fatalf("ExecuteBoard: %v", err)
+	}
+
+	raw, _ := board.GetVar("iteration_results")
+	results, ok := raw.([]any)
+	if !ok {
+		t.Fatalf("iteration_results shape = %T", raw)
+	}
+	if len(results) != 1 || results[0] != "from-extra" {
+		t.Fatalf("iteration_results = %v, want [from-extra]", results)
+	}
+}
+
+func TestRegister_ExtraBridgesAvailableToTypeScriptNode(t *testing.T) {
+	rt := jsrt.New(jsrt.WithPoolSize(1))
+	factory := nodepkg.NewFactory()
+	Register(factory, Deps{
+		ScriptRuntime: rt,
+		ExtraBridges: []bindings.BindingFunc{
+			testValueBridge("first"),
+			testValueBridge("second"),
+		},
+	})
+
+	n, err := factory.Build(graph.NodeDefinition{
+		ID:   "script_extra",
+		Type: "script",
+		Config: map[string]any{
+			"source": `board.setVar("extra_value", extra.value());`,
+		},
+	})
+	if err != nil {
+		t.Fatalf("Build script: %v", err)
+	}
+
+	board := graph.NewBoard()
+	if err := n.ExecuteBoard(graph.ExecutionContext{Context: context.Background()}, board); err != nil {
+		t.Fatalf("ExecuteBoard: %v", err)
+	}
+	if got, _ := board.GetVar("extra_value"); got != "second" {
+		t.Fatalf("extra_value = %v, want second", got)
+	}
+}
+
+func TestRegister_ExtraBridgesAvailableToScriptFSFallbackNode(t *testing.T) {
+	rt := jsrt.New(jsrt.WithPoolSize(1))
+	factory := nodepkg.NewFactory()
+	Register(factory, Deps{
+		ScriptRuntime: rt,
+		ScriptFS: fstest.MapFS{
+			"custom.js": {Data: []byte(`board.setVar("extra_value", extra.value());`)},
+		},
+		ExtraBridges: []bindings.BindingFunc{testValueBridge("from-fs")},
+	})
+
+	n, err := factory.Build(graph.NodeDefinition{
+		ID:   "fallback_extra",
+		Type: "custom",
+	})
+	if err != nil {
+		t.Fatalf("Build fallback: %v", err)
+	}
+
+	board := graph.NewBoard()
+	if err := n.ExecuteBoard(graph.ExecutionContext{Context: context.Background()}, board); err != nil {
+		t.Fatalf("ExecuteBoard: %v", err)
+	}
+	if got, _ := board.GetVar("extra_value"); got != "from-fs" {
+		t.Fatalf("extra_value = %v, want from-fs", got)
+	}
+}
+
+func TestRegister_ExtraBridgesCopiedForConstructedNodes(t *testing.T) {
+	rt := jsrt.New(jsrt.WithPoolSize(1))
+	extras := []bindings.BindingFunc{testValueBridge("before-mutation")}
+	factory := nodepkg.NewFactory()
+	Register(factory, Deps{
+		ScriptRuntime: rt,
+		ExtraBridges:  extras,
+	})
+
+	n, err := factory.Build(graph.NodeDefinition{
+		ID:   "script_alias",
+		Type: "script",
+		Config: map[string]any{
+			"source": `board.setVar("extra_value", extra.value());`,
+		},
+	})
+	if err != nil {
+		t.Fatalf("Build script: %v", err)
+	}
+	extras[0] = testValueBridge("after-mutation")
+
+	board := graph.NewBoard()
+	if err := n.ExecuteBoard(graph.ExecutionContext{Context: context.Background()}, board); err != nil {
+		t.Fatalf("ExecuteBoard: %v", err)
+	}
+	if got, _ := board.GetVar("extra_value"); got != "before-mutation" {
+		t.Fatalf("extra_value = %v, want before-mutation", got)
+	}
+}

--- a/sdk/graph/node/scripts/approval.js
+++ b/sdk/graph/node/scripts/approval.js
@@ -1,15 +1,51 @@
 (function() {
-  var decision = board.getVar("approval_decision");
-  var status = board.getVar("approval_status");
+  config = config || {};
+  var nodeID = node.id();
+  var keyPrefix = "__approval." + nodeID + ".";
+  var decisionKey = keyPrefix + "decision";
+  var statusKey = keyPrefix + "status";
+  var requestKey = keyPrefix + "request";
+
+  function clearVar(key) {
+      if (typeof board.deleteVar === "function") {
+          board.deleteVar(key);
+      } else {
+          board.setVar(key, undefined);
+      }
+  }
+
+  var decision = board.getVar(decisionKey);
+  var status = board.getVar(statusKey);
+  var legacyRequest = board.getVar("approval_request");
+  var legacyRequestForThisNode = legacyRequest && legacyRequest.node_id === nodeID;
+  var legacyRequestForOtherNode = legacyRequest && legacyRequest.node_id && legacyRequest.node_id !== nodeID;
+
+  if (!decision) {
+      if (legacyRequestForOtherNode) {
+          clearVar("approval_decision");
+      } else {
+          decision = board.getVar("approval_decision");
+      }
+  }
 
   if (decision) {
+      board.setVar(statusKey, decision);
       board.setVar("approval_status", decision);
+      clearVar(decisionKey);
+      clearVar("approval_decision");
+      clearVar(requestKey);
+      if (!legacyRequestForOtherNode) {
+          clearVar("approval_request");
+      }
   } else if (status !== "pending") {
-      board.setVar("approval_status", "pending");
-      board.setVar("approval_request", {
+      var request = {
           prompt: config.prompt || "Please approve or reject this action.",
-          node_id: node.id(),
-      });
-      signal.interrupt("waiting for approval");
+          node_id: nodeID,
+      };
+      board.setVar(statusKey, "pending");
+      board.setVar(requestKey, request);
+      board.setVar("approval_status", "pending");
+      board.setVar("approval_request", request);
+      signal.interrupt({ kind: "user_input", message: "waiting for approval" });
   }
 })();

--- a/sdk/graph/node/scripts/context.js
+++ b/sdk/graph/node/scripts/context.js
@@ -12,6 +12,26 @@
   for (var j = 0; j < commands.length; j++) {
       var cmd = commands[j];
       var result = shell.exec(cmd.command);
+      if (result.exit_code !== 0) {
+          var message = result.stderr || ("command failed: " + cmd.command);
+          var kind = "internal";
+          if (result.exit_code === -1) {
+              kind = "not_available";
+              if (message.indexOf("empty command") !== -1 || message.indexOf("not allowed") !== -1) {
+                  kind = "validation";
+              }
+          }
+          signal.error({
+              kind: kind,
+              message: message,
+              detail: {
+                  command: cmd.command,
+                  exit_code: result.exit_code,
+                  stderr: result.stderr || "",
+              }
+          });
+          return;
+      }
       var k = cmd.state_key || cmd.command;
       board.setVar(k, result.stdout);
   }

--- a/sdk/script/bindings/bridge_board.go
+++ b/sdk/script/bindings/bridge_board.go
@@ -30,6 +30,10 @@ type Board interface {
 	AppendChannelMessage(name string, msg model.Message)
 }
 
+type boardVarDeleter interface {
+	DeleteVar(key string)
+}
+
 // NewBoardBridge exposes board state as the global "board".
 //
 // Vars (control variables, untyped):
@@ -37,6 +41,7 @@ type Board interface {
 //   - setVar(key, val)
 //   - getVars()        → map[string]any
 //   - hasVar(key)      → bool
+//   - deleteVar(key)
 //
 // Channels (typed conversation history; multimodal-aware via the
 // model.Message projection in bridge_llm_marshal.go):
@@ -58,8 +63,15 @@ func NewBoardBridge(board Board) BindingFunc {
 		return "board", map[string]any{
 			"MAIN_CHANNEL": engine.MainChannel,
 
-			"getVar":  func(key string) any { v, _ := board.GetVar(key); return v },
-			"setVar":  func(key string, value any) { board.SetVar(key, value) },
+			"getVar": func(key string) any { v, _ := board.GetVar(key); return v },
+			"setVar": func(key string, value any) { board.SetVar(key, value) },
+			"deleteVar": func(key string) {
+				if deleter, ok := board.(boardVarDeleter); ok {
+					deleter.DeleteVar(key)
+					return
+				}
+				board.SetVar(key, nil)
+			},
 			"getVars": func() map[string]any { return board.Vars() },
 			"hasVar":  func(key string) bool { _, ok := board.GetVar(key); return ok },
 

--- a/sdk/script/bindings/bridge_fs.go
+++ b/sdk/script/bindings/bridge_fs.go
@@ -3,6 +3,7 @@ package bindings
 import (
 	"context"
 
+	"github.com/GizClaw/flowcraft/sdk/errdefs"
 	"github.com/GizClaw/flowcraft/sdk/workspace"
 )
 
@@ -12,7 +13,7 @@ func NewFSBridge(ws workspace.Workspace) BindingFunc {
 		return "fs", map[string]any{
 			"read": func(path string) (string, error) {
 				if ws == nil {
-					return "", nil
+					return "", errdefs.NotAvailablef("fs.read: workspace not configured")
 				}
 				data, err := ws.Read(ctx, path)
 				if err != nil {
@@ -22,7 +23,7 @@ func NewFSBridge(ws workspace.Workspace) BindingFunc {
 			},
 			"write": func(path, content string) error {
 				if ws == nil {
-					return nil
+					return errdefs.NotAvailablef("fs.write: workspace not configured")
 				}
 				return ws.Write(ctx, path, []byte(content))
 			},
@@ -35,7 +36,7 @@ func NewFSBridge(ws workspace.Workspace) BindingFunc {
 			},
 			"delete": func(path string) error {
 				if ws == nil {
-					return nil
+					return errdefs.NotAvailablef("fs.delete: workspace not configured")
 				}
 				return ws.Delete(ctx, path)
 			},

--- a/sdk/script/bindings/bridge_fs_test.go
+++ b/sdk/script/bindings/bridge_fs_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/GizClaw/flowcraft/sdk/engine"
+	"github.com/GizClaw/flowcraft/sdk/errdefs"
 	"github.com/GizClaw/flowcraft/sdk/script/bindings"
 	"github.com/GizClaw/flowcraft/sdk/script/jsrt"
 	"github.com/GizClaw/flowcraft/sdk/workspace"
@@ -47,31 +48,21 @@ func TestFSBridge_RoundTrip(t *testing.T) {
 	}
 }
 
-func TestFSBridge_NilWorkspace_NoOps(t *testing.T) {
-	// nil workspace must not panic — every op falls through to a benign default.
-	// Tests cover the zero-deps path scriptnode falls into when fs isn't configured.
-	rt := jsrt.New(jsrt.WithPoolSize(1))
-	board := engine.NewBoard()
+func TestFSBridge_NilWorkspace_ReadWriteDeleteNotAvailable(t *testing.T) {
+	_, raw := bindings.NewFSBridge(nil)(context.Background())
+	api := raw.(map[string]any)
 
-	env := bindings.BuildEnv(context.Background(), nil,
-		bindings.NewBoardBridge(board),
-		bindings.NewFSBridge(nil),
-	)
-	_, err := rt.Exec(context.Background(), "fs-nil", `
-		if (fs.exists("anything")) throw new Error("nil ws should report not-exists");
-		if (fs.read("anything") !== "") throw new Error("nil ws read should be empty string");
-
-		// write/delete must be no-op (no error, no panic).
-		fs.write("anything", "data");
-		fs.delete("anything");
-
-		board.setVar("ok", true);
-	`, env)
-	if err != nil {
-		t.Fatalf("unexpected error with nil workspace: %v", err)
+	if api["exists"].(func(string) bool)("anything") {
+		t.Fatal("nil workspace should report not-exists")
 	}
-	if v, _ := board.GetVar("ok"); v != true {
-		t.Fatal("script should have completed all assertions")
+	if _, err := api["read"].(func(string) (string, error))("anything"); !errdefs.IsNotAvailable(err) {
+		t.Fatalf("read error = %v, want NotAvailable", err)
+	}
+	if err := api["write"].(func(string, string) error)("anything", "data"); !errdefs.IsNotAvailable(err) {
+		t.Fatalf("write error = %v, want NotAvailable", err)
+	}
+	if err := api["delete"].(func(string) error)("anything"); !errdefs.IsNotAvailable(err) {
+		t.Fatalf("delete error = %v, want NotAvailable", err)
 	}
 }
 

--- a/sdk/script/bindings/bridge_host.go
+++ b/sdk/script/bindings/bridge_host.go
@@ -3,6 +3,7 @@ package bindings
 import (
 	"context"
 	"fmt"
+	"strings"
 	"sync"
 
 	"github.com/GizClaw/flowcraft/sdk/engine"
@@ -97,7 +98,11 @@ type StreamEmitter interface {
 // ctx.Host / ctx.Publisher the executor installed and reuses those
 // instances for all bindings. When emitter is nil host.emit silently
 // drops the call, matching graph.NoopPublisher on the Go side.
-func NewHostBridge(host engine.Host, source string, emitter StreamEmitter) BindingFunc {
+func NewHostBridge(host engine.Host, source string, emitter StreamEmitter, opts ...HostBridgeOption) BindingFunc {
+	cfg := hostBridgeConfig{}
+	for _, opt := range opts {
+		opt(&cfg)
+	}
 	return func(callCtx context.Context) (string, any) {
 		if host == nil {
 			host = engine.NoopHost{}
@@ -142,6 +147,9 @@ func NewHostBridge(host engine.Host, source string, emitter StreamEmitter) Bindi
 			},
 
 			"publish": func(subject string, payload any) error {
+				if err := validateHostPublishSubject(subject, cfg); err != nil {
+					return err
+				}
 				env, err := event.NewEnvelope(callCtx, event.Subject(subject), payload)
 				if err != nil {
 					// Bad subject / unmarshallable payload — this is
@@ -150,6 +158,9 @@ func NewHostBridge(host engine.Host, source string, emitter StreamEmitter) Bindi
 					// can react with the same Validation handling
 					// they use for other malformed bridge calls.
 					return errdefs.Validationf("host.publish: %s", err.Error())
+				}
+				if cfg.enforceRunID && strings.HasPrefix(subject, engine.SubjectPrefix) {
+					env.SetRunID(cfg.runID)
 				}
 				return host.Publish(callCtx, env)
 			},
@@ -200,6 +211,56 @@ func NewHostBridge(host engine.Host, source string, emitter StreamEmitter) Bindi
 			},
 		}
 	}
+}
+
+type hostBridgeConfig struct {
+	runID        string
+	enforceRunID bool
+}
+
+// HostBridgeOption configures NewHostBridge.
+type HostBridgeOption func(*hostBridgeConfig)
+
+// WithHostRunID constrains host.publish for engine.run.* subjects to the
+// current run while leaving custom non-engine subjects available.
+func WithHostRunID(runID string) HostBridgeOption {
+	return func(c *hostBridgeConfig) {
+		c.runID = runID
+		c.enforceRunID = true
+	}
+}
+
+func validateHostPublishSubject(subject string, cfg hostBridgeConfig) error {
+	if !cfg.enforceRunID {
+		return nil
+	}
+	runID, ok := engineSubjectRunID(subject)
+	if !ok {
+		return nil
+	}
+	if cfg.runID == "" {
+		return errdefs.Validationf("host.publish: engine subject %q requires a current run_id", subject)
+	}
+	want := engine.SanitiseID(cfg.runID)
+	if runID != want {
+		return errdefs.Validationf(
+			"host.publish: engine subject run_id %q does not match current run_id %q",
+			runID, want,
+		)
+	}
+	return nil
+}
+
+func engineSubjectRunID(subject string) (string, bool) {
+	if !strings.HasPrefix(subject, engine.SubjectPrefix) {
+		return "", false
+	}
+	rest := strings.TrimPrefix(subject, engine.SubjectPrefix)
+	idx := strings.IndexByte(rest, '.')
+	if idx < 0 {
+		return rest, true
+	}
+	return rest[:idx], true
 }
 
 // parseUserPrompt projects a script-supplied object onto engine.UserPrompt.

--- a/sdk/script/bindings/bridge_host_test.go
+++ b/sdk/script/bindings/bridge_host_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/GizClaw/flowcraft/sdk/engine"
+	"github.com/GizClaw/flowcraft/sdk/errdefs"
 	"github.com/GizClaw/flowcraft/sdk/event"
 	"github.com/GizClaw/flowcraft/sdk/model"
 )
@@ -59,6 +60,11 @@ func (h *recordingHost) ReportUsage(_ context.Context, u model.TokenUsage) error
 func invoke(host engine.Host) (string, map[string]any) {
 	name, raw := NewHostBridge(host, "test-source", nil)(context.Background())
 	return name, raw.(map[string]any)
+}
+
+func invokeForRun(host engine.Host, runID string) map[string]any {
+	_, raw := NewHostBridge(host, "test-source", nil, WithHostRunID(runID))(context.Background())
+	return raw.(map[string]any)
 }
 
 func invokeWithEmitter(host engine.Host, emitter StreamEmitter) map[string]any {
@@ -115,6 +121,61 @@ func TestHostBridge_Publish_RejectsBadSubject(t *testing.T) {
 	}
 	if len(host.publishCalls) != 0 {
 		t.Fatalf("host should not see invalid envelope, got %d calls", len(host.publishCalls))
+	}
+}
+
+func TestHostBridge_Publish_LegacyCallAllowsEngineSubject(t *testing.T) {
+	host := newRecordingHost()
+	_, api := invoke(host)
+	publish := api["publish"].(func(string, any) error)
+
+	if err := publish(string(engine.SubjectRunStart("run-legacy")), map[string]any{"ok": true}); err != nil {
+		t.Fatalf("legacy publish engine subject: %v", err)
+	}
+	if len(host.publishCalls) != 1 {
+		t.Fatalf("publish calls = %d, want 1", len(host.publishCalls))
+	}
+	if string(host.publishCalls[0].Subject) != string(engine.SubjectRunStart("run-legacy")) {
+		t.Fatalf("subject = %q", host.publishCalls[0].Subject)
+	}
+}
+
+func TestHostBridge_Publish_EngineSubjectMustMatchCurrentRun(t *testing.T) {
+	host := newRecordingHost()
+	api := invokeForRun(host, "run-1")
+	publish := api["publish"].(func(string, any) error)
+
+	if err := publish(string(engine.SubjectRunStart("run-2")), nil); !errdefs.IsValidation(err) {
+		t.Fatalf("publish cross-run error = %v, want Validation", err)
+	}
+	if len(host.publishCalls) != 0 {
+		t.Fatalf("cross-run publish should not reach host, got %d calls", len(host.publishCalls))
+	}
+
+	if err := publish(string(engine.SubjectRunStart("run-1")), map[string]any{"ok": true}); err != nil {
+		t.Fatalf("publish current run: %v", err)
+	}
+	if len(host.publishCalls) != 1 {
+		t.Fatalf("publish calls = %d, want 1", len(host.publishCalls))
+	}
+	if got := host.publishCalls[0].RunID(); got != "run-1" {
+		t.Fatalf("published RunID = %q, want run-1", got)
+	}
+}
+
+func TestHostBridge_Publish_CustomSubjectStillAllowedWithRunConstraint(t *testing.T) {
+	host := newRecordingHost()
+	api := invokeForRun(host, "run-1")
+	publish := api["publish"].(func(string, any) error)
+
+	if err := publish("agent.test.foo", map[string]any{"hello": "world"}); err != nil {
+		t.Fatalf("publish custom subject: %v", err)
+	}
+	if len(host.publishCalls) != 1 {
+		t.Fatalf("publish calls = %d, want 1", len(host.publishCalls))
+	}
+	if string(host.publishCalls[0].Subject) != "agent.test.foo" {
+		t.Fatalf("subject = %q", host.publishCalls[0].Subject)
 	}
 }
 

--- a/sdk/script/bindings/bridge_llm_facade_test.go
+++ b/sdk/script/bindings/bridge_llm_facade_test.go
@@ -205,6 +205,21 @@ func TestLLMBridge_Stream_PartExposesToolCall(t *testing.T) {
 	}
 }
 
+func TestLLMBridge_Stream_NextAfterCloseReturnsFalse(t *testing.T) {
+	rt := jsrt.New(jsrt.WithPoolSize(1))
+	res, _ := newScriptedLLM("done")
+
+	env := llmEnv(t, NewLLMBridge(LLMBridgeOptions{Resolver: res, Defaults: LLMRunOptions{Model: "m"}, Source: "test"}))
+	_, err := rt.Exec(context.Background(), "stream-next-after-close", `
+		var s = llm.stream(null);
+		s.close();
+		if (s.next()) throw new Error("next after close should return false");
+	`, env)
+	if err != nil {
+		t.Fatalf("script: %v", err)
+	}
+}
+
 func TestLLMBridge_Stream_FinishAfterDrainReturnsResult(t *testing.T) {
 	// Calling finish() after manual draining must still return the same
 	// result (the round driver caches the result on first finish).

--- a/sdk/script/bindings/bridge_llm_round.go
+++ b/sdk/script/bindings/bridge_llm_round.go
@@ -196,6 +196,9 @@ func startRound(
 // non-textual chunks fall back to a zero Part — Current() == Part{}
 // — to keep the iterator deterministic.
 func (s *roundStream) Next() bool {
+	if s == nil || s.inner == nil {
+		return false
+	}
 	s.current = model.Part{}
 	if !s.inner.Next() {
 		return false
@@ -237,6 +240,7 @@ func (s *roundStream) Text() string {
 func (s *roundStream) Close() error {
 	inner := s.inner
 	s.inner = nil
+	s.current = model.Part{}
 	if inner != nil {
 		return inner.Close()
 	}

--- a/sdk/script/bindings/bridge_llm_round_test.go
+++ b/sdk/script/bindings/bridge_llm_round_test.go
@@ -258,6 +258,32 @@ func TestRoundStream_TextChunks_ProjectAsPartText(t *testing.T) {
 	}
 }
 
+func TestRoundStream_NextAfterCloseReturnsFalse(t *testing.T) {
+	stream := &fakeStream{
+		chunks: []model.StreamChunk{{Content: "hello"}},
+	}
+	res := &fakeResolver{llm: &fakeLLM{stream: stream}}
+	rs, err := startRound(context.Background(), res, nil, "src", nil, roundOptions{Model: "m"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !rs.Next() {
+		t.Fatal("expected first chunk")
+	}
+	if got := rs.Current(); got.Type != model.PartText || got.Text != "hello" {
+		t.Fatalf("Current before close = %+v, want text hello", got)
+	}
+	if err := rs.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+	if rs.Next() {
+		t.Fatal("Next after Close = true, want false")
+	}
+	if got := rs.Current(); got != (model.Part{}) {
+		t.Fatalf("Current after Close/Next = %+v, want zero Part", got)
+	}
+}
+
 func TestRoundStream_ToolCallChunk_ProjectAsPartToolCall(t *testing.T) {
 	stream := &fakeStream{
 		chunks: []model.StreamChunk{

--- a/sdk/script/bindings/bridge_runtime.go
+++ b/sdk/script/bindings/bridge_runtime.go
@@ -3,8 +3,17 @@ package bindings
 import (
 	"context"
 
+	"github.com/GizClaw/flowcraft/sdk/errdefs"
 	"github.com/GizClaw/flowcraft/sdk/script"
 )
+
+type nestedExecSupport interface {
+	SupportsNestedExec() bool
+}
+
+type nestedExecRuntime interface {
+	ExecNested(ctx context.Context, name, source string, env *script.Env) (*script.Signal, error)
+}
 
 // RuntimeBinding returns the host object for global "runtime" (e.g. execScript).
 // Parent bindings are inherited by sub-scripts.
@@ -15,7 +24,29 @@ func RuntimeBinding(ctx context.Context, rt script.Runtime, parentBindings map[s
 				Config:   config,
 				Bindings: parentBindings,
 			}
+			if nested, ok := rt.(nestedExecRuntime); ok {
+				sig, err := nested.ExecNested(ctx, "inline", source, env)
+				if errdefs.IsNotAvailable(err) {
+					return nestedNotAvailableSignal(err), nil
+				}
+				return sig, err
+			}
+			if support, ok := rt.(nestedExecSupport); ok && !support.SupportsNestedExec() {
+				return nestedNotAvailableSignal(nil), nil
+			}
 			return rt.Exec(ctx, "inline", source, env)
 		},
+	}
+}
+
+func nestedNotAvailableSignal(err error) *script.Signal {
+	msg := "runtime.execScript: nested script execution is not available"
+	if err != nil {
+		msg = "runtime.execScript: " + err.Error()
+	}
+	return &script.Signal{
+		Type:    "error",
+		Kind:    string(script.ErrorKindNotAvailable),
+		Message: msg,
 	}
 }

--- a/sdk/script/bindings/bridge_runtime_test.go
+++ b/sdk/script/bindings/bridge_runtime_test.go
@@ -2,12 +2,16 @@ package bindings_test
 
 import (
 	"context"
+	"errors"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/GizClaw/flowcraft/sdk/engine"
 	"github.com/GizClaw/flowcraft/sdk/script"
 	"github.com/GizClaw/flowcraft/sdk/script/bindings"
 	"github.com/GizClaw/flowcraft/sdk/script/jsrt"
+	"github.com/GizClaw/flowcraft/sdk/script/luart"
 )
 
 // RuntimeBinding is normally wired by scriptnode, not user code, so these
@@ -115,5 +119,144 @@ func TestRuntimeBinding_ChildReceivesConfig(t *testing.T) {
 	}
 	if v, _ := board.GetVar("g"); v != "hi" {
 		t.Fatalf("child did not see config.greeting: got %v", v)
+	}
+}
+
+func TestRuntimeBinding_PoolSizeOneRejectsNestedExec(t *testing.T) {
+	rt := jsrt.New(jsrt.WithPoolSize(1))
+	board := engine.NewBoard()
+	env := envWithRuntime(context.Background(), rt, bindings.NewBoardBridge(board))
+
+	_, err := rt.Exec(context.Background(), "parent", `
+		var sig = runtime.execScript('board.setVar("from_child", 99);', null);
+		if (sig === null) throw new Error("expected rejection signal");
+		if (sig.Type !== "error") throw new Error("Type = " + sig.Type);
+		if (sig.Kind !== "not_available") throw new Error("Kind = " + sig.Kind);
+		board.setVar("rejected", true);
+	`, env)
+	if err != nil {
+		t.Fatalf("parent exec failed: %v", err)
+	}
+	if v, _ := board.GetVar("rejected"); v != true {
+		t.Fatal("script did not observe nested exec rejection")
+	}
+	if v, ok := board.GetVar("from_child"); ok && v != nil {
+		t.Fatalf("child script should not have run, got from_child=%v", v)
+	}
+}
+
+func TestRuntimeBinding_LuaPoolSizeOneRejectsNestedExec(t *testing.T) {
+	rt := luart.New(luart.WithPoolSize(1))
+	t.Cleanup(func() { _ = rt.Close() })
+	board := engine.NewBoard()
+	env := envWithRuntime(context.Background(), rt, bindings.NewBoardBridge(board))
+
+	_, err := rt.Exec(context.Background(), "parent", `
+		local sig = runtime.execScript('board.setVar("from_child", 99)', nil)
+		if sig == nil then error("expected rejection signal") end
+		if sig.type ~= "error" then error("type = " .. tostring(sig.type)) end
+		if sig.kind ~= "not_available" then error("kind = " .. tostring(sig.kind)) end
+		board.setVar("rejected_lua", true)
+	`, env)
+	if err != nil {
+		t.Fatalf("parent exec failed: %v", err)
+	}
+	if v, _ := board.GetVar("rejected_lua"); v != true {
+		t.Fatal("script did not observe nested exec rejection")
+	}
+	if v, ok := board.GetVar("from_child"); ok && v != nil {
+		t.Fatalf("child script should not have run, got from_child=%v", v)
+	}
+}
+
+func TestRuntimeBinding_ConcurrentParentsFailFastWhenPoolBusy(t *testing.T) {
+	rt := jsrt.New(jsrt.WithPoolSize(2))
+	board := engine.NewBoard()
+	barrier := newRuntimeBarrier(2)
+	env := envWithRuntime(
+		context.Background(),
+		rt,
+		bindings.NewBoardBridge(board),
+		func(context.Context) (string, any) {
+			return "barrier", map[string]any{
+				"beforeNested": barrier.before,
+				"afterNested":  barrier.after,
+			}
+		},
+	)
+
+	parent := `
+		barrier.beforeNested();
+		var sig = runtime.execScript('board.setVar("from_child", true);', null);
+		if (sig === null) throw new Error("expected rejection signal");
+		if (sig.Type !== "error") throw new Error("Type = " + sig.Type);
+		if (sig.Kind !== "not_available") throw new Error("Kind = " + sig.Kind);
+		barrier.afterNested();
+	`
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	errCh := make(chan error, 2)
+	for i := 0; i < 2; i++ {
+		go func() {
+			_, err := rt.Exec(ctx, "parent", parent, env)
+			errCh <- err
+		}()
+	}
+
+	for i := 0; i < 2; i++ {
+		select {
+		case err := <-errCh:
+			if err != nil {
+				t.Fatalf("parent %d exec failed: %v", i, err)
+			}
+		case <-time.After(3 * time.Second):
+			t.Fatal("concurrent nested exec did not fail fast")
+		}
+	}
+	if v, ok := board.GetVar("from_child"); ok && v != nil {
+		t.Fatalf("child script should not have run, got from_child=%v", v)
+	}
+}
+
+type runtimeBarrier struct {
+	want int
+
+	mu          sync.Mutex
+	beforeCount int
+	afterCount  int
+	beforeCh    chan struct{}
+	afterCh     chan struct{}
+}
+
+func newRuntimeBarrier(want int) *runtimeBarrier {
+	return &runtimeBarrier{
+		want:     want,
+		beforeCh: make(chan struct{}),
+		afterCh:  make(chan struct{}),
+	}
+}
+
+func (b *runtimeBarrier) before() error {
+	return b.wait(&b.beforeCount, b.beforeCh)
+}
+
+func (b *runtimeBarrier) after() error {
+	return b.wait(&b.afterCount, b.afterCh)
+}
+
+func (b *runtimeBarrier) wait(count *int, ch chan struct{}) error {
+	b.mu.Lock()
+	*count = *count + 1
+	if *count == b.want {
+		close(ch)
+	}
+	b.mu.Unlock()
+
+	select {
+	case <-ch:
+		return nil
+	case <-time.After(2 * time.Second):
+		return errors.New("barrier timeout")
 	}
 }

--- a/sdk/script/jsrt/jsrt.go
+++ b/sdk/script/jsrt/jsrt.go
@@ -83,6 +83,13 @@ func New(opts ...Option) *Runtime {
 	return r
 }
 
+// SupportsNestedExec reports whether runtime.execScript has any chance of
+// acquiring a second VM while a parent script is still holding one. Runtime
+// bindings still use ExecNested so they can fail fast when the pool is busy.
+func (r *Runtime) SupportsNestedExec() bool {
+	return r != nil && r.poolSize > 1
+}
+
 func (r *Runtime) init() {
 	r.once.Do(func() {
 		r.pool = make(chan *goja.Runtime, r.poolSize)
@@ -107,6 +114,10 @@ func (r *Runtime) newVM() *goja.Runtime {
 // is cancelled before one becomes available.
 var ErrVMPoolExhausted = errdefs.NotAvailable(errors.New("jsrt: VM pool exhausted, context cancelled while waiting"))
 
+// ErrVMPoolBusy is returned by nested execution when no VM is immediately
+// available. Nested scripts must not wait on the same pool their parent holds.
+var ErrVMPoolBusy = errdefs.NotAvailable(errors.New("jsrt: VM pool exhausted"))
+
 func (r *Runtime) acquire(ctx context.Context) (*goja.Runtime, error) {
 	r.init()
 	select {
@@ -114,6 +125,16 @@ func (r *Runtime) acquire(ctx context.Context) (*goja.Runtime, error) {
 		return vm, nil
 	case <-ctx.Done():
 		return nil, ErrVMPoolExhausted
+	}
+}
+
+func (r *Runtime) tryAcquire() (*goja.Runtime, error) {
+	r.init()
+	select {
+	case vm := <-r.pool:
+		return vm, nil
+	default:
+		return nil, ErrVMPoolBusy
 	}
 }
 
@@ -126,38 +147,52 @@ func (r *Runtime) release(vm *goja.Runtime) {
 // A built-in "signal" global is always injected, providing interrupt/error/done
 // control flow back to the host.
 func (r *Runtime) Exec(ctx context.Context, name, source string, env *script.Env) (*script.Signal, error) {
+	return r.exec(ctx, name, source, env, false)
+}
+
+// ExecNested runs a child script only when another VM is immediately
+// available. It is used by runtime.execScript to avoid parent scripts
+// deadlocking each other while they still hold their own VMs.
+func (r *Runtime) ExecNested(ctx context.Context, name, source string, env *script.Env) (*script.Signal, error) {
+	return r.exec(ctx, name, source, env, true)
+}
+
+func (r *Runtime) exec(ctx context.Context, name, source string, env *script.Env, nested bool) (*script.Signal, error) {
 	if r.maxExecTime > 0 {
 		var cancel context.CancelFunc
 		ctx, cancel = context.WithTimeout(ctx, r.maxExecTime)
 		defer cancel()
 	}
 
-	vm, err := r.acquire(ctx)
+	var (
+		vm  *goja.Runtime
+		err error
+	)
+	if nested {
+		vm, err = r.tryAcquire()
+	} else {
+		vm, err = r.acquire(ctx)
+	}
 	if err != nil {
 		return nil, err
 	}
+	defer r.discardAndRelease(vm)
 
 	vm.ClearInterrupt()
-
-	injectedNames := make([]string, 0, 8)
 
 	var config map[string]any
 	if env != nil {
 		config = env.Config
 	}
 	if err := vm.Set("config", config); err != nil {
-		r.release(vm)
 		return nil, fmt.Errorf("jsrt: set config: %w", err)
 	}
-	injectedNames = append(injectedNames, "config")
 
 	if env != nil {
 		for bname, bval := range env.Bindings {
 			if err := vm.Set(bname, bval); err != nil {
-				r.cleanupAndRelease(vm, injectedNames)
 				return nil, fmt.Errorf("jsrt: set binding %q: %w", bname, err)
 			}
-			injectedNames = append(injectedNames, bname)
 		}
 	}
 
@@ -186,10 +221,8 @@ func (r *Runtime) Exec(ctx context.Context, name, source string, env *script.Env
 		},
 	}
 	if err := vm.Set("signal", signalObj); err != nil {
-		r.cleanupAndRelease(vm, injectedNames)
 		return nil, fmt.Errorf("jsrt: set signal: %w", err)
 	}
-	injectedNames = append(injectedNames, "signal")
 
 	interruptDone := make(chan struct{})
 	defer close(interruptDone)
@@ -202,8 +235,6 @@ func (r *Runtime) Exec(ctx context.Context, name, source string, env *script.Env
 	}()
 
 	_, runErr := vm.RunString(wrapIIFE(source))
-
-	defer r.cleanupAndRelease(vm, injectedNames)
 
 	if runErr != nil {
 		if _, ok := runErr.(*goja.InterruptedError); ok {
@@ -225,11 +256,8 @@ func (r *Runtime) Exec(ctx context.Context, name, source string, env *script.Env
 	return nil, nil
 }
 
-func (r *Runtime) cleanupAndRelease(vm *goja.Runtime, names []string) {
-	for _, name := range names {
-		_ = vm.Set(name, goja.Undefined())
-	}
-	r.release(vm)
+func (r *Runtime) discardAndRelease(_ *goja.Runtime) {
+	r.release(r.newVM())
 }
 
 func wrapIIFE(source string) string {

--- a/sdk/script/jsrt/jsrt_test.go
+++ b/sdk/script/jsrt/jsrt_test.go
@@ -208,6 +208,42 @@ func TestRuntime_IIFE_VarIsolation(t *testing.T) {
 	}
 }
 
+func TestRuntime_GlobalObjectDoesNotLeakBetweenExecs(t *testing.T) {
+	rt := New(WithPoolSize(1))
+	var oldHostCalled bool
+	env := &script.Env{
+		Bindings: map[string]any{
+			"host": map[string]any{
+				"mark": func() { oldHostCalled = true },
+			},
+		},
+	}
+
+	_, err := rt.Exec(context.Background(), "pollute-global", `
+		globalThis.oldHost = host;
+		globalThis.leakedValue = "secret";
+	`, env)
+	if err != nil {
+		t.Fatalf("first exec: %v", err)
+	}
+
+	_, err = rt.Exec(context.Background(), "check-global", `
+		if (typeof globalThis.oldHost !== "undefined") {
+			globalThis.oldHost.mark();
+			throw new Error("old host leaked across executions");
+		}
+		if (typeof globalThis.leakedValue !== "undefined") {
+			throw new Error("global value leaked across executions: " + globalThis.leakedValue);
+		}
+	`, nil)
+	if err != nil {
+		t.Fatalf("global object should not leak between executions: %v", err)
+	}
+	if oldHostCalled {
+		t.Fatal("old host capability was callable from a later execution")
+	}
+}
+
 func TestEnrichError_GojaException(t *testing.T) {
 	rt := New(WithPoolSize(1))
 	_, err := rt.Exec(context.Background(), "err-test", `

--- a/sdk/script/luart/luart.go
+++ b/sdk/script/luart/luart.go
@@ -81,6 +81,13 @@ func New(opts ...Option) *Runtime {
 	return r
 }
 
+// SupportsNestedExec reports whether runtime.execScript has any chance of
+// acquiring a second LState while a parent script is still holding one.
+// Runtime bindings still use ExecNested so they can fail fast when busy.
+func (r *Runtime) SupportsNestedExec() bool {
+	return r != nil && r.poolSize > 1
+}
+
 func (r *Runtime) init() {
 	r.once.Do(func() {
 		r.pool = make(chan *lua.LState, r.poolSize)
@@ -101,6 +108,10 @@ func (r *Runtime) newVM() *lua.LState {
 // is cancelled before one becomes available.
 var ErrVMPoolExhausted = errdefs.NotAvailable(errors.New("luart: VM pool exhausted, context cancelled while waiting"))
 
+// ErrVMPoolBusy is returned by nested execution when no LState is immediately
+// available. Nested scripts must not wait on the same pool their parent holds.
+var ErrVMPoolBusy = errdefs.NotAvailable(errors.New("luart: VM pool exhausted"))
+
 // ErrRuntimeClosed is returned when Exec is called after Close.
 var ErrRuntimeClosed = errors.New("luart: runtime is closed")
 
@@ -117,6 +128,22 @@ func (r *Runtime) acquire(ctx context.Context) (*lua.LState, error) {
 		return L, nil
 	case <-ctx.Done():
 		return nil, ErrVMPoolExhausted
+	}
+}
+
+func (r *Runtime) tryAcquire() (*lua.LState, error) {
+	if r.closed.Load() {
+		return nil, ErrRuntimeClosed
+	}
+	r.init()
+	select {
+	case L := <-r.pool:
+		if L == nil {
+			return nil, ErrRuntimeClosed
+		}
+		return L, nil
+	default:
+		return nil, ErrVMPoolBusy
 	}
 }
 
@@ -146,13 +173,32 @@ func (r *Runtime) Close() error {
 // config and bindings as globals. A built-in "signal" global is always
 // injected for interrupt/error/done control flow back to the host.
 func (r *Runtime) Exec(ctx context.Context, name, source string, env *script.Env) (*script.Signal, error) {
+	return r.exec(ctx, name, source, env, false)
+}
+
+// ExecNested runs a child script only when another LState is immediately
+// available. It is used by runtime.execScript to avoid parent scripts
+// deadlocking each other while they still hold their own LStates.
+func (r *Runtime) ExecNested(ctx context.Context, name, source string, env *script.Env) (*script.Signal, error) {
+	return r.exec(ctx, name, source, env, true)
+}
+
+func (r *Runtime) exec(ctx context.Context, name, source string, env *script.Env, nested bool) (*script.Signal, error) {
 	if r.maxExecTime > 0 {
 		var cancel context.CancelFunc
 		ctx, cancel = context.WithTimeout(ctx, r.maxExecTime)
 		defer cancel()
 	}
 
-	L, err := r.acquire(ctx)
+	var (
+		L   *lua.LState
+		err error
+	)
+	if nested {
+		L, err = r.tryAcquire()
+	} else {
+		L, err = r.acquire(ctx)
+	}
 	if err != nil {
 		return nil, err
 	}
@@ -160,18 +206,13 @@ func (r *Runtime) Exec(ctx context.Context, name, source string, env *script.Env
 	L.RemoveContext()
 
 	injectedNames := make([]string, 0, 8)
-	var discardVM bool
 	defer func() {
 		L.RemoveContext()
 		for _, n := range injectedNames {
 			L.SetGlobal(n, lua.LNil)
 		}
-		if discardVM {
-			L.Close()
-			r.release(r.newVM())
-		} else {
-			r.release(L)
-		}
+		L.Close()
+		r.release(r.newVM())
 	}()
 
 	setGlobal := func(key string, val lua.LValue) {
@@ -223,7 +264,6 @@ func (r *Runtime) Exec(ctx context.Context, name, source string, env *script.Env
 		if sig != nil {
 			return sig, nil
 		}
-		discardVM = true
 		if ctx.Err() != nil {
 			return nil, errdefs.FromContext(fmt.Errorf("luart: script %q: execution cancelled: %w", name, ctx.Err()))
 		}

--- a/sdk/script/luart/luart_test.go
+++ b/sdk/script/luart/luart_test.go
@@ -170,6 +170,42 @@ func TestRuntime_IIFE_LocalIsolation(t *testing.T) {
 	}
 }
 
+func TestRuntime_GlobalObjectDoesNotLeakBetweenExecs(t *testing.T) {
+	rt := New(WithPoolSize(1))
+	var oldHostCalled bool
+	env := &script.Env{
+		Bindings: map[string]any{
+			"host": map[string]any{
+				"mark": func() { oldHostCalled = true },
+			},
+		},
+	}
+
+	_, err := rt.Exec(context.Background(), "pollute-global", `
+		_G.old_host = host
+		_G.leaked_value = "secret"
+	`, env)
+	if err != nil {
+		t.Fatalf("first exec: %v", err)
+	}
+
+	_, err = rt.Exec(context.Background(), "check-global", `
+		if _G.old_host ~= nil then
+			_G.old_host.mark()
+			error("old host leaked across executions")
+		end
+		if _G.leaked_value ~= nil then
+			error("global value leaked across executions: " .. tostring(_G.leaked_value))
+		end
+	`, nil)
+	if err != nil {
+		t.Fatalf("global object should not leak between executions: %v", err)
+	}
+	if oldHostCalled {
+		t.Fatal("old host capability was callable from a later execution")
+	}
+}
+
 func TestRuntime_Bindings(t *testing.T) {
 	rt := New(WithPoolSize(1))
 	var captured string
@@ -264,7 +300,7 @@ func TestRuntime_VMDiscardOnError_NoStateLeak(t *testing.T) {
 	}
 }
 
-func TestRuntime_VMDiscardOnError_SignalDoesNotDiscard(t *testing.T) {
+func TestRuntime_VMDiscardAfterSignal_NoStateLeak(t *testing.T) {
 	rt := New(WithPoolSize(1))
 
 	_, err := rt.Exec(context.Background(), "set-global", `
@@ -276,12 +312,12 @@ func TestRuntime_VMDiscardOnError_SignalDoesNotDiscard(t *testing.T) {
 	}
 
 	_, err = rt.Exec(context.Background(), "check-persist", `
-		if _G.persist_marker ~= 42 then
-			error("expected marker to persist after signal (VM not discarded)")
+		if _G.persist_marker ~= nil then
+			error("global state leaked after signal: " .. tostring(_G.persist_marker))
 		end
 	`, nil)
 	if err != nil {
-		t.Fatalf("VM should NOT be discarded on signal: %v", err)
+		t.Fatalf("VM should be discarded after signal: %v", err)
 	}
 }
 


### PR DESCRIPTION
## Summary
Script-backed graph nodes now fail closed around host capabilities and script runtime reuse instead of leaking old run state, silently swallowing missing dependencies, or hanging nested script execution.

- Run-scoped host publishing and stream subscriptions now prevent cross-run engine-event access from scriptnode bindings.
- JS and Lua runtimes now discard used VMs/LStates and fail fast for nested execution when the pool is busy, closing capability leaks and deadlock paths.
- Approval, context, fs, stream, and LLM stream bridges now have safer cleanup/error behavior, and `scriptnode.Deps.ExtraBridges` lets callers opt into custom script bridges explicitly.

## Test plan
- `go test -count=1 ./sdk/graph/node/scriptnode ./sdk/script/bindings ./sdk/script ./sdk/script/jsrt ./sdk/script/luart`
- `go test -count=1 ./sdk/...`
