### PR TITLE
test(inference): add conformance suites and wire all drivers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,49 +14,24 @@ permissions:
   contents: read
 
 jobs:
-  detect:
-    name: Detect changes
-    runs-on: ubuntu-latest
-    outputs:
-      core: ${{ steps.filter.outputs.core }}
-      drivers: ${{ steps.filter.outputs.drivers }}
-      backends: ${{ steps.filter.outputs.backends }}
-      memory: ${{ steps.filter.outputs.memory }}
-      ci: ${{ steps.filter.outputs.ci }}
-    steps:
-      - uses: actions/checkout@v4
-      - uses: dorny/paths-filter@v3
-        id: filter
-        with:
-          filters: |
-            core:
-              - 'core/**'
-            drivers:
-              - 'driver/**'
-            backends:
-              - 'backends/**'
-            memory:
-              - 'memory/**'
-            ci:
-              - '.github/workflows/**'
-              - '.release/**'
-              - '.golangci.yml'
-              - 'Makefile'
-              - 'tools/releasegate/**'
-
   compute-matrix:
     name: Compute module matrix
     runs-on: ubuntu-latest
     outputs:
       lint: ${{ steps.matrix.outputs.lint }}
+      lint_enabled: ${{ steps.matrix.outputs.lint_enabled }}
       test: ${{ steps.matrix.outputs.test }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Build module matrix
         id: matrix
+        env:
+          BASE_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || inputs.base_sha }}
         run: |
           python3 - <<'PY' > matrix.json
-          import json, pathlib
+          import json, os, pathlib, subprocess
 
           def modules(root):
               return sorted(
@@ -66,9 +41,48 @@ jobs:
 
           backends = modules("backends")
           drivers = modules("driver")
-          lint = ["core", *backends, *drivers, "memory", "memory/eval"]
-          test = lint + ["examples/forge"]
-          json.dump({"lint": {"module": lint}, "test": {"module": test}}, open("matrix.json", "w"))
+          all_lint = ["core", *backends, *drivers, "memory", "memory/eval"]
+
+          base = os.environ["BASE_SHA"]
+          files = subprocess.check_output(
+              ["git", "diff", "--name-only", f"{base}...HEAD"],
+              text=True,
+          ).splitlines()
+
+          changed = set()
+          root_trigger = False
+          root_trigger_files = {
+              "go.work",
+              "go.mod",
+              "go.sum",
+              "Makefile",
+              ".golangci.yml",
+          }
+
+          for file in files:
+              if file in root_trigger_files:
+                  root_trigger = True
+                  continue
+              parts = pathlib.PurePosixPath(file).parts
+              if file.startswith("core/"):
+                  changed.add("core")
+              elif file.startswith("memory/eval/"):
+                  changed.add("memory/eval")
+              elif file.startswith("memory/"):
+                  changed.add("memory")
+              elif file.startswith("driver/") and len(parts) >= 2:
+                  changed.add(f"driver/{parts[1]}")
+              elif file.startswith("backends/") and len(parts) >= 2:
+                  changed.add(f"backends/{parts[1]}")
+
+          lint = all_lint if root_trigger else sorted(changed & set(all_lint))
+          test = all_lint + ["examples/forge"]
+          json.dump(
+              {"lint": {"module": lint}, "test": {"module": test}},
+              open("matrix.json", "w"),
+          )
+          with open(os.environ["GITHUB_OUTPUT"], "a") as output:
+              output.write(f"lint_enabled={'true' if lint else 'false'}\n")
           PY
           echo "lint=$(jq -c .lint matrix.json)" >> "$GITHUB_OUTPUT"
           echo "test=$(jq -c .test matrix.json)" >> "$GITHUB_OUTPUT"
@@ -130,8 +144,8 @@ jobs:
 
   lint:
     name: Lint (${{ matrix.module }})
-    needs: [detect, compute-matrix]
-    if: needs.detect.outputs.core == 'true' || needs.detect.outputs.drivers == 'true' || needs.detect.outputs.backends == 'true' || needs.detect.outputs.memory == 'true'
+    needs: [compute-matrix]
+    if: needs.compute-matrix.outputs.lint_enabled == 'true'
     runs-on: ubuntu-latest
     strategy:
       matrix: ${{ fromJson(needs.compute-matrix.outputs.lint) }}

--- a/core/inference/inferencetest/concurrent.go
+++ b/core/inference/inferencetest/concurrent.go
@@ -1,0 +1,120 @@
+package inferencetest
+
+import (
+	"context"
+	"io"
+	"sync"
+	"testing"
+
+	"github.com/GizClaw/flowcraft/core/inference"
+)
+
+// GenerateConcurrentSuite exercises the concurrency contract of a
+// provider's bound Generate pipelines: compilers, transports, and
+// decoders must be safe for concurrent calls.
+type GenerateConcurrentSuite struct {
+	Model   inference.ModelRef
+	Request func() inference.GenerateRequest
+	Unary   inference.GenerateDriver
+	Stream  inference.GenerateStreamDriver
+
+	// Goroutines is the number of concurrent workers per operation.
+	// Non-positive uses the default (4).
+	Goroutines int
+}
+
+// RunGenerateConcurrent runs Explain/Execute and Explain/Stream
+// concurrently against whichever drivers are configured.
+func RunGenerateConcurrent(t *testing.T, suite GenerateConcurrentSuite) {
+	t.Helper()
+	if suite.Request == nil {
+		t.Fatal("GenerateConcurrentSuite requires a request constructor")
+	}
+	if suite.Unary == nil && suite.Stream == nil {
+		t.Fatal("GenerateConcurrentSuite requires at least one generate driver")
+	}
+	if err := suite.Model.Validate(); err != nil {
+		t.Fatalf("Model: %v", err)
+	}
+
+	workers := suite.Goroutines
+	if workers <= 0 {
+		workers = 4
+	}
+	var wg sync.WaitGroup
+	errorsCh := make(chan error, workers*2)
+
+	if suite.Unary != nil {
+		for range workers {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				request := suite.Request()
+				if _, err := suite.Unary.Explain(
+					context.Background(),
+					suite.Model,
+					request,
+				); err != nil {
+					errorsCh <- err
+					return
+				}
+				if _, err := suite.Unary.Execute(
+					context.Background(),
+					suite.Model,
+					request,
+				); err != nil {
+					errorsCh <- err
+					return
+				}
+			}()
+		}
+	}
+
+	if suite.Stream != nil {
+		for range workers {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				request := suite.Request()
+				if _, err := suite.Stream.Explain(
+					context.Background(),
+					suite.Model,
+					request,
+				); err != nil {
+					errorsCh <- err
+					return
+				}
+				stream, err := suite.Stream.Stream(
+					context.Background(),
+					suite.Model,
+					request,
+				)
+				if err != nil {
+					errorsCh <- err
+					return
+				}
+				defer func() { _ = stream.Close() }()
+				for {
+					_, err := stream.Next(context.Background())
+					if err == io.EOF {
+						break
+					}
+					if err != nil {
+						errorsCh <- err
+						return
+					}
+				}
+				if _, err := stream.Result(); err != nil {
+					errorsCh <- err
+					return
+				}
+			}()
+		}
+	}
+
+	wg.Wait()
+	close(errorsCh)
+	for err := range errorsCh {
+		t.Errorf("concurrent generate: %+v", err)
+	}
+}

