### PR TITLE
feat(core): runtime prompt event subscription, prompt lifecycle resolved events, and sandbox allowlist approval composition

### DIFF
--- a/.release/core-v0.1.5.json
+++ b/.release/core-v0.1.5.json
@@ -1,0 +1,9 @@
+{
+  "summary": "feat(core): runtime prompt event subscription, prompt lifecycle resolved events, and sandbox allowlist approval composition",
+  "releases": [
+    {
+      "module": "core",
+      "bump": "patch"
+    }
+  ]
+}

--- a/core/runtime/attach_test.go
+++ b/core/runtime/attach_test.go
@@ -1,0 +1,193 @@
+package runtime
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/GizClaw/flowcraft/core/agent"
+	"github.com/GizClaw/flowcraft/core/event"
+	"github.com/GizClaw/flowcraft/core/message"
+	"github.com/GizClaw/flowcraft/core/resource"
+	"github.com/GizClaw/flowcraft/core/runtime/session"
+)
+
+const attachEngineKind = "runtime-attach-engine"
+
+type attachEngineFactory struct {
+	engine agent.Engine
+}
+
+func (f attachEngineFactory) Spec() resource.Spec {
+	return resource.Spec{Kind: attachEngineKind}
+}
+
+func (f attachEngineFactory) New(context.Context, resource.Input) (any, error) {
+	if f.engine == nil {
+		return nil, errors.New("attach engine factory: nil engine")
+	}
+	return f.engine, nil
+}
+
+func TestRuntimeAttachDeliversPromptLifecycle(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	engine := agent.EngineFunc(func(
+		ctx context.Context,
+		_ agent.Run,
+		host agent.Host,
+		board *agent.Board,
+	) (*agent.Board, error) {
+		reply, err := host.AskUser(ctx, agent.UserPrompt{Source: "attach-test"})
+		if err != nil {
+			return board, err
+		}
+		if len(reply.Parts) == 0 {
+			return board, errors.New("AskUser reply missing parts")
+		}
+		return board, nil
+	})
+	reg := resource.NewRegistry()
+	reg.MustRegister(event.NewFactory())
+	reg.MustRegister(attachEngineFactory{engine: engine})
+
+	doc := parseRuntimeDoc(t, `version: v1
+resources:
+  events:
+    kind: event.Bus
+    impl: memory
+agents:
+  echo:
+    card: {name: Echo}
+    engine:
+      kind: runtime-attach-engine
+runtime:
+  event_bus: events
+  sessions:
+    idle_timeout: 1m
+    sink_buffer: 8
+`)
+
+	app, err := NewBuilder(reg).Build(ctx, doc)
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+
+	requested := make(chan session.PromptRequested, 1)
+	resolved := make(chan session.PromptResolved, 1)
+	requestedDetach, err := app.Attach(ctx, session.PatternPromptRequested(),
+		event.SinkFunc(func(ctx context.Context, env event.Envelope) error {
+			var req session.PromptRequested
+			if err := env.Decode(&req); err != nil {
+				return err
+			}
+			requested <- req
+			return nil
+		}))
+	if err != nil {
+		t.Fatalf("Attach requested: %v", err)
+	}
+	defer requestedDetach()
+	resolvedDetach, err := app.Attach(ctx, session.PatternPromptResolved(),
+		event.SinkFunc(func(ctx context.Context, env event.Envelope) error {
+			var res session.PromptResolved
+			if err := env.Decode(&res); err != nil {
+				return err
+			}
+			resolved <- res
+			return nil
+		}))
+	if err != nil {
+		t.Fatalf("Attach resolved: %v", err)
+	}
+	defer resolvedDetach()
+
+	lease, err := app.Sessions().Open(ctx, session.Key{
+		AgentID:   "echo",
+		ContextID: "attach-test",
+	})
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer func() { _ = lease.Close() }()
+	turn, err := lease.Session().Start(ctx, agent.Request{
+		Message: message.NewTextMessage(message.RoleUser, "hello"),
+	})
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	var req session.PromptRequested
+	select {
+	case req = <-requested:
+	case <-time.After(3 * time.Second):
+		t.Fatal("timed out waiting for PromptRequested")
+	}
+	if req.PromptID == "" || req.Prompt.Source != "attach-test" {
+		t.Fatalf("PromptRequested = %+v, want source attach-test", req)
+	}
+
+	if err := turn.Reply(ctx, req.PromptID, agent.UserReply{
+		Parts: []message.Part{message.TextPart{Text: "ok"}},
+	}); err != nil {
+		t.Fatalf("Reply: %v", err)
+	}
+	select {
+	case res := <-resolved:
+		if res.PromptID != req.PromptID || res.Status != session.PromptReplied {
+			t.Fatalf("PromptResolved = %+v, want prompt %s replied", res, req.PromptID)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("timed out waiting for PromptResolved")
+	}
+
+	if _, err := turn.Wait(ctx); err != nil {
+		t.Fatalf("Wait: %v", err)
+	}
+}
+
+func TestRuntimeAttachFailsAfterClose(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	reg := resource.NewRegistry()
+	reg.MustRegister(event.NewFactory())
+	reg.MustRegister(attachEngineFactory{engine: agent.EngineFunc(func(
+		_ context.Context,
+		_ agent.Run,
+		_ agent.Host,
+		board *agent.Board,
+	) (*agent.Board, error) {
+		return board, nil
+	})})
+
+	doc := parseRuntimeDoc(t, `version: v1
+resources:
+  events:
+    kind: event.Bus
+    impl: memory
+agents:
+  echo:
+    card: {name: Echo}
+    engine:
+      kind: runtime-attach-engine
+runtime:
+  event_bus: events
+  sessions:
+    idle_timeout: 1m
+    sink_buffer: 8
+`)
+	app, err := NewBuilder(reg).Build(ctx, doc)
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	if err := app.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	if _, err := app.Attach(ctx, session.PatternPromptRequested(),
+		event.SinkFunc(func(context.Context, event.Envelope) error { return nil })); err == nil {
+		t.Fatal("Attach after Close succeeded, want NotAvailable")
+	}
+}

--- a/core/runtime/builder.go
+++ b/core/runtime/builder.go
@@ -172,11 +172,7 @@ func (b *Builder) Build(ctx context.Context, doc deploy.Document) (*Runtime, err
 		catalogProvider = newDynamicCatalogProvider(assemblies)
 	}
 
-	// The session coordinator must observe every run event and stream
-	// delta in order; a dropping subscription could lose run-end
-	// delimiters or confirmed deltas, so the router blocks instead of
-	// using the bus default.
-	router := event.NewRouter(bus, event.WithDefaultAttachBackpressure(event.Block))
+	router := event.NewRouter(bus)
 	managerOptions := []session.ManagerOption{
 		session.WithIdleTimeout(cfg.Sessions.IdleTimeout),
 		session.WithSinkBufferSize(cfg.Sessions.SinkBuffer),

--- a/core/runtime/runtime.go
+++ b/core/runtime/runtime.go
@@ -1,11 +1,13 @@
 package runtime
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"sync"
 
 	"github.com/GizClaw/flowcraft/core/deploy"
+	"github.com/GizClaw/flowcraft/core/errdefs"
 	"github.com/GizClaw/flowcraft/core/event"
 	"github.com/GizClaw/flowcraft/core/runtime/session"
 )
@@ -26,6 +28,41 @@ func (r *Runtime) Sessions() *session.Manager {
 		return nil
 	}
 	return r.manager
+}
+
+// Attach subscribes pattern on the runtime's borrowed event router and
+// delivers matching envelopes to sink until the returned stop function
+// is called, ctx is cancelled, the subscription ends, or the sink
+// returns an error (which detaches that attachment). It is the
+// runtime-level entry point for consumers that want run events without
+// resolving the deployment document's event_bus resource themselves —
+// for example UI sinks subscribing to prompt lifecycle events:
+//
+//	detach, err := app.Attach(ctx, session.PatternPromptRequested(), sink)
+//	defer detach()
+//
+// The router is owned by the Runtime: Attach fails with NotAvailable
+// after Close, and every attachment is torn down when the Runtime
+// closes. External attachments inherit the bus default backpressure
+// (DropNewest), so a slow consumer drops envelopes instead of blocking
+// the run pipeline; pass event.WithAttachBackpressure to opt into a
+// different policy for a specific subscription.
+func (r *Runtime) Attach(
+	ctx context.Context,
+	pattern event.Pattern,
+	sink event.Sink,
+	opts ...event.AttachOption,
+) (func(), error) {
+	if r == nil || r.router == nil {
+		return nil, errdefs.Validationf("runtime: Attach requires a built Runtime")
+	}
+	if ctx == nil {
+		return nil, errdefs.Validationf("runtime: Attach context is required")
+	}
+	if sink == nil {
+		return nil, errdefs.Validationf("runtime: Attach sink is required")
+	}
+	return r.router.Attach(ctx, pattern, sink, opts...)
 }
 
 // Close stops new session work, waits for active turns, and releases

