### PR TITLE
feat(script): require explicit llm messages

### DIFF
--- a/sdk/script/bindings/bridge_llm.go
+++ b/sdk/script/bindings/bridge_llm.go
@@ -16,15 +16,14 @@ import (
 //
 // The bridge is the only consumer of these options at the moment, so
 // the surface stays minimal: a resolver to materialize the LLM, an
-// optional tool registry for function-calling, the per-call defaults
-// the script can override, a source label for diagnostics, and a hook
-// for the bridge to read the conversation history at call time.
+// optional tool registry for function-calling, the generation defaults
+// the script can override per call, and a source label for diagnostics.
 //
 // Notably absent — these were intentional decisions during the
 // "B-track" refactor:
 //
 //   - No llm.RoundConfig: scripts and the bridge interior speak the
-//     bridge's own LLMRunOptions / roundOptions types end-to-end.
+//     bridge's own call-options / roundOptions types end-to-end.
 //   - No Go-side OnEvent hook: scripts pull chunks via the iterator
 //     returned by stream(); a host-side event subscription will be
 //     added only when a real consumer needs it.
@@ -32,35 +31,38 @@ type LLMBridgeOptions struct {
 	Resolver llm.LLMResolver
 	Registry *tool.Registry
 
-	// Defaults are merged with the script-supplied overrides on every
-	// llm.run() / llm.stream() call. Any field the script omits is
-	// inherited from here; explicit script values win.
+	// Defaults are merged with the script-supplied generation overrides
+	// on every llm.run() / llm.stream() call. Any field the script
+	// omits is inherited from here; explicit script values win.
+	// Messages are never defaulted and must be supplied per call.
 	Defaults LLMRunOptions
 
 	// Source labels diagnostics (errors, future tracing). It is the
 	// bridge equivalent of "node id" / "event id" in legacy code.
 	Source string
-
-	// ReadMessages returns the conversation history to send to the
-	// LLM. Called once per script invocation so the script can mutate
-	// the board between rounds and have the next call see the update.
-	// When nil, an empty slice is used.
-	ReadMessages func(ctx context.Context) []model.Message
 }
 
-// LLMRunOptions is the strongly-typed object that scripts pass to
-// llm.run() / llm.stream().
+// LLMRunOptions is the defaultable generation-options subset shared by
+// LLMBridgeOptions.Defaults and per-call script overrides.
 //
-// All fields are optional; any unset field inherits the bridge's
-// LLMBridgeOptions.Defaults value. Pointer fields (Temperature,
-// JSONMode, Thinking) distinguish "script omitted" from "script
-// explicitly set to zero/false". Unknown JSON keys are rejected at
-// parse time so script typos surface immediately instead of silently
-// falling back to defaults.
+// Scripts pass a call object containing messages plus these optional
+// fields. Messages are parsed separately into an internal call-options
+// value so LLMBridgeOptions.Defaults cannot imply a default conversation.
+// The messages value is required on every call and must use the
+// canonical model.Message shape: role plus parts. Any unset generation
+// field inherits the bridge's LLMBridgeOptions.Defaults value.
+// Pointer fields (Temperature, JSONMode, Thinking) distinguish "script
+// omitted" from "script explicitly set to zero/false". Unknown JSON keys
+// are rejected at parse time so script typos surface immediately instead
+// of silently falling back to defaults.
 //
 // Script-side schema (JS / Lua):
 //
 //	llm.run({
+//	    messages: [{
+//	        role: "user",
+//	        parts: [{ type: "text", text: "What changed?" }],
+//	    }],
 //	    model:        "openai/gpt-4o-mini",   // optional, string
 //	    temperature:  0.2,                    // optional, number
 //	    max_tokens:   1024,                   // optional, integer
@@ -77,16 +79,24 @@ type LLMRunOptions struct {
 	Tools       []string `json:"tools,omitempty"`
 }
 
+type llmCallOptions struct {
+	messages   []model.Message
+	runOptions LLMRunOptions
+}
+
 // NewLLMBridge exposes LLM calls to scripts as the global "llm":
 //
-//	llm.run()                              // blocking, returns full result map
-//	llm.run({ model, temperature, ... })   // with per-call overrides
-//	llm.stream()                           // returns iterator { next, part, text, finish, close }
-//	llm.stream({ model, ... })             // streamed, with per-call overrides
+//	llm.run({ messages })                         // blocking, returns full result map
+//	llm.run({ messages, model, temperature, ... }) // with per-call overrides
+//	llm.stream({ messages })                      // returns iterator { next, part, text, finish, close }
+//	llm.stream({ messages, model, ... })          // streamed, with per-call overrides
 //
 // Iterator usage (multimodal-friendly):
 //
-//	var s = llm.stream({ model: "..." });
+//	var s = llm.stream({
+//	    messages: [{ role: "user", parts: [{ type: "text", text: "go on" }] }],
+//	    model: "...",
+//	});
 //	while (s.next()) {
 //	    var p = s.part();        // map projection of model.Part
 //	    if (p.type === "text")   write(p.text);
@@ -98,31 +108,24 @@ type LLMRunOptions struct {
 //
 // Neither mode writes to the board; the script controls what to do
 // with results (typically via the board bridge: board.setVar /
-// board.setChannel). See LLMRunOptions for the per-call schema.
+// board.setChannel). The per-call schema is parsed by parseRunOptions.
 func NewLLMBridge(opts LLMBridgeOptions) BindingFunc {
 	return func(callCtx context.Context) (string, any) {
-		readMsgs := func() []model.Message {
-			if opts.ReadMessages != nil {
-				return opts.ReadMessages(callCtx)
-			}
-			return nil
-		}
-
-		resolveOpts := func(rawOpts any) (roundOptions, error) {
-			override, err := parseRunOptions(rawOpts)
+		resolveOpts := func(rawOpts any) (roundOptions, []model.Message, error) {
+			callOpts, err := parseRunOptions(rawOpts)
 			if err != nil {
-				return roundOptions{}, err
+				return roundOptions{}, nil, err
 			}
-			return toRoundOptions(opts.Defaults, override), nil
+			return toRoundOptions(opts.Defaults, callOpts.runOptions), callOpts.messages, nil
 		}
 
 		return "llm", map[string]any{
 			"run": func(rawOpts any) (map[string]any, error) {
-				ro, err := resolveOpts(rawOpts)
+				ro, messages, err := resolveOpts(rawOpts)
 				if err != nil {
 					return nil, err
 				}
-				r, err := runRound(callCtx, opts.Resolver, opts.Registry, opts.Source, readMsgs(), ro)
+				r, err := runRound(callCtx, opts.Resolver, opts.Registry, opts.Source, messages, ro)
 				if err != nil {
 					return nil, err
 				}
@@ -130,11 +133,11 @@ func NewLLMBridge(opts LLMBridgeOptions) BindingFunc {
 			},
 
 			"stream": func(rawOpts any) (map[string]any, error) {
-				ro, err := resolveOpts(rawOpts)
+				ro, messages, err := resolveOpts(rawOpts)
 				if err != nil {
 					return nil, err
 				}
-				s, err := startRound(callCtx, opts.Resolver, opts.Registry, opts.Source, readMsgs(), ro)
+				s, err := startRound(callCtx, opts.Resolver, opts.Registry, opts.Source, messages, ro)
 				if err != nil {
 					return nil, err
 				}
@@ -156,37 +159,64 @@ func NewLLMBridge(opts LLMBridgeOptions) BindingFunc {
 	}
 }
 
-// parseRunOptions decodes the script-supplied options object into
-// LLMRunOptions. nil is treated as "no overrides" (zero value). Any
-// other non-map value, or any unknown JSON key, returns an error so
-// that the script sees a real exception instead of silently inheriting
-// the bridge defaults.
-func parseRunOptions(v any) (LLMRunOptions, error) {
+// parseRunOptions decodes the script-supplied call object into internal
+// call options. messages is mandatory and must be supplied explicitly
+// for each llm.run() / llm.stream() call; only generation fields flow
+// into LLMRunOptions for default merging. Any non-map value, missing or
+// null messages value, or unknown JSON key returns an error so that the
+// script sees a real exception instead of silently inheriting a default
+// conversation or an implicit history source.
+func parseRunOptions(v any) (llmCallOptions, error) {
 	if v == nil {
-		return LLMRunOptions{}, nil
+		return llmCallOptions{}, errdefs.Validationf("llm: missing required field %q", "messages")
 	}
 	m, ok := v.(map[string]any)
 	if !ok {
-		return LLMRunOptions{}, errdefs.Validationf("llm: options must be an object, got %T", v)
+		return llmCallOptions{}, errdefs.Validationf("llm: options must be an object, got %T", v)
 	}
-	if len(m) == 0 {
-		return LLMRunOptions{}, nil
+	rawMessages, ok := m["messages"]
+	if !ok {
+		return llmCallOptions{}, errdefs.Validationf("llm: missing required field %q", "messages")
+	}
+	messages, err := parseLLMMessages(rawMessages, "llm.messages")
+	if err != nil {
+		return llmCallOptions{}, err
 	}
 	raw, err := json.Marshal(m)
 	if err != nil {
-		return LLMRunOptions{}, fmt.Errorf("llm: marshal options: %w", err)
+		return llmCallOptions{}, fmt.Errorf("llm: marshal options: %w", err)
 	}
 	dec := json.NewDecoder(bytes.NewReader(raw))
 	dec.DisallowUnknownFields()
-	var opts LLMRunOptions
-	if err := dec.Decode(&opts); err != nil {
-		return LLMRunOptions{}, fmt.Errorf("llm: invalid options: %w", err)
+	var opts struct {
+		Messages    json.RawMessage `json:"messages"`
+		Model       string          `json:"model,omitempty"`
+		Temperature *float64        `json:"temperature,omitempty"`
+		MaxTokens   int64           `json:"max_tokens,omitempty"`
+		JSONMode    *bool           `json:"json_mode,omitempty"`
+		Thinking    *bool           `json:"thinking,omitempty"`
+		Tools       []string        `json:"tools,omitempty"`
 	}
-	return opts, nil
+	if err := dec.Decode(&opts); err != nil {
+		return llmCallOptions{}, fmt.Errorf("llm: invalid options: %w", err)
+	}
+	return llmCallOptions{
+		messages: messages,
+		runOptions: LLMRunOptions{
+			Model:       opts.Model,
+			Temperature: opts.Temperature,
+			MaxTokens:   opts.MaxTokens,
+			JSONMode:    opts.JSONMode,
+			Thinking:    opts.Thinking,
+			Tools:       opts.Tools,
+		},
+	}, nil
 }
 
 // toRoundOptions folds defaults with the script-supplied override into
-// the bridge-internal roundOptions value the round logic consumes.
+// the bridge-internal roundOptions value the round logic consumes. It
+// only handles generation options; messages are resolved by parseRunOptions
+// and passed to the round separately.
 //
 // Merge rules:
 //

--- a/sdk/script/bindings/bridge_llm_facade_test.go
+++ b/sdk/script/bindings/bridge_llm_facade_test.go
@@ -19,8 +19,10 @@ import (
 	"github.com/GizClaw/flowcraft/sdk/tool"
 )
 
+const jsCanonicalMessages = `[{ role: "user", parts: [{ type: "text", text: "hello" }] }]`
+
 // llmEnv assembles a script.Env that exposes only the "llm" global, backed
-// by the supplied resolver / registry / read-history function. Mirrors the
+// by the supplied resolver / registry. Mirrors the
 // minimal wiring a host would do when only LLM access matters.
 func llmEnv(t *testing.T, br BindingFunc) *script.Env {
 	t.Helper()
@@ -42,7 +44,7 @@ func newScriptedLLM(text string) (*fakeResolver, *fakeLLM) {
 }
 
 // ---------------------------------------------------------------------------
-// llm.run() — happy path + option / history wiring
+// llm.run() — happy path + explicit message / option wiring
 // ---------------------------------------------------------------------------
 
 func TestLLMBridge_Run_HappyPath(t *testing.T) {
@@ -53,14 +55,11 @@ func TestLLMBridge_Run_HappyPath(t *testing.T) {
 		Resolver: res,
 		Defaults: LLMRunOptions{Model: "default-model"},
 		Source:   "test",
-		ReadMessages: func(_ context.Context) []model.Message {
-			return []model.Message{{Role: model.RoleUser, Parts: []model.Part{{Type: model.PartText, Text: "hello"}}}}
-		},
 	})
 	env := llmEnv(t, bridge)
 
 	_, err := rt.Exec(context.Background(), "run", `
-		var r = llm.run(null);
+		var r = llm.run({ messages: `+jsCanonicalMessages+` });
 		if (r.content !== "hi from model") throw new Error("content: " + r.content);
 		if (!r.usage || r.usage.input_tokens !== 1) throw new Error("usage missing");
 		if (!r.messages || r.messages.length === 0) throw new Error("messages missing");
@@ -69,9 +68,9 @@ func TestLLMBridge_Run_HappyPath(t *testing.T) {
 		t.Fatalf("script: %v", err)
 	}
 
-	// History was forwarded to the LLM.
-	if len(llmd.gotMsgs) != 1 || llmd.gotMsgs[0].Role != model.RoleUser {
-		t.Errorf("LLM did not receive ReadMessages payload: %+v", llmd.gotMsgs)
+	// Script-supplied messages were forwarded to the LLM.
+	if len(llmd.gotMsgs) != 1 || llmd.gotMsgs[0].Role != model.RoleUser || llmd.gotMsgs[0].Content() != "hello" {
+		t.Errorf("LLM did not receive explicit messages payload: %+v", llmd.gotMsgs)
 	}
 	if res.gotModel != "default-model" {
 		t.Errorf("default model not used: %q", res.gotModel)
@@ -90,7 +89,7 @@ func TestLLMBridge_Run_ScriptOverrideWinsOverDefaults(t *testing.T) {
 	env := llmEnv(t, bridge)
 
 	_, err := rt.Exec(context.Background(), "override", `
-		llm.run({ model: "override-model" });
+		llm.run({ messages: `+jsCanonicalMessages+`, model: "override-model" });
 	`, env)
 	if err != nil {
 		t.Fatalf("script: %v", err)
@@ -109,11 +108,51 @@ func TestLLMBridge_Run_RejectsUnknownOption(t *testing.T) {
 	env := llmEnv(t, NewLLMBridge(LLMBridgeOptions{Resolver: res, Defaults: LLMRunOptions{Model: "m"}, Source: "test"}))
 	_, err := rt.Exec(context.Background(), "typo", `
 		try {
-			llm.run({ modle: "typo" });
+			llm.run({ messages: `+jsCanonicalMessages+`, modle: "typo" });
 			throw new Error("expected llm.run to reject unknown field");
 		} catch (e) {
 			if (String(e).indexOf("modle") === -1) {
 				throw new Error("error should name the bad field, got: " + e);
+			}
+		}
+	`, env)
+	if err != nil {
+		t.Fatalf("script: %v", err)
+	}
+}
+
+func TestLLMBridge_Run_RejectsMissingMessages(t *testing.T) {
+	rt := jsrt.New(jsrt.WithPoolSize(1))
+	res, _ := newScriptedLLM("ok")
+
+	env := llmEnv(t, NewLLMBridge(LLMBridgeOptions{Resolver: res, Defaults: LLMRunOptions{Model: "m"}, Source: "test"}))
+	_, err := rt.Exec(context.Background(), "missing-messages", `
+		try {
+			llm.run(null);
+			throw new Error("expected llm.run to reject missing messages");
+		} catch (e) {
+			if (String(e).indexOf("messages") === -1) {
+				throw new Error("error should name missing messages, got: " + e);
+			}
+		}
+	`, env)
+	if err != nil {
+		t.Fatalf("script: %v", err)
+	}
+}
+
+func TestLLMBridge_Run_RejectsContentShorthandMessages(t *testing.T) {
+	rt := jsrt.New(jsrt.WithPoolSize(1))
+	res, _ := newScriptedLLM("ok")
+
+	env := llmEnv(t, NewLLMBridge(LLMBridgeOptions{Resolver: res, Defaults: LLMRunOptions{Model: "m"}, Source: "test"}))
+	_, err := rt.Exec(context.Background(), "content-shorthand", `
+		try {
+			llm.run({ messages: [{ role: "user", content: "hello" }] });
+			throw new Error("expected llm.run to reject content shorthand");
+		} catch (e) {
+			if (String(e).indexOf("content") === -1) {
+				throw new Error("error should name content field, got: " + e);
 			}
 		}
 	`, env)
@@ -129,7 +168,7 @@ func TestLLMBridge_Run_ResolverErrorPropagates(t *testing.T) {
 	env := llmEnv(t, NewLLMBridge(LLMBridgeOptions{Resolver: res, Defaults: LLMRunOptions{Model: "m"}, Source: "test"}))
 	_, err := rt.Exec(context.Background(), "resolveerr", `
 		try {
-			llm.run(null);
+			llm.run({ messages: `+jsCanonicalMessages+` });
 			throw new Error("expected llm.run to throw on resolver error");
 		} catch (e) {
 			if (String(e).indexOf("provider unreachable") === -1) {
@@ -160,7 +199,7 @@ func TestLLMBridge_Stream_TextAccumulatesAcrossChunks(t *testing.T) {
 
 	env := llmEnv(t, NewLLMBridge(LLMBridgeOptions{Resolver: res, Defaults: LLMRunOptions{Model: "m"}, Source: "test"}))
 	_, err := rt.Exec(context.Background(), "stream-text", `
-		var s = llm.stream(null);
+		var s = llm.stream({ messages: `+jsCanonicalMessages+` });
 		var seen = "";
 		while (s.next()) {
 			seen += s.text();
@@ -190,7 +229,7 @@ func TestLLMBridge_Stream_PartExposesToolCall(t *testing.T) {
 
 	env := llmEnv(t, NewLLMBridge(LLMBridgeOptions{Resolver: res, Defaults: LLMRunOptions{Model: "m"}, Source: "test"}))
 	_, err := rt.Exec(context.Background(), "stream-part", `
-		var s = llm.stream(null);
+		var s = llm.stream({ messages: `+jsCanonicalMessages+` });
 		if (!s.next()) throw new Error("expected one chunk");
 		var p = s.part();
 		if (p.type !== "tool_call") throw new Error("part.type: " + p.type);
@@ -211,7 +250,7 @@ func TestLLMBridge_Stream_NextAfterCloseReturnsFalse(t *testing.T) {
 
 	env := llmEnv(t, NewLLMBridge(LLMBridgeOptions{Resolver: res, Defaults: LLMRunOptions{Model: "m"}, Source: "test"}))
 	_, err := rt.Exec(context.Background(), "stream-next-after-close", `
-		var s = llm.stream(null);
+		var s = llm.stream({ messages: `+jsCanonicalMessages+` });
 		s.close();
 		if (s.next()) throw new Error("next after close should return false");
 	`, env)
@@ -228,7 +267,7 @@ func TestLLMBridge_Stream_FinishAfterDrainReturnsResult(t *testing.T) {
 
 	env := llmEnv(t, NewLLMBridge(LLMBridgeOptions{Resolver: res, Defaults: LLMRunOptions{Model: "m"}, Source: "test"}))
 	_, err := rt.Exec(context.Background(), "stream-finish", `
-		var s = llm.stream(null);
+		var s = llm.stream({ messages: `+jsCanonicalMessages+` });
 		while (s.next()) {} // drain
 		var r = s.finish();
 		if (r.content !== "done") throw new Error("content: " + r.content);
@@ -248,7 +287,7 @@ func TestLLMBridge_Stream_StartFailureSurfacesAsThrow(t *testing.T) {
 	env := llmEnv(t, NewLLMBridge(LLMBridgeOptions{Resolver: res, Defaults: LLMRunOptions{Model: "m"}, Source: "test"}))
 	_, err := rt.Exec(context.Background(), "stream-fail", `
 		try {
-			llm.stream(null);
+			llm.stream({ messages: `+jsCanonicalMessages+` });
 			throw new Error("expected llm.stream to throw on start failure");
 		} catch (e) {
 			if (String(e).indexOf("nope") === -1) {
@@ -288,7 +327,7 @@ func TestLLMBridge_Run_ToolDefsForwardedToLLM(t *testing.T) {
 
 	// Script restricts to "calc" only; "search" must not reach the LLM.
 	_, err := rt.Exec(context.Background(), "run-tools", `
-		llm.run({ tools: ["calc"] });
+		llm.run({ messages: `+jsCanonicalMessages+`, tools: ["calc"] });
 	`, env)
 	if err != nil {
 		t.Fatalf("script: %v", err)

--- a/sdk/script/bindings/bridge_llm_test.go
+++ b/sdk/script/bindings/bridge_llm_test.go
@@ -4,32 +4,65 @@ import (
 	"reflect"
 	"strings"
 	"testing"
+
+	"github.com/GizClaw/flowcraft/sdk/model"
 )
 
 func pf(v float64) *float64 { return &v }
 func pb(v bool) *bool       { return &v }
+
+func canonicalMessagesRaw(text string) []any {
+	return []any{
+		map[string]any{
+			"role": "user",
+			"parts": []any{
+				map[string]any{"type": "text", "text": text},
+			},
+		},
+	}
+}
 
 // ---------------------------------------------------------------------------
 // parseRunOptions — input validation
 // ---------------------------------------------------------------------------
 
 func TestParseRunOptions_Nil(t *testing.T) {
-	got, err := parseRunOptions(nil)
-	if err != nil {
-		t.Fatalf("nil should be accepted, got err: %v", err)
+	_, err := parseRunOptions(nil)
+	if err == nil {
+		t.Fatal("nil options should be rejected")
 	}
-	if !reflect.DeepEqual(got, LLMRunOptions{}) {
-		t.Fatalf("nil should yield zero options, got %+v", got)
+	if !strings.Contains(err.Error(), "messages") {
+		t.Fatalf("error should mention missing messages, got: %v", err)
 	}
 }
 
 func TestParseRunOptions_EmptyMap(t *testing.T) {
-	got, err := parseRunOptions(map[string]any{})
-	if err != nil {
-		t.Fatalf("empty map should be accepted, got err: %v", err)
+	_, err := parseRunOptions(map[string]any{})
+	if err == nil {
+		t.Fatal("empty options should be rejected")
 	}
-	if !reflect.DeepEqual(got, LLMRunOptions{}) {
-		t.Fatalf("empty map should yield zero options, got %+v", got)
+	if !strings.Contains(err.Error(), "messages") {
+		t.Fatalf("error should mention missing messages, got: %v", err)
+	}
+}
+
+func TestParseRunOptions_MissingMessages(t *testing.T) {
+	_, err := parseRunOptions(map[string]any{"model": "m"})
+	if err == nil {
+		t.Fatal("options without messages should be rejected")
+	}
+	if !strings.Contains(err.Error(), "messages") {
+		t.Fatalf("error should mention missing messages, got: %v", err)
+	}
+}
+
+func TestParseRunOptions_NullMessages(t *testing.T) {
+	_, err := parseRunOptions(map[string]any{"messages": nil})
+	if err == nil {
+		t.Fatal("messages:null should be rejected")
+	}
+	if !strings.Contains(err.Error(), "messages") {
+		t.Fatalf("error should mention messages, got: %v", err)
 	}
 }
 
@@ -54,6 +87,7 @@ func TestParseRunOptions_NonMap(t *testing.T) {
 
 func TestParseRunOptions_AllFields(t *testing.T) {
 	in := map[string]any{
+		"messages":    canonicalMessagesRaw("hello"),
 		"model":       "openai/gpt-4o-mini",
 		"temperature": 0.25,
 		"max_tokens":  float64(1024), // jsrt/luart deliver numbers as float64
@@ -65,28 +99,33 @@ func TestParseRunOptions_AllFields(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if got.Model != "openai/gpt-4o-mini" {
-		t.Errorf("model = %q", got.Model)
+	if got.runOptions.Model != "openai/gpt-4o-mini" {
+		t.Errorf("model = %q", got.runOptions.Model)
 	}
-	if got.Temperature == nil || *got.Temperature != 0.25 {
-		t.Errorf("temperature = %v", got.Temperature)
+	if got.runOptions.Temperature == nil || *got.runOptions.Temperature != 0.25 {
+		t.Errorf("temperature = %v", got.runOptions.Temperature)
 	}
-	if got.MaxTokens != 1024 {
-		t.Errorf("max_tokens = %d", got.MaxTokens)
+	if got.runOptions.MaxTokens != 1024 {
+		t.Errorf("max_tokens = %d", got.runOptions.MaxTokens)
 	}
-	if got.JSONMode == nil || *got.JSONMode != true {
-		t.Errorf("json_mode = %v", got.JSONMode)
+	if got.runOptions.JSONMode == nil || *got.runOptions.JSONMode != true {
+		t.Errorf("json_mode = %v", got.runOptions.JSONMode)
 	}
-	if got.Thinking == nil || *got.Thinking != false {
-		t.Errorf("thinking = %v", got.Thinking)
+	if got.runOptions.Thinking == nil || *got.runOptions.Thinking != false {
+		t.Errorf("thinking = %v", got.runOptions.Thinking)
 	}
-	if len(got.Tools) != 2 || got.Tools[0] != "web_search" || got.Tools[1] != "calc" {
-		t.Errorf("tools = %v", got.Tools)
+	if len(got.runOptions.Tools) != 2 || got.runOptions.Tools[0] != "web_search" || got.runOptions.Tools[1] != "calc" {
+		t.Errorf("tools = %v", got.runOptions.Tools)
+	}
+	wantMessages := []model.Message{model.NewTextMessage(model.RoleUser, "hello")}
+	if !reflect.DeepEqual(got.messages, wantMessages) {
+		t.Errorf("messages = %+v, want %+v", got.messages, wantMessages)
 	}
 }
 
 func TestParseRunOptions_UnknownField_Rejected(t *testing.T) {
 	_, err := parseRunOptions(map[string]any{
+		"messages":   canonicalMessagesRaw("hello"),
 		"model":      "m1",
 		"temprature": 0.5, // typo!
 		"json_mode":  true,
@@ -99,12 +138,42 @@ func TestParseRunOptions_UnknownField_Rejected(t *testing.T) {
 	}
 }
 
+func TestParseRunOptions_RejectsMessageContentShorthand(t *testing.T) {
+	cases := []map[string]any{
+		{
+			"messages": []any{
+				map[string]any{"role": "user", "content": "hello"},
+			},
+		},
+		{
+			"messages": []any{
+				map[string]any{
+					"role":    "user",
+					"content": "hello",
+					"parts": []any{
+						map[string]any{"type": "text", "text": "hello"},
+					},
+				},
+			},
+		},
+	}
+	for _, in := range cases {
+		_, err := parseRunOptions(in)
+		if err == nil {
+			t.Fatalf("messages content shorthand should be rejected: %v", in)
+		}
+		if !strings.Contains(err.Error(), "content") {
+			t.Fatalf("error should name content field, got: %v", err)
+		}
+	}
+}
+
 func TestParseRunOptions_TypeMismatch_Rejected(t *testing.T) {
 	cases := []map[string]any{
-		{"temperature": "hot"}, // string in number field
-		{"max_tokens": "lots"},
-		{"json_mode": "yes"},
-		{"tools": "web_search"}, // string instead of []string
+		{"messages": canonicalMessagesRaw("hello"), "temperature": "hot"}, // string in number field
+		{"messages": canonicalMessagesRaw("hello"), "max_tokens": "lots"},
+		{"messages": canonicalMessagesRaw("hello"), "json_mode": "yes"},
+		{"messages": canonicalMessagesRaw("hello"), "tools": "web_search"}, // string instead of []string
 	}
 	for _, in := range cases {
 		_, err := parseRunOptions(in)
@@ -119,23 +188,24 @@ func TestParseRunOptions_TypeMismatch_Rejected(t *testing.T) {
 // test guards that decoding paths preserve that distinction.
 func TestParseRunOptions_BoolPointers_PreserveExplicitFalse(t *testing.T) {
 	got, err := parseRunOptions(map[string]any{
+		"messages":  canonicalMessagesRaw("hello"),
 		"json_mode": false,
 		"thinking":  false,
 	})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if got.JSONMode == nil {
+	if got.runOptions.JSONMode == nil {
 		t.Fatal("json_mode=false should produce non-nil pointer")
 	}
-	if *got.JSONMode != false {
-		t.Errorf("json_mode value = %v", *got.JSONMode)
+	if *got.runOptions.JSONMode != false {
+		t.Errorf("json_mode value = %v", *got.runOptions.JSONMode)
 	}
-	if got.Thinking == nil {
+	if got.runOptions.Thinking == nil {
 		t.Fatal("thinking=false should produce non-nil pointer")
 	}
-	if *got.Thinking != false {
-		t.Errorf("thinking value = %v", *got.Thinking)
+	if *got.runOptions.Thinking != false {
+		t.Errorf("thinking value = %v", *got.runOptions.Thinking)
 	}
 }
 

--- a/sdk/script/bindings/doc.go
+++ b/sdk/script/bindings/doc.go
@@ -42,7 +42,7 @@
 //	bridge_shell.go   sandboxed subprocesses (allowlist via ShellOption)
 //	bridge_fs.go      workspace files
 //	bridge_runtime.go sub-script execScript (inherits parent bindings)
-//	bridge_llm.go         NewLLMBridge facade + LLMRunOptions (script-facing options schema)
+//	bridge_llm.go         NewLLMBridge facade + defaultable LLMRunOptions schema
 //	bridge_llm_round.go   in-bridge round driver (resolver + GenerateStream + tool.Registry)
 //	llm_marshal.go        model.* ⇄ map[string]any projections (multimodal-aware)
 //	bridge_tools.go   tool.Registry (deny-by-default, explicit allowlist or AllowAll)

--- a/sdk/script/bindings/llm_marshal.go
+++ b/sdk/script/bindings/llm_marshal.go
@@ -235,6 +235,10 @@ var (
 		"parts":   {},
 		"content": {}, // emitted by messageToMap as a convenience; ignored on input
 	}
+	allowedCanonicalMessageKeys = map[string]struct{}{
+		"role":  {},
+		"parts": {},
+	}
 	allowedPartTextKeys       = map[string]struct{}{"type": {}, "text": {}}
 	allowedPartImageKeys      = map[string]struct{}{"type": {}, "image": {}}
 	allowedPartAudioKeys      = map[string]struct{}{"type": {}, "audio": {}}
@@ -274,13 +278,40 @@ func parseChannelMessages(raw any, ctx string) ([]model.Message, error) {
 	return out, nil
 }
 
+// parseLLMMessages converts the explicit llm.run/stream({ messages })
+// payload into canonical model.Message values. Unlike board channel
+// parsing, this path accepts only the canonical role+parts shape and
+// rejects the projected "content" convenience field.
+func parseLLMMessages(raw any, ctx string) ([]model.Message, error) {
+	if raw == nil {
+		return nil, errdefs.Validationf("%s: missing required field %q", ctx, "messages")
+	}
+	list, err := asAnyList(raw, ctx)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]model.Message, len(list))
+	for i, item := range list {
+		msg, err := parseMessageWithAllowedKeys(item, fmt.Sprintf("%s[%d]", ctx, i), allowedCanonicalMessageKeys)
+		if err != nil {
+			return nil, err
+		}
+		out[i] = msg
+	}
+	return out, nil
+}
+
 // parseMessage validates and converts one script-side message map.
 func parseMessage(raw any, ctx string) (model.Message, error) {
+	return parseMessageWithAllowedKeys(raw, ctx, allowedMessageKeys)
+}
+
+func parseMessageWithAllowedKeys(raw any, ctx string, allowed map[string]struct{}) (model.Message, error) {
 	m, err := asStringMap(raw, ctx)
 	if err != nil {
 		return model.Message{}, err
 	}
-	if err := rejectUnknownKeys(m, allowedMessageKeys, ctx); err != nil {
+	if err := rejectUnknownKeys(m, allowed, ctx); err != nil {
 		return model.Message{}, err
 	}
 

--- a/sdk/script/bindings/llm_marshal_test.go
+++ b/sdk/script/bindings/llm_marshal_test.go
@@ -438,6 +438,51 @@ func TestParseMessage_AcceptsContentKey_AsBijection(t *testing.T) {
 	}
 }
 
+func TestParseLLMMessages_AcceptsCanonicalMessages(t *testing.T) {
+	in := []any{
+		map[string]any{
+			"role": "user",
+			"parts": []any{
+				map[string]any{"type": "text", "text": "hello"},
+			},
+		},
+	}
+	got, err := parseLLMMessages(in, "llm.messages")
+	if err != nil {
+		t.Fatalf("canonical llm messages should parse: %v", err)
+	}
+	want := []model.Message{model.NewTextMessage(model.RoleUser, "hello")}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("messages = %+v, want %+v", got, want)
+	}
+}
+
+func TestParseLLMMessages_RejectsContentField(t *testing.T) {
+	cases := []any{
+		[]any{
+			map[string]any{"role": "user", "content": "hello"},
+		},
+		[]any{
+			map[string]any{
+				"role":    "user",
+				"content": "hello",
+				"parts": []any{
+					map[string]any{"type": "text", "text": "hello"},
+				},
+			},
+		},
+	}
+	for _, in := range cases {
+		_, err := parseLLMMessages(in, "llm.messages")
+		if err == nil {
+			t.Fatalf("content key should be rejected for llm messages: %v", in)
+		}
+		if !strings.Contains(err.Error(), "content") {
+			t.Fatalf("error should name content field, got: %v", err)
+		}
+	}
+}
+
 func TestParsePart_UnknownType(t *testing.T) {
 	in := map[string]any{"type": "future_thing"}
 	_, err := parsePart(in, "ctx")
@@ -540,6 +585,25 @@ func TestParseChannelMessages_NilAndEmpty(t *testing.T) {
 	}
 	if len(got) != 0 {
 		t.Errorf("empty should produce empty slice, got %#v", got)
+	}
+}
+
+func TestParseChannelMessages_AcceptsContentKeyRoundTrip(t *testing.T) {
+	in := []any{
+		map[string]any{
+			"role":    "assistant",
+			"content": "hello",
+			"parts": []any{
+				map[string]any{"type": "text", "text": "hello"},
+			},
+		},
+	}
+	got, err := parseChannelMessages(in, "setChannel")
+	if err != nil {
+		t.Fatalf("setChannel round-trip content key should remain accepted: %v", err)
+	}
+	if len(got) != 1 || got[0].Content() != "hello" {
+		t.Fatalf("parsed messages = %+v", got)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Script LLM calls now take their conversation explicitly through `llm.run({ messages })` and `llm.stream({ messages })`, removing the hidden Go-side history reader.
- LLM input messages must use the canonical `model.Message` shape (`role` plus `parts`), while board channel round-trips still accept returned `content` convenience fields.
- `LLMRunOptions` now only represents defaultable generation settings, so defaults cannot imply a conversation.

## Test plan
- [x] `go test -count=1 ./sdk/script/bindings`
- [x] `go test -count=1 ./sdk/...`
