### PR TITLE
refactor(sdk/memory): declare resource deps at registration

### DIFF
--- a/docs/guides/deploy.md
+++ b/docs/guides/deploy.md
@@ -522,8 +522,9 @@ A `memory.Assembly` is bound **whole** as the hooks' `memory` dependency
 that need the raw stores can address the implementation's exposed item — with
 the flowcraft implementation it is `system`, i.e. `memories/system`.
 
-The memory resource requires a workspace and the inference runtime item
-exported by the inference assembly:
+The flowcraft implementation requires a workspace and the inference runtime
+item exported by the inference assembly (deps are declared by the
+implementation at registration, not by the `sdk/memory` protocol):
 
 ```yaml
 # deploy.yaml

--- a/docs/guides/memory.md
+++ b/docs/guides/memory.md
@@ -215,17 +215,25 @@ the implementation factory by name, mirroring inference provider factories:
 ```go
 import (
     flowcraftmemory "github.com/GizClaw/flowcraft/memory/config"
+    sdkconfig "github.com/GizClaw/flowcraft/sdk/config"
     memoryconfig "github.com/GizClaw/flowcraft/sdk/memory/config"
 )
 
 deployBuilder.MustRegisterResource(
-    memoryconfig.NewDeployFactory("flowcraft", flowcraftmemory.Factory()),
+    memoryconfig.NewDeployFactory(
+        "flowcraft",
+        flowcraftmemory.Factory(),
+        sdkconfig.ResourceDepSpec{Name: "inference", Type: "inference.Runtime", Required: true},
+        sdkconfig.ResourceDepSpec{Name: "workspace", Type: "workspace.Workspace", Required: true},
+    ),
 )
 ```
 
-The resource requires a workspace (for the canonical stores) and an
-`inference.Runtime` (for generation and embeddings), and exposes its system
-as the `system` item:
+The `sdk/memory` protocol itself hard-codes no dependencies: each
+implementation declares the resource deps it needs at registration, and the
+factory type-asserts them. The flowcraft implementation requires a workspace
+(for the canonical stores) and an `inference.Runtime` (for generation and
+embeddings), and exposes its system as the `system` item:
 
 ```yaml
 resources:

--- a/docs/guides/runtime.md
+++ b/docs/guides/runtime.md
@@ -148,7 +148,8 @@ Aliases used below: `sdkscheduler` =
 `github.com/GizClaw/flowcraft/sdk/memory/config`, `flowcraftmemory` =
 `github.com/GizClaw/flowcraft/memory/config`, `flowcraftruntime` =
 `github.com/GizClaw/flowcraft/memory/runtime`, `graphconfig` =
