### PR TITLE
fix(core): make sandbox watcher close race-safe

### DIFF
--- a/core/sandbox/session_unix.go
+++ b/core/sandbox/session_unix.go
@@ -631,11 +631,7 @@ func (l *outputLog) close() {
 	for _, w := range subs {
 		w.deliver(SessionEvent{Seq: l.nextSeq, Type: SessionEventClosed})
 		w.once.Do(func() { close(w.ch) })
-		select {
-		case <-w.stop:
-		default:
-			close(w.stop)
-		}
+		w.stopOnce.Do(func() { close(w.stop) })
 	}
 	l.wakeReadersLocked()
 	l.mu.Unlock()
@@ -684,20 +680,17 @@ func (l *outputLog) removeSubscriber(w *watcher) {
 // one SessionEventLag (Seq = first missed byte cursor) and the
 // channel closes — the consumer recovers with Read(afterSeq).
 type watcher struct {
-	ch   chan SessionEvent
-	stop chan struct{}
-	once sync.Once
-	log  *outputLog
+	ch       chan SessionEvent
+	stop     chan struct{}
+	once     sync.Once
+	stopOnce sync.Once
+	log      *outputLog
 }
 
 func (w *watcher) Events() <-chan SessionEvent { return w.ch }
 
 func (w *watcher) Close() error {
-	select {
-	case <-w.stop:
-	default:
-		close(w.stop)
-	}
+	w.stopOnce.Do(func() { close(w.stop) })
 	return nil
 }
 
@@ -728,11 +721,7 @@ func (w *watcher) deliver(ev SessionEvent) bool {
 	default:
 	}
 	w.once.Do(func() { close(w.ch) })
-	select {
-	case <-w.stop:
-	default:
-		close(w.stop)
-	}
+	w.stopOnce.Do(func() { close(w.stop) })
 	return false
 }
 

--- a/core/sandbox/session_unix_internal_test.go
+++ b/core/sandbox/session_unix_internal_test.go
@@ -3,8 +3,11 @@
 package sandbox
 
 import (
+	"context"
 	"os"
+	"sync"
 	"testing"
+	"time"
 )
 
 // TestLocalSessionCloseInputIgnoresAlreadyClosed covers the race where
@@ -26,5 +29,55 @@ func TestLocalSessionCloseInputIgnoresAlreadyClosed(t *testing.T) {
 	}
 	if s.stdin != nil {
 		t.Fatal("CloseInput should detach the closed stdin")
+	}
+}
+
+// TestWatcherCloseIsIdempotent verifies the SessionWatcher contract:
+// Close may be called more than once, and the events channel still
+// terminates (the subscription is over).
+func TestWatcherCloseIsIdempotent(t *testing.T) {
+	l := newOutputLog(1 << 20)
+	w := l.subscribe()
+	go w.run(context.Background())
+
+	if err := w.Close(); err != nil {
+		t.Fatalf("first Close: %v", err)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatalf("second Close: %v", err)
+	}
+
+	select {
+	case _, ok := <-w.ch:
+		if ok {
+			t.Fatal("events channel should be closed after Close")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("events channel did not close after Close")
+	}
+}
+
+// TestWatcherConcurrentClose covers the close-of-closed-channel race on
+// the watcher's internal stop channel: a consumer calling Close at the
+// same time the owning session tears down through outputLog.close must
+// not double-close. The race detector flags the old unsynchronized
+// check-then-close pattern even when the panic does not fire.
+func TestWatcherConcurrentClose(t *testing.T) {
+	for i := 0; i < 200; i++ {
+		l := newOutputLog(1 << 20)
+		w := l.subscribe()
+		go w.run(context.Background())
+
+		var wg sync.WaitGroup
+		wg.Add(3)
+		go func() { defer wg.Done(); _ = w.Close() }()
+		go func() { defer wg.Done(); _ = w.Close() }()
+		go func() { defer wg.Done(); l.close() }()
+		wg.Wait()
+
+		// outputLog.close delivered the Closed event and closed the
+		// channel, so draining must terminate promptly.
+		for range w.ch {
+		}
 	}
 }


### PR DESCRIPTION
## Summary

Fixes an intermittent `panic: close of closed channel` in the sandbox event watcher.

The watcher's internal `stop` channel was closed with an unsynchronized check-then-close at three sites:

- `watcher.Close()` (consumer goroutine, no lock)
- `outputLog.close()` (session teardown, under the log mutex)
- the `deliver` queue-overflow path (under the log mutex)

When a consumer calls `Close()` at the same moment the session is torn down (e.g. `sess.Close()`, registry drain, or overflow), two goroutines can both observe the channel as open and both close it — the second close panics. The events channel was already safe because every close site goes through `sync.Once`; `stop` had no equivalent guard.

## Fix

Give `watcher` its own `stopOnce sync.Once` and route all three close sites through it. Semantics are unchanged: `run` still wakes on `<-w.stop`, and `Close()` remains idempotent.

## Tests

- `TestWatcherCloseIsIdempotent`: repeated `Close()` calls terminate the subscription.
- `TestWatcherConcurrentClose`: concurrent `Close()` racing with `outputLog.close()` (200 iterations); reproduces the original panic on the old code and passes under `-race` with the fix.

## Validation

- `go vet` + `go test ./... -count=1` in `core`: pass
- `go test -race ./core/sandbox/...`: pass
- `golangci-lint run ./sandbox/...`: 0 issues
- `make release-check`: changesets valid, no pending releases