### PR TITLE
chore(release): prepare sdk v0.5.0 migration docs and changeset

### DIFF
--- a/.release/sdk.json
+++ b/.release/sdk.json
@@ -1,0 +1,9 @@
+{
+  "summary": "Breaking cleanup: remove v0.4.x deprecated surfaces and land the unified runtime (engine into agent, llm/embedding/model into inference+message), the config.Factory/Source/Loader build protocol, and bubblewrap sandbox with network enforcement",
+  "releases": [
+    {
+      "module": "sdk",
+      "bump": "minor"
+    }
+  ]
+}

--- a/docs/index.md
+++ b/docs/index.md
@@ -41,6 +41,8 @@ retrieval, runtime orchestration, and voice. Source on
 
 ## Migrations
 
+- [`sdk/v0.5.0`](migrations/v0.5.0.md) — unified runtime, configuration
+  protocol, and sandbox cutover.
 - [`sdk/v0.4.0` + `memory/v0.1.0`](migrations/v0.4.0-memory-split.md) —
   memory-domain packages split into the standalone `memory` module.
 - [`sdk/v0.3.0`](migrations/v0.3.0.md) — breaking-change cutover

--- a/docs/migrations/v0.5.0.md
+++ b/docs/migrations/v0.5.0.md
@@ -1,147 +1,379 @@
 # Migrating to SDK v0.5.0
 
-SDK v0.5.0 removes four groups of deprecated surface in addition to the
-memory-domain packages described below:
+> Status: planned for `sdk/v0.5.0`. The release is the "unified runtime"
+> cutover: the execution, model, and configuration stacks are consolidated
+> into `sdk/agent` + `sdk/inference` + `sdk/message` + `sdk/config`, the
+> memory domain leaves the foundational SDK, and the sandbox backend moves
+> from nsjail to bubblewrap with network enforcement. `sdkx` and `memory`
+> follow with coordinated pins to `sdk v0.5.0`.
 
-## Agent identity: actor → agent
+## Summary
 
-The "actor" spelling of the agent-identity dimension is gone; only the
-`agent_id` spelling remains.
+`sdk/v0.5.0` is the breaking cleanup that lands the work accumulated after
+the `v0.4.x` line. Four themes drive it:
 
-| Removed                                            | Replacement                                                              |
-| -------------------------------------------------- | ------------------------------------------------------------------------ |
-| `event.HeaderActorID` (`"actor_id"`)               | `event.HeaderAgentID` (`"agent_id"`)                                     |
-| `event.Envelope.SetActorID` / `ActorID()`          | `event.Envelope.SetAgentID` / `AgentID()`                                |
-| `telemetry.AttrActorID` (`"actor.id"`)             | `telemetry.AttrAgentID` (`"agent.id"`)                                   |
-| `runner.WithActorKey` ctx-key                       | `agent.Run` (stamps `engine.Run.Attributes[telemetry.AttrAgentID]`)      |
+1. **Runtime convergence** — `sdk/engine`, `sdk/llm`, `sdk/embedding`,
+   `sdk/model`, and `sdk/script` are gone. The execution contract lives in
+   `sdk/agent` (`Engine` / `Board` / `Run` / `Host` / `Checkpoint` /
+   `Interrupt`), model calls live in `sdk/inference`, wire DTOs live in
+   `sdk/message`, and `sdk/graph` is now a first-class `agent.Engine`.
+2. **Memory domain leaves `sdk`** — `sdk/history`, `sdk/recall`,
+   `sdk/knowledge`, `sdk/retrieval`, and `sdk/textsearch` are removed.
+   Applications depend on the standalone `github.com/GizClaw/flowcraft/memory`
+   module.
+3. **Assembly protocol** — `sdk/config` introduces the unified
+   `Factory` / `Spec` / `DepSpec` / `Catalog` build protocol plus
+   `Source` / `Loader` document resolution, and `sdkx/deploy` is the
+   declarative assembly layer built on it.
+4. **Security and identity** — sandbox enforcement is explicit
+   (bubblewrap namespace backend with network policy; `LocalRunner` refuses
+   non-default network modes), and the "actor" spelling is fully replaced by
+   "agent" in event headers and telemetry attributes.
 
-`SetAgentID` no longer dual-writes the legacy header, and the graph executor
-resolves the agent id exclusively from `engine.Run.Attributes`. Direct executor
-callers that previously used `runner.WithActorKey(ctx, id)` must pass
-`executor.WithAttributes(map[string]string{telemetry.AttrAgentID: id})`
-(or drive through `agent.Run`).
+There is **no compatibility shim**. The deprecation surfaces carried through
+the `v0.4.x` line (workspace command aliases, actor spellings, the deprecated
+memory-domain packages) are deleted in one cut.
 
-## Workspace command shim
+---
 
