### PR TITLE
fix(sdk,sdkx): snapshot route policy and align Azure Responses API

### DIFF
--- a/.release/sdk-inference-policy.json
+++ b/.release/sdk-inference-policy.json
@@ -1,0 +1,9 @@
+{
+  "summary": "Expose an owned route policy clone on the inference config Assembly",
+  "releases": [
+    {
+      "module": "sdk",
+      "bump": "patch"
+    }
+  ]
+}

--- a/.release/sdkx-azure-responses.json
+++ b/.release/sdkx-azure-responses.json
@@ -1,0 +1,9 @@
+{
+  "summary": "Use the deployment-less Azure Responses path and gate reasoning includes on model capability",
+  "releases": [
+    {
+      "module": "sdkx",
+      "bump": "patch"
+    }
+  ]
+}

--- a/sdk/inference/config/builder.go
+++ b/sdk/inference/config/builder.go
@@ -205,6 +205,11 @@ type Assembly struct {
 	// Router is nil when the document has no route section; callers then
 	// address exact models through Runtime directly.
 	Router *route.Router
+	// Policy is the route policy the Router was built from, or nil when the
+	// document has no route section. It is an owned copy, so consumers can
+	// inspect targets (for example to derive policy digests or validate
+	// stable embedding identities) without mutating the document.
+	Policy *route.Policy
 }
 
 // ResolveItem exposes the exact inference runtime as "runtime" while
