### PR TITLE
feat(sdkx/inference): propagate provider request/response IDs to telemetry

### DIFF
--- a/docs/guides/inference.md
+++ b/docs/guides/inference.md
@@ -183,6 +183,7 @@ In the snippets below, `message` is
 `github.com/GizClaw/flowcraft/sdk/message` — request history and content
 use the shared message DTOs, not inference-specific types.
 
+{% raw %}
 ```go
 model := inference.ModelRef{ID: inference.ModelID{Provider: "openai", Name: "gpt-5.4"}}
 
@@ -208,6 +209,7 @@ resp, err := runtime.Generate(ctx, model, inference.GenerateRequest{
 })
 // resp.Message.Content.Parts, resp.FinishReason, resp.Usage, resp.Metadata
 ```
+{% endraw %}
 
 `intPtr` / `floatPtr` / `int64Ptr` in these snippets are local
 address-taking helpers (`func intPtr(v int) *int { return &v }`), not

--- a/docs/guides/memory.md
+++ b/docs/guides/memory.md
@@ -228,6 +228,7 @@ starts its workers when Runtime starts; the flowcraft implementation's
 Obtain an `sdkmemory.Assembly` from the deployment (for example as a bound
 dependency), then use the three capabilities directly:
 
+{% raw %}
 ```go
 var assembly sdkmemory.Assembly // bound from the deployment
 
@@ -263,6 +264,7 @@ err = assembly.PutDocument(ctx, sdkmemory.Document{
     Provenance:     []sdkmemory.SourceRef{{Kind: sdkmemory.SourceDocument, ID: "source/handbook"}},
 })
 ```
+{% endraw %}
 
 Implementations may expose implementation-specific services (workers,
 stores, backends) through their own types; the SDK contracts never require

--- a/sdk/errdefs/retry.go
+++ b/sdk/errdefs/retry.go
@@ -19,6 +19,13 @@ type RetryCountCoder interface {
 	RetryCount() int
 }
 
+// RequestIDCoder is implemented by errors that carry a provider-assigned
+// request identifier, useful for correlating a failure with the provider's
+// own trace/log surface.
+type RequestIDCoder interface {
+	RequestID() string
+}
+
 type retryAfterHint struct {
 	error
 	retryAfter time.Duration
@@ -103,4 +110,34 @@ func RetryCount(err error) int {
 		return coder.RetryCount()
 	}
 	return 0
+}
+
+type requestIDHint struct {
+	error
+	requestID string
+}
+
+func (e requestIDHint) Unwrap() error { return e.error }
+
+func (e requestIDHint) RequestID() string { return e.requestID }
+
+// WithRequestID wraps err with a provider-assigned request identifier. Nil
+// and empty identifiers return err unchanged so callers can attach them
+// unconditionally.
+func WithRequestID(err error, id string) error {
+	if err == nil || strings.TrimSpace(id) == "" {
+		return err
+	}
+	return requestIDHint{error: err, requestID: id}
+}
+
+// RequestID reads the provider request identifier from an error chain. It
+// reports false when the chain carries no identifier.
+func RequestID(err error) (string, bool) {
+	var coder RequestIDCoder
+	if errors.As(err, &coder) {
+		id := coder.RequestID()
+		return id, id != ""
+	}
+	return "", false
 }

--- a/sdk/errdefs/retry_test.go
+++ b/sdk/errdefs/retry_test.go
@@ -74,3 +74,29 @@ func TestParseRetryCount(t *testing.T) {
 		}
 	}
 }
+
+func TestWithRequestIDAndRequestID(t *testing.T) {
+	err := WithRequestID(NotAvailable(errors.New("boom")), "req-1")
+	got, ok := RequestID(err)
+	if !ok || got != "req-1" {
+		t.Fatalf("RequestID = %q/%v, want req-1/true", got, ok)
+	}
+	if got, ok := RequestID(errors.New("plain")); ok || got != "" {
+		t.Fatalf("RequestID(plain) = %q/%v, want empty/false", got, ok)
+	}
+}
+
+func TestRequestIDWalksWrappedChain(t *testing.T) {
+	inner := WithRequestID(Timeout(errors.New("slow")), "req-2")
+	wrapped := errors.Join(errors.New("outer"), inner)
+	got, ok := RequestID(wrapped)
+	if !ok || got != "req-2" {
+		t.Fatalf("RequestID = %q/%v, want req-2/true", got, ok)
+	}
+}
+
+func TestWithRequestIDIgnoresEmpty(t *testing.T) {
+	if got, ok := RequestID(WithRequestID(errors.New("plain"), " ")); ok || got != "" {
+		t.Fatalf("empty identifier reported: %q/%v", got, ok)
+	}
+}

--- a/sdk/go.mod
+++ b/sdk/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/expr-lang/expr v1.17.8
 	github.com/rs/xid v1.6.0
 	github.com/santhosh-tekuri/jsonschema/v5 v5.3.1
+	go.opentelemetry.io/contrib/instrumentation/runtime v0.65.0
 	go.opentelemetry.io/otel v1.40.0
 	go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploghttp v0.16.0
 	go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp v1.40.0

--- a/sdk/go.sum
+++ b/sdk/go.sum
@@ -36,6 +36,8 @@ github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 go.opentelemetry.io/auto/sdk v1.2.1 h1:jXsnJ4Lmnqd11kwkBV2LgLoFMZKizbCi5fNZ/ipaZ64=
 go.opentelemetry.io/auto/sdk v1.2.1/go.mod h1:KRTj+aOaElaLi+wW1kO/DZRXwkF4C5xPbEe3ZiIhN7Y=
+go.opentelemetry.io/contrib/instrumentation/runtime v0.65.0 h1:n8qdwrebNEHF/zHpueuZ4OacdJ8CdSaP7xef9WRZXTQ=
+go.opentelemetry.io/contrib/instrumentation/runtime v0.65.0/go.mod h1:Z1pjGxUL3nJ/IbDDfL6rBD0Xbz7ZOViRqrIUg4l1CYE=
 go.opentelemetry.io/otel v1.40.0 h1:oA5YeOcpRTXq6NN7frwmwFR0Cn3RhTVZvXsP4duvCms=
 go.opentelemetry.io/otel v1.40.0/go.mod h1:IMb+uXZUKkMXdPddhwAHm6UfOwJyh4ct1ybIlV14J0g=
 go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploghttp v0.16.0 h1:djrxvDxAe44mJUrKataUbOhCKhR3F8QCyWucO16hTQs=

--- a/sdk/inference/errors.go
+++ b/sdk/inference/errors.go
@@ -44,7 +44,12 @@ type Error struct {
 	// before surfacing this failure. Zero means the provider did not report
 	// a count.
 	WireAttempts int
-	cause        error
+	// RequestID is the provider-assigned request identifier attached to
+	// this failure when the provider reported one. Empty otherwise.
+	// Runtime telemetry mirrors it onto error spans and logs as
+	// llm.request.id.
+	RequestID string
+	cause     error
 }
 
 func NewError(kind ErrorKind, operation Operation, field FieldID, cause error) *Error {
@@ -73,6 +78,9 @@ func newProviderError(
 		err.RetryAfter = retryAfter
 	}
 	err.WireAttempts = errdefs.RetryCount(cause)
+	if requestID, ok := errdefs.RequestID(cause); ok {
+		err.RequestID = requestID
+	}
 	return err
 }
 

--- a/sdk/inference/generate_stream.go
+++ b/sdk/inference/generate_stream.go
@@ -123,6 +123,11 @@ type GenerateStreamEvent struct {
 	// Usage is a cumulative snapshot and replaces the previous snapshot.
 	Usage        *Usage       `json:"usage,omitempty"`
 	FinishReason FinishReason `json:"finish_reason,omitempty"`
+	// RequestID / ResponseID ride the terminal finish event when the
+	// provider exposes them. The stream accumulator carries them onto
+	// the final Result metadata.
+	RequestID  string `json:"request_id,omitempty"`
+	ResponseID string `json:"response_id,omitempty"`
 }
 
 // GenerateStreamDecoder implementations must support concurrent calls.
@@ -216,14 +221,16 @@ type generatePartAccumulator struct {
 }
 
 type decodedGenerateStream[RawEvent any] struct {
-	raw     ProviderStream[RawEvent]
-	decode  GenerateStreamDecoder[RawEvent]
-	model   ModelRef
-	request GenerateRequest
-	report  CompileReport
-	parts   map[int]*generatePartAccumulator
-	usage   Usage
-	finish  FinishReason
+	raw        ProviderStream[RawEvent]
+	decode     GenerateStreamDecoder[RawEvent]
+	model      ModelRef
+	request    GenerateRequest
+	report     CompileReport
+	parts      map[int]*generatePartAccumulator
+	usage      Usage
+	finish     FinishReason
+	requestID  string
+	responseID string
 
 	done      bool
 	result    GenerateResponse
@@ -328,6 +335,12 @@ func (s *decodedGenerateStream[RawEvent]) accumulate(
 	if event.Usage != nil {
 		s.usage = event.Usage.Clone()
 	}
+	if event.RequestID != "" {
+		s.requestID = event.RequestID
+	}
+	if event.ResponseID != "" {
+		s.responseID = event.ResponseID
+	}
 	if event.FinishReason != "" {
 		if s.finish != "" {
 			return fmt.Errorf("stream emitted multiple finish reasons")
@@ -420,8 +433,11 @@ func (s *decodedGenerateStream[RawEvent]) finishResult() {
 		},
 		FinishReason: s.finish,
 		Usage:        s.usage,
-		Metadata:     s.report.Metadata(s.model),
 	}
+	metadata := s.report.Metadata(s.model)
+	metadata.RequestID = s.requestID
+	metadata.ResponseID = s.responseID
+	response.Metadata = metadata
 	deriveGenerateUsage(s.request, &response)
 	if err := response.ValidateFor(s.request); err != nil {
 		s.resultErr = NewError(InvalidProviderResponse, OperationGenerate, "", err)

--- a/sdk/inference/model.go
+++ b/sdk/inference/model.go
@@ -140,6 +140,18 @@ type Metadata struct {
 	Model     ModelID    `json:"model"`
 	Operation Operation  `json:"operation"`
 	Decisions []Decision `json:"decisions,omitempty"`
+
+	// RequestID is the provider-assigned request identifier when the
+	// wire response carries one (e.g. DashScope request_id, or an error
+	// envelope's request id). Empty when the provider does not expose
+	// one. Runtime telemetry mirrors it onto spans as llm.request.id.
+	RequestID string `json:"request_id,omitempty"`
+	// ResponseID is the provider-assigned identifier of the response
+	// object when the wire response carries one (e.g. OpenAI
+	// response.id, Anthropic message.id, chat completion id). Empty
+	// when unavailable. Runtime telemetry mirrors it onto spans as
+	// llm.response.id.
+	ResponseID string `json:"response_id,omitempty"`
 }
 
 func clonePointer[T any](value *T) *T {

--- a/sdk/inference/route/router_generate.go
+++ b/sdk/inference/route/router_generate.go
@@ -46,7 +46,7 @@ func (r *Router) Generate(
 			return response, response.Metadata, err
 		},
 	)
-	recordRoute(ctx, span, inference.OperationGenerate, trace, err)
+	recordRoute(ctx, span, inference.OperationGenerate, trace, response.Metadata, err)
 	return response, trace, err
 }
 
@@ -55,7 +55,12 @@ func (r *Router) GenerateStream(
 	request inference.GenerateRequest,
 ) (stream inference.GenerateStream, routeTrace Trace, err error) {
 	ctx, span := startRouteSpan(ctx, inference.OperationGenerate)
-	defer func() { recordRoute(ctx, span, inference.OperationGenerate, routeTrace, err) }()
+	defer func() {
+		recordRoute(
+			ctx, span, inference.OperationGenerate, routeTrace,
+			inference.Metadata{}, err,
+		)
+	}()
 	snapshot := request.Clone()
 	stream, routeTrace, err = openSessionWithFallback(r,
 		ctx,

--- a/sdk/inference/route/router_generate_test.go
+++ b/sdk/inference/route/router_generate_test.go
@@ -607,5 +607,9 @@ func validGenerateResponse() inference.GenerateResponse {
 			},
 		},
 		FinishReason: inference.FinishCompleted,
+		Metadata: inference.Metadata{
+			RequestID:  "route-req",
+			ResponseID: "route-resp",
+		},
 	}
 }

--- a/sdk/inference/route/router_other.go
+++ b/sdk/inference/route/router_other.go
@@ -90,7 +90,7 @@ func (r *Router) Embed(
 			return response, response.Metadata, err
 		},
 	)
-	recordRoute(ctx, span, inference.OperationEmbed, trace, err)
+	recordRoute(ctx, span, inference.OperationEmbed, trace, response.Metadata, err)
 	return response, trace, err
 }
 
@@ -140,7 +140,7 @@ func (r *Router) Transcribe(
 			return response, response.Metadata, err
 		},
 	)
-	recordRoute(ctx, span, inference.OperationTranscription, trace, err)
+	recordRoute(ctx, span, inference.OperationTranscription, trace, response.Metadata, err)
 	return response, trace, err
 }
 
@@ -187,7 +187,10 @@ func (r *Router) OpenTranscription(
 		nil,
 		r.runtime.OpenTranscription,
 	)
-	recordRoute(ctx, span, inference.OperationTranscription, trace, err)
+	recordRoute(
+		ctx, span, inference.OperationTranscription, trace,
+		inference.Metadata{}, err,
+	)
 	return session, trace, err
 }
 
