### PR TITLE
feat(core): support env scalars in settings decode

### DIFF
--- a/core/agent/a2a/resource.go
+++ b/core/agent/a2a/resource.go
@@ -84,7 +84,8 @@ func (f *Factory) New(ctx context.Context, in resource.Input) (any, error) {
 	}
 	engineOpts = append(engineOpts, WithPollInterval(pollInterval))
 	if parsed.HistoryLength != nil {
-		engineOpts = append(engineOpts, WithHistoryLength(*parsed.HistoryLength))
+		engineOpts = append(engineOpts,
+			WithHistoryLength(int(*parsed.HistoryLength)))
 	}
 	if len(parsed.AcceptedOutputModes) > 0 {
 		engineOpts = append(engineOpts, WithAcceptedOutputModes(parsed.AcceptedOutputModes...))
@@ -119,7 +120,7 @@ type settings struct {
 	// PollInterval is the tasks/get polling cadence (Go duration string).
 	PollInterval string `json:"poll_interval,omitempty"`
 	// HistoryLength limits remote history carried by task responses.
-	HistoryLength *int `json:"history_length,omitempty"`
+	HistoryLength *resource.Int `json:"history_length,omitempty"`
 	// AcceptedOutputModes constrains remote output modalities.
 	AcceptedOutputModes []string `json:"accepted_output_modes,omitempty"`
 	// PreferredTransports orders transport selection (jsonrpc|grpc|http+json).

--- a/core/resource/scalar.go
+++ b/core/resource/scalar.go
@@ -1,0 +1,121 @@
+package resource
+
+import (
+	"encoding/json"
+	"strconv"
+
+	"github.com/GizClaw/flowcraft/core/errdefs"
+)
+
+// Int is a settings scalar that accepts either a JSON number literal
+// or a string. The string form is how an expanded ${env:NAME} value
+// arrives: expansion replaces the reference with the environment
+// variable's text, so a numeric field can consume env only through a
+// type like this one. Literal JSON numbers keep their exact behavior.
+type Int int
+
+// UnmarshalJSON accepts a JSON number or a string, parsing the string
+// with strconv.Atoi. A non-integer string is a validation error.
+func (v *Int) UnmarshalJSON(data []byte) error {
+	if len(data) > 0 && data[0] == '"' {
+		var s string
+		if err := json.Unmarshal(data, &s); err != nil {
+			return err
+		}
+		n, err := strconv.Atoi(s)
+		if err != nil {
+			return errdefs.Validationf(
+				"resource settings: int: %q: %v", s, err)
+		}
+		*v = Int(n)
+		return nil
+	}
+	var n int
+	if err := json.Unmarshal(data, &n); err != nil {
+		return err
+	}
+	*v = Int(n)
+	return nil
+}
+
+// Bool is a settings scalar that accepts either a JSON boolean literal
+// or a string (strconv.ParseBool: "true", "1", "false", "0", ...).
+type Bool bool
+
+// UnmarshalJSON accepts a JSON boolean or a string.
+func (v *Bool) UnmarshalJSON(data []byte) error {
+	if len(data) > 0 && data[0] == '"' {
+		var s string
+		if err := json.Unmarshal(data, &s); err != nil {
+			return err
+		}
+		b, err := strconv.ParseBool(s)
+		if err != nil {
+			return errdefs.Validationf(
+				"resource settings: bool: %q: %v", s, err)
+		}
+		*v = Bool(b)
+		return nil
+	}
+	var b bool
+	if err := json.Unmarshal(data, &b); err != nil {
+		return err
+	}
+	*v = Bool(b)
+	return nil
+}
+
+// Float64 is a settings scalar that accepts either a JSON number
+// literal or a string (strconv.ParseFloat).
+type Float64 float64
+
+// UnmarshalJSON accepts a JSON number or a string.
+func (v *Float64) UnmarshalJSON(data []byte) error {
+	if len(data) > 0 && data[0] == '"' {
+		var s string
+		if err := json.Unmarshal(data, &s); err != nil {
+			return err
+		}
+		f, err := strconv.ParseFloat(s, 64)
+		if err != nil {
+			return errdefs.Validationf(
+				"resource settings: float: %q: %v", s, err)
+		}
+		*v = Float64(f)
+		return nil
+	}
+	var f float64
+	if err := json.Unmarshal(data, &f); err != nil {
+		return err
+	}
+	*v = Float64(f)
+	return nil
+}
+
+// Int64 is a settings scalar that accepts either a JSON number literal
+// or a string (strconv.ParseInt). Use it for 64-bit integer settings
+// such as millisecond counters that must stay exact.
+type Int64 int64
+
+// UnmarshalJSON accepts a JSON number or a string.
+func (v *Int64) UnmarshalJSON(data []byte) error {
+	if len(data) > 0 && data[0] == '"' {
+		var s string
+		if err := json.Unmarshal(data, &s); err != nil {
+			return err
+		}
+		n, err := strconv.ParseInt(s, 10, 64)
+		if err != nil {
+			return errdefs.Validationf(
+				"resource settings: int64: %q: %v", s, err)
+		}
+		*v = Int64(n)
+		return nil
+	}
+	var n int64
+	if err := json.Unmarshal(data, &n); err != nil {
+		return err
+	}
+	*v = Int64(n)
+	return nil
+}

--- a/core/resource/scalar_test.go
+++ b/core/resource/scalar_test.go
@@ -1,0 +1,133 @@
+package resource
+
+import (
+	"strings"
+	"testing"
+)
+
+type scalarSettings struct {
+	Capacity *Int     `json:"capacity,omitempty"`
+	Resume   *Bool    `json:"resume,omitempty"`
+	Ratio    *Float64 `json:"ratio,omitempty"`
+	Millis   *Int64   `json:"millis,omitempty"`
+	Plain    Int      `json:"plain,omitempty"`
+}
+
+func TestDecodeSettingsScalarTypes(t *testing.T) {
+	t.Run("literals decode unchanged", func(t *testing.T) {
+		var s scalarSettings
+		err := DecodeSettings(&s, []byte(`{
+			"capacity": 8,
+			"resume": true,
+			"ratio": 1.5,
+			"millis": 3000,
+			"plain": 3
+		}`))
+		if err != nil {
+			t.Fatalf("DecodeSettings: %v", err)
+		}
+		if s.Capacity == nil || *s.Capacity != 8 {
+			t.Fatalf("Capacity = %v, want 8", s.Capacity)
+		}
+		if s.Resume == nil || !bool(*s.Resume) {
+			t.Fatalf("Resume = %v, want true", s.Resume)
+		}
+		if s.Ratio == nil || float64(*s.Ratio) != 1.5 {
+			t.Fatalf("Ratio = %v, want 1.5", s.Ratio)
+		}
+		if s.Millis == nil || *s.Millis != 3000 {
+			t.Fatalf("Millis = %v, want 3000", s.Millis)
+		}
+		if s.Plain != 3 {
+			t.Fatalf("Plain = %v, want 3", s.Plain)
+		}
+	})
+
+	t.Run("env strings decode through expansion", func(t *testing.T) {
+		lookup := map[string]string{
+			"FC_CAPACITY": "8",
+			"FC_RESUME":   "1",
+			"FC_RATIO":    "0.25",
+			"FC_MILLIS":   "3000",
+		}
+		var s scalarSettings
+		err := DecodeSettings(&s, []byte(`{
+			"capacity": "${env:FC_CAPACITY}",
+			"resume": "${env:FC_RESUME}",
+			"ratio": "${env:FC_RATIO}",
+			"millis": "${env:FC_MILLIS}"
+		}`), WithEnv(func(name string) (string, bool) {
+			v, ok := lookup[name]
+			return v, ok
+		}))
+		if err != nil {
+			t.Fatalf("DecodeSettings: %v", err)
+		}
+		if s.Capacity == nil || *s.Capacity != 8 {
+			t.Fatalf("Capacity = %v, want 8", s.Capacity)
+		}
+		if s.Resume == nil || !bool(*s.Resume) {
+			t.Fatalf("Resume = %v, want true", s.Resume)
+		}
+		if s.Ratio == nil || float64(*s.Ratio) != 0.25 {
+			t.Fatalf("Ratio = %v, want 0.25", s.Ratio)
+		}
+		if s.Millis == nil || *s.Millis != 3000 {
+			t.Fatalf("Millis = %v, want 3000", s.Millis)
+		}
+	})
+
+	t.Run("absent stays nil", func(t *testing.T) {
+		var s scalarSettings
+		if err := DecodeSettings(&s, []byte(`{"plain": 1}`)); err != nil {
+			t.Fatalf("DecodeSettings: %v", err)
+		}
+		if s.Capacity != nil || s.Resume != nil || s.Ratio != nil ||
+			s.Millis != nil {
+			t.Fatalf("absent pointer fields must stay nil: %+v", s)
+		}
+	})
+
+	t.Run("invalid strings are validation errors", func(t *testing.T) {
+		for name, raw := range map[string]string{
+			"int":   `{"capacity": "abc"}`,
+			"bool":  `{"resume": "maybe"}`,
+			"float": `{"ratio": "fast"}`,
+			"int64": `{"millis": "soon"}`,
+		} {
+			t.Run(name, func(t *testing.T) {
+				var s scalarSettings
+				err := DecodeSettings(&s, []byte(raw))
+				if err == nil {
+					t.Fatal("DecodeSettings unexpectedly succeeded")
+				}
+				if !strings.Contains(err.Error(), "resource settings:") {
+					t.Fatalf("error = %v, want resource settings prefix", err)
+				}
+			})
+		}
+	})
+
+	t.Run("missing env still fails before decode", func(t *testing.T) {
+		var s scalarSettings
+		err := DecodeSettings(&s, []byte(`{"capacity": "${env:FC_UNSET}"}`),
+			WithEnv(func(string) (string, bool) { return "", false }))
+		if err == nil {
+			t.Fatal("DecodeSettings unexpectedly succeeded")
+		}
+		if !strings.Contains(err.Error(), "not set") {
+			t.Fatalf("error = %v, want missing env mention", err)
+		}
+	})
+
+	t.Run("strict unknown fields still rejected", func(t *testing.T) {
+		var s scalarSettings
+		err := DecodeSettings(&s, []byte(`{"capacity": 8, "typo": true}`))
+		if err == nil {
+			t.Fatal("DecodeSettings unexpectedly succeeded")
+		}
+		if !strings.Contains(err.Error(), "typo") {
+			t.Fatalf("error = %v, want unknown field mention", err)
+		}
+	})
+}

--- a/core/runtime/config.go
+++ b/core/runtime/config.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/GizClaw/flowcraft/core/deploy"
 	"github.com/GizClaw/flowcraft/core/errdefs"
+	"github.com/GizClaw/flowcraft/core/resource"
 )
 
 const (
@@ -64,13 +65,13 @@ type configWire struct {
 }
 
 type sessionConfigWire struct {
-	IdleTimeout             *string `json:"idle_timeout,omitempty"`
-	SinkBuffer              *int    `json:"sink_buffer,omitempty"`
-	SpeculativeBufferEvents *int    `json:"speculative_buffer_events,omitempty"`
-	SpeculativeBufferBytes  *int    `json:"speculative_buffer_bytes,omitempty"`
-	DeliveryConcurrency     *int    `json:"delivery_concurrency,omitempty"`
-	MaxSessions             *int    `json:"max_sessions,omitempty"`
-	Resume                  *bool   `json:"resume,omitempty"`
+	IdleTimeout             *string        `json:"idle_timeout,omitempty"`
+	SinkBuffer              *resource.Int  `json:"sink_buffer,omitempty"`
+	SpeculativeBufferEvents *resource.Int  `json:"speculative_buffer_events,omitempty"`
+	SpeculativeBufferBytes  *resource.Int  `json:"speculative_buffer_bytes,omitempty"`
+	DeliveryConcurrency     *resource.Int  `json:"delivery_concurrency,omitempty"`
+	MaxSessions             *resource.Int  `json:"max_sessions,omitempty"`
+	Resume                  *resource.Bool `json:"resume,omitempty"`
 }
 
 type dynamicCatalogConfigWire struct {
@@ -83,7 +84,7 @@ func DecodeConfig(doc deploy.Document) (Config, error) {
 		return Config{}, errdefs.Validationf("runtime config: runtime section is required")
 	}
 	var wire configWire
-	if err := doc.Runtime.Decode(&wire); err != nil {
+	if err := resource.DecodeSettings(&wire, doc.Runtime.Bytes(), resource.ExpandEnv()); err != nil {
 		return Config{}, errdefs.Validation(fmt.Errorf("runtime config: decode: %w", err))
 	}
 	cfg := Config{
@@ -121,7 +122,7 @@ func DecodeConfig(doc deploy.Document) (Config, error) {
 				"runtime config: sessions.sink_buffer must be between 1 and %d",
 				maxSinkBuffer)
 		}
-		cfg.Sessions.SinkBuffer = *wire.Sessions.SinkBuffer
+		cfg.Sessions.SinkBuffer = int(*wire.Sessions.SinkBuffer)
 	}
 	if wire.Sessions.SpeculativeBufferEvents != nil {
 		if *wire.Sessions.SpeculativeBufferEvents <= 0 ||
@@ -130,7 +131,7 @@ func DecodeConfig(doc deploy.Document) (Config, error) {
 				"runtime config: sessions.speculative_buffer_events must be between 1 and %d",
 				maxSpeculativeBufferEvents)
 		}
-		cfg.Sessions.SpeculativeBufferEvents = *wire.Sessions.SpeculativeBufferEvents
+		cfg.Sessions.SpeculativeBufferEvents = int(*wire.Sessions.SpeculativeBufferEvents)
 	}
 	if wire.Sessions.SpeculativeBufferBytes != nil {
 		if *wire.Sessions.SpeculativeBufferBytes <= 0 ||
@@ -139,7 +140,7 @@ func DecodeConfig(doc deploy.Document) (Config, error) {
 				"runtime config: sessions.speculative_buffer_bytes must be between 1 and %d",
 				maxSpeculativeBufferBytes)
 		}
-		cfg.Sessions.SpeculativeBufferBytes = *wire.Sessions.SpeculativeBufferBytes
+		cfg.Sessions.SpeculativeBufferBytes = int(*wire.Sessions.SpeculativeBufferBytes)
 	}
 	if wire.Sessions.DeliveryConcurrency != nil {
 		if *wire.Sessions.DeliveryConcurrency <= 0 ||
@@ -148,17 +149,17 @@ func DecodeConfig(doc deploy.Document) (Config, error) {
 				"runtime config: sessions.delivery_concurrency must be between 1 and %d",
 				maxDeliveryConcurrency)
 		}
-		cfg.Sessions.DeliveryConcurrency = *wire.Sessions.DeliveryConcurrency
+		cfg.Sessions.DeliveryConcurrency = int(*wire.Sessions.DeliveryConcurrency)
 	}
 	if wire.Sessions.MaxSessions != nil {
 		if *wire.Sessions.MaxSessions <= 0 {
 			return Config{}, errdefs.Validationf(
 				"runtime config: sessions.max_sessions must be positive")
 		}
-		cfg.Sessions.MaxSessions = *wire.Sessions.MaxSessions
+		cfg.Sessions.MaxSessions = int(*wire.Sessions.MaxSessions)
 	}
 	if wire.Sessions.Resume != nil {
-		cfg.Sessions.Resume = *wire.Sessions.Resume
+		cfg.Sessions.Resume = bool(*wire.Sessions.Resume)
 	}
 	if cfg.Sessions.Resume && cfg.CheckpointStore == "" {
 		return Config{}, errdefs.Validationf(

--- a/core/runtime/config_test.go
+++ b/core/runtime/config_test.go
@@ -1,6 +1,7 @@
 package runtime
 
 import (
+	"os"
 	"strings"
 	"testing"
 	"time"
@@ -103,6 +104,81 @@ func TestDecodeConfigStrictAndValidated(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestDecodeConfig_EnvExpansion(t *testing.T) {
+	t.Run("string field from env", func(t *testing.T) {
+		t.Setenv("FLOWCRAFT_TEST_IDLE_TIMEOUT", "45s")
+		doc := parseRuntimeDocument(t, `  event_bus: events
+  sessions:
+    idle_timeout: ${env:FLOWCRAFT_TEST_IDLE_TIMEOUT}
+`)
+		cfg, err := DecodeConfig(doc)
+		if err != nil {
+			t.Fatalf("DecodeConfig: %v", err)
+		}
+		if cfg.Sessions.IdleTimeout != 45*time.Second {
+			t.Fatalf("IdleTimeout = %v, want 45s", cfg.Sessions.IdleTimeout)
+		}
+	})
+
+	t.Run("string map field from env", func(t *testing.T) {
+		t.Setenv("FLOWCRAFT_TEST_EVENT_BUS", "events")
+		doc := parseRuntimeDocument(t, "  event_bus: ${env:FLOWCRAFT_TEST_EVENT_BUS}\n")
+		cfg, err := DecodeConfig(doc)
+		if err != nil {
+			t.Fatalf("DecodeConfig: %v", err)
+		}
+		if cfg.EventBus != "events" {
+			t.Fatalf("EventBus = %q, want events", cfg.EventBus)
+		}
+	})
+
+	t.Run("missing env fails", func(t *testing.T) {
+		key := "FLOWCRAFT_TEST_MISSING_IDLE_TIMEOUT"
+		if value, ok := os.LookupEnv(key); ok {
+			t.Cleanup(func() { os.Setenv(key, value) })
+			os.Unsetenv(key)
+		}
+		doc := parseRuntimeDocument(t, `  event_bus: events
+  sessions:
+    idle_timeout: ${env:FLOWCRAFT_TEST_MISSING_IDLE_TIMEOUT}
+`)
+		if _, err := DecodeConfig(doc); err == nil {
+			t.Fatal("DecodeConfig unexpectedly succeeded with missing env")
+		}
+	})
+
+	t.Run("numeric field from env", func(t *testing.T) {
+		t.Setenv("FLOWCRAFT_TEST_SINK_BUFFER", "17")
+		doc := parseRuntimeDocument(t, `  event_bus: events
+  sessions:
+    sink_buffer: ${env:FLOWCRAFT_TEST_SINK_BUFFER}
+`)
+		cfg, err := DecodeConfig(doc)
+		if err != nil {
+			t.Fatalf("DecodeConfig: %v", err)
+		}
+		if cfg.Sessions.SinkBuffer != 17 {
+			t.Fatalf("SinkBuffer = %d, want 17", cfg.Sessions.SinkBuffer)
+		}
+	})
+
+	t.Run("bool field from env", func(t *testing.T) {
+		t.Setenv("FLOWCRAFT_TEST_RESUME", "true")
+		doc := parseRuntimeDocument(t, `  event_bus: events
+  checkpoint_store: cps
+  sessions:
+    resume: ${env:FLOWCRAFT_TEST_RESUME}
+`)
+		cfg, err := DecodeConfig(doc)
+		if err != nil {
+			t.Fatalf("DecodeConfig: %v", err)
+		}
+		if !cfg.Sessions.Resume {
+			t.Fatal("Resume = false, want true")
+		}
+	})
 }
 
 func TestDecodeConfig_DynamicCatalog(t *testing.T) {

--- a/core/runtime/config_test.go
+++ b/core/runtime/config_test.go
@@ -137,8 +137,10 @@ func TestDecodeConfig_EnvExpansion(t *testing.T) {
 	t.Run("missing env fails", func(t *testing.T) {
 		key := "FLOWCRAFT_TEST_MISSING_IDLE_TIMEOUT"
 		if value, ok := os.LookupEnv(key); ok {
-			t.Cleanup(func() { os.Setenv(key, value) })
-			os.Unsetenv(key)
+			t.Cleanup(func() { _ = os.Setenv(key, value) })
+			if err := os.Unsetenv(key); err != nil {
+				t.Fatalf("unset %s: %v", key, err)
+			}
 		}
 		doc := parseRuntimeDocument(t, `  event_bus: events
   sessions:

--- a/core/tool/mcp/config.go
+++ b/core/tool/mcp/config.go
@@ -34,8 +34,8 @@ type ServerSpec struct {
 	Headers     map[string]string `json:"headers,omitempty"`
 	HTTPTimeout *string           `json:"http_timeout,omitempty"`
 	Prefix      *string           `json:"prefix,omitempty"`
-	Resources   bool              `json:"resources,omitempty"`
-	Required    bool              `json:"required,omitempty"`
+	Resources   resource.Bool     `json:"resources,omitempty"`
+	Required    resource.Bool     `json:"required,omitempty"`
 }
 
 // Transport constants for ServerSpec.Transport.

--- a/core/workspace/resource.go
+++ b/core/workspace/resource.go
@@ -19,10 +19,10 @@ type Settings struct {
 // [ScopedWorkspace]. The switch is explicit: the scope is applied only
 // when Enabled is true.
 type ScopedSettings struct {
-	Enabled       bool     `json:"enabled"`
-	DenyRead      []string `json:"deny_read,omitempty"`
-	AllowWrite    []string `json:"allow_write,omitempty"`
-	MandatoryDeny []string `json:"mandatory_deny,omitempty"`
+	Enabled       resource.Bool `json:"enabled"`
+	DenyRead      []string      `json:"deny_read,omitempty"`
+	AllowWrite    []string      `json:"allow_write,omitempty"`
+	MandatoryDeny []string      `json:"mandatory_deny,omitempty"`
 }
 
 // Factory builds a local directory workspace as the

--- a/driver/anthropic/client.go
+++ b/driver/anthropic/client.go
@@ -50,7 +50,8 @@ func (m profileMaterial) newClients(spec Spec) *clients {
 		options = append(options, option.WithBaseURL(spec.BaseURL))
 	}
 	if spec.HTTPRetries != nil {
-		options = append(options, option.WithMaxRetries(sdkMaxRetries(*spec.HTTPRetries)))
+		options = append(options,
+			option.WithMaxRetries(sdkMaxRetries(int(*spec.HTTPRetries))))
 	}
 	return &clients{api: anthropicgo.NewClient(options...)}
 }

--- a/driver/anthropic/spec.go
+++ b/driver/anthropic/spec.go
@@ -13,7 +13,7 @@ type Spec struct {
 	BaseURL string `json:"base_url,omitempty"`
 	// HTTPRetries bounds wire-level retries inside one logical inference
 	// attempt, including the first.
-	HTTPRetries *int `json:"http_retries,omitempty"`
+	HTTPRetries *resource.Int `json:"http_retries,omitempty"`
 	// Models declares custom models or overrides built-in catalog entries.
 	Models []ModelSpec `json:"models,omitempty"`
 }

--- a/driver/azure/client.go
+++ b/driver/azure/client.go
@@ -55,7 +55,8 @@ func (m profileMaterial) newClients(spec Spec) *clients {
 		azure.WithAPIKey(m.apiKey),
 	}
 	if spec.HTTPRetries != nil {
-		options = append(options, sdkMaxRetriesOption(*spec.HTTPRetries))
+		options = append(options,
+			sdkMaxRetriesOption(int(*spec.HTTPRetries)))
 	}
 	return &clients{api: openaigo.NewClient(options...)}
 }

--- a/driver/azure/spec.go
+++ b/driver/azure/spec.go
@@ -20,7 +20,7 @@ type Spec struct {
 	APIVersion string `json:"api_version,omitempty"`
 	// HTTPRetries bounds wire-level retries inside one logical inference
 	// attempt, including the first.
-	HTTPRetries *int `json:"http_retries,omitempty"`
+	HTTPRetries *resource.Int `json:"http_retries,omitempty"`
 	// Models declares the deployments to expose; at least one is required.
 	Models []ModelSpec `json:"models"`
 }

--- a/driver/bytedance/client.go
+++ b/driver/bytedance/client.go
@@ -128,7 +128,8 @@ func (m profileMaterial) newClients(spec Spec) *clients {
 		utils.WithResponseHeaderTimeout(defaultResponseHeaderTimeout),
 	}
 	if spec.HTTPRetries != nil {
-		httpOptions = append(httpOptions, utils.WithRetryAttempts(*spec.HTTPRetries))
+		httpOptions = append(httpOptions,
+			utils.WithRetryAttempts(int(*spec.HTTPRetries)))
 	}
 	if spec.BaseURL != "" {
 		options = append(options, arkruntime.WithBaseUrl(spec.BaseURL))

--- a/driver/bytedance/spec.go
+++ b/driver/bytedance/spec.go
@@ -41,14 +41,14 @@ type Spec struct {
 	// HTTPRetries bounds wire-level HTTP retries on the Ark and Doubao
 	// speech HTTP clients. Zero disables transport retries so the route
 	// Router owns the full retry budget; nil keeps the httpkit default.
-	HTTPRetries *int `json:"http_retries,omitempty"`
+	HTTPRetries *resource.Int `json:"http_retries,omitempty"`
 	// Region selects the Ark service region.
 	Region string `json:"region,omitempty"`
 	// VideoPollIntervalMillis paces content-generation task polls (Seedance
 	// video). It tunes client-side waiting only — nothing is sent upstream —
 	// so it lives in the deployment Spec, not in a per-request extension.
 	// Unset defaults to defaultVideoPollInterval.
-	VideoPollIntervalMillis *int64 `json:"video_poll_interval_millis,omitempty"`
+	VideoPollIntervalMillis *resource.Int64 `json:"video_poll_interval_millis,omitempty"`
 	// Models declares additional models beyond the built-in catalog or
 	// overrides catalog entries by name.
 	Models []ModelSpec `json:"models,omitempty"`

--- a/driver/deepseek/client.go
+++ b/driver/deepseek/client.go
@@ -62,7 +62,8 @@ func (m profileMaterial) newClients(spec Spec) *clients {
 		option.WithBaseURL(baseURL),
 	}
 	if spec.HTTPRetries != nil {
-		options = append(options, option.WithMaxRetries(sdkMaxRetries(*spec.HTTPRetries)))
+		options = append(options,
+			option.WithMaxRetries(sdkMaxRetries(int(*spec.HTTPRetries))))
 	}
 	return &clients{api: openaigo.NewClient(options...)}
 }

--- a/driver/deepseek/spec.go
+++ b/driver/deepseek/spec.go
@@ -26,7 +26,7 @@ type Spec struct {
 	// attempt, including the first. Zero disables SDK-internal retries so
 	// the route Router owns the full retry budget; nil keeps the openai-go
 	// default (two retries).
-	HTTPRetries *int `json:"http_retries,omitempty"`
+	HTTPRetries *resource.Int `json:"http_retries,omitempty"`
 	// Models declares models outside the built-in catalog or overrides
 	// catalog entries by name.
 	Models []ModelSpec `json:"models,omitempty"`

--- a/driver/kimi/client.go
+++ b/driver/kimi/client.go
@@ -56,7 +56,8 @@ func (m profileMaterial) newClient(spec Spec) *kimiClient {
 		utils.WithResponseHeaderTimeout(5 * time.Minute),
 	}
 	if spec.HTTPRetries != nil {
-		options = append(options, utils.WithRetryAttempts(*spec.HTTPRetries))
+		options = append(options,
+			utils.WithRetryAttempts(int(*spec.HTTPRetries)))
 	}
 	return &kimiClient{
 		baseURL: baseURL,

--- a/driver/kimi/spec.go
+++ b/driver/kimi/spec.go
@@ -21,7 +21,7 @@ type Spec struct {
 	// HTTPRetries bounds wire-level HTTP retries inside one logical
 	// inference attempt. Zero disables transport retries so the route
 	// Router owns the full retry budget; nil keeps the httpkit default.
-	HTTPRetries *int `json:"http_retries,omitempty"`
+	HTTPRetries *resource.Int `json:"http_retries,omitempty"`
 	// Models declares models outside the built-in catalog or extends
 	// catalog entries by name.
 	Models []ModelSpec `json:"models,omitempty"`

--- a/driver/minimax/client.go
+++ b/driver/minimax/client.go
@@ -62,7 +62,8 @@ func (m profileMaterial) newClients(spec Spec) *clients {
 		option.WithBaseURL(baseURL),
 	}
 	if spec.HTTPRetries != nil {
-		options = append(options, option.WithMaxRetries(sdkMaxRetries(*spec.HTTPRetries)))
+		options = append(options,
+			option.WithMaxRetries(sdkMaxRetries(int(*spec.HTTPRetries))))
 	}
 	return &clients{
 		api:   anthropicgo.NewClient(options...),

--- a/driver/minimax/media.go
+++ b/driver/minimax/media.go
@@ -34,7 +34,8 @@ func newMediaClient(key, base string, spec Spec) *mediaClient {
 		utils.WithResponseHeaderTimeout(5 * time.Minute),
 	}
 	if spec.HTTPRetries != nil {
-		options = append(options, utils.WithRetryAttempts(*spec.HTTPRetries))
+		options = append(options,
+			utils.WithRetryAttempts(int(*spec.HTTPRetries)))
 	}
 	return &mediaClient{
 		http: utils.NewHttpClient(options...),

--- a/driver/minimax/spec.go
+++ b/driver/minimax/spec.go
@@ -26,9 +26,9 @@ type Spec struct {
 	// Zero disables transport retries so the route Router owns the full
 	// retry budget; nil keeps the httpkit default. The Anthropic Messages
 	// surface rides the vendor SDK and is not governed by this field.
-	HTTPRetries *int `json:"http_retries,omitempty"`
+	HTTPRetries *resource.Int `json:"http_retries,omitempty"`
 	// VideoPollIntervalMillis paces video task polling; defaults to 5000.
-	VideoPollIntervalMillis int `json:"video_poll_interval_millis,omitempty"`
+	VideoPollIntervalMillis resource.Int `json:"video_poll_interval_millis,omitempty"`
 	// Models declares models outside the built-in catalog or overrides
 	// catalog entries by name.
 	Models []ModelSpec `json:"models,omitempty"`

--- a/driver/openai/client.go
+++ b/driver/openai/client.go
@@ -62,7 +62,8 @@ func (m profileMaterial) newClients(spec Spec) *clients {
 		options = append(options, option.WithProject(spec.Project))
 	}
 	if spec.HTTPRetries != nil {
-		options = append(options, option.WithMaxRetries(sdkMaxRetries(*spec.HTTPRetries)))
+		options = append(options,
+			option.WithMaxRetries(sdkMaxRetries(int(*spec.HTTPRetries))))
 	}
 	return &clients{api: openai.NewClient(options...)}
 }

--- a/driver/openai/resource_test.go
+++ b/driver/openai/resource_test.go
@@ -35,6 +35,26 @@ func TestResourceFactoryBuildsProviderWithEnvSecret(t *testing.T) {
 	}
 }
 
+func TestResourceSettingsHTTPRetriesFromEnv(t *testing.T) {
+	t.Setenv("OPENAI_TEST_HTTP_RETRIES", "3")
+	settings, err := resource.DecodeTyped[ResourceSettings](
+		json.RawMessage(`{
+			"id": "openai",
+			"spec": {"http_retries": "${env:OPENAI_TEST_HTTP_RETRIES}"}
+		}`),
+		resource.ExpandEnv())
+	if err != nil {
+		t.Fatalf("DecodeTyped: %v", err)
+	}
+	spec, err := decodeSpec(settings.Spec)
+	if err != nil {
+		t.Fatalf("decodeSpec: %v", err)
+	}
+	if spec.HTTPRetries == nil || int(*spec.HTTPRetries) != 3 {
+		t.Fatalf("HTTPRetries = %v, want 3", spec.HTTPRetries)
+	}
+}
+
 func TestResourceFactoryRejectsMissingIDAndSecret(t *testing.T) {
 	if _, err := Factory().New(context.Background(), resource.Input{
 		Settings: json.RawMessage(`{"profiles":[]}`),

--- a/driver/openai/spec.go
+++ b/driver/openai/spec.go
@@ -34,7 +34,7 @@ type Spec struct {
 	// attempt, including the first. Zero disables SDK-internal retries so
 	// the route Router owns the full retry budget; nil keeps the openai-go
 	// default (two retries).
-	HTTPRetries *int `json:"http_retries,omitempty"`
+	HTTPRetries *resource.Int `json:"http_retries,omitempty"`
 	// Models declares additional models beyond the built-in catalog or
 	// overrides catalog entries by name.
 	Models []ModelSpec `json:"models,omitempty"`

--- a/driver/qwen/client.go
+++ b/driver/qwen/client.go
@@ -72,7 +72,8 @@ func (m profileMaterial) newClient(spec Spec) *dashClient {
 		utils.WithResponseHeaderTimeout(5 * time.Minute),
 	}
 	if spec.HTTPRetries != nil {
-		options = append(options, utils.WithRetryAttempts(*spec.HTTPRetries))
+		options = append(options,
+			utils.WithRetryAttempts(int(*spec.HTTPRetries)))
 	}
 	return &dashClient{
 		http: utils.NewHttpClient(options...),

--- a/driver/qwen/spec.go
+++ b/driver/qwen/spec.go
@@ -27,7 +27,7 @@ type Spec struct {
 	// HTTPRetries bounds wire-level HTTP retries inside one logical
 	// inference attempt. Zero disables transport retries so the route
 	// Router owns the full retry budget; nil keeps the httpkit default.
-	HTTPRetries *int `json:"http_retries,omitempty"`
+	HTTPRetries *resource.Int `json:"http_retries,omitempty"`
 	// Models declares models outside the built-in catalog or overrides
 	// catalog entries by name.
 	Models []ModelSpec `json:"models,omitempty"`


### PR DESCRIPTION
## Summary

Adds shared settings scalars `resource.Int` / `resource.Bool` / `resource.Float64` / `resource.Int64` in `core/resource`: each accepts a JSON literal or an expanded `${env:NAME}` string, so numeric/bool deployment settings can now be env-driven while staying strictly validated.

Adopted across env-enabled deployment settings:

- **core/runtime** — `DecodeConfig` now expands `${env:...}` in the runtime subtree before strict decode; `sessions.sink_buffer`, `speculative_buffer_events/bytes`, `delivery_concurrency`, `max_sessions` → `Int`, `resume` → `Bool`.
- **core/agent/a2a** — `history_length` → `Int`.
- **core/workspace** — `scoped.enabled` → `Bool`.
- **core/tool/mcp** — `servers[].resources` / `required` → `Bool`.
- **driver/*** — `spec.http_retries` → `Int` (openai, deepseek, qwen, kimi, minimax, bytedance, azure, anthropic); `video_poll_interval_millis` → `Int64` (bytedance) / `Int` (minimax).

Behavior is unchanged for literal JSON values; missing env vars still fail at expansion time, and unknown fields stay strictly rejected.

## Verification

- `go build` + `go test` pass for `core/resource`, `core/runtime/...`, `core/workspace`, `core/tool/mcp`, `core/agent/a2a`, and all 8 touched driver modules.
- New tests: scalar decode (literal/env/absent/invalid/strict) in `core/resource`; runtime env expansion (string field ok, numeric/bool from env, missing env fails) in `core/runtime`; `http_retries` from env in `driver/openai`.
- `make release-check`, gofmt, `git diff --check` clean.

## Follow-up (not in this PR)

Modules that decode settings without `ExpandEnv` (graph build knobs, event, memory hooks, delegation, scriptrt, tool middleware, inference/route) would need env expansion enabled first before adopting these scalars.