### PR TITLE
feat(core): first-class finish and provider_outputs script emit types

### DIFF
--- a/core/graph/nodes/script/emitter_test.go
+++ b/core/graph/nodes/script/emitter_test.go
@@ -201,3 +201,62 @@ func TestScriptEmitter_PassthroughReachesStreamSubscription(t *testing.T) {
 		t.Fatalf("Execute: %v", err)
 	}
 }
+
+func TestScriptEmitter_FinishDelta(t *testing.T) {
+	deltas := captureEmits(t, func(env *agent.ScriptEnv) {
+		emit := env.Bindings["host"].(map[string]any)["emit"].(func(string, any))
+		emit("finish", map[string]any{
+			"finish_reason": "completed",
+			"request_id":    "r1",
+			"response_id":   "s1",
+		})
+		emit("finish", map[string]any{})                    // missing finish_reason
+		emit("finish", map[string]any{"finish_reason": ""}) // empty finish_reason
+	})
+	if len(deltas) != 1 {
+		t.Fatalf("emitted %d deltas, want only the valid finish delta", len(deltas))
+	}
+	delta := deltas[0]
+	if delta.Type != agent.StreamDeltaFinish {
+		t.Fatalf("delta type = %q, want %q", delta.Type, agent.StreamDeltaFinish)
+	}
+	if delta.FinishReason != "completed" || delta.RequestID != "r1" || delta.ResponseID != "s1" {
+		t.Fatalf("finish delta = %+v, want typed fields", delta)
+	}
+	if delta.Payload != nil {
+		t.Fatalf("finish payload must not ride under the passthrough payload field, got %s", delta.Payload)
+	}
+}
+
+func TestScriptEmitter_ProviderOutputsDelta(t *testing.T) {
+	deltas := captureEmits(t, func(env *agent.ScriptEnv) {
+		emit := env.Bindings["host"].(map[string]any)["emit"].(func(string, any))
+		emit("provider_outputs", []any{
+			map[string]any{"provider": "openai", "extension": "citations", "value": map[string]any{"a": 1}},
+			map[string]any{"provider": "search", "extension": "results", "value": []any{1, 2}},
+		})
+		emit("provider_outputs", []any{})                                                       // empty
+		emit("provider_outputs", []any{map[string]any{"provider": "x"}})                        // missing extension
+		emit("provider_outputs", map[string]any{"provider": "x", "extension": "y", "value": 1}) // not an array
+	})
+	if len(deltas) != 1 {
+		t.Fatalf("emitted %d deltas, want only the valid provider_outputs delta", len(deltas))
+	}
+	delta := deltas[0]
+	if delta.Type != agent.StreamDeltaProviderOutputs {
+		t.Fatalf("delta type = %q, want %q", delta.Type, agent.StreamDeltaProviderOutputs)
+	}
+	outputs := delta.ProviderOutputs
+	if len(outputs) != 2 {
+		t.Fatalf("provider outputs = %+v, want 2 envelopes", outputs)
+	}
+	if outputs[0].Provider != "openai" || outputs[0].Extension != "citations" || string(outputs[0].Value) != `{"a":1}` {
+		t.Fatalf("output[0] = %+v", outputs[0])
+	}
+	if outputs[1].Provider != "search" || outputs[1].Extension != "results" || string(outputs[1].Value) != `[1,2]` {
+		t.Fatalf("output[1] = %+v", outputs[1])
+	}
+	if delta.Payload != nil {
+		t.Fatalf("provider_outputs must not ride under the passthrough payload field, got %s", delta.Payload)
+	}
+}

--- a/core/graph/nodes/script/node.go
+++ b/core/graph/nodes/script/node.go
@@ -184,6 +184,22 @@ func (e scriptEmitter) Emit(eventType string, payload any) {
 				Part: part,
 			})
 		}
+	case "finish":
+		// Terminal generation signal: typed like the inference node's
+		// finish delta so stream consumers see finish_reason /
+		// request_id / response_id at the top level.
+		if delta, ok := payloadToFinish(payload); ok {
+			_ = e.ec.EmitStreamDelta(delta)
+		}
+	case "provider_outputs":
+		// Final provider-owned observational outputs, one envelope per
+		// output — the same shape the inference node emits.
+		if outputs, ok := payloadToProviderOutputs(payload); ok {
+			_ = e.ec.EmitStreamDelta(agent.StreamDeltaPayload{
+				Type:            agent.StreamDeltaProviderOutputs,
+				ProviderOutputs: outputs,
+			})
+		}
 	default:
 		// Forward-compatible event types pass through with the raw
 		// payload riding under StreamDeltaPayload.Payload, so the
@@ -200,6 +216,67 @@ func (e scriptEmitter) Emit(eventType string, payload any) {
 		}
 		_ = e.ec.EmitStreamDelta(delta)
 	}
