### PR TITLE
docs: detail graph node types and script bridges, align flowcraft-config skill

### DIFF
--- a/docs/guides/graph.md
+++ b/docs/guides/graph.md
@@ -10,12 +10,12 @@ YAML graph definition into an `agent.Engine`, then runs waves over an
 
 ## Layers
 
-| Layer | Type | Job |
-| --- | --- | --- |
-| Wire | `GraphDefinition` | serializable graph document |
-| Registration | `Registry` + node types | bind node type names to handlers |
-| Build | `Build(def, reg, opts...)` | validate and compile edges/conditions |
-| Execution | `*Graph` | run the frontier wave by wave |
+| Layer        | Type                       | Job                                   |
+| ------------ | -------------------------- | ------------------------------------- |
+| Wire         | `GraphDefinition`          | serializable graph document           |
+| Registration | `Registry` + node types    | bind node type names to handlers      |
+| Build        | `Build(def, reg, opts...)` | validate and compile edges/conditions |
+| Execution    | `*Graph`                   | run the frontier wave by wave         |
 
 A `*Graph` is an `agent.Engine`.
 
@@ -27,35 +27,440 @@ A `*Graph` is an `agent.Engine`.
   "version": "1",
   "entry": "chat",
   "nodes": [
-    {"id": "chat", "type": "inference", "config": {
-      "model": {"id": {"provider": "deepseek", "name": "deepseek-v4-flash"}},
-      "messages_channel": "main"
-    }},
-    {"id": "tools", "type": "tool", "config": {
-      "messages_channel": "main",
-      "results_key": "tool_results"
-    }}
+    {
+      "id": "chat",
+      "type": "inference",
+      "config": {
+        "model": {
+          "id": { "provider": "deepseek", "name": "deepseek-v4-flash" }
+        },
+        "messages_channel": "main"
+      }
+    },
+    {
+      "id": "tools",
+      "type": "tool",
+      "config": {
+        "messages_channel": "main",
+        "results_key": "tool_results"
+      }
+    }
   ],
   "edges": [
-    {"from": "chat", "to": "tools", "condition": "tool_pending == true"},
-    {"from": "tools", "to": "chat"},
-    {"from": "chat", "to": "__end__"}
+    { "from": "chat", "to": "tools", "condition": "tool_pending == true" },
+    { "from": "tools", "to": "chat" },
+    { "from": "chat", "to": "__end__" }
   ]
 }
 ```
 
 `condition` and `skip_condition` use expr-lang expressions over board
 variables. `${board.<name>}` references inside config strings resolve before
-node decode.
+node decode, so `system_prompt` may interpolate upstream output. Node types
+must be registered in the registry passed to `Build`; an unregistered type
+fails `Build`, not `GraphDefinition.Validate`.
+
+## Engine settings (`agent.Engine/graph`)
+
+The deployment-facing factory is `core/graph/resource`. Its settings subtree:
+
+| Key                              | Meaning                                                                        |
+| -------------------------------- | ------------------------------------------------------------------------------ |
+| `graph`                          | graph definition: literal content, `{file: ...}`, or `{embed: ...}` (required) |
+| `script_runtime_name`            | name of the `agent.ScriptRuntime` dep bound to script nodes; default `js`      |
+| `build.max_iterations`           | cap on total node invocations per run                                          |
+| `build.timeout`                  | wall-clock bound for one `Execute` call (Go duration string, e.g. `1h`)        |
+| `build.run_end_publish_timeout`  | deadline for publishing run-end lifecycle events                               |
+| `build.max_node_retries`         | retries per node before the run fails                                          |
+| `build.parallel.enabled`         | enable parallel waves                                                          |
+| `build.parallel.branch_timeout`  | per-branch wall-clock bound                                                    |
+| `build.parallel.max_concurrency` | max concurrent branches                                                        |
+| `build.parallel.max_branches`    | max total branches per wave                                                    |
+| `build.parallel.merge_strategy`  | `first_write_wins` or `last_write_wins`                                        |
+
+Engine deps are derived from the definition: an inference node needs the
+`inference` dep (explicit `model`) and/or `router` dep (no `model`), a tool
+node needs `tools`, a script node needs `script_runtime`. `workspace` and
+`sandbox` are optional and unlock the script `fs` / `shell` globals (below).
 
 ## Node types
 
-- `inference` runs model inference and writes results/usage/tool pending keys.
-- `tool` executes pending tool calls in one batch.
-- `script` runs a JS or Lua script bound to an `agent.ScriptRuntime`.
+### `inference` — single-shot LLM generation
 
-Node factories are registered through `core/graph/nodes` and
-`core/graph/nodes/script`. The deployment-facing engine factory is
-`core/graph/resource`.
+Runs one `Generate` call: the channel tail is the current turn's input, the
+assistant message (tool calls included) is appended to the same channel.
+The node never executes tool calls — a `tool_calls` finish reason is flagged
+onto `tool_pending_key` and the graph routes onward.
 
-See [deploy.md](deploy.md) for the `agent.Engine/graph` resource binding.
+| Config field                             | Meaning                                                                                                           |
+| ---------------------------------------- | ----------------------------------------------------------------------------------------------------------------- |
+| `model`                                  | explicit target `{id: {provider, name}, profile?}`; absent defers selection to the wired router                   |
+| `messages_channel`                       | board channel holding the conversation; empty means the main channel                                              |
+| `system_prompt`                          | prepended system message when the context does not already start with one (may be `{file: ...}` / `{embed: ...}`) |
+| `output_key`                             | board var receiving the full assistant `Message`                                                                  |
+| `usage_key`                              | board var receiving the call's `inference.Usage`                                                                  |
+| `tool_pending_key`                       | board var receiving `finish_reason == tool_calls` (the condition edges branch on)                                 |
+| `stream`                                 | open a `GenerateStream`; text/reasoning deltas stream incrementally, the board still gets one assembled message   |
+| `tools`                                  | named catalog tools the model may call this turn                                                                  |
+| `all_tools`                              | send the catalog's entire visible set; with `tools`, names are declared `RequiredByName` and must exist           |
+| `tool_choice`                            | constrain when/which tools are called                                                                             |
+| `temperature` / `top_p`                  | sampling controls                                                                                                 |
+| `max_output_tokens`                      | output token cap                                                                                                  |
+| `reasoning_enabled` / `reasoning_effort` | universal reasoning switch / depth                                                                                |
+| `response_format`                        | `text`, `json_object`, or `json_schema` (name + schema); generated text is re-validated against the schema        |
+| `extensions`                             | provider knobs in the `{provider, id, fields}` wire form, resolved via the assembly's decoders                    |
+
+Behavior:
+
+- The channel tail must have role `user` or `tool`; everything before it is
+  the request context. An empty channel or wrong role is a validation error.
+- `model` uses the wired `inference.Assembly`; no `model` requires the
+  `inference.Router` (selector/fallback chain picks the target).
+- With `tools`/`all_tools` configured the tools dep's catalog must be wired;
+  unknown names fail the node.
+- Usage is reported to the host on every call. In stream mode a mid-stream
+  failure commits the buffered partial text to the board and reports the
+  last usage snapshot before propagating the error.
+
+### `tool` — batch tool execution
+
+Reads the `tool_call` parts off the channel tail's assistant message,
+executes the whole batch through the tool dispatcher (model-issued call ids
+preserved, so the provider can pair results next turn), and appends the
+results as one `role=tool` message — again a valid tail for `inference`.
+
+| Config field       | Meaning                                                                        |
+| ------------------ | ------------------------------------------------------------------------------ |
+| `messages_channel` | channel whose tail holds pending tool calls; empty means the main channel      |
+| `results_key`      | board var receiving the raw `[]message.Result` for downstream nodes/conditions |
+
+Behavior:
+
+- The channel tail must have role `assistant` and carry at least one
+  `tool_call` part.
+- Allow-listing and approval policy live in the dispatcher's middleware
+  chain, not in the node.
+- Each result is published as a stream delta; a publish failure is logged
+  and does not fail the node (the calls already executed — retries would
+  re-run side effects).
+
+### `script` — embedded script with host bindings
+
+Runs inline JS or Lua source on the bound `agent.ScriptRuntime`. Decoding is
+strict: unknown top-level config fields are errors.
+
+| Config field | Meaning                                                                                           |
+| ------------ | ------------------------------------------------------------------------------------------------- |
+| `runtime`    | name of the wired `agent.ScriptRuntime` (must equal the engine's `script_runtime_name`); required |
+| `source`     | inline script source; required (may be `{file: ...}` / `{embed: ...}`)                            |
+| `name`       | execution label for errors and runtime pooling; defaults to the node ID                           |
+| `config`     | becomes the script's `config` global; values may carry `${board.*}` references                    |
+
+Each invocation assembles a fresh script environment with the standard
+bridges below, executes the source, and maps control signals to Go errors.
+Subscriptions opened mid-script are bound to the invocation and never
+outlive it.
+
+## Script bridges
+
+Scripts never touch the Go context directly; the node exposes named globals
+through `core/agent/bindings` (plus three graph-layer bridges). Availability
+depends on the engine's deps:
+
+| Global      | Wired when                              | Provides                             |
+| ----------- | --------------------------------------- | ------------------------------------ |
+| `board`     | always                                  | read/write board vars and channels   |
+| `expr`      | always                                  | evaluate expr-lang expressions       |
+| `host`      | always                                  | publish/emit/interrupt/askUser/usage |
+| `run`       | always                                  | read-only run identity               |
+| `node`      | always                                  | current graph node identity          |
+| `tools`     | `tools` dep                             | call tools / list catalog            |
+| `inference` | `inference` and/or `router` dep         | LLM generation, routing, streaming   |
+| `stream`    | always (needs a host with an event bus) | subscribe to node stream deltas      |
+| `parallel`  | always (active during parallel waves)   | cancel sibling branches              |
+| `fs`        | `workspace` dep                         | workspace file operations            |
+| `shell`     | `sandbox` dep                           | sandboxed command execution          |
+| `runtime`   | always                                  | nested sub-script execution          |
+
+### `board`
+
+Direct read/write of the engine board.
+
+| Method                           | Signature                                                         |
+| -------------------------------- | ----------------------------------------------------------------- |
+| `board.getVar(key)`              | `any`                                                             |
+| `board.setVar(key, value)`       | —                                                                 |
+| `board.deleteVar(key)`           | —                                                                 |
+| `board.getVars()`                | `map`                                                             |
+| `board.hasVar(key)`              | `bool`                                                            |
+| `board.channel(name)`            | `array` of message objects (never null)                           |
+| `board.setChannel(name, msgs)`   | throws on validation errors                                       |
+| `board.appendChannel(name, msg)` | throws on validation errors                                       |
+| `board.MAIN_CHANNEL`             | the reserved default channel name (use it instead of the literal) |
+
+Messages use the inference wire format: `{role, content: {parts: [...]}}`
+with parts like `{"type": "text", "text": "..."}` or
+`{"type": "image", "source": {...}}`. Decoding is strict, so typos surface
+as errors.
+
+```js
+board.setVar("plan", "1. read files\n2. summarize");
+board.appendChannel(board.MAIN_CHANNEL, {
+  role: "user",
+  content: { parts: [{ type: "text", text: "go" }] },
+});
+```
+
+### `expr`
+
+Evaluates expr-lang against an environment map (compiled programs are LRU
+cached).
+
+```js
+var ok = expr.eval("score > 0.5 && !done", { score: 0.8, done: false });
+```
+
+### `host`
+
+The script-side handle onto `agent.Host`. Every method returns nil / `""` on
+a no-op host, so scripts can call them unconditionally.
+
+| Method                                            | Signature                                             |
+| ------------------------------------------------- | ----------------------------------------------------- |
+| `host.publish(subject, payload)`                  | `error` — low-level escape hatch to any event subject |
+| `host.emit(type, payload)`                        | void — per-node stream delta                          |
+| `host.checkInterrupt()`                           | `{cause, detail} \| null`                             |
+| `host.askUser({parts, schema, source, metadata})` | `{parts, metadata}`                                   |
+| `host.reportUsage({input, output, total})`        | `error`                                               |
+
+`host.emit` event types recognized by the graph script node:
+
+| Type          | Payload                                      | Resulting delta                |
+| ------------- | -------------------------------------------- | ------------------------------ |
+| `token`       | string (or any value, JSON-stringified)      | text part delta                |
+| `tool_call`   | JSON string or `{id, name, arguments}`       | tool call part delta           |
+| `tool_result` | `{tool_call_id, content, is_error}`          | tool result part delta         |
+| `part`        | canonical part wire object (`{"type": ...}`) | arbitrary `message.Part` delta |
+| anything else | —                                            | passthrough delta of that type |
+
+Emission is fire-and-forget: publish failures are dropped, not thrown.
+
+### `run`
+
+Read-only run identity, sourced from the ambient `RunInfo`. All getters
+return `""` when unset, so scripts can branch on absence directly.
+
+| Method                    | Returns                                  |
+| ------------------------- | ---------------------------------------- |
+| `run.get_run_id()`        | run id                                   |
+| `run.get_task_id()`       | task id                                  |
+| `run.get_agent_id()`      | agent id                                 |
+| `run.get_context_id()`    | conversation id                          |
+| `run.get_parent_run_id()` | parent run id (empty for top-level runs) |
+
+### `node`
+
+Per-step identity of the executing graph node (distinct from `run`, which is
+immutable across a whole run).
+
+| Method        | Returns                         |
+| ------------- | ------------------------------- |
+| `node.id()`   | the node's ID in the definition |
+| `node.type()` | the registered node type name   |
+
+### `tools`
+
+Script-callable facade over the tool dispatcher/catalog pair, with an
+allow-list set by the host (`WithAllowedToolNames` / `WithToolAllowAll`). By
+default **no** tool is callable.
+
+| Method                                         | Signature                                                      |
+| ---------------------------------------------- | -------------------------------------------------------------- |
+| `tools.call(name, argumentsJSON)`              | `{content, is_error, tool_call_id}`                            |
+| `tools.callAll([{name, arguments, id?}, ...])` | same shape per entry, plus `name`; batch via the dispatcher    |
+| `tools.list()`                                 | `[names]` the script is allowed to call                        |
+| `tools.definitions()`                          | wire-ready tool declarations to splice into a generate request |
+
+Denied entries get an `is_error` result in place; the rest of the batch
+still runs. A model-issued `id` passed to `callAll` is forwarded verbatim,
+which is required when results feed back into an LLM turn.
+
+### `inference`
+
+LLM generation from scripts. Requests/responses are the canonical
+`GenerateRequest` / `GenerateResponse` wire JSON; the bridge performs
+exactly one call per invocation, so multi-turn tool loops live in
+script-land (check `finish_reason`, call the message's tool parts via
+`tools.callAll`, continue with `input.role = "tool"`).
+
+| Method                                                                       | Behavior                                                                |
+| ---------------------------------------------------------------------------- | ----------------------------------------------------------------------- |
+| `inference.generate(request)`                                                | exact model (`model` key required) via the assembly                     |
+| `inference.route(request)`                                                   | router-selected target (no `model` key); response gains `trace`         |
+| `inference.explain(request)`                                                 | preflight against one exact model, no provider I/O                      |
+| `inference.routeExplain(request)`                                            | preflight through the router; returns `{explanation, decision, limits}` |
+| `inference.models()`                                                         | full catalog of model descriptors                                       |
+| `inference.inspect(model)`                                                   | one model's descriptor                                                  |
+| `inference.embed(request)` / `inference.routeEmbed(request)`                 | embedding twins of generate/route                                       |
+| `inference.explainEmbed(request)` / `inference.routeExplainEmbed(request)`   | embedding twins of explain/routeExplain                                 |
+| `inference.explainStream(request)` / `inference.routeExplainStream(request)` | local stream preflight without opening a provider stream                |
+| `inference.stream(request)` / `inference.routeStream(request)`               | streaming twins returning `{next, result, close}`                       |
+
+Stream handle: `next()` returns one event or `null` at EOF, `result()`
+returns the accumulated `GenerateResponse` after `next()` returned `null`,
+and `close()` abandons a stream early (idempotent).
+
+Extensions ride a bridge-level `extensions` array of
+`{provider, id, fields}`, resolved through decoders the host registered
+with `WithExtensionDecoder`; unregistered identities fail.
+
+```js
+var resp = inference.route({
+  context: board.channel(board.MAIN_CHANNEL).slice(0, -1),
+  input: {
+    role: "user",
+    content: {
+      content: "summarize the workspace",
+      intent: { text: { tools: tools.definitions() } },
+    },
+  },
+});
+if (resp.finish_reason === "tool_calls") {
+  // pull tool_call parts off resp.message, call tools.callAll, loop
+}
+```
+
+### `stream`
+
+Node stream subscriptions over the run's event bus. Subscriptions are
+scoped to the script invocation and closed automatically when it ends or
+when every subscribed node has terminated.
+
+| Method                                                                | Signature                                                             |
+| --------------------------------------------------------------------- | --------------------------------------------------------------------- |
+| `stream.subscribe_node({node_id \| node_ids, run_id?, buffer_size?})` | `{next, next_timeout_ms, current, close}`                             |
+| `iter.next()`                                                         | `bool` — blocks for the next matching event                           |
+| `iter.next_timeout_ms(ms)`                                            | `(bool, error)` — bounded wait; timeout returns false without closing |
+| `iter.current()`                                                      | latest event map, or null                                             |
+| `iter.close()`                                                        | idempotent early close                                                |
+
+Options: `node_id` and `node_ids` are mutually exclusive; `run_id` must
+match the current run (overrides are rejected); `buffer_size` is 1..4096,
+default 256, with `DropOldest` backpressure so slow scripts still see
+terminal lifecycle events.
+
+Each event is a map with `event`, `envelope_id`, `id`, `subject`, `time`,
+`run_id`, `node_id`, `agent_id`, plus payload fields. Lifecycle events are
+`step.started` / `step.ended` (status `success` or `error`) /
+`step.skipped`; stream deltas arrive as `event: "stream.delta"` with
+`type` / `part` / `speculative` / `branch_id` fields.
+
+```js
+var iter = stream.subscribe_node({ node_id: "planner" });
+while (iter.next_timeout_ms(5000)) {
+  var ev = iter.current();
+  if (ev.event === "step.ended") break;
+}
+iter.close();
+```
+
+### `parallel`
+
+Parallel-fork controls. The controller exists only while a parallel wave is
+in flight; outside one `cancelNode` returns `false` (fail open).
+
+| Method                                | Signature                               |
+| ------------------------------------- | --------------------------------------- |
+| `parallel.cancelNode(nodeID, reason)` | `bool` — true if a branch was cancelled |
+
+### `fs`
+
+Workspace file operations (wired when the engine has a `workspace` dep; the
+workspace's own scoping/deny rules apply).
+
+| Method                    | Signature         |
+| ------------------------- | ----------------- |
+| `fs.read(path)`           | `(string, error)` |
+| `fs.write(path, content)` | `error`           |
+| `fs.exists(path)`         | `bool`            |
+| `fs.delete(path)`         | `error`           |
+
+### `shell`
+
+Sandboxed command execution (wired when the engine has a `sandbox` dep).
+Returns a result map instead of throwing on non-zero exits.
+
+| Method                     | Signature                     |
+| -------------------------- | ----------------------------- |
+| `shell.exec(cmd, args...)` | `{exit_code, stdout, stderr}` |
+
+The host may restrict commands with `WithAllowedCommands`; a rejected
+command returns `exit_code: -1` with an error in `stderr`.
+
+### `runtime`
+
+Nested script execution. Child scripts inherit the parent's final bindings;
+the child's `config` global is the second argument.
+
+| Method                               | Signature                                             |
+| ------------------------------------ | ----------------------------------------------------- |
+| `runtime.execScript(source, config)` | `(signal, error)` — error signals throw in the parent |
+
+Nested execution is a runtime capability, not a guarantee: a pool with one
+busy VM degrades to a `not_available` signal instead of panicking.
+
+## Example
+
+```json
+{
+  "name": "assistant",
+  "entry": "chat",
+  "nodes": [
+    {
+      "id": "chat",
+      "type": "inference",
+      "config": {
+        "messages_channel": "main",
+        "tool_pending_key": "tool_pending",
+        "tools": ["read_file", "list_dir", "grep"]
+      }
+    },
+    {
+      "id": "tools",
+      "type": "tool",
+      "config": {
+        "messages_channel": "main",
+        "results_key": "tool_results"
+      }
+    },
+    {
+      "id": "finalize",
+      "type": "script",
+      "config": {
+        "runtime": "js",
+        "source": { "file": "./nodes/finalize.js" }
+      }
+    }
+  ],
+  "edges": [
+    { "from": "chat", "to": "tools", "condition": "tool_pending == true" },
+    { "from": "tools", "to": "chat" },
+    { "from": "chat", "to": "finalize", "condition": "tool_pending == false" },
+    { "from": "finalize", "to": "__end__" }
+  ]
+}
+```
+
+```js
+// nodes/finalize.js
+var last = board.channel(board.MAIN_CHANNEL).at(-1);
+board.setVar("summary", last.content.parts[0].text);
+host.emit("token", "done: " + run.get_run_id());
+```
+
+## Sources of truth
+
+`core/graph/definition.go`, `core/graph/graph.go`, `core/graph/execute.go`,
+`core/graph/nodes/inference.go`, `core/graph/nodes/tool.go`,
+`core/graph/nodes/script/`, `core/graph/resource/resource.go`,
+`core/agent/bindings/`.

--- a/skills/flowcraft-config/SKILL.md
+++ b/skills/flowcraft-config/SKILL.md
@@ -7,7 +7,7 @@ description: Author, validate, and troubleshoot complete FlowCraft deployment co
 
 Write complete FlowCraft deployment configuration: `deploy.yaml`, the
 `runtime` section, resource sub-documents, and graph JSON. Validate with
-the L2 dry-run harness and fix build failures against the reference cards.
+the L2 structural validator and fix errors against the reference cards.
 
 ## Workflow
 
@@ -22,38 +22,50 @@ the L2 dry-run harness and fix build failures against the reference cards.
    (`infer` vs `ws/project`).
 3. **Write sub-documents.** Read
    [references/resources.md](references/resources.md) for the owning
-   module's schema. Workspace before sandbox (sandbox deps a workspace
-   registry). Memory implementation modules are app-registered and the
-   concrete memory implementations are app-registered — omit
-   implementation examples; `core/memory` contracts and hooks are fine to use.
+   module's schema. Workspace before sandbox (custom sandbox runners may
+   depend on workspace resources). Memory implementation modules are
+   app-registered — omit implementation examples; `core/memory` contracts
+   and hooks are fine to use.
 4. **Write graph JSON.** Read [references/graph.md](references/graph.md).
    Model refs must use the nested `id` form; script nodes need `runtime`
    and `source`; wire edges back to the inference node after tool nodes.
-5. **Validate with L2.** Run
+5. **Validate structurally with L2.** Run
    `skills/flowcraft-config/scripts/validate-config.sh <deployment-file>`
    (or the installed copy's script). The validator pins the FlowCraft
-   module versions in its `go.mod` and works standalone from any
-   directory. It parses every sub-document, dry-builds the deployment
-   through the real `core/deploy` assembly with first-party factories
-   and stub secrets, decodes graph node configs statically, and
-   cross-checks the runtime section. It never reads real credentials and
-   never calls providers.
+   core module in its `go.mod` and works standalone from any directory.
+   It is structural only: it strictly decodes the document through
+   `core/deploy.Parse` (unknown fields are rejected, resource/agent
+   entries are shape-checked), strictly decodes and validates the
+   `runtime` subtree through `core/runtime.DecodeConfig` when present,
+   and structurally validates graph definitions through
+   `core/graph.GraphDefinition.Validate`. It does not build resources:
+   no factory registry, no settings `file`/`embed` resolution, no node
+   config decoding, no credentials, and no provider calls. Custom and
+   app-registered kinds pass as long as they fit the resource envelope;
+   their settings semantics are the host build's job.
 
    Sub-documents can also be validated on their own:
    `validate-config.sh --type inference inference.yaml` (types:
    `deploy`, `inference`, `workspace`, `sandbox`, `tool`, `graph`,
-   `agent`). Standalone checks use each module's real parser; graph and
-   inference additionally run their semantic checks (node config decode,
-   route targets against the provider catalog).
+   `agent`). Standalone types are parsed as JSON/YAML with strict YAML
+   conversion (duplicate keys rejected, single document enforced);
+   `graph` additionally runs `GraphDefinition.Validate` (unique node
+   ids, entry presence, edge endpoints). No sub-document schema is
+   decoded in standalone mode — `inference`, `workspace`, `sandbox`,
+   `tool`, and `agent` are syntax checks only.
 6. **Fix errors.** Each failure is prefixed `[parse]`, `[graph]`,
-   `[build]`, or `[runtime]`; the build short-circuits on the first error.
+   or `[build]` (`[parse]` input/syntax errors, `[graph]` graph
+   definition errors, `[build]` deploy document or runtime subtree
+   errors); validation stops at the first error.
    Consult [references/pitfalls.md](references/pitfalls.md) for the
-   error → cause map. Treat `warnings:` as review items: scope notes name
-   app-registered kinds the harness cannot construct, and tool allow-list
-   warnings flag names missing from the built catalog.
-7. **Hand off.** Report what was assembled, what L2 could not validate
-   (app-registered kinds/hooks/sources), and the registration code the
-   host still needs. If the deployment relies on runtime agent
+   error → cause map. The validator prints no warnings: custom and
+   app-registered kinds pass structurally, and settings semantics it
+   cannot check are the host build's responsibility.
+7. **Hand off.** Report the structural validation result and what L2
+   could not verify: settings schemas, factory resolution, `file`/`embed`
+   references, and graph node configs are validated only when the host
+   builds the deployment with its own registry. Note the registration
+   code the host still needs. If the deployment relies on runtime agent
    registration, call out that it needs the live registry API
    (`Runtime.RegisterAgent` / `UnregisterAgent`; see
    [references/runtime.md](references/runtime.md)) and any
@@ -61,11 +73,18 @@ the L2 dry-run harness and fix build failures against the reference cards.
 
 ## Cross-file invariants
 
+These invariants describe core semantics. The validator enforces the
+structural subset (see step 5); the rest are enforced when the host
+builds the deployment with its own factory registry.
+
 - Memory hooks bind a whole `memory.Assembly` resource; the settings
   schema is impl-owned. Concrete implementations are app-registered.
-- Sandbox resources need `deps: {workspaces: <workspace resource>}`.
-- `runtime.event_bus` is required when a `runtime` section exists; every
-  runtime resource/integration dep name must be an exact resource key.
+- Sandbox runners are `sandbox.Runner` resources; first-party impls
+  (`local`, `bwrap`, `seatbelt`) take no deps, custom impls declare
+  their own.
+- `runtime.event_bus` is required when a `runtime` section exists, and
+  `event_bus`/`checkpoint_store`/`dynamic_catalog.tools` values must name
+  resources in the document (the host build resolves them by contract).
 - `sessions.resume: true` requires `checkpoint_store`.
 - Agent `tools` is an allow-list, not a catalog declaration; `policy` is
   harness state, not engine settings.
@@ -84,12 +103,12 @@ workflow.
 ## Compatibility and versioning
 
 One skill version pins one FlowCraft version. The validator's `go.mod`
-requires `github.com/GizClaw/flowcraft/core v0.1.11` plus the relevant
-`driver/*` and `backends/*` modules; the schema cards in this skill
-document exactly that release. When FlowCraft releases a new version,
-bump the pins and reconcile the cards in the same change. The L2 harness
-registers the first-party surface only; document anything app-registered
-in the handoff.
+requires exactly `github.com/GizClaw/flowcraft/core v0.1.13`; the schema
+cards in this skill document that release (no `driver/*` or `backends/*`
+modules are required, since the validator never constructs factories).
+When FlowCraft releases a new version, bump the pin and reconcile the
+cards in the same change. Custom kinds are structurally valid by design;
+their factories and settings schemas live in the host application.
 
 ## Reference index
 

--- a/skills/flowcraft-config/references/deploy.md
+++ b/skills/flowcraft-config/references/deploy.md
@@ -1,8 +1,11 @@
 # Deploy document schema
 
 Owned by `core/deploy`. `deploy.Parse` strictly decodes JSON or YAML and
-validates the document shape. Resource factories are registered explicitly
-by the host.
+validates the document shape. The L2 validator runs exactly this:
+`core/deploy.Parse` plus `core/runtime.DecodeConfig` when a `runtime`
+section exists. It does not resolve factories, settings `file`/`embed`
+references, or kind semantics — resource factories are registered
+explicitly by the host, and the host build is where those checks happen.
 
 ## Top-level
 
@@ -25,6 +28,8 @@ runtime: {<opaque, decoded strictly by core/runtime>} # optional
 
 `settings` accepts inline JSON/YAML-compatible content, `{file: path}`, or
 `{embed: name}`. A file/embed reference must be the whole settings subtree.
+The validator never resolves these references; resolution and strict
+settings decoding happen in the host build.
 
 ## Ref
 
@@ -63,15 +68,21 @@ the core schema. Agent hooks use factory kind `hook.<slot>`.
 | --- | --- | --- |
 | `event.Bus` | `memory` | `core/event` |
 | `workspace.Workspace` | `local` | `core/workspace` |
-| `sandbox.Runner` | `local` | `core/sandbox` |
+| `sandbox.Runner` | `local`, `bwrap`, `seatbelt` | `core/sandbox/{local,bwrap,seatbelt}` |
 | `inference.Provider` | `openai`, `deepseek`, `qwen`, ... | `driver/<name>` |
 | `inference.Assembly` | `unified` | `core/inference` |
+| `inference.Router` | `unified` | `core/inference/route` |
+| `tool.Registry` | `memory` | `core/tool` |
 | `tool.Source` | app/provider-specific | host/app |
 | `tool.Assembly` | `memory` | `core/tool` |
 | `agent.ScriptRuntime` | `js`, `lua` | `core/agent/scriptrt/{jsrt,luart}` |
 | `agent.Engine` | `graph` | `core/graph/resource` |
 | `delegation.Service` | `local` | `core/delegation` |
-| `agent.CheckpointStore` | workspace/sqlite | `core/agent/checkpoint/workspace`, `backends/checkpoint/sqlite` |
+| `checkpoint.Store` | `workspace` | `core/agent/checkpoint/workspace` |
+| `agent.CheckpointStore` | `sqlite` | `backends/checkpoint/sqlite` |
+
+The table is informational: the validator accepts any kind that fits the
+resource envelope, and only the host build can construct these factories.
 
 Engine dependencies must match the graph engine's declared dep names:
 `inference`, `router`, `tools`, `workspace`, `sandbox`, `script_runtime`.

--- a/skills/flowcraft-config/references/graph.md
+++ b/skills/flowcraft-config/references/graph.md
@@ -29,31 +29,219 @@ File definitions are capped at 1 MiB.
 
 ## Rules
 
-- `entry` must name a node; IDs are unique.
-- Edges target node IDs or `__end__`.
-- `condition`/`skip_condition` are expr-lang expressions over board vars.
-- Model refs require the nested `id` form.
+- `entry` must name a node; IDs are unique — `--type graph` **validator**.
+- Edges target node IDs or `__end__` — `--type graph` **validator**.
+- `condition`/`skip_condition` are expr-lang expressions over board vars —
+  compiled by the host build, not checked by the validator.
+- Model refs require the nested `id` form — node config decode at host
+  build.
 - Script nodes require `runtime` and `source`; the bound runtime must match
-  the engine's `script_runtime_name`.
+  the engine's `script_runtime_name` — host build.
+
+The validator (`--type graph`) runs `GraphDefinition.Validate` only:
+structure, node id uniqueness, entry presence, and edge endpoints. Node
+configs are not decoded, node types are not checked against a registry,
+and expressions are not compiled; those checks happen when the host
+builds the graph engine.
+
+## Engine settings (`agent.Engine/graph`)
+
+| Key | Meaning |
+| --- | --- |
+| `graph` | graph definition: literal content, `{file: ...}`, or `{embed: ...}` (required) |
+| `script_runtime_name` | name of the `agent.ScriptRuntime` dep bound to script nodes; default `js` |
+| `build.max_iterations` | cap on total node invocations per run |
+| `build.timeout` | wall-clock bound for one execute call (e.g. `1h`) |
+| `build.run_end_publish_timeout` | deadline for run-end lifecycle events |
+| `build.max_node_retries` | per-node retries before the run fails |
+| `build.parallel.enabled` | enable parallel waves |
+| `build.parallel.branch_timeout` | per-branch wall-clock bound |
+| `build.parallel.max_concurrency` | max concurrent branches |
+| `build.parallel.max_branches` | max total branches per wave |
+| `build.parallel.merge_strategy` | `first_write_wins` or `last_write_wins` |
+
+Engine deps are derived from the definition: inference needs `inference`
+(explicit `model`) and/or `router` (no `model`), tool nodes need `tools`,
+script nodes need `script_runtime`. `workspace` and `sandbox` are optional
+and unlock the script `fs` / `shell` globals.
 
 ## Node types
 
-### inference
+### `inference` — single-shot LLM generation
 
-Common config fields: `model`, `messages_channel`, `system_prompt`,
-`output_key`, `usage_key`, `tool_pending_key`, `stream`, `tools`,
-`all_tools`, `tool_choice`, `temperature`, `top_p`, `max_output_tokens`,
-`reasoning_enabled`, `reasoning_effort`, `response_format`, `extensions`.
+Runs one `Generate` call; the channel tail is the current input (role
+`user` or `tool`), and the assistant message (tool calls included) is
+appended to the same channel. The node never executes tool calls — a
+`tool_calls` finish reason is flagged onto `tool_pending_key` for edges.
 
-### tool
+| Config field | Meaning |
+| --- | --- |
+| `model` | explicit target `{id: {provider, name}, profile?}`; absent defers to the wired router |
+| `messages_channel` | board channel holding the conversation; empty means the main channel |
+| `system_prompt` | prepended system message when the context does not start with one (may be `{file: ...}` / `{embed: ...}`) |
+| `output_key` / `usage_key` / `tool_pending_key` | board vars receiving the message / usage / tool-pending flag |
+| `stream` | stream deltas incrementally; the board still gets one assembled message |
+| `tools` / `all_tools` | named catalog tools, or the catalog's entire visible set |
+| `tool_choice` | constrain when/which tools are called |
+| `temperature` / `top_p` / `max_output_tokens` | sampling knobs |
+| `reasoning_enabled` / `reasoning_effort` | reasoning switch / depth |
+| `response_format` | `text`, `json_object`, or `json_schema` (re-validated) |
+| `extensions` | provider knobs `{provider, id, fields}` |
 
-Executes pending tool calls in one batch and appends one `role=tool` message.
+### `tool` — batch tool execution
 
-### script
+Reads the `tool_call` parts off the channel tail's assistant message,
+executes the whole batch through the tool dispatcher (call ids preserved),
+and appends the results as one `role=tool` message.
 
-Runs a JS or Lua script. `runtime` names the bound `agent.ScriptRuntime`.
+| Config field | Meaning |
+| --- | --- |
+| `messages_channel` | channel whose tail holds pending tool calls; empty means the main channel |
+| `results_key` | board var receiving the raw `[]message.Result` |
+
+Allow-listing/approval policy lives in the dispatcher's middleware, not the
+node.
+
+### `script` — embedded script with host bindings
+
+Runs inline JS or Lua on the bound `agent.ScriptRuntime`. Decoding is
+strict: unknown top-level config fields are errors.
+
+| Config field | Meaning |
+| --- | --- |
+| `runtime` | name of the wired `agent.ScriptRuntime`; must equal the engine's `script_runtime_name` (required) |
+| `source` | inline script source; required (may be `{file: ...}` / `{embed: ...}`) |
+| `name` | execution label for errors/runtime pooling; defaults to the node ID |
+| `config` | becomes the script's `config` global; values may carry `${board.*}` references |
+
+## Script bridges
+
+Scripts get named globals through `core/agent/bindings` (plus three
+graph-layer bridges). Availability depends on engine deps:
+
+| Global | Wired when | Provides |
+| --- | --- | --- |
+| `board` | always | read/write vars and channels |
+| `expr` | always | eval expr-lang expressions |
+| `host` | always | publish / emit / interrupt / askUser / usage |
+| `run` | always | read-only run identity |
+| `node` | always | current graph node identity |
+| `tools` | `tools` dep | call tools / list catalog |
+| `inference` | `inference` and/or `router` dep | LLM generation / routing / streaming |
+| `stream` | always (host with event bus) | subscribe to node stream deltas |
+| `parallel` | always (during parallel waves) | cancel sibling branches |
+| `fs` | `workspace` dep | workspace file ops |
+| `shell` | `sandbox` dep | sandboxed command execution |
+| `runtime` | always | nested sub-script execution |
+
+### `board`
+
+- `getVar(key)`, `setVar(key, value)`, `deleteVar(key)`, `getVars()`,
+  `hasVar(key)`
+- `channel(name)` → message objects (never null); `setChannel(name, msgs)`,
+  `appendChannel(name, msg)` throw on validation errors
+- `MAIN_CHANNEL` — the reserved default channel constant
+
+Messages use the inference wire format `{role, content: {parts: [...]}}`;
+decoding is strict, so typos surface as errors.
+
+### `expr`
+
+`expr.eval(expression, env)` — evaluate expr-lang against an environment
+map.
+
+### `host`
+
+`host.publish(subject, payload)`, `host.emit(type, payload)`,
+`host.checkInterrupt()` → `{cause, detail} | null`,
+`host.askUser({parts, schema, source, metadata})` →
+`{parts, metadata}`, `host.reportUsage({input, output, total})`.
+Every method returns nil/`""` on a no-op host.
+
+`host.emit` event types in the graph script node: `token` (text delta),
+`tool_call` (`{id, name, arguments}`), `tool_result`
+(`{tool_call_id, content, is_error}`), `part` (canonical part wire object),
+or a passthrough type. Emission is fire-and-forget.
+
+### `run`
+
+`get_run_id()`, `get_task_id()`, `get_agent_id()`, `get_context_id()`,
+`get_parent_run_id()` — all return `""` when unset.
+
+### `node`
+
+`node.id()` (the node's ID), `node.type()` (the registered type name).
+
+### `tools`
+
+- `call(name, argumentsJSON)` → `{content, is_error, tool_call_id}`
+- `callAll([{name, arguments, id?}, ...])` → per-entry result plus `name`;
+  model-issued `id`s are forwarded verbatim
+- `list()` → allowed tool names; `definitions()` → wire-ready tool JSON
+
+By default **no** tool is callable until the host allow-lists it; denied
+entries become `is_error` results.
+
+### `inference`
+
+Requests/responses are the canonical `GenerateRequest` / `GenerateResponse`
+wire JSON; the bridge performs one call per invocation, so multi-turn tool
+loops live in script-land (`tools.callAll`, then `input.role = "tool"`).
+
+- `generate(request)` — exact model (`model` key required)
+- `route(request)` — router-selected target (no `model`); response gains
+  `trace`
+- `explain(request)` / `routeExplain(request)` — provider-less preflight
+  (exact model vs router selection); the route twin returns
+  `{explanation, decision, limits}`
+- `models()` / `inspect(model)` — model catalog / one descriptor
+- `embed(request)` / `routeEmbed(request)` — embedding twins of
+  generate/route
+- `explainEmbed(request)` / `routeExplainEmbed(request)` — embedding twins
+  of explain/routeExplain
+- `explainStream(request)` / `routeExplainStream(request)` — stream
+  preflight without opening a provider stream
+- `stream(request)` / `routeStream(request)` — streaming twins returning
+  `{next, result, close}`
+
+Extensions ride an `extensions` array of `{provider, id, fields}`, resolved
+through host-registered decoders.
+
+### `stream`
+
+`stream.subscribe_node({node_id | node_ids, run_id?, buffer_size?})` →
+`{next, next_timeout_ms, current, close}`. `node_id`/`node_ids` are
+mutually exclusive; `run_id` must match the current run; `buffer_size` is
+1..4096 (default 256, `DropOldest`). Events are maps with `event`
+(`step.started` / `step.ended` / `step.skipped` / `stream.delta`),
+`envelope_id`, `id`, `subject`, `time`, `run_id`, `node_id`, `agent_id`.
+The iterator closes when every subscribed node has terminated or the
+invocation ends.
+
+### `parallel`
+
+`parallel.cancelNode(nodeID, reason)` → `bool`; false outside a parallel
+wave.
+
+### `fs`
+
+`fs.read(path)` → `(string, error)`, `fs.write(path, content)`,
+`fs.exists(path)` → `bool`, `fs.delete(path)`.
+
+### `shell`
+
+`shell.exec(cmd, args...)` → `{exit_code, stdout, stderr}` (no throw on
+non-zero exits; a rejected command returns `exit_code: -1`).
+
+### `runtime`
+
+`runtime.execScript(source, config)` — nested sub-script with inherited
+bindings; degrades to a `not_available` signal when the runtime cannot
+nest.
 
 ## Sources of truth
 
-`core/graph/definition.go`, `core/graph/nodes/`,
-`core/graph/resource/resource.go`, `docs/guides/graph.md`.
+`core/graph/definition.go`, `core/graph/nodes/inference.go`,
+`core/graph/nodes/tool.go`, `core/graph/nodes/script/`,
+`core/graph/resource/resource.go`, `core/agent/bindings/`,
+`docs/guides/graph.md`.

--- a/skills/flowcraft-config/references/pitfalls.md
+++ b/skills/flowcraft-config/references/pitfalls.md
@@ -2,45 +2,57 @@
 
 ## Common pitfalls
 
-1. Agent engine deps belong under `engine.deps`, not top-level `agent.deps`.
-2. `runtime.event_bus` is required when `runtime` exists.
-3. `sessions.resume: true` requires `checkpoint_store`.
-4. Graph model refs must use `model: {id: {provider, name}}`.
+The validator (`validate-config.sh`) is structural only: it enforces the
+subset marked **validator**. Everything else surfaces only when the host
+builds the deployment with its own factory registry, or at runtime.
+
+1. Agent engine deps belong under `engine.deps`, not top-level
+   `agent.deps` — **validator** (unknown field).
+2. `runtime.event_bus` is required when `runtime` exists — **validator**.
+3. `sessions.resume: true` requires `checkpoint_store` — **validator**.
+4. Graph model refs must use `model: {id: {provider, name}}` — host build.
 5. Script nodes need `runtime` and `source`; `runtime` must match the bound
-   script runtime.
-6. Resource settings file/embed refs must be the whole settings subtree.
-7. Runtime buffer/concurrency settings have hard upper bounds.
-8. Dynamic catalog mappings must cover every deployed agent directly or with
-   `default`.
-9. `tool.Assembly` with dynamic injection requires at least one tool source.
+   script runtime — host build.
+6. Resource settings file/embed refs must be the whole settings subtree —
+   host build.
+7. Runtime buffer/concurrency settings have hard upper bounds —
+   **validator**.
+8. Dynamic catalog mappings must cover every deployed agent directly or
+   with `default` — host build/runtime registration.
+9. `tool.Assembly` with dynamic injection requires at least one tool
+   source — host build.
 10. Local sandbox is a no-isolation backend and should not be used for
     untrusted production execution.
 11. Runtime registration cannot reuse a deployed agent name (`Conflict`);
     deployed agents can only be removed by changing the deployment
-    document.
+    document — runtime API.
 12. With `dynamic_catalog` configured and no `default`, runtime
     registration must pass `WithToolAssembly`; otherwise registration is
-    rejected up front.
+    rejected up front — runtime API.
 13. `UnregisterAgent` waits for active turns; a stuck engine times out
     (`WithRemoveTimeout` / ctx deadline) and the agent is left registered
-    — retry, don't assume removal happened.
+    — retry, don't assume removal happened — runtime API.
 
 ## Error map
 
-| Error | Likely cause | Fix |
-| --- | --- | --- |
-| no factory for `kind/impl` | typo or missing registration | fix kind/impl and register factory |
-| dep references missing resource | bad resource name | use an exact resource key |
-| dependency cycle | circular `deps` | break the cycle |
-| undeclared dep | document dep not in `Spec.Deps` | fix dep name or factory spec |
-| `runtime config: event_bus is required` | missing runtime `event_bus` | add an `event.Bus` resource and reference |
-| `sessions.resume requires checkpoint_store` | resume enabled without store | add store or set resume false |
-| graph `unknown field "provider"` | flattened model ref | use nested `id` |
-| script node missing `runtime`/`source` | incomplete script config | add both fields |
-| dynamic catalog uncovered agent | no per-agent or default mapping | add `default` or map every agent |
-| `runtime: agent "x" is a deployed agent` | register/remove collides with a document agent | register under a new name, or change the deployment |
-| `dynamic catalog has no default; agent "x" needs WithToolAssembly` | runtime registration without a tool mapping | add `WithToolAssembly` or configure `default` |
-| removal `DeadlineExceeded` | active turn did not finish in time | wait/retry; the agent is still registered |
+| Error | Caught by | Likely cause | Fix |
+| --- | --- | --- | --- |
+| `config utils: decode ... unknown field "x"` | validator | extra field outside the document schema | remove it or use a documented field |
+| `deployment document: version is required` | validator | missing `version: v1` | add the version field |
+| `resource: kind is required` | validator | resource entry without `kind` | add `kind` |
+| `runtime config: event_bus is required` | validator | missing runtime `event_bus` | add an `event.Bus` resource and reference |
+| `sessions.resume requires checkpoint_store` | validator | resume enabled without store | add store or set resume false |
+| graph structural errors (`entry`, duplicate node id, edge to unknown node) | validator | malformed graph definition | fix the graph JSON |
+| no factory for `kind/impl` | host build | typo or missing registration | fix kind/impl and register factory |
+| dep references missing resource | host build | bad resource name | use an exact resource key |
+| dependency cycle | host build | circular `deps` | break the cycle |
+| undeclared dep | host build | document dep not in `Spec.Deps` | fix dep name or factory spec |
+| graph `unknown field "provider"` | host build | flattened model ref | use nested `id` |
+| script node missing `runtime`/`source` | host build | incomplete script config | add both fields |
+| dynamic catalog uncovered agent | host build/runtime | no per-agent or default mapping | add `default` or map every agent |
+| `runtime: agent "x" is a deployed agent` | runtime API | register/remove collides with a document agent | register under a new name, or change the deployment |
+| `dynamic catalog has no default; agent "x" needs WithToolAssembly` | runtime API | runtime registration without a tool mapping | add `WithToolAssembly` or configure `default` |
+| removal `DeadlineExceeded` | runtime API | active turn did not finish in time | wait/retry; the agent is still registered |
 
 ## Debug order
 

--- a/skills/flowcraft-config/references/resources.md
+++ b/skills/flowcraft-config/references/resources.md
@@ -1,7 +1,9 @@
 # Resource sub-documents
 
 Sub-documents are attached through `settings: {file: ...}` or inline content.
-Each factory owns its settings schema.
+Each factory owns its settings schema. Standalone `--type` validation is
+syntax-only (strict YAML conversion, single document); settings semantics
+are checked when the host build decodes them through the factory.
 
 ## inference provider
 

--- a/skills/flowcraft-config/references/runtime.md
+++ b/skills/flowcraft-config/references/runtime.md
@@ -2,7 +2,7 @@
 
 Owned by `core/runtime`. `deploy.Parse` preserves the subtree opaquely;
 `runtime.DecodeConfig` decodes it strictly. `event_bus` is required when a
-`runtime` section exists.
+`runtime` section exists (the validator enforces this).
 
 ```yaml
 runtime:
@@ -24,19 +24,24 @@ runtime:
 
 ## Rules
 
-- `event_bus` must name an `event.Bus` resource.
-- `checkpoint_store`, when present, must name an `agent.CheckpointStore`.
-- `sessions.resume: true` requires `checkpoint_store`.
+- `event_bus` must name a resource whose built value implements the
+  `event.Bus` contract (validator: field required; host build: resolves
+  the name against the built resources).
+- `checkpoint_store`, when present, must name a resource whose built
+  value implements the `agent.CheckpointStore` contract — the document
+  kind can be `checkpoint.Store` (workspace) or `agent.CheckpointStore`
+  (sqlite) (host build resolves it; the validator checks `resume` rules).
+- `sessions.resume: true` requires `checkpoint_store` — **validator**.
 - `sessions.sink_buffer`, `delivery_concurrency`,
   `speculative_buffer_events`, and `speculative_buffer_bytes` are validated
-  against hard upper bounds.
+  against hard upper bounds — **validator**.
 - `sessions.max_sessions` limits distinct live session keys.
 - `dynamic_catalog.tools` maps agent IDs to `tool.Assembly` resources; the
   reserved `default` key is an optional fallback. Every deployed agent must
-  be mapped directly or covered by `default`. The mapping is live: agents
-  registered at runtime attach a tool assembly via `WithToolAssembly`
-  (see below) or fall back to `default`.
-- Runtime references do not require an `export` flag in the core schema.
+  be mapped directly or covered by `default` (host build/runtime
+  registration; the validator only checks the map is non-empty). The
+  mapping is live: agents registered at runtime attach a tool assembly via
+  `WithToolAssembly` (see below) or fall back to `default`.
 
 ## Dynamic agent registration (core/v0.1.11+)
 

--- a/skills/flowcraft-config/scripts/validator/go.mod
+++ b/skills/flowcraft-config/scripts/validator/go.mod
@@ -2,7 +2,7 @@ module github.com/GizClaw/flowcraft/skills/flowcraft-config/scripts/validator
 
 go 1.26.0
 
-require github.com/GizClaw/flowcraft/core v0.1.11
+require github.com/GizClaw/flowcraft/core v0.1.13
 
 require (
 	github.com/cenkalti/backoff/v5 v5.0.3 // indirect

--- a/skills/flowcraft-config/scripts/validator/go.sum
+++ b/skills/flowcraft-config/scripts/validator/go.sum
@@ -1,5 +1,5 @@
-github.com/GizClaw/flowcraft/core v0.1.11 h1:C71H9TYpXszPl50Pq1+Pev4ITtjxC6OwsGy/v3s0Wns=
-github.com/GizClaw/flowcraft/core v0.1.11/go.mod h1:t4e1E55RSCsZTDGLCKLeg0Qags72Y2Yz2ZtL3EyGy1k=
+github.com/GizClaw/flowcraft/core v0.1.13 h1:Ld0Kmxr3GPsDFwX3sb8bKDeznjiJKgMm2I6yZiDJTSk=
+github.com/GizClaw/flowcraft/core v0.1.13/go.mod h1:t4e1E55RSCsZTDGLCKLeg0Qags72Y2Yz2ZtL3EyGy1k=
 github.com/cenkalti/backoff/v5 v5.0.3 h1:ZN+IMa753KfX5hd8vVaMixjnqRZ3y8CuJKRKj1xcsSM=
 github.com/cenkalti/backoff/v5 v5.0.3/go.mod h1:rkhZdG3JZukswDf7f0cwqPNk4K0sa+F97BxZthm/crw=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=


### PR DESCRIPTION
## Summary

Two documentation changes:

### docs(core): graph node types and script bridges
`docs/guides/graph.md` rewritten from a stub into a full reference:
- engine settings (`graph`, `script_runtime_name`, `build.*` incl. parallel knobs)
- per-node config tables for `inference` / `tool` / `script` with behavior semantics
- all 12 script bridges (`board`, `expr`, `host`, `run`, `node`, `tools`, `inference`, `stream`, `parallel`, `fs`, `shell`, `runtime`) with method signatures, `host.emit` event types, and stream subscription semantics
- a complete runnable graph example (validated with the skill validator)

### docs(skills): align flowcraft-config skill
- rewrite `skills/flowcraft-config/references/graph.md` with the same node/bridge detail
- align SKILL.md and reference cards with the validator's real behavior: structural-only validation via `core/deploy.Parse` + `core/runtime.DecodeConfig` + `core/graph.GraphDefinition.Validate` (no dry-build, no factory registry, no settings resolution)
- fix stale core facts: sandbox runner deps, `checkpoint.Store` vs `agent.CheckpointStore`, `tool.Registry`, `inference.Router`, runtime ref checks
- error map split into validator-caught vs host-build/runtime errors
- bump the skill validator pin from core v0.1.11 → v0.1.13 and document the full latest `inference` bridge surface (explain/routeExplain/models/inspect/embed twins)

## Verification
- `make ci`, `make lint` (0 issues), `make release-check` all pass
- validator rebuilt against core v0.1.13; regression checks on minimal-deploy, opencraft.yaml, and graph examples pass; error prefixes unchanged
- installed skill copies (`~/.codex/skills`, `~/.agents/skills`) synced with the repo copy