### PR TITLE
fix(core): expand env/base/home refs in local workspace settings

### DIFF
--- a/core/workspace/resource.go
+++ b/core/workspace/resource.go
@@ -36,7 +36,20 @@ func (Factory) Spec() resource.Spec {
 
 // New implements resource.Factory.
 func (Factory) New(_ context.Context, in resource.Input) (any, error) {
-	settings, err := resource.DecodeTyped[Settings](in.Settings)
+	opts := []resource.ExpandOption{
+		resource.ExpandEnv(),
+		resource.ExpandHome(),
+	}
+	base := in.Loader.BaseDir()
+	if base != "" {
+		abs, err := filepath.Abs(base)
+		if err != nil {
+			return nil, errdefs.Validationf(
+				"workspace: resolve base dir: %v", err)
+		}
+		opts = append(opts, resource.ExpandBase(abs))
+	}
+	settings, err := resource.DecodeTyped[Settings](in.Settings, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -44,10 +57,8 @@ func (Factory) New(_ context.Context, in resource.Input) (any, error) {
 		return nil, errdefs.Validationf(
 			"workspace: settings.root is required")
 	}
-	if !filepath.IsAbs(settings.Root) && in.Loader != nil {
-		if base := in.Loader.BaseDir(); base != "" {
-			settings.Root = filepath.Join(base, settings.Root)
-		}
+	if !filepath.IsAbs(settings.Root) && base != "" {
+		settings.Root = filepath.Join(base, settings.Root)
 	}
 	local, err := NewLocalWorkspace(settings.Root)
 	if err != nil {
@@ -55,17 +66,17 @@ func (Factory) New(_ context.Context, in resource.Input) (any, error) {
 	}
 	var value Workspace = local
 	if settings.Scoped != nil && settings.Scoped.Enabled {
-		var opts []ScopedOption
+		var scopedOpts []ScopedOption
 		if len(settings.Scoped.DenyRead) > 0 {
-			opts = append(opts, WithDenyRead(settings.Scoped.DenyRead...))
+			scopedOpts = append(scopedOpts, WithDenyRead(settings.Scoped.DenyRead...))
 		}
 		if len(settings.Scoped.AllowWrite) > 0 {
-			opts = append(opts, WithAllowWrite(settings.Scoped.AllowWrite...))
+			scopedOpts = append(scopedOpts, WithAllowWrite(settings.Scoped.AllowWrite...))
 		}
 		if len(settings.Scoped.MandatoryDeny) > 0 {
-			opts = append(opts, WithMandatoryDeny(settings.Scoped.MandatoryDeny...))
+			scopedOpts = append(scopedOpts, WithMandatoryDeny(settings.Scoped.MandatoryDeny...))
 		}
-		value = NewScopedWorkspace(value, opts...)
+		value = NewScopedWorkspace(value, scopedOpts...)
 	}
 	return value, nil
 }

--- a/core/workspace/resource_test.go
+++ b/core/workspace/resource_test.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/GizClaw/flowcraft/core/errdefs"
 	"github.com/GizClaw/flowcraft/core/resource"
 	"github.com/GizClaw/flowcraft/core/workspace"
 )
@@ -110,5 +111,79 @@ func TestFactoryRelativeRootUsesLoaderBaseDir(t *testing.T) {
 	}
 	if local.Root() != resolved {
 		t.Fatalf("root = %q, want %q", local.Root(), resolved)
+	}
+}
+
+func TestFactoryExpandsSettingsRefs(t *testing.T) {
+	envRoot := t.TempDir()
+	base := t.TempDir()
+	home := t.TempDir()
+	t.Setenv("FLOWCRAFT_TEST_WS_ROOT", envRoot)
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+
+	reg := resource.NewRegistry()
+	if err := workspace.Register(reg); err != nil {
+		t.Fatal(err)
+	}
+	factory, _ := reg.Lookup("workspace.Workspace", "local")
+
+	for _, tc := range []struct {
+		name string
+		root string
+		want string
+	}{
+		{"env", "${env:FLOWCRAFT_TEST_WS_ROOT}", envRoot},
+		{"base", "${base}", base},
+		{"base rel", "${base:ws}", filepath.Join(base, "ws")},
+		{"home tilde", "~/ws", filepath.Join(home, "ws")},
+		{"home ref", "${home:ws}", filepath.Join(home, "ws")},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			value, err := factory.New(context.Background(), resource.Input{
+				Settings: []byte(`{"root": "` + tc.root + `"}`),
+				Loader:   resource.NewLoader(resource.WithBaseDir(base)),
+			})
+			if err != nil {
+				t.Fatalf("New: %v", err)
+			}
+			local, ok := value.(*workspace.LocalWorkspace)
+			if !ok {
+				t.Fatalf("New returned %T, want *workspace.LocalWorkspace", value)
+			}
+			want, err := filepath.EvalSymlinks(tc.want)
+			if err != nil {
+				t.Fatalf("eval symlinks: %v", err)
+			}
+			if local.Root() != want {
+				t.Fatalf("root = %q, want %q", local.Root(), want)
+			}
+		})
+	}
+}
+
+func TestFactoryExpansionErrors(t *testing.T) {
+	reg := resource.NewRegistry()
+	if err := workspace.Register(reg); err != nil {
+		t.Fatal(err)
+	}
+	factory, _ := reg.Lookup("workspace.Workspace", "local")
+
+	for _, tc := range []struct {
+		name     string
+		settings string
+	}{
+		{"unset env", `{"root": "${env:FLOWCRAFT_TEST_WS_UNSET}"}`},
+		{"unknown ref", `{"root": "${unknown}"}`},
+		{"base without base dir", `{"root": "${base}"}`},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := factory.New(context.Background(), resource.Input{
+				Settings: []byte(tc.settings),
+			})
+			if !errdefs.IsValidation(err) {
+				t.Fatalf("New error = %v, want validation error", err)
+			}
+		})
 	}
 }

