### PR TITLE
chore(release): publish core v0.1.8

### DIFF
--- a/.release/core-v0.1.8.json
+++ b/.release/core-v0.1.8.json
@@ -1,0 +1,9 @@
+{
+  "summary": "feat(core): runtime tool publication with background MCP reconnect; fix(core): make sandbox.Runner lifecycle part of the contract; fix(core): bound SessionRegistry.Close and wait out start races; fix(core): tighten MCP session lifecycle and tool projection",
+  "releases": [
+    {
+      "module": "core",
+      "bump": "patch"
+    }
+  ]
+}


### PR DESCRIPTION
Publishes the pending `core` delta since `core/v0.1.7`:

- feat(core): runtime tool publication with background MCP reconnect (#319)
- fix(core): make sandbox.Runner lifecycle part of the contract (#321)
- fix(core): bound SessionRegistry.Close and wait out start races (#322)
- fix(core): tighten MCP session lifecycle and tool projection (#323)

Local gates: `make ci`, `make release-check`, `make release-preflight` all pass; changeset validated via `make release-plan` (0.1.7 -> 0.1.8, tag `core/v0.1.8`).