-| Removed                                                                                          | Replacement                                                                  |
-| ------------------------------------------------------------------------------------------------ | ---------------------------------------------------------------------------- |
-| `sdk/workspace.CommandRunner`, `ExecOptions`, `ExecResult`, `CommandOption`, `NewLocalCommandRunner`, `NewScopedCommandRunner`, `NoopCommandRunner` (type aliases) | The corresponding `sdk/sandbox` types (`sandbox.Runner`, `sandbox.ExecOptions`, …) |
+## Module surface changes (vs `sdk/v0.4.x`)
 
-## Agent request metadata
+### Removed from `sdk`
 
-| Removed                     | Replacement                                                                                      |
-| --------------------------- | ------------------------------------------------------------------------------------------------ |
-| `agent.Request.Extensions`  | `agent.WithAttributes(map[string]string{...})` — serialise non-string values at the call site |
+| Removed package / path                                                                              | Destination / replacement                                                                                                              |
+| --------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------- |
+| `sdk/engine`                                                                                        | merged into `sdk/agent` — `Engine`, `Board`, `Run`, `Host`, `Checkpoint`, `Interrupt`, `LoadAndResume`, `RestoreBoard`, stream helpers |
+| `sdk/llm`                                                                                           | `sdk/inference` (Generate/Embed/Transcription/Realtime) + `sdk/message` (wire DTOs)                                                    |
+| `sdk/embedding`                                                                                     | `sdk/inference.Embed` / `inference.Runtime`                                                                                            |
+| `sdk/model`                                                                                         | `sdk/inference` (`ModelRef`, model config) + `sdk/message`                                                                             |
+| `sdk/script`                                                                                        | `sdk/agent/bindings` (host bindings); runtimes move to `sdkx/agent/jsrt` and `sdkx/agent/luart`                                        |
+| `sdk/kanban`                                                                                        | `sdkx/delegation/kanban` (async delegation backend)                                                                                    |
+| `sdk/history`                                                                                       | `memory` module                                                                                                                        |
+| `sdk/recall`                                                                                        | `memory` module                                                                                                                        |
+| `sdk/knowledge`                                                                                     | `memory` module                                                                                                                        |
+| `sdk/retrieval`                                                                                     | `memory` module                                                                                                                        |
+| `sdk/textsearch`                                                                                    | `memory` module                                                                                                                        |
+| `sdk/graph/runner`                                                                                  | `sdk/graph` kernel — a compiled `*graph.Graph` **is** an `agent.Engine`                                                                |
+| `sdk/graph/node/{llmnode,scriptnode,knowledgenode}`, `sdk/graph/variable`, `sdk/graph/node/scripts` | `sdk/graph/nodes` (`tool`, `inference`, `script`) + `sdk/graph/config`                                                                 |
+| `sdk/workspace` command shim (aliases)                                                              | `sdk/sandbox` types (`sandbox.Runner`, `sandbox.ExecOptions`, …)                                                                       |
+| `sdk/tool/schema.go`                                                                                | `message.DefineSchema` / `message.Definition`                                                                                          |
+| `sdk/internal/background`, `sdk/internal/syncx`                                                     | implementation details of the removed packages; not public API                                                                         |
 
-## Knowledge FS backends and local factory
+### Added to `sdk`
 
-| Removed                                                  | Replacement                                                                                          |
-| -------------------------------------------------------- | ---------------------------------------------------------------------------------------------------- |
-| `factory.NewLocal`, `LocalOption`, `WithLocal*`          | `factory.NewRetrieval(docs, idx, ...)` with `memory/retrieval/memory.Index` (tests) or a production `retrieval.Index` |
-| `backend/fs.NewChunkRepo` (`FSChunkRepo`)                | `backend/retrieval.NewChunkRepo`                                                                     |
-| `backend/fs.NewLayerRepo` (`FSLayerRepo`)                | `backend/retrieval.NewLayerRepo`                                                                     |
-| `knowledge.ServiceOptions.Now`                           | (removed; `DocumentRepo.Put` is authoritative for timestamps)                                         |
-| `namespace.Prefix.LegacyUserScopeV1`                     | `namespace.Prefix.UserScope`; `DecodeScope` still decodes V1 namespaces for migration reads           |
+- `sdk/config` — shared build protocol (`Factory` / `Spec` / `DepSpec` /
+  `Input` / `Catalog` / `ItemResolver` / `SourceFunc`) and document
+  resolution (`Source` / `Loader`, `DecodeSettings`).
+- `sdk/inference` (+ `sdk/inference/config`, `sdk/inference/route`,
+  `sdk/inference/inferencetest`) — the instance-owned unified runtime.
+- `sdk/message` (+ `sdk/message/media`) — provider-neutral wire DTOs and
+  JSON-Schema helpers.
+- `sdk/memory` — implementation-neutral memory capabilities
+  (`ContextProvider`, `TurnSink`, `DocumentSink`, `Scope`).
+- `sdk/delegation` — backend-neutral delegation contracts (`Mode`,
+  `Directory`, `Service`, `Handoff`, the `delegate` tool and referees).
+- `sdk/scheduler` (+ `sdk/scheduler/config`) — leased delivery control
+  plane (`Control`, `Client`, `Worker`).
+- Per-domain config packages wired for assembly: `sdk/tool/config`,
+  `sdk/workspace/config`, `sdk/sandbox/config`, `sdk/graph/config`,
+  `sdk/event/config`.
+- `sdk/tool/middleware` — recover, telemetry, concurrency, timeout,
+  ratelimit, approval, audit.
+- `sdk/agent/bindings` — script host bindings moved from `sdk/script/bindings`.
 
