### PR TITLE
fix(core): bound SessionRegistry.Close and wait out start races

### DIFF
--- a/core/sandbox/session_registry.go
+++ b/core/sandbox/session_registry.go
@@ -17,6 +17,13 @@ import (
 // stall) must not wedge the manager forever.
 const registryWaitTimeout = 10 * time.Second
 
+// registryCloseTimeout bounds the whole Close drain. Terminate's own
+// state sync is capped by registryWaitTimeout, but the per-session
+// Terminate call has no deadline of its own; sharing one deadline
+// across Close guarantees a Session whose Terminate blocks cannot
+// wedge shutdown indefinitely.
+const registryCloseTimeout = 30 * time.Second
+
 // SessionStarter implements one backend's spawn: it turns a SessionSpec
 // into a launched Session. It is the injection seam shared by every
 // backend's Runner (local, remote, and future seatbelt/bwrap) so
@@ -56,6 +63,11 @@ type sessionRecord struct {
 	exited  bool
 	exit    SessionExit
 	err     error
+	// ready is closed once the spawn settles: the session is assigned
+	// (spawn succeeded) or the record was removed (spawn failed). It
+	// lets Close wait out a start race instead of failing on a session
+	// that is still starting.
+	ready chan struct{}
 }
 
 func (r *SessionRegistry) Start(ctx context.Context, spec SessionSpec) (Session, error) {
@@ -70,7 +82,12 @@ func (r *SessionRegistry) Start(ctx context.Context, spec SessionSpec) (Session,
 		id = xid.New().String()
 	}
 
-	rec := &sessionRecord{id: id, spec: spec, started: time.Now()}
+	rec := &sessionRecord{
+		id:      id,
+		spec:    spec,
+		started: time.Now(),
+		ready:   make(chan struct{}),
+	}
 	r.mu.Lock()
 	if _, exists := r.sessions[id]; exists {
 		r.mu.Unlock()
@@ -85,10 +102,12 @@ func (r *SessionRegistry) Start(ctx context.Context, spec SessionSpec) (Session,
 	sess, err := r.starter(ctx, spec)
 	if err != nil {
 		r.remove(id)
+		close(rec.ready)
 		return nil, err
 	}
 	if sess == nil {
 		r.remove(id)
+		close(rec.ready)
 		return nil, errdefs.Internalf("sandbox: session starter returned a nil session")
 	}
 
@@ -96,6 +115,7 @@ func (r *SessionRegistry) Start(ctx context.Context, spec SessionSpec) (Session,
 	rec.session = sess
 	rec.pid = sess.PID()
 	r.mu.Unlock()
+	close(rec.ready)
 
 	go r.track(id, sess)
 	return &registrySession{inner: sess, reg: r, id: id}, nil
@@ -142,17 +162,20 @@ func (r *SessionRegistry) List(context.Context) ([]SessionInfo, error) {
 func (r *SessionRegistry) Terminate(ctx context.Context, id string) error {
 	r.mu.Lock()
 	rec := r.sessions[id]
-	r.mu.Unlock()
 	if rec == nil {
+		r.mu.Unlock()
 		return errdefs.NotFoundf("sandbox: unknown session id %q", id)
 	}
-	if rec.exited {
+	exited := rec.exited
+	session := rec.session
+	r.mu.Unlock()
+	if exited {
 		return nil
 	}
-	if rec.session == nil {
+	if session == nil {
 		return errdefs.NotAvailablef("sandbox: session %q is still starting", id)
 	}
-	if err := rec.session.Terminate(ctx); err != nil {
+	if err := session.Terminate(ctx); err != nil {
 		return err
 	}
 	// Synchronise the record: List must reflect the termination as soon
@@ -177,7 +200,22 @@ func (r *SessionRegistry) Terminate(ctx context.Context, id string) error {
 // Close returns, no session started through this registry remains
 // running. Records are kept so List still reports what ran; repeated
 // calls are safe because Terminate skips already-exited sessions.
+//
+// Close is bounded: the whole drain shares one deadline
+// (registryCloseTimeout) so a Session whose Terminate blocks cannot
+// wedge shutdown. Sessions still starting are waited on rather than
+// reported as NotAvailable, so a start race does not fail Close.
 func (r *SessionRegistry) Close() error {
+	return r.closeWithTimeout(registryCloseTimeout)
+}
+
+// closeWithTimeout is Close with an explicit overall budget. It is
+// split out so tests can exercise the deadline without waiting the
+// full registryCloseTimeout.
+func (r *SessionRegistry) closeWithTimeout(timeout time.Duration) error {
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
 	r.mu.Lock()
 	ids := make([]string, 0, len(r.sessions))
 	for id := range r.sessions {
@@ -187,11 +225,45 @@ func (r *SessionRegistry) Close() error {
 
 	var errs []error
 	for _, id := range ids {
-		if err := r.Terminate(context.Background(), id); err != nil {
+		if err := r.closeOne(ctx, id); err != nil {
 			errs = append(errs, err)
 		}
 	}
 	return errors.Join(errs...)
+}
+
+// closeOne terminates one session for Close. When the session is still
+// starting (its record is published before the spawn returns), it waits
+// for the spawn to settle — bounded by ctx — so a start race does not
+// surface as a spurious NotAvailable error. A record that vanished in
+// the meantime (spawn failed, or the session was already closed) has
+// nothing to drain and is not an error.
+func (r *SessionRegistry) closeOne(ctx context.Context, id string) error {
+	r.mu.Lock()
+	rec := r.sessions[id]
+	starting := rec != nil && rec.session == nil && !rec.exited
+	r.mu.Unlock()
+
+	if rec == nil {
+		return nil
+	}
+	if starting {
+		select {
+		case <-rec.ready:
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+		r.mu.Lock()
+		rec = r.sessions[id]
+		r.mu.Unlock()
+		if rec == nil {
+			return nil
+		}
+	}
+	if err := r.Terminate(ctx, id); err != nil && !errdefs.IsNotFound(err) {
+		return err
+	}
+	return nil
 }
 
 func (r *SessionRegistry) remove(id string) {

--- a/core/sandbox/session_registry_internal_test.go
+++ b/core/sandbox/session_registry_internal_test.go
@@ -1,0 +1,199 @@
+package sandbox
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+)
+
+// registryTestSession is a hermetic Session used to exercise
+// SessionRegistry bookkeeping without spawning processes.
+type registryTestSession struct {
+	terminated chan struct{}
+	once       sync.Once
+}
+
+func (s *registryTestSession) ID() string { return "test-session" }
+func (s *registryTestSession) PID() int   { return 42 }
+
+func (s *registryTestSession) Read(context.Context, int64, int) (SessionOutput, error) {
+	return SessionOutput{}, nil
+}
+
+func (s *registryTestSession) Write(context.Context, []byte) error { return nil }
+func (s *registryTestSession) CloseInput() error                   { return nil }
+func (s *registryTestSession) Resize(context.Context, int, int) error {
+	return nil
+}
+func (s *registryTestSession) Signal(context.Context, SessionSignal) error { return nil }
+func (s *registryTestSession) Terminate(context.Context) error {
+	if s.terminated != nil {
+		s.once.Do(func() { close(s.terminated) })
+	}
+	return nil
+}
+func (s *registryTestSession) Wait(ctx context.Context) (SessionExit, error) {
+	// Mirror a real session: Wait blocks until the process exits, i.e.
+	// until Terminate fires. Without this, the registry's background
+	// tracker would mark the record exited before Close's Terminate
+	// runs, and Terminate would skip the still-"running" session.
+	if s.terminated != nil {
+		select {
+		case <-s.terminated:
+		case <-ctx.Done():
+			return SessionExit{}, ctx.Err()
+		}
+	}
+	return SessionExit{Reason: SessionExited, Code: 0}, nil
+}
+func (s *registryTestSession) Watch(context.Context) (SessionWatcher, error) {
+	return nil, nil
+}
+func (s *registryTestSession) Close() error { return nil }
+func (s *registryTestSession) Capabilities() SessionCapabilities {
+	return SessionCapabilities{}
+}
+
+// blockingTerminateSession simulates a Session whose Terminate ignores
+// context cancellation — Close must still be bounded by its deadline.
+type blockingTerminateSession struct {
+	registryTestSession
+}
+
+func (s *blockingTerminateSession) Terminate(ctx context.Context) error {
+	<-ctx.Done()
+	return ctx.Err()
+}
+
+// TestSessionRegistryCloseWaitsForStartingSession verifies that Close
+// does not fail with NotAvailable when a session is still spawning:
+// it waits for the spawn to settle and then terminates the session.
+func TestSessionRegistryCloseWaitsForStartingSession(t *testing.T) {
+	spawnStarted := make(chan struct{})
+	releaseSpawn := make(chan struct{})
+	terminated := make(chan struct{})
+	sess := &registryTestSession{terminated: terminated}
+	starter := func(ctx context.Context, _ SessionSpec) (Session, error) {
+		close(spawnStarted)
+		select {
+		case <-releaseSpawn:
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		}
+		return sess, nil
+	}
+	reg := NewSessionRegistry(starter)
+
+	var startErr error
+	startDone := make(chan struct{})
+	go func() {
+		defer close(startDone)
+		_, startErr = reg.Start(context.Background(), SessionSpec{Argv: []string{"x"}})
+	}()
+	<-spawnStarted // record exists; session not yet assigned
+
+	closeDone := make(chan error, 1)
+	go func() { closeDone <- reg.Close() }()
+
+	select {
+	case err := <-closeDone:
+		t.Fatalf("Close returned before the starting session settled: %v", err)
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	close(releaseSpawn)
+	select {
+	case err := <-closeDone:
+		if err != nil {
+			t.Fatalf("Close: %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("Close did not wait for the starting session")
+	}
+	select {
+	case <-terminated:
+	case <-time.After(5 * time.Second):
+		t.Fatal("starting session was not terminated by Close")
+	}
+	select {
+	case <-startDone:
+	case <-time.After(5 * time.Second):
+		t.Fatal("Start did not return")
+	}
+	if startErr != nil {
+		t.Fatalf("Start: %v", startErr)
+	}
+}
+
+// TestSessionRegistryCloseIgnoresVanishedSpawn verifies that Close
+// treats a spawn that fails while Close is waiting as a non-event:
+// the record is removed by Start, so there is nothing left to drain.
+func TestSessionRegistryCloseIgnoresVanishedSpawn(t *testing.T) {
+	spawnStarted := make(chan struct{})
+	releaseSpawn := make(chan struct{})
+	starter := func(ctx context.Context, _ SessionSpec) (Session, error) {
+		close(spawnStarted)
+		select {
+		case <-releaseSpawn:
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		}
+		return nil, errors.New("spawn failed")
+	}
+	reg := NewSessionRegistry(starter)
+
+	startDone := make(chan struct{})
+	go func() {
+		defer close(startDone)
+		_, _ = reg.Start(context.Background(), SessionSpec{Argv: []string{"x"}})
+	}()
+	<-spawnStarted
+
+	closeDone := make(chan error, 1)
+	go func() { closeDone <- reg.Close() }()
+	close(releaseSpawn)
+
+	select {
+	case err := <-closeDone:
+		if err != nil {
+			t.Fatalf("Close: %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("Close did not return after the spawn failed")
+	}
+	select {
+	case <-startDone:
+	case <-time.After(5 * time.Second):
+		t.Fatal("Start did not return")
+	}
+}
+
+// TestSessionRegistryCloseBoundedByDeadline verifies that Close honors
+// its overall budget even when a Session's Terminate ignores context
+// cancellation and blocks forever.
+func TestSessionRegistryCloseBoundedByDeadline(t *testing.T) {
+	starter := func(context.Context, SessionSpec) (Session, error) {
+		return &blockingTerminateSession{
+			// A non-nil terminated channel makes the embedded Wait
+			// block like a real running process, so the tracker does
+			// not mark the session exited before Close's Terminate.
+			registryTestSession: registryTestSession{terminated: make(chan struct{})},
+		}, nil
+	}
+	reg := NewSessionRegistry(starter)
+	if _, err := reg.Start(context.Background(), SessionSpec{Argv: []string{"x"}}); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	begin := time.Now()
+	err := reg.closeWithTimeout(100 * time.Millisecond)
+	elapsed := time.Since(begin)
+	if err == nil {
+		t.Fatal("Close succeeded despite a Terminate that ignores cancellation; want a deadline error")
+	}
+	if elapsed > 5*time.Second {
+		t.Fatalf("Close took %v; want it bounded by the close deadline", elapsed)
+	}
+}


### PR DESCRIPTION
Follow-up to #321, addressing two review points on `SessionRegistry.Close`.

## Changes

1. **Overall deadline for Close.** `Close` now runs under one shared deadline (`registryCloseTimeout`, 30s). Previously it passed `context.Background()` into `Terminate`, so a `Session` whose `Terminate` ignores cancellation could wedge shutdown indefinitely. The per-session `Wait` state sync stays capped by `registryWaitTimeout`; the new budget covers the whole drain.

2. **Start race no longer errors.** `Start` publishes the registry record before the spawn returns, so `Close` could hit `Terminate`'s "still starting" `NotAvailable` and fail spuriously. Each record now has a `ready` channel closed when the spawn settles; `Close` waits (bounded by the same deadline) for still-starting sessions and then terminates them. A record that vanished in the meantime (spawn failure, session already closed) is treated as already drained, not an error.

3. **Data race fix surfaced by the new tests.** `Terminate`'s initial `rec.exited`/`rec.session` reads were outside the registry mutex and raced with the background tracker; the concurrent `Close` tests exposed it under `-race`. The reads now happen under the lock.

## Tests

- `TestSessionRegistryCloseWaitsForStartingSession` — Close waits for a mid-spawn session and terminates it without error.
- `TestSessionRegistryCloseIgnoresVanishedSpawn` — a spawn that fails while Close is waiting is a non-event.
- `TestSessionRegistryCloseBoundedByDeadline` — a Terminate that blocks forever still lets Close return within budget.

All sandbox tests pass with `-race`.

## Verification

- `make ci` — pass
- `make lint` — 0 issues
- `make release-check` — no pending releases
- `git diff --check` — clean