### PR TITLE
feat(release): automate changeset changelog PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,12 @@ name: CI
 on:
   pull_request:
     branches: [main]
+  workflow_dispatch:
+    inputs:
+      base_sha:
+        description: Base commit used for generated release PR validation
+        required: true
+        type: string
 
 permissions:
   contents: read
@@ -22,9 +28,13 @@ jobs:
       ci: ${{ steps.filter.outputs.ci }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - uses: dorny/paths-filter@v3
         id: filter
         with:
+          base: ${{ github.event_name == 'workflow_dispatch' && inputs.base_sha || '' }}
+          ref: ${{ github.event_name == 'workflow_dispatch' && github.sha || '' }}
           filters: |
             sdk:
               - 'sdk/**'
@@ -68,7 +78,7 @@ jobs:
         working-directory: tools/releasegate
         env:
           GOWORK: "off"
-          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          BASE_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || inputs.base_sha }}
         run: go run . validate --repo ../.. --base "$BASE_SHA"
 
       - name: Validate pending release plan
@@ -76,6 +86,13 @@ jobs:
         env:
           GOWORK: "off"
         run: go run . plan --repo ../..
+
+      - name: Validate generated release changelog
+        if: github.event_name == 'workflow_dispatch' || github.head_ref == 'automation/release-changelog'
+        working-directory: tools/releasegate
+        env:
+          GOWORK: "off"
+        run: go run . changelog --repo ../.. --check
 
   lint:
     name: Lint

--- a/.github/workflows/release-modules.yml
+++ b/.github/workflows/release-modules.yml
@@ -6,7 +6,9 @@ on:
   workflow_dispatch:
 
 permissions:
+  actions: write
   contents: write
+  pull-requests: write
 
 concurrency:
   group: release-modules
@@ -19,6 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       has_releases: ${{ steps.plan.outputs.has_releases }}
+      changelog_ready: ${{ steps.changelog.outputs.ready }}
       modules: ${{ steps.plan.outputs.modules }}
       tags: ${{ steps.plan.outputs.tags }}
     steps:
@@ -58,10 +61,109 @@ jobs:
             fi
           } >> "$GITHUB_OUTPUT"
 
+      - name: Prepare release changelog PR
+        id: changelog
+        if: steps.plan.outputs.has_releases == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_BRANCH: automation/release-changelog
+          TAGS_JSON: ${{ steps.plan.outputs.tags }}
+        run: |
+          set -euo pipefail
+          (
+            cd tools/releasegate
+            GOWORK=off go run . changelog --repo ../.. --write
+          )
+          if git diff --quiet -- CHANGELOG.md; then
+            while read -r tag; do
+              heading_line=$(awk -v heading="## \`$tag\` -" \
+                'index($0, heading) == 1 { print NR; exit }' CHANGELOG.md)
+              if [ -z "$heading_line" ]; then
+                echo "missing generated changelog heading for $tag" >&2
+                exit 1
+              fi
+              release_commit=$(git blame --porcelain \
+                -L "$heading_line,$heading_line" CHANGELOG.md |
+                awk 'NR == 1 { print $1 }')
+              release_commit=${release_commit#^}
+              release_pr_count=$(
+                gh api "repos/$GITHUB_REPOSITORY/commits/$release_commit/pulls" |
+                  jq --arg repo "$GITHUB_REPOSITORY" \
+                    --arg branch "$RELEASE_BRANCH" \
+                    'map(select(
+                      .head.repo.full_name == $repo and
+                      .head.ref == $branch and
+                      .base.ref == "main" and
+                      .merged_at != null
+                    )) | length'
+              )
+              if [ "$release_pr_count" -lt 1 ]; then
+                echo "generated changelog for $tag was not merged from $GITHUB_REPOSITORY:$RELEASE_BRANCH" >&2
+                exit 1
+              fi
+            done < <(jq -r '.[]' <<< "$TAGS_JSON")
+            echo "ready=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          git diff --check
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git switch -C "$RELEASE_BRANCH"
+          git add CHANGELOG.md
+          git commit -m "chore(release): update module changelog"
+
+          remote_tip=$(git ls-remote --heads origin \
+            "refs/heads/$RELEASE_BRANCH" | awk '{print $1}')
+          if [ -n "$remote_tip" ]; then
+            git fetch origin \
+              "refs/heads/$RELEASE_BRANCH:refs/remotes/origin/$RELEASE_BRANCH"
+            author_email=$(git show -s --format=%ae "$remote_tip")
+            subject=$(git show -s --format=%s "$remote_tip")
+            if [ "$author_email" != "41898282+github-actions[bot]@users.noreply.github.com" ] ||
+              [ "$subject" != "chore(release): update module changelog" ]; then
+              echo "$RELEASE_BRANCH contains a non-automation commit; refusing to overwrite it" >&2
+              exit 1
+            fi
+          fi
+          git push \
+            "--force-with-lease=refs/heads/$RELEASE_BRANCH:$remote_tip" \
+            origin \
+            "HEAD:refs/heads/$RELEASE_BRANCH"
+
+          pr_url=$(gh pr list \
+            --head "$RELEASE_BRANCH" \
+            --base main \
+            --state open \
+            --json url \
+            --jq '.[0].url // empty')
+          if [ -z "$pr_url" ]; then
+            body_file=$(mktemp)
+            {
+              echo "Aggregates all pending immutable changesets into \`CHANGELOG.md\`."
+              echo
+              echo "Planned tags:"
+              jq -r '.[] | \"- `\" + . + \"`\"' <<< "$TAGS_JSON"
+              echo
+              echo "Merging this PR reruns the module release gates and publishes all planned tags atomically."
+            } > "$body_file"
+            pr_url=$(gh pr create \
+              --base main \
+              --head "$RELEASE_BRANCH" \
+              --title "chore(release): update module changelog" \
+              --body-file "$body_file")
+          fi
+
+          gh workflow run ci.yml \
+            --ref "$RELEASE_BRANCH" \
+            --field "base_sha=$GITHUB_SHA"
+          echo "release changelog PR: $pr_url"
+          echo "ready=false" >> "$GITHUB_OUTPUT"
+
   gate:
     name: Gate ${{ matrix.release.module }} (Go ${{ matrix.go-version }})
     needs: plan