-`backend/fs.NewDocumentRepo` (`FSDocumentRepo`) is **not** removed and remains
-the canonical document store for the retrieval-wired stack.
+### Coordinated `sdkx` changes
 
-## Memory-domain package moves
+The same window rebuilds the provider/adaptor layer. `sdkx` follows `sdk` with
+a release pinned to `sdk v0.5.0`.
 
-SDK v0.5.0 also removes the deprecated memory-domain packages from the
-foundational SDK module. Applications should import the standalone `memory`
-module instead.
+| Removed (`sdkx`)                                   | Replacement (`sdkx`)                                                                    |
+| -------------------------------------------------- | --------------------------------------------------------------------------------------- |
+| `sdkx/llm/<provider>`, `sdkx/embedding/<provider>` | `sdkx/inference/<provider>` — providers implement the `sdk/inference` compiler contract |
+| `sdkx/engine`, `sdkx/claw`, `sdkx/extract`         | removed with the legacy runtimes                                                        |
+| `sdkx/recall`, `sdkx/retrieval`                    | the `memory` module's own stores and adapters                                           |
+| `sdkx/tool/{history,kanban,knowledge,memory}`      | `sdkx/delegation/kanban`, `sdkx/tool/{mcp,delegation}`, application-owned tools         |
+| `sdkx/sandbox/nsjail`                              | `sdkx/sandbox/bwrap` (Linux) + `sdkx/sandbox/seatbelt` (macOS)                          |
 
-| Removed package                              | Replacement                                                                                |
-| -------------------------------------------- | ------------------------------------------------------------------------------------------ |
-| `sdk/history`                                | `memory/history`                                                                           |
-| `sdk/recall`                                 | `memory/recall`                                                                            |
-| `sdk/knowledge`                              | `memory/knowledge`                                                                         |
-| `sdk/retrieval`                              | `memory/retrieval`                                                                         |
-| `sdk/textsearch`                             | `memory/text/{bm25,lemma,stem,tokenize}`                                                    |
-| `sdk/graph/node/knowledgenode`               | Build knowledge integration with `memory/knowledge` outside the foundational graph package |
-| `sdkx/recall/jobqueue/sqlite`                | Use the durable queues and stores provided by `memory/recall`                              |
-| `sdkx/retrieval/{postgres,sqlite,workspace}` | `memory/retrieval/{postgres,sqlite,workspace}`                                             |
-| `sdkx/tool/history`                          | Integrate `memory/history` through application-owned tools                                 |
-| `sdkx/tool/knowledge`                        | Integrate `memory/knowledge` through application-owned tools                               |
-| `sdkx/tool/memory`                           | Build file-tree model memory on `sdk/workspace` in application-owned code, or attach a filesystem MCP server via `sdkx/tool/mcp` |
+New `sdkx` surface: `sdkx/deploy` (assembly layer), `sdkx/runtime` +
+`sdkx/runtime/session` (process-level session owner above `deploy`),
+`sdkx/agent/{jsrt,luart}`, `sdkx/delegation` (+ `kanban`), `sdkx/scheduler`,
+`sdkx/memory` (`hook`, `render`).
 
-The old `sdk/recall` API used the v1 entry/retrieval-index data model. Its
-replacement is not an import-only rename: `memory/recall` uses temporal facts,
-canonical stores, projections, evidence, and explicit side-effect or async
-semantic processing. Migrate construction and persistence wiring to the new
-contracts.
+---
 
-The `sdkx/tool/memory` removal is separate from the memory-domain migration: it
-implemented Anthropic's file-based Memory Tool protocol over `sdk/workspace` and
-never depended on the standalone `memory` module. It is dropped because a
-model-driven file tree is an application policy decision, not an orchestration
-primitive — the tool's command set, path prefix, and truncation limits are all
-choices an application should own. `sdk/workspace` still provides the file-tree
-primitive to build it on.
+## Breaking changes by area
 
-The legacy retrieval namespace migration utility and the E2E module pinned to
-the removed SDK adapters are also gone. Use the corresponding `memory/retrieval`
-store and conformance suites for new integrations.
+### 1. Runtime: `sdk/engine` merges into `sdk/agent`
 
-`sdk/internal/background` and `sdk/internal/syncx` were implementation details
-used only by the removed packages. Their memory-module equivalents remain under
-`memory/internal`; they are not public APIs.
+The `sdk/engine` package is deleted. All execution-contract types now live in
+`sdk/agent`:
 
