### PR TITLE
feat(sdkx/runtime): config-driven per-agent dynamic catalogs

### DIFF
--- a/.release/sdk-dynamic-catalog.json
+++ b/.release/sdk-dynamic-catalog.json
@@ -1,0 +1,9 @@
+{
+  "summary": "sdk patch: expose tool Assembly Registry and Sources so session-scoped dynamic catalogs can share the executor's registry and reach source exposure metadata",
+  "releases": [
+    {
+      "module": "sdk",
+      "bump": "patch"
+    }
+  ]
+}

--- a/.release/sdkx-dynamic-catalog.json
+++ b/.release/sdkx-dynamic-catalog.json
@@ -1,0 +1,9 @@
+{
+  "summary": "sdkx patch: add runtime sessions.dynamic_catalog with per-agent tool.Assembly mapping and automatic per-session dynamic CatalogProvider wiring (tool_search registration, MCP exposure handoff, configurable injection policy); clean up integration decorator iteration",
+  "releases": [
+    {
+      "module": "sdkx",
+      "bump": "patch"
+    }
+  ]
+}

--- a/docs/guides/runtime.md
+++ b/docs/guides/runtime.md
@@ -125,11 +125,37 @@ runtime:
 are exact resource map keys. Runtime never discovers resources by kind.
 Runtime references are external consumers during deployment assembly, so
 `events`, `schedules`, `checkpoints`, `delegations`, and `memories` do not
-need `export: true`.
+need `export: true`; the same applies to every `tool.Assembly` resource
+named by `sessions.dynamic_catalog.tools`.
 
 `checkpoint_store` names an `agent.CheckpointStore` resource (sqlite or
 workspace-backed); `sessions.resume: true` enables checkpoint-based
 resumption and requires it. Omit both for a stateless runtime.
+
+`sessions.dynamic_catalog` enables the per-session dynamic tool
+catalog. `tools` maps agent IDs to `tool.Assembly` resource names and
+may include a `default` entry as the fallback for agents without an
+explicit mapping; every deployed agent must be covered either way.
+`default_exposure` (one of `always`, `direct`, `deferred`, `hidden`;
+defaults to `deferred`), `exposures`, `selected_retention`,
+`recent_window`, and `budget` tune the injection policy. The runtime
+creates one catalog per `(AgentID, ContextID)` session over the mapped
+assembly's shared registry, applies MCP source exposure metadata, and
+registers `tool_search`; sessions using dynamic injection should run
+their inference nodes with `all_tools: true`.
+
+```yaml
+runtime:
+  event_bus: events
+  sessions:
+    dynamic_catalog:
+      tools: {default: shared_tools, researcher: research_tools}
+      default_exposure: deferred
+      exposures: {tool_search: always}
+      selected_retention: 5
+      recent_window: 10
+      budget: {max_definitions: 32, max_bytes: 16384}
+```
 
 `delegation.local` accepts `max_concurrency`, `max_depth`, and a Go-duration
 `timeout` string. Its `backend` dependency is optional. The

--- a/sdk/tool/config/builder.go
+++ b/sdk/tool/config/builder.go
@@ -115,7 +115,31 @@ type Assembly struct {
 	// the assembly exposes both halves.
 	Catalog tool.Catalog
 
-	sources []Source
+	registry *tool.Registry
+	sources  []Source
+}
+
+// Registry returns the registry Build created. The dynamic injection
+// layer needs the concrete registry (not just the Catalog view) so it
+// can register search tools and lazy proxies on the same execution
+// surface the Executor dispatches against.
+func (a *Assembly) Registry() *tool.Registry {
+	if a == nil {
+		return nil
+	}
+	return a.registry
+}
+
+// Sources returns the attached external sources. Hosts use them to
+// reach source-owned metadata (for example an MCP source's per-tool
+// exposure declarations) after Build has attached them. The returned
+// slice is a copy; the sources themselves remain owned by the Assembly
+// until Close.
+func (a *Assembly) Sources() []Source {
+	if a == nil {
+		return nil
+	}
+	return slices.Clone(a.sources)
 }
 
 // Close releases every attached source, unregistering their tools.
