### PR TITLE
feat(release): add preflight tidy check for coordinated releases

### DIFF
--- a/.release/README.md
+++ b/.release/README.md
@@ -33,11 +33,21 @@ The CLI is a standalone Go module. Run these commands from the repository root:
 make release-check
 make release-check BASE=origin/main
 make release-plan
+make release-preflight
+make release-preflight-write
 make release-changelog
 ```
 
 `plan --json` prints the module plan, GitHub Actions matrix, and tags to create.
 With no pending release intent, it succeeds with empty arrays.
+
+`preflight` runs `go mod tidy` (with `GOWORK=off`) for every planned module. When
+the module releases in the same batch as an in-tree dependency, the dependency is
+replaced with its local directory so the tidy result reflects the versions that
+will exist after tagging. This catches new indirect requirements before the
+release gate runs. `preflight --write` applies the normalized tidy result to the
+module's `go.mod`/`go.sum` (without the temporary replace directives), so a
+coordinated release PR can commit the tidy state up front.
 
 After a changeset reaches `main`, the `Release modules` workflow aggregates all
 pending summaries, updates the module-version table and release sections in

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -75,6 +75,13 @@ make release-plan
 The release gate rejects a module whose same-batch dependency pins do not match
 the planned versions.
 
+Before opening a coordinated release PR, run `make release-preflight`. It tidies
+each planned module against the same-batch versions (using temporary local
+`replace` directives), so new indirect requirements introduced by the dependency
+bump are committed with the release instead of failing the gate after the first
+tag is published. `make release-preflight-write` applies the tidy results to the
+module's `go.mod`/`go.sum`.
+
 ## Release automation
 
 After a changeset reaches `main`, the `Release modules` workflow aggregates its

--- a/Makefile
+++ b/Makefile
@@ -36,6 +36,8 @@ help:
 	@echo "  make release-check  Test release tooling, validate changesets, and"
 	@echo "                      verify the pending module release plan."
 	@echo "  make release-plan   Print the pending module release plan as JSON."
+	@echo "  make release-preflight  Verify planned modules stay tidy when released together."
+	@echo "  make release-preflight-write  Apply preflight tidy results to go.mod/go.sum."
 	@echo "  make release-changelog  Aggregate pending changesets into CHANGELOG.md."
 	@echo ""
 	@echo "  make eval              Hermetic memory retrieval eval (memory/eval module)."
@@ -81,6 +83,14 @@ release-check:
 .PHONY: release-plan
 release-plan:
 	@cd tools/releasegate && GOWORK=off go run . plan --repo ../.. --json
+
+.PHONY: release-preflight
+release-preflight:
+	@cd tools/releasegate && GOWORK=off go run . preflight --repo ../..
+
+.PHONY: release-preflight-write
+release-preflight-write:
+	@cd tools/releasegate && GOWORK=off go run . preflight --repo ../.. --write
 
 .PHONY: release-changelog
 release-changelog:

--- a/sdkx/go.mod
+++ b/sdkx/go.mod
@@ -25,6 +25,8 @@ require (
 	modernc.org/sqlite v1.56.0
 )
 
+require github.com/creack/pty v1.1.24 // indirect
+
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.22.0 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/internal v1.12.0 // indirect

--- a/sdkx/go.sum
+++ b/sdkx/go.sum
@@ -10,8 +10,8 @@ github.com/AzureAD/microsoft-authentication-library-for-go v1.7.2/go.mod h1:HKpQ
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/GizClaw/doubao-speech-go v0.0.0-20260723152315-fe8153366feb h1:iS4tRKtteioA1ZDrUqn2tGkBjM4fiQeRoqJx6E3dD34=
 github.com/GizClaw/doubao-speech-go v0.0.0-20260723152315-fe8153366feb/go.mod h1:4R3wUAZkYk1BSgzv+QVF+2SZPu3VDy8NvaQdNRYGgBs=
-github.com/GizClaw/flowcraft/sdk v0.5.2 h1:PoYMJ/ct8I0B0pR8QrKNpgLmdxPoAFDNqQUdxUyopLY=
-github.com/GizClaw/flowcraft/sdk v0.5.2/go.mod h1:3p6UHZpLQOQYrBDobCw2THf7n8l+HEkB88Ct0usGvAs=
+github.com/GizClaw/flowcraft/sdk v0.5.3 h1:zeHaCoT0Gj7uHR6eNvT6OUKWyTeSFfrW3PP2vIdjZpE=
+github.com/GizClaw/flowcraft/sdk v0.5.3/go.mod h1:Nxcbz6SLISgg1mLxcuM0N5+w7ggX8SklJ1i/qgGE+Qs=
 github.com/Masterminds/semver/v3 v3.2.1 h1:RN9w6+7QoMeJVGyfmbcgs28Br8cvmnucEXnY0rYXWg0=
 github.com/Masterminds/semver/v3 v3.2.1/go.mod h1:qvl/7zhW3nngYb5+80sSMF+FG2BjYrf8m9wsX0PNOMQ=
 github.com/a2aproject/a2a-go v0.3.15 h1:h5YpCiPq3jxQ5rIns7oDjPag3ivP8u817AzdA4F+NiI=
@@ -31,6 +31,8 @@ github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
+github.com/creack/pty v1.1.24 h1:bJrF4RRfyJnbTJqzRLHzcGaZK1NeM5kTC9jGgovnR1s=
+github.com/creack/pty v1.1.24/go.mod h1:08sCNb52WyoAwi2QDyzUCTgcvVFhUzewun7wtTfvcwE=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/tools/releasegate/main.go
+++ b/tools/releasegate/main.go
@@ -73,7 +73,7 @@ func main() {
 
 func runCLI(args []string, stdout, stderr io.Writer) int {
 	if len(args) == 0 {
-		fmt.Fprintln(stderr, "usage: releasegate <validate|plan|changelog> [options]")
+		fmt.Fprintln(stderr, "usage: releasegate <validate|plan|changelog|preflight> [options]")
 		return 2
 	}
 
@@ -180,8 +180,26 @@ func runCLI(args []string, stdout, stderr io.Writer) int {
 		}
 		return 0
 
+	case "preflight":
+		flags := flag.NewFlagSet("preflight", flag.ContinueOnError)
+		flags.SetOutput(stderr)
+		repo := flags.String("repo", ".", "repository root")
+		write := flags.Bool("write", false, "write tidied go.mod/go.sum instead of failing")
+		if err := flags.Parse(args[1:]); err != nil {
+			return 2
+		}
+		if flags.NArg() != 0 {
+			fmt.Fprintln(stderr, "preflight does not accept positional arguments")
+			return 2
+		}
+		if err := preflightRepo(*repo, *write, stdout); err != nil {
+			fmt.Fprintf(stderr, "releasegate preflight: %v\n", err)
+			return 1
+		}
+		return 0
+
 	default:
-		fmt.Fprintf(stderr, "unknown command %q; usage: releasegate <validate|plan|changelog> [options]\n", args[0])
+		fmt.Fprintf(stderr, "unknown command %q; usage: releasegate <validate|plan|changelog|preflight> [options]\n", args[0])
 		return 2
 	}
 }
@@ -233,6 +251,298 @@ func validateRepo(repo, base string) error {
 		return fmt.Errorf("changeset %s was %s; .release changesets are immutable and may only be added", path, action)
 	}
 	return nil
+}
+
+func preflightRepo(repo string, write bool, stdout io.Writer) error {
+	plan, err := buildPlan(repo)
+	if err != nil {
+		return err
+	}
+	if len(plan.Modules) == 0 {
+		fmt.Fprintln(stdout, "no pending releases")
+		return nil
+	}
+	byModule := make(map[string]ModulePlan, len(plan.Modules))
+	for _, item := range plan.Modules {
+		byModule[item.Module] = item
+	}
+	for _, item := range plan.Modules {
+		changed, err := preflightModule(repo, item, byModule, write)
+		if err != nil {
+			return err
+		}
+		if write && changed {
+			fmt.Fprintf(stdout, "%s: updated go.mod/go.sum\n", item.Module)
+		} else {
+			fmt.Fprintf(stdout, "%s: preflight tidy OK\n", item.Module)
+		}
+	}
+	return nil
+}
+
+func preflightModule(repo string, item ModulePlan, plan map[string]ModulePlan, write bool) (bool, error) {
+	moduleDir := filepath.Join(repo, item.Dir)
+	modPath := filepath.Join(moduleDir, "go.mod")
+	sumPath := filepath.Join(moduleDir, "go.sum")
+	modData, err := os.ReadFile(modPath)
+	if err != nil {
+		return false, fmt.Errorf("module %s: read go.mod: %w", item.Module, err)
+	}
+	sumData := []byte{}
+	if _, err := os.Stat(sumPath); err == nil {
+		sumData, err = os.ReadFile(sumPath)
+		if err != nil {
+			return false, fmt.Errorf("module %s: read go.sum: %w", item.Module, err)
+		}
+	}
+
+	tempDir, err := os.MkdirTemp("", "releasegate-preflight-*")
+	if err != nil {
+		return false, fmt.Errorf("module %s: create temp dir: %w", item.Module, err)
+	}
+	defer os.RemoveAll(tempDir)
+	tempMod := filepath.Join(tempDir, "modfile.mod")
+	tempSum := filepath.Join(tempDir, "modfile.sum")
+	if err := os.WriteFile(tempMod, modData, 0o644); err != nil {
+		return false, fmt.Errorf("module %s: write temp go.mod: %w", item.Module, err)
+	}
+	if err := os.WriteFile(tempSum, sumData, 0o644); err != nil {
+		return false, fmt.Errorf("module %s: write temp go.sum: %w", item.Module, err)
+	}
+
+	deps := sameBatchDeps(item.Module, plan)
+	paths := make(map[string]bool, len(deps))
+	if len(deps) != 0 {
+		var replace strings.Builder
+		replace.WriteString("\nreplace (\n")
+		for _, dep := range deps {
+			depDir := filepath.Join(repo, dep.Dir)
+			modulePath, err := readModulePath(filepath.Join(depDir, "go.mod"))
+			if err != nil {
+				return false, err
+			}
+			target, err := filepath.Abs(depDir)
+			if err != nil {
+				return false, fmt.Errorf("module %s: resolve %s path: %w", item.Module, dep.Module, err)
+			}
+			paths[modulePath] = true
+			fmt.Fprintf(&replace, "\t%s => %s\n", modulePath, target)
+		}
+		replace.WriteString(")\n")
+		if err := os.WriteFile(tempMod, append(modData, []byte(replace.String())...), 0o644); err != nil {
+			return false, fmt.Errorf("module %s: write temp go.mod with replaces: %w", item.Module, err)
+		}
+	}
+
+	cmd := exec.Command("go", "mod", "tidy")
+	cmd.Dir = moduleDir
+	cmd.Env = withEnv(os.Environ(), map[string]string{
+		"GOWORK":  "off",
+		"GOFLAGS": "-modfile=" + tempMod,
+	})
+	if output, err := cmd.CombinedOutput(); err != nil {
+		return false, fmt.Errorf("module %s: go mod tidy: %w\n%s", item.Module, err, output)
+	}
+	tidiedMod, err := os.ReadFile(tempMod)
+	if err != nil {
+		return false, fmt.Errorf("module %s: read tidied go.mod: %w", item.Module, err)
+	}
+	tidiedSum, err := os.ReadFile(tempSum)
+	if err != nil {
+		return false, fmt.Errorf("module %s: read tidied go.sum: %w", item.Module, err)
+	}
+	normalizedMod := stripPreflightReplaces(tidiedMod, paths)
+	normalizedSum := filterPreflightSums(tidiedSum, paths)
+
+	var changedFiles []string
+	if !bytes.Equal(modData, normalizedMod) {
+		changedFiles = append(changedFiles, "go.mod")
+	}
+	if !bytes.Equal(sumData, normalizedSum) {
+		changedFiles = append(changedFiles, "go.sum")
+	}
+	if len(changedFiles) == 0 {
+		return false, nil
+	}
+	if !write {
+		var diff strings.Builder
+		if !bytes.Equal(modData, normalizedMod) {
+			fmt.Fprintf(&diff, "go.mod:\n%s", lineDiff(modData, normalizedMod))
+		}
+		if !bytes.Equal(sumData, normalizedSum) {
+			fmt.Fprintf(&diff, "go.sum:\n%s", lineDiff(sumData, normalizedSum))
+		}
+		return false, fmt.Errorf("module %s: %s not tidy for planned releases:\n%s"+
+			"run `releasegate preflight --write` to apply the changes",
+			item.Module, strings.Join(changedFiles, ", "), diff.String())
+	}
+	if err := writeModuleFile(modPath, normalizedMod); err != nil {
+		return false, fmt.Errorf("module %s: write go.mod: %w", item.Module, err)
+	}
+	if err := writeModuleFile(sumPath, normalizedSum); err != nil {
+		return false, fmt.Errorf("module %s: write go.sum: %w", item.Module, err)
+	}
+	return true, nil
+}
+
+func sameBatchDeps(module string, plan map[string]ModulePlan) []ModulePlan {
+	var deps []ModulePlan
+	for _, dependency := range moduleDependencies[module] {
+		if item, ok := plan[dependency]; ok {
+			deps = append(deps, item)
+		}
+	}
+	return deps
+}
+
+func stripPreflightReplaces(content []byte, paths map[string]bool) []byte {
+	if len(paths) == 0 {
+		return content
+	}
+	lines := strings.Split(string(content), "\n")
+	var out []string
+	var block []string
+	inBlock := false
+	flushBlock := func() {
+		kept := make([]string, 0, len(block))
+		for _, line := range block {
+			if !replaceLineTargets(line, paths) {
+				kept = append(kept, line)
+			}
+		}
+		if len(kept) != 0 {
+			out = append(out, kept...)
+		}
+		block = nil
+	}
+	for _, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if !inBlock && strings.HasPrefix(trimmed, "replace (") {
+			inBlock = true
+			block = []string{line}
+			continue
+		}
+		if inBlock {
+			block = append(block, line)
+			if trimmed == ")" {
+				flushBlock()
+				inBlock = false
+			}
+			continue
+		}
+		if strings.HasPrefix(trimmed, "replace ") && !strings.HasPrefix(trimmed, "replace (") &&
+			replaceLineTargets(line, paths) {
+			continue
+		}
+		out = append(out, line)
+	}
+	return []byte(strings.Join(out, "\n"))
+}
+
+func replaceLineTargets(line string, paths map[string]bool) bool {
+	fields := strings.Fields(line)
+	if len(fields) == 0 {
+		return false
+	}
+	if fields[0] == "replace" {
+		return len(fields) >= 2 && paths[fields[1]]
+	}
+	return paths[fields[0]]
+}
+
+func filterPreflightSums(sum []byte, paths map[string]bool) []byte {
+	if len(paths) == 0 {
+		return sum
+	}
+	lines := strings.Split(string(sum), "\n")
+	var out []string
+	for _, line := range lines {
+		if line == "" {
+			continue
+		}
+		fields := strings.Fields(line)
+		if len(fields) >= 1 && paths[fields[0]] {
+			continue
+		}
+		out = append(out, line)
+	}
+	return []byte(strings.Join(out, "\n"))
+}
+
+func lineDiff(oldData, newData []byte) string {
+	oldLines := splitLines(oldData)
+	newLines := splitLines(newData)
+	rows, cols := len(oldLines)+1, len(newLines)+1
+	dp := make([][]int, rows)
+	for i := range dp {
+		dp[i] = make([]int, cols)
+	}
+	for i := len(oldLines) - 1; i >= 0; i-- {
+		for j := len(newLines) - 1; j >= 0; j-- {
+			if oldLines[i] == newLines[j] {
+				dp[i][j] = dp[i+1][j+1] + 1
+			} else if dp[i+1][j] >= dp[i][j+1] {
+				dp[i][j] = dp[i+1][j]
+			} else {
+				dp[i][j] = dp[i][j+1]
+			}
+		}
+	}
+	var diff strings.Builder
+	i, j := 0, 0
+	for i < len(oldLines) && j < len(newLines) {
+		if oldLines[i] == newLines[j] {
+			fmt.Fprintf(&diff, "  %s\n", oldLines[i])
+			i++
+			j++
+		} else if dp[i+1][j] >= dp[i][j+1] {
+			fmt.Fprintf(&diff, "- %s\n", oldLines[i])
+			i++
+		} else {
+			fmt.Fprintf(&diff, "+ %s\n", newLines[j])
+			j++
+		}
+	}
+	for ; i < len(oldLines); i++ {
+		fmt.Fprintf(&diff, "- %s\n", oldLines[i])
+	}
+	for ; j < len(newLines); j++ {
+		fmt.Fprintf(&diff, "+ %s\n", newLines[j])
+	}
+	return diff.String()
+}
+
+func splitLines(data []byte) []string {
+	lines := strings.Split(string(data), "\n")
+	if len(lines) > 0 && lines[len(lines)-1] == "" {
+		lines = lines[:len(lines)-1]
+	}
+	return lines
+}
+
+func withEnv(env []string, overrides map[string]string) []string {
+	var out []string
+	for _, entry := range env {
+		key := entry
+		if index := strings.IndexByte(entry, '='); index >= 0 {
+			key = entry[:index]
+		}
+		if _, ok := overrides[key]; !ok {
+			out = append(out, entry)
+		}
+	}
+	for key, value := range overrides {
+		out = append(out, key+"="+value)
+	}
+	return out
+}
+
+func writeModuleFile(path string, content []byte) error {
+	mode := os.FileMode(0o644)
+	if info, err := os.Stat(path); err == nil {
+		mode = info.Mode().Perm()
+	}
+	return os.WriteFile(path, content, mode)
 }
 
 func loadChangesets(repo string) ([]Changeset, error) {

--- a/tools/releasegate/main_test.go
+++ b/tools/releasegate/main_test.go
@@ -204,6 +204,64 @@ func TestPlanEmptySetAndCLIJSON(t *testing.T) {
 	}
 }
 
+func TestPreflightDetectsAndWritesSameBatchTidy(t *testing.T) {
+	repo := initRepo(t)
+	seedModule(t, repo, "sdk", "")
+	seedModule(t, repo, "sdkx", "require github.com/GizClaw/flowcraft/sdk v1.0.0\n")
+	commitAll(t, repo, "seed")
+	gitRun(t, repo, "tag", "sdk/v1.0.0")
+	gitRun(t, repo, "tag", "sdkx/v1.0.0")
+
+	writeFile(t, repo, "memory/go.mod", "module github.com/GizClaw/flowcraft/memory\n\ngo 1.25.0\n")
+	writeFile(t, repo, "memory/module.go", "package memory\n")
+	writeFile(t, repo, "sdk/import.go", "package sdk\n\nimport _ \"github.com/GizClaw/flowcraft/memory\"\n")
+	writeFile(t, repo, "sdk/go.mod", moduleFile("sdk",
+		"require github.com/GizClaw/flowcraft/memory v0.1.0\n\nreplace github.com/GizClaw/flowcraft/memory => ../memory\n"))
+	writeFile(t, repo, "sdkx/import.go", "package sdkx\n\nimport _ \"github.com/GizClaw/flowcraft/sdk\"\n")
+	writeFile(t, repo, "sdkx/go.mod", moduleFile("sdkx",
+		"require github.com/GizClaw/flowcraft/sdk v1.0.1\n\nreplace github.com/GizClaw/flowcraft/memory => ../memory\n"))
+	writeFile(t, repo, ".release/all.json",
+		`{"summary":"coordinated","releases":[{"module":"sdk","bump":"patch"},{"module":"sdkx","bump":"patch"}]}`)
+	commitAll(t, repo, "changes")
+
+	var stdout, stderr bytes.Buffer
+	if code := runCLI([]string{"preflight", "--repo", repo}, &stdout, &stderr); code == 0 ||
+		!strings.Contains(stderr.String(), "github.com/GizClaw/flowcraft/memory") {
+		t.Fatalf("preflight check code = %d, stderr = %s", code, stderr.String())
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	if code := runCLI([]string{"preflight", "--repo", repo, "--write"}, &stdout, &stderr); code != 0 {
+		t.Fatalf("preflight write code = %d, stderr = %s", code, stderr.String())
+	}
+	sdkxMod, err := os.ReadFile(filepath.Join(repo, "sdkx/go.mod"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertContains(t, string(sdkxMod), "github.com/GizClaw/flowcraft/memory v0.1.0 // indirect")
+	if strings.Contains(string(sdkxMod), "replace github.com/GizClaw/flowcraft/sdk") {
+		t.Fatalf("preflight replace leaked into go.mod:\n%s", sdkxMod)
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	if code := runCLI([]string{"preflight", "--repo", repo}, &stdout, &stderr); code != 0 {
+		t.Fatalf("preflight check after write code = %d, stderr = %s", code, stderr.String())
+	}
+}
+
+func TestPreflightNoPendingReleases(t *testing.T) {
+	repo := initRepo(t)
+	var stdout, stderr bytes.Buffer
+	if code := runCLI([]string{"preflight", "--repo", repo}, &stdout, &stderr); code != 0 {
+		t.Fatalf("preflight code = %d, stderr = %s", code, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "no pending releases") {
+		t.Fatalf("stdout = %q, want no pending releases", stdout.String())
+	}
+}
+
 func TestChangelogSingleModuleUsesPlanTagAndUpdatesState(t *testing.T) {
 	repo := changelogRepo(t, "sdk", "1.2.3")
 	writeFile(t, repo, "sdk/change.go", "package sdk\n\nconst Changed = true\n")


### PR DESCRIPTION
## What

Adds `releasegate preflight` (plus `make release-preflight` / `make release-preflight-write`) so coordinated same-batch releases can prove their `go.mod`/`go.sum` will stay tidy **before** any tag is published.

For each planned module, preflight runs `GOWORK=off go mod tidy` against a temporary modfile. When the module releases in the same batch as an in-tree dependency, the dependency is temporarily `replace`d with its local directory — exactly the module graph that will exist after tagging. The temporary replace directives are stripped before comparing/writing, so the committed `go.mod` stays clean.

## Why

The sdk v0.5.3 + sdkx v0.5.5 release failed in `Release sdk and sdkx sequentially`: after `sdk/v0.5.3` was already published, the sdkx gate's `go mod tidy` added `require github.com/creack/pty v1.1.24 // indirect` (new transitive dependency from `sdk/sandbox`) and the strict `go.mod` diff rejected it. This PR also commits that tidy result (`sdkx/go.mod` + `sdkx/go.sum`), so the next release run can publish `sdkx/v0.5.5`.

## Changes

- `feat(release)`: releasegate `preflight` command, Makefile targets, `.release/README.md` + `CONTRIBUTING.md` docs, and tests covering the same-batch tidy flow.
- `chore(sdkx)`: apply preflight tidy for sdk v0.5.3 (adds `creack/pty` indirect, refreshes sdk checksums).

`make release-check` and `make release-preflight` both pass; pending plan is `sdkx/v0.5.5`.

Merging this PR triggers the Release workflow, which will open/refresh the changelog PR for `sdkx/v0.5.5`; merging that publishes the tag.