### PR TITLE
feat(sdkx/inference): expose hosted web_search capability in model metadata

### DIFF
--- a/docs/guides/inference.md
+++ b/docs/guides/inference.md
@@ -82,6 +82,17 @@ addressed to the executing provider that is unknown, meant for another
 operation, or colliding with a canonical field is a structured
 rejection.
 
+### Model capabilities
+
+`ModelDescriptor.Capabilities` is public, credential-free discovery
+metadata returned by `Runtime.Models` and `Runtime.InspectModel`. It lets a
+host decide whether the selected provider/model can serve an optional
+feature without hardcoding provider or model names — for example,
+`Capabilities.HostedWebSearch` reports whether the model accepts the hosted
+`web_search` tool. The tool's configuration still rides on
+`GenerateRequest.Extensions`; the capability bit only declares support, and
+the provider compiler rejects the extension when the bit is unset.
+
 ## Deployment configuration
 
 Deployments are described by a versioned `config.Document`. Documents

--- a/sdk/inference/model.go
+++ b/sdk/inference/model.go
@@ -102,14 +102,26 @@ func (l ModelLifecycle) ValidateFor(model ModelID) error {
 	return nil
 }
 
+// ModelCapabilities describes optional feature bits a model can serve.
+// Zero is the conservative declaration: every feature the struct omits is
+// treated as unsupported until a provider declares it.
+type ModelCapabilities struct {
+	// HostedWebSearch marks provider-side web_search tool support. It is
+	// discovery metadata for hosts; the search configuration itself still
+	// rides on GenerateRequest.Extensions as a provider GenerateOptions
+	// extension.
+	HostedWebSearch bool `json:"hosted_web_search,omitempty"`
+}
+
 // ModelDescriptor is public discovery metadata. Operations must be derived
 // from the drivers registered for the model rather than maintained as a
 // separate capability declaration.
 type ModelDescriptor struct {
-	ID         ModelID        `json:"id"`
-	Label      string         `json:"label,omitempty"`
-	Operations []Operation    `json:"operations"`
-	Lifecycle  ModelLifecycle `json:"lifecycle,omitzero"`
+	ID           ModelID           `json:"id"`
+	Label        string            `json:"label,omitempty"`
+	Operations   []Operation       `json:"operations"`
+	Capabilities ModelCapabilities `json:"capabilities,omitzero"`
+	Lifecycle    ModelLifecycle    `json:"lifecycle,omitzero"`
 }
 
 func (d ModelDescriptor) Clone() ModelDescriptor {
@@ -131,6 +143,13 @@ func (d ModelDescriptor) Validate() error {
 			return fmt.Errorf("duplicate model operation %q", operation)
 		}
 		seen[operation] = struct{}{}
+	}
+	if d.Capabilities.HostedWebSearch {
+		if _, ok := seen[OperationGenerate]; !ok {
+			return fmt.Errorf(
+				"hosted web search requires the generate operation",
+			)
+		}
 	}
 	return d.Lifecycle.ValidateFor(d.ID)
 }

--- a/sdk/inference/model_test.go
+++ b/sdk/inference/model_test.go
@@ -73,6 +73,34 @@ func TestModelDescriptorAllowsEmptyProfileProjection(t *testing.T) {
 	}
 }
 
