### PR TITLE
docs(release): prepare sdkx v0.5.0 release and run make release-changelog in CI

### DIFF
--- a/.github/workflows/release-modules.yml
+++ b/.github/workflows/release-modules.yml
@@ -70,10 +70,7 @@ jobs:
           TAGS_JSON: ${{ steps.plan.outputs.tags }}
         run: |
           set -euo pipefail
-          (
-            cd tools/releasegate
-            GOWORK=off go run . changelog --repo ../.. --write
-          )
+          make release-changelog
           if git diff --quiet -- CHANGELOG.md; then
             while read -r tag; do
               heading_line=$(awk -v heading="## \`$tag\` -" \

--- a/.release/sdkx.json
+++ b/.release/sdkx.json
@@ -1,0 +1,9 @@
+{
+  "summary": "sdkx v0.5.0: unify provider adapters under sdkx/inference, land deploy/runtime/scheduler/delegation and A2A assembly, swap nsjail for bubblewrap, and remove the legacy 0.4.x surfaces",
+  "releases": [
+    {
+      "module": "sdkx",
+      "bump": "minor"
+    }
+  ]
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,13 +13,21 @@ Release PR before their tags are published.
 | -------- | --------------- | ----------------------------------------------------------------------------------------- |
 | `sdk`    | `sdk/v0.5.0`    | Core agent, engine, graph, LLM, tool, workspace, event, and telemetry primitives.         |
 | `memory` | `memory/v0.1.7` | Standalone memory-domain module: recall, history, knowledge, retrieval, text, and stores. |
-| `sdkx`   | `sdkx/v0.4.10`  | Provider/adaptor release pinned to `sdk v0.4.8` and `memory v0.1.7`.                      |
+| `sdkx`   | `sdkx/v0.5.0`  | Provider/adaptor release pinned to `sdk v0.5.0`.                                            |
 
 ## [Unreleased]
 
-_No pending changes._
+- `sdkx/v0.5.0` — pending release: unified `sdkx/inference` providers,
+  `deploy`/`runtime`/`scheduler`/`delegation` assembly, bubblewrap sandbox,
+  and the A2A remote-proxy engine.
 
 <!-- releasegate:releases -->
+
+## `sdkx/v0.5.0` - 2026-08-08
+
+### Changed
+
+- sdkx v0.5.0: unify provider adapters under sdkx/inference, land deploy/runtime/scheduler/delegation and A2A assembly, swap nsjail for bubblewrap, and remove the legacy 0.4.x surfaces
 
 ## `sdk/v0.5.0` - 2026-08-08
 
@@ -156,19 +164,6 @@ General availability of the standalone daemon.
   secret providers, and TLS resolver helpers landed after `vesseld/v0.1.0`.
   These are documented in current README/examples and will be captured by the
   next daemon binary release tag.
-
-## `sdkx/v0.3.x` - 2026-05-09 to 2026-05-17
-
-Provider-adapter line paired with `sdk/v0.3.x`.
-
-### Highlights
-
-- Moved tool implementations for history, knowledge, and kanban into
-  `sdkx/tool/...` while keeping public signatures stable for migrated callers.
-- Added prompt-cache routing/markers and cache-token normalization for supported
-  providers.
-- Added nsjail sandbox backend and provider-name telemetry overrides.
-- Removed `sdkx/knowledge/watcher` alongside the SDK knowledge watcher cleanup.
 
 ## `vessel/v0.1.0` - 2026-05-11
 

--- a/docs/guides/deploy.md
+++ b/docs/guides/deploy.md
@@ -318,6 +318,7 @@ explicit external consumer is dead configuration and fails the build.
 | `tool.Assembly`           | `yaml`          | catalog + executor              | `sdk/tool/config`              |
 | `agent.ScriptRuntime`     | `js`            | JavaScript runtime              | `sdkx/agent/jsrt`               |
 | `agent.ScriptRuntime`     | `lua`           | Lua runtime                     | `sdkx/agent/luart`              |
+| `agent.Engine`            | `a2a`           | A2A remote-proxy engine (0.3 + 1.0, JSON-RPC + gRPC) | `sdkx/agent/a2a/config`          |
 | `event.Bus`               | `memory`        | in-process bus                  | `sdk/event/config`             |
 | `delegation.AsyncBackend` | `kanban-memory` | asynchronous delegation backend | `sdkx/delegation/kanban/config` |
 | `scheduler.Server`        | `local`         | shared scheduler server         | `sdk/scheduler/config`         |
@@ -997,6 +998,8 @@ warms up its catalog on first use).
   `sdk/tool/config/doc.go`, `sdk/event/config/resource.go`,
   `sdk/memory` and the implementation module.
 - Engine contract: `sdk/agent/doc.go`, `sdk/graph/config/factory.go`.
+- A2A remote-proxy engine: `sdkx/agent/a2a/doc.go`,
+  `sdkx/agent/a2a/config/factory.go` (engine kind `a2a`).
 - Delegation contracts and local runtime: `sdk/delegation/doc.go`,
   `sdkx/delegation/doc.go`, `sdkx/tool/delegation/doc.go`.
 - Lifecycle hooks: `sdk/agent/doc.go` (`Preparer`, `Referee`,

--- a/docs/index.md
+++ b/docs/index.md
@@ -43,6 +43,9 @@ retrieval, runtime orchestration, and voice. Source on
 
 - [`sdk/v0.5.0`](migrations/v0.5.0.md) — unified runtime, configuration
   protocol, and sandbox cutover.
+- [`sdkx/v0.5.0`](migrations/sdkx-v0.5.0.md) — unified provider adapters,
+  deploy/runtime assembly, bubblewrap sandbox, and the A2A remote-proxy
+  engine.
 - [`sdk/v0.4.0` + `memory/v0.1.0`](migrations/v0.4.0-memory-split.md) —
   memory-domain packages split into the standalone `memory` module.
 - [`sdk/v0.3.0`](migrations/v0.3.0.md) — breaking-change cutover

--- a/docs/migrations/sdkx-v0.5.0.md
+++ b/docs/migrations/sdkx-v0.5.0.md
@@ -1,0 +1,137 @@
+# Migrating to sdkx v0.5.0
+
+> Status: `sdkx/v0.5.0`, coordinated with `sdk/v0.5.0`. This release pins
+> `sdk v0.5.0` and rebuilds the provider / adapter layer accumulated through
+> the `v0.4.x` line: the legacy inference stacks are unified under
+> `sdkx/inference`, the sandbox backend moves from nsjail to bubblewrap, the
+> assembly surface (`deploy`, `runtime`, `scheduler`, `delegation`, `memory`
+> glue) becomes the supported way to wire applications, and the deprecated
+> `0.4.x` adapters are removed in one cut.
+
+## Summary
+
+`sdkx/v0.5.0` is the provider / adapter half of the "unified runtime"
+cutover documented in [`v0.5.0.md`](v0.5.0.md). Four themes drive it:
+
+1. **Unified inference providers** — `sdkx/llm/<provider>` and
+   `sdkx/embedding/<provider>` are gone. Providers implement the
+   `sdk/inference` compiler contract in `sdkx/inference/<provider>`, with
+   hardened protocol options, provider request/response ID propagation to
+   telemetry, and the `sdk/inference` router's retry / backoff / circuit
+   breaker.
+2. **Sandbox cutover** — `sdkx/sandbox/nsjail` is replaced by
+   `sdkx/sandbox/bwrap` (Linux, namespace-level FS/net with network policy)
+   and `sdkx/sandbox/seatbelt` (macOS).
+3. **Assembly surface** — `sdkx/deploy` (one YAML document → runnable
+   `Instance`s), `sdkx/runtime` (+ `sdkx/runtime/session`), `sdkx/scheduler`,
+   `sdkx/delegation` (+ `kanban` backend), and `sdkx/memory` (`hook`,
+   `render`) become the supported composition layer built on the unified
+   `sdk/config` `Factory` / `Source` / `Loader` protocol.
+4. **Legacy removal** — `sdkx/engine`, `sdkx/claw`, `sdkx/extract`,
+   `sdkx/recall`, `sdkx/retrieval`, and `sdkx/tool/{history,knowledge,kanban,
+   memory}` are deleted; the module drops its `memory` module dependency.
+
+---
+
+## Module surface changes (vs `sdkx/v0.4.x`)
+
+### Removed
+
+| Removed (`sdkx`)                                   | Replacement                                                                              |
+| -------------------------------------------------- | ---------------------------------------------------------------------------------------- |
+| `sdkx/llm/<provider>`, `sdkx/embedding/<provider>` | `sdkx/inference/<provider>` — providers implement the `sdk/inference` compiler contract |
+| `sdkx/engine`, `sdkx/claw`, `sdkx/extract`         | removed with the legacy runtimes                                                          |
+| `sdkx/recall`, `sdkx/retrieval`                    | the `memory` module's own stores and adapters                                             |
+| `sdkx/tool/{history,knowledge,kanban,memory}`      | `sdkx/delegation/kanban`, `sdkx/tool/{mcp,delegation}`, application-owned tools          |
+| `sdkx/sandbox/nsjail`                              | `sdkx/sandbox/bwrap` (Linux) + `sdkx/sandbox/seatbelt` (macOS)                            |
+
+The `memory` module dependency carried by `sdkx/v0.4.x` for the deprecated
+retrieval wrappers is removed together with those wrappers; `sdkx/v0.5.0`
+depends only on `sdk v0.5.0`.
+
+### New
+
+- `sdkx/inference/<provider>` — unified provider adapters (anthropic, azure,
+  bytedance, deepseek, kimi, minimax, openai, qwen) plus protocol-level HTTP
+  options, provider request/response IDs in telemetry, and router
+  retry / backoff / circuit breaker integration.
+- `sdkx/agent/a2a` (+ `sdkx/agent/a2a/config`, engine kind `a2a`) — A2A
+  remote-proxy engine covering protocol 0.3 and 1.0 over JSON-RPC and gRPC,
+  with bearer/basic/custom auth and stream / poll modes.
+- `sdkx/agent/{jsrt,luart}` — script runtimes moved from the retired
+  `sdk/script` domain; register as `agent.ScriptRuntime` (`js` / `lua`).
+- `sdkx/deploy` — declarative assembly: one YAML document names shared
+  resources, agents, engines, and lifecycle hooks; one `Build` call produces
+  runnable `Instance`s. Document references use the unified `config.Source` /
+  `config.Loader` forms (`{file:}`, `{embed:}`) and are capped at 1 MiB.
+- `sdkx/runtime` (+ `sdkx/runtime/session`) — transport-neutral application
+  core above a `deploy.Result`: event router, integrations, session manager,
+  interruptible streaming turns.
+- `sdkx/delegation` (+ `sdkx/delegation/kanban` and its `config` resource) —
+  async delegation backend implementing the `sdk/delegation` contracts.
+- `sdkx/scheduler` — in-process cron / timer / execution-queue / lease /
+  memory and delegation adapters for `sdk/scheduler`.
+- `sdkx/memory` (`hook`, `render`) — generic memory glue on the `sdk/memory`
+  contracts (GoTemplate renderer, context/turn lifecycle hooks).
+- `sdkx/tool/mcp` — expanded MCP bridge (`adapter`, `config`, `source`,
+  `transport`, `errors`); `sdkx/tool/delegation` — `delegate` /
+  `delegation_status` tools.
+- `sdkx/workspace/objstore/s3` — S3 object-store driver registration updated
+  for the tightened storage contract.
+
+### Included from the `v0.4.x` line
+
+The `0.4.x` line accumulated provider work that this release rebuilds and
+carries forward, most of which now lives in `sdkx/inference/<provider>`:
+
+- OpenAI Responses API adapters and stream-error handling.
+- MiniMax OpenAI-compatible provider, ByteDance Responses API cutover, and
+  Anthropic thinking-option wiring.
+- Provider HTTP-client hardening (protocol options) and request/response ID
+  telemetry.
+
+## Upgrade path
+
+1. **Bump modules** — `sdk` first, then `sdkx` (pins `sdk v0.5.0`):
+
+   ```bash
+   go get github.com/GizClaw/flowcraft/sdk@v0.5.0
+   go get github.com/GizClaw/flowcraft/sdkx@v0.5.0
+   go mod tidy
+   ```
+
+2. **Provider imports** — `sdkx/llm/*` and `sdkx/embedding/*` →
+   `sdkx/inference/*`; providers now implement the `sdk/inference` compiler
+   contract instead of the removed `sdk/llm` / `sdk/embedding` surfaces.
+3. **Sandbox** — switch `nsjail` configurations to `sdkx/sandbox/bwrap`
+   (Linux) or `sdkx/sandbox/seatbelt` (macOS) and honor the network policy
+   (non-default net modes need a namespace/container backend).
+4. **Memory adapters** — stop importing `sdkx/recall`, `sdkx/retrieval`, and
+   `sdkx/tool/{history,knowledge,kanban,memory}`; depend on the `memory`
+   module for storage and on `sdkx/delegation/kanban` +
+   `sdkx/tool/{mcp,delegation}` for the tool surface.
+5. **Assembly** — if you adopt `sdkx/deploy`, use the new `config.Source`
+   forms (`{file:}`, `{embed:}`), keep documents under 1 MiB, and register
+   every factory / engine kind before `Build`; `sdkx/runtime` owns the
+   deployment result and process lifecycle.
+
+## Backwards compatibility
+
+- No global shim. All `v0.4.x`-era deprecation surfaces listed above are
+  removed in this release.
+- `sdkx` no longer depends on the `memory` module; applications that need
+  memory storage depend on `memory` directly.
+- The `sdk/v0.5.0` migration guide remains the reference for the SDK-side
+  cutover (`sdk/engine`, `sdk/llm`, `sdk/embedding`, `sdk/model`,
+  `sdk/script` → `sdk/agent` + `sdk/inference` + `sdk/message` +
+  `sdk/config`).
+
+## Timeline
+
+- **`sdkx/v0.4.x`** (released): deprecation window — legacy adapters stayed
+  importable while the `sdk` and `memory` modules prepared the split.
+- **`sdk/v0.5.0`** (released 2026-08-08): SDK-side unified-runtime cutover.
+- **`sdkx/v0.5.0`** (this release): provider / adapter rebuild pinned to
+  `sdk v0.5.0`; all breaking changes above land as one cut.
+- **`memory`** (pending): awaits its own coordinated pin bump to
+  `sdk v0.5.0`; see the memory module's release notes.

--- a/docs/migrations/v0.5.0.md
+++ b/docs/migrations/v0.5.0.md
@@ -1,11 +1,12 @@
 # Migrating to SDK v0.5.0
 
-> Status: planned for `sdk/v0.5.0`. The release is the "unified runtime"
-> cutover: the execution, model, and configuration stacks are consolidated
-> into `sdk/agent` + `sdk/inference` + `sdk/message` + `sdk/config`, the
-> memory domain leaves the foundational SDK, and the sandbox backend moves
-> from nsjail to bubblewrap with network enforcement. `sdkx` and `memory`
-> follow with coordinated pins to `sdk v0.5.0`.
+> Status: `sdk/v0.5.0` (released 2026-08-08). The release is the "unified
+> runtime" cutover: the execution, model, and configuration stacks are
+> consolidated into `sdk/agent` + `sdk/inference` + `sdk/message` +
+> `sdk/config`, the memory domain leaves the foundational SDK, and the
+> sandbox backend moves from nsjail to bubblewrap with network enforcement.
+> `sdkx` follows as a coordinated release pinned to `sdk v0.5.0` (see
+> [`sdkx-v0.5.0.md`](sdkx-v0.5.0.md)); `memory` awaits its own pin bump.
 
 ## Summary
 
@@ -84,7 +85,8 @@ memory-domain packages) are deleted in one cut.
 ### Coordinated `sdkx` changes
 
 The same window rebuilds the provider/adaptor layer. `sdkx` follows `sdk` with
-a release pinned to `sdk v0.5.0`.
+a release pinned to `sdk v0.5.0`; see
+[`sdkx-v0.5.0.md`](sdkx-v0.5.0.md) for the adaptor and assembly moves.
 
 | Removed (`sdkx`)                                   | Replacement (`sdkx`)                                                                    |
 | -------------------------------------------------- | --------------------------------------------------------------------------------------- |
@@ -374,6 +376,7 @@ Additive surface for new integrations:
   this window.
 - **`sdk/v0.5.0`** (this release): all breaking changes above land as one cut.
   Release notes reference this file.
-- **`memory` + `sdkx`** (follow `sdk/v0.5.0`): tagged once their `go.mod` pins
-  are bumped to `sdk v0.5.0`. Their breaking windows overlap this release; see
-  their own changelog/migration notes for the adaptor and storage moves.
+- **`sdkx/v0.5.0`** (coordinated): provider/adaptor rebuild pinned to
+  `sdk v0.5.0`; see [`sdkx-v0.5.0.md`](sdkx-v0.5.0.md).
+- **`memory`** (pending): awaits its own coordinated pin bump to
+  `sdk v0.5.0`; see the memory module's release notes.

--- a/tools/releasegate/main.go
+++ b/tools/releasegate/main.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"sort"
 	"strconv"
 	"strings"
@@ -591,19 +592,23 @@ func updatePublishedState(changelog string, modules []ModulePlan) (string, error
 	updated := make(map[string]bool, len(tags))
 	for index := tableStart; index < tableEnd; index++ {
 		line := lines[index]
-		for module, tag := range tags {
-			prefix := "| `" + module + "` |"
-			if !strings.HasPrefix(line, prefix) {
-				continue
-			}
-			cells := strings.Split(line, "|")
-			if len(cells) < 5 {
-				return "", fmt.Errorf("invalid Current Published State row for module %s", module)
-			}
-			cells[2] = " `" + tag + "` "
-			lines[index] = strings.Join(cells, "|")
-			updated[module] = true
+		cells := strings.Split(line, "|")
+		if len(cells) < 3 {
+			continue
 		}
+		module := strings.Trim(strings.TrimSpace(cells[1]), "`")
+		tag, ok := tags[module]
+		if !ok {
+			continue
+		}
+		oldRe := regexp.MustCompile("`" + regexp.QuoteMeta(module) +
+			"/v[0-9]+\\.[0-9]+\\.[0-9]+`")
+		old := oldRe.FindString(cells[2])
+		if old == "" {
+			return "", fmt.Errorf("Current Published State row for module %s has no version cell", module)
+		}
+		lines[index] = strings.Replace(line, old, "`"+tag+"`", 1)
+		updated[module] = true
 	}
 	for module := range tags {
 		if !updated[module] {

--- a/tools/releasegate/main_test.go
+++ b/tools/releasegate/main_test.go
@@ -461,6 +461,31 @@ func TestChangelogCLIPrintCheckAndWrite(t *testing.T) {
 	}
 }
 
+func TestChangelogUpdatesPaddedPublishedStateRow(t *testing.T) {
+	before := "# Changelog\n\n" +
+		"## Current Published State\n\n" +
+		"| Module   | Latest tag      | Notes\n" +
+		"| -------- | --------------- | ----------------------------------------------------------------------------------------- |\n" +
+		"| `sdk`    | `sdk/v0.5.0`    | Core agent, engine, graph, LLM, tool, workspace, event, and telemetry primitives.         |\n" +
+		"| `memory` | `memory/v0.1.7` | Standalone memory-domain module: recall, history, knowledge, retrieval, text, and stores. |\n" +
+		"| `sdkx`   | `sdkx/v0.4.10`  | Provider/adaptor release pinned to `sdk v0.4.8` and `memory v0.1.7`.                      |\n" +
+		"\n## [Unreleased]\n"
+	got, err := updatePublishedState(before, []ModulePlan{{Module: "sdkx", Tag: "sdkx/v0.5.0"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	wantSdkx := "| `sdkx`   | `sdkx/v0.5.0`  | Provider/adaptor release pinned to `sdk v0.4.8` and `memory v0.1.7`.                      |"
+	if !strings.Contains(got, wantSdkx) {
+		t.Fatalf("padded sdkx row not updated with padding preserved:\n%s", got)
+	}
+	if !strings.Contains(got, "| `sdk`    | `sdk/v0.5.0`    |") {
+		t.Fatalf("unrelated sdk row changed:\n%s", got)
+	}
+	if !strings.Contains(got, "| `memory` | `memory/v0.1.7` |") {
+		t.Fatalf("unrelated memory row changed:\n%s", got)
+	}
+}
+
 func TestChangelogOnlyUpdatesActiveModuleRows(t *testing.T) {
 	repo := changelogRepo(t, "sdk", "1.0.0")
 	writeFile(t, repo, "sdk/change.go", "package sdk\n\nconst Changed = true\n")


### PR DESCRIPTION
## Motivation

Prepares the `sdkx/v0.5.0` release. `sdkx` is still at `sdkx/v0.4.10` but the
working tree already pins `sdk v0.5.0` and carries the full unified-runtime
rebuild, so this PR lands the release documentation, the changeset, and the
changelog.

Also wires `make release-changelog` into the CI flow as requested, and fixes a
regression in `tools/releasegate` that broke changelog generation against the
padded "Current Published State" table.

## User-visible changes

- New `.release/sdkx.json` changeset: `sdkx` minor bump (`0.4.10 -> 0.5.0`).
- New migration guide `docs/migrations/sdkx-v0.5.0.md` covering the changes
  accumulated from the `0.4.x` line: `sdkx/llm` + `sdkx/embedding` ->
  `sdkx/inference`, `nsjail` -> `sdkx/sandbox/bwrap`/`seatbelt`, the new
  `deploy`/`runtime`/`scheduler`/`delegation`/A2A surface, and the removed
  legacy adapters.
- `CHANGELOG.md`: generated `## sdkx/v0.5.0` section + refreshed Current
  Published State row and `[Unreleased]` note.
- Docs index, `docs/guides/deploy.md` (A2A engine row + further reading), and
  `docs/migrations/v0.5.0.md` status/timeline refreshed.

## CI / tooling

- `ci.yml`: `make release-changelog` now runs in CI and fails when the
  committed `CHANGELOG.md` does not match what the generator produces.
- `release-modules.yml`: the release workflow invokes `make release-changelog`
  directly.
- `tools/releasegate`: `updatePublishedState` now parses table cells instead
  of requiring the old single-space table format, preserving column padding;
  regression test added (`TestChangelogUpdatesPaddedPublishedStateRow`).

## Test evidence

- `make release-check` passes (releasegate `-race` tests, changeset
  validation, plan shows `sdkx: 0.4.10 -> 0.5.0 (minor), tag sdkx/v0.5.0`).
- Idempotency: after committing the generated changelog, re-running
  `make release-changelog` produces no diff (the CI check).
- `gofmt`, `go vet`, `git diff --check`, and workflow YAML parsing pass.

Note: like the `sdk/v0.3.x` section removed during the `sdk/v0.5.0` release,
the generator drops the untagged `sdkx/v0.3.x` historical section while the
release is pending; it can be restored after `sdkx/v0.5.0` is tagged.
