### PR TITLE
chore(driver): require core v0.1.12 across all driver modules

### DIFF
--- a/driver/anthropic/go.mod
+++ b/driver/anthropic/go.mod
@@ -3,7 +3,7 @@ module github.com/GizClaw/flowcraft/driver/anthropic
 go 1.26.0
 
 require (
-	github.com/GizClaw/flowcraft/core v0.1.10
+	github.com/GizClaw/flowcraft/core v0.1.12
 	github.com/anthropics/anthropic-sdk-go v1.61.0
 )
 

--- a/driver/anthropic/go.sum
+++ b/driver/anthropic/go.sum
@@ -1,5 +1,5 @@
-github.com/GizClaw/flowcraft/core v0.1.10 h1:Z0NAbJfNRPME/9hR6zqHxOEx5h4ktCJtVxVBjm+bgFY=
-github.com/GizClaw/flowcraft/core v0.1.10/go.mod h1:t4e1E55RSCsZTDGLCKLeg0Qags72Y2Yz2ZtL3EyGy1k=
+github.com/GizClaw/flowcraft/core v0.1.12 h1:Dvxn/4rvcnVFUMlbco3KndbzT6UXY6ZXlCFkGEEFxy4=
+github.com/GizClaw/flowcraft/core v0.1.12/go.mod h1:t4e1E55RSCsZTDGLCKLeg0Qags72Y2Yz2ZtL3EyGy1k=
 github.com/anthropics/anthropic-sdk-go v1.61.0 h1:JRTnm1tPqn5xo1xd1zfrcFDlcoWXVMvV1K68YmhpZKw=
 github.com/anthropics/anthropic-sdk-go v1.61.0/go.mod h1:3EfIfmFqxH6rbiLcIP4tPFyXL/IHakx2wDG4OU+TIEI=
 github.com/bahlo/generic-list-go v0.2.0 h1:5sz/EEAK+ls5wF+NeqDpk5+iNdMDXrh3z3nPnH1Wvgk=

--- a/driver/azure/go.mod
+++ b/driver/azure/go.mod
@@ -3,7 +3,7 @@ module github.com/GizClaw/flowcraft/driver/azure
 go 1.26.0
 
 require (
-	github.com/GizClaw/flowcraft/core v0.1.10
+	github.com/GizClaw/flowcraft/core v0.1.12
 	github.com/openai/openai-go/v3 v3.50.0
 )
 

--- a/driver/azure/go.sum
+++ b/driver/azure/go.sum
@@ -6,8 +6,8 @@ github.com/Azure/azure-sdk-for-go/sdk/internal v1.12.0 h1:fhqpLE3UEXi9lPaBRpQ6Xu
 github.com/Azure/azure-sdk-for-go/sdk/internal v1.12.0/go.mod h1:7dCRMLwisfRH3dBupKeNCioWYUZ4SS09Z14H+7i8ZoY=
 github.com/AzureAD/microsoft-authentication-library-for-go v1.7.2 h1:RHK7bS+HQMslb1sZpAokUt+zTVmue0hKSs2C791hhzU=
 github.com/AzureAD/microsoft-authentication-library-for-go v1.7.2/go.mod h1:HKpQxkWaGLJ+D/5H8QRpyQXA1eKjxkFlOMwck5+33Jk=
-github.com/GizClaw/flowcraft/core v0.1.10 h1:Z0NAbJfNRPME/9hR6zqHxOEx5h4ktCJtVxVBjm+bgFY=
-github.com/GizClaw/flowcraft/core v0.1.10/go.mod h1:t4e1E55RSCsZTDGLCKLeg0Qags72Y2Yz2ZtL3EyGy1k=
+github.com/GizClaw/flowcraft/core v0.1.12 h1:Dvxn/4rvcnVFUMlbco3KndbzT6UXY6ZXlCFkGEEFxy4=
+github.com/GizClaw/flowcraft/core v0.1.12/go.mod h1:t4e1E55RSCsZTDGLCKLeg0Qags72Y2Yz2ZtL3EyGy1k=
 github.com/cenkalti/backoff/v5 v5.0.3 h1:ZN+IMa753KfX5hd8vVaMixjnqRZ3y8CuJKRKj1xcsSM=
 github.com/cenkalti/backoff/v5 v5.0.3/go.mod h1:rkhZdG3JZukswDf7f0cwqPNk4K0sa+F97BxZthm/crw=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=

