### PR TITLE
chore(release): add core v0.1.15 changeset

### DIFF
--- a/.release/core-v0.1.15.json
+++ b/.release/core-v0.1.15.json
@@ -1,0 +1,9 @@
+{
+  "summary": "feat(core): lift board ref syntax into agent.Board — ${board.<path>} dot-path resolution through nested string-keyed maps and exported struct fields, typed JSON-literal defaults (${board.x:default}), fail-fast validation for missing references with \\${board.x} escaping, and json.Decoder.UseNumber config decoding to preserve integer precision; agent.Board gains Resolve/ResolveString, ContainsBoardRef, ExtractBoardRefs, and BoardRefMarker, the board bridge exposes board.resolve/board.resolveString, and graph.ContainsRef/graph.ExtractRefs become deprecated wrappers",
+  "releases": [
+    {
+      "module": "core",
+      "bump": "patch"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Adds the immutable `.release/core-v0.1.15.json` changeset so the release workflow plans a **patch** release for `core`, tagging `core/v0.1.15`.

Covers the accumulated delta since `core/v0.1.14`:

- feat(core): lift board ref syntax into `agent.Board` (#353) — dot-path resolution through nested maps/struct fields, typed JSON-literal defaults, fail-fast missing-reference validation with escaping, `json.Decoder.UseNumber` precision, new `agent.Board` API and `board.resolve`/\`board.resolveString` bridge entries.

## Verification

- `make release-plan`: core `0.1.14 -> 0.1.15` (patch), tag `core/v0.1.15`
- `make release-check`: changesets valid

Merging this PR lets the `Release modules` workflow aggregate the summary and open/refresh the `automation/release-changelog` PR; merging that PR creates the `core/v0.1.15` tag.