### PR TITLE
feat(core): dynamic agent registry for runtime register/unregister

### DIFF
--- a/core/agent/close.go
+++ b/core/agent/close.go
@@ -1,0 +1,43 @@
+package agent
+
+import (
+	"errors"
+	"io"
+)
+
+// Close releases the resources held by the agent's engine and lifecycle
+// hooks. Components that do not implement io.Closer are skipped, and
+// close errors are aggregated with errors.Join. Idempotency of each
+// component is that component's responsibility. Close is safe on a nil
+// receiver and on nil/typed-nil components.
+func (a *Agent) Close() error {
+	if a == nil {
+		return nil
+	}
+	var errs []error
+	closeIfCloser(&errs, a.Engine)
+	closeSlice(&errs, a.Prepare)
+	closeSlice(&errs, a.Observe)
+	closeSlice(&errs, a.Referees)
+	closeSlice(&errs, a.Commit)
+	return errors.Join(errs...)
+}
+
+func closeSlice[T any](errs *[]error, values []T) {
+	for _, value := range values {
+		closeIfCloser(errs, value)
+	}
+}
+
+func closeIfCloser(errs *[]error, value any) {
+	if value == nil || isNilInterface(value) {
+		return
+	}
+	closer, ok := value.(io.Closer)
+	if !ok {
+		return
+	}
+	if err := closer.Close(); err != nil {
+		*errs = append(*errs, err)
+	}
+}

--- a/core/agent/close_test.go
+++ b/core/agent/close_test.go
@@ -1,0 +1,145 @@
+package agent
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+type closableEngine struct {
+	closed bool
+	err    error
+}
+
+func (e *closableEngine) Execute(
+	context.Context, Run, Host, *Board,
+) (*Board, error) {
+	return nil, nil
+}
+
+func (e *closableEngine) Close() error {
+	e.closed = true
+	return e.err
+}
+
+type closablePreparer struct {
+	closed bool
+	err    error
+}
+
+func (p *closablePreparer) Before(
+	context.Context, Identity, *Request, *Board,
+) (*Board, error) {
+	return nil, nil
+}
+
+func (p *closablePreparer) Close() error {
+	p.closed = true
+	return p.err
+}
+
+type closableObserver struct {
+	BaseObserver
+	closed bool
+	err    error
+}
+
+func (o *closableObserver) Close() error {
+	o.closed = true
+	return o.err
+}
+
+type closableReferee struct {
+	closed bool
+	err    error
+}
+
+func (r *closableReferee) After(
+	context.Context, Identity, *Request, *Result,
+) (Decision, error) {
+	return Decision{}, nil
+}
+
+func (r *closableReferee) Close() error {
+	r.closed = true
+	return r.err
+}
+
+type closableCommitter struct {
+	closed bool
+	err    error
+}
+
+func (c *closableCommitter) Commit(
+	context.Context, Identity, *Request, *Result,
+) error {
+	return nil
+}
+
+func (c *closableCommitter) Close() error {
+	c.closed = true
+	return c.err
+}
+
+func TestAgentCloseClosesComponents(t *testing.T) {
+	engine := &closableEngine{}
+	prepare := &closablePreparer{}
+	observe := &closableObserver{}
+	referee := &closableReferee{}
+	commit := &closableCommitter{}
+
+	a := &Agent{
+		Engine:   engine,
+		Prepare:  []Preparer{prepare},
+		Observe:  []Observer{observe},
+		Referees: []Referee{referee},
+		Commit:   []Committer{commit},
+	}
+	if err := a.Close(); err != nil {
+		t.Fatalf("Close() error = %v", err)
+	}
+	for name, closed := range map[string]bool{
+		"engine":  engine.closed,
+		"prepare": prepare.closed,
+		"observe": observe.closed,
+		"referee": referee.closed,
+		"commit":  commit.closed,
+	} {
+		if !closed {
+			t.Errorf("%s was not closed", name)
+		}
+	}
+}
+
+func TestAgentCloseAggregatesErrors(t *testing.T) {
+	engineErr := errors.New("engine boom")
+	hookErr := errors.New("hook boom")
+	a := &Agent{
+		Engine: &closableEngine{err: engineErr},
+		Observe: []Observer{
+			&closableObserver{err: hookErr},
+			&closableObserver{},
+		},
+	}
+	err := a.Close()
+	if err == nil {
+		t.Fatal("Close() error = nil, want aggregated errors")
+	}
+	if !errors.Is(err, engineErr) || !errors.Is(err, hookErr) {
+		t.Fatalf("Close() error = %v, want both component errors", err)
+	}
+}
+
+func TestAgentCloseSkipsNilAndTypedNil(t *testing.T) {
+	a := &Agent{
+		Engine:  EngineFunc(nil),
+		Prepare: []Preparer{nil},
+	}
+	if err := a.Close(); err != nil {
+		t.Fatalf("Close() error = %v, want nil", err)
+	}
+	var nilAgent *Agent
+	if err := nilAgent.Close(); err != nil {
+		t.Fatalf("nil receiver Close() error = %v, want nil", err)
+	}
+}

