### PR TITLE
refactor(core): move delegation host wrapping out of runtime

### DIFF
--- a/core/delegation/doc.go
+++ b/core/delegation/doc.go
@@ -5,7 +5,9 @@
 // discovery; Service owns execution and status lookup. The local service
 // (LocalService), the deploy-bound directory (LocalDirectory), and the
 // delegation resource factories live in this package; the model-facing
-// delegate / delegation_status tools live in the tool subpackage.
+// delegate / delegation_status tools live in the tool subpackage, and the
+// runtime host-factory integration (exposing a Service on every turn host)
+// lives in the hostwrap subpackage.
 //
 // A host can expose a Service to execution-time tools with [WithService],
 // and consumers recover it with [ServiceFromHost].

--- a/core/delegation/hostwrap/doc.go
+++ b/core/delegation/hostwrap/doc.go
@@ -1,0 +1,8 @@
+// Package hostwrap bridges core/delegation and the runtime host factory
+// seam. It exposes the delegation service built in a deployment on
+// every turn host created by a runtime host factory.
+//
+// The runtime itself stays delegation-neutral: applications opt in by
+// installing a result-aware host factory decorator
+// (runtime.Builder.WithResultHostFactory) and delegating to [Wrap].
+package hostwrap

--- a/core/delegation/hostwrap/hostwrap.go
+++ b/core/delegation/hostwrap/hostwrap.go
@@ -1,0 +1,91 @@
+package hostwrap
+
+import (
+	"context"
+	"reflect"
+
+	"github.com/GizClaw/flowcraft/core/agent"
+	sdkdelegation "github.com/GizClaw/flowcraft/core/delegation"
+	"github.com/GizClaw/flowcraft/core/errdefs"
+	"github.com/GizClaw/flowcraft/core/runtime/session"
+)
+
+// Deployment is the minimal read-only deployment view needed to locate a
+// delegation service. *deploy.Result implements it.
+type Deployment interface {
+	Names() []string
+	Value(name string) (any, bool)
+}
+
+// Wrap exposes the single delegation.Service found in deployment on every
+// host created by hostFactory via delegation.WithService. Multiple services
+// are rejected; a deployment without a service leaves the factory unchanged.
+//
+// The caller owns both factory and deployment; Wrap only borrows them. The
+// canonical wiring is a runtime result-aware host factory decorator:
+//
+//	builder.WithResultHostFactory(func(result *deploy.Result,
+//		factory session.HostFactory) (session.HostFactory, error) {
+//		return hostwrap.Wrap(factory, result)
+//	})
+func Wrap(hostFactory session.HostFactory, deployment Deployment) (session.HostFactory, error) {
+	if isNilInterface(hostFactory) {
+		return nil, errdefs.Validationf("delegation hostwrap: nil host factory")
+	}
+	if isNilInterface(deployment) {
+		return nil, errdefs.Validationf("delegation hostwrap: nil deployment")
+	}
+	var service sdkdelegation.Service
+	for _, name := range deployment.Names() {
+		value, ok := deployment.Value(name)
+		if !ok {
+			continue
+		}
+		if candidate, ok := value.(sdkdelegation.Service); ok && !isNilInterface(candidate) {
+			if !isNilInterface(service) {
+				return nil, errdefs.Conflictf(
+					"delegation hostwrap: multiple delegation services built (%s)", name)
+			}
+			service = candidate
+		}
+	}
+	if isNilInterface(service) {
+		return hostFactory, nil
+	}
+	return serviceHostFactory{inner: hostFactory, service: service}, nil
+}
+
+type serviceHostFactory struct {
+	inner   session.HostFactory
+	service sdkdelegation.Service
+}
+
+func (f serviceHostFactory) NewHost(ctx context.Context, request session.HostRequest) (agent.Host, error) {
+	if isNilInterface(f.inner) {
+		return nil, errdefs.Internalf("delegation hostwrap: nil inner host factory")
+	}
+	host, err := f.inner.NewHost(ctx, request)
+	if err != nil {
+		return nil, err
+	}
+	if isNilInterface(host) {
+		return nil, errdefs.Internalf("delegation hostwrap: inner host factory returned nil host")
+	}
+	return sdkdelegation.WithService(host, f.service), nil
+}
+
+var _ session.HostFactory = serviceHostFactory{}
+
+func isNilInterface(value any) bool {
+	if value == nil {
+		return true
+	}
+	rv := reflect.ValueOf(value)
+	switch rv.Kind() {
+	case reflect.Chan, reflect.Func, reflect.Interface, reflect.Map,
+		reflect.Pointer, reflect.Slice:
+		return rv.IsNil()
+	default:
+		return false
+	}
+}

