### PR TITLE
feat(core): declare model max input token limits

### DIFF
--- a/.release/core-v0.1.12.json
+++ b/.release/core-v0.1.12.json
@@ -1,0 +1,9 @@
+{
+  "summary": "feat(core): declare per-model max input token limits through ModelDescriptor.ModelLimits and fill driver catalogs from official documentation; fix(core): make sandbox watcher close race-safe",
+  "releases": [
+    {
+      "module": "core",
+      "bump": "patch"
+    }
+  ]
+}

--- a/core/inference/model.go
+++ b/core/inference/model.go
@@ -113,6 +113,29 @@ type ModelCapabilities struct {
 	HostedWebSearch bool `json:"hosted_web_search,omitempty"`
 }
 
+// ModelLimits declares numeric capacity limits of a model. A nil field
+// means the limit is undeclared rather than zero: the provider catalog did
+// not claim a value, so callers must not assume an upper bound.
+type ModelLimits struct {
+	// MaxInputTokens caps the tokens a request may feed to the model as
+	// input context (prompt plus any prior turns). Nil when the provider
+	// catalog does not declare a limit.
+	MaxInputTokens *int `json:"max_input_tokens,omitempty"`
+}
+
+func (l ModelLimits) Clone() ModelLimits {
+	return ModelLimits{
+		MaxInputTokens: clonePointer(l.MaxInputTokens),
+	}
+}
+
+func (l ModelLimits) Validate() error {
+	if l.MaxInputTokens != nil && *l.MaxInputTokens <= 0 {
+		return fmt.Errorf("max input tokens must be positive")
+	}
+	return nil
+}
+
 // ModelDescriptor is public discovery metadata. Operations must be derived
 // from the drivers registered for the model rather than maintained as a
 // separate capability declaration.
@@ -121,11 +144,13 @@ type ModelDescriptor struct {
 	Label        string            `json:"label,omitempty"`
 	Operations   []Operation       `json:"operations"`
 	Capabilities ModelCapabilities `json:"capabilities,omitzero"`
+	Limits       ModelLimits       `json:"limits,omitzero"`
 	Lifecycle    ModelLifecycle    `json:"lifecycle,omitzero"`
 }
 
 func (d ModelDescriptor) Clone() ModelDescriptor {
 	d.Operations = append([]Operation(nil), d.Operations...)
+	d.Limits = d.Limits.Clone()
 	d.Lifecycle = d.Lifecycle.Clone()
 	return d
 }
@@ -150,6 +175,9 @@ func (d ModelDescriptor) Validate() error {
 				"hosted web search requires the generate operation",
 			)
 		}
+	}
+	if err := d.Limits.Validate(); err != nil {
+		return err
 	}
 	return d.Lifecycle.ValidateFor(d.ID)
 }

--- a/core/inference/model_test.go
+++ b/core/inference/model_test.go
@@ -1,0 +1,91 @@
+package inference_test
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/GizClaw/flowcraft/core/inference"
+)
+
+func TestModelLimitsValidate(t *testing.T) {
+	if err := (inference.ModelLimits{}).Validate(); err != nil {
+		t.Fatalf("empty limits: %v", err)
+	}
+	positive := 128_000
+	if err := (inference.ModelLimits{
+		MaxInputTokens: &positive,
+	}).Validate(); err != nil {
+		t.Fatalf("positive limit: %v", err)
+	}
+	for _, value := range []int{0, -1} {
+		limit := value
+		if err := (inference.ModelLimits{
+			MaxInputTokens: &limit,
+		}).Validate(); err == nil {
+			t.Fatalf("limit %d unexpectedly accepted", value)
+		}
+	}
+}
+
+func TestModelDescriptorValidateRejectsNonPositiveInputLimit(t *testing.T) {
+	limit := 0
+	descriptor := inference.ModelDescriptor{
+		ID:         inference.ModelID{Provider: "openai", Name: "gpt-x"},
+		Operations: []inference.Operation{inference.OperationGenerate},
+		Limits:     inference.ModelLimits{MaxInputTokens: &limit},
+	}
+	if err := descriptor.Validate(); err == nil {
+		t.Fatal("non-positive max input tokens unexpectedly accepted")
+	}
+}
+
+func TestModelDescriptorClonePreservesLimits(t *testing.T) {
+	limit := 200_000
+	original := inference.ModelDescriptor{
+		ID:         inference.ModelID{Provider: "openai", Name: "gpt-x"},
+		Operations: []inference.Operation{inference.OperationGenerate},
+		Limits: inference.ModelLimits{
+			MaxInputTokens: &limit,
+		},
+	}
+	clone := original.Clone()
+	*clone.Limits.MaxInputTokens = 100
+	if *original.Limits.MaxInputTokens != 200_000 {
+		t.Fatalf(
+			"clone shares max input tokens pointer: original = %d",
+			*original.Limits.MaxInputTokens,
+		)
+	}
+}
+
+func TestModelDescriptorJSONLimits(t *testing.T) {
+	descriptor := inference.ModelDescriptor{
+		ID:         inference.ModelID{Provider: "openai", Name: "gpt-x"},
+		Operations: []inference.Operation{inference.OperationGenerate},
+	}
+	encoded, err := json.Marshal(descriptor)
+	if err != nil {
+		t.Fatalf("marshal empty limits: %v", err)
+	}
+	if got := string(encoded); strings.Contains(got, `"limits"`) {
+		t.Fatalf("empty limits should be omitted, got %s", got)
+	}
+
+	limit := 128_000
+	descriptor.Limits.MaxInputTokens = &limit
+	encoded, err = json.Marshal(descriptor)
+	if err != nil {
+		t.Fatalf("marshal limits: %v", err)
+	}
+	var decoded struct {
+		Limits inference.ModelLimits `json:"limits"`
+	}
+	if err := json.Unmarshal(encoded, &decoded); err != nil {
+		t.Fatalf("unmarshal limits: %v", err)
+	}
+	if decoded.Limits.MaxInputTokens == nil ||
+		*decoded.Limits.MaxInputTokens != 128_000 {
+		t.Fatalf("decoded limits = %+v, want max_input_tokens 128000", decoded.Limits)
+	}
+}