--- a/docs/guides/workspace.md
+++ b/docs/guides/workspace.md
@@ -41,6 +41,14 @@ resources:
         allow_write: ["**"]
 ```
 
+`settings.root` supports scalar settings expansion: `${env:NAME}` reads an
+environment variable (an unset variable fails the build), `${base}` /
+`${base:rel}` resolve against the deployment document's base dir, and `~`,
+`~/...`, `${home}`, `${home:rel}` resolve against the user home directory. A
+plain relative root still resolves against the deployment base dir. Expansion
+applies to the whole settings subtree, so scoped patterns expand too; they
+must remain relative paths.
+
 Object-store backends are app-registered and not part of the current core module.
 
 See [sandbox.md](sandbox.md) for the execution boundary.


### PR DESCRIPTION
## Summary
The `workspace.Workspace` / `local` factory decoded its settings without any `resource.ExpandOption`, so `${env:NAME}` references passed through literally and `NewLocalWorkspace` created a directory named with the raw reference (for example `${env:FLOWCRAFT_ROOT}`).

This change enables `ExpandEnv` and `ExpandHome` unconditionally and `ExpandBase` against the loader base dir (normalized to absolute), while keeping the existing fallback that resolves plain relative roots against the base dir. Expansion applies to the whole settings subtree, so scoped patterns expand too.

## Behavior change
Previously `${...}` in settings passed through unchanged. Expansion is now strict, matching the other factories (drivers, sandbox/bwrap, agent/a2a): unknown references, unset env vars, and `${base}` without a loader base dir fail the build with a validation error.

## Tests
- `TestFactoryExpandsSettingsRefs`: env, base, base:rel, ~, home:rel
- `TestFactoryExpansionErrors`: unset env, unknown ref, base without base dir

## Verification
- `make ci` (vet + test, all modules)
- `make lint`
- `make release-check`
- `git diff --check`