### PR TITLE
fix(release): quote jq tag bullets in changelog PR body

### DIFF
--- a/.github/workflows/release-modules.yml
+++ b/.github/workflows/release-modules.yml
@@ -143,7 +143,7 @@ jobs:
               echo "Aggregates all pending immutable changesets into \`CHANGELOG.md\`."
               echo
               echo "Planned tags:"
-              jq -r '.[] | \"- `\" + . + \"`\"' <<< "$TAGS_JSON"
+              jq -r '.[] | "- `" + . + "`"' <<< "$TAGS_JSON"
               echo
               echo "Merging this PR reruns the module release gates and publishes all planned tags atomically."
             } > "$body_file"


### PR DESCRIPTION
## Motivation

The "Release modules" workflow failed on its first real changeset run
([run 31254885752](https://github.com/GizClaw/flowcraft/actions/runs/31254885752)):
the `Prepare release changelog PR` step crashed with

```
jq: error: syntax error, unexpected INVALID_CHARACTER ... at <top-level>, line 1:
.[] | \"- `\" + . + \"`\"
```

The `\"` escapes inside the single-quoted jq program are passed to bash
verbatim (literal backslashes + backticks), so jq rejects the program before
the changelog Release PR body is written.

## Fix

```diff
-              jq -r '.[] | \"- `\" + . + \"`\"' <<< "$TAGS_JSON"
+              jq -r '.[] | "- `" + . + "`"' <<< "$TAGS_JSON"
```

With the quotes unescaped the jq program is `.[] | "- `" + . + "`"`, which
emits Markdown bullets such as ``- `sdk/v0.5.0` `` for each planned tag.

## Verification

- Reproduced the failing jq program locally and confirmed the fixed form
  produces the intended output (no `jq` binary in the sandbox; validated via
  the YAML-parsed step script and Python emulation of the jq pipeline).
- `.github/workflows/release-modules.yml` still parses as valid YAML with
  jobs `plan` / `gate` / `eval` / `tag`.
- `git diff --check` clean.

After this merges, the push to `main` re-triggers the "Release modules"
workflow; it will refresh the existing `automation/release-changelog` branch
and open the changelog Release PR.