-## Configuration reference unification: `Source` + `Loader`
+| `v0.4.x`                                                 | `v0.5.0`                                                                                                                           |
+| -------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------- |
+| `engine.Engine`                                          | `agent.Engine`                                                                                                                     |
+| `engine.Board` / `engine.NewBoard`                       | `agent.Board` / `agent.NewBoard`                                                                                                   |
+| `engine.Run`                                             | `agent.Run` (typed `Identity` + `Attributes`)                                                                                      |
+| `engine.Host` / `engine.NoopHost` / `engine.ComposeHost` | `agent.Host` / `agent.NoopHost`                                                                                                    |
+| `engine.Checkpoint` / `engine.CheckpointStore`           | `agent.Checkpoint` / `agent.CheckpointStore`                                                                                       |
+| `engine.Interrupt` / `engine.Interrupted`                | `agent.Interrupt` / `agent.Interrupted`                                                                                            |
+| `engine.LoadAndResume`                                   | `agent.LoadAndResume` (same shape)                                                                                                 |
+| `engine.RestoreBoard`                                    | `agent.RestoreBoard`                                                                                                               |
+| `engine.NewDependencies`                                 | deps resolved at assembly time through `config.Factory` `DepSpec`s; run-time metadata rides `Run.Attributes` / `Run.ToolAllowList` |
 
-`SubDocument` is gone. Resource `settings`, graph definitions, agent
-recipe locations, and node-config refs all use the shared
-[`config.Source`](../../sdk/config/source.go) / [`config.Ref`](../../sdk/config/source.go)
-types and resolve through a single [`config.Loader`](../../sdk/config/loader.go)
-at build time. References are structured objects — there is no
-`@scheme://` string syntax and no scheme registry.
+The turn entry point changes:
 
-### Document forms
+```go
+// v0.4.x
+res, err := agent.Run(ctx, ag, eng, req, agent.WithEngineHost(host), ...)
 
-| Removed / changed                              | Replacement                                                              |
-| ---------------------------------------------- | ------------------------------------------------------------------------ |
-| `settings: {inline: {...}}`                    | `settings:` followed by the nested object directly (structured content; a string is also accepted) |
-| `settings: {file: ./x.yaml}`                   | unchanged (still `settings: {file: ./x.yaml}`)                           |
-| `graph: ./graphs/a.yaml` (string meant a path) | `graph: {file: ./graphs/a.yaml}` — a plain string is now literal content |
-| `agents: {x: {file: ./a.yaml}}`                | `agents: {x: {source: {file: ./a.yaml}}}` (or `source: {embed: name}`)   |
-| node `source`/`system_prompt: {file: ...}`     | unchanged, and `{embed: ...}` is now supported                            |
+// v0.5.0
+res, err := agent.Execute(ctx, ag, eng, req, agent.WithHost(host), ...)
+```
 
-A `Source` value is a plain string or a nested object (literal content),
-`{file: path}`, or `{embed: name}`. An object containing a `file`/`embed`
-key is a reference and must use exactly those keys; any other object is
-the document itself. The legacy `{"inline": ...}` object no longer has a
-special meaning — it decodes as content and the module's strict parser
-rejects the stray `inline` field.
+`agent.Run`'s options map onto `agent.ExecuteOption`s:
+`WithEngineHost` → `WithHost`, `WithDependencies` → assembly-time deps,
+`WithBoardSeed` → `WithPreparer`, `WithDecider` → `WithReferee`,
+`WithObserver`/`WithMaxRevise`/`WithResumeFrom`/`WithAttributes` are unchanged
+in spirit. `graph/runner.Runner` is gone: build a `*graph.Graph` (an
+`agent.Engine`) and pass it directly.
 
-### Unified build protocol: `config.Factory`
+### 2. Model stack: `sdk/llm` + `sdk/embedding` + `sdk/model` → `sdk/inference` + `sdk/message`
 
-One [Factory](../../sdk/config/resource.go) contract now covers every
-build step — resources, engine kinds, and lifecycle hooks:
+The three legacy packages are removed. `sdk/inference` is the unified,
+instance-owned runtime:
 
-| Removed                                           | Replacement                                                          |
-| ------------------------------------------------- | -------------------------------------------------------------------- |
-| `config.ResourceFactory` / `ResourceSpec` / `ResourceDepSpec` | `config.Factory` / `config.Spec` / `config.DepSpec`     |
-| `config.PreparerFactory` / `ObserverFactory` / `RefereeFactory` / `CommitterFactory` | hook factories implement `config.Factory` with a `hook.*` spec kind |
-| `config.Input.Settings *Opaque`                   | `config.Input.Settings json.RawMessage` — factories decode strictly via `config.DecodeSettings` |
-| `config.DocumentFactory`                          | removed; module builders implement `config.Factory` directly (`Spec()` + `New(ctx, config.Input)`) |
-| `agent.Factory` / `agent.Registry` / `agent.Config` / `agent.EngineSpec` / `agent.DepSpec` | engine kinds implement `config.Factory` (kind, empty impl); capabilities exposed via a separate interface |
-| `deploy.NewBuilder(agent.Registry, ...)`          | `deploy.NewBuilder(...)` + `Builder.RegisterEngine(factory)`          |
-| `deploy.ResourceSpecs()`                          | `Builder.Specs()` (all registered factory specs, registration snapshot) |
+- Four root operations: **Generate** (unary + streaming, including
+  image/audio/video/tool calls), **Embed**, **Transcription**, **Realtime**.
+- Callers address an exact `inference.ModelRef` (provider + model + credential
+  profile); `inference.Runtime` resolves, compiles, and executes.
+- `sdk/inference/route.Router` adds deployment-defined tiers, selectors,
+  retry/backoff, cross-target fallback, and per-target circuit breakers.
+- Deployment configuration and secret resolution live in
+  `sdk/inference/config` (`env`, `file` sources).
 
