### PR TITLE
recall/ops: support graceful runner shutdown

### DIFF
--- a/memory/recall/namespace.go
+++ b/memory/recall/namespace.go
@@ -1,0 +1,26 @@
+package recall
+
+import (
+	"strconv"
+	"strings"
+
+	retrievalns "github.com/GizClaw/flowcraft/memory/retrieval/namespace"
+)
+
+// NamespaceFor returns the v2 retrieval namespace for a memory scope.
+func NamespaceFor(s Scope) string {
+	rt := retrievalns.Sanitize(s.RuntimeID)
+	if s.UserID == "" {
+		return "recall_" + rt + "__global"
+	}
+	user := retrievalns.Sanitize(s.UserID)
+	var b strings.Builder
+	b.Grow(len("recall_") + len(rt) + len("__u") + 5 + 1 + len(user))
+	b.WriteString("recall_")
+	b.WriteString(rt)
+	b.WriteString("__u")
+	b.WriteString(strconv.Itoa(len(user)))
+	b.WriteByte('_')
+	b.WriteString(user)
+	return b.String()
+}

--- a/memory/recall/namespace_test.go
+++ b/memory/recall/namespace_test.go
@@ -1,0 +1,49 @@
+package recall
+
+import "testing"
+
+func TestNamespaceFor(t *testing.T) {
+	tests := []struct {
+		name  string
+		scope Scope
+		want  string
+	}{
+		{
+			name:  "global scope",
+			scope: Scope{RuntimeID: "rt"},
+			want:  "recall_rt__global",
+		},
+		{
+			name:  "user scope",
+			scope: Scope{RuntimeID: "rt", UserID: "alice"},
+			want:  "recall_rt__u5_alice",
+		},
+		{
+			name:  "sanitized runtime and user",
+			scope: Scope{RuntimeID: "prod/east", UserID: "bob@example.com"},
+			want:  "recall_prod_east__u15_bob_example_com",
+		},
+		{
+			name:  "empty runtime global",
+			scope: Scope{},
+			want:  "recall_anon__global",
+		},
+		{
+			name:  "empty runtime user",
+			scope: Scope{UserID: "alice"},
+			want:  "recall_anon__u5_alice",
+		},
+		{
+			name:  "delimiter containing user",
+			scope: Scope{RuntimeID: "rt", UserID: "bob__u_alice"},
+			want:  "recall_rt__u12_bob__u_alice",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := NamespaceFor(tt.scope); got != tt.want {
+				t.Fatalf("NamespaceFor(%+v) = %q, want %q", tt.scope, got, tt.want)
+			}
+		})
+	}
+}

