### PR TITLE
feat(sandbox): ProcessManager sessions, policy-driven net proxy, MITM, and process events

### DIFF
--- a/docs/guides/sandbox.md
+++ b/docs/guides/sandbox.md
@@ -155,6 +155,57 @@ the defaults and always win; `WorkDir` / `Stdin` fall back to defaults when
 unset; `Timeout` takes the smaller of the two; `Env.Inject` is a union with
 the caller winning on key collision.
 
+## Interactive and streaming sessions (`ProcessManager`)
+
+`Runner.Exec` is one-shot: it captures output and returns. For
+interactive shells, TUIs, or long-running processes that need to be
+driven and resumed, a runner may additionally implement
+`ProcessManager`:
+
+```go
+type ProcessManager interface {
+    Start(ctx context.Context, spec ProcessSpec) (Process, error)
+    List(ctx context.Context) ([]ProcessInfo, error)
+    Terminate(ctx context.Context, id string) error
+}
+```
+
+`ProcessSpec` reuses the same `ExecOptions` policy surface as `Exec`
+(`WorkDir`, `Env`, `Net`, `Resources`, `Timeout`) plus `Argv`, an
+optional caller-chosen `ID`, and `TTY`. There is no second env source:
+the process environment comes exclusively from `ExecOptions.Env`.
+Discover the capability with `ProcessManagerOf(r)` — the same
+conservative pattern as `EnforcementOf`; a runner that cannot spawn
+sessions fails `Start` with `errdefs.NotAvailable`, never by silently
+running a one-shot exec.
+
+Output is an append-only, byte-cursor log. Each `Read(ctx, afterSeq,
+maxBytes)` returns at most `maxBytes` bytes starting after the cursor,
+plus the next cursor and an `EOF` flag; a disconnected client resumes
+by reconnecting and reading from its last `NextSeq`. The log is bounded
+by `Resources.MaxOutputBytes` — when old output has been trimmed, reads
+that point into the gap fail with `ErrSequenceGap` instead of returning
+misleading partial data. TTY sessions merge stdout/stderr into one
+`ProcessStreamTTY` stream; pipe sessions carry separate
+`ProcessStreamStdout` / `ProcessStreamStderr` chunks.
+
+Policy is fixed once at `Start`: `Read` / `Write` / `Resize` never
+re-negotiate env, network, or resource caps. The decorators forward the
+capability with the same semantics as `Exec`:
+
+- `WithDefaults` merges `spec.Opts` through the security-biased merge.
+- `WithApproval` runs the predicate chain against `Argv[0]` and
+  surfaces `TTY=true` on the `ExecRequest`, so the approver sees it is
+  authorising a persistent command channel rather than one command.
+- `AllowCommands` gates `Argv[0]`; note that it cannot police input
+  typed inside an interactive shell afterwards — an approved
+  interactive session is an all-or-nothing command channel.
+
+`LocalRunner` (pipe or pty), `seatbelt`, and `bwrap` implement
+`ProcessManager`; the sandboxed backends run the session inside the
+same profile / namespace as `Exec`, including net enforcement and the
+host-side proxy for `allow_list` / `proxy` modes.
+
 ## Workspace vs Sandbox
 
 |             | Workspace                            | Sandbox                             |

--- a/docs/guides/sandbox.md
+++ b/docs/guides/sandbox.md
@@ -68,6 +68,39 @@ group-wide memory and CPU-time caps with a sampling watcher and
 kills the whole process group on overflow. `DiskBytes` still needs
 a quota-capable backend and is rejected with `NotAvailable`.
 
+### Rules, SOCKS5, MITM, and unix sockets
+
+`NetPolicy` carries three optional refinements on top of `Mode` /
+`AllowHosts` / `Proxy`:
+
+- `Rules` are explicit host/port allow or deny rules. Host forms are
+  `example.com` (the domain and all subdomains), `*.example.com`
+  (subdomains only), `1.2.3.4`, and `10.0.0.0/8`. Deny rules are
+  evaluated first across the whole set and always win; `AllowHosts`
+  is compiled as trailing allow rules. When IP/CIDR rules exist the
+  proxy resolves hostnames locally and pins the dial to a validated
+  IP, so neither the upstream nor DNS rebinding can bypass them.
+- `Proxy` accepts `http://host:port` and `socks5://[user:pass@]
+  host:port`. SOCKS5 conversion happens host-side; the child still
+  speaks the plain HTTP proxy protocol to the enforcement proxy.
+  HTTP upstreams now also receive `Proxy-Authorization` on CONNECT.
+- `MITM` (opt-in) terminates TLS for CONNECT tunnels: the proxy signs
+  per-host leaf certificates from a temporary in-memory CA, runs
+  hooks (`OnConnect` / `OnRequest` / `OnResponse`), and injects the CA
+  into the child via `SSL_CERT_FILE` (bundle bind-mounted for bwrap,
+  host path for seatbelt). MITM v1 is HTTP/1.1 only — h2-only clients
+  are not intercepted.
+- `UnixSockets` is an allow-list of host unix socket paths. bwrap
+  bind-mounts only the listed paths (missing paths fail `Start`
+  loudly); seatbelt rejects any non-empty list with `NotAvailable`.
+  The "default deny" for bwrap is namespace-visibility based: masked
+  directories (`/tmp`, and `/run` in isolated net modes) hide
+  everything else, while the host root remains read-only visible.
+
+All features are gated by `Enforcement` (`Socks5`, `MITM`,
+`UnixSocketPolicy`); the config builder rejects a policy the backend
+cannot enforce with `NotAvailable`, never by silently downgrading.
+
 ### Enforcement
 
 `EnforcementOf(r)` returns an `Enforcement` struct describing what
@@ -200,6 +233,12 @@ capability with the same semantics as `Exec`:
 - `AllowCommands` gates `Argv[0]`; note that it cannot police input
   typed inside an interactive shell afterwards — an approved
   interactive session is an all-or-nothing command channel.
+
+In sandbox config, `approval.interactive: true` installs the
+`Interactive()` predicate, so every TTY session start crosses the
+approver before spawning. With no approver configured the chain fails
+closed, which is the recommended way to forbid interactive sessions
+entirely.
 
 `LocalRunner` (pipe or pty), `seatbelt`, and `bwrap` implement
 `ProcessManager`; the sandboxed backends run the session inside the

--- a/docs/guides/sandbox.md
+++ b/docs/guides/sandbox.md
@@ -88,8 +88,15 @@ a quota-capable backend and is rejected with `NotAvailable`.
   per-host leaf certificates from a temporary in-memory CA, runs
   hooks (`OnConnect` / `OnRequest` / `OnResponse`), and injects the CA
   into the child via `SSL_CERT_FILE` (bundle bind-mounted for bwrap,
-  host path for seatbelt). MITM v1 is HTTP/1.1 only — h2-only clients
-  are not intercepted.
+  host path for seatbelt). Both HTTP/1.1 and HTTP/2 clients are
+  terminated (ALPN offers h2 + http/1.1; h2-only clients like gRPC
+  work). Host selection is policy-driven: empty `hosts` MITMs
+  everything, `hosts` restricts the set, and `exclude_hosts` always
+  raw-tunnels (allow/deny rules still apply, content hooks do not).
+  Because pinned clients fail closed at TLS, deployments with
+  cert-pinning applications should list those destinations in
+  `exclude_hosts` — that is the explicit pass-through, never a silent
+  downgrade.
 - `UnixSockets` is an allow-list of host unix socket paths. bwrap
   bind-mounts only the listed paths (missing paths fail `Start`
   loudly); seatbelt rejects any non-empty list with `NotAvailable`.
@@ -100,6 +107,58 @@ a quota-capable backend and is rejected with `NotAvailable`.
 All features are gated by `Enforcement` (`Socks5`, `MITM`,
 `UnixSocketPolicy`); the config builder rejects a policy the backend
 cannot enforce with `NotAvailable`, never by silently downgrading.
+
+Complete sandbox document exercising every knob:
+
+```yaml
+version: v1
+sandboxes:
+  coding:
+    backend: bwrap            # or seatbelt on macOS / local for dev
+    workspace: project
+    defaults:
+      timeout: 2m
+      env:
+        allow: [PATH, HOME, GOCACHE]
+        inject: { CI: "1" }
+      net:
+        mode: allow_list
+        rules:
+          - action: deny
+            host: "*.internal.example"
+          - action: allow
+            host: "example.com"
+            port: 443
+          - action: allow
+            host: "10.0.0.0/8"
+        unix_sockets: [/var/run/docker.sock]
+        mitm:
+          enabled: true
+          inspect_bodies: false
+          max_body_bytes: 65536
+          exclude_hosts: ["*.nopin.example"]
+      resources:
+        memory_bytes: 2147483648
+        cpu_millicores: 2000
+        max_output_bytes: 10485760
+    allowed_commands: [go, pytest, node]
+    approval:
+      interactive: true        # TTY session starts require approval
+      non_default_network: true
+      sensitive_commands: [rm]
+```
+
+The SOCKS5 variant only changes the proxy string — the child still
+speaks plain HTTP proxy to the enforcement proxy:
+
+```yaml
+      net:
+        mode: proxy
+        proxy: socks5://user:pass@proxy.example:1080
+        rules:
+          - action: deny
+            host: "*.blocked.example"
+```
 
 ### Enforcement
 
@@ -244,6 +303,28 @@ entirely.
 `ProcessManager`; the sandboxed backends run the session inside the
 same profile / namespace as `Exec`, including net enforcement and the
 host-side proxy for `allow_list` / `proxy` modes.
+
+### Signals and event push
+
+Processes expose two optional capabilities, discovered with the same
+`(T, bool)` pattern:
+
+- `ProcessSignalerOf(p)` finds `Signal(ctx, sig)`. P1 supports only
+  `interrupt` — true Ctrl-C semantics: a VINTR byte through the pty on
+  TTY sessions (the terminal driver signals the foreground process
+  group), SIGINT to the whole group on pipe sessions. The process may
+  catch the signal and continue; the session stays usable. A raw-mode
+  TTY (ISIG off) sees no signal — authentic Ctrl-C behaviour. After
+  the process exits or the session closes, `Signal` returns
+  `ErrProcessClosed`.
+- `ProcessEventSourceOf(p)` finds `Watch(ctx)`: a per-subscriber
+  bounded queue (256 events) that replays the retained output before
+  delivering live `ProcessEvent`s (output / exited / closed / lag).
+  The `Events()` channel closes on ctx cancellation, `watcher.Close()`,
+  or right after the session's `Closed` event. A slow subscriber
+  receives `ProcessEventLag` (with the first missed byte cursor) and
+  the watcher closes — recover with `Read(afterSeq=lag.Seq)` or
+  re-`Watch`; the pull `Read` path is unchanged.
 
 ## Workspace vs Sandbox
 

--- a/sdk/go.mod
+++ b/sdk/go.mod
@@ -3,6 +3,7 @@ module github.com/GizClaw/flowcraft/sdk
 go 1.25.0
 
 require (
+	github.com/creack/pty v1.1.24
 	github.com/expr-lang/expr v1.17.8
 	github.com/rs/xid v1.6.0
 	github.com/santhosh-tekuri/jsonschema/v5 v5.3.1

--- a/sdk/go.sum
+++ b/sdk/go.sum
@@ -2,6 +2,8 @@ github.com/cenkalti/backoff/v5 v5.0.3 h1:ZN+IMa753KfX5hd8vVaMixjnqRZ3y8CuJKRKj1x
 github.com/cenkalti/backoff/v5 v5.0.3/go.mod h1:rkhZdG3JZukswDf7f0cwqPNk4K0sa+F97BxZthm/crw=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
+github.com/creack/pty v1.1.24 h1:bJrF4RRfyJnbTJqzRLHzcGaZK1NeM5kTC9jGgovnR1s=
+github.com/creack/pty v1.1.24/go.mod h1:08sCNb52WyoAwi2QDyzUCTgcvVFhUzewun7wtTfvcwE=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/expr-lang/expr v1.17.8 h1:W1loDTT+0PQf5YteHSTpju2qfUfNoBt4yw9+wOEU9VM=

--- a/sdk/sandbox/approval.go
+++ b/sdk/sandbox/approval.go
@@ -9,14 +9,18 @@ import (
 	"github.com/GizClaw/flowcraft/sdk/errdefs"
 )
 
-// ExecRequest is a snapshot of one Runner.Exec call, shared by
-// predicates (which inspect it) and approval callbacks (which present
-// it to the approver). It is a DTO rather than loose parameters so new
-// fields remain additive for implementors.
+// ExecRequest is a snapshot of one Runner.Exec call (or one
+// ProcessManager.Start attempt), shared by predicates (which inspect
+// it) and approval callbacks (which present it to the approver). It is
+// a DTO rather than loose parameters so new fields remain additive for
+// implementors. TTY marks interactive session starts so the approver
+// can see that approval covers a persistent command channel rather
+// than a single command; it is false for ordinary Exec calls.
 type ExecRequest struct {
 	Command string
 	Args    []string
 	Opts    ExecOptions
+	TTY     bool
 }
 
 // Predicate decides whether an Exec call crosses a policy boundary and
@@ -97,13 +101,23 @@ type approvalRunner struct {
 
 func (r *approvalRunner) Exec(ctx context.Context, cmd string, args []string, opts ExecOptions) (*ExecResult, error) {
 	req := ExecRequest{Command: cmd, Args: args, Opts: opts}
+	if err := r.authorize(ctx, req); err != nil {
+		return nil, err
+	}
+	return r.inner.Exec(ctx, cmd, args, opts)
+}
+
+// authorize runs the predicate / approver chain for one request. It is
+// shared by Exec and ProcessManager.Start so interactive sessions go
+// through exactly the same fail-closed tripwire.
+func (r *approvalRunner) authorize(ctx context.Context, req ExecRequest) error {
 	for _, p := range r.preds {
 		if p == nil {
-			return nil, errdefs.PolicyDeniedf(
+			return errdefs.PolicyDeniedf(
 				"sandbox: nil approval predicate configured (fail-closed)")
 		}
 		if predicateFunc, ok := p.(PredicateFunc); ok && predicateFunc == nil {
-			return nil, errdefs.PolicyDeniedf(
+			return errdefs.PolicyDeniedf(
 				"sandbox: nil approval predicate function configured (fail-closed)")
 		}
 		reason, matched := p.Match(cloneExecRequest(req))
@@ -111,7 +125,7 @@ func (r *approvalRunner) Exec(ctx context.Context, cmd string, args []string, op
 			continue
 		}
 		if r.approve == nil {
-			return nil, errdefs.PolicyDeniedf(
+			return errdefs.PolicyDeniedf(
 				"sandbox: %s (no approver configured)", reason)
 		}
 		decision, err := r.approve(ctx, ApprovalRequest{
@@ -119,16 +133,62 @@ func (r *approvalRunner) Exec(ctx context.Context, cmd string, args []string, op
 			Reason: reason,
 		})
 		if err != nil {
-			return nil, fmt.Errorf(
-				"sandbox: approval for %q failed; not executed (fail-closed): %w", cmd, err)
+			return fmt.Errorf(
+				"sandbox: approval for %q failed; not executed (fail-closed): %w", req.Command, err)
 		}
 		if decision != Allow {
-			return nil, errdefs.PolicyDeniedf(
-				"sandbox: execution of %q denied: %s", cmd, reason)
+			return errdefs.PolicyDeniedf(
+				"sandbox: execution of %q denied: %s", req.Command, reason)
 		}
 		break
 	}
-	return r.inner.Exec(ctx, cmd, args, opts)
+	return nil
+}
+
+// Start implements ProcessManager: an interactive session crosses the
+// same predicate / approver chain as an Exec call, with TTY surfaced
+// on the request so the approver sees it is authorising a persistent
+// command channel. Once Start is approved, Read/Write/Resize/Terminate
+// never re-enter approval — the policy is fixed at Start.
+func (r *approvalRunner) Start(ctx context.Context, spec ProcessSpec) (Process, error) {
+	if len(spec.Argv) == 0 {
+		return nil, errdefs.Validationf("sandbox: ProcessSpec.Argv must name a command")
+	}
+	req := ExecRequest{
+		Command: spec.Argv[0],
+		Args:    spec.Argv[1:],
+		Opts:    spec.Opts,
+		TTY:     spec.TTY,
+	}
+	if err := r.authorize(ctx, req); err != nil {
+		return nil, err
+	}
+	pm := ProcessManagerOf(r.inner)
+	if pm == nil {
+		return nil, errdefs.NotAvailablef(
+			"sandbox: underlying runner does not support process sessions")
+	}
+	return pm.Start(ctx, spec)
+}
+
+// List forwards the inner runner's session list when it has one.
+func (r *approvalRunner) List(ctx context.Context) ([]ProcessInfo, error) {
+	pm := ProcessManagerOf(r.inner)
+	if pm == nil {
+		return nil, errdefs.NotAvailablef(
+			"sandbox: underlying runner does not support process sessions")
+	}
+	return pm.List(ctx)
+}
+
+// Terminate forwards to the inner runner's session manager.
+func (r *approvalRunner) Terminate(ctx context.Context, id string) error {
+	pm := ProcessManagerOf(r.inner)
+	if pm == nil {
+		return errdefs.NotAvailablef(
+			"sandbox: underlying runner does not support process sessions")
+	}
+	return pm.Terminate(ctx, id)
 }
 
 // cloneExecRequest prevents predicates / approvers from mutating the

--- a/sdk/sandbox/approval.go
+++ b/sdk/sandbox/approval.go
@@ -241,6 +241,21 @@ func CommandPatterns(patterns ...string) Predicate {
 	})
 }
 
+// Interactive returns a predicate that matches interactive session
+// starts (ProcessSpec.TTY == true). Ordinary Exec calls never match.
+// Because an interactive session is an all-or-nothing command channel,
+// deployments that want a human in the loop for persistent shells
+// should install this predicate; combined with a nil approver it
+// fail-closes into "interactive sessions are forbidden".
+func Interactive() Predicate {
+	return PredicateFunc(func(req ExecRequest) (string, bool) {
+		if req.TTY {
+			return "interactive TTY session start", true
+		}
+		return "", false
+	})
+}
+
 // NetNonDefault returns a predicate that matches any call requesting a
 // network posture other than NetDefault.
 func NetNonDefault() Predicate {

--- a/sdk/sandbox/approval_test.go
+++ b/sdk/sandbox/approval_test.go
@@ -301,3 +301,16 @@ func TestWithApproval_DenyErrorMentionsReason(t *testing.T) {
 		t.Fatalf("denial error should surface the reason, got: %v", err)
 	}
 }
+
+func TestInteractivePredicate(t *testing.T) {
+	p := sandbox.Interactive()
+	if _, matched := p.Match(sandbox.ExecRequest{Command: "sh", TTY: true}); !matched {
+		t.Fatal("TTY session start must match Interactive")
+	}
+	if _, matched := p.Match(sandbox.ExecRequest{Command: "sh"}); matched {
+		t.Fatal("plain Exec must not match Interactive")
+	}
+	if _, matched := p.Match(sandbox.ExecRequest{Command: "sh", TTY: false}); matched {
+		t.Fatal("pipe session must not match Interactive")
+	}
+}

--- a/sdk/sandbox/compose.go
+++ b/sdk/sandbox/compose.go
@@ -60,6 +60,9 @@ func DefaultLocalPolicy(root string, approval ApprovalFunc, sensitiveCommands ..
 // ComposeLocal adds no writable paths and never modifies backend
 // enforcement. Seatbelt callers should use seatbelt.WithWritablePaths
 // when constructing the backend for dedicated temp/cache directories.
+// When backend implements ProcessManager, the returned Runner forwards
+// it through the same decorators (defaults merge, approval, allow-list)
+// so interactive sessions stay inside the composed policy.
 func ComposeLocal(backend Runner, policy LocalPolicy) Runner {
 	runner := backend
 	if policy.AllowedCommands != nil {

--- a/sdk/sandbox/config/builder.go
+++ b/sdk/sandbox/config/builder.go
@@ -8,6 +8,7 @@ import (
 	"reflect"
 	"slices"
 	"sort"
+	"strings"
 	"time"
 
 	sdkconfig "github.com/GizClaw/flowcraft/sdk/config"
@@ -155,6 +156,15 @@ func validateEnforcement(
 		return unsupportedPolicy(name,
 			fmt.Sprintf("network mode %q", netModeName(defaults.Net.Mode)))
 	}
+	if strings.HasPrefix(defaults.Net.Proxy, "socks5://") && !enforcement.Socks5 {
+		return unsupportedPolicy(name, "socks5 upstream")
+	}
+	if defaults.Net.MITM != nil && defaults.Net.MITM.Enabled && !enforcement.MITM {
+		return unsupportedPolicy(name, "MITM")
+	}
+	if len(defaults.Net.UnixSockets) > 0 && !enforcement.UnixSocketPolicy {
+		return unsupportedPolicy(name, "unix socket allow-list")
+	}
 	if defaults.Resources.MemoryBytes > 0 && !enforcement.MemoryCap {
 		return unsupportedPolicy(name, "memory cap")
 	}
@@ -196,9 +206,12 @@ func toExecOptions(value Defaults) coresandbox.ExecOptions {
 			Inject: maps.Clone(value.Env.Inject),
 		},
 		Net: coresandbox.NetPolicy{
-			Mode:       toNetMode(value.Net.Mode),
-			AllowHosts: slices.Clone(value.Net.AllowHosts),
-			Proxy:      value.Net.Proxy,
+			Mode:        toNetMode(value.Net.Mode),
+			AllowHosts:  slices.Clone(value.Net.AllowHosts),
+			Rules:       toNetRules(value.Net.Rules),
+			Proxy:       value.Net.Proxy,
+			UnixSockets: slices.Clone(value.Net.UnixSockets),
+			MITM:        toMITMPolicy(value.Net.MITM),
 		},
 		Resources: coresandbox.ResourceLimits{
 			CPUMillicores:  value.Resources.CPUMillicores,
@@ -206,6 +219,33 @@ func toExecOptions(value Defaults) coresandbox.ExecOptions {
 			DiskBytes:      value.Resources.DiskBytes,
 			MaxOutputBytes: value.Resources.MaxOutputBytes,
 		},
+	}
+}
+
+func toNetRules(rules []NetRuleJSON) []coresandbox.NetRule {
+	out := make([]coresandbox.NetRule, 0, len(rules))
+	for _, r := range rules {
+		action := coresandbox.NetAllow
+		if r.Action == "deny" {
+			action = coresandbox.NetDeny
+		}
+		out = append(out, coresandbox.NetRule{
+			Action: action,
+			Host:   r.Host,
+			Port:   r.Port,
+		})
+	}
+	return out
+}
+
+func toMITMPolicy(m *MITMJSON) *coresandbox.MITMPolicy {
+	if m == nil {
+		return nil
+	}
+	return &coresandbox.MITMPolicy{
+		Enabled:       m.Enabled,
+		InspectBodies: m.InspectBodies,
+		MaxBodyBytes:  m.MaxBodyBytes,
 	}
 }
 
@@ -234,6 +274,9 @@ func approvalPredicates(root string, approval *ApprovalConfig) []coresandbox.Pre
 	}
 	if approval.NonDefaultNetwork {
 		predicates = append(predicates, coresandbox.NetNonDefault())
+	}
+	if approval.Interactive {
+		predicates = append(predicates, coresandbox.Interactive())
 	}
 	if len(approval.SensitiveCommands) > 0 {
 		predicates = append(predicates,

--- a/sdk/sandbox/config/builder.go
+++ b/sdk/sandbox/config/builder.go
@@ -246,6 +246,8 @@ func toMITMPolicy(m *MITMJSON) *coresandbox.MITMPolicy {
 		Enabled:       m.Enabled,
 		InspectBodies: m.InspectBodies,
 		MaxBodyBytes:  m.MaxBodyBytes,
+		Hosts:         slices.Clone(m.Hosts),
+		ExcludeHosts:  slices.Clone(m.ExcludeHosts),
 	}
 }
 

--- a/sdk/sandbox/config/document.go
+++ b/sdk/sandbox/config/document.go
@@ -89,9 +89,11 @@ type NetRuleJSON struct {
 
 // MITMJSON is the wire form of sandbox.MITMPolicy.
 type MITMJSON struct {
-	Enabled       bool  `json:"enabled,omitempty"`
-	InspectBodies bool  `json:"inspect_bodies,omitempty"`
-	MaxBodyBytes  int64 `json:"max_body_bytes,omitempty"`
+	Enabled       bool     `json:"enabled,omitempty"`
+	InspectBodies bool     `json:"inspect_bodies,omitempty"`
+	MaxBodyBytes  int64    `json:"max_body_bytes,omitempty"`
+	Hosts         []string `json:"hosts,omitempty"`
+	ExcludeHosts  []string `json:"exclude_hosts,omitempty"`
 }
 
 // ResourceDefaults configures process resource limits.

--- a/sdk/sandbox/config/document.go
+++ b/sdk/sandbox/config/document.go
@@ -71,9 +71,27 @@ type EnvDefaults struct {
 
 // NetDefaults configures outbound network policy.
 type NetDefaults struct {
-	Mode       string   `json:"mode,omitempty"`
-	AllowHosts []string `json:"allow_hosts,omitempty"`
-	Proxy      string   `json:"proxy,omitempty"`
+	Mode        string        `json:"mode,omitempty"`
+	AllowHosts  []string      `json:"allow_hosts,omitempty"`
+	Rules       []NetRuleJSON `json:"rules,omitempty"`
+	Proxy       string        `json:"proxy,omitempty"`
+	UnixSockets []string      `json:"unix_sockets,omitempty"`
+	MITM        *MITMJSON     `json:"mitm,omitempty"`
+}
+
+// NetRuleJSON is the wire form of sandbox.NetRule. Action is "allow"
+// or "deny"; port 0 means any port.
+type NetRuleJSON struct {
+	Action string `json:"action"`
+	Host   string `json:"host"`
+	Port   int    `json:"port,omitempty"`
+}
+
+// MITMJSON is the wire form of sandbox.MITMPolicy.
+type MITMJSON struct {
+	Enabled       bool  `json:"enabled,omitempty"`
+	InspectBodies bool  `json:"inspect_bodies,omitempty"`
+	MaxBodyBytes  int64 `json:"max_body_bytes,omitempty"`
 }
 
 // ResourceDefaults configures process resource limits.
@@ -88,6 +106,7 @@ type ResourceDefaults struct {
 type ApprovalConfig struct {
 	OutsideWorkDir    bool     `json:"outside_workdir,omitempty"`
 	NonDefaultNetwork bool     `json:"non_default_network,omitempty"`
+	Interactive       bool     `json:"interactive,omitempty"`
 	SensitiveCommands []string `json:"sensitive_commands,omitempty"`
 }
 
@@ -164,14 +183,15 @@ func (e SandboxEntry) validate() error {
 func (n NetDefaults) validate() error {
 	switch n.Mode {
 	case "", NetModeDefault, NetModeDenyAll:
-		if len(n.AllowHosts) != 0 || n.Proxy != "" {
+		if len(n.AllowHosts) != 0 || len(n.Rules) != 0 || n.Proxy != "" ||
+			len(n.UnixSockets) != 0 || n.MITM != nil {
 			return fmt.Errorf(
-				"defaults.net mode %q cannot set allow_hosts or proxy",
+				"defaults.net mode %q cannot set allow_hosts, rules, proxy, unix_sockets, or mitm",
 				defaultNetMode(n.Mode))
 		}
 	case NetModeAllowList:
-		if len(n.AllowHosts) == 0 {
-			return fmt.Errorf("defaults.net allow_list requires allow_hosts")
+		if len(n.AllowHosts) == 0 && len(n.Rules) == 0 {
+			return fmt.Errorf("defaults.net allow_list requires allow_hosts or rules")
 		}
 		if n.Proxy != "" {
 			return fmt.Errorf("defaults.net allow_list cannot set proxy")
@@ -191,7 +211,14 @@ func (n NetDefaults) validate() error {
 			return fmt.Errorf("defaults.net.allow_hosts[%d] is empty", i)
 		}
 	}
-	return nil
+	for i, rule := range n.Rules {
+		if rule.Action != "allow" && rule.Action != "deny" {
+			return fmt.Errorf("defaults.net.rules[%d].action must be \"allow\" or \"deny\"", i)
+		}
+	}
+	// Reuse the core policy validation for the new fields (proxy
+	// scheme, rule actions/ports, unix socket paths, MITM caps).
+	return toExecOptions(Defaults{Net: n}).Net.Validate()
 }
 
 func defaultNetMode(mode string) string {
@@ -223,7 +250,8 @@ func (r ResourceDefaults) validate(timeout time.Duration) error {
 
 func (a *ApprovalConfig) hasPredicates() bool {
 	return a != nil &&
-		(a.OutsideWorkDir || a.NonDefaultNetwork || len(a.SensitiveCommands) > 0)
+		(a.OutsideWorkDir || a.NonDefaultNetwork || a.Interactive ||
+			len(a.SensitiveCommands) > 0)
 }
 
 // Parse strictly decodes and validates exactly one document. YAML and

--- a/sdk/sandbox/config/netproxy_test.go
+++ b/sdk/sandbox/config/netproxy_test.go
@@ -1,0 +1,237 @@
+package config_test
+
+import (
+	"context"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/GizClaw/flowcraft/sdk/errdefs"
+	"github.com/GizClaw/flowcraft/sdk/sandbox"
+	sandboxconfig "github.com/GizClaw/flowcraft/sdk/sandbox/config"
+)
+
+func TestParseNetProxyEnhancements(t *testing.T) {
+	doc := mustParse(t, `
+version: v1
+sandboxes:
+  x:
+    backend: local
+    workspace: project
+    defaults:
+      net:
+        mode: allow_list
+        rules:
+          - action: deny
+            host: "*.internal.example"
+          - action: allow
+            host: "example.com"
+            port: 443
+          - action: allow
+            host: "10.0.0.0/8"
+        unix_sockets: [/run/docker.sock]
+        mitm:
+          enabled: true
+          inspect_bodies: true
+          max_body_bytes: 65536
+`)
+	net := doc.Sandboxes["x"].Defaults.Net
+	if len(net.Rules) != 3 || net.Rules[0].Action != "deny" || net.Rules[1].Port != 443 {
+		t.Fatalf("rules = %+v", net.Rules)
+	}
+	if len(net.UnixSockets) != 1 || net.UnixSockets[0] != "/run/docker.sock" {
+		t.Fatalf("unix_sockets = %v", net.UnixSockets)
+	}
+	if net.MITM == nil || !net.MITM.Enabled || !net.MITM.InspectBodies || net.MITM.MaxBodyBytes != 65536 {
+		t.Fatalf("mitm = %+v", net.MITM)
+	}
+
+	proxyDoc := mustParse(t, `
+version: v1
+sandboxes:
+  x:
+    backend: local
+    workspace: project
+    defaults:
+      net:
+        mode: proxy
+        proxy: socks5://user:pass@proxy.example:1080
+`)
+	if got := proxyDoc.Sandboxes["x"].Defaults.Net.Proxy; got != "socks5://user:pass@proxy.example:1080" {
+		t.Fatalf("proxy = %q", got)
+	}
+}
+
+func TestParseRejectsInvalidNetProxyEnhancements(t *testing.T) {
+	tests := map[string]string{
+		"bad action":                        `{backend: local, workspace: project, defaults: {net: {mode: allow_list, rules: [{action: maybe, host: x}]}}}`,
+		"bad port":                          `{backend: local, workspace: project, defaults: {net: {mode: allow_list, rules: [{action: allow, host: x, port: 70000}]}}}`,
+		"empty rule host":                   `{backend: local, workspace: project, defaults: {net: {mode: allow_list, rules: [{action: allow}]}}}`,
+		"bad scheme":                        `{backend: local, workspace: project, defaults: {net: {mode: proxy, proxy: "ftp://x"}}}`,
+		"relative socket":                   `{backend: local, workspace: project, defaults: {net: {mode: allow_list, allow_hosts: [x], unix_sockets: [run/docker.sock]}}}`,
+		"negative mitm":                     `{backend: local, workspace: project, defaults: {net: {mode: allow_list, allow_hosts: [x], mitm: {max_body_bytes: -1}}}}`,
+		"rules in default mode":             `{backend: local, workspace: project, defaults: {net: {mode: default, rules: [{action: allow, host: x}]}}}`,
+		"allow_list without hosts or rules": `{backend: local, workspace: project, defaults: {net: {mode: allow_list}}}`,
+	}
+	for name, entry := range tests {
+		t.Run(name, func(t *testing.T) {
+			_, err := sandboxconfig.Parse([]byte("version: v1\nsandboxes:\n  x: " + entry + "\n"))
+			if !errdefs.IsValidation(err) {
+				t.Fatalf("Validate = %v, want Validation", err)
+			}
+		})
+	}
+}
+
+func TestBuilderGatesProxyCapabilities(t *testing.T) {
+	root := t.TempDir()
+	builder := sandboxconfig.NewBuilder(sandboxconfig.Deps{Workspaces: buildWorkspaces(t, root, false)})
+	runner := &proxyCapsRunner{
+		caps: sandbox.Enforcement{
+			EnvAllowList: true,
+			NetModes:     []sandbox.NetMode{sandbox.NetAllowList, sandbox.NetProxy},
+		},
+	}
+	if err := builder.RegisterFactory("proxycaps", func(context.Context, sandboxconfig.FactoryInput) (sandbox.Runner, error) {
+		return runner, nil
+	}); err != nil {
+		t.Fatalf("RegisterFactory: %v", err)
+	}
+
+	tests := map[string]struct {
+		net   string
+		cap   string
+		field string
+	}{
+		"socks5": {
+			net:   `{mode: proxy, proxy: "socks5://user:pass@host:1080"}`,
+			cap:   "Socks5",
+			field: "socks5 upstream",
+		},
+		"mitm": {
+			net:   `{mode: allow_list, allow_hosts: [example.com], mitm: {enabled: true}}`,
+			cap:   "MITM",
+			field: "MITM",
+		},
+		"unix sockets": {
+			net:   `{mode: allow_list, allow_hosts: [example.com], unix_sockets: [/run/docker.sock]}`,
+			cap:   "UnixSocketPolicy",
+			field: "unix socket allow-list",
+		},
+	}
+	for name, tc := range tests {
+		t.Run(name+" unsupported", func(t *testing.T) {
+			doc := mustParse(t, "version: v1\nsandboxes:\n  x:\n    backend: proxycaps\n    workspace: project\n    defaults:\n      net: "+tc.net+"\n")
+			_, err := builder.Build(context.Background(), doc)
+			if !errdefs.IsNotAvailable(err) || !strings.Contains(err.Error(), tc.field) {
+				t.Fatalf("Build = %v, want NotAvailable containing %q", err, tc.field)
+			}
+		})
+		t.Run(name+" supported", func(t *testing.T) {
+			runner.caps = sandbox.Enforcement{
+				EnvAllowList: true,
+				NetModes:     []sandbox.NetMode{sandbox.NetAllowList, sandbox.NetProxy},
+			}
+			switch tc.cap {
+			case "Socks5":
+				runner.caps.Socks5 = true
+			case "MITM":
+				runner.caps.MITM = true
+			case "UnixSocketPolicy":
+				runner.caps.UnixSocketPolicy = true
+			}
+			doc := mustParse(t, "version: v1\nsandboxes:\n  x:\n    backend: proxycaps\n    workspace: project\n    defaults:\n      net: "+tc.net+"\n")
+			if _, err := builder.Build(context.Background(), doc); err != nil {
+				t.Fatalf("Build with capability = %v, want success", err)
+			}
+		})
+	}
+}
+
+func TestParseApprovalInteractive(t *testing.T) {
+	doc := mustParse(t, `
+version: v1
+sandboxes:
+  x:
+    backend: local
+    workspace: project
+    approval: {interactive: true}
+`)
+	if doc.Sandboxes["x"].Approval == nil || !doc.Sandboxes["x"].Approval.Interactive {
+		t.Fatalf("approval = %+v, want interactive: true", doc.Sandboxes["x"].Approval)
+	}
+}
+
+func TestApproval_InteractiveRequiresApproval(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("interactive sessions are unix-only")
+	}
+	root := t.TempDir()
+	var calls int
+	approver := func(_ context.Context, req sandbox.ApprovalRequest) (sandbox.Decision, error) {
+		calls++
+		if !req.Exec.TTY {
+			t.Errorf("approver saw TTY=%v, want true", req.Exec.TTY)
+		}
+		return sandbox.Allow, nil
+	}
+	builder := sandboxconfig.NewBuilder(sandboxconfig.Deps{
+		Workspaces: buildWorkspaces(t, root, false),
+		Approver:   approver,
+	})
+	doc := mustParse(t, `
+version: v1
+sandboxes:
+  x:
+    backend: local
+    workspace: project
+    approval: {interactive: true}
+`)
+	registry, err := builder.Build(context.Background(), doc)
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	runner, ok := registry.Get("x")
+	if !ok || runner == nil {
+		t.Fatal("sandbox x not resolved")
+	}
+	pm := sandbox.ProcessManagerOf(runner)
+	if pm == nil {
+		t.Fatal("composed runner must forward ProcessManager")
+	}
+
+	proc, err := pm.Start(context.Background(), sandbox.ProcessSpec{
+		Argv: []string{"/usr/bin/true"},
+		TTY:  true,
+	})
+	if err != nil {
+		t.Fatalf("TTY Start: %v", err)
+	}
+	defer func() { _ = proc.Close() }()
+	if calls != 1 {
+		t.Fatalf("approver calls = %d, want 1 for TTY start", calls)
+	}
+
+	proc, err = pm.Start(context.Background(), sandbox.ProcessSpec{
+		Argv: []string{"/usr/bin/true"},
+	})
+	if err != nil {
+		t.Fatalf("pipe Start: %v", err)
+	}
+	defer func() { _ = proc.Close() }()
+	if calls != 1 {
+		t.Fatalf("pipe start must not trip Interactive: calls = %d", calls)
+	}
+}
+
+type proxyCapsRunner struct {
+	caps sandbox.Enforcement
+}
+
+func (r *proxyCapsRunner) Enforcement() sandbox.Enforcement {
+	return r.caps
+}
+
+func (r *proxyCapsRunner) Exec(context.Context, string, []string, sandbox.ExecOptions) (*sandbox.ExecResult, error) {
+	return &sandbox.ExecResult{}, nil
+}

--- a/sdk/sandbox/config/netproxy_test.go
+++ b/sdk/sandbox/config/netproxy_test.go
@@ -34,6 +34,8 @@ sandboxes:
           enabled: true
           inspect_bodies: true
           max_body_bytes: 65536
+          hosts: ["example.com"]
+          exclude_hosts: ["*.nopin.example"]
 `)
 	net := doc.Sandboxes["x"].Defaults.Net
 	if len(net.Rules) != 3 || net.Rules[0].Action != "deny" || net.Rules[1].Port != 443 {
@@ -44,6 +46,12 @@ sandboxes:
 	}
 	if net.MITM == nil || !net.MITM.Enabled || !net.MITM.InspectBodies || net.MITM.MaxBodyBytes != 65536 {
 		t.Fatalf("mitm = %+v", net.MITM)
+	}
+	if len(net.MITM.Hosts) != 1 || net.MITM.Hosts[0] != "example.com" {
+		t.Fatalf("mitm.hosts = %v", net.MITM.Hosts)
+	}
+	if len(net.MITM.ExcludeHosts) != 1 || net.MITM.ExcludeHosts[0] != "*.nopin.example" {
+		t.Fatalf("mitm.exclude_hosts = %v", net.MITM.ExcludeHosts)
 	}
 
 	proxyDoc := mustParse(t, `

--- a/sdk/sandbox/decorator.go
+++ b/sdk/sandbox/decorator.go
@@ -34,6 +34,47 @@ func (r *allowCommandsRunner) Exec(ctx context.Context, cmd string, args []strin
 	return r.inner.Exec(ctx, cmd, args, opts)
 }
 
+// Start implements ProcessManager with the same gate as Exec: the
+// session's Argv[0] must be whitelisted before it is ever spawned.
+// Note this gates the session start, not input typed inside an
+// interactive shell — that is the documented all-or-nothing trade-off
+// of interactive sessions.
+func (r *allowCommandsRunner) Start(ctx context.Context, spec ProcessSpec) (Process, error) {
+	if len(spec.Argv) == 0 {
+		return nil, errdefs.Validationf("sandbox: ProcessSpec.Argv must name a command")
+	}
+	if !r.whitelist[spec.Argv[0]] {
+		return nil, errdefs.PolicyDeniedf(
+			"sandbox: command %q is not in the whitelist", spec.Argv[0])
+	}
+	pm := ProcessManagerOf(r.inner)
+	if pm == nil {
+		return nil, errdefs.NotAvailablef(
+			"sandbox: underlying runner does not support process sessions")
+	}
+	return pm.Start(ctx, spec)
+}
+
+// List forwards the inner runner's session list when it has one.
+func (r *allowCommandsRunner) List(ctx context.Context) ([]ProcessInfo, error) {
+	pm := ProcessManagerOf(r.inner)
+	if pm == nil {
+		return nil, errdefs.NotAvailablef(
+			"sandbox: underlying runner does not support process sessions")
+	}
+	return pm.List(ctx)
+}
+
+// Terminate forwards to the inner runner's session manager.
+func (r *allowCommandsRunner) Terminate(ctx context.Context, id string) error {
+	pm := ProcessManagerOf(r.inner)
+	if pm == nil {
+		return errdefs.NotAvailablef(
+			"sandbox: underlying runner does not support process sessions")
+	}
+	return pm.Terminate(ctx, id)
+}
+
 // Enforcement forwards the inner runner's report: gating command names
 // narrows what may run but adds no enforcement capability, so the
 // decorator claims exactly what its inner runner enforces — the
@@ -111,6 +152,39 @@ type defaultsRunner struct {
 
 func (r *defaultsRunner) Exec(ctx context.Context, cmd string, args []string, opts ExecOptions) (*ExecResult, error) {
 	return r.inner.Exec(ctx, cmd, args, r.merge(opts))
+}
+
+// Start implements ProcessManager: the session's Opts go through the
+// same security-biased merge as Exec, so daemon-owned Env/Net/
+// Resources policy is fixed before the backend ever sees the spawn.
+func (r *defaultsRunner) Start(ctx context.Context, spec ProcessSpec) (Process, error) {
+	pm := ProcessManagerOf(r.inner)
+	if pm == nil {
+		return nil, errdefs.NotAvailablef(
+			"sandbox: underlying runner does not support process sessions")
+	}
+	spec.Opts = r.merge(spec.Opts)
+	return pm.Start(ctx, spec)
+}
+
+// List forwards the inner runner's session list when it has one.
+func (r *defaultsRunner) List(ctx context.Context) ([]ProcessInfo, error) {
+	pm := ProcessManagerOf(r.inner)
+	if pm == nil {
+		return nil, errdefs.NotAvailablef(
+			"sandbox: underlying runner does not support process sessions")
+	}
+	return pm.List(ctx)
+}
+
+// Terminate forwards to the inner runner's session manager.
+func (r *defaultsRunner) Terminate(ctx context.Context, id string) error {
+	pm := ProcessManagerOf(r.inner)
+	if pm == nil {
+		return errdefs.NotAvailablef(
+			"sandbox: underlying runner does not support process sessions")
+	}
+	return pm.Terminate(ctx, id)
 }
 
 // Enforcement forwards the inner runner's report: fixing policy

--- a/sdk/sandbox/doc.go
+++ b/sdk/sandbox/doc.go
@@ -43,4 +43,18 @@
 // command-name gate, and WithApproval adds a fail-closed human decision
 // tripwire. The recommended local composition lives in
 // sdkx/sandbox.ComposeLocal.
+//
+// # Long-running sessions
+//
+// Runners may additionally implement ProcessManager (discovered with
+// ProcessManagerOf) to spawn interactive or streaming processes under
+// the same ExecOptions policy. Policy is fixed once at Start — env,
+// network posture, resource caps, and approval are never re-negotiated
+// per Read/Write. Output is a byte-cursor log: Read(afterSeq) replays
+// from any retained position, bounded by Resources.MaxOutputBytes, so
+// a reconnecting client resumes without re-running the process.
+// Backends without the capability (or without a pty) return
+// errdefs.NotAvailable rather than silently downgrading to Exec. The
+// decorators implement ProcessManager as well, so interactive sessions
+// cannot bypass the defaults / approval / allow-list chain.
 package sandbox

--- a/sdk/sandbox/enforcement.go
+++ b/sdk/sandbox/enforcement.go
@@ -15,6 +15,14 @@ package sandbox
 //   - NetModes: the set of NetMode values the backend can enforce at
 //     the OS level. NetDefault is never listed — it is the absence of
 //     a policy, not an enforceable posture.
+//   - Socks5: the backend's host-side proxy can dial a socks5://
+//     upstream (authentication included).
+//   - MITM: the backend can terminate TLS for configured CONNECT
+//     hosts and inject the temporary CA into the child environment.
+//   - UnixSocketPolicy: the backend can confine unix socket egress to
+//     an explicit allow-list. For bwrap this is namespace-visibility
+//     based (masked dirs deny, listed paths are bind-mounted in), so
+//     the claim is strongest in the isolated net modes.
 //   - MemoryCap: MemoryBytes is enforced (by whatever mechanism the
 //     backend has — cgroup, rlimit, or a sampling watcher) rather
 //     than rejected with NotAvailable.
@@ -28,6 +36,9 @@ package sandbox
 type Enforcement struct {
 	EnvAllowList     bool
 	NetModes         []NetMode
+	Socks5           bool
+	MITM             bool
+	UnixSocketPolicy bool
 	MemoryCap        bool
 	CPUCap           bool
 	DiskCap          bool

--- a/sdk/sandbox/enforcement_test.go
+++ b/sdk/sandbox/enforcement_test.go
@@ -35,6 +35,10 @@ func TestEnforcement_LocalRunner(t *testing.T) {
 	if e.DiskCap {
 		t.Error("DiskCap must stay unclaimed (no quota mechanism)")
 	}
+	if e.Socks5 || e.MITM || e.UnixSocketPolicy {
+		t.Errorf("LocalRunner must not claim proxy features, got Socks5=%v MITM=%v UnixSocketPolicy=%v",
+			e.Socks5, e.MITM, e.UnixSocketPolicy)
+	}
 	if e.FilesystemBounds {
 		t.Error("FilesystemBounds is OS-level confinement; LocalRunner must not claim it")
 	}
@@ -81,7 +85,9 @@ func TestEnforcementOf_ConservativeFallback(t *testing.T) {
 func enforcementEqual(a, b sandbox.Enforcement) bool {
 	if a.EnvAllowList != b.EnvAllowList || a.MemoryCap != b.MemoryCap ||
 		a.CPUCap != b.CPUCap || a.DiskCap != b.DiskCap ||
-		a.FilesystemBounds != b.FilesystemBounds {
+		a.FilesystemBounds != b.FilesystemBounds ||
+		a.Socks5 != b.Socks5 || a.MITM != b.MITM ||
+		a.UnixSocketPolicy != b.UnixSocketPolicy {
 		return false
 	}
 	if len(a.NetModes) != len(b.NetModes) {

--- a/sdk/sandbox/local.go
+++ b/sdk/sandbox/local.go
@@ -10,6 +10,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/GizClaw/flowcraft/sdk/errdefs"
@@ -57,6 +58,8 @@ func WithMaxOutputBytes(n int64) Option {
 type LocalRunner struct {
 	rootDir          string
 	defaultMaxOutput int64
+	processes        ProcessManager
+	registryOnce     sync.Once
 }
 
 // NewLocalRunner constructs a LocalRunner rooted at rootDir. The root is
@@ -73,6 +76,7 @@ func NewLocalRunner(rootDir string, opts ...Option) *LocalRunner {
 	for _, o := range opts {
 		o(r)
 	}
+	r.processes = NewProcessRegistry(r.spawnProcess)
 	return r
 }
 
@@ -96,19 +100,8 @@ func (r *LocalRunner) Exec(ctx context.Context, cmd string, args []string, opts 
 		return nil, errdefs.NotAvailablef(
 			"sandbox: net policy not supported by local runner; requires a kernel-level isolation backend")
 	}
-	if opts.Resources.DiskBytes != 0 {
-		return nil, errdefs.NotAvailablef(
-			"sandbox: disk limits not supported by local runner (no quota mechanism)")
-	}
-	if opts.Resources.CPUMillicores != 0 && opts.Timeout <= 0 {
-		return nil, errdefs.NotAvailablef(
-			"sandbox: CPUMillicores requires a per-call Timeout to derive a cpu-time cap")
-	}
-	maxRSSKB, maxCPU := deriveGroupCaps(opts.Resources, opts.Timeout)
-	if (maxRSSKB > 0 || maxCPU > 0) && !groupCapsAvailable() {
-		return nil, errdefs.NotAvailablef(
-			"sandbox: resource limits require process-group sampling, which is unavailable here " +
-				"(non-unix platform, or ps(1) cannot be executed)")
+	if err := ValidateExecPolicy(opts); err != nil {
+		return nil, err
 	}
 
 	if opts.Timeout > 0 {
@@ -180,6 +173,36 @@ func (r *LocalRunner) Exec(ctx context.Context, cmd string, args []string, opts 
 		return result, classifyStartError(cmd, err)
 	}
 	return result, nil
+}
+
+// Start implements the ProcessManager session capability of
+// LocalRunner. Policy validation mirrors Exec (ValidateExecPolicy plus
+// the NetDefault-only posture), then the command is spawned either on
+// pipes or a pty through the shared StartSession implementation.
+func (r *LocalRunner) Start(ctx context.Context, spec ProcessSpec) (Process, error) {
+	return r.registry().Start(ctx, spec)
+}
+
+// List implements ProcessManager.
+func (r *LocalRunner) List(ctx context.Context) ([]ProcessInfo, error) {
+	return r.registry().List(ctx)
+}
+
+// Terminate implements ProcessManager.
+func (r *LocalRunner) Terminate(ctx context.Context, id string) error {
+	return r.registry().Terminate(ctx, id)
+}
+
+// registry returns the session registry, initialising it lazily so a
+// zero-value LocalRunner still answers with NotAvailable instead of
+// panicking on a nil interface.
+func (r *LocalRunner) registry() ProcessManager {
+	r.registryOnce.Do(func() {
+		if r.processes == nil {
+			r.processes = NewProcessRegistry(r.spawnProcess)
+		}
+	})
+	return r.processes
 }
 
 // deriveGroupCaps converts policy resource limits into group-watcher

--- a/sdk/sandbox/netpolicy_test.go
+++ b/sdk/sandbox/netpolicy_test.go
@@ -1,0 +1,45 @@
+package sandbox_test
+
+import (
+	"testing"
+
+	"github.com/GizClaw/flowcraft/sdk/errdefs"
+	"github.com/GizClaw/flowcraft/sdk/sandbox"
+)
+
+func TestNetPolicy_Validate(t *testing.T) {
+	valid := sandbox.NetPolicy{
+		Mode: sandbox.NetAllowList,
+		Rules: []sandbox.NetRule{
+			{Action: sandbox.NetDeny, Host: "*.internal.example", Port: 0},
+			{Action: sandbox.NetAllow, Host: "example.com", Port: 443},
+			{Action: sandbox.NetAllow, Host: "10.0.0.0/8", Port: 0},
+		},
+		Proxy:       "socks5://user:pass@proxy.example:1080",
+		UnixSockets: []string{"/run/docker.sock"},
+		MITM:        &sandbox.MITMPolicy{Enabled: true, MaxBodyBytes: 65536},
+	}
+	if err := valid.Validate(); err != nil {
+		t.Fatalf("valid policy rejected: %v", err)
+	}
+
+	cases := []struct {
+		name string
+		pol  sandbox.NetPolicy
+	}{
+		{"bad scheme", sandbox.NetPolicy{Proxy: "ftp://x"}},
+		{"password without user", sandbox.NetPolicy{Proxy: "socks5://:pass@host:1080"}},
+		{"bad action", sandbox.NetPolicy{Rules: []sandbox.NetRule{{Action: sandbox.NetAction(9), Host: "x"}}}},
+		{"empty rule host", sandbox.NetPolicy{Rules: []sandbox.NetRule{{Action: sandbox.NetAllow, Host: " "}}}},
+		{"port out of range", sandbox.NetPolicy{Rules: []sandbox.NetRule{{Action: sandbox.NetAllow, Host: "x", Port: 70000}}}},
+		{"relative unix socket", sandbox.NetPolicy{UnixSockets: []string{"run/docker.sock"}}},
+		{"negative body cap", sandbox.NetPolicy{MITM: &sandbox.MITMPolicy{MaxBodyBytes: -1}}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if err := tc.pol.Validate(); !errdefs.IsValidation(err) {
+				t.Fatalf("Validate = %v, want Validation", err)
+			}
+		})
+	}
+}

--- a/sdk/sandbox/netpolicy_test.go
+++ b/sdk/sandbox/netpolicy_test.go
@@ -17,7 +17,12 @@ func TestNetPolicy_Validate(t *testing.T) {
 		},
 		Proxy:       "socks5://user:pass@proxy.example:1080",
 		UnixSockets: []string{"/run/docker.sock"},
-		MITM:        &sandbox.MITMPolicy{Enabled: true, MaxBodyBytes: 65536},
+		MITM: &sandbox.MITMPolicy{
+			Enabled:      true,
+			MaxBodyBytes: 65536,
+			Hosts:        []string{"example.com", "*.pinned.internal"},
+			ExcludeHosts: []string{"*.nopin.example"},
+		},
 	}
 	if err := valid.Validate(); err != nil {
 		t.Fatalf("valid policy rejected: %v", err)
@@ -34,6 +39,8 @@ func TestNetPolicy_Validate(t *testing.T) {
 		{"port out of range", sandbox.NetPolicy{Rules: []sandbox.NetRule{{Action: sandbox.NetAllow, Host: "x", Port: 70000}}}},
 		{"relative unix socket", sandbox.NetPolicy{UnixSockets: []string{"run/docker.sock"}}},
 		{"negative body cap", sandbox.NetPolicy{MITM: &sandbox.MITMPolicy{MaxBodyBytes: -1}}},
+		{"empty mitm host", sandbox.NetPolicy{MITM: &sandbox.MITMPolicy{Hosts: []string{" "}}}},
+		{"empty mitm exclude", sandbox.NetPolicy{MITM: &sandbox.MITMPolicy{ExcludeHosts: []string{""}}}},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/sdk/sandbox/process.go
+++ b/sdk/sandbox/process.go
@@ -1,0 +1,425 @@
+package sandbox
+
+import (
+	"context"
+	"errors"
+	"sort"
+	"sync"
+	"time"
+
+	"github.com/GizClaw/flowcraft/sdk/errdefs"
+
+	"github.com/rs/xid"
+)
+
+// Process errors. They are plain sentinels: callers distinguish them
+// with errors.Is rather than through errdefs classification, because
+// neither is a policy refusal — one is a handle-lifecycle state and the
+// other is a buffering guarantee that cannot be recovered by retrying.
+var (
+	// ErrProcessClosed is returned by Read/Write/Resize/Terminate after
+	// the session's Close has run. Wait remains usable: the exit status
+	// is cached and reaping already completed.
+	ErrProcessClosed = errors.New("sandbox: process session is closed")
+
+	// ErrSequenceGap is returned by Read when afterSeq points into
+	// output that the bounded replay buffer already dropped. The
+	// caller must start over from ProcessInfo-retrievable state or
+	// abandon the replay; retrying with the same cursor never helps.
+	ErrSequenceGap = errors.New("sandbox: output sequence gap; buffered output was truncated")
+)
+
+// registryWaitTimeout bounds the synchronous state sync after
+// Terminate. A process that survived SIGKILL (rare kernel-level
+// stall) must not wedge the manager forever.
+const registryWaitTimeout = 10 * time.Second
+
+// ProcessSpec describes one interactive or streaming process session.
+//
+// Field semantics:
+//
+//   - ID: caller-supplied unique identifier. Empty means the manager
+//     generates one (returned on the Process handle). Duplicate IDs
+//     are rejected with errdefs.Conflict while the earlier session is
+//     still open.
+//   - Argv: the command and its arguments; Argv[0] is the executable.
+//     An empty slice is a Validation error.
+//   - TTY: request a pseudo-terminal. The child then owns the
+//     controlling terminal, stdout/stderr are merged into the single
+//     ProcessStreamTTY stream, and Resize applies to the pty window.
+//     False runs the child on pipes with separate stdout/stderr
+//     streams.
+//   - Rows/Cols: initial pty window size (TTY only). Non-positive
+//     values default to 24x80.
+//   - Opts: the same policy surface as Runner.Exec (WorkDir, Env, Net,
+//     Resources, Timeout). Policy is fixed at Start; Read/Write/Resize
+//     never re-negotiate it.
+type ProcessSpec struct {
+	ID   string
+	Argv []string
+	TTY  bool
+	Rows int
+	Cols int
+	Opts ExecOptions
+}
+
+// ProcessStream identifies which output stream a chunk belongs to.
+// Non-TTY sessions carry ProcessStreamStdout / ProcessStreamStderr;
+// TTY sessions carry only ProcessStreamTTY (the pty merges them).
+type ProcessStream int
+
+const (
+	ProcessStreamStdout ProcessStream = iota
+	ProcessStreamStderr
+	ProcessStreamTTY
+)
+
+func (s ProcessStream) String() string {
+	switch s {
+	case ProcessStreamStdout:
+		return "stdout"
+	case ProcessStreamStderr:
+		return "stderr"
+	case ProcessStreamTTY:
+		return "tty"
+	default:
+		return "unknown"
+	}
+}
+
+// OutputChunk is one contiguous run of bytes from one stream. Seq is
+// the sequence number of the chunk's first byte.
+type OutputChunk struct {
+	Seq    int64
+	Stream ProcessStream
+	Data   []byte
+}
+
+// ProcessOutput is one Read result. NextSeq is the cursor the caller
+// passes as afterSeq on the next Read (exclusive: output before
+// NextSeq has been returned). EOF reports that no further output will
+// ever arrive — the process exited and every buffered byte has been
+// returned up to NextSeq. Data remains replayable until Close even
+// after EOF.
+type ProcessOutput struct {
+	NextSeq int64
+	Chunks  []OutputChunk
+	EOF     bool
+}
+
+// ProcessExitReason classifies why the process ended.
+type ProcessExitReason int
+
+const (
+	// ProcessExited is a normal exit, including a non-zero exit code.
+	ProcessExited ProcessExitReason = iota
+	// ProcessSignaled means the OS reported death by signal (and the
+	// session was not the one that sent it).
+	ProcessSignaled
+	// ProcessTerminated means Terminate stopped the session.
+	ProcessTerminated
+	// ProcessTimedOut means ExecOptions.Timeout elapsed and the
+	// session was killed; Wait also returns an errdefs timeout error.
+	ProcessTimedOut
+	// ProcessBudgetExceeded means a resource cap (MemoryBytes /
+	// CPUMillicores) killed the session; Wait also returns an errdefs
+	// BudgetExceeded error.
+	ProcessBudgetExceeded
+	// ProcessUnenforceable means the cap watcher lost its ability to
+	// sample and killed the session rather than run it unguarded; Wait
+	// also returns an errdefs NotAvailable error.
+	ProcessUnenforceable
+)
+
+func (r ProcessExitReason) String() string {
+	switch r {
+	case ProcessExited:
+		return "exited"
+	case ProcessSignaled:
+		return "signaled"
+	case ProcessTerminated:
+		return "terminated"
+	case ProcessTimedOut:
+		return "timed_out"
+	case ProcessBudgetExceeded:
+		return "budget_exceeded"
+	case ProcessUnenforceable:
+		return "unenforceable"
+	default:
+		return "unknown"
+	}
+}
+
+// ProcessExit is the final outcome of a session. Code is the process
+// exit code (0 on success), or -1 when the reason is not an ordinary
+// exit. Signal carries the terminating signal for ProcessSignaled.
+type ProcessExit struct {
+	Code   int
+	Signal int
+	Reason ProcessExitReason
+}
+
+// ProcessInfo is a snapshot of one managed session for List.
+type ProcessInfo struct {
+	ID        string
+	Argv      []string
+	TTY       bool
+	PID       int
+	StartedAt time.Time
+	Running   bool
+	Exit      *ProcessExit
+}
+
+// Process is a live session handle. The zero state is never valid: a
+// Process comes from ProcessManager.Start.
+//
+// Lifecycle contract:
+//
+//   - Read uses an append-only output log. afterSeq is an exclusive
+//     cursor; each call returns at most maxBytes bytes and advances
+//     NextSeq. If the bounded buffer already dropped output at
+//     afterSeq, Read fails with ErrSequenceGap. Read blocks until data
+//     is available, EOF, or ctx is done. Output remains readable until
+//     Close, including after Wait.
+//   - Write sends raw bytes to the child (stdin pipe or pty master).
+//     It writes all data or fails; a blocked child can block Write past
+//     ctx cancellation.
+//   - Resize is only valid for TTY sessions; pipe sessions return
+//     errdefs.NotAvailable.
+//   - Terminate sends SIGTERM, then SIGKILL after a short grace period
+//     (or when ctx is done). It is idempotent on an exited process and
+//     leaves the output log readable.
+//   - Wait blocks until the process exits (or ctx is done) and returns
+//     the cached outcome; it is safe to call repeatedly and after
+//     Close.
+//   - Close terminates a still-running session, reaps it, and releases
+//     the output log. Close is idempotent; the manager forgets the
+//     session so it no longer appears in List.
+type Process interface {
+	ID() string
+	PID() int
+	Read(ctx context.Context, afterSeq int64, maxBytes int) (ProcessOutput, error)
+	Write(ctx context.Context, data []byte) error
+	Resize(ctx context.Context, rows, cols int) error
+	Terminate(ctx context.Context) error
+	Wait(ctx context.Context) (ProcessExit, error)
+	Close() error
+}
+
+// ProcessManager is the optional long-running-session capability of a
+// sandbox. Runner.Exec remains the one-shot interface; a Runner that
+// additionally implements ProcessManager can spawn interactive or
+// streaming processes under the same ExecOptions policy. Backends that
+// cannot spawn sessions must not implement this interface — callers
+// discover capability with ProcessManagerOf and never see a silent
+// downgrade, mirroring EnforcementOf.
+//
+// Policy is applied once, at Start: Read/Write/Resize/Terminate do not
+// re-negotiate Env/Net/Resources. Unsupported requests (e.g. TTY on a
+// backend without a pty) fail at Start with errdefs.NotAvailable.
+type ProcessManager interface {
+	Start(ctx context.Context, spec ProcessSpec) (Process, error)
+	List(ctx context.Context) ([]ProcessInfo, error)
+	Terminate(ctx context.Context, id string) error
+}
+
+// ProcessStarter implements one backend's spawn: it turns a ProcessSpec
+// into a launched Process. It is the injection seam shared by every
+// backend's ProcessManager (LocalRunner, seatbelt, bwrap) so session
+// bookkeeping stays in one place.
+type ProcessStarter func(ctx context.Context, spec ProcessSpec) (Process, error)
+
+// ProcessManagerOf returns the ProcessManager implemented by r, or nil
+// when the runner (including a nil one) does not support sessions. It
+// is the ProcessManager twin of EnforcementOf and the canonical way to
+// discover the optional capability on a decorated runner chain.
+func ProcessManagerOf(r Runner) ProcessManager {
+	if pm, ok := r.(ProcessManager); ok {
+		return pm
+	}
+	return nil
+}
+
+// NewProcessRegistry returns a ProcessManager whose sessions are
+// tracked in-process and started by starter. It implements the ID
+// uniqueness / generation, List, Terminate-by-ID, and Close removal
+// contract so every backend gets identical session semantics.
+func NewProcessRegistry(starter ProcessStarter) ProcessManager {
+	return &processRegistry{
+		starter:  starter,
+		sessions: make(map[string]*processRecord),
+	}
+}
+
+type processRegistry struct {
+	starter  ProcessStarter
+	mu       sync.Mutex
+	sessions map[string]*processRecord
+}
+
+type processRecord struct {
+	id      string
+	spec    ProcessSpec
+	proc    Process
+	pid     int
+	started time.Time
+	exited  bool
+	exit    ProcessExit
+	err     error
+}
+
+func (r *processRegistry) Start(ctx context.Context, spec ProcessSpec) (Process, error) {
+	if r.starter == nil {
+		return nil, errdefs.NotAvailablef("sandbox: process starter not configured")
+	}
+	if len(spec.Argv) == 0 {
+		return nil, errdefs.Validationf("sandbox: ProcessSpec.Argv must name a command")
+	}
+	id := spec.ID
+	if id == "" {
+		id = xid.New().String()
+	}
+
+	rec := &processRecord{id: id, spec: spec, started: time.Now()}
+	r.mu.Lock()
+	if _, exists := r.sessions[id]; exists {
+		r.mu.Unlock()
+		return nil, errdefs.Conflictf("sandbox: process id %q already exists", id)
+	}
+	r.sessions[id] = rec
+	r.mu.Unlock()
+
+	proc, err := r.starter(ctx, spec)
+	if err != nil {
+		r.remove(id)
+		return nil, err
+	}
+	if proc == nil {
+		r.remove(id)
+		return nil, errdefs.Internalf("sandbox: process starter returned a nil process")
+	}
+
+	r.mu.Lock()
+	rec.proc = proc
+	rec.pid = proc.PID()
+	r.mu.Unlock()
+
+	go r.track(id, proc)
+	return &registryProcess{inner: proc, reg: r, id: id}, nil
+}
+
+func (r *processRegistry) track(id string, proc Process) {
+	exit, err := proc.Wait(context.Background())
+	r.mu.Lock()
+	if rec := r.sessions[id]; rec != nil {
+		rec.exited = true
+		rec.exit = exit
+		rec.err = err
+	}
+	r.mu.Unlock()
+}
+
+func (r *processRegistry) List(context.Context) ([]ProcessInfo, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	out := make([]ProcessInfo, 0, len(r.sessions))
+	for _, rec := range r.sessions {
+		info := ProcessInfo{
+			ID:        rec.id,
+			Argv:      append([]string(nil), rec.spec.Argv...),
+			TTY:       rec.spec.TTY,
+			PID:       rec.pid,
+			StartedAt: rec.started,
+			Running:   !rec.exited,
+		}
+		if rec.exited {
+			info.Exit = &rec.exit
+		}
+		out = append(out, info)
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].StartedAt.Equal(out[j].StartedAt) {
+			return out[i].ID < out[j].ID
+		}
+		return out[i].StartedAt.Before(out[j].StartedAt)
+	})
+	return out, nil
+}
+
+func (r *processRegistry) Terminate(ctx context.Context, id string) error {
+	r.mu.Lock()
+	rec := r.sessions[id]
+	r.mu.Unlock()
+	if rec == nil {
+		return errdefs.NotFoundf("sandbox: unknown process id %q", id)
+	}
+	if rec.exited {
+		return nil
+	}
+	if rec.proc == nil {
+		return errdefs.NotAvailablef("sandbox: process %q is still starting", id)
+	}
+	if err := rec.proc.Terminate(ctx); err != nil {
+		return err
+	}
+	// Synchronise the record: List must reflect the termination as soon
+	// as Terminate returns, not whenever the background tracker next
+	// gets scheduled. Wait is already satisfied for a terminated
+	// process, so this is a quick state sync, not a second reaping.
+	waitCtx, cancel := context.WithTimeout(context.Background(), registryWaitTimeout)
+	defer cancel()
+	exit, err := rec.proc.Wait(waitCtx)
+	r.mu.Lock()
+	if cur := r.sessions[id]; cur == rec && !rec.exited {
+		rec.exited = true
+		rec.exit = exit
+		rec.err = err
+	}
+	r.mu.Unlock()
+	return nil
+}
+
+func (r *processRegistry) remove(id string) {
+	r.mu.Lock()
+	delete(r.sessions, id)
+	r.mu.Unlock()
+}
+
+// registryProcess forwards to the underlying session and removes the
+// registry record on Close. ID is the registry-resolved ID so callers
+// always see the stable identifier, including manager-generated ones.
+type registryProcess struct {
+	inner Process
+	reg   *processRegistry
+	id    string
+	once  sync.Once
+}
+
+func (p *registryProcess) ID() string { return p.id }
+func (p *registryProcess) PID() int   { return p.inner.PID() }
+
+func (p *registryProcess) Read(ctx context.Context, afterSeq int64, maxBytes int) (ProcessOutput, error) {
+	return p.inner.Read(ctx, afterSeq, maxBytes)
+}
+
+func (p *registryProcess) Write(ctx context.Context, data []byte) error {
+	return p.inner.Write(ctx, data)
+}
+
+func (p *registryProcess) Resize(ctx context.Context, rows, cols int) error {
+	return p.inner.Resize(ctx, rows, cols)
+}
+
+func (p *registryProcess) Terminate(ctx context.Context) error {
+	return p.inner.Terminate(ctx)
+}
+
+func (p *registryProcess) Wait(ctx context.Context) (ProcessExit, error) {
+	return p.inner.Wait(ctx)
+}
+
+func (p *registryProcess) Close() error {
+	err := p.inner.Close()
+	p.once.Do(func() { p.reg.remove(p.id) })
+	return err
+}

--- a/sdk/sandbox/process.go
+++ b/sdk/sandbox/process.go
@@ -206,6 +206,114 @@ type Process interface {
 	Close() error
 }
 
+// ProcessSignal is a soft signal a Process can receive. Unlike
+// Terminate, a signal interrupts: the process may catch it and
+// continue, and the session stays usable.
+type ProcessSignal int
+
+const (
+	// ProcessSignalInterrupt is Ctrl-C semantics: VINTR on TTY
+	// sessions (the terminal driver signals the foreground process
+	// group), SIGINT to the whole group on pipe sessions.
+	ProcessSignalInterrupt ProcessSignal = iota
+)
+
+func (s ProcessSignal) String() string {
+	switch s {
+	case ProcessSignalInterrupt:
+		return "interrupt"
+	default:
+		return "unknown"
+	}
+}
+
+// ProcessSignaler is the optional signal capability of a Process.
+// Discover it with ProcessSignalerOf. Backends without the capability
+// must not implement it; Signal then surfaces NotAvailable instead of
+// a silent no-op.
+type ProcessSignaler interface {
+	Signal(ctx context.Context, sig ProcessSignal) error
+}
+
+// ProcessSignalerOf returns the ProcessSignaler implemented by p, if
+// any. It is the (T, bool) twin of ProcessManagerOf for process-level
+// capabilities.
+func ProcessSignalerOf(p Process) (ProcessSignaler, bool) {
+	s, ok := p.(ProcessSignaler)
+	return s, ok
+}
+
+// ProcessEventType classifies one pushed process event.
+type ProcessEventType int
+
+const (
+	// ProcessEventOutput carries one output chunk (Seq = the chunk's
+	// first byte; Data references the process's immutable buffer).
+	ProcessEventOutput ProcessEventType = iota
+	// ProcessEventExited carries the final exit; Seq is the completion
+	// cursor (all output has been emitted).
+	ProcessEventExited
+	// ProcessEventClosed is emitted when the session is Closed; the
+	// Events channel closes right after it.
+	ProcessEventClosed
+	// ProcessEventLag means the subscriber's bounded queue overflowed.
+	// Seq is the first missed byte cursor: the consumer must
+	// Read(afterSeq=Lag.Seq) to fill the gap. The watcher closes
+	// immediately after this event — re-Watch to resume live delivery.
+	ProcessEventLag
+)
+
+func (t ProcessEventType) String() string {
+	switch t {
+	case ProcessEventOutput:
+		return "output"
+	case ProcessEventExited:
+		return "exited"
+	case ProcessEventClosed:
+		return "closed"
+	case ProcessEventLag:
+		return "lag"
+	default:
+		return "unknown"
+	}
+}
+
+// ProcessEvent is one pushed event. Field validity follows Type:
+// Output fills Seq/Stream/Data; Exited fills Seq/Exit; Lag fills Seq;
+// Closed fills Seq only.
+type ProcessEvent struct {
+	Seq    int64
+	Type   ProcessEventType
+	Stream ProcessStream
+	Data   []byte
+	Exit   *ProcessExit
+}
+
+// ProcessWatcher is one subscription to a Process's event stream.
+// Events delivers replay-then-live events in seq order. The channel
+// closes when ctx cancels, when Close is called, or right after the
+// process's Closed event.
+type ProcessWatcher interface {
+	Events() <-chan ProcessEvent
+	Close() error
+}
+
+// ProcessEventSource is the optional push-capability of a Process:
+// Watch subscribes one independent bounded queue that replays the
+// retained output before delivering live events. Discover it with
+// ProcessEventSourceOf. Pull-based Read is unchanged and stays the
+// recovery path after ProcessEventLag.
+type ProcessEventSource interface {
+	Watch(ctx context.Context) (ProcessWatcher, error)
+}
+
+// ProcessEventSourceOf returns the ProcessEventSource implemented by
+// p, if any.
+func ProcessEventSourceOf(p Process) (ProcessEventSource, bool) {
+	s, ok := p.(ProcessEventSource)
+	return s, ok
+}
+
 // ProcessManager is the optional long-running-session capability of a
 // sandbox. Runner.Exec remains the one-shot interface; a Runner that
 // additionally implements ProcessManager can spawn interactive or
@@ -289,6 +397,9 @@ func (r *processRegistry) Start(ctx context.Context, spec ProcessSpec) (Process,
 	r.sessions[id] = rec
 	r.mu.Unlock()
 
+	// Resolve the ID before spawning so the backend's Process handle
+	// and the registry record share one identifier.
+	spec.ID = id
 	proc, err := r.starter(ctx, spec)
 	if err != nil {
 		r.remove(id)
@@ -412,6 +523,28 @@ func (p *registryProcess) Resize(ctx context.Context, rows, cols int) error {
 
 func (p *registryProcess) Terminate(ctx context.Context) error {
 	return p.inner.Terminate(ctx)
+}
+
+// Signal forwards the optional signal capability of the underlying
+// session. registryProcess wraps inner as a named field, so methods
+// are not promoted automatically; the wrapper must implement the
+// optional interfaces itself for discovery to work on Start handles.
+func (p *registryProcess) Signal(ctx context.Context, sig ProcessSignal) error {
+	signaler, ok := ProcessSignalerOf(p.inner)
+	if !ok {
+		return errdefs.NotAvailablef("sandbox: process does not support signals")
+	}
+	return signaler.Signal(ctx, sig)
+}
+
+// Watch forwards the optional event-source capability of the
+// underlying session, mirroring Signal.
+func (p *registryProcess) Watch(ctx context.Context) (ProcessWatcher, error) {
+	source, ok := ProcessEventSourceOf(p.inner)
+	if !ok {
+		return nil, errdefs.NotAvailablef("sandbox: process does not support event streams")
+	}
+	return source.Watch(ctx)
 }
 
 func (p *registryProcess) Wait(ctx context.Context) (ProcessExit, error) {

--- a/sdk/sandbox/process_other.go
+++ b/sdk/sandbox/process_other.go
@@ -1,0 +1,28 @@
+//go:build !unix
+
+package sandbox
+
+import (
+	"context"
+	"os/exec"
+
+	"github.com/GizClaw/flowcraft/sdk/errdefs"
+)
+
+// StartSession is not available off unix: interactive sessions need
+// pty(4), process groups, and signal delivery that have no portable
+// Windows equivalent. ProcessManagerOf still discovers the capability
+// through ProcessManager, so callers see NotAvailable rather than a
+// silent downgrade.
+func StartSession(_ context.Context, _ *exec.Cmd, _ ExecOptions, _ bool, _, _ int) (Process, error) {
+	return nil, errdefs.NotAvailablef(
+		"sandbox: interactive process sessions require a unix platform")
+}
+
+// spawnProcess is the non-unix LocalRunner starter: the registry stays
+// functional, but every Start fails with NotAvailable rather than
+// silently downgrading to a one-shot Exec.
+func (r *LocalRunner) spawnProcess(context.Context, ProcessSpec) (Process, error) {
+	return nil, errdefs.NotAvailablef(
+		"sandbox: interactive process sessions require a unix platform")
+}

--- a/sdk/sandbox/process_other.go
+++ b/sdk/sandbox/process_other.go
@@ -14,7 +14,7 @@ import (
 // Windows equivalent. ProcessManagerOf still discovers the capability
 // through ProcessManager, so callers see NotAvailable rather than a
 // silent downgrade.
-func StartSession(_ context.Context, _ *exec.Cmd, _ ExecOptions, _ bool, _, _ int) (Process, error) {
+func StartSession(_ context.Context, _ ProcessSpec, _ *exec.Cmd) (Process, error) {
 	return nil, errdefs.NotAvailablef(
 		"sandbox: interactive process sessions require a unix platform")
 }

--- a/sdk/sandbox/process_test.go
+++ b/sdk/sandbox/process_test.go
@@ -1,0 +1,199 @@
+package sandbox_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/GizClaw/flowcraft/sdk/errdefs"
+	"github.com/GizClaw/flowcraft/sdk/sandbox"
+)
+
+func TestProcessManagerOf_Discovery(t *testing.T) {
+	if pm := sandbox.ProcessManagerOf(sandbox.NewLocalRunner(t.TempDir())); pm == nil {
+		t.Fatal("LocalRunner must implement ProcessManager")
+	}
+	if pm := sandbox.ProcessManagerOf(sandbox.NoopRunner{}); pm != nil {
+		t.Fatalf("NoopRunner must not advertise sessions, got %T", pm)
+	}
+	if pm := sandbox.ProcessManagerOf(nil); pm != nil {
+		t.Fatalf("nil runner must yield nil ProcessManager, got %T", pm)
+	}
+
+	// Decorators forward the capability; a chain over a non-PM runner
+	// still answers ProcessManagerOf but fails Start with NotAvailable.
+	local := sandbox.NewLocalRunner(t.TempDir())
+	chained := sandbox.WithDefaults(
+		sandbox.AllowCommands(local, []string{"echo"}),
+		sandbox.ExecOptions{Timeout: 1},
+	)
+	if pm := sandbox.ProcessManagerOf(chained); pm == nil {
+		t.Fatal("decorated LocalRunner must forward ProcessManager")
+	}
+	noopChain := sandbox.WithDefaults(sandbox.NoopRunner{}, sandbox.ExecOptions{Timeout: 1})
+	if pm := sandbox.ProcessManagerOf(noopChain); pm == nil {
+		t.Fatal("ProcessManagerOf on decorated runner must report the decorator")
+	}
+	if _, err := sandbox.ProcessManagerOf(noopChain).Start(
+		context.Background(), sandbox.ProcessSpec{Argv: []string{"echo"}}); !errdefs.IsNotAvailable(err) {
+		t.Fatalf("Start over NoopRunner = %v, want NotAvailable", err)
+	}
+}
+
+func TestWithDefaults_ProcessManagerMergesPolicy(t *testing.T) {
+	fake := &fakeRunner{pm: &fakePM{}}
+	defaults := sandbox.ExecOptions{
+		Timeout: 5,
+		Env: sandbox.EnvPolicy{
+			Allow:  []string{"DEFAULT"},
+			Inject: map[string]string{"D": "d"},
+		},
+		Net: sandbox.NetPolicy{Mode: sandbox.NetDenyAll},
+		Resources: sandbox.ResourceLimits{
+			MemoryBytes: 1 << 20,
+		},
+	}
+	rn := sandbox.WithDefaults(fake, defaults)
+	pm := sandbox.ProcessManagerOf(rn)
+	if pm == nil {
+		t.Fatal("WithDefaults must forward ProcessManager")
+	}
+
+	_, err := pm.Start(context.Background(), sandbox.ProcessSpec{
+		Argv: []string{"sh"},
+		Opts: sandbox.ExecOptions{
+			Timeout: 100,
+			Env: sandbox.EnvPolicy{
+				Allow:  []string{"CALLER"},
+				Inject: map[string]string{"C": "c"},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	got := fake.pm.specs[0].Opts
+	if got.Timeout != 5 {
+		t.Errorf("Timeout = %v, want min(100, 5) = 5", got.Timeout)
+	}
+	if len(got.Env.Allow) != 1 || got.Env.Allow[0] != "DEFAULT" {
+		t.Errorf("Env.Allow = %v, want defaults to win", got.Env.Allow)
+	}
+	if got.Env.Inject["D"] != "d" || got.Env.Inject["C"] != "c" {
+		t.Errorf("Env.Inject = %v, want union with caller override", got.Env.Inject)
+	}
+	if got.Net.Mode != sandbox.NetDenyAll {
+		t.Errorf("Net = %+v, want defaults to win", got.Net)
+	}
+	if got.Resources.MemoryBytes != 1<<20 {
+		t.Errorf("Resources = %+v, want defaults to win", got.Resources)
+	}
+}
+
+func TestWithApproval_ProcessManagerGatesStartWithTTY(t *testing.T) {
+	fake := &fakeRunner{pm: &fakePM{}}
+	var got []sandbox.ExecRequest
+	approve := func(_ context.Context, req sandbox.ApprovalRequest) (sandbox.Decision, error) {
+		got = append(got, req.Exec)
+		return sandbox.Allow, nil
+	}
+	rn := sandbox.WithApproval(fake, approve, sandbox.CommandPatterns("sh"))
+	pm := sandbox.ProcessManagerOf(rn)
+	if pm == nil {
+		t.Fatal("WithApproval must forward ProcessManager")
+	}
+
+	if _, err := pm.Start(context.Background(), sandbox.ProcessSpec{
+		Argv: []string{"sh", "-c", "x"},
+		TTY:  true,
+	}); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("approver called %d times, want 1", len(got))
+	}
+	if !got[0].TTY || got[0].Command != "sh" {
+		t.Fatalf("approver saw %+v, want TTY=true sh", got[0])
+	}
+
+	deny := sandbox.WithApproval(fake, func(context.Context, sandbox.ApprovalRequest) (sandbox.Decision, error) {
+		return sandbox.Deny, nil
+	}, sandbox.CommandPatterns("sh"))
+	if _, err := sandbox.ProcessManagerOf(deny).Start(context.Background(), sandbox.ProcessSpec{
+		Argv: []string{"sh"},
+	}); !errdefs.IsPolicyDenied(err) {
+		t.Fatalf("denied Start = %v, want PolicyDenied", err)
+	}
+}
+
+func TestAllowCommands_ProcessManagerGatesStart(t *testing.T) {
+	fake := &fakeRunner{pm: &fakePM{}}
+	rn := sandbox.AllowCommands(fake, []string{"sh"})
+	pm := sandbox.ProcessManagerOf(rn)
+	if pm == nil {
+		t.Fatal("AllowCommands must forward ProcessManager")
+	}
+	if _, err := pm.Start(context.Background(), sandbox.ProcessSpec{
+		Argv: []string{"bash"},
+	}); !errdefs.IsPolicyDenied(err) {
+		t.Fatalf("non-whitelisted Start = %v, want PolicyDenied", err)
+	}
+	if _, err := pm.Start(context.Background(), sandbox.ProcessSpec{
+		Argv: []string{"sh"},
+	}); err != nil {
+		t.Fatalf("whitelisted Start: %v", err)
+	}
+}
+
+type fakeProcess struct{}
+
+func (fakeProcess) ID() string { return "fake" }
+func (fakeProcess) PID() int   { return 42 }
+func (fakeProcess) Read(context.Context, int64, int) (sandbox.ProcessOutput, error) {
+	return sandbox.ProcessOutput{}, nil
+}
+func (fakeProcess) Write(context.Context, []byte) error { return nil }
+func (fakeProcess) Resize(context.Context, int, int) error {
+	return nil
+}
+func (fakeProcess) Terminate(context.Context) error { return nil }
+func (fakeProcess) Wait(context.Context) (sandbox.ProcessExit, error) {
+	return sandbox.ProcessExit{}, nil
+}
+func (fakeProcess) Close() error { return nil }
+
+type fakePM struct {
+	specs []sandbox.ProcessSpec
+}
+
+func (f *fakePM) Start(_ context.Context, spec sandbox.ProcessSpec) (sandbox.Process, error) {
+	f.specs = append(f.specs, spec)
+	return fakeProcess{}, nil
+}
+
+func (f *fakePM) List(context.Context) ([]sandbox.ProcessInfo, error) {
+	return nil, nil
+}
+
+func (f *fakePM) Terminate(context.Context, string) error {
+	return nil
+}
+
+type fakeRunner struct {
+	pm *fakePM
+}
+
+func (r fakeRunner) Exec(context.Context, string, []string, sandbox.ExecOptions) (*sandbox.ExecResult, error) {
+	return &sandbox.ExecResult{}, nil
+}
+
+func (r fakeRunner) Start(ctx context.Context, spec sandbox.ProcessSpec) (sandbox.Process, error) {
+	return r.pm.Start(ctx, spec)
+}
+
+func (r fakeRunner) List(ctx context.Context) ([]sandbox.ProcessInfo, error) {
+	return r.pm.List(ctx)
+}
+
+func (r fakeRunner) Terminate(ctx context.Context, id string) error {
+	return r.pm.Terminate(ctx, id)
+}

--- a/sdk/sandbox/process_unix.go
+++ b/sdk/sandbox/process_unix.go
@@ -1,0 +1,574 @@
+//go:build unix
+
+package sandbox
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"sync"
+	"syscall"
+	"time"
+
+	"github.com/GizClaw/flowcraft/sdk/errdefs"
+
+	"github.com/creack/pty"
+)
+
+const (
+	defaultSessionRows = 24
+	defaultSessionCols = 80
+	sessionCopyChunk   = 32 * 1024
+	// sessionTerminateGrace is how long Terminate waits after SIGTERM
+	// before escalating to SIGKILL, so TUI/REPL children get a chance
+	// to restore the terminal and flush state.
+	sessionTerminateGrace = 2 * time.Second
+)
+
+// StartSession launches an already-configured *exec.Cmd as a Process.
+// cmd.Dir / cmd.Env must already be resolved by the caller; StartSession
+// owns the stdio plumbing only:
+//
+//   - tty=true: a pty becomes the child's controlling terminal; stdout
+//     and stderr are merged into ProcessStreamTTY.
+//   - tty=false: stdin is piped and stdout/stderr are tagged streams.
+//
+// Policy validation belongs to the backend (see ValidateExecPolicy);
+// this constructor enforces mechanics only. opts.Resources.
+// MaxOutputBytes bounds the replayable output ring when positive;
+// non-positive keeps all output (callers that want the default cap
+// must apply it, as the built-in runners do).
+//
+// StartSession is the shared seam the built-in runners use so
+// seatbelt/bwrap/LocalRunner all get identical seq, resize, and
+// termination semantics.
+func StartSession(ctx context.Context, cmd *exec.Cmd, opts ExecOptions, tty bool, rows, cols int) (Process, error) {
+	if cmd == nil {
+		return nil, errdefs.Validationf("sandbox: nil command for process session")
+	}
+	if rows <= 0 {
+		rows = defaultSessionRows
+	}
+	if cols <= 0 {
+		cols = defaultSessionCols
+	}
+
+	s := &session{
+		cmd:  cmd,
+		out:  newOutputLog(opts.Resources.MaxOutputBytes),
+		done: make(chan struct{}),
+	}
+
+	if tty {
+		ptmx, err := pty.StartWithSize(cmd, &pty.Winsize{Rows: uint16(rows), Cols: uint16(cols)})
+		if err != nil {
+			return nil, classifyStartError(cmd.Path, err)
+		}
+		s.ptmx = ptmx
+		s.stdin = ptmx
+		s.pgid = cmd.Process.Pid
+		s.copiers.Add(1)
+		go func() {
+			defer s.copiers.Done()
+			s.copyLoop(ptmx)
+		}()
+	} else {
+		stdin, err := cmd.StdinPipe()
+		if err != nil {
+			return nil, classifyStartError(cmd.Path, err)
+		}
+		cmd.Stdout = sessionWriter{out: s.out, stream: ProcessStreamStdout}
+		cmd.Stderr = sessionWriter{out: s.out, stream: ProcessStreamStderr}
+		// Unlike Exec, the session owns cancellation: no CommandContext
+		// Cancel hook (which would reject a plain exec.Command), and no
+		// ctx kill — the session lives until Terminate/Close.
+		cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+		if err := cmd.Start(); err != nil {
+			_ = stdin.Close()
+			return nil, classifyStartError(cmd.Path, err)
+		}
+		s.stdin = stdin
+		s.pgid = cmd.Process.Pid
+	}
+	s.proc = cmd.Process
+
+	if opts.Resources.MemoryBytes > 0 || opts.Resources.CPUMillicores > 0 {
+		// The Start ctx only bounds the spawn; the session outlives it.
+		// WithoutCancel keeps the watcher's telemetry rooted in the
+		// originating trace without making a canceled Start kill the
+		// session.
+		s.watcher = StartGroupCapsWatcher(context.WithoutCancel(ctx), s.pgid, opts.Resources, opts.Timeout)
+	}
+	if opts.Timeout > 0 {
+		timer := time.AfterFunc(opts.Timeout, s.timeoutKill)
+		go func() {
+			<-s.done
+			timer.Stop()
+		}()
+	}
+	go s.reap()
+	return s, nil
+}
+
+// spawnProcess is LocalRunner's ProcessStarter: it applies the same
+// policy surface as Exec and hands the configured command to the
+// shared session implementation.
+func (r *LocalRunner) spawnProcess(ctx context.Context, spec ProcessSpec) (Process, error) {
+	if err := ValidateExecPolicy(spec.Opts); err != nil {
+		return nil, err
+	}
+	if spec.Opts.Net.Mode != NetDefault {
+		return nil, errdefs.NotAvailablef(
+			"sandbox: net policy not supported by local runner; requires a kernel-level isolation backend")
+	}
+	workDir, err := r.resolveWorkDir(spec.Opts.WorkDir)
+	if err != nil {
+		return nil, err
+	}
+	maxOut := spec.Opts.Resources.MaxOutputBytes
+	if maxOut <= 0 {
+		maxOut = r.defaultMaxOutput
+	}
+	spec.Opts.Resources.MaxOutputBytes = maxOut
+
+	cmd := exec.Command(spec.Argv[0], spec.Argv[1:]...)
+	cmd.Dir = workDir
+	cmd.Env = buildEnv(spec.Opts.Env)
+	return StartSession(ctx, cmd, spec.Opts, spec.TTY, spec.Rows, spec.Cols)
+}
+
+// session is the concrete Process implementation shared by all unix
+// backends.
+type session struct {
+	cmd     *exec.Cmd
+	ptmx    *os.File
+	stdin   io.WriteCloser
+	proc    *os.Process
+	pgid    int
+	out     *outputLog
+	watcher *GroupCapsWatcher
+	copiers sync.WaitGroup
+
+	mu         sync.Mutex
+	closed     bool
+	timedOut   bool
+	terminated bool
+	exit       ProcessExit
+	waitErr    error
+	done       chan struct{}
+}
+
+func (s *session) ID() string { return "" }
+
+func (s *session) PID() int {
+	if s.proc == nil {
+		return 0
+	}
+	return s.proc.Pid
+}
+
+func (s *session) Read(ctx context.Context, afterSeq int64, maxBytes int) (ProcessOutput, error) {
+	if s.isClosed() {
+		return ProcessOutput{}, ErrProcessClosed
+	}
+	return s.out.read(ctx, afterSeq, maxBytes)
+}
+
+func (s *session) Write(ctx context.Context, data []byte) error {
+	if s.isClosed() {
+		return ErrProcessClosed
+	}
+	if len(data) == 0 {
+		return nil
+	}
+	done := make(chan error, 1)
+	go func() {
+		_, err := io.Copy(s.stdin, bytes.NewReader(data))
+		done <- err
+	}()
+	select {
+	case err := <-done:
+		if err != nil {
+			return errdefs.Internal(fmt.Errorf("sandbox: process write: %w", err))
+		}
+		return nil
+	case <-ctx.Done():
+		// The child is not draining; the write goroutine stays blocked
+		// on the fd until the session closes. Callers should not retry
+		// the same bytes blindly.
+		return ctx.Err()
+	}
+}
+
+func (s *session) Resize(_ context.Context, rows, cols int) error {
+	if rows <= 0 || cols <= 0 {
+		return errdefs.Validationf("sandbox: rows and cols must be positive")
+	}
+	if s.isClosed() {
+		return ErrProcessClosed
+	}
+	s.mu.Lock()
+	ptmx := s.ptmx
+	s.mu.Unlock()
+	if ptmx == nil {
+		return errdefs.NotAvailablef("sandbox: Resize requires a TTY session")
+	}
+	return pty.Setsize(ptmx, &pty.Winsize{Rows: uint16(rows), Cols: uint16(cols)})
+}
+
+func (s *session) Terminate(ctx context.Context) error {
+	if s.isClosed() {
+		return ErrProcessClosed
+	}
+	select {
+	case <-s.done:
+		return nil
+	default:
+	}
+	s.mu.Lock()
+	s.terminated = true
+	s.mu.Unlock()
+	return s.signal(ctx, false)
+}
+
+func (s *session) Wait(ctx context.Context) (ProcessExit, error) {
+	select {
+	case <-s.done:
+	case <-ctx.Done():
+		return ProcessExit{}, ctx.Err()
+	}
+	s.mu.Lock()
+	exit, err := s.exit, s.waitErr
+	s.mu.Unlock()
+	return exit, err
+}
+
+func (s *session) Close() error {
+	s.mu.Lock()
+	if s.closed {
+		s.mu.Unlock()
+		return nil
+	}
+	s.closed = true
+	s.mu.Unlock()
+
+	select {
+	case <-s.done:
+	default:
+		_ = syscall.Kill(-s.pgid, syscall.SIGKILL)
+		<-s.done
+	}
+	if s.ptmx != nil {
+		_ = s.ptmx.Close()
+	}
+	if s.stdin != nil && s.stdin != s.ptmx {
+		_ = s.stdin.Close()
+	}
+	s.out.close()
+	return nil
+}
+
+func (s *session) isClosed() bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.closed
+}
+
+// timeoutKill is the ExecOptions.Timeout enforcement: the session is
+// killed with SIGKILL, like Runner.Exec does on ctx deadline.
+func (s *session) timeoutKill() {
+	s.mu.Lock()
+	s.timedOut = true
+	s.mu.Unlock()
+	_ = s.signal(context.Background(), true)
+}
+
+// signal stops the session. force uses SIGKILL directly (timeout /
+// close path); otherwise SIGTERM first with a short grace period
+// bounded by ctx.
+func (s *session) signal(ctx context.Context, force bool) error {
+	if force {
+		_ = syscall.Kill(-s.pgid, syscall.SIGKILL)
+		return nil
+	}
+	_ = syscall.Kill(-s.pgid, syscall.SIGTERM)
+
+	grace := sessionTerminateGrace
+	if deadline, ok := ctx.Deadline(); ok {
+		if remaining := time.Until(deadline); remaining < grace {
+			grace = remaining
+		}
+	}
+	if grace <= 0 {
+		_ = syscall.Kill(-s.pgid, syscall.SIGKILL)
+		return ctx.Err()
+	}
+	timer := time.NewTimer(grace)
+	defer timer.Stop()
+	select {
+	case <-s.done:
+		return nil
+	case <-timer.C:
+		_ = syscall.Kill(-s.pgid, syscall.SIGKILL)
+		return nil
+	case <-ctx.Done():
+		_ = syscall.Kill(-s.pgid, syscall.SIGKILL)
+		return ctx.Err()
+	}
+}
+
+// reap reaps the child, classifies the outcome, then finishes the
+// output log. cmd.Wait also waits for the stdout/stderr copy goroutines
+// (sessionWriter), so finish() after Wait never races buffered output.
+func (s *session) reap() {
+	waitErr := s.cmd.Wait()
+	if s.watcher != nil {
+		s.watcher.Stop()
+	}
+	if s.ptmx != nil {
+		_ = s.ptmx.Close()
+	}
+	// The pty copier may still hold bytes read before the child's last
+	// write flushed; wait for it so EOF is never reported early.
+	s.copiers.Wait()
+
+	exit, err := s.classifyExit(waitErr)
+	s.mu.Lock()
+	s.exit = exit
+	s.waitErr = err
+	s.mu.Unlock()
+	s.out.finish()
+	close(s.done)
+}
+
+func (s *session) classifyExit(waitErr error) (ProcessExit, error) {
+	if s.watcher != nil {
+		// Order matters: a watcher that gave up on sampling killed the
+		// group without proving any budget was exceeded, so reporting
+		// BudgetExceeded there would be a false accusation.
+		if sampleErr := s.watcher.Unenforceable(); sampleErr != nil {
+			return ProcessExit{Code: -1, Reason: ProcessUnenforceable},
+				errdefs.NotAvailablef(
+					"sandbox: resource caps became unenforceable while running process: %v", sampleErr)
+		}
+		if cap := s.watcher.Exceeded(); cap != "" {
+			return ProcessExit{Code: -1, Reason: ProcessBudgetExceeded},
+				errdefs.BudgetExceededf(
+					"sandbox: %s resource cap exceeded while running process", cap)
+		}
+	}
+
+	s.mu.Lock()
+	timedOut := s.timedOut
+	terminated := s.terminated
+	s.mu.Unlock()
+	if timedOut {
+		return ProcessExit{Code: -1, Reason: ProcessTimedOut},
+			errdefs.FromContext(fmt.Errorf("sandbox: process exceeded its Timeout: %w", context.DeadlineExceeded))
+	}
+	if waitErr == nil {
+		return ProcessExit{Code: 0, Reason: ProcessExited}, nil
+	}
+	if exitErr, ok := waitErr.(*exec.ExitError); ok {
+		if ws, ok := exitErr.Sys().(syscall.WaitStatus); ok && ws.Signaled() {
+			if terminated {
+				return ProcessExit{Code: -1, Signal: int(ws.Signal()), Reason: ProcessTerminated}, nil
+			}
+			return ProcessExit{Code: -1, Signal: int(ws.Signal()), Reason: ProcessSignaled}, nil
+		}
+		return ProcessExit{Code: exitErr.ExitCode(), Reason: ProcessExited}, nil
+	}
+	return ProcessExit{Code: -1, Reason: ProcessExited},
+		errdefs.Internal(fmt.Errorf("sandbox: process wait: %w", waitErr))
+}
+
+func (s *session) copyLoop(r io.Reader) {
+	buf := make([]byte, sessionCopyChunk)
+	for {
+		n, err := r.Read(buf)
+		if n > 0 {
+			s.out.append(ProcessStreamTTY, buf[:n])
+		}
+		if err != nil {
+			return
+		}
+	}
+}
+
+// sessionWriter is exec.Cmd's stdout/stderr sink for pipe sessions.
+// cmd.Wait waits for these writers, so output ordering relative to
+// process exit is exact.
+type sessionWriter struct {
+	out    *outputLog
+	stream ProcessStream
+}
+
+func (w sessionWriter) Write(p []byte) (int, error) {
+	w.out.append(w.stream, p)
+	return len(p), nil
+}
+
+// outputLog is the append-only, bounded, replayable output buffer. Seq
+// is a byte cursor: each chunk records the sequence of its first byte
+// and the log advances by len(data). When the ring budget is exceeded,
+// oldest whole chunks are dropped and Read reports ErrSequenceGap for
+// cursors below the retained range.
+type outputLog struct {
+	mu      sync.Mutex
+	wake    chan struct{}
+	chunks  []outputChunk
+	total   int64
+	nextSeq int64
+	max     int64
+	eof     bool
+	closed  bool
+}
+
+type outputChunk struct {
+	seq    int64
+	stream ProcessStream
+	data   []byte
+}
+
+func newOutputLog(maxBytes int64) *outputLog {
+	return &outputLog{wake: make(chan struct{}), max: maxBytes}
+}
+
+func (l *outputLog) append(stream ProcessStream, data []byte) {
+	if len(data) == 0 {
+		return
+	}
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	if l.closed {
+		return
+	}
+	l.chunks = append(l.chunks, outputChunk{
+		seq:    l.nextSeq,
+		stream: stream,
+		data:   append([]byte(nil), data...),
+	})
+	l.total += int64(len(data))
+	l.nextSeq += int64(len(data))
+	l.trimLocked()
+	l.wakeReadersLocked()
+}
+
+func (l *outputLog) finish() {
+	l.mu.Lock()
+	l.eof = true
+	l.wakeReadersLocked()
+	l.mu.Unlock()
+}
+
+func (l *outputLog) close() {
+	l.mu.Lock()
+	l.closed = true
+	l.wakeReadersLocked()
+	l.mu.Unlock()
+}
+
+// read returns output at/after afterSeq, at most maxBytes, blocking
+// until data, EOF, or ctx cancellation.
+func (l *outputLog) read(ctx context.Context, afterSeq int64, maxBytes int) (ProcessOutput, error) {
+	if maxBytes <= 0 {
+		return ProcessOutput{}, errdefs.Validationf("sandbox: Read maxBytes must be positive")
+	}
+	l.mu.Lock()
+	for {
+		if l.closed {
+			l.mu.Unlock()
+			return ProcessOutput{}, ErrProcessClosed
+		}
+		if retained := l.retainedSeqLocked(); retained > afterSeq {
+			l.mu.Unlock()
+			return ProcessOutput{}, fmt.Errorf("%w: afterSeq %d, retained from %d", ErrSequenceGap, afterSeq, retained)
+		}
+		if l.nextSeq < afterSeq {
+			l.mu.Unlock()
+			return ProcessOutput{}, errdefs.Validationf(
+				"sandbox: afterSeq %d is beyond buffered output (next=%d)", afterSeq, l.nextSeq)
+		}
+		if out, ok := l.collectLocked(afterSeq, maxBytes); ok {
+			l.mu.Unlock()
+			return out, nil
+		}
+		if l.eof {
+			l.mu.Unlock()
+			return ProcessOutput{NextSeq: afterSeq, EOF: true}, nil
+		}
+		wake := l.wake
+		l.mu.Unlock()
+		select {
+		case <-wake:
+		case <-ctx.Done():
+			return ProcessOutput{}, ctx.Err()
+		}
+		l.mu.Lock()
+	}
+}
+
+func (l *outputLog) collectLocked(afterSeq int64, maxBytes int) (ProcessOutput, bool) {
+	remaining := int64(maxBytes)
+	next := afterSeq
+	var chunks []OutputChunk
+	for _, ch := range l.chunks {
+		if remaining <= 0 {
+			break
+		}
+		end := ch.seq + int64(len(ch.data))
+		if next >= end {
+			continue
+		}
+		start := next - ch.seq
+		n := int64(len(ch.data)) - start
+		if n > remaining {
+			n = remaining
+		}
+		chunks = append(chunks, OutputChunk{
+			Seq:    next,
+			Stream: ch.stream,
+			Data:   append([]byte(nil), ch.data[start:start+n]...),
+		})
+		next += n
+		remaining -= n
+	}
+	if len(chunks) == 0 {
+		return ProcessOutput{}, false
+	}
+	return ProcessOutput{
+		NextSeq: next,
+		Chunks:  chunks,
+		EOF:     l.eof && next == l.nextSeq,
+	}, true
+}
+
+func (l *outputLog) retainedSeqLocked() int64 {
+	if len(l.chunks) == 0 {
+		return l.nextSeq
+	}
+	return l.chunks[0].seq
+}
+
+func (l *outputLog) trimLocked() {
+	if l.max <= 0 {
+		return
+	}
+	// Never drop the only chunk: a single chunk larger than the budget
+	// is bounded by sessionCopyChunk and stays replayable.
+	for len(l.chunks) > 1 && l.total > l.max {
+		l.total -= int64(len(l.chunks[0].data))
+		l.chunks = l.chunks[1:]
+	}
+}
+
+// wakeReadersLocked notifies blocked Reads that the log changed. The
+// closed channel is immediately replaced so future waits get a fresh
+// signal channel.
+func (l *outputLog) wakeReadersLocked() {
+	close(l.wake)
+	l.wake = make(chan struct{})
+}

--- a/sdk/sandbox/process_unix.go
+++ b/sdk/sandbox/process_unix.go
@@ -230,11 +230,17 @@ func (s *session) Resize(_ context.Context, rows, cols int) error {
 	}
 	s.mu.Lock()
 	ptmx := s.ptmx
-	s.mu.Unlock()
 	if ptmx == nil {
+		s.mu.Unlock()
 		return errdefs.NotAvailablef("sandbox: Resize requires a TTY session")
 	}
-	return pty.Setsize(ptmx, &pty.Winsize{Rows: uint16(rows), Cols: uint16(cols)})
+	// Setsize uses Fd(), which is not safe against a concurrent Close
+	// (reap / Close nil the field under the same lock, then close the
+	// fd outside it). Holding the lock across the ioctl serializes the
+	// two paths.
+	err := pty.Setsize(ptmx, &pty.Winsize{Rows: uint16(rows), Cols: uint16(cols)})
+	s.mu.Unlock()
+	return err
 }
 
 func (s *session) Terminate(ctx context.Context) error {
@@ -362,11 +368,19 @@ func (s *session) Close() error {
 		_ = syscall.Kill(-s.pgid, syscall.SIGKILL)
 		<-s.done
 	}
-	if s.ptmx != nil {
-		_ = s.ptmx.Close()
+	s.mu.Lock()
+	ptmx := s.ptmx
+	s.ptmx = nil
+	s.mu.Unlock()
+	if ptmx != nil {
+		_ = ptmx.Close()
 	}
-	if s.stdin != nil && s.stdin != s.ptmx {
-		_ = s.stdin.Close()
+	s.mu.Lock()
+	stdin := s.stdin
+	s.stdin = nil
+	s.mu.Unlock()
+	if stdin != nil && stdin != ptmx {
+		_ = stdin.Close()
 	}
 	s.out.close()
 	return nil
@@ -429,8 +443,12 @@ func (s *session) reap() {
 	if s.watcher != nil {
 		s.watcher.Stop()
 	}
-	if s.ptmx != nil {
-		_ = s.ptmx.Close()
+	s.mu.Lock()
+	ptmx := s.ptmx
+	s.ptmx = nil
+	s.mu.Unlock()
+	if ptmx != nil {
+		_ = ptmx.Close()
 	}
 	// The pty copier may still hold bytes read before the child's last
 	// write flushed; wait for it so EOF is never reported early.

--- a/sdk/sandbox/process_unix.go
+++ b/sdk/sandbox/process_unix.go
@@ -5,6 +5,7 @@ package sandbox
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -16,12 +17,17 @@ import (
 	"github.com/GizClaw/flowcraft/sdk/errdefs"
 
 	"github.com/creack/pty"
+	"github.com/rs/xid"
 )
 
 const (
 	defaultSessionRows = 24
 	defaultSessionCols = 80
 	sessionCopyChunk   = 32 * 1024
+	// watcherQueueSize bounds each event subscriber's live queue.
+	// Overflow surfaces as ProcessEventLag followed by the watcher
+	// closing; consumers recover with Read(afterSeq).
+	watcherQueueSize = 256
 	// sessionTerminateGrace is how long Terminate waits after SIGTERM
 	// before escalating to SIGKILL, so TUI/REPL children get a chance
 	// to restore the terminal and flush state.
@@ -37,7 +43,7 @@ const (
 //   - tty=false: stdin is piped and stdout/stderr are tagged streams.
 //
 // Policy validation belongs to the backend (see ValidateExecPolicy);
-// this constructor enforces mechanics only. opts.Resources.
+// this constructor enforces mechanics only. spec.Opts.Resources.
 // MaxOutputBytes bounds the replayable output ring when positive;
 // non-positive keeps all output (callers that want the default cap
 // must apply it, as the built-in runners do).
@@ -45,24 +51,35 @@ const (
 // StartSession is the shared seam the built-in runners use so
 // seatbelt/bwrap/LocalRunner all get identical seq, resize, and
 // termination semantics.
-func StartSession(ctx context.Context, cmd *exec.Cmd, opts ExecOptions, tty bool, rows, cols int) (Process, error) {
+//
+// The returned Process always carries a stable ID: spec.ID when set,
+// otherwise a manager-generated one. Built-in registries resolve the
+// ID before spawning, so ProcessManager.List / Terminate and the
+// handle's ID() always agree.
+func StartSession(ctx context.Context, spec ProcessSpec, cmd *exec.Cmd) (Process, error) {
 	if cmd == nil {
 		return nil, errdefs.Validationf("sandbox: nil command for process session")
 	}
+	rows, cols := spec.Rows, spec.Cols
 	if rows <= 0 {
 		rows = defaultSessionRows
 	}
 	if cols <= 0 {
 		cols = defaultSessionCols
 	}
+	id := spec.ID
+	if id == "" {
+		id = xid.New().String()
+	}
 
 	s := &session{
+		id:   id,
 		cmd:  cmd,
-		out:  newOutputLog(opts.Resources.MaxOutputBytes),
+		out:  newOutputLog(spec.Opts.Resources.MaxOutputBytes),
 		done: make(chan struct{}),
 	}
 
-	if tty {
+	if spec.TTY {
 		ptmx, err := pty.StartWithSize(cmd, &pty.Winsize{Rows: uint16(rows), Cols: uint16(cols)})
 		if err != nil {
 			return nil, classifyStartError(cmd.Path, err)
@@ -95,15 +112,15 @@ func StartSession(ctx context.Context, cmd *exec.Cmd, opts ExecOptions, tty bool
 	}
 	s.proc = cmd.Process
 
-	if opts.Resources.MemoryBytes > 0 || opts.Resources.CPUMillicores > 0 {
+	if spec.Opts.Resources.MemoryBytes > 0 || spec.Opts.Resources.CPUMillicores > 0 {
 		// The Start ctx only bounds the spawn; the session outlives it.
 		// WithoutCancel keeps the watcher's telemetry rooted in the
 		// originating trace without making a canceled Start kill the
 		// session.
-		s.watcher = StartGroupCapsWatcher(context.WithoutCancel(ctx), s.pgid, opts.Resources, opts.Timeout)
+		s.watcher = StartGroupCapsWatcher(context.WithoutCancel(ctx), s.pgid, spec.Opts.Resources, spec.Opts.Timeout)
 	}
-	if opts.Timeout > 0 {
-		timer := time.AfterFunc(opts.Timeout, s.timeoutKill)
+	if spec.Opts.Timeout > 0 {
+		timer := time.AfterFunc(spec.Opts.Timeout, s.timeoutKill)
 		go func() {
 			<-s.done
 			timer.Stop()
@@ -137,12 +154,13 @@ func (r *LocalRunner) spawnProcess(ctx context.Context, spec ProcessSpec) (Proce
 	cmd := exec.Command(spec.Argv[0], spec.Argv[1:]...)
 	cmd.Dir = workDir
 	cmd.Env = buildEnv(spec.Opts.Env)
-	return StartSession(ctx, cmd, spec.Opts, spec.TTY, spec.Rows, spec.Cols)
+	return StartSession(ctx, spec, cmd)
 }
 
 // session is the concrete Process implementation shared by all unix
 // backends.
 type session struct {
+	id      string
 	cmd     *exec.Cmd
 	ptmx    *os.File
 	stdin   io.WriteCloser
@@ -161,7 +179,7 @@ type session struct {
 	done       chan struct{}
 }
 
-func (s *session) ID() string { return "" }
+func (s *session) ID() string { return s.id }
 
 func (s *session) PID() int {
 	if s.proc == nil {
@@ -232,6 +250,89 @@ func (s *session) Terminate(ctx context.Context) error {
 	s.terminated = true
 	s.mu.Unlock()
 	return s.signal(ctx, false)
+}
+
+// Signal implements ProcessSignaler. Interrupt means Ctrl-C semantics:
+// a VINTR byte on TTY sessions (the terminal driver signals the
+// foreground process group), SIGINT to the whole group on pipe
+// sessions. The process may catch the signal and continue; the session
+// stays usable.
+func (s *session) Signal(_ context.Context, sig ProcessSignal) error {
+	if sig != ProcessSignalInterrupt {
+		return errdefs.NotAvailablef("sandbox: signal %v not supported", sig)
+	}
+	if s.isClosed() {
+		return ErrProcessClosed
+	}
+	select {
+	case <-s.done:
+		return ErrProcessClosed
+	default:
+	}
+	s.mu.Lock()
+	ptmx := s.ptmx
+	s.mu.Unlock()
+	if ptmx != nil {
+		// VINTR through the pty master is a no-op when the child put
+		// the terminal in raw mode (ISIG off) — authentic Ctrl-C
+		// behaviour, documented on ProcessSignaler.
+		if _, err := ptmx.Write([]byte{0x03}); err != nil {
+			return errdefs.Internal(fmt.Errorf("sandbox: signal write to pty: %w", err))
+		}
+		return nil
+	}
+	if err := syscall.Kill(-s.pgid, syscall.SIGINT); err != nil {
+		if errors.Is(err, syscall.ESRCH) {
+			return ErrProcessClosed
+		}
+		return errdefs.Internal(fmt.Errorf("sandbox: signal process group: %w", err))
+	}
+	return nil
+}
+
+// Watch implements ProcessEventSource: it subscribes an independent
+// bounded queue that replays the retained output before delivering
+// live events. The channel closes on ctx cancellation, watcher.Close,
+// or right after the process's Closed event.
+func (s *session) Watch(ctx context.Context) (ProcessWatcher, error) {
+	if s.isClosed() {
+		return nil, ErrProcessClosed
+	}
+	s.out.mu.Lock()
+	if s.out.closed {
+		s.out.mu.Unlock()
+		return nil, ErrProcessClosed
+	}
+	w := s.out.subscribe()
+	if len(s.out.chunks) > watcherQueueSize {
+		// Replay alone would overflow the queue; skip the partial
+		// replay and deliver one Lag from the retained start instead.
+		start := s.out.retainedSeqLocked()
+		w.ch <- ProcessEvent{Seq: start, Type: ProcessEventLag}
+		for i, sub := range s.out.subscribers {
+			if sub == w {
+				s.out.subscribers = append(s.out.subscribers[:i], s.out.subscribers[i+1:]...)
+				break
+			}
+		}
+		w.once.Do(func() { close(w.ch) })
+		s.out.mu.Unlock()
+		return w, nil
+	}
+	for _, chunk := range s.out.chunks {
+		w.ch <- ProcessEvent{
+			Seq:    chunk.seq,
+			Stream: chunk.stream,
+			Data:   chunk.data,
+			Type:   ProcessEventOutput,
+		}
+	}
+	if s.out.eof {
+		w.ch <- ProcessEvent{Seq: s.out.nextSeq, Type: ProcessEventExited, Exit: &s.out.exit}
+	}
+	s.out.mu.Unlock()
+	go w.run(ctx)
+	return w, nil
 }
 
 func (s *session) Wait(ctx context.Context) (ProcessExit, error) {
@@ -340,7 +441,7 @@ func (s *session) reap() {
 	s.exit = exit
 	s.waitErr = err
 	s.mu.Unlock()
-	s.out.finish()
+	s.out.finish(s.exit)
 	close(s.done)
 }
 
@@ -417,14 +518,16 @@ func (w sessionWriter) Write(p []byte) (int, error) {
 // oldest whole chunks are dropped and Read reports ErrSequenceGap for
 // cursors below the retained range.
 type outputLog struct {
-	mu      sync.Mutex
-	wake    chan struct{}
-	chunks  []outputChunk
-	total   int64
-	nextSeq int64
-	max     int64
-	eof     bool
-	closed  bool
+	mu          sync.Mutex
+	wake        chan struct{}
+	chunks      []outputChunk
+	total       int64
+	nextSeq     int64
+	max         int64
+	eof         bool
+	closed      bool
+	exit        ProcessExit
+	subscribers []*watcher
 }
 
 type outputChunk struct {
@@ -454,21 +557,140 @@ func (l *outputLog) append(stream ProcessStream, data []byte) {
 	l.total += int64(len(data))
 	l.nextSeq += int64(len(data))
 	l.trimLocked()
+	l.deliver(ProcessEvent{
+		Seq:    l.nextSeq - int64(len(data)),
+		Stream: stream,
+		Data:   l.chunks[len(l.chunks)-1].data,
+		Type:   ProcessEventOutput,
+	})
 	l.wakeReadersLocked()
 }
 
-func (l *outputLog) finish() {
+// finish marks the stream complete and pushes Exited to every
+// subscriber. The watcher channels stay open until Close, watcher
+// Close, or ctx cancellation.
+func (l *outputLog) finish(exit ProcessExit) {
 	l.mu.Lock()
 	l.eof = true
+	l.exit = exit
+	l.deliver(ProcessEvent{Seq: l.nextSeq, Type: ProcessEventExited, Exit: &l.exit})
 	l.wakeReadersLocked()
 	l.mu.Unlock()
 }
 
+// close marks the log closed, pushes Closed to every subscriber, and
+// terminates their channels and feed goroutines.
 func (l *outputLog) close() {
 	l.mu.Lock()
 	l.closed = true
+	subs := l.subscribers
+	l.subscribers = nil
+	for _, w := range subs {
+		w.deliver(ProcessEvent{Seq: l.nextSeq, Type: ProcessEventClosed})
+		w.once.Do(func() { close(w.ch) })
+		select {
+		case <-w.stop:
+		default:
+			close(w.stop)
+		}
+	}
 	l.wakeReadersLocked()
 	l.mu.Unlock()
+}
+
+// subscribe registers a new independent watcher. It must be called
+// with l.mu held; Watch then replays retained chunks before releasing
+// the lock, so no append can slip between replay and subscription.
+func (l *outputLog) subscribe() *watcher {
+	w := &watcher{
+		ch:   make(chan ProcessEvent, watcherQueueSize),
+		stop: make(chan struct{}),
+		log:  l,
+	}
+	l.subscribers = append(l.subscribers, w)
+	return w
+}
+
+// deliver pushes one event to every active subscriber, dropping
+// watchers that lagged (they close themselves after the Lag event).
+// Callers hold l.mu; all sends are non-blocking.
+func (l *outputLog) deliver(ev ProcessEvent) {
+	kept := l.subscribers[:0]
+	for _, w := range l.subscribers {
+		if w.deliver(ev) {
+			kept = append(kept, w)
+		}
+	}
+	l.subscribers = kept
+}
+
+func (l *outputLog) removeSubscriber(w *watcher) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	for i, sub := range l.subscribers {
+		if sub == w {
+			l.subscribers = append(l.subscribers[:i], l.subscribers[i+1:]...)
+			return
+		}
+	}
+}
+
+// watcher is one event subscription. Events is replay-then-live; the
+// channel closes on ctx cancellation, watcher.Close, or after the
+// process's Closed event. On queue overflow the subscriber receives
+// one ProcessEventLag (Seq = first missed byte cursor) and the
+// channel closes — the consumer recovers with Read(afterSeq).
+type watcher struct {
+	ch   chan ProcessEvent
+	stop chan struct{}
+	once sync.Once
+	log  *outputLog
+}
+
+func (w *watcher) Events() <-chan ProcessEvent { return w.ch }
+
+func (w *watcher) Close() error {
+	select {
+	case <-w.stop:
+	default:
+		close(w.stop)
+	}
+	return nil
+}
+
+func (w *watcher) run(ctx context.Context) {
+	select {
+	case <-ctx.Done():
+	case <-w.stop:
+	}
+	w.log.removeSubscriber(w)
+	w.once.Do(func() { close(w.ch) })
+}
+
+// deliver performs a non-blocking push. On overflow it makes room for
+// one Lag event (the first undelivered event's cursor), closes the
+// channel, and returns false so the log detaches the watcher.
+func (w *watcher) deliver(ev ProcessEvent) bool {
+	select {
+	case w.ch <- ev:
+		return true
+	default:
+	}
+	select {
+	case <-w.ch:
+	default:
+	}
+	select {
+	case w.ch <- ProcessEvent{Seq: ev.Seq, Type: ProcessEventLag}:
+	default:
+	}
+	w.once.Do(func() { close(w.ch) })
+	select {
+	case <-w.stop:
+	default:
+		close(w.stop)
+	}
+	return false
 }
 
 // read returns output at/after afterSeq, at most maxBytes, blocking

--- a/sdk/sandbox/process_unix_internal_test.go
+++ b/sdk/sandbox/process_unix_internal_test.go
@@ -15,7 +15,7 @@ func TestOutputLog_TrimAndSequenceGap(t *testing.T) {
 	log.append(ProcessStreamStdout, bytesOf(60))
 	log.append(ProcessStreamStdout, bytesOf(60))
 	log.append(ProcessStreamStdout, bytesOf(60))
-	log.finish()
+	log.finish(ProcessExit{})
 
 	if got := log.retainedSeqLocked(); got != 120 {
 		t.Fatalf("retainedSeq = %d, want 120 (only the newest 60-byte chunk fits the 100-byte budget)", got)
@@ -51,7 +51,7 @@ func TestOutputLog_TrimAndSequenceGap(t *testing.T) {
 func TestOutputLog_SingleChunkOverBudgetStaysReplayable(t *testing.T) {
 	log := newOutputLog(10)
 	log.append(ProcessStreamTTY, bytesOf(100))
-	log.finish()
+	log.finish(ProcessExit{})
 
 	out, err := log.read(context.Background(), 0, 4096)
 	if err != nil {
@@ -103,6 +103,102 @@ func TestOutputLog_FutureSeqIsValidation(t *testing.T) {
 	_, err := log.read(context.Background(), 99, 16)
 	if !errdefs.IsValidation(err) {
 		t.Fatalf("future afterSeq error = %v, want Validation", err)
+	}
+}
+
+func TestWatcher_ReplayThenLiveOrdering(t *testing.T) {
+	log := newOutputLog(0)
+	log.append(ProcessStreamStdout, []byte("one"))
+	log.mu.Lock()
+	w := log.subscribe()
+	log.mu.Unlock()
+	go w.run(context.Background())
+
+	done := make(chan []ProcessEvent, 1)
+	go func() {
+		var got []ProcessEvent
+		for ev := range w.Events() {
+			got = append(got, ev)
+		}
+		done <- got
+	}()
+
+	log.append(ProcessStreamStderr, []byte("two"))
+	log.finish(ProcessExit{Code: 7, Reason: ProcessExited})
+	_ = w.Close()
+
+	got := <-done
+	// subscribe() is live-only (replay belongs to session.Watch), so
+	// pre-subscribe output is not delivered.
+	if len(got) != 2 {
+		types := make([]string, len(got))
+		for i, ev := range got {
+			types[i] = ev.Type.String()
+		}
+		t.Fatalf("events = %d (%v), want live(1) + exited(1)", len(got), types)
+	}
+	if got[0].Type != ProcessEventOutput || string(got[0].Data) != "two" || got[0].Stream != ProcessStreamStderr {
+		t.Fatalf("event[1] = %+v", got[1])
+	}
+	if got[1].Type != ProcessEventExited || got[1].Exit == nil || got[1].Exit.Code != 7 {
+		t.Fatalf("event[1] = %+v, want Exited(7)", got[1])
+	}
+	if got[1].Seq != 6 {
+		t.Fatalf("Exited seq = %d, want 6 (3+3 bytes)", got[1].Seq)
+	}
+}
+
+func TestWatcher_LagThenClose(t *testing.T) {
+	log := newOutputLog(0)
+	log.mu.Lock()
+	w := log.subscribe()
+	log.mu.Unlock()
+	go w.run(context.Background())
+
+	for i := 0; i < 300; i++ {
+		log.append(ProcessStreamStdout, []byte("x"))
+	}
+
+	done := make(chan []ProcessEvent, 1)
+	go func() {
+		var got []ProcessEvent
+		for ev := range w.Events() {
+			got = append(got, ev)
+		}
+		done <- got
+	}()
+	got := <-done
+	if len(got) != watcherQueueSize {
+		t.Fatalf("drained %d events, want queue capacity %d (one slot freed for Lag)", len(got), watcherQueueSize)
+	}
+	last := got[len(got)-1]
+	if last.Type != ProcessEventLag {
+		t.Fatalf("last event = %v, want ProcessEventLag", last.Type)
+	}
+	if last.Seq == 0 {
+		t.Fatal("Lag must carry the first missed byte cursor")
+	}
+}
+
+func TestWatcher_ClosedEventOnLogClose(t *testing.T) {
+	log := newOutputLog(0)
+	log.mu.Lock()
+	w := log.subscribe()
+	log.mu.Unlock()
+	go w.run(context.Background())
+
+	done := make(chan []ProcessEvent, 1)
+	go func() {
+		var got []ProcessEvent
+		for ev := range w.Events() {
+			got = append(got, ev)
+		}
+		done <- got
+	}()
+	log.close()
+	got := <-done
+	if len(got) != 1 || got[0].Type != ProcessEventClosed {
+		t.Fatalf("events = %+v, want one Closed", got)
 	}
 }
 

--- a/sdk/sandbox/process_unix_internal_test.go
+++ b/sdk/sandbox/process_unix_internal_test.go
@@ -1,0 +1,115 @@
+//go:build unix
+
+package sandbox
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/GizClaw/flowcraft/sdk/errdefs"
+)
+
+func TestOutputLog_TrimAndSequenceGap(t *testing.T) {
+	log := newOutputLog(100)
+	log.append(ProcessStreamStdout, bytesOf(60))
+	log.append(ProcessStreamStdout, bytesOf(60))
+	log.append(ProcessStreamStdout, bytesOf(60))
+	log.finish()
+
+	if got := log.retainedSeqLocked(); got != 120 {
+		t.Fatalf("retainedSeq = %d, want 120 (only the newest 60-byte chunk fits the 100-byte budget)", got)
+	}
+
+	// The first chunk was trimmed: reading from seq 0 must report the
+	// gap instead of silently returning the tail.
+	_, err := log.read(context.Background(), 0, 4096)
+	if !errors.Is(err, ErrSequenceGap) {
+		t.Fatalf("read(0) error = %v, want ErrSequenceGap", err)
+	}
+
+	out, err := log.read(context.Background(), 120, 4096)
+	if err != nil {
+		t.Fatalf("read(120): %v", err)
+	}
+	if out.NextSeq != 180 || len(out.Chunks) != 1 || len(out.Chunks[0].Data) != 60 {
+		t.Fatalf("read(120) = %+v, want 60 bytes ending at seq 180", out)
+	}
+	if !out.EOF {
+		t.Fatal("reading the tail after finish must set EOF")
+	}
+
+	tail, err := log.read(context.Background(), 180, 4096)
+	if err != nil {
+		t.Fatalf("read(120): %v", err)
+	}
+	if !tail.EOF || len(tail.Chunks) != 0 {
+		t.Fatalf("caught-up read = %+v, want empty chunks + EOF", tail)
+	}
+}
+
+func TestOutputLog_SingleChunkOverBudgetStaysReplayable(t *testing.T) {
+	log := newOutputLog(10)
+	log.append(ProcessStreamTTY, bytesOf(100))
+	log.finish()
+
+	out, err := log.read(context.Background(), 0, 4096)
+	if err != nil {
+		t.Fatalf("read(0): %v", err)
+	}
+	if out.NextSeq != 100 || len(out.Chunks[0].Data) != 100 {
+		t.Fatalf("single oversized chunk must stay readable, got %+v", out)
+	}
+}
+
+func TestOutputLog_ReadBlocksThenCtxCancel(t *testing.T) {
+	log := newOutputLog(0)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	_, err := log.read(ctx, 0, 16)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("read on canceled ctx = %v, want context.Canceled", err)
+	}
+
+	// A blocked read wakes when output arrives.
+	ctx = context.Background()
+	done := make(chan error, 1)
+	go func() {
+		_, err := log.read(ctx, 0, 16)
+		done <- err
+	}()
+	log.append(ProcessStreamStdout, []byte("hello"))
+	if err := <-done; err != nil {
+		t.Fatalf("blocked read after append: %v", err)
+	}
+}
+
+func TestOutputLog_CloseWakesReaders(t *testing.T) {
+	log := newOutputLog(0)
+	done := make(chan error, 1)
+	go func() {
+		_, err := log.read(context.Background(), 0, 16)
+		done <- err
+	}()
+	log.close()
+	if err := <-done; !errors.Is(err, ErrProcessClosed) {
+		t.Fatalf("read after close = %v, want ErrProcessClosed", err)
+	}
+}
+
+func TestOutputLog_FutureSeqIsValidation(t *testing.T) {
+	log := newOutputLog(0)
+	log.append(ProcessStreamStdout, bytesOf(5))
+	_, err := log.read(context.Background(), 99, 16)
+	if !errdefs.IsValidation(err) {
+		t.Fatalf("future afterSeq error = %v, want Validation", err)
+	}
+}
+
+func bytesOf(n int) []byte {
+	out := make([]byte, n)
+	for i := range out {
+		out[i] = 'a'
+	}
+	return out
+}

--- a/sdk/sandbox/process_unix_test.go
+++ b/sdk/sandbox/process_unix_test.go
@@ -5,6 +5,7 @@ package sandbox_test
 import (
 	"context"
 	"errors"
+	"os/exec"
 	"strings"
 	"testing"
 	"time"
@@ -226,6 +227,200 @@ func TestLocalProcess_ReadAfterClose(t *testing.T) {
 	}
 	if _, err := proc.Read(context.Background(), 0, 16); !errors.Is(err, sandbox.ErrProcessClosed) {
 		t.Fatalf("Read after Close = %v, want ErrProcessClosed", err)
+	}
+}
+
+func TestStartSession_ResolvesID(t *testing.T) {
+	// Direct (non-registry) use must still yield a stable ID: the
+	// caller's ID when set, otherwise a generated one.
+	proc, err := sandbox.StartSession(context.Background(),
+		sandbox.ProcessSpec{ID: "custom", Argv: []string{"/usr/bin/true"}},
+		exec.Command("/usr/bin/true"))
+	if err != nil {
+		t.Fatalf("StartSession(custom id): %v", err)
+	}
+	defer func() { _ = proc.Close() }()
+	if proc.ID() != "custom" {
+		t.Fatalf("ID = %q, want custom", proc.ID())
+	}
+
+	proc, err = sandbox.StartSession(context.Background(),
+		sandbox.ProcessSpec{Argv: []string{"/usr/bin/true"}},
+		exec.Command("/usr/bin/true"))
+	if err != nil {
+		t.Fatalf("StartSession(generated id): %v", err)
+	}
+	defer func() { _ = proc.Close() }()
+	if proc.ID() == "" {
+		t.Fatal("StartSession must generate an ID when spec.ID is empty")
+	}
+}
+
+func TestLocalProcess_Signal_NonTTY(t *testing.T) {
+	runner := sandbox.NewLocalRunner(t.TempDir())
+	proc, err := runner.Start(context.Background(), sandbox.ProcessSpec{
+		Argv: []string{"/bin/sh", "-c", `trap 'echo caught; exit 0' INT; echo ready; read x`},
+	})
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer func() { _ = proc.Close() }()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	readUntil(t, proc, ctx, "ready")
+
+	signaler, ok := sandbox.ProcessSignalerOf(proc)
+	if !ok {
+		t.Fatal("ProcessSignalerOf must find the signal capability on Start handles")
+	}
+	if err := signaler.Signal(ctx, sandbox.ProcessSignalInterrupt); err != nil {
+		t.Fatalf("Signal: %v", err)
+	}
+	if got := readUntil(t, proc, ctx, "caught"); !strings.Contains(got, "caught") {
+		t.Fatalf("trap output missing: %q", got)
+	}
+	exit, err := proc.Wait(ctx)
+	if err != nil {
+		t.Fatalf("Wait: %v", err)
+	}
+	if exit.Code != 0 || exit.Reason != sandbox.ProcessExited {
+		t.Fatalf("exit = %+v, want exited(0)", exit)
+	}
+}
+
+func TestLocalProcess_Signal_TTY(t *testing.T) {
+	runner := sandbox.NewLocalRunner(t.TempDir())
+	proc, err := runner.Start(context.Background(), sandbox.ProcessSpec{
+		Argv: []string{"/bin/sh", "-c", `trap 'echo caught; exit 0' INT; echo ready; read x`},
+		TTY:  true,
+	})
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer func() { _ = proc.Close() }()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	readUntil(t, proc, ctx, "ready")
+
+	signaler, _ := sandbox.ProcessSignalerOf(proc)
+	if err := signaler.Signal(ctx, sandbox.ProcessSignalInterrupt); err != nil {
+		t.Fatalf("Signal: %v", err)
+	}
+	if got := readUntil(t, proc, ctx, "caught"); !strings.Contains(got, "caught") {
+		t.Fatalf("VINTR did not reach the foreground process group: %q", got)
+	}
+	if exit, err := proc.Wait(ctx); err != nil || exit.Code != 0 {
+		t.Fatalf("Wait = %+v, %v; want exited(0)", exit, err)
+	}
+}
+
+func TestLocalProcess_Signal_AfterExit_ErrProcessClosed(t *testing.T) {
+	runner := sandbox.NewLocalRunner(t.TempDir())
+	proc, err := runner.Start(context.Background(), sandbox.ProcessSpec{
+		Argv: []string{"/usr/bin/true"},
+	})
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer func() { _ = proc.Close() }()
+	if _, err := proc.Wait(context.Background()); err != nil {
+		t.Fatalf("Wait: %v", err)
+	}
+	signaler, ok := sandbox.ProcessSignalerOf(proc)
+	if !ok {
+		t.Fatal("ProcessSignalerOf must find the capability on Start handles")
+	}
+	if err := signaler.Signal(context.Background(), sandbox.ProcessSignalInterrupt); !errors.Is(err, sandbox.ErrProcessClosed) {
+		t.Fatalf("Signal after exit = %v, want ErrProcessClosed", err)
+	}
+}
+
+func TestLocalProcess_Watch_ReplayThenLive(t *testing.T) {
+	runner := sandbox.NewLocalRunner(t.TempDir())
+	proc, err := runner.Start(context.Background(), sandbox.ProcessSpec{
+		Argv: []string{"/bin/sh", "-c", "printf first; sleep 0.3; printf second"},
+	})
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer func() { _ = proc.Close() }()
+
+	source, ok := sandbox.ProcessEventSourceOf(proc)
+	if !ok {
+		t.Fatal("ProcessEventSourceOf must find the capability on Start handles")
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	w, err := source.Watch(ctx)
+	if err != nil {
+		t.Fatalf("Watch: %v", err)
+	}
+	defer func() { _ = w.Close() }()
+
+	done := make(chan []sandbox.ProcessEvent, 1)
+	go func() {
+		var got []sandbox.ProcessEvent
+		for ev := range w.Events() {
+			got = append(got, ev)
+		}
+		done <- got
+	}()
+	if _, err := proc.Wait(ctx); err != nil {
+		t.Fatalf("Wait: %v", err)
+	}
+	_ = w.Close()
+	events := <-done
+
+	var sb strings.Builder
+	var exited *sandbox.ProcessExit
+	var exitedSeq int64
+	for _, ev := range events {
+		switch ev.Type {
+		case sandbox.ProcessEventOutput:
+			sb.Write(ev.Data)
+		case sandbox.ProcessEventExited:
+			exited = ev.Exit
+			exitedSeq = ev.Seq
+		case sandbox.ProcessEventLag, sandbox.ProcessEventClosed:
+			t.Fatalf("unexpected event %v", ev.Type)
+		}
+	}
+	if sb.String() != "firstsecond" {
+		t.Fatalf("streamed output = %q, want firstsecond", sb.String())
+	}
+	if exited == nil || exited.Code != 0 {
+		t.Fatalf("Exited event = %+v, want exited(0)", exited)
+	}
+	// Seq alignment with the pull cursor: everything Read from 0 must
+	// end at the Exited seq.
+	out, err := proc.Read(ctx, 0, 4096)
+	if err != nil {
+		t.Fatalf("Read: %v", err)
+	}
+	if out.NextSeq != exitedSeq || out.NextSeq != int64(len("firstsecond")) {
+		t.Fatalf("Read NextSeq = %d, Exited seq = %d, want %d", out.NextSeq, exitedSeq, len("firstsecond"))
+	}
+}
+
+func TestLocalProcess_Watch_AfterClose_ErrProcessClosed(t *testing.T) {
+	runner := sandbox.NewLocalRunner(t.TempDir())
+	proc, err := runner.Start(context.Background(), sandbox.ProcessSpec{
+		Argv: []string{"/usr/bin/true"},
+	})
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	if err := proc.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	source, ok := sandbox.ProcessEventSourceOf(proc)
+	if !ok {
+		t.Fatal("ProcessEventSourceOf must find the capability on Start handles")
+	}
+	if _, err := source.Watch(context.Background()); !errors.Is(err, sandbox.ErrProcessClosed) {
+		t.Fatalf("Watch after Close = %v, want ErrProcessClosed", err)
 	}
 }
 

--- a/sdk/sandbox/process_unix_test.go
+++ b/sdk/sandbox/process_unix_test.go
@@ -1,0 +1,273 @@
+//go:build unix
+
+package sandbox_test
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/GizClaw/flowcraft/sdk/errdefs"
+	"github.com/GizClaw/flowcraft/sdk/sandbox"
+)
+
+func TestLocalProcess_PipeStreamsAndExitCode(t *testing.T) {
+	runner := sandbox.NewLocalRunner(t.TempDir())
+	proc, err := runner.Start(context.Background(), sandbox.ProcessSpec{
+		Argv: []string{"/bin/sh", "-c", "printf OUT; printf ERR >&2; exit 7"},
+	})
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer func() { _ = proc.Close() }()
+
+	out := readAll(t, proc, 5*time.Second)
+	var stdout, stderr strings.Builder
+	for _, ch := range out.Chunks {
+		switch ch.Stream {
+		case sandbox.ProcessStreamStdout:
+			stdout.Write(ch.Data)
+		case sandbox.ProcessStreamStderr:
+			stderr.Write(ch.Data)
+		default:
+			t.Errorf("unexpected stream %v", ch.Stream)
+		}
+	}
+	if stdout.String() != "OUT" {
+		t.Errorf("stdout = %q, want OUT", stdout.String())
+	}
+	if stderr.String() != "ERR" {
+		t.Errorf("stderr = %q, want ERR", stderr.String())
+	}
+	if !out.EOF {
+		t.Fatal("Read should report EOF after the process exits and output drains")
+	}
+
+	exit, err := proc.Wait(context.Background())
+	if err != nil {
+		t.Fatalf("Wait: %v", err)
+	}
+	if exit.Reason != sandbox.ProcessExited || exit.Code != 7 {
+		t.Fatalf("exit = %+v, want exited(7)", exit)
+	}
+}
+
+func TestLocalProcess_TTYWriteResizeReadExit(t *testing.T) {
+	runner := sandbox.NewLocalRunner(t.TempDir())
+	proc, err := runner.Start(context.Background(), sandbox.ProcessSpec{
+		Argv: []string{"/bin/sh"},
+		TTY:  true,
+	})
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer func() { _ = proc.Close() }()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	if err := proc.Write(ctx, []byte("stty size\n")); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	got := readUntil(t, proc, ctx, "24 80")
+	if !strings.Contains(got, "24 80") {
+		t.Fatalf("default window missing: %q", got)
+	}
+
+	if err := proc.Resize(ctx, 40, 120); err != nil {
+		t.Fatalf("Resize: %v", err)
+	}
+	if err := proc.Write(ctx, []byte("stty size\n")); err != nil {
+		t.Fatalf("Write after resize: %v", err)
+	}
+	got = readUntil(t, proc, ctx, "40 120")
+	if !strings.Contains(got, "40 120") {
+		t.Fatalf("resized window missing: %q", got)
+	}
+
+	if err := proc.Write(ctx, []byte("exit\n")); err != nil {
+		t.Fatalf("Write exit: %v", err)
+	}
+	exit, err := proc.Wait(ctx)
+	if err != nil {
+		t.Fatalf("Wait: %v", err)
+	}
+	if exit.Code != 0 || exit.Reason != sandbox.ProcessExited {
+		t.Fatalf("exit = %+v, want exited(0)", exit)
+	}
+}
+
+func TestLocalProcess_ResizeRejectedWithoutTTY(t *testing.T) {
+	runner := sandbox.NewLocalRunner(t.TempDir())
+	proc, err := runner.Start(context.Background(), sandbox.ProcessSpec{
+		Argv: []string{"/bin/sleep", "1"},
+	})
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer func() { _ = proc.Close() }()
+	if err := proc.Resize(context.Background(), 24, 80); !errdefs.IsNotAvailable(err) {
+		t.Fatalf("Resize on pipe session = %v, want NotAvailable", err)
+	}
+}
+
+func TestLocalProcess_Timeout(t *testing.T) {
+	runner := sandbox.NewLocalRunner(t.TempDir())
+	proc, err := runner.Start(context.Background(), sandbox.ProcessSpec{
+		Argv: []string{"/bin/sleep", "30"},
+		Opts: sandbox.ExecOptions{Timeout: 150 * time.Millisecond},
+	})
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer func() { _ = proc.Close() }()
+
+	exit, err := proc.Wait(context.Background())
+	if !errdefs.IsTimeout(err) {
+		t.Fatalf("Wait error = %v, want timeout", err)
+	}
+	if exit.Reason != sandbox.ProcessTimedOut {
+		t.Fatalf("exit = %+v, want ProcessTimedOut", exit)
+	}
+}
+
+func TestLocalProcessManager_RegistryLifecycle(t *testing.T) {
+	runner := sandbox.NewLocalRunner(t.TempDir())
+	ctx := context.Background()
+
+	proc, err := runner.Start(ctx, sandbox.ProcessSpec{
+		ID:   "known",
+		Argv: []string{"/bin/sh", "-c", "sleep 30"},
+	})
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer func() { _ = proc.Close() }()
+
+	if _, err := runner.Start(ctx, sandbox.ProcessSpec{ID: "known", Argv: []string{"/bin/true"}}); !errdefs.IsConflict(err) {
+		t.Fatalf("duplicate ID error = %v, want Conflict", err)
+	}
+
+	infos, err := runner.List(ctx)
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(infos) != 1 || infos[0].ID != "known" || !infos[0].Running || infos[0].PID <= 0 {
+		t.Fatalf("infos = %+v, want one running 'known' session", infos)
+	}
+
+	if err := runner.Terminate(ctx, "missing"); !errdefs.IsNotFound(err) {
+		t.Fatalf("Terminate unknown = %v, want NotFound", err)
+	}
+	if err := runner.Terminate(ctx, "known"); err != nil {
+		t.Fatalf("Terminate: %v", err)
+	}
+	exit, err := proc.Wait(ctx)
+	if err != nil {
+		t.Fatalf("Wait after Terminate: %v", err)
+	}
+	if exit.Reason != sandbox.ProcessTerminated {
+		t.Fatalf("exit = %+v, want ProcessTerminated", exit)
+	}
+
+	infos, err = runner.List(ctx)
+	if err != nil {
+		t.Fatalf("List after Terminate: %v", err)
+	}
+	if len(infos) != 1 || infos[0].Running || infos[0].Exit == nil {
+		t.Fatalf("exited session must stay listed until Close: %+v", infos)
+	}
+
+	if err := proc.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	infos, err = runner.List(ctx)
+	if err != nil {
+		t.Fatalf("List after Close: %v", err)
+	}
+	if len(infos) != 0 {
+		t.Fatalf("sessions after Close = %+v, want none", infos)
+	}
+}
+
+func TestLocalProcessManager_GeneratedID(t *testing.T) {
+	runner := sandbox.NewLocalRunner(t.TempDir())
+	proc, err := runner.Start(context.Background(), sandbox.ProcessSpec{
+		Argv: []string{"/bin/sleep", "1"},
+	})
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer func() { _ = proc.Close() }()
+	if proc.ID() == "" {
+		t.Fatal("empty spec.ID must produce a manager-generated ID")
+	}
+	infos, err := runner.List(context.Background())
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(infos) != 1 || infos[0].ID != proc.ID() {
+		t.Fatalf("infos = %+v, want generated ID %q", infos, proc.ID())
+	}
+}
+
+func TestLocalProcess_ReadAfterClose(t *testing.T) {
+	runner := sandbox.NewLocalRunner(t.TempDir())
+	proc, err := runner.Start(context.Background(), sandbox.ProcessSpec{
+		Argv: []string{"/usr/bin/true"},
+	})
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	if err := proc.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	if _, err := proc.Read(context.Background(), 0, 16); !errors.Is(err, sandbox.ErrProcessClosed) {
+		t.Fatalf("Read after Close = %v, want ErrProcessClosed", err)
+	}
+}
+
+func readAll(t *testing.T, proc sandbox.Process, timeout time.Duration) sandbox.ProcessOutput {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+	var seq int64
+	var out sandbox.ProcessOutput
+	for {
+		chunk, err := proc.Read(ctx, seq, 4096)
+		if err != nil {
+			t.Fatalf("Read: %v", err)
+		}
+		out.Chunks = append(out.Chunks, chunk.Chunks...)
+		seq = chunk.NextSeq
+		if chunk.EOF {
+			out.NextSeq = chunk.NextSeq
+			out.EOF = true
+			return out
+		}
+	}
+}
+
+func readUntil(t *testing.T, proc sandbox.Process, ctx context.Context, want string) string {
+	t.Helper()
+	var seq int64
+	var sb strings.Builder
+	for {
+		out, err := proc.Read(ctx, seq, 4096)
+		if err != nil {
+			t.Fatalf("Read: %v", err)
+		}
+		for _, ch := range out.Chunks {
+			sb.Write(ch.Data)
+		}
+		seq = out.NextSeq
+		if strings.Contains(sb.String(), want) {
+			return sb.String()
+		}
+		if out.EOF {
+			return sb.String()
+		}
+	}
+}

--- a/sdk/sandbox/sandbox.go
+++ b/sdk/sandbox/sandbox.go
@@ -151,10 +151,19 @@ type NetRule struct {
 // MITMPolicy enables TLS termination and content hooks for CONNECT
 // traffic. It is opt-in: a nil policy or Enabled=false leaves CONNECT
 // tunnels untouched.
+//
+// Host selection: empty Hosts means "all CONNECT traffic is MITM'd"
+// (the default; pinned clients then fail closed at TLS). Non-empty
+// Hosts restricts MITM to the listed hosts, and ExcludeHosts always
+// bypasses MITM with a raw tunnel (allow/deny rules still apply).
+// Exclude wins over Hosts. Host forms follow NetRule: "example.com",
+// "*.example.com", IP literals, and CIDR prefixes.
 type MITMPolicy struct {
 	Enabled       bool
-	InspectBodies bool  // buffer request/response bodies for hooks (bounded)
-	MaxBodyBytes  int64 // body buffer cap; 0 uses the engine default (64 KiB)
+	InspectBodies bool
+	MaxBodyBytes  int64
+	Hosts         []string // non-empty: only these hosts get MITM
+	ExcludeHosts  []string // never MITM these hosts (raw tunnel)
 }
 
 // Validate checks NetPolicy's cross-backend invariants. Backend
@@ -202,6 +211,16 @@ func (p NetPolicy) Validate() error {
 	if p.MITM != nil {
 		if p.MITM.MaxBodyBytes < 0 {
 			return errdefs.Validationf("sandbox: mitm.max_body_bytes must be non-negative")
+		}
+		for i, host := range p.MITM.Hosts {
+			if strings.TrimSpace(host) == "" {
+				return errdefs.Validationf("sandbox: mitm.hosts[%d] is empty", i)
+			}
+		}
+		for i, host := range p.MITM.ExcludeHosts {
+			if strings.TrimSpace(host) == "" {
+				return errdefs.Validationf("sandbox: mitm.exclude_hosts[%d] is empty", i)
+			}
 		}
 	}
 	return nil

--- a/sdk/sandbox/sandbox.go
+++ b/sdk/sandbox/sandbox.go
@@ -3,6 +3,9 @@ package sandbox
 import (
 	"context"
 	"errors"
+	"net/url"
+	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/GizClaw/flowcraft/sdk/errdefs"
@@ -93,9 +96,115 @@ const (
 // errdefs.NotAvailable until a sandboxed backend with kernel-level
 // enforcement is wired up.
 type NetPolicy struct {
-	Mode       NetMode
-	AllowHosts []string
-	Proxy      string
+	Mode        NetMode
+	AllowHosts  []string    // deprecated: compiled as trailing allow rules
+	Rules       []NetRule   // explicit rules; deny wins over allow
+	Proxy       string      // http://host:port or socks5://[user:pass@]host:port
+	UnixSockets []string    // allowed host unix socket paths (backend-gated)
+	MITM        *MITMPolicy // non-nil + Enabled enables HTTPS content hooks
+}
+
+// NetAction is the verdict of one network rule. Rules express an
+// already-decided policy; they never trigger approval.
+type NetAction int
+
+const (
+	// NetDeny blocks the destination.
+	NetDeny NetAction = iota
+	// NetAllow permits the destination.
+	NetAllow
+)
+
+func (a NetAction) String() string {
+	switch a {
+	case NetDeny:
+		return "deny"
+	case NetAllow:
+		return "allow"
+	default:
+		return "unknown"
+	}
+}
+
+// NetRule is one host/port-level allow or deny rule.
+//
+// Host forms:
+//
+//   - "example.com": the bare domain AND every subdomain (legacy
+//     AllowHosts semantics; this is domain-and-descendants, not
+//     exact-only).
+//   - "*.example.com": subdomains only (any depth), never the bare
+//     domain.
+//   - "1.2.3.4": exact IP literal.
+//   - "10.0.0.0/8": CIDR prefix.
+//
+// Unicode hostnames are normalized to punycode when the policy is
+// compiled (see sdkx/internal/httpkit). Port 0 matches any port;
+// otherwise the request port (URL explicit port or protocol default,
+// CONNECT target port) must match exactly.
+type NetRule struct {
+	Action NetAction
+	Host   string
+	Port   int
+}
+
+// MITMPolicy enables TLS termination and content hooks for CONNECT
+// traffic. It is opt-in: a nil policy or Enabled=false leaves CONNECT
+// tunnels untouched.
+type MITMPolicy struct {
+	Enabled       bool
+	InspectBodies bool  // buffer request/response bodies for hooks (bounded)
+	MaxBodyBytes  int64 // body buffer cap; 0 uses the engine default (64 KiB)
+}
+
+// Validate checks NetPolicy's cross-backend invariants. Backend
+// capability gating (which modes / features a runner enforces) is
+// separate and happens via Enforcement.
+func (p NetPolicy) Validate() error {
+	if p.Mode < NetDefault || p.Mode > NetProxy {
+		return errdefs.Validationf("sandbox: unknown net mode %d", int(p.Mode))
+	}
+	if p.Proxy != "" {
+		u, err := url.Parse(p.Proxy)
+		if err != nil {
+			return errdefs.Validationf("sandbox: invalid proxy URL %q: %v", p.Proxy, err)
+		}
+		if u.Scheme != "http" && u.Scheme != "socks5" {
+			return errdefs.Validationf(
+				"sandbox: proxy scheme %q must be http or socks5", u.Scheme)
+		}
+		if u.Host == "" {
+			return errdefs.Validationf("sandbox: proxy URL %q has no host", p.Proxy)
+		}
+		if u.User != nil {
+			if _, hasPassword := u.User.Password(); hasPassword && u.User.Username() == "" {
+				return errdefs.Validationf(
+					"sandbox: proxy URL %q has a password but no username", p.Proxy)
+			}
+		}
+	}
+	for i, rule := range p.Rules {
+		if rule.Action != NetDeny && rule.Action != NetAllow {
+			return errdefs.Validationf("sandbox: net rule %d has invalid action %d", i, int(rule.Action))
+		}
+		if strings.TrimSpace(rule.Host) == "" {
+			return errdefs.Validationf("sandbox: net rule %d has an empty host", i)
+		}
+		if rule.Port < 0 || rule.Port > 65535 {
+			return errdefs.Validationf("sandbox: net rule %d port %d out of range", i, rule.Port)
+		}
+	}
+	for _, path := range p.UnixSockets {
+		if !filepath.IsAbs(path) {
+			return errdefs.Validationf("sandbox: unix socket path %q must be absolute", path)
+		}
+	}
+	if p.MITM != nil {
+		if p.MITM.MaxBodyBytes < 0 {
+			return errdefs.Validationf("sandbox: mitm.max_body_bytes must be non-negative")
+		}
+	}
+	return nil
 }
 
 // ResourceLimits caps how much the child process may consume.

--- a/sdk/sandbox/sandbox.go
+++ b/sdk/sandbox/sandbox.go
@@ -126,6 +126,36 @@ type ResourceLimits struct {
 	MaxOutputBytes int64
 }
 
+// ValidateExecPolicy runs the policy checks every built-in backend
+// applies before spawning anything, whether through Runner.Exec or
+// ProcessManager.Start:
+//
+//   - DiskBytes is rejected everywhere (no backend has a quota
+//     mechanism yet).
+//   - CPUMillicores derives its budget from Timeout, so it is rejected
+//     when Timeout is absent.
+//   - MemoryBytes / CPUMillicores ride the shared process-group
+//     sampler; where that sampler cannot run, honouring the request
+//     would silently run without caps, so it is rejected instead.
+//
+// Backend-specific posture checks (which Net modes a runner enforces,
+// WorkDir confinement) stay in each backend.
+func ValidateExecPolicy(opts ExecOptions) error {
+	if opts.Resources.DiskBytes != 0 {
+		return errdefs.NotAvailablef(
+			"sandbox: disk limits not supported (no quota mechanism)")
+	}
+	if opts.Resources.CPUMillicores != 0 && opts.Timeout <= 0 {
+		return errdefs.NotAvailablef(
+			"sandbox: CPUMillicores requires a per-call Timeout to derive a cpu-time cap")
+	}
+	if (opts.Resources.MemoryBytes > 0 || opts.Resources.CPUMillicores > 0) && !groupCapsAvailable() {
+		return errdefs.NotAvailablef(
+			"sandbox: resource limits require process-group sampling, which is unavailable here")
+	}
+	return nil
+}
+
 // ErrPathTraversal is returned when a WorkDir resolves outside the
 // runner's root, including via symlinks. sandbox owns its own
 // ErrPathTraversal so this package does not depend on sdk/workspace

--- a/sdkx/internal/hostmatch/hostmatch.go
+++ b/sdkx/internal/hostmatch/hostmatch.go
@@ -1,0 +1,153 @@
+// Package hostmatch compiles host patterns (domains, wildcards, IP
+// literals, CIDR prefixes) into a pure matching set. It is shared by
+// the sandbox net-rule matcher (sdkx/internal/httpkit) and the MITM
+// host selector so both interpret "example.com",
+// "*.example.com", "1.2.3.4", and "10.0.0.0/8" identically.
+package hostmatch
+
+import (
+	"fmt"
+	"net/netip"
+	"strings"
+
+	"golang.org/x/net/idna"
+)
+
+// Pattern is one compiled host pattern.
+//
+//   - "example.com": the bare domain AND every subdomain
+//     (domain-and-descendants).
+//   - "*.example.com": subdomains only, any depth; never the bare
+//     domain.
+//   - "1.2.3.4" / "10.0.0.0/8": IP / CIDR, evaluated via MatchIP.
+type Pattern struct {
+	wild   bool
+	host   string
+	addr   netip.Addr
+	prefix netip.Prefix
+}
+
+// Compile normalizes one host pattern. Unicode names are converted to
+// punycode; case and trailing dots are normalized. A literal "*" is
+// only allowed as the leading "*." wildcard.
+func Compile(raw string) (*Pattern, error) {
+	host := strings.TrimSpace(raw)
+	if host == "" {
+		return nil, fmt.Errorf("empty host")
+	}
+	if strings.Contains(host, "*") && !strings.HasPrefix(host, "*.") {
+		return nil, fmt.Errorf("host %q: \"*\" is only allowed as a leading \"*.\" wildcard", raw)
+	}
+	p := &Pattern{wild: strings.HasPrefix(host, "*.")}
+	if p.wild {
+		host = strings.TrimPrefix(host, "*.")
+		if host == "" || strings.Contains(host, "*") {
+			return nil, fmt.Errorf("wildcard host %q must have form \"*.example.com\"", raw)
+		}
+	}
+	host = normalize(host)
+	p.host = host
+
+	if !p.wild {
+		if addr, err := netip.ParseAddr(host); err == nil {
+			p.addr = addr.Unmap()
+		} else if prefix, err := netip.ParsePrefix(host); err == nil {
+			p.prefix = prefix.Masked()
+		}
+	}
+	return p, nil
+}
+
+// IsIP reports whether the pattern is an IP literal or CIDR prefix
+// (evaluated against resolved addresses, never hostnames).
+func (p *Pattern) IsIP() bool { return p.addr.IsValid() || p.prefix.IsValid() }
+
+// Match evaluates a hostname against the pattern.
+func (p *Pattern) Match(host string) bool {
+	if p.IsIP() {
+		return false
+	}
+	host = normalize(host)
+	if p.wild {
+		return strings.HasSuffix(host, "."+p.host)
+	}
+	return host == p.host || strings.HasSuffix(host, "."+p.host)
+}
+
+// MatchIP evaluates a resolved address against the pattern.
+func (p *Pattern) MatchIP(ip netip.Addr) bool {
+	ip = ip.Unmap()
+	if p.addr.IsValid() {
+		return ip == p.addr
+	}
+	if p.prefix.IsValid() {
+		return p.prefix.Contains(ip)
+	}
+	return false
+}
+
+// Set is an ordered collection of patterns; Match returns true when
+// any pattern matches.
+type Set struct {
+	patterns []*Pattern
+}
+
+// New compiles a host list into a Set. An empty list yields an empty
+// (never-matching) set; malformed entries are Validation errors.
+func New(hosts []string) (*Set, error) {
+	s := &Set{}
+	for _, raw := range hosts {
+		p, err := Compile(raw)
+		if err != nil {
+			return nil, err
+		}
+		s.patterns = append(s.patterns, p)
+	}
+	return s, nil
+}
+
+// Empty reports whether the set has no patterns.
+func (s *Set) Empty() bool { return len(s.patterns) == 0 }
+
+// Match reports whether any pattern matches the hostname.
+func (s *Set) Match(host string) bool {
+	for _, p := range s.patterns {
+		if p.Match(host) {
+			return true
+		}
+	}
+	return false
+}
+
+// MatchIP reports whether any IP/CIDR pattern matches the address.
+func (s *Set) MatchIP(ip netip.Addr) bool {
+	for _, p := range s.patterns {
+		if p.MatchIP(ip) {
+			return true
+		}
+	}
+	return false
+}
+
+// normalize lowercases, strips the trailing dot, and converts unicode
+// hostnames to punycode. IDNA failures leave the input unchanged so
+// callers can still reject it via their own defaults.
+func normalize(host string) string {
+	host = strings.TrimSuffix(strings.ToLower(strings.TrimSpace(host)), ".")
+	if isASCII(host) {
+		return host
+	}
+	if ascii, err := idna.Lookup.ToASCII(host); err == nil {
+		return ascii
+	}
+	return host
+}
+
+func isASCII(s string) bool {
+	for i := 0; i < len(s); i++ {
+		if s[i] >= 0x80 {
+			return false
+		}
+	}
+	return true
+}

--- a/sdkx/internal/hostmatch/hostmatch_test.go
+++ b/sdkx/internal/hostmatch/hostmatch_test.go
@@ -1,0 +1,66 @@
+package hostmatch
+
+import (
+	"net/netip"
+	"testing"
+)
+
+func TestSet_MatchSemantics(t *testing.T) {
+	s, err := New([]string{
+		"example.com",
+		"*.blocked.example",
+		"10.0.0.0/8",
+		"1.2.3.4",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, host := range []string{"example.com", "api.example.com", "a.b.example.com"} {
+		if !s.Match(host) {
+			t.Errorf("%s: bare domain must match descendants", host)
+		}
+	}
+	if s.Match("blocked.example") {
+		t.Error("wildcard base must not match bare domain")
+	}
+	for _, host := range []string{"x.blocked.example", "a.b.blocked.example"} {
+		if !s.Match(host) {
+			t.Errorf("%s: wildcard subdomain must match", host)
+		}
+	}
+	if !s.MatchIP(netip.MustParseAddr("10.9.9.9")) {
+		t.Error("CIDR match failed")
+	}
+	if !s.MatchIP(netip.MustParseAddr("1.2.3.4")) {
+		t.Error("exact IP match failed")
+	}
+	if s.MatchIP(netip.MustParseAddr("11.0.0.1")) {
+		t.Error("out-of-prefix IP must not match")
+	}
+}
+
+func TestSet_EmptyAndNormalization(t *testing.T) {
+	empty, err := New(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !empty.Empty() || empty.Match("anything.example") {
+		t.Fatal("empty set must never match")
+	}
+
+	s, err := New([]string{"MÜNCHEN.EXAMPLE."})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !s.Match("xn--mnchen-3ya.example") {
+		t.Fatal("unicode rule must match punycode host")
+	}
+}
+
+func TestCompile_Invalid(t *testing.T) {
+	for _, host := range []string{"", "a*b.example", "*.", "*"} {
+		if _, err := Compile(host); err == nil {
+			t.Errorf("host %q: expected error", host)
+		}
+	}
+}

--- a/sdkx/internal/httpkit/matcher.go
+++ b/sdkx/internal/httpkit/matcher.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/GizClaw/flowcraft/sdk/errdefs"
 	"github.com/GizClaw/flowcraft/sdk/sandbox"
-	"golang.org/x/net/idna"
+	"github.com/GizClaw/flowcraft/sdkx/internal/hostmatch"
 )
 
 // Matcher evaluates sandbox.NetPolicy rules against a destination.
@@ -39,11 +39,7 @@ type compiledRule struct {
 	action sandbox.NetAction
 	port   int
 	desc   string
-
-	host   string // normalized hostname (domain / wildcard base)
-	wild   bool
-	addr   netip.Addr
-	prefix netip.Prefix
+	host   *hostmatch.Pattern
 }
 
 // NewMatcher compiles policy into a Matcher. The policy should already
@@ -56,7 +52,7 @@ func NewMatcher(policy sandbox.NetPolicy) (*Matcher, error) {
 		if err != nil {
 			return nil, errdefs.Validationf("sandbox: net rule %d: %v", i, err)
 		}
-		if c.addr.IsValid() || c.prefix.IsValid() {
+		if c.host.IsIP() {
 			m.hasIPRules = true
 		}
 		m.rules = append(m.rules, c)
@@ -69,7 +65,7 @@ func NewMatcher(policy sandbox.NetPolicy) (*Matcher, error) {
 		if err != nil {
 			return nil, errdefs.Validationf("sandbox: allow_hosts entry %q: %v", host, err)
 		}
-		if c.addr.IsValid() || c.prefix.IsValid() {
+		if c.host.IsIP() {
 			m.hasIPRules = true
 		}
 		m.rules = append(m.rules, c)
@@ -87,7 +83,7 @@ func (m *Matcher) HasIPRules() bool { return m.hasIPRules }
 func (m *Matcher) Match(host string, port int) (sandbox.NetAction, string, bool) {
 	host = normalizeHost(host)
 	for _, r := range m.rules {
-		if r.addr.IsValid() || r.prefix.IsValid() || !hostMatches(r, host) {
+		if r.host.IsIP() || !r.host.Match(host) {
 			continue
 		}
 		if !portMatches(r.port, port) {
@@ -98,7 +94,7 @@ func (m *Matcher) Match(host string, port int) (sandbox.NetAction, string, bool)
 		}
 	}
 	for _, r := range m.rules {
-		if r.addr.IsValid() || r.prefix.IsValid() || !hostMatches(r, host) {
+		if r.host.IsIP() || !r.host.Match(host) {
 			continue
 		}
 		if !portMatches(r.port, port) {
@@ -112,7 +108,7 @@ func (m *Matcher) Match(host string, port int) (sandbox.NetAction, string, bool)
 // MatchIP evaluates IP/CIDR rules against one resolved address.
 func (m *Matcher) MatchIP(ip netip.Addr, port int) (sandbox.NetAction, string, bool) {
 	for _, r := range m.rules {
-		if !ipMatches(r, ip) {
+		if !r.host.MatchIP(ip) {
 			continue
 		}
 		if !portMatches(r.port, port) {
@@ -123,7 +119,7 @@ func (m *Matcher) MatchIP(ip netip.Addr, port int) (sandbox.NetAction, string, b
 		}
 	}
 	for _, r := range m.rules {
-		if !ipMatches(r, ip) {
+		if !r.host.MatchIP(ip) {
 			continue
 		}
 		if !portMatches(r.port, port) {
@@ -136,88 +132,25 @@ func (m *Matcher) MatchIP(ip netip.Addr, port int) (sandbox.NetAction, string, b
 
 func compileRule(rule sandbox.NetRule) (compiledRule, error) {
 	c := compiledRule{action: rule.Action, port: rule.Port}
-	host := strings.TrimSpace(rule.Host)
-	if host == "" {
-		return c, fmt.Errorf("empty host")
+	pattern, err := hostmatch.Compile(rule.Host)
+	if err != nil {
+		return c, err
 	}
-	if strings.Contains(host, "*") && !strings.HasPrefix(host, "*.") {
-		return c, fmt.Errorf("host %q: \"*\" is only allowed as a leading \"*.\" wildcard", rule.Host)
-	}
-	c.wild = strings.HasPrefix(host, "*.")
-	if c.wild {
-		host = strings.TrimPrefix(host, "*.")
-		if host == "" || strings.Contains(host, "*") {
-			return c, fmt.Errorf("wildcard host %q must have form \"*.example.com\"", rule.Host)
-		}
-	}
-	host = normalizeHost(host)
-	c.host = host
-
-	if !c.wild {
-		if addr, err := netip.ParseAddr(host); err == nil {
-			c.addr = addr.Unmap()
-			c.desc = fmt.Sprintf("%s %s", c.action, c.addr.String())
-		} else if prefix, err := netip.ParsePrefix(host); err == nil {
-			c.prefix = prefix.Masked()
-			c.addr = netip.Addr{} // prefix rules use prefix only
-			c.desc = fmt.Sprintf("%s %s", c.action, c.prefix.String())
-		}
-	}
-	if c.desc == "" {
-		pattern := c.host
-		if c.wild {
-			pattern = "*." + c.host
-		}
-		c.desc = fmt.Sprintf("%s %s", c.action, pattern)
-	}
+	c.host = pattern
+	c.desc = fmt.Sprintf("%s %s", c.action, rule.Host)
 	if c.port != 0 {
 		c.desc += fmt.Sprintf(":%d", c.port)
 	}
 	return c, nil
 }
 
-func hostMatches(r compiledRule, host string) bool {
-	if r.wild {
-		return strings.HasSuffix(host, "."+r.host)
-	}
-	return host == r.host || strings.HasSuffix(host, "."+r.host)
-}
-
-func ipMatches(r compiledRule, ip netip.Addr) bool {
-	ip = ip.Unmap()
-	if r.addr.IsValid() {
-		return ip == r.addr
-	}
-	if r.prefix.IsValid() {
-		return r.prefix.Contains(ip)
-	}
-	return false
-}
-
 func portMatches(rulePort, port int) bool {
 	return rulePort == 0 || rulePort == port
 }
 
-// normalizeHost lowercases, strips the trailing dot, and converts
-// unicode hostnames to punycode. IDNA failures leave the input
-// unchanged so the proxy can still reject it via the allow-list
-// default; rules themselves are normalized at compile time.
+// normalizeHost mirrors hostmatch's normalization for request-side
+// lookups (no IDNA failure surfacing — mismatches fall through to the
+// mode default).
 func normalizeHost(host string) string {
-	host = strings.TrimSuffix(strings.ToLower(strings.TrimSpace(host)), ".")
-	if ascii := isASCII(host); ascii {
-		return host
-	}
-	if ascii, err := idna.Lookup.ToASCII(host); err == nil {
-		return ascii
-	}
-	return host
-}
-
-func isASCII(s string) bool {
-	for i := 0; i < len(s); i++ {
-		if s[i] >= 0x80 {
-			return false
-		}
-	}
-	return true
+	return strings.TrimSuffix(strings.ToLower(strings.TrimSpace(host)), ".")
 }

--- a/sdkx/internal/httpkit/matcher.go
+++ b/sdkx/internal/httpkit/matcher.go
@@ -1,0 +1,223 @@
+package httpkit
+
+import (
+	"fmt"
+	"net/netip"
+	"strings"
+
+	"github.com/GizClaw/flowcraft/sdk/errdefs"
+	"github.com/GizClaw/flowcraft/sdk/sandbox"
+	"golang.org/x/net/idna"
+)
+
+// Matcher evaluates sandbox.NetPolicy rules against a destination.
+// Rules are compiled once at construction: hostnames are normalized
+// (lowercase, trailing dot removed, IDNA → punycode) and IP/CIDR
+// entries are parsed so Match / MatchIP stay pure and IO-free.
+//
+// Semantics:
+//
+//   - "example.com": the bare domain and every subdomain
+//     (domain-and-descendants, matching the legacy AllowHosts
+//     behaviour).
+//   - "*.example.com": subdomains only, any depth; never the bare
+//     domain.
+//   - "1.2.3.4" / "10.0.0.0/8": IP / CIDR, evaluated by MatchIP
+//     against locally resolved addresses.
+//   - Deny rules are evaluated first across the whole rule set; a
+//     single deny match wins over any allow.
+//   - Port 0 matches any port.
+//
+// AllowHosts is compiled as trailing allow rules, so explicit deny
+// rules always take precedence over the legacy allow-list.
+type Matcher struct {
+	rules      []compiledRule
+	hasIPRules bool
+}
+
+type compiledRule struct {
+	action sandbox.NetAction
+	port   int
+	desc   string
+
+	host   string // normalized hostname (domain / wildcard base)
+	wild   bool
+	addr   netip.Addr
+	prefix netip.Prefix
+}
+
+// NewMatcher compiles policy into a Matcher. The policy should already
+// have passed NetPolicy.Validate; this constructor re-checks the rule
+// forms it needs and returns Validation errors for malformed hosts.
+func NewMatcher(policy sandbox.NetPolicy) (*Matcher, error) {
+	m := &Matcher{}
+	for i, rule := range policy.Rules {
+		c, err := compileRule(rule)
+		if err != nil {
+			return nil, errdefs.Validationf("sandbox: net rule %d: %v", i, err)
+		}
+		if c.addr.IsValid() || c.prefix.IsValid() {
+			m.hasIPRules = true
+		}
+		m.rules = append(m.rules, c)
+	}
+	// Legacy allow-list entries become allow rules appended after the
+	// explicit rules, preserving "explicit deny wins" while keeping
+	// old configurations byte-for-byte equivalent.
+	for _, host := range policy.AllowHosts {
+		c, err := compileRule(sandbox.NetRule{Action: sandbox.NetAllow, Host: host})
+		if err != nil {
+			return nil, errdefs.Validationf("sandbox: allow_hosts entry %q: %v", host, err)
+		}
+		if c.addr.IsValid() || c.prefix.IsValid() {
+			m.hasIPRules = true
+		}
+		m.rules = append(m.rules, c)
+	}
+	return m, nil
+}
+
+// HasIPRules reports whether any rule needs local DNS resolution
+// (exact IP or CIDR entries).
+func (m *Matcher) HasIPRules() bool { return m.hasIPRules }
+
+// Match evaluates hostname rules for host:port. It never resolves DNS;
+// callers apply IP/CIDR rules separately via MatchIP. The returned
+// rule string describes the decisive rule ("" when nothing matched).
+func (m *Matcher) Match(host string, port int) (sandbox.NetAction, string, bool) {
+	host = normalizeHost(host)
+	for _, r := range m.rules {
+		if r.addr.IsValid() || r.prefix.IsValid() || !hostMatches(r, host) {
+			continue
+		}
+		if !portMatches(r.port, port) {
+			continue
+		}
+		if r.action == sandbox.NetDeny {
+			return sandbox.NetDeny, r.desc, true
+		}
+	}
+	for _, r := range m.rules {
+		if r.addr.IsValid() || r.prefix.IsValid() || !hostMatches(r, host) {
+			continue
+		}
+		if !portMatches(r.port, port) {
+			continue
+		}
+		return sandbox.NetAllow, r.desc, true
+	}
+	return sandbox.NetAllow, "", false
+}
+
+// MatchIP evaluates IP/CIDR rules against one resolved address.
+func (m *Matcher) MatchIP(ip netip.Addr, port int) (sandbox.NetAction, string, bool) {
+	for _, r := range m.rules {
+		if !ipMatches(r, ip) {
+			continue
+		}
+		if !portMatches(r.port, port) {
+			continue
+		}
+		if r.action == sandbox.NetDeny {
+			return sandbox.NetDeny, r.desc, true
+		}
+	}
+	for _, r := range m.rules {
+		if !ipMatches(r, ip) {
+			continue
+		}
+		if !portMatches(r.port, port) {
+			continue
+		}
+		return sandbox.NetAllow, r.desc, true
+	}
+	return sandbox.NetAllow, "", false
+}
+
+func compileRule(rule sandbox.NetRule) (compiledRule, error) {
+	c := compiledRule{action: rule.Action, port: rule.Port}
+	host := strings.TrimSpace(rule.Host)
+	if host == "" {
+		return c, fmt.Errorf("empty host")
+	}
+	if strings.Contains(host, "*") && !strings.HasPrefix(host, "*.") {
+		return c, fmt.Errorf("host %q: \"*\" is only allowed as a leading \"*.\" wildcard", rule.Host)
+	}
+	c.wild = strings.HasPrefix(host, "*.")
+	if c.wild {
+		host = strings.TrimPrefix(host, "*.")
+		if host == "" || strings.Contains(host, "*") {
+			return c, fmt.Errorf("wildcard host %q must have form \"*.example.com\"", rule.Host)
+		}
+	}
+	host = normalizeHost(host)
+	c.host = host
+
+	if !c.wild {
+		if addr, err := netip.ParseAddr(host); err == nil {
+			c.addr = addr.Unmap()
+			c.desc = fmt.Sprintf("%s %s", c.action, c.addr.String())
+		} else if prefix, err := netip.ParsePrefix(host); err == nil {
+			c.prefix = prefix.Masked()
+			c.addr = netip.Addr{} // prefix rules use prefix only
+			c.desc = fmt.Sprintf("%s %s", c.action, c.prefix.String())
+		}
+	}
+	if c.desc == "" {
+		pattern := c.host
+		if c.wild {
+			pattern = "*." + c.host
+		}
+		c.desc = fmt.Sprintf("%s %s", c.action, pattern)
+	}
+	if c.port != 0 {
+		c.desc += fmt.Sprintf(":%d", c.port)
+	}
+	return c, nil
+}
+
+func hostMatches(r compiledRule, host string) bool {
+	if r.wild {
+		return strings.HasSuffix(host, "."+r.host)
+	}
+	return host == r.host || strings.HasSuffix(host, "."+r.host)
+}
+
+func ipMatches(r compiledRule, ip netip.Addr) bool {
+	ip = ip.Unmap()
+	if r.addr.IsValid() {
+		return ip == r.addr
+	}
+	if r.prefix.IsValid() {
+		return r.prefix.Contains(ip)
+	}
+	return false
+}
+
+func portMatches(rulePort, port int) bool {
+	return rulePort == 0 || rulePort == port
+}
+
+// normalizeHost lowercases, strips the trailing dot, and converts
+// unicode hostnames to punycode. IDNA failures leave the input
+// unchanged so the proxy can still reject it via the allow-list
+// default; rules themselves are normalized at compile time.
+func normalizeHost(host string) string {
+	host = strings.TrimSuffix(strings.ToLower(strings.TrimSpace(host)), ".")
+	if ascii := isASCII(host); ascii {
+		return host
+	}
+	if ascii, err := idna.Lookup.ToASCII(host); err == nil {
+		return ascii
+	}
+	return host
+}
+
+func isASCII(s string) bool {
+	for i := 0; i < len(s); i++ {
+		if s[i] >= 0x80 {
+			return false
+		}
+	}
+	return true
+}

--- a/sdkx/internal/httpkit/matcher_test.go
+++ b/sdkx/internal/httpkit/matcher_test.go
@@ -1,0 +1,142 @@
+package httpkit
+
+import (
+	"net/netip"
+	"testing"
+
+	"github.com/GizClaw/flowcraft/sdk/errdefs"
+	"github.com/GizClaw/flowcraft/sdk/sandbox"
+)
+
+func TestMatcher_DenyWinsOverAllow(t *testing.T) {
+	m, err := NewMatcher(sandbox.NetPolicy{
+		Rules: []sandbox.NetRule{
+			{Action: sandbox.NetAllow, Host: "example.com"},
+			{Action: sandbox.NetDeny, Host: "*.internal.example.com"},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if action, rule, matched := m.Match("api.internal.example.com", 443); !matched || action != sandbox.NetDeny {
+		t.Fatalf("deny rule must win: action=%v rule=%q matched=%v", action, rule, matched)
+	}
+	if action, _, matched := m.Match("example.com", 443); !matched || action != sandbox.NetAllow {
+		t.Fatalf("allow rule missing: action=%v matched=%v", action, matched)
+	}
+}
+
+func TestMatcher_DomainAndWildcardSemantics(t *testing.T) {
+	m, err := NewMatcher(sandbox.NetPolicy{
+		Rules: []sandbox.NetRule{
+			{Action: sandbox.NetAllow, Host: "example.com"},
+			{Action: sandbox.NetDeny, Host: "*.blocked.example"},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Bare domain AND descendants.
+	for _, host := range []string{"example.com", "api.example.com", "a.b.example.com"} {
+		if action, _, matched := m.Match(host, 80); !matched || action != sandbox.NetAllow {
+			t.Errorf("%s: want allow", host)
+		}
+	}
+	// Wildcard: subdomains only, never the bare domain.
+	if action, _, matched := m.Match("blocked.example", 80); matched {
+		t.Errorf("bare wildcard base must not match: action=%v", action)
+	}
+	for _, host := range []string{"x.blocked.example", "a.b.blocked.example"} {
+		if action, _, matched := m.Match(host, 80); !matched || action != sandbox.NetDeny {
+			t.Errorf("%s: want deny", host)
+		}
+	}
+}
+
+func TestMatcher_PortMatching(t *testing.T) {
+	m, err := NewMatcher(sandbox.NetPolicy{
+		Rules: []sandbox.NetRule{
+			{Action: sandbox.NetAllow, Host: "example.com", Port: 443},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, _, matched := m.Match("example.com", 80); matched {
+		t.Fatal("port 80 must not match a 443-only rule")
+	}
+	if action, _, matched := m.Match("example.com", 443); !matched || action != sandbox.NetAllow {
+		t.Fatal("port 443 must match")
+	}
+}
+
+func TestMatcher_IPAndCIDR(t *testing.T) {
+	m, err := NewMatcher(sandbox.NetPolicy{
+		Rules: []sandbox.NetRule{
+			{Action: sandbox.NetAllow, Host: "10.0.0.0/8", Port: 443},
+			{Action: sandbox.NetDeny, Host: "10.1.2.3"},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !m.HasIPRules() {
+		t.Fatal("IP rules must be reported")
+	}
+	if action, _, matched := m.MatchIP(netip.MustParseAddr("10.9.9.9"), 443); !matched || action != sandbox.NetAllow {
+		t.Fatalf("CIDR allow missing: %v %v", action, matched)
+	}
+	if _, _, matched := m.MatchIP(netip.MustParseAddr("10.9.9.9"), 80); matched {
+		t.Fatal("CIDR rule is port-bound; port 80 must not match")
+	}
+	if action, _, matched := m.MatchIP(netip.MustParseAddr("10.1.2.3"), 443); !matched || action != sandbox.NetDeny {
+		t.Fatalf("exact IP deny missing: %v %v", action, matched)
+	}
+	if _, _, matched := m.MatchIP(netip.MustParseAddr("11.0.0.1"), 443); matched {
+		t.Fatal("out-of-prefix IP must not match")
+	}
+}
+
+func TestMatcher_AllowHostsCompiledAsTrailingAllow(t *testing.T) {
+	m, err := NewMatcher(sandbox.NetPolicy{
+		AllowHosts: []string{"legacy.example"},
+		Rules: []sandbox.NetRule{
+			{Action: sandbox.NetDeny, Host: "*.blocked.example"},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if action, _, matched := m.Match("api.legacy.example", 80); !matched || action != sandbox.NetAllow {
+		t.Fatalf("legacy allow missing for subdomain: %v %v", action, matched)
+	}
+	if action, _, matched := m.Match("x.blocked.example", 80); !matched || action != sandbox.NetDeny {
+		t.Fatalf("explicit deny missing: %v %v", action, matched)
+	}
+}
+
+func TestMatcher_IDNA(t *testing.T) {
+	m, err := NewMatcher(sandbox.NetPolicy{
+		Rules: []sandbox.NetRule{{Action: sandbox.NetAllow, Host: "münchen.example"}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if action, _, matched := m.Match("xn--mnchen-3ya.example", 80); !matched || action != sandbox.NetAllow {
+		t.Fatalf("punycode host must match unicode rule: %v %v", action, matched)
+	}
+	if action, _, matched := m.Match("MÜNCHEN.EXAMPLE.", 80); !matched || action != sandbox.NetAllow {
+		t.Fatalf("case/trailing-dot normalization missing: %v %v", action, matched)
+	}
+}
+
+func TestMatcher_InvalidRules(t *testing.T) {
+	for _, host := range []string{"", "a*b.example", "*.", "*"} {
+		_, err := NewMatcher(sandbox.NetPolicy{
+			Rules: []sandbox.NetRule{{Action: sandbox.NetAllow, Host: host}},
+		})
+		if !errdefs.IsValidation(err) {
+			t.Errorf("host %q: err = %v, want Validation", host, err)
+		}
+	}
+}

--- a/sdkx/internal/httpkit/mitm/bundle.go
+++ b/sdkx/internal/httpkit/mitm/bundle.go
@@ -1,0 +1,49 @@
+package mitm
+
+import (
+	"os"
+	"path/filepath"
+)
+
+// systemBundleCandidates are the common system CA bundle locations on
+// Linux and macOS. The first existing file is copied into the merged
+// bundle so SSL_CERT_FILE still trusts the platform's roots.
+var systemBundleCandidates = []string{
+	"/etc/ssl/certs/ca-certificates.crt",
+	"/etc/pki/tls/certs/ca-bundle.crt",
+	"/etc/ssl/ca-bundle.pem",
+	"/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem",
+	"/etc/ssl/cert.pem",
+}
+
+// WriteBundle writes the temporary MITM CA alongside a copy of the
+// system roots into a fresh 0600 temp file, and returns its path plus
+// a cleanup function. The path is meant to be bound into the sandbox
+// and referenced by SSL_CERT_FILE.
+func WriteBundle(caPEM []byte) (string, func(), error) {
+	dir, err := os.MkdirTemp("", "flowcraft-ca-bundle-")
+	if err != nil {
+		return "", nil, err
+	}
+	cleanup := func() { _ = os.RemoveAll(dir) }
+	path := filepath.Join(dir, "ca-bundle.pem")
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o600)
+	if err != nil {
+		cleanup()
+		return "", nil, err
+	}
+	for _, candidate := range systemBundleCandidates {
+		data, readErr := os.ReadFile(candidate)
+		if readErr != nil {
+			continue
+		}
+		_, _ = f.Write(data)
+		_, _ = f.Write([]byte("\n"))
+	}
+	_, _ = f.Write(caPEM)
+	if err := f.Close(); err != nil {
+		cleanup()
+		return "", nil, err
+	}
+	return path, cleanup, nil
+}

--- a/sdkx/internal/httpkit/mitm/ca.go
+++ b/sdkx/internal/httpkit/mitm/ca.go
@@ -1,0 +1,131 @@
+package mitm
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"fmt"
+	"math/big"
+	"net"
+	"net/netip"
+	"sync"
+	"time"
+)
+
+// caValidity is how long the ephemeral root CA lives. Leaves are
+// issued for slightly less so they never outlive their signer.
+const caValidity = 24 * time.Hour
+
+// CA is a per-run temporary certificate authority. The private key
+// lives only in memory and is discarded when the CA is garbage
+// collected; leaf certificates are cached per host.
+type CA struct {
+	cert   *x509.Certificate
+	key    *ecdsa.PrivateKey
+	pem    []byte
+	mu     sync.Mutex
+	leaves map[string]*tls.Certificate
+}
+
+// NewCA generates a fresh self-signed ECDSA P-256 root CA.
+func NewCA() (*CA, error) {
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		return nil, fmt.Errorf("mitm: generate CA key: %w", err)
+	}
+	serial, err := randomSerial()
+	if err != nil {
+		return nil, err
+	}
+	now := time.Now()
+	tmpl := &x509.Certificate{
+		SerialNumber:          serial,
+		Subject:               pkix.Name{CommonName: "flowcraft netproxy temporary CA"},
+		NotBefore:             now.Add(-time.Hour),
+		NotAfter:              now.Add(caValidity),
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageDigitalSignature,
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	if err != nil {
+		return nil, fmt.Errorf("mitm: create CA certificate: %w", err)
+	}
+	cert, err := x509.ParseCertificate(der)
+	if err != nil {
+		return nil, fmt.Errorf("mitm: parse CA certificate: %w", err)
+	}
+	return &CA{
+		cert:   cert,
+		key:    key,
+		pem:    pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der}),
+		leaves: make(map[string]*tls.Certificate),
+	}, nil
+}
+
+// PEM returns the root CA certificate in PEM form for bundle
+// injection into the sandbox.
+func (c *CA) PEM() []byte { return append([]byte(nil), c.pem...) }
+
+// Leaf returns (and caches) a leaf certificate whose SAN is host —
+// a DNS SAN for hostnames, an IP SAN for literals.
+func (c *CA) Leaf(host string) (*tls.Certificate, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if leaf, ok := c.leaves[host]; ok {
+		return leaf, nil
+	}
+	leaf, err := c.issueLeaf(host)
+	if err != nil {
+		return nil, err
+	}
+	c.leaves[host] = leaf
+	return leaf, nil
+}
+
+func (c *CA) issueLeaf(host string) (*tls.Certificate, error) {
+	serial, err := randomSerial()
+	if err != nil {
+		return nil, err
+	}
+	now := time.Now()
+	tmpl := &x509.Certificate{
+		SerialNumber: serial,
+		Subject:      pkix.Name{CommonName: host},
+		NotBefore:    now.Add(-time.Hour),
+		NotAfter:     now.Add(caValidity - time.Hour),
+		KeyUsage:     x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+	}
+	if ip, err := netip.ParseAddr(host); err == nil {
+		tmpl.IPAddresses = []net.IP{net.IP(ip.AsSlice())}
+	} else {
+		tmpl.DNSNames = []string{host}
+	}
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		return nil, fmt.Errorf("mitm: generate leaf key: %w", err)
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, c.cert, &key.PublicKey, c.key)
+	if err != nil {
+		return nil, fmt.Errorf("mitm: issue leaf for %q: %w", host, err)
+	}
+	return &tls.Certificate{
+		Certificate: [][]byte{der, c.cert.Raw},
+		PrivateKey:  key,
+		Leaf:        tmpl,
+	}, nil
+}
+
+func randomSerial() (*big.Int, error) {
+	limit := new(big.Int).Lsh(big.NewInt(1), 128)
+	serial, err := rand.Int(rand.Reader, limit)
+	if err != nil {
+		return nil, fmt.Errorf("mitm: random serial: %w", err)
+	}
+	return serial, nil
+}

--- a/sdkx/internal/httpkit/mitm/engine.go
+++ b/sdkx/internal/httpkit/mitm/engine.go
@@ -1,0 +1,233 @@
+package mitm
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+
+	"github.com/GizClaw/flowcraft/sdk/sandbox"
+)
+
+// DefaultMaxBodyBytes caps buffered bodies when
+// MITMPolicy.MaxBodyBytes is zero.
+const DefaultMaxBodyBytes = 64 << 10
+
+// Engine terminates TLS for one CONNECT tunnel and runs decrypted
+// requests through hooks and an outbound transport. One Engine is
+// shared by all tunnels of one proxy instance; it is safe for
+// concurrent use.
+type Engine struct {
+	policy *sandbox.MITMPolicy
+	hooks  ProxyHooks
+	ca     *CA
+	roots  *x509.CertPool
+	dial   func(ctx context.Context, hostport string) (net.Conn, error)
+	cap    int64
+}
+
+// New builds an Engine. dial must return a raw (pre-TLS) connection to
+// the target — the enforcement proxy's policy-aware dialer. roots
+// overrides the system pool used to verify the target's certificate
+// (nil means system roots).
+func New(policy *sandbox.MITMPolicy, hooks ProxyHooks, dial func(context.Context, string) (net.Conn, error), roots *x509.CertPool) (*Engine, error) {
+	if policy == nil {
+		return nil, fmt.Errorf("mitm: nil policy")
+	}
+	ca, err := NewCA()
+	if err != nil {
+		return nil, err
+	}
+	capBytes := policy.MaxBodyBytes
+	if capBytes <= 0 {
+		capBytes = DefaultMaxBodyBytes
+	}
+	return &Engine{
+		policy: policy,
+		hooks:  hooks,
+		ca:     ca,
+		roots:  roots,
+		dial:   dial,
+		cap:    capBytes,
+	}, nil
+}
+
+// PEM exposes the temporary root CA for bundle injection.
+func (e *Engine) PEM() []byte { return e.ca.PEM() }
+
+// Serve terminates TLS on client for serverName, forwards decrypted
+// HTTP/1.1 requests to dialHostport (TLS-verified against the real
+// target), and writes responses back. It returns when the client
+// closes the connection or a fatal protocol error occurs.
+func (e *Engine) Serve(client net.Conn, serverName, dialHostport string) error {
+	leaf, err := e.ca.Leaf(serverName)
+	if err != nil {
+		return err
+	}
+	tlsConn := tls.Server(client, &tls.Config{
+		Certificates: []tls.Certificate{*leaf},
+		// v1 is HTTP/1.1 only: no h2 ALPN, so h2-only clients are
+		// rejected at handshake and everything else falls back cleanly.
+		NextProtos: []string{"http/1.1"},
+		MinVersion: tls.VersionTLS12,
+	})
+	if err := tlsConn.Handshake(); err != nil {
+		return fmt.Errorf("mitm: client handshake: %w", err)
+	}
+	defer func() { _ = tlsConn.Close() }()
+
+	transport := &http.Transport{
+		DialTLSContext: func(ctx context.Context, _, _ string) (net.Conn, error) {
+			return e.dialTLS(ctx, dialHostport, serverName)
+		},
+		ForceAttemptHTTP2:   false,
+		MaxIdleConns:        4,
+		MaxIdleConnsPerHost: 2,
+	}
+	defer transport.CloseIdleConnections()
+
+	br := bufio.NewReader(tlsConn)
+	for {
+		req, err := http.ReadRequest(br)
+		if err != nil {
+			return nil // client closed or keep-alive ended
+		}
+		info, err := e.inspectRequest(req)
+		if err != nil {
+			writeError(tlsConn, http.StatusBadGateway, "mitm: read request body")
+			return nil
+		}
+		if e.hooks != nil && info != nil {
+			if err := e.hooks.OnRequest(context.Background(), info); err != nil {
+				writeError(tlsConn, http.StatusForbidden, "mitm: request blocked by hook")
+				return nil
+			}
+		}
+		outReq := req.Clone(context.Background())
+		outReq.RequestURI = ""
+		outReq.URL.Scheme = "https"
+		outReq.URL.Host = dialHostport
+		resp, err := transport.RoundTrip(outReq)
+		if err != nil {
+			writeError(tlsConn, http.StatusBadGateway, "mitm: upstream request failed")
+			return nil
+		}
+
+		if info, err := e.inspectResponse(resp); err != nil {
+			_ = resp.Body.Close()
+			writeError(tlsConn, http.StatusBadGateway, "mitm: read response body")
+			return nil
+		} else if info != nil {
+			if e.hooks != nil {
+				if hookErr := e.hooks.OnResponse(context.Background(), info); hookErr != nil {
+					_ = resp.Body.Close()
+					writeError(tlsConn, http.StatusForbidden, "mitm: response blocked by hook")
+					return nil
+				}
+			}
+		}
+
+		// The client side is HTTP/1.1 even when the origin negotiated
+		// h2; normalize the status line before writing back.
+		resp.Proto = "HTTP/1.1"
+		resp.ProtoMajor = 1
+		resp.ProtoMinor = 1
+		closeConn := req.Close || resp.Close
+		if err := resp.Write(tlsConn); err != nil {
+			return err
+		}
+		if closeConn {
+			return nil
+		}
+	}
+}
+
+// inspectRequest buffers the body only when inspection is on and
+// Content-Length is bounded by the cap; otherwise the body is passed
+// through untouched and the hook sees Body nil.
+func (e *Engine) inspectRequest(req *http.Request) (*RequestInfo, error) {
+	if e.hooks == nil {
+		return nil, nil
+	}
+	info := &RequestInfo{
+		Method: req.Method,
+		Scheme: "https",
+		Host:   req.Host,
+		Path:   req.URL.RequestURI(),
+		Header: req.Header.Clone(),
+	}
+	if !e.policy.InspectBodies {
+		return info, nil
+	}
+	if req.Body == nil || req.ContentLength < 0 || req.ContentLength > e.cap {
+		return info, nil
+	}
+	consumed, err := io.ReadAll(io.LimitReader(req.Body, e.cap+1))
+	if err != nil {
+		return nil, err
+	}
+	if int64(len(consumed)) > e.cap {
+		// Content-Length lied; do not inspect, but preserve the bytes
+		// we already consumed so the upstream body stays intact.
+		req.Body = io.NopCloser(io.MultiReader(bytes.NewReader(consumed), req.Body))
+		return info, nil
+	}
+	info.Body = consumed
+	req.Body = io.NopCloser(bytes.NewReader(consumed))
+	return info, nil
+}
+
+func (e *Engine) inspectResponse(resp *http.Response) (*ResponseInfo, error) {
+	if e.hooks == nil {
+		return nil, nil
+	}
+	info := &ResponseInfo{
+		StatusCode: resp.StatusCode,
+		Header:     resp.Header.Clone(),
+	}
+	if !e.policy.InspectBodies {
+		return info, nil
+	}
+	if resp.Body == nil || resp.ContentLength < 0 || resp.ContentLength > e.cap {
+		return info, nil
+	}
+	consumed, err := io.ReadAll(io.LimitReader(resp.Body, e.cap+1))
+	if err != nil {
+		return nil, err
+	}
+	if int64(len(consumed)) > e.cap {
+		resp.Body = io.NopCloser(io.MultiReader(bytes.NewReader(consumed), resp.Body))
+		return info, nil
+	}
+	info.Body = consumed
+	resp.Body = io.NopCloser(bytes.NewReader(consumed))
+	return info, nil
+}
+
+func (e *Engine) dialTLS(ctx context.Context, hostport, serverName string) (net.Conn, error) {
+	raw, err := e.dial(ctx, hostport)
+	if err != nil {
+		return nil, err
+	}
+	tlsConn := tls.Client(raw, &tls.Config{
+		ServerName: serverName,
+		RootCAs:    e.roots,
+		MinVersion: tls.VersionTLS12,
+	})
+	if err := tlsConn.HandshakeContext(ctx); err != nil {
+		_ = raw.Close()
+		return nil, fmt.Errorf("mitm: upstream handshake: %w", err)
+	}
+	return tlsConn, nil
+}
+
+func writeError(w io.Writer, status int, msg string) {
+	body := msg + "\n"
+	_, _ = fmt.Fprintf(w, "HTTP/1.1 %d %s\r\nContent-Type: text/plain\r\nContent-Length: %d\r\nConnection: close\r\n\r\n%s",
+		status, http.StatusText(status), len(body), body)
+}

--- a/sdkx/internal/httpkit/mitm/engine.go
+++ b/sdkx/internal/httpkit/mitm/engine.go
@@ -6,12 +6,16 @@ import (
 	"context"
 	"crypto/tls"
 	"crypto/x509"
+	"errors"
 	"fmt"
 	"io"
 	"net"
 	"net/http"
+	"net/netip"
 
 	"github.com/GizClaw/flowcraft/sdk/sandbox"
+	"github.com/GizClaw/flowcraft/sdkx/internal/hostmatch"
+	"golang.org/x/net/http2"
 )
 
 // DefaultMaxBodyBytes caps buffered bodies when
@@ -23,13 +27,19 @@ const DefaultMaxBodyBytes = 64 << 10
 // shared by all tunnels of one proxy instance; it is safe for
 // concurrent use.
 type Engine struct {
-	policy *sandbox.MITMPolicy
-	hooks  ProxyHooks
-	ca     *CA
-	roots  *x509.CertPool
-	dial   func(ctx context.Context, hostport string) (net.Conn, error)
-	cap    int64
+	policy   *sandbox.MITMPolicy
+	hooks    ProxyHooks
+	ca       *CA
+	roots    *x509.CertPool
+	dial     func(ctx context.Context, hostport string) (net.Conn, error)
+	cap      int64
+	includes *hostmatch.Set
+	excludes *hostmatch.Set
 }
+
+// errBlocked marks a hook refusal: the caller writes 403 and ends the
+// tunnel.
+var errBlocked = errors.New("mitm: blocked by hook")
 
 // New builds an Engine. dial must return a raw (pre-TLS) connection to
 // the target — the enforcement proxy's policy-aware dialer. roots
@@ -47,23 +57,56 @@ func New(policy *sandbox.MITMPolicy, hooks ProxyHooks, dial func(context.Context
 	if capBytes <= 0 {
 		capBytes = DefaultMaxBodyBytes
 	}
+	includes, err := hostmatch.New(policy.Hosts)
+	if err != nil {
+		return nil, fmt.Errorf("mitm: hosts: %w", err)
+	}
+	excludes, err := hostmatch.New(policy.ExcludeHosts)
+	if err != nil {
+		return nil, fmt.Errorf("mitm: exclude_hosts: %w", err)
+	}
 	return &Engine{
-		policy: policy,
-		hooks:  hooks,
-		ca:     ca,
-		roots:  roots,
-		dial:   dial,
-		cap:    capBytes,
+		policy:   policy,
+		hooks:    hooks,
+		ca:       ca,
+		roots:    roots,
+		dial:     dial,
+		cap:      capBytes,
+		includes: includes,
+		excludes: excludes,
 	}, nil
 }
 
 // PEM exposes the temporary root CA for bundle injection.
 func (e *Engine) PEM() []byte { return e.ca.PEM() }
 
-// Serve terminates TLS on client for serverName, forwards decrypted
-// HTTP/1.1 requests to dialHostport (TLS-verified against the real
-// target), and writes responses back. It returns when the client
-// closes the connection or a fatal protocol error occurs.
+// ShouldMITM reports whether a CONNECT host is subject to TLS
+// termination under the policy's host selection. Excludes always win;
+// an empty include list means "all hosts". Hosts that bypass MITM get
+// a raw tunnel (allow/deny rules still apply; content hooks do not).
+func (e *Engine) ShouldMITM(host string) bool {
+	if e.excludes != nil && mitmSetMatches(e.excludes, host) {
+		return false
+	}
+	if e.includes != nil && !e.includes.Empty() && !mitmSetMatches(e.includes, host) {
+		return false
+	}
+	return true
+}
+
+// mitmSetMatches evaluates a host against a pattern set, routing IP
+// literals through MatchIP so "127.0.0.1" entries work as expected.
+func mitmSetMatches(s *hostmatch.Set, host string) bool {
+	if ip, err := netip.ParseAddr(host); err == nil {
+		return s.MatchIP(ip.Unmap())
+	}
+	return s.Match(host)
+}
+
+// Serve terminates TLS on client for serverName and forwards decrypted
+// HTTP/1.1 or HTTP/2 requests — the client's ALPN choice decides — to
+// dialHostport (TLS-verified against the real target). It returns when
+// the client closes the connection or a fatal protocol error occurs.
 func (e *Engine) Serve(client net.Conn, serverName, dialHostport string) error {
 	leaf, err := e.ca.Leaf(serverName)
 	if err != nil {
@@ -71,9 +114,9 @@ func (e *Engine) Serve(client net.Conn, serverName, dialHostport string) error {
 	}
 	tlsConn := tls.Server(client, &tls.Config{
 		Certificates: []tls.Certificate{*leaf},
-		// v1 is HTTP/1.1 only: no h2 ALPN, so h2-only clients are
-		// rejected at handshake and everything else falls back cleanly.
-		NextProtos: []string{"http/1.1"},
+		// h2 and http/1.1 are both offered; the client picks. h2-only
+		// clients (gRPC etc.) work; everything else falls back to h1.
+		NextProtos: []string{"h2", "http/1.1"},
 		MinVersion: tls.VersionTLS12,
 	})
 	if err := tlsConn.Handshake(); err != nil {
@@ -81,68 +124,131 @@ func (e *Engine) Serve(client net.Conn, serverName, dialHostport string) error {
 	}
 	defer func() { _ = tlsConn.Close() }()
 
-	transport := &http.Transport{
+	transport := e.newTransport(serverName, dialHostport)
+	defer transport.CloseIdleConnections()
+
+	if tlsConn.ConnectionState().NegotiatedProtocol == "h2" {
+		h2 := &http2.Server{}
+		h2.ServeConn(tlsConn, &http2.ServeConnOpts{
+			Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				e.serveH2(w, r, transport, serverName, dialHostport)
+			}),
+		})
+		return nil
+	}
+	return e.serveH1(tlsConn, transport, serverName, dialHostport)
+}
+
+func (e *Engine) newTransport(serverName, dialHostport string) *http.Transport {
+	return &http.Transport{
 		DialTLSContext: func(ctx context.Context, _, _ string) (net.Conn, error) {
 			return e.dialTLS(ctx, dialHostport, serverName)
 		},
-		ForceAttemptHTTP2:   false,
+		ForceAttemptHTTP2:   true,
 		MaxIdleConns:        4,
 		MaxIdleConnsPerHost: 2,
 	}
-	defer transport.CloseIdleConnections()
+}
 
+func (e *Engine) serveH1(tlsConn *tls.Conn, transport *http.Transport, serverName, dialHostport string) error {
 	br := bufio.NewReader(tlsConn)
 	for {
 		req, err := http.ReadRequest(br)
 		if err != nil {
 			return nil // client closed or keep-alive ended
 		}
-		info, err := e.inspectRequest(req)
-		if err != nil {
-			writeError(tlsConn, http.StatusBadGateway, "mitm: read request body")
+		resp, err := e.forward(req, transport, serverName, dialHostport)
+		if err == errBlocked {
+			writeError(tlsConn, http.StatusForbidden, "mitm: blocked by hook")
 			return nil
 		}
-		if e.hooks != nil && info != nil {
-			if err := e.hooks.OnRequest(context.Background(), info); err != nil {
-				writeError(tlsConn, http.StatusForbidden, "mitm: request blocked by hook")
-				return nil
-			}
-		}
-		outReq := req.Clone(context.Background())
-		outReq.RequestURI = ""
-		outReq.URL.Scheme = "https"
-		outReq.URL.Host = dialHostport
-		resp, err := transport.RoundTrip(outReq)
 		if err != nil {
 			writeError(tlsConn, http.StatusBadGateway, "mitm: upstream request failed")
 			return nil
 		}
-
-		if info, err := e.inspectResponse(resp); err != nil {
-			_ = resp.Body.Close()
-			writeError(tlsConn, http.StatusBadGateway, "mitm: read response body")
-			return nil
-		} else if info != nil {
-			if e.hooks != nil {
-				if hookErr := e.hooks.OnResponse(context.Background(), info); hookErr != nil {
-					_ = resp.Body.Close()
-					writeError(tlsConn, http.StatusForbidden, "mitm: response blocked by hook")
-					return nil
-				}
-			}
-		}
-
-		// The client side is HTTP/1.1 even when the origin negotiated
-		// h2; normalize the status line before writing back.
-		resp.Proto = "HTTP/1.1"
-		resp.ProtoMajor = 1
-		resp.ProtoMinor = 1
 		closeConn := req.Close || resp.Close
 		if err := resp.Write(tlsConn); err != nil {
 			return err
 		}
 		if closeConn {
 			return nil
+		}
+	}
+}
+
+func (e *Engine) serveH2(w http.ResponseWriter, r *http.Request, transport *http.Transport, serverName, dialHostport string) {
+	resp, err := e.forward(r, transport, serverName, dialHostport)
+	if err == errBlocked {
+		http.Error(w, "mitm: blocked by hook", http.StatusForbidden)
+		return
+	}
+	if err != nil {
+		http.Error(w, "mitm: upstream request failed", http.StatusBadGateway)
+		return
+	}
+	defer func() { _ = resp.Body.Close() }()
+	copyResponse(w, resp)
+}
+
+// forward runs hooks and the outbound round trip for one decrypted
+// request, returning the response ready to write. errBlocked means a
+// hook refused the traffic.
+func (e *Engine) forward(req *http.Request, transport *http.Transport, serverName, dialHostport string) (*http.Response, error) {
+	info, err := e.inspectRequest(req)
+	if err != nil {
+		return nil, err
+	}
+	if e.hooks != nil && info != nil {
+		if err := e.hooks.OnRequest(context.Background(), info); err != nil {
+			return nil, errBlocked
+		}
+	}
+	outReq := req.Clone(context.Background())
+	outReq.RequestURI = ""
+	outReq.URL.Scheme = "https"
+	outReq.URL.Host = dialHostport
+	resp, err := transport.RoundTrip(outReq)
+	if err != nil {
+		return nil, err
+	}
+	respInfo, err := e.inspectResponse(resp)
+	if err != nil {
+		_ = resp.Body.Close()
+		return nil, err
+	}
+	if e.hooks != nil && respInfo != nil {
+		if err := e.hooks.OnResponse(context.Background(), respInfo); err != nil {
+			_ = resp.Body.Close()
+			return nil, errBlocked
+		}
+	}
+	// The client-facing protocol is whatever the client negotiated;
+	// the response framing is produced by resp.Write (h1) or
+	// copyResponse (h2), so normalize the status line only.
+	resp.Proto = "HTTP/1.1"
+	resp.ProtoMajor = 1
+	resp.ProtoMinor = 1
+	return resp, nil
+}
+
+func copyResponse(w http.ResponseWriter, resp *http.Response) {
+	h := w.Header()
+	for k, vs := range resp.Trailer {
+		for _, v := range vs {
+			h.Add(http.TrailerPrefix+k, v)
+		}
+	}
+	copyHeader(h, resp.Header)
+	w.WriteHeader(resp.StatusCode)
+	if resp.Body != nil {
+		_, _ = io.Copy(w, resp.Body)
+	}
+}
+
+func copyHeader(dst, src http.Header) {
+	for k, vs := range src {
+		for _, v := range vs {
+			dst.Add(k, v)
 		}
 	}
 }

--- a/sdkx/internal/httpkit/mitm/hooks.go
+++ b/sdkx/internal/httpkit/mitm/hooks.go
@@ -2,8 +2,10 @@
 // enforcement proxy: a per-run temporary CA signs leaf certificates
 // for CONNECT hosts, the proxy terminates TLS with the child, applies
 // hooks, and re-establishes TLS to the real target. It is HTTP/1.1
-// only by design (ALPN advertises http/1.1); h2-only clients are
-// documented as unsupported.
+// and HTTP/2 capable: ALPN offers both h2 and http/1.1, so gRPC-style
+// h2-only clients are terminated too, with everything else falling
+// back to h1. Host selection (MITMPolicy.Hosts / ExcludeHosts)
+// decides which CONNECT tunnels are terminated at all.
 package mitm
 
 import (

--- a/sdkx/internal/httpkit/mitm/hooks.go
+++ b/sdkx/internal/httpkit/mitm/hooks.go
@@ -1,0 +1,50 @@
+// Package mitm implements opt-in TLS termination for the sandbox
+// enforcement proxy: a per-run temporary CA signs leaf certificates
+// for CONNECT hosts, the proxy terminates TLS with the child, applies
+// hooks, and re-establishes TLS to the real target. It is HTTP/1.1
+// only by design (ALPN advertises http/1.1); h2-only clients are
+// documented as unsupported.
+package mitm
+
+import (
+	"context"
+	"net/http"
+)
+
+// ConnectInfo describes one CONNECT attempt before any tunnel or TLS
+// termination happens.
+type ConnectInfo struct {
+	Host string
+	Port int
+}
+
+// RequestInfo is a decrypted request as seen by hooks. Body is only
+// populated when body inspection is enabled and the request has a
+// bounded Content-Length; streaming bodies pass through uninspected
+// with Body nil.
+type RequestInfo struct {
+	Method string
+	Scheme string
+	Host   string
+	Path   string
+	Header http.Header
+	Body   []byte
+}
+
+// ResponseInfo is a decrypted response as seen by hooks. Body follows
+// the same bounded-Content-Length rule as RequestInfo.Body.
+type ResponseInfo struct {
+	StatusCode int
+	Header     http.Header
+	Body       []byte
+}
+
+// ProxyHooks observes (and can block) decrypted traffic. Returning an
+// error from any hook blocks the request/connection with 403.
+// Hooks only run when MITM is enabled; plain CONNECT tunnels and
+// plain HTTP forwarding never invoke them.
+type ProxyHooks interface {
+	OnConnect(ctx context.Context, c *ConnectInfo) error
+	OnRequest(ctx context.Context, req *RequestInfo) error
+	OnResponse(ctx context.Context, resp *ResponseInfo) error
+}

--- a/sdkx/internal/httpkit/mitm/writebundle_test.go
+++ b/sdkx/internal/httpkit/mitm/writebundle_test.go
@@ -1,0 +1,22 @@
+package mitm
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestWriteBundleAppendsCA(t *testing.T) {
+	path, cleanup, err := WriteBundle([]byte("-----BEGIN CERTIFICATE-----\nXXXXCAXXXX\n-----END CERTIFICATE-----\n"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cleanup()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(data), "XXXXCAXXXX") {
+		t.Fatalf("CA not appended: %d bytes", len(data))
+	}
+}

--- a/sdkx/internal/httpkit/netproxy.go
+++ b/sdkx/internal/httpkit/netproxy.go
@@ -300,7 +300,7 @@ func (p *Proxy) serveConnect(w http.ResponseWriter, r *http.Request) {
 	if _, err := client.Write([]byte("HTTP/1.1 200 Connection Established\r\n\r\n")); err != nil {
 		return
 	}
-	if p.mitm != nil {
+	if p.mitm != nil && p.mitm.ShouldMITM(host) {
 		if err := p.mitm.Serve(client, host, dialHost); err != nil {
 			return
 		}

--- a/sdkx/internal/httpkit/netproxy.go
+++ b/sdkx/internal/httpkit/netproxy.go
@@ -16,23 +16,33 @@
 //
 // Trust boundary: the proxy is spawned by the host application and is
 // the sandboxed child's only network egress. A compromised child can
-// reach exactly the destinations the proxy's allow-list (or upstream)
-// permits — that is the configured policy, not a sandbox escape. The
-// proxy must therefore be pinned and audited like any trust anchor.
+// reach exactly the destinations the proxy's policy permits — that is
+// the configured policy, not a sandbox escape. The proxy must
+// therefore be pinned and audited like any trust anchor. When MITM is
+// enabled, the temporary CA becomes an additional trust anchor and
+// must be treated with the same care.
 package httpkit
 
 import (
 	"bufio"
+	"context"
+	"crypto/x509"
+	"encoding/base64"
 	"fmt"
 	"io"
 	"net"
 	"net/http"
+	"net/netip"
 	"net/url"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
+	"sync"
 
 	"github.com/GizClaw/flowcraft/sdk/sandbox"
+	"github.com/GizClaw/flowcraft/sdkx/internal/httpkit/mitm"
+	"golang.org/x/net/proxy"
 )
 
 // ProxyConfig configures one enforcement proxy instance. It is named
@@ -41,12 +51,17 @@ import (
 type ProxyConfig struct {
 	// Mode is sandbox.NetAllowList or sandbox.NetProxy.
 	Mode sandbox.NetMode
-	// AllowHosts is the allow-list: hostname suffixes ("example.com"
-	// matches "api.example.com") and exact IP literals. Ignored in
-	// proxy mode.
+	// AllowHosts is the deprecated allow-list: hostname suffixes and
+	// exact IP literals. Compiled as trailing allow rules (see
+	// Matcher); explicit Rules deny rules always win.
 	AllowHosts []string
-	// Upstream is the proxy-mode upstream URL ("http://host:port").
-	// Ignored in allow-list mode.
+	// Rules are explicit host/port allow or deny rules. In
+	// NetAllowList mode they define what is reachable; in NetProxy
+	// mode deny rules override the upstream and everything else is
+	// delegated to the upstream.
+	Rules []sandbox.NetRule
+	// Upstream is the proxy-mode upstream URL: "http://host:port" or
+	// "socks5://[user:pass@]host:port". Ignored in allow-list mode.
 	Upstream string
 	// TCPLoopback binds 127.0.0.1:0 (an ephemeral loopback TCP port)
 	// instead of a unix socket. The seatbelt backend uses this because
@@ -54,6 +69,27 @@ type ProxyConfig struct {
 	// through the single SBPL-allowed loopback port. The bwrap backend
 	// leaves it false and uses the unix socket for its bridge.
 	TCPLoopback bool
+	// MITM enables TLS termination for CONNECT tunnels (opt-in).
+	MITM *sandbox.MITMPolicy
+	// OnDecision receives one audit record per allow/deny decision.
+	// It must not block the proxy; keep it fast and non-throwing.
+	OnDecision func(ProxyDecision)
+	// Hooks observe/block traffic. OnConnect applies to every CONNECT;
+	// OnRequest / OnResponse run only on MITM-decrypted traffic.
+	Hooks mitm.ProxyHooks
+	// OutboundRoots overrides the roots used to verify the real
+	// target's TLS certificate during MITM. Nil means system roots.
+	OutboundRoots *x509.CertPool
+}
+
+// ProxyDecision is one audit record: which destination was decided,
+// with which action, and which rule ("" = mode default) decided it.
+type ProxyDecision struct {
+	Host   string
+	Port   int
+	Action sandbox.NetAction
+	Mode   sandbox.NetMode
+	Rule   string
 }
 
 // Proxy is a host-side enforcement proxy listening on a unix socket
@@ -64,8 +100,16 @@ type Proxy struct {
 	ln        net.Listener
 	srv       *http.Server
 	transport *http.Transport
-	dir       string
-	path      string
+	upstream  *url.URL
+	socksDial proxy.ContextDialer
+	mitm      *mitm.Engine
+
+	matcherOnce sync.Once
+	compiled    *Matcher
+	matcherErr  error
+
+	dir  string
+	path string
 }
 
 // Start serves the enforcement proxy in the background and returns
@@ -74,10 +118,52 @@ type Proxy struct {
 // socket in a fresh per-run temp directory (mode 0600) whose path is
 // available via SocketPath for bind-mounting into a sandbox.
 func Start(cfg ProxyConfig) (*Proxy, error) {
-	p := &Proxy{
-		cfg:       cfg,
-		transport: buildTransport(cfg),
+	if cfg.Mode != sandbox.NetAllowList && cfg.Mode != sandbox.NetProxy {
+		return nil, fmt.Errorf(
+			"netproxy: mode must be allow_list or proxy, got %d", int(cfg.Mode))
 	}
+	if err := (sandbox.NetPolicy{
+		Mode:       cfg.Mode,
+		AllowHosts: cfg.AllowHosts,
+		Rules:      cfg.Rules,
+		Proxy:      cfg.Upstream,
+		MITM:       cfg.MITM,
+	}).Validate(); err != nil {
+		return nil, err
+	}
+
+	p := &Proxy{cfg: cfg}
+	if cfg.Upstream != "" {
+		u, err := url.Parse(cfg.Upstream)
+		if err != nil {
+			return nil, fmt.Errorf("netproxy: parse upstream %q: %w", cfg.Upstream, err)
+		}
+		switch u.Scheme {
+		case "http":
+			p.transport = &http.Transport{Proxy: http.ProxyURL(u)}
+		case "socks5":
+			dialer, err := socks5Dialer(u)
+			if err != nil {
+				return nil, err
+			}
+			p.socksDial = dialer
+			p.transport = &http.Transport{DialContext: dialer.DialContext}
+		default:
+			return nil, fmt.Errorf("netproxy: unsupported upstream scheme %q", u.Scheme)
+		}
+		p.upstream = u
+	} else {
+		p.transport = &http.Transport{Proxy: nil}
+	}
+
+	if cfg.MITM != nil && cfg.MITM.Enabled {
+		engine, err := mitm.New(cfg.MITM, cfg.Hooks, p.dialTarget, cfg.OutboundRoots)
+		if err != nil {
+			return nil, err
+		}
+		p.mitm = engine
+	}
+
 	if cfg.TCPLoopback {
 		ln, err := net.Listen("tcp", "127.0.0.1:0")
 		if err != nil {
@@ -118,6 +204,15 @@ func (p *Proxy) SocketPath() string { return p.path }
 // dial; for a unix-socket proxy it is the socket path address.
 func (p *Proxy) Addr() net.Addr { return p.ln.Addr() }
 
+// CAPEM returns the temporary MITM root CA in PEM form, for bundle
+// injection into the sandbox. Nil when MITM is disabled.
+func (p *Proxy) CAPEM() []byte {
+	if p.mitm == nil {
+		return nil
+	}
+	return p.mitm.PEM()
+}
+
 // Close stops the server, closes the listener, and removes the temp
 // directory (including the socket file) when one was created.
 func (p *Proxy) Close() error {
@@ -128,19 +223,6 @@ func (p *Proxy) Close() error {
 		return os.RemoveAll(p.dir)
 	}
 	return nil
-}
-
-// buildTransport returns the outbound transport. Proxy is set
-// explicitly in both modes so Go's ProxyFromEnvironment never leaks
-// the host application's proxy settings into the sandbox path: direct
-// dial for allow-list mode, the configured upstream for proxy mode.
-func buildTransport(cfg ProxyConfig) *http.Transport {
-	if cfg.Upstream != "" {
-		if u, err := url.Parse(cfg.Upstream); err == nil {
-			return &http.Transport{Proxy: http.ProxyURL(u)}
-		}
-	}
-	return &http.Transport{Proxy: nil}
 }
 
 // ServeHTTP implements http.Handler for both HTTP absolute-form
@@ -154,11 +236,28 @@ func (p *Proxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 }
 
 func (p *Proxy) serveHTTP(w http.ResponseWriter, r *http.Request) {
-	if !p.allowed(r.URL.Host) {
+	host, port := splitHostPort(r.URL.Host, 80)
+	action, rule, dialHost, err := p.decide(r.Context(), r.URL.Host, 80)
+	if err != nil {
+		http.Error(w, "netproxy: "+err.Error(), http.StatusBadGateway)
+		return
+	}
+	p.audit(host, port, action, rule)
+	if action != sandbox.NetAllow {
 		http.Error(w, "netproxy: destination not allowed", http.StatusForbidden)
 		return
 	}
-	resp, err := p.transport.RoundTrip(r)
+	out := r
+	if dialHost != r.URL.Host {
+		clone := r.Clone(r.Context())
+		clone.Host = r.Host
+		if clone.Host == "" {
+			clone.Host = r.URL.Host
+		}
+		clone.URL.Host = dialHost
+		out = clone
+	}
+	resp, err := p.transport.RoundTrip(out)
 	if err != nil {
 		http.Error(w, "netproxy: "+err.Error(), http.StatusBadGateway)
 		return
@@ -170,9 +269,22 @@ func (p *Proxy) serveHTTP(w http.ResponseWriter, r *http.Request) {
 }
 
 func (p *Proxy) serveConnect(w http.ResponseWriter, r *http.Request) {
-	if !p.allowed(r.Host) {
+	host, port := splitHostPort(r.Host, 443)
+	action, rule, dialHost, err := p.decide(r.Context(), r.Host, 443)
+	if err != nil {
+		http.Error(w, "netproxy: "+err.Error(), http.StatusBadGateway)
+		return
+	}
+	p.audit(host, port, action, rule)
+	if action != sandbox.NetAllow {
 		http.Error(w, "netproxy: destination not allowed", http.StatusForbidden)
 		return
+	}
+	if p.cfg.Hooks != nil {
+		if err := p.cfg.Hooks.OnConnect(r.Context(), &mitm.ConnectInfo{Host: host, Port: port}); err != nil {
+			http.Error(w, "netproxy: connect blocked by hook", http.StatusForbidden)
+			return
+		}
 	}
 	hj, ok := w.(http.Hijacker)
 	if !ok {
@@ -185,73 +297,222 @@ func (p *Proxy) serveConnect(w http.ResponseWriter, r *http.Request) {
 	}
 	defer func() { _ = client.Close() }()
 
-	target, err := p.dialTarget(r.Host)
+	if _, err := client.Write([]byte("HTTP/1.1 200 Connection Established\r\n\r\n")); err != nil {
+		return
+	}
+	if p.mitm != nil {
+		if err := p.mitm.Serve(client, host, dialHost); err != nil {
+			return
+		}
+		return
+	}
+
+	target, err := p.dialTarget(r.Context(), dialHost)
 	if err != nil {
 		return
 	}
 	defer func() { _ = target.Close() }()
-
-	if _, err := client.Write([]byte("HTTP/1.1 200 Connection Established\r\n\r\n")); err != nil {
-		return
-	}
 	go func() { _, _ = io.Copy(target, client); _ = target.Close() }()
 	_, _ = io.Copy(client, target)
 }
 
-// dialTarget dials the CONNECT target directly (allow-list mode) or
-// establishes a CONNECT tunnel through the upstream (proxy mode).
-func (p *Proxy) dialTarget(hostport string) (net.Conn, error) {
-	if p.cfg.Upstream != "" {
-		u, err := url.Parse(p.cfg.Upstream)
-		if err != nil {
-			return nil, err
-		}
-		up, err := net.Dial("tcp", u.Host)
-		if err != nil {
-			return nil, err
-		}
-		if _, err := fmt.Fprintf(up, "CONNECT %s HTTP/1.1\r\nHost: %s\r\n\r\n", hostport, hostport); err != nil {
-			_ = up.Close()
-			return nil, err
-		}
-		br := bufio.NewReader(up)
-		resp, err := http.ReadResponse(br, &http.Request{Method: http.MethodConnect})
-		if err != nil {
-			_ = up.Close()
-			return nil, err
-		}
-		if resp.StatusCode != http.StatusOK {
-			_ = up.Close()
-			return nil, fmt.Errorf("netproxy: upstream refused CONNECT: %d", resp.StatusCode)
-		}
-		return up, nil
+// decide evaluates the policy for one destination. It returns the
+// verdict, the decisive rule description ("" = mode default), and the
+// concrete dial target. When IP/CIDR rules exist the hostname is
+// resolved locally and the dial target is pinned to a validated IP so
+// neither the upstream nor a rebinding DNS response can bypass the
+// rule set.
+func (p *Proxy) decide(ctx context.Context, hostport string, defaultPort int) (sandbox.NetAction, string, string, error) {
+	host, port := splitHostPort(hostport, defaultPort)
+	dialHost := hostport
+	m := p.matcher()
+	if m == nil {
+		return sandbox.NetDeny, "", dialHost, fmt.Errorf("netproxy: policy matcher unavailable")
 	}
-	return net.Dial("tcp", hostport)
+	if ip, err := netip.ParseAddr(host); err == nil {
+		action, rule, matched := m.MatchIP(ip.Unmap(), port)
+		if action == sandbox.NetDeny {
+			return action, rule, dialHost, nil
+		}
+		if matched {
+			return action, rule, dialHost, nil
+		}
+		if p.cfg.Mode == sandbox.NetAllowList {
+			return sandbox.NetDeny, "", dialHost, nil
+		}
+		return sandbox.NetAllow, "", dialHost, nil
+	}
+
+	action, rule, matched := m.Match(host, port)
+	if action == sandbox.NetDeny {
+		return action, rule, dialHost, nil
+	}
+	if m.HasIPRules() {
+		addrs, err := net.DefaultResolver.LookupNetIP(ctx, "ip", host)
+		if err != nil {
+			// With IP rules present we cannot prove the destination is
+			// not denied, so we fail closed.
+			return sandbox.NetDeny, "", dialHost, fmt.Errorf(
+				"netproxy: resolve %s for IP rules: %w", host, err)
+		}
+		chosen := netip.Addr{}
+		ipAllow := false
+		for _, addr := range addrs {
+			addr = addr.Unmap()
+			if ipAction, ipRule, ipMatched := m.MatchIP(addr, port); ipMatched && ipAction == sandbox.NetDeny {
+				return sandbox.NetDeny, ipRule, dialHost, nil
+			}
+			if !chosen.IsValid() {
+				chosen = addr
+			}
+			if ipAction, _, ipMatched := m.MatchIP(addr, port); ipMatched && ipAction == sandbox.NetAllow {
+				ipAllow = true
+			}
+		}
+		if chosen.IsValid() {
+			dialHost = net.JoinHostPort(chosen.String(), strconv.Itoa(port))
+		}
+		if matched || ipAllow {
+			return sandbox.NetAllow, rule, dialHost, nil
+		}
+		if p.cfg.Mode == sandbox.NetAllowList {
+			return sandbox.NetDeny, "", dialHost, nil
+		}
+		return sandbox.NetAllow, "", dialHost, nil
+	}
+	if matched {
+		return sandbox.NetAllow, rule, dialHost, nil
+	}
+	if p.cfg.Mode == sandbox.NetAllowList {
+		return sandbox.NetDeny, "", dialHost, nil
+	}
+	return sandbox.NetAllow, "", dialHost, nil
 }
 
-// allowed evaluates the allow-list. Hostname entries are suffixes
-// ("example.com" matches "api.example.com"); IP literals match exactly
-// so a dotted IP cannot suffix-match a longer string.
-func (p *Proxy) allowed(hostport string) bool {
-	if p.cfg.Mode == sandbox.NetProxy {
-		return true // upstream is the policy
+// audit emits one decision record when OnDecision is configured.
+func (p *Proxy) audit(host string, port int, action sandbox.NetAction, rule string) {
+	if p.cfg.OnDecision != nil {
+		p.cfg.OnDecision(ProxyDecision{
+			Host:   host,
+			Port:   port,
+			Action: action,
+			Mode:   p.cfg.Mode,
+			Rule:   rule,
+		})
 	}
-	host := hostport
-	if h, _, err := net.SplitHostPort(hostport); err == nil {
-		host = h
-	}
-	for _, entry := range p.cfg.AllowHosts {
-		if net.ParseIP(entry) != nil {
-			if entry == host {
-				return true
+}
+
+// dialTarget dials the CONNECT target directly (allow-list mode),
+// establishes a CONNECT tunnel through an HTTP upstream, or dials
+// through a SOCKS5 upstream (proxy mode).
+func (p *Proxy) dialTarget(ctx context.Context, hostport string) (net.Conn, error) {
+	if p.upstream != nil {
+		switch p.upstream.Scheme {
+		case "http":
+			up, err := (&net.Dialer{}).DialContext(ctx, "tcp", p.upstream.Host)
+			if err != nil {
+				return nil, err
 			}
-			continue
+			req := "CONNECT " + hostport + " HTTP/1.1\r\nHost: " + hostport
+			if p.upstream.User != nil {
+				user := p.upstream.User.Username()
+				pass, _ := p.upstream.User.Password()
+				req += "\r\nProxy-Authorization: Basic " +
+					base64.StdEncoding.EncodeToString([]byte(user+":"+pass))
+			}
+			req += "\r\n\r\n"
+			if _, err := io.WriteString(up, req); err != nil {
+				_ = up.Close()
+				return nil, err
+			}
+			br := bufio.NewReader(up)
+			resp, err := http.ReadResponse(br, &http.Request{Method: http.MethodConnect})
+			if err != nil {
+				_ = up.Close()
+				return nil, err
+			}
+			if resp.StatusCode != http.StatusOK {
+				_ = up.Close()
+				return nil, fmt.Errorf("netproxy: upstream refused CONNECT: %d", resp.StatusCode)
+			}
+			return up, nil
+		case "socks5":
+			return p.socksDial.DialContext(ctx, "tcp", hostport)
 		}
-		if host == entry || strings.HasSuffix(host, "."+entry) {
+	}
+	return (&net.Dialer{}).DialContext(ctx, "tcp", hostport)
+}
+
+// allowed evaluates the legacy allow-list semantics used by tests and
+// back-compat call sites: hostname suffixes, exact IP literals, and
+// proxy-mode deferral. Real request handling goes through decide,
+// which additionally applies rules, ports, and IP pinning.
+func (p *Proxy) allowed(hostport string) bool {
+	host, port := splitHostPort(hostport, 0)
+	m := p.matcher()
+	if m == nil {
+		return false
+	}
+	if ip, err := netip.ParseAddr(host); err == nil {
+		action, _, matched := m.MatchIP(ip.Unmap(), port)
+		if action == sandbox.NetDeny {
+			return false
+		}
+		if matched {
 			return true
 		}
+		return p.cfg.Mode == sandbox.NetProxy
 	}
-	return false
+	action, _, matched := m.Match(host, port)
+	if action == sandbox.NetDeny {
+		return false
+	}
+	if matched {
+		return true
+	}
+	return p.cfg.Mode == sandbox.NetProxy
+}
+
+func (p *Proxy) matcher() *Matcher {
+	p.matcherOnce.Do(func() {
+		p.compiled, p.matcherErr = NewMatcher(sandbox.NetPolicy{
+			Mode:       p.cfg.Mode,
+			AllowHosts: p.cfg.AllowHosts,
+			Rules:      p.cfg.Rules,
+		})
+	})
+	return p.compiled
+}
+
+func socks5Dialer(u *url.URL) (proxy.ContextDialer, error) {
+	var auth *proxy.Auth
+	if u.User != nil {
+		auth = &proxy.Auth{User: u.User.Username()}
+		if pass, ok := u.User.Password(); ok {
+			auth.Password = pass
+		}
+	}
+	dialer, err := proxy.SOCKS5("tcp", u.Host, auth, proxy.Direct)
+	if err != nil {
+		return nil, fmt.Errorf("netproxy: socks5 dialer: %w", err)
+	}
+	cd, ok := dialer.(proxy.ContextDialer)
+	if !ok {
+		return nil, fmt.Errorf("netproxy: socks5 dialer does not implement DialContext")
+	}
+	return cd, nil
+}
+
+func splitHostPort(hostport string, defaultPort int) (string, int) {
+	host, portStr, err := net.SplitHostPort(hostport)
+	if err != nil {
+		return strings.Trim(hostport, "[]"), defaultPort
+	}
+	port, err := strconv.Atoi(portStr)
+	if err != nil {
+		port = defaultPort
+	}
+	return strings.Trim(host, "[]"), port
 }
 
 func copyHeader(dst, src http.Header) {

--- a/sdkx/internal/httpkit/netproxy_enhance_test.go
+++ b/sdkx/internal/httpkit/netproxy_enhance_test.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/GizClaw/flowcraft/sdk/sandbox"
 	"github.com/GizClaw/flowcraft/sdkx/internal/httpkit/mitm"
+	"golang.org/x/net/http2"
 )
 
 func TestRules_DenyOverridesInProxyMode(t *testing.T) {
@@ -334,6 +335,249 @@ func TestMITM_HookBlocksRequest(t *testing.T) {
 	}
 }
 
+func TestMITM_SSEStreamsUnbuffered(t *testing.T) {
+	release := make(chan struct{})
+	defer func() {
+		select {
+		case <-release:
+		default:
+			close(release)
+		}
+	}()
+	targetCA, targetCert := issueTestCert(t, "127.0.0.1")
+	target := startTLSOriginHandler(t, targetCert, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.Header().Set("Cache-Control", "no-cache")
+		w.WriteHeader(http.StatusOK)
+		flusher, ok := w.(http.Flusher)
+		if !ok {
+			return
+		}
+		_, _ = fmt.Fprint(w, "data: first\n\n")
+		flusher.Flush()
+		<-release
+		_, _ = fmt.Fprint(w, "data: second\n\n")
+		flusher.Flush()
+	}))
+	defer func() { _ = target.Close() }()
+
+	roots := x509.NewCertPool()
+	roots.AppendCertsFromPEM(targetCAPEM(t, targetCA))
+	hooks := &recordingHooks{}
+	p, err := Start(ProxyConfig{
+		Mode:          sandbox.NetAllowList,
+		AllowHosts:    []string{"127.0.0.1"},
+		MITM:          &sandbox.MITMPolicy{Enabled: true, InspectBodies: true},
+		Hooks:         hooks,
+		OutboundRoots: roots,
+	})
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer func() { _ = p.Close() }()
+
+	conn := dialProxy(t, p)
+	defer func() { _ = conn.Close() }()
+	targetAddr := target.Addr().String()
+	_, _ = fmt.Fprintf(conn, "CONNECT %s HTTP/1.1\r\nHost: %s\r\n\r\n", targetAddr, targetAddr)
+	if _, err := http.ReadResponse(bufio.NewReader(conn), &http.Request{Method: http.MethodConnect}); err != nil {
+		t.Fatalf("read CONNECT response: %v", err)
+	}
+	caPool := x509.NewCertPool()
+	caPool.AppendCertsFromPEM(p.CAPEM())
+	tlsConn := tls.Client(conn, &tls.Config{RootCAs: caPool, ServerName: "127.0.0.1", MinVersion: tls.VersionTLS12})
+	if err := tlsConn.Handshake(); err != nil {
+		t.Fatalf("client handshake: %v", err)
+	}
+	defer func() { _ = tlsConn.Close() }()
+	_, _ = fmt.Fprintf(tlsConn, "GET /stream HTTP/1.1\r\nHost: %s\r\nConnection: close\r\n\r\n", targetAddr)
+	br := bufio.NewReader(tlsConn)
+	if _, err := http.ReadResponse(br, nil); err != nil {
+		t.Fatalf("read response headers: %v", err)
+	}
+
+	// The first SSE event must arrive while the origin is still
+	// streaming — a buffering MITM would block here until release.
+	if err := tlsConn.SetReadDeadline(time.Now().Add(5 * time.Second)); err != nil {
+		t.Fatal(err)
+	}
+	var got strings.Builder
+	buf := make([]byte, 4096)
+	for !strings.Contains(got.String(), "data: first") {
+		n, err := br.Read(buf)
+		if n > 0 {
+			got.Write(buf[:n])
+		}
+		if err != nil {
+			t.Fatalf("first SSE event not delivered while origin still streaming: %v", err)
+		}
+	}
+	close(release)
+
+	for {
+		n, err := br.Read(buf)
+		if n > 0 {
+			got.Write(buf[:n])
+		}
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			t.Fatalf("read stream tail: %v", err)
+		}
+	}
+	if !strings.Contains(got.String(), "data: second") {
+		t.Fatalf("stream tail missing: %q", got.String())
+	}
+	hooks.mu.Lock()
+	defer hooks.mu.Unlock()
+	if len(hooks.responses) != 1 || hooks.responses[0].Body != nil {
+		t.Fatalf("streaming responses must reach hooks with Body nil, got %+v", hooks.responses)
+	}
+}
+
+func TestMITM_HTTP2Client(t *testing.T) {
+	srv := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = fmt.Fprint(w, "mitm-h2-ok")
+	}))
+	srv.EnableHTTP2 = true
+	srv.StartTLS()
+	defer srv.Close()
+
+	roots := x509.NewCertPool()
+	roots.AddCert(srv.Certificate())
+	hooks := &recordingHooks{}
+	p, err := Start(ProxyConfig{
+		Mode:          sandbox.NetAllowList,
+		AllowHosts:    []string{"127.0.0.1"},
+		MITM:          &sandbox.MITMPolicy{Enabled: true, InspectBodies: true},
+		Hooks:         hooks,
+		OutboundRoots: roots,
+	})
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer func() { _ = p.Close() }()
+
+	targetAddr := strings.TrimPrefix(srv.URL, "https://")
+	conn := dialProxy(t, p)
+	defer func() { _ = conn.Close() }()
+	_, _ = fmt.Fprintf(conn, "CONNECT %s HTTP/1.1\r\nHost: %s\r\n\r\n", targetAddr, targetAddr)
+	if _, err := http.ReadResponse(bufio.NewReader(conn), &http.Request{Method: http.MethodConnect}); err != nil {
+		t.Fatalf("read CONNECT response: %v", err)
+	}
+
+	caPool := x509.NewCertPool()
+	caPool.AppendCertsFromPEM(p.CAPEM())
+	// h2-only client: ALPN offers only h2, so a server without h2
+	// support would fail the handshake with "no application protocol".
+	tlsConn := tls.Client(conn, &tls.Config{
+		RootCAs:    caPool,
+		ServerName: "127.0.0.1",
+		NextProtos: []string{"h2"},
+		MinVersion: tls.VersionTLS12,
+	})
+	if err := tlsConn.Handshake(); err != nil {
+		t.Fatalf("h2 client handshake through MITM: %v", err)
+	}
+	defer func() { _ = tlsConn.Close() }()
+
+	client := &http2.Transport{
+		DialTLSContext: func(context.Context, string, string, *tls.Config) (net.Conn, error) {
+			return tlsConn, nil
+		},
+	}
+	defer client.CloseIdleConnections()
+	req, err := http.NewRequest(http.MethodGet, "https://"+targetAddr+"/", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp, err := client.RoundTrip(req)
+	if err != nil {
+		t.Fatalf("h2 RoundTrip: %v", err)
+	}
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("read h2 body: %v", err)
+	}
+	_ = resp.Body.Close()
+	if string(body) != "mitm-h2-ok" {
+		t.Fatalf("h2 body = %q, want mitm-h2-ok", body)
+	}
+	hooks.mu.Lock()
+	defer hooks.mu.Unlock()
+	if len(hooks.requests) != 1 || len(hooks.responses) != 1 {
+		t.Fatalf("hooks = reqs:%d resps:%d, want 1/1 over h2", len(hooks.requests), len(hooks.responses))
+	}
+}
+
+func TestMITM_HostSelection(t *testing.T) {
+	echo := startEchoServer(t)
+	defer func() { _ = echo.Close() }()
+	target := echo.Addr().String()
+
+	tests := []struct {
+		name     string
+		mitm     *sandbox.MITMPolicy
+		wantMITM bool
+	}{
+		{"exclude wins", &sandbox.MITMPolicy{Enabled: true, ExcludeHosts: []string{"127.0.0.1"}}, false},
+		{"include miss", &sandbox.MITMPolicy{Enabled: true, Hosts: []string{"example.com"}}, false},
+		{"include hit", &sandbox.MITMPolicy{Enabled: true, Hosts: []string{"127.0.0.1"}}, true},
+		{"all default", &sandbox.MITMPolicy{Enabled: true}, true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			hooks := &recordingHooks{}
+			p, err := Start(ProxyConfig{
+				Mode:       sandbox.NetAllowList,
+				AllowHosts: []string{"127.0.0.1"},
+				MITM:       tc.mitm,
+				Hooks:      hooks,
+			})
+			if err != nil {
+				t.Fatalf("Start: %v", err)
+			}
+			defer func() { _ = p.Close() }()
+
+			conn := dialProxy(t, p)
+			defer func() { _ = conn.Close() }()
+			_, _ = fmt.Fprintf(conn, "CONNECT %s HTTP/1.1\r\nHost: %s\r\n\r\n", target, target)
+			if _, err := http.ReadResponse(bufio.NewReader(conn), &http.Request{Method: http.MethodConnect}); err != nil {
+				t.Fatalf("read CONNECT response: %v", err)
+			}
+			if _, err := conn.Write([]byte("ping")); err != nil {
+				t.Fatal(err)
+			}
+			buf := make([]byte, 4)
+			if tc.wantMITM {
+				// MITM'd: the tunnel speaks TLS, so plaintext "ping"
+				// must not come back as "ping"; a handshake alert or a
+				// timeout is the expected outcome.
+				_ = conn.SetReadDeadline(time.Now().Add(500 * time.Millisecond))
+				n, err := conn.Read(buf)
+				if err == nil && string(buf[:n]) == "ping" {
+					t.Fatalf("expected MITM TLS, got raw echo")
+				}
+				return
+			}
+			_ = conn.SetReadDeadline(time.Now().Add(5 * time.Second))
+			_, err = io.ReadFull(conn, buf)
+			if err != nil {
+				t.Fatalf("raw tunnel read: %v", err)
+			}
+			if string(buf) != "ping" {
+				t.Fatalf("raw tunnel echo = %q, want ping", buf)
+			}
+			hooks.mu.Lock()
+			defer hooks.mu.Unlock()
+			if hooks.connect != 1 {
+				t.Fatalf("OnConnect calls = %d, want 1 even for excluded hosts", hooks.connect)
+			}
+		})
+	}
+}
+
 // --- test helpers ---
 
 func startEchoServer(t *testing.T) net.Listener {
@@ -613,15 +857,20 @@ func targetCAPEM(t *testing.T, ca *x509.Certificate) []byte {
 
 func startTLSOrigin(t *testing.T, _ *x509.Certificate, cert *tls.Certificate) net.Listener {
 	t.Helper()
+	return startTLSOriginHandler(t, cert, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.Copy(io.Discard, r.Body)
+		_, _ = fmt.Fprint(w, "mitm-ok")
+	}))
+}
+
+func startTLSOriginHandler(t *testing.T, cert *tls.Certificate, handler http.Handler) net.Listener {
+	t.Helper()
 	ln, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
 		t.Fatal(err)
 	}
 	tlsLn := tls.NewListener(ln, &tls.Config{Certificates: []tls.Certificate{*cert}, MinVersion: tls.VersionTLS12})
-	srv := &http.Server{Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		_, _ = io.Copy(io.Discard, r.Body)
-		_, _ = fmt.Fprint(w, "mitm-ok")
-	})}
+	srv := &http.Server{Handler: handler}
 	go func() { _ = srv.Serve(tlsLn) }()
 	return &closingListener{Listener: tlsLn, closer: func() { _ = srv.Close() }}
 }

--- a/sdkx/internal/httpkit/netproxy_enhance_test.go
+++ b/sdkx/internal/httpkit/netproxy_enhance_test.go
@@ -1,0 +1,637 @@
+package httpkit
+
+import (
+	"bufio"
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"fmt"
+	"io"
+	"math/big"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/GizClaw/flowcraft/sdk/sandbox"
+	"github.com/GizClaw/flowcraft/sdkx/internal/httpkit/mitm"
+)
+
+func TestRules_DenyOverridesInProxyMode(t *testing.T) {
+	var decisions []ProxyDecision
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = fmt.Fprint(w, "upstream-ok")
+	}))
+	defer upstream.Close()
+
+	p, err := Start(ProxyConfig{
+		Mode:       sandbox.NetProxy,
+		Rules:      []sandbox.NetRule{{Action: sandbox.NetDeny, Host: "blocked.example"}},
+		Upstream:   upstream.URL,
+		OnDecision: func(d ProxyDecision) { decisions = append(decisions, d) },
+	})
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer func() { _ = p.Close() }()
+
+	conn := dialProxy(t, p)
+	defer func() { _ = conn.Close() }()
+	_, _ = fmt.Fprintf(conn, "CONNECT blocked.example:443 HTTP/1.1\r\nHost: blocked.example:443\r\n\r\n")
+	resp, err := http.ReadResponse(bufio.NewReader(conn), &http.Request{Method: http.MethodConnect})
+	if err != nil {
+		t.Fatalf("read CONNECT response: %v", err)
+	}
+	if resp.StatusCode != http.StatusForbidden {
+		t.Fatalf("status = %d, want 403 for deny rule", resp.StatusCode)
+	}
+	if len(decisions) != 1 || decisions[0].Action != sandbox.NetDeny || !strings.Contains(decisions[0].Rule, "blocked.example") {
+		t.Fatalf("decisions = %+v, want one deny for blocked.example", decisions)
+	}
+}
+
+func TestDecisionAudit_AllowList(t *testing.T) {
+	var decisions []ProxyDecision
+	echo := startEchoServer(t)
+	defer func() { _ = echo.Close() }()
+
+	p, err := Start(ProxyConfig{
+		Mode:       sandbox.NetAllowList,
+		AllowHosts: []string{"127.0.0.1"},
+		OnDecision: func(d ProxyDecision) { decisions = append(decisions, d) },
+	})
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer func() { _ = p.Close() }()
+
+	conn := dialProxy(t, p)
+	defer func() { _ = conn.Close() }()
+	_, _ = fmt.Fprintf(conn, "CONNECT %s HTTP/1.1\r\nHost: %s\r\n\r\n", echo.Addr().String(), echo.Addr().String())
+	resp, err := http.ReadResponse(bufio.NewReader(conn), &http.Request{Method: http.MethodConnect})
+	if err != nil {
+		t.Fatalf("read CONNECT response: %v", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("CONNECT status = %d, want 200", resp.StatusCode)
+	}
+	if len(decisions) != 1 || decisions[0].Action != sandbox.NetAllow || decisions[0].Port == 0 {
+		t.Fatalf("decisions = %+v, want one allow with port", decisions)
+	}
+}
+
+func TestSocks5Upstream_HTTPForward(t *testing.T) {
+	socks := startSocks5Server(t, "user", "pass")
+	defer func() { _ = socks.Close() }()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = fmt.Fprint(w, "socks-ok")
+	}))
+	defer srv.Close()
+
+	p, err := Start(ProxyConfig{
+		Mode:     sandbox.NetProxy,
+		Upstream: "socks5://user:pass@" + socks.Addr().String(),
+	})
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer func() { _ = p.Close() }()
+
+	conn := dialProxy(t, p)
+	defer func() { _ = conn.Close() }()
+	_, _ = fmt.Fprintf(conn, "GET %s/hello HTTP/1.1\r\nHost: %s\r\nConnection: close\r\n\r\n",
+		srv.URL, strings.TrimPrefix(srv.URL, "http://"))
+	resp, body := readResponse(t, bufio.NewReader(conn))
+	if resp.StatusCode != http.StatusOK || body != "socks-ok" {
+		t.Fatalf("status=%d body=%q, want 200 socks-ok", resp.StatusCode, body)
+	}
+	if !socks.authed() {
+		t.Fatal("socks5 server did not receive credentials")
+	}
+}
+
+func TestSocks5Upstream_CONNECT(t *testing.T) {
+	socks := startSocks5Server(t, "", "")
+	defer func() { _ = socks.Close() }()
+	echo := startEchoServer(t)
+	defer func() { _ = echo.Close() }()
+
+	p, err := Start(ProxyConfig{
+		Mode:     sandbox.NetProxy,
+		Upstream: "socks5://" + socks.Addr().String(),
+	})
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer func() { _ = p.Close() }()
+
+	conn := dialProxy(t, p)
+	defer func() { _ = conn.Close() }()
+	target := echo.Addr().String()
+	_, _ = fmt.Fprintf(conn, "CONNECT %s HTTP/1.1\r\nHost: %s\r\n\r\n", target, target)
+	resp, err := http.ReadResponse(bufio.NewReader(conn), &http.Request{Method: http.MethodConnect})
+	if err != nil {
+		t.Fatalf("read CONNECT response: %v", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("CONNECT status = %d, want 200", resp.StatusCode)
+	}
+	if _, err := conn.Write([]byte("ping")); err != nil {
+		t.Fatal(err)
+	}
+	buf := make([]byte, 4)
+	if _, err := io.ReadFull(conn, buf); err != nil {
+		t.Fatalf("tunnel echo: %v", err)
+	}
+	if string(buf) != "ping" {
+		t.Fatalf("echo = %q", buf)
+	}
+	if !socks.sawTarget(target) {
+		t.Fatalf("socks5 server targets = %v, want %q", socks.targets(), target)
+	}
+}
+
+func TestHTTPUpstream_CONNECT_SendsAuth(t *testing.T) {
+	var (
+		mu   sync.Mutex
+		auth string
+	)
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodConnect {
+			http.Error(w, "expect CONNECT", http.StatusBadRequest)
+			return
+		}
+		mu.Lock()
+		auth = r.Header.Get("Proxy-Authorization")
+		mu.Unlock()
+		hj, ok := w.(http.Hijacker)
+		if !ok {
+			http.Error(w, "hijack unsupported", http.StatusInternalServerError)
+			return
+		}
+		client, _, err := hj.Hijack()
+		if err != nil {
+			return
+		}
+		_, _ = client.Write([]byte("HTTP/1.1 200 Connection Established\r\n\r\n"))
+		target, err := net.Dial("tcp", r.Host)
+		if err != nil {
+			_ = client.Close()
+			return
+		}
+		go func() { _, _ = io.Copy(target, client); _ = target.Close() }()
+		_, _ = io.Copy(client, target)
+	}))
+	defer upstream.Close()
+
+	echo := startEchoServer(t)
+	defer func() { _ = echo.Close() }()
+
+	u := strings.Replace(upstream.URL, "http://", "http://user:secret@", 1)
+	p, err := Start(ProxyConfig{Mode: sandbox.NetProxy, Upstream: u})
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer func() { _ = p.Close() }()
+
+	conn := dialProxy(t, p)
+	defer func() { _ = conn.Close() }()
+	target := echo.Addr().String()
+	_, _ = fmt.Fprintf(conn, "CONNECT %s HTTP/1.1\r\nHost: %s\r\n\r\n", target, target)
+	resp, err := http.ReadResponse(bufio.NewReader(conn), &http.Request{Method: http.MethodConnect})
+	if err != nil {
+		t.Fatalf("read CONNECT response: %v", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("CONNECT status = %d, want 200", resp.StatusCode)
+	}
+	if _, err := conn.Write([]byte("ping")); err != nil {
+		t.Fatal(err)
+	}
+	buf := make([]byte, 4)
+	if _, err := io.ReadFull(conn, buf); err != nil {
+		t.Fatalf("tunnel echo: %v", err)
+	}
+	mu.Lock()
+	gotAuth := auth
+	mu.Unlock()
+	if !strings.HasPrefix(gotAuth, "Basic ") {
+		t.Fatalf("Proxy-Authorization = %q, want Basic", gotAuth)
+	}
+}
+
+func TestMITM_HooksAndBodyInspection(t *testing.T) {
+	targetCA, targetCert := issueTestCert(t, "127.0.0.1")
+	target := startTLSOrigin(t, targetCA, targetCert)
+	defer func() { _ = target.Close() }()
+
+	roots := x509.NewCertPool()
+	roots.AppendCertsFromPEM(targetCAPEM(t, targetCA))
+
+	hooks := &recordingHooks{}
+	p, err := Start(ProxyConfig{
+		Mode:          sandbox.NetAllowList,
+		AllowHosts:    []string{"127.0.0.1"},
+		MITM:          &sandbox.MITMPolicy{Enabled: true, InspectBodies: true},
+		Hooks:         hooks,
+		OutboundRoots: roots,
+	})
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer func() { _ = p.Close() }()
+
+	caPool := x509.NewCertPool()
+	caPool.AppendCertsFromPEM(p.CAPEM())
+	if len(p.CAPEM()) == 0 {
+		t.Fatal("CAPEM empty with MITM enabled")
+	}
+
+	conn := dialProxy(t, p)
+	defer func() { _ = conn.Close() }()
+	targetAddr := target.Addr().String()
+	_, _ = fmt.Fprintf(conn, "CONNECT %s HTTP/1.1\r\nHost: %s\r\n\r\n", targetAddr, targetAddr)
+	resp, err := http.ReadResponse(bufio.NewReader(conn), &http.Request{Method: http.MethodConnect})
+	if err != nil {
+		t.Fatalf("read CONNECT response: %v", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("CONNECT status = %d, want 200", resp.StatusCode)
+	}
+
+	tlsConn := tls.Client(conn, &tls.Config{
+		RootCAs:    caPool,
+		ServerName: "127.0.0.1",
+		MinVersion: tls.VersionTLS12,
+	})
+	if err := tlsConn.Handshake(); err != nil {
+		t.Fatalf("client handshake through MITM: %v", err)
+	}
+	_, _ = fmt.Fprintf(tlsConn, "POST /submit HTTP/1.1\r\nHost: %s\r\nContent-Length: 5\r\nConnection: close\r\n\r\nhello", targetAddr)
+	br := bufio.NewReader(tlsConn)
+	resp, body := readResponse(t, br)
+	if resp.StatusCode != http.StatusOK || body != "mitm-ok" {
+		t.Fatalf("status=%d body=%q, want 200 mitm-ok", resp.StatusCode, body)
+	}
+
+	if hooks.connect == 0 {
+		t.Fatal("OnConnect not called")
+	}
+	if len(hooks.requests) != 1 || string(hooks.requests[0].Body) != "hello" || hooks.requests[0].Path != "/submit" {
+		t.Fatalf("requests = %+v, want one inspected POST /submit body=hello", hooks.requests)
+	}
+	if len(hooks.responses) != 1 || string(hooks.responses[0].Body) != "mitm-ok" {
+		t.Fatalf("responses = %+v, want one inspected body=mitm-ok", hooks.responses)
+	}
+}
+
+func TestMITM_HookBlocksRequest(t *testing.T) {
+	targetCA, targetCert := issueTestCert(t, "127.0.0.1")
+	target := startTLSOrigin(t, targetCA, targetCert)
+	defer func() { _ = target.Close() }()
+
+	roots := x509.NewCertPool()
+	roots.AppendCertsFromPEM(targetCAPEM(t, targetCA))
+	hooks := &recordingHooks{blockRequest: true}
+	p, err := Start(ProxyConfig{
+		Mode:          sandbox.NetAllowList,
+		AllowHosts:    []string{"127.0.0.1"},
+		MITM:          &sandbox.MITMPolicy{Enabled: true},
+		Hooks:         hooks,
+		OutboundRoots: roots,
+	})
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer func() { _ = p.Close() }()
+
+	conn := dialProxy(t, p)
+	defer func() { _ = conn.Close() }()
+	targetAddr := target.Addr().String()
+	_, _ = fmt.Fprintf(conn, "CONNECT %s HTTP/1.1\r\nHost: %s\r\n\r\n", targetAddr, targetAddr)
+	if _, err := http.ReadResponse(bufio.NewReader(conn), &http.Request{Method: http.MethodConnect}); err != nil {
+		t.Fatalf("read CONNECT response: %v", err)
+	}
+	caPool := x509.NewCertPool()
+	caPool.AppendCertsFromPEM(p.CAPEM())
+	tlsConn := tls.Client(conn, &tls.Config{RootCAs: caPool, ServerName: "127.0.0.1", MinVersion: tls.VersionTLS12})
+	if err := tlsConn.Handshake(); err != nil {
+		t.Fatalf("client handshake: %v", err)
+	}
+	_, _ = fmt.Fprintf(tlsConn, "GET / HTTP/1.1\r\nHost: %s\r\nConnection: close\r\n\r\n", targetAddr)
+	resp, _ := readResponse(t, bufio.NewReader(tlsConn))
+	if resp.StatusCode != http.StatusForbidden {
+		t.Fatalf("status = %d, want 403 from hook", resp.StatusCode)
+	}
+}
+
+// --- test helpers ---
+
+func startEchoServer(t *testing.T) net.Listener {
+	t.Helper()
+	echo, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	go func() {
+		for {
+			conn, err := echo.Accept()
+			if err != nil {
+				return
+			}
+			go func() {
+				defer func() { _ = conn.Close() }()
+				_, _ = io.Copy(conn, conn)
+			}()
+		}
+	}()
+	return echo
+}
+
+type socks5Server struct {
+	ln         net.Listener
+	user       string
+	pass       string
+	mu         sync.Mutex
+	authedFlag bool
+	targetList []string
+}
+
+func startSocks5Server(t *testing.T, user, pass string) *socks5Server {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	s := &socks5Server{ln: ln, user: user, pass: pass}
+	go s.acceptLoop()
+	return s
+}
+
+func (s *socks5Server) Addr() net.Addr { return s.ln.Addr() }
+func (s *socks5Server) Close() error   { return s.ln.Close() }
+
+func (s *socks5Server) authed() bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.authedFlag
+}
+
+func (s *socks5Server) sawTarget(target string) bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for _, got := range s.targetList {
+		if got == target {
+			return true
+		}
+	}
+	return false
+}
+
+func (s *socks5Server) targets() []string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return append([]string(nil), s.targetList...)
+}
+
+func (s *socks5Server) acceptLoop() {
+	for {
+		conn, err := s.ln.Accept()
+		if err != nil {
+			return
+		}
+		go s.handle(conn)
+	}
+}
+
+func (s *socks5Server) handle(conn net.Conn) {
+	defer func() { _ = conn.Close() }()
+	br := bufio.NewReader(conn)
+	ver, err := br.ReadByte()
+	if err != nil || ver != 5 {
+		return
+	}
+	nmethods, err := br.ReadByte()
+	if err != nil {
+		return
+	}
+	methods := make([]byte, nmethods)
+	if _, err := io.ReadFull(br, methods); err != nil {
+		return
+	}
+	if s.user != "" {
+		if _, err := conn.Write([]byte{5, 2}); err != nil {
+			return
+		}
+		// RFC 1929 username/password subnegotiation.
+		header := make([]byte, 2)
+		if _, err := io.ReadFull(br, header); err != nil || header[0] != 1 {
+			return
+		}
+		uname := make([]byte, header[1])
+		if _, err := io.ReadFull(br, uname); err != nil {
+			return
+		}
+		plen := make([]byte, 1)
+		if _, err := io.ReadFull(br, plen); err != nil {
+			return
+		}
+		passwd := make([]byte, plen[0])
+		if _, err := io.ReadFull(br, passwd); err != nil {
+			return
+		}
+		if string(uname) != s.user || string(passwd) != s.pass {
+			_, _ = conn.Write([]byte{1, 1})
+			return
+		}
+		_, _ = conn.Write([]byte{1, 0})
+		s.mu.Lock()
+		s.authedFlag = true
+		s.mu.Unlock()
+	} else {
+		if _, err := conn.Write([]byte{5, 0}); err != nil {
+			return
+		}
+	}
+
+	req := make([]byte, 4)
+	if _, err := io.ReadFull(br, req); err != nil || req[0] != 5 || req[1] != 1 {
+		return
+	}
+	host, err := readSocksAddr(br, req[3])
+	if err != nil {
+		return
+	}
+	portBytes := make([]byte, 2)
+	if _, err := io.ReadFull(br, portBytes); err != nil {
+		return
+	}
+	target := net.JoinHostPort(host, fmt.Sprintf("%d", int(portBytes[0])<<8|int(portBytes[1])))
+	s.mu.Lock()
+	s.targetList = append(s.targetList, target)
+	s.mu.Unlock()
+
+	upstream, err := net.Dial("tcp", target)
+	if err != nil {
+		return
+	}
+	defer func() { _ = upstream.Close() }()
+	// Reply: success, IPv4 0.0.0.0:0.
+	if _, err := conn.Write([]byte{5, 0, 0, 1, 0, 0, 0, 0, 0, 0}); err != nil {
+		return
+	}
+	go func() { _, _ = io.Copy(upstream, conn) }()
+	_, _ = io.Copy(conn, upstream)
+}
+
+func readSocksAddr(br *bufio.Reader, atyp byte) (string, error) {
+	switch atyp {
+	case 1:
+		b := make([]byte, 4)
+		if _, err := io.ReadFull(br, b); err != nil {
+			return "", err
+		}
+		return net.IP(b).String(), nil
+	case 3:
+		l := make([]byte, 1)
+		if _, err := io.ReadFull(br, l); err != nil {
+			return "", err
+		}
+		b := make([]byte, l[0])
+		if _, err := io.ReadFull(br, b); err != nil {
+			return "", err
+		}
+		return string(b), nil
+	case 4:
+		b := make([]byte, 16)
+		if _, err := io.ReadFull(br, b); err != nil {
+			return "", err
+		}
+		return net.IP(b).String(), nil
+	default:
+		return "", fmt.Errorf("unknown atyp %d", atyp)
+	}
+}
+
+type recordingHooks struct {
+	blockConnect bool
+	blockRequest bool
+	connect      int
+	requests     []*mitm.RequestInfo
+	mu           sync.Mutex
+	responses    []*mitm.ResponseInfo
+}
+
+func (h *recordingHooks) OnConnect(context.Context, *mitm.ConnectInfo) error {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.connect++
+	if h.blockConnect {
+		return fmt.Errorf("blocked")
+	}
+	return nil
+}
+
+func (h *recordingHooks) OnRequest(_ context.Context, req *mitm.RequestInfo) error {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.requests = append(h.requests, req)
+	if h.blockRequest {
+		return fmt.Errorf("blocked")
+	}
+	return nil
+}
+
+func (h *recordingHooks) OnResponse(_ context.Context, resp *mitm.ResponseInfo) error {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.responses = append(h.responses, resp)
+	return nil
+}
+
+func issueTestCert(t *testing.T, host string) (*x509.Certificate, *tls.Certificate) {
+	t.Helper()
+	caKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	now := time.Now()
+	caTmpl := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: "test CA"},
+		NotBefore:             now.Add(-time.Hour),
+		NotAfter:              now.Add(24 * time.Hour),
+		KeyUsage:              x509.KeyUsageCertSign,
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+	}
+	caDER, err := x509.CreateCertificate(rand.Reader, caTmpl, caTmpl, &caKey.PublicKey, caKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	caCert, err := x509.ParseCertificate(caDER)
+	if err != nil {
+		t.Fatal(err)
+	}
+	leafKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	leafTmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(2),
+		Subject:      pkix.Name{CommonName: host},
+		NotBefore:    now.Add(-time.Hour),
+		NotAfter:     now.Add(24 * time.Hour),
+		KeyUsage:     x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		IPAddresses:  []net.IP{net.ParseIP(host)},
+	}
+	leafDER, err := x509.CreateCertificate(rand.Reader, leafTmpl, caCert, &leafKey.PublicKey, caKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	leafCert, err := x509.ParseCertificate(leafDER)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return caCert, &tls.Certificate{Certificate: [][]byte{leafDER, caDER}, PrivateKey: leafKey, Leaf: leafCert}
+}
+
+func targetCAPEM(t *testing.T, ca *x509.Certificate) []byte {
+	t.Helper()
+	return pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: ca.Raw})
+}
+
+func startTLSOrigin(t *testing.T, _ *x509.Certificate, cert *tls.Certificate) net.Listener {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	tlsLn := tls.NewListener(ln, &tls.Config{Certificates: []tls.Certificate{*cert}, MinVersion: tls.VersionTLS12})
+	srv := &http.Server{Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.Copy(io.Discard, r.Body)
+		_, _ = fmt.Fprint(w, "mitm-ok")
+	})}
+	go func() { _ = srv.Serve(tlsLn) }()
+	return &closingListener{Listener: tlsLn, closer: func() { _ = srv.Close() }}
+}
+
+type closingListener struct {
+	net.Listener
+	closer func()
+}
+
+func (l *closingListener) Close() error {
+	l.closer()
+	return l.Listener.Close()
+}

--- a/sdkx/sandbox/bwrap/doc.go
+++ b/sdkx/sandbox/bwrap/doc.go
@@ -148,9 +148,13 @@
 // The host-side enforcement proxy supports rule-based allow/deny,
 // socks5:// upstreams, MITM (TLS termination + hooks) with a merged
 // CA bundle ro-bound into the sandbox and injected via SSL_CERT_FILE,
-// and per-decision audit callbacks. UnixSockets entries are
-// bind-mounted into the sandbox (they must exist at Start); paths in
-// masked directories (/tmp, /run in isolated net modes) are denied by
-// absence. The bridge protocol is unchanged: the child always speaks
-// plain HTTP proxy to the host proxy.
+// and per-decision audit callbacks. MITM terminates both HTTP/1.1 and
+// HTTP/2 clients (ALPN h2 + http/1.1); MITMPolicy.Hosts /
+// ExcludeHosts select which CONNECT tunnels are terminated, so
+// cert-pinning destinations can be raw-tunnelled explicitly.
+// UnixSockets entries are bind-mounted into the sandbox (they must
+// exist at Start); paths in masked directories (/tmp, /run in
+// isolated net modes) are denied by absence. The bridge protocol is
+// unchanged: the child always speaks plain HTTP proxy to the host
+// proxy.
 package bwrap

--- a/sdkx/sandbox/bwrap/doc.go
+++ b/sdkx/sandbox/bwrap/doc.go
@@ -142,4 +142,15 @@
 // for NetAllowList / NetProxy, with the host proxy owned by the
 // session). Stdio is either a pty (TTY: true) or tagged pipes, with
 // the seq-cursor replay contract defined in sdk/sandbox.
+//
+// # Proxy enhancements
+//
+// The host-side enforcement proxy supports rule-based allow/deny,
+// socks5:// upstreams, MITM (TLS termination + hooks) with a merged
+// CA bundle ro-bound into the sandbox and injected via SSL_CERT_FILE,
+// and per-decision audit callbacks. UnixSockets entries are
+// bind-mounted into the sandbox (they must exist at Start); paths in
+// masked directories (/tmp, /run in isolated net modes) are denied by
+// absence. The bridge protocol is unchanged: the child always speaks
+// plain HTTP proxy to the host proxy.
 package bwrap

--- a/sdkx/sandbox/bwrap/doc.go
+++ b/sdkx/sandbox/bwrap/doc.go
@@ -134,4 +134,12 @@
 // The result is a Runner whose Net / Resources policy is fixed by
 // WithDefaults, whose commands are gated by AllowCommands, and whose
 // Exec actually runs inside an isolated namespace.
+//
+// # Interactive sessions
+//
+// Runner also implements sandbox.ProcessManager: sessions run inside
+// the same bwrap invocation as Exec (same flags, same in-netns bridge
+// for NetAllowList / NetProxy, with the host proxy owned by the
+// session). Stdio is either a pty (TTY: true) or tagged pipes, with
+// the seq-cursor replay contract defined in sdk/sandbox.
 package bwrap

--- a/sdkx/sandbox/bwrap/integration_linux_test.go
+++ b/sdkx/sandbox/bwrap/integration_linux_test.go
@@ -699,6 +699,20 @@ func TestIntegration_MITM_HTTPS(t *testing.T) {
 		t.Fatalf("New: %v", err)
 	}
 
+	// The isolated net posture needs bwrap to bring up loopback in the
+	// fresh net namespace (RTM_NEWADDR). Stripped-down kernels / CI
+	// runners without the required capability fail here with EPERM;
+	// per the lane's policy, skip rather than fail when the host
+	// cannot apply the boundary at all.
+	probe, probeErr := runner.Exec(context.Background(), "/bin/true", nil, sandbox.ExecOptions{
+		Net:     sandbox.NetPolicy{Mode: sandbox.NetAllowList, AllowHosts: []string{"127.0.0.1"}},
+		Timeout: 5 * time.Second,
+	})
+	if probeErr != nil || probe.ExitCode != 0 {
+		t.Skipf("bwrap net isolation cannot be applied on this host: err=%v stderr=%q",
+			probeErr, probe.Stderr)
+	}
+
 	res, err := runner.Exec(
 		context.Background(),
 		os.Args[0],

--- a/sdkx/sandbox/bwrap/integration_linux_test.go
+++ b/sdkx/sandbox/bwrap/integration_linux_test.go
@@ -19,9 +19,14 @@ package bwrap
 
 import (
 	"context"
+	"crypto/tls"
+	"crypto/x509"
 	"fmt"
+	"io"
+	"net"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -33,6 +38,59 @@ import (
 	"github.com/GizClaw/flowcraft/sdk/errdefs"
 	"github.com/GizClaw/flowcraft/sdk/sandbox"
 )
+
+// TestIntegrationHelper is re-executed by the integration tests as the
+// sandboxed child. It is inert unless the helper env is set.
+func TestIntegrationHelper(t *testing.T) {
+	switch os.Getenv("FLOWCRAFT_TEST_HELPER_MODE") {
+	case "unix-client":
+		path := os.Getenv("FLOWCRAFT_TEST_SOCK")
+		conn, err := net.Dial("unix", path)
+		if err != nil {
+			t.Fatalf("dial unix %s: %v", path, err)
+		}
+		defer func() { _ = conn.Close() }()
+		if _, err := conn.Write([]byte("ping")); err != nil {
+			t.Fatalf("write: %v", err)
+		}
+		buf := make([]byte, 4)
+		if _, err := io.ReadFull(conn, buf); err != nil {
+			t.Fatalf("read: %v", err)
+		}
+		if string(buf) != "pong" {
+			t.Fatalf("echo = %q, want pong", buf)
+		}
+		fmt.Print("unix-ok")
+	case "https-client":
+		target := os.Getenv("FLOWCRAFT_TEST_TARGET")
+		proxyURL, err := url.Parse(os.Getenv("HTTPS_PROXY"))
+		if err != nil {
+			t.Fatalf("parse HTTPS_PROXY: %v", err)
+		}
+		pool := x509.NewCertPool()
+		pemData, err := os.ReadFile(os.Getenv("SSL_CERT_FILE"))
+		if err != nil {
+			t.Fatalf("read SSL_CERT_FILE: %v", err)
+		}
+		if !pool.AppendCertsFromPEM(pemData) {
+			t.Fatalf("SSL_CERT_FILE contains no usable certificates")
+		}
+		client := &http.Client{Transport: &http.Transport{
+			Proxy:           http.ProxyURL(proxyURL),
+			TLSClientConfig: &tls.Config{RootCAs: pool, MinVersion: tls.VersionTLS12},
+		}}
+		resp, err := client.Get(target)
+		if err != nil {
+			t.Fatalf("GET %s: %v", target, err)
+		}
+		defer func() { _ = resp.Body.Close() }()
+		body, err := io.ReadAll(resp.Body)
+		if err != nil {
+			t.Fatalf("read body: %v", err)
+		}
+		fmt.Print(string(body))
+	}
+}
 
 func requireBwrap(t *testing.T) {
 	t.Helper()
@@ -542,5 +600,133 @@ func TestIntegration_IsolatedModesMaskHostUDS(t *testing.T) {
 	}
 	if _, err := os.Stat(marker); !os.IsNotExist(err) {
 		t.Errorf("private /run marker leaked to host, stat err=%v", err)
+	}
+}
+
+// startUnixEcho serves one "ping" → "pong" exchange on a unix socket.
+func startUnixEcho(t *testing.T, path string) net.Listener {
+	t.Helper()
+	ln, err := net.Listen("unix", path)
+	if err != nil {
+		t.Fatalf("listen unix %s: %v", path, err)
+	}
+	go func() {
+		for {
+			conn, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			go func() {
+				defer func() { _ = conn.Close() }()
+				buf := make([]byte, 4)
+				if _, err := io.ReadFull(conn, buf); err != nil {
+					return
+				}
+				if string(buf) == "ping" {
+					_, _ = conn.Write([]byte("pong"))
+				}
+			}()
+		}
+	}()
+	return ln
+}
+
+// TestIntegration_UnixSocketAllowDeny is the real-environment unix
+// socket policy assertion: a listed socket is bind-mounted and
+// reachable from inside the sandbox, an unlisted socket is invisible
+// (masked /tmp) and the helper's dial fails.
+func TestIntegration_UnixSocketAllowDeny(t *testing.T) {
+	dir := t.TempDir()
+	allowed := filepath.Join(dir, "allowed.sock")
+	denied := filepath.Join(dir, "denied.sock")
+	allowedLn := startUnixEcho(t, allowed)
+	defer func() { _ = allowedLn.Close() }()
+	deniedLn := startUnixEcho(t, denied)
+	defer func() { _ = deniedLn.Close() }()
+
+	runner := newIntegrationRunner(t)
+	ctx := context.Background()
+	env := sandbox.EnvPolicy{
+		Allow: []string{"PATH", "HOME"},
+		Inject: map[string]string{
+			"FLOWCRAFT_TEST_HELPER":      "1",
+			"FLOWCRAFT_TEST_HELPER_MODE": "unix-client",
+			"FLOWCRAFT_TEST_SOCK":        allowed,
+		},
+	}
+	res, err := runner.Exec(ctx, os.Args[0], []string{"-test.run", "^TestIntegrationHelper$"}, sandbox.ExecOptions{
+		Timeout: 15 * time.Second,
+		Env:     env,
+		Net:     sandbox.NetPolicy{UnixSockets: []string{allowed}},
+	})
+	if err != nil {
+		t.Fatalf("allowed Exec: %v", err)
+	}
+	if res.ExitCode != 0 || !strings.Contains(res.Stdout, "unix-ok") {
+		t.Fatalf("allowed socket unreachable: exit=%d stdout=%q stderr=%q",
+			res.ExitCode, res.Stdout, res.Stderr)
+	}
+
+	env.Inject["FLOWCRAFT_TEST_SOCK"] = denied
+	res, err = runner.Exec(ctx, os.Args[0], []string{"-test.run", "^TestIntegrationHelper$"}, sandbox.ExecOptions{
+		Timeout: 15 * time.Second,
+		Env:     env,
+		Net:     sandbox.NetPolicy{UnixSockets: []string{allowed}},
+	})
+	if err != nil {
+		t.Fatalf("denied Exec: %v", err)
+	}
+	if res.ExitCode == 0 {
+		t.Fatalf("unlisted socket reachable: stdout=%q stderr=%q", res.Stdout, res.Stderr)
+	}
+}
+
+// TestIntegration_MITM_HTTPS is the real-environment MITM assertion:
+// the sandboxed child reaches a local HTTPS origin through the
+// enforcement proxy's TLS termination, trusting the injected
+// SSL_CERT_FILE bundle (loaded explicitly, like curl --cacert).
+func TestIntegration_MITM_HTTPS(t *testing.T) {
+	srv := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = fmt.Fprint(w, "mitm-real-ok")
+	}))
+	srv.StartTLS()
+	defer srv.Close()
+
+	roots := x509.NewCertPool()
+	roots.AddCert(srv.Certificate())
+	runner, err := New(newIntegrationRoot(t), WithOutboundRoots(roots))
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	res, err := runner.Exec(
+		context.Background(),
+		os.Args[0],
+		[]string{"-test.run", "^TestIntegrationHelper$"},
+		sandbox.ExecOptions{
+			Timeout: 30 * time.Second,
+			Env: sandbox.EnvPolicy{
+				Allow: []string{"PATH", "HOME"},
+				Inject: map[string]string{
+					"FLOWCRAFT_TEST_HELPER":      "1",
+					"FLOWCRAFT_TEST_HELPER_MODE": "https-client",
+					"FLOWCRAFT_TEST_TARGET":      srv.URL,
+				},
+			},
+			Net: sandbox.NetPolicy{
+				Mode:       sandbox.NetAllowList,
+				AllowHosts: []string{"127.0.0.1"},
+				MITM:       &sandbox.MITMPolicy{Enabled: true},
+			},
+		},
+	)
+	if err != nil {
+		t.Fatalf("Exec: %v", err)
+	}
+	if res.ExitCode != 0 {
+		t.Fatalf("exit=%d stdout=%q stderr=%q", res.ExitCode, res.Stdout, res.Stderr)
+	}
+	if !strings.Contains(res.Stdout, "mitm-real-ok") {
+		t.Fatalf("MITM response missing origin body: %q", res.Stdout)
 	}
 }

--- a/sdkx/sandbox/bwrap/runner.go
+++ b/sdkx/sandbox/bwrap/runner.go
@@ -1,5 +1,10 @@
 package bwrap
 
+import (
+	"github.com/GizClaw/flowcraft/sdkx/internal/httpkit"
+	"github.com/GizClaw/flowcraft/sdkx/internal/httpkit/mitm"
+)
+
 // RunnerOption configures a Runner at construction time.
 type RunnerOption func(*runnerConfig)
 
@@ -10,6 +15,8 @@ type runnerConfig struct {
 	binFrom  string   // raw value supplied to WithBinary, "" if defaulted
 	extra    []string // extra bwrap flags injected before the "--" separator
 	writable []string // additional explicitly writable host paths
+	decision func(httpkit.ProxyDecision)
+	hooks    mitm.ProxyHooks
 }
 
 // WithBinary overrides the bwrap binary path. By default the Runner
@@ -45,5 +52,21 @@ func WithExtraFlags(flags ...string) RunnerOption {
 func WithWritablePaths(paths ...string) RunnerOption {
 	return func(c *runnerConfig) {
 		c.writable = append(c.writable, paths...)
+	}
+}
+
+// WithProxyDecision installs the per-decision audit callback used by
+// the host-side enforcement proxy. Keep it fast and non-throwing.
+func WithProxyDecision(fn func(httpkit.ProxyDecision)) RunnerOption {
+	return func(c *runnerConfig) {
+		c.decision = fn
+	}
+}
+
+// WithProxyHooks installs MITM observation/blocking hooks. They only
+// fire when the sandbox policy enables MITM.
+func WithProxyHooks(h mitm.ProxyHooks) RunnerOption {
+	return func(c *runnerConfig) {
+		c.hooks = h
 	}
 }

--- a/sdkx/sandbox/bwrap/runner.go
+++ b/sdkx/sandbox/bwrap/runner.go
@@ -1,6 +1,8 @@
 package bwrap
 
 import (
+	"crypto/x509"
+
 	"github.com/GizClaw/flowcraft/sdkx/internal/httpkit"
 	"github.com/GizClaw/flowcraft/sdkx/internal/httpkit/mitm"
 )
@@ -17,6 +19,7 @@ type runnerConfig struct {
 	writable []string // additional explicitly writable host paths
 	decision func(httpkit.ProxyDecision)
 	hooks    mitm.ProxyHooks
+	roots    *x509.CertPool
 }
 
 // WithBinary overrides the bwrap binary path. By default the Runner
@@ -68,5 +71,15 @@ func WithProxyDecision(fn func(httpkit.ProxyDecision)) RunnerOption {
 func WithProxyHooks(h mitm.ProxyHooks) RunnerOption {
 	return func(c *runnerConfig) {
 		c.hooks = h
+	}
+}
+
+// WithOutboundRoots overrides the roots used to verify the real
+// target's TLS certificate during MITM (nil means system roots). Use
+// it for custom/internal CAs; it never weakens the child side, which
+// still trusts only the injected temporary CA plus system roots.
+func WithOutboundRoots(roots *x509.CertPool) RunnerOption {
+	return func(c *runnerConfig) {
+		c.roots = roots
 	}
 }

--- a/sdkx/sandbox/bwrap/runner_linux.go
+++ b/sdkx/sandbox/bwrap/runner_linux.go
@@ -5,6 +5,7 @@ package bwrap
 import (
 	"bytes"
 	"context"
+	"crypto/x509"
 	"errors"
 	"fmt"
 	"maps"
@@ -43,6 +44,7 @@ type Runner struct {
 	processes        sandbox.ProcessManager
 	decision         func(httpkit.ProxyDecision)
 	hooks            mitm.ProxyHooks
+	outboundRoots    *x509.CertPool
 }
 
 // Enforcement reports the dimensions bwrap plus the shared
@@ -131,6 +133,7 @@ func New(rootDir string, opts ...RunnerOption) (*Runner, error) {
 		defaultMaxOutput: defaultMaxOutputBytes,
 		decision:         cfg.decision,
 		hooks:            cfg.hooks,
+		outboundRoots:    cfg.roots,
 	}
 	runner.processes = sandbox.NewProcessRegistry(runner.spawnProcess)
 	return runner, nil
@@ -162,13 +165,14 @@ func (r *Runner) Exec(ctx context.Context, cmd string, args []string, opts sandb
 	if proxyMode {
 		var err error
 		proxy, err = httpkit.Start(httpkit.ProxyConfig{
-			Mode:       opts.Net.Mode,
-			AllowHosts: opts.Net.AllowHosts,
-			Rules:      opts.Net.Rules,
-			Upstream:   opts.Net.Proxy,
-			MITM:       opts.Net.MITM,
-			OnDecision: r.decision,
-			Hooks:      r.hooks,
+			Mode:          opts.Net.Mode,
+			AllowHosts:    opts.Net.AllowHosts,
+			Rules:         opts.Net.Rules,
+			Upstream:      opts.Net.Proxy,
+			MITM:          opts.Net.MITM,
+			OnDecision:    r.decision,
+			Hooks:         r.hooks,
+			OutboundRoots: r.outboundRoots,
 		})
 		if err != nil {
 			return nil, errdefs.Internalf("bwrap: start enforcement proxy: %v", err)
@@ -361,13 +365,14 @@ func (r *Runner) spawnProcess(ctx context.Context, spec sandbox.ProcessSpec) (sa
 	var proxy *httpkit.Proxy
 	if proxyMode {
 		proxy, err = httpkit.Start(httpkit.ProxyConfig{
-			Mode:       spec.Opts.Net.Mode,
-			AllowHosts: spec.Opts.Net.AllowHosts,
-			Rules:      spec.Opts.Net.Rules,
-			Upstream:   spec.Opts.Net.Proxy,
-			MITM:       spec.Opts.Net.MITM,
-			OnDecision: r.decision,
-			Hooks:      r.hooks,
+			Mode:          spec.Opts.Net.Mode,
+			AllowHosts:    spec.Opts.Net.AllowHosts,
+			Rules:         spec.Opts.Net.Rules,
+			Upstream:      spec.Opts.Net.Proxy,
+			MITM:          spec.Opts.Net.MITM,
+			OnDecision:    r.decision,
+			Hooks:         r.hooks,
+			OutboundRoots: r.outboundRoots,
 		})
 		if err != nil {
 			return nil, errdefs.Internalf("bwrap: start enforcement proxy: %v", err)
@@ -464,7 +469,7 @@ func (r *Runner) spawnProcess(ctx context.Context, spec sandbox.ProcessSpec) (sa
 	}
 	spec.Opts.Resources.MaxOutputBytes = maxOut
 
-	proc, err := sandbox.StartSession(ctx, c, spec.Opts, spec.TTY, spec.Rows, spec.Cols)
+	proc, err := sandbox.StartSession(ctx, spec, c)
 	if err != nil {
 		if proxy != nil {
 			_ = proxy.Close()

--- a/sdkx/sandbox/bwrap/runner_linux.go
+++ b/sdkx/sandbox/bwrap/runner_linux.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"maps"
 	"math"
 	"os"
 	"os/exec"
@@ -19,6 +20,7 @@ import (
 	"github.com/GizClaw/flowcraft/sdk/errdefs"
 	"github.com/GizClaw/flowcraft/sdk/sandbox"
 	"github.com/GizClaw/flowcraft/sdkx/internal/httpkit"
+	"github.com/GizClaw/flowcraft/sdkx/internal/httpkit/mitm"
 	"github.com/GizClaw/flowcraft/sdkx/sandbox/bwrap/internal/bridge"
 )
 
@@ -39,6 +41,8 @@ type Runner struct {
 	writablePaths    []string
 	defaultMaxOutput int64
 	processes        sandbox.ProcessManager
+	decision         func(httpkit.ProxyDecision)
+	hooks            mitm.ProxyHooks
 }
 
 // Enforcement reports the dimensions bwrap plus the shared
@@ -54,6 +58,9 @@ func (r *Runner) Enforcement() sandbox.Enforcement {
 			sandbox.NetAllowList,
 			sandbox.NetProxy,
 		},
+		Socks5:           true,
+		MITM:             true,
+		UnixSocketPolicy: true,
 		MemoryCap:        caps,
 		CPUCap:           caps,
 		FilesystemBounds: true,
@@ -122,6 +129,8 @@ func New(rootDir string, opts ...RunnerOption) (*Runner, error) {
 		extraFlags:       append([]string(nil), cfg.extra...),
 		writablePaths:    writable,
 		defaultMaxOutput: defaultMaxOutputBytes,
+		decision:         cfg.decision,
+		hooks:            cfg.hooks,
 	}
 	runner.processes = sandbox.NewProcessRegistry(runner.spawnProcess)
 	return runner, nil
@@ -155,12 +164,36 @@ func (r *Runner) Exec(ctx context.Context, cmd string, args []string, opts sandb
 		proxy, err = httpkit.Start(httpkit.ProxyConfig{
 			Mode:       opts.Net.Mode,
 			AllowHosts: opts.Net.AllowHosts,
+			Rules:      opts.Net.Rules,
 			Upstream:   opts.Net.Proxy,
+			MITM:       opts.Net.MITM,
+			OnDecision: r.decision,
+			Hooks:      r.hooks,
 		})
 		if err != nil {
 			return nil, errdefs.Internalf("bwrap: start enforcement proxy: %v", err)
 		}
 		defer func() { _ = proxy.Close() }()
+	}
+
+	var bundlePath string
+	var bundleCleanup func()
+	if opts.Net.MITM != nil && opts.Net.MITM.Enabled {
+		if proxy == nil {
+			return nil, errdefs.NotAvailablef(
+				"bwrap: MITM requires allow_list or proxy net mode")
+		}
+		bundlePath, bundleCleanup, err = mitm.WriteBundle(proxy.CAPEM())
+		if err != nil {
+			return nil, errdefs.Internalf("bwrap: write CA bundle: %v", err)
+		}
+		defer bundleCleanup()
+		if opts.Env.Inject == nil {
+			opts.Env.Inject = make(map[string]string)
+		} else {
+			opts.Env.Inject = maps.Clone(opts.Env.Inject)
+		}
+		opts.Env.Inject["SSL_CERT_FILE"] = bundlePath
 	}
 
 	flags, err := buildFlags(opts, os.Environ())
@@ -169,6 +202,16 @@ func (r *Runner) Exec(ctx context.Context, cmd string, args []string, opts sandb
 	}
 	fsFlags := filesystemFlags(r.rootDir, r.writablePaths)
 	fsFlags = append(fsFlags, netIsolationFlags(opts.Net.Mode)...)
+	if bundlePath != "" {
+		fsFlags = append(fsFlags, "--ro-bind", bundlePath, bundlePath)
+	}
+	for _, path := range opts.Net.UnixSockets {
+		if _, statErr := os.Stat(path); statErr != nil {
+			return nil, errdefs.NotFoundf(
+				"bwrap: allowed unix socket %q does not exist: %v", path, statErr)
+		}
+		fsFlags = append(fsFlags, "--bind", path, path)
+	}
 
 	// The post-"--" argv. For NetAllowList / NetProxy the command is
 	// the in-netns bridge, which then runs the real command as its
@@ -320,10 +363,39 @@ func (r *Runner) spawnProcess(ctx context.Context, spec sandbox.ProcessSpec) (sa
 		proxy, err = httpkit.Start(httpkit.ProxyConfig{
 			Mode:       spec.Opts.Net.Mode,
 			AllowHosts: spec.Opts.Net.AllowHosts,
+			Rules:      spec.Opts.Net.Rules,
 			Upstream:   spec.Opts.Net.Proxy,
+			MITM:       spec.Opts.Net.MITM,
+			OnDecision: r.decision,
+			Hooks:      r.hooks,
 		})
 		if err != nil {
 			return nil, errdefs.Internalf("bwrap: start enforcement proxy: %v", err)
+		}
+	}
+
+	var bundlePath string
+	var bundleCleanup func()
+	if spec.Opts.Net.MITM != nil && spec.Opts.Net.MITM.Enabled {
+		if proxy == nil {
+			return nil, errdefs.NotAvailablef(
+				"bwrap: MITM requires allow_list or proxy net mode")
+		}
+		bundlePath, bundleCleanup, err = mitm.WriteBundle(proxy.CAPEM())
+		if err != nil {
+			_ = proxy.Close()
+			return nil, errdefs.Internalf("bwrap: write CA bundle: %v", err)
+		}
+		if spec.Opts.Env.Inject == nil {
+			spec.Opts.Env.Inject = make(map[string]string)
+		} else {
+			spec.Opts.Env.Inject = maps.Clone(spec.Opts.Env.Inject)
+		}
+		spec.Opts.Env.Inject["SSL_CERT_FILE"] = bundlePath
+	}
+	abortBundle := func() {
+		if bundleCleanup != nil {
+			bundleCleanup()
 		}
 	}
 
@@ -332,10 +404,25 @@ func (r *Runner) spawnProcess(ctx context.Context, spec sandbox.ProcessSpec) (sa
 		if proxy != nil {
 			_ = proxy.Close()
 		}
+		abortBundle()
 		return nil, err
 	}
 	fsFlags := filesystemFlags(r.rootDir, r.writablePaths)
 	fsFlags = append(fsFlags, netIsolationFlags(spec.Opts.Net.Mode)...)
+	if bundlePath != "" {
+		fsFlags = append(fsFlags, "--ro-bind", bundlePath, bundlePath)
+	}
+	for _, path := range spec.Opts.Net.UnixSockets {
+		if _, statErr := os.Stat(path); statErr != nil {
+			if proxy != nil {
+				_ = proxy.Close()
+			}
+			abortBundle()
+			return nil, errdefs.NotFoundf(
+				"bwrap: allowed unix socket %q does not exist: %v", path, statErr)
+		}
+		fsFlags = append(fsFlags, "--bind", path, path)
+	}
 
 	var command []string
 	if proxyMode {
@@ -344,6 +431,7 @@ func (r *Runner) spawnProcess(ctx context.Context, spec sandbox.ProcessSpec) (sa
 			if proxy != nil {
 				_ = proxy.Close()
 			}
+			abortBundle()
 			return nil, errdefs.Internalf(
 				"bwrap: resolve host binary for in-netns bridge: %v", err)
 		}
@@ -381,10 +469,14 @@ func (r *Runner) spawnProcess(ctx context.Context, spec sandbox.ProcessSpec) (sa
 		if proxy != nil {
 			_ = proxy.Close()
 		}
+		abortBundle()
 		return nil, err
 	}
 	if proxy != nil {
-		cleanup := &sessionCleanup{cleanup: func() { _ = proxy.Close() }}
+		cleanup := &sessionCleanup{cleanup: func() {
+			_ = proxy.Close()
+			abortBundle()
+		}}
 		go func() {
 			_, _ = proc.Wait(context.Background())
 			cleanup.once.Do(cleanup.cleanup)

--- a/sdkx/sandbox/bwrap/runner_linux.go
+++ b/sdkx/sandbox/bwrap/runner_linux.go
@@ -12,6 +12,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"sync"
 	"syscall"
 	"time"
 
@@ -37,6 +38,7 @@ type Runner struct {
 	extraFlags       []string
 	writablePaths    []string
 	defaultMaxOutput int64
+	processes        sandbox.ProcessManager
 }
 
 // Enforcement reports the dimensions bwrap plus the shared
@@ -114,13 +116,15 @@ func New(rootDir string, opts ...RunnerOption) (*Runner, error) {
 		}
 	}
 
-	return &Runner{
+	runner := &Runner{
 		rootDir:          abs,
 		binary:           binary,
 		extraFlags:       append([]string(nil), cfg.extra...),
 		writablePaths:    writable,
 		defaultMaxOutput: defaultMaxOutputBytes,
-	}, nil
+	}
+	runner.processes = sandbox.NewProcessRegistry(runner.spawnProcess)
+	return runner, nil
 }
 
 // Exec runs cmd with args inside a bubblewrap invocation that enforces
@@ -132,22 +136,8 @@ func (r *Runner) Exec(ctx context.Context, cmd string, args []string, opts sandb
 	if cmd == "" {
 		return nil, errdefs.Validationf("bwrap: empty command")
 	}
-	if opts.Resources.DiskBytes != 0 {
-		return nil, errdefs.NotAvailablef(
-			"bwrap: disk limits not supported (no quota mechanism)")
-	}
-	if opts.Resources.CPUMillicores != 0 && opts.Timeout <= 0 {
-		return nil, errdefs.NotAvailablef(
-			"bwrap: CPUMillicores requires a per-call Timeout to derive a cpu-time cap")
-	}
-	// Memory and cpu caps ride on the shared sampling watcher, not on
-	// bwrap. Where that watcher cannot sample, honouring the call
-	// would run the child with no cap at all, so reject it instead of
-	// pretending.
-	if (opts.Resources.MemoryBytes > 0 || opts.Resources.CPUMillicores > 0) && !sandbox.GroupCapsSupported() {
-		return nil, errdefs.NotAvailablef(
-			"bwrap: resource limits require process-group sampling, which is unavailable here",
-		)
+	if err := sandbox.ValidateExecPolicy(opts); err != nil {
+		return nil, err
 	}
 
 	resolvedWorkDir, err := r.resolveWorkDir(opts.WorkDir)
@@ -286,6 +276,140 @@ func (r *Runner) Exec(ctx context.Context, cmd string, args []string, opts sandb
 		return result, classifyStartError(cmd, runErr)
 	}
 	return result, nil
+}
+
+// Start implements sandbox.ProcessManager. The session runs inside the
+// same bubblewrap invocation as Exec; the in-netns bridge and host
+// enforcement proxy, when NetAllowList / NetProxy needs them, are
+// owned by the session and closed when the session exits or is closed.
+func (r *Runner) Start(ctx context.Context, spec sandbox.ProcessSpec) (sandbox.Process, error) {
+	return r.processes.Start(ctx, spec)
+}
+
+// List implements sandbox.ProcessManager.
+func (r *Runner) List(ctx context.Context) ([]sandbox.ProcessInfo, error) {
+	return r.processes.List(ctx)
+}
+
+// Terminate implements sandbox.ProcessManager.
+func (r *Runner) Terminate(ctx context.Context, id string) error {
+	return r.processes.Terminate(ctx, id)
+}
+
+// spawnProcess is the Runner's sandbox.ProcessStarter. It reuses the
+// exact flag assembly Exec uses (buildFlags + filesystemFlags +
+// netIsolationFlags + bridge re-exec), then hands the bwrap command to
+// the shared session implementation for pty/pipe stdio.
+func (r *Runner) spawnProcess(ctx context.Context, spec sandbox.ProcessSpec) (sandbox.Process, error) {
+	if len(spec.Argv) == 0 {
+		return nil, errdefs.Validationf("bwrap: empty command")
+	}
+	if err := sandbox.ValidateExecPolicy(spec.Opts); err != nil {
+		return nil, err
+	}
+
+	resolvedWorkDir, err := r.resolveWorkDir(spec.Opts.WorkDir)
+	if err != nil {
+		return nil, err
+	}
+	spec.Opts.WorkDir = resolvedWorkDir
+
+	proxyMode := spec.Opts.Net.Mode == sandbox.NetAllowList || spec.Opts.Net.Mode == sandbox.NetProxy
+	var proxy *httpkit.Proxy
+	if proxyMode {
+		proxy, err = httpkit.Start(httpkit.ProxyConfig{
+			Mode:       spec.Opts.Net.Mode,
+			AllowHosts: spec.Opts.Net.AllowHosts,
+			Upstream:   spec.Opts.Net.Proxy,
+		})
+		if err != nil {
+			return nil, errdefs.Internalf("bwrap: start enforcement proxy: %v", err)
+		}
+	}
+
+	flags, err := buildFlags(spec.Opts, os.Environ())
+	if err != nil {
+		if proxy != nil {
+			_ = proxy.Close()
+		}
+		return nil, err
+	}
+	fsFlags := filesystemFlags(r.rootDir, r.writablePaths)
+	fsFlags = append(fsFlags, netIsolationFlags(spec.Opts.Net.Mode)...)
+
+	var command []string
+	if proxyMode {
+		exe, err := os.Executable()
+		if err != nil {
+			if proxy != nil {
+				_ = proxy.Close()
+			}
+			return nil, errdefs.Internalf(
+				"bwrap: resolve host binary for in-netns bridge: %v", err)
+		}
+		fsFlags = append(fsFlags,
+			"--ro-bind", exe, exe,
+			"--bind", proxy.SocketPath(), sandboxProxySock,
+		)
+		command = append([]string{
+			exe, bridge.Marker, "--sock", sandboxProxySock, "--", spec.Argv[0],
+		}, spec.Argv[1:]...)
+	} else {
+		command = append([]string{spec.Argv[0]}, spec.Argv[1:]...)
+	}
+
+	argv := append([]string{}, r.extraFlags...)
+	argv = append(argv, flags...)
+	argv = append(argv, fsFlags...)
+	argv = append(argv, "--")
+	argv = append(argv, command...)
+
+	c := exec.Command(r.binary, argv...)
+	c.Env = os.Environ()
+
+	maxOut := spec.Opts.Resources.MaxOutputBytes
+	if maxOut <= 0 {
+		maxOut = r.defaultMaxOutput
+	}
+	if maxOut <= 0 {
+		maxOut = math.MaxInt64
+	}
+	spec.Opts.Resources.MaxOutputBytes = maxOut
+
+	proc, err := sandbox.StartSession(ctx, c, spec.Opts, spec.TTY, spec.Rows, spec.Cols)
+	if err != nil {
+		if proxy != nil {
+			_ = proxy.Close()
+		}
+		return nil, err
+	}
+	if proxy != nil {
+		cleanup := &sessionCleanup{cleanup: func() { _ = proxy.Close() }}
+		go func() {
+			_, _ = proc.Wait(context.Background())
+			cleanup.once.Do(cleanup.cleanup)
+		}()
+		return &sessionProcess{Process: proc, cleanup: cleanup}, nil
+	}
+	return proc, nil
+}
+
+// sessionProcess keeps a sandbox.Process's side resources (the host
+// enforcement proxy) alive for exactly as long as the session.
+type sessionProcess struct {
+	sandbox.Process
+	cleanup *sessionCleanup
+}
+
+func (p *sessionProcess) Close() error {
+	err := p.Process.Close()
+	p.cleanup.once.Do(p.cleanup.cleanup)
+	return err
+}
+
+type sessionCleanup struct {
+	once    sync.Once
+	cleanup func()
 }
 
 func resolveConfiguredPath(path string) (string, error) {

--- a/sdkx/sandbox/bwrap/runner_linux_test.go
+++ b/sdkx/sandbox/bwrap/runner_linux_test.go
@@ -422,7 +422,7 @@ func TestRunner_ProcessManager_PipeSession(t *testing.T) {
 			break
 		}
 	}
-	if !strings.Contains(sb.String(), "CMD:/bin/echo") || !strings.Contains(sb.String(), "CMD:hi") {
+	if !strings.Contains(sb.String(), "CMD:/bin/echo") || !strings.Contains(sb.String(), "ARG:hi") {
 		t.Fatalf(`session output missing post-"--" argv: %q`, sb.String())
 	}
 	if exit, err := proc.Wait(ctx); err != nil || exit.Code != 0 {

--- a/sdkx/sandbox/bwrap/runner_linux_test.go
+++ b/sdkx/sandbox/bwrap/runner_linux_test.go
@@ -390,3 +390,97 @@ func TestRunner_Exec_EmptyCommandRejected(t *testing.T) {
 		t.Fatalf("expected validation error for empty command")
 	}
 }
+
+func TestRunner_ProcessManager_PipeSession(t *testing.T) {
+	bin := fakeBwrap(t, echoScript)
+	r, err := New(t.TempDir(), WithBinary(bin))
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	proc, err := r.Start(context.Background(), sandbox.ProcessSpec{
+		Argv: []string{"/bin/echo", "hi"},
+	})
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer func() { _ = proc.Close() }()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	var sb strings.Builder
+	var seq int64
+	for {
+		out, err := proc.Read(ctx, seq, 4096)
+		if err != nil {
+			t.Fatalf("Read: %v", err)
+		}
+		for _, ch := range out.Chunks {
+			sb.Write(ch.Data)
+		}
+		seq = out.NextSeq
+		if out.EOF {
+			break
+		}
+	}
+	if !strings.Contains(sb.String(), "CMD:/bin/echo") || !strings.Contains(sb.String(), "CMD:hi") {
+		t.Fatalf(`session output missing post-"--" argv: %q`, sb.String())
+	}
+	if exit, err := proc.Wait(ctx); err != nil || exit.Code != 0 {
+		t.Fatalf("Wait = %+v, %v; want exited(0)", exit, err)
+	}
+}
+
+func TestRunner_ProcessManager_TTYSession(t *testing.T) {
+	bin := fakeBwrap(t, echoScript)
+	r, err := New(t.TempDir(), WithBinary(bin))
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	proc, err := r.Start(context.Background(), sandbox.ProcessSpec{
+		Argv: []string{"/bin/echo", "hi"},
+		TTY:  true,
+	})
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer func() { _ = proc.Close() }()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	var sb strings.Builder
+	var seq int64
+	for {
+		out, err := proc.Read(ctx, seq, 4096)
+		if err != nil {
+			t.Fatalf("Read: %v", err)
+		}
+		for _, ch := range out.Chunks {
+			sb.Write(ch.Data)
+		}
+		seq = out.NextSeq
+		if out.EOF {
+			break
+		}
+	}
+	if !strings.Contains(sb.String(), "CMD:/bin/echo") {
+		t.Fatalf("TTY session output missing argv: %q", sb.String())
+	}
+	if exit, err := proc.Wait(ctx); err != nil || exit.Code != 0 {
+		t.Fatalf("Wait = %+v, %v; want exited(0)", exit, err)
+	}
+}
+
+func TestRunner_ProcessManager_PolicyRejected(t *testing.T) {
+	bin := fakeBwrap(t, echoScript)
+	r, err := New(t.TempDir(), WithBinary(bin))
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	_, err = r.Start(context.Background(), sandbox.ProcessSpec{
+		Argv: []string{"/bin/true"},
+		Opts: sandbox.ExecOptions{Resources: sandbox.ResourceLimits{DiskBytes: 1}},
+	})
+	if !errdefs.IsNotAvailable(err) {
+		t.Fatalf("disk-limit Start = %v, want NotAvailable", err)
+	}
+}

--- a/sdkx/sandbox/bwrap/runner_linux_test.go
+++ b/sdkx/sandbox/bwrap/runner_linux_test.go
@@ -484,3 +484,130 @@ func TestRunner_ProcessManager_PolicyRejected(t *testing.T) {
 		t.Fatalf("disk-limit Start = %v, want NotAvailable", err)
 	}
 }
+
+func TestRunner_Enforcement_ProxyFeatures(t *testing.T) {
+	bin := fakeBwrap(t, echoScript)
+	r, err := New(t.TempDir(), WithBinary(bin))
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	e := r.Enforcement()
+	if !e.Socks5 || !e.MITM || !e.UnixSocketPolicy {
+		t.Errorf("bwrap must claim socks5/mitm/unix-socket policy, got %+v", e)
+	}
+}
+
+func TestRunner_ProcessManager_UnixSocketBindFlags(t *testing.T) {
+	bin := fakeBwrap(t, echoScript)
+	sock := filepath.Join(t.TempDir(), "test.sock")
+	if err := os.WriteFile(sock, nil, 0o600); err != nil {
+		t.Fatalf("create socket file: %v", err)
+	}
+	r, err := New(t.TempDir(), WithBinary(bin))
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	proc, err := r.Start(context.Background(), sandbox.ProcessSpec{
+		Argv: []string{"/bin/echo", "hi"},
+		Opts: sandbox.ExecOptions{Net: sandbox.NetPolicy{
+			UnixSockets: []string{sock},
+		}},
+	})
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer func() { _ = proc.Close() }()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	var sb strings.Builder
+	var seq int64
+	for {
+		out, err := proc.Read(ctx, seq, 4096)
+		if err != nil {
+			t.Fatalf("Read: %v", err)
+		}
+		for _, ch := range out.Chunks {
+			sb.Write(ch.Data)
+		}
+		seq = out.NextSeq
+		if out.EOF {
+			break
+		}
+	}
+	if !strings.Contains(sb.String(), "ARG:--bind\nARG:"+sock+"\n") {
+		t.Fatalf("unix socket bind not emitted: %q", sb.String())
+	}
+}
+
+func TestRunner_ProcessManager_UnixSocketMissing_NotFound(t *testing.T) {
+	bin := fakeBwrap(t, echoScript)
+	r, err := New(t.TempDir(), WithBinary(bin))
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	_, err = r.Start(context.Background(), sandbox.ProcessSpec{
+		Argv: []string{"/bin/true"},
+		Opts: sandbox.ExecOptions{Net: sandbox.NetPolicy{
+			UnixSockets: []string{"/no/such/socket"},
+		}},
+	})
+	if !errdefs.IsNotFound(err) {
+		t.Fatalf("missing socket Start = %v, want NotFound", err)
+	}
+}
+
+func TestRunner_Exec_UnixSocketMissing_NotFound(t *testing.T) {
+	bin := fakeBwrap(t, echoScript)
+	r, err := New(t.TempDir(), WithBinary(bin))
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	_, err = r.Exec(context.Background(), "/bin/true", nil, sandbox.ExecOptions{
+		Net: sandbox.NetPolicy{UnixSockets: []string{"/no/such/socket"}},
+	})
+	if !errdefs.IsNotFound(err) {
+		t.Fatalf("missing socket Exec = %v, want NotFound", err)
+	}
+}
+
+func TestRunner_ProcessManager_MITMBundleInjected(t *testing.T) {
+	bin := fakeBwrap(t, echoScript)
+	r, err := New(t.TempDir(), WithBinary(bin))
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	proc, err := r.Start(context.Background(), sandbox.ProcessSpec{
+		Argv: []string{"/bin/echo", "hi"},
+		Opts: sandbox.ExecOptions{Net: sandbox.NetPolicy{
+			Mode:       sandbox.NetAllowList,
+			AllowHosts: []string{"example.com"},
+			MITM:       &sandbox.MITMPolicy{Enabled: true},
+		}},
+	})
+	if err != nil {
+		t.Fatalf("Start with MITM: %v", err)
+	}
+	defer func() { _ = proc.Close() }()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	var sb strings.Builder
+	var seq int64
+	for {
+		out, err := proc.Read(ctx, seq, 4096)
+		if err != nil {
+			t.Fatalf("Read: %v", err)
+		}
+		for _, ch := range out.Chunks {
+			sb.Write(ch.Data)
+		}
+		seq = out.NextSeq
+		if out.EOF {
+			break
+		}
+	}
+	if !strings.Contains(sb.String(), "ARG:SSL_CERT_FILE") || !strings.Contains(sb.String(), "ARG:--ro-bind") {
+		t.Fatalf("MITM CA bundle env/bind missing: %q", sb.String())
+	}
+}

--- a/sdkx/sandbox/bwrap/runner_other.go
+++ b/sdkx/sandbox/bwrap/runner_other.go
@@ -41,3 +41,21 @@ func (*Runner) Exec(ctx context.Context, cmd string, args []string, opts sandbox
 func (*Runner) Enforcement() sandbox.Enforcement {
 	return sandbox.Enforcement{}
 }
+
+// Start is unreachable because New never returns a non-nil Runner on
+// non-Linux platforms. It exists so *Runner satisfies
+// sandbox.ProcessManager in type assertions written by portable code.
+func (*Runner) Start(ctx context.Context, spec sandbox.ProcessSpec) (sandbox.Process, error) {
+	_, _ = ctx, spec
+	return nil, errdefs.NotAvailablef("bwrap: not available on this platform")
+}
+
+// List is unreachable outside Linux.
+func (*Runner) List(context.Context) ([]sandbox.ProcessInfo, error) {
+	return nil, errdefs.NotAvailablef("bwrap: not available on this platform")
+}
+
+// Terminate is unreachable outside Linux.
+func (*Runner) Terminate(context.Context, string) error {
+	return errdefs.NotAvailablef("bwrap: not available on this platform")
+}

--- a/sdkx/sandbox/bwrap/runner_other_test.go
+++ b/sdkx/sandbox/bwrap/runner_other_test.go
@@ -31,3 +31,23 @@ func TestStubRunner_ExecNotAvailable(t *testing.T) {
 		t.Errorf("expected NotAvailable, got %v", err)
 	}
 }
+
+// TestStubRunner_ProcessManagerNotAvailable pins the same contract for
+// the optional session capability: portable code that discovers it via
+// ProcessManagerOf gets NotAvailable, never a silent downgrade.
+func TestStubRunner_ProcessManagerNotAvailable(t *testing.T) {
+	var r Runner
+	pm := sandbox.ProcessManagerOf(&r)
+	if pm == nil {
+		t.Fatal("stub Runner must implement ProcessManager for type assertions")
+	}
+	if _, err := pm.Start(context.Background(), sandbox.ProcessSpec{Argv: []string{"/bin/true"}}); !errdefs.IsNotAvailable(err) {
+		t.Errorf("Start = %v, want NotAvailable", err)
+	}
+	if _, err := pm.List(context.Background()); !errdefs.IsNotAvailable(err) {
+		t.Errorf("List = %v, want NotAvailable", err)
+	}
+	if err := pm.Terminate(context.Background(), "x"); !errdefs.IsNotAvailable(err) {
+		t.Errorf("Terminate = %v, want NotAvailable", err)
+	}
+}

--- a/sdkx/sandbox/seatbelt/doc.go
+++ b/sdkx/sandbox/seatbelt/doc.go
@@ -75,4 +75,12 @@
 // functional and is the same primitive Chrome and Anthropic's
 // sandbox-runtime rely on. A future Virtualization.framework backend
 // can supersede this package without changing the Runner seam.
+//
+// # Interactive sessions
+//
+// Runner also implements sandbox.ProcessManager: sessions run inside
+// the same generated SBPL profile as Exec (including the enforcement
+// proxy for NetAllowList / NetProxy, which lives as long as the
+// session). Stdio is either a pty (TTY: true) or tagged pipes, with
+// the seq-cursor replay contract defined in sdk/sandbox.
 package seatbelt

--- a/sdkx/sandbox/seatbelt/doc.go
+++ b/sdkx/sandbox/seatbelt/doc.go
@@ -88,7 +88,21 @@
 //
 // The host-side enforcement proxy supports rule-based allow/deny,
 // socks5:// upstreams, MITM (TLS termination + hooks) with
-// SSL_CERT_FILE injection, and per-decision audit callbacks. Unix
-// socket allow-lists are not enforceable under SBPL, so any non-empty
-// UnixSockets policy is rejected with errdefs.NotAvailable.
+// SSL_CERT_FILE injection, and per-decision audit callbacks. MITM
+// terminates both HTTP/1.1 and HTTP/2 clients (ALPN h2 + http/1.1);
+// MITMPolicy.Hosts / ExcludeHosts select which CONNECT tunnels are
+// terminated, so cert-pinning destinations can be raw-tunnelled
+// explicitly. Unix socket allow-lists are not enforceable under SBPL,
+// so any non-empty UnixSockets policy is rejected with
+// errdefs.NotAvailable.
+//
+// macOS CA-injection caveat: Go and curl on macOS use the Security
+// framework / SecureTransport by default and ignore SSL_CERT_FILE,
+// and under SBPL the Security framework is unreachable (the child's
+// system pool is empty). Programs must explicitly load the injected
+// bundle (Go: tls.Config.RootCAs from SSL_CERT_FILE; curl:
+// --cacert "$SSL_CERT_FILE") — the environment variable is the
+// carrier, not the automatic trust source. This matches the
+// blast-radius posture: only bundle-aware programs get MITM'd
+// transparently; the rest fail TLS rather than trusting silently.
 package seatbelt

--- a/sdkx/sandbox/seatbelt/doc.go
+++ b/sdkx/sandbox/seatbelt/doc.go
@@ -83,4 +83,12 @@
 // proxy for NetAllowList / NetProxy, which lives as long as the
 // session). Stdio is either a pty (TTY: true) or tagged pipes, with
 // the seq-cursor replay contract defined in sdk/sandbox.
+//
+// # Proxy enhancements
+//
+// The host-side enforcement proxy supports rule-based allow/deny,
+// socks5:// upstreams, MITM (TLS termination + hooks) with
+// SSL_CERT_FILE injection, and per-decision audit callbacks. Unix
+// socket allow-lists are not enforceable under SBPL, so any non-empty
+// UnixSockets policy is rejected with errdefs.NotAvailable.
 package seatbelt

--- a/sdkx/sandbox/seatbelt/integration_darwin_test.go
+++ b/sdkx/sandbox/seatbelt/integration_darwin_test.go
@@ -4,10 +4,15 @@ package seatbelt
 
 import (
 	"context"
+	"crypto/tls"
+	"crypto/x509"
 	"fmt"
+	"io"
 	"net"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
+	"os"
 	"os/exec"
 	"strconv"
 	"strings"
@@ -16,6 +21,102 @@ import (
 
 	"github.com/GizClaw/flowcraft/sdk/sandbox"
 )
+
+// TestIntegrationHelper is re-executed by the MITM integration test
+// as the sandboxed child. It is inert unless the helper env is set.
+func TestIntegrationHelper(t *testing.T) {
+	if os.Getenv("FLOWCRAFT_TEST_HELPER") != "1" {
+		return
+	}
+	switch os.Getenv("FLOWCRAFT_TEST_HELPER_MODE") {
+	case "https-client":
+		target := os.Getenv("FLOWCRAFT_TEST_TARGET")
+		// Use the proxy explicitly: Go's ProxyFromEnvironment bypasses
+		// loopback targets by design, but a real proxy-aware client
+		// (curl, browsers) honors HTTPS_PROXY here. The transport still
+		// verifies the MITM leaf through SSL_CERT_FILE.
+		proxyURL, err := url.Parse(os.Getenv("HTTPS_PROXY"))
+		if err != nil {
+			t.Fatalf("parse HTTPS_PROXY: %v", err)
+		}
+		// Load the injected bundle explicitly: on macOS Go's system
+		// root store is the Security framework, which both ignores
+		// SSL_CERT_FILE and is unreachable under SBPL (empty pool).
+		// This is the --cacert behaviour curl would use.
+		pool := x509.NewCertPool()
+		pemData, err := os.ReadFile(os.Getenv("SSL_CERT_FILE"))
+		if err != nil {
+			t.Fatalf("read SSL_CERT_FILE: %v", err)
+		}
+		if !pool.AppendCertsFromPEM(pemData) {
+			t.Fatalf("SSL_CERT_FILE contains no usable certificates")
+		}
+		client := &http.Client{Transport: &http.Transport{
+			Proxy:           http.ProxyURL(proxyURL),
+			TLSClientConfig: &tls.Config{RootCAs: pool, MinVersion: tls.VersionTLS12},
+		}}
+		resp, err := client.Get(target)
+		if err != nil {
+			t.Fatalf("GET %s: %v", target, err)
+		}
+		defer func() { _ = resp.Body.Close() }()
+		body, err := io.ReadAll(resp.Body)
+		if err != nil {
+			t.Fatalf("read body: %v", err)
+		}
+		fmt.Print(string(body))
+	}
+}
+
+// TestIntegration_MITM_HTTPS is the real-environment MITM assertion:
+// a Go client inside the Seatbelt sandbox trusts the injected
+// SSL_CERT_FILE bundle, reaches a local HTTPS origin through the
+// enforcement proxy's TLS termination, and receives the origin body.
+func TestIntegration_MITM_HTTPS(t *testing.T) {
+	srv := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = fmt.Fprint(w, "mitm-real-ok")
+	}))
+	srv.StartTLS()
+	defer srv.Close()
+
+	roots := x509.NewCertPool()
+	roots.AddCert(srv.Certificate())
+	runner, err := New(t.TempDir(), WithOutboundRoots(roots))
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	result, err := runner.Exec(
+		context.Background(),
+		os.Args[0],
+		[]string{"-test.run", "^TestIntegrationHelper$"},
+		sandbox.ExecOptions{
+			Timeout: 30 * time.Second,
+			Env: sandbox.EnvPolicy{
+				Allow: []string{"PATH", "HOME"},
+				Inject: map[string]string{
+					"FLOWCRAFT_TEST_HELPER":      "1",
+					"FLOWCRAFT_TEST_HELPER_MODE": "https-client",
+					"FLOWCRAFT_TEST_TARGET":      srv.URL,
+				},
+			},
+			Net: sandbox.NetPolicy{
+				Mode:       sandbox.NetAllowList,
+				AllowHosts: []string{"127.0.0.1"},
+				MITM:       &sandbox.MITMPolicy{Enabled: true},
+			},
+		},
+	)
+	if err != nil {
+		t.Fatalf("Exec: %v", err)
+	}
+	if result.ExitCode != 0 {
+		t.Fatalf("exit=%d stdout=%q stderr=%q", result.ExitCode, result.Stdout, result.Stderr)
+	}
+	if !strings.Contains(result.Stdout, "mitm-real-ok") {
+		t.Fatalf("MITM response missing origin body: %q", result.Stdout)
+	}
+}
 
 // TestIntegration_NetDenyAll proves the generated SBPL profile blocks
 // even loopback connections at the OS level. A local listener avoids

--- a/sdkx/sandbox/seatbelt/runner.go
+++ b/sdkx/sandbox/seatbelt/runner.go
@@ -1,6 +1,8 @@
 package seatbelt
 
 import (
+	"crypto/x509"
+
 	"github.com/GizClaw/flowcraft/sdkx/internal/httpkit"
 	"github.com/GizClaw/flowcraft/sdkx/internal/httpkit/mitm"
 )
@@ -16,6 +18,7 @@ type runnerConfig struct {
 	writable []string // extra writable paths, resolved at construction
 	decision func(httpkit.ProxyDecision)
 	hooks    mitm.ProxyHooks
+	roots    *x509.CertPool
 }
 
 // WithBinary overrides the sandbox-exec binary path. By default the
@@ -55,5 +58,15 @@ func WithProxyDecision(fn func(httpkit.ProxyDecision)) RunnerOption {
 func WithProxyHooks(h mitm.ProxyHooks) RunnerOption {
 	return func(c *runnerConfig) {
 		c.hooks = h
+	}
+}
+
+// WithOutboundRoots overrides the roots used to verify the real
+// target's TLS certificate during MITM (nil means system roots). Use
+// it for custom/internal CAs; it never weakens the child side, which
+// still trusts only the injected temporary CA plus system roots.
+func WithOutboundRoots(roots *x509.CertPool) RunnerOption {
+	return func(c *runnerConfig) {
+		c.roots = roots
 	}
 }

--- a/sdkx/sandbox/seatbelt/runner.go
+++ b/sdkx/sandbox/seatbelt/runner.go
@@ -1,5 +1,10 @@
 package seatbelt
 
+import (
+	"github.com/GizClaw/flowcraft/sdkx/internal/httpkit"
+	"github.com/GizClaw/flowcraft/sdkx/internal/httpkit/mitm"
+)
+
 // RunnerOption configures a Runner at construction time.
 type RunnerOption func(*runnerConfig)
 
@@ -9,6 +14,8 @@ type RunnerOption func(*runnerConfig)
 type runnerConfig struct {
 	binFrom  string   // raw value supplied to WithBinary, "" if defaulted
 	writable []string // extra writable paths, resolved at construction
+	decision func(httpkit.ProxyDecision)
+	hooks    mitm.ProxyHooks
 }
 
 // WithBinary overrides the sandbox-exec binary path. By default the
@@ -32,5 +39,21 @@ func WithBinary(path string) RunnerOption {
 func WithWritablePaths(paths ...string) RunnerOption {
 	return func(c *runnerConfig) {
 		c.writable = append(c.writable, paths...)
+	}
+}
+
+// WithProxyDecision installs the per-decision audit callback used by
+// the host-side enforcement proxy. Keep it fast and non-throwing.
+func WithProxyDecision(fn func(httpkit.ProxyDecision)) RunnerOption {
+	return func(c *runnerConfig) {
+		c.decision = fn
+	}
+}
+
+// WithProxyHooks installs MITM observation/blocking hooks. They only
+// fire when the sandbox policy enables MITM.
+func WithProxyHooks(h mitm.ProxyHooks) RunnerOption {
+	return func(c *runnerConfig) {
+		c.hooks = h
 	}
 }

--- a/sdkx/sandbox/seatbelt/runner_darwin.go
+++ b/sdkx/sandbox/seatbelt/runner_darwin.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"maps"
 	"math"
 	"net"
 	"os"
@@ -20,6 +21,7 @@ import (
 	"github.com/GizClaw/flowcraft/sdk/errdefs"
 	"github.com/GizClaw/flowcraft/sdk/sandbox"
 	"github.com/GizClaw/flowcraft/sdkx/internal/httpkit"
+	"github.com/GizClaw/flowcraft/sdkx/internal/httpkit/mitm"
 )
 
 const defaultMaxOutputBytes int64 = 10 * 1024 * 1024
@@ -31,6 +33,8 @@ type Runner struct {
 	writable         []string
 	defaultMaxOutput int64
 	processes        sandbox.ProcessManager
+	decision         func(httpkit.ProxyDecision)
+	hooks            mitm.ProxyHooks
 }
 
 // New constructs a Seatbelt Runner rooted at rootDir.
@@ -73,6 +77,8 @@ func New(rootDir string, opts ...RunnerOption) (*Runner, error) {
 		binary:           binary,
 		writable:         dedupe(writable),
 		defaultMaxOutput: defaultMaxOutputBytes,
+		decision:         cfg.decision,
+		hooks:            cfg.hooks,
 	}
 	runner.processes = sandbox.NewProcessRegistry(runner.spawnProcess)
 	return runner, nil
@@ -92,6 +98,8 @@ func (r *Runner) Enforcement() sandbox.Enforcement {
 			sandbox.NetAllowList,
 			sandbox.NetProxy,
 		},
+		Socks5:           true,
+		MITM:             true,
 		MemoryCap:        caps,
 		CPUCap:           caps,
 		FilesystemBounds: true,
@@ -102,6 +110,10 @@ func (r *Runner) Enforcement() sandbox.Enforcement {
 func (r *Runner) Exec(ctx context.Context, cmd string, args []string, opts sandbox.ExecOptions) (*sandbox.ExecResult, error) {
 	if cmd == "" {
 		return nil, errdefs.Validationf("seatbelt: empty command")
+	}
+	if len(opts.Net.UnixSockets) > 0 {
+		return nil, errdefs.NotAvailablef(
+			"seatbelt: unix socket allow-list is not supported (SBPL does not confine unix sockets)")
 	}
 	if err := sandbox.ValidateExecPolicy(opts); err != nil {
 		return nil, err
@@ -123,8 +135,12 @@ func (r *Runner) Exec(ctx context.Context, cmd string, args []string, opts sandb
 		proxy, err = httpkit.Start(httpkit.ProxyConfig{
 			Mode:        opts.Net.Mode,
 			AllowHosts:  opts.Net.AllowHosts,
+			Rules:       opts.Net.Rules,
 			Upstream:    opts.Net.Proxy,
 			TCPLoopback: true,
+			MITM:        opts.Net.MITM,
+			OnDecision:  r.decision,
+			Hooks:       r.hooks,
 		})
 		if err != nil {
 			return nil, errdefs.Internalf("seatbelt: start enforcement proxy: %v", err)
@@ -135,6 +151,20 @@ func (r *Runner) Exec(ctx context.Context, cmd string, args []string, opts sandb
 			return nil, errdefs.Internalf("seatbelt: proxy bound %T, want TCP loopback", proxy.Addr())
 		}
 		proxyPort = addr.Port
+	}
+
+	var bundlePath string
+	var bundleCleanup func()
+	if opts.Net.MITM != nil && opts.Net.MITM.Enabled {
+		if proxy == nil {
+			return nil, errdefs.NotAvailablef(
+				"seatbelt: MITM requires allow_list or proxy net mode")
+		}
+		bundlePath, bundleCleanup, err = mitm.WriteBundle(proxy.CAPEM())
+		if err != nil {
+			return nil, errdefs.Internalf("seatbelt: write CA bundle: %v", err)
+		}
+		defer bundleCleanup()
 	}
 
 	profile, err := buildProfile(r.writable, opts.Net, proxyPort)
@@ -152,6 +182,9 @@ func (r *Runner) Exec(ctx context.Context, cmd string, args []string, opts sandb
 	c := exec.CommandContext(ctx, r.binary, argv...)
 	c.Dir = workDir
 	c.Env = buildEnv(opts.Env, proxyPort)
+	if bundlePath != "" {
+		c.Env = append(c.Env, "SSL_CERT_FILE="+bundlePath)
+	}
 	c.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
 	c.Cancel = func() error {
 		if c.Process == nil {
@@ -239,6 +272,10 @@ func (r *Runner) spawnProcess(ctx context.Context, spec sandbox.ProcessSpec) (sa
 	if len(spec.Argv) == 0 {
 		return nil, errdefs.Validationf("seatbelt: empty command")
 	}
+	if len(spec.Opts.Net.UnixSockets) > 0 {
+		return nil, errdefs.NotAvailablef(
+			"seatbelt: unix socket allow-list is not supported (SBPL does not confine unix sockets)")
+	}
 	if err := sandbox.ValidateExecPolicy(spec.Opts); err != nil {
 		return nil, err
 	}
@@ -255,8 +292,12 @@ func (r *Runner) spawnProcess(ctx context.Context, spec sandbox.ProcessSpec) (sa
 		proxy, err = httpkit.Start(httpkit.ProxyConfig{
 			Mode:        spec.Opts.Net.Mode,
 			AllowHosts:  spec.Opts.Net.AllowHosts,
+			Rules:       spec.Opts.Net.Rules,
 			Upstream:    spec.Opts.Net.Proxy,
 			TCPLoopback: true,
+			MITM:        spec.Opts.Net.MITM,
+			OnDecision:  r.decision,
+			Hooks:       r.hooks,
 		})
 		if err != nil {
 			return nil, errdefs.Internalf("seatbelt: start enforcement proxy: %v", err)
@@ -269,11 +310,37 @@ func (r *Runner) spawnProcess(ctx context.Context, spec sandbox.ProcessSpec) (sa
 		proxyPort = addr.Port
 	}
 
+	var bundlePath string
+	var bundleCleanup func()
+	if spec.Opts.Net.MITM != nil && spec.Opts.Net.MITM.Enabled {
+		if proxy == nil {
+			return nil, errdefs.NotAvailablef(
+				"seatbelt: MITM requires allow_list or proxy net mode")
+		}
+		bundlePath, bundleCleanup, err = mitm.WriteBundle(proxy.CAPEM())
+		if err != nil {
+			_ = proxy.Close()
+			return nil, errdefs.Internalf("seatbelt: write CA bundle: %v", err)
+		}
+		if spec.Opts.Env.Inject == nil {
+			spec.Opts.Env.Inject = make(map[string]string)
+		} else {
+			spec.Opts.Env.Inject = maps.Clone(spec.Opts.Env.Inject)
+		}
+		spec.Opts.Env.Inject["SSL_CERT_FILE"] = bundlePath
+	}
+	abortBundle := func() {
+		if bundleCleanup != nil {
+			bundleCleanup()
+		}
+	}
+
 	profile, err := buildProfile(r.writable, spec.Opts.Net, proxyPort)
 	if err != nil {
 		if proxy != nil {
 			_ = proxy.Close()
 		}
+		abortBundle()
 		return nil, err
 	}
 
@@ -282,6 +349,9 @@ func (r *Runner) spawnProcess(ctx context.Context, spec sandbox.ProcessSpec) (sa
 	c := exec.Command(r.binary, argv...)
 	c.Dir = workDir
 	c.Env = buildEnv(spec.Opts.Env, proxyPort)
+	if bundlePath != "" {
+		c.Env = append(c.Env, "SSL_CERT_FILE="+bundlePath)
+	}
 
 	maxOut := spec.Opts.Resources.MaxOutputBytes
 	if maxOut <= 0 {
@@ -297,10 +367,14 @@ func (r *Runner) spawnProcess(ctx context.Context, spec sandbox.ProcessSpec) (sa
 		if proxy != nil {
 			_ = proxy.Close()
 		}
+		abortBundle()
 		return nil, err
 	}
 	if proxy != nil {
-		cleanup := &sessionCleanup{cleanup: func() { _ = proxy.Close() }}
+		cleanup := &sessionCleanup{cleanup: func() {
+			_ = proxy.Close()
+			abortBundle()
+		}}
 		go func() {
 			_, _ = proc.Wait(context.Background())
 			cleanup.once.Do(cleanup.cleanup)

--- a/sdkx/sandbox/seatbelt/runner_darwin.go
+++ b/sdkx/sandbox/seatbelt/runner_darwin.go
@@ -13,6 +13,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"sync"
 	"syscall"
 	"time"
 
@@ -29,6 +30,7 @@ type Runner struct {
 	binary           string
 	writable         []string
 	defaultMaxOutput int64
+	processes        sandbox.ProcessManager
 }
 
 // New constructs a Seatbelt Runner rooted at rootDir.
@@ -66,12 +68,14 @@ func New(rootDir string, opts ...RunnerOption) (*Runner, error) {
 		writable = append(writable, resolved)
 	}
 
-	return &Runner{
+	runner := &Runner{
 		rootDir:          root,
 		binary:           binary,
 		writable:         dedupe(writable),
 		defaultMaxOutput: defaultMaxOutputBytes,
-	}, nil
+	}
+	runner.processes = sandbox.NewProcessRegistry(runner.spawnProcess)
+	return runner, nil
 }
 
 // Enforcement reports the policy dimensions Seatbelt plus the shared
@@ -99,24 +103,8 @@ func (r *Runner) Exec(ctx context.Context, cmd string, args []string, opts sandb
 	if cmd == "" {
 		return nil, errdefs.Validationf("seatbelt: empty command")
 	}
-	if opts.Resources.DiskBytes != 0 {
-		return nil, errdefs.NotAvailablef(
-			"seatbelt: disk limits not supported (no quota mechanism)",
-		)
-	}
-	if opts.Resources.CPUMillicores != 0 && opts.Timeout <= 0 {
-		return nil, errdefs.NotAvailablef(
-			"seatbelt: CPUMillicores requires a per-call Timeout to derive a cpu-time cap",
-		)
-	}
-	// Memory and cpu caps ride on the shared sampling watcher, not on
-	// the Seatbelt profile. Where that watcher cannot sample, honouring
-	// the call would run the child with no cap at all, so reject it
-	// instead of pretending.
-	if (opts.Resources.MemoryBytes > 0 || opts.Resources.CPUMillicores > 0) && !sandbox.GroupCapsSupported() {
-		return nil, errdefs.NotAvailablef(
-			"seatbelt: resource limits require process-group sampling, which is unavailable here",
-		)
+	if err := sandbox.ValidateExecPolicy(opts); err != nil {
+		return nil, err
 	}
 
 	workDir, err := r.resolveWorkDir(opts.WorkDir)
@@ -223,6 +211,121 @@ func (r *Runner) Exec(ctx context.Context, cmd string, args []string, opts sandb
 		return result, classifyStartError(cmd, runErr)
 	}
 	return result, nil
+}
+
+// Start implements sandbox.ProcessManager. The session runs inside the
+// same generated Seatbelt profile as Exec; the enforcement proxy, when
+// NetAllowList / NetProxy needs one, is owned by the session and closed
+// when the session exits or is closed.
+func (r *Runner) Start(ctx context.Context, spec sandbox.ProcessSpec) (sandbox.Process, error) {
+	return r.processes.Start(ctx, spec)
+}
+
+// List implements sandbox.ProcessManager.
+func (r *Runner) List(ctx context.Context) ([]sandbox.ProcessInfo, error) {
+	return r.processes.List(ctx)
+}
+
+// Terminate implements sandbox.ProcessManager.
+func (r *Runner) Terminate(ctx context.Context, id string) error {
+	return r.processes.Terminate(ctx, id)
+}
+
+// spawnProcess is the Runner's sandbox.ProcessStarter. It mirrors Exec:
+// same policy validation, same profile, same proxy wiring — but the
+// stdio is owned by the shared session implementation instead of being
+// captured into an ExecResult.
+func (r *Runner) spawnProcess(ctx context.Context, spec sandbox.ProcessSpec) (sandbox.Process, error) {
+	if len(spec.Argv) == 0 {
+		return nil, errdefs.Validationf("seatbelt: empty command")
+	}
+	if err := sandbox.ValidateExecPolicy(spec.Opts); err != nil {
+		return nil, err
+	}
+
+	workDir, err := r.resolveWorkDir(spec.Opts.WorkDir)
+	if err != nil {
+		return nil, err
+	}
+
+	proxyMode := spec.Opts.Net.Mode == sandbox.NetAllowList || spec.Opts.Net.Mode == sandbox.NetProxy
+	var proxy *httpkit.Proxy
+	proxyPort := 0
+	if proxyMode {
+		proxy, err = httpkit.Start(httpkit.ProxyConfig{
+			Mode:        spec.Opts.Net.Mode,
+			AllowHosts:  spec.Opts.Net.AllowHosts,
+			Upstream:    spec.Opts.Net.Proxy,
+			TCPLoopback: true,
+		})
+		if err != nil {
+			return nil, errdefs.Internalf("seatbelt: start enforcement proxy: %v", err)
+		}
+		addr, ok := proxy.Addr().(*net.TCPAddr)
+		if !ok {
+			_ = proxy.Close()
+			return nil, errdefs.Internalf("seatbelt: proxy bound %T, want TCP loopback", proxy.Addr())
+		}
+		proxyPort = addr.Port
+	}
+
+	profile, err := buildProfile(r.writable, spec.Opts.Net, proxyPort)
+	if err != nil {
+		if proxy != nil {
+			_ = proxy.Close()
+		}
+		return nil, err
+	}
+
+	argv := []string{"-p", profile, spec.Argv[0]}
+	argv = append(argv, spec.Argv[1:]...)
+	c := exec.Command(r.binary, argv...)
+	c.Dir = workDir
+	c.Env = buildEnv(spec.Opts.Env, proxyPort)
+
+	maxOut := spec.Opts.Resources.MaxOutputBytes
+	if maxOut <= 0 {
+		maxOut = r.defaultMaxOutput
+	}
+	if maxOut <= 0 {
+		maxOut = math.MaxInt64
+	}
+	spec.Opts.Resources.MaxOutputBytes = maxOut
+
+	proc, err := sandbox.StartSession(ctx, c, spec.Opts, spec.TTY, spec.Rows, spec.Cols)
+	if err != nil {
+		if proxy != nil {
+			_ = proxy.Close()
+		}
+		return nil, err
+	}
+	if proxy != nil {
+		cleanup := &sessionCleanup{cleanup: func() { _ = proxy.Close() }}
+		go func() {
+			_, _ = proc.Wait(context.Background())
+			cleanup.once.Do(cleanup.cleanup)
+		}()
+		return &sessionProcess{Process: proc, cleanup: cleanup}, nil
+	}
+	return proc, nil
+}
+
+// sessionProcess keeps a sandbox.Process's side resources (the
+// enforcement proxy) alive for exactly as long as the session.
+type sessionProcess struct {
+	sandbox.Process
+	cleanup *sessionCleanup
+}
+
+func (p *sessionProcess) Close() error {
+	err := p.Process.Close()
+	p.cleanup.once.Do(p.cleanup.cleanup)
+	return err
+}
+
+type sessionCleanup struct {
+	once    sync.Once
+	cleanup func()
 }
 
 func (r *Runner) resolveWorkDir(dir string) (string, error) {

--- a/sdkx/sandbox/seatbelt/runner_darwin.go
+++ b/sdkx/sandbox/seatbelt/runner_darwin.go
@@ -5,6 +5,7 @@ package seatbelt
 import (
 	"bytes"
 	"context"
+	"crypto/x509"
 	"errors"
 	"fmt"
 	"maps"
@@ -35,6 +36,7 @@ type Runner struct {
 	processes        sandbox.ProcessManager
 	decision         func(httpkit.ProxyDecision)
 	hooks            mitm.ProxyHooks
+	outboundRoots    *x509.CertPool
 }
 
 // New constructs a Seatbelt Runner rooted at rootDir.
@@ -79,6 +81,7 @@ func New(rootDir string, opts ...RunnerOption) (*Runner, error) {
 		defaultMaxOutput: defaultMaxOutputBytes,
 		decision:         cfg.decision,
 		hooks:            cfg.hooks,
+		outboundRoots:    cfg.roots,
 	}
 	runner.processes = sandbox.NewProcessRegistry(runner.spawnProcess)
 	return runner, nil
@@ -133,14 +136,15 @@ func (r *Runner) Exec(ctx context.Context, cmd string, args []string, opts sandb
 	proxyPort := 0
 	if proxyMode {
 		proxy, err = httpkit.Start(httpkit.ProxyConfig{
-			Mode:        opts.Net.Mode,
-			AllowHosts:  opts.Net.AllowHosts,
-			Rules:       opts.Net.Rules,
-			Upstream:    opts.Net.Proxy,
-			TCPLoopback: true,
-			MITM:        opts.Net.MITM,
-			OnDecision:  r.decision,
-			Hooks:       r.hooks,
+			Mode:          opts.Net.Mode,
+			AllowHosts:    opts.Net.AllowHosts,
+			Rules:         opts.Net.Rules,
+			Upstream:      opts.Net.Proxy,
+			TCPLoopback:   true,
+			MITM:          opts.Net.MITM,
+			OnDecision:    r.decision,
+			Hooks:         r.hooks,
+			OutboundRoots: r.outboundRoots,
 		})
 		if err != nil {
 			return nil, errdefs.Internalf("seatbelt: start enforcement proxy: %v", err)
@@ -290,14 +294,15 @@ func (r *Runner) spawnProcess(ctx context.Context, spec sandbox.ProcessSpec) (sa
 	proxyPort := 0
 	if proxyMode {
 		proxy, err = httpkit.Start(httpkit.ProxyConfig{
-			Mode:        spec.Opts.Net.Mode,
-			AllowHosts:  spec.Opts.Net.AllowHosts,
-			Rules:       spec.Opts.Net.Rules,
-			Upstream:    spec.Opts.Net.Proxy,
-			TCPLoopback: true,
-			MITM:        spec.Opts.Net.MITM,
-			OnDecision:  r.decision,
-			Hooks:       r.hooks,
+			Mode:          spec.Opts.Net.Mode,
+			AllowHosts:    spec.Opts.Net.AllowHosts,
+			Rules:         spec.Opts.Net.Rules,
+			Upstream:      spec.Opts.Net.Proxy,
+			TCPLoopback:   true,
+			MITM:          spec.Opts.Net.MITM,
+			OnDecision:    r.decision,
+			Hooks:         r.hooks,
+			OutboundRoots: r.outboundRoots,
 		})
 		if err != nil {
 			return nil, errdefs.Internalf("seatbelt: start enforcement proxy: %v", err)
@@ -362,7 +367,7 @@ func (r *Runner) spawnProcess(ctx context.Context, spec sandbox.ProcessSpec) (sa
 	}
 	spec.Opts.Resources.MaxOutputBytes = maxOut
 
-	proc, err := sandbox.StartSession(ctx, c, spec.Opts, spec.TTY, spec.Rows, spec.Cols)
+	proc, err := sandbox.StartSession(ctx, spec, c)
 	if err != nil {
 		if proxy != nil {
 			_ = proxy.Close()

--- a/sdkx/sandbox/seatbelt/runner_darwin_test.go
+++ b/sdkx/sandbox/seatbelt/runner_darwin_test.go
@@ -96,6 +96,9 @@ func TestRunner_UnsupportedPolicies(t *testing.T) {
 		"unknown-net-mode": {
 			Net: sandbox.NetPolicy{Mode: sandbox.NetMode(99)},
 		},
+		"unix sockets": {
+			Net: sandbox.NetPolicy{UnixSockets: []string{"/tmp/test.sock"}},
+		},
 	} {
 		t.Run(name, func(t *testing.T) {
 			_, err := runner.Exec(context.Background(), "/usr/bin/true", nil, opts)
@@ -240,6 +243,62 @@ func TestRunner_ProcessManager_PolicyRejected(t *testing.T) {
 	})
 	if !errdefs.IsNotAvailable(err) {
 		t.Fatalf("disk-limit Start = %v, want NotAvailable", err)
+	}
+}
+
+func TestRunner_Enforcement_ProxyFeatures(t *testing.T) {
+	runner, err := New(t.TempDir())
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	e := runner.Enforcement()
+	if !e.Socks5 || !e.MITM {
+		t.Errorf("seatbelt proxy supports socks5 + MITM host-side, got Socks5=%v MITM=%v", e.Socks5, e.MITM)
+	}
+	if e.UnixSocketPolicy {
+		t.Error("seatbelt must not claim unix socket policy (SBPL does not confine unix sockets)")
+	}
+}
+
+func TestRunner_ProcessManager_UnixSocketsNotAvailable(t *testing.T) {
+	runner, err := New(t.TempDir())
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	_, err = runner.Start(context.Background(), sandbox.ProcessSpec{
+		Argv: []string{"/usr/bin/true"},
+		Opts: sandbox.ExecOptions{Net: sandbox.NetPolicy{
+			UnixSockets: []string{"/tmp/test.sock"},
+		}},
+	})
+	if !errdefs.IsNotAvailable(err) {
+		t.Fatalf("unix socket policy Start = %v, want NotAvailable", err)
+	}
+}
+
+func TestRunner_ProcessManager_MITMStart(t *testing.T) {
+	runner, err := New(t.TempDir())
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	proc, err := runner.Start(context.Background(), sandbox.ProcessSpec{
+		Argv: []string{"/usr/bin/true"},
+		Opts: sandbox.ExecOptions{Net: sandbox.NetPolicy{
+			Mode:       sandbox.NetAllowList,
+			AllowHosts: []string{"example.com"},
+			MITM:       &sandbox.MITMPolicy{Enabled: true},
+		}},
+	})
+	if err != nil {
+		t.Fatalf("Start with MITM: %v", err)
+	}
+	defer func() { _ = proc.Close() }()
+	exit, err := proc.Wait(context.Background())
+	if err != nil {
+		t.Fatalf("Wait: %v", err)
+	}
+	if exit.Code != 0 {
+		t.Fatalf("exit = %+v, want 0", exit)
 	}
 }
 

--- a/sdkx/sandbox/seatbelt/runner_darwin_test.go
+++ b/sdkx/sandbox/seatbelt/runner_darwin_test.go
@@ -137,6 +137,112 @@ func TestRunner_FilesystemWriteBound(t *testing.T) {
 	}
 }
 
+func TestRunner_ProcessManager_PipeSession(t *testing.T) {
+	runner, err := New(t.TempDir())
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	proc, err := runner.Start(context.Background(), sandbox.ProcessSpec{
+		Argv: []string{"/bin/sh", "-c", "printf OUT; printf ERR >&2; exit 7"},
+	})
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer func() { _ = proc.Close() }()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	var stdout, stderr strings.Builder
+	var seq int64
+	for {
+		out, err := proc.Read(ctx, seq, 4096)
+		if err != nil {
+			t.Fatalf("Read: %v", err)
+		}
+		for _, ch := range out.Chunks {
+			switch ch.Stream {
+			case sandbox.ProcessStreamStdout:
+				stdout.Write(ch.Data)
+			case sandbox.ProcessStreamStderr:
+				stderr.Write(ch.Data)
+			}
+		}
+		seq = out.NextSeq
+		if out.EOF {
+			break
+		}
+	}
+	if stdout.String() != "OUT" || stderr.String() != "ERR" {
+		t.Fatalf("stdout=%q stderr=%q, want OUT/ERR", stdout.String(), stderr.String())
+	}
+	exit, err := proc.Wait(ctx)
+	if err != nil {
+		t.Fatalf("Wait: %v", err)
+	}
+	if exit.Code != 7 || exit.Reason != sandbox.ProcessExited {
+		t.Fatalf("exit = %+v, want exited(7)", exit)
+	}
+}
+
+func TestRunner_ProcessManager_TTYSession(t *testing.T) {
+	runner, err := New(t.TempDir())
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	proc, err := runner.Start(context.Background(), sandbox.ProcessSpec{
+		Argv: []string{"/bin/sh"},
+		TTY:  true,
+	})
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer func() { _ = proc.Close() }()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	if err := proc.Write(ctx, []byte("printf ok\n")); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	var sb strings.Builder
+	var seq int64
+	for !strings.Contains(sb.String(), "ok") {
+		out, err := proc.Read(ctx, seq, 4096)
+		if err != nil {
+			t.Fatalf("Read: %v", err)
+		}
+		for _, ch := range out.Chunks {
+			sb.Write(ch.Data)
+		}
+		seq = out.NextSeq
+		if out.EOF {
+			break
+		}
+	}
+	if !strings.Contains(sb.String(), "ok") {
+		t.Fatalf("TTY output missing 'ok': %q", sb.String())
+	}
+	if err := proc.Write(ctx, []byte("exit\n")); err != nil {
+		t.Fatalf("Write exit: %v", err)
+	}
+	if exit, err := proc.Wait(ctx); err != nil || exit.Code != 0 {
+		t.Fatalf("Wait = %+v, %v; want exited(0)", exit, err)
+	}
+}
+
+func TestRunner_ProcessManager_PolicyRejected(t *testing.T) {
+	runner, err := New(t.TempDir())
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	_, err = runner.Start(context.Background(), sandbox.ProcessSpec{
+		Argv: []string{"/usr/bin/true"},
+		Opts: sandbox.ExecOptions{Resources: sandbox.ResourceLimits{DiskBytes: 1}},
+	})
+	if !errdefs.IsNotAvailable(err) {
+		t.Fatalf("disk-limit Start = %v, want NotAvailable", err)
+	}
+}
+
 func TestBuildEnv_ProxyModeInjectsAndStrips(t *testing.T) {
 	t.Setenv("HTTP_PROXY", "http://host-proxy:3128")
 	t.Setenv("NO_PROXY", "localhost")

--- a/sdkx/sandbox/seatbelt/runner_other.go
+++ b/sdkx/sandbox/seatbelt/runner_other.go
@@ -31,3 +31,19 @@ func (*Runner) Exec(ctx context.Context, cmd string, args []string, opts sandbox
 func (*Runner) Enforcement() sandbox.Enforcement {
 	return sandbox.Enforcement{}
 }
+
+// Start is unreachable because New cannot construct a Runner.
+func (*Runner) Start(ctx context.Context, spec sandbox.ProcessSpec) (sandbox.Process, error) {
+	_, _ = ctx, spec
+	return nil, errdefs.NotAvailablef("seatbelt: not available on this platform")
+}
+
+// List is unreachable outside macOS.
+func (*Runner) List(context.Context) ([]sandbox.ProcessInfo, error) {
+	return nil, errdefs.NotAvailablef("seatbelt: not available on this platform")
+}
+
+// Terminate is unreachable outside macOS.
+func (*Runner) Terminate(context.Context, string) error {
+	return errdefs.NotAvailablef("seatbelt: not available on this platform")
+}

--- a/sdkx/tool/exec/doc.go
+++ b/sdkx/tool/exec/doc.go
@@ -71,7 +71,7 @@
 // output with a sequence cursor:
 //
 //	{
-//	  "action":          "start|read|write|resize|status|terminate|close",
+//	  "action":          "start|read|write|resize|status|signal|terminate|close",
 //	  "session_id":      "session id from start (all actions except start)",
 //	  "command":         "program to run (start)",
 //	  "args":            ["arg", ...],
@@ -82,7 +82,8 @@
 //	  "timeout_seconds": 300,
 //	  "after_seq":       0,
 //	  "max_bytes":       4096,
-//	  "data":            "input to write"
+//	  "data":            "input to write",
+//	  "signal":          "interrupt (signal action)"
 //	}
 //
 // read returns {"next_seq", "eof", "chunks":[{"seq","stream","data"}]}

--- a/sdkx/tool/exec/doc.go
+++ b/sdkx/tool/exec/doc.go
@@ -1,22 +1,24 @@
-// Package exec ships the LLM-callable "exec" tool: a generic shell
-// command runner over [sandbox.Runner]. It is the missing piece that
-// turns coding-agent style harnesses (SWE-bench, Terminal-Bench)
-// into something the model can drive end-to-end — the model emits
-// `exec(command, args...)`, the tool delegates to a sandboxed
-// runner, and the captured stdout/stderr/exit_code surfaces back as
-// the tool result.
+// Package exec ships the LLM-callable command tools: "exec", a
+// one-shot shell command runner over [sandbox.Runner], and
+// "exec_session", an interactive / streaming session driver over
+// [sandbox.ProcessManager]. Together they turn coding-agent style
+// harnesses (SWE-bench, Terminal-Bench) into something the model can
+// drive end-to-end — the model emits `exec(command, args...)` or
+// `exec_session(action, session_id, ...)`, the tool delegates to a
+// sandboxed runner, and output surfaces back as the tool result.
 //
 // # Primitive category: sandbox boundary
 //
-// This tool ships built-in because it *is* the execution boundary. An
-// out-of-process MCP server cannot supply it: the point of exec is to
-// run a command under the host's own [sandbox.Runner], honouring that
-// runner's isolation, approval, and resource policy. A remote server
-// would run commands in its own environment under its own rules,
-// which is a different capability wearing the same name. See
-// sdkx/tool's package doc for the boundary this sits on; hosts wanting
-// command execution *somewhere else* should attach an MCP server for
-// that environment instead.
+// These tools ship built-in because they *are* the execution boundary.
+// An out-of-process MCP server cannot supply them: the point of exec
+// and exec_session is to run a command under the host's own
+// [sandbox.Runner] / [sandbox.ProcessManager], honouring that runner's
+// isolation, approval, and resource policy. A remote server would run
+// commands in its own environment under its own rules, which is a
+// different capability wearing the same name. See sdkx/tool's package
+// doc for the boundary this sits on; hosts wanting command execution
+// *somewhere else* should attach an MCP server for that environment
+// instead.
 //
 // # Why sdkx
 //
@@ -28,13 +30,14 @@
 //
 // # Deny-by-default
 //
-// [New] requires a non-nil [sandbox.Runner]. Callers cannot
-// construct an exec tool that "falls back to host shell" by leaving
-// the runner empty; that bypass would defeat the whole point of
-// sdk/sandbox. The mistake is caught at wiring time
-// (errdefs.Validation), not at the first LLM call. If you genuinely
-// want a no-op for tests, pass [sandbox.NoopRunner]{} or build a
-// runner with [sandbox.AllowCommands] around an empty whitelist.
+// [New] requires a non-nil [sandbox.Runner] and [NewSession] requires
+// a non-nil [sandbox.ProcessManager]. Callers cannot construct a tool
+// that "falls back to host shell" by leaving the runner empty; that
+// bypass would defeat the whole point of sdk/sandbox. The mistake is
+// caught at wiring time (errdefs.Validation), not at the first LLM
+// call. If you genuinely want a no-op for tests, pass
+// [sandbox.NoopRunner]{} or build a runner with
+// [sandbox.AllowCommands] around an empty whitelist.
 //
 // # Wire shape
 //
@@ -62,12 +65,40 @@
 // all (validation failure, sandbox policy rejection, timeout, IO
 // error from the runner).
 //
+// # exec_session wire shape
+//
+// The session tool keeps a process alive across calls and replays its
+// output with a sequence cursor:
+//
+//	{
+//	  "action":          "start|read|write|resize|status|terminate|close",
+//	  "session_id":      "session id from start (all actions except start)",
+//	  "command":         "program to run (start)",
+//	  "args":            ["arg", ...],
+//	  "workdir":         "relative to the sandbox root",
+//	  "tty":             false,
+//	  "rows":            24,
+//	  "cols":            80,
+//	  "timeout_seconds": 300,
+//	  "after_seq":       0,
+//	  "max_bytes":       4096,
+//	  "data":            "input to write"
+//	}
+//
+// read returns {"next_seq", "eof", "chunks":[{"seq","stream","data"}]}
+// with stream "stdout", "stderr", or "tty" (merged). status returns
+// {"running", "exit_code", "reason", "signal", "pid", "tty", "argv"}.
+// Policy is fixed once at start; an interactive session is an
+// all-or-nothing command channel. Idle sessions are reclaimed by a
+// TTL (default 30 minutes, configurable via [WithSessionTTL]) and all
+// sessions are terminated by [SessionTool.Close].
+//
 // # Relationship to sandbox policy
 //
 // The tool itself carries zero policy; everything (env allow-list,
-// network mode, resource caps, output truncation, command
-// whitelist) lives in the injected [sandbox.Runner]. To restrict
-// what the LLM can run, compose the runner before passing it in:
+// network mode, resource caps, output truncation, command whitelist,
+// approval) lives in the injected runner. To restrict what the LLM can
+// run, compose the runner before passing it in:
 //
 //	rn := sandbox.AllowCommands(
 //	    sandbox.NewLocalRunner(workdir, sandbox.WithMaxOutputBytes(1<<20)),
@@ -75,8 +106,13 @@
 //	)
 //	t, err := exec.New(rn)
 //
-// The same sandbox can be shared with the script-engine shell
-// bridge, host-application sandbox resources, and any
-// future sdkx/sandbox/{bwrap,container,microvm} backend without
-// changing this tool's call site.
+// The decorators forward [sandbox.ProcessManager] too, so the same
+// composed chain powers exec_session:
+//
+//	pm := sandbox.ProcessManagerOf(rn)
+//	st, err := exec.NewSession(pm)
+//
+// The same sandbox can be shared with the script-engine shell bridge,
+// host-application sandbox resources, and the sdkx/sandbox/{seatbelt,
+// bwrap} backends without changing these tools' call sites.
 package exec

--- a/sdkx/tool/exec/session.go
+++ b/sdkx/tool/exec/session.go
@@ -1,0 +1,495 @@
+package exec
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/GizClaw/flowcraft/sdk/errdefs"
+	"github.com/GizClaw/flowcraft/sdk/message"
+	"github.com/GizClaw/flowcraft/sdk/sandbox"
+	"github.com/GizClaw/flowcraft/sdk/tool"
+)
+
+// SessionName is the canonical tool id of the interactive session
+// driver, registered alongside [Name] by hosts that want one.
+const SessionName = "exec_session"
+
+const (
+	defaultMaxBytes   = 4096
+	maxReadBytes      = 1 << 20
+	defaultSessionTTL = 30 * time.Minute
+)
+
+// SessionTool is the LLM-callable session driver. It holds the tool's
+// own session registry (the injected ProcessManager tracks processes;
+// the tool tracks which sessions this LLM context owns). Safe for
+// concurrent use; call Close when the host shuts down so no session
+// outlives the tool.
+type SessionTool struct {
+	pm             sandbox.ProcessManager
+	defaultTimeout time.Duration
+	ttl            time.Duration
+
+	mu       sync.Mutex
+	sessions map[string]*sessionState
+	closed   bool
+
+	stopCh   chan struct{}
+	stopOnce sync.Once
+	wg       sync.WaitGroup
+}
+
+type sessionState struct {
+	proc     sandbox.Process
+	lastUsed time.Time
+}
+
+// SessionOption configures a [SessionTool] at construction time.
+type SessionOption func(*SessionTool)
+
+// WithSessionDefaultTimeout sets the sandbox session-lifetime timeout
+// used when start does not supply timeout_seconds. Zero means "no
+// tool-imposed default" — the session runs until it exits, is
+// terminated, or is closed. Negative values are treated as zero.
+func WithSessionDefaultTimeout(d time.Duration) SessionOption {
+	return func(t *SessionTool) {
+		if d > 0 {
+			t.defaultTimeout = d
+		}
+	}
+}
+
+// WithSessionTTL sets how long an idle session is kept before the
+// tool terminates it. Defaults to 30 minutes. Pass a non-positive
+// value to disable expiry (sessions then live until close / process
+// exit).
+func WithSessionTTL(d time.Duration) SessionOption {
+	return func(t *SessionTool) {
+		t.ttl = d
+	}
+}
+
+// NewSession constructs the exec_session tool. pm MUST be non-nil:
+// there is no host-shell fallback and no silent downgrade to one-shot
+// Exec.
+func NewSession(pm sandbox.ProcessManager, opts ...SessionOption) (*SessionTool, error) {
+	if pm == nil {
+		return nil, errdefs.Validationf(
+			"exec_session: sandbox.ProcessManager is required; use sandbox.ProcessManagerOf(runner) to discover it")
+	}
+	t := &SessionTool{
+		pm:       pm,
+		ttl:      defaultSessionTTL,
+		sessions: make(map[string]*sessionState),
+		stopCh:   make(chan struct{}),
+	}
+	for _, o := range opts {
+		o(t)
+	}
+	if t.ttl > 0 {
+		t.wg.Add(1)
+		go t.reapLoop()
+	}
+	return t, nil
+}
+
+// MustNewSession is the panic-on-error variant of [NewSession].
+func MustNewSession(pm sandbox.ProcessManager, opts ...SessionOption) *SessionTool {
+	t, err := NewSession(pm, opts...)
+	if err != nil {
+		panic(err)
+	}
+	return t
+}
+
+// Close stops the idle reaper and terminates every session the tool
+// owns, so no child process outlives the host. Close is idempotent;
+// after Close, Execute returns NotAvailable.
+func (t *SessionTool) Close() error {
+	t.stopOnce.Do(func() { close(t.stopCh) })
+	t.wg.Wait()
+
+	t.mu.Lock()
+	if t.closed {
+		t.mu.Unlock()
+		return nil
+	}
+	t.closed = true
+	sessions := t.sessions
+	t.sessions = make(map[string]*sessionState)
+	t.mu.Unlock()
+
+	for _, s := range sessions {
+		_ = s.proc.Close()
+	}
+	return nil
+}
+
+// Definition returns the model-facing schema.
+func (t *SessionTool) Definition() message.Definition {
+	return message.DefineSchema(
+		SessionName,
+		"Start and drive an interactive or streaming process session "+
+			"inside the agent's sandbox. Sessions keep running between "+
+			"calls and output is replayed with a sequence cursor "+
+			"(after_seq / next_seq), so you can drive REPLs, TUIs, and "+
+			"long-running processes step by step. Policy (env, network, "+
+			"resources, approval) is fixed at start; an interactive "+
+			"session is an all-or-nothing command channel, so prefer "+
+			"the exec tool for one-shot commands.",
+		message.ToolEnumProperty("action", "string",
+			"Operation to perform. start creates a session and returns its session_id; read returns buffered output from after_seq; write sends input bytes; resize sets the pty window size; status reports whether the session is still running and its exit; terminate stops the process (output stays readable until close); close frees the session.",
+			"start", "read", "write", "resize", "status", "terminate", "close"),
+		message.ToolProperty("session_id", "string",
+			"Session id returned by start. Required for every action except start."),
+		message.ToolProperty("command", "string",
+			"The program to run (required for start). Resolved against the sandbox's PATH policy."),
+		message.ToolArrayProperty("args",
+			"Arguments passed verbatim to the program (start).",
+			message.Items("string")),
+		message.ToolProperty("workdir", "string",
+			"Working directory, relative to the sandbox root (start). Empty means the sandbox root itself."),
+		message.ToolProperty("tty", "boolean",
+			"Request a pseudo-terminal (start). TTY sessions merge stdout/stderr into one stream and support resize."),
+		message.ToolProperty("rows", "integer",
+			"Pty rows (start / resize). Positive; defaults to 24."),
+		message.ToolProperty("cols", "integer",
+			"Pty columns (start / resize). Positive; defaults to 80."),
+		message.ToolProperty("timeout_seconds", "number",
+			"Session-lifetime timeout in seconds (start). Falls back to the tool's default when omitted; zero or negative disables the sandbox-imposed timeout."),
+		message.ToolProperty("after_seq", "integer",
+			"Read cursor: return output after this sequence number (read). Omit to read from the beginning."),
+		message.ToolProperty("max_bytes", "integer",
+			"Maximum bytes to return in one read. Defaults to 4096, capped at 1048576."),
+		message.ToolProperty("data", "string",
+			"Input bytes to write to the process (write)."),
+	).Required("action").DisallowAdditionalProperties().Build()
+}
+
+// Metadata implements [tool.ToolMetadata]. Sessions execute arbitrary
+// sandboxed commands, so the tool mutates state.
+func (t *SessionTool) Metadata() tool.ToolMeta {
+	return tool.ToolMeta{MutatesState: true}
+}
+
+// sessionArgs is the wire-side input. Pointer fields distinguish
+// "omitted" from "zero value" where that matters.
+type sessionArgs struct {
+	Action         string   `json:"action"`
+	SessionID      string   `json:"session_id"`
+	Command        string   `json:"command"`
+	Args           []string `json:"args"`
+	Workdir        string   `json:"workdir"`
+	TTY            bool     `json:"tty"`
+	Rows           int      `json:"rows"`
+	Cols           int      `json:"cols"`
+	TimeoutSeconds *float64 `json:"timeout_seconds"`
+	AfterSeq       *int64   `json:"after_seq"`
+	MaxBytes       *int     `json:"max_bytes"`
+	Data           string   `json:"data"`
+}
+
+// Execute implements [tool.Tool]. It parses the action, dispatches to
+// the session manager, and JSON-encodes the result. Sandbox and
+// session errors are forwarded with their errdefs classification so
+// callers can react without parsing strings.
+func (t *SessionTool) Execute(ctx context.Context, arguments string) (string, error) {
+	var a sessionArgs
+	if err := json.Unmarshal([]byte(arguments), &a); err != nil {
+		return "", errdefs.Validationf("exec_session: parse arguments: %v", err)
+	}
+
+	t.mu.Lock()
+	closed := t.closed
+	t.mu.Unlock()
+	if closed {
+		return "", errdefs.NotAvailablef("exec_session: tool is closed")
+	}
+
+	switch a.Action {
+	case "start", "":
+		return t.start(ctx, a)
+	case "read":
+		return t.read(ctx, a)
+	case "write":
+		return t.write(ctx, a)
+	case "resize":
+		return t.resize(ctx, a)
+	case "status":
+		return t.status(ctx, a)
+	case "terminate":
+		return t.terminate(ctx, a)
+	case "close":
+		return t.close(ctx, a)
+	default:
+		return "", errdefs.Validationf(
+			"exec_session: unknown action %q (start|read|write|resize|status|terminate|close)", a.Action)
+	}
+}
+
+func (t *SessionTool) start(ctx context.Context, a sessionArgs) (string, error) {
+	if strings.TrimSpace(a.Command) == "" {
+		return "", errdefs.Validationf("exec_session: command must be non-empty")
+	}
+	argv := append([]string{a.Command}, a.Args...)
+	proc, err := t.pm.Start(ctx, sandbox.ProcessSpec{
+		Argv: argv,
+		TTY:  a.TTY,
+		Rows: a.Rows,
+		Cols: a.Cols,
+		Opts: sandbox.ExecOptions{
+			WorkDir: a.Workdir,
+			Timeout: t.resolveSessionTimeout(a.TimeoutSeconds),
+		},
+	})
+	if err != nil {
+		return "", err
+	}
+
+	t.mu.Lock()
+	t.sessions[proc.ID()] = &sessionState{proc: proc, lastUsed: time.Now()}
+	t.mu.Unlock()
+
+	payload, err := json.Marshal(struct {
+		SessionID string `json:"session_id"`
+		PID       int    `json:"pid"`
+		TTY       bool   `json:"tty"`
+	}{
+		SessionID: proc.ID(),
+		PID:       proc.PID(),
+		TTY:       a.TTY,
+	})
+	if err != nil {
+		return "", errdefs.Internalf("exec_session: encode start result: %v", err)
+	}
+	return string(payload), nil
+}
+
+func (t *SessionTool) read(ctx context.Context, a sessionArgs) (string, error) {
+	s, err := t.lookup(a.SessionID)
+	if err != nil {
+		return "", err
+	}
+	var afterSeq int64
+	if a.AfterSeq != nil {
+		afterSeq = *a.AfterSeq
+	}
+	maxBytes := defaultMaxBytes
+	if a.MaxBytes != nil {
+		maxBytes = *a.MaxBytes
+	}
+	if maxBytes <= 0 {
+		return "", errdefs.Validationf("exec_session: max_bytes must be positive")
+	}
+	if maxBytes > maxReadBytes {
+		maxBytes = maxReadBytes
+	}
+
+	out, err := s.proc.Read(ctx, afterSeq, maxBytes)
+	if err != nil {
+		return "", classifySessionError(err)
+	}
+	chunks := make([]chunkResult, 0, len(out.Chunks))
+	for _, ch := range out.Chunks {
+		chunks = append(chunks, chunkResult{
+			Seq:    ch.Seq,
+			Stream: ch.Stream.String(),
+			Data:   string(ch.Data),
+		})
+	}
+	payload, err := json.Marshal(struct {
+		NextSeq int64         `json:"next_seq"`
+		EOF     bool          `json:"eof"`
+		Chunks  []chunkResult `json:"chunks"`
+	}{
+		NextSeq: out.NextSeq,
+		EOF:     out.EOF,
+		Chunks:  chunks,
+	})
+	if err != nil {
+		return "", errdefs.Internalf("exec_session: encode read result: %v", err)
+	}
+	return string(payload), nil
+}
+
+func (t *SessionTool) write(ctx context.Context, a sessionArgs) (string, error) {
+	s, err := t.lookup(a.SessionID)
+	if err != nil {
+		return "", err
+	}
+	if a.Data == "" {
+		return "", errdefs.Validationf("exec_session: data must not be empty")
+	}
+	if err := s.proc.Write(ctx, []byte(a.Data)); err != nil {
+		return "", classifySessionError(err)
+	}
+	return "{}", nil
+}
+
+func (t *SessionTool) resize(ctx context.Context, a sessionArgs) (string, error) {
+	s, err := t.lookup(a.SessionID)
+	if err != nil {
+		return "", err
+	}
+	if a.Rows <= 0 || a.Cols <= 0 {
+		return "", errdefs.Validationf("exec_session: rows and cols must be positive")
+	}
+	if err := s.proc.Resize(ctx, a.Rows, a.Cols); err != nil {
+		return "", classifySessionError(err)
+	}
+	return "{}", nil
+}
+
+func (t *SessionTool) status(ctx context.Context, a sessionArgs) (string, error) {
+	if _, err := t.lookup(a.SessionID); err != nil {
+		return "", err
+	}
+	infos, err := t.pm.List(ctx)
+	if err != nil {
+		return "", err
+	}
+	for _, info := range infos {
+		if info.ID != a.SessionID {
+			continue
+		}
+		out := struct {
+			Running  bool     `json:"running"`
+			ExitCode int      `json:"exit_code"`
+			Reason   string   `json:"reason"`
+			Signal   int      `json:"signal"`
+			PID      int      `json:"pid"`
+			TTY      bool     `json:"tty"`
+			Argv     []string `json:"argv"`
+		}{
+			Running: info.Running,
+			PID:     info.PID,
+			TTY:     info.TTY,
+			Argv:    info.Argv,
+		}
+		if info.Exit != nil {
+			out.ExitCode = info.Exit.Code
+			out.Reason = info.Exit.Reason.String()
+			out.Signal = info.Exit.Signal
+		}
+		payload, err := json.Marshal(out)
+		if err != nil {
+			return "", errdefs.Internalf("exec_session: encode status result: %v", err)
+		}
+		return string(payload), nil
+	}
+	return "", errdefs.NotFoundf("exec_session: session %q not found in manager", a.SessionID)
+}
+
+func (t *SessionTool) terminate(ctx context.Context, a sessionArgs) (string, error) {
+	if _, err := t.lookup(a.SessionID); err != nil {
+		return "", err
+	}
+	// Go through the manager so the exited state is recorded
+	// synchronously and status immediately reflects termination.
+	if err := t.pm.Terminate(ctx, a.SessionID); err != nil {
+		return "", err
+	}
+	return "{}", nil
+}
+
+func (t *SessionTool) close(ctx context.Context, a sessionArgs) (string, error) {
+	s, err := t.lookup(a.SessionID)
+	if err != nil {
+		return "", err
+	}
+	closeErr := s.proc.Close()
+	t.mu.Lock()
+	delete(t.sessions, a.SessionID)
+	t.mu.Unlock()
+	if closeErr != nil {
+		return "", classifySessionError(closeErr)
+	}
+	return "{}", nil
+}
+
+func (t *SessionTool) lookup(id string) (*sessionState, error) {
+	if id == "" {
+		return nil, errdefs.Validationf("exec_session: session_id is required")
+	}
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	s := t.sessions[id]
+	if s == nil {
+		return nil, errdefs.NotFoundf("exec_session: unknown session %q", id)
+	}
+	s.lastUsed = time.Now()
+	return s, nil
+}
+
+// resolveSessionTimeout maps the optional timeout_seconds knob to a
+// time.Duration, mirroring [Tool.resolveTimeout].
+func (t *SessionTool) resolveSessionTimeout(s *float64) time.Duration {
+	if s == nil {
+		return t.defaultTimeout
+	}
+	if *s <= 0 {
+		return 0
+	}
+	return time.Duration(*s * float64(time.Second))
+}
+
+// classifySessionError maps session-level sentinels onto errdefs
+// categories so callers can handle them with errdefs.Is*.
+func classifySessionError(err error) error {
+	switch {
+	case errors.Is(err, sandbox.ErrProcessClosed):
+		return errdefs.NotFoundf("exec_session: session is closed")
+	case errors.Is(err, sandbox.ErrSequenceGap):
+		return errdefs.Validationf("exec_session: after_seq points into output the buffer already trimmed; restart from a newer cursor")
+	default:
+		return err
+	}
+}
+
+func (t *SessionTool) reapLoop() {
+	defer t.wg.Done()
+	interval := t.ttl / 4
+	if interval <= 0 {
+		interval = 10 * time.Millisecond
+	}
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-t.stopCh:
+			return
+		case <-ticker.C:
+			t.expire()
+		}
+	}
+}
+
+func (t *SessionTool) expire() {
+	now := time.Now()
+	t.mu.Lock()
+	var stale []*sessionState
+	for id, s := range t.sessions {
+		if now.Sub(s.lastUsed) >= t.ttl {
+			delete(t.sessions, id)
+			stale = append(stale, s)
+		}
+	}
+	t.mu.Unlock()
+	for _, s := range stale {
+		_ = s.proc.Close()
+	}
+}
+
+type chunkResult struct {
+	Seq    int64  `json:"seq"`
+	Stream string `json:"stream"`
+	Data   string `json:"data"`
+}
+
+// Compile-time assertion the session tool satisfies the contracts.
+// Keeps signature drift in sdk/tool from silently breaking it.
+var _ tool.Tool = (*SessionTool)(nil)

--- a/sdkx/tool/exec/session.go
+++ b/sdkx/tool/exec/session.go
@@ -142,8 +142,8 @@ func (t *SessionTool) Definition() message.Definition {
 			"session is an all-or-nothing command channel, so prefer "+
 			"the exec tool for one-shot commands.",
 		message.ToolEnumProperty("action", "string",
-			"Operation to perform. start creates a session and returns its session_id; read returns buffered output from after_seq; write sends input bytes; resize sets the pty window size; status reports whether the session is still running and its exit; terminate stops the process (output stays readable until close); close frees the session.",
-			"start", "read", "write", "resize", "status", "terminate", "close"),
+			"Operation to perform. start creates a session and returns its session_id; read returns buffered output from after_seq; write sends input bytes; resize sets the pty window size; status reports whether the session is still running and its exit; signal interrupts the session (Ctrl-C semantics, the session stays usable); terminate stops the process (output stays readable until close); close frees the session.",
+			"start", "read", "write", "resize", "status", "signal", "terminate", "close"),
 		message.ToolProperty("session_id", "string",
 			"Session id returned by start. Required for every action except start."),
 		message.ToolProperty("command", "string",
@@ -167,6 +167,9 @@ func (t *SessionTool) Definition() message.Definition {
 			"Maximum bytes to return in one read. Defaults to 4096, capped at 1048576."),
 		message.ToolProperty("data", "string",
 			"Input bytes to write to the process (write)."),
+		message.ToolEnumProperty("signal", "string",
+			"Signal to send (signal action). Only interrupt is supported: VINTR on TTY sessions, SIGINT to the process group otherwise.",
+			"interrupt"),
 	).Required("action").DisallowAdditionalProperties().Build()
 }
 
@@ -191,6 +194,7 @@ type sessionArgs struct {
 	AfterSeq       *int64   `json:"after_seq"`
 	MaxBytes       *int     `json:"max_bytes"`
 	Data           string   `json:"data"`
+	Signal         string   `json:"signal"`
 }
 
 // Execute implements [tool.Tool]. It parses the action, dispatches to
@@ -221,6 +225,8 @@ func (t *SessionTool) Execute(ctx context.Context, arguments string) (string, er
 		return t.resize(ctx, a)
 	case "status":
 		return t.status(ctx, a)
+	case "signal":
+		return t.signal(ctx, a)
 	case "terminate":
 		return t.terminate(ctx, a)
 	case "close":
@@ -229,6 +235,29 @@ func (t *SessionTool) Execute(ctx context.Context, arguments string) (string, er
 		return "", errdefs.Validationf(
 			"exec_session: unknown action %q (start|read|write|resize|status|terminate|close)", a.Action)
 	}
+}
+
+func (t *SessionTool) signal(ctx context.Context, a sessionArgs) (string, error) {
+	s, err := t.lookup(a.SessionID)
+	if err != nil {
+		return "", err
+	}
+	sig := a.Signal
+	if sig == "" {
+		sig = "interrupt"
+	}
+	if sig != "interrupt" {
+		return "", errdefs.Validationf("exec_session: unsupported signal %q", sig)
+	}
+	signaler, ok := sandbox.ProcessSignalerOf(s.proc)
+	if !ok {
+		return "", errdefs.NotAvailablef(
+			"exec_session: backend does not support process signals")
+	}
+	if err := signaler.Signal(ctx, sandbox.ProcessSignalInterrupt); err != nil {
+		return "", classifySessionError(err)
+	}
+	return "{}", nil
 }
 
 func (t *SessionTool) start(ctx context.Context, a sessionArgs) (string, error) {

--- a/sdkx/tool/exec/session_test.go
+++ b/sdkx/tool/exec/session_test.go
@@ -56,8 +56,13 @@ func TestSessionDefinition_Shape(t *testing.T) {
 	props, _ := schema["properties"].(map[string]any)
 	action, _ := props["action"].(map[string]any)
 	enums, _ := action["enum"].([]any)
-	if len(enums) != 7 {
-		t.Fatalf("action enum = %v, want 7 actions", enums)
+	if len(enums) != 8 {
+		t.Fatalf("action enum = %v, want 8 actions", enums)
+	}
+	signalProp, _ := props["signal"].(map[string]any)
+	signalEnums, _ := signalProp["enum"].([]any)
+	if len(signalEnums) != 1 || signalEnums[0] != "interrupt" {
+		t.Fatalf("signal enum = %v, want [interrupt]", signalEnums)
 	}
 }
 
@@ -133,6 +138,81 @@ func TestSessionExecute_Resize_Validation(t *testing.T) {
 	if !errdefs.IsValidation(err) {
 		t.Fatalf("bad resize = %v, want Validation", err)
 	}
+}
+
+func TestSessionExecute_Signal_UnsupportedBackend(t *testing.T) {
+	tl, err := exec.NewSession(&fakePM{})
+	if err != nil {
+		t.Fatalf("NewSession: %v", err)
+	}
+	defer func() { _ = tl.Close() }()
+	start, err := tl.Execute(context.Background(), `{"action":"start","command":"sh"}`)
+	if err != nil {
+		t.Fatalf("start: %v", err)
+	}
+	id := sessionID(t, start)
+	_, err = tl.Execute(context.Background(), `{"action":"signal","session_id":"`+id+`"}`)
+	if !errdefs.IsNotAvailable(err) {
+		t.Fatalf("signal on unsupported backend = %v, want NotAvailable", err)
+	}
+	_, err = tl.Execute(context.Background(), `{"action":"signal","session_id":"`+id+`","signal":"term"}`)
+	if !errdefs.IsValidation(err) {
+		t.Fatalf("unknown signal = %v, want Validation", err)
+	}
+}
+
+func TestSessionExecute_Signal_E2E(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("pty/process sessions are unix-only")
+	}
+	rn := sandbox.NewLocalRunner(t.TempDir())
+	tl, err := exec.NewSession(sandbox.ProcessManagerOf(rn))
+	if err != nil {
+		t.Fatalf("NewSession: %v", err)
+	}
+	defer func() { _ = tl.Close() }()
+
+	start, err := tl.Execute(context.Background(),
+		`{"action":"start","command":"/bin/sh","args":["-c","trap 'echo caught; exit 0' INT; echo ready; read x"]}`)
+	if err != nil {
+		t.Fatalf("start: %v", err)
+	}
+	id := sessionID(t, start)
+
+	var sb strings.Builder
+	var seq int64
+	for !strings.Contains(sb.String(), "ready") {
+		out := readSessionAction(t, tl, id, seq)
+		for _, ch := range out.Chunks {
+			sb.WriteString(ch.Data)
+		}
+		seq = out.NextSeq
+		if out.EOF {
+			break
+		}
+	}
+	if _, err := tl.Execute(context.Background(),
+		`{"action":"signal","session_id":"`+id+`"}`); err != nil {
+		t.Fatalf("signal: %v", err)
+	}
+	for !strings.Contains(sb.String(), "caught") {
+		out := readSessionAction(t, tl, id, seq)
+		for _, ch := range out.Chunks {
+			sb.WriteString(ch.Data)
+		}
+		seq = out.NextSeq
+		if out.EOF {
+			break
+		}
+	}
+	if !strings.Contains(sb.String(), "caught") {
+		t.Fatalf("signal did not interrupt the session: %q", sb.String())
+	}
+	st := waitSessionStatus(t, tl, id, false, 5*time.Second)
+	if st.Reason != "exited" || st.ExitCode != 0 {
+		t.Fatalf("status = %+v, want exited(0)", st)
+	}
+	closeSessionAction(t, tl, id)
 }
 
 func TestSessionExecute_Close_TerminatesSessions(t *testing.T) {

--- a/sdkx/tool/exec/session_test.go
+++ b/sdkx/tool/exec/session_test.go
@@ -1,0 +1,427 @@
+package exec_test
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/GizClaw/flowcraft/sdk/errdefs"
+	"github.com/GizClaw/flowcraft/sdk/sandbox"
+	"github.com/GizClaw/flowcraft/sdkx/tool/exec"
+)
+
+func TestNewSession_NilManager_Rejected(t *testing.T) {
+	if _, err := exec.NewSession(nil); err == nil || !errdefs.IsValidation(err) {
+		t.Fatalf("NewSession(nil) = %v, want Validation (deny-by-default)", err)
+	}
+}
+
+func TestNewSession_FakeManager_OK(t *testing.T) {
+	tl, err := exec.NewSession(&fakePM{})
+	if err != nil {
+		t.Fatalf("NewSession(fake): %v", err)
+	}
+	defer func() { _ = tl.Close() }()
+	if tl == nil {
+		t.Fatal("NewSession returned nil tool")
+	}
+}
+
+func TestSessionDefinition_Shape(t *testing.T) {
+	tl, err := exec.NewSession(&fakePM{})
+	if err != nil {
+		t.Fatalf("NewSession: %v", err)
+	}
+	defer func() { _ = tl.Close() }()
+
+	def := tl.Definition()
+	if def.Name != exec.SessionName {
+		t.Fatalf("Definition.Name = %q, want %q", def.Name, exec.SessionName)
+	}
+	var schema map[string]any
+	if err := json.Unmarshal(def.InputSchema, &schema); err != nil {
+		t.Fatalf("InputSchema not valid JSON: %v", err)
+	}
+	required, _ := schema["required"].([]any)
+	if len(required) != 1 || required[0] != "action" {
+		t.Fatalf("required = %v, want [action]", required)
+	}
+	if got := schema["additionalProperties"]; got != false {
+		t.Fatalf("additionalProperties = %v, want false", got)
+	}
+	props, _ := schema["properties"].(map[string]any)
+	action, _ := props["action"].(map[string]any)
+	enums, _ := action["enum"].([]any)
+	if len(enums) != 7 {
+		t.Fatalf("action enum = %v, want 7 actions", enums)
+	}
+}
+
+func TestSessionExecute_UnknownAction_Validation(t *testing.T) {
+	tl, err := exec.NewSession(&fakePM{})
+	if err != nil {
+		t.Fatalf("NewSession: %v", err)
+	}
+	defer func() { _ = tl.Close() }()
+	_, err = tl.Execute(context.Background(), `{"action":"explode"}`)
+	if !errdefs.IsValidation(err) {
+		t.Fatalf("unknown action = %v, want Validation", err)
+	}
+}
+
+func TestSessionExecute_Start_RequiresCommand(t *testing.T) {
+	tl, err := exec.NewSession(&fakePM{})
+	if err != nil {
+		t.Fatalf("NewSession: %v", err)
+	}
+	defer func() { _ = tl.Close() }()
+	_, err = tl.Execute(context.Background(), `{"action":"start","command":"  "}`)
+	if !errdefs.IsValidation(err) {
+		t.Fatalf("blank command = %v, want Validation", err)
+	}
+}
+
+func TestSessionExecute_Read_UnknownSession_NotFound(t *testing.T) {
+	tl, err := exec.NewSession(&fakePM{})
+	if err != nil {
+		t.Fatalf("NewSession: %v", err)
+	}
+	defer func() { _ = tl.Close() }()
+	_, err = tl.Execute(context.Background(), `{"action":"read","session_id":"nope"}`)
+	if !errdefs.IsNotFound(err) {
+		t.Fatalf("unknown session read = %v, want NotFound", err)
+	}
+	_, err = tl.Execute(context.Background(), `{"action":"read"}`)
+	if !errdefs.IsValidation(err) {
+		t.Fatalf("missing session_id = %v, want Validation", err)
+	}
+}
+
+func TestSessionExecute_Write_EmptyData_Validation(t *testing.T) {
+	tl, err := exec.NewSession(&fakePM{})
+	if err != nil {
+		t.Fatalf("NewSession: %v", err)
+	}
+	defer func() { _ = tl.Close() }()
+	start, err := tl.Execute(context.Background(), `{"action":"start","command":"sh"}`)
+	if err != nil {
+		t.Fatalf("start: %v", err)
+	}
+	id := sessionID(t, start)
+	_, err = tl.Execute(context.Background(), `{"action":"write","session_id":"`+id+`","data":""}`)
+	if !errdefs.IsValidation(err) {
+		t.Fatalf("empty write = %v, want Validation", err)
+	}
+}
+
+func TestSessionExecute_Resize_Validation(t *testing.T) {
+	tl, err := exec.NewSession(&fakePM{})
+	if err != nil {
+		t.Fatalf("NewSession: %v", err)
+	}
+	defer func() { _ = tl.Close() }()
+	start, err := tl.Execute(context.Background(), `{"action":"start","command":"sh"}`)
+	if err != nil {
+		t.Fatalf("start: %v", err)
+	}
+	id := sessionID(t, start)
+	_, err = tl.Execute(context.Background(), `{"action":"resize","session_id":"`+id+`","rows":0,"cols":80}`)
+	if !errdefs.IsValidation(err) {
+		t.Fatalf("bad resize = %v, want Validation", err)
+	}
+}
+
+func TestSessionExecute_Close_TerminatesSessions(t *testing.T) {
+	pm := &fakePM{}
+	tl, err := exec.NewSession(pm)
+	if err != nil {
+		t.Fatalf("NewSession: %v", err)
+	}
+	start, err := tl.Execute(context.Background(), `{"action":"start","command":"sh"}`)
+	if err != nil {
+		t.Fatalf("start: %v", err)
+	}
+	id := sessionID(t, start)
+	if err := tl.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	if len(pm.closed) != 1 || pm.closed[0] != id {
+		t.Fatalf("closed sessions = %v, want [%s]", pm.closed, id)
+	}
+	if _, err := tl.Execute(context.Background(), `{"action":"status","session_id":"`+id+`"}`); !errdefs.IsNotAvailable(err) {
+		t.Fatalf("Execute after Close = %v, want NotAvailable", err)
+	}
+}
+
+func TestSessionExecute_E2E_PipeSession(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("pty/process sessions are unix-only")
+	}
+	rn := sandbox.NewLocalRunner(t.TempDir())
+	pm := sandbox.ProcessManagerOf(rn)
+	if pm == nil {
+		t.Fatal("LocalRunner must implement ProcessManager")
+	}
+	tl, err := exec.NewSession(pm)
+	if err != nil {
+		t.Fatalf("NewSession: %v", err)
+	}
+	defer func() { _ = tl.Close() }()
+
+	start, err := tl.Execute(context.Background(),
+		`{"action":"start","command":"/bin/sh","args":["-c","printf OUT; printf ERR >&2; exit 7"]}`)
+	if err != nil {
+		t.Fatalf("start: %v", err)
+	}
+	id := sessionID(t, start)
+
+	var stdout, stderr strings.Builder
+	var seq int64
+	for {
+		out := readSessionAction(t, tl, id, seq)
+		for _, ch := range out.Chunks {
+			switch ch.Stream {
+			case "stdout":
+				stdout.WriteString(ch.Data)
+			case "stderr":
+				stderr.WriteString(ch.Data)
+			}
+		}
+		seq = out.NextSeq
+		if out.EOF {
+			break
+		}
+	}
+	if stdout.String() != "OUT" || stderr.String() != "ERR" {
+		t.Fatalf("stdout=%q stderr=%q, want OUT/ERR", stdout.String(), stderr.String())
+	}
+
+	st := waitSessionStatus(t, tl, id, false, 5*time.Second)
+	if st.ExitCode != 7 || st.Reason != "exited" {
+		t.Fatalf("status = %+v, want exited(7)", st)
+	}
+	closeSessionAction(t, tl, id)
+}
+
+func TestSessionExecute_E2E_TTYSession(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("pty/process sessions are unix-only")
+	}
+	rn := sandbox.NewLocalRunner(t.TempDir())
+	tl, err := exec.NewSession(sandbox.ProcessManagerOf(rn))
+	if err != nil {
+		t.Fatalf("NewSession: %v", err)
+	}
+	defer func() { _ = tl.Close() }()
+
+	start, err := tl.Execute(context.Background(),
+		`{"action":"start","command":"/bin/sh","tty":true,"rows":24,"cols":80}`)
+	if err != nil {
+		t.Fatalf("start: %v", err)
+	}
+	id := sessionID(t, start)
+
+	if _, err := tl.Execute(context.Background(),
+		`{"action":"write","session_id":"`+id+`","data":"printf ok\n"}`); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	var sb strings.Builder
+	var seq int64
+	for !strings.Contains(sb.String(), "ok") {
+		out := readSessionAction(t, tl, id, seq)
+		for _, ch := range out.Chunks {
+			sb.WriteString(ch.Data)
+		}
+		seq = out.NextSeq
+		if out.EOF {
+			break
+		}
+	}
+	if !strings.Contains(sb.String(), "ok") {
+		t.Fatalf("TTY output missing 'ok': %q", sb.String())
+	}
+	if _, err := tl.Execute(context.Background(),
+		`{"action":"resize","session_id":"`+id+`","rows":40,"cols":120}`); err != nil {
+		t.Fatalf("resize: %v", err)
+	}
+	st := waitSessionStatus(t, tl, id, true, 5*time.Second)
+	if !st.Running {
+		t.Fatalf("session should still be running: %+v", st)
+	}
+	if _, err := tl.Execute(context.Background(),
+		`{"action":"terminate","session_id":"`+id+`"}`); err != nil {
+		t.Fatalf("terminate: %v", err)
+	}
+	st = waitSessionStatus(t, tl, id, false, 5*time.Second)
+	if st.Reason != "terminated" {
+		t.Fatalf("reason = %q, want terminated", st.Reason)
+	}
+	closeSessionAction(t, tl, id)
+}
+
+func TestSessionExecute_TTL_ExpiresIdleSession(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("pty/process sessions are unix-only")
+	}
+	rn := sandbox.NewLocalRunner(t.TempDir())
+	pm := sandbox.ProcessManagerOf(rn)
+	tl, err := exec.NewSession(pm, exec.WithSessionTTL(50*time.Millisecond))
+	if err != nil {
+		t.Fatalf("NewSession: %v", err)
+	}
+	defer func() { _ = tl.Close() }()
+
+	start, err := tl.Execute(context.Background(),
+		`{"action":"start","command":"/bin/sleep","args":["30"]}`)
+	if err != nil {
+		t.Fatalf("start: %v", err)
+	}
+	id := sessionID(t, start)
+
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		infos, err := pm.List(context.Background())
+		if err != nil {
+			t.Fatalf("List: %v", err)
+		}
+		if len(infos) == 0 {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("idle session was not expired by TTL: %+v", infos)
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	// The tool's own map must forget it too: status now fails NotFound.
+	if _, err := tl.Execute(context.Background(), `{"action":"status","session_id":"`+id+`"}`); !errdefs.IsNotFound(err) {
+		t.Fatalf("status after TTL expiry = %v, want NotFound", err)
+	}
+}
+
+// sessionReadResult / sessionStatusResult mirror the session tool's
+// wire output.
+type sessionReadResult struct {
+	NextSeq int64 `json:"next_seq"`
+	EOF     bool  `json:"eof"`
+	Chunks  []struct {
+		Seq    int64  `json:"seq"`
+		Stream string `json:"stream"`
+		Data   string `json:"data"`
+	} `json:"chunks"`
+}
+
+type sessionStatusResult struct {
+	Running  bool     `json:"running"`
+	ExitCode int      `json:"exit_code"`
+	Reason   string   `json:"reason"`
+	Signal   int      `json:"signal"`
+	PID      int      `json:"pid"`
+	TTY      bool     `json:"tty"`
+	Argv     []string `json:"argv"`
+}
+
+func sessionID(t *testing.T, start string) string {
+	t.Helper()
+	var got struct {
+		SessionID string `json:"session_id"`
+	}
+	if err := json.Unmarshal([]byte(start), &got); err != nil {
+		t.Fatalf("start result not valid JSON %q: %v", start, err)
+	}
+	if got.SessionID == "" {
+		t.Fatalf("start result missing session_id: %q", start)
+	}
+	return got.SessionID
+}
+
+func readSessionAction(t *testing.T, tl *exec.SessionTool, id string, afterSeq int64) sessionReadResult {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	raw, err := tl.Execute(ctx, fmt.Sprintf(
+		`{"action":"read","session_id":"%s","after_seq":%d,"max_bytes":4096}`, id, afterSeq))
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	var out sessionReadResult
+	if err := json.Unmarshal([]byte(raw), &out); err != nil {
+		t.Fatalf("read result not valid JSON %q: %v", raw, err)
+	}
+	return out
+}
+
+func waitSessionStatus(t *testing.T, tl *exec.SessionTool, id string, wantRunning bool, timeout time.Duration) sessionStatusResult {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for {
+		raw, err := tl.Execute(context.Background(), `{"action":"status","session_id":"`+id+`"}`)
+		if err != nil {
+			t.Fatalf("status: %v", err)
+		}
+		var st sessionStatusResult
+		if err := json.Unmarshal([]byte(raw), &st); err != nil {
+			t.Fatalf("status result not valid JSON %q: %v", raw, err)
+		}
+		if st.Running == wantRunning {
+			return st
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("status did not reach running=%v: %+v", wantRunning, st)
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+}
+
+func closeSessionAction(t *testing.T, tl *exec.SessionTool, id string) {
+	t.Helper()
+	if _, err := tl.Execute(context.Background(), `{"action":"close","session_id":"`+id+`"}`); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+}
+
+// fakePM records starts/closes for unit-level session-tool tests.
+type fakePM struct {
+	closed []string
+}
+
+func (f *fakePM) Start(_ context.Context, spec sandbox.ProcessSpec) (sandbox.Process, error) {
+	if len(spec.Argv) == 0 {
+		return nil, errdefs.Validationf("fake: empty argv")
+	}
+	return &fakeProcess{id: "fake-" + spec.Argv[0], pm: f}, nil
+}
+
+func (f *fakePM) List(context.Context) ([]sandbox.ProcessInfo, error) {
+	return nil, nil
+}
+
+func (f *fakePM) Terminate(context.Context, string) error {
+	return nil
+}
+
+type fakeProcess struct {
+	id string
+	pm *fakePM
+}
+
+func (p *fakeProcess) ID() string { return p.id }
+func (p *fakeProcess) PID() int   { return 42 }
+func (p *fakeProcess) Read(context.Context, int64, int) (sandbox.ProcessOutput, error) {
+	return sandbox.ProcessOutput{}, nil
+}
+func (p *fakeProcess) Write(context.Context, []byte) error { return nil }
+func (p *fakeProcess) Resize(context.Context, int, int) error {
+	return nil
+}
+func (p *fakeProcess) Terminate(context.Context) error { return nil }
+func (p *fakeProcess) Wait(context.Context) (sandbox.ProcessExit, error) {
+	return sandbox.ProcessExit{}, nil
+}
+func (p *fakeProcess) Close() error {
+	p.pm.closed = append(p.pm.closed, p.id)
+	return nil
+}


### PR DESCRIPTION
## Summary

Enhances the sandbox layer with interactive process sessions, policy-driven network egress, and process-level signal/event capabilities. Three stacked commits:

### 1. ProcessManager sessions (`sdk/sandbox` + `sdkx/sandbox/{seatbelt,bwrap}` + `sdkx/tool/exec`)

- Optional `ProcessManager` capability (discovered via `ProcessManagerOf`) with pty/pipe sessions, seq-cursor output replay, a bounded ring buffer with explicit `ErrSequenceGap`, an ID registry, and a full `Terminate`/`Wait`/`Close` lifecycle.
- Decorators (`WithDefaults` / `WithApproval` / `AllowCommands`) forward the capability; `approval.interactive` gates TTY session starts through the same approval chain.
- New `exec_session` tool (`start` / `read` / `write` / `resize` / `status` / `signal` / `terminate` / `close`) with idle-TTL reclamation.

### 2. Network proxy enhancements (`sdk/sandbox`, `sdkx/internal/httpkit`, backends, config)

- Rule-based allow/deny (`NetRule`: domain, wildcard, IP, CIDR; deny wins; `AllowHosts` compiled as trailing allow rules).
- `socks5://` upstreams with authentication (HTTP and CONNECT paths), `Proxy-Authorization` on HTTP upstream CONNECT, and a `ProxyDecision` audit callback.
- Opt-in MITM: temporary in-memory ECDSA CA, per-host leaf certificates, hooks (`OnConnect` / `OnRequest` / `OnResponse`), bounded body inspection with streaming pass-through, and CA bundle injection via `SSL_CERT_FILE`.
- MITM serves both HTTP/1.1 and HTTP/2 clients (ALPN `h2` + `http/1.1`); `MITMPolicy.Hosts` / `ExcludeHosts` select which tunnels are terminated so cert-pinning destinations can be raw-tunnelled explicitly (default remains fail-closed).
- Unix socket allow-list (bwrap bind-mounts listed paths; seatbelt rejects the policy with `NotAvailable`). All features are gated by `Enforcement` capability bits and config validation.

### 3. Process signals and event push

- `ProcessSignalerOf` — `interrupt` is true Ctrl-C semantics: VINTR through the pty on TTY sessions, SIGINT to the process group on pipe sessions.
- `ProcessEventSourceOf` — replay-then-live watchers with per-subscriber bounded queues; overflow emits `ProcessEventLag` (with the first missed byte cursor) and closes the watcher; events are seq-aligned with the pull `Read` cursor.
- New shared `hostmatch` package so net rules and MITM host selection interpret host patterns identically.

## Testing

- `make ci`, `make lint`, `make release-check`, and `git diff --check` are all green.
- New unit and integration coverage: matcher semantics (deny priority, ports, CIDR, wildcard, IDNA), socks5 auth + CONNECT, decision audit, MITM h1/h2/SSE/hook-block, unix socket policy, seq replay/gap, signals (TTY + non-TTY), watcher replay/lag/close, and the `exec_session` signal action.
- Real-environment lanes: seatbelt MITM HTTPS (macOS) and bwrap unix socket allow/deny + MITM HTTPS (Linux `integration_bwrap`).

## Notes

- No `.release/` changeset is included and no tags are pushed, so tag/release CI is intentionally not triggered.
- macOS caveat: Go and curl on macOS use the Security framework and ignore `SSL_CERT_FILE` by default; the injected CA bundle must be loaded explicitly (`tls.Config.RootCAs` or `curl --cacert`) — documented in the seatbelt package.