+func TestModelDescriptorCapabilitiesRequireGenerateOperation(t *testing.T) {
+	descriptor := ModelDescriptor{
+		ID:           ModelID{Provider: "openai", Name: "gpt-5"},
+		Operations:   []Operation{OperationEmbed},
+		Capabilities: ModelCapabilities{HostedWebSearch: true},
+	}
+	if err := descriptor.Validate(); err == nil {
+		t.Fatal("Validate accepted hosted web search without the generate operation")
+	}
+	descriptor.Operations = []Operation{OperationGenerate}
+	if err := descriptor.Validate(); err != nil {
+		t.Fatalf("Validate with generate: %v", err)
+	}
+}
+
+func TestModelDescriptorCloneCopiesCapabilities(t *testing.T) {
+	descriptor := ModelDescriptor{
+		ID:           ModelID{Provider: "openai", Name: "gpt-5"},
+		Operations:   []Operation{OperationGenerate},
+		Capabilities: ModelCapabilities{HostedWebSearch: true},
+	}
+	clone := descriptor.Clone()
+	clone.Capabilities.HostedWebSearch = false
+	if !descriptor.Capabilities.HostedWebSearch {
+		t.Fatal("clone mutation leaked into the source descriptor")
+	}
+}
+
 func TestModelLifecycleRejectsActiveRetirementMetadata(t *testing.T) {
 	retirement := time.Now().UTC()
 	descriptor := ModelDescriptor{

--- a/sdkx/inference/azure/azure_test.go
+++ b/sdkx/inference/azure/azure_test.go
@@ -66,6 +66,10 @@ func TestSpecValidation(t *testing.T) {
 			raw:  `{"endpoint":"https://res.openai.azure.com","models":[{"name":"m","kind":"generate","dimensions":true}]}`,
 		},
 		{
+			name: "web search on embed",
+			raw:  `{"endpoint":"https://res.openai.azure.com","models":[{"name":"m","kind":"embed","web_search":true}]}`,
+		},
+		{
 			name: "bad version token",
 			raw:  `{"endpoint":"https://res.openai.azure.com","api_version":"2025-01-01?x=1","models":[{"name":"m","kind":"generate"}]}`,
 		},
@@ -115,6 +119,7 @@ func TestFactoryBuild(t *testing.T) {
 			"endpoint": "https://res.openai.azure.com",
 			"models": [
 				{"name": "chat-1", "kind": "generate", "vision": true},
+				{"name": "search-1", "kind": "generate", "web_search": true},
 				{"name": "embed-1", "kind": "embed", "dimensions": true},
 				{"name": "stt-1", "kind": "asr"}
 			]
@@ -131,16 +136,22 @@ func TestFactoryBuild(t *testing.T) {
 	if provider.ID != "azure" {
 		t.Fatalf("provider ID = %q", provider.ID)
 	}
-	if len(provider.Models) != 3 {
+	if len(provider.Models) != 4 {
 		t.Fatalf("models = %d", len(provider.Models))
 	}
 	if provider.Models[0].Openers.Generate == nil {
 		t.Fatal("generate deployment has no generate opener")
 	}
-	if provider.Models[1].Openers.Embed == nil {
+	if provider.Models[0].Descriptor.Capabilities.HostedWebSearch {
+		t.Fatal("chat-1 must not claim hosted web search without the flag")
+	}
+	if !provider.Models[1].Descriptor.Capabilities.HostedWebSearch {
+		t.Fatal("search-1 must carry the declared hosted web search capability")
+	}
+	if provider.Models[2].Openers.Embed == nil {
 		t.Fatal("embed deployment has no embed opener")
 	}
-	if provider.Models[2].Openers.Transcription == nil {
+	if provider.Models[3].Openers.Transcription == nil {
 		t.Fatal("asr deployment has no transcription opener")
 	}
 }
@@ -224,5 +235,62 @@ func TestGenerateEndToEnd(t *testing.T) {
 	text, ok := response.Message.Content.Parts[0].(message.TextPart)
 	if !ok || text.Text != "ok" {
 		t.Fatalf("part = %#v", response.Message.Content.Parts[0])
+	}
+}
+
+func TestKernelGenerateWebSearchCapabilityGate(t *testing.T) {
+	spec, err := decodeSpec([]byte(
+		`{"endpoint":"https://res.openai.azure.com","models":[{"name":"chat-1","kind":"generate"}]}`,
+	))
+	if err != nil {
+		t.Fatalf("decodeSpec: %v", err)
+	}
+	cls := profileMaterial{apiKey: "az-key"}.newClients(spec)
+	request := inference.GenerateRequest{
+		Input: inference.GenerateInput{
+			Role: inference.InputRoleUser,
+			Content: inference.InputContent{
+				Content: message.Content{Parts: []message.Part{
+					message.TextPart{Text: "hi"},
+				}},
+				Intent: inference.Intent{Text: &inference.TextIntent{}},
+			},
+		},
+		Extensions: inference.Extensions{
+			openai.GenerateOptions{
+				Provider:  "azure",
+				WebSearch: &openai.GenerateWebSearch{},
+			},
+		},
+	}
+	for _, tc := range []struct {
+		name string
+		caps openai.Capabilities
+		ok   bool
+	}{
+		{name: "declared", caps: openai.Capabilities{WebSearch: true}, ok: true},
+		{name: "undeclared", caps: openai.Capabilities{}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			operations, err := openai.KernelGenerate(
+				cls.api,
+				"chat-1",
+				tc.caps,
+			)
+			if err != nil {
+				t.Fatalf("KernelGenerate: %v", err)
+			}
+			_, err = operations.Unary.Explain(
+				context.Background(),
+				azureModel("chat-1"),
+				request,
+			)
+			if tc.ok && err != nil {
+				t.Fatalf("Explain with capability: %v", err)
+			}
+			if !tc.ok && !inference.IsKind(err, inference.InvalidExtension) {
+				t.Fatalf("Explain without capability = %v, want InvalidExtension", err)
+			}
+		})
 	}
 }

--- a/sdkx/inference/azure/factory.go
+++ b/sdkx/inference/azure/factory.go
@@ -44,8 +44,13 @@ func Factory() config.Factory {
 		for _, model := range spec.Models {
 			id := inference.ModelID{Provider: input.ID, Name: model.Name}
 			provider.Models = append(provider.Models, inference.ModelImplementation{
-				Descriptor: inference.ModelDescriptor{ID: id},
-				Openers:    openersFor(spec, model, profiles, id),
+				Descriptor: inference.ModelDescriptor{
+					ID: id,
+					Capabilities: inference.ModelCapabilities{
+						HostedWebSearch: model.WebSearch,
+					},
+				},
+				Openers: openersFor(spec, model, profiles, id),
 			})
 		}
 		return provider, nil
@@ -76,6 +81,7 @@ func openersFor(
 	caps := openai.Capabilities{
 		Vision:     model.Vision,
 		Reasoning:  model.Reasoning,
+		WebSearch:  model.WebSearch,
 		Dimensions: model.Dimensions,
 	}
 	switch modelKind(model.Kind) {

--- a/sdkx/inference/azure/spec.go
+++ b/sdkx/inference/azure/spec.go
@@ -39,6 +39,10 @@ type ModelSpec struct {
 	Vision bool `json:"vision,omitempty"`
 	// Reasoning accepts reasoning effort and summary knobs (generate only).
 	Reasoning bool `json:"reasoning,omitempty"`
+	// WebSearch accepts the hosted web_search tool (generate only). The
+	// Responses API web_search tool works with GPT-4 and later deployments,
+	// subject to the subscription-level feature switch.
+	WebSearch bool `json:"web_search,omitempty"`
 	// Dimensions accepts the embed dimensions knob (embed only).
 	Dimensions bool `json:"dimensions,omitempty"`
 }
@@ -93,6 +97,13 @@ func (s Spec) Validate() error {
 		if model.Reasoning && modelKind(model.Kind) != kindGenerate {
 			return fmt.Errorf(
 				"azure: deployment %q sets reasoning on kind %q",
+				model.Name,
+				model.Kind,
+			)
+		}
+		if model.WebSearch && modelKind(model.Kind) != kindGenerate {
+			return fmt.Errorf(
+				"azure: deployment %q sets web_search on kind %q",
 				model.Name,
 				model.Kind,
 			)

--- a/sdkx/inference/bytedance/catalog.go
+++ b/sdkx/inference/bytedance/catalog.go
@@ -26,6 +26,11 @@ type catalogEntry struct {
 	video bool
 	// generate: supports the thinking control behind reasoning effort.
 	reasoning bool
+	// webSearch (generate) accepts the hosted Web Search (联网内容插件)
+	// tool. Support is per model per the Ark tool-calling capability
+	// matrix; see
+	// https://www.volcengine.com/docs/82379/1330310#f44ceef7.
+	webSearch bool
 	// embed: accepts image items (multimodal embedding).
 	imageInput bool
 	// embed: accepts custom output dimensions.
@@ -47,31 +52,31 @@ type catalogEntry struct {
 var catalog = map[string]catalogEntry{
 	// Seed 2.1 (2026-06) — current flagship tier. The whole Seed 2.x line is
 	// natively multimodal (text/image/video in) with thinking support.
-	"doubao-seed-2-1-pro":   {kind: kindGenerate, vision: true, video: true, reasoning: true},
-	"doubao-seed-2-1-turbo": {kind: kindGenerate, vision: true, video: true, reasoning: true},
+	"doubao-seed-2-1-pro":   {kind: kindGenerate, vision: true, video: true, reasoning: true, webSearch: true},
+	"doubao-seed-2-1-turbo": {kind: kindGenerate, vision: true, video: true, reasoning: true, webSearch: true},
 
 	// Seed 2.0 (2026-02) — general agent line plus the code-tuned variant.
-	"doubao-seed-2-0-pro":  {kind: kindGenerate, vision: true, video: true, reasoning: true},
-	"doubao-seed-2-0-lite": {kind: kindGenerate, vision: true, video: true, reasoning: true},
-	"doubao-seed-2-0-mini": {kind: kindGenerate, vision: true, video: true, reasoning: true},
-	"doubao-seed-2-0-code": {kind: kindGenerate, vision: true, reasoning: true},
+	"doubao-seed-2-0-pro":  {kind: kindGenerate, vision: true, video: true, reasoning: true, webSearch: true},
+	"doubao-seed-2-0-lite": {kind: kindGenerate, vision: true, video: true, reasoning: true, webSearch: true},
+	"doubao-seed-2-0-mini": {kind: kindGenerate, vision: true, video: true, reasoning: true, webSearch: true},
+	"doubao-seed-2-0-code": {kind: kindGenerate, vision: true, reasoning: true, webSearch: true},
 
 	// Seed 1.x — superseded by the 2.x line; kept routable for existing
 	// deployments, announced as deprecated with a replacement.
 	"doubao-seed-1-8": {
-		kind: kindGenerate, vision: true, video: true, reasoning: true,
+		kind: kindGenerate, vision: true, video: true, reasoning: true, webSearch: true,
 		deprecated: true, replacement: "doubao-seed-2-0-lite",
 	},
 	"doubao-seed-1-6": {
-		kind: kindGenerate, reasoning: true,
+		kind: kindGenerate, reasoning: true, webSearch: true,
 		deprecated: true, replacement: "doubao-seed-2-0-mini",
 	},
 	"doubao-seed-1-6-vision": {
-		kind: kindGenerate, vision: true, reasoning: true,
+		kind: kindGenerate, vision: true, reasoning: true, webSearch: true,
 		deprecated: true, replacement: "doubao-seed-2-0-lite",
 	},
 	"doubao-seed-1-6-flash": {
-		kind: kindGenerate, reasoning: true,
+		kind: kindGenerate, reasoning: true, webSearch: true,
 		deprecated: true, replacement: "doubao-seed-2-0-mini",
 	},
 
@@ -127,6 +132,7 @@ func mergedCatalog(spec Spec) (map[string]catalogEntry, error) {
 			vision:        model.Vision,
 			video:         model.Video,
 			reasoning:     model.Reasoning,
+			webSearch:     model.WebSearch,
 			imageInput:    model.ImageInput,
 			dimensions:    model.Dimensions,
 			maxResolution: model.MaxResolution,

--- a/sdkx/inference/bytedance/conformance_test.go
+++ b/sdkx/inference/bytedance/conformance_test.go
@@ -403,6 +403,20 @@ func TestConformanceGenerateCompilerPlainModel(t *testing.T) {
 				Field: inference.FieldGenerateIntentReasoningEffort,
 				Kind:  inference.UnsupportedFeature,
 			},
+			{
+				Name: "web search on model without hosted web search",
+				Request: func() inference.GenerateRequest {
+					request := simpleTextRequest("hi")
+					request.Extensions = inference.Extensions{
+						GenerateOptions{WebSearch: &GenerateWebSearch{}},
+					}
+					return request
+				},
+				Field: inference.FieldID(
+					"extension.bytedance.generate_options.web_search",
+				),
+				Kind: inference.InvalidExtension,
+			},
 		},
 	})
 }

--- a/sdkx/inference/bytedance/factory.go
+++ b/sdkx/inference/bytedance/factory.go
@@ -54,7 +54,12 @@ func Factory() config.Factory {
 		for _, name := range names {
 			entry := models[name]
 			id := inference.ModelID{Provider: input.ID, Name: name}
-			descriptor := inference.ModelDescriptor{ID: id}
+			descriptor := inference.ModelDescriptor{
+				ID: id,
+				Capabilities: inference.ModelCapabilities{
+					HostedWebSearch: entry.webSearch,
+				},
+			}
 			if entry.deprecated {
 				descriptor.Lifecycle.Status = inference.ModelStatusDeprecated
 				if entry.replacement != "" {

--- a/sdkx/inference/bytedance/factory_test.go
+++ b/sdkx/inference/bytedance/factory_test.go
@@ -99,7 +99,13 @@ func TestFactoryExposesCatalog(t *testing.T) {
 	if seed.Openers.Generate == nil {
 		t.Fatal("generate model has no generate opener")
 	}
+	if !seed.Descriptor.Capabilities.HostedWebSearch {
+		t.Fatal("doubao-seed-2-1-pro lost its hosted web search capability")
+	}
 	legacy := byName["doubao-seed-1-6"]
+	if !legacy.Descriptor.Capabilities.HostedWebSearch {
+		t.Fatal("doubao-seed-1-6 lost its hosted web search capability")
+	}
 	if legacy.Descriptor.Lifecycle.Status != inference.ModelStatusDeprecated {
 		t.Fatalf("seed-1-6 lifecycle = %q", legacy.Descriptor.Lifecycle.Status)
 	}
@@ -112,6 +118,9 @@ func TestFactoryExposesCatalog(t *testing.T) {
 	}
 	if byName["doubao-embedding-large"].Openers.Embed == nil {
 		t.Fatal("embed model has no embed opener")
+	}
+	if byName["doubao-embedding-large"].Descriptor.Capabilities.HostedWebSearch {
+		t.Fatal("embed model must not claim hosted web search")
 	}
 	if byName["doubao-asr-sauc-2-0"].Openers.Transcription == nil {
 		t.Fatal("asr model has no transcription opener")
@@ -192,9 +201,10 @@ func TestFactoryCustomModelAndEndpoint(t *testing.T) {
 	})
 	provider := buildProvider(t, map[string]any{
 		"models": []map[string]any{{
-			"name":   "my-internal-model",
-			"kind":   "generate",
-			"vision": true,
+			"name":       "my-internal-model",
+			"kind":       "generate",
+			"vision":     true,
+			"web_search": true,
 		}},
 	}, profiles)
 	var custom *inference.ModelImplementation
@@ -208,6 +218,9 @@ func TestFactoryCustomModelAndEndpoint(t *testing.T) {
 	}
 	if custom.Openers.Generate == nil {
 		t.Fatal("custom generate model has no opener")
+	}
+	if !custom.Descriptor.Capabilities.HostedWebSearch {
+		t.Fatal("custom model must carry the declared hosted web search capability")
 	}
 }
 

--- a/sdkx/inference/bytedance/generate.go
+++ b/sdkx/inference/bytedance/generate.go
@@ -364,7 +364,7 @@ func compileGenerate(
 		// one; extensions for other operations are rejected wholesale.
 		options, other := operationExtensions[GenerateOptions](request.Extensions)
 		rejectOtherExtensions("generate", other, ledger)
-		compileGenerateOptions(&wire, options, request, ledger)
+		compileGenerateOptions(&wire, options, entry, request, ledger)
 
 		report := ledger.report()
 		if len(ledger.order) > 0 {
@@ -378,6 +378,7 @@ func compileGenerate(
 func compileGenerateOptions(
 	wire *generateWire,
 	options GenerateOptions,
+	entry catalogEntry,
 	_ inference.GenerateRequest,
 	ledger *ledger,
 ) {
@@ -403,6 +404,13 @@ func compileGenerateOptions(
 		wire.maxToolCalls = options.MaxToolCalls
 	}
 	if options.WebSearch != nil {
+		if !entry.webSearch {
+			ledger.reject(
+				inference.ExtensionField("web_search").Qualify(options),
+				"model does not support hosted web search",
+			)
+			return
+		}
 		search := options.WebSearch
 		wire.webSearch = &wireWebSearch{
 			limit:      search.Limit,

--- a/sdkx/inference/bytedance/spec.go
+++ b/sdkx/inference/bytedance/spec.go
@@ -67,6 +67,9 @@ type ModelSpec struct {
 	Video bool `json:"video,omitempty"`
 	// Reasoning (generate) enables the reasoning effort control.
 	Reasoning bool `json:"reasoning,omitempty"`
+	// WebSearch (generate) enables the hosted Web Search (联网内容插件)
+	// tool.
+	WebSearch bool `json:"web_search,omitempty"`
 	// ImageInput (embed) allows image items via multimodal embedding.
 	ImageInput bool `json:"image_input,omitempty"`
 	// Dimensions (embed) allows custom output dimensions.

--- a/sdkx/inference/openai/catalog.go
+++ b/sdkx/inference/openai/catalog.go
@@ -16,9 +16,13 @@ const (
 // catalogEntry is one model in the built-in catalog. Capability flags mirror
 // ModelSpec so deployment-declared models behave identically.
 type catalogEntry struct {
-	kind        modelKind
-	vision      bool
-	reasoning   bool
+	kind      modelKind
+	vision    bool
+	reasoning bool
+	// webSearch (generate) accepts the hosted web_search tool. Model
+	// support is per model per the OpenAI model documentation; see
+	// https://developers.openai.com/api/docs/models.
+	webSearch   bool
 	dimensions  bool
 	deprecated  bool
 	replacement string
@@ -29,29 +33,30 @@ type catalogEntry struct {
 // via Spec.Models.
 var catalog = map[string]catalogEntry{
 	// Generate — GPT-5.6 flagship family (reasoning + vision).
-	"gpt-5.6-sol":   {kind: kindGenerate, vision: true, reasoning: true},
-	"gpt-5.6-terra": {kind: kindGenerate, vision: true, reasoning: true},
-	"gpt-5.6-luna":  {kind: kindGenerate, vision: true, reasoning: true},
+	"gpt-5.6-sol":   {kind: kindGenerate, vision: true, reasoning: true, webSearch: true},
+	"gpt-5.6-terra": {kind: kindGenerate, vision: true, reasoning: true, webSearch: true},
+	"gpt-5.6-luna":  {kind: kindGenerate, vision: true, reasoning: true, webSearch: true},
 	// Generate — previous generations, superseded but available.
 	"gpt-5.5": {
-		kind: kindGenerate, vision: true, reasoning: true,
+		kind: kindGenerate, vision: true, reasoning: true, webSearch: true,
 		deprecated: true, replacement: "gpt-5.6-sol",
 	},
 	"gpt-5.4": {
-		kind: kindGenerate, vision: true, reasoning: true,
+		kind: kindGenerate, vision: true, reasoning: true, webSearch: true,
 		deprecated: true, replacement: "gpt-5.6-sol",
 	},
 	"gpt-5.4-mini": {
-		kind: kindGenerate, vision: true, reasoning: true,
+		kind: kindGenerate, vision: true, reasoning: true, webSearch: true,
 		deprecated: true, replacement: "gpt-5.6-terra",
 	},
 	"gpt-5.4-nano": {
-		kind: kindGenerate, vision: true, reasoning: true,
+		kind: kindGenerate, vision: true, reasoning: true, webSearch: true,
 		deprecated: true, replacement: "gpt-5.6-luna",
 	},
 	// Generate — GPT-4.1 line: vision without the reasoning control.
-	"gpt-4.1":      {kind: kindGenerate, vision: true},
-	"gpt-4.1-mini": {kind: kindGenerate, vision: true},
+	"gpt-4.1":      {kind: kindGenerate, vision: true, webSearch: true},
+	"gpt-4.1-mini": {kind: kindGenerate, vision: true, webSearch: true},
+	// gpt-4.1-nano has no hosted web_search tool.
 	"gpt-4.1-nano": {kind: kindGenerate, vision: true},
 
 	// Embed.
@@ -99,6 +104,7 @@ func mergedCatalog(spec Spec) (map[string]catalogEntry, error) {
 			kind:       modelKind(model.Kind),
 			vision:     model.Vision,
 			reasoning:  model.Reasoning,
+			webSearch:  model.WebSearch,
 			dimensions: model.Dimensions,
 		}
 	}

--- a/sdkx/inference/openai/factory.go
+++ b/sdkx/inference/openai/factory.go
@@ -54,7 +54,12 @@ func Factory() config.Factory {
 		for _, name := range names {
 			entry := models[name]
 			id := inference.ModelID{Provider: input.ID, Name: name}
-			descriptor := inference.ModelDescriptor{ID: id}
+			descriptor := inference.ModelDescriptor{
+				ID: id,
+				Capabilities: inference.ModelCapabilities{
+					HostedWebSearch: entry.webSearch,
+				},
+			}
 			if entry.deprecated {
 				descriptor.Lifecycle.Status = inference.ModelStatusDeprecated
 				if entry.replacement != "" {

--- a/sdkx/inference/openai/generate.go
+++ b/sdkx/inference/openai/generate.go
@@ -345,7 +345,7 @@ func compileGenerate(
 		// one; extensions for other operations are rejected wholesale.
 		options, other := operationExtensions[GenerateOptions](request.Extensions)
 		rejectOtherExtensions("generate", other, ledger)
-		compileGenerateOptions(&wire, options, ledger)
+		compileGenerateOptions(&wire, options, entry, ledger)
 
 		report := ledger.report()
 		if len(ledger.order) > 0 {
@@ -359,9 +359,17 @@ func compileGenerate(
 func compileGenerateOptions(
 	wire *generateWire,
 	options GenerateOptions,
+	entry catalogEntry,
 	ledger *ledger,
 ) {
 	if options.WebSearch == nil {
+		return
+	}
+	if !entry.webSearch {
+		ledger.reject(
+			inference.ExtensionField("web_search").Qualify(options),
+			"model does not support hosted web search",
+		)
 		return
 	}
 	search := options.WebSearch

--- a/sdkx/inference/openai/generate_open.go
+++ b/sdkx/inference/openai/generate_open.go
@@ -17,5 +17,6 @@ func openGenerate(
 	return KernelGenerate(cls.api, id.Name, Capabilities{
 		Vision:    entry.vision,
 		Reasoning: entry.reasoning,
+		WebSearch: entry.webSearch,
 	})
 }

--- a/sdkx/inference/openai/generate_openai_test.go
+++ b/sdkx/inference/openai/generate_openai_test.go
@@ -284,6 +284,45 @@ func TestFactoryBuild(t *testing.T) {
 		whisper.Descriptor.Lifecycle.Replacement.Name != "gpt-4o-transcribe" {
 		t.Fatalf("whisper replacement = %+v", whisper.Descriptor.Lifecycle.Replacement)
 	}
+	byName := make(map[string]inference.ModelImplementation, len(provider.Models))
+	for _, model := range provider.Models {
+		byName[model.Descriptor.ID.Name] = model
+	}
+	if !byName["gpt-5.6-sol"].Descriptor.Capabilities.HostedWebSearch {
+		t.Fatal("gpt-5.6-sol lost its hosted web search capability")
+	}
+	if byName["gpt-4.1-nano"].Descriptor.Capabilities.HostedWebSearch {
+		t.Fatal("gpt-4.1-nano must not claim hosted web search")
+	}
+}
+
+func TestFactoryCustomModelWebSearchCapability(t *testing.T) {
+	input := config.ProviderInput{
+		ID: "openai",
+		Spec: json.RawMessage(
+			`{"models":[{"name":"my-search","kind":"generate","web_search":true}]}`,
+		),
+		Profiles: []config.ResolvedProfile{{
+			ID:      "default",
+			Secrets: map[string]config.Secret{SecretAPIKey: testSecret(t, "sk-test")},
+		}},
+	}
+	provider, err := Factory().Build(context.Background(), input)
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	var custom *inference.ModelImplementation
+	for index := range provider.Models {
+		if provider.Models[index].Descriptor.ID.Name == "my-search" {
+			custom = &provider.Models[index]
+		}
+	}
+	if custom == nil {
+		t.Fatal("my-search missing from provider models")
+	}
+	if !custom.Descriptor.Capabilities.HostedWebSearch {
+		t.Fatal("custom model must carry the declared hosted web search capability")
+	}
 }
 
 // ---------------------------------------------------------------------------

--- a/sdkx/inference/openai/kernel.go
+++ b/sdkx/inference/openai/kernel.go
@@ -22,6 +22,8 @@ type Capabilities struct {
 	Vision bool
 	// Reasoning accepts the reasoning effort and summary knobs.
 	Reasoning bool
+	// WebSearch accepts the hosted web_search tool on generate.
+	WebSearch bool
 	// Dimensions accepts the embed dimensions knob.
 	Dimensions bool
 }
@@ -38,6 +40,7 @@ func KernelGenerate(
 			kind:      kindGenerate,
 			vision:    caps.Vision,
 			reasoning: caps.Reasoning,
+			webSearch: caps.WebSearch,
 		}),
 		transportGenerate(client),
 		decodeGenerate,

--- a/sdkx/inference/openai/spec.go
+++ b/sdkx/inference/openai/spec.go
@@ -44,6 +44,8 @@ type ModelSpec struct {
 	Vision bool `json:"vision,omitempty"`
 	// Reasoning (generate) enables the reasoning effort control.
 	Reasoning bool `json:"reasoning,omitempty"`
+	// WebSearch (generate) enables the hosted web_search tool.
+	WebSearch bool `json:"web_search,omitempty"`
 	// Dimensions (embed) allows custom output dimensions.
 	Dimensions bool `json:"dimensions,omitempty"`
 }

--- a/sdkx/inference/openai/websearch_test.go
+++ b/sdkx/inference/openai/websearch_test.go
@@ -3,6 +3,7 @@ package openai
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"strings"
 	"testing"
 
@@ -67,6 +68,27 @@ func TestGenerateOptionsWebSearchCompilesToHostedTool(t *testing.T) {
 		if !strings.Contains(body, want) {
 			t.Fatalf("tool JSON %s does not contain %s", body, want)
 		}
+	}
+}
+
+func TestGenerateOptionsWebSearchRejectedWithoutCapability(t *testing.T) {
+	request := simpleTextRequest("hi")
+	request.Extensions = inference.Extensions{
+		GenerateOptions{WebSearch: &GenerateWebSearch{}},
+	}
+	_, err := compileGenerate("gpt-4.1-nano", catalog["gpt-4.1-nano"])(
+		context.Background(),
+		openaiModel("gpt-4.1-nano"),
+		request,
+		inference.GenerateExecutionUnary,
+	)
+	if !inference.IsKind(err, inference.InvalidExtension) {
+		t.Fatalf("error = %v, want InvalidExtension", err)
+	}
+	var inferenceErr *inference.Error
+	if !errors.As(err, &inferenceErr) ||
+		inferenceErr.Field != "extension.openai.generate_options.web_search" {
+		t.Fatalf("error field = %v, want web_search extension", inferenceErr)
 	}
 }
 


### PR DESCRIPTION
Expose a hosted `web_search` capability bit in provider model metadata so hosts can determine whether the selected provider/model supports hosted search without hardcoding provider names. Request-level configuration continues to ride on `GenerateRequest.Extensions`.

## Changes

- **sdk/inference**: add `ModelDescriptor.Capabilities.HostedWebSearch` (public, credential-free discovery metadata). Validation requires the generate operation when the bit is set.
- **openai**: per-model capability flags from the official OpenAI model docs (`gpt-4.1-nano` is the only built-in generate model without `web_search`); add `ModelSpec.web_search`, thread through the openai kernel `Capabilities`, and gate the compiler on the same bit.
- **bytedance**: per-model capability flags from the official Ark tool-calling capability matrix (all built-in generate models support Web Search); add `ModelSpec.web_search` and gate the compiler.
- **azure**: add per-deployment `ModelSpec.web_search` (default false, generate only) and thread it through the openai kernel and descriptor.
- Compilers reject the `web_search` extension with a structured `InvalidExtension` when the model lacks the bit.
- Docs: add a "Model capabilities" section to the inference guide.

## Verification

- `make ci` (vet + test across modules): pass
- `make lint` (CI-gated modules): 0 issues
- `make release-check`: changesets valid, no pending releases
- `git diff --check`: clean