### PR TITLE
refactor(sdk,sdkx)!: move graph agent factory to sdk/graph/config

### DIFF
--- a/docs/guides/deploy.md
+++ b/docs/guides/deploy.md
@@ -248,7 +248,7 @@ import (
     "github.com/GizClaw/flowcraft/sdk/agent"
     "github.com/GizClaw/flowcraft/sdk/message"
     "github.com/GizClaw/flowcraft/sdkx/deploy"
-    graphagent "github.com/GizClaw/flowcraft/sdkx/agent/graph"
+    graphconfig "github.com/GizClaw/flowcraft/sdk/graph/config"
     inferenceconfig "github.com/GizClaw/flowcraft/sdk/inference/config"
 )
 
@@ -256,7 +256,7 @@ func main() {
     ctx := context.Background()
 
     engines := agent.NewRegistry()
-    engines.MustRegister(graphagent.NewFactory())
+    engines.MustRegister(graphconfig.NewFactory())
 
     builder := deploy.NewBuilder(engines)
     // Register the inference resource; pass your provider factory and
@@ -430,7 +430,7 @@ agents:
 
 ### Engines
 
-The graph engine (`sdkx/agent/graph`) is the built-in. Its
+The graph engine (`sdk/graph/config`) is the built-in. Its
 settings accept a graph definition by file path, by explicit
 `{file: ...}`, or by `{inline: ...}`:
 
@@ -623,7 +623,7 @@ toolBuilder := toolconfig.NewBuilder(toolconfig.Deps{})
 toolBuilder.RegisterBuiltins(tooldelegation.New(directory)...)
 
 engines := agent.NewRegistry()
-engines.MustRegister(graphagent.NewFactory(graphagent.WithBaseDir(configDir)))
+engines.MustRegister(graphconfig.NewFactory(graphconfig.WithBaseDir(configDir)))
 
 builder := deploy.NewBuilder(engines, deploy.WithBaseDir(configDir))
 builder.MustRegisterResource(toolconfig.NewDeployFactory(toolBuilder))
@@ -828,7 +828,7 @@ The host owns execution behavior; `Result` owns the bus lifecycle.
 
 ```go
 engines := agent.NewRegistry()
-engines.MustRegister(graphagent.NewFactory(graphagent.WithBaseDir(configDir)))
+engines.MustRegister(graphconfig.NewFactory(graphconfig.WithBaseDir(configDir)))
 
 builder := deploy.NewBuilder(engines)
 
@@ -974,7 +974,7 @@ factory is registered.
 
 For full turn-level tests (the engine, the host, the hook chain),
 see `sdkx/delegation/integration_test.go` and the engine-specific packages
-(`sdkx/agent/graph`). The deploy layer itself is
+(`sdk/graph/config`). The deploy layer itself is
 hermetic: a `Build` over a parsed document does not perform network
 I/O unless a resource factory does (e.g. an inference provider that
 warms up its catalog on first use).
@@ -989,7 +989,7 @@ warms up its catalog on first use).
   `sdk/sandbox/config/doc.go`, `sdk/inference/config/doc.go`,
   `sdk/tool/config/doc.go`, `sdk/event/config/resource.go`,
   `sdk/memory/config/doc.go`.
-- Engine contract: `sdk/agent/doc.go`, `sdkx/agent/graph/factory.go`.
+- Engine contract: `sdk/agent/doc.go`, `sdk/graph/config/factory.go`.
 - Delegation contracts and local runtime: `sdk/delegation/doc.go`,
   `sdkx/delegation/doc.go`, `sdkx/tool/delegation/doc.go`.
 - Lifecycle hooks: `sdk/agent/doc.go` (`Preparer`, `Referee`,

--- a/docs/guides/graph.md
+++ b/docs/guides/graph.md
@@ -225,7 +225,7 @@ cancel a branch through the `parallel.cancelNode` bridge.
 
 ## Deploy integration
 
-`sdkx/agent/graph` ships the production factory used by the `graph` engine
+`sdk/graph/config` ships the production factory used by the `graph` engine
 kind in deployment documents. It wires the standard node factories
 (inference, tool, script) and exposes the canonical dependency names:
 
@@ -288,7 +288,7 @@ type is registered.
 - Package contract: `sdk/graph/doc.go` (the four layers in detail).
 - Standard node types: `sdk/graph/nodes/doc.go`,
   `sdk/graph/nodes/script/node.go`.
-- Production factory: `sdkx/agent/graph/factory.go`.
+- Production factory: `sdk/graph/config/factory.go`.
 - Board and run contract: `sdk/agent/board.go`, `sdk/agent/execute.go`
   (`Run` / `Identity`).
 - Engine wiring in deployment documents:

--- a/docs/guides/runtime.md
+++ b/docs/guides/runtime.md
@@ -147,12 +147,13 @@ Aliases used below: `sdkscheduler` =
 `github.com/GizClaw/flowcraft/sdk/inference/config`, `memoryconfig` =
 `github.com/GizClaw/flowcraft/sdk/memory/config`, `flowcraftmemory` =
 `github.com/GizClaw/flowcraft/memory/config`, `flowcraftruntime` =
-`github.com/GizClaw/flowcraft/memory/runtime`, and `message` =
+`github.com/GizClaw/flowcraft/memory/runtime`, `graphconfig` =
+`github.com/GizClaw/flowcraft/sdk/graph/config`, and `message` =
 `github.com/GizClaw/flowcraft/sdk/message`.
 
 ```go
 engines := agent.NewRegistry()
-engines.MustRegister(graphagent.NewFactory(graphagent.WithBaseDir(configDir)))
+engines.MustRegister(graphconfig.NewFactory(graphconfig.WithBaseDir(configDir)))
 
 deployBuilder := deploy.NewBuilder(engines, deploy.WithBaseDir(configDir))
 deployBuilder.MustRegisterResource(eventconfig.NewMemoryDeployFactory())

--- a/examples/forge/internal/app/assemble.go
+++ b/examples/forge/internal/app/assemble.go
@@ -9,13 +9,13 @@ import (
 	flowcraftruntime "github.com/GizClaw/flowcraft/memory/runtime"
 	"github.com/GizClaw/flowcraft/sdk/agent"
 	eventconfig "github.com/GizClaw/flowcraft/sdk/event/config"
+	graphconfig "github.com/GizClaw/flowcraft/sdk/graph/config"
 	inferenceconfig "github.com/GizClaw/flowcraft/sdk/inference/config"
 	envresolver "github.com/GizClaw/flowcraft/sdk/inference/config/env"
 	memoryconfig "github.com/GizClaw/flowcraft/sdk/memory/config"
 	schedulerconfig "github.com/GizClaw/flowcraft/sdk/scheduler/config"
 	toolconfig "github.com/GizClaw/flowcraft/sdk/tool/config"
 	workspaceconfig "github.com/GizClaw/flowcraft/sdk/workspace/config"
-	graphagent "github.com/GizClaw/flowcraft/sdkx/agent/graph"
 	jsrt "github.com/GizClaw/flowcraft/sdkx/agent/jsrt"
 	kanbanconfig "github.com/GizClaw/flowcraft/sdkx/delegation/kanban/config"
 	"github.com/GizClaw/flowcraft/sdkx/deploy"
@@ -36,7 +36,7 @@ import (
 
 func buildRuntimeFromDocument(ctx context.Context, a *App, doc deploy.Document) (*runtimecore.Runtime, error) {
 	engines := agent.NewRegistry()
-	engines.MustRegister(graphagent.NewFactory(graphagent.WithBaseDir(a.dir)))
+	engines.MustRegister(graphconfig.NewFactory(graphconfig.WithBaseDir(a.dir)))
 	simtools.Register(a.tools, &a.toolCalls)
 
 	deployBuilder := deploy.NewBuilder(engines, deploy.WithBaseDir(a.dir))

--- a/sdk/graph/config/factory.go
+++ b/sdk/graph/config/factory.go
@@ -1,5 +1,7 @@
-// Package graphagent provides the production agent.Factory for sdk/graph.
-package graphagent
+// Package config assembles graph agents: it provides the production
+// agent.Factory for sdk/graph and is the graph domain's deployment
+// configuration assembly.
+package config
 
 import (
 	"bytes"

--- a/sdk/graph/config/factory_test.go
+++ b/sdk/graph/config/factory_test.go
@@ -1,4 +1,4 @@
-package graphagent
+package config
 
 import (
 	"context"

--- a/sdkx/deploy/graph_factory_test.go
+++ b/sdkx/deploy/graph_factory_test.go
@@ -5,14 +5,14 @@ import (
 	"testing"
 
 	"github.com/GizClaw/flowcraft/sdk/agent"
-	graphagent "github.com/GizClaw/flowcraft/sdkx/agent/graph"
+	graphconfig "github.com/GizClaw/flowcraft/sdk/graph/config"
 	"github.com/GizClaw/flowcraft/sdkx/agent/jsrt"
 	"github.com/GizClaw/flowcraft/sdkx/deploy"
 )
 
 func TestGraphFactoryJavaScriptDeployment(t *testing.T) {
 	engines := agent.NewRegistry()
-	engines.MustRegister(graphagent.NewFactory())
+	engines.MustRegister(graphconfig.NewFactory())
 	builder := deploy.NewBuilder(engines)
 	builder.MustRegisterResource(jsrt.NewDeployFactory())
 

--- a/sdkx/scheduler/scheduler_test.go
+++ b/sdkx/scheduler/scheduler_test.go
@@ -535,41 +535,70 @@ func TestCompleteRetentionRejectsDeadlineBeyondServerMaximum(t *testing.T) {
 }
 
 func TestRuleReplaceAndRemoveShareTriggerGate(t *testing.T) {
-	server, _ := newTestServer(t)
-	key := scheduleKey{namespace: "race", id: "job"}
-	if err := server.PutRule(context.Background(), rule("race", "job", sdkscheduler.OverlapAllow)); err != nil {
-		t.Fatal(err)
-	}
-	server.mu.Lock()
-	old := server.rules[key]
-	server.mu.Unlock()
-	gate := server.gateForKey(key)
-	gate.Lock()
-	fired := make(chan struct{})
-	go func() {
+	t.Run("replace drops admitted stale fire", func(t *testing.T) {
+		store := &blockingRuleStore{
+			memoryRuleStore: &memoryRuleStore{rules: make(map[scheduleKey]sdkscheduler.Rule)},
+		}
+		server, err := NewLocalServer(WithRuleStore(store))
+		if err != nil {
+			t.Fatal(err)
+		}
+		t.Cleanup(func() { _ = server.Close() })
+		key := scheduleKey{namespace: "race", id: "job"}
+		if err := server.PutRule(context.Background(), rule("race", "job", sdkscheduler.OverlapAllow)); err != nil {
+			t.Fatal(err)
+		}
+		server.mu.Lock()
+		old := server.rules[key]
+		server.mu.Unlock()
+
+		store.saveEntered = make(chan struct{})
+		store.continueSave = make(chan struct{})
+		replaced := rule("race", "job", sdkscheduler.OverlapAllow)
+		replaced.Task = task("new")
+		replaceDone := make(chan error, 1)
+		go func() { replaceDone <- server.PutRule(context.Background(), replaced) }()
+		<-store.saveEntered
+
+		fired := make(chan struct{})
+		go func() {
+			server.fireRule(key, old, old.generation)
+			close(fired)
+		}()
+		if delivery := claim(t, server, "race", time.Minute); delivery != nil {
+			t.Fatalf("fire passed trigger gate before replacement completed: %+v", delivery)
+		}
+		close(store.continueSave)
+		if err := <-replaceDone; err != nil {
+			t.Fatal(err)
+		}
+		<-fired
+		if delivery := claim(t, server, "race", time.Minute); delivery != nil {
+			t.Fatalf("replaced generation queued stale fire: %+v", delivery)
+		}
+	})
+
+	t.Run("delete leaves queued execution", func(t *testing.T) {
+		server, _ := newTestServer(t)
+		key := scheduleKey{namespace: "race", id: "job"}
+		if err := server.PutRule(context.Background(), rule("race", "job", sdkscheduler.OverlapAllow)); err != nil {
+			t.Fatal(err)
+		}
+		server.mu.Lock()
+		old := server.rules[key]
+		server.mu.Unlock()
 		server.fireRule(key, old, old.generation)
-		close(fired)
-	}()
-	time.Sleep(10 * time.Millisecond)
-	replaced := rule("race", "job", sdkscheduler.OverlapAllow)
-	replaced.Task = task("new")
-	replaceDone := make(chan error, 1)
-	go func() { replaceDone <- server.PutRule(context.Background(), replaced) }()
-	gate.Unlock()
-	<-fired
-	if err := <-replaceDone; err != nil {
-		t.Fatal(err)
-	}
-	if err := server.DeleteRule(context.Background(), "race", "job"); err != nil {
-		t.Fatal(err)
-	}
-	server.fireRule(key, old, old.generation)
-	if delivery := claim(t, server, "race", time.Minute); delivery == nil {
-		t.Fatal("delete canceled an execution already queued before removal")
-	}
-	if extra := claim(t, server, "race", time.Minute); extra != nil {
-		t.Fatalf("removed generation queued extra work: %+v", extra)
-	}
+		if err := server.DeleteRule(context.Background(), "race", "job"); err != nil {
+			t.Fatal(err)
+		}
+		server.fireRule(key, old, old.generation)
+		if delivery := claim(t, server, "race", time.Minute); delivery == nil {
+			t.Fatal("delete canceled an execution already queued before removal")
+		}
+		if extra := claim(t, server, "race", time.Minute); extra != nil {
+			t.Fatalf("removed generation queued extra work: %+v", extra)
+		}
+	})
 }
 
 type memoryRuleStore struct {


### PR DESCRIPTION
Migrates the graph agent factory from sdkx/agent/graph to sdk/graph/config as graph-domain configuration assembly.

Changes:
- New package sdk/graph/config (package config), preserving the exported API (NewFactory, options, dep names).
- Removed sdkx/agent/graph.
- Updated examples/forge, the sdkx/deploy integration test, and the deploy/graph/runtime guides to the new import path.

Breaking change: existing imports of sdkx/agent/graph must switch to sdk/graph/config.

Validated with go test ./sdk/..., go test ./sdkx/..., go test ./examples/forge/... and make release-check. Release changeset intentionally not included per request; add before publishing.