### PR TITLE
feat(core): expose response_format on graph inference node config

### DIFF
--- a/core/graph/nodes/inference.go
+++ b/core/graph/nodes/inference.go
@@ -70,6 +70,12 @@ type InferenceConfig struct {
 	ReasoningEnabled *bool                     `json:"reasoning_enabled,omitempty"`
 	ReasoningEffort  inference.ReasoningEffort `json:"reasoning_effort,omitempty"`
 
+	// ResponseFormat shapes the model's reply: text, json_object, or
+	// json_schema (name + schema). Providers that cannot honor the
+	// shape reject the request at compile time; the runtime re-validates
+	// the generated text against the schema before returning it.
+	ResponseFormat *inference.ResponseFormat `json:"response_format,omitempty"`
+
 	// Extensions names provider knobs in the shared {provider, id,
 	// fields} wire form (see inference.DecodeExtensions). Decoders are
 	// provider-carried: the deploy path aggregates them from the wired
@@ -257,6 +263,7 @@ func buildGenerateRequest(ec graph.ExecutionContext, board *agent.Board, channel
 	}
 
 	text := &inference.TextIntent{
+		Response:         cfg.ResponseFormat,
 		ToolChoice:       cfg.ToolChoice,
 		Temperature:      cfg.Temperature,
 		TopP:             cfg.TopP,

--- a/core/graph/nodes/inference_test.go
+++ b/core/graph/nodes/inference_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"io"
 	"reflect"
+	"strings"
 	"sync"
 	"testing"
 
@@ -714,6 +715,139 @@ func TestInferenceNode_Extensions(t *testing.T) {
 	}
 	if ext, ok := exts[0].(testExtension); !ok || ext.CacheKey != "sess-1" {
 		t.Fatalf("extension = %+v (%T), want cache_key sess-1", exts[0], exts[0])
+	}
+}
+
+func TestInferenceNode_ResponseFormat_ReachesRequest(t *testing.T) {
+	fake := &inferencetest.GenerateFake{
+		Respond: func(inference.GenerateRequest) inference.GenerateResponse {
+			return inference.GenerateResponse{
+				Message: message.Message{
+					Role: message.RoleAssistant,
+					Content: message.Content{Parts: []message.Part{
+						message.TextPart{Text: `{"answer":"42"}`},
+					}},
+				},
+				FinishReason: inference.FinishCompleted,
+			}
+		},
+	}
+	reg := inferenceRegistry(t, InferenceNodeDeps{Assembly: fake.Assembly(t)})
+	g := singleNodeGraph(t, reg, "inference", InferenceConfig{
+		Model: ptr(inferencetest.DefaultFakeModel),
+		ResponseFormat: &inference.ResponseFormat{
+			Kind: inference.ResponseJSONSchema,
+			Name: "answer",
+			Schema: json.RawMessage(
+				`{"type":"object","properties":{"answer":{"type":"string"}},"required":["answer"]}`,
+			),
+		},
+	})
+	board := userBoard()
+	if err := executeGraph(t, g, agent.NoopHost{}, board); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+
+	req := fake.LastRequest()
+	response := req.Input.Content.Intent.Text.Response
+	if response == nil || response.Kind != inference.ResponseJSONSchema ||
+		response.Name != "answer" || len(response.Schema) == 0 {
+		t.Fatalf("request response format = %#v, want json_schema answer", response)
+	}
+	msgs := board.Channel(agent.MainChannel)
+	if text, ok := msgs[len(msgs)-1].Content.Parts[0].(message.TextPart); !ok ||
+		text.Text != `{"answer":"42"}` {
+		t.Fatalf("assistant message = %+v, want structured JSON", msgs[len(msgs)-1].Content.Parts[0])
+	}
+}
+
+func TestInferenceNode_ResponseFormat_Enforced(t *testing.T) {
+	cases := []struct {
+		name    string
+		format  *inference.ResponseFormat
+		respond string
+		want    string
+	}{
+		{
+			name:    "json_object rejects plain text",
+			respond: "ok",
+			format: &inference.ResponseFormat{
+				Kind: inference.ResponseJSONObject,
+			},
+			want: "structured generate response is not valid JSON",
+		},
+		{
+			name:    "json_schema rejects non-conforming JSON",
+			respond: `{"answer":42}`,
+			format: &inference.ResponseFormat{
+				Kind: inference.ResponseJSONSchema,
+				Name: "answer",
+				Schema: json.RawMessage(
+					`{"type":"object","properties":{"answer":{"type":"string"}},"required":["answer"]}`,
+				),
+			},
+			want: "does not match requested JSON schema",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			fake := &inferencetest.GenerateFake{
+				Respond: func(inference.GenerateRequest) inference.GenerateResponse {
+					return inference.GenerateResponse{
+						Message: message.Message{
+							Role: message.RoleAssistant,
+							Content: message.Content{Parts: []message.Part{
+								message.TextPart{Text: tc.respond},
+							}},
+						},
+						FinishReason: inference.FinishCompleted,
+					}
+				},
+			}
+			reg := inferenceRegistry(t, InferenceNodeDeps{Assembly: fake.Assembly(t)})
+			g := singleNodeGraph(t, reg, "inference", InferenceConfig{
+				Model:          ptr(inferencetest.DefaultFakeModel),
+				ResponseFormat: tc.format,
+			})
+			err := executeGraph(t, g, agent.NoopHost{}, userBoard())
+			if err == nil || !strings.Contains(responseCause(err), tc.want) {
+				t.Fatalf("Execute error = %v, want containing %q", err, tc.want)
+			}
+		})
+	}
+}
+
+// responseCause collects every layer of the error chain so assertions
+// can see the provider-response detail behind the kind/operation
+// envelope and its errdefs classification wrapper.
+func responseCause(err error) string {
+	var parts []string
+	for e := err; e != nil; {
+		parts = append(parts, e.Error())
+		var inferErr *inference.Error
+		if errors.As(e, &inferErr) && inferErr.Unwrap() != nil {
+			e = inferErr.Unwrap()
+			continue
+		}
+		e = errors.Unwrap(e)
+	}
+	return strings.Join(parts, " | ")
+}
+
+func TestInferenceNode_ResponseFormat_RejectsInvalidSchema(t *testing.T) {
+	fake := &inferencetest.GenerateFake{}
+	reg := inferenceRegistry(t, InferenceNodeDeps{Assembly: fake.Assembly(t)})
+	g := singleNodeGraph(t, reg, "inference", InferenceConfig{
+		Model: ptr(inferencetest.DefaultFakeModel),
+		ResponseFormat: &inference.ResponseFormat{
+			Kind:   inference.ResponseJSONSchema,
+			Name:   "answer",
+			Schema: json.RawMessage(`{"type":1}`),
+		},
+	})
+	err := executeGraph(t, g, agent.NoopHost{}, userBoard())
+	if err == nil || !strings.Contains(responseCause(err), "schema") {
+		t.Fatalf("Execute error = %v, want schema validation failure", err)
 	}
 }
 

