### PR TITLE
agent: run Agent.Prepare hooks in Execute

### DIFF
--- a/.release/core-v0.1.7.json
+++ b/.release/core-v0.1.7.json
@@ -1,0 +1,9 @@
+{
+  "summary": "fix(core): run Agent.Prepare hooks in Execute",
+  "releases": [
+    {
+      "module": "core",
+      "bump": "patch"
+    }
+  ]
+}

--- a/core/agent/execute.go
+++ b/core/agent/execute.go
@@ -492,6 +492,11 @@ func applyOptions(ag Agent, opts []ExecuteOption) execConfig {
 			rc.committers = append(rc.committers, c)
 		}
 	}
+	for _, p := range ag.Prepare {
+		if p != nil {
+			rc.preparers = append(rc.preparers, p)
+		}
+	}
 	for _, o := range opts {
 		if o != nil {
 			o(&rc)

--- a/core/agent/execute_test.go
+++ b/core/agent/execute_test.go
@@ -76,6 +76,49 @@ func TestRun_CleanCompletion_Defaults(t *testing.T) {
 	}
 }
 
+func TestRun_AgentPreparersRunBeforeEngine(t *testing.T) {
+	prepared := false
+	preparer := agent.PreparerFunc(func(
+		_ context.Context, _ agent.Identity, _ *agent.Request, prev *agent.Board,
+	) (*agent.Board, error) {
+		prepared = true
+		board := prev
+		if board == nil {
+			board = agent.NewBoard()
+		}
+		board.SetVar("world.prepped", "yes")
+		return board, nil
+	})
+	var engineSeen string
+	eng := agent.EngineFunc(func(
+		_ context.Context, _ agent.Run, _ agent.Host, b *agent.Board,
+	) (*agent.Board, error) {
+		if v, ok := b.GetVar("world.prepped"); ok {
+			engineSeen, _ = v.(string)
+		}
+		b.AppendChannelMessage(agent.MainChannel,
+			message.NewTextMessage(message.RoleAssistant, "ok"))
+		return b, nil
+	})
+	res, err := agent.Execute(context.Background(),
+		agent.Agent{
+			ID:      "a",
+			Prepare: []agent.Preparer{preparer},
+		}, eng, newReq("hi"))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !prepared {
+		t.Fatal("Agent.Preparers did not run")
+	}
+	if engineSeen != "yes" {
+		t.Errorf("engine did not see preparer board var: %q", engineSeen)
+	}
+	if res.Status != agent.StatusCompleted {
+		t.Errorf("status = %q", res.Status)
+	}
+}
+
 func TestRun_RunIDPropagatesIntoEngineRun(t *testing.T) {
 	var seen string
 	eng := agent.EngineFunc(func(_ context.Context, r agent.Run, _ agent.Host, b *agent.Board) (*agent.Board, error) {


### PR DESCRIPTION
## Problem

`agent.applyOptions` copies `Observe`, `Referees`, and `Commit` from the `Agent` value into the run config, but never copies `Prepare`. As a result, deploy-configured **prepare hooks never run**: the board is seeded without any agent-level preparation (worldstate, memory summary, history injection, system prompt shaping).

The comment on `WithPreparer` claims "the chain runs after agent applies any Agent.Preparers declared on the agent value" — the agent-level hooks are simply never applied.

## Fix

Append `ag.Prepare` to `rc.preparers` before applying call-site `WithPreparer` options, so agent-level preparation runs first and call-site preparers can build on top (matching the documented ordering).

## Test

`TestRun_AgentPreparersRunBeforeEngine` builds an Agent with a `Preparer` that sets a board var, and asserts the engine sees the var (and that the preparer ran). Without the fix the test fails (`Agent.Preparers did not run`).

Repro in opencraft: with a `prepare:` hook in the deploy doc, `world.sections` / memory summary / AGENTS.md never reach the model — the hook factory resolves and attaches, but `agent.Execute` drops it.