### PR TITLE
feat(core): runtime tool publication with background MCP reconnect

### DIFF
--- a/core/tool/assembly.go
+++ b/core/tool/assembly.go
@@ -80,6 +80,11 @@ func NewAssembly(sources []Source, opts ...AssemblyOption) (*Assembly, error) {
 	if err != nil {
 		return nil, err
 	}
+	for _, src := range sources {
+		if attacher, ok := src.(RegistryAttacher); ok {
+			attacher.Attach(registry)
+		}
+	}
 	return &Assembly{
 		registry: registry,
 		executor: NewExecutor(registry, o.middleware...),

--- a/core/tool/assembly_test.go
+++ b/core/tool/assembly_test.go
@@ -92,3 +92,39 @@ func TestAssembly_CloseReleasesRegistry(t *testing.T) {
 		t.Fatalf("second Close: %v", err)
 	}
 }
+
+// attacherSource contributes one eager tool and publishes one runtime
+// tool through the Registrar the assembly hands it.
+type attacherSource struct {
+	attached bool
+}
+
+func (a *attacherSource) Tools() []tool.Tool {
+	return []tool.Tool{funcTool("eager", "eager")}
+}
+
+func (a *attacherSource) LazyTools() []tool.LazyTool { return nil }
+
+func (a *attacherSource) Attach(r tool.Registrar) {
+	a.attached = true
+	if err := r.Add(funcTool("runtime", "runtime")); err != nil {
+		panic(err)
+	}
+}
+
+func TestAssembly_AttachesRegistryToSources(t *testing.T) {
+	attacher := &attacherSource{}
+	assembly, err := tool.NewAssembly([]tool.Source{attacher})
+	if err != nil {
+		t.Fatalf("NewAssembly: %v", err)
+	}
+	if !attacher.attached {
+		t.Fatal("source never received the registrar")
+	}
+	if _, ok := assembly.Catalog().Get("runtime"); !ok {
+		t.Fatal("runtime-published tool missing from catalog")
+	}
+	if _, ok := assembly.Catalog().Get("eager"); !ok {
+		t.Fatal("eager tool missing from catalog")
+	}
+}

--- a/core/tool/mcp/doc.go
+++ b/core/tool/mcp/doc.go
@@ -37,8 +37,12 @@
 //	// reg now holds askuser plus filesystem__read_file, filesystem__write_file, ...
 //	exec := tool.NewExecutor(reg, mws...)
 //
-// AddServer is synchronous: once it returns, the registry is complete
-// for that server, so a host can finish wiring before serving traffic.
+// AddServer attempts to connect synchronously, and a server that is
+// reachable is complete before the call returns. A server that cannot
+// be reached is not a startup failure: the Source keeps retrying in
+// the background with exponential backoff and publishes the server's
+// tools to the registry the moment a connection succeeds. Hosts can
+// therefore finish wiring before every server is up.
 //
 // # Namespacing
 //
@@ -61,10 +65,11 @@
 // This package adds no cache of its own. The go-sdk maintains a TTL
 // cache for tools/list — with the TTL advertised by the server — and
 // invalidates it on a tools/list_changed notification. Source hooks
-// that notification to reconcile the registry: new and changed tools are
-// re-registered, vanished ones are unregistered, and other servers are
-// untouched. [Source.Refresh] does the same on demand, which is what
-// servers that never send the notification need.
+// The Source hooks the notification to reconcile the registry: new and
+// changed tools are added, vanished ones are removed, and other
+// servers are untouched. The same reconcile runs when a background
+// reconnect brings a server back, which is what servers that were down
+// at startup need.
 //
 // A tools/list failure leaves the previous projection in place. Making
 // the model abruptly lose sight of tools it was told about is worse than
@@ -74,10 +79,13 @@
 //
 // Each server owns its session and its slice of the registry. When a
 // server dies its tools return errdefs.NotAvailable naming that server;
-// other servers and every built-in tool keep working. [Source.Close]
-// releases all sessions, which for a stdio server means closing stdin,
-// waiting, then escalating to SIGTERM and SIGKILL as the MCP spec
-// prescribes — hosts never reap child processes themselves.
+// other servers and every built-in tool keep working. The Source also
+// reconnects a dead server in the background, and its tools are
+// re-published when it comes back. [Source.Close] cancels all
+// reconnection and releases every session, which for a stdio server
+// means closing stdin, waiting, then escalating to SIGTERM and SIGKILL
+// as the MCP spec prescribes — hosts never reap child processes
+// themselves.
 //
 // # Result rendering
 //

--- a/core/tool/mcp/source.go
+++ b/core/tool/mcp/source.go
@@ -2,69 +2,203 @@ package mcp
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/GizClaw/flowcraft/core/errdefs"
-	"github.com/GizClaw/flowcraft/core/tool"
+	"github.com/GizClaw/flowcraft/core/telemetry"
+	sdktool "github.com/GizClaw/flowcraft/core/tool"
 
 	mcpsdk "github.com/modelcontextprotocol/go-sdk/mcp"
+	otellog "go.opentelemetry.io/otel/log"
 )
 
 // DefaultPrefixSeparator joins a server name to a tool name when
 // namespacing is enabled.
 const DefaultPrefixSeparator = "__"
 
+// DefaultConnectTimeout bounds every connection attempt, initial and
+// retried. The build context may carry no deadline at all, so without
+// a per-attempt bound a hung stdio child or a black-holed dial would
+// stall startup or a background retry forever.
+const DefaultConnectTimeout = 30 * time.Second
+
+// DefaultRetryBackoff is the delay before the first background
+// reconnection attempt. The delay doubles on each failure up to
+// DefaultRetryMaxBackoff.
+const (
+	DefaultRetryBackoff    = time.Second
+	DefaultRetryMaxBackoff = 30 * time.Second
+)
+
+// DefaultLivenessInterval is how often a connected server is pinged to
+// detect that it died. The go-sdk does not surface a peer disconnect
+// until a request fails and, on modern protocol versions, disables its
+// own keepalive, so this package probes with the standard MCP ping.
+const DefaultLivenessInterval = 15 * time.Second
+
 // Source is a tool.Source that connects MCP servers and exposes their