-`config.Input` gains `Resolve` / `ResolveSource` / `ResolveDocument`;
-the assembly host injects a shared `config.Loader`
-(`deploy.WithLoader(loader)`), so every factory resolves its settings
-through the same loader. `config.Catalog` is the unified registry keyed
-by `(kind, impl)`; workspace/tool/sandbox builders implement
-`config.Factory` themselves, while modules whose expansion is
-construct-time (inference/memory) expose a `deployFactory` implementing
-it.
+`sdk/message` owns the provider-neutral wire DTOs that used to live in
+`sdk/llm`: `message.Message` / `message.Content` / `message.Part`,
+`message/media` (image/audio/video `Source` / `Format`), and the tool DTOs
+`message.Definition` / `message.Call` / `message.Result`. Schema helpers move
+too: `sdk/tool/schema.go` is replaced by `message.DefineSchema(...)`.
 
-### Behavior tightenings
+Provider adapters move from `sdkx/llm/<provider>` + `sdkx/embedding/<provider>`
+to `sdkx/inference/<provider>` and implement the `sdk/inference` provider
+compiler contract (active-field ledger, structured rejections for anything a
+provider cannot honor natively).
 
-- All resolved documents (literal, content, file, embed) are capped at
-  a default **1 MiB** (`config.WithMaxBytes` to change it).
-- `{file: ...}` paths resolve against the loader `baseDir`; after cleaning
-  and symlink resolution the target must stay inside it (absolute paths
-  inside `baseDir` are allowed, anything escaping is `Forbidden`).
+### 3. Graph: a declarative DAG that is an `agent.Engine`
+
+`sdk/graph/runner`, the `sdk/graph/node/*` node packages, and
+`sdk/graph/variable` are removed. The new `sdk/graph` kernel:
+
+```go
+reg := graph.NewRegistry()
+nodes.RegisterTool(reg, toolDispatcher)                 // tool node type
+nodes.RegisterInference(reg, inferenceDeps)             // inference node type
+scriptnode.Register(reg, scriptDeps)                    // script node type
+g, err := graph.Build(def, reg)                         // *graph.Graph implements agent.Engine
+res, err := agent.Execute(ctx, ag, g, req, agent.WithHost(host))
+```
+
+- `GraphDefinition` stays the serialisable document; node configs remain
+  opaque `json.RawMessage`.
+- Node behaviour registers per type name via `RegisterType` into a `Registry`;
+  standard factories ship in `sdk/graph/nodes` (`tool`, `inference`, `script`).
+- YAML graph definition files are supported (`sdk/graph/config` converts YAML
+  authoring sugar to JSON via `sdk/config/utils`).
+- `sdk/graph/config` is the production engine factory for deployment documents
+  (kind `graph`); it wires the standard node factories and declares deps
+  `inference`, `tools`, `workspace`, `sandbox`, `script_runtime`.
+
+### 4. Memory domain leaves `sdk`
+
+`sdk/history`, `sdk/recall`, `sdk/knowledge`, `sdk/retrieval`, and
+`sdk/textsearch` are removed from the foundational module. New and existing
+code must depend on `github.com/GizClaw/flowcraft/memory`:
+
+```bash
+go get github.com/GizClaw/flowcraft/sdk@v0.5.0
+go get github.com/GizClaw/flowcraft/memory@<latest>
+go mod tidy
+```
+
+The `memory` module's own layout has been reorganising independently of `sdk`:
+the `memory/v0.1.x` line kept the sdk-shaped package names (`memory/history`,
+`memory/recall`, `memory/knowledge`, `memory/retrieval`, `memory/text`), while
+current `memory` main moves to the component/system architecture
+(`memory.System` implementing the `sdk/memory` capabilities, with
+`memory/component`, `memory/derive`, `memory/lines`, `memory/lifecycle`,
+`memory/projection`, `memory/retrieval`, `memory/runtime`, `memory/sources`,
+`memory/storage`, `memory/views`, `memory/worker`). Follow the `memory`
+module's own release notes for its migration; the sdk-side rule is simply to
+not import memory-domain packages from `sdk` anymore.
+
+The `sdkx` adapters pinned to the removed SDK domain are gone as well
+(`sdkx/recall`, `sdkx/retrieval`, `sdkx/tool/{history,knowledge,memory}`,
+`sdkx/engine`, `sdkx/claw`). `sdkx/tool/memory` (Anthropic's file-based Memory
+Tool over `sdk/workspace`) is dropped because a model-driven file tree is an
+application policy decision — build it on `sdk/workspace` in application-owned
+code, or attach a filesystem MCP server via `sdkx/tool/mcp`.
+
+### 5. Identity: "actor" → "agent"
+
+| Removed                                   | Replacement                                                          |
+| ----------------------------------------- | -------------------------------------------------------------------- |
+| `event.HeaderActorID` (`"actor_id"`)      | `event.HeaderAgentID` (`"agent_id"`)                                 |
+| `event.Envelope.SetActorID` / `ActorID()` | `event.Envelope.SetAgentID` / `AgentID()`                            |
+| `telemetry.AttrActorID` (`"actor.id"`)    | `telemetry.AttrAgentID` (`"agent.id"`)                               |
+| `runner.WithActorKey` ctx key             | `agent.WithAttributes(map[string]string{telemetry.AttrAgentID: id})` |
+
+`SetAgentID` no longer dual-writes the legacy `actor_id` header, and engines
+resolve the agent identity from `Run.Identity.AgentID` /
+`Run.Attributes[telemetry.AttrAgentID]`. Direct executor callers that used
+`runner.WithActorKey(ctx, id)` pass the id via `agent.WithAttributes`.
+
+### 6. Agent request metadata
+
+`agent.Request.Extensions` is removed. Pass arbitrary metadata through
+`agent.WithAttributes(map[string]string{...})`; non-string values must be
+serialised at the call site. The resulting map flows into `Run.Attributes`,
+telemetry spans, and event headers alongside the well-known identity keys.
+
+### 7. Run summary telemetry
+
+`telemetry.RunSummary` / `telemetry.RecordRunSummary` (the short-lived
+`engine.run.summary` span) are removed. Run-level usage aggregation is a
+`Host` capability (`UsageReporter`): implement it on your host if you need
+per-run totals. Canonical telemetry attributes now use the `agent_id` /
+`run_id` / `task_id` / `context_id` keys exclusively.
+
+### 8. Workspace command shim
+
+`sdk/workspace.CommandRunner`, `ExecOptions`, `ExecResult`, `CommandOption`,
+`NewLocalCommandRunner`, `NewScopedCommandRunner`, and `NoopCommandRunner`
+(type aliases into `sdk/sandbox`) are removed. Import `sdk/sandbox` directly:
+
+```diff
+-import "github.com/GizClaw/flowcraft/sdk/workspace"
+- runner := workspace.NewLocalCommandRunner("/var/agent/root")
++import "github.com/GizClaw/flowcraft/sdk/sandbox"
++ runner := sandbox.NewLocalRunner("/var/agent/root")
+```
+
+### 9. Tool system
+
+- `sdk/tool/schema.go` is removed; build tool definitions with
+  `message.DefineSchema(...)` or set `Definition.InputSchema` directly.
+- The registry split into a read-side `Catalog` (`Get`, `Definitions`) and an
+  `Executor` that owns dispatch and the middleware chain. A `Registry` is a
+  `Catalog`; naming a tool that was not registered fails the build.
+- `sdk/tool/config` assembles an `Executor` from a versioned policy document
+  (middleware list + registry scopes) with built-in kinds: recover, telemetry,
+  concurrency, timeout, ratelimit, approval, audit.
+
+### 10. Sandbox: bubblewrap + explicit network enforcement
+
+- `sdkx/sandbox/nsjail` is replaced by `sdkx/sandbox/bwrap` (Linux:
+  namespace-level FS/net, soft CPU/memory caps, network allow-list/proxy) and
+  `sdkx/sandbox/seatbelt` (macOS).
+- `sandbox.ExecOptions` policy groups are enforced: `Env` (explicit
+  allow-list + inject map), `Net` (`NetDefault` / `NetDenyAll` /
+  `NetAllowList` / `NetProxy`), `Resources` (CPU/memory/disk caps +
+  `MaxOutputBytes`).
+- `LocalRunner` accepts only `NetDefault`; non-default network modes return
+  `errdefs.NotAvailable` unless a namespace/container backend enforces them.
+  `DiskBytes` similarly requires a quota-capable backend.
+- New helpers: `sandbox.EnforcementOf` (inspect the honest policy surface),
+  `sandbox/approval.go`, `sandbox/compose.go`, and the unix/other-local runner
+  split (`local_unix.go` / `local_other.go`).
+
+### 11. Assembly protocol: `sdk/config` + `sdkx/deploy` (new)
+
+These are **new in v0.5.0**, not renames of released APIs. `sdkx/deploy` is the
+assembly layer: one YAML document names shared resources and agents, and one
+`Build` call produces runnable `Instance` values.
+
+- One `config.Factory` contract covers every build step — resources, engine
+  kinds, and lifecycle hooks (`config.Spec` / `config.DepSpec` /
+  `config.Input` / `config.Catalog` / `config.ItemResolver`).
+- Document references use `config.Source` / `config.Ref`: a plain string or a
+  nested object is literal content; `{file: path}` and `{embed: name}` are
+  references resolved through a shared `config.Loader` injected by the host
+  (`deploy.WithLoader(loader)`). There is no `@scheme://` string syntax.
+- Lifecycle hooks (preparers, observers, referees, committers) register as
+  `config.Factory` implementations with a `hook.*` spec kind.
+- Behavior tightenings:
+  - Every resolved document (literal, file, embed) is capped at **1 MiB**
+    by default (`config.WithMaxBytes` to change it).
+  - `{file: ...}` paths resolve against the loader `baseDir`; after cleaning
+    and symlink resolution the target must stay inside it — anything escaping
+    is `errdefs.Forbidden`.
+
+### 12. New contracts: `sdk/message`, `sdk/memory`, `sdk/delegation`, `sdk/scheduler`
+
+Additive surface for new integrations:
+
+- `sdk/message` — wire DTOs and schema helpers (see §2).
+- `sdk/memory` — `Scope` (hard runtime+tenant partition),
+  `ContextProvider`, `TurnSink`, `DocumentSink`, `ContextRenderer`;
+  implementations live in the `memory` module and `sdkx/memory`.
+- `sdk/delegation` — `Mode` (sync / handoff / async), `Directory`
+  (target discovery), `Service` (execution + status), `Handoff`, the unified
+  `delegate` tool, and static/directory-backed referees;
+  `sdkx/delegation/kanban` is the in-memory async backend.
+- `sdk/scheduler` — `Control` (rules + one-shots with idempotent delivery),
+  typed `Client[T]` / `Worker[T]`, `sdkx/scheduler` provides in-process
+  adapters.
+
+---
+
+## Upgrade path
+
+1. **Bump modules** — `sdk` first, then the coordinated `memory` and `sdkx`
+   releases that pin `sdk v0.5.0`:
+
+   ```bash
+   go get github.com/GizClaw/flowcraft/sdk@v0.5.0
+   go get github.com/GizClaw/flowcraft/sdkx@<next>      # pins sdk v0.5.0
+   go get github.com/GizClaw/flowcraft/memory@<next>    # pins sdk v0.5.0
+   go mod tidy
+   ```
+
+2. **Runtime imports** — `sdk/engine` → `sdk/agent`; `agent.Run` →
+   `agent.Execute`; `graph/runner.Runner` → `graph.Build` + `agent.Execute`.
+3. **Model calls** — `sdk/llm` / `sdk/embedding` / `sdk/model` →
+   `sdk/inference` + `sdk/message`; provider imports `sdkx/llm/*` and
+   `sdkx/embedding/*` → `sdkx/inference/*`.
+4. **Tool schemas** — `sdk/tool` schema helpers → `message.DefineSchema`;
+   adopt the `Catalog` / `Executor` split where you dispatched directly.
+5. **Memory** — stop importing `sdk/history|recall|knowledge|retrieval|textsearch`
+   and the removed `sdkx` adapters; depend on the `memory` module and follow
+   its own migration notes.
+6. **Identity/telemetry** — `actor_*` → `agent_*` renames; move run-summary
+   reporting onto your `Host`'s `UsageReporter`.
+7. **Workspace/sandbox** — drop `workspace.*CommandRunner*` aliases;
+   switch `nsjail` configurations to `sdkx/sandbox/bwrap` and honor the new
+   network policy (non-default net modes need a real backend).
+8. **Deployment documents** — if you adopt `sdkx/deploy`, use the new
+   `config.Source` forms (`{file:}`, `{embed:}`), keep documents under 1 MiB,
+   and register every factory/engine kind before `Build`.
+
+## Backwards compatibility
+
+- No global shim. All `v0.4.x`-era deprecation surfaces listed above are
+  removed in this release; there is no transitional alias layer.
+- On-disk artefacts: `agent.RestoreBoard` / `Board.RestoreFrom` still
+  rehydrate `MainChannel` when a snapshot carries no channels; the legacy
+  empty-string `MainChannel` key migration from the v0.2/v0.3 era is gone.
+- The `sdk/v0.3.0` migration guide remains the reference for the earlier
+  `workflow` → `agent + engine + graph` cutover; `sdk/v0.4.0` documents the
+  memory-module split.
+
+## Timeline
+
+- **`sdk/v0.4.0` – `sdk/v0.4.8`** (released): deprecation notices in place
+  for the surfaces removed here; users SHOULD have migrated imports during
+  this window.
+- **`sdk/v0.5.0`** (this release): all breaking changes above land as one cut.
+  Release notes reference this file.
+- **`memory` + `sdkx`** (follow `sdk/v0.5.0`): tagged once their `go.mod` pins
+  are bumped to `sdk v0.5.0`. Their breaking windows overlap this release; see
+  their own changelog/migration notes for the adaptor and storage moves.

