### PR TITLE
feat(core): add runtime generation reload with multi-bus router

### DIFF
--- a/core/deploy/builder.go
+++ b/core/deploy/builder.go
@@ -72,27 +72,27 @@ func (b *Builder) Build(ctx context.Context, doc Document) (*Result, error) {
 		res := doc.Resources[name]
 		factory, ok := b.registry.Lookup(res.Kind, res.Impl)
 		if !ok {
-			_ = closeAll(values, order)
+			_ = closeAll(values, order, nil)
 			return nil, errdefs.Validationf(
 				"deploy: resource %q: no factory for %s/%s",
 				name, res.Kind, res.Impl)
 		}
 		if err := validateDeps(factory, res.Deps); err != nil {
-			_ = closeAll(values, order)
+			_ = closeAll(values, order, nil)
 			return nil, errdefs.Validationf("deploy: resource %q: %v", name, err)
 		}
 		settings := res.Settings
 		if b.loader != nil {
 			settings, err = resolveSettings(ctx, b.loader, settings)
 			if err != nil {
-				_ = closeAll(values, order)
+				_ = closeAll(values, order, nil)
 				return nil, errdefs.Validationf(
 					"deploy: resource %q: %v", name, err)
 			}
 		}
 		deps, err := resolveDeps(values, res.Deps)
 		if err != nil {
-			_ = closeAll(values, order)
+			_ = closeAll(values, order, nil)
 			return nil, errdefs.Validationf("deploy: resource %q: %v", name, err)
 		}
 		value, err := factory.New(ctx, resource.Input{
@@ -101,7 +101,7 @@ func (b *Builder) Build(ctx context.Context, doc Document) (*Result, error) {
 			Loader:   b.loader,
 		})
 		if err != nil {
-			_ = closeAll(values, order)
+			_ = closeAll(values, order, nil)
 			return nil, errdefs.Validationf("deploy: resource %q: %v", name, err)
 		}
 		values[name] = value
@@ -483,9 +483,35 @@ func resolveDeps(values map[string]any, deps resource.Deps) (map[string]any, err
 // Result owns the built resource values in construction order.
 // The caller closes it (or the runtime layer closes it) when done.
 type Result struct {
-	values map[string]any
-	order  []string
-	agents map[string]*agent.Agent
+	values   map[string]any
+	order    []string
+	agents   map[string]*agent.Agent
+	detached map[string]struct{}
+}
+
+// Detach marks resource names as caller-owned: Result.Close will not
+// close them, and the caller takes over their lifecycle. It is used by
+// the runtime to reject a reload whose event bus factory returned the
+// current generation's bus without letting the aborted result close a
+// bus another generation still uses.
+func (r *Result) Detach(names ...string) {
+	if r == nil || len(names) == 0 {
+		return
+	}
+	if r.detached == nil {
+		r.detached = make(map[string]struct{}, len(names))
+	}
+	for _, name := range names {
+		r.detached[name] = struct{}{}
+	}
+}
+
+func (r *Result) isDetached(name string) bool {
+	if r == nil || r.detached == nil {
+		return false
+	}
+	_, ok := r.detached[name]
+	return ok
 }
 
 // Value returns the built resource registered under name.
@@ -527,7 +553,7 @@ func (r *Result) Close() error {
 		return nil
 	}
 	var errs []error
-	if err := closeAll(r.values, r.order); err != nil {
+	if err := closeAll(r.values, r.order, r); err != nil {
 		errs = append(errs, err)
 	}
 	for _, name := range r.AgentNames() {
@@ -542,10 +568,14 @@ func (r *Result) Close() error {
 	return errors.Join(errs...)
 }
 
-func closeAll(values map[string]any, order []string) error {
+func closeAll(values map[string]any, order []string, result *Result) error {
 	var errs []error
 	for i := len(order) - 1; i >= 0; i-- {
-		value, ok := values[order[i]]
+		name := order[i]
+		if result != nil && result.isDetached(name) {
+			continue
+		}
+		value, ok := values[name]
 		if !ok {
 			continue
 		}

--- a/core/deploy/close_internal_test.go
+++ b/core/deploy/close_internal_test.go
@@ -18,6 +18,7 @@ func TestCloseAllJoinsErrors(t *testing.T) {
 			"b": closeErr{err: second},
 		},
 		[]string{"a", "b"},
+		nil,
 	)
 	if err == nil {
 		t.Fatal("closeAll returned nil, want joined errors")

--- a/core/event/router.go
+++ b/core/event/router.go
@@ -2,6 +2,7 @@ package event
 
 import (
 	"context"
+	"strconv"
 	"sync"
 
 	"github.com/GizClaw/flowcraft/core/errdefs"
@@ -71,23 +72,31 @@ func WithAttachBackpressure(p BackpressurePolicy) AttachOption {
 }
 
 // WithOnDetach registers a callback invoked when the attachment stops
-// because its sink returned an error. It is NOT called for Close or
-// context cancellation.
+// because its sink returned an error. It is NOT called for Close,
+// context cancellation, or RemoveBus.
 func WithOnDetach(fn func(error)) AttachOption {
 	return func(o *attachOptions) { o.onDetach = fn }
 }
 
 // Router is the generalized subscription fan-out primitive: it
-// subscribes patterns on a [Bus] and delivers matching envelopes to
-// attached [Sink]s. It is what the agent stream router used to be,
-// minus the agent-specific delta decoding — session streaming,
-// dashboards, and any multi-consumer subscription build on it.
+// subscribes patterns on one or more [Bus]es and delivers matching
+// envelopes to attached [Sink]s. It is what the agent stream router
+// used to be, minus the agent-specific delta decoding — session
+// streaming, dashboards, and any multi-consumer subscription build on
+// it.
+//
+// A Router is multi-bus: the runtime attaches one bus per deployment
+// generation, so subscriptions survive generation reloads while each
+// generation's events stay on its own bus. [Router.AddBus] and
+// [Router.RemoveBus] manage the set; RemoveBus drops the subscriptions
+// on that bus without affecting attachments subscribed to other buses.
+// Bus implementations must be comparable (use pointer receivers).
 type Router struct {
-	bus Bus
-
 	mu          sync.Mutex
 	closed      bool
-	attachments map[SubscriptionID]*routerAttachment
+	buses       map[Bus]struct{}
+	attachments map[string]*routerAttachment
+	nextID      uint64
 	wg          sync.WaitGroup
 
 	attachBackpressure    BackpressurePolicy
@@ -100,8 +109,8 @@ func NewRouter(bus Bus, opts ...RouterOption) *Router {
 		panic("event.NewRouter: bus is nil")
 	}
 	r := &Router{
-		bus:         bus,
-		attachments: make(map[SubscriptionID]*routerAttachment),
+		buses:       map[Bus]struct{}{bus: {}},
+		attachments: make(map[string]*routerAttachment),
 	}
 	routerOpts := routerOptions{}
 	for _, opt := range opts {
@@ -112,6 +121,93 @@ func NewRouter(bus Bus, opts ...RouterOption) *Router {
 	r.attachBackpressure = routerOpts.attachBackpressure
 	r.attachBackpressureSet = routerOpts.attachBackpressureSet
 	return r
+}
+
+// AddBus subscribes every existing attachment to an additional bus.
+// Envelopes published on bus are delivered to every attachment that
+// was attached before or after the call. AddBus is all-or-nothing: if
+// any subscription fails, the bus is not attached and every
+// subscription already opened for it is closed. AddBus after Close
+// fails with NotAvailable; nil bus is a validation error.
+func (r *Router) AddBus(bus Bus) error {
+	if r == nil {
+		return errdefs.Validationf("event router: AddBus on nil router")
+	}
+	if bus == nil {
+		return errdefs.Validationf("event router: AddBus requires a bus")
+	}
+
+	r.mu.Lock()
+	if r.closed {
+		r.mu.Unlock()
+		return errdefs.NotAvailablef("event router: closed")
+	}
+	if _, exists := r.buses[bus]; exists {
+		r.mu.Unlock()
+		return errdefs.Conflictf("event router: bus already attached")
+	}
+	var subs []*busSub
+	for _, a := range r.attachments {
+		sub, err := bus.Subscribe(a.ctx, a.pattern, a.subOpts...)
+		if err != nil {
+			for _, bs := range subs {
+				_ = bs.sub.Close()
+			}
+			r.mu.Unlock()
+			return err
+		}
+		bs := &busSub{attachment: a, bus: bus, sub: sub, ctx: a.ctx}
+		a.subs = append(a.subs, bs)
+		subs = append(subs, bs)
+	}
+	r.buses[bus] = struct{}{}
+	// Register the goroutines under the lock so a concurrent Close can
+	// never observe a zero counter while AddBus is still adding.
+	r.wg.Add(len(subs))
+	r.mu.Unlock()
+
+	for _, bs := range subs {
+		go bs.attachment.runBus(bs)
+	}
+	return nil
+}
+
+// RemoveBus detaches bus from every attachment and unsubscribes it.
+// Existing attachments keep their subscriptions on the remaining
+// buses. Removing a bus that is not attached is a no-op.
+func (r *Router) RemoveBus(bus Bus) error {
+	if r == nil || bus == nil {
+		return nil
+	}
+	r.mu.Lock()
+	if _, exists := r.buses[bus]; !exists {
+		r.mu.Unlock()
+		return nil
+	}
+	delete(r.buses, bus)
+	var closed []Subscription
+	for _, a := range r.attachments {
+		for i := len(a.subs) - 1; i >= 0; i-- {
+			if a.subs[i].bus != bus {
+				continue
+			}
+			closed = append(closed, a.subs[i].sub)
+			a.subs = append(a.subs[:i], a.subs[i+1:]...)
+		}
+	}
+	r.mu.Unlock()
+	for _, sub := range closed {
+		_ = sub.Close()
+	}
+	return nil
+}
+
+// busSub is one attachment's subscription on one bus.
+type busSub struct {
+	attachment *routerAttachment
+	bus        Bus
+	sub        Subscription
+	ctx        context.Context
 }
 
 // Attach subscribes pattern and delivers matching envelopes to sink
@@ -151,30 +247,41 @@ func (r *Router) Attach(
 		r.mu.Unlock()
 		return nil, errdefs.NotAvailablef("event router: closed")
 	}
-	r.mu.Unlock()
-
-	sub, err := r.bus.Subscribe(ctx, pattern, subOpts...)
-	if err != nil {
-		return nil, err
-	}
+	r.nextID++
 	a := &routerAttachment{
 		router:   r,
-		sub:      sub,
+		id:       "attach-" + strconv.FormatUint(r.nextID, 10),
+		ctx:      ctx,
+		pattern:  pattern,
+		subOpts:  subOpts,
 		sink:     sink,
 		onDetach: o.onDetach,
 	}
-	r.mu.Lock()
-	if r.closed {
-		r.mu.Unlock()
-		_ = sub.Close()
-		return nil, errdefs.NotAvailablef("event router: closed")
+	r.attachments[a.id] = a
+	var subs []*busSub
+	for bus := range r.buses {
+		sub, err := bus.Subscribe(ctx, pattern, subOpts...)
+		if err != nil {
+			for _, bs := range subs {
+				_ = bs.sub.Close()
+			}
+			delete(r.attachments, a.id)
+			r.mu.Unlock()
+			return nil, err
+		}
+		bs := &busSub{attachment: a, bus: bus, sub: sub, ctx: ctx}
+		a.subs = append(a.subs, bs)
+		subs = append(subs, bs)
 	}
-	r.attachments[sub.ID()] = a
+	// Register the goroutines under the lock so a concurrent Close can
+	// never observe a zero counter while Attach is still adding.
+	r.wg.Add(len(subs))
 	r.mu.Unlock()
 
-	r.wg.Add(1)
-	go a.run(ctx)
-	return func() { r.detach(a) }, nil
+	for _, bs := range subs {
+		go a.runBus(bs)
+	}
+	return func() { r.detach(a, nil) }, nil
 }
 
 // Close tears down every attachment and waits for their loops to
@@ -186,52 +293,95 @@ func (r *Router) Close() error {
 		return nil
 	}
 	r.closed = true
-	attachments := r.attachments
-	r.attachments = make(map[SubscriptionID]*routerAttachment)
+	r.buses = make(map[Bus]struct{})
+	var subs []Subscription
+	for _, a := range r.attachments {
+		for _, bs := range a.subs {
+			subs = append(subs, bs.sub)
+		}
+		a.subs = nil
+	}
+	r.attachments = make(map[string]*routerAttachment)
 	r.mu.Unlock()
 
-	for _, a := range attachments {
-		_ = a.sub.Close()
+	for _, sub := range subs {
+		_ = sub.Close()
 	}
 	r.wg.Wait()
 	return nil
 }
 
-func (r *Router) detach(a *routerAttachment) {
-	r.mu.Lock()
-	delete(r.attachments, a.sub.ID())
-	r.mu.Unlock()
-	_ = a.sub.Close()
+// detach removes the attachment from the router, closes every
+// remaining bus subscription, and reports cause through onDetach when
+// non-nil. Idempotent.
+func (r *Router) detach(a *routerAttachment, cause error) {
+	a.closeOnce.Do(func() {
+		r.mu.Lock()
+		delete(r.attachments, a.id)
+		subs := a.subs
+		a.subs = nil
+		r.mu.Unlock()
+		for _, bs := range subs {
+			_ = bs.sub.Close()
+		}
+		if cause != nil && a.onDetach != nil {
+			a.onDetach(cause)
+		}
+	})
 }
 
 type routerAttachment struct {
 	router   *Router
-	sub      Subscription
+	id       string
+	ctx      context.Context
+	pattern  Pattern
+	subOpts  []SubOption
 	sink     Sink
 	onDetach func(error)
+
+	subs      []*busSub // guarded by router.mu
+	closeOnce sync.Once
 }
 
-func (a *routerAttachment) run(ctx context.Context) {
+// runBus delivers envelopes from one bus subscription to the
+// attachment's sink. A subscription closed because RemoveBus or Close
+// removed it exits quietly; one closed while still attached means the
+// bus died and detaches the whole attachment.
+func (a *routerAttachment) runBus(bs *busSub) {
 	defer a.router.wg.Done()
 	for {
 		select {
-		case env, ok := <-a.sub.C():
+		case env, ok := <-bs.sub.C():
 			if !ok {
-				a.router.detach(a)
+				a.subEnded(bs)
 				return
 			}
-			if err := a.sink.OnEnvelope(ctx, env); err != nil {
-				a.router.detach(a)
-				if a.onDetach != nil {
-					a.onDetach(err)
-				}
+			if err := a.sink.OnEnvelope(bs.ctx, env); err != nil {
+				a.router.detach(a, err)
 				return
 			}
-		case <-ctx.Done():
-			a.router.detach(a)
+		case <-bs.ctx.Done():
+			a.router.detach(a, nil)
 			return
 		}
 	}
 }
 
-var _ Sink = SinkFunc(nil)
+// subEnded handles a closed subscription channel. If the bus
+// subscription is still attached the bus itself ended (detach); if it
+// was removed by RemoveBus/Close the loop just exits.
+func (a *routerAttachment) subEnded(bs *busSub) {
+	r := a.router
+	r.mu.Lock()
+	found := false
+	for _, sub := range a.subs {
+		if sub == bs {
+			found = true
+			break
+		}
+	}
+	r.mu.Unlock()
+	if found {
+		r.detach(a, nil)
+	}
+}

--- a/core/event/router_multibus_test.go
+++ b/core/event/router_multibus_test.go
@@ -1,0 +1,167 @@
+package event_test
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/GizClaw/flowcraft/core/errdefs"
+	"github.com/GizClaw/flowcraft/core/event"
+)
+
+func publish(t *testing.T, bus event.Bus, subject string) {
+	t.Helper()
+	if err := bus.Publish(context.Background(), event.Envelope{
+		Subject: event.Subject(subject),
+	}); err != nil {
+		t.Fatalf("Publish(%s): %v", subject, err)
+	}
+}
+
+func TestRouterAddBusDeliversToExistingAttachments(t *testing.T) {
+	bus1 := event.NewMemoryBus()
+	t.Cleanup(func() { _ = bus1.Close() })
+	router := event.NewRouter(bus1)
+	t.Cleanup(func() { _ = router.Close() })
+
+	sink := &captureSink{}
+	stop, err := router.Attach(context.Background(),
+		event.Pattern("test.multi.*"), sink)
+	if err != nil {
+		t.Fatalf("Attach: %v", err)
+	}
+	t.Cleanup(stop)
+
+	bus2 := event.NewMemoryBus()
+	t.Cleanup(func() { _ = bus2.Close() })
+	if err := router.AddBus(bus2); err != nil {
+		t.Fatalf("AddBus: %v", err)
+	}
+	publish(t, bus2, "test.multi.two")
+	waitFor(t, func() bool { return sink.count() == 1 })
+}
+
+func TestRouterRemoveBusStopsDeliveryFromThatBus(t *testing.T) {
+	bus1 := event.NewMemoryBus()
+	t.Cleanup(func() { _ = bus1.Close() })
+	bus2 := event.NewMemoryBus()
+	t.Cleanup(func() { _ = bus2.Close() })
+	router := event.NewRouter(bus1)
+	t.Cleanup(func() { _ = router.Close() })
+	if err := router.AddBus(bus2); err != nil {
+		t.Fatalf("AddBus: %v", err)
+	}
+
+	sink := &captureSink{}
+	stop, err := router.Attach(context.Background(),
+		event.Pattern("test.multi.*"), sink)
+	if err != nil {
+		t.Fatalf("Attach: %v", err)
+	}
+	t.Cleanup(stop)
+
+	publish(t, bus1, "test.multi.one")
+	publish(t, bus2, "test.multi.two")
+	waitFor(t, func() bool { return sink.count() == 2 })
+
+	if err := router.RemoveBus(bus2); err != nil {
+		t.Fatalf("RemoveBus: %v", err)
+	}
+	publish(t, bus1, "test.multi.three")
+	waitFor(t, func() bool { return sink.count() == 3 })
+	publish(t, bus2, "test.multi.four")
+	time.Sleep(50 * time.Millisecond)
+	if sink.count() != 3 {
+		t.Fatalf("deliveries after RemoveBus = %d, want 3", sink.count())
+	}
+}
+
+func TestRouterAttachSubscribesEveryBus(t *testing.T) {
+	bus1 := event.NewMemoryBus()
+	t.Cleanup(func() { _ = bus1.Close() })
+	bus2 := event.NewMemoryBus()
+	t.Cleanup(func() { _ = bus2.Close() })
+	router := event.NewRouter(bus1)
+	t.Cleanup(func() { _ = router.Close() })
+	if err := router.AddBus(bus2); err != nil {
+		t.Fatalf("AddBus: %v", err)
+	}
+
+	sink := &captureSink{}
+	stop, err := router.Attach(context.Background(),
+		event.Pattern("test.multi.*"), sink)
+	if err != nil {
+		t.Fatalf("Attach: %v", err)
+	}
+	t.Cleanup(stop)
+
+	publish(t, bus1, "test.multi.one")
+	publish(t, bus2, "test.multi.two")
+	waitFor(t, func() bool { return sink.count() == 2 })
+}
+
+func TestRouterAddBusErrors(t *testing.T) {
+	bus1 := event.NewMemoryBus()
+	t.Cleanup(func() { _ = bus1.Close() })
+	router := event.NewRouter(bus1)
+
+	if err := router.AddBus(bus1); !errdefs.IsConflict(err) {
+		t.Fatalf("AddBus(duplicate) error = %v, want conflict", err)
+	}
+	if err := router.AddBus(nil); !errdefs.IsValidation(err) {
+		t.Fatalf("AddBus(nil) error = %v, want validation", err)
+	}
+	if err := router.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	if err := router.AddBus(event.NewMemoryBus()); !errdefs.IsNotAvailable(err) {
+		t.Fatalf("AddBus after Close error = %v, want not available", err)
+	}
+}
+
+func TestRouterRemoveBusUnknownIsNoop(t *testing.T) {
+	bus1 := event.NewMemoryBus()
+	t.Cleanup(func() { _ = bus1.Close() })
+	router := event.NewRouter(bus1)
+	t.Cleanup(func() { _ = router.Close() })
+	if err := router.RemoveBus(event.NewMemoryBus()); err != nil {
+		t.Fatalf("RemoveBus(unknown) error = %v, want nil", err)
+	}
+}
+
+// TestRouterConcurrentAddBusClose exercises the WaitGroup registration
+// ordering under -race: AddBus must register its goroutines before
+// releasing the lock, so a concurrent Close can never observe a zero
+// counter while Add is still running.
+func TestRouterConcurrentAddBusClose(t *testing.T) {
+	bus1 := event.NewMemoryBus()
+	t.Cleanup(func() { _ = bus1.Close() })
+	router := event.NewRouter(bus1)
+
+	sink := &captureSink{}
+	stop, err := router.Attach(context.Background(),
+		event.Pattern("test.multi.*"), sink)
+	if err != nil {
+		t.Fatalf("Attach: %v", err)
+	}
+	defer stop()
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 200; i++ {
+			b := event.NewMemoryBus()
+			if err := router.AddBus(b); err != nil {
+				return // router closed
+			}
+			time.Sleep(time.Microsecond)
+		}
+	}()
+	time.Sleep(2 * time.Millisecond)
+	if err := router.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	wg.Wait()
+}

--- a/core/resource/registry.go
+++ b/core/resource/registry.go
@@ -1,6 +1,10 @@
 package resource
 
-import "github.com/GizClaw/flowcraft/core/errdefs"
+import (
+	"sync"
+
+	"github.com/GizClaw/flowcraft/core/errdefs"
+)
 
 // Key is the unique (Kind, Impl) identity of a factory in a registry.
 type Key struct {
@@ -12,6 +16,7 @@ type Key struct {
 // resource module registers its factories explicitly; there is no
 // global state.
 type Registry struct {
+	mu        sync.RWMutex
 	factories map[Key]Factory
 }
 
@@ -31,6 +36,8 @@ func (r *Registry) Register(f Factory) error {
 		return err
 	}
 	key := Key{Kind: spec.Kind, Impl: spec.Impl}
+	r.mu.Lock()
+	defer r.mu.Unlock()
 	if _, dup := r.factories[key]; dup {
 		return errdefs.Conflictf(
 			"resource registry: factory %s/%s already registered",
@@ -50,12 +57,16 @@ func (r *Registry) MustRegister(f Factory) {
 // Lookup returns the factory for kind/impl. An empty impl matches a
 // factory registered with an empty impl.
 func (r *Registry) Lookup(kind Kind, impl string) (Factory, bool) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
 	f, ok := r.factories[Key{Kind: kind, Impl: impl}]
 	return f, ok
 }
 
 // Specs returns the registered factory specs in unspecified order.
 func (r *Registry) Specs() []Spec {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
 	specs := make([]Spec, 0, len(r.factories))
 	for _, f := range r.factories {
 		specs = append(specs, f.Spec())

--- a/core/resource/registry_test.go
+++ b/core/resource/registry_test.go
@@ -2,6 +2,8 @@ package resource
 
 import (
 	"context"
+	"fmt"
+	"sync"
 	"testing"
 
 	"github.com/GizClaw/flowcraft/core/errdefs"
@@ -49,5 +51,66 @@ func TestRegistrySpecs(t *testing.T) {
 	r.MustRegister(fakeFactory{spec: Spec{Kind: "tool.Assembly", Impl: "yaml"}})
 	if got := len(r.Specs()); got != 2 {
 		t.Fatalf("Specs() = %d entries, want 2", got)
+	}
+}
+
+// TestRegistryConcurrentAccess runs concurrent Register / Lookup / Specs
+// to prove the registry is safe under -race. Registration is host-owned,
+// so distinct (kind, impl) keys are used to keep the writes legal.
+func TestRegistryConcurrentAccess(t *testing.T) {
+	r := NewRegistry()
+	const writers = 8
+	const perWriter = 64
+	const readers = 8
+
+	// Seed a base set every reader keeps looking up while writers add
+	// new keys concurrently. New keys are asserted after the writers
+	// finish; lookups of not-yet-registered keys are expected misses.
+	for i := 0; i < 16; i++ {
+		r.MustRegister(fakeFactory{
+			spec: Spec{Kind: Kind(fmt.Sprintf("base.%d", i)), Impl: "impl"},
+		})
+	}
+
+	var wg sync.WaitGroup
+	wg.Add(writers + readers)
+	for w := 0; w < writers; w++ {
+		go func(w int) {
+			defer wg.Done()
+			for i := 0; i < perWriter; i++ {
+				kind := Kind(fmt.Sprintf("kind.%d.%d", w, i))
+				if err := r.Register(fakeFactory{
+					spec: Spec{Kind: kind, Impl: "impl"},
+				}); err != nil {
+					t.Errorf("Register(%s): %v", kind, err)
+					return
+				}
+			}
+		}(w)
+	}
+	for rIdx := 0; rIdx < readers; rIdx++ {
+		go func(w int) {
+			defer wg.Done()
+			for i := 0; i < perWriter*2; i++ {
+				base := Kind(fmt.Sprintf("base.%d", i%16))
+				if _, ok := r.Lookup(base, "impl"); !ok {
+					t.Errorf("Lookup(%s) = not found", base)
+					return
+				}
+				_ = r.Specs()
+			}
+		}(rIdx)
+	}
+	wg.Wait()
+	if got := len(r.Specs()); got != writers*perWriter+16 {
+		t.Fatalf("Specs() = %d entries, want %d", got, writers*perWriter+16)
+	}
+	for w := 0; w < writers; w++ {
+		for i := 0; i < perWriter; i++ {
+			kind := Kind(fmt.Sprintf("kind.%d.%d", w, i))
+			if _, ok := r.Lookup(kind, "impl"); !ok {
+				t.Fatalf("Lookup(%s) = not found after writers finished", kind)
+			}
+		}
 	}
 }

--- a/core/runtime/builder.go
+++ b/core/runtime/builder.go
@@ -176,6 +176,16 @@ func (b *Builder) Build(ctx context.Context, doc deploy.Document) (*Runtime, err
 
 	router := event.NewRouter(bus)
 	registry := newAgentRegistry(result)
+	initial := &Generation{
+		id:          1,
+		doc:         doc,
+		registry:    registry,
+		result:      result,
+		bus:         bus,
+		hostFactory: hostFactory,
+		resolver:    generationResolver{registry: registry, result: result},
+		catalog:     liveCatalog,
+	}
 	managerOptions := []session.ManagerOption{
 		session.WithIdleTimeout(cfg.Sessions.IdleTimeout),
 		session.WithSinkBufferSize(cfg.Sessions.SinkBuffer),
@@ -196,21 +206,24 @@ func (b *Builder) Build(ctx context.Context, doc deploy.Document) (*Runtime, err
 		managerOptions = append(managerOptions,
 			session.WithCatalogProvider(catalogProvider))
 	}
-	manager, err := session.NewManager(registry, hostFactory, router, managerOptions...)
+	manager, err := session.NewManager(initial.resolver, hostFactory, router, managerOptions...)
 	if err != nil {
 		_ = router.Close()
 		_ = result.Close()
 		return nil, fmt.Errorf("runtime create session manager: %w", err)
 	}
 	return &Runtime{
-		manager:     manager,
-		router:      router,
-		result:      result,
-		registry:    registry,
-		liveCatalog: liveCatalog,
-		resources:   reg,
-		loader:      b.loader,
-		bus:         bus,
+		manager:       manager,
+		router:        router,
+		result:        result,
+		registry:      registry,
+		liveCatalog:   liveCatalog,
+		resources:     reg,
+		loader:        b.loader,
+		bus:           bus,
+		hostDecorator: b.hostDecorator,
+		current:       initial,
+		nextGenID:     1,
 	}, nil
 }
 

--- a/core/runtime/events.go
+++ b/core/runtime/events.go
@@ -13,6 +13,11 @@ import (
 // namespace.
 const agentLifecyclePrefix = "runtime.agent."
 
+// runtimeRebuildPrefix is the subject root for runtime generation
+// reload events. Like the agent lifecycle subjects, it sits outside the
+// engine-owned "agent.run.*" namespace.
+const runtimeRebuildPrefix = "runtime.rebuild."
+
 // SubjectAgentRegistered returns the subject for a successful dynamic
 // registration:
 //
@@ -34,6 +39,38 @@ func PatternAgentLifecycle() event.Pattern {
 	return event.Pattern(agentLifecyclePrefix + ">")
 }
 
+// SubjectRuntimeRebuildStarted is published when a Reload begins
+// building the next generation.
+func SubjectRuntimeRebuildStarted() event.Subject {
+	return event.Subject(runtimeRebuildPrefix + "started")
+}
+
+// SubjectRuntimeRebuildCompleted is published after a Reload atomically
+// swapped the current generation.
+func SubjectRuntimeRebuildCompleted() event.Subject {
+	return event.Subject(runtimeRebuildPrefix + "completed")
+}
+
+// SubjectRuntimeRebuildFailed is published when a Reload aborts before
+// any swap; the previous generation keeps serving.
+func SubjectRuntimeRebuildFailed() event.Subject {
+	return event.Subject(runtimeRebuildPrefix + "failed")
+}
+
+// PatternRuntimeRebuild matches every runtime generation reload event.
+func PatternRuntimeRebuild() event.Pattern {
+	return event.Pattern(runtimeRebuildPrefix + ">")
+}
+
+// RuntimeRebuildEvent is the payload of runtime.rebuild.* events.
+type RuntimeRebuildEvent struct {
+	GenerationID         uint64   `json:"generation_id"`
+	PreviousGenerationID uint64   `json:"previous_generation_id,omitempty"`
+	ReboundAgents        []string `json:"rebound_agents,omitempty"`
+	DrainedAgents        []string `json:"drained_agents,omitempty"`
+	Error                string   `json:"error,omitempty"`
+}
+
 // AgentLifecycleEvent is the payload of runtime.agent.* lifecycle
 // events. It intentionally carries only identity and card summary, so
 // the envelope stays small.
@@ -48,7 +85,7 @@ type AgentLifecycleEvent struct {
 func (r *Runtime) publishLifecycleEvent(
 	ctx context.Context,
 	subject event.Subject,
-	payload AgentLifecycleEvent,
+	payload any,
 ) {
 	if r == nil || r.bus == nil || isNilContext(ctx) {
 		return

--- a/core/runtime/generation.go
+++ b/core/runtime/generation.go
@@ -1,0 +1,126 @@
+package runtime
+
+import (
+	"errors"
+	"fmt"
+	"sort"
+	"sync"
+
+	"github.com/GizClaw/flowcraft/core/agent"
+	"github.com/GizClaw/flowcraft/core/deploy"
+	"github.com/GizClaw/flowcraft/core/event"
+	"github.com/GizClaw/flowcraft/core/runtime/session"
+)
+
+// Generation is one immutable deployment snapshot plus the services
+// derived from it: the built result, the host factory, the per-agent
+// resolver, and the dynamic tool catalog. A generation is built as a
+// value and swapped into the Runtime atomically; it is never mutated
+// while current except for the one-time freeze performed by Reload
+// (adopting the dynamic instances that retire with it).
+type Generation struct {
+	id          uint64
+	doc         deploy.Document
+	registry    *AgentRegistry
+	result      *deploy.Result
+	bus         event.Bus
+	hostFactory session.HostFactory
+	resolver    session.InstanceResolver
+	catalog     *catalogRegistry
+
+	// adopted are the dynamic agent instances that retire with this
+	// generation. They are frozen by Reload at swap time (empty while
+	// current) and closed exactly once when the generation closes.
+	adopted map[string]*agent.Agent
+
+	closeOnce sync.Once
+	closeErr  error
+}
+
+// generationResolver pins deployed agents to one generation's result and
+// serves dynamic agents from the live registry while current, or from the
+// frozen set once Reload has retired the generation. The frozen branch
+// guarantees that a Start which captured the retired epoch still resolves
+// the exact instances that generation served.
+type generationResolver struct {
+	registry *AgentRegistry
+	result   *deploy.Result
+	frozen   map[string]*agent.Agent
+}
+
+// Instance implements session.InstanceResolver.
+func (r generationResolver) Instance(id string) (*agent.Agent, bool) {
+	if r.frozen != nil {
+		if instance, ok := r.frozen[id]; ok {
+			return instance, true
+		}
+		return r.result.Agent(id)
+	}
+	if instance, ok := r.registry.Dynamic(id); ok {
+		return instance, true
+	}
+	return r.result.Agent(id)
+}
+
+// freeze adopts the given dynamic instances into the generation so they
+// retire (and later close) with it, and pins the resolver to them.
+// Callers must hold lifecycleMu so no registration or reload can mutate
+// the live registry concurrently.
+func (g *Generation) freeze(dynamic map[string]*agent.Agent) {
+	if g == nil {
+		return
+	}
+	g.adopted = dynamic
+	g.resolver = generationResolver{
+		registry: g.registry,
+		result:   g.result,
+		frozen:   dynamic,
+	}
+}
+
+// unfreeze restores the live resolver after an aborted swap, so the
+// still-current generation keeps serving dynamic registrations.
+func (g *Generation) unfreeze() {
+	if g == nil {
+		return
+	}
+	g.adopted = nil
+	g.resolver = generationResolver{
+		registry: g.registry,
+		result:   g.result,
+	}
+}
+
+// close releases the generation's result and adopted dynamic instances
+// exactly once. Deployed agents are owned by the result; dynamic
+// instances are owned by the generation that adopted them.
+func (g *Generation) close() error {
+	if g == nil {
+		return nil
+	}
+	g.closeOnce.Do(func() {
+		var errs []error
+		if g.result != nil {
+			if err := g.result.Close(); err != nil {
+				errs = append(errs, fmt.Errorf(
+					"runtime generation %d: close deployment: %w", g.id, err))
+			}
+		}
+		if len(g.adopted) > 0 {
+			names := make([]string, 0, len(g.adopted))
+			for name := range g.adopted {
+				names = append(names, name)
+			}
+			sort.Strings(names)
+			for _, name := range names {
+				if err := g.adopted[name].Close(); err != nil {
+					errs = append(errs, fmt.Errorf(
+						"runtime generation %d: close dynamic agent %q: %w",
+						g.id, name, err))
+				}
+			}
+		}
+		g.closeErr = errors.Join(errs...)
+	})
+	return g.closeErr
+}

--- a/core/runtime/lifecycle.go
+++ b/core/runtime/lifecycle.go
@@ -148,7 +148,11 @@ func (r *Runtime) RegisterAgent(
 	if r.liveCatalog != nil {
 		r.liveCatalog.Set(name, assembly)
 	}
-	if err := r.registry.Put(name, instance); err != nil {
+	if err := r.registry.Put(name, dynamicAgentEntry{
+		instance:     instance,
+		definition:   def,
+		toolAssembly: options.toolResource,
+	}); err != nil {
 		_ = instance.Close()
 		return nil, err
 	}
@@ -199,7 +203,7 @@ func (r *Runtime) UnregisterAgent(
 		return errdefs.NotAvailablef("runtime: closed")
 	}
 
-	instance, ok := r.registry.Delete(name)
+	entry, ok := r.registry.Delete(name)
 	if !ok {
 		if _, deployed := r.result.Agent(name); deployed {
 			return errdefs.Conflictf(
@@ -219,19 +223,19 @@ func (r *Runtime) UnregisterAgent(
 		// Drain failed (usually a deadline): keep the tombstone so new
 		// sessions stay blocked, restore the agent so the registration
 		// is still visible, and let the caller retry.
-		_ = r.registry.Put(name, instance)
+		_ = r.registry.Put(name, entry)
 		return err
 	}
 	if r.liveCatalog != nil {
 		r.liveCatalog.Delete(name)
 	}
-	if err := instance.Close(); err != nil {
+	if err := entry.instance.Close(); err != nil {
 		return err
 	}
 	r.publishLifecycleEvent(ctx, SubjectAgentRemoved(name), AgentLifecycleEvent{
 		AgentID:     name,
-		Name:        instance.Card.Name,
-		Description: instance.Card.Description,
+		Name:        entry.instance.Card.Name,
+		Description: entry.instance.Card.Description,
 	})
 	return nil
 }

--- a/core/runtime/registry.go
+++ b/core/runtime/registry.go
@@ -1,7 +1,6 @@
 package runtime
 
 import (
-	"errors"
 	"sort"
 	"sync"
 
@@ -10,6 +9,15 @@ import (
 	"github.com/GizClaw/flowcraft/core/errdefs"
 )
 
+// dynamicAgentEntry is the bookkeeping record of one dynamically
+// registered agent: the assembled instance plus everything Reload needs
+// to re-bind it against a new generation.
+type dynamicAgentEntry struct {
+	instance     *agent.Agent
+	definition   agent.Definition
+	toolAssembly string // WithToolAssembly resource name; "" = none/default
+}
+
 // AgentRegistry is the runtime-live, concurrency-safe agent view.
 // Dynamically registered agents live in its own map; statically deployed
 // agents are served as a read-only fallback from the deployment result.
@@ -17,20 +25,15 @@ import (
 // both kinds through one seam.
 type AgentRegistry struct {
 	mu       sync.RWMutex
-	agents   map[string]*agent.Agent
+	agents   map[string]dynamicAgentEntry
 	deployed *deploy.Result
 }
 
 func newAgentRegistry(deployed *deploy.Result) *AgentRegistry {
 	return &AgentRegistry{
-		agents:   make(map[string]*agent.Agent),
+		agents:   make(map[string]dynamicAgentEntry),
 		deployed: deployed,
 	}
-}
-
-// Instance implements session.InstanceResolver.
-func (r *AgentRegistry) Instance(id string) (*agent.Agent, bool) {
-	return r.Agent(id)
 }
 
 // Agent resolves a dynamically registered agent first, then falls back
@@ -40,10 +43,10 @@ func (r *AgentRegistry) Agent(id string) (*agent.Agent, bool) {
 		return nil, false
 	}
 	r.mu.RLock()
-	instance, ok := r.agents[id]
+	entry, ok := r.agents[id]
 	r.mu.RUnlock()
 	if ok {
-		return instance, true
+		return entry.instance, true
 	}
 	if r.deployed != nil {
 		return r.deployed.Agent(id)
@@ -76,12 +79,66 @@ func (r *AgentRegistry) AgentNames() []string {
 	return names
 }
 
+// Dynamic returns the live instance registered under id, or ok=false.
+// It is the dynamic-only view used by per-generation resolvers.
+func (r *AgentRegistry) Dynamic(id string) (*agent.Agent, bool) {
+	if r == nil {
+		return nil, false
+	}
+	r.mu.RLock()
+	entry, ok := r.agents[id]
+	r.mu.RUnlock()
+	if !ok {
+		return nil, false
+	}
+	return entry.instance, true
+}
+
+// Entries returns a defensive copy of every dynamic registration.
+func (r *AgentRegistry) Entries() map[string]dynamicAgentEntry {
+	if r == nil {
+		return nil
+	}
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	out := make(map[string]dynamicAgentEntry, len(r.agents))
+	for id, entry := range r.agents {
+		out[id] = entry
+	}
+	return out
+}
+
+// Replace atomically swaps the dynamic view and the deployed fallback.
+// It is the Reload commit path; callers must hold lifecycleMu.
+func (r *AgentRegistry) Replace(
+	entries map[string]dynamicAgentEntry,
+	deployed *deploy.Result,
+) {
+	if r == nil {
+		return
+	}
+	r.mu.Lock()
+	r.agents = entries
+	r.deployed = deployed
+	r.mu.Unlock()
+}
+
+// dynamicInstances projects a registry entry snapshot into the
+// instance-only map a generation adopts at swap/close time.
+func dynamicInstances(entries map[string]dynamicAgentEntry) map[string]*agent.Agent {
+	out := make(map[string]*agent.Agent, len(entries))
+	for name, entry := range entries {
+		out[name] = entry.instance
+	}
+	return out
+}
+
 // Put registers a dynamically registered agent, rejecting duplicates.
-func (r *AgentRegistry) Put(id string, instance *agent.Agent) error {
+func (r *AgentRegistry) Put(id string, entry dynamicAgentEntry) error {
 	if r == nil {
 		return errdefs.Validationf("runtime: agent registry is nil")
 	}
-	if id == "" || instance == nil {
+	if id == "" || entry.instance == nil {
 		return errdefs.Validationf(
 			"runtime: agent registry Put requires an id and a non-nil agent")
 	}
@@ -90,44 +147,29 @@ func (r *AgentRegistry) Put(id string, instance *agent.Agent) error {
 	if _, exists := r.agents[id]; exists {
 		return errdefs.Conflictf("runtime: agent %q is already registered", id)
 	}
-	r.agents[id] = instance
+	r.agents[id] = entry
 	return nil
 }
 
-// Delete removes and returns a dynamically registered agent. Deployed
+// Delete removes and returns a dynamically registered entry. Deployed
 // agents are not affected and return ok=false.
-func (r *AgentRegistry) Delete(id string) (*agent.Agent, bool) {
+func (r *AgentRegistry) Delete(id string) (dynamicAgentEntry, bool) {
 	if r == nil {
-		return nil, false
+		return dynamicAgentEntry{}, false
 	}
 	r.mu.Lock()
 	defer r.mu.Unlock()
-	instance, ok := r.agents[id]
+	entry, ok := r.agents[id]
 	if !ok {
-		return nil, false
+		return dynamicAgentEntry{}, false
 	}
 	delete(r.agents, id)
-	return instance, true
+	return entry, true
 }
 
-// Close closes every dynamically registered agent. Deployed agents are
-// owned (and closed) by deploy.Result, so they are left untouched.
+// Close is retained for API compatibility but is a no-op: dynamic
+// instances are owned by the generation that adopted them and closed by
+// Generation.close, so closing them here would double-close.
 func (r *AgentRegistry) Close() error {
-	if r == nil {
-		return nil
-	}
-	r.mu.RLock()
-	instances := make([]*agent.Agent, 0, len(r.agents))
-	for _, instance := range r.agents {
-		instances = append(instances, instance)
-	}
-	r.mu.RUnlock()
-
-	var errs []error
-	for _, instance := range instances {
-		if err := instance.Close(); err != nil {
-			errs = append(errs, err)
-		}
-	}
-	return errors.Join(errs...)
+	return nil
 }

--- a/core/runtime/reload.go
+++ b/core/runtime/reload.go
@@ -1,0 +1,389 @@
+package runtime
+
+import (
+	"context"
+	"fmt"
+	"sort"
+
+	"github.com/GizClaw/flowcraft/core/agent"
+	"github.com/GizClaw/flowcraft/core/deploy"
+	"github.com/GizClaw/flowcraft/core/errdefs"
+	"github.com/GizClaw/flowcraft/core/event"
+	"github.com/GizClaw/flowcraft/core/runtime/session"
+	"github.com/GizClaw/flowcraft/core/tool"
+)
+
+type reloadOptions struct{}
+
+// ReloadOption configures one Reload call. The option set is reserved
+// for future policy (e.g. dropping vs failing on re-bind); v1 has no
+// options.
+type ReloadOption func(*reloadOptions) error
+
+// ReloadResult describes one successful generation swap.
+type ReloadResult struct {
+	GenerationID  uint64
+	PreviousID    uint64
+	ReboundAgents []string
+	DrainedAgents []string
+}
+
+// Reload transactionally replaces the deployment document with a new
+// generation:
+//
+//  1. Validates the document and decodes the runtime config.
+//  2. Builds the new deploy.Result (rollback on failure).
+//  3. Asserts the system resources (event_bus, checkpoint_store,
+//     sessions.resume) are unchanged — they are pinned per Runtime.
+//  4. Rebuilds the host factory with the same decorator.
+//  5. Re-binds every dynamic agent against the new result; any failure
+//     aborts the whole reload.
+//  6. Drains sessions of deployed agents removed by the new document.
+//  7. Atomically swaps the manager epoch and the runtime's current
+//     generation; the old generation retires and closes once its
+//     in-flight turns drain.
+//
+// In-flight turns always complete on the generation they started on;
+// the next Start uses the new generation. Reload is serialized with
+// RegisterAgent / UnregisterAgent / Close via lifecycleMu.
+func (r *Runtime) Reload(
+	ctx context.Context,
+	doc deploy.Document,
+	opts ...ReloadOption,
+) (*ReloadResult, error) {
+	if r == nil {
+		return nil, errdefs.Validationf(
+			"runtime: Reload requires a built Runtime")
+	}
+	if isNilContext(ctx) {
+		return nil, errdefs.Validationf(
+			"runtime: Reload context is required")
+	}
+	for _, option := range opts {
+		if isNil(option) {
+			return nil, errdefs.Validationf(
+				"runtime: ReloadOption must not be nil")
+		}
+		if err := option(&reloadOptions{}); err != nil {
+			return nil, err
+		}
+	}
+
+	r.lifecycleMu.Lock()
+	defer r.lifecycleMu.Unlock()
+	if r.closed {
+		return nil, errdefs.NotAvailablef("runtime: closed")
+	}
+	// Allocate the attempt's generation id up front and publish the
+	// started event before any validation so every attempt (success or
+	// failure) has a complete started -> completed/failed chain with a
+	// distinct id.
+	newGenID := r.nextGenID + 1
+	r.nextGenID = newGenID
+	previousID := uint64(0)
+	if r.current != nil {
+		previousID = r.current.id
+	}
+	r.publishLifecycleEvent(ctx, SubjectRuntimeRebuildStarted(),
+		RuntimeRebuildEvent{GenerationID: newGenID})
+	fail := func(err error) (*ReloadResult, error) {
+		r.publishLifecycleEvent(ctx, SubjectRuntimeRebuildFailed(),
+			RuntimeRebuildEvent{GenerationID: newGenID, Error: err.Error()})
+		return nil, err
+	}
+	if err := doc.Validate(); err != nil {
+		return fail(fmt.Errorf(
+			"runtime reload validate deployment: %w", err))
+	}
+	cfg, err := DecodeConfig(doc)
+	if err != nil {
+		return fail(err)
+	}
+
+	// Build the new deployment result transactionally.
+	deployBuilder := deploy.NewBuilder(r.resources)
+	if r.loader != nil {
+		deployBuilder = deploy.NewBuilder(
+			r.resources, deploy.WithLoader(r.loader))
+	}
+	newResult, err := deployBuilder.Deploy(ctx, doc)
+	if err != nil {
+		return fail(fmt.Errorf("runtime reload build deployment: %w", err))
+	}
+	// drainAttempted collects every agent this Reload attempt tried to
+	// remove, so an abort can clear their tombstones and leave the old
+	// generation fully serving.
+	var drainAttempted []string
+	abort := func(err error) error {
+		for _, name := range drainAttempted {
+			r.manager.ReopenAgent(name)
+		}
+		_ = newResult.Close()
+		r.publishLifecycleEvent(ctx, SubjectRuntimeRebuildFailed(),
+			RuntimeRebuildEvent{GenerationID: newGenID, Error: err.Error()})
+		return err
+	}
+
+	// Resolve the new generation's system resources and validate the
+	// resume contract. The bus and checkpoint store may change
+	// configuration (or implementation) freely: each generation owns
+	// its own values, the router subscribes to every live generation's
+	// bus, and turns resolve their store from their epoch. Continuity
+	// of durable session state across a store change is the host's
+	// responsibility (same backing storage or migration).
+	newBus, err := resolveValue[event.Bus](
+		newResult, cfg.EventBus, "event_bus")
+	if err != nil {
+		return nil, abort(err)
+	}
+	var newCheckpoints agent.CheckpointStore
+	if cfg.CheckpointStore != "" {
+		newCheckpoints, err = resolveValue[agent.CheckpointStore](
+			newResult, cfg.CheckpointStore, "checkpoint_store")
+		if err != nil {
+			return nil, abort(err)
+		}
+	}
+	if cfg.Sessions.Resume {
+		if newCheckpoints == nil {
+			return nil, abort(errdefs.Validationf(
+				"runtime reload: sessions.resume requires checkpoint_store"))
+		}
+		if _, ok := newCheckpoints.(agent.CheckpointDeleter); !ok {
+			return nil, abort(errdefs.Validationf(
+				"runtime reload: sessions.resume requires a checkpoint store " +
+					"that implements CheckpointDeleter"))
+		}
+	}
+	// Each generation must own its bus: reject a reload whose bus
+	// factory returned the current generation's bus (a shared
+	// singleton), detaching it from the new result so the abort path
+	// cannot close a bus the old generation still routes on.
+	if newBus == r.bus {
+		newResult.Detach(cfg.EventBus)
+		return nil, abort(errdefs.Conflictf(
+			"runtime reload: event_bus factory returned the current " +
+				"generation's bus; each generation must own its bus"))
+	}
+
+	// Rebuild the host factory with the same decoration policy.
+	baseHostFactory, err := newBaseHostFactory(newBus, newCheckpoints)
+	if err != nil {
+		return nil, abort(err)
+	}
+	hostFactory := session.HostFactory(baseHostFactory)
+	if r.hostDecorator != nil {
+		hostFactory, err = r.hostDecorator(baseHostFactory)
+		if err != nil {
+			return nil, abort(fmt.Errorf(
+				"runtime reload decorate host factory: %w", err))
+		}
+		if isNil(hostFactory) {
+			return nil, abort(errdefs.Internalf(
+				"runtime reload host factory decorator returned nil"))
+		}
+	}
+	hostFactory, err = wrapDelegation(hostFactory, newResult)
+	if err != nil {
+		return nil, abort(err)
+	}
+
+	// Resolve the new generation's dynamic tool catalog.
+	var newCatalog *catalogRegistry
+	if cfg.DynamicCatalog != nil {
+		assemblies, resolveErr := resolveDynamicCatalogAssemblies(
+			doc, newResult, cfg.DynamicCatalog)
+		if resolveErr != nil {
+			return nil, abort(resolveErr)
+		}
+		newCatalog = newCatalogRegistry(assemblies)
+	}
+
+	// Re-bind every dynamic agent against the new generation. Any
+	// failure closes the partially bound instances and aborts.
+	entries := r.registry.Entries()
+	rebound := make(map[string]*agent.Agent, len(entries))
+	newEntries := make(map[string]dynamicAgentEntry, len(entries))
+	closeRebound := func() {
+		for _, name := range sortedKeys(rebound) {
+			_ = rebound[name].Close()
+		}
+	}
+	for _, name := range sortedKeys(entries) {
+		entry := entries[name]
+		instance, bindErr := deploy.BindAgent(
+			ctx, r.resources, newResult, r.loader, name, entry.definition)
+		if bindErr != nil {
+			closeRebound()
+			return nil, abort(fmt.Errorf(
+				"runtime reload: re-bind agent %q: %w", name, bindErr))
+		}
+		rebound[name] = instance
+		if entry.toolAssembly != "" {
+			if newCatalog == nil {
+				closeRebound()
+				return nil, abort(errdefs.Validationf(
+					"runtime reload: agent %q has tool assembly %q but "+
+						"the new document has no dynamic_catalog",
+					name, entry.toolAssembly))
+			}
+			value, ok := newResult.Value(entry.toolAssembly)
+			if !ok {
+				closeRebound()
+				return nil, abort(errdefs.NotFoundf(
+					"runtime reload: tool assembly resource %q for agent %q not found",
+					entry.toolAssembly, name))
+			}
+			assembly, typeOK := value.(*tool.Assembly)
+			if !typeOK || assembly == nil {
+				closeRebound()
+				return nil, abort(errdefs.Validationf(
+					"runtime reload: tool assembly resource %q for agent %q is %T, want *tool.Assembly",
+					entry.toolAssembly, name, value))
+			}
+			newCatalog.Set(name, assembly)
+		} else if newCatalog != nil && !newCatalog.hasDefault() {
+			closeRebound()
+			return nil, abort(errdefs.Validationf(
+				"runtime reload: dynamic catalog has no default; "+
+					"agent %q needs WithToolAssembly", name))
+		}
+		newEntries[name] = dynamicAgentEntry{
+			instance:     instance,
+			definition:   entry.definition,
+			toolAssembly: entry.toolAssembly,
+		}
+	}
+
+	// Drain sessions of deployed agents the new document removes, then
+	// clear tombstones for agents that remain (or are re-added).
+	var drained []string
+	for _, name := range r.result.AgentNames() {
+		if _, still := doc.Agents[name]; still {
+			continue
+		}
+		drainAttempted = append(drainAttempted, name)
+		if err := r.manager.RemoveAgent(ctx, name); err != nil {
+			closeRebound()
+			return nil, abort(fmt.Errorf(
+				"runtime reload: drain removed agent %q: %w", name, err))
+		}
+		drained = append(drained, name)
+	}
+	for name := range doc.Agents {
+		r.manager.ReopenAgent(name)
+	}
+
+	// Apply the new session tunables.
+	if err := r.manager.UpdateTunables(session.Tunables{
+		IdleTimeout:         cfg.Sessions.IdleTimeout,
+		SinkBuffer:          cfg.Sessions.SinkBuffer,
+		SpeculativeEvents:   cfg.Sessions.SpeculativeBufferEvents,
+		SpeculativeBytes:    cfg.Sessions.SpeculativeBufferBytes,
+		DeliveryConcurrency: cfg.Sessions.DeliveryConcurrency,
+		MaxSessions:         cfg.Sessions.MaxSessions,
+	}); err != nil {
+		closeRebound()
+		return nil, abort(err)
+	}
+
+	// Freeze the retiring generation, swap the live view, and commit.
+	oldGen := r.current
+	if oldGen != nil {
+		oldGen.freeze(dynamicInstances(entries))
+	}
+	newGen := &Generation{
+		id:          newGenID,
+		doc:         doc,
+		registry:    r.registry,
+		result:      newResult,
+		bus:         newBus,
+		hostFactory: hostFactory,
+		resolver: generationResolver{
+			registry: r.registry,
+			result:   newResult,
+		},
+		catalog: newCatalog,
+	}
+	r.registry.Replace(newEntries, newResult)
+	// The live view is swapped before the epoch swap on purpose: the
+	// new generation's resolver serves dynamic agents from the live
+	// registry, so ordering it after SwapDeps would expose a window
+	// where a new-epoch turn resolves an old-generation instance. The
+	// early Replace only means discovery readers may briefly observe
+	// the new (fully valid) instances before the epoch commits; all
+	// mutation paths are serialized by lifecycleMu.
+	// Route the new generation's bus through the runtime router before
+	// the swap so the first new-generation turns are streamed; the old
+	// bus is unsubscribed when its generation retires.
+	if err := r.router.AddBus(newBus); err != nil {
+		if oldGen != nil {
+			oldGen.unfreeze()
+		}
+		// Belt and braces: AddBus is all-or-nothing, so the new bus is
+		// never attached on error; removing it here keeps the invariant
+		// even if a future router change makes AddBus partial.
+		_ = r.router.RemoveBus(newBus)
+		r.registry.Replace(entries, oldGen.result)
+		closeRebound()
+		return nil, abort(fmt.Errorf("runtime reload attach bus: %w", err))
+	}
+	deps := session.Deps{
+		Resolver:    newGen.resolver,
+		HostFactory: hostFactory,
+		Checkpoints: newCheckpoints,
+		Resume:      cfg.Sessions.Resume,
+	}
+	if newGen.catalog != nil {
+		// Assign through the concrete pointer so a nil catalog stays a
+		// nil interface instead of a typed-nil.
+		deps.CatalogProvider = newGen.catalog
+	}
+	if err := r.manager.SwapDeps(deps, func(_ uint64, _ session.Deps) {
+		if oldGen != nil && oldGen.bus != nil {
+			_ = r.router.RemoveBus(oldGen.bus)
+		}
+		_ = oldGen.close()
+	}); err != nil {
+		// Unreachable under lifecycleMu (Close holds it); roll back.
+		if oldGen != nil {
+			oldGen.unfreeze()
+		}
+		_ = r.router.RemoveBus(newBus)
+		r.registry.Replace(entries, oldGen.result)
+		closeRebound()
+		return nil, abort(errdefs.Internalf(
+			"runtime reload swap: %v", err))
+	}
+
+	r.current = newGen
+	r.result = newResult
+	r.liveCatalog = newCatalog
+	r.bus = newBus
+	r.nextGenID = newGenID
+
+	reboundNames := sortedKeys(newEntries)
+	sort.Strings(drained)
+	r.publishLifecycleEvent(ctx, SubjectRuntimeRebuildCompleted(),
+		RuntimeRebuildEvent{
+			GenerationID:         newGenID,
+			PreviousGenerationID: previousID,
+			ReboundAgents:        reboundNames,
+			DrainedAgents:        drained,
+		})
+	return &ReloadResult{
+		GenerationID:  newGenID,
+		PreviousID:    previousID,
+		ReboundAgents: reboundNames,
+		DrainedAgents: drained,
+	}, nil
+}
+
+func sortedKeys[V any](m map[string]V) []string {
+	keys := make([]string, 0, len(m))
+	for key := range m {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	return keys
+}

--- a/core/runtime/reload_test.go
+++ b/core/runtime/reload_test.go
@@ -1,0 +1,696 @@
+package runtime
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/GizClaw/flowcraft/core/agent"
+	"github.com/GizClaw/flowcraft/core/deploy"
+	"github.com/GizClaw/flowcraft/core/errdefs"
+	"github.com/GizClaw/flowcraft/core/event"
+	"github.com/GizClaw/flowcraft/core/message"
+	"github.com/GizClaw/flowcraft/core/resource"
+	"github.com/GizClaw/flowcraft/core/runtime/session"
+)
+
+const reloadEngineKind = "reload-engine"
+
+// gatedEngineFactory builds engines that report their generation and
+// block on a shared gate until it is closed, so tests can hold a turn
+// in flight across a reload.
+type gatedEngineFactory struct {
+	gen  atomic.Int64
+	runs chan int64
+	gate chan struct{}
+}
+
+func (f *gatedEngineFactory) Spec() resource.Spec {
+	return resource.Spec{Kind: reloadEngineKind}
+}
+
+func (f *gatedEngineFactory) New(context.Context, resource.Input) (any, error) {
+	gen := f.gen.Add(1)
+	return agent.EngineFunc(func(
+		ctx context.Context,
+		run agent.Run,
+		host agent.Host,
+		board *agent.Board,
+	) (*agent.Board, error) {
+		select {
+		case f.runs <- gen:
+		default:
+		}
+		_ = publishRunEvent(ctx, host, agent.SubjectRunStart(run.RunID), run)
+		select {
+		case <-f.gate:
+		case <-ctx.Done():
+			return board, ctx.Err()
+		}
+		board.AppendChannelMessage(
+			agent.MainChannel,
+			message.NewTextMessage(message.RoleAssistant, "ok"))
+		_ = publishRunEvent(ctx, host, agent.SubjectRunEnd(run.RunID), run)
+		return board, nil
+	}), nil
+}
+
+func waitForGen(t *testing.T, runs <-chan int64, want int64) {
+	t.Helper()
+	deadline := time.Now().Add(10 * time.Second)
+	for time.Now().Before(deadline) {
+		select {
+		case got := <-runs:
+			if got == want {
+				return
+			}
+		default:
+			time.Sleep(5 * time.Millisecond)
+		}
+	}
+	t.Fatalf("engine generation %d not observed", want)
+}
+
+// recordedBusFactory records every bus it builds so tests can publish
+// on the exact old/new generation buses.
+type recordedBusFactory struct {
+	built chan event.Bus
+}
+
+func (f recordedBusFactory) Spec() resource.Spec {
+	return resource.Spec{Kind: "event.Bus", Impl: "recorded"}
+}
+
+func (f recordedBusFactory) New(context.Context, resource.Input) (any, error) {
+	bus := event.NewMemoryBus()
+	f.built <- bus
+	return bus, nil
+}
+
+// sharedCheckpointBacking is one storage layer shared by every store
+// handle a factory produces, simulating a store that survives a
+// rebuild (e.g. the same sqlite file behind two handles).
+type sharedCheckpointBacking struct {
+	mu  sync.Mutex
+	cps map[string]agent.Checkpoint
+}
+
+type sharedCheckpointStore struct{ backing *sharedCheckpointBacking }
+
+func (s *sharedCheckpointStore) Save(_ context.Context, cp agent.Checkpoint) error {
+	s.backing.mu.Lock()
+	defer s.backing.mu.Unlock()
+	s.backing.cps[cp.ExecID] = cp.Clone()
+	return nil
+}
+
+func (s *sharedCheckpointStore) Load(_ context.Context, id string) (*agent.Checkpoint, error) {
+	s.backing.mu.Lock()
+	defer s.backing.mu.Unlock()
+	cp, ok := s.backing.cps[id]
+	if !ok {
+		return nil, nil
+	}
+	clone := cp.Clone()
+	return &clone, nil
+}
+
+func (s *sharedCheckpointStore) Delete(_ context.Context, id string) error {
+	s.backing.mu.Lock()
+	defer s.backing.mu.Unlock()
+	delete(s.backing.cps, id)
+	return nil
+}
+
+type sharedStoreFactory struct{ backing *sharedCheckpointBacking }
+
+func (f sharedStoreFactory) Spec() resource.Spec {
+	return resource.Spec{Kind: "agent.CheckpointStore", Impl: "shared"}
+}
+
+func (f sharedStoreFactory) New(context.Context, resource.Input) (any, error) {
+	return &sharedCheckpointStore{backing: f.backing}, nil
+}
+
+// noDeleteStore implements the CheckpointStore contract without
+// CheckpointDeleter, for resume-contract validation tests.
+type noDeleteStore struct{}
+
+func (noDeleteStore) Save(context.Context, agent.Checkpoint) error { return nil }
+func (noDeleteStore) Load(context.Context, string) (*agent.Checkpoint, error) {
+	return nil, nil
+}
+
+type noDeleteStoreFactory struct{}
+
+func (noDeleteStoreFactory) Spec() resource.Spec {
+	return resource.Spec{Kind: "agent.CheckpointStore", Impl: "nodelete"}
+}
+
+func (noDeleteStoreFactory) New(context.Context, resource.Input) (any, error) {
+	return noDeleteStore{}, nil
+}
+
+// appendEngineFactory completes every turn by appending one assistant
+// message, so tests can count conversation history across reloads.
+type appendEngineFactory struct{}
+
+func (appendEngineFactory) Spec() resource.Spec {
+	return resource.Spec{Kind: "append-engine"}
+}
+
+func (appendEngineFactory) New(context.Context, resource.Input) (any, error) {
+	return agent.EngineFunc(func(
+		ctx context.Context,
+		run agent.Run,
+		host agent.Host,
+		board *agent.Board,
+	) (*agent.Board, error) {
+		_ = publishRunEvent(ctx, host, agent.SubjectRunStart(run.RunID), run)
+		board.AppendChannelMessage(
+			agent.MainChannel,
+			message.NewTextMessage(message.RoleAssistant, "ok"))
+		_ = publishRunEvent(ctx, host, agent.SubjectRunEnd(run.RunID), run)
+		return board, nil
+	}), nil
+}
+
+// recordSink collects envelopes for runtime-level Attach assertions.
+type recordSink struct {
+	mu  sync.Mutex
+	got []event.Envelope
+}
+
+func (s *recordSink) OnEnvelope(_ context.Context, env event.Envelope) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.got = append(s.got, env)
+	return nil
+}
+
+func (s *recordSink) count() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return len(s.got)
+}
+
+func reloadDoc(t *testing.T, agents, extra string) deploy.Document {
+	t.Helper()
+	return parseRuntimeDoc(t, `version: v1
+resources:
+  events: {kind: event.Bus, impl: memory}
+`+extra+`
+agents:
+`+agents+`
+runtime:
+  event_bus: events
+  sessions: {idle_timeout: 1m, sink_buffer: 8}
+`)
+}
+
+func TestRuntimeReloadSwapsGenerationWithInFlightTurn(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	f := &gatedEngineFactory{
+		runs: make(chan int64, 8),
+		gate: make(chan struct{}),
+	}
+	reg := resource.NewRegistry()
+	reg.MustRegister(f)
+	reg.MustRegister(event.NewFactory())
+
+	doc1 := reloadDoc(t, `  bot:
+    card: {name: Bot}
+    engine: {kind: reload-engine}
+`, "")
+	app, err := NewBuilder(reg).Build(ctx, doc1)
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	t.Cleanup(func() { _ = app.Close() })
+
+	lease, err := app.Sessions().Open(ctx, session.Key{
+		AgentID: "bot", ContextID: "ctx",
+	})
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	t.Cleanup(func() { _ = lease.Close() })
+	turn, err := lease.Session().Start(ctx, agent.Request{})
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	waitForGen(t, f.runs, 1)
+
+	// Reload while the turn is blocked on the gate.
+	doc2 := reloadDoc(t, `  bot:
+    card: {name: Bot v2}
+    engine: {kind: reload-engine}
+`, "")
+	result, err := app.Reload(ctx, doc2)
+	if err != nil {
+		t.Fatalf("Reload: %v", err)
+	}
+	if result.GenerationID != 2 || result.PreviousID != 1 {
+		t.Fatalf("ReloadResult = %+v, want generation 2 over 1", result)
+	}
+	if _, ok := app.Agent("bot"); !ok {
+		t.Fatal("bot not resolvable after reload")
+	}
+
+	// The in-flight turn completes on generation 1.
+	close(f.gate)
+	if _, err := turn.Wait(ctx); err != nil {
+		t.Fatalf("in-flight turn Wait: %v", err)
+	}
+
+	// The next turn runs on generation 2.
+	next, err := lease.Session().Start(ctx, agent.Request{})
+	if err != nil {
+		t.Fatalf("Start after reload: %v", err)
+	}
+	waitForGen(t, f.runs, 2)
+	if _, err := next.Wait(ctx); err != nil {
+		t.Fatalf("next turn Wait: %v", err)
+	}
+}
+
+func TestRuntimeReloadAllowsBusConfigChange(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	built := make(chan event.Bus, 4)
+	reg := resource.NewRegistry()
+	reg.MustRegister(recordedBusFactory{built: built})
+	reg.MustRegister(appendEngineFactory{})
+
+	doc1 := parseRuntimeDoc(t, `version: v1
+resources:
+  events: {kind: event.Bus, impl: recorded, settings: {route_cache_size: 1024}}
+agents:
+  bot:
+    card: {name: Bot}
+    engine: {kind: append-engine}
+runtime:
+  event_bus: events
+  sessions: {idle_timeout: 1m, sink_buffer: 8}
+`)
+	app, err := NewBuilder(reg).Build(ctx, doc1)
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	t.Cleanup(func() { _ = app.Close() })
+	bus1 := <-built
+
+	sink := &recordSink{}
+	detach, err := app.Attach(ctx, event.Pattern("reload.bus.*"), sink)
+	if err != nil {
+		t.Fatalf("Attach: %v", err)
+	}
+	t.Cleanup(detach)
+
+	// The new document changes the bus resource settings: reload must
+	// accept it, attach the new bus to the router, and retire bus1.
+	doc2 := parseRuntimeDoc(t, `version: v1
+resources:
+  events: {kind: event.Bus, impl: recorded, settings: {route_cache_size: 2048}}
+agents:
+  bot:
+    card: {name: Bot v2}
+    engine: {kind: append-engine}
+runtime:
+  event_bus: events
+  sessions: {idle_timeout: 1m, sink_buffer: 8}
+`)
+	if _, err := app.Reload(ctx, doc2); err != nil {
+		t.Fatalf("Reload with bus config change: %v", err)
+	}
+	bus2 := <-built
+	if app.bus != bus2 {
+		t.Fatal("runtime bus not switched to the new generation's bus")
+	}
+
+	publishOn(t, bus2, "reload.bus.after")
+	waitForCount(t, sink, 1)
+	// The old bus was removed and closed with the retired generation:
+	// publishing on it must not reach the attachment.
+	_ = bus1.Publish(context.Background(), event.Envelope{
+		Subject: event.Subject("reload.bus.old"),
+	})
+	time.Sleep(50 * time.Millisecond)
+	if sink.count() != 1 {
+		t.Fatalf("old bus delivery after reload = %d, want 1", sink.count())
+	}
+}
+
+func TestRuntimeReloadAllowsCheckpointConfigChange(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	backing := &sharedCheckpointBacking{cps: make(map[string]agent.Checkpoint)}
+	reg := resource.NewRegistry()
+	reg.MustRegister(event.NewFactory())
+	reg.MustRegister(sharedStoreFactory{backing: backing})
+	reg.MustRegister(appendEngineFactory{})
+
+	doc1 := parseRuntimeDoc(t, `version: v1
+resources:
+  events: {kind: event.Bus, impl: memory}
+  cps: {kind: agent.CheckpointStore, impl: shared, settings: {window: 10}}
+agents:
+  bot:
+    card: {name: Bot}
+    engine: {kind: append-engine}
+runtime:
+  event_bus: events
+  checkpoint_store: cps
+  sessions: {idle_timeout: 1m, sink_buffer: 8, resume: true}
+`)
+	app, err := NewBuilder(reg).Build(ctx, doc1)
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	t.Cleanup(func() { _ = app.Close() })
+
+	first := runTurn(t, app.Sessions(), "bot", "ctx")
+	if got := assistantCount(first.LastBoard); got != 1 {
+		t.Fatalf("first turn messages = %d, want 1", got)
+	}
+
+	// Reload with different checkpoint store settings (same backing).
+	doc2 := parseRuntimeDoc(t, `version: v1
+resources:
+  events: {kind: event.Bus, impl: memory}
+  cps: {kind: agent.CheckpointStore, impl: shared, settings: {window: 40}}
+agents:
+  bot:
+    card: {name: Bot v2}
+    engine: {kind: append-engine}
+runtime:
+  event_bus: events
+  checkpoint_store: cps
+  sessions: {idle_timeout: 1m, sink_buffer: 8, resume: true}
+`)
+	if _, err := app.Reload(ctx, doc2); err != nil {
+		t.Fatalf("Reload with checkpoint config change: %v", err)
+	}
+
+	// Same session key continues on the new store handle; the committed
+	// history from the first turn must carry over.
+	second := runTurn(t, app.Sessions(), "bot", "ctx")
+	if got := assistantCount(second.LastBoard); got != 2 {
+		t.Fatalf("second turn messages = %d, want 2 (history preserved)", got)
+	}
+}
+
+func TestRuntimeReloadRebindsDynamicAgents(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	reg := resource.NewRegistry()
+	reg.MustRegister(event.NewFactory())
+	reg.MustRegister(appendEngineFactory{})
+	doc := reloadDoc(t, `  bot:
+    card: {name: Bot}
+    engine: {kind: append-engine}
+`, "")
+	app, err := NewBuilder(reg).Build(ctx, doc)
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	t.Cleanup(func() { _ = app.Close() })
+
+	instance, err := app.RegisterAgent(ctx, "dyn", agent.Definition{
+		Card: agent.AgentCard{Name: "Dyn"},
+		Engine: agent.EngineRef{
+			Kind: "append-engine",
+		},
+	})
+	if err != nil {
+		t.Fatalf("RegisterAgent: %v", err)
+	}
+	if instance == nil {
+		t.Fatal("RegisterAgent returned nil instance")
+	}
+
+	if _, err := app.Reload(ctx, doc); err != nil {
+		t.Fatalf("Reload: %v", err)
+	}
+	if _, ok := app.Agent("dyn"); !ok {
+		t.Fatal("dynamic agent lost after reload")
+	}
+	runTurn(t, app.Sessions(), "dyn", "ctx")
+}
+
+func TestRuntimeReloadDrainsRemovedAgents(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	reg := resource.NewRegistry()
+	reg.MustRegister(event.NewFactory())
+	reg.MustRegister(appendEngineFactory{})
+	doc1 := reloadDoc(t, `  bot:
+    card: {name: Bot}
+    engine: {kind: append-engine}
+  extra:
+    card: {name: Extra}
+    engine: {kind: append-engine}
+`, "")
+	app, err := NewBuilder(reg).Build(ctx, doc1)
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	t.Cleanup(func() { _ = app.Close() })
+
+	runTurn(t, app.Sessions(), "extra", "ctx")
+	doc2 := reloadDoc(t, `  bot:
+    card: {name: Bot}
+    engine: {kind: append-engine}
+`, "")
+	result, err := app.Reload(ctx, doc2)
+	if err != nil {
+		t.Fatalf("Reload: %v", err)
+	}
+	if len(result.DrainedAgents) != 1 || result.DrainedAgents[0] != "extra" {
+		t.Fatalf("DrainedAgents = %v, want [extra]", result.DrainedAgents)
+	}
+	if _, err := app.Sessions().Open(ctx, session.Key{
+		AgentID: "extra", ContextID: "ctx",
+	}); !errdefs.IsNotFound(err) {
+		t.Fatalf("Open(removed agent) error = %v, want not found", err)
+	}
+	runTurn(t, app.Sessions(), "bot", "ctx")
+}
+
+func TestRuntimeReloadDrainTimeoutClearsTombstone(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	f := &gatedEngineFactory{
+		runs: make(chan int64, 8),
+		gate: make(chan struct{}),
+	}
+	reg := resource.NewRegistry()
+	reg.MustRegister(f)
+	reg.MustRegister(event.NewFactory())
+	doc1 := reloadDoc(t, `  bot:
+    card: {name: Bot}
+    engine: {kind: reload-engine}
+  extra:
+    card: {name: Extra}
+    engine: {kind: reload-engine}
+`, "")
+	app, err := NewBuilder(reg).Build(ctx, doc1)
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	t.Cleanup(func() { _ = app.Close() })
+
+	// Keep "extra" busy so the reload drain cannot finish within the
+	// short reload context.
+	lease, err := app.Sessions().Open(ctx, session.Key{
+		AgentID: "extra", ContextID: "ctx",
+	})
+	if err != nil {
+		t.Fatalf("Open(extra): %v", err)
+	}
+	t.Cleanup(func() { _ = lease.Close() })
+	turn, err := lease.Session().Start(ctx, agent.Request{})
+	if err != nil {
+		t.Fatalf("Start(extra): %v", err)
+	}
+	waitForGen(t, f.runs, 2)
+
+	reloadCtx, cancelReload := context.WithTimeout(
+		context.Background(), 100*time.Millisecond)
+	defer cancelReload()
+	doc2 := reloadDoc(t, `  bot:
+    card: {name: Bot}
+    engine: {kind: reload-engine}
+`, "")
+	if _, err := app.Reload(reloadCtx, doc2); !errdefs.IsTimeout(err) {
+		t.Fatalf("Reload error = %v, want deadline exceeded", err)
+	}
+	// The failed reload must leave the old generation fully serving:
+	// the tombstone "extra" tried to drain is cleared.
+	if _, err := app.Sessions().Open(context.Background(), session.Key{
+		AgentID: "extra", ContextID: "ctx",
+	}); err != nil {
+		t.Fatalf("Open(extra) after failed reload = %v, want nil", err)
+	}
+	close(f.gate)
+	if _, err := turn.Wait(ctx); err != nil {
+		t.Fatalf("in-flight turn Wait: %v", err)
+	}
+}
+
+func TestRuntimeReloadFailureKeepsOldGeneration(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	reg := resource.NewRegistry()
+	reg.MustRegister(event.NewFactory())
+	reg.MustRegister(appendEngineFactory{})
+	doc1 := reloadDoc(t, `  bot:
+    card: {name: Bot}
+    engine: {kind: append-engine}
+`, "")
+	app, err := NewBuilder(reg).Build(ctx, doc1)
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	t.Cleanup(func() { _ = app.Close() })
+
+	doc2 := reloadDoc(t, `  bot:
+    card: {name: Bot}
+    engine: {kind: append-engine}
+`, `  bad: {kind: nope.Thing, impl: x}`)
+	if _, err := app.Reload(ctx, doc2); err == nil {
+		t.Fatal("Reload with unresolvable resource succeeded, want error")
+	}
+	runTurn(t, app.Sessions(), "bot", "ctx")
+	if app.current.id != 1 {
+		t.Fatalf("generation id after failed reload = %d, want 1", app.current.id)
+	}
+}
+
+func TestRuntimeReloadResumeRequiresDeleterStore(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	reg := resource.NewRegistry()
+	reg.MustRegister(event.NewFactory())
+	reg.MustRegister(noDeleteStoreFactory{})
+	reg.MustRegister(appendEngineFactory{})
+	doc1 := reloadDoc(t, `  bot:
+    card: {name: Bot}
+    engine: {kind: append-engine}
+`, "")
+	app, err := NewBuilder(reg).Build(ctx, doc1)
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	t.Cleanup(func() { _ = app.Close() })
+
+	doc2 := parseRuntimeDoc(t, `version: v1
+resources:
+  events: {kind: event.Bus, impl: memory}
+  cps: {kind: agent.CheckpointStore, impl: nodelete}
+agents:
+  bot:
+    card: {name: Bot}
+    engine: {kind: append-engine}
+runtime:
+  event_bus: events
+  checkpoint_store: cps
+  sessions: {idle_timeout: 1m, sink_buffer: 8, resume: true}
+`)
+	if _, err := app.Reload(ctx, doc2); !errdefs.IsValidation(err) {
+		t.Fatalf("Reload resume-without-deleter error = %v, want validation", err)
+	}
+}
+
+// TestRuntimeReloadRejectsSharedBusFactory guards the ownership
+// assumption that every generation owns its own bus: a factory that
+// returns the current generation's bus must be rejected without the
+// aborted result closing the shared bus.
+func TestRuntimeReloadRejectsSharedBusFactory(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	bus := event.NewMemoryBus()
+	t.Cleanup(func() { _ = bus.Close() })
+	reg := resource.NewRegistry()
+	reg.MustRegister(singletonBusFactory{bus: bus})
+	reg.MustRegister(appendEngineFactory{})
+	doc := parseRuntimeDoc(t, `version: v1
+resources:
+  events: {kind: event.Bus, impl: singleton}
+agents:
+  bot:
+    card: {name: Bot}
+    engine: {kind: append-engine}
+runtime:
+  event_bus: events
+  sessions: {idle_timeout: 1m, sink_buffer: 8}
+`)
+	app, err := NewBuilder(reg).Build(ctx, doc)
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	t.Cleanup(func() { _ = app.Close() })
+
+	if _, err := app.Reload(ctx, doc); !errdefs.IsConflict(err) {
+		t.Fatalf("Reload with shared bus error = %v, want conflict", err)
+	}
+	// The old generation keeps serving and its bus is still open.
+	runTurn(t, app.Sessions(), "bot", "ctx")
+	publishOn(t, bus, "reload.shared.alive")
+}
+
+type singletonBusFactory struct{ bus event.Bus }
+
+func (f singletonBusFactory) Spec() resource.Spec {
+	return resource.Spec{Kind: "event.Bus", Impl: "singleton"}
+}
+
+func (f singletonBusFactory) New(context.Context, resource.Input) (any, error) {
+	return f.bus, nil
+}
+
+func publishOn(t *testing.T, bus event.Bus, subject string) {
+	t.Helper()
+	if err := bus.Publish(context.Background(), event.Envelope{
+		Subject: event.Subject(subject),
+	}); err != nil {
+		t.Fatalf("Publish(%s): %v", subject, err)
+	}
+}
+
+func waitForCount(t *testing.T, sink *recordSink, want int) {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		if sink.count() >= want {
+			return
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Fatalf("sink count = %d, want %d", sink.count(), want)
+}
+
+func assistantCount(board *agent.Board) int {
+	if board == nil {
+		return 0
+	}
+	count := 0
+	for _, m := range board.Channel(agent.MainChannel) {
+		if m.Role == message.RoleAssistant {
+			count++
+		}
+	}
+	return count
+}

--- a/core/runtime/runtime.go
+++ b/core/runtime/runtime.go
@@ -31,6 +31,15 @@ type Runtime struct {
 	resources *resource.Registry
 	loader    *resource.Loader
 	bus       event.Bus
+	// hostDecorator is retained from the Builder so a later Reload can
+	// rebuild a host factory for a new deployment generation with the
+	// exact same decoration policy.
+	hostDecorator HostFactoryDecorator
+	// current is the active deployment generation. Reload replaces it
+	// atomically; Close retires and closes it.
+	current *Generation
+	// nextGenID allocates generation ids.
+	nextGenID uint64
 
 	// lifecycleMu serializes RegisterAgent / UnregisterAgent / Close so
 	// a removal can never sweep away a concurrent registration.
@@ -113,7 +122,10 @@ func (r *Runtime) Close() error {
 	r.closed = true
 	r.lifecycleMu.Unlock()
 	r.closeOnce.Do(func() {
-		r.closeErr = closeOwned(r.manager, r.router, r.result, r.registry)
+		if r.current != nil {
+			r.current.freeze(dynamicInstances(r.registry.Entries()))
+		}
+		r.closeErr = closeOwned(r.manager, r.router, r.current)
 	})
 	return r.closeErr
 }
@@ -121,8 +133,7 @@ func (r *Runtime) Close() error {
 func closeOwned(
 	manager *session.Manager,
 	router *event.Router,
-	result *deploy.Result,
-	registry *AgentRegistry,
+	current *Generation,
 ) error {
 	var errs []error
 	if manager != nil {
@@ -135,14 +146,9 @@ func closeOwned(
 			errs = append(errs, fmt.Errorf("runtime close stream router: %w", err))
 		}
 	}
-	if result != nil {
-		if err := result.Close(); err != nil {
-			errs = append(errs, fmt.Errorf("runtime close deployment: %w", err))
-		}
-	}
-	if registry != nil {
-		if err := registry.Close(); err != nil {
-			errs = append(errs, fmt.Errorf("runtime close agent registry: %w", err))
+	if current != nil {
+		if err := current.close(); err != nil {
+			errs = append(errs, fmt.Errorf("runtime close generation: %w", err))
 		}
 	}
 	return errors.Join(errs...)

--- a/core/runtime/session/config.go
+++ b/core/runtime/session/config.go
@@ -1,0 +1,57 @@
+package session
+
+import (
+	"time"
+
+	"github.com/GizClaw/flowcraft/core/errdefs"
+)
+
+// Tunables are the manager-level session settings a generation reload
+// may change. Semantics:
+//
+//   - IdleTimeout and MaxSessions are read live by the manager, so a
+//     change applies immediately (future timers and open checks).
+//   - SinkBuffer, SpeculativeEvents, SpeculativeBytes, and
+//     DeliveryConcurrency are captured by each Session at creation, so
+//     a change applies to sessions created afterwards.
+type Tunables struct {
+	IdleTimeout         time.Duration
+	SinkBuffer          int
+	SpeculativeEvents   int
+	SpeculativeBytes    int
+	DeliveryConcurrency int
+	MaxSessions         int
+}
+
+// UpdateTunables validates and atomically applies new manager tunables.
+// Validation mirrors the With* ManagerOptions (positive bounds).
+func (m *Manager) UpdateTunables(t Tunables) error {
+	if m == nil {
+		return errdefs.Validationf("runtime session: manager is nil")
+	}
+	opts := managerOptions{}
+	for _, option := range []ManagerOption{
+		WithIdleTimeout(t.IdleTimeout),
+		WithSinkBufferSize(t.SinkBuffer),
+		WithSpeculativeBufferLimits(t.SpeculativeEvents, t.SpeculativeBytes),
+		WithDeliveryConcurrency(t.DeliveryConcurrency),
+		WithMaxSessions(t.MaxSessions),
+	} {
+		if err := option(&opts); err != nil {
+			return err
+		}
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.closed {
+		return ErrManagerClosed
+	}
+	m.idleTimeout = opts.idleTimeout
+	m.sinkBuffer = opts.sinkBuffer
+	m.speculativeEvents = opts.speculativeEvents
+	m.speculativeBytes = opts.speculativeBytes
+	m.deliveryConcurrency = opts.deliveryConcurrency
+	m.maxSessions = opts.maxSessions
+	return nil
+}

--- a/core/runtime/session/epoch.go
+++ b/core/runtime/session/epoch.go
@@ -1,0 +1,119 @@
+package session
+
+import (
+	"github.com/GizClaw/flowcraft/core/agent"
+	"github.com/GizClaw/flowcraft/core/errdefs"
+)
+
+// Deps is one Start's complete consistency snapshot: the resolver,
+// host factory, and catalog provider a turn may use, tagged with the
+// epoch they belong to. A turn bound to an epoch never mixes
+// dependencies from another epoch, so a generation swap can never tear
+// a single execution.
+type Deps struct {
+	Resolver        InstanceResolver
+	HostFactory     HostFactory
+	CatalogProvider CatalogProvider
+	// Checkpoints and Resume are the epoch's session durability
+	// settings: turns resolve them from their epoch, so a generation
+	// reload can change the store or the resume flag without touching
+	// in-flight turns.
+	Checkpoints agent.CheckpointStore
+	Resume      bool
+	Epoch       uint64
+}
+
+// epochState tracks one epoch's dependencies and the references held
+// by in-flight turns. A retired epoch stays alive until its refs drop
+// to zero, then its onRetired hook (installed by SwapDeps) runs so the
+// owner can release the underlying generation exactly once.
+type epochState struct {
+	deps      Deps
+	refs      int
+	retired   bool
+	onRetired func(epoch uint64, deps Deps)
+}
+
+// beginEpoch atomically captures the current epoch and increments its
+// reference count. The returned release function MUST be called exactly
+// once per acquisition; it is safe to call again (a no-op), and it
+// decrements the refcount for the captured epoch, not the current one.
+// A missing current epoch is an internal invariant violation and is
+// surfaced as an error rather than handed to the caller as empty deps.
+func (m *Manager) beginEpoch() (Deps, func(), error) {
+	m.mu.Lock()
+	state := m.epochs[m.epochSeq]
+	if state == nil {
+		m.mu.Unlock()
+		return Deps{}, func() {}, errdefs.Internalf(
+			"runtime session: current epoch %d is missing", m.epochSeq)
+	}
+	state.refs++
+	deps := state.deps
+	m.mu.Unlock()
+	return deps, func() { m.endEpoch(deps.Epoch) }, nil
+}
+
+// endEpoch releases one reference on epoch. When the epoch is retired
+// and its refs reach zero it is removed from the manager and its
+// onRetired hook runs (outside the manager lock).
+func (m *Manager) endEpoch(epoch uint64) {
+	m.mu.Lock()
+	state := m.epochs[epoch]
+	if state == nil || state.refs <= 0 {
+		m.mu.Unlock()
+		return
+	}
+	state.refs--
+	if state.refs > 0 || !state.retired {
+		m.mu.Unlock()
+		return
+	}
+	delete(m.epochs, epoch)
+	hook := state.onRetired
+	deps := state.deps
+	m.mu.Unlock()
+	if hook != nil {
+		hook(epoch, deps)
+	}
+}
+
+// SwapDeps atomically retires the current epoch and installs deps as
+// the new current epoch. onRetired, when non-nil, is invoked exactly
+// once when the retired epoch's references reach zero (immediately, if
+// none are outstanding). SwapDeps fails after the manager is closed.
+func (m *Manager) SwapDeps(
+	deps Deps,
+	onRetired func(epoch uint64, d Deps),
+) error {
+	if isNil(deps.Resolver) || isNil(deps.HostFactory) {
+		return errdefs.Validationf(
+			"runtime session: swap deps require a resolver and a host factory")
+	}
+
+	m.mu.Lock()
+	if m.closed {
+		m.mu.Unlock()
+		return ErrManagerClosed
+	}
+	m.epochSeq++
+	deps.Epoch = m.epochSeq
+	m.epochs[deps.Epoch] = &epochState{deps: deps}
+
+	var retireNow *epochState
+	if prev := m.epochs[m.epochSeq-1]; prev != nil {
+		prev.onRetired = onRetired
+		prev.retired = true
+		if prev.refs == 0 {
+			delete(m.epochs, prev.deps.Epoch)
+			retireNow = prev
+		}
+	}
+	m.deps = deps
+	m.mu.Unlock()
+
+	if retireNow != nil && retireNow.onRetired != nil {
+		retireNow.onRetired(retireNow.deps.Epoch, retireNow.deps)
+	}
+	return nil
+}

--- a/core/runtime/session/epoch_test.go
+++ b/core/runtime/session/epoch_test.go
@@ -1,0 +1,188 @@
+package session
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/GizClaw/flowcraft/core/agent"
+	"github.com/GizClaw/flowcraft/core/errdefs"
+	"github.com/GizClaw/flowcraft/core/event"
+	"github.com/GizClaw/flowcraft/core/message"
+	"github.com/GizClaw/flowcraft/core/tool"
+)
+
+type stubToolSession struct{}
+
+func (stubToolSession) Get(string) (tool.Tool, bool)          { return nil, false }
+func (stubToolSession) Definitions() []message.ToolDefinition { return nil }
+func (stubToolSession) Require(...string)                     {}
+func (stubToolSession) Select(...string)                      {}
+func (stubToolSession) RecordCall(message.ToolCall)           {}
+func (stubToolSession) AdvanceTurn()                          {}
+func (stubToolSession) Search(context.Context, string, int) ([]tool.SearchHit, error) {
+	return nil, nil
+}
+func (stubToolSession) SearchWithLoad(context.Context, string, int) ([]tool.SearchHit, error) {
+	return nil, nil
+}
+func (stubToolSession) Load(context.Context) error { return nil }
+func (stubToolSession) EnsureLoaded(context.Context, ...string) error {
+	return nil
+}
+
+func TestManagerEpochSwapRetiresWhenReferencesDrain(t *testing.T) {
+	manager, _ := newTestManager(t, time.Minute)
+
+	deps, release, err := manager.beginEpoch()
+	if err != nil {
+		t.Fatalf("beginEpoch: %v", err)
+	}
+	if deps.Epoch != 1 {
+		t.Fatalf("beginEpoch epoch = %d, want 1", deps.Epoch)
+	}
+
+	var retired []uint64
+	next := Deps{
+		Resolver:    manager.deps.Resolver,
+		HostFactory: manager.deps.HostFactory,
+		Epoch:       0, // SwapDeps assigns the next epoch
+	}
+	if err := manager.SwapDeps(next, func(epoch uint64, _ Deps) {
+		retired = append(retired, epoch)
+	}); err != nil {
+		t.Fatalf("SwapDeps: %v", err)
+	}
+	if len(retired) != 0 {
+		t.Fatalf("onRetired fired while refs outstanding: %v", retired)
+	}
+
+	release()
+	if len(retired) != 1 || retired[0] != 1 {
+		t.Fatalf("onRetired = %v, want [1] after refs drained", retired)
+	}
+
+	// A second release is a no-op and must not fire the hook again.
+	release()
+	if len(retired) != 1 {
+		t.Fatalf("onRetired fired twice: %v", retired)
+	}
+}
+
+func TestManagerEpochSwapRetiresImmediatelyWhenUnreferenced(t *testing.T) {
+	manager, _ := newTestManager(t, time.Minute)
+
+	var retired []uint64
+	next := Deps{
+		Resolver:    manager.deps.Resolver,
+		HostFactory: manager.deps.HostFactory,
+	}
+	if err := manager.SwapDeps(next, func(epoch uint64, _ Deps) {
+		retired = append(retired, epoch)
+	}); err != nil {
+		t.Fatalf("SwapDeps: %v", err)
+	}
+	if len(retired) != 1 || retired[0] != 1 {
+		t.Fatalf("onRetired = %v, want [1] (no refs outstanding)", retired)
+	}
+	if manager.deps.Epoch != 2 {
+		t.Fatalf("current epoch = %d, want 2", manager.deps.Epoch)
+	}
+}
+
+func TestManagerSwapDepsRejectsInvalid(t *testing.T) {
+	manager, _ := newTestManager(t, time.Minute)
+	if err := manager.SwapDeps(Deps{}, nil); !errdefs.IsValidation(err) {
+		t.Fatalf("SwapDeps(empty) error = %v, want validation", err)
+	}
+	if err := manager.SwapDeps(Deps{
+		Resolver: manager.deps.Resolver,
+	}, nil); !errdefs.IsValidation(err) {
+		t.Fatalf("SwapDeps(no host) error = %v, want validation", err)
+	}
+}
+
+func TestManagerEpochSwapAfterCloseRejected(t *testing.T) {
+	manager, _ := newTestManager(t, time.Minute)
+	if err := manager.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	if err := manager.SwapDeps(manager.deps, nil); !errdefs.IsNotAvailable(err) {
+		t.Fatalf("SwapDeps after close error = %v, want not available", err)
+	}
+}
+
+// TestSessionCatalogInvalidatesAcrossEpochs verifies that a session
+// builds a fresh tool catalog when its next Start runs on a new epoch
+// instead of reusing the previous epoch's cached view.
+func TestSessionCatalogInvalidatesAcrossEpochs(t *testing.T) {
+	resolver := &testResolver{instances: map[string]*agent.Agent{
+		"agent-a": {},
+	}}
+	router := event.NewRouter(event.NewMemoryBus())
+	t.Cleanup(func() { _ = router.Close() })
+
+	var builds atomic.Int64
+	provider := CatalogProviderFunc(func(
+		context.Context,
+		*agent.Agent,
+	) (tool.Session, error) {
+		builds.Add(1)
+		return stubToolSession{}, nil
+	})
+	manager, err := NewManager(
+		resolver,
+		HostFactoryFunc(func(context.Context, HostRequest) (agent.Host, error) {
+			return agent.NoopHost{}, nil
+		}),
+		router,
+		WithIdleTimeout(time.Minute),
+		WithCatalogProvider(provider),
+	)
+	if err != nil {
+		t.Fatalf("NewManager: %v", err)
+	}
+	t.Cleanup(func() { _ = manager.Close() })
+
+	lease, err := manager.Open(context.Background(), Key{
+		AgentID: "agent-a", ContextID: "ctx",
+	})
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	t.Cleanup(func() { _ = lease.Close() })
+	s := lease.Session()
+
+	first, _, err := manager.beginEpoch()
+	if err != nil {
+		t.Fatalf("beginEpoch: %v", err)
+	}
+	catalog, err := s.catalogFor(context.Background(), first, &agent.Agent{})
+	if err != nil {
+		t.Fatalf("catalogFor(epoch 1): %v", err)
+	}
+	if catalog == nil || builds.Load() != 1 {
+		t.Fatalf("epoch 1 catalog build count = %d, want 1", builds.Load())
+	}
+	// Same epoch reuses the cache.
+	if _, err := s.catalogFor(context.Background(), first, &agent.Agent{}); err != nil {
+		t.Fatalf("catalogFor(epoch 1, again): %v", err)
+	}
+	if builds.Load() != 1 {
+		t.Fatalf("same-epoch build count = %d, want 1 (cached)", builds.Load())
+	}
+
+	second := Deps{
+		Resolver:        manager.deps.Resolver,
+		HostFactory:     manager.deps.HostFactory,
+		CatalogProvider: provider,
+		Epoch:           2,
+	}
+	if _, err := s.catalogFor(context.Background(), second, &agent.Agent{}); err != nil {
+		t.Fatalf("catalogFor(epoch 2): %v", err)
+	}
+	if builds.Load() != 2 {
+		t.Fatalf("cross-epoch build count = %d, want 2", builds.Load())
+	}
+}

--- a/core/runtime/session/manager.go
+++ b/core/runtime/session/manager.go
@@ -30,8 +30,6 @@ type managerEntry struct {
 // It borrows its resolver, HostFactory, and event router and never
 // closes them.
 type Manager struct {
-	resolver            InstanceResolver
-	hostFactory         HostFactory
 	router              *event.Router
 	idleTimeout         time.Duration
 	sinkBuffer          int
@@ -39,10 +37,13 @@ type Manager struct {
 	speculativeBytes    int
 	deliveryConcurrency int
 	maxSessions         int
-	checkpoints         agent.CheckpointStore
-	resume              bool
 	observer            SessionObserver
-	catalogProvider     CatalogProvider
+
+	// deps is the current epoch's execution snapshot; epochs tracks
+	// every live (current or retired-but-referenced) epoch.
+	deps     Deps
+	epochSeq uint64
+	epochs   map[uint64]*epochState
 
 	mu        sync.Mutex
 	entries   map[Key]*managerEntry
@@ -98,9 +99,7 @@ func NewManager(
 				"runtime session: resume requires a checkpoint store that implements CheckpointDeleter")
 		}
 	}
-	return &Manager{
-		resolver:            resolver,
-		hostFactory:         hostFactory,
+	m := &Manager{
 		router:              router,
 		idleTimeout:         opts.idleTimeout,
 		sinkBuffer:          opts.sinkBuffer,
@@ -108,13 +107,48 @@ func NewManager(
 		speculativeBytes:    opts.speculativeBytes,
 		deliveryConcurrency: opts.deliveryConcurrency,
 		maxSessions:         opts.maxSessions,
-		checkpoints:         opts.checkpoints,
-		resume:              opts.resume,
 		observer:            opts.observer,
-		catalogProvider:     opts.catalogProvider,
 		entries:             make(map[Key]*managerEntry),
 		removed:             make(map[string]struct{}),
-	}, nil
+		epochSeq:            1,
+		epochs:              make(map[uint64]*epochState),
+	}
+	m.initEpoch(resolver, hostFactory, opts.catalogProvider,
+		opts.checkpoints, opts.resume)
+	return m, nil
+}
+
+func (m *Manager) initEpoch(
+	resolver InstanceResolver,
+	hostFactory HostFactory,
+	catalogProvider CatalogProvider,
+	checkpoints agent.CheckpointStore,
+	resume bool,
+) {
+	m.epochs[1] = &epochState{
+		deps: Deps{
+			Resolver:        resolver,
+			HostFactory:     hostFactory,
+			CatalogProvider: catalogProvider,
+			Checkpoints:     checkpoints,
+			Resume:          resume,
+			Epoch:           1,
+		},
+	}
+	m.deps = m.epochs[1].deps
+}
+
+// currentDeps returns the current epoch's dependency snapshot. It is
+// used by session-level operations that run outside a turn (e.g.
+// Resumable); turn-scoped operations must use the epoch acquired at
+// Start so a concurrent swap cannot tear them.
+func (m *Manager) currentDeps() Deps {
+	if m == nil {
+		return Deps{}
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.deps
 }
 
 // Open returns an independent Lease over the Session identified by key.
@@ -164,18 +198,18 @@ func (m *Manager) open(ctx context.Context, key Key) (*Lease, error) {
 			"runtime session: max sessions reached (%d)", m.maxSessions)
 	}
 
-	instance, ok := m.resolver.Instance(key.AgentID)
+	instance, ok := m.deps.Resolver.Instance(key.AgentID)
 	if !ok {
 		return nil, errdefs.NotFoundf("runtime session: agent %q is not deployed", key.AgentID)
 	}
 	if instance == nil {
-		return nil, errdefs.Internalf("runtime session: resolver returned a nil instance for agent %q", key.AgentID)
+		return nil, errdefs.Internalf(
+			"runtime session: resolver returned a nil instance for agent %q",
+			key.AgentID)
 	}
 	session := newSession(
-		key, instance, m.hostFactory, m.router, m.sinkBuffer,
+		key, m, m.router, m.sinkBuffer,
 		m.speculativeEvents, m.speculativeBytes, m.deliveryConcurrency,
-		m.checkpoints, m.resume,
-		m.catalogProvider,
 		func(changed *Session) {
 			m.activityChanged(key, changed)
 		},

--- a/core/runtime/session/resume_test.go
+++ b/core/runtime/session/resume_test.go
@@ -332,7 +332,7 @@ func parkRun(
 		ResumableRunID: runID,
 		Request:        req,
 		Board:          agent.NewBoard().Snapshot(),
-	})
+	}, store, true)
 }
 
 type resumeProbeEngine struct {

--- a/core/runtime/session/session.go
+++ b/core/runtime/session/session.go
@@ -29,16 +29,12 @@ const (
 // deployment and event-routing dependencies from the runtime.
 type Session struct {
 	key                 Key
-	instance            *agent.Agent
-	hostFactory         HostFactory
+	manager             *Manager
 	router              *event.Router
 	sinkBuffer          int
 	speculativeEvents   int
 	speculativeBytes    int
 	deliveryConcurrency int
-	checkpoints         agent.CheckpointStore
-	resume              bool
-	catalogProvider     CatalogProvider
 
 	startMu        sync.Mutex
 	mu             sync.Mutex
@@ -48,6 +44,7 @@ type Session struct {
 	active         *Turn
 	closing        bool
 	catalog        sdktool.Session
+	catalogEpoch   uint64
 	activityNotify func(*Session)
 	observer       SessionObserver
 	closeOnce      sync.Once
@@ -56,31 +53,23 @@ type Session struct {
 
 func newSession(
 	key Key,
-	instance *agent.Agent,
-	hostFactory HostFactory,
+	manager *Manager,
 	router *event.Router,
 	sinkBuffer int,
 	speculativeEvents int,
 	speculativeBytes int,
 	deliveryConcurrency int,
-	checkpoints agent.CheckpointStore,
-	resume bool,
-	catalogProvider CatalogProvider,
 	activityNotify func(*Session),
 	observer SessionObserver,
 ) *Session {
 	return &Session{
 		key:                 key,
-		instance:            instance,
-		hostFactory:         hostFactory,
+		manager:             manager,
 		router:              router,
 		sinkBuffer:          sinkBuffer,
 		speculativeEvents:   speculativeEvents,
 		speculativeBytes:    speculativeBytes,
 		deliveryConcurrency: deliveryConcurrency,
-		checkpoints:         checkpoints,
-		resume:              resume,
-		catalogProvider:     catalogProvider,
 		activityNotify:      activityNotify,
 		observer:            observer,
 	}
@@ -102,6 +91,19 @@ func (s *Session) Start(ctx context.Context, request agent.Request, sinks ...Sin
 	s.startMu.Lock()
 	defer s.startMu.Unlock()
 
+	// Pin this turn to one epoch: every dependency the turn uses comes
+	// from this snapshot, so a concurrent generation swap cannot tear it.
+	deps, epochRelease, err := s.manager.beginEpoch()
+	if err != nil {
+		return nil, err
+	}
+	epochHeld := true
+	defer func() {
+		if epochHeld {
+			epochRelease()
+		}
+	}()
+
 	release, err := s.interruptActive(ctx)
 	if err != nil {
 		return nil, err
@@ -117,7 +119,7 @@ func (s *Session) Start(ctx context.Context, request agent.Request, sinks ...Sin
 	if err != nil {
 		return nil, err
 	}
-	state, err := s.loadSessionState(ctx)
+	state, err := s.loadSessionState(ctx, deps.Checkpoints, deps.Resume)
 	if err != nil {
 		return nil, err
 	}
@@ -127,10 +129,12 @@ func (s *Session) Start(ctx context.Context, request agent.Request, sinks ...Sin
 	}
 	request.ContextID = s.key.ContextID
 	request.RunID = runID
-	turn, err := s.startTurnLocked(ctx, request, runID, nil, nil, snapshot, sinks)
+	turn, err := s.startTurnLocked(
+		ctx, request, runID, deps, epochRelease, nil, nil, snapshot, sinks)
 	if err != nil {
 		return nil, err
 	}
+	epochHeld = false
 	activityHeld = false
 	return turn, nil
 }
@@ -155,6 +159,17 @@ func (s *Session) Resume(ctx context.Context, sinks ...SinkSpec) (*Turn, error) 
 	s.startMu.Lock()
 	defer s.startMu.Unlock()
 
+	deps, epochRelease, err := s.manager.beginEpoch()
+	if err != nil {
+		return nil, err
+	}
+	epochHeld := true
+	defer func() {
+		if epochHeld {
+			epochRelease()
+		}
+	}()
+
 	release, err := s.interruptActive(ctx)
 	if err != nil {
 		return nil, err
@@ -166,7 +181,7 @@ func (s *Session) Resume(ctx context.Context, sinks ...SinkSpec) (*Turn, error) 
 		}
 	}()
 
-	state, err := s.loadSessionState(ctx)
+	state, err := s.loadSessionState(ctx, deps.Checkpoints, deps.Resume)
 	if err != nil {
 		return nil, err
 	}
@@ -175,7 +190,18 @@ func (s *Session) Resume(ctx context.Context, sinks ...SinkSpec) (*Turn, error) 
 			"runtime session: no interrupted run to resume")
 	}
 	runID := state.ResumableRunID
-	resumeFrom, resumeCtx, err := s.loadResumableCheckpoint(ctx, runID)
+	instance, ok := deps.Resolver.Instance(s.key.AgentID)
+	if !ok {
+		return nil, errdefs.NotFoundf(
+			"runtime session: agent %q is not deployed", s.key.AgentID)
+	}
+	if instance == nil {
+		return nil, errdefs.Internalf(
+			"runtime session: resolver returned a nil instance for agent %q",
+			s.key.AgentID)
+	}
+	resumeFrom, resumeCtx, err := s.loadResumableCheckpoint(
+		ctx, runID, instance, deps.Checkpoints, deps.Resume)
 	if err != nil {
 		return nil, err
 	}
@@ -183,7 +209,7 @@ func (s *Session) Resume(ctx context.Context, sinks ...SinkSpec) (*Turn, error) 
 		// The parked marker points at a run whose checkpoint is gone
 		// (store eviction, manual cleanup); drop the marker so the
 		// session does not stay stuck in a resumable state.
-		s.clearParkedRun(state)
+		s.clearParkedRun(state, deps.Checkpoints, deps.Resume)
 		return nil, errdefs.NotFoundf(
 			"runtime session: checkpoint for parked run %s is gone", runID)
 	}
@@ -194,10 +220,12 @@ func (s *Session) Resume(ctx context.Context, sinks ...SinkSpec) (*Turn, error) 
 	request := *state.Request
 	request.ContextID = s.key.ContextID
 	request.RunID = runID
-	turn, err := s.startTurnLocked(ctx, request, runID, resumeFrom, resumeCtx, nil, sinks)
+	turn, err := s.startTurnLocked(
+		ctx, request, runID, deps, epochRelease, resumeFrom, resumeCtx, nil, sinks)
 	if err != nil {
 		return nil, err
 	}
+	epochHeld = false
 	activityHeld = false
 	return turn, nil
 }
@@ -205,14 +233,18 @@ func (s *Session) Resume(ctx context.Context, sinks ...SinkSpec) (*Turn, error) 
 // Resumable reports whether a previous turn ended without committing
 // and can be replayed via Resume. It returns the parked run id.
 func (s *Session) Resumable(ctx context.Context) (string, bool, error) {
-	if s == nil || !s.resume || s.checkpoints == nil {
+	if s == nil {
+		return "", false, nil
+	}
+	deps := s.manager.currentDeps()
+	if !deps.Resume || deps.Checkpoints == nil {
 		return "", false, nil
 	}
 	if ctx == nil {
 		return "", false, errdefs.Validationf(
 			"runtime session: Resumable context is required")
 	}
-	state, err := s.loadSessionState(ctx)
+	state, err := s.loadSessionState(ctx, deps.Checkpoints, deps.Resume)
 	if err != nil {
 		return "", false, err
 	}
@@ -280,18 +312,38 @@ func (s *Session) startTurnLocked(
 	ctx context.Context,
 	request agent.Request,
 	runID string,
+	deps Deps,
+	epochRelease func(),
 	resumeFrom *agent.Checkpoint,
 	resumeCtx *agent.ResumeContext,
 	snapshot *agent.BoardSnapshot,
 	sinks []SinkSpec,
 ) (*Turn, error) {
 	turn := newTurn(s, runID, ctx)
+	turn.release = epochRelease
+	turn.checkpoints = deps.Checkpoints
+	turn.resume = deps.Resume
 	turn.resumeFrom = resumeFrom
 	turn.resumeCtx = resumeCtx
 	turn.snapshot = snapshot
-	catalog, err := s.catalogFor(ctx)
+	instance, ok := deps.Resolver.Instance(s.key.AgentID)
+	if !ok {
+		turn.cancel()
+		epochRelease()
+		return nil, errdefs.NotFoundf(
+			"runtime session: agent %q is not deployed", s.key.AgentID)
+	}
+	if instance == nil {
+		turn.cancel()
+		epochRelease()
+		return nil, errdefs.Internalf(
+			"runtime session: resolver returned a nil instance for agent %q",
+			s.key.AgentID)
+	}
+	catalog, err := s.catalogFor(ctx, deps, instance)
 	if err != nil {
 		turn.cancel()
+		epochRelease()
 		return nil, err
 	}
 	if catalog != nil {
@@ -305,15 +357,18 @@ func (s *Session) startTurnLocked(
 	}
 	if err := hostRequest.Validate(); err != nil {
 		turn.cancel()
+		epochRelease()
 		return nil, err
 	}
-	host, err := s.hostFactory.NewHost(turn.runCtx, hostRequest)
+	host, err := deps.HostFactory.NewHost(turn.runCtx, hostRequest)
 	if err != nil {
 		turn.cancel()
+		epochRelease()
 		return nil, err
 	}
 	if isNil(host) {
 		turn.cancel()
+		epochRelease()
 		return nil, errdefs.Internalf("runtime session: HostFactory returned nil Host")
 	}
 	turn.host = host
@@ -366,6 +421,7 @@ func (s *Session) startTurnLocked(
 			attachment.detach(attachErr)
 		}
 		turn.cancel()
+		epochRelease()
 		return nil, attachErr
 	}
 	turn.coordinator = coordinator
@@ -380,6 +436,7 @@ func (s *Session) startTurnLocked(
 			attachment.detach(ErrSessionClosed)
 		}
 		turn.cancel()
+		epochRelease()
 		return nil, ErrSessionClosed
 	}
 	s.active = turn
@@ -389,7 +446,7 @@ func (s *Session) startTurnLocked(
 	s.mu.Unlock()
 
 	s.notifySessionStarted(turn)
-	go turn.execute(s.instance, request)
+	go turn.execute(instance, request)
 	return turn, nil
 }
 
@@ -431,11 +488,15 @@ func freshRunID() (string, error) {
 
 // loadSessionState reads the session's durable state, or (nil, nil)
 // when resume is disabled, no store is wired, or no record exists yet.
-func (s *Session) loadSessionState(ctx context.Context) (*sessionState, error) {
-	if s == nil || !s.resume || s.checkpoints == nil {
+func (s *Session) loadSessionState(
+	ctx context.Context,
+	checkpoints agent.CheckpointStore,
+	resume bool,
+) (*sessionState, error) {
+	if s == nil || !resume || checkpoints == nil {
 		return nil, nil
 	}
-	cp, err := s.checkpoints.Load(ctx, sessionStateID(s.key))
+	cp, err := checkpoints.Load(ctx, sessionStateID(s.key))
 	if err != nil {
 		return nil, fmt.Errorf("runtime session: load session state: %w", err)
 	}
@@ -453,8 +514,12 @@ func (s *Session) loadSessionState(ctx context.Context) (*sessionState, error) {
 
 // saveSessionState persists the session state record. Best-effort: a
 // store failure leaves the previous record in place.
-func (s *Session) saveSessionState(state *sessionState) {
-	if s == nil || !s.resume || s.checkpoints == nil || state == nil {
+func (s *Session) saveSessionState(
+	state *sessionState,
+	checkpoints agent.CheckpointStore,
+	resume bool,
+) {
+	if s == nil || !resume || checkpoints == nil || state == nil {
 		return
 	}
 	payload, err := json.Marshal(state)
@@ -474,18 +539,22 @@ func (s *Session) saveSessionState(state *sessionState) {
 	ctx, cancel := context.WithTimeout(
 		context.WithoutCancel(context.Background()), 5*time.Second)
 	defer cancel()
-	_ = s.checkpoints.Save(ctx, cp)
+	_ = checkpoints.Save(ctx, cp)
 }
 
 // clearParkedRun drops the resumable marker (e.g. the parked run's
 // checkpoint no longer exists) while preserving the committed board.
-func (s *Session) clearParkedRun(state *sessionState) {
+func (s *Session) clearParkedRun(
+	state *sessionState,
+	checkpoints agent.CheckpointStore,
+	resume bool,
+) {
 	if state == nil {
 		return
 	}
 	state.ResumableRunID = ""
 	state.Request = nil
-	s.saveSessionState(state)
+	s.saveSessionState(state, checkpoints, resume)
 }
 
 // afterTurn updates session state after a turn reaches its terminal
@@ -497,13 +566,14 @@ func (s *Session) clearParkedRun(state *sessionState) {
 //     checkpoint and park their run id + original request so Resume
 //     can replay them. The committed board is left untouched.
 func (s *Session) afterTurn(turn *Turn, result *agent.Result) {
-	if s == nil || !s.resume || s.checkpoints == nil || turn == nil {
+	if s == nil || turn == nil ||
+		!turn.resume || turn.checkpoints == nil {
 		return
 	}
 	ctx, cancel := context.WithTimeout(
 		context.WithoutCancel(context.Background()), 5*time.Second)
 	defer cancel()
-	prev, err := s.loadSessionState(ctx)
+	prev, err := s.loadSessionState(ctx, turn.checkpoints, turn.resume)
 	if err != nil {
 		prev = nil
 	}
@@ -512,7 +582,7 @@ func (s *Session) afterTurn(turn *Turn, result *agent.Result) {
 		state.Board = prev.Board
 	}
 	if result != nil && result.Committed {
-		s.deleteCheckpoint(turn.runID)
+		s.deleteCheckpoint(turn.runID, turn.checkpoints)
 		if result.LastBoard != nil {
 			state.Board = result.LastBoard.Snapshot()
 		}
@@ -523,17 +593,20 @@ func (s *Session) afterTurn(turn *Turn, result *agent.Result) {
 		request := turn.request
 		state.Request = &request
 	}
-	s.saveSessionState(state)
+	s.saveSessionState(state, turn.checkpoints, turn.resume)
 }
 
 // deleteCheckpoint removes a committed run's checkpoint. Best-effort:
 // a failed delete leaves an orphaned checkpoint under a run id that no
 // session state references, which is harmless.
-func (s *Session) deleteCheckpoint(runID string) {
-	if s == nil || !s.resume || s.checkpoints == nil {
+func (s *Session) deleteCheckpoint(
+	runID string,
+	checkpoints agent.CheckpointStore,
+) {
+	if checkpoints == nil {
 		return
 	}
-	deleter, ok := s.checkpoints.(agent.CheckpointDeleter)
+	deleter, ok := checkpoints.(agent.CheckpointDeleter)
 	if !ok {
 		return
 	}
@@ -549,8 +622,14 @@ func (s *Session) deleteCheckpoint(runID string) {
 func (s *Session) loadResumableCheckpoint(
 	ctx context.Context,
 	runID string,
+	instance *agent.Agent,
+	checkpoints agent.CheckpointStore,
+	resume bool,
 ) (*agent.Checkpoint, *agent.ResumeContext, error) {
-	cp, err := s.checkpoints.Load(ctx, runID)
+	if !resume || checkpoints == nil {
+		return nil, nil, nil
+	}
+	cp, err := checkpoints.Load(ctx, runID)
 	if err != nil {
 		return nil, nil, fmt.Errorf(
 			"runtime session: load checkpoint %s: %w", runID, err)
@@ -563,12 +642,12 @@ func (s *Session) loadResumableCheckpoint(
 			"runtime session: checkpoint exec id %q does not match parked run %q",
 			cp.ExecID, runID)
 	}
-	if !agent.IsResumable(s.instance.Engine) {
+	if !agent.IsResumable(instance.Engine) {
 		return nil, nil, errdefs.NotAvailablef(
 			"runtime session: engine %T does not support resume but checkpoint %s exists",
-			s.instance.Engine, runID)
+			instance.Engine, runID)
 	}
-	if resumer, ok := agent.AsResumer(s.instance.Engine); ok {
+	if resumer, ok := agent.AsResumer(instance.Engine); ok {
 		if err := resumer.CanResume(*cp); err != nil {
 			return nil, nil, fmt.Errorf(
 				"runtime session: checkpoint %s is not resumable: %w", runID, err)
@@ -682,21 +761,29 @@ func (s *Session) close() error {
 	return s.closeErr
 }
 
-// catalogFor returns the session catalog, creating it once via the
-// provider on the first Start. Start is serialized by startMu, so the
-// creation path is race-free; the defensive branch handles a provider
-// shared with code paths outside this Session.
-func (s *Session) catalogFor(ctx context.Context) (sdktool.Session, error) {
+// catalogFor returns the session catalog for one epoch, creating it via
+// the epoch's provider on first use. A catalog cached for a previous
+// epoch is not reused: after a generation swap the session must build
+// its injection view against the new epoch's assembly. Start is
+// serialized by startMu, so the creation path is race-free; the
+// defensive branch handles a provider shared with code paths outside
+// this Session.
+func (s *Session) catalogFor(
+	ctx context.Context,
+	deps Deps,
+	instance *agent.Agent,
+) (sdktool.Session, error) {
 	s.mu.Lock()
 	catalog := s.catalog
+	epoch := s.catalogEpoch
 	s.mu.Unlock()
-	if catalog != nil {
+	if catalog != nil && epoch == deps.Epoch {
 		return catalog, nil
 	}
-	if s.catalogProvider == nil {
+	if deps.CatalogProvider == nil {
 		return nil, nil
 	}
-	catalog, err := s.catalogProvider.NewCatalog(ctx, s.instance)
+	catalog, err := deps.CatalogProvider.NewCatalog(ctx, instance)
 	if err != nil {
 		return nil, err
 	}
@@ -705,8 +792,9 @@ func (s *Session) catalogFor(ctx context.Context) (sdktool.Session, error) {
 			"runtime session: CatalogProvider returned a nil catalog")
 	}
 	s.mu.Lock()
-	if s.catalog == nil {
+	if s.catalog == nil || s.catalogEpoch != deps.Epoch {
 		s.catalog = catalog
+		s.catalogEpoch = deps.Epoch
 	}
 	s.mu.Unlock()
 	return catalog, nil

--- a/core/runtime/session/turn.go
+++ b/core/runtime/session/turn.go
@@ -18,6 +18,15 @@ type Turn struct {
 	runID   string
 	runCtx  context.Context
 	cancel  context.CancelFunc
+	// release drops the epoch reference acquired at Start/Resume. It is
+	// idempotent and invoked exactly when the turn stops using its
+	// epoch's dependencies (in finish, or on startTurnLocked failure).
+	release func()
+	// checkpoints and resume are the turn's epoch durability settings,
+	// pinned so afterTurn writes session state to the store the turn
+	// started on even across a generation swap.
+	checkpoints agent.CheckpointStore
+	resume      bool
 
 	resumeFrom *agent.Checkpoint
 	resumeCtx  *agent.ResumeContext
@@ -312,6 +321,9 @@ func (t *Turn) finish(result *agent.Result, err error) {
 	}
 	if t.session != nil {
 		t.session.turnFinished(t, result, err)
+	}
+	if t.release != nil {
+		t.release()
 	}
 	close(t.done)
 }


### PR DESCRIPTION
## Summary

Adds `Runtime.Reload` — transactional, in-process generation swapping of the deployment document — built on an epoch refcount in the session manager and a multi-bus event router.

### Core mechanism

- **Generation**: one immutable `deploy.Result` plus its host factory, per-agent resolver, bus, and tool catalog. `Reload` builds the next generation, then atomically swaps; the old generation retires and closes exactly once its in-flight turns drain.
- **session.Deps**: every turn resolves its instance, host, catalog, and checkpoint store from its own epoch, so a reload never tears an in-flight turn and the next `Start` uses the new generation.
- **Multi-bus event router**: `event.Router` gains `AddBus`/`RemoveBus`; each generation owns its bus, the router fans out across every live generation's bus, and `Runtime.Attach` consumers survive reloads. Bus and checkpoint store configuration may change freely on reload.
- **Dynamic agents** are re-bound against the new generation (transactional rollback on failure); deployed agents removed by the new document are drained; session tunables apply with documented immediate-vs-new-session semantics.
- `resource.Registry` is now concurrency-safe (`RWMutex`) so host factory registration can race reload builds safely.

### Reliability fixes included

- Failed reload aborts clear the drain tombstones so the old generation keeps fully serving.
- `AddBus` is all-or-nothing; a shared/singleton bus factory is rejected explicitly without closing the current generation's bus.
- `Router` registers WaitGroup goroutines under its lock (no `Add`/`Wait` race).
- Each reload attempt gets a distinct generation id and a complete `started -> completed/failed` event chain.
- `beginEpoch` surfaces its invariant violation as an error instead of returning empty deps.

## Tests

- `core/event`: multi-bus routing (AddBus delivers to existing attachments, RemoveBus isolates buses, all-bus subscribe), concurrent AddBus/Close under `-race`.
- `core/runtime`: reload with an in-flight turn, bus/checkpoint config changes (with history continuity via shared backing), dynamic agent re-bind, removed-agent drain, drain-timeout tombstone recovery, failure rollback, shared-bus rejection, resume contract validation.
- Full `-race` suite for `runtime/...`, `event`, `deploy`; `make ci`, `make lint` (0 issues), `make release-check` all pass.

## Notes

- Design document lives in `docs/plans/2026-08-18-runtime-reload-generations.md` (local-only, not committed).
- This is a core API addition (`minor`); per repo rules, no `.release/` changeset is added on the PR — one should accompany the next core tag.