### PR TITLE
feat(sdk,sdkx): declarative sandbox-backed exec builtins

### DIFF
--- a/.release/sdk-tool-sandbox-patch.json
+++ b/.release/sdk-tool-sandbox-patch.json
@@ -1,0 +1,9 @@
+{
+  "summary": "tool.Assembly declares an optional sandbox.Runner dep forwarded to source factories, and builtin tools can be registered as per-build factories (RegisterBuiltinFactory) that consume resource deps",
+  "releases": [
+    {
+      "module": "sdk",
+      "bump": "patch"
+    }
+  ]
+}

--- a/.release/sdkx-tool-exec-builtin-patch.json
+++ b/.release/sdkx-tool-exec-builtin-patch.json
@@ -1,0 +1,9 @@
+{
+  "summary": "sdkx/tool/exec adds RegisterBuiltin, wiring sandbox-backed exec and exec_session builtin factories that consume the tool.Assembly sandbox dep",
+  "releases": [
+    {
+      "module": "sdkx",
+      "bump": "patch"
+    }
+  ]
+}

--- a/docs/guides/deploy.md
+++ b/docs/guides/deploy.md
@@ -317,7 +317,7 @@ explicit external consumer is dead configuration and fails the build.
 | `workspace.Registry`      | `yaml`          | workspace container             | `sdk/workspace/config`         |
 | `sandbox.Registry`        | `yaml`          | sandbox container               | `sdk/sandbox/config`            |
 | `inference.Assembly`      | `yaml`          | runtime (+ optional router)     | `sdk/inference/config`    |
-| `tool.Assembly`           | `yaml`          | catalog + executor              | `sdk/tool/config`              |
+| `tool.Assembly`           | `yaml`          | catalog + executor; optional `sandbox` dep for sandbox-backed exec | `sdk/tool/config` |
 | `agent.ScriptRuntime`     | `js`            | JavaScript runtime              | `sdkx/agent/script/jsrt`        |
 | `agent.ScriptRuntime`     | `lua`           | Lua runtime                     | `sdkx/agent/script/luart`       |
 | `agent.Engine`            | `a2a`           | A2A remote-proxy engine (0.3 + 1.0, JSON-RPC + gRPC) | `sdkx/agent/a2a/config`          |

--- a/docs/guides/tool.md
+++ b/docs/guides/tool.md
@@ -235,16 +235,23 @@ toolBuilder := toolconfig.NewBuilder(toolconfig.Deps{
     Approver:  approver,
     AuditSink: auditSink,
 })
-toolBuilder.RegisterBuiltins(searchTool{}, execTool{})
+exec.RegisterBuiltin(toolBuilder) // sandbox-backed exec / exec_session
 
 builder.MustRegisterResource(toolconfig.NewDeployFactory(toolBuilder))
 ```
 
 ```yaml
 resources:
+  boxes:
+    kind: sandbox.Registry
+    impl: yaml
+    settings:
+      file: ./sandboxes.yaml
   tools:
     kind: tool.Assembly
     impl: yaml
+    deps:
+      sandbox: boxes/coding
     settings:
       file: ./tools.yaml
 ```
@@ -255,7 +262,7 @@ version: v1
 sources:
   - kind: builtin
     spec:
-      tools: [search, exec]
+      tools: [exec, exec_session]
 middlewares:
   - kind: recover
   - kind: telemetry
@@ -269,10 +276,18 @@ scopes: { exec: platform }
 ```
 
 The `builtin` source resolves hand-written Go tools from the builder's
-catalog; naming a tool that was not registered fails the build. Built-in
-middleware kinds map 1:1 to the constructors in `sdk/tool/middleware`. Custom
-kinds register on the `Builder` via `RegisterFactory`; external sources (e.g.
-MCP) register via `RegisterSourceFactory`.
+catalog; naming a tool that was not registered fails the build. Tools may be
+registered either as pre-constructed values (`RegisterBuiltin`) or as
+per-build factories (`RegisterBuiltinFactory`). `exec.RegisterBuiltin` uses
+the factory form: the tool is built once per assembly from the
+`tool.Assembly` resource's `sandbox` dep, so the deployment document decides
+which sandbox `exec` and `exec_session` run under. Naming a factory-backed
+tool without binding the `sandbox` dep fails the build.
+
+Built-in middleware kinds map 1:1 to the constructors in
+`sdk/tool/middleware`. Custom kinds register on the `Builder` via
+`RegisterFactory`; external sources (e.g. MCP) register via
+`RegisterSourceFactory`.
 
 A graph engine binds a `tool.Assembly` through its `tools` dep and the
 executor becomes the dispatch target for `tool` nodes and for inference-driven

