### PR TITLE
feat(core): lift board ref syntax into agent.Board

### DIFF
--- a/core/agent/bindings/bridge_board.go
+++ b/core/agent/bindings/bridge_board.go
@@ -2,6 +2,8 @@ package bindings
 
 import (
 	"context"
+	"encoding/json"
+	"fmt"
 
 	"github.com/GizClaw/flowcraft/core/agent"
 )
@@ -14,6 +16,8 @@ import (
 //   - getVars()        → map[string]any
 //   - hasVar(key)      → bool
 //   - deleteVar(key)
+//   - resolve(str)         → any       (typed ${board.*} expansion)
+//   - resolveString(str)   → string    (text ${board.*} expansion)
 //
 // Channels (typed conversation history; multimodal-aware via the
 // message.Message projection in project.go):
@@ -40,6 +44,23 @@ func NewBoardBridge(board *agent.Board) BindingFunc {
 			"deleteVar": func(key string) { board.DeleteVar(key) },
 			"getVars":   func() map[string]any { return board.Vars() },
 			"hasVar":    func(key string) bool { _, ok := board.GetVar(key); return ok },
+
+			"resolve": func(s string) (any, error) {
+				return board.ResolveString(s)
+			},
+			"resolveString": func(s string) (string, error) {
+				v, err := board.ResolveString(s)
+				if err != nil {
+					return "", err
+				}
+				if str, ok := v.(string); ok {
+					return str, nil
+				}
+				if b, err := json.Marshal(v); err == nil {
+					return string(b), nil
+				}
+				return fmt.Sprintf("%v", v), nil
+			},
 
 			"channel": func(name string) ([]any, error) {
 				return messagesToScript(board.Channel(name))

--- a/core/agent/bindings/bridge_board_test.go
+++ b/core/agent/bindings/bridge_board_test.go
@@ -1,0 +1,46 @@
+package bindings
+
+import (
+	"context"
+	"testing"
+
+	"github.com/GizClaw/flowcraft/core/agent"
+	"github.com/GizClaw/flowcraft/core/errdefs"
+)
+
+func TestBoardBridgeResolve(t *testing.T) {
+	board := agent.NewBoard()
+	board.SetVar("user", map[string]any{"name": "ada"})
+	board.SetVar("n", float64(3))
+
+	env := BuildEnv(context.Background(), nil, NewBoardBridge(board))
+	b, ok := env.Bindings["board"].(map[string]any)
+	if !ok {
+		t.Fatalf("board binding = %T", env.Bindings["board"])
+	}
+	resolve := b["resolve"].(func(string) (any, error))
+	resolveString := b["resolveString"].(func(string) (string, error))
+
+	v, err := resolve("${board.user.name}")
+	if err != nil || v != "ada" {
+		t.Fatalf("resolve = %v, %v", v, err)
+	}
+	v, err = resolve("${board.n}")
+	if err != nil || v != float64(3) {
+		t.Fatalf("resolve typed = %v, %v", v, err)
+	}
+	s, err := resolveString("n=${board.n}")
+	if err != nil || s != "n=3" {
+		t.Fatalf("resolveString = %q, %v", s, err)
+	}
+	s, err = resolveString("${board.user.name}")
+	if err != nil || s != "ada" {
+		t.Fatalf("resolveString typed = %q, %v", s, err)
+	}
+	if _, err := resolve("${board.missing}"); err == nil || !errdefs.IsValidation(err) {
+		t.Fatalf("missing ref err = %v, want validation error", err)
+	}
+	if _, err := resolveString("x ${board.missing}"); err == nil || !errdefs.IsValidation(err) {
+		t.Fatalf("missing embedded ref err = %v, want validation error", err)
+	}
+}

--- a/core/agent/bindings/doc.go
+++ b/core/agent/bindings/doc.go
@@ -10,9 +10,8 @@
 //
 // Existing bridges:
 //
-//   - board: scoped copy-on-read view of the engine board (namespace =
-//     node ID), with resolve/resolveString for ${board.<name>}
-//     interpolation
+//   - board: direct read/write view of the engine board, with
+//     resolve/resolveString for ${board.<name>} interpolation
 //
 //   - expr: boolean expression evaluation with the same interpolation
 //
@@ -52,12 +51,15 @@
 //
 // # Interpolation
 //
-// Strings that embed ${board.<name>} are expanded by the board bridge
-// against a scoped view of the board. ExprHost uses the same mechanism
-// for condition expressions, so conditions written in YAML and script
-// literals share one interpolation path. Undefined references fail
-// hard: the template resolver returns a validation error and the
-// binding surfaces it rather than substituting a sentinel.
+// Config values that carry ${board.<path>} references are expanded by
+// the graph kernel before the script node decodes, so scripts see
+// resolved values in their config global. Scripts can also expand
+// references dynamically through the board bridge's resolve (typed)
+// and resolveString (text) helpers. References support dot paths
+// (${board.user.name}), an optional default (${board.x:default}), and
+// fail with a validation error when the referenced variable is missing
+// and no default is given. Prefix a reference with a backslash
+// (\${board.x}) to emit it literally.
 //
 // # Env shape
 //

--- a/core/agent/board_refs.go
+++ b/core/agent/board_refs.go
@@ -1,0 +1,375 @@
+package agent
+
+import (
+	"encoding/json"
+	"fmt"
+	"reflect"
+	"regexp"
+	"sort"
+	"strings"
+
+	"github.com/GizClaw/flowcraft/core/errdefs"
+)
+
+// Board reference syntax
+//
+// Strings may embed ${board.<path>} references, where <path> is a
+// dot-separated path into the board vars (${board.user.name} reads var
+// "user" and then its "name" field). Nested lookup walks maps with
+// string keys (map[string]string, map[string]int, ...) and exported
+// struct fields, dereferencing pointers along the way. An exact
+// variable name is tried first, so a var literally named "user.name"
+// wins over nested lookup.
+// An optional default follows a colon: ${board.limit:3}. A reference
+// standing alone in a string keeps the variable's typed value (a list
+// stays a list); when embedded in a longer string the value is
+// interpolated as text. Referencing a missing variable is a validation
+// error unless a default is given. When a reference stands alone, a
+// default that is a valid JSON literal keeps its type
+// (${board.limit:3} yields a number); otherwise it stays text. Defaults
+// are raw text and may not nest further references. Prefix a reference
+// with a backslash (\${board.x}) to emit it literally; within a
+// default, \} and \\ produce "}" and "\".
+
+// BoardRefMarker is the literal prefix of every board reference.
+const BoardRefMarker = "${board."
+
+var boardIdentPattern = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_]*$`)
+
+// boardRefPattern matches reference syntax for static analysis
+// (ContainsBoardRef / ExtractBoardRefs). Runtime expansion uses the
+// scanner in resolveString instead, which also handles escapes.
+var boardRefPattern = regexp.MustCompile(`\$\{board\.([A-Za-z_][A-Za-z0-9_]*(?:\.[A-Za-z_][A-Za-z0-9_]*)*)(?::((?:[^}\\]|\\.)*))?\}`)
+
+// ContainsBoardRef reports whether v — a decoded JSON value or a plain
+// string — contains at least one live (unescaped) "${board.*}"
+// reference.
+func ContainsBoardRef(v any) bool {
+	return len(findBoardRefs(v)) > 0
+}
+
+// ExtractBoardRefs returns the sorted, deduplicated board paths
+// referenced anywhere inside v. Escaped references and defaults are
+// not included.
+func ExtractBoardRefs(v any) []string {
+	seen := map[string]bool{}
+	for _, r := range findBoardRefs(v) {
+		seen[r] = true
+	}
+	out := make([]string, 0, len(seen))
+	for r := range seen {
+		out = append(out, r)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func findBoardRefs(v any) []string {
+	switch t := v.(type) {
+	case string:
+		return findStringRefs(t)
+	case []any:
+		var out []string
+		for _, e := range t {
+			out = append(out, findBoardRefs(e)...)
+		}
+		return out
+	case map[string]any:
+		var out []string
+		for _, e := range t {
+			out = append(out, findBoardRefs(e)...)
+		}
+		return out
+	default:
+		return nil
+	}
+}
+
+// findStringRefs returns the paths of all live (unescaped) references
+// in s. The regex does not know about escapes, so matches preceded by
+// an odd run of backslashes are skipped.
+func findStringRefs(s string) []string {
+	idxs := boardRefPattern.FindAllStringSubmatchIndex(s, -1)
+	var out []string
+	for _, m := range idxs {
+		if backslashed(s, m[0]) {
+			continue
+		}
+		out = append(out, s[m[2]:m[3]])
+	}
+	return out
+}
+
+// ResolveString expands board references in s. When s is exactly one
+// reference, the variable's typed value (or typed default) is
+// returned; otherwise the interpolated string is returned. Missing
+// references fail with a validation error unless a default is given.
+func (b *Board) ResolveString(s string) (any, error) {
+	return b.resolveString(s)
+}
+
+func (b *Board) resolveString(s string) (any, error) {
+	if !strings.Contains(s, BoardRefMarker) {
+		return s, nil
+	}
+	var sb strings.Builder
+	pos := 0
+	for i := 0; i < len(s); {
+		idx := strings.Index(s[i:], BoardRefMarker)
+		if idx < 0 {
+			break
+		}
+		idx += i
+		end := refEnd(s, idx+len(BoardRefMarker))
+		if backslashed(s, idx) {
+			// Escaped reference: emit the literal text, dropping the
+			// escaping backslash. Unterminated markers are fine here.
+			if end < 0 {
+				end = len(s)
+			}
+			sb.WriteString(s[pos : idx-1])
+			sb.WriteString(s[idx:end])
+			pos = end
+			i = end
+			continue
+		}
+		if end < 0 {
+			return nil, errdefs.Validationf(
+				"malformed board reference in %q (escape literal text with \\%s)", s, BoardRefMarker)
+		}
+		// A single reference spanning the whole string keeps the
+		// variable's typed value.
+		if idx == 0 && end == len(s) {
+			body := s[len(BoardRefMarker) : end-1]
+			if strings.Contains(body, BoardRefMarker) {
+				return nil, errdefs.Validationf(
+					"nested board references are not supported: %q", s)
+			}
+			path, def, hasDef, ok := parseBoardRef(body)
+			if !ok {
+				return nil, errdefs.Validationf(
+					"malformed board reference in %q (escape literal text with \\%s)", s, BoardRefMarker)
+			}
+			if v, found := b.lookupBoardRef(path); found {
+				return v, nil
+			}
+			if hasDef {
+				return typedBoardDefault(def), nil
+			}
+			return nil, boardRefMissingError(path)
+		}
+		body := s[idx+len(BoardRefMarker) : end-1]
+		if strings.Contains(body, BoardRefMarker) {
+			return nil, errdefs.Validationf(
+				"nested board references are not supported: %q", s)
+		}
+		path, def, hasDef, ok := parseBoardRef(body)
+		if !ok {
+			return nil, errdefs.Validationf(
+				"malformed board reference in %q (escape literal text with \\%s)", s, BoardRefMarker)
+		}
+		if v, found := b.lookupBoardRef(path); found {
+			sb.WriteString(s[pos:idx])
+			sb.WriteString(stringifyBoardValue(v))
+		} else if hasDef {
+			sb.WriteString(s[pos:idx])
+			sb.WriteString(def)
+		} else {
+			return nil, boardRefMissingError(path)
+		}
+		pos = end
+		i = end
+	}
+	sb.WriteString(s[pos:])
+	return sb.String(), nil
+}
+
+// Resolve expands board references throughout v, a decoded JSON value
+// (strings, []any, map[string]any, or leaf scalars). References inside
+// object keys are rejected: config keys are part of the node type's
+// contract and must stay constant.
+func (b *Board) Resolve(v any) (any, error) {
+	switch t := v.(type) {
+	case string:
+		return b.resolveString(t)
+	case []any:
+		out := make([]any, len(t))
+		for i, e := range t {
+			r, err := b.Resolve(e)
+			if err != nil {
+				return nil, err
+			}
+			out[i] = r
+		}
+		return out, nil
+	case map[string]any:
+		out := make(map[string]any, len(t))
+		for k, e := range t {
+			if boardRefPattern.MatchString(k) {
+				return nil, errdefs.Validationf(
+					"board references are not supported in object keys: %q", k)
+			}
+			r, err := b.Resolve(e)
+			if err != nil {
+				return nil, err
+			}
+			out[k] = r
+		}
+		return out, nil
+	default:
+		return v, nil
+	}
+}
+
+// lookupBoardRef resolves a reference path. The exact variable name is
+// tried first; otherwise the path is walked segment by segment through
+// nested maps (any map type with string keys) and exported struct
+// fields.
+func (b *Board) lookupBoardRef(path string) (any, bool) {
+	if v, ok := b.GetVar(path); ok {
+		return v, true
+	}
+	segs := strings.Split(path, ".")
+	if len(segs) == 1 {
+		return nil, false
+	}
+	v, ok := b.GetVar(segs[0])
+	if !ok {
+		return nil, false
+	}
+	for _, seg := range segs[1:] {
+		v, ok = lookupBoardSegment(v, seg)
+		if !ok {
+			return nil, false
+		}
+	}
+	return v, true
+}
+
+// lookupBoardSegment resolves one path segment against a value.
+// Reflection keeps the lookup open to any map with a string key type
+// (map[string]string, map[string]int, named map types) instead of
+// special-casing every combination; pointers are dereferenced and
+// exported struct fields are readable by Go field name.
+func lookupBoardSegment(v any, seg string) (any, bool) {
+	rv := reflect.ValueOf(v)
+	for rv.IsValid() && rv.Kind() == reflect.Pointer {
+		if rv.IsNil() {
+			return nil, false
+		}
+		rv = rv.Elem()
+	}
+	if !rv.IsValid() {
+		return nil, false
+	}
+	switch rv.Kind() {
+	case reflect.Map:
+		if rv.Type().Key().Kind() != reflect.String {
+			return nil, false
+		}
+		ev := rv.MapIndex(reflect.ValueOf(seg).Convert(rv.Type().Key()))
+		if !ev.IsValid() {
+			return nil, false
+		}
+		return ev.Interface(), true
+	case reflect.Struct:
+		f := rv.FieldByName(seg)
+		if !f.IsValid() || !f.CanInterface() {
+			return nil, false
+		}
+		return f.Interface(), true
+	default:
+		return nil, false
+	}
+}
+
+func parseBoardRef(body string) (path, def string, hasDef bool, ok bool) {
+	path, def, hasDef = strings.Cut(body, ":")
+	if !validBoardPath(path) {
+		return "", "", false, false
+	}
+	if hasDef {
+		def = unescapeBoardDefault(def)
+	}
+	return path, def, hasDef, true
+}
+
+func validBoardPath(p string) bool {
+	if p == "" {
+		return false
+	}
+	for seg := range strings.SplitSeq(p, ".") {
+		if !boardIdentPattern.MatchString(seg) {
+			return false
+		}
+	}
+	return true
+}
+
+// refEnd returns the index just past the closing brace of the
+// reference starting at from, or -1 when unterminated. A \} inside the
+// body is part of a default, not the terminator.
+func refEnd(s string, from int) int {
+	for i := from; i < len(s); i++ {
+		if s[i] == '}' && !backslashed(s, i) {
+			return i + 1
+		}
+	}
+	return -1
+}
+
+// backslashed reports whether s[i] is preceded by an odd number of
+// backslashes, i.e. escaped.
+func backslashed(s string, i int) bool {
+	n := 0
+	for j := i - 1; j >= 0 && s[j] == '\\'; j-- {
+		n++
+	}
+	return n%2 == 1
+}
+
+// unescapeBoardDefault unescapes \} and \\ inside a default value.
+func unescapeBoardDefault(s string) string {
+	if !strings.Contains(s, `\`) {
+		return s
+	}
+	var sb strings.Builder
+	for i := 0; i < len(s); i++ {
+		if s[i] == '\\' && i+1 < len(s) && (s[i+1] == '}' || s[i+1] == '\\') {
+			sb.WriteByte(s[i+1])
+			i++
+			continue
+		}
+		sb.WriteByte(s[i])
+	}
+	return sb.String()
+}
+
+// typedBoardDefault turns a default into a typed value when it is a
+// valid JSON literal; otherwise it stays a string. This lets
+// ${board.limit:3} fill an integer config field while
+// ${board.who:anon} stays text.
+func typedBoardDefault(raw string) any {
+	var v any
+	if err := json.Unmarshal([]byte(raw), &v); err == nil {
+		return v
+	}
+	return raw
+}
+
+// stringifyBoardValue renders an interpolated value as text: strings
+// verbatim, JSON-like values as compact JSON, everything else via %v.
+func stringifyBoardValue(v any) string {
+	if s, ok := v.(string); ok {
+		return s
+	}
+	if b, err := json.Marshal(v); err == nil {
+		return string(b)
+	}
+	return fmt.Sprintf("%v", v)
+}
+
+func boardRefMissingError(path string) error {
+	return errdefs.Validationf(
+		"board reference ${board.%s} does not resolve: %q is not set", path, path)
+}

--- a/core/agent/board_refs_test.go
+++ b/core/agent/board_refs_test.go
@@ -1,0 +1,331 @@
+package agent
+
+import (
+	"testing"
+
+	"github.com/GizClaw/flowcraft/core/errdefs"
+)
+
+func TestResolveStringWholeKeepsType(t *testing.T) {
+	board := NewBoard()
+	board.SetVar("docs", []any{"a", "b"})
+	board.SetVar("limit", float64(3))
+	board.SetVar("ok", true)
+	board.SetVar("meta", map[string]any{"k": "v"})
+
+	cases := []struct {
+		ref  string
+		want any
+	}{
+		{"${board.docs}", []any{"a", "b"}},
+		{"${board.limit}", float64(3)},
+		{"${board.ok}", true},
+		{"${board.meta}", map[string]any{"k": "v"}},
+	}
+	for _, c := range cases {
+		got, err := board.ResolveString(c.ref)
+		if err != nil {
+			t.Fatalf("ResolveString(%q): %v", c.ref, err)
+		}
+		if !equalAny(got, c.want) {
+			t.Fatalf("ResolveString(%q) = %#v, want %#v", c.ref, got, c.want)
+		}
+	}
+}
+
+func TestResolveStringInterpolates(t *testing.T) {
+	board := NewBoard()
+	board.SetVar("city", "Paris")
+	board.SetVar("list", []any{"a", "b"})
+	board.SetVar("n", float64(3))
+
+	cases := []struct {
+		in   string
+		want string
+	}{
+		{"weather in ${board.city} please", "weather in Paris please"},
+		{"items: ${board.list}", `items: ["a","b"]`},
+		{"n=${board.n}", "n=3"},
+	}
+	for _, c := range cases {
+		got, err := board.ResolveString(c.in)
+		if err != nil {
+			t.Fatalf("ResolveString(%q): %v", c.in, err)
+		}
+		if got != c.want {
+			t.Fatalf("ResolveString(%q) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}
+
+func TestResolveStringDotPath(t *testing.T) {
+	board := NewBoard()
+	board.SetVar("user", map[string]any{
+		"name": "ada",
+		"profile": map[string]any{
+			"age": float64(36),
+		},
+	})
+
+	got, err := board.ResolveString("${board.user.name}")
+	if err != nil || got != "ada" {
+		t.Fatalf("ResolveString(user.name) = %v, %v", got, err)
+	}
+	got, err = board.ResolveString("${board.user.profile.age}")
+	if err != nil || got != float64(36) {
+		t.Fatalf("ResolveString(user.profile.age) = %v, %v", got, err)
+	}
+	got, err = board.ResolveString("age ${board.user.profile.age}")
+	if err != nil || got != "age 36" {
+		t.Fatalf("ResolveString(embedded) = %v, %v", got, err)
+	}
+}
+
+func TestResolveStringExactKeyWins(t *testing.T) {
+	board := NewBoard()
+	board.SetVar("user.name", "exact")
+	board.SetVar("user", map[string]any{"name": "nested"})
+
+	got, err := board.ResolveString("${board.user.name}")
+	if err != nil || got != "exact" {
+		t.Fatalf("ResolveString = %v, %v; exact key should win", got, err)
+	}
+}
+
+func TestResolveStringNestedLookupTypes(t *testing.T) {
+	type dict map[string]int
+	board := NewBoard()
+	board.SetVar("cfg", map[string]string{"env": "prod"})
+	board.SetVar("limits", map[string]int{"retries": 3})
+	board.SetVar("named", dict{"port": 8080})
+	board.SetVar("ptr", &map[string]string{"mode": "fast"})
+	board.SetVar("svc", struct{ Timeout int }{Timeout: 30})
+
+	cases := []struct {
+		in   string
+		want any
+	}{
+		{"${board.cfg.env}", "prod"},
+		{"env ${board.cfg.env}", "env prod"},
+		{"${board.limits.retries}", 3},
+		{"${board.named.port}", 8080},
+		{"${board.ptr.mode}", "fast"},
+		{"${board.svc.Timeout}", 30},
+	}
+	for _, c := range cases {
+		got, err := board.ResolveString(c.in)
+		if err != nil {
+			t.Fatalf("ResolveString(%q): %v", c.in, err)
+		}
+		if !equalAny(got, c.want) {
+			t.Fatalf("ResolveString(%q) = %#v, want %#v", c.in, got, c.want)
+		}
+	}
+
+	// Missing keys and unexported fields still fail hard.
+	if _, err := board.ResolveString("${board.cfg.missing}"); err == nil || !errdefs.IsValidation(err) {
+		t.Fatalf("missing map key err = %v, want validation error", err)
+	}
+	if _, err := board.ResolveString("${board.svc.missing}"); err == nil || !errdefs.IsValidation(err) {
+		t.Fatalf("missing field err = %v, want validation error", err)
+	}
+	board.SetVar("hidden", struct{ secret string }{secret: "x"})
+	if _, err := board.ResolveString("${board.hidden.secret}"); err == nil || !errdefs.IsValidation(err) {
+		t.Fatalf("unexported field err = %v, want validation error", err)
+	}
+}
+
+func TestResolveStringDefaults(t *testing.T) {
+	board := NewBoard()
+
+	// Plain string default.
+	got, err := board.ResolveString("${board.who:anon}")
+	if err != nil || got != "anon" {
+		t.Fatalf("string default = %v, %v", got, err)
+	}
+	// JSON-literal default keeps its type.
+	got, err = board.ResolveString("${board.limit:3}")
+	if err != nil || got != float64(3) {
+		t.Fatalf("typed default = %v, %v", got, err)
+	}
+	got, err = board.ResolveString("${board.flag:false}")
+	if err != nil || got != false {
+		t.Fatalf("bool default = %v, %v", got, err)
+	}
+	// Embedded default is text.
+	got, err = board.ResolveString("limit ${board.limit:10}")
+	if err != nil || got != "limit 10" {
+		t.Fatalf("embedded default = %v, %v", got, err)
+	}
+	// Colons inside the default are fine.
+	got, err = board.ResolveString("${board.url:http://example.com}")
+	if err != nil || got != "http://example.com" {
+		t.Fatalf("colon default = %v, %v", got, err)
+	}
+	// Empty default.
+	got, err = board.ResolveString("${board.x:}")
+	if err != nil || got != "" {
+		t.Fatalf("empty default = %v, %v", got, err)
+	}
+	// Escaped brace and backslash inside a default.
+	got, err = board.ResolveString(`${board.x:a\}b}`)
+	if err != nil || got != "a}b" {
+		t.Fatalf("escaped brace default = %v, %v", got, err)
+	}
+	got, err = board.ResolveString(`${board.x:a\\b}`)
+	if err != nil || got != `a\b` {
+		t.Fatalf("escaped backslash default = %v, %v", got, err)
+	}
+	// An existing value beats the default.
+	board.SetVar("limit", float64(9))
+	got, err = board.ResolveString("${board.limit:3}")
+	if err != nil || got != float64(9) {
+		t.Fatalf("existing value should win = %v, %v", got, err)
+	}
+	// Dot-path default.
+	got, err = board.ResolveString("${board.user.name:anon}")
+	if err != nil || got != "anon" {
+		t.Fatalf("dot-path default = %v, %v", got, err)
+	}
+}
+
+func TestResolveStringMissingFails(t *testing.T) {
+	board := NewBoard()
+	board.SetVar("user", map[string]any{"name": "ada"})
+
+	cases := []string{
+		"${board.nope}",
+		"x ${board.nope}",
+		"${board.user.missing}",
+		"${board.missing.name}",
+	}
+	for _, in := range cases {
+		if _, err := board.ResolveString(in); err == nil || !errdefs.IsValidation(err) {
+			t.Fatalf("ResolveString(%q) err = %v, want validation error", in, err)
+		}
+	}
+}
+
+func TestResolveStringMalformedFails(t *testing.T) {
+	board := NewBoard()
+	cases := []string{
+		"${board.1x}",
+		"${board.x",
+		"${board.x:${board.y}}",
+		"${board.x.:1}",
+		"${board.}",
+	}
+	for _, in := range cases {
+		if _, err := board.ResolveString(in); err == nil || !errdefs.IsValidation(err) {
+			t.Fatalf("ResolveString(%q) err = %v, want validation error", in, err)
+		}
+	}
+}
+
+func TestResolveStringEscaped(t *testing.T) {
+	board := NewBoard()
+	board.SetVar("x", "Paris")
+
+	// \${board.x} emits the literal reference, even when the var is missing.
+	got, err := board.ResolveString(`\${board.x}`)
+	if err != nil || got != "${board.x}" {
+		t.Fatalf("escaped ref = %v, %v", got, err)
+	}
+	got, err = board.ResolveString(`\${board.nope}`)
+	if err != nil || got != "${board.nope}" {
+		t.Fatalf("escaped missing ref = %v, %v", got, err)
+	}
+	// Escaped refs mix with live refs.
+	got, err = board.ResolveString(`literal \${board.x} value ${board.x}`)
+	if err != nil || got != "literal ${board.x} value Paris" {
+		t.Fatalf("mixed = %v, %v", got, err)
+	}
+	// An even run of backslashes leaves the reference live.
+	got, err = board.ResolveString(`\\${board.x}`)
+	if err != nil || got != `\\Paris` {
+		t.Fatalf("even backslashes = %v, %v", got, err)
+	}
+}
+
+func TestResolveValueWalk(t *testing.T) {
+	board := NewBoard()
+	board.SetVar("x", "Paris")
+	board.SetVar("user", map[string]any{"name": "ada"})
+
+	in := map[string]any{
+		"a": "${board.x}",
+		"b": []any{"${board.x}", "${board.user.name}"},
+		"c": float64(3),
+	}
+	got, err := board.Resolve(in)
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	m := got.(map[string]any)
+	if m["a"] != "Paris" {
+		t.Fatalf("a = %v", m["a"])
+	}
+	list := m["b"].([]any)
+	if list[0] != "Paris" || list[1] != "ada" {
+		t.Fatalf("b = %v", list)
+	}
+}
+
+func TestResolveRejectsKeyRefs(t *testing.T) {
+	board := NewBoard()
+	board.SetVar("k", "dynamic")
+
+	if _, err := board.Resolve(map[string]any{"${board.k}": 1}); err == nil || !errdefs.IsValidation(err) {
+		t.Fatalf("key ref err = %v, want validation error", err)
+	}
+	if _, err := board.Resolve(map[string]any{`\${board.k}`: 1}); err == nil || !errdefs.IsValidation(err) {
+		t.Fatalf("escaped key ref err = %v, want validation error", err)
+	}
+}
+
+func TestContainsAndExtractBoardRefs(t *testing.T) {
+	cfg := map[string]any{
+		"a": "${board.user.name}",
+		"b": []any{"${board.y:def}", `\${board.skip}`},
+		"c": float64(3),
+	}
+	if !ContainsBoardRef(cfg["a"]) || ContainsBoardRef(cfg["c"]) {
+		t.Fatalf("ContainsBoardRef wrong")
+	}
+	if ContainsBoardRef(`\${board.skip}`) {
+		t.Fatalf("escaped ref should not count as live")
+	}
+	refs := ExtractBoardRefs(cfg)
+	if len(refs) != 2 || refs[0] != "user.name" || refs[1] != "y" {
+		t.Fatalf("ExtractBoardRefs = %v", refs)
+	}
+}
+
+func equalAny(a, b any) bool {
+	switch av := a.(type) {
+	case []any:
+		bv, ok := b.([]any)
+		if !ok || len(av) != len(bv) {
+			return false
+		}
+		for i := range av {
+			if !equalAny(av[i], bv[i]) {
+				return false
+			}
+		}
+		return true
+	case map[string]any:
+		bv, ok := b.(map[string]any)
+		if !ok || len(av) != len(bv) {
+			return false
+		}
+		for k, v := range av {
+			if !equalAny(v, bv[k]) {
+				return false
+			}
+		}
+		return true
+	default:
+		return a == b
+	}
+}

--- a/core/graph/analyze.go
+++ b/core/graph/analyze.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"sort"
+	"strings"
 )
 
 // Warning is a non-fatal build-time finding about the graph's
@@ -191,7 +192,14 @@ func checkUnresolvedReferences(nodes map[string]*nodeSlot, order []string) []War
 			continue // malformed config already fails Build elsewhere
 		}
 		for _, ref := range ExtractRefs(cfg) {
-			if !provided[ref] {
+			// A nested path counts as provided when any node writes its
+			// root segment (e.g. ${board.user.name} is satisfied by a
+			// write to "user").
+			root := ref
+			if i := strings.IndexByte(ref, '.'); i >= 0 {
+				root = ref[:i]
+			}
+			if !provided[ref] && !provided[root] {
 				warnings = append(warnings, Warning{
 					Kind:   WarningUnresolvedReference,
 					NodeID: id,

--- a/core/graph/doc.go
+++ b/core/graph/doc.go
@@ -24,8 +24,9 @@
 //     roles, and returns an immutable [*Graph]. A *Graph IS an
 //     [agent.Engine] — no per-run wrapper, no rebuild step.
 //  4. Execution — [*Graph.Execute] advances a node frontier wave by
-//     wave. Per node it resolves "${board.<name>}" references inside
-//     the raw config, decodes the typed config, validates the declared
+//     wave. Per node it resolves "${board.<path>}" references inside
+//     the raw config (failing on missing variables unless a default
+//     is given), decodes the typed config, validates the declared
 //     reads, invokes the handler, validates the declared writes, and
 //     routes to the next frontier.
 //

--- a/core/graph/resolve.go
+++ b/core/graph/resolve.go
@@ -3,128 +3,61 @@ package graph
 import (
 	"bytes"
 	"encoding/json"
-	"fmt"
-	"regexp"
-	"sort"
+	"io"
 
 	"github.com/GizClaw/flowcraft/core/agent"
 	"github.com/GizClaw/flowcraft/core/errdefs"
 )
 
-// boardRefPattern matches "${board.<name>}" references inside node
-// config strings. <name> is a board variable name.
-//
-// References are resolved per invocation, immediately before the typed
-// config decode: a node can consume values written by an upstream node
-// in the same run, and nothing is baked into shared registration
-// state.
-var boardRefPattern = regexp.MustCompile(`\$\{board\.([A-Za-z_][A-Za-z0-9_]*)\}`)
-
 // ContainsRef reports whether v — a decoded JSON value or a plain
-// string — contains at least one "${board.*}" reference.
-func ContainsRef(v any) bool {
-	return len(findRefs(v)) > 0
-}
-
-// ExtractRefs returns the sorted, deduplicated board variable names
-// referenced anywhere inside v. Useful for tooling and for
-// documentation generation off a [GraphDefinition].
-func ExtractRefs(v any) []string {
-	seen := map[string]bool{}
-	for _, r := range findRefs(v) {
-		seen[r] = true
-	}
-	out := make([]string, 0, len(seen))
-	for r := range seen {
-		out = append(out, r)
-	}
-	sort.Strings(out)
-	return out
-}
-
-func findRefs(v any) []string {
-	switch t := v.(type) {
-	case string:
-		var out []string
-		for _, m := range boardRefPattern.FindAllStringSubmatch(t, -1) {
-			out = append(out, m[1])
-		}
-		return out
-	case []any:
-		var out []string
-		for _, e := range t {
-			out = append(out, findRefs(e)...)
-		}
-		return out
-	case map[string]any:
-		var out []string
-		for _, e := range t {
-			out = append(out, findRefs(e)...)
-		}
-		return out
-	default:
-		return nil
-	}
-}
-
-// resolveRefs substitutes board references throughout v, a decoded
-// JSON value.
+// string — contains at least one live "${board.*}" reference.
 //
-// A string consisting of exactly one reference is replaced by the
-// variable's typed value (a list stays a list, a map stays a map). A
-// reference embedded in a longer string is interpolated with fmt's %v
-// verb. References to missing variables are left literally in place so
-// misconfigurations surface at decode time instead of silently
-// zeroing.
-func resolveRefs(v any, board *agent.Board) any {
-	switch t := v.(type) {
-	case string:
-		return resolveStringRefs(t, board)
-	case []any:
-		out := make([]any, len(t))
-		for i, e := range t {
-			out[i] = resolveRefs(e, board)
-		}
-		return out
-	case map[string]any:
-		out := make(map[string]any, len(t))
-		for k, e := range t {
-			out[k] = resolveRefs(e, board)
-		}
-		return out
-	default:
-		return v
-	}
+// Deprecated: use [agent.ContainsBoardRef].
+func ContainsRef(v any) bool {
+	return agent.ContainsBoardRef(v)
 }
 
-func resolveStringRefs(s string, board *agent.Board) any {
-	if m := boardRefPattern.FindStringSubmatch(s); m != nil && m[0] == s {
-		if val, ok := board.GetVar(m[1]); ok {
-			return val
-		}
-		return s
-	}
-	return boardRefPattern.ReplaceAllStringFunc(s, func(match string) string {
-		name := boardRefPattern.FindStringSubmatch(match)[1]
-		if val, ok := board.GetVar(name); ok {
-			return fmt.Sprintf("%v", val)
-		}
-		return match
-	})
+// ExtractRefs returns the sorted, deduplicated board paths referenced
+// anywhere inside v.
+//
+// Deprecated: use [agent.ExtractBoardRefs].
+func ExtractRefs(v any) []string {
+	return agent.ExtractBoardRefs(v)
 }
 
 // resolveConfig resolves board references inside a raw JSON node
 // config, returning the rewritten raw JSON for the typed decode.
 // Configs without the reference marker are returned unchanged.
+//
+// References are resolved per invocation, immediately before the typed
+// config decode: a node can consume values written by an upstream node
+// in the same run, and nothing is baked into shared registration
+// state. Missing references fail the node with a validation error
+// unless the reference carries a default.
 func resolveConfig(raw json.RawMessage, board *agent.Board) (json.RawMessage, error) {
-	if len(raw) == 0 || !bytes.Contains(raw, []byte("${board.")) {
+	if len(raw) == 0 || !bytes.Contains(raw, []byte(agent.BoardRefMarker)) {
 		return raw, nil
 	}
+	// Numbers stay json.Number through the round-trip so unrelated
+	// literals (e.g. 64-bit or arbitrarily large integers) are re-encoded
+	// verbatim instead of losing precision via float64.
+	dec := json.NewDecoder(bytes.NewReader(raw))
+	dec.UseNumber()
 	var v any
-	if err := json.Unmarshal(raw, &v); err != nil {
+	if err := dec.Decode(&v); err != nil {
 		return nil, errdefs.Validationf("node config is not valid JSON: %v", err)
 	}
-	out, err := json.Marshal(resolveRefs(v, board))
+	if err := dec.Decode(new(any)); err != io.EOF {
+		if err == nil {
+			return nil, errdefs.Validationf("node config has trailing data after the JSON value")
+		}
+		return nil, errdefs.Validationf("node config is not valid JSON: %v", err)
+	}
+	resolved, err := board.Resolve(v)
+	if err != nil {
+		return nil, errdefs.Validationf("node config: %v", err)
+	}
+	out, err := json.Marshal(resolved)
 	if err != nil {
 		return nil, errdefs.Internalf("failed to re-encode resolved node config: %v", err)
 	}

--- a/core/graph/resolve_test.go
+++ b/core/graph/resolve_test.go
@@ -1,6 +1,7 @@
 package graph
 
 import (
+	"bytes"
 	"encoding/json"
 	"testing"
 
@@ -47,15 +48,51 @@ func TestResolveConfigInterpolatesEmbeddedRefs(t *testing.T) {
 	}
 }
 
-func TestResolveConfigLeavesMissingVarsUntouched(t *testing.T) {
+func TestResolveConfigMissingVarFails(t *testing.T) {
 	board := agent.NewBoard()
 	raw := json.RawMessage(`{"prompt": "${board.nope}"}`)
+	if _, err := resolveConfig(raw, board); err == nil {
+		t.Fatal("resolveConfig should fail on a missing variable")
+	}
+}
+
+func TestResolveConfigDotPathAndDefault(t *testing.T) {
+	board := agent.NewBoard()
+	board.SetVar("user", map[string]any{"name": "ada"})
+
+	raw := json.RawMessage(`{"prompt": "hi ${board.user.name} (${board.fallback:anon})"}`)
 	out, err := resolveConfig(raw, board)
 	if err != nil {
 		t.Fatalf("resolveConfig: %v", err)
 	}
-	if string(out) != `{"prompt":"${board.nope}"}` && string(out) != string(raw) {
-		t.Fatalf("missing var should stay literal, got %s", out)
+	var decoded struct {
+		Prompt string `json:"prompt"`
+	}
+	if err := json.Unmarshal(out, &decoded); err != nil {
+		t.Fatalf("unmarshal resolved: %v", err)
+	}
+	if decoded.Prompt != "hi ada (anon)" {
+		t.Fatalf("prompt = %q", decoded.Prompt)
+	}
+}
+
+func TestResolveConfigEscapedRefStaysLiteral(t *testing.T) {
+	board := agent.NewBoard()
+	board.SetVar("x", "Paris")
+
+	raw := json.RawMessage(`{"prompt": "\\${board.x}"}`)
+	out, err := resolveConfig(raw, board)
+	if err != nil {
+		t.Fatalf("resolveConfig: %v", err)
+	}
+	var decoded struct {
+		Prompt string `json:"prompt"`
+	}
+	if err := json.Unmarshal(out, &decoded); err != nil {
+		t.Fatalf("unmarshal resolved: %v", err)
+	}
+	if decoded.Prompt != "${board.x}" {
+		t.Fatalf("prompt = %q, want literal ${board.x}", decoded.Prompt)
 	}
 }
 
@@ -67,6 +104,46 @@ func TestResolveConfigFastPath(t *testing.T) {
 	}
 	if string(out) != string(raw) {
 		t.Fatalf("fast path should return input unchanged, got %s", out)
+	}
+}
+
+func TestResolveConfigPreservesBigIntegers(t *testing.T) {
+	board := agent.NewBoard()
+	board.SetVar("x", "ok")
+
+	raw := json.RawMessage(
+		`{"id": 9007199254740993, "note": "see ${board.x} docs", "wide": 123456789012345678901234567890}`)
+	out, err := resolveConfig(raw, board)
+	if err != nil {
+		t.Fatalf("resolveConfig: %v", err)
+	}
+	// The unrelated literals must survive the round-trip verbatim, not
+	// as float64 re-encodings (which would lose precision).
+	if !bytes.Contains(out, []byte("9007199254740993")) {
+		t.Fatalf("int64 literal lost: %s", out)
+	}
+	if !bytes.Contains(out, []byte("123456789012345678901234567890")) {
+		t.Fatalf("wide integer literal lost: %s", out)
+	}
+
+	var decoded struct {
+		ID   int64  `json:"id"`
+		Note string `json:"note"`
+	}
+	if err := json.Unmarshal(out, &decoded); err != nil {
+		t.Fatalf("unmarshal resolved: %v", err)
+	}
+	if decoded.ID != 9007199254740993 || decoded.Note != "see ok docs" {
+		t.Fatalf("decoded = %+v", decoded)
+	}
+	var wide struct {
+		Wide json.Number `json:"wide"`
+	}
+	if err := json.Unmarshal(out, &wide); err != nil {
+		t.Fatalf("unmarshal wide: %v", err)
+	}
+	if wide.Wide.String() != "123456789012345678901234567890" {
+		t.Fatalf("wide = %s", wide.Wide.String())
 	}
 }
 

--- a/docs/guides/graph.md
+++ b/docs/guides/graph.md
@@ -55,10 +55,18 @@ A `*Graph` is an `agent.Engine`.
 ```
 
 `condition` and `skip_condition` use expr-lang expressions over board