--- a/core/inference/inferencetest/conformance_test.go
+++ b/core/inference/inferencetest/conformance_test.go
@@ -1,0 +1,211 @@
+package inferencetest_test
+
+import (
+	"context"
+	"errors"
+	"io"
+	"testing"
+
+	"github.com/GizClaw/flowcraft/core/inference"
+	"github.com/GizClaw/flowcraft/core/inference/inferencetest"
+	"github.com/GizClaw/flowcraft/core/message"
+)
+
+func TestEmbedFakeAssembly(t *testing.T) {
+	fake := &inferencetest.EmbedFake{}
+	assembly := fake.Assembly(t)
+
+	request := inference.EmbedRequest{
+		Items: []inference.EmbedItem{{
+			Content: message.Content{Parts: []message.Part{message.TextPart{Text: "hi"}}},
+		}},
+	}
+	response, err := assembly.Embed(context.Background(), inferencetest.DefaultFakeEmbedModel, request)
+	if err != nil {
+		t.Fatalf("Embed: %v", err)
+	}
+	if len(response.Embeddings) != 1 {
+		t.Fatalf("embeddings = %d, want 1", len(response.Embeddings))
+	}
+	if len(fake.Requests()) != 1 {
+		t.Fatalf("compiler requests = %d, want 1", len(fake.Requests()))
+	}
+}
+
+func TestRunEmbedUnary(t *testing.T) {
+	calls := &inferencetest.Counter{}
+	driver, err := inference.BindEmbed(
+		inference.Compiler[inference.EmbedRequest, string](
+			func(_ context.Context, _ inference.ModelRef, request inference.EmbedRequest) (inference.Compiled[string], error) {
+				return inference.Compiled[string]{
+					Wire: "wire",
+					Report: inferencetest.NativeReport(
+						inference.OperationEmbed,
+						request.ActiveFields()...,
+					),
+				}, nil
+			},
+		),
+		countingTransport(calls, func(_ context.Context, wire string) (string, error) { return wire, nil }),
+		inference.Decoder[string, inference.EmbedResponse](
+			func(_ context.Context, _ string) (inference.EmbedResponse, error) {
+				return inference.EmbedResponse{
+					Embeddings: []inference.Embedding{{Vector: []float32{1}}},
+				}, nil
+			},
+		),
+	)
+	if err != nil {
+		t.Fatalf("BindEmbed: %v", err)
+	}
+	inferencetest.RunEmbedUnary(t, inferencetest.EmbedUnarySuite{
+		Model: inferencetest.DefaultFakeEmbedModel,
+		Request: func() inference.EmbedRequest {
+			return inference.EmbedRequest{
+				Items: []inference.EmbedItem{{
+					Content: message.Content{Parts: []message.Part{message.TextPart{Text: "hi"}}},
+				}},
+			}
+		},
+		Driver:         driver,
+		TransportCalls: calls.Load,
+	})
+}
+
+func TestRunGenerateStreamFailure(t *testing.T) {
+	calls := &inferencetest.Counter{}
+	driver, err := inference.BindGenerateStream(
+		inference.GenerateCompiler[string](
+			func(_ context.Context, _ inference.ModelRef, request inference.GenerateRequest, shape inference.GenerateExecutionShape) (inference.Compiled[string], error) {
+				return inference.Compiled[string]{
+					Wire: "wire",
+					Report: inferencetest.NativeReport(
+						inference.OperationGenerate,
+						request.ActiveFieldsFor(shape)...,
+					),
+				}, nil
+			},
+		),
+		countingTransport(calls, func(_ context.Context, _ string) (inference.ProviderStream[inference.GenerateStreamEvent], error) {
+			return &failingGenerateStream{}, nil
+		}),
+		inference.GenerateStreamDecoder[inference.GenerateStreamEvent](
+			func(_ context.Context, event inference.GenerateStreamEvent) (inference.GenerateStreamEvent, error) {
+				return event, nil
+			},
+		),
+	)
+	if err != nil {
+		t.Fatalf("BindGenerateStream: %v", err)
+	}
+	inferencetest.RunGenerateStreamFailure(t, inferencetest.GenerateStreamFailureSuite{
+		Model: inferencetest.DefaultFakeModel,
+		Request: func() inference.GenerateRequest {
+			return inference.GenerateRequest{Input: inference.GenerateInput{
+				Role: inference.InputRoleUser,
+				Content: inference.InputContent{
+					Content: message.Content{Parts: []message.Part{message.TextPart{Text: "hi"}}},
+					Intent:  inference.Intent{Text: &inference.TextIntent{}},
+				},
+			}}
+		},
+		Driver:         driver,
+		TransportCalls: calls.Load,
+		AssertError: func(t *testing.T, err error) {
+			if !errors.Is(err, errStreamBoom) {
+				t.Fatalf("Next error = %v, want errStreamBoom", err)
+			}
+		},
+	})
+}
+
+func TestRunGenerateConcurrent(t *testing.T) {
+	calls := &inferencetest.Counter{}
+	operations, err := inference.BindGenerateOperations(
+		inference.GenerateCompiler[string](
+			func(_ context.Context, _ inference.ModelRef, request inference.GenerateRequest, shape inference.GenerateExecutionShape) (inference.Compiled[string], error) {
+				return inference.Compiled[string]{
+					Wire: "wire",
+					Report: inferencetest.NativeReport(
+						inference.OperationGenerate,
+						request.ActiveFieldsFor(shape)...,
+					),
+				}, nil
+			},
+		),
+		countingTransport(calls, func(_ context.Context, wire string) (string, error) { return wire, nil }),
+		inference.Decoder[string, inference.GenerateResponse](
+			func(_ context.Context, _ string) (inference.GenerateResponse, error) {
+				return inference.GenerateResponse{
+					Message: message.Message{
+						Role:    message.RoleAssistant,
+						Content: message.Content{Parts: []message.Part{message.TextPart{Text: "ok"}}},
+					},
+					FinishReason: inference.FinishCompleted,
+				}, nil
+			},
+		),
+		countingTransport(calls, func(_ context.Context, _ string) (inference.ProviderStream[inference.GenerateStreamEvent], error) {
+			return &okGenerateStream{events: []inference.GenerateStreamEvent{
+				{PartIndex: 0, Delta: inference.TextPartDelta{Text: "ok"}},
+				{FinishReason: inference.FinishCompleted},
+			}}, nil
+		}),
+		inference.GenerateStreamDecoder[inference.GenerateStreamEvent](
+			func(_ context.Context, event inference.GenerateStreamEvent) (inference.GenerateStreamEvent, error) {
+				return event, nil
+			},
+		),
+	)
+	if err != nil {
+		t.Fatalf("BindGenerateOperations: %v", err)
+	}
+	inferencetest.RunGenerateConcurrent(t, inferencetest.GenerateConcurrentSuite{
+		Model: inferencetest.DefaultFakeModel,
+		Request: func() inference.GenerateRequest {
+			return inference.GenerateRequest{Input: inference.GenerateInput{
+				Role: inference.InputRoleUser,
+				Content: inference.InputContent{
+					Content: message.Content{Parts: []message.Part{message.TextPart{Text: "hi"}}},
+					Intent:  inference.Intent{Text: &inference.TextIntent{}},
+				},
+			}}
+		},
+		Unary:  operations.Unary,
+		Stream: operations.Stream,
+	})
+}
+
+var errStreamBoom = errors.New("stream boom")
+
+type failingGenerateStream struct{}
+
+func (*failingGenerateStream) Next(context.Context) (inference.GenerateStreamEvent, error) {
+	return inference.GenerateStreamEvent{}, errStreamBoom
+}
+func (*failingGenerateStream) Close() error { return nil }
+
+type okGenerateStream struct {
+	events []inference.GenerateStreamEvent
+	index  int
+}
+
+func (s *okGenerateStream) Next(context.Context) (inference.GenerateStreamEvent, error) {
+	if s.index >= len(s.events) {
+		return inference.GenerateStreamEvent{}, io.EOF
+	}
+	event := s.events[s.index]
+	s.index++
+	return event, nil
+}
+func (*okGenerateStream) Close() error { return nil }
+
+func countingTransport[Wire, Raw any](
+	calls *inferencetest.Counter,
+	next inference.Transport[Wire, Raw],
+) inference.Transport[Wire, Raw] {
+	return func(ctx context.Context, wire Wire) (Raw, error) {
+		calls.Inc()
+		return next(ctx, wire)
+	}
+}

--- a/core/inference/inferencetest/doc.go
+++ b/core/inference/inferencetest/doc.go
@@ -2,8 +2,10 @@
 // providers.
 //
 // Provider packages should keep provider-specific wire assertions in their own
-// tests and use these suites for the shared Runtime contracts: Explain must not
-// perform provider I/O, execution metadata must retain compiler decisions,
-// requests must remain caller-owned, and sessions must compile each input
-// before transport.
+// tests and use these suites for the shared Runtime contracts: Explain must
+// not perform provider I/O, execution metadata must retain compiler
+// decisions, requests must remain caller-owned, generate unary/stream paths
+// must agree on their active field set, stream failures must surface through
+// Next/Result/Close, and compilers/transports/decoders must be safe for
+// concurrent use.
 package inferencetest