--- a/sdk/tool/config/builder.go
+++ b/sdk/tool/config/builder.go
@@ -40,10 +40,11 @@ const RegistryDep = "registry"
 // of the tool surface. No global registration: two Builders in one
 // process stay independent.
 type Builder struct {
-	deps            Deps
-	builtins        map[string]tool.Tool
-	middlewares     *sdkconfig.Registry[sdkconfig.Input, tool.Middleware]
-	sourceFactories map[string]SourceFactory
+	deps             Deps
+	builtins         map[string]tool.Tool
+	builtinFactories map[string]BuiltinFactory
+	middlewares      *sdkconfig.Registry[sdkconfig.Input, tool.Middleware]
+	sourceFactories  map[string]SourceFactory
 }
 
 // NewBuilder returns a Builder with the built-in middleware factories
@@ -52,10 +53,11 @@ type Builder struct {
 // dependency.
 func NewBuilder(deps Deps) *Builder {
 	b := &Builder{
-		deps:            deps,
-		builtins:        make(map[string]tool.Tool),
-		middlewares:     sdkconfig.NewRegistry[sdkconfig.Input, tool.Middleware](),
-		sourceFactories: make(map[string]SourceFactory),
+		deps:             deps,
+		builtins:         make(map[string]tool.Tool),
+		builtinFactories: make(map[string]BuiltinFactory),
+		middlewares:      sdkconfig.NewRegistry[sdkconfig.Input, tool.Middleware](),
+		sourceFactories:  make(map[string]SourceFactory),
 	}
 	b.registerBuiltins()
 	b.sourceFactories[BuiltinKind] = b.builtinSourceFactory
@@ -77,6 +79,10 @@ func (b *Builder) RegisterBuiltin(t tool.Tool) {
 	if _, exists := b.builtins[name]; exists {
 		panic(fmt.Sprintf("config.RegisterBuiltin: tool %q is already registered", name))
 	}
+	if _, exists := b.builtinFactories[name]; exists {
+		panic(fmt.Sprintf(
+			"config.RegisterBuiltin: tool %q is already registered as a builtin factory", name))
+	}
 	b.builtins[name] = t
 }
 
@@ -85,6 +91,38 @@ func (b *Builder) RegisterBuiltins(tools ...tool.Tool) {
 	for _, t := range tools {
 		b.RegisterBuiltin(t)
 	}
+}
+
+// RegisterBuiltinFactory adds a hand-written Go tool factory to the
+// builtin catalog. Unlike [RegisterBuiltin]'s pre-constructed tools, a
+// factory is invoked once per Build with the source's [sdkconfig.Input],
+// so it can consume resource-level deps — for example the sandbox
+// runner bound through a tool.Assembly resource:
+//
+//	builder.RegisterBuiltinFactory("exec", func(_ context.Context, in sdkconfig.Input) (tool.Tool, error) {
+//	    runner, ok := in.Dep(DepSandbox).(sandbox.Runner)
+//	    ...
+//	})
+//
+// The document enables it by name through a builtin source entry, the
+// same way it enables constructed tools. Nil factories, empty names,
+// and duplicates (against either catalog) are programming bugs.
+func (b *Builder) RegisterBuiltinFactory(name string, factory BuiltinFactory) {
+	if name == "" {
+		panic("config.RegisterBuiltinFactory: name is empty")
+	}
+	if factory == nil {
+		panic(fmt.Sprintf("config.RegisterBuiltinFactory: factory for %q is nil", name))
+	}
+	if _, exists := b.builtins[name]; exists {
+		panic(fmt.Sprintf(
+			"config.RegisterBuiltinFactory: tool %q is already registered as a builtin", name))
+	}
+	if _, exists := b.builtinFactories[name]; exists {
+		panic(fmt.Sprintf(
+			"config.RegisterBuiltinFactory: factory for %q is already registered", name))
+	}
+	b.builtinFactories[name] = factory
 }
 
 // RegisterFactory adds a factory for kind. Empty kinds, nil factories,
@@ -174,11 +212,20 @@ func (a *Assembly) Close() error {
 // whatever already attached, so an error never leaves child processes
 // behind.
 func (b *Builder) Build(ctx context.Context, doc Document) (*Assembly, error) {
+	return b.build(ctx, doc, nil)
+}
+
+// build assembles the Executor and the Registry. deps carries the
+// resource-level dependencies (declared by [Builder.Spec] and resolved
+// by a deployment engine) down to every source factory, so a builtin
+// factory can reach values the document cannot express — the sandbox
+// runner behind exec, for example.
+func (b *Builder) build(ctx context.Context, doc Document, deps map[string]any) (*Assembly, error) {
 	if err := doc.Validate(); err != nil {
 		return nil, err
 	}
 	registry := tool.NewRegistry()
-	sources, err := b.buildSources(ctx, doc.Sources, registry)
+	sources, err := b.buildSources(ctx, doc.Sources, registry, deps)
 	if err != nil {
 		return nil, err
 	}

--- a/sdk/tool/config/doc.go
+++ b/sdk/tool/config/doc.go
@@ -35,7 +35,8 @@
 // before anything else so their tools are in the registry by the time
 // scopes and middleware name them. The builtin source kind is
 // registered by default and resolves hand-written Go tools the host
-// registered on the Builder:
+// registered on the Builder — either pre-constructed values via
+// RegisterBuiltin, or per-build factories via RegisterBuiltinFactory:
 //
 //	sources:
 //	  - kind: builtin
@@ -48,6 +49,24 @@
 // External source kinds are opt-in through
 // [Builder.RegisterSourceFactory], since each pulls in an external
 // dependency.
+//
+// # Resource deps
+//
+// The tool.Assembly deployment resource declares one optional
+// dependency, DepSandbox (type "sandbox.Runner"), so a deployment can
+// bind a sandbox out of a sandbox.Registry:
+//
+//	resources:
+//	  tools:
+//	    kind: tool.Assembly
+//	    impl: yaml
+//	    deps: {sandbox: boxes/main}
+//	    settings: {file: ./tools.yaml}
+//
+// The resolved value is carried in every source factory's Input.Deps.
+// Builtin factories that build command tools (sdkx/tool/exec's
+// sandbox-backed exec / exec_session) consume it there; source kinds
+// that do not need it simply ignore the key.
 //
 // Sources are live resources — child processes, HTTP sessions — so
 // Build returns an Assembly rather than a bare Executor, and the caller

--- a/sdk/tool/config/resource.go
+++ b/sdk/tool/config/resource.go
@@ -12,9 +12,38 @@ import (
 // so consumers take the whole assembly rather than one item out of it.
 const ResourceKind = "tool.Assembly"
 
+// DepSandbox is the optional resource-level dependency carrying the
+// sandbox.Runner command tools are built over. It is declared so a
+// deployment can bind one sandbox out of a sandbox.Registry:
+//
+//	resources:
+//	  boxes:
+//	    kind: sandbox.Registry
+//	    impl: yaml
+//	    settings: {file: ./sandboxes.yaml}
+//	  tools:
+//	    kind: tool.Assembly
+//	    impl: yaml
+//	    deps: {sandbox: boxes/main}
+//	    settings: {file: ./tools.yaml}
+//
+// The value is passed to every source factory's Input.Deps; builtin
+// tool factories (e.g. sdkx/tool/exec's sandbox-backed exec) consume
+// it there. It is optional: an assembly that only wires MCP servers or
+// host-constructed tools does not need it.
+const DepSandbox = "sandbox"
+
 // Spec implements config.Factory.
 func (b *Builder) Spec() config.Spec {
-	return config.Spec{Kind: ResourceKind, Impl: "yaml"}
+	return config.Spec{
+		Kind: ResourceKind,
+		Impl: "yaml",
+		Deps: []config.DepSpec{{
+			Name:     DepSandbox,
+			Type:     "sandbox.Runner",
+			Required: false,
+		}},
+	}
 }
 
 // New implements config.Factory: the settings subtree is the tool
@@ -33,5 +62,5 @@ func (b *Builder) New(ctx context.Context, in config.Input) (any, error) {
 	if err != nil {
 		return nil, err
 	}
-	return b.Build(ctx, doc)
+	return b.build(ctx, doc, in.Deps)
 }

--- a/sdk/tool/config/resource_test.go
+++ b/sdk/tool/config/resource_test.go
@@ -3,10 +3,13 @@ package config_test
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"reflect"
+	"strings"
 	"testing"
 
 	sdkconfig "github.com/GizClaw/flowcraft/sdk/config"
+	"github.com/GizClaw/flowcraft/sdk/tool"
 	"github.com/GizClaw/flowcraft/sdk/tool/config"
 )
 
@@ -15,9 +18,67 @@ func TestDeployFactorySpec(t *testing.T) {
 	want := sdkconfig.Spec{
 		Kind: config.ResourceKind,
 		Impl: "yaml",
+		Deps: []sdkconfig.DepSpec{{
+			Name:     config.DepSandbox,
+			Type:     "sandbox.Runner",
+			Required: false,
+		}},
 	}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("Spec() = %+v, want %+v", got, want)
+	}
+}
+
+func TestDeployFactoryNewPassesDepsToBuiltinFactories(t *testing.T) {
+	factory := config.NewBuilder(config.Deps{})
+	var got any
+	factory.RegisterBuiltinFactory("made", func(
+		_ context.Context,
+		in sdkconfig.Input,
+	) (tool.Tool, error) {
+		got, _ = in.Dep(config.DepSandbox)
+		return echoTool("made"), nil
+	})
+	value, err := factory.New(context.Background(), sdkconfig.Input{
+		Resolve: resolveLiteral(t),
+		Settings: literalSettings(t, `{
+			"version": "v1",
+			"sources": [{"kind": "builtin", "spec": {"tools": ["made"]}}]
+		}`),
+		Deps: map[string]any{config.DepSandbox: "the-runner"},
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	assembly := value.(*config.Assembly)
+	if _, ok := assembly.Catalog.Get("made"); !ok {
+		t.Fatal("builtin factory tool missing from catalog")
+	}
+	if got != "the-runner" {
+		t.Fatalf("factory dep = %#v, want %q", got, "the-runner")
+	}
+}
+
+func TestDeployFactoryNewBuiltinFactoryErrorsPropagate(t *testing.T) {
+	factory := config.NewBuilder(config.Deps{})
+	factory.RegisterBuiltinFactory("needy", func(
+		_ context.Context,
+		in sdkconfig.Input,
+	) (tool.Tool, error) {
+		if _, ok := in.Dep(config.DepSandbox); !ok {
+			return nil, errors.New("needs sandbox dep")
+		}
+		return echoTool("needy"), nil
+	})
+	_, err := factory.New(context.Background(), sdkconfig.Input{
+		Resolve: resolveLiteral(t),
+		Settings: literalSettings(t, `{
+			"version": "v1",
+			"sources": [{"kind": "builtin", "spec": {"tools": ["needy"]}}]
+		}`),
+	})
+	if err == nil || !strings.Contains(err.Error(), "needs sandbox dep") {
+		t.Fatalf("New error = %v, want missing-dep failure", err)
 	}
 }
 

--- a/sdk/tool/config/source.go
+++ b/sdk/tool/config/source.go
@@ -48,6 +48,13 @@ type Source interface {
 // fail at build time, not silently drop a server.
 type SourceFactory func(ctx context.Context, in sdkconfig.Input) (Source, error)
 
+// BuiltinFactory constructs one hand-written Go tool at Build time from
+// the builtin source's [sdkconfig.Input]. The input carries the same
+// resource-level Deps the enclosing tool.Assembly resource was bound
+// with, so a tool like exec can reach a sandbox.Runner without the
+// document encoding live objects.
+type BuiltinFactory = sdkconfig.Func[sdkconfig.Input, tool.Tool]
+
 // SourceEntry is one attachment declared in the document: a factory
 // kind plus its opaque spec. Spec stays an undecoded JSON subtree so
 // each factory owns its own schema.
@@ -92,18 +99,35 @@ func (b *Builder) builtinSourceFactory(_ context.Context, in sdkconfig.Input) (S
 			"builtin source: tools must name at least one tool")
 	}
 	return &builtinSource{
-		catalog: b.builtins,
-		names:   append([]string(nil), spec.Tools...),
+		catalog:   b.builtins,
+		factories: b.builtinFactories,
+		deps:      in.Deps,
+		names:     append([]string(nil), spec.Tools...),
 	}, nil
 }
 
 type builtinSource struct {
-	catalog map[string]tool.Tool
-	names   []string
+	catalog   map[string]tool.Tool
+	factories map[string]BuiltinFactory
+	deps      map[string]any
+	names     []string
 }
 
-func (s *builtinSource) Attach(_ context.Context, registry *tool.Registry) error {
+func (s *builtinSource) Attach(ctx context.Context, registry *tool.Registry) error {
 	for _, name := range s.names {
+		if factory, ok := s.factories[name]; ok {
+			registered, err := factory(ctx, sdkconfig.Input{Deps: s.deps})
+			if err != nil {
+				return fmt.Errorf(
+					"builtin source: build builtin tool %q: %w", name, err)
+			}
+			if isNilTool(registered) {
+				return errdefs.Validationf(
+					"builtin source: factory for builtin tool %q returned a nil tool", name)
+			}
+			registry.Register(registered)
+			continue
+		}
 		registered, ok := s.catalog[name]
 		if !ok {
 			return errdefs.Validationf(
@@ -124,7 +148,12 @@ func (s *builtinSource) Close() error { return nil }
 // running or half a server's tools in the registry. That is why Build
 // returns the attached sources on success: the caller must close them,
 // and there is no other handle to them.
-func (b *Builder) buildSources(ctx context.Context, entries []SourceEntry, registry *tool.Registry) ([]Source, error) {
+func (b *Builder) buildSources(
+	ctx context.Context,
+	entries []SourceEntry,
+	registry *tool.Registry,
+	deps map[string]any,
+) ([]Source, error) {
 	attached := make([]Source, 0, len(entries))
 	closeAttached := func() {
 		for _, a := range slices.Backward(attached) {
@@ -140,7 +169,10 @@ func (b *Builder) buildSources(ctx context.Context, entries []SourceEntry, regis
 					"(register it with Builder.RegisterSourceFactory)", i, entry.Kind,
 			))
 		}
-		source, err := factory(ctx, sdkconfig.Input{Settings: entry.Spec})
+		source, err := factory(ctx, sdkconfig.Input{
+			Settings: entry.Spec,
+			Deps:     deps,
+		})
 		if err != nil {
 			closeAttached()
 			return nil, fmt.Errorf(

--- a/sdkx/go.mod
+++ b/sdkx/go.mod
@@ -2,7 +2,7 @@ module github.com/GizClaw/flowcraft/sdkx
 
 go 1.26.0
 
-require github.com/GizClaw/flowcraft/sdk v0.5.4
+require github.com/GizClaw/flowcraft/sdk v0.5.5
 
 require (
 	github.com/GizClaw/doubao-speech-go v0.0.0-20260723152315-fe8153366feb

--- a/sdkx/tool/exec/builtin.go
+++ b/sdkx/tool/exec/builtin.go
@@ -1,0 +1,91 @@
+package exec
+
+import (
+	"context"
+
+	sdkconfig "github.com/GizClaw/flowcraft/sdk/config"
+	"github.com/GizClaw/flowcraft/sdk/errdefs"
+	"github.com/GizClaw/flowcraft/sdk/sandbox"
+	sdktool "github.com/GizClaw/flowcraft/sdk/tool"
+	toolconfig "github.com/GizClaw/flowcraft/sdk/tool/config"
+)
+
+// RegisterBuiltin wires the sandbox-backed exec and exec_session tools
+// into a tool config builder as builtin factories. Unlike a
+// pre-constructed builtin, each factory runs once per Build and pulls
+// the sandbox runner out of the tool.Assembly resource's deps, so the
+// deployment document owns which sandbox the tools execute under:
+//
+//	// host wiring
+//	exec.RegisterBuiltin(toolBuilder)
+//	deployBuilder.MustRegisterResource(toolBuilder)
+//
+//	// deploy.yaml
+//	resources:
+//	  boxes:
+//	    kind: sandbox.Registry
+//	    impl: yaml
+//	    settings: {file: ./sandboxes.yaml}
+//	  tools:
+//	    kind: tool.Assembly
+//	    impl: yaml
+//	    deps: {sandbox: boxes/main}
+//	    settings: {file: ./tools.yaml}
+//
+//	// tools.yaml
+//	version: v1
+//	sources:
+//	  - kind: builtin
+//	    spec: {tools: [exec, exec_session]}
+//
+// The exec factory fails closed when the sandbox dep is absent or not
+// a sandbox.Runner. exec_session additionally requires the runner to
+// implement sandbox.ProcessManager (local, bwrap, and seatbelt runners
+// all do); a runner without sessions fails with NotAvailable when the
+// document names it. Duplicate registration is a programming bug and
+// panics inside the builder.
+func RegisterBuiltin(b *toolconfig.Builder) {
+	b.RegisterBuiltinFactory(Name, execFactory)
+	b.RegisterBuiltinFactory(SessionName, sessionFactory)
+}
+
+func execFactory(_ context.Context, in sdkconfig.Input) (sdktool.Tool, error) {
+	runner, err := sandboxRunner(in)
+	if err != nil {
+		return nil, err
+	}
+	return New(runner)
+}
+
+func sessionFactory(_ context.Context, in sdkconfig.Input) (sdktool.Tool, error) {
+	runner, err := sandboxRunner(in)
+	if err != nil {
+		return nil, err
+	}
+	pm := sandbox.ProcessManagerOf(runner)
+	if pm == nil {
+		return nil, errdefs.NotAvailablef(
+			"exec: sandbox runner does not implement ProcessManager; %s requires an interactive-capable backend",
+			SessionName)
+	}
+	return NewSession(pm)
+}
+
+// sandboxRunner resolves the tool.Assembly resource's sandbox dep. It
+// is deliberately strict: an exec tool without a runner would be a
+// host-shell fallback, which this package never allows.
+func sandboxRunner(in sdkconfig.Input) (sandbox.Runner, error) {
+	value, ok := in.Dep(toolconfig.DepSandbox)
+	if !ok {
+		return nil, errdefs.Validationf(
+			"exec builtin: tool.Assembly resource dep %q is not bound; declare deps: {sandbox: boxes/<name>}",
+			toolconfig.DepSandbox)
+	}
+	runner, ok := value.(sandbox.Runner)
+	if !ok {
+		return nil, errdefs.Validationf(
+			"exec builtin: tool.Assembly dep %q is %T, want sandbox.Runner",
+			toolconfig.DepSandbox, value)
+	}
+	return runner, nil
+}

--- a/sdkx/tool/exec/builtin_test.go
+++ b/sdkx/tool/exec/builtin_test.go
@@ -1,0 +1,137 @@
+package exec_test
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	sdkconfig "github.com/GizClaw/flowcraft/sdk/config"
+	"github.com/GizClaw/flowcraft/sdk/errdefs"
+	"github.com/GizClaw/flowcraft/sdk/sandbox"
+	toolconfig "github.com/GizClaw/flowcraft/sdk/tool/config"
+	"github.com/GizClaw/flowcraft/sdkx/tool/exec"
+)
+
+func builtinDoc(tools ...string) string {
+	quoted := make([]string, 0, len(tools))
+	for _, name := range tools {
+		quoted = append(quoted, `"`+name+`"`)
+	}
+	return `{"version":"v1","sources":[{"kind":"builtin","spec":{"tools":[` +
+		strings.Join(quoted, ",") + `]}}]}`
+}
+
+func TestRegisterBuiltin_ExecRunsThroughSandboxDep(t *testing.T) {
+	builder := toolconfig.NewBuilder(toolconfig.Deps{})
+	exec.RegisterBuiltin(builder)
+	runner := &fakeRunner{
+		retResult: &sandbox.ExecResult{ExitCode: 0, Stdout: "hello"},
+	}
+	value, err := builder.New(context.Background(), sdkconfig.Input{
+		Resolve:  resolveLiteral(t),
+		Settings: literalSettings(t, builtinDoc("exec")),
+		Deps:     map[string]any{toolconfig.DepSandbox: runner},
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	assembly := value.(*toolconfig.Assembly)
+	execTool, ok := assembly.Catalog.Get(exec.Name)
+	if !ok {
+		t.Fatal("exec missing from catalog")
+	}
+	out, err := execTool.Execute(
+		context.Background(),
+		`{"command":"ls","args":["-la"]}`)
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if !strings.Contains(out, "hello") {
+		t.Fatalf("Execute output = %q, want runner result", out)
+	}
+	if runner.gotCmd != "ls" {
+		t.Fatalf("runner command = %q, want ls", runner.gotCmd)
+	}
+}
+
+func TestRegisterBuiltin_SessionWithProcessManager(t *testing.T) {
+	builder := toolconfig.NewBuilder(toolconfig.Deps{})
+	exec.RegisterBuiltin(builder)
+	value, err := builder.New(context.Background(), sdkconfig.Input{
+		Resolve:  resolveLiteral(t),
+		Settings: literalSettings(t, builtinDoc("exec", "exec_session")),
+		Deps: map[string]any{
+			toolconfig.DepSandbox: sandbox.NewLocalRunner(t.TempDir()),
+		},
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	assembly := value.(*toolconfig.Assembly)
+	sessionTool, ok := assembly.Catalog.Get(exec.SessionName)
+	if !ok {
+		t.Fatal("exec_session missing from catalog")
+	}
+	t.Cleanup(func() {
+		_ = sessionTool.(interface{ Close() error }).Close()
+	})
+}
+
+func TestRegisterBuiltin_MissingSandboxDepFailsClosed(t *testing.T) {
+	builder := toolconfig.NewBuilder(toolconfig.Deps{})
+	exec.RegisterBuiltin(builder)
+	_, err := builder.New(context.Background(), sdkconfig.Input{
+		Resolve:  resolveLiteral(t),
+		Settings: literalSettings(t, builtinDoc("exec")),
+	})
+	if err == nil || !errdefs.IsValidation(err) ||
+		!strings.Contains(err.Error(), "sandbox") {
+		t.Fatalf("New error = %v, want missing sandbox dep validation", err)
+	}
+}
+
+func TestRegisterBuiltin_WrongDepTypeFailsClosed(t *testing.T) {
+	builder := toolconfig.NewBuilder(toolconfig.Deps{})
+	exec.RegisterBuiltin(builder)
+	_, err := builder.New(context.Background(), sdkconfig.Input{
+		Resolve:  resolveLiteral(t),
+		Settings: literalSettings(t, builtinDoc("exec")),
+		Deps:     map[string]any{toolconfig.DepSandbox: "not-a-runner"},
+	})
+	if err == nil || !errdefs.IsValidation(err) ||
+		!strings.Contains(err.Error(), "sandbox.Runner") {
+		t.Fatalf("New error = %v, want wrong dep type validation", err)
+	}
+}
+
+func TestRegisterBuiltin_SessionRequiresProcessManager(t *testing.T) {
+	builder := toolconfig.NewBuilder(toolconfig.Deps{})
+	exec.RegisterBuiltin(builder)
+	_, err := builder.New(context.Background(), sdkconfig.Input{
+		Resolve:  resolveLiteral(t),
+		Settings: literalSettings(t, builtinDoc("exec_session")),
+		Deps: map[string]any{
+			toolconfig.DepSandbox: &fakeRunner{},
+		},
+	})
+	if err == nil || !errdefs.IsNotAvailable(err) {
+		t.Fatalf("New error = %v, want NotAvailable for runner without sessions", err)
+	}
+}
+
+func literalSettings(t *testing.T, doc string) json.RawMessage {
+	t.Helper()
+	raw, err := json.Marshal(doc)
+	if err != nil {
+		t.Fatalf("marshal literal settings: %v", err)
+	}
+	return json.RawMessage(raw)
+}
+
+func resolveLiteral(t *testing.T) func(context.Context, sdkconfig.Source) ([]byte, error) {
+	t.Helper()
+	return func(ctx context.Context, src sdkconfig.Source) ([]byte, error) {
+		return sdkconfig.NewLoader().Load(ctx, src)
+	}
+}

--- a/sdkx/tool/exec/doc.go
+++ b/sdkx/tool/exec/doc.go
@@ -116,4 +116,31 @@
 // The same sandbox can be shared with the script-engine shell bridge,
 // host-application sandbox resources, and the sdkx/sandbox/{seatbelt,
 // bwrap} backends without changing these tools' call sites.
+//
+// # Declarative wiring
+//
+// Hosts that assemble through sdk/tool/config can register both tools
+// as builtin factories with [RegisterBuiltin]. Each factory is invoked
+// once per assembly and reads the sandbox runner out of the
+// tool.Assembly resource's `sandbox` dep, so the deployment document
+// chooses which sandbox the tools execute under instead of the host
+// hard-wiring one:
+//
+//	exec.RegisterBuiltin(toolBuilder)
+//
+//	resources:
+//	  tools:
+//	    kind: tool.Assembly
+//	    impl: yaml
+//	    deps: {sandbox: boxes/coding}
+//	    settings: {file: ./tools.yaml}
+//
+//	tools.yaml:
+//	  sources:
+//	    - kind: builtin
+//	      spec: {tools: [exec, exec_session]}
+//
+// The exec factory fails closed when the dep is missing or not a
+// sandbox.Runner; exec_session additionally fails with NotAvailable
+// when the runner has no ProcessManager.
 package exec

--- a/skills/flowcraft-config/references/deploy.md
+++ b/skills/flowcraft-config/references/deploy.md
@@ -79,7 +79,7 @@ unknown fields.
 | `workspace.Registry` | `yaml` | container, item `workspace.Workspace` | `sdk/workspace/config` |
 | `sandbox.Registry` | `yaml` | container, item `sandbox.Runner` | `sdk/sandbox/config` |
 | `inference.Assembly` | `yaml` | runtime + optional router, item `inference.Runtime` | `sdk/inference/config` |
-| `tool.Assembly` | `yaml` | catalog + executor | `sdk/tool/config` |
+| `tool.Assembly` | `yaml` | catalog + executor; optional `deps.sandbox` (`sandbox.Runner`) for sandbox-backed exec tools | `sdk/tool/config` |
 | `event.Bus` | `memory` | in-process bus | `sdk/event/config` |
 | `agent.ScriptRuntime` | `js` / `lua` | script runtime | `sdkx/agent/script/{jsrt,luart}` |
 | `scheduler.Server` | `local` | unstarted scheduler server | `sdk/scheduler/config` + `sdkx/scheduler` |

--- a/skills/flowcraft-config/references/resources.md
+++ b/skills/flowcraft-config/references/resources.md
@@ -129,6 +129,13 @@ scopes:
 Unknown source/middleware kinds and unknown builtin tool names fail Build.
 `agent.tools` allow-lists are runtime policy gates, not build-time checks.
 
+Sandbox-backed command tools (`exec`, `exec_session`) register on the tool
+builder with `exec.RegisterBuiltin(toolBuilder)`. The tool resource then
+declares the optional `deps: {sandbox: boxes/<name>}` binding to a
+`sandbox.Registry` item; the tools are built from that runner per assembly
+and the build fails closed when the dep is missing or not a
+`sandbox.Runner`.
+
 ## Other first-party settings
 
 - `event.Bus/memory`: `route_cache_size` — 0 disables cache, negative keeps

--- a/tools/releasegate/main.go
+++ b/tools/releasegate/main.go
@@ -436,6 +436,13 @@ func stripPreflightReplaces(content []byte, paths map[string]bool) []byte {
 		}
 		out = append(out, line)
 	}
+	// The preflight replace block is appended after a leading newline, so
+	// stripping it leaves a blank line that plain `go mod tidy` would not
+	// write. Drop the extra trailing empty lines, keeping the one that
+	// represents the final newline, so --write output matches tidy.
+	for len(out) > 1 && out[len(out)-1] == "" && out[len(out)-2] == "" {
+		out = out[:len(out)-1]
+	}
 	return []byte(strings.Join(out, "\n"))
 }
 

--- a/tools/releasegate/main_test.go
+++ b/tools/releasegate/main_test.go
@@ -243,6 +243,12 @@ func TestPreflightDetectsAndWritesSameBatchTidy(t *testing.T) {
 	if strings.Contains(string(sdkxMod), "replace github.com/GizClaw/flowcraft/sdk") {
 		t.Fatalf("preflight replace leaked into go.mod:\n%s", sdkxMod)
 	}
+	if strings.HasSuffix(string(sdkxMod), "\n\n") {
+		t.Fatalf("preflight write left a blank line at EOF:\n%s", sdkxMod)
+	}
+	if !strings.HasSuffix(string(sdkxMod), "\n") {
+		t.Fatalf("preflight write must end with a newline:\n%s", sdkxMod)
+	}
 
 	stdout.Reset()
 	stderr.Reset()


### PR DESCRIPTION
## What

Makes the `exec` / `exec_session` tools declaratively bound to a sandbox resource in deployment documents.

- `tool.Assembly` now declares an optional `sandbox` dep (`sandbox.Runner`), resolved by the deploy engine from a `sandbox.Registry` item and forwarded to every source factory's `Input.Deps`.
- `sdk/tool/config` adds `RegisterBuiltinFactory`: builtin tools can be built per assembly from resource deps (pre-constructed `RegisterBuiltin` remains supported; the two registries are mutually exclusive per name).
- `sdkx/tool/exec` adds `exec.RegisterBuiltin`, wiring `exec` and `exec_session` to the sandbox runner from the dep. Missing/wrong-typed dep fails the build (Validation); `exec_session` without a `ProcessManager`-capable runner fails with `NotAvailable`.

```yaml
resources:
  boxes:
    kind: sandbox.Registry
    impl: yaml
    settings: { file: ./sandboxes.yaml }
  tools:
    kind: tool.Assembly
    impl: yaml
    deps: { sandbox: boxes/coding }
    settings: { file: ./tools.yaml }
```

```yaml
# tools.yaml
version: v1
sources:
  - kind: builtin
    spec: { tools: [exec, exec_session] }
```

## Release prep

Adds changesets for coordinated patch releases: `sdk v0.5.5` and `sdkx v0.5.7` (sdkx `go.mod` preflight-tidied against the same-batch version).

Also fixes `releasegate preflight --write`, which left a trailing blank line in `go.mod` after stripping the temporary same-batch replace block, so its output differs from plain `go mod tidy` and fails `git diff --check`.

## Checks

- `make ci` — pass
- `make lint` — 0 issues
- `make release-check` / `make release-plan` / `make release-preflight` — pass (sdk 0.5.4 → 0.5.5, sdkx 0.5.6 → 0.5.7)
- `git diff --check` — clean

Follow-up (after this release lands): wire `exec.RegisterBuiltin` into the flowcraft-config validator and bump its pinned module versions.