--- a/core/deploy/builder.go
+++ b/core/deploy/builder.go
@@ -3,6 +3,7 @@ package deploy
 import (
 	"context"
 	"errors"
+	"fmt"
 	"io"
 	"reflect"
 	"sort"
@@ -200,134 +201,204 @@ func (b *Builder) Deploy(ctx context.Context, doc Document) (*Result, error) {
 	return result, nil
 }
 
-// bindAgents constructs every [agent.Agent] from its Definition: the
-// engine from the registry (kind = EngineRef.Kind / Impl), then each
-// hook under "hook.<slot>". Hooks are wired (attached) before being
-// recorded on the agent.
+// bindAgents constructs every [agent.Agent] from its Definition and
+// records it on the result.
 func (b *Builder) bindAgents(ctx context.Context, result *Result, doc Document) error {
 	for name, def := range doc.Agents {
-		engineFactory, ok := b.registry.Lookup(def.Engine.Kind, def.Engine.Impl)
-		if !ok {
-			return errdefs.Validationf(
-				"deploy: agent %q: no factory for engine %s/%s",
-				name, def.Engine.Kind, def.Engine.Impl)
-		}
-		if err := validateDeps(engineFactory, def.Engine.Deps); err != nil {
-			return errdefs.Validationf("deploy: agent %q engine: %v", name, err)
-		}
-		engineDeps, err := resolveDeps(result.values, def.Engine.Deps)
-		if err != nil {
-			return errdefs.Validationf("deploy: agent %q: %v", name, err)
-		}
-		engine, err := engineFactory.New(ctx, resource.Input{
-			Settings: def.Engine.Settings,
-			Deps:     engineDeps,
-			Loader:   b.loader,
-		})
-		if err != nil {
-			return errdefs.Validationf("deploy: agent %q engine: %v", name, err)
-		}
-		engineContract, ok := engine.(agent.Engine)
-		if !ok {
-			return errdefs.Validationf(
-				"deploy: agent %q: engine factory returned %T, want agent.Engine",
-				name, engine)
-		}
-
-		prepare, err := buildHookList[agent.Preparer](
-			b, result, ctx, name, agent.HookSlotPreparer, def.Prepare)
+		instance, err := BindAgent(ctx, b.registry, result, b.loader, name, def)
 		if err != nil {
 			return err
 		}
-		observe, err := buildHookList[agent.Observer](
-			b, result, ctx, name, agent.HookSlotObserver, def.Observe)
-		if err != nil {
-			return err
-		}
-		referees, err := buildHookList[agent.Referee](
-			b, result, ctx, name, agent.HookSlotReferee, def.Referees)
-		if err != nil {
-			return err
-		}
-		commit, err := buildHookList[agent.Committer](
-			b, result, ctx, name, agent.HookSlotCommitter, def.Commit)
-		if err != nil {
-			return err
-		}
-
-		policy := agent.Policy{}
-		if def.Policy != nil {
-			policy = *def.Policy
-		}
-
-		result.agents[name] = &agent.Agent{
-			ID:       name,
-			Card:     def.Card,
-			Tools:    def.Tools,
-			Policy:   policy,
-			Engine:   engineContract,
-			Prepare:  prepare,
-			Observe:  observe,
-			Referees: referees,
-			Commit:   commit,
-		}
+		result.agents[name] = instance
 	}
 	return nil
 }
 
+// BindAgent assembles one [agent.Agent] from its Definition: the engine
+// from the registry (kind = EngineRef.Kind / Impl), then each hook under
+// "hook.<slot>", wiring [resource.Wireable] hooks before recording them
+// on the agent. It never mutates result (result.agents stays untouched),
+// so callers decide where the assembled agent is recorded — deployment
+// build records it on the Result, while core/runtime registers it in the
+// live agent registry.
+//
+// On failure, every component already constructed (engine and any wired
+// hooks) is closed in reverse order so a partial assembly never leaks
+// attached subscriptions or other resources.
+func BindAgent(
+	ctx context.Context,
+	reg *resource.Registry,
+	result *Result,
+	loader *resource.Loader,
+	name string,
+	def agent.Definition,
+) (*agent.Agent, error) {
+	if reg == nil {
+		return nil, errdefs.Validationf(
+			"deploy: agent %q: resource registry is required", name)
+	}
+	engineFactory, ok := reg.Lookup(def.Engine.Kind, def.Engine.Impl)
+	if !ok {
+		return nil, errdefs.Validationf(
+			"deploy: agent %q: no factory for engine %s/%s",
+			name, def.Engine.Kind, def.Engine.Impl)
+	}
+	if err := validateDeps(engineFactory, def.Engine.Deps); err != nil {
+		return nil, errdefs.Validationf("deploy: agent %q engine: %v", name, err)
+	}
+	engineDeps, err := resolveDeps(result.values, def.Engine.Deps)
+	if err != nil {
+		return nil, errdefs.Validationf("deploy: agent %q: %v", name, err)
+	}
+
+	var constructed []any
+	fail := func(err error) (*agent.Agent, error) {
+		closeAgentParts(constructed)
+		return nil, err
+	}
+
+	engine, err := engineFactory.New(ctx, resource.Input{
+		Settings: def.Engine.Settings,
+		Deps:     engineDeps,
+		Loader:   loader,
+	})
+	if err != nil {
+		return fail(errdefs.Validationf("deploy: agent %q engine: %v", name, err))
+	}
+	engineContract, ok := engine.(agent.Engine)
+	if !ok {
+		return fail(errdefs.Validationf(
+			"deploy: agent %q: engine factory returned %T, want agent.Engine",
+			name, engine))
+	}
+	constructed = append(constructed, engineContract)
+
+	prepare, err := buildHookList[agent.Preparer](
+		reg, loader, result, ctx, name, agent.HookSlotPreparer, def.Prepare)
+	if err != nil {
+		return fail(err)
+	}
+	constructed = appendAny(constructed, prepare)
+
+	observe, err := buildHookList[agent.Observer](
+		reg, loader, result, ctx, name, agent.HookSlotObserver, def.Observe)
+	if err != nil {
+		return fail(err)
+	}
+	constructed = appendAny(constructed, observe)
+
+	referees, err := buildHookList[agent.Referee](
+		reg, loader, result, ctx, name, agent.HookSlotReferee, def.Referees)
+	if err != nil {
+		return fail(err)
+	}
+	constructed = appendAny(constructed, referees)
+
+	commit, err := buildHookList[agent.Committer](
+		reg, loader, result, ctx, name, agent.HookSlotCommitter, def.Commit)
+	if err != nil {
+		return fail(err)
+	}
+
+	policy := agent.Policy{}
+	if def.Policy != nil {
+		policy = *def.Policy
+	}
+	return &agent.Agent{
+		ID:       name,
+		Card:     def.Card,
+		Tools:    def.Tools,
+		Policy:   policy,
+		Engine:   engineContract,
+		Prepare:  prepare,
+		Observe:  observe,
+		Referees: referees,
+		Commit:   commit,
+	}, nil
+}
+
 // buildHookList constructs every hook in one slot, type-asserting the
 // factory values to T (agent.Preparer / Observer / Referee /
-// Committer) and wiring [resource.Wireable] values before recording
-// them on the agent.
+// Committer) and wiring [resource.Wireable] values before recording them
+// on the agent. On failure every constructed hook is closed in reverse
+// order.
 func buildHookList[T any](
-	b *Builder,
+	reg *resource.Registry,
+	loader *resource.Loader,
 	result *Result,
 	ctx context.Context,
 	name, slot string,
 	entries []agent.Hook,
 ) ([]T, error) {
 	var values []T
+	var constructed []any
+	fail := func(err error) ([]T, error) {
+		closeAgentParts(constructed)
+		return nil, err
+	}
 	for i, entry := range entries {
 		kind := resource.Kind("hook." + slot)
-		factory, ok := b.registry.Lookup(kind, entry.Type)
+		factory, ok := reg.Lookup(kind, entry.Type)
 		if !ok {
-			return nil, errdefs.Validationf(
+			return fail(errdefs.Validationf(
 				"deploy: agent %q: no factory for hook %s/%s",
-				name, kind, entry.Type)
+				name, kind, entry.Type))
 		}
 		if err := validateDeps(factory, entry.Deps); err != nil {
-			return nil, errdefs.Validationf(
-				"deploy: agent %q: hook %s[%d]: %v", name, slot, i, err)
+			return fail(errdefs.Validationf(
+				"deploy: agent %q: hook %s[%d]: %v", name, slot, i, err))
 		}
 		deps, err := resolveDeps(result.values, entry.Deps)
 		if err != nil {
-			return nil, errdefs.Validationf(
-				"deploy: agent %q: hook %s[%d]: %v", name, slot, i, err)
+			return fail(errdefs.Validationf(
+				"deploy: agent %q: hook %s[%d]: %v", name, slot, i, err))
 		}
 		value, err := factory.New(ctx, resource.Input{
 			Settings: entry.Settings,
 			Deps:     deps,
-			Loader:   b.loader,
+			Loader:   loader,
 		})
 		if err != nil {
-			return nil, errdefs.Validationf(
-				"deploy: agent %q: hook %s[%d]: %v", name, slot, i, err)
+			return fail(errdefs.Validationf(
+				"deploy: agent %q: hook %s[%d]: %v", name, slot, i, err))
 		}
+		constructed = append(constructed, value)
 		typed, ok := value.(T)
 		if !ok {
-			return nil, errdefs.Validationf(
+			return fail(errdefs.Validationf(
 				"deploy: agent %q: hook %s[%d] factory returned %T, want %T",
-				name, slot, i, value, *new(T))
+				name, slot, i, value, *new(T)))
 		}
 		if w, ok := value.(resource.Wireable); ok {
 			if err := w.Wire(ctx); err != nil {
-				return nil, errdefs.Validationf(
-					"deploy: agent %q: wire hook %s[%d]: %v", name, slot, i, err)
+				return fail(errdefs.Validationf(
+					"deploy: agent %q: wire hook %s[%d]: %v", name, slot, i, err))
 			}
 		}
 		values = append(values, typed)
 	}
 	return values, nil
+}
+
+func appendAny[T any](dst []any, values []T) []any {
+	for _, value := range values {
+		dst = append(dst, value)
+	}
+	return dst
+}
+
+// closeAgentParts closes every io.Closer among values in reverse order,
+// best-effort, skipping nil and typed-nil entries.
+func closeAgentParts(values []any) {
+	for i := len(values) - 1; i >= 0; i-- {
+		value := values[i]
+		if value == nil || isNilValue(value) {
+			continue
+		}
+		if closer, ok := value.(io.Closer); ok {
+			_ = closer.Close()
+		}
+	}
 }
 
 // validateDeps checks document deps against the factory's declared
@@ -449,9 +520,26 @@ func (r *Result) AgentNames() []string {
 	return names
 }
 
-// Close closes every io.Closer value in reverse construction order.
+// Close closes every io.Closer resource value in reverse construction
+// order, then closes every bound agent (engine and lifecycle hooks).
 func (r *Result) Close() error {
-	return closeAll(r.values, r.order)
+	if r == nil {
+		return nil
+	}
+	var errs []error
+	if err := closeAll(r.values, r.order); err != nil {
+		errs = append(errs, err)
+	}
+	for _, name := range r.AgentNames() {
+		instance := r.agents[name]
+		if instance == nil {
+			continue
+		}
+		if err := instance.Close(); err != nil {
+			errs = append(errs, fmt.Errorf("deploy: close agent %q: %w", name, err))
+		}
+	}
+	return errors.Join(errs...)
 }
 
 func closeAll(values map[string]any, order []string) error {

--- a/core/deploy/builder_test.go
+++ b/core/deploy/builder_test.go
@@ -501,3 +501,145 @@ func TestResultCloseReversesOrder(t *testing.T) {
 		t.Fatal("not all values were closed")
 	}
 }
+
+type closableAgentEngine struct {
+	closed bool
+}
+
+func (e *closableAgentEngine) Execute(
+	_ context.Context,
+	_ agent.Run,
+	_ agent.Host,
+	board *agent.Board,
+) (*agent.Board, error) {
+	return board, nil
+}
+
+func (e *closableAgentEngine) Close() error {
+	e.closed = true
+	return nil
+}
+
+type closableEngineFactory struct{ value *closableAgentEngine }
+
+func (f closableEngineFactory) Spec() resource.Spec {
+	return resource.Spec{Kind: "engine.test", Impl: "close"}
+}
+
+func (f closableEngineFactory) New(context.Context, resource.Input) (any, error) {
+	return f.value, nil
+}
+
+type closableHook struct {
+	agent.BaseObserver
+	closed bool
+}
+
+func (h *closableHook) Close() error {
+	h.closed = true
+	return nil
+}
+
+type sequenceHookFactory struct {
+	value  *closableHook
+	calls  int
+	failOn int
+}
+
+func (f *sequenceHookFactory) Spec() resource.Spec {
+	return resource.Spec{Kind: "hook.observe", Impl: "close"}
+}
+
+func (f *sequenceHookFactory) New(context.Context, resource.Input) (any, error) {
+	f.calls++
+	if f.failOn > 0 && f.calls == f.failOn {
+		return nil, errors.New("hook boom")
+	}
+	return f.value, nil
+}
+
+func TestBindAgentDoesNotMutateResult(t *testing.T) {
+	reg := resource.NewRegistry()
+	reg.MustRegister(engineFactory{})
+
+	result, err := deploy.NewBuilder(reg).Build(context.Background(), deploy.Document{Version: "v1"})
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	defer func() { _ = result.Close() }()
+
+	instance, err := deploy.BindAgent(context.Background(), reg, result, nil, "a", agent.Definition{
+		Card:   agent.AgentCard{Name: "A"},
+		Engine: agent.EngineRef{Kind: "engine.test", Impl: "graph"},
+	})
+	if err != nil {
+		t.Fatalf("BindAgent: %v", err)
+	}
+	if instance.ID != "a" {
+		t.Fatalf("instance ID = %q, want a", instance.ID)
+	}
+	if _, ok := result.Agent("a"); ok {
+		t.Fatal("BindAgent mutated result agents")
+	}
+}
+
+func TestBindAgentRollsBackOnHookFailure(t *testing.T) {
+	reg := resource.NewRegistry()
+	engine := &closableAgentEngine{}
+	hook := &closableHook{}
+	reg.MustRegister(closableEngineFactory{value: engine})
+	reg.MustRegister(&sequenceHookFactory{value: hook, failOn: 2})
+
+	result, err := deploy.NewBuilder(reg).Build(context.Background(), deploy.Document{Version: "v1"})
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	defer func() { _ = result.Close() }()
+
+	_, err = deploy.BindAgent(context.Background(), reg, result, nil, "a", agent.Definition{
+		Card:    agent.AgentCard{Name: "A"},
+		Engine:  agent.EngineRef{Kind: "engine.test", Impl: "close"},
+		Observe: []agent.Hook{{Type: "close"}, {Type: "close"}},
+	})
+	if err == nil {
+		t.Fatal("BindAgent unexpectedly succeeded")
+	}
+	if !engine.closed {
+		t.Fatal("engine was not closed after hook failure")
+	}
+	if !hook.closed {
+		t.Fatal("wired hook was not closed during rollback")
+	}
+}
+
+func TestResultCloseClosesAgents(t *testing.T) {
+	reg := resource.NewRegistry()
+	engine := &closableAgentEngine{}
+	hook := &closableHook{}
+	reg.MustRegister(closableEngineFactory{value: engine})
+	reg.MustRegister(&sequenceHookFactory{value: hook})
+
+	doc := deploy.Document{
+		Version: "v1",
+		Agents: map[string]agent.Definition{
+			"a": {
+				Card:    agent.AgentCard{Name: "A"},
+				Engine:  agent.EngineRef{Kind: "engine.test", Impl: "close"},
+				Observe: []agent.Hook{{Type: "close"}},
+			},
+		},
+	}
+	result, err := deploy.NewBuilder(reg).Deploy(context.Background(), doc)
+	if err != nil {
+		t.Fatalf("Deploy: %v", err)
+	}
+	if err := result.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	if !engine.closed {
+		t.Fatal("agent engine was not closed by Result.Close")
+	}
+	if !hook.closed {
+		t.Fatal("agent hook was not closed by Result.Close")
+	}
+}

--- a/core/runtime/builder.go
+++ b/core/runtime/builder.go
@@ -162,6 +162,7 @@ func (b *Builder) Build(ctx context.Context, doc deploy.Document) (*Runtime, err
 	}
 
 	var catalogProvider session.CatalogProvider
+	var liveCatalog *catalogRegistry
 	if cfg.DynamicCatalog != nil {
 		assemblies, resolveErr := resolveDynamicCatalogAssemblies(
 			doc, result, cfg.DynamicCatalog)
@@ -169,10 +170,12 @@ func (b *Builder) Build(ctx context.Context, doc deploy.Document) (*Runtime, err
 			_ = result.Close()
 			return nil, resolveErr
 		}
-		catalogProvider = newDynamicCatalogProvider(assemblies)
+		liveCatalog = newCatalogRegistry(assemblies)
+		catalogProvider = liveCatalog
 	}
 
 	router := event.NewRouter(bus)
+	registry := newAgentRegistry(result)
 	managerOptions := []session.ManagerOption{
 		session.WithIdleTimeout(cfg.Sessions.IdleTimeout),
 		session.WithSinkBufferSize(cfg.Sessions.SinkBuffer),
@@ -193,24 +196,22 @@ func (b *Builder) Build(ctx context.Context, doc deploy.Document) (*Runtime, err
 		managerOptions = append(managerOptions,
 			session.WithCatalogProvider(catalogProvider))
 	}
-	manager, err := session.NewManager(
-		resultResolver{result: result}, hostFactory, router, managerOptions...)
+	manager, err := session.NewManager(registry, hostFactory, router, managerOptions...)
 	if err != nil {
 		_ = router.Close()
 		_ = result.Close()
 		return nil, fmt.Errorf("runtime create session manager: %w", err)
 	}
-	return &Runtime{manager: manager, router: router, result: result}, nil
-}
-
-// resultResolver adapts core deploy.Result to the session manager's
-// InstanceResolver (method name differs: Agent vs Instance).
-type resultResolver struct {
-	result *deploy.Result
-}
-
-func (r resultResolver) Instance(id string) (*agent.Agent, bool) {
-	return r.result.Agent(id)
+	return &Runtime{
+		manager:     manager,
+		router:      router,
+		result:      result,
+		registry:    registry,
+		liveCatalog: liveCatalog,
+		resources:   reg,
+		loader:      b.loader,
+		bus:         bus,
+	}, nil
 }
 
 func resolveValue[T any](result *deploy.Result, name, field string) (T, error) {

--- a/core/runtime/dynamic.go
+++ b/core/runtime/dynamic.go
@@ -2,6 +2,7 @@ package runtime
 
 import (
 	"context"
+	"sync"
 
 	"github.com/GizClaw/flowcraft/core/agent"
 	"github.com/GizClaw/flowcraft/core/deploy"
@@ -68,25 +69,93 @@ func resolveDynamicCatalogAssemblies(
 	return assemblies, nil
 }
 
-// newDynamicCatalogProvider builds one tool session per Session over
-// the mapped assembly. The Session borrows the view and never closes
-// it.
-func newDynamicCatalogProvider(
-	assemblies map[string]*tool.Assembly,
-) session.CatalogProvider {
-	return session.CatalogProviderFunc(func(
-		ctx context.Context,
-		instance *agent.Agent,
-	) (tool.Session, error) {
-		assembly := assemblies[instance.ID]
-		if assembly == nil {
-			assembly = assemblies[dynamicCatalogDefaultAgent]
-		}
-		if assembly == nil {
-			return nil, errdefs.Internalf(
-				"runtime dynamic catalog: agent %q has no tool assembly",
-				instance.ID)
-		}
-		return assembly.NewSession(), nil
-	})
+// catalogRegistry is the live agentID → tool.Assembly mapping behind the
+// dynamic catalog. It is safe for concurrent use: the build-time mapping
+// is seeded once, then RegisterAgent/UnregisterAgent update it at runtime.
+// It implements session.CatalogProvider so the session manager consumes
+// it directly.
+type catalogRegistry struct {
+	mu         sync.RWMutex
+	assemblies map[string]*tool.Assembly
+	def        *tool.Assembly
 }
+
+func newCatalogRegistry(assemblies map[string]*tool.Assembly) *catalogRegistry {
+	c := &catalogRegistry{
+		assemblies: make(map[string]*tool.Assembly, len(assemblies)),
+	}
+	for id, assembly := range assemblies {
+		if id == dynamicCatalogDefaultAgent {
+			c.def = assembly
+			continue
+		}
+		c.assemblies[id] = assembly
+	}
+	return c
+}
+
+// NewCatalog implements session.CatalogProvider: one tool session per
+// Session over the mapped assembly, falling back to the default.
+func (c *catalogRegistry) NewCatalog(
+	_ context.Context,
+	instance *agent.Agent,
+) (tool.Session, error) {
+	if c == nil {
+		return nil, nil
+	}
+	if instance == nil {
+		return nil, errdefs.Internalf(
+			"runtime dynamic catalog: nil agent instance")
+	}
+	c.mu.RLock()
+	assembly := c.assemblies[instance.ID]
+	def := c.def
+	c.mu.RUnlock()
+	if assembly == nil {
+		assembly = def
+	}
+	if assembly == nil {
+		return nil, errdefs.Internalf(
+			"runtime dynamic catalog: agent %q has no tool assembly",
+			instance.ID)
+	}
+	return assembly.NewSession(), nil
+}
+
+// Set updates the mapping for one agent (or the default when id is the
+// reserved default key).
+func (c *catalogRegistry) Set(id string, assembly *tool.Assembly) {
+	if c == nil || id == "" {
+		return
+	}
+	c.mu.Lock()
+	if id == dynamicCatalogDefaultAgent {
+		c.def = assembly
+	} else {
+		c.assemblies[id] = assembly
+	}
+	c.mu.Unlock()
+}
+
+// Delete removes the mapping for one agent. The default entry is never
+// removable.
+func (c *catalogRegistry) Delete(id string) {
+	if c == nil || id == "" || id == dynamicCatalogDefaultAgent {
+		return
+	}
+	c.mu.Lock()
+	delete(c.assemblies, id)
+	c.mu.Unlock()
+}
+
+// hasDefault reports whether a fallback tool assembly is configured.
+func (c *catalogRegistry) hasDefault() bool {
+	if c == nil {
+		return false
+	}
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return c.def != nil
+}
+
+var _ session.CatalogProvider = (*catalogRegistry)(nil)

--- a/core/runtime/events.go
+++ b/core/runtime/events.go
@@ -1,0 +1,64 @@
+package runtime
+
+import (
+	"context"
+	"log"
+
+	"github.com/GizClaw/flowcraft/core/agent"
+	"github.com/GizClaw/flowcraft/core/event"
+)
+
+// agentLifecyclePrefix is the subject root for runtime agent lifecycle
+// events. It deliberately sits outside the engine-owned "agent.run.*"
+// namespace.
+const agentLifecyclePrefix = "runtime.agent."
+
+// SubjectAgentRegistered returns the subject for a successful dynamic
+// registration:
+//
+//	runtime.agent.<id>.registered
+func SubjectAgentRegistered(id string) event.Subject {
+	return event.Subject(agentLifecyclePrefix + agent.SanitiseID(id) + ".registered")
+}
+
+// SubjectAgentRemoved returns the subject for a successful dynamic
+// removal:
+//
+//	runtime.agent.<id>.removed
+func SubjectAgentRemoved(id string) event.Subject {
+	return event.Subject(agentLifecyclePrefix + agent.SanitiseID(id) + ".removed")
+}
+
+// PatternAgentLifecycle matches every runtime agent lifecycle event.
+func PatternAgentLifecycle() event.Pattern {
+	return event.Pattern(agentLifecyclePrefix + ">")
+}
+
+// AgentLifecycleEvent is the payload of runtime.agent.* lifecycle
+// events. It intentionally carries only identity and card summary, so
+// the envelope stays small.
+type AgentLifecycleEvent struct {
+	AgentID     string `json:"agent_id"`
+	Name        string `json:"name,omitempty"`
+	Description string `json:"description,omitempty"`
+}
+
+// publishLifecycleEvent is a best-effort notification: publish failures
+// never change the outcome of register/remove and are only logged.
+func (r *Runtime) publishLifecycleEvent(
+	ctx context.Context,
+	subject event.Subject,
+	payload AgentLifecycleEvent,
+) {
+	if r == nil || r.bus == nil || isNilContext(ctx) {
+		return
+	}
+	envelope, err := event.NewEnvelope(ctx, subject, payload)
+	if err != nil {
+		log.Printf("runtime: lifecycle event %q: %v", subject, err)
+		return
+	}
+	if err := r.bus.Publish(ctx, envelope); err != nil {
+		log.Printf("runtime: lifecycle event %q: %v", subject, err)
+	}
+}

--- a/core/runtime/lifecycle.go
+++ b/core/runtime/lifecycle.go
@@ -1,0 +1,245 @@
+package runtime
+
+import (
+	"context"
+	"strings"
+	"time"
+
+	"github.com/GizClaw/flowcraft/core/agent"
+	"github.com/GizClaw/flowcraft/core/deploy"
+	"github.com/GizClaw/flowcraft/core/errdefs"
+	"github.com/GizClaw/flowcraft/core/tool"
+)
+
+type registerOptions struct {
+	toolResource string
+}
+
+// RegisterAgentOption configures one dynamic agent registration.
+type RegisterAgentOption func(*registerOptions) error
+
+// WithToolAssembly names a built tool.Assembly resource used as the new
+// agent's dynamic catalog entry. It requires the deployment to have a
+// dynamic_catalog section.
+func WithToolAssembly(resourceName string) RegisterAgentOption {
+	return func(o *registerOptions) error {
+		if strings.TrimSpace(resourceName) == "" {
+			return errdefs.Validationf(
+				"runtime: WithToolAssembly requires a resource name")
+		}
+		o.toolResource = resourceName
+		return nil
+	}
+}
+
+type removeOptions struct {
+	timeout time.Duration
+}
+
+// UnregisterAgentOption configures one dynamic agent removal.
+type UnregisterAgentOption func(*removeOptions) error
+
+// WithRemoveTimeout bounds how long UnregisterAgent waits for active
+// turns to finish before giving up. On timeout the agent is left in
+// place (registration intact, sessions intact) and the call is retryable.
+func WithRemoveTimeout(d time.Duration) UnregisterAgentOption {
+	return func(o *removeOptions) error {
+		if d <= 0 {
+			return errdefs.Validationf(
+				"runtime: WithRemoveTimeout must be positive")
+		}
+		o.timeout = d
+		return nil
+	}
+}
+
+// RegisterAgent assembles and registers a new agent at runtime: the
+// Definition is run through the same assembly path as deployment
+// (deploy.BindAgent), then the agent becomes resolvable by the session
+// manager. The name must not collide with an existing dynamic agent or
+// a deployed agent (both are Conflict).
+//
+// RegisterAgent is serialized with UnregisterAgent and Close. After
+// Close it fails with NotAvailable.
+func (r *Runtime) RegisterAgent(
+	ctx context.Context,
+	name string,
+	def agent.Definition,
+	opts ...RegisterAgentOption,
+) (*agent.Agent, error) {
+	if r == nil {
+		return nil, errdefs.Validationf(
+			"runtime: RegisterAgent requires a built Runtime")
+	}
+	if isNilContext(ctx) {
+		return nil, errdefs.Validationf(
+			"runtime: RegisterAgent context is required")
+	}
+	if err := validateAgentID(name); err != nil {
+		return nil, err
+	}
+	if err := def.Validate(); err != nil {
+		return nil, errdefs.Validationf(
+			"runtime: register agent %q: %v", name, err)
+	}
+
+	options := registerOptions{}
+	for _, option := range opts {
+		if isNil(option) {
+			return nil, errdefs.Validationf(
+				"runtime: RegisterAgentOption must not be nil")
+		}
+		if err := option(&options); err != nil {
+			return nil, err
+		}
+	}
+
+	r.lifecycleMu.Lock()
+	defer r.lifecycleMu.Unlock()
+	if r.closed {
+		return nil, errdefs.NotAvailablef("runtime: closed")
+	}
+	if _, ok := r.registry.Agent(name); ok {
+		return nil, errdefs.Conflictf("runtime: agent %q is already registered", name)
+	}
+	if _, deployed := r.result.Agent(name); deployed {
+		return nil, errdefs.Conflictf(
+			"runtime: agent %q is a deployed agent", name)
+	}
+
+	instance, err := deploy.BindAgent(ctx, r.resources, r.result, r.loader, name, def)
+	if err != nil {
+		return nil, err
+	}
+
+	var assembly *tool.Assembly
+	if options.toolResource != "" {
+		if r.liveCatalog == nil {
+			_ = instance.Close()
+			return nil, errdefs.Validationf(
+				"runtime: dynamic catalog is not configured; cannot attach tool assembly %q",
+				options.toolResource)
+		}
+		value, ok := r.result.Value(options.toolResource)
+		if !ok {
+			_ = instance.Close()
+			return nil, errdefs.NotFoundf(
+				"runtime: tool assembly resource %q not found",
+				options.toolResource)
+		}
+		var typeOK bool
+		assembly, typeOK = value.(*tool.Assembly)
+		if !typeOK || assembly == nil {
+			_ = instance.Close()
+			return nil, errdefs.Validationf(
+				"runtime: tool assembly resource %q is %T, want *tool.Assembly",
+				options.toolResource, value)
+		}
+	} else if r.liveCatalog != nil && !r.liveCatalog.hasDefault() {
+		// Mirrors the build-time rule: with a dynamic catalog every
+		// agent must have an explicit tool assembly or a default.
+		_ = instance.Close()
+		return nil, errdefs.Validationf(
+			"runtime: dynamic catalog has no default; agent %q needs WithToolAssembly",
+			name)
+	}
+
+	r.manager.ReopenAgent(name)
+	if r.liveCatalog != nil {
+		r.liveCatalog.Set(name, assembly)
+	}
+	if err := r.registry.Put(name, instance); err != nil {
+		_ = instance.Close()
+		return nil, err
+	}
+	r.publishLifecycleEvent(ctx, SubjectAgentRegistered(name), AgentLifecycleEvent{
+		AgentID:     name,
+		Name:        def.Card.Name,
+		Description: def.Card.Description,
+	})
+	return instance, nil
+}
+
+// UnregisterAgent removes a dynamically registered agent: new session
+// activity is blocked, live sessions are drained (active turns are
+// allowed to finish, bounded by ctx or WithRemoveTimeout), and the
+// agent's engine and hooks are closed. Unknown names are an idempotent
+// no-op; deployed (static) agents cannot be removed at runtime.
+func (r *Runtime) UnregisterAgent(
+	ctx context.Context,
+	name string,
+	opts ...UnregisterAgentOption,
+) error {
+	if r == nil {
+		return errdefs.Validationf(
+			"runtime: UnregisterAgent requires a built Runtime")
+	}
+	if isNilContext(ctx) {
+		return errdefs.Validationf(
+			"runtime: UnregisterAgent context is required")
+	}
+	if err := validateAgentID(name); err != nil {
+		return err
+	}
+
+	options := removeOptions{}
+	for _, option := range opts {
+		if isNil(option) {
+			return errdefs.Validationf(
+				"runtime: UnregisterAgentOption must not be nil")
+		}
+		if err := option(&options); err != nil {
+			return err
+		}
+	}
+
+	r.lifecycleMu.Lock()
+	defer r.lifecycleMu.Unlock()
+	if r.closed {
+		return errdefs.NotAvailablef("runtime: closed")
+	}
+
+	instance, ok := r.registry.Delete(name)
+	if !ok {
+		if _, deployed := r.result.Agent(name); deployed {
+			return errdefs.Conflictf(
+				"runtime: agent %q is a deployed agent; remove it from the deployment document",
+				name)
+		}
+		return nil // idempotent: unknown name
+	}
+
+	removeCtx := ctx
+	if options.timeout > 0 {
+		var cancel context.CancelFunc
+		removeCtx, cancel = context.WithTimeout(ctx, options.timeout)
+		defer cancel()
+	}
+	if err := r.manager.RemoveAgent(removeCtx, name); err != nil {
+		// Drain failed (usually a deadline): keep the tombstone so new
+		// sessions stay blocked, restore the agent so the registration
+		// is still visible, and let the caller retry.
+		_ = r.registry.Put(name, instance)
+		return err
+	}
+	if r.liveCatalog != nil {
+		r.liveCatalog.Delete(name)
+	}
+	if err := instance.Close(); err != nil {
+		return err
+	}
+	r.publishLifecycleEvent(ctx, SubjectAgentRemoved(name), AgentLifecycleEvent{
+		AgentID:     name,
+		Name:        instance.Card.Name,
+		Description: instance.Card.Description,
+	})
+	return nil
+}
+
+func validateAgentID(name string) error {
+	if name == "" || strings.TrimSpace(name) != name {
+		return errdefs.Validationf(
+			"runtime: agent id must be non-empty and must not have surrounding whitespace")
+	}
+	return nil
+}

--- a/core/runtime/lifecycle_test.go
+++ b/core/runtime/lifecycle_test.go
@@ -1,0 +1,426 @@
+package runtime
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/GizClaw/flowcraft/core/agent"
+	"github.com/GizClaw/flowcraft/core/deploy"
+	"github.com/GizClaw/flowcraft/core/errdefs"
+	"github.com/GizClaw/flowcraft/core/event"
+	"github.com/GizClaw/flowcraft/core/resource"
+	"github.com/GizClaw/flowcraft/core/runtime/session"
+	"github.com/GizClaw/flowcraft/core/tool"
+)
+
+// simpleRunEngine publishes the run lifecycle delimiters the stream
+// coordinator needs and completes immediately.
+func simpleRunEngine() agent.Engine {
+	return agent.EngineFunc(func(
+		ctx context.Context,
+		run agent.Run,
+		host agent.Host,
+		board *agent.Board,
+	) (*agent.Board, error) {
+		if err := publishRunEvent(ctx, host, agent.SubjectRunStart(run.RunID), run); err != nil {
+			return board, err
+		}
+		if err := publishRunEvent(ctx, host, agent.SubjectRunEnd(run.RunID), run); err != nil {
+			return board, err
+		}
+		return board, nil
+	})
+}
+
+// blockingRunEngine holds a turn open until release is closed.
+func blockingRunEngine(release <-chan struct{}) agent.Engine {
+	return agent.EngineFunc(func(
+		ctx context.Context,
+		run agent.Run,
+		host agent.Host,
+		board *agent.Board,
+	) (*agent.Board, error) {
+		if err := publishRunEvent(ctx, host, agent.SubjectRunStart(run.RunID), run); err != nil {
+			return board, err
+		}
+		select {
+		case <-release:
+		case <-ctx.Done():
+			return board, ctx.Err()
+		}
+		if err := publishRunEvent(ctx, host, agent.SubjectRunEnd(run.RunID), run); err != nil {
+			return board, err
+		}
+		return board, nil
+	})
+}
+
+func lifecycleDoc(t *testing.T) deploy.Document {
+	t.Helper()
+	return parseRuntimeDoc(t, `version: v1
+resources:
+  events: {kind: event.Bus, impl: test}
+agents:
+  bot:
+    card: {name: Bot}
+    engine: {kind: agent.Engine, impl: test}
+runtime:
+  event_bus: events
+  sessions: {idle_timeout: 1h, sink_buffer: 8}
+`)
+}
+
+func buildLifecycleApp(
+	t *testing.T,
+	doc deploy.Document,
+	engine agent.Engine,
+) (*Runtime, event.Bus) {
+	t.Helper()
+	bus := event.NewMemoryBus()
+	reg := resource.NewRegistry()
+	reg.MustRegister(testEngineFactory{engine: engine})
+	reg.MustRegister(testResourceFactory{
+		spec:  resource.Spec{Kind: testEventKind, Impl: testEventImpl},
+		value: bus,
+	})
+	app, err := NewBuilder(reg).Build(context.Background(), doc)
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	t.Cleanup(func() { _ = app.Close() })
+	return app, bus
+}
+
+func dynamicDefinition(name string) agent.Definition {
+	return agent.Definition{
+		Card:   agent.AgentCard{Name: name},
+		Engine: agent.EngineRef{Kind: testEngineKind, Impl: testEngineImpl},
+	}
+}
+
+func TestRuntimeRegisterAgentEndToEnd(t *testing.T) {
+	app, _ := buildLifecycleApp(t, lifecycleDoc(t), simpleRunEngine())
+
+	instance, err := app.RegisterAgent(
+		context.Background(), "dyn", dynamicDefinition("Dyn"))
+	if err != nil {
+		t.Fatalf("RegisterAgent: %v", err)
+	}
+	if instance.ID != "dyn" {
+		t.Fatalf("instance ID = %q, want dyn", instance.ID)
+	}
+	if got, ok := app.Agent("dyn"); !ok || got != instance {
+		t.Fatal("Agent(dyn) did not resolve the registered instance")
+	}
+	names := app.AgentNames()
+	if len(names) != 2 || names[0] != "bot" || names[1] != "dyn" {
+		t.Fatalf("AgentNames = %v, want [bot dyn]", names)
+	}
+
+	result := runTurn(t, app.Sessions(), "dyn", "conv")
+	if result.Status != agent.StatusCompleted {
+		t.Fatalf("dynamic agent turn status = %q", result.Status)
+	}
+}
+
+func TestRuntimeRegisterAgentConflicts(t *testing.T) {
+	app, _ := buildLifecycleApp(t, lifecycleDoc(t), simpleRunEngine())
+
+	if _, err := app.RegisterAgent(
+		context.Background(), "bot", dynamicDefinition("Bot")); !errdefs.IsConflict(err) {
+		t.Fatalf("RegisterAgent over deployed name error = %v, want conflict", err)
+	}
+	if _, err := app.RegisterAgent(
+		context.Background(), "dyn", dynamicDefinition("Dyn")); err != nil {
+		t.Fatalf("first RegisterAgent: %v", err)
+	}
+	if _, err := app.RegisterAgent(
+		context.Background(), "dyn", dynamicDefinition("Dyn2")); !errdefs.IsConflict(err) {
+		t.Fatalf("duplicate RegisterAgent error = %v, want conflict", err)
+	}
+}
+
+func TestRuntimeRegisterAgentRejectsInvalidInput(t *testing.T) {
+	app, _ := buildLifecycleApp(t, lifecycleDoc(t), simpleRunEngine())
+
+	if _, err := app.RegisterAgent(
+		context.Background(), " bad", dynamicDefinition("Bad")); !errdefs.IsValidation(err) {
+		t.Fatalf("padded id error = %v, want validation", err)
+	}
+	bad := dynamicDefinition("Bad")
+	bad.Card = agent.AgentCard{} // missing name
+	if _, err := app.RegisterAgent(
+		context.Background(), "bad", bad); !errdefs.IsValidation(err) {
+		t.Fatalf("invalid definition error = %v, want validation", err)
+	}
+	if _, err := app.RegisterAgent(
+		context.Background(), "bad", dynamicDefinition("Bad"),
+		WithToolAssembly("   ")); !errdefs.IsValidation(err) {
+		t.Fatalf("blank tool resource error = %v, want validation", err)
+	}
+}
+
+func TestRuntimeUnregisterAgent(t *testing.T) {
+	app, _ := buildLifecycleApp(t, lifecycleDoc(t), simpleRunEngine())
+
+	if _, err := app.RegisterAgent(
+		context.Background(), "dyn", dynamicDefinition("Dyn")); err != nil {
+		t.Fatalf("RegisterAgent: %v", err)
+	}
+	if err := app.UnregisterAgent(context.Background(), "dyn"); err != nil {
+		t.Fatalf("UnregisterAgent: %v", err)
+	}
+	if _, ok := app.Agent("dyn"); ok {
+		t.Fatal("Agent(dyn) still resolves after removal")
+	}
+	names := app.AgentNames()
+	if len(names) != 1 || names[0] != "bot" {
+		t.Fatalf("AgentNames after removal = %v, want [bot]", names)
+	}
+	if _, err := app.Sessions().Open(
+		context.Background(),
+		keyFor("dyn", "conv"),
+	); !errdefs.IsNotFound(err) {
+		t.Fatalf("Open removed agent error = %v, want not found", err)
+	}
+
+	// Unknown name is an idempotent no-op; deployed agents conflict.
+	if err := app.UnregisterAgent(context.Background(), "nope"); err != nil {
+		t.Fatalf("unknown UnregisterAgent error = %v, want nil", err)
+	}
+	if err := app.UnregisterAgent(context.Background(), "bot"); !errdefs.IsConflict(err) {
+		t.Fatalf("UnregisterAgent deployed error = %v, want conflict", err)
+	}
+}
+
+func TestRuntimeReRegisterAfterRemoval(t *testing.T) {
+	app, _ := buildLifecycleApp(t, lifecycleDoc(t), simpleRunEngine())
+
+	for i := 0; i < 2; i++ {
+		if _, err := app.RegisterAgent(
+			context.Background(), "dyn", dynamicDefinition("Dyn")); err != nil {
+			t.Fatalf("RegisterAgent round %d: %v", i, err)
+		}
+		if result := runTurn(t, app.Sessions(), "dyn", "conv"); result.Status != agent.StatusCompleted {
+			t.Fatalf("round %d status = %q", i, result.Status)
+		}
+		if err := app.UnregisterAgent(context.Background(), "dyn"); err != nil {
+			t.Fatalf("UnregisterAgent round %d: %v", i, err)
+		}
+	}
+}
+
+func TestRuntimeUnregisterAgentDrainTimeout(t *testing.T) {
+	release := make(chan struct{})
+	app, _ := buildLifecycleApp(t, lifecycleDoc(t), blockingRunEngine(release))
+
+	if _, err := app.RegisterAgent(
+		context.Background(), "dyn", dynamicDefinition("Dyn")); err != nil {
+		t.Fatalf("RegisterAgent: %v", err)
+	}
+	lease, err := app.Sessions().GetOrCreate(context.Background(), keyFor("dyn", "conv"))
+	if err != nil {
+		t.Fatalf("GetOrCreate: %v", err)
+	}
+	turn, err := lease.Session().Start(context.Background(), agent.Request{})
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	err = app.UnregisterAgent(
+		context.Background(), "dyn", WithRemoveTimeout(50*time.Millisecond))
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("UnregisterAgent error = %v, want DeadlineExceeded", err)
+	}
+	// Registration restored, sessions blocked, agent still present.
+	if _, ok := app.Agent("dyn"); !ok {
+		t.Fatal("agent disappeared after failed removal")
+	}
+	if _, err := app.Sessions().Open(
+		context.Background(),
+		keyFor("dyn", "conv2"),
+	); !errdefs.IsNotFound(err) {
+		t.Fatalf("Open after failed removal error = %v, want not found", err)
+	}
+
+	close(release)
+	if _, err := turn.Wait(context.Background()); err != nil {
+		t.Fatalf("turn Wait: %v", err)
+	}
+	if err := app.UnregisterAgent(context.Background(), "dyn"); err != nil {
+		t.Fatalf("retry UnregisterAgent: %v", err)
+	}
+	if _, ok := app.Agent("dyn"); ok {
+		t.Fatal("agent still present after successful removal")
+	}
+}
+
+func TestRuntimeRegisterAgentToolAssembly(t *testing.T) {
+	got := make(chan []string, 1)
+	reg := resource.NewRegistry()
+	reg.MustRegister(testEngineFactory{engine: catalogEngine(t, got)})
+	reg.MustRegister(testResourceFactory{
+		spec:  resource.Spec{Kind: testEventKind, Impl: testEventImpl},
+		value: event.NewMemoryBus(),
+	})
+	reg.MustRegister(testResourceFactory{
+		spec:  resource.Spec{Kind: tool.AssemblyKind, Impl: "yaml"},
+		value: buildTestAssembly(t, "research_tool"),
+	})
+	reg.MustRegister(testResourceFactory{
+		spec:  resource.Spec{Kind: tool.AssemblyKind, Impl: "test"},
+		value: buildTestAssembly(t, "assist_tool"),
+	})
+	doc := dynamicCatalogDoc(t, `      researcher: research_tools
+      assistant: assistant_tools
+`)
+	app, err := NewBuilder(reg).Build(context.Background(), doc)
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	defer func() { _ = app.Close() }()
+
+	if _, err := app.RegisterAgent(
+		context.Background(), "dyn", dynamicDefinition("Dyn"),
+		WithToolAssembly("assistant_tools"),
+	); err != nil {
+		t.Fatalf("RegisterAgent: %v", err)
+	}
+	if result := runTurn(t, app.Sessions(), "dyn", "conv"); result.Status != agent.StatusCompleted {
+		t.Fatalf("turn status = %q", result.Status)
+	}
+	select {
+	case defs := <-got:
+		assertDefinitions(t, defs, []string{"assist_tool"}, []string{"research_tool"})
+	case <-time.After(5 * time.Second):
+		t.Fatal("dynamic agent turn never observed its tool catalog")
+	}
+
+	if _, err := app.RegisterAgent(
+		context.Background(), "dyn2", dynamicDefinition("Dyn2"),
+		WithToolAssembly("missing_tools"),
+	); !errdefs.IsNotFound(err) {
+		t.Fatalf("missing tool resource error = %v, want not found", err)
+	}
+	if _, ok := app.Agent("dyn2"); ok {
+		t.Fatal("agent registered despite missing tool resource")
+	}
+	// No default configured: an agent without an explicit assembly is
+	// rejected up front (mirrors the build-time rule).
+	if _, err := app.RegisterAgent(
+		context.Background(), "dyn3", dynamicDefinition("Dyn3"),
+	); !errdefs.IsValidation(err) {
+		t.Fatalf("register without assembly and no default error = %v, want validation", err)
+	}
+	if _, ok := app.Agent("dyn3"); ok {
+		t.Fatal("agent registered despite missing tool mapping")
+	}
+}
+
+func TestRuntimeRegisterAgentWithoutDynamicCatalog(t *testing.T) {
+	app, _ := buildLifecycleApp(t, lifecycleDoc(t), simpleRunEngine())
+
+	if _, err := app.RegisterAgent(
+		context.Background(), "dyn", dynamicDefinition("Dyn"),
+		WithToolAssembly("kit"),
+	); !errdefs.IsValidation(err) {
+		t.Fatalf("tool assembly without dynamic catalog error = %v, want validation", err)
+	}
+	// Without an explicit assembly the agent still registers and runs.
+	if _, err := app.RegisterAgent(
+		context.Background(), "dyn", dynamicDefinition("Dyn")); err != nil {
+		t.Fatalf("RegisterAgent without dynamic catalog: %v", err)
+	}
+}
+
+func TestRuntimeRegisterAfterClose(t *testing.T) {
+	app, _ := buildLifecycleApp(t, lifecycleDoc(t), simpleRunEngine())
+	if err := app.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	if _, err := app.RegisterAgent(
+		context.Background(), "dyn", dynamicDefinition("Dyn")); !errdefs.IsNotAvailable(err) {
+		t.Fatalf("RegisterAgent after Close error = %v, want not available", err)
+	}
+	if err := app.UnregisterAgent(context.Background(), "bot"); !errdefs.IsNotAvailable(err) {
+		t.Fatalf("UnregisterAgent after Close error = %v, want not available", err)
+	}
+}
+
+func TestRuntimeLifecycleEvents(t *testing.T) {
+	app, bus := buildLifecycleApp(t, lifecycleDoc(t), simpleRunEngine())
+	sub, err := bus.Subscribe(context.Background(), PatternAgentLifecycle())
+	if err != nil {
+		t.Fatalf("Subscribe: %v", err)
+	}
+	defer func() { _ = sub.Close() }()
+
+	if _, err := app.RegisterAgent(
+		context.Background(), "dyn", dynamicDefinition("Dyn")); err != nil {
+		t.Fatalf("RegisterAgent: %v", err)
+	}
+	if err := app.UnregisterAgent(context.Background(), "dyn"); err != nil {
+		t.Fatalf("UnregisterAgent: %v", err)
+	}
+
+	var subjects []event.Subject
+	deadline := time.After(5 * time.Second)
+	for len(subjects) < 2 {
+		select {
+		case env := <-sub.C():
+			subjects = append(subjects, env.Subject)
+			var payload AgentLifecycleEvent
+			if err := env.Decode(&payload); err != nil {
+				t.Fatalf("decode lifecycle payload: %v", err)
+			}
+			if payload.AgentID != "dyn" {
+				t.Fatalf("payload agent_id = %q, want dyn", payload.AgentID)
+			}
+		case <-deadline:
+			t.Fatalf("timed out waiting for lifecycle events, got %v", subjects)
+		}
+	}
+	if subjects[0] != SubjectAgentRegistered("dyn") ||
+		subjects[1] != SubjectAgentRemoved("dyn") {
+		t.Fatalf("subjects = %v, want [registered removed]", subjects)
+	}
+}
+
+func TestRuntimeRegisterUnregisterConcurrent(t *testing.T) {
+	app, _ := buildLifecycleApp(t, lifecycleDoc(t), simpleRunEngine())
+
+	var wg sync.WaitGroup
+	for i := 0; i < 8; i++ {
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < 10; j++ {
+				_, _ = app.RegisterAgent(
+					context.Background(), "dyn", dynamicDefinition("Dyn"))
+			}
+		}()
+		go func() {
+			defer wg.Done()
+			for j := 0; j < 10; j++ {
+				_ = app.UnregisterAgent(context.Background(), "dyn")
+			}
+		}()
+	}
+	wg.Wait()
+
+	// Whatever the final state, the runtime must stay internally
+	// consistent: a removed agent refuses new sessions; a registered one
+	// resolves.
+	if _, ok := app.Agent("dyn"); ok {
+		if result := runTurn(t, app.Sessions(), "dyn", "conv"); result.Status != agent.StatusCompleted {
+			t.Fatalf("final registered agent turn status = %q", result.Status)
+		}
+	}
+}
+
+func keyFor(agentID, contextID string) session.Key {
+	return session.Key{AgentID: agentID, ContextID: contextID}
+}

--- a/core/runtime/registry.go
+++ b/core/runtime/registry.go
@@ -1,0 +1,133 @@
+package runtime
+
+import (
+	"errors"
+	"sort"
+	"sync"
+
+	"github.com/GizClaw/flowcraft/core/agent"
+	"github.com/GizClaw/flowcraft/core/deploy"
+	"github.com/GizClaw/flowcraft/core/errdefs"
+)
+
+// AgentRegistry is the runtime-live, concurrency-safe agent view.
+// Dynamically registered agents live in its own map; statically deployed
+// agents are served as a read-only fallback from the deployment result.
+// It implements session.InstanceResolver, so the session manager resolves
+// both kinds through one seam.
+type AgentRegistry struct {
+	mu       sync.RWMutex
+	agents   map[string]*agent.Agent
+	deployed *deploy.Result
+}
+
+func newAgentRegistry(deployed *deploy.Result) *AgentRegistry {
+	return &AgentRegistry{
+		agents:   make(map[string]*agent.Agent),
+		deployed: deployed,
+	}
+}
+
+// Instance implements session.InstanceResolver.
+func (r *AgentRegistry) Instance(id string) (*agent.Agent, bool) {
+	return r.Agent(id)
+}
+
+// Agent resolves a dynamically registered agent first, then falls back
+// to the deployment snapshot.
+func (r *AgentRegistry) Agent(id string) (*agent.Agent, bool) {
+	if r == nil {
+		return nil, false
+	}
+	r.mu.RLock()
+	instance, ok := r.agents[id]
+	r.mu.RUnlock()
+	if ok {
+		return instance, true
+	}
+	if r.deployed != nil {
+		return r.deployed.Agent(id)
+	}
+	return nil, false
+}
+
+// AgentNames returns the sorted union of dynamically registered and
+// deployed agent names.
+func (r *AgentRegistry) AgentNames() []string {
+	if r == nil {
+		return nil
+	}
+	seen := make(map[string]struct{})
+	r.mu.RLock()
+	for name := range r.agents {
+		seen[name] = struct{}{}
+	}
+	r.mu.RUnlock()
+	if r.deployed != nil {
+		for _, name := range r.deployed.AgentNames() {
+			seen[name] = struct{}{}
+		}
+	}
+	names := make([]string, 0, len(seen))
+	for name := range seen {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
+}
+
+// Put registers a dynamically registered agent, rejecting duplicates.
+func (r *AgentRegistry) Put(id string, instance *agent.Agent) error {
+	if r == nil {
+		return errdefs.Validationf("runtime: agent registry is nil")
+	}
+	if id == "" || instance == nil {
+		return errdefs.Validationf(
+			"runtime: agent registry Put requires an id and a non-nil agent")
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if _, exists := r.agents[id]; exists {
+		return errdefs.Conflictf("runtime: agent %q is already registered", id)
+	}
+	r.agents[id] = instance
+	return nil
+}
+
+// Delete removes and returns a dynamically registered agent. Deployed
+// agents are not affected and return ok=false.
+func (r *AgentRegistry) Delete(id string) (*agent.Agent, bool) {
+	if r == nil {
+		return nil, false
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	instance, ok := r.agents[id]
+	if !ok {
+		return nil, false
+	}
+	delete(r.agents, id)
+	return instance, true
+}
+
+// Close closes every dynamically registered agent. Deployed agents are
+// owned (and closed) by deploy.Result, so they are left untouched.
+func (r *AgentRegistry) Close() error {
+	if r == nil {
+		return nil
+	}
+	r.mu.RLock()
+	instances := make([]*agent.Agent, 0, len(r.agents))
+	for _, instance := range r.agents {
+		instances = append(instances, instance)
+	}
+	r.mu.RUnlock()
+
+	var errs []error
+	for _, instance := range instances {
+		if err := instance.Close(); err != nil {
+			errs = append(errs, err)
+		}
+	}
+	return errors.Join(errs...)
+}

--- a/core/runtime/runtime.go
+++ b/core/runtime/runtime.go
@@ -6,9 +6,11 @@ import (
 	"fmt"
 	"sync"
 
+	"github.com/GizClaw/flowcraft/core/agent"
 	"github.com/GizClaw/flowcraft/core/deploy"
 	"github.com/GizClaw/flowcraft/core/errdefs"
 	"github.com/GizClaw/flowcraft/core/event"
+	"github.com/GizClaw/flowcraft/core/resource"
 	"github.com/GizClaw/flowcraft/core/runtime/session"
 )
 
@@ -17,6 +19,23 @@ type Runtime struct {
 	manager *session.Manager
 	router  *event.Router
 	result  *deploy.Result
+	// registry is the live agent view: dynamically registered agents
+	// plus a read-only fallback to the deployment snapshot.
+	registry *AgentRegistry
+	// liveCatalog is the mutable dynamic tool catalog; nil when the
+	// deployment has no dynamic_catalog section.
+	liveCatalog *catalogRegistry
+	// resources and loader are retained from the Builder so agents can
+	// be assembled at runtime with the same factories and source
+	// resolution as deployment time.
+	resources *resource.Registry
+	loader    *resource.Loader
+	bus       event.Bus
+
+	// lifecycleMu serializes RegisterAgent / UnregisterAgent / Close so
+	// a removal can never sweep away a concurrent registration.
+	lifecycleMu sync.Mutex
+	closed      bool
 
 	closeOnce sync.Once
 	closeErr  error
@@ -65,6 +84,24 @@ func (r *Runtime) Attach(
 	return r.router.Attach(ctx, pattern, sink, opts...)
 }
 
+// Agent resolves an agent by name from the live view (dynamically
+// registered first, then the deployment snapshot).
+func (r *Runtime) Agent(name string) (*agent.Agent, bool) {
+	if r == nil || r.registry == nil {
+		return nil, false
+	}
+	return r.registry.Agent(name)
+}
+
+// AgentNames returns the sorted union of deployed and dynamically
+// registered agent names.
+func (r *Runtime) AgentNames() []string {
+	if r == nil || r.registry == nil {
+		return nil
+	}
+	return r.registry.AgentNames()
+}
+
 // Close stops new session work, waits for active turns, and releases
 // all owned objects. Concurrent callers wait for and receive the same
 // aggregate result.
@@ -72,8 +109,11 @@ func (r *Runtime) Close() error {
 	if r == nil {
 		return nil
 	}
+	r.lifecycleMu.Lock()
+	r.closed = true
+	r.lifecycleMu.Unlock()
 	r.closeOnce.Do(func() {
-		r.closeErr = closeOwned(r.manager, r.router, r.result)
+		r.closeErr = closeOwned(r.manager, r.router, r.result, r.registry)
 	})
 	return r.closeErr
 }
@@ -82,6 +122,7 @@ func closeOwned(
 	manager *session.Manager,
 	router *event.Router,
 	result *deploy.Result,
+	registry *AgentRegistry,
 ) error {
 	var errs []error
 	if manager != nil {
@@ -97,6 +138,11 @@ func closeOwned(
 	if result != nil {
 		if err := result.Close(); err != nil {
 			errs = append(errs, fmt.Errorf("runtime close deployment: %w", err))
+		}
+	}
+	if registry != nil {
+		if err := registry.Close(); err != nil {
+			errs = append(errs, fmt.Errorf("runtime close agent registry: %w", err))
 		}
 	}
 	return errors.Join(errs...)

--- a/core/runtime/session/manager.go
+++ b/core/runtime/session/manager.go
@@ -46,10 +46,15 @@ type Manager struct {
 
 	mu        sync.Mutex
 	entries   map[Key]*managerEntry
+	removed   map[string]struct{}
 	closed    bool
 	closeOnce sync.Once
 	closeErr  error
 }
+
+// agentDrainPollInterval is how often RemoveAgent re-checks whether
+// the target agent's sessions have become idle while draining.
+const agentDrainPollInterval = 10 * time.Millisecond
 
 // NewManager constructs a Session manager over borrowed runtime dependencies.
 func NewManager(
@@ -108,6 +113,7 @@ func NewManager(
 		observer:            opts.observer,
 		catalogProvider:     opts.catalogProvider,
 		entries:             make(map[Key]*managerEntry),
+		removed:             make(map[string]struct{}),
 	}, nil
 }
 
@@ -139,6 +145,10 @@ func (m *Manager) open(ctx context.Context, key Key) (*Lease, error) {
 	defer m.mu.Unlock()
 	if m.closed {
 		return nil, ErrManagerClosed
+	}
+	if _, gone := m.removed[key.AgentID]; gone {
+		return nil, errdefs.NotFoundf(
+			"runtime session: agent %q is not deployed", key.AgentID)
 	}
 	if entry := m.entries[key]; entry != nil {
 		entry.leases++
@@ -190,7 +200,9 @@ func (m *Manager) release(key Key, session *Session) error {
 	}
 	entry.leases--
 	if entry.leases == 0 && session.isIdle() {
-		m.scheduleIdleTimerLocked(key, entry)
+		if _, gone := m.removed[key.AgentID]; !gone {
+			m.scheduleIdleTimerLocked(key, entry)
+		}
 	}
 	return nil
 }
@@ -211,12 +223,18 @@ func (m *Manager) activityChanged(key Key, session *Session) {
 		entry.timer.Stop()
 		entry.timer = nil
 	}
+	if _, gone := m.removed[key.AgentID]; gone {
+		return
+	}
 	if entry.leases == 0 && session.isIdle() {
 		m.scheduleIdleTimerLocked(key, entry)
 	}
 }
 
 func (m *Manager) scheduleIdleTimerLocked(key Key, entry *managerEntry) {
+	if _, gone := m.removed[key.AgentID]; gone {
+		return
+	}
 	entry.idleGeneration++
 	generation := entry.idleGeneration
 	session := entry.session
@@ -236,10 +254,115 @@ func (m *Manager) reclaim(key Key, session *Session, generation uint64) {
 		m.mu.Unlock()
 		return
 	}
+	if _, gone := m.removed[key.AgentID]; gone {
+		m.mu.Unlock()
+		return
+	}
 	delete(m.entries, key)
 	entry.timer = nil
 	m.mu.Unlock()
 	_ = session.close()
+}
+
+// RemoveAgent blocks new session activity for the named agent and
+// drains its live sessions: it waits (bounded by ctx) for every active
+// turn to finish naturally, then closes the now-idle sessions. On ctx
+// expiry the tombstone stays in place (new opens keep failing), the
+// sessions are left intact, and no partial removal state is produced —
+// callers may retry. Repeated calls are idempotent.
+func (m *Manager) RemoveAgent(ctx context.Context, name string) error {
+	if m == nil {
+		return nil
+	}
+	if isNil(ctx) {
+		return errdefs.Validationf("runtime session: context is required")
+	}
+
+	m.mu.Lock()
+	if m.closed {
+		m.mu.Unlock()
+		return ErrManagerClosed
+	}
+	m.removed[name] = struct{}{}
+	// Stop idle-reclamation timers and invalidate in-flight callbacks so
+	// sessions are not reclaimed while we drain them.
+	for key, entry := range m.entries {
+		if key.AgentID != name {
+			continue
+		}
+		entry.idleGeneration++
+		if entry.timer != nil {
+			entry.timer.Stop()
+			entry.timer = nil
+		}
+	}
+	m.mu.Unlock()
+
+	if err := m.awaitAgentIdle(ctx, name); err != nil {
+		return err
+	}
+
+	var closing []*Session
+	m.mu.Lock()
+	for key, entry := range m.entries {
+		if key.AgentID != name {
+			continue
+		}
+		if entry.session.markClosing() {
+			closing = append(closing, entry.session)
+		}
+		delete(m.entries, key)
+	}
+	m.mu.Unlock()
+
+	for _, s := range closing {
+		s.notifySessionClosing(true)
+	}
+	var errs []error
+	for _, s := range closing {
+		if err := s.close(); err != nil {
+			errs = append(errs, err)
+		}
+	}
+	return errors.Join(errs...)
+}
+
+// ReopenAgent clears the tombstone left by RemoveAgent, re-admitting
+// session activity for the name. It is used when re-registering an
+// agent under the same ID.
+func (m *Manager) ReopenAgent(name string) {
+	if m == nil {
+		return
+	}
+	m.mu.Lock()
+	delete(m.removed, name)
+	m.mu.Unlock()
+}
+
+func (m *Manager) awaitAgentIdle(ctx context.Context, name string) error {
+	ticker := time.NewTicker(agentDrainPollInterval)
+	defer ticker.Stop()
+	for {
+		if m.agentIdle(name) {
+			return nil
+		}
+		select {
+		case <-ctx.Done():
+			return errdefs.FromContext(ctx.Err())
+		case <-ticker.C:
+		}
+	}
+}
+
+func (m *Manager) agentIdle(name string) bool {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	for key, entry := range m.entries {
+		if key.AgentID == name && !entry.session.isIdle() {
+			return false
+		}
+	}
+	return true
 }
 
 // Close stops reclamation, refuses new leases, and closes every Session.

--- a/core/runtime/session/remove_agent_test.go
+++ b/core/runtime/session/remove_agent_test.go
@@ -1,0 +1,217 @@
+package session
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/GizClaw/flowcraft/core/agent"
+	"github.com/GizClaw/flowcraft/core/errdefs"
+	"github.com/GizClaw/flowcraft/core/event"
+)
+
+// blockingEngine returns an engine that blocks until release is closed
+// or ctx is done, so tests can hold a turn open deterministically.
+func blockingEngine(release <-chan struct{}) agent.Engine {
+	return agent.EngineFunc(func(
+		ctx context.Context,
+		_ agent.Run,
+		_ agent.Host,
+		board *agent.Board,
+	) (*agent.Board, error) {
+		select {
+		case <-release:
+			return board, nil
+		case <-ctx.Done():
+			return board, ctx.Err()
+		}
+	})
+}
+
+func TestManagerRemoveAgentBlocksNewSessions(t *testing.T) {
+	manager, _ := newTestManager(t, time.Hour)
+
+	first, err := manager.GetOrCreate(context.Background(), Key{AgentID: "agent-a", ContextID: "c1"})
+	if err != nil {
+		t.Fatalf("GetOrCreate: %v", err)
+	}
+	defer func() { _ = first.Close() }()
+
+	if err := manager.RemoveAgent(context.Background(), "agent-a"); err != nil {
+		t.Fatalf("RemoveAgent: %v", err)
+	}
+	if _, err := manager.Open(context.Background(), Key{AgentID: "agent-a", ContextID: "c2"}); !errdefs.IsNotFound(err) {
+		t.Fatalf("Open removed agent error = %v, want not found", err)
+	}
+	// Existing lease is dead after removal.
+	if _, err := first.Session().Start(context.Background(), agent.Request{}); !errors.Is(err, ErrSessionClosed) {
+		t.Fatalf("Start on removed lease error = %v, want ErrSessionClosed", err)
+	}
+	// Unrelated agent is unaffected.
+	other, err := manager.GetOrCreate(context.Background(), Key{AgentID: "agent-b", ContextID: "c1"})
+	if err != nil {
+		t.Fatalf("GetOrCreate(agent-b): %v", err)
+	}
+	defer func() { _ = other.Close() }()
+}
+
+func TestManagerRemoveAgentIdempotentAndReopen(t *testing.T) {
+	manager, _ := newTestManager(t, time.Hour)
+
+	if err := manager.RemoveAgent(context.Background(), "agent-a"); err != nil {
+		t.Fatalf("first RemoveAgent: %v", err)
+	}
+	if err := manager.RemoveAgent(context.Background(), "agent-a"); err != nil {
+		t.Fatalf("second RemoveAgent: %v", err)
+	}
+	if _, err := manager.Open(context.Background(), Key{AgentID: "agent-a", ContextID: "c1"}); !errdefs.IsNotFound(err) {
+		t.Fatalf("Open after RemoveAgent error = %v, want not found", err)
+	}
+
+	manager.ReopenAgent("agent-a")
+	if _, err := manager.GetOrCreate(context.Background(), Key{AgentID: "agent-a", ContextID: "c1"}); err != nil {
+		t.Fatalf("GetOrCreate after ReopenAgent: %v", err)
+	}
+}
+
+func TestManagerRemoveAgentDrainsActiveTurn(t *testing.T) {
+	release := make(chan struct{})
+	manager, session, _, _ := newTurnSession(t, withRunEnd(blockingEngine(release)),
+		func(bus event.Bus) HostFactory {
+			return HostFactoryFunc(func(_ context.Context, _ HostRequest) (agent.Host, error) {
+				return testHost{bus: bus}, nil
+			})
+		})
+
+	turn, err := session.Start(context.Background(), agent.Request{})
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	removed := make(chan error, 1)
+	go func() {
+		removed <- manager.RemoveAgent(context.Background(), "agent-a")
+	}()
+
+	// Wait until the tombstone is in place so the drain has actually
+	// started; then new opens (even for another context) must be refused.
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		manager.mu.Lock()
+		_, gone := manager.removed["agent-a"]
+		manager.mu.Unlock()
+		if gone {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("RemoveAgent did not start draining")
+		}
+		time.Sleep(time.Millisecond)
+	}
+	if _, err := manager.Open(context.Background(), Key{AgentID: "agent-a", ContextID: "c2"}); !errdefs.IsNotFound(err) {
+		t.Fatalf("Open during drain error = %v, want not found", err)
+	}
+
+	close(release)
+	select {
+	case err := <-removed:
+		if err != nil {
+			t.Fatalf("RemoveAgent: %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("RemoveAgent did not return after turn finished")
+	}
+	if _, err := turn.Wait(context.Background()); err != nil {
+		t.Fatalf("turn Wait: %v", err)
+	}
+}
+
+func TestManagerRemoveAgentTimeoutKeepsSessions(t *testing.T) {
+	release := make(chan struct{})
+	manager, session, _, _ := newTurnSession(t, withRunEnd(blockingEngine(release)),
+		func(bus event.Bus) HostFactory {
+			return HostFactoryFunc(func(_ context.Context, _ HostRequest) (agent.Host, error) {
+				return testHost{bus: bus}, nil
+			})
+		})
+
+	if _, err := session.Start(context.Background(), agent.Request{}); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+	if err := manager.RemoveAgent(ctx, "agent-a"); !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("RemoveAgent error = %v, want DeadlineExceeded", err)
+	}
+
+	// Tombstone persists: new opens still fail.
+	if _, err := manager.Open(context.Background(), Key{AgentID: "agent-a", ContextID: "c2"}); !errdefs.IsNotFound(err) {
+		t.Fatalf("Open after timeout error = %v, want not found", err)
+	}
+	// Sessions were left intact, not deleted.
+	manager.mu.Lock()
+	entry := manager.entries[Key{AgentID: "agent-a", ContextID: "ctx"}]
+	manager.mu.Unlock()
+	if entry == nil {
+		t.Fatal("session was removed despite timeout")
+	}
+
+	close(release)
+	if err := manager.RemoveAgent(context.Background(), "agent-a"); err != nil {
+		t.Fatalf("retry RemoveAgent: %v", err)
+	}
+	manager.mu.Lock()
+	entry = manager.entries[Key{AgentID: "agent-a", ContextID: "ctx"}]
+	manager.mu.Unlock()
+	if entry != nil {
+		t.Fatal("session survived successful RemoveAgent retry")
+	}
+}
+
+func TestManagerRemoveAgentConcurrentOpenRace(t *testing.T) {
+	manager, _ := newTestManager(t, time.Hour)
+
+	const opens = 64
+	const removes = 8
+	var wg sync.WaitGroup
+	for i := 0; i < opens; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+			defer cancel()
+			lease, err := manager.GetOrCreate(ctx, Key{
+				AgentID:   "agent-a",
+				ContextID: "c",
+			})
+			if err == nil {
+				_ = lease.Close()
+			}
+		}(i)
+	}
+	for i := 0; i < removes; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_ = manager.RemoveAgent(context.Background(), "agent-a")
+		}()
+	}
+	wg.Wait()
+
+	// After RemoveAgent returned, no session for the removed agent may
+	// remain, and new opens must fail.
+	manager.mu.Lock()
+	for key := range manager.entries {
+		if key.AgentID == "agent-a" {
+			manager.mu.Unlock()
+			t.Fatalf("leaked session for removed agent: %+v", key)
+		}
+	}
+	manager.mu.Unlock()
+	if _, err := manager.Open(context.Background(), Key{AgentID: "agent-a", ContextID: "c"}); !errdefs.IsNotFound(err) {
+		t.Fatalf("Open after concurrent removal error = %v, want not found", err)
+	}
+}

--- a/docs/plans/2026-08-15-dynamic-agent-registry.md
+++ b/docs/plans/2026-08-15-dynamic-agent-registry.md
@@ -1,0 +1,475 @@
+---
+layout: default
+title: core/runtime 动态增删 agent 方案
+---
+# core/runtime 动态增删 Agent 方案（动态 Agent 注册表）
+
+> **状态**: 草案,待评审。
+> **日期**: 2026-08-15
+> **作用域**: 改 `core/runtime`（新增动态 Agent 注册表与 `RegisterAgent` / `UnregisterAgent` API）、`core/runtime/session`（`Manager.RemoveAgent` / 有界关闭）、`core/deploy`（抽取 `BindAgent`）、`core/agent`（`Agent.Close`）；不改 `resource` 契约、不改 `deploy.Result` 的不可变语义、不改 `tool` / `memory` / `inference` / `event` 的既有契约。
+> **前置**: `session.InstanceResolver`（已有，窄接口）、`deploy.bindAgents`（已有，agent 装配逻辑）、`tool.Registry.Add/Remove`（已有，运行期增删先例）、`delegation.Directory`（已有，只读绑定）。
+> **本期不做**: 免重启的引擎代码热替换（属于插件/Reconcile 范围）、运行时改 `runtime` 配置（max_sessions 等）、跨进程自动拉起 agent（远程引擎继续走 A2A）、delegation 目录的活绑定（作为后续项列出）。
+
+## 0. TL;DR
+
+**现状是静态的：agent 在 `runtime.Builder.Build` 时一次性绑定到 `deploy.Result.agents`（普通 map），`session.Manager` 只持有该 map 的只读快照，`Runtime` 没有增删 API。运行期"动态"的只有 session（按 `Key{AgentID, ContextID}` 懒创建、空闲回收）和构建期解析的 `dynamic_catalog` 工具映射——都不是动态 agent。**
+
+方案：在 `core/runtime` 新增一个**活的 Agent 注册表**（`AgentRegistry`，mutex 保护），实现已有的 `session.InstanceResolver` 接口；`Runtime` 保留构建期的 `resource.Registry` / `Loader` / `deploy.Result` 只读视图，供运行期装配新 agent 时解析 engine/hook factory 与依赖。对外暴露：
+
+```go
+func (r *Runtime) RegisterAgent(ctx context.Context, name string, def agent.Definition, opts ...RegisterAgentOption) (*agent.Agent, error)
+func (r *Runtime) UnregisterAgent(ctx context.Context, name string, opts ...UnregisterAgentOption) error
+func (r *Runtime) Agent(name string) (*agent.Agent, bool)
+func (r *Runtime) AgentNames() []string
+```
+
+删除语义的关键是并发正确性：在 `session.Manager` 内维护 per-agent tombstone（`removed` 集合），`open` 在持有 `m.mu` 时先查 tombstone，从根上消除"Open 与 Remove 交错导致会话泄漏"的竞态；随后按 `Manager.Close` 的既有模式收集并关闭该 agent 的存量 session（中断活跃 turn + 等待），最后关闭 engine/hooks 并移出注册表。
+
+分 3 个阶段落地，每阶段独立合入、可回滚，遵循 Conventional Commits（scope：`core`）。
+
+## 1. 背景与现状
+
+### 1.1 当前数据流
+
+```
+deploy.Document（静态）
+  → runtime.Builder.Build
+    → deploy.Builder.Deploy：bindAgents 把每个 Definition 装配成 *agent.Agent
+      写入 deploy.Result.agents（普通 map，无锁、无增删方法）
+    → session.NewManager(resultResolver{result}, ...)
+       resultResolver.Instance(id) = result.Agent(id)   // 只读快照
+  → Runtime{manager, router, result}
+```
+
+关键代码位置：
+
+- agent 装配：`deploy.bindAgents`（[builder.go](/Users/haivivi/Workspace/flowcraft/core/deploy/builder.go:207)），结果写入 `result.agents[name]`（[builder.go](/Users/haivivi/Workspace/flowcraft/core/deploy/builder.go:263)）。
+- 只读快照：`resultResolver`（[builder.go](/Users/haivivi/Workspace/flowcraft/core/runtime/builder.go:206)）与 `Result.Agent`（[builder.go](/Users/haivivi/Workspace/flowcraft/core/deploy/builder.go:437)）。
+- 会话懒创建：`Manager.open` 在持有 `m.mu` 时调 `resolver.Instance(key.AgentID)`，不存在则返回 `NotFound`（[manager.go](/Users/haivivi/Workspace/flowcraft/core/runtime/session/manager.go:124)）。
+- 空闲回收：`Manager.reclaim` 删除条目并 `session.close()`（[manager.go](/Users/haivivi/Workspace/flowcraft/core/runtime/session/manager.go:231)）。
+- 动态工具目录：`resolveDynamicCatalogAssemblies` + `newDynamicCatalogProvider` 在构建期把 `agentID → tool.Assembly` 固化成 map（[dynamic.go](/Users/haivivi/Workspace/flowcraft/core/runtime/dynamic.go:26)）。
+- 运行期增删先例：`tool.Registry.Add/Remove`（Remove 会对 `io.Closer` 释放资源，[registry.go](/Users/haivivi/Workspace/flowcraft/core/tool/registry.go:114)）。
+
+### 1.2 现状结论
+
+- `deploy.Result` 是部署期产物，`agents` 无并发保护、无增删方法；`Runtime` 不保留 `resource.Registry` / `Loader`，无法事后装配新 agent。
+- `session.Manager` 通过窄接口 `InstanceResolver` 解析 agent——**这是最顺的接缝**，替换实现即可让新 agent 可被会话使用。
+- `Session.close` 已有"中断活跃 turn + 等待收尾"的完整语义（[session.go](/Users/haivivi/Workspace/flowcraft/core/runtime/session/session.go:654)），删除 agent 时可直接复用；唯一缺口是等待用 `context.Background()`，需要改为可被调用方 ctx 约束。
+- agent 的 engine/hooks 目前**没有关闭路径**：`deploy.Result.Close` 只关资源值，不关 `*agent.Agent` 的 Engine/hook（[builder.go](/Users/haivivi/Workspace/flowcraft/core/deploy/builder.go:452)）。动态删除必须补上，否则删掉的 agent 泄漏引擎资源。
+- `delegation.LocalDirectory` 绑定一次后不可变（[directory.go](/Users/haivivi/Workspace/flowcraft/core/delegation/directory.go:37)），动态 agent 默认不会成为委托目标——本期文档化该限制，活目录列为后续项。
+
+## 2. 目标与非目标
+
+### 目标
+
+- 不重建 `Runtime`、不重启进程的前提下，注册一个新 agent 并立即能对它 `Manager.Open` / `GetOrCreate` 开会话、跑 turn。
+- 删除一个 agent：新会话被拒绝，存量会话与活跃 turn 有序收尾，engine/hooks 释放，再次注册同名 agent 可用。
+- 与动态工具目录联动：新 agent 可携带工具装配（`tool.Assembly`）或回退到 `default`。
+- 保持现有架构原则：无全局状态、显式注册、严格校验、错误分类（`errdefs`）、`deploy.Result` 不可变。
+- 并发正确：Open 与 Remove 任意交错不泄漏会话、不悬挂 turn、不出现"删除后仍可开新会话"。
+
+### 非目标（本期）
+
+- 免重启的引擎/hook 代码级热替换（plugin/Reconcile 范围，见既有插件方案）。
+- 运行时修改 `runtime` 配置（idle_timeout、max_sessions 等）或事件总线拓扑。
+- 让动态 agent 自动出现在 `delegation.Directory` 中（只读目录 v1 不做活绑定）。
+- 跨进程拉起新 agent 进程（远程引擎用 A2A，本地引擎 factory 仍是构建期注册的 `resource.Factory`）。
+
+## 3. 总体结构
+
+```
+                      runtime.Runtime
+        ┌─────────────────┼──────────────────┐
+        │                 │                  │
+   deploy.Result      resource.Registry   session.Manager
+   （只读：资源值        （保留，供        （持有 tombstone；
+    / 依赖解析）         RegisterAgent       新增 RemoveAgent）
+         │              装配 engine/hooks）
+         │                 │                  │
+         └──────► AgentRegistry（活的）◄──────┘
+                   ├─ map[string]*agent.Agent    // 并发安全
+                   ├─ map[string]*tool.Assembly  // 动态目录（活的）
+                   └─ implements session.InstanceResolver
+```
+
+要点：
+
+- `AgentRegistry` 是 `core/runtime` 内新增包内类型，实现 `session.InstanceResolver`（只多一个方法面：`Instance(id)`），替代 `resultResolver` 交给 `Manager`。
+- `deploy.Result` **保持不可变**：它是部署期快照；动态增删只发生在 `AgentRegistry` 这一"活"层，避免把运行期可变性引入部署产物。
+- `Runtime` 持有 `resource.Registry`（builder 现在用完即丢，需要保留）与 `Loader`，`RegisterAgent` 时复用部署期同一套 factory 与依赖解析逻辑。
+- 删除并发安全由两层协作：`AgentRegistry` 负责"发现"（`Agent/AgentNames/Instance`），`session.Manager` 内的 tombstone 负责"开关"（阻止新会话打开）。
+
+## 4. API 设计
+
+### 4.1 `core/runtime`：Runtime 对外 API
+
+```go
+// RegisterAgentOption 配置一次动态注册。
+type RegisterAgentOption func(*registerOptions) error
+
+// WithToolAssembly 为动态 agent 指定工具装配资源（部署文档 resources
+// 中已构建的 *tool.Assembly 名字）。未指定时回退 dynamic_catalog 的
+// default；dynamic_catalog 已配置但无 default 时，注册必须显式携带该选项。
+func WithToolAssembly(resourceName string) RegisterAgentOption
+
+// RegisterAgent 装配并注册一个新 agent。name 即 agent ID，必须非空、
+// 无首尾空白。同名已注册 → Conflict；同名曾删除（tombstone）→ 允许重注册。
+func (r *Runtime) RegisterAgent(ctx context.Context, name string, def agent.Definition, opts ...RegisterAgentOption) (*agent.Agent, error)
+
+// UnregisterAgentOption 配置一次删除。
+type UnregisterAgentOption func(*removeOptions) error
+
+// WithRemoveTimeout 约束删除总耗时（含活跃 turn 的收尾等待）；缺省无界。
+func WithRemoveTimeout(d time.Duration) UnregisterAgentOption
+
+// UnregisterAgent 删除一个动态注册的 agent：阻塞新会话 → 排空存量会话
+//（等待活跃 turn 自然结束）→ 移出注册表 → 关闭 engine/hooks。
+// 未知名字 → 幂等 nil（对齐 tool.Registry.Remove）；静态部署 agent → Conflict。
+func (r *Runtime) UnregisterAgent(ctx context.Context, name string, opts ...UnregisterAgentOption) error
+
+// Agent / AgentNames 是"活"的发现视图（区别于 deploy.Result 的部署快照）。
+func (r *Runtime) Agent(name string) (*agent.Agent, bool)
+func (r *Runtime) AgentNames() []string
+```
+
+`Runtime` 结构新增字段：`registry *AgentRegistry`（活的）、`resources *resource.Registry`（保留）、`loader *resource.Loader`（保留）、`liveCatalog *catalogRegistry`（活的工具目录，见 §6）、`bus event.Bus`（生命周期事件用）、`lifecycleMu sync.Mutex` + `closed bool`（操作互斥，见 §5.4）。`Builder.Build` 结束时把这些与 `deploy.Result` 一起交还给 `Runtime`。
+
+### 4.2 `core/runtime`：AgentRegistry
+
+```go
+// AgentRegistry 是运行期可变、并发安全的 agent 视图。
+type AgentRegistry struct {
+    mu       sync.RWMutex
+    agents   map[string]*agent.Agent // 动态注册的 agent
+    deployed *deploy.Result          // 只读回退视图（静态部署 agent）
+}
+
+func (r *AgentRegistry) Instance(id string) (*agent.Agent, bool) // session.InstanceResolver
+func (r *AgentRegistry) Agent(id string) (*agent.Agent, bool)
+func (r *AgentRegistry) AgentNames() []string
+func (r *AgentRegistry) Put(id string, a *agent.Agent) error   // 重复 → Conflict
+func (r *AgentRegistry) Delete(id string) (*agent.Agent, bool)
+func (r *AgentRegistry) Close() error                          // 关闭剩余动态 agent
+```
+
+`Agent/Instance/AgentNames` 先查动态 map，再回退 `deployed`，因此 `Runtime.Agent` 是"部署快照 + 动态层"的合并视图。`Delete/Close` 只作用于动态 map——静态 agent 的生命周期仍归 `deploy.Result` 所有，杜绝双关。
+
+### 4.3 `core/deploy`：抽取 BindAgent
+
+把 `bindAgents` 循环体抽成可复用的导出函数，构建期 `bindAgents` 与运行期 `RegisterAgent` 共用同一装配路径（engine factory `New` → hooks 构建 + `Wire` → 组装 `*agent.Agent`）：
+
+```go
+// BindAgent 用注册表中的 factory 装配单个 agent，返回运行形态。
+// 不修改 result（不动 result.agents）；依赖解析只读 result.values。
+func BindAgent(
+    ctx context.Context,
+    reg *resource.Registry,
+    result *Result,
+    loader *resource.Loader,
+    name string,
+    def agent.Definition,
+) (*agent.Agent, error)
+```
+
+`bindAgents` 重构为循环调 `BindAgent` 再 `result.agents[name] = a`，行为不变。
+
+### 4.4 `core/agent`：Agent.Close
+
+```go
+// Close 释放 agent 持有的引擎与钩子（实现 io.Closer 的组件），
+// 逐项 close 并 errors.Join 汇总。幂等由各组件自身保证。
+func (a *Agent) Close() error
+```
+
+同时修复一个既有的资源泄漏：`deploy.Result.Close` 在逆序关闭资源值后，对每个 `agents` 成员调用 `a.Close()`。这是行为增强，不破坏现有调用方（此前 engine/hooks 从没被关闭过）。
+
+`BindAgent` 内部做部分装配回滚：engine 已构造、后续 hook 构造/Wire 失败时，按逆序关闭已构造的 engine 与 hooks（实现 `io.Closer` 的组件），避免运行期注册失败泄漏已 Wire 的订阅。
+
+### 4.5 `core/runtime/session`：Manager 增删与排空
+
+```go
+// RemoveAgent 阻塞该 agent 的新会话打开，排空其存量会话：
+//   - 等待所有活跃 turn 自然结束（有界，ctx 控制）；
+//   - 全部 idle 后关闭会话（此时 close 不等待，安全）；
+//   - ctx 超时/取消 → 返回 DeadlineExceeded/Canceled，tombstone 保留，
+//     会话原样保留，调用方可重试（幂等收尾剩余会话）。
+func (m *Manager) RemoveAgent(ctx context.Context, name string) error
+
+// ReopenAgent 清除 RemoveAgent 留下的 tombstone，供重注册同名 agent。
+func (m *Manager) ReopenAgent(name string)
+```
+
+**为什么是"排空"而不是"中断 + 等待"**：有界等待"中断后的 turn 退出"存在安全死角——若 ctx 超时，`close` 返回但 turn goroutine 可能仍存活，此时关闭 engine 是 use-after-free。排空方案把"有界等待"放在 turn **自然结束**上，超时即放弃本次删除（不拆机），从根上消除部分删除状态；会话全部 idle 后的关闭是无等待的，天然安全。
+
+`Manager.RemoveAgent` 不需要改 `Session.close` 签名（保持无参、中断 + 无界等待的既有语义），仅新增：
+
+```go
+// Manager 新增字段
+removed map[string]struct{} // tombstone：阻塞该 agent 的新会话
+
+// open() 在 m.mu 内新增一行（见 §5.2）
+// release / activityChanged / scheduleIdleTimerLocked / reclaim 对
+// removed 中的 agent 跳过空闲回收，避免排水期间会话被提前回收。
+```
+
+### 4.6 注册示例
+
+```yaml
+# 一段可注入的 agent config（与部署文档 agents.<name> 同构）
+card:
+  name: Ticket QA
+  description: 评审工单改动
+  skills: [{id: qa, name: QA, description: 代码评审}]
+engine:
+  kind: agent.Engine
+  impl: graph
+  settings: {graph: ticket-qa}
+policy: {max_revise: 1}
+tools: [search, git]
+observe:
+  - type: audit
+    settings: {channel: ticket-events}
+```
+
+```go
+var def agent.Definition // 上面的 YAML 严格解码（同部署文档解码路径）
+instance, err := app.RegisterAgent(ctx, "ticket-qa",
+    def,
+    runtime.WithToolAssembly("kit"), // 可选：动态工具目录
+)
+if err != nil { /* Validation/Conflict/NotFound ... */ }
+
+lease, err := app.Sessions().GetOrCreate(ctx, session.Key{
+    AgentID: "ticket-qa", ContextID: "user-7",
+})
+// ... Start / Wait，与静态 agent 完全一致
+
+if err := app.UnregisterAgent(ctx, "ticket-qa",
+    runtime.WithRemoveTimeout(30*time.Second),
+); err != nil { /* DeadlineExceeded: 可重试 */ }
+```
+
+## 5. 删除语义与并发正确性
+
+### 5.1 状态机
+
+```
+active ──UnregisterAgent──► removing ──关闭全部会话/释放资源──► removed
+   ▲                                                            │
+   └──────────────── ReopenAgent + RegisterAgent ◄──────────────┘
+```
+
+- `removing`：新会话打开被拒（tombstone 生效）；发现视图暂不列出（若排空失败，agent 会被放回）。
+- `removed`：发现视图（`Agent` / `AgentNames`）不再列出；engine/hooks 已释放。
+- 重注册：`RegisterAgent` 先装配成功，再 `ReopenAgent` + `Put`，避免失败时留下"半开"状态。
+
+### 5.2 竞态分析（Open vs Remove）
+
+若删除只做"注册表 delete + 收集会话"，存在会话泄漏的交错：
+
+1. `open` 持有 `m.mu` 解析 `resolver.Instance(id)` 成功（此刻删除尚未发生）。
+2. 删除线程删注册表、收集会话（此时条目尚未插入）并解锁。
+3. `open` 插入新会话后解锁——该会话指向已删除的 agent，且永远不会被删除流程关闭。
+
+修复：**tombstone 放在 `Manager` 内、检查发生在 `m.mu` 之下**。`open` 的流程变为：
+
+```go
+m.mu.Lock()
+defer m.mu.Unlock()
+if m.closed { ... }
+if _, gone := m.removed[key.AgentID]; gone {
+    return nil, errdefs.NotFoundf("runtime session: agent %q is not deployed", key.AgentID)
+}
+// ... 既有 entries 命中 / resolver 解析 / 插入
+```
+
+`RemoveAgent` 在同一个 `m.mu` 内先写 tombstone（幂等），随后在锁外**排空**（等待 idle），最后关闭并清理条目：
+
+```go
+func (m *Manager) RemoveAgent(ctx context.Context, name string) error {
+    if isNil(ctx) { return errdefs.Validationf("runtime session: context is required") }
+    m.mu.Lock()
+    if m.closed { m.mu.Unlock(); return ErrManagerClosed }
+    m.removed[name] = struct{}{}          // 幂等：重试时保留
+    for key, entry := range m.entries {
+        if key.AgentID != name { continue }
+        entry.idleGeneration++             // 使迟到的 reclaim 回调失效
+        if entry.timer != nil { entry.timer.Stop(); entry.timer = nil }
+    }
+    var sessions []*Session
+    for key, entry := range m.entries {
+        if key.AgentID == name { sessions = append(sessions, entry.session) }
+    }
+    m.mu.Unlock()
+
+    // 排空：等待所有活跃 turn 自然结束（有界）。超时即放弃，
+    // 不关闭任何会话、不产生部分删除状态。
+    if err := m.awaitAgentIdle(ctx, name); err != nil { return err }
+
+    // 全部 idle 后关闭：close 对 idle 会话无等待，安全。
+    for _, s := range sessions { s.markClosing() }
+    for _, s := range sessions { s.notifySessionClosing(true) }
+    var errs []error
+    for _, s := range sessions { if err := s.close(); err != nil { errs = append(errs, err) } }
+
+    m.mu.Lock()
+    for key := range m.entries {
+        if key.AgentID == name { delete(m.entries, key) }
+    }
+    m.mu.Unlock()
+    return errors.Join(errs...)
+}
+```
+
+`awaitAgentIdle` 以短周期轮询 `agentIdle(name)`（所有 `Key.AgentID == name` 的会话均 `isIdle()`）并 select `ctx.Done()`；`release / activityChanged / scheduleIdleTimerLocked / reclaim` 对 `removed` 中的 agent 一律跳过（不调度、不回收），保证排空期间会话不被并发回收。排空通过后到关闭之间，若某会话被持有 lease 的调用方启动了新 turn，`Session.close` 的中断 + 无界等待语义兜底，仍然安全。
+
+因为 `open` 的"检查 tombstone → 解析 → 插入"全程持有 `m.mu`，而 `RemoveAgent` 的"写 tombstone → 收集"也在 `m.mu` 内，二者互斥后必居其一：
+
+- `open` 先完成：会话已插入，`RemoveAgent` 收集时可见并被关闭；
+- `RemoveAgent` 先完成：`open` 在 tombstone 检查处被拒。
+
+不存在中间态。`reclaim` 竞态同理：条目已被 `RemoveAgent` 删除，迟到的 reclaim 回调在 `m.mu` 内检查条目不存在即空操作（既有逻辑已覆盖）。
+
+### 5.3 Runtime.UnregisterAgent 的清理顺序
+
+```go
+func (r *Runtime) UnregisterAgent(ctx context.Context, name string, opts ...UnregisterAgentOption) error {
+    r.lifecycleMu.Lock()               // 与 RegisterAgent / Close 互斥（§5.4）
+    defer r.lifecycleMu.Unlock()
+    if r.closed { return errdefs.NotAvailablef("runtime: closed") }
+
+    // 0. 定位：只允许删除动态 agent
+    instance, ok := r.registry.Delete(name)
+    if !ok {
+        if _, deployed := r.result.Agent(name); deployed {
+            return errdefs.Conflictf("runtime: agent %q is deployed; remove it from the document", name)
+        }
+        return nil // 未知名字：幂等
+    }
+
+    // 1. 阻塞新会话 + 排空存量会话（ctx 有界等待 turn 自然结束）
+    if err := r.manager.RemoveAgent(ctx, name); err != nil {
+        // 超时/取消：tombstone 保留（新会话仍被拒），agent 仍在注册表，
+        // engine/hooks 未释放（turn 可能仍存活）。调用方可重试。
+        r.registry.Put(name, instance)
+        return err
+    }
+    // 2. 移出动态工具目录
+    if r.liveCatalog != nil { r.liveCatalog.Delete(name) }
+    // 3. 释放 engine/hooks（此时已无会话引用该 agent）
+    return instance.Close()
+}
+```
+
+顺序原则：**先断电（堵新会话）、再排水（等 turn 结束）、最后拆机（释放资源）**。`RemoveAgent` 失败时把 agent **放回注册表**（排空期间它暂时离开发现视图，失败即恢复），保证失败重试的语义干净；只有全部会话确认关闭后才允许 `Close` engine/hooks。
+
+### 5.4 操作互斥（Register / Unregister / Close）
+
+`Manager` 内的 tombstone 只解决 `Open vs Remove`；**`Register` 与 `Remove` 之间仍需一个更高的互斥**，否则存在覆盖竞态：
+
+1. `UnregisterAgent` 执行 `manager.RemoveAgent`（tombstone 已写入）。
+2. 并发 `RegisterAgent` 构建成功 → `ReopenAgent` 清 tombstone → 新 agent `Put`。
+3. `UnregisterAgent` 继续 `registry.Delete`——删掉并 Close 了刚注册的新 agent。
+
+修复：`Runtime` 持有 `lifecycleMu sync.Mutex`，`RegisterAgent` / `UnregisterAgent` / `Close` 全程持有（控制面 QPS 低，全局锁足够）。`Runtime.Close` 顺序：抢 `lifecycleMu` → 置 `closed` → `manager.Close` → `router.Close` → `result.Close`（静态 agent）→ `registry.Close`（动态 agent）；持锁期间任何增删调用先等锁、再撞 `closed` 返回 `NotAvailable`。`RegisterAgent` 的提交顺序固定为：`ReopenAgent` → `liveCatalog.Set` → `registry.Put` → 发布事件，全程在 `lifecycleMu` 内，不存在中间可见状态。
+
+## 6. 动态工具目录联动
+
+现状的 `newDynamicCatalogProvider` 捕获构建期 map，运行期不可变。改造为活的 `catalogRegistry`：
+
+```go
+// catalogRegistry 是 agentID → tool.Assembly 的活映射，兼容 default 回退。
+type catalogRegistry struct {
+    mu         sync.RWMutex
+    assemblies map[string]*tool.Assembly
+    def        *tool.Assembly // 构建期 dynamic_catalog 的 default
+}
+
+func (c *catalogRegistry) NewCatalog(ctx context.Context, instance *agent.Agent) (tool.Session, error)
+func (c *catalogRegistry) Set(id string, a *tool.Assembly)
+func (c *catalogRegistry) Delete(id string)
+```
+
+规则：
+
+- 构建期把 `resolveDynamicCatalogAssemblies` 的结果灌入 `catalogRegistry`（行为不变）。
+- `RegisterAgent` 带 `WithToolAssembly("resourceName")` 时，用 `deploy.Result.Value` 解析已构建的 `*tool.Assembly` 并 `Set`；未指定时回退 `default`；`dynamic_catalog` 已配置但无 `default` 且未显式指定 → 注册期 `Validation`（对齐构建期"每个 agent 必须有映射或 default"的规则）；`dynamic_catalog` 未配置时 agent 无工具目录（与现状一致）。
+- `UnregisterAgent` 调用 `Delete`；`default` 本身不可删除。
+
+## 7. 事件与可观测性（P2，可选）
+
+新增运行期生命周期主题（`core/runtime/events.go`），供 UI/运维订阅：
+
+```
+runtime.agent.<id>.registered
+runtime.agent.<id>.removed
+```
+
+载荷仅包含 `agent_id`、`name`、`description`（从 `AgentCard` 取，避免事件放大）。删除失败（排空超时）不发布 `removed`，只发布 `removed` 成功事件。事件经 `Runtime.Attach` 可订阅，与现有 `agent.run.*` 命名空间并存。**不阻塞注册/删除主流程**：发布失败仅记日志。
+
+## 8. 与既有机制的关系
+
+| 机制 | 关系 | 动作 |
+| --- | --- | --- |
+| `session.Manager` | 窄接口 `InstanceResolver` 替换实现 | 新增 tombstone + `RemoveAgent/ReopenAgent`，`open` 增加一行检查 |
+| `deploy.Result` | 部署期快照，保持不可变 | 不改；动态层独立为 `AgentRegistry` |
+| `dynamic_catalog` | agent → tool assembly 构建期映射 | 变活：`catalogRegistry`，行为兼容 |
+| `delegation.Directory` | 绑定一次后不可变 | 本期文档化限制：动态 agent 不作为委托目标；活目录列后续项 |
+| `memory` | 按 `AgentID` 硬分区 | 无需改动；动态 agent 天然可写 |
+| checkpoint/resume | 按 runID 存储，不按 agent 索引 | 删除 agent 后其 parked run 无法恢复（会话已关）；存储清理属开放问题 |
+| `tool.Registry.Add/Remove` | 运行期增删先例 | 本方案的删除顺序与其一致（先移出、后释放 `io.Closer`） |
+| 插件 / A2A | 引擎仍是构建期注册的 `resource.Factory` | `RegisterAgent` 只引用既有 factory，不引入新的引擎加载机制 |
+
+## 9. 对既有代码的影响与兼容性
+
+- **零破坏**：`deploy.Result` 公开面不变；`Manager.Open/GetOrCreate` 签名不变；`Session.close` 签名不变。
+- **行为增强**：`deploy.Result.Close` 新增关闭 agents（修复 engine/hooks 泄漏）；`dynamic_catalog` 内部从静态 map 换为活映射，对外语义不变。
+- **错误分类**：重复注册（含与静态 agent 同名）→ `errdefs.Conflict`；未知删除 → 幂等 nil（对齐 `tool.Registry.Remove`）；删除静态部署 agent → `Conflict`；构建/装配失败 → `Validation`；排空超时 → `DeadlineExceeded` 归类（agent 放回注册表，可重试）。
+- **构建门禁**：按仓库规范跑 `make ci`、`make lint`、`git diff --check`；发布时才加 `.release/core.json` changeset（summary 覆盖自上一 tag 的全部累积变更）。
+
+## 10. 分阶段落地
+
+| 阶段 | 内容 | 交付物 | 验收 |
+| --- | --- | --- | --- |
+| P0 | 抽取 `deploy.BindAgent`（含部分装配回滚）；`agent.Agent.Close`；`deploy.Result.Close` 关闭 agents | 重构 + 单测 | 既有 `core/deploy`、`core/runtime` 测试全绿；`Result.Close` 关闭引擎、`BindAgent` 中途失败回滚测试通过 |
+| P1 | `AgentRegistry` + `catalogRegistry`；`Manager.RemoveAgent(ctx,name)/ReopenAgent` + tombstone + 排空；`Runtime.RegisterAgent/UnregisterAgent/Agent/AgentNames` + options + `lifecycleMu` | API + 单测 + 并发竞态测试 | 动态注册→开会话→跑 turn 端到端通过；Open vs Remove、Register vs Remove 交错测试无泄漏、无覆盖 |
+| P2 | 生命周期事件（§7）；文档（本方案归档进 guides）；`examples/forge` 动态增删示例（受 GOWORK=off 固定版本约束，随下次 core 发布落地）；`.release/core.json`（仅实际发布时添加） | 事件 + 文档 + 示例 + changeset | 手册可跟随完成"运行期加一个 agent → 对话 → 删除 → 重加" |
+
+每阶段独立合入、可回滚。
+
+> **2026-08-15 进度**：P0、P1 与 P2 的生命周期事件已实现并通过 `core` 模块全量测试（`go test ./...`，含 `-race` 并发用例：Open vs Remove、Register vs Remove、Close vs Register）。`examples/forge` 动态增删示例与 `.release/core.json` changeset 按发布流程延后（`examples/` 以 `GOWORK=off` 固定版本构建，需等 core 实际发布后落地）。
+
+## 11. 测试与验收
+
+### P1 核心测试矩阵
+
+- `RegisterAgent` 成功 → `Manager.GetOrCreate` 开新会话 → `Start` 跑 turn 成功。
+- 重复注册同名 → `Conflict`。
+- `UnregisterAgent` 后 `Open` → `NotFound`；`Agent/AgentNames` 不再列出。
+- 删除时存在活跃 turn → 排空等待其自然结束；engine `Close` 被调用。
+- 排空超时（turn 不结束 + `WithRemoveTimeout` 到期）→ `DeadlineExceeded`，agent 放回注册表，engine **未被** Close，重试后成功。
+- 删除后重注册同名 → 可再次开会话（tombstone 清除）。
+- `WithToolAssembly` 解析失败 → `NotFound`；缺省回退 `default`。
+- 动态 agent 无 `dynamic_catalog` 配置时 → 无工具目录，不报错。
+- `BindAgent` 中途失败（hook factory 报错）→ 已构造的 engine/hooks 被逆序 Close。
+- 删除静态部署 agent → `Conflict`；删除未知名字 → 幂等 nil。
+
+### 并发竞态测试（关键）
+
+- `N` 个 goroutine 并发 `Open` + `M` 个 goroutine 并发 `RemoveAgent` 同 agent：最终不存在"已删除 agent 的会话"且无泄漏；用 `-race` 跑。
+- `RemoveAgent` 与 `reclaim` 并发：迟到的 idle timer 不得复活已删除条目。
+- `RegisterAgent`（重注册）与 `Open` 并发：`Open` 要么在 tombstone 清除前被拒，要么成功后拿到新 agent。
+- `RegisterAgent` 与 `UnregisterAgent` 并发同 agent（`lifecycleMu` 下）：串行化，不出现"删掉刚注册的新 agent"覆盖。
+- `Runtime.Close` 与 `RegisterAgent` 并发：`RegisterAgent` 等锁后返回 `NotAvailable`，无泄漏。
+
+### 门禁
+
+`make ci`、`make lint`、`git diff --check`；`core` 模块发布前 `make release-plan` 确认 changeset 覆盖累积变更。
+
+## 12. 开放问题
+
+1. ~~`UnregisterAgent` 对未知名字：`NotFound` 还是幂等 `nil`？~~ **已定：幂等 nil**（与 `tool.Registry.Remove` 一致）。
+2. ~~删除时的收尾策略：中断 + 等待 vs drain？~~ **已定：drain（等自然结束）**，超时即放弃本次删除、不拆机；中断式删除作为后续项（需要 turn 强制退出机制）。
+3. checkpoint 清理：`CheckpointStore` 按 runID 索引、无按 agent 批量删除接口；被删 agent 的存量 checkpoint 是否要新增按 agent 清理？（建议暂不，交给存储侧保留策略。）
+4. `delegation.Directory` 活绑定是否值得做：动态 agent 作为委托目标的价值与实现成本（需要把只读 `Deployment` 视图换成可刷新目录）？（建议 P2 后单独评审。）
+5. ~~动态 agent 的事件载荷是否要包含完整 `AgentCard`？~~ **已定：只给 `agent_id` + `name` + `description`**（避免事件放大）。


### PR DESCRIPTION
## Summary

Implements the dynamic agent registry plan in [docs/plans/2026-08-15-dynamic-agent-registry.md](/Users/haivivi/Workspace/flowcraft/docs/plans/2026-08-15-dynamic-agent-registry.md): agents can now be registered and removed at runtime without rebuilding the Runtime.

- `core/runtime`: live `AgentRegistry` (implements `session.InstanceResolver`, dynamic layer over the immutable `deploy.Result`), `Runtime.RegisterAgent` / `UnregisterAgent` / `Agent` / `AgentNames`, `lifecycleMu` serializing register/remove/close, `WithToolAssembly` / `WithRemoveTimeout` options, and `runtime.agent.*` lifecycle events.
- `core/runtime/session`: `Manager.RemoveAgent(ctx, name)` blocks new sessions via a per-agent tombstone and drains active turns (bounded, retryable, no partial removal); `ReopenAgent` for re-registration.
- `core/deploy`: `BindAgent` extracted for reuse by runtime registration (with partial-assembly rollback); `Result.Close` now closes agents' engine/hooks (previously leaked).
- `core/agent`: `Agent.Close()` releases engine and lifecycle hooks.

## Verification

- `core` module: `go test ./... -count=1` green (incl. `-race` concurrency tests: Open vs Remove, Register vs Remove, Close vs Register); `go vet ./...` and `golangci-lint run ./...` 0 issues; `git diff --check` clean.
- External-module check: a temporary forge-module test exercised register → run turn → unregister → re-register end-to-end against local core via the workspace; removed after verification (per the plan, a permanent forge demo waits for the next core release because `examples/` builds pinned with `GOWORK=off`).