### PR TITLE
sdkx/claw: Allow injecting history stores

### DIFF
--- a/sdkx/claw/claw.go
+++ b/sdkx/claw/claw.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"sync"
 
+	memoryhistory "github.com/GizClaw/flowcraft/memory/history"
 	"github.com/GizClaw/flowcraft/sdk/agent"
 	"github.com/GizClaw/flowcraft/sdk/engine"
 	"github.com/GizClaw/flowcraft/sdk/llm"
@@ -11,16 +12,17 @@ import (
 	sdkworkspace "github.com/GizClaw/flowcraft/sdk/workspace"
 )
 
-// Claw is a local single-agent runtime backed by one workspace.
+// Claw is a local single-agent runtime configured by one root workspace.
 type Claw struct {
-	ws       sdkworkspace.Workspace
-	cfg      Config
-	agent    agent.Agent
-	engine   engine.Engine
-	resolver llm.LLMResolver
-	tools    *tool.Registry
-	history  *historyRuntime
-	memory   *memoryRuntime
+	ws           sdkworkspace.Workspace
+	cfg          Config
+	agent        agent.Agent
+	engine       engine.Engine
+	resolver     llm.LLMResolver
+	tools        *tool.Registry
+	history      *historyRuntime
+	historyStore memoryhistory.Store
+	memory       *memoryRuntime
 
 	memoryMu sync.RWMutex
 
@@ -33,9 +35,11 @@ type Claw struct {
 }
 
 // New constructs a Claw from the fixed workspace config layout.
-func New(ws sdkworkspace.Workspace) (_ *Claw, err error) {
+func New(ws sdkworkspace.Workspace, opts ...Option) (_ *Claw, err error) {
+	resolved := resolveOptions(opts)
 	c := &Claw{
-		ws: ws,
+		ws:           ws,
+		historyStore: resolved.historyStore,
 	}
 	defer func() {
 		if err != nil {

--- a/sdkx/claw/history.go
+++ b/sdkx/claw/history.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"strings"
 
-	sdkhistory "github.com/GizClaw/flowcraft/sdk/history"
+	memoryhistory "github.com/GizClaw/flowcraft/memory/history"
 	"github.com/GizClaw/flowcraft/sdk/model"
 )
 
@@ -18,7 +18,7 @@ type HistoryConfig struct {
 }
 
 type historyRuntime struct {
-	hist sdkhistory.History
+	hist memoryhistory.History
 	cfg  HistoryConfig
 }
 
@@ -29,13 +29,16 @@ func (c *Claw) buildHistory(_ context.Context) (*historyRuntime, error) {
 	}
 	switch strings.TrimSpace(cfg.Kind) {
 	case "", "buffer":
-		store := sdkhistory.NewFileStore(c.ws, c.cfg.Workspace.HistoryRoot)
-		opts := []sdkhistory.BufferOption{}
+		store := c.historyStore
+		if store == nil {
+			store = memoryhistory.NewFileStore(c.ws, c.cfg.Workspace.HistoryRoot)
+		}
+		opts := []memoryhistory.BufferOption{}
 		if cfg.MaxMessages > 0 {
-			opts = append(opts, sdkhistory.WithBufferMax(cfg.MaxMessages))
+			opts = append(opts, memoryhistory.WithBufferMax(cfg.MaxMessages))
 		}
 		return &historyRuntime{
-			hist: sdkhistory.NewBuffer(store, opts...),
+			hist: memoryhistory.NewBuffer(store, opts...),
 			cfg:  cfg,
 		}, nil
 	case "compacted":
@@ -49,7 +52,7 @@ func (h *historyRuntime) load(ctx context.Context, contextID string) ([]model.Me
 	if h == nil || h.hist == nil || strings.TrimSpace(contextID) == "" {
 		return nil, nil
 	}
-	return h.hist.Load(ctx, contextID, sdkhistory.Budget{
+	return h.hist.Load(ctx, contextID, memoryhistory.Budget{
 		MaxMessages: h.cfg.MaxMessages,
 		MaxTokens:   h.cfg.MaxTokens,
 	})

--- a/sdkx/claw/history_test.go
+++ b/sdkx/claw/history_test.go
@@ -1,0 +1,220 @@
+package claw
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"sync"
+	"testing"
+
+	"github.com/GizClaw/flowcraft/sdk/model"
+	"github.com/GizClaw/flowcraft/sdk/workspace"
+)
+
+func TestHistoryUsesWorkspaceFileStoreByDefault(t *testing.T) {
+	ws := workspace.NewMemWorkspace()
+	writeHistoryTestConfig(t, ws, true, "custom-history")
+
+	app, err := New(ws)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	defer app.Close()
+
+	ctx := context.Background()
+	if err := app.history.appendTurn(ctx, "conversation", model.NewTextMessage(model.RoleUser, "hello"), []model.Message{
+		model.NewTextMessage(model.RoleAssistant, "hi"),
+	}); err != nil {
+		t.Fatalf("appendTurn: %v", err)
+	}
+
+	exists, err := ws.Exists(ctx, "custom-history/conversation/messages.jsonl")
+	if err != nil {
+		t.Fatalf("Exists: %v", err)
+	}
+	if !exists {
+		t.Fatal("default history file does not exist")
+	}
+}
+
+func TestHistoryUsesInjectedStoreWithoutWorkspacePrefix(t *testing.T) {
+	ws := workspace.NewMemWorkspace()
+	writeHistoryTestConfig(t, ws, true, "must-not-be-used")
+	store := newRecordingHistoryStore()
+
+	app, err := New(ws, WithHistoryStore(store))
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	defer app.Close()
+
+	ctx := context.Background()
+	want := []model.Message{
+		model.NewTextMessage(model.RoleUser, "hello"),
+		model.NewTextMessage(model.RoleAssistant, "hi"),
+	}
+	if err := app.history.appendTurn(ctx, "conversation", want[0], want[1:]); err != nil {
+		t.Fatalf("appendTurn: %v", err)
+	}
+	got, err := app.history.load(ctx, "conversation")
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("history = %#v, want %#v", got, want)
+	}
+
+	exists, err := ws.Exists(ctx, "must-not-be-used/conversation/messages.jsonl")
+	if err != nil {
+		t.Fatalf("Exists: %v", err)
+	}
+	if exists {
+		t.Fatal("injected Store unexpectedly wrote to workspace history root")
+	}
+}
+
+func TestDisabledHistoryDoesNotAccessInjectedStore(t *testing.T) {
+	ws := workspace.NewMemWorkspace()
+	writeHistoryTestConfig(t, ws, false, "history")
+	store := newRecordingHistoryStore()
+
+	app, err := New(ws, WithHistoryStore(store))
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	defer app.Close()
+
+	if app.history != nil {
+		t.Fatal("history runtime is enabled")
+	}
+	if got := store.callCount(); got != 0 {
+		t.Fatalf("injected Store calls = %d, want 0", got)
+	}
+}
+
+func TestNilHistoryStoreUsesWorkspaceDefault(t *testing.T) {
+	ws := workspace.NewMemWorkspace()
+	writeHistoryTestConfig(t, ws, true, "history")
+
+	app, err := New(ws, WithHistoryStore(nil))
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	defer app.Close()
+
+	ctx := context.Background()
+	if err := app.history.appendTurn(ctx, "conversation", model.NewTextMessage(model.RoleUser, "hello"), nil); err != nil {
+		t.Fatalf("appendTurn: %v", err)
+	}
+	exists, err := ws.Exists(ctx, "history/conversation/messages.jsonl")
+	if err != nil {
+		t.Fatalf("Exists: %v", err)
+	}
+	if !exists {
+		t.Fatal("default history file does not exist")
+	}
+}
+
+func TestInjectedHistoryStoreErrorsPropagate(t *testing.T) {
+	errLoad := errors.New("load failed")
+	errSave := errors.New("save failed")
+
+	for _, tc := range []struct {
+		name     string
+		store    *recordingHistoryStore
+		exercise func(*historyRuntime) error
+		want     error
+	}{
+		{
+			name:  "load",
+			store: &recordingHistoryStore{loadErr: errLoad},
+			exercise: func(history *historyRuntime) error {
+				_, err := history.load(context.Background(), "conversation")
+				return err
+			},
+			want: errLoad,
+		},
+		{
+			name:  "append",
+			store: &recordingHistoryStore{saveErr: errSave},
+			exercise: func(history *historyRuntime) error {
+				return history.appendTurn(context.Background(), "conversation", model.NewTextMessage(model.RoleUser, "hello"), nil)
+			},
+			want: errSave,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ws := workspace.NewMemWorkspace()
+			writeHistoryTestConfig(t, ws, true, "history")
+			app, err := New(ws, WithHistoryStore(tc.store))
+			if err != nil {
+				t.Fatalf("New: %v", err)
+			}
+			defer app.Close()
+
+			if err := tc.exercise(app.history); !errors.Is(err, tc.want) {
+				t.Fatalf("error = %v, want %v", err, tc.want)
+			}
+		})
+	}
+}
+
+func writeHistoryTestConfig(t *testing.T, ws workspace.Workspace, enabled bool, root string) {
+	t.Helper()
+	cfg := defaultConfig()
+	cfg.Memory.Enabled = false
+	cfg.History.Enabled = enabled
+	cfg.History.Kind = "buffer"
+	cfg.Workspace.HistoryRoot = root
+	writeTestConfig(t, ws, cfg)
+}
+
+type recordingHistoryStore struct {
+	mu       sync.Mutex
+	messages map[string][]model.Message
+	loadErr  error
+	saveErr  error
+	calls    int
+}
+
+func newRecordingHistoryStore() *recordingHistoryStore {
+	return &recordingHistoryStore{messages: make(map[string][]model.Message)}
+}
+
+func (s *recordingHistoryStore) GetMessages(_ context.Context, conversationID string) ([]model.Message, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.calls++
+	if s.loadErr != nil {
+		return nil, s.loadErr
+	}
+	return append([]model.Message(nil), s.messages[conversationID]...), nil
+}
+
+func (s *recordingHistoryStore) SaveMessages(_ context.Context, conversationID string, messages []model.Message) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.calls++
+	if s.saveErr != nil {
+		return s.saveErr
+	}
+	if s.messages == nil {
+		s.messages = make(map[string][]model.Message)
+	}
+	s.messages[conversationID] = append([]model.Message(nil), messages...)
+	return nil
+}
+
+func (s *recordingHistoryStore) DeleteMessages(_ context.Context, conversationID string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.calls++
+	delete(s.messages, conversationID)
+	return nil
+}
+
+func (s *recordingHistoryStore) callCount() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.calls
+}

--- a/sdkx/claw/options.go
+++ b/sdkx/claw/options.go
@@ -1,0 +1,32 @@
+package claw
+
+import memoryhistory "github.com/GizClaw/flowcraft/memory/history"
+
+type options struct {
+	historyStore memoryhistory.Store
+}
+
+// Option configures a Claw at construction time.
+type Option func(*options)
+
+// WithHistoryStore provides the persistence Store used when History is
+// enabled. A nil Store is ignored, leaving the Workspace-backed default in
+// place. The caller retains ownership of the Store and any resources behind
+// it.
+func WithHistoryStore(store memoryhistory.Store) Option {
+	return func(opts *options) {
+		if store != nil {
+			opts.historyStore = store
+		}
+	}
+}
+
+func resolveOptions(opts []Option) options {
+	var resolved options
+	for _, opt := range opts {
+		if opt != nil {
+			opt(&resolved)
+		}
+	}
+	return resolved
+}


### PR DESCRIPTION
## Summary

- add `claw.WithHistoryStore(memory/history.Store)` without changing existing `claw.New(ws)` callers
- use the injected Store only when History is enabled, otherwise retain the Workspace-backed `FileStore` and existing JSONL layout
- migrate Claw History wiring to the canonical `memory/history` package and cover default, injected, disabled, nil, and error behavior

## Validation

- `go test ./sdkx/claw/... -count=1`
- `go test -race ./sdkx/claw/... -count=1`
- `go test ./cmd/claw/... -count=1`
- `GOWORK=off go test ./... -count=1` from `sdkx/`
- `git diff --check`

Closes #228
