### PR TITLE
chore(release): prepare sdk v0.5.3 and sdkx v0.5.5 patch releases

### DIFF
--- a/.release/sdk-runtime-patch.json
+++ b/.release/sdk-runtime-patch.json
@@ -1,0 +1,9 @@
+{
+  "summary": "sdk patch: sandbox ProcessManager sessions, rule-based net policy, MITM, process events; pty Resize race fix; dynamic tool injection and policy middleware; hosted web_search capability metadata",
+  "releases": [
+    {
+      "module": "sdk",
+      "bump": "patch"
+    }
+  ]
+}

--- a/.release/sdkx-runtime-patch.json
+++ b/.release/sdkx-runtime-patch.json
@@ -1,0 +1,9 @@
+{
+  "summary": "sdkx patch: hosted web_search via ProviderOutputs, dynamic tool injection / lazy MCP attach / policy middleware / session wiring, session lifecycle observer, sandbox sessions and net policy, bwrap CI alignment",
+  "releases": [
+    {
+      "module": "sdkx",
+      "bump": "patch"
+    }
+  ]
+}

--- a/sdkx/go.mod
+++ b/sdkx/go.mod
@@ -2,7 +2,7 @@ module github.com/GizClaw/flowcraft/sdkx
 
 go 1.26.0
 
-require github.com/GizClaw/flowcraft/sdk v0.5.2
+require github.com/GizClaw/flowcraft/sdk v0.5.3
 
 require (
 	github.com/GizClaw/doubao-speech-go v0.0.0-20260723152315-fe8153366feb


### PR DESCRIPTION
Prepares the next sdk + sdkx patch release batch:

- Adds `.release/sdk-runtime-patch.json` — `sdk` patch changeset covering sandbox ProcessManager sessions, rule-based net policy, MITM, process events, the pty Resize race fix, dynamic tool injection / policy middleware, and hosted web_search capability metadata.
- Adds `.release/sdkx-runtime-patch.json` — `sdkx` patch changeset covering hosted web_search via ProviderOutputs, dynamic tool injection / lazy MCP attach / policy middleware / session wiring, session lifecycle observer, sandbox sessions and net policy, and bwrap CI alignment.
- Pins `sdkx/go.mod` to `sdk v0.5.3` for the coordinated same-batch release.

`make release-check BASE=origin/main` passes; the pending plan is `sdk/v0.5.3` and `sdkx/v0.5.5`.

Merging this PR triggers the Release modules workflow, which will open/refresh the `automation/release-changelog` PR; merging that PR runs the module gates and publishes the tags.