### PR TITLE
fix(sdkx): drop stale sdk v0.5.1 checksums from go.sum

### DIFF
--- a/sdkx/go.sum
+++ b/sdkx/go.sum
@@ -10,8 +10,6 @@ github.com/AzureAD/microsoft-authentication-library-for-go v1.2.2/go.mod h1:wP83
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/GizClaw/doubao-speech-go v0.0.0-20260723152315-fe8153366feb h1:iS4tRKtteioA1ZDrUqn2tGkBjM4fiQeRoqJx6E3dD34=
 github.com/GizClaw/doubao-speech-go v0.0.0-20260723152315-fe8153366feb/go.mod h1:4R3wUAZkYk1BSgzv+QVF+2SZPu3VDy8NvaQdNRYGgBs=
-github.com/GizClaw/flowcraft/sdk v0.5.1 h1:8t5bere7fYf/VlWCxoMmMMZofQGbMAQY6f1SZLpbTEc=
-github.com/GizClaw/flowcraft/sdk v0.5.1/go.mod h1:3p6UHZpLQOQYrBDobCw2THf7n8l+HEkB88Ct0usGvAs=
 github.com/Masterminds/semver/v3 v3.2.1 h1:RN9w6+7QoMeJVGyfmbcgs28Br8cvmnucEXnY0rYXWg0=
 github.com/Masterminds/semver/v3 v3.2.1/go.mod h1:qvl/7zhW3nngYb5+80sSMF+FG2BjYrf8m9wsX0PNOMQ=
 github.com/a2aproject/a2a-go v0.3.15 h1:h5YpCiPq3jxQ5rIns7oDjPag3ivP8u817AzdA4F+NiI=


### PR DESCRIPTION
## Summary

Fixes the failed release gate on main (`Gate sdkx (Go 1.26) / Verify module is tidy`).

## Root cause

The release workflow runs `go mod tidy` with `GOWORK=off` and a temporary modfile that replaces `github.com/GizClaw/flowcraft/sdk` with the local module. Under that isolated module file, the committed `sdk v0.5.1` checksum lines in `sdkx/go.sum` are no longer needed and `go mod tidy` removes them, so the `diff` check fails.

## Fix

Remove the two stale `github.com/GizClaw/flowcraft/sdk v0.5.1` entries from `sdkx/go.sum`.

Verified locally by reproducing the release-gate steps (`GOWORK=off`, temporary modfile with the local sdk replace, `go mod tidy`): the resulting go.mod and go.sum are identical to the committed files.