--- a/core/inference/inferencetest/embed.go
+++ b/core/inference/inferencetest/embed.go
@@ -1,0 +1,157 @@
+package inferencetest
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"github.com/GizClaw/flowcraft/core/inference"
+	"github.com/GizClaw/flowcraft/core/resource"
+)
+
+// DefaultFakeEmbedModel is EmbedFake's default model ref.
+var DefaultFakeEmbedModel = inference.ModelRef{
+	ID:      inference.ModelID{Provider: "fake", Name: "embed"},
+	Profile: "default",
+}
+
+// EmbedFake is a canned Embed provider for tests: one provider, one
+// profile, one model. Execute answers via Respond, and every request
+// reaching the compiler is captured for assertion. It drives the real
+// Runtime resolve/compile/validate pipeline.
+type EmbedFake struct {
+	// Model is the ref the runtime resolves. Defaults to
+	// DefaultFakeEmbedModel.
+	Model inference.ModelRef
+	// Respond answers Embed calls. Default: one unit-length vector per
+	// request item.
+	Respond func(inference.EmbedRequest) inference.EmbedResponse
+
+	mu       sync.Mutex
+	requests []inference.EmbedRequest
+}
+
+// Assembly builds the fake's inference assembly.
+func (f *EmbedFake) Assembly(t *testing.T) *inference.Assembly {
+	t.Helper()
+	model := f.Model
+	if model.ID.Provider == "" {
+		model = DefaultFakeEmbedModel
+	}
+	respond := f.Respond
+	if respond == nil {
+		respond = func(request inference.EmbedRequest) inference.EmbedResponse {
+			embeddings := make([]inference.Embedding, len(request.Items))
+			for index := range embeddings {
+				embeddings[index] = inference.Embedding{Vector: []float32{1}}
+			}
+			return inference.EmbedResponse{Embeddings: embeddings}
+		}
+	}
+
+	compile := inference.Compiler[inference.EmbedRequest, string](
+		func(_ context.Context, _ inference.ModelRef, req inference.EmbedRequest) (inference.Compiled[string], error) {
+			f.mu.Lock()
+			f.requests = append(f.requests, req.Clone())
+			f.mu.Unlock()
+			return inference.Compiled[string]{
+				Wire:   "wire",
+				Report: NativeReport(inference.OperationEmbed, req.ActiveFields()...),
+			}, nil
+		},
+	)
+	transport := inference.Transport[string, string](
+		func(_ context.Context, wire string) (string, error) { return wire, nil },
+	)
+	decode := inference.Decoder[string, inference.EmbedResponse](
+		func(_ context.Context, _ string) (inference.EmbedResponse, error) {
+			return respond(f.lastRequest()), nil
+		},
+	)
+	driver, err := inference.BindEmbed(compile, transport, decode)
+	if err != nil {
+		t.Fatalf("BindEmbed: %v", err)
+	}
+
+	definition := inference.ProviderDefinition{
+		ID: model.ID.Provider,
+		Profiles: []inference.ProfileDefinition{{
+			ID:         model.Profile,
+			Operations: []inference.Operation{inference.OperationEmbed},
+		}},
+		Models: []inference.ModelImplementation{{
+			Descriptor: inference.ModelDescriptor{ID: model.ID},
+			Openers: inference.Openers{
+				Embed: func(_ context.Context, _ inference.ModelRef) (inference.EmbedDriver, error) {
+					return driver, nil
+				},
+			},
+		}},
+	}
+	value, err := inference.Factory{}.New(context.Background(), resource.Input{
+		Deps: map[string]any{"provider." + model.ID.Provider: definition},
+	})
+	if err != nil {
+		t.Fatalf("build assembly: %v", err)
+	}
+	return value.(*inference.Assembly)
+}
+
+// Requests returns the cloned requests that reached the compiler, in
+// order.
+func (f *EmbedFake) Requests() []inference.EmbedRequest {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return append([]inference.EmbedRequest(nil), f.requests...)
+}
+
+// LastRequest returns the most recently compiled request.
+func (f *EmbedFake) LastRequest() inference.EmbedRequest {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if len(f.requests) == 0 {
+		return inference.EmbedRequest{}
+	}
+	return f.requests[len(f.requests)-1]
+}
+
+func (f *EmbedFake) lastRequest() inference.EmbedRequest {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if len(f.requests) == 0 {
+		return inference.EmbedRequest{}
+	}
+	return f.requests[len(f.requests)-1]
+}
+
+// EmbedUnarySuite verifies the shared Runtime contracts for Embed
+// drivers.
+type EmbedUnarySuite struct {
+	Model   inference.ModelRef
+	Request func() inference.EmbedRequest
+	Driver  inference.EmbedDriver
+
+	TransportCalls func() int64
+	AssertResponse func(*testing.T, inference.EmbedResponse)
+}
+
+// RunEmbedUnary runs the Embed-specific unary conformance suite.
+func RunEmbedUnary(t *testing.T, suite EmbedUnarySuite) {
+	t.Helper()
+	if suite.Driver == nil {
+		t.Fatal("EmbedUnarySuite requires a driver")
+	}
+	RunUnary(t, UnarySuite[inference.EmbedRequest, inference.EmbedResponse]{
+		Operation: inference.OperationEmbed,
+		Model:     suite.Model,
+		Request:   suite.Request,
+		Snapshot: func(request inference.EmbedRequest) any {
+			return request.Clone()
+		},
+		Explain:        suite.Driver.Explain,
+		Execute:        suite.Driver.Execute,
+		Metadata:       func(response inference.EmbedResponse) inference.Metadata { return response.Metadata },
+		TransportCalls: suite.TransportCalls,
+		AssertResponse: suite.AssertResponse,
+	})
+}

--- a/core/inference/inferencetest/stream.go
+++ b/core/inference/inferencetest/stream.go
@@ -149,3 +149,80 @@ func RunGenerateStream(t *testing.T, suite GenerateStreamSuite) {
 	}
 	assertUnchanged(t, expected, request.Clone())
 }
+
+// GenerateStreamFailureSuite verifies that a provider stream can fail
+// cleanly mid-stream: Next surfaces the error, Result carries the same
+// failure, and Close remains usable afterwards.
+type GenerateStreamFailureSuite struct {
+	Model   inference.ModelRef
+	Request func() inference.GenerateRequest
+	Driver  inference.GenerateStreamDriver
+
+	TransportCalls func() int64
+	AssertError    func(*testing.T, error)
+}
+
+func RunGenerateStreamFailure(t *testing.T, suite GenerateStreamFailureSuite) {
+	t.Helper()
+	if suite.Request == nil || suite.Driver == nil || suite.TransportCalls == nil {
+		t.Fatal("GenerateStreamFailureSuite requires request, driver, and transport probe")
+	}
+	if err := suite.Model.Validate(); err != nil {
+		t.Fatalf("Model: %v", err)
+	}
+
+	request := suite.Request()
+	expected := request.Clone()
+	before := suite.TransportCalls()
+	explanation, err := suite.Driver.Explain(context.Background(), suite.Model, request)
+	if err != nil {
+		t.Fatalf("Explain: %v", err)
+	}
+	if suite.TransportCalls() != before ||
+		explanation.Operation != inference.OperationGenerate ||
+		len(explanation.Decisions) == 0 {
+		t.Fatalf("Explain performed I/O or lost decisions: %+v", explanation)
+	}
+	assertUnchanged(t, expected, request.Clone())
+
+	stream, err := suite.Driver.Stream(context.Background(), suite.Model, request)
+	if err != nil {
+		t.Fatalf("Stream: %v", err)
+	}
+	closed := false
+	t.Cleanup(func() {
+		if !closed {
+			_ = stream.Close()
+		}
+	})
+	if suite.TransportCalls() != before+1 {
+		t.Fatalf("Stream transport calls = %d, want %d", suite.TransportCalls(), before+1)
+	}
+
+	var nextErr error
+	for {
+		_, err := stream.Next(context.Background())
+		if err == io.EOF {
+			t.Fatal("Next reached EOF, want a mid-stream error")
+		}
+		if err != nil {
+			nextErr = err
+			break
+		}
+	}
+	if nextErr == nil {
+		t.Fatal("Next returned no error")
+	}
+	if suite.AssertError != nil {
+		suite.AssertError(t, nextErr)
+	}
+
+	if _, resultErr := stream.Result(); resultErr == nil {
+		t.Fatal("Result after stream failure = nil, want error")
+	}
+	if closeErr := stream.Close(); closeErr != nil {
+		t.Fatalf("Close after stream failure: %v", closeErr)
+	}
+	closed = true
+	assertUnchanged(t, expected, request.Clone())
+}

--- a/driver/anthropic/conformance_test.go
+++ b/driver/anthropic/conformance_test.go
@@ -1,0 +1,147 @@
+package anthropic
+
+import (
+	"context"
+	"errors"
+	"io"
+	"testing"
+
+	"github.com/GizClaw/flowcraft/core/inference"
+	"github.com/GizClaw/flowcraft/core/inference/inferencetest"
+	"github.com/GizClaw/flowcraft/core/message"
+)
+
+func conformanceTextRequest() inference.GenerateRequest {
+	return inference.GenerateRequest{Input: inference.GenerateInput{
+		Role: inference.InputRoleUser,
+		Content: inference.InputContent{
+			Content: message.Content{Parts: []message.Part{message.TextPart{Text: "hi"}}},
+			Intent:  inference.Intent{Text: &inference.TextIntent{}},
+		},
+	}}
+}
+
+func conformanceModel(name string) inference.ModelRef {
+	return inference.ModelRef{
+		ID:      inference.ModelID{Provider: "anthropic", Name: name},
+		Profile: "default",
+	}
+}
+
+func conformanceGenerateDrivers[Wire any](
+	t *testing.T,
+	compile inference.GenerateCompiler[Wire],
+	calls *inferencetest.Counter,
+) (inference.GenerateDriver, inference.GenerateStreamDriver) {
+	t.Helper()
+	operations, err := inference.BindGenerateOperations(
+		compile,
+		countingTransport(calls, func(_ context.Context, wire Wire) (Wire, error) { return wire, nil }),
+		inference.Decoder[Wire, inference.GenerateResponse](
+			func(_ context.Context, _ Wire) (inference.GenerateResponse, error) {
+				return inference.GenerateResponse{
+					Message: message.Message{
+						Role:    message.RoleAssistant,
+						Content: message.Content{Parts: []message.Part{message.TextPart{Text: "ok"}}},
+					},
+					FinishReason: inference.FinishCompleted,
+				}, nil
+			},
+		),
+		countingTransport(calls, func(_ context.Context, _ Wire) (inference.ProviderStream[inference.GenerateStreamEvent], error) {
+			return &conformanceStream{events: []inference.GenerateStreamEvent{
+				{PartIndex: 0, Delta: inference.TextPartDelta{Text: "ok"}},
+				{FinishReason: inference.FinishCompleted},
+			}}, nil
+		}),
+		inference.GenerateStreamDecoder[inference.GenerateStreamEvent](
+			func(_ context.Context, event inference.GenerateStreamEvent) (inference.GenerateStreamEvent, error) {
+				return event, nil
+			},
+		),
+	)
+	if err != nil {
+		t.Fatalf("BindGenerateOperations: %v", err)
+	}
+	return operations.Unary, operations.Stream
+}
+
+func countingTransport[Wire, Raw any](
+	calls *inferencetest.Counter,
+	next inference.Transport[Wire, Raw],
+) inference.Transport[Wire, Raw] {
+	return func(ctx context.Context, wire Wire) (Raw, error) {
+		calls.Inc()
+		return next(ctx, wire)
+	}
+}
+
+type conformanceStream struct {
+	events []inference.GenerateStreamEvent
+	index  int
+}
+
+func (s *conformanceStream) Next(context.Context) (inference.GenerateStreamEvent, error) {
+	if s.index >= len(s.events) {
+		return inference.GenerateStreamEvent{}, io.EOF
+	}
+	event := s.events[s.index]
+	s.index++
+	return event, nil
+}
+
+func (*conformanceStream) Close() error { return nil }
+
+func TestConformanceGenerateConcurrent(t *testing.T) {
+	calls := &inferencetest.Counter{}
+	unary, stream := conformanceGenerateDrivers(
+		t,
+		compileGenerate("claude-sonnet-5", catalog["claude-sonnet-5"]),
+		calls,
+	)
+	inferencetest.RunGenerateConcurrent(t, inferencetest.GenerateConcurrentSuite{
+		Model:      conformanceModel("claude-sonnet-5"),
+		Request:    conformanceTextRequest,
+		Unary:      unary,
+		Stream:     stream,
+		Goroutines: 2,
+	})
+}
+
+var errStreamFailure = errors.New("stream failure")
+
+type failingStream struct{}
+
+func (*failingStream) Next(context.Context) (inference.GenerateStreamEvent, error) {
+	return inference.GenerateStreamEvent{}, errStreamFailure
+}
+func (*failingStream) Close() error { return nil }
+
+func TestConformanceGenerateStreamFailureProvider(t *testing.T) {
+	calls := &inferencetest.Counter{}
+	operations, err := inference.BindGenerateStream(
+		compileGenerate("claude-sonnet-5", catalog["claude-sonnet-5"]),
+		countingTransport(calls, func(_ context.Context, _ generateWire) (inference.ProviderStream[inference.GenerateStreamEvent], error) {
+			return &failingStream{}, nil
+		}),
+		inference.GenerateStreamDecoder[inference.GenerateStreamEvent](
+			func(_ context.Context, event inference.GenerateStreamEvent) (inference.GenerateStreamEvent, error) {
+				return event, nil
+			},
+		),
+	)
+	if err != nil {
+		t.Fatalf("BindGenerateStream: %v", err)
+	}
+	inferencetest.RunGenerateStreamFailure(t, inferencetest.GenerateStreamFailureSuite{
+		Model:          conformanceModel("claude-sonnet-5"),
+		Request:        conformanceTextRequest,
+		Driver:         operations,
+		TransportCalls: calls.Load,
+		AssertError: func(t *testing.T, err error) {
+			if !errors.Is(err, errStreamFailure) {
+				t.Fatalf("stream error = %v", err)
+			}
+		},
+	})
+}

