### PR TITLE
feat(core): stream signals, request-id telemetry, and usage/audio enrichment

### DIFF
--- a/core/agent/stream.go
+++ b/core/agent/stream.go
@@ -2,6 +2,7 @@ package agent
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"reflect"
 
@@ -143,6 +144,33 @@ func validateStreamDelta(p StreamDeltaPayload) error {
 		}
 		if p.Reason != "" {
 			return fmt.Errorf("engine: stream delta part must not carry Reason")
+		}
+		return validateStreamDataIdentity(p)
+	case StreamDeltaFinish:
+		if p.FinishReason == "" {
+			return fmt.Errorf("engine: stream delta finish requires FinishReason")
+		}
+		if !partIsNil(p.Part) {
+			return fmt.Errorf("engine: stream delta finish must not carry Part")
+		}
+		return validateStreamDataIdentity(p)
+	case StreamDeltaProviderOutputs:
+		if len(p.ProviderOutputs) == 0 {
+			return fmt.Errorf("engine: stream delta provider_outputs requires ProviderOutputs")
+		}
+		for i, output := range p.ProviderOutputs {
+			if output.Provider == "" {
+				return fmt.Errorf("engine: stream delta provider_outputs[%d] requires Provider", i)
+			}
+			if output.Extension == "" {
+				return fmt.Errorf("engine: stream delta provider_outputs[%d] requires Extension", i)
+			}
+			if len(output.Value) == 0 || !json.Valid(output.Value) {
+				return fmt.Errorf("engine: stream delta provider_outputs[%d] has invalid Value", i)
+			}
+		}
+		if !partIsNil(p.Part) {
+			return fmt.Errorf("engine: stream delta provider_outputs must not carry Part")
 		}
 		return validateStreamDataIdentity(p)
 	case StreamDeltaParallelBranchAccept, StreamDeltaParallelBranchCancel:

--- a/core/agent/stream_internal_test.go
+++ b/core/agent/stream_internal_test.go
@@ -2,6 +2,7 @@ package agent
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"testing"
 
@@ -269,5 +270,81 @@ func TestEmitStreamDelta_AcceptsForwardCompatibleType(t *testing.T) {
 	}
 	if len(pub.got) != 1 {
 		t.Fatalf("expected publish, got %d", len(pub.got))
+	}
+}
+
+func TestEmitStreamDelta_FinishAndProviderOutputs(t *testing.T) {
+	t.Parallel()
+	pub := &capturePublisher{}
+
+	if err := EmitStreamDelta(context.Background(), pub, "r", "n",
+		StreamDeltaPayload{Type: StreamDeltaFinish}); err == nil {
+		t.Fatal("expected error for finish without FinishReason")
+	}
+	if err := EmitStreamDelta(context.Background(), pub, "r", "n", StreamDeltaPayload{
+		Type:         StreamDeltaFinish,
+		FinishReason: "completed",
+		Part:         message.TextPart{Text: "x"},
+	}); err == nil {
+		t.Fatal("expected error for finish carrying Part")
+	}
+	if err := EmitStreamDelta(context.Background(), pub, "r", "n",
+		StreamDeltaPayload{Type: StreamDeltaProviderOutputs}); err == nil {
+		t.Fatal("expected error for provider_outputs without ProviderOutputs")
+	}
+	if err := EmitStreamDelta(context.Background(), pub, "r", "n", StreamDeltaPayload{
+		Type: StreamDeltaProviderOutputs,
+		ProviderOutputs: []ProviderOutputEnvelope{
+			{Provider: "fake", Extension: "web_search"},
+		},
+	}); err == nil {
+		t.Fatal("expected error for provider output envelope without Value")
+	}
+	if len(pub.got) != 0 {
+		t.Fatalf("malformed terminal deltas leaked through: %d envelopes", len(pub.got))
+	}
+
+	if err := EmitStreamDelta(context.Background(), pub, "r", "n", StreamDeltaPayload{
+		Type:         StreamDeltaFinish,
+		FinishReason: "completed",
+		RequestID:    "req-1",
+		ResponseID:   "resp-1",
+	}); err != nil {
+		t.Fatalf("valid finish delta: %v", err)
+	}
+	if err := EmitStreamDelta(context.Background(), pub, "r", "n", StreamDeltaPayload{
+		Type: StreamDeltaProviderOutputs,
+		ProviderOutputs: []ProviderOutputEnvelope{{
+			Provider:  "fake",
+			Extension: "web_search",
+			Value:     json.RawMessage(`{"query":"flowcraft"}`),
+		}},
+	}); err != nil {
+		t.Fatalf("valid provider_outputs delta: %v", err)
+	}
+	if len(pub.got) != 2 {
+		t.Fatalf("expected 2 envelopes, got %d", len(pub.got))
+	}
+
+	finish, err := DecodeStreamDelta(pub.got[0])
+	if err != nil {
+		t.Fatalf("DecodeStreamDelta finish: %v", err)
+	}
+	if finish.Type != StreamDeltaFinish ||
+		finish.FinishReason != "completed" ||
+		finish.RequestID != "req-1" || finish.ResponseID != "resp-1" {
+		t.Fatalf("finish payload = %+v", finish)
+	}
+
+	outputs, err := DecodeStreamDelta(pub.got[1])
+	if err != nil {
+		t.Fatalf("DecodeStreamDelta provider_outputs: %v", err)
+	}
+	if outputs.Type != StreamDeltaProviderOutputs ||
+		len(outputs.ProviderOutputs) != 1 ||
+		outputs.ProviderOutputs[0].Provider != "fake" ||
+		outputs.ProviderOutputs[0].Extension != "web_search" ||
+		string(outputs.ProviderOutputs[0].Value) != `{"query":"flowcraft"}` {
+		t.Fatalf("provider_outputs payload = %+v", outputs)
 	}
 }