-    if: needs.plan.outputs.has_releases == 'true'
+    if: needs.plan.outputs.has_releases == 'true' && needs.plan.outputs.changelog_ready == 'true'
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -153,7 +255,7 @@ jobs:
   retrieval-e2e:
     name: Release gate / retrieval e2e
     needs: [plan, gate]
-    if: needs.plan.outputs.has_releases == 'true' && (contains(needs.plan.outputs.modules, '"module":"sdk"') || contains(needs.plan.outputs.modules, '"module":"memory"') || contains(needs.plan.outputs.modules, '"module":"sdkx"'))
+    if: needs.plan.outputs.has_releases == 'true' && needs.plan.outputs.changelog_ready == 'true' && (contains(needs.plan.outputs.modules, '"module":"sdk"') || contains(needs.plan.outputs.modules, '"module":"memory"') || contains(needs.plan.outputs.modules, '"module":"sdkx"'))
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -166,7 +268,7 @@ jobs:
   eval:
     name: Release gate / hermetic eval
     needs: [plan, gate]
-    if: needs.plan.outputs.has_releases == 'true' && (contains(needs.plan.outputs.modules, '"module":"sdk"') || contains(needs.plan.outputs.modules, '"module":"memory"') || contains(needs.plan.outputs.modules, '"module":"sdkx"'))
+    if: needs.plan.outputs.has_releases == 'true' && needs.plan.outputs.changelog_ready == 'true' && (contains(needs.plan.outputs.modules, '"module":"sdk"') || contains(needs.plan.outputs.modules, '"module":"memory"') || contains(needs.plan.outputs.modules, '"module":"sdkx"'))
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -179,7 +281,7 @@ jobs:
   tag:
     name: Publish module tags
     needs: [plan, gate, retrieval-e2e, eval]
-    if: always() && needs.plan.outputs.has_releases == 'true'
+    if: always() && needs.plan.outputs.has_releases == 'true' && needs.plan.outputs.changelog_ready == 'true'
     runs-on: ubuntu-latest
     steps:
       - name: Require every release gate
@@ -213,6 +315,7 @@ jobs:
           set -euo pipefail
           (
             cd tools/releasegate
+            GOWORK=off go run . changelog --repo ../.. --check
             GOWORK=off go run . plan --repo ../.. --json
           ) > /tmp/release-plan.json
           actual_tags=$(jq -c '.tags' /tmp/release-plan.json)

--- a/.release/README.md
+++ b/.release/README.md
@@ -1,6 +1,8 @@
 # Release changesets
 
-每个 `.release/*.json` 文件都是不可变的发布意图。文件合入后不得修改、重命名或删除；后续修正应新增 changeset。
+Each `.release/*.json` file is an immutable release intent. After it reaches
+`main`, do not modify, rename, or delete it. Add another changeset to correct
+the intent.
 
 ```json
 {
@@ -14,15 +16,18 @@
 }
 ```
 
-- `summary` 必须是非空单行字符串，且不能包含 releasegate 保留 marker。
-- `releases` 至少包含一项。
-- `module` 只能是 `sdk`、`memory`、`sdkx` 或 `voice`。
-- `bump` 只能是 `patch` 或 `minor`。
-- 同一文件中不能重复声明同一模块。
-- 多个未消费 changeset 声明同一模块时，发布计划采用最高 bump（`minor` 高于 `patch`）。
-- changeset 是否已消费由文件是否存在于对应模块的最新 `module/vX.Y.Z` tag 中决定。
+- `summary` must be a non-empty single line and must not contain the reserved
+  releasegate marker.
+- `releases` must contain at least one entry.
+- `module` must be `sdk`, `memory`, `sdkx`, or `voice`.
+- `bump` must be `patch` or `minor`.
+- A changeset cannot declare the same module more than once.
+- Multiple pending changesets for one module use the highest bump (`minor`
+  outranks `patch`).
+- A changeset is consumed for a module when that file exists in the module's
+  latest `module/vX.Y.Z` tag.
 
-CLI 是独立 Go module。从仓库根目录运行：
+The CLI is a standalone Go module. Run these commands from the repository root:
 
 ```sh
 make release-check
@@ -31,13 +36,22 @@ make release-plan
 make release-changelog
 ```
 
-`plan --json` 输出模块计划、GitHub Actions matrix 和待创建 tags。若没有未消费的发布意图，命令成功并输出空数组。
+`plan --json` prints the module plan, GitHub Actions matrix, and tags to create.
+With no pending release intent, it succeeds with empty arrays.
 
-changeset 合入 `main` 后，`Release modules` workflow 会聚合所有待处理
-`summary`，更新 `CHANGELOG.md` 的模块版本表和 release sections，并创建或
-更新 `automation/release-changelog` Release PR。该 PR 的内容由
-`make release-changelog` 确定；通常不需要在功能 PR 中手动提交生成结果。
+After a changeset reaches `main`, the `Release modules` workflow aggregates all
+pending summaries, updates the module-version table and release sections in
+`CHANGELOG.md`, and opens or refreshes the
+`automation/release-changelog` Release PR. `make release-changelog` determines
+that PR's content; feature PRs normally do not commit the generated output.
 
-Release PR 合并后，workflow 会再次验证 changelog、执行模块 gates，并在全部
-检查通过后原子创建所有计划 tags。Release PR 未合并、changelog 不一致或任一
-gate 失败时均不会创建 tag。
+Merging the Release PR makes the workflow validate the changelog again and run
+the module gates. It creates every planned tag atomically only after all checks
+pass. An unmerged Release PR, a changelog mismatch, or any failed gate creates
+no tags.
+
+Pending sections converge before publication: if a failed batch receives more
+changesets, releasegate replaces that module's untagged section with the newly
+aggregated section. Once a real tag exists, its changelog section becomes
+historical and is never rewritten. Changeset files themselves remain in the
+repository because tag containment is the consumption ledger.

--- a/.release/README.md
+++ b/.release/README.md
@@ -14,7 +14,7 @@
 }
 ```
 
-- `summary` 必须是非空字符串。
+- `summary` 必须是非空单行字符串，且不能包含 releasegate 保留 marker。
 - `releases` 至少包含一项。
 - `module` 只能是 `sdk`、`memory`、`sdkx` 或 `voice`。
 - `bump` 只能是 `patch` 或 `minor`。
@@ -28,6 +28,16 @@ CLI 是独立 Go module。从仓库根目录运行：
 make release-check
 make release-check BASE=origin/main
 make release-plan
+make release-changelog
 ```
 
 `plan --json` 输出模块计划、GitHub Actions matrix 和待创建 tags。若没有未消费的发布意图，命令成功并输出空数组。
