### PR TITLE
fix(core): make sandbox.Runner lifecycle part of the contract

### DIFF
--- a/core/agent/scriptrt/jsrt/bindings_bridge_shell_test.go
+++ b/core/agent/scriptrt/jsrt/bindings_bridge_shell_test.go
@@ -18,6 +18,10 @@ type fakeCommandRunner struct {
 	exitCode int
 }
 
+func (f *fakeCommandRunner) Close() error {
+	return nil
+}
+
 func (f *fakeCommandRunner) Capabilities() sandbox.Capabilities {
 	return sandbox.Capabilities{}
 }
@@ -37,6 +41,10 @@ func (f *fakeCommandRunner) Terminate(context.Context, string) error {
 // errorCommandRunner always fails — used to verify the bridge's error
 // translation branch (Go err → exit_code -1 + stderr).
 type errorCommandRunner struct{ err error }
+
+func (e *errorCommandRunner) Close() error {
+	return nil
+}
 
 func (e *errorCommandRunner) Capabilities() sandbox.Capabilities {
 	return sandbox.Capabilities{}

--- a/core/graph/nodes/script/node_test.go
+++ b/core/graph/nodes/script/node_test.go
@@ -252,6 +252,7 @@ func (stubWorkspace) Stat(context.Context, string) (fs.FileInfo, error) { return
 
 type stubRunner struct{}
 
+func (stubRunner) Close() error                       { return nil }
 func (stubRunner) Capabilities() sandbox.Capabilities { return sandbox.Capabilities{} }
 func (stubRunner) Start(context.Context, sandbox.SessionSpec) (sandbox.Session, error) {
 	return nil, errdefs.NotAvailablef("script node test: stub runner cannot start sessions")

--- a/core/sandbox/approval.go
+++ b/core/sandbox/approval.go
@@ -234,6 +234,11 @@ func (r *approvalRunner) Capabilities() Capabilities {
 	return r.inner.Capabilities()
 }
 
+// Close forwards to the inner runner so lifecycle survives decoration.
+func (r *approvalRunner) Close() error {
+	return r.inner.Close()
+}
+
 // CommandPatterns returns a predicate that matches when the command's
 // base name glob-matches any of the patterns (e.g. "rm", "dd",
 // "git"). It inspects the command string only — a shell invocation

--- a/core/sandbox/bwrap/runner_linux.go
+++ b/core/sandbox/bwrap/runner_linux.go
@@ -153,6 +153,12 @@ func (r *Runner) Terminate(ctx context.Context, id string) error {
 	return r.sessions.Terminate(ctx, id)
 }
 
+// Close implements core/sandbox.Runner: it terminates every session
+// started through this runner. Safe to call more than once.
+func (r *Runner) Close() error {
+	return r.sessions.Close()
+}
+
 // spawnProcess is the core sandbox SessionStarter. It builds the bwrap
 // invocation from the SessionSpec and hands it to the shared session
 // implementation.

--- a/core/sandbox/bwrap/runner_other.go
+++ b/core/sandbox/bwrap/runner_other.go
@@ -39,3 +39,8 @@ func (*Runner) List(context.Context) ([]sandbox.SessionInfo, error) {
 func (*Runner) Terminate(context.Context, string) error {
 	return errdefs.NotAvailablef("bwrap: not available on this platform")
 }
+
+// Close is unreachable outside Linux.
+func (*Runner) Close() error {
+	return errdefs.NotAvailablef("bwrap: not available on this platform")
+}

--- a/core/sandbox/contract.go
+++ b/core/sandbox/contract.go
@@ -11,12 +11,22 @@ import (
 // an errdefs.NotAvailable error rather than silently downgrading the
 // request.
 //
+// Lifecycle is part of the contract, not a convention: Close releases
+// every resource the runner owns — active sessions, forked daemons,
+// sockets, backend state. Decorators MUST forward Close to their inner
+// runner so wrapping never hides the backend's cleanup.
+//
 // Capabilities is mandatory: it is the explicit, wire-safe declaration
 // of what this backend can do. Callers and tools never discover
 // features through interface assertions — unsupported operations on a
 // returned [Session] fail with errdefs.NotAvailable, and Capabilities
 // says up front why.
 type Runner interface {
+	// Close releases every resource owned by the runner. It must be
+	// safe to call more than once and when nothing was ever started;
+	// implementations should terminate active sessions rather than
+	// silently abandoning them.
+	Close() error
 	Capabilities() Capabilities
 	Start(ctx context.Context, spec SessionSpec) (Session, error)
 	List(ctx context.Context) ([]SessionInfo, error)

--- a/core/sandbox/decorator.go
+++ b/core/sandbox/decorator.go
@@ -68,6 +68,11 @@ func (r *allowCommandsRunner) Capabilities() Capabilities {
 	return r.inner.Capabilities()
 }
 
+// Close forwards to the inner runner so lifecycle survives decoration.
+func (r *allowCommandsRunner) Close() error {
+	return r.inner.Close()
+}
+
 // WithDefaults returns a Runner that merges defaults into every Exec
 // call's ExecOptions before delegating to inner. It is the
 // composition seam that lets a runtime owner (typically a host
@@ -162,6 +167,11 @@ func (r *defaultsRunner) Terminate(ctx context.Context, id string) error {
 // which session features it provides.
 func (r *defaultsRunner) Capabilities() Capabilities {
 	return r.inner.Capabilities()
+}
+
+// Close forwards to the inner runner so lifecycle survives decoration.
+func (r *defaultsRunner) Close() error {
+	return r.inner.Close()
 }
 
 // merge applies the rules documented on [WithDefaults]. Kept on a

--- a/core/sandbox/decorator_test.go
+++ b/core/sandbox/decorator_test.go
@@ -1,0 +1,78 @@
+package sandbox_test
+
+import (
+	"context"
+	"io"
+	"testing"
+
+	"github.com/GizClaw/flowcraft/core/sandbox"
+)
+
+// closingRunner records whether Close reached it, so tests can prove
+// that decoration does not hide the inner runner's lifecycle.
+type closingRunner struct {
+	closed bool
+}
+
+func (r *closingRunner) Close() error {
+	r.closed = true
+	return nil
+}
+
+func (r *closingRunner) Capabilities() sandbox.Capabilities {
+	return sandbox.Capabilities{}
+}
+
+func (r *closingRunner) Start(context.Context, sandbox.SessionSpec) (sandbox.Session, error) {
+	return nil, nil
+}
+
+func (r *closingRunner) List(context.Context) ([]sandbox.SessionInfo, error) {
+	return nil, nil
+}
+
+func (r *closingRunner) Terminate(context.Context, string) error {
+	return nil
+}
+
+// TestDecoratorsForwardClose exercises the full recommended chain —
+// WithDefaults(WithApproval(AllowCommands(inner))) — and asserts that
+// Close reaches the backend exactly once through every decorator.
+func TestDecoratorsForwardClose(t *testing.T) {
+	inner := &closingRunner{}
+	runner := sandbox.WithDefaults(
+		sandbox.WithApproval(
+			sandbox.AllowCommands(inner, nil),
+			nil, nil,
+		),
+		sandbox.ExecOptions{},
+	)
+
+	closer, ok := runner.(io.Closer)
+	if !ok {
+		t.Fatal("decorated runner must implement io.Closer")
+	}
+	if err := closer.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	if !inner.closed {
+		t.Fatal("Close was not forwarded to the inner runner")
+	}
+}
+
+// TestRunnerCloseIsIdempotent verifies the contract that Close is safe
+// to call more than once and when nothing was ever started.
+func TestRunnerCloseIsIdempotent(t *testing.T) {
+	runner := sandbox.WithDefaults(
+		sandbox.WithApproval(
+			sandbox.AllowCommands(&closingRunner{}, nil),
+			nil, nil,
+		),
+		sandbox.ExecOptions{},
+	)
+	for i := 0; i < 2; i++ {
+		if err := runner.Close(); err != nil {
+			t.Fatalf("Close #%d: %v", i+1, err)
+		}
+	}
+}

--- a/core/sandbox/doc.go
+++ b/core/sandbox/doc.go
@@ -11,7 +11,10 @@
 // changing call sites. Every Runner declares [Capabilities] up front —
 // policy enforcement and session features — and every started [Session]
 // declares its own [SessionCapabilities], so tools never discover
-// abilities through interface assertions.
+// abilities through interface assertions. Lifecycle is part of the
+// contract too: every Runner implements Close, which terminates active
+// sessions and releases backend-owned resources, and the decorators
+// forward it so wrapping never hides the backend's cleanup.
 //
 // ExecOptions carries three policy groups beyond the obvious WorkDir /
 // Stdin / Timeout knobs:

--- a/core/sandbox/local/local.go
+++ b/core/sandbox/local/local.go
@@ -125,6 +125,13 @@ func (r *Runner) Terminate(ctx context.Context, id string) error {
 	return r.registry().Terminate(ctx, id)
 }
 
+// Close implements core/sandbox.Runner: it terminates every session
+// started through this runner. Safe to call more than once and when the
+// runner never started anything.
+func (r *Runner) Close() error {
+	return r.registry().Close()
+}
+
 // registry returns the session registry, initialising it lazily so a
 // zero-value Runner still answers with NotAvailable instead of
 // panicking on a nil interface.

--- a/core/sandbox/seatbelt/runner_darwin.go
+++ b/core/sandbox/seatbelt/runner_darwin.go
@@ -131,6 +131,12 @@ func (r *Runner) Terminate(ctx context.Context, id string) error {
 	return r.sessions.Terminate(ctx, id)
 }
 
+// Close implements core/sandbox.Runner: it terminates every session
+// started through this runner. Safe to call more than once.
+func (r *Runner) Close() error {
+	return r.sessions.Close()
+}
+
 // spawnProcess is the core sandbox SessionStarter.
 func (r *Runner) spawnProcess(
 	ctx context.Context,

--- a/core/sandbox/seatbelt/runner_other.go
+++ b/core/sandbox/seatbelt/runner_other.go
@@ -39,3 +39,8 @@ func (*Runner) List(context.Context) ([]sandbox.SessionInfo, error) {
 func (*Runner) Terminate(context.Context, string) error {
 	return errdefs.NotAvailablef("seatbelt: not available on this platform")
 }
+
+// Close is unreachable outside macOS.
+func (*Runner) Close() error {
+	return errdefs.NotAvailablef("seatbelt: not available on this platform")
+}

--- a/core/sandbox/session_registry.go
+++ b/core/sandbox/session_registry.go
@@ -2,6 +2,7 @@ package sandbox
 
 import (
 	"context"
+	"errors"
 	"sort"
 	"sync"
 	"time"
@@ -169,6 +170,28 @@ func (r *SessionRegistry) Terminate(ctx context.Context, id string) error {
 	}
 	r.mu.Unlock()
 	return nil
+}
+
+// Close terminates every session still tracked by the registry. It is
+// the lifecycle drain backends delegate to from [Runner.Close]: after
+// Close returns, no session started through this registry remains
+// running. Records are kept so List still reports what ran; repeated
+// calls are safe because Terminate skips already-exited sessions.
+func (r *SessionRegistry) Close() error {
+	r.mu.Lock()
+	ids := make([]string, 0, len(r.sessions))
+	for id := range r.sessions {
+		ids = append(ids, id)
+	}
+	r.mu.Unlock()
+
+	var errs []error
+	for _, id := range ids {
+		if err := r.Terminate(context.Background(), id); err != nil {
+			errs = append(errs, err)
+		}
+	}
+	return errors.Join(errs...)
 }
 
 func (r *SessionRegistry) remove(id string) {

--- a/core/sandbox/session_test.go
+++ b/core/sandbox/session_test.go
@@ -134,3 +134,36 @@ func TestSessionSignal(t *testing.T) {
 		t.Fatalf("exit = %+v, want non-zero/signaled after interrupt", exit)
 	}
 }
+
+// TestRunnerCloseTerminatesSessions verifies that Runner.Close drains
+// every active session: after Close, no session started through the
+// runner is still running.
+func TestRunnerCloseTerminatesSessions(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	r := local.New(t.TempDir())
+
+	sess, err := r.Start(ctx, sandbox.SessionSpec{
+		Argv: []string{"sleep", "30"},
+	})
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer func() { _ = sess.Close() }()
+
+	if err := r.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	exit, err := sess.Wait(ctx)
+	if err != nil {
+		t.Fatalf("Wait after Close: %v", err)
+	}
+	if exit.Code == 0 && exit.Reason == sandbox.SessionExited {
+		t.Fatalf("exit = %+v, want non-zero/signaled after runner Close", exit)
+	}
+
+	// A second Close must be safe and must not error.
+	if err := r.Close(); err != nil {
+		t.Fatalf("second Close: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

`sandbox.Runner` owns resources (child processes, sockets, sandbox backends), but lifecycle was only a convention (`io.Closer`) instead of part of the contract. The decorators — `WithApproval`, `WithDefaults`, `AllowCommands` — returned a `Runner` without forwarding closer-ness, so `deploy.Result.Close` → `closeAll` silently skipped a decorated runner's inner `Close` at shutdown, leaking daemon children (see #318).

## Changes

- Add `Close() error` to the `sandbox.Runner` interface and document that lifecycle is part of the contract.
- `approvalRunner`, `allowCommandsRunner`, `defaultsRunner` now forward `Close` to the inner runner, so wrapping never hides the backend's cleanup.
- Add `SessionRegistry.Close` (terminates every tracked session) and implement `Close` on `local.Runner`, `bwrap.Runner`, `seatbelt.Runner` (platform stubs return `NotAvailable`), all idempotent.
- No change needed in the deploy framework: `closeAll` already closes `io.Closer` values, and decorated runners now implement it.
- Tests: decorator chain forwards `Close` to the backend; `Runner.Close` terminates active sessions and is idempotent.

## Verification

- `make ci` — pass
- `make lint` — 0 issues
- `make release-check` — no pending releases
- `git diff --check` — clean

Fixes #318