--- a/driver/azure/conformance_test.go
+++ b/driver/azure/conformance_test.go
@@ -1,0 +1,184 @@
+package azure
+
+import (
+	"context"
+	"errors"
+	"io"
+	"testing"
+
+	"github.com/GizClaw/flowcraft/core/inference"
+	"github.com/GizClaw/flowcraft/core/inference/inferencetest"
+	"github.com/GizClaw/flowcraft/core/message"
+)
+
+func conformanceTextRequest() inference.GenerateRequest {
+	return inference.GenerateRequest{Input: inference.GenerateInput{
+		Role: inference.InputRoleUser,
+		Content: inference.InputContent{
+			Content: message.Content{Parts: []message.Part{message.TextPart{Text: "hi"}}},
+			Intent:  inference.Intent{Text: &inference.TextIntent{}},
+		},
+	}}
+}
+
+func conformanceModel(name string) inference.ModelRef {
+	return inference.ModelRef{
+		ID:      inference.ModelID{Provider: driverID, Name: name},
+		Profile: "default",
+	}
+}
+
+func conformanceGenerateDrivers[Wire any](
+	t *testing.T,
+	compile inference.GenerateCompiler[Wire],
+	calls *inferencetest.Counter,
+) (inference.GenerateDriver, inference.GenerateStreamDriver) {
+	t.Helper()
+	operations, err := inference.BindGenerateOperations(
+		compile,
+		countingTransport(calls, func(_ context.Context, wire Wire) (Wire, error) { return wire, nil }),
+		inference.Decoder[Wire, inference.GenerateResponse](
+			func(_ context.Context, _ Wire) (inference.GenerateResponse, error) {
+				return inference.GenerateResponse{
+					Message: message.Message{
+						Role:    message.RoleAssistant,
+						Content: message.Content{Parts: []message.Part{message.TextPart{Text: "ok"}}},
+					},
+					FinishReason: inference.FinishCompleted,
+				}, nil
+			},
+		),
+		countingTransport(calls, func(_ context.Context, _ Wire) (inference.ProviderStream[inference.GenerateStreamEvent], error) {
+			return &conformanceStream{events: []inference.GenerateStreamEvent{
+				{PartIndex: 0, Delta: inference.TextPartDelta{Text: "ok"}},
+				{FinishReason: inference.FinishCompleted},
+			}}, nil
+		}),
+		inference.GenerateStreamDecoder[inference.GenerateStreamEvent](
+			func(_ context.Context, event inference.GenerateStreamEvent) (inference.GenerateStreamEvent, error) {
+				return event, nil
+			},
+		),
+	)
+	if err != nil {
+		t.Fatalf("BindGenerateOperations: %v", err)
+	}
+	return operations.Unary, operations.Stream
+}
+
+func conformanceEmbedDriver[Wire any](
+	t *testing.T,
+	compile inference.Compiler[inference.EmbedRequest, Wire],
+	calls *inferencetest.Counter,
+) inference.EmbedDriver {
+	t.Helper()
+	driver, err := inference.BindEmbed(
+		compile,
+		countingTransport(calls, func(_ context.Context, wire Wire) (Wire, error) { return wire, nil }),
+		inference.Decoder[Wire, inference.EmbedResponse](
+			func(_ context.Context, _ Wire) (inference.EmbedResponse, error) {
+				return inference.EmbedResponse{
+					Embeddings: []inference.Embedding{{Vector: []float32{1}}},
+				}, nil
+			},
+		),
+	)
+	if err != nil {
+		t.Fatalf("BindEmbed: %v", err)
+	}
+	return driver
+}
+
+func countingTransport[Wire, Raw any](
+	calls *inferencetest.Counter,
+	next inference.Transport[Wire, Raw],
+) inference.Transport[Wire, Raw] {
+	return func(ctx context.Context, wire Wire) (Raw, error) {
+		calls.Inc()
+		return next(ctx, wire)
+	}
+}
+
+type conformanceStream struct {
+	events []inference.GenerateStreamEvent
+	index  int
+}
+
+func (s *conformanceStream) Next(context.Context) (inference.GenerateStreamEvent, error) {
+	if s.index >= len(s.events) {
+		return inference.GenerateStreamEvent{}, io.EOF
+	}
+	event := s.events[s.index]
+	s.index++
+	return event, nil
+}
+func (*conformanceStream) Close() error { return nil }
+
+func TestConformanceGenerateConcurrent(t *testing.T) {
+	calls := &inferencetest.Counter{}
+	entry := entryFor(ModelSpec{Name: "deploy", Kind: "generate"})
+	unary, stream := conformanceGenerateDrivers(t, compileGenerate("deploy", entry), calls)
+	inferencetest.RunGenerateConcurrent(t, inferencetest.GenerateConcurrentSuite{
+		Model:      conformanceModel("deploy"),
+		Request:    conformanceTextRequest,
+		Unary:      unary,
+		Stream:     stream,
+		Goroutines: 2,
+	})
+}
+
+var errStreamFailure = errors.New("stream failure")
+
+type failingStream struct{}
+
+func (*failingStream) Next(context.Context) (inference.GenerateStreamEvent, error) {
+	return inference.GenerateStreamEvent{}, errStreamFailure
+}
+func (*failingStream) Close() error { return nil }
+
+func TestConformanceGenerateStreamFailure(t *testing.T) {
+	calls := &inferencetest.Counter{}
+	entry := entryFor(ModelSpec{Name: "deploy", Kind: "generate"})
+	driver, err := inference.BindGenerateStream(
+		compileGenerate("deploy", entry),
+		countingTransport(calls, func(_ context.Context, _ generateWire) (inference.ProviderStream[inference.GenerateStreamEvent], error) {
+			return &failingStream{}, nil
+		}),
+		inference.GenerateStreamDecoder[inference.GenerateStreamEvent](
+			func(_ context.Context, event inference.GenerateStreamEvent) (inference.GenerateStreamEvent, error) {
+				return event, nil
+			},
+		),
+	)
+	if err != nil {
+		t.Fatalf("BindGenerateStream: %v", err)
+	}
+	inferencetest.RunGenerateStreamFailure(t, inferencetest.GenerateStreamFailureSuite{
+		Model:          conformanceModel("deploy"),
+		Request:        conformanceTextRequest,
+		Driver:         driver,
+		TransportCalls: calls.Load,
+		AssertError: func(t *testing.T, err error) {
+			if !errors.Is(err, errStreamFailure) {
+				t.Fatalf("stream error = %v", err)
+			}
+		},
+	})
+}
+
+func TestConformanceEmbedUnary(t *testing.T) {
+	calls := &inferencetest.Counter{}
+	deployment := "embed-deploy"
+	entry := entryFor(ModelSpec{Name: deployment, Kind: "embed", Dimensions: true})
+	driver := conformanceEmbedDriver(t, compileEmbed(deployment, entry), calls)
+	inferencetest.RunEmbedUnary(t, inferencetest.EmbedUnarySuite{
+		Model: conformanceModel(deployment),
+		Request: func() inference.EmbedRequest {
+			return inference.EmbedRequest{Items: []inference.EmbedItem{{
+				Content: message.Content{Parts: []message.Part{message.TextPart{Text: "hi"}}},
+			}}}
+		},
+		Driver:         driver,
+		TransportCalls: calls.Load,
+	})
+}

