### PR TITLE
memory: Depend on sdk v0.4.8

### DIFF
--- a/memory/go.mod
+++ b/memory/go.mod
@@ -3,7 +3,7 @@ module github.com/GizClaw/flowcraft/memory
 go 1.25.0
 
 require (
-	github.com/GizClaw/flowcraft/sdk v0.4.2
+	github.com/GizClaw/flowcraft/sdk v0.4.8
 	github.com/blevesearch/bleve/v2 v2.6.0
 	github.com/coder/hnsw v0.6.1
 	github.com/dgraph-io/badger/v4 v4.9.1

--- a/memory/go.sum
+++ b/memory/go.sum
@@ -1,5 +1,5 @@
-github.com/GizClaw/flowcraft/sdk v0.4.2 h1:xKQ9zhdK6C0ioJIrc4GOnog8TbAnEDJaGQqSbBXjaaQ=
-github.com/GizClaw/flowcraft/sdk v0.4.2/go.mod h1:CtWO/keRfKzfyTuKD3axf6QSpDB/vEqbBIRgvK9qpKw=
+github.com/GizClaw/flowcraft/sdk v0.4.8 h1:fgbgMfZW8U3qAhzIjU+lFFRpoR0GcrF4MB0Oolq8+dI=
+github.com/GizClaw/flowcraft/sdk v0.4.8/go.mod h1:CtWO/keRfKzfyTuKD3axf6QSpDB/vEqbBIRgvK9qpKw=
 github.com/RoaringBitmap/roaring/v2 v2.14.5 h1:ckd0o545JqDPeVJDgeFoaM21eBixUnlWfYgjE5VnyWw=
 github.com/RoaringBitmap/roaring/v2 v2.14.5/go.mod h1:eq4wdNXxtJIS/oikeCzdX1rBzek7ANzbth041hrU8Q4=
 github.com/bits-and-blooms/bitset v1.24.2 h1:M7/NzVbsytmtfHbumG+K2bremQPMJuqv1JD3vOaFxp0=


### PR DESCRIPTION
## Summary

- update the memory module to require `github.com/GizClaw/flowcraft/sdk v0.4.8`
- refresh the SDK module checksums
- make the BBH `LocalWorkspace` API changes from #230 resolve outside the repository workspace

## Validation

- `GOWORK=off GOPROXY=direct GONOSUMDB='github.com/GizClaw/flowcraft/*' go mod tidy`
- `GOWORK=off GOPROXY=direct GONOSUMDB='github.com/GizClaw/flowcraft/*' go test -count=1 ./...` in `memory`
- `git diff --check`
