### PR TITLE
fix(core): fresh run ids per turn and explicit session resume

### DIFF
--- a/.release/core-v0.1.6.json
+++ b/.release/core-v0.1.6.json
@@ -1,0 +1,9 @@
+{
+  "summary": "fix(core): fresh run ids per turn, session-scoped committed history, explicit resume, and immediate Turn.Cancel",
+  "releases": [
+    {
+      "module": "core",
+      "bump": "patch"
+    }
+  ]
+}

--- a/core/runtime/session/options.go
+++ b/core/runtime/session/options.go
@@ -130,9 +130,18 @@ func WithCheckpointStore(store agent.CheckpointStore) ManagerOption {
 	}
 }
 
-// WithResume enables session-level resume: each session key maps to a
-// stable run id, checkpoints are loaded before Start, and committed
-// checkpoints are deleted after completion.
+// WithResume enables session-level durability across turns:
+//
+//   - Every turn gets a fresh run id; conversation history carries
+//     over from the session's last committed board, persisted under a
+//     session-scoped key in the checkpoint store.
+//   - Turns that end without committing park their run id; Resume
+//     replays that specific interrupted execution from its checkpoint.
+//   - Committed turns delete their run checkpoint and advance the
+//     session board.
+//
+// It requires a checkpoint store ([WithCheckpointStore]) whose
+// implementation also satisfies [agent.CheckpointDeleter].
 func WithResume(enable bool) ManagerOption {
 	return func(options *managerOptions) error {
 		options.resume = enable

--- a/core/runtime/session/resume_test.go
+++ b/core/runtime/session/resume_test.go
@@ -2,6 +2,7 @@ package session
 
 import (
 	"context"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -12,80 +13,199 @@ import (
 	"github.com/GizClaw/flowcraft/core/message"
 )
 
-func TestStableRunIDIsDeterministicPerKey(t *testing.T) {
-	first := stableRunID(Key{AgentID: "agent-a", ContextID: "ctx"})
-	second := stableRunID(Key{AgentID: "agent-a", ContextID: "ctx"})
-	other := stableRunID(Key{AgentID: "agent-a", ContextID: "other"})
+func TestSessionStateIDIsDeterministicPerKey(t *testing.T) {
+	first := sessionStateID(Key{AgentID: "agent-a", ContextID: "ctx"})
+	second := sessionStateID(Key{AgentID: "agent-a", ContextID: "ctx"})
+	other := sessionStateID(Key{AgentID: "agent-a", ContextID: "other"})
 	if first != second {
-		t.Fatalf("stable run id changed for same key: %q != %q", first, second)
+		t.Fatalf("session state id changed for same key: %q != %q", first, second)
 	}
 	if first == other {
-		t.Fatalf("stable run id collided across contexts: %q", first)
+		t.Fatalf("session state id collided across contexts: %q", first)
 	}
 }
 
-func TestSessionResume_FreshStartUsesStableRunID(t *testing.T) {
-	engine := &resumeProbeEngine{}
+func TestSessionResume_FreshStartUsesFreshRunID(t *testing.T) {
+	engine := &resumeProbeEngine{reply: "hello"}
 	store := &resumeTestStore{cps: make(map[string]agent.Checkpoint)}
 	session := newResumeSession(t, engine, store)
 
-	turn, err := session.Start(context.Background(),
+	req := agent.Request{Message: message.NewTextMessage(message.RoleUser, "hi")}
+	first, err := session.Start(context.Background(), req)
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	if !strings.HasPrefix(first.RunID(), "run-") {
+		t.Fatalf("RunID = %q, want run- prefix", first.RunID())
+	}
+	if _, err := first.Wait(context.Background()); err != nil {
+		t.Fatalf("Wait: %v", err)
+	}
+
+	second, err := session.Start(context.Background(), req)
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	if second.RunID() == first.RunID() {
+		t.Fatalf("second turn reused run id %q", second.RunID())
+	}
+	if _, err := second.Wait(context.Background()); err != nil {
+		t.Fatalf("Wait: %v", err)
+	}
+
+	got := engine.snapshot()
+	if got.resume != nil {
+		t.Fatalf("fresh start got ResumeFrom: %+v", got.resume)
+	}
+	if got.resumeCtx != nil {
+		t.Fatalf("fresh start got ResumeContext: %+v", got.resumeCtx)
+	}
+}
+
+func TestSessionResume_NewTurnCarriesCommittedBoard(t *testing.T) {
+	engine := &resumeProbeEngine{reply: "first"}
+	store := &resumeTestStore{cps: make(map[string]agent.Checkpoint)}
+	session := newResumeSession(t, engine, store)
+
+	first, err := session.Start(context.Background(),
 		agent.Request{Message: message.NewTextMessage(message.RoleUser, "hi")})
 	if err != nil {
 		t.Fatalf("Start: %v", err)
 	}
-	wantRunID := stableRunID(Key{AgentID: "agent-a", ContextID: "ctx"})
-	if turn.RunID() != wantRunID {
-		t.Fatalf("RunID = %q, want stable %q", turn.RunID(), wantRunID)
-	}
-	if _, err := turn.Wait(context.Background()); err != nil {
+	if _, err := first.Wait(context.Background()); err != nil {
 		t.Fatalf("Wait: %v", err)
 	}
-	engine.mu.Lock()
-	defer engine.mu.Unlock()
-	if engine.gotResume != nil {
-		t.Fatalf("fresh start got ResumeFrom: %+v", engine.gotResume)
-	}
-	if engine.gotResumeCtx != nil {
-		t.Fatalf("fresh start got ResumeContext: %+v", engine.gotResumeCtx)
-	}
-}
 
-func TestSessionResume_ResumesFromCheckpointAndDeletesOnCommit(t *testing.T) {
-	engine := &resumeProbeEngine{}
-	store := &resumeTestStore{cps: make(map[string]agent.Checkpoint)}
-	session := newResumeSession(t, engine, store)
-
-	runID := stableRunID(Key{AgentID: "agent-a", ContextID: "ctx"})
-	originalStart := time.Now().Add(-2 * time.Hour)
-	store.cps[runID] = agent.Checkpoint{
-		ExecID:            runID,
-		Steps:             []string{"wave-1"},
-		Board:             agent.NewBoard().Snapshot(),
-		Timestamp:         time.Now().Add(-time.Hour),
-		OriginalStartedAt: originalStart,
-		SpecVersion:       "v1",
+	// The committed turn must delete its run checkpoint and park nothing.
+	store.mu.Lock()
+	deleted := append([]string(nil), store.deleted...)
+	store.mu.Unlock()
+	if len(deleted) != 1 || deleted[0] != first.RunID() {
+		t.Fatalf("deleted = %v, want [%s]", deleted, first.RunID())
+	}
+	if runID, ok, err := session.Resumable(context.Background()); err != nil || ok {
+		t.Fatalf("Resumable = (%q, %v, %v), want no parked run", runID, ok, err)
 	}
 
-	turn, err := session.Start(context.Background(),
-		agent.Request{Message: message.NewTextMessage(message.RoleUser, "continue")})
+	second, err := session.Start(context.Background(),
+		agent.Request{Message: message.NewTextMessage(message.RoleUser, "again")})
 	if err != nil {
 		t.Fatalf("Start: %v", err)
 	}
+	if second.RunID() == first.RunID() {
+		t.Fatalf("second turn reused run id %q", second.RunID())
+	}
+	if _, err := second.Wait(context.Background()); err != nil {
+		t.Fatalf("Wait: %v", err)
+	}
+
+	got := engine.snapshot()
+	if got.resume != nil {
+		t.Fatalf("new turn must not resume: %+v", got.resume)
+	}
+	msgs := got.board.Channels[agent.MainChannel]
+	if len(msgs) != 3 {
+		t.Fatalf("main channel has %d messages, want 3 (history hi/first + new again)", len(msgs))
+	}
+	if msgs[0].Role != message.RoleUser || msgs[0].Content.Text() != "hi" {
+		t.Fatalf("msgs[0] = %+v, want user 'hi'", msgs[0])
+	}
+	if msgs[1].Role != message.RoleAssistant || msgs[1].Content.Text() != "first" {
+		t.Fatalf("msgs[1] = %+v, want assistant 'first'", msgs[1])
+	}
+	if msgs[2].Role != message.RoleUser || msgs[2].Content.Text() != "again" {
+		t.Fatalf("msgs[2] = %+v, want user 'again'", msgs[2])
+	}
+}
+
+func TestSessionResume_NewTurnAfterInterruptStartsFresh(t *testing.T) {
+	engine := &resumeProbeEngine{interrupt: true}
+	store := &resumeTestStore{cps: make(map[string]agent.Checkpoint)}
+	session := newResumeSession(t, engine, store)
+
+	first, err := session.Start(context.Background(),
+		agent.Request{Message: message.NewTextMessage(message.RoleUser, "hi")})
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	result, err := first.Wait(context.Background())
+	if err != nil {
+		t.Fatalf("Wait: %v", err)
+	}
+	if result.Status != agent.StatusInterrupted {
+		t.Fatalf("Status = %q, want interrupted", result.Status)
+	}
+	firstRunID := first.RunID()
+	if runID, ok, err := session.Resumable(context.Background()); err != nil || !ok || runID != firstRunID {
+		t.Fatalf("Resumable = (%q, %v, %v), want parked %q", runID, ok, err, firstRunID)
+	}
+
+	// A new user message starts a fresh run; it must NOT resume the
+	// parked one, and it starts from the last COMMITTED board (empty
+	// here, because the interrupted run never committed).
+	engine.interrupt = false
+	engine.reply = "ok"
+	second, err := session.Start(context.Background(),
+		agent.Request{Message: message.NewTextMessage(message.RoleUser, "again")})
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	if second.RunID() == firstRunID {
+		t.Fatalf("new turn reused parked run id %q", firstRunID)
+	}
+	if _, err := second.Wait(context.Background()); err != nil {
+		t.Fatalf("Wait: %v", err)
+	}
+	got := engine.snapshot()
+	if got.resume != nil {
+		t.Fatalf("new turn must not resume the parked run: %+v", got.resume)
+	}
+	msgs := got.board.Channels[agent.MainChannel]
+	if len(msgs) != 1 {
+		t.Fatalf("main channel has %d messages, want 1 (interrupted board is not committed)", len(msgs))
+	}
+	if msgs[0].Content.Text() != "again" {
+		t.Fatalf("msgs[0] = %+v, want user 'again'", msgs[0])
+	}
+
+	// The new committed turn moves the conversation forward: the old
+	// parked marker is cleared.
+	if runID, ok, err := session.Resumable(context.Background()); err != nil || ok {
+		t.Fatalf("Resumable after commit = (%q, %v, %v), want cleared", runID, ok, err)
+	}
+}
+
+func TestSessionResume_ResumeReplaysParkedRunAndDeletesOnCommit(t *testing.T) {
+	engine := &resumeProbeEngine{reply: "done"}
+	store := &resumeTestStore{cps: make(map[string]agent.Checkpoint)}
+	session := newResumeSession(t, engine, store)
+
+	runID := "run-" + strings.Repeat("a", 16)
+	originalStart := time.Now().Add(-2 * time.Hour)
+	parkRun(t, session, store, runID, originalStart,
+		&agent.Request{TaskID: "task-1", Message: message.NewTextMessage(message.RoleUser, "continue")})
+
+	turn, err := session.Resume(context.Background())
+	if err != nil {
+		t.Fatalf("Resume: %v", err)
+	}
+	if turn.RunID() != runID {
+		t.Fatalf("RunID = %q, want parked %q", turn.RunID(), runID)
+	}
 	if _, err := turn.Wait(context.Background()); err != nil {
 		t.Fatalf("Wait: %v", err)
 	}
 
-	engine.mu.Lock()
-	gotResume := engine.gotResume
-	gotCtx := engine.gotResumeCtx
-	engine.mu.Unlock()
-	if gotResume == nil || gotResume.ExecID != runID || len(gotResume.Steps) != 1 {
-		t.Fatalf("engine ResumeFrom = %+v, want run %s checkpoint", gotResume, runID)
+	got := engine.snapshot()
+	if got.resume == nil || got.resume.ExecID != runID || len(got.resume.Steps) != 1 {
+		t.Fatalf("engine ResumeFrom = %+v, want run %s checkpoint", got.resume, runID)
 	}
-	if gotCtx == nil || gotCtx.Attempt < 2 || gotCtx.Signal != "session" ||
-		!gotCtx.StartedAt.Equal(originalStart) {
-		t.Fatalf("engine ResumeContext = %+v, want session resume metadata", gotCtx)
+	if got.resumeCtx == nil || got.resumeCtx.Attempt < 2 || got.resumeCtx.Signal != "resume" ||
+		!got.resumeCtx.StartedAt.Equal(originalStart) {
+		t.Fatalf("engine ResumeContext = %+v, want resume metadata", got.resumeCtx)
+	}
+	if got.taskID != "task-1" {
+		t.Fatalf("TaskID = %q, want task-1 (original request must be replayed)", got.taskID)
 	}
 
 	store.mu.Lock()
@@ -94,24 +214,23 @@ func TestSessionResume_ResumesFromCheckpointAndDeletesOnCommit(t *testing.T) {
 	if len(deleted) != 1 || deleted[0] != runID {
 		t.Fatalf("deleted = %v, want [%s]", deleted, runID)
 	}
+	if runID, ok, err := session.Resumable(context.Background()); err != nil || ok {
+		t.Fatalf("Resumable after commit = (%q, %v, %v), want cleared", runID, ok, err)
+	}
 }
 
-func TestSessionResume_KeepsCheckpointWhenInterrupted(t *testing.T) {
+func TestSessionResume_ResumeKeepsCheckpointWhenInterrupted(t *testing.T) {
 	engine := &resumeProbeEngine{interrupt: true}
 	store := &resumeTestStore{cps: make(map[string]agent.Checkpoint)}
 	session := newResumeSession(t, engine, store)
 
-	runID := stableRunID(Key{AgentID: "agent-a", ContextID: "ctx"})
-	store.cps[runID] = agent.Checkpoint{
-		ExecID: runID,
-		Steps:  []string{"wave-1"},
-		Board:  agent.NewBoard().Snapshot(),
-	}
+	runID := "run-" + strings.Repeat("b", 16)
+	parkRun(t, session, store, runID, time.Now().Add(-time.Hour),
+		&agent.Request{Message: message.NewTextMessage(message.RoleUser, "continue")})
 
-	turn, err := session.Start(context.Background(),
-		agent.Request{Message: message.NewTextMessage(message.RoleUser, "again")})
+	turn, err := session.Resume(context.Background())
 	if err != nil {
-		t.Fatalf("Start: %v", err)
+		t.Fatalf("Resume: %v", err)
 	}
 	result, err := turn.Wait(context.Background())
 	if err != nil {
@@ -121,9 +240,27 @@ func TestSessionResume_KeepsCheckpointWhenInterrupted(t *testing.T) {
 		t.Fatalf("Status = %q, want interrupted", result.Status)
 	}
 	store.mu.Lock()
-	defer store.mu.Unlock()
-	if len(store.deleted) != 0 {
-		t.Fatalf("interrupted run deleted checkpoint: %v", store.deleted)
+	deleted := append([]string(nil), store.deleted...)
+	_, kept := store.cps[runID]
+	store.mu.Unlock()
+	if len(deleted) != 0 {
+		t.Fatalf("interrupted resume deleted checkpoint: %v", deleted)
+	}
+	if !kept {
+		t.Fatalf("checkpoint %s was removed", runID)
+	}
+	if runID, ok, err := session.Resumable(context.Background()); err != nil || !ok || runID != turn.RunID() {
+		t.Fatalf("Resumable = (%q, %v, %v), want parked %q", runID, ok, err, turn.RunID())
+	}
+}
+
+func TestSessionResume_ResumeWithoutParkedRun(t *testing.T) {
+	engine := &resumeProbeEngine{}
+	store := &resumeTestStore{cps: make(map[string]agent.Checkpoint)}
+	session := newResumeSession(t, engine, store)
+
+	if _, err := session.Resume(context.Background()); !errdefs.IsNotFound(err) {
+		t.Fatalf("Resume error = %v, want NotFound", err)
 	}
 }
 
@@ -139,15 +276,12 @@ func TestSessionResume_RejectsNonResumableEngine(t *testing.T) {
 	store := &resumeTestStore{cps: make(map[string]agent.Checkpoint)}
 	session := newResumeSession(t, engine, store)
 
-	runID := stableRunID(Key{AgentID: "agent-a", ContextID: "ctx"})
-	store.cps[runID] = agent.Checkpoint{
-		ExecID: runID,
-		Steps:  []string{"wave-1"},
-		Board:  agent.NewBoard().Snapshot(),
-	}
-	if _, err := session.Start(context.Background(),
-		agent.Request{Message: message.NewTextMessage(message.RoleUser, "hi")}); !errdefs.IsNotAvailable(err) {
-		t.Fatalf("Start error = %v, want NotAvailable", err)
+	runID := "run-" + strings.Repeat("c", 16)
+	parkRun(t, session, store, runID, time.Now().Add(-time.Hour),
+		&agent.Request{Message: message.NewTextMessage(message.RoleUser, "continue")})
+
+	if _, err := session.Resume(context.Background()); !errdefs.IsNotAvailable(err) {
+		t.Fatalf("Resume error = %v, want NotAvailable", err)
 	}
 }
 
@@ -175,11 +309,58 @@ func TestManagerResumeRequiresStore(t *testing.T) {
 	}
 }
 
+func parkRun(
+	t *testing.T,
+	session *Session,
+	store *resumeTestStore,
+	runID string,
+	originalStart time.Time,
+	req *agent.Request,
+) {
+	t.Helper()
+	board := agent.NewBoard()
+	board.AppendChannelMessage(agent.MainChannel, message.NewTextMessage(message.RoleUser, "seed"))
+	store.cps[runID] = agent.Checkpoint{
+		ExecID:            runID,
+		Steps:             []string{"wave-1"},
+		Board:             board.Snapshot(),
+		Timestamp:         time.Now().Add(-time.Hour),
+		OriginalStartedAt: originalStart,
+		SpecVersion:       "v1",
+	}
+	session.saveSessionState(&sessionState{
+		ResumableRunID: runID,
+		Request:        req,
+		Board:          agent.NewBoard().Snapshot(),
+	})
+}
+
 type resumeProbeEngine struct {
 	mu           sync.Mutex
 	gotResume    *agent.Checkpoint
 	gotResumeCtx *agent.ResumeContext
+	gotBoard     *agent.BoardSnapshot
+	gotTaskID    string
+	reply        string
 	interrupt    bool
+}
+
+type resumeProbeSnapshot struct {
+	resume    *agent.Checkpoint
+	resumeCtx *agent.ResumeContext
+	board     *agent.BoardSnapshot
+	taskID    string
+}
+
+func (e *resumeProbeEngine) snapshot() resumeProbeSnapshot {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	return resumeProbeSnapshot{
+		resume:    e.gotResume,
+		resumeCtx: e.gotResumeCtx,
+		board:     e.gotBoard,
+		taskID:    e.gotTaskID,
+	}
 }
 
 func (e *resumeProbeEngine) Execute(
@@ -198,8 +379,13 @@ func (e *resumeProbeEngine) Execute(
 		value := rc
 		e.gotResumeCtx = &value
 	}
+	e.gotBoard = board.Snapshot()
+	e.gotTaskID = run.TaskID
 	if e.interrupt {
 		return board, agent.Interrupted(agent.Interrupt{Cause: agent.CauseUserInput})
+	}
+	if e.reply != "" {
+		board.AppendChannelMessage(agent.MainChannel, message.NewTextMessage(message.RoleAssistant, e.reply))
 	}
 	return board, nil
 }

--- a/core/runtime/session/session.go
+++ b/core/runtime/session/session.go
@@ -2,8 +2,10 @@ package session
 
 import (
 	"context"
+	"crypto/rand"
 	"crypto/sha256"
 	"encoding/hex"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"sync"
@@ -93,16 +95,172 @@ func (s *Session) Start(ctx context.Context, request agent.Request, sinks ...Sin
 	if ctx == nil {
 		return nil, errdefs.Validationf("runtime session: Start context is required")
 	}
+	if err := validateSinks(sinks); err != nil {
+		return nil, err
+	}
+
+	s.startMu.Lock()
+	defer s.startMu.Unlock()
+
+	release, err := s.interruptActive(ctx)
+	if err != nil {
+		return nil, err
+	}
+	activityHeld := true
+	defer func() {
+		if activityHeld {
+			release()
+		}
+	}()
+
+	runID, err := freshRunID()
+	if err != nil {
+		return nil, err
+	}
+	state, err := s.loadSessionState(ctx)
+	if err != nil {
+		return nil, err
+	}
+	var snapshot *agent.BoardSnapshot
+	if state != nil {
+		snapshot = state.Board
+	}
+	request.ContextID = s.key.ContextID
+	request.RunID = runID
+	turn, err := s.startTurnLocked(ctx, request, runID, nil, nil, snapshot, sinks)
+	if err != nil {
+		return nil, err
+	}
+	activityHeld = false
+	return turn, nil
+}
+
+// Resume re-executes the session's parked interrupted run. The parked
+// run is the most recent turn that ended without committing; its
+// checkpoint is loaded and replayed under the original run id and
+// request, so the engine picks up where it stopped instead of starting
+// fresh. A new user message MUST go through Start — Resume does not
+// carry a request.
+func (s *Session) Resume(ctx context.Context, sinks ...SinkSpec) (*Turn, error) {
+	if s == nil {
+		return nil, ErrSessionClosed
+	}
+	if ctx == nil {
+		return nil, errdefs.Validationf("runtime session: Resume context is required")
+	}
+	if err := validateSinks(sinks); err != nil {
+		return nil, err
+	}
+
+	s.startMu.Lock()
+	defer s.startMu.Unlock()
+
+	release, err := s.interruptActive(ctx)
+	if err != nil {
+		return nil, err
+	}
+	activityHeld := true
+	defer func() {
+		if activityHeld {
+			release()
+		}
+	}()
+
+	state, err := s.loadSessionState(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if state == nil || state.ResumableRunID == "" {
+		return nil, errdefs.NotFoundf(
+			"runtime session: no interrupted run to resume")
+	}
+	runID := state.ResumableRunID
+	resumeFrom, resumeCtx, err := s.loadResumableCheckpoint(ctx, runID)
+	if err != nil {
+		return nil, err
+	}
+	if resumeFrom == nil {
+		// The parked marker points at a run whose checkpoint is gone
+		// (store eviction, manual cleanup); drop the marker so the
+		// session does not stay stuck in a resumable state.
+		s.clearParkedRun(state)
+		return nil, errdefs.NotFoundf(
+			"runtime session: checkpoint for parked run %s is gone", runID)
+	}
+	if state.Request == nil {
+		return nil, errdefs.Validationf(
+			"runtime session: parked run %s has no stored request", runID)
+	}
+	request := *state.Request
+	request.ContextID = s.key.ContextID
+	request.RunID = runID
+	turn, err := s.startTurnLocked(ctx, request, runID, resumeFrom, resumeCtx, nil, sinks)
+	if err != nil {
+		return nil, err
+	}
+	activityHeld = false
+	return turn, nil
+}
+
+// Resumable reports whether a previous turn ended without committing
+// and can be replayed via Resume. It returns the parked run id.
+func (s *Session) Resumable(ctx context.Context) (string, bool, error) {
+	if s == nil || !s.resume || s.checkpoints == nil {
+		return "", false, nil
+	}
+	if ctx == nil {
+		return "", false, errdefs.Validationf(
+			"runtime session: Resumable context is required")
+	}
+	state, err := s.loadSessionState(ctx)
+	if err != nil {
+		return "", false, err
+	}
+	if state == nil || state.ResumableRunID == "" {
+		return "", false, nil
+	}
+	return state.ResumableRunID, true, nil
+}
+
+// interruptActive stops any running turn and reserves one activity slot
+// for the incoming turn. The returned release MUST be called on every
+// path that does not install a turn; once a turn is installed the slot
+// belongs to the running turn and is released by turnFinished.
+func (s *Session) interruptActive(ctx context.Context) (func(), error) {
+	s.changeActivity(activityTurn, 1)
+	release := func() { s.changeActivity(activityTurn, -1) }
+
+	s.mu.Lock()
+	if s.closing {
+		s.mu.Unlock()
+		release()
+		return nil, ErrSessionClosed
+	}
+	old := s.active
+	s.mu.Unlock()
+	if old != nil {
+		_ = old.Interrupt(agent.Interrupt{Cause: agent.CauseUserInput})
+		_, _ = old.Wait(ctx)
+	}
+	if err := ctx.Err(); err != nil {
+		release()
+		return nil, errdefs.FromContext(err)
+	}
+	return release, nil
+}
+
+// validateSinks rejects structurally invalid sink specifications.
+func validateSinks(sinks []SinkSpec) error {
 	for _, spec := range sinks {
 		if err := spec.Validate(); err != nil {
-			return nil, err
+			return err
 		}
 	}
 	seen := make(map[string]struct{}, len(sinks))
 	authorities := 0
 	for _, spec := range sinks {
 		if _, exists := seen[spec.ID]; exists {
-			return nil, errdefs.Validationf("runtime session: duplicate SinkSpec.ID %q", spec.ID)
+			return errdefs.Validationf("runtime session: duplicate SinkSpec.ID %q", spec.ID)
 		}
 		seen[spec.ID] = struct{}{}
 		if spec.Authority == AuthorityAuthoritative {
@@ -110,52 +268,27 @@ func (s *Session) Start(ctx context.Context, request agent.Request, sinks ...Sin
 		}
 	}
 	if authorities > 1 {
-		return nil, errdefs.Validationf("runtime session: at most one authoritative sink is allowed per turn")
+		return errdefs.Validationf("runtime session: at most one authoritative sink is allowed per turn")
 	}
+	return nil
+}
 
-	s.startMu.Lock()
-	startLocked := true
-	defer func() {
-		if startLocked {
-			s.startMu.Unlock()
-		}
-	}()
-
-	s.mu.Lock()
-	if s.closing {
-		s.mu.Unlock()
-		return nil, ErrSessionClosed
-	}
-	old := s.active
-	s.mu.Unlock()
-	s.changeActivity(activityTurn, 1)
-	activityHeld := true
-	defer func() {
-		if activityHeld {
-			s.changeActivity(activityTurn, -1)
-		}
-	}()
-	if old != nil {
-		_ = old.Interrupt(agent.Interrupt{Cause: agent.CauseUserInput})
-		_, _ = old.Wait(ctx)
-	}
-	if err := ctx.Err(); err != nil {
-		return nil, errdefs.FromContext(err)
-	}
-
-	runID, err := s.nextRunID()
-	if err != nil {
-		return nil, err
-	}
-	resumeFrom, resumeCtx, err := s.loadResume(ctx, runID)
-	if err != nil {
-		return nil, err
-	}
-	request.ContextID = s.key.ContextID
-	request.RunID = runID
+// startTurnLocked installs and asynchronously runs one turn. It must be
+// called with startMu held and with the caller's activity slot already
+// reserved. request.ContextID and request.RunID must already be set.
+func (s *Session) startTurnLocked(
+	ctx context.Context,
+	request agent.Request,
+	runID string,
+	resumeFrom *agent.Checkpoint,
+	resumeCtx *agent.ResumeContext,
+	snapshot *agent.BoardSnapshot,
+	sinks []SinkSpec,
+) (*Turn, error) {
 	turn := newTurn(s, runID, ctx)
 	turn.resumeFrom = resumeFrom
 	turn.resumeCtx = resumeCtx
+	turn.snapshot = snapshot
 	catalog, err := s.catalogFor(ctx)
 	if err != nil {
 		turn.cancel()
@@ -254,34 +387,169 @@ func (s *Session) Start(ctx context.Context, request agent.Request, sinks ...Sin
 	turn.state = TurnRunning
 	turn.mu.Unlock()
 	s.mu.Unlock()
-	activityHeld = false
 
-	startLocked = false
-	s.startMu.Unlock()
 	s.notifySessionStarted(turn)
 	go turn.execute(s.instance, request)
 	return turn, nil
 }
 
-// nextRunID returns the stable run id for the session key when resume
-// is enabled, otherwise a fresh random id.
-func (s *Session) nextRunID() (string, error) {
-	if s.resume {
-		return stableRunID(s.key), nil
-	}
-	return randomID()
+// ---------- Session state and resume ----------
+
+// sessionState is the durable per-session record kept in the checkpoint
+// store under a reserved "session-" key. It is NOT a run checkpoint:
+//
+//   - Board holds the session's last committed board (conversation
+//     history). Every fresh Start seeds its run from this board so
+//     history carries across turns without re-identifying a run.
+//   - ResumableRunID names the most recent turn that ended without
+//     committing. Resume replays that specific execution from its
+//     checkpoint. Empty when no interrupted execution is parked.
+//   - Request is the original request of the parked run; Resume must
+//     re-execute under the same request (same task, same inputs).
+type sessionState struct {
+	ResumableRunID string               `json:"resumable_run_id,omitempty"`
+	Request        *agent.Request       `json:"request,omitempty"`
+	Board          *agent.BoardSnapshot `json:"-"`
 }
 
-// loadResume loads the checkpoint for runID when resume is enabled.
-// It returns nil, nil for a fresh start. A checkpoint whose engine
-// cannot resume is a configuration error, not a silent fresh run.
-func (s *Session) loadResume(
+// sessionStateID derives the durable key for one session's state. It is
+// stable across process restarts and never collides with run ids
+// ("run-" prefix) or prompt ids (bare hex).
+func sessionStateID(key Key) string {
+	sum := sha256.Sum256([]byte(key.AgentID + "\x00" + key.ContextID))
+	return "session-" + hex.EncodeToString(sum[:16])
+}
+
+// freshRunID returns a new run id for a fresh turn.
+func freshRunID() (string, error) {
+	var bytes [8]byte
+	if _, err := rand.Read(bytes[:]); err != nil {
+		return "", errdefs.Internal(fmt.Errorf("runtime session: allocate run id: %w", err))
+	}
+	return "run-" + hex.EncodeToString(bytes[:]), nil
+}
+
+// loadSessionState reads the session's durable state, or (nil, nil)
+// when resume is disabled, no store is wired, or no record exists yet.
+func (s *Session) loadSessionState(ctx context.Context) (*sessionState, error) {
+	if s == nil || !s.resume || s.checkpoints == nil {
+		return nil, nil
+	}
+	cp, err := s.checkpoints.Load(ctx, sessionStateID(s.key))
+	if err != nil {
+		return nil, fmt.Errorf("runtime session: load session state: %w", err)
+	}
+	if cp == nil {
+		return nil, nil
+	}
+	state := &sessionState{Board: cp.Board}
+	if len(cp.Payload) > 0 {
+		if err := json.Unmarshal(cp.Payload, state); err != nil {
+			return nil, fmt.Errorf("runtime session: decode session state: %w", err)
+		}
+	}
+	return state, nil
+}
+
+// saveSessionState persists the session state record. Best-effort: a
+// store failure leaves the previous record in place.
+func (s *Session) saveSessionState(state *sessionState) {
+	if s == nil || !s.resume || s.checkpoints == nil || state == nil {
+		return
+	}
+	payload, err := json.Marshal(state)
+	if err != nil {
+		return
+	}
+	board := state.Board
+	if board == nil {
+		board = agent.NewBoard().Snapshot()
+	}
+	cp := agent.Checkpoint{
+		ExecID:     sessionStateID(s.key),
+		Board:      board,
+		Payload:    payload,
+		Attributes: map[string]string{"runtime.session.kind": "state"},
+	}
+	ctx, cancel := context.WithTimeout(
+		context.WithoutCancel(context.Background()), 5*time.Second)
+	defer cancel()
+	_ = s.checkpoints.Save(ctx, cp)
+}
+
+// clearParkedRun drops the resumable marker (e.g. the parked run's
+// checkpoint no longer exists) while preserving the committed board.
+func (s *Session) clearParkedRun(state *sessionState) {
+	if state == nil {
+		return
+	}
+	state.ResumableRunID = ""
+	state.Request = nil
+	s.saveSessionState(state)
+}
+
+// afterTurn updates session state after a turn reaches its terminal
+// state:
+//
+//   - Committed runs advance the session board and delete their run
+//     checkpoint; nothing stays parked.
+//   - Interrupted, canceled, failed, and aborted runs keep their
+//     checkpoint and park their run id + original request so Resume
+//     can replay them. The committed board is left untouched.
+func (s *Session) afterTurn(turn *Turn, result *agent.Result) {
+	if s == nil || !s.resume || s.checkpoints == nil || turn == nil {
+		return
+	}
+	ctx, cancel := context.WithTimeout(
+		context.WithoutCancel(context.Background()), 5*time.Second)
+	defer cancel()
+	prev, err := s.loadSessionState(ctx)
+	if err != nil {
+		prev = nil
+	}
+	state := &sessionState{}
+	if prev != nil {
+		state.Board = prev.Board
+	}
+	if result != nil && result.Committed {
+		s.deleteCheckpoint(turn.runID)
+		if result.LastBoard != nil {
+			state.Board = result.LastBoard.Snapshot()
+		}
+		state.ResumableRunID = ""
+		state.Request = nil
+	} else {
+		state.ResumableRunID = turn.runID
+		request := turn.request
+		state.Request = &request
+	}
+	s.saveSessionState(state)
+}
+
+// deleteCheckpoint removes a committed run's checkpoint. Best-effort:
+// a failed delete leaves an orphaned checkpoint under a run id that no
+// session state references, which is harmless.
+func (s *Session) deleteCheckpoint(runID string) {
+	if s == nil || !s.resume || s.checkpoints == nil {
+		return
+	}
+	deleter, ok := s.checkpoints.(agent.CheckpointDeleter)
+	if !ok {
+		return
+	}
+	ctx, cancel := context.WithTimeout(
+		context.WithoutCancel(context.Background()), 5*time.Second)
+	defer cancel()
+	_ = deleter.Delete(ctx, runID)
+}
+
+// loadResumableCheckpoint loads and validates the parked run's
+// checkpoint. A missing checkpoint returns (nil, nil, nil) so the
+// caller can clear the stale marker.
+func (s *Session) loadResumableCheckpoint(
 	ctx context.Context,
 	runID string,
 ) (*agent.Checkpoint, *agent.ResumeContext, error) {
-	if !s.resume || s.checkpoints == nil {
-		return nil, nil, nil
-	}
 	cp, err := s.checkpoints.Load(ctx, runID)
 	if err != nil {
 		return nil, nil, fmt.Errorf(
@@ -289,6 +557,11 @@ func (s *Session) loadResume(
 	}
 	if cp == nil {
 		return nil, nil, nil
+	}
+	if cp.ExecID != runID {
+		return nil, nil, errdefs.Validationf(
+			"runtime session: checkpoint exec id %q does not match parked run %q",
+			cp.ExecID, runID)
 	}
 	if !agent.IsResumable(s.instance.Engine) {
 		return nil, nil, errdefs.NotAvailablef(
@@ -308,35 +581,10 @@ func (s *Session) loadResume(
 	resumeCtx := agent.ResumeContext{
 		Attempt:      2,
 		StartedAt:    startedAt,
-		Signal:       "session",
+		Signal:       "resume",
 		CheckpointAt: cp.Timestamp,
 	}
 	return cp, &resumeCtx, nil
-}
-
-// cleanupCheckpoint removes a committed run's checkpoint so the next
-// turn starts fresh. Interrupted, failed, and canceled runs keep
-// theirs. Deletion is best-effort.
-func (s *Session) cleanupCheckpoint(runID string, result *agent.Result) {
-	if s == nil || !s.resume || s.checkpoints == nil ||
-		result == nil || !result.Committed {
-		return
-	}
-	deleter, ok := s.checkpoints.(agent.CheckpointDeleter)
-	if !ok {
-		return
-	}
-	ctx, cancel := context.WithTimeout(
-		context.WithoutCancel(context.Background()), 5*time.Second)
-	defer cancel()
-	_ = deleter.Delete(ctx, runID)
-}
-
-// stableRunID derives the logical run id for one session key. It is
-// stable across process restarts so resume can find the checkpoint.
-func stableRunID(key Key) string {
-	sum := sha256.Sum256([]byte(key.AgentID + "\x00" + key.ContextID))
-	return "run-" + hex.EncodeToString(sum[:16])
 }
 
 // Key returns this Session's immutable identity.

--- a/core/runtime/session/session_test.go
+++ b/core/runtime/session/session_test.go
@@ -410,6 +410,36 @@ func TestTurnWaitAndInterruptSemantics(t *testing.T) {
 	wg.Wait()
 }
 
+func TestTurnCancelImmediatelyStopsBlockedRun(t *testing.T) {
+	started := make(chan struct{})
+	engine := agent.EngineFunc(func(ctx context.Context, _ agent.Run, _ agent.Host, board *agent.Board) (*agent.Board, error) {
+		close(started)
+		// Simulate an engine stuck in a long call that never polls
+		// cooperative interrupts: only context cancellation can stop it.
+		<-ctx.Done()
+		return board, ctx.Err()
+	})
+	_, session, _, _ := newTurnSession(t, engine, turnHostFactory)
+
+	turn, err := session.Start(context.Background(), agent.Request{
+		Message: message.NewTextMessage(message.RoleUser, "hi"),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	<-started
+
+	turn.Cancel()
+	turn.Cancel() // idempotent
+	result, err := turn.Wait(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Status != agent.StatusCanceled || turn.State() != TurnCanceled {
+		t.Fatalf("result status = %q, turn state = %q", result.Status, turn.State())
+	}
+}
+
 func TestAuthoritativeAckCommitsOnlyFrozenPrefix(t *testing.T) {
 	committed := make(chan string, 1)
 	engine := agent.EngineFunc(func(

--- a/core/runtime/session/turn.go
+++ b/core/runtime/session/turn.go
@@ -21,6 +21,8 @@ type Turn struct {
 
 	resumeFrom *agent.Checkpoint
 	resumeCtx  *agent.ResumeContext
+	snapshot   *agent.BoardSnapshot
+	request    agent.Request
 
 	interrupts chan agent.Interrupt
 	done       chan struct{}
@@ -94,6 +96,23 @@ func (t *Turn) State() TurnState {
 	t.mu.Lock()
 	defer t.mu.Unlock()
 	return t.state
+}
+
+// Cancel immediately stops the turn by cancelling its execution
+// context. Unlike [Turn.Interrupt], which the engine only observes at
+// its next safe checkpoint, Cancel takes effect as soon as the engine
+// notices the context cancellation — typically while it is blocked in
+// I/O or an inference call.
+//
+// The run settles as [agent.StatusCanceled], a non-committed outcome:
+// with resume enabled the session parks the run and its checkpoint
+// stays resumable via [Session.Resume]. Cancel is idempotent and safe
+// to call after the turn has finished.
+func (t *Turn) Cancel() {
+	if t == nil {
+		return
+	}
+	t.cancel()
 }
 
 // Interrupt cooperatively asks the engine to stop. The first cause wins.
@@ -188,6 +207,9 @@ func (t *Turn) execute(instance *agent.Agent, request agent.Request) {
 	if t.resumeFrom != nil {
 		options = append(options, agent.WithResumeFrom(t.resumeFrom))
 	}
+	if t.snapshot != nil {
+		options = append(options, agent.WithPreparer(sessionHistoryPreparer(t.snapshot)))
+	}
 	t.mu.Lock()
 	hasAuthority := t.authorityID != ""
 	t.mu.Unlock()
@@ -201,8 +223,40 @@ func (t *Turn) execute(instance *agent.Agent, request agent.Request) {
 	if t.resumeCtx != nil {
 		execCtx = agent.WithResumeContext(t.runCtx, *t.resumeCtx)
 	}
+	t.request = request
 	result, err := agent.Execute(execCtx, *instance, nil, request, options...)
 	t.finish(result, err)
+}
+
+// sessionHistoryPreparer restores the session's last committed board
+// (conversation history) for a fresh turn, then merges the default
+// seed's new message and inputs on top. It is only used for fresh
+// starts; Resume passes the checkpoint board instead. Earlier links in
+// the Preparer chain run before this one, so their non-main-channel
+// output (retrieval, tool state, …) is overlaid on the restored board
+// rather than lost.
+func sessionHistoryPreparer(history *agent.BoardSnapshot) agent.Preparer {
+	return agent.PreparerFunc(func(
+		_ context.Context,
+		_ agent.Identity,
+		_ *agent.Request,
+		prev *agent.Board,
+	) (*agent.Board, error) {
+		board := agent.RestoreBoard(history)
+		for _, msg := range prev.Channel(agent.MainChannel) {
+			board.AppendChannelMessage(agent.MainChannel, msg)
+		}
+		for key, msgs := range prev.ChannelsCopy() {
+			if key == agent.MainChannel {
+				continue
+			}
+			board.SetChannel(key, msgs)
+		}
+		for key, value := range prev.Vars() {
+			board.SetVar(key, value)
+		}
+		return board, nil
+	})
 }
 
 func (t *Turn) finish(result *agent.Result, err error) {
@@ -254,7 +308,7 @@ func (t *Turn) finish(result *agent.Result, err error) {
 		detachCoordinator()
 	}
 	if t.session != nil {
-		t.session.cleanupCheckpoint(t.runID, result)
+		t.session.afterTurn(t, result)
 	}
 	if t.session != nil {
 		t.session.turnFinished(t, result, err)


### PR DESCRIPTION
## Summary

Fixes #313. The runtime session previously reused one stable run id per session key whenever `sessions.resume: true` was enabled, and every `Session.Start` implicitly loaded the checkpoint stored under that id. After a completed turn the checkpoint sat at a terminal graph state, so the next turn resumed it and short-circuited instantly (no LLM call, no stream, no usage).

This PR decouples the two conflated semantics:

- **Every `Start` mints a fresh run id** (`run-<hex>`); run identity is per-execution, never per-session.
- **Conversation history is session-scoped state.** A new durable record keyed `session-<sha256>` in the checkpoint store holds the last committed board (history), the parked run id, and the original request.
- **Resume is explicit.** `Session.Resume(ctx, sinks...)` replays the specific parked run under its original run id and request (loading its checkpoint, `Signal: "resume"`). `Session.Resumable(ctx)` reports whether a run is parked. A new user message always starts a fresh run and never implicitly resumes.
- **Immediate stop.** `Turn.Cancel()` cancels the turn's execution context directly, so engines blocked in long calls stop immediately (settles as `StatusCanceled`, still parked/resumable).

## Behavior details

- Committed turns delete their run checkpoint and advance the session board; interrupted/canceled/failed/aborted turns keep their checkpoint and park their run id + original request.
- Even if a checkpoint delete fails, the orphan stays unreferenced and can no longer short-circuit a new turn.
- Migration: after upgrading, pre-existing stable run-id checkpoints are no longer referenced; the first turn of a session starts with empty history.

## Changeset

Adds `.release/core-v0.1.6.json` (patch): `core 0.1.5 -> 0.1.6`, covering the full delta since the last core tag.

## Checks

- `make ci` — passed (vet + test, all modules)
- `make release-check` / `make release-plan` / `make release-preflight` — passed; plan: `core/v0.1.6`
- `golangci-lint` on `core` — 0 issues
- Note: `make lint` reports 4 pre-existing issues under the untracked `backends/plugin/` directory, unrelated to this change.