--- a/core/graph/resource/resource_test.go
+++ b/core/graph/resource/resource_test.go
@@ -231,3 +231,62 @@ func TestFactoryRejectsExtensionsWithoutConfiguredDecoder(t *testing.T) {
 		t.Fatalf("Execute error = %v, want Validation for unregistered extension", err)
 	}
 }
+
+func TestFactoryWiresResponseFormatConfig(t *testing.T) {
+	fake := &inferencetest.GenerateFake{
+		Respond: func(inference.GenerateRequest) inference.GenerateResponse {
+			return inference.GenerateResponse{
+				Message: message.Message{
+					Role: message.RoleAssistant,
+					Content: message.Content{Parts: []message.Part{
+						message.TextPart{Text: `{"answer":"42"}`},
+					}},
+				},
+				FinishReason: inference.FinishCompleted,
+			}
+		},
+	}
+	def, _ := json.Marshal(map[string]any{
+		"name":  "g",
+		"entry": "n1",
+		"nodes": []any{
+			map[string]any{
+				"id":   "n1",
+				"type": "inference",
+				"config": map[string]any{
+					"model": map[string]any{
+						"id":      map[string]any{"provider": "fake", "name": "echo"},
+						"profile": "default",
+					},
+					"response_format": map[string]any{
+						"kind": "json_schema",
+						"name": "answer",
+						"schema": map[string]any{
+							"type":       "object",
+							"properties": map[string]any{"answer": map[string]any{"type": "string"}},
+							"required":   []any{"answer"},
+						},
+					},
+				},
+			},
+		},
+		"edges": []any{},
+	})
+	value, err := (graphresource.Factory{}).New(context.Background(), resource.Input{
+		Settings: []byte(`{"graph": ` + string(def) + `}`),
+		Deps: map[string]any{
+			"inference": fake.Assembly(t),
+		},
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	if err := executeTestGraph(t, value.(*coregraph.Graph)); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	response := fake.LastRequest().Input.Content.Intent.Text.Response
+	if response == nil || response.Kind != inference.ResponseJSONSchema ||
+		response.Name != "answer" || len(response.Schema) == 0 {
+		t.Fatalf("request response format = %#v, want json_schema answer", response)
+	}
+}


### PR DESCRIPTION
## Summary

The graph `inference` node now accepts a `response_format` config so deployments can request structured output directly from yaml:

```yaml
- id: llm
  type: inference
  config:
    response_format:
      kind: json_schema
      name: answer
      schema:
        type: object
        properties:
          answer: {type: string}
        required: [answer]
```

It maps straight into `TextIntent.Response` and reuses the existing pipeline: request-time offline schema compile (no remote refs), provider-native `response_format` compilation (or compile-time rejection for providers without a schema surface), and post-generation re-validation of the text against the requested schema.

## Changes

- `InferenceConfig.ResponseFormat` (`response_format`) wired into `buildGenerateRequest`.
- Tests: node-level (request carries kind/name/schema; `json_object` rejects plain text; `json_schema` rejects non-conforming JSON; invalid schema fails request validation) and a graph-resource yaml end-to-end test.

## Verification

- `go vet` + `go test ./... -count=1` (core): pass
- `golangci-lint` core: 0 issues
- `git diff --check` clean