### PR TITLE
chore(release): add core v0.1.11 changeset

### DIFF
--- a/.release/core-v0.1.11.json
+++ b/.release/core-v0.1.11.json
@@ -1,0 +1,9 @@
+{
+  "summary": "feat(core): dynamic agent registry for runtime agent register/unregister with lifecycle-aware cleanup; feat(core): expose response_format on graph inference node config",
+  "releases": [
+    {
+      "module": "core",
+      "bump": "patch"
+    }
+  ]
+}


### PR DESCRIPTION
Adds the `.release/core-v0.1.11.json` changeset for the pending `core` patch release v0.1.11.

Covers the accumulated delta since `core/v0.1.10`:

- feat(core): dynamic agent registry for runtime register/unregister (#335)
- feat(core): expose response_format on graph inference node config (#334)

Local gates run:

- `make release-check` (incl. `BASE=origin/main`) — changesets valid, plan `core: 0.1.10 -> 0.1.11 (patch)`, tag `core/v0.1.11`
- `make ci` — vet + test pass across all modules
- `make lint` — 0 issues on all CI-gated modules
- `git diff --check` — clean

The `Release modules` workflow will aggregate this changeset into the changelog and publish `core/v0.1.11` after the Release PR merges and gates pass.