### PR TITLE
feat(core): expose explain, embed, and model catalog in the script inference bridge

### DIFF
--- a/.release/core-v0.1.13.json
+++ b/.release/core-v0.1.13.json
@@ -1,0 +1,9 @@
+{
+  "summary": "feat(core): expose inference explain, embed, and model-catalog entry points in the script bridge — inference.models/inspect, the embed family (embed/routeEmbed/explainEmbed/routeExplainEmbed), stream preflight (explainStream/routeExplainStream with a public Router.ExplainGenerateStream), with route-level explain responses carrying the selected model's declared limits",
+  "releases": [
+    {
+      "module": "core",
+      "bump": "patch"
+    }
+  ]
+}

--- a/core/agent/bindings/bridge_inference.go
+++ b/core/agent/bindings/bridge_inference.go
@@ -48,6 +48,38 @@ func WithExtensionDecoder(provider, id string, decoder inference.ExtensionDecode
 //     router's selector/fallback chain chooses the target; the
 //     response gains a "trace" key with the route.Trace projection.
 //
+//   - explain(request): one exact-model Assembly.ExplainGenerate call.
+//     Same request shape as generate (model key required); returns the
+//     canonical Explanation wire JSON with no provider I/O, so scripts
+//     can preflight a request against one concrete model.
+//
+//   - routeExplain(request): one Router.ExplainGenerate call. Same
+//     shape as route (no model key); returns {explanation, decision,
+//     limits} where decision records the selected model and limits is
+//     that model's declared ModelLimits — scripts can compare the
+//     pending context against max_input_tokens before executing.
+//
+//   - models(): one Assembly.Models call. Returns the full catalog of
+//     ModelDescriptor wire JSON (id, capabilities, limits, lifecycle),
+//     so scripts can enumerate what the host registered.
+//
+//   - inspect(model): one Assembly.InspectModel call. The argument is
+//     a ModelRef wire JSON ({id: {provider, name}, profile?}); returns
+//     that model's ModelDescriptor.
+//
+//   - embed(request) / routeEmbed(request): the Embed twins of
+//     generate/route — exact model (model key required) vs router
+//     selection (no model key, response gains "trace").
+//
+//   - explainEmbed(request) / routeExplainEmbed(request): the Embed
+//     twins of explain/routeExplain; routeExplainEmbed returns
+//     {explanation, decision, limits} for the selected embed model.
+//
+//   - explainStream(request) / routeExplainStream(request): the
+//     Generate-stream twins of explain/routeExplain — local stream
+//     compilation without opening a provider stream;
+//     routeExplainStream returns {explanation, decision, limits}.
+//
 //   - stream(request) / routeStream(request): the streaming twins of
 //     the above. Both return an iterator handle:
 //
@@ -94,7 +126,11 @@ func NewInferenceBridge(assembly *inference.Assembly, router *route.Router, opts
 				if assembly == nil {
 					return nil, errdefs.NotAvailablef("inference.generate: no assembly wired")
 				}
-				ref, req, err := parseInferenceGenerateCall(raw, cfg.extensions)
+				ref, req, err := parseInferenceGenerateCall(
+					raw,
+					cfg.extensions,
+					"inference.generate",
+				)
 				if err != nil {
 					return nil, err
 				}
@@ -108,10 +144,15 @@ func NewInferenceBridge(assembly *inference.Assembly, router *route.Router, opts
 				if router == nil {
 					return nil, errdefs.NotAvailablef("inference.route: no router wired")
 				}
-				req, err := parseInferenceRouteCall(raw, cfg.extensions, "inference.route")
+				req, extensions, err := parseInferenceRouteCall[inference.GenerateRequest](
+					raw,
+					cfg.extensions,
+					"inference.route",
+				)
 				if err != nil {
 					return nil, err
 				}
+				req.Extensions = extensions
 				resp, trace, err := router.Generate(ctx, req)
 				if err != nil {
 					return nil, err
@@ -120,22 +161,204 @@ func NewInferenceBridge(assembly *inference.Assembly, router *route.Router, opts
 				if err != nil {
 					return nil, err
 				}
-				obj, ok := out.(map[string]any)
-				if !ok {
-					return nil, errdefs.Internalf("inference.route: response projection is %T, want object", out)
+				return attachTrace(out, trace, "inference.route")
+			},
+			"explain": func(raw any) (any, error) {
+				if assembly == nil {
+					return nil, errdefs.NotAvailablef("inference.explain: no assembly wired")
 				}
-				traceJSON, err := toScriptJSON(trace, "inference.route trace")
+				ref, req, err := parseInferenceGenerateCall(
+					raw,
+					cfg.extensions,
+					"inference.explain",
+				)
 				if err != nil {
 					return nil, err
 				}
-				obj["trace"] = traceJSON
-				return obj, nil
+				explanation, err := assembly.ExplainGenerate(ctx, ref, req)
+				if err != nil {
+					return nil, err
+				}
+				return toScriptJSON(explanation, "inference.explain response")
+			},
+			"routeExplain": func(raw any) (any, error) {
+				if router == nil {
+					return nil, errdefs.NotAvailablef("inference.routeExplain: no router wired")
+				}
+				req, extensions, err := parseInferenceRouteCall[inference.GenerateRequest](
+					raw,
+					cfg.extensions,
+					"inference.routeExplain",
+				)
+				if err != nil {
+					return nil, err
+				}
+				req.Extensions = extensions
+				explanation, decision, err := router.ExplainGenerate(ctx, req)
+				if err != nil {
+					return nil, err
+				}
+				return routeExplainResult(
+					router,
+					explanation,
+					decision,
+					"inference.routeExplain",
+				)
+			},
+			"models": func() (any, error) {
+				if assembly == nil {
+					return nil, errdefs.NotAvailablef("inference.models: no assembly wired")
+				}
+				return toScriptJSON(assembly.Models(), "inference.models response")
+			},
+			"inspect": func(raw any) (any, error) {
+				if assembly == nil {
+					return nil, errdefs.NotAvailablef("inference.inspect: no assembly wired")
+				}
+				var ref inference.ModelRef
+				if err := decodeStrictJSON(raw, &ref, "inference.inspect.model"); err != nil {
+					return nil, err
+				}
+				descriptor, err := assembly.InspectModel(ref)
+				if err != nil {
+					return nil, err
+				}
+				return toScriptJSON(descriptor, "inference.inspect response")
+			},
+			"explainStream": func(raw any) (any, error) {
+				if assembly == nil {
+					return nil, errdefs.NotAvailablef("inference.explainStream: no assembly wired")
+				}
+				ref, req, err := parseInferenceGenerateCall(
+					raw,
+					cfg.extensions,
+					"inference.explainStream",
+				)
+				if err != nil {
+					return nil, err
+				}
+				explanation, err := assembly.ExplainGenerateStream(ctx, ref, req)
+				if err != nil {
+					return nil, err
+				}
+				return toScriptJSON(explanation, "inference.explainStream response")
+			},
+			"routeExplainStream": func(raw any) (any, error) {
+				if router == nil {
+					return nil, errdefs.NotAvailablef("inference.routeExplainStream: no router wired")
+				}
+				req, extensions, err := parseInferenceRouteCall[inference.GenerateRequest](
+					raw,
+					cfg.extensions,
+					"inference.routeExplainStream",
+				)
+				if err != nil {
+					return nil, err
+				}
+				req.Extensions = extensions
+				explanation, decision, err := router.ExplainGenerateStream(ctx, req)
+				if err != nil {
+					return nil, err
+				}
+				return routeExplainResult(
+					router,
+					explanation,
+					decision,
+					"inference.routeExplainStream",
+				)
+			},
+			"embed": func(raw any) (any, error) {
+				if assembly == nil {
+					return nil, errdefs.NotAvailablef("inference.embed: no assembly wired")
+				}
+				ref, req, err := parseInferenceEmbedCall(
+					raw,
+					cfg.extensions,
+					"inference.embed",
+				)
+				if err != nil {
+					return nil, err
+				}
+				resp, err := assembly.Embed(ctx, ref, req)
+				if err != nil {
+					return nil, err
+				}
+				return toScriptJSON(resp, "inference.embed response")
+			},
+			"routeEmbed": func(raw any) (any, error) {
+				if router == nil {
+					return nil, errdefs.NotAvailablef("inference.routeEmbed: no router wired")
+				}
+				req, extensions, err := parseInferenceRouteCall[inference.EmbedRequest](
+					raw,
+					cfg.extensions,
+					"inference.routeEmbed",
+				)
+				if err != nil {
+					return nil, err
+				}
+				req.Extensions = extensions
+				resp, trace, err := router.Embed(ctx, req)
+				if err != nil {
+					return nil, err
+				}
+				out, err := toScriptJSON(resp, "inference.routeEmbed response")
+				if err != nil {
+					return nil, err
+				}
+				return attachTrace(out, trace, "inference.routeEmbed")
+			},
+			"explainEmbed": func(raw any) (any, error) {
+				if assembly == nil {
+					return nil, errdefs.NotAvailablef("inference.explainEmbed: no assembly wired")
+				}
+				ref, req, err := parseInferenceEmbedCall(
+					raw,
+					cfg.extensions,
+					"inference.explainEmbed",
+				)
+				if err != nil {
+					return nil, err
+				}
+				explanation, err := assembly.ExplainEmbed(ctx, ref, req)
+				if err != nil {
+					return nil, err
+				}
+				return toScriptJSON(explanation, "inference.explainEmbed response")
+			},
+			"routeExplainEmbed": func(raw any) (any, error) {
+				if router == nil {
+					return nil, errdefs.NotAvailablef("inference.routeExplainEmbed: no router wired")
+				}
+				req, extensions, err := parseInferenceRouteCall[inference.EmbedRequest](
+					raw,
+					cfg.extensions,
+					"inference.routeExplainEmbed",
+				)
+				if err != nil {
+					return nil, err
+				}
+				req.Extensions = extensions
+				explanation, decision, err := router.ExplainEmbed(ctx, req)
+				if err != nil {
+					return nil, err
+				}
+				return routeExplainResult(
+					router,
+					explanation,
+					decision,
+					"inference.routeExplainEmbed",
+				)
 			},
 			"stream": func(raw any) (any, error) {
 				if assembly == nil {
 					return nil, errdefs.NotAvailablef("inference.stream: no assembly wired")
 				}
-				ref, req, err := parseInferenceGenerateCall(raw, cfg.extensions)
+				ref, req, err := parseInferenceGenerateCall(
+					raw,
+					cfg.extensions,
+					"inference.stream",
+				)
 				if err != nil {
 					return nil, err
 				}
@@ -149,10 +372,15 @@ func NewInferenceBridge(assembly *inference.Assembly, router *route.Router, opts
 				if router == nil {
 					return nil, errdefs.NotAvailablef("inference.routeStream: no router wired")
 				}
-				req, err := parseInferenceRouteCall(raw, cfg.extensions, "inference.routeStream")
+				req, extensions, err := parseInferenceRouteCall[inference.GenerateRequest](
+					raw,
+					cfg.extensions,
+					"inference.routeStream",
+				)
 				if err != nil {
 					return nil, err
 				}
+				req.Extensions = extensions
 				stream, trace, err := router.GenerateStream(ctx, req)
 				if err != nil {
 					return nil, err
@@ -230,24 +458,31 @@ func newStreamHandle(ctx context.Context, stream inference.GenerateStream, trace
 	}
 }
 
-// parseInferenceGenerateCall splits the script-facing generate request
-// into the model target and the canonical GenerateRequest. "model" is
-// a bridge-level key (the wire request has no model field — routing
-// ownership lives with the caller, not the payload), so it is stripped
-// before the strict decode; "extensions" is stripped the same way and
-// resolved through the host-registered decoders.
-func parseInferenceGenerateCall(raw any, decoders map[string]inference.ExtensionDecoder) (inference.ModelRef, inference.GenerateRequest, error) {
+// parseInferenceGenerateCall splits the script-facing generate-family
+// request into the model target and the canonical GenerateRequest.
+// "model" is a bridge-level key (the wire request has no model field —
+// routing ownership lives with the caller, not the payload), so it is
+// stripped before the strict decode; "extensions" is stripped the same
+// way and resolved through the host-registered decoders.
+func parseInferenceGenerateCall(
+	raw any,
+	decoders map[string]inference.ExtensionDecoder,
+	field string,
+) (inference.ModelRef, inference.GenerateRequest, error) {
 	var ref inference.ModelRef
 	var req inference.GenerateRequest
 	obj, ok := raw.(map[string]any)
 	if !ok {
-		return ref, req, errdefs.Validationf("inference.generate: expected an object, got %T", raw)
+		return ref, req, errdefs.Validationf("%s: expected an object, got %T", field, raw)
 	}
 	modelRaw, ok := obj["model"]
 	if !ok || modelRaw == nil {
-		return ref, req, errdefs.Validationf("inference.generate: model is required (use inference.route for router-chosen targets)")
+		return ref, req, errdefs.Validationf(
+			"%s: model is required (use the route entry point for router-chosen targets)",
+			field,
+		)
 	}
-	if err := decodeStrictJSON(modelRaw, &ref, "inference.generate.model"); err != nil {
+	if err := decodeStrictJSON(modelRaw, &ref, field+".model"); err != nil {
 		return ref, req, err
 	}
 	rest := make(map[string]any, len(obj)-1)
@@ -256,41 +491,133 @@ func parseInferenceGenerateCall(raw any, decoders map[string]inference.Extension
 			rest[k] = v
 		}
 	}
-	if err := decodeRequestRest(rest, &req, decoders, "inference.generate"); err != nil {
+	extensions, err := decodeRequestRest(rest, &req, decoders, field)
+	if err != nil {
 		return ref, req, err
 	}
+	req.Extensions = extensions
 	return ref, req, nil
 }
 
-// parseInferenceRouteCall decodes a router-entry request: no model
-// key (rejected by the strict decode), extensions stripped and
-// resolved like the runtime entry.
-func parseInferenceRouteCall(raw any, decoders map[string]inference.ExtensionDecoder, field string) (inference.GenerateRequest, error) {
-	var req inference.GenerateRequest
+// parseInferenceEmbedCall splits the script-facing embed-family
+// request into the model target and the canonical EmbedRequest. It
+// mirrors parseInferenceGenerateCall: "model" and "extensions" are
+// bridge-level keys stripped before the strict decode.
+func parseInferenceEmbedCall(
+	raw any,
+	decoders map[string]inference.ExtensionDecoder,
+	field string,
+) (inference.ModelRef, inference.EmbedRequest, error) {
+	var ref inference.ModelRef
+	var req inference.EmbedRequest
 	obj, ok := raw.(map[string]any)
 	if !ok {
-		return req, errdefs.Validationf("%s: expected an object, got %T", field, raw)
+		return ref, req, errdefs.Validationf("%s: expected an object, got %T", field, raw)
 	}
-	if err := decodeRequestRest(obj, &req, decoders, field); err != nil {
-		return req, err
+	modelRaw, ok := obj["model"]
+	if !ok || modelRaw == nil {
+		return ref, req, errdefs.Validationf(
+			"%s: model is required (use the route entry point for router-chosen targets)",
+			field,
+		)
 	}
-	return req, nil
+	if err := decodeStrictJSON(modelRaw, &ref, field+".model"); err != nil {
+		return ref, req, err
+	}
+	rest := make(map[string]any, len(obj)-1)
+	for k, v := range obj {
+		if k != "model" {
+			rest[k] = v
+		}
+	}
+	extensions, err := decodeRequestRest(rest, &req, decoders, field)
+	if err != nil {
+		return ref, req, err
+	}
+	req.Extensions = extensions
+	return ref, req, nil
+}
+
+// attachTrace adds a route.Trace projection to a script-facing
+// response object under "trace".
+func attachTrace(out any, trace route.Trace, field string) (any, error) {
+	obj, ok := out.(map[string]any)
+	if !ok {
+		return nil, errdefs.Internalf(
+			"%s: response projection is %T, want object",
+			field,
+			out,
+		)
+	}
+	traceJSON, err := toScriptJSON(trace, field+" trace")
+	if err != nil {
+		return nil, err
+	}
+	obj["trace"] = traceJSON
+	return obj, nil
+}
+
+// routeExplainResult projects an explanation plus the selected model's
+// declared limits into the script-facing {explanation, decision,
+// limits} shape shared by every route*Explain entry point.
+func routeExplainResult(
+	router *route.Router,
+	explanation inference.Explanation,
+	decision route.Decision,
+	field string,
+) (any, error) {
+	descriptor, err := router.Target().InspectModel(decision.Selected)
+	if err != nil {
+		return nil, errdefs.Internalf("%s: inspect selected model: %v", field, err)
+	}
+	out, err := toScriptJSON(map[string]any{
+		"explanation": explanation,
+		"decision":    decision,
+		"limits":      descriptor.Limits,
+	}, field+" response")
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+// parseInferenceRouteCall decodes a router-entry request: no model key
+// (rejected by the strict decode), extensions stripped and resolved
+// like the runtime entry. The caller assigns the resolved extensions
+// to req.Extensions.
+func parseInferenceRouteCall[T any](
+	raw any,
+	decoders map[string]inference.ExtensionDecoder,
+	field string,
+) (T, inference.Extensions, error) {
+	var req T
+	obj, ok := raw.(map[string]any)
+	if !ok {
+		return req, nil, errdefs.Validationf("%s: expected an object, got %T", field, raw)
+	}
+	extensions, err := decodeRequestRest(obj, &req, decoders, field)
+	if err != nil {
+		return req, nil, err
+	}
+	return req, extensions, nil
 }
 
 // decodeRequestRest strips the bridge-level "extensions" key, strict-
-// decodes the remaining canonical wire into req, then resolves the
-// extensions through the host registry.
-func decodeRequestRest(obj map[string]any, req *inference.GenerateRequest, decoders map[string]inference.ExtensionDecoder, field string) error {
+// decodes the remaining canonical wire into req, and resolves the
+// extensions through the host registry. The caller assigns the
+// resolved extensions to req.Extensions (the wire structs keep the
+// field JSON-hidden).
+func decodeRequestRest[T any](
+	obj map[string]any,
+	req *T,
+	decoders map[string]inference.ExtensionDecoder,
+	field string,
+) (inference.Extensions, error) {
 	extRaw, rest := splitExtensionsKey(obj)
 	if err := decodeStrictJSON(rest, req, field); err != nil {
-		return err
+		return nil, err
 	}
-	extensions, err := decodeScriptExtensions(extRaw, decoders, field+".extensions")
-	if err != nil {
-		return err
-	}
-	req.Extensions = extensions
-	return nil
+	return decodeScriptExtensions(extRaw, decoders, field+".extensions")
 }
 
 // splitExtensionsKey pulls the bridge-level "extensions" key out of a

--- a/core/agent/bindings/bridge_inference_test.go
+++ b/core/agent/bindings/bridge_inference_test.go
@@ -28,11 +28,32 @@ func fakeRouter(t *testing.T, runtime *inference.Assembly) *route.Router {
 	return router
 }
 
+func fakeEmbedRouter(t *testing.T, runtime *inference.Assembly) *route.Router {
+	t.Helper()
+	router, err := route.New(runtime, route.Selectors{
+		Embed: inferencetest.StaticEmbedSelector(inferencetest.DefaultFakeEmbedModel),
+	})
+	if err != nil {
+		t.Fatalf("route.New: %v", err)
+	}
+	return router
+}
+
 type inferenceAPI struct {
-	generate    func(raw any) (any, error)
-	route       func(raw any) (any, error)
-	stream      func(raw any) (any, error)
-	routeStream func(raw any) (any, error)
+	generate           func(raw any) (any, error)
+	route              func(raw any) (any, error)
+	explain            func(raw any) (any, error)
+	routeExplain       func(raw any) (any, error)
+	models             func() (any, error)
+	inspect            func(raw any) (any, error)
+	explainStream      func(raw any) (any, error)
+	routeExplainStream func(raw any) (any, error)
+	embed              func(raw any) (any, error)
+	routeEmbed         func(raw any) (any, error)
+	explainEmbed       func(raw any) (any, error)
+	routeExplainEmbed  func(raw any) (any, error)
+	stream             func(raw any) (any, error)
+	routeStream        func(raw any) (any, error)
 }
 
 func newInferenceAPI(t *testing.T, runtime *inference.Assembly, router *route.Router, opts ...InferenceBridgeOption) inferenceAPI {
@@ -53,6 +74,46 @@ func newInferenceAPI(t *testing.T, runtime *inference.Assembly, router *route.Ro
 	if !ok {
 		t.Fatalf("inference.route = %T", m["route"])
 	}
+	explainFn, ok := m["explain"].(func(any) (any, error))
+	if !ok {
+		t.Fatalf("inference.explain = %T", m["explain"])
+	}
+	routeExplainFn, ok := m["routeExplain"].(func(any) (any, error))
+	if !ok {
+		t.Fatalf("inference.routeExplain = %T", m["routeExplain"])
+	}
+	modelsFn, ok := m["models"].(func() (any, error))
+	if !ok {
+		t.Fatalf("inference.models = %T", m["models"])
+	}
+	inspectFn, ok := m["inspect"].(func(any) (any, error))
+	if !ok {
+		t.Fatalf("inference.inspect = %T", m["inspect"])
+	}
+	explainStreamFn, ok := m["explainStream"].(func(any) (any, error))
+	if !ok {
+		t.Fatalf("inference.explainStream = %T", m["explainStream"])
+	}
+	routeExplainStreamFn, ok := m["routeExplainStream"].(func(any) (any, error))
+	if !ok {
+		t.Fatalf("inference.routeExplainStream = %T", m["routeExplainStream"])
+	}
+	embedFn, ok := m["embed"].(func(any) (any, error))
+	if !ok {
+		t.Fatalf("inference.embed = %T", m["embed"])
+	}
+	routeEmbedFn, ok := m["routeEmbed"].(func(any) (any, error))
+	if !ok {
+		t.Fatalf("inference.routeEmbed = %T", m["routeEmbed"])
+	}
+	explainEmbedFn, ok := m["explainEmbed"].(func(any) (any, error))
+	if !ok {
+		t.Fatalf("inference.explainEmbed = %T", m["explainEmbed"])
+	}
+	routeExplainEmbedFn, ok := m["routeExplainEmbed"].(func(any) (any, error))
+	if !ok {
+		t.Fatalf("inference.routeExplainEmbed = %T", m["routeExplainEmbed"])
+	}
 	streamFn, ok := m["stream"].(func(any) (any, error))
 	if !ok {
 		t.Fatalf("inference.stream = %T", m["stream"])
@@ -61,7 +122,22 @@ func newInferenceAPI(t *testing.T, runtime *inference.Assembly, router *route.Ro
 	if !ok {
 		t.Fatalf("inference.routeStream = %T", m["routeStream"])
 	}
-	return inferenceAPI{generate: generate, route: routeFn, stream: streamFn, routeStream: routeStreamFn}
+	return inferenceAPI{
+		generate:           generate,
+		route:              routeFn,
+		explain:            explainFn,
+		routeExplain:       routeExplainFn,
+		models:             modelsFn,
+		inspect:            inspectFn,
+		explainStream:      explainStreamFn,
+		routeExplainStream: routeExplainStreamFn,
+		embed:              embedFn,
+		routeEmbed:         routeEmbedFn,
+		explainEmbed:       explainEmbedFn,
+		routeExplainEmbed:  routeExplainEmbedFn,
+		stream:             streamFn,
+		routeStream:        routeStreamFn,
+	}
 }
 
 // streamHandle mirrors the script-facing iterator triple.
@@ -105,6 +181,14 @@ func userInput(text string) map[string]any {
 		"content": map[string]any{
 			"parts":  []any{map[string]any{"type": "text", "text": text}},
 			"intent": map[string]any{"text": map[string]any{}},
+		},
+	}
+}
+
+func embedItem(text string) map[string]any {
+	return map[string]any{
+		"content": map[string]any{
+			"parts": []any{map[string]any{"type": "text", "text": text}},
 		},
 	}
 }
@@ -253,6 +337,395 @@ func TestInferenceBridge_Route_NoRouter(t *testing.T) {
 	_, err := api.route(map[string]any{"input": userInput("hi")})
 	if err == nil || !errdefs.IsNotAvailable(err) {
 		t.Fatalf("unwired route error = %v, want NotAvailable", err)
+	}
+}
+
+func TestInferenceBridge_Explain_RoundTrip(t *testing.T) {
+	fake := &inferencetest.GenerateFake{}
+	api := newInferenceAPI(t, fake.Assembly(t), nil)
+
+	out, err := api.explain(map[string]any{
+		"model": fakeModelJSON(),
+		"input": userInput("hi"),
+	})
+	if err != nil {
+		t.Fatalf("explain: %v", err)
+	}
+	explanation, ok := out.(map[string]any)
+	if !ok {
+		t.Fatalf("explanation = %T, want object", out)
+	}
+	if explanation["Operation"] != string(inference.OperationGenerate) {
+		t.Fatalf("explanation.Operation = %v, want %q",
+			explanation["Operation"], inference.OperationGenerate)
+	}
+	model, ok := explanation["Model"].(map[string]any)
+	if !ok || model["id"] == nil {
+		t.Fatalf("explanation.Model = %v, want model identity", explanation["Model"])
+	}
+	// Explain compiles locally: the compiler ran, but no transport
+	// execution produced a response.
+	if reqs := fake.Requests(); len(reqs) != 1 {
+		t.Fatalf("explain compiled requests = %d, want 1", len(reqs))
+	}
+}
+
+func TestInferenceBridge_Explain_NoRuntime(t *testing.T) {
+	api := newInferenceAPI(t, nil, nil)
+	_, err := api.explain(map[string]any{
+		"model": fakeModelJSON(),
+		"input": userInput("hi"),
+	})
+	if err == nil || !errdefs.IsNotAvailable(err) {
+		t.Fatalf("unwired explain error = %v, want NotAvailable", err)
+	}
+}
+
+func TestInferenceBridge_RouteExplain_RoundTrip(t *testing.T) {
+	limit := 128_000
+	fake := &inferencetest.GenerateFake{
+		Descriptor: inference.ModelDescriptor{
+			ID: inferencetest.DefaultFakeModel.ID,
+			Limits: inference.ModelLimits{
+				MaxInputTokens: &limit,
+			},
+		},
+	}
+	runtime := fake.Assembly(t)
+	api := newInferenceAPI(t, runtime, fakeRouter(t, runtime))
+
+	out, err := api.routeExplain(map[string]any{"input": userInput("hi")})
+	if err != nil {
+		t.Fatalf("routeExplain: %v", err)
+	}
+	obj, ok := out.(map[string]any)
+	if !ok {
+		t.Fatalf("routeExplain result = %T, want object", out)
+	}
+	if _, ok := obj["explanation"].(map[string]any); !ok {
+		t.Fatalf("routeExplain.explanation = %T, want object", obj["explanation"])
+	}
+	decision, ok := obj["decision"].(map[string]any)
+	if !ok {
+		t.Fatalf("routeExplain.decision = %T, want object", obj["decision"])
+	}
+	selected, ok := decision["selected"].(map[string]any)
+	if !ok || selected["id"] == nil {
+		t.Fatalf("routeExplain.decision.selected = %v, want model identity", decision["selected"])
+	}
+	limits, ok := obj["limits"].(map[string]any)
+	if !ok {
+		t.Fatalf("routeExplain.limits = %T, want object", obj["limits"])
+	}
+	if limits["max_input_tokens"] != float64(limit) {
+		t.Fatalf("routeExplain.limits.max_input_tokens = %v, want %d",
+			limits["max_input_tokens"], limit)
+	}
+	// One compile for the routed preflight; no transport execution.
+	if reqs := fake.Requests(); len(reqs) != 1 {
+		t.Fatalf("routeExplain compiled requests = %d, want 1", len(reqs))
+	}
+}
+
+func TestInferenceBridge_RouteExplain_RejectsModelKey(t *testing.T) {
+	fake := &inferencetest.GenerateFake{}
+	runtime := fake.Assembly(t)
+	api := newInferenceAPI(t, runtime, fakeRouter(t, runtime))
+
+	_, err := api.routeExplain(map[string]any{
+		"model": fakeModelJSON(),
+		"input": userInput("hi"),
+	})
+	if err == nil || !errdefs.IsValidation(err) {
+		t.Fatalf("routeExplain with model key error = %v, want validation-classified", err)
+	}
+}
+
+func TestInferenceBridge_RouteExplain_NoRouter(t *testing.T) {
+	fake := &inferencetest.GenerateFake{}
+	api := newInferenceAPI(t, fake.Assembly(t), nil)
+
+	_, err := api.routeExplain(map[string]any{"input": userInput("hi")})
+	if err == nil || !errdefs.IsNotAvailable(err) {
+		t.Fatalf("unwired routeExplain error = %v, want NotAvailable", err)
+	}
+}
+
+func TestInferenceBridge_Models_RoundTrip(t *testing.T) {
+	limit := 128_000
+	fake := &inferencetest.GenerateFake{
+		Descriptor: inference.ModelDescriptor{
+			ID: inferencetest.DefaultFakeModel.ID,
+			Limits: inference.ModelLimits{
+				MaxInputTokens: &limit,
+			},
+		},
+	}
+	api := newInferenceAPI(t, fake.Assembly(t), nil)
+
+	out, err := api.models()
+	if err != nil {
+		t.Fatalf("models: %v", err)
+	}
+	models, ok := out.([]any)
+	if !ok || len(models) != 1 {
+		t.Fatalf("models = %T (%v), want one descriptor", out, out)
+	}
+	descriptor, ok := models[0].(map[string]any)
+	if !ok {
+		t.Fatalf("model descriptor = %T, want object", models[0])
+	}
+	limits, ok := descriptor["limits"].(map[string]any)
+	if !ok || limits["max_input_tokens"] != float64(limit) {
+		t.Fatalf("descriptor limits = %v, want max_input_tokens %d", descriptor["limits"], limit)
+	}
+}
+
+func TestInferenceBridge_Models_NoRuntime(t *testing.T) {
+	api := newInferenceAPI(t, nil, nil)
+	_, err := api.models()
+	if err == nil || !errdefs.IsNotAvailable(err) {
+		t.Fatalf("unwired models error = %v, want NotAvailable", err)
+	}
+}
+
+func TestInferenceBridge_Inspect_RoundTrip(t *testing.T) {
+	limit := 64_000
+	fake := &inferencetest.GenerateFake{
+		Descriptor: inference.ModelDescriptor{
+			ID: inferencetest.DefaultFakeModel.ID,
+			Limits: inference.ModelLimits{
+				MaxInputTokens: &limit,
+			},
+		},
+	}
+	api := newInferenceAPI(t, fake.Assembly(t), nil)
+
+	out, err := api.inspect(fakeModelJSON())
+	if err != nil {
+		t.Fatalf("inspect: %v", err)
+	}
+	descriptor, ok := out.(map[string]any)
+	if !ok {
+		t.Fatalf("descriptor = %T, want object", out)
+	}
+	limits, ok := descriptor["limits"].(map[string]any)
+	if !ok || limits["max_input_tokens"] != float64(limit) {
+		t.Fatalf("descriptor limits = %v, want max_input_tokens %d", descriptor["limits"], limit)
+	}
+}
+
+func TestInferenceBridge_Inspect_UnknownModel(t *testing.T) {
+	fake := &inferencetest.GenerateFake{}
+	api := newInferenceAPI(t, fake.Assembly(t), nil)
+
+	_, err := api.inspect(map[string]any{
+		"id": map[string]any{"provider": "fake", "name": "ghost"},
+	})
+	if err == nil {
+		t.Fatal("inspect of unknown model should fail")
+	}
+}
+
+func TestInferenceBridge_ExplainStream_RoundTrip(t *testing.T) {
+	fake := &inferencetest.GenerateFake{}
+	api := newInferenceAPI(t, fake.Assembly(t), nil)
+
+	out, err := api.explainStream(map[string]any{
+		"model": fakeModelJSON(),
+		"input": userInput("hi"),
+	})
+	if err != nil {
+		t.Fatalf("explainStream: %v", err)
+	}
+	explanation, ok := out.(map[string]any)
+	if !ok {
+		t.Fatalf("explanation = %T, want object", out)
+	}
+	if explanation["Operation"] != string(inference.OperationGenerate) {
+		t.Fatalf("explanation.Operation = %v, want %q",
+			explanation["Operation"], inference.OperationGenerate)
+	}
+}
+
+func TestInferenceBridge_RouteExplainStream_RoundTrip(t *testing.T) {
+	limit := 128_000
+	fake := &inferencetest.GenerateFake{
+		Descriptor: inference.ModelDescriptor{
+			ID: inferencetest.DefaultFakeModel.ID,
+			Limits: inference.ModelLimits{
+				MaxInputTokens: &limit,
+			},
+		},
+	}
+	runtime := fake.Assembly(t)
+	api := newInferenceAPI(t, runtime, fakeRouter(t, runtime))
+
+	out, err := api.routeExplainStream(map[string]any{"input": userInput("hi")})
+	if err != nil {
+		t.Fatalf("routeExplainStream: %v", err)
+	}
+	obj, ok := out.(map[string]any)
+	if !ok {
+		t.Fatalf("routeExplainStream result = %T, want object", out)
+	}
+	if _, ok := obj["explanation"].(map[string]any); !ok {
+		t.Fatalf("routeExplainStream.explanation = %T, want object", obj["explanation"])
+	}
+	decision, ok := obj["decision"].(map[string]any)
+	if !ok || decision["selected"] == nil {
+		t.Fatalf("routeExplainStream.decision = %v, want selected model", obj["decision"])
+	}
+	limits, ok := obj["limits"].(map[string]any)
+	if !ok || limits["max_input_tokens"] != float64(limit) {
+		t.Fatalf("routeExplainStream.limits = %v, want max_input_tokens %d",
+			obj["limits"], limit)
+	}
+}
+
+func TestInferenceBridge_Embed_RoundTrip(t *testing.T) {
+	fake := &inferencetest.EmbedFake{}
+	api := newInferenceAPI(t, fake.Assembly(t), nil)
+
+	out, err := api.embed(map[string]any{
+		"model": map[string]any{
+			"id":      map[string]any{"provider": "fake", "name": "embed"},
+			"profile": "default",
+		},
+		"items": []any{embedItem("hello")},
+	})
+	if err != nil {
+		t.Fatalf("embed: %v", err)
+	}
+	resp, ok := out.(map[string]any)
+	if !ok {
+		t.Fatalf("embed response = %T, want object", out)
+	}
+	embeddings, ok := resp["embeddings"].([]any)
+	if !ok || len(embeddings) != 1 {
+		t.Fatalf("embeddings = %v, want one vector", resp["embeddings"])
+	}
+}
+
+func TestInferenceBridge_Embed_NoRuntime(t *testing.T) {
+	api := newInferenceAPI(t, nil, nil)
+	_, err := api.embed(map[string]any{
+		"model": map[string]any{
+			"id": map[string]any{"provider": "fake", "name": "embed"},
+		},
+		"items": []any{embedItem("hello")},
+	})
+	if err == nil || !errdefs.IsNotAvailable(err) {
+		t.Fatalf("unwired embed error = %v, want NotAvailable", err)
+	}
+}
+
+func TestInferenceBridge_RouteEmbed_RoundTrip(t *testing.T) {
+	fake := &inferencetest.EmbedFake{}
+	runtime := fake.Assembly(t)
+	api := newInferenceAPI(t, runtime, fakeEmbedRouter(t, runtime))
+
+	out, err := api.routeEmbed(map[string]any{
+		"items": []any{embedItem("hello")},
+	})
+	if err != nil {
+		t.Fatalf("routeEmbed: %v", err)
+	}
+	resp, ok := out.(map[string]any)
+	if !ok {
+		t.Fatalf("routeEmbed response = %T, want object", out)
+	}
+	if _, ok := resp["embeddings"].([]any); !ok {
+		t.Fatalf("embeddings = %T, want array", resp["embeddings"])
+	}
+	trace, ok := resp["trace"].(map[string]any)
+	if !ok {
+		t.Fatalf("trace missing or %T, want object", resp["trace"])
+	}
+	executed, ok := trace["executed"].(map[string]any)
+	if !ok {
+		t.Fatalf("trace.executed = %T, want object", trace["executed"])
+	}
+	id, ok := executed["id"].(map[string]any)
+	if !ok || id["provider"] != "fake" || id["name"] != "embed" {
+		t.Fatalf("trace.executed.id = %v, want fake/embed", executed["id"])
+	}
+}
+
+func TestInferenceBridge_RouteEmbed_RejectsModelKey(t *testing.T) {
+	fake := &inferencetest.EmbedFake{}
+	runtime := fake.Assembly(t)
+	api := newInferenceAPI(t, runtime, fakeEmbedRouter(t, runtime))
+
+	_, err := api.routeEmbed(map[string]any{
+		"model": map[string]any{
+			"id": map[string]any{"provider": "fake", "name": "embed"},
+		},
+		"items": []any{embedItem("hello")},
+	})
+	if err == nil || !errdefs.IsValidation(err) {
+		t.Fatalf("routeEmbed with model key error = %v, want validation-classified", err)
+	}
+}
+
+func TestInferenceBridge_ExplainEmbed_RoundTrip(t *testing.T) {
+	fake := &inferencetest.EmbedFake{}
+	api := newInferenceAPI(t, fake.Assembly(t), nil)
+
+	out, err := api.explainEmbed(map[string]any{
+		"model": map[string]any{
+			"id":      map[string]any{"provider": "fake", "name": "embed"},
+			"profile": "default",
+		},
+		"items": []any{embedItem("hello")},
+	})
+	if err != nil {
+		t.Fatalf("explainEmbed: %v", err)
+	}
+	explanation, ok := out.(map[string]any)
+	if !ok {
+		t.Fatalf("explanation = %T, want object", out)
+	}
+	if explanation["Operation"] != string(inference.OperationEmbed) {
+		t.Fatalf("explanation.Operation = %v, want %q",
+			explanation["Operation"], inference.OperationEmbed)
+	}
+}
+
+func TestInferenceBridge_RouteExplainEmbed_RoundTrip(t *testing.T) {
+	limit := 8_192
+	fake := &inferencetest.EmbedFake{
+		Descriptor: inference.ModelDescriptor{
+			ID: inferencetest.DefaultFakeEmbedModel.ID,
+			Limits: inference.ModelLimits{
+				MaxInputTokens: &limit,
+			},
+		},
+	}
+	runtime := fake.Assembly(t)
+	api := newInferenceAPI(t, runtime, fakeEmbedRouter(t, runtime))
+
+	out, err := api.routeExplainEmbed(map[string]any{
+		"items": []any{embedItem("hello")},
+	})
+	if err != nil {
+		t.Fatalf("routeExplainEmbed: %v", err)
+	}
+	obj, ok := out.(map[string]any)
+	if !ok {
+		t.Fatalf("routeExplainEmbed result = %T, want object", out)
+	}
+	if _, ok := obj["explanation"].(map[string]any); !ok {
+		t.Fatalf("routeExplainEmbed.explanation = %T, want object", obj["explanation"])
+	}
+	decision, ok := obj["decision"].(map[string]any)
+	if !ok || decision["selected"] == nil {
+		t.Fatalf("routeExplainEmbed.decision = %v, want selected model", obj["decision"])
+	}
+	limits, ok := obj["limits"].(map[string]any)
+	if !ok || limits["max_input_tokens"] != float64(limit) {
+		t.Fatalf("routeExplainEmbed.limits = %v, want max_input_tokens %d",
+			obj["limits"], limit)
 	}
 }
 

--- a/core/inference/inferencetest/embed.go
+++ b/core/inference/inferencetest/embed.go
@@ -23,6 +23,10 @@ type EmbedFake struct {
 	// Model is the ref the runtime resolves. Defaults to
 	// DefaultFakeEmbedModel.
 	Model inference.ModelRef
+	// Descriptor overrides the model's discovery metadata. The zero
+	// value falls back to {ID: Model.ID}, so tests can declare limits
+	// or lifecycle without rebuilding the provider.
+	Descriptor inference.ModelDescriptor
 	// Respond answers Embed calls. Default: one unit-length vector per
 	// request item.
 	Respond func(inference.EmbedRequest) inference.EmbedResponse
@@ -72,6 +76,10 @@ func (f *EmbedFake) Assembly(t *testing.T) *inference.Assembly {
 	if err != nil {
 		t.Fatalf("BindEmbed: %v", err)
 	}
+	descriptor := f.Descriptor
+	if descriptor.ID.Provider == "" {
+		descriptor = inference.ModelDescriptor{ID: model.ID}
+	}
 
 	definition := inference.ProviderDefinition{
 		ID: model.ID.Provider,
@@ -80,7 +88,7 @@ func (f *EmbedFake) Assembly(t *testing.T) *inference.Assembly {
 			Operations: []inference.Operation{inference.OperationEmbed},
 		}},
 		Models: []inference.ModelImplementation{{
-			Descriptor: inference.ModelDescriptor{ID: model.ID},
+			Descriptor: descriptor,
 			Openers: inference.Openers{
 				Embed: func(_ context.Context, _ inference.ModelRef) (inference.EmbedDriver, error) {
 					return driver, nil

--- a/core/inference/inferencetest/fake.go
+++ b/core/inference/inferencetest/fake.go
@@ -27,6 +27,10 @@ type GenerateFake struct {
 	// Model is the ref the runtime resolves. Defaults to
 	// DefaultFakeModel.
 	Model inference.ModelRef
+	// Descriptor overrides the model's discovery metadata. The zero
+	// value falls back to {ID: Model.ID}, so tests can declare limits
+	// or lifecycle without rebuilding the provider.
+	Descriptor inference.ModelDescriptor
 	// Respond answers unary Generate calls. Default: a one-part "ok"
 	// text message with inference.FinishCompleted.
 	Respond func(inference.GenerateRequest) inference.GenerateResponse
@@ -113,6 +117,10 @@ func (f *GenerateFake) Assembly(t *testing.T) *inference.Assembly {
 	if err != nil {
 		t.Fatalf("BindGenerateOperations: %v", err)
 	}
+	descriptor := f.Descriptor
+	if descriptor.ID.Provider == "" {
+		descriptor = inference.ModelDescriptor{ID: model.ID}
+	}
 	definition := inference.ProviderDefinition{
 		ID:                model.ID.Provider,
 		ExtensionDecoders: f.ExtensionDecoders,
@@ -121,7 +129,7 @@ func (f *GenerateFake) Assembly(t *testing.T) *inference.Assembly {
 			Operations: []inference.Operation{inference.OperationGenerate},
 		}},
 		Models: []inference.ModelImplementation{{
-			Descriptor: inference.ModelDescriptor{ID: model.ID},
+			Descriptor: descriptor,
 			Openers: inference.Openers{
 				Generate: func(_ context.Context, _ inference.ModelRef) (inference.GenerateOperations, error) {
 					return operations, nil
@@ -181,6 +189,26 @@ func StaticGenerateSelector(ref inference.ModelRef) route.GenerateSelector {
 type generateSelectorFunc func(context.Context, inference.GenerateRequest) (route.Decision, error)
 
 func (f generateSelectorFunc) SelectGenerate(ctx context.Context, req inference.GenerateRequest) (route.Decision, error) {
+	return f(ctx, req)
+}
+
+// StaticEmbedSelector returns a route.EmbedSelector that always
+// selects ref on the primary tier — the smallest router wiring for
+// tests that need the embed route path without a policy engine.
+func StaticEmbedSelector(ref inference.ModelRef) route.EmbedSelector {
+	return embedSelectorFunc(func(context.Context, inference.EmbedRequest) (route.Decision, error) {
+		return route.Decision{
+			Operation: inference.OperationEmbed,
+			Tier:      "primary",
+			Proposed:  ref,
+			Selected:  ref,
+		}, nil
+	})
+}
+
+type embedSelectorFunc func(context.Context, inference.EmbedRequest) (route.Decision, error)
+
+func (f embedSelectorFunc) SelectEmbed(ctx context.Context, req inference.EmbedRequest) (route.Decision, error) {
 	return f(ctx, req)
 }
 

--- a/core/inference/route/router_generate.go
+++ b/core/inference/route/router_generate.go
@@ -101,6 +101,25 @@ func (r *Router) ExplainGenerate(
 	return explanation, decision, err
 }
 
+// ExplainGenerateStream explains the selected target's Generate stream
+// compilation without provider I/O.
+func (r *Router) ExplainGenerateStream(
+	ctx context.Context,
+	request inference.GenerateRequest,
+) (inference.Explanation, Decision, error) {
+	snapshot := request.Clone()
+	decision, err := r.selectGenerate(ctx, snapshot)
+	if err != nil {
+		return inference.Explanation{}, Decision{}, err
+	}
+	explanation, err := r.target.ExplainGenerateStream(
+		ctx,
+		decision.Selected,
+		snapshot,
+	)
+	return explanation, decision, err
+}
+
 func (r *Router) selectGenerate(
 	ctx context.Context,
 	snapshot inference.GenerateRequest,


### PR DESCRIPTION
## Summary

Extends the script-facing `inference` bridge with three families of entry points, all backed by existing core APIs (no provider I/O for the explain/preflight paths):

### Model catalog
- `inference.models()` → `Assembly.Models()`, full `ModelDescriptor` list (id, capabilities, limits, lifecycle)
- `inference.inspect(model)` → `Assembly.InspectModel(ref)`

### Embed family
- `inference.embed(request)` → `Assembly.Embed`
- `inference.routeEmbed(request)` → `Router.Embed` (response gains `trace`)
- `inference.explainEmbed(request)` → `Assembly.ExplainEmbed`
- `inference.routeExplainEmbed(request)` → `Router.ExplainEmbed`, returns `{explanation, decision, limits}`

### Stream preflight
- `inference.explainStream(request)` → `Assembly.ExplainGenerateStream`
- `inference.routeExplainStream(request)` → `Router.ExplainGenerateStream` (new public method), returns `{explanation, decision, limits}`

Route-level explain responses include the selected model's declared `limits.max_input_tokens` so scripts can compare pending context size before executing. Request parsers were generalized (`parseInferenceRouteCall`/`decodeRequestRest` are now generic) and the route explain projection is shared via `routeExplainResult`. `inferencetest` gains `StaticEmbedSelector` and descriptor overrides on `GenerateFake`/`EmbedFake`.

## Release

Includes `.release/core-v0.1.13.json` (patch): `core 0.1.12 -> 0.1.13`, tag `core/v0.1.13`. CI tags core after merge.

## Validation

- `make ci` ✅
- `make lint` ✅ (0 issues)
- `make release-plan` / `make release-check` / `make release-preflight` ✅
- `git diff --check` ✅