### PR TITLE
test(core): complete agent conformance suites and wire real implementations

### DIFF
--- a/core/agent/a2a/contract_test.go
+++ b/core/agent/a2a/contract_test.go
@@ -1,0 +1,53 @@
+package a2a
+
+import (
+	"context"
+	"testing"
+
+	"github.com/GizClaw/flowcraft/core/agent"
+	"github.com/GizClaw/flowcraft/core/agent/agenttest"
+	a2aprotocol "github.com/a2aproject/a2a-go/v2/a2a"
+)
+
+// testCard is a minimal JSON-RPC AgentCard pointing at a port that is
+// never dialled: every contract subtest drives an empty board, which
+// completes as a local no-op before any network call.
+func testCard() *a2aprotocol.AgentCard {
+	return &a2aprotocol.AgentCard{
+		Name: "contract-agent",
+		SupportedInterfaces: []*a2aprotocol.AgentInterface{
+			{
+				URL:             "http://127.0.0.1:9/jsonrpc",
+				ProtocolBinding: a2aprotocol.TransportProtocolJSONRPC,
+				ProtocolVersion: a2aprotocol.Version,
+			},
+		},
+	}
+}
+
+// TestEngine_Contract runs the shared agent.Engine conformance suite
+// against the A2A proxy engine.
+func TestEngine_Contract(t *testing.T) {
+	// Construction is deterministic (fixed card + options): validate it
+	// once up front so the per-subtest factory never needs *testing.T.
+	// The suite's factory must return a fresh engine per subtest.
+	if _, err := New(context.Background(), testCard(), WithStreamMode(StreamModeOff)); err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	agenttest.EngineSuite(t, func() (agent.Engine, agenttest.Capabilities) {
+		eng, _ := New(context.Background(), testCard(), WithStreamMode(StreamModeOff))
+		return eng, agenttest.Capabilities{SupportsResume: true}
+	})
+}
+
+// TestEngine_ResumerContract runs the shared agent.Resumer conformance
+// suite against Engine.CanResume.
+func TestEngine_ResumerContract(t *testing.T) {
+	if _, err := New(context.Background(), testCard(), WithStreamMode(StreamModeOff)); err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	agenttest.ResumerSuite(t, func() agent.Resumer {
+		eng, _ := New(context.Background(), testCard(), WithStreamMode(StreamModeOff))
+		return eng
+	})
+}

