### PR TITLE
chore(release): add core v0.1.3 changeset

### DIFF
--- a/.release/core-v0.1.3.json
+++ b/.release/core-v0.1.3.json
@@ -1,0 +1,9 @@
+{
+  "summary": "Add stream terminal signals and request-id telemetry, stamp usage model/latency, and enrich driver usage and audio support",
+  "releases": [
+    {
+      "module": "core",
+      "bump": "patch"
+    }
+  ]
+}


### PR DESCRIPTION
Adds the immutable patch changeset for the next core release.

## Planned release
- `core`: `v0.1.2` -> `v0.1.3` (patch), tag `core/v0.1.3`

## Delta covered since `core/v0.1.2`
- #304 stream reasoning/terminal deltas, request-id telemetry, usage model/latency stamping, and driver usage/audio enrichment

## Verification
- `make release-check BASE=origin/main`
- `make release-plan`
- `make release-preflight` (core tidy OK)

Merging this triggers the Release modules workflow: it aggregates the pending summary into `CHANGELOG.md`, opens the `automation/release-changelog` PR, and after that PR merges, gates and publishes the `core/v0.1.3` tag.