### PR TITLE
chore(release): add core v0.1.4 changeset

### DIFF
--- a/.release/core-v0.1.4.json
+++ b/.release/core-v0.1.4.json
@@ -1,0 +1,9 @@
+{
+  "summary": "Treat already-closed sandbox stdin as a no-op close to fix the release-gate exec race",
+  "releases": [
+    {
+      "module": "core",
+      "bump": "patch"
+    }
+  ]
+}


### PR DESCRIPTION
Adds the immutable patch changeset for the next core release.

## Planned release
- `core`: `v0.1.3` -> `v0.1.4` (patch), tag `core/v0.1.4`

## Delta covered since `core/v0.1.3`
- #307 fix sandbox stdin close race (`file already closed` flake in the release gate)

## Verification
- `make release-check BASE=origin/main`
- `make release-plan`
- `make release-preflight` (core tidy OK)

Merging this triggers the Release modules workflow: it aggregates the pending summary into `CHANGELOG.md`, opens the `automation/release-changelog` PR, and after that PR merges, gates and publishes the `core/v0.1.4` tag.