### PR TITLE
feat(driver/bytedance): add layer decomposition and background image options

### DIFF
--- a/driver/bytedance/client.go
+++ b/driver/bytedance/client.go
@@ -2,6 +2,7 @@ package bytedance
 
 import (
 	"fmt"
+	"net/http"
 	"strings"
 	"time"
 
@@ -25,6 +26,9 @@ const (
 	// defaultClientTimeout is the whole-request budget (mirrors the SDK
 	// default of 10m).
 	defaultClientTimeout = 10 * time.Minute
+	// defaultArkBaseURL mirrors the SDK's default when the profile does not
+	// override it; the raw images path derives its URL from the same value.
+	defaultArkBaseURL = "https://ark.cn-beijing.volces.com/api/v3"
 )
 
 // profileMaterial is one credential profile after secret resolution: the
@@ -47,6 +51,13 @@ type clients struct {
 	// endpoints binds model names to this account's deployment addresses
 	// (ProfileSpec.Endpoints); empty maps resolve to the catalog name.
 	endpoints map[string]string
+	// Raw request support: the pinned SDK cannot encode every official
+	// parameter (image layer_decomposition/background), so the image
+	// transport falls back to a direct POST carrying the same credentials,
+	// base URL, and HTTP client.
+	apiKey     string
+	baseURL    string
+	httpClient *http.Client
 }
 
 // endpoint resolves the wire address for one catalog model within this
@@ -121,6 +132,13 @@ func newProfileMaterial(profile ProfileSettings) (profileMaterial, error) {
 // and speech drivers fail with a clear error when opened.
 func (m profileMaterial) newClients(spec Spec) *clients {
 	built := &clients{endpoints: m.spec.Endpoints}
+	built.apiKey = m.apiKey
+	built.baseURL = spec.BaseURL
+	if built.baseURL == "" {
+		built.baseURL = defaultArkBaseURL
+	} else {
+		built.baseURL = strings.TrimSuffix(built.baseURL, "/")
+	}
 	options := []arkruntime.ConfigOption{}
 	httpOptions := []utils.Option{
 		utils.WithHTTP2(),
@@ -131,6 +149,8 @@ func (m profileMaterial) newClients(spec Spec) *clients {
 		httpOptions = append(httpOptions,
 			utils.WithRetryAttempts(int(*spec.HTTPRetries)))
 	}
+	httpClient := utils.NewHttpClient(httpOptions...)
+	built.httpClient = httpClient
 	if spec.BaseURL != "" {
 		options = append(options, arkruntime.WithBaseUrl(spec.BaseURL))
 	}
@@ -138,7 +158,7 @@ func (m profileMaterial) newClients(spec Spec) *clients {
 		options = append(options, arkruntime.WithRegion(spec.Region))
 	}
 	options = append(options,
-		arkruntime.WithHTTPClient(utils.NewHttpClient(httpOptions...)),
+		arkruntime.WithHTTPClient(httpClient),
 		// SDK-internal retries are disabled; the retry transport above owns
 		// replayable transient failures so attempts do not multiply.
 		arkruntime.WithRetryTimes(0),

--- a/driver/bytedance/extensions.go
+++ b/driver/bytedance/extensions.go
@@ -213,6 +213,14 @@ type ImageOptions struct {
 	// WebSearch attaches the web search tool (Seedream generations that
 	// support tools only).
 	WebSearch *bool `json:"web_search,omitempty"`
+	// LayerDecomposition asks Seedream 5.0 pro to decompose the input image
+	// into one base image and up to 16 independently editable layers.
+	// Requires an input image and resolution-level sizing.
+	LayerDecomposition *bool `json:"layer_decomposition,omitempty"`
+	// Background controls the output alpha channel: "transparent" or
+	// "opaque". Seedream 5.0 pro image-to-image only, with exactly one
+	// input image that has an alpha channel.
+	Background string `json:"background,omitempty"`
 }
 
 // ImageOptimizePrompt configures provider-side prompt rewriting.
@@ -250,6 +258,12 @@ func (o ImageOptions) ActiveFields() []inference.ExtensionField {
 	if o.WebSearch != nil {
 		fields = append(fields, "web_search")
 	}
+	if o.LayerDecomposition != nil {
+		fields = append(fields, "layer_decomposition")
+	}
+	if o.Background != "" {
+		fields = append(fields, "background")
+	}
 	return fields
 }
 
@@ -284,9 +298,20 @@ func (o ImageOptions) Validate() error {
 		}
 	}
 	switch o.SizeToken {
-	case "", "1k", "2k", "4k", "adaptive":
+	case "", "1k", "1.5k", "2k", "3k", "4k", "adaptive":
 	default:
-		return fmt.Errorf("size_token must be 1k, 2k, 4k, or adaptive, not %q", o.SizeToken)
+		return fmt.Errorf(
+			"size_token must be 1k, 1.5k, 2k, 3k, 4k, or adaptive, not %q",
+			o.SizeToken,
+		)
+	}
+	switch o.Background {
+	case "", "transparent", "opaque":
+	default:
+		return fmt.Errorf("background must be transparent or opaque, not %q", o.Background)
+	}
+	if o.LayerDecomposition != nil && *o.LayerDecomposition && o.Background != "" {
+		return fmt.Errorf("background and layer decomposition are mutually exclusive")
 	}
 	return nil
 }
@@ -297,6 +322,7 @@ func (o ImageOptions) Clone() inference.Extension {
 	o.Sequential = clonePointer(o.Sequential)
 	o.SequentialMaxImages = clonePointer(o.SequentialMaxImages)
 	o.WebSearch = clonePointer(o.WebSearch)
+	o.LayerDecomposition = clonePointer(o.LayerDecomposition)
 	if o.OptimizePrompt != nil {
 		optimize := *o.OptimizePrompt
 		o.OptimizePrompt = &optimize

--- a/driver/bytedance/extensions_test.go
+++ b/driver/bytedance/extensions_test.go
@@ -1,0 +1,76 @@
+package bytedance
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestImageOptionsActiveFields(t *testing.T) {
+	enabled := true
+	options := ImageOptions{
+		LayerDecomposition: &enabled,
+		Background:         "transparent",
+	}
+	fields := options.ActiveFields()
+	want := map[string]bool{
+		"layer_decomposition": false,
+		"background":          false,
+	}
+	for _, field := range fields {
+		if _, ok := want[string(field)]; ok {
+			want[string(field)] = true
+		}
+	}
+	for name, seen := range want {
+		if !seen {
+			t.Errorf("ActiveFields missing %q; got %#v", name, fields)
+		}
+	}
+}
+
+func TestImageOptionsValidateSizeToken(t *testing.T) {
+	for _, token := range []string{"1k", "1.5k", "2k", "3k", "4k", "adaptive"} {
+		options := ImageOptions{SizeToken: token}
+		if err := options.Validate(); err != nil {
+			t.Errorf("SizeToken %q: Validate() = %v, want nil", token, err)
+		}
+	}
+	if err := (ImageOptions{SizeToken: "8k"}).Validate(); err == nil {
+		t.Fatal("SizeToken 8k: Validate() = nil, want error")
+	}
+}
+
+func TestImageOptionsValidateBackground(t *testing.T) {
+	for _, value := range []string{"transparent", "opaque"} {
+		if err := (ImageOptions{Background: value}).Validate(); err != nil {
+			t.Errorf("Background %q: Validate() = %v, want nil", value, err)
+		}
+	}
+	if err := (ImageOptions{Background: "alpha"}).Validate(); err == nil {
+		t.Fatal("Background alpha: Validate() = nil, want error")
+	}
+}
+
+func TestImageOptionsValidateBackgroundLayerConflict(t *testing.T) {
+	enabled := true
+	err := (ImageOptions{Background: "transparent", LayerDecomposition: &enabled}).Validate()
+	if err == nil || !strings.Contains(err.Error(), "mutually exclusive") {
+		t.Fatalf("Validate() = %v, want background/layer_decomposition conflict", err)
+	}
+}
+
+func TestImageOptionsCloneDeepCopiesNewFields(t *testing.T) {
+	enabled := true
+	options := ImageOptions{LayerDecomposition: &enabled}
+	cloned, ok := options.Clone().(ImageOptions)
+	if !ok {
+		t.Fatalf("Clone() type = %T, want ImageOptions", options.Clone())
+	}
+	if cloned.LayerDecomposition == nil {
+		t.Fatal("Clone() lost layer_decomposition")
+	}
+	*cloned.LayerDecomposition = false
+	if !*options.LayerDecomposition {
+		t.Fatal("Clone() shares the layer_decomposition pointer")
+	}
+}

--- a/driver/bytedance/image.go
+++ b/driver/bytedance/image.go
@@ -1,18 +1,26 @@
 package bytedance
 
 import (
+	"bytes"
 	"context"
 	"encoding/base64"
+	"encoding/json"
 	"fmt"
+	"io"
+	"net/http"
 	"strings"
 
+	"github.com/GizClaw/flowcraft/core/errdefs"
 	"github.com/GizClaw/flowcraft/core/inference"
 	"github.com/GizClaw/flowcraft/core/message"
 	"github.com/GizClaw/flowcraft/core/message/media"
 
-	"github.com/volcengine/volcengine-go-sdk/service/arkruntime"
 	arkmodel "github.com/volcengine/volcengine-go-sdk/service/arkruntime/model"
 )
+
+// generateImagesPath is the Ark images endpoint suffix; the SDK appends the
+// same path to its base URL.
+const generateImagesPath = "/images/generations"
 
 // Image generation runs on the Ark images endpoint (seedream). The prompt is
 // the request's text; image parts become image-to-image references. The API
@@ -37,6 +45,10 @@ type imageWire struct {
 	sequential     bool // grouped generation in one call
 	sequentialMax  *int
 	webSearch      bool
+	// Official parameters the pinned SDK request struct cannot encode
+	// (Seedream 5.0 pro only). They force the raw request path.
+	layerDecomposition *bool
+	background         string
 }
 
 type wireOptimizePrompt struct {
@@ -234,6 +246,43 @@ func compileImageOptions(
 	if options.WebSearch != nil && *options.WebSearch {
 		wire.webSearch = true
 	}
+	if options.LayerDecomposition != nil && *options.LayerDecomposition {
+		switch {
+		case len(wire.references) == 0:
+			ledger.reject(
+				field("layer_decomposition"),
+				"layer decomposition requires an input image",
+			)
+		case wire.sequential:
+			ledger.reject(
+				field("layer_decomposition"),
+				"layer decomposition is not supported with sequential generation",
+			)
+		case image != nil && image.Size != nil:
+			ledger.reject(
+				field("layer_decomposition"),
+				"layer decomposition supports resolution levels only; use size_token instead of explicit dimensions",
+			)
+		default:
+			wire.layerDecomposition = options.LayerDecomposition
+		}
+	}
+	if options.Background != "" {
+		switch {
+		case len(wire.references) != 1:
+			ledger.reject(
+				field("background"),
+				"background requires exactly one input image with an alpha channel",
+			)
+		case wire.sequential:
+			ledger.reject(
+				field("background"),
+				"background is not supported with sequential generation",
+			)
+		default:
+			wire.background = options.Background
+		}
+	}
 }
 
 // arkSizeToken normalizes the named size tier to the provider's casing.
@@ -241,12 +290,10 @@ func arkSizeToken(token string) string {
 	if token == "adaptive" {
 		return "adaptive"
 	}
-	return strings.ToUpper(token) // 1k | 2k | 4k
+	return strings.ToUpper(token) // 1k | 1.5k | 2k | 3k | 4k
 }
 
-func transportImage(
-	client *arkruntime.Client,
-) inference.Transport[imageWire, imageRaw] {
+func transportImage(cls *clients) inference.Transport[imageWire, imageRaw] {
 	return func(ctx context.Context, wire imageWire) (imageRaw, error) {
 		raw := imageRaw{mediaType: media.ImageFormat(wire.format).MediaType()}
 		// Grouped generation returns its whole set from one call; only the
@@ -259,7 +306,7 @@ func transportImage(
 			if err := ctx.Err(); err != nil {
 				return imageRaw{}, err
 			}
-			single, err := generateOneImage(ctx, client, wire)
+			single, err := generateOneImage(ctx, cls, wire)
 			if err != nil {
 				return imageRaw{}, err
 			}
@@ -274,7 +321,7 @@ func transportImage(
 
 func generateOneImage(
 	ctx context.Context,
-	client *arkruntime.Client,
+	cls *clients,
 	wire imageWire,
 ) (imageRaw, error) {
 	request := arkmodel.GenerateImagesRequest{
@@ -330,10 +377,47 @@ func generateOneImage(
 			Type: arkmodel.ToolTypeWebSearch,
 		}}
 	}
-	response, err := client.GenerateImages(ctx, request)
-	if err != nil {
-		return imageRaw{}, classifyError(err)
+	if wire.layerDecomposition == nil && wire.background == "" {
+		response, err := cls.ark.GenerateImages(ctx, request)
+		if err != nil {
+			return imageRaw{}, classifyError(err)
+		}
+		return imageRawFromResponse(response)
 	}
+	body, err := imageRequestMap(request)
+	if err != nil {
+		return imageRaw{}, errdefs.Validation(fmt.Errorf("bytedance: image request: %w", err))
+	}
+	if wire.layerDecomposition != nil {
+		body["layer_decomposition"] = *wire.layerDecomposition
+	}
+	if wire.background != "" {
+		body["background"] = wire.background
+	}
+	response, err := cls.postImagesRaw(ctx, body)
+	if err != nil {
+		return imageRaw{}, err
+	}
+	return imageRawFromResponse(response)
+}
+
+// imageRequestMap serializes the SDK request exactly as GenerateImages would,
+// so the raw path carries the same wire body plus the fields the pinned SDK
+// struct cannot encode.
+func imageRequestMap(request arkmodel.GenerateImagesRequest) (map[string]any, error) {
+	encoded, err := json.Marshal(request)
+	if err != nil {
+		return nil, err
+	}
+	var body map[string]any
+	if err := json.Unmarshal(encoded, &body); err != nil {
+		return nil, err
+	}
+	return body, nil
+}
+
+// imageRawFromResponse folds an ImagesResponse into the transport raw shape.
+func imageRawFromResponse(response arkmodel.ImagesResponse) (imageRaw, error) {
 	if failure := response.Error; failure != nil {
 		return imageRaw{}, classifyResponseError(failure.Code, failure.Message)
 	}
@@ -349,6 +433,74 @@ func generateOneImage(
 		raw.totalTokens = usage.TotalTokens
 	}
 	return raw, nil
+}
+
+// postImagesRaw issues a raw POST to the Ark images endpoint. The pinned SDK
+// request struct cannot encode layer_decomposition/background, so requests
+// carrying those fields take this path, reusing the profile's API key, base
+// URL, and retry/timeout HTTP client so behavior matches the SDK path.
+func (c *clients) postImagesRaw(
+	ctx context.Context,
+	body map[string]any,
+) (arkmodel.ImagesResponse, error) {
+	payload, err := json.Marshal(body)
+	if err != nil {
+		return arkmodel.ImagesResponse{}, err
+	}
+	request, err := http.NewRequestWithContext(
+		ctx,
+		http.MethodPost,
+		c.baseURL+generateImagesPath,
+		bytes.NewReader(payload),
+	)
+	if err != nil {
+		return arkmodel.ImagesResponse{}, err
+	}
+	request.Header.Set("Authorization", "Bearer "+c.apiKey)
+	request.Header.Set("Content-Type", "application/json")
+	request.Header.Set("Accept", "application/json")
+	response, err := c.httpClient.Do(request)
+	if err != nil {
+		return arkmodel.ImagesResponse{}, errdefs.NotAvailable(
+			fmt.Errorf("bytedance: image request: %w", err),
+		)
+	}
+	defer func() { _ = response.Body.Close() }()
+	requestID := response.Header.Get(arkmodel.ClientRequestHeader)
+	if response.StatusCode < http.StatusOK || response.StatusCode >= http.StatusMultipleChoices {
+		return arkmodel.ImagesResponse{}, imageRawError(
+			response.StatusCode, requestID, response.Body,
+		)
+	}
+	var images arkmodel.ImagesResponse
+	if err := json.NewDecoder(response.Body).Decode(&images); err != nil {
+		return arkmodel.ImagesResponse{}, errdefs.NotAvailable(
+			fmt.Errorf("bytedance: decode image response: %w", err),
+		)
+	}
+	return images, nil
+}
+
+// imageRawError classifies a failed raw image request the same way the SDK
+// does: the JSON error envelope wins when present, status-code taxonomy
+// otherwise.
+func imageRawError(status int, requestID string, body io.Reader) error {
+	var envelope arkmodel.ErrorResponse
+	if err := json.NewDecoder(body).Decode(&envelope); err != nil || envelope.Error == nil {
+		return errdefs.WithRequestID(
+			classifyHTTPStatus(
+				status,
+				"",
+				"",
+				fmt.Errorf("bytedance: image request failed with status %d", status),
+			),
+			requestID,
+		)
+	}
+	failure := envelope.Error
+	failure.HTTPStatusCode = status
+	failure.RequestId = requestID
+	return classifyError(failure)
 }
 
 func decodeImage(
@@ -450,8 +602,7 @@ func openImage(
 	id inference.ModelID,
 	profile string,
 ) (inference.GenerateOperations, error) {
-	ark, err := cls.requireArk(profile)
-	if err != nil {
+	if _, err := cls.requireArk(profile); err != nil {
 		return inference.GenerateOperations{}, err
 	}
 	if err := cls.requireArkAPIKey(profile, "Seedream image generation"); err != nil {
@@ -459,7 +610,7 @@ func openImage(
 	}
 	unary, err := inference.BindGenerate(
 		compileImage(cls.endpoint(id.Name)),
-		transportImage(ark),
+		transportImage(cls),
 		decodeImage,
 	)
 	if err != nil {

--- a/driver/bytedance/image_test.go
+++ b/driver/bytedance/image_test.go
@@ -1,0 +1,325 @@
+package bytedance
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/GizClaw/flowcraft/core/errdefs"
+	"github.com/GizClaw/flowcraft/core/inference"
+	"github.com/GizClaw/flowcraft/core/message"
+	"github.com/GizClaw/flowcraft/core/message/media"
+)
+
+func compileImageRequest(parts []message.Part, options ImageOptions) inference.GenerateRequest {
+	var extensions inference.Extensions
+	extensions = append(extensions, options)
+	return inference.GenerateRequest{
+		Input: inference.GenerateInput{
+			Role: inference.InputRoleUser,
+			Content: inference.InputContent{
+				Content: message.Content{Parts: parts},
+				Intent:  inference.Intent{Image: &inference.ImageIntent{}},
+			},
+		},
+		Extensions: extensions,
+	}
+}
+
+func imageReferencePart(t *testing.T) message.ImagePart {
+	t.Helper()
+	source, err := media.NewImageURL("https://example.com/input.png", "image/png")
+	if err != nil {
+		t.Fatalf("NewImageURL: %v", err)
+	}
+	return message.ImagePart{Source: source}
+}
+
+func compileImageWire(
+	t *testing.T,
+	request inference.GenerateRequest,
+) (imageWire, inference.CompileReport, error) {
+	t.Helper()
+	compiled, err := compileImage("ep-test")(
+		context.Background(),
+		inference.ModelRef{ID: inference.ModelID{Provider: driverID, Name: "seedream-5-0-pro"}},
+		request,
+		inference.GenerateExecutionUnary,
+	)
+	if err != nil {
+		return imageWire{}, compiled.Report, err
+	}
+	return compiled.Wire, compiled.Report, nil
+}
+
+// rejectedReason returns the ledger reason for one rejected field, or ""
+// when the compile did not reject it.
+func rejectedReason(report inference.CompileReport, field inference.FieldID) string {
+	for _, decision := range report.Decisions {
+		if decision.Field == field && decision.Disposition == inference.Rejected {
+			return decision.Reason
+		}
+	}
+	return ""
+}
+
+func TestCompileImageLayerDecomposition(t *testing.T) {
+	enabled := true
+	wire, _, err := compileImageWire(
+		t,
+		compileImageRequest(
+			[]message.Part{imageReferencePart(t)},
+			ImageOptions{LayerDecomposition: &enabled},
+		),
+	)
+	if err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+	if wire.layerDecomposition == nil || !*wire.layerDecomposition {
+		t.Fatal("wire.layerDecomposition not set")
+	}
+}
+
+func TestCompileImageLayerDecompositionRejects(t *testing.T) {
+	enabled := true
+	size := media.ImageSize{Width: 1024, Height: 1024}
+	cases := []struct {
+		name    string
+		request inference.GenerateRequest
+		reason  string
+	}{
+		{
+			name: "no reference image",
+			request: compileImageRequest(
+				[]message.Part{message.TextPart{Text: "decompose"}},
+				ImageOptions{LayerDecomposition: &enabled},
+			),
+			reason: "layer decomposition requires an input image",
+		},
+		{
+			name: "canonical size",
+			request: func() inference.GenerateRequest {
+				request := compileImageRequest(
+					[]message.Part{imageReferencePart(t)},
+					ImageOptions{LayerDecomposition: &enabled},
+				)
+				request.Input.Content.Intent.Image.Size = &size
+				return request
+			}(),
+			reason: "resolution levels only",
+		},
+		{
+			name: "sequential conflict",
+			request: compileImageRequest(
+				[]message.Part{imageReferencePart(t)},
+				ImageOptions{
+					LayerDecomposition: &enabled,
+					Sequential:         &enabled,
+				},
+			),
+			reason: "not supported with sequential generation",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, report, err := compileImageWire(t, tc.request)
+			if err == nil {
+				t.Fatalf("compile error = nil, want rejection")
+			}
+			field := inference.ExtensionField("layer_decomposition").Qualify(ImageOptions{})
+			if reason := rejectedReason(report, field); !strings.Contains(reason, tc.reason) {
+				t.Fatalf("rejected reason = %q, want %q", reason, tc.reason)
+			}
+		})
+	}
+}
+
+func TestCompileImageBackground(t *testing.T) {
+	wire, _, err := compileImageWire(
+		t,
+		compileImageRequest(
+			[]message.Part{imageReferencePart(t)},
+			ImageOptions{Background: "transparent"},
+		),
+	)
+	if err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+	if wire.background != "transparent" {
+		t.Fatalf("wire.background = %q, want transparent", wire.background)
+	}
+}
+
+func TestCompileImageBackgroundRejects(t *testing.T) {
+	enabled := true
+	second, err := media.NewImageURL("https://example.com/input2.png", "image/png")
+	if err != nil {
+		t.Fatalf("NewImageURL: %v", err)
+	}
+	cases := []struct {
+		name    string
+		request inference.GenerateRequest
+		reason  string
+	}{
+		{
+			name: "no reference image",
+			request: compileImageRequest(
+				[]message.Part{message.TextPart{Text: "edit"}},
+				ImageOptions{Background: "opaque"},
+			),
+			reason: "exactly one input image",
+		},
+		{
+			name: "two reference images",
+			request: compileImageRequest(
+				[]message.Part{
+					message.ImagePart{Source: mustImageSource(t)},
+					message.ImagePart{Source: second},
+				},
+				ImageOptions{Background: "opaque"},
+			),
+			reason: "exactly one input image",
+		},
+		{
+			name: "sequential conflict",
+			request: compileImageRequest(
+				[]message.Part{imageReferencePart(t)},
+				ImageOptions{Background: "opaque", Sequential: &enabled},
+			),
+			reason: "not supported with sequential generation",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, report, err := compileImageWire(t, tc.request)
+			if err == nil {
+				t.Fatalf("compile error = nil, want rejection")
+			}
+			field := inference.ExtensionField("background").Qualify(ImageOptions{})
+			if reason := rejectedReason(report, field); !strings.Contains(reason, tc.reason) {
+				t.Fatalf("rejected reason = %q, want %q", reason, tc.reason)
+			}
+		})
+	}
+}
+
+func mustImageSource(t *testing.T) media.ImageSource {
+	t.Helper()
+	source, err := media.NewImageURL("https://example.com/input1.png", "image/png")
+	if err != nil {
+		t.Fatalf("NewImageURL: %v", err)
+	}
+	return source
+}
+
+func TestCompileImageSizeToken(t *testing.T) {
+	for _, tc := range []struct {
+		token string
+		want  string
+	}{
+		{"1k", "1K"},
+		{"1.5k", "1.5K"},
+		{"3k", "3K"},
+		{"4k", "4K"},
+	} {
+		wire, _, err := compileImageWire(
+			t,
+			compileImageRequest(nil, ImageOptions{SizeToken: tc.token}),
+		)
+		if err != nil {
+			t.Fatalf("size_token %s: compile: %v", tc.token, err)
+		}
+		if wire.size != tc.want {
+			t.Errorf("size_token %s: wire.size = %q, want %q", tc.token, wire.size, tc.want)
+		}
+	}
+}
+
+func TestTransportImageRawCarriesExtendedFields(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		if request.URL.Path != generateImagesPath {
+			t.Errorf("path = %q, want %q", request.URL.Path, generateImagesPath)
+		}
+		var body map[string]any
+		if err := json.NewDecoder(request.Body).Decode(&body); err != nil {
+			t.Errorf("decode body: %v", err)
+		}
+		for key, want := range map[string]any{
+			"model":               "ep-test",
+			"prompt":              "make it transparent",
+			"response_format":     "url",
+			"layer_decomposition": true,
+			"background":          "transparent",
+		} {
+			if body[key] != want {
+				t.Errorf("body[%q] = %#v, want %#v", key, body[key], want)
+			}
+		}
+		if request.Header.Get("Authorization") != "Bearer sk-test" {
+			t.Errorf("Authorization = %q, want Bearer sk-test", request.Header.Get("Authorization"))
+		}
+		writer.Header().Set("Content-Type", "application/json")
+		_, _ = writer.Write([]byte(`{
+			"model": "ep-test",
+			"created": 1,
+			"data": [{"url": "https://example.com/out.png", "size": "2048x2048"}],
+			"usage": {"generated_images": 1, "output_tokens": 100, "total_tokens": 100}
+		}`))
+	}))
+	defer server.Close()
+
+	enabled := true
+	cls := &clients{
+		apiKey:     "sk-test",
+		baseURL:    server.URL,
+		httpClient: server.Client(),
+	}
+	raw, err := transportImage(cls)(context.Background(), imageWire{
+		model:              "ep-test",
+		prompt:             "make it transparent",
+		count:              1,
+		delivery:           "url",
+		layerDecomposition: &enabled,
+		background:         "transparent",
+	})
+	if err != nil {
+		t.Fatalf("transport: %v", err)
+	}
+	if len(raw.images) != 1 || raw.images[0].url != "https://example.com/out.png" {
+		t.Fatalf("raw.images = %#v, want one url image", raw.images)
+	}
+	if raw.outputTokens != 100 || raw.totalTokens != 100 {
+		t.Fatalf("usage = %#v, want 100/100", raw)
+	}
+}
+
+func TestTransportImageRawErrorClassification(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		writer.Header().Set("Content-Type", "application/json")
+		writer.WriteHeader(http.StatusBadRequest)
+		_, _ = writer.Write([]byte(`{"error":{"code":"InvalidParameter","message":"bad size"}}`))
+	}))
+	defer server.Close()
+
+	cls := &clients{
+		apiKey:     "sk-test",
+		baseURL:    server.URL,
+		httpClient: server.Client(),
+	}
+	_, err := transportImage(cls)(context.Background(), imageWire{
+		model:      "ep-test",
+		prompt:     "edit",
+		count:      1,
+		delivery:   "url",
+		background: "transparent",
+	})
+	if err == nil {
+		t.Fatal("transport error = nil, want validation")
+	}
+	if !errdefs.IsValidation(err) {
+		t.Fatalf("transport error = %v, want errdefs.Validation", err)
+	}
+}


### PR DESCRIPTION
## Summary

Extends the bytedance driver's `ImageOptions` with the official ModelArk image parameters that were missing, verified against the image generation API docs (1541523 / 1824121 / 2582774):

- `layer_decomposition` (Seedream 5.0 pro): decompose the input image into one base image and up to 16 layers.
- `background` (`transparent` / `opaque`, Seedream 5.0 pro): output alpha channel control for image-to-image with an alpha-channel input.
- `size_token` gains the `1.5k` (5.0 pro) and `3k` (5.0 lite) tiers.

Note: the official images API has no `mask_image`/`strength` — "local redraw" on 5.0 pro is prompt-coordinate driven (`<point>`/`<bbox>`), so no mask parameters were added.

## Transport

`GenerateImagesRequest` in the pinned SDK (v1.2.14, and latest v1.2.47) cannot encode `layer_decomposition`/`background`. Requests carrying either field now take a raw POST path that reuses the profile's API key, base URL, and HTTP client (same timeout/retry budget), with the same error classification as the SDK path. Unchanged requests keep using the SDK.

## Compile-time constraints

- `layer_decomposition` requires an input image, rejects sequential generation, and supports resolution-level sizing only (explicit canonical size is rejected).
- `background` requires exactly one input image and rejects sequential generation.
- `layer_decomposition` and `background` are mutually exclusive (validated).

## Tests

Added `extensions_test.go` and `image_test.go`: Validate enums/conflicts, compile mapping and rejection branches, raw transport request body (extended fields + auth) and 400 error classification. `make ci`, `make lint`, `make release-check`, and `git diff --check` all pass.

No changeset added — not tagging a release in this PR.