### PR TITLE
chore(release): add core v0.1.2 changeset

### DIFF
--- a/.release/core-v0.1.2.json
+++ b/.release/core-v0.1.2.json
@@ -1,0 +1,9 @@
+{
+  "summary": "Add inference and agent conformance suites and expand workspace settings references",
+  "releases": [
+    {
+      "module": "core",
+      "bump": "patch"
+    }
+  ]
+}


### PR DESCRIPTION
Adds the immutable patch changeset for the next core release.

## Planned release
- `core`: `v0.1.1` -> `v0.1.2` (patch), tag `core/v0.1.2`

## Delta covered since `core/v0.1.1`
- #299 test(inference): conformance suites and wire all drivers
- #300 test(core): agent conformance suites and real implementations
- #301 fix(core): expand env/base/home refs in workspace settings

## Verification
- `make release-check BASE=origin/main`
- `make release-plan`
- `make release-preflight` (core tidy OK)

Merging this PR triggers the Release modules workflow: it aggregates the pending summary into `CHANGELOG.md`, opens the `automation/release-changelog` PR, and after that PR merges, gates and publishes the `core/v0.1.2` tag.