+
+changeset 合入 `main` 后，`Release modules` workflow 会聚合所有待处理
+`summary`，更新 `CHANGELOG.md` 的模块版本表和 release sections，并创建或
+更新 `automation/release-changelog` Release PR。该 PR 的内容由
+`make release-changelog` 确定；通常不需要在功能 PR 中手动提交生成结果。
+
+Release PR 合并后，workflow 会再次验证 changelog、执行模块 gates，并在全部
+检查通过后原子创建所有计划 tags。Release PR 未合并、changelog 不一致或任一
+gate 失败时均不会创建 tag。

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,8 @@ All notable changes to this repository are documented here. FlowCraft is a
 multi-module monorepo; each Go module is released independently with its own tag
 prefix, for example `sdk/vX.Y.Z`, `memory/vX.Y.Z`, and `sdkx/vX.Y.Z`.
 
-Per-release artifacts and generated notes also live on the
-[GitHub Releases](https://github.com/GizClaw/flowcraft/releases) page.
+Pending changesets are aggregated into module release sections by the automated
+Release PR before their tags are published.
 
 ## Current Published State
 
@@ -25,6 +25,8 @@ Per-release artifacts and generated notes also live on the
 - Retired the `vessel` runtime and `vesseld` daemon from the active source
   tree, CI, release automation, examples, and documentation. Existing tags and
   release artifacts are retained as historical, unsupported releases.
+
+<!-- releasegate:releases -->
 
 ## `sdk/v0.4.0` - 2026-05-30
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -54,9 +54,14 @@ the versions being planned in the same batch. The dependency order is
 make release-plan
 ```
 
-On `main`, the release workflow validates each planned module independently
-with `GOWORK=off`, including tidy, build, vet, and race tests. Relevant
-`sdk`/`memory`/`sdkx` batches also run retrieval E2E and hermetic evals. Only
-after every required gate succeeds are all module tags pushed atomically.
-Failed runs create no tags and are retried by the next push to `main` or a
-manual workflow dispatch.
+After a changeset reaches `main`, automation aggregates its summaries into
+`CHANGELOG.md` and opens or updates the `automation/release-changelog` Release
+PR. Feature PRs should not commit this generated changelog update. Maintainers
+can reproduce it locally with `make release-changelog`.
+
+When the Release PR merges, the release workflow validates each planned module
+independently with `GOWORK=off`, including tidy, build, vet, and race tests.
+Relevant `sdk`/`memory`/`sdkx` batches also run retrieval E2E and hermetic
+evals. Only after the generated changelog and every required gate succeed are
+all module tags pushed atomically. Failed runs create no tags and are retried
+by the next push to `main` or a manual workflow dispatch.

--- a/Makefile
+++ b/Makefile
@@ -45,6 +45,7 @@ help:
 	@echo "  make release-check  Test release tooling, validate changesets, and"
 	@echo "                      verify the pending module release plan."
 	@echo "  make release-plan   Print the pending module release plan as JSON."
+	@echo "  make release-changelog  Aggregate pending changesets into CHANGELOG.md."
 	@echo ""
 	@echo "Test suites under tests/ (default 'make test' already runs them"
 	@echo "in compile-check / no-credential mode; the targets below are the"
@@ -104,6 +105,10 @@ release-check:
 .PHONY: release-plan
 release-plan:
 	@cd tools/releasegate && GOWORK=off go run . plan --repo ../.. --json
+
+.PHONY: release-changelog
+release-changelog:
+	@cd tools/releasegate && GOWORK=off go run . changelog --repo ../.. --write
 
 # `make test-e2e` runs the build-tagged retrieval workspace suite.
 # CI runs it explicitly via `make ci-e2e` (or by adding it to a

--- a/README.md
+++ b/README.md
@@ -244,9 +244,10 @@ Issues and pull requests are welcome. Before opening a PR:
 
 Library releases are declared explicitly with immutable `.release/*.json`
 changesets for `sdk`, `memory`, `sdkx`, and `voice`; a changeset is optional for
-ordinary PRs. After merge, each pending module passes isolated tidy, build, vet,
-and race-test gates before all planned tags are pushed atomically. Claw remains
-source-only and does not receive module tags. See
+ordinary PRs. After merge, automation aggregates pending summaries into a
+Release PR that updates `CHANGELOG.md`. Merging that PR runs isolated tidy,
+build, vet, and race-test gates before all planned tags are pushed atomically.
+Claw remains source-only and does not receive module tags. See
 [`CONTRIBUTING.md`](CONTRIBUTING.md) for the contract and coordinated dependency
 rules.
 

--- a/tools/releasegate/main.go
+++ b/tools/releasegate/main.go
@@ -15,6 +15,8 @@ import (
 	"strings"
 )
 
+const changelogMarker = "<!-- releasegate:releases -->"
+
 var moduleOrder = []string{"sdk", "memory", "sdkx", "voice"}
 
 var moduleDependencies = map[string][]string{
@@ -71,7 +73,7 @@ func main() {
 
 func runCLI(args []string, stdout, stderr io.Writer) int {
 	if len(args) == 0 {
-		fmt.Fprintln(stderr, "usage: releasegate <validate|plan> [options]")
+		fmt.Fprintln(stderr, "usage: releasegate <validate|plan|changelog> [options]")
 		return 2
 	}
 
@@ -130,8 +132,56 @@ func runCLI(args []string, stdout, stderr io.Writer) int {
 		}
 		return 0
 
+	case "changelog":
+		flags := flag.NewFlagSet("changelog", flag.ContinueOnError)
+		flags.SetOutput(stderr)
+		repo := flags.String("repo", ".", "repository root")
+		check := flags.Bool("check", false, "verify CHANGELOG.md is current")
+		write := flags.Bool("write", false, "write CHANGELOG.md")
+		if err := flags.Parse(args[1:]); err != nil {
+			return 2
+		}
+		if flags.NArg() != 0 {
+			fmt.Fprintln(stderr, "changelog does not accept positional arguments")
+			return 2
+		}
+		if *check && *write {
+			fmt.Fprintln(stderr, "changelog --check and --write are mutually exclusive")
+			return 2
+		}
+		content, err := buildChangelog(*repo)
+		if err != nil {
+			fmt.Fprintf(stderr, "releasegate changelog: %v\n", err)
+			return 1
+		}
+		path := filepath.Join(*repo, "CHANGELOG.md")
+		if *check {
+			current, err := os.ReadFile(path)
+			if err != nil {
+				fmt.Fprintf(stderr, "releasegate changelog: read CHANGELOG.md: %v\n", err)
+				return 1
+			}
+			if !bytes.Equal(current, content) {
+				fmt.Fprintln(stderr, "releasegate changelog: CHANGELOG.md is out of date; run changelog --write")
+				return 1
+			}
+			return 0
+		}
+		if *write {
+			if err := atomicWriteFile(path, content); err != nil {
+				fmt.Fprintf(stderr, "releasegate changelog: %v\n", err)
+				return 1
+			}
+			return 0
+		}
+		if _, err := stdout.Write(content); err != nil {
+			fmt.Fprintf(stderr, "releasegate changelog: write output: %v\n", err)
+			return 1
+		}
+		return 0
+
 	default:
-		fmt.Fprintf(stderr, "unknown command %q; usage: releasegate <validate|plan> [options]\n", args[0])
+		fmt.Fprintf(stderr, "unknown command %q; usage: releasegate <validate|plan|changelog> [options]\n", args[0])
 		return 2
 	}
 }
@@ -212,8 +262,15 @@ func loadChangesets(repo string) ([]Changeset, error) {
 			return nil, fmt.Errorf("%s: invalid JSON: %w", relativePath(repo, path), err)
 		}
 		changeset.file = relativePath(repo, path)
-		if strings.TrimSpace(changeset.Summary) == "" {
+		changeset.Summary = strings.TrimSpace(changeset.Summary)
+		if changeset.Summary == "" {
 			return nil, fmt.Errorf("%s: summary must be non-empty", changeset.file)
+		}
+		if strings.ContainsAny(changeset.Summary, "\r\n") {
+			return nil, fmt.Errorf("%s: summary must be a single line", changeset.file)
+		}
+		if strings.Contains(changeset.Summary, changelogMarker) {
+			return nil, fmt.Errorf("%s: summary contains reserved changelog marker", changeset.file)
 		}
 		if len(changeset.Releases) == 0 {
 			return nil, fmt.Errorf("%s: releases must contain at least one release", changeset.file)
@@ -330,6 +387,263 @@ func buildPlan(repo string) (Plan, error) {
 		empty.Tags = append(empty.Tags, item.Tag)
 	}
 	return empty, nil
+}
+
+func buildChangelog(repo string) ([]byte, error) {
+	plan, err := buildPlan(repo)
+	if err != nil {
+		return nil, err
+	}
+	path := filepath.Join(repo, "CHANGELOG.md")
+	current, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read CHANGELOG.md: %w", err)
+	}
+	if len(plan.Modules) == 0 {
+		return current, nil
+	}
+
+	markerCount := bytes.Count(current, []byte(changelogMarker))
+	if markerCount != 1 {
+		return nil, fmt.Errorf("CHANGELOG.md must contain exactly one %s marker; found %d", changelogMarker, markerCount)
+	}
+	changesets, err := loadChangesets(repo)
+	if err != nil {
+		return nil, err
+	}
+	byFile := make(map[string]Changeset, len(changesets))
+	for _, changeset := range changesets {
+		byFile[changeset.file] = changeset
+	}
+
+	content := string(current)
+	content, err = removeUnpublishedSections(repo, content, plan.Modules)
+	if err != nil {
+		return nil, err
+	}
+	var additions []string
+	for _, item := range plan.Modules {
+		date, summaries, err := changelogRelease(repo, item, byFile)
+		if err != nil {
+			return nil, err
+		}
+		section := formatReleaseSection(item.Tag, date, summaries)
+		additions = append(additions, section)
+	}
+
+	content, err = updatePublishedState(content, plan.Modules)
+	if err != nil {
+		return nil, err
+	}
+	if len(additions) != 0 {
+		index := strings.Index(content, changelogMarker) + len(changelogMarker)
+		insertion := "\n\n" + strings.Join(additions, "\n\n")
+		content = content[:index] + insertion + content[index:]
+	}
+	return []byte(content), nil
+}
+
+type changelogSectionSpan struct {
+	start int
+	end   int
+	tag   string
+}
+
+func removeUnpublishedSections(repo, changelog string, modules []ModulePlan) (string, error) {
+	pending := make(map[string]bool, len(modules))
+	for _, item := range modules {
+		pending[item.Module] = true
+	}
+	output, err := git(repo, "tag", "--list")
+	if err != nil {
+		return "", fmt.Errorf("list tags: %w", err)
+	}
+	existingTags := make(map[string]bool)
+	for _, tag := range strings.Fields(output) {
+		existingTags[tag] = true
+	}
+
+	var headings []int
+	for offset := 0; offset < len(changelog); {
+		end := strings.IndexByte(changelog[offset:], '\n')
+		if end < 0 {
+			end = len(changelog) - offset
+		}
+		line := changelog[offset : offset+end]
+		if strings.HasPrefix(line, "## ") {
+			headings = append(headings, offset)
+		}
+		offset += end + 1
+	}
+
+	var candidates []changelogSectionSpan
+	for index, start := range headings {
+		lineEnd := strings.IndexByte(changelog[start:], '\n')
+		if lineEnd < 0 {
+			lineEnd = len(changelog) - start
+		}
+		tag, module, ok := releaseHeading(changelog[start : start+lineEnd])
+		if !ok || !pending[module] {
+			continue
+		}
+		end := len(changelog)
+		if index+1 < len(headings) {
+			end = headings[index+1]
+		}
+		candidates = append(candidates, changelogSectionSpan{start: start, end: end, tag: tag})
+	}
+
+	var removals []changelogSectionSpan
+	for _, candidate := range candidates {
+		if !existingTags[candidate.tag] {
+			removals = append(removals, candidate)
+		}
+	}
+	for index := len(removals) - 1; index >= 0; index-- {
+		span := removals[index]
+		changelog = changelog[:span.start] + changelog[span.end:]
+	}
+	return changelog, nil
+}
+
+func releaseHeading(line string) (tag, module string, ok bool) {
+	const prefix = "## `"
+	const separator = "` - "
+	if !strings.HasPrefix(line, prefix) {
+		return "", "", false
+	}
+	end := strings.Index(line[len(prefix):], separator)
+	if end < 0 {
+		return "", "", false
+	}
+	tag = line[len(prefix) : len(prefix)+end]
+	slash := strings.Index(tag, "/v")
+	if slash <= 0 {
+		return "", "", false
+	}
+	return tag, tag[:slash], true
+}
+
+func changelogRelease(repo string, item ModulePlan, changesets map[string]Changeset) (string, []string, error) {
+	var latestDate string
+	var summaries []string
+	seen := make(map[string]bool)
+	for _, file := range item.Replaces {
+		changeset, ok := changesets[file]
+		if !ok {
+			return "", nil, fmt.Errorf("module %s references missing changeset %s", item.Module, file)
+		}
+		output, err := git(repo, "log", "-1", "--format=%cs", "--", file)
+		if err != nil {
+			return "", nil, fmt.Errorf("find commit date for %s: %w", file, err)
+		}
+		date := strings.TrimSpace(output)
+		if date == "" {
+			return "", nil, fmt.Errorf("%s has no commit date", file)
+		}
+		if date > latestDate {
+			latestDate = date
+		}
+		belongs := false
+		for _, release := range changeset.Releases {
+			if release.Module == item.Module {
+				belongs = true
+				break
+			}
+		}
+		if belongs && !seen[changeset.Summary] {
+			seen[changeset.Summary] = true
+			summaries = append(summaries, changeset.Summary)
+		}
+	}
+	return latestDate, summaries, nil
+}
+
+func formatReleaseSection(tag, date string, summaries []string) string {
+	var builder strings.Builder
+	fmt.Fprintf(&builder, "## `%s` - %s\n\n### Changed\n\n", tag, date)
+	for _, summary := range summaries {
+		fmt.Fprintf(&builder, "- %s\n", summary)
+	}
+	return strings.TrimSuffix(builder.String(), "\n")
+}
+
+func updatePublishedState(changelog string, modules []ModulePlan) (string, error) {
+	tags := make(map[string]string, len(modules))
+	for _, item := range modules {
+		tags[item.Module] = item.Tag
+	}
+	lines := strings.Split(changelog, "\n")
+	tableStart := -1
+	tableEnd := len(lines)
+	for index, line := range lines {
+		if line == "## Current Published State" {
+			tableStart = index + 1
+			continue
+		}
+		if tableStart >= 0 && strings.HasPrefix(line, "## ") {
+			tableEnd = index
+			break
+		}
+	}
+	if tableStart < 0 {
+		return "", errors.New("CHANGELOG.md has no Current Published State section")
+	}
+	updated := make(map[string]bool, len(tags))
+	for index := tableStart; index < tableEnd; index++ {
+		line := lines[index]
+		for module, tag := range tags {
+			prefix := "| `" + module + "` |"
+			if !strings.HasPrefix(line, prefix) {
+				continue
+			}
+			cells := strings.Split(line, "|")
+			if len(cells) < 5 {
+				return "", fmt.Errorf("invalid Current Published State row for module %s", module)
+			}
+			cells[2] = " `" + tag + "` "
+			lines[index] = strings.Join(cells, "|")
+			updated[module] = true
+		}
+	}
+	for module := range tags {
+		if !updated[module] {
+			return "", fmt.Errorf("Current Published State has no row for module %s", module)
+		}
+	}
+	return strings.Join(lines, "\n"), nil
+}
+
+func atomicWriteFile(path string, content []byte) error {
+	info, err := os.Stat(path)
+	if err != nil {
+		return fmt.Errorf("stat %s: %w", path, err)
+	}
+	file, err := os.CreateTemp(filepath.Dir(path), ".releasegate-changelog-*")
+	if err != nil {
+		return fmt.Errorf("create temporary changelog: %w", err)
+	}
+	tempPath := file.Name()
+	defer os.Remove(tempPath)
+	if err := file.Chmod(info.Mode().Perm()); err != nil {
+		file.Close()
+		return fmt.Errorf("set temporary changelog permissions: %w", err)
+	}
+	if _, err := file.Write(content); err != nil {
+		file.Close()
+		return fmt.Errorf("write temporary changelog: %w", err)
+	}
+	if err := file.Sync(); err != nil {
+		file.Close()
+		return fmt.Errorf("sync temporary changelog: %w", err)
+	}
+	if err := file.Close(); err != nil {
+		return fmt.Errorf("close temporary changelog: %w", err)
+	}
+	if err := os.Rename(tempPath, path); err != nil {
+		return fmt.Errorf("replace CHANGELOG.md: %w", err)
+	}
+	return nil
 }
 
 func latestModuleTag(repo, module string) (tagVersion, error) {

--- a/tools/releasegate/main_test.go
+++ b/tools/releasegate/main_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 )
@@ -22,6 +23,8 @@ func TestLoadChangesetsRejectsInvalidContracts(t *testing.T) {
 		{"duplicate module", `{"summary":"x","releases":[{"module":"sdk","bump":"patch"},{"module":"sdk","bump":"minor"}]}`, "duplicate"},
 		{"unknown field", `{"summary":"x","releases":[{"module":"sdk","bump":"patch"}],"extra":true}`, "unknown field"},
 		{"empty releases", `{"summary":"x","releases":[]}`, "release"},
+		{"multiline summary", "{\"summary\":\"first\\nsecond\",\"releases\":[{\"module\":\"sdk\",\"bump\":\"patch\"}]}", "single line"},
+		{"reserved marker", `{"summary":"break <!-- releasegate:releases --> parsing","releases":[{"module":"sdk","bump":"patch"}]}`, "reserved"},
 	}
 
 	for _, tt := range tests {
@@ -203,6 +206,281 @@ func TestPlanEmptySetAndCLIJSON(t *testing.T) {
 	}
 }
 
+func TestChangelogSingleModuleUsesPlanTagAndUpdatesState(t *testing.T) {
+	repo := changelogRepo(t, "sdk", "1.2.3")
+	writeFile(t, repo, "sdk/change.go", "package sdk\n\nconst Changed = true\n")
+	writeFile(t, repo, ".release/z-patch.json", validChangeset("patch fix", "sdk", "patch"))
+	writeFile(t, repo, ".release/a-minor.json", validChangeset("minor feature", "sdk", "minor"))
+	commitAllAt(t, repo, "changes", "2026-07-25T12:00:00Z")
+
+	got, err := buildChangelog(repo)
+	if err != nil {
+		t.Fatal(err)
+	}
+	text := string(got)
+	assertContains(t, text, "| `sdk` | `sdk/v1.3.0` |")
+	assertContains(t, text, "## `sdk/v1.3.0` - 2026-07-25\n\n### Changed\n\n- minor feature\n- patch fix\n")
+	if strings.Index(text, "- minor feature") > strings.Index(text, "- patch fix") {
+		t.Fatal("bullets must follow stable changeset filename order")
+	}
+}
+
+func TestChangelogAssignsMultiModuleSummariesAndDeduplicates(t *testing.T) {
+	repo := changelogRepo(t, "sdk", "1.0.0")
+	seedModule(t, repo, "voice", "require github.com/GizClaw/flowcraft/sdk v1.0.0\n")
+	commitAll(t, repo, "seed voice")
+	gitRun(t, repo, "tag", "voice/v2.0.0")
+	changelogPath := filepath.Join(repo, "CHANGELOG.md")
+	changelog, err := os.ReadFile(changelogPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	writeFile(t, repo, "CHANGELOG.md", strings.Replace(string(changelog), "| `vessel`", "| `voice` | `voice/v2.0.0` | Active. |\n| `vessel`", 1))
+	writeFile(t, repo, "sdk/change.go", "package sdk\n\nconst Changed = true\n")
+	writeFile(t, repo, "voice/change.go", "package voice\n\nconst Changed = true\n")
+	writeFile(t, repo, "voice/go.mod", moduleFile("voice", "require github.com/GizClaw/flowcraft/sdk v1.0.1\n"))
+	writeFile(t, repo, ".release/a.json", `{"summary":"shared","releases":[{"module":"sdk","bump":"patch"},{"module":"voice","bump":"patch"}]}`)
+	writeFile(t, repo, ".release/b.json", validChangeset("sdk only", "sdk", "patch"))
+	writeFile(t, repo, ".release/c.json", validChangeset("shared", "sdk", "patch"))
+	commitAllAt(t, repo, "changes", "2026-07-24T12:00:00Z")
+
+	got, err := buildChangelog(repo)
+	if err != nil {
+		t.Fatal(err)
+	}
+	text := string(got)
+	sdk := changelogSection(t, text, "sdk/v1.0.1")
+	voice := changelogSection(t, text, "voice/v2.0.1")
+	if strings.Count(sdk, "- shared\n") != 1 || !strings.Contains(sdk, "- sdk only\n") {
+		t.Fatalf("sdk section = %q", sdk)
+	}
+	if strings.Count(voice, "- shared\n") != 1 || strings.Contains(voice, "sdk only") {
+		t.Fatalf("voice section = %q", voice)
+	}
+}
+
+func TestChangelogUsesLatestChangesetCommitDate(t *testing.T) {
+	repo := changelogRepo(t, "sdk", "1.0.0")
+	writeFile(t, repo, "sdk/change.go", "package sdk\n\nconst Changed = true\n")
+	writeFile(t, repo, ".release/a.json", validChangeset("first", "sdk", "patch"))
+	commitAllAt(t, repo, "first", "2026-07-20T12:00:00Z")
+	writeFile(t, repo, ".release/b.json", validChangeset("second", "sdk", "patch"))
+	commitAllAt(t, repo, "second", "2026-07-26T12:00:00Z")
+
+	got, err := buildChangelog(repo)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertContains(t, string(got), "## `sdk/v1.0.1` - 2026-07-26")
+}
+
+func TestChangelogIsIdempotentAndRepairsExistingSection(t *testing.T) {
+	repo := changelogRepo(t, "sdk", "1.0.0")
+	writeFile(t, repo, "sdk/change.go", "package sdk\n\nconst Changed = true\n")
+	writeFile(t, repo, ".release/a.json", validChangeset("change", "sdk", "patch"))
+	commitAllAt(t, repo, "change", "2026-07-25T12:00:00Z")
+
+	first, err := buildChangelog(repo)
+	if err != nil {
+		t.Fatal(err)
+	}
+	writeFile(t, repo, "CHANGELOG.md", string(first))
+	second, err := buildChangelog(repo)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(first, second) {
+		t.Fatal("second changelog generation changed content")
+	}
+
+	writeFile(t, repo, "CHANGELOG.md", strings.Replace(string(first), "- change", "- wrong", 1))
+	repaired, err := buildChangelog(repo)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(first, repaired) {
+		t.Fatalf("repaired changelog differs from expected:\n%s", repaired)
+	}
+}
+
+func TestChangelogRebuildsUntaggedSectionWhenSummaryAndDateChange(t *testing.T) {
+	repo := changelogRepo(t, "sdk", "1.0.0")
+	writeFile(t, repo, "sdk/change.go", "package sdk\n\nconst Changed = true\n")
+	writeFile(t, repo, ".release/a.json", validChangeset("first", "sdk", "patch"))
+	commitAllAt(t, repo, "first", "2026-07-20T12:00:00Z")
+
+	first, err := buildChangelog(repo)
+	if err != nil {
+		t.Fatal(err)
+	}
+	writeFile(t, repo, "CHANGELOG.md", string(first))
+	writeFile(t, repo, ".release/b.json", validChangeset("second", "sdk", "patch"))
+	commitAllAt(t, repo, "second", "2026-07-26T12:00:00Z")
+
+	got, err := buildChangelog(repo)
+	if err != nil {
+		t.Fatal(err)
+	}
+	text := string(got)
+	if strings.Count(text, "## `sdk/v1.0.1`") != 1 {
+		t.Fatalf("expected one rebuilt section:\n%s", text)
+	}
+	assertContains(t, text, "## `sdk/v1.0.1` - 2026-07-26\n\n### Changed\n\n- first\n- second\n")
+	writeFile(t, repo, "CHANGELOG.md", text)
+	again, err := buildChangelog(repo)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(got, again) {
+		t.Fatal("rebuilt changelog is not byte-idempotent")
+	}
+}
+
+func TestChangelogRemovesOldUntaggedPatchSectionAfterMinorBump(t *testing.T) {
+	repo := changelogRepo(t, "sdk", "1.0.0")
+	writeFile(t, repo, "sdk/change.go", "package sdk\n\nconst Changed = true\n")
+	writeFile(t, repo, ".release/a.json", validChangeset("patch", "sdk", "patch"))
+	commitAllAt(t, repo, "patch", "2026-07-20T12:00:00Z")
+
+	patchChangelog, err := buildChangelog(repo)
+	if err != nil {
+		t.Fatal(err)
+	}
+	writeFile(t, repo, "CHANGELOG.md", string(patchChangelog))
+	writeFile(t, repo, ".release/b.json", validChangeset("minor", "sdk", "minor"))
+	commitAllAt(t, repo, "minor", "2026-07-26T12:00:00Z")
+
+	got, err := buildChangelog(repo)
+	if err != nil {
+		t.Fatal(err)
+	}
+	text := string(got)
+	if strings.Contains(text, "## `sdk/v1.0.1`") {
+		t.Fatalf("stale untagged patch section remains:\n%s", text)
+	}
+	assertContains(t, text, "## `sdk/v1.1.0` - 2026-07-26\n\n### Changed\n\n- patch\n- minor\n")
+	assertContains(t, text, "| `sdk` | `sdk/v1.1.0` |")
+}
+
+func TestChangelogPreservesTaggedHistoricalSection(t *testing.T) {
+	repo := changelogRepo(t, "sdk", "1.0.0")
+	writeFile(t, repo, "sdk/change.go", "package sdk\n\nconst First = true\n")
+	writeFile(t, repo, ".release/a.json", validChangeset("first", "sdk", "patch"))
+	commitAllAt(t, repo, "first", "2026-07-20T12:00:00Z")
+
+	released, err := buildChangelog(repo)
+	if err != nil {
+		t.Fatal(err)
+	}
+	taggedSection := changelogSection(t, string(released), "sdk/v1.0.1")
+	writeFile(t, repo, "CHANGELOG.md", string(released))
+	commitAllAt(t, repo, "release changelog", "2026-07-21T12:00:00Z")
+	gitRun(t, repo, "tag", "sdk/v1.0.1")
+
+	writeFile(t, repo, "sdk/change.go", "package sdk\n\nconst First = true\nconst Second = true\n")
+	writeFile(t, repo, ".release/b.json", validChangeset("second", "sdk", "patch"))
+	commitAllAt(t, repo, "second", "2026-07-26T12:00:00Z")
+
+	got, err := buildChangelog(repo)
+	if err != nil {
+		t.Fatal(err)
+	}
+	text := string(got)
+	if section := changelogSection(t, text, "sdk/v1.0.1"); section != taggedSection {
+		t.Fatalf("tagged section changed:\nwant:\n%s\ngot:\n%s", taggedSection, section)
+	}
+	assertContains(t, text, "## `sdk/v1.0.2` - 2026-07-26\n\n### Changed\n\n- second\n")
+}
+
+func TestChangelogRejectsMissingMarkerAndUncommittedChangeset(t *testing.T) {
+	t.Run("missing marker", func(t *testing.T) {
+		repo := changelogRepo(t, "sdk", "1.0.0")
+		writeFile(t, repo, "CHANGELOG.md", strings.Replace(changelogFixture("sdk", "1.0.0"), changelogMarker+"\n", "", 1))
+		writeFile(t, repo, "sdk/change.go", "package sdk\n\nconst Changed = true\n")
+		writeFile(t, repo, ".release/a.json", validChangeset("change", "sdk", "patch"))
+		commitAllAt(t, repo, "change", "2026-07-25T12:00:00Z")
+		if _, err := buildChangelog(repo); err == nil || !strings.Contains(err.Error(), "marker") {
+			t.Fatalf("buildChangelog() error = %v, want marker error", err)
+		}
+	})
+
+	t.Run("uncommitted changeset", func(t *testing.T) {
+		repo := changelogRepo(t, "sdk", "1.0.0")
+		writeFile(t, repo, "sdk/change.go", "package sdk\n\nconst Changed = true\n")
+		writeFile(t, repo, ".release/a.json", validChangeset("change", "sdk", "patch"))
+		if _, err := buildChangelog(repo); err == nil || !strings.Contains(err.Error(), "commit date") {
+			t.Fatalf("buildChangelog() error = %v, want commit date error", err)
+		}
+	})
+}
+
+func TestChangelogEmptyPlanIsNoOp(t *testing.T) {
+	repo := initRepo(t)
+	body := "# Changelog\n\nNo release marker is needed yet.\n"
+	writeFile(t, repo, "CHANGELOG.md", body)
+	got, err := buildChangelog(repo)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != body {
+		t.Fatalf("buildChangelog() = %q, want unchanged", got)
+	}
+}
+
+func TestChangelogCLIPrintCheckAndWrite(t *testing.T) {
+	repo := changelogRepo(t, "sdk", "1.0.0")
+	writeFile(t, repo, "sdk/change.go", "package sdk\n\nconst Changed = true\n")
+	writeFile(t, repo, ".release/a.json", validChangeset("change", "sdk", "patch"))
+	commitAllAt(t, repo, "change", "2026-07-25T12:00:00Z")
+
+	var stdout, stderr bytes.Buffer
+	if code := runCLI([]string{"changelog", "--repo", repo}, &stdout, &stderr); code != 0 {
+		t.Fatalf("print code = %d, stderr = %s", code, stderr.String())
+	}
+	expected := stdout.String()
+	if code := runCLI([]string{"changelog", "--repo", repo, "--check"}, &stdout, &stderr); code == 0 ||
+		!strings.Contains(stderr.String(), "--write") {
+		t.Fatalf("check should fail before write: code=%d stderr=%q", code, stderr.String())
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	if code := runCLI([]string{"changelog", "--repo", repo, "--write"}, &stdout, &stderr); code != 0 {
+		t.Fatalf("write code = %d, stderr = %s", code, stderr.String())
+	}
+	data, err := os.ReadFile(filepath.Join(repo, "CHANGELOG.md"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data) != expected {
+		t.Fatalf("written changelog differs from printed output")
+	}
+	if code := runCLI([]string{"changelog", "--repo", repo, "--check"}, &stdout, &stderr); code != 0 {
+		t.Fatalf("check after write code = %d, stderr = %s", code, stderr.String())
+	}
+	if code := runCLI([]string{"changelog", "--repo", repo, "--check", "--write"}, &stdout, &stderr); code != 2 {
+		t.Fatalf("mutually exclusive flags code = %d, want 2", code)
+	}
+}
+
+func TestChangelogOnlyUpdatesActiveModuleRows(t *testing.T) {
+	repo := changelogRepo(t, "sdk", "1.0.0")
+	writeFile(t, repo, "sdk/change.go", "package sdk\n\nconst Changed = true\n")
+	writeFile(t, repo, ".release/a.json", validChangeset("change", "sdk", "patch"))
+	commitAllAt(t, repo, "change", "2026-07-25T12:00:00Z")
+	before := changelogFixture("sdk", "1.0.0")
+	got, err := buildChangelog(repo)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(
+		tableLine(string(got), "`vessel`"),
+		tableLine(before, "`vessel`"),
+	) {
+		t.Fatal("retired row changed")
+	}
+}
+
 func initRepo(t *testing.T) string {
 	t.Helper()
 	repo := t.TempDir()
@@ -243,6 +521,70 @@ func commitAll(t *testing.T, repo, message string) {
 	t.Helper()
 	gitRun(t, repo, "add", "-A")
 	gitRun(t, repo, "commit", "-q", "-m", message)
+}
+
+func commitAllAt(t *testing.T, repo, message, date string) {
+	t.Helper()
+	gitRun(t, repo, "add", "-A")
+	cmd := exec.Command("git", "-C", repo, "commit", "-q", "-m", message)
+	cmd.Env = append(os.Environ(), "GIT_AUTHOR_DATE="+date, "GIT_COMMITTER_DATE="+date)
+	if output, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git commit: %v\n%s", err, output)
+	}
+}
+
+func changelogRepo(t *testing.T, module, version string) string {
+	t.Helper()
+	repo := initRepo(t)
+	seedModule(t, repo, module, "")
+	writeFile(t, repo, "CHANGELOG.md", changelogFixture(module, version))
+	commitAll(t, repo, "seed module and changelog")
+	if module != "sdk" || version != "0.1.0" {
+		gitRun(t, repo, "tag", "sdk/v0.1.0")
+	}
+	gitRun(t, repo, "tag", module+"/v"+version)
+	return repo
+}
+
+func changelogFixture(module, version string) string {
+	return "# Changelog\n\n" +
+		"## Current Published State\n\n" +
+		"| Module | Latest tag | Notes |\n" +
+		"| --- | --- | --- |\n" +
+		"| `" + module + "` | `" + module + "/v" + version + "` | Active. |\n" +
+		"| `vessel` | `vessel/v0.3.0` | Retired. |\n\n" +
+		"## [Unreleased]\n\n- Pending notes stay here.\n\n" +
+		changelogMarker + "\n\n" +
+		"## `sdk/v0.1.0` - 2026-01-01\n\nHistorical text must stay byte-for-byte unchanged.\n"
+}
+
+func changelogSection(t *testing.T, changelog, tag string) string {
+	t.Helper()
+	start := strings.Index(changelog, "## `"+tag+"`")
+	if start < 0 {
+		t.Fatalf("missing section for %s", tag)
+	}
+	rest := changelog[start:]
+	if next := strings.Index(rest[3:], "\n## "); next >= 0 {
+		return rest[:next+3]
+	}
+	return rest
+}
+
+func tableLine(body, module string) string {
+	for _, line := range strings.Split(body, "\n") {
+		if strings.HasPrefix(line, "| "+module+" |") {
+			return line
+		}
+	}
+	return ""
+}
+
+func assertContains(t *testing.T, got, want string) {
+	t.Helper()
+	if !strings.Contains(got, want) {
+		t.Fatalf("missing %q in:\n%s", want, got)
+	}
 }
 
 func gitRun(t *testing.T, repo string, args ...string) {


### PR DESCRIPTION
## Summary

Pending changesets can now produce durable release notes without bypassing `main` branch protection.

- Aggregates immutable changeset summaries into deterministic per-module `CHANGELOG.md` sections and updates the published-version table.
- Opens or refreshes a protected `automation/release-changelog` Release PR after release intent reaches `main`.
- Runs required CI explicitly on the bot-created PR, whose `GITHUB_TOKEN` push would otherwise suppress recursive workflows.
- Publishes tags only after every planned section is traced to a merged Release PR from this repository and all module gates pass.
- Rebuilds still-unpublished sections when a failed release batch absorbs later changesets, while preserving sections backed by real tags.

No changeset is included in this PR, so merging it does not create a Release PR or module tags.

## Validation

- `make ci`
- `make test-e2e`
- `make release-check`
- `make release-plan`
- `GOWORK=off go test -count=1 -race ./...` in `tools/releasegate`
- `GOWORK=off go vet ./...` in `tools/releasegate`
- `actionlint`
- `git diff --check`
- Structured adversarial and simplification reviews; no unresolved P1/P2 findings

The GitHub-hosted create/update/merge cycle cannot be exercised safely before this workflow exists on `main`; its event, permission, provenance, lease, and failure paths were validated statically and with fixture-backed CLI tests.

## Post-Deploy Monitoring & Validation

- **Window/owner:** repository maintainers should observe the first changeset-bearing merge through completion of its generated Release PR.
- **Logs:** inspect the `Release modules` run for `Prepare release changelog PR`, `Validate generated release changelog`, and `Publish module tags`.
- **Healthy signals:** exactly one open `automation/release-changelog` PR, required `CI` attached to its head SHA, deterministic changelog output, and tags appearing only after that PR merges.
- **Failure signals:** missing/duplicate Release PRs, a refused force lease, provenance rejection, red changelog check, or any tag appearing before Release PR merge.
- **Mitigation:** do not create tags manually; inspect the automation branch ownership/provenance, correct the changeset or workflow defect, then rerun `Release modules`. Atomic publication ensures a failed retry leaves zero partial tags.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
