### PR TITLE
refactor(examples/forge): decode config YAML through JSON wire boundary

### DIFF
--- a/examples/forge/go.mod
+++ b/examples/forge/go.mod
@@ -9,7 +9,6 @@ require (
 	github.com/charmbracelet/bubbles v1.0.0
 	github.com/charmbracelet/bubbletea v1.3.10
 	github.com/charmbracelet/lipgloss v1.1.0
-	gopkg.in/yaml.v3 v3.0.1
 )
 
 require (

--- a/examples/forge/go.sum
+++ b/examples/forge/go.sum
@@ -9,4 +9,3 @@ github.com/mattn/go-runewidth v0.0.19/go.mod h1:XBkDxAl56ILZc9knddidhrOlY5R/pDhg
 google.golang.org/genproto v0.0.0-20260803160001-6ac0973c030d h1:33JLrUF0lFT31667SAtJzZAjLewV0ew5Mizks4caz0A=
 google.golang.org/genproto v0.0.0-20260803160001-6ac0973c030d/go.mod h1:I7vGRdTamb7ukERkgP9I+0e4p21O4ak3cM7ICA3krg8=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
-gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/examples/forge/internal/app/assemble.go
+++ b/examples/forge/internal/app/assemble.go
@@ -1,14 +1,18 @@
 package app
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
 	"path/filepath"
 
+	"github.com/GizClaw/flowcraft/examples/forge/internal/simtools"
 	flowcraftmemory "github.com/GizClaw/flowcraft/memory/config"
 	flowcraftruntime "github.com/GizClaw/flowcraft/memory/runtime"
 	"github.com/GizClaw/flowcraft/sdk/agent"
 	sdkconfig "github.com/GizClaw/flowcraft/sdk/config"
+	configutils "github.com/GizClaw/flowcraft/sdk/config/utils"
 	eventconfig "github.com/GizClaw/flowcraft/sdk/event/config"
 	graphconfig "github.com/GizClaw/flowcraft/sdk/graph/config"
 	inferenceconfig "github.com/GizClaw/flowcraft/sdk/inference/config"
@@ -30,9 +34,6 @@ import (
 	runtimecore "github.com/GizClaw/flowcraft/sdkx/runtime"
 	delegationruntime "github.com/GizClaw/flowcraft/sdkx/runtime/integration/delegation"
 	sdkscheduler "github.com/GizClaw/flowcraft/sdkx/scheduler"
-	"gopkg.in/yaml.v3"
-
-	"github.com/GizClaw/flowcraft/examples/forge/internal/simtools"
 )
 
 func buildRuntimeFromDocument(ctx context.Context, a *App, doc deploy.Document) (*runtimecore.Runtime, error) {
@@ -114,9 +115,19 @@ func providerFactories() map[string]inferenceconfig.Factory {
 // untouched; this is application-side file resolution, which the docs
 // leave to the consumer. Workspace roots resolve against the host
 // builder's BaseDir instead of a document field.
+//
+// YAML is converted to JSON at the parsing boundary by sdk/config/utils;
+// the rewrite then happens on plain JSON values, and the returned bytes
+// are JSON, which deploy.Parse accepts natively.
 func absolutizeDeployment(raw []byte, dir string) ([]byte, error) {
+	jsonData, err := configutils.ToJSON(raw)
+	if err != nil {
+		return nil, err
+	}
 	var document map[string]any
-	if err := yaml.Unmarshal(raw, &document); err != nil {
+	decoder := json.NewDecoder(bytes.NewReader(jsonData))
+	decoder.UseNumber()
+	if err := decoder.Decode(&document); err != nil {
 		return nil, err
 	}
 	resources, _ := document["resources"].(map[string]any)
@@ -133,5 +144,5 @@ func absolutizeDeployment(raw []byte, dir string) ([]byte, error) {
 			settings["file"] = filepath.Join(dir, file)
 		}
 	}
-	return yaml.Marshal(document)
+	return json.Marshal(document)
 }

--- a/examples/forge/internal/app/assemble_test.go
+++ b/examples/forge/internal/app/assemble_test.go
@@ -1,0 +1,67 @@
+package app
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+
+	"github.com/GizClaw/flowcraft/sdkx/deploy"
+)
+
+func TestAbsolutizeDeploymentRewritesRelativeFilesAsJSON(t *testing.T) {
+	raw := []byte(`
+version: v1
+agents: {}
+resources:
+  workspace:
+    kind: workspace.Registry
+    impl: yaml
+    settings: {file: workspace.yaml}
+  inference:
+    kind: inference.Assembly
+    impl: yaml
+    settings: {file: /abs/inference.yaml}
+  inline:
+    kind: workspace.Registry
+    impl: yaml
+    settings:
+      inline:
+        version: v1
+        workspaces: {}
+`)
+	out, err := absolutizeDeployment(raw, "/scenario")
+	if err != nil {
+		t.Fatalf("absolutizeDeployment: %v", err)
+	}
+	if !bytes.HasPrefix(bytes.TrimSpace(out), []byte("{")) {
+		t.Fatalf("output is not JSON: %s", out)
+	}
+	if _, err := deploy.Parse(out); err != nil {
+		t.Fatalf("deploy.Parse(JSON): %v", err)
+	}
+
+	var doc map[string]any
+	if err := json.Unmarshal(out, &doc); err != nil {
+		t.Fatalf("json.Unmarshal(output): %v", err)
+	}
+	resources := doc["resources"].(map[string]any)
+	workspace := resources["workspace"].(map[string]any)["settings"].(map[string]any)
+	if got := workspace["file"]; got != "/scenario/workspace.yaml" {
+		t.Fatalf("workspace file = %v, want /scenario/workspace.yaml", got)
+	}
+	inference := resources["inference"].(map[string]any)["settings"].(map[string]any)
+	if got := inference["file"]; got != "/abs/inference.yaml" {
+		t.Fatalf("absolute file = %v, want unchanged", got)
+	}
+	inline := resources["inline"].(map[string]any)["settings"].(map[string]any)
+	if _, ok := inline["inline"]; !ok {
+		t.Fatalf("inline settings were not preserved: %v", inline)
+	}
+}
+
+func TestAbsolutizeDeploymentRejectsMultipleDocuments(t *testing.T) {
+	raw := []byte("version: v1\n---\nversion: v1\n")
+	if _, err := absolutizeDeployment(raw, "/x"); err == nil {
+		t.Fatal("expected multiple YAML documents to be rejected")
+	}
+}

--- a/examples/forge/internal/app/info.go
+++ b/examples/forge/internal/app/info.go
@@ -1,15 +1,16 @@
 package app
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
 
 	flowcraftmemory "github.com/GizClaw/flowcraft/memory/config"
+	configutils "github.com/GizClaw/flowcraft/sdk/config/utils"
 	"github.com/GizClaw/flowcraft/sdkx/deploy"
 	memoryhook "github.com/GizClaw/flowcraft/sdkx/memory/hook"
-	"gopkg.in/yaml.v3"
 )
 
 // inspectDocument reads metadata out of the native documents without
@@ -17,8 +18,7 @@ import (
 func inspectDocument(workspaceDir string, doc deploy.Document) (Info, error) {
 	info := Info{ContextID: "__default__"}
 	if rawSpeakers, err := os.ReadFile(filepath.Join(workspaceDir, "speakers.yaml")); err == nil {
-		var speakers map[string]string
-		if err := yaml.Unmarshal(rawSpeakers, &speakers); err == nil {
+		if speakers, err := decodeSpeakers(rawSpeakers); err == nil {
 			info.Speakers = speakers
 		}
 	}
@@ -31,8 +31,7 @@ func inspectDocument(workspaceDir string, doc deploy.Document) (Info, error) {
 		break
 	}
 	if rawMemory, err := os.ReadFile(filepath.Join(workspaceDir, "memory.yaml")); err == nil {
-		var settings flowcraftmemory.Settings
-		if err := yaml.Unmarshal(rawMemory, &settings); err == nil {
+		if settings, err := decodeMemorySettings(rawMemory); err == nil {
 			info.MemoryEnabled = true
 			info.GenerateModel = settings.Generate.Provider + "/" + settings.Generate.Name
 			if len(settings.Scopes) > 0 {
@@ -72,17 +71,8 @@ func requireProviderCredential(workspaceDir string) error {
 	if err != nil {
 		return fmt.Errorf("read inference config: %w", err)
 	}
-	var doc struct {
-		Providers []struct {
-			Profiles []struct {
-				Secrets map[string]struct {
-					Resolver string `yaml:"resolver"`
-					Key      string `yaml:"key"`
-				} `yaml:"secrets"`
-			} `yaml:"profiles"`
-		} `yaml:"providers"`
-	}
-	if err := yaml.Unmarshal(raw, &doc); err != nil {
+	doc, err := decodeInferenceCredentials(raw)
+	if err != nil {
 		return fmt.Errorf("decode inference config: %w", err)
 	}
 	var keys []string
@@ -99,4 +89,63 @@ func requireProviderCredential(workspaceDir string) error {
 		}
 	}
 	return fmt.Errorf("no provider credentials available; set one of %s in .env", strings.Join(keys, ", "))
+}
+
+// decodeSpeakers reads the YAML authoring file with JSON semantics:
+// utils converts the document at the boundary, and the result is a
+// plain string map.
+func decodeSpeakers(raw []byte) (map[string]string, error) {
+	jsonData, err := configutils.ToJSON(raw)
+	if err != nil {
+		return nil, err
+	}
+	var speakers map[string]string
+	if err := json.Unmarshal(jsonData, &speakers); err != nil {
+		return nil, err
+	}
+	return speakers, nil
+}
+
+// decodeMemorySettings decodes memory.yaml through the JSON wire
+// protocol. The settings type is JSON-tagged, so the YAML document
+// must pass through utils.ToJSON before encoding/json sees it; this
+// keeps keys like runtime_id matching the wire protocol.
+func decodeMemorySettings(raw []byte) (flowcraftmemory.Settings, error) {
+	jsonData, err := configutils.ToJSON(raw)
+	if err != nil {
+		return flowcraftmemory.Settings{}, err
+	}
+	var settings flowcraftmemory.Settings
+	if err := json.Unmarshal(jsonData, &settings); err != nil {
+		return flowcraftmemory.Settings{}, err
+	}
+	return settings, nil
+}
+
+type inferenceCredentials struct {
+	Providers []struct {
+		Profiles []struct {
+			Secrets map[string]struct {
+				Resolver string `json:"resolver"`
+				Key      string `json:"key"`
+			} `json:"secrets"`
+		} `json:"profiles"`
+	} `json:"providers"`
+}
+
+// decodeInferenceCredentials converts the YAML authoring document to
+// JSON and decodes only the secret references the preflight needs.
+// json.Unmarshal (not utils.Decode) is used on purpose: version, id,
+// driver, and provider-specific fields are valid in inference.yaml but
+// irrelevant here, and the preflight should stay best-effort.
+func decodeInferenceCredentials(raw []byte) (inferenceCredentials, error) {
+	jsonData, err := configutils.ToJSON(raw)
+	if err != nil {
+		return inferenceCredentials{}, err
+	}
+	var doc inferenceCredentials
+	if err := json.Unmarshal(jsonData, &doc); err != nil {
+		return inferenceCredentials{}, err
+	}
+	return doc, nil
 }

--- a/examples/forge/internal/app/info_test.go
+++ b/examples/forge/internal/app/info_test.go
@@ -1,0 +1,63 @@
+package app
+
+import (
+	"testing"
+)
+
+func TestDecodeSpeakers(t *testing.T) {
+	raw := []byte("narrator: 旁白\nrole_wukong: 悟空\n")
+	speakers, err := decodeSpeakers(raw)
+	if err != nil {
+		t.Fatalf("decodeSpeakers: %v", err)
+	}
+	if speakers["narrator"] != "旁白" || speakers["role_wukong"] != "悟空" {
+		t.Fatalf("speakers = %v", speakers)
+	}
+}
+
+func TestDecodeMemorySettingsUsesJSONKeys(t *testing.T) {
+	raw := []byte(`
+generate: {provider: fake, name: echo}
+scopes:
+  - runtime_id: prod
+    user_id: u1
+    agent_id: a1
+`)
+	settings, err := decodeMemorySettings(raw)
+	if err != nil {
+		t.Fatalf("decodeMemorySettings: %v", err)
+	}
+	if settings.Generate.Provider != "fake" || settings.Generate.Name != "echo" {
+		t.Fatalf("generate = %+v", settings.Generate)
+	}
+	if len(settings.Scopes) != 1 {
+		t.Fatalf("scopes = %+v, want one entry", settings.Scopes)
+	}
+	scope := settings.Scopes[0]
+	if scope.RuntimeID != "prod" || scope.UserID != "u1" || scope.AgentID != "a1" {
+		t.Fatalf("scope = %+v", scope)
+	}
+}
+
+func TestDecodeInferenceCredentialsIgnoresProviderFields(t *testing.T) {
+	raw := []byte(`
+version: v1
+providers:
+  - id: deepseek
+    driver: deepseek
+    profiles:
+      - secrets:
+          api_key: {resolver: env, key: DEEPSEEK_API_KEY}
+`)
+	doc, err := decodeInferenceCredentials(raw)
+	if err != nil {
+		t.Fatalf("decodeInferenceCredentials: %v", err)
+	}
+	if len(doc.Providers) != 1 || len(doc.Providers[0].Profiles) != 1 {
+		t.Fatalf("doc = %+v", doc)
+	}
+	secret := doc.Providers[0].Profiles[0].Secrets["api_key"]
+	if secret.Resolver != "env" || secret.Key != "DEEPSEEK_API_KEY" {
+		t.Fatalf("secret = %+v", secret)
+	}
+}

--- a/examples/forge/internal/commands/test.go
+++ b/examples/forge/internal/commands/test.go
@@ -2,6 +2,7 @@ package commands
 
 import (
 	"context"
+	"encoding/json"
 	"flag"
 	"fmt"
 	"os"
@@ -9,18 +10,17 @@ import (
 	"strings"
 	"time"
 
-	"gopkg.in/yaml.v3"
-
 	"github.com/GizClaw/flowcraft/examples/forge/internal/app"
 	"github.com/GizClaw/flowcraft/examples/forge/internal/scenario"
 	"github.com/GizClaw/flowcraft/sdk/agent"
+	configutils "github.com/GizClaw/flowcraft/sdk/config/utils"
 )
 
 type testFile struct {
-	Name        string   `yaml:"name"`
-	Description string   `yaml:"description"`
-	Raid        string   `yaml:"raid"`
-	Turns       []string `yaml:"turns"`
+	Name        string   `json:"name"`
+	Description string   `json:"description"`
+	Raid        string   `json:"raid"`
+	Turns       []string `json:"turns"`
 }
 
 type testMetrics struct {
@@ -61,8 +61,8 @@ func testCmd(args []string) error {
 	if err != nil {
 		return err
 	}
-	var test testFile
-	if err := yaml.Unmarshal(raw, &test); err != nil {
+	test, err := parseTestFile(raw)
+	if err != nil {
 		return fmt.Errorf("test %q: %w", *testSource, err)
 	}
 	raid := strings.TrimSpace(test.Raid)
@@ -93,6 +93,21 @@ func testCmd(args []string) error {
 	}
 	fmt.Printf("wrote test %s\n", outputDir)
 	return nil
+}
+
+// parseTestFile decodes a scenario test document. utils converts the
+// YAML authoring form to JSON at the boundary; json.Unmarshal keeps the
+// decode permissive so test files may carry extra fields.
+func parseTestFile(data []byte) (testFile, error) {
+	jsonData, err := configutils.ToJSON(data)
+	if err != nil {
+		return testFile{}, err
+	}
+	var test testFile
+	if err := json.Unmarshal(jsonData, &test); err != nil {
+		return testFile{}, err
+	}
+	return test, nil
 }
 
 func runTestTurns(workspacePath, logPath string, inputs []string, timeout time.Duration) (testMetrics, error) {

--- a/examples/forge/internal/commands/test_test.go
+++ b/examples/forge/internal/commands/test_test.go
@@ -1,0 +1,33 @@
+package commands
+
+import (
+	"testing"
+)
+
+func TestParseTestFile(t *testing.T) {
+	raw := []byte(`
+name: werewolf_opening_setup
+description: Starts a new Werewolf game.
+raid: werewolf
+turns:
+  - 开始狼人杀
+future: ignored
+`)
+	test, err := parseTestFile(raw)
+	if err != nil {
+		t.Fatalf("parseTestFile: %v", err)
+	}
+	if test.Name != "werewolf_opening_setup" || test.Raid != "werewolf" {
+		t.Fatalf("test = %+v", test)
+	}
+	if len(test.Turns) != 1 || test.Turns[0] != "开始狼人杀" {
+		t.Fatalf("turns = %+v", test.Turns)
+	}
+}
+
+func TestParseTestFileRejectsDuplicateKeys(t *testing.T) {
+	raw := []byte("name: one\nname: two\nraid: werewolf\n")
+	if _, err := parseTestFile(raw); err == nil {
+		t.Fatal("expected duplicate YAML keys to be rejected")
+	}
+}


### PR DESCRIPTION
## Summary

Replaces direct `gopkg.in/yaml.v3` decoding in `examples/forge` with the SDK config JSON wire boundary (`sdk/config/utils` + `encoding/json`) and drops the now-unused yaml dependency.

## Changes

- `assemble.go`: absolutize deployment documents via `configutils.ToJSON` and emit JSON.
- `info.go`: decode speakers, memory settings, and inference credentials through the JSON boundary.
- `commands/test.go`: parse scenario test files through the JSON boundary.
- Adds unit tests for the new decode helpers and deployment absolutization.
- Removes `gopkg.in/yaml.v3` from `go.mod`/`go.sum`.

## Verification

- `go test ./...` in `examples/forge` passes.
- `go vet ./...` in `examples/forge` passes.
- `git diff --check` is clean.