### PR TITLE
feat(sdkx/tool): dynamic tool injection, lazy MCP attach, policy middleware, and session wiring

### DIFF
--- a/sdk/config/layer.go
+++ b/sdk/config/layer.go
@@ -1,0 +1,129 @@
+package config
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/GizClaw/flowcraft/sdk/config/utils"
+	"github.com/GizClaw/flowcraft/sdk/errdefs"
+)
+
+// Layer is one named configuration layer in a layered document. Later
+// layers override earlier ones: maps merge recursively, scalars and
+// arrays are replaced wholesale, and an explicit null deletes the key.
+// Source forms (literal, content, file, embed) reuse the Loader, so
+// path confinement, size limits, and error classification apply to
+// every layer.
+type Layer struct {
+	// Name identifies the layer in Layered.Origins (e.g. "defaults",
+	// "host"). Required.
+	Name string
+	// Source is the layer document.
+	Source Source
+}
+
+// Layered is the merged result of LoadLayers: the JSON document ready
+// for strict decoding by the consumer, plus per-key provenance.
+type Layered struct {
+	// Data is the merged document as JSON.
+	Data []byte
+	// Origins maps every present leaf key path ("tools.middlewares" ->
+	// "tools.middlewares.0.kind") to the layer name that last set it.
+	Origins map[string]string
+}
+
+// LoadLayers resolves every layer through the Loader, deep-merges them
+// in order, and returns the merged JSON document plus provenance. The
+// caller still owns strict decoding (DecodeSettings / utils.Decode), so
+// unknown fields in any layer fail at the consumer's build step with
+// the same guarantees as a single document.
+func (l *Loader) LoadLayers(ctx context.Context, layers []Layer) (Layered, error) {
+	if l == nil {
+		return Layered{}, errdefs.Validationf("config layer: loader is nil")
+	}
+	if len(layers) == 0 {
+		return Layered{}, errdefs.Validationf(
+			"config layer: at least one layer is required")
+	}
+	for i, layer := range layers {
+		if strings.TrimSpace(layer.Name) == "" {
+			return Layered{}, errdefs.Validationf(
+				"config layer: layers[%d]: name is required", i)
+		}
+	}
+
+	merged := make(map[string]any)
+	origins := make(map[string]string)
+	for _, layer := range layers {
+		data, err := l.Load(ctx, layer.Source)
+		if err != nil {
+			return Layered{}, fmt.Errorf("config layer %q: %w", layer.Name, err)
+		}
+		doc, err := decodeDocumentMap(data)
+		if err != nil {
+			return Layered{}, fmt.Errorf("config layer %q: %w", layer.Name, err)
+		}
+		mergeInto(merged, origins, doc, layer.Name, "")
+	}
+	raw, err := json.Marshal(merged)
+	if err != nil {
+		return Layered{}, errdefs.Internalf(
+			"config layer: encode merged document: %v", err)
+	}
+	return Layered{Data: raw, Origins: origins}, nil
+}
+
+// decodeDocumentMap converts one JSON/YAML document to its map form.
+// JSON arrays and scalars are rejected: a config layer must be an
+// object.
+func decodeDocumentMap(data []byte) (map[string]any, error) {
+	jsonData, err := utils.ToJSON(data)
+	if err != nil {
+		return nil, err
+	}
+	var doc map[string]any
+	decoder := json.NewDecoder(bytes.NewReader(jsonData))
+	if err := decoder.Decode(&doc); err != nil {
+		return nil, fmt.Errorf("config layer: decode document: %w", err)
+	}
+	return doc, nil
+}
+
+func mergeInto(dst map[string]any, origins map[string]string, src map[string]any, layerName, prefix string) {
+	for key, value := range src {
+		path := key
+		if prefix != "" {
+			path = prefix + "." + key
+		}
+		if child, ok := value.(map[string]any); ok {
+			existing, exists := dst[key]
+			existingMap, isMap := existing.(map[string]any)
+			if !exists || !isMap {
+				existingMap = make(map[string]any)
+				dst[key] = existingMap
+			}
+			mergeInto(existingMap, origins, child, layerName, path)
+			continue
+		}
+		if value == nil {
+			delete(dst, key)
+			clearOriginsUnder(origins, path)
+			delete(origins, path)
+			continue
+		}
+		dst[key] = value
+		clearOriginsUnder(origins, path)
+		origins[path] = layerName
+	}
+}
+
+func clearOriginsUnder(origins map[string]string, prefix string) {
+	for path := range origins {
+		if path == prefix || strings.HasPrefix(path, prefix+".") {
+			delete(origins, path)
+		}
+	}
+}