-`github.com/GizClaw/flowcraft/sdk/graph/config`, and `message` =
+`github.com/GizClaw/flowcraft/sdk/graph/config`, `sdkconfig` =
+`github.com/GizClaw/flowcraft/sdk/config`, and `message` =
 `github.com/GizClaw/flowcraft/sdk/message`.
 
 ```go
@@ -169,7 +170,12 @@ deployBuilder.MustRegisterResource(kanbanconfig.NewMemoryDeployFactory())
 workspaceBuilder := workspaceconfig.NewBuilder(workspaceconfig.Deps{BaseDir: configDir})
 deployBuilder.MustRegisterResource(workspaceconfig.NewDeployFactory(workspaceBuilder))
 deployBuilder.MustRegisterResource(inferenceconfig.NewDeployFactory(providerFactories, secretResolvers))
-deployBuilder.MustRegisterResource(memoryconfig.NewDeployFactory("flowcraft", flowcraftmemory.Factory()))
+deployBuilder.MustRegisterResource(memoryconfig.NewDeployFactory(
+    "flowcraft",
+    flowcraftmemory.Factory(),
+    sdkconfig.ResourceDepSpec{Name: "inference", Type: "inference.Runtime", Required: true},
+    sdkconfig.ResourceDepSpec{Name: "workspace", Type: "workspace.Workspace", Required: true},
+))
 
 tools := tool.NewRegistry()
 delegationFactory, err := delegationruntime.NewFactory(tools)

--- a/examples/forge/internal/app/assemble.go
+++ b/examples/forge/internal/app/assemble.go
@@ -8,6 +8,7 @@ import (
 	flowcraftmemory "github.com/GizClaw/flowcraft/memory/config"
 	flowcraftruntime "github.com/GizClaw/flowcraft/memory/runtime"
 	"github.com/GizClaw/flowcraft/sdk/agent"
+	sdkconfig "github.com/GizClaw/flowcraft/sdk/config"
 	eventconfig "github.com/GizClaw/flowcraft/sdk/event/config"
 	graphconfig "github.com/GizClaw/flowcraft/sdk/graph/config"
 	inferenceconfig "github.com/GizClaw/flowcraft/sdk/inference/config"
@@ -64,7 +65,12 @@ func buildRuntimeFromDocument(ctx context.Context, a *App, doc deploy.Document) 
 	factories := providerFactories()
 	resolvers := map[string]inferenceconfig.SecretResolver{"env": envresolver.New()}
 	deployBuilder.MustRegisterResource(inferenceconfig.NewDeployFactory(factories, resolvers))
-	deployBuilder.MustRegisterResource(memoryconfig.NewDeployFactory("flowcraft", flowcraftmemory.Factory()))
+	deployBuilder.MustRegisterResource(memoryconfig.NewDeployFactory(
+		"flowcraft",
+		flowcraftmemory.Factory(),
+		sdkconfig.ResourceDepSpec{Name: "inference", Type: "inference.Runtime", Required: true},
+		sdkconfig.ResourceDepSpec{Name: "workspace", Type: "workspace.Workspace", Required: true},
+	))
 	deployBuilder.RegisterPreparer(memoryhook.ContextType, memoryhook.ContextPreparerFactory)
 	deployBuilder.RegisterCommitter(memoryhook.TurnType, memoryhook.TurnCommitterFactory)
 

--- a/memory/config/factory.go
+++ b/memory/config/factory.go
@@ -2,10 +2,12 @@ package config
 
 import (
 	"context"
-	"errors"
 
 	"github.com/GizClaw/flowcraft/sdk/config/utils"
+	"github.com/GizClaw/flowcraft/sdk/errdefs"
+	"github.com/GizClaw/flowcraft/sdk/inference"
 	sdkmemory "github.com/GizClaw/flowcraft/sdk/memory"
+	"github.com/GizClaw/flowcraft/sdk/workspace"
 )
 
 func decodeSettings(data []byte) (Settings, error) {
@@ -15,19 +17,34 @@ func decodeSettings(data []byte) (Settings, error) {
 // Factory returns the flowcraft memory implementation factory. It is
 // registered by applications into the generic sdk/memory assembly,
 // mirroring how inference provider factories are registered.
+//
+// The flowcraft implementation consumes two deployment dependencies:
+//   - "inference" (*inference.Runtime, required);
+//   - "workspace" (workspace.Workspace, required until the storage
+//     backend refactor replaces workspace-backed stores with Log/KV).
 func Factory() sdkmemory.Factory {
 	return sdkmemory.FactoryFunc(func(ctx context.Context, input sdkmemory.Input) (sdkmemory.Assembly, error) {
-		if input.Workspace == nil {
-			return nil, errors.New("memory config: workspace is required")
+		rawInference, ok := input.Deps["inference"]
+		if !ok {
+			return nil, errdefs.NotFoundf("memory config: dependency \"inference\" is required")
 		}
-		if input.Inference == nil {
-			return nil, errors.New("memory config: inference runtime is required")
+		runtime, ok := rawInference.(*inference.Runtime)
+		if !ok || runtime == nil {
+			return nil, errdefs.Validationf("memory config: dependency \"inference\" has wrong type")
+		}
+		rawWorkspace, ok := input.Deps["workspace"]
+		if !ok {
+			return nil, errdefs.NotFoundf("memory config: dependency \"workspace\" is required")
+		}
+		ws, ok := rawWorkspace.(workspace.Workspace)
+		if !ok || nilInterface(ws) {
+			return nil, errdefs.Validationf("memory config: dependency \"workspace\" has wrong type")
 		}
 		settings, err := decodeSettings(input.Settings)
 		if err != nil {
 			return nil, err
 		}
-		builder, err := NewBuilder(input.Workspace, input.Inference)
+		builder, err := NewBuilder(ws, runtime)
 		if err != nil {
 			return nil, err
 		}

--- a/memory/config/factory_test.go
+++ b/memory/config/factory_test.go
@@ -1,0 +1,77 @@
+package config
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	sdkmemory "github.com/GizClaw/flowcraft/sdk/memory"
+	"github.com/GizClaw/flowcraft/sdk/workspace"
+)
+
+func TestFactoryRejectsMissingDeps(t *testing.T) {
+	factory := Factory()
+	if _, err := factory.New(context.Background(), sdkmemory.Input{}); err == nil {
+		t.Fatal("New succeeded without deps")
+	} else if !strings.Contains(err.Error(), "inference") {
+		t.Fatalf("missing inference error = %v", err)
+	}
+	runtime, _, _ := testRuntime(t)
+	if _, err := factory.New(context.Background(), sdkmemory.Input{
+		Deps: map[string]any{"inference": runtime},
+	}); err == nil {
+		t.Fatal("New succeeded without workspace")
+	} else if !strings.Contains(err.Error(), "workspace") {
+		t.Fatalf("missing workspace error = %v", err)
+	}
+}
+
+func TestFactoryRejectsWrongDepTypes(t *testing.T) {
+	factory := Factory()
+	if _, err := factory.New(context.Background(), sdkmemory.Input{
+		Deps: map[string]any{
+			"inference": "not a runtime",
+			"workspace": workspace.NewMemWorkspace(),
+		},
+	}); err == nil {
+		t.Fatal("New accepted a non-runtime inference dep")
+	}
+	runtime, _, _ := testRuntime(t)
+	if _, err := factory.New(context.Background(), sdkmemory.Input{
+		Deps: map[string]any{
+			"inference": runtime,
+			"workspace": "not a workspace",
+		},
+	}); err == nil {
+		t.Fatal("New accepted a non-workspace workspace dep")
+	}
+}
+
+func TestFactoryBuildsAssemblyFromDeps(t *testing.T) {
+	runtime, _, _ := testRuntime(t)
+	// Wire-format settings: durations are strings, so marshal through the
+	// JSON protocol instead of the Go struct (Duration only unmarshals).
+	settings := []byte(`{
+		"generate": {"provider": "fake", "name": "generate"},
+		"embed": {"provider": "fake", "name": "embed"},
+		"scopes": [{"runtime_id": "memory", "user_id": "tenant"}]
+	}`)
+	assembly, err := Factory().New(context.Background(), sdkmemory.Input{
+		Settings: settings,
+		Deps: map[string]any{
+			"inference": runtime,
+			"workspace": workspace.NewMemWorkspace(),
+		},
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	built, ok := assembly.(*Assembly)
+	if !ok {
+		t.Fatalf("New returned %T, want *Assembly", assembly)
+	}
+	defer built.Close()
+	if built.System == nil {
+		t.Fatal("assembly has no system")
+	}
+}

--- a/sdk/memory/assembly.go
+++ b/sdk/memory/assembly.go
@@ -2,9 +2,6 @@ package memory
 
 import (
 	"context"
-
-	"github.com/GizClaw/flowcraft/sdk/inference"
-	"github.com/GizClaw/flowcraft/sdk/workspace"
 )
 
 // Assembly is the memory capability contract a deployment binds to:
@@ -24,10 +21,15 @@ type Assembly interface {
 // implementation-owned settings document to a memory Factory. Settings
 // is the raw settings sub-document (typically the memory.yaml bytes);
 // its schema belongs to the implementation, not to this package.
+//
+// Deps holds resolved dependencies keyed by the names the implementation
+// declared when it registered. This package deliberately knows nothing
+// about those names or types: each implementation (such as the flowcraft
+// memory module) names and type-asserts its own dependencies, exactly
+// like inference provider factories.
 type Input struct {
-	Workspace workspace.Workspace
-	Inference *inference.Runtime
-	Settings  []byte
+	Settings []byte
+	Deps     map[string]any
 }
 
 // Factory builds one Assembly from deployment inputs. Implementations

--- a/sdk/memory/config/doc.go
+++ b/sdk/memory/config/doc.go
@@ -2,5 +2,7 @@
 // resources. It knows only the sdk/memory contracts; every concrete
 // implementation (such as the flowcraft memory module) lives in its own
 // module and is registered here by the application, exactly like
-// inference provider factories.
+// inference provider factories. The deployment dependencies an
+// implementation needs are declared at registration through
+// NewDeployFactory; this package never hard-codes them.
 package config

--- a/sdk/memory/config/resource.go
+++ b/sdk/memory/config/resource.go
@@ -6,9 +6,7 @@ import (
 
 	sdkconfig "github.com/GizClaw/flowcraft/sdk/config"
 	"github.com/GizClaw/flowcraft/sdk/errdefs"
-	"github.com/GizClaw/flowcraft/sdk/inference"
 	sdkmemory "github.com/GizClaw/flowcraft/sdk/memory"
-	"github.com/GizClaw/flowcraft/sdk/workspace"
 )
 
 // ResourceKind is the deployment resource category for memory
@@ -24,6 +22,7 @@ type ResourceSettings struct {
 type deployFactory struct {
 	impl    string
 	factory sdkmemory.Factory
+	deps    []sdkconfig.ResourceDepSpec
 }
 
 // NewDeployFactory returns a deployment factory for one memory
@@ -35,8 +34,22 @@ type deployFactory struct {
 //	    kind: memory.Assembly
 //	    impl: flowcraft
 //	    settings: {file: ./memory.yaml}
-func NewDeployFactory(impl string, factory sdkmemory.Factory) sdkconfig.ResourceFactory {
-	return &deployFactory{impl: impl, factory: factory}
+//
+// Deps declares the resource dependencies the implementation needs; the
+// sdk/memory protocol itself never hard-codes them. The flowcraft
+// implementation, for example, registers "inference" and "workspace"
+// here. Every bound dependency is forwarded to the implementation
+// factory, which names and type-asserts its own dependencies.
+func NewDeployFactory(
+	impl string,
+	factory sdkmemory.Factory,
+	deps ...sdkconfig.ResourceDepSpec,
+) sdkconfig.ResourceFactory {
+	return &deployFactory{
+		impl:    impl,
+		factory: factory,
+		deps:    append([]sdkconfig.ResourceDepSpec(nil), deps...),
+	}
 }
 
 func (f *deployFactory) Spec() sdkconfig.ResourceSpec {
@@ -44,10 +57,7 @@ func (f *deployFactory) Spec() sdkconfig.ResourceSpec {
 		Kind:     ResourceKind,
 		Impl:     f.impl,
 		ItemType: "memory.System",
-		Deps: []sdkconfig.ResourceDepSpec{
-			{Name: "workspace", Type: "workspace.Workspace", Required: true},
-			{Name: "inference", Type: "inference.Runtime", Required: true},
-		},
+		Deps:     f.deps,
 	}
 }
 
@@ -65,31 +75,8 @@ func (f *deployFactory) New(ctx context.Context, in sdkconfig.Input) (any, error
 	if err != nil {
 		return nil, err
 	}
-	rawWorkspace, ok := in.Dep("workspace")
-	if !ok {
-		return nil, errdefs.NotFoundf(
-			"memory resource: dependency %q is not bound", "workspace")
-	}
-	ws, ok := rawWorkspace.(workspace.Workspace)
-	if !ok || ws == nil {
-		return nil, errdefs.Validationf(
-			"memory resource: dependency %q has Go type %T, want workspace.Workspace",
-			"workspace", rawWorkspace)
-	}
-	rawInference, ok := in.Dep("inference")
-	if !ok {
-		return nil, errdefs.NotFoundf(
-			"memory resource: dependency %q is not bound", "inference")
-	}
-	runtime, ok := rawInference.(*inference.Runtime)
-	if !ok || runtime == nil {
-		return nil, errdefs.Validationf(
-			"memory resource: dependency %q has Go type %T, want *inference.Runtime",
-			"inference", rawInference)
-	}
 	return f.factory.New(ctx, sdkmemory.Input{
-		Workspace: ws,
-		Inference: runtime,
-		Settings:  data,
+		Settings: data,
+		Deps:     in.Deps,
 	})
 }

--- a/sdk/memory/config/resource_test.go
+++ b/sdk/memory/config/resource_test.go
@@ -7,7 +7,6 @@ import (
 	"testing"
 
 	sdkconfig "github.com/GizClaw/flowcraft/sdk/config"
-	"github.com/GizClaw/flowcraft/sdk/errdefs"
 	"github.com/GizClaw/flowcraft/sdk/inference/inferencetest"
 	sdkmemory "github.com/GizClaw/flowcraft/sdk/memory"
 	memoryconfig "github.com/GizClaw/flowcraft/sdk/memory/config"
@@ -27,14 +26,19 @@ func (fakeAssembly) PutDocument(context.Context, sdkmemory.Document) error {
 var _ sdkmemory.Assembly = fakeAssembly{}
 
 func TestDeployFactorySpec(t *testing.T) {
-	got := memoryconfig.NewDeployFactory("flowcraft", nil).Spec()
+	got := memoryconfig.NewDeployFactory(
+		"flowcraft",
+		nil,
+		sdkconfig.ResourceDepSpec{Name: "inference", Type: "inference.Runtime", Required: true},
+		sdkconfig.ResourceDepSpec{Name: "workspace", Type: "workspace.Workspace", Required: true},
+	).Spec()
 	want := sdkconfig.ResourceSpec{
 		Kind:     memoryconfig.ResourceKind,
 		Impl:     "flowcraft",
 		ItemType: "memory.System",
 		Deps: []sdkconfig.ResourceDepSpec{
-			{Name: "workspace", Type: "workspace.Workspace", Required: true},
 			{Name: "inference", Type: "inference.Runtime", Required: true},
+			{Name: "workspace", Type: "workspace.Workspace", Required: true},
 		},
 	}
 	if !reflect.DeepEqual(got, want) {
@@ -70,8 +74,8 @@ func TestDeployFactoryNewPassesDepsAndSettings(t *testing.T) {
 	if _, ok := value.(sdkmemory.Assembly); !ok {
 		t.Fatalf("New returned %T, want memory.Assembly", value)
 	}
-	if received.Workspace != ws || received.Inference != runtime {
-		t.Fatalf("factory received deps = %#v", received)
+	if received.Deps["workspace"] != ws || received.Deps["inference"] != runtime {
+		t.Fatalf("factory received deps = %#v", received.Deps)
 	}
 	var decoded map[string]any
 	if err := json.Unmarshal(received.Settings, &decoded); err != nil {
@@ -93,21 +97,6 @@ func TestDeployFactoryNewRejectsInvalidInputs(t *testing.T) {
 		Settings: settingsJSON(t, `{"unknown": true}`),
 	}); err == nil {
 		t.Fatal("New accepted an unknown resource setting")
-	}
-	if _, err := factory.New(context.Background(), sdkconfig.Input{
-		Settings: settingsJSON(t, `{"inline":{"version":"v1"}}`),
-	}); err == nil || !errdefs.IsNotFound(err) {
-		t.Fatalf("missing deps error = %v, want NotFound", err)
-	}
-	runtime := (&inferencetest.GenerateFake{}).Runtime(t)
-	if _, err := factory.New(context.Background(), sdkconfig.Input{
-		Settings: settingsJSON(t, `{"inline":{"version":"v1"}}`),
-		Deps: map[string]any{
-			"workspace": "not a workspace",
-			"inference": runtime,
-		},
-	}); err == nil || !errdefs.IsValidation(err) {
-		t.Fatalf("wrong dep type error = %v, want Validation", err)
 	}
 	if _, err := memoryconfig.NewDeployFactory("flowcraft", nil).New(
 		context.Background(),


### PR DESCRIPTION
## Summary

The `sdk/memory` protocol no longer hard-codes `workspace` / `inference` dependencies. Instead:

- `sdkmemory.Input` carries a generic `Deps` map; the protocol stays agnostic about names and types.
- `NewDeployFactory` accepts variadic `ResourceDepSpec`s so each implementation declares deps at registration.
- The flowcraft memory factory type-asserts its own `inference` and `workspace` deps.
- Docs, the forge example, and tests are updated accordingly.

## Validation

- `make ci` passes (vet + tests across sdk, memory, sdkx, examples/forge)
- `make release-check` passes