--- a/core/agent/subjects.go
+++ b/core/agent/subjects.go
@@ -264,6 +264,18 @@ const (
 	// reasoning. Required field: Part.
 	StreamDeltaPart StreamDeltaType = "part"
 
+	// StreamDeltaFinish marks the terminal event of a generation's
+	// delta sequence: the normalized finish reason and the
+	// provider-issued request / response identifiers. Required field:
+	// FinishReason; RequestID / ResponseID are optional.
+	StreamDeltaFinish StreamDeltaType = "finish"
+
+	// StreamDeltaProviderOutputs carries the final collection of
+	// provider-owned observational outputs (citations, search-call
+	// records, code-interpreter metadata) attached to a generation.
+	// Required field: ProviderOutputs.
+	StreamDeltaProviderOutputs StreamDeltaType = "provider_outputs"
+
 	// StreamDeltaParallelBranchAccept marks a speculative parallel
 	// branch's stream output as accepted by the graph runner.
 	// Required fields: ForkID, BranchID.
@@ -286,16 +298,19 @@ const (
 //
 // Per-Type field requirements:
 //
-//	Type           Required               Recommended
-//	------------   --------------------   --------------------
-//	part           Part                   —
-//	parallel_branch_accept ForkID, BranchID —
-//	parallel_branch_cancel ForkID, BranchID Reason
+//	Type                     Required         Recommended
+//	-----------------------   ---------------  --------------------
+//	part                      Part             —
+//	finish                    FinishReason     RequestID, ResponseID
+//	provider_outputs          ProviderOutputs  —
+//	parallel_branch_accept    ForkID, BranchID —
+//	parallel_branch_cancel    ForkID, BranchID Reason
 //
-// Speculative part deltas additionally require both ForkID and
-// BranchID. Non-speculative part deltas MUST carry neither field,
-// avoiding a half-speculative state that consumers cannot interpret
-// safely. Parallel-branch control deltas MUST NOT carry Part.
+// Speculative data deltas (part, finish, provider_outputs)
+// additionally require both ForkID and BranchID. Non-speculative data
+// deltas MUST carry neither field, avoiding a half-speculative state
+// that consumers cannot interpret safely. Parallel-branch control
+// deltas MUST NOT carry Part.
 type StreamDeltaPayload struct {
 	// Type discriminates the payload variant. See StreamDeltaType
 	// constants for the standard values.
@@ -320,21 +335,51 @@ type StreamDeltaPayload struct {
 
 	// Reason carries the rollback/abort reason for parallel_branch_cancel.
 	Reason string `json:"reason,omitempty"`
+
+	// FinishReason carries the normalized finish reason on "finish".
+	// Values use the inference.FinishReason vocabulary.
+	FinishReason string `json:"finish_reason,omitempty"`
+
+	// RequestID and ResponseID ride the "finish" delta when the
+	// provider exposes them.
+	RequestID  string `json:"request_id,omitempty"`
+	ResponseID string `json:"response_id,omitempty"`
+
+	// ProviderOutputs carries the final observational outputs on
+	// "provider_outputs", one envelope per output.
+	ProviderOutputs []ProviderOutputEnvelope `json:"provider_outputs,omitempty"`
+}
+
+// ProviderOutputEnvelope carries one provider-owned observational
+// output on a [StreamDeltaProviderOutputs] delta: the provider /
+// extension identity plus the raw output value. Value is opaque to the
+// stream protocol; consumers decode it against the provider
+// extension's schema when they recognize the family.
+type ProviderOutputEnvelope struct {
+	Provider  string          `json:"provider"`
+	Extension string          `json:"extension"`
+	Value     json.RawMessage `json:"value"`
 }
 
 // MarshalJSON encodes Part through [message.MarshalPart] so the wire
 // form carries the canonical "type" discriminator.
 func (p StreamDeltaPayload) MarshalJSON() ([]byte, error) {
 	wire := struct {
-		Type        StreamDeltaType `json:"type"`
-		Part        json.RawMessage `json:"part,omitempty"`
-		Speculative bool            `json:"speculative,omitempty"`
-		ForkID      string          `json:"fork_id,omitempty"`
-		BranchID    string          `json:"branch_id,omitempty"`
-		Reason      string          `json:"reason,omitempty"`
+		Type            StreamDeltaType          `json:"type"`
+		Part            json.RawMessage          `json:"part,omitempty"`
+		Speculative     bool                     `json:"speculative,omitempty"`
+		ForkID          string                   `json:"fork_id,omitempty"`
+		BranchID        string                   `json:"branch_id,omitempty"`
+		Reason          string                   `json:"reason,omitempty"`
+		FinishReason    string                   `json:"finish_reason,omitempty"`
+		RequestID       string                   `json:"request_id,omitempty"`
+		ResponseID      string                   `json:"response_id,omitempty"`
+		ProviderOutputs []ProviderOutputEnvelope `json:"provider_outputs,omitempty"`
 	}{
 		Type: p.Type, Speculative: p.Speculative, ForkID: p.ForkID,
 		BranchID: p.BranchID, Reason: p.Reason,
+		FinishReason: p.FinishReason, RequestID: p.RequestID,
+		ResponseID: p.ResponseID, ProviderOutputs: p.ProviderOutputs,
 	}
 	if p.Part != nil {
 		raw, err := message.MarshalPart(p.Part)
@@ -350,12 +395,16 @@ func (p StreamDeltaPayload) MarshalJSON() ([]byte, error) {
 // [message.UnmarshalPart].
 func (p *StreamDeltaPayload) UnmarshalJSON(data []byte) error {
 	var wire struct {
-		Type        StreamDeltaType `json:"type"`
-		Part        json.RawMessage `json:"part"`
-		Speculative bool            `json:"speculative"`
-		ForkID      string          `json:"fork_id"`
-		BranchID    string          `json:"branch_id"`
-		Reason      string          `json:"reason"`
+		Type            StreamDeltaType          `json:"type"`
+		Part            json.RawMessage          `json:"part"`
+		Speculative     bool                     `json:"speculative"`
+		ForkID          string                   `json:"fork_id"`
+		BranchID        string                   `json:"branch_id"`
+		Reason          string                   `json:"reason"`
+		FinishReason    string                   `json:"finish_reason"`
+		RequestID       string                   `json:"request_id"`
+		ResponseID      string                   `json:"response_id"`
+		ProviderOutputs []ProviderOutputEnvelope `json:"provider_outputs"`
 	}
 	if err := json.Unmarshal(data, &wire); err != nil {
 		return err
@@ -365,6 +414,10 @@ func (p *StreamDeltaPayload) UnmarshalJSON(data []byte) error {
 	p.ForkID = wire.ForkID
 	p.BranchID = wire.BranchID
 	p.Reason = wire.Reason
+	p.FinishReason = wire.FinishReason
+	p.RequestID = wire.RequestID
+	p.ResponseID = wire.ResponseID
+	p.ProviderOutputs = wire.ProviderOutputs
 	if len(wire.Part) > 0 && string(wire.Part) != "null" {
 		part, err := message.UnmarshalPart(wire.Part)
 		if err != nil {

--- a/core/graph/execute.go
+++ b/core/graph/execute.go
@@ -238,6 +238,10 @@ func (g *Graph) invokeNode(ctx context.Context, run agent.Run, host agent.Host, 
 	defer func() {
 		status := execStatus(err)
 		if err != nil && !isInterruptedErr(err) {
+			if requestID, ok := errdefs.RequestID(err); ok {
+				span.SetAttributes(
+					attribute.String(telemetry.AttrLLMRequestID, requestID))
+			}
 			span.RecordError(err)
 			span.SetStatus(codes.Error, err.Error())
 		} else {

--- a/core/graph/node_span_test.go
+++ b/core/graph/node_span_test.go
@@ -1,0 +1,63 @@
+package graph
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/GizClaw/flowcraft/core/agent"
+	"github.com/GizClaw/flowcraft/core/errdefs"
+	"github.com/GizClaw/flowcraft/core/telemetry"
+
+	"go.opentelemetry.io/otel"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+)
+
+func TestNodeSpanErrorRecordsRequestID(t *testing.T) {
+	prev := otel.GetTracerProvider()
+	rec := tracetest.NewSpanRecorder()
+	tp := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(rec))
+	otel.SetTracerProvider(tp)
+	t.Cleanup(func() {
+		_ = tp.Shutdown(context.Background())
+		otel.SetTracerProvider(prev)
+	})
+
+	reg := NewRegistry()
+	if err := RegisterType(reg, "failing", NodeType[struct{}]{
+		Handler: func(_ ExecutionContext, _ *agent.Board, _ struct{}) error {
+			return errdefs.WithRequestID(
+				errdefs.Validation(errors.New("boom")), "req-node-1")
+		},
+	}); err != nil {
+		t.Fatalf("register failing: %v", err)
+	}
+	g := mustBuild(t, &GraphDefinition{
+		Name:  "g",
+		Entry: "n",
+		Nodes: []NodeDefinition{{ID: "n", Type: "failing"}},
+	}, reg)
+
+	if _, err := g.Execute(
+		context.Background(), testRun(), agent.NoopHost{}, agent.NewBoard(),
+	); err == nil {
+		t.Fatal("expected node failure")
+	}
+
+	var found bool
+	for _, span := range rec.Ended() {
+		for _, kv := range span.Attributes() {
+			if kv.Key != telemetry.AttrLLMRequestID {
+				continue
+			}
+			found = true
+			if got := kv.Value.AsString(); got != "req-node-1" {
+				t.Fatalf("llm.request.id = %q, want req-node-1", got)
+			}
+		}
+	}
+	if !found {
+		t.Fatal("node span did not record llm.request.id")
+	}
+}

--- a/core/graph/nodes/inference.go
+++ b/core/graph/nodes/inference.go
@@ -2,6 +2,7 @@ package nodes
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"io"
 
@@ -45,9 +46,12 @@ type InferenceConfig struct {
 	// through a tool node and loop back.
 	ToolPendingKey string `json:"tool_pending_key,omitempty"`
 
-	// Stream opens a GenerateStream and publishes text deltas as
-	// token stream events; the board still receives exactly one
-	// assembled message (tool_call parts included).
+	// Stream opens a GenerateStream and publishes text and reasoning
+	// deltas as token stream events. Reasoning fragments arrive as
+	// incremental message.ReasoningPart deltas: consumers concatenate
+	// Text and take Signature/ID from the terminal fragment. The board
+	// still receives exactly one assembled message (tool_call parts
+	// included).
 	Stream bool `json:"stream,omitempty"`
 
 	// Tools names the catalog tools the model may call this turn.
@@ -138,18 +142,19 @@ func runInference(ec graph.ExecutionContext, board *agent.Board, cfg InferenceCo
 		}
 	}
 
-	// Stream every part of the response: text (unless it was already
-	// streamed token-by-token), images, audio, files, tool calls and
-	// results, reasoning — each as one StreamDeltaPart. The board still
-	// receives the complete assembled message.
+	// Stream every part of the response: text and reasoning (unless
+	// they were already streamed incrementally), images, audio, files,
+	// tool calls and results — each as one StreamDeltaPart. The board
+	// still receives the complete assembled message.
 	for _, part := range resp.Message.Content.Parts {
 		normalized, err := message.NormalizePart(part)
 		if err != nil {
 			return err
 		}
 		if cfg.Stream {
-			if _, ok := normalized.(message.TextPart); ok {
-				continue // tokens were already streamed by MessageStream
+			switch normalized.(type) {
+			case message.TextPart, message.ReasoningPart:
+				continue // already streamed incrementally
 			}
 		}
 		if err := ec.EmitStreamDelta(agent.StreamDeltaPayload{
@@ -175,7 +180,47 @@ func runInference(ec graph.ExecutionContext, board *agent.Board, cfg InferenceCo
 			return err
 		}
 	}
+	if err := emitGenerationTerminal(ec, resp); err != nil {
+		return err
+	}
 	return nil
+}
+
+// emitGenerationTerminal publishes the terminal stream deltas of one
+// successful generation: the final provider-owned outputs (when any)
+// followed by the finish signal carrying the normalized finish reason
+// and the provider-issued request / response identifiers. It fixes the
+// node's previous silent drop of ProviderOutputs and gives downstream
+// stream consumers a definitive end-of-generation event.
+func emitGenerationTerminal(ec graph.ExecutionContext, resp inference.GenerateResponse) error {
+	if len(resp.ProviderOutputs) > 0 {
+		envelopes := make([]agent.ProviderOutputEnvelope, 0, len(resp.ProviderOutputs))
+		for _, output := range resp.ProviderOutputs {
+			raw, err := json.Marshal(output)
+			if err != nil {
+				return errdefs.Validationf(
+					"inference node: marshal provider output %q/%q: %v",
+					output.ProviderID(), output.ExtensionID(), err)
+			}
+			envelopes = append(envelopes, agent.ProviderOutputEnvelope{
+				Provider:  output.ProviderID(),
+				Extension: output.ExtensionID(),
+				Value:     raw,
+			})
+		}
+		if err := ec.EmitStreamDelta(agent.StreamDeltaPayload{
+			Type:            agent.StreamDeltaProviderOutputs,
+			ProviderOutputs: envelopes,
+		}); err != nil {
+			return err
+		}
+	}
+	return ec.EmitStreamDelta(agent.StreamDeltaPayload{
+		Type:         agent.StreamDeltaFinish,
+		FinishReason: string(resp.FinishReason),
+		RequestID:    resp.Metadata.RequestID,
+		ResponseID:   resp.Metadata.ResponseID,
+	})
 }
 
 // buildGenerateRequest splits the channel tail into context + current
@@ -337,12 +382,18 @@ func executeGenerate(ec graph.ExecutionContext, board *agent.Board, cfg Inferenc
 
 // executeGenerateStream drains a GenerateStream through a
 // MessageStream: each text delta is buffered and published as a token
-// event. On success the caller appends the driver-accumulated response
-// (complete message, tool_calls included). On a mid-stream failure —
-// driver error or run interruption — the buffered partial text is
-// committed to the board as one assistant message before the error
-// propagates, so downstream consumers and a host-saved board keep the
-// progress instead of silently losing every token.
+// event, and each reasoning delta is published incrementally as a
+// reasoning part. On success the caller appends the driver-accumulated
+// response (complete message, tool_calls included). On a mid-stream
+// failure — driver error or run interruption — the buffered partial
+// text is committed to the board as one assistant message before the
+// error propagates, so downstream consumers and a host-saved board keep
+// the progress instead of silently losing every token. Partial
+// reasoning is streamed but not committed to the board: an unsigned
+// fragment must not round-trip into a conversation context that
+// requires signed reasoning. The last cumulative usage snapshot seen
+// before the failure is still reported to the host, so budget
+// accounting observes the tokens the provider already billed.
 func executeGenerateStream(ec graph.ExecutionContext, board *agent.Board, cfg InferenceConfig, deps InferenceNodeDeps, req inference.GenerateRequest) (inference.GenerateResponse, error) {
 	var stream inference.GenerateStream
 	var err error
@@ -372,8 +423,26 @@ func executeGenerateStream(ec graph.ExecutionContext, board *agent.Board, cfg In
 
 func drainGenerateStream(ec graph.ExecutionContext, board *agent.Board, channel string, stream inference.GenerateStream) (response inference.GenerateResponse, err error) {
 	s := ec.NewMessageStream(channel)
+	var (
+		lastUsage inference.Usage
+		usageSeen bool
+	)
+	reportPartialUsage := func() {
+		if !usageSeen || ec.Host == nil {
+			return
+		}
+		if reportErr := ec.Host.ReportUsage(ec.Context, lastUsage); reportErr != nil {
+			telemetry.WarnErr(ec.Context, "inference node: report partial usage", reportErr,
+				otellog.String("node.type", "inference"),
+				otellog.String("channel", channel))
+		}
+	}
 	defer func() {
 		if err != nil {
+			// The provider may have billed tokens before the stream
+			// failed; surface the last cumulative usage snapshot so
+			// budget accounting still observes the partial spend.
+			reportPartialUsage()
 			// Preserve the original stream error; partial materialization
 			// is best effort, but if Close itself fails the caller should
 			// still see why their partial materialization didn't land.
@@ -392,8 +461,35 @@ func drainGenerateStream(ec graph.ExecutionContext, board *agent.Board, channel 
 		if nextErr != nil {
 			return response, nextErr
 		}
-		if delta, ok := event.Delta.(inference.TextPartDelta); ok && delta.Text != "" {
+		if event.Usage != nil {
+			lastUsage = event.Usage.Clone()
+			usageSeen = true
+		}
+		switch delta := event.Delta.(type) {
+		case inference.TextPartDelta:
+			if delta.Text == "" {
+				continue
+			}
 			if emitErr := s.Emit(delta.Text); emitErr != nil {
+				return response, emitErr
+			}
+		case inference.ReasoningDelta:
+			// Reasoning fragments bypass MessageStream, which is
+			// text-only: publish each fragment as an incremental
+			// reasoning part. Signature/ID ride the terminal fragment.
+			part := message.ReasoningPart{
+				Text:      delta.Text,
+				Signature: delta.Signature,
+				ID:        delta.ID,
+			}
+			if err := part.Validate(); err != nil {
+				// ID-only bookkeeping delta with nothing displayable.
+				continue
+			}
+			if emitErr := ec.EmitStreamDelta(agent.StreamDeltaPayload{
+				Type: agent.StreamDeltaPart,
+				Part: part,
+			}); emitErr != nil {
 				return response, emitErr
 			}
 		}

--- a/core/graph/nodes/inference_test.go
+++ b/core/graph/nodes/inference_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"io"
+	"reflect"
 	"sync"
 	"testing"
 
@@ -30,12 +31,20 @@ type captureHost struct {
 	agent.NoopHost
 	mu        sync.Mutex
 	envelopes []event.Envelope
+	usages    []inference.Usage
 }
 
 func (h *captureHost) Publish(_ context.Context, env event.Envelope) error {
 	h.mu.Lock()
 	defer h.mu.Unlock()
 	h.envelopes = append(h.envelopes, env)
+	return nil
+}
+
+func (h *captureHost) ReportUsage(_ context.Context, usage inference.Usage) error {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.usages = append(h.usages, usage)
 	return nil
 }
 
@@ -457,8 +466,8 @@ func TestInferenceNode_Stream_PublishesDeltasAppendsAssembled(t *testing.T) {
 
 	// Subscribers saw one token event per text delta, in order.
 	deltas := host.published(agent.SubjectStreamDelta("run-1", "test-agent.node.n"))
-	if len(deltas) != 2 {
-		t.Fatalf("stream-delta envelopes = %d, want 2", len(deltas))
+	if len(deltas) != 3 {
+		t.Fatalf("stream-delta envelopes = %d, want 3", len(deltas))
 	}
 	for i, want := range []string{"hel", "lo"} {
 		var payload agent.StreamDeltaPayload
@@ -470,6 +479,14 @@ func TestInferenceNode_Stream_PublishesDeltasAppendsAssembled(t *testing.T) {
 			t.Fatalf("delta %d = %+v, want text part %q", i, payload, want)
 		}
 	}
+	var finish agent.StreamDeltaPayload
+	if err := deltas[2].Decode(&finish); err != nil {
+		t.Fatalf("finish delta payload: %v", err)
+	}
+	if finish.Type != agent.StreamDeltaFinish ||
+		finish.FinishReason != string(inference.FinishCompleted) {
+		t.Fatalf("finish delta = %+v, want completed finish", finish)
+	}
 
 	// …and the board still received exactly one assembled message.
 	msgs := board.Channel(agent.MainChannel)
@@ -479,6 +496,181 @@ func TestInferenceNode_Stream_PublishesDeltasAppendsAssembled(t *testing.T) {
 	if text, ok := msgs[1].Content.Parts[0].(message.TextPart); !ok || text.Text != "hello" {
 		t.Fatalf("assembled message = %+v, want text %q", msgs[1].Content.Parts[0], "hello")
 	}
+}
+
+func TestInferenceNode_Stream_PublishesReasoningDeltas(t *testing.T) {
+	fake := &inferencetest.GenerateFake{
+		Events: []inference.GenerateStreamEvent{
+			{PartIndex: 0, Delta: inference.ReasoningDelta{Text: "thin"}},
+			{PartIndex: 0, Delta: inference.ReasoningDelta{Text: "king"}},
+			{PartIndex: 1, Delta: inference.TextPartDelta{Text: "answer"}},
+			{PartIndex: 0, Delta: inference.ReasoningDelta{Signature: "sig-1", ID: "trace-1"}},
+			{FinishReason: inference.FinishCompleted},
+		},
+	}
+	reg := inferenceRegistry(t, InferenceNodeDeps{Assembly: fake.Assembly(t)})
+	g := singleNodeGraph(t, reg, "inference", InferenceConfig{
+		Model:  ptr(inferencetest.DefaultFakeModel),
+		Stream: true,
+	})
+	host := &captureHost{}
+	board := userBoard()
+	if err := executeGraph(t, g, host, board); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+
+	// Subscribers saw each reasoning fragment as an incremental
+	// reasoning part, interleaved with the text token, and no
+	// duplicate complete-part emission at the end.
+	deltas := host.published(agent.SubjectStreamDelta("run-1", "test-agent.node.n"))
+	want := []message.Part{
+		message.ReasoningPart{Text: "thin"},
+		message.ReasoningPart{Text: "king"},
+		message.TextPart{Text: "answer"},
+		message.ReasoningPart{Signature: "sig-1", ID: "trace-1"},
+	}
+	if len(deltas) != len(want)+1 {
+		t.Fatalf("stream-delta envelopes = %d, want %d", len(deltas), len(want)+1)
+	}
+	for i, part := range want {
+		var payload agent.StreamDeltaPayload
+		if err := deltas[i].Decode(&payload); err != nil {
+			t.Fatalf("delta %d payload: %v", i, err)
+		}
+		if payload.Type != agent.StreamDeltaPart {
+			t.Fatalf("delta %d type = %q, want part", i, payload.Type)
+		}
+		if !reflect.DeepEqual(payload.Part, part) {
+			t.Fatalf("delta %d part = %#v, want %#v", i, payload.Part, part)
+		}
+	}
+	var finish agent.StreamDeltaPayload
+	if err := deltas[len(want)].Decode(&finish); err != nil {
+		t.Fatalf("finish delta payload: %v", err)
+	}
+	if finish.Type != agent.StreamDeltaFinish ||
+		finish.FinishReason != string(inference.FinishCompleted) {
+		t.Fatalf("finish delta = %+v, want completed finish", finish)
+	}
+
+	// …and the board still received exactly one assembled message
+	// with the complete reasoning trace plus the answer text.
+	msgs := board.Channel(agent.MainChannel)
+	if len(msgs) != 2 {
+		t.Fatalf("channel len = %d, want user + one assistant", len(msgs))
+	}
+	parts := msgs[1].Content.Parts
+	if len(parts) != 2 {
+		t.Fatalf("assembled parts = %d, want 2", len(parts))
+	}
+	reasoning, ok := parts[0].(message.ReasoningPart)
+	if !ok || reasoning.Text != "thinking" ||
+		reasoning.Signature != "sig-1" || reasoning.ID != "trace-1" {
+		t.Fatalf("assembled reasoning = %#v", parts[0])
+	}
+	if text, ok := parts[1].(message.TextPart); !ok || text.Text != "answer" {
+		t.Fatalf("assembled text = %#v", parts[1])
+	}
+}
+
+func TestInferenceNode_EmitsProviderOutputsAndFinishMetadata(t *testing.T) {
+	fake := &inferencetest.GenerateFake{
+		Events: []inference.GenerateStreamEvent{
+			{PartIndex: 0, Delta: inference.TextPartDelta{Text: "hi"}},
+			{
+				FinishReason:    inference.FinishCompleted,
+				ProviderOutputs: inference.ProviderOutputs{testProviderOutput{Query: "flowcraft"}},
+				RequestID:       "req-1",
+				ResponseID:      "resp-1",
+			},
+		},
+	}
+	reg := inferenceRegistry(t, InferenceNodeDeps{Assembly: fake.Assembly(t)})
+	g := singleNodeGraph(t, reg, "inference", InferenceConfig{
+		Model:  ptr(inferencetest.DefaultFakeModel),
+		Stream: true,
+	})
+	host := &captureHost{}
+	if err := executeGraph(t, g, host, userBoard()); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+
+	deltas := host.published(agent.SubjectStreamDelta("run-1", "test-agent.node.n"))
+	if len(deltas) != 3 {
+		t.Fatalf("stream-delta envelopes = %d, want 3", len(deltas))
+	}
+
+	var outputs agent.StreamDeltaPayload
+	if err := deltas[1].Decode(&outputs); err != nil {
+		t.Fatalf("provider_outputs payload: %v", err)
+	}
+	if outputs.Type != agent.StreamDeltaProviderOutputs || len(outputs.ProviderOutputs) != 1 {
+		t.Fatalf("provider_outputs delta = %+v", outputs)
+	}
+	env := outputs.ProviderOutputs[0]
+	if env.Provider != "fake" || env.Extension != "web_search" {
+		t.Fatalf("provider_outputs envelope = %+v", env)
+	}
+	var output testProviderOutput
+	if err := json.Unmarshal(env.Value, &output); err != nil {
+		t.Fatalf("decode provider output value: %v", err)
+	}
+	if output.Query != "flowcraft" {
+		t.Fatalf("provider output = %+v", output)
+	}
+
+	var finish agent.StreamDeltaPayload
+	if err := deltas[2].Decode(&finish); err != nil {
+		t.Fatalf("finish payload: %v", err)
+	}
+	if finish.Type != agent.StreamDeltaFinish ||
+		finish.FinishReason != string(inference.FinishCompleted) ||
+		finish.RequestID != "req-1" || finish.ResponseID != "resp-1" {
+		t.Fatalf("finish delta = %+v", finish)
+	}
+}
+
+func TestInferenceNode_StreamFailureReportsPartialUsage(t *testing.T) {
+	fake := &inferencetest.GenerateFake{
+		Events: []inference.GenerateStreamEvent{
+			{PartIndex: 0, Delta: inference.TextPartDelta{Text: "hel"}},
+			{Usage: &inference.Usage{InputTokens: 3, OutputTokens: 4, TotalTokens: 7}},
+		},
+		StreamErr:   errors.New("connection reset"),
+		StreamErrAt: 2,
+	}
+	reg := inferenceRegistry(t, InferenceNodeDeps{Assembly: fake.Assembly(t)})
+	g := singleNodeGraph(t, reg, "inference", InferenceConfig{
+		Model:  ptr(inferencetest.DefaultFakeModel),
+		Stream: true,
+	})
+	host := &captureHost{}
+	if err := executeGraph(t, g, host, userBoard()); err == nil {
+		t.Fatal("mid-stream failure must propagate")
+	}
+	host.mu.Lock()
+	usages := append([]inference.Usage(nil), host.usages...)
+	host.mu.Unlock()
+	if len(usages) != 1 {
+		t.Fatalf("usage reports = %d, want 1", len(usages))
+	}
+	if usages[0].TotalTokens != 7 ||
+		usages[0].InputTokens != 3 || usages[0].OutputTokens != 4 {
+		t.Fatalf("partial usage = %+v", usages[0])
+	}
+}
+
+// testProviderOutput exercises the provider-outputs stream delta with
+// a concrete, JSON-round-trippable output family.
+type testProviderOutput struct {
+	Query string `json:"query,omitempty"`
+}
+
+func (testProviderOutput) ProviderID() string  { return "fake" }
+func (testProviderOutput) ExtensionID() string { return "web_search" }
+func (testProviderOutput) Validate() error     { return nil }
+func (o testProviderOutput) Clone() inference.ProviderOutput {
+	return o
 }
 
 // testExtension mirrors a provider option struct for the extensions

--- a/core/graph/subjects.go
+++ b/core/graph/subjects.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/GizClaw/flowcraft/core/agent"
+	"github.com/GizClaw/flowcraft/core/errdefs"
 	"github.com/GizClaw/flowcraft/core/event"
 )
 
@@ -24,6 +25,10 @@ func stepActorFor(agentID, nodeID string) string {
 type RunEventPayload struct {
 	Graph string `json:"graph"`
 	Error string `json:"error,omitempty"`
+
+	// RequestID is the provider-assigned request identifier carried by
+	// the failure, when the error chain exposes one. Empty otherwise.
+	RequestID string `json:"request_id,omitempty"`
 }
 
 func publishRunEvent(ctx context.Context, host agent.Host, g *Graph, run agent.Run, subject event.Subject, runErr error) error {
@@ -33,6 +38,9 @@ func publishRunEvent(ctx context.Context, host agent.Host, g *Graph, run agent.R
 	payload := RunEventPayload{Graph: g.name}
 	if runErr != nil {
 		payload.Error = runErr.Error()
+		if requestID, ok := errdefs.RequestID(runErr); ok {
+			payload.RequestID = requestID
+		}
 	}
 	env, err := event.NewEnvelope(ctx, subject, payload)
 	if err != nil {
@@ -64,6 +72,10 @@ type StepEventPayload struct {
 
 	// Error carries the failure message on step-error envelopes.
 	Error string `json:"error,omitempty"`
+
+	// RequestID is the provider-assigned request identifier carried by
+	// the failure, when the error chain exposes one. Empty otherwise.
+	RequestID string `json:"request_id,omitempty"`
 }
 
 // publishStepStarted / publishStepCompleted / publishStepError emit
@@ -88,8 +100,12 @@ func publishStepSkipped(ctx context.Context, host agent.Host, g *Graph, info age
 }
 
 func publishStepError(ctx context.Context, host agent.Host, g *Graph, info agent.RunInfo, nodeID string, stepErr error) {
+	payload := StepEventPayload{NodeID: nodeID, Graph: g.name, Error: stepErr.Error()}
+	if requestID, ok := errdefs.RequestID(stepErr); ok {
+		payload.RequestID = requestID
+	}
 	publishStep(ctx, host, agent.SubjectStepError(info.RunID, stepActorFor(info.AgentID, nodeID)),
-		info, StepEventPayload{NodeID: nodeID, Graph: g.name, Error: stepErr.Error()})
+		info, payload)
 }
 
 func publishStep(ctx context.Context, host agent.Host, subject event.Subject, info agent.RunInfo, payload StepEventPayload) {

--- a/core/graph/subjects_test.go
+++ b/core/graph/subjects_test.go
@@ -1,9 +1,12 @@
 package graph
 
 import (
+	"context"
+	"errors"
 	"testing"
 
 	"github.com/GizClaw/flowcraft/core/agent"
+	"github.com/GizClaw/flowcraft/core/errdefs"
 )
 
 func TestStepActorForIncludesAgentID(t *testing.T) {
@@ -27,5 +30,52 @@ func TestStepActorSubjectCarriesSanitizedAgentSegment(t *testing.T) {
 	}
 	if agent.SanitiseID("acme-agent") == "" {
 		t.Fatal("sanitised agent id unexpectedly empty")
+	}
+}
+
+func TestStepErrorPayloadCarriesRequestID(t *testing.T) {
+	host := &publishHost{}
+	g := &Graph{name: "g"}
+	info := agent.RunInfo{Identity: agent.Identity{AgentID: "alice", RunID: "run-1"}}
+	stepErr := errdefs.WithRequestID(
+		errdefs.Validation(errors.New("boom")), "req-ui-1")
+
+	publishStepError(context.Background(), host, g, info, "n1", stepErr)
+
+	if len(host.envs) != 1 {
+		t.Fatalf("published = %d envelopes, want 1", len(host.envs))
+	}
+	var payload StepEventPayload
+	if err := host.envs[0].Decode(&payload); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if payload.Error != "boom" || payload.RequestID != "req-ui-1" {
+		t.Fatalf("payload = %+v", payload)
+	}
+}
+
+func TestRunErrorPayloadCarriesRequestID(t *testing.T) {
+	host := &publishHost{}
+	g := &Graph{name: "g"}
+	run := testRun()
+	runErr := errdefs.WithRequestID(
+		errdefs.Validation(errors.New("boom")), "req-ui-2")
+
+	if err := publishRunEvent(
+		context.Background(), host, g, run,
+		agent.SubjectRunEnd(run.RunID), runErr,
+	); err != nil {
+		t.Fatalf("publishRunEvent: %v", err)
+	}
+
+	if len(host.envs) != 1 {
+		t.Fatalf("published = %d envelopes, want 1", len(host.envs))
+	}
+	var payload RunEventPayload
+	if err := host.envs[0].Decode(&payload); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if payload.Error != "boom" || payload.RequestID != "req-ui-2" {
+		t.Fatalf("payload = %+v", payload)
 	}
 }

--- a/core/inference/generate_driver.go
+++ b/core/inference/generate_driver.go
@@ -1,6 +1,9 @@
 package inference
 
-import "context"
+import (
+	"context"
+	"time"
+)
 
 type generateDriver[Wire, Raw any] struct {
 	pipeline *pipeline[GenerateRequest, Wire, Raw, GenerateResponse]
@@ -25,11 +28,19 @@ func (d *generateDriver[Wire, Raw]) Execute(
 	model ModelRef,
 	request GenerateRequest,
 ) (GenerateResponse, error) {
+	start := time.Now()
 	response, report, err := d.pipeline.execute(ctx, model, request)
 	if err != nil {
 		return GenerateResponse{}, err
 	}
 	deriveGenerateUsage(request, &response)
+	// Stamp the call-context envelope the driver never sees: the exact
+	// model (including credential profile) that produced the call and the
+	// wall-clock latency of the producing call. Hosts bucket and enforce
+	// per-model budgets off Usage.Model; without this stamp the field
+	// would be zero for every provider.
+	response.Usage.Model = model
+	response.Usage.LatencyMs = time.Since(start).Milliseconds()
 	response.Metadata = mergeProviderIDs(report.Metadata(model), response.Metadata)
 	return response, nil
 }

--- a/core/inference/generate_stream.go
+++ b/core/inference/generate_stream.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"sort"
 	"strings"
+	"time"
 
 	"github.com/GizClaw/flowcraft/core/message"
 	"github.com/GizClaw/flowcraft/core/message/media"
@@ -198,12 +199,13 @@ func (d *generateStreamDriver[Wire, RawEvent]) Stream(
 		)
 	}
 	return &decodedGenerateStream[RawEvent]{
-		raw:     raw,
-		decode:  d.decode,
-		model:   model,
-		request: request.Clone(),
-		report:  compiled.Report,
-		parts:   make(map[int]*generatePartAccumulator),
+		raw:       raw,
+		decode:    d.decode,
+		model:     model,
+		request:   request.Clone(),
+		report:    compiled.Report,
+		parts:     make(map[int]*generatePartAccumulator),
+		startedAt: time.Now(),
 	}, nil
 }
 
@@ -237,6 +239,7 @@ type decodedGenerateStream[RawEvent any] struct {
 	requestID  string
 	responseID string
 	outputs    ProviderOutputs
+	startedAt  time.Time
 
 	done      bool
 	result    GenerateResponse
@@ -454,6 +457,11 @@ func (s *decodedGenerateStream[RawEvent]) finishResult() {
 	metadata.ResponseID = s.responseID
 	response.Metadata = metadata
 	deriveGenerateUsage(s.request, &response)
+	// Stamp the call-context envelope at the terminal result, matching the
+	// unary driver: the exact model reference that produced the stream and
+	// the wall-clock latency from stream open to completion.
+	response.Usage.Model = s.model
+	response.Usage.LatencyMs = time.Since(s.startedAt).Milliseconds()
 	if err := response.ValidateFor(s.request); err != nil {
 		s.resultErr = NewError(InvalidProviderResponse, OperationGenerate, "", err)
 		return
@@ -482,10 +490,17 @@ func (p *generatePartAccumulator) result() (message.Part, error) {
 		if err != nil {
 			return nil, err
 		}
+		duration := p.audioDuration
+		if duration == nil {
+			millis, ok := media.AudioDurationMillis(p.audio.Bytes(), *p.audioFormat)
+			if ok {
+				duration = &millis
+			}
+		}
 		return message.AudioPart{
 			Source:         source,
 			Format:         clonePointer(p.audioFormat),
-			DurationMillis: clonePointer(p.audioDuration),
+			DurationMillis: clonePointer(duration),
 		}, nil
 	case message.PartImage:
 		if p.completeImage == nil {

--- a/core/inference/inferencetest/stream.go
+++ b/core/inference/inferencetest/stream.go
@@ -137,6 +137,19 @@ func RunGenerateStream(t *testing.T, suite GenerateStreamSuite) {
 		len(response.Metadata.Decisions) == 0 {
 		t.Fatalf("Result metadata = %+v", response.Metadata)
 	}
+	if response.Usage.Model != suite.Model {
+		t.Fatalf(
+			"Usage.Model = %+v, want %+v",
+			response.Usage.Model,
+			suite.Model,
+		)
+	}
+	if response.Usage.LatencyMs < 0 {
+		t.Fatalf(
+			"Usage.LatencyMs = %d, want non-negative",
+			response.Usage.LatencyMs,
+		)
+	}
 	if suite.AssertResult != nil {
 		suite.AssertResult(t, response)
 	}

--- a/core/inference/inferencetest/unary.go
+++ b/core/inference/inferencetest/unary.go
@@ -42,6 +42,7 @@ func RunGenerateUnary(t *testing.T, suite GenerateUnarySuite) {
 	if suite.Driver == nil {
 		t.Fatal("GenerateUnarySuite requires a driver")
 	}
+	assertResponse := suite.AssertResponse
 	RunUnary(t, UnarySuite[inference.GenerateRequest, inference.GenerateResponse]{
 		Operation: inference.OperationGenerate,
 		Model:     suite.Model,
@@ -53,7 +54,24 @@ func RunGenerateUnary(t *testing.T, suite GenerateUnarySuite) {
 		Execute:        suite.Driver.Execute,
 		Metadata:       func(response inference.GenerateResponse) inference.Metadata { return response.Metadata },
 		TransportCalls: suite.TransportCalls,
-		AssertResponse: suite.AssertResponse,
+		AssertResponse: func(t *testing.T, response inference.GenerateResponse) {
+			if response.Usage.Model != suite.Model {
+				t.Fatalf(
+					"Usage.Model = %+v, want %+v",
+					response.Usage.Model,
+					suite.Model,
+				)
+			}
+			if response.Usage.LatencyMs < 0 {
+				t.Fatalf(
+					"Usage.LatencyMs = %d, want non-negative",
+					response.Usage.LatencyMs,
+				)
+			}
+			if assertResponse != nil {
+				assertResponse(t, response)
+			}
+		},
 	})
 }
 

--- a/core/inference/route/router_generate.go
+++ b/core/inference/route/router_generate.go
@@ -55,12 +55,6 @@ func (r *Router) GenerateStream(
 	request inference.GenerateRequest,
 ) (stream inference.GenerateStream, routeTrace Trace, err error) {
 	ctx, span := startRouteSpan(ctx, inference.OperationGenerate)
-	defer func() {
-		recordRoute(
-			ctx, span, inference.OperationGenerate, routeTrace,
-			inference.Metadata{}, err,
-		)
-	}()
 	snapshot := request.Clone()
 	stream, routeTrace, err = openSessionWithFallback(r,
 		ctx,
@@ -81,6 +75,15 @@ func (r *Router) GenerateStream(
 			return r.target.GenerateStream(ctx, target, snapshot)
 		},
 	)
+	if err != nil {
+		recordRoute(
+			ctx, span, inference.OperationGenerate, routeTrace,
+			inference.Metadata{}, err,
+		)
+		return stream, routeTrace, err
+	}
+	stream = wrapRouteStream(
+		ctx, span, inference.OperationGenerate, routeTrace, stream)
 	return stream, routeTrace, err
 }
 

--- a/core/inference/route/telemetry.go
+++ b/core/inference/route/telemetry.go
@@ -2,7 +2,11 @@ package route
 
 import (
 	"context"
+	"errors"
+	"io"
+	"sync"
 
+	"github.com/GizClaw/flowcraft/core/errdefs"
 	"github.com/GizClaw/flowcraft/core/inference"
 	"github.com/GizClaw/flowcraft/core/telemetry"
 
@@ -113,6 +117,10 @@ func recordRoute(
 	}
 	if err != nil {
 		routeExecCount.Add(ctx, 1, metric.WithAttributes(opAttr, attribute.String("status", "error")))
+		if requestID, ok := errdefs.RequestID(err); ok {
+			span.SetAttributes(
+				attribute.String(telemetry.AttrLLMRequestID, requestID))
+		}
 		span.SetStatus(codes.Error, err.Error())
 		span.End()
 		return
@@ -136,4 +144,60 @@ func recordRoute(
 	routeExecCount.Add(ctx, 1, metric.WithAttributes(opAttr, attribute.String("status", "success")))
 	span.SetStatus(codes.Ok, "OK")
 	span.End()
+}
+
+// routeGenerateStream defers the route span close from stream-open
+// time to stream completion. The provider-issued request / response
+// identifiers ride the terminal finish event, so they are only known
+// once the stream has been drained to its result.
+type routeGenerateStream struct {
+	inner      inference.GenerateStream
+	ctx        context.Context
+	span       trace.Span
+	operation  inference.Operation
+	routeTrace Trace
+	once       sync.Once
+}
+
+func wrapRouteStream(
+	ctx context.Context,
+	span trace.Span,
+	operation inference.Operation,
+	routeTrace Trace,
+	inner inference.GenerateStream,
+) inference.GenerateStream {
+	return &routeGenerateStream{
+		inner:      inner,
+		ctx:        ctx,
+		span:       span,
+		operation:  operation,
+		routeTrace: routeTrace,
+	}
+}
+
+func (s *routeGenerateStream) finish(metadata inference.Metadata, err error) {
+	s.once.Do(func() {
+		recordRoute(s.ctx, s.span, s.operation, s.routeTrace, metadata, err)
+	})
+}
+
+func (s *routeGenerateStream) Next(ctx context.Context) (inference.GenerateStreamEvent, error) {
+	event, err := s.inner.Next(ctx)
+	if err != nil && !errors.Is(err, io.EOF) {
+		s.finish(inference.Metadata{}, err)
+	}
+	return event, err
+}
+
+func (s *routeGenerateStream) Result() (inference.GenerateResponse, error) {
+	response, err := s.inner.Result()
+	s.finish(response.Metadata, err)
+	return response, err
+}
+
+func (s *routeGenerateStream) Close() error {
+	err := s.inner.Close()
+	s.finish(inference.Metadata{}, errdefs.Validationf(
+		"inference route: stream closed before completion"))
+	return err
 }

--- a/core/inference/route/telemetry_test.go
+++ b/core/inference/route/telemetry_test.go
@@ -1,0 +1,149 @@
+package route
+
+import (
+	"context"
+	"errors"
+	"io"
+	"testing"
+
+	"github.com/GizClaw/flowcraft/core/errdefs"
+	"github.com/GizClaw/flowcraft/core/inference"
+	"github.com/GizClaw/flowcraft/core/telemetry"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+)
+
+func installTestTracer(t *testing.T) *tracetest.SpanRecorder {
+	t.Helper()
+	prev := otel.GetTracerProvider()
+	rec := tracetest.NewSpanRecorder()
+	tp := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(rec))
+	otel.SetTracerProvider(tp)
+	t.Cleanup(func() {
+		_ = tp.Shutdown(context.Background())
+		otel.SetTracerProvider(prev)
+	})
+	return rec
+}
+
+func spanAttributeValue(span sdktrace.ReadOnlySpan, key attribute.Key) (string, bool) {
+	for _, kv := range span.Attributes() {
+		if kv.Key == key {
+			return kv.Value.AsString(), true
+		}
+	}
+	return "", false
+}
+
+type fakeRouteStream struct {
+	events    []inference.GenerateStreamEvent
+	next      int
+	err       error
+	result    inference.GenerateResponse
+	resultErr error
+}
+
+func (s *fakeRouteStream) Next(context.Context) (inference.GenerateStreamEvent, error) {
+	if s.next < len(s.events) {
+		event := s.events[s.next]
+		s.next++
+		return event, nil
+	}
+	if s.err != nil {
+		return inference.GenerateStreamEvent{}, s.err
+	}
+	return inference.GenerateStreamEvent{}, io.EOF
+}
+
+func (s *fakeRouteStream) Result() (inference.GenerateResponse, error) {
+	return s.result, s.resultErr
+}
+
+func (*fakeRouteStream) Close() error { return nil }
+
+func TestRecordRouteErrorRecordsRequestID(t *testing.T) {
+	rec := installTestTracer(t)
+	ctx, span := startRouteSpan(context.Background(), inference.OperationGenerate)
+	recordRoute(ctx, span, inference.OperationGenerate, Trace{},
+		inference.Metadata{},
+		errdefs.WithRequestID(errdefs.Validation(errors.New("boom")), "req-err-1"))
+
+	spans := rec.Ended()
+	if len(spans) != 1 {
+		t.Fatalf("ended spans = %d, want 1", len(spans))
+	}
+	if got, ok := spanAttributeValue(spans[0], telemetry.AttrLLMRequestID); !ok || got != "req-err-1" {
+		t.Fatalf("llm.request.id = %q/%v, want req-err-1", got, ok)
+	}
+	if _, ok := spanAttributeValue(spans[0], telemetry.AttrLLMResponseID); ok {
+		t.Fatal("llm.response.id should be absent on error")
+	}
+}
+
+func TestRouteStreamRecordsIDsOnCompletion(t *testing.T) {
+	rec := installTestTracer(t)
+	ctx, span := startRouteSpan(context.Background(), inference.OperationGenerate)
+	wrapped := wrapRouteStream(ctx, span, inference.OperationGenerate, Trace{}, &fakeRouteStream{
+		events: []inference.GenerateStreamEvent{{
+			PartIndex: 0,
+			Delta:     inference.TextPartDelta{Text: "hi"},
+		}},
+		result: inference.GenerateResponse{
+			Metadata: inference.Metadata{RequestID: "req-1", ResponseID: "resp-1"},
+		},
+	})
+
+	for {
+		_, err := wrapped.Next(context.Background())
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		if err != nil {
+			t.Fatalf("Next: %v", err)
+		}
+	}
+	if _, err := wrapped.Result(); err != nil {
+		t.Fatalf("Result: %v", err)
+	}
+	if err := wrapped.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	spans := rec.Ended()
+	if len(spans) != 1 {
+		t.Fatalf("ended spans = %d, want 1", len(spans))
+	}
+	if got, ok := spanAttributeValue(spans[0], telemetry.AttrLLMRequestID); !ok || got != "req-1" {
+		t.Fatalf("llm.request.id = %q/%v, want req-1", got, ok)
+	}
+	if got, ok := spanAttributeValue(spans[0], telemetry.AttrLLMResponseID); !ok || got != "resp-1" {
+		t.Fatalf("llm.response.id = %q/%v, want resp-1", got, ok)
+	}
+}
+
+func TestRouteStreamRecordsRequestIDOnFailure(t *testing.T) {
+	rec := installTestTracer(t)
+	ctx, span := startRouteSpan(context.Background(), inference.OperationGenerate)
+	wrapped := wrapRouteStream(ctx, span, inference.OperationGenerate, Trace{}, &fakeRouteStream{
+		err: errdefs.WithRequestID(errdefs.Validation(errors.New("boom")), "req-err-2"),
+	})
+
+	if _, err := wrapped.Next(context.Background()); err == nil {
+		t.Fatal("Next unexpectedly succeeded")
+	}
+	_ = wrapped.Close()
+
+	spans := rec.Ended()
+	if len(spans) != 1 {
+		t.Fatalf("ended spans = %d, want 1", len(spans))
+	}
+	if got, ok := spanAttributeValue(spans[0], telemetry.AttrLLMRequestID); !ok || got != "req-err-2" {
+		t.Fatalf("llm.request.id = %q/%v, want req-err-2", got, ok)
+	}
+	if _, ok := spanAttributeValue(spans[0], telemetry.AttrLLMResponseID); ok {
+		t.Fatal("llm.response.id should be absent on failure")
+	}
+}

--- a/core/message/media/audio.go
+++ b/core/message/media/audio.go
@@ -2,6 +2,7 @@ package media
 
 import (
 	"bytes"
+	"encoding/binary"
 	"fmt"
 )
 
@@ -83,4 +84,174 @@ func (c AudioChunk) Validate() error {
 		return fmt.Errorf("audio chunk data is required")
 	}
 	return nil
+}
+
+// AudioDurationMillis derives the duration of an encoded audio payload in
+// milliseconds when it can be computed without a full decoder. Raw PCM
+// families are exact from the byte count; MPEG audio (mp3) is estimated
+// from its frame headers. ok reports false for encodings that require a
+// real decoder (opus, aac, flac) or for malformed payloads, so callers can
+// distinguish "unknown" from a real zero.
+func AudioDurationMillis(data []byte, format AudioFormat) (int64, bool) {
+	if len(data) == 0 {
+		return 0, false
+	}
+	switch format.Encoding {
+	case AudioEncodingPCM16, AudioEncodingPCM24, AudioEncodingFloat32:
+		if format.SampleRateHz <= 0 || format.Channels <= 0 {
+			return 0, false
+		}
+		bytesPerSample := map[AudioEncoding]int64{
+			AudioEncodingPCM16:   2,
+			AudioEncodingPCM24:   3,
+			AudioEncodingFloat32: 4,
+		}[format.Encoding]
+		frameBytes := bytesPerSample * int64(format.Channels)
+		return int64(len(data)) / frameBytes * 1000 / int64(format.SampleRateHz), true
+	case AudioEncodingMP3:
+		return mpegAudioDurationMillis(data)
+	default:
+		return 0, false
+	}
+}
+
+// mpegAudioDurationMillis walks MPEG audio frame headers and sums the
+// samples they declare. Layer III MPEG-1 frames carry 1152 samples and
+// MPEG-2/2.5 frames 576, so the estimate stays accurate for CBR and VBR
+// alike as long as every frame is present. It skips a leading ID3v2 tag and
+// stops at the first boundary that does not parse as another frame.
+func mpegAudioDurationMillis(data []byte) (int64, bool) {
+	pos := skipID3v2(data)
+	var totalSamples, sampleRate int
+	for pos+4 <= len(data) {
+		if data[pos] != 0xff || data[pos+1]&0xe0 != 0xe0 {
+			pos++
+			continue
+		}
+		header := binary.BigEndian.Uint32(data[pos : pos+4])
+		bitrate, rate, padding, samples, ok := mpegFrameParams(header)
+		if !ok || bitrate == 0 || rate == 0 {
+			pos++
+			continue
+		}
+		frameLen := mpegFrameLength(header, bitrate, rate, padding, samples)
+		if frameLen <= 0 || pos+frameLen > len(data) {
+			break
+		}
+		if sampleRate == 0 {
+			sampleRate = rate
+		} else if rate != sampleRate {
+			// Mixed sample rates cannot be summed meaningfully.
+			return 0, false
+		}
+		totalSamples += samples
+		pos += frameLen
+	}
+	if sampleRate == 0 || totalSamples == 0 {
+		return 0, false
+	}
+	return int64(totalSamples) * 1000 / int64(sampleRate), true
+}
+
+// skipID3v2 returns the offset just past a leading ID3v2 tag, or zero when
+// the payload does not begin with one.
+func skipID3v2(data []byte) int {
+	if len(data) <= 10 || !bytes.Equal(data[:3], []byte("ID3")) {
+		return 0
+	}
+	size := int(data[6])<<21 | int(data[7])<<14 | int(data[8])<<7 | int(data[9])
+	total := 10 + size
+	if data[5]&0x10 != 0 {
+		total += 10 // footer flag mirrors the header.
+	}
+	if total <= len(data) {
+		return total
+	}
+	return 0
+}
+
+// mpegFrameParams decodes version, layer, bitrate (bits per second), sample
+// rate, padding, and samples per frame from a 4-byte MPEG audio header.
+func mpegFrameParams(header uint32) (
+	bitrate, rate, padding, samples int,
+	ok bool,
+) {
+	version := (header >> 19) & 0x3
+	layer := (header >> 17) & 0x3
+	if version == 0x1 || layer == 0x0 {
+		return 0, 0, 0, 0, false
+	}
+	bitrateIndex := int((header >> 12) & 0xf)
+	rateIndex := int((header >> 10) & 0x3)
+	if bitrateIndex == 0xf || bitrateIndex == 0 || rateIndex == 0x3 {
+		return 0, 0, 0, 0, false
+	}
+	padding = int((header >> 9) & 0x1)
+	bitrate = mpegBitrate(version, layer, bitrateIndex)
+	rate = mpegSampleRate(version, rateIndex)
+	samples = mpegSamplesPerFrame(version, layer)
+	if bitrate == 0 || rate == 0 || samples == 0 {
+		return 0, 0, 0, 0, false
+	}
+	return bitrate, rate, padding, samples, true
+}
+
+func mpegFrameLength(
+	header uint32,
+	bitrate, rate, padding, samples int,
+) int {
+	if (header>>17)&0x3 == 0x3 { // Layer I
+		return (12*bitrate/rate + padding) * 4
+	}
+	return samples*bitrate/(8*rate) + padding
+}
+
+func mpegBitrate(version, layer uint32, index int) int {
+	rates := [][]int{
+		// MPEG-1
+		{32, 64, 96, 128, 160, 192, 224, 256, 288, 320, 352, 384, 416, 448, 0}, // Layer I
+		{32, 48, 56, 64, 80, 96, 112, 128, 160, 192, 224, 256, 320, 384, 0},    // Layer II
+		{32, 40, 48, 56, 64, 80, 96, 112, 128, 160, 192, 224, 256, 320, 0},     // Layer III
+		{32, 48, 56, 64, 80, 96, 112, 128, 144, 160, 176, 192, 224, 256, 0},    // Layer I
+		{8, 16, 24, 32, 40, 48, 56, 64, 80, 96, 112, 128, 144, 160, 0},         // Layer II
+		{8, 16, 24, 32, 40, 48, 56, 64, 80, 96, 112, 128, 144, 160, 0},         // Layer III
+	}
+	table := 0
+	if version != 0x3 {
+		table = 3
+	}
+	table += 3 - int(layer)
+	return rates[table][index-1] * 1000
+}
+
+func mpegSampleRate(version uint32, index int) int {
+	rates := [][]int{
+		{44100, 48000, 32000}, // MPEG-1
+		{22050, 24000, 16000}, // MPEG-2
+		{11025, 12000, 8000},  // MPEG-2.5
+	}
+	switch version {
+	case 0x3:
+		return rates[0][index]
+	case 0x2:
+		return rates[1][index]
+	case 0x0:
+		return rates[2][index]
+	default:
+		return 0
+	}
+}
+
+func mpegSamplesPerFrame(version, layer uint32) int {
+	switch layer {
+	case 0x3: // Layer I
+		return 384
+	case 0x2: // Layer II
+		return 1152
+	default: // Layer III
+		if version == 0x3 {
+			return 1152
+		}
+		return 576
+	}
 }

--- a/core/message/media/audio_test.go
+++ b/core/message/media/audio_test.go
@@ -1,6 +1,9 @@
 package media
 
-import "testing"
+import (
+	"encoding/binary"
+	"testing"
+)
 
 func TestAudioFormatAndChunksValidate(t *testing.T) {
 	format := AudioFormat{
@@ -23,4 +26,70 @@ func TestAudioFormatAndChunksValidate(t *testing.T) {
 	if err := chunk.Validate(); err != nil {
 		t.Fatalf("chunk Validate: %v", err)
 	}
+}
+
+func TestAudioDurationMillis(t *testing.T) {
+	t.Run("raw PCM is exact", func(t *testing.T) {
+		// 1 second of 16-bit stereo at 44.1 kHz = 176400 bytes.
+		format := AudioFormat{
+			Encoding:     AudioEncodingPCM16,
+			SampleRateHz: 44100,
+			Channels:     2,
+		}
+		millis, ok := AudioDurationMillis(make([]byte, 176400), format)
+		if !ok || millis != 1000 {
+			t.Fatalf("AudioDurationMillis = (%d, %v), want (1000, true)", millis, ok)
+		}
+	})
+
+	t.Run("mp3 frame headers", func(t *testing.T) {
+		// 10 MPEG-1 Layer III frames at 128 kbps / 44.1 kHz, no padding.
+		// Each frame holds 1152 samples and spans 417 bytes.
+		const frameLen = 417
+		payload := make([]byte, 10*frameLen)
+		for i := 0; i < 10; i++ {
+			header := uint32(0xfffb_9000) // sync, MPEG1, Layer III, 128kbps, 44.1kHz
+			binary.BigEndian.PutUint32(payload[i*frameLen:], header)
+		}
+		millis, ok := AudioDurationMillis(payload, AudioFormat{Encoding: AudioEncodingMP3})
+		if !ok {
+			t.Fatal("AudioDurationMillis(mp3) = not ok")
+		}
+		want := int64(10 * 1152 * 1000 / 44100)
+		if millis != want {
+			t.Fatalf("AudioDurationMillis(mp3) = %d, want %d", millis, want)
+		}
+	})
+
+	t.Run("mp3 skips leading ID3v2", func(t *testing.T) {
+		const frameLen = 417
+		payload := make([]byte, 0, 10+8+2*frameLen)
+		tag := make([]byte, 10+8)
+		copy(tag, "ID3")
+		tag[3], tag[4], tag[5] = 4, 0, 0
+		tag[6], tag[7], tag[8], tag[9] = 0, 0, 0, 8 // synchsafe size 8
+		payload = append(payload, tag...)
+		frames := make([]byte, 2*frameLen)
+		for i := 0; i < 2; i++ {
+			binary.BigEndian.PutUint32(frames[i*frameLen:], 0xfffb_9000)
+		}
+		payload = append(payload, frames...)
+		millis, ok := AudioDurationMillis(payload, AudioFormat{Encoding: AudioEncodingMP3})
+		if !ok {
+			t.Fatal("AudioDurationMillis(mp3 with ID3v2) = not ok")
+		}
+		want := int64(2 * 1152 * 1000 / 44100)
+		if millis != want {
+			t.Fatalf("AudioDurationMillis(mp3 with ID3v2) = %d, want %d", millis, want)
+		}
+	})
+
+	t.Run("unsupported encoding", func(t *testing.T) {
+		if _, ok := AudioDurationMillis(
+			[]byte("opus"),
+			AudioFormat{Encoding: AudioEncodingOpus},
+		); ok {
+			t.Fatal("AudioDurationMillis(opus) = ok, want not ok")
+		}
+	})
 }

--- a/driver/anthropic/generate.go
+++ b/driver/anthropic/generate.go
@@ -126,10 +126,15 @@ type rawToolCall struct {
 }
 
 type rawUsage struct {
-	inputTokens      int64
-	outputTokens     int64
-	cacheReadTokens  int64
-	cacheWriteTokens int64
+	inputTokens       int64
+	outputTokens      int64
+	cacheReadTokens   int64
+	cacheWriteTokens  int64
+	cacheWrite5m      int64
+	cacheWrite1h      int64
+	thinkingTokens    int64
+	webSearchRequests int64
+	webFetchRequests  int64
 }
 
 // streamRaw is one provider stream event. The streaming transport assigns

--- a/driver/anthropic/generate_anthropic.go
+++ b/driver/anthropic/generate_anthropic.go
@@ -214,14 +214,26 @@ func messageToRaw(message *anthropicgo.Message) (generateRaw, error) {
 			})
 		}
 	}
-	raw.usage = rawUsage{
-		inputTokens:      message.Usage.InputTokens,
-		outputTokens:     message.Usage.OutputTokens,
-		cacheReadTokens:  message.Usage.CacheReadInputTokens,
-		cacheWriteTokens: message.Usage.CacheCreationInputTokens,
-	}
+	raw.usage = usageFromSDK(message.Usage)
 	raw.finish = stopReasonFinish(message.StopReason, len(raw.toolCalls) > 0)
 	return raw, nil
+}
+
+// usageFromSDK lowers the SDK usage object onto the provider raw model,
+// keeping every counter the Messages API reports: cache totals and their
+// per-TTL breakdown, thinking tokens, and server tool request counts.
+func usageFromSDK(usage anthropicgo.Usage) rawUsage {
+	return rawUsage{
+		inputTokens:       usage.InputTokens,
+		outputTokens:      usage.OutputTokens,
+		cacheReadTokens:   usage.CacheReadInputTokens,
+		cacheWriteTokens:  usage.CacheCreationInputTokens,
+		cacheWrite5m:      usage.CacheCreation.Ephemeral5mInputTokens,
+		cacheWrite1h:      usage.CacheCreation.Ephemeral1hInputTokens,
+		thinkingTokens:    usage.OutputTokensDetails.ThinkingTokens,
+		webSearchRequests: usage.ServerToolUse.WebSearchRequests,
+		webFetchRequests:  usage.ServerToolUse.WebFetchRequests,
+	}
 }
 
 // stopReasonFinish maps the API's stop reasons onto canonical finish
@@ -303,6 +315,44 @@ func rawUsageCanonical(raw rawUsage) inference.Usage {
 	if raw.cacheWriteTokens > 0 {
 		write := raw.cacheWriteTokens
 		usage.Input.CacheWriteTokens = &write
+	}
+	// Preserve the per-TTL cache-write split only when it agrees with the
+	// total; a provider that reports the total without the split stays
+	// valid because the breakdown is optional.
+	cacheWrites := make([]inference.CacheWriteUsage, 0, 2)
+	if raw.cacheWrite5m > 0 {
+		cacheWrites = append(cacheWrites, inference.CacheWriteUsage{
+			TTL:    inference.CacheTTL5Minutes,
+			Tokens: raw.cacheWrite5m,
+		})
+	}
+	if raw.cacheWrite1h > 0 {
+		cacheWrites = append(cacheWrites, inference.CacheWriteUsage{
+			TTL:    inference.CacheTTL1Hour,
+			Tokens: raw.cacheWrite1h,
+		})
+	}
+	if len(cacheWrites) > 0 &&
+		raw.cacheWrite5m+raw.cacheWrite1h == raw.cacheWriteTokens {
+		usage.Input.CacheWrites = cacheWrites
+	}
+	if raw.thinkingTokens > 0 {
+		thinking := raw.thinkingTokens
+		usage.Output.ReasoningTokens = &thinking
+		// thinking_tokens is always a subset of output_tokens.
+		usage.Output.ReasoningAccounting = inference.ReasoningIncludedInOutput
+	}
+	if raw.webSearchRequests > 0 {
+		usage.Tools = append(usage.Tools, inference.ToolUsage{
+			Kind:     inference.ToolUsageWebSearch,
+			Requests: raw.webSearchRequests,
+		})
+	}
+	if raw.webFetchRequests > 0 {
+		usage.Tools = append(usage.Tools, inference.ToolUsage{
+			Kind:     inference.ToolUsageWebFetch,
+			Requests: raw.webFetchRequests,
+		})
 	}
 	return usage
 }

--- a/driver/anthropic/generate_stream.go
+++ b/driver/anthropic/generate_stream.go
@@ -88,9 +88,7 @@ func (s *messagesStream) apply(
 	switch event.Type {
 	case "message_start":
 		s.id = event.Message.ID
-		s.usage.inputTokens = event.Message.Usage.InputTokens
-		s.usage.cacheReadTokens = event.Message.Usage.CacheReadInputTokens
-		s.usage.cacheWriteTokens = event.Message.Usage.CacheCreationInputTokens
+		s.usage = usageFromSDK(event.Message.Usage)
 		return streamRaw{}, false, nil
 	case "content_block_start":
 		return s.applyBlockStart(event.Index, event.ContentBlock)
@@ -98,6 +96,9 @@ func (s *messagesStream) apply(
 		return s.applyBlockDelta(event)
 	case "message_delta":
 		s.usage.outputTokens = event.Usage.OutputTokens
+		s.usage.thinkingTokens = event.Usage.OutputTokensDetails.ThinkingTokens
+		s.usage.webSearchRequests = event.Usage.ServerToolUse.WebSearchRequests
+		s.usage.webFetchRequests = event.Usage.ServerToolUse.WebFetchRequests
 		return s.finishEvent(stopReasonFinish(event.Delta.StopReason, s.sawTools))
 	}
 	// content_block_stop, message_stop, ping: lifecycle bookkeeping. The

--- a/driver/azure/generate.go
+++ b/driver/azure/generate.go
@@ -138,11 +138,12 @@ type rawToolCall struct {
 }
 
 type rawUsage struct {
-	inputTokens     int64
-	outputTokens    int64
-	totalTokens     int64
-	cachedTokens    int64
-	reasoningTokens int64
+	inputTokens      int64
+	outputTokens     int64
+	totalTokens      int64
+	cachedTokens     int64
+	cacheWriteTokens int64
+	reasoningTokens  int64
 }
 
 // streamRaw is one provider stream event. The streaming transport assigns

--- a/driver/azure/generate_openai.go
+++ b/driver/azure/generate_openai.go
@@ -336,11 +336,12 @@ func openaiCitations(
 
 func responseUsage(usage responses.ResponseUsage) rawUsage {
 	raw := rawUsage{
-		inputTokens:     usage.InputTokens,
-		outputTokens:    usage.OutputTokens,
-		totalTokens:     usage.TotalTokens,
-		cachedTokens:    usage.InputTokensDetails.CachedTokens,
-		reasoningTokens: usage.OutputTokensDetails.ReasoningTokens,
+		inputTokens:      usage.InputTokens,
+		outputTokens:     usage.OutputTokens,
+		totalTokens:      usage.TotalTokens,
+		cachedTokens:     usage.InputTokensDetails.CachedTokens,
+		cacheWriteTokens: usage.InputTokensDetails.CacheWriteTokens,
+		reasoningTokens:  usage.OutputTokensDetails.ReasoningTokens,
 	}
 	if raw.totalTokens == 0 {
 		raw.totalTokens = raw.inputTokens + raw.outputTokens
@@ -455,6 +456,10 @@ func rawUsageCanonical(raw rawUsage) inference.Usage {
 	if raw.cachedTokens > 0 {
 		cached := raw.cachedTokens
 		usage.Input.CacheReadTokens = &cached
+	}
+	if raw.cacheWriteTokens > 0 {
+		write := raw.cacheWriteTokens
+		usage.Input.CacheWriteTokens = &write
 	}
 	if raw.reasoningTokens > 0 {
 		reasoning := raw.reasoningTokens

--- a/driver/azure/tts.go
+++ b/driver/azure/tts.go
@@ -279,11 +279,19 @@ func decodeTTS(
 		return inference.GenerateResponse{}, fmt.Errorf("azure: audio payload: %w", err)
 	}
 	format := raw.format
+	var duration *int64
+	if millis, ok := media.AudioDurationMillis(raw.data, raw.format); ok {
+		duration = &millis
+	}
 	return inference.GenerateResponse{
 		Message: message.Message{
 			Role: message.RoleAssistant,
 			Content: message.Content{Parts: []message.Part{
-				message.AudioPart{Source: source, Format: &format},
+				message.AudioPart{
+					Source:         source,
+					Format:         &format,
+					DurationMillis: duration,
+				},
 			}},
 		},
 		FinishReason: inference.FinishCompleted,

--- a/driver/bytedance/generate.go
+++ b/driver/bytedance/generate.go
@@ -143,11 +143,14 @@ type rawToolCall struct {
 }
 
 type rawUsage struct {
-	inputTokens     int64
-	outputTokens    int64
-	totalTokens     int64
-	cachedTokens    int64
-	reasoningTokens int64
+	inputTokens       int64
+	outputTokens      int64
+	totalTokens       int64
+	cachedTokens      int64
+	reasoningTokens   int64
+	inputAudioTokens  int64
+	webSearchRequests int64
+	mcpRequests       int64
 }
 
 // streamRaw is one provider stream event. The streaming transport assigns

--- a/driver/bytedance/generate_ark.go
+++ b/driver/bytedance/generate_ark.go
@@ -401,11 +401,16 @@ func arkCitations(annotations []*arkresponses.Annotation) []inference.Citation {
 
 func arkUsage(usage *arkresponses.Usage) rawUsage {
 	raw := rawUsage{
-		inputTokens:     usage.GetInputTokens(),
-		outputTokens:    usage.GetOutputTokens(),
-		totalTokens:     usage.GetTotalTokens(),
-		cachedTokens:    usage.GetInputTokensDetails().GetCachedTokens(),
-		reasoningTokens: usage.GetOutputTokensDetails().GetReasoningTokens(),
+		inputTokens:      usage.GetInputTokens(),
+		outputTokens:     usage.GetOutputTokens(),
+		totalTokens:      usage.GetTotalTokens(),
+		cachedTokens:     usage.GetInputTokensDetails().GetCachedTokens(),
+		reasoningTokens:  usage.GetOutputTokensDetails().GetReasoningTokens(),
+		inputAudioTokens: usage.GetInputTokensDetails().GetAudioTokens(),
+	}
+	if tool := usage.GetToolUsage(); tool != nil {
+		raw.webSearchRequests = tool.GetWebSearch()
+		raw.mcpRequests = tool.GetMcp()
 	}
 	if raw.totalTokens == 0 {
 		raw.totalTokens = raw.inputTokens + raw.outputTokens
@@ -526,6 +531,25 @@ func rawUsageCanonical(raw rawUsage) inference.Usage {
 		usage.Output.ReasoningTokens = &reasoning
 		// Ark reports output_tokens inclusive of reasoning tokens.
 		usage.Output.ReasoningAccounting = inference.ReasoningIncludedInOutput
+	}
+	if raw.inputAudioTokens > 0 {
+		usage.Input.ByModality = append(usage.Input.ByModality,
+			inference.ModalityTokenUsage{
+				Modality: inference.ModalityAudio,
+				Tokens:   raw.inputAudioTokens,
+			})
+	}
+	if raw.webSearchRequests > 0 {
+		usage.Tools = append(usage.Tools, inference.ToolUsage{
+			Kind:     inference.ToolUsageWebSearch,
+			Requests: raw.webSearchRequests,
+		})
+	}
+	if raw.mcpRequests > 0 {
+		usage.Tools = append(usage.Tools, inference.ToolUsage{
+			Kind:     inference.ToolUsageMCP,
+			Requests: raw.mcpRequests,
+		})
 	}
 	return usage
 }

--- a/driver/bytedance/tts.go
+++ b/driver/bytedance/tts.go
@@ -361,11 +361,19 @@ func decodeTTS(
 		return inference.GenerateResponse{}, fmt.Errorf("bytedance: audio payload: %w", err)
 	}
 	format := raw.format
+	var duration *int64
+	if millis, ok := media.AudioDurationMillis(raw.data, raw.format); ok {
+		duration = &millis
+	}
 	return inference.GenerateResponse{
 		Message: message.Message{
 			Role: message.RoleAssistant,
 			Content: message.Content{Parts: []message.Part{
-				message.AudioPart{Source: source, Format: &format},
+				message.AudioPart{
+					Source:         source,
+					Format:         &format,
+					DurationMillis: duration,
+				},
 			}},
 		},
 		FinishReason: inference.FinishCompleted,

--- a/driver/deepseek/generate.go
+++ b/driver/deepseek/generate.go
@@ -40,12 +40,14 @@ type rawToolCall struct {
 }
 
 type rawUsage struct {
-	input     int64
-	output    int64
-	total     int64
-	cached    int64
-	reasoning int64
-	present   bool
+	input      int64
+	output     int64
+	total      int64
+	cached     int64
+	cacheWrite int64
+	uncached   int64
+	reasoning  int64
+	present    bool
 }
 
 // streamRawKind enumerates the events the stateful stream transport hands
@@ -250,6 +252,14 @@ func rawUsageCanonical(raw rawUsage) inference.Usage {
 	if raw.cached > 0 {
 		cached := raw.cached
 		usage.Input.CacheReadTokens = &cached
+	}
+	if raw.cacheWrite > 0 {
+		write := raw.cacheWrite
+		usage.Input.CacheWriteTokens = &write
+	}
+	if raw.uncached > 0 {
+		uncached := raw.uncached
+		usage.Input.UncachedTokens = &uncached
 	}
 	if raw.reasoning > 0 {
 		reasoning := raw.reasoning

--- a/driver/deepseek/generate_chat.go
+++ b/driver/deepseek/generate_chat.go
@@ -565,6 +565,14 @@ func usageToRaw(usage openaigo.CompletionUsage) rawUsage {
 			raw.cached = cached
 		}
 	}
+	// DeepSeek reports the uncached (freshly processed) input as
+	// prompt_cache_miss_tokens alongside the hit counter.
+	if field, exists := usage.JSON.ExtraFields["prompt_cache_miss_tokens"]; exists && field.Raw() != "" {
+		var uncached int64
+		if err := json.Unmarshal([]byte(field.Raw()), &uncached); err == nil {
+			raw.uncached = uncached
+		}
+	}
 	return raw
 }
 

--- a/driver/deepseek/generate_responses.go
+++ b/driver/deepseek/generate_responses.go
@@ -739,12 +739,13 @@ func deepseekCitations(
 
 func responsesUsage(usage responses.ResponseUsage) rawUsage {
 	raw := rawUsage{
-		input:     usage.InputTokens,
-		output:    usage.OutputTokens,
-		total:     usage.TotalTokens,
-		cached:    usage.InputTokensDetails.CachedTokens,
-		reasoning: usage.OutputTokensDetails.ReasoningTokens,
-		present:   true,
+		input:      usage.InputTokens,
+		output:     usage.OutputTokens,
+		total:      usage.TotalTokens,
+		cached:     usage.InputTokensDetails.CachedTokens,
+		cacheWrite: usage.InputTokensDetails.CacheWriteTokens,
+		reasoning:  usage.OutputTokensDetails.ReasoningTokens,
+		present:    true,
 	}
 	if raw.total == 0 {
 		raw.total = raw.input + raw.output

--- a/driver/deepseek/generate_test.go
+++ b/driver/deepseek/generate_test.go
@@ -119,6 +119,7 @@ func chatCompletionJSON(reasoning string) string {
 			"completion_tokens":         7,
 			"total_tokens":              19,
 			"prompt_cache_hit_tokens":   3,
+			"prompt_cache_miss_tokens":  9,
 			"completion_tokens_details": map[string]any{"reasoning_tokens": 2},
 		},
 	})
@@ -207,6 +208,10 @@ func TestChatUnaryReasoning(t *testing.T) {
 	if response.Usage.Input.CacheReadTokens == nil ||
 		*response.Usage.Input.CacheReadTokens != 3 {
 		t.Fatalf("cache = %+v", response.Usage.Input)
+	}
+	if response.Usage.Input.UncachedTokens == nil ||
+		*response.Usage.Input.UncachedTokens != 9 {
+		t.Fatalf("uncached = %+v", response.Usage.Input)
 	}
 	if response.Usage.Output.ReasoningTokens == nil ||
 		*response.Usage.Output.ReasoningTokens != 2 {

--- a/driver/minimax/generate.go
+++ b/driver/minimax/generate.go
@@ -124,10 +124,15 @@ type rawToolCall struct {
 }
 
 type rawUsage struct {
-	inputTokens      int64
-	outputTokens     int64
-	cacheReadTokens  int64
-	cacheWriteTokens int64
+	inputTokens       int64
+	outputTokens      int64
+	cacheReadTokens   int64
+	cacheWriteTokens  int64
+	cacheWrite5m      int64
+	cacheWrite1h      int64
+	thinkingTokens    int64
+	webSearchRequests int64
+	webFetchRequests  int64
 }
 
 // streamRaw is one provider stream event. The streaming transport assigns

--- a/driver/minimax/generate_anthropic.go
+++ b/driver/minimax/generate_anthropic.go
@@ -217,14 +217,26 @@ func messageToRaw(message *anthropicgo.Message) (generateRaw, error) {
 			})
 		}
 	}
-	raw.usage = rawUsage{
-		inputTokens:      message.Usage.InputTokens,
-		outputTokens:     message.Usage.OutputTokens,
-		cacheReadTokens:  message.Usage.CacheReadInputTokens,
-		cacheWriteTokens: message.Usage.CacheCreationInputTokens,
-	}
+	raw.usage = usageFromSDK(message.Usage)
 	raw.finish = stopReasonFinish(message.StopReason, len(raw.toolCalls) > 0)
 	return raw, nil
+}
+
+// usageFromSDK lowers the SDK usage object onto the provider raw model,
+// keeping every counter the Messages protocol can report: cache totals and
+// their per-TTL breakdown, thinking tokens, and server tool request counts.
+func usageFromSDK(usage anthropicgo.Usage) rawUsage {
+	return rawUsage{
+		inputTokens:       usage.InputTokens,
+		outputTokens:      usage.OutputTokens,
+		cacheReadTokens:   usage.CacheReadInputTokens,
+		cacheWriteTokens:  usage.CacheCreationInputTokens,
+		cacheWrite5m:      usage.CacheCreation.Ephemeral5mInputTokens,
+		cacheWrite1h:      usage.CacheCreation.Ephemeral1hInputTokens,
+		thinkingTokens:    usage.OutputTokensDetails.ThinkingTokens,
+		webSearchRequests: usage.ServerToolUse.WebSearchRequests,
+		webFetchRequests:  usage.ServerToolUse.WebFetchRequests,
+	}
 }
 
 // stopReasonFinish maps the API's stop reasons onto canonical finish
@@ -306,6 +318,41 @@ func rawUsageCanonical(raw rawUsage) inference.Usage {
 	if raw.cacheWriteTokens > 0 {
 		write := raw.cacheWriteTokens
 		usage.Input.CacheWriteTokens = &write
+	}
+	cacheWrites := make([]inference.CacheWriteUsage, 0, 2)
+	if raw.cacheWrite5m > 0 {
+		cacheWrites = append(cacheWrites, inference.CacheWriteUsage{
+			TTL:    inference.CacheTTL5Minutes,
+			Tokens: raw.cacheWrite5m,
+		})
+	}
+	if raw.cacheWrite1h > 0 {
+		cacheWrites = append(cacheWrites, inference.CacheWriteUsage{
+			TTL:    inference.CacheTTL1Hour,
+			Tokens: raw.cacheWrite1h,
+		})
+	}
+	if len(cacheWrites) > 0 &&
+		raw.cacheWrite5m+raw.cacheWrite1h == raw.cacheWriteTokens {
+		usage.Input.CacheWrites = cacheWrites
+	}
+	if raw.thinkingTokens > 0 {
+		thinking := raw.thinkingTokens
+		usage.Output.ReasoningTokens = &thinking
+		// thinking_tokens is always a subset of output_tokens.
+		usage.Output.ReasoningAccounting = inference.ReasoningIncludedInOutput
+	}
+	if raw.webSearchRequests > 0 {
+		usage.Tools = append(usage.Tools, inference.ToolUsage{
+			Kind:     inference.ToolUsageWebSearch,
+			Requests: raw.webSearchRequests,
+		})
+	}
+	if raw.webFetchRequests > 0 {
+		usage.Tools = append(usage.Tools, inference.ToolUsage{
+			Kind:     inference.ToolUsageWebFetch,
+			Requests: raw.webFetchRequests,
+		})
 	}
 	return usage
 }

--- a/driver/minimax/generate_stream.go
+++ b/driver/minimax/generate_stream.go
@@ -88,9 +88,7 @@ func (s *messagesStream) apply(
 	switch event.Type {
 	case "message_start":
 		s.id = event.Message.ID
-		s.usage.inputTokens = event.Message.Usage.InputTokens
-		s.usage.cacheReadTokens = event.Message.Usage.CacheReadInputTokens
-		s.usage.cacheWriteTokens = event.Message.Usage.CacheCreationInputTokens
+		s.usage = usageFromSDK(event.Message.Usage)
 		return streamRaw{}, false, nil
 	case "content_block_start":
 		return s.applyBlockStart(event.Index, event.ContentBlock)
@@ -98,6 +96,9 @@ func (s *messagesStream) apply(
 		return s.applyBlockDelta(event)
 	case "message_delta":
 		s.usage.outputTokens = event.Usage.OutputTokens
+		s.usage.thinkingTokens = event.Usage.OutputTokensDetails.ThinkingTokens
+		s.usage.webSearchRequests = event.Usage.ServerToolUse.WebSearchRequests
+		s.usage.webFetchRequests = event.Usage.ServerToolUse.WebFetchRequests
 		return s.finishEvent(stopReasonFinish(event.Delta.StopReason, s.sawTools))
 	}
 	// content_block_stop, message_stop, ping: lifecycle bookkeeping. The

--- a/driver/minimax/music.go
+++ b/driver/minimax/music.go
@@ -295,11 +295,19 @@ func decodeMusic(
 		return inference.GenerateResponse{}, fmt.Errorf("minimax: music payload: %w", err)
 	}
 	format := raw.format
+	var duration *int64
+	if millis, ok := media.AudioDurationMillis(raw.data, raw.format); ok {
+		duration = &millis
+	}
 	return inference.GenerateResponse{
 		Message: message.Message{
 			Role: message.RoleAssistant,
 			Content: message.Content{Parts: []message.Part{
-				message.AudioPart{Source: source, Format: &format},
+				message.AudioPart{
+					Source:         source,
+					Format:         &format,
+					DurationMillis: duration,
+				},
 			}},
 		},
 		FinishReason: inference.FinishCompleted,

--- a/driver/minimax/tts.go
+++ b/driver/minimax/tts.go
@@ -288,11 +288,19 @@ func decodeTTS(
 		return inference.GenerateResponse{}, fmt.Errorf("minimax: audio payload: %w", err)
 	}
 	format := raw.format
+	var duration *int64
+	if millis, ok := media.AudioDurationMillis(raw.data, raw.format); ok {
+		duration = &millis
+	}
 	return inference.GenerateResponse{
 		Message: message.Message{
 			Role: message.RoleAssistant,
 			Content: message.Content{Parts: []message.Part{
-				message.AudioPart{Source: source, Format: &format},
+				message.AudioPart{
+					Source:         source,
+					Format:         &format,
+					DurationMillis: duration,
+				},
 			}},
 		},
 		FinishReason: inference.FinishCompleted,

--- a/driver/openai/generate.go
+++ b/driver/openai/generate.go
@@ -138,11 +138,16 @@ type rawToolCall struct {
 }
 
 type rawUsage struct {
-	inputTokens     int64
-	outputTokens    int64
-	totalTokens     int64
-	cachedTokens    int64
-	reasoningTokens int64
+	inputTokens              int64
+	outputTokens             int64
+	totalTokens              int64
+	cachedTokens             int64
+	cacheWriteTokens         int64
+	reasoningTokens          int64
+	acceptedPredictionTokens int64
+	rejectedPredictionTokens int64
+	inputAudioTokens         int64
+	outputAudioTokens        int64
 }
 
 // streamRaw is one provider stream event. The streaming transport assigns

--- a/driver/openai/generate_chat.go
+++ b/driver/openai/generate_chat.go
@@ -253,11 +253,16 @@ func chatFinishReason(reason string) (inference.FinishReason, error) {
 
 func chatUsageToRaw(usage openai.CompletionUsage) rawUsage {
 	return rawUsage{
-		inputTokens:     usage.PromptTokens,
-		outputTokens:    usage.CompletionTokens,
-		totalTokens:     usage.TotalTokens,
-		cachedTokens:    usage.PromptTokensDetails.CachedTokens,
-		reasoningTokens: usage.CompletionTokensDetails.ReasoningTokens,
+		inputTokens:              usage.PromptTokens,
+		outputTokens:             usage.CompletionTokens,
+		totalTokens:              usage.TotalTokens,
+		cachedTokens:             usage.PromptTokensDetails.CachedTokens,
+		cacheWriteTokens:         usage.PromptTokensDetails.CacheWriteTokens,
+		reasoningTokens:          usage.CompletionTokensDetails.ReasoningTokens,
+		acceptedPredictionTokens: usage.CompletionTokensDetails.AcceptedPredictionTokens,
+		rejectedPredictionTokens: usage.CompletionTokensDetails.RejectedPredictionTokens,
+		inputAudioTokens:         usage.PromptTokensDetails.AudioTokens,
+		outputAudioTokens:        usage.CompletionTokensDetails.AudioTokens,
 	}
 }
 

--- a/driver/openai/generate_chat_test.go
+++ b/driver/openai/generate_chat_test.go
@@ -9,6 +9,8 @@ import (
 	"testing"
 
 	"github.com/GizClaw/flowcraft/core/inference"
+
+	"github.com/openai/openai-go/v3"
 )
 
 func TestChatCompileRejectsWebSearch(t *testing.T) {
@@ -25,6 +27,68 @@ func TestChatCompileRejectsWebSearch(t *testing.T) {
 	if compiled.Wire.webSearch != nil {
 		t.Fatal("chat wire carries web_search")
 	}
+}
+
+func TestChatUsageMapsProviderDetails(t *testing.T) {
+	var wireUsage openai.CompletionUsage
+	if err := json.Unmarshal([]byte(`{
+		"prompt_tokens": 10,
+		"completion_tokens": 8,
+		"total_tokens": 18,
+		"prompt_tokens_details": {
+			"cached_tokens": 3,
+			"cache_write_tokens": 4,
+			"audio_tokens": 2
+		},
+		"completion_tokens_details": {
+			"reasoning_tokens": 5,
+			"accepted_prediction_tokens": 1,
+			"rejected_prediction_tokens": 1,
+			"audio_tokens": 2
+		}
+	}`), &wireUsage); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	usage := rawUsageCanonical(chatUsageToRaw(wireUsage))
+
+	if usage.Input.CacheReadTokens == nil || *usage.Input.CacheReadTokens != 3 {
+		t.Fatalf("cache read = %+v", usage.Input)
+	}
+	if usage.Input.CacheWriteTokens == nil || *usage.Input.CacheWriteTokens != 4 {
+		t.Fatalf("cache write = %+v", usage.Input)
+	}
+	if usage.Output.ReasoningTokens == nil || *usage.Output.ReasoningTokens != 5 {
+		t.Fatalf("reasoning = %+v", usage.Output)
+	}
+	if usage.Output.ReasoningAccounting != inference.ReasoningIncludedInOutput {
+		t.Fatalf(
+			"reasoning accounting = %q, want included_in_output",
+			usage.Output.ReasoningAccounting,
+		)
+	}
+	if usage.Output.AcceptedPredictionTokens == nil ||
+		*usage.Output.AcceptedPredictionTokens != 1 {
+		t.Fatalf("accepted predictions = %+v", usage.Output)
+	}
+	if usage.Output.RejectedPredictionTokens == nil ||
+		*usage.Output.RejectedPredictionTokens != 1 {
+		t.Fatalf("rejected predictions = %+v", usage.Output)
+	}
+	if got := modalityTokens(usage.Input.ByModality); got != 2 {
+		t.Fatalf("input audio tokens = %d, want 2", got)
+	}
+	if got := modalityTokens(usage.Output.ByModality); got != 2 {
+		t.Fatalf("output audio tokens = %d, want 2", got)
+	}
+}
+
+func modalityTokens(usages []inference.ModalityTokenUsage) int64 {
+	for _, usage := range usages {
+		if usage.Modality == inference.ModalityAudio {
+			return usage.Tokens
+		}
+	}
+	return 0
 }
 
 func TestChatUnaryTransportAndDecode(t *testing.T) {

--- a/driver/openai/generate_openai.go
+++ b/driver/openai/generate_openai.go
@@ -336,11 +336,12 @@ func openaiCitations(
 
 func responseUsage(usage responses.ResponseUsage) rawUsage {
 	raw := rawUsage{
-		inputTokens:     usage.InputTokens,
-		outputTokens:    usage.OutputTokens,
-		totalTokens:     usage.TotalTokens,
-		cachedTokens:    usage.InputTokensDetails.CachedTokens,
-		reasoningTokens: usage.OutputTokensDetails.ReasoningTokens,
+		inputTokens:      usage.InputTokens,
+		outputTokens:     usage.OutputTokens,
+		totalTokens:      usage.TotalTokens,
+		cachedTokens:     usage.InputTokensDetails.CachedTokens,
+		cacheWriteTokens: usage.InputTokensDetails.CacheWriteTokens,
+		reasoningTokens:  usage.OutputTokensDetails.ReasoningTokens,
 	}
 	if raw.totalTokens == 0 {
 		raw.totalTokens = raw.inputTokens + raw.outputTokens
@@ -456,11 +457,37 @@ func rawUsageCanonical(raw rawUsage) inference.Usage {
 		cached := raw.cachedTokens
 		usage.Input.CacheReadTokens = &cached
 	}
+	if raw.cacheWriteTokens > 0 {
+		write := raw.cacheWriteTokens
+		usage.Input.CacheWriteTokens = &write
+	}
 	if raw.reasoningTokens > 0 {
 		reasoning := raw.reasoningTokens
 		usage.Output.ReasoningTokens = &reasoning
 		// The Responses API reports output_tokens inclusive of reasoning.
 		usage.Output.ReasoningAccounting = inference.ReasoningIncludedInOutput
+	}
+	if raw.acceptedPredictionTokens > 0 {
+		accepted := raw.acceptedPredictionTokens
+		usage.Output.AcceptedPredictionTokens = &accepted
+	}
+	if raw.rejectedPredictionTokens > 0 {
+		rejected := raw.rejectedPredictionTokens
+		usage.Output.RejectedPredictionTokens = &rejected
+	}
+	if raw.inputAudioTokens > 0 {
+		usage.Input.ByModality = append(usage.Input.ByModality,
+			inference.ModalityTokenUsage{
+				Modality: inference.ModalityAudio,
+				Tokens:   raw.inputAudioTokens,
+			})
+	}
+	if raw.outputAudioTokens > 0 {
+		usage.Output.ByModality = append(usage.Output.ByModality,
+			inference.ModalityTokenUsage{
+				Modality: inference.ModalityAudio,
+				Tokens:   raw.outputAudioTokens,
+			})
 	}
 	return usage
 }

--- a/driver/openai/tts.go
+++ b/driver/openai/tts.go
@@ -279,11 +279,19 @@ func decodeTTS(
 		return inference.GenerateResponse{}, fmt.Errorf("openai: audio payload: %w", err)
 	}
 	format := raw.format
+	var duration *int64
+	if millis, ok := media.AudioDurationMillis(raw.data, raw.format); ok {
+		duration = &millis
+	}
 	return inference.GenerateResponse{
 		Message: message.Message{
 			Role: message.RoleAssistant,
 			Content: message.Content{Parts: []message.Part{
-				message.AudioPart{Source: source, Format: &format},
+				message.AudioPart{
+					Source:         source,
+					Format:         &format,
+					DurationMillis: duration,
+				},
 			}},
 		},
 		FinishReason: inference.FinishCompleted,

--- a/driver/qwen/generate.go
+++ b/driver/qwen/generate.go
@@ -635,6 +635,7 @@ type dashUsage struct {
 	InputTokens     int64 `json:"input_tokens"`
 	OutputTokens    int64 `json:"output_tokens"`
 	TotalTokens     int64 `json:"total_tokens"`
+	CachedTokens    int64 `json:"-"`
 	ReasoningTokens int64 `json:"-"`
 }
 
@@ -644,9 +645,17 @@ func (u dashUsage) canonical() inference.Usage {
 		OutputTokens: u.OutputTokens,
 		TotalTokens:  u.TotalTokens,
 	}
+	if u.CachedTokens > 0 {
+		cached := u.CachedTokens
+		usage.Input.CacheReadTokens = &cached
+	}
 	if u.ReasoningTokens > 0 {
 		reasoning := u.ReasoningTokens
 		usage.Output.ReasoningTokens = &reasoning
+		// DashScope accounts for thinking tokens outside output_tokens:
+		// output_tokens covers the visible answer only, while reasoning
+		// tokens are billed separately at the output price.
+		usage.Output.ReasoningAccounting = inference.ReasoningAdditional
 	}
 	return usage
 }
@@ -669,9 +678,12 @@ type dashResponse struct {
 		} `json:"choices"`
 	} `json:"output"`
 	Usage struct {
-		InputTokens   int64 `json:"input_tokens"`
-		OutputTokens  int64 `json:"output_tokens"`
-		TotalTokens   int64 `json:"total_tokens"`
+		InputTokens  int64 `json:"input_tokens"`
+		OutputTokens int64 `json:"output_tokens"`
+		TotalTokens  int64 `json:"total_tokens"`
+		InputDetails struct {
+			CachedTokens int64 `json:"cached_tokens"`
+		} `json:"input_tokens_details"`
 		OutputDetails struct {
 			ReasoningTokens int64 `json:"reasoning_tokens"`
 		} `json:"output_tokens_details"`
@@ -683,6 +695,7 @@ func (r dashResponse) usage() dashUsage {
 		InputTokens:     r.Usage.InputTokens,
 		OutputTokens:    r.Usage.OutputTokens,
 		TotalTokens:     r.Usage.TotalTokens,
+		CachedTokens:    r.Usage.InputDetails.CachedTokens,
 		ReasoningTokens: r.Usage.OutputDetails.ReasoningTokens,
 	}
 }

--- a/driver/qwen/generate_test.go
+++ b/driver/qwen/generate_test.go
@@ -1,0 +1,61 @@
+package qwen
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/GizClaw/flowcraft/core/inference"
+)
+
+func TestDashUsageCanonical(t *testing.T) {
+	usage := dashUsage{
+		InputTokens:     11,
+		OutputTokens:    3,
+		TotalTokens:     14,
+		CachedTokens:    2,
+		ReasoningTokens: 5,
+	}
+	canonical := usage.canonical()
+	if canonical.Input.CacheReadTokens == nil ||
+		*canonical.Input.CacheReadTokens != 2 {
+		t.Fatalf("cache read = %+v", canonical.Input)
+	}
+	if canonical.Output.ReasoningTokens == nil ||
+		*canonical.Output.ReasoningTokens != 5 {
+		t.Fatalf("reasoning = %+v", canonical.Output)
+	}
+	if canonical.Output.ReasoningAccounting != inference.ReasoningAdditional {
+		t.Fatalf(
+			"reasoning accounting = %q, want %q",
+			canonical.Output.ReasoningAccounting,
+			inference.ReasoningAdditional,
+		)
+	}
+	// Reasoning rides outside output_tokens on DashScope, so the canonical
+	// usage must pass validation with the additional accounting semantics.
+	if err := canonical.Validate(); err != nil {
+		t.Fatalf("Validate: %v", err)
+	}
+}
+
+func TestDashResponseUsageParsesCacheAndReasoning(t *testing.T) {
+	var envelope dashResponse
+	if err := json.Unmarshal([]byte(`{
+		"usage": {
+			"input_tokens": 11,
+			"output_tokens": 3,
+			"total_tokens": 14,
+			"input_tokens_details": {"cached_tokens": 2},
+			"output_tokens_details": {"reasoning_tokens": 5}
+		}
+	}`), &envelope); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	usage := envelope.usage()
+	if usage.CachedTokens != 2 {
+		t.Fatalf("cached tokens = %d, want 2", usage.CachedTokens)
+	}
+	if usage.ReasoningTokens != 5 {
+		t.Fatalf("reasoning tokens = %d, want 5", usage.ReasoningTokens)
+	}
+}


### PR DESCRIPTION
## Summary
Four related improvements to the inference streaming and telemetry surface:

1. **Stream protocol** — reasoning fragments now stream incrementally as `ReasoningPart` deltas, and every generation ends with two new terminal deltas: `provider_outputs` (fixes silent drop of citations/search metadata) and `finish` (finish reason + request/response ids). A mid-stream failure still reports the last cumulative usage snapshot.
2. **Request/response ids** — routed calls record `llm.request.id` / `llm.response.id` on the route span, stream spans are finalized at drain completion (not stream open), error paths record `llm.request.id` from the error chain, and step/run error events expose `request_id` to downstream UIs.
3. **Usage stamping** — unary and streamed generate responses stamp `Usage.Model` and `Usage.LatencyMs`, with conformance assertions.
4. **Audio/driver enrichment** — derive encoded audio durations (PCM/MP3) and apply them across TTS drivers; enrich driver usage breakdowns (cache TTL split, reasoning accounting, prediction tokens, audio modalities).

## Verification
- `make ci` (vet + test, all modules)
- `make lint`
- `make release-check BASE=origin/main`
- `git diff --check`

No release changeset added (only added when tagging).