--- a/driver/bytedance/go.mod
+++ b/driver/bytedance/go.mod
@@ -4,7 +4,7 @@ go 1.26.0
 
 require (
 	github.com/GizClaw/doubao-speech-go v0.0.0-20260723152315-fe8153366feb
-	github.com/GizClaw/flowcraft/core v0.1.10
+	github.com/GizClaw/flowcraft/core v0.1.12
 	github.com/volcengine/volcengine-go-sdk v1.2.14
 )
 

--- a/driver/bytedance/go.sum
+++ b/driver/bytedance/go.sum
@@ -2,8 +2,8 @@ cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMT
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/GizClaw/doubao-speech-go v0.0.0-20260723152315-fe8153366feb h1:iS4tRKtteioA1ZDrUqn2tGkBjM4fiQeRoqJx6E3dD34=
 github.com/GizClaw/doubao-speech-go v0.0.0-20260723152315-fe8153366feb/go.mod h1:4R3wUAZkYk1BSgzv+QVF+2SZPu3VDy8NvaQdNRYGgBs=
-github.com/GizClaw/flowcraft/core v0.1.10 h1:Z0NAbJfNRPME/9hR6zqHxOEx5h4ktCJtVxVBjm+bgFY=
-github.com/GizClaw/flowcraft/core v0.1.10/go.mod h1:t4e1E55RSCsZTDGLCKLeg0Qags72Y2Yz2ZtL3EyGy1k=
+github.com/GizClaw/flowcraft/core v0.1.12 h1:Dvxn/4rvcnVFUMlbco3KndbzT6UXY6ZXlCFkGEEFxy4=
+github.com/GizClaw/flowcraft/core v0.1.12/go.mod h1:t4e1E55RSCsZTDGLCKLeg0Qags72Y2Yz2ZtL3EyGy1k=
 github.com/avast/retry-go v3.0.0+incompatible/go.mod h1:XtSnn+n/sHqQIpZ10K1qAevBhOOCWBLXXy3hyiqqBrY=
 github.com/cenkalti/backoff/v5 v5.0.3 h1:ZN+IMa753KfX5hd8vVaMixjnqRZ3y8CuJKRKj1xcsSM=
 github.com/cenkalti/backoff/v5 v5.0.3/go.mod h1:rkhZdG3JZukswDf7f0cwqPNk4K0sa+F97BxZthm/crw=

--- a/driver/deepseek/go.mod
+++ b/driver/deepseek/go.mod
@@ -3,7 +3,7 @@ module github.com/GizClaw/flowcraft/driver/deepseek
 go 1.26.0
 
 require (
-	github.com/GizClaw/flowcraft/core v0.1.10
+	github.com/GizClaw/flowcraft/core v0.1.12
 	github.com/openai/openai-go/v3 v3.50.0
 )
 

--- a/driver/deepseek/go.sum
+++ b/driver/deepseek/go.sum
@@ -1,5 +1,5 @@
-github.com/GizClaw/flowcraft/core v0.1.10 h1:Z0NAbJfNRPME/9hR6zqHxOEx5h4ktCJtVxVBjm+bgFY=
-github.com/GizClaw/flowcraft/core v0.1.10/go.mod h1:t4e1E55RSCsZTDGLCKLeg0Qags72Y2Yz2ZtL3EyGy1k=
+github.com/GizClaw/flowcraft/core v0.1.12 h1:Dvxn/4rvcnVFUMlbco3KndbzT6UXY6ZXlCFkGEEFxy4=
+github.com/GizClaw/flowcraft/core v0.1.12/go.mod h1:t4e1E55RSCsZTDGLCKLeg0Qags72Y2Yz2ZtL3EyGy1k=
 github.com/cenkalti/backoff/v5 v5.0.3 h1:ZN+IMa753KfX5hd8vVaMixjnqRZ3y8CuJKRKj1xcsSM=
 github.com/cenkalti/backoff/v5 v5.0.3/go.mod h1:rkhZdG3JZukswDf7f0cwqPNk4K0sa+F97BxZthm/crw=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=

