### PR TITLE
feat(sdk/inference): add router retry/backoff and circuit breaker resilience

### DIFF
--- a/docs/guides/inference.md
+++ b/docs/guides/inference.md
@@ -369,6 +369,63 @@ canonical validation never enters selection at all. Custom selection
 logic (score-aware, request-aware) builds `route.New(runtime,
 selectors)` directly.
 
+## Retry, backoff, and circuit breaker
+
+`route.Router` can retry a transient provider failure on the same target
+before falling back. Retries are conservative by default: only
+`ProviderFailure` classified as rate limit, timeout, or unavailable is
+retried, never after observable output, and never for validation,
+compile rejections, policy denials, or context cancellation. Streams and
+sessions only retry before they open; once a stream or session is
+returned, the Router never transparently reopens it.
+
+The route policy section declares retries and the per-target circuit
+breaker. The DTO is JSON (the config entry point still accepts YAML and
+converts it to JSON):
+
+```json
+{
+  "route": {
+    "generate": [
+      {"tier": "primary", "targets": [{"model": {"id": {"provider": "openai", "name": "gpt"}}}]}
+    ],
+    "retry": {
+      "generate": {
+        "max_attempts": 3,
+        "max_total_attempts": 8,
+        "backoff": {"kind": "exponential", "initial": "100ms", "max": "2s", "jitter": "full"},
+        "retryable": ["rate_limit", "timeout", "unavailable"],
+        "fallback_on_retry_exhausted": false
+      }
+    },
+    "circuit_breaker": {
+      "failure_threshold": 5,
+      "recovery_window": "30s",
+      "half_open_max_probes": 1
+    }
+  }
+}
+```
+
+`fallback_on_retry_exhausted` is off by default: a transient provider
+failure never moves to another target unless the deployment opts in.
+Circuit-breaker state is per `Operation + ModelRef` and lives on the
+`Router` instance; open targets are skipped without wire attempts, and a
+half-open circuit admits one probe at a time.
+
+`http_retries` on any provider spec means total wire attempts including
+the first. On httpkit-backed providers it sets the transport retry
+budget; on openai / anthropic / azure / deepseek it maps to the vendor
+SDK's max-retries option. `0` disables provider-level retries so the
+Router owns the whole budget.
+
+`max_total_attempts` caps logical attempts across all targets for one
+request (0 or absent means no cap). Circuit state can be cleared at
+runtime with `Router.ResetCircuitBreaker()`.
+
+Programmatic callers build the same behavior with
+`route.WithRetryPolicies` and `route.WithCircuitBreaker`.
+
 ## Hot reload
 
 There is no built-in `config.Reloader` in the current stack. `Builder` and

--- a/sdk/errdefs/retry.go
+++ b/sdk/errdefs/retry.go
@@ -1,0 +1,106 @@
+package errdefs
+
+import (
+	"errors"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// RetryAfterCoder is implemented by errors that carry a server-provided
+// retry hint (typically from a Retry-After response header).
+type RetryAfterCoder interface {
+	RetryAfter() time.Duration
+}
+
+// RetryCountCoder is implemented by errors that carry the number of wire
+// attempts (HTTP sends) that already happened before the failure surfaced.
+type RetryCountCoder interface {
+	RetryCount() int
+}
+
+type retryAfterHint struct {
+	error
+	retryAfter time.Duration
+}
+
+func (e retryAfterHint) Unwrap() error { return e.error }
+
+func (e retryAfterHint) RetryAfter() time.Duration { return e.retryAfter }
+
+// WithRetryAfter wraps err with a Retry-After hint. Nil and non-positive
+// durations return err unchanged so callers can attach hints unconditionally.
+func WithRetryAfter(err error, d time.Duration) error {
+	if err == nil || d <= 0 {
+		return err
+	}
+	return retryAfterHint{error: err, retryAfter: d}
+}
+
+// RetryAfter reads the hint from an error chain. It reports false when the
+// chain carries no hint or the hint is not positive.
+func RetryAfter(err error) (time.Duration, bool) {
+	var coder RetryAfterCoder
+	if errors.As(err, &coder) {
+		d := coder.RetryAfter()
+		return d, d > 0
+	}
+	return 0, false
+}
+
+// ParseRetryAfter parses the seconds form of a Retry-After header value.
+// Invalid, empty, and negative values return zero.
+func ParseRetryAfter(value string) time.Duration {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return 0
+	}
+	seconds, err := strconv.Atoi(value)
+	if err != nil || seconds < 0 {
+		return 0
+	}
+	return time.Duration(seconds) * time.Second
+}
+
+// ParseRetryCount parses a zero-based retry-count header (e.g. the
+// X-Stainless-Retry-Count header vendor SDKs send). Invalid, empty, and
+// negative values return zero.
+func ParseRetryCount(value string) int {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return 0
+	}
+	count, err := strconv.Atoi(value)
+	if err != nil || count < 0 {
+		return 0
+	}
+	return count
+}
+
+type retryCountHint struct {
+	error
+	retryCount int
+}
+
+func (e retryCountHint) Unwrap() error { return e.error }
+
+func (e retryCountHint) RetryCount() int { return e.retryCount }
+
+// WithRetryCount wraps err with the number of wire attempts already made.
+// Nil and non-positive counts return err unchanged.
+func WithRetryCount(err error, count int) error {
+	if err == nil || count <= 0 {
+		return err
+	}
+	return retryCountHint{error: err, retryCount: count}
+}
+
+// RetryCount reads the wire-attempt count from an error chain. Zero means no
+// count was recorded.
+func RetryCount(err error) int {
+	var coder RetryCountCoder
+	if errors.As(err, &coder) {
+		return coder.RetryCount()
+	}
+	return 0
+}

--- a/sdk/errdefs/retry_test.go
+++ b/sdk/errdefs/retry_test.go
@@ -1,0 +1,76 @@
+package errdefs
+
+import (
+	"errors"
+	"testing"
+	"time"
+)
+
+func TestWithRetryAfterAndRetryAfter(t *testing.T) {
+	err := WithRetryAfter(NotAvailable(errors.New("boom")), 3*time.Second)
+	got, ok := RetryAfter(err)
+	if !ok || got != 3*time.Second {
+		t.Fatalf("RetryAfter = %v/%v, want 3s/true", got, ok)
+	}
+}
+
+func TestRetryAfterWalksWrappedChain(t *testing.T) {
+	inner := WithRetryAfter(Timeout(errors.New("slow")), 2*time.Second)
+	wrapped := errors.Join(errors.New("outer"), inner)
+	got, ok := RetryAfter(wrapped)
+	if !ok || got != 2*time.Second {
+		t.Fatalf("RetryAfter = %v/%v, want 2s/true", got, ok)
+	}
+}
+
+func TestRetryAfterIgnoresMissingAndNonPositive(t *testing.T) {
+	if _, ok := RetryAfter(errors.New("plain")); ok {
+		t.Fatal("plain error reported a retry hint")
+	}
+	if got := WithRetryAfter(errors.New("plain"), 0); got == nil {
+		t.Fatal("WithRetryAfter with zero returned nil")
+	}
+	if _, ok := RetryAfter(WithRetryAfter(errors.New("plain"), 0)); ok {
+		t.Fatal("non-positive hint reported")
+	}
+}
+
+func TestParseRetryAfter(t *testing.T) {
+	for value, want := range map[string]time.Duration{
+		"":    0,
+		"1":   time.Second,
+		" 5 ": 5 * time.Second,
+		"-1":  0,
+		"abc": 0,
+		"1.5": 0, // seconds form only
+	} {
+		if got := ParseRetryAfter(value); got != want {
+			t.Errorf("ParseRetryAfter(%q) = %v, want %v", value, got, want)
+		}
+	}
+}
+
+func TestWithRetryCountAndRetryCount(t *testing.T) {
+	err := WithRetryCount(NotAvailable(errors.New("boom")), 3)
+	if got := RetryCount(err); got != 3 {
+		t.Fatalf("RetryCount = %d, want 3", got)
+	}
+	if got := RetryCount(errors.New("plain")); got != 0 {
+		t.Fatalf("RetryCount(plain) = %d, want 0", got)
+	}
+}
+
+func TestParseRetryCount(t *testing.T) {
+	for value, want := range map[string]int{
+		"":    0,
+		"0":   0,
+		"2":   2,
+		" 3 ": 3,
+		"-1":  0,
+		"x":   0,
+	} {
+		if got := ParseRetryCount(value); got != want {
+			t.Errorf("ParseRetryCount(%q) = %d, want %d", value, got, want)
+		}
+	}
+}

--- a/sdk/inference/config/builder.go
+++ b/sdk/inference/config/builder.go
@@ -235,7 +235,11 @@ func (b *Builder) NewAssembly(
 	}
 	assembly := Assembly{Runtime: runtime}
 	if document.Route != nil {
-		router, err := route.New(runtime, document.Route.Selectors())
+		options, err := document.Route.Options()
+		if err != nil {
+			return Assembly{}, fmt.Errorf("build route options: %w", err)
+		}
+		router, err := route.New(runtime, document.Route.Selectors(), options...)
 		if err != nil {
 			return Assembly{}, fmt.Errorf("build route router: %w", err)
 		}

--- a/sdk/inference/config/resilience_test.go
+++ b/sdk/inference/config/resilience_test.go
@@ -1,0 +1,149 @@
+package config
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/GizClaw/flowcraft/sdk/errdefs"
+	"github.com/GizClaw/flowcraft/sdk/inference"
+	"github.com/GizClaw/flowcraft/sdk/inference/route"
+	"github.com/GizClaw/flowcraft/sdk/message"
+)
+
+func TestAssemblyAppliesRetryPolicyFromJSON(t *testing.T) {
+	calls := 0
+	driver, err := inference.BindGenerate(
+		func(
+			_ context.Context,
+			_ inference.ModelRef,
+			request inference.GenerateRequest,
+			shape inference.GenerateExecutionShape,
+		) (inference.Compiled[string], error) {
+			active := request.ActiveFieldsFor(shape)
+			decisions := make([]inference.Decision, len(active))
+			for index, field := range active {
+				decisions[index] = inference.Decision{
+					Field: field, Disposition: inference.Native,
+				}
+			}
+			return inference.Compiled[string]{
+				Wire: "wire",
+				Report: inference.CompileReport{
+					Operation: inference.OperationGenerate, Decisions: decisions,
+				},
+			}, nil
+		},
+		func(context.Context, string) (string, error) {
+			calls++
+			if calls == 1 {
+				return "", errdefs.RateLimit(errors.New("slow down"))
+			}
+			return "ok", nil
+		},
+		func(context.Context, string) (inference.GenerateResponse, error) {
+			return inference.GenerateResponse{
+				Message: message.Message{
+					Role: message.RoleAssistant,
+					Content: message.Content{
+						Parts: []message.Part{message.TextPart{Text: "ok"}},
+					},
+				},
+				FinishReason: inference.FinishCompleted,
+			}, nil
+		},
+	)
+	if err != nil {
+		t.Fatalf("BindGenerate: %v", err)
+	}
+	builder, err := NewBuilder(
+		map[string]Factory{"fake": FactoryFunc(func(
+			_ context.Context,
+			input ProviderInput,
+		) (inference.ProviderDefinition, error) {
+			return inference.ProviderDefinition{
+				ID: input.ID,
+				Models: []inference.ModelImplementation{{
+					Descriptor: inference.ModelDescriptor{
+						ID: inference.ModelID{Provider: input.ID, Name: "model"},
+					},
+					Openers: inference.Openers{
+						Generate: func(
+							context.Context,
+							inference.ModelRef,
+						) (inference.GenerateOperations, error) {
+							return inference.GenerateOperations{Unary: driver}, nil
+						},
+					},
+				}},
+			}, nil
+		})},
+		nil,
+	)
+	if err != nil {
+		t.Fatalf("NewBuilder: %v", err)
+	}
+
+	document, err := Parse([]byte(`{
+		"version": "v1",
+		"providers": [{"id": "fake", "driver": "fake"}],
+		"route": {
+			"generate": [{
+				"tier": "primary",
+				"targets": [{"model": {
+					"id": {"provider": "fake", "name": "model"}
+				}}]
+			}],
+			"retry": {
+				"generate": {
+					"max_attempts": 2,
+					"backoff": {"kind": "fixed", "initial": "1ms"},
+					"retryable": ["rate_limit"]
+				}
+			}
+		}
+	}`))
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	assembly, err := builder.NewAssembly(context.Background(), document)
+	if err != nil {
+		t.Fatalf("NewAssembly: %v", err)
+	}
+	if assembly.Router == nil {
+		t.Fatal("route section did not compose a Router")
+	}
+
+	response, trace, err := assembly.Router.Generate(
+		context.Background(),
+		inference.GenerateRequest{
+			Input: inference.GenerateInput{
+				Role: inference.InputRoleUser,
+				Content: inference.InputContent{
+					Content: message.Content{
+						Parts: []message.Part{message.TextPart{Text: "hi"}},
+					},
+					Intent: inference.Intent{Text: &inference.TextIntent{}},
+				},
+			},
+		},
+	)
+	if err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+	if calls != 2 {
+		t.Fatalf("transport calls = %d, want 2", calls)
+	}
+	if response.Metadata.Model.Name != "model" {
+		t.Fatalf("executed = %+v", response.Metadata.Model)
+	}
+	retries := 0
+	for _, attempt := range trace.Attempts {
+		if attempt.Trigger == route.AttemptTriggerRetry {
+			retries++
+		}
+	}
+	if retries != 1 {
+		t.Fatalf("retry triggers = %d, trace = %+v", retries, trace.Attempts)
+	}
+}

--- a/sdk/inference/errors.go
+++ b/sdk/inference/errors.go
@@ -3,6 +3,7 @@ package inference
 import (
 	"errors"
 	"fmt"
+	"time"
 
 	"github.com/GizClaw/flowcraft/sdk/errdefs"
 )