--- a/sdk/graph/config/factory.go
+++ b/sdk/graph/config/factory.go
@@ -1,5 +1,5 @@
 // Package config assembles graph agents: it provides the production
-// agent.Factory for sdk/graph and is the graph domain's deployment
+// config.Factory for sdk/graph and is the graph domain's deployment
 // configuration assembly.
 package config
 

--- a/sdkx/deploy/doc.go
+++ b/sdkx/deploy/doc.go
@@ -7,10 +7,10 @@
 // registered impl, so a deployment links only the integrations it
 // actually names — the same opt-in rule sdk/tool/config applies to
 // MCP. Values YAML cannot express arrive through registered
-// factories and sources supplied by the application. Resource
-// factories publish a [ResourceSpec] before construction, allowing
-// Build to validate dependency names, required bindings, whole-resource
-// kinds, and item types before calling [ResourceFactory.New].
+// factories and sources supplied by the application. Factories publish
+// a [config.Spec] before construction, allowing Build to validate
+// dependency names, required bindings, whole-resource kinds, and item
+// types before calling [config.Factory.New].
 //
 // The document is JSON at the protocol level — YAML is accepted as
 // authoring sugar and converted by sdk/config/utils before strict
@@ -46,7 +46,7 @@
 //	    card: {name: 研究员, description: 深度调研}
 //	    tools: [search, fetch]
 //	    engine:
