### PR TITLE
sdkx: Update BBH module dependencies

### DIFF
--- a/sdkx/go.mod
+++ b/sdkx/go.mod
@@ -3,8 +3,8 @@ module github.com/GizClaw/flowcraft/sdkx
 go 1.25.0
 
 require (
-	github.com/GizClaw/flowcraft/memory v0.1.6
-	github.com/GizClaw/flowcraft/sdk v0.4.6
+	github.com/GizClaw/flowcraft/memory v0.1.7
+	github.com/GizClaw/flowcraft/sdk v0.4.8
 )
 
 require (

--- a/sdkx/go.sum
+++ b/sdkx/go.sum
@@ -8,10 +8,10 @@ github.com/Azure/azure-sdk-for-go/sdk/internal v1.10.0/go.mod h1:iZDifYGJTIgIIkY
 github.com/AzureAD/microsoft-authentication-library-for-go v1.2.2 h1:XHOnouVk1mxXfQidrMEnLlPk9UMeRtyBTnEFtxkV0kU=
 github.com/AzureAD/microsoft-authentication-library-for-go v1.2.2/go.mod h1:wP83P5OoQ5p6ip3ScPr0BAq0BvuPAvacpEuSzyouqAI=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
-github.com/GizClaw/flowcraft/memory v0.1.6 h1:awF5eN+TD5UNGLolbQj3Ldp3P89KCE2T787cZqv+vOs=
-github.com/GizClaw/flowcraft/memory v0.1.6/go.mod h1:FKrzqusZECJVKhsHVRBZZbZbbtwQ/DVKq0AnL+wUmuM=
-github.com/GizClaw/flowcraft/sdk v0.4.6 h1:dfGEvZT0fIFWCyEsvVrzQOwSjeDOGH6650EX0OFioNs=
-github.com/GizClaw/flowcraft/sdk v0.4.6/go.mod h1:CtWO/keRfKzfyTuKD3axf6QSpDB/vEqbBIRgvK9qpKw=
+github.com/GizClaw/flowcraft/memory v0.1.7 h1:dGxDjnH4W/DtaQNv9IkkNhP5QyDQ8gTF/h7Oun9KARQ=
+github.com/GizClaw/flowcraft/memory v0.1.7/go.mod h1:0so+oNUTRZqXYU3OZ8gsGEt4LV5Rn46KUVMO9SUkLb4=
+github.com/GizClaw/flowcraft/sdk v0.4.8 h1:fgbgMfZW8U3qAhzIjU+lFFRpoR0GcrF4MB0Oolq8+dI=
+github.com/GizClaw/flowcraft/sdk v0.4.8/go.mod h1:CtWO/keRfKzfyTuKD3axf6QSpDB/vEqbBIRgvK9qpKw=
 github.com/Masterminds/semver/v3 v3.2.1 h1:RN9w6+7QoMeJVGyfmbcgs28Br8cvmnucEXnY0rYXWg0=
 github.com/Masterminds/semver/v3 v3.2.1/go.mod h1:qvl/7zhW3nngYb5+80sSMF+FG2BjYrf8m9wsX0PNOMQ=
 github.com/PuerkitoBio/goquery v1.11.0 h1:jZ7pwMQXIITcUXNH83LLk+txlaEy6NVOfTuP43xxfqw=


### PR DESCRIPTION
## Summary

- update `sdkx` to consume `sdk/v0.4.8` from #230
- update `sdkx` to consume `memory/v0.1.7` from #231
- refresh checksums for the released module graph

## Validation

- `GOWORK=off GOPROXY=direct GONOSUMDB='github.com/GizClaw/flowcraft/*' go test -count=1 ./...` (from `sdkx/`)