--- a/driver/bytedance/conformance_test.go
+++ b/driver/bytedance/conformance_test.go
@@ -1,0 +1,183 @@
+package bytedance
+
+import (
+	"context"
+	"errors"
+	"io"
+	"testing"
+
+	"github.com/GizClaw/flowcraft/core/inference"
+	"github.com/GizClaw/flowcraft/core/inference/inferencetest"
+	"github.com/GizClaw/flowcraft/core/message"
+)
+
+func conformanceTextRequest() inference.GenerateRequest {
+	return inference.GenerateRequest{Input: inference.GenerateInput{
+		Role: inference.InputRoleUser,
+		Content: inference.InputContent{
+			Content: message.Content{Parts: []message.Part{message.TextPart{Text: "hi"}}},
+			Intent:  inference.Intent{Text: &inference.TextIntent{}},
+		},
+	}}
+}
+
+func conformanceModel(name string) inference.ModelRef {
+	return inference.ModelRef{
+		ID:      inference.ModelID{Provider: driverID, Name: name},
+		Profile: "default",
+	}
+}
+
+func conformanceGenerateDrivers[Wire any](
+	t *testing.T,
+	compile inference.GenerateCompiler[Wire],
+	calls *inferencetest.Counter,
+) (inference.GenerateDriver, inference.GenerateStreamDriver) {
+	t.Helper()
+	operations, err := inference.BindGenerateOperations(
+		compile,
+		countingTransport(calls, func(_ context.Context, wire Wire) (Wire, error) { return wire, nil }),
+		inference.Decoder[Wire, inference.GenerateResponse](
+			func(_ context.Context, _ Wire) (inference.GenerateResponse, error) {
+				return inference.GenerateResponse{
+					Message: message.Message{
+						Role:    message.RoleAssistant,
+						Content: message.Content{Parts: []message.Part{message.TextPart{Text: "ok"}}},
+					},
+					FinishReason: inference.FinishCompleted,
+				}, nil
+			},
+		),
+		countingTransport(calls, func(_ context.Context, _ Wire) (inference.ProviderStream[inference.GenerateStreamEvent], error) {
+			return &conformanceStream{events: []inference.GenerateStreamEvent{
+				{PartIndex: 0, Delta: inference.TextPartDelta{Text: "ok"}},
+				{FinishReason: inference.FinishCompleted},
+			}}, nil
+		}),
+		inference.GenerateStreamDecoder[inference.GenerateStreamEvent](
+			func(_ context.Context, event inference.GenerateStreamEvent) (inference.GenerateStreamEvent, error) {
+				return event, nil
+			},
+		),
+	)
+	if err != nil {
+		t.Fatalf("BindGenerateOperations: %v", err)
+	}
+	return operations.Unary, operations.Stream
+}
+
+func conformanceEmbedDriver[Wire any](
+	t *testing.T,
+	compile inference.Compiler[inference.EmbedRequest, Wire],
+	calls *inferencetest.Counter,
+) inference.EmbedDriver {
+	t.Helper()
+	driver, err := inference.BindEmbed(
+		compile,
+		countingTransport(calls, func(_ context.Context, wire Wire) (Wire, error) { return wire, nil }),
+		inference.Decoder[Wire, inference.EmbedResponse](
+			func(_ context.Context, _ Wire) (inference.EmbedResponse, error) {
+				return inference.EmbedResponse{
+					Embeddings: []inference.Embedding{{Vector: []float32{1}}},
+				}, nil
+			},
+		),
+	)
+	if err != nil {
+		t.Fatalf("BindEmbed: %v", err)
+	}
+	return driver
+}
+
+func countingTransport[Wire, Raw any](
+	calls *inferencetest.Counter,
+	next inference.Transport[Wire, Raw],
+) inference.Transport[Wire, Raw] {
+	return func(ctx context.Context, wire Wire) (Raw, error) {
+		calls.Inc()
+		return next(ctx, wire)
+	}
+}
+
+type conformanceStream struct {
+	events []inference.GenerateStreamEvent
+	index  int
+}
+
+func (s *conformanceStream) Next(context.Context) (inference.GenerateStreamEvent, error) {
+	if s.index >= len(s.events) {
+		return inference.GenerateStreamEvent{}, io.EOF
+	}
+	event := s.events[s.index]
+	s.index++
+	return event, nil
+}
+func (*conformanceStream) Close() error { return nil }
+
+func TestConformanceGenerateConcurrent(t *testing.T) {
+	calls := &inferencetest.Counter{}
+	model := "doubao-seed-2-0-lite"
+	unary, stream := conformanceGenerateDrivers(t, compileGenerate(model, catalog[model]), calls)
+	inferencetest.RunGenerateConcurrent(t, inferencetest.GenerateConcurrentSuite{
+		Model:      conformanceModel(model),
+		Request:    conformanceTextRequest,
+		Unary:      unary,
+		Stream:     stream,
+		Goroutines: 2,
+	})
+}
+
+var errStreamFailure = errors.New("stream failure")
+
+type failingStream struct{}
+
+func (*failingStream) Next(context.Context) (inference.GenerateStreamEvent, error) {
+	return inference.GenerateStreamEvent{}, errStreamFailure
+}
+func (*failingStream) Close() error { return nil }
+
+func TestConformanceGenerateStreamFailure(t *testing.T) {
+	calls := &inferencetest.Counter{}
+	model := "doubao-seed-2-0-lite"
+	driver, err := inference.BindGenerateStream(
+		compileGenerate(model, catalog[model]),
+		countingTransport(calls, func(_ context.Context, _ generateWire) (inference.ProviderStream[inference.GenerateStreamEvent], error) {
+			return &failingStream{}, nil
+		}),
+		inference.GenerateStreamDecoder[inference.GenerateStreamEvent](
+			func(_ context.Context, event inference.GenerateStreamEvent) (inference.GenerateStreamEvent, error) {
+				return event, nil
+			},
+		),
+	)
+	if err != nil {
+		t.Fatalf("BindGenerateStream: %v", err)
+	}
+	inferencetest.RunGenerateStreamFailure(t, inferencetest.GenerateStreamFailureSuite{
+		Model:          conformanceModel(model),
+		Request:        conformanceTextRequest,
+		Driver:         driver,
+		TransportCalls: calls.Load,
+		AssertError: func(t *testing.T, err error) {
+			if !errors.Is(err, errStreamFailure) {
+				t.Fatalf("stream error = %v", err)
+			}
+		},
+	})
+}
+
+func TestConformanceEmbedUnary(t *testing.T) {
+	calls := &inferencetest.Counter{}
+	model := "doubao-embedding-large"
+	driver := conformanceEmbedDriver(t, compileEmbed(model, catalog[model]), calls)
+	inferencetest.RunEmbedUnary(t, inferencetest.EmbedUnarySuite{
+		Model: conformanceModel(model),
+		Request: func() inference.EmbedRequest {
+			return inference.EmbedRequest{Items: []inference.EmbedItem{{
+				Content: message.Content{Parts: []message.Part{message.TextPart{Text: "hi"}}},
+			}}}
+		},
+		Driver:         driver,
+		TransportCalls: calls.Load,
+	})
+}