--- a/core/agent/agenttest/after_execute_suite.go
+++ b/core/agent/agenttest/after_execute_suite.go
@@ -1,25 +1,3 @@
-// Package agenttest provides reusable contract-test machinery for
-// the interfaces declared in core/agent — [agent.Referee] and
-// [agent.Observer] today, more if the agent package grows.
-//
-// Modeled on the stdlib xxxtest layout: ONE xxxtest sub-package
-// per parent package, multiple suites within when the parent
-// declares multiple contractual interfaces. See io/iotest,
-// net/http/httptest, gocloud.dev/blob/drivertest for the same
-// pattern in the wider Go ecosystem.
-//
-// # What lives here
-//
-//   - [RefereeSuite] — the contract every [agent.Referee]
-//     implementation should pass.
-//   - [ObserverSuite] — the contract every [agent.Observer]
-//     implementation should pass.
-//
-// # What does NOT live here
-//
-// Referee / Observer business logic — those are per-implementation
-// unit tests. The suites only enforce "agent.Execute can call you
-// safely without crashing the run".
 package agenttest
 
 import (

--- a/core/agent/agenttest/checkpoint_store_suite.go
+++ b/core/agent/agenttest/checkpoint_store_suite.go
@@ -1,6 +1,3 @@
-// Package agenttest provides shared conformance suites for core/agent
-// contracts. Store implementations (workspace, future sqlite, ...) run
-// the same suite so behaviour cannot drift between backends.
 package agenttest
 
 import (
@@ -203,15 +200,19 @@ func CheckpointStoreSuite(t *testing.T, newStore func() agent.CheckpointStore) {
 }
 
 func checkpointStoreSample(execID string) agent.Checkpoint {
+	// Fixed whole-second timestamps keep the identity checks portable:
+	// stores that truncate sub-second precision must still pass.
+	ts := time.Unix(1_700_000_000, 0)
 	return agent.Checkpoint{
-		ExecID:      execID,
-		Steps:       []string{"wave-1"},
-		Iteration:   3,
-		Board:       checkpointStoreBoard(),
-		Payload:     []byte(`{"task_id":"t1"}`),
-		Attributes:  map[string]string{"tenant": "tenant-a"},
-		Timestamp:   time.Now(),
-		SpecVersion: "v1",
+		ExecID:            execID,
+		Steps:             []string{"wave-1"},
+		Iteration:         3,
+		Board:             checkpointStoreBoard(),
+		Payload:           []byte(`{"task_id":"t1"}`),
+		Attributes:        map[string]string{"tenant": "tenant-a"},
+		Timestamp:         ts,
+		OriginalStartedAt: ts,
+		SpecVersion:       "v1",
 	}
 }
 
@@ -237,9 +238,14 @@ func containsString(values []string, want string) bool {
 }
 
 func checkpointEqual(a, b agent.Checkpoint) bool {
-	if !a.Timestamp.Equal(b.Timestamp) || !a.OriginalStartedAt.Equal(b.OriginalStartedAt) {
+	if !a.OriginalStartedAt.Equal(b.OriginalStartedAt) {
 		return false
 	}
+	// Timestamp is advisory: [agent.Checkpoint] explicitly allows
+	// hosts to overwrite it when they persist, and sub-second
+	// precision is not portable across store backends. OriginalStartedAt
+	// is compared separately above because resume plumbing
+	// (agent.LoadAndResume) threads it through the store.
 	a.Timestamp = time.Time{}
 	b.Timestamp = time.Time{}
 	a.OriginalStartedAt = time.Time{}

--- a/core/agent/agenttest/doc.go
+++ b/core/agent/agenttest/doc.go
@@ -1,6 +1,9 @@
 // Package agenttest provides reusable contract-test machinery for
 // the interfaces declared in core/agent — [agent.Engine], [agent.Host],
-// [agent.Observer] and [agent.Referee] today.
+// [agent.Observer], [agent.Referee], [agent.CheckpointStore],
+// [agent.Resumer], [agent.StreamSink], [agent.Preparer],
+// [agent.Committer], [agent.CommitViewProvider],
+// [agent.CheckpointSuggester] and [agent.ScriptRuntime].
 //
 // Modeled on net/http/httptest, testing/iotest, and
 // gocloud.dev/blob/drivertest: a single sibling package next to its
@@ -34,11 +37,44 @@
 //   - [RefereeSuite] — the standard contract every
 //     [agent.Referee] implementation should pass.
 //
+//   - [CheckpointStoreSuite] — the shared conformance suite every
+//     [agent.CheckpointStore] implementation should pass, including
+//     the optional [agent.CheckpointLister] / [agent.CheckpointDeleter]
+//     extensions.
+//
+//   - [ResumerSuite] — the contract every [agent.Resumer]
+//     implementation should pass (cheap, classified, mutation-free,
+//     concurrent-safe).
+//
+//   - [StreamSinkSuite] — the contract every [agent.StreamSink]
+//     implementation should pass (panic-free, ctx-observing,
+//     concurrent-safe).
+//
+//   - [PreparerSuite] — the contract every [agent.Preparer]
+//     implementation should pass (non-nil fresh boards, no input
+//     mutation, ctx-observing).
+//
+//   - [CommitterSuite] — the contract every [agent.Committer]
+//     implementation should pass (no input mutation, ctx-observing).
+//
+//   - [CommitViewProviderSuite] — the contract every
+//     [agent.CommitViewProvider] implementation should pass (non-nil
+//     projected board, no input mutation, ctx-observing).
+//
+//   - [CheckpointSuggesterSuite] — the contract every
+//     [agent.CheckpointSuggester] implementation should pass
+//     (panic-free, prompt return).
+//
+//   - [ScriptRuntimeSuite] — the contract every [agent.ScriptRuntime]
+//     implementation should pass (panic-free, executes a caller-supplied
+//     minimal fixture, concurrent-safe).
+//
 //   - [MockHost] — a minimal Host implementation that records every
-//     interaction, lets tests inject interrupts / user replies, and
-//     exposes the captured envelopes / usage / checkpoints for
-//     assertion. Engines may use it directly in their own tests
-//     instead of re-implementing the full Host surface.
+//     interaction, lets tests inject interrupts / user replies /
+//     publish-checkpoint-usage errors, and exposes the captured
+//     envelopes / usage / checkpoints for assertion. Engines may use
+//     it directly in their own tests instead of re-implementing the
+//     full Host surface.
 //
 // # What does NOT live here
 //

--- a/core/agent/agenttest/engine_suite.go
+++ b/core/agent/agenttest/engine_suite.go
@@ -70,6 +70,7 @@ func EngineSuite(t *testing.T, f Factory) {
 	t.Run("InterruptZeroValue", func(t *testing.T) { testInterruptZeroValue(t, f) })
 	t.Run("AttributesUntouched", func(t *testing.T) { testAttributesUntouched(t, f) })
 	t.Run("PublishErrorTolerated", func(t *testing.T) { testPublishErrorTolerated(t, f) })
+	t.Run("BudgetExceededPropagated", func(t *testing.T) { testBudgetExceeded(t, f) })
 	t.Run("ResumeForeignExecID", func(t *testing.T) { testResumeForeignExecID(t, f) })
 	t.Run("ResumeNotSupported", func(t *testing.T) { testResumeNotSupported(t, f) })
 }
@@ -117,9 +118,15 @@ func testContextCancel(t *testing.T, f Factory) {
 
 	// Engines may finish before noticing cancel (trivial engines that
 	// do no work succeed immediately); only assert the error shape
-	// when an error is present.
-	if err != nil && !errors.Is(err, context.Canceled) && !errors.Is(err, context.DeadlineExceeded) {
-		t.Errorf("ctx-cancel error is not context.Canceled / DeadlineExceeded: %v", err)
+	// when an error is present. agent.Execute accepts both the raw
+	// context errors and their classified errdefs equivalents
+	// (Aborted/Timeout), so the suite accepts the same set.
+	if err != nil &&
+		!errors.Is(err, context.Canceled) &&
+		!errors.Is(err, context.DeadlineExceeded) &&
+		!errdefs.IsAborted(err) &&
+		!errdefs.IsTimeout(err) {
+		t.Errorf("ctx-cancel error is not context.Canceled / DeadlineExceeded (or their classified equivalents): %v", err)
 	}
 	if got == nil {
 		t.Error("ctx-cancel returned nil board; partial board must still be returned")
@@ -226,6 +233,11 @@ func testAttributesUntouched(t *testing.T, f Factory) {
 // testPublishErrorTolerated verifies that a Publisher returning an
 // error does not cause the engine to fail the run. Publish errors are
 // observability concerns, never control flow per [agent.Publisher].
+//
+// The one documented exception is the mandatory run-end envelope
+// ([agent.SubjectRunEnd]): engines that treat it as a delivery
+// barrier may surface [agent.RunEndPublishError]. Every other
+// mid-run publish failure must be swallowed.
 func testPublishErrorTolerated(t *testing.T, f Factory) {
 	t.Helper()
 	eng, _ := f()
@@ -237,9 +249,46 @@ func testPublishErrorTolerated(t *testing.T, f Factory) {
 	run := agent.Run{Identity: agent.Identity{RunID: "run-pub-err"}}
 
 	_, err := eng.Execute(context.Background(), run, host, board)
-	if err != nil {
+	var runEndErr *agent.RunEndPublishError
+	if err != nil && !errors.As(err, &runEndErr) {
 		t.Fatalf("Execute failed because Publish returned error; "+
-			"publish errors must not propagate: %v", err)
+			"publish errors must not propagate (except the run-end barrier): %v", err)
+	}
+}
+
+// testBudgetExceeded verifies the [agent.UsageReporter] budget
+// contract on the engine side: when ReportUsage returns a
+// budget-exceeded error, the engine MUST stop performing further
+// LLM-cost-incurring work and return the error from Execute.
+//
+// Engines that never call ReportUsage cannot observe the signal, so
+// the subtest skips when no usage was reported.
+func testBudgetExceeded(t *testing.T, f Factory) {
+	t.Helper()
+	eng, _ := f()
+
+	host := NewMockHost()
+	host.SetUsageError(errdefs.BudgetExceededf("simulated budget exhaustion"))
+
+	board := agent.NewBoard()
+	run := agent.Run{Identity: agent.Identity{RunID: "run-budget"}}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	got, err := eng.Execute(ctx, run, host, board)
+	if got == nil {
+		t.Error("budget-exceeded run returned nil board; partial board must still be returned")
+	}
+
+	if len(host.Usages()) == 0 {
+		t.Skip("engine never reported usage; the budget signal cannot be observed by this engine")
+	}
+	if err == nil {
+		t.Fatal("engine observed a BudgetExceeded usage error but completed cleanly; it must stop LLM-cost-incurring work and return the error")
+	}
+	if !errdefs.IsBudgetExceeded(err) {
+		t.Fatalf("budget-exceeded error must satisfy errdefs.IsBudgetExceeded; got %v", err)
 	}
 }
 

--- a/core/agent/agenttest/engine_suite_test.go
+++ b/core/agent/agenttest/engine_suite_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/GizClaw/flowcraft/core/agent"
 	"github.com/GizClaw/flowcraft/core/agent/agenttest"
 	"github.com/GizClaw/flowcraft/core/errdefs"
+	"github.com/GizClaw/flowcraft/core/inference"
 )
 
 // fakeEngine is the minimum-correct agent.Engine for the contract
@@ -69,6 +70,41 @@ func (fakeResumableEngine) Execute(
 	}
 }
 
+// fakeUsageReportingEngine reports one usage delta before completing,
+// so the suite's budget-exceeded subtest can observe the signal. It
+// is otherwise identical to fakeEngine.
+type fakeUsageReportingEngine struct{}
+
+func (fakeUsageReportingEngine) Execute(
+	ctx context.Context,
+	run agent.Run,
+	host agent.Host,
+	board *agent.Board,
+) (*agent.Board, error) {
+	if run.ResumeFrom != nil {
+		if run.ResumeFrom.ExecID != run.RunID {
+			return board, errdefs.Validationf(
+				"engine: ResumeFrom.ExecID %q != Run.RunID %q",
+				run.ResumeFrom.ExecID, run.RunID,
+			)
+		}
+		return board, errdefs.NotAvailablef("fakeUsageReportingEngine: resume not supported")
+	}
+
+	if err := host.ReportUsage(ctx, inference.Usage{InputTokens: 1}); err != nil {
+		return board, err
+	}
+
+	select {
+	case <-ctx.Done():
+		return board, ctx.Err()
+	case intr := <-host.Interrupts():
+		return board, agent.Interrupted(intr)
+	default:
+		return board, nil
+	}
+}
+
 // TestSuite_FakeEngine pins down that the contract suite passes
 // against a minimal correct agent. If this ever fails, the suite
 // itself has drifted from the agent.Engine contract.
@@ -83,5 +119,14 @@ func TestSuite_FakeEngine(t *testing.T) {
 func TestSuite_FakeResumableEngine(t *testing.T) {
 	agenttest.EngineSuite(t, func() (agent.Engine, agenttest.Capabilities) {
 		return fakeResumableEngine{}, agenttest.Capabilities{SupportsResume: true}
+	})
+}
+
+// TestSuite_FakeUsageReportingEngine pins down the budget-exceeded
+// branch: the fake reports usage, observes the injected budget error,
+// and returns it.
+func TestSuite_FakeUsageReportingEngine(t *testing.T) {
+	agenttest.EngineSuite(t, func() (agent.Engine, agenttest.Capabilities) {
+		return fakeUsageReportingEngine{}, agenttest.Capabilities{}
 	})
 }

--- a/core/agent/agenttest/hook_suites_test.go
+++ b/core/agent/agenttest/hook_suites_test.go
@@ -1,0 +1,87 @@
+package agenttest_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/GizClaw/flowcraft/core/agent"
+	"github.com/GizClaw/flowcraft/core/agent/agenttest"
+	"github.com/GizClaw/flowcraft/core/errdefs"
+)
+
+// fakePreparer clones the previous board, satisfying the fresh-value
+// and no-mutation rules.
+type fakePreparer struct{}
+
+func (fakePreparer) Before(
+	_ context.Context,
+	_ agent.Identity,
+	_ *agent.Request,
+	prev *agent.Board,
+) (*agent.Board, error) {
+	return prev.Clone(), nil
+}
+
+func TestPreparerSuite_FakePreparer(t *testing.T) {
+	agenttest.PreparerSuite(t, func() agent.Preparer { return fakePreparer{} })
+}
+
+// fakeCommitter accepts everything.
+type fakeCommitter struct{}
+
+func (fakeCommitter) Commit(context.Context, agent.Identity, *agent.Request, *agent.Result) error {
+	return nil
+}
+
+func TestCommitterSuite_FakeCommitter(t *testing.T) {
+	agenttest.CommitterSuite(t, func() agent.Committer { return fakeCommitter{} })
+}
+
+// fakeCommitViewProvider passes the result board through, rejecting
+// results without one.
+type fakeCommitViewProvider struct{}
+
+func (fakeCommitViewProvider) CommitView(
+	_ context.Context,
+	_ agent.Identity,
+	_ *agent.Request,
+	res *agent.Result,
+) (agent.CommitView, error) {
+	if res == nil || res.LastBoard == nil {
+		return agent.CommitView{}, errdefs.Validationf("agenttest: result board is required")
+	}
+	return agent.CommitView{LastBoard: res.LastBoard}, nil
+}
+
+func TestCommitViewProviderSuite_FakeProvider(t *testing.T) {
+	agenttest.CommitViewProviderSuite(t, func() agent.CommitViewProvider { return fakeCommitViewProvider{} })
+}
+
+// fakeSuggester is a conforming advisory no-op.
+type fakeSuggester struct{}
+
+func (fakeSuggester) SuggestCheckpoint() error { return nil }
+
+func TestCheckpointSuggesterSuite_FakeSuggester(t *testing.T) {
+	agenttest.CheckpointSuggesterSuite(t, func() agent.CheckpointSuggester { return fakeSuggester{} })
+}
+
+// fakeScriptRuntime executes anything without error.
+type fakeScriptRuntime struct{}
+
+func (fakeScriptRuntime) Exec(
+	context.Context,
+	string,
+	string,
+	*agent.ScriptEnv,
+) (*agent.ScriptSignal, error) {
+	return nil, nil
+}
+
+func TestScriptRuntimeSuite_FakeRuntime(t *testing.T) {
+	agenttest.ScriptRuntimeSuite(
+		t,
+		func() agent.ScriptRuntime { return fakeScriptRuntime{} },
+		agenttest.ScriptFixture{Source: "1 + 1;"},
+	)
+}

--- a/core/agent/agenttest/host_suite.go
+++ b/core/agent/agenttest/host_suite.go
@@ -42,6 +42,7 @@ import (
 	"time"
 
 	"github.com/GizClaw/flowcraft/core/agent"
+	"github.com/GizClaw/flowcraft/core/errdefs"
 	"github.com/GizClaw/flowcraft/core/event"
 	"github.com/GizClaw/flowcraft/core/inference"
 )
@@ -62,9 +63,10 @@ type HostCapabilities struct {
 
 	// SkipPublishConcurrency is true when the host's Publish
 	// implementation is intentionally serial (e.g. a writer-locked
-	// log shipper that must preserve order). The suite then runs
-	// the Publish concurrency probe sequentially so the test
-	// reflects the real serial-only contract.
+	// log shipper that must preserve order). The suite then keeps
+	// Publish calls out of the concurrent phase and issues them
+	// sequentially instead, so the test reflects the real
+	// serial-only contract.
 	SkipPublishConcurrency bool
 
 	// AcceptsBudgetExceeded, when true, indicates the host's
@@ -152,10 +154,16 @@ func hostAskUserClassification(t *testing.T, f HostFactory, c HostCapabilities) 
 	if err == nil {
 		_ = reply.Parts
 		if c.SkipAskUserNotAvailable {
+			if len(reply.Parts) == 0 {
+				t.Errorf("AskUser succeeded but returned a zero reply; a host declaring SkipAskUserNotAvailable must produce a real reply")
+			}
 			return
 		}
 		t.Logf("AskUser returned (%+v, nil) on a host that did not declare SkipAskUserNotAvailable; if this host genuinely supports prompting, set HostCapabilities.SkipAskUserNotAvailable=true", reply)
 		return
+	}
+	if !errdefs.IsNotAvailable(err) {
+		t.Errorf("AskUser error must satisfy errdefs.IsNotAvailable (the UserPrompter contract reserves that class for UI-less hosts); got %v", err)
 	}
 }
 
@@ -176,16 +184,20 @@ func hostConcurrentAccess(t *testing.T, f HostFactory, c HostCapabilities) {
 					t.Errorf("concurrent host call panicked: %v", r)
 				}
 			}()
-			_ = h.Publish(ctx, event.Envelope{Subject: "test"})
+			if !c.SkipPublishConcurrency {
+				_ = h.Publish(ctx, event.Envelope{Subject: "test"})
+			}
 			_ = h.Checkpoint(ctx, agent.Checkpoint{ExecID: "x"})
 			_ = h.ReportUsage(ctx, inference.Usage{})
 			_ = h.Interrupts()
 		}()
 	}
-	if c.SkipPublishConcurrency {
-		_ = h.Publish(ctx, event.Envelope{Subject: "seq"})
-	}
 	wg.Wait()
+	if c.SkipPublishConcurrency {
+		for i := 0; i < n; i++ {
+			_ = h.Publish(ctx, event.Envelope{Subject: "seq"})
+		}
+	}
 }
 
 // hostRecoverPanicAs converts a panic inside a method probe into a

--- a/core/agent/agenttest/lifecycle_suites.go
+++ b/core/agent/agenttest/lifecycle_suites.go
@@ -1,0 +1,272 @@
+package agenttest
+
+import (
+	"context"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/GizClaw/flowcraft/core/agent"
+	"github.com/GizClaw/flowcraft/core/message"
+)
+
+// PreparerFactory builds a fresh [agent.Preparer] for each subtest so
+// subtests do not share implementation state.
+type PreparerFactory func() agent.Preparer
+
+// PreparerSuite runs every contract probe that applies to the
+// [agent.Preparer] produced by f:
+//
+//   - zero inputs must not panic;
+//   - a successful Before MUST return a non-nil, fresh Board (the
+//     engine mutates the returned board in place, so returning the
+//     input aliases the previous stage's state);
+//   - the previous board must not be mutated on the success path;
+//   - Before MUST honour ctx cancellation and return promptly.
+func PreparerSuite(t *testing.T, f PreparerFactory) {
+	t.Helper()
+
+	t.Run("ZeroInputNoPanic", func(t *testing.T) { preparerZeroInput(t, f) })
+	t.Run("NonNilBoardOnSuccess", func(t *testing.T) { preparerNonNilBoard(t, f) })
+	t.Run("FreshBoardPerCall", func(t *testing.T) { preparerFreshBoard(t, f) })
+	t.Run("DoesNotMutatePrevious", func(t *testing.T) { preparerNoMutation(t, f) })
+	t.Run("CancelledCtxReturnsPromptly", func(t *testing.T) { preparerCancelledCtx(t, f) })
+}
+
+// ---------- subtests ----------
+
+func preparerZeroInput(t *testing.T, f PreparerFactory) {
+	t.Helper()
+	p := f()
+	defer recoverPanicAs(t, "Before(zero inputs)")
+	_, _ = p.Before(context.Background(), agent.Identity{}, &agent.Request{}, agent.NewBoard())
+}
+
+func preparerNonNilBoard(t *testing.T, f PreparerFactory) {
+	t.Helper()
+	p := f()
+	req := &agent.Request{TaskID: "t1"}
+	next, err := p.Before(context.Background(), agent.Identity{RunID: "r1"}, req, agent.NewBoard())
+	if err != nil {
+		t.Skipf("preparer rejected the minimal inputs: %v", err)
+	}
+	if next == nil {
+		t.Error("Before returned (nil, nil); a successful Before MUST return a non-nil board")
+	}
+}
+
+func preparerFreshBoard(t *testing.T, f PreparerFactory) {
+	t.Helper()
+	p := f()
+	req := &agent.Request{TaskID: "t1"}
+	id := agent.Identity{RunID: "r1"}
+	prev := agent.NewBoard()
+
+	first, err := p.Before(context.Background(), id, req, prev)
+	if err != nil {
+		t.Skipf("preparer rejected the minimal inputs: %v", err)
+	}
+	if first == prev {
+		t.Error("Before returned the input board; Preparers MUST return a fresh value each call (the engine mutates it in place)")
+	}
+	second, err := p.Before(context.Background(), id, req, prev)
+	if err != nil {
+		t.Skipf("second Before rejected the minimal inputs: %v", err)
+	}
+	if second == prev {
+		t.Error("Before returned the input board; Preparers MUST return a fresh value each call")
+	}
+	if second == first {
+		t.Error("two Before calls returned the same board pointer; each call MUST allocate a fresh value")
+	}
+}
+
+func preparerNoMutation(t *testing.T, f PreparerFactory) {
+	t.Helper()
+	p := f()
+	req := &agent.Request{TaskID: "t1"}
+	id := agent.Identity{RunID: "r1"}
+	prev := agent.NewBoard()
+	prev.SetVar("keep", "me")
+	before := prev.Clone()
+
+	if _, err := p.Before(context.Background(), id, req, prev); err != nil {
+		t.Skipf("preparer rejected the minimal inputs: %v", err)
+	}
+	if !reflect.DeepEqual(prev, before) {
+		t.Errorf("Before mutated the previous board:\n  before: %+v\n  after : %+v", before, prev)
+	}
+}
+
+func preparerCancelledCtx(t *testing.T, f PreparerFactory) {
+	t.Helper()
+	p := f()
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	done := make(chan struct{})
+	go func() {
+		_, _ = p.Before(ctx, agent.Identity{}, &agent.Request{}, agent.NewBoard())
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Before did not return within 2s of a cancelled ctx; Preparers MUST honour ctx cancellation")
+	}
+}
+
+// CommitterFactory builds a fresh [agent.Committer] for each subtest.
+type CommitterFactory func() agent.Committer
+
+// CommitterSuite runs every contract probe that applies to the
+// [agent.Committer] produced by f:
+//
+//   - zero inputs must not panic;
+//   - Commit MUST NOT mutate the Request or Result it receives;
+//   - Commit MUST honour ctx cancellation and return promptly.
+func CommitterSuite(t *testing.T, f CommitterFactory) {
+	t.Helper()
+
+	t.Run("ZeroInputNoPanic", func(t *testing.T) { committerZeroInput(t, f) })
+	t.Run("DoesNotMutateInputs", func(t *testing.T) { committerNoMutation(t, f) })
+	t.Run("CancelledCtxReturnsPromptly", func(t *testing.T) { committerCancelledCtx(t, f) })
+}
+
+// ---------- subtests ----------
+
+func committerZeroInput(t *testing.T, f CommitterFactory) {
+	t.Helper()
+	c := f()
+	defer recoverPanicAs(t, "Commit(zero inputs)")
+	_ = c.Commit(context.Background(), agent.Identity{}, &agent.Request{}, &agent.Result{})
+}
+
+func committerNoMutation(t *testing.T, f CommitterFactory) {
+	t.Helper()
+	c := f()
+	board := agent.NewBoard()
+	board.AppendChannelMessage(agent.MainChannel, message.NewTextMessage(message.RoleAssistant, "hi"))
+	req := &agent.Request{TaskID: "t1", ContextID: "c1"}
+	res := &agent.Result{
+		TaskID:    "t1",
+		RunID:     "r1",
+		Status:    agent.StatusCompleted,
+		Committed: true,
+		State:     map[string]any{"k": "v"},
+		LastBoard: board,
+	}
+	reqBefore := *req
+	resBefore := *res
+
+	_ = c.Commit(context.Background(), agent.Identity{AgentID: "a", RunID: "r1"}, req, res)
+
+	if !reflect.DeepEqual(*req, reqBefore) {
+		t.Errorf("Commit mutated *Request:\n  before: %+v\n  after : %+v", reqBefore, *req)
+	}
+	if !reflect.DeepEqual(*res, resBefore) {
+		t.Errorf("Commit mutated *Result:\n  before: %+v\n  after : %+v", resBefore, *res)
+	}
+}
+
+func committerCancelledCtx(t *testing.T, f CommitterFactory) {
+	t.Helper()
+	c := f()
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	done := make(chan struct{})
+	go func() {
+		_ = c.Commit(ctx, agent.Identity{}, &agent.Request{}, &agent.Result{})
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Commit did not return within 2s of a cancelled ctx; Committers MUST honour ctx cancellation")
+	}
+}
+
+// CommitViewFactory builds a fresh [agent.CommitViewProvider] for each
+// subtest.
+type CommitViewFactory func() agent.CommitViewProvider
+
+// CommitViewProviderSuite runs every contract probe that applies to
+// the [agent.CommitViewProvider] produced by f:
+//
+//   - zero inputs must not panic;
+//   - a successful CommitView MUST carry a non-nil LastBoard (a nil
+//     board with a nil error silently fails finalization);
+//   - CommitView MUST NOT mutate the Request or Result it receives;
+//   - CommitView MUST honour ctx cancellation and return promptly.
+func CommitViewProviderSuite(t *testing.T, f CommitViewFactory) {
+	t.Helper()
+
+	t.Run("ZeroInputNoPanic", func(t *testing.T) { commitViewZeroInput(t, f) })
+	t.Run("NonNilBoardOnSuccess", func(t *testing.T) { commitViewNonNilBoard(t, f) })
+	t.Run("DoesNotMutateInputs", func(t *testing.T) { commitViewNoMutation(t, f) })
+	t.Run("CancelledCtxReturnsPromptly", func(t *testing.T) { commitViewCancelledCtx(t, f) })
+}
+
+// ---------- subtests ----------
+
+func commitViewZeroInput(t *testing.T, f CommitViewFactory) {
+	t.Helper()
+	p := f()
+	defer recoverPanicAs(t, "CommitView(zero inputs)")
+	_, _ = p.CommitView(context.Background(), agent.Identity{}, &agent.Request{}, &agent.Result{})
+}
+
+func commitViewNonNilBoard(t *testing.T, f CommitViewFactory) {
+	t.Helper()
+	p := f()
+	req := &agent.Request{TaskID: "t1"}
+	res := &agent.Result{Status: agent.StatusCompleted, LastBoard: agent.NewBoard()}
+	view, err := p.CommitView(context.Background(), agent.Identity{RunID: "r1"}, req, res)
+	if err != nil {
+		t.Skipf("provider rejected the minimal inputs: %v", err)
+	}
+	if view.LastBoard == nil {
+		t.Error("CommitView returned (CommitView{LastBoard: nil}, nil); a nil LastBoard silently fails finalization and must instead be surfaced as an error")
+	}
+}
+
+func commitViewNoMutation(t *testing.T, f CommitViewFactory) {
+	t.Helper()
+	p := f()
+	req := &agent.Request{TaskID: "t1", ContextID: "c1"}
+	res := &agent.Result{
+		TaskID:    "t1",
+		RunID:     "r1",
+		Status:    agent.StatusCompleted,
+		Committed: true,
+		State:     map[string]any{"k": "v"},
+		LastBoard: agent.NewBoard(),
+	}
+	reqBefore := *req
+	resBefore := *res
+
+	_, _ = p.CommitView(context.Background(), agent.Identity{AgentID: "a", RunID: "r1"}, req, res)
+
+	if !reflect.DeepEqual(*req, reqBefore) {
+		t.Errorf("CommitView mutated *Request:\n  before: %+v\n  after : %+v", reqBefore, *req)
+	}
+	if !reflect.DeepEqual(*res, resBefore) {
+		t.Errorf("CommitView mutated *Result:\n  before: %+v\n  after : %+v", resBefore, *res)
+	}
+}
+
+func commitViewCancelledCtx(t *testing.T, f CommitViewFactory) {
+	t.Helper()
+	p := f()
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	done := make(chan struct{})
+	go func() {
+		_, _ = p.CommitView(ctx, agent.Identity{}, &agent.Request{}, &agent.Result{})
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("CommitView did not return within 2s of a cancelled ctx; providers MUST honour ctx cancellation")
+	}
+}

--- a/core/agent/agenttest/mock_host.go
+++ b/core/agent/agenttest/mock_host.go
@@ -38,6 +38,10 @@ type MockHost struct {
 
 	// checkpointErr, if non-nil, is returned from every Checkpoint.
 	checkpointErr error
+
+	// usageErr, if non-nil, is returned from every ReportUsage call
+	// (after the usage value is recorded).
+	usageErr error
 }
 
 // NewMockHost returns a ready-to-use MockHost. The interrupt channel
@@ -162,8 +166,17 @@ func (h *MockHost) Checkpoints() []agent.Checkpoint {
 func (h *MockHost) ReportUsage(_ context.Context, usage inference.Usage) error {
 	h.mu.Lock()
 	h.usages = append(h.usages, usage)
+	err := h.usageErr
 	h.mu.Unlock()
-	return nil
+	return err
+}
+
+// SetUsageError configures all subsequent ReportUsage calls to return
+// err (typically errdefs.BudgetExceeded). Pass nil to clear.
+func (h *MockHost) SetUsageError(err error) {
+	h.mu.Lock()
+	h.usageErr = err
+	h.mu.Unlock()
 }
 
 // Usages returns a copy of every usage report.

--- a/core/agent/agenttest/new_suites_test.go
+++ b/core/agent/agenttest/new_suites_test.go
@@ -1,0 +1,33 @@
+package agenttest_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/GizClaw/flowcraft/core/agent"
+	"github.com/GizClaw/flowcraft/core/agent/agenttest"
+	"github.com/GizClaw/flowcraft/core/event"
+)
+
+// fakeResumer accepts everything. It pins down that the suite passes
+// a minimal correct Resumer; if this ever fails the suite has drifted
+// from the agent.Resumer contract.
+type fakeResumer struct{}
+
+func (fakeResumer) CanResume(agent.Checkpoint) error { return nil }
+
+func TestResumerSuite_FakeResumer(t *testing.T) {
+	agenttest.ResumerSuite(t, func() agent.Resumer { return fakeResumer{} })
+}
+
+// fakeSink discards every delta. It pins down that the suite passes
+// a minimal correct StreamSink.
+type fakeSink struct{}
+
+func (fakeSink) OnDelta(context.Context, event.Envelope, agent.StreamDeltaPayload) error {
+	return nil
+}
+
+func TestStreamSinkSuite_FakeSink(t *testing.T) {
+	agenttest.StreamSinkSuite(t, func() agent.StreamSink { return fakeSink{} })
+}

--- a/core/agent/agenttest/observer_suite.go
+++ b/core/agent/agenttest/observer_suite.go
@@ -13,9 +13,9 @@ import (
 // ObserverFactory builds a fresh [agent.Observer] for each subtest.
 type ObserverFactory func() agent.Observer
 
-// HookCapabilities lets observers opt out of subtests that
+// ObserverCapabilities lets observers opt out of subtests that
 // don't apply. Most observers pass the zero value.
-type HookCapabilities struct {
+type ObserverCapabilities struct {
 	// SkipMutationCheck is true for observers that intentionally
 	// mutate the *Request / *Result they receive. The interface
 	// godoc says "MUST treat as read-only"; this knob exists only
@@ -32,9 +32,9 @@ type HookCapabilities struct {
 
 // ObserverSuite runs every applicable contract subtest against
 // observers produced by f.
-func ObserverSuite(t *testing.T, f ObserverFactory, caps ...HookCapabilities) {
+func ObserverSuite(t *testing.T, f ObserverFactory, caps ...ObserverCapabilities) {
 	t.Helper()
-	c := HookCapabilities{}
+	c := ObserverCapabilities{}
 	if len(caps) > 0 {
 		c = caps[0]
 	}

--- a/core/agent/agenttest/resumer_suite.go
+++ b/core/agent/agenttest/resumer_suite.go
@@ -1,0 +1,135 @@
+package agenttest
+
+import (
+	"reflect"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/GizClaw/flowcraft/core/agent"
+	"github.com/GizClaw/flowcraft/core/errdefs"
+)
+
+// ResumerFactory builds a fresh [agent.Resumer] for each subtest so
+// subtests do not share implementation state.
+type ResumerFactory func() agent.Resumer
+
+// ResumerSuite runs every contract probe that applies to the
+// [agent.Resumer] produced by f. Resumer is the optional cheap,
+// local-only admission probe an engine exposes ahead of resume:
+//
+//   - zero / malformed checkpoints must not panic, and any returned
+//     error must be classified as Validation (wrong shape) or
+//     NotAvailable (recognised but not resumable);
+//   - an empty SpecVersion must never be rejected as a drift failure
+//     (the checkpoint contract says empty means "skip drift check");
+//   - the probe must not mutate the caller's checkpoint;
+//   - it must be cheap (no I/O, no LLM calls) and safe for
+//     concurrent use.
+func ResumerSuite(t *testing.T, f ResumerFactory) {
+	t.Helper()
+
+	t.Run("ZeroInputNoPanic", func(t *testing.T) { resumerZeroInput(t, f) })
+	t.Run("EmptySpecVersionNotDrift", func(t *testing.T) { resumerEmptySpecVersion(t, f) })
+	t.Run("DoesNotMutateCheckpoint", func(t *testing.T) { resumerNoMutation(t, f) })
+	t.Run("PromptReturn", func(t *testing.T) { resumerPromptReturn(t, f) })
+	t.Run("ConcurrentSafe", func(t *testing.T) { resumerConcurrent(t, f) })
+}
+
+// ---------- subtests ----------
+
+func resumerZeroInput(t *testing.T, f ResumerFactory) {
+	t.Helper()
+	r := f()
+	defer recoverPanicAs(t, "CanResume(zero checkpoint)")
+	err := r.CanResume(agent.Checkpoint{})
+	if err != nil && !errdefs.IsValidation(err) && !errdefs.IsNotAvailable(err) {
+		t.Errorf("CanResume(zero checkpoint) = %v; must be nil or classified Validation/NotAvailable", err)
+	}
+}
+
+// resumerEmptySpecVersion verifies the documented "empty SpecVersion
+// means skip the drift check" rule: a Resumer must never return
+// NotAvailable for a checkpoint whose SpecVersion is empty, whatever
+// its own current version is.
+func resumerEmptySpecVersion(t *testing.T, f ResumerFactory) {
+	t.Helper()
+	r := f()
+	cp := agent.Checkpoint{
+		ExecID: "run-1",
+		Board:  &agent.BoardSnapshot{},
+	}
+	defer recoverPanicAs(t, "CanResume(empty SpecVersion)")
+	err := r.CanResume(cp)
+	if errdefs.IsNotAvailable(err) {
+		t.Fatalf("CanResume rejected an empty SpecVersion as NotAvailable; empty means 'skip drift check': %v", err)
+	}
+	if err != nil && !errdefs.IsValidation(err) {
+		t.Errorf("CanResume(empty SpecVersion) = %v; non-drift rejections must be classified Validation", err)
+	}
+}
+
+// resumerNoMutation asserts the probe treats the checkpoint as
+// caller-owned: rejections (or acceptances) must not modify the
+// shared Steps / Board / Payload / Attributes state.
+func resumerNoMutation(t *testing.T, f ResumerFactory) {
+	t.Helper()
+	r := f()
+	cp := agent.Checkpoint{
+		ExecID:            "run-1",
+		Steps:             []string{"wave-1", "wave-2"},
+		Iteration:         3,
+		Board:             &agent.BoardSnapshot{Vars: map[string]any{"x": float64(1)}},
+		Payload:           []byte(`{"task_id":"t1"}`),
+		Attributes:        map[string]string{"tenant": "acme"},
+		Timestamp:         time.Unix(1_700_000_000, 0),
+		OriginalStartedAt: time.Unix(1_700_000_000, 0),
+		SpecVersion:       "v1",
+	}
+	before := cp.Clone()
+	defer recoverPanicAs(t, "CanResume(mutation probe)")
+	_ = r.CanResume(cp)
+	if !reflect.DeepEqual(cp, before) {
+		t.Errorf("CanResume mutated its checkpoint:\n  before: %+v\n  after : %+v", before, cp)
+	}
+}
+
+// resumerPromptReturn bounds CanResume so an implementation that
+// performs I/O / LLM calls against the contract ("MUST be cheap")
+// fails loudly instead of hanging the suite.
+func resumerPromptReturn(t *testing.T, f ResumerFactory) {
+	t.Helper()
+	r := f()
+	cp := agent.Checkpoint{ExecID: "run-1", Board: &agent.BoardSnapshot{}}
+	done := make(chan struct{})
+	go func() {
+		_ = r.CanResume(cp)
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("CanResume did not return within 2s; Resumer probes MUST be cheap (no I/O, no LLM calls)")
+	}
+}
+
+func resumerConcurrent(t *testing.T, f ResumerFactory) {
+	t.Helper()
+	r := f()
+	cp := agent.Checkpoint{ExecID: "run-1", Board: &agent.BoardSnapshot{}}
+	const n = 16
+	var wg sync.WaitGroup
+	for i := 0; i < n; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			defer func() {
+				if r := recover(); r != nil {
+					t.Errorf("concurrent CanResume panicked: %v", r)
+				}
+			}()
+			_ = r.CanResume(cp)
+		}()
+	}
+	wg.Wait()
+}

--- a/core/agent/agenttest/script_runtime_suite.go
+++ b/core/agent/agenttest/script_runtime_suite.go
@@ -1,0 +1,78 @@
+package agenttest
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/GizClaw/flowcraft/core/agent"
+)
+
+// ScriptRuntimeFactory builds a fresh [agent.ScriptRuntime] for each
+// subtest.
+type ScriptRuntimeFactory func() agent.ScriptRuntime
+
+// ScriptFixture describes a minimal script the runtime under test must
+// execute without any host bindings. The source is passed verbatim to
+// [agent.ScriptRuntime.Exec]; the suite only requires it to complete
+// without an error (a nil *ScriptSignal is a valid plain completion).
+type ScriptFixture struct {
+	// Source is a minimal runnable script. The zero value (empty
+	// source) is a valid trivial script for both bundled runtimes.
+	Source string
+}
+
+// ScriptRuntimeSuite runs every contract probe that applies to the
+// [agent.ScriptRuntime] produced by f:
+//
+//   - zero inputs must not panic (an error is acceptable);
+//   - the declared fixture must execute without an error;
+//   - Exec MUST be safe for concurrent use.
+func ScriptRuntimeSuite(t *testing.T, f ScriptRuntimeFactory, fixture ScriptFixture) {
+	t.Helper()
+
+	t.Run("ZeroInputNoPanic", func(t *testing.T) { scriptZeroInput(t, f) })
+	t.Run("FixtureCompletes", func(t *testing.T) { scriptFixture(t, f, fixture) })
+	t.Run("ConcurrentSafe", func(t *testing.T) { scriptConcurrent(t, f, fixture) })
+}
+
+// ---------- subtests ----------
+
+func scriptZeroInput(t *testing.T, f ScriptRuntimeFactory) {
+	t.Helper()
+	r := f()
+	defer recoverPanicAs(t, "Exec(zero inputs)")
+	_, _ = r.Exec(context.Background(), "", "", &agent.ScriptEnv{})
+}
+
+func scriptFixture(t *testing.T, f ScriptRuntimeFactory, fixture ScriptFixture) {
+	t.Helper()
+	r := f()
+	defer recoverPanicAs(t, "Exec(fixture)")
+	if _, err := r.Exec(context.Background(), "agenttest", fixture.Source, &agent.ScriptEnv{}); err != nil {
+		t.Errorf("Exec(fixture) = %v; the declared minimal script must execute without error", err)
+	}
+}
+
+func scriptConcurrent(t *testing.T, f ScriptRuntimeFactory, fixture ScriptFixture) {
+	t.Helper()
+	r := f()
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	const n = 16
+	var wg sync.WaitGroup
+	for i := 0; i < n; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			defer func() {
+				if r := recover(); r != nil {
+					t.Errorf("concurrent Exec panicked: %v", r)
+				}
+			}()
+			_, _ = r.Exec(ctx, "agenttest", fixture.Source, &agent.ScriptEnv{})
+		}()
+	}
+	wg.Wait()
+}

--- a/core/agent/agenttest/stream_sink_suite.go
+++ b/core/agent/agenttest/stream_sink_suite.go
@@ -1,0 +1,85 @@
+package agenttest
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/GizClaw/flowcraft/core/agent"
+	"github.com/GizClaw/flowcraft/core/event"
+	"github.com/GizClaw/flowcraft/core/message"
+)
+
+// SinkFactory builds a fresh [agent.StreamSink] for each subtest so
+// subtests do not share sink state.
+type SinkFactory func() agent.StreamSink
+
+// StreamSinkSuite runs every contract probe that applies to the
+// [agent.StreamSink] produced by f:
+//
+//   - zero-value envelopes and payloads must not panic;
+//   - OnDelta MUST observe ctx cancellation and return promptly;
+//   - implementations MUST be safe for concurrent OnDelta calls.
+func StreamSinkSuite(t *testing.T, f SinkFactory) {
+	t.Helper()
+
+	t.Run("ZeroInputNoPanic", func(t *testing.T) { sinkZeroInput(t, f) })
+	t.Run("CancelledCtxReturnsPromptly", func(t *testing.T) { sinkCancelledCtx(t, f) })
+	t.Run("ConcurrentSafe", func(t *testing.T) { sinkConcurrent(t, f) })
+}
+
+// ---------- subtests ----------
+
+func sinkZeroInput(t *testing.T, f SinkFactory) {
+	t.Helper()
+	s := f()
+	defer recoverPanicAs(t, "OnDelta(zero inputs)")
+	_ = s.OnDelta(context.Background(), event.Envelope{}, agent.StreamDeltaPayload{})
+	_ = s.OnDelta(context.Background(), event.Envelope{}, agent.StreamDeltaPayload{
+		Type: agent.StreamDeltaPart,
+		Part: message.NewTextMessage(message.RoleAssistant, "hi").Content.Parts[0],
+	})
+}
+
+func sinkCancelledCtx(t *testing.T, f SinkFactory) {
+	t.Helper()
+	s := f()
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	done := make(chan struct{})
+	go func() {
+		_ = s.OnDelta(ctx, event.Envelope{}, agent.StreamDeltaPayload{})
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("OnDelta did not return within 2s of a cancelled ctx; sinks MUST observe ctx.Done")
+	}
+}
+
+func sinkConcurrent(t *testing.T, f SinkFactory) {
+	t.Helper()
+	s := f()
+	ctx := context.Background()
+	part := message.NewTextMessage(message.RoleAssistant, "hi").Content.Parts[0]
+	const n = 16
+	var wg sync.WaitGroup
+	for i := 0; i < n; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			defer func() {
+				if r := recover(); r != nil {
+					t.Errorf("concurrent OnDelta panicked: %v", r)
+				}
+			}()
+			_ = s.OnDelta(ctx, event.Envelope{}, agent.StreamDeltaPayload{
+				Type: agent.StreamDeltaPart,
+				Part: part,
+			})
+		}()
+	}
+	wg.Wait()
+}

--- a/core/agent/agenttest/suggester_suite.go
+++ b/core/agent/agenttest/suggester_suite.go
@@ -1,0 +1,45 @@
+package agenttest
+
+import (
+	"testing"
+	"time"
+
+	"github.com/GizClaw/flowcraft/core/agent"
+)
+
+// SuggesterFactory builds a fresh [agent.CheckpointSuggester] for each
+// subtest.
+type SuggesterFactory func() agent.CheckpointSuggester
+
+// CheckpointSuggesterSuite runs every contract probe that applies to
+// the [agent.CheckpointSuggester] produced by f:
+//
+//   - a suggestion on a fresh engine must not panic and may return any
+//     error (the host logs/retries; there is no classification
+//     contract);
+//   - SuggestCheckpoint is advisory and MUST return promptly — it is
+//     not obligated to have written anything by the time it returns.
+func CheckpointSuggesterSuite(t *testing.T, f SuggesterFactory) {
+	t.Helper()
+
+	t.Run("ZeroStateNoPanic", func(t *testing.T) {
+		t.Helper()
+		s := f()
+		defer recoverPanicAs(t, "SuggestCheckpoint(fresh engine)")
+		_ = s.SuggestCheckpoint()
+	})
+	t.Run("ReturnsPromptly", func(t *testing.T) {
+		t.Helper()
+		s := f()
+		done := make(chan struct{})
+		go func() {
+			_ = s.SuggestCheckpoint()
+			close(done)
+		}()
+		select {
+		case <-done:
+		case <-time.After(2 * time.Second):
+			t.Fatal("SuggestCheckpoint did not return within 2s; the suggestion is advisory and must return immediately")
+		}
+	})
+}

--- a/core/agent/middleware_test.go
+++ b/core/agent/middleware_test.go
@@ -11,6 +11,7 @@ import (
 	"go.opentelemetry.io/otel/sdk/trace/tracetest"
 
 	"github.com/GizClaw/flowcraft/core/agent"
+	"github.com/GizClaw/flowcraft/core/agent/agenttest"
 	"github.com/GizClaw/flowcraft/core/errdefs"
 	"github.com/GizClaw/flowcraft/core/event"
 	"github.com/GizClaw/flowcraft/core/inference"
@@ -40,6 +41,15 @@ func TestComposeHost_OrdersFirstSliceEntryAsOutermost(t *testing.T) {
 	if len(seen) != 3 || seen[0] != want[0] || seen[1] != want[1] || seen[2] != want[2] {
 		t.Fatalf("call order = %v, want %v (declaration order)", seen, want)
 	}
+}
+
+// TestHostFuncs_HostSuiteContract pins down the zero-override adapter
+// as a conforming Host: every nil func field must delegate to Inner
+// exactly like a hand-written host.
+func TestHostFuncs_HostSuiteContract(t *testing.T) {
+	agenttest.HostSuite(t, func() agent.Host {
+		return agent.HostFuncs{Inner: agent.NoopHost{}}
+	})
 }
 
 func TestComposeHost_NoMiddlewaresEchoesBase(t *testing.T) {

--- a/core/agent/scriptrt/jsrt/contract_test.go
+++ b/core/agent/scriptrt/jsrt/contract_test.go
@@ -1,0 +1,18 @@
+package jsrt
+
+import (
+	"testing"
+
+	"github.com/GizClaw/flowcraft/core/agent"
+	"github.com/GizClaw/flowcraft/core/agent/agenttest"
+)
+
+// TestRuntime_ScriptRuntimeContract runs the shared agent.ScriptRuntime
+// conformance suite against the JS runtime.
+func TestRuntime_ScriptRuntimeContract(t *testing.T) {
+	agenttest.ScriptRuntimeSuite(
+		t,
+		func() agent.ScriptRuntime { return New() },
+		agenttest.ScriptFixture{Source: "1 + 1;"},
+	)
+}

--- a/core/agent/scriptrt/luart/contract_test.go
+++ b/core/agent/scriptrt/luart/contract_test.go
@@ -1,0 +1,18 @@
+package luart
+
+import (
+	"testing"
+
+	"github.com/GizClaw/flowcraft/core/agent"
+	"github.com/GizClaw/flowcraft/core/agent/agenttest"
+)
+
+// TestRuntime_ScriptRuntimeContract runs the shared agent.ScriptRuntime
+// conformance suite against the Lua runtime.
+func TestRuntime_ScriptRuntimeContract(t *testing.T) {
+	agenttest.ScriptRuntimeSuite(
+		t,
+		func() agent.ScriptRuntime { return New() },
+		agenttest.ScriptFixture{Source: "local x = 1"},
+	)
+}

--- a/core/graph/contract_test.go
+++ b/core/graph/contract_test.go
@@ -1,0 +1,47 @@
+package graph
+
+import (
+	"testing"
+
+	"github.com/GizClaw/flowcraft/core/agent"
+	"github.com/GizClaw/flowcraft/core/agent/agenttest"
+)
+
+// minimalContractDef builds the smallest runnable graph: one echo node
+// feeding END. It is reused by every contract subtest via a fresh
+// factory call.
+func minimalContractDef() *GraphDefinition {
+	return &GraphDefinition{
+		Name:  "contract",
+		Entry: "a",
+		Nodes: []NodeDefinition{{ID: "a", Type: "echo"}},
+		Edges: []EdgeDefinition{{From: "a", To: END}},
+	}
+}
+
+// TestGraph_EngineContract runs the shared agent.Engine conformance
+// suite against the graph runner. Graph supports checkpoint-driven
+// resume, so the factory advertises SupportsResume.
+func TestGraph_EngineContract(t *testing.T) {
+	agenttest.EngineSuite(t, func() (agent.Engine, agenttest.Capabilities) {
+		g := mustBuild(t, minimalContractDef(), newTestRegistry(t))
+		return g, agenttest.Capabilities{SupportsResume: true}
+	})
+}
+
+// TestGraph_ResumerContract runs the shared agent.Resumer conformance
+// suite against Graph.CanResume.
+func TestGraph_ResumerContract(t *testing.T) {
+	agenttest.ResumerSuite(t, func() agent.Resumer {
+		return mustBuild(t, minimalContractDef(), newTestRegistry(t))
+	})
+}
+
+// TestGraph_CheckpointSuggesterContract runs the shared
+// agent.CheckpointSuggester conformance suite against the graph
+// engine's advisory checkpoint suggestion.
+func TestGraph_CheckpointSuggesterContract(t *testing.T) {
+	agenttest.CheckpointSuggesterSuite(t, func() agent.CheckpointSuggester {
+		return mustBuild(t, minimalContractDef(), newTestRegistry(t))
+	})
+}

--- a/core/graph/resume.go
+++ b/core/graph/resume.go
@@ -39,3 +39,14 @@ func (g *Graph) CanResume(cp agent.Checkpoint) error {
 	}
 	return nil
 }
+
+// SuggestCheckpoint implements [agent.CheckpointSuggester]. Graph
+// execution already stamps a checkpoint at every wave boundary, so a
+// voluntary suggestion has nothing extra to do: the next completed
+// wave persists one unconditionally. Returning nil documents that the
+// suggestion is always honoured by construction.
+func (g *Graph) SuggestCheckpoint() error { return nil }
+
+// Compile-time assertion that the graph engine exposes the optional
+// advisory checkpoint suggestion surface.
+var _ agent.CheckpointSuggester = (*Graph)(nil)

--- a/core/memory/hook/contract_test.go
+++ b/core/memory/hook/contract_test.go
@@ -1,0 +1,56 @@
+package hook
+
+import (
+	"context"
+	"testing"
+
+	"github.com/GizClaw/flowcraft/core/agent"
+	"github.com/GizClaw/flowcraft/core/agent/agenttest"
+	"github.com/GizClaw/flowcraft/core/resource"
+)
+
+// TestContextPreparer_PreparerContract runs the shared agent.Preparer
+// conformance suite against the memory.context seed hook.
+func TestContextPreparer_PreparerContract(t *testing.T) {
+	assembly, _, _ := newFakeAssembly(t)
+	input := resource.Input{
+		Settings: settingsNode(t, `
+query:
+  literal: alpha
+scope:
+  runtime_id: memory
+  user_id: tenant
+output: recalled
+`),
+		Deps: map[string]any{depName: assembly},
+	}
+	if _, err := (ContextPreparer{}).New(context.Background(), input); err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	agenttest.PreparerSuite(t, func() agent.Preparer {
+		p, _ := (ContextPreparer{}).New(context.Background(), input)
+		return p.(agent.Preparer)
+	})
+}
+
+// TestTurnCommitter_CommitterContract runs the shared agent.Committer
+// conformance suite against the memory.turn finalizer.
+func TestTurnCommitter_CommitterContract(t *testing.T) {
+	assembly, _, _ := newFakeAssembly(t)
+	input := resource.Input{
+		Settings: settingsNode(t, `
+scope:
+  runtime_id: memory
+  user_id: tenant
+channel: main
+`),
+		Deps: map[string]any{depName: assembly},
+	}
+	if _, err := (TurnCommitter{}).New(context.Background(), input); err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	agenttest.CommitterSuite(t, func() agent.Committer {
+		c, _ := (TurnCommitter{}).New(context.Background(), input)
+		return c.(agent.Committer)
+	})
+}

--- a/core/runtime/host_contract_test.go
+++ b/core/runtime/host_contract_test.go
@@ -1,0 +1,24 @@
+package runtime
+
+import (
+	"testing"
+
+	"github.com/GizClaw/flowcraft/core/agent"
+	"github.com/GizClaw/flowcraft/core/agent/agenttest"
+	"github.com/GizClaw/flowcraft/core/event"
+)
+
+// TestBaseHost_HostSuiteContract runs the shared agent.Host conformance
+// suite against the runtime's production baseHost. Each subtest builds
+// a fresh host on its own bus.
+func TestBaseHost_HostSuiteContract(t *testing.T) {
+	agenttest.HostSuite(t, func() agent.Host {
+		bus := event.NewMemoryBus()
+		t.Cleanup(func() { _ = bus.Close() })
+		factory, err := newBaseHostFactory(bus)
+		if err != nil {
+			t.Fatalf("newBaseHostFactory: %v", err)
+		}
+		return mustBaseHost(t, factory)
+	})
+}

--- a/core/runtime/session/turn_contract_test.go
+++ b/core/runtime/session/turn_contract_test.go
@@ -1,0 +1,50 @@
+package session
+
+import (
+	"context"
+	"testing"
+
+	"github.com/GizClaw/flowcraft/core/agent"
+	"github.com/GizClaw/flowcraft/core/agent/agenttest"
+)
+
+// TestTurn_ObserverContract runs the shared agent.Observer conformance
+// suite against the session Turn's observer surface.
+func TestTurn_ObserverContract(t *testing.T) {
+	agenttest.ObserverSuite(t, func() agent.Observer {
+		return newTurn(nil, "run-observer", context.Background())
+	})
+}
+
+// TestTurn_RefereeContract runs the shared agent.Referee conformance
+// suite against Turn.After.
+func TestTurn_RefereeContract(t *testing.T) {
+	agenttest.RefereeSuite(t, func() agent.Referee {
+		return newTurn(nil, "run-referee", context.Background())
+	})
+}
+
+// TestTurn_CommitViewProviderContract runs the shared
+// agent.CommitViewProvider conformance suite against Turn.CommitView.
+func TestTurn_CommitViewProviderContract(t *testing.T) {
+	agenttest.CommitViewProviderSuite(t, func() agent.CommitViewProvider {
+		return newTurn(nil, "run-view", context.Background())
+	})
+}
+
+// TestTurn_StreamSinkContract runs the shared agent.StreamSink
+// conformance suite against both production sinks: the queued sink and
+// the turn's stream coordinator.
+func TestTurn_StreamSinkContract(t *testing.T) {
+	t.Run("QueuedSink", func(t *testing.T) {
+		agenttest.StreamSinkSuite(t, func() agent.StreamSink {
+			return newQueuedSink(nil, "run-sink", SinkSpec{}, 16)
+		})
+	})
+	t.Run("Coordinator", func(t *testing.T) {
+		agenttest.StreamSinkSuite(t, func() agent.StreamSink {
+			turn := newTurn(nil, "run-coord", context.Background())
+			return newStreamCoordinator(turn, nil, nil, 0, 0)
+		})
+	})
+}


### PR DESCRIPTION
## Summary

Completes the `core/agent/agenttest` contract suite set and adopts it across real implementations, so every behavioral interface in `core/agent` now has an enforced conformance surface.

### agenttest additions
- New suites: `PreparerSuite`, `CommitterSuite`, `CommitViewProviderSuite`, `CheckpointSuggesterSuite`, `ScriptRuntimeSuite`.
- `EngineSuite`: adds `BudgetExceededPropagated`; models the run-end publish barrier (`RunEndPublishError`) and the classified cancel/abort error shapes that `agent.Execute` accepts.
- `HostSuite`: `SkipAskUserNotAvailable` now really asserts a non-zero reply, non-nil `AskUser` errors must be `errdefs.IsNotAvailable`, and `SkipPublishConcurrency` actually serializes `Publish`.
- `MockHost`: new `SetUsageError` injection for budget probes.
- `CheckpointStoreSuite`: stops requiring exact `Timestamp` equality (hosts may overwrite it); still verifies `OriginalStartedAt`.
- Doc hygiene: single package doc, `HookCapabilities` renamed `ObserverCapabilities`.

### Wiring
- Engines: `graph.Graph`, `a2a.Engine` (Engine + Resumer suites).
- Hosts/hooks: runtime `baseHost`, `session.Turn` (Observer/Referee/CommitViewProvider) and its sinks (StreamSink), memory hook `ContextPreparer`/`TurnCommitter` (Preparer/Committer).
- Runtimes: `jsrt`, `luart` (ScriptRuntime); `HostFuncs` adapter (Host).
- `Graph` now implements `agent.CheckpointSuggester` as a conforming no-op: wave-boundary checkpoints already fire unconditionally.

## Verification
- `make ci`, `make lint`, `make release-check`, `git diff --check` all pass locally.