--- a/core/delegation/hostwrap/hostwrap_test.go
+++ b/core/delegation/hostwrap/hostwrap_test.go
@@ -2,7 +2,6 @@ package hostwrap_test
 
 import (
 	"context"
-	"reflect"
 	"testing"
 
 	"github.com/GizClaw/flowcraft/core/agent"
@@ -85,8 +84,12 @@ func TestWrapWithoutServiceLeavesFactoryUnchanged(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Wrap: %v", err)
 	}
-	if reflect.ValueOf(factory).Pointer() != reflect.ValueOf(inner).Pointer() {
-		t.Fatalf("Wrap returned a different factory without a delegation service")
+	host, err := factory.NewHost(context.Background(), hostRequest())
+	if err != nil {
+		t.Fatalf("NewHost: %v", err)
+	}
+	if _, ok := sdkdelegation.ServiceFromHost(host); ok {
+		t.Fatalf("host unexpectedly exposes a delegation service without one built")
 	}
 }
 

--- a/core/delegation/hostwrap/hostwrap_test.go
+++ b/core/delegation/hostwrap/hostwrap_test.go
@@ -1,0 +1,147 @@
+package hostwrap_test
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	"github.com/GizClaw/flowcraft/core/agent"
+	sdkdelegation "github.com/GizClaw/flowcraft/core/delegation"
+	"github.com/GizClaw/flowcraft/core/delegation/hostwrap"
+	"github.com/GizClaw/flowcraft/core/errdefs"
+	"github.com/GizClaw/flowcraft/core/event"
+	"github.com/GizClaw/flowcraft/core/runtime/session"
+)
+
+type fakeDelegationService struct{}
+
+func (*fakeDelegationService) Delegate(context.Context, sdkdelegation.Request) (sdkdelegation.Response, error) {
+	return sdkdelegation.Response{}, nil
+}
+
+func (*fakeDelegationService) Get(context.Context, string) (sdkdelegation.Response, error) {
+	return sdkdelegation.Response{}, nil
+}
+
+type fakeDeployment struct {
+	names  []string
+	values map[string]any
+}
+
+func (d *fakeDeployment) Names() []string { return d.names }
+func (d *fakeDeployment) Value(name string) (any, bool) {
+	value, ok := d.values[name]
+	return value, ok
+}
+
+type eventBusHost struct {
+	agent.NoopHost
+	bus event.Bus
+}
+
+func (h *eventBusHost) EventBus() event.Bus { return h.bus }
+
+func hostRequest() session.HostRequest {
+	return session.HostRequest{
+		Key:        session.Key{AgentID: "bot", ContextID: "conv"},
+		RunID:      "run-1",
+		Interrupts: make(chan agent.Interrupt),
+		AskUser: func(context.Context, agent.UserPrompt) (agent.UserReply, error) {
+			return agent.UserReply{}, nil
+		},
+	}
+}
+
+func TestWrapExposesDelegationService(t *testing.T) {
+	service := &fakeDelegationService{}
+	inner := session.HostFactoryFunc(func(_ context.Context, _ session.HostRequest) (agent.Host, error) {
+		return agent.NoopHost{}, nil
+	})
+	factory, err := hostwrap.Wrap(inner, &fakeDeployment{
+		names:  []string{"delegation"},
+		values: map[string]any{"delegation": service},
+	})
+	if err != nil {
+		t.Fatalf("Wrap: %v", err)
+	}
+	host, err := factory.NewHost(context.Background(), hostRequest())
+	if err != nil {
+		t.Fatalf("NewHost: %v", err)
+	}
+	got, ok := sdkdelegation.ServiceFromHost(host)
+	if !ok || got != service {
+		t.Fatalf("ServiceFromHost = (%v, %v), want (%v, true)", got, ok, service)
+	}
+}
+
+func TestWrapWithoutServiceLeavesFactoryUnchanged(t *testing.T) {
+	inner := session.HostFactoryFunc(func(_ context.Context, _ session.HostRequest) (agent.Host, error) {
+		return agent.NoopHost{}, nil
+	})
+	factory, err := hostwrap.Wrap(inner, &fakeDeployment{
+		names:  []string{"events"},
+		values: map[string]any{"events": event.NewMemoryBus()},
+	})
+	if err != nil {
+		t.Fatalf("Wrap: %v", err)
+	}
+	if reflect.ValueOf(factory).Pointer() != reflect.ValueOf(inner).Pointer() {
+		t.Fatalf("Wrap returned a different factory without a delegation service")
+	}
+}
+
+func TestWrapRejectsMultipleDelegationServices(t *testing.T) {
+	inner := session.HostFactoryFunc(func(_ context.Context, _ session.HostRequest) (agent.Host, error) {
+		return agent.NoopHost{}, nil
+	})
+	_, err := hostwrap.Wrap(inner, &fakeDeployment{
+		names: []string{"a", "b"},
+		values: map[string]any{
+			"a": &fakeDelegationService{},
+			"b": &fakeDelegationService{},
+		},
+	})
+	if err == nil || !errdefs.IsConflict(err) {
+		t.Fatalf("Wrap error = %v, want conflict", err)
+	}
+}
+
+func TestWrapRejectsNilDeployment(t *testing.T) {
+	inner := session.HostFactoryFunc(func(_ context.Context, _ session.HostRequest) (agent.Host, error) {
+		return agent.NoopHost{}, nil
+	})
+	if _, err := hostwrap.Wrap(inner, nil); !errdefs.IsValidation(err) {
+		t.Fatalf("Wrap error = %v, want validation", err)
+	}
+}
+
+func TestWrapPreservesInnerEventBus(t *testing.T) {
+	bus := event.NewMemoryBus()
+	t.Cleanup(func() { _ = bus.Close() })
+	service := &fakeDelegationService{}
+	inner := session.HostFactoryFunc(func(_ context.Context, _ session.HostRequest) (agent.Host, error) {
+		return &eventBusHost{bus: bus}, nil
+	})
+	factory, err := hostwrap.Wrap(inner, &fakeDeployment{
+		names:  []string{"delegation"},
+		values: map[string]any{"delegation": service},
+	})
+	if err != nil {
+		t.Fatalf("Wrap: %v", err)
+	}
+	host, err := factory.NewHost(context.Background(), hostRequest())
+	if err != nil {
+		t.Fatalf("NewHost: %v", err)
+	}
+	got, ok := agent.EventBusFromHost(host)
+	if !ok || got != bus {
+		t.Fatalf("EventBusFromHost = (%v, %v), want (%v, true)", got, ok, bus)
+	}
+}
+
+func TestWrapRejectsNilInnerFactory(t *testing.T) {
+	_, err := hostwrap.Wrap(nil, &fakeDeployment{})
+	if err == nil {
+		t.Fatalf("Wrap with nil inner factory: want error")
+	}
+}