@@ -158,7 +182,7 @@ func (b *Builder) Build(ctx context.Context, doc Document) (*Assembly, error) {
 	if err != nil {
 		return nil, err
 	}
-	assembly := &Assembly{sources: sources}
+	assembly := &Assembly{sources: sources, registry: registry}
 
 	for name, scope := range doc.Scopes {
 		registered, ok := registry.Get(name)

--- a/sdk/tool/config/config_test.go
+++ b/sdk/tool/config/config_test.go
@@ -680,6 +680,41 @@ func TestBuild_SourceToolsJoinTheRegistry(t *testing.T) {
 	}
 }
 
+func TestAssembly_RegistryAndSourcesExposeBuildInternals(t *testing.T) {
+	builder := config.NewBuilder(config.Deps{})
+	builder.RegisterBuiltin(echoTool("builtin"))
+	source := &fakeSource{tools: []string{"remote"}}
+	builder.RegisterSourceFactory("fake", func(context.Context, sdkconfig.Input) (config.Source, error) {
+		return source, nil
+	})
+
+	doc := sourceDoc(t, "fake")
+	doc.Sources = append([]config.SourceEntry{builtinSource(t, "builtin")}, doc.Sources...)
+
+	assembly, err := builder.Build(context.Background(), doc)
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	t.Cleanup(func() { _ = assembly.Close() })
+
+	if assembly.Registry() == nil {
+		t.Fatal("Registry() returned nil")
+	}
+	if assembly.Registry() != assembly.Catalog {
+		t.Error("Registry() is not the registry the Catalog view wraps")
+	}
+	sources := assembly.Sources()
+	if len(sources) != 2 || sources[1] != source {
+		t.Fatalf("Sources() = %#v, want builtin + fake source", sources)
+	}
+	// The returned slice is a copy: mutating it must not affect the
+	// assembly's ownership.
+	sources[0] = nil
+	if got := assembly.Sources(); len(got) != 2 || got[1] != source {
+		t.Fatalf("Sources() changed after caller mutation: %#v", got)
+	}
+}
+
 func TestBuild_SourceAttachesBeforeScopes(t *testing.T) {
 	builder := config.NewBuilder(config.Deps{})
 	builder.RegisterSourceFactory("fake", func(context.Context, sdkconfig.Input) (config.Source, error) {

--- a/sdkx/go.mod
+++ b/sdkx/go.mod
@@ -2,7 +2,7 @@ module github.com/GizClaw/flowcraft/sdkx
 
 go 1.26.0
 
-require github.com/GizClaw/flowcraft/sdk v0.5.3
+require github.com/GizClaw/flowcraft/sdk v0.5.4
 
 require (
 	github.com/GizClaw/doubao-speech-go v0.0.0-20260723152315-fe8153366feb

--- a/sdkx/go.sum
+++ b/sdkx/go.sum
@@ -10,8 +10,6 @@ github.com/AzureAD/microsoft-authentication-library-for-go v1.7.2/go.mod h1:HKpQ
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/GizClaw/doubao-speech-go v0.0.0-20260723152315-fe8153366feb h1:iS4tRKtteioA1ZDrUqn2tGkBjM4fiQeRoqJx6E3dD34=
 github.com/GizClaw/doubao-speech-go v0.0.0-20260723152315-fe8153366feb/go.mod h1:4R3wUAZkYk1BSgzv+QVF+2SZPu3VDy8NvaQdNRYGgBs=
-github.com/GizClaw/flowcraft/sdk v0.5.3 h1:zeHaCoT0Gj7uHR6eNvT6OUKWyTeSFfrW3PP2vIdjZpE=
-github.com/GizClaw/flowcraft/sdk v0.5.3/go.mod h1:Nxcbz6SLISgg1mLxcuM0N5+w7ggX8SklJ1i/qgGE+Qs=
 github.com/Masterminds/semver/v3 v3.2.1 h1:RN9w6+7QoMeJVGyfmbcgs28Br8cvmnucEXnY0rYXWg0=
 github.com/Masterminds/semver/v3 v3.2.1/go.mod h1:qvl/7zhW3nngYb5+80sSMF+FG2BjYrf8m9wsX0PNOMQ=
 github.com/a2aproject/a2a-go v0.3.15 h1:h5YpCiPq3jxQ5rIns7oDjPag3ivP8u817AzdA4F+NiI=

--- a/sdkx/runtime/builder.go
+++ b/sdkx/runtime/builder.go
@@ -13,6 +13,7 @@ import (
 	"github.com/GizClaw/flowcraft/sdk/event"
 	sdkscheduler "github.com/GizClaw/flowcraft/sdk/scheduler"
 	schedulerconfig "github.com/GizClaw/flowcraft/sdk/scheduler/config"
+	toolconfig "github.com/GizClaw/flowcraft/sdk/tool/config"
 	"github.com/GizClaw/flowcraft/sdkx/deploy"
 	"github.com/GizClaw/flowcraft/sdkx/runtime/session"
 )
@@ -175,6 +176,17 @@ func (b *Builder) Build(ctx context.Context, doc deploy.Document) (*Runtime, err
 	}
 	owned.result = result
 
+	var catalogProvider session.CatalogProvider
+	if cfg.Sessions.DynamicCatalog != nil {
+		assemblies, err := resolveDynamicCatalogAssemblies(
+			doc, result, cfg.Sessions.DynamicCatalog)
+		if err != nil {
+			return nil, fail(err)
+		}
+		catalogProvider = newDynamicCatalogProvider(
+			assemblies, cfg.Sessions.DynamicCatalog)
+	}
+
 	schedulerServer, err := resolveScheduler(result, cfg.Scheduler)
 	if err != nil {
 		return nil, fail(err)
@@ -222,19 +234,19 @@ func (b *Builder) Build(ctx context.Context, doc deploy.Document) (*Runtime, err
 
 	// Wrapping in reverse configuration order makes integrations[0] the
 	// outermost decorator while preserving each decorator's ordinary semantics.
-	for i := len(owned.integrations) - 1; i >= 0; i-- {
+	for _, v := range slices.Backward(owned.integrations) {
 		if isNil(hostFactory) {
 			return nil, fail(errdefs.Internalf(
-				"runtime integration %q received a nil HostFactory", owned.integrations[i].name))
+				"runtime integration %q received a nil HostFactory", v.name))
 		}
-		hostFactory, err = owned.integrations[i].integration.DecorateHost(hostFactory)
+		hostFactory, err = v.integration.DecorateHost(hostFactory)
 		if err != nil {
 			return nil, fail(fmt.Errorf(
-				"runtime integration %q decorate host: %w", owned.integrations[i].name, err))
+				"runtime integration %q decorate host: %w", v.name, err))
 		}
 		if isNil(hostFactory) {
 			return nil, fail(errdefs.Internalf(
-				"runtime integration %q decorate host returned nil", owned.integrations[i].name))
+				"runtime integration %q decorate host returned nil", v.name))
 		}
 	}
 
@@ -257,6 +269,10 @@ func (b *Builder) Build(ctx context.Context, doc deploy.Document) (*Runtime, err
 			session.WithCheckpointStore(checkpoints),
 			session.WithResume(cfg.Sessions.Resume),
 		)
+	}
+	if catalogProvider != nil {
+		managerOptions = append(managerOptions,
+			session.WithCatalogProvider(catalogProvider))
 	}
 	manager, err := session.NewManager(result, hostFactory, router, managerOptions...)
 	if err != nil {
@@ -348,6 +364,22 @@ func resolveCatalog(
 			}
 		}
 		external = append(external, cfg.Scheduler)
+	}
+	if cfg.Sessions.DynamicCatalog != nil {
+		for agentID, resourceName := range cfg.Sessions.DynamicCatalog.Tools {
+			entry, exists := doc.Resources[resourceName]
+			if !exists {
+				return nil, nil, errdefs.NotFoundf(
+					"runtime config sessions.dynamic_catalog.tools[%q]: resource %q is not defined",
+					agentID, resourceName)
+			}
+			if entry.Kind != toolconfig.ResourceKind {
+				return nil, nil, errdefs.Validationf(
+					"runtime config sessions.dynamic_catalog.tools[%q]: resource %q has kind %q, want %q",
+					agentID, resourceName, entry.Kind, toolconfig.ResourceKind)
+			}
+			external = append(external, resourceName)
+		}
 	}
 	for i, item := range cfg.Integrations {
 		registered, exists := catalog[item.Kind]

--- a/sdkx/runtime/config.go
+++ b/sdkx/runtime/config.go
@@ -10,6 +10,7 @@ import (
 	sdkconfig "github.com/GizClaw/flowcraft/sdk/config"
 	"github.com/GizClaw/flowcraft/sdk/errdefs"
 	"github.com/GizClaw/flowcraft/sdkx/deploy"
+	"github.com/GizClaw/flowcraft/sdkx/tool/dynamic"
 )
 
 const (
@@ -43,6 +44,30 @@ type SessionConfig struct {
 	SpeculativeBufferEvents int
 	SpeculativeBufferBytes  int
 	Resume                  bool
+	// DynamicCatalog enables the per-session dynamic injection catalog
+	// for the configured agents. Nil keeps the current behaviour: the
+	// session manager runs without a catalog provider.
+	DynamicCatalog *DynamicCatalogConfig
+}
+
+// DynamicCatalogConfig is the declarative policy for the per-session
+// dynamic catalog. Tools maps agent IDs to tool.Assembly resource
+// names; the reserved "default" key is the fallback for agents without
+// an explicit entry.
+type DynamicCatalogConfig struct {
+	Tools             map[string]string
+	DefaultExposure   dynamic.Exposure
+	Exposures         map[string]dynamic.Exposure
+	SelectedRetention int
+	RecentWindow      int
+	Budget            DynamicBudgetConfig
+}
+
+// DynamicBudgetConfig caps how many definitions reach the model per
+// turn. Zero fields fall back to the dynamic package defaults.
+type DynamicBudgetConfig struct {
+	MaxDefinitions int
+	MaxBytes       int64
 }
 
 // IntegrationConfig configures one independently prepared integration.
@@ -62,11 +87,26 @@ type configWire struct {
 }
 
 type sessionConfigWire struct {
-	IdleTimeout             *string `json:"idle_timeout,omitempty"`
-	SinkBuffer              *int    `json:"sink_buffer,omitempty"`
-	SpeculativeBufferEvents *int    `json:"speculative_buffer_events,omitempty"`
-	SpeculativeBufferBytes  *int    `json:"speculative_buffer_bytes,omitempty"`
-	Resume                  *bool   `json:"resume,omitempty"`
+	IdleTimeout             *string                   `json:"idle_timeout,omitempty"`
+	SinkBuffer              *int                      `json:"sink_buffer,omitempty"`
+	SpeculativeBufferEvents *int                      `json:"speculative_buffer_events,omitempty"`
+	SpeculativeBufferBytes  *int                      `json:"speculative_buffer_bytes,omitempty"`
+	Resume                  *bool                     `json:"resume,omitempty"`
+	DynamicCatalog          *dynamicCatalogConfigWire `json:"dynamic_catalog,omitempty"`
+}
+
+type dynamicCatalogConfigWire struct {
+	Tools             map[string]string           `json:"tools,omitempty"`
+	DefaultExposure   *string                     `json:"default_exposure,omitempty"`
+	Exposures         map[string]dynamic.Exposure `json:"exposures,omitempty"`
+	SelectedRetention *int                        `json:"selected_retention,omitempty"`
+	RecentWindow      *int                        `json:"recent_window,omitempty"`
+	Budget            *dynamicBudgetConfigWire    `json:"budget,omitempty"`
+}
+
+type dynamicBudgetConfigWire struct {
+	MaxDefinitions *int   `json:"max_definitions,omitempty"`
+	MaxBytes       *int64 `json:"max_bytes,omitempty"`
 }
 
 type integrationConfigWire struct {
@@ -141,6 +181,13 @@ func DecodeConfig(doc deploy.Document) (Config, error) {
 		return Config{}, errdefs.Validationf(
 			"runtime config: sessions.resume requires checkpoint_store")
 	}
+	if wire.Sessions.DynamicCatalog != nil {
+		catalog, err := decodeDynamicCatalog(wire.Sessions.DynamicCatalog)
+		if err != nil {
+			return Config{}, err
+		}
+		cfg.Sessions.DynamicCatalog = catalog
+	}
 
 	seenNames := make(map[string]struct{}, len(wire.Items))
 	for i, item := range wire.Items {
@@ -177,6 +224,94 @@ func DecodeConfig(doc deploy.Document) (Config, error) {
 		}
 		cfg.Integrations[i] = IntegrationConfig{
 			Name: name, Kind: kind, Deps: deps, Settings: item.Settings,
+		}
+	}
+	return cfg, nil
+}
+
+// decodeDynamicCatalog strictly decodes and validates the
+// sessions.dynamic_catalog subtree. Resource existence and agent
+// coverage are deployment facts, so they are checked by the Builder
+// rather than here.
+func decodeDynamicCatalog(wire *dynamicCatalogConfigWire) (*DynamicCatalogConfig, error) {
+	if len(wire.Tools) == 0 {
+		return nil, errdefs.Validationf(
+			"runtime config: sessions.dynamic_catalog.tools must map agent IDs to tool resource names")
+	}
+	tools := make(map[string]string, len(wire.Tools))
+	for agentID, resource := range wire.Tools {
+		if strings.TrimSpace(agentID) == "" {
+			return nil, errdefs.Validationf(
+				"runtime config: sessions.dynamic_catalog.tools has an empty agent ID")
+		}
+		if strings.TrimSpace(resource) == "" {
+			return nil, errdefs.Validationf(
+				"runtime config: sessions.dynamic_catalog.tools[%q] is empty",
+				agentID)
+		}
+		tools[agentID] = resource
+	}
+
+	cfg := &DynamicCatalogConfig{
+		Tools:             tools,
+		DefaultExposure:   dynamic.ExposureDeferred,
+		Exposures:         map[string]dynamic.Exposure{},
+		SelectedRetention: 0,
+		RecentWindow:      0,
+	}
+	if wire.DefaultExposure != nil {
+		exp := dynamic.Exposure(strings.TrimSpace(*wire.DefaultExposure))
+		if exp == "" {
+			return nil, errdefs.Validationf(
+				"runtime config: sessions.dynamic_catalog.default_exposure is empty")
+		}
+		if !exp.Valid() {
+			return nil, errdefs.Validationf(
+				"runtime config: sessions.dynamic_catalog.default_exposure %q is invalid",
+				exp)
+		}
+		cfg.DefaultExposure = exp
+	}
+	for name, exp := range wire.Exposures {
+		if strings.TrimSpace(name) == "" {
+			return nil, errdefs.Validationf(
+				"runtime config: sessions.dynamic_catalog.exposures has an empty tool name")
+		}
+		if !exp.Valid() {
+			return nil, errdefs.Validationf(
+				"runtime config: sessions.dynamic_catalog.exposures[%s] %q is invalid",
+				name, exp)
+		}
+		cfg.Exposures[name] = exp
+	}
+	if wire.SelectedRetention != nil {
+		if *wire.SelectedRetention < 0 {
+			return nil, errdefs.Validationf(
+				"runtime config: sessions.dynamic_catalog.selected_retention must not be negative")
+		}
+		cfg.SelectedRetention = *wire.SelectedRetention
+	}
+	if wire.RecentWindow != nil {
+		if *wire.RecentWindow < 0 {
+			return nil, errdefs.Validationf(
+				"runtime config: sessions.dynamic_catalog.recent_window must not be negative")
+		}
+		cfg.RecentWindow = *wire.RecentWindow
+	}
+	if wire.Budget != nil {
+		if wire.Budget.MaxDefinitions != nil {
+			if *wire.Budget.MaxDefinitions < 0 {
+				return nil, errdefs.Validationf(
+					"runtime config: sessions.dynamic_catalog.budget.max_definitions must not be negative")
+			}
+			cfg.Budget.MaxDefinitions = *wire.Budget.MaxDefinitions
+		}
+		if wire.Budget.MaxBytes != nil {
+			if *wire.Budget.MaxBytes < 0 {
+				return nil, errdefs.Validationf(
+					"runtime config: sessions.dynamic_catalog.budget.max_bytes must not be negative")
+			}
+			cfg.Budget.MaxBytes = *wire.Budget.MaxBytes
 		}
 	}
 	return cfg, nil

--- a/sdkx/runtime/config_test.go
+++ b/sdkx/runtime/config_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/GizClaw/flowcraft/sdk/event"
 	"github.com/GizClaw/flowcraft/sdkx/deploy"
 	"github.com/GizClaw/flowcraft/sdkx/runtime/session"
+	"github.com/GizClaw/flowcraft/sdkx/tool/dynamic"
 )
 
 func parseRuntimeDocument(t *testing.T, runtimeYAML string) deploy.Document {
@@ -127,5 +128,115 @@ func TestRegisterIntegrationRejectsInvalidFactoriesAndSpecs(t *testing.T) {
 	}
 	if err := builder.RegisterIntegration(good); err == nil {
 		t.Fatal("duplicate kind accepted")
+	}
+}
+
+func TestDecodeConfig_DynamicCatalog(t *testing.T) {
+	t.Run("valid", func(t *testing.T) {
+		doc := parseRuntimeDocument(t, `  event_bus: events
+  sessions:
+    dynamic_catalog:
+      tools: {default: shared_tools, researcher: research_tools}
+      default_exposure: direct
+      exposures: {tool_search: always, exec: hidden}
+      selected_retention: 3
+      recent_window: 7
+      budget: {max_definitions: 20, max_bytes: 4096}
+`)
+		cfg, err := DecodeConfig(doc)
+		if err != nil {
+			t.Fatalf("DecodeConfig: %v", err)
+		}
+		dc := cfg.Sessions.DynamicCatalog
+		if dc == nil {
+			t.Fatal("DynamicCatalog is nil")
+		}
+		if dc.Tools["default"] != "shared_tools" ||
+			dc.Tools["researcher"] != "research_tools" {
+			t.Fatalf("Tools = %#v", dc.Tools)
+		}
+		if dc.DefaultExposure != dynamic.ExposureDirect {
+			t.Errorf("DefaultExposure = %q, want direct", dc.DefaultExposure)
+		}
+		if dc.Exposures["tool_search"] != dynamic.ExposureAlways ||
+			dc.Exposures["exec"] != dynamic.ExposureHidden {
+			t.Errorf("Exposures = %#v", dc.Exposures)
+		}
+		if dc.SelectedRetention != 3 || dc.RecentWindow != 7 {
+			t.Errorf("retention/window = %d/%d, want 3/7",
+				dc.SelectedRetention, dc.RecentWindow)
+		}
+		if dc.Budget.MaxDefinitions != 20 || dc.Budget.MaxBytes != 4096 {
+			t.Errorf("budget = %+v, want 20/4096", dc.Budget)
+		}
+	})
+
+	t.Run("omitted policy uses defaults", func(t *testing.T) {
+		doc := parseRuntimeDocument(t, `  event_bus: events
+  sessions:
+    dynamic_catalog:
+      tools: {researcher: research_tools}
+`)
+		cfg, err := DecodeConfig(doc)
+		if err != nil {
+			t.Fatalf("DecodeConfig: %v", err)
+		}
+		dc := cfg.Sessions.DynamicCatalog
+		if dc.DefaultExposure != dynamic.ExposureDeferred {
+			t.Errorf("DefaultExposure = %q, want deferred", dc.DefaultExposure)
+		}
+		if len(dc.Exposures) != 0 || dc.SelectedRetention != 0 ||
+			dc.RecentWindow != 0 || dc.Budget.MaxDefinitions != 0 ||
+			dc.Budget.MaxBytes != 0 {
+			t.Errorf("unexpected non-default policy: %#v", dc)
+		}
+	})
+
+	for name, runtimeYAML := range map[string]string{
+		"missing tools": `  event_bus: events
+  sessions:
+    dynamic_catalog: {}
+`,
+		"empty agent key": `  event_bus: events
+  sessions:
+    dynamic_catalog:
+      tools: {'': research_tools}
+`,
+		"empty resource": `  event_bus: events
+  sessions:
+    dynamic_catalog:
+      tools: {researcher: ''}
+`,
+		"bad default exposure": `  event_bus: events
+  sessions:
+    dynamic_catalog:
+      tools: {researcher: research_tools}
+      default_exposure: sometimes
+`,
+		"bad exposure value": `  event_bus: events
+  sessions:
+    dynamic_catalog:
+      tools: {researcher: research_tools}
+      exposures: {exec: maybe}
+`,
+		"negative retention": `  event_bus: events
+  sessions:
+    dynamic_catalog:
+      tools: {researcher: research_tools}
+      selected_retention: -1
+`,
+		"negative budget": `  event_bus: events
+  sessions:
+    dynamic_catalog:
+      tools: {researcher: research_tools}
+      budget: {max_definitions: -2}
+`,
+	} {
+		t.Run(name, func(t *testing.T) {
+			doc := parseRuntimeDocument(t, runtimeYAML)
+			if _, err := DecodeConfig(doc); err == nil {
+				t.Fatal("DecodeConfig unexpectedly succeeded")
+			}
+		})
 	}
 }

--- a/sdkx/runtime/dynamic.go
+++ b/sdkx/runtime/dynamic.go
@@ -1,0 +1,131 @@
+package runtime
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/GizClaw/flowcraft/sdk/errdefs"
+	sdktool "github.com/GizClaw/flowcraft/sdk/tool"
+	toolconfig "github.com/GizClaw/flowcraft/sdk/tool/config"
+	"github.com/GizClaw/flowcraft/sdkx/deploy"
+	"github.com/GizClaw/flowcraft/sdkx/runtime/session"
+	"github.com/GizClaw/flowcraft/sdkx/tool/dynamic"
+)
+
+// dynamicCatalogDefaultAgent is the reserved tools key used as the
+// fallback assembly for agents without an explicit entry.
+const dynamicCatalogDefaultAgent = "default"
+
+// resolveDynamicCatalogAssemblies validates the agent -> tool resource
+// mapping against the deployment and resolves every referenced
+// assembly. Unknown agent keys are typos and fail the build; every
+// deployed agent must have an explicit entry unless a default is
+// declared.
+func resolveDynamicCatalogAssemblies(
+	doc deploy.Document,
+	result *deploy.Result,
+	cfg *DynamicCatalogConfig,
+) (map[string]*toolconfig.Assembly, error) {
+	for agentID := range cfg.Tools {
+		if agentID == dynamicCatalogDefaultAgent {
+			continue
+		}
+		if _, deployed := doc.Agents[agentID]; !deployed {
+			return nil, errdefs.Validationf(
+				"runtime config sessions.dynamic_catalog.tools[%q]: no such deployed agent",
+				agentID)
+		}
+	}
+	_, hasDefault := cfg.Tools[dynamicCatalogDefaultAgent]
+	for agentID := range doc.Agents {
+		if _, mapped := cfg.Tools[agentID]; !mapped && !hasDefault {
+			return nil, errdefs.Validationf(
+				"runtime config sessions.dynamic_catalog.tools: agent %q has no tool resource and no default",
+				agentID)
+		}
+	}
+
+	assemblies := make(map[string]*toolconfig.Assembly, len(cfg.Tools))
+	resolved := make(map[string]*toolconfig.Assembly, len(cfg.Tools))
+	for agentID, resourceName := range cfg.Tools {
+		assembly, exists := resolved[resourceName]
+		if !exists {
+			var err error
+			assembly, err = deploy.ResourceAs[*toolconfig.Assembly](result, resourceName)
+			if err != nil {
+				return nil, fmt.Errorf(
+					"runtime config sessions.dynamic_catalog.tools[%q]: resolve %q: %w",
+					agentID, resourceName, err)
+			}
+			resolved[resourceName] = assembly
+		}
+		assemblies[agentID] = assembly
+	}
+	return assemblies, nil
+}
+
+// newDynamicCatalogProvider builds one dynamic catalog per session over
+// the mapped assembly's shared registry. The catalog is per-session
+// state: each Session gets its own injection view, while the registry
+// and the exposure metadata stay shared. The Session owns the catalog
+// and closes it exactly once at session close.
+func newDynamicCatalogProvider(
+	assemblies map[string]*toolconfig.Assembly,
+	cfg *DynamicCatalogConfig,
+) session.CatalogProvider {
+	return session.CatalogProviderFunc(func(
+		ctx context.Context,
+		instance *deploy.Instance,
+	) (sdktool.Catalog, error) {
+		assembly := assemblies[instance.Agent.ID]
+		if assembly == nil {
+			assembly = assemblies[dynamicCatalogDefaultAgent]
+		}
+		if assembly == nil || assembly.Registry() == nil {
+			return nil, errdefs.Internalf(
+				"runtime dynamic catalog: agent %q has no tool assembly",
+				instance.Agent.ID)
+		}
+		reg := assembly.Registry()
+
+		// Build a fresh policy per session: the catalog mutates its
+		// policy map (SetExposure, Register), so sharing one map across
+		// sessions would leak state and race.
+		policy := dynamic.Policy{
+			Default:           cfg.DefaultExposure,
+			Exposures:         make(map[string]dynamic.Exposure, len(cfg.Exposures)),
+			SelectedRetention: cfg.SelectedRetention,
+			RecentWindow:      cfg.RecentWindow,
+			Budget: dynamic.Budget{
+				MaxDefinitions: cfg.Budget.MaxDefinitions,
+				MaxBytes:       cfg.Budget.MaxBytes,
+			},
+		}
+		catalog := dynamic.New(reg, dynamic.WithPolicy(policy))
+
+		if err := dynamic.RegisterSearchTool(reg, catalog); err != nil {
+			_ = catalog.Close()
+			return nil, fmt.Errorf(
+				"runtime dynamic catalog: register tool_search: %w", err)
+		}
+		for _, source := range assembly.Sources() {
+			if exposures, ok := source.(dynamic.ExposureSource); ok {
+				if err := exposures.ApplyExposures(catalog); err != nil {
+					_ = catalog.Close()
+					return nil, fmt.Errorf(
+						"runtime dynamic catalog: apply exposures: %w", err)
+				}
+			}
+		}
+		// Config-declared exposures are host policy and win over the
+		// tool source's own metadata.
+		for name, exposure := range cfg.Exposures {
+			if err := catalog.SetExposure(name, exposure); err != nil {
+				_ = catalog.Close()
+				return nil, fmt.Errorf(
+					"runtime dynamic catalog: set exposure %q: %w", name, err)
+			}
+		}
+		return catalog, nil
+	})
+}

--- a/sdkx/runtime/dynamic_test.go
+++ b/sdkx/runtime/dynamic_test.go
@@ -1,0 +1,334 @@
+package runtime
+
+import (
+	"context"
+	"encoding/json"
+	"sync"
+	"testing"
+
+	"github.com/GizClaw/flowcraft/sdk/agent"
+	sdkconfig "github.com/GizClaw/flowcraft/sdk/config"
+	"github.com/GizClaw/flowcraft/sdk/errdefs"
+	"github.com/GizClaw/flowcraft/sdk/event"
+	"github.com/GizClaw/flowcraft/sdk/message"
+	sdktool "github.com/GizClaw/flowcraft/sdk/tool"
+	toolconfig "github.com/GizClaw/flowcraft/sdk/tool/config"
+	"github.com/GizClaw/flowcraft/sdkx/deploy"
+	"github.com/GizClaw/flowcraft/sdkx/runtime/session"
+	"github.com/GizClaw/flowcraft/sdkx/tool/dynamic"
+)
+
+// exposureSource is a config source that registers tools and publishes
+// their exposure metadata onto a session catalog, mirroring how the MCP
+// source carries config-declared exposure into the dynamic layer.
+type exposureSource struct {
+	names    []string
+	exposure dynamic.Exposure
+}
+
+func (s *exposureSource) Attach(_ context.Context, reg *sdktool.Registry) error {
+	for _, name := range s.names {
+		reg.Register(sdktool.FuncTool(message.Definition{
+			Name:        name,
+			Description: name,
+			InputSchema: json.RawMessage(`{"type":"object"}`),
+		}, func(_ context.Context, _ string) (string, error) {
+			return "ran:" + name, nil
+		}))
+	}
+	return nil
+}
+
+func (s *exposureSource) Close() error { return nil }
+
+func (s *exposureSource) ApplyExposures(cat *dynamic.Catalog) error {
+	for _, name := range s.names {
+		if err := cat.SetExposure(name, s.exposure); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func buildExposureAssembly(t *testing.T, source *exposureSource) *toolconfig.Assembly {
+	t.Helper()
+	builder := toolconfig.NewBuilder(toolconfig.Deps{})
+	builder.RegisterSourceFactory("exposure",
+		func(context.Context, sdkconfig.Input) (toolconfig.Source, error) {
+			return source, nil
+		})
+	assembly, err := builder.Build(context.Background(), toolconfig.Document{
+		Version: toolconfig.VersionV1,
+		Sources: []toolconfig.SourceEntry{{
+			Kind: "exposure",
+			Spec: json.RawMessage(`{}`),
+		}},
+	})
+	if err != nil {
+		t.Fatalf("tool assembly build: %v", err)
+	}
+	t.Cleanup(func() { _ = assembly.Close() })
+	return assembly
+}
+
+func dynamicCatalogDoc(t *testing.T) deploy.Document {
+	t.Helper()
+	doc, err := deploy.Parse([]byte(`version: v1
+resources:
+  events: {kind: event.Bus, impl: test}
+  research_tools: {kind: tool.Assembly, impl: yaml}
+  assistant_tools: {kind: tool.Assembly, impl: test}
+agents:
+  researcher: {engine: {kind: test}}
+  assistant: {engine: {kind: test}}
+runtime:
+  event_bus: events
+  sessions:
+    dynamic_catalog:
+      tools: {researcher: research_tools, assistant: assistant_tools}
+      default_exposure: deferred
+      exposures: {tool_search: always}
+      selected_retention: 3
+      recent_window: 7
+      budget: {max_definitions: 20, max_bytes: 4096}
+`))
+	if err != nil {
+		t.Fatalf("deploy.Parse: %v", err)
+	}
+	return doc
+}
+
+func TestBuild_DynamicCatalogMapsToolsPerAgent(t *testing.T) {
+	deployBuilder := deploy.NewBuilder()
+	deployBuilder.MustRegisterEngine(testEngineFactory{engine: agent.EngineFunc(
+		func(_ context.Context, _ agent.Run, _ agent.Host, board *agent.Board) (*agent.Board, error) {
+			return board, nil
+		},
+	)})
+	if err := deployBuilder.RegisterResource(testResourceFactory{
+		spec:  sdkconfig.Spec{Kind: eventBusResourceKind, Impl: "test"},
+		value: event.NewMemoryBus(),
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := deployBuilder.RegisterResource(testResourceFactory{
+		spec: sdkconfig.Spec{Kind: toolconfig.ResourceKind, Impl: "yaml"},
+		value: buildExposureAssembly(t, &exposureSource{
+			names:    []string{"research_tool"},
+			exposure: dynamic.ExposureAlways,
+		}),
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := deployBuilder.RegisterResource(testResourceFactory{
+		spec: sdkconfig.Spec{Kind: toolconfig.ResourceKind, Impl: "test"},
+		value: buildExposureAssembly(t, &exposureSource{
+			names:    []string{"assist_tool"},
+			exposure: dynamic.ExposureAlways,
+		}),
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	var mu sync.Mutex
+	saw := map[string]sdktool.Catalog{}
+	builder := NewBuilder(deployBuilder)
+	if err := builder.WithHostFactory(func(base session.HostFactory) (session.HostFactory, error) {
+		return session.HostFactoryFunc(func(ctx context.Context, req session.HostRequest) (agent.Host, error) {
+			host, err := base.NewHost(ctx, req)
+			if err != nil {
+				return nil, err
+			}
+			if catalog, ok := sdktool.CatalogFromContext(ctx); ok {
+				mu.Lock()
+				saw[req.Key.AgentID] = catalog
+				mu.Unlock()
+			}
+			return host, nil
+		}), nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	runtime, err := builder.Build(context.Background(), dynamicCatalogDoc(t))
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	defer func() { _ = runtime.Close() }()
+
+	runTurn := func(agentID, contextID string) {
+		t.Helper()
+		lease, err := runtime.Sessions().Open(context.Background(), session.Key{
+			AgentID: agentID, ContextID: contextID,
+		})
+		if err != nil {
+			t.Fatalf("Open(%s): %v", agentID, err)
+		}
+		defer func() { _ = lease.Close() }()
+		turn, err := lease.Session().Start(context.Background(), agent.Request{})
+		if err != nil {
+			t.Fatalf("Start(%s): %v", agentID, err)
+		}
+		if _, err := turn.Wait(context.Background()); err != nil {
+			t.Fatalf("Wait(%s): %v", agentID, err)
+		}
+	}
+
+	runTurn("researcher", "conv")
+	runTurn("assistant", "conv")
+	// A second conversation of the same agent gets its own catalog.
+	runTurn("researcher", "other-conv")
+
+	mu.Lock()
+	defer mu.Unlock()
+	researchCat, ok := saw["researcher"].(*dynamic.Catalog)
+	if !ok {
+		t.Fatalf("researcher catalog type = %T, want *dynamic.Catalog", saw["researcher"])
+	}
+	assistCat, ok := saw["assistant"].(*dynamic.Catalog)
+	if !ok {
+		t.Fatalf("assistant catalog type = %T, want *dynamic.Catalog", saw["assistant"])
+	}
+	if researchCat == assistCat {
+		t.Fatal("agents share one catalog instance")
+	}
+
+	assertDefinitions := func(cat *dynamic.Catalog, want, notWant []string) {
+		t.Helper()
+		names := make(map[string]bool)
+		for _, def := range cat.Definitions() {
+			names[def.Name] = true
+		}
+		for _, name := range want {
+			if !names[name] {
+				t.Errorf("catalog definitions missing %q: %v", name, cat.Definitions())
+			}
+		}
+		for _, name := range notWant {
+			if names[name] {
+				t.Errorf("catalog unexpectedly contains %q", name)
+			}
+		}
+	}
+	assertDefinitions(researchCat,
+		[]string{"tool_search", "research_tool"}, []string{"assist_tool"})
+	assertDefinitions(assistCat,
+		[]string{"tool_search", "assist_tool"}, []string{"research_tool"})
+}
+
+func newDynamicDeployBuilder(t *testing.T) *deploy.Builder {
+	t.Helper()
+	deployBuilder := deploy.NewBuilder()
+	deployBuilder.MustRegisterEngine(testEngineFactory{engine: agent.EngineFunc(
+		func(_ context.Context, _ agent.Run, _ agent.Host, board *agent.Board) (*agent.Board, error) {
+			return board, nil
+		},
+	)})
+	if err := deployBuilder.RegisterResource(testResourceFactory{
+		spec:  sdkconfig.Spec{Kind: eventBusResourceKind, Impl: "test"},
+		value: event.NewMemoryBus(),
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := deployBuilder.RegisterResource(testResourceFactory{
+		spec: sdkconfig.Spec{Kind: toolconfig.ResourceKind, Impl: "yaml"},
+		value: buildExposureAssembly(t, &exposureSource{
+			names:    []string{"research_tool"},
+			exposure: dynamic.ExposureAlways,
+		}),
+	}); err != nil {
+		t.Fatal(err)
+	}
+	return deployBuilder
+}
+
+func TestBuild_DynamicCatalogRejectsBadMappings(t *testing.T) {
+	for name, tc := range map[string]struct {
+		runtimeYAML string
+		notFound    bool
+	}{
+		"missing resource": {`  event_bus: events
+  sessions:
+    dynamic_catalog:
+      tools: {researcher: nope}
+`, true},
+		"unknown agent": {`  event_bus: events
+  sessions:
+    dynamic_catalog:
+      tools: {ghost: research_tools}
+`, false},
+		"uncovered agent": {`  event_bus: events
+  sessions:
+    dynamic_catalog:
+      tools: {researcher: research_tools}
+`, false},
+	} {
+		t.Run(name, func(t *testing.T) {
+			doc, err := deploy.Parse([]byte(`version: v1
+resources:
+  events: {kind: event.Bus, impl: test}
+  research_tools: {kind: tool.Assembly, impl: yaml}
+agents:
+  researcher: {engine: {kind: test}}
+  assistant: {engine: {kind: test}}
+runtime:
+` + tc.runtimeYAML))
+			if err != nil {
+				t.Fatalf("deploy.Parse: %v", err)
+			}
+			_, err = NewBuilder(newDynamicDeployBuilder(t)).Build(
+				context.Background(), doc,
+			)
+			if err == nil {
+				t.Fatal("Build unexpectedly succeeded")
+			}
+			if tc.notFound && !errdefs.IsNotFound(err) {
+				t.Fatalf("Build error = %v, want NotFound", err)
+			}
+			if !tc.notFound && !errdefs.IsValidation(err) {
+				t.Fatalf("Build error = %v, want validation", err)
+			}
+		})
+	}
+}
+
+func TestBuild_DynamicCatalogDefaultCoversAgents(t *testing.T) {
+	deployBuilder := newDynamicDeployBuilder(t)
+	doc, err := deploy.Parse([]byte(`version: v1
+resources:
+  events: {kind: event.Bus, impl: test}
+  research_tools: {kind: tool.Assembly, impl: yaml}
+agents:
+  researcher: {engine: {kind: test}}
+  assistant: {engine: {kind: test}}
+runtime:
+  event_bus: events
+  sessions:
+    dynamic_catalog:
+      tools: {default: research_tools}
+`))
+	if err != nil {
+		t.Fatalf("deploy.Parse: %v", err)
+	}
+
+	runtime, err := NewBuilder(deployBuilder).Build(context.Background(), doc)
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	defer func() { _ = runtime.Close() }()
+
+	lease, err := runtime.Sessions().Open(context.Background(), session.Key{
+		AgentID: "assistant", ContextID: "conv",
+	})
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer func() { _ = lease.Close() }()
+	turn, err := lease.Session().Start(context.Background(), agent.Request{})
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	if _, err := turn.Wait(context.Background()); err != nil {
+		t.Fatalf("Wait: %v", err)
+	}
+}

--- a/sdkx/tool/dynamic/catalog.go
+++ b/sdkx/tool/dynamic/catalog.go
@@ -10,6 +10,15 @@ import (
 	sdktool "github.com/GizClaw/flowcraft/sdk/tool"
 )
 
+// ExposureSource is implemented by tool sources that can publish their
+// per-tool exposure metadata onto a session catalog after attachment.
+// The MCP source implements it; hosts and the runtime use it to carry
+// config-declared exposure declarations (server-level and per-tool)
+// into the injection view without importing the source package.
+type ExposureSource interface {
+	ApplyExposures(*Catalog) error
+}
+
 // Catalog is the session-scoped, model-facing view over a shared
 // tool.Registry. It implements the tool.Catalog contract with
 // Exposure-based injection:

--- a/skills/flowcraft-config/references/runtime.md
+++ b/skills/flowcraft-config/references/runtime.md
@@ -15,6 +15,13 @@ runtime:
     speculative_buffer_events: 1024   # default 1024, positive
     speculative_buffer_bytes: 1048576 # default 1 MiB, positive
     resume: false              # true requires checkpoint_store
+    dynamic_catalog:           # optional per-session dynamic tool catalog
+      tools: {default: tool_asm, researcher: research_tools}
+      default_exposure: deferred   # always|direct|deferred|hidden
+      exposures: {tool_search: always}
+      selected_retention: 5        # 0 uses the dynamic default (5)
+      recent_window: 10            # 0 uses the dynamic default (10)
+      budget: {max_definitions: 32, max_bytes: 16384}
   integrations:
     - name: delegation         # unique, required
       kind: delegation.local   # required
@@ -29,8 +36,21 @@ runtime:
   are exact resource map keys; runtime never discovers resources by kind.
 - Runtime references are external consumers during deploy assembly:
   those resources do not need `export: true`, but plain `deploy.Builder`
-  needs them passed via `WithExternalResourceConsumers`.
+  needs them passed via `WithExternalResourceConsumers`. Tool assemblies
+  named by `sessions.dynamic_catalog.tools` are runtime references too.
 - `sessions.resume: true` without `checkpoint_store` is an error.
+- `sessions.dynamic_catalog.tools` is a required map from agent IDs to
+  `tool.Assembly` resource names; the reserved `default` key is an
+  optional fallback. Every referenced resource must exist and have kind
+  `tool.Assembly`, every key must name a deployed agent (or `default`),
+  and every deployed agent must have an entry unless `default` is set.
+- `default_exposure` and `exposures` values must be one of
+  `always`/`direct`/`deferred`/`hidden`; retention/window/budget fields
+  must not be negative (zero means use the dynamic package default).
+- Runtime creates one catalog per `(AgentID, ContextID)` session over
+  the mapped assembly's shared registry, applies MCP source exposure
+  metadata, and registers `tool_search`. Inference nodes that use the
+  dynamic view should set `all_tools: true`.
 - `checkpoint_store` must name an `agent.CheckpointStore` resource
   (sqlite or workspace-backed).
 - Durations are Go duration strings (`10m`, `30s`); unitless numbers are


### PR DESCRIPTION
## What

Adds `runtime.sessions.dynamic_catalog` so the per-session dynamic tool catalog can be declared in config and wired automatically:

```yaml
runtime:
  event_bus: events
  sessions:
    dynamic_catalog:
      tools:
        default: shared_tools
        researcher: research_tools
        assistant: assistant_tools
      default_exposure: deferred
      exposures: {tool_search: always}
      selected_retention: 5
      recent_window: 10
      budget: {max_definitions: 32, max_bytes: 16384}
```

Each `(AgentID, ContextID)` session gets its own catalog over the mapped `tool.Assembly`'s shared registry. The runtime:

- registers `tool_search` automatically;
- applies MCP source exposure metadata (`ApplyExposures`) so config-declared `exposure`/`tools` in tools.yaml reach the catalog;
- applies `exposures` overrides as host-level policy;
- closes the catalog when the session closes.

## Changes

- `sdk/tool/config`: expose `Assembly.Registry()` and `Assembly.Sources()` so the dynamic layer can share the executor's registry and reach source exposure metadata.
- `sdkx/tool/dynamic`: add the neutral `ExposureSource` interface (the MCP source already satisfies it).
- `sdkx/runtime`: strict `dynamic_catalog` config parsing/validation, per-agent tool resource resolution (agent coverage + unknown-key checks), and automatic `session.CatalogProvider` wiring.
- Docs: runtime guide + flowcraft-config reference card.
- Release: new immutable changesets for the coordinated `sdk` + `sdkx` batch; `sdkx` requires the planned `sdk v0.5.4` (preflight-tidied).

## Planned tags

- `sdk/v0.5.4`
- `sdkx/v0.5.6`

## Checks

- `make ci` ✅
- `make lint` ✅ (0 issues on sdk/memory/memory-eval/sdkx)
- `make release-check` ✅ (changesets valid, plan matches)
- `make release-preflight` / `-write` ✅
- `git diff --check` ✅