### PR TITLE
fix(core): treat already-closed sandbox stdin as a no-op close

### DIFF
--- a/core/sandbox/session_unix.go
+++ b/core/sandbox/session_unix.go
@@ -226,6 +226,12 @@ func (s *localSession) CloseInput() error {
 	}
 	err := s.stdin.Close()
 	s.stdin = nil
+	if errors.Is(err, os.ErrClosed) {
+		// cmd.Wait (running in reap) closes the parent-side stdin write
+		// end once the child exits. Racing that cleanup is a successful
+		// no-op: the input is already closed, which is the desired state.
+		return nil
+	}
 	return err
 }
 

--- a/core/sandbox/session_unix_internal_test.go
+++ b/core/sandbox/session_unix_internal_test.go
@@ -1,0 +1,30 @@
+//go:build unix
+
+package sandbox
+
+import (
+	"os"
+	"testing"
+)
+
+// TestLocalSessionCloseInputIgnoresAlreadyClosed covers the race where
+// cmd.Wait (running in reap) closes the parent-side stdin write end just
+// before Exec calls CloseInput: closing an already-closed pipe must be a
+// no-op success, not an error that fails the whole Exec.
+func TestLocalSessionCloseInputIgnoresAlreadyClosed(t *testing.T) {
+	_, w, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	s := &localSession{stdin: w}
+	if err := s.CloseInput(); err != nil {
+		t.Fatalf("CloseInput on an already-closed stdin = %v, want nil", err)
+	}
+	if s.stdin != nil {
+		t.Fatal("CloseInput should detach the closed stdin")
+	}
+}


### PR DESCRIPTION
## Problem
`core/v0.1.3` release gate failed on a `-race` run with:

```
--- FAIL: TestExecNonZeroExit
    exec_test.go:49: Exec: close |1: file already closed
```

## Root cause
`localSession.CloseInput` and the session reap goroutine race to close the parent-side stdin write end: `cmd.Wait` (running in `reap`) closes the pipe once the child exits, so a fast-exiting command like `sh -c "exit 3"` can leave `CloseInput` closing an already-closed `*os.File`, which returns `&os.PathError{Op: "close", Path: "|1", Err: os.ErrClosed}` and fails the whole one-shot `sandbox.Exec`.

## Fix
`CloseInput` now treats `os.ErrClosed` as a successful no-op — the input is already in the desired closed state — and still detaches the handle.

## Verification
- `go test -count=1 -race ./...` in `core` (the exact release-gate command)
- targeted `TestLocalSessionCloseInputIgnoresAlreadyClosed` plus `TestExec*` with `-race -count=20`
- `go vet`, `golangci-lint`, `git diff --check`