--- a/core/runtime/builder.go
+++ b/core/runtime/builder.go
@@ -7,7 +7,6 @@ import (
 	"sync"
 
 	"github.com/GizClaw/flowcraft/core/agent"
-	"github.com/GizClaw/flowcraft/core/delegation"
 	"github.com/GizClaw/flowcraft/core/deploy"
 	"github.com/GizClaw/flowcraft/core/errdefs"
 	"github.com/GizClaw/flowcraft/core/event"
@@ -22,15 +21,23 @@ import (
 // agent.HostFuncs{Inner: base, ...}.
 type HostFactoryDecorator func(session.HostFactory) (session.HostFactory, error)
 
+// ResultHostFactoryDecorator wraps the runtime's host factory with access to
+// the fully assembled deployment. It runs after any HostFactoryDecorator, so
+// the deployment-aware layer sits outermost and can expose deployment-built
+// services (e.g. delegation) on every turn host. The result is borrowed only
+// for the duration of the call.
+type ResultHostFactoryDecorator func(result *deploy.Result, factory session.HostFactory) (session.HostFactory, error)
+
 // Builder transactionally assembles one Runtime over a resource
 // registry. It is single-use.
 type Builder struct {
 	reg *resource.Registry
 
-	mu            sync.Mutex
-	used          bool
-	hostDecorator HostFactoryDecorator
-	loader        *resource.Loader
+	mu                  sync.Mutex
+	used                bool
+	hostDecorator       HostFactoryDecorator
+	resultHostDecorator ResultHostFactoryDecorator
+	loader              *resource.Loader
 }
 
 // NewBuilder creates a Runtime builder over a resource registry. The
@@ -59,6 +66,28 @@ func (b *Builder) WithHostFactory(decorator HostFactoryDecorator) error {
 		return errdefs.Validationf("runtime host factory decorator is already set")
 	}
 	b.hostDecorator = decorator
+	return nil
+}
+
+// WithResultHostFactory installs a decorator that runs after WithHostFactory
+// with access to the fully assembled deployment. It is rejected when nil or
+// after Build starts.
+func (b *Builder) WithResultHostFactory(decorator ResultHostFactoryDecorator) error {
+	if b == nil {
+		return errdefs.Validationf("runtime Builder is nil")
+	}
+	if decorator == nil {
+		return errdefs.Validationf("runtime result host factory decorator is nil")
+	}
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if b.used {
+		return ErrBuilderUsed
+	}
+	if b.resultHostDecorator != nil {
+		return errdefs.Validationf("runtime result host factory decorator is already set")
+	}
+	b.resultHostDecorator = decorator
 	return nil
 }
 
@@ -155,10 +184,17 @@ func (b *Builder) Build(ctx context.Context, doc deploy.Document) (*Runtime, err
 				"runtime host factory decorator returned nil")
 		}
 	}