--- a/core/runtime/session/events.go
+++ b/core/runtime/session/events.go
@@ -19,3 +19,49 @@ type PromptRequested struct {
 func SubjectPromptRequested(runID string) event.Subject {
 	return event.Subject(fmt.Sprintf("%s%s.prompt.requested", agent.SubjectPrefix, agent.SanitiseID(runID)))
 }
+
+// PatternPromptRequested matches every run's prompt-request event.
+func PatternPromptRequested() event.Pattern {
+	return event.Pattern(agent.SubjectPrefix + "*.prompt.requested")
+}
+
+// PromptStatus is the terminal lifecycle state of one prompt.
+type PromptStatus string
+
+const (
+	// PromptReplied is published when a Reply satisfied the prompt.
+	PromptReplied PromptStatus = "replied"
+	// PromptExpired is published when the AskUser context ended before
+	// a reply arrived (timeout or host cancellation).
+	PromptExpired PromptStatus = "expired"
+	// PromptInterrupted is published when a turn interrupt closed the
+	// prompt.
+	PromptInterrupted PromptStatus = "interrupted"
+	// PromptClosed is published when the turn ended while the prompt
+	// was still pending, or when the prompt could not be published.
+	PromptClosed PromptStatus = "closed"
+)
+
+// PromptResolved is published when a prompt stops waiting for user
+// input, so consumers (UI views) can close or invalidate the pending
+// interaction immediately instead of waiting for the whole turn to end.
+// It is a best-effort notification: publish failures do not change the
+// Reply / AskUser result.
+type PromptResolved struct {
+	RunID    string       `json:"run_id"`
+	TurnID   string       `json:"turn_id"`
+	PromptID string       `json:"prompt_id"`
+	Status   PromptStatus `json:"status"`
+}
+
+// SubjectPromptResolved returns the run-scoped prompt resolution
+// subject, sharing the run namespace with SubjectPromptRequested so a
+// "agent.run.<id>.>" subscription observes both.
+func SubjectPromptResolved(runID string) event.Subject {
+	return event.Subject(fmt.Sprintf("%s%s.prompt.resolved", agent.SubjectPrefix, agent.SanitiseID(runID)))
+}
+
+// PatternPromptResolved matches every run's prompt-resolution event.
+func PatternPromptResolved() event.Pattern {
+	return event.Pattern(agent.SubjectPrefix + "*.prompt.resolved")
+}

--- a/core/runtime/session/events_test.go
+++ b/core/runtime/session/events_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/GizClaw/flowcraft/core/agent"
+	"github.com/GizClaw/flowcraft/core/event"
 )
 
 func TestSubjectPromptRequestedUsesSanitizedRunNamespace(t *testing.T) {
@@ -14,5 +15,38 @@ func TestSubjectPromptRequestedUsesSanitizedRunNamespace(t *testing.T) {
 	}
 	if err := got.Validate(); err != nil {
 		t.Fatalf("subject validation error = %v", err)
+	}
+}
+
+func TestPromptResolvedSubjectUsesSanitizedRunNamespace(t *testing.T) {
+	got := SubjectPromptResolved("run.with*>wildcards")
+	want := agent.SubjectPrefix + "run_with__wildcards.prompt.resolved"
+	if string(got) != want {
+		t.Fatalf("subject = %q, want %q", got, want)
+	}
+	if err := got.Validate(); err != nil {
+		t.Fatalf("subject validation error = %v", err)
+	}
+}
+
+func TestPromptPatternsMatchOnlyTheirOwnSubject(t *testing.T) {
+	requested := PatternPromptRequested()
+	resolved := PatternPromptResolved()
+	for _, pattern := range []event.Pattern{requested, resolved} {
+		if err := pattern.Validate(); err != nil {
+			t.Fatalf("pattern %q validation error = %v", pattern, err)
+		}
+	}
+	if !requested.Matches(SubjectPromptRequested("run-1")) {
+		t.Fatal("requested pattern does not match a prompt-requested subject")
+	}
+	if !resolved.Matches(SubjectPromptResolved("run-1")) {
+		t.Fatal("resolved pattern does not match a prompt-resolved subject")
+	}
+	if requested.Matches(SubjectPromptResolved("run-1")) {
+		t.Fatal("requested pattern matches a prompt-resolved subject")
+	}
+	if resolved.Matches(SubjectPromptRequested("run-1")) {
+		t.Fatal("resolved pattern matches a prompt-requested subject")
 	}
 }

--- a/core/runtime/session/lifecycle_test.go
+++ b/core/runtime/session/lifecycle_test.go
@@ -509,3 +509,199 @@ func TestHostFactoryNilAndErrorPreventExecution(t *testing.T) {
 		t.Fatalf("engine executions = %d, want 0", executions.Load())
 	}
 }