--- a/driver/deepseek/conformance_test.go
+++ b/driver/deepseek/conformance_test.go
@@ -1,0 +1,144 @@
+package deepseek
+
+import (
+	"context"
+	"errors"
+	"io"
+	"testing"
+
+	"github.com/GizClaw/flowcraft/core/inference"
+	"github.com/GizClaw/flowcraft/core/inference/inferencetest"
+	"github.com/GizClaw/flowcraft/core/message"
+)
+
+func conformanceTextRequest() inference.GenerateRequest {
+	return inference.GenerateRequest{Input: inference.GenerateInput{
+		Role: inference.InputRoleUser,
+		Content: inference.InputContent{
+			Content: message.Content{Parts: []message.Part{message.TextPart{Text: "hi"}}},
+			Intent:  inference.Intent{Text: &inference.TextIntent{}},
+		},
+	}}
+}
+
+func conformanceModel(name string) inference.ModelRef {
+	return inference.ModelRef{
+		ID:      inference.ModelID{Provider: driverID, Name: name},
+		Profile: "default",
+	}
+}
+
+func conformanceGenerateDrivers[Wire any](
+	t *testing.T,
+	compile inference.GenerateCompiler[Wire],
+	calls *inferencetest.Counter,
+) (inference.GenerateDriver, inference.GenerateStreamDriver) {
+	t.Helper()
+	operations, err := inference.BindGenerateOperations(
+		compile,
+		countingTransport(calls, func(_ context.Context, wire Wire) (Wire, error) { return wire, nil }),
+		inference.Decoder[Wire, inference.GenerateResponse](
+			func(_ context.Context, _ Wire) (inference.GenerateResponse, error) {
+				return inference.GenerateResponse{
+					Message: message.Message{
+						Role:    message.RoleAssistant,
+						Content: message.Content{Parts: []message.Part{message.TextPart{Text: "ok"}}},
+					},
+					FinishReason: inference.FinishCompleted,
+				}, nil
+			},
+		),
+		countingTransport(calls, func(_ context.Context, _ Wire) (inference.ProviderStream[inference.GenerateStreamEvent], error) {
+			return &conformanceStream{events: []inference.GenerateStreamEvent{
+				{PartIndex: 0, Delta: inference.TextPartDelta{Text: "ok"}},
+				{FinishReason: inference.FinishCompleted},
+			}}, nil
+		}),
+		inference.GenerateStreamDecoder[inference.GenerateStreamEvent](
+			func(_ context.Context, event inference.GenerateStreamEvent) (inference.GenerateStreamEvent, error) {
+				return event, nil
+			},
+		),
+	)
+	if err != nil {
+		t.Fatalf("BindGenerateOperations: %v", err)
+	}
+	return operations.Unary, operations.Stream
+}
+
+func countingTransport[Wire, Raw any](
+	calls *inferencetest.Counter,
+	next inference.Transport[Wire, Raw],
+) inference.Transport[Wire, Raw] {
+	return func(ctx context.Context, wire Wire) (Raw, error) {
+		calls.Inc()
+		return next(ctx, wire)
+	}
+}
+
+type conformanceStream struct {
+	events []inference.GenerateStreamEvent
+	index  int
+}
+
+func (s *conformanceStream) Next(context.Context) (inference.GenerateStreamEvent, error) {
+	if s.index >= len(s.events) {
+		return inference.GenerateStreamEvent{}, io.EOF
+	}
+	event := s.events[s.index]
+	s.index++
+	return event, nil
+}
+func (*conformanceStream) Close() error { return nil }
+
+func TestConformanceGenerateConcurrent(t *testing.T) {
+	calls := &inferencetest.Counter{}
+	model := "deepseek-v4-flash"
+	unary, stream := conformanceGenerateDrivers(t, compileChatGenerate(model, catalog[model]), calls)
+	inferencetest.RunGenerateConcurrent(t, inferencetest.GenerateConcurrentSuite{
+		Model:      conformanceModel(model),
+		Request:    conformanceTextRequest,
+		Unary:      unary,
+		Stream:     stream,
+		Goroutines: 2,
+	})
+}
+
+var errStreamFailure = errors.New("stream failure")
+
+type failingStream struct{}
+
+func (*failingStream) Next(context.Context) (inference.GenerateStreamEvent, error) {
+	return inference.GenerateStreamEvent{}, errStreamFailure
+}
+func (*failingStream) Close() error { return nil }
+
+func TestConformanceGenerateStreamFailure(t *testing.T) {
+	calls := &inferencetest.Counter{}
+	model := "deepseek-v4-flash"
+	driver, err := inference.BindGenerateStream(
+		compileChatGenerate(model, catalog[model]),
+		countingTransport(calls, func(_ context.Context, _ chatWire) (inference.ProviderStream[inference.GenerateStreamEvent], error) {
+			return &failingStream{}, nil
+		}),
+		inference.GenerateStreamDecoder[inference.GenerateStreamEvent](
+			func(_ context.Context, event inference.GenerateStreamEvent) (inference.GenerateStreamEvent, error) {
+				return event, nil
+			},
+		),
+	)
+	if err != nil {
+		t.Fatalf("BindGenerateStream: %v", err)
+	}
+	inferencetest.RunGenerateStreamFailure(t, inferencetest.GenerateStreamFailureSuite{
+		Model:          conformanceModel(model),
+		Request:        conformanceTextRequest,
+		Driver:         driver,
+		TransportCalls: calls.Load,
+		AssertError: func(t *testing.T, err error) {
+			if !errors.Is(err, errStreamFailure) {
+				t.Fatalf("stream error = %v", err)
+			}
+		},
+	})
+}

--- a/driver/kimi/conformance_test.go
+++ b/driver/kimi/conformance_test.go
@@ -1,0 +1,144 @@
+package kimi
+
+import (
+	"context"
+	"errors"
+	"io"
+	"testing"
+
+	"github.com/GizClaw/flowcraft/core/inference"
+	"github.com/GizClaw/flowcraft/core/inference/inferencetest"
+	"github.com/GizClaw/flowcraft/core/message"
+)
+
+func conformanceTextRequest() inference.GenerateRequest {
+	return inference.GenerateRequest{Input: inference.GenerateInput{
+		Role: inference.InputRoleUser,
+		Content: inference.InputContent{
+			Content: message.Content{Parts: []message.Part{message.TextPart{Text: "hi"}}},
+			Intent:  inference.Intent{Text: &inference.TextIntent{}},
+		},
+	}}
+}
+
+func conformanceModel(name string) inference.ModelRef {
+	return inference.ModelRef{
+		ID:      inference.ModelID{Provider: driverID, Name: name},
+		Profile: "default",
+	}
+}
+
+func conformanceGenerateDrivers[Wire any](
+	t *testing.T,
+	compile inference.GenerateCompiler[Wire],
+	calls *inferencetest.Counter,
+) (inference.GenerateDriver, inference.GenerateStreamDriver) {
+	t.Helper()
+	operations, err := inference.BindGenerateOperations(
+		compile,
+		countingTransport(calls, func(_ context.Context, wire Wire) (Wire, error) { return wire, nil }),
+		inference.Decoder[Wire, inference.GenerateResponse](
+			func(_ context.Context, _ Wire) (inference.GenerateResponse, error) {
+				return inference.GenerateResponse{
+					Message: message.Message{
+						Role:    message.RoleAssistant,
+						Content: message.Content{Parts: []message.Part{message.TextPart{Text: "ok"}}},
+					},
+					FinishReason: inference.FinishCompleted,
+				}, nil
+			},
+		),
+		countingTransport(calls, func(_ context.Context, _ Wire) (inference.ProviderStream[inference.GenerateStreamEvent], error) {
+			return &conformanceStream{events: []inference.GenerateStreamEvent{
+				{PartIndex: 0, Delta: inference.TextPartDelta{Text: "ok"}},
+				{FinishReason: inference.FinishCompleted},
+			}}, nil
+		}),
+		inference.GenerateStreamDecoder[inference.GenerateStreamEvent](
+			func(_ context.Context, event inference.GenerateStreamEvent) (inference.GenerateStreamEvent, error) {
+				return event, nil
+			},
+		),
+	)
+	if err != nil {
+		t.Fatalf("BindGenerateOperations: %v", err)
+	}
+	return operations.Unary, operations.Stream
+}
+
+func countingTransport[Wire, Raw any](
+	calls *inferencetest.Counter,
+	next inference.Transport[Wire, Raw],
+) inference.Transport[Wire, Raw] {
+	return func(ctx context.Context, wire Wire) (Raw, error) {
+		calls.Inc()
+		return next(ctx, wire)
+	}
+}
+
+type conformanceStream struct {
+	events []inference.GenerateStreamEvent
+	index  int
+}
+
+func (s *conformanceStream) Next(context.Context) (inference.GenerateStreamEvent, error) {
+	if s.index >= len(s.events) {
+		return inference.GenerateStreamEvent{}, io.EOF
+	}
+	event := s.events[s.index]
+	s.index++
+	return event, nil
+}
+func (*conformanceStream) Close() error { return nil }
+
+func TestConformanceGenerateConcurrent(t *testing.T) {
+	calls := &inferencetest.Counter{}
+	model := "kimi-k2.6"
+	unary, stream := conformanceGenerateDrivers(t, compileGenerate(model, catalog[model]), calls)
+	inferencetest.RunGenerateConcurrent(t, inferencetest.GenerateConcurrentSuite{
+		Model:      conformanceModel(model),
+		Request:    conformanceTextRequest,
+		Unary:      unary,
+		Stream:     stream,
+		Goroutines: 2,
+	})
+}
+
+var errStreamFailure = errors.New("stream failure")
+
+type failingStream struct{}
+
+func (*failingStream) Next(context.Context) (inference.GenerateStreamEvent, error) {
+	return inference.GenerateStreamEvent{}, errStreamFailure
+}
+func (*failingStream) Close() error { return nil }
+
+func TestConformanceGenerateStreamFailure(t *testing.T) {
+	calls := &inferencetest.Counter{}
+	model := "kimi-k2.6"
+	driver, err := inference.BindGenerateStream(
+		compileGenerate(model, catalog[model]),
+		countingTransport(calls, func(_ context.Context, _ generateWire) (inference.ProviderStream[inference.GenerateStreamEvent], error) {
+			return &failingStream{}, nil
+		}),
+		inference.GenerateStreamDecoder[inference.GenerateStreamEvent](
+			func(_ context.Context, event inference.GenerateStreamEvent) (inference.GenerateStreamEvent, error) {
+				return event, nil
+			},
+		),
+	)
+	if err != nil {
+		t.Fatalf("BindGenerateStream: %v", err)
+	}
+	inferencetest.RunGenerateStreamFailure(t, inferencetest.GenerateStreamFailureSuite{
+		Model:          conformanceModel(model),
+		Request:        conformanceTextRequest,
+		Driver:         driver,
+		TransportCalls: calls.Load,
+		AssertError: func(t *testing.T, err error) {
+			if !errors.Is(err, errStreamFailure) {
+				t.Fatalf("stream error = %v", err)
+			}
+		},
+	})
+}

