### PR TITLE
sdk/model: add message name metadata

### DIFF
--- a/sdk/model/message.go
+++ b/sdk/model/message.go
@@ -80,6 +80,7 @@ type Part struct {
 // Message is a multi-modal, provider-agnostic chat message.
 type Message struct {
 	Role  Role   `json:"role"`
+	Name  string `json:"name,omitzero"`
 	Parts []Part `json:"parts"`
 }
 
@@ -88,6 +89,7 @@ type Message struct {
 func (m Message) Clone() Message {
 	return Message{
 		Role:  m.Role,
+		Name:  m.Name,
 		Parts: CloneParts(m.Parts),
 	}
 }

--- a/sdk/model/message_test.go
+++ b/sdk/model/message_test.go
@@ -59,6 +59,18 @@ func TestNewTextMessage(t *testing.T) {
 	}
 }
 
+func TestMessage_ClonePreservesName(t *testing.T) {
+	msg := NewTextMessage(RoleAssistant, "hi")
+	msg.Name = "generate_game_master"
+
+	cp := msg.Clone()
+	msg.Name = "mutated"
+
+	if cp.Name != "generate_game_master" {
+		t.Fatalf("Name = %q, want generate_game_master", cp.Name)
+	}
+}
+
 func TestNewImageMessage(t *testing.T) {
 	msg := NewImageMessage(RoleUser, "describe this", "https://img.example.com/cat.jpg")
 	if len(msg.Parts) != 2 {


### PR DESCRIPTION
## Summary
- add a zero-value-omitted Name field to model.Message
- preserve Name through Message.Clone
- cover the clone behavior with a focused model test

## Test
- go test ./model