--- a/memory/recall/ops/runner.go
+++ b/memory/recall/ops/runner.go
@@ -60,7 +60,14 @@ func NewRunner(mem recall.Memory, opts ...Option) (*Runner, error) {
 
 // Run continuously drains the configured target until ctx is cancelled.
 func (r *Runner) Run(ctx context.Context, opts RunOptions) error {
+	return r.run(ctx, nil, opts)
+}
+
+func (r *Runner) run(ctx context.Context, stop <-chan struct{}, opts RunOptions) error {
 	for {
+		if stopped(stop) {
+			return nil
+		}
 		if err := ctx.Err(); err != nil {
 			return err
 		}
@@ -69,15 +76,21 @@ func (r *Runner) Run(ctx context.Context, opts RunOptions) error {
 			if errdefs.IsValidation(err) {
 				return err
 			}
-			if waitErr := sleepContext(ctx, r.cfg.ErrorBackoff); waitErr != nil {
+			if waitErr := sleepContext(ctx, stop, r.cfg.ErrorBackoff); waitErr != nil {
 				return waitErr
 			}
+			if stopped(stop) {
+				return err
+			}
 			continue
+		}
+		if stopped(stop) {
+			return nil
 		}
 		if res.TotalClaimed() > 0 {
 			continue
 		}
-		if err := sleepContext(ctx, r.cfg.IdleInterval); err != nil {
+		if err := sleepContext(ctx, stop, r.cfg.IdleInterval); err != nil {
 			return err
 		}
 	}
@@ -152,13 +165,27 @@ func (r *Runner) emit(ctx context.Context, event Event) {
 	r.cfg.Metrics.ObserveRecallOps(ctx, event)
 }
 
-func sleepContext(ctx context.Context, d time.Duration) error {
+func stopped(stop <-chan struct{}) bool {
+	if stop == nil {
+		return false
+	}
+	select {
+	case <-stop:
+		return true
+	default:
+		return false
+	}
+}
+
+func sleepContext(ctx context.Context, stop <-chan struct{}, d time.Duration) error {
 	if d <= 0 {
 		return ctx.Err()
 	}
 	timer := time.NewTimer(d)
 	defer timer.Stop()
 	select {
+	case <-stop:
+		return nil
 	case <-ctx.Done():
 		return ctx.Err()
 	case <-timer.C:

--- a/memory/recall/ops/runner_test.go
+++ b/memory/recall/ops/runner_test.go
@@ -188,6 +188,109 @@ func TestSupervisorGracefulStopDoesNotCancelInflightDrain(t *testing.T) {
 	default:
 		t.Fatal("processor did not finish")
 	}
+	if err := supervisor.GracefulStop(context.Background()); err != nil {
+		t.Fatalf("second GracefulStop after successful release: %v", err)
+	}
+}
+
+func TestSupervisorGracefulStopReportsParentCancellationDuringInflightDrain(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	scope := recall.Scope{RuntimeID: "rt", UserID: "u1"}
+	started := make(chan struct{})
+	release := make(chan struct{})
+	runner := &Runner{
+		side: blockingSideEffectProcessor{
+			started: started,
+			release: release,
+		},
+		cfg: Config{
+			WorkerID:           "test",
+			BatchSize:          1,
+			IdleInterval:       time.Hour,
+			ErrorBackoff:       time.Hour,
+			DrainSideEffects:   true,
+			DrainAsyncSemantic: false,
+			Now:                time.Now,
+		},
+	}
+	supervisor, err := Start(ctx, runner, Target{Scopes: []recall.Scope{scope}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	<-started
+	stopDone := make(chan error, 1)
+	go func() {
+		stopDone <- supervisor.GracefulStop(context.Background())
+	}()
+	select {
+	case <-supervisor.stop:
+	case <-time.After(time.Second):
+		t.Fatal("GracefulStop did not request stop")
+	}
+	cancel()
+	select {
+	case err := <-stopDone:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("GracefulStop error = %v, want context.Canceled", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("GracefulStop did not return after parent cancellation")
+	}
+	close(release)
+}
+
+func TestSupervisorGracefulStopReportsConcurrentStopDuringInflightDrain(t *testing.T) {
+	ctx := context.Background()
+	scope := recall.Scope{RuntimeID: "rt", UserID: "u1"}
+	started := make(chan struct{})
+	release := make(chan struct{})
+	runner := &Runner{
+		side: blockingSideEffectProcessor{
+			started: started,
+			release: release,
+		},
+		cfg: Config{
+			WorkerID:           "test",
+			BatchSize:          1,
+			IdleInterval:       time.Hour,
+			ErrorBackoff:       time.Hour,
+			DrainSideEffects:   true,
+			DrainAsyncSemantic: false,
+			Now:                time.Now,
+		},
+	}
+	supervisor, err := Start(ctx, runner, Target{Scopes: []recall.Scope{scope}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	<-started
+	stopDone := make(chan error, 1)
+	go func() {
+		stopDone <- supervisor.GracefulStop(context.Background())
+	}()
+	select {
+	case <-supervisor.stop:
+	case <-time.After(time.Second):
+		t.Fatal("GracefulStop did not request stop")
+	}
+	forceDone := make(chan error, 1)
+	go func() {
+		forceDone <- supervisor.Stop()
+	}()
+	select {
+	case err := <-stopDone:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("GracefulStop error = %v, want context.Canceled", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("GracefulStop did not return after concurrent Stop")
+	}
+	select {
+	case <-forceDone:
+	case <-time.After(time.Second):
+		t.Fatal("Stop did not return after cancelling in-flight drain")
+	}
+	close(release)
 }
 
 func TestSupervisorGracefulStopPreservesInflightDrainError(t *testing.T) {

--- a/memory/recall/ops/runner_test.go
+++ b/memory/recall/ops/runner_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -134,6 +135,140 @@ func TestSupervisorStartAndStop(t *testing.T) {
 	}
 	if err := supervisor.Stop(); err != nil {
 		t.Fatalf("Stop: %v", err)
+	}
+}
+
+func TestSupervisorGracefulStopDoesNotCancelInflightDrain(t *testing.T) {
+	ctx := context.Background()
+	scope := recall.Scope{RuntimeID: "rt", UserID: "u1"}
+	started := make(chan struct{})
+	release := make(chan struct{})
+	done := make(chan struct{})
+	runner := &Runner{
+		side: blockingSideEffectProcessor{
+			started: started,
+			release: release,
+			done:    done,
+		},
+		cfg: Config{
+			WorkerID:           "test",
+			BatchSize:          1,
+			IdleInterval:       time.Hour,
+			ErrorBackoff:       time.Hour,
+			DrainSideEffects:   true,
+			DrainAsyncSemantic: false,
+			Now:                time.Now,
+		},
+	}
+	supervisor, err := Start(ctx, runner, Target{Scopes: []recall.Scope{scope}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	<-started
+	stopDone := make(chan error, 1)
+	go func() {
+		stopDone <- supervisor.GracefulStop(context.Background())
+	}()
+	select {
+	case err := <-stopDone:
+		t.Fatalf("GracefulStop returned before in-flight drain completed: %v", err)
+	case <-time.After(10 * time.Millisecond):
+	}
+	close(release)
+	select {
+	case err := <-stopDone:
+		if err != nil {
+			t.Fatalf("GracefulStop: %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("GracefulStop did not return after drain completed")
+	}
+	select {
+	case <-done:
+	default:
+		t.Fatal("processor did not finish")
+	}
+}
+
+func TestSupervisorGracefulStopPreservesInflightDrainError(t *testing.T) {
+	ctx := context.Background()
+	scope := recall.Scope{RuntimeID: "rt", UserID: "u1"}
+	wantErr := errors.New("side effect failed")
+	started := make(chan struct{})
+	release := make(chan struct{})
+	runner := &Runner{
+		side: blockingErrorSideEffectProcessor{
+			started: started,
+			release: release,
+			err:     wantErr,
+		},
+		cfg: Config{
+			WorkerID:           "test",
+			BatchSize:          1,
+			IdleInterval:       time.Hour,
+			ErrorBackoff:       time.Hour,
+			DrainSideEffects:   true,
+			DrainAsyncSemantic: false,
+			Now:                time.Now,
+		},
+	}
+	supervisor, err := Start(ctx, runner, Target{Scopes: []recall.Scope{scope}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	<-started
+	stopDone := make(chan error, 1)
+	go func() {
+		stopDone <- supervisor.GracefulStop(context.Background())
+	}()
+	close(release)
+	select {
+	case err := <-stopDone:
+		if err == nil {
+			t.Fatal("GracefulStop error = nil, want worker failure")
+		}
+		if !strings.Contains(err.Error(), wantErr.Error()) {
+			t.Fatalf("GracefulStop error = %v, want text containing %q", err, wantErr)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("GracefulStop did not return after failed drain")
+	}
+}
+
+func TestSupervisorGracefulStopDeadlineDoesNotWaitForever(t *testing.T) {
+	ctx := context.Background()
+	scope := recall.Scope{RuntimeID: "rt", UserID: "u1"}
+	started := make(chan struct{})
+	release := make(chan struct{})
+	runner := &Runner{
+		side: blockingSideEffectProcessor{
+			started: started,
+			release: release,
+		},
+		cfg: Config{
+			WorkerID:           "test",
+			BatchSize:          1,
+			IdleInterval:       time.Hour,
+			ErrorBackoff:       time.Hour,
+			DrainSideEffects:   true,
+			DrainAsyncSemantic: false,
+			Now:                time.Now,
+		},
+	}
+	supervisor, err := Start(ctx, runner, Target{Scopes: []recall.Scope{scope}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	<-started
+	deadlineCtx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
+	defer cancel()
+	err = supervisor.GracefulStop(deadlineCtx)
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("GracefulStop error = %v, want context deadline", err)
+	}
+	close(release)
+	if err := supervisor.Stop(); err != nil && !errors.Is(err, context.Canceled) {
+		t.Fatalf("Stop after deadline GracefulStop: %v", err)
 	}
 }
 
@@ -300,6 +435,41 @@ type durableParts struct {
 	store recall.TemporalStore
 	side  recall.SideEffectOutbox
 	async recall.AsyncSemanticQueue
+}
+
+type blockingSideEffectProcessor struct {
+	started chan<- struct{}
+	release <-chan struct{}
+	done    chan<- struct{}
+}
+
+func (p blockingSideEffectProcessor) ProcessSideEffects(ctx context.Context, opts recall.SideEffectProcessOptions) (recall.SideEffectProcessResult, error) {
+	close(p.started)
+	select {
+	case <-p.release:
+		if p.done != nil {
+			close(p.done)
+		}
+		return recall.SideEffectProcessResult{Claimed: 1, Completed: 1}, nil
+	case <-ctx.Done():
+		return recall.SideEffectProcessResult{}, ctx.Err()
+	}
+}
+
+type blockingErrorSideEffectProcessor struct {
+	started chan<- struct{}
+	release <-chan struct{}
+	err     error
+}
+
+func (p blockingErrorSideEffectProcessor) ProcessSideEffects(ctx context.Context, opts recall.SideEffectProcessOptions) (recall.SideEffectProcessResult, error) {
+	close(p.started)
+	select {
+	case <-p.release:
+		return recall.SideEffectProcessResult{Claimed: 1}, p.err
+	case <-ctx.Done():
+		return recall.SideEffectProcessResult{}, ctx.Err()
+	}
 }
 
 type staticEnumerator []recall.Scope

--- a/memory/recall/ops/supervisor.go
+++ b/memory/recall/ops/supervisor.go
@@ -9,13 +9,16 @@ import (
 // cancellation. It is intentionally small: callers still own signal handling,
 // logging, and whether an error should restart the surrounding process.
 type Supervisor struct {
+	runCtx context.Context
 	cancel context.CancelFunc
 	stop   chan struct{}
 	once   sync.Once
 	wg     sync.WaitGroup
 
-	mu   sync.Mutex
-	errs []error
+	mu               sync.Mutex
+	graceful         bool
+	gracefulReleased bool
+	errs             []error
 }
 
 // Start starts runner loops for each target. The returned Supervisor is stopped
@@ -27,16 +30,17 @@ func Start(ctx context.Context, runner *Runner, targets ...Target) (*Supervisor,
 	if len(targets) == 0 {
 		return nil, validationf("at least one target is required")
 	}
-	ctx, cancel := context.WithCancel(ctx)
-	s := &Supervisor{cancel: cancel, stop: make(chan struct{})}
+	runCtx, cancel := context.WithCancel(ctx)
+	s := &Supervisor{runCtx: runCtx, cancel: cancel, stop: make(chan struct{})}
 	for _, target := range targets {
 		target := target
 		s.wg.Add(1)
 		go func() {
 			defer s.wg.Done()
-			if err := runner.run(ctx, s.stop, RunOptions{Target: target}); err != nil && ctx.Err() == nil {
-				s.addErr(err)
-				cancel()
+			if err := runner.run(runCtx, s.stop, RunOptions{Target: target}); err != nil {
+				if s.recordRunError(err) {
+					cancel()
+				}
 			}
 		}()
 	}
@@ -66,6 +70,7 @@ func (s *Supervisor) GracefulStop(ctx context.Context) error {
 	if ctx == nil {
 		ctx = context.Background()
 	}
+	s.beginGracefulStop()
 	s.once.Do(func() {
 		close(s.stop)
 	})
@@ -76,12 +81,44 @@ func (s *Supervisor) GracefulStop(ctx context.Context) error {
 	}()
 	select {
 	case <-done:
-		s.cancel()
-		return s.err()
+		if err := s.gracefulErr(); err != nil {
+			s.cancel()
+			return err
+		}
+		s.releaseGraceful()
+		return nil
 	case <-ctx.Done():
 		s.cancel()
 		return ctx.Err()
 	}
+}
+
+func (s *Supervisor) beginGracefulStop() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.graceful = true
+}
+
+func (s *Supervisor) releaseGraceful() {
+	s.mu.Lock()
+	s.gracefulReleased = true
+	s.mu.Unlock()
+	s.cancel()
+}
+
+func (s *Supervisor) gracefulErr() error {
+	s.mu.Lock()
+	if len(s.errs) > 0 {
+		err := s.errs[0]
+		s.mu.Unlock()
+		return err
+	}
+	released := s.gracefulReleased
+	s.mu.Unlock()
+	if released {
+		return nil
+	}
+	return s.runCtx.Err()
 }
 
 func (s *Supervisor) err() error {
@@ -93,8 +130,12 @@ func (s *Supervisor) err() error {
 	return s.errs[0]
 }
 
-func (s *Supervisor) addErr(err error) {
+func (s *Supervisor) recordRunError(err error) bool {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	s.errs = append(s.errs, err)
+	runErr := s.runCtx.Err()
+	if runErr == nil || s.graceful {
+		s.errs = append(s.errs, err)
+	}
+	return runErr == nil
 }

--- a/memory/recall/ops/supervisor.go
+++ b/memory/recall/ops/supervisor.go
@@ -10,6 +10,8 @@ import (
 // logging, and whether an error should restart the surrounding process.
 type Supervisor struct {
 	cancel context.CancelFunc
+	stop   chan struct{}
+	once   sync.Once
 	wg     sync.WaitGroup
 
 	mu   sync.Mutex
@@ -26,13 +28,13 @@ func Start(ctx context.Context, runner *Runner, targets ...Target) (*Supervisor,
 		return nil, validationf("at least one target is required")
 	}
 	ctx, cancel := context.WithCancel(ctx)
-	s := &Supervisor{cancel: cancel}
+	s := &Supervisor{cancel: cancel, stop: make(chan struct{})}
 	for _, target := range targets {
 		target := target
 		s.wg.Add(1)
 		go func() {
 			defer s.wg.Done()
-			if err := runner.Run(ctx, RunOptions{Target: target}); err != nil && ctx.Err() == nil {
+			if err := runner.run(ctx, s.stop, RunOptions{Target: target}); err != nil && ctx.Err() == nil {
 				s.addErr(err)
 				cancel()
 			}
@@ -47,8 +49,42 @@ func (s *Supervisor) Stop() error {
 	if s == nil {
 		return nil
 	}
+	s.once.Do(func() {
+		close(s.stop)
+	})
 	s.cancel()
 	s.wg.Wait()
+	return s.err()
+}
+
+// GracefulStop asks worker loops to stop before the next drain pass and waits
+// for any in-flight drain to finish without cancelling its context.
+func (s *Supervisor) GracefulStop(ctx context.Context) error {
+	if s == nil {
+		return nil
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	s.once.Do(func() {
+		close(s.stop)
+	})
+	done := make(chan struct{})
+	go func() {
+		s.wg.Wait()
+		close(done)
+	}()
+	select {
+	case <-done:
+		s.cancel()
+		return s.err()
+	case <-ctx.Done():
+		s.cancel()
+		return ctx.Err()
+	}
+}
+
+func (s *Supervisor) err() error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	if len(s.errs) == 0 {


### PR DESCRIPTION
Reopens the recall ops shutdown work against `main`; the earlier PR was merged into `codex/flowcraft-claw-runtime-base` instead of `main`.

This PR keeps recall lifecycle support separate from the Claw runtime PR.

- add recall namespace helpers
- support graceful runner shutdown and supervisor draining
- report forced graceful shutdown cancellation
- cover shutdown, cancellation, and namespace behavior with tests

Validation:

```text
cd memory
go test -count=1 ./recall ./recall/ops
```