### PR TITLE
docs(guides): align tutorials with module APIs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,6 @@
 
 # ── Git config ──
 !.gitignore
-!.golangci.yml
 
 # ── Root documentation ──
 !README.md
@@ -14,6 +13,9 @@
 !CODE_OF_CONDUCT.md
 !docs/
 !docs/**
+
+# ── Go CI ──
+!.golangci.yml
 
 # ── Go source ──
 !go.mod

--- a/docs/guides/deploy.md
+++ b/docs/guides/deploy.md
@@ -201,7 +201,9 @@ shape:
 | `observe`  | `agent.Observer` (read-only)           | Lifecycle events (start, interrupt, revise, end)   | Logging, metrics, notifications, snapshots            |
 
 `policy` is **not** a hook — it is a per-call struct
-(`max_revise`, `artifact_channels`) read by the engine factory.
+(`max_revise`, `artifact_channels`) that the harness turns into
+per-call execute options (`agent.WithMaxRevise` /
+`agent.WithArtifactChannels`); the engine factory never reads it.
 
 Only `discard_on_interrupt` is built in. Every other hook kind must
 be registered on the `Builder` (`RegisterPreparer`, `RegisterReferee`,
@@ -421,15 +423,17 @@ agents:
 ```
 
 - `card` is the declarative subset of `agent.AgentCard`.
-- `tools` is a per-agent allow-list (policy gate, validated at build
-  time against the tool catalog).
+- `tools` is a per-agent allow-list (policy gate): it is promoted to
+  `Run.ToolAllowList` and enforced by the engine at runtime; the
+  document itself does not validate names against the catalog.
 - `engine` is opaque to the loader; the registered engine factory
   decodes and validates `settings` strictly.
 - `deps` is keyed by the engine's `Spec.Deps`; type mismatches fail
   the build.
-- `policy` is a per-call struct, not a hook. The graph engine reads
-  `max_revise`; custom engines can read whichever fields they
-  declared.
+- `policy` is a per-call struct, not a hook. The harness turns
+  `max_revise` / `artifact_channels` into per-call execute options
+  (`WithMaxRevise` / `WithArtifactChannels`); engines never see the
+  policy block.
 
 ### Engines
 
@@ -527,9 +531,10 @@ A `memory.Assembly` is bound **whole** as the hooks' `memory` dependency
 that need the raw stores can address the implementation's exposed item — with
 the flowcraft implementation it is `system`, i.e. `memories/system`.
 
-The flowcraft implementation requires a workspace and the inference runtime
-item exported by the inference assembly (deps are declared by the
-implementation at registration, not by the `sdk/memory` protocol):
+The flowcraft implementation requires a workspace and the whole inference
+assembly — the runtime plus its route policy — as the `inference` dep (deps
+are declared by the implementation at registration, not by the `sdk/memory`
+protocol):
 
 ```yaml
 # deploy.yaml
@@ -548,7 +553,7 @@ resources:
     impl: flowcraft
     deps:
       workspace: ws/project
-      inference: infer/runtime
+      inference: infer
     settings: {file: ./memory.yaml}
 agents:
   researcher:
@@ -577,10 +582,24 @@ providers:
   - id: openai
     driver: openai
     profiles:
-      - id: default
-        operations: [embed]
+      - operations: [embed]
         secrets:
           api_key: {resolver: env, key: OPENAI_API_KEY}
+  - id: deepseek
+    driver: deepseek
+    profiles:
+      - operations: [generate]
+        secrets:
+          api_key: {resolver: env, key: DEEPSEEK_API_KEY}
+route:
+  generate:
+    - tier: primary
+      targets:
+        - model: {id: {provider: deepseek, name: deepseek-v4-flash}}
+  embed:
+    - tier: primary
+      targets:
+        - model: {id: {provider: openai, name: text-embedding-3-small}}
 ```
 
 ```yaml
@@ -588,9 +607,6 @@ providers:
 storage:
   log: {driver: workspace}
   kv: {driver: workspace}
-generate:
-  provider: deepseek
-  name: deepseek-v4-flash
 embed:
   provider: openai
   name: text-embedding-3-small
@@ -600,10 +616,11 @@ scopes:
 interval: 1m
 ```
 
-Credentials and provider catalogs stay in `inference.yaml`; `memory.yaml`
-contains only flat model references (provider, name, optional profile),
-scopes, and derivation/maintenance policy. The implementation owns the full
-schema of its settings document (which has no `version` field).
+Credentials, provider catalogs, and the generate route stay in
+`inference.yaml`; `memory.yaml` contains only the flat embed model reference
+(provider, name, optional profile), scopes, and derivation/maintenance
+policy. The implementation owns the full schema of its settings document
+(which has no `version` field).
 
 Background work is not a cron schema anymore. The flowcraft implementation
 owns a worker and lifecycle runner; in an application Runtime, register the

--- a/docs/guides/event.md
+++ b/docs/guides/event.md
@@ -10,8 +10,9 @@ no-op bus (`NoopBus`) ship in the box; remote implementations (NATS,
 Kafka, …) plug into the same `Bus` interface.
 
 A bus is a **host capability**, not a graph build dep. Deployments
-build it, then surface it through `agent.Host.EventBus()` per turn —
-the engine asks the host for the bus it needs. See
+build it, then surface it through the optional `agent.EventBusProvider`
+capability on the turn host — the engine asks the host for the bus it
+needs. See
 [deploy.md#event-bus-and-the-host](deploy.md#event-bus-and-the-host)
 for the wiring.
 
@@ -137,6 +138,7 @@ decides:
 | `DropNewest` (default) | incoming envelope is dropped; older items stay                           |
 | `DropOldest`           | oldest buffered item is dropped; new one is enqueued                     |
 | `Block`                | `Publish` blocks until the buffer has room or the publishing ctx cancels |
+| `Sample`               | keeps each envelope with probability `WithSampleRate`; kept envelopes still follow the buffer-full drop path |
 
 Drop policies are fast paths — `Block` is the only one that can
 back-pressure publishers. Use `Block` only when a slow subscriber is
@@ -145,10 +147,10 @@ default to `DropNewest` and observe drop counts via the `Observer`.
 
 ## Host integration
 
-`agent.Host` declares an `EventBus() event.Bus` capability. Engines
-(such as the graph runner) call this per turn to publish lifecycle
-events; the host owns the bus and may share one bus across many
-runs or give each run its own.
+`agent.EventBusProvider` is the optional host capability for exposing a
+bus (`EventBus() event.Bus`). Engines (such as the graph runner) call
+this per turn to publish lifecycle events; the host owns the bus and
+may share one bus across many runs or give each run its own.
 
 ```go
 type runtimeHost struct {
@@ -187,11 +189,13 @@ error surface every other deploy extension point uses.
 
 ## Observing a bus
 
-`MemoryBus` accepts an `Observer` for lifecycle instrumentation —
-durations, drop counts, subscriber count, and the route cache
-hit/miss ratio. Replace it with your own `Observer` implementation
-to forward to Prometheus, OTel, or a custom metric sink. Drops and
-backpressure events are first-class signals here, not log noise.
+`MemoryBus` accepts an `Observer` for lifecycle instrumentation.
+The observer sees `OnPublish` / `OnDeliver` / `OnDrop` per envelope,
+so durations and drop counts (by reason) are easy to derive and
+forward to Prometheus, OTel, or a custom metric sink. Subscriber
+counts and route-cache hit/miss ratios are not part of the
+`Observer` surface. Drops and backpressure events are first-class
+signals here, not log noise.
 
 ## Testing
 
@@ -212,7 +216,7 @@ shared `Bus` contract.
   / `SubOption` surface), `sdk/event/envelope.go`, `sdk/event/subject.go`,
   `sdk/event/observer.go`, `sdk/event/trace.go`.
 - Host capability that reaches it: `sdk/agent/host.go`
-  (`Host.EventBus`).
+  (`EventBusProvider`).
 - Assembly: `sdk/event/config/resource.go`, the `event.Bus` resource
   in [deploy.md](deploy.md#first-party-impls).
 - Remote bridges: per-package `doc.go` (NATS / SSE / …).

--- a/docs/guides/inference.md
+++ b/docs/guides/inference.md
@@ -483,7 +483,7 @@ attempt spans nest under the route span).
 
 Every operation emits one span at the `Runtime` funnel:
 
-- `inference.generate` / `inference.embed` / `inference.transcribe` /
+- `inference.generate` / `inference.embed` / `inference.transcription` /
   `inference.realtime` (streaming adds a `.stream` suffix)
 - Attributes: `inference.operation`, `llm.provider`, `llm.model`,
   `inference.profile` — the `llm.*` keys match the rest of the
@@ -544,8 +544,8 @@ covering protocol quirks, catalog, spec schema, and extensions.
 | Driver      |            Generate            |        Embed         |    Transcription    | Realtime | Secret(s)                                                |
 | ----------- | :----------------------------: | :------------------: | :-----------------: | :------: | -------------------------------------------------------- |
 | `anthropic` |               ✓                |                      |                     |          | `api_key`                                                |
-| `azure`     |               ✓                |          ✓           |          ✓          |          | `api_key`                                                |
-| `bytedance` | ✓ (+image/audio/video intents) |          ✓           | ✓ (unary + session) |    ✓     | `api_key`, `speech_api_key`, `access_key` / `secret_key` |
+| `azure`     | ✓ (+image/audio intents)       |          ✓           |          ✓          |          | `api_key`                                                |
+| `bytedance` | ✓ (+image/audio/video intents) |          ✓           | ✓ (session only)    |    ✓     | `api_key`, `speech_api_key`, `access_key` / `secret_key` |
 | `deepseek`  |               ✓                |                      |                     |          | `api_key`                                                |
 | `kimi`      |               ✓                |                      |                     |          | `api_key`                                                |
 | `minimax`   | ✓ (+image/audio/video intents) |                      |                     |          | `api_key`                                                |

--- a/docs/guides/runtime.md
+++ b/docs/guides/runtime.md
@@ -45,6 +45,12 @@ resources:
     kind: scheduler.Server
     impl: local
 
+  checkpoints:
+    kind: agent.CheckpointStore
+    impl: sqlite
+    settings:
+      path: ./data/checkpoints.db
+
   ws:
     kind: workspace.Registry
     impl: yaml
@@ -75,7 +81,7 @@ resources:
     impl: flowcraft
     deps:
       workspace: ws/project
-      inference: infer/runtime
+      inference: infer
     settings:
       file: ./memory.yaml
 
@@ -92,11 +98,13 @@ agents:
 runtime:
   event_bus: events
   scheduler: schedules
+  checkpoint_store: checkpoints
   sessions:
     idle_timeout: 10m
     sink_buffer: 256
     speculative_buffer_events: 1024
     speculative_buffer_bytes: 1048576
+    resume: true
   integrations:
     - name: delegation
       kind: delegation.local
@@ -113,10 +121,15 @@ runtime:
       settings: {}
 ```
 
-`event_bus`, `scheduler`, and every integration dependency are exact resource
-map keys. Runtime never discovers resources by kind. Runtime references are
-external consumers during deployment assembly, so `events`, `schedules`,
-`delegations`, and `memories` do not need `export: true`.
+`event_bus`, `scheduler`, `checkpoint_store`, and every integration dependency
+are exact resource map keys. Runtime never discovers resources by kind.
+Runtime references are external consumers during deployment assembly, so
+`events`, `schedules`, `checkpoints`, `delegations`, and `memories` do not
+need `export: true`.
+
+`checkpoint_store` names an `agent.CheckpointStore` resource (sqlite or
+workspace-backed); `sessions.resume: true` enables checkpoint-based
+resumption and requires it. Omit both for a stateless runtime.
 
 `delegation.local` accepts `max_concurrency`, `max_depth`, and a Go-duration
 `timeout` string. Its `backend` dependency is optional. The
@@ -142,7 +155,8 @@ registry:
 
 Aliases used below: `sdkscheduler` =
 `github.com/GizClaw/flowcraft/sdkx/scheduler`, `schedulerconfig` =
-`github.com/GizClaw/flowcraft/sdk/scheduler/config`, `workspaceconfig` =
+`github.com/GizClaw/flowcraft/sdk/scheduler/config`, `sqlitecheckpointconfig` =
+`github.com/GizClaw/flowcraft/sdkx/agent/checkpoint/sqlite/config`, `workspaceconfig` =
 `github.com/GizClaw/flowcraft/sdk/workspace/config`, `inferenceconfig` =
 `github.com/GizClaw/flowcraft/sdk/inference/config`, `memoryconfig` =
 `flowcraftmemory` =
@@ -164,6 +178,8 @@ if err := sdkscheduler.Register(schedulerBuilder); err != nil {
     return err
 }
 deployBuilder.MustRegisterResource(schedulerconfig.NewDeployFactory("local", schedulerBuilder))
+
+deployBuilder.MustRegisterResource(sqlitecheckpointconfig.NewFactory())
 
 deployBuilder.MustRegisterResource(kanbanconfig.NewMemoryDeployFactory())
 
@@ -234,8 +250,9 @@ if err != nil {
 ```
 
 `Session.Start` always replaces a caller-supplied `Request.ContextID` with the
-session key and replaces `Request.RunID` with a new root RunID. Use
-`turn.RunID()` for event correlation.
+session key and replaces `Request.RunID` with the session's root RunID — fresh
+per turn by default, stable across turns when `sessions.resume` is enabled.
+Use `turn.RunID()` for event correlation.
 
 Prompt requests arrive through the same event stream as
 `session.PromptRequested`. Reply with the correlated prompt ID:

--- a/docs/guides/tool.md
+++ b/docs/guides/tool.md
@@ -212,7 +212,7 @@ delegated to MCP. The rule:
 | Package                | Tool name(s)                     | Category                                                       |
 | ---------------------- | -------------------------------- | -------------------------------------------------------------- |
 | `sdkx/tool/askuser`    | `ask_user`                       | host bridge (reaches the `agent.UserPrompter` host capability) |
-| `sdkx/tool/exec`       | `exec`                           | sandbox boundary (reaches `sandbox.Runner`)                    |
+| `sdkx/tool/exec`       | `exec`, `exec_session`           | sandbox boundary (reaches `sandbox.Runner` / `ProcessManager`) |
 | `sdkx/tool/delegation` | `delegate`, `delegation_status` | orchestration state through `sdk/delegation` contracts         |
 | `sdkx/tool/mcp`        | (catalog from MCP servers)       | adapter                                                        |
 

--- a/docs/guides/workspace.md
+++ b/docs/guides/workspace.md
@@ -85,9 +85,9 @@ diagnostics; it is not part of the `Workspace` interface.
 
 | Type                      | Backing store                                   | Atomic rename         | Use when                                                                |
 | ------------------------- | ----------------------------------------------- | --------------------- | ----------------------------------------------------------------------- |
-| `LocalWorkspace`          | local directory                                 | yes (POSIX rename(2)) | production per-host state, durable across restarts                      |
+| `LocalWorkspace`          | local directory                                 | yes (POSIX rename(2)) | production per-host state; survives process restarts (`DurableOnWrite=false`) |
 | `MemWorkspace`            | in-memory map                                   | yes (in-process)      | tests, ephemeral runs, scratch space                                    |
-| `ScopedWorkspace`         | wraps another `Workspace` with deny/allow rules | inherits inner        | least-privilege isolation: deny-by-default read, allow-by-default write |
+| `ScopedWorkspace`         | wraps another `Workspace` with deny/allow rules | inherits inner        | least-privilege isolation: reads denied only by `denyRead`; writes allowed only by `allowWrite` |
 | `Sub(ws, prefix)`         | virtual subtree of another `Workspace`          | inherits inner        | composability: a subsystem sees its own prefix as root                  |
 | `sdkx/workspace/objstore` | S3 / GCS / Azure Blob                           | backend-dependent     | cross-host shared state                                                 |
 


### PR DESCRIPTION
## Summary

Aligns the `docs/guides` tutorials with the actual module code. All discrepancies found during the API review are fixed; this is a docs-only change (plus a small `.gitignore` section reorder).

## Key fixes

- **deploy / runtime (memory wiring)**: the flowcraft memory resource binds the whole `inference.Assembly` (`inference: infer`), not the `infer/runtime` item; `memory.yaml` no longer accepts a `generate:` block (generate models are owned by the inference route policy); the example `inference.yaml` now declares a `route:` policy and uses the default (empty-id) profile.
- **runtime**: documents `checkpoint_store` and `sessions.resume` (with the sqlite `agent.CheckpointStore` resource and its factory registration), and clarifies root RunID semantics when resume is enabled.
- **event**: `EventBus()` is described as the optional `agent.EventBusProvider` host capability; the backpressure table now includes `Sample`; the `Observer` section reflects the actual `OnPublish` / `OnDeliver` / `OnDrop` surface.
- **inference**: span name corrected to `inference.transcription`; provider inventory fixed (bytedance transcription is session-only; azure supports image/audio generate intents).
- **tool**: `sdkx/tool/exec` now lists `exec_session` alongside `exec`.
- **workspace**: `ScopedWorkspace` semantics corrected (reads denied only by `denyRead`; writes allowed only by `allowWrite`); `LocalWorkspace` durability wording matches `DurableOnWrite=false`.
- **deploy**: `policy` is applied by the harness as execute options (not read by the engine factory); agent `tools` is a runtime-enforced allow-list, not a build-time catalog validation.

## Validation

- `git diff --check` passes.
- `make release-check` passes (changesets valid, no pending releases).
- All YAML blocks in the guides re-parse.