### PR TITLE
fix(core): tighten MCP session lifecycle and tool projection

### DIFF
--- a/core/tool/mcp/source.go
+++ b/core/tool/mcp/source.go
@@ -412,8 +412,10 @@ func (s *Source) connect(
 
 // attachSession installs a connected session, reconciles the server's
 // tool projection, and registers the server on the Source unless it is
-// already there (a reconnect). On failure the session is closed and
-// srv.session is cleared, so a retry starts from a clean state.
+// already there (a reconnect). On failure — reconcile, a concurrently
+// closed Source, or an already-attached name — the session is closed
+// and srv.session is cleared, so a retry starts from a clean state and
+// no live connection is orphaned.
 func (s *Source) attachSession(
 	ctx context.Context,
 	srv *server,
@@ -424,25 +426,35 @@ func (s *Source) attachSession(
 	srv.mu.Unlock()
 
 	if err := s.reconcile(ctx, srv); err != nil {
-		srv.mu.Lock()
-		if srv.session == session {
-			srv.session = nil
-		}
-		srv.mu.Unlock()
-		_ = session.Close()
+		abandonAttach(srv, session)
 		return err
 	}
 
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	if s.closed {
+		abandonAttach(srv, session)
 		return errdefs.NotAvailablef("mcp: source is closed")
 	}
 	if other, exists := s.servers[srv.name]; exists && other != srv {
+		abandonAttach(srv, session)
 		return errdefs.Validationf("mcp: server %q is already attached", srv.name)
 	}
 	s.servers[srv.name] = srv
 	return nil
+}
+
+// abandonAttach tears down a session that failed to attach. It clears
+// srv.session when it still points at the failed session and then
+// closes it, so every attachSession error path releases the connection
+// exactly once.
+func abandonAttach(srv *server, session *mcpsdk.ClientSession) {
+	srv.mu.Lock()
+	if srv.session == session {
+		srv.session = nil
+	}
+	srv.mu.Unlock()
+	_ = session.Close()
 }
 
 // reconcile re-lists the server's tools and updates its projection,
@@ -459,18 +471,7 @@ func (s *Source) reconcile(ctx context.Context, srv *server) error {
 		return errdefs.NotAvailablef("mcp: server %q: list tools: %v", srv.name, err)
 	}
 
-	next := make([]sdktool.Tool, 0, len(res.Tools)+2)
-	for _, mt := range res.Tools {
-		if mt == nil || mt.Name == "" {
-			continue
-		}
-		next = append(next, newAdaptedTool(srv, srv.qualify(mt.Name), mt))
-	}
-	if srv.resources {
-		for _, spec := range resourceToolSpecs(srv) {
-			next = append(next, spec.tool)
-		}
-	}
+	next := projectTools(srv, res.Tools, srv.resources)
 
 	srv.mu.Lock()
 	added, removed := diffTools(srv.tools, next)
@@ -479,6 +480,37 @@ func (s *Source) reconcile(ctx context.Context, srv *server) error {
 
 	s.publish(added, removed)
 	return nil
+}
+
+// projectTools renders a server's tool list into the local projection,
+// keeping the first occurrence of each qualified name. MCP requires
+// tool names to be unique, but a misbehaving server may still return
+// duplicates; deduplicating here keeps srv.tools, the publish deltas,
+// and Tools() consistent. Resource bridge tools are appended when
+// enabled and lose to a same-named server tool.
+func projectTools(srv *server, list []*mcpsdk.Tool, resources bool) []sdktool.Tool {
+	next := make([]sdktool.Tool, 0, len(list)+2)
+	seen := make(map[string]struct{}, len(list)+2)
+	add := func(name string, t sdktool.Tool) {
+		if _, dup := seen[name]; dup {
+			return
+		}
+		seen[name] = struct{}{}
+		next = append(next, t)
+	}
+	for _, mt := range list {
+		if mt == nil || mt.Name == "" {
+			continue
+		}
+		name := srv.qualify(mt.Name)
+		add(name, newAdaptedTool(srv, name, mt))
+	}
+	if resources {
+		for _, spec := range resourceToolSpecs(srv) {
+			add(spec.tool.Definition().Name, spec.tool)
+		}
+	}
+	return next
 }
 
 // diffTools splits the move from old to next into additions and
@@ -585,7 +617,9 @@ func (s *Source) retryLoop(srv *server) {
 				go s.watch(srv)
 				return
 			}
-			_ = session.Close()
+			// attachSession owns the session on failure: every error
+			// path closes it and clears srv.session, so nothing to do
+			// here.
 			if errdefs.IsValidation(err) {
 				telemetry.Error(s.baseCtx, "mcp: server rejected attach, giving up",
 					otellog.String("server", srv.name),

--- a/core/tool/mcp/source_test.go
+++ b/core/tool/mcp/source_test.go
@@ -313,3 +313,188 @@ func TestSource_ReconnectsAfterServerExit(t *testing.T) {
 		return err == nil && out == "ok"
 	})
 }
+
+// countingTransport wraps a transport and counts Close calls on every
+// connection it hands out, so tests can assert exactly when sessions
+// are torn down.
+type countingTransport struct {
+	inner  mcpsdk.Transport
+	mu     sync.Mutex
+	closes int
+}
+
+func (t *countingTransport) Connect(ctx context.Context) (mcpsdk.Connection, error) {
+	conn, err := t.inner.Connect(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return &countingConn{Connection: conn, parent: t}, nil
+}
+
+func (t *countingTransport) closeCount() int {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return t.closes
+}
+
+type countingConn struct {
+	mcpsdk.Connection
+	parent *countingTransport
+}
+
+func (c *countingConn) Close() error {
+	c.parent.mu.Lock()
+	c.parent.closes++
+	c.parent.mu.Unlock()
+	return c.Connection.Close()
+}
+
+// connectCountingServer spins up an in-memory MCP server and returns a
+// connected client session whose transport counts Close calls.
+func connectCountingServer(t *testing.T, src *Source, name string) (*server, *mcpsdk.ClientSession, *countingTransport) {
+	t.Helper()
+	clientT, serverT := mcpsdk.NewInMemoryTransports()
+	mcpServer := mcpsdk.NewServer(&mcpsdk.Implementation{Name: name, Version: "test"}, nil)
+	mcpServer.AddTool(&mcpsdk.Tool{
+		Name:        "mem_tool",
+		InputSchema: map[string]any{"type": "object"},
+	}, func(_ context.Context, _ *mcpsdk.CallToolRequest) (*mcpsdk.CallToolResult, error) {
+		return &mcpsdk.CallToolResult{
+			Content: []mcpsdk.Content{&mcpsdk.TextContent{Text: "ok"}},
+		}, nil
+	})
+	go func() { _, _ = mcpServer.Connect(context.Background(), serverT, nil) }()
+
+	counting := &countingTransport{inner: clientT}
+	srv := &server{
+		name:       name,
+		prefix:     name + DefaultPrefixSeparator,
+		transport:  counting,
+		cfg:        &serverConfig{prefix: name + DefaultPrefixSeparator, clientName: "flowcraft", clientVer: "v1"},
+		clientName: "flowcraft",
+		clientVer:  "v1",
+	}
+	session, err := src.connect(context.Background(), srv, srv.cfg)
+	if err != nil {
+		t.Fatalf("connect %q: %v", name, err)
+	}
+	return srv, session, counting
+}
+
+// TestAttachSessionClosesSessionWhenSourceClosed locks in the closed
+// branch of attachSession: a session that connected while the Source
+// was closing must not be orphaned, because AddServer's retry path is
+// a no-op once the source is closed.
+func TestAttachSessionClosesSessionWhenSourceClosed(t *testing.T) {
+	src := NewSource(WithConnectTimeout(2 * time.Second))
+	srv, session, counting := connectCountingServer(t, src, "mem")
+
+	if err := src.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	err := src.attachSession(context.Background(), srv, session)
+	if !errdefs.IsNotAvailable(err) {
+		t.Fatalf("attachSession after Close = %v, want NotAvailable", err)
+	}
+	if got := counting.closeCount(); got != 1 {
+		t.Fatalf("session Close calls = %d, want 1 (orphaned session)", got)
+	}
+	srv.mu.Lock()
+	current := srv.session
+	srv.mu.Unlock()
+	if current != nil {
+		t.Fatal("srv.session still set after failed attach")
+	}
+}
+
+// TestAttachSessionClosesSessionWhenAlreadyAttached locks in the
+// duplicate branch: a second concurrent attach of the same server name
+// must close its own session rather than leak it.
+func TestAttachSessionClosesSessionWhenAlreadyAttached(t *testing.T) {
+	src := NewSource(WithConnectTimeout(2 * time.Second))
+	srv1, session1, _ := connectCountingServer(t, src, "mem")
+	if err := src.attachSession(context.Background(), srv1, session1); err != nil {
+		t.Fatalf("first attachSession: %v", err)
+	}
+
+	_, session2, counting2 := connectCountingServer(t, src, "mem")
+	srv2 := &server{
+		name:       "mem",
+		prefix:     "mem" + DefaultPrefixSeparator,
+		transport:  counting2,
+		cfg:        &serverConfig{prefix: "mem" + DefaultPrefixSeparator, clientName: "flowcraft", clientVer: "v1"},
+		clientName: "flowcraft",
+		clientVer:  "v1",
+	}
+	err := src.attachSession(context.Background(), srv2, session2)
+	if !errdefs.IsValidation(err) {
+		t.Fatalf("second attachSession = %v, want Validation", err)
+	}
+	if got := counting2.closeCount(); got != 1 {
+		t.Fatalf("duplicate session Close calls = %d, want 1 (orphaned session)", got)
+	}
+}
+
+// TestAttachSessionClosesSessionOnReconcileFailure verifies the
+// reconcile-failure path closes the session exactly once, which is
+// what makes retryLoop's own Close redundant.
+func TestAttachSessionClosesSessionOnReconcileFailure(t *testing.T) {
+	src := NewSource(WithConnectTimeout(2 * time.Second))
+	srv, session, counting := connectCountingServer(t, src, "mem")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	err := src.attachSession(ctx, srv, session)
+	if err == nil {
+		t.Fatal("attachSession with canceled context returned nil")
+	}
+	if got := counting.closeCount(); got != 1 {
+		t.Fatalf("session Close calls = %d, want 1", got)
+	}
+	srv.mu.Lock()
+	current := srv.session
+	srv.mu.Unlock()
+	if current != nil {
+		t.Fatal("srv.session still set after failed attach")
+	}
+}
+
+func TestProjectToolsDeduplicatesNames(t *testing.T) {
+	srv := &server{name: "s", prefix: "s" + DefaultPrefixSeparator}
+	dup := &mcpsdk.Tool{Name: "dup", InputSchema: map[string]any{"type": "object"}}
+	list := []*mcpsdk.Tool{
+		dup,
+		{Name: "other", InputSchema: map[string]any{"type": "object"}},
+		nil,
+		dup,
+		{Name: "", InputSchema: map[string]any{"type": "object"}},
+	}
+	tools := projectTools(srv, list, false)
+	if len(tools) != 2 {
+		t.Fatalf("projectTools returned %d tools, want 2 (deduped): %v", len(tools), toolNames(tools))
+	}
+	if tools[0].Definition().Name != "s"+DefaultPrefixSeparator+"dup" ||
+		tools[1].Definition().Name != "s"+DefaultPrefixSeparator+"other" {
+		t.Fatalf("projectTools = %v, want [s__dup s__other]", toolNames(tools))
+	}
+
+	// A server tool that collides with a resource bridge name wins; the
+	// projection must still be unique when resources are enabled.
+	withResource := []*mcpsdk.Tool{{Name: "list_resources", InputSchema: map[string]any{"type": "object"}}}
+	tools = projectTools(srv, withResource, true)
+	want := []string{
+		"s" + DefaultPrefixSeparator + "list_resources",
+		"s" + DefaultPrefixSeparator + "read_resource",
+	}
+	if len(tools) != 2 || tools[0].Definition().Name != want[0] || tools[1].Definition().Name != want[1] {
+		t.Fatalf("projectTools with resource collision = %v, want %v", toolNames(tools), want)
+	}
+}
+
+func toolNames(tools []sdktool.Tool) []string {
+	names := make([]string, 0, len(tools))
+	for _, tl := range tools {
+		names = append(names, tl.Definition().Name)
+	}
+	return names
+}

--- a/core/tool/mcp/transport.go
+++ b/core/tool/mcp/transport.go
@@ -19,7 +19,10 @@ import (
 // in the host's log stream rather than vanishing. Environment is the
 // caller's business: env entries are appended to the current
 // environment in "KEY=VALUE" form, so a caller can pass credentials
-// without exporting them process-wide.
+// without exporting them process-wide. The process environment is
+// re-read at every Connect, so a background reconnect sees the current
+// environment rather than a snapshot taken when the transport was
+// built; the caller-supplied env entries are captured at construction.
 //
 // Closing the session created from this transport closes the child's
 // stdin, waits, then escalates to SIGTERM and SIGKILL — the shutdown
@@ -29,14 +32,14 @@ func Stdio(command string, args []string, env map[string]string) (mcpsdk.Transpo
 	if command == "" {
 		return nil, fmt.Errorf("mcp: stdio transport command is empty")
 	}
-	var envList []string
+	var envCopy map[string]string
 	if len(env) > 0 {
-		envList = os.Environ()
+		envCopy = make(map[string]string, len(env))
 		for key, value := range env {
-			envList = append(envList, key+"="+value)
+			envCopy[key] = value
 		}
 	}
-	return &reconnectableStdio{command: command, args: args, env: envList}, nil
+	return &reconnectableStdio{command: command, args: args, env: envCopy}, nil
 }
 
 // reconnectableStdio is a [mcpsdk.Transport] that spawns a fresh child
@@ -45,20 +48,32 @@ func Stdio(command string, args []string, env map[string]string) (mcpsdk.Transpo
 // background reconnect path needs a transport that can be retried, so
 // each attempt builds a brand-new command and delegates to a fresh
 // CommandTransport (which owns the pipes and the SIGTERM/SIGKILL
-// shutdown sequence).
+// shutdown sequence). Each Connect rebuilds the child's environment
+// from the current process environment plus the caller's additions, so
+// reconnects never run against a stale snapshot.
 type reconnectableStdio struct {
 	command string
 	args    []string
-	env     []string
+	env     map[string]string
 }
 
-func (t *reconnectableStdio) Connect(ctx context.Context) (mcpsdk.Connection, error) {
+// newCommand builds the child command for one connection attempt.
+func (t *reconnectableStdio) newCommand() *exec.Cmd {
 	cmd := exec.Command(t.command, t.args...)
 	cmd.Stderr = os.Stderr
 	if t.env != nil {
-		cmd.Env = t.env
+		// os.Environ returns a fresh slice each call, so appending the
+		// caller's entries is safe.
+		cmd.Env = os.Environ()
+		for key, value := range t.env {
+			cmd.Env = append(cmd.Env, key+"="+value)
+		}
 	}
-	return (&mcpsdk.CommandTransport{Command: cmd}).Connect(ctx)
+	return cmd
+}
+
+func (t *reconnectableStdio) Connect(ctx context.Context) (mcpsdk.Connection, error) {
+	return (&mcpsdk.CommandTransport{Command: t.newCommand()}).Connect(ctx)
 }
 
 var _ mcpsdk.Transport = (*reconnectableStdio)(nil)

--- a/core/tool/mcp/transport_test.go
+++ b/core/tool/mcp/transport_test.go
@@ -1,0 +1,55 @@
+package mcp
+
+import (
+	"path/filepath"
+	"slices"
+	"testing"
+)
+
+// TestReconnectableStdioRereadsEnvironment verifies that each
+// connection attempt rebuilds the child environment from the current
+// process environment instead of a snapshot taken when Stdio was
+// called.
+func TestReconnectableStdioRereadsEnvironment(t *testing.T) {
+	t.Setenv("FC_MCP_STDIO_TEST", "first")
+	tport, err := Stdio("true", nil, map[string]string{"FC_MCP_STDIO_EXTRA": "x"})
+	if err != nil {
+		t.Fatalf("Stdio: %v", err)
+	}
+	rs, ok := tport.(*reconnectableStdio)
+	if !ok {
+		t.Fatalf("Stdio returned %T, want *reconnectableStdio", tport)
+	}
+
+	assertEnv := func(wantValue string) {
+		t.Helper()
+		cmd := rs.newCommand()
+		if !slices.Contains(cmd.Env, "FC_MCP_STDIO_TEST="+wantValue) {
+			t.Fatalf("child env missing FC_MCP_STDIO_TEST=%s (env %v)", wantValue, cmd.Env)
+		}
+		if !slices.Contains(cmd.Env, "FC_MCP_STDIO_EXTRA=x") {
+			t.Fatalf("child env missing caller-supplied FC_MCP_STDIO_EXTRA=x (env %v)", cmd.Env)
+		}
+	}
+
+	assertEnv("first")
+	t.Setenv("FC_MCP_STDIO_TEST", "second")
+	assertEnv("second")
+}
+
+// TestReconnectableStdioNilEnvInheritsAtSpawn keeps the no-extra-env
+// contract: with no caller env, the child command carries a nil Env,
+// so the exec layer inherits the environment at spawn time.
+func TestReconnectableStdioNilEnvInheritsAtSpawn(t *testing.T) {
+	tport, err := Stdio("true", nil, nil)
+	if err != nil {
+		t.Fatalf("Stdio: %v", err)
+	}
+	cmd := tport.(*reconnectableStdio).newCommand()
+	if cmd.Env != nil {
+		t.Fatalf("child env = %v, want nil (inherit at spawn)", cmd.Env)
+	}
+	if filepath.Base(cmd.Path) != "true" {
+		t.Fatalf("command path = %q, want a true binary", cmd.Path)
+	}
+}

--- a/core/tool/registry.go
+++ b/core/tool/registry.go
@@ -111,17 +111,28 @@ func (r *Registry) Add(t Tool) error {
 	return r.addLocked(t)
 }
 
-// Remove unregisters the named tool at runtime. Unknown names are
-// ignored; after Close it is a no-op.
+// Remove unregisters the named tool at runtime. If the removed tool
+// implements io.Closer, it is closed so runtime removals (e.g. a
+// shrunk MCP tool projection) release whatever resources the tool
+// holds; the close happens outside the registry lock and is
+// best-effort. Unknown names are ignored; after Close it is a no-op.
 func (r *Registry) Remove(name string) {
 	r.mu.Lock()
-	defer r.mu.Unlock()
+	t, ok := r.tools[name]
+	if !ok {
+		r.mu.Unlock()
+		return
+	}
 	delete(r.tools, name)
 	for i, n := range r.order {
 		if n == name {
 			r.order = append(r.order[:i], r.order[i+1:]...)
 			break
 		}
+	}
+	r.mu.Unlock()
+	if c, ok := t.(io.Closer); ok {
+		_ = c.Close()
 	}
 }
 

--- a/core/tool/registry_test.go
+++ b/core/tool/registry_test.go
@@ -198,6 +198,41 @@ func TestRegistry_AddRemoveAtRuntime(t *testing.T) {
 	}
 }
 
+func TestRegistry_RemoveClosesRemovedTool(t *testing.T) {
+	reg, err := tool.NewRegistry(nil)
+	if err != nil {
+		t.Fatalf("NewRegistry: %v", err)
+	}
+	var closed atomic.Bool
+	removed := &closableTool{tool: funcTool("gone", "x"), closed: &closed}
+	if err := reg.Add(removed); err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+	if err := reg.Add(funcTool("kept", "y")); err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+
+	reg.Remove("gone")
+	if !closed.Load() {
+		t.Fatal("removed tool was not closed")
+	}
+	if _, ok := reg.Get("gone"); ok {
+		t.Fatal("removed tool still registered")
+	}
+	if _, ok := reg.Get("kept"); !ok {
+		t.Fatal("unrelated tool was removed")
+	}
+
+	// Unknown names are ignored and never close anything.
+	reg.Remove("missing")
+	if _, ok := reg.Get("kept"); !ok {
+		t.Fatal("unknown-name Remove dropped a registered tool")
+	}
+	if reg.Len() != 1 {
+		t.Fatalf("Len = %d, want 1 after unknown-name Remove", reg.Len())
+	}
+}
+
 func TestRegistry_AddDuplicateRuntimeFollowsPolicy(t *testing.T) {
 	reg, err := tool.NewRegistry([]tool.Source{
 		source{tools: []tool.Tool{funcTool("dup", "first")}},


### PR DESCRIPTION
## Summary

Fixes five issues found while reviewing the MCP tool source and the tool registry:

1. **No orphaned sessions on failed attach** — `attachSession` now closes the session on every failure path (reconcile failure, concurrently closed `Source`, already-attached name) via a shared `abandonAttach` helper that also clears `srv.session`. Previously the `closed` branch returned `NotAvailable` without closing, and since `scheduleRetry` is a no-op on a closed source, a `Connect` racing `Source.Close()` leaked the connection (and its stdio child process).
2. **No redundant close in retryLoop** — removed `retryLoop`'s extra `session.Close()` now that `attachSession` owns cleanup on all failure paths (go-sdk `Close` is idempotent, so this was harmless but redundant).
3. **Deduplicated tool projection** — new `projectTools` keeps the first occurrence of each qualified name when assembling the projection, so `srv.tools`, publish deltas, and `Tools()` stay consistent even if a server returns duplicate tool names. Resource bridge tools participate in dedup (a same-named server tool wins).
4. **Stdio reconnects see current environment** — `reconnectableStdio` stores the caller-supplied env additions and rebuilds `cmd.Env` from `os.Environ()` at every `Connect`, instead of snapshotting the process environment when the transport was constructed.
5. **Registry.Remove releases removed tools** — a removed tool that implements `io.Closer` is now closed (outside the registry lock, best-effort), so a shrunk runtime tool projection releases resources. Unknown names remain a no-op.

## Behavior note

`Registry.Remove` now closes removed `io.Closer` tools. The only runtime `Remove` caller is the MCP publish path; current MCP adapters do not implement `io.Closer`, so there is no behavior change for existing deployments.

## Verification

- `make ci` (vet + test across modules): pass
- `make release-check`: pass (no pending releases)
- `golangci-lint` on CI-gated modules (`core`, `driver/*`, `memory`, `memory/eval`): 0 issues
- `go test -race` on `core/tool/mcp` and `core/tool`: pass
- New regression tests: attach-session close on all failure paths, projection dedup, stdio env re-read, `Registry.Remove` closing

Note: local `make lint` also surfaces 4 issues in the untracked `backends/plugin/` directory (errcheck/unused); that directory is unrelated to this change and not part of this PR.