### PR TITLE
chore(core): lower module Go version to 1.25

### DIFF
--- a/core/go.mod
+++ b/core/go.mod
@@ -1,6 +1,6 @@
 module github.com/GizClaw/flowcraft/core
 
-go 1.26.0
+go 1.25.0
 
 require (
 	github.com/a2aproject/a2a-go/v2 v2.4.0


### PR DESCRIPTION
## Summary

Lower `core/go.mod`'s Go directive from 1.26.0 to 1.25.0.

- core's dependency graph already floors at go 1.25 (otel, x/net, grpc, x/sys, etc.); go 1.24 fails with `go.opentelemetry.io/otel@v1.43.0 requires go >= 1.25.0`.
- Nothing in core uses 1.26-specific language or stdlib features; verified by building, vetting and testing the module under `GOTOOLCHAIN=go1.25.0`.
- `go.work` and sibling modules stay at 1.26 because `driver/bytedance` depends on `doubao-speech-go`, which requires go 1.26.
- `go mod tidy` shows no other changes (go.sum / go.work.sum untouched).

## Verification

- `make ci` (vet + test, all modules): pass
- `make lint` (golangci-lint): 0 issues
- `make release-check`: changesets valid, no pending releases
- `git diff --check`: clean