### PR TITLE
fix(release): prepare isolated modfile from the module directory

### DIFF
--- a/.github/workflows/release-modules.yml
+++ b/.github/workflows/release-modules.yml
@@ -178,17 +178,17 @@ jobs:
 
       - name: Prepare isolated module file
         id: modfile
+        working-directory: ${{ matrix.release.dir }}
         env:
           MODULE: ${{ matrix.release.module }}
-          MODULE_DIR: ${{ matrix.release.dir }}
           RELEASES_JSON: ${{ needs.plan.outputs.modules }}
         run: |
           set -euo pipefail
           modfile="$RUNNER_TEMP/${MODULE}.mod"
           sumfile="$RUNNER_TEMP/${MODULE}.sum"
-          cp "$MODULE_DIR/go.mod" "$modfile"
-          if [ -f "$MODULE_DIR/go.sum" ]; then
-            cp "$MODULE_DIR/go.sum" "$sumfile"
+          cp go.mod "$modfile"
+          if [ -f go.sum ]; then
+            cp go.sum "$sumfile"
           else
             : > "$sumfile"
           fi


### PR DESCRIPTION
## Problem

The Release modules gate for same-batch releases fails in `Prepare isolated module file`:

```
go: cannot find main module, but -modfile was set.
        -modfile cannot be used to set the module root directory.
```

The step runs `go mod edit -modfile=$RUNNER_TEMP/${MODULE}.mod` from the repository root, which is not a Go module. The v0.5.0 tags avoided this because sdk and sdkx were released in separate batches, so no same-batch replace was needed; the current sdk v0.5.1 + sdkx v0.5.1 batch hits it every time.

## Fix

Run the `Prepare isolated module file` step with `working-directory: ${{ matrix.release.dir }}` and copy `go.mod`/`go.sum` relative to that directory, matching the tidy/build/vet/test steps.

Validated locally: actionlint passes, and the exact prepare + `go mod tidy` flow for sdkx (replace sdk + memory to workspace paths, GOWORK=off) produces zero mod/sum diffs.

Merging this PR lets the pending release proceed: changelog for sdk/v0.5.1 and sdkx/v0.5.1 is already merged (#262), so the next Release modules run will publish both tags.