### PR TITLE
chore(release): add core v0.1.16 changeset

### DIFF
--- a/.release/core-v0.1.16.json
+++ b/.release/core-v0.1.16.json
@@ -1,0 +1,9 @@
+{
+  "summary": "feat(core): support env scalars in settings decode — add resource.Int/Bool/Float64/Int64 scalar settings types that accept JSON literals or strings, so ${env:NAME} expansion can feed numeric and boolean fields; runtime session config, MCP tool server specs, workspace scoped settings, and A2A history_length now decode through the env-aware settings path with strict unknown-field rejection and clear validation errors for unparseable strings; also harden env restore error checks in runtime config tests",
+  "releases": [
+    {
+      "module": "core",
+      "bump": "patch"
+    }
+  ]
+}


### PR DESCRIPTION
Release intent for core 0.1.15 -> 0.1.16 (patch), tag `core/v0.1.16`.

Covers the accumulated core delta since core/v0.1.15: env scalar support in settings decode (resource.Int/Bool/Float64/Int64 accepting JSON literals or env-expanded strings) wired into runtime session config, MCP tool server specs, workspace scoped settings, and A2A history length, plus a runtime config test hardening.

Validated locally with `make release-check` and `make release-preflight`.