--- a/driver/minimax/conformance_test.go
+++ b/driver/minimax/conformance_test.go
@@ -1,0 +1,144 @@
+package minimax
+
+import (
+	"context"
+	"errors"
+	"io"
+	"testing"
+
+	"github.com/GizClaw/flowcraft/core/inference"
+	"github.com/GizClaw/flowcraft/core/inference/inferencetest"
+	"github.com/GizClaw/flowcraft/core/message"
+)
+
+func conformanceTextRequest() inference.GenerateRequest {
+	return inference.GenerateRequest{Input: inference.GenerateInput{
+		Role: inference.InputRoleUser,
+		Content: inference.InputContent{
+			Content: message.Content{Parts: []message.Part{message.TextPart{Text: "hi"}}},
+			Intent:  inference.Intent{Text: &inference.TextIntent{}},
+		},
+	}}
+}
+
+func conformanceModel(name string) inference.ModelRef {
+	return inference.ModelRef{
+		ID:      inference.ModelID{Provider: driverID, Name: name},
+		Profile: "default",
+	}
+}
+
+func conformanceGenerateDrivers[Wire any](
+	t *testing.T,
+	compile inference.GenerateCompiler[Wire],
+	calls *inferencetest.Counter,
+) (inference.GenerateDriver, inference.GenerateStreamDriver) {
+	t.Helper()
+	operations, err := inference.BindGenerateOperations(
+		compile,
+		countingTransport(calls, func(_ context.Context, wire Wire) (Wire, error) { return wire, nil }),
+		inference.Decoder[Wire, inference.GenerateResponse](
+			func(_ context.Context, _ Wire) (inference.GenerateResponse, error) {
+				return inference.GenerateResponse{
+					Message: message.Message{
+						Role:    message.RoleAssistant,
+						Content: message.Content{Parts: []message.Part{message.TextPart{Text: "ok"}}},
+					},
+					FinishReason: inference.FinishCompleted,
+				}, nil
+			},
+		),
+		countingTransport(calls, func(_ context.Context, _ Wire) (inference.ProviderStream[inference.GenerateStreamEvent], error) {
+			return &conformanceStream{events: []inference.GenerateStreamEvent{
+				{PartIndex: 0, Delta: inference.TextPartDelta{Text: "ok"}},
+				{FinishReason: inference.FinishCompleted},
+			}}, nil
+		}),
+		inference.GenerateStreamDecoder[inference.GenerateStreamEvent](
+			func(_ context.Context, event inference.GenerateStreamEvent) (inference.GenerateStreamEvent, error) {
+				return event, nil
+			},
+		),
+	)
+	if err != nil {
+		t.Fatalf("BindGenerateOperations: %v", err)
+	}
+	return operations.Unary, operations.Stream
+}
+
+func countingTransport[Wire, Raw any](
+	calls *inferencetest.Counter,
+	next inference.Transport[Wire, Raw],
+) inference.Transport[Wire, Raw] {
+	return func(ctx context.Context, wire Wire) (Raw, error) {
+		calls.Inc()
+		return next(ctx, wire)
+	}
+}
+
+type conformanceStream struct {
+	events []inference.GenerateStreamEvent
+	index  int
+}
+
+func (s *conformanceStream) Next(context.Context) (inference.GenerateStreamEvent, error) {
+	if s.index >= len(s.events) {
+		return inference.GenerateStreamEvent{}, io.EOF
+	}
+	event := s.events[s.index]
+	s.index++
+	return event, nil
+}
+func (*conformanceStream) Close() error { return nil }
+
+func TestConformanceGenerateConcurrent(t *testing.T) {
+	calls := &inferencetest.Counter{}
+	model := "MiniMax-M3"
+	unary, stream := conformanceGenerateDrivers(t, compileGenerate(model, catalog[model]), calls)
+	inferencetest.RunGenerateConcurrent(t, inferencetest.GenerateConcurrentSuite{
+		Model:      conformanceModel(model),
+		Request:    conformanceTextRequest,
+		Unary:      unary,
+		Stream:     stream,
+		Goroutines: 2,
+	})
+}
+
+var errStreamFailure = errors.New("stream failure")
+
+type failingStream struct{}
+
+func (*failingStream) Next(context.Context) (inference.GenerateStreamEvent, error) {
+	return inference.GenerateStreamEvent{}, errStreamFailure
+}
+func (*failingStream) Close() error { return nil }
+
+func TestConformanceGenerateStreamFailure(t *testing.T) {
+	calls := &inferencetest.Counter{}
+	model := "MiniMax-M3"
+	driver, err := inference.BindGenerateStream(
+		compileGenerate(model, catalog[model]),
+		countingTransport(calls, func(_ context.Context, _ generateWire) (inference.ProviderStream[inference.GenerateStreamEvent], error) {
+			return &failingStream{}, nil
+		}),
+		inference.GenerateStreamDecoder[inference.GenerateStreamEvent](
+			func(_ context.Context, event inference.GenerateStreamEvent) (inference.GenerateStreamEvent, error) {
+				return event, nil
+			},
+		),
+	)
+	if err != nil {
+		t.Fatalf("BindGenerateStream: %v", err)
+	}
+	inferencetest.RunGenerateStreamFailure(t, inferencetest.GenerateStreamFailureSuite{
+		Model:          conformanceModel(model),
+		Request:        conformanceTextRequest,
+		Driver:         driver,
+		TransportCalls: calls.Load,
+		AssertError: func(t *testing.T, err error) {
+			if !errors.Is(err, errStreamFailure) {
+				t.Fatalf("stream error = %v", err)
+			}
+		},
+	})
+}

--- a/driver/openai/conformance_new_test.go
+++ b/driver/openai/conformance_new_test.go
@@ -1,0 +1,145 @@
+package openai
+
+import (
+	"context"
+	"errors"
+	"io"
+	"testing"
+
+	"github.com/GizClaw/flowcraft/core/inference"
+	"github.com/GizClaw/flowcraft/core/inference/inferencetest"
+	"github.com/GizClaw/flowcraft/core/message"
+)
+
+func TestConformanceGenerateConcurrent(t *testing.T) {
+	calls := &inferencetest.Counter{}
+	unary, stream := conformanceGenerateDriversOpenAI(t, calls)
+	inferencetest.RunGenerateConcurrent(t, inferencetest.GenerateConcurrentSuite{
+		Model:      openaiModel("gpt-5.6-sol"),
+		Request:    func() inference.GenerateRequest { return simpleTextRequest("hi") },
+		Unary:      unary,
+		Stream:     stream,
+		Goroutines: 2,
+	})
+}
+
+func conformanceGenerateDriversOpenAI(
+	t *testing.T,
+	calls *inferencetest.Counter,
+) (inference.GenerateDriver, inference.GenerateStreamDriver) {
+	t.Helper()
+	model := "gpt-5.6-sol"
+	operations, err := inference.BindGenerateOperations(
+		compileGenerate(model, catalog[model]),
+		countingTransport(calls, func(_ context.Context, wire generateWire) (generateWire, error) { return wire, nil }),
+		inference.Decoder[generateWire, inference.GenerateResponse](
+			func(_ context.Context, _ generateWire) (inference.GenerateResponse, error) {
+				return inference.GenerateResponse{
+					Message: message.Message{
+						Role:    message.RoleAssistant,
+						Content: message.Content{Parts: []message.Part{message.TextPart{Text: "ok"}}},
+					},
+					FinishReason: inference.FinishCompleted,
+				}, nil
+			},
+		),
+		countingTransport(calls, func(_ context.Context, _ generateWire) (inference.ProviderStream[inference.GenerateStreamEvent], error) {
+			return &okOpenAIStream{events: []inference.GenerateStreamEvent{
+				{PartIndex: 0, Delta: inference.TextPartDelta{Text: "ok"}},
+				{FinishReason: inference.FinishCompleted},
+			}}, nil
+		}),
+		inference.GenerateStreamDecoder[inference.GenerateStreamEvent](
+			func(_ context.Context, event inference.GenerateStreamEvent) (inference.GenerateStreamEvent, error) {
+				return event, nil
+			},
+		),
+	)
+	if err != nil {
+		t.Fatalf("BindGenerateOperations: %v", err)
+	}
+	return operations.Unary, operations.Stream
+}
+
+type okOpenAIStream struct {
+	events []inference.GenerateStreamEvent
+	index  int
+}
+
+func (s *okOpenAIStream) Next(context.Context) (inference.GenerateStreamEvent, error) {
+	if s.index >= len(s.events) {
+		return inference.GenerateStreamEvent{}, io.EOF
+	}
+	event := s.events[s.index]
+	s.index++
+	return event, nil
+}
+func (*okOpenAIStream) Close() error { return nil }
+
+func TestConformanceEmbedUnary(t *testing.T) {
+	calls := &inferencetest.Counter{}
+	model := "text-embedding-3-large"
+	driver, err := inference.BindEmbed(
+		compileEmbed(model, catalog[model]),
+		countingTransport(calls, func(_ context.Context, wire embedWire) (embedWire, error) { return wire, nil }),
+		inference.Decoder[embedWire, inference.EmbedResponse](
+			func(_ context.Context, _ embedWire) (inference.EmbedResponse, error) {
+				return inference.EmbedResponse{
+					Embeddings: []inference.Embedding{{Vector: []float32{1}}},
+				}, nil
+			},
+		),
+	)
+	if err != nil {
+		t.Fatalf("BindEmbed: %v", err)
+	}
+	inferencetest.RunEmbedUnary(t, inferencetest.EmbedUnarySuite{
+		Model: openaiModel(model),
+		Request: func() inference.EmbedRequest {
+			return inference.EmbedRequest{Items: []inference.EmbedItem{{
+				Content: message.Content{Parts: []message.Part{message.TextPart{Text: "hi"}}},
+			}}}
+		},
+		Driver:         driver,
+		TransportCalls: calls.Load,
+	})
+}
+
+var errOpenAIStreamFailure = errors.New("openai stream failure")
+
+type failingOpenAIStream struct{}
+
+func (*failingOpenAIStream) Next(context.Context) (inference.GenerateStreamEvent, error) {
+	return inference.GenerateStreamEvent{}, errOpenAIStreamFailure
+}
+func (*failingOpenAIStream) Close() error { return nil }
+
+func TestConformanceGenerateStreamFailure(t *testing.T) {
+	calls := &inferencetest.Counter{}
+	model := "gpt-5.6-sol"
+	driver, err := inference.BindGenerateStream(
+		compileGenerate(model, catalog[model]),
+		countingTransport(calls, func(_ context.Context, _ generateWire) (inference.ProviderStream[inference.GenerateStreamEvent], error) {
+			return &failingOpenAIStream{}, nil
+		}),
+		inference.GenerateStreamDecoder[inference.GenerateStreamEvent](
+			func(_ context.Context, event inference.GenerateStreamEvent) (inference.GenerateStreamEvent, error) {
+				return event, nil
+			},
+		),
+	)
+	if err != nil {
+		t.Fatalf("BindGenerateStream: %v", err)
+	}
+	inferencetest.RunGenerateStreamFailure(t, inferencetest.GenerateStreamFailureSuite{
+		Model:          openaiModel(model),
+		Request:        func() inference.GenerateRequest { return simpleTextRequest("hi") },
+		Driver:         driver,
+		TransportCalls: calls.Load,
+		AssertError: func(t *testing.T, err error) {
+			if !errors.Is(err, errOpenAIStreamFailure) {
+				t.Fatalf("stream error = %v", err)
+			}
+		},
+	})
+}