+
+type capturedPromptEvent struct {
+	kind     string // "requested" or "resolved"
+	promptID string
+	status   PromptStatus
+}
+
+func capturePromptLifecycle(sub event.Subscription) chan capturedPromptEvent {
+	events := make(chan capturedPromptEvent, 32)
+	go func() {
+		for env := range sub.C() {
+			switch env.Subject {
+			case SubjectPromptRequested(env.RunID()):
+				var req PromptRequested
+				if env.Decode(&req) == nil {
+					events <- capturedPromptEvent{kind: "requested", promptID: req.PromptID}
+				}
+			case SubjectPromptResolved(env.RunID()):
+				var res PromptResolved
+				if env.Decode(&res) == nil {
+					events <- capturedPromptEvent{
+						kind:     "resolved",
+						promptID: res.PromptID,
+						status:   res.Status,
+					}
+				}
+			}
+		}
+	}()
+	return events
+}
+
+func waitForPromptEvent(t *testing.T, events chan capturedPromptEvent, want capturedPromptEvent) {
+	t.Helper()
+	timeout := time.After(3 * time.Second)
+	for {
+		select {
+		case got := <-events:
+			if got == want {
+				return
+			}
+		case <-timeout:
+			t.Fatalf("timed out waiting for prompt event %+v", want)
+		}
+	}
+}
+
+func waitForAnyPromptEvent(t *testing.T, events chan capturedPromptEvent) capturedPromptEvent {
+	t.Helper()
+	select {
+	case got := <-events:
+		return got
+	case <-time.After(3 * time.Second):
+		t.Fatal("timed out waiting for the first prompt event")
+		return capturedPromptEvent{}
+	}
+}
+
+func TestPromptResolutionEvents(t *testing.T) {
+	t.Run("replied", func(t *testing.T) {
+		engine := agent.EngineFunc(func(ctx context.Context, _ agent.Run, host agent.Host, board *agent.Board) (*agent.Board, error) {
+			reply, err := host.AskUser(ctx, agent.UserPrompt{Source: "replied"})
+			if err != nil {
+				return board, err
+			}
+			if len(reply.Parts) == 0 {
+				return board, errors.New("AskUser reply missing parts")
+			}
+			return board, nil
+		})
+		_, session, _, bus := newTurnSession(t, engine, turnHostFactory)
+		sub, _ := bus.Subscribe(context.Background(), agent.PatternAllRuns())
+		defer func() { _ = sub.Close() }()
+		events := capturePromptLifecycle(sub)
+		turn, err := session.Start(context.Background(), agent.Request{
+			Message: message.NewTextMessage(message.RoleUser, "hi"),
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		req := waitForAnyPromptEvent(t, events)
+		if req.kind != "requested" {
+			t.Fatalf("first prompt event = %+v, want requested", req)
+		}
+		if err := turn.Reply(context.Background(), req.promptID, agent.UserReply{
+			Parts: []message.Part{message.TextPart{Text: "ok"}},
+		}); err != nil {
+			t.Fatal(err)
+		}
+		waitForPromptEvent(t, events, capturedPromptEvent{
+			kind:     "resolved",
+			promptID: req.promptID,
+			status:   PromptReplied,
+		})
+		if _, err := turn.Wait(context.Background()); err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	t.Run("expired", func(t *testing.T) {
+		engine := agent.EngineFunc(func(ctx context.Context, _ agent.Run, host agent.Host, board *agent.Board) (*agent.Board, error) {
+			promptCtx, cancel := context.WithTimeout(ctx, 20*time.Millisecond)
+			defer cancel()
+			_, err := host.AskUser(promptCtx, agent.UserPrompt{Source: "expired"})
+			return board, err
+		})
+		_, session, _, bus := newTurnSession(t, engine, turnHostFactory)
+		sub, _ := bus.Subscribe(context.Background(), agent.PatternAllRuns())
+		defer func() { _ = sub.Close() }()
+		events := capturePromptLifecycle(sub)
+		turn, err := session.Start(context.Background(), agent.Request{
+			Message: message.NewTextMessage(message.RoleUser, "hi"),
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		req := waitForAnyPromptEvent(t, events)
+		if _, err := turn.Wait(context.Background()); err != nil {
+			t.Fatal(err)
+		}
+		waitForPromptEvent(t, events, capturedPromptEvent{
+			kind:     "resolved",
+			promptID: req.promptID,
+			status:   PromptExpired,
+		})
+	})
+
+	t.Run("interrupted", func(t *testing.T) {
+		engine := agent.EngineFunc(func(ctx context.Context, _ agent.Run, host agent.Host, board *agent.Board) (*agent.Board, error) {
+			_, err := host.AskUser(ctx, agent.UserPrompt{Source: "interrupted"})
+			return board, err
+		})
+		_, session, _, bus := newTurnSession(t, engine, turnHostFactory)
+		sub, _ := bus.Subscribe(context.Background(), agent.PatternAllRuns())
+		defer func() { _ = sub.Close() }()
+		events := capturePromptLifecycle(sub)
+		turn, err := session.Start(context.Background(), agent.Request{
+			Message: message.NewTextMessage(message.RoleUser, "hi"),
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		req := waitForAnyPromptEvent(t, events)
+		if err := turn.Interrupt(agent.Interrupt{Cause: agent.CauseUserInput}); err != nil {
+			t.Fatal(err)
+		}
+		result, err := turn.Wait(context.Background())
+		if err != nil {
+			t.Fatal(err)
+		}
+		if result.Status != agent.StatusInterrupted {
+			t.Fatalf("status = %q, want interrupted", result.Status)
+		}
+		waitForPromptEvent(t, events, capturedPromptEvent{
+			kind:     "resolved",
+			promptID: req.promptID,
+			status:   PromptInterrupted,
+		})
+	})
+
+	t.Run("closed", func(t *testing.T) {
+		askDone := make(chan error, 1)
+		release := make(chan struct{})
+		engine := agent.EngineFunc(func(ctx context.Context, _ agent.Run, host agent.Host, board *agent.Board) (*agent.Board, error) {
+			go func() {
+				_, err := host.AskUser(ctx, agent.UserPrompt{Source: "closed"})
+				askDone <- err
+			}()
+			<-release
+			return board, nil
+		})
+		_, session, _, bus := newTurnSession(t, engine, turnHostFactory)
+		sub, _ := bus.Subscribe(context.Background(), agent.PatternAllRuns())
+		defer func() { _ = sub.Close() }()
+		events := capturePromptLifecycle(sub)
+		turn, err := session.Start(context.Background(), agent.Request{
+			Message: message.NewTextMessage(message.RoleUser, "hi"),
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		req := waitForAnyPromptEvent(t, events)
+		close(release)
+		if _, err := turn.Wait(context.Background()); err != nil {
+			t.Fatal(err)
+		}
+		waitForPromptEvent(t, events, capturedPromptEvent{
+			kind:     "resolved",
+			promptID: req.promptID,
+			status:   PromptClosed,
+		})
+		if err := <-askDone; !errors.Is(err, ErrPromptClosed) {
+			t.Fatalf("AskUser error = %v, want closed", err)
+		}
+	})
+}

--- a/core/runtime/session/prompt.go
+++ b/core/runtime/session/prompt.go
@@ -5,6 +5,7 @@ import (
 	"crypto/rand"
 	"encoding/hex"
 	"fmt"
+	"time"
 
 	"github.com/GizClaw/flowcraft/core/agent"
 	"github.com/GizClaw/flowcraft/core/errdefs"
@@ -30,6 +31,18 @@ type promptEntry struct {
 	state   promptState
 	outcome chan promptOutcome
 }
+
+// promptResolution records one prompt that left the pending state, so
+// the caller can publish PromptResolved after releasing the turn lock.
+type promptResolution struct {
+	promptID string
+	status   PromptStatus
+}
+
+// promptResolvePublishTimeout bounds the best-effort PromptResolved
+// publish so a slow subscriber can never stall turn finalization or
+// interrupt handling.
+const promptResolvePublishTimeout = 2 * time.Second
 
 // Reply supplies a response to one prompt without affecting other prompts.
 func (t *Turn) Reply(ctx context.Context, promptID string, reply agent.UserReply) error {
@@ -58,6 +71,7 @@ func (t *Turn) Reply(ctx context.Context, promptID string, reply agent.UserReply
 		entry.outcome <- promptOutcome{reply: reply}
 		t.mu.Unlock()
 		t.session.changeActivity(activityPrompt, -1)
+		t.publishPromptResolved(t.host, promptID, PromptReplied)
 		return nil
 	default:
 		t.mu.Unlock()
@@ -107,6 +121,7 @@ func (t *Turn) askUser(ctx context.Context, prompt agent.UserPrompt) (agent.User
 	if err != nil {
 		if t.resolvePrompt(promptID, promptClosed, promptOutcome{err: err}) {
 			t.session.changeActivity(activityPrompt, -1)
+			t.publishPromptResolved(host, promptID, PromptClosed)
 		}
 		return agent.UserReply{}, err
 	}
@@ -118,6 +133,7 @@ func (t *Turn) askUser(ctx context.Context, prompt agent.UserPrompt) (agent.User
 		ctxErr := errdefs.FromContext(ctx.Err())
 		if t.resolvePrompt(promptID, promptExpired, promptOutcome{err: ctxErr}) {
 			t.session.changeActivity(activityPrompt, -1)
+			t.publishPromptResolved(host, promptID, PromptExpired)
 			return agent.UserReply{}, ctxErr
 		}
 		outcome := <-entry.outcome
@@ -140,36 +156,70 @@ func (t *Turn) resolvePrompt(promptID string, state promptState, outcome promptO
 	return true
 }
 
-func (t *Turn) interruptPendingPromptsLocked(interrupt agent.Interrupt) int {
-	changed := 0
-	for _, entry := range t.prompts {
+func (t *Turn) interruptPendingPromptsLocked(interrupt agent.Interrupt) []promptResolution {
+	var resolved []promptResolution
+	for promptID, entry := range t.prompts {
 		if entry.state != promptPending {
 			continue
 		}
 		entry.state = promptInterrupted
 		entry.outcome <- promptOutcome{err: agent.Interrupted(interrupt)}
-		changed++
+		resolved = append(resolved, promptResolution{
+			promptID: promptID,
+			status:   PromptInterrupted,
+		})
 	}
-	return changed
+	return resolved
 }
 
-func (t *Turn) closePendingPromptsLocked() int {
-	changed := 0
-	for _, entry := range t.prompts {
+func (t *Turn) closePendingPromptsLocked() []promptResolution {
+	var resolved []promptResolution
+	for promptID, entry := range t.prompts {
 		if entry.state != promptPending {
 			continue
 		}
 		entry.state = promptClosed
 		entry.outcome <- promptOutcome{err: ErrPromptClosed}
-		changed++
+		resolved = append(resolved, promptResolution{
+			promptID: promptID,
+			status:   PromptClosed,
+		})
 	}
-	return changed
+	return resolved
 }
 
 func (t *Turn) finishPromptActivity(count int) {
 	if count > 0 {
 		t.session.changeActivity(activityPrompt, -count)
 	}
+}
+
+// publishPromptResolved emits one best-effort PromptResolved envelope.
+// It is called only after the turn lock is released — Publish can block
+// on Block-backpressure subscribers, so it must never run under t.mu.
+func (t *Turn) publishPromptResolved(host agent.Host, promptID string, status PromptStatus) {
+	if t == nil || host == nil || promptID == "" {
+		return
+	}
+	ctx, cancel := context.WithTimeout(
+		context.WithoutCancel(t.runCtx),
+		promptResolvePublishTimeout,
+	)
+	defer cancel()
+	envelope, err := event.NewEnvelope(ctx, SubjectPromptResolved(t.runID), PromptResolved{
+		RunID:    t.runID,
+		TurnID:   t.runID,
+		PromptID: promptID,
+		Status:   status,
+	})
+	if err != nil {
+		return
+	}
+	envelope.SetRunID(t.runID)
+	if t.session != nil {
+		envelope.SetAgentID(t.session.key.AgentID)
+	}
+	_ = host.Publish(ctx, envelope)
 }
 
 func randomID() (string, error) {

--- a/core/runtime/session/session.go
+++ b/core/runtime/session/session.go
@@ -217,11 +217,16 @@ func (s *Session) Start(ctx context.Context, request agent.Request, sinks ...Sin
 	// Single subscription to the whole run namespace: `>` matches both
 	// the run lifecycle events (run-end delimits attempts) and the
 	// stream deltas. Two subscriptions would deliver every stream delta
-	// twice.
+	// twice. The coordinator must observe every event and delta in
+	// order; a dropping subscription could lose run-end delimiters or
+	// confirmed deltas, so it explicitly blocks instead of using the
+	// bus default (external Runtime.Attach consumers keep the
+	// non-blocking default).
 	detach, attachErr := s.router.Attach(
 		context.Background(),
 		agent.PatternRun(runID),
 		coordinator,
+		event.WithAttachBackpressure(event.Block),
 	)
 	if attachErr != nil {
 		for _, attachment := range attachments {

--- a/core/runtime/session/turn.go
+++ b/core/runtime/session/turn.go
@@ -114,9 +114,12 @@ func (t *Turn) Interrupt(interrupt agent.Interrupt) error {
 	case t.interrupts <- interrupt:
 	default:
 	}
-	prompts := t.interruptPendingPromptsLocked(interrupt)
+	resolved := t.interruptPendingPromptsLocked(interrupt)
 	t.mu.Unlock()
-	t.finishPromptActivity(prompts)
+	t.finishPromptActivity(len(resolved))
+	for _, r := range resolved {
+		t.publishPromptResolved(t.host, r.promptID, r.status)
+	}
 	return nil
 }
 
@@ -213,13 +216,16 @@ func (t *Turn) finish(result *agent.Result, err error) {
 	t.result = result
 	t.err = err
 	t.state = terminalState(result, err)
-	prompts := t.closePendingPromptsLocked()
+	resolved := t.closePendingPromptsLocked()
 	attachments := append([]*queuedSink(nil), t.attachments...)
 	coordinator := t.coordinator
 	detachCoordinator := t.coordinatorDetach
 	t.mu.Unlock()
 
-	t.finishPromptActivity(prompts)
+	t.finishPromptActivity(len(resolved))
+	for _, r := range resolved {
+		t.publishPromptResolved(t.host, r.promptID, r.status)
+	}
 	var runEndErr *agent.RunEndPublishError
 	runEndFailed := result != nil && errors.As(result.Err, &runEndErr)
 	var finalizeErr error

--- a/core/sandbox/allowlist.go
+++ b/core/sandbox/allowlist.go
@@ -1,0 +1,368 @@
+package sandbox
+
+import (
+	"path/filepath"
+	"strings"
+	"sync"
+
+	"github.com/GizClaw/flowcraft/core/errdefs"
+)
+
+// rule is one parsed allowlist entry: a token prefix plus an optional
+// trailing wildcard.
+type rule struct {
+	tokens   []string
+	wildcard bool
+}
+
+// Allowlist is a thread-safe set of command rules used to decide which
+// Exec calls are in-bounds (no human approval needed). A rule is a
+// whitespace-separated token prefix of the normalized command, with an
+// optional trailing "*" that matches any remaining arguments; without
+// "*" the rule matches the normalized command exactly:
+//
+//	go run *     matches "go run main.go", "go run test", and "go run"
+//	go *         matches any "go" invocation
+//	git status   matches only "git status"
+//
+// The first token is matched against the command's base name as well as
+// its literal form, so "/usr/bin/go" satisfies the rule "go *". Rules
+// are intended to be assembled from layered configuration (defaults +
+// project overrides via NewAllowlist/Add/Union) and mutated at runtime
+// (Add/Set) while Exec calls are in flight.
+//
+// Allowlist matching is deliberately heuristic: NormaliseExec unwraps
+// "sh -c" wrappers, and scripts containing shell control characters are
+// never matched, so they fall through to the approver. Like every
+// predicate, the allowlist is the tripwire, not the wall — OS-level
+// backend enforcement remains the security boundary.
+type Allowlist struct {
+	mu    sync.RWMutex
+	rules []rule
+}
+
+// NewAllowlist builds an allowlist from rules. Invalid rules abort the
+// construction; the returned list is nil.
+func NewAllowlist(rules ...string) (*Allowlist, error) {
+	a := &Allowlist{}
+	if err := a.Add(rules...); err != nil {
+		return nil, err
+	}
+	return a, nil
+}
+
+// Add appends rules. Add is idempotent (duplicate rules are ignored)
+// and all rules are validated before any is applied, so a single
+// invalid rule leaves the allowlist unchanged.
+func (a *Allowlist) Add(rules ...string) error {
+	if a == nil {
+		return errdefs.Validationf("sandbox allowlist: nil Allowlist")
+	}
+	parsed := make([]rule, 0, len(rules))
+	for _, raw := range rules {
+		r, err := parseRule(raw)
+		if err != nil {
+			return err
+		}
+		parsed = append(parsed, r)
+	}
+	a.mu.Lock()
+	seen := make(map[string]bool, len(a.rules)+len(parsed))
+	for _, r := range a.rules {
+		seen[r.String()] = true
+	}
+	for _, r := range parsed {
+		if seen[r.String()] {
+			continue
+		}
+		seen[r.String()] = true
+		a.rules = append(a.rules, r)
+	}
+	a.mu.Unlock()
+	return nil
+}
+
+// Set replaces the whole rule set (config reload). All rules are
+// validated before the replacement is applied.
+func (a *Allowlist) Set(rules []string) error {
+	if a == nil {
+		return errdefs.Validationf("sandbox allowlist: nil Allowlist")
+	}
+	parsed := make([]rule, 0, len(rules))
+	for _, raw := range rules {
+		r, err := parseRule(raw)
+		if err != nil {
+			return err
+		}
+		parsed = append(parsed, r)
+	}
+	a.mu.Lock()
+	a.rules = parsed
+	a.mu.Unlock()
+	return nil
+}
+
+// Union merges other's rules into a without duplicating entries. It is
+// the composition primitive for layered configuration (defaults ∪
+// project overrides).
+func (a *Allowlist) Union(other *Allowlist) error {
+	if other == nil {
+		return nil
+	}
+	seen := make(map[string]bool, len(a.Rules()))
+	for _, raw := range a.Rules() {
+		seen[raw] = true
+	}
+	var add []string
+	for _, raw := range other.Rules() {
+		if !seen[raw] {
+			seen[raw] = true
+			add = append(add, raw)
+		}
+	}
+	return a.Add(add...)
+}
+
+// Rules returns a snapshot of the current rule strings, suitable for
+// persisting the effective list back into config.
+func (a *Allowlist) Rules() []string {
+	if a == nil {
+		return nil
+	}
+	a.mu.RLock()
+	defer a.mu.RUnlock()
+	out := make([]string, 0, len(a.rules))
+	for _, r := range a.rules {
+		out = append(out, r.String())
+	}
+	return out
+}
+
+// Matches reports whether req is in-bounds according to the rules.
+func (a *Allowlist) Matches(req ExecRequest) bool {
+	if a == nil {
+		return false
+	}
+	tokens := NormaliseExec(req)
+	if len(tokens) == 0 {
+		return false
+	}
+	a.mu.RLock()
+	defer a.mu.RUnlock()
+	for _, r := range a.rules {
+		if matchRule(r, tokens) {
+			return true
+		}
+	}
+	return false
+}
+
+// NotAllowed returns a Predicate that matches calls outside the
+// allowlist, so WithApproval routes them to the approver (or fails
+// closed when no approver is configured).
+func (a *Allowlist) NotAllowed() Predicate {
+	return PredicateFunc(func(req ExecRequest) (string, bool) {
+		if a != nil && a.Matches(req) {
+			return "", false
+		}
+		return "command not in sandbox allowlist", true
+	})
+}
+
+// NormaliseExec returns the token list used for allowlist matching. A
+// "sh -c <script>" invocation is unwrapped to the script's tokens when
+// the script is a simple command; complex scripts (shell control
+// characters, substitutions, redirects) are not unwrapped, so their
+// token list is the raw argv and they never match an allowlist rule.
+func NormaliseExec(req ExecRequest) []string {
+	if tokens, ok := unwrapShellExec(req); ok {
+		return tokens
+	}
+	return append([]string{req.Command}, req.Args...)
+}
+
+func unwrapShellExec(req ExecRequest) ([]string, bool) {
+	if req.Command == "" || len(req.Args) < 2 {
+		return nil, false
+	}
+	if !isShellName(filepath.Base(req.Command)) || !isDashCArg(req.Args[0]) {
+		return nil, false
+	}
+	tokens, ok := tokenizeShellScript(req.Args[1])
+	if !ok {
+		return nil, false
+	}
+	return tokens, true
+}
+
+func isShellName(name string) bool {
+	switch name {
+	case "sh", "bash", "zsh", "dash", "ash", "ksh", "fish":
+		return true
+	default:
+		return false
+	}
+}
+
+func isDashCArg(arg string) bool {
+	if arg == "-c" {
+		return true
+	}
+	return strings.HasPrefix(arg, "-") && strings.Contains(arg, "c")
+}
+
+// tokenizeShellScript splits a sh -c script into argument tokens and
+// reports whether it is a simple invocation safe for allowlist
+// matching. Scripts containing unquoted shell control characters
+// (command separators, pipes, redirects, substitutions, subshells,
+// newlines) or unterminated quotes are reported as unsafe, and the
+// caller then treats the call as needing approval instead of matching
+// it against the allowlist. Leading "NAME=value" assignments are
+// skipped so "FOO=1 go run main.go" still matches "go run *".
+func tokenizeShellScript(script string) ([]string, bool) {
+	var tokens []string
+	var cur strings.Builder
+	inSingle, inDouble, escaping := false, false, false
+	flush := func() {
+		if cur.Len() > 0 {
+			tokens = append(tokens, cur.String())
+			cur.Reset()
+		}
+	}
+	for _, r := range script {
+		if escaping {
+			cur.WriteRune(r)
+			escaping = false
+			continue
+		}
+		if inSingle {
+			if r == '\'' {
+				inSingle = false
+			} else {
+				cur.WriteRune(r)
+			}
+			continue
+		}
+		if inDouble {
+			if r == '"' {
+				inDouble = false
+			} else {
+				cur.WriteRune(r)
+			}
+			continue
+		}
+		switch r {
+		case '\\':
+			escaping = true
+		case '\'':
+			inSingle = true
+		case '"':
+			inDouble = true
+		case ' ', '\t':
+			flush()
+		case '&', ';', '|', '<', '>', '`', '$', '(', ')', '\n':
+			return nil, false
+		default:
+			cur.WriteRune(r)
+		}
+	}
+	if escaping || inSingle || inDouble {
+		return nil, false
+	}
+	flush()
+	for len(tokens) > 0 && isEnvAssignment(tokens[0]) {
+		tokens = tokens[1:]
+	}
+	if len(tokens) == 0 {
+		return nil, false
+	}
+	return tokens, true
+}
+
+func isEnvAssignment(token string) bool {
+	eq := strings.IndexByte(token, '=')
+	if eq <= 0 {
+		return false
+	}
+	name := token[:eq]
+	for i, r := range name {
+		if i == 0 {
+			if r != '_' && (r < 'a' || r > 'z') && (r < 'A' || r > 'Z') {
+				return false
+			}
+			continue
+		}
+		if r != '_' && (r < 'a' || r > 'z') && (r < 'A' || r > 'Z') && (r < '0' || r > '9') {
+			return false
+		}
+	}
+	return true
+}
+
+func parseRule(raw string) (rule, error) {
+	tokens := strings.Fields(raw)
+	if len(tokens) == 0 {
+		return rule{}, errdefs.Validationf("sandbox allowlist: empty rule")
+	}
+	wildcard := false
+	if tokens[len(tokens)-1] == "*" {
+		wildcard = true
+		tokens = tokens[:len(tokens)-1]
+	}
+	if len(tokens) == 0 {
+		return rule{}, errdefs.Validationf(
+			"sandbox allowlist: rule %q must name a command", raw)
+	}
+	for _, tok := range tokens {
+		if strings.Contains(tok, "*") {
+			return rule{}, errdefs.Validationf(
+				"sandbox allowlist: rule %q: '*' is only allowed as the final token", raw)
+		}
+	}
+	return rule{tokens: tokens, wildcard: wildcard}, nil
+}
+
+// String renders the rule back to its canonical config form.
+func (r rule) String() string {
+	raw := strings.Join(r.tokens, " ")
+	if r.wildcard {
+		raw += " *"
+	}
+	return raw
+}
+
+func matchRule(r rule, tokens []string) bool {
+	if r.wildcard {
+		if len(tokens) < len(r.tokens) {
+			return false
+		}
+	} else if len(tokens) != len(r.tokens) {
+		return false
+	}
+	for i, want := range r.tokens {
+		got := tokens[i]
+		if i == 0 {
+			if !tokenEqual(want, got) {
+				return false
+			}
+			continue
+		}
+		if want != got {
+			return false
+		}
+	}
+	return true
+}
+
+// tokenEqual matches a rule's program token against the command's
+// program token literally, or against its base name when the rule names
+// a bare program (no slash).
+func tokenEqual(want, got string) bool {
+	if want == got {
+		return true
+	}
+	if strings.ContainsRune(want, '/') {
+		return false
+	}
+	return want == filepath.Base(got)
+}

--- a/core/sandbox/allowlist_test.go
+++ b/core/sandbox/allowlist_test.go
@@ -1,0 +1,252 @@
+package sandbox_test
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/GizClaw/flowcraft/core/errdefs"
+	"github.com/GizClaw/flowcraft/core/sandbox"
+)
+
+func TestAllowlistRejectsInvalidRules(t *testing.T) {
+	for _, rule := range []string{"", "*", "go r*n", "go run * extra", "  "} {
+		if _, err := sandbox.NewAllowlist(rule); err == nil {
+			t.Fatalf("NewAllowlist(%q) succeeded, want error", rule)
+		}
+	}
+	if _, err := sandbox.NewAllowlist("go *"); err != nil {
+		t.Fatalf("NewAllowlist(go *) error = %v", err)
+	}
+}
+
+func TestAllowlistMatches(t *testing.T) {
+	a, err := sandbox.NewAllowlist("go *", "go run *", "git status", "/usr/bin/git *")
+	if err != nil {
+		t.Fatal(err)
+	}
+	cases := []struct {
+		name string
+		req  sandbox.ExecRequest
+		want bool
+	}{
+		{"bare go", sandbox.ExecRequest{Command: "go"}, true},
+		{"go build", sandbox.ExecRequest{Command: "go", Args: []string{"build", "x"}}, true},
+		{"absolute go by basename", sandbox.ExecRequest{Command: "/usr/bin/go", Args: []string{"mod", "tidy"}}, true},
+		{"go run", sandbox.ExecRequest{Command: "go", Args: []string{"run"}}, true},
+		{"go run main", sandbox.ExecRequest{Command: "go", Args: []string{"run", "main.go"}}, true},
+		{"other program", sandbox.ExecRequest{Command: "python3"}, false},
+		{"exact git status", sandbox.ExecRequest{Command: "git", Args: []string{"status"}}, true},
+		{"git status with args", sandbox.ExecRequest{Command: "git", Args: []string{"status", "-s"}}, false},
+		{"bare git", sandbox.ExecRequest{Command: "git"}, false},
+		{"slash rule literal", sandbox.ExecRequest{Command: "/usr/bin/git", Args: []string{"log"}}, true},
+		{"slash rule not basename", sandbox.ExecRequest{Command: "git", Args: []string{"log"}}, false},
+	}
+	for _, tc := range cases {
+		if got := a.Matches(tc.req); got != tc.want {
+			t.Errorf("%s: Matches(%+v) = %v, want %v", tc.name, tc.req, got, tc.want)
+		}
+	}
+}
+
+func TestNormaliseExecUnwrapsShell(t *testing.T) {
+	tokens := sandbox.NormaliseExec(sandbox.ExecRequest{
+		Command: "sh", Args: []string{"-c", "go run main.go"},
+	})
+	if want := []string{"go", "run", "main.go"}; !reflect.DeepEqual(tokens, want) {
+		t.Fatalf("NormaliseExec(sh -c) = %v, want %v", tokens, want)
+	}
+	tokens = sandbox.NormaliseExec(sandbox.ExecRequest{
+		Command: "git", Args: []string{"status"},
+	})
+	if want := []string{"git", "status"}; !reflect.DeepEqual(tokens, want) {
+		t.Fatalf("NormaliseExec(git status) = %v, want %v", tokens, want)
+	}
+	tokens = sandbox.NormaliseExec(sandbox.ExecRequest{
+		Command: "/bin/sh", Args: []string{"-c", "FOO=1 python3 script.py"},
+	})
+	if want := []string{"python3", "script.py"}; !reflect.DeepEqual(tokens, want) {
+		t.Fatalf("NormaliseExec(env-prefixed) = %v, want %v", tokens, want)
+	}
+}
+
+func TestAllowlistMatchesShellInvocation(t *testing.T) {
+	a, err := sandbox.NewAllowlist("go *", "python3 *", "ls *", "echo *")
+	if err != nil {
+		t.Fatal(err)
+	}
+	cases := []struct {
+		name string
+		req  sandbox.ExecRequest
+		want bool
+	}{
+		{"sh -c simple", sandbox.ExecRequest{Command: "sh", Args: []string{"-c", "go run main.go"}}, true},
+		{"abs sh -c", sandbox.ExecRequest{Command: "/bin/sh", Args: []string{"-c", "python3 script.py"}}, true},
+		{"bash -lc", sandbox.ExecRequest{Command: "bash", Args: []string{"-lc", "ls -la"}}, true},
+		{"quoted arg", sandbox.ExecRequest{Command: "sh", Args: []string{"-c", `echo 'a b'`}}, true},
+		{"env prefix", sandbox.ExecRequest{Command: "sh", Args: []string{"-c", "FOO=1 go test ./..."}}, true},
+		{"command chain denied", sandbox.ExecRequest{Command: "sh", Args: []string{"-c", "npm install && rm -rf /"}}, false},
+		{"pipe denied", sandbox.ExecRequest{Command: "sh", Args: []string{"-c", "go list | grep x"}}, false},
+		{"substitution denied", sandbox.ExecRequest{Command: "sh", Args: []string{"-c", "go run $(echo x)"}}, false},
+		{"unterminated quote denied", sandbox.ExecRequest{Command: "sh", Args: []string{"-c", `echo "oops`}}, false},
+	}
+	for _, tc := range cases {
+		if got := a.Matches(tc.req); got != tc.want {
+			t.Errorf("%s: Matches(%+v) = %v, want %v", tc.name, tc.req, got, tc.want)
+		}
+	}
+}
+
+func TestAllowlistMutationAndUnion(t *testing.T) {
+	a, err := sandbox.NewAllowlist("ls *")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := a.Add("go *", "ls *"); err != nil {
+		t.Fatal(err)
+	}
+	if want := []string{"ls *", "go *"}; !reflect.DeepEqual(a.Rules(), want) {
+		t.Fatalf("Rules() = %v, want %v", a.Rules(), want)
+	}
+
+	extra, err := sandbox.NewAllowlist("git status", "go *")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := a.Union(extra); err != nil {
+		t.Fatal(err)
+	}
+	if want := []string{"ls *", "go *", "git status"}; !reflect.DeepEqual(a.Rules(), want) {
+		t.Fatalf("Rules() after Union = %v, want %v", a.Rules(), want)
+	}
+
+	if err := a.Set([]string{"python3 *"}); err != nil {
+		t.Fatal(err)
+	}
+	if a.Matches(sandbox.ExecRequest{Command: "go"}) {
+		t.Fatal("Set did not replace rules: go still matches")
+	}
+	if !a.Matches(sandbox.ExecRequest{Command: "python3", Args: []string{"x.py"}}) {
+		t.Fatal("Set did not apply replacement: python3 does not match")
+	}
+	if err := a.Add("bad rule * inside"); err == nil {
+		t.Fatal("Add applied an invalid rule")
+	}
+	if want := []string{"python3 *"}; !reflect.DeepEqual(a.Rules(), want) {
+		t.Fatalf("Rules() after failed Add = %v, want %v", a.Rules(), want)
+	}
+}
+
+func TestAllowlistConcurrentAddAndMatch(t *testing.T) {
+	a, err := sandbox.NewAllowlist("go *")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var wg sync.WaitGroup
+	for range 8 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for i := 0; i < 100; i++ {
+				_ = a.Add(fmt.Sprintf("tool-%d *", i))
+			}
+		}()
+	}
+	for range 8 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for range 100 {
+				if !a.Matches(sandbox.ExecRequest{Command: "go", Args: []string{"build"}}) {
+					t.Error("allowlist lost the base rule during concurrent Add")
+				}
+			}
+		}()
+	}
+	wg.Wait()
+	if got := len(a.Rules()); got != 101 {
+		t.Fatalf("rules = %d, want 101 (idempotent Add)", got)
+	}
+}
+
+func TestAllowlistNotAllowedPredicate(t *testing.T) {
+	a, err := sandbox.NewAllowlist("go *")
+	if err != nil {
+		t.Fatal(err)
+	}
+	p := a.NotAllowed()
+	if reason, matched := p.Match(sandbox.ExecRequest{Command: "go"}); matched {
+		t.Fatalf("NotAllowed matched an allowlisted command: %s", reason)
+	}
+	if reason, matched := p.Match(sandbox.ExecRequest{Command: "rm", Args: []string{"-rf", "/"}}); !matched || reason == "" {
+		t.Fatalf("NotAllowed did not match an out-of-bounds command: %q, %v", reason, matched)
+	}
+	var nilList *sandbox.Allowlist
+	if _, matched := nilList.NotAllowed().Match(sandbox.ExecRequest{Command: "anything"}); !matched {
+		t.Fatal("nil allowlist NotAllowed must match every command (fail closed)")
+	}
+}
+
+func TestWithApprovalUsesAllowlist(t *testing.T) {
+	inner := localRunner(t)
+	var approvals atomic.Int64
+	approve := sandbox.ApprovalFunc(func(context.Context, sandbox.ApprovalRequest) (sandbox.Decision, error) {
+		approvals.Add(1)
+		return sandbox.Allow, nil
+	})
+	allowlist, err := sandbox.NewAllowlist("echo *")
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx := context.Background()
+
+	// In-bounds call: allowlist pre-approves, approver is never asked.
+	runner := sandbox.WithApproval(inner, approve, allowlist)
+	result, err := sandbox.Exec(ctx, runner, "echo", []string{"hi"}, sandbox.ExecOptions{})
+	if err != nil {
+		t.Fatalf("Exec(echo hi): %v", err)
+	}
+	if result.ExitCode != 0 || result.Stdout != "hi\n" {
+		t.Fatalf("result = %+v", result)
+	}
+	if approvals.Load() != 0 {
+		t.Fatalf("approver called %d times for an allowlisted command", approvals.Load())
+	}
+
+	// sh -c unwrapping happens before allowlist matching.
+	result, err = sandbox.Exec(ctx, runner, "sh", []string{"-c", "echo hi"}, sandbox.ExecOptions{})
+	if err != nil {
+		t.Fatalf("Exec(sh -c echo hi): %v", err)
+	}
+	if result.ExitCode != 0 || result.Stdout != "hi\n" {
+		t.Fatalf("result = %+v", result)
+	}
+	if approvals.Load() != 0 {
+		t.Fatalf("approver called for an unwrapped allowlisted command")
+	}
+
+	// Out-of-bounds with a nil approver fails closed without executing.
+	denyRunner := sandbox.WithApproval(inner, nil, allowlist)
+	if _, err := sandbox.Exec(ctx, denyRunner, "ls", nil, sandbox.ExecOptions{}); !errdefs.IsPolicyDenied(err) {
+		t.Fatalf("Exec(ls) error = %v, want policy denied", err)
+	}
+	if approvals.Load() != 0 {
+		t.Fatalf("nil approver was invoked")
+	}
+
+	// Out-of-bounds with an approving approver executes and asks once.
+	runner = sandbox.WithApproval(inner, approve, allowlist)
+	result, err = sandbox.Exec(ctx, runner, "ls", nil, sandbox.ExecOptions{})
+	if err != nil {
+		t.Fatalf("Exec(ls): %v", err)
+	}
+	if result.ExitCode != 0 {
+		t.Fatalf("exit code = %d, want 0", result.ExitCode)
+	}
+	if approvals.Load() != 1 {
+		t.Fatalf("approver calls = %d, want 1", approvals.Load())
+	}
+}

--- a/core/sandbox/approval.go
+++ b/core/sandbox/approval.go
@@ -69,13 +69,24 @@ type ApprovalRequest struct {
 type ApprovalFunc func(ctx context.Context, req ApprovalRequest) (Decision, error)
 
 // WithApproval returns a Runner that consults approve before
-// delegating to inner, but only when at least one predicate matches.
-// In-bounds calls pass straight through without any approver
-// round-trip. When several predicates match, only the first one's
-// reason is reported — one call, one decision.
+// delegating to inner, but only when the call is out-of-bounds.
+// Calls matching allowlist are pre-approved and pass straight through
+// without any approver round-trip. When allowlist is non-nil, every
+// other call consults the approver (reason "command not in sandbox
+// allowlist"); predicates add extra tripwires on top of that (workdir
+// escapes, non-default network posture, …). When several predicates
+// match, only the first one's reason is reported — one call, one
+// decision. With allowlist nil, only predicate-matching calls reach
+// the approver.
 //
 // Contract:
 //
+//   - allowlist may be nil (no pre-approved commands) or an empty
+//     list (every call goes through the approver).
+//   - Matching the allowlist bypasses the predicates as well: it is a
+//     blanket pre-authorization of the call. Deployments that also
+//     want per-call approval on other dimensions (network posture,
+//     workdir) should keep those calls out of the allowlist.
 //   - Denied decisions surface as errdefs.PolicyDenied and the inner
 //     runner is never invoked.
 //   - ApprovalFunc errors are fail-closed: the call does not run.
@@ -90,14 +101,15 @@ type ApprovalFunc func(ctx context.Context, req ApprovalRequest) (Decision, erro
 // the effective policy. Reversing them makes the approver see only the
 // caller's pre-merge options. The recommended local chain uses the
 // former ordering.
-func WithApproval(inner Runner, approve ApprovalFunc, preds ...Predicate) Runner {
-	return &approvalRunner{inner: inner, approve: approve, preds: preds}
+func WithApproval(inner Runner, approve ApprovalFunc, allowlist *Allowlist, preds ...Predicate) Runner {
+	return &approvalRunner{inner: inner, approve: approve, allowlist: allowlist, preds: preds}
 }
 
 type approvalRunner struct {
-	inner   Runner
-	approve ApprovalFunc
-	preds   []Predicate
+	inner     Runner
+	approve   ApprovalFunc
+	allowlist *Allowlist
+	preds     []Predicate
 }
 
 func (r *approvalRunner) Exec(ctx context.Context, cmd string, args []string, opts ExecOptions) (*ExecResult, error) {
@@ -108,10 +120,13 @@ func (r *approvalRunner) Exec(ctx context.Context, cmd string, args []string, op
 	return Exec(ctx, r.inner, cmd, args, opts)
 }
 
-// authorize runs the predicate / approver chain for one request. It is
-// shared by Exec and Runner.Start so interactive sessions go
-// through exactly the same fail-closed tripwire.
+// authorize runs the allowlist / predicate / approver chain for one
+// request. It is shared by Exec and Runner.Start so interactive
+// sessions go through exactly the same fail-closed tripwire.
 func (r *approvalRunner) authorize(ctx context.Context, req ExecRequest) error {
+	if r.allowlist != nil && r.allowlist.Matches(req) {
+		return nil
+	}
 	for _, p := range r.preds {
 		if p == nil {
 			return errdefs.PolicyDeniedf(
@@ -125,23 +140,30 @@ func (r *approvalRunner) authorize(ctx context.Context, req ExecRequest) error {
 		if !matched {
 			continue
 		}
-		if r.approve == nil {
-			return errdefs.PolicyDeniedf(
-				"sandbox: %s (no approver configured)", reason)
-		}
-		decision, err := r.approve(ctx, ApprovalRequest{
-			Exec:   cloneExecRequest(req),
-			Reason: reason,
-		})
-		if err != nil {
-			return fmt.Errorf(
-				"sandbox: approval for %q failed; not executed (fail-closed): %w", req.Command, err)
-		}
-		if decision != Allow {
-			return errdefs.PolicyDeniedf(
-				"sandbox: execution of %q denied: %s", req.Command, reason)
-		}
-		break
+		return r.requestApproval(ctx, req, reason)
+	}
+	if r.allowlist != nil {
+		return r.requestApproval(ctx, req, "command not in sandbox allowlist")
+	}
+	return nil
+}
+
+func (r *approvalRunner) requestApproval(ctx context.Context, req ExecRequest, reason string) error {
+	if r.approve == nil {
+		return errdefs.PolicyDeniedf(
+			"sandbox: %s (no approver configured)", reason)
+	}
+	decision, err := r.approve(ctx, ApprovalRequest{
+		Exec:   cloneExecRequest(req),
+		Reason: reason,
+	})
+	if err != nil {
+		return fmt.Errorf(
+			"sandbox: approval for %q failed; not executed (fail-closed): %w", req.Command, err)
+	}
+	if decision != Allow {
+		return errdefs.PolicyDeniedf(
+			"sandbox: execution of %q denied: %s", req.Command, reason)
 	}
 	return nil
 }

--- a/core/sandbox/compose.go
+++ b/core/sandbox/compose.go
@@ -5,12 +5,15 @@ package sandbox
 //
 //   - AllowedCommands nil means no command-name gate is installed.
 //     A non-nil empty slice installs a gate that blocks every command.
+//   - Allowlist nil means no command is pre-approved; a non-nil list
+//     skips the approver for matching calls.
 //   - Predicates nil means no approval tripwire is installed.
 //   - Approval may be nil; if a predicate matches, WithApproval then
 //     fails closed with PolicyDenied.
 type LocalPolicy struct {
 	Defaults        ExecOptions
 	AllowedCommands []string
+	Allowlist       *Allowlist
 	Approval        ApprovalFunc
 	Predicates      []Predicate
 }
@@ -46,7 +49,7 @@ func DefaultLocalPolicy(root string, approval ApprovalFunc, sensitiveCommands ..
 //
 //	WithDefaults(
 //	    WithApproval(
-//	        AllowCommands(backend),
+//	        AllowCommands(backend), allowlist,
 //	    ),
 //	)
 //
@@ -55,7 +58,9 @@ func DefaultLocalPolicy(root string, approval ApprovalFunc, sensitiveCommands ..
 // WithApproval inspects the call, so the approver sees the effective
 // Env / Net / Resources posture rather than the caller's raw request.
 // AllowCommands sits closest to the backend and remains an independent
-// hard gate: approval cannot bypass a command allow-list.
+// hard gate: approval cannot bypass a command allow-list. The
+// Allowlist pre-approves in-bounds commands so the human approver is
+// only consulted for the rest.
 //
 // ComposeLocal adds no writable paths and never modifies backend
 // enforcement. Seatbelt callers should use seatbelt.WithWritablePaths
@@ -68,10 +73,11 @@ func ComposeLocal(backend Runner, policy LocalPolicy) Runner {
 	if policy.AllowedCommands != nil {
 		runner = AllowCommands(runner, policy.AllowedCommands)
 	}
-	if len(policy.Predicates) > 0 {
+	if policy.Allowlist != nil || len(policy.Predicates) > 0 {
 		runner = WithApproval(
 			runner,
 			policy.Approval,
+			policy.Allowlist,
 			policy.Predicates...,
 		)
 	}

--- a/docs/guides/event.md
+++ b/docs/guides/event.md
@@ -47,3 +47,6 @@ resources:
 ```
 
 The runtime host exposes the bus through `agent.EventBusProvider`.
+Runtime-level consumers can also subscribe through `Runtime.Attach`
+without resolving the resource themselves; the prompt lifecycle events
+are documented in [prompt.md](prompt.md).

--- a/docs/guides/prompt.md
+++ b/docs/guides/prompt.md
@@ -1,0 +1,71 @@
+---
+layout: default
+title: Prompt Lifecycle Events
+---
+# Prompt Lifecycle Events
+
+Prompts are how an engine asks the host (and through it, the end user)
+for input mid-run. This guide covers the lifecycle events UI consumers
+subscribe to.
+
+## Prompt lifecycle events
+
+Every prompt is announced with `PromptRequested` and terminated with
+`PromptResolved`, both under the run's event namespace:
+
+| Subject | Payload |
+| --- | --- |
+| `agent.run.<run_id>.prompt.requested` | `PromptRequested` |
+| `agent.run.<run_id>.prompt.resolved` | `PromptResolved` |
+
+Convenience subjects and patterns live in `core/runtime/session`:
+
+```go
+session.SubjectPromptRequested(runID)
+session.SubjectPromptResolved(runID)
+session.PatternPromptRequested() // agent.run.*.prompt.requested
+session.PatternPromptResolved()  // agent.run.*.prompt.resolved
+```
+
+`PromptRequested` carries the run/turn/prompt IDs plus the
+`agent.UserPrompt` payload.
+`PromptResolved` is a best-effort notification carrying the same IDs
+and a terminal `Status`:
+
+- `replied` — a `Reply` satisfied the prompt;
+- `expired` — the `AskUser` context ended before a reply arrived
+  (timeout or host cancellation);
+- `interrupted` — a turn interrupt closed the prompt;
+- `closed` — the turn ended while the prompt was pending, or the
+  prompt could not be published.
+
+`PromptResolved` publish failures never change the `Reply` / `AskUser`
+result. It lets a UI close or mark a pending interaction immediately
+instead of waiting for the whole turn to finish.
+
+### Subscribing through the Runtime
+
+`Runtime.Attach` exposes the runtime's event router, so consumers do
+not need to resolve the deployment document's `event_bus` resource:
+
+```go
+detach, err := app.Attach(ctx, session.PatternPromptRequested(),
+	event.SinkFunc(func(ctx context.Context, env event.Envelope) error {
+		var req session.PromptRequested
+		if err := env.Decode(&req); err != nil {
+			return err
+		}
+		// open the interaction view, keyed by req.PromptID
+		return nil
+	}))
+if err != nil {
+	return err
+}
+defer detach()
+```
+
+Subscribe to `PatternPromptResolved()` the same way and close the view
+by `PromptID` when the matching `PromptResolved` arrives. External
+attachments use the bus default backpressure (`DropNewest`), so a slow
+UI drops envelopes instead of blocking the run pipeline; pass
+`event.WithAttachBackpressure` to opt into a different policy.

--- a/docs/guides/runtime.md
+++ b/docs/guides/runtime.md
@@ -27,6 +27,25 @@ defer app.Close()
 
 `Runtime` owns its `deploy.Result`, event router, and session manager.
 
+## Subscribing to runtime events
+
+`Runtime.Attach` subscribes a sink to the runtime's event router
+without resolving the deployment document's `event_bus` resource:
+
+```go
+detach, err := app.Attach(ctx, session.PatternPromptRequested(), sink)
+if err != nil {
+    return err
+}
+defer detach()
+```
+
+Attachments are torn down when the Runtime closes, and `Attach` fails
+with `NotAvailable` afterwards. External attachments inherit the bus
+default backpressure (`DropNewest`); pass
+`event.WithAttachBackpressure` to override per subscription. See
+[prompt.md](prompt.md) for the prompt lifecycle events.
+
 ## Runtime config
 
 ```yaml


### PR DESCRIPTION
## Summary

Implements the prompt event surface and sandbox allowlist composition:

- **Runtime.Attach** — runtime-level event subscription entry (`session.PatternPromptRequested()` / `PatternPromptResolved()`), no deployment-resource parsing needed. External attachments default to non-blocking `DropNewest`; the session coordinator keeps explicit `Block`.
- **PromptResolved** — prompt lifecycle terminal events (`replied` / `expired` / `interrupted` / `closed`) published on Reply, AskUser timeout, turn interrupt, and turn finish. Best-effort, published outside the turn lock so a slow subscriber cannot stall finalization.
- **sandbox.Allowlist** — thread-safe rule set (`go run *`, `git status`, ...), `Add`/`Set`/`Union`/`Rules` for layered config and dynamic injection, `sh -c` unwrapping with basename program matching; complex shell scripts never auto-allow. `WithApproval` now takes the allowlist: matching calls skip the approver, non-matching calls (when allowlist is non-nil) go to the approver, nil approver fails closed. `ComposeLocal`/`LocalPolicy` wired.
- **Docs** — new `docs/guides/prompt.md` (lifecycle events), runtime.md / event.md subscription entry points.

## Release

- Adds `.release/core-v0.1.5.json` (patch)
- `make release-plan`: `core: 0.1.4 -> 0.1.5 (patch), tag core/v0.1.5`
- `make release-preflight`: preflight tidy OK

## Verification

- `make ci` (vet + test, all modules) pass
- `make lint` pass
- `make release-check` pass
- `git diff --check` clean

## Notes

- `WithApproval` signature changed (allowlist param) — intentional pre-1.0 API change.
- `docs/plans/` and `docs/reporters/` are untracked local files, not part of this PR.