--- a/driver/kimi/go.mod
+++ b/driver/kimi/go.mod
@@ -3,7 +3,7 @@ module github.com/GizClaw/flowcraft/driver/kimi
 go 1.26.0
 
 require (
-	github.com/GizClaw/flowcraft/core v0.1.10
+	github.com/GizClaw/flowcraft/core v0.1.12
 	go.opentelemetry.io/otel/log v0.16.0
 )
 

--- a/driver/kimi/go.sum
+++ b/driver/kimi/go.sum
@@ -1,5 +1,5 @@
-github.com/GizClaw/flowcraft/core v0.1.10 h1:Z0NAbJfNRPME/9hR6zqHxOEx5h4ktCJtVxVBjm+bgFY=
-github.com/GizClaw/flowcraft/core v0.1.10/go.mod h1:t4e1E55RSCsZTDGLCKLeg0Qags72Y2Yz2ZtL3EyGy1k=
+github.com/GizClaw/flowcraft/core v0.1.12 h1:Dvxn/4rvcnVFUMlbco3KndbzT6UXY6ZXlCFkGEEFxy4=
+github.com/GizClaw/flowcraft/core v0.1.12/go.mod h1:t4e1E55RSCsZTDGLCKLeg0Qags72Y2Yz2ZtL3EyGy1k=
 github.com/cenkalti/backoff/v5 v5.0.3 h1:ZN+IMa753KfX5hd8vVaMixjnqRZ3y8CuJKRKj1xcsSM=
 github.com/cenkalti/backoff/v5 v5.0.3/go.mod h1:rkhZdG3JZukswDf7f0cwqPNk4K0sa+F97BxZthm/crw=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=

--- a/driver/minimax/go.mod
+++ b/driver/minimax/go.mod
@@ -3,7 +3,7 @@ module github.com/GizClaw/flowcraft/driver/minimax
 go 1.26.0
 
 require (
-	github.com/GizClaw/flowcraft/core v0.1.10
+	github.com/GizClaw/flowcraft/core v0.1.12
 	github.com/anthropics/anthropic-sdk-go v1.61.0
 )
 

--- a/driver/minimax/go.sum
+++ b/driver/minimax/go.sum
@@ -1,5 +1,5 @@
-github.com/GizClaw/flowcraft/core v0.1.10 h1:Z0NAbJfNRPME/9hR6zqHxOEx5h4ktCJtVxVBjm+bgFY=
-github.com/GizClaw/flowcraft/core v0.1.10/go.mod h1:t4e1E55RSCsZTDGLCKLeg0Qags72Y2Yz2ZtL3EyGy1k=
+github.com/GizClaw/flowcraft/core v0.1.12 h1:Dvxn/4rvcnVFUMlbco3KndbzT6UXY6ZXlCFkGEEFxy4=
+github.com/GizClaw/flowcraft/core v0.1.12/go.mod h1:t4e1E55RSCsZTDGLCKLeg0Qags72Y2Yz2ZtL3EyGy1k=
 github.com/anthropics/anthropic-sdk-go v1.61.0 h1:JRTnm1tPqn5xo1xd1zfrcFDlcoWXVMvV1K68YmhpZKw=
 github.com/anthropics/anthropic-sdk-go v1.61.0/go.mod h1:3EfIfmFqxH6rbiLcIP4tPFyXL/IHakx2wDG4OU+TIEI=
 github.com/bahlo/generic-list-go v0.2.0 h1:5sz/EEAK+ls5wF+NeqDpk5+iNdMDXrh3z3nPnH1Wvgk=