-	hostFactory, err = wrapDelegation(hostFactory, result)
-	if err != nil {
-		_ = result.Close()
-		return nil, err
+	if b.resultHostDecorator != nil {
+		hostFactory, err = b.resultHostDecorator(result, hostFactory)
+		if err != nil {
+			_ = result.Close()
+			return nil, fmt.Errorf("runtime decorate host factory with deployment: %w", err)
+		}
+		if isNil(hostFactory) {
+			_ = result.Close()
+			return nil, errdefs.Internalf(
+				"runtime result host factory decorator returned nil")
+		}
 	}
 
 	var catalogProvider session.CatalogProvider
@@ -213,17 +249,18 @@ func (b *Builder) Build(ctx context.Context, doc deploy.Document) (*Runtime, err
 		return nil, fmt.Errorf("runtime create session manager: %w", err)
 	}
 	return &Runtime{
-		manager:       manager,
-		router:        router,
-		result:        result,
-		registry:      registry,
-		liveCatalog:   liveCatalog,
-		resources:     reg,
-		loader:        b.loader,
-		bus:           bus,
-		hostDecorator: b.hostDecorator,
-		current:       initial,
-		nextGenID:     1,
+		manager:             manager,
+		router:              router,
+		result:              result,
+		registry:            registry,
+		liveCatalog:         liveCatalog,
+		resources:           reg,
+		loader:              b.loader,
+		bus:                 bus,
+		hostDecorator:       b.hostDecorator,
+		resultHostDecorator: b.resultHostDecorator,
+		current:             initial,
+		nextGenID:           1,
 	}, nil
 }
 
@@ -241,45 +278,6 @@ func resolveValue[T any](result *deploy.Result, name, field string) (T, error) {
 			field, name, value, reflect.TypeFor[T]())
 	}
 	return typed, nil
-}
-
-// wrapDelegation exposes a delegation.Service found among the built
-// resources on every turn host via delegation.WithService.
-func wrapDelegation(
-	hostFactory session.HostFactory,
-	result *deploy.Result,
-) (session.HostFactory, error) {
-	var service delegation.Service
-	for _, name := range result.Names() {
-		value, _ := result.Value(name)
-		if candidate, ok := value.(delegation.Service); ok && !isNil(candidate) {
-			if !isNil(service) {
-				return nil, errdefs.Conflictf(
-					"runtime: multiple delegation services built (%s)", name)
-			}
-			service = candidate
-		}
-	}
-	if isNil(service) {
-		return hostFactory, nil
-	}
-	return delegationHostFactory{inner: hostFactory, service: service}, nil
-}
-
-type delegationHostFactory struct {
-	inner   session.HostFactory
-	service delegation.Service
-}
-
-func (f delegationHostFactory) NewHost(
-	ctx context.Context,
-	request session.HostRequest,
-) (agent.Host, error) {
-	host, err := f.inner.NewHost(ctx, request)
-	if err != nil {
-		return nil, err
-	}
-	return delegation.WithService(host, f.service), nil
 }
 
 func isNilContext(ctx context.Context) bool {

--- a/core/runtime/builder_test.go
+++ b/core/runtime/builder_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/GizClaw/flowcraft/core/agent"
 	"github.com/GizClaw/flowcraft/core/delegation"
+	"github.com/GizClaw/flowcraft/core/delegation/hostwrap"
 	"github.com/GizClaw/flowcraft/core/deploy"
 	"github.com/GizClaw/flowcraft/core/errdefs"
 	"github.com/GizClaw/flowcraft/core/event"
@@ -52,6 +53,14 @@ func TestBuilderIsSingleUse(t *testing.T) {
 	}); !errors.Is(err, ErrBuilderUsed) {
 		t.Fatalf("WithHostFactory after Build error = %v, want ErrBuilderUsed", err)
 	}
