### PR TITLE
chore(release): add core v0.1.14 changeset

### DIFF
--- a/.release/core-v0.1.14.json
+++ b/.release/core-v0.1.14.json
@@ -1,0 +1,9 @@
+{
+  "summary": "feat(core): add runtime generation reload with multi-bus ownership and epoch-pinned sessions (Runtime.Reload, per-generation host factories/catalogs, dynamic agent drain/rebind); expose built deployment resources via Runtime.Resource; move delegation host wrapping out of runtime to an opt-in deployment-aware host factory decorator (WithResultHostFactory + core/delegation/hostwrap), so delegation services are no longer auto-exposed on turn hosts",
+  "releases": [
+    {
+      "module": "core",
+      "bump": "patch"
+    }
+  ]
+}


### PR DESCRIPTION
Adds the core v0.1.14 patch changeset covering the accumulated delta since core/v0.1.13:

- runtime generation reload with multi-bus ownership and epoch-pinned sessions (#349);
- expose built deployment resources via `Runtime.Resource`;
- delegation host wrapping moved out of runtime to the opt-in `WithResultHostFactory` + `core/delegation/hostwrap` decorator.

`make release-plan` confirms `core: 0.1.13 -> 0.1.14 (patch)`, `make release-check` passes, and `make release-preflight` reports preflight tidy OK.