### PR TITLE
feat: provider-carried extension decoders for graph inference nodes

### DIFF
--- a/.release/core-v0.1.10.json
+++ b/.release/core-v0.1.10.json
@@ -1,0 +1,9 @@
+{
+  "summary": "feat(core): provider-carried extension decoders for graph inference node extensions — move the extension wire types into core/inference, carry decoders on ProviderDefinition, and aggregate them per configured provider so graph yaml extensions work without host-side registration",
+  "releases": [
+    {
+      "module": "core",
+      "bump": "patch"
+    }
+  ]
+}

--- a/core/agent/bindings/bridge_inference.go
+++ b/core/agent/bindings/bridge_inference.go
@@ -1,13 +1,9 @@
 package bindings
 
 import (
-	"bytes"
 	"context"
-	"encoding/json"
 	"errors"
-	"fmt"
 	"io"
-	"reflect"
 
 	"github.com/GizClaw/flowcraft/core/errdefs"
 	"github.com/GizClaw/flowcraft/core/inference"
@@ -21,43 +17,19 @@ import (
 // identities fail with a validation error — scripts can only pick
 // from the menu the host explicit offers, never invent provider knobs.
 
-// ExtensionDecoder builds one typed extension from its script-facing
-// fields object. Decoding must be strict: unknown fields are typos,
-// not optional extras.
-type ExtensionDecoder func(fields json.RawMessage) (inference.Extension, error)
-
-// ExtensionDecoderFor adapts a factory for a provider's option struct
-// into an ExtensionDecoder. T must be a pointer type whose fields
-// carry the provider's JSON contract (e.g. func() *kimi.GenerateOptions).
-func ExtensionDecoderFor[T inference.Extension](factory func() T) ExtensionDecoder {
-	return func(fields json.RawMessage) (inference.Extension, error) {
-		ext := factory()
-		value := reflect.ValueOf(ext)
-		if !value.IsValid() || value.Kind() != reflect.Pointer || value.IsNil() {
-			return nil, errdefs.Internalf("extension factory returned %T, want a non-nil pointer", ext)
-		}
-		dec := json.NewDecoder(bytes.NewReader(fields))
-		dec.DisallowUnknownFields()
-		if err := dec.Decode(ext); err != nil {
-			return nil, errdefs.Validationf("extension fields: %v", err)
-		}
-		return ext, nil
-	}
-}
-
 // InferenceBridgeOption customizes NewInferenceBridge.
 type InferenceBridgeOption func(*inferenceBridgeConfig)
 
 type inferenceBridgeConfig struct {
-	extensions map[string]ExtensionDecoder
+	extensions map[string]inference.ExtensionDecoder
 }
 
 // WithExtensionDecoder registers the decoder for one
 // provider/extension identity pair, keyed "provider/id".
-func WithExtensionDecoder(provider, id string, decoder ExtensionDecoder) InferenceBridgeOption {
+func WithExtensionDecoder(provider, id string, decoder inference.ExtensionDecoder) InferenceBridgeOption {
 	return func(cfg *inferenceBridgeConfig) {
 		if cfg.extensions == nil {
-			cfg.extensions = make(map[string]ExtensionDecoder)
+			cfg.extensions = make(map[string]inference.ExtensionDecoder)
 		}
 		cfg.extensions[provider+"/"+id] = decoder
 	}
@@ -264,7 +236,7 @@ func newStreamHandle(ctx context.Context, stream inference.GenerateStream, trace
 // ownership lives with the caller, not the payload), so it is stripped
 // before the strict decode; "extensions" is stripped the same way and
 // resolved through the host-registered decoders.
-func parseInferenceGenerateCall(raw any, decoders map[string]ExtensionDecoder) (inference.ModelRef, inference.GenerateRequest, error) {
+func parseInferenceGenerateCall(raw any, decoders map[string]inference.ExtensionDecoder) (inference.ModelRef, inference.GenerateRequest, error) {
 	var ref inference.ModelRef
 	var req inference.GenerateRequest
 	obj, ok := raw.(map[string]any)
@@ -293,7 +265,7 @@ func parseInferenceGenerateCall(raw any, decoders map[string]ExtensionDecoder) (
 // parseInferenceRouteCall decodes a router-entry request: no model
 // key (rejected by the strict decode), extensions stripped and
 // resolved like the runtime entry.
-func parseInferenceRouteCall(raw any, decoders map[string]ExtensionDecoder, field string) (inference.GenerateRequest, error) {
+func parseInferenceRouteCall(raw any, decoders map[string]inference.ExtensionDecoder, field string) (inference.GenerateRequest, error) {
 	var req inference.GenerateRequest
 	obj, ok := raw.(map[string]any)
 	if !ok {
@@ -308,7 +280,7 @@ func parseInferenceRouteCall(raw any, decoders map[string]ExtensionDecoder, fiel
 // decodeRequestRest strips the bridge-level "extensions" key, strict-
 // decodes the remaining canonical wire into req, then resolves the
 // extensions through the host registry.
-func decodeRequestRest(obj map[string]any, req *inference.GenerateRequest, decoders map[string]ExtensionDecoder, field string) error {
+func decodeRequestRest(obj map[string]any, req *inference.GenerateRequest, decoders map[string]inference.ExtensionDecoder, field string) error {
 	extRaw, rest := splitExtensionsKey(obj)
 	if err := decodeStrictJSON(rest, req, field); err != nil {
 		return err
@@ -337,63 +309,17 @@ func splitExtensionsKey(obj map[string]any) (extRaw any, rest map[string]any) {
 	return extRaw, rest
 }
 
-// ExtensionEntry is the wire form of one extension reference: which
-// provider's which extension, plus its fields object. Shared by the
-// script bridge and graph nodes — anywhere a JSON document needs to
-// name a typed extension.
-type ExtensionEntry struct {
-	Provider string          `json:"provider"`
-	ID       string          `json:"id"`
-	Fields   json.RawMessage `json:"fields"`
-}
-
-// DecodeExtensions resolves entries into typed extensions via the
-// host-registered decoders. Unregistered identities are validation
-// errors: the host's registry is the whole menu. A decoder returning
-// an extension whose identity does not match the registered key is a
-// host wiring bug and surfaces as an internal error.
-func DecodeExtensions(entries []ExtensionEntry, decoders map[string]ExtensionDecoder, field string) (inference.Extensions, error) {
-	var extensions inference.Extensions
-	for i, entry := range entries {
-		entryField := fmt.Sprintf("%s[%d]", field, i)
-		if entry.Provider == "" || entry.ID == "" {
-			return nil, errdefs.Validationf("%s: provider and id are required", entryField)
-		}
-		key := entry.Provider + "/" + entry.ID
-		decoder, ok := decoders[key]
-		if !ok {
-			return nil, errdefs.Validationf("%s: extension %q is not registered by the host", entryField, key)
-		}
-		fields := entry.Fields
-		if len(fields) == 0 {
-			fields = json.RawMessage(`{}`)
-		}
-		extension, err := decoder(fields)
-		if err != nil {
-			return nil, fmt.Errorf("%s: %w", entryField, err)
-		}
-		if extension.ProviderID() != entry.Provider || extension.ExtensionID() != entry.ID {
-			return nil, errdefs.Internalf(
-				"%s: decoder for %q returned extension %q/%q",
-				entryField, key, extension.ProviderID(), extension.ExtensionID(),
-			)
-		}
-		extensions = append(extensions, extension)
-	}
-	return extensions, nil
-}
-
 // decodeScriptExtensions resolves a script "extensions" array —
 // entries of {provider, id, fields} — into typed extensions via the
 // host-registered decoders. Strict decoding rejects unknown entry
 // keys as typos.
-func decodeScriptExtensions(raw any, decoders map[string]ExtensionDecoder, field string) (inference.Extensions, error) {
+func decodeScriptExtensions(raw any, decoders map[string]inference.ExtensionDecoder, field string) (inference.Extensions, error) {
 	if raw == nil {
 		return nil, nil
 	}
-	var entries []ExtensionEntry
+	var entries []inference.ExtensionEntry
 	if err := decodeStrictJSON(raw, &entries, field); err != nil {
 		return nil, err
 	}
-	return DecodeExtensions(entries, decoders, field)
+	return inference.DecodeExtensions(entries, decoders, field)
 }

--- a/core/agent/bindings/bridge_inference_test.go
+++ b/core/agent/bindings/bridge_inference_test.go
@@ -343,8 +343,8 @@ func (e testExtension) Validate() error { return nil }
 
 func (e testExtension) Clone() inference.Extension { return e }
 
-func testExtensionDecoder() ExtensionDecoder {
-	return ExtensionDecoderFor(func() *testExtension { return &testExtension{} })
+func testExtensionDecoder() inference.ExtensionDecoder {
+	return inference.ExtensionDecoderFor(func() *testExtension { return &testExtension{} })
 }
 
 func TestInferenceBridge_Generate_Extensions(t *testing.T) {
@@ -466,7 +466,7 @@ func TestInferenceBridge_Extensions_NonPointerFactory(t *testing.T) {
 	// A value-type factory satisfies the constraint at compile time
 	// but cannot be decoded into; the decoder must fail as a host
 	// wiring error, not a confusing script-facing validation error.
-	decoder := ExtensionDecoderFor(func() testExtension { return testExtension{} })
+	decoder := inference.ExtensionDecoderFor(func() testExtension { return testExtension{} })
 	_, err := decoder(json.RawMessage(`{}`))
 	if err == nil || !errdefs.IsInternal(err) {
 		t.Fatalf("non-pointer factory error = %v, want internal-classified", err)

--- a/core/graph/nodes/inference.go
+++ b/core/graph/nodes/inference.go
@@ -7,7 +7,6 @@ import (
 	"io"
 
 	"github.com/GizClaw/flowcraft/core/agent"
-	"github.com/GizClaw/flowcraft/core/agent/bindings"
 	"github.com/GizClaw/flowcraft/core/errdefs"
 	"github.com/GizClaw/flowcraft/core/graph"
 	"github.com/GizClaw/flowcraft/core/inference"
@@ -71,9 +70,11 @@ type InferenceConfig struct {
 	ReasoningEnabled *bool                     `json:"reasoning_enabled,omitempty"`
 	ReasoningEffort  inference.ReasoningEffort `json:"reasoning_effort,omitempty"`
 
-	// Extensions names host-registered provider knobs in the shared
-	// {provider, id, fields} wire form (see bindings.DecodeExtensions).
-	Extensions []bindings.ExtensionEntry `json:"extensions,omitempty"`
+	// Extensions names provider knobs in the shared {provider, id,
+	// fields} wire form (see inference.DecodeExtensions). Decoders are
+	// provider-carried: the deploy path aggregates them from the wired
+	// inference assembly, so only configured providers are available.
+	Extensions []inference.ExtensionEntry `json:"extensions,omitempty"`
 }
 
 // InferenceNodeDeps wires the inference node's collaborators. Runtime
@@ -88,7 +89,9 @@ type InferenceNodeDeps struct {
 	Catalog tool.Catalog
 	// Extensions maps "provider/id" to decoders, the same registry
 	// shape the script bridge wires with bindings.WithExtensionDecoder.
-	Extensions map[string]bindings.ExtensionDecoder
+	// The deploy path populates it from the inference assembly's
+	// provider-carried decoders.
+	Extensions map[string]inference.ExtensionDecoder
 }
 
 // Inference returns the "inference" node type: one Generate call per
@@ -269,7 +272,7 @@ func buildGenerateRequest(ec graph.ExecutionContext, board *agent.Board, channel
 		text.Tools = definitions
 	}
 
-	extensions, err := bindings.DecodeExtensions(cfg.Extensions, deps.Extensions, "inference node extensions")
+	extensions, err := inference.DecodeExtensions(cfg.Extensions, deps.Extensions, "inference node extensions")
 	if err != nil {
 		return req, err
 	}

--- a/core/graph/nodes/inference_test.go
+++ b/core/graph/nodes/inference_test.go
@@ -10,7 +10,6 @@ import (
 	"testing"
 
 	"github.com/GizClaw/flowcraft/core/agent"
-	"github.com/GizClaw/flowcraft/core/agent/bindings"
 	"github.com/GizClaw/flowcraft/core/errdefs"
 	"github.com/GizClaw/flowcraft/core/event"
 	"github.com/GizClaw/flowcraft/core/graph"
@@ -694,13 +693,13 @@ func TestInferenceNode_Extensions(t *testing.T) {
 	fake := &inferencetest.GenerateFake{}
 	reg := inferenceRegistry(t, InferenceNodeDeps{
 		Assembly: fake.Assembly(t),
-		Extensions: map[string]bindings.ExtensionDecoder{
-			"fake/generate_options": bindings.ExtensionDecoderFor(func() *testExtension { return &testExtension{} }),
+		Extensions: map[string]inference.ExtensionDecoder{
+			"fake/generate_options": inference.ExtensionDecoderFor(func() *testExtension { return &testExtension{} }),
 		},
 	})
 	g := singleNodeGraph(t, reg, "inference", InferenceConfig{
 		Model: ptr(inferencetest.DefaultFakeModel),
-		Extensions: []bindings.ExtensionEntry{{
+		Extensions: []inference.ExtensionEntry{{
 			Provider: "fake",
 			ID:       "generate_options",
 			Fields:   json.RawMessage(`{"cache_key":"sess-1"}`),

--- a/core/graph/resource/resource.go
+++ b/core/graph/resource/resource.go
@@ -135,10 +135,16 @@ func (Factory) New(ctx context.Context, in res.Input) (any, error) {
 	}
 	if deps.inference != nil {
 		inferenceDeps.Assembly = deps.inference
+		inferenceDeps.Extensions = deps.inference.ExtensionDecoders()
 		scriptDeps.InferenceAssembly = deps.inference
 	}
 	if deps.router != nil {
 		inferenceDeps.Router = deps.router
+		if deps.inference == nil {
+			// A router-only deployment still needs the provider-carried
+			// decoders of its target assembly.
+			inferenceDeps.Extensions = deps.router.Target().ExtensionDecoders()
+		}
 		scriptDeps.InferenceRouter = deps.router
 	}
 	if deps.tools != nil {

--- a/core/graph/resource/resource_test.go
+++ b/core/graph/resource/resource_test.go
@@ -5,10 +5,14 @@ import (
 	"encoding/json"
 	"testing"
 
+	"github.com/GizClaw/flowcraft/core/agent"
 	"github.com/GizClaw/flowcraft/core/errdefs"
 	coregraph "github.com/GizClaw/flowcraft/core/graph"
 	graphresource "github.com/GizClaw/flowcraft/core/graph/resource"
+	"github.com/GizClaw/flowcraft/core/inference"
 	"github.com/GizClaw/flowcraft/core/inference/inferencetest"
+	"github.com/GizClaw/flowcraft/core/inference/route"
+	"github.com/GizClaw/flowcraft/core/message"
 	"github.com/GizClaw/flowcraft/core/resource"
 )
 
@@ -83,5 +87,147 @@ func TestFactoryBuildsGraphEngine(t *testing.T) {
 	}
 	if _, ok := value.(*coregraph.Graph); !ok {
 		t.Fatalf("New returned %T, want *coregraph.Graph", value)
+	}
+}
+
+// graphTestExtension is a canned provider extension riding the fake
+// provider definition, proving graph yaml extensions reach the runtime.
+type graphTestExtension struct {
+	Provider string
+	Flag     bool `json:"flag,omitempty"`
+}
+
+func (e *graphTestExtension) ProviderID() string  { return e.Provider }
+func (e *graphTestExtension) ExtensionID() string { return "generate_options" }
+func (e *graphTestExtension) ActiveFields() []inference.ExtensionField {
+	return []inference.ExtensionField{"flag"}
+}
+func (e *graphTestExtension) Validate() error { return nil }
+func (e *graphTestExtension) Clone() inference.Extension {
+	copy := *e
+	return &copy
+}
+
+func graphWithExtensions(t *testing.T, model any) []byte {
+	t.Helper()
+	node := map[string]any{
+		"id":   "n1",
+		"type": "inference",
+		"config": map[string]any{
+			"extensions": []any{
+				map[string]any{
+					"provider": "fake",
+					"id":       "generate_options",
+					"fields":   map[string]any{"flag": true},
+				},
+			},
+		},
+	}
+	if model != nil {
+		node["config"].(map[string]any)["model"] = model
+	}
+	def, err := json.Marshal(map[string]any{
+		"name":  "g",
+		"entry": "n1",
+		"nodes": []any{node},
+		"edges": []any{},
+	})
+	if err != nil {
+		t.Fatalf("marshal graph: %v", err)
+	}
+	return def
+}
+
+func executeTestGraph(t *testing.T, g *coregraph.Graph) error {
+	t.Helper()
+	board := agent.NewBoard()
+	board.AppendChannelMessage(agent.MainChannel,
+		message.NewTextMessage(message.RoleUser, "hi"))
+	_, err := g.Execute(context.Background(),
+		agent.Run{Identity: agent.Identity{AgentID: "test-agent", RunID: "run-1"}},
+		agent.NoopHost{}, board)
+	return err
+}
+
+func fakeWithDecoder(t *testing.T) *inferencetest.GenerateFake {
+	t.Helper()
+	return &inferencetest.GenerateFake{
+		ExtensionDecoders: map[string]inference.ExtensionDecoder{
+			"generate_options": inference.ExtensionDecoderFor(func() *graphTestExtension {
+				return &graphTestExtension{Provider: "fake"}
+			}),
+		},
+	}
+}
+
+func TestFactoryWiresProviderCarriedInferenceExtensions(t *testing.T) {
+	fake := fakeWithDecoder(t)
+	def := graphWithExtensions(t, map[string]any{
+		"id":      map[string]any{"provider": "fake", "name": "echo"},
+		"profile": "default",
+	})
+	value, err := (graphresource.Factory{}).New(context.Background(), resource.Input{
+		Settings: []byte(`{"graph": ` + string(def) + `}`),
+		Deps: map[string]any{
+			"inference": fake.Assembly(t),
+		},
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	if err := executeTestGraph(t, value.(*coregraph.Graph)); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	req := fake.LastRequest()
+	if len(req.Extensions) != 1 {
+		t.Fatalf("request extensions = %#v, want 1", req.Extensions)
+	}
+	ext, ok := req.Extensions[0].(*graphTestExtension)
+	if !ok || !ext.Flag || ext.Provider != "fake" {
+		t.Fatalf("decoded extension = %#v", req.Extensions[0])
+	}
+}
+
+func TestFactoryWiresExtensionsForRouterOnlyDeployment(t *testing.T) {
+	fake := fakeWithDecoder(t)
+	router, err := route.New(fake.Assembly(t), route.Selectors{
+		Generate: inferencetest.StaticGenerateSelector(inferencetest.DefaultFakeModel),
+	})
+	if err != nil {
+		t.Fatalf("route.New: %v", err)
+	}
+	value, err := (graphresource.Factory{}).New(context.Background(), resource.Input{
+		Settings: []byte(`{"graph": ` + string(graphWithExtensions(t, nil)) + `}`),
+		Deps: map[string]any{
+			"router": router,
+		},
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	if err := executeTestGraph(t, value.(*coregraph.Graph)); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if len(fake.LastRequest().Extensions) != 1 {
+		t.Fatalf("request extensions = %#v, want 1", fake.LastRequest().Extensions)
+	}
+}
+
+func TestFactoryRejectsExtensionsWithoutConfiguredDecoder(t *testing.T) {
+	def := graphWithExtensions(t, map[string]any{
+		"id": map[string]any{"provider": "fake", "name": "echo"},
+	})
+	value, err := (graphresource.Factory{}).New(context.Background(), resource.Input{
+		Settings: []byte(`{"graph": ` + string(def) + `}`),
+		Deps: map[string]any{
+			"inference": (&inferencetest.GenerateFake{}).Assembly(t),
+		},
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	err = executeTestGraph(t, value.(*coregraph.Graph))
+	if err == nil || !errdefs.IsValidation(err) {
+		t.Fatalf("Execute error = %v, want Validation for unregistered extension", err)
 	}
 }

--- a/core/inference/assembly.go
+++ b/core/inference/assembly.go
@@ -35,6 +35,21 @@ func (a *Assembly) Providers() []ProviderDefinition {
 	return providers
 }
 
+// ExtensionDecoders returns every configured provider's extension
+// decoders keyed "provider/extension" — the registry shape handed to
+// DecodeExtensions. Decoders are provider-carried, so the available
+// menu tracks the providers actually configured in the deployment
+// instead of host-side registration.
+func (a *Assembly) ExtensionDecoders() map[string]ExtensionDecoder {
+	decoders := make(map[string]ExtensionDecoder)
+	for providerID, def := range a.providers {
+		for extensionID, decoder := range def.ExtensionDecoders {
+			decoders[providerID+"/"+extensionID] = decoder
+		}
+	}
+	return decoders
+}
+
 // registryView freezes the provider catalog into the execution
 // registry on first use (idempotent, concurrent-safe).
 func (a *Assembly) registryView() (map[string]providerEntry, error) {

--- a/core/inference/extension_registry.go
+++ b/core/inference/extension_registry.go
@@ -1,0 +1,81 @@
+package inference
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"reflect"
+
+	"github.com/GizClaw/flowcraft/core/errdefs"
+)
+
+// ExtensionDecoder builds one typed extension from its wire-facing
+// fields object. Decoding must be strict: unknown fields are typos,
+// not optional extras.
+type ExtensionDecoder func(fields json.RawMessage) (Extension, error)
+
+// ExtensionDecoderFor adapts a factory for a provider's option struct
+// into an ExtensionDecoder. T must be a pointer type whose fields
+// carry the provider's JSON contract (e.g. func() *deepseek.GenerateOptions).
+func ExtensionDecoderFor[T Extension](factory func() T) ExtensionDecoder {
+	return func(fields json.RawMessage) (Extension, error) {
+		ext := factory()
+		value := reflect.ValueOf(ext)
+		if !value.IsValid() || value.Kind() != reflect.Pointer || value.IsNil() {
+			return nil, errdefs.Internalf("extension factory returned %T, want a non-nil pointer", ext)
+		}
+		dec := json.NewDecoder(bytes.NewReader(fields))
+		dec.DisallowUnknownFields()
+		if err := dec.Decode(ext); err != nil {
+			return nil, errdefs.Validationf("extension fields: %v", err)
+		}
+		return ext, nil
+	}
+}
+
+// ExtensionEntry is the wire form of one extension reference: which
+// provider's which extension, plus its fields object. Shared by the
+// script bridge and graph nodes — anywhere a JSON document needs to
+// name a typed extension.
+type ExtensionEntry struct {
+	Provider string          `json:"provider"`
+	ID       string          `json:"id"`
+	Fields   json.RawMessage `json:"fields"`
+}
+
+// DecodeExtensions resolves entries into typed extensions via the
+// registered decoders — by default the provider-carried decoders a
+// configured provider registers; a host may add more. Unregistered
+// identities are validation errors: the registry is the whole menu.
+// A decoder returning an extension whose identity does not match the
+// registered key is a wiring bug and surfaces as an internal error.
+func DecodeExtensions(entries []ExtensionEntry, decoders map[string]ExtensionDecoder, field string) (Extensions, error) {
+	var extensions Extensions
+	for i, entry := range entries {
+		entryField := fmt.Sprintf("%s[%d]", field, i)
+		if entry.Provider == "" || entry.ID == "" {
+			return nil, errdefs.Validationf("%s: provider and id are required", entryField)
+		}
+		key := entry.Provider + "/" + entry.ID
+		decoder, ok := decoders[key]
+		if !ok {
+			return nil, errdefs.Validationf("%s: extension %q is not registered by the host", entryField, key)
+		}
+		fields := entry.Fields
+		if len(fields) == 0 {
+			fields = json.RawMessage(`{}`)
+		}
+		extension, err := decoder(fields)
+		if err != nil {
+			return nil, fmt.Errorf("%s: %w", entryField, err)
+		}
+		if extension.ProviderID() != entry.Provider || extension.ExtensionID() != entry.ID {
+			return nil, errdefs.Internalf(
+				"%s: decoder for %q returned extension %q/%q",
+				entryField, key, extension.ProviderID(), extension.ExtensionID(),
+			)
+		}
+		extensions = append(extensions, extension)
+	}
+	return extensions, nil
+}

--- a/core/inference/extension_registry_test.go
+++ b/core/inference/extension_registry_test.go
@@ -1,0 +1,134 @@
+package inference
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/GizClaw/flowcraft/core/errdefs"
+)
+
+type registryTestExtension struct {
+	Provider string
+	Enabled  bool `json:"enabled,omitempty"`
+}
+
+func (e registryTestExtension) ProviderID() string             { return e.Provider }
+func (e registryTestExtension) ExtensionID() string            { return "generate_options" }
+func (e registryTestExtension) ActiveFields() []ExtensionField { return nil }
+func (e registryTestExtension) Validate() error                { return nil }
+func (e registryTestExtension) Clone() Extension {
+	copy := e
+	return &copy
+}
+
+func registryDecoder(provider string) ExtensionDecoder {
+	return ExtensionDecoderFor(func() *registryTestExtension {
+		return &registryTestExtension{Provider: provider}
+	})
+}
+
+func TestExtensionDecoderForStrictDecode(t *testing.T) {
+	ext, err := registryDecoder("fake")(json.RawMessage(`{"enabled":true}`))
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	typed, ok := ext.(*registryTestExtension)
+	if !ok || !typed.Enabled || typed.Provider != "fake" {
+		t.Fatalf("decoded extension = %#v", ext)
+	}
+
+	if _, err := registryDecoder("fake")(json.RawMessage(`{"typo":1}`)); err == nil ||
+		!errdefs.IsValidation(err) {
+		t.Fatalf("unknown field error = %v, want Validation", err)
+	}
+}
+
+func TestExtensionDecoderForRejectsNonPointerFactory(t *testing.T) {
+	decoder := ExtensionDecoderFor(func() registryTestExtension { return registryTestExtension{} })
+	if _, err := decoder(json.RawMessage(`{}`)); err == nil || !errdefs.IsInternal(err) {
+		t.Fatalf("non-pointer factory error = %v, want Internal", err)
+	}
+}
+
+func TestDecodeExtensions(t *testing.T) {
+	decoders := map[string]ExtensionDecoder{
+		"fake/generate_options": registryDecoder("fake"),
+	}
+	extensions, err := DecodeExtensions([]ExtensionEntry{{
+		Provider: "fake",
+		ID:       "generate_options",
+		Fields:   json.RawMessage(`{"enabled":true}`),
+	}}, decoders, "cfg")
+	if err != nil {
+		t.Fatalf("DecodeExtensions: %v", err)
+	}
+	if len(extensions) != 1 {
+		t.Fatalf("extensions = %#v, want 1", extensions)
+	}
+	typed, ok := extensions[0].(*registryTestExtension)
+	if !ok || !typed.Enabled || typed.Provider != "fake" {
+		t.Fatalf("decoded extension = %#v", extensions[0])
+	}
+}
+
+func TestDecodeExtensionsDefaultsEmptyFields(t *testing.T) {
+	decoders := map[string]ExtensionDecoder{
+		"fake/generate_options": registryDecoder("fake"),
+	}
+	extensions, err := DecodeExtensions([]ExtensionEntry{{
+		Provider: "fake",
+		ID:       "generate_options",
+	}}, decoders, "cfg")
+	if err != nil {
+		t.Fatalf("DecodeExtensions: %v", err)
+	}
+	typed := extensions[0].(*registryTestExtension)
+	if typed.Enabled {
+		t.Fatalf("empty fields decoded as %#v", typed)
+	}
+}
+
+func TestDecodeExtensionsRequiresProviderAndID(t *testing.T) {
+	decoders := map[string]ExtensionDecoder{
+		"fake/generate_options": registryDecoder("fake"),
+	}
+	for _, entry := range []ExtensionEntry{
+		{ID: "generate_options"},
+		{Provider: "fake"},
+	} {
+		if _, err := DecodeExtensions([]ExtensionEntry{entry}, decoders, "cfg"); err == nil ||
+			!errdefs.IsValidation(err) {
+			t.Fatalf("entry %#v error = %v, want Validation", entry, err)
+		}
+	}
+}
+
+func TestDecodeExtensionsUnregisteredIdentity(t *testing.T) {
+	decoders := map[string]ExtensionDecoder{
+		"fake/generate_options": registryDecoder("fake"),
+	}
+	_, err := DecodeExtensions([]ExtensionEntry{{
+		Provider: "kimi",
+		ID:       "generate_options",
+	}}, decoders, "cfg")
+	if err == nil || !errdefs.IsValidation(err) ||
+		!strings.Contains(err.Error(), "not registered by the host") {
+		t.Fatalf("unregistered error = %v, want Validation naming the identity", err)
+	}
+}
+
+func TestDecodeExtensionsIdentityMismatch(t *testing.T) {
+	// The decoder is registered under "other/..." but produces an
+	// extension whose ProviderID does not match — a wiring bug.
+	decoders := map[string]ExtensionDecoder{
+		"other/generate_options": registryDecoder("fake"),
+	}
+	_, err := DecodeExtensions([]ExtensionEntry{{
+		Provider: "other",
+		ID:       "generate_options",
+	}}, decoders, "cfg")
+	if err == nil || !errdefs.IsInternal(err) {
+		t.Fatalf("identity mismatch error = %v, want Internal", err)
+	}
+}

--- a/core/inference/inferencetest/fake.go
+++ b/core/inference/inferencetest/fake.go
@@ -41,6 +41,10 @@ type GenerateFake struct {
 	StreamErr   error
 	StreamErrAt int
 
+	// ExtensionDecoders are carried on the fake provider definition,
+	// keyed by extension ID (see inference.ProviderDefinition).
+	ExtensionDecoders map[string]inference.ExtensionDecoder
+
 	mu       sync.Mutex
 	requests []inference.GenerateRequest
 }
@@ -110,7 +114,8 @@ func (f *GenerateFake) Assembly(t *testing.T) *inference.Assembly {
 		t.Fatalf("BindGenerateOperations: %v", err)
 	}
 	definition := inference.ProviderDefinition{
-		ID: model.ID.Provider,
+		ID:                model.ID.Provider,
+		ExtensionDecoders: f.ExtensionDecoders,
 		Profiles: []inference.ProfileDefinition{{
 			ID:         model.Profile,
 			Operations: []inference.Operation{inference.OperationGenerate},

--- a/core/inference/provider_definition.go
+++ b/core/inference/provider_definition.go
@@ -46,6 +46,13 @@ type ProviderDefinition struct {
 	Profiles []ProfileDefinition
 	Models   []ModelImplementation
 	Dynamic  *Openers
+	// ExtensionDecoders maps extension IDs (e.g. "generate_options")
+	// to the decoders this provider owns. Decoders are bound to the
+	// provider's deployment ID: decoding an entry named
+	// {provider: ID, id: ...} yields an extension whose ProviderID
+	// matches. Assembly aggregates them into "provider/extension"
+	// keys for the graph engine and script bridge.
+	ExtensionDecoders map[string]ExtensionDecoder
 }
 
 type profileEntry struct {

--- a/core/inference/route/router.go
+++ b/core/inference/route/router.go
@@ -249,6 +249,11 @@ func (r *Router) ResetCircuitBreaker() {
 	}
 }
 
+// Target returns the router's underlying inference assembly.
+func (r *Router) Target() *inference.Assembly {
+	return r.target
+}
+
 // maxFallbackTargets bounds total targets tried for one request, counting the
 // initially selected target.
 const maxFallbackTargets = 8

--- a/driver/azure/resource.go
+++ b/driver/azure/resource.go
@@ -70,7 +70,14 @@ func buildProvider(settings ResourceSettings) (inference.ProviderDefinition, err
 		profiles[profile.ID] = material
 	}
 
-	provider := inference.ProviderDefinition{ID: settings.ID}
+	provider := inference.ProviderDefinition{
+		ID: settings.ID,
+		ExtensionDecoders: map[string]inference.ExtensionDecoder{
+			extensionGenerate: inference.ExtensionDecoderFor(func() *GenerateOptions {
+				return &GenerateOptions{Provider: settings.ID}
+			}),
+		},
+	}
 	for _, profile := range settings.Profiles {
 		provider.Profiles = append(
 			provider.Profiles,

--- a/driver/azure/resource_test.go
+++ b/driver/azure/resource_test.go
@@ -64,3 +64,73 @@ func TestRegisterAddsAzureProviderFactory(t *testing.T) {
 		t.Fatalf("factory %s/azure missing", ResourceKind)
 	}
 }
+
+func TestProviderCarriesGenerateOptionsDecoder(t *testing.T) {
+	value, err := Factory().New(context.Background(), resource.Input{
+		Settings: json.RawMessage(`{
+			"id": "azure",
+			"spec": {
+				"endpoint": "https://example.openai.azure.com",
+				"models": [{"name": "gpt-5", "kind": "generate"}]
+			},
+			"profiles": [{"id": "default", "secrets": {"api_key": "sk-test"}}]
+		}`),
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	provider := value.(inference.ProviderDefinition)
+	decoder, ok := provider.ExtensionDecoders[extensionGenerate]
+	if !ok {
+		t.Fatalf("ExtensionDecoders = %#v, want %q", provider.ExtensionDecoders, extensionGenerate)
+	}
+
+	extensions, err := inference.DecodeExtensions([]inference.ExtensionEntry{{
+		Provider: "azure",
+		ID:       extensionGenerate,
+		Fields: json.RawMessage(`{
+			"web_search": {
+				"tool_choice": {"required": true},
+				"search_context_size": "high"
+			}
+		}`),
+	}}, map[string]inference.ExtensionDecoder{
+		"azure/" + extensionGenerate: decoder,
+	}, "extensions")
+	if err != nil {
+		t.Fatalf("DecodeExtensions: %v", err)
+	}
+	options := extensions[0].(*GenerateOptions)
+	if options.ProviderID() != "azure" || options.WebSearch == nil ||
+		options.WebSearch.ToolChoice == nil || !options.WebSearch.ToolChoice.Required ||
+		options.WebSearch.SearchContextSize != "high" {
+		t.Fatalf("decoded options = %#v", options)
+	}
+
+	value, err = Factory().New(context.Background(), resource.Input{
+		Settings: json.RawMessage(`{
+			"id": "az-prod",
+			"spec": {
+				"endpoint": "https://example.openai.azure.com",
+				"models": [{"name": "gpt-5", "kind": "generate"}]
+			},
+			"profiles": [{"id": "default", "secrets": {"api_key": "sk-test"}}]
+		}`),
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	decoder = value.(inference.ProviderDefinition).ExtensionDecoders[extensionGenerate]
+	extensions, err = inference.DecodeExtensions([]inference.ExtensionEntry{{
+		Provider: "az-prod",
+		ID:       extensionGenerate,
+	}}, map[string]inference.ExtensionDecoder{
+		"az-prod/" + extensionGenerate: decoder,
+	}, "extensions")
+	if err != nil {
+		t.Fatalf("DecodeExtensions: %v", err)
+	}
+	if options := extensions[0].(*GenerateOptions); options.ProviderID() != "az-prod" {
+		t.Fatalf("ProviderID = %q, want %q", options.ProviderID(), "az-prod")
+	}
+}

--- a/driver/bytedance/resource.go
+++ b/driver/bytedance/resource.go
@@ -76,7 +76,20 @@ func buildProvider(settings ResourceSettings) (inference.ProviderDefinition, err
 		profiles[profile.ID] = material
 	}
 
-	provider := inference.ProviderDefinition{ID: settings.ID}
+	provider := inference.ProviderDefinition{
+		ID: settings.ID,
+		ExtensionDecoders: map[string]inference.ExtensionDecoder{
+			extensionGenerate: inference.ExtensionDecoderFor(func() *GenerateOptions {
+				return &GenerateOptions{Provider: settings.ID}
+			}),
+			extensionImage: inference.ExtensionDecoderFor(func() *ImageOptions {
+				return &ImageOptions{Provider: settings.ID}
+			}),
+			extensionVideo: inference.ExtensionDecoderFor(func() *VideoOptions {
+				return &VideoOptions{Provider: settings.ID}
+			}),
+		},
+	}
 	for _, profile := range settings.Profiles {
 		provider.Profiles = append(
 			provider.Profiles,

--- a/driver/bytedance/resource_test.go
+++ b/driver/bytedance/resource_test.go
@@ -60,3 +60,85 @@ func TestRegisterAddsByTedanceProviderFactory(t *testing.T) {
 		t.Fatalf("factory %s/bytedance missing", ResourceKind)
 	}
 }
+
+func TestProviderCarriesExtensionDecoders(t *testing.T) {
+	value, err := Factory().New(context.Background(), resource.Input{
+		Settings: json.RawMessage(`{
+			"id": "bytedance",
+			"profiles": [{"id": "default", "secrets": {"api_key": "sk-test"}}]
+		}`),
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	provider := value.(inference.ProviderDefinition)
+	decoders := map[string]inference.ExtensionDecoder{}
+	for id, decoder := range provider.ExtensionDecoders {
+		decoders["bytedance/"+id] = decoder
+	}
+	for _, id := range []string{extensionGenerate, extensionImage, extensionVideo} {
+		if _, ok := decoders["bytedance/"+id]; !ok {
+			t.Fatalf("ExtensionDecoders = %#v, want %q", provider.ExtensionDecoders, id)
+		}
+	}
+
+	extensions, err := inference.DecodeExtensions([]inference.ExtensionEntry{
+		{
+			Provider: "bytedance",
+			ID:       extensionGenerate,
+			Fields:   json.RawMessage(`{"service_tier":"auto","web_search":{"limit":3}}`),
+		},
+		{
+			Provider: "bytedance",
+			ID:       extensionImage,
+			Fields:   json.RawMessage(`{"watermark":true,"size_token":"1k"}`),
+		},
+		{
+			Provider: "bytedance",
+			ID:       extensionVideo,
+			Fields:   json.RawMessage(`{"camera_fixed":true,"generate_audio":true}`),
+		},
+	}, decoders, "extensions")
+	if err != nil {
+		t.Fatalf("DecodeExtensions: %v", err)
+	}
+	generate, ok := extensions[0].(*GenerateOptions)
+	if !ok || generate.ProviderID() != "bytedance" || generate.ServiceTier != "auto" ||
+		generate.WebSearch == nil || generate.WebSearch.Limit == nil ||
+		*generate.WebSearch.Limit != 3 {
+		t.Fatalf("decoded generate options = %#v", extensions[0])
+	}
+	image, ok := extensions[1].(*ImageOptions)
+	if !ok || image.ProviderID() != "bytedance" || image.Watermark == nil ||
+		!*image.Watermark || image.SizeToken != "1k" {
+		t.Fatalf("decoded image options = %#v", extensions[1])
+	}
+	video, ok := extensions[2].(*VideoOptions)
+	if !ok || video.ProviderID() != "bytedance" || video.CameraFixed == nil ||
+		!*video.CameraFixed || video.GenerateAudio == nil || !*video.GenerateAudio {
+		t.Fatalf("decoded video options = %#v", extensions[2])
+	}
+
+	value, err = Factory().New(context.Background(), resource.Input{
+		Settings: json.RawMessage(`{
+			"id": "bd-prod",
+			"profiles": [{"id": "default", "secrets": {"api_key": "sk-test"}}]
+		}`),
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	decoder := value.(inference.ProviderDefinition).ExtensionDecoders[extensionGenerate]
+	extensions, err = inference.DecodeExtensions([]inference.ExtensionEntry{{
+		Provider: "bd-prod",
+		ID:       extensionGenerate,
+	}}, map[string]inference.ExtensionDecoder{
+		"bd-prod/" + extensionGenerate: decoder,
+	}, "extensions")
+	if err != nil {
+		t.Fatalf("DecodeExtensions: %v", err)
+	}
+	if options := extensions[0].(*GenerateOptions); options.ProviderID() != "bd-prod" {
+		t.Fatalf("ProviderID = %q, want %q", options.ProviderID(), "bd-prod")
+	}
+}

--- a/driver/deepseek/resource.go
+++ b/driver/deepseek/resource.go
@@ -73,7 +73,10 @@ func Register(r *resource.Registry) error {
 // deployment provider config. It validates the provider Spec, merges the
 // model catalog, resolves every credential profile, and binds each catalog
 // model to the openers its kind serves. Unknown models fail closed: only
-// catalog models (built-in or declared via Spec.Models) are exposed.
+// catalog models (built-in or declared via Spec.Models) are exposed. The
+// definition carries the generate_options decoder bound to the deployment
+// provider ID, so graph yaml can enable provider knobs (web_search) without
+// host-side registration.
 func buildProvider(settings ResourceSettings) (inference.ProviderDefinition, error) {
 	spec, err := decodeSpec(settings.Spec)
 	if err != nil {
@@ -115,7 +118,17 @@ func buildProvider(settings ResourceSettings) (inference.ProviderDefinition, err
 		profiles[profile.ID] = material
 	}
 
-	provider := inference.ProviderDefinition{ID: settings.ID}
+	provider := inference.ProviderDefinition{
+		ID: settings.ID,
+		ExtensionDecoders: map[string]inference.ExtensionDecoder{
+			extensionGenerate: inference.ExtensionDecoderFor(func() *GenerateOptions {
+				// Bind the deployment provider ID: the identity check in
+				// DecodeExtensions compares against the wire provider, which
+				// for graph yaml is the configured provider ID.
+				return &GenerateOptions{Provider: settings.ID}
+			}),
+		},
+	}
 	for _, profile := range settings.Profiles {
 		provider.Profiles = append(
 			provider.Profiles,

--- a/driver/deepseek/resource_test.go
+++ b/driver/deepseek/resource_test.go
@@ -3,8 +3,10 @@ package deepseek
 import (
 	"context"
 	"encoding/json"
+	"strings"
 	"testing"
 
+	"github.com/GizClaw/flowcraft/core/errdefs"
 	"github.com/GizClaw/flowcraft/core/inference"
 	"github.com/GizClaw/flowcraft/core/resource"
 )
@@ -132,5 +134,101 @@ func TestRegisterAddsDeepSeekProviderFactory(t *testing.T) {
 	}
 	if _, ok := reg.Lookup(ResourceKind, "deepseek"); !ok {
 		t.Fatalf("factory %s/deepseek missing", ResourceKind)
+	}
+}
+
+func TestProviderCarriesGenerateOptionsDecoder(t *testing.T) {
+	value, err := Factory().New(context.Background(), resource.Input{
+		Settings: json.RawMessage(`{
+			"id": "deepseek",
+			"spec": {"api": "responses"},
+			"profiles": [{
+				"id": "default",
+				"secrets": {"api_key": "sk-test"}
+			}]
+		}`),
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	provider := value.(inference.ProviderDefinition)
+	decoder, ok := provider.ExtensionDecoders[extensionGenerate]
+	if !ok {
+		t.Fatalf("ExtensionDecoders = %#v, want %q", provider.ExtensionDecoders, extensionGenerate)
+	}
+
+	extensions, err := inference.DecodeExtensions([]inference.ExtensionEntry{{
+		Provider: "deepseek",
+		ID:       extensionGenerate,
+		Fields: json.RawMessage(`{
+			"web_search": {
+				"tool_choice": {"required": true},
+				"search_context_size": "high"
+			}
+		}`),
+	}}, map[string]inference.ExtensionDecoder{
+		"deepseek/" + extensionGenerate: decoder,
+	}, "extensions")
+	if err != nil {
+		t.Fatalf("DecodeExtensions: %v", err)
+	}
+	options, ok := extensions[0].(*GenerateOptions)
+	if !ok {
+		t.Fatalf("decoded extension = %T, want *GenerateOptions", extensions[0])
+	}
+	if options.ProviderID() != "deepseek" || options.ExtensionID() != extensionGenerate ||
+		options.WebSearch == nil || options.WebSearch.ToolChoice == nil ||
+		!options.WebSearch.ToolChoice.Required ||
+		options.WebSearch.SearchContextSize != "high" {
+		t.Fatalf("decoded options = %#v", options)
+	}
+}
+
+func TestProviderDecoderBindsDeploymentID(t *testing.T) {
+	value, err := Factory().New(context.Background(), resource.Input{
+		Settings: json.RawMessage(`{
+			"id": "ds-prod",
+			"spec": {"api": "responses"},
+			"profiles": [{
+				"id": "default",
+				"secrets": {"api_key": "sk-test"}
+			}]
+		}`),
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	provider := value.(inference.ProviderDefinition)
+	decoder, ok := provider.ExtensionDecoders[extensionGenerate]
+	if !ok {
+		t.Fatalf("ExtensionDecoders = %#v, want %q", provider.ExtensionDecoders, extensionGenerate)
+	}
+
+	// The decoder is bound to the deployment ID: the identity check
+	// passes for entries naming "ds-prod".
+	extensions, err := inference.DecodeExtensions([]inference.ExtensionEntry{{
+		Provider: "ds-prod",
+		ID:       extensionGenerate,
+	}}, map[string]inference.ExtensionDecoder{
+		"ds-prod/" + extensionGenerate: decoder,
+	}, "extensions")
+	if err != nil {
+		t.Fatalf("DecodeExtensions: %v", err)
+	}
+	if options := extensions[0].(*GenerateOptions); options.ProviderID() != "ds-prod" {
+		t.Fatalf("ProviderID = %q, want %q", options.ProviderID(), "ds-prod")
+	}
+
+	// Entries naming the driver default (or any other ID) stay
+	// unregistered instead of silently decoding with a mismatch.
+	_, err = inference.DecodeExtensions([]inference.ExtensionEntry{{
+		Provider: "deepseek",
+		ID:       extensionGenerate,
+	}}, map[string]inference.ExtensionDecoder{
+		"ds-prod/" + extensionGenerate: decoder,
+	}, "extensions")
+	if err == nil || !errdefs.IsValidation(err) ||
+		!strings.Contains(err.Error(), "not registered by the host") {
+		t.Fatalf("wrong-provider error = %v, want Validation for unregistered identity", err)
 	}
 }

--- a/driver/kimi/resource.go
+++ b/driver/kimi/resource.go
@@ -74,7 +74,14 @@ func buildProvider(settings ResourceSettings) (inference.ProviderDefinition, err
 		profiles[profile.ID] = material
 	}
 
-	provider := inference.ProviderDefinition{ID: settings.ID}
+	provider := inference.ProviderDefinition{
+		ID: settings.ID,
+		ExtensionDecoders: map[string]inference.ExtensionDecoder{
+			extensionGenerate: inference.ExtensionDecoderFor(func() *GenerateOptions {
+				return &GenerateOptions{Provider: settings.ID}
+			}),
+		},
+	}
 	for _, profile := range settings.Profiles {
 		provider.Profiles = append(
 			provider.Profiles,

--- a/driver/kimi/resource_test.go
+++ b/driver/kimi/resource_test.go
@@ -42,3 +42,59 @@ func TestRegisterAddsKimiProviderFactory(t *testing.T) {
 		t.Fatalf("factory %s/kimi missing", ResourceKind)
 	}
 }
+
+func TestProviderCarriesGenerateOptionsDecoder(t *testing.T) {
+	value, err := Factory().New(context.Background(), resource.Input{
+		Settings: json.RawMessage(`{
+			"id": "kimi",
+			"profiles": [{"id": "default", "secrets": {"api_key": "sk-test"}}]
+		}`),
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	provider := value.(inference.ProviderDefinition)
+	decoder, ok := provider.ExtensionDecoders[extensionGenerate]
+	if !ok {
+		t.Fatalf("ExtensionDecoders = %#v, want %q", provider.ExtensionDecoders, extensionGenerate)
+	}
+
+	extensions, err := inference.DecodeExtensions([]inference.ExtensionEntry{{
+		Provider: "kimi",
+		ID:       extensionGenerate,
+		Fields:   json.RawMessage(`{"prompt_cache_key":"sess-1","preserve_thinking":true}`),
+	}}, map[string]inference.ExtensionDecoder{
+		"kimi/" + extensionGenerate: decoder,
+	}, "extensions")
+	if err != nil {
+		t.Fatalf("DecodeExtensions: %v", err)
+	}
+	options := extensions[0].(*GenerateOptions)
+	if options.ProviderID() != "kimi" || options.PromptCacheKey != "sess-1" ||
+		options.PreserveThinking == nil || !*options.PreserveThinking {
+		t.Fatalf("decoded options = %#v", options)
+	}
+
+	value, err = Factory().New(context.Background(), resource.Input{
+		Settings: json.RawMessage(`{
+			"id": "km-prod",
+			"profiles": [{"id": "default", "secrets": {"api_key": "sk-test"}}]
+		}`),
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	decoder = value.(inference.ProviderDefinition).ExtensionDecoders[extensionGenerate]
+	extensions, err = inference.DecodeExtensions([]inference.ExtensionEntry{{
+		Provider: "km-prod",
+		ID:       extensionGenerate,
+	}}, map[string]inference.ExtensionDecoder{
+		"km-prod/" + extensionGenerate: decoder,
+	}, "extensions")
+	if err != nil {
+		t.Fatalf("DecodeExtensions: %v", err)
+	}
+	if options := extensions[0].(*GenerateOptions); options.ProviderID() != "km-prod" {
+		t.Fatalf("ProviderID = %q, want %q", options.ProviderID(), "km-prod")
+	}
+}

--- a/driver/minimax/resource.go
+++ b/driver/minimax/resource.go
@@ -75,7 +75,14 @@ func buildProvider(settings ResourceSettings) (inference.ProviderDefinition, err
 		profiles[profile.ID] = material
 	}
 
-	provider := inference.ProviderDefinition{ID: settings.ID}
+	provider := inference.ProviderDefinition{
+		ID: settings.ID,
+		ExtensionDecoders: map[string]inference.ExtensionDecoder{
+			extensionMusic: inference.ExtensionDecoderFor(func() *MusicOptions {
+				return &MusicOptions{Provider: settings.ID}
+			}),
+		},
+	}
 	for _, profile := range settings.Profiles {
 		provider.Profiles = append(
 			provider.Profiles,

--- a/driver/minimax/resource_test.go
+++ b/driver/minimax/resource_test.go
@@ -42,3 +42,59 @@ func TestRegisterAddsMiniMaxProviderFactory(t *testing.T) {
 		t.Fatalf("factory %s/minimax missing", ResourceKind)
 	}
 }
+
+func TestProviderCarriesMusicOptionsDecoder(t *testing.T) {
+	value, err := Factory().New(context.Background(), resource.Input{
+		Settings: json.RawMessage(`{
+			"id": "minimax",
+			"profiles": [{"id": "default", "secrets": {"api_key": "sk-test"}}]
+		}`),
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	provider := value.(inference.ProviderDefinition)
+	decoder, ok := provider.ExtensionDecoders[extensionMusic]
+	if !ok {
+		t.Fatalf("ExtensionDecoders = %#v, want %q", provider.ExtensionDecoders, extensionMusic)
+	}
+
+	extensions, err := inference.DecodeExtensions([]inference.ExtensionEntry{{
+		Provider: "minimax",
+		ID:       extensionMusic,
+		Fields:   json.RawMessage(`{"lyrics":"hello world","instrumental":true}`),
+	}}, map[string]inference.ExtensionDecoder{
+		"minimax/" + extensionMusic: decoder,
+	}, "extensions")
+	if err != nil {
+		t.Fatalf("DecodeExtensions: %v", err)
+	}
+	options := extensions[0].(*MusicOptions)
+	if options.ProviderID() != "minimax" || options.Lyrics != "hello world" ||
+		options.Instrumental == nil || !*options.Instrumental {
+		t.Fatalf("decoded options = %#v", options)
+	}
+
+	value, err = Factory().New(context.Background(), resource.Input{
+		Settings: json.RawMessage(`{
+			"id": "mm-prod",
+			"profiles": [{"id": "default", "secrets": {"api_key": "sk-test"}}]
+		}`),
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	decoder = value.(inference.ProviderDefinition).ExtensionDecoders[extensionMusic]
+	extensions, err = inference.DecodeExtensions([]inference.ExtensionEntry{{
+		Provider: "mm-prod",
+		ID:       extensionMusic,
+	}}, map[string]inference.ExtensionDecoder{
+		"mm-prod/" + extensionMusic: decoder,
+	}, "extensions")
+	if err != nil {
+		t.Fatalf("DecodeExtensions: %v", err)
+	}
+	if options := extensions[0].(*MusicOptions); options.ProviderID() != "mm-prod" {
+		t.Fatalf("ProviderID = %q, want %q", options.ProviderID(), "mm-prod")
+	}
+}

--- a/driver/openai/resource.go
+++ b/driver/openai/resource.go
@@ -94,7 +94,14 @@ func buildProvider(settings ResourceSettings) (inference.ProviderDefinition, err
 		profiles[profile.ID] = material
 	}
 
-	provider := inference.ProviderDefinition{ID: settings.ID}
+	provider := inference.ProviderDefinition{
+		ID: settings.ID,
+		ExtensionDecoders: map[string]inference.ExtensionDecoder{
+			extensionGenerate: inference.ExtensionDecoderFor(func() *GenerateOptions {
+				return &GenerateOptions{Provider: settings.ID}
+			}),
+		},
+	}
 	for _, profile := range settings.Profiles {
 		provider.Profiles = append(
 			provider.Profiles,

--- a/driver/openai/resource_test.go
+++ b/driver/openai/resource_test.go
@@ -60,3 +60,67 @@ func TestRegisterAddsOpenAIProviderFactory(t *testing.T) {
 		t.Fatalf("factory %s/openai missing", ResourceKind)
 	}
 }
+
+func TestProviderCarriesGenerateOptionsDecoder(t *testing.T) {
+	value, err := Factory().New(context.Background(), resource.Input{
+		Settings: json.RawMessage(`{
+			"id": "openai",
+			"profiles": [{"id": "default", "secrets": {"api_key": "sk-test"}}]
+		}`),
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	provider := value.(inference.ProviderDefinition)
+	decoder, ok := provider.ExtensionDecoders[extensionGenerate]
+	if !ok {
+		t.Fatalf("ExtensionDecoders = %#v, want %q", provider.ExtensionDecoders, extensionGenerate)
+	}
+
+	extensions, err := inference.DecodeExtensions([]inference.ExtensionEntry{{
+		Provider: "openai",
+		ID:       extensionGenerate,
+		Fields: json.RawMessage(`{
+			"web_search": {
+				"tool_choice": {"required": true},
+				"search_context_size": "high"
+			}
+		}`),
+	}}, map[string]inference.ExtensionDecoder{
+		"openai/" + extensionGenerate: decoder,
+	}, "extensions")
+	if err != nil {
+		t.Fatalf("DecodeExtensions: %v", err)
+	}
+	options := extensions[0].(*GenerateOptions)
+	if options.ProviderID() != "openai" || options.WebSearch == nil ||
+		options.WebSearch.ToolChoice == nil || !options.WebSearch.ToolChoice.Required ||
+		options.WebSearch.SearchContextSize != "high" {
+		t.Fatalf("decoded options = %#v", options)
+	}
+
+	// A renamed deployment still decodes: the decoder is bound to the
+	// deployment provider ID, not the driver default.
+	value, err = Factory().New(context.Background(), resource.Input{
+		Settings: json.RawMessage(`{
+			"id": "oa-prod",
+			"profiles": [{"id": "default", "secrets": {"api_key": "sk-test"}}]
+		}`),
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	decoder = value.(inference.ProviderDefinition).ExtensionDecoders[extensionGenerate]
+	extensions, err = inference.DecodeExtensions([]inference.ExtensionEntry{{
+		Provider: "oa-prod",
+		ID:       extensionGenerate,
+	}}, map[string]inference.ExtensionDecoder{
+		"oa-prod/" + extensionGenerate: decoder,
+	}, "extensions")
+	if err != nil {
+		t.Fatalf("DecodeExtensions: %v", err)
+	}
+	if options := extensions[0].(*GenerateOptions); options.ProviderID() != "oa-prod" {
+		t.Fatalf("ProviderID = %q, want %q", options.ProviderID(), "oa-prod")
+	}
+}

--- a/driver/qwen/resource.go
+++ b/driver/qwen/resource.go
@@ -75,7 +75,17 @@ func buildProvider(settings ResourceSettings) (inference.ProviderDefinition, err
 		profiles[profile.ID] = material
 	}
 
-	provider := inference.ProviderDefinition{ID: settings.ID}
+	provider := inference.ProviderDefinition{
+		ID: settings.ID,
+		ExtensionDecoders: map[string]inference.ExtensionDecoder{
+			extensionGenerate: inference.ExtensionDecoderFor(func() *GenerateOptions {
+				return &GenerateOptions{Provider: settings.ID}
+			}),
+			extensionEmbed: inference.ExtensionDecoderFor(func() *EmbedOptions {
+				return &EmbedOptions{Provider: settings.ID}
+			}),
+		},
+	}
 	for _, profile := range settings.Profiles {
 		provider.Profiles = append(
 			provider.Profiles,

--- a/driver/qwen/resource_test.go
+++ b/driver/qwen/resource_test.go
@@ -42,3 +42,77 @@ func TestRegisterAddsQwenProviderFactory(t *testing.T) {
 		t.Fatalf("factory %s/qwen missing", ResourceKind)
 	}
 }
+
+func TestProviderCarriesExtensionDecoders(t *testing.T) {
+	value, err := Factory().New(context.Background(), resource.Input{
+		Settings: json.RawMessage(`{
+			"id": "qwen",
+			"profiles": [{"id": "default", "secrets": {"api_key": "sk-test"}}]
+		}`),
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	provider := value.(inference.ProviderDefinition)
+	decoders := map[string]inference.ExtensionDecoder{}
+	for id, decoder := range provider.ExtensionDecoders {
+		decoders["qwen/"+id] = decoder
+	}
+	if _, ok := decoders["qwen/"+extensionGenerate]; !ok {
+		t.Fatalf("ExtensionDecoders = %#v, want %q", provider.ExtensionDecoders, extensionGenerate)
+	}
+	if _, ok := decoders["qwen/"+extensionEmbed]; !ok {
+		t.Fatalf("ExtensionDecoders = %#v, want %q", provider.ExtensionDecoders, extensionEmbed)
+	}
+
+	extensions, err := inference.DecodeExtensions([]inference.ExtensionEntry{
+		{
+			Provider: "qwen",
+			ID:       extensionGenerate,
+			Fields:   json.RawMessage(`{"thinking_budget":100,"top_k":20}`),
+		},
+		{
+			Provider: "qwen",
+			ID:       extensionEmbed,
+			Fields:   json.RawMessage(`{"text_type":"query","instruct":"rank by relevance"}`),
+		},
+	}, decoders, "extensions")
+	if err != nil {
+		t.Fatalf("DecodeExtensions: %v", err)
+	}
+	generate, ok := extensions[0].(*GenerateOptions)
+	if !ok || generate.ProviderID() != "qwen" || generate.ThinkingBudget == nil ||
+		*generate.ThinkingBudget != 100 || generate.TopK == nil || *generate.TopK != 20 {
+		t.Fatalf("decoded generate options = %#v", extensions[0])
+	}
+	embed, ok := extensions[1].(*EmbedOptions)
+	if !ok || embed.ProviderID() != "qwen" || embed.TextType != "query" ||
+		embed.Instruct != "rank by relevance" {
+		t.Fatalf("decoded embed options = %#v", extensions[1])
+	}
+
+	// A renamed deployment still decodes: decoders are bound to the
+	// deployment provider ID, not the driver default.
+	value, err = Factory().New(context.Background(), resource.Input{
+		Settings: json.RawMessage(`{
+			"id": "qw-prod",
+			"profiles": [{"id": "default", "secrets": {"api_key": "sk-test"}}]
+		}`),
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	decoder := value.(inference.ProviderDefinition).ExtensionDecoders[extensionGenerate]
+	extensions, err = inference.DecodeExtensions([]inference.ExtensionEntry{{
+		Provider: "qw-prod",
+		ID:       extensionGenerate,
+	}}, map[string]inference.ExtensionDecoder{
+		"qw-prod/" + extensionGenerate: decoder,
+	}, "extensions")
+	if err != nil {
+		t.Fatalf("DecodeExtensions: %v", err)
+	}
+	if options := extensions[0].(*GenerateOptions); options.ProviderID() != "qw-prod" {
+		t.Fatalf("ProviderID = %q, want %q", options.ProviderID(), "qw-prod")
+	}
+}

--- a/go.work
+++ b/go.work
@@ -15,7 +15,3 @@ use (
 	./memory
 	./memory/eval
 )
-
-replace github.com/GizClaw/flowcraft/driver/deepseek v0.1.0 => ./driver/deepseek
-
-replace github.com/GizClaw/flowcraft/driver/openai v0.1.0 => ./driver/openai


### PR DESCRIPTION
## Summary

Graph `inference` node `extensions` currently always fail at runtime with `extension "deepseek/generate_options" is not registered by the host`: the deploy path never wires a decoder registry, and decoders only existed as host-side, hand-registered entries on the script bridge.

This PR makes decoders **provider-carried**, so the menu available to graph yaml matches the providers actually configured — zero host-side code.

## Changes

- **core**: move the extension wire types (`ExtensionDecoder`, `ExtensionDecoderFor`, `ExtensionEntry`, `DecodeExtensions`) from `core/agent/bindings` into `core/inference`; `ProviderDefinition` gains `ExtensionDecoders`; `Assembly.ExtensionDecoders()` aggregates them per configured provider; the graph resource wires them into the inference node (including router-only deployments via `Router.Target()`). `bindings` now uses the inference types directly, with no re-export shims.
- **drivers**: deepseek, openai, azure, kimi, qwen, bytedance, minimax register their extension decoders in `buildProvider`, bound to the deployment provider ID so renamed deployments decode correctly (qwen also embeds `embed_options`; bytedance image/video options; minimax music options).
- **tests**: unit tests for the registry, resource-layer wiring tests (assembly + router-only + unregistered rejection), and per-driver decoder registration/deployment-ID binding tests.

## Verification

- `go vet` + `go test ./... -count=1` across all workspace modules: pass
- `golangci-lint` on core + all drivers: 0 issues
- `git diff --check` clean; `make release-check`: changesets valid, no pending releases

Closes #330