### PR TITLE
docs(release): refresh changelog header and released state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,16 +9,23 @@ Release PR before their tags are published.
 
 ## Current Published State
 
-| Module | Latest tag | Notes |
-| --- | --- | --- |
-| `sdk` | `sdk/v0.5.0` | Core agent, engine, graph, LLM, tool, workspace, event, and telemetry primitives. |
-| `memory` | `memory/v0.1.0` | First standalone memory-domain release: recall v2, history, knowledge, retrieval, text, and stores. |
-| `sdkx` | `sdkx/v0.4.0` | Provider/adaptor release pinned to `sdk v0.4.0` and `memory v0.1.0`. |
-| `vessel` | `vessel/v0.3.0` | Retired; historical tags remain available, but source and active support have been removed from `main`. |
-| `voice` | `voice/v0.2.0` | Voice pipeline module. |
-| `cmd/vesseld` | `vesseld/v0.1.0` | Retired; historical release artifacts remain available, but no further releases are planned. |
+| Module   | Latest tag      | Notes                                                                                     |
+| -------- | --------------- | ----------------------------------------------------------------------------------------- |
+| `sdk`    | `sdk/v0.5.0`    | Core agent, engine, graph, LLM, tool, workspace, event, and telemetry primitives.         |
+| `memory` | `memory/v0.1.7` | Standalone memory-domain module: recall, history, knowledge, retrieval, text, and stores. |
+| `sdkx`   | `sdkx/v0.4.10`  | Provider/adaptor release pinned to `sdk v0.4.8` and `memory v0.1.7`.                      |
 
 ## [Unreleased]
+
+_No pending changes._
+
+<!-- releasegate:releases -->
+
+## `sdk/v0.5.0` - 2026-08-08
+
+### Changed
+
+- Breaking cleanup: remove v0.4.x deprecated surfaces and land the unified runtime (engine into agent, llm/embedding/model into inference+message), the config.Factory/Source/Loader build protocol, and bubblewrap sandbox with network enforcement
 
 ### Removed
 
@@ -36,14 +43,6 @@ Release PR before their tags are published.
   `sdk/workspace`. Model-driven file memory is an application concern: build it
   on `sdk/workspace` in application-owned code, or attach a filesystem MCP
   server through `sdkx/tool/mcp`.
-
-<!-- releasegate:releases -->
-
-## `sdk/v0.5.0` - 2026-08-08
-
-### Changed
-
-- Breaking cleanup: remove v0.4.x deprecated surfaces and land the unified runtime (engine into agent, llm/embedding/model into inference+message), the config.Factory/Source/Loader build protocol, and bubblewrap sandbox with network enforcement
 
 ## `sdk/v0.4.0` - 2026-05-30
 


### PR DESCRIPTION
## Motivation

After `sdk/v0.5.0` shipped, the top of `CHANGELOG.md` was stale:

- The **Current Published State** table still listed `memory/v0.1.0`,
  `sdkx/v0.4.0`, and `voice/v0.2.0`, while the actual latest tags are
  `memory/v0.1.7`, `sdkx/v0.4.10`, and `voice/v0.2.2`; the `sdkx` note still
  claimed pins to `sdk v0.4.0` / `memory v0.1.0`.
- The table retained rows for `vessel` / `cmd/vesseld` (retired) and `voice`
  (source removed from `main` in the unified-runtime refactor).
- `[Unreleased]` still listed removals that were released in `sdk/v0.5.0`.

## Changes

- Published State: keep the active modules (`sdk`, `memory`, `sdkx`), drop the
  retired/removed rows, bump `memory` → `memory/v0.1.7` and `sdkx` →
  `sdkx/v0.4.10`, and fix the `sdkx` pin note (`sdk v0.4.8` + `memory v0.1.7`).
- `[Unreleased]`: cleared to "No pending changes."
- Moved the four removal bullets into the released `## sdk/v0.5.0` section under
  a new `### Removed` heading so the history is preserved next to the tag.

## Verification

- `git diff --check` clean.
- Only `CHANGELOG.md` touched; unrelated working-tree changes (e.g.
  `sdkx/go.mod` dependency work) intentionally not included.