@@ -35,7 +36,15 @@ type Error struct {
 	Kind      ErrorKind
 	Operation Operation
 	Field     FieldID
-	cause     error
+	// RetryAfter is a server-provided backoff hint (Retry-After) when a
+	// provider failure carries one. Zero means no hint. It is diagnostic
+	// metadata, not part of the redacted Error() text.
+	RetryAfter time.Duration
+	// WireAttempts is the number of HTTP sends the provider transport made
+	// before surfacing this failure. Zero means the provider did not report
+	// a count.
+	WireAttempts int
+	cause        error
 }
 
 func NewError(kind ErrorKind, operation Operation, field FieldID, cause error) *Error {
@@ -59,7 +68,12 @@ func newProviderError(
 	if !errdefs.HasClassification(classified) {
 		classified = errdefs.ClassifyProviderError(provider, classified)
 	}
-	return NewError(ProviderFailure, operation, "", classified)
+	err := NewError(ProviderFailure, operation, "", classified)
+	if retryAfter, ok := errdefs.RetryAfter(cause); ok {
+		err.RetryAfter = retryAfter
+	}
+	err.WireAttempts = errdefs.RetryCount(cause)
+	return err
 }
 
 func (e *Error) Error() string {

--- a/sdk/inference/errors_test.go
+++ b/sdk/inference/errors_test.go
@@ -9,6 +9,7 @@ import (
 	"strconv"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/GizClaw/flowcraft/sdk/errdefs"
 )
@@ -91,6 +92,28 @@ func TestNewProviderFailureDefaultsToNotAvailable(t *testing.T) {
 	)
 	if !errdefs.IsNotAvailable(err) {
 		t.Fatalf("NewError = %v, want errdefs.NotAvailable", err)
+	}
+}
+
+func TestProviderFailureCarriesRetryAfter(t *testing.T) {
+	cause := errdefs.WithRetryAfter(
+		errdefs.RateLimit(errors.New("slow down")),
+		5*time.Second,
+	)
+	err := newProviderError(OperationGenerate, "fake", cause)
+	if err.RetryAfter != 5*time.Second {
+		t.Fatalf("RetryAfter = %v, want 5s", err.RetryAfter)
+	}
+	if got, ok := errdefs.RetryAfter(err); !ok || got != 5*time.Second {
+		t.Fatalf("RetryAfter through chain = %v/%v, want 5s/true", got, ok)
+	}
+}
+
+func TestProviderFailureCarriesWireAttempts(t *testing.T) {
+	cause := errdefs.WithRetryCount(errors.New("boom"), 3)
+	err := newProviderError(OperationGenerate, "fake", cause)
+	if err.WireAttempts != 3 {
+		t.Fatalf("WireAttempts = %d, want 3", err.WireAttempts)
 	}
 }
 

--- a/sdk/inference/route/doc.go
+++ b/sdk/inference/route/doc.go
@@ -4,4 +4,11 @@
 // target pools, selector contracts, and route traces. It does not declare model
 // capabilities: selectors return an exact inference.ModelRef, and the provider
 // compiler remains the authority on whether the concrete request is executable.
+//
+// Router also owns resilience: same-target retry/backoff (RetryPolicy),
+// cross-target fallback, and an optional per-target circuit breaker
+// (CircuitBreakerConfig). Retry defaults are conservative — only transient
+// ProviderFailure without observable output is retried — and stream/session
+// operations never reopen after a successful open.
+// ResetCircuitBreaker clears all breaker state on the instance.
 package route

--- a/sdk/inference/route/errors.go
+++ b/sdk/inference/route/errors.go
@@ -22,6 +22,7 @@ const (
 	FallbackFailed            ErrorKind = "fallback_failed"
 	FallbackContractViolation ErrorKind = "fallback_contract_violation"
 	FallbackLimitExceeded     ErrorKind = "fallback_limit_exceeded"
+	CircuitOpen               ErrorKind = "circuit_open"
 )
 
 // Error carries safe route context. Error() excludes selector inputs and
@@ -67,7 +68,7 @@ func classify(kind ErrorKind, cause error) error {
 		return errdefs.Validation(cause)
 	case SelectorUnavailable, NoRoute:
 		return errdefs.NotAvailable(cause)
-	case SelectionFailed, FallbackFailed:
+	case SelectionFailed, FallbackFailed, CircuitOpen:
 		classified := errdefs.FromContext(cause)
 		if errdefs.HasClassification(classified) {
 			return classified

--- a/sdk/inference/route/errors_test.go
+++ b/sdk/inference/route/errors_test.go
@@ -22,6 +22,7 @@ func TestErrorClassificationCoversEveryKind(t *testing.T) {
 		{FallbackFailed, errdefs.IsNotAvailable},
 		{FallbackContractViolation, errdefs.IsInternal},
 		{FallbackLimitExceeded, errdefs.IsInternal},
+		{CircuitOpen, errdefs.IsNotAvailable},
 	}
 	for _, item := range kinds {
 		err := NewError(item.kind, inference.OperationGenerate, errors.New("cause"))

--- a/sdk/inference/route/policy.go
+++ b/sdk/inference/route/policy.go
@@ -1,11 +1,15 @@
 package route
 
 import (
+	"bytes"
+	"context"
+	"encoding/json"
 	"fmt"
 	"math"
 	"regexp"
 	"slices"
 
+	"github.com/GizClaw/flowcraft/sdk/errdefs"
 	"github.com/GizClaw/flowcraft/sdk/inference"
 )
 
@@ -26,10 +30,10 @@ func (t Tier) Validate() error {
 // value is in [0,1], and higher is better. Scores guide selection only; they
 // never claim that a request is executable.
 type ModelScore struct {
-	Quality     *float64 `json:"quality,omitempty" yaml:"quality,omitempty"`
-	Economy     *float64 `json:"economy,omitempty" yaml:"economy,omitempty"`
-	Speed       *float64 `json:"speed,omitempty" yaml:"speed,omitempty"`
-	Reliability *float64 `json:"reliability,omitempty" yaml:"reliability,omitempty"`
+	Quality     *float64 `json:"quality,omitempty"`
+	Economy     *float64 `json:"economy,omitempty"`
+	Speed       *float64 `json:"speed,omitempty"`
+	Reliability *float64 `json:"reliability,omitempty"`
 }
 
 // IsZero reports whether no signal is populated. It drives both JSON
@@ -72,8 +76,8 @@ func (s ModelScore) Validate() error {
 
 // Target is one exact executable model candidate plus route-only signals.
 type Target struct {
-	Model inference.ModelRef `json:"model" yaml:"model"`
-	Score ModelScore         `json:"score,omitzero" yaml:"score,omitempty"`
+	Model inference.ModelRef `json:"model"`
+	Score ModelScore         `json:"score,omitzero"`
 }
 
 func (t Target) Clone() Target {
@@ -90,8 +94,8 @@ func (t Target) Validate() error {
 
 // Pool is the allowlist of exact model targets available to one tier.
 type Pool struct {
-	Tier    Tier     `json:"tier" yaml:"tier"`
-	Targets []Target `json:"targets" yaml:"targets"`
+	Tier    Tier     `json:"tier"`
+	Targets []Target `json:"targets"`
 }
 
 func (p Pool) Clone() Pool {
@@ -126,19 +130,30 @@ func (p Pool) Validate() error {
 // Policy owns operation-specific tier allowlists. It is descriptive route
 // configuration, not an inference capability catalog.
 type Policy struct {
-	Generate      []Pool `json:"generate,omitempty" yaml:"generate,omitempty"`
-	Embed         []Pool `json:"embed,omitempty" yaml:"embed,omitempty"`
-	Transcription []Pool `json:"transcription,omitempty" yaml:"transcription,omitempty"`
-	Realtime      []Pool `json:"realtime,omitempty" yaml:"realtime,omitempty"`
+	Generate       []Pool                `json:"generate,omitempty"`
+	Embed          []Pool                `json:"embed,omitempty"`
+	Transcription  []Pool                `json:"transcription,omitempty"`
+	Realtime       []Pool                `json:"realtime,omitempty"`
+	Retry          *RetryConfig          `json:"retry,omitempty"`
+	CircuitBreaker *CircuitBreakerConfig `json:"circuit_breaker,omitempty"`
 }
 
 func (p Policy) Clone() Policy {
-	return Policy{
+	cloned := Policy{
 		Generate:      clonePools(p.Generate),
 		Embed:         clonePools(p.Embed),
 		Transcription: clonePools(p.Transcription),
 		Realtime:      clonePools(p.Realtime),
 	}
+	if p.Retry != nil {
+		retry := p.Retry.Clone()
+		cloned.Retry = &retry
+	}
+	if p.CircuitBreaker != nil {
+		breaker := *p.CircuitBreaker
+		cloned.CircuitBreaker = &breaker
+	}
+	return cloned
 }
 
 func (p Policy) Validate() error {
@@ -171,7 +186,254 @@ func (p Policy) Validate() error {
 			seen[pool.Tier] = struct{}{}
 		}
 	}
+	if p.Retry != nil {
+		if err := p.Retry.validate(hasPools(p)); err != nil {
+			return err
+		}
+	}
+	if p.CircuitBreaker != nil {
+		if err := p.CircuitBreaker.validate(); err != nil {
+			return fmt.Errorf("circuit breaker: %w", err)
+		}
+	}
 	return nil
+}
+
+func hasPools(policy Policy) func(inference.Operation) bool {
+	return func(operation inference.Operation) bool {
+		switch operation {
+		case inference.OperationGenerate:
+			return len(policy.Generate) > 0
+		case inference.OperationEmbed:
+			return len(policy.Embed) > 0
+		case inference.OperationTranscription:
+			return len(policy.Transcription) > 0
+		case inference.OperationRealtime:
+			return len(policy.Realtime) > 0
+		default:
+			return false
+		}
+	}
+}
+
+// RetryConfig is the JSON-only deployment form of RetryPolicies.
+type RetryConfig struct {
+	Generate             *RetryPolicyConfig `json:"generate,omitempty"`
+	Embed                *RetryPolicyConfig `json:"embed,omitempty"`
+	Transcription        *RetryPolicyConfig `json:"transcription,omitempty"`
+	TranscriptionSession *RetryPolicyConfig `json:"transcription_session,omitempty"`
+	Realtime             *RetryPolicyConfig `json:"realtime,omitempty"`
+}
+
+// UnmarshalJSON enforces the JSON-only DTO boundary strictly: unknown fields
+// inside the retry section are rejected.
+func (c *RetryConfig) UnmarshalJSON(data []byte) error {
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	decoder.DisallowUnknownFields()
+	type alias RetryConfig
+	var raw alias
+	if err := decoder.Decode(&raw); err != nil {
+		return fmt.Errorf("decode retry config: %w", err)
+	}
+	*c = RetryConfig(raw)
+	return nil
+}
+
+func (c RetryConfig) Clone() RetryConfig {
+	return RetryConfig{
+		Generate:             c.Generate.Clone(),
+		Embed:                c.Embed.Clone(),
+		Transcription:        c.Transcription.Clone(),
+		TranscriptionSession: c.TranscriptionSession.Clone(),
+		Realtime:             c.Realtime.Clone(),
+	}
+}
+
+func (c RetryConfig) validate(hasPools func(inference.Operation) bool) error {
+	entries := []struct {
+		operation inference.Operation
+		config    *RetryPolicyConfig
+	}{
+		{inference.OperationGenerate, c.Generate},
+		{inference.OperationEmbed, c.Embed},
+		{inference.OperationTranscription, c.Transcription},
+		{inference.OperationTranscription, c.TranscriptionSession},
+		{inference.OperationRealtime, c.Realtime},
+	}
+	for _, entry := range entries {
+		if entry.config == nil {
+			continue
+		}
+		if !hasPools(entry.operation) {
+			return fmt.Errorf(
+				"%s retry policy requires %s pools",
+				entry.operation,
+				entry.operation,
+			)
+		}
+		if err := entry.config.validate(); err != nil {
+			return fmt.Errorf("%s retry policy: %w", entry.operation, err)
+		}
+	}
+	return nil
+}
+
+func (c RetryConfig) policies() (RetryPolicies, error) {
+	var out RetryPolicies
+	var err error
+	if out.Generate, err = c.Generate.policy(); err != nil {
+		return RetryPolicies{}, fmt.Errorf("generate retry policy: %w", err)
+	}
+	if out.Embed, err = c.Embed.policy(); err != nil {
+		return RetryPolicies{}, fmt.Errorf("embed retry policy: %w", err)
+	}
+	if out.Transcription, err = c.Transcription.policy(); err != nil {
+		return RetryPolicies{}, fmt.Errorf("transcription retry policy: %w", err)
+	}
+	if out.TranscriptionSession, err = c.TranscriptionSession.policy(); err != nil {
+		return RetryPolicies{}, fmt.Errorf("transcription session retry policy: %w", err)
+	}
+	if out.Realtime, err = c.Realtime.policy(); err != nil {
+		return RetryPolicies{}, fmt.Errorf("realtime retry policy: %w", err)
+	}
+	return out, nil
+}
+
+// RetryableClass is one built-in error class a deployment may allow for
+// same-target retry.
+type RetryableClass string
+
+const (
+	RetryableRateLimit   RetryableClass = "rate_limit"
+	RetryableTimeout     RetryableClass = "timeout"
+	RetryableUnavailable RetryableClass = "unavailable"
+)
+
+// RetryPolicyConfig is the JSON-only deployment form of RetryPolicy.
+type RetryPolicyConfig struct {
+	MaxAttempts              int              `json:"max_attempts,omitempty"`
+	MaxTotalAttempts         int              `json:"max_total_attempts,omitempty"`
+	Backoff                  *Backoff         `json:"backoff,omitempty"`
+	Retryable                []RetryableClass `json:"retryable,omitempty"`
+	FallbackOnRetryExhausted bool             `json:"fallback_on_retry_exhausted,omitempty"`
+}
+
+// UnmarshalJSON enforces the JSON-only DTO boundary strictly.
+func (c *RetryPolicyConfig) UnmarshalJSON(data []byte) error {
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	decoder.DisallowUnknownFields()
+	type alias RetryPolicyConfig
+	var raw alias
+	if err := decoder.Decode(&raw); err != nil {
+		return fmt.Errorf("decode retry policy: %w", err)
+	}
+	*c = RetryPolicyConfig(raw)
+	return nil
+}
+
+func (c *RetryPolicyConfig) Clone() *RetryPolicyConfig {
+	if c == nil {
+		return nil
+	}
+	cloned := *c
+	if c.Backoff != nil {
+		backoff := *c.Backoff
+		cloned.Backoff = &backoff
+	}
+	cloned.Retryable = append([]RetryableClass(nil), c.Retryable...)
+	return &cloned
+}
+
+func (c *RetryPolicyConfig) validate() error {
+	if c == nil {
+		return nil
+	}
+	if c.MaxAttempts < 0 {
+		return fmt.Errorf("max_attempts must not be negative")
+	}
+	if c.MaxTotalAttempts < 0 {
+		return fmt.Errorf("max_total_attempts must not be negative")
+	}
+	if c.Backoff != nil {
+		if err := c.Backoff.validate(); err != nil {
+			return fmt.Errorf("backoff: %w", err)
+		}
+	}
+	seen := make(map[RetryableClass]struct{}, len(c.Retryable))
+	for _, class := range c.Retryable {
+		switch class {
+		case RetryableRateLimit, RetryableTimeout, RetryableUnavailable:
+		default:
+			return fmt.Errorf("unknown retryable class %q", class)
+		}
+		if _, ok := seen[class]; ok {
+			return fmt.Errorf("duplicate retryable class %q", class)
+		}
+		seen[class] = struct{}{}
+	}
+	return nil
+}
+
+func (c *RetryPolicyConfig) policy() (*RetryPolicy, error) {
+	if c == nil {
+		return nil, nil
+	}
+	var retryable func(context.Context, RetryDecision) bool
+	if c.Retryable == nil {
+		retryable = DefaultRetryable
+	} else {
+		classes := make(map[RetryableClass]struct{}, len(c.Retryable))
+		for _, class := range c.Retryable {
+			classes[class] = struct{}{}
+		}
+		retryable = func(_ context.Context, decision RetryDecision) bool {
+			if decision.ObservableOutput ||
+				decision.ErrorKind != inference.ProviderFailure {
+				return false
+			}
+			if _, ok := classes[RetryableRateLimit]; ok &&
+				errdefs.IsRateLimit(decision.Err) {
+				return true
+			}
+			if _, ok := classes[RetryableTimeout]; ok &&
+				errdefs.IsTimeout(decision.Err) {
+				return true
+			}
+			if _, ok := classes[RetryableUnavailable]; ok &&
+				errdefs.IsNotAvailable(decision.Err) {
+				return true
+			}
+			return false
+		}
+	}
+	var backoff Backoff
+	if c.Backoff != nil {
+		backoff = *c.Backoff
+	}
+	return &RetryPolicy{
+		MaxAttempts:              c.MaxAttempts,
+		MaxTotalAttempts:         c.MaxTotalAttempts,
+		Backoff:                  backoff,
+		Retryable:                retryable,
+		FallbackOnRetryExhausted: c.FallbackOnRetryExhausted,
+	}, nil
+}
+
+// Options converts the policy's retry and circuit-breaker sections into
+// Router construction options.
+func (p Policy) Options() ([]Option, error) {
+	var options []Option
+	if p.Retry != nil {
+		policies, err := p.Retry.policies()
+		if err != nil {
+			return nil, err
+		}
+		options = append(options, WithRetryPolicies(policies))
+	}
+	if p.CircuitBreaker != nil {
+		options = append(options, WithCircuitBreaker(*p.CircuitBreaker))
+	}
+	return options, nil
 }
 
 // ValidateFor checks every configured target against an immutable inference

--- a/sdk/inference/route/resilience.go
+++ b/sdk/inference/route/resilience.go
@@ -1,0 +1,632 @@
+package route
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"math"
+	"math/rand"
+	"sync"
+	"time"
+
+	"github.com/GizClaw/flowcraft/sdk/errdefs"
+	"github.com/GizClaw/flowcraft/sdk/inference"
+	"github.com/GizClaw/flowcraft/sdk/telemetry"
+
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
+)
+
+// RetryPolicies holds one optional retry policy per operation. A nil entry
+// disables retry for that operation (the pre-resilience behavior).
+type RetryPolicies struct {
+	Generate             *RetryPolicy
+	Embed                *RetryPolicy
+	Transcription        *RetryPolicy
+	TranscriptionSession *RetryPolicy
+	Realtime             *RetryPolicy
+}
+
+func (p RetryPolicies) policyFor(operation inference.Operation) *RetryPolicy {
+	switch operation {
+	case inference.OperationGenerate:
+		return p.Generate
+	case inference.OperationEmbed:
+		return p.Embed
+	case inference.OperationTranscription:
+		return p.Transcription
+	case inference.OperationRealtime:
+		return p.Realtime
+	default:
+		return nil
+	}
+}
+
+// sessionPolicyFor returns the retry policy for stream/session opens. The
+// transcription session has its own policy slot even though it shares the
+// operation label with unary Transcribe.
+func (p RetryPolicies) sessionPolicyFor(operation inference.Operation) *RetryPolicy {
+	switch operation {
+	case inference.OperationGenerate:
+		return p.Generate
+	case inference.OperationTranscription:
+		return p.TranscriptionSession
+	case inference.OperationRealtime:
+		return p.Realtime
+	default:
+		return nil
+	}
+}
+
+// RetryDecision is the observable input to a Retryable predicate.
+type RetryDecision struct {
+	Operation        inference.Operation
+	Phase            AttemptPhase
+	Trigger          AttemptTrigger
+	ErrorKind        inference.ErrorKind
+	Err              error
+	Attempt          int
+	ObservableOutput bool
+}
+
+// RetryPolicy controls same-target retry for one operation.
+type RetryPolicy struct {
+	// MaxAttempts is the total logical attempts including the first.
+	// Values below 2 disable retry.
+	MaxAttempts int
+
+	// Backoff controls the delay between attempts. The zero value selects
+	// exponential backoff: 100ms seed, 2s cap, full jitter.
+	Backoff Backoff
+
+	// Retryable decides whether one failure may be retried on the same
+	// target. Nil selects DefaultRetryable. Safety invariants (no retry
+	// after observable output, no retry for compiler/validation/cancel
+	// kinds) are enforced before this predicate is consulted.
+	Retryable func(context.Context, RetryDecision) bool
+
+	// FallbackOnRetryExhausted allows a transient provider failure to move
+	// to the next target once its retry budget is exhausted. Default false
+	// keeps the pre-resilience fallback boundary (compile rejections only).
+	FallbackOnRetryExhausted bool
+
+	// MaxTotalAttempts caps logical attempts across all targets for one
+	// request. Zero disables the global cap; per-target MaxAttempts still
+	// applies.
+	MaxTotalAttempts int
+}
+
+func (p *RetryPolicy) effective() RetryPolicy {
+	if p == nil {
+		return RetryPolicy{MaxAttempts: 1}
+	}
+	effective := *p
+	if effective.MaxAttempts < 1 {
+		effective.MaxAttempts = 1
+	}
+	if effective.MaxTotalAttempts < 0 {
+		effective.MaxTotalAttempts = 0
+	}
+	effective.Backoff = effective.Backoff.normalized()
+	return effective
+}
+
+func (p *RetryPolicy) validate() error {
+	if p == nil {
+		return nil
+	}
+	if p.MaxAttempts < 0 {
+		return fmt.Errorf("retry max attempts must not be negative")
+	}
+	if p.MaxTotalAttempts < 0 {
+		return fmt.Errorf("retry max total attempts must not be negative")
+	}
+	return p.Backoff.validate()
+}
+
+// DefaultRetryable is the conservative same-target retry predicate: only
+// ProviderFailure classified as rate limit, timeout, or not available, and
+// never after observable output.
+var DefaultRetryable = func(_ context.Context, decision RetryDecision) bool {
+	if decision.ObservableOutput || decision.ErrorKind != inference.ProviderFailure {
+		return false
+	}
+	return transientFailure(decision.Err)
+}
+
+func transientFailure(err error) bool {
+	return errdefs.IsRateLimit(err) ||
+		errdefs.IsTimeout(err) ||
+		errdefs.IsNotAvailable(err)
+}
+
+func transientProviderFailure(err error) bool {
+	var inferenceErr *inference.Error
+	if !errors.As(err, &inferenceErr) ||
+		inferenceErr.Kind != inference.ProviderFailure {
+		return false
+	}
+	return transientFailure(err)
+}
+
+func nonRetryableKind(kind inference.ErrorKind) bool {
+	switch kind {
+	case inference.InvalidRequest,
+		inference.UnsupportedOperation,
+		inference.UnsupportedFeature,
+		inference.InvalidExtension,
+		inference.UnknownProvider,
+		inference.UnknownModel,
+		inference.UnknownProfile,
+		inference.PolicyDenied,
+		inference.OperationInterrupted,
+		inference.CompilerContractViolation,
+		inference.InvalidProviderResponse:
+		return true
+	default:
+		return false
+	}
+}
+
+// retryEligible applies the shared safety invariants before consulting the
+// policy's Retryable predicate.
+func retryEligible(
+	ctx context.Context,
+	policy *RetryPolicy,
+	decision RetryDecision,
+) bool {
+	if policy == nil ||
+		policy.MaxAttempts < 2 ||
+		decision.Attempt >= policy.MaxAttempts ||
+		decision.ObservableOutput ||
+		decision.Phase == AttemptPhasePreflight ||
+		nonRetryableKind(decision.ErrorKind) {
+		return false
+	}
+	retryable := policy.Retryable
+	if retryable == nil {
+		retryable = DefaultRetryable
+	}
+	return retryable(ctx, decision)
+}
+
+// BackoffKind selects the delay growth curve.
+type BackoffKind string
+
+const (
+	BackoffFixed       BackoffKind = "fixed"
+	BackoffExponential BackoffKind = "exponential"
+)
+
+// JitterKind selects how delay is randomized.
+type JitterKind string
+
+const (
+	JitterNone  JitterKind = "none"
+	JitterFull  JitterKind = "full"
+	JitterEqual JitterKind = "equal"
+)
+
+// Backoff is the retry delay policy. Zero values select the defaults when
+// used through RetryPolicy.
+type Backoff struct {
+	Kind       BackoffKind
+	Initial    time.Duration
+	Max        time.Duration
+	Multiplier float64
+	Jitter     JitterKind
+}
+
+func (b Backoff) normalized() Backoff {
+	if b.Kind == "" {
+		b.Kind = BackoffExponential
+	}
+	if b.Initial <= 0 {
+		b.Initial = 100 * time.Millisecond
+	}
+	if b.Max <= 0 {
+		b.Max = 2 * time.Second
+	}
+	if b.Multiplier <= 0 {
+		b.Multiplier = 2
+	}
+	if b.Jitter == "" {
+		b.Jitter = JitterFull
+	}
+	return b
+}
+
+func (b Backoff) validate() error {
+	switch b.Kind {
+	case "", BackoffFixed, BackoffExponential:
+	default:
+		return fmt.Errorf("unknown backoff kind %q", b.Kind)
+	}
+	switch b.Jitter {
+	case "", JitterNone, JitterFull, JitterEqual:
+	default:
+		return fmt.Errorf("unknown backoff jitter %q", b.Jitter)
+	}
+	if b.Initial < 0 {
+		return fmt.Errorf("backoff initial must not be negative")
+	}
+	if b.Max < 0 {
+		return fmt.Errorf("backoff max must not be negative")
+	}
+	if b.Multiplier < 0 {
+		return fmt.Errorf("backoff multiplier must not be negative")
+	}
+	return nil
+}
+
+// retryDelay returns the sleep before retry attempt number attempt (1 is the
+// first retry after the initial attempt). A Retry-After hint on err overrides
+// the policy backoff and may exceed Max.
+func retryDelay(policy Backoff, attempt int, err error) time.Duration {
+	if d, ok := errdefs.RetryAfter(err); ok {
+		return d
+	}
+	backoff := policy.normalized()
+	var delay time.Duration
+	switch backoff.Kind {
+	case BackoffFixed:
+		delay = backoff.Initial
+	default:
+		growth := math.Pow(backoff.Multiplier, float64(attempt-1))
+		delay = time.Duration(float64(backoff.Initial) * growth)
+	}
+	if delay > backoff.Max {
+		delay = backoff.Max
+	}
+	if delay <= 0 {
+		return 0
+	}
+	switch backoff.Jitter {
+	case JitterNone:
+		return delay
+	case JitterEqual:
+		half := delay / 2
+		return half + time.Duration(rand.Int63n(int64(half)+1))
+	default: // JitterFull
+		return time.Duration(rand.Int63n(int64(delay) + 1))
+	}
+}
+
+// UnmarshalJSON decodes the JSON-only wire form of Backoff. Durations use
+// time.ParseDuration strings ("100ms", "2s").
+func (b *Backoff) UnmarshalJSON(data []byte) error {
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	decoder.DisallowUnknownFields()
+	var raw struct {
+		Kind       BackoffKind `json:"kind"`
+		Initial    string      `json:"initial"`
+		Max        string      `json:"max"`
+		Multiplier float64     `json:"multiplier"`
+		Jitter     JitterKind  `json:"jitter"`
+	}
+	if err := decoder.Decode(&raw); err != nil {
+		return fmt.Errorf("decode backoff: %w", err)
+	}
+	var initial, max time.Duration
+	var err error
+	if raw.Initial != "" {
+		initial, err = time.ParseDuration(raw.Initial)
+		if err != nil {
+			return fmt.Errorf("backoff initial: %w", err)
+		}
+	}
+	if raw.Max != "" {
+		max, err = time.ParseDuration(raw.Max)
+		if err != nil {
+			return fmt.Errorf("backoff max: %w", err)
+		}
+	}
+	*b = Backoff{
+		Kind:       raw.Kind,
+		Initial:    initial,
+		Max:        max,
+		Multiplier: raw.Multiplier,
+		Jitter:     raw.Jitter,
+	}
+	return nil
+}
+
+// CircuitBreakerConfig controls the per-target circuit breaker.
+type CircuitBreakerConfig struct {
+	// FailureThreshold is consecutive transient failures that open the
+	// circuit. Zero selects the default of 5.
+	FailureThreshold int
+
+	// RecoveryWindow is how long an open circuit stays open before one
+	// half-open probe is allowed. Zero selects the default of 30s.
+	RecoveryWindow time.Duration
+
+	// HalfOpenMaxProbes bounds concurrent probes while half-open. Zero
+	// selects the default of 1.
+	HalfOpenMaxProbes int
+}
+
+func (c CircuitBreakerConfig) normalized() CircuitBreakerConfig {
+	if c.FailureThreshold < 1 {
+		c.FailureThreshold = 5
+	}
+	if c.RecoveryWindow <= 0 {
+		c.RecoveryWindow = 30 * time.Second
+	}
+	if c.HalfOpenMaxProbes < 1 {
+		c.HalfOpenMaxProbes = 1
+	}
+	return c
+}
+
+func (c CircuitBreakerConfig) validate() error {
+	if c.FailureThreshold < 0 {
+		return fmt.Errorf("circuit breaker failure threshold must not be negative")
+	}
+	if c.RecoveryWindow < 0 {
+		return fmt.Errorf("circuit breaker recovery window must not be negative")
+	}
+	if c.HalfOpenMaxProbes < 0 {
+		return fmt.Errorf("circuit breaker half-open max probes must not be negative")
+	}
+	return nil
+}
+
+// UnmarshalJSON decodes the JSON-only wire form of CircuitBreakerConfig.
+// RecoveryWindow uses a time.ParseDuration string.
+func (c *CircuitBreakerConfig) UnmarshalJSON(data []byte) error {
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	decoder.DisallowUnknownFields()
+	var raw struct {
+		FailureThreshold  int    `json:"failure_threshold"`
+		RecoveryWindow    string `json:"recovery_window"`
+		HalfOpenMaxProbes int    `json:"half_open_max_probes"`
+	}
+	if err := decoder.Decode(&raw); err != nil {
+		return fmt.Errorf("decode circuit breaker: %w", err)
+	}
+	var recovery time.Duration
+	if raw.RecoveryWindow != "" {
+		var err error
+		recovery, err = time.ParseDuration(raw.RecoveryWindow)
+		if err != nil {
+			return fmt.Errorf("circuit breaker recovery_window: %w", err)
+		}
+	}
+	*c = CircuitBreakerConfig{
+		FailureThreshold:  raw.FailureThreshold,
+		RecoveryWindow:    recovery,
+		HalfOpenMaxProbes: raw.HalfOpenMaxProbes,
+	}
+	return nil
+}
+
+// Option configures a Router at construction time.
+type Option func(*routerOptions) error
+
+type routerOptions struct {
+	retry   RetryPolicies
+	breaker *CircuitBreakerConfig
+	clock   func() time.Time
+	sleeper func(context.Context, time.Duration) error
+}
+
+// WithRetryPolicies enables retry/backoff for the operations covered by the
+// supplied policies. A policy without its operation selector is rejected by
+// New.
+func WithRetryPolicies(policies RetryPolicies) Option {
+	return func(configured *routerOptions) error {
+		configured.retry = policies
+		return nil
+	}
+}
+
+// WithCircuitBreaker enables the per-target circuit breaker. Zero values in
+// the config select the documented defaults.
+func WithCircuitBreaker(config CircuitBreakerConfig) Option {
+	return func(configured *routerOptions) error {
+		if err := config.validate(); err != nil {
+			return err
+		}
+		normalized := config.normalized()
+		configured.breaker = &normalized
+		return nil
+	}
+}
+
+func withTestClock(clock func() time.Time) Option {
+	return func(configured *routerOptions) error {
+		configured.clock = clock
+		return nil
+	}
+}
+
+func withTestSleeper(sleeper func(context.Context, time.Duration) error) Option {
+	return func(configured *routerOptions) error {
+		configured.sleeper = sleeper
+		return nil
+	}
+}
+
+func defaultSleeper(ctx context.Context, delay time.Duration) error {
+	timer := time.NewTimer(delay)
+	defer timer.Stop()
+	select {
+	case <-timer.C:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+type circuitKey struct {
+	operation inference.Operation
+	model     inference.ModelRef
+}
+
+type circuitState string
+
+const (
+	circuitClosed   circuitState = "closed"
+	circuitOpen     circuitState = "open"
+	circuitHalfOpen circuitState = "half_open"
+)
+
+type circuitEntry struct {
+	state    circuitState
+	failures int
+	openedAt time.Time
+	probes   int
+}
+
+type circuitBreaker struct {
+	config  CircuitBreakerConfig
+	clock   func() time.Time
+	mu      sync.Mutex
+	entries map[circuitKey]*circuitEntry
+}
+
+func newCircuitBreaker(
+	config CircuitBreakerConfig,
+	clock func() time.Time,
+) *circuitBreaker {
+	if clock == nil {
+		clock = time.Now
+	}
+	return &circuitBreaker{
+		config:  config.normalized(),
+		clock:   clock,
+		entries: make(map[circuitKey]*circuitEntry),
+	}
+}
+
+type breakerDecision struct {
+	state   circuitState
+	allowed bool
+}
+
+func (b *circuitBreaker) begin(
+	ctx context.Context,
+	key circuitKey,
+) breakerDecision {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	entry := b.entries[key]
+	if entry == nil {
+		entry = &circuitEntry{state: circuitClosed}
+		b.entries[key] = entry
+	}
+	now := b.clock()
+	switch entry.state {
+	case circuitClosed:
+		return breakerDecision{state: circuitClosed, allowed: true}
+	case circuitOpen:
+		if now.Sub(entry.openedAt) >= b.config.RecoveryWindow {
+			entry.state = circuitHalfOpen
+			entry.probes = 1
+			recordCircuitMetric(ctx, routeCircuitProbes, key)
+			return breakerDecision{state: circuitHalfOpen, allowed: true}
+		}
+		recordCircuitMetric(ctx, routeCircuitSkips, key)
+		return breakerDecision{state: circuitOpen, allowed: false}
+	case circuitHalfOpen:
+		if entry.probes < b.config.HalfOpenMaxProbes {
+			entry.probes++
+			recordCircuitMetric(ctx, routeCircuitProbes, key)
+			return breakerDecision{state: circuitHalfOpen, allowed: true}
+		}
+		recordCircuitMetric(ctx, routeCircuitSkips, key)
+		return breakerDecision{state: circuitHalfOpen, allowed: false}
+	default:
+		recordCircuitMetric(ctx, routeCircuitSkips, key)
+		return breakerDecision{state: entry.state, allowed: false}
+	}
+}
+
+// finish records the outcome of an allowed attempt. counted marks failures
+// that should feed the breaker (transient provider failures only). A nil err
+// closes the circuit and resets the failure count. The returned string is a
+// circuit transition ("open" or "closed") when this outcome changed the
+// circuit state, otherwise empty.
+func (b *circuitBreaker) finish(
+	ctx context.Context,
+	key circuitKey,
+	err error,
+	counted bool,
+) string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	entry := b.entries[key]
+	if entry == nil {
+		return ""
+	}
+	now := b.clock()
+	switch entry.state {
+	case circuitHalfOpen:
+		if entry.probes > 0 {
+			entry.probes--
+		}
+		if err == nil {
+			entry.state = circuitClosed
+			entry.failures = 0
+			return "closed"
+		}
+		if counted {
+			entry.state = circuitOpen
+			entry.openedAt = now
+			recordCircuitMetric(ctx, routeCircuitOpens, key)
+			return "open"
+		}
+	case circuitClosed:
+		if err == nil {
+			entry.failures = 0
+			return ""
+		}
+		if counted {
+			entry.failures++
+			if entry.failures >= b.config.FailureThreshold {
+				entry.state = circuitOpen
+				entry.openedAt = now
+				recordCircuitMetric(ctx, routeCircuitOpens, key)
+				return "open"
+			}
+		}
+	}
+	return ""
+}
+
+func (b *circuitBreaker) isOpen(key circuitKey) bool {
+	if b == nil {
+		return false
+	}
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	entry := b.entries[key]
+	if entry == nil || entry.state != circuitOpen {
+		return false
+	}
+	return b.clock().Sub(entry.openedAt) < b.config.RecoveryWindow
+}
+
+func (b *circuitBreaker) reset() {
+	if b == nil {
+		return
+	}
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	clear(b.entries)
+}
+
+func recordCircuitMetric(
+	ctx context.Context,
+	counter metric.Int64Counter,
+	key circuitKey,
+) {
+	counter.Add(ctx, 1, metric.WithAttributes(
+		attribute.String("inference.operation", string(key.operation)),
+		attribute.String(telemetry.AttrLLMProvider, key.model.ID.Provider),
+		attribute.String(telemetry.AttrLLMModel, key.model.ID.Name),
+	))
+}

--- a/sdk/inference/route/resilience_test.go
+++ b/sdk/inference/route/resilience_test.go
@@ -1,0 +1,791 @@
+package route
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/GizClaw/flowcraft/sdk/errdefs"
+	"github.com/GizClaw/flowcraft/sdk/inference"
+)
+
+func newCountingGenerateRuntime(
+	t *testing.T,
+	fail func(attempt int) error,
+) *inference.Runtime {
+	t.Helper()
+	return newTwoModelGenerateRuntime(t, map[string]func(_ int) error{
+		"model": fail,
+	})
+}
+
+func newTwoModelGenerateRuntime(
+	t *testing.T,
+	behaviors map[string]func(_ int) error,
+) *inference.Runtime {
+	t.Helper()
+	compile := func(
+		_ context.Context,
+		_ inference.ModelRef,
+		request inference.GenerateRequest,
+		shape inference.GenerateExecutionShape,
+	) (inference.Compiled[string], error) {
+		active := request.ActiveFieldsFor(shape)
+		decisions := make([]inference.Decision, len(active))
+		for index, field := range active {
+			decisions[index] = inference.Decision{
+				Field: field, Disposition: inference.Native,
+			}
+		}
+		return inference.Compiled[string]{
+			Wire: "wire",
+			Report: inference.CompileReport{
+				Operation: inference.OperationGenerate, Decisions: decisions,
+			},
+		}, nil
+	}
+	decode := func(_ context.Context, _ string) (inference.GenerateResponse, error) {
+		return validGenerateResponse(), nil
+	}
+	models := make([]inference.ModelImplementation, 0, len(behaviors))
+	for name, fail := range behaviors {
+		counter := 0
+		transport := func(_ context.Context, _ string) (string, error) {
+			counter++
+			if err := fail(counter); err != nil {
+				return "", err
+			}
+			return "ok", nil
+		}
+		driver, err := inference.BindGenerate(compile, transport, decode)
+		if err != nil {
+			t.Fatalf("BindGenerate (%s): %v", name, err)
+		}
+		models = append(models, inference.ModelImplementation{
+			Descriptor: inference.ModelDescriptor{
+				ID: inference.ModelID{Provider: "fake", Name: name},
+			},
+			Openers: inference.Openers{
+				Generate: func(
+					context.Context,
+					inference.ModelRef,
+				) (inference.GenerateOperations, error) {
+					return inference.GenerateOperations{Unary: driver}, nil
+				},
+			},
+		})
+	}
+	runtime, err := inference.NewRuntime([]inference.ProviderDefinition{{
+		ID: "fake", Models: models,
+	}})
+	if err != nil {
+		t.Fatalf("NewRuntime: %v", err)
+	}
+	return runtime
+}
+
+func retryRouter(
+	t *testing.T,
+	runtime *inference.Runtime,
+	model inference.ModelRef,
+	fallback GenerateFallbackPolicy,
+	options ...Option,
+) *Router {
+	t.Helper()
+	selectors := Selectors{
+		Generate: generateSelectorFunc(func(
+			context.Context,
+			inference.GenerateRequest,
+		) (Decision, error) {
+			return generateDecision(model), nil
+		}),
+		GenerateFallback: fallback,
+	}
+	router, err := New(runtime, selectors, options...)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	return router
+}
+
+func TestRetryThenSuccess(t *testing.T) {
+	attempts := 0
+	runtime := newCountingGenerateRuntime(t, func(attempt int) error {
+		attempts = attempt
+		if attempt <= 2 {
+			return errdefs.RateLimit(errors.New("slow down"))
+		}
+		return nil
+	})
+	var delays []time.Duration
+	router := retryRouter(t, runtime, generateModel("model"), nil,
+		WithRetryPolicies(RetryPolicies{
+			Generate: &RetryPolicy{MaxAttempts: 3},
+		}),
+		withTestSleeper(func(_ context.Context, delay time.Duration) error {
+			delays = append(delays, delay)
+			return nil
+		}),
+	)
+
+	response, trace, err := router.Generate(
+		context.Background(),
+		generateRequest("hello"),
+	)
+	if err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+	if attempts != 3 || response.Metadata.Model.Name != "model" {
+		t.Fatalf("attempts/response = %d/%+v", attempts, response)
+	}
+	if len(delays) != 2 {
+		t.Fatalf("slept %d times, want 2", len(delays))
+	}
+	if delays[0] <= 0 || delays[1] <= 0 {
+		t.Fatalf("delays = %v, want positive", delays)
+	}
+	retries := 0
+	for _, attempt := range trace.Attempts {
+		if attempt.Trigger == AttemptTriggerRetry {
+			retries++
+		}
+	}
+	if retries != 2 {
+		t.Fatalf("retry triggers = %d, trace = %+v", retries, trace.Attempts)
+	}
+}
+
+func TestRetryExhaustedReturnsLastError(t *testing.T) {
+	runtime := newCountingGenerateRuntime(t, func(_ int) error {
+		return errdefs.RateLimit(errors.New("slow down"))
+	})
+	router := retryRouter(t, runtime, generateModel("model"), nil,
+		WithRetryPolicies(RetryPolicies{
+			Generate: &RetryPolicy{MaxAttempts: 2},
+		}),
+		withTestSleeper(func(_ context.Context, _ time.Duration) error { return nil }),
+	)
+
+	_, trace, err := router.Generate(context.Background(), generateRequest("hello"))
+	if !inference.IsKind(err, inference.ProviderFailure) {
+		t.Fatalf("Generate error = %v, want provider failure", err)
+	}
+	if !errdefs.IsRateLimit(err) {
+		t.Fatalf("Generate error = %v, want rate limit classification", err)
+	}
+	if len(trace.Attempts) != 4 {
+		t.Fatalf("trace attempts = %+v, want preflight+execute per attempt", trace.Attempts)
+	}
+}
+
+func TestNoRetryOnOperationInterrupted(t *testing.T) {
+	runtime := newCountingGenerateRuntime(t, func(_ int) error {
+		return context.Canceled
+	})
+	router := retryRouter(t, runtime, generateModel("model"), nil,
+		WithRetryPolicies(RetryPolicies{
+			Generate: &RetryPolicy{MaxAttempts: 3},
+		}),
+	)
+
+	_, trace, err := router.Generate(context.Background(), generateRequest("hello"))
+	if !errdefs.IsAborted(err) {
+		t.Fatalf("Generate error = %v, want aborted classification", err)
+	}
+	for _, attempt := range trace.Attempts {
+		if attempt.Trigger == AttemptTriggerRetry {
+			t.Fatalf("unexpected retry attempt: %+v", attempt)
+		}
+	}
+}
+
+func TestNoRetryOnCompilerRejection(t *testing.T) {
+	runtime := newGenerateRouteRuntime(t, map[string]generateRouteBehavior{
+		"model": {reject: inference.UnsupportedFeature},
+	})
+	router := retryRouter(t, runtime, generateModel("model"), nil,
+		WithRetryPolicies(RetryPolicies{
+			Generate: &RetryPolicy{
+				MaxAttempts: 3,
+				Retryable: func(context.Context, RetryDecision) bool {
+					return true
+				},
+			},
+		}),
+	)
+
+	_, trace, err := router.Generate(context.Background(), generateRequest("hello"))
+	if !inference.IsKind(err, inference.UnsupportedFeature) {
+		t.Fatalf("Generate error = %v, want unsupported feature", err)
+	}
+	if len(trace.Attempts) != 1 {
+		t.Fatalf("trace attempts = %+v, want a single rejection", trace.Attempts)
+	}
+}
+
+func TestFallbackOnRetryExhausted(t *testing.T) {
+	first := generateModel("first")
+	second := generateModel("second")
+	firstAttempts := 0
+	runtime := newTwoModelGenerateRuntime(t,
+		map[string]func(_ int) error{
+			"first": func(_ int) error {
+				firstAttempts++
+				return errdefs.RateLimit(errors.New("slow down"))
+			},
+			"second": func(_ int) error { return nil },
+		},
+	)
+	router := retryRouter(t, runtime, first, generateFallbackFunc(func(
+		context.Context,
+		inference.GenerateRequest,
+		Attempt,
+	) (inference.ModelRef, bool, error) {
+		return second, true, nil
+	}), WithRetryPolicies(RetryPolicies{
+		Generate: &RetryPolicy{
+			MaxAttempts:              2,
+			FallbackOnRetryExhausted: true,
+		},
+	}), withTestSleeper(func(_ context.Context, _ time.Duration) error { return nil }))
+
+	response, trace, err := router.Generate(
+		context.Background(),
+		generateRequest("hello"),
+	)
+	if err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+	if response.Metadata.Model.Name != "second" {
+		t.Fatalf("executed = %+v, want second", response.Metadata.Model)
+	}
+	if firstAttempts != 2 {
+		t.Fatalf("primary attempts = %d, want 2", firstAttempts)
+	}
+	if len(trace.Fallbacks) != 1 {
+		t.Fatalf("fallbacks = %+v, want 1", trace.Fallbacks)
+	}
+}
+
+func TestRetryAfterOverridesBackoff(t *testing.T) {
+	runtime := newCountingGenerateRuntime(t, func(_ int) error {
+		return errdefs.WithRetryAfter(
+			errdefs.RateLimit(errors.New("slow down")),
+			7*time.Second,
+		)
+	})
+	var delays []time.Duration
+	router := retryRouter(t, runtime, generateModel("model"), nil,
+		WithRetryPolicies(RetryPolicies{
+			Generate: &RetryPolicy{
+				MaxAttempts: 2,
+				Backoff:     Backoff{Kind: BackoffFixed, Initial: time.Second},
+			},
+		}),
+		withTestSleeper(func(_ context.Context, delay time.Duration) error {
+			delays = append(delays, delay)
+			return nil
+		}),
+	)
+
+	_, _, err := router.Generate(context.Background(), generateRequest("hello"))
+	if !inference.IsKind(err, inference.ProviderFailure) {
+		t.Fatalf("Generate error = %v, want provider failure", err)
+	}
+	if len(delays) != 1 || delays[0] != 7*time.Second {
+		t.Fatalf("delays = %v, want [7s]", delays)
+	}
+}
+
+func TestBackoffStopsOnContextCancel(t *testing.T) {
+	runtime := newCountingGenerateRuntime(t, func(_ int) error {
+		return errdefs.RateLimit(errors.New("slow down"))
+	})
+	router := retryRouter(t, runtime, generateModel("model"), nil,
+		WithRetryPolicies(RetryPolicies{
+			Generate: &RetryPolicy{MaxAttempts: 3},
+		}),
+		withTestSleeper(func(ctx context.Context, _ time.Duration) error {
+			return ctx.Err()
+		}),
+	)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	_, _, err := router.Generate(ctx, generateRequest("hello"))
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("Generate error = %v, want context canceled", err)
+	}
+}
+
+func TestBreakerOpensSkipsAndRecovers(t *testing.T) {
+	failMode := true
+	runtime := newCountingGenerateRuntime(t, func(_ int) error {
+		if failMode {
+			return errdefs.RateLimit(errors.New("slow down"))
+		}
+		return nil
+	})
+	now := time.Now()
+	router := retryRouter(t, runtime, generateModel("model"), nil,
+		WithCircuitBreaker(CircuitBreakerConfig{
+			FailureThreshold:  2,
+			RecoveryWindow:    time.Hour,
+			HalfOpenMaxProbes: 1,
+		}),
+		withTestClock(func() time.Time { return now }),
+		withTestSleeper(func(_ context.Context, _ time.Duration) error { return nil }),
+	)
+
+	// Two transient failures open the circuit; the second carries the
+	// closed → open transition in its trace.
+	var openTrace Trace
+	for index := range 2 {
+		_, trace, err := router.Generate(
+			context.Background(),
+			generateRequest("hello"),
+		)
+		if !inference.IsKind(err, inference.ProviderFailure) {
+			t.Fatalf("Generate error = %v, want provider failure", err)
+		}
+		if index == 1 {
+			openTrace = trace
+		}
+	}
+	if transition := openTrace.Attempts[len(openTrace.Attempts)-1].CircuitTransition; transition != "open" {
+		t.Fatalf("opening attempt transition = %q, want open", transition)
+	}
+	// Third call is skipped: no fallback policy, so CircuitOpen.
+	_, trace, err := router.Generate(context.Background(), generateRequest("hello"))
+	if !IsKind(err, CircuitOpen) {
+		t.Fatalf("Generate error = %v, want circuit open", err)
+	}
+	if trace.Attempts[len(trace.Attempts)-1].Outcome != AttemptOutcomeSkipped ||
+		trace.Attempts[len(trace.Attempts)-1].Circuit != "open" {
+		t.Fatalf("last attempt = %+v, want open skip", trace.Attempts[len(trace.Attempts)-1])
+	}
+
+	// Recovery window elapses and the half-open probe succeeds, closing it.
+	failMode = false
+	now = now.Add(2 * time.Hour)
+	_, probeTrace, err := router.Generate(
+		context.Background(),
+		generateRequest("hello"),
+	)
+	if err != nil {
+		t.Fatalf("half-open probe: %v", err)
+	}
+	if transition := probeTrace.Attempts[len(probeTrace.Attempts)-1].CircuitTransition; transition != "closed" {
+		t.Fatalf("probe transition = %q, want closed", transition)
+	}
+	if _, _, err := router.Generate(
+		context.Background(),
+		generateRequest("hello"),
+	); err != nil {
+		t.Fatalf("closed circuit call: %v", err)
+	}
+
+	// A new transient failure starts the counter again.
+	failMode = true
+	if _, _, err := router.Generate(
+		context.Background(),
+		generateRequest("hello"),
+	); !inference.IsKind(err, inference.ProviderFailure) {
+		t.Fatalf("Generate error = %v, want provider failure", err)
+	}
+}
+
+func TestResetCircuitBreaker(t *testing.T) {
+	runtime := newCountingGenerateRuntime(t, func(int) error {
+		return errdefs.RateLimit(errors.New("slow down"))
+	})
+	router := retryRouter(t, runtime, generateModel("model"), nil,
+		WithCircuitBreaker(CircuitBreakerConfig{
+			FailureThreshold:  1,
+			RecoveryWindow:    time.Hour,
+			HalfOpenMaxProbes: 1,
+		}),
+		withTestClock(func() time.Time { return time.Now() }),
+		withTestSleeper(func(context.Context, time.Duration) error { return nil }),
+	)
+
+	if _, _, err := router.Generate(
+		context.Background(),
+		generateRequest("hello"),
+	); !inference.IsKind(err, inference.ProviderFailure) {
+		t.Fatalf("Generate error = %v, want provider failure", err)
+	}
+	if _, _, err := router.Generate(
+		context.Background(),
+		generateRequest("hello"),
+	); !IsKind(err, CircuitOpen) {
+		t.Fatalf("Generate error = %v, want circuit open", err)
+	}
+
+	router.ResetCircuitBreaker()
+	if _, _, err := router.Generate(
+		context.Background(),
+		generateRequest("hello"),
+	); !inference.IsKind(err, inference.ProviderFailure) {
+		t.Fatalf("Generate after reset = %v, want provider failure, not circuit open", err)
+	}
+}
+
+func TestGlobalAttemptBudgetStopsRetriesAndFallback(t *testing.T) {
+	runtime := newTwoModelGenerateRuntime(t, map[string]func(int) error{
+		"first":  func(int) error { return errdefs.RateLimit(errors.New("slow")) },
+		"second": func(int) error { return errdefs.RateLimit(errors.New("slow")) },
+	})
+	router := retryRouter(t, runtime, generateModel("first"), generateFallbackFunc(func(
+		context.Context,
+		inference.GenerateRequest,
+		Attempt,
+	) (inference.ModelRef, bool, error) {
+		return generateModel("second"), true, nil
+	}), WithRetryPolicies(RetryPolicies{
+		Generate: &RetryPolicy{
+			MaxAttempts:              3,
+			MaxTotalAttempts:         2,
+			FallbackOnRetryExhausted: true,
+		},
+	}), withTestSleeper(func(context.Context, time.Duration) error { return nil }))
+
+	_, trace, err := router.Generate(
+		context.Background(),
+		generateRequest("hello"),
+	)
+	if !inference.IsKind(err, inference.ProviderFailure) {
+		t.Fatalf("Generate error = %v, want provider failure", err)
+	}
+	if len(trace.Fallbacks) != 0 {
+		t.Fatalf("fallbacks = %+v, want none under global budget", trace.Fallbacks)
+	}
+	// Two logical attempts (preflight + execute each) exhausted the budget.
+	if len(trace.Attempts) != 4 {
+		t.Fatalf("trace attempts = %+v, want 4 records for 2 logical attempts", trace.Attempts)
+	}
+}
+
+func TestBreakerHalfOpenConcurrentProbes(t *testing.T) {
+	failMode := true
+	var transportCalls atomic.Int64
+	probeStarted := make(chan struct{})
+	releaseProbe := make(chan struct{})
+	var probeOnce sync.Once
+	runtime := newTwoModelGenerateRuntime(t, map[string]func(int) error{
+		"model": func(int) error {
+			transportCalls.Add(1)
+			if failMode {
+				return errdefs.RateLimit(errors.New("slow down"))
+			}
+			probeOnce.Do(func() { close(probeStarted) })
+			<-releaseProbe
+			return nil
+		},
+	})
+	now := time.Now()
+	router := retryRouter(t, runtime, generateModel("model"), nil,
+		WithCircuitBreaker(CircuitBreakerConfig{
+			FailureThreshold:  1,
+			RecoveryWindow:    time.Hour,
+			HalfOpenMaxProbes: 1,
+		}),
+		withTestClock(func() time.Time { return now }),
+		withTestSleeper(func(context.Context, time.Duration) error { return nil }),
+	)
+
+	if _, _, err := router.Generate(
+		context.Background(),
+		generateRequest("hello"),
+	); !inference.IsKind(err, inference.ProviderFailure) {
+		t.Fatalf("Generate error = %v, want provider failure", err)
+	}
+	failMode = false
+	now = now.Add(2 * time.Hour)
+
+	const workers = 8
+	results := make(chan error, workers)
+	var group sync.WaitGroup
+	for range workers {
+		group.Add(1)
+		go func() {
+			defer group.Done()
+			_, _, err := router.Generate(
+				context.Background(),
+				generateRequest("hello"),
+			)
+			results <- err
+		}()
+	}
+
+	// The single half-open probe is now blocked in transport. Every other
+	// worker must be denied until it finishes.
+	<-probeStarted
+	circuitOpens := 0
+	for circuitOpens < workers-1 {
+		err := <-results
+		if !IsKind(err, CircuitOpen) {
+			t.Fatalf("unexpected result before probe released: %v", err)
+		}
+		circuitOpens++
+	}
+	close(releaseProbe)
+	if err := <-results; err != nil {
+		t.Fatalf("probe result = %v, want success", err)
+	}
+	group.Wait()
+	close(results)
+
+	if got := transportCalls.Load(); got != 2 {
+		t.Fatalf("transport calls = %d, want 2 (open + single probe)", got)
+	}
+	if _, _, err := router.Generate(
+		context.Background(),
+		generateRequest("hello"),
+	); err != nil {
+		t.Fatalf("Generate after probe = %v, want success on closed circuit", err)
+	}
+}
+
+func TestPolicyJSONRetryAndCircuitBreaker(t *testing.T) {
+	data := `{
+		"generate": [{
+			"tier": "primary",
+			"targets": [{"model": {"id": {"provider": "fake", "name": "model"}}}]
+		}],
+		"retry": {
+			"generate": {
+				"max_attempts": 2,
+				"max_total_attempts": 4,
+				"backoff": {"kind": "fixed", "initial": "250ms"},
+				"retryable": ["rate_limit"],
+				"fallback_on_retry_exhausted": true
+			}
+		},
+		"circuit_breaker": {
+			"failure_threshold": 3,
+			"recovery_window": "45s",
+			"half_open_max_probes": 1
+		}
+	}`
+	var policy Policy
+	if err := json.Unmarshal([]byte(data), &policy); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if err := policy.Validate(); err != nil {
+		t.Fatalf("Validate: %v", err)
+	}
+	options, err := policy.Options()
+	if err != nil {
+		t.Fatalf("Options: %v", err)
+	}
+	if len(options) != 2 {
+		t.Fatalf("options = %d, want 2", len(options))
+	}
+}
+
+func TestPolicyJSONRejectsUnknownRetryFields(t *testing.T) {
+	data := `{
+		"generate": [{
+			"tier": "primary",
+			"targets": [{"model": {"id": {"provider": "fake", "name": "model"}}}]
+		}],
+		"retry": {
+			"generate": {"max_attempts": 2, "bogus": true}
+		}
+	}`
+	var policy Policy
+	if err := json.Unmarshal([]byte(data), &policy); err == nil {
+		t.Fatal("Unmarshal accepted an unknown retry field")
+	}
+}
+
+func TestRetryPolicyRequiresSelector(t *testing.T) {
+	runtime := newGenerateRouteRuntime(t, map[string]generateRouteBehavior{
+		"model": {},
+	})
+	_, err := New(runtime, Selectors{
+		Generate: generateSelectorFunc(func(
+			context.Context,
+			inference.GenerateRequest,
+		) (Decision, error) {
+			return generateDecision(generateModel("model")), nil
+		}),
+	}, WithRetryPolicies(RetryPolicies{
+		Embed: &RetryPolicy{MaxAttempts: 2},
+	}))
+	if err == nil || !errdefs.IsValidation(err) {
+		t.Fatalf("New error = %v, want validation failure", err)
+	}
+}
+
+func TestRetryPolicyConfigRequiresPools(t *testing.T) {
+	policy := Policy{
+		Generate: []Pool{{
+			Tier:    "primary",
+			Targets: []Target{{Model: generateModel("model")}},
+		}},
+		Retry: &RetryConfig{
+			Embed: &RetryPolicyConfig{MaxAttempts: 2},
+		},
+	}
+	if err := policy.Validate(); err == nil ||
+		!strings.Contains(err.Error(), "embed retry policy") {
+		t.Fatal("Validate accepted retry policy without pools")
+	}
+}
+
+func TestTraceCloneOwnsNewAttemptFields(t *testing.T) {
+	target := generateModel("model")
+	trace := Trace{
+		Attempts: []Attempt{{
+			Target: target, Phase: AttemptPhaseExecute,
+			Trigger: AttemptTriggerRetry, Outcome: AttemptOutcomeFailed,
+			Number: 2, BackoffMillis: 5, Circuit: "half_open",
+		}},
+	}
+	clone := trace.Clone()
+	clone.Attempts[0].Number = 9
+	if trace.Attempts[0].Number != 2 {
+		t.Fatal("trace clone shares attempt number")
+	}
+}
+
+func TestPolicyJSONUnknownCircuitFieldRejected(t *testing.T) {
+	data := `{
+		"generate": [{
+			"tier": "primary",
+			"targets": [{"model": {"id": {"provider": "fake", "name": "model"}}}]
+		}],
+		"circuit_breaker": {"failure_threshold": 3, "bogus": true}
+	}`
+	var policy Policy
+	if err := json.Unmarshal([]byte(data), &policy); err == nil {
+		t.Fatal("Unmarshal accepted an unknown circuit breaker field")
+	}
+}
+
+func TestGenerateStreamRetriesOpenFailure(t *testing.T) {
+	first := generateModel("stream")
+	opens := 0
+	// Build a dedicated runtime whose stream opener fails once with a
+	// transient error and then succeeds.
+	compile := func(
+		_ context.Context,
+		_ inference.ModelRef,
+		request inference.GenerateRequest,
+		shape inference.GenerateExecutionShape,
+	) (inference.Compiled[string], error) {
+		active := request.ActiveFieldsFor(shape)
+		decisions := make([]inference.Decision, len(active))
+		for index, field := range active {
+			decisions[index] = inference.Decision{
+				Field: field, Disposition: inference.Native,
+			}
+		}
+		return inference.Compiled[string]{
+			Wire: "wire",
+			Report: inference.CompileReport{
+				Operation: inference.OperationGenerate, Decisions: decisions,
+			},
+		}, nil
+	}
+	operations, err := inference.BindGenerateOperations(
+		compile,
+		func(_ context.Context, _ string) (string, error) { return "ok", nil },
+		func(_ context.Context, _ string) (inference.GenerateResponse, error) {
+			return validGenerateResponse(), nil
+		},
+		func(_ context.Context, _ string) (inference.ProviderStream[streamRaw], error) {
+			opens++
+			if opens == 1 {
+				return nil, errdefs.RateLimit(errors.New("slow down"))
+			}
+			return &routeProviderStream{events: []streamRaw{{finish: true}}}, nil
+		},
+		func(_ context.Context, raw streamRaw) (inference.GenerateStreamEvent, error) {
+			if raw.finish {
+				return inference.GenerateStreamEvent{FinishReason: inference.FinishCompleted}, nil
+			}
+			return inference.GenerateStreamEvent{}, nil
+		},
+	)
+	if err != nil {
+		t.Fatalf("BindGenerateOperations: %v", err)
+	}
+	streamRuntime, err := inference.NewRuntime([]inference.ProviderDefinition{{
+		ID: "fake",
+		Models: []inference.ModelImplementation{{
+			Descriptor: inference.ModelDescriptor{
+				ID: inference.ModelID{Provider: "fake", Name: "stream"},
+			},
+			Openers: inference.Openers{
+				Generate: func(
+					context.Context,
+					inference.ModelRef,
+				) (inference.GenerateOperations, error) {
+					return operations, nil
+				},
+			},
+		}},
+	}})
+	if err != nil {
+		t.Fatalf("NewRuntime: %v", err)
+	}
+	router := retryRouter(t, streamRuntime, first, nil,
+		WithRetryPolicies(RetryPolicies{
+			Generate: &RetryPolicy{MaxAttempts: 2},
+		}),
+		withTestSleeper(func(_ context.Context, _ time.Duration) error { return nil }),
+	)
+	stream, trace, err := router.GenerateStream(
+		context.Background(),
+		generateRequest("hello"),
+	)
+	if err != nil {
+		t.Fatalf("GenerateStream: %v", err)
+	}
+	defer func() { _ = stream.Close() }()
+	if opens != 2 {
+		t.Fatalf("stream opens = %d, want 2", opens)
+	}
+	retries := 0
+	for _, attempt := range trace.Attempts {
+		if attempt.Trigger == AttemptTriggerRetry {
+			retries++
+		}
+	}
+	if retries != 1 {
+		t.Fatalf("retry triggers = %d, trace = %+v", retries, trace.Attempts)
+	}
+	if trace.Executed != first ||
+		trace.Attempts[len(trace.Attempts)-1].Outcome != AttemptOutcomeOpened {
+		t.Fatalf("trace = %+v", trace)
+	}
+}
+
+func TestAttemptJSONUsesJSONWireField(t *testing.T) {
+	data, err := json.Marshal(Attempt{
+		Target: generateModel("model"), Phase: AttemptPhaseExecute,
+		Trigger: AttemptTriggerRetry, Outcome: AttemptOutcomeFailed,
+		Number: 2, BackoffMillis: 25,
+	})
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	var raw map[string]any
+	if err := json.Unmarshal(data, &raw); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if raw["attempt"] != float64(2) || raw["backoff_ms"] != float64(25) {
+		t.Fatalf("wire fields = %+v", raw)
+	}
+	if _, ok := raw["number"]; ok {
+		t.Fatalf("unexpected Go field name on wire: %+v", raw)
+	}
+}

--- a/sdk/inference/route/router.go
+++ b/sdk/inference/route/router.go
@@ -697,7 +697,7 @@ func nextFallbackTarget[Request any](
 	}
 	if !skipEligibility {
 		eligible := fallbackEligible(attempt)
-		if !eligible && !(allowTransient && attempt.Transient) {
+		if !eligible && (!allowTransient || !attempt.Transient) {
 			return inference.ModelRef{}, false, nil
 		}
 	}

--- a/sdk/inference/route/router.go
+++ b/sdk/inference/route/router.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"reflect"
+	"time"
 
 	"github.com/GizClaw/flowcraft/sdk/errdefs"
 	"github.com/GizClaw/flowcraft/sdk/inference"
@@ -86,6 +87,7 @@ type AttemptTrigger string
 
 const (
 	AttemptTriggerSelection AttemptTrigger = "selection"
+	AttemptTriggerRetry     AttemptTrigger = "retry"
 	AttemptTriggerFallback  AttemptTrigger = "fallback"
 )
 
@@ -95,6 +97,7 @@ const (
 	AttemptOutcomeSucceeded AttemptOutcome = "succeeded"
 	AttemptOutcomeFailed    AttemptOutcome = "failed"
 	AttemptOutcomeOpened    AttemptOutcome = "opened"
+	AttemptOutcomeSkipped   AttemptOutcome = "skipped"
 )
 
 // Attempt records only observable route facts. In particular, an opened
@@ -106,6 +109,24 @@ type Attempt struct {
 	Outcome          AttemptOutcome      `json:"outcome"`
 	ErrorKind        inference.ErrorKind `json:"error_kind,omitempty"`
 	ObservableOutput bool                `json:"observable_output"`
+	// Number is the 1-based attempt number within one target. The initial
+	// attempt is 1; retries are 2+.
+	Number int `json:"attempt,omitempty"`
+	// BackoffMillis is the delay slept before this attempt. Zero for the
+	// first attempt.
+	BackoffMillis int64 `json:"backoff_ms,omitempty"`
+	// Circuit is the circuit state before this attempt ("open", "half_open",
+	// or empty when the breaker is disabled).
+	Circuit string `json:"circuit,omitempty"`
+	// CircuitTransition records a circuit state change caused by this
+	// attempt ("open" or "closed"), empty when the state did not change.
+	CircuitTransition string `json:"circuit_transition,omitempty"`
+	// WireAttempts records the provider-reported HTTP sends inside this
+	// logical attempt when the provider propagates the count.
+	WireAttempts int `json:"wire_attempts,omitempty"`
+	// Transient marks a provider failure classified as retryable/transient.
+	// It feeds fallback-on-retry-exhausted decisions.
+	Transient bool `json:"transient,omitempty"`
 }
 
 // Trace separates route selection from compiler field dispositions. Executed
@@ -132,12 +153,19 @@ func (t Trace) Clone() Trace {
 type Router struct {
 	runtime   *inference.Runtime
 	selectors Selectors
+	retry     RetryPolicies
+	breaker   *circuitBreaker
+	sleeper   func(context.Context, time.Duration) error
 }
 
 // New requires at least one operation selector. A fallback policy without its
 // operation selector is a misconfiguration: the policy would never run, so
 // New rejects it instead of silently ignoring it.
-func New(runtime *inference.Runtime, selectors Selectors) (*Router, error) {
+func New(
+	runtime *inference.Runtime,
+	selectors Selectors,
+	options ...Option,
+) (*Router, error) {
 	if runtime == nil {
 		return nil, errdefs.Validationf("inference runtime is required")
 	}
@@ -168,7 +196,72 @@ func New(runtime *inference.Runtime, selectors Selectors) (*Router, error) {
 			)
 		}
 	}
-	return &Router{runtime: runtime, selectors: selectors}, nil
+	var configured routerOptions
+	configured.clock = time.Now
+	configured.sleeper = defaultSleeper
+	for index, option := range options {
+		if option == nil {
+			return nil, errdefs.Validationf("router option %d is nil", index)
+		}
+		if err := option(&configured); err != nil {
+			return nil, errdefs.Validationf("router option %d: %v", index, err)
+		}
+	}
+	if err := validateRetryPolicies(configured.retry, selectors); err != nil {
+		return nil, err
+	}
+	var breaker *circuitBreaker
+	if configured.breaker != nil {
+		breaker = newCircuitBreaker(*configured.breaker, configured.clock)
+	}
+	return &Router{
+		runtime:   runtime,
+		selectors: selectors,
+		retry:     configured.retry,
+		breaker:   breaker,
+		sleeper:   configured.sleeper,
+	}, nil
+}
+
+func validateRetryPolicies(
+	policies RetryPolicies,
+	selectors Selectors,
+) error {
+	entries := []struct {
+		operation inference.Operation
+		policy    *RetryPolicy
+		selector  any
+	}{
+		{inference.OperationGenerate, policies.Generate, selectors.Generate},
+		{inference.OperationEmbed, policies.Embed, selectors.Embed},
+		{inference.OperationTranscription, policies.Transcription, selectors.Transcription},
+		{inference.OperationTranscription, policies.TranscriptionSession, selectors.TranscriptionSession},
+		{inference.OperationRealtime, policies.Realtime, selectors.Realtime},
+	}
+	for _, entry := range entries {
+		if entry.policy == nil {
+			continue
+		}
+		if isNilInterface(entry.selector) {
+			return errdefs.Validationf(
+				"%s retry policy requires a %s selector",
+				entry.operation,
+				entry.operation,
+			)
+		}
+		if err := entry.policy.validate(); err != nil {
+			return errdefs.Validationf("%s retry policy: %v", entry.operation, err)
+		}
+	}
+	return nil
+}
+
+// ResetCircuitBreaker clears all per-target circuit state. In-flight calls
+// finish against the breaker they already started; new calls start closed.
+func (r *Router) ResetCircuitBreaker() {
+	if r.breaker != nil {
+		r.breaker.reset()
+	}
 }
 
 // maxFallbackTargets bounds total targets tried for one request, counting the
@@ -176,14 +269,15 @@ func New(runtime *inference.Runtime, selectors Selectors) (*Router, error) {
 const maxFallbackTargets = 8
 
 // executeWithFallback runs one unary operation (Generate, Embed, Transcribe)
-// across fallback targets. snapshot must already be an owned clone; selectors
-// and fallback policies receive their own clones so they cannot mutate the
-// request being executed. preflight may be nil: without it the compiler runs
-// inside execute, and a local rejection still surfaces with a fallback-eligible
-// kind before any provider I/O.
+// across fallback targets with per-target retry/backoff and the circuit
+// breaker. snapshot must already be an owned clone; selectors and fallback
+// policies receive their own clones so they cannot mutate the request being
+// executed. preflight may be nil: without it the compiler runs inside execute,
+// and a local rejection still surfaces with a fallback-eligible kind before
+// any provider I/O.
 func executeWithFallback[Request any, Response any](
+	r *Router,
 	ctx context.Context,
-	runtime *inference.Runtime,
 	operation inference.Operation,
 	snapshot Request,
 	clone func(Request) Request,
@@ -196,7 +290,7 @@ func executeWithFallback[Request any, Response any](
 ) (Response, Trace, error) {
 	var zero Response
 	decision, err := selectTarget(
-		ctx, runtime, operation, snapshot, clone, validate, selector, selectRequest,
+		ctx, r.runtime, operation, snapshot, clone, validate, selector, selectRequest,
 	)
 	if err != nil {
 		return zero, Trace{}, err
@@ -205,14 +299,148 @@ func executeWithFallback[Request any, Response any](
 	target := decision.Selected
 	trigger := AttemptTriggerSelection
 	seen := map[inference.ModelRef]struct{}{target: {}}
+	policy := r.retry.policyFor(operation).effective()
+	var lastErr error
+	totalAttempts := 0
 	for {
-		if preflight != nil {
-			if err := preflight(ctx, target, snapshot); err != nil {
-				attempt := failedAttempt(target, AttemptPhasePreflight, trigger, err)
+		breakerAllowed := false
+		var key circuitKey
+		if r.breaker != nil {
+			key = circuitKey{operation: operation, model: target}
+			gate := r.breaker.begin(ctx, key)
+			breakerAllowed = gate.allowed
+			if !breakerAllowed {
+				trace.Attempts = append(trace.Attempts, Attempt{
+					Target: target, Phase: AttemptPhaseExecute, Trigger: trigger,
+					Outcome: AttemptOutcomeSkipped, Circuit: string(gate.state),
+				})
+				next, ok, fallbackErr := nextFallbackTarget(r,
+					ctx, operation, snapshot, clone,
+					Attempt{Target: target, Phase: AttemptPhaseExecute, Trigger: trigger, Outcome: AttemptOutcomeSkipped},
+					&trace, seen, fallbackNext, true, false, AttemptPhaseExecute,
+				)
+				if fallbackErr != nil {
+					return zero, trace, fallbackErr
+				}
+				if !ok {
+					if lastErr != nil {
+						return zero, trace, lastErr
+					}
+					return zero, trace, NewError(
+						CircuitOpen,
+						operation,
+						errors.New("all route targets are circuit-open"),
+					)
+				}
+				target, trigger = next, AttemptTriggerFallback
+				continue
+			}
+		}
+
+		attemptNumber := 0
+		var backoffMillis int64
+		for {
+			if policy.MaxTotalAttempts > 0 &&
+				totalAttempts >= policy.MaxTotalAttempts {
+				if lastErr != nil {
+					return zero, trace, lastErr
+				}
+				return zero, trace, errors.New("retry total attempt budget exhausted")
+			}
+			attemptNumber++
+			totalAttempts++
+			attemptTrigger := trigger
+			if attemptNumber > 1 {
+				attemptTrigger = AttemptTriggerRetry
+			}
+			if attemptNumber > 1 {
+				delay := retryDelay(policy.Backoff, attemptNumber-1, lastErr)
+				if err := r.sleeper(ctx, delay); err != nil {
+					return zero, trace, err
+				}
+				backoffMillis = delay.Milliseconds()
+			}
+			if preflight != nil {
+				if err := preflight(ctx, target, snapshot); err != nil {
+					attempt := failedAttempt(target, AttemptPhasePreflight, attemptTrigger, err)
+					attempt.Number = attemptNumber
+					attempt.BackoffMillis = backoffMillis
+					if r.breaker != nil {
+						attempt.CircuitTransition = r.breaker.finish(
+							ctx, key, err, false,
+						)
+					}
+					trace.Attempts = append(trace.Attempts, attempt)
+					if policy.MaxTotalAttempts > 0 &&
+						totalAttempts >= policy.MaxTotalAttempts {
+						return zero, trace, err
+					}
+					if fallbackEligible(attempt) {
+						next, ok, fallbackErr := nextFallbackTarget(r,
+							ctx, operation, snapshot, clone,
+							attempt, &trace, seen, fallbackNext, false, false, AttemptPhaseExecute,
+						)
+						if fallbackErr != nil {
+							return zero, trace, fallbackErr
+						}
+						if !ok {
+							return zero, trace, err
+						}
+						target, trigger = next, AttemptTriggerFallback
+						break
+					}
+					decision := retryDecision(
+						operation, AttemptPhasePreflight, attemptTrigger, err, attemptNumber,
+					)
+					if retryEligible(ctx, &policy, decision) {
+						lastErr = err
+						continue
+					}
+					allowTransient := policy.FallbackOnRetryExhausted && attempt.Transient
+					next, ok, fallbackErr := nextFallbackTarget(r,
+						ctx, operation, snapshot, clone,
+						attempt, &trace, seen, fallbackNext, false, allowTransient, AttemptPhaseExecute,
+					)
+					if fallbackErr != nil {
+						return zero, trace, fallbackErr
+					}
+					if !ok {
+						return zero, trace, err
+					}
+					target, trigger = next, AttemptTriggerFallback
+					break
+				}
+				trace.Attempts = append(trace.Attempts, Attempt{
+					Target: target, Phase: AttemptPhasePreflight, Trigger: trigger,
+					Outcome: AttemptOutcomeSucceeded, Number: attemptNumber,
+				})
+			}
+			response, metadata, err := execute(ctx, target, snapshot)
+			if err != nil {
+				attempt := failedAttempt(target, AttemptPhaseExecute, attemptTrigger, err)
+				attempt.Number = attemptNumber
+				attempt.BackoffMillis = backoffMillis
+				if r.breaker != nil {
+					attempt.CircuitTransition = r.breaker.finish(
+						ctx, key, err, attempt.Transient,
+					)
+				}
 				trace.Attempts = append(trace.Attempts, attempt)
-				next, ok, fallbackErr := nextFallbackTarget(
-					ctx, runtime, operation, snapshot, clone,
-					attempt, &trace, seen, fallbackNext,
+				if policy.MaxTotalAttempts > 0 &&
+					totalAttempts >= policy.MaxTotalAttempts {
+					return zero, trace, err
+				}
+				decision := retryDecision(
+					operation, AttemptPhaseExecute, attemptTrigger, err, attemptNumber,
+				)
+				if retryEligible(ctx, &policy, decision) {
+					lastErr = err
+					continue
+				}
+				allowTransient := policy.FallbackOnRetryExhausted && attempt.Transient
+				next, ok, fallbackErr := nextFallbackTarget(r,
+					ctx, operation, snapshot, clone,
+					attempt, &trace, seen, fallbackNext, false, allowTransient, AttemptPhaseExecute,
 				)
 				if fallbackErr != nil {
 					return zero, trace, fallbackErr
@@ -221,54 +449,39 @@ func executeWithFallback[Request any, Response any](
 					return zero, trace, err
 				}
 				target, trigger = next, AttemptTriggerFallback
-				continue
+				break
+			}
+			transition := ""
+			if r.breaker != nil {
+				transition = r.breaker.finish(ctx, key, nil, false)
 			}
 			trace.Attempts = append(trace.Attempts, Attempt{
-				Target: target, Phase: AttemptPhasePreflight, Trigger: trigger,
-				Outcome: AttemptOutcomeSucceeded,
+				Target: target, Phase: AttemptPhaseExecute, Trigger: attemptTrigger,
+				Outcome: AttemptOutcomeSucceeded, Number: attemptNumber,
+				CircuitTransition: transition,
 			})
-		}
-		response, metadata, err := execute(ctx, target, snapshot)
-		if err != nil {
-			attempt := failedAttempt(target, AttemptPhaseExecute, trigger, err)
-			trace.Attempts = append(trace.Attempts, attempt)
-			next, ok, fallbackErr := nextFallbackTarget(
-				ctx, runtime, operation, snapshot, clone,
-				attempt, &trace, seen, fallbackNext,
-			)
-			if fallbackErr != nil {
-				return zero, trace, fallbackErr
+			trace.Executed = target
+			if metadata.Operation != operation || metadata.Model != target.ID {
+				return zero, trace, NewError(
+					SelectorContractViolation,
+					operation,
+					errors.New("inference response does not match selected route"),
+				)
 			}
-			if !ok {
-				return zero, trace, err
-			}
-			target, trigger = next, AttemptTriggerFallback
-			continue
+			return response, trace, nil
 		}
-		trace.Attempts = append(trace.Attempts, Attempt{
-			Target: target, Phase: AttemptPhaseExecute, Trigger: trigger,
-			Outcome: AttemptOutcomeSucceeded,
-		})
-		trace.Executed = target
-		if metadata.Operation != operation || metadata.Model != target.ID {
-			return zero, trace, NewError(
-				SelectorContractViolation,
-				operation,
-				errors.New("inference response does not match selected route"),
-			)
-		}
-		return response, trace, nil
 	}
 }
 
 // openSessionWithFallback opens a stream or session across fallback targets
-// (OpenTranscription, OpenRealtime). Fallback only exists before open: an
-// opened session is owned by the caller and never migrates. There is no
-// preflight pass because opening already compiles locally before any provider
-// I/O, so a compiler rejection surfaces with a fallback-eligible kind.
+// with per-target retry/backoff and the circuit breaker. Fallback and retry
+// only exist before open: an opened session is owned by the caller and never
+// migrates. preflight is optional and only used by GenerateStream; without it
+// opening already compiles locally before any provider I/O, so a compiler
+// rejection surfaces with a fallback-eligible kind.
 func openSessionWithFallback[Request any, Session any](
+	r *Router,
 	ctx context.Context,
-	runtime *inference.Runtime,
 	operation inference.Operation,
 	snapshot Request,
 	clone func(Request) Request,
@@ -276,11 +489,12 @@ func openSessionWithFallback[Request any, Session any](
 	selector any,
 	selectRequest func(context.Context, Request) (Decision, error),
 	fallbackNext func(context.Context, Request, Attempt) (inference.ModelRef, bool, error),
+	preflight func(context.Context, inference.ModelRef, Request) error,
 	open func(context.Context, inference.ModelRef, Request) (Session, error),
 ) (Session, Trace, error) {
 	var zero Session
 	decision, err := selectTarget(
-		ctx, runtime, operation, snapshot, clone, validate, selector, selectRequest,
+		ctx, r.runtime, operation, snapshot, clone, validate, selector, selectRequest,
 	)
 	if err != nil {
 		return zero, Trace{}, err
@@ -289,40 +503,184 @@ func openSessionWithFallback[Request any, Session any](
 	target := decision.Selected
 	trigger := AttemptTriggerSelection
 	seen := map[inference.ModelRef]struct{}{target: {}}
+	policy := r.retry.sessionPolicyFor(operation).effective()
+	skipPhase := AttemptPhaseOpen
+	if preflight != nil {
+		skipPhase = AttemptPhasePreflight
+	}
+	var lastErr error
+	totalAttempts := 0
 	for {
-		session, err := open(ctx, target, snapshot)
-		if err != nil {
-			attempt := failedAttempt(target, AttemptPhaseOpen, trigger, err)
-			trace.Attempts = append(trace.Attempts, attempt)
-			next, ok, fallbackErr := nextFallbackTarget(
-				ctx, runtime, operation, snapshot, clone,
-				attempt, &trace, seen, fallbackNext,
-			)
-			if fallbackErr != nil {
-				return zero, trace, fallbackErr
+		breakerAllowed := false
+		var key circuitKey
+		if r.breaker != nil {
+			key = circuitKey{operation: operation, model: target}
+			gate := r.breaker.begin(ctx, key)
+			breakerAllowed = gate.allowed
+			if !breakerAllowed {
+				trace.Attempts = append(trace.Attempts, Attempt{
+					Target: target, Phase: skipPhase, Trigger: trigger,
+					Outcome: AttemptOutcomeSkipped, Circuit: string(gate.state),
+				})
+				next, ok, fallbackErr := nextFallbackTarget(r,
+					ctx, operation, snapshot, clone,
+					Attempt{Target: target, Phase: skipPhase, Trigger: trigger, Outcome: AttemptOutcomeSkipped},
+					&trace, seen, fallbackNext, true, false, skipPhase,
+				)
+				if fallbackErr != nil {
+					return zero, trace, fallbackErr
+				}
+				if !ok {
+					if lastErr != nil {
+						return zero, trace, lastErr
+					}
+					return zero, trace, NewError(
+						CircuitOpen,
+						operation,
+						errors.New("all route targets are circuit-open"),
+					)
+				}
+				target, trigger = next, AttemptTriggerFallback
+				continue
 			}
-			if !ok {
-				return zero, trace, err
-			}
-			target, trigger = next, AttemptTriggerFallback
-			continue
 		}
-		trace.Attempts = append(trace.Attempts, Attempt{
-			Target: target, Phase: AttemptPhaseOpen, Trigger: trigger,
-			Outcome: AttemptOutcomeOpened,
-		})
-		trace.Executed = target
-		return session, trace, nil
+
+		attemptNumber := 0
+		var backoffMillis int64
+		for {
+			if policy.MaxTotalAttempts > 0 &&
+				totalAttempts >= policy.MaxTotalAttempts {
+				if lastErr != nil {
+					return zero, trace, lastErr
+				}
+				return zero, trace, errors.New("retry total attempt budget exhausted")
+			}
+			attemptNumber++
+			totalAttempts++
+			attemptTrigger := trigger
+			if attemptNumber > 1 {
+				attemptTrigger = AttemptTriggerRetry
+			}
+			if attemptNumber > 1 {
+				delay := retryDelay(policy.Backoff, attemptNumber-1, lastErr)
+				if err := r.sleeper(ctx, delay); err != nil {
+					return zero, trace, err
+				}
+				backoffMillis = delay.Milliseconds()
+			}
+			if preflight != nil {
+				if err := preflight(ctx, target, snapshot); err != nil {
+					attempt := failedAttempt(target, AttemptPhasePreflight, attemptTrigger, err)
+					attempt.Number = attemptNumber
+					attempt.BackoffMillis = backoffMillis
+					if r.breaker != nil {
+						attempt.CircuitTransition = r.breaker.finish(
+							ctx, key, err, false,
+						)
+					}
+					trace.Attempts = append(trace.Attempts, attempt)
+					if policy.MaxTotalAttempts > 0 &&
+						totalAttempts >= policy.MaxTotalAttempts {
+						return zero, trace, err
+					}
+					if fallbackEligible(attempt) {
+						next, ok, fallbackErr := nextFallbackTarget(r,
+							ctx, operation, snapshot, clone,
+							attempt, &trace, seen, fallbackNext, false, false, skipPhase,
+						)
+						if fallbackErr != nil {
+							return zero, trace, fallbackErr
+						}
+						if !ok {
+							return zero, trace, err
+						}
+						target, trigger = next, AttemptTriggerFallback
+						break
+					}
+					if retryEligible(ctx, &policy, retryDecision(
+						operation, AttemptPhasePreflight, attemptTrigger, err, attemptNumber,
+					)) {
+						lastErr = err
+						continue
+					}
+					allowTransient := policy.FallbackOnRetryExhausted && attempt.Transient
+					next, ok, fallbackErr := nextFallbackTarget(r,
+						ctx, operation, snapshot, clone,
+						attempt, &trace, seen, fallbackNext, false, allowTransient, skipPhase,
+					)
+					if fallbackErr != nil {
+						return zero, trace, fallbackErr
+					}
+					if !ok {
+						return zero, trace, err
+					}
+					target, trigger = next, AttemptTriggerFallback
+					break
+				}
+				trace.Attempts = append(trace.Attempts, Attempt{
+					Target: target, Phase: AttemptPhasePreflight, Trigger: trigger,
+					Outcome: AttemptOutcomeSucceeded, Number: attemptNumber,
+				})
+			}
+			session, err := open(ctx, target, snapshot)
+			if err != nil {
+				attempt := failedAttempt(target, AttemptPhaseOpen, attemptTrigger, err)
+				attempt.Number = attemptNumber
+				attempt.BackoffMillis = backoffMillis
+				if r.breaker != nil {
+					attempt.CircuitTransition = r.breaker.finish(
+						ctx, key, err, attempt.Transient,
+					)
+				}
+				trace.Attempts = append(trace.Attempts, attempt)
+				if policy.MaxTotalAttempts > 0 &&
+					totalAttempts >= policy.MaxTotalAttempts {
+					return zero, trace, err
+				}
+				if retryEligible(ctx, &policy, retryDecision(
+					operation, AttemptPhaseOpen, attemptTrigger, err, attemptNumber,
+				)) {
+					lastErr = err
+					continue
+				}
+				allowTransient := policy.FallbackOnRetryExhausted && attempt.Transient
+				next, ok, fallbackErr := nextFallbackTarget(r,
+					ctx, operation, snapshot, clone,
+					attempt, &trace, seen, fallbackNext, false, allowTransient, skipPhase,
+				)
+				if fallbackErr != nil {
+					return zero, trace, fallbackErr
+				}
+				if !ok {
+					return zero, trace, err
+				}
+				target, trigger = next, AttemptTriggerFallback
+				break
+			}
+			transition := ""
+			if r.breaker != nil {
+				transition = r.breaker.finish(ctx, key, nil, false)
+			}
+			trace.Attempts = append(trace.Attempts, Attempt{
+				Target: target, Phase: AttemptPhaseOpen, Trigger: attemptTrigger,
+				Outcome: AttemptOutcomeOpened, Number: attemptNumber,
+				CircuitTransition: transition,
+			})
+			trace.Executed = target
+			return session, trace, nil
+		}
 	}
 }
 
 // nextFallbackTarget asks the operation's fallback policy for another target
 // and enforces the shared contract: transport-safe eligibility, bounded target
-// count, valid and previously unattempted targets, and runtime-confirmed
-// operation support. A nil fallbackNext disables fallback for the operation.
+// count, valid and previously unattempted targets, runtime-confirmed operation
+// support, and circuit-open skips. skipEligibility bypasses the transport-safe
+// gate for circuit-open skips; allowTransient permits retry-exhausted transient
+// provider failures when the operation policy opts in.
 func nextFallbackTarget[Request any](
+	r *Router,
 	ctx context.Context,
-	runtime *inference.Runtime,
 	operation inference.Operation,
 	snapshot Request,
 	clone func(Request) Request,
@@ -330,9 +688,18 @@ func nextFallbackTarget[Request any](
 	trace *Trace,
 	seen map[inference.ModelRef]struct{},
 	fallbackNext func(context.Context, Request, Attempt) (inference.ModelRef, bool, error),
+	skipEligibility bool,
+	allowTransient bool,
+	skipPhase AttemptPhase,
 ) (inference.ModelRef, bool, error) {
-	if fallbackNext == nil || !fallbackEligible(attempt) {
+	if fallbackNext == nil {
 		return inference.ModelRef{}, false, nil
+	}
+	if !skipEligibility {
+		eligible := fallbackEligible(attempt)
+		if !eligible && !(allowTransient && attempt.Transient) {
+			return inference.ModelRef{}, false, nil
+		}
 	}
 	next, ok, err := fallbackNext(ctx, clone(snapshot), attempt)
 	if err != nil {
@@ -352,54 +719,94 @@ func nextFallbackTarget[Request any](
 		}
 		return inference.ModelRef{}, false, nil
 	}
-	if len(seen) >= maxFallbackTargets {
-		return inference.ModelRef{}, false, NewError(
-			FallbackLimitExceeded,
-			operation,
-			fmt.Errorf("%s fallback exceeds %d targets", operation, maxFallbackTargets),
-		)
+	for {
+		if len(seen) >= maxFallbackTargets {
+			return inference.ModelRef{}, false, NewError(
+				FallbackLimitExceeded,
+				operation,
+				fmt.Errorf("%s fallback exceeds %d targets", operation, maxFallbackTargets),
+			)
+		}
+		if err := next.Validate(); err != nil {
+			return inference.ModelRef{}, false, NewError(
+				FallbackContractViolation,
+				operation,
+				fmt.Errorf("invalid fallback target: %w", err),
+			)
+		}
+		if _, duplicate := seen[next]; duplicate {
+			return inference.ModelRef{}, false, NewError(
+				FallbackContractViolation,
+				operation,
+				errors.New("fallback returned a previously attempted target"),
+			)
+		}
+		descriptor, err := r.runtime.InspectModel(next)
+		if err != nil {
+			return inference.ModelRef{}, false, NewError(
+				FallbackContractViolation,
+				operation,
+				err,
+			)
+		}
+		if !supportsOperation(descriptor, operation) {
+			return inference.ModelRef{}, false, NewError(
+				FallbackContractViolation,
+				operation,
+				errors.New("fallback returned a model without the operation"),
+			)
+		}
+		if descriptor.Lifecycle.Status == inference.ModelStatusRetired {
+			return inference.ModelRef{}, false, NewError(
+				FallbackContractViolation,
+				operation,
+				errors.New("fallback returned a retired model"),
+			)
+		}
+		if r.breaker != nil && r.breaker.isOpen(circuitKey{
+			operation: operation, model: next,
+		}) {
+			seen[next] = struct{}{}
+			trace.Attempts = append(trace.Attempts, Attempt{
+				Target: next, Phase: skipPhase, Trigger: AttemptTriggerFallback,
+				Outcome: AttemptOutcomeSkipped, Circuit: "open",
+			})
+			if len(seen) >= maxFallbackTargets {
+				return inference.ModelRef{}, false, NewError(
+					FallbackLimitExceeded,
+					operation,
+					fmt.Errorf("%s fallback exceeds %d targets", operation, maxFallbackTargets),
+				)
+			}
+			next, ok, err = fallbackNext(ctx, clone(snapshot), Attempt{
+				Target: next, Phase: skipPhase, Trigger: AttemptTriggerFallback,
+				Outcome: AttemptOutcomeSkipped, Circuit: "open",
+			})
+			if err != nil {
+				var routeErr *Error
+				if errors.As(err, &routeErr) {
+					return inference.ModelRef{}, false, err
+				}
+				return inference.ModelRef{}, false, NewError(FallbackFailed, operation, err)
+			}
+			if !ok {
+				if next != (inference.ModelRef{}) {
+					return inference.ModelRef{}, false, NewError(
+						FallbackContractViolation,
+						operation,
+						errors.New("fallback stop returned a target"),
+					)
+				}
+				return inference.ModelRef{}, false, nil
+			}
+			continue
+		}
+		seen[next] = struct{}{}
+		trace.Fallbacks = append(trace.Fallbacks, FallbackHop{
+			From: attempt.Target, To: next, Reason: string(attempt.ErrorKind),
+		})
+		return next, true, nil
 	}
-	if err := next.Validate(); err != nil {
-		return inference.ModelRef{}, false, NewError(
-			FallbackContractViolation,
-			operation,
-			fmt.Errorf("invalid fallback target: %w", err),
-		)
-	}
-	if _, duplicate := seen[next]; duplicate {
-		return inference.ModelRef{}, false, NewError(
-			FallbackContractViolation,
-			operation,
-			errors.New("fallback returned a previously attempted target"),
-		)
-	}
-	descriptor, err := runtime.InspectModel(next)
-	if err != nil {
-		return inference.ModelRef{}, false, NewError(
-			FallbackContractViolation,
-			operation,
-			err,
-		)
-	}
-	if !supportsOperation(descriptor, operation) {
-		return inference.ModelRef{}, false, NewError(
-			FallbackContractViolation,
-			operation,
-			errors.New("fallback returned a model without the operation"),
-		)
-	}
-	if descriptor.Lifecycle.Status == inference.ModelStatusRetired {
-		return inference.ModelRef{}, false, NewError(
-			FallbackContractViolation,
-			operation,
-			errors.New("fallback returned a retired model"),
-		)
-	}
-	seen[next] = struct{}{}
-	trace.Fallbacks = append(trace.Fallbacks, FallbackHop{
-		From: attempt.Target, To: next, Reason: string(attempt.ErrorKind),
-	})
-	return next, true, nil
 }
 
 // failedAttempt records a failed attempt with the inference error kind that
@@ -418,8 +825,31 @@ func failedAttempt(
 	var inferenceErr *inference.Error
 	if errors.As(err, &inferenceErr) {
 		attempt.ErrorKind = inferenceErr.Kind
+		attempt.WireAttempts = inferenceErr.WireAttempts
 	}
+	attempt.Transient = transientProviderFailure(err)
 	return attempt
+}
+
+func retryDecision(
+	operation inference.Operation,
+	phase AttemptPhase,
+	trigger AttemptTrigger,
+	err error,
+	attempt int,
+) RetryDecision {
+	decision := RetryDecision{
+		Operation: operation,
+		Phase:     phase,
+		Trigger:   trigger,
+		Err:       err,
+		Attempt:   attempt,
+	}
+	var inferenceErr *inference.Error
+	if errors.As(err, &inferenceErr) {
+		decision.ErrorKind = inferenceErr.Kind
+	}
+	return decision
 }
 
 // fallbackEligible reports whether a failed attempt is transport-safe to

--- a/sdk/inference/route/router_generate.go
+++ b/sdk/inference/route/router_generate.go
@@ -26,9 +26,8 @@ func (r *Router) Generate(
 	request inference.GenerateRequest,
 ) (inference.GenerateResponse, Trace, error) {
 	ctx, span := startRouteSpan(ctx, inference.OperationGenerate)
-	response, trace, err := executeWithFallback(
+	response, trace, err := executeWithFallback(r,
 		ctx,
-		r.runtime,
 		inference.OperationGenerate,
 		request.Clone(),
 		inference.GenerateRequest.Clone,
@@ -58,63 +57,26 @@ func (r *Router) GenerateStream(
 	ctx, span := startRouteSpan(ctx, inference.OperationGenerate)
 	defer func() { recordRoute(ctx, span, inference.OperationGenerate, routeTrace, err) }()
 	snapshot := request.Clone()
-	decision, err := r.selectGenerate(ctx, snapshot)
-	if err != nil {
-		return nil, Trace{}, err
-	}
-	fallbackNext := generateFallbackNext(r.selectors.GenerateFallback)
-	trace := Trace{Decision: decision}
-	target := decision.Selected
-	trigger := AttemptTriggerSelection
-	seen := map[inference.ModelRef]struct{}{target: {}}
-	for {
-		if _, err := r.runtime.ExplainGenerateStream(ctx, target, snapshot); err != nil {
-			attempt := failedAttempt(target, AttemptPhasePreflight, trigger, err)
-			trace.Attempts = append(trace.Attempts, attempt)
-			next, ok, fallbackErr := nextFallbackTarget(
-				ctx, r.runtime, inference.OperationGenerate,
-				snapshot, inference.GenerateRequest.Clone,
-				attempt, &trace, seen, fallbackNext,
-			)
-			if fallbackErr != nil {
-				return nil, trace, fallbackErr
-			}
-			if !ok {
-				return nil, trace, err
-			}
-			target, trigger = next, AttemptTriggerFallback
-			continue
-		}
-		trace.Attempts = append(trace.Attempts, Attempt{
-			Target: target, Phase: AttemptPhasePreflight, Trigger: trigger,
-			Outcome: AttemptOutcomeSucceeded,
-		})
-
-		stream, err := r.runtime.GenerateStream(ctx, target, snapshot)
-		if err != nil {
-			attempt := failedAttempt(target, AttemptPhaseOpen, trigger, err)
-			trace.Attempts = append(trace.Attempts, attempt)
-			next, ok, fallbackErr := nextFallbackTarget(
-				ctx, r.runtime, inference.OperationGenerate,
-				snapshot, inference.GenerateRequest.Clone,
-				attempt, &trace, seen, fallbackNext,
-			)
-			if fallbackErr != nil {
-				return nil, trace, fallbackErr
-			}
-			if !ok {
-				return nil, trace, err
-			}
-			target, trigger = next, AttemptTriggerFallback
-			continue
-		}
-		trace.Attempts = append(trace.Attempts, Attempt{
-			Target: target, Phase: AttemptPhaseOpen, Trigger: trigger,
-			Outcome: AttemptOutcomeOpened,
-		})
-		trace.Executed = target
-		return stream, trace, nil
-	}
+	stream, routeTrace, err = openSessionWithFallback(r,
+		ctx,
+		inference.OperationGenerate,
+		snapshot,
+		inference.GenerateRequest.Clone,
+		inference.GenerateRequest.Validate,
+		r.selectors.Generate,
+		func(ctx context.Context, snapshot inference.GenerateRequest) (Decision, error) {
+			return r.selectors.Generate.SelectGenerate(ctx, snapshot)
+		},
+		generateFallbackNext(r.selectors.GenerateFallback),
+		func(ctx context.Context, target inference.ModelRef, snapshot inference.GenerateRequest) error {
+			_, err := r.runtime.ExplainGenerateStream(ctx, target, snapshot)
+			return err
+		},
+		func(ctx context.Context, target inference.ModelRef, snapshot inference.GenerateRequest) (inference.GenerateStream, error) {
+			return r.runtime.GenerateStream(ctx, target, snapshot)
+		},
+	)
+	return stream, routeTrace, err
 }
 
 // ExplainGenerate explains the selected target's unary Generate compilation.

--- a/sdk/inference/route/router_other.go
+++ b/sdk/inference/route/router_other.go
@@ -73,9 +73,8 @@ func (r *Router) Embed(
 	request inference.EmbedRequest,
 ) (inference.EmbedResponse, Trace, error) {
 	ctx, span := startRouteSpan(ctx, inference.OperationEmbed)
-	response, trace, err := executeWithFallback(
+	response, trace, err := executeWithFallback(r,
 		ctx,
-		r.runtime,
 		inference.OperationEmbed,
 		request.Clone(),
 		inference.EmbedRequest.Clone,
@@ -124,9 +123,8 @@ func (r *Router) Transcribe(
 	request inference.TranscriptionRequest,
 ) (inference.TranscriptionResponse, Trace, error) {
 	ctx, span := startRouteSpan(ctx, inference.OperationTranscription)
-	response, trace, err := executeWithFallback(
+	response, trace, err := executeWithFallback(r,
 		ctx,
-		r.runtime,
 		inference.OperationTranscription,
 		request.Clone(),
 		inference.TranscriptionRequest.Clone,
@@ -175,9 +173,8 @@ func (r *Router) OpenTranscription(
 	config inference.TranscriptionSessionConfig,
 ) (inference.OpenedTranscriptionSession, Trace, error) {
 	ctx, span := startRouteSpan(ctx, inference.OperationTranscription)
-	session, trace, err := openSessionWithFallback(
+	session, trace, err := openSessionWithFallback(r,
 		ctx,
-		r.runtime,
 		inference.OperationTranscription,
 		config.Clone(),
 		inference.TranscriptionSessionConfig.Clone,
@@ -187,6 +184,7 @@ func (r *Router) OpenTranscription(
 			return r.selectors.TranscriptionSession.SelectTranscriptionSession(ctx, snapshot)
 		},
 		transcriptionSessionFallbackNext(r.selectors.TranscriptionSessionFallback),
+		nil,
 		r.runtime.OpenTranscription,
 	)
 	recordRoute(ctx, span, inference.OperationTranscription, trace, err)
@@ -226,9 +224,8 @@ func (r *Router) OpenRealtime(
 	config inference.RealtimeConfig,
 ) (inference.OpenedRealtimeSession, Trace, error) {
 	ctx, span := startRouteSpan(ctx, inference.OperationRealtime)
-	session, trace, err := openSessionWithFallback(
+	session, trace, err := openSessionWithFallback(r,
 		ctx,
-		r.runtime,
 		inference.OperationRealtime,
 		config.Clone(),
 		inference.RealtimeConfig.Clone,
@@ -238,6 +235,7 @@ func (r *Router) OpenRealtime(
 			return r.selectors.Realtime.SelectRealtime(ctx, snapshot)
 		},
 		realtimeFallbackNext(r.selectors.RealtimeFallback),
+		nil,
 		r.runtime.OpenRealtime,
 	)
 	recordRoute(ctx, span, inference.OperationRealtime, trace, err)

--- a/sdk/inference/route/telemetry.go
+++ b/sdk/inference/route/telemetry.go
@@ -27,6 +27,18 @@ var (
 	routeFallbackCount, _ = routeMeter.Int64Counter(
 		"fallbacks.total",
 		metric.WithDescription("Routed operations that fell back at least once"))
+	routeRetryCount, _ = routeMeter.Int64Counter(
+		"retries.total",
+		metric.WithDescription("Same-target retry attempts"))
+	routeCircuitOpens, _ = routeMeter.Int64Counter(
+		"circuit.opens",
+		metric.WithDescription("Circuit transitions to open"))
+	routeCircuitSkips, _ = routeMeter.Int64Counter(
+		"circuit.skips",
+		metric.WithDescription("Attempts skipped because the circuit was open"))
+	routeCircuitProbes, _ = routeMeter.Int64Counter(
+		"circuit.half_open_probes",
+		metric.WithDescription("Half-open circuit probes"))
 )
 
 func startRouteSpan(ctx context.Context, operation inference.Operation) (context.Context, trace.Span) {
@@ -46,11 +58,18 @@ func recordRoute(
 ) {
 	opAttr := attribute.String("inference.operation", string(operation))
 	selected := routeTrace.Decision.Selected
+	retries := 0
+	for _, attempt := range routeTrace.Attempts {
+		if attempt.Trigger == AttemptTriggerRetry {
+			retries++
+		}
+	}
 	span.SetAttributes(
 		attribute.String("route.selected.provider", selected.ID.Provider),
 		attribute.String("route.selected.model", selected.ID.Name),
 		attribute.Int("route.attempts", len(routeTrace.Attempts)),
 		attribute.Int("route.fallbacks", len(routeTrace.Fallbacks)),
+		attribute.Int("route.retries", retries),
 	)
 	for _, attempt := range routeTrace.Attempts {
 		attrs := []attribute.KeyValue{
@@ -63,7 +82,33 @@ func recordRoute(
 		if attempt.ErrorKind != "" {
 			attrs = append(attrs, attribute.String("error_kind", string(attempt.ErrorKind)))
 		}
+		if attempt.Number > 0 {
+			attrs = append(attrs, attribute.Int("attempt", attempt.Number))
+		}
+		if attempt.BackoffMillis > 0 {
+			attrs = append(attrs, attribute.Int64("backoff_ms", attempt.BackoffMillis))
+		}
+		if attempt.Circuit != "" {
+			attrs = append(attrs, attribute.String("circuit", attempt.Circuit))
+		}
+		if attempt.CircuitTransition != "" {
+			attrs = append(
+				attrs,
+				attribute.String("circuit_transition", attempt.CircuitTransition),
+			)
+		}
+		if attempt.WireAttempts > 0 {
+			attrs = append(attrs, attribute.Int("wire_attempts", attempt.WireAttempts))
+		}
 		span.AddEvent("route.attempt", trace.WithAttributes(attrs...))
+		if attempt.Trigger == AttemptTriggerRetry {
+			routeRetryCount.Add(ctx, 1, metric.WithAttributes(
+				opAttr,
+				attribute.String(telemetry.AttrLLMProvider, attempt.Target.ID.Provider),
+				attribute.String(telemetry.AttrLLMModel, attempt.Target.ID.Name),
+				attribute.String("error_kind", string(attempt.ErrorKind)),
+			))
+		}
 	}
 	if err != nil {
 		routeExecCount.Add(ctx, 1, metric.WithAttributes(opAttr, attribute.String("status", "error")))

--- a/sdkx/inference/anthropic/anthropic_test.go
+++ b/sdkx/inference/anthropic/anthropic_test.go
@@ -9,6 +9,7 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/GizClaw/flowcraft/sdk/errdefs"
 	"github.com/GizClaw/flowcraft/sdk/inference"
@@ -407,6 +408,45 @@ func TestClassifyError(t *testing.T) {
 				t.Fatalf("classified error = %v", err)
 			}
 		})
+	}
+}
+
+func TestRateLimitCarriesRetryAfter(t *testing.T) {
+	server, _ := newCapturedAnthropic(t, func(w http.ResponseWriter, _ *http.Request, _ map[string]any) {
+		w.Header().Set("Retry-After", "2")
+		w.WriteHeader(http.StatusTooManyRequests)
+		_, _ = fmt.Fprint(w, `{"type":"error","error":{"type":"rate_limit_error","message":"slow down"}}`)
+	})
+	defer server.Close()
+	cls := testClients(t, server)
+	operations, err := openGenerate(
+		cls,
+		catalog["claude-sonnet-5"],
+		claudeModel("claude-sonnet-5").ID,
+		"default",
+	)
+	if err != nil {
+		t.Fatalf("openGenerate: %v", err)
+	}
+	_, err = operations.Unary.Execute(
+		context.Background(),
+		claudeModel("claude-sonnet-5"),
+		simpleTextRequest("hi"),
+	)
+	if !errdefs.IsRateLimit(err) {
+		t.Fatalf("err = %v, want rate limit", err)
+	}
+	if got, ok := errdefs.RetryAfter(err); !ok || got != 2*time.Second {
+		t.Fatalf("RetryAfter = %v/%v, want 2s/true", got, ok)
+	}
+	if got := errdefs.RetryCount(err); got < 1 {
+		t.Fatalf("RetryCount = %d, want at least 1 wire attempt", got)
+	}
+}
+
+func TestSpecRejectsNegativeHTTPRetries(t *testing.T) {
+	if _, err := decodeSpec([]byte(`{"http_retries":-1}`)); err == nil {
+		t.Fatal("decodeSpec accepted negative http_retries")
 	}
 }
 

--- a/sdkx/inference/anthropic/client.go
+++ b/sdkx/inference/anthropic/client.go
@@ -52,5 +52,17 @@ func (m profileMaterial) newClients(spec Spec) *clients {
 	if spec.BaseURL != "" {
 		options = append(options, option.WithBaseURL(spec.BaseURL))
 	}
+	if spec.HTTPRetries != nil {
+		options = append(options, option.WithMaxRetries(sdkMaxRetries(*spec.HTTPRetries)))
+	}
 	return &clients{api: anthropicgo.NewClient(options...)}
+}
+
+// sdkMaxRetries converts a total-attempt budget (including the first) into
+// the SDK's retry-count option.
+func sdkMaxRetries(total int) int {
+	if total <= 1 {
+		return 0
+	}
+	return total - 1
 }

--- a/sdkx/inference/anthropic/doc.go
+++ b/sdkx/inference/anthropic/doc.go
@@ -46,4 +46,13 @@
 // and optional model declarations for deployments serving unreleased or
 // gateway-renamed models. All models are generate kind; the built-in
 // catalog tracks the Claude lineup of July 2026.
+//
+// # Retries
+//
+// The provider Spec accepts `http_retries` (total wire attempts including
+// the first). Nil keeps the anthropic-sdk-go default (two retries); 0
+// disables SDK-internal retries so the route Router owns the budget; N maps
+// to option.WithMaxRetries(N-1). Retry-After and the SDK retry count are
+// propagated onto ProviderFailure so Router backoff and trace
+// wire_attempts can observe them.
 package anthropic

--- a/sdkx/inference/anthropic/errors.go
+++ b/sdkx/inference/anthropic/errors.go
@@ -22,9 +22,33 @@ func classifyError(err error) error {
 	}
 	var apiErr *anthropic.Error
 	if errors.As(err, &apiErr) {
-		return classifyHTTPStatus(apiErr.StatusCode, err)
+		classified := classifyHTTPStatus(apiErr.StatusCode, err)
+		if apiErr.Response != nil {
+			classified = errdefs.WithRetryAfter(
+				classified,
+				errdefs.ParseRetryAfter(apiErr.Response.Header.Get("Retry-After")),
+			)
+		}
+		if attempts := wireAttempts(apiErr.Request); attempts > 0 {
+			classified = errdefs.WithRetryCount(classified, attempts)
+		}
+		return classified
 	}
 	return errdefs.NotAvailable(fmt.Errorf("anthropic: %w", err))
+}
+
+// wireAttempts derives the total HTTP sends from the SDK's
+// X-Stainless-Retry-Count header (zero-based retry count on the final
+// request). Zero means the count was unavailable.
+func wireAttempts(request *http.Request) int {
+	if request == nil {
+		return 0
+	}
+	value := request.Header.Get("X-Stainless-Retry-Count")
+	if value == "" {
+		return 0
+	}
+	return errdefs.ParseRetryCount(value) + 1
 }
 
 func classifyHTTPStatus(status int, err error) error {

--- a/sdkx/inference/anthropic/spec.go
+++ b/sdkx/inference/anthropic/spec.go
@@ -11,6 +11,11 @@ type Spec struct {
 	// BaseURL overrides the API origin, e.g. for a gateway. Empty uses the
 	// SDK default (https://api.anthropic.com).
 	BaseURL string `json:"base_url,omitempty"`
+	// HTTPRetries bounds wire-level retries inside one logical inference
+	// attempt, including the first. Zero disables SDK-internal retries so
+	// the route Router owns the full retry budget; nil keeps the
+	// anthropic-sdk-go default (two retries).
+	HTTPRetries *int `json:"http_retries,omitempty"`
 	// Models declares custom models or overrides built-in catalog entries.
 	Models []ModelSpec `json:"models,omitempty"`
 }
@@ -31,6 +36,9 @@ func (s Spec) Validate() error {
 		!strings.HasPrefix(s.BaseURL, "https://") &&
 		!strings.HasPrefix(s.BaseURL, "http://") {
 		return fmt.Errorf("anthropic: base_url %q must be an http(s) URL", s.BaseURL)
+	}
+	if s.HTTPRetries != nil && *s.HTTPRetries < 0 {
+		return fmt.Errorf("anthropic: http_retries must not be negative")
 	}
 	seen := make(map[string]bool, len(s.Models))
 	for _, model := range s.Models {

--- a/sdkx/inference/azure/azure_test.go
+++ b/sdkx/inference/azure/azure_test.go
@@ -83,6 +83,14 @@ func TestSpecValidation(t *testing.T) {
 	}
 }
 
+func TestSpecRejectsNegativeHTTPRetries(t *testing.T) {
+	if _, err := decodeSpec([]byte(
+		`{"endpoint":"https://res.openai.azure.com","http_retries":-1,"models":[{"name":"chat-1","kind":"generate"}]}`,
+	)); err == nil {
+		t.Fatal("decodeSpec accepted negative http_retries")
+	}
+}
+
 func TestProfileMaterial(t *testing.T) {
 	t.Run("missing api key", func(t *testing.T) {
 		if _, err := newProfileMaterial(config.ResolvedProfile{ID: "default"}); err == nil {

--- a/sdkx/inference/azure/client.go
+++ b/sdkx/inference/azure/client.go
@@ -58,13 +58,26 @@ func (m profileMaterial) newClients(spec Spec) *clients {
 	if version == "" {
 		version = DefaultAPIVersion
 	}
-	return &clients{
-		api: openaigo.NewClient(
-			azure.WithEndpoint(strings.TrimSuffix(spec.Endpoint, "/"), version),
-			azure.WithAPIKey(m.apiKey),
-			option.WithMiddleware(deploymentRouteMiddleware),
-		),
+	options := []option.RequestOption{
+		azure.WithEndpoint(strings.TrimSuffix(spec.Endpoint, "/"), version),
+		azure.WithAPIKey(m.apiKey),
+		option.WithMiddleware(deploymentRouteMiddleware),
 	}
+	if spec.HTTPRetries != nil {
+		options = append(options, sdkMaxRetriesOption(*spec.HTTPRetries))
+	}
+	return &clients{
+		api: openaigo.NewClient(options...),
+	}
+}
+
+// sdkMaxRetriesOption converts a total-attempt budget (including the first)
+// into the openai-go retry-count option.
+func sdkMaxRetriesOption(total int) option.RequestOption {
+	if total <= 1 {
+		return option.WithMaxRetries(0)
+	}
+	return option.WithMaxRetries(total - 1)
 }
 
 // deploymentRouteMiddleware scopes the Responses API route to its

--- a/sdkx/inference/azure/doc.go
+++ b/sdkx/inference/azure/doc.go
@@ -31,4 +31,12 @@
 // The resource endpoint and api-version live on the provider Spec
 // (endpoint, api_version), not per profile: all profiles of one provider
 // config share one resource.
+//
+// # Retries
+//
+// The provider Spec accepts `http_retries` (total wire attempts including
+// the first). Nil keeps the openai-go default (two retries); 0 disables
+// SDK-internal retries so the route Router owns the budget; N maps to
+// option.WithMaxRetries(N-1). Error classification rides the openai kernel,
+// so Retry-After and the SDK retry count propagate onto ProviderFailure.
 package azure

--- a/sdkx/inference/azure/spec.go
+++ b/sdkx/inference/azure/spec.go
@@ -20,6 +20,11 @@ type Spec struct {
 	// APIVersion overrides the query api-version; defaults to
 	// DefaultAPIVersion.
 	APIVersion string `json:"api_version,omitempty"`
+	// HTTPRetries bounds wire-level retries inside one logical inference
+	// attempt, including the first. Zero disables SDK-internal retries so
+	// the route Router owns the full retry budget; nil keeps the openai-go
+	// default (two retries).
+	HTTPRetries *int `json:"http_retries,omitempty"`
 	// Models declares the deployments to expose; at least one is required.
 	Models []ModelSpec `json:"models"`
 }
@@ -51,6 +56,9 @@ func (s Spec) Validate() error {
 	}
 	if s.APIVersion != "" && strings.ContainsAny(s.APIVersion, "?&") {
 		return fmt.Errorf("azure: api_version %q is not a version token", s.APIVersion)
+	}
+	if s.HTTPRetries != nil && *s.HTTPRetries < 0 {
+		return fmt.Errorf("azure: http_retries must not be negative")
 	}
 	if len(s.Models) == 0 {
 		return fmt.Errorf(

--- a/sdkx/inference/bytedance/client.go
+++ b/sdkx/inference/bytedance/client.go
@@ -128,6 +128,14 @@ func secretString(secret config.Secret) string {
 func (m profileMaterial) newClients(spec Spec) *clients {
 	built := &clients{endpoints: m.spec.Endpoints}
 	options := []arkruntime.ConfigOption{}
+	httpOptions := []httpkit.Option{
+		httpkit.WithHTTP2(),
+		httpkit.WithTimeout(defaultClientTimeout),
+		httpkit.WithResponseHeaderTimeout(defaultResponseHeaderTimeout),
+	}
+	if spec.HTTPRetries != nil {
+		httpOptions = append(httpOptions, httpkit.WithRetryAttempts(*spec.HTTPRetries))
+	}
 	if spec.BaseURL != "" {
 		options = append(options, arkruntime.WithBaseUrl(spec.BaseURL))
 	}
@@ -135,11 +143,7 @@ func (m profileMaterial) newClients(spec Spec) *clients {
 		options = append(options, arkruntime.WithRegion(spec.Region))
 	}
 	options = append(options,
-		arkruntime.WithHTTPClient(httpkit.NewClient(
-			httpkit.WithHTTP2(),
-			httpkit.WithTimeout(defaultClientTimeout),
-			httpkit.WithResponseHeaderTimeout(defaultResponseHeaderTimeout),
-		)),
+		arkruntime.WithHTTPClient(httpkit.NewClient(httpOptions...)),
 		// SDK-internal retries are disabled; the retry transport above owns
 		// replayable transient failures so attempts do not multiply.
 		arkruntime.WithRetryTimes(0),
@@ -158,6 +162,11 @@ func (m profileMaterial) newClients(spec Spec) *clients {
 	}
 	if speechKey != "" && m.spec.AppID != "" {
 		options := []doubaospeech.Option{doubaospeech.WithAPIKey(speechKey)}
+		// The speech SDK shares the httpkit retry budget with the Ark
+		// client so http_retries governs both surfaces.
+		options = append(options, doubaospeech.WithHTTPClient(
+			httpkit.NewClient(httpOptions...),
+		))
 		if spec.SpeechBaseURL != "" {
 			options = append(options, doubaospeech.WithBaseURL(spec.SpeechBaseURL))
 		}

--- a/sdkx/inference/bytedance/doc.go
+++ b/sdkx/inference/bytedance/doc.go
@@ -75,4 +75,15 @@
 // resource IDs, or — for realtime models — the duplex engine version.
 // Unmapped models are addressed by their catalog name. See
 // integration_test.go for a worked example.
+//
+// # Retries
+//
+// The provider Spec accepts `http_retries` (total wire attempts including
+// the first). It governs the Ark and Doubao speech HTTP clients through the
+// shared httpkit transport. Nil keeps the httpkit default (three attempts);
+// 0 disables transport retries so the route Router owns the budget; N sets
+// total wire attempts. The Ark and speech SDK error types do not expose
+// response headers, so Retry-After is honored inside the httpkit transport
+// but is not visible to Router backoff; wire attempts are likewise not
+// reported through the SDK error chain.
 package bytedance

--- a/sdkx/inference/bytedance/factory_test.go
+++ b/sdkx/inference/bytedance/factory_test.go
@@ -44,6 +44,12 @@ func testProfiles() []config.ResolvedProfile {
 	}}
 }
 
+func TestSpecRejectsNegativeHTTPRetries(t *testing.T) {
+	if _, err := decodeSpec([]byte(`{"http_retries":-1}`)); err == nil {
+		t.Fatal("decodeSpec accepted negative http_retries")
+	}
+}
+
 func testProfilesWithSpec(t *testing.T, spec ProfileSpec) []config.ResolvedProfile {
 	t.Helper()
 	secret, err := config.NewSecret([]byte("test-key"))

--- a/sdkx/inference/bytedance/spec.go
+++ b/sdkx/inference/bytedance/spec.go
@@ -38,6 +38,10 @@ type Spec struct {
 	// SpeechWebSocketURL overrides the Doubao speech WebSocket endpoint (ASR,
 	// realtime duplex).
 	SpeechWebSocketURL string `json:"speech_web_socket_url,omitempty"`
+	// HTTPRetries bounds wire-level HTTP retries on the Ark and Doubao
+	// speech HTTP clients. Zero disables transport retries so the route
+	// Router owns the full retry budget; nil keeps the httpkit default.
+	HTTPRetries *int `json:"http_retries,omitempty"`
 	// Region selects the Ark service region.
 	Region string `json:"region,omitempty"`
 	// VideoPollIntervalMillis paces content-generation task polls (Seedance
@@ -114,6 +118,9 @@ func (s Spec) videoPollInterval() time.Duration {
 func (s Spec) Validate() error {
 	if s.VideoPollIntervalMillis != nil && *s.VideoPollIntervalMillis <= 0 {
 		return fmt.Errorf("video_poll_interval_millis must be positive")
+	}
+	if s.HTTPRetries != nil && *s.HTTPRetries < 0 {
+		return fmt.Errorf("http_retries must not be negative")
 	}
 	for name, value := range map[string]string{
 		"base_url":              s.BaseURL,

--- a/sdkx/inference/deepseek/client.go
+++ b/sdkx/inference/deepseek/client.go
@@ -58,10 +58,23 @@ func (m profileMaterial) newClients(spec Spec) *clients {
 	if baseURL == "" {
 		baseURL = defaultBaseURL
 	}
-	return &clients{
-		api: openaigo.NewClient(
-			option.WithAPIKey(m.apiKey),
-			option.WithBaseURL(baseURL),
-		),
+	options := []option.RequestOption{
+		option.WithAPIKey(m.apiKey),
+		option.WithBaseURL(baseURL),
 	}
+	if spec.HTTPRetries != nil {
+		options = append(options, sdkMaxRetriesOption(*spec.HTTPRetries))
+	}
+	return &clients{
+		api: openaigo.NewClient(options...),
+	}
+}
+
+// sdkMaxRetriesOption converts a total-attempt budget (including the first)
+// into the openai-go retry-count option.
+func sdkMaxRetriesOption(total int) option.RequestOption {
+	if total <= 1 {
+		return option.WithMaxRetries(0)
+	}
+	return option.WithMaxRetries(total - 1)
 }

--- a/sdkx/inference/deepseek/doc.go
+++ b/sdkx/inference/deepseek/doc.go
@@ -63,4 +63,13 @@
 //
 // Each profile resolves one api_key secret; the spec optionally overrides
 // base_url and declares extra models.
+//
+// # Retries
+//
+// The provider Spec accepts `http_retries` (total wire attempts including
+// the first). Nil keeps the openai-go default (two retries); 0 disables
+// SDK-internal retries so the route Router owns the budget; N maps to
+// option.WithMaxRetries(N-1). Retry-After and the SDK retry count are
+// propagated onto ProviderFailure so Router backoff and trace
+// wire_attempts can observe them.
 package deepseek

--- a/sdkx/inference/deepseek/errors.go
+++ b/sdkx/inference/deepseek/errors.go
@@ -21,9 +21,33 @@ func classifyError(err error) error {
 		return classified
 	}
 	if apiErr, ok := errors.AsType[*openaigo.Error](err); ok {
-		return classifyHTTPStatus(apiErr.StatusCode, err)
+		classified := classifyHTTPStatus(apiErr.StatusCode, err)
+		if apiErr.Response != nil {
+			classified = errdefs.WithRetryAfter(
+				classified,
+				errdefs.ParseRetryAfter(apiErr.Response.Header.Get("Retry-After")),
+			)
+		}
+		if attempts := wireAttempts(apiErr.Request); attempts > 0 {
+			classified = errdefs.WithRetryCount(classified, attempts)
+		}
+		return classified
 	}
 	return errdefs.NotAvailable(fmt.Errorf("deepseek: %w", err))
+}
+
+// wireAttempts derives the total HTTP sends from the SDK's
+// X-Stainless-Retry-Count header (zero-based retry count on the final
+// request). Zero means the count was unavailable.
+func wireAttempts(request *http.Request) int {
+	if request == nil {
+		return 0
+	}
+	value := request.Header.Get("X-Stainless-Retry-Count")
+	if value == "" {
+		return 0
+	}
+	return errdefs.ParseRetryCount(value) + 1
 }
 
 func classifyHTTPStatus(status int, err error) error {

--- a/sdkx/inference/deepseek/generate_test.go
+++ b/sdkx/inference/deepseek/generate_test.go
@@ -1,13 +1,16 @@
 package deepseek
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"sync"
 	"testing"
+	"time"
 
+	"github.com/GizClaw/flowcraft/sdk/errdefs"
 	"github.com/GizClaw/flowcraft/sdk/inference"
 	"github.com/GizClaw/flowcraft/sdk/message"
 )
@@ -72,6 +75,43 @@ func (s *chatServer) clients(t *testing.T) *clients {
 		t.Fatalf("decodeSpec: %v", err)
 	}
 	return profileMaterial{apiKey: "test-key"}.newClients(spec)
+}
+
+func TestRateLimitCarriesRetryAfter(t *testing.T) {
+	server := newChatServer(t, func(w http.ResponseWriter, _ map[string]any) {
+		w.Header().Set("Retry-After", "2")
+		w.WriteHeader(http.StatusTooManyRequests)
+		_, _ = fmt.Fprint(w, `{"error":{"message":"slow down","type":"rate_limit_error","code":"x"}}`)
+	})
+	cls := server.clients(t)
+	driver, err := inference.BindGenerate(
+		compileGenerate("deepseek-v4-pro", catalog["deepseek-v4-pro"]),
+		transportGenerate(cls.api),
+		decodeGenerate,
+	)
+	if err != nil {
+		t.Fatalf("BindGenerate: %v", err)
+	}
+	_, err = driver.Execute(
+		context.Background(),
+		generateModel("deepseek-v4-pro"),
+		simpleTextRequest("hi"),
+	)
+	if !errdefs.IsRateLimit(err) {
+		t.Fatalf("err = %v, want rate limit", err)
+	}
+	if got, ok := errdefs.RetryAfter(err); !ok || got != 2*time.Second {
+		t.Fatalf("RetryAfter = %v/%v, want 2s/true", got, ok)
+	}
+	if got := errdefs.RetryCount(err); got < 1 {
+		t.Fatalf("RetryCount = %d, want at least 1 wire attempt", got)
+	}
+}
+
+func TestSpecRejectsNegativeHTTPRetries(t *testing.T) {
+	if _, err := decodeSpec([]byte(`{"http_retries":-1}`)); err == nil {
+		t.Fatal("decodeSpec accepted negative http_retries")
+	}
 }
 
 // chatCompletionJSON renders a unary completion fixture. Extra message

--- a/sdkx/inference/deepseek/spec.go
+++ b/sdkx/inference/deepseek/spec.go
@@ -18,6 +18,11 @@ type Spec struct {
 	// https://api.deepseek.com (the OpenAI-compatible surface; the
 	// provider serves chat completions only, no Responses API).
 	BaseURL string `json:"base_url,omitempty"`
+	// HTTPRetries bounds wire-level retries inside one logical inference
+	// attempt, including the first. Zero disables SDK-internal retries so
+	// the route Router owns the full retry budget; nil keeps the openai-go
+	// default (two retries).
+	HTTPRetries *int `json:"http_retries,omitempty"`
 	// Models declares models outside the built-in catalog or overrides
 	// catalog entries by name.
 	Models []ModelSpec `json:"models,omitempty"`
@@ -50,6 +55,9 @@ func (s Spec) Validate() error {
 		if err := validateURL("base_url", s.BaseURL); err != nil {
 			return err
 		}
+	}
+	if s.HTTPRetries != nil && *s.HTTPRetries < 0 {
+		return fmt.Errorf("http_retries must not be negative")
 	}
 	seen := make(map[string]struct{}, len(s.Models))
 	for _, model := range s.Models {

--- a/sdkx/inference/kimi/client.go
+++ b/sdkx/inference/kimi/client.go
@@ -54,13 +54,17 @@ func (m profileMaterial) newClient(spec Spec) *kimiClient {
 	if baseURL == "" {
 		baseURL = defaultBaseURL
 	}
+	options := []httpkit.Option{
+		httpkit.WithTimeout(300 * time.Second),
+		httpkit.WithResponseHeaderTimeout(5 * time.Minute),
+	}
+	if spec.HTTPRetries != nil {
+		options = append(options, httpkit.WithRetryAttempts(*spec.HTTPRetries))
+	}
 	return &kimiClient{
 		baseURL: baseURL,
 		apiKey:  m.apiKey,
-		http: httpkit.NewClient(
-			httpkit.WithTimeout(300*time.Second),
-			httpkit.WithResponseHeaderTimeout(5*time.Minute),
-		),
+		http:    httpkit.NewClient(options...),
 	}
 }
 
@@ -110,7 +114,13 @@ func (c *kimiClient) postJSON(ctx context.Context, body any, out any) error {
 		return errdefs.NotAvailable(fmt.Errorf("kimi: read response: %w", err))
 	}
 	if response.StatusCode < 200 || response.StatusCode >= 300 {
-		return classifyHTTPError(ctx, response.StatusCode, payload)
+		return errdefs.WithRetryCount(
+			errdefs.WithRetryAfter(
+				classifyHTTPError(ctx, response.StatusCode, payload),
+				errdefs.ParseRetryAfter(response.Header.Get("Retry-After")),
+			),
+			httpkit.RetryCountOf(response),
+		)
 	}
 	if err := json.Unmarshal(payload, out); err != nil {
 		return errdefs.NotAvailable(fmt.Errorf("kimi: decode response: %w", err))

--- a/sdkx/inference/kimi/doc.go
+++ b/sdkx/inference/kimi/doc.go
@@ -57,4 +57,13 @@
 // kimi-k2.7-code pair, kimi-k2.6, kimi-k2.5, and the moonshot-v1 family
 // (text plus vision previews). Deployments declare additional models
 // through the spec (name, kind, vision, video, reasoning).
+//
+// # Retries
+//
+// The provider Spec accepts `http_retries` (total wire attempts including
+// the first). Nil keeps the httpkit default (three attempts); 0 disables
+// transport retries so the route Router owns the budget; N sets total wire
+// attempts. Retry-After and wire attempts observed at the HTTP layer are
+// propagated onto ProviderFailure so Router backoff and trace
+// wire_attempts can observe them.
 package kimi

--- a/sdkx/inference/kimi/generate_stream.go
+++ b/sdkx/inference/kimi/generate_stream.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/GizClaw/flowcraft/sdk/errdefs"
 	"github.com/GizClaw/flowcraft/sdk/inference"
+	"github.com/GizClaw/flowcraft/sdkx/internal/httpkit"
 )
 
 // chunkEnvelope is one streaming chunk: delta content, optional finish
@@ -98,7 +99,13 @@ func transportGenerateStream(client *kimiClient) inference.Transport[generateWir
 		if response.StatusCode < 200 || response.StatusCode >= 300 {
 			defer func() { _ = response.Body.Close() }()
 			payload, _ := io.ReadAll(response.Body)
-			return nil, classifyHTTPError(ctx, response.StatusCode, payload)
+			return nil, errdefs.WithRetryCount(
+				errdefs.WithRetryAfter(
+					classifyHTTPError(ctx, response.StatusCode, payload),
+					errdefs.ParseRetryAfter(response.Header.Get("Retry-After")),
+				),
+				httpkit.RetryCountOf(response),
+			)
 		}
 		streamCtx, cancel := context.WithCancel(ctx)
 		return &chatStream{

--- a/sdkx/inference/kimi/kimi_test.go
+++ b/sdkx/inference/kimi/kimi_test.go
@@ -316,3 +316,9 @@ func TestFactoryRejectsBadSecrets(t *testing.T) {
 		t.Fatalf("err = %v", err)
 	}
 }
+
+func TestSpecRejectsNegativeHTTPRetries(t *testing.T) {
+	if _, err := decodeSpec([]byte(`{"http_retries":-1}`)); err == nil {
+		t.Fatal("decodeSpec accepted negative http_retries")
+	}
+}

--- a/sdkx/inference/kimi/spec.go
+++ b/sdkx/inference/kimi/spec.go
@@ -18,6 +18,10 @@ type Spec struct {
 	// https://api.moonshot.cn/v1 (the OpenAI-compatible surface; chat
 	// completions only).
 	BaseURL string `json:"base_url,omitempty"`
+	// HTTPRetries bounds wire-level HTTP retries inside one logical
+	// inference attempt. Zero disables transport retries so the route
+	// Router owns the full retry budget; nil keeps the httpkit default.
+	HTTPRetries *int `json:"http_retries,omitempty"`
 	// Models declares models outside the built-in catalog or extends
 	// catalog entries by name.
 	Models []ModelSpec `json:"models,omitempty"`
@@ -54,6 +58,9 @@ func (s Spec) Validate() error {
 		if err := validateURL("base_url", s.BaseURL); err != nil {
 			return err
 		}
+	}
+	if s.HTTPRetries != nil && *s.HTTPRetries < 0 {
+		return fmt.Errorf("http_retries must not be negative")
 	}
 	seen := make(map[string]struct{}, len(s.Models))
 	for _, model := range s.Models {

--- a/sdkx/inference/minimax/client.go
+++ b/sdkx/inference/minimax/client.go
@@ -61,11 +61,24 @@ func (m profileMaterial) newClients(spec Spec) *clients {
 	if baseURL == "" {
 		baseURL = defaultBaseURL
 	}
-	return &clients{
-		api: anthropicgo.NewClient(
-			option.WithAPIKey(m.apiKey),
-			option.WithBaseURL(baseURL),
-		),
-		media: newMediaClient(m.apiKey, spec.mediaBaseURL()),
+	options := []option.RequestOption{
+		option.WithAPIKey(m.apiKey),
+		option.WithBaseURL(baseURL),
 	}
+	if spec.HTTPRetries != nil {
+		options = append(options, option.WithMaxRetries(sdkMaxRetries(*spec.HTTPRetries)))
+	}
+	return &clients{
+		api:   anthropicgo.NewClient(options...),
+		media: newMediaClient(m.apiKey, spec.mediaBaseURL(), spec),
+	}
+}
+
+// sdkMaxRetries converts a total-attempt budget (including the first) into
+// the SDK's retry-count option.
+func sdkMaxRetries(total int) int {
+	if total <= 1 {
+		return 0
+	}
+	return total - 1
 }

--- a/sdkx/inference/minimax/doc.go
+++ b/sdkx/inference/minimax/doc.go
@@ -103,4 +103,14 @@
 // base_url (Anthropic endpoint) and media_base_url (media API root, which
 // defaults to base_url with the /anthropic suffix trimmed), paces video
 // polling, and declares extra models.
+//
+// # Retries
+//
+// The provider Spec accepts `http_retries` (total wire attempts including
+// the first). It maps to option.WithMaxRetries on the Anthropic Messages
+// client and to the httpkit retry budget on the media client. Nil keeps the
+// SDK/httpkit defaults; 0 disables provider-level retries so the route
+// Router owns the budget. Retry-After and wire attempts are propagated onto
+// ProviderFailure so Router backoff and trace wire_attempts can observe
+// them.
 package minimax

--- a/sdkx/inference/minimax/media.go
+++ b/sdkx/inference/minimax/media.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/GizClaw/flowcraft/sdk/errdefs"
 	"github.com/GizClaw/flowcraft/sdk/inference"
 	"github.com/GizClaw/flowcraft/sdk/message/media"
 	"github.com/GizClaw/flowcraft/sdkx/internal/httpkit"
@@ -27,12 +28,16 @@ type mediaClient struct {
 	base string // API root, e.g. https://api.minimaxi.com
 }
 
-func newMediaClient(key, base string) *mediaClient {
+func newMediaClient(key, base string, spec Spec) *mediaClient {
+	options := []httpkit.Option{
+		httpkit.WithTimeout(10 * time.Minute),
+		httpkit.WithResponseHeaderTimeout(5 * time.Minute),
+	}
+	if spec.HTTPRetries != nil {
+		options = append(options, httpkit.WithRetryAttempts(*spec.HTTPRetries))
+	}
 	return &mediaClient{
-		http: httpkit.NewClient(
-			httpkit.WithTimeout(10*time.Minute),
-			httpkit.WithResponseHeaderTimeout(5*time.Minute),
-		),
+		http: httpkit.NewClient(options...),
 		key:  key,
 		base: strings.TrimRight(base, "/"),
 	}
@@ -71,10 +76,16 @@ func (c *mediaClient) request(
 	if resp.StatusCode != http.StatusOK {
 		defer func() { _ = resp.Body.Close() }()
 		snippet, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
-		return nil, classifyHTTPStatus(resp.StatusCode, fmt.Errorf(
-			"minimax: %s %s: HTTP %d: %s",
-			method, path, resp.StatusCode, strings.TrimSpace(string(snippet)),
-		))
+		return nil, errdefs.WithRetryCount(
+			errdefs.WithRetryAfter(
+				classifyHTTPStatus(resp.StatusCode, fmt.Errorf(
+					"minimax: %s %s: HTTP %d: %s",
+					method, path, resp.StatusCode, strings.TrimSpace(string(snippet)),
+				)),
+				errdefs.ParseRetryAfter(resp.Header.Get("Retry-After")),
+			),
+			httpkit.RetryCountOf(resp),
+		)
 	}
 	return resp, nil
 }

--- a/sdkx/inference/minimax/minimax_test.go
+++ b/sdkx/inference/minimax/minimax_test.go
@@ -274,3 +274,9 @@ func TestFactoryRejectsBadSecrets(t *testing.T) {
 		t.Fatalf("err = %v", err)
 	}
 }
+
+func TestSpecRejectsNegativeHTTPRetries(t *testing.T) {
+	if _, err := decodeSpec([]byte(`{"http_retries":-1}`)); err == nil {
+		t.Fatal("decodeSpec accepted negative http_retries")
+	}
+}

--- a/sdkx/inference/minimax/spec.go
+++ b/sdkx/inference/minimax/spec.go
@@ -22,6 +22,11 @@ type Spec struct {
 	// MediaBaseURL overrides the media API root (t2a, video, image).
 	// Defaults to BaseURL with the /anthropic suffix trimmed.
 	MediaBaseURL string `json:"media_base_url,omitempty"`
+	// HTTPRetries bounds wire-level HTTP retries on the media client.
+	// Zero disables transport retries so the route Router owns the full
+	// retry budget; nil keeps the httpkit default. The Anthropic Messages
+	// surface rides the vendor SDK and is not governed by this field.
+	HTTPRetries *int `json:"http_retries,omitempty"`
 	// VideoPollIntervalMillis paces video task polling; defaults to 5000.
 	VideoPollIntervalMillis int `json:"video_poll_interval_millis,omitempty"`
 	// Models declares models outside the built-in catalog or overrides
@@ -68,6 +73,9 @@ func (s Spec) Validate() error {
 	}
 	if s.VideoPollIntervalMillis < 0 {
 		return fmt.Errorf("video_poll_interval_millis must not be negative")
+	}
+	if s.HTTPRetries != nil && *s.HTTPRetries < 0 {
+		return fmt.Errorf("http_retries must not be negative")
 	}
 	seen := make(map[string]struct{}, len(s.Models))
 	for _, model := range s.Models {

--- a/sdkx/inference/openai/client.go
+++ b/sdkx/inference/openai/client.go
@@ -68,5 +68,17 @@ func (m profileMaterial) newClients(spec Spec) *clients {
 	if spec.Project != "" {
 		options = append(options, option.WithProject(spec.Project))
 	}
+	if spec.HTTPRetries != nil {
+		options = append(options, option.WithMaxRetries(sdkMaxRetries(*spec.HTTPRetries)))
+	}
 	return &clients{api: openai.NewClient(options...)}
+}
+
+// sdkMaxRetries converts a total-attempt budget (including the first) into
+// the SDK's retry-count option.
+func sdkMaxRetries(total int) int {
+	if total <= 1 {
+		return 0
+	}
+	return total - 1
 }

--- a/sdkx/inference/openai/doc.go
+++ b/sdkx/inference/openai/doc.go
@@ -37,4 +37,13 @@
 //		map[string]config.SecretResolver{"env": env.New()},
 //	)
 //	assembly, _ := builder.NewAssembly(ctx, document) // Runtime + Router
+//
+// # Retries
+//
+// The provider Spec accepts `http_retries` (total wire attempts including
+// the first). Nil keeps the openai-go default (two retries); 0 disables
+// SDK-internal retries so the route Router owns the budget; N maps to
+// option.WithMaxRetries(N-1). Retry-After and the SDK retry count are
+// propagated onto ProviderFailure so Router backoff and trace
+// wire_attempts can observe them.
 package openai

--- a/sdkx/inference/openai/errors.go
+++ b/sdkx/inference/openai/errors.go
@@ -22,9 +22,33 @@ func classifyError(err error) error {
 		return classified
 	}
 	if apiErr, ok := errors.AsType[*openai.Error](err); ok {
-		return classifyHTTPStatus(apiErr.StatusCode, err)
+		classified := classifyHTTPStatus(apiErr.StatusCode, err)
+		if apiErr.Response != nil {
+			classified = errdefs.WithRetryAfter(
+				classified,
+				errdefs.ParseRetryAfter(apiErr.Response.Header.Get("Retry-After")),
+			)
+		}
+		if attempts := wireAttempts(apiErr.Request); attempts > 0 {
+			classified = errdefs.WithRetryCount(classified, attempts)
+		}
+		return classified
 	}
 	return errdefs.NotAvailable(fmt.Errorf("openai: %w", err))
+}
+
+// wireAttempts derives the total HTTP sends from the SDK's
+// X-Stainless-Retry-Count header (zero-based retry count on the final
+// request). Zero means the count was unavailable.
+func wireAttempts(request *http.Request) int {
+	if request == nil {
+		return 0
+	}
+	value := request.Header.Get("X-Stainless-Retry-Count")
+	if value == "" {
+		return 0
+	}
+	return errdefs.ParseRetryCount(value) + 1
 }
 
 func classifyHTTPStatus(status int, err error) error {

--- a/sdkx/inference/openai/generate_openai_test.go
+++ b/sdkx/inference/openai/generate_openai_test.go
@@ -10,6 +10,7 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/GizClaw/flowcraft/sdk/errdefs"
 	"github.com/GizClaw/flowcraft/sdk/inference"
@@ -450,6 +451,45 @@ func TestClassifyError(t *testing.T) {
 				t.Fatalf("classified error = %v", err)
 			}
 		})
+	}
+}
+
+func TestRateLimitCarriesRetryAfter(t *testing.T) {
+	server, _ := newCapturedOpenAI(t, func(w http.ResponseWriter, _ *http.Request, _ map[string]any) {
+		w.Header().Set("Retry-After", "4")
+		w.WriteHeader(http.StatusTooManyRequests)
+		_, _ = fmt.Fprint(w, `{"error":{"message":"slow down","type":"rate_limit_error","code":"x"}}`)
+	})
+	defer server.Close()
+	cls := testClients(t, server)
+	operations, err := openGenerate(
+		cls,
+		catalog["gpt-5.6-sol"],
+		openaiModel("gpt-5.6-sol").ID,
+		"default",
+	)
+	if err != nil {
+		t.Fatalf("openGenerate: %v", err)
+	}
+	_, err = operations.Unary.Execute(
+		context.Background(),
+		openaiModel("gpt-5.6-sol"),
+		simpleTextRequest("hi"),
+	)
+	if !errdefs.IsRateLimit(err) {
+		t.Fatalf("err = %v, want rate limit", err)
+	}
+	if got, ok := errdefs.RetryAfter(err); !ok || got != 4*time.Second {
+		t.Fatalf("RetryAfter = %v/%v, want 4s/true", got, ok)
+	}
+	if got := errdefs.RetryCount(err); got < 1 {
+		t.Fatalf("RetryCount = %d, want at least 1 wire attempt", got)
+	}
+}
+
+func TestSpecRejectsNegativeHTTPRetries(t *testing.T) {
+	if _, err := decodeSpec([]byte(`{"http_retries":-1}`)); err == nil {
+		t.Fatal("decodeSpec accepted negative http_retries")
 	}
 }
 

--- a/sdkx/inference/openai/spec.go
+++ b/sdkx/inference/openai/spec.go
@@ -25,6 +25,11 @@ type Spec struct {
 	Organization string `json:"organization,omitempty"`
 	// Project sets the OpenAI-Project header.
 	Project string `json:"project,omitempty"`
+	// HTTPRetries bounds wire-level retries inside one logical inference
+	// attempt, including the first. Zero disables SDK-internal retries so
+	// the route Router owns the full retry budget; nil keeps the openai-go
+	// default (two retries).
+	HTTPRetries *int `json:"http_retries,omitempty"`
 	// Models declares additional models beyond the built-in catalog or
 	// overrides catalog entries by name.
 	Models []ModelSpec `json:"models,omitempty"`
@@ -60,6 +65,9 @@ func (s Spec) Validate() error {
 		!strings.HasPrefix(s.BaseURL, "https://") &&
 		!strings.HasPrefix(s.BaseURL, "http://") {
 		return fmt.Errorf("base_url must be an http(s) URL")
+	}
+	if s.HTTPRetries != nil && *s.HTTPRetries < 0 {
+		return fmt.Errorf("http_retries must not be negative")
 	}
 	seen := make(map[string]struct{}, len(s.Models))
 	for index, model := range s.Models {

--- a/sdkx/inference/qwen/client.go
+++ b/sdkx/inference/qwen/client.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/GizClaw/flowcraft/sdk/errdefs"
 	"github.com/GizClaw/flowcraft/sdk/inference/config"
 	"github.com/GizClaw/flowcraft/sdk/telemetry"
 	"github.com/GizClaw/flowcraft/sdkx/internal/httpkit"
@@ -67,11 +68,15 @@ func newProfileMaterial(profile config.ResolvedProfile) (profileMaterial, error)
 }
 
 func (m profileMaterial) newClient(spec Spec) *dashClient {
+	options := []httpkit.Option{
+		httpkit.WithTimeout(10 * time.Minute),
+		httpkit.WithResponseHeaderTimeout(5 * time.Minute),
+	}
+	if spec.HTTPRetries != nil {
+		options = append(options, httpkit.WithRetryAttempts(*spec.HTTPRetries))
+	}
 	return &dashClient{
-		http: httpkit.NewClient(
-			httpkit.WithTimeout(10*time.Minute),
-			httpkit.WithResponseHeaderTimeout(5*time.Minute),
-		),
+		http: httpkit.NewClient(options...),
 		key:  m.apiKey,
 		base: spec.apiBase(),
 	}
@@ -120,8 +125,14 @@ func (c *dashClient) request(
 				otellog.String("provider", "qwen"),
 				otellog.Int("http.status", resp.StatusCode))
 		}
-		return nil, classifyHTTPError(
-			resp.StatusCode, failure.Code, failure.Message, snippet,
+		return nil, errdefs.WithRetryCount(
+			errdefs.WithRetryAfter(
+				classifyHTTPError(
+					resp.StatusCode, failure.Code, failure.Message, snippet,
+				),
+				errdefs.ParseRetryAfter(resp.Header.Get("Retry-After")),
+			),
+			httpkit.RetryCountOf(resp),
 		)
 	}
 	return resp, nil

--- a/sdkx/inference/qwen/doc.go
+++ b/sdkx/inference/qwen/doc.go
@@ -65,4 +65,13 @@
 // the spec (name, kind, vision, reasoning). Media output (image /
 // speech / video generation) lives in dedicated DashScope SKUs, not this
 // driver.
+//
+// # Retries
+//
+// The provider Spec accepts `http_retries` (total wire attempts including
+// the first). Nil keeps the httpkit default (three attempts); 0 disables
+// transport retries so the route Router owns the budget; N sets total wire
+// attempts. Retry-After and wire attempts observed at the HTTP layer are
+// propagated onto ProviderFailure so Router backoff and trace
+// wire_attempts can observe them.
 package qwen

--- a/sdkx/inference/qwen/generate_test.go
+++ b/sdkx/inference/qwen/generate_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/GizClaw/flowcraft/sdk/errdefs"
 	"github.com/GizClaw/flowcraft/sdk/inference"
@@ -743,6 +744,35 @@ func TestErrorClassification(t *testing.T) {
 				t.Fatalf("err = %v", err)
 			}
 		})
+	}
+}
+
+func TestRateLimitCarriesRetryAfter(t *testing.T) {
+	server := newDashServer(t, func(w http.ResponseWriter, _ map[string]any) {
+		w.Header().Set("Retry-After", "3")
+		w.WriteHeader(http.StatusTooManyRequests)
+		_, _ = fmt.Fprint(w, `{"code":"Throttling.RateQuota","message":"slow down"}`)
+	})
+	runtime := newTestRuntime(t, server)
+	_, err := runtime.Generate(
+		context.Background(),
+		qwenModel("qwen-plus"),
+		simpleTextRequest("hi"),
+	)
+	if !errdefs.IsRateLimit(err) {
+		t.Fatalf("err = %v, want rate limit", err)
+	}
+	if got, ok := errdefs.RetryAfter(err); !ok || got != 3*time.Second {
+		t.Fatalf("RetryAfter = %v/%v, want 3s/true", got, ok)
+	}
+	if got := errdefs.RetryCount(err); got < 1 {
+		t.Fatalf("RetryCount = %d, want at least 1 wire attempt", got)
+	}
+}
+
+func TestSpecRejectsNegativeHTTPRetries(t *testing.T) {
+	if _, err := decodeSpec([]byte(`{"http_retries":-1}`)); err == nil {
+		t.Fatal("decodeSpec accepted negative http_retries")
 	}
 }
 

--- a/sdkx/inference/qwen/spec.go
+++ b/sdkx/inference/qwen/spec.go
@@ -24,6 +24,10 @@ type Spec struct {
 	// https://dashscope.aliyuncs.com; workspace-dedicated and regional
 	// domains plug in here (without the /api/v1 suffix).
 	BaseURL string `json:"base_url,omitempty"`
+	// HTTPRetries bounds wire-level HTTP retries inside one logical
+	// inference attempt. Zero disables transport retries so the route
+	// Router owns the full retry budget; nil keeps the httpkit default.
+	HTTPRetries *int `json:"http_retries,omitempty"`
 	// Models declares models outside the built-in catalog or overrides
 	// catalog entries by name.
 	Models []ModelSpec `json:"models,omitempty"`
@@ -59,6 +63,9 @@ func (s Spec) Validate() error {
 		if err := validateURL("base_url", s.BaseURL); err != nil {
 			return err
 		}
+	}
+	if s.HTTPRetries != nil && *s.HTTPRetries < 0 {
+		return fmt.Errorf("http_retries must not be negative")
 	}
 	seen := make(map[string]bool, len(s.Models))
 	for _, model := range s.Models {

--- a/sdkx/internal/httpkit/httpkit.go
+++ b/sdkx/internal/httpkit/httpkit.go
@@ -13,6 +13,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/GizClaw/flowcraft/sdk/errdefs"
+
 	"github.com/quic-go/quic-go"
 	"github.com/quic-go/quic-go/http3"
 	"golang.org/x/net/http2"
@@ -141,6 +143,18 @@ func WithRetry(config RetryConfig) Option {
 		cfg.Retry = config
 		cfg.RetryEnabled = true
 	}
+}
+
+// WithRetryAttempts sets the total wire attempts including the first,
+// keeping the default backoff curve. Zero or negative disables transport
+// retries so an outer retry owner (route.Router) controls the full budget.
+func WithRetryAttempts(maxAttempts int) Option {
+	if maxAttempts <= 0 {
+		return WithoutRetry()
+	}
+	config := DefaultRetry
+	config.MaxAttempts = maxAttempts
+	return WithRetry(config)
 }
 
 func WithoutRetry() Option {
@@ -272,6 +286,19 @@ type retryTransport struct {
 	config RetryConfig
 }
 
+// retryCountHeader is the internal response header carrying the total wire
+// attempts (1-based) that produced the response.
+const retryCountHeader = "X-Flowcraft-Retry-Count"
+
+// RetryCountOf reports the wire attempts that produced a response. It
+// returns 0 for responses the retry transport did not stamp.
+func RetryCountOf(response *http.Response) int {
+	if response == nil {
+		return 0
+	}
+	return errdefs.ParseRetryCount(response.Header.Get(retryCountHeader))
+}
+
 func (t *retryTransport) RoundTrip(request *http.Request) (*http.Response, error) {
 	// Without GetBody the body cannot be replayed: one attempt, exactly
 	// like a bare transport.
@@ -295,6 +322,12 @@ func (t *retryTransport) RoundTrip(request *http.Request) (*http.Response, error
 
 		response, err = t.base.RoundTrip(attemptRequest)
 		if attempt >= t.config.MaxAttempts || !retryable(response, err) {
+			if err != nil {
+				err = errdefs.WithRetryCount(err, attempt)
+			}
+			if response != nil {
+				response.Header.Set(retryCountHeader, strconv.Itoa(attempt))
+			}
 			return response, err
 		}
 		if response != nil && response.Body != nil {
@@ -309,7 +342,10 @@ func (t *retryTransport) RoundTrip(request *http.Request) (*http.Response, error
 		case <-timer.C:
 		case <-request.Context().Done():
 			timer.Stop()
-			return nil, request.Context().Err()
+			return nil, errdefs.WithRetryCount(
+				request.Context().Err(),
+				attempt,
+			)
 		}
 	}
 }

--- a/sdkx/internal/httpkit/httpkit_test.go
+++ b/sdkx/internal/httpkit/httpkit_test.go
@@ -20,6 +20,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/GizClaw/flowcraft/sdk/errdefs"
+
 	"github.com/quic-go/quic-go"
 	"github.com/quic-go/quic-go/http3"
 )
@@ -424,5 +426,69 @@ func TestContextCancellationStopsBackoff(t *testing.T) {
 	_, err = client.Do(request)
 	if err == nil || !errors.Is(err, context.Canceled) {
 		t.Fatalf("err = %v, want context.Canceled", err)
+	}
+}
+
+type failingRoundTripper struct {
+	calls int
+}
+
+func (f *failingRoundTripper) RoundTrip(*http.Request) (*http.Response, error) {
+	f.calls++
+	return nil, errors.New("transport failed")
+}
+
+func TestRetryCountAttachedToFinalTransportError(t *testing.T) {
+	base := &failingRoundTripper{}
+	client := &http.Client{
+		Transport: newRetryTransport(base, fastRetry()),
+	}
+	request, err := http.NewRequest(
+		http.MethodPost,
+		"https://example.invalid/",
+		bytes.NewReader([]byte("x")),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = client.Do(request)
+	if err == nil {
+		t.Fatal("Do succeeded, want transport failure")
+	}
+	if got := errdefs.RetryCount(err); got != 3 {
+		t.Fatalf("RetryCount = %d, want 3", got)
+	}
+	if base.calls != 3 {
+		t.Fatalf("base calls = %d, want 3", base.calls)
+	}
+}
+
+func TestRetryCountOfStatusResponse(t *testing.T) {
+	var calls atomic.Int64
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		calls.Add(1)
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}))
+	defer server.Close()
+
+	client := &http.Client{Transport: newRetryTransport(nil, fastRetry())}
+	request, err := http.NewRequest(
+		http.MethodPost,
+		server.URL,
+		bytes.NewReader([]byte("x")),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	response, err := client.Do(request)
+	if err != nil {
+		t.Fatalf("Do: %v", err)
+	}
+	defer func() { _ = response.Body.Close() }()
+	if got := RetryCountOf(response); got != 3 {
+		t.Fatalf("RetryCountOf = %d, want 3", got)
+	}
+	if calls.Load() != 3 {
+		t.Fatalf("calls = %d, want 3", calls.Load())
 	}
 }


### PR DESCRIPTION
## Summary

Adds a complete resilience layer to `sdk/inference/route.Router`:

- Same-target retry/backoff via `RetryPolicy` / `RetryPolicies` (fixed/exponential, jitter, Retry-After override, optional fallback after retry exhaustion)
- Per-target circuit breaker (`CircuitBreakerConfig`), closed/open/half-open with concurrent single-probe admission
- Global logical-attempt budget (`MaxTotalAttempts`) and `Router.ResetCircuitBreaker()`
- Trace/telemetry: retry trigger, attempt number, backoff, circuit state/transitions, wire attempts
- JSON-only route policy sections (`retry`, `circuit_breaker`) wired through `config.Builder.NewAssembly`
- Provider coordination:
  - httpkit: `WithRetryAttempts`, `Retry-After` + wire-attempt propagation on status and transport failures
  - openai/anthropic/azure/deepseek: `http_retries` mapped to SDK `WithMaxRetries`, Retry-After from error response, wire attempts from `X-Stainless-Retry-Count`
  - qwen/kimi/minimax/bytedance: `http_retries` on provider specs; bytedance speech client shares the httpkit retry budget
- Docs: inference guide updated; provider `doc.go` retry notes

## Verification

- `make ci` passes (vet + tests across sdk, memory, sdkx, examples)
- `go test -race ./sdk/inference/route/...` passes
- `make release-check` passes (no release changesets added)