-//	      kind: graph                     # looked up in agent.Registry
+//	      kind: graph                     # looked up in the Builder's catalog
 //	      settings:                       # opaque; the factory validates
 //	        graph: graphs/research.yaml
 //	    deps:                             # keyed by the factory's DepSpec
@@ -165,7 +165,7 @@
 // Some resources hold named items and implement [ItemResolver]: a
 // workspace registry's workspaces, a sandbox registry's runners.
 // Those are addressed as "resource/item". The factory's
-// [ResourceSpec.ItemType] is checked against the consumer's declared
+// [config.Spec.ItemType] is checked against the consumer's declared
 // dep type before ResolveItem is called.
 //
 // Others are single objects — an inference Assembly, a tool

--- a/sdkx/deploy/document.go
+++ b/sdkx/deploy/document.go
@@ -50,7 +50,7 @@ type Document struct {
 // (matched against DepSpec.Type when a whole resource is bound), an
 // implementation selector, that impl's dependencies on other
 // resources, and its opaque settings subtree (strictly decoded by the
-// registered ResourceFactory).
+// registered config.Factory).
 type ResourceEntry struct {
 	Kind string `json:"kind"`
 	Impl string `json:"impl"`
@@ -62,7 +62,7 @@ type ResourceEntry struct {
 
 	// Deps binds factory-declared dependency names to other resources
 	// (or host sources). Build validates these names and required
-	// bindings against ResourceSpec.Deps before calling the factory.
+	// bindings against config.Spec.Deps before calling the factory.
 	Deps map[string]DepRef `json:"deps,omitempty"`
 
 	Settings json.RawMessage `json:"settings,omitempty"`
@@ -88,10 +88,11 @@ type AgentEntry struct {
 	// promoted to Run.ToolAllowList by the harness).
 	Tools []string `json:"tools,omitempty"`
 
-	// Engine selects an engine kind from the agent.Registry.
+	// Engine selects an engine kind from the engine factories registered
+	// on the Builder.
 	Engine EngineEntry `json:"engine"`
 
-	// Deps binds EngineSpec-declared dep names to resources or
+	// Deps binds Spec-declared dep names to resources or
 	// sources.
 	Deps map[string]DepRef `json:"deps,omitempty"`
 


### PR DESCRIPTION
## Motivation

Prepares the `sdk` v0.5.0 breaking release. The existing
`docs/migrations/v0.5.0.md` was a temporary in-repo note that referenced APIs
that never shipped in any released 0.4.x tag (e.g. `config.ResourceFactory`,
`SubDocument`, `deploy.NewBuilder(agent.Registry, ...)`). This PR rewrites the
migration guide against the real `sdk/v0.4.8` → `main` diff and adds the
release changeset so the Release modules workflow can generate the changelog.

## Changes

- Rewrite `docs/migrations/v0.5.0.md` against the actual 0.4.x → 0.5.0
  changes: `sdk/engine` → `sdk/agent`, `sdk/llm|embedding|model` →
  `sdk/inference` + `sdk/message`, graph rewrite, memory-domain removal,
  actor→agent identity, sandbox nsjail→bwrap with network enforcement, and the
  new `sdk/config` (`Factory` / `Source` / `Loader`) + `sdkx/deploy` assembly
  protocol.
- Link the migration guide from `docs/index.md`.
- Add `.release/sdk.json` changeset (`sdk`, `minor`) — the Release modules
  workflow will aggregate it into `CHANGELOG.md` and open the Release PR.
- Fix stale doc comments referencing removed APIs (`agent.Factory`,
  `agent.Registry`, `ResourceSpec`, `ResourceFactory`, `EngineSpec`) in
  `sdk/graph/config` and `sdkx/deploy`.

## Verification

- `make release-check` passes: `changesets valid`, plan
  `sdk: 0.4.8 -> 0.5.0 (minor), tag sdk/v0.5.0`.
- `git diff --check` clean.