+	if err := builder.WithResultHostFactory(func(
+		*deploy.Result,
+		session.HostFactory,
+	) (session.HostFactory, error) {
+		return nil, nil
+	}); !errors.Is(err, ErrBuilderUsed) {
+		t.Fatalf("WithResultHostFactory after Build error = %v, want ErrBuilderUsed", err)
+	}
 }
 
 func TestWithHostFactoryValidation(t *testing.T) {
@@ -65,6 +74,75 @@ func TestWithHostFactoryValidation(t *testing.T) {
 	}
 	if err := builder.WithHostFactory(decorator); !errdefs.IsValidation(err) {
 		t.Fatalf("duplicate decorator error = %v, want validation", err)
+	}
+}
+
+func TestWithResultHostFactoryValidation(t *testing.T) {
+	builder := NewBuilder(resource.NewRegistry())
+	if err := builder.WithResultHostFactory(nil); !errdefs.IsValidation(err) {
+		t.Fatalf("nil decorator error = %v, want validation", err)
+	}
+	decorator := func(
+		*deploy.Result,
+		session.HostFactory,
+	) (session.HostFactory, error) {
+		return nil, nil
+	}
+	if err := builder.WithResultHostFactory(decorator); err != nil {
+		t.Fatalf("first decorator: %v", err)
+	}
+	if err := builder.WithResultHostFactory(decorator); !errdefs.IsValidation(err) {
+		t.Fatalf("duplicate decorator error = %v, want validation", err)
+	}
+}
+
+func TestBuildAppliesResultHostFactoryDecorator(t *testing.T) {
+	var received *deploy.Result
+	var applied bool
+	reg := newBaseRegistry(t, event.NewMemoryBus(), &recordingCheckpointStore{}, noopEngine())
+	builder := NewBuilder(reg)
+	if err := builder.WithResultHostFactory(func(
+		result *deploy.Result,
+		factory session.HostFactory,
+	) (session.HostFactory, error) {
+		received = result
+		applied = true
+		return factory, nil
+	}); err != nil {
+		t.Fatalf("WithResultHostFactory: %v", err)
+	}
+
+	app, err := builder.Build(context.Background(), baseRuntimeDoc(t))
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	defer func() { _ = app.Close() }()
+
+	if !applied || received == nil {
+		t.Fatalf("result host factory decorator not applied (applied=%v, result=%v)", applied, received)
+	}
+	if len(received.Names()) == 0 {
+		t.Fatalf("decorator received empty deployment")
+	}
+	if result := runTurn(t, app.Sessions(), "bot", "conv"); result.Status != agent.StatusCompleted {
+		t.Fatalf("result status = %q", result.Status)
+	}
+}
+
+func TestBuildAbortsOnResultHostFactoryError(t *testing.T) {
+	reg := newBaseRegistry(t, event.NewMemoryBus(), &recordingCheckpointStore{}, noopEngine())
+	builder := NewBuilder(reg)
+	if err := builder.WithResultHostFactory(func(
+		*deploy.Result,
+		session.HostFactory,
+	) (session.HostFactory, error) {
+		return nil, errdefs.Validationf("boom")
+	}); err != nil {
+		t.Fatalf("WithResultHostFactory: %v", err)
+	}
+	_, err := builder.Build(context.Background(), baseRuntimeDoc(t))
+	if err == nil || !errdefs.IsValidation(err) || !strings.Contains(err.Error(), "boom") {
+		t.Fatalf("Build error = %v, want wrapped validation error containing boom", err)
 	}
 }
 
@@ -319,7 +397,7 @@ func (s *fakeDelegationService) Get(context.Context, string) (delegation.Respons
 	return delegation.Response{}, nil
 }
 
-func TestBuildWrapsDelegationService(t *testing.T) {
+func TestBuildWrapsDelegationServiceWhenRequested(t *testing.T) {
 	service := &fakeDelegationService{id: "local"}
 	var got delegation.Service
 	engine := agent.EngineFunc(func(
@@ -345,7 +423,16 @@ func TestBuildWrapsDelegationService(t *testing.T) {
 		Kind: delegation.ServiceKind, Impl: "local",
 	}
 
-	app, err := NewBuilder(reg).Build(context.Background(), doc)
+	builder := NewBuilder(reg)
+	if err := builder.WithResultHostFactory(func(
+		result *deploy.Result,
+		factory session.HostFactory,
+	) (session.HostFactory, error) {
+		return hostwrap.Wrap(factory, result)
+	}); err != nil {
+		t.Fatalf("WithResultHostFactory: %v", err)
+	}
+	app, err := builder.Build(context.Background(), doc)
 	if err != nil {
 		t.Fatalf("Build: %v", err)
 	}
@@ -356,6 +443,40 @@ func TestBuildWrapsDelegationService(t *testing.T) {
 	}
 	if got != service {
 		t.Fatalf("engine received service %p, want %p", got, service)
+	}
+}
+
+func TestBuildWithoutResultHostFactoryLeavesHostUnexposed(t *testing.T) {
+	service := &fakeDelegationService{id: "local"}
+	engine := agent.EngineFunc(func(
+		_ context.Context,
+		_ agent.Run,
+		host agent.Host,
+		board *agent.Board,
+	) (*agent.Board, error) {
+		if _, ok := delegation.ServiceFromHost(host); ok {
+			return board, errors.New("delegation service unexpectedly exposed on host")
+		}
+		return board, nil
+	})
+	reg := newBaseRegistry(t, event.NewMemoryBus(), &recordingCheckpointStore{}, engine)
+	reg.MustRegister(testResourceFactory{
+		spec:  resource.Spec{Kind: delegation.ServiceKind, Impl: "local"},
+		value: service,
+	})
+	doc := baseRuntimeDoc(t)
+	doc.Resources["delegation"] = resource.Resource{
+		Kind: delegation.ServiceKind, Impl: "local",
+	}
+
+	app, err := NewBuilder(reg).Build(context.Background(), doc)
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	defer func() { _ = app.Close() }()
+
+	if result := runTurn(t, app.Sessions(), "bot", "conv"); result.Status != agent.StatusCompleted {
+		t.Fatalf("result status = %q", result.Status)
 	}
 }
 
@@ -380,29 +501,6 @@ func TestBuildBindsDelegationDirectory(t *testing.T) {
 	}
 	if len(targets) != 1 || targets[0].ID != "bot" {
 		t.Fatalf("bound targets = %+v, want [bot]", targets)
-	}
-}
-
-func TestBuildRejectsMultipleDelegationServices(t *testing.T) {
-	reg := newBaseRegistry(t, event.NewMemoryBus(), &recordingCheckpointStore{}, noopEngine())
-	reg.MustRegister(testResourceFactory{
-		spec:  resource.Spec{Kind: delegation.ServiceKind, Impl: "a"},
-		value: &fakeDelegationService{id: "a"},
-	})
-	reg.MustRegister(testResourceFactory{
-		spec:  resource.Spec{Kind: delegation.ServiceKind, Impl: "b"},
-		value: &fakeDelegationService{id: "b"},
-	})
-	doc := baseRuntimeDoc(t)
-	doc.Resources["delegation_a"] = resource.Resource{
-		Kind: delegation.ServiceKind, Impl: "a",
-	}
-	doc.Resources["delegation_b"] = resource.Resource{
-		Kind: delegation.ServiceKind, Impl: "b",
-	}
-	if _, err := NewBuilder(reg).Build(context.Background(), doc); err == nil ||
-		!strings.Contains(err.Error(), "multiple delegation services") {
-		t.Fatalf("Build error = %v, want multiple delegation services conflict", err)
 	}
 }
 

--- a/core/runtime/reload.go
+++ b/core/runtime/reload.go
@@ -183,9 +183,16 @@ func (r *Runtime) Reload(
 				"runtime reload host factory decorator returned nil"))
 		}
 	}
