### PR TITLE
fix(sdkx): add missing sdk v0.5.1 checksums to go.sum

### DIFF
--- a/sdkx/go.sum
+++ b/sdkx/go.sum
@@ -10,6 +10,8 @@ github.com/AzureAD/microsoft-authentication-library-for-go v1.2.2/go.mod h1:wP83
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/GizClaw/doubao-speech-go v0.0.0-20260723152315-fe8153366feb h1:iS4tRKtteioA1ZDrUqn2tGkBjM4fiQeRoqJx6E3dD34=
 github.com/GizClaw/doubao-speech-go v0.0.0-20260723152315-fe8153366feb/go.mod h1:4R3wUAZkYk1BSgzv+QVF+2SZPu3VDy8NvaQdNRYGgBs=
+github.com/GizClaw/flowcraft/sdk v0.5.1 h1:8t5bere7fYf/VlWCxoMmMMZofQGbMAQY6f1SZLpbTEc=
+github.com/GizClaw/flowcraft/sdk v0.5.1/go.mod h1:3p6UHZpLQOQYrBDobCw2THf7n8l+HEkB88Ct0usGvAs=
 github.com/Masterminds/semver/v3 v3.2.1 h1:RN9w6+7QoMeJVGyfmbcgs28Br8cvmnucEXnY0rYXWg0=
 github.com/Masterminds/semver/v3 v3.2.1/go.mod h1:qvl/7zhW3nngYb5+80sSMF+FG2BjYrf8m9wsX0PNOMQ=
 github.com/a2aproject/a2a-go v0.3.15 h1:h5YpCiPq3jxQ5rIns7oDjPag3ivP8u817AzdA4F+NiI=


### PR DESCRIPTION
## Why

The `sdkx/v0.5.2` release gate failed at **Verify module is tidy** ([run 31352863513](https://github.com/GizClaw/flowcraft/actions/runs/31352863513)): with `GOWORK=off`, `go mod tidy` adds the missing `github.com/GizClaw/flowcraft/sdk v0.5.1` checksum entries to `sdkx/go.sum`. Workspace builds never noticed because sdk resolves locally via `go.work`.

## Change

- `sdkx/go.sum`: add the two missing `sdk v0.5.1` hash lines.

## Verification

- `GOWORK=off go mod tidy` in `sdkx` is now idempotent (no diff).
- `make release-check`: changesets valid; `sdkx: 0.5.1 -> 0.5.2 (patch), tag sdkx/v0.5.2`.

Merging this to `main` re-runs the module release workflow; CI will then publish the `sdkx/v0.5.2` tag.