--- a/driver/anthropic/catalog.go
+++ b/driver/anthropic/catalog.go
@@ -10,47 +10,58 @@ type catalogEntry struct {
 	replacement      string
 	reasoningLevels  bool
 	reasoningDisable bool
+	// maxInputTokens caps the input context (system + messages + tools)
+	// in tokens; zero means undeclared. Values mirror the context window
+	// published on https://platform.claude.com/docs/en/about-claude/models.
+	maxInputTokens int
 }
 
 // catalog is the built-in model list, aligned with the Claude lineup of
 // July 2026.
 var catalog = map[string]catalogEntry{
-	"claude-fable-5":  {vision: true, reasoning: true, reasoningLevels: true, reasoningDisable: true},
-	"claude-opus-5":   {vision: true, reasoning: true, reasoningLevels: true, reasoningDisable: true},
-	"claude-sonnet-5": {vision: true, reasoning: true, reasoningLevels: true, reasoningDisable: true},
+	"claude-fable-5":  {vision: true, reasoning: true, reasoningLevels: true, reasoningDisable: true, maxInputTokens: 1_000_000},
+	"claude-opus-5":   {vision: true, reasoning: true, reasoningLevels: true, reasoningDisable: true, maxInputTokens: 1_000_000},
+	"claude-sonnet-5": {vision: true, reasoning: true, reasoningLevels: true, reasoningDisable: true, maxInputTokens: 1_000_000},
 	"claude-haiku-4-5": {
 		vision: true, reasoning: true,
 		reasoningLevels: true, reasoningDisable: true,
+		maxInputTokens: 200_000,
 	},
 	"claude-haiku-4-5-20251001": {
 		vision: true, reasoning: true,
 		reasoningLevels: true, reasoningDisable: true,
+		maxInputTokens: 200_000,
 	},
 
 	"claude-opus-4-8": {
 		vision: true, reasoning: true,
 		reasoningLevels: true, reasoningDisable: true,
 		deprecated: true, replacement: "claude-opus-5",
+		maxInputTokens: 1_000_000,
 	},
 	"claude-opus-4-7": {
 		vision: true, reasoning: true,
 		reasoningLevels: true, reasoningDisable: true,
 		deprecated: true, replacement: "claude-opus-5",
+		maxInputTokens: 1_000_000,
 	},
 	"claude-sonnet-4-6": {
 		vision: true, reasoning: true,
 		reasoningLevels: true, reasoningDisable: true,
 		deprecated: true, replacement: "claude-sonnet-5",
+		maxInputTokens: 1_000_000,
 	},
 	"claude-sonnet-4-5": {
 		vision: true, reasoning: true,
 		reasoningLevels: true, reasoningDisable: true,
 		deprecated: true, replacement: "claude-sonnet-5",
+		maxInputTokens: 200_000,
 	},
 	"claude-opus-4-1": {
 		vision: true, reasoning: true,
 		reasoningLevels: true, reasoningDisable: true,
 		deprecated: true, replacement: "claude-opus-5",
+		maxInputTokens: 200_000,
 	},
 }
 

--- a/driver/anthropic/catalog_test.go
+++ b/driver/anthropic/catalog_test.go
@@ -1,0 +1,44 @@
+package anthropic
+
+import (
+	"testing"
+
+	"github.com/GizClaw/flowcraft/core/inference"
+)
+
+func TestCatalogDeclaresMaxInputTokens(t *testing.T) {
+	provider, err := buildProvider(ResourceSettings{ID: "anthropic"})
+	if err != nil {
+		t.Fatalf("buildProvider: %v", err)
+	}
+	descriptors := make(map[string]inference.ModelDescriptor, len(provider.Models))
+	for _, model := range provider.Models {
+		descriptors[model.Descriptor.ID.Name] = model.Descriptor
+	}
+	for name, entry := range catalog {
+		descriptor, ok := descriptors[name]
+		if !ok {
+			t.Fatalf("catalog model %q missing from provider", name)
+		}
+		if entry.maxInputTokens <= 0 || descriptor.Limits.MaxInputTokens == nil {
+			t.Errorf("model %q: max input tokens not declared", name)
+		}
+	}
+	checks := map[string]int{
+		"claude-opus-5":     1_000_000,
+		"claude-haiku-4-5":  200_000,
+		"claude-sonnet-4-6": 1_000_000,
+		"claude-opus-4-1":   200_000,
+	}
+	for name, want := range checks {
+		descriptor, ok := descriptors[name]
+		if !ok {
+			t.Fatalf("model %q missing from provider", name)
+		}
+		if descriptor.Limits.MaxInputTokens == nil ||
+			*descriptor.Limits.MaxInputTokens != want {
+			t.Errorf("model %q: max input tokens = %v, want %d",
+				name, descriptor.Limits.MaxInputTokens, want)
+		}
+	}
+}

--- a/driver/anthropic/resource.go
+++ b/driver/anthropic/resource.go
@@ -105,6 +105,9 @@ func buildProvider(settings ResourceSettings) (inference.ProviderDefinition, err
 				descriptor.Lifecycle.Replacement = &replacement
 			}
 		}
