### PR TITLE
workflows: add OpenAI PR review

### DIFF
--- a/.github/workflows/openai-pr-review.yml
+++ b/.github/workflows/openai-pr-review.yml
@@ -1,0 +1,36 @@
+name: OpenAI PR review
+
+on:
+  pull_request:
+    types: [opened]
+  issue_comment:
+    types: [created]
+  workflow_dispatch:
+    inputs:
+      pull_request_number:
+        description: Open pull request to review.
+        required: true
+        type: string
+
+permissions:
+  checks: write
+  contents: read
+  issues: write
+  pull-requests: write
+
+concurrency:
+  group: openai-pr-review-${{ github.event.pull_request.number || github.event.issue.number || inputs.pull_request_number }}
+  cancel-in-progress: true
+
+jobs:
+  review:
+    uses: GizClaw/github-workflows/.github/workflows/codex-openai-review.yml@0.1.2
+    with:
+      model: gpt-5.6-terra
+      effort: medium
+      review-instructions: >-
+        Review only the pull-request diff and report actionable correctness,
+        security, regression, cross-module contract, and test-coverage findings.
+      pull_request_number: ${{ inputs.pull_request_number }}
+    secrets:
+      OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}


### PR DESCRIPTION
## What changed

Add the shared OpenAI PR review caller workflow for this GizClaw-maintained repository.

The workflow reviews newly opened PRs, accepts collaborator `@codex` review requests, supports manual dispatch, reports lifecycle through PR checks and comment reactions, and passes only `OPENAI_API_KEY` to the reusable workflow.

## Why

All GizClaw-owned code repositories should use the organization-managed reviewer. Upstream forks and mirrors are intentionally excluded.

## Validation

- `git diff --check`
- Workflow YAML parsed successfully
- Caller matches `GizClaw/github-workflows@0.1.2`