### PR TITLE
claw: keep history XML out of provider text

### DIFF
--- a/sdkx/claw/llm_adapter.go
+++ b/sdkx/claw/llm_adapter.go
@@ -52,18 +52,50 @@ func (m providerSafeLLM) GenerateStream(ctx context.Context, messages []llm.Mess
 func providerSafeMessages(messages []llm.Message) []llm.Message {
 	var out []llm.Message
 	for i, msg := range messages {
-		if !needsProviderSafeUserText(msg) {
+		safe, changed := providerSafeMessage(msg)
+		if !changed {
 			continue
 		}
 		if out == nil {
 			out = model.CloneMessages(messages)
 		}
-		out[i] = llm.NewTextMessage(llm.RoleUser, providerSafeEmptyUserText)
+		out[i] = safe
 	}
 	if out != nil {
 		return out
 	}
 	return messages
+}
+
+func providerSafeMessage(msg llm.Message) (llm.Message, bool) {
+	var changed bool
+	if parts, ok := stripClawHistoryXMLParts(msg.Parts); ok {
+		msg.Parts = parts
+		changed = true
+	}
+	if needsProviderSafeUserText(msg) {
+		return llm.NewTextMessage(llm.RoleUser, providerSafeEmptyUserText), true
+	}
+	return msg, changed
+}
+
+func stripClawHistoryXMLParts(parts []llm.Part) ([]llm.Part, bool) {
+	for i, part := range parts {
+		if !isClawHistoryXMLPart(part) {
+			continue
+		}
+		out := make([]llm.Part, 0, len(parts)-1)
+		for _, part := range parts[:i] {
+			out = append(out, part.Clone())
+		}
+		for _, part := range parts[i+1:] {
+			if !isClawHistoryXMLPart(part) {
+				out = append(out, part.Clone())
+			}
+		}
+		return out, true
+	}
+	return parts, false
 }
 
 func needsProviderSafeUserText(msg llm.Message) bool {

--- a/sdkx/claw/llm_adapter_test.go
+++ b/sdkx/claw/llm_adapter_test.go
@@ -42,3 +42,28 @@ func TestProviderSafeMessagesLeavesStructuredUserContentAlone(t *testing.T) {
 		t.Fatalf("structured message changed: %+v", out[0])
 	}
 }
+
+func TestProviderSafeMessagesStripsClawHistoryXMLWithoutMutatingInput(t *testing.T) {
+	in := []llm.Message{{
+		Role: llm.RoleAssistant,
+		Parts: []llm.Part{
+			{Type: clawHistoryXMLPartType, Text: `<node id="answer" />`},
+			{Type: llm.PartText, Text: "hello"},
+			{Type: clawHistoryXMLPartType, Text: `<speaker name="Momo" />`},
+		},
+	}}
+
+	out := providerSafeMessages(in)
+	if &out[0] == &in[0] {
+		t.Fatal("providerSafeMessages returned the original backing array after stripping metadata")
+	}
+	if got := out[0].Content(); got != "hello" {
+		t.Fatalf("provider-safe content = %q, want hello", got)
+	}
+	if len(out[0].Parts) != 1 || out[0].Parts[0].Type != llm.PartText {
+		t.Fatalf("provider-safe parts = %+v, want only visible text", out[0].Parts)
+	}
+	if got := clawHistoryXMLAttr(in[0], "node", "id"); got != "answer" {
+		t.Fatalf("input metadata mutated, node id = %q", got)
+	}
+}

--- a/sdkx/claw/roundtrip.go
+++ b/sdkx/claw/roundtrip.go
@@ -224,7 +224,7 @@ func (c *Claw) boardSeeder() agent.BoardSeeder {
 				return nil, fmt.Errorf("claw: load history: %w", err)
 			}
 			if len(prior) > 0 {
-				board.SetChannel(engine.MainChannel, renderClawHistoryXML(prior))
+				board.SetChannel(engine.MainChannel, prior)
 			}
 		}
 		if c.memory != nil {
@@ -502,20 +502,6 @@ func withClawHistoryXML(msg model.Message, nodeID, speakerName string) model.Mes
 	}
 	msg.Parts = append(meta, msg.Parts...)
 	return msg
-}
-
-func renderClawHistoryXML(messages []model.Message) []model.Message {
-	out := make([]model.Message, 0, len(messages))
-	for _, msg := range messages {
-		cp := msg.Clone()
-		for i, part := range cp.Parts {
-			if part.Type == clawHistoryXMLPartType {
-				cp.Parts[i].Type = model.PartText
-			}
-		}
-		out = append(out, cp)
-	}
-	return out
 }
 
 func isClawHistoryXMLPart(part model.Part) bool {

--- a/sdkx/claw/roundtrip_test.go
+++ b/sdkx/claw/roundtrip_test.go
@@ -245,11 +245,78 @@ func TestRoundTripLoadsConfiguredHistoryByContextID(t *testing.T) {
 	if second[0].Role != model.RoleUser || second[0].Content() != "first question" {
 		t.Fatalf("message 0 = (%s, %q), want first user turn", second[0].Role, second[0].Content())
 	}
-	if second[1].Role != model.RoleAssistant || second[1].Content() != `<node id="answer" />first reply` {
-		t.Fatalf("message 1 = (%s, %q), want first assistant turn with node XML", second[1].Role, second[1].Content())
+	if second[1].Role != model.RoleAssistant || second[1].Content() != "first reply" {
+		t.Fatalf("message 1 = (%s, %q), want clean first assistant turn", second[1].Role, second[1].Content())
+	}
+	if got := clawHistoryXMLAttr(second[1], "node", "id"); got != "" {
+		t.Fatalf("provider-visible message retained node XML = %q", got)
 	}
 	if second[2].Role != model.RoleUser || second[2].Content() != "second question" {
 		t.Fatalf("message 2 = (%s, %q), want second user turn", second[2].Role, second[2].Content())
+	}
+}
+
+func TestRoundTripProviderHistoryStripsNodeXMLBeforeLaterReply(t *testing.T) {
+	ws, err := workspace.NewLocalWorkspace(t.TempDir())
+	if err != nil {
+		t.Fatalf("NewLocalWorkspace: %v", err)
+	}
+	llm := &historyEchoLLM{}
+	app := newTestClaw(t, ws, llm, func(cfg *Config) {
+		cfg.History.Enabled = true
+		cfg.History.Kind = "buffer"
+		cfg.History.MaxMessages = 10
+	})
+	defer app.Close()
+
+	resp, err := app.RoundTrip(Request{Text: "first question"})
+	if err != nil {
+		t.Fatalf("RoundTrip first: %v", err)
+	}
+	for {
+		if _, err := resp.Next(); errors.Is(err, io.EOF) {
+			break
+		} else if err != nil {
+			t.Fatalf("Next first: %v", err)
+		}
+	}
+
+	history, err := app.history.load(context.Background(), app.contextID())
+	if err != nil {
+		t.Fatalf("load history: %v", err)
+	}
+	if len(history) != 2 {
+		t.Fatalf("history messages = %d, want user + assistant: %+v", len(history), history)
+	}
+	if got := history[1].Content(); got != "first reply" {
+		t.Fatalf("persisted assistant content = %q, want first reply", got)
+	}
+	if got := clawHistoryXMLAttr(history[1], "node", "id"); got != "answer" {
+		t.Fatalf("persisted assistant node XML = %q, want answer", got)
+	}
+
+	resp, err = app.RoundTrip(Request{Text: "second question"})
+	if err != nil {
+		t.Fatalf("RoundTrip second: %v", err)
+	}
+	var streamed strings.Builder
+	for {
+		ev, err := resp.Next()
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		if err != nil {
+			t.Fatalf("Next second: %v", err)
+		}
+		if ev.Type == EventToken {
+			streamed.WriteString(ev.Content)
+			if strings.Contains(ev.Content, "<node") {
+				t.Fatalf("token leaked node XML: %q", ev.Content)
+			}
+		}
+	}
+	if got := streamed.String(); got != "first reply / later reply" {
+		t.Fatalf("second reply = %q, want clean history echo", got)
 	}
 }
 
@@ -408,23 +475,21 @@ func TestRoundTripHistoryParsesSpeakerDirectiveIntoMetadata(t *testing.T) {
 	if err != nil {
 		t.Fatalf("SeedBoard: %v", err)
 	}
+	var foundStructuredSpeaker bool
 	for _, msg := range board.Channel(engine.MainChannel) {
 		for _, part := range msg.Parts {
+			if part.Type == model.PartText && strings.Contains(part.Text, "<speaker") {
+				t.Fatalf("board history rendered speaker XML as visible text: %+v", msg)
+			}
 			if part.Type == clawHistoryXMLPartType {
-				t.Fatalf("board history should render XML metadata as text before LLM: %+v", msg)
+				if got, ok := parseXMLDirectiveAttr(part.Text, "speaker", "name"); ok && got == "沈知秋" {
+					foundStructuredSpeaker = true
+				}
 			}
 		}
 	}
-	foundRenderedSpeaker := false
-	for _, msg := range board.Channel(engine.MainChannel) {
-		for _, part := range msg.Parts {
-			if part.Type == model.PartText && part.Text == `<speaker name="沈知秋" />` {
-				foundRenderedSpeaker = true
-			}
-		}
-	}
-	if !foundRenderedSpeaker {
-		t.Fatalf("board history did not retain speaker XML as text: %+v", board.Channel(engine.MainChannel))
+	if !foundStructuredSpeaker {
+		t.Fatalf("board history did not retain speaker XML metadata: %+v", board.Channel(engine.MainChannel))
 	}
 }
 
@@ -1155,6 +1220,35 @@ func (c *capturingLLM) calls() [][]llm.Message {
 		out[i] = model.CloneMessages(msgs)
 	}
 	return out
+}
+
+type historyEchoLLM struct {
+	mu    sync.Mutex
+	calls int
+}
+
+func (h *historyEchoLLM) Generate(context.Context, []llm.Message, ...llm.GenerateOption) (llm.Message, llm.TokenUsage, error) {
+	return llm.Message{}, llm.TokenUsage{}, nil
+}
+
+func (h *historyEchoLLM) GenerateStream(_ context.Context, msgs []llm.Message, _ ...llm.GenerateOption) (llm.StreamMessage, error) {
+	h.mu.Lock()
+	h.calls++
+	call := h.calls
+	h.mu.Unlock()
+
+	reply := "first reply"
+	if call > 1 {
+		reply = "missing assistant history / later reply"
+		for _, msg := range msgs {
+			if msg.Role == llm.RoleAssistant {
+				reply = msg.Content() + " / later reply"
+				break
+			}
+		}
+	}
+	msg := llm.NewTextMessage(llm.RoleAssistant, reply)
+	return &sliceStream{msg: msg, chunks: []string{reply}}, nil
 }
 
 type toolCallLLM struct{}


### PR DESCRIPTION
## Summary
- Fixes #222 by keeping Claw node/speaker XML as structured history metadata instead of rendering it into visible text.
- Strip Claw history XML from provider-bound messages so later model turns cannot echo node markers as assistant content.
- Add regression coverage for persisted metadata, provider-visible history, clean streamed replies, and non-mutating provider sanitization.

## Validation
- go test ./sdkx/claw -count=1
- go test -race ./sdkx/claw -count=1
- cd sdkx && go test ./... -count=1
- cd cmd/claw && go test ./cli -count=1
- git diff --check

## Review
- Ran go-code-review loop: Round 1 found and fixed deep-copy isolation for sanitized parts; Round 2 found no new negative findings.