@@ -238,7 +241,10 @@ func (r *Router) OpenRealtime(
 		nil,
 		r.runtime.OpenRealtime,
 	)
-	recordRoute(ctx, span, inference.OperationRealtime, trace, err)
+	recordRoute(
+		ctx, span, inference.OperationRealtime, trace,
+		inference.Metadata{}, err,
+	)
 	return session, trace, err
 }
 

--- a/sdk/inference/route/telemetry.go
+++ b/sdk/inference/route/telemetry.go
@@ -54,6 +54,7 @@ func recordRoute(
 	span trace.Span,
 	operation inference.Operation,
 	routeTrace Trace,
+	metadata inference.Metadata,
 	err error,
 ) {
 	opAttr := attribute.String("inference.operation", string(operation))
@@ -121,6 +122,14 @@ func recordRoute(
 		attribute.String("route.executed.provider", executed.ID.Provider),
 		attribute.String("route.executed.model", executed.ID.Name),
 	)
+	if metadata.RequestID != "" {
+		span.SetAttributes(
+			attribute.String(telemetry.AttrLLMRequestID, metadata.RequestID))
+	}
+	if metadata.ResponseID != "" {
+		span.SetAttributes(
+			attribute.String(telemetry.AttrLLMResponseID, metadata.ResponseID))
+	}
 	if len(routeTrace.Fallbacks) > 0 {
 		routeFallbackCount.Add(ctx, 1, metric.WithAttributes(opAttr))
 	}

--- a/sdk/inference/route/telemetry_test.go
+++ b/sdk/inference/route/telemetry_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/GizClaw/flowcraft/sdk/inference"
+	"github.com/GizClaw/flowcraft/sdk/telemetry"
 
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
@@ -88,10 +89,12 @@ func TestRouteTelemetryRecordsFallbackJourney(t *testing.T) {
 		t.Fatalf("route span status = %v, want Ok", routeSpan.Status())
 	}
 	for key, want := range map[string]any{
-		"route.selected.provider": "fake",
-		"route.selected.model":    "primary",
-		"route.executed.model":    "backup",
-		"route.fallbacks":         1,
+		"route.selected.provider":   "fake",
+		"route.selected.model":      "primary",
+		"route.executed.model":      "backup",
+		"route.fallbacks":           1,
+		telemetry.AttrLLMRequestID:  "route-req",
+		telemetry.AttrLLMResponseID: "route-resp",
 	} {
 		attr, ok := routeSpanAttr(routeSpan, key)
 		if !ok {

--- a/sdk/inference/runtime.go
+++ b/sdk/inference/runtime.go
@@ -105,6 +105,7 @@ func (r *Runtime) Generate(
 		if err == nil {
 			tel.stampUsage(&resp.Usage)
 			tel.recordUsage(ctx, resp.Usage)
+			tel.recordIDs(ctx, resp.Metadata)
 		}
 		tel.finish(ctx, err)
 	}()
@@ -220,6 +221,7 @@ func (r *Runtime) Embed(
 	defer func() {
 		if err == nil {
 			tel.recordEmbedUsage(ctx, resp.Usage)
+			tel.recordIDs(ctx, resp.Metadata)
 		}
 		tel.finish(ctx, err)
 	}()

--- a/sdk/inference/runtime_audio.go
+++ b/sdk/inference/runtime_audio.go
@@ -14,6 +14,7 @@ func (r *Runtime) Transcribe(
 	defer func() {
 		if err == nil {
 			tel.recordTranscriptionUsage(ctx, resp.Usage)
+			tel.recordIDs(ctx, resp.Metadata)
 		}
 		tel.finish(ctx, err)
 	}()

--- a/sdk/inference/telemetry.go
+++ b/sdk/inference/telemetry.go
@@ -110,16 +110,45 @@ func (t callTelemetry) finish(ctx context.Context, err error) {
 	}
 	kind := classifyError(err)
 	t.span.SetAttributes(attribute.String("inference.error_kind", kind))
-	t.span.SetStatus(codes.Error, err.Error())
-	t.span.End()
-	inferenceExecCount.Add(ctx, 1, t.metricAttrs(attribute.String("status", "error")))
-	inferenceErrorCount.Add(ctx, 1, t.metricAttrs(attribute.String("error_kind", kind)))
-	telemetry.Warn(ctx, "inference operation failed",
+	logAttrs := []otellog.KeyValue{
 		otellog.String("inference.operation", string(t.op)),
 		otellog.String(telemetry.AttrLLMProvider, t.model.ID.Provider),
 		otellog.String(telemetry.AttrLLMModel, t.model.ID.Name),
 		otellog.String("inference.error_kind", kind),
-		otellog.String(telemetry.AttrErrorMessage, err.Error()))
+		otellog.String(telemetry.AttrErrorMessage, err.Error()),
+	}
+	if requestID := requestIDOf(err); requestID != "" {
+		t.span.SetAttributes(attribute.String(telemetry.AttrLLMRequestID, requestID))
+		logAttrs = append(logAttrs, otellog.String(telemetry.AttrLLMRequestID, requestID))
+	}
+	t.span.SetStatus(codes.Error, err.Error())
+	t.span.End()
+	inferenceExecCount.Add(ctx, 1, t.metricAttrs(attribute.String("status", "error")))
+	inferenceErrorCount.Add(ctx, 1, t.metricAttrs(attribute.String("error_kind", kind)))
+	telemetry.Warn(ctx, "inference operation failed", logAttrs...)
+}
+
+// requestIDOf extracts the provider request identifier from a structured
+// inference error when the provider attached one.
+func requestIDOf(err error) string {
+	var inferenceErr *Error
+	if errors.As(err, &inferenceErr) {
+		return inferenceErr.RequestID
+	}
+	return ""
+}
+
+// recordIDs mirrors provider-assigned request/response identifiers onto
+// the call span. Empty values are left out so spans stay slim.
+func (t callTelemetry) recordIDs(_ context.Context, metadata Metadata) {
+	if metadata.RequestID != "" {
+		t.span.SetAttributes(
+			attribute.String(telemetry.AttrLLMRequestID, metadata.RequestID))
+	}
+	if metadata.ResponseID != "" {
+		t.span.SetAttributes(
+			attribute.String(telemetry.AttrLLMResponseID, metadata.ResponseID))
+	}
 }
 
 // stampUsage fills the call-context envelope on a usage value about
@@ -206,10 +235,12 @@ func (t callTelemetry) recordTranscriptionUsage(_ context.Context, usage Transcr
 // the one recorded.
 type telemetryStream struct {
 	GenerateStream
-	tel  callTelemetry
-	ctx  context.Context
-	once sync.Once
-	last *Usage
+	tel        callTelemetry
+	ctx        context.Context
+	once       sync.Once
+	last       *Usage
+	requestID  string
+	responseID string
 }
 
 func wrapStreamTelemetry(ctx context.Context, tel callTelemetry, stream GenerateStream) GenerateStream {
@@ -224,6 +255,12 @@ func (s *telemetryStream) Next(ctx context.Context) (GenerateStreamEvent, error)
 			// caller-visible event carry the same envelope.
 			s.tel.stampUsage(event.Usage)
 			s.last = event.Usage
+		}
+		if event.RequestID != "" {
+			s.requestID = event.RequestID
+		}
+		if event.ResponseID != "" {
+			s.responseID = event.ResponseID
 		}
 		return event, nil
 	}
@@ -241,6 +278,7 @@ func (s *telemetryStream) Result() (GenerateResponse, error) {
 	resp, err := s.GenerateStream.Result()
 	if err == nil {
 		s.tel.stampUsage(&resp.Usage)
+		s.tel.recordIDs(s.ctx, resp.Metadata)
 	}
 	return resp, err
 }
@@ -260,6 +298,12 @@ func (s *telemetryStream) end(err error) {
 	s.once.Do(func() {
 		if s.last != nil {
 			s.tel.recordUsage(s.ctx, *s.last)
+		}
+		if s.requestID != "" || s.responseID != "" {
+			s.tel.recordIDs(s.ctx, Metadata{
+				RequestID:  s.requestID,
+				ResponseID: s.responseID,
+			})
 		}
 		s.tel.finish(s.ctx, err)
 	})

--- a/sdk/inference/telemetry_test.go
+++ b/sdk/inference/telemetry_test.go
@@ -7,6 +7,7 @@ import (
 	"sync/atomic"
 	"testing"
 
+	"github.com/GizClaw/flowcraft/sdk/errdefs"
 	"github.com/GizClaw/flowcraft/sdk/telemetry"
 
 	"github.com/GizClaw/flowcraft/sdk/message"
@@ -103,6 +104,10 @@ func TestRuntimeTelemetryGenerateSuccess(t *testing.T) {
 					TotalTokens:  15,
 					Input:        InputTokenUsage{CacheReadTokens: &cached},
 				},
+				Metadata: Metadata{
+					RequestID:  "req-1",
+					ResponseID: "resp-1",
+				},
 			}, nil
 		},
 		nil,
@@ -130,6 +135,8 @@ func TestRuntimeTelemetryGenerateSuccess(t *testing.T) {
 		telemetry.AttrLLMOutputTokens:      int64(5),
 		telemetry.AttrLLMTotalTokens:       int64(15),
 		telemetry.AttrLLMCachedInputTokens: int64(4),
+		telemetry.AttrLLMRequestID:         "req-1",
+		telemetry.AttrLLMResponseID:        "resp-1",
 	} {
 		attr, ok := attrs[key]
 		if !ok {
@@ -150,7 +157,8 @@ func TestRuntimeTelemetryGenerateSuccess(t *testing.T) {
 
 func TestRuntimeTelemetryGenerateFailure(t *testing.T) {
 	recorder := installSpanRecorder(t)
-	runtime := newTelemetryRuntime(t, errors.New("connection reset"),
+	runtime := newTelemetryRuntime(t,
+		errdefs.WithRequestID(errors.New("connection reset"), "req-fail"),
 		func(context.Context, string) (GenerateResponse, error) {
 			return GenerateResponse{}, errors.New("decode unused")
 		},
@@ -172,6 +180,9 @@ func TestRuntimeTelemetryGenerateFailure(t *testing.T) {
 	if got := attrs["inference.error_kind"].AsString(); got != string(ProviderFailure) {
 		t.Fatalf("error_kind = %q, want %q", got, ProviderFailure)
 	}
+	if got := attrs[telemetry.AttrLLMRequestID].AsString(); got != "req-fail" {
+		t.Fatalf("request id attr = %q, want req-fail", got)
+	}
 }
 
 func TestRuntimeTelemetryStreamClosesSpanOnEOF(t *testing.T) {
@@ -185,7 +196,11 @@ func TestRuntimeTelemetryStreamClosesSpanOnEOF(t *testing.T) {
 		[]GenerateStreamEvent{
 			{PartIndex: 0, Delta: TextPartDelta{Text: "ok"}},
 			{Usage: usage},
-			{FinishReason: FinishCompleted},
+			{
+				FinishReason: FinishCompleted,
+				RequestID:    "req-stream",
+				ResponseID:   "resp-stream",
+			},
 		},
 	)
 	stream, err := runtime.GenerateStream(context.Background(), telemetryModelRef(), validGenerateTextRequest())
@@ -227,6 +242,12 @@ func TestRuntimeTelemetryStreamClosesSpanOnEOF(t *testing.T) {
 	if got := attrs[telemetry.AttrLLMTotalTokens].AsInt64(); got != 10 {
 		t.Fatalf("total tokens attr = %d, want 10", got)
 	}
+	if got := attrs[telemetry.AttrLLMRequestID].AsString(); got != "req-stream" {
+		t.Fatalf("request id attr = %q, want req-stream", got)
+	}
+	if got := attrs[telemetry.AttrLLMResponseID].AsString(); got != "resp-stream" {
+		t.Fatalf("response id attr = %q, want resp-stream", got)
+	}
 }
 
 func TestRuntimeStampsUsageEnvelope(t *testing.T) {
@@ -245,7 +266,11 @@ func TestRuntimeStampsUsageEnvelope(t *testing.T) {
 		[]GenerateStreamEvent{
 			{Usage: &Usage{InputTokens: 1, OutputTokens: 1, TotalTokens: 2}},
 			{PartIndex: 0, Delta: TextPartDelta{Text: "ok"}},
-			{FinishReason: FinishCompleted},
+			{
+				FinishReason: FinishCompleted,
+				RequestID:    "req-stream",
+				ResponseID:   "resp-stream",
+			},
 		},
 	)
 	resp, err := runtime.Generate(context.Background(), telemetryModelRef(), validGenerateTextRequest())
@@ -283,6 +308,10 @@ func TestRuntimeStampsUsageEnvelope(t *testing.T) {
 	}
 	if result.Usage.Model != telemetryModelRef() {
 		t.Fatalf("result usage not stamped: %+v", result.Usage.Model)
+	}
+	if result.Metadata.RequestID != "req-stream" ||
+		result.Metadata.ResponseID != "resp-stream" {
+		t.Fatalf("result ids = %+v", result.Metadata)
 	}
 	_ = stream.Close()
 }

--- a/sdk/inference/unary.go
+++ b/sdk/inference/unary.go
@@ -30,7 +30,7 @@ func (d *generateDriver[Wire, Raw]) Execute(
 		return GenerateResponse{}, err
 	}
 	deriveGenerateUsage(request, &response)
-	response.Metadata = report.Metadata(model)
+	response.Metadata = mergeProviderIDs(report.Metadata(model), response.Metadata)
 	return response, nil
 }
 
@@ -58,7 +58,7 @@ func (d *embedDriver[Wire, Raw]) Execute(
 		return EmbedResponse{}, err
 	}
 	response.Usage.ItemCount = len(response.Embeddings)
-	response.Metadata = report.Metadata(model)
+	response.Metadata = mergeProviderIDs(report.Metadata(model), response.Metadata)
 	return response, nil
 }
 
@@ -85,6 +85,18 @@ func (d *transcriptionDriver[Wire, Raw]) Execute(
 	if err != nil {
 		return TranscriptionResponse{}, err
 	}
-	response.Metadata = report.Metadata(model)
+	response.Metadata = mergeProviderIDs(report.Metadata(model), response.Metadata)
 	return response, nil
+}
+
+// mergeProviderIDs keeps provider-reported request/response identifiers
+// when the runtime stamps the operation metadata over the decoder's result.
+func mergeProviderIDs(metadata, decoded Metadata) Metadata {
+	if decoded.RequestID != "" {
+		metadata.RequestID = decoded.RequestID
+	}
+	if decoded.ResponseID != "" {
+		metadata.ResponseID = decoded.ResponseID
+	}
+	return metadata
 }

--- a/sdk/telemetry/attrs.go
+++ b/sdk/telemetry/attrs.go
@@ -142,6 +142,19 @@ const (
 	// milliseconds.
 	AttrLLMLatencyMs = "llm.latency.ms"
 
+	// AttrLLMRequestID is the provider-assigned request identifier for
+	// an inference call (e.g. DashScope's request_id or an error
+	// envelope's request id). Use it to join flowcraft spans with the
+	// provider's own request logs.
+	AttrLLMRequestID = "llm.request.id"
+
+	// AttrLLMResponseID is the provider-assigned identifier of the
+	// response object (e.g. OpenAI Responses' response.id, Anthropic's
+	// message.id, or a chat completion id). Providers that only expose
+	// one identifier usually surface it here rather than in
+	// AttrLLMRequestID.
+	AttrLLMResponseID = "llm.response.id"
+
 	// ----- Conversation / data scope -----
 
 	// AttrConversationID identifies the conversation an operation

--- a/sdk/telemetry/attrs_test.go
+++ b/sdk/telemetry/attrs_test.go
@@ -29,6 +29,8 @@ func TestAttrConstants_StableNames(t *testing.T) {
 		{AttrLLMCachedInputTokens, "llm.tokens.input.cached"},
 		{AttrLLMCostMicros, "llm.cost.micros"},
 		{AttrLLMLatencyMs, "llm.latency.ms"},
+		{AttrLLMRequestID, "llm.request.id"},
+		{AttrLLMResponseID, "llm.response.id"},
 		{AttrConversationID, "conversation.id"},
 		{AttrDatasetID, "dataset.id"},
 		{AttrErrorMessage, "error.message"},

--- a/sdk/telemetry/meter.go
+++ b/sdk/telemetry/meter.go
@@ -3,15 +3,21 @@ package telemetry
 import (
 	"context"
 	"fmt"
+	"time"
 
+	otelruntime "go.opentelemetry.io/contrib/instrumentation/runtime"
 	"go.opentelemetry.io/otel"
 	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
 )
 
 type meterOptions struct {
 	export         sdkmetric.Exporter
+	reader         sdkmetric.Reader
 	serviceName    string
 	serviceVersion string
+
+	runtimeMetrics         bool
+	runtimeMetricsInterval time.Duration
 
 	// optErr — see options.optErr in trace.go.
 	optErr error
@@ -26,6 +32,16 @@ func WithMeterExporter(exp sdkmetric.Exporter) MeterOption {
 	}
 }
 
+// WithMeterReader replaces the default PeriodicReader with an explicit
+// [sdkmetric.Reader]. Use it when you need deterministic collection in tests
+// (e.g. [sdkmetric.NewManualReader]) or want to attach a runtime metric
+// producer. It is mutually exclusive with [WithMeterExporter].
+func WithMeterReader(r sdkmetric.Reader) MeterOption {
+	return func(opts *meterOptions) {
+		opts.reader = r
+	}
+}
+
 func WithMeterServiceName(name string) MeterOption {
 	return func(opts *meterOptions) {
 		opts.serviceName = name
@@ -35,6 +51,21 @@ func WithMeterServiceName(name string) MeterOption {
 func WithMeterServiceVersion(version string) MeterOption {
 	return func(opts *meterOptions) {
 		opts.serviceVersion = version
+	}
+}
+
+// WithRuntimeMetrics enables Go runtime metrics collection (memory, GC,
+// goroutines, GOMAXPROCS) via
+// go.opentelemetry.io/contrib/instrumentation/runtime. The interval is the
+// minimum time between reads of the Go runtime metrics; values <= 0 fall back
+// to the contrib default of 15s. Metrics are exported through the same
+// MeterProvider configured for this pipeline, so combine it with
+// [WithMeterExporter] or [WithMeterReader] when you want them to reach a
+// collector.
+func WithRuntimeMetrics(interval time.Duration) MeterOption {
+	return func(opts *meterOptions) {
+		opts.runtimeMetrics = true
+		opts.runtimeMetricsInterval = interval
 	}
 }
 
@@ -54,6 +85,9 @@ func InitMeter(ctx context.Context, opts ...MeterOption) (func(context.Context) 
 	if o.optErr != nil {
 		return nil, o.optErr
 	}
+	if o.reader != nil && o.export != nil {
+		return nil, fmt.Errorf("telemetry: WithMeterReader and WithMeterExporter are mutually exclusive")
+	}
 
 	res, err := buildResource(ctx, o.serviceName, o.serviceVersion)
 	if err != nil {
@@ -61,18 +95,32 @@ func InitMeter(ctx context.Context, opts ...MeterOption) (func(context.Context) 
 	}
 
 	var mp *sdkmetric.MeterProvider
-	if o.export != nil {
+	switch {
+	case o.reader != nil:
+		mp = sdkmetric.NewMeterProvider(
+			sdkmetric.WithResource(res),
+			sdkmetric.WithReader(o.reader),
+		)
+	case o.export != nil:
 		reader := sdkmetric.NewPeriodicReader(o.export)
 		mp = sdkmetric.NewMeterProvider(
 			sdkmetric.WithResource(res),
 			sdkmetric.WithReader(reader),
 		)
-	} else {
+	default:
 		mp = sdkmetric.NewMeterProvider(
 			sdkmetric.WithResource(res),
 		)
 	}
 
 	otel.SetMeterProvider(mp)
+	if o.runtimeMetrics {
+		if err := otelruntime.Start(
+			otelruntime.WithMinimumReadMemStatsInterval(o.runtimeMetricsInterval),
+		); err != nil {
+			_ = mp.Shutdown(ctx)
+			return nil, fmt.Errorf("telemetry: start runtime metrics: %w", err)
+		}
+	}
 	return mp.Shutdown, nil
 }

--- a/sdk/telemetry/meter_test.go
+++ b/sdk/telemetry/meter_test.go
@@ -1,0 +1,125 @@
+package telemetry
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+)
+
+func TestWithRuntimeMetrics(t *testing.T) {
+	o := &meterOptions{}
+	WithRuntimeMetrics(3 * time.Second)(o)
+	if !o.runtimeMetrics {
+		t.Fatal("expected runtime metrics to be enabled")
+	}
+	if o.runtimeMetricsInterval != 3*time.Second {
+		t.Fatalf("expected interval 3s, got %v", o.runtimeMetricsInterval)
+	}
+}
+
+func TestWithMeterReader(t *testing.T) {
+	o := &meterOptions{}
+	r := sdkmetric.NewManualReader()
+	WithMeterReader(r)(o)
+	if o.reader != r {
+		t.Fatal("expected provided reader to be stored")
+	}
+}
+
+func TestInitMeter_WithMeterReader_UsesProvidedReader(t *testing.T) {
+	ctx := context.Background()
+	reader := sdkmetric.NewManualReader()
+	shutdown, err := InitMeter(ctx, WithMeterReader(reader))
+	if err != nil {
+		t.Fatalf("InitMeter error: %v", err)
+	}
+	defer func() { _ = shutdown(ctx) }()
+
+	counter, err := Meter().Int64Counter("test.counter")
+	if err != nil {
+		t.Fatalf("create counter error: %v", err)
+	}
+	counter.Add(ctx, 1)
+
+	var resources metricdata.ResourceMetrics
+	if err := reader.Collect(ctx, &resources); err != nil {
+		t.Fatalf("Collect: %v", err)
+	}
+	if !hasMetric(resources, "test.counter") {
+		t.Fatal("expected test.counter to be exported via the provided reader")
+	}
+}
+
+func TestInitMeter_ReaderAndExporterConflict(t *testing.T) {
+	_, err := InitMeter(context.Background(),
+		WithMeterReader(sdkmetric.NewManualReader()),
+		WithMeterExporter(noopMeterExporter{}),
+	)
+	if err == nil {
+		t.Fatal("expected error for conflicting reader and exporter")
+	}
+}
+
+func TestInitMeter_WithRuntimeMetrics_ExportsGoRuntimeMetrics(t *testing.T) {
+	ctx := context.Background()
+	reader := sdkmetric.NewManualReader()
+	shutdown, err := InitMeter(ctx,
+		WithMeterReader(reader),
+		WithRuntimeMetrics(time.Second),
+	)
+	if err != nil {
+		t.Fatalf("InitMeter error: %v", err)
+	}
+	defer func() { _ = shutdown(ctx) }()
+
+	var resources metricdata.ResourceMetrics
+	if err := reader.Collect(ctx, &resources); err != nil {
+		t.Fatalf("Collect: %v", err)
+	}
+
+	for _, name := range []string{
+		"go.memory.used",
+		"go.memory.allocated",
+		"go.goroutine.count",
+	} {
+		if !hasMetric(resources, name) {
+			t.Errorf("runtime metric %q was not exported", name)
+		}
+	}
+}
+
+func hasMetric(resources metricdata.ResourceMetrics, name string) bool {
+	for _, scope := range resources.ScopeMetrics {
+		for _, m := range scope.Metrics {
+			if m.Name == name {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+type noopMeterExporter struct{}
+
+func (noopMeterExporter) Temporality(sdkmetric.InstrumentKind) metricdata.Temporality {
+	return metricdata.CumulativeTemporality
+}
+
+func (noopMeterExporter) Aggregation(sdkmetric.InstrumentKind) sdkmetric.Aggregation {
+	return nil
+}
+
+func (noopMeterExporter) Export(context.Context, *metricdata.ResourceMetrics) error {
+	return nil
+}
+
+func (noopMeterExporter) ForceFlush(context.Context) error {
+	return nil
+}
+
+func (noopMeterExporter) Shutdown(context.Context) error {
+	return nil
+}

--- a/sdkx/inference/anthropic/anthropic_test.go
+++ b/sdkx/inference/anthropic/anthropic_test.go
@@ -413,6 +413,7 @@ func TestClassifyError(t *testing.T) {
 
 func TestRateLimitCarriesRetryAfter(t *testing.T) {
 	server, _ := newCapturedAnthropic(t, func(w http.ResponseWriter, _ *http.Request, _ map[string]any) {
+		w.Header().Set("request-id", "req-anthropic")
 		w.Header().Set("Retry-After", "2")
 		w.WriteHeader(http.StatusTooManyRequests)
 		_, _ = fmt.Fprint(w, `{"type":"error","error":{"type":"rate_limit_error","message":"slow down"}}`)
@@ -441,6 +442,9 @@ func TestRateLimitCarriesRetryAfter(t *testing.T) {
 	}
 	if got := errdefs.RetryCount(err); got < 1 {
 		t.Fatalf("RetryCount = %d, want at least 1 wire attempt", got)
+	}
+	if got, ok := errdefs.RequestID(err); !ok || got != "req-anthropic" {
+		t.Fatalf("RequestID = %q/%v, want req-anthropic/true", got, ok)
 	}
 }
 
@@ -609,6 +613,9 @@ func TestGenerateUnaryThinkingBlocks(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Generate: %v", err)
 	}
+	if response.Metadata.ResponseID != "msg_1" {
+		t.Fatalf("response id = %q, want msg_1", response.Metadata.ResponseID)
+	}
 	parts := response.Message.Content.Parts
 	if len(parts) != 3 {
 		t.Fatalf("parts = %+v", parts)
@@ -705,6 +712,9 @@ func TestGenerateStreamThinkingBlocks(t *testing.T) {
 	response, err := generateStream.Result()
 	if err != nil {
 		t.Fatalf("Result: %v", err)
+	}
+	if response.Metadata.ResponseID != "msg_1" {
+		t.Fatalf("stream response id = %q, want msg_1", response.Metadata.ResponseID)
 	}
 	parts := response.Message.Content.Parts
 	if len(parts) != 3 {

--- a/sdkx/inference/anthropic/errors.go
+++ b/sdkx/inference/anthropic/errors.go
@@ -23,6 +23,7 @@ func classifyError(err error) error {
 	var apiErr *anthropic.Error
 	if errors.As(err, &apiErr) {
 		classified := classifyHTTPStatus(apiErr.StatusCode, err)
+		classified = errdefs.WithRequestID(classified, apiErr.RequestID)
 		if apiErr.Response != nil {
 			classified = errdefs.WithRetryAfter(
 				classified,

--- a/sdkx/inference/anthropic/generate.go
+++ b/sdkx/inference/anthropic/generate.go
@@ -136,13 +136,14 @@ type rawUsage struct {
 // canonical part indices (it is the stateful stage) so the decoder function
 // stays pure and concurrency-safe.
 type streamRaw struct {
-	kind      streamRawKind
-	part      int    // canonical part index (text / tool / reasoning kinds)
-	text      string // text / thinking delta
-	signature string // terminal reasoning signature (redacted data included)
-	tool      streamRawTool
-	usage     *rawUsage
-	finish    inference.FinishReason
+	kind       streamRawKind
+	part       int    // canonical part index (text / tool / reasoning kinds)
+	text       string // text / thinking delta
+	signature  string // terminal reasoning signature (redacted data included)
+	responseID string // message id captured at message_start
+	tool       streamRawTool
+	usage      *rawUsage
+	finish     inference.FinishReason
 }
 
 type streamRawKind int

--- a/sdkx/inference/anthropic/generate_anthropic.go
+++ b/sdkx/inference/anthropic/generate_anthropic.go
@@ -288,6 +288,7 @@ func decodeGenerate(
 		},
 		FinishReason: raw.finish,
 		Usage:        rawUsageCanonical(raw.usage),
+		Metadata:     inference.Metadata{ResponseID: raw.id},
 	}, nil
 }
 

--- a/sdkx/inference/anthropic/generate_stream.go
+++ b/sdkx/inference/anthropic/generate_stream.go
@@ -24,6 +24,7 @@ type messagesStream struct {
 	finished bool
 	sawTools bool
 	usage    rawUsage // accumulates message_start input + message_delta output
+	id       string   // message id from message_start
 }
 
 type streamPart struct {
@@ -87,6 +88,7 @@ func (s *messagesStream) apply(
 ) (streamRaw, bool, error) {
 	switch event.Type {
 	case "message_start":
+		s.id = event.Message.ID
 		s.usage.inputTokens = event.Message.Usage.InputTokens
 		s.usage.cacheReadTokens = event.Message.Usage.CacheReadInputTokens
 		s.usage.cacheWriteTokens = event.Message.Usage.CacheCreationInputTokens
@@ -227,9 +229,10 @@ func (s *messagesStream) finishEvent(
 	s.finished = true
 	usage := s.usage
 	return streamRaw{
-		kind:   streamRawFinish,
-		usage:  &usage,
-		finish: finish,
+		kind:       streamRawFinish,
+		usage:      &usage,
+		finish:     finish,
+		responseID: s.id,
 	}, true, nil
 }
 
@@ -263,7 +266,10 @@ func decodeGenerateStream(
 			},
 		}, nil
 	case streamRawFinish:
-		event := inference.GenerateStreamEvent{FinishReason: raw.finish}
+		event := inference.GenerateStreamEvent{
+			FinishReason: raw.finish,
+			ResponseID:   raw.responseID,
+		}
 		if raw.usage != nil {
 			usage := rawUsageCanonical(*raw.usage)
 			event.Usage = &usage

--- a/sdkx/inference/bytedance/errors.go
+++ b/sdkx/inference/bytedance/errors.go
@@ -22,10 +22,18 @@ func classifyError(err error) error {
 		return classified
 	}
 	if apiErr, ok := errors.AsType[*arkmodel.APIError](err); ok {
-		return classifyHTTPStatus(apiErr.HTTPStatusCode, apiErr.Code, apiErr.Message, err)
+		return errdefs.WithRequestID(
+			classifyHTTPStatus(
+				apiErr.HTTPStatusCode, apiErr.Code, apiErr.Message, err,
+			),
+			apiErr.RequestId,
+		)
 	}
 	if reqErr, ok := errors.AsType[*arkmodel.RequestError](err); ok {
-		return classifyHTTPStatus(reqErr.HTTPStatusCode, "", "", reqErr.Err)
+		return errdefs.WithRequestID(
+			classifyHTTPStatus(reqErr.HTTPStatusCode, "", "", reqErr.Err),
+			reqErr.RequestId,
+		)
 	}
 	if speechErr, ok := errors.AsType[*doubaospeech.Error](err); ok {
 		return classifySpeechError(speechErr, err)
@@ -55,19 +63,22 @@ func classifyHTTPStatus(status int, code, message string, err error) error {
 }
 
 func classifySpeechError(speechErr *doubaospeech.Error, err error) error {
+	var classified error
 	switch {
 	case speechErr.IsAuthError():
 		if speechErr.HTTPStatus == http.StatusForbidden {
-			return errdefs.Forbidden(fmt.Errorf("bytedance: %w", err))
+			classified = errdefs.Forbidden(fmt.Errorf("bytedance: %w", err))
+		} else {
+			classified = errdefs.Unauthorized(fmt.Errorf("bytedance: %w", err))
 		}
-		return errdefs.Unauthorized(fmt.Errorf("bytedance: %w", err))
 	case speechErr.IsRateLimit(), speechErr.IsQuotaExceeded():
-		return errdefs.RateLimit(fmt.Errorf("bytedance: %w", err))
+		classified = errdefs.RateLimit(fmt.Errorf("bytedance: %w", err))
 	case speechErr.IsInvalidParam():
-		return errdefs.Validation(fmt.Errorf("bytedance: %w", err))
+		classified = errdefs.Validation(fmt.Errorf("bytedance: %w", err))
 	case speechErr.IsServerError():
-		return errdefs.NotAvailable(fmt.Errorf("bytedance: %w", err))
+		classified = errdefs.NotAvailable(fmt.Errorf("bytedance: %w", err))
 	default:
-		return errdefs.NotAvailable(fmt.Errorf("bytedance: %w", err))
+		classified = errdefs.NotAvailable(fmt.Errorf("bytedance: %w", err))
 	}
+	return errdefs.WithRequestID(classified, speechErr.ReqID)
 }

--- a/sdkx/inference/bytedance/generate.go
+++ b/sdkx/inference/bytedance/generate.go
@@ -152,13 +152,14 @@ type rawUsage struct {
 // canonical part indices (it is the stateful stage) so the decoder function
 // stays pure and concurrency-safe.
 type streamRaw struct {
-	kind   streamRawKind
-	part   int    // canonical part index (text / tool / reasoning kinds)
-	text   string // text / summary delta
-	id     string // terminal reasoning item id
-	tool   streamRawTool
-	usage  *rawUsage
-	finish inference.FinishReason
+	kind       streamRawKind
+	part       int    // canonical part index (text / tool / reasoning kinds)
+	text       string // text / summary delta
+	id         string // terminal reasoning item id
+	responseID string // response id from the terminal event
+	tool       streamRawTool
+	usage      *rawUsage
+	finish     inference.FinishReason
 }
 
 type streamRawKind int

--- a/sdkx/inference/bytedance/generate_ark.go
+++ b/sdkx/inference/bytedance/generate_ark.go
@@ -468,6 +468,7 @@ func decodeGenerate(
 		},
 		FinishReason: raw.finish,
 		Usage:        rawUsageCanonical(raw.usage),
+		Metadata:     inference.Metadata{ResponseID: raw.id},
 	}
 	return response, nil
 }

--- a/sdkx/inference/bytedance/generate_more_test.go
+++ b/sdkx/inference/bytedance/generate_more_test.go
@@ -169,6 +169,9 @@ func TestGenerateStreamCapturedWire(t *testing.T) {
 	if result.FinishReason != inference.FinishToolCalls {
 		t.Fatalf("result finish = %q", result.FinishReason)
 	}
+	if result.Metadata.ResponseID != "resp_1" {
+		t.Fatalf("stream response id = %q, want resp_1", result.Metadata.ResponseID)
+	}
 	parts := result.Message.Content.Parts
 	text, ok := parts[0].(message.TextPart)
 	if !ok || text.Text != "hello" {
@@ -190,6 +193,7 @@ func TestGenerateStreamCapturedWire(t *testing.T) {
 func TestGenerateErrorClassification(t *testing.T) {
 	server, _ := newCapturedArk(t, func(w http.ResponseWriter, _ map[string]any, _ bool) {
 		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("X-Client-Request-Id", "r1")
 		w.WriteHeader(http.StatusTooManyRequests)
 		_, _ = fmt.Fprint(w, `{"error":{"code":"rate_limit","message":"slow down","type":"rate_limit","request_id":"r1"}}`)
 	})
@@ -208,6 +212,9 @@ func TestGenerateErrorClassification(t *testing.T) {
 	}
 	if !errdefs.HasClassification(errdefs.FromContext(err)) {
 		t.Fatalf("classification lost: %v", err)
+	}
+	if got, ok := errdefs.RequestID(err); !ok || got != "r1" {
+		t.Fatalf("RequestID = %q/%v, want r1/true", got, ok)
 	}
 }
 

--- a/sdkx/inference/bytedance/generate_stream.go
+++ b/sdkx/inference/bytedance/generate_stream.go
@@ -283,9 +283,10 @@ func (s *responsesStream) finishEvent(
 	s.finished = true
 	usage := arkUsage(response.GetUsage())
 	return streamRaw{
-		kind:   streamRawFinish,
-		usage:  &usage,
-		finish: finish,
+		kind:       streamRawFinish,
+		usage:      &usage,
+		finish:     finish,
+		responseID: response.GetId(),
 	}, nil
 }
 
@@ -329,7 +330,10 @@ func decodeGenerateStream(
 			},
 		}, nil
 	case streamRawFinish:
-		event := inference.GenerateStreamEvent{FinishReason: raw.finish}
+		event := inference.GenerateStreamEvent{
+			FinishReason: raw.finish,
+			ResponseID:   raw.responseID,
+		}
 		if raw.usage != nil {
 			usage := rawUsageCanonical(*raw.usage)
 			event.Usage = &usage

--- a/sdkx/inference/bytedance/generate_test.go
+++ b/sdkx/inference/bytedance/generate_test.go
@@ -198,6 +198,9 @@ func TestGenerateUnaryCapturedWire(t *testing.T) {
 	if response.FinishReason != inference.FinishCompleted {
 		t.Fatalf("finish = %q", response.FinishReason)
 	}
+	if response.Metadata.ResponseID != "resp_1" {
+		t.Fatalf("response id = %q, want resp_1", response.Metadata.ResponseID)
+	}
 	if response.Usage.TotalTokens != 19 {
 		t.Fatalf("usage = %+v", response.Usage)
 	}

--- a/sdkx/inference/bytedance/tts.go
+++ b/sdkx/inference/bytedance/tts.go
@@ -43,17 +43,19 @@ type ttsWire struct {
 }
 
 type ttsRaw struct {
-	data   []byte
-	format media.AudioFormat
+	data      []byte
+	format    media.AudioFormat
+	requestID string
 }
 
 // ttsStreamRaw carries the negotiated format with every delta: the format is
 // fixed at compile time, flows compile → transport → raw, and never passes
 // through the stateless decoder's construction site.
 type ttsStreamRaw struct {
-	data   []byte
-	format *media.AudioFormat
-	last   bool
+	data      []byte
+	format    *media.AudioFormat
+	requestID string
+	last      bool
 }
 
 func compileTTS(
@@ -273,6 +275,9 @@ func transportTTS(
 				return ttsRaw{}, failure
 			}
 			raw.data = append(raw.data, chunk.Audio...)
+			if chunk.ReqID != "" {
+				raw.requestID = chunk.ReqID
+			}
 		}
 		if len(raw.data) == 0 {
 			return ttsRaw{}, fmt.Errorf("bytedance: synthesis produced no audio")
@@ -364,6 +369,7 @@ func decodeTTS(
 			}},
 		},
 		FinishReason: inference.FinishCompleted,
+		Metadata:     inference.Metadata{RequestID: raw.requestID},
 	}, nil
 }
 
@@ -375,9 +381,10 @@ func decodeTTS(
 // audio deltas, one finish event, then EOF — the runtime requires exactly
 // that terminal sequence.
 type ttsStream struct {
-	pull   func() (*doubaospeech.TTSV2Chunk, error, bool)
-	stop   func()
-	format media.AudioFormat
+	pull      func() (*doubaospeech.TTSV2Chunk, error, bool)
+	stop      func()
+	format    media.AudioFormat
+	requestID string
 
 	emitFinish bool // final audio chunk delivered; finish event pending
 	done       bool // finish delivered; next Next returns EOF
@@ -407,7 +414,7 @@ func (s *ttsStream) Next(ctx context.Context) (ttsStreamRaw, error) {
 		if s.emitFinish {
 			s.emitFinish = false
 			s.done = true
-			return ttsStreamRaw{last: true}, nil
+			return ttsStreamRaw{last: true, requestID: s.requestID}, nil
 		}
 		chunk, err, ok := s.pull()
 		if err != nil {
@@ -426,6 +433,9 @@ func (s *ttsStream) Next(ctx context.Context) (ttsStreamRaw, error) {
 		}
 		if chunk.IsLast {
 			s.emitFinish = true
+		}
+		if chunk.ReqID != "" {
+			s.requestID = chunk.ReqID
 		}
 		if len(chunk.Audio) == 0 {
 			continue // progress-only line, or a silent final chunk
@@ -450,6 +460,7 @@ func decodeTTSStream(
 	if raw.last {
 		return inference.GenerateStreamEvent{
 			FinishReason: inference.FinishCompleted,
+			RequestID:    raw.requestID,
 		}, nil
 	}
 	if len(raw.data) == 0 || raw.format == nil {

--- a/sdkx/inference/bytedance/tts_test.go
+++ b/sdkx/inference/bytedance/tts_test.go
@@ -221,6 +221,9 @@ func TestTTSStreamDeltas(t *testing.T) {
 	if string(part.Source.Bytes()) != "chunk-1chunk-2" {
 		t.Fatalf("audio = %q", part.Source.Bytes())
 	}
+	if result.Metadata.RequestID != "req-1" {
+		t.Fatalf("request id = %q, want req-1", result.Metadata.RequestID)
+	}
 }
 
 func TestTTSRejections(t *testing.T) {

--- a/sdkx/inference/deepseek/errors.go
+++ b/sdkx/inference/deepseek/errors.go
@@ -23,6 +23,10 @@ func classifyError(err error) error {
 	if apiErr, ok := errors.AsType[*openaigo.Error](err); ok {
 		classified := classifyHTTPStatus(apiErr.StatusCode, err)
 		if apiErr.Response != nil {
+			classified = errdefs.WithRequestID(
+				classified,
+				apiErr.Response.Header.Get("x-request-id"),
+			)
 			classified = errdefs.WithRetryAfter(
 				classified,
 				errdefs.ParseRetryAfter(apiErr.Response.Header.Get("Retry-After")),

--- a/sdkx/inference/deepseek/generate.go
+++ b/sdkx/inference/deepseek/generate.go
@@ -62,6 +62,7 @@ type wireToolChoice struct {
 // generateRaw is the transport stage's normalized completion: everything
 // the decoder needs, nothing it does not.
 type generateRaw struct {
+	id        string // chat completion id from the wire response
 	reasoning string
 	text      string
 	toolCalls []rawToolCall
@@ -96,12 +97,13 @@ const (
 )
 
 type streamRaw struct {
-	kind   streamRawKind
-	part   int // canonical part index, assigned by the transport
-	text   string
-	tool   streamRawTool
-	usage  *rawUsage
-	finish inference.FinishReason
+	kind       streamRawKind
+	part       int // canonical part index, assigned by the transport
+	text       string
+	responseID string // chat completion id from the stream chunks
+	tool       streamRawTool
+	usage      *rawUsage
+	finish     inference.FinishReason
 }
 
 type streamRawTool struct {

--- a/sdkx/inference/deepseek/generate_chat.go
+++ b/sdkx/inference/deepseek/generate_chat.go
@@ -145,6 +145,7 @@ func completionToRaw(response *openaigo.ChatCompletion) (generateRaw, error) {
 	}
 
 	raw := generateRaw{
+		id:        response.ID,
 		reasoning: reasoningContentOf(choice.Message.JSON.ExtraFields),
 		text:      choice.Message.Content,
 		finish:    finish,
@@ -245,6 +246,7 @@ func decodeGenerate(_ context.Context, raw generateRaw) (inference.GenerateRespo
 			Content: message.Content{Parts: parts},
 		},
 		FinishReason: raw.finish,
+		Metadata:     inference.Metadata{ResponseID: raw.id},
 	}
 	if raw.usage.present {
 		response.Usage = rawUsageCanonical(raw.usage)

--- a/sdkx/inference/deepseek/generate_more_test.go
+++ b/sdkx/inference/deepseek/generate_more_test.go
@@ -93,6 +93,9 @@ func TestGenerateUnaryReasoning(t *testing.T) {
 	if response.Usage.Output.ReasoningAccounting != inference.ReasoningIncludedInOutput {
 		t.Fatalf("accounting = %q", response.Usage.Output.ReasoningAccounting)
 	}
+	if response.Metadata.ResponseID != "chatcmpl_1" {
+		t.Fatalf("response id = %q, want chatcmpl_1", response.Metadata.ResponseID)
+	}
 }
 
 func TestGenerateStreamReasoningThenText(t *testing.T) {
@@ -155,6 +158,16 @@ func TestGenerateStreamReasoningThenText(t *testing.T) {
 	}
 	if finish.Usage == nil || finish.Usage.TotalTokens != 19 {
 		t.Fatalf("usage = %+v", finish.Usage)
+	}
+	if finish.ResponseID != "chatcmpl_1" {
+		t.Fatalf("stream response id = %q, want chatcmpl_1", finish.ResponseID)
+	}
+	result, err := stream.Result()
+	if err != nil {
+		t.Fatalf("Result: %v", err)
+	}
+	if result.Metadata.ResponseID != "chatcmpl_1" {
+		t.Fatalf("result response id = %q, want chatcmpl_1", result.Metadata.ResponseID)
 	}
 }
 

--- a/sdkx/inference/deepseek/generate_stream.go
+++ b/sdkx/inference/deepseek/generate_stream.go
@@ -32,6 +32,7 @@ type chatStream struct {
 	usage     *rawUsage
 	sawTools  bool
 	ended     bool
+	id        string // chat completion id from the stream chunks
 }
 
 // transportGenerateStream opens the streaming request and returns the
@@ -93,6 +94,9 @@ func (s *chatStream) Next(ctx context.Context) (streamRaw, error) {
 // usage are recorded, not emitted: the finish event ships at stream end so
 // it carries both.
 func (s *chatStream) apply(chunk openaigo.ChatCompletionChunk) {
+	if chunk.ID != "" {
+		s.id = chunk.ID
+	}
 	if chunk.Usage.JSON.PromptTokens.Valid() || chunk.Usage.JSON.CompletionTokens.Valid() {
 		usage := usageToRaw(chunk.Usage)
 		s.usage = &usage
@@ -152,7 +156,12 @@ func (s *chatStream) end() {
 	if finish == "" {
 		finish = inference.FinishCompleted
 	}
-	s.pending = append(s.pending, streamRaw{kind: streamRawFinish, finish: finish, usage: s.usage})
+	s.pending = append(s.pending, streamRaw{
+		kind:       streamRawFinish,
+		finish:     finish,
+		usage:      s.usage,
+		responseID: s.id,
+	})
 }
 
 func (s *chatStream) assignPart() int {
@@ -199,7 +208,10 @@ func decodeGenerateStream(_ context.Context, raw streamRaw) (inference.GenerateS
 			},
 		}, nil
 	case streamRawFinish:
-		event := inference.GenerateStreamEvent{FinishReason: raw.finish}
+		event := inference.GenerateStreamEvent{
+			FinishReason: raw.finish,
+			ResponseID:   raw.responseID,
+		}
 		if raw.usage != nil {
 			usage := rawUsageCanonical(*raw.usage)
 			event.Usage = &usage

--- a/sdkx/inference/deepseek/generate_test.go
+++ b/sdkx/inference/deepseek/generate_test.go
@@ -79,6 +79,7 @@ func (s *chatServer) clients(t *testing.T) *clients {
 
 func TestRateLimitCarriesRetryAfter(t *testing.T) {
 	server := newChatServer(t, func(w http.ResponseWriter, _ map[string]any) {
+		w.Header().Set("x-request-id", "req-deepseek")
 		w.Header().Set("Retry-After", "2")
 		w.WriteHeader(http.StatusTooManyRequests)
 		_, _ = fmt.Fprint(w, `{"error":{"message":"slow down","type":"rate_limit_error","code":"x"}}`)
@@ -105,6 +106,9 @@ func TestRateLimitCarriesRetryAfter(t *testing.T) {
 	}
 	if got := errdefs.RetryCount(err); got < 1 {
 		t.Fatalf("RetryCount = %d, want at least 1 wire attempt", got)
+	}
+	if got, ok := errdefs.RequestID(err); !ok || got != "req-deepseek" {
+		t.Fatalf("RequestID = %q/%v, want req-deepseek/true", got, ok)
 	}
 }
 

--- a/sdkx/inference/kimi/errors.go
+++ b/sdkx/inference/kimi/errors.go
@@ -22,6 +22,8 @@ type errorEnvelope struct {
 		Type    string `json:"type"`
 		Code    string `json:"code"`
 	} `json:"error"`
+	// RequestID is the request identifier some Kimi failure bodies carry.
+	RequestID string `json:"request_id"`
 }
 
 // classifyError normalizes transport-level errors into the errdefs
@@ -72,31 +74,32 @@ func classifyHTTPError(ctx context.Context, status int, body []byte) error {
 	}
 	detail := fmt.Errorf("kimi: HTTP %d: %s", status, message)
 
+	var classified error
 	switch status {
 	case http.StatusBadRequest:
 		// Kimi marks request-shape failures invalid_request_error; a
 		// missing model surfaces as a 400 naming the model.
 		if strings.Contains(kind, "invalid") || kind == "" {
-			return errdefs.Validation(detail)
+			classified = errdefs.Validation(detail)
+		} else {
+			classified = classifyKind(kind, detail)
 		}
-		return classifyKind(kind, detail)
 	case http.StatusUnauthorized:
-		return errdefs.Unauthorized(detail)
+		classified = errdefs.Unauthorized(detail)
 	case http.StatusForbidden:
-		return errdefs.Forbidden(detail)
+		classified = errdefs.Forbidden(detail)
 	case http.StatusNotFound:
-		return errdefs.Validation(detail)
+		classified = errdefs.Validation(detail)
 	case http.StatusTooManyRequests:
-		return errdefs.RateLimit(detail)
+		classified = errdefs.RateLimit(detail)
 	case http.StatusRequestTimeout, http.StatusGatewayTimeout:
-		return errdefs.Timeout(detail)
+		classified = errdefs.Timeout(detail)
 	case http.StatusConflict:
-		return errdefs.Conflict(detail)
+		classified = errdefs.Conflict(detail)
+	default:
+		classified = errdefs.NotAvailable(detail)
 	}
-	if status >= 500 {
-		return errdefs.NotAvailable(detail)
-	}
-	return errdefs.NotAvailable(detail)
+	return errdefs.WithRequestID(classified, envelope.RequestID)
 }
 
 // classifyKind maps Kimi's error.type vocabulary when the status alone

--- a/sdkx/inference/kimi/generate_chat.go
+++ b/sdkx/inference/kimi/generate_chat.go
@@ -12,6 +12,7 @@ import (
 // generateRaw is the transport stage's normalized completion: everything
 // the decoder needs, nothing it does not.
 type generateRaw struct {
+	id        string // chat completion id from the wire response
 	reasoning string
 	text      string
 	toolCalls []rawToolCall
@@ -105,6 +106,7 @@ func completionToRaw(envelope *completionEnvelope) (generateRaw, error) {
 	}
 
 	raw := generateRaw{
+		id:        envelope.ID,
 		reasoning: choice.Message.ReasoningContent,
 		text:      choice.Message.Content,
 		finish:    finish,
@@ -165,6 +167,7 @@ func decodeGenerate(_ context.Context, raw generateRaw) (inference.GenerateRespo
 			Content: message.Content{Parts: parts},
 		},
 		FinishReason: raw.finish,
+		Metadata:     inference.Metadata{ResponseID: raw.id},
 	}
 	if raw.usage.present {
 		response.Usage = rawUsageCanonical(raw.usage)

--- a/sdkx/inference/kimi/generate_stream.go
+++ b/sdkx/inference/kimi/generate_stream.go
@@ -14,6 +14,7 @@ import (
 // reason, and (on the final chunk, since the driver always requests
 // stream_options.include_usage) the usage object.
 type chunkEnvelope struct {
+	ID      string `json:"id"`
 	Choices []struct {
 		Index int `json:"index"`
 		Delta struct {
@@ -47,12 +48,13 @@ const (
 )
 
 type streamRaw struct {
-	kind   streamRawKind
-	part   int // canonical part index, assigned by the transport
-	text   string
-	tool   streamRawTool
-	usage  *rawUsage
-	finish inference.FinishReason
+	kind       streamRawKind
+	part       int // canonical part index, assigned by the transport
+	text       string
+	responseID string // chat completion id from the stream chunks
+	tool       streamRawTool
+	usage      *rawUsage
+	finish     inference.FinishReason
 }
 
 type streamRawTool struct {
@@ -81,6 +83,7 @@ type chatStream struct {
 	usage    *rawUsage
 	sawTools bool
 	ended    bool
+	id       string // chat completion id from the stream chunks
 }
 
 // transportGenerateStream opens the streaming request and returns the
@@ -158,6 +161,9 @@ func (s *chatStream) apply(data []byte) error {
 	if err := json.Unmarshal(data, &chunk); err != nil {
 		return errdefs.NotAvailablef("kimi: decode stream chunk: %v", err)
 	}
+	if chunk.ID != "" {
+		s.id = chunk.ID
+	}
 	if chunk.Usage != nil {
 		usage := chunk.Usage.toRaw()
 		s.usage = &usage
@@ -212,7 +218,12 @@ func (s *chatStream) end() {
 	if finish == "" {
 		finish = inference.FinishCompleted
 	}
-	s.pending = append(s.pending, streamRaw{kind: streamRawFinish, finish: finish, usage: s.usage})
+	s.pending = append(s.pending, streamRaw{
+		kind:       streamRawFinish,
+		finish:     finish,
+		usage:      s.usage,
+		responseID: s.id,
+	})
 }
 
 func (s *chatStream) assignPart() int {
@@ -259,7 +270,10 @@ func decodeGenerateStream(_ context.Context, raw streamRaw) (inference.GenerateS
 			},
 		}, nil
 	case streamRawFinish:
-		event := inference.GenerateStreamEvent{FinishReason: raw.finish}
+		event := inference.GenerateStreamEvent{
+			FinishReason: raw.finish,
+			ResponseID:   raw.responseID,
+		}
 		if raw.usage != nil {
 			usage := rawUsageCanonical(*raw.usage)
 			event.Usage = &usage

--- a/sdkx/inference/kimi/generate_test.go
+++ b/sdkx/inference/kimi/generate_test.go
@@ -59,6 +59,9 @@ func TestUnaryTextOnWire(t *testing.T) {
 	if response.Usage.Input.CacheReadTokens == nil || *response.Usage.Input.CacheReadTokens != 10 {
 		t.Fatalf("cached tokens = %+v", response.Usage.Input.CacheReadTokens)
 	}
+	if response.Metadata.ResponseID != "cmpl-1" {
+		t.Fatalf("response id = %q, want cmpl-1", response.Metadata.ResponseID)
+	}
 }
 
 func TestMultimodalContentParts(t *testing.T) {
@@ -627,6 +630,7 @@ func TestStreamTextAndUsage(t *testing.T) {
 	var text string
 	var usage *inference.Usage
 	var finish inference.FinishReason
+	var responseID string
 	for {
 		event, err := stream.Next(context.Background())
 		if err == io.EOF {
@@ -644,6 +648,7 @@ func TestStreamTextAndUsage(t *testing.T) {
 		}
 		if event.FinishReason != "" {
 			finish = event.FinishReason
+			responseID = event.ResponseID
 		}
 	}
 	if text != "你好" || finish != inference.FinishCompleted {
@@ -651,6 +656,16 @@ func TestStreamTextAndUsage(t *testing.T) {
 	}
 	if usage == nil || usage.InputTokens != 19 || usage.OutputTokens != 13 {
 		t.Fatalf("usage = %+v", usage)
+	}
+	if responseID != "cmpl-1" {
+		t.Fatalf("stream response id = %q, want cmpl-1", responseID)
+	}
+	result, err := stream.Result()
+	if err != nil {
+		t.Fatalf("Result: %v", err)
+	}
+	if result.Metadata.ResponseID != "cmpl-1" {
+		t.Fatalf("result response id = %q, want cmpl-1", result.Metadata.ResponseID)
 	}
 }
 
@@ -727,12 +742,13 @@ func TestStreamReasoningAndToolCalls(t *testing.T) {
 
 func TestErrorClassification(t *testing.T) {
 	cases := []struct {
-		name   string
-		status int
-		body   string
-		check  func(error) bool
+		name      string
+		status    int
+		body      string
+		check     func(error) bool
+		requestID string
 	}{
-		{name: "rate limit", status: 429, body: `{"error":{"type":"rate_limit_error","message":"slow down"}}`, check: errdefs.IsRateLimit},
+		{name: "rate limit", status: 429, body: `{"error":{"type":"rate_limit_error","message":"slow down"},"request_id":"kr-1"}`, check: errdefs.IsRateLimit, requestID: "kr-1"},
 		{name: "bad key", status: 401, body: `{"error":{"type":"authentication_error","message":"bad key"}}`, check: errdefs.IsUnauthorized},
 		{name: "invalid request", status: 400, body: `{"error":{"type":"invalid_request_error","message":"bad model"}}`, check: errdefs.IsValidation},
 		{name: "server error", status: 500, body: `{"error":{"type":"server_error","message":"boom"}}`, check: errdefs.IsNotAvailable},
@@ -747,6 +763,11 @@ func TestErrorClassification(t *testing.T) {
 			_, err := runtime.Generate(context.Background(), kimiModel("moonshot-v1-8k"), simpleTextRequest("hi"))
 			if !tc.check(err) {
 				t.Fatalf("error = %v", err)
+			}
+			if tc.requestID != "" {
+				if got, ok := errdefs.RequestID(err); !ok || got != tc.requestID {
+					t.Fatalf("RequestID = %q/%v, want %q/true", got, ok, tc.requestID)
+				}
 			}
 		})
 	}

--- a/sdkx/inference/minimax/image.go
+++ b/sdkx/inference/minimax/image.go
@@ -34,6 +34,7 @@ type imageRaw struct {
 	urls      []string
 	b64       []string
 	mediaType string
+	requestID string
 }
 
 // imageAspectRatios are the ratios image_generation accepts.
@@ -228,6 +229,9 @@ type imageResponse struct {
 		URLs []string `json:"image_urls"`
 		B64  []string `json:"image_base64"`
 	} `json:"data"`
+	// ID is the trace id for request tracking on the image_generation
+	// endpoint.
+	ID       string   `json:"id"`
 	BaseResp baseResp `json:"base_resp"`
 }
 
@@ -246,6 +250,7 @@ func transportImage(
 			urls:      resp.Data.URLs,
 			b64:       resp.Data.B64,
 			mediaType: media.ImageFormatJPEG.MediaType(),
+			requestID: resp.ID,
 		}, nil
 	}
 }
@@ -290,6 +295,7 @@ func decodeImage(
 		Usage: inference.Usage{
 			GeneratedImages: &generated,
 		},
+		Metadata: inference.Metadata{RequestID: raw.requestID},
 	}, nil
 }
 

--- a/sdkx/inference/minimax/image_test.go
+++ b/sdkx/inference/minimax/image_test.go
@@ -39,6 +39,7 @@ func imageGenerateRequest(intent inference.ImageIntent) inference.GenerateReques
 func imageEnvelope(data map[string]any) string {
 	payload, _ := json.Marshal(map[string]any{
 		"data":      data,
+		"id":        "img-1",
 		"base_resp": map[string]any{"status_code": 0, "status_msg": "success"},
 	})
 	return string(payload)
@@ -75,6 +76,9 @@ func TestImageUnaryCapturedWire(t *testing.T) {
 	}
 	if response.FinishReason != inference.FinishCompleted {
 		t.Fatalf("finish = %q", response.FinishReason)
+	}
+	if response.Metadata.RequestID != "img-1" {
+		t.Fatalf("request id = %q, want img-1", response.Metadata.RequestID)
 	}
 	if len(response.Message.Content.Parts) != 2 {
 		t.Fatalf("parts = %d", len(response.Message.Content.Parts))
@@ -155,6 +159,9 @@ func TestImageInlineDelivery(t *testing.T) {
 	)
 	if err != nil {
 		t.Fatalf("Generate: %v", err)
+	}
+	if response.Metadata.RequestID != "img-1" {
+		t.Fatalf("request id = %q, want img-1", response.Metadata.RequestID)
 	}
 	if len(response.Message.Content.Parts) != 1 {
 		t.Fatalf("parts = %d", len(response.Message.Content.Parts))

--- a/sdkx/inference/minimax/media.go
+++ b/sdkx/inference/minimax/media.go
@@ -76,12 +76,20 @@ func (c *mediaClient) request(
 	if resp.StatusCode != http.StatusOK {
 		defer func() { _ = resp.Body.Close() }()
 		snippet, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+		var errorBody struct {
+			RequestID string `json:"request_id"`
+		}
+		_ = json.Unmarshal(snippet, &errorBody)
+		classified := classifyHTTPStatus(resp.StatusCode, fmt.Errorf(
+			"minimax: %s %s: HTTP %d: %s",
+			method, path, resp.StatusCode, strings.TrimSpace(string(snippet)),
+		))
+		if errorBody.RequestID != "" {
+			classified = errdefs.WithRequestID(classified, errorBody.RequestID)
+		}
 		return nil, errdefs.WithRetryCount(
 			errdefs.WithRetryAfter(
-				classifyHTTPStatus(resp.StatusCode, fmt.Errorf(
-					"minimax: %s %s: HTTP %d: %s",
-					method, path, resp.StatusCode, strings.TrimSpace(string(snippet)),
-				)),
+				classified,
 				errdefs.ParseRetryAfter(resp.Header.Get("Retry-After")),
 			),
 			httpkit.RetryCountOf(resp),
@@ -188,6 +196,9 @@ type hexAudioStreamEvent struct {
 		Audio  string `json:"audio"`
 		Status int    `json:"status"`
 	} `json:"data"`
+	// TraceID is the server-assigned session id; every SSE chunk carries
+	// the trace for the same request.
+	TraceID  string   `json:"trace_id"`
 	BaseResp baseResp `json:"base_resp"`
 }
 
@@ -195,16 +206,18 @@ type hexAudioStreamEvent struct {
 // format is fixed at compile time, flows compile → transport → raw, and
 // never passes through the stateless decoder's construction site.
 type hexAudioStreamRaw struct {
-	data   []byte
-	format *media.AudioFormat
-	last   bool
+	data      []byte
+	format    *media.AudioFormat
+	requestID string
+	last      bool
 }
 
 type hexAudioStream struct {
-	body   io.ReadCloser
-	events chan hexAudioStreamEvent
-	errs   chan error
-	format media.AudioFormat
+	body    io.ReadCloser
+	events  chan hexAudioStreamEvent
+	errs    chan error
+	format  media.AudioFormat
+	traceID string // last trace id seen; rides the synthetic finish
 
 	emitFinish bool // terminal chunk seen; finish event pending
 	done       bool // finish delivered; next Next returns EOF
@@ -246,7 +259,7 @@ func (s *hexAudioStream) Next(ctx context.Context) (hexAudioStreamRaw, error) {
 	if s.emitFinish {
 		s.emitFinish = false
 		s.done = true
-		return hexAudioStreamRaw{last: true}, nil
+		return hexAudioStreamRaw{last: true, requestID: s.traceID}, nil
 	}
 	if s.done {
 		return hexAudioStreamRaw{}, io.EOF
@@ -270,6 +283,9 @@ func (s *hexAudioStream) Next(ctx context.Context) (hexAudioStreamRaw, error) {
 		if failure := event.BaseResp.err("audio stream"); failure != nil {
 			return hexAudioStreamRaw{}, failure
 		}
+		if event.TraceID != "" {
+			s.traceID = event.TraceID
+		}
 		if event.Data.Status == 2 {
 			s.emitFinish = true
 		}
@@ -278,7 +294,7 @@ func (s *hexAudioStream) Next(ctx context.Context) (hexAudioStreamRaw, error) {
 				// Silent terminal chunk: finish immediately.
 				s.emitFinish = false
 				s.done = true
-				return hexAudioStreamRaw{last: true}, nil
+				return hexAudioStreamRaw{last: true, requestID: s.traceID}, nil
 			}
 			return s.Next(ctx) // progress-only event
 		}
@@ -287,7 +303,11 @@ func (s *hexAudioStream) Next(ctx context.Context) (hexAudioStreamRaw, error) {
 			return hexAudioStreamRaw{}, err
 		}
 		format := s.format
-		return hexAudioStreamRaw{data: data, format: &format}, nil
+		return hexAudioStreamRaw{
+			data:      data,
+			format:    &format,
+			requestID: s.traceID,
+		}, nil
 	}
 }
 
@@ -305,6 +325,7 @@ func decodeHexAudioStream(
 	if raw.last {
 		return inference.GenerateStreamEvent{
 			FinishReason: inference.FinishCompleted,
+			RequestID:    raw.requestID,
 		}, nil
 	}
 	if len(raw.data) == 0 || raw.format == nil {
@@ -314,6 +335,7 @@ func decodeHexAudioStream(
 	}
 	format := *raw.format
 	return inference.GenerateStreamEvent{
-		Delta: inference.AudioPartDelta{Data: raw.data, Format: &format},
+		Delta:     inference.AudioPartDelta{Data: raw.data, Format: &format},
+		RequestID: raw.requestID,
 	}, nil
 }

--- a/sdkx/inference/minimax/music.go
+++ b/sdkx/inference/minimax/music.go
@@ -37,8 +37,9 @@ type musicWire struct {
 }
 
 type musicRaw struct {
-	data   []byte
-	format media.AudioFormat
+	data      []byte
+	format    media.AudioFormat
+	requestID string
 }
 
 var musicSampleRates = map[int]bool{
@@ -256,6 +257,9 @@ type musicResponse struct {
 	Data struct {
 		Audio string `json:"audio"`
 	} `json:"data"`
+	// TraceID is the server-assigned request trace id; the docs' example
+	// places it at the envelope root alongside data and base_resp.
+	TraceID  string   `json:"trace_id"`
 	BaseResp baseResp `json:"base_resp"`
 }
 
@@ -274,7 +278,11 @@ func transportMusic(
 		if err != nil {
 			return musicRaw{}, err
 		}
-		return musicRaw{data: data, format: musicCanonicalFormat(wire)}, nil
+		return musicRaw{
+			data:      data,
+			format:    musicCanonicalFormat(wire),
+			requestID: resp.TraceID,
+		}, nil
 	}
 }
 
@@ -295,6 +303,7 @@ func decodeMusic(
 			}},
 		},
 		FinishReason: inference.FinishCompleted,
+		Metadata:     inference.Metadata{RequestID: raw.requestID},
 	}, nil
 }
 

--- a/sdkx/inference/minimax/music_test.go
+++ b/sdkx/inference/minimax/music_test.go
@@ -35,6 +35,7 @@ func musicOKServer(t *testing.T, audio []byte) *messagesServer {
 	return newMessagesServer(t, func(w http.ResponseWriter, body map[string]any) {
 		payload, _ := json.Marshal(map[string]any{
 			"data":      map[string]any{"audio": hex.EncodeToString(audio), "status": 2},
+			"trace_id":  "music-1",
 			"base_resp": map[string]any{"status_code": 0, "status_msg": "success"},
 		})
 		_, _ = w.Write(payload)
@@ -101,6 +102,9 @@ func TestMusicUnary(t *testing.T) {
 	}
 	if response.FinishReason != inference.FinishCompleted {
 		t.Fatalf("finish = %v", response.FinishReason)
+	}
+	if response.Metadata.RequestID != "music-1" {
+		t.Fatalf("request id = %q, want music-1", response.Metadata.RequestID)
 	}
 
 	sent := server.body(t, 0)
@@ -199,12 +203,14 @@ func TestMusicStream(t *testing.T) {
 		for _, chunk := range chunks {
 			payload, _ := json.Marshal(map[string]any{
 				"data":      map[string]any{"audio": chunk, "status": 1},
+				"trace_id":  "music-1",
 				"base_resp": map[string]any{"status_code": 0},
 			})
 			_, _ = w.Write([]byte("data: " + string(payload) + "\n\n"))
 		}
 		payload, _ := json.Marshal(map[string]any{
 			"data":      map[string]any{"audio": "", "status": 2},
+			"trace_id":  "music-1",
 			"base_resp": map[string]any{"status_code": 0},
 		})
 		_, _ = w.Write([]byte("data: " + string(payload) + "\n\n"))
@@ -238,6 +244,13 @@ func TestMusicStream(t *testing.T) {
 	}
 	if !finished {
 		t.Fatal("no finish event")
+	}
+	result, err := stream.Result()
+	if err != nil {
+		t.Fatalf("Result: %v", err)
+	}
+	if result.Metadata.RequestID != "music-1" {
+		t.Fatalf("stream request id = %q, want music-1", result.Metadata.RequestID)
 	}
 
 	sent := server.body(t, 0)

--- a/sdkx/inference/minimax/tts.go
+++ b/sdkx/inference/minimax/tts.go
@@ -29,8 +29,9 @@ type ttsWire struct {
 }
 
 type ttsRaw struct {
-	data   []byte
-	format media.AudioFormat
+	data      []byte
+	format    media.AudioFormat
+	requestID string
 }
 
 var ttsSampleRates = map[int]bool{
@@ -249,6 +250,9 @@ type ttsResponse struct {
 	Data struct {
 		Audio string `json:"audio"`
 	} `json:"data"`
+	// TraceID is the server-assigned session id the docs describe as
+	// "used for troubleshooting and support".
+	TraceID  string   `json:"trace_id"`
 	BaseResp baseResp `json:"base_resp"`
 }
 
@@ -267,7 +271,11 @@ func transportTTS(
 		if err != nil {
 			return ttsRaw{}, err
 		}
-		return ttsRaw{data: data, format: ttsCanonicalFormat(wire)}, nil
+		return ttsRaw{
+			data:      data,
+			format:    ttsCanonicalFormat(wire),
+			requestID: resp.TraceID,
+		}, nil
 	}
 }
 
@@ -288,6 +296,7 @@ func decodeTTS(
 			}},
 		},
 		FinishReason: inference.FinishCompleted,
+		Metadata:     inference.Metadata{RequestID: raw.requestID},
 	}, nil
 }
 

--- a/sdkx/inference/minimax/tts_test.go
+++ b/sdkx/inference/minimax/tts_test.go
@@ -45,6 +45,7 @@ func ttsGenerateRequest(format media.AudioFormat) inference.GenerateRequest {
 func ttsUnaryBody(audio string) string {
 	payload, _ := json.Marshal(map[string]any{
 		"data":      map[string]any{"audio": hex.EncodeToString([]byte(audio))},
+		"trace_id":  "tts-1",
 		"base_resp": map[string]any{"status_code": 0, "status_msg": "success"},
 	})
 	return string(payload)
@@ -69,6 +70,7 @@ func ttsStreamChunk(status int, audio string) map[string]any {
 			"audio":  hex.EncodeToString([]byte(audio)),
 			"status": status,
 		},
+		"trace_id":  "tts-1",
 		"base_resp": map[string]any{"status_code": 0, "status_msg": "success"},
 	}
 }
@@ -92,6 +94,9 @@ func TestTTSUnaryCapturedWire(t *testing.T) {
 	}
 	if response.FinishReason != inference.FinishCompleted {
 		t.Fatalf("finish = %q", response.FinishReason)
+	}
+	if response.Metadata.RequestID != "tts-1" {
+		t.Fatalf("request id = %q, want tts-1", response.Metadata.RequestID)
 	}
 	if len(response.Message.Content.Parts) != 1 {
 		t.Fatalf("parts = %d", len(response.Message.Content.Parts))
@@ -330,6 +335,9 @@ func TestTTSStreamDeltas(t *testing.T) {
 	if string(part.Source.Bytes()) != "chunk-1chunk-2" {
 		t.Fatalf("audio = %q", part.Source.Bytes())
 	}
+	if result.Metadata.RequestID != "tts-1" {
+		t.Fatalf("stream request id = %q, want tts-1", result.Metadata.RequestID)
+	}
 
 	body := server.body(t, 0)
 	if body["stream"] != true {
@@ -369,5 +377,32 @@ func TestTTSStreamBaseRespError(t *testing.T) {
 	}
 	if !errdefs.IsRateLimit(err) {
 		t.Fatalf("classification = %v", err)
+	}
+}
+
+// TestMediaHTTPErrorRequestID asserts a non-200 media response carries
+// its request_id onto the classified error (the OpenAI-style error body
+// MiniMax documents for its async/v2 endpoints).
+func TestMediaHTTPErrorRequestID(t *testing.T) {
+	server := newMessagesServer(t, func(w http.ResponseWriter, _ map[string]any) {
+		w.WriteHeader(http.StatusTooManyRequests)
+		_, _ = fmt.Fprint(w, `{"type":"error","error":{"type":"rate_limit_error","message":"slow down"},"request_id":"rid-1"}`)
+	})
+	runtime := newTestRuntime(t, server)
+
+	_, err := runtime.Generate(
+		context.Background(),
+		minimaxModel("speech-2.8-hd"),
+		ttsGenerateRequest(media.AudioFormat{Encoding: media.AudioEncodingMP3}),
+	)
+	if err == nil {
+		t.Fatal("expected HTTP failure")
+	}
+	if !errdefs.IsRateLimit(err) {
+		t.Fatalf("classification = %v", err)
+	}
+	var inferenceErr *inference.Error
+	if !errors.As(err, &inferenceErr) || inferenceErr.RequestID != "rid-1" {
+		t.Fatalf("request id = %v, want rid-1", err)
 	}
 }

--- a/sdkx/inference/minimax/video.go
+++ b/sdkx/inference/minimax/video.go
@@ -32,7 +32,8 @@ type videoWire struct {
 }
 
 type videoRaw struct {
-	videoURL string
+	videoURL  string
+	requestID string
 }
 
 func compileVideo(
@@ -269,6 +270,10 @@ func transportVideo(
 		}
 
 		query := url.Values{"task_id": {created.TaskID}}
+		// MiniMax's v1 video endpoint returns no request/trace id on
+		// success; the task_id is the only server-assigned handle for the
+		// create request, so it doubles as the request id for tracing.
+		requestID := created.TaskID
 		for {
 			var task videoQueryResponse
 			if err := client.getJSON(ctx, "/v1/query/video_generation", query, &task); err != nil {
@@ -299,7 +304,10 @@ func transportVideo(
 						task.FileID,
 					)
 				}
-				return videoRaw{videoURL: file.File.DownloadURL}, nil
+				return videoRaw{
+					videoURL:  file.File.DownloadURL,
+					requestID: requestID,
+				}, nil
 			case "fail", "failed":
 				return videoRaw{}, errdefs.NotAvailable(fmt.Errorf(
 					"minimax: video task %q failed server-side",
@@ -335,6 +343,7 @@ func decodeVideo(
 		Usage: inference.Usage{
 			GeneratedVideos: &generated,
 		},
+		Metadata: inference.Metadata{RequestID: raw.requestID},
 	}, nil
 }
 

--- a/sdkx/inference/minimax/video_test.go
+++ b/sdkx/inference/minimax/video_test.go
@@ -96,6 +96,9 @@ func TestVideoUnaryCapturedWire(t *testing.T) {
 	if response.FinishReason != inference.FinishCompleted {
 		t.Fatalf("finish = %q", response.FinishReason)
 	}
+	if response.Metadata.RequestID != "task-1" {
+		t.Fatalf("request id = %q, want task-1", response.Metadata.RequestID)
+	}
 	if len(response.Message.Content.Parts) != 1 {
 		t.Fatalf("parts = %d", len(response.Message.Content.Parts))
 	}

--- a/sdkx/inference/openai/errors.go
+++ b/sdkx/inference/openai/errors.go
@@ -24,6 +24,10 @@ func classifyError(err error) error {
 	if apiErr, ok := errors.AsType[*openai.Error](err); ok {
 		classified := classifyHTTPStatus(apiErr.StatusCode, err)
 		if apiErr.Response != nil {
+			classified = errdefs.WithRequestID(
+				classified,
+				apiErr.Response.Header.Get("x-request-id"),
+			)
 			classified = errdefs.WithRetryAfter(
 				classified,
 				errdefs.ParseRetryAfter(apiErr.Response.Header.Get("Retry-After")),

--- a/sdkx/inference/openai/generate.go
+++ b/sdkx/inference/openai/generate.go
@@ -129,14 +129,15 @@ type rawUsage struct {
 // canonical part indices (it is the stateful stage) so the decoder function
 // stays pure and concurrency-safe.
 type streamRaw struct {
-	kind      streamRawKind
-	part      int    // canonical part index (text / tool / reasoning kinds)
-	text      string // text / summary delta
-	signature string // terminal reasoning encrypted payload
-	id        string // terminal reasoning item id
-	tool      streamRawTool
-	usage     *rawUsage
-	finish    inference.FinishReason
+	kind       streamRawKind
+	part       int    // canonical part index (text / tool / reasoning kinds)
+	text       string // text / summary delta
+	signature  string // terminal reasoning encrypted payload
+	id         string // terminal reasoning item id
+	responseID string // response-level id from the terminal event
+	tool       streamRawTool
+	usage      *rawUsage
+	finish     inference.FinishReason
 }
 
 type streamRawKind int

--- a/sdkx/inference/openai/generate_openai.go
+++ b/sdkx/inference/openai/generate_openai.go
@@ -330,6 +330,7 @@ func decodeGenerate(
 		},
 		FinishReason: raw.finish,
 		Usage:        rawUsageCanonical(raw.usage),
+		Metadata:     inference.Metadata{ResponseID: raw.id},
 	}, nil
 }
 

--- a/sdkx/inference/openai/generate_openai_operations_test.go
+++ b/sdkx/inference/openai/generate_openai_operations_test.go
@@ -425,6 +425,9 @@ func TestGenerateUnaryReasoningItem(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Execute: %v", err)
 	}
+	if response.Metadata.ResponseID != "resp_1" {
+		t.Fatalf("response id = %q, want resp_1", response.Metadata.ResponseID)
+	}
 	parts := response.Message.Content.Parts
 	if len(parts) != 2 {
 		t.Fatalf("parts = %+v", parts)
@@ -516,6 +519,9 @@ func TestGenerateStreamReasoning(t *testing.T) {
 	response, err := stream.Result()
 	if err != nil {
 		t.Fatalf("Result: %v", err)
+	}
+	if response.Metadata.ResponseID != "resp_1" {
+		t.Fatalf("stream response id = %q, want resp_1", response.Metadata.ResponseID)
 	}
 	parts := response.Message.Content.Parts
 	if len(parts) != 2 {

--- a/sdkx/inference/openai/generate_openai_test.go
+++ b/sdkx/inference/openai/generate_openai_test.go
@@ -456,6 +456,7 @@ func TestClassifyError(t *testing.T) {
 
 func TestRateLimitCarriesRetryAfter(t *testing.T) {
 	server, _ := newCapturedOpenAI(t, func(w http.ResponseWriter, _ *http.Request, _ map[string]any) {
+		w.Header().Set("x-request-id", "req-openai")
 		w.Header().Set("Retry-After", "4")
 		w.WriteHeader(http.StatusTooManyRequests)
 		_, _ = fmt.Fprint(w, `{"error":{"message":"slow down","type":"rate_limit_error","code":"x"}}`)
@@ -484,6 +485,9 @@ func TestRateLimitCarriesRetryAfter(t *testing.T) {
 	}
 	if got := errdefs.RetryCount(err); got < 1 {
 		t.Fatalf("RetryCount = %d, want at least 1 wire attempt", got)
+	}
+	if got, ok := errdefs.RequestID(err); !ok || got != "req-openai" {
+		t.Fatalf("RequestID = %q/%v, want req-openai/true", got, ok)
 	}
 }
 

--- a/sdkx/inference/openai/generate_stream.go
+++ b/sdkx/inference/openai/generate_stream.go
@@ -246,9 +246,10 @@ func (s *responsesStream) finishEvent(
 	s.finished = true
 	usage := responseUsage(response.Usage)
 	return streamRaw{
-		kind:   streamRawFinish,
-		usage:  &usage,
-		finish: finish,
+		kind:       streamRawFinish,
+		usage:      &usage,
+		finish:     finish,
+		responseID: response.ID,
 	}, nil
 }
 
@@ -283,7 +284,10 @@ func decodeGenerateStream(
 			},
 		}, nil
 	case streamRawFinish:
-		event := inference.GenerateStreamEvent{FinishReason: raw.finish}
+		event := inference.GenerateStreamEvent{
+			FinishReason: raw.finish,
+			ResponseID:   raw.responseID,
+		}
 		if raw.usage != nil {
 			usage := rawUsageCanonical(*raw.usage)
 			event.Usage = &usage

--- a/sdkx/inference/qwen/client.go
+++ b/sdkx/inference/qwen/client.go
@@ -112,8 +112,9 @@ func (c *dashClient) request(
 	if resp.StatusCode != http.StatusOK {
 		defer func() { _ = resp.Body.Close() }()
 		var failure struct {
-			Code    string `json:"code"`
-			Message string `json:"message"`
+			Code      string `json:"code"`
+			Message   string `json:"message"`
+			RequestID string `json:"request_id"`
 		}
 		snippet, _ := io.ReadAll(io.LimitReader(resp.Body, 8192))
 		// A failure here means we cannot enrich classifyHTTPError with
@@ -125,11 +126,15 @@ func (c *dashClient) request(
 				otellog.String("provider", "qwen"),
 				otellog.Int("http.status", resp.StatusCode))
 		}
+		classified := errdefs.WithRequestID(
+			classifyHTTPError(
+				resp.StatusCode, failure.Code, failure.Message, snippet,
+			),
+			failure.RequestID,
+		)
 		return nil, errdefs.WithRetryCount(
 			errdefs.WithRetryAfter(
-				classifyHTTPError(
-					resp.StatusCode, failure.Code, failure.Message, snippet,
-				),
+				classified,
 				errdefs.ParseRetryAfter(resp.Header.Get("Retry-After")),
 			),
 			httpkit.RetryCountOf(resp),

--- a/sdkx/inference/qwen/embed.go
+++ b/sdkx/inference/qwen/embed.go
@@ -251,6 +251,7 @@ func embedImageValue(source media.ImageSource, ledger *ledger) string {
 type embedRaw struct {
 	vectors     [][]float32
 	inputTokens int64
+	requestID   string
 }
 
 // dashEmbedEnvelope is the embedding response envelope, shared by the
@@ -322,7 +323,9 @@ func transportEmbedText(
 	if err := client.postJSON(ctx, wire.Path, body, &envelope); err != nil {
 		return embedRaw{}, err
 	}
-	if err := classifyEnvelope(envelope.Code, envelope.Message); err != nil {
+	if err := classifyEnvelope(
+		envelope.Code, envelope.Message, envelope.RequestID,
+	); err != nil {
 		return embedRaw{}, err
 	}
 	vectors := make([][]float32, len(wire.Texts))
@@ -335,7 +338,11 @@ func transportEmbedText(
 		}
 		vectors[embedding.TextIndex] = embedding.Embedding
 	}
-	return embedRaw{vectors: vectors, inputTokens: envelope.tokens()}, nil
+	return embedRaw{
+		vectors:     vectors,
+		inputTokens: envelope.tokens(),
+		requestID:   envelope.RequestID,
+	}, nil
 }
 
 // multimodalEmbedBody is the multimodal-embedding request body, used by
@@ -377,7 +384,9 @@ func transportEmbedIndependent(
 	); err != nil {
 		return embedRaw{}, err
 	}
-	if err := classifyEnvelope(envelope.Code, envelope.Message); err != nil {
+	if err := classifyEnvelope(
+		envelope.Code, envelope.Message, envelope.RequestID,
+	); err != nil {
 		return embedRaw{}, err
 	}
 	vectors := make([][]float32, len(wire.Contents))
@@ -390,7 +399,11 @@ func transportEmbedIndependent(
 		}
 		vectors[embedding.Index] = embedding.Embedding
 	}
-	return embedRaw{vectors: vectors, inputTokens: envelope.tokens()}, nil
+	return embedRaw{
+		vectors:     vectors,
+		inputTokens: envelope.tokens(),
+		requestID:   envelope.RequestID,
+	}, nil
 }
 
 // transportEmbedFusion fuses each multi-part item into one vector, one
@@ -408,7 +421,9 @@ func transportEmbedFusion(
 		); err != nil {
 			return embedRaw{}, err
 		}
-		if err := classifyEnvelope(envelope.Code, envelope.Message); err != nil {
+		if err := classifyEnvelope(
+			envelope.Code, envelope.Message, envelope.RequestID,
+		); err != nil {
 			return embedRaw{}, err
 		}
 		if len(envelope.Output.Embeddings) != 1 {
@@ -419,6 +434,9 @@ func transportEmbedFusion(
 		}
 		raw.vectors = append(raw.vectors, envelope.Output.Embeddings[0].Embedding)
 		raw.inputTokens += envelope.tokens()
+		if envelope.RequestID != "" {
+			raw.requestID = envelope.RequestID
+		}
 	}
 	return raw, nil
 }
@@ -443,5 +461,6 @@ func decodeEmbed(
 			InputTokens: raw.inputTokens,
 			ItemCount:   len(raw.vectors),
 		},
+		Metadata: inference.Metadata{RequestID: raw.requestID},
 	}, nil
 }

--- a/sdkx/inference/qwen/embed_test.go
+++ b/sdkx/inference/qwen/embed_test.go
@@ -2,6 +2,7 @@ package qwen
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"strings"
@@ -99,6 +100,9 @@ func TestTextEmbeddingOnWire(t *testing.T) {
 	}
 	if response.Usage.InputTokens != 27 || response.Usage.ItemCount != 2 {
 		t.Fatalf("usage = %+v", response.Usage)
+	}
+	if response.Metadata.RequestID != "emb-1" {
+		t.Fatalf("request id = %q, want emb-1", response.Metadata.RequestID)
 	}
 }
 
@@ -380,6 +384,10 @@ func TestEmbedEnvelopeError(t *testing.T) {
 	)
 	if !errdefs.IsUnauthorized(err) {
 		t.Fatalf("error = %v, want unauthorized", err)
+	}
+	var inferenceErr *inference.Error
+	if !errors.As(err, &inferenceErr) || inferenceErr.RequestID != "x" {
+		t.Fatalf("error request id = %+v, want x", inferenceErr)
 	}
 }
 

--- a/sdkx/inference/qwen/errors.go
+++ b/sdkx/inference/qwen/errors.go
@@ -57,14 +57,15 @@ func classifyCode(code string, err error) error {
 
 // classifyEnvelope checks the code/message pair on a 200 response: SSE
 // streams and edge gateways can report failures with an HTTP-200 envelope
-// whose code is non-empty.
-func classifyEnvelope(code, message string) error {
+// whose code is non-empty. requestID, when present, rides onto the
+// classified error for upstream correlation.
+func classifyEnvelope(code, message, requestID string) error {
 	if code == "" {
 		return nil
 	}
 	err := fmt.Errorf("qwen: %s: %s", code, message)
 	if classified := classifyCode(code, err); classified != nil {
-		return classified
+		return errdefs.WithRequestID(classified, requestID)
 	}
-	return errdefs.NotAvailable(err)
+	return errdefs.WithRequestID(errdefs.NotAvailable(err), requestID)
 }

--- a/sdkx/inference/qwen/generate.go
+++ b/sdkx/inference/qwen/generate.go
@@ -754,6 +754,7 @@ func decodeGenerate(
 	}
 	response.FinishReason = finishReason(choice.FinishReason)
 	response.Usage = raw.usage().canonical()
+	response.Metadata.RequestID = raw.RequestID
 	return response, nil
 }
 
@@ -767,7 +768,9 @@ func transportGenerate(
 		if err := client.postJSON(ctx, wire.Path, wire, &envelope); err != nil {
 			return dashResponse{}, err
 		}
-		if err := classifyEnvelope(envelope.Code, envelope.Message); err != nil {
+		if err := classifyEnvelope(
+			envelope.Code, envelope.Message, envelope.RequestID,
+		); err != nil {
 			return dashResponse{}, err
 		}
 		return envelope, nil

--- a/sdkx/inference/qwen/generate_stream.go
+++ b/sdkx/inference/qwen/generate_stream.go
@@ -25,6 +25,9 @@ type streamFragment struct {
 	call   *wireToolCall // tool-call delta
 	finish string        // wire finish reason
 	usage  *dashUsage
+	// requestID rides every fragment from the shared SSE envelope so the
+	// terminal event can carry it onto the canonical stream result.
+	requestID string
 }
 
 type fragmentKind int
@@ -82,6 +85,7 @@ func decodeStreamFragment(
 	case fragmentFinish:
 		event := inference.GenerateStreamEvent{
 			FinishReason: finishReason(fragment.finish),
+			RequestID:    fragment.requestID,
 		}
 		if fragment.usage != nil {
 			usage := fragment.usage.canonical()
@@ -207,7 +211,9 @@ func splitChunk(payload []byte) ([]streamFragment, error) {
 	if err := json.Unmarshal(payload, &chunk); err != nil {
 		return nil, fmt.Errorf("qwen: decode stream chunk: %w", err)
 	}
-	if err := classifyEnvelope(chunk.Code, chunk.Message); err != nil {
+	if err := classifyEnvelope(
+		chunk.Code, chunk.Message, chunk.RequestID,
+	); err != nil {
 		return nil, err
 	}
 	if len(chunk.Output.Choices) == 0 {
@@ -216,32 +222,36 @@ func splitChunk(payload []byte) ([]streamFragment, error) {
 	choice := chunk.Output.Choices[0]
 	message := choice.Message
 	var fragments []streamFragment
+	stamp := func(fragment streamFragment) streamFragment {
+		fragment.requestID = chunk.RequestID
+		return fragment
+	}
 	if message.ReasoningContent != "" {
-		fragments = append(fragments, streamFragment{
+		fragments = append(fragments, stamp(streamFragment{
 			kind: fragmentReasoning,
 			text: message.ReasoningContent,
-		})
+		}))
 	}
 	if text := messageContentText(message.Content); text != "" {
-		fragments = append(fragments, streamFragment{
+		fragments = append(fragments, stamp(streamFragment{
 			kind: fragmentText,
 			text: text,
-		})
+		}))
 	}
 	for i := range message.ToolCalls {
 		call := message.ToolCalls[i]
-		fragments = append(fragments, streamFragment{
+		fragments = append(fragments, stamp(streamFragment{
 			kind: fragmentToolCall,
 			call: &call,
-		})
+		}))
 	}
 	if choice.FinishReason != "" && choice.FinishReason != "null" {
 		usage := chunk.usage()
-		fragments = append(fragments, streamFragment{
+		fragments = append(fragments, stamp(streamFragment{
 			kind:   fragmentFinish,
 			finish: choice.FinishReason,
 			usage:  &usage,
-		})
+		}))
 	}
 	return fragments, nil
 }

--- a/sdkx/inference/qwen/generate_test.go
+++ b/sdkx/inference/qwen/generate_test.go
@@ -46,6 +46,9 @@ func TestUnaryTextOnWire(t *testing.T) {
 	if response.Usage.TotalTokens != 19 {
 		t.Fatalf("usage = %+v", response.Usage)
 	}
+	if response.Metadata.RequestID != "req_1" {
+		t.Fatalf("request id = %q, want req_1", response.Metadata.RequestID)
+	}
 
 	if path := server.path(t, 0); path != pathTextGeneration {
 		t.Fatalf("path = %q", path)
@@ -714,6 +717,9 @@ func TestStreamToolCalls(t *testing.T) {
 	}
 	if string(call.Call.Arguments) != `{"city":"hz"}` {
 		t.Fatalf("arguments = %s", call.Call.Arguments)
+	}
+	if result.Metadata.RequestID != "req_1" {
+		t.Fatalf("stream request id = %q, want req_1", result.Metadata.RequestID)
 	}
 }
 


### PR DESCRIPTION
## Summary

Wire provider-assigned request/response identifiers through the inference stack so OTel spans, logs, returned metadata, and errors can be joined with provider-side traces.

## SDK core

- `sdk/errdefs`: new `WithRequestID` / `RequestID` error hints for provider request ids on failures.
- `sdk/inference`: `Metadata` and `GenerateStreamEvent` now carry `RequestID` / `ResponseID`; `Error` carries `RequestID`; unary, stream, and route telemetry record `llm.request.id` / `llm.response.id` on spans and warning logs, and the stream accumulator forwards ids onto `Result()` metadata.
- `sdk/telemetry`: new `AttrLLMRequestID` / `AttrLLMResponseID` attributes, plus `WithMeterReader` and `WithRuntimeMetrics` meter options.

## Provider wiring

| Provider | Success | Failure |
| --- | --- | --- |
| qwen | `request_id` → `llm.request.id` | error body `request_id` |
| openai (and azure via the shared openai kernel) | response `id` → `llm.response.id` | `x-request-id` response header |
| deepseek | response `id` → `llm.response.id` | `x-request-id` response header |
| anthropic / minimax chat | `message.id` → `llm.response.id` | provider request id |
| kimi | completion `id` → `llm.response.id` | error body `request_id` |
| bytedance | Responses `id` / TTS `reqid` | Ark/Speech request id |
| minimax media (t2a_v2, music, image, video) | `trace_id` / image `id` / video `task_id` → `llm.request.id` | error body `request_id` |

## Docs

- Wrap Go snippets in `{% raw %}` blocks so the inference and memory guides render correctly under Jekyll.

## Testing

- `make ci` (vet + tests across all modules) ✅
- `make lint` (golangci-lint on sdk, memory, memory/eval, sdkx) ✅
- `make release-check` ✅
- `git diff --check` ✅

## Notes

- MiniMax media per official docs: t2a_v2 and music return top-level `trace_id`; image_generation returns `id` (documented as "Trace ID for request tracking"); video v1 only returns `task_id`, which is used as the request id since it is the only server-assigned handle. Non-2xx media errors use the OpenAI-style `request_id` error body.
- Bytedance's `X-Client-Request-Id` is client-generated and echoed back by the server; the SDK prefers the echoed response header over the body `request_id`.