+}
+
+// payloadToFinish decodes a script-supplied finish payload into the
+// typed finish delta. Accepted shape: an object with finish_reason
+// (required) and optional request_id / response_id.
+func payloadToFinish(payload any) (agent.StreamDeltaPayload, bool) {
+	raw, ok := marshalPayload(payload)
+	if !ok {
+		return agent.StreamDeltaPayload{}, false
+	}
+	var wire struct {
+		FinishReason string `json:"finish_reason"`
+		RequestID    string `json:"request_id"`
+		ResponseID   string `json:"response_id"`
+	}
+	if err := json.Unmarshal(raw, &wire); err != nil {
+		return agent.StreamDeltaPayload{}, false
+	}
+	if wire.FinishReason == "" {
+		return agent.StreamDeltaPayload{}, false
+	}
+	return agent.StreamDeltaPayload{
+		Type:         agent.StreamDeltaFinish,
+		FinishReason: wire.FinishReason,
+		RequestID:    wire.RequestID,
+		ResponseID:   wire.ResponseID,
+	}, true
+}
+
+// payloadToProviderOutputs decodes a script-supplied provider_outputs
+// payload into wire envelopes. Accepted shape: a non-empty array of
+// {provider, extension, value} objects; value is opaque and rides as
+// raw JSON.
+func payloadToProviderOutputs(payload any) ([]agent.ProviderOutputEnvelope, bool) {
+	raw, ok := marshalPayload(payload)
+	if !ok {
+		return nil, false
+	}
+	var wire []struct {
+		Provider  string          `json:"provider"`
+		Extension string          `json:"extension"`
+		Value     json.RawMessage `json:"value"`
+	}
+	if err := json.Unmarshal(raw, &wire); err != nil {
+		return nil, false
+	}
+	if len(wire) == 0 {
+		return nil, false
+	}
+	out := make([]agent.ProviderOutputEnvelope, 0, len(wire))
+	for _, entry := range wire {
+		if entry.Provider == "" || entry.Extension == "" || len(entry.Value) == 0 {
+			return nil, false
+		}
+		out = append(out, agent.ProviderOutputEnvelope{
+			Provider:  entry.Provider,
+			Extension: entry.Extension,
+			Value:     entry.Value,
+		})
+	}
+	return out, true
 }
 
 // payloadToPart decodes a canonical part wire object (a map or JSON

--- a/core/runtime/reload_test.go
+++ b/core/runtime/reload_test.go
@@ -73,6 +73,26 @@ func waitForGen(t *testing.T, runs <-chan int64, want int64) {
 	t.Fatalf("engine generation %d not observed", want)
 }
 
+// waitForEngineRun blocks until the gated engine reports one run and
+// returns the observed generation. Multi-agent builds instantiate engines
+// in resource order, which is not deterministic, so tests must not couple
+// a wait to a specific generation number — any run from the turn under test
+// is enough to know it reached the engine and is blocked on the gate.
+func waitForEngineRun(t *testing.T, runs <-chan int64) int64 {
+	t.Helper()
+	deadline := time.Now().Add(10 * time.Second)
+	for time.Now().Before(deadline) {
+		select {
+		case got := <-runs:
+			return got
+		default:
+			time.Sleep(5 * time.Millisecond)
+		}
+	}
+	t.Fatalf("engine run not observed")
+	return 0
+}
+
 // recordedBusFactory records every bus it builds so tests can publish
 // on the exact old/new generation buses.
 type recordedBusFactory struct {
@@ -669,7 +689,7 @@ func TestRuntimeReloadDrainTimeoutClearsTombstone(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Start(extra): %v", err)
 	}
-	waitForGen(t, f.runs, 2)
+	waitForEngineRun(t, f.runs)
 
 	reloadCtx, cancelReload := context.WithTimeout(
 		context.Background(), 100*time.Millisecond)

--- a/docs/guides/graph.md
+++ b/docs/guides/graph.md
@@ -249,12 +249,16 @@ a no-op host, so scripts can call them unconditionally.
 | `tool_call`   | JSON string or `{id, name, arguments}`       | tool call part delta           |
 | `tool_result` | `{tool_call_id, content, is_error}`          | tool result part delta         |
 | `part`        | canonical part wire object (`{"type": ...}`) | arbitrary `message.Part` delta |
+| `finish`      | `{finish_reason, request_id?, response_id?}` | finish delta with typed fields |
+| `provider_outputs` | `[{provider, extension, value}]`        | provider_outputs delta         |
 | anything else | any value                                    | passthrough delta; raw payload rides under `payload` |
 
 Emission is fire-and-forget: publish failures are dropped, not thrown.
 Payloads that do not decode into the type's required shape (e.g. a
 `tool_call` without `id`) are skipped instead of published as empty
-deltas.
+deltas. `finish` requires `finish_reason`; `provider_outputs` requires
+a non-empty array with `provider` / `extension` / `value` on every
+entry.
 
 ### `run`
 


### PR DESCRIPTION
## Summary

Makes `host.emit`'s `finish` and `provider_outputs` event types first-class in `scriptEmitter.Emit`, so a JS script node can emit wire-identical terminal deltas to the inference node instead of wrapping them under the passthrough `payload` field.

- `finish`: decodes `{finish_reason, request_id?, response_id?}` into the typed `StreamDeltaFinish` fields (requires non-empty `finish_reason`).
- `provider_outputs`: decodes a non-empty `[{provider, extension, value}]` array into `StreamDeltaProviderOutputs` envelopes.
- Invalid payloads skip emission, matching the existing void contract for `tool_call` / `tool_result` / `part`.
- Docs updated with the new event types.

Also includes a test-stability fix:

- `fix(core): de-flake runtime reload drain timeout test` — the test previously required the in-flight turn to report engine construction generation 2, but multi-agent builds instantiate engines in nondeterministic resource order; it now waits for any engine run. This is the flake hit during the CI gate (reload_test.go:672, `engine generation 2 not observed`).

## Verification

- `make ci` (vet + test, all modules): pass
- Flaky test rerun 10/10 after the fix
- `make lint` (golangci-lint): 0 issues
- `make release-check`: changesets valid, no pending releases
- `git diff --check`: clean

## Commits

- `feat(core): first-class finish and provider_outputs script emit types`
- `fix(core): de-flake runtime reload drain timeout test`