### PR TITLE
claw: add direct memory fact appends

### DIFF
--- a/sdkx/claw/claw.go
+++ b/sdkx/claw/claw.go
@@ -2,7 +2,6 @@ package claw
 
 import (
 	"context"
-	"errors"
 	"sync"
 
 	"github.com/GizClaw/flowcraft/sdk/agent"
@@ -22,6 +21,8 @@ type Claw struct {
 	tools    *tool.Registry
 	history  *historyRuntime
 	memory   *memoryRuntime
+
+	memoryMu sync.RWMutex
 
 	toolMu             sync.RWMutex
 	toolHandlers       map[string]ToolHandler
@@ -96,9 +97,12 @@ func (c *Claw) CloseContext(ctx context.Context) error {
 			return err
 		}
 	}
-	var errs []error
-	if c.memory != nil {
-		errs = append(errs, c.memory.close(ctx))
+	c.memoryMu.Lock()
+	mem := c.memory
+	c.memory = nil
+	c.memoryMu.Unlock()
+	if mem == nil {
+		return nil
 	}
-	return errors.Join(errs...)
+	return mem.close(ctx)
 }

--- a/sdkx/claw/debug_server.go
+++ b/sdkx/claw/debug_server.go
@@ -129,11 +129,15 @@ func (c *Claw) serveDebugHistory(w http.ResponseWriter, r *http.Request) {
 
 func (c *Claw) serveDebugMemory(w http.ResponseWriter) {
 	cfg := c.cfg.Memory
-	if c.memory != nil {
-		cfg = c.memory.cfg
+	c.memoryMu.RLock()
+	mem := c.memory
+	if mem != nil {
+		cfg = mem.cfg
 	}
+	enabled := mem != nil
+	c.memoryMu.RUnlock()
 	writeDebugJSON(w, http.StatusOK, debugMemoryResponse{
-		Enabled: c.memory != nil,
+		Enabled: enabled,
 		Root:    c.cfg.Workspace.MemoryRoot,
 		Scope:   cfg.Scope,
 		Write: debugMemoryWriteInfo{
@@ -155,24 +159,41 @@ func (c *Claw) serveDebugMemory(w http.ResponseWriter) {
 }
 
 func (c *Claw) serveDebugRecall(w http.ResponseWriter, r *http.Request) {
-	if c.memory == nil || c.memory.mem == nil {
+	c.memoryMu.RLock()
+	mem := c.memory
+	if mem == nil || mem.mem == nil {
+		c.memoryMu.RUnlock()
 		writeDebugJSON(w, http.StatusOK, debugRecallResponse{
 			Enabled: false,
 			Hits:    []debugRecallHit{},
 		})
 		return
 	}
+	c.memoryMu.RUnlock()
+
 	var req debugRecallRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		writeDebugError(w, http.StatusBadRequest, fmt.Sprintf("decode recall request: %v", err))
 		return
 	}
-	query := c.memory.debugRecallQuery(req)
+	query := debugRecallQuery(c.cfg.Memory, req)
 	if recallQueryEmpty(query) {
 		writeDebugError(w, http.StatusBadRequest, "recall request requires text or structured query fields")
 		return
 	}
-	hits, err := c.memory.mem.Recall(r.Context(), c.memory.scope, query)
+	c.memoryMu.RLock()
+	mem = c.memory
+	if mem == nil || mem.mem == nil {
+		c.memoryMu.RUnlock()
+		writeDebugJSON(w, http.StatusOK, debugRecallResponse{
+			Enabled: false,
+			Hits:    []debugRecallHit{},
+		})
+		return
+	}
+	query = mem.debugRecallQuery(req)
+	hits, err := mem.mem.Recall(r.Context(), mem.scope, query)
+	c.memoryMu.RUnlock()
 	if err != nil {
 		writeDebugError(w, http.StatusInternalServerError, fmt.Sprintf("recall: %v", err))
 		return
@@ -201,9 +222,13 @@ func (c *Claw) serveDebugRecall(w http.ResponseWriter, r *http.Request) {
 }
 
 func (m *memoryRuntime) debugRecallQuery(req debugRecallRequest) recall.Query {
+	return debugRecallQuery(m.cfg, req)
+}
+
+func debugRecallQuery(cfg MemoryConfig, req debugRecallRequest) recall.Query {
 	limit := req.TopK
 	if limit <= 0 {
-		limit = m.cfg.Recall.TopK
+		limit = cfg.Recall.TopK
 	}
 	if limit <= 0 {
 		limit = 5

--- a/sdkx/claw/debug_server_test.go
+++ b/sdkx/claw/debug_server_test.go
@@ -135,3 +135,22 @@ func TestDebugHTTPRecallUsesMemoryRuntime(t *testing.T) {
 		t.Fatalf("recall hit = %q, want saved fact", got)
 	}
 }
+
+func TestDebugHTTPRecallDisabledIgnoresRequestBody(t *testing.T) {
+	app := &Claw{}
+	req := httptest.NewRequest(http.MethodPost, "/debug/recall", bytes.NewBufferString(`{`))
+	rec := httptest.NewRecorder()
+
+	app.ServeDebugHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("recall status = %d, body=%s", rec.Code, rec.Body.String())
+	}
+	var recallResp debugRecallResponse
+	if err := json.NewDecoder(rec.Body).Decode(&recallResp); err != nil {
+		t.Fatalf("decode recall debug: %v", err)
+	}
+	if recallResp.Enabled || len(recallResp.Hits) != 0 {
+		t.Fatalf("recall debug = %+v, want disabled with no hits", recallResp)
+	}
+}

--- a/sdkx/claw/memory_fact.go
+++ b/sdkx/claw/memory_fact.go
@@ -1,0 +1,219 @@
+package claw
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+	"time"
+
+	"github.com/GizClaw/flowcraft/memory/recall"
+	"github.com/GizClaw/flowcraft/sdk/errdefs"
+)
+
+// ErrMemoryDisabled is returned when a caller tries to append memory through a
+// Claw instance whose workspace has memory disabled.
+var ErrMemoryDisabled = errors.New("claw: memory is disabled")
+
+// MemoryFactKind is a public semantic memory fact kind accepted by
+// AppendMemoryFact.
+type MemoryFactKind string
+
+const (
+	MemoryFactEvent      MemoryFactKind = "event"
+	MemoryFactState      MemoryFactKind = "state"
+	MemoryFactPreference MemoryFactKind = "preference"
+	MemoryFactProcedure  MemoryFactKind = "procedure"
+	MemoryFactRelation   MemoryFactKind = "relation"
+	MemoryFactPlan       MemoryFactKind = "plan"
+	MemoryFactNote       MemoryFactKind = "note"
+)
+
+// MemoryFact is a caller-supplied structured memory fact for Claw workspace
+// memory. Content is the primary recall surface; structured fields should only
+// be set when the caller has stable domain semantics for them.
+type MemoryFact struct {
+	// Kind maps to Flowcraft's public semantic memory fact kinds. Empty
+	// defaults to MemoryFactNote. The reserved internal episode kind is not
+	// accepted through this API.
+	Kind MemoryFactKind
+
+	// Content is the recall-friendly natural-language fact text. This is the
+	// primary text used by memory recall and prompt context, so callers should
+	// make it understandable without requiring Metadata.
+	Content string
+
+	// Subject is the primary entity this fact is about, when the caller has a
+	// stable entity identity. Examples: "pet:pet-123", "user:alice", or
+	// "workspace:demo". Leave empty when the fact is general, when the entity is
+	// unknown, or when Content alone is the intended recall surface.
+	Subject string
+
+	// Predicate is the stable relation, attribute, or domain action for the
+	// fact. Examples: "pet_drive", "favorite_food", "current_mood", or
+	// "played_game". For event facts, this is a good place for the domain event
+	// type. Leave empty when the caller does not have a durable schema label and
+	// only wants text recall.
+	Predicate string
+
+	// Object is the target or value of Subject+Predicate when it is naturally
+	// representable as a short string. Examples: "wash", "sushi", "happy", or
+	// "game:maze". Do not serialize complex payloads into Object; put complex
+	// domain data in Metadata and keep Content human-readable.
+	Object string
+
+	// Entities are additional searchable entities mentioned by the fact. Use
+	// stable ids or names that should help later recall, such as pet ids, item
+	// ids, game ids, location names, or participant ids. Entities are not a
+	// replacement for Subject; Subject is the main focus, while Entities are
+	// extra recall anchors. Leave empty when there are no reliable anchors.
+	Entities []string
+
+	// Metadata preserves the original domain payload as JSON-compatible
+	// structured data.
+	Metadata map[string]any
+
+	// ObservedAt is the observation time. Zero means time.Now().
+	ObservedAt time.Time
+
+	// Optional validity bounds for facts that should not be timeless.
+	ValidFrom *time.Time
+	ValidTo   *time.Time
+}
+
+// AppendMemoryFactResult reports the canonical memory facts written by
+// AppendMemoryFact.
+type AppendMemoryFactResult struct {
+	// FactIDs are the canonical memory fact ids written by this call.
+	FactIDs []string
+
+	// AsyncRequestID and SemanticPending mirror recall async write semantics if
+	// the underlying memory write mode needs them.
+	AsyncRequestID  string
+	SemanticPending bool
+}
+
+// AppendMemoryFact writes a caller-supplied structured fact into this Claw
+// workspace's configured memory runtime without creating a chat turn.
+func (c *Claw) AppendMemoryFact(ctx context.Context, fact MemoryFact) (AppendMemoryFactResult, error) {
+	if c == nil {
+		return AppendMemoryFactResult{}, ErrMemoryDisabled
+	}
+	c.memoryMu.RLock()
+	defer c.memoryMu.RUnlock()
+	if c.memory == nil || c.memory.mem == nil {
+		return AppendMemoryFactResult{}, ErrMemoryDisabled
+	}
+	return c.memory.appendMemoryFact(ctx, fact)
+}
+
+func (m *memoryRuntime) appendMemoryFact(ctx context.Context, fact MemoryFact) (AppendMemoryFactResult, error) {
+	if m == nil || m.mem == nil {
+		return AppendMemoryFactResult{}, ErrMemoryDisabled
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	now := time.Now()
+	tf, err := memoryFactToRecallFact(fact, now)
+	if err != nil {
+		return AppendMemoryFactResult{}, err
+	}
+	res, err := m.mem.Save(ctx, m.scope, recall.SaveRequest{
+		Facts:      []recall.TemporalFact{tf},
+		ObservedAt: tf.ObservedAt,
+		Tier:       m.cfg.Write.Tier,
+		Mode:       parseWriteMode(m.cfg.Write.Mode),
+	})
+	if err != nil {
+		return AppendMemoryFactResult{}, err
+	}
+	if err := m.drainSideEffects(ctx); err != nil {
+		return AppendMemoryFactResult{}, err
+	}
+	return AppendMemoryFactResult{
+		FactIDs:         append([]string(nil), res.FactIDs...),
+		AsyncRequestID:  res.AsyncRequestID,
+		SemanticPending: res.SemanticPending,
+	}, nil
+}
+
+func memoryFactToRecallFact(fact MemoryFact, now time.Time) (recall.TemporalFact, error) {
+	kind, err := recallKindFromMemoryFactKind(fact.Kind)
+	if err != nil {
+		return recall.TemporalFact{}, err
+	}
+	content := strings.TrimSpace(fact.Content)
+	if content == "" {
+		return recall.TemporalFact{}, errdefs.Validationf("claw: memory fact content is required")
+	}
+	if len(fact.Metadata) > 0 {
+		if _, err := json.Marshal(fact.Metadata); err != nil {
+			return recall.TemporalFact{}, errdefs.Validationf("claw: memory fact metadata must be JSON-compatible: %v", err)
+		}
+	}
+	observedAt := fact.ObservedAt
+	if observedAt.IsZero() {
+		observedAt = now
+	}
+	return recall.TemporalFact{
+		Kind:       kind,
+		Content:    content,
+		Subject:    strings.TrimSpace(fact.Subject),
+		Predicate:  strings.TrimSpace(fact.Predicate),
+		Object:     strings.TrimSpace(fact.Object),
+		Entities:   nonEmptyStrings(fact.Entities),
+		ObservedAt: observedAt,
+		ValidFrom:  cloneTimePtr(fact.ValidFrom),
+		ValidTo:    cloneTimePtr(fact.ValidTo),
+		Polarity:   recall.PolarityAffirmed,
+		Modality:   recall.ModalityActual,
+		Certainty:  recall.CertaintyExplicit,
+		Confidence: 0.9,
+		Metadata:   cloneMemoryFactMetadata(fact.Metadata),
+	}, nil
+}
+
+func recallKindFromMemoryFactKind(kind MemoryFactKind) (recall.FactKind, error) {
+	switch strings.TrimSpace(string(kind)) {
+	case "":
+		return recall.FactNote, nil
+	case string(MemoryFactEvent):
+		return recall.FactEvent, nil
+	case string(MemoryFactState):
+		return recall.FactState, nil
+	case string(MemoryFactPreference):
+		return recall.FactPreference, nil
+	case string(MemoryFactProcedure):
+		return recall.FactProcedure, nil
+	case string(MemoryFactRelation):
+		return recall.FactRelation, nil
+	case string(MemoryFactPlan):
+		return recall.FactPlan, nil
+	case string(MemoryFactNote):
+		return recall.FactNote, nil
+	case string(recall.FactEpisode):
+		return "", errdefs.Validationf("claw: memory fact kind %q is reserved", recall.FactEpisode)
+	default:
+		return "", errdefs.Validationf("claw: unsupported memory fact kind %q", kind)
+	}
+}
+
+func cloneTimePtr(in *time.Time) *time.Time {
+	if in == nil {
+		return nil
+	}
+	out := *in
+	return &out
+}
+
+func cloneMemoryFactMetadata(in map[string]any) map[string]any {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make(map[string]any, len(in))
+	for k, v := range in {
+		out[k] = v
+	}
+	return out
+}

--- a/sdkx/claw/memory_test.go
+++ b/sdkx/claw/memory_test.go
@@ -2,13 +2,423 @@ package claw
 
 import (
 	"context"
+	"encoding/json"
+	"errors"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/GizClaw/flowcraft/memory/recall"
+	"github.com/GizClaw/flowcraft/sdk/errdefs"
 	"github.com/GizClaw/flowcraft/sdk/model"
+	"github.com/GizClaw/flowcraft/sdk/workspace"
 )
+
+func TestAppendMemoryFactWritesRecallableFact(t *testing.T) {
+	app := newMemoryEnabledTestClaw(t)
+	defer app.Close()
+
+	ctx := context.Background()
+	res, err := app.AppendMemoryFact(ctx, MemoryFact{
+		Kind:      MemoryFactEvent,
+		Content:   "The user washed pet:pet-123 and the pet became cleaner.",
+		Subject:   "pet:pet-123",
+		Predicate: "pet_drive",
+		Object:    "wash",
+		Entities:  []string{"pet:pet-123"},
+	})
+	if err != nil {
+		t.Fatalf("AppendMemoryFact: %v", err)
+	}
+	if len(res.FactIDs) != 1 || res.FactIDs[0] == "" {
+		t.Fatalf("FactIDs = %+v, want one id", res.FactIDs)
+	}
+
+	hits, err := app.memory.mem.Recall(ctx, app.memory.scope, recall.Query{
+		Text:      "pet became cleaner washed",
+		Kinds:     []recall.FactKind{recall.FactEvent},
+		Limit:     5,
+		GraphHops: 0,
+	})
+	if err != nil {
+		t.Fatalf("Recall: %v", err)
+	}
+	if len(hits) == 0 {
+		t.Fatalf("AppendMemoryFact fact was not recallable")
+	}
+	if got := hits[0].Fact.Content; !strings.Contains(got, "pet became cleaner") {
+		t.Fatalf("recall content = %q", got)
+	}
+}
+
+func TestAppendMemoryFactSupportsPublicSemanticKinds(t *testing.T) {
+	app := newMemoryEnabledTestClaw(t)
+	defer app.Close()
+
+	ctx := context.Background()
+	for _, kind := range []MemoryFactKind{
+		MemoryFactEvent,
+		MemoryFactState,
+		MemoryFactPreference,
+		MemoryFactProcedure,
+		MemoryFactRelation,
+		MemoryFactPlan,
+		MemoryFactNote,
+	} {
+		res, err := app.AppendMemoryFact(ctx, MemoryFact{
+			Kind:    kind,
+			Content: "public semantic memory fact " + string(kind),
+		})
+		if err != nil {
+			t.Fatalf("AppendMemoryFact kind=%s: %v", kind, err)
+		}
+		if len(res.FactIDs) != 1 {
+			t.Fatalf("AppendMemoryFact kind=%s FactIDs = %+v, want one id", kind, res.FactIDs)
+		}
+		stored, err := app.memory.backend.TemporalStore().Get(ctx, app.memory.scope, res.FactIDs[0])
+		if err != nil {
+			t.Fatalf("Get kind=%s: %v", kind, err)
+		}
+		if stored.Kind != recall.FactKind(kind) {
+			t.Fatalf("stored kind = %s, want %s", stored.Kind, kind)
+		}
+	}
+}
+
+func TestAppendMemoryFactDefaultsEmptyKindToNote(t *testing.T) {
+	app := newMemoryEnabledTestClaw(t)
+	defer app.Close()
+
+	res, err := app.AppendMemoryFact(context.Background(), MemoryFact{
+		Content: "empty kind should default to a note",
+	})
+	if err != nil {
+		t.Fatalf("AppendMemoryFact: %v", err)
+	}
+	stored, err := app.memory.backend.TemporalStore().Get(context.Background(), app.memory.scope, res.FactIDs[0])
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if stored.Kind != recall.FactNote {
+		t.Fatalf("stored kind = %s, want note", stored.Kind)
+	}
+}
+
+func TestAppendMemoryFactRejectsReservedEpisodeKind(t *testing.T) {
+	app := newMemoryEnabledTestClaw(t)
+	defer app.Close()
+
+	_, err := app.AppendMemoryFact(context.Background(), MemoryFact{
+		Kind:    MemoryFactKind(recall.FactEpisode),
+		Content: "raw episode should not be accepted",
+	})
+	if err == nil {
+		t.Fatal("expected reserved episode kind to fail")
+	}
+	if !errdefs.IsValidation(err) {
+		t.Fatalf("episode error = %v, want validation classification", err)
+	}
+}
+
+func TestAppendMemoryFactPreservesStructuredFields(t *testing.T) {
+	app := newMemoryEnabledTestClaw(t)
+	defer app.Close()
+
+	ctx := context.Background()
+	observedAt := time.Date(2026, 7, 6, 8, 9, 10, 0, time.UTC)
+	validFrom := observedAt.Add(-time.Hour)
+	validTo := observedAt.Add(time.Hour)
+	metadata := map[string]any{
+		"type":          "pet_drive",
+		"pet_id":        "pet-123",
+		"points_delta":  float64(-3),
+		"pet_exp_delta": float64(10),
+		"life_delta":    map[string]any{"cleanliness": float64(15)},
+		"tags":          []any{"pet", "care"},
+	}
+	res, err := app.AppendMemoryFact(ctx, MemoryFact{
+		Kind:       MemoryFactEvent,
+		Content:    "The user cared for the pet by washing it.",
+		Subject:    " pet:pet-123 ",
+		Predicate:  " pet_drive ",
+		Object:     " wash ",
+		Entities:   []string{"pet:pet-123", " ", "petdef:petdef-cat"},
+		Metadata:   metadata,
+		ObservedAt: observedAt,
+		ValidFrom:  &validFrom,
+		ValidTo:    &validTo,
+	})
+	if err != nil {
+		t.Fatalf("AppendMemoryFact: %v", err)
+	}
+	stored, err := app.memory.backend.TemporalStore().Get(ctx, app.memory.scope, res.FactIDs[0])
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if stored.Kind != recall.FactEvent ||
+		stored.Subject != "pet:pet-123" ||
+		stored.Predicate != "pet drive" ||
+		stored.Object != "wash" {
+		t.Fatalf("stored structured fields = kind=%s subject=%q predicate=%q object=%q",
+			stored.Kind, stored.Subject, stored.Predicate, stored.Object)
+	}
+	for _, want := range []string{"pet:pet-123", "petdef:petdef-cat"} {
+		if !hasString(stored.Entities, want) {
+			t.Fatalf("entities = %q, missing %q", strings.Join(stored.Entities, ","), want)
+		}
+	}
+	if !stored.ObservedAt.Equal(observedAt) ||
+		stored.ValidFrom == nil || !stored.ValidFrom.Equal(validFrom) ||
+		stored.ValidTo == nil || !stored.ValidTo.Equal(validTo) {
+		t.Fatalf("stored times = observed=%s validFrom=%v validTo=%v", stored.ObservedAt, stored.ValidFrom, stored.ValidTo)
+	}
+	assertJSONEqual(t, stored.Metadata, metadata)
+}
+
+func TestAppendMemoryFactPreservesMetadataJSONRoundTrip(t *testing.T) {
+	root := t.TempDir()
+	ws, err := workspace.NewLocalWorkspace(root)
+	if err != nil {
+		t.Fatalf("NewLocalWorkspace: %v", err)
+	}
+	app := newTestClaw(t, ws, staticLLM{reply: "ok"}, enableTestMemory)
+
+	ctx := context.Background()
+	metadata := map[string]any{
+		"source": "gizclaw",
+		"score":  float64(3),
+		"nested": map[string]any{"ok": true},
+		"tags":   []any{"pet", "memory"},
+	}
+	res, err := app.AppendMemoryFact(ctx, MemoryFact{
+		Kind:     MemoryFactNote,
+		Content:  "metadata should survive persistence",
+		Metadata: metadata,
+	})
+	if err != nil {
+		t.Fatalf("AppendMemoryFact: %v", err)
+	}
+	if err := app.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	ws2, err := workspace.NewLocalWorkspace(root)
+	if err != nil {
+		t.Fatalf("NewLocalWorkspace reopen: %v", err)
+	}
+	reopened, err := New(ws2)
+	if err != nil {
+		t.Fatalf("New reopen: %v", err)
+	}
+	defer reopened.Close()
+
+	stored, err := reopened.memory.backend.TemporalStore().Get(ctx, reopened.memory.scope, res.FactIDs[0])
+	if err != nil {
+		t.Fatalf("Get reopened fact: %v", err)
+	}
+	assertJSONEqual(t, stored.Metadata, metadata)
+}
+
+func TestAppendMemoryFactMemoryDisabled(t *testing.T) {
+	ws, err := workspace.NewLocalWorkspace(t.TempDir())
+	if err != nil {
+		t.Fatalf("NewLocalWorkspace: %v", err)
+	}
+	app := newTestClaw(t, ws, staticLLM{reply: "ok"}, nil)
+	defer app.Close()
+
+	_, err = app.AppendMemoryFact(context.Background(), MemoryFact{Content: "memory is disabled"})
+	if !errors.Is(err, ErrMemoryDisabled) {
+		t.Fatalf("AppendMemoryFact error = %v, want ErrMemoryDisabled", err)
+	}
+}
+
+func TestAppendMemoryFactAfterCloseReturnsError(t *testing.T) {
+	app := newMemoryEnabledTestClaw(t)
+	if err := app.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	_, err := app.AppendMemoryFact(context.Background(), MemoryFact{Content: "after close"})
+	if !errors.Is(err, ErrMemoryDisabled) {
+		t.Fatalf("AppendMemoryFact after close error = %v, want ErrMemoryDisabled", err)
+	}
+}
+
+func TestAppendMemoryFactAfterCloseErrorReturnsDisabled(t *testing.T) {
+	closeErr := errors.New("close failed")
+	app := &Claw{
+		memory: &memoryRuntime{
+			mem: &closeErrMemory{err: closeErr},
+		},
+	}
+	if err := app.CloseContext(context.Background()); !errors.Is(err, closeErr) {
+		t.Fatalf("CloseContext error = %v, want %v", err, closeErr)
+	}
+	_, err := app.AppendMemoryFact(context.Background(), MemoryFact{Content: "after failed close"})
+	if !errors.Is(err, ErrMemoryDisabled) {
+		t.Fatalf("AppendMemoryFact after failed close = %v, want ErrMemoryDisabled", err)
+	}
+}
+
+func TestAppendMemoryFactValidation(t *testing.T) {
+	app := newMemoryEnabledTestClaw(t)
+	defer app.Close()
+
+	tests := []struct {
+		name string
+		fact MemoryFact
+	}{
+		{
+			name: "empty content",
+			fact: MemoryFact{Kind: MemoryFactNote},
+		},
+		{
+			name: "unsupported kind",
+			fact: MemoryFact{Kind: "unknown", Content: "invalid kind"},
+		},
+		{
+			name: "non json metadata",
+			fact: MemoryFact{
+				Kind:     MemoryFactNote,
+				Content:  "invalid metadata",
+				Metadata: map[string]any{"bad": func() {}},
+			},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := app.AppendMemoryFact(context.Background(), tc.fact)
+			if err == nil {
+				t.Fatal("expected validation error")
+			}
+			if !errdefs.IsValidation(err) {
+				t.Fatalf("error = %v, want validation classification", err)
+			}
+		})
+	}
+}
+
+func TestAppendMemoryFactReturnsSaveError(t *testing.T) {
+	saveErr := errors.New("save failed")
+	app := &Claw{
+		memory: &memoryRuntime{
+			mem:   &saveErrMemory{err: saveErr},
+			scope: recall.Scope{RuntimeID: "rt", UserID: "u", AgentID: "a"},
+		},
+	}
+	_, err := app.AppendMemoryFact(context.Background(), MemoryFact{Content: "save should fail"})
+	if !errors.Is(err, saveErr) {
+		t.Fatalf("AppendMemoryFact error = %v, want %v", err, saveErr)
+	}
+}
+
+func TestAppendMemoryFactReturnsSideEffectError(t *testing.T) {
+	mem, err := recall.New()
+	if err != nil {
+		t.Fatalf("recall.New: %v", err)
+	}
+	defer mem.Close()
+
+	sideErr := errors.New("side effect failed")
+	app := &Claw{
+		memory: &memoryRuntime{
+			mem:   mem,
+			side:  failingSideEffectProcessor{err: sideErr},
+			scope: recall.Scope{RuntimeID: "rt", UserID: "u", AgentID: "a"},
+		},
+	}
+	_, err = app.AppendMemoryFact(context.Background(), MemoryFact{Content: "side effects should fail"})
+	if !errors.Is(err, sideErr) {
+		t.Fatalf("AppendMemoryFact error = %v, want %v", err, sideErr)
+	}
+}
+
+func TestAppendMemoryFactAsyncSemanticModeWritesFactSynchronously(t *testing.T) {
+	app := newMemoryEnabledTestClawWith(t, func(cfg *Config) {
+		cfg.Memory.Write.Mode = "async_semantic"
+	})
+	defer app.Close()
+
+	res, err := app.AppendMemoryFact(context.Background(), MemoryFact{
+		Kind:    MemoryFactEvent,
+		Content: "facts-only async semantic append should write immediately",
+	})
+	if err != nil {
+		t.Fatalf("AppendMemoryFact: %v", err)
+	}
+	if len(res.FactIDs) != 1 || res.AsyncRequestID != "" || res.SemanticPending {
+		t.Fatalf("result = %+v, want one sync fact and no async pending", res)
+	}
+	if _, err := app.memory.backend.TemporalStore().Get(context.Background(), app.memory.scope, res.FactIDs[0]); err != nil {
+		t.Fatalf("Get appended fact: %v", err)
+	}
+}
+
+func TestAppendMemoryFactConcurrentClose(t *testing.T) {
+	for i := 0; i < 20; i++ {
+		app := newMemoryEnabledTestClaw(t)
+		start := make(chan struct{})
+		errs := make(chan error, 2)
+		go func() {
+			<-start
+			_, err := app.AppendMemoryFact(context.Background(), MemoryFact{Content: "concurrent fact"})
+			if err != nil && !errors.Is(err, ErrMemoryDisabled) {
+				errs <- err
+				return
+			}
+			errs <- nil
+		}()
+		go func() {
+			<-start
+			errs <- app.CloseContext(context.Background())
+		}()
+		close(start)
+		for j := 0; j < 2; j++ {
+			if err := <-errs; err != nil {
+				t.Fatalf("iteration %d: %v", i, err)
+			}
+		}
+	}
+}
+
+func TestAppendMemoryFactDrainsSideEffects(t *testing.T) {
+	mem, err := recall.New()
+	if err != nil {
+		t.Fatalf("recall.New: %v", err)
+	}
+	defer mem.Close()
+
+	side := &recordingSideEffectProcessor{}
+	runtime := &memoryRuntime{
+		mem:  mem,
+		side: side,
+		scope: recall.Scope{
+			RuntimeID: "rt",
+			UserID:    "u",
+			AgentID:   "a",
+		},
+	}
+	res, err := runtime.appendMemoryFact(context.Background(), MemoryFact{
+		Kind:    MemoryFactNote,
+		Content: "direct fact should drain side effects",
+	})
+	if err != nil {
+		t.Fatalf("appendMemoryFact: %v", err)
+	}
+	if len(res.FactIDs) != 1 {
+		t.Fatalf("FactIDs = %+v, want one id", res.FactIDs)
+	}
+	if side.calls != 1 {
+		t.Fatalf("side-effect drain calls = %d, want 1", side.calls)
+	}
+	if side.last.WorkerID != "claw" {
+		t.Fatalf("worker id = %q, want claw", side.last.WorkerID)
+	}
+	if side.last.Scope.PartitionKey() != runtime.scope.PartitionKey() {
+		t.Fatalf("scope = %+v, want %+v", side.last.Scope, runtime.scope)
+	}
+}
 
 func TestSaveTurnDrainsSideEffects(t *testing.T) {
 	mem, err := recall.New()
@@ -283,4 +693,76 @@ func (p *recordingSideEffectProcessor) ProcessSideEffects(_ context.Context, opt
 	}
 	p.last = opts
 	return recall.SideEffectProcessResult{Claimed: 1, Completed: 1}, nil
+}
+
+func newMemoryEnabledTestClaw(t *testing.T) *Claw {
+	return newMemoryEnabledTestClawWith(t, nil)
+}
+
+func newMemoryEnabledTestClawWith(t *testing.T, mutate func(*Config)) *Claw {
+	t.Helper()
+	ws, err := workspace.NewLocalWorkspace(t.TempDir())
+	if err != nil {
+		t.Fatalf("NewLocalWorkspace: %v", err)
+	}
+	return newTestClaw(t, ws, staticLLM{reply: "ok"}, func(cfg *Config) {
+		enableTestMemory(cfg)
+		if mutate != nil {
+			mutate(cfg)
+		}
+	})
+}
+
+func enableTestMemory(cfg *Config) {
+	cfg.Memory.Enabled = true
+	cfg.Memory.Retrieval.Backend = "memory"
+	cfg.Memory.Backend = "memory"
+}
+
+func assertJSONEqual(t *testing.T, got, want any) {
+	t.Helper()
+	gotJSON, err := json.Marshal(got)
+	if err != nil {
+		t.Fatalf("marshal got: %v", err)
+	}
+	wantJSON, err := json.Marshal(want)
+	if err != nil {
+		t.Fatalf("marshal want: %v", err)
+	}
+	if string(gotJSON) != string(wantJSON) {
+		t.Fatalf("json = %s, want %s", gotJSON, wantJSON)
+	}
+}
+
+func hasString(values []string, want string) bool {
+	for _, value := range values {
+		if value == want {
+			return true
+		}
+	}
+	return false
+}
+
+type closeErrMemory struct {
+	recordingMemory
+	err error
+}
+
+func (m *closeErrMemory) Close() error { return m.err }
+
+type saveErrMemory struct {
+	recordingMemory
+	err error
+}
+
+func (m *saveErrMemory) Save(context.Context, recall.Scope, recall.SaveRequest) (recall.SaveResult, error) {
+	return recall.SaveResult{}, m.err
+}
+
+type failingSideEffectProcessor struct {
+	err error
+}
+
+func (p failingSideEffectProcessor) ProcessSideEffects(context.Context, recall.SideEffectProcessOptions) (recall.SideEffectProcessResult, error) {
+	return recall.SideEffectProcessResult{}, p.err
 }

--- a/sdkx/claw/roundtrip.go
+++ b/sdkx/claw/roundtrip.go
@@ -165,19 +165,24 @@ func (c *Claw) runRoundTrip(ctx context.Context, id string, req Request, events 
 		_ = sendRoundEvent(ctx, events, Event{Type: EventError, Err: result.Err.Error(), IsError: true, Result: result})
 		return
 	}
-	if c.memory != nil {
+	c.memoryMu.RLock()
+	mem := c.memory
+	if mem != nil {
 		var boardVars map[string]any
 		if result != nil && result.LastBoard != nil {
 			boardVars = result.LastBoard.Vars()
 		}
 		if err := sendRoundEvent(ctx, events, Event{Type: EventStatus, Content: "extracting"}); err != nil {
+			c.memoryMu.RUnlock()
 			return
 		}
-		if err := c.memory.saveTurn(ctx, id, req.Text, streams.memoryAssistant(result), boardVars); err != nil {
+		if err := mem.saveTurn(ctx, id, req.Text, streams.memoryAssistant(result), boardVars); err != nil {
+			c.memoryMu.RUnlock()
 			_ = sendRoundEvent(ctx, events, Event{Type: EventError, Err: err.Error(), IsError: true, Result: result})
 			return
 		}
 	}
+	c.memoryMu.RUnlock()
 	if c.history != nil {
 		if err := c.history.appendTurn(ctx, id, model.NewTextMessage(model.RoleUser, req.Text), streams.historyAssistants()); err != nil {
 			_ = sendRoundEvent(ctx, events, Event{Type: EventError, Err: err.Error(), IsError: true, Result: result})
@@ -227,14 +232,19 @@ func (c *Claw) boardSeeder() agent.BoardSeeder {
 				board.SetChannel(engine.MainChannel, prior)
 			}
 		}
-		if c.memory != nil {
-			memVars, err := c.memory.recallBoardVars(ctx, req.Message.Content())
+		c.memoryMu.RLock()
+		mem := c.memory
+		if mem != nil {
+			memVars, err := mem.recallBoardVars(ctx, req.Message.Content())
+			c.memoryMu.RUnlock()
 			if err != nil {
 				return nil, fmt.Errorf("claw: recall memory: %w", err)
 			}
 			for key, value := range memVars {
 				board.SetVar(key, value)
 			}
+		} else {
+			c.memoryMu.RUnlock()
 		}
 		board.AppendChannelMessage(engine.MainChannel, req.Message)
 		for k, v := range req.Inputs {
@@ -660,9 +670,12 @@ func (r *roundController) commitPartial(ctx context.Context) error {
 	ctx = context.WithoutCancel(ctx)
 	assistant := model.NewTextMessage(model.RoleAssistant, text)
 	var errs []error
-	if r.claw.memory != nil {
-		errs = append(errs, r.claw.memory.saveTurn(ctx, r.contextID, r.userText, assistant, nil))
+	r.claw.memoryMu.RLock()
+	mem := r.claw.memory
+	if mem != nil {
+		errs = append(errs, mem.saveTurn(ctx, r.contextID, r.userText, assistant, nil))
 	}
+	r.claw.memoryMu.RUnlock()
 	if r.claw.history != nil {
 		errs = append(errs, r.claw.history.appendTurn(ctx, r.contextID, model.NewTextMessage(model.RoleUser, r.userText), []model.Message{assistant}))
 	}


### PR DESCRIPTION
## Summary

Adds a public `sdkx/claw` API for host applications to append structured memory facts directly into Claw workspace memory without creating a chat turn.

- Adds `MemoryFact`, public semantic kind constants, `AppendMemoryFactResult`, and `MemoryFactAppender`
- Routes writes through the existing Claw memory runtime, recall save path, write tier, and side-effect drain
- Rejects unsupported kinds and the reserved internal `episode` kind; validates JSON-compatible metadata
- Covers recallability, structured field persistence, JSON metadata round-trip, disabled/closed memory behavior, public kind support, and side-effect processing

Fixes #224

## Validation

- `go test ./sdkx/claw`
- `go test ./sdkx/claw ./memory/recall`
- `go test ./cmd/claw/... ./sdkx/... ./memory/...`

Note: `go test ./...` from the repository root is not applicable because the root is a `go.work` workspace root, not a selected module prefix.