--- a/sdk/config/layer_test.go
+++ b/sdk/config/layer_test.go
@@ -1,0 +1,117 @@
+package config
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+)
+
+func TestLoadLayers_DeepMergeAndOrigins(t *testing.T) {
+	loader := NewLoader()
+	layered, err := loader.LoadLayers(context.Background(), []Layer{
+		{
+			Name:   "defaults",
+			Source: LiteralSource("a: 1\nnested:\n  x: 1\n  list: [1, 2]\n"),
+		},
+		{
+			Name:   "overrides",
+			Source: LiteralSource("a: 2\nnested:\n  second: 2\n  list: [3]\n"),
+		},
+	})
+	if err != nil {
+		t.Fatalf("LoadLayers: %v", err)
+	}
+	var got map[string]any
+	if err := json.Unmarshal(layered.Data, &got); err != nil {
+		t.Fatalf("merged data is not an object: %v\n%s", err, layered.Data)
+	}
+	want := map[string]any{
+		"a": float64(2),
+		"nested": map[string]any{
+			"x":      float64(1),
+			"second": float64(2),
+			"list":   []any{float64(3)},
+		},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("merged = %#v, want %#v", got, want)
+	}
+	wantOrigins := map[string]string{
+		"a":             "overrides",
+		"nested.x":      "defaults",
+		"nested.second": "overrides",
+		"nested.list":   "overrides",
+	}
+	if !reflect.DeepEqual(layered.Origins, wantOrigins) {
+		t.Errorf("origins = %#v, want %#v", layered.Origins, wantOrigins)
+	}
+}
+
+func TestLoadLayers_NullDeletesKey(t *testing.T) {
+	loader := NewLoader()
+	layered, err := loader.LoadLayers(context.Background(), []Layer{
+		{Name: "base", Source: LiteralSource("a: 1\nb: 2\n")},
+		{Name: "override", Source: LiteralSource("a: null\n")},
+	})
+	if err != nil {
+		t.Fatalf("LoadLayers: %v", err)
+	}
+	var got map[string]any
+	if err := json.Unmarshal(layered.Data, &got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if _, ok := got["a"]; ok {
+		t.Errorf("merged still contains deleted key a: %#v", got)
+	}
+	if got["b"] != float64(2) {
+		t.Errorf("merged b = %v, want 2", got["b"])
+	}
+}
+
+func TestLoadLayers_FileLayersResolveAgainstBaseDir(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "defaults.yaml"), []byte("a: 1\n"), 0o600); err != nil {
+		t.Fatalf("write defaults: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "host.yaml"), []byte("a: 3\nb: 4\n"), 0o600); err != nil {
+		t.Fatalf("write host: %v", err)
+	}
+	loader := NewLoader(WithBaseDir(dir))
+	layered, err := loader.LoadLayers(context.Background(), []Layer{
+		{Name: "defaults", Source: FileSource("./defaults.yaml")},
+		{Name: "host", Source: FileSource("./host.yaml")},
+	})
+	if err != nil {
+		t.Fatalf("LoadLayers: %v", err)
+	}
+	var got map[string]any
+	if err := json.Unmarshal(layered.Data, &got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if got["a"] != float64(3) || got["b"] != float64(4) {
+		t.Errorf("merged = %#v, want a=3 b=4", got)
+	}
+	if layered.Origins["a"] != "host" {
+		t.Errorf("origin of a = %q, want host", layered.Origins["a"])
+	}
+}
+
+func TestLoadLayers_RejectsBadInput(t *testing.T) {
+	loader := NewLoader()
+	if _, err := loader.LoadLayers(context.Background(), nil); err == nil {
+		t.Error("empty layers accepted, want error")
+	}
+	if _, err := loader.LoadLayers(context.Background(), []Layer{
+		{Name: " ", Source: LiteralSource("a: 1")},
+	}); err == nil {
+		t.Error("blank layer name accepted, want error")
+	}
+	if _, err := loader.LoadLayers(context.Background(), []Layer{
+		{Name: "list", Source: LiteralSource("- 1\n- 2")},
+	}); err == nil {
+		t.Error("non-object layer accepted, want error")
+	}
+}

--- a/sdk/config/source.go
+++ b/sdk/config/source.go
@@ -71,6 +71,29 @@ type Source struct {
 	path    string          // SourceFile / SourceEmbed
 }
 
+// LiteralSource builds a Source from plain document content.
+func LiteralSource(literal string) Source {
+	return Source{kind: SourceLiteral, literal: literal}
+}
+
+// ContentSource builds a Source from a structured JSON/YAML subtree
+// carried inline in the parent document.
+func ContentSource(raw json.RawMessage) Source {
+	return Source{kind: SourceContent, raw: raw}
+}
+
+// FileSource builds a Source that references an external file, resolved
+// against the Loader's base directory.
+func FileSource(path string) Source {
+	return Source{kind: SourceFile, path: path}
+}
+
+// EmbedSource builds a Source that references a build-time embedded
+// asset from the Loader's embed registry.
+func EmbedSource(path string) Source {
+	return Source{kind: SourceEmbed, path: path}
+}
+
 // Kind returns the source form.
 func (s Source) Kind() SourceKind { return s.kind }
 

--- a/sdk/graph/config/factory.go
+++ b/sdk/graph/config/factory.go
@@ -450,9 +450,19 @@ func scanInferenceConfig(raw json.RawMessage) (modelConfigured bool, staticTools
 	if model, ok := fields["model"]; ok && !bytes.Equal(bytes.TrimSpace(model), []byte("null")) {
 		modelConfigured = true
 	}
-	tools, ok := fields["tools"]
-	if !ok || bytes.Equal(bytes.TrimSpace(tools), []byte("null")) {
-		return modelConfigured, nil, false, nil
+	tools, hasTools := fields["tools"]
+	allTools := false
+	if rawAll, ok := fields["all_tools"]; ok {
+		if err := json.Unmarshal(rawAll, &allTools); err != nil {
+			return false, nil, false, errdefs.Validationf(
+				"inference config all_tools must be a boolean: %v", err)
+		}
+	}
+	if !hasTools {
+		return modelConfigured, nil, allTools, nil
+	}
+	if bytes.Equal(bytes.TrimSpace(tools), []byte("null")) {
+		return modelConfigured, nil, allTools, nil
 	}
 	var names []string
 	if err := json.Unmarshal(tools, &names); err != nil {
@@ -464,7 +474,7 @@ func scanInferenceConfig(raw json.RawMessage) (modelConfigured bool, staticTools
 			staticTools = append(staticTools, name)
 		}
 	}
-	return modelConfigured, staticTools, len(names) > 0, nil
+	return modelConfigured, staticTools, len(names) > 0 || allTools, nil
 }
 
 func validateRequiredDeps(required nodeRequirements, deps dependencies) error {

--- a/sdk/graph/config/factory_test.go
+++ b/sdk/graph/config/factory_test.go
@@ -578,6 +578,40 @@ func TestFactoryInferenceDependencyScanPreservesBoardReferences(t *testing.T) {
 	}
 }
 
+func TestFactoryInferenceAllToolsRequiresToolDep(t *testing.T) {
+	_, err := NewFactory().New(context.Background(), sdkconfig.Input{
+		Deps: map[string]any{
+			DepInference: &inferenceconfig.Assembly{Runtime: &inference.Runtime{}},
+		},
+		Settings: inlineSettings(validDefinition("inference", map[string]any{
+			"model": map[string]any{
+				"id": map[string]any{"provider": "fake", "name": "model"},
+			},
+			"all_tools": true,
+		})),
+	})
+	if !errdefs.IsNotFound(err) {
+		t.Fatalf("all_tools without tool dep = %v, want NotFound", err)
+	}
+}
+
+func TestFactoryInferenceRejectsNonBooleanAllTools(t *testing.T) {
+	_, err := NewFactory().New(context.Background(), sdkconfig.Input{
+		Deps: map[string]any{
+			DepInference: &inferenceconfig.Assembly{Runtime: &inference.Runtime{}},
+		},
+		Settings: inlineSettings(validDefinition("inference", map[string]any{
+			"model": map[string]any{
+				"id": map[string]any{"provider": "fake", "name": "model"},
+			},
+			"all_tools": "yes",
+		})),
+	})
+	if !errdefs.IsValidation(err) {
+		t.Fatalf("non-boolean all_tools = %v, want Validation", err)
+	}
+}
+
 func TestFactoryRejectsIncompleteAssemblies(t *testing.T) {
 	for name, deps := range map[string]map[string]any{
 		"inference runtime": {

--- a/sdk/graph/nodes/inference.go
+++ b/sdk/graph/nodes/inference.go
@@ -1,6 +1,7 @@
 package nodes
 
 import (
+	"context"
 	"errors"
 	"io"
 
@@ -51,6 +52,13 @@ type InferenceConfig struct {
 
 	// Tools names the catalog tools the model may call this turn.
 	Tools []string `json:"tools,omitempty"`
+	// AllTools sends the catalog's entire visible set instead of only
+	// the named Tools. The node stays catalog-agnostic: whatever
+	// Definitions returns (a dynamic injection view, a filtered view,
+	// the plain registry) is what the model sees. When Tools is also
+	// set, the names are declared to the catalog as RequiredByName via
+	// an optional interface and must still exist.
+	AllTools bool `json:"all_tools,omitempty"`
 	// The remaining knobs ride the text intent verbatim.
 	ToolChoice       *inference.ToolChoice     `json:"tool_choice,omitempty"`
 	Temperature      *float64                  `json:"temperature,omitempty"`
@@ -113,7 +121,7 @@ func runInference(ec graph.ExecutionContext, board *agent.Board, cfg InferenceCo
 	if channel == "" {
 		channel = agent.MainChannel
 	}
-	req, err := buildGenerateRequest(board, channel, cfg, deps)
+	req, err := buildGenerateRequest(ec, board, channel, cfg, deps)
 	if err != nil {
 		return err
 	}
@@ -121,6 +129,13 @@ func runInference(ec graph.ExecutionContext, board *agent.Board, cfg InferenceCo
 	resp, err := executeGenerate(ec, board, cfg, deps, req)
 	if err != nil {
 		return err
+	}
+	if len(cfg.Tools) > 0 || cfg.AllTools {
+		if catalog := roundCatalog(ec.Context, cfg, deps); catalog != nil {
+			if advancer, ok := catalog.(roundAdvancer); ok {
+				advancer.AdvanceTurn()
+			}
+		}
 	}
 
 	for _, part := range resp.Message.Content.Parts {
@@ -161,7 +176,7 @@ func runInference(ec graph.ExecutionContext, board *agent.Board, cfg InferenceCo
 // buildGenerateRequest splits the channel tail into context + current
 // input — the exact shape GenerateRequest demands — and attaches the
 // configured text intent and extensions.
-func buildGenerateRequest(board *agent.Board, channel string, cfg InferenceConfig, deps InferenceNodeDeps) (inference.GenerateRequest, error) {
+func buildGenerateRequest(ec graph.ExecutionContext, board *agent.Board, channel string, cfg InferenceConfig, deps InferenceNodeDeps) (inference.GenerateRequest, error) {
 	var req inference.GenerateRequest
 	messages := board.Channel(channel)
 	if len(messages) == 0 {
@@ -196,8 +211,8 @@ func buildGenerateRequest(board *agent.Board, channel string, cfg InferenceConfi
 		ReasoningEnabled: cfg.ReasoningEnabled,
 		ReasoningEffort:  cfg.ReasoningEffort,
 	}
-	if len(cfg.Tools) > 0 {
-		definitions, err := toolDefinitions(cfg.Tools, deps.Catalog)
+	if len(cfg.Tools) > 0 || cfg.AllTools {
+		definitions, err := toolDefinitions(ec.Context, cfg.Tools, deps.Catalog, cfg.AllTools)
 		if err != nil {
 			return req, err
 		}
@@ -222,10 +237,47 @@ func buildGenerateRequest(board *agent.Board, channel string, cfg InferenceConfi
 	}, nil
 }
 
-func toolDefinitions(names []string, catalog tool.Catalog) ([]message.Definition, error) {
+func toolDefinitions(ctx context.Context, names []string, catalog tool.Catalog, allTools bool) ([]message.Definition, error) {
 	if catalog == nil {
 		return nil, errdefs.Validationf("inference node: tools configured but no tool catalog wired")
 	}
+	if allTools {
+		if override, ok := tool.CatalogFromContext(ctx); ok {
+			catalog = override
+		}
+		return resolveAllTools(names, catalog)
+	}
+	return resolveExplicitTools(names, catalog)
+}
+
+// requiredCatalog is implemented by catalogs that accept RequiredByName
+// declarations. The inference node never assumes one: it is an optional
+// contract a catalog (like the dynamic injection view) may implement.
+type requiredCatalog interface {
+	Require(names ...string)
+}
+
+// roundAdvancer is the optional per-round lifecycle contract: a
+// session-scoped catalog advances its Selected retention once per
+// inference node invocation, which is the correct granularity for M
+// rounds (a single user turn may contain several rounds).
+type roundAdvancer interface {
+	AdvanceTurn()
+}
+
+// roundCatalog resolves the catalog this round's request was built
+// from: the context override for all_tools mode, otherwise the bound
+// dependency.
+func roundCatalog(ctx context.Context, cfg InferenceConfig, deps InferenceNodeDeps) tool.Catalog {
+	if cfg.AllTools {
+		if override, ok := tool.CatalogFromContext(ctx); ok {
+			return override
+		}
+	}
+	return deps.Catalog
+}
+
+func resolveExplicitTools(names []string, catalog tool.Catalog) ([]message.Definition, error) {
 	available := make(map[string]message.Definition)
 	for _, def := range catalog.Definitions() {
 		available[def.Name] = def
@@ -237,6 +289,26 @@ func toolDefinitions(names []string, catalog tool.Catalog) ([]message.Definition
 			return nil, errdefs.Validationf("inference node: unknown tool %q", name)
 		}
 		definitions[i] = def
+	}
+	return definitions, nil
+}
+
+func resolveAllTools(names []string, catalog tool.Catalog) ([]message.Definition, error) {
+	if rc, ok := catalog.(requiredCatalog); ok {
+		rc.Require(names...)
+	}
+	definitions := catalog.Definitions()
+	if len(names) == 0 {
+		return definitions, nil
+	}
+	available := make(map[string]struct{}, len(definitions))
+	for _, def := range definitions {
+		available[def.Name] = struct{}{}
+	}
+	for _, name := range names {
+		if _, ok := available[name]; !ok {
+			return nil, errdefs.Validationf("inference node: unknown tool %q", name)
+		}
 	}
 	return definitions, nil
 }

--- a/sdk/graph/nodes/inference_test.go
+++ b/sdk/graph/nodes/inference_test.go
@@ -255,6 +255,130 @@ func TestInferenceNode_UnknownToolRejected(t *testing.T) {
 	}
 }
 
+// fakeVisibleCatalog is a minimal stand-in for a catalog whose
+// Definitions are the final model-visible set (the dynamic injection
+// view being one such implementation): it accepts RequiredByName
+// declarations through an optional interface the node does not depend
+// on.
+type fakeVisibleCatalog struct {
+	defs     []message.Definition
+	required []string
+	advances int
+}
+
+func (f *fakeVisibleCatalog) Get(string) (tool.Tool, bool) { return nil, false }
+func (f *fakeVisibleCatalog) Definitions() []message.Definition {
+	return f.defs
+}
+func (f *fakeVisibleCatalog) Require(names ...string) {
+	f.required = append(f.required, names...)
+}
+func (f *fakeVisibleCatalog) AdvanceTurn() { f.advances++ }
+
+func TestInferenceNode_AllTools(t *testing.T) {
+	fake := &inferencetest.GenerateFake{}
+	catalog := &fakeVisibleCatalog{
+		defs: []message.Definition{
+			{Name: "search", InputSchema: json.RawMessage(`{"type":"object"}`)},
+			{Name: "archive", InputSchema: json.RawMessage(`{"type":"object"}`)},
+		},
+	}
+	reg := inferenceRegistry(t, InferenceNodeDeps{Runtime: fake.Runtime(t), Catalog: catalog})
+	g := singleNodeGraph(t, reg, "inference", InferenceConfig{
+		Model:    ptr(inferencetest.DefaultFakeModel),
+		Tools:    []string{"search"},
+		AllTools: true,
+	})
+	board := userBoard()
+	if err := executeGraph(t, g, agent.NoopHost{}, board); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+
+	if len(catalog.required) != 1 || catalog.required[0] != "search" {
+		t.Errorf("RequiredByName = %v, want [search]", catalog.required)
+	}
+	intentTools := fake.LastRequest().Input.Content.Intent.Text.Tools
+	if len(intentTools) != 2 {
+		t.Fatalf("intent tools = %+v, want catalog-defined set", intentTools)
+	}
+	if intentTools[0].Name != "search" || intentTools[1].Name != "archive" {
+		t.Errorf("intent tool names = %v, want [search archive]", intentTools)
+	}
+	if catalog.advances != 1 {
+		t.Errorf("AdvanceTurn calls = %d, want 1 per round", catalog.advances)
+	}
+}
+
+func TestInferenceNode_AllToolsUsesContextOverride(t *testing.T) {
+	fake := &inferencetest.GenerateFake{}
+	override := &fakeVisibleCatalog{
+		defs: []message.Definition{
+			{Name: "search", InputSchema: json.RawMessage(`{"type":"object"}`)},
+			{Name: "archive", InputSchema: json.RawMessage(`{"type":"object"}`)},
+		},
+	}
+	// The bound catalog is a plain empty registry; the override on the
+	// execution context must win in all_tools mode.
+	bound := tool.NewRegistry()
+	reg := inferenceRegistry(t, InferenceNodeDeps{
+		Runtime: fake.Runtime(t),
+		Catalog: bound,
+	})
+	g := singleNodeGraph(t, reg, "inference", InferenceConfig{
+		Model:    ptr(inferencetest.DefaultFakeModel),
+		Tools:    []string{"search"},
+		AllTools: true,
+	})
+
+	ctx := tool.WithCatalogOnContext(context.Background(), override)
+	board := userBoard()
+	if _, err := g.Execute(ctx,
+		agent.Run{Identity: agent.Identity{AgentID: "test-agent", RunID: "run-1"}},
+		agent.NoopHost{}, board); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	intentTools := fake.LastRequest().Input.Content.Intent.Text.Tools
+	if len(intentTools) != 2 {
+		t.Fatalf("intent tools = %+v, want the context override's set", intentTools)
+	}
+	if len(override.required) != 1 || override.required[0] != "search" {
+		t.Errorf("RequiredByName = %v, want [search]", override.required)
+	}
+	if override.advances != 1 {
+		t.Errorf("AdvanceTurn calls = %d, want 1", override.advances)
+	}
+}
+
+func TestInferenceNode_AllToolsRejectsUnknownName(t *testing.T) {
+	fake := &inferencetest.GenerateFake{}
+	catalog := &fakeVisibleCatalog{
+		defs: []message.Definition{
+			{Name: "search", InputSchema: json.RawMessage(`{"type":"object"}`)},
+		},
+	}
+	reg := inferenceRegistry(t, InferenceNodeDeps{Runtime: fake.Runtime(t), Catalog: catalog})
+	g := singleNodeGraph(t, reg, "inference", InferenceConfig{
+		Model:    ptr(inferencetest.DefaultFakeModel),
+		Tools:    []string{"ghost"},
+		AllTools: true,
+	})
+	if err := executeGraph(t, g, agent.NoopHost{}, userBoard()); err == nil || !errdefs.IsValidation(err) {
+		t.Fatalf("unknown tool in dynamic mode = %v, want Validation", err)
+	}
+}
+
+func TestInferenceNode_AllToolsRequiresCatalog(t *testing.T) {
+	fake := &inferencetest.GenerateFake{}
+	reg := inferenceRegistry(t, InferenceNodeDeps{Runtime: fake.Runtime(t)})
+	g := singleNodeGraph(t, reg, "inference", InferenceConfig{
+		Model:    ptr(inferencetest.DefaultFakeModel),
+		AllTools: true,
+	})
+	if err := executeGraph(t, g, agent.NoopHost{}, userBoard()); err == nil {
+		t.Fatal("AllTools without a catalog succeeded, want error")
+	}
+}
+
 func TestInferenceNode_RouterPathWhenNoModel(t *testing.T) {
 	fake := &inferencetest.GenerateFake{}
 	runtime := fake.Runtime(t)

--- a/sdk/tool/config/builtin.go
+++ b/sdk/tool/config/builtin.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"regexp"
 	"time"
 
 	sdkconfig "github.com/GizClaw/flowcraft/sdk/config"
@@ -22,6 +23,8 @@ const (
 	KindRateLimit   = "ratelimit"
 	KindApproval    = "approval"
 	KindAudit       = "audit"
+	KindResultLimit = "resultlimit"
+	KindRedact      = "redact"
 )
 
 func (b *Builder) registerBuiltins() {
@@ -39,6 +42,8 @@ func (b *Builder) registerBuiltins() {
 	register(KindRateLimit, b.rateLimitFactory)
 	register(KindApproval, b.approvalFactory)
 	register(KindAudit, b.auditFactory)
+	register(KindResultLimit, resultLimitFactory)
+	register(KindRedact, redactFactory)
 }
 
 // noSpecFactory wraps a plain constructor, rejecting any spec: the kind
@@ -158,6 +163,61 @@ func (b *Builder) auditFactory(_ context.Context, in sdkconfig.Input) (tool.Midd
 			"kind %q requires an AuditSink in config.Deps", KindAudit))
 	}
 	return middleware.Audit(b.deps.AuditSink), nil
+}
+
+type resultLimitSpec struct {
+	MaxChars int    `json:"max_chars"`
+	Marker   string `json:"marker,omitempty"`
+}
+
+func resultLimitFactory(_ context.Context, in sdkconfig.Input) (tool.Middleware, error) {
+	s, err := DecodeSpec[resultLimitSpec](in.Settings)
+	if err != nil {
+		return nil, err
+	}
+	if s.MaxChars <= 0 {
+		return nil, errdefs.Validation(fmt.Errorf(
+			"resultlimit spec: max_chars must be positive, got %d", s.MaxChars))
+	}
+	return middleware.ResultLimiter(s.MaxChars,
+		middleware.WithResultMarker(s.Marker)), nil
+}
+
+type redactSpec struct {
+	Rules []redactRuleSpec `json:"rules"`
+}
+
+type redactRuleSpec struct {
+	Pattern     string `json:"pattern"`
+	Replacement string `json:"replacement,omitempty"`
+}
+
+func redactFactory(_ context.Context, in sdkconfig.Input) (tool.Middleware, error) {
+	s, err := DecodeSpec[redactSpec](in.Settings)
+	if err != nil {
+		return nil, err
+	}
+	if len(s.Rules) == 0 {
+		return nil, errdefs.Validation(fmt.Errorf(
+			"redact spec: rules must list at least one pattern"))
+	}
+	rules := make([]middleware.RedactRule, 0, len(s.Rules))
+	for i, rule := range s.Rules {
+		if rule.Pattern == "" {
+			return nil, errdefs.Validation(fmt.Errorf(
+				"redact spec: rules[%d]: pattern is required", i))
+		}
+		compiled, err := regexp.Compile(rule.Pattern)
+		if err != nil {
+			return nil, errdefs.Validation(fmt.Errorf(
+				"redact spec: rules[%d]: invalid pattern %q: %w", i, rule.Pattern, err))
+		}
+		rules = append(rules, middleware.RedactRule{
+			Pattern:     compiled,
+			Replacement: rule.Replacement,
+		})
+	}
+	return middleware.Redact(rules...), nil
 }
 
 func catalogFrom(in sdkconfig.Input) (tool.Catalog, error) {

--- a/sdk/tool/config/config_test.go
+++ b/sdk/tool/config/config_test.go
@@ -276,6 +276,46 @@ func TestBuild_FailFast(t *testing.T) {
 			tools:   []string{"x"},
 			wantErr: "takes no spec",
 		},
+		{
+			name: "resultlimit zero max_chars",
+			doc: config.Document{Version: "v1", Middlewares: []config.MiddlewareEntry{
+				{Kind: "resultlimit", Spec: specJSON(t, `{"max_chars":0}`)},
+			}},
+			tools:   []string{"x"},
+			wantErr: "max_chars",
+		},
+		{
+			name: "resultlimit unknown spec field",
+			doc: config.Document{Version: "v1", Middlewares: []config.MiddlewareEntry{
+				{Kind: "resultlimit", Spec: specJSON(t, `{"max":10}`)},
+			}},
+			tools:   []string{"x"},
+			wantErr: "max",
+		},
+		{
+			name: "redact empty rules",
+			doc: config.Document{Version: "v1", Middlewares: []config.MiddlewareEntry{
+				{Kind: "redact", Spec: specJSON(t, `{"rules":[]}`)},
+			}},
+			tools:   []string{"x"},
+			wantErr: "at least one",
+		},
+		{
+			name: "redact invalid regex",
+			doc: config.Document{Version: "v1", Middlewares: []config.MiddlewareEntry{
+				{Kind: "redact", Spec: specJSON(t, `{"rules":[{"pattern":"("}]}`)},
+			}},
+			tools:   []string{"x"},
+			wantErr: "invalid pattern",
+		},
+		{
+			name: "redact unknown spec field",
+			doc: config.Document{Version: "v1", Middlewares: []config.MiddlewareEntry{
+				{Kind: "redact", Spec: specJSON(t, `{"patterns":["x"]}`)},
+			}},
+			tools:   []string{"x"},
+			wantErr: "patterns",
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -401,6 +441,89 @@ func TestTimeoutSpec_RejectsNumericDuration(t *testing.T) {
 	}}
 	if _, err := builder.Build(context.Background(), doc); err == nil {
 		t.Error("numeric duration should be rejected; units belong in the file")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// resultlimit / redact kinds
+// ---------------------------------------------------------------------------
+
+func longEchoTool(name string, n int) tool.Tool {
+	return tool.FuncTool(message.Definition{Name: name},
+		func(_ context.Context, _ string) (string, error) {
+			return strings.Repeat("x", n), nil
+		})
+}
+
+func TestBuild_ResultLimitTruncates(t *testing.T) {
+	builder := config.NewBuilder(config.Deps{})
+	builder.RegisterBuiltin(longEchoTool("long", 500))
+	doc, err := config.Parse([]byte(`
+version: v1
+sources:
+  - kind: builtin
+    spec: {tools: [long]}
+middlewares:
+  - kind: resultlimit
+    spec: {max_chars: 64, marker: "[cut]"}
+`))
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	assembly, err := builder.Build(context.Background(), doc)
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	t.Cleanup(func() { _ = assembly.Close() })
+	res := assembly.Executor.Execute(context.Background(), call("long"))
+	if res.IsError {
+		t.Fatalf("unexpected error result: %q", res.Content)
+	}
+	if len([]rune(res.Content)) != 64 {
+		t.Errorf("content length = %d, want 64", len([]rune(res.Content)))
+	}
+	if !strings.HasSuffix(res.Content, "[cut]") {
+		t.Errorf("content %q does not end with configured marker", res.Content)
+	}
+}
+
+func TestBuild_RedactAppliesToCallAndResult(t *testing.T) {
+	builder := config.NewBuilder(config.Deps{})
+	builder.RegisterBuiltin(tool.FuncTool(message.Definition{Name: "secret"},
+		func(_ context.Context, args string) (string, error) {
+			return "token=abc123 args=" + args, nil
+		}))
+	doc, err := config.Parse([]byte(`
+version: v1
+sources:
+  - kind: builtin
+    spec: {tools: [secret]}
+middlewares:
+  - kind: redact
+    spec:
+      rules:
+        - pattern: "abc123"
+          replacement: "[REDACTED]"
+`))
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	assembly, err := builder.Build(context.Background(), doc)
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	t.Cleanup(func() { _ = assembly.Close() })
+	res := assembly.Executor.Execute(context.Background(), message.Call{
+		ID: "c1", Name: "secret", Arguments: json.RawMessage(`{"token":"abc123"}`),
+	})
+	if res.IsError {
+		t.Fatalf("unexpected error result: %q", res.Content)
+	}
+	if strings.Contains(res.Content, "abc123") {
+		t.Errorf("content still contains the secret: %q", res.Content)
+	}
+	if !strings.Contains(res.Content, "[REDACTED]") || !strings.Contains(res.Content, "args=") {
+		t.Errorf("content = %q, want redacted marker plus untouched argument echo", res.Content)
 	}
 }
 

--- a/sdk/tool/context.go
+++ b/sdk/tool/context.go
@@ -1,0 +1,28 @@
+package tool
+
+import "context"
+
+type catalogContextKey struct{}
+
+// WithCatalogOnContext attaches a session-scoped Catalog to ctx. It is
+// the neutral plumbing between a session owner (sdkx/runtime/session),
+// model-facing consumers (the inference node), and session-scoped
+// tools (tool_search). The attached catalog is a view, not an owner:
+// whoever creates it is responsible for closing it.
+func WithCatalogOnContext(ctx context.Context, c Catalog) context.Context {
+	return context.WithValue(ctx, catalogContextKey{}, c)
+}
+
+// CatalogFromContext returns the session catalog attached by
+// WithCatalogOnContext. The bool is false when no catalog is attached
+// (or when a typed nil was stored — treat that as absent).
+func CatalogFromContext(ctx context.Context) (Catalog, bool) {
+	c, ok := ctx.Value(catalogContextKey{}).(Catalog)
+	if !ok {
+		return nil, false
+	}
+	if c == nil {
+		return nil, false
+	}
+	return c, true
+}

--- a/sdk/tool/context_test.go
+++ b/sdk/tool/context_test.go
@@ -1,0 +1,28 @@
+package tool
+
+import (
+	"context"
+	"testing"
+)
+
+func TestCatalogContext_RoundTrip(t *testing.T) {
+	reg := NewRegistry()
+	ctx := WithCatalogOnContext(context.Background(), reg)
+	got, ok := CatalogFromContext(ctx)
+	if !ok {
+		t.Fatal("catalog missing from context")
+	}
+	if got != Catalog(reg) {
+		t.Errorf("catalog = %T, want the registry", got)
+	}
+}
+
+func TestCatalogContext_AbsentAndNil(t *testing.T) {
+	if _, ok := CatalogFromContext(context.Background()); ok {
+		t.Error("empty context reported a catalog")
+	}
+	ctx := WithCatalogOnContext(context.Background(), nil)
+	if _, ok := CatalogFromContext(ctx); ok {
+		t.Error("typed nil catalog reported as present")
+	}
+}

--- a/sdk/tool/middleware/redact.go
+++ b/sdk/tool/middleware/redact.go
@@ -1,0 +1,122 @@
+package middleware
+
+import (
+	"context"
+	"regexp"
+
+	"github.com/GizClaw/flowcraft/sdk/message"
+	"github.com/GizClaw/flowcraft/sdk/tool"
+)
+
+// DefaultRedaction is the replacement applied when a rule does not
+// specify one.
+const DefaultRedaction = "[REDACTED]"
+
+// RedactRule is one regex-based redaction: every match of Pattern is
+// replaced by Replacement (DefaultRedaction when empty). Patterns use
+// Go's regexp (RE2) syntax; the replacement string may reference
+// capture groups with ${name} or $1.
+type RedactRule struct {
+	Pattern     *regexp.Regexp
+	Replacement string
+}
+
+// Redact rewrites tool result content through the given rules before it
+// is returned to the model. Call arguments are deliberately left
+// untouched: the tool needs the real arguments to execute, and the
+// audit path has its own redacting sink ([AuditRedacted]).
+func Redact(rules ...RedactRule) tool.Middleware {
+	red := newRedactor(rules...)
+	return func(next tool.Dispatch) tool.Dispatch {
+		return func(ctx context.Context, call message.Call) message.Result {
+			return red.Result(next(ctx, call))
+		}
+	}
+}
+
+// RedactPatterns is the shorthand form of [Redact]: each pattern is
+// replaced with DefaultRedaction.
+func RedactPatterns(patterns ...string) tool.Middleware {
+	rules := make([]RedactRule, 0, len(patterns))
+	for _, pattern := range patterns {
+		rules = append(rules, RedactRule{Pattern: regexp.MustCompile(pattern)})
+	}
+	return Redact(rules...)
+}
+
+// AuditRedacted is [Audit] over a redacting wrapper: the audit record
+// receives redacted copies of both call arguments and result content,
+// while the model and the tool continue to see the originals. Pair it
+// with [Redact] when the model-facing result must also be stripped:
+//
+//	exec := tool.NewExecutor(reg,
+//	    middleware.Redact(rules...),
+//	    middleware.AuditRedacted(sink, rules...),
+//	)
+func AuditRedacted(sink AuditSink, rules ...RedactRule) tool.Middleware {
+	if sink == nil {
+		panic("middleware.AuditRedacted: sink is nil")
+	}
+	red := newRedactor(rules...)
+	return Audit(redactingSink{sink: sink, redactor: red})
+}
+
+// redactingSink redacts each record before handing it to the wrapped
+// sink.
+type redactingSink struct {
+	sink     AuditSink
+	redactor *redactor
+}
+
+func (s redactingSink) Record(ctx context.Context, rec AuditRecord) {
+	rec.Call.Arguments = s.redactor.Bytes(rec.Call.Arguments)
+	rec.Result = s.redactor.Result(rec.Result)
+	s.sink.Record(ctx, rec)
+}
+
+type redactor struct {
+	rules []RedactRule
+}
+
+func newRedactor(rules ...RedactRule) *redactor {
+	for _, rule := range rules {
+		if rule.Pattern == nil {
+			panic("middleware: redaction rule has a nil pattern")
+		}
+	}
+	return &redactor{rules: rules}
+}
+
+func (r *redactor) String(s string) string {
+	if len(r.rules) == 0 {
+		return s
+	}
+	for _, rule := range r.rules {
+		replacement := rule.Replacement
+		if replacement == "" {
+			replacement = DefaultRedaction
+		}
+		s = rule.Pattern.ReplaceAllString(s, replacement)
+	}
+	return s
+}
+
+func (r *redactor) Bytes(b []byte) []byte {
+	if len(r.rules) == 0 {
+		return b
+	}
+	out := b
+	for _, rule := range r.rules {
+		replacement := rule.Replacement
+		if replacement == "" {
+			replacement = DefaultRedaction
+		}
+		out = rule.Pattern.ReplaceAll(out, []byte(replacement))
+	}
+	return out
+}
+
+func (r *redactor) Result(res message.Result) message.Result {
+	res.Content = r.String(res.Content)
+	return res
+}

--- a/sdk/tool/middleware/redact_test.go
+++ b/sdk/tool/middleware/redact_test.go
@@ -1,0 +1,137 @@
+package middleware
+
+import (
+	"context"
+	"encoding/json"
+	"regexp"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/GizClaw/flowcraft/sdk/message"
+	"github.com/GizClaw/flowcraft/sdk/tool"
+)
+
+func TestRedact_RedactsResultKeepsArguments(t *testing.T) {
+	var sawArgs json.RawMessage
+	reg := catalogWith(tool.FuncTool(message.Definition{Name: "secret"},
+		func(_ context.Context, args string) (string, error) {
+			sawArgs = json.RawMessage(args)
+			return "token=abc123 and keep=ok", nil
+		}))
+	exec := tool.NewExecutor(reg, Redact(RedactRule{
+		Pattern: regexp.MustCompile(`abc123`),
+	}))
+
+	res := exec.Execute(context.Background(), message.Call{
+		ID: "c1", Name: "secret", Arguments: json.RawMessage(`{"token":"abc123"}`),
+	})
+	if res.IsError {
+		t.Fatalf("unexpected error: %q", res.Content)
+	}
+	if strings.Contains(res.Content, "abc123") {
+		t.Errorf("result still contains secret: %q", res.Content)
+	}
+	if !strings.Contains(res.Content, "[REDACTED]") {
+		t.Errorf("result has no redaction marker: %q", res.Content)
+	}
+	if got := string(sawArgs); !strings.Contains(got, "abc123") {
+		t.Errorf("tool should receive original arguments for execution, got %s", got)
+	}
+}
+
+func TestRedact_CustomReplacement(t *testing.T) {
+	reg := catalogWith(tool.FuncTool(message.Definition{Name: "card"},
+		func(_ context.Context, _ string) (string, error) {
+			return "card 4111-1111-1111-1111 ok", nil
+		}))
+	exec := tool.NewExecutor(reg, Redact(RedactRule{
+		Pattern:     regexp.MustCompile(`\d{4}-\d{4}-\d{4}-\d{4}`),
+		Replacement: "<card>",
+	}))
+	res := exec.Execute(context.Background(), call("card"))
+	if strings.Contains(res.Content, "4111") {
+		t.Errorf("content still contains card number: %q", res.Content)
+	}
+	if !strings.Contains(res.Content, "<card>") {
+		t.Errorf("content has no custom replacement: %q", res.Content)
+	}
+}
+
+func TestRedact_WithAuditRedactedRecord(t *testing.T) {
+	var mu sync.Mutex
+	var recorded []AuditRecord
+	sink := AuditSinkFunc(func(_ context.Context, rec AuditRecord) {
+		mu.Lock()
+		recorded = append(recorded, rec)
+		mu.Unlock()
+	})
+	reg := catalogWith(tool.FuncTool(message.Definition{Name: "secret"},
+		func(_ context.Context, args string) (string, error) {
+			return "token=abc123", nil
+		}))
+	exec := tool.NewExecutor(reg,
+		Redact(RedactRule{Pattern: regexp.MustCompile(`abc123`)}),
+		AuditRedacted(sink, RedactRule{Pattern: regexp.MustCompile(`abc123`)}),
+	)
+
+	call := message.Call{
+		ID: "c1", Name: "secret", Arguments: json.RawMessage(`{"token":"abc123"}`),
+	}
+	if res := exec.Execute(context.Background(), call); res.IsError {
+		t.Fatalf("unexpected error: %q", res.Content)
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	if len(recorded) != 1 {
+		t.Fatalf("audit records = %d, want 1", len(recorded))
+	}
+	rec := recorded[0]
+	if strings.Contains(string(rec.Call.Arguments), "abc123") {
+		t.Errorf("audit call arguments are not redacted: %s", rec.Call.Arguments)
+	}
+	if strings.Contains(rec.Result.Content, "abc123") {
+		t.Errorf("audit result content is not redacted: %q", rec.Result.Content)
+	}
+}
+
+func TestAuditRedacted_ModelSeesOriginalAuditRedacted(t *testing.T) {
+	var recorded []AuditRecord
+	sink := AuditSinkFunc(func(_ context.Context, rec AuditRecord) {
+		recorded = append(recorded, rec)
+	})
+	reg := catalogWith(tool.FuncTool(message.Definition{Name: "secret"},
+		func(_ context.Context, _ string) (string, error) {
+			return "token=abc123", nil
+		}))
+	exec := tool.NewExecutor(reg,
+		AuditRedacted(sink, RedactRule{
+			Pattern: regexp.MustCompile(`abc123`),
+		}),
+	)
+
+	res := exec.Execute(context.Background(), message.Call{
+		ID: "c1", Name: "secret", Arguments: json.RawMessage(`{"token":"abc123"}`),
+	})
+	if !strings.Contains(res.Content, "abc123") {
+		t.Errorf("model-facing content was redacted, want original: %q", res.Content)
+	}
+	if len(recorded) != 1 {
+		t.Fatalf("audit records = %d, want 1", len(recorded))
+	}
+	if strings.Contains(recorded[0].Result.Content, "abc123") {
+		t.Errorf("audit content is not redacted: %q", recorded[0].Result.Content)
+	}
+	if strings.Contains(string(recorded[0].Call.Arguments), "abc123") {
+		t.Errorf("audit arguments are not redacted: %s", recorded[0].Call.Arguments)
+	}
+}
+
+func TestRedact_NilPatternPanics(t *testing.T) {
+	defer func() {
+		if recover() == nil {
+			t.Error("expected panic for nil pattern")
+		}
+	}()
+	Redact(RedactRule{Replacement: "x"})
+}

--- a/sdk/tool/middleware/resultlimit.go
+++ b/sdk/tool/middleware/resultlimit.go
@@ -1,0 +1,81 @@
+package middleware
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/GizClaw/flowcraft/sdk/message"
+	"github.com/GizClaw/flowcraft/sdk/tool"
+)
+
+// DefaultResultMarker is appended to a result whose content exceeds the
+// configured limit. It is deliberately plain and model-readable:
+// truncation is an outcome the model should see and self-correct from,
+// not a hidden loss of data.
+const DefaultResultMarker = "\n…[result truncated]"
+
+// ResultLimiter caps how long a tool result may be. Content beyond the
+// limit is dropped and DefaultResultMarker (or a custom marker) is
+// appended, so the model knows the result was shortened. IsError is
+// preserved: truncation is not an error, it is a policy outcome.
+//
+// The limit is measured in Unicode code points, not bytes, so a
+// multibyte result is never cut in the middle of a rune. The marker
+// itself counts against the limit; when the limit is too small to hold
+// the full marker, the marker is trimmed to fit.
+//
+// Place it inside (after) Recover and Telemetry and outside (before)
+// Audit so every downstream consumer — including audit — sees the
+// final, limited content.
+func ResultLimiter(max int, opts ...ResultLimitOption) tool.Middleware {
+	if max <= 0 {
+		panic(fmt.Sprintf("middleware.ResultLimiter: max must be positive, got %d", max))
+	}
+	cfg := resultLimitConfig{marker: DefaultResultMarker}
+	for _, opt := range opts {
+		if opt != nil {
+			opt(&cfg)
+		}
+	}
+	if cfg.marker == "" {
+		cfg.marker = DefaultResultMarker
+	}
+	return func(next tool.Dispatch) tool.Dispatch {
+		return func(ctx context.Context, call message.Call) message.Result {
+			return limitResult(next(ctx, call), max, cfg.marker)
+		}
+	}
+}
+
+// ResultLimitOption configures a ResultLimiter.
+type ResultLimitOption func(*resultLimitConfig)
+
+type resultLimitConfig struct {
+	marker string
+}
+
+// WithResultMarker replaces the truncation marker appended to limited
+// results. An empty marker falls back to DefaultResultMarker.
+func WithResultMarker(marker string) ResultLimitOption {
+	return func(c *resultLimitConfig) { c.marker = marker }
+}
+
+func limitResult(res message.Result, max int, marker string) message.Result {
+	runes := []rune(res.Content)
+	if len(runes) <= max {
+		return res
+	}
+	markerRunes := []rune(marker)
+	if len(markerRunes) > max {
+		markerRunes = markerRunes[:max]
+	}
+	keep := max - len(markerRunes)
+	if keep < 0 {
+		keep = 0
+	}
+	out := make([]rune, 0, max)
+	out = append(out, runes[:keep]...)
+	out = append(out, markerRunes...)
+	res.Content = string(out)
+	return res
+}

--- a/sdk/tool/middleware/resultlimit_test.go
+++ b/sdk/tool/middleware/resultlimit_test.go
@@ -1,0 +1,100 @@
+package middleware
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/GizClaw/flowcraft/sdk/message"
+	"github.com/GizClaw/flowcraft/sdk/tool"
+)
+
+func longTool(n int) tool.Tool {
+	return tool.FuncTool(message.Definition{Name: "long"},
+		func(_ context.Context, _ string) (string, error) {
+			return strings.Repeat("x", n), nil
+		})
+}
+
+func TestResultLimiter_TruncatesWithMarker(t *testing.T) {
+	exec := tool.NewExecutor(catalogWith(longTool(1000)), ResultLimiter(100))
+	res := exec.Execute(context.Background(), call("long"))
+	if res.IsError {
+		t.Fatalf("unexpected error result: %q", res.Content)
+	}
+	if len([]rune(res.Content)) != 100 {
+		t.Errorf("limited content length = %d, want 100", len([]rune(res.Content)))
+	}
+	if !strings.HasSuffix(res.Content, DefaultResultMarker) {
+		t.Errorf("content %q does not end with default marker %q", res.Content, DefaultResultMarker)
+	}
+}
+
+func TestResultLimiter_UnderLimitUntouched(t *testing.T) {
+	exec := tool.NewExecutor(catalogWith(longTool(50)), ResultLimiter(100))
+	res := exec.Execute(context.Background(), call("long"))
+	if res.Content != strings.Repeat("x", 50) {
+		t.Errorf("content = %q, want the full 50 runes", res.Content)
+	}
+}
+
+func TestResultLimiter_TruncatesErrorResults(t *testing.T) {
+	exec := tool.NewExecutor(catalogWith(tool.FuncTool(
+		message.Definition{Name: "boom"},
+		func(_ context.Context, _ string) (string, error) {
+			return "", &errLike{}
+		})), ResultLimiter(20))
+	res := exec.Execute(context.Background(), call("boom"))
+	if !res.IsError {
+		t.Fatal("expected IsError to survive truncation")
+	}
+	if len([]rune(res.Content)) != 20 {
+		t.Errorf("limited error length = %d, want 20", len([]rune(res.Content)))
+	}
+}
+
+type errLike struct{}
+
+func (e *errLike) Error() string { return strings.Repeat("y", 500) }
+
+func TestResultLimiter_CustomMarker(t *testing.T) {
+	exec := tool.NewExecutor(catalogWith(longTool(1000)),
+		ResultLimiter(64, WithResultMarker("[cut here]")))
+	res := exec.Execute(context.Background(), call("long"))
+	if !strings.HasSuffix(res.Content, "[cut here]") {
+		t.Errorf("content %q does not end with custom marker", res.Content)
+	}
+}
+
+func TestResultLimiter_TrimsMarkerToFitTinyLimit(t *testing.T) {
+	exec := tool.NewExecutor(catalogWith(longTool(1000)),
+		ResultLimiter(3, WithResultMarker("MARK")))
+	res := exec.Execute(context.Background(), call("long"))
+	if res.Content != "MAR" {
+		t.Errorf("content = %q, want marker trimmed to 3 runes", res.Content)
+	}
+}
+
+func TestResultLimiter_DoesNotSplitRunes(t *testing.T) {
+	content := strings.Repeat("你", 100)
+	exec := tool.NewExecutor(catalogWith(tool.FuncTool(
+		message.Definition{Name: "cjk"},
+		func(_ context.Context, _ string) (string, error) { return content, nil })),
+		ResultLimiter(40))
+	res := exec.Execute(context.Background(), call("cjk"))
+	if !strings.HasSuffix(res.Content, DefaultResultMarker) {
+		t.Fatalf("content %q does not end with marker", res.Content)
+	}
+	if len([]rune(res.Content)) != 40 {
+		t.Errorf("limited content length = %d, want 40 runes", len([]rune(res.Content)))
+	}
+}
+
+func TestResultLimiter_InvalidMaxPanics(t *testing.T) {
+	defer func() {
+		if recover() == nil {
+			t.Error("expected panic for non-positive max")
+		}
+	}()
+	ResultLimiter(0)
+}

--- a/sdkx/go.mod
+++ b/sdkx/go.mod
@@ -20,6 +20,7 @@ require (
 	go.opentelemetry.io/otel/sdk/log/logtest v0.16.0
 	go.opentelemetry.io/otel/trace v1.43.0
 	golang.org/x/net v0.56.0
+	golang.org/x/sync v0.22.0
 	gopkg.in/natefinch/lumberjack.v2 v2.2.1
 	modernc.org/sqlite v1.56.0
 )
@@ -46,9 +47,6 @@ require (
 	modernc.org/mathutil v1.7.1 // indirect
 	modernc.org/memory v1.11.0 // indirect
 	sigs.k8s.io/yaml v1.4.0 // indirect
-)
-
-require (
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.17.0 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/internal v1.10.0 // indirect
 	github.com/bahlo/generic-list-go v0.2.0 // indirect
@@ -85,7 +83,6 @@ require (
 	go.opentelemetry.io/otel/sdk/metric v1.43.0
 	go.opentelemetry.io/proto/otlp v1.9.0 // indirect
 	go.yaml.in/yaml/v4 v4.0.0-rc.2 // indirect
-	golang.org/x/sync v0.22.0 // indirect
 	golang.org/x/text v0.40.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20260427160629-7cedc36a6bc4 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260427160629-7cedc36a6bc4 // indirect

--- a/sdkx/runtime/session/catalog.go
+++ b/sdkx/runtime/session/catalog.go
@@ -1,0 +1,30 @@
+package session
+
+import (
+	"context"
+
+	"github.com/GizClaw/flowcraft/sdk/tool"
+	"github.com/GizClaw/flowcraft/sdkx/deploy"
+)
+
+// CatalogProvider constructs the per-session tool catalog. The provider
+// runs once per Session (on its first Start) and its result is attached
+// to every turn's execution context, where session-scoped tools
+// (tool_search) and the inference node's all_tools mode pick it up. The
+// Session owns the catalog: it is closed exactly once when the Session
+// closes, via the optional io.Closer contract.
+//
+// The provider is deliberately generic — it returns tool.Catalog, not a
+// dynamic catalog — so hosts can supply a dynamic injection view, a
+// filtered view, or nothing at all without the runtime knowing which.
+type CatalogProvider interface {
+	NewCatalog(ctx context.Context, instance *deploy.Instance) (tool.Catalog, error)
+}
+
+// CatalogProviderFunc adapts a plain function to CatalogProvider.
+type CatalogProviderFunc func(ctx context.Context, instance *deploy.Instance) (tool.Catalog, error)
+
+// NewCatalog implements CatalogProvider.
+func (f CatalogProviderFunc) NewCatalog(ctx context.Context, instance *deploy.Instance) (tool.Catalog, error) {
+	return f(ctx, instance)
+}

--- a/sdkx/runtime/session/catalog_test.go
+++ b/sdkx/runtime/session/catalog_test.go
@@ -1,0 +1,175 @@
+package session
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/GizClaw/flowcraft/sdk/agent"
+	"github.com/GizClaw/flowcraft/sdk/event"
+	"github.com/GizClaw/flowcraft/sdk/message"
+	sdktool "github.com/GizClaw/flowcraft/sdk/tool"
+	"github.com/GizClaw/flowcraft/sdkx/deploy"
+)
+
+type fakeSessionCatalog struct {
+	defs   []message.Definition
+	closed atomic.Int64
+}
+
+func (f *fakeSessionCatalog) Get(string) (sdktool.Tool, bool) { return nil, false }
+func (f *fakeSessionCatalog) Definitions() []message.Definition {
+	return f.defs
+}
+func (f *fakeSessionCatalog) Close() error {
+	f.closed.Add(1)
+	return nil
+}
+
+func catalogAwareHostFactory(t *testing.T, bus event.Bus, got *sdktool.Catalog) HostFactory {
+	t.Helper()
+	var mu sync.Mutex
+	return HostFactoryFunc(func(ctx context.Context, _ HostRequest) (agent.Host, error) {
+		catalog, ok := sdktool.CatalogFromContext(ctx)
+		mu.Lock()
+		if ok {
+			*got = catalog
+		}
+		mu.Unlock()
+		if !ok {
+			t.Error("turn context carries no session catalog")
+		}
+		return testHost{bus: bus}, nil
+	})
+}
+
+func TestSessionCatalogProvider_AttachesOnceAndCloses(t *testing.T) {
+	cat := &fakeSessionCatalog{}
+	var providerCalls atomic.Int64
+	provider := CatalogProviderFunc(func(context.Context, *deploy.Instance) (sdktool.Catalog, error) {
+		providerCalls.Add(1)
+		return cat, nil
+	})
+
+	var saw sdktool.Catalog
+	engine := agent.EngineFunc(func(
+		ctx context.Context,
+		run agent.Run,
+		host agent.Host,
+		board *agent.Board,
+	) (*agent.Board, error) {
+		return board, nil
+	})
+	_, session, _, _ := newTurnSession(t, engine,
+		func(bus event.Bus) HostFactory { return catalogAwareHostFactory(t, bus, &saw) },
+		WithCatalogProvider(provider),
+	)
+
+	req := agent.Request{Message: message.NewTextMessage(message.RoleUser, "hi")}
+	for i := 0; i < 2; i++ {
+		turn, err := session.Start(context.Background(), req)
+		if err != nil {
+			t.Fatalf("Start %d: %v", i, err)
+		}
+		if _, err := turn.Wait(context.Background()); err != nil {
+			t.Fatalf("Wait %d: %v", i, err)
+		}
+	}
+	if providerCalls.Load() != 1 {
+		t.Errorf("provider calls = %d, want 1 (created once per session)", providerCalls.Load())
+	}
+	if saw == nil || saw != sdktool.Catalog(cat) {
+		t.Errorf("host saw catalog %T, want the provider's catalog", saw)
+	}
+}
+
+func TestSessionCatalogProvider_CloseFoldsIntoSessionClose(t *testing.T) {
+	cat := &fakeSessionCatalog{}
+	_, session, _, _ := newTurnSession(t,
+		agent.EngineFunc(func(
+			ctx context.Context,
+			run agent.Run,
+			host agent.Host,
+			board *agent.Board,
+		) (*agent.Board, error) {
+			return board, nil
+		}),
+		func(bus event.Bus) HostFactory {
+			return HostFactoryFunc(func(context.Context, HostRequest) (agent.Host, error) {
+				return testHost{bus: bus}, nil
+			})
+		},
+		WithCatalogProvider(CatalogProviderFunc(func(context.Context, *deploy.Instance) (sdktool.Catalog, error) {
+			return cat, nil
+		})),
+	)
+
+	// Force catalog creation, then close the session.
+	if _, err := session.Start(context.Background(),
+		agent.Request{Message: message.NewTextMessage(message.RoleUser, "hi")}); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	if err := session.close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+	if cat.closed.Load() != 1 {
+		t.Errorf("catalog close calls = %d, want exactly 1", cat.closed.Load())
+	}
+}
+
+func TestSessionCatalogProvider_ProviderErrorFailsStart(t *testing.T) {
+	_, session, _, _ := newTurnSession(t,
+		agent.EngineFunc(func(
+			ctx context.Context,
+			run agent.Run,
+			host agent.Host,
+			board *agent.Board,
+		) (*agent.Board, error) {
+			return board, nil
+		}),
+		func(bus event.Bus) HostFactory {
+			return HostFactoryFunc(func(context.Context, HostRequest) (agent.Host, error) {
+				return testHost{bus: bus}, nil
+			})
+		},
+		WithCatalogProvider(CatalogProviderFunc(func(context.Context, *deploy.Instance) (sdktool.Catalog, error) {
+			return nil, errors.New("catalog unavailable")
+		})),
+	)
+	_, err := session.Start(context.Background(),
+		agent.Request{Message: message.NewTextMessage(message.RoleUser, "hi")})
+	if err == nil || err.Error() != "catalog unavailable" {
+		t.Fatalf("Start error = %v, want provider error", err)
+	}
+}
+
+func TestSessionCatalogProvider_NilProviderIsNoop(t *testing.T) {
+	_, session, _, _ := newTurnSession(t,
+		agent.EngineFunc(func(
+			ctx context.Context,
+			run agent.Run,
+			host agent.Host,
+			board *agent.Board,
+		) (*agent.Board, error) {
+			return board, nil
+		}),
+		func(bus event.Bus) HostFactory {
+			return HostFactoryFunc(func(ctx context.Context, _ HostRequest) (agent.Host, error) {
+				if _, ok := sdktool.CatalogFromContext(ctx); ok {
+					t.Error("no provider configured, but a catalog reached the turn context")
+				}
+				return testHost{bus: bus}, nil
+			})
+		},
+	)
+	turn, err := session.Start(context.Background(),
+		agent.Request{Message: message.NewTextMessage(message.RoleUser, "hi")})
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	if _, err := turn.Wait(context.Background()); err != nil {
+		t.Fatalf("Wait: %v", err)
+	}
+}

--- a/sdkx/runtime/session/manager.go
+++ b/sdkx/runtime/session/manager.go
@@ -39,6 +39,7 @@ type Manager struct {
 	checkpoints       agent.CheckpointStore
 	resume            bool
 	observer          SessionObserver
+	catalogProvider   CatalogProvider
 
 	mu        sync.Mutex
 	entries   map[Key]*managerEntry
@@ -98,6 +99,7 @@ func NewManager(
 		checkpoints:       opts.checkpoints,
 		resume:            opts.resume,
 		observer:          opts.observer,
+		catalogProvider:   opts.catalogProvider,
 		entries:           make(map[Key]*managerEntry),
 	}, nil
 }
@@ -152,6 +154,7 @@ func (m *Manager) open(ctx context.Context, key Key) (*Lease, error) {
 		key, instance, m.hostFactory, m.router, m.sinkBuffer,
 		m.speculativeEvents, m.speculativeBytes,
 		m.checkpoints, m.resume,
+		m.catalogProvider,
 		func(changed *Session) {
 			m.activityChanged(key, changed)
 		},

--- a/sdkx/runtime/session/options.go
+++ b/sdkx/runtime/session/options.go
@@ -22,6 +22,7 @@ type managerOptions struct {
 	checkpoints       agent.CheckpointStore
 	resume            bool
 	observer          SessionObserver
+	catalogProvider   CatalogProvider
 }
 
 // WithSinkBufferSize sets the queue size used when SinkSpec.QueueSize is zero.
@@ -56,6 +57,20 @@ func WithSessionObserver(observer SessionObserver) ManagerOption {
 			return errdefs.Validationf("runtime session: session observer is required")
 		}
 		options.observer = observer
+		return nil
+	}
+}
+
+// WithCatalogProvider wires a per-session tool catalog provider. When
+// set, every Session created by this Manager builds one catalog on its
+// first Start, attaches it to each turn's execution context, and closes
+// it when the Session closes.
+func WithCatalogProvider(provider CatalogProvider) ManagerOption {
+	return func(options *managerOptions) error {
+		if isNil(provider) {
+			return errdefs.Validationf("runtime session: catalog provider is required")
+		}
+		options.catalogProvider = provider
 		return nil
 	}
 }

--- a/sdkx/runtime/session/session.go
+++ b/sdkx/runtime/session/session.go
@@ -6,11 +6,13 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"io"
 	"sync"
 	"time"
 
 	"github.com/GizClaw/flowcraft/sdk/agent"
 	"github.com/GizClaw/flowcraft/sdk/errdefs"
+	sdktool "github.com/GizClaw/flowcraft/sdk/tool"
 	"github.com/GizClaw/flowcraft/sdkx/deploy"
 )
 
@@ -34,6 +36,7 @@ type Session struct {
 	speculativeBytes  int
 	checkpoints       agent.CheckpointStore
 	resume            bool
+	catalogProvider   CatalogProvider
 
 	startMu        sync.Mutex
 	mu             sync.Mutex
@@ -42,6 +45,7 @@ type Session struct {
 	attachedSinks  int
 	active         *Turn
 	closing        bool
+	catalog        sdktool.Catalog
 	activityNotify func(*Session)
 	observer       SessionObserver
 	closeOnce      sync.Once
@@ -58,6 +62,7 @@ func newSession(
 	speculativeBytes int,
 	checkpoints agent.CheckpointStore,
 	resume bool,
+	catalogProvider CatalogProvider,
 	activityNotify func(*Session),
 	observer SessionObserver,
 ) *Session {
@@ -71,6 +76,7 @@ func newSession(
 		speculativeBytes:  speculativeBytes,
 		checkpoints:       checkpoints,
 		resume:            resume,
+		catalogProvider:   catalogProvider,
 		activityNotify:    activityNotify,
 		observer:          observer,
 	}
@@ -148,6 +154,14 @@ func (s *Session) Start(ctx context.Context, request agent.Request, sinks ...Sin
 	turn := newTurn(s, runID, ctx)
 	turn.resumeFrom = resumeFrom
 	turn.resumeCtx = resumeCtx
+	catalog, err := s.catalogFor(ctx)
+	if err != nil {
+		turn.cancel()
+		return nil, err
+	}
+	if catalog != nil {
+		turn.runCtx = sdktool.WithCatalogOnContext(turn.runCtx, catalog)
+	}
 	hostRequest := HostRequest{
 		Key:        s.key,
 		RunID:      runID,
@@ -404,9 +418,65 @@ func (s *Session) close() error {
 			}
 		}
 		s.startMu.Unlock()
+		s.closeCatalog()
 		s.notifySessionClosed(s.closeErr)
 	})
 	return s.closeErr
+}
+
+// catalogFor returns the session catalog, creating it once via the
+// provider on the first Start. Start is serialized by startMu, so the
+// creation path is race-free; the defensive branch handles a provider
+// shared with code paths outside this Session.
+func (s *Session) catalogFor(ctx context.Context) (sdktool.Catalog, error) {
+	s.mu.Lock()
+	catalog := s.catalog
+	s.mu.Unlock()
+	if catalog != nil {
+		return catalog, nil
+	}
+	if s.catalogProvider == nil {
+		return nil, nil
+	}
+	catalog, err := s.catalogProvider.NewCatalog(ctx, s.instance)
+	if err != nil {
+		return nil, err
+	}
+	if catalog == nil {
+		return nil, errdefs.Internalf(
+			"runtime session: CatalogProvider returned a nil catalog")
+	}
+	s.mu.Lock()
+	if s.catalog == nil {
+		s.catalog = catalog
+	} else {
+		if closer, ok := catalog.(io.Closer); ok {
+			_ = closer.Close()
+		}
+		catalog = s.catalog
+	}
+	s.mu.Unlock()
+	return catalog, nil
+}
+
+// closeCatalog closes the session catalog exactly once, after any
+// active turn has been awaited. A close error is folded into the
+// session's close error when none is set yet.
+func (s *Session) closeCatalog() {
+	s.mu.Lock()
+	catalog := s.catalog
+	s.catalog = nil
+	s.mu.Unlock()
+	if catalog == nil {
+		return
+	}
+	closer, ok := catalog.(io.Closer)
+	if !ok {
+		return
+	}
+	if err := closer.Close(); err != nil && s.closeErr == nil {
+		s.closeErr = err
+	}
 }
 
 func (s *Session) beginClose() {

--- a/sdkx/sandbox/bwrap/runner_linux_test.go
+++ b/sdkx/sandbox/bwrap/runner_linux_test.go
@@ -518,25 +518,9 @@ func TestRunner_ProcessManager_UnixSocketBindFlags(t *testing.T) {
 	}
 	defer func() { _ = proc.Close() }()
 
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-	defer cancel()
-	var sb strings.Builder
-	var seq int64
-	for {
-		out, err := proc.Read(ctx, seq, 4096)
-		if err != nil {
-			t.Fatalf("Read: %v", err)
-		}
-		for _, ch := range out.Chunks {
-			sb.Write(ch.Data)
-		}
-		seq = out.NextSeq
-		if out.EOF {
-			break
-		}
-	}
-	if !strings.Contains(sb.String(), "ARG:--bind\nARG:"+sock+"\n") {
-		t.Fatalf("unix socket bind not emitted: %q", sb.String())
+	sb := drainProcessStdout(t, proc)
+	if !strings.Contains(sb, "ARG:--bind\nARG:"+sock+"\n") {
+		t.Fatalf("unix socket bind not emitted: %q", sb)
 	}
 }
 
@@ -590,6 +574,19 @@ func TestRunner_ProcessManager_MITMBundleInjected(t *testing.T) {
 	}
 	defer func() { _ = proc.Close() }()
 
+	sb := drainProcessStdout(t, proc)
+	if !strings.Contains(sb, "ARG:SSL_CERT_FILE") || !strings.Contains(sb, "ARG:--ro-bind") {
+		t.Fatalf("MITM CA bundle env/bind missing: %q", sb)
+	}
+}
+
+// drainProcessStdout reads a process to EOF and returns only its stdout
+// bytes. The fake bwrap prints ARG: lines on stdout and the command
+// name on stderr; Process.Read merges the two streams into one chunk
+// sequence with no ordering guarantee between them, so argv-shape
+// assertions must look at stdout alone to be deterministic.
+func drainProcessStdout(t *testing.T, proc sandbox.Process) string {
+	t.Helper()
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 	var sb strings.Builder
@@ -600,14 +597,14 @@ func TestRunner_ProcessManager_MITMBundleInjected(t *testing.T) {
 			t.Fatalf("Read: %v", err)
 		}
 		for _, ch := range out.Chunks {
-			sb.Write(ch.Data)
+			if ch.Stream == sandbox.ProcessStreamStdout {
+				sb.Write(ch.Data)
+			}
 		}
 		seq = out.NextSeq
 		if out.EOF {
 			break
 		}
 	}
-	if !strings.Contains(sb.String(), "ARG:SSL_CERT_FILE") || !strings.Contains(sb.String(), "ARG:--ro-bind") {
-		t.Fatalf("MITM CA bundle env/bind missing: %q", sb.String())
-	}
+	return sb.String()
 }

--- a/sdkx/tool/dynamic/catalog.go
+++ b/sdkx/tool/dynamic/catalog.go
@@ -138,7 +138,11 @@ func (c *Catalog) Require(names ...string) {
 }
 
 // Select marks names as selected for the policy's retention rounds.
-// tool_search calls this for its select argument.
+// Selection carries an implicit load contract: a selected tool must be
+// loaded before the next Definitions call, otherwise the model would
+// see its placeholder schema. tool_search enforces this by loading each
+// name before selecting; direct callers (hosts) are responsible for
+// preloading via EnsureLoaded.
 func (c *Catalog) Select(names ...string) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
@@ -285,6 +289,9 @@ func (c *Catalog) EnsureLoaded(ctx context.Context, names ...string) error {
 				}
 				continue
 			}
+			// A concrete tool needs no loading; it is loaded by
+			// definition, so selection is safe.
+			continue
 		}
 		errs = append(errs, errdefs.NotFoundf(
 			"dynamic: no deferred loader for tool %q", name))

--- a/sdkx/tool/dynamic/catalog.go
+++ b/sdkx/tool/dynamic/catalog.go
@@ -1,0 +1,326 @@
+package dynamic
+
+import (
+	"context"
+	"errors"
+	"sync"
+
+	"github.com/GizClaw/flowcraft/sdk/errdefs"
+	"github.com/GizClaw/flowcraft/sdk/message"
+	sdktool "github.com/GizClaw/flowcraft/sdk/tool"
+)
+
+// Catalog is the session-scoped, model-facing view over a shared
+// tool.Registry. It implements the tool.Catalog contract with
+// Exposure-based injection:
+//
+//   - Get and Definitions never load, never block on the network, and
+//     never fail — every deferred source is loaded through Load /
+//     EnsureLoaded / Execute instead;
+//   - Definitions is a pure function of the current state, so repeated
+//     calls with the same state return identical, sorted output;
+//   - the underlying Registry remains the execution surface, so
+//     injection never gates callability.
+//
+// A Catalog is per-session state: create it when a conversation starts,
+// advance turns after each inference round, and Close it when the
+// conversation ends to release deferred tool sessions.
+type Catalog struct {
+	reg *sdktool.Registry
+
+	mu      sync.RWMutex
+	policy  Policy
+	st      state
+	proxies map[string]*LazyTool
+	closed  bool
+}
+
+// Option configures the catalog policy. Options mutate the policy in
+// order, so WithPolicy may be overridden by later options.
+type Option func(*Policy)
+
+// WithPolicy replaces the whole policy.
+func WithPolicy(p Policy) Option {
+	return func(dst *Policy) { *dst = p }
+}
+
+// WithDefaultExposure sets the exposure applied to tools without an
+// explicit entry.
+func WithDefaultExposure(e Exposure) Option {
+	return func(p *Policy) { p.Default = e }
+}
+
+// WithExposure pins one tool to an explicit exposure.
+func WithExposure(name string, e Exposure) Option {
+	return func(p *Policy) { p.Exposures[name] = e }
+}
+
+// WithSelectedRetention sets how many rounds a selected tool stays
+// visible (M).
+func WithSelectedRetention(rounds int) Option {
+	return func(p *Policy) { p.SelectedRetention = rounds }
+}
+
+// WithRecentWindow sets how many rounds a used direct tool stays
+// visible.
+func WithRecentWindow(rounds int) Option {
+	return func(p *Policy) { p.RecentWindow = rounds }
+}
+
+// WithBudget sets the per-turn definition budget.
+func WithBudget(b Budget) Option {
+	return func(p *Policy) { p.Budget = b }
+}
+
+// New creates a catalog over reg with the given policy options. A nil
+// registry or invalid policy is a programming bug and panics.
+func New(reg *sdktool.Registry, opts ...Option) *Catalog {
+	if reg == nil {
+		panic("dynamic.New: registry is nil")
+	}
+	policy := DefaultPolicy()
+	for _, opt := range opts {
+		if opt != nil {
+			opt(&policy)
+		}
+	}
+	if err := policy.Validate(); err != nil {
+		panic("dynamic.New: " + err.Error())
+	}
+	return &Catalog{
+		reg:     reg,
+		policy:  policy,
+		st:      *newState(),
+		proxies: make(map[string]*LazyTool),
+	}
+}
+
+// Get implements tool.Catalog. It never loads: the proxy returned for a
+// deferred tool stays valid and loads on Execute.
+func (c *Catalog) Get(name string) (sdktool.Tool, bool) {
+	return c.reg.Get(name)
+}
+
+// Definitions implements tool.Catalog: the visibility-filtered,
+// budget-pruned, name-sorted definitions for this round.
+func (c *Catalog) Definitions() []message.Definition {
+	c.mu.RLock()
+	policy := c.policyCopy()
+	st := c.st.snapshot()
+	c.mu.RUnlock()
+
+	all := c.reg.Definitions()
+	cands := make([]candidate, 0, len(all))
+	for _, def := range all {
+		cands = append(cands, candidate{
+			name: def.Name,
+			def:  def,
+			exp:  policy.exposureOf(def.Name),
+		})
+	}
+	visible := visibleCandidates(cands, st, policy)
+	out := make([]message.Definition, 0, len(visible))
+	for _, cand := range visible {
+		out = append(out, cand.def)
+	}
+	return out
+}
+
+// Require adds names to the RequiredByName set. Tools named in a
+// node's explicit tools list should be required before each round.
+func (c *Catalog) Require(names ...string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.closed {
+		return
+	}
+	c.st.require(names...)
+}
+
+// Select marks names as selected for the policy's retention rounds.
+// tool_search calls this for its select argument.
+func (c *Catalog) Select(names ...string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.closed {
+		return
+	}
+	c.st.selectNames(names, c.policy.selectedRetention())
+}
+
+// RecordCall records that the model called name this round, refreshing
+// its Selected and UsedRecently state.
+func (c *Catalog) RecordCall(call message.Call) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.closed {
+		return
+	}
+	c.st.recordCall(call.Name, c.policy.selectedRetention())
+}
+
+// AdvanceTurn moves to the next round, expiring Selected and
+// UsedRecently entries. Call it once per inference round (e.g. in
+// OnTurnFinished).
+func (c *Catalog) AdvanceTurn() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.closed {
+		return
+	}
+	c.st.advanceTurn(c.policy.recentWindow())
+}
+
+// SetExposure updates one tool's exposure at runtime. It takes effect
+// on the next Definitions call.
+func (c *Catalog) SetExposure(name string, e Exposure) error {
+	if !e.Valid() {
+		return errdefs.Validationf("dynamic: exposure %q is invalid", e)
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.closed {
+		return errdefs.NotAvailablef("dynamic: catalog is closed")
+	}
+	c.policy.Exposures[name] = e
+	return nil
+}
+
+// Register adds an already-implemented tool to the shared registry and
+// records its exposure. It is a convenience for hosts that build the
+// dynamic surface programmatically.
+func (c *Catalog) Register(t sdktool.Tool, exp Exposure) error {
+	if t == nil {
+		return errdefs.Validationf("dynamic: Register: tool is nil")
+	}
+	def := t.Definition()
+	if def.Name == "" {
+		return errdefs.Validationf("dynamic: Register: tool definition name is required")
+	}
+	if !exp.Valid() {
+		return errdefs.Validationf("dynamic: exposure %q is invalid", exp)
+	}
+	c.mu.Lock()
+	if c.closed {
+		c.mu.Unlock()
+		return errdefs.NotAvailablef("dynamic: catalog is closed")
+	}
+	c.policy.Exposures[def.Name] = exp
+	c.mu.Unlock()
+	c.reg.Register(t)
+	return nil
+}
+
+// RegisterProxy creates a deferred proxy, registers it into the shared
+// registry, and records its exposure. The loader runs only when
+// EnsureLoaded / Load / Execute demands it.
+func (c *Catalog) RegisterProxy(name string, loader Loader, exp Exposure, opts ...LazyOption) error {
+	if name == "" {
+		return errdefs.Validationf("dynamic: RegisterProxy: name is empty")
+	}
+	if loader == nil {
+		return errdefs.Validationf("dynamic: RegisterProxy: loader is nil")
+	}
+	if !exp.Valid() {
+		return errdefs.Validationf("dynamic: exposure %q is invalid", exp)
+	}
+	c.mu.Lock()
+	if c.closed {
+		c.mu.Unlock()
+		return errdefs.NotAvailablef("dynamic: catalog is closed")
+	}
+	if _, exists := c.proxies[name]; exists {
+		c.mu.Unlock()
+		return errdefs.Conflictf("dynamic: proxy %q already registered", name)
+	}
+	proxy := NewLazyTool(c.reg, name, loader, opts...)
+	c.proxies[name] = proxy
+	c.policy.Exposures[name] = exp
+	c.mu.Unlock()
+	c.reg.Register(proxy)
+	return nil
+}
+
+// Load eagerly loads every deferred proxy. One failing source does not
+// stop the others; errors are joined. tool_search calls this before
+// ranking so freshly attached servers contribute results.
+func (c *Catalog) Load(ctx context.Context) error {
+	c.mu.RLock()
+	proxies := make([]*LazyTool, 0, len(c.proxies))
+	for _, proxy := range c.proxies {
+		proxies = append(proxies, proxy)
+	}
+	c.mu.RUnlock()
+
+	var errs []error
+	for _, proxy := range proxies {
+		if err := proxy.EnsureLoaded(ctx); err != nil {
+			errs = append(errs, err)
+		}
+	}
+	return errors.Join(errs...)
+}
+
+// EnsureLoaded loads the named proxies. With no names it behaves like
+// Load.
+func (c *Catalog) EnsureLoaded(ctx context.Context, names ...string) error {
+	if len(names) == 0 {
+		return c.Load(ctx)
+	}
+	var errs []error
+	for _, name := range names {
+		c.mu.RLock()
+		proxy := c.proxies[name]
+		c.mu.RUnlock()
+		if proxy != nil {
+			if err := proxy.EnsureLoaded(ctx); err != nil {
+				errs = append(errs, err)
+			}
+			continue
+		}
+		if t, ok := c.reg.Get(name); ok {
+			if lazy, ok := t.(interface{ EnsureLoaded(context.Context) error }); ok {
+				if err := lazy.EnsureLoaded(ctx); err != nil {
+					errs = append(errs, err)
+				}
+				continue
+			}
+		}
+		errs = append(errs, errdefs.NotFoundf(
+			"dynamic: no deferred loader for tool %q", name))
+	}
+	return errors.Join(errs...)
+}
+
+// Close releases every deferred proxy session. Idempotent.
+func (c *Catalog) Close() error {
+	c.mu.Lock()
+	if c.closed {
+		c.mu.Unlock()
+		return nil
+	}
+	c.closed = true
+	proxies := make([]*LazyTool, 0, len(c.proxies))
+	for _, proxy := range c.proxies {
+		proxies = append(proxies, proxy)
+	}
+	c.proxies = make(map[string]*LazyTool)
+	c.mu.Unlock()
+
+	var errs []error
+	for _, proxy := range proxies {
+		if err := proxy.Close(); err != nil {
+			errs = append(errs, err)
+		}
+	}
+	return errors.Join(errs...)
+}
+
+func (c *Catalog) policyCopy() Policy {
+	p := c.policy
+	p.Exposures = make(map[string]Exposure, len(c.policy.Exposures))
+	for name, e := range c.policy.Exposures {
+		p.Exposures[name] = e
+	}
+	return p
+}

--- a/sdkx/tool/dynamic/catalog_test.go
+++ b/sdkx/tool/dynamic/catalog_test.go
@@ -1,0 +1,273 @@
+package dynamic
+
+import (
+	"context"
+	"encoding/json"
+	"reflect"
+	"sync/atomic"
+	"testing"
+
+	"github.com/GizClaw/flowcraft/sdk/errdefs"
+	"github.com/GizClaw/flowcraft/sdk/message"
+	sdktool "github.com/GizClaw/flowcraft/sdk/tool"
+)
+
+func funcTool(name, desc string) sdktool.Tool {
+	return sdktool.FuncTool(message.Definition{
+		Name:        name,
+		Description: desc,
+		InputSchema: json.RawMessage(`{"type":"object"}`),
+	}, func(_ context.Context, _ string) (string, error) {
+		return "ran:" + name, nil
+	})
+}
+
+func testCatalog(t *testing.T, reg *sdktool.Registry) *Catalog {
+	t.Helper()
+	c := New(reg,
+		WithExposure("always_tool", ExposureAlways),
+		WithExposure("direct_tool", ExposureDirect),
+		WithExposure("deferred_tool", ExposureDeferred),
+		WithExposure("hidden_tool", ExposureHidden),
+		WithSelectedRetention(2),
+		WithRecentWindow(1),
+	)
+	return c
+}
+
+func names(defs []message.Definition) []string {
+	out := make([]string, 0, len(defs))
+	for _, d := range defs {
+		out = append(out, d.Name)
+	}
+	return out
+}
+
+func TestCatalog_BaselineDefinitions(t *testing.T) {
+	reg := sdktool.NewRegistry()
+	reg.Register(funcTool("always_tool", "alpha"))
+	reg.Register(funcTool("direct_tool", "beta"))
+	reg.Register(funcTool("deferred_tool", "gamma"))
+	reg.Register(funcTool("hidden_tool", "delta"))
+	c := testCatalog(t, reg)
+	t.Cleanup(func() { _ = c.Close() })
+
+	got := names(c.Definitions())
+	want := []string{"always_tool"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("Definitions = %v, want %v", got, want)
+	}
+}
+
+func TestCatalog_RequiredAndSelected(t *testing.T) {
+	reg := sdktool.NewRegistry()
+	for _, name := range []string{"always_tool", "direct_tool", "deferred_tool", "hidden_tool"} {
+		reg.Register(funcTool(name, "x"))
+	}
+	c := testCatalog(t, reg)
+	t.Cleanup(func() { _ = c.Close() })
+
+	c.Require("deferred_tool", "hidden_tool")
+	c.Select("deferred_tool")
+	got := names(c.Definitions())
+	want := []string{"always_tool", "deferred_tool", "hidden_tool"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("Definitions = %v, want %v", got, want)
+	}
+}
+
+func TestCatalog_SelectedExpiresAfterRounds(t *testing.T) {
+	reg := sdktool.NewRegistry()
+	reg.Register(funcTool("always_tool", "x"))
+	reg.Register(funcTool("deferred_tool", "x"))
+	c := testCatalog(t, reg)
+	t.Cleanup(func() { _ = c.Close() })
+
+	c.Select("deferred_tool")
+	if got := names(c.Definitions()); !reflect.DeepEqual(got, []string{"always_tool", "deferred_tool"}) {
+		t.Fatalf("after select Definitions = %v", got)
+	}
+	c.AdvanceTurn()
+	if got := names(c.Definitions()); !reflect.DeepEqual(got, []string{"always_tool", "deferred_tool"}) {
+		t.Fatalf("after one turn Definitions = %v", got)
+	}
+	c.AdvanceTurn()
+	if got := names(c.Definitions()); !reflect.DeepEqual(got, []string{"always_tool"}) {
+		t.Fatalf("after two turns Definitions = %v, want selected expiry", got)
+	}
+}
+
+func TestCatalog_RecordCallKeepsDirectVisible(t *testing.T) {
+	reg := sdktool.NewRegistry()
+	reg.Register(funcTool("always_tool", "x"))
+	reg.Register(funcTool("direct_tool", "x"))
+	c := testCatalog(t, reg)
+	t.Cleanup(func() { _ = c.Close() })
+
+	if got := names(c.Definitions()); !reflect.DeepEqual(got, []string{"always_tool"}) {
+		t.Fatalf("baseline Definitions = %v", got)
+	}
+	c.RecordCall(message.Call{ID: "c1", Name: "direct_tool"})
+	if got := names(c.Definitions()); !reflect.DeepEqual(got, []string{"always_tool", "direct_tool"}) {
+		t.Fatalf("after RecordCall Definitions = %v", got)
+	}
+	c.AdvanceTurn()
+	c.AdvanceTurn()
+	if got := names(c.Definitions()); !reflect.DeepEqual(got, []string{"always_tool"}) {
+		t.Fatalf("after window expiry Definitions = %v", got)
+	}
+}
+
+func TestCatalog_SearchExcludesAlwaysAndHidden(t *testing.T) {
+	reg := sdktool.NewRegistry()
+	reg.Register(funcTool("always_tool", "alpha shared"))
+	reg.Register(funcTool("direct_tool", "alpha shared"))
+	reg.Register(funcTool("deferred_tool", "alpha shared"))
+	reg.Register(funcTool("hidden_tool", "alpha shared"))
+	c := testCatalog(t, reg)
+	t.Cleanup(func() { _ = c.Close() })
+
+	hits, err := c.Search(context.Background(), "alpha", 10)
+	if err != nil {
+		t.Fatalf("Search: %v", err)
+	}
+	got := make([]string, 0, len(hits))
+	for _, h := range hits {
+		got = append(got, h.Name)
+	}
+	want := []string{"deferred_tool", "direct_tool"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("Search hits = %v, want %v", got, want)
+	}
+}
+
+func TestCatalog_RegisterAndSetExposure(t *testing.T) {
+	reg := sdktool.NewRegistry()
+	c := New(reg, WithDefaultExposure(ExposureDeferred))
+	t.Cleanup(func() { _ = c.Close() })
+
+	if err := c.Register(funcTool("late", "x"), ExposureAlways); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+	if got := names(c.Definitions()); !reflect.DeepEqual(got, []string{"late"}) {
+		t.Fatalf("Definitions = %v, want [late]", got)
+	}
+	if err := c.SetExposure("late", ExposureHidden); err != nil {
+		t.Fatalf("SetExposure: %v", err)
+	}
+	if got := names(c.Definitions()); len(got) != 0 {
+		t.Fatalf("Definitions after hidden = %v, want empty", got)
+	}
+}
+
+func TestCatalog_RegisterProxyLoadsOnDemand(t *testing.T) {
+	reg := sdktool.NewRegistry()
+	c := New(reg, WithDefaultExposure(ExposureDeferred))
+	t.Cleanup(func() { _ = c.Close() })
+
+	var loads atomic.Int32
+	inner := funcTool("proxy_tool", "real description")
+	if err := c.RegisterProxy("proxy_tool", func(_ context.Context) (sdktool.Tool, error) {
+		loads.Add(1)
+		return inner, nil
+	}, ExposureAlways); err != nil {
+		t.Fatalf("RegisterProxy: %v", err)
+	}
+
+	// Visible with a placeholder definition before loading.
+	defs := c.Definitions()
+	if len(defs) != 1 || defs[0].Name != "proxy_tool" {
+		t.Fatalf("Definitions = %v, want proxy placeholder", names(defs))
+	}
+	if loads.Load() != 0 {
+		t.Fatalf("loader ran during Definitions, want lazy: %d", loads.Load())
+	}
+	if defs[0].Description != "" {
+		t.Errorf("placeholder description = %q, want empty", defs[0].Description)
+	}
+
+	tool, ok := c.Get("proxy_tool")
+	if !ok {
+		t.Fatal("proxy missing from catalog")
+	}
+	res, err := tool.Execute(context.Background(), "{}")
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if res != "ran:proxy_tool" {
+		t.Fatalf("Execute = %q", res)
+	}
+	if loads.Load() != 1 {
+		t.Errorf("loader calls = %d, want 1", loads.Load())
+	}
+	// After load, the real definition is served.
+	if got := c.Definitions()[0].Description; got != "real description" {
+		t.Errorf("definition description = %q, want real", got)
+	}
+}
+
+func TestCatalog_EnsureLoadedUnknownTool(t *testing.T) {
+	c := New(sdktool.NewRegistry())
+	t.Cleanup(func() { _ = c.Close() })
+	err := c.EnsureLoaded(context.Background(), "ghost")
+	if !errdefs.IsNotFound(err) {
+		t.Fatalf("EnsureLoaded = %v, want NotFound", err)
+	}
+}
+
+func TestCatalog_CloseIsIdempotentAndForbidsLoads(t *testing.T) {
+	reg := sdktool.NewRegistry()
+	c := New(reg)
+	var loads atomic.Int32
+	if err := c.RegisterProxy("p", func(_ context.Context) (sdktool.Tool, error) {
+		loads.Add(1)
+		return funcTool("p", "x"), nil
+	}, ExposureDeferred); err != nil {
+		t.Fatalf("RegisterProxy: %v", err)
+	}
+	if err := c.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	if err := c.Close(); err != nil {
+		t.Fatalf("second Close: %v", err)
+	}
+	if err := c.EnsureLoaded(context.Background(), "p"); !errdefs.IsNotAvailable(err) {
+		t.Fatalf("EnsureLoaded after close = %v, want NotAvailable", err)
+	}
+	if loads.Load() != 0 {
+		t.Errorf("loader ran after close: %d", loads.Load())
+	}
+}
+
+func TestCatalog_DefinitionsSortedAndDeterministic(t *testing.T) {
+	reg := sdktool.NewRegistry()
+	reg.Register(funcTool("zeta", "x"))
+	reg.Register(funcTool("alpha", "x"))
+	reg.Register(funcTool("mid", "x"))
+	c := New(reg, WithDefaultExposure(ExposureAlways))
+	t.Cleanup(func() { _ = c.Close() })
+
+	first := names(c.Definitions())
+	second := names(c.Definitions())
+	want := []string{"alpha", "mid", "zeta"}
+	if !reflect.DeepEqual(first, want) || !reflect.DeepEqual(second, want) {
+		t.Errorf("Definitions = %v / %v, want stable %v", first, second, want)
+	}
+}
+
+func TestCatalog_NewRejectsBadPolicy(t *testing.T) {
+	defer func() {
+		if recover() == nil {
+			t.Error("expected panic for invalid policy")
+		}
+	}()
+	New(sdktool.NewRegistry(), WithDefaultExposure(Exposure("bogus")))
+}
+
+func TestCatalog_SetExposureAfterClose(t *testing.T) {
+	c := New(sdktool.NewRegistry())
+	_ = c.Close()
+	if err := c.SetExposure("x", ExposureAlways); !errdefs.IsNotAvailable(err) {
+		t.Fatalf("SetExposure after close = %v, want NotAvailable", err)
+	}
+}

--- a/sdkx/tool/dynamic/catalog_test.go
+++ b/sdkx/tool/dynamic/catalog_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"reflect"
+	"strings"
 	"sync/atomic"
 	"testing"
 
@@ -212,6 +213,54 @@ func TestCatalog_EnsureLoadedUnknownTool(t *testing.T) {
 	err := c.EnsureLoaded(context.Background(), "ghost")
 	if !errdefs.IsNotFound(err) {
 		t.Fatalf("EnsureLoaded = %v, want NotFound", err)
+	}
+}
+
+func TestCatalog_SearchDoesNotWakeDeferredProxies(t *testing.T) {
+	reg := sdktool.NewRegistry()
+	c := New(reg, WithDefaultExposure(ExposureDeferred))
+	t.Cleanup(func() { _ = c.Close() })
+
+	var loads atomic.Int32
+	if err := c.RegisterProxy("p", func(_ context.Context) (sdktool.Tool, error) {
+		loads.Add(1)
+		return funcTool("p", "alpha real"), nil
+	}, ExposureDeferred, WithPlaceholder(message.Definition{
+		Name:        "p",
+		Description: "alpha declared",
+	})); err != nil {
+		t.Fatalf("RegisterProxy: %v", err)
+	}
+
+	hits, err := c.Search(context.Background(), "alpha", 10)
+	if err != nil {
+		t.Fatalf("Search: %v", err)
+	}
+	if loads.Load() != 0 {
+		t.Fatalf("Search woke the deferred proxy: %d loader calls", loads.Load())
+	}
+	if len(hits) != 1 || hits[0].Name != "p" {
+		t.Fatalf("Search hits = %+v, want the declared proxy metadata", hits)
+	}
+
+	// The explicit opt-in wakes deferred proxies.
+	hits, err = c.SearchWithLoad(context.Background(), "alpha", 10)
+	if err != nil {
+		t.Fatalf("SearchWithLoad: %v", err)
+	}
+	if loads.Load() != 1 {
+		t.Fatalf("SearchWithLoad did not load the proxy: %d loader calls", loads.Load())
+	}
+	if len(hits) != 1 || !strings.Contains(hits[0].Description, "real") {
+		t.Fatalf("SearchWithLoad hits = %+v, want the loaded real metadata", hits)
+	}
+
+	// The proxy is now loaded; select must not load it again.
+	if err := c.EnsureLoaded(context.Background(), "p"); err != nil {
+		t.Fatalf("EnsureLoaded: %v", err)
+	}
+	if loads.Load() != 1 {
+		t.Errorf("loader calls after select = %d, want exactly 1", loads.Load())
 	}
 }
 

--- a/sdkx/tool/dynamic/context.go
+++ b/sdkx/tool/dynamic/context.go
@@ -1,0 +1,25 @@
+package dynamic
+
+import (
+	"context"
+
+	sdktool "github.com/GizClaw/flowcraft/sdk/tool"
+)
+
+// WithCatalog attaches the session catalog to ctx so session-scoped
+// tools (tool_search) can resolve it at execution time. The pattern
+// rides the neutral sdk/tool context channel, so the inference node
+// and the runtime session layer share one plumbing.
+func WithCatalog(ctx context.Context, c *Catalog) context.Context {
+	return sdktool.WithCatalogOnContext(ctx, c)
+}
+
+// FromContext returns the session catalog attached by WithCatalog.
+func FromContext(ctx context.Context) (*Catalog, bool) {
+	c, ok := sdktool.CatalogFromContext(ctx)
+	if !ok {
+		return nil, false
+	}
+	cat, ok := c.(*Catalog)
+	return cat, ok
+}

--- a/sdkx/tool/dynamic/exposure.go
+++ b/sdkx/tool/dynamic/exposure.go
@@ -1,0 +1,189 @@
+// Package dynamic implements the tool-injection layer described in
+// docs/plans/2026-08-10-tool-dynamic-injection.md: an Exposure-driven
+// read-side Catalog over a shared tool.Registry, BM25 tool search, and
+// lazily loaded proxy tools.
+//
+// The package deliberately sits on the read side only. Injection rules
+// decide what the model sees (Definitions), never what can be called:
+// the Executor keeps dispatching against the full Registry, and access
+// control stays in the Approval middleware.
+package dynamic
+
+import (
+	"encoding/json"
+	"strings"
+
+	"github.com/GizClaw/flowcraft/sdk/errdefs"
+	"github.com/GizClaw/flowcraft/sdk/message"
+)
+
+// Exposure controls whether a tool appears in the model-visible
+// Definitions. It is host policy, never part of message.Definition.
+type Exposure string
+
+const (
+	// ExposureAlways marks a tool that appears in Definitions every
+	// turn. Keep this set small; it is the stable baseline.
+	ExposureAlways Exposure = "always"
+	// ExposureDirect marks a tool that appears only when it is
+	// RequiredByName or has been selected/used recently.
+	ExposureDirect Exposure = "direct"
+	// ExposureDeferred marks a tool that is hidden until tool_search
+	// surfaces it; once selected it stays visible for M rounds.
+	ExposureDeferred Exposure = "deferred"
+	// ExposureHidden marks a tool that never appears in Definitions
+	// (not even via search). RequiredByName can still surface it,
+	// matching the legacy ScopePlatform contract, and the tool remains
+	// callable by exact name at all times.
+	ExposureHidden Exposure = "hidden"
+)
+
+// Valid reports whether e is one of the four exposure levels.
+func (e Exposure) Valid() bool {
+	switch e {
+	case ExposureAlways, ExposureDirect, ExposureDeferred, ExposureHidden:
+		return true
+	default:
+		return false
+	}
+}
+
+// rank orders exposures for deterministic pruning: lower ranks are
+// evicted last.
+func (e Exposure) rank() int {
+	switch e {
+	case ExposureAlways:
+		return 0
+	case ExposureDirect:
+		return 1
+	case ExposureDeferred:
+		return 2
+	case ExposureHidden:
+		return 3
+	default:
+		return 4
+	}
+}
+
+// searchable reports whether tool_search may surface the exposure.
+func (e Exposure) searchable() bool {
+	return e == ExposureDirect || e == ExposureDeferred
+}
+
+// Budget caps how many definitions reach the model per turn.
+type Budget struct {
+	// MaxDefinitions caps the number of definitions. Zero falls back to
+	// DefaultBudget.MaxDefinitions.
+	MaxDefinitions int
+	// MaxBytes caps the total serialized size of the definitions. Zero
+	// falls back to DefaultBudget.MaxBytes.
+	MaxBytes int64
+}
+
+// DefaultBudget is the built-in budget: 32 tools or 16 KiB of
+// definitions per turn, whichever is hit first.
+var DefaultBudget = Budget{
+	MaxDefinitions: 32,
+	MaxBytes:       16 * 1024,
+}
+
+// Policy is the host-declared injection policy for one catalog.
+type Policy struct {
+	// Default is the exposure applied to registered tools that have no
+	// explicit entry in Exposures. Deferred keeps the baseline small:
+	// only Always tools and RequiredByName names appear until search
+	// selects more.
+	Default Exposure
+	// Exposures maps tool names to explicit exposure levels.
+	Exposures map[string]Exposure
+	// SelectedRetention is how many rounds a selected tool stays
+	// visible (M in the plan). Zero falls back to 5.
+	SelectedRetention int
+	// RecentWindow is how many rounds a recently used direct tool stays
+	// visible. Zero falls back to 10.
+	RecentWindow int
+	// Budget caps the visible set. Zero uses DefaultBudget.
+	Budget Budget
+}
+
+// Validate checks policy invariants. An unset Default is a validation
+// error: silently choosing a default would hide or expose every tool
+// based on a typo.
+func (p Policy) Validate() error {
+	if !p.Default.Valid() {
+		return errdefs.Validationf(
+			"dynamic: default exposure %q is invalid", p.Default)
+	}
+	for name, e := range p.Exposures {
+		if strings.TrimSpace(name) == "" {
+			return errdefs.Validationf("dynamic: exposure map has an empty tool name")
+		}
+		if !e.Valid() {
+			return errdefs.Validationf(
+				"dynamic: exposure %q for tool %q is invalid", e, name)
+		}
+	}
+	return nil
+}
+
+// exposureOf resolves the exposure for name, defaulting to p.Default.
+func (p Policy) exposureOf(name string) Exposure {
+	if e, ok := p.Exposures[name]; ok {
+		return e
+	}
+	return p.Default
+}
+
+func (p Policy) selectedRetention() int {
+	if p.SelectedRetention <= 0 {
+		return 5
+	}
+	return p.SelectedRetention
+}
+
+func (p Policy) recentWindow() int {
+	if p.RecentWindow <= 0 {
+		return 10
+	}
+	return p.RecentWindow
+}
+
+func (p Policy) budget() Budget {
+	b := p.Budget
+	if b.MaxDefinitions <= 0 {
+		b.MaxDefinitions = DefaultBudget.MaxDefinitions
+	}
+	if b.MaxBytes <= 0 {
+		b.MaxBytes = DefaultBudget.MaxBytes
+	}
+	return b
+}
+
+// DefaultPolicy returns the recommended policy: everything deferred by
+// default, 5 selected rounds, 10 recent rounds, and the default budget.
+func DefaultPolicy() Policy {
+	return Policy{
+		Default:           ExposureDeferred,
+		Exposures:         map[string]Exposure{},
+		SelectedRetention: 5,
+		RecentWindow:      10,
+		Budget:            DefaultBudget,
+	}
+}
+
+// definitionBytes approximates the serialized size of a Definition for
+// budget pruning without allocating a JSON marshal per turn. The
+// approximation is intentionally conservative (adds fixed overhead) and
+// deterministic.
+func definitionBytes(d message.Definition) int64 {
+	return int64(len(d.Name) + len(d.Description) + len(d.InputSchema) + 32)
+}
+
+// compactJSON marshals v into a single-line JSON string.
+func compactJSON(v any) (string, error) {
+	raw, err := json.Marshal(v)
+	if err != nil {
+		return "", err
+	}
+	return string(raw), nil
+}

--- a/sdkx/tool/dynamic/proxy.go
+++ b/sdkx/tool/dynamic/proxy.go
@@ -1,0 +1,293 @@
+package dynamic
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"sync"
+	"time"
+
+	"github.com/GizClaw/flowcraft/sdk/errdefs"
+	"github.com/GizClaw/flowcraft/sdk/message"
+	sdktool "github.com/GizClaw/flowcraft/sdk/tool"
+	"golang.org/x/sync/singleflight"
+)
+
+// Loader loads the real implementation of a deferred tool. It is the
+// only place a LazyTool may do network or process work; Definition()
+// and Get() never call it.
+type Loader func(ctx context.Context) (sdktool.Tool, error)
+
+// RetryPolicy bounds how many times EnsureLoaded attempts the loader.
+type RetryPolicy struct {
+	// Attempts is the total number of loader invocations, including the
+	// first. Zero falls back to DefaultRetryPolicy.Attempts.
+	Attempts int
+	// BaseDelay is the first retry delay; each retry doubles it.
+	BaseDelay time.Duration
+	// MaxDelay caps the exponential backoff.
+	MaxDelay time.Duration
+}
+
+// DefaultRetryPolicy is the built-in retry policy: three attempts with
+// 100ms, 200ms, 400ms backoff (capped at 1s).
+var DefaultRetryPolicy = RetryPolicy{
+	Attempts:  3,
+	BaseDelay: 100 * time.Millisecond,
+	MaxDelay:  time.Second,
+}
+
+func (p RetryPolicy) attempts() int {
+	if p.Attempts <= 0 {
+		return DefaultRetryPolicy.Attempts
+	}
+	return p.Attempts
+}
+
+// LazyTool is a stable registry entry for a deferred tool. Before it is
+// loaded it serves a placeholder definition; after EnsureLoaded it
+// forwards to the real tool — preferring the registry's current entry
+// for that name so a later MCP reconcile is picked up automatically.
+type LazyTool struct {
+	name        string
+	reg         *sdktool.Registry
+	loader      Loader
+	placeholder message.Definition
+	retry       RetryPolicy
+
+	group   singleflight.Group
+	mu      sync.RWMutex
+	inner   sdktool.Tool
+	loaded  bool
+	lastErr error
+	closed  bool
+}
+
+var (
+	_ sdktool.Tool         = (*LazyTool)(nil)
+	_ sdktool.ToolMetadata = (*LazyTool)(nil)
+	_ io.Closer            = (*LazyTool)(nil)
+)
+
+// NewLazyTool creates a deferred tool proxy. reg is the registry the
+// proxy is registered into (optional); when set, forwarding prefers the
+// registry's current entry so external reconciles stay visible.
+func NewLazyTool(reg *sdktool.Registry, name string, loader Loader, opts ...LazyOption) *LazyTool {
+	if name == "" {
+		panic("dynamic.NewLazyTool: name is empty")
+	}
+	if loader == nil {
+		panic("dynamic.NewLazyTool: loader is nil")
+	}
+	t := &LazyTool{
+		name:   name,
+		reg:    reg,
+		loader: loader,
+		placeholder: message.Definition{
+			Name:        name,
+			InputSchema: json.RawMessage(`{"type":"object"}`),
+		},
+		retry: DefaultRetryPolicy,
+	}
+	for _, opt := range opts {
+		if opt != nil {
+			opt(t)
+		}
+	}
+	if t.placeholder.Name == "" {
+		t.placeholder.Name = name
+	}
+	if len(t.placeholder.InputSchema) == 0 {
+		t.placeholder.InputSchema = json.RawMessage(`{"type":"object"}`)
+	}
+	return t
+}
+
+// LazyOption configures a LazyTool.
+type LazyOption func(*LazyTool)
+
+// WithPlaceholder overrides the definition served before loading. The
+// name is forced to the proxy's name so the registry key stays stable.
+func WithPlaceholder(def message.Definition) LazyOption {
+	return func(t *LazyTool) {
+		def.Name = t.name
+		t.placeholder = def
+	}
+}
+
+// WithRetryPolicy overrides the loader retry policy.
+func WithRetryPolicy(p RetryPolicy) LazyOption {
+	return func(t *LazyTool) { t.retry = p }
+}
+
+// EnsureLoaded loads the real tool at most once concurrently
+// (singleflight) and retries on failure per the retry policy. A failed
+// load keeps the proxy in the unloaded state so the next call may
+// retry; a closed proxy never loads again.
+func (t *LazyTool) EnsureLoaded(ctx context.Context) error {
+	if ctx == nil {
+		return errdefs.Validationf("dynamic: EnsureLoaded: context is nil")
+	}
+	if t.isClosed() {
+		return errdefs.NotAvailablef("dynamic: tool %q is closed", t.name)
+	}
+	_, err, _ := t.group.Do(t.name, func() (any, error) {
+		return nil, t.loadOnce(ctx)
+	})
+	return err
+}
+
+func (t *LazyTool) loadOnce(ctx context.Context) error {
+	t.mu.RLock()
+	loaded := t.loaded
+	t.mu.RUnlock()
+	if loaded {
+		return nil
+	}
+
+	var lastErr error
+	attempts := t.retry.attempts()
+	for attempt := range attempts {
+		if attempt > 0 {
+			delay := backoff(t.retry.BaseDelay, t.retry.MaxDelay, attempt-1)
+			if err := sleepCtx(ctx, delay); err != nil {
+				return err
+			}
+		}
+		tool, err := t.loader(ctx)
+		if err == nil && tool == nil {
+			err = errdefs.Internalf("dynamic: loader for %q returned a nil tool", t.name)
+		}
+		if err == nil {
+			t.mu.Lock()
+			if !t.closed {
+				t.inner = tool
+				t.loaded = true
+				t.lastErr = nil
+			}
+			t.mu.Unlock()
+			return nil
+		}
+		lastErr = err
+	}
+	t.mu.Lock()
+	if !t.closed {
+		t.lastErr = lastErr
+	}
+	t.mu.Unlock()
+	return lastErr
+}
+
+// Definition returns the loaded tool's definition, or the placeholder
+// while unloaded. It never loads and never fails.
+func (t *LazyTool) Definition() message.Definition {
+	if current := t.current(); current != nil {
+		return current.Definition()
+	}
+	return t.placeholder
+}
+
+// Execute loads the real tool (with retries) and forwards the call. A
+// failed or closed load surfaces as a typed NotAvailable error.
+func (t *LazyTool) Execute(ctx context.Context, arguments string) (string, error) {
+	if err := t.EnsureLoaded(ctx); err != nil {
+		return "", errdefs.NotAvailablef(
+			"dynamic: tool %q is not available: %v", t.name, err)
+	}
+	current := t.current()
+	if current == nil {
+		return "", errdefs.NotAvailablef(
+			"dynamic: tool %q loaded without an implementation", t.name)
+	}
+	return current.Execute(ctx, arguments)
+}
+
+// Metadata reports the loaded tool's metadata, or a conservative zero
+// ToolMeta while unloaded.
+func (t *LazyTool) Metadata() sdktool.ToolMeta {
+	if current := t.current(); current != nil {
+		return sdktool.MetadataOf(current)
+	}
+	return sdktool.ToolMeta{}
+}
+
+// Close idempotently closes the loaded implementation (if it is an
+// io.Closer) and forbids further loads.
+func (t *LazyTool) Close() error {
+	t.mu.Lock()
+	if t.closed {
+		t.mu.Unlock()
+		return nil
+	}
+	t.closed = true
+	inner := t.inner
+	t.inner = nil
+	t.mu.Unlock()
+	if closer, ok := inner.(io.Closer); ok {
+		return closer.Close()
+	}
+	return nil
+}
+
+// LastError returns the most recent load failure, or nil when the
+// proxy is loaded or never attempted.
+func (t *LazyTool) LastError() error {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+	return t.lastErr
+}
+
+func (t *LazyTool) isClosed() bool {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+	return t.closed
+}
+
+// current prefers the registry's live entry (it may have been replaced
+// by a reconcile) and falls back to the loaded inner tool. Until the
+// proxy is loaded it never consults the registry: Registry.Register
+// calls Definition() while holding its write lock, and consulting the
+// registry there would self-deadlock.
+func (t *LazyTool) current() sdktool.Tool {
+	t.mu.RLock()
+	loaded := t.loaded
+	inner := t.inner
+	t.mu.RUnlock()
+	if !loaded {
+		return nil
+	}
+	if t.reg != nil {
+		if candidate, ok := t.reg.Get(t.name); ok && candidate != t {
+			return candidate
+		}
+	}
+	return inner
+}
+
+func backoff(base, max time.Duration, attempt int) time.Duration {
+	if base <= 0 {
+		return 0
+	}
+	delay := base
+	for i := 0; i < attempt && delay < max; i++ {
+		delay *= 2
+	}
+	if max > 0 && delay > max {
+		return max
+	}
+	return delay
+}
+
+func sleepCtx(ctx context.Context, delay time.Duration) error {
+	if delay <= 0 {
+		return nil
+	}
+	timer := time.NewTimer(delay)
+	defer timer.Stop()
+	select {
+	case <-timer.C:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}

--- a/sdkx/tool/dynamic/proxy_test.go
+++ b/sdkx/tool/dynamic/proxy_test.go
@@ -1,0 +1,201 @@
+package dynamic
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/GizClaw/flowcraft/sdk/errdefs"
+	sdktool "github.com/GizClaw/flowcraft/sdk/tool"
+)
+
+type closableFuncTool struct {
+	sdktool.Tool
+	closed *bool
+}
+
+func (c closableFuncTool) Close() error {
+	*c.closed = true
+	return nil
+}
+
+func TestLazyTool_SingleflightConcurrentLoad(t *testing.T) {
+	var calls atomic.Int32
+	proxy := NewLazyTool(nil, "p", func(_ context.Context) (sdktool.Tool, error) {
+		calls.Add(1)
+		return funcTool("p", "real"), nil
+	})
+
+	const n = 16
+	var wg sync.WaitGroup
+	errs := make([]error, n)
+	for i := range n {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			errs[i] = proxy.EnsureLoaded(context.Background())
+		}(i)
+	}
+	wg.Wait()
+	for i, err := range errs {
+		if err != nil {
+			t.Fatalf("EnsureLoaded[%d] = %v", i, err)
+		}
+	}
+	if calls.Load() != 1 {
+		t.Errorf("loader calls = %d, want 1 (singleflight)", calls.Load())
+	}
+}
+
+func TestLazyTool_RetriesWithinCall(t *testing.T) {
+	var calls atomic.Int32
+	proxy := NewLazyTool(nil, "p", func(_ context.Context) (sdktool.Tool, error) {
+		if calls.Add(1) < 2 {
+			return nil, errors.New("transient")
+		}
+		return funcTool("p", "real"), nil
+	}, WithRetryPolicy(RetryPolicy{Attempts: 3, BaseDelay: 0, MaxDelay: 0}))
+
+	if err := proxy.EnsureLoaded(context.Background()); err != nil {
+		t.Fatalf("EnsureLoaded: %v", err)
+	}
+	if calls.Load() != 2 {
+		t.Errorf("loader calls = %d, want 2 (first attempt failed)", calls.Load())
+	}
+}
+
+func TestLazyTool_FailedLoadRetriesOnNextCall(t *testing.T) {
+	var calls atomic.Int32
+	proxy := NewLazyTool(nil, "p", func(_ context.Context) (sdktool.Tool, error) {
+		calls.Add(1)
+		return nil, errors.New("always fails")
+	}, WithRetryPolicy(RetryPolicy{Attempts: 2, BaseDelay: 0, MaxDelay: 0}))
+
+	if err := proxy.EnsureLoaded(context.Background()); err == nil {
+		t.Fatal("first EnsureLoaded succeeded, want error")
+	}
+	if proxy.LastError() == nil {
+		t.Fatal("LastError is nil after failed load")
+	}
+	if err := proxy.EnsureLoaded(context.Background()); err == nil {
+		t.Fatal("second EnsureLoaded succeeded, want error")
+	}
+	if calls.Load() != 4 {
+		t.Errorf("loader calls = %d, want 4 (retry across two calls)", calls.Load())
+	}
+}
+
+func TestLazyTool_PlaceholderThenRealDefinition(t *testing.T) {
+	proxy := NewLazyTool(nil, "p", func(_ context.Context) (sdktool.Tool, error) {
+		return funcTool("p", "real description"), nil
+	})
+
+	before := proxy.Definition()
+	if before.Name != "p" || before.Description != "" {
+		t.Errorf("placeholder = %+v, want name p with empty description", before)
+	}
+	if err := proxy.EnsureLoaded(context.Background()); err != nil {
+		t.Fatalf("EnsureLoaded: %v", err)
+	}
+	after := proxy.Definition()
+	if after.Description != "real description" {
+		t.Errorf("loaded definition = %+v, want real description", after)
+	}
+}
+
+func TestLazyTool_MetadataDelegatesAfterLoad(t *testing.T) {
+	type metaTool struct {
+		sdktool.Tool
+	}
+	inner := funcTool("p", "x")
+	proxy := NewLazyTool(nil, "p", func(_ context.Context) (sdktool.Tool, error) {
+		return metaTool{Tool: inner}, nil
+	})
+	if got := proxy.Metadata(); got != (sdktool.ToolMeta{}) {
+		t.Errorf("unloaded metadata = %+v, want zero", got)
+	}
+}
+
+func TestLazyTool_ExecuteLoadsAndForwards(t *testing.T) {
+	var loads atomic.Int32
+	proxy := NewLazyTool(nil, "p", func(_ context.Context) (sdktool.Tool, error) {
+		loads.Add(1)
+		return funcTool("p", "real"), nil
+	})
+	res, err := proxy.Execute(context.Background(), "{}")
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if res != "ran:p" {
+		t.Errorf("Execute result = %q, want ran:p", res)
+	}
+	if loads.Load() != 1 {
+		t.Errorf("loader calls = %d, want 1", loads.Load())
+	}
+}
+
+func TestLazyTool_ExecuteFailureIsNotAvailable(t *testing.T) {
+	proxy := NewLazyTool(nil, "p", func(_ context.Context) (sdktool.Tool, error) {
+		return nil, errors.New("down")
+	}, WithRetryPolicy(RetryPolicy{Attempts: 1, BaseDelay: 0}))
+	_, err := proxy.Execute(context.Background(), "{}")
+	if !errdefs.IsNotAvailable(err) {
+		t.Fatalf("Execute error = %v, want NotAvailable", err)
+	}
+}
+
+func TestLazyTool_CloseClosesInnerAndForbidsLoad(t *testing.T) {
+	closed := false
+	inner := closableFuncTool{Tool: funcTool("p", "real"), closed: &closed}
+	proxy := NewLazyTool(nil, "p", func(_ context.Context) (sdktool.Tool, error) {
+		return inner, nil
+	})
+	if err := proxy.EnsureLoaded(context.Background()); err != nil {
+		t.Fatalf("EnsureLoaded: %v", err)
+	}
+	if err := proxy.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	if !closed {
+		t.Error("inner tool was not closed")
+	}
+	if err := proxy.Close(); err != nil {
+		t.Fatalf("second Close: %v", err)
+	}
+	if err := proxy.EnsureLoaded(context.Background()); !errdefs.IsNotAvailable(err) {
+		t.Fatalf("EnsureLoaded after close = %v, want NotAvailable", err)
+	}
+	if _, err := proxy.Execute(context.Background(), "{}"); !errdefs.IsNotAvailable(err) {
+		t.Fatalf("Execute after close = %v, want NotAvailable", err)
+	}
+}
+
+func TestLazyTool_ForwardsToRegistryReplacement(t *testing.T) {
+	reg := sdktool.NewRegistry()
+	proxy := NewLazyTool(reg, "p", func(_ context.Context) (sdktool.Tool, error) {
+		return funcTool("p", "old"), nil
+	})
+	reg.Register(proxy)
+	if err := proxy.EnsureLoaded(context.Background()); err != nil {
+		t.Fatalf("EnsureLoaded: %v", err)
+	}
+	replacement := funcTool("p", "new")
+	reg.Register(replacement)
+	if got := proxy.Definition().Description; got != "new" {
+		t.Errorf("definition = %q, want registry replacement", got)
+	}
+	if res, err := proxy.Execute(context.Background(), "{}"); err != nil || res != "ran:p" {
+		t.Errorf("Execute = %q, %v; want registry replacement", res, err)
+	}
+}
+
+func TestLazyTool_RejectsNilLoader(t *testing.T) {
+	defer func() {
+		if recover() == nil {
+			t.Error("expected panic for nil loader")
+		}
+	}()
+	NewLazyTool(nil, "p", nil)
+}

--- a/sdkx/tool/dynamic/record.go
+++ b/sdkx/tool/dynamic/record.go
@@ -1,0 +1,28 @@
+package dynamic
+
+import (
+	"context"
+
+	"github.com/GizClaw/flowcraft/sdk/message"
+	sdktool "github.com/GizClaw/flowcraft/sdk/tool"
+)
+
+// RecordCalls feeds every dispatched tool call back into the session
+// catalog found on the execution context, through the optional
+// RecordCall contract. It records attempts (including denied or failed
+// calls): the model choosing a tool is itself the Selected/UsedRecently
+// signal. Without a catalog on the context the middleware is a no-op,
+// so one chain serves sessions with and without dynamic injection.
+func RecordCalls() sdktool.Middleware {
+	return func(next sdktool.Dispatch) sdktool.Dispatch {
+		return func(ctx context.Context, call message.Call) message.Result {
+			res := next(ctx, call)
+			if catalog, ok := sdktool.CatalogFromContext(ctx); ok {
+				if recorder, ok := catalog.(interface{ RecordCall(message.Call) }); ok {
+					recorder.RecordCall(call)
+				}
+			}
+			return res
+		}
+	}
+}

--- a/sdkx/tool/dynamic/record_test.go
+++ b/sdkx/tool/dynamic/record_test.go
@@ -1,0 +1,36 @@
+package dynamic
+
+import (
+	"context"
+	"testing"
+
+	"github.com/GizClaw/flowcraft/sdk/message"
+	sdktool "github.com/GizClaw/flowcraft/sdk/tool"
+)
+
+func TestRecordCalls_FeedsSessionCatalog(t *testing.T) {
+	reg := sdktool.NewRegistry()
+	reg.Register(funcTool("direct_tool", "x"))
+	c := New(reg, WithExposure("direct_tool", ExposureDirect), WithSelectedRetention(2))
+	t.Cleanup(func() { _ = c.Close() })
+
+	exec := sdktool.NewExecutor(reg, RecordCalls())
+	call := message.Call{ID: "c1", Name: "direct_tool", Arguments: []byte(`{}`)}
+	if res := exec.Execute(WithCatalog(context.Background(), c), call); res.IsError {
+		t.Fatalf("unexpected error: %q", res.Content)
+	}
+	if got := names(c.Definitions()); len(got) != 1 || got[0] != "direct_tool" {
+		t.Errorf("Definitions after RecordCalls = %v, want [direct_tool]", got)
+	}
+}
+
+func TestRecordCalls_NoCatalogIsNoop(t *testing.T) {
+	reg := sdktool.NewRegistry()
+	reg.Register(funcTool("x", "x"))
+	exec := sdktool.NewExecutor(reg, RecordCalls())
+	res := exec.Execute(context.Background(),
+		message.Call{ID: "c1", Name: "x", Arguments: []byte(`{}`)})
+	if res.IsError {
+		t.Fatalf("unexpected error: %q", res.Content)
+	}
+}

--- a/sdkx/tool/dynamic/search.go
+++ b/sdkx/tool/dynamic/search.go
@@ -1,0 +1,175 @@
+package dynamic
+
+import (
+	"context"
+	"math"
+	"sort"
+	"strings"
+	"unicode"
+)
+
+// SearchHit is one tool_search result.
+type SearchHit struct {
+	Name        string  `json:"name"`
+	Description string  `json:"description"`
+	Score       float64 `json:"score"`
+}
+
+type searchDoc struct {
+	name string
+	text string
+}
+
+// defaultSearchLimit is used when tool_search omits limit.
+const defaultSearchLimit = 8
+
+// Search triggers a catalog load (so deferred servers contribute their
+// real tools) and ranks searchable definitions against query with BM25.
+// Searchable exposures are Direct and Deferred; Always tools are already
+// visible and Hidden tools must never be surfaced. Load failures are
+// intentionally non-fatal: one unreachable server must not hide the
+// tools that did load, matching the MCP failure-isolation contract.
+func (c *Catalog) Search(ctx context.Context, query string, limit int) ([]SearchHit, error) {
+	_ = c.Load(ctx)
+	c.mu.RLock()
+	policy := c.policyCopy()
+	c.mu.RUnlock()
+
+	defs := c.reg.Definitions()
+	docs := make([]searchDoc, 0, len(defs))
+	for _, def := range defs {
+		if !policy.exposureOf(def.Name).searchable() {
+			continue
+		}
+		docs = append(docs, searchDoc{
+			name: def.Name,
+			text: def.Name + " " + def.Description,
+		})
+	}
+	return bm25Search(docs, query, limit), nil
+}
+
+// bm25Search ranks docs against query with Okapi BM25 (k1=1.2, b=0.75,
+// smoothed IDF). Scores are computed on the fly: the tool catalog is
+// bounded (hundreds to low thousands), so no persistent index is
+// warranted. Ties break by name, keeping results deterministic.
+func bm25Search(docs []searchDoc, query string, limit int) []SearchHit {
+	queryTerms := tokenize(query)
+	if len(queryTerms) == 0 || len(docs) == 0 {
+		return []SearchHit{}
+	}
+	if limit <= 0 {
+		limit = defaultSearchLimit
+	}
+	if limit > len(docs) {
+		limit = len(docs)
+	}
+
+	const k1, b = 1.2, 0.75
+	termFreqs := make([]map[string]int, len(docs))
+	df := make(map[string]int)
+	avgDL := 0.0
+	for i, doc := range docs {
+		terms := tokenize(doc.text)
+		freqs := make(map[string]int, len(terms))
+		for _, term := range terms {
+			freqs[term]++
+		}
+		termFreqs[i] = freqs
+		for term := range freqs {
+			df[term]++
+		}
+		avgDL += float64(len(terms))
+	}
+	n := float64(len(docs))
+	if n > 0 {
+		avgDL /= n
+	}
+	if avgDL <= 0 {
+		avgDL = 1
+	}
+
+	idf := make(map[string]float64, len(df))
+	for term, occurrences := range df {
+		idf[term] = math.Log(1 + (n-float64(occurrences)+0.5)/(float64(occurrences)+0.5))
+	}
+
+	queryUnique := make(map[string]struct{}, len(queryTerms))
+	for _, term := range queryTerms {
+		queryUnique[term] = struct{}{}
+	}
+
+	type scored struct {
+		index int
+		score float64
+	}
+	scores := make([]scored, 0, len(docs))
+	for i, freqs := range termFreqs {
+		score := 0.0
+		dl := 0
+		for term := range freqs {
+			dl += freqs[term]
+		}
+		for term := range queryUnique {
+			tf := float64(freqs[term])
+			if tf == 0 {
+				continue
+			}
+			denominator := tf + k1*(1-b+b*float64(dl)/avgDL)
+			score += idf[term] * (tf * (k1 + 1)) / denominator
+		}
+		if score > 0 {
+			scores = append(scores, scored{index: i, score: score})
+		}
+	}
+	sort.Slice(scores, func(i, j int) bool {
+		if scores[i].score != scores[j].score {
+			return scores[i].score > scores[j].score
+		}
+		return docs[scores[i].index].name < docs[scores[j].index].name
+	})
+	if len(scores) > limit {
+		scores = scores[:limit]
+	}
+
+	hits := make([]SearchHit, 0, len(scores))
+	for _, s := range scores {
+		doc := docs[s.index]
+		description := ""
+		if trimmed := strings.TrimSpace(strings.TrimPrefix(doc.text, doc.name)); trimmed != "" {
+			description = trimmed
+		}
+		hits = append(hits, SearchHit{
+			Name:        doc.name,
+			Description: description,
+			Score:       s.score,
+		})
+	}
+	return hits
+}
+
+// tokenize lowercases and splits into Unicode letter/digit runs of at
+// least two characters. Tool descriptions are short and provider-facing,
+// so no stopword list is applied — every meaningful token contributes.
+func tokenize(s string) []string {
+	lower := strings.ToLower(s)
+	runes := []rune(lower)
+	var tokens []string
+	start := -1
+	for i, r := range runes {
+		if unicode.IsLetter(r) || unicode.IsDigit(r) {
+			if start < 0 {
+				start = i
+			}
+			continue
+		}
+		if start >= 0 && i-start >= 2 {
+			tokens = append(tokens, string(runes[start:i]))
+		}
+		start = -1
+	}
+	if start >= 0 && len(runes)-start >= 2 {
+		tokens = append(tokens, string(runes[start:]))
+	}
+	return tokens
+}

--- a/sdkx/tool/dynamic/search.go
+++ b/sdkx/tool/dynamic/search.go
@@ -23,14 +23,33 @@ type searchDoc struct {
 // defaultSearchLimit is used when tool_search omits limit.
 const defaultSearchLimit = 8
 
-// Search triggers a catalog load (so deferred servers contribute their
-// real tools) and ranks searchable definitions against query with BM25.
-// Searchable exposures are Direct and Deferred; Always tools are already
-// visible and Hidden tools must never be surfaced. Load failures are
-// intentionally non-fatal: one unreachable server must not hide the
-// tools that did load, matching the MCP failure-isolation contract.
+// Search ranks the already-known searchable definitions against query
+// with BM25. Searchable exposures are Direct and Deferred; Always tools
+// are already visible and Hidden tools must never be surfaced.
+//
+// Search never loads: deferred proxies are searched by their declared
+// placeholder metadata (name + description), so the first search does
+// not wake up every MCP server. Only a later select (or an explicit
+// Load / EnsureLoaded by the host) connects the chosen server — that is
+// what keeps "deferred" deferred. Hosts that need the complete metadata
+// set (including undeclared server tools) opt into SearchWithLoad or
+// call Load / prewarm explicitly.
 func (c *Catalog) Search(ctx context.Context, query string, limit int) ([]SearchHit, error) {
-	_ = c.Load(ctx)
+	return c.search(ctx, query, limit, false)
+}
+
+// SearchWithLoad is the explicit opt-in for hosts that want the full
+// metadata set: it loads every deferred proxy (connecting MCP servers)
+// before ranking. Default Search stays lazy — a first search must not
+// wake every server just to answer a query.
+func (c *Catalog) SearchWithLoad(ctx context.Context, query string, limit int) ([]SearchHit, error) {
+	return c.search(ctx, query, limit, true)
+}
+
+func (c *Catalog) search(ctx context.Context, query string, limit int, load bool) ([]SearchHit, error) {
+	if load {
+		_ = c.Load(ctx)
+	}
 	c.mu.RLock()
 	policy := c.policyCopy()
 	c.mu.RUnlock()

--- a/sdkx/tool/dynamic/search_test.go
+++ b/sdkx/tool/dynamic/search_test.go
@@ -1,0 +1,64 @@
+package dynamic
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestTokenize(t *testing.T) {
+	got := tokenize("Read file from GitHub repository 你好世界")
+	want := []string{"read", "file", "from", "github", "repository", "你好世界"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("tokenize = %v, want %v", got, want)
+	}
+}
+
+func TestBm25Search_RanksExactMatchFirst(t *testing.T) {
+	docs := []searchDoc{
+		{name: "fs__read_file", text: "fs__read_file read file contents from disk"},
+		{name: "git__search", text: "git__search search code in repositories"},
+	}
+	hits := bm25Search(docs, "read file", 10)
+	if len(hits) != 1 {
+		t.Fatalf("hits = %d, want 1 (only the matching doc scores)", len(hits))
+	}
+	if hits[0].Name != "fs__read_file" {
+		t.Errorf("top hit = %q, want fs__read_file", hits[0].Name)
+	}
+}
+
+func TestBm25Search_EmptyQueryAndLimit(t *testing.T) {
+	docs := []searchDoc{{name: "a", text: "a alpha"}, {name: "b", text: "b beta"}}
+	if hits := bm25Search(docs, "", 10); len(hits) != 0 {
+		t.Errorf("empty query returned hits: %v", hits)
+	}
+	if hits := bm25Search(docs, "alpha beta", 1); len(hits) != 1 {
+		t.Errorf("limit 1 returned %d hits", len(hits))
+	}
+	if hits := bm25Search(docs, "alpha", 0); len(hits) > defaultSearchLimit {
+		t.Errorf("default limit not applied: %d hits", len(hits))
+	}
+}
+
+func TestBm25Search_TieBreaksByName(t *testing.T) {
+	docs := []searchDoc{
+		{name: "b_tool", text: "b_tool zap"},
+		{name: "a_tool", text: "a_tool zap"},
+	}
+	hits := bm25Search(docs, "zap", 10)
+	if hits[0].Name != "a_tool" {
+		t.Errorf("tie-break order = %v, want a_tool first", hits[0].Name)
+	}
+}
+
+func TestBm25Search_Deterministic(t *testing.T) {
+	docs := []searchDoc{
+		{name: "one", text: "one alpha beta"},
+		{name: "two", text: "two beta gamma"},
+	}
+	first := bm25Search(docs, "beta", 10)
+	second := bm25Search(docs, "beta", 10)
+	if !reflect.DeepEqual(first, second) {
+		t.Errorf("search is not deterministic: %v vs %v", first, second)
+	}
+}

--- a/sdkx/tool/dynamic/state.go
+++ b/sdkx/tool/dynamic/state.go
@@ -1,0 +1,103 @@
+package dynamic
+
+// state is the per-session injection state. All mutations happen
+// through explicit methods; Definitions() only reads a snapshot, so the
+// visibility computation stays a pure function of (candidates, state,
+// policy).
+type state struct {
+	required map[string]struct{}
+	selected map[string]int
+	recent   map[string]uint64
+	turn     uint64
+}
+
+func newState() *state {
+	return &state{
+		required: make(map[string]struct{}),
+		selected: make(map[string]int),
+		recent:   make(map[string]uint64),
+	}
+}
+
+// snapshot returns a defensive copy safe to read without the state
+// mutex held.
+func (s *state) snapshot() stateSnapshot {
+	snap := stateSnapshot{
+		required: make(map[string]struct{}, len(s.required)),
+		selected: make(map[string]int, len(s.selected)),
+		recent:   make(map[string]uint64, len(s.recent)),
+		turn:     s.turn,
+	}
+	for name := range s.required {
+		snap.required[name] = struct{}{}
+	}
+	for name, rounds := range s.selected {
+		snap.selected[name] = rounds
+	}
+	for name, at := range s.recent {
+		snap.recent[name] = at
+	}
+	return snap
+}
+
+type stateSnapshot struct {
+	required map[string]struct{}
+	selected map[string]int
+	recent   map[string]uint64
+	turn     uint64
+}
+
+func (s stateSnapshot) isRequired(name string) bool {
+	_, ok := s.required[name]
+	return ok
+}
+
+func (s stateSnapshot) isRecent(name string, window int) bool {
+	at, ok := s.recent[name]
+	if !ok || window <= 0 {
+		return false
+	}
+	return s.turn-at <= uint64(window)
+}
+
+// require adds names to the RequiredByName set. Idempotent.
+func (s *state) require(names ...string) {
+	for _, name := range names {
+		s.required[name] = struct{}{}
+	}
+}
+
+// selectNames marks names as selected for retention rounds. Selecting
+// an already selected tool refreshes its remaining rounds to the full
+// retention, matching "Selected 保持 M 轮" semantics.
+func (s *state) selectNames(names []string, retention int) {
+	for _, name := range names {
+		s.selected[name] = retention
+	}
+}
+
+// recordCall marks a tool as selected and recently used at the current
+// turn.
+func (s *state) recordCall(name string, retention int) {
+	s.selected[name] = retention
+	s.recent[name] = s.turn
+}
+
+// advanceTurn moves to the next round and expires selected tools whose
+// remaining rounds reached zero. UsedRecently entries older than the
+// window are dropped so the recent map stays bounded.
+func (s *state) advanceTurn(recentWindow int) {
+	s.turn++
+	for name, rounds := range s.selected {
+		if rounds <= 1 {
+			delete(s.selected, name)
+			continue
+		}
+		s.selected[name] = rounds - 1
+	}
+	for name, at := range s.recent {
+		if s.turn-at > uint64(recentWindow) {
+			delete(s.recent, name)
+		}
+	}
+}

--- a/sdkx/tool/dynamic/state_test.go
+++ b/sdkx/tool/dynamic/state_test.go
@@ -1,0 +1,43 @@
+package dynamic
+
+import "testing"
+
+func TestState_SelectedExpiresAfterM(t *testing.T) {
+	st := newState()
+	st.selectNames([]string{"x"}, 2)
+	if st.selected["x"] != 2 {
+		t.Fatalf("selected rounds = %d, want 2", st.selected["x"])
+	}
+	st.advanceTurn(10)
+	if st.selected["x"] != 1 {
+		t.Fatalf("after one turn rounds = %d, want 1", st.selected["x"])
+	}
+	st.advanceTurn(10)
+	if _, ok := st.selected["x"]; ok {
+		t.Fatal("selected tool survived its retention window")
+	}
+}
+
+func TestState_RecordCallRefreshesAndMarksRecent(t *testing.T) {
+	st := newState()
+	st.turn = 5
+	st.recordCall("x", 3)
+	if st.selected["x"] != 3 {
+		t.Errorf("selected = %d, want 3", st.selected["x"])
+	}
+	if st.recent["x"] != 5 {
+		t.Errorf("recent = %d, want 5", st.recent["x"])
+	}
+}
+
+func TestState_RecentWindowExpires(t *testing.T) {
+	st := newState()
+	st.turn = 1
+	st.recordCall("x", 1)
+	for i := 0; i < 11; i++ {
+		st.advanceTurn(5)
+	}
+	if _, ok := st.recent["x"]; ok {
+		t.Error("recent entry survived the window")
+	}
+}

--- a/sdkx/tool/dynamic/tool.go
+++ b/sdkx/tool/dynamic/tool.go
@@ -44,7 +44,8 @@ func (SearchTool) Definition() message.Definition {
 		ToolName,
 		"Search the available tool catalog for tools relevant to the current task. "+
 			"Use select to make the named tools visible to the model starting from the next round; "+
-			"selected tools remain available for the configured number of rounds.",
+			"selected tools are loaded immediately so the next round sees their real schemas, "+
+			"and remain available for the configured number of rounds.",
 		message.ToolProperty("query", "string",
 			"natural-language or keyword query describing the capability to find"),
 		message.ToolPropertyWithDefault("limit", "integer",
@@ -62,8 +63,9 @@ type searchArgs struct {
 }
 
 type searchResult struct {
-	Query string      `json:"query"`
-	Hits  []SearchHit `json:"hits"`
+	Query    string      `json:"query"`
+	Hits     []SearchHit `json:"hits"`
+	Selected []string    `json:"selected,omitempty"`
 }
 
 // Execute parses the query, triggers a catalog load, ranks hits, and
@@ -85,8 +87,16 @@ func (SearchTool) Execute(ctx context.Context, arguments string) (string, error)
 	if err != nil {
 		return "", err
 	}
-	if len(args.Select) > 0 {
-		catalog.Select(args.Select...)
+	selected := make([]string, 0, len(args.Select))
+	for _, name := range args.Select {
+		// Selected tools must be loaded: round N+1 shows the real
+		// definition, never the LazyTool placeholder. A tool that
+		// cannot load is simply not selected.
+		if err := catalog.EnsureLoaded(ctx, name); err != nil {
+			continue
+		}
+		catalog.Select(name)
+		selected = append(selected, name)
 	}
-	return compactJSON(searchResult{Query: args.Query, Hits: hits})
+	return compactJSON(searchResult{Query: args.Query, Hits: hits, Selected: selected})
 }

--- a/sdkx/tool/dynamic/tool.go
+++ b/sdkx/tool/dynamic/tool.go
@@ -1,0 +1,92 @@
+package dynamic
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+
+	"github.com/GizClaw/flowcraft/sdk/errdefs"
+	"github.com/GizClaw/flowcraft/sdk/message"
+	sdktool "github.com/GizClaw/flowcraft/sdk/tool"
+)
+
+// ToolName is the built-in tool_search tool name. Register it on the
+// shared registry with ExposureAlways so the model always has a way to
+// discover deferred tools.
+const ToolName = "tool_search"
+
+// SearchTool is the model-facing discovery tool. It resolves the
+// session catalog from context (see WithCatalog) so one instance can be
+// registered on the shared registry for all sessions.
+type SearchTool struct{}
+
+var _ sdktool.Tool = SearchTool{}
+
+// NewSearchTool returns the tool_search implementation.
+func NewSearchTool() SearchTool { return SearchTool{} }
+
+// RegisterSearchTool registers tool_search on the shared registry and
+// marks it ExposureAlways so the model always has a discovery path. The
+// catalog itself is resolved per call from context, so one registration
+// serves every session.
+func RegisterSearchTool(reg *sdktool.Registry, catalog *Catalog) error {
+	if reg == nil {
+		return errdefs.Validationf("dynamic: RegisterSearchTool: registry is nil")
+	}
+	if catalog == nil {
+		return errdefs.Validationf("dynamic: RegisterSearchTool: catalog is nil")
+	}
+	return catalog.Register(NewSearchTool(), ExposureAlways)
+}
+
+func (SearchTool) Definition() message.Definition {
+	return message.DefineSchema(
+		ToolName,
+		"Search the available tool catalog for tools relevant to the current task. "+
+			"Use select to make the named tools visible to the model starting from the next round; "+
+			"selected tools remain available for the configured number of rounds.",
+		message.ToolProperty("query", "string",
+			"natural-language or keyword query describing the capability to find"),
+		message.ToolPropertyWithDefault("limit", "integer",
+			"maximum number of hits to return", defaultSearchLimit),
+		message.ToolArrayProperty("select",
+			"tool names from the hits to make visible for upcoming rounds",
+			message.Items("string")),
+	).Required("query").Build()
+}
+
+type searchArgs struct {
+	Query  string   `json:"query"`
+	Limit  int      `json:"limit,omitempty"`
+	Select []string `json:"select,omitempty"`
+}
+
+type searchResult struct {
+	Query string      `json:"query"`
+	Hits  []SearchHit `json:"hits"`
+}
+
+// Execute parses the query, triggers a catalog load, ranks hits, and
+// applies the select list.
+func (SearchTool) Execute(ctx context.Context, arguments string) (string, error) {
+	catalog, ok := FromContext(ctx)
+	if !ok {
+		return "", errdefs.NotAvailablef(
+			"dynamic: %s requires a dynamic catalog on the context", ToolName)
+	}
+	var args searchArgs
+	if err := json.Unmarshal([]byte(arguments), &args); err != nil {
+		return "", errdefs.Validationf("dynamic: %s: parse arguments: %v", ToolName, err)
+	}
+	if strings.TrimSpace(args.Query) == "" {
+		return "", errdefs.Validationf("dynamic: %s: query is required", ToolName)
+	}
+	hits, err := catalog.Search(ctx, args.Query, args.Limit)
+	if err != nil {
+		return "", err
+	}
+	if len(args.Select) > 0 {
+		catalog.Select(args.Select...)
+	}
+	return compactJSON(searchResult{Query: args.Query, Hits: hits})
+}

--- a/sdkx/tool/dynamic/tool_test.go
+++ b/sdkx/tool/dynamic/tool_test.go
@@ -88,7 +88,10 @@ func TestSearchTool_SelectLoadsRealSchemaForNextRound(t *testing.T) {
 			).Required("path").Build(),
 			func(_ context.Context, _ string) (string, error) { return "ok", nil },
 		), nil
-	}, ExposureDeferred); err != nil {
+	}, ExposureDeferred, WithPlaceholder(message.Definition{
+		Name:        "deferred_tool",
+		Description: "alpha shared declared description",
+	})); err != nil {
 		t.Fatalf("RegisterProxy: %v", err)
 	}
 
@@ -99,6 +102,9 @@ func TestSearchTool_SelectLoadsRealSchemaForNextRound(t *testing.T) {
 		t.Fatalf("Execute: %v", err)
 	}
 	var result struct {
+		Hits []struct {
+			Name string `json:"name"`
+		} `json:"hits"`
 		Selected []string `json:"selected"`
 	}
 	if err := json.Unmarshal([]byte(raw), &result); err != nil {
@@ -106,6 +112,9 @@ func TestSearchTool_SelectLoadsRealSchemaForNextRound(t *testing.T) {
 	}
 	if len(result.Selected) != 1 || result.Selected[0] != "deferred_tool" {
 		t.Fatalf("selected = %v, want [deferred_tool]", result.Selected)
+	}
+	if len(result.Hits) != 1 || result.Hits[0].Name != "deferred_tool" {
+		t.Fatalf("hits = %+v, want the declared proxy", result.Hits)
 	}
 
 	// Round N+1: the real definition, not the LazyTool placeholder.
@@ -134,7 +143,7 @@ func TestSearchTool_SelectSkipsUnloadableTool(t *testing.T) {
 
 	ctx := WithCatalog(context.Background(), c)
 	raw, err := NewSearchTool().Execute(ctx,
-		`{"query":"server unreachable","select":["down"]}`)
+		`{"query":"down","select":["down"]}`)
 	if err != nil {
 		t.Fatalf("Execute: %v", err)
 	}

--- a/sdkx/tool/dynamic/tool_test.go
+++ b/sdkx/tool/dynamic/tool_test.go
@@ -3,11 +3,13 @@ package dynamic
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"reflect"
 	"strings"
 	"testing"
 
 	"github.com/GizClaw/flowcraft/sdk/errdefs"
+	"github.com/GizClaw/flowcraft/sdk/message"
 	sdktool "github.com/GizClaw/flowcraft/sdk/tool"
 )
 
@@ -71,6 +73,82 @@ func TestSearchTool_RejectsBadInput(t *testing.T) {
 	}
 	if _, err := NewSearchTool().Execute(ctx, `not json`); !errdefs.IsValidation(err) {
 		t.Errorf("bad json = %v, want Validation", err)
+	}
+}
+
+func TestSearchTool_SelectLoadsRealSchemaForNextRound(t *testing.T) {
+	reg := sdktool.NewRegistry()
+	c := New(reg, WithDefaultExposure(ExposureDeferred), WithSelectedRetention(3))
+	t.Cleanup(func() { _ = c.Close() })
+
+	if err := c.RegisterProxy("deferred_tool", func(_ context.Context) (sdktool.Tool, error) {
+		return sdktool.FuncTool(
+			message.DefineSchema("deferred_tool", "alpha shared real description",
+				message.ToolProperty("path", "string", "file path"),
+			).Required("path").Build(),
+			func(_ context.Context, _ string) (string, error) { return "ok", nil },
+		), nil
+	}, ExposureDeferred); err != nil {
+		t.Fatalf("RegisterProxy: %v", err)
+	}
+
+	ctx := WithCatalog(context.Background(), c)
+	raw, err := NewSearchTool().Execute(ctx,
+		`{"query":"alpha","select":["deferred_tool"]}`)
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	var result struct {
+		Selected []string `json:"selected"`
+	}
+	if err := json.Unmarshal([]byte(raw), &result); err != nil {
+		t.Fatalf("result is not JSON: %v\n%s", err, raw)
+	}
+	if len(result.Selected) != 1 || result.Selected[0] != "deferred_tool" {
+		t.Fatalf("selected = %v, want [deferred_tool]", result.Selected)
+	}
+
+	// Round N+1: the real definition, not the LazyTool placeholder.
+	defs := c.Definitions()
+	if len(defs) != 1 {
+		t.Fatalf("Definitions = %v, want the selected tool", names(defs))
+	}
+	if defs[0].Description != "alpha shared real description" {
+		t.Errorf("next-round description = %q, want real description", defs[0].Description)
+	}
+	if !strings.Contains(string(defs[0].InputSchema), "path") {
+		t.Errorf("next-round schema = %s, want the loaded tool's real schema", defs[0].InputSchema)
+	}
+}
+
+func TestSearchTool_SelectSkipsUnloadableTool(t *testing.T) {
+	reg := sdktool.NewRegistry()
+	c := New(reg, WithDefaultExposure(ExposureDeferred), WithSelectedRetention(3))
+	t.Cleanup(func() { _ = c.Close() })
+
+	if err := c.RegisterProxy("down", func(context.Context) (sdktool.Tool, error) {
+		return nil, errors.New("server unreachable")
+	}, ExposureDeferred, WithRetryPolicy(RetryPolicy{Attempts: 1, BaseDelay: 0})); err != nil {
+		t.Fatalf("RegisterProxy: %v", err)
+	}
+
+	ctx := WithCatalog(context.Background(), c)
+	raw, err := NewSearchTool().Execute(ctx,
+		`{"query":"server unreachable","select":["down"]}`)
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	var result struct {
+		Selected []string `json:"selected"`
+	}
+	if err := json.Unmarshal([]byte(raw), &result); err != nil {
+		t.Fatalf("result is not JSON: %v\n%s", err, raw)
+	}
+	if len(result.Selected) != 0 {
+		t.Fatalf("selected = %v, want empty for unloadable tool", result.Selected)
+	}
+	if got := names(c.Definitions()); len(got) != 0 {
+		t.Errorf("unloadable tool was selected: %v", got)
 	}
 }
 

--- a/sdkx/tool/dynamic/tool_test.go
+++ b/sdkx/tool/dynamic/tool_test.go
@@ -1,0 +1,100 @@
+package dynamic
+
+import (
+	"context"
+	"encoding/json"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/GizClaw/flowcraft/sdk/errdefs"
+	sdktool "github.com/GizClaw/flowcraft/sdk/tool"
+)
+
+func TestSearchTool_RequiresCatalogOnContext(t *testing.T) {
+	_, err := NewSearchTool().Execute(context.Background(), `{"query":"x"}`)
+	if !errdefs.IsNotAvailable(err) {
+		t.Fatalf("Execute without catalog = %v, want NotAvailable", err)
+	}
+}
+
+func TestSearchTool_ReturnsHitsAndSelects(t *testing.T) {
+	reg := sdktool.NewRegistry()
+	reg.Register(funcTool("deferred_tool", "alpha shared"))
+	reg.Register(funcTool("direct_tool", "alpha shared"))
+	c := New(reg,
+		WithDefaultExposure(ExposureDeferred),
+		WithExposure("direct_tool", ExposureDirect),
+		WithSelectedRetention(2),
+	)
+	t.Cleanup(func() { _ = c.Close() })
+
+	ctx := WithCatalog(context.Background(), c)
+	raw, err := NewSearchTool().Execute(ctx, `{"query":"alpha","select":["deferred_tool"]}`)
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	var result struct {
+		Query string `json:"query"`
+		Hits  []struct {
+			Name string `json:"name"`
+		} `json:"hits"`
+	}
+	if err := json.Unmarshal([]byte(raw), &result); err != nil {
+		t.Fatalf("result is not JSON: %v\n%s", err, raw)
+	}
+	if result.Query != "alpha" {
+		t.Errorf("query = %q", result.Query)
+	}
+	if len(result.Hits) != 2 {
+		t.Fatalf("hits = %d, want 2", len(result.Hits))
+	}
+	if !strings.Contains(raw, "deferred_tool") {
+		t.Errorf("result does not contain deferred_tool: %s", raw)
+	}
+
+	defs := c.Definitions()
+	got := names(defs)
+	want := []string{"deferred_tool"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("Definitions after select = %v, want %v", got, want)
+	}
+}
+
+func TestSearchTool_RejectsBadInput(t *testing.T) {
+	c := New(sdktool.NewRegistry())
+	t.Cleanup(func() { _ = c.Close() })
+	ctx := WithCatalog(context.Background(), c)
+
+	if _, err := NewSearchTool().Execute(ctx, `{"limit":2}`); !errdefs.IsValidation(err) {
+		t.Errorf("missing query = %v, want Validation", err)
+	}
+	if _, err := NewSearchTool().Execute(ctx, `not json`); !errdefs.IsValidation(err) {
+		t.Errorf("bad json = %v, want Validation", err)
+	}
+}
+
+func TestSearchTool_Definition(t *testing.T) {
+	def := NewSearchTool().Definition()
+	if def.Name != ToolName {
+		t.Errorf("name = %q, want %q", def.Name, ToolName)
+	}
+	if err := def.Validate(); err != nil {
+		t.Errorf("definition invalid: %v", err)
+	}
+}
+
+func TestRegisterSearchTool(t *testing.T) {
+	reg := sdktool.NewRegistry()
+	c := New(reg)
+	t.Cleanup(func() { _ = c.Close() })
+	if err := RegisterSearchTool(reg, c); err != nil {
+		t.Fatalf("RegisterSearchTool: %v", err)
+	}
+	if got := names(c.Definitions()); len(got) != 1 || got[0] != ToolName {
+		t.Errorf("Definitions = %v, want [%s]", got, ToolName)
+	}
+	if _, ok := reg.Get(ToolName); !ok {
+		t.Fatal("tool_search missing from registry")
+	}
+}

--- a/sdkx/tool/dynamic/visibility.go
+++ b/sdkx/tool/dynamic/visibility.go
@@ -1,0 +1,88 @@
+package dynamic
+
+import (
+	"sort"
+
+	"github.com/GizClaw/flowcraft/sdk/message"
+)
+
+// candidate couples one registry tool with its exposure and definition
+// for the visibility computation.
+type candidate struct {
+	name string
+	def  message.Definition
+	exp  Exposure
+}
+
+// visibleCandidates applies the visibility algorithm and returns the
+// definitions that reach the model this round, sorted by name for
+// stable output. The computation is pure: it never mutates the catalog
+// or the state.
+func visibleCandidates(cands []candidate, st stateSnapshot, policy Policy) []candidate {
+	budget := policy.budget()
+	visible := make([]candidate, 0, len(cands))
+	for _, c := range cands {
+		if include(c, st, policy) {
+			visible = append(visible, c)
+		}
+	}
+
+	// Deterministic pruning order: exposure rank, RequiredByName,
+	// selected rounds, recency, then name.
+	sort.SliceStable(visible, func(i, j int) bool {
+		return lessPriority(visible[i], visible[j], st)
+	})
+	if len(visible) > budget.MaxDefinitions {
+		visible = visible[:budget.MaxDefinitions]
+	}
+
+	kept := make([]candidate, 0, len(visible))
+	var total int64
+	for i, c := range visible {
+		size := definitionBytes(c.def)
+		if total+size > budget.MaxBytes && i > 0 {
+			break
+		}
+		total += size
+		kept = append(kept, c)
+	}
+
+	sort.Slice(kept, func(i, j int) bool {
+		return kept[i].name < kept[j].name
+	})
+	return kept
+}
+
+func include(c candidate, st stateSnapshot, policy Policy) bool {
+	required := st.isRequired(c.name)
+	selected := st.selected[c.name] > 0
+	recent := st.isRecent(c.name, policy.recentWindow())
+	switch c.exp {
+	case ExposureAlways:
+		return true
+	case ExposureDirect:
+		return required || selected || recent
+	case ExposureDeferred:
+		return required || selected
+	case ExposureHidden:
+		return required
+	default:
+		return false
+	}
+}
+
+func lessPriority(a, b candidate, st stateSnapshot) bool {
+	if ar, br := a.exp.rank(), b.exp.rank(); ar != br {
+		return ar < br
+	}
+	if ar, br := st.isRequired(a.name), st.isRequired(b.name); ar != br {
+		return ar
+	}
+	if as, bs := st.selected[a.name], st.selected[b.name]; as != bs {
+		return as > bs
+	}
+	if ar, br := st.recent[a.name], st.recent[b.name]; ar != br {
+		return ar > br
+	}
+	return a.name < b.name
+}

--- a/sdkx/tool/dynamic/visibility_test.go
+++ b/sdkx/tool/dynamic/visibility_test.go
@@ -1,0 +1,173 @@
+package dynamic
+
+import (
+	"encoding/json"
+	"reflect"
+	"testing"
+
+	"github.com/GizClaw/flowcraft/sdk/message"
+)
+
+func def(name string) message.Definition {
+	return message.Definition{
+		Name:        name,
+		Description: "tool " + name,
+		InputSchema: json.RawMessage(`{"type":"object"}`),
+	}
+}
+
+func candidates(names ...string) []candidate {
+	out := make([]candidate, 0, len(names))
+	for _, name := range names {
+		out = append(out, candidate{name: name, def: def(name), exp: ExposureDeferred})
+	}
+	return out
+}
+
+func withExposures(cands []candidate, exps map[string]Exposure) []candidate {
+	for i := range cands {
+		if e, ok := exps[cands[i].name]; ok {
+			cands[i].exp = e
+		}
+	}
+	return cands
+}
+
+func visibleNames(cands []candidate, st stateSnapshot, policy Policy) []string {
+	out := visibleCandidates(cands, st, policy)
+	names := make([]string, 0, len(out))
+	for _, c := range out {
+		names = append(names, c.name)
+	}
+	return names
+}
+
+func TestVisibility_ExposureBaselines(t *testing.T) {
+	policy := DefaultPolicy()
+	policy.Default = ExposureHidden
+	policy.Budget = Budget{MaxDefinitions: 100, MaxBytes: 1 << 20}
+	policy.SelectedRetention = 3
+	policy.RecentWindow = 3
+	st := newState().snapshot()
+
+	cands := withExposures(candidates("always_a", "direct_b", "deferred_c", "hidden_d"), map[string]Exposure{
+		"always_a": ExposureAlways, "direct_b": ExposureDirect,
+		"deferred_c": ExposureDeferred, "hidden_d": ExposureHidden,
+	})
+
+	got := visibleNames(cands, st, policy)
+	want := []string{"always_a"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("baseline visible = %v, want %v", got, want)
+	}
+}
+
+func TestVisibility_DirectRequiredRecent(t *testing.T) {
+	policy := DefaultPolicy()
+	policy.Default = ExposureHidden
+	policy.Budget = Budget{MaxDefinitions: 100, MaxBytes: 1 << 20}
+	policy.SelectedRetention = 3
+	policy.RecentWindow = 3
+
+	cands := withExposures(candidates("d1", "d2", "d3"), map[string]Exposure{
+		"d1": ExposureDirect, "d2": ExposureDirect, "d3": ExposureDirect,
+	})
+
+	base := newState()
+	base.turn = 10
+	base.require("d1")
+	base.selectNames([]string{"d2"}, 3)
+	base.recordCall("d3", 3)
+
+	got := visibleNames(cands, base.snapshot(), policy)
+	want := []string{"d1", "d2", "d3"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("direct visible = %v, want %v", got, want)
+	}
+}
+
+func TestVisibility_DeferredRequiresSelection(t *testing.T) {
+	policy := DefaultPolicy()
+	policy.Default = ExposureHidden
+	policy.Budget = Budget{MaxDefinitions: 100, MaxBytes: 1 << 20}
+	policy.SelectedRetention = 2
+
+	cands := withExposures(candidates("def"), map[string]Exposure{"def": ExposureDeferred})
+
+	if got := visibleNames(cands, newState().snapshot(), policy); len(got) != 0 {
+		t.Errorf("unselected deferred tool visible: %v", got)
+	}
+
+	st := newState()
+	st.selectNames([]string{"def"}, 2)
+	if got := visibleNames(cands, st.snapshot(), policy); !reflect.DeepEqual(got, []string{"def"}) {
+		t.Errorf("selected deferred tool not visible: %v", got)
+	}
+
+	st.advanceTurn(10)
+	if got := visibleNames(cands, st.snapshot(), policy); !reflect.DeepEqual(got, []string{"def"}) {
+		t.Errorf("deferred tool expired one round early: %v", got)
+	}
+	st.advanceTurn(10)
+	if got := visibleNames(cands, st.snapshot(), policy); len(got) != 0 {
+		t.Errorf("deferred tool visible after retention expiry: %v", got)
+	}
+}
+
+func TestVisibility_HiddenOnlyRequired(t *testing.T) {
+	policy := DefaultPolicy()
+	policy.Default = ExposureHidden
+	policy.Budget = Budget{MaxDefinitions: 100, MaxBytes: 1 << 20}
+
+	cands := withExposures(candidates("h"), map[string]Exposure{"h": ExposureHidden})
+	st := newState()
+	st.recordCall("h", 5)
+	if got := visibleNames(cands, st.snapshot(), policy); len(got) != 0 {
+		t.Errorf("hidden tool visible after use: %v", got)
+	}
+	st.require("h")
+	if got := visibleNames(cands, st.snapshot(), policy); !reflect.DeepEqual(got, []string{"h"}) {
+		t.Errorf("hidden tool not visible when required: %v", got)
+	}
+}
+
+func TestVisibility_BudgetPrunesDeterministically(t *testing.T) {
+	policy := DefaultPolicy()
+	policy.Default = ExposureDeferred
+	policy.Budget = Budget{MaxDefinitions: 3, MaxBytes: 1 << 20}
+	policy.SelectedRetention = 3
+	policy.RecentWindow = 10
+
+	cands := withExposures(candidates("a", "b", "c", "d"), map[string]Exposure{
+		"a": ExposureAlways, "b": ExposureAlways, "c": ExposureAlways, "d": ExposureAlways,
+	})
+	st := newState().snapshot()
+	got := visibleNames(cands, st, policy)
+	if !reflect.DeepEqual(got, []string{"a", "b", "c"}) {
+		t.Errorf("pruned = %v, want [a b c]", got)
+	}
+	// Deterministic: same input, same output.
+	if again := visibleNames(cands, st, policy); !reflect.DeepEqual(got, again) {
+		t.Errorf("visible set is not deterministic: %v vs %v", got, again)
+	}
+}
+
+func TestVisibility_ByteBudgetEvictsLargestLast(t *testing.T) {
+	policy := DefaultPolicy()
+	policy.Default = ExposureAlways
+	policy.Budget = Budget{MaxDefinitions: 100, MaxBytes: 200}
+
+	big := def("big")
+	big.Description = string(make([]byte, 500))
+	small := def("small")
+	small.Description = "x"
+
+	cands := []candidate{
+		{name: "big", def: big, exp: ExposureAlways},
+		{name: "small", def: small, exp: ExposureAlways},
+	}
+	got := visibleNames(cands, newState().snapshot(), policy)
+	if !reflect.DeepEqual(got, []string{"big"}) {
+		t.Errorf("byte budget result = %v, want only big (first never evicted)", got)
+	}
+}

--- a/sdkx/tool/mcp/config.go
+++ b/sdkx/tool/mcp/config.go
@@ -11,6 +11,7 @@ import (
 	"github.com/GizClaw/flowcraft/sdk/errdefs"
 	sdktool "github.com/GizClaw/flowcraft/sdk/tool"
 	toolconfig "github.com/GizClaw/flowcraft/sdk/tool/config"
+	"github.com/GizClaw/flowcraft/sdkx/tool/dynamic"
 	mcpsdk "github.com/modelcontextprotocol/go-sdk/mcp"
 )
 
@@ -65,6 +66,20 @@ type ServerSpec struct {
 	// Prefix overrides the default "<name>__" namespace. An explicit
 	// empty string registers tools under their bare server-side names.
 	Prefix *string `json:"prefix,omitempty"`
+
+	// Defer attaches without connecting: no child process and no
+	// tools/list until the first load. Declared tools in Tools are
+	// registered as lazy proxies immediately.
+	Defer bool `json:"defer,omitempty"`
+	// Exposure is the server-level exposure for every tool it
+	// contributes; per-tool entries in Tools override it. The default is
+	// "deferred" so MCP tools reach the model through tool_search.
+	Exposure dynamic.Exposure `json:"exposure,omitempty"`
+	// Tools maps server-side tool names to exposure overrides.
+	Tools map[string]dynamic.Exposure `json:"tools,omitempty"`
+	// Resources bridges the server's MCP resources into two registry
+	// tools (<prefix>list_resources / <prefix>read_resource).
+	Resources bool `json:"resources,omitempty"`
 }
 
 // Transport constants for ServerSpec.Transport.
@@ -176,6 +191,23 @@ func (s ServerSpec) validate(index int) error {
 			"mcp: servers[%d] (%s): unknown transport %q (want %q or %q)",
 			index, s.Name, s.Transport, TransportStdio, TransportHTTP)
 	}
+	if s.Exposure != "" && !s.Exposure.Valid() {
+		return errdefs.Validationf(
+			"mcp: servers[%d] (%s): exposure %q is not a valid exposure",
+			index, s.Name, s.Exposure)
+	}
+	for toolName, exp := range s.Tools {
+		if strings.TrimSpace(toolName) == "" {
+			return errdefs.Validationf(
+				"mcp: servers[%d] (%s): tools map has an empty tool name",
+				index, s.Name)
+		}
+		if !exp.Valid() {
+			return errdefs.Validationf(
+				"mcp: servers[%d] (%s): tools[%s]: exposure %q is not a valid exposure",
+				index, s.Name, toolName, exp)
+		}
+	}
 	return nil
 }
 
@@ -200,6 +232,22 @@ func (s ServerSpec) options() []ServerOption {
 	}
 	if s.Prefix != nil {
 		opts = append(opts, WithPrefix(*s.Prefix))
+	}
+	if s.Defer {
+		opts = append(opts, WithDeferred(true))
+	}
+	if s.Exposure != "" {
+		opts = append(opts, WithExposure(s.Exposure))
+	}
+	if len(s.Tools) > 0 {
+		tools := make(map[string]dynamic.Exposure, len(s.Tools))
+		for name, exp := range s.Tools {
+			tools[name] = exp
+		}
+		opts = append(opts, WithTools(tools))
+	}
+	if s.Resources {
+		opts = append(opts, WithResources(true))
 	}
 	return opts
 }

--- a/sdkx/tool/mcp/mcp_test.go
+++ b/sdkx/tool/mcp/mcp_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/GizClaw/flowcraft/sdk/errdefs"
 	"github.com/GizClaw/flowcraft/sdk/message"
 	sdktool "github.com/GizClaw/flowcraft/sdk/tool"
+	"github.com/GizClaw/flowcraft/sdkx/tool/dynamic"
 	"github.com/GizClaw/flowcraft/sdkx/tool/mcp"
 	mcpsdk "github.com/modelcontextprotocol/go-sdk/mcp"
 )
@@ -67,6 +68,21 @@ func (ts *testServer) addTool(name, description string, schema any, ann *mcpsdk.
 		InputSchema: schema,
 		Annotations: ann,
 	}, handler)
+}
+
+func (ts *testServer) addResource(uri, name, description, mimeType, text string) {
+	ts.server.AddResource(&mcpsdk.Resource{
+		URI:         uri,
+		Name:        name,
+		Description: description,
+		MIMEType:    mimeType,
+	}, func(_ context.Context, _ *mcpsdk.ReadResourceRequest) (*mcpsdk.ReadResourceResult, error) {
+		return &mcpsdk.ReadResourceResult{
+			Contents: []*mcpsdk.ResourceContents{
+				{URI: uri, MIMEType: mimeType, Text: text},
+			},
+		}, nil
+	})
 }
 
 func textResult(text string) mcpsdk.ToolHandler {
@@ -722,11 +738,335 @@ func TestConfig_ParseSpecRejectsBadInput(t *testing.T) {
 		{"stdio with url", `{"servers":[{"name":"x","transport":"stdio","command":"x","url":"http://x"}]}`},
 		{"http with command", `{"servers":[{"name":"x","transport":"http","url":"http://x","command":"y"}]}`},
 		{"bad scope", `{"servers":[{"name":"x","transport":"stdio","command":"x","scope":"secret"}]}`},
+		{"bad exposure", `{"servers":[{"name":"x","transport":"stdio","command":"x","exposure":"secret"}]}`},
+		{"bad tool exposure", `{"servers":[{"name":"x","transport":"stdio","command":"x","tools":{"read_file":"secret"}}]}`},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			if _, err := mcp.ParseSpec(specNode(t, tc.raw)); err == nil {
 				t.Errorf("ParseSpec(%q) succeeded, want error", tc.name)
 			}
 		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// deferred attach + exposure
+// ---------------------------------------------------------------------------
+
+func TestAddServer_DeferredRegistersDeclaredProxyWithoutConnecting(t *testing.T) {
+	ts := newTestServer(t, "fs")
+	ts.addTool("read_file", "Read a file", objectSchema(), nil, textResult("contents"))
+
+	reg := sdktool.NewRegistry()
+	src := mcp.NewSource(reg)
+	t.Cleanup(func() { _ = src.Close() })
+
+	err := src.AddServer(t.Context(), "filesystem", ts.transport,
+		mcp.WithDeferred(true),
+		mcp.WithTools(map[string]dynamic.Exposure{"read_file": dynamic.ExposureDeferred}),
+	)
+	if err != nil {
+		t.Fatalf("AddServer(deferred): %v", err)
+	}
+
+	tool, ok := reg.Get("filesystem__read_file")
+	if !ok {
+		t.Fatalf("declared proxy missing from registry; have %v", reg.Names())
+	}
+	lazy, isLazy := tool.(*dynamic.LazyTool)
+	if !isLazy {
+		t.Fatalf("declared tool type = %T, want *dynamic.LazyTool", tool)
+	}
+	if def := lazy.Definition(); def.Name != "filesystem__read_file" ||
+		!strings.Contains(def.Description, "deferred") {
+		t.Errorf("placeholder definition = %+v", def)
+	}
+	if got := src.ToolNames("filesystem"); len(got) != 1 || got[0] != "filesystem__read_file" {
+		t.Errorf("ToolNames = %v, want the declared proxy", got)
+	}
+	if reg.Len() != 1 {
+		t.Errorf("registry Len = %d, want only the declared proxy", reg.Len())
+	}
+
+	// Serve the server side, then load; the proxy is replaced by the
+	// real adapted tool and stays callable.
+	ts.serve(t)
+	if err := src.Refresh(t.Context()); err != nil {
+		t.Fatalf("Refresh(deferred): %v", err)
+	}
+	tool, ok = reg.Get("filesystem__read_file")
+	if !ok {
+		t.Fatal("tool missing after load")
+	}
+	if _, isLazy := tool.(*dynamic.LazyTool); isLazy {
+		t.Fatal("tool is still a proxy after load, want adapted tool")
+	}
+	res, err := tool.Execute(t.Context(), `{}`)
+	if err != nil {
+		t.Fatalf("Execute after load: %v", err)
+	}
+	if res != "contents" {
+		t.Errorf("Execute = %q, want contents", res)
+	}
+	if err := src.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+}
+
+func TestAddServer_DeferredExecutesThroughProxy(t *testing.T) {
+	ts := newTestServer(t, "fs")
+	ts.addTool("read_file", "Read a file", objectSchema(), nil, textResult("mcp-content"))
+	ts.serve(t)
+
+	reg := sdktool.NewRegistry()
+	src := mcp.NewSource(reg)
+	t.Cleanup(func() { _ = src.Close() })
+
+	if err := src.AddServer(t.Context(), "filesystem", ts.transport,
+		mcp.WithDeferred(true),
+		mcp.WithTools(map[string]dynamic.Exposure{"read_file": dynamic.ExposureDeferred}),
+	); err != nil {
+		t.Fatalf("AddServer(deferred): %v", err)
+	}
+
+	tool, ok := reg.Get("filesystem__read_file")
+	if !ok {
+		t.Fatal("declared proxy missing")
+	}
+	res, err := tool.Execute(t.Context(), `{}`)
+	if err != nil {
+		t.Fatalf("Execute through proxy: %v", err)
+	}
+	if res != "mcp-content" {
+		t.Errorf("Execute = %q, want mcp-content", res)
+	}
+	if err := src.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+}
+
+func TestAddServer_DeferredExposureWithDynamicCatalog(t *testing.T) {
+	ts := newTestServer(t, "fs")
+	ts.addTool("read_file", "Read a file", objectSchema(), nil, textResult("x"))
+	ts.addTool("write_file", "Write a file", objectSchema(), nil, textResult("x"))
+
+	reg := sdktool.NewRegistry()
+	dyn := dynamic.New(reg)
+	src := mcp.NewSource(reg)
+	t.Cleanup(func() { _ = src.Close() })
+	t.Cleanup(func() { _ = dyn.Close() })
+
+	err := src.AddServer(t.Context(), "filesystem", ts.transport,
+		mcp.WithDeferred(true),
+		mcp.WithDynamicCatalog(dyn),
+		mcp.WithExposure(dynamic.ExposureDeferred),
+		mcp.WithTools(map[string]dynamic.Exposure{
+			"read_file": dynamic.ExposureAlways,
+		}),
+	)
+	if err != nil {
+		t.Fatalf("AddServer(deferred): %v", err)
+	}
+
+	// read_file is always-visible even as a placeholder; write_file
+	// stays deferred and hidden until selected.
+	defs := dyn.Definitions()
+	if len(defs) != 1 || defs[0].Name != "filesystem__read_file" {
+		t.Fatalf("dynamic Definitions = %v, want only read_file placeholder", defs)
+	}
+
+	ts.serve(t)
+	if err := src.Refresh(t.Context()); err != nil {
+		t.Fatalf("Refresh: %v", err)
+	}
+	defs = dyn.Definitions()
+	if len(defs) != 1 || defs[0].Name != "filesystem__read_file" {
+		t.Fatalf("dynamic Definitions after load = %v", defs)
+	}
+	if defs[0].Description != "Read a file" {
+		t.Errorf("loaded description = %q, want real description", defs[0].Description)
+	}
+
+	dyn.Select("filesystem__write_file")
+	got := make([]string, 0, 2)
+	for _, d := range dyn.Definitions() {
+		got = append(got, d.Name)
+	}
+	want := []string{"filesystem__read_file", "filesystem__write_file"}
+	if len(got) != 2 || got[0] != want[0] || got[1] != want[1] {
+		t.Errorf("Definitions after select = %v, want %v", got, want)
+	}
+	if err := src.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+}
+
+func TestAddServer_DeferredRejectsInvalidExposure(t *testing.T) {
+	src := mcp.NewSource(sdktool.NewRegistry())
+	t.Cleanup(func() { _ = src.Close() })
+	err := src.AddServer(t.Context(), "fs", &mcpsdk.CommandTransport{},
+		mcp.WithDeferred(true),
+		mcp.WithTools(map[string]dynamic.Exposure{"x": dynamic.Exposure("bogus")}),
+	)
+	if !errdefs.IsValidation(err) {
+		t.Fatalf("AddServer = %v, want Validation", err)
+	}
+}
+
+func TestAddServer_DeferredOwnershipConflict(t *testing.T) {
+	first := newTestServer(t, "a")
+	first.addTool("read", "Read A", objectSchema(), nil, textResult("a"))
+	second := newTestServer(t, "b")
+	second.addTool("read", "Read B", objectSchema(), nil, textResult("b"))
+
+	reg := sdktool.NewRegistry()
+	src := mcp.NewSource(reg)
+	t.Cleanup(func() { _ = src.Close() })
+
+	tools := map[string]dynamic.Exposure{"read": dynamic.ExposureDeferred}
+	if err := src.AddServer(t.Context(), "alpha", first.transport,
+		mcp.WithDeferred(true), mcp.WithPrefix("shared__"), mcp.WithTools(tools)); err != nil {
+		t.Fatalf("AddServer alpha: %v", err)
+	}
+	err := src.AddServer(t.Context(), "beta", second.transport,
+		mcp.WithDeferred(true), mcp.WithPrefix("shared__"), mcp.WithTools(tools))
+	if err == nil || !errdefs.IsConflict(err) {
+		t.Fatalf("AddServer beta = %v, want Conflict", err)
+	}
+	if got := src.Servers(); len(got) != 1 || got[0] != "alpha" {
+		t.Fatalf("attached servers = %v, want only alpha", got)
+	}
+}
+
+func TestApplyExposures_SyncServer(t *testing.T) {
+	ts := newTestServer(t, "fs")
+	ts.addTool("read_file", "Read a file", objectSchema(), nil, textResult("x"))
+	ts.addTool("write_file", "Write a file", objectSchema(), nil, textResult("x"))
+	ts.serve(t)
+
+	reg := sdktool.NewRegistry()
+	dyn := dynamic.New(reg)
+	t.Cleanup(func() { _ = dyn.Close() })
+	src := mcp.NewSource(reg)
+	t.Cleanup(func() { _ = src.Close() })
+
+	if err := src.AddServer(t.Context(), "filesystem", ts.transport,
+		mcp.WithExposure(dynamic.ExposureAlways),
+		mcp.WithTools(map[string]dynamic.Exposure{"read_file": dynamic.ExposureHidden}),
+	); err != nil {
+		t.Fatalf("AddServer: %v", err)
+	}
+	if err := src.ApplyExposures(dyn); err != nil {
+		t.Fatalf("ApplyExposures: %v", err)
+	}
+	got := make([]string, 0, 1)
+	for _, d := range dyn.Definitions() {
+		got = append(got, d.Name)
+	}
+	if len(got) != 1 || got[0] != "filesystem__write_file" {
+		t.Errorf("Definitions = %v, want only write_file (read_file hidden)", got)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// resources bridge
+// ---------------------------------------------------------------------------
+
+func TestAddServer_ResourcesBridge(t *testing.T) {
+	ts := newTestServer(t, "fs")
+	ts.addTool("read_file", "Read a file", objectSchema(), nil, textResult("x"))
+	ts.addResource("file:///tmp/a.txt", "a.txt", "A text file", "text/plain", "hello")
+	ts.serve(t)
+
+	reg := sdktool.NewRegistry()
+	src := mcp.NewSource(reg)
+	t.Cleanup(func() { _ = src.Close() })
+
+	if err := src.AddServer(t.Context(), "filesystem", ts.transport,
+		mcp.WithResources(true)); err != nil {
+		t.Fatalf("AddServer: %v", err)
+	}
+	for _, name := range []string{
+		"filesystem__list_resources",
+		"filesystem__read_resource",
+	} {
+		if _, ok := reg.Get(name); !ok {
+			t.Fatalf("resource bridge tool %q missing; have %v", name, reg.Names())
+		}
+	}
+
+	list, _ := reg.Get("filesystem__list_resources")
+	raw, err := list.Execute(t.Context(), `{}`)
+	if err != nil {
+		t.Fatalf("list resources: %v", err)
+	}
+	if !strings.Contains(raw, "file:///tmp/a.txt") ||
+		!strings.Contains(raw, "A text file") {
+		t.Errorf("list output = %s, want resource metadata", raw)
+	}
+
+	read, _ := reg.Get("filesystem__read_resource")
+	raw, err = read.Execute(t.Context(), `{"uri":"file:///tmp/a.txt"}`)
+	if err != nil {
+		t.Fatalf("read resource: %v", err)
+	}
+	if !strings.Contains(raw, "hello") {
+		t.Errorf("read output = %s, want resource text", raw)
+	}
+
+	if err := src.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+}
+
+func TestAddServer_DeferredResourcesBridgeLoadsOnRefresh(t *testing.T) {
+	ts := newTestServer(t, "fs")
+	ts.addResource("file:///tmp/a.txt", "a.txt", "A text file", "text/plain", "hello")
+	ts.serve(t)
+
+	reg := sdktool.NewRegistry()
+	src := mcp.NewSource(reg)
+	t.Cleanup(func() { _ = src.Close() })
+
+	if err := src.AddServer(t.Context(), "filesystem", ts.transport,
+		mcp.WithDeferred(true), mcp.WithResources(true)); err != nil {
+		t.Fatalf("AddServer(deferred): %v", err)
+	}
+	if _, ok := reg.Get("filesystem__list_resources"); ok {
+		t.Fatal("resource bridge tools must not register before the deferred load")
+	}
+	if err := src.Refresh(t.Context()); err != nil {
+		t.Fatalf("Refresh: %v", err)
+	}
+	read, ok := reg.Get("filesystem__read_resource")
+	if !ok {
+		t.Fatalf("resource bridge missing after load; have %v", reg.Names())
+	}
+	raw, err := read.Execute(t.Context(), `{"uri":"file:///tmp/a.txt"}`)
+	if err != nil {
+		t.Fatalf("read resource: %v", err)
+	}
+	if !strings.Contains(raw, "hello") {
+		t.Errorf("read output = %s, want resource text", raw)
+	}
+	if err := src.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+}
+
+func TestConfig_ParseSpecAcceptsResources(t *testing.T) {
+	spec, err := mcp.ParseSpec(specNode(t, `{
+		"servers": [{
+			"name": "x",
+			"transport": "stdio",
+			"command": "x",
+			"resources": true
+		}]
+	}`))
+	if err != nil {
+		t.Fatalf("ParseSpec: %v", err)
+	}
+	if len(spec.Servers) != 1 || !spec.Servers[0].Resources {
+		t.Errorf("parsed spec = %+v, want resources enabled", spec.Servers)
 	}
 }

--- a/sdkx/tool/mcp/resources.go
+++ b/sdkx/tool/mcp/resources.go
@@ -1,0 +1,192 @@
+package mcp
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"strings"
+
+	"github.com/GizClaw/flowcraft/sdk/errdefs"
+	"github.com/GizClaw/flowcraft/sdk/message"
+	sdktool "github.com/GizClaw/flowcraft/sdk/tool"
+	mcpsdk "github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+// Resource bridge tool names, namespaced like any other tool by the
+// server prefix (filesystem__list_resources, filesystem__read_resource).
+const (
+	listResourcesToolName = "list_resources"
+	readResourceToolName  = "read_resource"
+)
+
+type resourceKind uint8
+
+const (
+	resourceList resourceKind = iota
+	resourceRead
+)
+
+// resourceTool adapts one MCP resource operation to the local tool
+// contract, so resources flow through the same registry, exposure,
+// approval, and middleware machinery as every other tool.
+type resourceTool struct {
+	server *server
+	def    message.Definition
+	kind   resourceKind
+}
+
+var _ sdktool.Tool = (*resourceTool)(nil)
+
+func (r *resourceTool) Definition() message.Definition { return r.def }
+
+func (r *resourceTool) Execute(ctx context.Context, arguments string) (string, error) {
+	session, err := r.server.currentSession()
+	if err != nil {
+		return "", err
+	}
+	switch r.kind {
+	case resourceList:
+		return r.list(ctx, session)
+	case resourceRead:
+		return r.read(ctx, session, arguments)
+	default:
+		return "", errdefs.Internalf("mcp: unknown resource tool kind")
+	}
+}
+
+func (r *resourceTool) list(ctx context.Context, session *mcpsdk.ClientSession) (string, error) {
+	res, err := session.ListResources(ctx, nil)
+	if err != nil {
+		return "", errdefs.NotAvailablef(
+			"mcp: server %q: list resources: %v", r.server.name, err)
+	}
+	raw, err := json.Marshal(renderResourceList(res))
+	if err != nil {
+		return "", errdefs.Internalf(
+			"mcp: server %q: encode resource list: %v", r.server.name, err)
+	}
+	return string(raw), nil
+}
+
+func (r *resourceTool) read(ctx context.Context, session *mcpsdk.ClientSession, arguments string) (string, error) {
+	var args struct {
+		URI string `json:"uri"`
+	}
+	if err := json.Unmarshal([]byte(arguments), &args); err != nil {
+		return "", errdefs.Validationf(
+			"mcp: %s: parse arguments: %v", readResourceToolName, err)
+	}
+	if strings.TrimSpace(args.URI) == "" {
+		return "", errdefs.Validationf(
+			"mcp: %s: uri is required", readResourceToolName)
+	}
+	res, err := session.ReadResource(ctx, &mcpsdk.ReadResourceParams{URI: args.URI})
+	if err != nil {
+		return "", errdefs.NotAvailablef(
+			"mcp: server %q: read resource %q: %v", r.server.name, args.URI, err)
+	}
+	raw, err := json.Marshal(renderResourceContents(res.Contents))
+	if err != nil {
+		return "", errdefs.Internalf(
+			"mcp: server %q: encode resource contents: %v", r.server.name, err)
+	}
+	return string(raw), nil
+}
+
+type resourceMeta struct {
+	URI         string `json:"uri"`
+	Name        string `json:"name,omitempty"`
+	Title       string `json:"title,omitempty"`
+	Description string `json:"description,omitempty"`
+	MIMEType    string `json:"mime_type,omitempty"`
+	Size        int64  `json:"size,omitempty"`
+}
+
+func renderResourceList(res *mcpsdk.ListResourcesResult) []resourceMeta {
+	if res == nil {
+		return []resourceMeta{}
+	}
+	out := make([]resourceMeta, 0, len(res.Resources))
+	for _, r := range res.Resources {
+		if r == nil {
+			continue
+		}
+		out = append(out, resourceMeta{
+			URI:         r.URI,
+			Name:        r.Name,
+			Title:       r.Title,
+			Description: r.Description,
+			MIMEType:    r.MIMEType,
+			Size:        r.Size,
+		})
+	}
+	return out
+}
+
+type renderedResource struct {
+	URI        string `json:"uri"`
+	MIMEType   string `json:"mime_type,omitempty"`
+	Text       string `json:"text,omitempty"`
+	BlobBase64 string `json:"blob_base64,omitempty"`
+}
+
+func renderResourceContents(contents []*mcpsdk.ResourceContents) []renderedResource {
+	if len(contents) == 0 {
+		return []renderedResource{}
+	}
+	out := make([]renderedResource, 0, len(contents))
+	for _, c := range contents {
+		if c == nil {
+			continue
+		}
+		item := renderedResource{URI: c.URI, MIMEType: c.MIMEType, Text: c.Text}
+		if len(c.Blob) > 0 {
+			item.BlobBase64 = base64.StdEncoding.EncodeToString(c.Blob)
+		}
+		out = append(out, item)
+	}
+	return out
+}
+
+func listResourcesDefinition(qualified string) message.Definition {
+	return message.Definition{
+		Name:        qualified,
+		Description: "List the resources this MCP server exposes (uri, name, description, mime type, size).",
+		InputSchema: json.RawMessage(`{"type":"object"}`),
+	}
+}
+
+func readResourceDefinition(qualified string) message.Definition {
+	return message.DefineSchema(
+		qualified,
+		"Read one resource from this MCP server by URI. Returns the resource contents as JSON; binary blobs are base64-encoded.",
+		message.ToolProperty("uri", "string", "the resource URI to read"),
+	).Required("uri").Build()
+}
+
+// resourceToolSpec pairs a resource bridge remote name with its tool.
+type resourceToolSpec struct {
+	remote string
+	tool   sdktool.Tool
+}
+
+func resourceToolSpecs(srv *server) []resourceToolSpec {
+	return []resourceToolSpec{
+		{
+			remote: listResourcesToolName,
+			tool: &resourceTool{
+				server: srv,
+				kind:   resourceList,
+				def:    listResourcesDefinition(srv.qualify(listResourcesToolName)),
+			},
+		},
+		{
+			remote: readResourceToolName,
+			tool: &resourceTool{
+				server: srv,
+				kind:   resourceRead,
+				def:    readResourceDefinition(srv.qualify(readResourceToolName)),
+			},
+		},
+	}
+}

--- a/sdkx/tool/mcp/source.go
+++ b/sdkx/tool/mcp/source.go
@@ -8,8 +8,11 @@ import (
 	"sync"
 
 	"github.com/GizClaw/flowcraft/sdk/errdefs"
+	"github.com/GizClaw/flowcraft/sdk/message"
 	sdktool "github.com/GizClaw/flowcraft/sdk/tool"
+	"github.com/GizClaw/flowcraft/sdkx/tool/dynamic"
 	mcpsdk "github.com/modelcontextprotocol/go-sdk/mcp"
+	"golang.org/x/sync/singleflight"
 )
 
 // DefaultPrefixSeparator joins a server name to a tool name when
@@ -78,10 +81,29 @@ type server struct {
 	scope     string
 	prefix    string
 	transport mcpsdk.Transport
+	deferred  bool
+	exposure  dynamic.Exposure
+	// tools maps server-side tool names to exposure overrides.
+	tools map[string]dynamic.Exposure
+	// toolExposure maps qualified registry names to their per-tool
+	// exposure; names without an entry use the server-level exposure.
+	toolExposure map[string]dynamic.Exposure
+	dynamicCat   *dynamic.Catalog
+	clientName   string
+	clientVer    string
+	clientOpts   *mcpsdk.ClientOptions
+	onListError  func(server string, err error)
+	resources    bool
+	// resourceTools tracks qualified names registered by the resource
+	// bridge, so a server-side tool with the same name is never
+	// shadowed by the bridge.
+	resourceTools map[string]struct{}
 
 	mu         sync.Mutex
 	session    *mcpsdk.ClientSession
 	registered map[string]struct{}
+	declared   map[string]struct{}
+	loadGroup  singleflight.Group
 }
 
 // currentSession returns the live session or a typed error if the
@@ -116,6 +138,12 @@ type serverConfig struct {
 	clientVer   string
 	clientOpts  *mcpsdk.ClientOptions
 	onListError func(server string, err error)
+	deferred    bool
+	exposure    dynamic.Exposure
+	exposureSet bool
+	tools       map[string]dynamic.Exposure
+	dynamicCat  *dynamic.Catalog
+	resources   bool
 }
 
 // WithScope sets the registry scope the server's tools register under.
@@ -124,6 +152,49 @@ type serverConfig struct {
 // tool listings but remain callable by explicit name.
 func WithScope(scope string) ServerOption {
 	return func(c *serverConfig) { c.scope = scope }
+}
+
+// WithDeferred attaches the server without connecting: no child process
+// and no tools/list until the first load. Declared tools (see
+// WithTools) are registered as lazy proxies immediately; servers
+// without a tools map register nothing until loaded.
+func WithDeferred(deferred bool) ServerOption {
+	return func(c *serverConfig) { c.deferred = deferred }
+}
+
+// WithExposure sets the default exposure for every tool this server
+// contributes. Per-tool entries in WithTools override it. The default
+// is dynamic.ExposureDeferred: MCP tools enter the model's view through
+// tool_search, not by dumping every server into the prompt.
+func WithExposure(exposure dynamic.Exposure) ServerOption {
+	return func(c *serverConfig) {
+		c.exposure = exposure
+		c.exposureSet = true
+	}
+}
+
+// WithTools declares per-tool exposure by server-side tool name (not
+// the qualified registry name — prefixing stays WithPrefix's job). For
+// deferred servers these names are also registered immediately as lazy
+// proxies, so they are callable by exact name before the first load.
+func WithTools(tools map[string]dynamic.Exposure) ServerOption {
+	return func(c *serverConfig) { c.tools = tools }
+}
+
+// WithDynamicCatalog wires a dynamic catalog for exposure metadata:
+// every tool this server registers gets its exposure recorded there,
+// and deferred proxies are registered through the catalog. A host
+// using the dynamic injection layer should always pass its session
+// catalog here.
+func WithDynamicCatalog(cat *dynamic.Catalog) ServerOption {
+	return func(c *serverConfig) { c.dynamicCat = cat }
+}
+
+// WithResources bridges the server's MCP resources into two registry
+// tools — <prefix>list_resources and <prefix>read_resource — so they
+// inherit exposure, approval, and every other middleware capability.
+func WithResources(enabled bool) ServerOption {
+	return func(c *serverConfig) { c.resources = enabled }
 }
 
 // WithPrefix overrides the namespace prefix applied to the server's tool
@@ -193,24 +264,41 @@ func (s *Source) AddServer(ctx context.Context, name string, transport mcpsdk.Tr
 	for _, opt := range opts {
 		opt(cfg)
 	}
+	exposure := cfg.exposure
+	if !cfg.exposureSet {
+		exposure = dynamic.ExposureDeferred
+	}
+	if err := validateExposureConfig(exposure, cfg.tools); err != nil {
+		return err
+	}
 
-	s.mu.Lock()
-	if s.closed {
-		s.mu.Unlock()
-		return errdefs.NotAvailablef("mcp: source is closed")
+	toolExposure := make(map[string]dynamic.Exposure, len(cfg.tools))
+	for remote, exp := range cfg.tools {
+		toolExposure[qualify(cfg.prefix, remote)] = exp
 	}
-	if _, exists := s.servers[name]; exists {
-		s.mu.Unlock()
-		return errdefs.Validationf("mcp: server %q is already attached", name)
-	}
-	s.mu.Unlock()
 
 	srv := &server{
-		name:       name,
-		scope:      cfg.scope,
-		prefix:     cfg.prefix,
-		transport:  transport,
-		registered: make(map[string]struct{}),
+		name:          name,
+		scope:         cfg.scope,
+		prefix:        cfg.prefix,
+		transport:     transport,
+		deferred:      cfg.deferred,
+		exposure:      exposure,
+		tools:         cfg.tools,
+		toolExposure:  toolExposure,
+		dynamicCat:    cfg.dynamicCat,
+		clientName:    cfg.clientName,
+		clientVer:     cfg.clientVer,
+		clientOpts:    cfg.clientOpts,
+		onListError:   cfg.onListError,
+		resources:     cfg.resources,
+		resourceTools: make(map[string]struct{}),
+		registered:    make(map[string]struct{}),
+		declared:      make(map[string]struct{}),
+	}
+
+	if cfg.deferred {
+		return s.addDeferred(srv)
 	}
 
 	session, err := s.connect(ctx, srv, cfg)
@@ -225,17 +313,205 @@ func (s *Source) AddServer(ctx context.Context, name string, transport mcpsdk.Tr
 		_ = session.Close()
 		return err
 	}
+	if cfg.resources {
+		if err := s.reconcileResources(ctx, srv); err != nil {
+			s.unregisterAll(srv)
+			_ = session.Close()
+			return err
+		}
+	}
 
 	s.mu.Lock()
-	defer s.mu.Unlock()
 	if s.closed {
 		// Close raced us; undo rather than leak the session.
 		s.unregisterAll(srv)
 		_ = session.Close()
+		s.mu.Unlock()
 		return errdefs.NotAvailablef("mcp: source is closed")
 	}
+	if _, exists := s.servers[name]; exists {
+		s.mu.Unlock()
+		s.unregisterAll(srv)
+		_ = session.Close()
+		return errdefs.Validationf("mcp: server %q is already attached", name)
+	}
 	s.servers[name] = srv
+	s.mu.Unlock()
 	return nil
+}
+
+// addDeferred publishes a server without connecting. Declared tools
+// (WithTools) are pre-claimed and registered as lazy proxies; tools not
+// declared appear only after the first load.
+func (s *Source) addDeferred(srv *server) error {
+	var claimed []string
+	for remote := range srv.tools {
+		qualified := srv.qualify(remote)
+		if !s.claimOwnership(srv.name, qualified) {
+			for _, name := range claimed {
+				s.releaseOwnership(name)
+			}
+			return errdefs.Conflictf(
+				"mcp: tool %q is already owned by another attached server",
+				qualified)
+		}
+		claimed = append(claimed, qualified)
+	}
+
+	s.mu.Lock()
+	if s.closed {
+		s.mu.Unlock()
+		for _, name := range claimed {
+			s.releaseOwnership(name)
+		}
+		return errdefs.NotAvailablef("mcp: source is closed")
+	}
+	if _, exists := s.servers[srv.name]; exists {
+		s.mu.Unlock()
+		for _, name := range claimed {
+			s.releaseOwnership(name)
+		}
+		return errdefs.Validationf("mcp: server %q is already attached", srv.name)
+	}
+	s.servers[srv.name] = srv
+	s.mu.Unlock()
+
+	if err := s.registerDeclaredProxies(srv); err != nil {
+		s.mu.Lock()
+		if current, ok := s.servers[srv.name]; ok && current == srv {
+			delete(s.servers, srv.name)
+		}
+		s.mu.Unlock()
+		for _, name := range claimed {
+			s.releaseOwnership(name)
+		}
+		return err
+	}
+	return nil
+}
+
+// registerDeclaredProxies creates a LazyTool per declared tool name and
+// registers it so the tool is callable by exact name before the first
+// load. Loaders share the server's singleflight session.
+func (s *Source) registerDeclaredProxies(srv *server) error {
+	for remote, exp := range srv.tools {
+		qualified := srv.qualify(remote)
+		loader := s.deferredLoader(srv, remote)
+		placeholder := message.Definition{
+			Name:        qualified,
+			Description: fmt.Sprintf("deferred MCP tool %s/%s; loads on first use", srv.name, remote),
+			InputSchema: emptySchema,
+		}
+		if srv.dynamicCat != nil {
+			if err := srv.dynamicCat.RegisterProxy(qualified, loader, exp,
+				dynamic.WithPlaceholder(placeholder)); err != nil {
+				return err
+			}
+		} else {
+			proxy := dynamic.NewLazyTool(s.registry, qualified, loader,
+				dynamic.WithPlaceholder(placeholder))
+			s.registry.RegisterWithScope(proxy, srv.scope)
+		}
+		srv.declared[qualified] = struct{}{}
+	}
+	return nil
+}
+
+// deferredLoader connects the server on first use (singleflight),
+// reconciles the registry, and returns the live adapted tool for the
+// declared remote name.
+func (s *Source) deferredLoader(srv *server, remote string) dynamic.Loader {
+	return func(ctx context.Context) (sdktool.Tool, error) {
+		if err := s.ensureSession(ctx, srv); err != nil {
+			return nil, err
+		}
+		if err := s.reconcile(ctx, srv); err != nil {
+			return nil, err
+		}
+		if srv.resources {
+			if err := s.reconcileResources(ctx, srv); err != nil {
+				return nil, err
+			}
+		}
+		qualified := srv.qualify(remote)
+		tool, ok := s.registry.Get(qualified)
+		if !ok {
+			return nil, errdefs.NotAvailablef(
+				"mcp: server %q no longer exposes declared tool %q", srv.name, remote)
+		}
+		if _, isLazy := tool.(*dynamic.LazyTool); isLazy {
+			return nil, errdefs.NotAvailablef(
+				"mcp: server %q did not list declared tool %q", srv.name, remote)
+		}
+		return tool, nil
+	}
+}
+
+// ensureSession connects a deferred server at most once concurrently.
+// The first successful session wins; a failed attempt is retried on the
+// next call.
+func (s *Source) ensureSession(ctx context.Context, srv *server) error {
+	srv.mu.Lock()
+	if srv.session != nil {
+		srv.mu.Unlock()
+		return nil
+	}
+	srv.mu.Unlock()
+
+	_, err, _ := srv.loadGroup.Do(srv.name, func() (any, error) {
+		srv.mu.Lock()
+		if srv.session != nil {
+			srv.mu.Unlock()
+			return nil, nil
+		}
+		srv.mu.Unlock()
+
+		cfg := &serverConfig{
+			scope:       srv.scope,
+			prefix:      srv.prefix,
+			clientName:  srv.clientName,
+			clientVer:   srv.clientVer,
+			clientOpts:  srv.clientOpts,
+			onListError: srv.onListError,
+		}
+		session, err := s.connect(ctx, srv, cfg)
+		if err != nil {
+			return nil, err
+		}
+		srv.mu.Lock()
+		if srv.session == nil {
+			srv.session = session
+		} else {
+			_ = session.Close()
+		}
+		srv.mu.Unlock()
+		return nil, nil
+	})
+	return err
+}
+
+func validateExposureConfig(defaultExposure dynamic.Exposure, tools map[string]dynamic.Exposure) error {
+	if !defaultExposure.Valid() {
+		return errdefs.Validationf(
+			"mcp: server exposure %q is invalid", defaultExposure)
+	}
+	for remote, exp := range tools {
+		if strings.TrimSpace(remote) == "" {
+			return errdefs.Validationf("mcp: tools map has an empty tool name")
+		}
+		if !exp.Valid() {
+			return errdefs.Validationf(
+				"mcp: exposure %q for tool %q is invalid", exp, remote)
+		}
+	}
+	return nil
+}
+
+func qualify(prefix, name string) string {
+	if prefix == "" {
+		return name
+	}
+	return prefix + name
 }
 
 // connect builds the go-sdk client with the reconcile hook wired and
@@ -300,6 +576,7 @@ func (s *Source) reconcile(ctx context.Context, srv *server) error {
 		if _, already := srv.registered[qualified]; already {
 			continue
 		}
+		preOwned := s.ownerIs(srv.name, qualified)
 		if !s.claimOwnership(srv.name, qualified) {
 			for _, name := range claimedNew {
 				s.releaseOwnership(name)
@@ -308,7 +585,9 @@ func (s *Source) reconcile(ctx context.Context, srv *server) error {
 				"mcp: tool %q is already owned by another attached server",
 				qualified)
 		}
-		claimedNew = append(claimedNew, qualified)
+		if !preOwned {
+			claimedNew = append(claimedNew, qualified)
+		}
 	}
 
 	for _, mt := range res.Tools {
@@ -321,6 +600,7 @@ func (s *Source) reconcile(ctx context.Context, srv *server) error {
 			continue
 		}
 		s.registry.RegisterWithScope(newAdaptedTool(srv, qualified, mt), srv.scope)
+		s.applyExposure(srv, qualified)
 	}
 	for previous := range srv.registered {
 		if _, still := fresh[previous]; !still {
@@ -329,6 +609,50 @@ func (s *Source) reconcile(ctx context.Context, srv *server) error {
 		}
 	}
 	srv.registered = fresh
+	return nil
+}
+
+// reconcileResources validates that the server supports resources and
+// registers the two resource-bridge tools. The bridge never shadows a
+// server-side tool with the same name; once registered, the bridge
+// tools are re-registered on refresh so metadata stays current.
+func (s *Source) reconcileResources(ctx context.Context, srv *server) error {
+	session, err := srv.currentSession()
+	if err != nil {
+		return err
+	}
+	if _, err := session.ListResources(ctx, nil); err != nil {
+		return errdefs.NotAvailablef(
+			"mcp: server %q: list resources: %v", srv.name, err)
+	}
+	for _, spec := range resourceToolSpecs(srv) {
+		qualified := srv.qualify(spec.remote)
+
+		srv.mu.Lock()
+		_, isResource := srv.resourceTools[qualified]
+		_, isServerTool := srv.registered[qualified]
+		srv.mu.Unlock()
+		if !isResource {
+			if isServerTool {
+				// The server's own tool with this name wins; the bridge
+				// stays out of the way.
+				continue
+			}
+			if !s.claimOwnership(srv.name, qualified) {
+				return errdefs.Conflictf(
+					"mcp: resource tool %q is already owned by another attached server",
+					qualified)
+			}
+			srv.mu.Lock()
+			srv.resourceTools[qualified] = struct{}{}
+			srv.mu.Unlock()
+		}
+		s.registry.RegisterWithScope(spec.tool, srv.scope)
+		s.applyExposure(srv, qualified)
+		srv.mu.Lock()
+		srv.registered[qualified] = struct{}{}
+		srv.mu.Unlock()
+	}
 	return nil
 }
 
@@ -348,6 +672,57 @@ func (s *Source) releaseOwnership(qualified string) {
 	s.ownerMu.Lock()
 	delete(s.owners, qualified)
 	s.ownerMu.Unlock()
+}
+
+// ownerIs reports whether qualified is currently owned by serverName.
+func (s *Source) ownerIs(serverName, qualified string) bool {
+	s.ownerMu.Lock()
+	defer s.ownerMu.Unlock()
+	return s.owners[qualified] == serverName
+}
+
+// applyExposure records a tool's exposure on the wired dynamic catalog.
+// Per-tool entries win; everything else uses the server-level default.
+func (s *Source) applyExposure(srv *server, qualified string) {
+	if srv.dynamicCat == nil {
+		return
+	}
+	_ = srv.dynamicCat.SetExposure(qualified, s.exposureFor(srv, qualified))
+}
+
+func (s *Source) exposureFor(srv *server, qualified string) dynamic.Exposure {
+	if exp, ok := srv.toolExposure[qualified]; ok {
+		return exp
+	}
+	return srv.exposure
+}
+
+// ApplyExposures records every attached server's exposure metadata on a
+// dynamic catalog. Hosts that wire the catalog after attachment (e.g.
+// through a config source) use this instead of WithDynamicCatalog.
+func (s *Source) ApplyExposures(cat *dynamic.Catalog) error {
+	if cat == nil {
+		return errdefs.Validationf("mcp: ApplyExposures: catalog is nil")
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for _, srv := range s.servers {
+		srv.mu.Lock()
+		names := make([]string, 0, len(srv.registered)+len(srv.declared))
+		for qualified := range srv.registered {
+			names = append(names, qualified)
+		}
+		for qualified := range srv.declared {
+			names = append(names, qualified)
+		}
+		srv.mu.Unlock()
+		for _, qualified := range names {
+			if err := cat.SetExposure(qualified, s.exposureFor(srv, qualified)); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
 }
 
 // Refresh re-lists every attached server and reconciles the registry.
@@ -370,8 +745,20 @@ func (s *Source) Refresh(ctx context.Context) error {
 
 	var errs []error
 	for _, srv := range attached {
+		if srv.deferred {
+			if err := s.ensureSession(ctx, srv); err != nil {
+				errs = append(errs, err)
+				continue
+			}
+		}
 		if err := s.reconcile(ctx, srv); err != nil {
 			errs = append(errs, err)
+			continue
+		}
+		if srv.resources {
+			if err := s.reconcileResources(ctx, srv); err != nil {
+				errs = append(errs, err)
+			}
 		}
 	}
 	return errors.Join(errs...)
@@ -417,8 +804,11 @@ func (s *Source) ToolNames(name string) []string {
 	}
 	srv.mu.Lock()
 	defer srv.mu.Unlock()
-	names := make([]string, 0, len(srv.registered))
+	names := make([]string, 0, len(srv.registered)+len(srv.declared))
 	for tool := range srv.registered {
+		names = append(names, tool)
+	}
+	for tool := range srv.declared {
 		names = append(names, tool)
 	}
 	return names
@@ -459,7 +849,12 @@ func (s *Source) unregisterAll(srv *server) {
 		s.registry.Unregister(name)
 		s.releaseOwnership(name)
 	}
+	for name := range srv.declared {
+		s.registry.Unregister(name)
+		s.releaseOwnership(name)
+	}
 	srv.registered = make(map[string]struct{})
+	srv.declared = make(map[string]struct{})
 }
 
 // closeServer clears the session pointer before closing so concurrent


### PR DESCRIPTION
## Summary

Implements the P1 dynamic tool-injection plan (`docs/plans/2026-08-10-tool-dynamic-injection.md`): exposure-driven model-visible catalogs over the shared tool Registry, BM25 discovery, lazy proxy loading, MCP deferred attach, policy middleware, and per-session wiring.

## What changed

### `sdkx/tool/dynamic` (new package)
- `Exposure` (`always` / `direct` / `deferred` / `hidden`) with a deterministic visibility algorithm: RequiredByName, Selected retention for M rounds, UsedRecently, and budget pruning (count + bytes) with stable name tie-breaks.
- `DynamicCatalog` wraps `*tool.Registry` and implements `tool.Catalog`; `Get`/`Definitions` never load or block.
- `LazyTool` proxies: singleflight load, bounded retry with backoff, idempotent `Close`, placeholder definitions, and forwarding to the registry's live entry after load.
- `tool_search`: lightweight Unicode-aware BM25 over `Name + Description`; `select` makes tools visible from the next round while same-turn callability stays open.
- `RecordCalls()` middleware feeds executed calls back into the session catalog via the context.

### `sdk/tool`
- `ResultLimiter` middleware (rune-safe truncation + configurable marker) and `Redact` / `AuditRedacted` middleware (regex redaction for model results and audit records).
- `resultlimit` / `redact` config kinds with strict spec decoding.
- Neutral context channel `WithCatalogOnContext` / `CatalogFromContext` shared by the session layer, inference node, and session-scoped tools.

### `sdkx/tool/mcp`
- Deferred attach: no connect / no child process until first load; declared tools are registered as lazy proxies immediately.
- Server-level and per-tool exposure via `WithExposure` / `WithTools` / `WithDynamicCatalog` / `ApplyExposures`, plus `defer` / `exposure` / `tools` / `resources` in the config spec.
- Resources bridge: `<prefix>list_resources` and `<prefix>read_resource` registry tools (text verbatim, blobs base64).

### `sdk/graph`
- Inference node `all_tools: true` mode: the catalog's entire visible set is sent to the provider, with `cfg.Tools` declared as RequiredByName through an optional interface; the node stays catalog-agnostic.
- Per-round `AdvanceTurn()` via an optional interface; build-time dependency scan recognizes `all_tools` and validates its boolean type.

### `sdkx/runtime/session`
- `CatalogProvider` + `WithCatalogProvider`: one catalog per session, attached to every turn's execution context, closed exactly once with the session.

### `sdk/config`
- `Loader.LoadLayers`: deep-merges layered documents (maps recurse, scalars/arrays replace, null deletes) with per-key origin tracking; exported `LiteralSource` / `ContentSource` / `FileSource` / `EmbedSource` constructors.

## Testing

- `make ci`, `make lint`, `make release-check`, and `git diff --check` all pass.
- New unit/integration coverage: visibility algorithm determinism, BM25 ranking, singleflight/retry/Close behavior, MCP deferred lifecycle and resource bridge, `all_tools` node modes, session catalog lifecycle, layered config merging.

## Out of scope

- `examples/forge` demo wiring (requires a released sdkx to consume locally).
- MCP resources as message-context injection (needs a new message contract).
- Env-key mapping in the layered config loader.
- Unrelated working-tree changes under `memory/` were left untouched.