### PR TITLE
fix(core): keep payloads on script bridge emit channel

### DIFF
--- a/core/agent/bindings/bridge_host.go
+++ b/core/agent/bindings/bridge_host.go
@@ -56,7 +56,8 @@ type StreamEmitter interface {
 //   - host.emit is the high-level node-stream channel. Callers adapt
 //     it to their emitter (e.g. graph's EmitStreamDelta); payloads
 //     should decode cleanly into agent.StreamDeltaPayload — passing a
-//     bare value is wrapped by the adapter, not here.
+//     bare value is wrapped by the adapter, not here. Unknown event
+//     types carry the raw payload in the delta's "payload" field.
 //
 // The bridge does NOT own the agent.Host nor the StreamEmitter; the
 // caller (typically a script node) feeds it whatever ctx.Host /

--- a/core/agent/subjects.go
+++ b/core/agent/subjects.go
@@ -305,6 +305,7 @@ const (
 //	provider_outputs          ProviderOutputs  —
 //	parallel_branch_accept    ForkID, BranchID —
 //	parallel_branch_cancel    ForkID, BranchID Reason
+//	(forward-compatible)      Payload          —
 //
 // Speculative data deltas (part, finish, provider_outputs)
 // additionally require both ForkID and BranchID. Non-speculative data
@@ -315,6 +316,13 @@ type StreamDeltaPayload struct {
 	// Type discriminates the payload variant. See StreamDeltaType
 	// constants for the standard values.
 	Type StreamDeltaType `json:"type"`
+
+	// Payload carries the raw script-supplied value for
+	// forward-compatible / custom event types (host.emit with an
+	// unrecognized type). Standard types decode their fields directly
+	// and leave this empty. Opaque to the stream protocol; consumers
+	// decode it against the event type's own schema.
+	Payload json.RawMessage `json:"payload,omitempty"`
 
 	// Part carries one canonical output part. Required on "part".
 	// Wire-encoded with the same type discriminator as
@@ -366,6 +374,7 @@ type ProviderOutputEnvelope struct {
 func (p StreamDeltaPayload) MarshalJSON() ([]byte, error) {
 	wire := struct {
 		Type            StreamDeltaType          `json:"type"`
+		Payload         json.RawMessage          `json:"payload,omitempty"`
 		Part            json.RawMessage          `json:"part,omitempty"`
 		Speculative     bool                     `json:"speculative,omitempty"`
 		ForkID          string                   `json:"fork_id,omitempty"`
@@ -380,6 +389,9 @@ func (p StreamDeltaPayload) MarshalJSON() ([]byte, error) {
 		BranchID: p.BranchID, Reason: p.Reason,
 		FinishReason: p.FinishReason, RequestID: p.RequestID,
 		ResponseID: p.ResponseID, ProviderOutputs: p.ProviderOutputs,
+	}
+	if len(p.Payload) > 0 {
+		wire.Payload = p.Payload
 	}
 	if p.Part != nil {
 		raw, err := message.MarshalPart(p.Part)
@@ -396,6 +408,7 @@ func (p StreamDeltaPayload) MarshalJSON() ([]byte, error) {
 func (p *StreamDeltaPayload) UnmarshalJSON(data []byte) error {
 	var wire struct {
 		Type            StreamDeltaType          `json:"type"`
+		Payload         json.RawMessage          `json:"payload"`
 		Part            json.RawMessage          `json:"part"`
 		Speculative     bool                     `json:"speculative"`
 		ForkID          string                   `json:"fork_id"`
@@ -410,6 +423,7 @@ func (p *StreamDeltaPayload) UnmarshalJSON(data []byte) error {
 		return err
 	}
 	p.Type = wire.Type
+	p.Payload = wire.Payload
 	p.Speculative = wire.Speculative
 	p.ForkID = wire.ForkID
 	p.BranchID = wire.BranchID

--- a/core/graph/nodes/script/bridge_stream.go
+++ b/core/graph/nodes/script/bridge_stream.go
@@ -591,6 +591,14 @@ func decodeEnvelopePayloadMap(env event.Envelope) map[string]any {
 
 func streamDeltaPayloadToMap(p agent.StreamDeltaPayload) map[string]any {
 	out := map[string]any{"type": string(p.Type)}
+	if len(p.Payload) > 0 {
+		var raw any
+		if json.Unmarshal(p.Payload, &raw) == nil {
+			out["payload"] = raw
+		} else {
+			out["payload"] = string(p.Payload)
+		}
+	}
 	if p.Part != nil {
 		raw, err := message.MarshalPart(p.Part)
 		if err == nil {

--- a/core/graph/nodes/script/emitter_test.go
+++ b/core/graph/nodes/script/emitter_test.go
@@ -1,8 +1,13 @@
 package script
 
 import (
+	"context"
+	"encoding/json"
+	"sync"
 	"testing"
 
+	"github.com/GizClaw/flowcraft/core/agent"
+	"github.com/GizClaw/flowcraft/core/event"
 	"github.com/GizClaw/flowcraft/core/message"
 )
 
@@ -67,5 +72,132 @@ func TestPayloadToPart(t *testing.T) {
 	}
 	if _, ok := payloadToPart(nil); ok {
 		t.Fatal("nil payload must be rejected")
+	}
+}
+
+type emitCaptureHost struct {
+	agent.NoopHost
+	mu   sync.Mutex
+	envs []event.Envelope
+}
+
+func (h *emitCaptureHost) Publish(_ context.Context, env event.Envelope) error {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.envs = append(h.envs, env)
+	return nil
+}
+
+func captureEmits(t *testing.T, emit func(*agent.ScriptEnv)) []agent.StreamDeltaPayload {
+	t.Helper()
+	host := &emitCaptureHost{}
+	rt := fakeRuntime{exec: func(_ context.Context, _, _ string, env *agent.ScriptEnv) (*agent.ScriptSignal, error) {
+		emit(env)
+		return nil, nil
+	}}
+	reg := scriptRegistry(t, ScriptNodeDeps{Runtimes: map[string]agent.ScriptRuntime{"fake": rt}})
+	g := singleScriptGraph(t, reg, ScriptConfig{Runtime: "fake", Source: "x"})
+	if err := executeGraphWithHost(g, host, agent.NewBoard()); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+
+	host.mu.Lock()
+	defer host.mu.Unlock()
+	var deltas []agent.StreamDeltaPayload
+	for _, env := range host.envs {
+		if !agent.IsStreamDelta(env.Subject) {
+			continue
+		}
+		delta, err := agent.DecodeStreamDelta(env)
+		if err != nil {
+			t.Fatalf("DecodeStreamDelta: %v", err)
+		}
+		deltas = append(deltas, delta)
+	}
+	return deltas
+}
+
+func TestScriptEmitter_PassthroughCarriesPayload(t *testing.T) {
+	deltas := captureEmits(t, func(env *agent.ScriptEnv) {
+		emit := env.Bindings["host"].(map[string]any)["emit"].(func(string, any))
+		emit("progress", map[string]any{"pct": 42, "label": "x"})
+		emit("custom", nil)
+	})
+	if len(deltas) != 2 {
+		t.Fatalf("emitted %d deltas, want 2", len(deltas))
+	}
+	if deltas[0].Type != "progress" {
+		t.Fatalf("first delta type = %q, want progress", deltas[0].Type)
+	}
+	var payload map[string]any
+	if err := json.Unmarshal(deltas[0].Payload, &payload); err != nil {
+		t.Fatalf("decode passthrough payload %s: %v", deltas[0].Payload, err)
+	}
+	if payload["pct"] != float64(42) || payload["label"] != "x" {
+		t.Fatalf("passthrough payload = %v, want {pct:42 label:x}", payload)
+	}
+	if deltas[1].Type != "custom" {
+		t.Fatalf("second delta type = %q, want custom", deltas[1].Type)
+	}
+	if deltas[1].Payload != nil {
+		t.Fatalf("nil payload should not attach a payload field, got %s", deltas[1].Payload)
+	}
+}
+
+func TestScriptEmitter_InvalidPayloadSkipsEmission(t *testing.T) {
+	deltas := captureEmits(t, func(env *agent.ScriptEnv) {
+		emit := env.Bindings["host"].(map[string]any)["emit"].(func(string, any))
+		emit("tool_call", map[string]any{"name": "search"}) // missing id
+		emit("tool_result", map[string]any{"content": "x"}) // missing tool_call_id
+		emit("part", map[string]any{"type": "hologram"})    // unknown part kind
+		emit("token", "kept")
+	})
+	if len(deltas) != 1 {
+		t.Fatalf("emitted %d deltas, want only the valid token delta", len(deltas))
+	}
+	if deltas[0].Type != agent.StreamDeltaPart {
+		t.Fatalf("delta type = %q, want %q", deltas[0].Type, agent.StreamDeltaPart)
+	}
+	text, ok := deltas[0].Part.(message.TextPart)
+	if !ok || text.Text != "kept" {
+		t.Fatalf("delta part = %#v, want kept text part", deltas[0].Part)
+	}
+}
+
+func TestScriptEmitter_PassthroughReachesStreamSubscription(t *testing.T) {
+	bus := event.NewMemoryBus()
+	t.Cleanup(func() { _ = bus.Close() })
+	host := &eventBusHost{bus: bus}
+
+	rt := fakeRuntime{exec: func(ctx context.Context, _, _ string, env *agent.ScriptEnv) (*agent.ScriptSignal, error) {
+		stream := streamBinding(t, env)
+		it, err := stream.subscribeNode(map[string]any{"node_id": "n"})
+		if err != nil {
+			t.Errorf("subscribe_node: %v", err)
+			return nil, nil
+		}
+		next := it["next"].(func() bool)
+		current := it["current"].(func() map[string]any)
+		emit := env.Bindings["host"].(map[string]any)["emit"].(func(string, any))
+		emit("progress", map[string]any{"pct": 42})
+		if !next() {
+			t.Error("next() = false, want the emitted delta")
+			return nil, nil
+		}
+		cur := current()
+		if cur["event"] != "stream.delta" || cur["type"] != "progress" {
+			t.Errorf("current = %v, want stream.delta progress", cur)
+			return nil, nil
+		}
+		payload, ok := cur["payload"].(map[string]any)
+		if !ok || payload["pct"] != float64(42) {
+			t.Errorf("payload projection = %v, want {pct:42}", cur["payload"])
+		}
+		return nil, nil
+	}}
+	reg := scriptRegistry(t, ScriptNodeDeps{Runtimes: map[string]agent.ScriptRuntime{"fake": rt}})
+	g := singleScriptGraph(t, reg, ScriptConfig{Runtime: "fake", Source: "x"})
+	if err := executeGraphWithHost(g, host, agent.NewBoard()); err != nil {
+		t.Fatalf("Execute: %v", err)
 	}
 }

--- a/core/graph/nodes/script/node.go
+++ b/core/graph/nodes/script/node.go
@@ -149,46 +149,57 @@ func decodeScriptConfig(raw json.RawMessage) (ScriptConfig, error) {
 // scriptEmitter adapts graph's per-node stream-delta channel to the
 // host bridge's StreamEmitter. The bridge's emit is fire-and-forget,
 // so publish failures are dropped here — matching the emitter's void
-// contract.
+// contract. Known event types whose payload fails to decode are
+// skipped entirely rather than published as empty deltas.
 type scriptEmitter struct{ ec graph.ExecutionContext }
 
 func (e scriptEmitter) Emit(eventType string, payload any) {
-	delta := agent.StreamDeltaPayload{}
 	switch eventType {
 	case "token":
-		delta = agent.StreamDeltaPayload{
+		_ = e.ec.EmitStreamDelta(agent.StreamDeltaPayload{
 			Type: agent.StreamDeltaPart,
 			Part: message.TextPart{Text: stringifyPayload(payload)},
-		}
+		})
 	case "tool_call":
 		if call, ok := payloadToToolCall(payload); ok {
-			delta = agent.StreamDeltaPayload{
+			_ = e.ec.EmitStreamDelta(agent.StreamDeltaPayload{
 				Type: agent.StreamDeltaPart,
 				Part: message.ToolCallPart{Call: call},
-			}
+			})
 		}
 	case "tool_result":
 		if result, ok := payloadToToolResult(payload); ok {
-			delta = agent.StreamDeltaPayload{
+			_ = e.ec.EmitStreamDelta(agent.StreamDeltaPayload{
 				Type: agent.StreamDeltaPart,
 				Part: message.ToolResultPart{Result: result},
-			}
+			})
 		}
 	case "part":
 		// Generic part event: the payload is a canonical part wire
 		// object (e.g. {"type":"image","source":...}), so scripts can
 		// emit any message.Part kind.
 		if part, ok := payloadToPart(payload); ok {
-			delta = agent.StreamDeltaPayload{
+			_ = e.ec.EmitStreamDelta(agent.StreamDeltaPayload{
 				Type: agent.StreamDeltaPart,
 				Part: part,
-			}
+			})
 		}
 	default:
-		// Forward-compatible event types pass through unchanged.
-		delta = agent.StreamDeltaPayload{Type: agent.StreamDeltaType(eventType)}
+		// Forward-compatible event types pass through with the raw
+		// payload riding under StreamDeltaPayload.Payload, so the
+		// script's value survives to stream consumers. Values that
+		// cannot be marshalled are dropped — nothing representable
+		// could be published anyway.
+		raw, ok := marshalPayload(payload)
+		if !ok {
+			return
+		}
+		delta := agent.StreamDeltaPayload{Type: agent.StreamDeltaType(eventType)}
+		if payload != nil {
+			delta.Payload = raw
+		}
+		_ = e.ec.EmitStreamDelta(delta)
 	}
-	_ = e.ec.EmitStreamDelta(delta)
 }
 
 // payloadToPart decodes a canonical part wire object (a map or JSON

--- a/core/message/doc.go
+++ b/core/message/doc.go
@@ -17,4 +17,10 @@
 // The media subpackage holds the operation-neutral Source / Format types
 // that ride inside multimodal Parts (images, audio, video). They are DTOs
 // for the same reason and live here for the same reason.
+//
+// Live media rides the same Part model: media.Stream / media.Pipe define a
+// bounded pull transport, and a stream-backed Audio/Video Source is how a
+// part exists while it is in flight. Streams are never serialized and never
+// enter durable context or history — MaterializeContent converts them back
+// into inline-byte parts at the commit boundary.
 package message

--- a/core/message/media/source.go
+++ b/core/message/media/source.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"mime"
 	"net/url"
+	"reflect"
 	"strings"
 )
 
@@ -17,11 +18,16 @@ type SourceKind string
 const (
 	SourceURL    SourceKind = "url"
 	SourceInline SourceKind = "inline"
+	// SourceStream marks a live, pull-based source of typed items (see
+	// [Stream]). It is the transport form of a media part: valid while a
+	// message is in flight, never in durable context or history — callers
+	// materialize it (message.MaterializeContent) before storage.
+	SourceStream SourceKind = "stream"
 )
 
 func (k SourceKind) Validate() error {
 	switch k {
-	case SourceURL, SourceInline:
+	case SourceURL, SourceInline, SourceStream:
 		return nil
 	default:
 		return fmt.Errorf("unknown media source kind %q", k)
@@ -33,6 +39,11 @@ type source struct {
 	url       string
 	data      []byte
 	mediaType string
+	// stream carries the live [Stream] handle for stream-kind sources. It
+	// is stored as any because the item type is caller-defined; the typed
+	// constructors (NewAudioStream / NewVideoStream) keep the
+	// instantiation at the call site.
+	stream any
 }
 
 type (
@@ -106,6 +117,23 @@ func NewVideoBytes(data []byte, mediaType string) (VideoSource, error) {
 	return VideoSource{source: value}, err
 }
 
+// NewAudioStream wraps a live, pull-based stream as an audio source. The
+// stream's item type is caller-defined (the message package instantiates it
+// as message.Stream, i.e. media.Stream[Part]); mediaType declares the audio
+// codec family and is required.
+func NewAudioStream[T any](stream Stream[T], mediaType string) (AudioSource, error) {
+	value, err := newStream(stream, mediaType, "audio/")
+	return AudioSource{source: value}, err
+}
+
+// NewVideoStream wraps a live, pull-based stream as a video source. The
+// stream's item type is caller-defined; mediaType declares the video
+// container family and is required.
+func NewVideoStream[T any](stream Stream[T], mediaType string) (VideoSource, error) {
+	value, err := newStream(stream, mediaType, "video/")
+	return VideoSource{source: value}, err
+}
+
 func newURL(rawURL, mediaType, prefix string) (source, error) {
 	parsed, err := url.ParseRequestURI(rawURL)
 	if err != nil || parsed.Scheme == "" || parsed.Host == "" {
@@ -116,6 +144,22 @@ func newURL(rawURL, mediaType, prefix string) (source, error) {
 		return source{}, err
 	}
 	value := source{kind: SourceURL, url: rawURL, mediaType: normalized}
+	return value, value.Validate()
+}
+
+func newStream[T any](stream Stream[T], mediaType, prefix string) (source, error) {
+	if isNilStream(stream) {
+		return source{}, fmt.Errorf("stream media source requires a stream")
+	}
+	normalized, err := normalizeMediaType(mediaType, prefix, true)
+	if err != nil {
+		return source{}, err
+	}
+	value := source{
+		kind:      SourceStream,
+		stream:    stream,
+		mediaType: normalized,
+	}
 	return value, value.Validate()
 }
 
@@ -140,7 +184,7 @@ func validateMediaType(value, prefix string, required bool) error {
 func normalizeMediaType(value, prefix string, required bool) (string, error) {
 	if value == "" {
 		if required {
-			return "", fmt.Errorf("inline media source media type is required")
+			return "", fmt.Errorf("media source media type is required")
 		}
 		return "", nil
 	}
@@ -155,7 +199,11 @@ func validateTypedSource(value source, prefix string) error {
 	if err := value.Validate(); err != nil {
 		return err
 	}
-	return validateMediaType(value.mediaType, prefix, value.kind == SourceInline)
+	return validateMediaType(
+		value.mediaType,
+		prefix,
+		value.kind == SourceInline || value.kind == SourceStream,
+	)
 }
 
 func unmarshalTypedSource(data []byte, target *source, prefix string) error {
@@ -169,7 +217,7 @@ func unmarshalTypedSource(data []byte, target *source, prefix string) error {
 	normalized, err := normalizeMediaType(
 		value.mediaType,
 		prefix,
-		value.kind == SourceInline,
+		value.kind == SourceInline || value.kind == SourceStream,
 	)
 	if err != nil {
 		return err
@@ -182,6 +230,13 @@ func unmarshalTypedSource(data []byte, target *source, prefix string) error {
 func (s source) Kind() SourceKind { return s.kind }
 func (s source) URL() string      { return s.url }
 func (s source) Bytes() []byte    { return bytes.Clone(s.data) }
+
+// Stream returns the live item stream carried by a stream-kind source, or
+// nil for URL and inline sources. The concrete item type is
+// caller-defined; a message.Stream caller asserts the returned handle to
+// message.Stream.
+func (s source) Stream() any { return s.stream }
+
 func (s source) MediaType() string {
 	return s.mediaType
 }
@@ -207,6 +262,13 @@ func (s source) Validate() error {
 		if s.mediaType == "" {
 			return fmt.Errorf("inline media source media type is required")
 		}
+	case SourceStream:
+		if isNilStream(s.stream) || s.url != "" || len(s.data) != 0 {
+			return fmt.Errorf("stream media source has invalid payload")
+		}
+		if s.mediaType == "" {
+			return fmt.Errorf("stream media source media type is required")
+		}
 	default:
 		return s.kind.Validate()
 	}
@@ -216,6 +278,9 @@ func (s source) Validate() error {
 func (s source) MarshalJSON() ([]byte, error) {
 	if err := s.Validate(); err != nil {
 		return nil, err
+	}
+	if s.kind == SourceStream {
+		return nil, fmt.Errorf("stream media source cannot be serialized")
 	}
 	return json.Marshal(struct {
 		Kind      SourceKind `json:"kind"`
@@ -246,6 +311,18 @@ func (s *source) UnmarshalJSON(data []byte) error {
 	}
 	*s = candidate
 	return nil
+}
+
+func isNilStream(value any) bool {
+	if value == nil {
+		return true
+	}
+	switch v := reflect.ValueOf(value); v.Kind() {
+	case reflect.Chan, reflect.Func, reflect.Interface, reflect.Map,
+		reflect.Pointer, reflect.Slice:
+		return v.IsNil()
+	}
+	return false
 }
 
 func decodeStrict(data []byte, value any) error {

--- a/core/message/media/source_test.go
+++ b/core/message/media/source_test.go
@@ -1,7 +1,9 @@
 package media
 
 import (
+	"context"
 	"encoding/json"
+	"strings"
 	"testing"
 )
 
@@ -87,5 +89,88 @@ func TestInlineImageCopiesInput(t *testing.T) {
 	copyOut[0] = 'X'
 	if got := string(source.Bytes()); got != "secret image" {
 		t.Fatalf("source bytes mutated through returned slice: %q", got)
+	}
+}
+
+func TestStreamSourcesCarryLiveStreams(t *testing.T) {
+	pipe := NewPipe[string](1)
+	if !pipe.Send("live") {
+		t.Fatal("pipe rejected its first item")
+	}
+	audio, err := NewAudioStream[string](pipe, "audio/pcm")
+	if err != nil {
+		t.Fatalf("NewAudioStream: %v", err)
+	}
+	if audio.Kind() != SourceStream {
+		t.Fatalf("audio kind = %q, want %q", audio.Kind(), SourceStream)
+	}
+	if audio.MediaType() != "audio/pcm" {
+		t.Fatalf("audio media type = %q", audio.MediaType())
+	}
+	stream, ok := audio.Stream().(Stream[string])
+	if !ok {
+		t.Fatalf("audio Stream() = %T, want Stream[string]", audio.Stream())
+	}
+	value, err := stream.Read(context.Background())
+	if err != nil || value != "live" {
+		t.Fatalf("stream read = (%q, %v)", value, err)
+	}
+
+	video, err := NewVideoStream[string](pipe, "video/mp4")
+	if err != nil {
+		t.Fatalf("NewVideoStream: %v", err)
+	}
+	if video.Kind() != SourceStream || video.MediaType() != "video/mp4" {
+		t.Fatalf("video stream source = kind %q type %q", video.Kind(), video.MediaType())
+	}
+}
+
+func TestStreamSourcesRejectBadInput(t *testing.T) {
+	if _, err := NewAudioStream[string](nil, "audio/pcm"); err == nil {
+		t.Fatal("audio stream accepted a nil stream")
+	}
+	var nilPipe *Pipe[string]
+	if _, err := NewAudioStream[string](nilPipe, "audio/pcm"); err == nil {
+		t.Fatal("audio stream accepted a typed nil stream")
+	}
+	pipe := NewPipe[string](0)
+	if _, err := NewAudioStream[string](pipe, ""); err == nil {
+		t.Fatal("audio stream accepted an empty media type")
+	}
+	if _, err := NewAudioStream[string](pipe, "video/mp4"); err == nil {
+		t.Fatal("audio stream accepted a video media type")
+	}
+	if _, err := NewVideoStream[string](pipe, "image/jpeg"); err == nil {
+		t.Fatal("video stream accepted an image media type")
+	}
+}
+
+func TestStreamSourcesAreNotSerializable(t *testing.T) {
+	pipe := NewPipe[string](0)
+	audio, err := NewAudioStream[string](pipe, "audio/pcm")
+	if err != nil {
+		t.Fatalf("NewAudioStream: %v", err)
+	}
+	if _, err := json.Marshal(audio); err == nil ||
+		!strings.Contains(err.Error(), "cannot be serialized") {
+		t.Fatalf("Marshal(stream source) = %v, want serialization error", err)
+	}
+	if err := json.Unmarshal([]byte(`{"kind":"stream","media_type":"audio/pcm"}`), &audio); err == nil {
+		t.Fatal("Unmarshal accepted a stream-kind wire source without a stream")
+	}
+}
+
+func TestStreamSourceCloneSharesLiveHandle(t *testing.T) {
+	pipe := NewPipe[string](0)
+	audio, err := NewAudioStream[string](pipe, "audio/pcm")
+	if err != nil {
+		t.Fatalf("NewAudioStream: %v", err)
+	}
+	clone := audio.Clone()
+	if clone.Kind() != SourceStream {
+		t.Fatalf("clone kind = %q", clone.Kind())
+	}
+	if clone.Stream() != audio.Stream() {
+		t.Fatal("clone does not share the live stream handle")
 	}
 }

--- a/core/message/media/stream.go
+++ b/core/message/media/stream.go
@@ -1,0 +1,170 @@
+package media
+
+import (
+	"context"
+	"io"
+	"sync"
+)
+
+// Stream is a pull-based source of typed items.
+//
+// Contract:
+//   - Read returns (value, nil) for each available item.
+//   - Read returns (zero, io.EOF) when the stream ends normally.
+//   - Read returns (zero, err) when the stream is interrupted or the
+//     caller's context is canceled.
+//   - After returning a non-nil error caused by the stream itself (EOF or
+//     interrupt), all subsequent Read calls return the same error.
+//
+// The item type is instantiated by the owner of the stream: the message
+// package exposes Stream[Part] as the canonical live-content transport.
+type Stream[T any] interface {
+	Read(ctx context.Context) (T, error)
+}
+
+// Pipe is the standard implementation of Stream[T]: a typed, bounded pipe
+// with explicit normal-close and interrupt semantics.
+//
+// Producers call Send; it blocks when the buffer is full, which is how
+// backpressure propagates from a slow consumer. Consumers call Read.
+// Close ends the stream normally (Read drains buffered items, then returns
+// io.EOF). Interrupt aborts the stream: Read returns context.Canceled
+// immediately, even when buffered items remain.
+type Pipe[T any] struct {
+	ch        chan T
+	interrupt context.Context
+	cancel    context.CancelFunc
+	closeOnce sync.Once
+
+	mu      sync.Mutex
+	lastErr error
+}
+
+// NewPipe creates a buffered Pipe with the given capacity. bufferSize must
+// be non-negative.
+func NewPipe[T any](bufferSize int) *Pipe[T] {
+	ctx, cancel := context.WithCancel(context.Background())
+	return &Pipe[T]{
+		ch:        make(chan T, bufferSize),
+		interrupt: ctx,
+		cancel:    cancel,
+	}
+}
+
+// Read returns the next value from the pipe.
+//
+//   - Returns io.EOF after Close once all buffered values are consumed.
+//   - Returns context.Canceled immediately after Interrupt, skipping
+//     buffered values.
+//   - Returns ctx.Err() when the caller's context is canceled. This is a
+//     per-call cancellation: the stream itself stays usable.
+//
+// After Read returns a stream-level error (io.EOF or context.Canceled), all
+// subsequent Read calls return the same error.
+func (p *Pipe[T]) Read(ctx context.Context) (T, error) {
+	p.mu.Lock()
+	if p.lastErr != nil {
+		err := p.lastErr
+		p.mu.Unlock()
+		var zero T
+		return zero, err
+	}
+	p.mu.Unlock()
+
+	// Interrupt takes precedence over any pending value or a normal Close.
+	// Without this pre-check the select below is chosen at random when both
+	// a value/closed channel and the interrupt channel are ready, which
+	// would let an abnormal termination be observed as a clean io.EOF —
+	// e.g. a producer that calls Interrupt() and then runs a deferred
+	// Close(). Checking the interrupt channel first makes "Interrupt
+	// returns context.Canceled immediately, skipping buffered values" a
+	// deterministic guarantee.
+	select {
+	case <-p.interrupt.Done():
+		var zero T
+		p.mu.Lock()
+		p.lastErr = context.Canceled
+		p.mu.Unlock()
+		return zero, context.Canceled
+	default:
+	}
+
+	// The caller's context is checked before values for the same reason:
+	// a canceled call should not observe a pending value as if nothing
+	// happened. Unlike Interrupt, this is not recorded — a later Read with
+	// a fresh context can keep consuming.
+	select {
+	case <-ctx.Done():
+		var zero T
+		return zero, ctx.Err()
+	default:
+	}
+
+	select {
+	case v, ok := <-p.ch:
+		if !ok {
+			var zero T
+			p.mu.Lock()
+			p.lastErr = io.EOF
+			p.mu.Unlock()
+			return zero, io.EOF
+		}
+		return v, nil
+	case <-ctx.Done():
+		var zero T
+		return zero, ctx.Err()
+	case <-p.interrupt.Done():
+		var zero T
+		p.mu.Lock()
+		p.lastErr = context.Canceled
+		p.mu.Unlock()
+		return zero, context.Canceled
+	}
+}
+
+// Send writes a value into the pipe, blocking while the buffer is full
+// (backpressure). It returns false when the pipe has been interrupted.
+// Callers must not call Send after Close: sending on a closed channel
+// panics per Go semantics.
+func (p *Pipe[T]) Send(v T) bool {
+	select {
+	case <-p.interrupt.Done():
+		return false
+	default:
+	}
+	select {
+	case p.ch <- v:
+		return true
+	case <-p.interrupt.Done():
+		return false
+	}
+}
+
+// TrySend writes a value into the pipe without blocking. It returns false
+// when the pipe is interrupted or the buffer is full.
+func (p *Pipe[T]) TrySend(v T) bool {
+	select {
+	case <-p.interrupt.Done():
+		return false
+	default:
+	}
+	select {
+	case p.ch <- v:
+		return true
+	default:
+		return false
+	}
+}
+
+// Close signals normal end of stream. After all buffered values are
+// consumed, Read returns io.EOF. Safe to call multiple times (idempotent
+// via sync.Once).
+func (p *Pipe[T]) Close() {
+	p.closeOnce.Do(func() { close(p.ch) })
+}
+
+// Interrupt signals abnormal end of stream. Read returns context.Canceled
+// immediately, even if buffered values remain. Idempotent.
+func (p *Pipe[T]) Interrupt() {
+	p.cancel()
+}

--- a/core/message/media/stream_test.go
+++ b/core/message/media/stream_test.go
@@ -1,0 +1,126 @@
+package media
+
+import (
+	"context"
+	"errors"
+	"io"
+	"testing"
+	"time"
+)
+
+func TestPipeOrderedReadDrainThenEOF(t *testing.T) {
+	pipe := NewPipe[string](3)
+	for _, value := range []string{"a", "b", "c"} {
+		if !pipe.Send(value) {
+			t.Fatalf("Send(%q) rejected", value)
+		}
+	}
+	ctx := context.Background()
+	for _, want := range []string{"a", "b", "c"} {
+		got, err := pipe.Read(ctx)
+		if err != nil {
+			t.Fatalf("Read: %v", err)
+		}
+		if got != want {
+			t.Fatalf("Read = %q, want %q", got, want)
+		}
+	}
+	pipe.Close()
+	if _, err := pipe.Read(ctx); !errors.Is(err, io.EOF) {
+		t.Fatalf("Read after Close = %v, want io.EOF", err)
+	}
+	if _, err := pipe.Read(ctx); !errors.Is(err, io.EOF) {
+		t.Fatalf("subsequent Read = %v, want io.EOF", err)
+	}
+}
+
+func TestPipeBufferBoundsBackpressure(t *testing.T) {
+	pipe := NewPipe[int](1)
+	if !pipe.Send(1) {
+		t.Fatal("first Send rejected")
+	}
+	if pipe.TrySend(2) {
+		t.Fatal("TrySend accepted a value on a full buffer")
+	}
+
+	done := make(chan bool, 1)
+	go func() {
+		done <- pipe.Send(2)
+	}()
+	select {
+	case <-done:
+		t.Fatal("Send completed while the buffer was full")
+	case <-time.After(20 * time.Millisecond):
+	}
+
+	value, err := pipe.Read(context.Background())
+	if err != nil || value != 1 {
+		t.Fatalf("Read = (%v, %v), want (1, nil)", value, err)
+	}
+	select {
+	case ok := <-done:
+		if !ok {
+			t.Fatal("blocked Send was rejected")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("blocked Send did not complete after drain")
+	}
+}
+
+func TestPipeInterruptSkipsBufferedValues(t *testing.T) {
+	pipe := NewPipe[string](2)
+	pipe.Send("stale-1")
+	pipe.Send("stale-2")
+	pipe.Interrupt()
+	if _, err := pipe.Read(context.Background()); !errors.Is(err, context.Canceled) {
+		t.Fatalf("Read after Interrupt = %v, want context.Canceled", err)
+	}
+	if _, err := pipe.Read(context.Background()); !errors.Is(err, context.Canceled) {
+		t.Fatalf("subsequent Read = %v, want context.Canceled", err)
+	}
+}
+
+func TestPipeInterruptTakesPrecedenceOverClose(t *testing.T) {
+	pipe := NewPipe[int](1)
+	pipe.Send(1)
+	pipe.Interrupt()
+	pipe.Close() // deferred Close must not mask the interrupt
+	if _, err := pipe.Read(context.Background()); !errors.Is(err, context.Canceled) {
+		t.Fatalf("Read = %v, want context.Canceled", err)
+	}
+}
+
+func TestPipeInterruptedSendRejected(t *testing.T) {
+	pipe := NewPipe[int](0)
+	pipe.Interrupt()
+	if pipe.Send(1) {
+		t.Fatal("Send succeeded on an interrupted pipe")
+	}
+	if pipe.TrySend(1) {
+		t.Fatal("TrySend succeeded on an interrupted pipe")
+	}
+}
+
+func TestPipeCallerContextCancellationIsPerCall(t *testing.T) {
+	pipe := NewPipe[string](1)
+	pipe.Send("kept")
+	canceled, cancel := context.WithCancel(context.Background())
+	cancel()
+	if _, err := pipe.Read(canceled); !errors.Is(err, context.Canceled) {
+		t.Fatalf("Read with canceled ctx = %v, want context.Canceled", err)
+	}
+	// The stream itself is untouched: a fresh context still sees the value.
+	value, err := pipe.Read(context.Background())
+	if err != nil || value != "kept" {
+		t.Fatalf("Read = (%q, %v), want (\"kept\", nil)", value, err)
+	}
+}
+
+func TestPipeCloseIdempotent(t *testing.T) {
+	pipe := NewPipe[int](0)
+	pipe.Close()
+	pipe.Close()
+	if _, err := pipe.Read(context.Background()); !errors.Is(err, io.EOF) {
+		t.Fatalf("Read = %v, want io.EOF", err)
+	}
+}

--- a/core/message/stream.go
+++ b/core/message/stream.go
@@ -1,0 +1,236 @@
+package message
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+
+	"github.com/GizClaw/flowcraft/core/message/media"
+)
+
+// Stream is the canonical pull-based transport for live content: the
+// message-level instantiation of [media.Stream] over [Part].
+//
+// A Stream is how a message "exists" while it is in flight — for example
+// the audio/video input of a live session. It is deliberately not a new
+// DTO: the items are ordinary [Part] values, and a stream-backed part is
+// materialized back into ordinary parts before it enters durable context
+// or history (see [MaterializeContent]).
+type Stream = media.Stream[Part]
+
+// Pipe is the bounded, buffered implementation of [Stream]. Producers Send
+// into it (blocking when the buffer is full, which is the backpressure
+// contract); consumers Read from it. See [media.Pipe] for the full
+// Close / Interrupt semantics.
+type Pipe = media.Pipe[Part]
+
+// NewPartPipe creates a bounded part pipe with the given buffer capacity.
+func NewPartPipe(bufferSize int) *Pipe {
+	return media.NewPipe[Part](bufferSize)
+}
+
+// NewAudioStream wraps a live part stream as an audio source, the
+// message-level convenience for [media.NewAudioStream] instantiated over
+// [Part].
+func NewAudioStream(stream Stream, mediaType string) (media.AudioSource, error) {
+	return media.NewAudioStream(stream, mediaType)
+}
+
+// NewVideoStream wraps a live part stream as a video source, the
+// message-level convenience for [media.NewVideoStream] instantiated over
+// [Part].
+func NewVideoStream(stream Stream, mediaType string) (media.VideoSource, error) {
+	return media.NewVideoStream(stream, mediaType)
+}
+
+// HasStreamSource reports whether any part in content carries a
+// stream-backed media source. It is the cheap pre-check callers use before
+// deciding whether [MaterializeContent] has work to do.
+func HasStreamSource(content Content) bool {
+	for _, part := range content.Parts {
+		normalized, err := NormalizePart(part)
+		if err != nil {
+			continue
+		}
+		switch value := normalized.(type) {
+		case AudioPart:
+			if value.Source.Kind() == media.SourceStream {
+				return true
+			}
+		case VideoPart:
+			if value.Source.Kind() == media.SourceStream {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// MaterializeContent converts every stream-backed audio and video part in
+// content into its durable form by draining the stream to completion:
+//   - a stream-backed AudioPart becomes one inline-byte AudioPart;
+//   - a stream-backed VideoPart becomes one inline-byte VideoPart.
+//
+// Content without stream sources is returned unchanged. The stream is
+// consumed exactly once: callers that also read it live must materialize
+// from their own accumulated bytes instead (or ensure the stream is still
+// readable here).
+func MaterializeContent(ctx context.Context, content Content) (Content, error) {
+	if !HasStreamSource(content) {
+		return content, nil
+	}
+	out := make([]Part, 0, len(content.Parts))
+	for _, part := range content.Parts {
+		normalized, err := NormalizePart(part)
+		if err != nil {
+			return Content{}, fmt.Errorf("materialize content: %w", err)
+		}
+		materialized, err := MaterializePart(ctx, normalized)
+		if err != nil {
+			return Content{}, err
+		}
+		out = append(out, materialized...)
+	}
+	return Content{Parts: out}, nil
+}
+
+// MaterializePart returns part in its durable form. Stream-backed audio
+// and video parts are drained into inline-byte parts; every other part is
+// returned unchanged. See [MaterializeContent] for the rules.
+func MaterializePart(ctx context.Context, part Part) ([]Part, error) {
+	normalized, err := NormalizePart(part)
+	if err != nil {
+		return nil, err
+	}
+	switch value := normalized.(type) {
+	case AudioPart:
+		return materializeAudioPart(ctx, value)
+	case VideoPart:
+		return materializeVideoPart(ctx, value)
+	default:
+		return []Part{normalized}, nil
+	}
+}
+
+func materializeAudioPart(ctx context.Context, part AudioPart) ([]Part, error) {
+	if part.Source.Kind() != media.SourceStream {
+		return []Part{part}, nil
+	}
+	stream, ok := part.Source.Stream().(Stream)
+	if !ok {
+		return nil, fmt.Errorf(
+			"materialize audio: stream source carries %T, want message.Stream",
+			part.Source.Stream(),
+		)
+	}
+	var data bytes.Buffer
+	var format *media.AudioFormat
+	for {
+		item, err := stream.Read(ctx)
+		if err != nil {
+			if errors.Is(err, io.EOF) {
+				break
+			}
+			return nil, fmt.Errorf("materialize audio: %w", err)
+		}
+		audio, ok := item.(AudioPart)
+		if !ok {
+			return nil, fmt.Errorf(
+				"materialize audio: stream yielded %T, want audio part", item)
+		}
+		if audio.Source.Kind() != media.SourceInline {
+			return nil, fmt.Errorf(
+				"materialize audio: stream part must carry inline bytes")
+		}
+		data.Write(audio.Source.Bytes())
+		if audio.Format == nil {
+			continue
+		}
+		if format == nil {
+			copied := *audio.Format
+			format = &copied
+			continue
+		}
+		if *format != *audio.Format {
+			return nil, fmt.Errorf(
+				"materialize audio: stream mixes formats %v and %v",
+				*format, *audio.Format)
+		}
+	}
+	if data.Len() == 0 {
+		return nil, fmt.Errorf("materialize audio: stream produced no audio data")
+	}
+	mediaType := ""
+	if format != nil {
+		mediaType = format.Encoding.MediaType()
+	}
+	if mediaType == "" {
+		mediaType = part.Source.MediaType()
+	}
+	source, err := media.NewAudioBytes(data.Bytes(), mediaType)
+	if err != nil {
+		return nil, fmt.Errorf("materialize audio: %w", err)
+	}
+	duration := part.DurationMillis
+	if duration == nil && format != nil {
+		if millis, ok := media.AudioDurationMillis(data.Bytes(), *format); ok {
+			duration = &millis
+		}
+	}
+	materialized := AudioPart{
+		Source:         source,
+		Format:         format,
+		DurationMillis: duration,
+	}
+	if err := materialized.Validate(); err != nil {
+		return nil, fmt.Errorf("materialize audio: %w", err)
+	}
+	return []Part{materialized}, nil
+}
+
+func materializeVideoPart(ctx context.Context, part VideoPart) ([]Part, error) {
+	if part.Source.Kind() != media.SourceStream {
+		return []Part{part}, nil
+	}
+	stream, ok := part.Source.Stream().(Stream)
+	if !ok {
+		return nil, fmt.Errorf(
+			"materialize video: stream source carries %T, want message.Stream",
+			part.Source.Stream(),
+		)
+	}
+	var data bytes.Buffer
+	for {
+		item, err := stream.Read(ctx)
+		if err != nil {
+			if errors.Is(err, io.EOF) {
+				break
+			}
+			return nil, fmt.Errorf("materialize video: %w", err)
+		}
+		video, ok := item.(VideoPart)
+		if !ok {
+			return nil, fmt.Errorf(
+				"materialize video: stream yielded %T, want video part", item)
+		}
+		if video.Source.Kind() != media.SourceInline {
+			return nil, fmt.Errorf(
+				"materialize video: stream part must carry inline bytes")
+		}
+		data.Write(video.Source.Bytes())
+	}
+	if data.Len() == 0 {
+		return nil, fmt.Errorf("materialize video: stream produced no video data")
+	}
+	source, err := media.NewVideoBytes(data.Bytes(), part.Source.MediaType())
+	if err != nil {
+		return nil, fmt.Errorf("materialize video: %w", err)
+	}
+	materialized := VideoPart{Source: source}
+	if err := materialized.Validate(); err != nil {
+		return nil, fmt.Errorf("materialize video: %w", err)
+	}
+	return []Part{materialized}, nil
+}

--- a/core/message/stream_test.go
+++ b/core/message/stream_test.go
@@ -1,0 +1,215 @@
+package message_test
+
+import (
+	"context"
+	"encoding/json"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/GizClaw/flowcraft/core/message"
+	"github.com/GizClaw/flowcraft/core/message/media"
+)
+
+func TestPartPipeRoundTrip(t *testing.T) {
+	pipe := message.NewPartPipe(2)
+	if !pipe.Send(message.TextPart{Text: "hello"}) {
+		t.Fatal("Send rejected")
+	}
+	item, err := pipe.Read(context.Background())
+	if err != nil {
+		t.Fatalf("Read: %v", err)
+	}
+	if item.Kind() != message.PartText {
+		t.Fatalf("item kind = %q", item.Kind())
+	}
+}
+
+func TestMaterializeAudioStreamIntoInlinePart(t *testing.T) {
+	format := media.AudioFormat{
+		Encoding:     media.AudioEncodingPCM16,
+		SampleRateHz: 1000,
+		Channels:     1,
+	}
+	chunk := func(data string) message.Part {
+		source, err := media.NewAudioBytes([]byte(data), "audio/pcm")
+		if err != nil {
+			t.Fatalf("NewAudioBytes: %v", err)
+		}
+		return message.AudioPart{Source: source, Format: &format}
+	}
+	pipe := message.NewPartPipe(2)
+	pipe.Send(chunk("abcd"))
+	pipe.Send(chunk("ef"))
+	pipe.Close()
+	source, err := media.NewAudioStream(pipe, "audio/pcm")
+	if err != nil {
+		t.Fatalf("NewAudioStream: %v", err)
+	}
+	content := message.Content{Parts: []message.Part{
+		message.TextPart{Text: "transcript"},
+		message.AudioPart{Source: source},
+	}}
+
+	materialized, err := message.MaterializeContent(context.Background(), content)
+	if err != nil {
+		t.Fatalf("MaterializeContent: %v", err)
+	}
+	if message.HasStreamSource(materialized) {
+		t.Fatal("materialized content still carries a stream source")
+	}
+	if len(materialized.Parts) != 2 {
+		t.Fatalf("materialized parts = %d, want 2", len(materialized.Parts))
+	}
+	audio, ok := materialized.Parts[1].(message.AudioPart)
+	if !ok {
+		t.Fatalf("materialized part 1 = %T, want AudioPart", materialized.Parts[1])
+	}
+	if audio.Source.Kind() != media.SourceInline {
+		t.Fatalf("materialized source kind = %q", audio.Source.Kind())
+	}
+	if got := string(audio.Source.Bytes()); got != "abcdef" {
+		t.Fatalf("materialized bytes = %q, want \"abcdef\"", got)
+	}
+	if audio.Format == nil || *audio.Format != format {
+		t.Fatalf("materialized format = %v, want %v", audio.Format, format)
+	}
+	if audio.DurationMillis == nil || *audio.DurationMillis != 3 {
+		t.Fatalf("materialized duration = %v, want 3ms", audio.DurationMillis)
+	}
+}
+
+func TestMaterializeVideoStreamIntoInlinePart(t *testing.T) {
+	chunk := func(data string) message.Part {
+		source, err := media.NewVideoBytes([]byte(data), "video/mp4")
+		if err != nil {
+			t.Fatalf("NewVideoBytes: %v", err)
+		}
+		return message.VideoPart{Source: source}
+	}
+	pipe := message.NewPartPipe(2)
+	pipe.Send(chunk("moov"))
+	pipe.Send(chunk("mdat"))
+	pipe.Close()
+	source, err := media.NewVideoStream(pipe, "video/mp4")
+	if err != nil {
+		t.Fatalf("NewVideoStream: %v", err)
+	}
+	content := message.Content{Parts: []message.Part{
+		message.VideoPart{Source: source},
+	}}
+	materialized, err := message.MaterializeContent(context.Background(), content)
+	if err != nil {
+		t.Fatalf("MaterializeContent: %v", err)
+	}
+	video, ok := materialized.Parts[0].(message.VideoPart)
+	if !ok {
+		t.Fatalf("materialized part = %T, want VideoPart", materialized.Parts[0])
+	}
+	if got := string(video.Source.Bytes()); got != "moovmdat" {
+		t.Fatalf("materialized bytes = %q", got)
+	}
+}
+
+func TestMaterializeContentWithoutStreamsIsUnchanged(t *testing.T) {
+	source, err := media.NewAudioBytes([]byte("audio"), "audio/mpeg")
+	if err != nil {
+		t.Fatalf("NewAudioBytes: %v", err)
+	}
+	content := message.Content{Parts: []message.Part{
+		message.TextPart{Text: "hi"},
+		message.AudioPart{Source: source},
+	}}
+	got, err := message.MaterializeContent(context.Background(), content)
+	if err != nil {
+		t.Fatalf("MaterializeContent: %v", err)
+	}
+	if !reflect.DeepEqual(got, content) {
+		t.Fatal("materialization modified a stream-free content")
+	}
+}
+
+func TestMaterializeStreamRejectsUnexpectedItems(t *testing.T) {
+	pipe := message.NewPartPipe(1)
+	pipe.Send(message.TextPart{Text: "oops"})
+	pipe.Close()
+	source, err := media.NewAudioStream(pipe, "audio/pcm")
+	if err != nil {
+		t.Fatalf("NewAudioStream: %v", err)
+	}
+	content := message.Content{Parts: []message.Part{
+		message.AudioPart{Source: source},
+	}}
+	if _, err := message.MaterializeContent(context.Background(), content); err == nil ||
+		!strings.Contains(err.Error(), "want audio part") {
+		t.Fatalf("MaterializeContent = %v, want unexpected-item error", err)
+	}
+}
+
+func TestMaterializeEmptyStreamErrors(t *testing.T) {
+	pipe := message.NewPartPipe(0)
+	pipe.Close()
+	source, err := media.NewAudioStream(pipe, "audio/pcm")
+	if err != nil {
+		t.Fatalf("NewAudioStream: %v", err)
+	}
+	content := message.Content{Parts: []message.Part{
+		message.AudioPart{Source: source},
+	}}
+	if _, err := message.MaterializeContent(context.Background(), content); err == nil ||
+		!strings.Contains(err.Error(), "no audio data") {
+		t.Fatalf("MaterializeContent = %v, want empty-stream error", err)
+	}
+}
+
+func TestMaterializeInterruptedStreamErrors(t *testing.T) {
+	pipe := message.NewPartPipe(0)
+	pipe.Interrupt()
+	source, err := media.NewAudioStream(pipe, "audio/pcm")
+	if err != nil {
+		t.Fatalf("NewAudioStream: %v", err)
+	}
+	content := message.Content{Parts: []message.Part{
+		message.AudioPart{Source: source},
+	}}
+	if _, err := message.MaterializeContent(context.Background(), content); err == nil {
+		t.Fatal("MaterializeContent accepted an interrupted stream")
+	}
+}
+
+func TestHasStreamSource(t *testing.T) {
+	pipe := message.NewPartPipe(0)
+	source, err := media.NewAudioStream(pipe, "audio/pcm")
+	if err != nil {
+		t.Fatalf("NewAudioStream: %v", err)
+	}
+	inline, err := media.NewAudioBytes([]byte("x"), "audio/pcm")
+	if err != nil {
+		t.Fatalf("NewAudioBytes: %v", err)
+	}
+	if !message.HasStreamSource(message.Content{Parts: []message.Part{
+		message.AudioPart{Source: source},
+	}}) {
+		t.Fatal("HasStreamSource missed a stream-backed audio part")
+	}
+	if message.HasStreamSource(message.Content{Parts: []message.Part{
+		message.AudioPart{Source: inline},
+		message.TextPart{Text: "x"},
+	}}) {
+		t.Fatal("HasStreamSource reported a stream source for inline parts")
+	}
+}
+
+func TestStreamContentCannotBeJSONEncoded(t *testing.T) {
+	pipe := message.NewPartPipe(0)
+	source, err := media.NewAudioStream(pipe, "audio/pcm")
+	if err != nil {
+		t.Fatalf("NewAudioStream: %v", err)
+	}
+	content := message.Content{Parts: []message.Part{
+		message.AudioPart{Source: source},
+	}}
+	if _, err := json.Marshal(content); err == nil {
+		t.Fatal("Marshal accepted a stream-backed content")
+	}
+}

--- a/docs/guides/graph.md
+++ b/docs/guides/graph.md
@@ -249,9 +249,12 @@ a no-op host, so scripts can call them unconditionally.
 | `tool_call`   | JSON string or `{id, name, arguments}`       | tool call part delta           |
 | `tool_result` | `{tool_call_id, content, is_error}`          | tool result part delta         |
 | `part`        | canonical part wire object (`{"type": ...}`) | arbitrary `message.Part` delta |
-| anything else | —                                            | passthrough delta of that type |
+| anything else | any value                                    | passthrough delta; raw payload rides under `payload` |
 
 Emission is fire-and-forget: publish failures are dropped, not thrown.
+Payloads that do not decode into the type's required shape (e.g. a
+`tool_call` without `id`) are skipped instead of published as empty
+deltas.
 
 ### `run`
 
@@ -361,7 +364,8 @@ Each event is a map with `event`, `envelope_id`, `id`, `subject`, `time`,
 `run_id`, `node_id`, `agent_id`, plus payload fields. Lifecycle events are
 `step.started` / `step.ended` (status `success` or `error`) /
 `step.skipped`; stream deltas arrive as `event: "stream.delta"` with
-`type` / `part` / `speculative` / `branch_id` fields.
+`type` / `part` / `speculative` / `branch_id` fields, plus `payload`
+carrying the raw value of forward-compatible custom emit types.
 
 ```js
 var iter = stream.subscribe_node({ node_id: "planner" });


### PR DESCRIPTION
## Summary

Fixes payload loss on the core script bridge's `host.emit` channel.

- `scriptEmitter.Emit` now carries the raw script payload for forward-compatible / custom event types (previously only the event type reached the wire, e.g. `host.emit("progress", {pct: 42})` published `{"type":"progress"}` with the payload dropped).
- Invalid `tool_call` / `tool_result` / `part` payloads now skip emission instead of publishing an empty `{"type":""}` delta.
- `StreamDeltaPayload` gains a wire-safe `payload` field (custom `MarshalJSON`/`UnmarshalJSON` updated); existing wire format is unchanged since the field is omitted when empty.
- Stream subscription projection surfaces the passthrough `payload`.

Also includes the previously staged `core/message` live-media-stream transport commit (media.Stream/media.Pipe, stream-backed audio/video sources, MaterializeContent conversion) as a separate commit.

## Tests

- New: passthrough payload reaches the delta and stream subscription projection; invalid payloads skip emission; nil payload stays type-only.
- `make ci` (vet + test, all modules), `make lint` (golangci-lint), `make release-check`, and `git diff --check` all pass on this branch.

## Commits

- `fix(core): keep payloads on script bridge emit channel`
- `feat(core/message): add live media stream transport`