-// tools as ordinary core/tool.Tool values. It connects eagerly at
-// AddServer time, so the tool list is complete before the Source is
-// handed to a Registry or Assembly.
+// tools as ordinary core/tool.Tool values.
+//
+// Connection is best-effort. AddServer attempts to connect and
+// discover tools immediately; a failure that is the server's fault —
+// unreachable, missing binary, timeout — schedules background
+// reconnection with exponential backoff instead of failing the host,
+// and the tools are published to the attached [sdktool.Registrar]
+// when the server comes up. A failure that is our configuration's
+// fault (validation, rejection) still returns an error to the caller.
+// Once connected, a server that dies is reconnected the same way: its
+// tools stay visible, and calls fail with per-server NotAvailable
+// until the connection is restored.
 type Source struct {
-	mu      sync.Mutex
-	servers map[string]*server
-	closed  bool
+	mu        sync.Mutex
+	servers   map[string]*server
+	retrying  map[string]struct{}
+	closed    bool
+	registrar sdktool.Registrar
+
+	// baseCtx is the Source-owned context governing background work.
+	// It is canceled on Close so retries never outlive the source.
+	// The attach context is deliberately NOT used for retries: it is
+	// typically request-scoped and gone by the time a retry needs to
+	// run.
+	baseCtx context.Context
+	cancel  context.CancelFunc
+
+	connectTimeout time.Duration
+	retryInitial   time.Duration
+	retryMax       time.Duration
+	liveness       time.Duration
+}
+
+// SourceOption configures a Source.
+type SourceOption func(*Source)
+
+// WithConnectTimeout bounds each connection attempt. Non-positive
+// values fall back to DefaultConnectTimeout.
+func WithConnectTimeout(d time.Duration) SourceOption {
+	return func(s *Source) {
+		if d > 0 {
+			s.connectTimeout = d
+		}
+	}
+}
+
+// WithRetryBackoff sets the initial and maximum delays between
+// background connection attempts. Non-positive values fall back to
+// the defaults, and max is clamped to be at least initial.
+func WithRetryBackoff(initial, max time.Duration) SourceOption {
+	return func(s *Source) {
+		if initial > 0 {
+			s.retryInitial = initial
+		}
+		if max > 0 {
+			s.retryMax = max
+		}
+	}
+}
+
+// WithLivenessInterval sets how often a connected server is pinged to
+// detect a dead connection. Non-positive values fall back to
+// DefaultLivenessInterval.
+func WithLivenessInterval(d time.Duration) SourceOption {
+	return func(s *Source) {
+		if d > 0 {
+			s.liveness = d
+		}
+	}
 }
 
 // NewSource returns an empty MCP Source.