--- a/driver/qwen/conformance_test.go
+++ b/driver/qwen/conformance_test.go
@@ -1,0 +1,185 @@
+package qwen
+
+import (
+	"context"
+	"errors"
+	"io"
+	"testing"
+
+	"github.com/GizClaw/flowcraft/core/inference"
+	"github.com/GizClaw/flowcraft/core/inference/inferencetest"
+	"github.com/GizClaw/flowcraft/core/message"
+)
+
+func conformanceTextRequest() inference.GenerateRequest {
+	return inference.GenerateRequest{Input: inference.GenerateInput{
+		Role: inference.InputRoleUser,
+		Content: inference.InputContent{
+			Content: message.Content{Parts: []message.Part{message.TextPart{Text: "hi"}}},
+			Intent:  inference.Intent{Text: &inference.TextIntent{}},
+		},
+	}}
+}
+
+func conformanceModel(name string) inference.ModelRef {
+	return inference.ModelRef{
+		ID:      inference.ModelID{Provider: driverID, Name: name},
+		Profile: "default",
+	}
+}
+
+func conformanceEmbedRequest() inference.EmbedRequest {
+	return inference.EmbedRequest{Items: []inference.EmbedItem{{
+		Content: message.Content{Parts: []message.Part{message.TextPart{Text: "hi"}}},
+	}}}
+}
+
+func conformanceGenerateDrivers[Wire any](
+	t *testing.T,
+	compile inference.GenerateCompiler[Wire],
+	calls *inferencetest.Counter,
+) (inference.GenerateDriver, inference.GenerateStreamDriver) {
+	t.Helper()
+	operations, err := inference.BindGenerateOperations(
+		compile,
+		countingTransport(calls, func(_ context.Context, wire Wire) (Wire, error) { return wire, nil }),
+		inference.Decoder[Wire, inference.GenerateResponse](
+			func(_ context.Context, _ Wire) (inference.GenerateResponse, error) {
+				return inference.GenerateResponse{
+					Message: message.Message{
+						Role:    message.RoleAssistant,
+						Content: message.Content{Parts: []message.Part{message.TextPart{Text: "ok"}}},
+					},
+					FinishReason: inference.FinishCompleted,
+				}, nil
+			},
+		),
+		countingTransport(calls, func(_ context.Context, _ Wire) (inference.ProviderStream[inference.GenerateStreamEvent], error) {
+			return &conformanceStream{events: []inference.GenerateStreamEvent{
+				{PartIndex: 0, Delta: inference.TextPartDelta{Text: "ok"}},
+				{FinishReason: inference.FinishCompleted},
+			}}, nil
+		}),
+		inference.GenerateStreamDecoder[inference.GenerateStreamEvent](
+			func(_ context.Context, event inference.GenerateStreamEvent) (inference.GenerateStreamEvent, error) {
+				return event, nil
+			},
+		),
+	)
+	if err != nil {
+		t.Fatalf("BindGenerateOperations: %v", err)
+	}
+	return operations.Unary, operations.Stream
+}
+
+func conformanceEmbedDriver[Wire any](
+	t *testing.T,
+	compile inference.Compiler[inference.EmbedRequest, Wire],
+	calls *inferencetest.Counter,
+) inference.EmbedDriver {
+	t.Helper()
+	driver, err := inference.BindEmbed(
+		compile,
+		countingTransport(calls, func(_ context.Context, wire Wire) (Wire, error) { return wire, nil }),
+		inference.Decoder[Wire, inference.EmbedResponse](
+			func(_ context.Context, _ Wire) (inference.EmbedResponse, error) {
+				return inference.EmbedResponse{
+					Embeddings: []inference.Embedding{{Vector: []float32{1}}},
+				}, nil
+			},
+		),
+	)
+	if err != nil {
+		t.Fatalf("BindEmbed: %v", err)
+	}
+	return driver
+}
+
+func countingTransport[Wire, Raw any](
+	calls *inferencetest.Counter,
+	next inference.Transport[Wire, Raw],
+) inference.Transport[Wire, Raw] {
+	return func(ctx context.Context, wire Wire) (Raw, error) {
+		calls.Inc()
+		return next(ctx, wire)
+	}
+}
+
+type conformanceStream struct {
+	events []inference.GenerateStreamEvent
+	index  int
+}
+
+func (s *conformanceStream) Next(context.Context) (inference.GenerateStreamEvent, error) {
+	if s.index >= len(s.events) {
+		return inference.GenerateStreamEvent{}, io.EOF
+	}
+	event := s.events[s.index]
+	s.index++
+	return event, nil
+}
+func (*conformanceStream) Close() error { return nil }
+
+func TestConformanceGenerateConcurrent(t *testing.T) {
+	calls := &inferencetest.Counter{}
+	model := "qwen-plus"
+	unary, stream := conformanceGenerateDrivers(t, compileGenerate(model, catalog[model]), calls)
+	inferencetest.RunGenerateConcurrent(t, inferencetest.GenerateConcurrentSuite{
+		Model:      conformanceModel(model),
+		Request:    conformanceTextRequest,
+		Unary:      unary,
+		Stream:     stream,
+		Goroutines: 2,
+	})
+}
+
+func TestConformanceEmbedUnary(t *testing.T) {
+	calls := &inferencetest.Counter{}
+	model := "text-embedding-v4"
+	driver := conformanceEmbedDriver(t, compileEmbed(model, catalog[model]), calls)
+	inferencetest.RunEmbedUnary(t, inferencetest.EmbedUnarySuite{
+		Model:          conformanceModel(model),
+		Request:        conformanceEmbedRequest,
+		Driver:         driver,
+		TransportCalls: calls.Load,
+	})
+}
+
+var errStreamFailure = errors.New("stream failure")
+
+type failingStream struct{}
+
+func (*failingStream) Next(context.Context) (inference.GenerateStreamEvent, error) {
+	return inference.GenerateStreamEvent{}, errStreamFailure
+}
+func (*failingStream) Close() error { return nil }
+
+func TestConformanceGenerateStreamFailure(t *testing.T) {
+	calls := &inferencetest.Counter{}
+	model := "qwen-plus"
+	driver, err := inference.BindGenerateStream(
+		compileGenerate(model, catalog[model]),
+		countingTransport(calls, func(_ context.Context, _ generateWire) (inference.ProviderStream[inference.GenerateStreamEvent], error) {
+			return &failingStream{}, nil
+		}),
+		inference.GenerateStreamDecoder[inference.GenerateStreamEvent](
+			func(_ context.Context, event inference.GenerateStreamEvent) (inference.GenerateStreamEvent, error) {
+				return event, nil
+			},
+		),
+	)
+	if err != nil {
+		t.Fatalf("BindGenerateStream: %v", err)
+	}
+	inferencetest.RunGenerateStreamFailure(t, inferencetest.GenerateStreamFailureSuite{
+		Model:          conformanceModel(model),
+		Request:        conformanceTextRequest,
+		Driver:         driver,
+		TransportCalls: calls.Load,
+		AssertError: func(t *testing.T, err error) {
+			if !errors.Is(err, errStreamFailure) {
+				t.Fatalf("stream error = %v", err)
+			}
+		},
+	})
+}


### PR DESCRIPTION
Add inferencetest embed/stream-failure/concurrent suites, wire them into every driver, and make CI lint matrix change-driven.