--- a/driver/openai/go.mod
+++ b/driver/openai/go.mod
@@ -3,7 +3,7 @@ module github.com/GizClaw/flowcraft/driver/openai
 go 1.26.0
 
 require (
-	github.com/GizClaw/flowcraft/core v0.1.10
+	github.com/GizClaw/flowcraft/core v0.1.12
 	github.com/openai/openai-go/v3 v3.50.0
 )
 

--- a/driver/openai/go.sum
+++ b/driver/openai/go.sum
@@ -1,5 +1,5 @@
-github.com/GizClaw/flowcraft/core v0.1.10 h1:Z0NAbJfNRPME/9hR6zqHxOEx5h4ktCJtVxVBjm+bgFY=
-github.com/GizClaw/flowcraft/core v0.1.10/go.mod h1:t4e1E55RSCsZTDGLCKLeg0Qags72Y2Yz2ZtL3EyGy1k=
+github.com/GizClaw/flowcraft/core v0.1.12 h1:Dvxn/4rvcnVFUMlbco3KndbzT6UXY6ZXlCFkGEEFxy4=
+github.com/GizClaw/flowcraft/core v0.1.12/go.mod h1:t4e1E55RSCsZTDGLCKLeg0Qags72Y2Yz2ZtL3EyGy1k=
 github.com/cenkalti/backoff/v5 v5.0.3 h1:ZN+IMa753KfX5hd8vVaMixjnqRZ3y8CuJKRKj1xcsSM=
 github.com/cenkalti/backoff/v5 v5.0.3/go.mod h1:rkhZdG3JZukswDf7f0cwqPNk4K0sa+F97BxZthm/crw=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=

--- a/driver/qwen/go.mod
+++ b/driver/qwen/go.mod
@@ -3,7 +3,7 @@ module github.com/GizClaw/flowcraft/driver/qwen
 go 1.26.0
 
 require (
-	github.com/GizClaw/flowcraft/core v0.1.10
+	github.com/GizClaw/flowcraft/core v0.1.12
 	go.opentelemetry.io/otel/log v0.16.0
 )
 

--- a/driver/qwen/go.sum
+++ b/driver/qwen/go.sum
@@ -1,5 +1,5 @@
-github.com/GizClaw/flowcraft/core v0.1.10 h1:Z0NAbJfNRPME/9hR6zqHxOEx5h4ktCJtVxVBjm+bgFY=
-github.com/GizClaw/flowcraft/core v0.1.10/go.mod h1:t4e1E55RSCsZTDGLCKLeg0Qags72Y2Yz2ZtL3EyGy1k=
+github.com/GizClaw/flowcraft/core v0.1.12 h1:Dvxn/4rvcnVFUMlbco3KndbzT6UXY6ZXlCFkGEEFxy4=
+github.com/GizClaw/flowcraft/core v0.1.12/go.mod h1:t4e1E55RSCsZTDGLCKLeg0Qags72Y2Yz2ZtL3EyGy1k=
 github.com/cenkalti/backoff/v5 v5.0.3 h1:ZN+IMa753KfX5hd8vVaMixjnqRZ3y8CuJKRKj1xcsSM=
 github.com/cenkalti/backoff/v5 v5.0.3/go.mod h1:rkhZdG3JZukswDf7f0cwqPNk4K0sa+F97BxZthm/crw=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=


### PR DESCRIPTION
## Summary

`core/v0.1.12` is published and adds `ModelDescriptor.ModelLimits` (per-model max input token limits), which every driver catalog now consumes. Bump the eight driver modules' `go.mod` requirement from `core v0.1.10` to `core v0.1.12` and refresh `go.sum`.

Covers: anthropic, azure, bytedance, deepseek, kimi, minimax, openai, qwen.

## Verification

- `GOWORK=off go mod tidy` per module (no pending diff beyond `go.sum`)
- `GOWORK=off go test ./... -count=1` per module against the released `core/v0.1.12`: all pass

After this merges, each driver gets tagged `v0.1.3` at the merge commit (same flow as the `core v0.1.10` bump in #333).