### PR TITLE
docs: sync guides and flowcraft-config skill with core v0.1.11

### DIFF
--- a/docs/guides/deploy.md
+++ b/docs/guides/deploy.md
@@ -97,6 +97,12 @@ if err != nil {
 defer result.Close()
 ```
 
+`Result.Close` closes every built resource value in reverse construction
+order, then closes each bound agent (engine and lifecycle hooks). Agents
+can also be assembled individually at runtime via the exported
+`deploy.BindAgent` — the same path `core/runtime` uses for its live agent
+registry (see [runtime.md](runtime.md)).
+
 ## Layered configuration
 
 `deploy.LoadLayers` loads multiple `Layer` values, merges them in ascending

--- a/docs/guides/event.md
+++ b/docs/guides/event.md
@@ -49,4 +49,8 @@ resources:
 The runtime host exposes the bus through `agent.EventBusProvider`.
 Runtime-level consumers can also subscribe through `Runtime.Attach`
 without resolving the resource themselves; the prompt lifecycle events
-are documented in [prompt.md](prompt.md).
+are documented in [prompt.md](prompt.md). Runtime agent lifecycle events
+(`runtime.agent.<id>.registered` / `.removed`, subscribe with
+`PatternAgentLifecycle()`) live in a separate namespace and are published
+on successful dynamic registration/removal (see
+[runtime.md](runtime.md)).

--- a/docs/guides/prompt.md
+++ b/docs/guides/prompt.md
@@ -69,3 +69,7 @@ by `PromptID` when the matching `PromptResolved` arrives. External
 attachments use the bus default backpressure (`DropNewest`), so a slow
 UI drops envelopes instead of blocking the run pipeline; pass
 `event.WithAttachBackpressure` to opt into a different policy.
+
+Runtime agent lifecycle events (`runtime.agent.*`, `PatternAgentLifecycle`)
+are published in a separate namespace — see
+[runtime.md](runtime.md) for dynamic registration/removal.

--- a/docs/guides/resource.md
+++ b/docs/guides/resource.md
@@ -33,7 +33,8 @@ dependencies, and a `Loader` for `Source` references.
 
 `resource.Graph` validates named resources, resolves dependency refs, rejects
 cycles, and returns a stable topological order. `deploy.Builder` uses that
-order to construct resources and to close them in reverse order on failure.
+order to construct resources and to close them in reverse order on failure;
+`deploy.Result.Close` also closes each bound agent (engine and hooks).
 
 ### Loader and Source
 

--- a/docs/guides/runtime.md
+++ b/docs/guides/runtime.md
@@ -26,6 +26,8 @@ defer app.Close()
 ```
 
 `Runtime` owns its `deploy.Result`, event router, and session manager.
+`Close` releases the deployment (resources and deployed agents), the
+session manager, and any dynamically registered agents.
 
 ## Subscribing to runtime events
 
@@ -44,7 +46,9 @@ Attachments are torn down when the Runtime closes, and `Attach` fails
 with `NotAvailable` afterwards. External attachments inherit the bus
 default backpressure (`DropNewest`); pass
 `event.WithAttachBackpressure` to override per subscription. See
-[prompt.md](prompt.md) for the prompt lifecycle events.
+[prompt.md](prompt.md) for the prompt lifecycle events, and the
+"Dynamic agent registry" section below for the `runtime.agent.*`
+lifecycle events published on dynamic registration/removal.
 
 ## Runtime config
 
@@ -72,7 +76,9 @@ Rules:
 - `checkpoint_store` is optional; it names an `agent.CheckpointStore`.
 - `sessions.resume` requires `checkpoint_store`.
 - `dynamic_catalog.tools` maps agent IDs to `tool.Assembly` resources.
-  The reserved `default` key is an optional fallback.
+  The reserved `default` key is an optional fallback. The mapping is
+  live: dynamically registered agents may attach a tool assembly at
+  registration time (see below).
 - Buffer and concurrency fields are validated against hard upper bounds.
 
 ## Sessions
@@ -99,6 +105,58 @@ result, err := turn.Wait(ctx)
 
 `SinkSpec` controls streaming delivery, visibility, authority, and queue
 size. `delivery_concurrency` bounds in-flight sink callbacks.
+
+## Dynamic agent registry
+
+Agents are normally declared in the deployment document and fixed for the
+life of the `Runtime`. `Runtime` also exposes a live registry so agents
+can be registered and removed at runtime without rebuilding:
+
+```go
+instance, err := app.RegisterAgent(ctx, "qa", agent.Definition{
+    Card:   agent.AgentCard{Name: "Ticket QA"},
+    Engine: agent.EngineRef{Kind: "agent.Engine", Impl: "graph"},
+}, runtime.WithToolAssembly("shared_tools")) // optional tool catalog
+if err != nil {
+    return err
+}
+
+lease, err := app.Sessions().GetOrCreate(ctx, session.Key{
+    AgentID: "qa", ContextID: "user-7",
+})
+// ... Start / Wait, exactly like a deployed agent
+
+if err := app.UnregisterAgent(ctx, "qa",
+    runtime.WithRemoveTimeout(30*time.Second)); err != nil {
+    return err
+}
+```
+
+Semantics:
+
+- `RegisterAgent` runs the `Definition` through the same assembly path as
+  deployment (`deploy.BindAgent`: engine factory, dependency resolution,
+  hook construction and wiring). A name that collides with a deployed or
+  already-registered agent is a `Conflict`; assembly failures are
+  `Validation` and never leave a partial registration.
+- `UnregisterAgent` blocks new sessions for the agent, waits for active
+  turns to finish naturally (bounded by the caller context or
+  `WithRemoveTimeout`), then closes the agent's engine and hooks. On
+  timeout the agent stays registered and sessions stay intact; the call
+  is retryable. Unknown names are an idempotent no-op; deployed agents
+  cannot be removed at runtime (`Conflict`).
+- `Agent` / `AgentNames` are the live view: dynamically registered agents
+  plus the deployment snapshot.
+- With `dynamic_catalog` configured, a registration must either carry
+  `WithToolAssembly(<resource name>)` or be covered by the `default`
+  assembly — the same rule the build enforces for deployed agents.
+- Every successful register/remove publishes a lifecycle event under
+  `runtime.agent.<id>.registered` / `.removed` (subscribe with
+  `PatternAgentLifecycle()`); the payload carries `agent_id`, `name`, and
+  `description`.
+
+`Manager.RemoveAgent` / `Manager.ReopenAgent` are the session-manager
+level primitives behind removal and re-registration.
 
 ## Host decorators
 

--- a/docs/guides/tool.md
+++ b/docs/guides/tool.md
@@ -15,6 +15,10 @@ directory, the executor dispatcher, and a middleware chain.
 | `Catalog` | read-side view (`Get`, `Definitions`) |
 | `Executor` | dispatches every call through middleware |
 
+`Registry.Add` / `Registry.Remove` register and unregister tools at
+runtime (removal closes `io.Closer` tools); deferred sources use this
+surface to publish tools discovered after construction.
+
 ## Tool contract
 
 ```go

--- a/skills/flowcraft-config/SKILL.md
+++ b/skills/flowcraft-config/SKILL.md
@@ -53,7 +53,11 @@ the L2 dry-run harness and fix build failures against the reference cards.
    warnings flag names missing from the built catalog.
 7. **Hand off.** Report what was assembled, what L2 could not validate
    (app-registered kinds/hooks/sources), and the registration code the
-   host still needs.
+   host still needs. If the deployment relies on runtime agent
+   registration, call out that it needs the live registry API
+   (`Runtime.RegisterAgent` / `UnregisterAgent`; see
+   [references/runtime.md](references/runtime.md)) and any
+   `dynamic_catalog` `default`/`WithToolAssembly` requirement.
 
 ## Cross-file invariants
 
@@ -66,6 +70,9 @@ the L2 dry-run harness and fix build failures against the reference cards.
 - Agent `tools` is an allow-list, not a catalog declaration; `policy` is
   harness state, not engine settings.
 - Graph `model` refs: `model: {id: {provider, name}}`.
+- Runtime-registered agents reuse the deployment assembly path; their
+  names must not collide with deployed agents, and with a `dynamic_catalog`
+  they need a tool mapping or a `default`.
 
 ## Templates
 
@@ -77,7 +84,7 @@ workflow.
 ## Compatibility and versioning
 
 One skill version pins one FlowCraft version. The validator's `go.mod`
-requires `github.com/GizClaw/flowcraft/core v0.1.0` plus the relevant
+requires `github.com/GizClaw/flowcraft/core v0.1.11` plus the relevant
 `driver/*` and `backends/*` modules; the schema cards in this skill
 document exactly that release. When FlowCraft releases a new version,
 bump the pins and reconcile the cards in the same change. The L2 harness

--- a/skills/flowcraft-config/assets/minimal-deploy/deploy.yaml
+++ b/skills/flowcraft-config/assets/minimal-deploy/deploy.yaml
@@ -8,16 +8,22 @@ resources:
       route_cache_size: 1024
 
   ws:
-    kind: workspace.Registry
-    impl: yaml
+    kind: workspace.Workspace
+    impl: local
     settings:
       file: ./workspace.yaml
 
-  infer:
-    kind: inference.Assembly
-    impl: yaml
+  provider:
+    kind: inference.Provider
+    impl: deepseek
     settings:
       file: ./inference.yaml
+
+  infer:
+    kind: inference.Assembly
+    impl: unified
+    deps:
+      provider: provider
 
 agents:
   assistant:
@@ -25,12 +31,13 @@ agents:
       name: Assistant
       description: Handles interactive requests with memory.
     engine:
-      kind: graph
+      kind: agent.Engine
+      impl: graph
+      deps:
+        inference: infer
+        workspace: ws
       settings:
         graph: {file: ./graphs/assistant.json}
-    deps:
-      inference: infer
-      workspace: ws/project
 
 runtime:
   event_bus: events

--- a/skills/flowcraft-config/assets/minimal-deploy/inference.yaml
+++ b/skills/flowcraft-config/assets/minimal-deploy/inference.yaml
@@ -1,22 +1,8 @@
-version: v1
-providers:
-  - id: deepseek
-    driver: deepseek
-    profiles:
-      - secrets:
-          api_key: {resolver: env, key: DEEPSEEK_API_KEY}
-  - id: openai
-    driver: openai
-    profiles:
-      - operations: [embed]
-        secrets:
-          api_key: {resolver: env, key: OPENAI_API_KEY}
-route:
-  generate:
-    - tier: primary
-      targets:
-        - model: {id: {provider: deepseek, name: deepseek-v4-flash}}
-  embed:
-    - tier: primary
-      targets:
-        - model: {id: {provider: openai, name: text-embedding-3-small}}
+# inference.Provider/deepseek settings (referenced via
+# resources.provider.settings.file in deploy.yaml).
+id: deepseek
+spec:
+  api: chat
+profiles:
+  - secrets:
+      api_key: ${env:DEEPSEEK_API_KEY}

--- a/skills/flowcraft-config/assets/minimal-deploy/workspace.yaml
+++ b/skills/flowcraft-config/assets/minimal-deploy/workspace.yaml
@@ -1,10 +1,8 @@
-version: v1
-workspaces:
-  project:
-    driver: local
-    settings:
-      root: workspace
-    scope:
-      deny_read: ["**/.env"]
-      allow_write: ["**"]
-      mandatory_deny: [".git/**"]
+# workspace.Workspace/local settings (referenced via
+# resources.ws.settings.file in deploy.yaml).
+root: ./workspace
+scoped:
+  enabled: true
+  deny_read: ["**/.env"]
+  allow_write: ["**"]
+  mandatory_deny: [".git/**"]

--- a/skills/flowcraft-config/references/graph.md
+++ b/skills/flowcraft-config/references/graph.md
@@ -42,7 +42,8 @@ File definitions are capped at 1 MiB.
 
 Common config fields: `model`, `messages_channel`, `system_prompt`,
 `output_key`, `usage_key`, `tool_pending_key`, `stream`, `tools`,
-`all_tools`, `temperature`, `max_output_tokens`, `extensions`.
+`all_tools`, `tool_choice`, `temperature`, `top_p`, `max_output_tokens`,
+`reasoning_enabled`, `reasoning_effort`, `response_format`, `extensions`.
 
 ### tool
 

--- a/skills/flowcraft-config/references/pitfalls.md
+++ b/skills/flowcraft-config/references/pitfalls.md
@@ -15,6 +15,15 @@
 9. `tool.Assembly` with dynamic injection requires at least one tool source.
 10. Local sandbox is a no-isolation backend and should not be used for
     untrusted production execution.
+11. Runtime registration cannot reuse a deployed agent name (`Conflict`);
+    deployed agents can only be removed by changing the deployment
+    document.
+12. With `dynamic_catalog` configured and no `default`, runtime
+    registration must pass `WithToolAssembly`; otherwise registration is
+    rejected up front.
+13. `UnregisterAgent` waits for active turns; a stuck engine times out
+    (`WithRemoveTimeout` / ctx deadline) and the agent is left registered
+    — retry, don't assume removal happened.
 
 ## Error map
 
@@ -29,6 +38,9 @@
 | graph `unknown field "provider"` | flattened model ref | use nested `id` |
 | script node missing `runtime`/`source` | incomplete script config | add both fields |
 | dynamic catalog uncovered agent | no per-agent or default mapping | add `default` or map every agent |
+| `runtime: agent "x" is a deployed agent` | register/remove collides with a document agent | register under a new name, or change the deployment |
+| `dynamic catalog has no default; agent "x" needs WithToolAssembly` | runtime registration without a tool mapping | add `WithToolAssembly` or configure `default` |
+| removal `DeadlineExceeded` | active turn did not finish in time | wait/retry; the agent is still registered |
 
 ## Debug order
 

--- a/skills/flowcraft-config/references/resources.md
+++ b/skills/flowcraft-config/references/resources.md
@@ -8,15 +8,19 @@ Each factory owns its settings schema.
 ```yaml
 id: deepseek
 spec:
-  api: chat
+  api: chat             # "chat" (default) or "responses"
+  base_url: https://api.deepseek.com   # optional override
+  models:               # optional: declare/override catalog models
+    - {name: deepseek-v4-flash, kind: generate, reasoning: true, responses: true}
 profiles:
   - secrets:
-      api_key: {resolver: env, key: DEEPSEEK_API_KEY}
+      api_key: ${env:DEEPSEEK_API_KEY}
 ```
 
-Provider IDs and profile IDs must be identifiers. Secret values are resolved
-through the host's resolver registry. Provider drivers are registered from
-`driver/<name>`.
+Provider IDs and profile IDs must be identifiers. Secret values use the
+settings expansion syntax (`${env:NAME}` for an environment variable,
+`${base:rel}` / `~` / `${home:rel}` for paths); a missing variable fails
+the build. Provider drivers are registered from `driver/<name>`.
 
 ## inference assembly
 

--- a/skills/flowcraft-config/references/runtime.md
+++ b/skills/flowcraft-config/references/runtime.md
@@ -33,9 +33,49 @@ runtime:
 - `sessions.max_sessions` limits distinct live session keys.
 - `dynamic_catalog.tools` maps agent IDs to `tool.Assembly` resources; the
   reserved `default` key is an optional fallback. Every deployed agent must
-  be mapped directly or covered by `default`.
+  be mapped directly or covered by `default`. The mapping is live: agents
+  registered at runtime attach a tool assembly via `WithToolAssembly`
+  (see below) or fall back to `default`.
 - Runtime references do not require an `export` flag in the core schema.
+
+## Dynamic agent registration (core/v0.1.11+)
+
+Agents can be registered and removed at runtime without rebuilding:
+
+```go
+instance, err := app.RegisterAgent(ctx, "qa", agent.Definition{
+    Card:   agent.AgentCard{Name: "Ticket QA"},
+    Engine: agent.EngineRef{Kind: "agent.Engine", Impl: "graph"},
+}, runtime.WithToolAssembly("shared_tools")) // optional; needs dynamic_catalog
+if err != nil { /* Validation / Conflict / NotFound */ }
+
+// Sessions work exactly like deployed agents:
+lease, err := app.Sessions().GetOrCreate(ctx, session.Key{
+    AgentID: "qa", ContextID: "user-7",
+})
+
+// Removal drains active turns (bounded) before closing engine/hooks:
+if err := app.UnregisterAgent(ctx, "qa",
+    runtime.WithRemoveTimeout(30*time.Second)); err != nil {
+    /* DeadlineExceeded: registration restored, retryable */
+}
+```
+
+Rules:
+
+- `RegisterAgent` uses the same assembly path as deployment
+  (`deploy.BindAgent`); a name colliding with a deployed or registered
+  agent is `Conflict`, assembly failures are `Validation`.
+- `UnregisterAgent` blocks new sessions, waits for active turns (bounded
+  by ctx or `WithRemoveTimeout`), then releases engine/hooks. Unknown
+  names are an idempotent no-op; deployed agents cannot be removed at
+  runtime (`Conflict`).
+- With `dynamic_catalog` configured and no `default`, registration must
+  carry `WithToolAssembly(<resource name>)`.
+- `runtime.agent.<id>.registered` / `.removed` lifecycle events are
+  published on success (subscribe with `PatternAgentLifecycle()`).
 
 ## Sources of truth
 
-`core/runtime/config.go`, `core/runtime/doc.go`, `docs/guides/runtime.md`.
+`core/runtime/config.go`, `core/runtime/doc.go`, `core/runtime/lifecycle.go`,
+`docs/guides/runtime.md`.

--- a/skills/flowcraft-config/scripts/validator/go.mod
+++ b/skills/flowcraft-config/scripts/validator/go.mod
@@ -2,7 +2,7 @@ module github.com/GizClaw/flowcraft/skills/flowcraft-config/scripts/validator
 
 go 1.26.0
 
-require github.com/GizClaw/flowcraft/core v0.1.0
+require github.com/GizClaw/flowcraft/core v0.1.11
 
 require (
 	github.com/cenkalti/backoff/v5 v5.0.3 // indirect

--- a/skills/flowcraft-config/scripts/validator/go.sum
+++ b/skills/flowcraft-config/scripts/validator/go.sum
@@ -1,3 +1,5 @@
+github.com/GizClaw/flowcraft/core v0.1.11 h1:C71H9TYpXszPl50Pq1+Pev4ITtjxC6OwsGy/v3s0Wns=
+github.com/GizClaw/flowcraft/core v0.1.11/go.mod h1:t4e1E55RSCsZTDGLCKLeg0Qags72Y2Yz2ZtL3EyGy1k=
 github.com/cenkalti/backoff/v5 v5.0.3 h1:ZN+IMa753KfX5hd8vVaMixjnqRZ3y8CuJKRKj1xcsSM=
 github.com/cenkalti/backoff/v5 v5.0.3/go.mod h1:rkhZdG3JZukswDf7f0cwqPNk4K0sa+F97BxZthm/crw=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=


### PR DESCRIPTION
## Summary

Post-release documentation sync for `core/v0.1.11` (dynamic agent registry):

- **docs/guides**: `runtime.md` gains a "Dynamic agent registry" section (RegisterAgent/UnregisterAgent/Agent/AgentNames, drain semantics, `runtime.agent.*` lifecycle events, live `dynamic_catalog`); `deploy.md`/`resource.md` note `Result.Close` agent cleanup and `BindAgent`; `event.md`/`prompt.md` reference the new lifecycle namespace; `tool.md` documents `Registry.Add/Remove`.
- **skills/flowcraft-config**: runtime card mirrors the dynamic agent API; resources card fixes the provider secret syntax to env expansion; pitfalls gains dynamic-agent cases; `minimal-deploy` template rewritten to the current schema (it previously failed validation with a top-level `deps` error).
- **validator pin bump**: `scripts/validator/go.mod` core `v0.1.0` → `v0.1.11`, `go.sum` reconciled.

## Verification

- `GOWORK=off go build ./...` + `go vet ./...` in the validator module pass.
- `validate-config.sh` passes on the template: deployment (4 resources, 1 agent), graph definition, inference and workspace sub-documents all OK.