### PR TITLE
feat(sdkx/runtime/session): add session lifecycle observer

### DIFF
--- a/sdkx/runtime/session/manager.go
+++ b/sdkx/runtime/session/manager.go
@@ -38,6 +38,7 @@ type Manager struct {
 	speculativeBytes  int
 	checkpoints       agent.CheckpointStore
 	resume            bool
+	observer          SessionObserver
 
 	mu        sync.Mutex
 	entries   map[Key]*managerEntry
@@ -96,6 +97,7 @@ func NewManager(
 		speculativeBytes:  opts.speculativeBytes,
 		checkpoints:       opts.checkpoints,
 		resume:            opts.resume,
+		observer:          opts.observer,
 		entries:           make(map[Key]*managerEntry),
 	}, nil
 }
@@ -152,7 +154,8 @@ func (m *Manager) open(ctx context.Context, key Key) (*Lease, error) {
 		m.checkpoints, m.resume,
 		func(changed *Session) {
 			m.activityChanged(key, changed)
-		})
+		},
+		m.observer)
 	m.entries[key] = &managerEntry{session: session, leases: 1}
 	return newLease(m, key, session), nil
 }
@@ -235,6 +238,7 @@ func (m *Manager) Close() error {
 		m.mu.Lock()
 		m.closed = true
 		sessions := make([]*Session, 0, len(m.entries))
+		closing := make([]*Session, 0, len(m.entries))
 		for key, entry := range m.entries {
 			entry.idleGeneration++
 			if entry.timer != nil {
@@ -242,10 +246,16 @@ func (m *Manager) Close() error {
 				entry.timer = nil
 			}
 			sessions = append(sessions, entry.session)
-			entry.session.beginClose()
+			if entry.session.markClosing() {
+				closing = append(closing, entry.session)
+			}
 			delete(m.entries, key)
 		}
 		m.mu.Unlock()
+
+		for _, session := range closing {
+			session.notifySessionClosing(true)
+		}
 
 		var closeErrors []error
 		for _, session := range sessions {

--- a/sdkx/runtime/session/observer.go
+++ b/sdkx/runtime/session/observer.go
@@ -1,0 +1,59 @@
+package session
+
+import "github.com/GizClaw/flowcraft/sdk/agent"
+
+// SessionObserver observes session-level lifecycle transitions without
+// affecting their outcome. It is the public hook for metrics, tracing, and
+// accounting that wants the session view (Key, RunID, terminal outcome)
+// rather than per-run agent events.
+//
+// Concurrency contract:
+//
+//   - Every method is called synchronously from the goroutine performing
+//     the transition, outside Session and Manager locks.
+//   - Implementations must return promptly and MUST NOT call back into
+//     Session or Manager methods; long-running side effects must be
+//     dispatched asynchronously by the observer itself.
+//   - Implementations must be safe for concurrent use: SessionStarted and
+//     TurnFinished can be called from a turn goroutine while Closing and
+//     Closed run on a close/reclaim goroutine.
+//
+// Embed [BaseSessionObserver] to satisfy the interface with no-op defaults
+// when only a subset of the lifecycle is interesting.
+type SessionObserver interface {
+	// OnSessionStarted fires after Start successfully scheduled a new turn
+	// and before Start returns to its caller. turn is the running turn.
+	OnSessionStarted(session *Session, turn *Turn)
+
+	// OnSessionClosing fires exactly once when the Session begins closing,
+	// covering explicit close, idle timeout reclamation, and Manager
+	// shutdown. Active turns may still be finalizing at this point.
+	OnSessionClosing(session *Session)
+
+	// OnSessionClosed fires exactly once after closing completed and any
+	// active turn has been shut down and awaited. err is the close error,
+	// or nil on a clean close.
+	OnSessionClosed(session *Session, err error)
+
+	// OnTurnFinished fires when a turn reaches its terminal state.
+	// result and err are the same values Turn.Wait returns.
+	// It is called before Turn.Wait unblocks, so observers MUST NOT call
+	// Turn.Wait from this callback.
+	OnTurnFinished(session *Session, turn *Turn, result *agent.Result, err error)
+}
+
+// BaseSessionObserver provides no-op default implementations of every
+// SessionObserver method.
+type BaseSessionObserver struct{}
+
+// OnSessionStarted is a no-op.
+func (BaseSessionObserver) OnSessionStarted(*Session, *Turn) {}
+
+// OnSessionClosing is a no-op.
+func (BaseSessionObserver) OnSessionClosing(*Session) {}
+
+// OnSessionClosed is a no-op.
+func (BaseSessionObserver) OnSessionClosed(*Session, error) {}
+
+// OnTurnFinished is a no-op.
+func (BaseSessionObserver) OnTurnFinished(*Session, *Turn, *agent.Result, error) {}

--- a/sdkx/runtime/session/observer_test.go
+++ b/sdkx/runtime/session/observer_test.go
@@ -1,0 +1,216 @@
+package session
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/GizClaw/flowcraft/sdk/agent"
+	"github.com/GizClaw/flowcraft/sdk/errdefs"
+	"github.com/GizClaw/flowcraft/sdk/event"
+	"github.com/GizClaw/flowcraft/sdkx/deploy"
+)
+
+type recordingSessionObserver struct {
+	BaseSessionObserver
+
+	mu     sync.Mutex
+	events []string
+}
+
+func (o *recordingSessionObserver) add(event string) {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	o.events = append(o.events, event)
+}
+
+func (o *recordingSessionObserver) OnSessionStarted(*Session, *Turn) {
+	o.add("started")
+}
+
+func (o *recordingSessionObserver) OnSessionClosing(*Session) {
+	o.add("closing")
+}
+
+func (o *recordingSessionObserver) OnSessionClosed(*Session, error) {
+	o.add("closed")
+}
+
+func (o *recordingSessionObserver) OnTurnFinished(*Session, *Turn, *agent.Result, error) {
+	o.add("turnFinished")
+}
+
+func (o *recordingSessionObserver) snapshot() []string {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	return append([]string(nil), o.events...)
+}
+
+func eventsEqual(got []string, want ...string) bool {
+	if len(got) != len(want) {
+		return false
+	}
+	for i := range got {
+		if got[i] != want[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func TestSessionObserverStartAndTurnFinished(t *testing.T) {
+	observer := &recordingSessionObserver{}
+	engine := agent.EngineFunc(func(
+		context.Context, agent.Run, agent.Host, *agent.Board,
+	) (*agent.Board, error) {
+		return agent.NewBoard(), nil
+	})
+	_, session, _, _ := newTurnSession(
+		t, engine, turnHostFactory, WithSessionObserver(observer))
+
+	turn, err := session.Start(context.Background(), agent.Request{})
+	if err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+	if got := observer.snapshot(); !containsEvent(got, "started") {
+		t.Fatalf("observer events after Start = %v, want started", got)
+	}
+	if _, err := turn.Wait(context.Background()); err != nil {
+		t.Fatalf("Turn.Wait() error = %v", err)
+	}
+	eventually(t, time.Second, func() bool {
+		return eventsEqual(observer.snapshot(), "started", "turnFinished")
+	})
+}
+
+func TestSessionObserverFiresOnceOnManagerClose(t *testing.T) {
+	observer := &recordingSessionObserver{}
+	engine := agent.EngineFunc(func(
+		context.Context, agent.Run, agent.Host, *agent.Board,
+	) (*agent.Board, error) {
+		return agent.NewBoard(), nil
+	})
+	manager, _, _, _ := newTurnSession(
+		t, engine, turnHostFactory, WithSessionObserver(observer))
+
+	if err := manager.Close(); err != nil {
+		t.Fatalf("Manager.Close() error = %v", err)
+	}
+	if got := observer.snapshot(); !eventsEqual(got, "closing", "closed") {
+		t.Fatalf("observer events = %v, want [closing closed]", got)
+	}
+}
+
+func TestSessionObserverFiresOnIdleReclaim(t *testing.T) {
+	observer := &recordingSessionObserver{}
+	resolver := &testResolver{instances: map[string]*deploy.Instance{"agent-a": {}}}
+	router := agent.NewStreamRouter(event.NewMemoryBus())
+	t.Cleanup(func() { _ = router.Close() })
+	manager, err := NewManager(
+		resolver,
+		HostFactoryFunc(func(context.Context, HostRequest) (agent.Host, error) {
+			return agent.NoopHost{}, nil
+		}),
+		router,
+		WithIdleTimeout(15*time.Millisecond),
+		WithSessionObserver(observer),
+	)
+	if err != nil {
+		t.Fatalf("NewManager() error = %v", err)
+	}
+	t.Cleanup(func() { _ = manager.Close() })
+
+	lease, err := manager.Open(context.Background(), Key{AgentID: "agent-a", ContextID: "ctx"})
+	if err != nil {
+		t.Fatalf("Open() error = %v", err)
+	}
+	_ = lease.Close()
+
+	eventually(t, time.Second, func() bool {
+		return manager.sessionCount() == 0 &&
+			eventsEqual(observer.snapshot(), "closing", "closed")
+	})
+}
+
+func TestSessionObserverCloseInterruptsAndWaitsForTurn(t *testing.T) {
+	observer := &recordingSessionObserver{}
+	engine := agent.EngineFunc(func(
+		ctx context.Context, _ agent.Run, host agent.Host, board *agent.Board,
+	) (*agent.Board, error) {
+		select {
+		case interrupt := <-host.Interrupts():
+			return board, agent.Interrupted(interrupt)
+		case <-ctx.Done():
+			return board, ctx.Err()
+		}
+	})
+	manager, session, _, _ := newTurnSession(
+		t, engine, turnHostFactory, WithSessionObserver(observer))
+
+	turn, err := session.Start(context.Background(), agent.Request{})
+	if err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+	if err := manager.Close(); err != nil {
+		t.Fatalf("Manager.Close() error = %v", err)
+	}
+	if turn.State() != TurnInterrupted {
+		t.Fatalf("turn state = %q, want interrupted", turn.State())
+	}
+	if got := observer.snapshot(); !eventsEqual(
+		got, "started", "closing", "turnFinished", "closed",
+	) {
+		t.Fatalf("observer events = %v, want [started closing turnFinished closed]", got)
+	}
+}
+
+func TestSessionObserverNotFiredOnFailedStart(t *testing.T) {
+	observer := &recordingSessionObserver{}
+	engine := agent.EngineFunc(func(
+		context.Context, agent.Run, agent.Host, *agent.Board,
+	) (*agent.Board, error) {
+		return agent.NewBoard(), nil
+	})
+	_, session, _, _ := newTurnSession(
+		t, engine,
+		func(event.Bus) HostFactory {
+			return HostFactoryFunc(func(context.Context, HostRequest) (agent.Host, error) {
+				return nil, errdefs.NotAvailablef("host unavailable")
+			})
+		},
+		WithSessionObserver(observer),
+	)
+
+	if _, err := session.Start(context.Background(), agent.Request{}); err == nil {
+		t.Fatal("Start() error = nil, want failure")
+	}
+	if got := observer.snapshot(); len(got) != 0 {
+		t.Fatalf("observer events = %v, want none", got)
+	}
+}
+
+func TestWithSessionObserverRejectsTypedNil(t *testing.T) {
+	router := agent.NewStreamRouter(event.NewMemoryBus())
+	defer func() { _ = router.Close() }()
+	var observer SessionObserver
+	if _, err := NewManager(
+		&testResolver{},
+		HostFactoryFunc(func(context.Context, HostRequest) (agent.Host, error) {
+			return agent.NoopHost{}, nil
+		}),
+		router,
+		WithSessionObserver(observer),
+	); !errdefs.IsValidation(err) {
+		t.Fatalf("NewManager() error = %v, want validation", err)
+	}
+}
+
+func containsEvent(events []string, want string) bool {
+	for _, event := range events {
+		if event == want {
+			return true
+		}
+	}
+	return false
+}

--- a/sdkx/runtime/session/options.go
+++ b/sdkx/runtime/session/options.go
@@ -21,6 +21,7 @@ type managerOptions struct {
 	speculativeBytes  int
 	checkpoints       agent.CheckpointStore
 	resume            bool
+	observer          SessionObserver
 }
 
 // WithSinkBufferSize sets the queue size used when SinkSpec.QueueSize is zero.
@@ -42,6 +43,19 @@ func WithSpeculativeBufferLimits(events, bytes int) ManagerOption {
 		}
 		options.speculativeEvents = events
 		options.speculativeBytes = bytes
+		return nil
+	}
+}
+
+// WithSessionObserver attaches a session-level lifecycle observer to every
+// Session created by this Manager. See SessionObserver for the callback
+// contract.
+func WithSessionObserver(observer SessionObserver) ManagerOption {
+	return func(options *managerOptions) error {
+		if isNil(observer) {
+			return errdefs.Validationf("runtime session: session observer is required")
+		}
+		options.observer = observer
 		return nil
 	}
 }

--- a/sdkx/runtime/session/session.go
+++ b/sdkx/runtime/session/session.go
@@ -43,6 +43,7 @@ type Session struct {
 	active         *Turn
 	closing        bool
 	activityNotify func(*Session)
+	observer       SessionObserver
 	closeOnce      sync.Once
 	closeErr       error
 }
@@ -58,6 +59,7 @@ func newSession(
 	checkpoints agent.CheckpointStore,
 	resume bool,
 	activityNotify func(*Session),
+	observer SessionObserver,
 ) *Session {
 	return &Session{
 		key:               key,
@@ -70,6 +72,7 @@ func newSession(
 		checkpoints:       checkpoints,
 		resume:            resume,
 		activityNotify:    activityNotify,
+		observer:          observer,
 	}
 }
 
@@ -103,7 +106,12 @@ func (s *Session) Start(ctx context.Context, request agent.Request, sinks ...Sin
 	}
 
 	s.startMu.Lock()
-	defer s.startMu.Unlock()
+	startLocked := true
+	defer func() {
+		if startLocked {
+			s.startMu.Unlock()
+		}
+	}()
 
 	s.mu.Lock()
 	if s.closing {
@@ -223,6 +231,9 @@ func (s *Session) Start(ctx context.Context, request agent.Request, sinks ...Sin
 	s.mu.Unlock()
 	activityHeld = false
 
+	startLocked = false
+	s.startMu.Unlock()
+	s.notifySessionStarted(turn)
 	go turn.execute(s.instance, request)
 	return turn, nil
 }
@@ -393,24 +404,58 @@ func (s *Session) close() error {
 			}
 		}
 		s.startMu.Unlock()
+		s.notifySessionClosed(s.closeErr)
 	})
 	return s.closeErr
 }
 
 func (s *Session) beginClose() {
-	if s == nil {
-		return
-	}
-	s.mu.Lock()
-	s.closing = true
-	s.mu.Unlock()
+	s.notifySessionClosing(s.markClosing())
 }
 
-func (s *Session) turnFinished(turn *Turn) {
+// markClosing transitions the Session to the closing state exactly once.
+func (s *Session) markClosing() bool {
+	if s == nil {
+		return false
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.closing {
+		return false
+	}
+	s.closing = true
+	return true
+}
+
+func (s *Session) notifySessionClosing(first bool) {
+	if !first || s == nil || s.observer == nil {
+		return
+	}
+	s.observer.OnSessionClosing(s)
+}
+
+func (s *Session) notifySessionClosed(err error) {
+	if s == nil || s.observer == nil {
+		return
+	}
+	s.observer.OnSessionClosed(s, err)
+}
+
+func (s *Session) notifySessionStarted(turn *Turn) {
+	if s == nil || s.observer == nil {
+		return
+	}
+	s.observer.OnSessionStarted(s, turn)
+}
+
+func (s *Session) turnFinished(turn *Turn, result *agent.Result, err error) {
 	s.mu.Lock()
 	if s.active == turn {
 		s.active = nil
 	}
 	s.mu.Unlock()
 	s.changeActivity(activityTurn, -1)
+	if s.observer != nil {
+		s.observer.OnTurnFinished(s, turn, result, err)
+	}
 }

--- a/sdkx/runtime/session/turn.go
+++ b/sdkx/runtime/session/turn.go
@@ -251,8 +251,9 @@ func (t *Turn) finish(result *agent.Result, err error) {
 	if t.session != nil {
 		t.session.cleanupCheckpoint(t.runID, result)
 	}
-	t.session.turnFinished(t)
-
+	if t.session != nil {
+		t.session.turnFinished(t, result, err)
+	}
 	close(t.done)
 }
 


### PR DESCRIPTION
## Summary

Adds public session-level lifecycle observation to `sdkx/runtime/session`:

- New `SessionObserver` interface with `BaseSessionObserver` no-op defaults.
- Callbacks for `OnSessionStarted`, `OnSessionClosing`, `OnSessionClosed`, and `OnTurnFinished` (with result/error).
- Hooks fire at `Session.Start`, session close (explicit close, idle timeout reclamation, and Manager shutdown), and turn completion.
- New `WithSessionObserver` Manager option wires the observer to every Session created by the Manager.

## Test plan

- `go test ./runtime/... -count=1`
- `go test -race ./runtime/session`
- `go vet ./runtime/session`
- golangci-lint: 0 issues