-	hostFactory, err = wrapDelegation(hostFactory, newResult)
-	if err != nil {
-		return nil, abort(err)
+	if r.resultHostDecorator != nil {
+		hostFactory, err = r.resultHostDecorator(newResult, hostFactory)
+		if err != nil {
+			return nil, abort(fmt.Errorf(
+				"runtime reload decorate host factory with deployment: %w", err))
+		}
+		if isNil(hostFactory) {
+			return nil, abort(errdefs.Internalf(
+				"runtime reload result host factory decorator returned nil"))
+		}
 	}
 
 	// Resolve the new generation's dynamic tool catalog.

--- a/core/runtime/reload_test.go
+++ b/core/runtime/reload_test.go
@@ -278,6 +278,153 @@ func TestRuntimeReloadSwapsGenerationWithInFlightTurn(t *testing.T) {
 	}
 }
 
+const markerEngineKind = "marker-engine"
+
+type generationMarker interface {
+	GenerationMarker() int
+}
+
+// markerHost tags a host with the generation whose result-aware decorator
+// produced it, without replacing any underlying capability.
+type markerHost struct {
+	agent.Host
+	gen int
+}
+
+func (h markerHost) GenerationMarker() int  { return h.gen }
+func (h markerHost) UnwrapHost() agent.Host { return h.Host }
+
+type markerEngineFactory struct {
+	markers chan int
+}
+
+func (f markerEngineFactory) Spec() resource.Spec {
+	return resource.Spec{Kind: markerEngineKind}
+}
+
+func (f markerEngineFactory) New(context.Context, resource.Input) (any, error) {
+	return agent.EngineFunc(func(
+		_ context.Context,
+		_ agent.Run,
+		host agent.Host,
+		board *agent.Board,
+	) (*agent.Board, error) {
+		marker := 0
+		if m, ok := host.(generationMarker); ok {
+			marker = m.GenerationMarker()
+		}
+		select {
+		case f.markers <- marker:
+		default:
+		}
+		board.AppendChannelMessage(
+			agent.MainChannel,
+			message.NewTextMessage(message.RoleAssistant, "ok"))
+		return board, nil
+	}), nil
+}
+
+func TestRuntimeReloadReappliesResultHostDecorator(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	engine := &markerEngineFactory{markers: make(chan int, 8)}
+	reg := resource.NewRegistry()
+	reg.MustRegister(engine)
+	reg.MustRegister(event.NewFactory())
+
+	builder := NewBuilder(reg)
+	var calls atomic.Int64
+	var mu sync.Mutex
+	var results []*deploy.Result
+	if err := builder.WithResultHostFactory(func(
+		result *deploy.Result,
+		factory session.HostFactory,
+	) (session.HostFactory, error) {
+		gen := int(calls.Add(1))
+		mu.Lock()
+		results = append(results, result)
+		mu.Unlock()
+		return session.HostFactoryFunc(func(
+			ctx context.Context,
+			request session.HostRequest,
+		) (agent.Host, error) {
+			host, err := factory.NewHost(ctx, request)
+			if err != nil {
+				return nil, err
+			}
+			return markerHost{Host: host, gen: gen}, nil
+		}), nil
+	}); err != nil {
+		t.Fatalf("WithResultHostFactory: %v", err)
+	}
+
+	doc1 := reloadDoc(t, `  bot:
+    card: {name: Bot}
+    engine: {kind: marker-engine}
+`, "")
+	app, err := builder.Build(ctx, doc1)
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	t.Cleanup(func() { _ = app.Close() })
+
+	if marker := runMarkerTurn(t, ctx, app, engine.markers, 1); marker != 1 {
+		t.Fatalf("generation 1 turn marker = %d, want 1", marker)
+	}
+
+	doc2 := reloadDoc(t, `  bot:
+    card: {name: Bot v2}
+    engine: {kind: marker-engine}
+`, "")
+	if _, err := app.Reload(ctx, doc2); err != nil {
+		t.Fatalf("Reload: %v", err)
+	}
+	if marker := runMarkerTurn(t, ctx, app, engine.markers, 2); marker != 2 {
+		t.Fatalf("generation 2 turn marker = %d, want 2", marker)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(results) != 2 {
+		t.Fatalf("decorator calls = %d, want 2 (one per generation)", len(results))
+	}
+	if results[0] == results[1] {
+		t.Fatalf("decorator received the same result for both generations")
+	}
+}
+
+func runMarkerTurn(
+	t *testing.T,
+	ctx context.Context,
+	app *Runtime,
+	markers <-chan int,
+	wantCall int,
+) int {
+	t.Helper()
+	lease, err := app.Sessions().Open(ctx, session.Key{
+		AgentID: "bot", ContextID: "ctx",
+	})
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	t.Cleanup(func() { _ = lease.Close() })
+	turn, err := lease.Session().Start(ctx, agent.Request{})
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	if _, err := turn.Wait(ctx); err != nil {
+		t.Fatalf("turn %d Wait: %v", wantCall, err)
+	}
+	select {
+	case marker := <-markers:
+		return marker
+	case <-ctx.Done():
+		t.Fatalf("marker %d not observed: %v", wantCall, ctx.Err())
+		return 0
+	}
+}
+
 func TestRuntimeReloadAllowsBusConfigChange(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
 	defer cancel()

--- a/core/runtime/runtime.go
+++ b/core/runtime/runtime.go
@@ -35,6 +35,10 @@ type Runtime struct {
 	// rebuild a host factory for a new deployment generation with the
 	// exact same decoration policy.
 	hostDecorator HostFactoryDecorator
+	// resultHostDecorator is retained from the Builder so a later Reload
+	// re-applies the deployment-aware decoration to the new generation's
+	// host factory.
+	resultHostDecorator ResultHostFactoryDecorator
 	// current is the active deployment generation. Reload replaces it
 	// atomically; Close retires and closes it.
 	current *Generation

--- a/core/runtime/runtime.go
+++ b/core/runtime/runtime.go
@@ -115,6 +115,20 @@ func (r *Runtime) AgentNames() []string {
 	return r.registry.AgentNames()
 }
 
+// Resource borrows the current generation's built deployment resource
+// value by deployment name. Like Agent, it resolves through the live
+// view: after a Reload it returns the new generation's value, and the
+// retired generation's values are closed with it. Callers borrow the
+// value and must not close it. For values the application must own the
+// lifecycle of (or keep across reloads), construct them outside the
+// runtime and inject them through the resource registry instead.
+func (r *Runtime) Resource(name string) (any, bool) {
+	if r == nil || r.current == nil || r.current.result == nil {
+		return nil, false
+	}
+	return r.current.result.Value(name)
+}
+
 // Close stops new session work, waits for active turns, and releases
 // all owned objects. Concurrent callers wait for and receive the same
 // aggregate result.

--- a/core/runtime/runtime_resource_test.go
+++ b/core/runtime/runtime_resource_test.go
@@ -1,0 +1,94 @@
+package runtime
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/GizClaw/flowcraft/core/event"
+	"github.com/GizClaw/flowcraft/core/resource"
+)
+
+const testDBResourceKind = "runtime-test-db"
+
+type testDB struct {
+	name string
+}
+
+func TestRuntimeResourceReturnsBuiltValue(t *testing.T) {
+	db := &testDB{name: "pool-a"}
+	reg := newBaseRegistry(t, event.NewMemoryBus(), &recordingCheckpointStore{}, noopEngine())
+	reg.MustRegister(testResourceFactory{
+		spec:  resource.Spec{Kind: testDBResourceKind, Impl: "a"},
+		value: db,
+	})
+
+	doc := baseRuntimeDoc(t)
+	doc.Resources["db"] = resource.Resource{Kind: testDBResourceKind, Impl: "a"}
+
+	app, err := NewBuilder(reg).Build(context.Background(), doc)
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	t.Cleanup(func() { _ = app.Close() })
+
+	got, ok := app.Resource("db")
+	if !ok || got != db {
+		t.Fatalf("Resource(db) = (%v, %v), want (%v, true)", got, ok, db)
+	}
+	if got, ok := app.Resource("missing"); ok || got != nil {
+		t.Fatalf("Resource(missing) = (%v, %v), want (nil, false)", got, ok)
+	}
+	var nilApp *Runtime
+	if got, ok := nilApp.Resource("db"); ok || got != nil {
+		t.Fatalf("nil Runtime Resource(db) = (%v, %v), want (nil, false)", got, ok)
+	}
+}
+
+func TestRuntimeResourceFollowsReloadGeneration(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	dbA := &testDB{name: "pool-a"}
+	dbB := &testDB{name: "pool-b"}
+	reg := resource.NewRegistry()
+	reg.MustRegister(testEngineFactory{engine: noopEngine()})
+	reg.MustRegister(event.NewFactory())
+	reg.MustRegister(testResourceFactory{
+		spec:  resource.Spec{Kind: testDBResourceKind, Impl: "a"},
+		value: dbA,
+	})
+	reg.MustRegister(testResourceFactory{
+		spec:  resource.Spec{Kind: testDBResourceKind, Impl: "b"},
+		value: dbB,
+	})
+
+	agents := `  bot:
+    card: {name: Bot}
+    engine: {kind: agent.Engine, impl: test}
+`
+	app, err := NewBuilder(reg).Build(ctx, reloadDoc(t, agents, `  db: {kind: runtime-test-db, impl: a}
+`))
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	t.Cleanup(func() { _ = app.Close() })
+
+	got, ok := app.Resource("db")
+	if !ok || got != dbA {
+		t.Fatalf("Resource(db) before reload = (%v, %v), want (%v, true)", got, ok, dbA)
+	}
+
+	if _, err := app.Reload(ctx, reloadDoc(t, agents, `  db: {kind: runtime-test-db, impl: b}
+`)); err != nil {
+		t.Fatalf("Reload: %v", err)
+	}
+
+	got, ok = app.Resource("db")
+	if !ok || got != dbB {
+		t.Fatalf("Resource(db) after reload = (%v, %v), want (%v, true)", got, ok, dbB)
+	}
+	if got, ok := app.Resource("missing"); ok || got != nil {
+		t.Fatalf("Resource(missing) after reload = (%v, %v), want (nil, false)", got, ok)
+	}
+}

--- a/docs/guides/runtime.md
+++ b/docs/guides/runtime.md
@@ -163,4 +163,19 @@ level primitives behind removal and re-registration.
 `runtime.Builder.WithHostFactory` wraps the base host factory. The decorator
 must delegate any method it does not override.
 
+`runtime.Builder.WithResultHostFactory` wraps the factory a second time with
+access to the fully assembled deployment, after `WithHostFactory` has run.
+This is the seam for deployment-built, run-scoped services: applications opt
+in and decide which services to expose on every turn host, and the runtime
+itself stays neutral to them. For example, exposing a delegation service:
+
+```go
+builder.WithResultHostFactory(func(result *deploy.Result, factory session.HostFactory) (session.HostFactory, error) {
+    return hostwrap.Wrap(factory, result) // delegation.Service onto every turn host
+})
+```
+
+The decorator is retained across reloads and re-applied to each new
+generation's host factory with that generation's deployment.
+
 See [deploy.md](deploy.md) and [resource.md](resource.md).

--- a/docs/guides/runtime.md
+++ b/docs/guides/runtime.md
@@ -50,6 +50,27 @@ default backpressure (`DropNewest`); pass
 "Dynamic agent registry" section below for the `runtime.agent.*`
 lifecycle events published on dynamic registration/removal.
 
+## Accessing deployment resources
+
+`Runtime.Resource` borrows a built resource value by its deployment
+name from the current generation, mirroring `Agent` for the resource
+view:
+
+```go
+db, ok := app.Resource("db")
+if !ok {
+    return errors.New("deployment has no db resource")
+}
+```
+
+Values are borrowed: the Runtime owns the deployment and closes
+resources when it closes, and a `Reload` retires the previous
+generation's values. Use this for access to deployment-built services
+such as a database pool. If the application must own a value's
+lifecycle or keep it across reloads, construct it outside the runtime
+and inject it through a resource factory registered in the registry
+instead.
+
 ## Runtime config
 
 ```yaml


### PR DESCRIPTION
## Summary

Removes `wrapDelegation` from `core/runtime` so the runtime stays delegation-neutral, and adds a deployment-aware host factory seam:

- `runtime.Builder.WithResultHostFactory(decorator)`: runs after `WithHostFactory` with the fully assembled `*deploy.Result`; re-applied per generation on reload.
- `core/delegation/hostwrap.Wrap(factory, deployment)`: exposes the single built `delegation.Service` on every turn host (conflict on multiple services, no-op without one).
- Applications opt in with `builder.WithResultHostFactory(hostwrap.Wrap)`.

## Behavior note (breaking, opt-in)

Previously any deployment that built a `delegation.Service` resource had it exposed automatically on every turn host, and multiple services failed `Build`. That behavior has shipped since core v0.1.0. With this change the exposure is opt-in: deployments using delegation must install `WithResultHostFactory(hostwrap.Wrap)`, otherwise `ServiceFromHost` reports not-found. The next core changeset should call this out explicitly.

## Tests

- `core/delegation/hostwrap`: service exposure, no-op without a service, multiple-service conflict, validation, event-bus passthrough.
- `core/runtime`: result decorator validation / application / error abort, opt-in end-to-end delegation exposure, and reload re-application of the decorator with the new generation's result.
- Gates: `make ci`, `make lint` (0 issues), `make release-check`, `git diff --check` all pass.