### PR TITLE
revert(release): leave sdkx v0.5.0 changelog generation to CI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,21 +13,13 @@ Release PR before their tags are published.
 | -------- | --------------- | ----------------------------------------------------------------------------------------- |
 | `sdk`    | `sdk/v0.5.0`    | Core agent, engine, graph, LLM, tool, workspace, event, and telemetry primitives.         |
 | `memory` | `memory/v0.1.7` | Standalone memory-domain module: recall, history, knowledge, retrieval, text, and stores. |
-| `sdkx`   | `sdkx/v0.5.0`  | Provider/adaptor release pinned to `sdk v0.5.0`.                                            |
+| `sdkx`   | `sdkx/v0.4.10`  | Provider/adaptor release pinned to `sdk v0.4.8` and `memory v0.1.7`.                      |
 
 ## [Unreleased]
 
-- `sdkx/v0.5.0` — pending release: unified `sdkx/inference` providers,
-  `deploy`/`runtime`/`scheduler`/`delegation` assembly, bubblewrap sandbox,
-  and the A2A remote-proxy engine.
+_No pending changes._
 
 <!-- releasegate:releases -->
-
-## `sdkx/v0.5.0` - 2026-08-08
-
-### Changed
-
-- sdkx v0.5.0: unify provider adapters under sdkx/inference, land deploy/runtime/scheduler/delegation and A2A assembly, swap nsjail for bubblewrap, and remove the legacy 0.4.x surfaces
 
 ## `sdk/v0.5.0` - 2026-08-08
 
@@ -164,6 +156,19 @@ General availability of the standalone daemon.
   secret providers, and TLS resolver helpers landed after `vesseld/v0.1.0`.
   These are documented in current README/examples and will be captured by the
   next daemon binary release tag.
+
+## `sdkx/v0.3.x` - 2026-05-09 to 2026-05-17
+
+Provider-adapter line paired with `sdk/v0.3.x`.
+
+### Highlights
+
+- Moved tool implementations for history, knowledge, and kanban into
+  `sdkx/tool/...` while keeping public signatures stable for migrated callers.
+- Added prompt-cache routing/markers and cache-token normalization for supported
+  providers.
+- Added nsjail sandbox backend and provider-name telemetry overrides.
+- Removed `sdkx/knowledge/watcher` alongside the SDK knowledge watcher cleanup.
 
 ## `vessel/v0.1.0` - 2026-05-11
 


### PR DESCRIPTION
## Problem

The release workflow red: https://github.com/GizClaw/flowcraft/actions/runs/31258307248

PR #256 committed the generated `## sdkx/v0.5.0` CHANGELOG section by
hand. `release-modules.yml` ("Prepare release changelog PR") treats a
clean `CHANGELOG.md` (`git diff --quiet`) as "already generated" and then
requires the section to have been merged from the
`automation/release-changelog` branch; because the section came from the
changeset PR instead, the step fails with:
`generated changelog for sdkx/v0.5.0 was not merged from
GizClaw/flowcraft:automation/release-changelog`.

## Fix

Restore `CHANGELOG.md` to the pre-#256 state so the release workflow
takes the generation path: on the next push to `main` it runs
`make release-changelog` itself, opens the `automation/release-changelog`
PR, and only then publishes the `sdkx/v0.5.0` tag.

Verified locally: with this commit, `make release-changelog` produces a
diff against the committed `CHANGELOG.md`, so the automation will
regenerate the section instead of failing the verification branch.