-func NewSource() *Source {
-	return &Source{servers: make(map[string]*server)}
+func NewSource(opts ...SourceOption) *Source {
+	ctx, cancel := context.WithCancel(context.Background())
+	s := &Source{
+		servers:        make(map[string]*server),
+		retrying:       make(map[string]struct{}),
+		baseCtx:        ctx,
+		cancel:         cancel,
+		connectTimeout: DefaultConnectTimeout,
+		retryInitial:   DefaultRetryBackoff,
+		retryMax:       DefaultRetryMaxBackoff,
+		liveness:       DefaultLivenessInterval,
+	}
+	for _, opt := range opts {
+		if opt != nil {
+			opt(s)
+		}
+	}
+	if s.retryMax < s.retryInitial {
+		s.retryMax = s.retryInitial
+	}
+	return s
 }
 
 // Tools implements tool.Source: every discovered tool plus optional
-// resource-bridge tools, in server attach order.
-func (s *Source) Tools() []tool.Tool {
+// resource-bridge tools, for every server attached so far.
+func (s *Source) Tools() []sdktool.Tool {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	var out []tool.Tool
+	var out []sdktool.Tool
 	for _, srv := range s.servers {
 		out = append(out, srv.tools...)
 	}
 	return out
 }
 
-// LazyTools implements tool.Source. MCP tools are discovered eagerly, so
-// there are no lazy entries.
-func (s *Source) LazyTools() []tool.LazyTool { return nil }
+// LazyTools implements tool.Source. MCP tools are discovered eagerly
+// when a connection succeeds; a not-yet-connected server contributes
+// nothing until the background retry brings it up.
+func (s *Source) LazyTools() []sdktool.LazyTool { return nil }
 
-// server is one live connection plus its exposed tools.
+// Attach implements tool.RegistryAttacher. The registrar receives
+// every runtime tool publication. Connected servers' current
+// projections are published immediately — duplicates of the
+// construction-time snapshot are ignored — so a server that connected
+// between the registry snapshot and this call is not lost.
+func (s *Source) Attach(r sdktool.Registrar) {
+	if r == nil {
+		return
+	}
+	var current []sdktool.Tool
+	s.mu.Lock()
+	s.registrar = r
+	for _, srv := range s.servers {
+		srv.mu.Lock()
+		current = append(current, srv.tools...)
+		srv.mu.Unlock()
+	}
+	s.mu.Unlock()
+	for _, t := range current {
+		if err := r.Add(t); err != nil && !errdefs.IsConflict(err) {
+			telemetry.WarnErr(s.baseCtx, "mcp: publish tool failed", err,
+				otellog.String("tool", t.Definition().Name))
+		}
+	}
+}
+
+// server is one live or connecting server plus its exposed tools.
 type server struct {
 	name      string
 	prefix    string
 	transport mcpsdk.Transport
+	cfg       *serverConfig
 
-	clientName  string
-	clientVer   string
-	clientOpts  *mcpsdk.ClientOptions
-	onListError func(server string, err error)
-	resources   bool
+	clientName string
+	clientVer  string
+	clientOpts *mcpsdk.ClientOptions
+	onListErr  func(server string, err error)
+	resources  bool
 
 	mu      sync.Mutex
 	session *mcpsdk.ClientSession
-	tools   []tool.Tool
+	tools   []sdktool.Tool
 }
 
 // currentSession returns the live session or a typed error if the
-// server has been detached.
+// server is not connected.
 func (s *server) currentSession() (*mcpsdk.ClientSession, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -129,8 +263,17 @@ func WithResources(enabled bool) ServerOption {
 	return func(c *serverConfig) { c.resources = enabled }
 }
 
-// AddServer connects to one MCP server, discovers its tools, and stores
-// them on the Source.
+// AddServer attaches one MCP server. It attempts to connect and
+// discover tools immediately; on a server-side failure (unreachable,
+// missing binary, timeout) the attempt is retried in the background
+// with backoff and AddServer returns nil, so a host can finish
+// starting up while the server converges. Validation failures — a
+// rejected connection, an invalid request, a duplicate name — are
+// configuration errors and are returned to the caller.
+//
+// The transport must tolerate being connected more than once when a
+// background retry is needed; the Stdio and StreamableHTTP transports
+// built by this package both do.
 func (s *Source) AddServer(
 	ctx context.Context,
 	name string,
@@ -156,48 +299,58 @@ func (s *Source) AddServer(
 	}
 
 	srv := &server{
-		name:        name,
-		prefix:      cfg.prefix,
-		transport:   transport,
-		clientName:  cfg.clientName,
-		clientVer:   cfg.clientVer,
-		clientOpts:  cfg.clientOpts,
-		onListError: cfg.onListError,
-		resources:   cfg.resources,
-	}
-	session, err := s.connect(ctx, srv, cfg)
-	if err != nil {
-		return err
-	}
-	srv.mu.Lock()
-	srv.session = session
-	srv.mu.Unlock()
-
-	if err := s.reconcile(ctx, srv); err != nil {
-		_ = session.Close()
-		return err
-	}
-	if cfg.resources {
-		for _, spec := range resourceToolSpecs(srv) {
-			srv.tools = append(srv.tools, spec.tool)
-		}
+		name:       name,
+		prefix:     cfg.prefix,
+		transport:  transport,
+		cfg:        cfg,
+		clientName: cfg.clientName,
+		clientVer:  cfg.clientVer,
+		clientOpts: cfg.clientOpts,
+		onListErr:  cfg.onListError,
+		resources:  cfg.resources,
 	}
 
 	s.mu.Lock()
-	defer s.mu.Unlock()
 	if s.closed {
-		_ = session.Close()
+		s.mu.Unlock()
 		return errdefs.NotAvailablef("mcp: source is closed")
 	}
 	if _, exists := s.servers[name]; exists {
-		_ = session.Close()
+		s.mu.Unlock()
 		return errdefs.Validationf("mcp: server %q is already attached", name)
 	}
-	s.servers[name] = srv
+	if _, pending := s.retrying[name]; pending {
+		s.mu.Unlock()
+		return errdefs.Validationf("mcp: server %q is already attached", name)
+	}
+	s.mu.Unlock()
+
+	attemptCtx, cancel := context.WithTimeout(ctx, s.connectTimeout)
+	session, err := s.connect(attemptCtx, srv, cfg)
+	cancel()
+	if err != nil {
+		if fatalAttachError(ctx, err) {
+			return fmt.Errorf("mcp: attach server %q: %w", name, err)
+		}
+		s.scheduleRetry(srv)
+		return nil
+	}
+
+	reconcileCtx, cancel := context.WithTimeout(ctx, s.connectTimeout)
+	defer cancel()
+	if err := s.attachSession(reconcileCtx, srv, session); err != nil {
+		if fatalAttachError(ctx, err) {
+			return fmt.Errorf("mcp: attach server %q: %w", name, err)
+		}
+		s.scheduleRetry(srv)
+		return nil
+	}
+	go s.watch(srv)
 	return nil
 }
 
-// Close releases all sessions. Idempotent.
+// Close stops all background reconnection, closes every session, and
+// releases the tool projections. Idempotent.
 func (s *Source) Close() error {
 	s.mu.Lock()
 	if s.closed {
@@ -208,6 +361,8 @@ func (s *Source) Close() error {
 	servers := s.servers
 	s.servers = nil
 	s.mu.Unlock()
+
+	s.cancel()
 
 	var first error
 	for _, srv := range servers {
@@ -255,7 +410,45 @@ func (s *Source) connect(
 	return session, nil
 }
 
-// reconcile re-lists the server's tools and stores adapted tools.
+// attachSession installs a connected session, reconciles the server's
+// tool projection, and registers the server on the Source unless it is
+// already there (a reconnect). On failure the session is closed and
+// srv.session is cleared, so a retry starts from a clean state.
+func (s *Source) attachSession(
+	ctx context.Context,
+	srv *server,
+	session *mcpsdk.ClientSession,
+) error {
+	srv.mu.Lock()
+	srv.session = session
+	srv.mu.Unlock()
+
+	if err := s.reconcile(ctx, srv); err != nil {
+		srv.mu.Lock()
+		if srv.session == session {
+			srv.session = nil
+		}
+		srv.mu.Unlock()
+		_ = session.Close()
+		return err
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.closed {
+		return errdefs.NotAvailablef("mcp: source is closed")
+	}
+	if other, exists := s.servers[srv.name]; exists && other != srv {
+		return errdefs.Validationf("mcp: server %q is already attached", srv.name)
+	}
+	s.servers[srv.name] = srv
+	return nil
+}
+
+// reconcile re-lists the server's tools and updates its projection,
+// publishing additions and removals to the attached registrar. The
+// previous projection is kept on failure, so the model never loses
+// sight of tools it was told about.
 func (s *Source) reconcile(ctx context.Context, srv *server) error {
 	session, err := srv.currentSession()
 	if err != nil {
@@ -266,16 +459,238 @@ func (s *Source) reconcile(ctx context.Context, srv *server) error {
 		return errdefs.NotAvailablef("mcp: server %q: list tools: %v", srv.name, err)
 	}
 
-	srv.mu.Lock()
-	defer srv.mu.Unlock()
-	srv.tools = srv.tools[:0]
+	next := make([]sdktool.Tool, 0, len(res.Tools)+2)
 	for _, mt := range res.Tools {
 		if mt == nil || mt.Name == "" {
 			continue
 		}
-		srv.tools = append(srv.tools, newAdaptedTool(srv, srv.qualify(mt.Name), mt))
+		next = append(next, newAdaptedTool(srv, srv.qualify(mt.Name), mt))
 	}
+	if srv.resources {
+		for _, spec := range resourceToolSpecs(srv) {
+			next = append(next, spec.tool)
+		}
+	}
+
+	srv.mu.Lock()
+	added, removed := diffTools(srv.tools, next)
+	srv.tools = next
+	srv.mu.Unlock()
+
+	s.publish(added, removed)
 	return nil
 }
 
-var _ tool.Source = (*Source)(nil)
+// diffTools splits the move from old to next into additions and
+// removals by tool name.
+func diffTools(old, next []sdktool.Tool) (added, removed []sdktool.Tool) {
+	oldNames := make(map[string]struct{}, len(old))
+	for _, t := range old {
+		oldNames[t.Definition().Name] = struct{}{}
+	}
+	nextNames := make(map[string]struct{}, len(next))
+	for _, t := range next {
+		name := t.Definition().Name
+		if _, dup := nextNames[name]; dup {
+			continue
+		}
+		nextNames[name] = struct{}{}
+		if _, known := oldNames[name]; !known {
+			added = append(added, t)
+		}
+	}
+	for _, t := range old {
+		if _, still := nextNames[t.Definition().Name]; !still {
+			removed = append(removed, t)
+		}
+	}
+	return added, removed
+}
+
+// publish pushes tool additions and removals to the attached
+// registrar, if any. A duplicate Add is not an error here: the tool
+// may already be present from the construction-time snapshot.
+func (s *Source) publish(added, removed []sdktool.Tool) {
+	s.mu.Lock()
+	reg := s.registrar
+	s.mu.Unlock()
+	if reg == nil {
+		return
+	}
+	for _, t := range added {
+		if err := reg.Add(t); err != nil && !errdefs.IsConflict(err) {
+			telemetry.WarnErr(s.baseCtx, "mcp: publish tool failed", err,
+				otellog.String("tool", t.Definition().Name))
+		}
+	}
+	for _, t := range removed {
+		reg.Remove(t.Definition().Name)
+	}
+}
+
+// fatalAttachError reports whether a failed attach must surface to the
+// caller instead of being retried in the background: configuration
+// errors (validation/rejection) and a dead or canceled caller context.
+func fatalAttachError(ctx context.Context, err error) bool {
+	if err == nil {
+		return false
+	}
+	if errdefs.IsValidation(err) {
+		return true
+	}
+	if ctx.Err() != nil || errors.Is(err, context.Canceled) {
+		return true
+	}
+	return false
+}
+
+// scheduleRetry starts a background reconnection loop for srv unless
+// one is already running or the source is closed.
+func (s *Source) scheduleRetry(srv *server) {
+	s.mu.Lock()
+	if s.closed {
+		s.mu.Unlock()
+		return
+	}
+	if _, running := s.retrying[srv.name]; running {
+		s.mu.Unlock()
+		return
+	}
+	s.retrying[srv.name] = struct{}{}
+	s.mu.Unlock()
+	go s.retryLoop(srv)
+}
+
+// retryLoop reconnects srv with exponential backoff until it succeeds
+// or the source closes.
+func (s *Source) retryLoop(srv *server) {
+	backoff := s.retryInitial
+	for {
+		select {
+		case <-s.baseCtx.Done():
+			s.clearRetrying(srv.name)
+			return
+		case <-time.After(backoff):
+		}
+
+		attemptCtx, cancel := context.WithTimeout(s.baseCtx, s.connectTimeout)
+		session, err := s.connect(attemptCtx, srv, srv.cfg)
+		cancel()
+		if err == nil {
+			reconcileCtx, cancel := context.WithTimeout(s.baseCtx, s.connectTimeout)
+			err = s.attachSession(reconcileCtx, srv, session)
+			cancel()
+			if err == nil {
+				s.clearRetrying(srv.name)
+				go s.watch(srv)
+				return
+			}
+			_ = session.Close()
+			if errdefs.IsValidation(err) {
+				telemetry.Error(s.baseCtx, "mcp: server rejected attach, giving up",
+					otellog.String("server", srv.name),
+					otellog.String(telemetry.AttrErrorMessage, err.Error()))
+				s.clearRetrying(srv.name)
+				return
+			}
+			if s.baseCtx.Err() != nil {
+				s.clearRetrying(srv.name)
+				return
+			}
+			telemetry.WarnErr(s.baseCtx, "mcp: server attach failed, will retry", err,
+				otellog.String("server", srv.name))
+			backoff = s.nextBackoff(backoff)
+			continue
+		}
+
+		if errdefs.IsValidation(err) {
+			// The peer is there but rejects us — retrying cannot fix a
+			// configuration problem, so stop instead of churning.
+			telemetry.Error(s.baseCtx, "mcp: server rejected connection, giving up",
+				otellog.String("server", srv.name),
+				otellog.String(telemetry.AttrErrorMessage, err.Error()))
+			s.clearRetrying(srv.name)
+			return
+		}
+		if s.baseCtx.Err() != nil {
+			s.clearRetrying(srv.name)
+			return
+		}
+		telemetry.WarnErr(s.baseCtx, "mcp: server connect failed, will retry", err,
+			otellog.String("server", srv.name))
+		backoff = s.nextBackoff(backoff)
+	}
+}
+
+// nextBackoff doubles cur up to the configured maximum.
+func (s *Source) nextBackoff(cur time.Duration) time.Duration {
+	next := cur * 2
+	if next > s.retryMax {
+		return s.retryMax
+	}
+	return next
+}
+
+func (s *Source) clearRetrying(name string) {
+	s.mu.Lock()
+	delete(s.retrying, name)
+	s.mu.Unlock()
+}
+
+// watch monitors srv's current session with periodic pings and
+// schedules a reconnect when the session dies on the server's side.
+// The tool projection is kept: calls fail with per-server NotAvailable
+// until the reconnection succeeds.
+func (s *Source) watch(srv *server) {
+	srv.mu.Lock()
+	session := srv.session
+	srv.mu.Unlock()
+	if session == nil {
+		return
+	}
+	ticker := time.NewTicker(s.liveness)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-s.baseCtx.Done():
+			return
+		case <-ticker.C:
+		}
+		srv.mu.Lock()
+		cur := srv.session
+		srv.mu.Unlock()
+		if cur != session {
+			return // a reconnect installed a newer session; it has its own watcher
+		}
+
+		pingCtx, cancel := context.WithTimeout(s.baseCtx, s.liveness)
+		err := session.Ping(pingCtx, nil)
+		cancel()
+		if err == nil {
+			continue
+		}
+		if s.baseCtx.Err() != nil {
+			return
+		}
+		srv.mu.Lock()
+		stillCurrent := srv.session == session
+		if stillCurrent {
+			srv.session = nil
+		}
+		srv.mu.Unlock()
+		if !stillCurrent {
+			return // a newer session replaced the dead one
+		}
+
+		telemetry.Warn(s.baseCtx, "mcp: server connection lost, reconnecting",
+			otellog.String("server", srv.name),
+			otellog.String(telemetry.AttrErrorMessage, err.Error()))
+		s.scheduleRetry(srv)
+		return
+	}
+}
+
+var (
+	_ sdktool.Source           = (*Source)(nil)
+	_ sdktool.RegistryAttacher = (*Source)(nil)
+)

--- a/core/tool/mcp/source_test.go
+++ b/core/tool/mcp/source_test.go
@@ -1,0 +1,315 @@
+package mcp
+
+import (
+	"context"
+	"errors"
+	"os"
+	"strconv"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/GizClaw/flowcraft/core/errdefs"
+	sdktool "github.com/GizClaw/flowcraft/core/tool"
+	mcpsdk "github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+// recordingRegistrar records runtime tool publications.
+type recordingRegistrar struct {
+	mu    sync.Mutex
+	tools map[string]sdktool.Tool
+	added []string
+}
+
+func newRecordingRegistrar() *recordingRegistrar {
+	return &recordingRegistrar{tools: make(map[string]sdktool.Tool)}
+}
+
+func (r *recordingRegistrar) Add(t sdktool.Tool) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	name := t.Definition().Name
+	if _, exists := r.tools[name]; exists {
+		return errdefs.Conflictf("tool: duplicate tool %q", name)
+	}
+	r.tools[name] = t
+	r.added = append(r.added, name)
+	return nil
+}
+
+func (r *recordingRegistrar) Remove(name string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	delete(r.tools, name)
+}
+
+func (r *recordingRegistrar) has(name string) bool {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	_, ok := r.tools[name]
+	return ok
+}
+
+// failNTimesTransport fails the first n Connect calls, then delegates
+// to a freshly built transport. It simulates a server that is down at
+// startup and comes up later.
+type failNTimesTransport struct {
+	remaining int32
+	calls     atomic.Int32
+	inner     func() (mcpsdk.Transport, error)
+}
+
+func (f *failNTimesTransport) Connect(ctx context.Context) (mcpsdk.Connection, error) {
+	f.calls.Add(1)
+	if atomic.AddInt32(&f.remaining, -1) >= 0 {
+		return nil, errors.New("server is down")
+	}
+	t, err := f.inner()
+	if err != nil {
+		return nil, err
+	}
+	return t.Connect(ctx)
+}
+
+// blockingTransport fails every Connect by blocking until the attempt
+// context expires, like a server that accepts the dial but never
+// answers the handshake.
+type blockingTransport struct {
+	connects atomic.Int32
+}
+
+func (b *blockingTransport) Connect(ctx context.Context) (mcpsdk.Connection, error) {
+	b.connects.Add(1)
+	<-ctx.Done()
+	return nil, ctx.Err()
+}
+
+// TestMCPHelperProcess is a stdio MCP server executed as a child of
+// the test binary (the standard go test re-exec pattern). It is a
+// no-op unless FC_MCP_HELPER=1.
+//
+// Environment:
+//   - FC_MCP_HELPER_DELAY_MS: sleep before serving (slow startup)
+//   - FC_MCP_HELPER_EXIT_MS: exit after serving for this long
+func TestMCPHelperProcess(t *testing.T) {
+	if os.Getenv("FC_MCP_HELPER") != "1" {
+		return
+	}
+	if delay := envMillis(t, "FC_MCP_HELPER_DELAY_MS"); delay > 0 {
+		time.Sleep(delay)
+	}
+
+	server := mcpsdk.NewServer(
+		&mcpsdk.Implementation{Name: "helper", Version: "test"}, nil)
+	server.AddTool(&mcpsdk.Tool{
+		Name:        "helper_tool",
+		InputSchema: map[string]any{"type": "object"},
+	}, func(_ context.Context, _ *mcpsdk.CallToolRequest) (*mcpsdk.CallToolResult, error) {
+		return &mcpsdk.CallToolResult{
+			Content: []mcpsdk.Content{&mcpsdk.TextContent{Text: "ok"}},
+		}, nil
+	})
+
+	ctx := context.Background()
+	if exit := envMillis(t, "FC_MCP_HELPER_EXIT_MS"); exit > 0 {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, exit)
+		defer cancel()
+	}
+	_ = server.Run(ctx, &mcpsdk.StdioTransport{})
+}
+
+func envMillis(t *testing.T, key string) time.Duration {
+	t.Helper()
+	raw := os.Getenv(key)
+	if raw == "" {
+		return 0
+	}
+	ms, err := strconv.Atoi(raw)
+	if err != nil {
+		t.Fatalf("invalid %s: %v", key, err)
+	}
+	return time.Duration(ms) * time.Millisecond
+}
+
+// helperStdio builds a stdio transport that runs the helper process.
+func helperStdio(delayMS, exitMS int) (mcpsdk.Transport, error) {
+	env := map[string]string{"FC_MCP_HELPER": "1"}
+	if delayMS > 0 {
+		env["FC_MCP_HELPER_DELAY_MS"] = strconv.Itoa(delayMS)
+	}
+	if exitMS > 0 {
+		env["FC_MCP_HELPER_EXIT_MS"] = strconv.Itoa(exitMS)
+	}
+	return Stdio(os.Args[0], []string{"-test.run=TestMCPHelperProcess"}, env)
+}
+
+func waitFor(t *testing.T, timeout time.Duration, what string, cond func() bool) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if cond() {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("timed out waiting for %s", what)
+}
+
+func TestSource_AddServerValidationErrors(t *testing.T) {
+	src := NewSource(WithConnectTimeout(50 * time.Millisecond))
+	t.Cleanup(func() { _ = src.Close() })
+
+	ctx := context.Background()
+	if err := src.AddServer(ctx, "  ", &blockingTransport{}); !errdefs.IsValidation(err) {
+		t.Fatalf("empty name error = %v, want Validation", err)
+	}
+	if err := src.AddServer(ctx, "nil", nil); !errdefs.IsValidation(err) {
+		t.Fatalf("nil transport error = %v, want Validation", err)
+	}
+
+	if err := src.AddServer(ctx, "dup", &blockingTransport{}); err != nil {
+		t.Fatalf("first AddServer: %v", err)
+	}
+	if err := src.AddServer(ctx, "dup", &blockingTransport{}); !errdefs.IsValidation(err) {
+		t.Fatalf("duplicate name error = %v, want Validation", err)
+	}
+}
+
+func TestSource_CanceledContextIsFatal(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	src := NewSource(WithConnectTimeout(time.Second))
+	t.Cleanup(func() { _ = src.Close() })
+
+	err := src.AddServer(ctx, "gone", &blockingTransport{})
+	if err == nil {
+		t.Fatal("AddServer with canceled context returned nil")
+	}
+	src.mu.Lock()
+	pending := len(src.retrying)
+	src.mu.Unlock()
+	if pending != 0 {
+		t.Fatalf("canceled context scheduled %d retries, want 0", pending)
+	}
+}
+
+func TestSource_InitialConnectPublishesTools(t *testing.T) {
+	ctx := context.Background()
+	clientT, serverT := mcpsdk.NewInMemoryTransports()
+	server := mcpsdk.NewServer(
+		&mcpsdk.Implementation{Name: "mem", Version: "test"}, nil)
+	server.AddTool(&mcpsdk.Tool{
+		Name:        "mem_tool",
+		InputSchema: map[string]any{"type": "object"},
+	}, func(_ context.Context, _ *mcpsdk.CallToolRequest) (*mcpsdk.CallToolResult, error) {
+		return &mcpsdk.CallToolResult{Content: []mcpsdk.Content{&mcpsdk.TextContent{Text: "ok"}}}, nil
+	})
+	go func() { _, _ = server.Connect(ctx, serverT, nil) }()
+
+	src := NewSource(WithConnectTimeout(2 * time.Second))
+	t.Cleanup(func() { _ = src.Close() })
+	reg := newRecordingRegistrar()
+	src.Attach(reg)
+
+	if err := src.AddServer(ctx, "mem", clientT); err != nil {
+		t.Fatalf("AddServer: %v", err)
+	}
+	if !reg.has("mem__mem_tool") {
+		t.Fatalf("mem__mem_tool not published; registrar has %v", reg.added)
+	}
+	tools := src.Tools()
+	if len(tools) != 1 || tools[0].Definition().Name != "mem__mem_tool" {
+		t.Fatalf("Tools() = %v, want [mem__mem_tool]", tools)
+	}
+}
+
+func TestSource_RetriesUntilServerComesUp(t *testing.T) {
+	src := NewSource(
+		WithConnectTimeout(2*time.Second),
+		WithRetryBackoff(20*time.Millisecond, 50*time.Millisecond),
+	)
+	t.Cleanup(func() { _ = src.Close() })
+	reg := newRecordingRegistrar()
+	src.Attach(reg)
+
+	ft := &failNTimesTransport{
+		remaining: 2,
+		inner: func() (mcpsdk.Transport, error) {
+			return helperStdio(0, 0)
+		},
+	}
+	if err := src.AddServer(context.Background(), "late", ft); err != nil {
+		t.Fatalf("AddServer: %v", err)
+	}
+	waitFor(t, 5*time.Second, "background retry to publish tools", func() bool {
+		return reg.has("late__helper_tool")
+	})
+	if got := ft.calls.Load(); got != 3 {
+		t.Fatalf("connect attempts = %d, want 3", got)
+	}
+}
+
+func TestSource_TimeoutFailureRetriesAndCloseStops(t *testing.T) {
+	src := NewSource(
+		WithConnectTimeout(40*time.Millisecond),
+		WithRetryBackoff(10*time.Millisecond, 20*time.Millisecond),
+	)
+	t.Cleanup(func() { _ = src.Close() })
+	bt := &blockingTransport{}
+
+	if err := src.AddServer(context.Background(), "slow", bt); err != nil {
+		t.Fatalf("AddServer: %v", err)
+	}
+	time.Sleep(150 * time.Millisecond)
+	if bt.connects.Load() < 2 {
+		t.Fatalf("expected background retries, got %d connects", bt.connects.Load())
+	}
+
+	if err := src.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	after := bt.connects.Load()
+	time.Sleep(100 * time.Millisecond)
+	if got := bt.connects.Load(); got != after {
+		t.Fatalf("connects grew after Close: %d -> %d", after, got)
+	}
+}
+
+func TestSource_ReconnectsAfterServerExit(t *testing.T) {
+	src := NewSource(
+		WithConnectTimeout(2*time.Second),
+		WithRetryBackoff(30*time.Millisecond, 100*time.Millisecond),
+		WithLivenessInterval(50*time.Millisecond),
+	)
+	t.Cleanup(func() { _ = src.Close() })
+
+	tport, err := helperStdio(0, 400)
+	if err != nil {
+		t.Fatalf("helperStdio: %v", err)
+	}
+	if err := src.AddServer(context.Background(), "dying", tport); err != nil {
+		t.Fatalf("AddServer: %v", err)
+	}
+	waitFor(t, 5*time.Second, "first connect", func() bool {
+		return len(src.Tools()) == 1
+	})
+	tool := src.Tools()[0]
+
+	execute := func() (string, error) {
+		return tool.Execute(context.Background(), "{}")
+	}
+	if _, err := execute(); err != nil {
+		t.Fatalf("execute before server exit: %v", err)
+	}
+
+	waitFor(t, 5*time.Second, "server death to surface as NotAvailable", func() bool {
+		_, err := execute()
+		return err != nil && errdefs.IsNotAvailable(err)
+	})
+	waitFor(t, 10*time.Second, "reconnect to restore execution", func() bool {
+		out, err := execute()
+		return err == nil && out == "ok"
+	})
+}

--- a/core/tool/mcp/transport.go
+++ b/core/tool/mcp/transport.go
@@ -1,6 +1,7 @@
 package mcp
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"os"
@@ -28,16 +29,39 @@ func Stdio(command string, args []string, env map[string]string) (mcpsdk.Transpo
 	if command == "" {
 		return nil, fmt.Errorf("mcp: stdio transport command is empty")
 	}
-	cmd := exec.Command(command, args...)
-	cmd.Stderr = os.Stderr
+	var envList []string
 	if len(env) > 0 {
-		cmd.Env = os.Environ()
+		envList = os.Environ()
 		for key, value := range env {
-			cmd.Env = append(cmd.Env, key+"="+value)
+			envList = append(envList, key+"="+value)
 		}
 	}
-	return &mcpsdk.CommandTransport{Command: cmd}, nil
+	return &reconnectableStdio{command: command, args: args, env: envList}, nil
 }
+
+// reconnectableStdio is a [mcpsdk.Transport] that spawns a fresh child
+// process on every Connect call. The SDK's CommandTransport wraps a
+// single *exec.Cmd and can therefore only be connected once; the
+// background reconnect path needs a transport that can be retried, so
+// each attempt builds a brand-new command and delegates to a fresh
+// CommandTransport (which owns the pipes and the SIGTERM/SIGKILL
+// shutdown sequence).
+type reconnectableStdio struct {
+	command string
+	args    []string
+	env     []string
+}
+
+func (t *reconnectableStdio) Connect(ctx context.Context) (mcpsdk.Connection, error) {
+	cmd := exec.Command(t.command, t.args...)
+	cmd.Stderr = os.Stderr
+	if t.env != nil {
+		cmd.Env = t.env
+	}
+	return (&mcpsdk.CommandTransport{Command: cmd}).Connect(ctx)
+}
+
+var _ mcpsdk.Transport = (*reconnectableStdio)(nil)
 
 // StreamableHTTP builds a transport that talks to a remote MCP server
 // over the streamable-HTTP binding: POST for requests, a standing SSE

--- a/core/tool/registry.go
+++ b/core/tool/registry.go
@@ -42,8 +42,10 @@ func WithConflictPolicy(p ConflictPolicy) Option {
 
 // Registry aggregates tools from many [Source] values. It implements
 // [Catalog]; the underlying execution surface for an Executor is the
-// same value. A Registry is immutable after construction — sources
-// are a build-time concern, not a runtime one.
+// same value. The tool set is fixed at construction — sources are a
+// build-time concern — and changes at runtime only through the
+// [Registrar] surface (Add/Remove), which deferred sources use to
+// publish tools discovered after construction.
 //
 // A Registry is safe for concurrent use. Close releases every
 // contributed tool that implements io.Closer (deferred proxies
@@ -95,6 +97,34 @@ func NewRegistry(sources []Source, opts ...Option) (*Registry, error) {
 	return r, nil
 }
 
+// Add registers one tool at runtime. It follows the same duplicate
+// policy as construction and fails after Close.
+func (r *Registry) Add(t Tool) error {
+	if t == nil {
+		return errdefs.Validationf("tool: nil tool")
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.closed {
+		return errdefs.NotAvailablef("tool: registry is closed")
+	}
+	return r.addLocked(t)
+}
+
+// Remove unregisters the named tool at runtime. Unknown names are
+// ignored; after Close it is a no-op.
+func (r *Registry) Remove(name string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	delete(r.tools, name)
+	for i, n := range r.order {
+		if n == name {
+			r.order = append(r.order[:i], r.order[i+1:]...)
+			break
+		}
+	}
+}
+
 func (r *Registry) add(t Tool) error {
 	def := t.Definition()
 	if strings.TrimSpace(def.Name) == "" {
@@ -102,6 +132,14 @@ func (r *Registry) add(t Tool) error {
 	}
 	r.mu.Lock()
 	defer r.mu.Unlock()
+	return r.addLocked(t)
+}
+
+func (r *Registry) addLocked(t Tool) error {
+	def := t.Definition()
+	if strings.TrimSpace(def.Name) == "" {
+		return errdefs.Validationf("tool: tool definition name is required")
+	}
 	if _, exists := r.tools[def.Name]; exists {
 		if r.conflict == ConflictError {
 			return errdefs.Conflictf(
@@ -114,6 +152,8 @@ func (r *Registry) add(t Tool) error {
 	r.order = append(r.order, def.Name)
 	return nil
 }
+
+var _ Registrar = (*Registry)(nil)
 
 // Get implements Catalog. A deferred tool returns its proxy, which
 // serves the placeholder definition until first Execute.

--- a/core/tool/registry_test.go
+++ b/core/tool/registry_test.go
@@ -3,7 +3,9 @@ package tool_test
 import (
 	"context"
 	"errors"
+	"fmt"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"testing"
 
@@ -170,4 +172,107 @@ func TestRegistry_RejectsNilSourceAndBadLazyTool(t *testing.T) {
 	if !errdefs.IsValidation(err) {
 		t.Fatalf("placeholder mismatch error = %v, want Validation", err)
 	}
+}
+
+func TestRegistry_AddRemoveAtRuntime(t *testing.T) {
+	reg, err := tool.NewRegistry(nil)
+	if err != nil {
+		t.Fatalf("NewRegistry: %v", err)
+	}
+	if err := reg.Add(funcTool("late", "late")); err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+	if _, ok := reg.Get("late"); !ok {
+		t.Fatal("Get(late) missing after Add")
+	}
+	if !containsDefinition(reg.Definitions(), "late") {
+		t.Fatalf("Definitions after Add = %v", reg.Definitions())
+	}
+
+	reg.Remove("late")
+	if _, ok := reg.Get("late"); ok {
+		t.Fatal("Get(late) still present after Remove")
+	}
+	if reg.Len() != 0 {
+		t.Fatalf("Len = %d, want 0", reg.Len())
+	}
+}
+
+func TestRegistry_AddDuplicateRuntimeFollowsPolicy(t *testing.T) {
+	reg, err := tool.NewRegistry([]tool.Source{
+		source{tools: []tool.Tool{funcTool("dup", "first")}},
+	})
+	if err != nil {
+		t.Fatalf("NewRegistry: %v", err)
+	}
+	if err := reg.Add(funcTool("dup", "second")); !errdefs.IsConflict(err) {
+		t.Fatalf("Add duplicate error = %v, want Conflict", err)
+	}
+
+	overwrite, err := tool.NewRegistry(nil, tool.WithConflictPolicy(tool.ConflictOverwrite))
+	if err != nil {
+		t.Fatalf("NewRegistry: %v", err)
+	}
+	if err := overwrite.Add(funcTool("dup", "runtime")); err != nil {
+		t.Fatalf("Add with overwrite: %v", err)
+	}
+	got, _ := overwrite.Get("dup")
+	if !strings.Contains(mustExecute(t, got), "runtime") {
+		t.Fatalf("overwritten runtime tool executes %q", mustExecute(t, got))
+	}
+}
+
+func TestRegistry_AddRejectsNilAndClosed(t *testing.T) {
+	reg, err := tool.NewRegistry(nil)
+	if err != nil {
+		t.Fatalf("NewRegistry: %v", err)
+	}
+	if err := reg.Add(nil); !errdefs.IsValidation(err) {
+		t.Fatalf("nil Add error = %v, want Validation", err)
+	}
+	if err := reg.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	if err := reg.Add(funcTool("after", "close")); !errdefs.IsNotAvailable(err) {
+		t.Fatalf("Add after Close error = %v, want NotAvailable", err)
+	}
+	// Remove after Close is a documented no-op and must not panic.
+	reg.Remove("after")
+}
+
+func TestRegistry_ConcurrentAddRemove(t *testing.T) {
+	reg, err := tool.NewRegistry(nil)
+	if err != nil {
+		t.Fatalf("NewRegistry: %v", err)
+	}
+	const workers = 8
+	const perWorker = 50
+	var wg sync.WaitGroup
+	for w := range workers {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for i := range perWorker {
+				name := fmt.Sprintf("t-%d-%d", w, i)
+				if err := reg.Add(funcTool(name, "x")); err != nil {
+					t.Errorf("Add %s: %v", name, err)
+					return
+				}
+				reg.Remove(name)
+			}
+		}()
+	}
+	wg.Wait()
+	if reg.Len() != 0 {
+		t.Fatalf("Len = %d, want 0 after concurrent add/remove", reg.Len())
+	}
+}
+
+func containsDefinition(defs []message.ToolDefinition, name string) bool {
+	for _, def := range defs {
+		if def.Name == name {
+			return true
+		}
+	}
+	return false
 }

--- a/core/tool/source.go
+++ b/core/tool/source.go
@@ -22,6 +22,25 @@ type Source interface {
 	LazyTools() []LazyTool
 }
 
+// Registrar is the runtime mutation surface of a [Registry]. Sources
+// that discover tools after construction — an MCP server that connects
+// in the background, a refresh that re-lists remote tools — use it to
+// publish tools as they become available.
+type Registrar interface {
+	// Add registers one tool. Duplicate names follow the registry's
+	// ConflictPolicy; adding to a closed registry returns an error.
+	Add(t Tool) error
+	// Remove unregisters the named tool, if present.
+	Remove(name string)
+}
+
+// RegistryAttacher is an optional [Source] capability: the assembly
+// hands the built [Registry]'s [Registrar] to sources that need to
+// publish tools after construction (background connects, refresh).
+type RegistryAttacher interface {
+	Attach(r Registrar)
+}
+
 // LazyTool is a deferred tool descriptor contributed by a Source.
 // Name must equal Placeholder.Name; Load performs any network or
 // process work the tool needs.

--- a/docs/guides/tool.md
+++ b/docs/guides/tool.md
@@ -59,7 +59,13 @@ resources:
           tool_search: always
 ```
 
-MCP servers are registered as a `tool.Source/mcp` resource. Middleware lives
-in `core/tool/middleware`.
+MCP servers are registered as a `tool.Source/mcp` resource. Attach is
+best-effort: a server that is unreachable at startup is retried in the
+background with exponential backoff, and its tools are published to the
+registry the moment it connects. A server that dies later is
+reconnected the same way; its tools stay registered and calls fail with
+a per-server `NotAvailable` error until the connection is restored.
+Configuration errors (a rejected connection, an invalid spec) still
+fail the deployment. Middleware lives in `core/tool/middleware`.
 
 See [runtime.md](runtime.md) for per-session dynamic catalogs.


### PR DESCRIPTION
## Summary

MCP server attach failures currently fail the whole deployment, and a
server that connects after startup — or dies and recovers — can never
contribute tools to an already-built registry. This change makes the
tool registry runtime-mutable and turns MCP connection into a
background-converging process.

## Changes

**core/tool**
- Add `Registrar` interface (`Add`/`Remove`) implemented by `Registry`;
  runtime additions follow the existing conflict policy and fail after
  `Close`.
- Add optional `RegistryAttacher` source capability; `NewAssembly`
  hands the built registry to implementing sources after construction.
- `Registry` doc contract updated: the tool set is fixed at
  construction and changes at runtime only through `Registrar`.

**core/tool/mcp**
- `AddServer` attempts to connect immediately; unreachable/timeout
  failures schedule background reconnection with exponential backoff
  (1s→30s capped) instead of failing the host, and tools are published
  to the attached registrar when the server comes up. Validation /
  rejection failures and a canceled caller context remain fatal.
- Connected servers are ping-monitored (`session.Ping`) and reconnected
  on death; the tool projection is kept so calls fail with per-server
  `NotAvailable` until the connection is restored. Retries stop on
  validation-class errors instead of churning.
- `Stdio` transport is now re-connectable: each `Connect` spawns a
  fresh child process (the SDK's `CommandTransport` wraps a single
  `exec.Cmd` and cannot be reused).
- Retry lifecycle is owned by the `Source` (canceled on `Close`), not
  the request-scoped attach context.

**Docs**: `docs/guides/tool.md`, `core/tool/mcp/doc.go` updated for the
new attach/reconnect semantics.

## Tests

- `core/tool`: registrar Add/Remove/conflict/closed/concurrent;
  assembly `RegistryAttacher` wiring.
- `core/tool/mcp`: end-to-end via a stdio helper process — background
  retry publishes tools once the server comes up, a server that exits
  mid-session is reconnected and execution recovers, validation stays
  fatal, canceled context is fatal, `Close` stops retries.
- Verified: `make ci`, `make release-check`, `git diff --check` all
  pass; golangci-lint is clean for every module this change touches.

Closes #320