@@ -235,6 +240,8 @@ func (b *Builder) NewAssembly(
 	}
 	assembly := Assembly{Runtime: runtime}
 	if document.Route != nil {
+		clonedPolicy := document.Route.Clone()
+		assembly.Policy = &clonedPolicy
 		options, err := document.Route.Options()
 		if err != nil {
 			return Assembly{}, fmt.Errorf("build route options: %w", err)

--- a/sdk/inference/config/route_test.go
+++ b/sdk/inference/config/route_test.go
@@ -259,6 +259,13 @@ func TestBuilderNewAssembly(t *testing.T) {
 		if assembly.Runtime == nil || assembly.Router == nil {
 			t.Fatalf("assembly = %+v, want runtime and router", assembly)
 		}
+		if assembly.Policy == nil || len(assembly.Policy.Generate) != 1 ||
+			len(assembly.Policy.Generate[0].Targets) != 1 ||
+			assembly.Policy.Generate[0].Targets[0].Model != (inference.ModelRef{
+				ID: inference.ModelID{Provider: "fake", Name: "model"},
+			}) {
+			t.Fatalf("assembly policy = %+v", assembly.Policy)
+		}
 		response, trace, err := assembly.Router.Generate(
 			t.Context(),
 			inference.GenerateRequest{

--- a/sdkx/go.mod
+++ b/sdkx/go.mod
@@ -2,7 +2,7 @@ module github.com/GizClaw/flowcraft/sdkx
 
 go 1.26.0
 
-require github.com/GizClaw/flowcraft/sdk v0.5.0
+require github.com/GizClaw/flowcraft/sdk v0.5.1
 
 require (
 	github.com/GizClaw/doubao-speech-go v0.0.0-20260723152315-fe8153366feb

--- a/sdkx/go.sum
+++ b/sdkx/go.sum
@@ -10,8 +10,6 @@ github.com/AzureAD/microsoft-authentication-library-for-go v1.2.2/go.mod h1:wP83
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/GizClaw/doubao-speech-go v0.0.0-20260723152315-fe8153366feb h1:iS4tRKtteioA1ZDrUqn2tGkBjM4fiQeRoqJx6E3dD34=
 github.com/GizClaw/doubao-speech-go v0.0.0-20260723152315-fe8153366feb/go.mod h1:4R3wUAZkYk1BSgzv+QVF+2SZPu3VDy8NvaQdNRYGgBs=
-github.com/GizClaw/flowcraft/sdk v0.5.0 h1:nbGTWg2RT/He5BtSWB+zTJseWsWdT7hckXmPq3T+a3o=
-github.com/GizClaw/flowcraft/sdk v0.5.0/go.mod h1:3p6UHZpLQOQYrBDobCw2THf7n8l+HEkB88Ct0usGvAs=
 github.com/Masterminds/semver/v3 v3.2.1 h1:RN9w6+7QoMeJVGyfmbcgs28Br8cvmnucEXnY0rYXWg0=
 github.com/Masterminds/semver/v3 v3.2.1/go.mod h1:qvl/7zhW3nngYb5+80sSMF+FG2BjYrf8m9wsX0PNOMQ=
 github.com/a2aproject/a2a-go v0.3.15 h1:h5YpCiPq3jxQ5rIns7oDjPag3ivP8u817AzdA4F+NiI=

--- a/sdkx/inference/azure/azure_test.go
+++ b/sdkx/inference/azure/azure_test.go
@@ -154,14 +154,14 @@ func azureModel(name string) inference.ModelRef {
 }
 
 // TestGenerateEndToEnd drives the kernel generate driver against a captured
-// server and pins the Azure request shape: the deployment-scoped path plus
-// the api-version query and api-key header.
+// server and pins the Azure request shape: the deployment-less Responses
+// path plus the api-version query and api-key header.
 func TestGenerateEndToEnd(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(
 		w http.ResponseWriter,
 		r *http.Request,
 	) {
-		if r.URL.Path != "/openai/deployments/chat-1/responses" {
+		if r.URL.Path != "/openai/responses" {
 			t.Errorf("path = %q", r.URL.Path)
 		}
 		if r.URL.Query().Get("api-version") != DefaultAPIVersion {

--- a/sdkx/inference/azure/client.go
+++ b/sdkx/inference/azure/client.go
@@ -1,12 +1,7 @@
 package azure
 
 import (
-	"bytes"
-	"encoding/json"
 	"fmt"
-	"io"
-	"net/http"
-	"net/url"
 	"strings"
 
 	"github.com/GizClaw/flowcraft/sdk/inference/config"
@@ -61,7 +56,6 @@ func (m profileMaterial) newClients(spec Spec) *clients {
 	options := []option.RequestOption{
 		azure.WithEndpoint(strings.TrimSuffix(spec.Endpoint, "/"), version),
 		azure.WithAPIKey(m.apiKey),
-		option.WithMiddleware(deploymentRouteMiddleware),
 	}
 	if spec.HTTPRetries != nil {
 		options = append(options, sdkMaxRetriesOption(*spec.HTTPRetries))
@@ -78,34 +72,4 @@ func sdkMaxRetriesOption(total int) option.RequestOption {
 		return option.WithMaxRetries(0)
 	}
 	return option.WithMaxRetries(total - 1)
-}
-
-// deploymentRouteMiddleware scopes the Responses API route to its
-// deployment. The pinned SDK's azure middleware predates the Responses API
-// and only rewrites chat completions, embeddings, speech, images, and
-// transcriptions; /openai/responses would otherwise hit the deployment-less
-// path and 404. The rewrite mirrors the SDK's own getJSONRoute.
-func deploymentRouteMiddleware(
-	r *http.Request,
-	next option.MiddlewareNext,
-) (*http.Response, error) {
-	if r.URL.Path != "/openai/responses" || r.Body == nil {
-		return next(r)
-	}
-	payload, err := io.ReadAll(r.Body)
-	if err != nil {
-		return nil, err
-	}
-	r.Body = io.NopCloser(bytes.NewReader(payload))
-	var envelope struct {
-		Model string `json:"model"`
-	}
-	if err := json.Unmarshal(payload, &envelope); err != nil {
-		return nil, err
-	}
-	if envelope.Model != "" {
-		r.URL.Path = "/openai/deployments/" +
-			url.PathEscape(envelope.Model) + "/responses"
-	}
-	return next(r)
 }

--- a/sdkx/inference/openai/generate.go
+++ b/sdkx/inference/openai/generate.go
@@ -32,6 +32,11 @@ type generateWire struct {
 	tools       []wireTool
 	toolChoice  *wireToolChoice
 	stream      bool
+	// includeReasoning asks the Responses API to attach the encrypted
+	// reasoning payload. Only reasoning models can carry it; Azure rejects
+	// the include on plain chat models, so it must follow the capability
+	// declaration instead of being unconditional.
+	includeReasoning bool
 }
 
 type wireItemKind string
@@ -293,8 +298,9 @@ func compileGenerate(
 			request.ActiveFieldsFor(shape),
 		)
 		wire := generateWire{
-			model:  model,
-			stream: shape == inference.GenerateExecutionStream,
+			model:            model,
+			stream:           shape == inference.GenerateExecutionStream,
+			includeReasoning: entry.reasoning,
 		}
 
 		// Context messages → items. System stays a native system-role item;

--- a/sdkx/inference/openai/generate_openai.go
+++ b/sdkx/inference/openai/generate_openai.go
@@ -66,13 +66,15 @@ func wireToParams(wire generateWire) responses.ResponseNewParams {
 	params := responses.ResponseNewParams{
 		Model: wire.model,
 		Input: responses.ResponseNewParamsInputUnion{OfInputItemList: items},
-		// Reasoning traces are worthless to consumers without their
-		// encrypted payload: without it the reasoning cannot round-trip
-		// into later context, which breaks agent loops silently. The
-		// include flag costs nothing on non-reasoning models.
-		Include: []responses.ResponseIncludable{
+	}
+	// Reasoning traces are worthless to consumers without their encrypted
+	// payload: without it the reasoning cannot round-trip into later
+	// context, which breaks agent loops silently. Only reasoning models
+	// accept the include; Azure rejects it on plain chat deployments.
+	if wire.includeReasoning {
+		params.Include = []responses.ResponseIncludable{
 			responses.ResponseIncludableReasoningEncryptedContent,
-		},
+		}
 	}
 	if wire.maxTokens != nil {
 		params.MaxOutputTokens = param.NewOpt(*wire.maxTokens)


### PR DESCRIPTION
## What

- sdk: expose an owned `route.Policy` clone on the inference config `Assembly` so consumers can inspect route targets without mutating the document.
- sdkx/azure: drop the deployment-rewrite middleware and use the deployment-less `/openai/responses` path (model in body), matching the current Azure Responses API.
- sdkx/openai: send `reasoning.encrypted_content` only when the model declares the reasoning capability, fixing Azure rejection on plain chat deployments.

## Release

Adds immutable changesets:

- `.release/sdk-inference-policy.json` -> sdk patch (sdk/v0.5.1)
- `.release/sdkx-azure-responses.json` -> sdkx patch (sdkx/v0.5.1)

`make release-check` / `make release-plan` confirms the planned tags:

- sdk: 0.5.0 -> 0.5.1 (patch), tag sdk/v0.5.1
- sdkx: 0.5.0 -> 0.5.1 (patch), tag sdkx/v0.5.1

sdkx is pinned to same-batch sdk v0.5.1; sdkx go.sum updated so the release tidy gate is clean.

## Gates

- sdk/sdkx: go vet, go test, golangci-lint all pass
- releasegate validate + plan pass
- git diff --check clean