+		if entry.maxInputTokens > 0 {
+			descriptor.Limits.MaxInputTokens = &entry.maxInputTokens
+		}
 		provider.Models = append(provider.Models, inference.ModelImplementation{
 			Descriptor: descriptor,
 			Openers:    openersFor(spec, entry, profiles, id),

--- a/driver/bytedance/catalog.go
+++ b/driver/bytedance/catalog.go
@@ -41,6 +41,14 @@ type catalogEntry struct {
 	// lifecycle: deprecated models stay routable but announce a replacement.
 	deprecated  bool
 	replacement string
+	// maxInputTokens caps the input context in tokens; zero means
+	// undeclared. Generate values mirror the family context window on
+	// the Volcengine Ark model detail pages; the official model list
+	// (https://www.volcengine.com/docs/82379/1330310) reports separate
+	// per-version max-input values (typically 224K or 256K, with 1M
+	// long-context tiers), so these entries are the family-level upper
+	// bound. Embedding values mirror the documented per-input limit.
+	maxInputTokens int
 }
 
 // catalog is the built-in model registry. Names are stable Volcengine model
@@ -52,36 +60,40 @@ type catalogEntry struct {
 var catalog = map[string]catalogEntry{
 	// Seed 2.1 (2026-06) — current flagship tier. The whole Seed 2.x line is
 	// natively multimodal (text/image/video in) with thinking support.
-	"doubao-seed-2-1-pro":   {kind: kindGenerate, vision: true, video: true, reasoning: true, webSearch: true},
-	"doubao-seed-2-1-turbo": {kind: kindGenerate, vision: true, video: true, reasoning: true, webSearch: true},
+	"doubao-seed-2-1-pro":   {kind: kindGenerate, vision: true, video: true, reasoning: true, webSearch: true, maxInputTokens: 256_000},
+	"doubao-seed-2-1-turbo": {kind: kindGenerate, vision: true, video: true, reasoning: true, webSearch: true, maxInputTokens: 256_000},
 
 	// Seed 2.0 (2026-02) — general agent line plus the code-tuned variant.
-	"doubao-seed-2-0-pro":  {kind: kindGenerate, vision: true, video: true, reasoning: true, webSearch: true},
-	"doubao-seed-2-0-lite": {kind: kindGenerate, vision: true, video: true, reasoning: true, webSearch: true},
-	"doubao-seed-2-0-mini": {kind: kindGenerate, vision: true, video: true, reasoning: true, webSearch: true},
-	"doubao-seed-2-0-code": {kind: kindGenerate, vision: true, reasoning: true, webSearch: true},
+	"doubao-seed-2-0-pro":  {kind: kindGenerate, vision: true, video: true, reasoning: true, webSearch: true, maxInputTokens: 256_000},
+	"doubao-seed-2-0-lite": {kind: kindGenerate, vision: true, video: true, reasoning: true, webSearch: true, maxInputTokens: 256_000},
+	"doubao-seed-2-0-mini": {kind: kindGenerate, vision: true, video: true, reasoning: true, webSearch: true, maxInputTokens: 256_000},
+	"doubao-seed-2-0-code": {kind: kindGenerate, vision: true, reasoning: true, webSearch: true, maxInputTokens: 256_000},
 
 	// Seed 1.x — superseded by the 2.x line; kept routable for existing
 	// deployments, announced as deprecated with a replacement.
 	"doubao-seed-1-8": {
 		kind: kindGenerate, vision: true, video: true, reasoning: true, webSearch: true,
 		deprecated: true, replacement: "doubao-seed-2-0-lite",
+		maxInputTokens: 256_000,
 	},
 	"doubao-seed-1-6": {
 		kind: kindGenerate, reasoning: true, webSearch: true,
 		deprecated: true, replacement: "doubao-seed-2-0-mini",
+		maxInputTokens: 256_000,
 	},
 	"doubao-seed-1-6-vision": {
 		kind: kindGenerate, vision: true, reasoning: true, webSearch: true,
 		deprecated: true, replacement: "doubao-seed-2-0-lite",
+		maxInputTokens: 256_000,
 	},
 	"doubao-seed-1-6-flash": {
 		kind: kindGenerate, reasoning: true, webSearch: true,
 		deprecated: true, replacement: "doubao-seed-2-0-mini",
+		maxInputTokens: 256_000,
 	},
 
-	"doubao-embedding-large":  {kind: kindEmbed, dimensions: true},
-	"doubao-embedding-vision": {kind: kindEmbed, imageInput: true, dimensions: true},
+	"doubao-embedding-large":  {kind: kindEmbed, dimensions: true, maxInputTokens: 4_095},
+	"doubao-embedding-vision": {kind: kindEmbed, imageInput: true, dimensions: true, maxInputTokens: 8_191},
 
 	// Seedream image generation; 5.0/4.5 current, 4.0 superseded.
 	"doubao-seedream-5-0": {kind: kindImage},

--- a/driver/bytedance/catalog_test.go
+++ b/driver/bytedance/catalog_test.go
@@ -1,0 +1,47 @@
+package bytedance
+
+import (
+	"testing"
+
+	"github.com/GizClaw/flowcraft/core/inference"
+)
+
+func TestCatalogDeclaresMaxInputTokens(t *testing.T) {
+	provider, err := buildProvider(ResourceSettings{ID: "bytedance"})
+	if err != nil {
+		t.Fatalf("buildProvider: %v", err)
+	}
+	descriptors := make(map[string]inference.ModelDescriptor, len(provider.Models))
+	for _, model := range provider.Models {
+		descriptors[model.Descriptor.ID.Name] = model.Descriptor
+	}
+	for name, entry := range catalog {
+		if entry.kind != kindGenerate && entry.kind != kindEmbed {
+			continue
+		}
+		descriptor, ok := descriptors[name]
+		if !ok {
+			t.Fatalf("catalog model %q missing from provider", name)
+		}
+		if entry.maxInputTokens <= 0 || descriptor.Limits.MaxInputTokens == nil {
+			t.Errorf("model %q: max input tokens not declared", name)
+		}
+	}
+	checks := map[string]int{
+		"doubao-seed-2-1-pro":     256_000,
+		"doubao-seed-1-6-vision":  256_000,
+		"doubao-embedding-large":  4_095,
+		"doubao-embedding-vision": 8_191,
+	}
+	for name, want := range checks {
+		descriptor, ok := descriptors[name]
+		if !ok {
+			t.Fatalf("model %q missing from provider", name)
+		}
+		if descriptor.Limits.MaxInputTokens == nil ||
+			*descriptor.Limits.MaxInputTokens != want {
+			t.Errorf("model %q: max input tokens = %v, want %d",
+				name, descriptor.Limits.MaxInputTokens, want)
+		}
+	}
+}

--- a/driver/bytedance/resource.go
+++ b/driver/bytedance/resource.go
@@ -131,6 +131,9 @@ func buildProvider(settings ResourceSettings) (inference.ProviderDefinition, err
 				descriptor.Lifecycle.Replacement = &replacement
 			}
 		}
+		if entry.maxInputTokens > 0 {
+			descriptor.Limits.MaxInputTokens = &entry.maxInputTokens
+		}
 		provider.Models = append(provider.Models, inference.ModelImplementation{
 			Descriptor: descriptor,
 			Openers:    openersFor(spec, entry, profiles, id),

--- a/driver/deepseek/catalog.go
+++ b/driver/deepseek/catalog.go
@@ -36,6 +36,10 @@ type catalogEntry struct {
 	responses bool
 	// webSearch accepts the hosted web_search tool on the Responses API.
 	webSearch bool
+	// maxInputTokens caps the input context in tokens; zero means
+	// undeclared. Both V4 models carry the 1M context published on
+	// https://api-docs.deepseek.com/quick_start/pricing.
+	maxInputTokens int
 }
 
 // catalog reflects DeepSeek's public API as of 2026-08.
@@ -51,16 +55,18 @@ type catalogEntry struct {
 // landed after the initial flash-only launch.
 var catalog = map[string]catalogEntry{
 	"deepseek-v4-flash": {
-		kind:      kindGenerate,
-		reasoning: true,
-		responses: true,
-		webSearch: true,
+		kind:           kindGenerate,
+		reasoning:      true,
+		responses:      true,
+		webSearch:      true,
+		maxInputTokens: 1_000_000,
 	},
 	"deepseek-v4-pro": {
-		kind:      kindGenerate,
-		reasoning: true,
-		responses: true,
-		webSearch: true,
+		kind:           kindGenerate,
+		reasoning:      true,
+		responses:      true,
+		webSearch:      true,
+		maxInputTokens: 1_000_000,
 	},
 }
 

--- a/driver/deepseek/catalog_test.go
+++ b/driver/deepseek/catalog_test.go
@@ -1,0 +1,23 @@
+package deepseek
+
+import (
+	"testing"
+)
+
+func TestCatalogDeclaresMaxInputTokens(t *testing.T) {
+	provider, err := buildProvider(ResourceSettings{ID: "deepseek"})
+	if err != nil {
+		t.Fatalf("buildProvider: %v", err)
+	}
+	for _, model := range provider.Models {
+		name := model.Descriptor.ID.Name
+		if catalog[name].maxInputTokens <= 0 {
+			t.Errorf("model %q: max input tokens not declared", name)
+		}
+		if model.Descriptor.Limits.MaxInputTokens == nil ||
+			*model.Descriptor.Limits.MaxInputTokens != 1_000_000 {
+			t.Errorf("model %q: max input tokens = %v, want 1000000",
+				name, model.Descriptor.Limits.MaxInputTokens)
+		}
+	}
+}

--- a/driver/deepseek/resource.go
+++ b/driver/deepseek/resource.go
@@ -142,14 +142,18 @@ func buildProvider(settings ResourceSettings) (inference.ProviderDefinition, err
 		entry := models[name]
 		entry.api = spec.apiMode()
 		id := inference.ModelID{Provider: settings.ID, Name: name}
-		provider.Models = append(provider.Models, inference.ModelImplementation{
-			Descriptor: inference.ModelDescriptor{
-				ID: id,
-				Capabilities: inference.ModelCapabilities{
-					HostedWebSearch: entry.api == apiResponses && entry.webSearch,
-				},
+		descriptor := inference.ModelDescriptor{
+			ID: id,
+			Capabilities: inference.ModelCapabilities{
+				HostedWebSearch: entry.api == apiResponses && entry.webSearch,
 			},
-			Openers: openersFor(spec, entry, profiles, id),
+		}
+		if entry.maxInputTokens > 0 {
+			descriptor.Limits.MaxInputTokens = &entry.maxInputTokens
+		}
+		provider.Models = append(provider.Models, inference.ModelImplementation{
+			Descriptor: descriptor,
+			Openers:    openersFor(spec, entry, profiles, id),
 		})
 	}
 	return provider, nil

--- a/driver/kimi/catalog.go
+++ b/driver/kimi/catalog.go
@@ -39,6 +39,11 @@ type catalogEntry struct {
 	// reasoning (kimi-k3, kimi-k2.7-code): traces round-trip natively and
 	// no knob exists to turn the behaviour off.
 	keepThinkingAlways bool
+	// maxInputTokens caps the input context in tokens; zero means
+	// undeclared. Values mirror the context windows published on
+	// https://platform.kimi.com/docs/models (moonshot-v1 variants state
+	// 8k/32k/128k).
+	maxInputTokens int
 }
 
 // catalog reflects Kimi's public API as of 2026-07.
@@ -59,6 +64,7 @@ var catalog = map[string]catalogEntry{
 		reasoningAlways:    true,
 		reasoningEffort:    true,
 		keepThinkingAlways: true,
+		maxInputTokens:     1_000_000,
 	},
 	"kimi-k2.7-code": {
 		kind:               kindGenerate,
@@ -66,6 +72,7 @@ var catalog = map[string]catalogEntry{
 		reasoning:          true,
 		reasoningAlways:    true,
 		keepThinkingAlways: true,
+		maxInputTokens:     256_000,
 	},
 	"kimi-k2.7-code-highspeed": {
 		kind:               kindGenerate,
@@ -73,28 +80,30 @@ var catalog = map[string]catalogEntry{
 		reasoning:          true,
 		reasoningAlways:    true,
 		keepThinkingAlways: true,
+		maxInputTokens:     256_000,
 	},
 	"kimi-k2.6": {
-		kind:         kindGenerate,
-		vision:       true,
-		reasoning:    true,
-		keepThinking: true,
+		kind:           kindGenerate,
+		vision:         true,
+		reasoning:      true,
+		keepThinking:   true,
+		maxInputTokens: 256_000,
 	},
 	"kimi-k2.5": {
-		kind:      kindGenerate,
-		vision:    true,
-		reasoning: true,
+		kind:           kindGenerate,
+		vision:         true,
+		reasoning:      true,
+		maxInputTokens: 256_000,
 	},
 
 	// moonshot-v1: text generation plus vision previews; the only family
 	// with sampling knobs and the only one without thinking.
-	"moonshot-v1-8k":                  {kind: kindGenerate, sampling: true},
-	"moonshot-v1-32k":                 {kind: kindGenerate, sampling: true},
-	"moonshot-v1-128k":                {kind: kindGenerate, sampling: true},
-	"moonshot-v1-auto":                {kind: kindGenerate, sampling: true},
-	"moonshot-v1-8k-vision-preview":   {kind: kindGenerate, sampling: true, vision: true},
-	"moonshot-v1-32k-vision-preview":  {kind: kindGenerate, sampling: true, vision: true},
-	"moonshot-v1-128k-vision-preview": {kind: kindGenerate, sampling: true, vision: true},
+	"moonshot-v1-8k":                  {kind: kindGenerate, sampling: true, maxInputTokens: 8_192},
+	"moonshot-v1-32k":                 {kind: kindGenerate, sampling: true, maxInputTokens: 32_768},
+	"moonshot-v1-128k":                {kind: kindGenerate, sampling: true, maxInputTokens: 131_072},
+	"moonshot-v1-8k-vision-preview":   {kind: kindGenerate, sampling: true, vision: true, maxInputTokens: 8_192},
+	"moonshot-v1-32k-vision-preview":  {kind: kindGenerate, sampling: true, vision: true, maxInputTokens: 32_768},
+	"moonshot-v1-128k-vision-preview": {kind: kindGenerate, sampling: true, vision: true, maxInputTokens: 131_072},
 }
 
 func (e catalogEntry) validate() error {

--- a/driver/kimi/catalog_test.go
+++ b/driver/kimi/catalog_test.go
@@ -1,0 +1,43 @@
+package kimi
+
+import (
+	"testing"
+
+	"github.com/GizClaw/flowcraft/core/inference"
+)
+
+func TestCatalogDeclaresMaxInputTokens(t *testing.T) {
+	provider, err := buildProvider(ResourceSettings{ID: "kimi"})
+	if err != nil {
+		t.Fatalf("buildProvider: %v", err)
+	}
+	descriptors := make(map[string]inference.ModelDescriptor, len(provider.Models))
+	for _, model := range provider.Models {
+		descriptors[model.Descriptor.ID.Name] = model.Descriptor
+	}
+	for name, entry := range catalog {
+		if entry.maxInputTokens <= 0 {
+			t.Errorf("model %q: max input tokens not declared", name)
+		}
+		descriptor := descriptors[name]
+		if descriptor.Limits.MaxInputTokens == nil ||
+			*descriptor.Limits.MaxInputTokens != entry.maxInputTokens {
+			t.Errorf("model %q: descriptor limit = %v, want %d",
+				name, descriptor.Limits.MaxInputTokens, entry.maxInputTokens)
+		}
+	}
+	checks := map[string]int{
+		"kimi-k3":          1_000_000,
+		"kimi-k2.7-code":   256_000,
+		"moonshot-v1-8k":   8_192,
+		"moonshot-v1-128k": 131_072,
+	}
+	for name, want := range checks {
+		descriptor := descriptors[name]
+		if descriptor.Limits.MaxInputTokens == nil ||
+			*descriptor.Limits.MaxInputTokens != want {
+			t.Errorf("model %q: max input tokens = %v, want %d",
+				name, descriptor.Limits.MaxInputTokens, want)
+		}
+	}
+}

--- a/driver/kimi/resource.go
+++ b/driver/kimi/resource.go
@@ -94,8 +94,12 @@ func buildProvider(settings ResourceSettings) (inference.ProviderDefinition, err
 	for _, name := range sortedNames(models) {
 		entry := models[name]
 		id := inference.ModelID{Provider: settings.ID, Name: name}
+		descriptor := inference.ModelDescriptor{ID: id}
+		if entry.maxInputTokens > 0 {
+			descriptor.Limits.MaxInputTokens = &entry.maxInputTokens
+		}
 		provider.Models = append(provider.Models, inference.ModelImplementation{
-			Descriptor: inference.ModelDescriptor{ID: id},
+			Descriptor: descriptor,
 			Openers:    openersFor(spec, entry, profiles, id),
 		})
 	}

--- a/driver/minimax/catalog.go
+++ b/driver/minimax/catalog.go
@@ -39,6 +39,10 @@ type catalogEntry struct {
 	// videoI2VOnly marks image-to-video models: the request must carry a
 	// first-frame image.
 	videoI2VOnly bool
+	// maxInputTokens caps the input context in tokens; zero means
+	// undeclared. M3 holds the 1M context and the M2.x series holds
+	// 204,800 per https://platform.minimaxi.com/docs/guides/text-generation.
+	maxInputTokens int
 }
 
 // catalog reflects MiniMax's lineup as of 2026-07. Sources:
@@ -54,14 +58,14 @@ type catalogEntry struct {
 // absent: the canonical audio intent is voice-shaped and has no honest
 // surface for lyrics/instrumental control.
 var catalog = map[string]catalogEntry{
-	"MiniMax-M3":             {kind: kindGenerate, vision: true, reasoning: true, reasoningDisable: true},
-	"MiniMax-M2.7":           {kind: kindGenerate, reasoning: true},
-	"MiniMax-M2.7-highspeed": {kind: kindGenerate, reasoning: true},
-	"MiniMax-M2.5":           {kind: kindGenerate, reasoning: true},
-	"MiniMax-M2.5-highspeed": {kind: kindGenerate, reasoning: true},
-	"MiniMax-M2.1":           {kind: kindGenerate, reasoning: true},
-	"MiniMax-M2.1-highspeed": {kind: kindGenerate, reasoning: true},
-	"MiniMax-M2":             {kind: kindGenerate, reasoning: true},
+	"MiniMax-M3":             {kind: kindGenerate, vision: true, reasoning: true, reasoningDisable: true, maxInputTokens: 1_000_000},
+	"MiniMax-M2.7":           {kind: kindGenerate, reasoning: true, maxInputTokens: 204_800},
+	"MiniMax-M2.7-highspeed": {kind: kindGenerate, reasoning: true, maxInputTokens: 204_800},
+	"MiniMax-M2.5":           {kind: kindGenerate, reasoning: true, maxInputTokens: 204_800},
+	"MiniMax-M2.5-highspeed": {kind: kindGenerate, reasoning: true, maxInputTokens: 204_800},
+	"MiniMax-M2.1":           {kind: kindGenerate, reasoning: true, maxInputTokens: 204_800},
+	"MiniMax-M2.1-highspeed": {kind: kindGenerate, reasoning: true, maxInputTokens: 204_800},
+	"MiniMax-M2":             {kind: kindGenerate, reasoning: true, maxInputTokens: 204_800},
 
 	// Speech synthesis (t2a_v2): HD and turbo tiers.
 	"speech-2.8-hd":    {kind: kindTTS},

--- a/driver/minimax/catalog_test.go
+++ b/driver/minimax/catalog_test.go
@@ -1,0 +1,40 @@
+package minimax
+
+import (
+	"testing"
+
+	"github.com/GizClaw/flowcraft/core/inference"
+)
+
+func TestCatalogDeclaresMaxInputTokens(t *testing.T) {
+	provider, err := buildProvider(ResourceSettings{ID: "minimax"})
+	if err != nil {
+		t.Fatalf("buildProvider: %v", err)
+	}
+	descriptors := make(map[string]inference.ModelDescriptor, len(provider.Models))
+	for _, model := range provider.Models {
+		descriptors[model.Descriptor.ID.Name] = model.Descriptor
+	}
+	for name, entry := range catalog {
+		if entry.kind != kindGenerate {
+			continue
+		}
+		descriptor := descriptors[name]
+		if entry.maxInputTokens <= 0 || descriptor.Limits.MaxInputTokens == nil {
+			t.Errorf("model %q: max input tokens not declared", name)
+		}
+	}
+	checks := map[string]int{
+		"MiniMax-M3":             1_000_000,
+		"MiniMax-M2.7":           204_800,
+		"MiniMax-M2.5-highspeed": 204_800,
+	}
+	for name, want := range checks {
+		descriptor := descriptors[name]
+		if descriptor.Limits.MaxInputTokens == nil ||
+			*descriptor.Limits.MaxInputTokens != want {
+			t.Errorf("model %q: max input tokens = %v, want %d",
+				name, descriptor.Limits.MaxInputTokens, want)
+		}
+	}
+}

--- a/driver/minimax/resource.go
+++ b/driver/minimax/resource.go
@@ -95,8 +95,12 @@ func buildProvider(settings ResourceSettings) (inference.ProviderDefinition, err
 	for _, name := range sortedNames(models) {
 		entry := models[name]
 		id := inference.ModelID{Provider: settings.ID, Name: name}
+		descriptor := inference.ModelDescriptor{ID: id}
+		if entry.maxInputTokens > 0 {
+			descriptor.Limits.MaxInputTokens = &entry.maxInputTokens
+		}
 		provider.Models = append(provider.Models, inference.ModelImplementation{
-			Descriptor: inference.ModelDescriptor{ID: id},
+			Descriptor: descriptor,
 			Openers:    openersFor(spec, entry, profiles, id),
 		})
 	}

--- a/driver/openai/catalog.go
+++ b/driver/openai/catalog.go
@@ -34,6 +34,11 @@ type catalogEntry struct {
 	dimensions  bool
 	deprecated  bool
 	replacement string
+	// maxInputTokens caps the input context (prompt plus prior turns) in
+	// tokens; zero means undeclared. Generate values mirror the context
+	// window on https://developers.openai.com/api/docs/models; embedding
+	// values mirror the per-request input limit.
+	maxInputTokens int
 }
 
 // catalog is the built-in model list, aligned with the OpenAI model lineup
@@ -41,38 +46,43 @@ type catalogEntry struct {
 // via Spec.Models.
 var catalog = map[string]catalogEntry{
 	// Generate — GPT-5.6 flagship family (reasoning + vision).
-	"gpt-5.6-sol":   {kind: kindGenerate, vision: true, reasoning: true, webSearch: true},
-	"gpt-5.6-terra": {kind: kindGenerate, vision: true, reasoning: true, webSearch: true},
-	"gpt-5.6-luna":  {kind: kindGenerate, vision: true, reasoning: true, webSearch: true},
+	"gpt-5.6-sol":   {kind: kindGenerate, vision: true, reasoning: true, webSearch: true, maxInputTokens: 1_050_000},
+	"gpt-5.6-terra": {kind: kindGenerate, vision: true, reasoning: true, webSearch: true, maxInputTokens: 1_050_000},
+	"gpt-5.6-luna":  {kind: kindGenerate, vision: true, reasoning: true, webSearch: true, maxInputTokens: 1_050_000},
 	// Generate — previous generations, superseded but available.
 	"gpt-5.5": {
 		kind: kindGenerate, vision: true, reasoning: true, webSearch: true,
 		deprecated: true, replacement: "gpt-5.6-sol",
+		maxInputTokens: 1_050_000,
 	},
 	"gpt-5.4": {
 		kind: kindGenerate, vision: true, reasoning: true, webSearch: true,
 		deprecated: true, replacement: "gpt-5.6-sol",
+		maxInputTokens: 1_050_000,
 	},
 	"gpt-5.4-mini": {
 		kind: kindGenerate, vision: true, reasoning: true, webSearch: true,
 		deprecated: true, replacement: "gpt-5.6-terra",
+		maxInputTokens: 400_000,
 	},
 	"gpt-5.4-nano": {
 		kind: kindGenerate, vision: true, reasoning: true, webSearch: true,
 		deprecated: true, replacement: "gpt-5.6-luna",
+		maxInputTokens: 400_000,
 	},
 	// Generate — GPT-4.1 line: vision without the reasoning control.
-	"gpt-4.1":      {kind: kindGenerate, vision: true, webSearch: true},
-	"gpt-4.1-mini": {kind: kindGenerate, vision: true, webSearch: true},
+	"gpt-4.1":      {kind: kindGenerate, vision: true, webSearch: true, maxInputTokens: 1_047_576},
+	"gpt-4.1-mini": {kind: kindGenerate, vision: true, webSearch: true, maxInputTokens: 1_047_576},
 	// gpt-4.1-nano has no hosted web_search tool.
-	"gpt-4.1-nano": {kind: kindGenerate, vision: true},
+	"gpt-4.1-nano": {kind: kindGenerate, vision: true, maxInputTokens: 1_047_576},
 
 	// Embed.
-	"text-embedding-3-small": {kind: kindEmbed, dimensions: true},
-	"text-embedding-3-large": {kind: kindEmbed, dimensions: true},
+	"text-embedding-3-small": {kind: kindEmbed, dimensions: true, maxInputTokens: 8_192},
+	"text-embedding-3-large": {kind: kindEmbed, dimensions: true, maxInputTokens: 8_192},
 	"text-embedding-ada-002": {
 		kind:       kindEmbed,
 		deprecated: true, replacement: "text-embedding-3-small",
+		maxInputTokens: 8_192,
 	},
 
 	// Image.

--- a/driver/openai/catalog_test.go
+++ b/driver/openai/catalog_test.go
@@ -1,0 +1,47 @@
+package openai
+
+import (
+	"testing"
+
+	"github.com/GizClaw/flowcraft/core/inference"
+)
+
+func TestCatalogDeclaresMaxInputTokens(t *testing.T) {
+	provider, err := buildProvider(ResourceSettings{ID: "openai"})
+	if err != nil {
+		t.Fatalf("buildProvider: %v", err)
+	}
+	descriptors := make(map[string]inference.ModelDescriptor, len(provider.Models))
+	for _, model := range provider.Models {
+		descriptors[model.Descriptor.ID.Name] = model.Descriptor
+	}
+	for name, entry := range catalog {
+		if entry.kind != kindGenerate && entry.kind != kindEmbed {
+			continue
+		}
+		descriptor, ok := descriptors[name]
+		if !ok {
+			t.Fatalf("catalog model %q missing from provider", name)
+		}
+		if descriptor.Limits.MaxInputTokens == nil {
+			t.Errorf("model %q: max input tokens not declared", name)
+		}
+	}
+	checks := map[string]int{
+		"gpt-5.6-sol":            1_050_000,
+		"gpt-5.4-mini":           400_000,
+		"gpt-4.1":                1_047_576,
+		"text-embedding-3-small": 8_192,
+	}
+	for name, want := range checks {
+		descriptor, ok := descriptors[name]
+		if !ok {
+			t.Fatalf("model %q missing from provider", name)
+		}
+		if descriptor.Limits.MaxInputTokens == nil ||
+			*descriptor.Limits.MaxInputTokens != want {
+			t.Errorf("model %q: max input tokens = %v, want %d",
+				name, descriptor.Limits.MaxInputTokens, want)
+		}
+	}
+}

--- a/driver/openai/resource.go
+++ b/driver/openai/resource.go
@@ -136,6 +136,9 @@ func buildProvider(settings ResourceSettings) (inference.ProviderDefinition, err
 				descriptor.Lifecycle.Replacement = &replacement
 			}
 		}
+		if entry.maxInputTokens > 0 {
+			descriptor.Limits.MaxInputTokens = &entry.maxInputTokens
+		}
 		provider.Models = append(provider.Models, inference.ModelImplementation{
 			Descriptor: descriptor,
 			Openers:    openersFor(spec, entry, profiles, id),

--- a/driver/qwen/catalog.go
+++ b/driver/qwen/catalog.go
@@ -39,6 +39,11 @@ type catalogEntry struct {
 	// embedDimensions lists the vector sizes an embed model accepts; nil
 	// means the model takes no dimension parameter.
 	embedDimensions []int
+	// maxInputTokens caps the input context in tokens; zero means
+	// undeclared. Values mirror the published maximum input length
+	// (最大输入长度) on the per-model pages at
+	// https://www.alibabacloud.com/help/zh/model-studio/models.
+	maxInputTokens int
 }
 
 // catalog reflects the DashScope commercial lineup as of 2026-07.
@@ -51,29 +56,31 @@ type catalogEntry struct {
 // thinking on reject the shape. The legacy qwen-plus/turbo/flash/max
 // names stay text-only here — custom models declare through the spec.
 var catalog = map[string]catalogEntry{
-	"qwen3.8-max-preview": {kind: kindGenerate, vision: true, video: true, reasoning: true, reasoningEffort: true, preserveThinking: true, thinkingStreamOnly: true},
-	"qwen3.7-max":         {kind: kindGenerate, vision: true, video: true, reasoning: true, preserveThinking: true, thinkingStreamOnly: true},
-	"qwen3.7-plus":        {kind: kindGenerate, vision: true, video: true, reasoning: true, preserveThinking: true, thinkingStreamOnly: true},
-	"qwen3.7-flash":       {kind: kindGenerate, vision: true, video: true, reasoning: true, preserveThinking: true, thinkingStreamOnly: true},
-	"qwen3-vl-plus":       {kind: kindGenerate, vision: true, video: true, reasoning: true, thinkingStreamOnly: true},
-	"qwen3-vl-flash":      {kind: kindGenerate, vision: true, video: true, reasoning: true, thinkingStreamOnly: true},
+	"qwen3.8-max-preview": {kind: kindGenerate, vision: true, video: true, reasoning: true, reasoningEffort: true, preserveThinking: true, thinkingStreamOnly: true, maxInputTokens: 983_616},
+	"qwen3.7-max":         {kind: kindGenerate, vision: true, video: true, reasoning: true, preserveThinking: true, thinkingStreamOnly: true, maxInputTokens: 991_808},
+	"qwen3.7-plus":        {kind: kindGenerate, vision: true, video: true, reasoning: true, preserveThinking: true, thinkingStreamOnly: true, maxInputTokens: 991_808},
+	"qwen3.7-flash":       {kind: kindGenerate, vision: true, video: true, reasoning: true, preserveThinking: true, thinkingStreamOnly: true, maxInputTokens: 991_808},
+	"qwen3-vl-plus":       {kind: kindGenerate, vision: true, video: true, reasoning: true, thinkingStreamOnly: true, maxInputTokens: 260_096},
+	"qwen3-vl-flash":      {kind: kindGenerate, vision: true, video: true, reasoning: true, thinkingStreamOnly: true, maxInputTokens: 260_096},
 
-	"qwen-plus":  {kind: kindGenerate},
-	"qwen-turbo": {kind: kindGenerate},
-	"qwen-flash": {kind: kindGenerate},
-	"qwen-max":   {kind: kindGenerate},
+	"qwen-plus":  {kind: kindGenerate, maxInputTokens: 997_952},
+	"qwen-turbo": {kind: kindGenerate, maxInputTokens: 98_304},
+	"qwen-flash": {kind: kindGenerate, maxInputTokens: 997_952},
+	"qwen-max":   {kind: kindGenerate, maxInputTokens: 30_720},
 
 	// Embeddings. The multimodal model is served in the Beijing region
 	// only; text-embedding-v4 batches at most 10 rows per request.
 	"text-embedding-v4": {
 		kind:            kindEmbed,
 		embedDimensions: []int{2048, 1536, 1024, 768, 512, 256, 128, 64},
+		maxInputTokens:  8_192,
 	},
 	"qwen3-vl-embedding": {
 		kind:            kindEmbed,
 		vision:          true,
 		video:           true,
 		embedDimensions: []int{2560, 2048, 1536, 1024, 768, 512, 256},
+		maxInputTokens:  32_000,
 	},
 }
 

--- a/driver/qwen/catalog_test.go
+++ b/driver/qwen/catalog_test.go
@@ -1,0 +1,43 @@
+package qwen
+
+import (
+	"testing"
+
+	"github.com/GizClaw/flowcraft/core/inference"
+)
+
+func TestCatalogDeclaresMaxInputTokens(t *testing.T) {
+	provider, err := buildProvider(ResourceSettings{ID: "qwen"})
+	if err != nil {
+		t.Fatalf("buildProvider: %v", err)
+	}
+	descriptors := make(map[string]inference.ModelDescriptor, len(provider.Models))
+	for _, model := range provider.Models {
+		descriptors[model.Descriptor.ID.Name] = model.Descriptor
+	}
+	for name, entry := range catalog {
+		if entry.maxInputTokens <= 0 {
+			t.Errorf("model %q: max input tokens not declared", name)
+		}
+		descriptor := descriptors[name]
+		if descriptor.Limits.MaxInputTokens == nil ||
+			*descriptor.Limits.MaxInputTokens != entry.maxInputTokens {
+			t.Errorf("model %q: descriptor limit = %v, want %d",
+				name, descriptor.Limits.MaxInputTokens, entry.maxInputTokens)
+		}
+	}
+	checks := map[string]int{
+		"qwen3.7-max":       991_808,
+		"qwen3-vl-plus":     260_096,
+		"qwen-max":          30_720,
+		"text-embedding-v4": 8_192,
+	}
+	for name, want := range checks {
+		descriptor := descriptors[name]
+		if descriptor.Limits.MaxInputTokens == nil ||
+			*descriptor.Limits.MaxInputTokens != want {
+			t.Errorf("model %q: max input tokens = %v, want %d",
+				name, descriptor.Limits.MaxInputTokens, want)
+		}
+	}
+}

--- a/driver/qwen/resource.go
+++ b/driver/qwen/resource.go
@@ -98,8 +98,12 @@ func buildProvider(settings ResourceSettings) (inference.ProviderDefinition, err
 	for _, name := range sortedNames(models) {
 		entry := models[name]
 		id := inference.ModelID{Provider: settings.ID, Name: name}
+		descriptor := inference.ModelDescriptor{ID: id}
+		if entry.maxInputTokens > 0 {
+			descriptor.Limits.MaxInputTokens = &entry.maxInputTokens
+		}
 		provider.Models = append(provider.Models, inference.ModelImplementation{
-			Descriptor: inference.ModelDescriptor{ID: id},
+			Descriptor: descriptor,
 			Openers:    openersFor(spec, entry, profiles, id),
 		})
 	}


### PR DESCRIPTION
## Summary

Expose each model's maximum input token capacity through inference discovery metadata and fill the built-in driver catalogs with values from the providers' official documentation.

### Core

- Add `ModelLimits.MaxInputTokens` (`*int`, nil = undeclared) to `core/inference` `ModelDescriptor`, wired into `Clone`/`Validate`, with JSON `limits` (omitzero) serialization and unit tests.

### Driver catalogs

Each driver's `catalogEntry` gains `maxInputTokens` and maps it to `descriptor.Limits.MaxInputTokens` in `buildProvider`:

- **openai** – GPT-5.6 family / GPT-5.5 / GPT-5.4 (1,050,000), GPT-5.4 mini/nano (400,000), GPT-4.1 family (1,047,576), embeddings (8,192) per developers.openai.com
- **anthropic** – Fable/Opus/Sonnet 5, Opus 4.8/4.7, Sonnet 4.6 (1M); Haiku 4.5, Sonnet 4.5, Opus 4.1 (200K) per platform.claude.com + AWS model cards
- **deepseek** – v4-flash/v4-pro (1M) per api-docs.deepseek.com
- **kimi** – k3 (1M), K2.7 Code/K2.6/K2.5 (256K), moonshot-v1 8k/32k/128k per platform.kimi.com
- **minimax** – M3 (1M), M2.x series (204,800) per platform.minimaxi.com
- **qwen** – qwen3.8/3.7/3-vl/plus/turbo/flash/max per Alibaba Cloud Model Studio pages (最大输入长度)
- **bytedance** – Doubao Seed 2.x/1.x (256K family context window), embeddings per Volcengine Ark docs

Each driver adds a `catalog_test.go` asserting every generate/embed model declares a limit and that it maps through to the descriptor.

## Notes

- `Spec.Models`-declared custom models keep limits undeclared unless filled later; azure has no built-in catalog.
- Qwen values use the published max input length (thinking-mode value where thinking is always on); bytedance uses the family-level context window since the official list reports per-version max input (224K/256K, plus 1M long-context tiers).

## Validation

- `make ci` ✅
- `make lint` ✅ (0 issues)
- `make release-check` ✅ (no pending releases)
- `git diff --check` ✅