-variables. `${board.<name>}` references inside config strings resolve before
-node decode, so `system_prompt` may interpolate upstream output. Node types
-must be registered in the registry passed to `Build`; an unregistered type
-fails `Build`, not `GraphDefinition.Validate`.
+variables. `${board.<path>}` references inside config strings resolve before
+node decode, so `system_prompt` may interpolate upstream output. Paths are
+dot-separated: `${board.user.name}` reads var `user` and then its `name`
+field (an exact variable named `user.name` wins). Nested lookup walks maps
+with string keys (`map[string]any`, `map[string]string`, ...) and exported
+struct fields. An optional default follows a colon (`${board.limit:3}`); a
+reference standing alone keeps the variable's typed value, and defaults that
+are valid JSON literals keep their type. Referencing a missing variable is a
+validation error unless a default is given — prefix with a backslash
+(`\${board.x}`) to emit literal text. Node types must be registered in the
+registry passed to `Build`; an unregistered type fails `Build`, not
+`GraphDefinition.Validate`.
 
 ## Engine settings (`agent.Engine/graph`)
 


### PR DESCRIPTION
## Summary

Lifts the `${board.<path>}` reference syntax from `core/graph` into `core/agent`, making it a first-class `agent.Board` contract, and extends the syntax:

- **Dot paths**: `${board.user.name}` resolves through nested maps (any map with string keys: `map[string]any`, `map[string]string`, ...) and exported struct fields; exact variable names win over nested lookup.
- **Defaults**: `${board.x:default}` falls back when the variable is missing; a standalone reference with a JSON-literal default keeps its type (`${board.limit:3}` → number).
- **Fail fast**: missing references now fail with a validation error instead of staying literal, so unresolved `${board.x}` never leaks into model prompts. Escaped `\${board.x}` emits literal text.
- **Precision**: `resolveConfig` now decodes with `json.Decoder.UseNumber`, so unrelated integer literals in node configs are re-encoded verbatim (no float64 precision loss).

## API

- `agent.Board`: new `ResolveString` / `Resolve`, plus `ContainsBoardRef`, `ExtractBoardRefs`, `BoardRefMarker`.
- Board bridge: scripts can expand references at runtime via `board.resolve` / `board.resolveString` (previously documented but missing).
- `graph.ContainsRef` / `graph.ExtractRefs` are now deprecated wrappers delegating to `agent`.

## Notes

- Build-time analysis (`WarningUnresolvedReference`) treats nested paths as satisfied by writes to their root segment.
- References in object keys are rejected; defaults cannot nest references.
- No `.release/` changeset: no module release intent in this PR.

## Verification

- `make ci`, `make lint`, `make release-check`, `git diff --check` all pass.
- New tests cover typed whole-string refs, dot paths, defaults, fail-fast errors, escaping, nested lookup types, and big-integer preservation.