### PR TITLE
fix(sdkx): add sdk v0.5.2 checksums to go.sum

### DIFF
--- a/sdkx/go.sum
+++ b/sdkx/go.sum
@@ -10,6 +10,8 @@ github.com/AzureAD/microsoft-authentication-library-for-go v1.2.2/go.mod h1:wP83
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/GizClaw/doubao-speech-go v0.0.0-20260723152315-fe8153366feb h1:iS4tRKtteioA1ZDrUqn2tGkBjM4fiQeRoqJx6E3dD34=
 github.com/GizClaw/doubao-speech-go v0.0.0-20260723152315-fe8153366feb/go.mod h1:4R3wUAZkYk1BSgzv+QVF+2SZPu3VDy8NvaQdNRYGgBs=
+github.com/GizClaw/flowcraft/sdk v0.5.2 h1:PoYMJ/ct8I0B0pR8QrKNpgLmdxPoAFDNqQUdxUyopLY=
+github.com/GizClaw/flowcraft/sdk v0.5.2/go.mod h1:3p6UHZpLQOQYrBDobCw2THf7n8l+HEkB88Ct0usGvAs=
 github.com/Masterminds/semver/v3 v3.2.1 h1:RN9w6+7QoMeJVGyfmbcgs28Br8cvmnucEXnY0rYXWg0=
 github.com/Masterminds/semver/v3 v3.2.1/go.mod h1:qvl/7zhW3nngYb5+80sSMF+FG2BjYrf8m9wsX0PNOMQ=
 github.com/a2aproject/a2a-go v0.3.15 h1:h5YpCiPq3jxQ5rIns7oDjPag3ivP8u817AzdA4F+NiI=


### PR DESCRIPTION
## Summary

Fixes the failed sdkx release gate (`Gate sdkx (Go 1.26) / Verify module is tidy`).

## Root cause

For the sdkx-only release (v0.5.4), the release workflow runs `go mod tidy` with `GOWORK=off` against the already-released `sdk v0.5.2` and no local replace. `sdkx/go.sum` was missing the `sdk v0.5.2` checksum lines, so tidy added them and the diff check failed.

## Fix

Add the two `github.com/GizClaw/flowcraft/sdk v0.5.2` checksum entries to `sdkx/go.sum`.

Verified locally by reproducing the release-gate steps (`GOWORK=off`, temporary modfile, `go mod tidy`): the resulting go.mod and go.sum are identical to the committed files.