### PR TITLE
feat(core): add first-class transcription with live part-stream input

### DIFF
--- a/core/agent/a2a/convert.go
+++ b/core/agent/a2a/convert.go
@@ -3,6 +3,7 @@ package a2a
 import (
 	"encoding/base64"
 	"encoding/json"
+	"fmt"
 	"strings"
 
 	"github.com/GizClaw/flowcraft/core/message"
@@ -56,6 +57,9 @@ func a2aPartFromMediaSource(src interface {
 		out := a2aprotocol.NewFileURLPart(a2aprotocol.URL(src.URL()), src.MediaType())
 		out.Filename = name
 		return out, true, nil
+	case media.SourceStream:
+		return nil, false, fmt.Errorf(
+			"stream media sources cannot be converted to A2A")
 	default:
 		out := a2aprotocol.NewRawPart(src.Bytes())
 		out.MediaType = src.MediaType()

--- a/core/agent/bindings/bridge_inference.go
+++ b/core/agent/bindings/bridge_inference.go
@@ -8,6 +8,7 @@ import (
 	"github.com/GizClaw/flowcraft/core/errdefs"
 	"github.com/GizClaw/flowcraft/core/inference"
 	"github.com/GizClaw/flowcraft/core/inference/route"
+	"github.com/GizClaw/flowcraft/core/message/media"
 )
 
 // Extensions cross the boundary through host-registered decoders:
@@ -74,6 +75,32 @@ func WithExtensionDecoder(provider, id string, decoder inference.ExtensionDecode
 //   - explainEmbed(request) / routeExplainEmbed(request): the Embed
 //     twins of explain/routeExplain; routeExplainEmbed returns
 //     {explanation, decision, limits} for the selected embed model.
+//
+//   - transcribe(request) / routeTranscribe(request): the speech
+//     recognition twins of generate/route — exact model (model key
+//     required, audio source in the canonical request) vs router
+//     selection (no model key, response gains "trace").
+//
+//   - explainTranscribe(request) / routeExplainTranscribe(request):
+//     the transcription twins of explain/routeExplain;
+//     routeExplainTranscribe returns {explanation, decision, limits}.
+//
+//   - transcribeSession(request) / routeTranscribeSession(request):
+//     duplex speech-recognition sessions. Both return a session handle:
+//
+//     var s = inference.transcribeSession(req)   // input_format + model
+//     s.send({data: <base64>, sequence: 1})      // media.AudioChunk
+//     var ev
+//     while ((ev = s.next()) !== null) { ... }   // partial/final events
+//     var resp = s.result()                      // TranscriptionResponse
+//     s.interrupt()                              // barge-in (optional)
+//     s.close()
+//
+//     send() feeds audio chunks; next() projects TranscriptionSessionEvent
+//     wire JSON and returns null at EOF; result() yields the accumulated
+//     TranscriptionResponse; interrupt() terminates the session abnormally;
+//     close() exits early. routeTranscribeSession attaches "trace" to the
+//     result object, mirroring routeTranscribe.
 //
 //   - explainStream(request) / routeExplainStream(request): the
 //     Generate-stream twins of explain/routeExplain — local stream
@@ -350,6 +377,129 @@ func NewInferenceBridge(assembly *inference.Assembly, router *route.Router, opts
 					"inference.routeExplainEmbed",
 				)
 			},
+			"transcribe": func(raw any) (any, error) {
+				if assembly == nil {
+					return nil, errdefs.NotAvailablef("inference.transcribe: no assembly wired")
+				}
+				ref, req, extensions, err := parseInferenceModelCall[inference.TranscriptionRequest](
+					raw,
+					cfg.extensions,
+					"inference.transcribe",
+				)
+				if err != nil {
+					return nil, err
+				}
+				req.Extensions = extensions
+				resp, err := assembly.Transcribe(ctx, ref, req)
+				if err != nil {
+					return nil, err
+				}
+				return toScriptJSON(resp, "inference.transcribe response")
+			},
+			"routeTranscribe": func(raw any) (any, error) {
+				if router == nil {
+					return nil, errdefs.NotAvailablef("inference.routeTranscribe: no router wired")
+				}
+				req, extensions, err := parseInferenceRouteCall[inference.TranscriptionRequest](
+					raw,
+					cfg.extensions,
+					"inference.routeTranscribe",
+				)
+				if err != nil {
+					return nil, err
+				}
+				req.Extensions = extensions
+				resp, trace, err := router.Transcribe(ctx, req)
+				if err != nil {
+					return nil, err
+				}
+				out, err := toScriptJSON(resp, "inference.routeTranscribe response")
+				if err != nil {
+					return nil, err
+				}
+				return attachTrace(out, trace, "inference.routeTranscribe")
+			},
+			"explainTranscribe": func(raw any) (any, error) {
+				if assembly == nil {
+					return nil, errdefs.NotAvailablef("inference.explainTranscribe: no assembly wired")
+				}
+				ref, req, extensions, err := parseInferenceModelCall[inference.TranscriptionRequest](
+					raw,
+					cfg.extensions,
+					"inference.explainTranscribe",
+				)
+				if err != nil {
+					return nil, err
+				}
+				req.Extensions = extensions
+				explanation, err := assembly.ExplainTranscribe(ctx, ref, req)
+				if err != nil {
+					return nil, err
+				}
+				return toScriptJSON(explanation, "inference.explainTranscribe response")
+			},
+			"routeExplainTranscribe": func(raw any) (any, error) {
+				if router == nil {
+					return nil, errdefs.NotAvailablef("inference.routeExplainTranscribe: no router wired")
+				}
+				req, extensions, err := parseInferenceRouteCall[inference.TranscriptionRequest](
+					raw,
+					cfg.extensions,
+					"inference.routeExplainTranscribe",
+				)
+				if err != nil {
+					return nil, err
+				}
+				req.Extensions = extensions
+				explanation, decision, err := router.ExplainTranscribe(ctx, req)
+				if err != nil {
+					return nil, err
+				}
+				return routeExplainResult(
+					router,
+					explanation,
+					decision,
+					"inference.routeExplainTranscribe",
+				)
+			},
+			"transcribeSession": func(raw any) (any, error) {
+				if assembly == nil {
+					return nil, errdefs.NotAvailablef("inference.transcribeSession: no assembly wired")
+				}
+				ref, req, extensions, err := parseInferenceModelCall[inference.TranscriptionSessionRequest](
+					raw,
+					cfg.extensions,
+					"inference.transcribeSession",
+				)
+				if err != nil {
+					return nil, err
+				}
+				req.Extensions = extensions
+				session, err := assembly.TranscribeSession(ctx, ref, req)
+				if err != nil {
+					return nil, err
+				}
+				return newTranscriptionSessionHandle(ctx, session, nil), nil
+			},
+			"routeTranscribeSession": func(raw any) (any, error) {
+				if router == nil {
+					return nil, errdefs.NotAvailablef("inference.routeTranscribeSession: no router wired")
+				}
+				req, extensions, err := parseInferenceRouteCall[inference.TranscriptionSessionRequest](
+					raw,
+					cfg.extensions,
+					"inference.routeTranscribeSession",
+				)
+				if err != nil {
+					return nil, err
+				}
+				req.Extensions = extensions
+				session, trace, err := router.TranscribeSession(ctx, req)
+				if err != nil {
+					return nil, err
+				}
+				return newTranscriptionSessionHandle(ctx, session, &trace), nil
+			},
 			"stream": func(raw any) (any, error) {
 				if assembly == nil {
 					return nil, errdefs.NotAvailablef("inference.stream: no assembly wired")
@@ -458,32 +608,158 @@ func newStreamHandle(ctx context.Context, stream inference.GenerateStream, trace
 	}
 }
 
+// newTranscriptionSessionHandle adapts an inference.TranscriptionSession
+// into the script-facing handle:
+//   - send(chunk) -> one media.AudioChunk wire JSON ({data, sequence});
+//     fails once the session has drained or terminated
+//   - next() -> one TranscriptionSessionEvent wire JSON, or null once the
+//     session ends normally (EOF) or fails; errors surface as script
+//     exceptions and terminate the iteration
+//   - result() -> the driver-accumulated TranscriptionResponse (the exact
+//     shape transcribe/routeTranscribe return), valid only after next()
+//     returned null so partial sessions cannot be mistaken for complete ones
+//   - interrupt() -> terminates the session abnormally (barge-in); the
+//     interruption surfaces from the next next()/result() call
+//   - close() -> idempotent early exit
+//
+// trace, when non-nil (router-opened sessions), is attached to the result
+// object under "trace", mirroring inference.routeTranscribe.
+func newTranscriptionSessionHandle(
+	ctx context.Context,
+	session inference.TranscriptionSession,
+	trace *route.Trace,
+) map[string]any {
+	done := false
+	closed := false
+	return map[string]any{
+		"send": func(chunk any) error {
+			if done {
+				return errdefs.Validationf(
+					"inference.transcribeSession: session ended",
+				)
+			}
+			var audio media.AudioChunk
+			if err := decodeStrictJSON(
+				chunk,
+				&audio,
+				"inference.transcribeSession.send",
+			); err != nil {
+				return err
+			}
+			return session.Send(ctx, audio)
+		},
+		"next": func() (any, error) {
+			if done {
+				return nil, nil
+			}
+			event, err := session.Next(ctx)
+			if err != nil {
+				done = true
+				if errors.Is(err, io.EOF) {
+					return nil, nil
+				}
+				return nil, err
+			}
+			return toScriptJSON(event, "inference.transcribeSession event")
+		},
+		"result": func() (any, error) {
+			if !done {
+				return nil, errdefs.Validationf(
+					"inference.transcribeSession.result: drain the session (next() -> null) first",
+				)
+			}
+			resp, err := session.Result()
+			if err != nil {
+				return nil, err
+			}
+			out, err := toScriptJSON(resp, "inference.transcribeSession result")
+			if err != nil {
+				return nil, err
+			}
+			obj, ok := out.(map[string]any)
+			if !ok {
+				return nil, errdefs.Internalf(
+					"inference.transcribeSession: result projection is %T, want object",
+					out,
+				)
+			}
+			if trace != nil {
+				traceJSON, err := toScriptJSON(
+					*trace,
+					"inference.transcribeSession trace",
+				)
+				if err != nil {
+					return nil, err
+				}
+				obj["trace"] = traceJSON
+			}
+			return obj, nil
+		},
+		"interrupt": func() error {
+			return session.Interrupt()
+		},
+		"close": func() error {
+			done = true
+			if closed {
+				return nil
+			}
+			closed = true
+			return session.Close()
+		},
+	}
+}
+
 // parseInferenceGenerateCall splits the script-facing generate-family
 // request into the model target and the canonical GenerateRequest.
-// "model" is a bridge-level key (the wire request has no model field —
-// routing ownership lives with the caller, not the payload), so it is
-// stripped before the strict decode; "extensions" is stripped the same
-// way and resolved through the host-registered decoders.
 func parseInferenceGenerateCall(
 	raw any,
 	decoders map[string]inference.ExtensionDecoder,
 	field string,
 ) (inference.ModelRef, inference.GenerateRequest, error) {
+	ref, req, extensions, err := parseInferenceModelCall[inference.GenerateRequest](
+		raw,
+		decoders,
+		field,
+	)
+	if err != nil {
+		return ref, req, err
+	}
+	req.Extensions = extensions
+	return ref, req, nil
+}
+
+// parseInferenceModelCall splits a script-facing model-addressed request
+// into the model target and the canonical request. "model" is a
+// bridge-level key (the wire request has no model field — routing
+// ownership lives with the caller, not the payload), so it is stripped
+// before the strict decode; "extensions" is stripped the same way and
+// resolved through the host-registered decoders. The caller assigns the
+// resolved extensions to req.Extensions (the wire structs keep the field
+// JSON-hidden).
+func parseInferenceModelCall[T any](
+	raw any,
+	decoders map[string]inference.ExtensionDecoder,
+	field string,
+) (inference.ModelRef, T, inference.Extensions, error) {
 	var ref inference.ModelRef
-	var req inference.GenerateRequest
+	var req T
 	obj, ok := raw.(map[string]any)
 	if !ok {
-		return ref, req, errdefs.Validationf("%s: expected an object, got %T", field, raw)
+		return ref, req, nil, errdefs.Validationf(
+			"%s: expected an object, got %T",
+			field,
+			raw,
+		)
 	}
 	modelRaw, ok := obj["model"]
 	if !ok || modelRaw == nil {
-		return ref, req, errdefs.Validationf(
+		return ref, req, nil, errdefs.Validationf(
 			"%s: model is required (use the route entry point for router-chosen targets)",
 			field,
 		)
 	}
 	if err := decodeStrictJSON(modelRaw, &ref, field+".model"); err != nil {
-		return ref, req, err
+		return ref, req, nil, err
 	}
 	rest := make(map[string]any, len(obj)-1)
 	for k, v := range obj {
@@ -493,44 +769,24 @@ func parseInferenceGenerateCall(
 	}
 	extensions, err := decodeRequestRest(rest, &req, decoders, field)
 	if err != nil {
-		return ref, req, err
+		return ref, req, nil, err
 	}
-	req.Extensions = extensions
-	return ref, req, nil
+	return ref, req, extensions, nil
 }
 
 // parseInferenceEmbedCall splits the script-facing embed-family
 // request into the model target and the canonical EmbedRequest. It
-// mirrors parseInferenceGenerateCall: "model" and "extensions" are
-// bridge-level keys stripped before the strict decode.
+// mirrors parseInferenceGenerateCall through the shared generic parser.
 func parseInferenceEmbedCall(
 	raw any,
 	decoders map[string]inference.ExtensionDecoder,
 	field string,
 ) (inference.ModelRef, inference.EmbedRequest, error) {
-	var ref inference.ModelRef
-	var req inference.EmbedRequest
-	obj, ok := raw.(map[string]any)
-	if !ok {
-		return ref, req, errdefs.Validationf("%s: expected an object, got %T", field, raw)
-	}
-	modelRaw, ok := obj["model"]
-	if !ok || modelRaw == nil {
-		return ref, req, errdefs.Validationf(
-			"%s: model is required (use the route entry point for router-chosen targets)",
-			field,
-		)
-	}
-	if err := decodeStrictJSON(modelRaw, &ref, field+".model"); err != nil {
-		return ref, req, err
-	}
-	rest := make(map[string]any, len(obj)-1)
-	for k, v := range obj {
-		if k != "model" {
-			rest[k] = v
-		}
-	}
-	extensions, err := decodeRequestRest(rest, &req, decoders, field)
+	ref, req, extensions, err := parseInferenceModelCall[inference.EmbedRequest](
+		raw,
+		decoders,
+		field,
+	)
 	if err != nil {
 		return ref, req, err
 	}

--- a/core/agent/bindings/bridge_inference_test.go
+++ b/core/agent/bindings/bridge_inference_test.go
@@ -39,21 +39,39 @@ func fakeEmbedRouter(t *testing.T, runtime *inference.Assembly) *route.Router {
 	return router
 }
 
+func fakeTranscribeRouter(t *testing.T, runtime *inference.Assembly) *route.Router {
+	t.Helper()
+	router, err := route.New(runtime, route.Selectors{
+		Transcribe:        inferencetest.StaticTranscribeSelector(inferencetest.DefaultFakeTranscribeModel),
+		TranscribeSession: inferencetest.StaticTranscribeSessionSelector(inferencetest.DefaultFakeTranscribeModel),
+	})
+	if err != nil {
+		t.Fatalf("route.New: %v", err)
+	}
+	return router
+}
+
 type inferenceAPI struct {
-	generate           func(raw any) (any, error)
-	route              func(raw any) (any, error)
-	explain            func(raw any) (any, error)
-	routeExplain       func(raw any) (any, error)
-	models             func() (any, error)
-	inspect            func(raw any) (any, error)
-	explainStream      func(raw any) (any, error)
-	routeExplainStream func(raw any) (any, error)
-	embed              func(raw any) (any, error)
-	routeEmbed         func(raw any) (any, error)
-	explainEmbed       func(raw any) (any, error)
-	routeExplainEmbed  func(raw any) (any, error)
-	stream             func(raw any) (any, error)
-	routeStream        func(raw any) (any, error)
+	generate               func(raw any) (any, error)
+	route                  func(raw any) (any, error)
+	explain                func(raw any) (any, error)
+	routeExplain           func(raw any) (any, error)
+	models                 func() (any, error)
+	inspect                func(raw any) (any, error)
+	explainStream          func(raw any) (any, error)
+	routeExplainStream     func(raw any) (any, error)
+	embed                  func(raw any) (any, error)
+	routeEmbed             func(raw any) (any, error)
+	explainEmbed           func(raw any) (any, error)
+	routeExplainEmbed      func(raw any) (any, error)
+	stream                 func(raw any) (any, error)
+	routeStream            func(raw any) (any, error)
+	transcribe             func(raw any) (any, error)
+	routeTranscribe        func(raw any) (any, error)
+	explainTranscribe      func(raw any) (any, error)
+	routeExplainTranscribe func(raw any) (any, error)
+	transcribeSession      func(raw any) (any, error)
+	routeTranscribeSession func(raw any) (any, error)
 }
 
 func newInferenceAPI(t *testing.T, runtime *inference.Assembly, router *route.Router, opts ...InferenceBridgeOption) inferenceAPI {
@@ -122,21 +140,51 @@ func newInferenceAPI(t *testing.T, runtime *inference.Assembly, router *route.Ro
 	if !ok {
 		t.Fatalf("inference.routeStream = %T", m["routeStream"])
 	}
+	transcribeFn, ok := m["transcribe"].(func(any) (any, error))
+	if !ok {
+		t.Fatalf("inference.transcribe = %T", m["transcribe"])
+	}
+	routeTranscribeFn, ok := m["routeTranscribe"].(func(any) (any, error))
+	if !ok {
+		t.Fatalf("inference.routeTranscribe = %T", m["routeTranscribe"])
+	}
+	explainTranscribeFn, ok := m["explainTranscribe"].(func(any) (any, error))
+	if !ok {
+		t.Fatalf("inference.explainTranscribe = %T", m["explainTranscribe"])
+	}
+	routeExplainTranscribeFn, ok := m["routeExplainTranscribe"].(func(any) (any, error))
+	if !ok {
+		t.Fatalf("inference.routeExplainTranscribe = %T", m["routeExplainTranscribe"])
+	}
+	transcribeSessionFn, ok := m["transcribeSession"].(func(any) (any, error))
+	if !ok {
+		t.Fatalf("inference.transcribeSession = %T", m["transcribeSession"])
+	}
+	routeTranscribeSessionFn, ok := m["routeTranscribeSession"].(func(any) (any, error))
+	if !ok {
+		t.Fatalf("inference.routeTranscribeSession = %T", m["routeTranscribeSession"])
+	}
 	return inferenceAPI{
-		generate:           generate,
-		route:              routeFn,
-		explain:            explainFn,
-		routeExplain:       routeExplainFn,
-		models:             modelsFn,
-		inspect:            inspectFn,
-		explainStream:      explainStreamFn,
-		routeExplainStream: routeExplainStreamFn,
-		embed:              embedFn,
-		routeEmbed:         routeEmbedFn,
-		explainEmbed:       explainEmbedFn,
-		routeExplainEmbed:  routeExplainEmbedFn,
-		stream:             streamFn,
-		routeStream:        routeStreamFn,
+		generate:               generate,
+		route:                  routeFn,
+		explain:                explainFn,
+		routeExplain:           routeExplainFn,
+		models:                 modelsFn,
+		inspect:                inspectFn,
+		explainStream:          explainStreamFn,
+		routeExplainStream:     routeExplainStreamFn,
+		embed:                  embedFn,
+		routeEmbed:             routeEmbedFn,
+		explainEmbed:           explainEmbedFn,
+		routeExplainEmbed:      routeExplainEmbedFn,
+		stream:                 streamFn,
+		routeStream:            routeStreamFn,
+		transcribe:             transcribeFn,
+		routeTranscribe:        routeTranscribeFn,
+		explainTranscribe:      explainTranscribeFn,
+		routeExplainTranscribe: routeExplainTranscribeFn,
+		transcribeSession:      transcribeSessionFn,
+		routeTranscribeSession: routeTranscribeSessionFn,
 	}
 }
 
@@ -168,10 +216,79 @@ func openStream(t *testing.T, raw any) streamHandle {
 	return streamHandle{next: next, result: result, close: closeFn}
 }
 
+// sessionHandle mirrors the script-facing transcription session handle.
+type sessionHandle struct {
+	send      func(any) error
+	next      func() (any, error)
+	result    func() (any, error)
+	interrupt func() error
+	close     func() error
+}
+
+func openSession(t *testing.T, raw any) sessionHandle {
+	t.Helper()
+	m, ok := raw.(map[string]any)
+	if !ok {
+		t.Fatalf("session handle = %T, want map[string]any", raw)
+	}
+	send, ok := m["send"].(func(any) error)
+	if !ok {
+		t.Fatalf("session.send = %T", m["send"])
+	}
+	next, ok := m["next"].(func() (any, error))
+	if !ok {
+		t.Fatalf("session.next = %T", m["next"])
+	}
+	result, ok := m["result"].(func() (any, error))
+	if !ok {
+		t.Fatalf("session.result = %T", m["result"])
+	}
+	interrupt, ok := m["interrupt"].(func() error)
+	if !ok {
+		t.Fatalf("session.interrupt = %T", m["interrupt"])
+	}
+	closeFn, ok := m["close"].(func() error)
+	if !ok {
+		t.Fatalf("session.close = %T", m["close"])
+	}
+	return sessionHandle{
+		send:      send,
+		next:      next,
+		result:    result,
+		interrupt: interrupt,
+		close:     closeFn,
+	}
+}
+
 func fakeModelJSON() map[string]any {
 	return map[string]any{
 		"id":      map[string]any{"provider": "fake", "name": "echo"},
 		"profile": "default",
+	}
+}
+
+func fakeTranscribeModelJSON() map[string]any {
+	return map[string]any{
+		"id":      map[string]any{"provider": "fake", "name": "transcribe"},
+		"profile": "default",
+	}
+}
+
+func transcribeAudioJSON() map[string]any {
+	return map[string]any{
+		"kind":       "inline",
+		"data":       []byte{1, 2, 3, 4},
+		"media_type": "audio/wav",
+	}
+}
+
+func transcribeSessionJSON() map[string]any {
+	return map[string]any{
+		"input_format": map[string]any{
+			"encoding":       "pcm16",
+			"sample_rate_hz": 16000,
+			"channels":       1,
+		},
 	}
 }
 
@@ -888,6 +1005,349 @@ func TestInferenceBridge_Extensions_StrictFields(t *testing.T) {
 	})
 	if err == nil || !errdefs.IsValidation(err) {
 		t.Fatalf("typo fields error = %v, want validation-classified", err)
+	}
+}
+
+func TestInferenceBridge_Transcribe_RoundTrip(t *testing.T) {
+	fake := &inferencetest.TranscriptionFake{}
+	api := newInferenceAPI(t, fake.Assembly(t), nil)
+
+	out, err := api.transcribe(map[string]any{
+		"model": fakeTranscribeModelJSON(),
+		"audio": transcribeAudioJSON(),
+	})
+	if err != nil {
+		t.Fatalf("transcribe: %v", err)
+	}
+	resp, ok := out.(map[string]any)
+	if !ok {
+		t.Fatalf("transcribe response = %T, want object", out)
+	}
+	if resp["text"] != "ok" {
+		t.Fatalf("text = %v, want %q", resp["text"], "ok")
+	}
+}
+
+func TestInferenceBridge_Transcribe_NoRuntime(t *testing.T) {
+	api := newInferenceAPI(t, nil, nil)
+	_, err := api.transcribe(map[string]any{
+		"model": fakeTranscribeModelJSON(),
+		"audio": transcribeAudioJSON(),
+	})
+	if err == nil || !errdefs.IsNotAvailable(err) {
+		t.Fatalf("unwired transcribe error = %v, want NotAvailable", err)
+	}
+}
+
+func TestInferenceBridge_RouteTranscribe_RoundTrip(t *testing.T) {
+	fake := &inferencetest.TranscriptionFake{}
+	runtime := fake.Assembly(t)
+	api := newInferenceAPI(t, runtime, fakeTranscribeRouter(t, runtime))
+
+	out, err := api.routeTranscribe(map[string]any{
+		"audio": transcribeAudioJSON(),
+	})
+	if err != nil {
+		t.Fatalf("routeTranscribe: %v", err)
+	}
+	resp, ok := out.(map[string]any)
+	if !ok {
+		t.Fatalf("routeTranscribe response = %T, want object", out)
+	}
+	trace, ok := resp["trace"].(map[string]any)
+	if !ok {
+		t.Fatalf("trace missing or %T, want object", resp["trace"])
+	}
+	executed, ok := trace["executed"].(map[string]any)
+	if !ok {
+		t.Fatalf("trace.executed = %T, want object", trace["executed"])
+	}
+	id, ok := executed["id"].(map[string]any)
+	if !ok || id["provider"] != "fake" || id["name"] != "transcribe" {
+		t.Fatalf("trace.executed.id = %v, want fake/transcribe", executed["id"])
+	}
+}
+
+func TestInferenceBridge_RouteTranscribe_RejectsModelKey(t *testing.T) {
+	fake := &inferencetest.TranscriptionFake{}
+	runtime := fake.Assembly(t)
+	api := newInferenceAPI(t, runtime, fakeTranscribeRouter(t, runtime))
+
+	_, err := api.routeTranscribe(map[string]any{
+		"model": fakeTranscribeModelJSON(),
+		"audio": transcribeAudioJSON(),
+	})
+	if err == nil || !errdefs.IsValidation(err) {
+		t.Fatalf("routeTranscribe with model key error = %v, want validation-classified", err)
+	}
+}
+
+func TestInferenceBridge_Transcribe_Extensions(t *testing.T) {
+	fake := &inferencetest.TranscriptionFake{}
+	api := newInferenceAPI(t, fake.Assembly(t), nil,
+		WithExtensionDecoder("fake", "generate_options", testExtensionDecoder()))
+
+	_, err := api.transcribe(map[string]any{
+		"model": fakeTranscribeModelJSON(),
+		"audio": transcribeAudioJSON(),
+		"extensions": []any{map[string]any{
+			"provider": "fake",
+			"id":       "generate_options",
+			"fields":   map[string]any{"cache_key": "sess-1"},
+		}},
+	})
+	if err != nil {
+		t.Fatalf("transcribe with extensions: %v", err)
+	}
+	reqs := fake.Requests()
+	if len(reqs) != 1 || len(reqs[0].Extensions) != 1 {
+		t.Fatalf("provider saw %+v, want one extension", reqs)
+	}
+	ext, ok := reqs[0].Extensions[0].(testExtension)
+	if !ok || ext.CacheKey != "sess-1" {
+		t.Fatalf("extension = %+v (%T), want cache_key sess-1", reqs[0].Extensions[0], reqs[0].Extensions[0])
+	}
+}
+
+func TestInferenceBridge_RouteTranscribe_Extensions(t *testing.T) {
+	fake := &inferencetest.TranscriptionFake{}
+	runtime := fake.Assembly(t)
+	api := newInferenceAPI(t, runtime, fakeTranscribeRouter(t, runtime),
+		WithExtensionDecoder("fake", "generate_options", testExtensionDecoder()))
+
+	_, err := api.routeTranscribe(map[string]any{
+		"audio": transcribeAudioJSON(),
+		"extensions": []any{map[string]any{
+			"provider": "fake",
+			"id":       "generate_options",
+			"fields":   map[string]any{"cache_key": "sess-2"},
+		}},
+	})
+	if err != nil {
+		t.Fatalf("routeTranscribe with extensions: %v", err)
+	}
+	reqs := fake.Requests()
+	if len(reqs) != 1 || len(reqs[0].Extensions) != 1 {
+		t.Fatalf("router forwarded %+v, want one extension", reqs)
+	}
+	if ext, ok := reqs[0].Extensions[0].(testExtension); !ok || ext.CacheKey != "sess-2" {
+		t.Fatalf("extension = %+v (%T), want cache_key sess-2", reqs[0].Extensions[0], reqs[0].Extensions[0])
+	}
+}
+
+func TestInferenceBridge_TranscribeSession_Extensions(t *testing.T) {
+	fake := &inferencetest.TranscriptionFake{}
+	api := newInferenceAPI(t, fake.Assembly(t), nil,
+		WithExtensionDecoder("fake", "generate_options", testExtensionDecoder()))
+
+	_, err := api.transcribeSession(map[string]any{
+		"model":        fakeTranscribeModelJSON(),
+		"input_format": transcribeSessionJSON()["input_format"],
+		"extensions": []any{map[string]any{
+			"provider": "fake",
+			"id":       "generate_options",
+			"fields":   map[string]any{"cache_key": "sess-3"},
+		}},
+	})
+	if err != nil {
+		t.Fatalf("transcribeSession with extensions: %v", err)
+	}
+	reqs := fake.SessionRequests()
+	if len(reqs) != 1 || len(reqs[0].Extensions) != 1 {
+		t.Fatalf("provider saw %+v, want one session extension", reqs)
+	}
+	if ext, ok := reqs[0].Extensions[0].(testExtension); !ok || ext.CacheKey != "sess-3" {
+		t.Fatalf("extension = %+v (%T), want cache_key sess-3", reqs[0].Extensions[0], reqs[0].Extensions[0])
+	}
+}
+
+func TestInferenceBridge_RouteTranscribeSession_Extensions(t *testing.T) {
+	fake := &inferencetest.TranscriptionFake{}
+	runtime := fake.Assembly(t)
+	api := newInferenceAPI(t, runtime, fakeTranscribeRouter(t, runtime),
+		WithExtensionDecoder("fake", "generate_options", testExtensionDecoder()))
+
+	raw := transcribeSessionJSON()
+	raw["extensions"] = []any{map[string]any{
+		"provider": "fake",
+		"id":       "generate_options",
+		"fields":   map[string]any{"cache_key": "sess-4"},
+	}}
+	_, err := api.routeTranscribeSession(raw)
+	if err != nil {
+		t.Fatalf("routeTranscribeSession with extensions: %v", err)
+	}
+	// Route session open compiles twice: the Explain preflight and the
+	// actual open. Both must carry the extension.
+	reqs := fake.SessionRequests()
+	if len(reqs) != 2 {
+		t.Fatalf("router forwarded %d session requests, want 2", len(reqs))
+	}
+	for _, req := range reqs {
+		if len(req.Extensions) != 1 {
+			t.Fatalf("session request extensions = %+v, want one", req.Extensions)
+		}
+		if ext, ok := req.Extensions[0].(testExtension); !ok || ext.CacheKey != "sess-4" {
+			t.Fatalf("extension = %+v (%T), want cache_key sess-4",
+				req.Extensions[0], req.Extensions[0])
+		}
+	}
+}
+
+func TestInferenceBridge_ExplainTranscribe_RoundTrip(t *testing.T) {
+	fake := &inferencetest.TranscriptionFake{}
+	api := newInferenceAPI(t, fake.Assembly(t), nil)
+
+	out, err := api.explainTranscribe(map[string]any{
+		"model": fakeTranscribeModelJSON(),
+		"audio": transcribeAudioJSON(),
+	})
+	if err != nil {
+		t.Fatalf("explainTranscribe: %v", err)
+	}
+	explanation, ok := out.(map[string]any)
+	if !ok {
+		t.Fatalf("explanation = %T, want object", out)
+	}
+	if explanation["Operation"] != string(inference.OperationTranscription) {
+		t.Fatalf("explanation.Operation = %v, want %q",
+			explanation["Operation"], inference.OperationTranscription)
+	}
+}
+
+func TestInferenceBridge_RouteExplainTranscribe_RoundTrip(t *testing.T) {
+	fake := &inferencetest.TranscriptionFake{}
+	runtime := fake.Assembly(t)
+	api := newInferenceAPI(t, runtime, fakeTranscribeRouter(t, runtime))
+
+	out, err := api.routeExplainTranscribe(map[string]any{
+		"audio": transcribeAudioJSON(),
+	})
+	if err != nil {
+		t.Fatalf("routeExplainTranscribe: %v", err)
+	}
+	resp, ok := out.(map[string]any)
+	if !ok {
+		t.Fatalf("routeExplainTranscribe response = %T, want object", out)
+	}
+	if _, ok := resp["explanation"].(map[string]any); !ok {
+		t.Fatalf("explanation = %T, want object", resp["explanation"])
+	}
+	if _, ok := resp["decision"].(map[string]any); !ok {
+		t.Fatalf("decision = %T, want object", resp["decision"])
+	}
+	if _, ok := resp["limits"].(map[string]any); !ok {
+		t.Fatalf("limits = %T, want object", resp["limits"])
+	}
+}
+
+func TestInferenceBridge_TranscribeSession_RoundTrip(t *testing.T) {
+	fake := &inferencetest.TranscriptionFake{}
+	api := newInferenceAPI(t, fake.Assembly(t), nil)
+
+	out, err := api.transcribeSession(map[string]any{
+		"model":        fakeTranscribeModelJSON(),
+		"input_format": transcribeSessionJSON()["input_format"],
+	})
+	if err != nil {
+		t.Fatalf("transcribeSession: %v", err)
+	}
+	handle := openSession(t, out)
+	if err := handle.send(map[string]any{
+		"data":     []byte{0, 0},
+		"sequence": 1,
+	}); err != nil {
+		t.Fatalf("send: %v", err)
+	}
+	for {
+		event, err := handle.next()
+		if err != nil {
+			t.Fatalf("next: %v", err)
+		}
+		if event == nil {
+			break
+		}
+	}
+	result, err := handle.result()
+	if err != nil {
+		t.Fatalf("result: %v", err)
+	}
+	resp, ok := result.(map[string]any)
+	if !ok {
+		t.Fatalf("result = %T, want object", result)
+	}
+	if resp["text"] != "ok" {
+		t.Fatalf("text = %v, want %q", resp["text"], "ok")
+	}
+	if err := handle.close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+}
+
+func TestInferenceBridge_RouteTranscribeSession_RoundTrip(t *testing.T) {
+	fake := &inferencetest.TranscriptionFake{}
+	runtime := fake.Assembly(t)
+	api := newInferenceAPI(t, runtime, fakeTranscribeRouter(t, runtime))
+
+	out, err := api.routeTranscribeSession(transcribeSessionJSON())
+	if err != nil {
+		t.Fatalf("routeTranscribeSession: %v", err)
+	}
+	handle := openSession(t, out)
+	if err := handle.send(map[string]any{"data": []byte{0, 0}}); err != nil {
+		t.Fatalf("send: %v", err)
+	}
+	for {
+		event, err := handle.next()
+		if err != nil {
+			t.Fatalf("next: %v", err)
+		}
+		if event == nil {
+			break
+		}
+	}
+	result, err := handle.result()
+	if err != nil {
+		t.Fatalf("result: %v", err)
+	}
+	resp, ok := result.(map[string]any)
+	if !ok {
+		t.Fatalf("result = %T, want object", result)
+	}
+	if _, ok := resp["trace"].(map[string]any); !ok {
+		t.Fatalf("trace missing or %T, want object", resp["trace"])
+	}
+	if err := handle.close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+}
+
+func TestInferenceBridge_TranscribeSession_Interrupt(t *testing.T) {
+	fake := &inferencetest.TranscriptionFake{}
+	api := newInferenceAPI(t, fake.Assembly(t), nil)
+
+	out, err := api.transcribeSession(map[string]any{
+		"model":        fakeTranscribeModelJSON(),
+		"input_format": transcribeSessionJSON()["input_format"],
+	})
+	if err != nil {
+		t.Fatalf("transcribeSession: %v", err)
+	}
+	handle := openSession(t, out)
+	if err := handle.send(map[string]any{"data": []byte{0, 0}}); err != nil {
+		t.Fatalf("send: %v", err)
+	}
+	if err := handle.interrupt(); err != nil {
+		t.Fatalf("interrupt: %v", err)
+	}
+	if _, err := handle.next(); err == nil {
+		t.Fatal("next after interrupt succeeded, want interruption error")
+	}
+	if _, err := handle.result(); err == nil {
+		t.Fatal("result after interrupt succeeded, want interruption error")
+	}
+	if err := handle.close(); err != nil {
+		t.Fatalf("close: %v", err)
 	}
 }
 

--- a/core/agent/bindings/doc.go
+++ b/core/agent/bindings/doc.go
@@ -33,14 +33,15 @@
 //     call ids, definitions for wire-ready tool declarations
 //     (see NewToolBridge)
 //
-//   - inference: single-shot LLM generation — generate resolves an
-//     explicit model through the inference.Runtime, route defers
-//     target selection to a route.Router and adds a routing trace;
-//     stream/routeStream are the pull-based iterator twins whose
-//     accumulated result matches the unary shape. Requests and
-//     responses are the canonical GenerateRequest / GenerateResponse
-//     wire JSON, and multi-turn tool loops are orchestrated in
-//     script-land (see NewInferenceBridge)
+//   - inference: canonical inference operations — generate/embed/
+//     transcribe resolve an explicit model through the
+//     inference.Assembly, route variants defer target selection to a
+//     route.Router and add a routing trace; stream/routeStream are the
+//     pull-based iterator twins whose accumulated result matches the
+//     unary shape, and transcribeSession/routeTranscribeSession open a
+//     duplex session handle (send/next/result/interrupt/close). Requests
+//     and responses are the canonical wire JSON, and multi-turn tool
+//     loops are orchestrated in script-land (see NewInferenceBridge)
 //
 //   - runtime: named sub-script execution via runtime.execScript,
 //     with nested-exec capability probing (see NewRuntimeBridge)

--- a/core/agent/execute.go
+++ b/core/agent/execute.go
@@ -284,6 +284,21 @@ func Execute(
 		res.Err = ctxErr
 		res.Committed = false
 	}
+	// History forbids stream-backed media sources: a message that is about
+	// to become conversation history materializes each stream into the
+	// existing inline-byte parts before it is stored or handed to
+	// observers. This runs exactly once, on the final committed result —
+	// never per attempt, so a revise retry still sees the live stream.
+	if res.Committed {
+		if err := materializeHistory(ctx, res.LastBoard); err != nil {
+			res.Committed = false
+			res.State["finalize_reason"] = "history_materialize_failed"
+			if obs != nil {
+				obs.OnRunEnd(ctx, id, res)
+			}
+			return res, fmt.Errorf("agent: materialize history: %w", err)
+		}
+	}
 	if res.Committed && len(rc.committers) > 0 {
 		commitRes := res
 		if rc.commitViewProvider != nil {
@@ -303,6 +318,14 @@ func Execute(
 					obs.OnRunEnd(ctx, id, res)
 				}
 				return res, errdefs.Validationf("agent: CommitViewProvider returned nil board")
+			}
+			if err := materializeHistory(ctx, view.LastBoard); err != nil {
+				res.Committed = false
+				res.State["finalize_reason"] = "commit_view_failed"
+				if obs != nil {
+					obs.OnRunEnd(ctx, id, res)
+				}
+				return res, fmt.Errorf("agent: materialize commit view: %w", err)
 			}
 			projected := *res
 			// The commit projection is a self-contained board produced by
@@ -335,6 +358,35 @@ func materializeResult(res *Result, board *Board, artifactChannels []string, see
 	res.LastBoard = board
 	res.Messages = newAssistantMessages(board, seedLen)
 	res.Artifacts = collectArtifacts(board, artifactChannels)
+}
+
+// materializeHistory converts every stream-backed media source on the board
+// into its durable part form (see message.MaterializeContent) so no live
+// stream handle ever becomes conversation history. Boards without stream
+// sources are left untouched.
+func materializeHistory(ctx context.Context, board *Board) error {
+	if board == nil {
+		return nil
+	}
+	channels := board.ChannelsCopy()
+	for name, msgs := range channels {
+		changed := false
+		for i := range msgs {
+			if !message.HasStreamSource(msgs[i].Content) {
+				continue
+			}
+			content, err := message.MaterializeContent(ctx, msgs[i].Content)
+			if err != nil {
+				return fmt.Errorf("channel %q: %w", name, err)
+			}
+			msgs[i].Content = content
+			changed = true
+		}
+		if changed {
+			board.SetChannel(name, msgs)
+		}
+	}
+	return nil
 }
 
 // itoa is a zero-alloc small-int formatter used for the attempt

--- a/core/agent/execute_test.go
+++ b/core/agent/execute_test.go
@@ -2,6 +2,7 @@ package agent_test
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"strings"
 	"sync"
@@ -13,6 +14,7 @@ import (
 	"github.com/GizClaw/flowcraft/core/errdefs"
 	"github.com/GizClaw/flowcraft/core/inference"
 	"github.com/GizClaw/flowcraft/core/message"
+	"github.com/GizClaw/flowcraft/core/message/media"
 	"github.com/GizClaw/flowcraft/core/telemetry"
 )
 
@@ -47,6 +49,66 @@ func TestRun_EmptyAgentIDRejected(t *testing.T) {
 	}
 	if res != nil {
 		t.Errorf("expected nil result on infrastructure error, got %+v", res)
+	}
+}
+
+func TestRun_CommittedBoardMaterializesStreamSources(t *testing.T) {
+	format := media.AudioFormat{
+		Encoding:     media.AudioEncodingPCM16,
+		SampleRateHz: 1000,
+		Channels:     1,
+	}
+	chunk, err := media.NewAudioBytes([]byte("abcd"), "audio/pcm")
+	if err != nil {
+		t.Fatalf("NewAudioBytes: %v", err)
+	}
+	pipe := message.NewPartPipe(1)
+	pipe.Send(message.AudioPart{Source: chunk, Format: &format})
+	pipe.Close()
+	stream, err := message.NewAudioStream(pipe, "audio/pcm")
+	if err != nil {
+		t.Fatalf("NewAudioStream: %v", err)
+	}
+	req := agent.Request{Message: message.Message{
+		Role: message.RoleUser,
+		Content: message.Content{Parts: []message.Part{
+			message.AudioPart{Source: stream},
+		}},
+	}}
+	engine := agent.EngineFunc(func(
+		_ context.Context, _ agent.Run, _ agent.Host, b *agent.Board,
+	) (*agent.Board, error) {
+		b.AppendChannelMessage(agent.MainChannel,
+			message.NewTextMessage(message.RoleAssistant, "heard you"))
+		return b, nil
+	})
+	res, err := agent.Execute(context.Background(),
+		agent.Agent{ID: "a"}, engine, req)
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if res.Status != agent.StatusCompleted {
+		t.Fatalf("Status = %q, want completed", res.Status)
+	}
+	msgs := res.LastBoard.Channel(agent.MainChannel)
+	if len(msgs) != 2 {
+		t.Fatalf("main channel has %d messages, want 2", len(msgs))
+	}
+	user := msgs[0]
+	if message.HasStreamSource(user.Content) {
+		t.Fatal("committed history still carries a stream source")
+	}
+	audio, ok := user.Content.Parts[0].(message.AudioPart)
+	if !ok {
+		t.Fatalf("committed user part = %T, want AudioPart", user.Content.Parts[0])
+	}
+	if got := string(audio.Source.Bytes()); got != "abcd" {
+		t.Fatalf("committed audio bytes = %q, want \"abcd\"", got)
+	}
+	// Materialized history must be serializable: stream handles cannot
+	// cross the durable boundary.
+	if _, err := json.Marshal(res.LastBoard.Snapshot()); err != nil {
+		t.Fatalf("committed board is not serializable: %v", err)
 	}
 }
 

--- a/core/inference/assembly.go
+++ b/core/inference/assembly.go
@@ -208,6 +208,86 @@ func (a *Assembly) ExplainEmbed(
 	return driver.Explain(ctx, ref, req)
 }
 
+// Transcribe executes one unary transcription request against the model
+// addressed by ref.
+func (a *Assembly) Transcribe(
+	ctx context.Context,
+	ref ModelRef,
+	req TranscriptionRequest,
+) (TranscriptionResponse, error) {
+	operations, err := a.openTranscribe(ctx, ref)
+	if err != nil {
+		return TranscriptionResponse{}, err
+	}
+	if operations.Unary == nil {
+		return TranscriptionResponse{}, NewError(
+			UnsupportedOperation, OperationTranscription, "",
+			fmt.Errorf("model %q has no unary transcription driver", ref.ID.Name),
+		)
+	}
+	return operations.Unary.Execute(ctx, ref, req)
+}
+
+// ExplainTranscribe runs the compiler for a unary transcription request
+// without provider I/O.
+func (a *Assembly) ExplainTranscribe(
+	ctx context.Context,
+	ref ModelRef,
+	req TranscriptionRequest,
+) (Explanation, error) {
+	operations, err := a.openTranscribe(ctx, ref)
+	if err != nil {
+		return Explanation{}, err
+	}
+	if operations.Unary == nil {
+		return Explanation{}, NewError(
+			UnsupportedOperation, OperationTranscription, "",
+			fmt.Errorf("model %q has no unary transcription driver", ref.ID.Name),
+		)
+	}
+	return operations.Unary.Explain(ctx, ref, req)
+}
+
+// TranscribeSession opens a duplex transcription session against the model
+// addressed by ref. Audio is fed through the returned session after open.
+func (a *Assembly) TranscribeSession(
+	ctx context.Context,
+	ref ModelRef,
+	req TranscriptionSessionRequest,
+) (TranscriptionSession, error) {
+	operations, err := a.openTranscribe(ctx, ref)
+	if err != nil {
+		return nil, err
+	}
+	if operations.Session == nil {
+		return nil, NewError(
+			UnsupportedOperation, OperationTranscription, "",
+			fmt.Errorf("model %q has no transcription session driver", ref.ID.Name),
+		)
+	}
+	return operations.Session.Open(ctx, ref, req)
+}
+
+// ExplainTranscribeSession compiles a transcription session request without
+// provider I/O.
+func (a *Assembly) ExplainTranscribeSession(
+	ctx context.Context,
+	ref ModelRef,
+	req TranscriptionSessionRequest,
+) (Explanation, error) {
+	operations, err := a.openTranscribe(ctx, ref)
+	if err != nil {
+		return Explanation{}, err
+	}
+	if operations.Session == nil {
+		return Explanation{}, NewError(
+			UnsupportedOperation, OperationTranscription, "",
+			fmt.Errorf("model %q has no transcription session driver", ref.ID.Name),
+		)
+	}
+	return operations.Session.Explain(ctx, ref, req)
+}
+
 func (a *Assembly) openGenerate(
 	ctx context.Context,
 	ref ModelRef,
@@ -244,6 +324,25 @@ func (a *Assembly) openEmbed(
 		return nil, err
 	}
 	return model.Openers.Embed(ctx, ref)
+}
+
+func (a *Assembly) openTranscribe(
+	ctx context.Context,
+	ref ModelRef,
+) (TranscribeOperations, error) {
+	entry, model, err := a.lookupEntry(ref, OperationTranscription)
+	if err != nil {
+		return TranscribeOperations{}, err
+	}
+	if model.Openers.Transcribe == nil {
+		return TranscribeOperations{}, NewError(
+			UnsupportedOperation, OperationTranscription, "",
+			fmt.Errorf("model %q has no transcribe openers", ref.ID.Name))
+	}
+	if err := entry.checkProfile(ref, OperationTranscription); err != nil {
+		return TranscribeOperations{}, err
+	}
+	return model.Openers.Transcribe(ctx, ref)
 }
 
 func (a *Assembly) lookupEntry(

--- a/core/inference/doc.go
+++ b/core/inference/doc.go
@@ -9,10 +9,14 @@
 //     generate_input.go, generate_intent.go, generate_output.go,
 //     generate_driver.go
 //   - Embed domain: embedding.go
+//   - Transcribe domain: transcribe.go (unary whole-file recognition and
+//     the duplex TranscriptionSession), transcribe_stream.go (live
+//     message.Stream input pumped into a session)
 //   - Resource layer: assembly.go (the inference.Assembly resource
 //     with execution), route/ (the inference.Router decorator:
 //     tiers, selectors, retry/backoff, circuit breaker, trace)
 //
-// The execution runtime (Runtime over a provider registry) and the
-// Router resource are deferred; they land here in later milestones.
+// Realtime — the fourth workload — is reserved in the operation enum and
+// field ledger but has no request/session surface yet; it lands in a later
+// milestone.
 package inference

--- a/core/inference/generate.go
+++ b/core/inference/generate.go
@@ -107,13 +107,22 @@ func (r GenerateRequest) Clone() GenerateRequest {
 }
 
 func (r GenerateRequest) Validate() error {
-	for i, message := range r.Context {
-		if err := message.Validate(); err != nil {
+	for i, msg := range r.Context {
+		if err := msg.Validate(); err != nil {
 			return fmt.Errorf("context message %d: %w", i, err)
+		}
+		if message.HasStreamSource(msg.Content) {
+			return fmt.Errorf(
+				"context message %d: stream media sources are not allowed in context",
+				i,
+			)
 		}
 	}
 	if err := r.Input.Validate(); err != nil {
 		return fmt.Errorf("generate input: %w", err)
+	}
+	if message.HasStreamSource(r.Input.Content.Content) {
+		return fmt.Errorf("generate input: stream media sources are not allowed")
 	}
 	return r.Extensions.Validate()
 }

--- a/core/inference/inferencetest/conformance_test.go
+++ b/core/inference/inferencetest/conformance_test.go
@@ -4,11 +4,14 @@ import (
 	"context"
 	"errors"
 	"io"
+	"sync"
 	"testing"
 
 	"github.com/GizClaw/flowcraft/core/inference"
 	"github.com/GizClaw/flowcraft/core/inference/inferencetest"
 	"github.com/GizClaw/flowcraft/core/message"
+	"github.com/GizClaw/flowcraft/core/message/media"
+	"github.com/GizClaw/flowcraft/core/resource"
 )
 
 func TestEmbedFakeAssembly(t *testing.T) {
@@ -207,5 +210,407 @@ func countingTransport[Wire, Raw any](
 	return func(ctx context.Context, wire Wire) (Raw, error) {
 		calls.Inc()
 		return next(ctx, wire)
+	}
+}
+
+func TestTranscribeFakeAssembly(t *testing.T) {
+	fake := &inferencetest.TranscriptionFake{}
+	assembly := fake.Assembly(t)
+
+	request := inference.TranscriptionRequest{
+		Audio: mustAudioSource(t),
+	}
+	response, err := assembly.Transcribe(
+		context.Background(),
+		inferencetest.DefaultFakeTranscribeModel,
+		request,
+	)
+	if err != nil {
+		t.Fatalf("Transcribe: %v", err)
+	}
+	if response.Text != "ok" {
+		t.Fatalf("Text = %q, want %q", response.Text, "ok")
+	}
+	if len(fake.Requests()) != 1 {
+		t.Fatalf("compiler requests = %d, want 1", len(fake.Requests()))
+	}
+}
+
+func TestRunTranscribeUnary(t *testing.T) {
+	calls := &inferencetest.Counter{}
+	driver, err := inference.BindTranscribe(
+		inference.Compiler[inference.TranscriptionRequest, string](
+			func(_ context.Context, _ inference.ModelRef, request inference.TranscriptionRequest) (inference.Compiled[string], error) {
+				return inference.Compiled[string]{
+					Wire: "wire",
+					Report: inferencetest.NativeReport(
+						inference.OperationTranscription,
+						request.ActiveFields()...,
+					),
+				}, nil
+			},
+		),
+		countingTransport(calls, func(_ context.Context, wire string) (string, error) {
+			return wire, nil
+		}),
+		inference.Decoder[string, inference.TranscriptionResponse](
+			func(_ context.Context, _ string) (inference.TranscriptionResponse, error) {
+				return inference.TranscriptionResponse{
+					Text: "hello",
+					Segments: []inference.TranscriptionSegment{{
+						Text: "hello",
+					}},
+				}, nil
+			},
+		),
+	)
+	if err != nil {
+		t.Fatalf("BindTranscribe: %v", err)
+	}
+	inferencetest.RunTranscribeUnary(t, inferencetest.TranscriptionUnarySuite{
+		Model: inferencetest.DefaultFakeTranscribeModel,
+		Request: func() inference.TranscriptionRequest {
+			return inference.TranscriptionRequest{Audio: mustAudioSource(t)}
+		},
+		Driver:         driver,
+		TransportCalls: calls.Load,
+	})
+}
+
+type scriptedRawEvent struct {
+	Text  string
+	Final bool
+}
+
+type scriptedRawSession struct {
+	mu          sync.Mutex
+	events      []scriptedRawEvent
+	sends       int
+	interrupted bool
+	closed      bool
+}
+
+func (s *scriptedRawSession) Send(
+	context.Context,
+	media.AudioChunk,
+) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.sends++
+	return nil
+}
+
+func (s *scriptedRawSession) Next(
+	context.Context,
+) (scriptedRawEvent, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.interrupted {
+		return scriptedRawEvent{}, errors.New("session interrupted")
+	}
+	if len(s.events) == 0 {
+		return scriptedRawEvent{}, io.EOF
+	}
+	event := s.events[0]
+	s.events = s.events[1:]
+	return event, nil
+}
+
+func (s *scriptedRawSession) Interrupt() error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.interrupted = true
+	return nil
+}
+
+func (s *scriptedRawSession) Close() error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.closed = true
+	return nil
+}
+
+func countingTranscribeSessionTransport[Wire, RawEvent any](
+	calls *inferencetest.Counter,
+	next inference.TranscriptionSessionTransport[Wire, RawEvent],
+) inference.TranscriptionSessionTransport[Wire, RawEvent] {
+	return func(
+		ctx context.Context,
+		wire Wire,
+	) (inference.ProviderSession[RawEvent], error) {
+		calls.Inc()
+		return next(ctx, wire)
+	}
+}
+
+func bindScriptedSession(
+	calls *inferencetest.Counter,
+	raw *scriptedRawSession,
+) (inference.TranscriptionSessionDriver, error) {
+	return inference.BindTranscribeSession(
+		inference.Compiler[inference.TranscriptionSessionRequest, string](
+			func(_ context.Context, _ inference.ModelRef, request inference.TranscriptionSessionRequest) (inference.Compiled[string], error) {
+				return inference.Compiled[string]{
+					Wire: "wire",
+					Report: inferencetest.NativeReport(
+						inference.OperationTranscription,
+						request.ActiveFields()...,
+					),
+				}, nil
+			},
+		),
+		countingTranscribeSessionTransport(
+			calls,
+			func(_ context.Context, _ string) (inference.ProviderSession[scriptedRawEvent], error) {
+				return raw, nil
+			},
+		),
+		inference.TranscriptionSessionDecoder[scriptedRawEvent](
+			func(_ context.Context, event scriptedRawEvent) (inference.TranscriptionSessionEvent, error) {
+				return inference.TranscriptionSessionEvent{
+					Text:  event.Text,
+					Final: event.Final,
+				}, nil
+			},
+		),
+	)
+}
+
+func sessionRequest() inference.TranscriptionSessionRequest {
+	return inference.TranscriptionSessionRequest{
+		InputFormat: media.AudioFormat{
+			Encoding:     media.AudioEncodingPCM16,
+			SampleRateHz: 16000,
+			Channels:     1,
+		},
+	}
+}
+
+func mustAudioSource(t *testing.T) media.AudioSource {
+	t.Helper()
+	source, err := media.NewAudioBytes([]byte{1, 2, 3, 4}, "audio/wav")
+	if err != nil {
+		t.Fatalf("NewAudioBytes: %v", err)
+	}
+	return source
+}
+
+func TestRunTranscribeSession(t *testing.T) {
+	calls := &inferencetest.Counter{}
+	raw := &scriptedRawSession{events: []scriptedRawEvent{
+		{Text: "hel"},
+		{Text: "hello", Final: true},
+		{Text: "wor"},
+		{Text: "world", Final: true},
+	}}
+	driver, err := bindScriptedSession(calls, raw)
+	if err != nil {
+		t.Fatalf("BindTranscribeSession: %v", err)
+	}
+	inferencetest.RunTranscribeSession(t, inferencetest.TranscriptionSessionSuite{
+		Model:   inferencetest.DefaultFakeTranscribeModel,
+		Request: sessionRequest,
+		Driver:  driver,
+		Feed: func(ctx context.Context, session inference.TranscriptionSession) error {
+			for i := 0; i < 3; i++ {
+				if err := session.Send(ctx, media.AudioChunk{Data: []byte{0, 0}}); err != nil {
+					return err
+				}
+			}
+			return nil
+		},
+		TransportCalls: calls.Load,
+		AssertResult: func(t *testing.T, response inference.TranscriptionResponse) {
+			if response.Text != "hello\nworld" {
+				t.Fatalf("Text = %q, want %q", response.Text, "hello\nworld")
+			}
+			if len(response.Segments) != 2 ||
+				response.Segments[0].Text != "hello" ||
+				response.Segments[1].Text != "world" {
+				t.Fatalf("Segments = %+v", response.Segments)
+			}
+		},
+	})
+	if raw.sends != 3 {
+		t.Fatalf("provider sends = %d, want 3", raw.sends)
+	}
+}
+
+func TestTranscribeSessionInterrupt(t *testing.T) {
+	calls := &inferencetest.Counter{}
+	raw := &scriptedRawSession{events: []scriptedRawEvent{{Text: "partial"}}}
+	driver, err := bindScriptedSession(calls, raw)
+	if err != nil {
+		t.Fatalf("BindTranscribeSession: %v", err)
+	}
+	session, err := driver.Open(
+		context.Background(),
+		inferencetest.DefaultFakeTranscribeModel,
+		sessionRequest(),
+	)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	if err := session.Send(
+		context.Background(),
+		media.AudioChunk{Data: []byte{0, 0}},
+	); err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+	if err := session.Interrupt(); err != nil {
+		t.Fatalf("Interrupt: %v", err)
+	}
+	if _, err := session.Next(context.Background()); !isInterrupted(err) {
+		t.Fatalf("Next after Interrupt = %v, want interruption", err)
+	}
+	if _, err := session.Result(); !isInterrupted(err) {
+		t.Fatalf("Result after Interrupt = %v, want interruption", err)
+	}
+	if err := session.Send(
+		context.Background(),
+		media.AudioChunk{Data: []byte{0, 0}},
+	); !isInterrupted(err) {
+		t.Fatalf("Send after Interrupt = %v, want interruption", err)
+	}
+	if err := session.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+}
+
+func isInterrupted(err error) bool {
+	if err == nil {
+		return false
+	}
+	var inferenceErr *inference.Error
+	return errors.As(err, &inferenceErr) &&
+		inferenceErr.Kind == inference.OperationInterrupted
+}
+
+func TestRunTranscribeDualOperations(t *testing.T) {
+	calls := &inferencetest.Counter{}
+	raw := &scriptedRawSession{events: []scriptedRawEvent{{Text: "hi", Final: true}}}
+	operations, err := inference.BindTranscribeOperations(
+		inference.Compiler[inference.TranscriptionRequest, string](
+			func(_ context.Context, _ inference.ModelRef, request inference.TranscriptionRequest) (inference.Compiled[string], error) {
+				return inference.Compiled[string]{
+					Wire: "wire",
+					Report: inferencetest.NativeReport(
+						inference.OperationTranscription,
+						request.ActiveFields()...,
+					),
+				}, nil
+			},
+		),
+		countingTransport(calls, func(_ context.Context, wire string) (string, error) {
+			return wire, nil
+		}),
+		inference.Decoder[string, inference.TranscriptionResponse](
+			func(_ context.Context, _ string) (inference.TranscriptionResponse, error) {
+				return inference.TranscriptionResponse{
+					Text:     "hi",
+					Segments: []inference.TranscriptionSegment{{Text: "hi"}},
+				}, nil
+			},
+		),
+		inference.Compiler[inference.TranscriptionSessionRequest, string](
+			func(_ context.Context, _ inference.ModelRef, request inference.TranscriptionSessionRequest) (inference.Compiled[string], error) {
+				return inference.Compiled[string]{
+					Wire: "wire",
+					Report: inferencetest.NativeReport(
+						inference.OperationTranscription,
+						request.ActiveFields()...,
+					),
+				}, nil
+			},
+		),
+		countingTranscribeSessionTransport(
+			calls,
+			func(_ context.Context, _ string) (inference.ProviderSession[scriptedRawEvent], error) {
+				return raw, nil
+			},
+		),
+		inference.TranscriptionSessionDecoder[scriptedRawEvent](
+			func(_ context.Context, event scriptedRawEvent) (inference.TranscriptionSessionEvent, error) {
+				return inference.TranscriptionSessionEvent{
+					Text:  event.Text,
+					Final: event.Final,
+				}, nil
+			},
+		),
+	)
+	if err != nil {
+		t.Fatalf("BindTranscribeOperations: %v", err)
+	}
+	if err := operations.Validate(); err != nil {
+		t.Fatalf("TranscribeOperations.Validate: %v", err)
+	}
+
+	model := inferencetest.DefaultFakeTranscribeModel
+	definition := inference.ProviderDefinition{
+		ID: model.ID.Provider,
+		Profiles: []inference.ProfileDefinition{{
+			ID:         model.Profile,
+			Operations: []inference.Operation{inference.OperationTranscription},
+		}},
+		Models: []inference.ModelImplementation{{
+			Descriptor: inference.ModelDescriptor{ID: model.ID},
+			Openers: inference.Openers{
+				Transcribe: func(
+					_ context.Context,
+					_ inference.ModelRef,
+				) (inference.TranscribeOperations, error) {
+					return operations, nil
+				},
+			},
+		}},
+	}
+	value, err := inference.Factory{}.New(context.Background(), resource.Input{
+		Deps: map[string]any{"provider." + model.ID.Provider: definition},
+	})
+	if err != nil {
+		t.Fatalf("build assembly: %v", err)
+	}
+	assembly := value.(*inference.Assembly)
+
+	response, err := assembly.Transcribe(
+		context.Background(),
+		model,
+		inference.TranscriptionRequest{Audio: mustAudioSource(t)},
+	)
+	if err != nil {
+		t.Fatalf("Transcribe: %v", err)
+	}
+	if response.Text != "hi" {
+		t.Fatalf("unary Text = %q, want %q", response.Text, "hi")
+	}
+	session, err := assembly.TranscribeSession(
+		context.Background(),
+		model,
+		sessionRequest(),
+	)
+	if err != nil {
+		t.Fatalf("TranscribeSession: %v", err)
+	}
+	if err := session.Send(
+		context.Background(),
+		media.AudioChunk{Data: []byte{0, 0}},
+	); err != nil {
+		t.Fatalf("session Send: %v", err)
+	}
+	for {
+		_, err := session.Next(context.Background())
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			t.Fatalf("session Next: %v", err)
+		}
+	}
+	sessionResult, err := session.Result()
+	if err != nil {
+		t.Fatalf("session Result: %v", err)
+	}
+	if sessionResult.Text != "hi" {
+		t.Fatalf("session Text = %q, want %q", sessionResult.Text, "hi")
 	}
 }

--- a/core/inference/inferencetest/fake.go
+++ b/core/inference/inferencetest/fake.go
@@ -212,6 +212,51 @@ func (f embedSelectorFunc) SelectEmbed(ctx context.Context, req inference.EmbedR
 	return f(ctx, req)
 }
 
+// StaticTranscribeSelector returns a route.TranscribeSelector that always
+// selects ref on the primary tier — the smallest router wiring for tests
+// that need the unary transcription route path.
+func StaticTranscribeSelector(ref inference.ModelRef) route.TranscribeSelector {
+	return transcribeSelectorFunc(func(context.Context, inference.TranscriptionRequest) (route.Decision, error) {
+		return route.Decision{
+			Operation: inference.OperationTranscription,
+			Tier:      "primary",
+			Proposed:  ref,
+			Selected:  ref,
+		}, nil
+	})
+}
+
+type transcribeSelectorFunc func(context.Context, inference.TranscriptionRequest) (route.Decision, error)
+
+func (f transcribeSelectorFunc) SelectTranscribe(
+	ctx context.Context,
+	req inference.TranscriptionRequest,
+) (route.Decision, error) {
+	return f(ctx, req)
+}
+
+// StaticTranscribeSessionSelector returns a route.TranscriptionSessionSelector
+// that always selects ref on the primary tier.
+func StaticTranscribeSessionSelector(ref inference.ModelRef) route.TranscriptionSessionSelector {
+	return transcribeSessionSelectorFunc(func(context.Context, inference.TranscriptionSessionRequest) (route.Decision, error) {
+		return route.Decision{
+			Operation: inference.OperationTranscription,
+			Tier:      "primary",
+			Proposed:  ref,
+			Selected:  ref,
+		}, nil
+	})
+}
+
+type transcribeSessionSelectorFunc func(context.Context, inference.TranscriptionSessionRequest) (route.Decision, error)
+
+func (f transcribeSessionSelectorFunc) SelectTranscribeSession(
+	ctx context.Context,
+	req inference.TranscriptionSessionRequest,
+) (route.Decision, error) {
+	return f(ctx, req)
+}
+
 // eventStream is a ProviderStream over canned events.
 type eventStream struct {
 	events []inference.GenerateStreamEvent

--- a/core/inference/inferencetest/transcribe.go
+++ b/core/inference/inferencetest/transcribe.go
@@ -1,0 +1,376 @@
+package inferencetest
+
+import (
+	"context"
+	"io"
+	"sync"
+	"testing"
+
+	"github.com/GizClaw/flowcraft/core/inference"
+	"github.com/GizClaw/flowcraft/core/message/media"
+	"github.com/GizClaw/flowcraft/core/resource"
+)
+
+// DefaultFakeTranscribeModel is TranscriptionFake's default model ref.
+var DefaultFakeTranscribeModel = inference.ModelRef{
+	ID:      inference.ModelID{Provider: "fake", Name: "transcribe"},
+	Profile: "default",
+}
+
+// TranscriptionFake is a canned unary transcription provider for tests: one
+// provider, one profile, one model. Execute answers via Respond, and every
+// request reaching the compiler is captured for assertion. It drives the
+// real resolve/compile/validate pipeline.
+type TranscriptionFake struct {
+	// Model is the ref the runtime resolves. Defaults to
+	// DefaultFakeTranscribeModel.
+	Model inference.ModelRef
+	// Descriptor overrides the model's discovery metadata. The zero
+	// value falls back to {ID: Model.ID}.
+	Descriptor inference.ModelDescriptor
+	// Respond answers Transcribe calls. Default: "ok" with one segment.
+	Respond func(inference.TranscriptionRequest) inference.TranscriptionResponse
+	// SessionEvents plays back on TranscribeSession. Default: one final
+	// "ok" event.
+	SessionEvents []inference.TranscriptionSessionEvent
+
+	mu              sync.Mutex
+	requests        []inference.TranscriptionRequest
+	sessionRequests []inference.TranscriptionSessionRequest
+}
+
+// Requests returns the captured compiler requests in order.
+func (f *TranscriptionFake) Requests() []inference.TranscriptionRequest {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return append([]inference.TranscriptionRequest(nil), f.requests...)
+}
+
+// SessionRequests returns the captured session compiler requests in order.
+func (f *TranscriptionFake) SessionRequests() []inference.TranscriptionSessionRequest {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return append([]inference.TranscriptionSessionRequest(nil), f.sessionRequests...)
+}
+
+// Assembly builds the fake's inference assembly.
+func (f *TranscriptionFake) Assembly(t *testing.T) *inference.Assembly {
+	t.Helper()
+	model := f.Model
+	if model.ID.Provider == "" {
+		model = DefaultFakeTranscribeModel
+	}
+	respond := f.Respond
+	if respond == nil {
+		respond = func(inference.TranscriptionRequest) inference.TranscriptionResponse {
+			return inference.TranscriptionResponse{
+				Text: "ok",
+				Segments: []inference.TranscriptionSegment{{
+					Text: "ok",
+				}},
+			}
+		}
+	}
+
+	compile := inference.Compiler[inference.TranscriptionRequest, string](
+		func(_ context.Context, _ inference.ModelRef, req inference.TranscriptionRequest) (inference.Compiled[string], error) {
+			f.mu.Lock()
+			f.requests = append(f.requests, req.Clone())
+			f.mu.Unlock()
+			return inference.Compiled[string]{
+				Wire:   "wire",
+				Report: NativeReport(inference.OperationTranscription, req.ActiveFields()...),
+			}, nil
+		},
+	)
+	transport := inference.Transport[string, string](
+		func(_ context.Context, wire string) (string, error) { return wire, nil },
+	)
+	decode := inference.Decoder[string, inference.TranscriptionResponse](
+		func(_ context.Context, _ string) (inference.TranscriptionResponse, error) {
+			return respond(f.lastRequest()), nil
+		},
+	)
+	sessionCompile := inference.Compiler[inference.TranscriptionSessionRequest, string](
+		func(_ context.Context, _ inference.ModelRef, req inference.TranscriptionSessionRequest) (inference.Compiled[string], error) {
+			f.mu.Lock()
+			f.sessionRequests = append(f.sessionRequests, req.Clone())
+			f.mu.Unlock()
+			return inference.Compiled[string]{
+				Wire:   "wire",
+				Report: NativeReport(inference.OperationTranscription, req.ActiveFields()...),
+			}, nil
+		},
+	)
+	events := f.SessionEvents
+	if events == nil {
+		events = []inference.TranscriptionSessionEvent{{
+			Text:  "ok",
+			Final: true,
+		}}
+	}
+	sessionTransport := inference.TranscriptionSessionTransport[string, inference.TranscriptionSessionEvent](
+		func(_ context.Context, _ string) (inference.ProviderSession[inference.TranscriptionSessionEvent], error) {
+			return &fakeProviderSession{events: events}, nil
+		},
+	)
+	sessionDecode := inference.TranscriptionSessionDecoder[inference.TranscriptionSessionEvent](
+		func(_ context.Context, event inference.TranscriptionSessionEvent) (inference.TranscriptionSessionEvent, error) {
+			return event, nil
+		},
+	)
+	operations, err := inference.BindTranscribeOperations(
+		compile,
+		transport,
+		decode,
+		sessionCompile,
+		sessionTransport,
+		sessionDecode,
+	)
+	if err != nil {
+		t.Fatalf("BindTranscribeOperations: %v", err)
+	}
+	descriptor := f.Descriptor
+	if descriptor.ID.Provider == "" {
+		descriptor = inference.ModelDescriptor{ID: model.ID}
+	}
+
+	definition := inference.ProviderDefinition{
+		ID: model.ID.Provider,
+		Profiles: []inference.ProfileDefinition{{
+			ID:         model.Profile,
+			Operations: []inference.Operation{inference.OperationTranscription},
+		}},
+		Models: []inference.ModelImplementation{{
+			Descriptor: descriptor,
+			Openers: inference.Openers{
+				Transcribe: func(
+					_ context.Context,
+					_ inference.ModelRef,
+				) (inference.TranscribeOperations, error) {
+					return operations, nil
+				},
+			},
+		}},
+	}
+	value, err := inference.Factory{}.New(context.Background(), resource.Input{
+		Deps: map[string]any{"provider." + model.ID.Provider: definition},
+	})
+	if err != nil {
+		t.Fatalf("build assembly: %v", err)
+	}
+	return value.(*inference.Assembly)
+}
+
+func (f *TranscriptionFake) lastRequest() inference.TranscriptionRequest {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if len(f.requests) == 0 {
+		return inference.TranscriptionRequest{}
+	}
+	return f.requests[len(f.requests)-1]
+}
+
+// fakeProviderSession is the canned provider session behind
+// TranscriptionFake's session driver: it records sends and plays back the
+// configured canonical events (the decoder is the identity function).
+type fakeProviderSession struct {
+	mu     sync.Mutex
+	events []inference.TranscriptionSessionEvent
+	sends  int
+}
+
+func (s *fakeProviderSession) Send(
+	context.Context,
+	media.AudioChunk,
+) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.sends++
+	return nil
+}
+
+func (s *fakeProviderSession) Next(
+	context.Context,
+) (inference.TranscriptionSessionEvent, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if len(s.events) == 0 {
+		return inference.TranscriptionSessionEvent{}, io.EOF
+	}
+	event := s.events[0]
+	s.events = s.events[1:]
+	return event, nil
+}
+
+func (s *fakeProviderSession) Interrupt() error { return nil }
+func (s *fakeProviderSession) Close() error     { return nil }
+
+// TranscriptionUnarySuite verifies the unary transcription driver contract
+// through the shared UnarySuite.
+type TranscriptionUnarySuite struct {
+	Model   inference.ModelRef
+	Request func() inference.TranscriptionRequest
+	Driver  inference.TranscriptionDriver
+
+	TransportCalls func() int64
+	AssertResponse func(*testing.T, inference.TranscriptionResponse)
+}
+
+func RunTranscribeUnary(t *testing.T, suite TranscriptionUnarySuite) {
+	t.Helper()
+	if suite.Driver == nil {
+		t.Fatal("TranscriptionUnarySuite requires a driver")
+	}
+	assertResponse := suite.AssertResponse
+	RunUnary(t, UnarySuite[inference.TranscriptionRequest, inference.TranscriptionResponse]{
+		Operation: inference.OperationTranscription,
+		Model:     suite.Model,
+		Request:   suite.Request,
+		Snapshot: func(request inference.TranscriptionRequest) any {
+			return request.Clone()
+		},
+		Explain: suite.Driver.Explain,
+		Execute: suite.Driver.Execute,
+		Metadata: func(response inference.TranscriptionResponse) inference.Metadata {
+			return response.Metadata
+		},
+		TransportCalls: suite.TransportCalls,
+		AssertResponse: func(t *testing.T, response inference.TranscriptionResponse) {
+			if response.Usage.Model != suite.Model {
+				t.Fatalf(
+					"Usage.Model = %+v, want %+v",
+					response.Usage.Model,
+					suite.Model,
+				)
+			}
+			if response.Usage.LatencyMs < 0 {
+				t.Fatalf(
+					"Usage.LatencyMs = %d, want non-negative",
+					response.Usage.LatencyMs,
+				)
+			}
+			if assertResponse != nil {
+				assertResponse(t, response)
+			}
+		},
+	})
+}
+
+// TranscriptionSessionSuite verifies the duplex transcription session
+// contract: Explain without provider I/O, Open with exactly one transport
+// call, Send/Next over the scripted provider session, Result with stamped
+// metadata, and Close.
+type TranscriptionSessionSuite struct {
+	Model   inference.ModelRef
+	Request func() inference.TranscriptionSessionRequest
+	Driver  inference.TranscriptionSessionDriver
+
+	// Feed sends audio chunks into the opened session before draining.
+	// Default: one valid PCM chunk.
+	Feed           func(context.Context, inference.TranscriptionSession) error
+	TransportCalls func() int64
+	AssertEvent    func(*testing.T, inference.TranscriptionSessionEvent)
+	AssertResult   func(*testing.T, inference.TranscriptionResponse)
+	AssertClose    func(*testing.T, error)
+}
+
+func RunTranscribeSession(t *testing.T, suite TranscriptionSessionSuite) {
+	t.Helper()
+	if suite.Request == nil || suite.Driver == nil ||
+		suite.TransportCalls == nil {
+		t.Fatal(
+			"TranscriptionSessionSuite requires request, driver, and transport probe",
+		)
+	}
+	if err := suite.Model.Validate(); err != nil {
+		t.Fatalf("Model: %v", err)
+	}
+
+	request := suite.Request()
+	expected := request.Clone()
+	before := suite.TransportCalls()
+	explanation, err := suite.Driver.Explain(
+		context.Background(),
+		suite.Model,
+		request,
+	)
+	if err != nil {
+		t.Fatalf("Explain: %v", err)
+	}
+	if suite.TransportCalls() != before ||
+		explanation.Operation != inference.OperationTranscription ||
+		len(explanation.Decisions) == 0 {
+		t.Fatalf("Explain performed I/O or lost decisions: %+v", explanation)
+	}
+	assertUnchanged(t, expected, request.Clone())
+
+	session, err := suite.Driver.Open(
+		context.Background(),
+		suite.Model,
+		request,
+	)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	if suite.TransportCalls() != before+1 {
+		t.Fatalf(
+			"Open transport calls = %d, want %d",
+			suite.TransportCalls(),
+			before+1,
+		)
+	}
+	feed := suite.Feed
+	if feed == nil {
+		feed = func(ctx context.Context, session inference.TranscriptionSession) error {
+			return session.Send(ctx, media.AudioChunk{Data: []byte{0, 0}})
+		}
+	}
+	if err := feed(context.Background(), session); err != nil {
+		t.Fatalf("Feed: %v", err)
+	}
+	for {
+		event, err := session.Next(context.Background())
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			t.Fatalf("Next: %v", err)
+		}
+		if suite.AssertEvent != nil {
+			suite.AssertEvent(t, event)
+		}
+	}
+	response, err := session.Result()
+	if err != nil {
+		t.Fatalf("Result: %v", err)
+	}
+	if response.Metadata.Model != suite.Model.ID ||
+		response.Metadata.Operation != inference.OperationTranscription ||
+		len(response.Metadata.Decisions) == 0 {
+		t.Fatalf("Result metadata = %+v", response.Metadata)
+	}
+	if response.Usage.Model != suite.Model {
+		t.Fatalf(
+			"Usage.Model = %+v, want %+v",
+			response.Usage.Model,
+			suite.Model,
+		)
+	}
+	if response.Usage.LatencyMs < 0 {
+		t.Fatalf(
+			"Usage.LatencyMs = %d, want non-negative",
+			response.Usage.LatencyMs,
+		)
+	}
+	if suite.AssertResult != nil {
+		suite.AssertResult(t, response)
+	}
+	closeErr := session.Close()
+	if suite.AssertClose != nil {
+		suite.AssertClose(t, closeErr)
+	} else if closeErr != nil {
+		t.Fatalf("Close: %v", closeErr)
+	}
+	assertUnchanged(t, expected, request.Clone())
+}

--- a/core/inference/provider_definition.go
+++ b/core/inference/provider_definition.go
@@ -16,11 +16,16 @@ type (
 	// OpenEmbed materializes an embedding driver. It follows OpenGenerate's
 	// runtime-owned context and local, bounded construction contract.
 	OpenEmbed func(context.Context, ModelRef) (EmbedDriver, error)
+	// OpenTranscribe materializes transcription operations (unary and/or
+	// duplex session). It follows OpenGenerate's runtime-owned context and
+	// local, bounded construction contract.
+	OpenTranscribe func(context.Context, ModelRef) (TranscribeOperations, error)
 )
 
 type Openers struct {
-	Generate OpenGenerate
-	Embed    OpenEmbed
+	Generate   OpenGenerate
+	Embed      OpenEmbed
+	Transcribe OpenTranscribe
 }
 
 // ModelImplementation binds descriptive metadata to the operation openers that
@@ -206,6 +211,9 @@ func (openers Openers) Operations() []Operation {
 	}
 	if openers.Embed != nil {
 		operations = append(operations, OperationEmbed)
+	}
+	if openers.Transcribe != nil {
+		operations = append(operations, OperationTranscription)
 	}
 	return operations
 }

--- a/core/inference/route/doc.go
+++ b/core/inference/route/doc.go
@@ -1,4 +1,5 @@
-// Package route provides optional model selection above inference.Runtime.
+// Package route provides optional model selection above the inference
+// Assembly (inference.Assembly).
 //
 // It owns deployment-defined tiers, normalized model scores, operation-specific
 // target pools, selector contracts, and route traces. It does not declare model

--- a/core/inference/route/policy.go
+++ b/core/inference/route/policy.go
@@ -132,14 +132,16 @@ func (p Pool) Validate() error {
 type Policy struct {
 	Generate       []Pool                `json:"generate,omitempty"`
 	Embed          []Pool                `json:"embed,omitempty"`
+	Transcription  []Pool                `json:"transcription,omitempty"`
 	Retry          *RetryConfig          `json:"retry,omitempty"`
 	CircuitBreaker *CircuitBreakerConfig `json:"circuit_breaker,omitempty"`
 }
 
 func (p Policy) Clone() Policy {
 	cloned := Policy{
-		Generate: clonePools(p.Generate),
-		Embed:    clonePools(p.Embed),
+		Generate:      clonePools(p.Generate),
+		Embed:         clonePools(p.Embed),
+		Transcription: clonePools(p.Transcription),
 	}
 	if p.Retry != nil {
 		retry := p.Retry.Clone()
@@ -153,7 +155,7 @@ func (p Policy) Clone() Policy {
 }
 
 func (p Policy) Validate() error {
-	total := len(p.Generate) + len(p.Embed)
+	total := len(p.Generate) + len(p.Embed) + len(p.Transcription)
 	if total == 0 {
 		return fmt.Errorf("route policy has no pools")
 	}
@@ -163,6 +165,7 @@ func (p Policy) Validate() error {
 	}{
 		{operation: inference.OperationGenerate, pools: p.Generate},
 		{operation: inference.OperationEmbed, pools: p.Embed},
+		{operation: inference.OperationTranscription, pools: p.Transcription},
 	}
 	for _, entry := range operations {
 		seen := make(map[Tier]struct{}, len(entry.pools))
@@ -200,6 +203,8 @@ func hasPools(policy Policy) func(inference.Operation) bool {
 			return len(policy.Generate) > 0
 		case inference.OperationEmbed:
 			return len(policy.Embed) > 0
+		case inference.OperationTranscription:
+			return len(policy.Transcription) > 0
 		default:
 			return false
 		}
@@ -208,8 +213,9 @@ func hasPools(policy Policy) func(inference.Operation) bool {
 
 // RetryConfig is the JSON-only deployment form of RetryPolicies.
 type RetryConfig struct {
-	Generate *RetryPolicyConfig `json:"generate,omitempty"`
-	Embed    *RetryPolicyConfig `json:"embed,omitempty"`
+	Generate      *RetryPolicyConfig `json:"generate,omitempty"`
+	Embed         *RetryPolicyConfig `json:"embed,omitempty"`
+	Transcription *RetryPolicyConfig `json:"transcription,omitempty"`
 }
 
 // UnmarshalJSON enforces the JSON-only DTO boundary strictly: unknown fields
@@ -228,8 +234,9 @@ func (c *RetryConfig) UnmarshalJSON(data []byte) error {
 
 func (c RetryConfig) Clone() RetryConfig {
 	return RetryConfig{
-		Generate: c.Generate.Clone(),
-		Embed:    c.Embed.Clone(),
+		Generate:      c.Generate.Clone(),
+		Embed:         c.Embed.Clone(),
+		Transcription: c.Transcription.Clone(),
 	}
 }
 
@@ -240,6 +247,7 @@ func (c RetryConfig) validate(hasPools func(inference.Operation) bool) error {
 	}{
 		{inference.OperationGenerate, c.Generate},
 		{inference.OperationEmbed, c.Embed},
+		{inference.OperationTranscription, c.Transcription},
 	}
 	for _, entry := range entries {
 		if entry.config == nil {
@@ -267,6 +275,9 @@ func (c RetryConfig) policies() (RetryPolicies, error) {
 	}
 	if out.Embed, err = c.Embed.policy(); err != nil {
 		return RetryPolicies{}, fmt.Errorf("embed retry policy: %w", err)
+	}
+	if out.Transcription, err = c.Transcription.policy(); err != nil {
+		return RetryPolicies{}, fmt.Errorf("transcription retry policy: %w", err)
 	}
 	return out, nil
 }

--- a/core/inference/route/resilience.go
+++ b/core/inference/route/resilience.go
@@ -22,8 +22,9 @@ import (
 // RetryPolicies holds one optional retry policy per operation. A nil entry
 // disables retry for that operation (the pre-resilience behavior).
 type RetryPolicies struct {
-	Generate *RetryPolicy
-	Embed    *RetryPolicy
+	Generate      *RetryPolicy
+	Embed         *RetryPolicy
+	Transcription *RetryPolicy
 }
 
 func (p RetryPolicies) policyFor(operation inference.Operation) *RetryPolicy {
@@ -32,6 +33,8 @@ func (p RetryPolicies) policyFor(operation inference.Operation) *RetryPolicy {
 		return p.Generate
 	case inference.OperationEmbed:
 		return p.Embed
+	case inference.OperationTranscription:
+		return p.Transcription
 	default:
 		return nil
 	}

--- a/core/inference/route/route_test.go
+++ b/core/inference/route/route_test.go
@@ -2,11 +2,15 @@ package route
 
 import (
 	"context"
+	"io"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/GizClaw/flowcraft/core/errdefs"
 	"github.com/GizClaw/flowcraft/core/inference"
 	"github.com/GizClaw/flowcraft/core/message"
+	"github.com/GizClaw/flowcraft/core/message/media"
 	"github.com/GizClaw/flowcraft/core/resource"
 )
 
@@ -198,5 +202,729 @@ func TestFactoryBuildsRouterFromSettings(t *testing.T) {
 	}
 	if response.Usage.TotalTokens != 7 {
 		t.Fatalf("usage = %+v, want 7", response.Usage)
+	}
+}
+
+func transcriptionProviderDefinition(
+	t *testing.T,
+	id string,
+	fail bool,
+) inference.ProviderDefinition {
+	t.Helper()
+	return transcriptionProviderWithTransports(
+		t,
+		id,
+		routeTransport(fail),
+		routeSessionTransport(fail),
+	)
+}
+
+// transcriptionProviderWithTransports builds a transcription provider
+// definition with caller-supplied unary and session transports, so tests can
+// inject retry/circuit behavior per attempt.
+func transcriptionProviderWithTransports(
+	t *testing.T,
+	id string,
+	unaryTransport inference.Transport[routeWire, routeRaw],
+	sessionTransport inference.TranscriptionSessionTransport[routeWire, routeRawEvent],
+) inference.ProviderDefinition {
+	t.Helper()
+	unary, err := inference.BindTranscribe(
+		inference.Compiler[inference.TranscriptionRequest, routeWire](
+			func(_ context.Context, _ inference.ModelRef, request inference.TranscriptionRequest) (inference.Compiled[routeWire], error) {
+				return routeTranscriptionCompiled(request.ActiveFields())
+			},
+		),
+		unaryTransport,
+		inference.Decoder[routeRaw, inference.TranscriptionResponse](
+			func(_ context.Context, raw routeRaw) (inference.TranscriptionResponse, error) {
+				return inference.TranscriptionResponse{
+					Text:     raw.Text,
+					Segments: []inference.TranscriptionSegment{{Text: raw.Text}},
+				}, nil
+			},
+		),
+	)
+	if err != nil {
+		t.Fatalf("BindTranscribe: %v", err)
+	}
+	session, err := inference.BindTranscribeSession(
+		inference.Compiler[inference.TranscriptionSessionRequest, routeWire](
+			func(_ context.Context, _ inference.ModelRef, request inference.TranscriptionSessionRequest) (inference.Compiled[routeWire], error) {
+				return routeTranscriptionCompiled(request.ActiveFields())
+			},
+		),
+		sessionTransport,
+		inference.TranscriptionSessionDecoder[routeRawEvent](
+			func(_ context.Context, event routeRawEvent) (inference.TranscriptionSessionEvent, error) {
+				return inference.TranscriptionSessionEvent{
+					Text:  event.Text,
+					Final: event.Final,
+				}, nil
+			},
+		),
+	)
+	if err != nil {
+		t.Fatalf("BindTranscribeSession: %v", err)
+	}
+	return inference.ProviderDefinition{
+		ID: id,
+		Models: []inference.ModelImplementation{{
+			Descriptor: inference.ModelDescriptor{
+				ID: inference.ModelID{Provider: id, Name: "model-1"},
+			},
+			Openers: inference.Openers{
+				Transcribe: func(
+					_ context.Context,
+					_ inference.ModelRef,
+				) (inference.TranscribeOperations, error) {
+					return inference.TranscribeOperations{
+						Unary:   unary,
+						Session: session,
+					}, nil
+				},
+			},
+		}},
+	}
+}
+
+func routeTranscriptionCompiled(
+	active []inference.FieldID,
+) (inference.Compiled[routeWire], error) {
+	decisions := make([]inference.Decision, len(active))
+	for index, field := range active {
+		decisions[index] = inference.Decision{
+			Field:       field,
+			Disposition: inference.Native,
+		}
+	}
+	return inference.Compiled[routeWire]{
+		Wire: routeWire{},
+		Report: inference.CompileReport{
+			Operation: inference.OperationTranscription,
+			Decisions: decisions,
+		},
+	}, nil
+}
+
+type routeRawEvent struct {
+	Text  string
+	Final bool
+}
+
+type routeRawSession struct {
+	events []routeRawEvent
+}
+
+func (s *routeRawSession) Send(
+	context.Context,
+	media.AudioChunk,
+) error {
+	return nil
+}
+
+func (s *routeRawSession) Next(context.Context) (routeRawEvent, error) {
+	if len(s.events) == 0 {
+		return routeRawEvent{}, io.EOF
+	}
+	event := s.events[0]
+	s.events = s.events[1:]
+	return event, nil
+}
+
+func (s *routeRawSession) Interrupt() error { return nil }
+func (s *routeRawSession) Close() error     { return nil }
+
+func routeSessionTransport(
+	fail bool,
+) inference.TranscriptionSessionTransport[routeWire, routeRawEvent] {
+	return func(
+		context.Context,
+		routeWire,
+	) (inference.ProviderSession[routeRawEvent], error) {
+		if fail {
+			return nil, errdefs.NotAvailablef("upstream unavailable")
+		}
+		return &routeRawSession{
+			events: []routeRawEvent{{Text: "ok", Final: true}},
+		}, nil
+	}
+}
+
+// transcribeUnaryTransport fails the first failures calls with a transient
+// error, then succeeds, so tests can exercise same-target retry.
+func transcribeUnaryTransport(
+	failures int,
+) inference.Transport[routeWire, routeRaw] {
+	var mu sync.Mutex
+	calls := 0
+	return func(context.Context, routeWire) (routeRaw, error) {
+		mu.Lock()
+		calls++
+		fail := calls <= failures
+		mu.Unlock()
+		if fail {
+			return routeRaw{}, errdefs.NotAvailablef("upstream unavailable")
+		}
+		return routeRaw{Text: "ok"}, nil
+	}
+}
+
+// transcribeSessionTransport fails the first failures opens with a transient
+// error, then opens a session.
+func transcribeSessionTransport(
+	failures int,
+) inference.TranscriptionSessionTransport[routeWire, routeRawEvent] {
+	var mu sync.Mutex
+	calls := 0
+	return func(
+		context.Context,
+		routeWire,
+	) (inference.ProviderSession[routeRawEvent], error) {
+		mu.Lock()
+		calls++
+		fail := calls <= failures
+		mu.Unlock()
+		if fail {
+			return nil, errdefs.NotAvailablef("upstream unavailable")
+		}
+		return &routeRawSession{
+			events: []routeRawEvent{{Text: "ok", Final: true}},
+		}, nil
+	}
+}
+
+func routeTranscriptionRequest() inference.TranscriptionRequest {
+	source, err := media.NewAudioBytes([]byte{1, 2, 3, 4}, "audio/wav")
+	if err != nil {
+		panic(err)
+	}
+	return inference.TranscriptionRequest{Audio: source}
+}
+
+func routeTranscriptionSessionRequest() inference.TranscriptionSessionRequest {
+	return inference.TranscriptionSessionRequest{
+		InputFormat: media.AudioFormat{
+			Encoding:     media.AudioEncodingPCM16,
+			SampleRateHz: 16000,
+			Channels:     1,
+		},
+	}
+}
+
+func transcriptionAssemblyWith(
+	t *testing.T,
+	definitions map[string]inference.ProviderDefinition,
+) *inference.Assembly {
+	t.Helper()
+	deps := make(map[string]any, len(definitions))
+	for name, definition := range definitions {
+		deps["provider."+name] = definition
+	}
+	value, err := inference.Factory{}.New(context.Background(), resource.Input{
+		Deps: deps,
+	})
+	if err != nil {
+		t.Fatalf("build transcription assembly: %v", err)
+	}
+	return value.(*inference.Assembly)
+}
+
+// noopSleeper replaces the retry backoff sleeper so resilience tests run
+// without real delays. Tests live in the route package and can reach the
+// unexported routerOptions.
+func noopSleeper() Option {
+	return func(configured *routerOptions) error {
+		configured.sleeper = func(context.Context, time.Duration) error {
+			return nil
+		}
+		return nil
+	}
+}
+
+func newTranscriptionRouteAssembly(t *testing.T) *inference.Assembly {
+	t.Helper()
+	return transcriptionAssemblyWith(t, map[string]inference.ProviderDefinition{
+		"bad":  transcriptionProviderDefinition(t, "bad", true),
+		"good": transcriptionProviderDefinition(t, "good", false),
+	})
+}
+
+func TestPolicyTranscriptionPools(t *testing.T) {
+	policy := Policy{
+		Transcription: []Pool{{
+			Tier: "primary",
+			Targets: []Target{{
+				Model: inference.ModelRef{
+					ID: inference.ModelID{Provider: "good", Name: "model-1"},
+				},
+			}},
+		}},
+	}
+	if err := policy.Validate(); err != nil {
+		t.Fatalf("Validate: %v", err)
+	}
+	if err := (Policy{}).Validate(); err == nil {
+		t.Fatal("empty policy validated")
+	}
+}
+
+func TestRouterTranscribeFallsBackAcrossPools(t *testing.T) {
+	assembly := newTranscriptionRouteAssembly(t)
+	policy := Policy{
+		Transcription: []Pool{
+			{Tier: "primary", Targets: []Target{{
+				Model: inference.ModelRef{
+					ID: inference.ModelID{Provider: "bad", Name: "model-1"},
+				},
+			}}},
+			{Tier: "fallback", Targets: []Target{{
+				Model: inference.ModelRef{
+					ID: inference.ModelID{Provider: "good", Name: "model-1"},
+				},
+			}}},
+		},
+		Retry: &RetryConfig{
+			Transcription: &RetryPolicyConfig{
+				MaxAttempts:              1,
+				Retryable:                []RetryableClass{RetryableUnavailable},
+				FallbackOnRetryExhausted: true,
+			},
+		},
+	}
+	options, err := policy.Options()
+	if err != nil {
+		t.Fatalf("Options: %v", err)
+	}
+	router, err := New(assembly, policy.Selectors(), options...)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	response, trace, err := router.Transcribe(
+		context.Background(),
+		routeTranscriptionRequest(),
+	)
+	if err != nil {
+		t.Fatalf("Transcribe: %v", err)
+	}
+	if response.Text != "ok" {
+		t.Fatalf("Text = %q, want fallback response", response.Text)
+	}
+	if len(trace.Fallbacks) != 1 ||
+		trace.Fallbacks[0].From.ID.Provider != "bad" ||
+		trace.Fallbacks[0].To.ID.Provider != "good" {
+		t.Fatalf("fallbacks = %+v", trace.Fallbacks)
+	}
+}
+
+func TestRouterTranscribeSessionOpens(t *testing.T) {
+	assembly := newTranscriptionRouteAssembly(t)
+	policy := Policy{
+		Transcription: []Pool{{
+			Tier: "primary",
+			Targets: []Target{{
+				Model: inference.ModelRef{
+					ID: inference.ModelID{Provider: "good", Name: "model-1"},
+				},
+			}},
+		}},
+	}
+	router, err := New(assembly, policy.Selectors())
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	session, _, err := router.TranscribeSession(
+		context.Background(),
+		routeTranscriptionSessionRequest(),
+	)
+	if err != nil {
+		t.Fatalf("TranscribeSession: %v", err)
+	}
+	if err := session.Send(
+		context.Background(),
+		media.AudioChunk{Data: []byte{0, 0}},
+	); err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+	for {
+		_, err := session.Next(context.Background())
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			t.Fatalf("Next: %v", err)
+		}
+	}
+	response, err := session.Result()
+	if err != nil {
+		t.Fatalf("Result: %v", err)
+	}
+	if response.Text != "ok" {
+		t.Fatalf("Text = %q, want %q", response.Text, "ok")
+	}
+	if err := session.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+}
+
+func TestFactoryBuildsRouterWithTranscription(t *testing.T) {
+	assembly := newTranscriptionRouteAssembly(t)
+	factory := Factory{}
+	value, err := factory.New(context.Background(), resource.Input{
+		Deps: map[string]any{"target": assembly},
+		Settings: []byte(`{
+			"transcription": [
+				{"tier": "primary", "targets": [{"model": {"id": {"provider": "good", "name": "model-1"}}}]}
+			],
+			"retry": {
+				"transcription": {"max_attempts": 1}
+			}
+		}`),
+	})
+	if err != nil {
+		t.Fatalf("Factory.New: %v", err)
+	}
+	router, ok := value.(*Router)
+	if !ok {
+		t.Fatalf("Factory.New returned %T, want *Router", value)
+	}
+	response, _, err := router.Transcribe(
+		context.Background(),
+		routeTranscriptionRequest(),
+	)
+	if err != nil {
+		t.Fatalf("Transcribe: %v", err)
+	}
+	if response.Text != "ok" {
+		t.Fatalf("Text = %q, want %q", response.Text, "ok")
+	}
+}
+
+func TestRouterTranscribeStream(t *testing.T) {
+	assembly := newTranscriptionRouteAssembly(t)
+	policy := Policy{
+		Transcription: []Pool{{
+			Tier: "primary",
+			Targets: []Target{{
+				Model: inference.ModelRef{
+					ID: inference.ModelID{Provider: "good", Name: "model-1"},
+				},
+			}},
+		}},
+	}
+	router, err := New(assembly, policy.Selectors())
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	source, err := media.NewAudioBytes([]byte{0, 0}, "audio/pcm")
+	if err != nil {
+		t.Fatalf("NewAudioBytes: %v", err)
+	}
+	pipe := message.NewPartPipe(1)
+	pipe.Send(message.AudioPart{Source: source})
+	pipe.Close()
+	response, trace, err := router.TranscribeStream(
+		context.Background(),
+		routeTranscriptionSessionRequest(),
+		pipe,
+	)
+	if err != nil {
+		t.Fatalf("TranscribeStream: %v", err)
+	}
+	if response.Text != "ok" {
+		t.Fatalf("Text = %q, want %q", response.Text, "ok")
+	}
+	if trace.Executed.ID.Provider != "good" {
+		t.Fatalf("trace executed = %+v, want good provider", trace.Executed)
+	}
+}
+
+func TestRouterTranscribeRetriesSameTarget(t *testing.T) {
+	retryRef := inference.ModelRef{
+		ID: inference.ModelID{Provider: "retry", Name: "model-1"},
+	}
+	assembly := transcriptionAssemblyWith(t, map[string]inference.ProviderDefinition{
+		"retry": transcriptionProviderWithTransports(
+			t,
+			"retry",
+			transcribeUnaryTransport(1),
+			routeSessionTransport(false),
+		),
+	})
+	policy := Policy{
+		Transcription: []Pool{{
+			Tier:    "primary",
+			Targets: []Target{{Model: retryRef}},
+		}},
+		Retry: &RetryConfig{
+			Transcription: &RetryPolicyConfig{
+				MaxAttempts: 2,
+				Retryable:   []RetryableClass{RetryableUnavailable},
+			},
+		},
+	}
+	options, err := policy.Options()
+	if err != nil {
+		t.Fatalf("Options: %v", err)
+	}
+	router, err := New(
+		assembly,
+		policy.Selectors(),
+		append(options, noopSleeper())...,
+	)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	response, trace, err := router.Transcribe(
+		context.Background(), routeTranscriptionRequest(),
+	)
+	if err != nil {
+		t.Fatalf("Transcribe: %v", err)
+	}
+	if response.Text != "ok" {
+		t.Fatalf("Text = %q, want %q", response.Text, "ok")
+	}
+	if len(trace.Attempts) != 2 {
+		t.Fatalf("attempts = %d, want 2", len(trace.Attempts))
+	}
+	first, second := trace.Attempts[0], trace.Attempts[1]
+	if first.Outcome != AttemptOutcomeFailed ||
+		first.Trigger != AttemptTriggerSelection ||
+		!first.Transient {
+		t.Fatalf("first attempt = %+v, want transient failed selection", first)
+	}
+	if second.Outcome != AttemptOutcomeSucceeded ||
+		second.Trigger != AttemptTriggerRetry {
+		t.Fatalf("second attempt = %+v, want retried success", second)
+	}
+	if trace.Executed != retryRef {
+		t.Fatalf("executed = %+v, want retry target", trace.Executed)
+	}
+}
+
+func TestRouterTranscribeCircuitBreakerSkipsOpenTarget(t *testing.T) {
+	badRef := inference.ModelRef{
+		ID: inference.ModelID{Provider: "bad", Name: "model-1"},
+	}
+	assembly := newTranscriptionRouteAssembly(t)
+	policy := Policy{
+		Transcription: []Pool{{
+			Tier:    "primary",
+			Targets: []Target{{Model: badRef}},
+		}},
+		CircuitBreaker: &CircuitBreakerConfig{
+			FailureThreshold: 1,
+			RecoveryWindow:   time.Hour,
+		},
+	}
+	options, err := policy.Options()
+	if err != nil {
+		t.Fatalf("Options: %v", err)
+	}
+	router, err := New(
+		assembly,
+		policy.Selectors(),
+		append(options, noopSleeper())...,
+	)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	_, trace, err := router.Transcribe(
+		context.Background(), routeTranscriptionRequest(),
+	)
+	if err == nil {
+		t.Fatal("first Transcribe succeeded against a failing target")
+	}
+	if len(trace.Attempts) != 1 ||
+		trace.Attempts[0].Outcome != AttemptOutcomeFailed ||
+		trace.Attempts[0].CircuitTransition != "open" {
+		t.Fatalf("first attempts = %+v, want failure that opens the circuit",
+			trace.Attempts)
+	}
+
+	_, trace, err = router.Transcribe(
+		context.Background(), routeTranscriptionRequest(),
+	)
+	if !IsKind(err, CircuitOpen) {
+		t.Fatalf("second Transcribe = %v, want circuit-open rejection", err)
+	}
+	if len(trace.Attempts) != 1 ||
+		trace.Attempts[0].Outcome != AttemptOutcomeSkipped ||
+		trace.Attempts[0].Circuit != "open" {
+		t.Fatalf("second attempts = %+v, want circuit-open skip", trace.Attempts)
+	}
+}
+
+func TestRouterTranscribeSessionRetriesOpen(t *testing.T) {
+	retryRef := inference.ModelRef{
+		ID: inference.ModelID{Provider: "retry", Name: "model-1"},
+	}
+	assembly := transcriptionAssemblyWith(t, map[string]inference.ProviderDefinition{
+		"retry": transcriptionProviderWithTransports(
+			t,
+			"retry",
+			routeTransport(false),
+			transcribeSessionTransport(1),
+		),
+	})
+	policy := Policy{
+		Transcription: []Pool{{
+			Tier:    "primary",
+			Targets: []Target{{Model: retryRef}},
+		}},
+		Retry: &RetryConfig{
+			Transcription: &RetryPolicyConfig{
+				MaxAttempts: 2,
+				Retryable:   []RetryableClass{RetryableUnavailable},
+			},
+		},
+	}
+	options, err := policy.Options()
+	if err != nil {
+		t.Fatalf("Options: %v", err)
+	}
+	router, err := New(
+		assembly,
+		policy.Selectors(),
+		append(options, noopSleeper())...,
+	)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	session, trace, err := router.TranscribeSession(
+		context.Background(), routeTranscriptionSessionRequest(),
+	)
+	if err != nil {
+		t.Fatalf("TranscribeSession: %v", err)
+	}
+	if session == nil {
+		t.Fatal("TranscribeSession returned a nil session")
+	}
+	// Each logical open attempt re-runs the session preflight, so one
+	// retry yields four attempts: preflight+open per logical attempt.
+	if len(trace.Attempts) != 4 {
+		t.Fatalf("attempts = %d, want 4", len(trace.Attempts))
+	}
+	first, second := trace.Attempts[1], trace.Attempts[3]
+	if first.Outcome != AttemptOutcomeFailed ||
+		first.Phase != AttemptPhaseOpen ||
+		!first.Transient {
+		t.Fatalf("first attempt = %+v, want transient open failure", first)
+	}
+	if second.Outcome != AttemptOutcomeOpened ||
+		second.Trigger != AttemptTriggerRetry {
+		t.Fatalf("second attempt = %+v, want retried open", second)
+	}
+	if trace.Executed != retryRef {
+		t.Fatalf("executed = %+v, want retry target", trace.Executed)
+	}
+}
+
+func TestRouterTranscribeSessionFallsBackAfterRetryExhausted(t *testing.T) {
+	badRef := inference.ModelRef{
+		ID: inference.ModelID{Provider: "bad", Name: "model-1"},
+	}
+	goodRef := inference.ModelRef{
+		ID: inference.ModelID{Provider: "good", Name: "model-1"},
+	}
+	assembly := newTranscriptionRouteAssembly(t)
+	policy := Policy{
+		Transcription: []Pool{
+			{Tier: "primary", Targets: []Target{{Model: badRef}}},
+			{Tier: "fallback", Targets: []Target{{Model: goodRef}}},
+		},
+		Retry: &RetryConfig{
+			Transcription: &RetryPolicyConfig{
+				MaxAttempts:              1,
+				Retryable:                []RetryableClass{RetryableUnavailable},
+				FallbackOnRetryExhausted: true,
+			},
+		},
+	}
+	options, err := policy.Options()
+	if err != nil {
+		t.Fatalf("Options: %v", err)
+	}
+	router, err := New(
+		assembly,
+		policy.Selectors(),
+		append(options, noopSleeper())...,
+	)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	session, trace, err := router.TranscribeSession(
+		context.Background(), routeTranscriptionSessionRequest(),
+	)
+	if err != nil {
+		t.Fatalf("TranscribeSession: %v", err)
+	}
+	if session == nil {
+		t.Fatal("TranscribeSession returned a nil session")
+	}
+	if len(trace.Fallbacks) != 1 ||
+		trace.Fallbacks[0].From != badRef ||
+		trace.Fallbacks[0].To != goodRef {
+		t.Fatalf("fallbacks = %+v, want bad -> good", trace.Fallbacks)
+	}
+	if trace.Executed != goodRef {
+		t.Fatalf("executed = %+v, want fallback target", trace.Executed)
+	}
+}
+
+func TestRouterTranscribeSessionCircuitBreakerSkipsOpenTarget(t *testing.T) {
+	badRef := inference.ModelRef{
+		ID: inference.ModelID{Provider: "bad", Name: "model-1"},
+	}
+	assembly := newTranscriptionRouteAssembly(t)
+	policy := Policy{
+		Transcription: []Pool{{
+			Tier:    "primary",
+			Targets: []Target{{Model: badRef}},
+		}},
+		CircuitBreaker: &CircuitBreakerConfig{
+			FailureThreshold: 1,
+			RecoveryWindow:   time.Hour,
+		},
+	}
+	options, err := policy.Options()
+	if err != nil {
+		t.Fatalf("Options: %v", err)
+	}
+	router, err := New(
+		assembly,
+		policy.Selectors(),
+		append(options, noopSleeper())...,
+	)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	_, trace, err := router.TranscribeSession(
+		context.Background(), routeTranscriptionSessionRequest(),
+	)
+	if err == nil {
+		t.Fatal("first TranscribeSession succeeded against a failing target")
+	}
+	if len(trace.Attempts) != 2 {
+		t.Fatalf("first attempts = %d, want 2 (preflight + open)",
+			len(trace.Attempts))
+	}
+	openAttempt := trace.Attempts[1]
+	if openAttempt.Outcome != AttemptOutcomeFailed ||
+		openAttempt.CircuitTransition != "open" {
+		t.Fatalf("first attempts = %+v, want failure that opens the circuit",
+			trace.Attempts)
+	}
+
+	_, trace, err = router.TranscribeSession(
+		context.Background(), routeTranscriptionSessionRequest(),
+	)
+	if !IsKind(err, CircuitOpen) {
+		t.Fatalf("second TranscribeSession = %v, want circuit-open rejection", err)
+	}
+	if len(trace.Attempts) != 1 ||
+		trace.Attempts[0].Outcome != AttemptOutcomeSkipped ||
+		trace.Attempts[0].Circuit != "open" {
+		t.Fatalf("second attempts = %+v, want circuit-open skip", trace.Attempts)
 	}
 }

--- a/core/inference/route/router.go
+++ b/core/inference/route/router.go
@@ -12,10 +12,14 @@ import (
 )
 
 type Selectors struct {
-	Generate         GenerateSelector
-	GenerateFallback GenerateFallbackPolicy
-	Embed            EmbedSelector
-	EmbedFallback    EmbedFallbackPolicy
+	Generate                  GenerateSelector
+	GenerateFallback          GenerateFallbackPolicy
+	Embed                     EmbedSelector
+	EmbedFallback             EmbedFallbackPolicy
+	Transcribe                TranscribeSelector
+	TranscribeFallback        TranscribeFallbackPolicy
+	TranscribeSession         TranscriptionSessionSelector
+	TranscribeSessionFallback TranscriptionSessionFallbackPolicy
 }
 
 // Decision is the selector output before inference execution. Proposed records
@@ -164,7 +168,9 @@ func New(
 		return nil, errdefs.Validationf("inference assembly is required")
 	}
 	if isNilInterface(selectors.Generate) &&
-		isNilInterface(selectors.Embed) {
+		isNilInterface(selectors.Embed) &&
+		isNilInterface(selectors.Transcribe) &&
+		isNilInterface(selectors.TranscribeSession) {
 		return nil, errdefs.Validationf("at least one route selector is required")
 	}
 	orphans := []struct {
@@ -174,6 +180,8 @@ func New(
 	}{
 		{inference.OperationGenerate, selectors.Generate, selectors.GenerateFallback},
 		{inference.OperationEmbed, selectors.Embed, selectors.EmbedFallback},
+		{inference.OperationTranscription, selectors.Transcribe, selectors.TranscribeFallback},
+		{inference.OperationTranscription, selectors.TranscribeSession, selectors.TranscribeSessionFallback},
 	}
 	for _, orphan := range orphans {
 		if !isNilInterface(orphan.fallback) && isNilInterface(orphan.selector) {
@@ -236,6 +244,22 @@ func validateRetryPolicies(
 		}
 		if err := entry.policy.validate(); err != nil {
 			return errdefs.Validationf("%s retry policy: %v", entry.operation, err)
+		}
+	}
+	if policies.Transcription != nil {
+		// Transcription pools serve both the unary and session selectors,
+		// so one retry policy covers either surface.
+		if isNilInterface(selectors.Transcribe) &&
+			isNilInterface(selectors.TranscribeSession) {
+			return errdefs.Validationf(
+				"transcription retry policy requires a transcription selector",
+			)
+		}
+		if err := policies.Transcription.validate(); err != nil {
+			return errdefs.Validationf(
+				"transcription retry policy: %v",
+				err,
+			)
 		}
 	}
 	return nil

--- a/core/inference/route/router_policy.go
+++ b/core/inference/route/router_policy.go
@@ -21,11 +21,16 @@ import (
 func (p Policy) Selectors() Selectors {
 	generate := newPolicyRoute(inference.OperationGenerate, p.Generate)
 	embed := newPolicyRoute(inference.OperationEmbed, p.Embed)
+	transcribe := newPolicyRoute(inference.OperationTranscription, p.Transcription)
 	return Selectors{
-		Generate:         generate,
-		GenerateFallback: generate,
-		Embed:            embed,
-		EmbedFallback:    embed,
+		Generate:                  generate,
+		GenerateFallback:          generate,
+		Embed:                     embed,
+		EmbedFallback:             embed,
+		Transcribe:                transcribe,
+		TranscribeFallback:        transcribe,
+		TranscribeSession:         transcribe,
+		TranscribeSessionFallback: transcribe,
 	}
 }
 
@@ -117,6 +122,36 @@ func (r *policyRoute) SelectEmbed(
 func (r *policyRoute) NextEmbed(
 	_ context.Context,
 	_ inference.EmbedRequest,
+	attempt Attempt,
+) (inference.ModelRef, bool, error) {
+	return r.nextTarget(attempt)
+}
+
+func (r *policyRoute) SelectTranscribe(
+	context.Context,
+	inference.TranscriptionRequest,
+) (Decision, error) {
+	return r.selectTarget()
+}
+
+func (r *policyRoute) NextTranscribe(
+	_ context.Context,
+	_ inference.TranscriptionRequest,
+	attempt Attempt,
+) (inference.ModelRef, bool, error) {
+	return r.nextTarget(attempt)
+}
+
+func (r *policyRoute) SelectTranscribeSession(
+	context.Context,
+	inference.TranscriptionSessionRequest,
+) (Decision, error) {
+	return r.selectTarget()
+}
+
+func (r *policyRoute) NextTranscribeSession(
+	_ context.Context,
+	_ inference.TranscriptionSessionRequest,
 	attempt Attempt,
 ) (inference.ModelRef, bool, error) {
 	return r.nextTarget(attempt)

--- a/core/inference/route/router_transcribe.go
+++ b/core/inference/route/router_transcribe.go
@@ -1,0 +1,213 @@
+package route
+
+import (
+	"context"
+	"errors"
+	"io"
+
+	"github.com/GizClaw/flowcraft/core/inference"
+	"github.com/GizClaw/flowcraft/core/message"
+)
+
+type TranscribeSelector interface {
+	SelectTranscribe(context.Context, inference.TranscriptionRequest) (Decision, error)
+}
+
+// TranscribeFallbackPolicy chooses another exact target after a structured,
+// transport-safe failed unary transcription attempt. Both the request and
+// attempt are snapshots; returning ok=false stops fallback.
+type TranscribeFallbackPolicy interface {
+	NextTranscribe(
+		context.Context,
+		inference.TranscriptionRequest,
+		Attempt,
+	) (inference.ModelRef, bool, error)
+}
+
+type TranscriptionSessionSelector interface {
+	SelectTranscribeSession(
+		context.Context,
+		inference.TranscriptionSessionRequest,
+	) (Decision, error)
+}
+
+// TranscriptionSessionFallbackPolicy chooses another exact target after a
+// structured, transport-safe failed session open. Fallback exists only
+// before open: once a session opens it belongs to the caller.
+type TranscriptionSessionFallbackPolicy interface {
+	NextTranscribeSession(
+		context.Context,
+		inference.TranscriptionSessionRequest,
+		Attempt,
+	) (inference.ModelRef, bool, error)
+}
+
+func (r *Router) Transcribe(
+	ctx context.Context,
+	request inference.TranscriptionRequest,
+) (inference.TranscriptionResponse, Trace, error) {
+	ctx, span := startRouteSpan(ctx, inference.OperationTranscription)
+	response, trace, err := executeWithFallback(r,
+		ctx,
+		inference.OperationTranscription,
+		request.Clone(),
+		inference.TranscriptionRequest.Clone,
+		inference.TranscriptionRequest.Validate,
+		r.selectors.Transcribe,
+		func(ctx context.Context, snapshot inference.TranscriptionRequest) (Decision, error) {
+			return r.selectors.Transcribe.SelectTranscribe(ctx, snapshot)
+		},
+		transcribeFallbackNext(r.selectors.TranscribeFallback),
+		nil,
+		func(ctx context.Context, target inference.ModelRef, snapshot inference.TranscriptionRequest) (inference.TranscriptionResponse, inference.Metadata, error) {
+			response, err := r.target.Transcribe(ctx, target, snapshot)
+			return response, response.Metadata, err
+		},
+	)
+	recordRoute(ctx, span, inference.OperationTranscription, trace, response.Metadata, err)
+	return response, trace, err
+}
+
+func (r *Router) ExplainTranscribe(
+	ctx context.Context,
+	request inference.TranscriptionRequest,
+) (inference.Explanation, Decision, error) {
+	snapshot := request.Clone()
+	decision, err := selectTarget(
+		ctx,
+		r.target,
+		inference.OperationTranscription,
+		snapshot,
+		inference.TranscriptionRequest.Clone,
+		inference.TranscriptionRequest.Validate,
+		r.selectors.Transcribe,
+		func(ctx context.Context, snapshot inference.TranscriptionRequest) (Decision, error) {
+			return r.selectors.Transcribe.SelectTranscribe(ctx, snapshot)
+		},
+	)
+	if err != nil {
+		return inference.Explanation{}, Decision{}, err
+	}
+	explanation, err := r.target.ExplainTranscribe(
+		ctx,
+		decision.Selected,
+		snapshot,
+	)
+	return explanation, decision, err
+}
+
+func (r *Router) TranscribeSession(
+	ctx context.Context,
+	request inference.TranscriptionSessionRequest,
+) (session inference.TranscriptionSession, routeTrace Trace, err error) {
+	ctx, span := startRouteSpan(ctx, inference.OperationTranscription)
+	snapshot := request.Clone()
+	session, routeTrace, err = openSessionWithFallback(r,
+		ctx,
+		inference.OperationTranscription,
+		snapshot,
+		inference.TranscriptionSessionRequest.Clone,
+		inference.TranscriptionSessionRequest.Validate,
+		r.selectors.TranscribeSession,
+		func(ctx context.Context, snapshot inference.TranscriptionSessionRequest) (Decision, error) {
+			return r.selectors.TranscribeSession.SelectTranscribeSession(ctx, snapshot)
+		},
+		transcribeSessionFallbackNext(r.selectors.TranscribeSessionFallback),
+		func(ctx context.Context, target inference.ModelRef, snapshot inference.TranscriptionSessionRequest) error {
+			_, err := r.target.ExplainTranscribeSession(ctx, target, snapshot)
+			return err
+		},
+		func(ctx context.Context, target inference.ModelRef, snapshot inference.TranscriptionSessionRequest) (inference.TranscriptionSession, error) {
+			return r.target.TranscribeSession(ctx, target, snapshot)
+		},
+	)
+	if err != nil {
+		recordRoute(
+			ctx, span, inference.OperationTranscription, routeTrace,
+			inference.Metadata{}, err,
+		)
+		return session, routeTrace, err
+	}
+	session = wrapRouteTranscriptionSession(
+		ctx, span, inference.OperationTranscription, routeTrace, session)
+	return session, routeTrace, err
+}
+
+// TranscribeStream opens a routed transcription session, feeds the live
+// part stream into it, drains the session to EOF, and returns the final
+// transcript with the route trace. It is the one-shot form of
+// [Router.TranscribeSession] plus [inference.FeedTranscription]; callers
+// that want partial events as they arrive use the session directly.
+func (r *Router) TranscribeStream(
+	ctx context.Context,
+	request inference.TranscriptionSessionRequest,
+	stream message.Stream,
+) (inference.TranscriptionResponse, Trace, error) {
+	session, routeTrace, err := r.TranscribeSession(ctx, request)
+	if err != nil {
+		return inference.TranscriptionResponse{}, routeTrace, err
+	}
+	if err := inference.FeedTranscription(
+		ctx, session, request.InputFormat, stream,
+	); err != nil {
+		return inference.TranscriptionResponse{}, routeTrace, err
+	}
+	for {
+		if _, err := session.Next(ctx); err != nil {
+			if errors.Is(err, io.EOF) {
+				break
+			}
+			return inference.TranscriptionResponse{}, routeTrace, err
+		}
+	}
+	response, err := session.Result()
+	return response, routeTrace, err
+}
+
+// ExplainTranscribeSession compiles the selected target's transcription
+// session request without provider I/O.
+func (r *Router) ExplainTranscribeSession(
+	ctx context.Context,
+	request inference.TranscriptionSessionRequest,
+) (inference.Explanation, Decision, error) {
+	snapshot := request.Clone()
+	decision, err := selectTarget(
+		ctx,
+		r.target,
+		inference.OperationTranscription,
+		snapshot,
+		inference.TranscriptionSessionRequest.Clone,
+		inference.TranscriptionSessionRequest.Validate,
+		r.selectors.TranscribeSession,
+		func(ctx context.Context, snapshot inference.TranscriptionSessionRequest) (Decision, error) {
+			return r.selectors.TranscribeSession.SelectTranscribeSession(ctx, snapshot)
+		},
+	)
+	if err != nil {
+		return inference.Explanation{}, Decision{}, err
+	}
+	explanation, err := r.target.ExplainTranscribeSession(
+		ctx,
+		decision.Selected,
+		snapshot,
+	)
+	return explanation, decision, err
+}
+
+func transcribeFallbackNext(
+	policy TranscribeFallbackPolicy,
+) func(context.Context, inference.TranscriptionRequest, Attempt) (inference.ModelRef, bool, error) {
+	if isNilInterface(policy) {
+		return nil
+	}
+	return policy.NextTranscribe
+}
+
+func transcribeSessionFallbackNext(
+	policy TranscriptionSessionFallbackPolicy,
+) func(context.Context, inference.TranscriptionSessionRequest, Attempt) (inference.ModelRef, bool, error) {
+	if isNilInterface(policy) {
+		return nil
+	}
+	return policy.NextTranscribeSession
+}

--- a/core/inference/route/telemetry.go
+++ b/core/inference/route/telemetry.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/GizClaw/flowcraft/core/errdefs"
 	"github.com/GizClaw/flowcraft/core/inference"
+	"github.com/GizClaw/flowcraft/core/message/media"
 	"github.com/GizClaw/flowcraft/core/telemetry"
 
 	"go.opentelemetry.io/otel/attribute"
@@ -199,5 +200,79 @@ func (s *routeGenerateStream) Close() error {
 	err := s.inner.Close()
 	s.finish(inference.Metadata{}, errdefs.Validationf(
 		"inference route: stream closed before completion"))
+	return err
+}
+
+// routeTranscriptionSession defers the route span close from session-open
+// time to session completion, mirroring routeGenerateStream. A session may
+// also end through Interrupt (barge-in), which reports the interruption to
+// the span.
+type routeTranscriptionSession struct {
+	inner      inference.TranscriptionSession
+	ctx        context.Context
+	span       trace.Span
+	operation  inference.Operation
+	routeTrace Trace
+	once       sync.Once
+}
+
+func wrapRouteTranscriptionSession(
+	ctx context.Context,
+	span trace.Span,
+	operation inference.Operation,
+	routeTrace Trace,
+	inner inference.TranscriptionSession,
+) inference.TranscriptionSession {
+	return &routeTranscriptionSession{
+		inner:      inner,
+		ctx:        ctx,
+		span:       span,
+		operation:  operation,
+		routeTrace: routeTrace,
+	}
+}
+
+func (s *routeTranscriptionSession) finish(
+	metadata inference.Metadata,
+	err error,
+) {
+	s.once.Do(func() {
+		recordRoute(s.ctx, s.span, s.operation, s.routeTrace, metadata, err)
+	})
+}
+
+func (s *routeTranscriptionSession) Send(
+	ctx context.Context,
+	chunk media.AudioChunk,
+) error {
+	return s.inner.Send(ctx, chunk)
+}
+
+func (s *routeTranscriptionSession) Next(
+	ctx context.Context,
+) (inference.TranscriptionSessionEvent, error) {
+	event, err := s.inner.Next(ctx)
+	if err != nil && !errors.Is(err, io.EOF) {
+		s.finish(inference.Metadata{}, err)
+	}
+	return event, err
+}
+
+func (s *routeTranscriptionSession) Result() (inference.TranscriptionResponse, error) {
+	response, err := s.inner.Result()
+	s.finish(response.Metadata, err)
+	return response, err
+}
+
+func (s *routeTranscriptionSession) Interrupt() error {
+	err := s.inner.Interrupt()
+	s.finish(inference.Metadata{}, err)
+	return err
+}
+
+func (s *routeTranscriptionSession) Close() error {
+	err := s.inner.Close()
+	s.finish(inference.Metadata{}, errdefs.Validationf(
+		"inference route: transcription session closed before completion"))
 	return err
 }

--- a/core/inference/stream_source_test.go
+++ b/core/inference/stream_source_test.go
@@ -1,0 +1,43 @@
+package inference
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/GizClaw/flowcraft/core/message"
+	"github.com/GizClaw/flowcraft/core/message/media"
+)
+
+func TestGenerateRequestRejectsStreamSourcesInContextAndInput(t *testing.T) {
+	pipe := message.NewPartPipe(0)
+	source, err := media.NewAudioStream[message.Part](pipe, "audio/pcm")
+	if err != nil {
+		t.Fatalf("NewAudioStream: %v", err)
+	}
+	streamPart := message.AudioPart{Source: source}
+
+	inContext := GenerateRequest{
+		Context: []message.Message{{
+			Role:    message.RoleUser,
+			Content: message.Content{Parts: []message.Part{streamPart}},
+		}},
+	}
+	if err := inContext.Validate(); err == nil ||
+		!strings.Contains(err.Error(), "not allowed in context") {
+		t.Fatalf("context Validate = %v, want context rejection", err)
+	}
+
+	inInput := GenerateRequest{
+		Input: GenerateInput{
+			Role: InputRoleUser,
+			Content: InputContent{
+				Content: message.Content{Parts: []message.Part{streamPart}},
+				Intent:  Intent{Text: &TextIntent{}},
+			},
+		},
+	}
+	if err := inInput.Validate(); err == nil ||
+		!strings.Contains(err.Error(), "not allowed") {
+		t.Fatalf("input Validate = %v, want input rejection", err)
+	}
+}

--- a/core/inference/transcribe.go
+++ b/core/inference/transcribe.go
@@ -1,0 +1,808 @@
+package inference
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/GizClaw/flowcraft/core/errdefs"
+	"github.com/GizClaw/flowcraft/core/message/media"
+)
+
+// TranscriptionRequest is the canonical input for whole-file speech
+// recognition. The audio source is mandatory; language, prompt, and
+// timestamps are optional provider-neutral controls whose support is decided
+// per driver at compile time through the field ledger.
+type TranscriptionRequest struct {
+	Audio      media.AudioSource `json:"audio"`
+	Language   string            `json:"language,omitempty"`
+	Prompt     string            `json:"prompt,omitempty"`
+	Timestamps bool              `json:"timestamps,omitempty"`
+	Extensions Extensions        `json:"-" ledger:"extension"`
+}
+
+func (r TranscriptionRequest) Clone() TranscriptionRequest {
+	r.Audio = r.Audio.Clone()
+	r.Extensions = r.Extensions.Clone()
+	return r
+}
+
+func (r TranscriptionRequest) Validate() error {
+	if err := r.Audio.Validate(); err != nil {
+		return err
+	}
+	if r.Audio.Kind() == media.SourceStream {
+		return fmt.Errorf(
+			"transcription request audio must be complete: " +
+				"use TranscribeSession for stream sources",
+		)
+	}
+	return r.Extensions.Validate()
+}
+
+func (r TranscriptionRequest) ActiveFields() []FieldID {
+	fields := []FieldID{FieldTranscriptionAudio}
+	if r.Language != "" {
+		fields = append(fields, FieldTranscriptionLanguage)
+	}
+	if r.Prompt != "" {
+		fields = append(fields, FieldTranscriptionPrompt)
+	}
+	if r.Timestamps {
+		fields = append(fields, FieldTranscriptionTimestamps)
+	}
+	return r.Extensions.AppendActiveFields(fields)
+}
+
+// TranscriptionSegment is one completed utterance of a transcript.
+// StartMillis/EndMillis bound the utterance in the session's audio timeline
+// when the provider reports timing; Words carries word-level timing when
+// available.
+type TranscriptionSegment struct {
+	Text        string              `json:"text"`
+	StartMillis int64               `json:"start_millis,omitempty"`
+	EndMillis   int64               `json:"end_millis,omitempty"`
+	Words       []TranscriptionWord `json:"words,omitempty"`
+}
+
+func (s TranscriptionSegment) Validate() error {
+	if s.Text == "" {
+		return fmt.Errorf("transcription segment text is required")
+	}
+	if s.StartMillis < 0 || s.EndMillis < 0 {
+		return fmt.Errorf("transcription segment timestamps must not be negative")
+	}
+	if s.StartMillis != 0 && s.EndMillis != 0 && s.EndMillis < s.StartMillis {
+		return fmt.Errorf("transcription segment end precedes start")
+	}
+	for index, word := range s.Words {
+		if err := word.Validate(); err != nil {
+			return fmt.Errorf("transcription segment word %d: %w", index, err)
+		}
+	}
+	return nil
+}
+
+type TranscriptionWord struct {
+	Word        string `json:"word"`
+	StartMillis int64  `json:"start_millis,omitempty"`
+	EndMillis   int64  `json:"end_millis,omitempty"`
+}
+
+func (w TranscriptionWord) Validate() error {
+	if w.Word == "" {
+		return fmt.Errorf("transcription word text is required")
+	}
+	if w.StartMillis < 0 || w.EndMillis < 0 {
+		return fmt.Errorf("transcription word timestamps must not be negative")
+	}
+	if w.StartMillis != 0 && w.EndMillis != 0 && w.EndMillis < w.StartMillis {
+		return fmt.Errorf("transcription word end precedes start")
+	}
+	return nil
+}
+
+// TranscriptionResponse is the canonical recognition result. Text is the
+// joined transcript; Segments carries per-utterance text with optional
+// timing; Language reports the request hint or the detected language;
+// DurationMillis is the recognized audio duration when the provider reports
+// one.
+type TranscriptionResponse struct {
+	Text           string                 `json:"text"`
+	Segments       []TranscriptionSegment `json:"segments,omitempty"`
+	Language       string                 `json:"language,omitempty"`
+	DurationMillis *int64                 `json:"duration_millis,omitempty"`
+	Usage          Usage                  `json:"usage"`
+	Metadata       Metadata               `json:"metadata"`
+}
+
+func (r TranscriptionResponse) Clone() TranscriptionResponse {
+	r.Segments = append([]TranscriptionSegment(nil), r.Segments...)
+	r.Usage = r.Usage.Clone()
+	r.Metadata = r.Metadata.Clone()
+	return r
+}
+
+func (r TranscriptionResponse) ValidateFor(request TranscriptionRequest) error {
+	if err := validateTranscriptionSegments(r.Segments); err != nil {
+		return err
+	}
+	if r.DurationMillis != nil && *r.DurationMillis < 0 {
+		return fmt.Errorf("transcription duration must not be negative")
+	}
+	return nil
+}
+
+func validateTranscriptionSegments(segments []TranscriptionSegment) error {
+	for index, segment := range segments {
+		if err := segment.Validate(); err != nil {
+			return fmt.Errorf("transcription segment %d: %w", index, err)
+		}
+	}
+	return nil
+}
+
+// TranscriptionSessionRequest opens a duplex speech-recognition session.
+// Audio arrives incrementally after open through TranscriptionSession.Send;
+// InputFormat is therefore mandatory and negotiated at open time. Language,
+// Prompt, and Timestamps follow the unary semantics.
+type TranscriptionSessionRequest struct {
+	InputFormat media.AudioFormat `json:"input_format"`
+	Language    string            `json:"language,omitempty"`
+	Prompt      string            `json:"prompt,omitempty"`
+	Timestamps  bool              `json:"timestamps,omitempty"`
+	Extensions  Extensions        `json:"-" ledger:"extension"`
+}
+
+func (r TranscriptionSessionRequest) Clone() TranscriptionSessionRequest {
+	r.Extensions = r.Extensions.Clone()
+	return r
+}
+
+func (r TranscriptionSessionRequest) Validate() error {
+	if err := r.InputFormat.Validate(); err != nil {
+		return fmt.Errorf("transcription session input format: %w", err)
+	}
+	return r.Extensions.Validate()
+}
+
+func (r TranscriptionSessionRequest) ActiveFields() []FieldID {
+	fields := []FieldID{FieldTranscriptionInputFormat}
+	if r.Language != "" {
+		fields = append(fields, FieldTranscriptionLanguage)
+	}
+	if r.Prompt != "" {
+		fields = append(fields, FieldTranscriptionPrompt)
+	}
+	if r.Timestamps {
+		fields = append(fields, FieldTranscriptionTimestamps)
+	}
+	return r.Extensions.AppendActiveFields(fields)
+}
+
+// TranscriptionSessionEvent is one canonical session event. Text carries the
+// full current utterance hypothesis (partial); Final closes the current
+// utterance and commits it to the transcript; Segment is an alternative
+// provider style that commits a completed utterance directly. Providers
+// choose one style per event, never both.
+type TranscriptionSessionEvent struct {
+	Text        string                `json:"text,omitempty"`
+	Final       bool                  `json:"final,omitempty"`
+	Segment     *TranscriptionSegment `json:"segment,omitempty"`
+	StartMillis int64                 `json:"start_millis,omitempty"`
+	EndMillis   int64                 `json:"end_millis,omitempty"`
+	Language    string                `json:"language,omitempty"`
+	// Usage is a cumulative session snapshot and replaces the previous
+	// snapshot.
+	Usage      *Usage `json:"usage,omitempty"`
+	RequestID  string `json:"request_id,omitempty"`
+	ResponseID string `json:"response_id,omitempty"`
+}
+
+func (e TranscriptionSessionEvent) empty() bool {
+	return e.Text == "" && !e.Final && e.Segment == nil &&
+		e.StartMillis == 0 && e.EndMillis == 0 && e.Language == "" &&
+		e.Usage == nil && e.RequestID == "" && e.ResponseID == ""
+}
+
+// TranscriptionSession is the canonical duplex recognition session: the
+// caller feeds audio chunks in and drains partial/final transcript events
+// out. Send and Next may be called concurrently. Next returns io.EOF after
+// the provider ends the session normally; Result then yields the final
+// transcript. Interrupt terminates the session abnormally (barge-in): after
+// Interrupt, Send/Next/Result fail with an interruption error and no Result
+// is produced. Close ends the session normally without producing a result by
+// itself; callers drain Next to EOF first.
+type TranscriptionSession interface {
+	Send(context.Context, media.AudioChunk) error
+	Next(context.Context) (TranscriptionSessionEvent, error)
+	Result() (TranscriptionResponse, error)
+	Interrupt() error
+	Close() error
+}
+
+// TranscriptionSessionDecoder converts provider-native session events into
+// canonical TranscriptionSessionEvents. Implementations must support
+// concurrent calls; sessions serialize decoder use themselves.
+type TranscriptionSessionDecoder[RawEvent any] func(
+	context.Context,
+	RawEvent,
+) (TranscriptionSessionEvent, error)
+
+// ProviderSession is the provider-native bidirectional session opened by a
+// transcription transport. Send receives canonical chunks and encodes them
+// to the provider wire format; Next returns provider-native events.
+type ProviderSession[RawEvent any] interface {
+	Send(context.Context, media.AudioChunk) error
+	Next(context.Context) (RawEvent, error)
+	Interrupt() error
+	Close() error
+}
+
+// TranscriptionSessionTransport opens a provider-native session. It is the
+// sole stage allowed to perform provider I/O for sessions; like every
+// transport it must support concurrent calls.
+type TranscriptionSessionTransport[Wire, RawEvent any] func(
+	context.Context,
+	Wire,
+) (ProviderSession[RawEvent], error)
+
+type TranscriptionDriver interface {
+	Explain(context.Context, ModelRef, TranscriptionRequest) (Explanation, error)
+	Execute(context.Context, ModelRef, TranscriptionRequest) (TranscriptionResponse, error)
+	inferenceTranscriptionDriver()
+}
+
+type TranscriptionSessionDriver interface {
+	Explain(context.Context, ModelRef, TranscriptionSessionRequest) (Explanation, error)
+	Open(context.Context, ModelRef, TranscriptionSessionRequest) (TranscriptionSession, error)
+	inferenceTranscriptionSessionDriver()
+}
+
+// TranscribeOperations materializes the unary and/or duplex session drivers
+// a transcription model serves. Openers.Transcribe returns it; the assembly
+// routes each execution shape to the matching driver.
+type TranscribeOperations struct {
+	Unary   TranscriptionDriver
+	Session TranscriptionSessionDriver
+}
+
+type transcribeCompilerBinding struct {
+	_ byte
+}
+
+type boundTranscribeDriver interface {
+	transcribeCompilerBinding() *transcribeCompilerBinding
+}
+
+func (o TranscribeOperations) Validate() error {
+	if isNilValue(o.Unary) && isNilValue(o.Session) {
+		return fmt.Errorf("transcribe operations require a unary or session driver")
+	}
+	if !isNilValue(o.Unary) && !isNilValue(o.Session) {
+		unary, unaryOK := o.Unary.(boundTranscribeDriver)
+		session, sessionOK := o.Session.(boundTranscribeDriver)
+		if !unaryOK || !sessionOK ||
+			unary.transcribeCompilerBinding() != session.transcribeCompilerBinding() {
+			return fmt.Errorf(
+				"dual transcribe operations must be created by BindTranscribeOperations",
+			)
+		}
+	}
+	return nil
+}
+
+// BindTranscribe binds one unary transcription pipeline. compile is local
+// validation and wire construction only; transport owns provider I/O.
+func BindTranscribe[Wire, Raw any](
+	compile Compiler[TranscriptionRequest, Wire],
+	transport Transport[Wire, Raw],
+	decode Decoder[Raw, TranscriptionResponse],
+) (TranscriptionDriver, error) {
+	return bindTranscribe(
+		compile,
+		transport,
+		decode,
+		&transcribeCompilerBinding{},
+	)
+}
+
+func bindTranscribe[Wire, Raw any](
+	compile Compiler[TranscriptionRequest, Wire],
+	transport Transport[Wire, Raw],
+	decode Decoder[Raw, TranscriptionResponse],
+	binding *transcribeCompilerBinding,
+) (TranscriptionDriver, error) {
+	bound, err := bindPipeline(
+		OperationTranscription,
+		compile,
+		transport,
+		decode,
+		TranscriptionRequest.Validate,
+		TranscriptionRequest.ActiveFields,
+		func(request TranscriptionRequest) Extensions { return request.Extensions },
+		func(request TranscriptionRequest, extensions Extensions) TranscriptionRequest {
+			request.Extensions = extensions
+			return request
+		},
+		TranscriptionRequest.Clone,
+		func(request TranscriptionRequest, response TranscriptionResponse) error {
+			return response.ValidateFor(request)
+		},
+	)
+	if err != nil {
+		return nil, err
+	}
+	return &transcribeDriver[Wire, Raw]{
+		pipeline: bound,
+		binding:  binding,
+	}, nil
+}
+
+// BindTranscribeSession binds one duplex session driver. The shared pipeline
+// compiles and validates the session request exactly like unary
+// transcription; the transport opens the provider session and the decoder
+// normalizes its events.
+func BindTranscribeSession[Wire, RawEvent any](
+	compile Compiler[TranscriptionSessionRequest, Wire],
+	transport TranscriptionSessionTransport[Wire, RawEvent],
+	decode TranscriptionSessionDecoder[RawEvent],
+) (TranscriptionSessionDriver, error) {
+	return bindTranscribeSession(
+		compile,
+		transport,
+		decode,
+		&transcribeCompilerBinding{},
+	)
+}
+
+func bindTranscribeSession[Wire, RawEvent any](
+	compile Compiler[TranscriptionSessionRequest, Wire],
+	transport TranscriptionSessionTransport[Wire, RawEvent],
+	decode TranscriptionSessionDecoder[RawEvent],
+	binding *transcribeCompilerBinding,
+) (TranscriptionSessionDriver, error) {
+	if decode == nil {
+		return nil, errdefs.Validationf(
+			"inference transcription session requires a decoder",
+		)
+	}
+	// The session shares the compile/validate pipeline with unary
+	// transcription. Its decode stage never runs as a unary decoder:
+	// events decode per raw event inside the session, not per response.
+	bound, err := bindPipeline(
+		OperationTranscription,
+		compile,
+		Transport[Wire, ProviderSession[RawEvent]](transport),
+		func(context.Context, ProviderSession[RawEvent]) (TranscriptionResponse, error) {
+			return TranscriptionResponse{}, fmt.Errorf(
+				"transcription session has no unary decode",
+			)
+		},
+		TranscriptionSessionRequest.Validate,
+		TranscriptionSessionRequest.ActiveFields,
+		func(request TranscriptionSessionRequest) Extensions {
+			return request.Extensions
+		},
+		func(request TranscriptionSessionRequest, extensions Extensions) TranscriptionSessionRequest {
+			request.Extensions = extensions
+			return request
+		},
+		TranscriptionSessionRequest.Clone,
+		func(request TranscriptionSessionRequest, response TranscriptionResponse) error {
+			return validateSessionResult(response)
+		},
+	)
+	if err != nil {
+		return nil, err
+	}
+	return &transcribeSessionDriver[Wire, RawEvent]{
+		pipeline: bound,
+		decode:   decode,
+		binding:  binding,
+	}, nil
+}
+
+// BindTranscribeOperations binds unary and session drivers against the same
+// wire family so the runtime can prove both shapes were constructed
+// together. The shapes compile different request contracts (a complete
+// audio source vs an open-time session request), so each takes its own
+// compiler while sharing the Wire type and binding.
+func BindTranscribeOperations[Wire, Raw, RawEvent any](
+	compile Compiler[TranscriptionRequest, Wire],
+	transport Transport[Wire, Raw],
+	decode Decoder[Raw, TranscriptionResponse],
+	sessionCompile Compiler[TranscriptionSessionRequest, Wire],
+	sessionTransport TranscriptionSessionTransport[Wire, RawEvent],
+	sessionDecode TranscriptionSessionDecoder[RawEvent],
+) (TranscribeOperations, error) {
+	binding := &transcribeCompilerBinding{}
+	unary, err := bindTranscribe(compile, transport, decode, binding)
+	if err != nil {
+		return TranscribeOperations{}, err
+	}
+	session, err := bindTranscribeSession(
+		sessionCompile,
+		sessionTransport,
+		sessionDecode,
+		binding,
+	)
+	if err != nil {
+		return TranscribeOperations{}, err
+	}
+	return TranscribeOperations{Unary: unary, Session: session}, nil
+}
+
+type transcribeDriver[Wire, Raw any] struct {
+	pipeline *pipeline[TranscriptionRequest, Wire, Raw, TranscriptionResponse]
+	binding  *transcribeCompilerBinding
+}
+
+func (*transcribeDriver[Wire, Raw]) inferenceTranscriptionDriver() {}
+func (d *transcribeDriver[Wire, Raw]) transcribeCompilerBinding() *transcribeCompilerBinding {
+	return d.binding
+}
+
+func (d *transcribeDriver[Wire, Raw]) Explain(
+	ctx context.Context,
+	model ModelRef,
+	request TranscriptionRequest,
+) (Explanation, error) {
+	return d.pipeline.explain(ctx, model, request)
+}
+
+func (d *transcribeDriver[Wire, Raw]) Execute(
+	ctx context.Context,
+	model ModelRef,
+	request TranscriptionRequest,
+) (TranscriptionResponse, error) {
+	start := time.Now()
+	response, report, err := d.pipeline.execute(ctx, model, request)
+	if err != nil {
+		return TranscriptionResponse{}, err
+	}
+	response.Usage.Model = model
+	response.Usage.LatencyMs = time.Since(start).Milliseconds()
+	response.Metadata = mergeProviderIDs(
+		report.Metadata(model),
+		response.Metadata,
+	)
+	return response, nil
+}
+
+type transcribeSessionDriver[Wire, RawEvent any] struct {
+	pipeline *pipeline[
+		TranscriptionSessionRequest,
+		Wire,
+		ProviderSession[RawEvent],
+		TranscriptionResponse,
+	]
+	decode  TranscriptionSessionDecoder[RawEvent]
+	binding *transcribeCompilerBinding
+}
+
+func (*transcribeSessionDriver[Wire, RawEvent]) inferenceTranscriptionSessionDriver() {}
+func (d *transcribeSessionDriver[Wire, RawEvent]) transcribeCompilerBinding() *transcribeCompilerBinding {
+	return d.binding
+}
+
+func (d *transcribeSessionDriver[Wire, RawEvent]) Explain(
+	ctx context.Context,
+	model ModelRef,
+	request TranscriptionSessionRequest,
+) (Explanation, error) {
+	return d.pipeline.explain(ctx, model, request)
+}
+
+func (d *transcribeSessionDriver[Wire, RawEvent]) Open(
+	ctx context.Context,
+	model ModelRef,
+	request TranscriptionSessionRequest,
+) (TranscriptionSession, error) {
+	compiled, err := d.pipeline.prepare(ctx, model, request)
+	if err != nil {
+		return nil, err
+	}
+	raw, err := d.pipeline.transport(ctx, compiled.Wire)
+	if err != nil {
+		return nil, newProviderError(
+			OperationTranscription,
+			model.ID.Provider,
+			err,
+		)
+	}
+	if isNilValue(raw) {
+		return nil, NewError(
+			InvalidProviderResponse,
+			OperationTranscription,
+			"",
+			fmt.Errorf("provider opened a nil transcription session"),
+		)
+	}
+	return &decodedTranscriptionSession[RawEvent]{
+		raw:       raw,
+		decode:    d.decode,
+		model:     model,
+		request:   request.Clone(),
+		report:    compiled.Report,
+		startedAt: time.Now(),
+	}, nil
+}
+
+type decodedTranscriptionSession[RawEvent any] struct {
+	raw     ProviderSession[RawEvent]
+	decode  TranscriptionSessionDecoder[RawEvent]
+	model   ModelRef
+	request TranscriptionSessionRequest
+	report  CompileReport
+
+	mu        sync.Mutex
+	done      bool
+	result    TranscriptionResponse
+	resultErr error
+
+	segments     []TranscriptionSegment
+	partialText  string
+	partialStart *int64
+	language     string
+	usage        Usage
+	requestID    string
+	responseID   string
+	startedAt    time.Time
+}
+
+func (s *decodedTranscriptionSession[RawEvent]) Send(
+	ctx context.Context,
+	chunk media.AudioChunk,
+) error {
+	if err := chunk.Validate(); err != nil {
+		return NewError(
+			InvalidRequest,
+			OperationTranscription,
+			FieldTranscriptionAudio,
+			err,
+		)
+	}
+	s.mu.Lock()
+	if s.done {
+		err := s.resultErr
+		if err == nil {
+			err = NewError(
+				OperationInterrupted,
+				OperationTranscription,
+				"",
+				fmt.Errorf("transcription session ended"),
+			)
+		}
+		s.mu.Unlock()
+		return err
+	}
+	s.mu.Unlock()
+	return s.raw.Send(ctx, chunk)
+}
+
+func (s *decodedTranscriptionSession[RawEvent]) Next(
+	ctx context.Context,
+) (TranscriptionSessionEvent, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.done {
+		if s.resultErr != nil {
+			return TranscriptionSessionEvent{}, s.resultErr
+		}
+		return TranscriptionSessionEvent{}, io.EOF
+	}
+	rawEvent, err := s.raw.Next(ctx)
+	if err == io.EOF {
+		s.finishResultLocked()
+		if s.resultErr != nil {
+			return TranscriptionSessionEvent{}, s.resultErr
+		}
+		return TranscriptionSessionEvent{}, io.EOF
+	}
+	if err != nil {
+		s.done = true
+		s.resultErr = newProviderError(
+			OperationTranscription,
+			s.model.ID.Provider,
+			err,
+		)
+		return TranscriptionSessionEvent{}, s.resultErr
+	}
+	event, err := s.decode(ctx, rawEvent)
+	if err != nil {
+		s.done = true
+		s.resultErr = NewError(
+			InvalidProviderResponse,
+			OperationTranscription,
+			"",
+			err,
+		)
+		return TranscriptionSessionEvent{}, s.resultErr
+	}
+	if err := s.accumulate(event); err != nil {
+		s.done = true
+		s.resultErr = NewError(
+			InvalidProviderResponse,
+			OperationTranscription,
+			"",
+			err,
+		)
+		return TranscriptionSessionEvent{}, s.resultErr
+	}
+	return event, nil
+}
+
+func (s *decodedTranscriptionSession[RawEvent]) Result() (TranscriptionResponse, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if !s.done {
+		return TranscriptionResponse{}, NewError(
+			InvalidProviderResponse,
+			OperationTranscription,
+			"",
+			fmt.Errorf("transcription session is not complete"),
+		)
+	}
+	return s.result.Clone(), s.resultErr
+}
+
+func (s *decodedTranscriptionSession[RawEvent]) Interrupt() error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.done {
+		return NewError(
+			OperationInterrupted,
+			OperationTranscription,
+			"",
+			fmt.Errorf("transcription session already ended"),
+		)
+	}
+	err := s.raw.Interrupt()
+	s.done = true
+	if err != nil {
+		s.resultErr = newProviderError(
+			OperationTranscription,
+			s.model.ID.Provider,
+			err,
+		)
+		return s.resultErr
+	}
+	s.resultErr = NewError(
+		OperationInterrupted,
+		OperationTranscription,
+		"",
+		fmt.Errorf("transcription session interrupted"),
+	)
+	return nil
+}
+
+func (s *decodedTranscriptionSession[RawEvent]) Close() error {
+	if err := s.raw.Close(); err != nil {
+		return newProviderError(
+			OperationTranscription,
+			s.model.ID.Provider,
+			err,
+		)
+	}
+	return nil
+}
+
+func (s *decodedTranscriptionSession[RawEvent]) accumulate(
+	event TranscriptionSessionEvent,
+) error {
+	if event.empty() {
+		return fmt.Errorf("transcription session event is empty")
+	}
+	if event.StartMillis < 0 || event.EndMillis < 0 {
+		return fmt.Errorf("transcription session timestamps must not be negative")
+	}
+	if event.StartMillis != 0 && event.EndMillis != 0 &&
+		event.EndMillis < event.StartMillis {
+		return fmt.Errorf("transcription session end precedes start")
+	}
+	if event.Usage != nil {
+		if err := event.Usage.Validate(); err != nil {
+			return fmt.Errorf("transcription session usage: %w", err)
+		}
+	}
+	if event.Segment != nil {
+		if err := event.Segment.Validate(); err != nil {
+			return fmt.Errorf("transcription session segment: %w", err)
+		}
+	}
+	if event.Text != "" {
+		s.partialText = event.Text
+		if event.StartMillis != 0 {
+			start := event.StartMillis
+			s.partialStart = &start
+		}
+	}
+	switch {
+	case event.Final && event.Segment != nil:
+		s.segments = append(s.segments, *event.Segment)
+		s.partialText = ""
+		s.partialStart = nil
+	case event.Final:
+		if s.partialText != "" {
+			segment := TranscriptionSegment{
+				Text:        s.partialText,
+				StartMillis: event.StartMillis,
+				EndMillis:   event.EndMillis,
+			}
+			if s.partialStart != nil && segment.StartMillis == 0 {
+				segment.StartMillis = *s.partialStart
+			}
+			s.segments = append(s.segments, segment)
+			s.partialText = ""
+			s.partialStart = nil
+		}
+	case event.Segment != nil:
+		s.segments = append(s.segments, *event.Segment)
+	}
+	if event.Language != "" {
+		s.language = event.Language
+	}
+	if event.Usage != nil {
+		s.usage = event.Usage.Clone()
+	}
+	if event.RequestID != "" {
+		s.requestID = event.RequestID
+	}
+	if event.ResponseID != "" {
+		s.responseID = event.ResponseID
+	}
+	return nil
+}
+
+func (s *decodedTranscriptionSession[RawEvent]) finishResultLocked() {
+	s.done = true
+	var text strings.Builder
+	for index, segment := range s.segments {
+		if index > 0 {
+			text.WriteString("\n")
+		}
+		text.WriteString(segment.Text)
+	}
+	if s.partialText != "" {
+		if text.Len() > 0 {
+			text.WriteString("\n")
+		}
+		text.WriteString(s.partialText)
+	}
+	response := TranscriptionResponse{
+		Text:     text.String(),
+		Segments: append([]TranscriptionSegment(nil), s.segments...),
+		Language: s.language,
+		Usage:    s.usage,
+	}
+	metadata := s.report.Metadata(s.model)
+	metadata.RequestID = s.requestID
+	metadata.ResponseID = s.responseID
+	response.Metadata = metadata
+	response.Usage.Model = s.model
+	response.Usage.LatencyMs = time.Since(s.startedAt).Milliseconds()
+	if err := validateSessionResult(response); err != nil {
+		s.resultErr = NewError(
+			InvalidProviderResponse,
+			OperationTranscription,
+			"",
+			err,
+		)
+		return
+	}
+	s.result = response
+}
+
+func validateSessionResult(response TranscriptionResponse) error {
+	if err := validateTranscriptionSegments(response.Segments); err != nil {
+		return err
+	}
+	if response.DurationMillis != nil && *response.DurationMillis < 0 {
+		return fmt.Errorf("transcription duration must not be negative")
+	}
+	return nil
+}

--- a/core/inference/transcribe_stream.go
+++ b/core/inference/transcribe_stream.go
@@ -1,0 +1,111 @@
+package inference
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+
+	"github.com/GizClaw/flowcraft/core/message"
+	"github.com/GizClaw/flowcraft/core/message/media"
+)
+
+// FeedTranscription pumps a live part stream into an open transcription
+// session. It is the stream adapter between the pull-based message.Stream
+// transport and the session's provider-compatible Send(AudioChunk) surface:
+//
+//   - every item must be an AudioPart carrying inline bytes; each becomes
+//     one AudioChunk with a monotonic Sequence;
+//   - an item Format, when present, must match format — the session's
+//     negotiated input format;
+//   - stream EOF ends feeding normally (the caller then drains the session);
+//   - any other Read error aborts the session via Interrupt (barge-in) and
+//     is returned.
+//
+// Item-shape errors (wrong part kind, non-inline source, format mismatch)
+// return without touching the session so the caller can decide whether to
+// abort or repair the stream.
+func FeedTranscription(
+	ctx context.Context,
+	session TranscriptionSession,
+	format media.AudioFormat,
+	stream message.Stream,
+) error {
+	if isNilValue(session) {
+		return fmt.Errorf("feed transcription: session is nil")
+	}
+	if isNilValue(stream) {
+		return fmt.Errorf("feed transcription: stream is nil")
+	}
+	var sequence uint64
+	for {
+		item, err := stream.Read(ctx)
+		if err != nil {
+			if errors.Is(err, io.EOF) {
+				return nil
+			}
+			if interruptErr := session.Interrupt(); interruptErr != nil {
+				return fmt.Errorf(
+					"feed transcription: interrupt session after stream failure: %v (stream: %w)",
+					interruptErr, err,
+				)
+			}
+			return fmt.Errorf("feed transcription: stream: %w", err)
+		}
+		part, err := message.NormalizePart(item)
+		if err != nil {
+			return fmt.Errorf("feed transcription: stream item: %w", err)
+		}
+		audio, ok := part.(message.AudioPart)
+		if !ok {
+			return fmt.Errorf(
+				"feed transcription: stream yielded %T, want audio part", part)
+		}
+		if audio.Source.Kind() != media.SourceInline {
+			return fmt.Errorf(
+				"feed transcription: stream audio must carry inline bytes")
+		}
+		if audio.Format != nil && *audio.Format != format {
+			return fmt.Errorf(
+				"feed transcription: stream audio format %v does not match session input format %v",
+				*audio.Format, format,
+			)
+		}
+		chunk := media.AudioChunk{
+			Data:     audio.Source.Bytes(),
+			Sequence: sequence,
+		}
+		sequence++
+		if err := session.Send(ctx, chunk); err != nil {
+			return fmt.Errorf("feed transcription: session send: %w", err)
+		}
+	}
+}
+
+// TranscribeStream opens a duplex transcription session against the model
+// addressed by ref, feeds the live part stream into it, drains the session
+// to EOF, and returns the final transcript. Callers that want partials as
+// they arrive use TranscribeSession plus FeedTranscription directly.
+func (a *Assembly) TranscribeStream(
+	ctx context.Context,
+	ref ModelRef,
+	req TranscriptionSessionRequest,
+	stream message.Stream,
+) (TranscriptionResponse, error) {
+	session, err := a.TranscribeSession(ctx, ref, req)
+	if err != nil {
+		return TranscriptionResponse{}, err
+	}
+	if err := FeedTranscription(ctx, session, req.InputFormat, stream); err != nil {
+		return TranscriptionResponse{}, err
+	}
+	for {
+		if _, err := session.Next(ctx); err != nil {
+			if errors.Is(err, io.EOF) {
+				break
+			}
+			return TranscriptionResponse{}, err
+		}
+	}
+	return session.Result()
+}

--- a/core/inference/transcribe_stream_assembly_test.go
+++ b/core/inference/transcribe_stream_assembly_test.go
@@ -1,0 +1,74 @@
+package inference_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/GizClaw/flowcraft/core/inference"
+	"github.com/GizClaw/flowcraft/core/inference/inferencetest"
+	"github.com/GizClaw/flowcraft/core/message"
+	"github.com/GizClaw/flowcraft/core/message/media"
+)
+
+func TestAssemblyTranscribeStreamReturnsTranscript(t *testing.T) {
+	assembly := (&inferencetest.TranscriptionFake{}).Assembly(t)
+	format := media.AudioFormat{
+		Encoding:     media.AudioEncodingPCM16,
+		SampleRateHz: 16000,
+		Channels:     1,
+	}
+	source, err := media.NewAudioBytes([]byte{0, 0}, "audio/pcm")
+	if err != nil {
+		t.Fatalf("NewAudioBytes: %v", err)
+	}
+	pipe := message.NewPartPipe(1)
+	pipe.Send(message.AudioPart{Source: source, Format: &format})
+	pipe.Close()
+	response, err := assembly.TranscribeStream(
+		context.Background(),
+		inferencetest.DefaultFakeTranscribeModel,
+		inference.TranscriptionSessionRequest{InputFormat: format},
+		pipe,
+	)
+	if err != nil {
+		t.Fatalf("TranscribeStream: %v", err)
+	}
+	if response.Text != "ok" {
+		t.Fatalf("Text = %q, want %q", response.Text, "ok")
+	}
+}
+
+func TestAssemblyTranscribeStreamRejectsBadItems(t *testing.T) {
+	assembly := (&inferencetest.TranscriptionFake{}).Assembly(t)
+	format := media.AudioFormat{
+		Encoding:     media.AudioEncodingPCM16,
+		SampleRateHz: 16000,
+		Channels:     1,
+	}
+	pipe := message.NewPartPipe(1)
+	pipe.Send(message.TextPart{Text: "nope"})
+	pipe.Close()
+	_, err := assembly.TranscribeStream(
+		context.Background(),
+		inferencetest.DefaultFakeTranscribeModel,
+		inference.TranscriptionSessionRequest{InputFormat: format},
+		pipe,
+	)
+	if err == nil || !strings.Contains(err.Error(), "want audio part") {
+		t.Fatalf("TranscribeStream = %v, want audio-part error", err)
+	}
+}
+
+func TestTranscriptionRequestRejectsStreamSource(t *testing.T) {
+	pipe := message.NewPartPipe(0)
+	source, err := message.NewAudioStream(pipe, "audio/pcm")
+	if err != nil {
+		t.Fatalf("NewAudioStream: %v", err)
+	}
+	request := inference.TranscriptionRequest{Audio: source}
+	err = request.Validate()
+	if err == nil || !strings.Contains(err.Error(), "TranscribeSession") {
+		t.Fatalf("Validate = %v, want TranscribeSession rejection", err)
+	}
+}

--- a/core/inference/transcribe_stream_test.go
+++ b/core/inference/transcribe_stream_test.go
@@ -1,0 +1,192 @@
+package inference
+
+import (
+	"context"
+	"errors"
+	"io"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/GizClaw/flowcraft/core/message"
+	"github.com/GizClaw/flowcraft/core/message/media"
+)
+
+var feedTestFormat = media.AudioFormat{
+	Encoding:     media.AudioEncodingPCM16,
+	SampleRateHz: 16000,
+	Channels:     1,
+}
+
+type recordingFeedSession struct {
+	mu        sync.Mutex
+	chunks    []media.AudioChunk
+	interrupt int
+}
+
+func (s *recordingFeedSession) Send(_ context.Context, chunk media.AudioChunk) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.chunks = append(s.chunks, chunk.Clone())
+	return nil
+}
+
+func (s *recordingFeedSession) Next(context.Context) (TranscriptionSessionEvent, error) {
+	return TranscriptionSessionEvent{}, io.EOF
+}
+
+func (s *recordingFeedSession) Result() (TranscriptionResponse, error) {
+	return TranscriptionResponse{Text: "ok"}, nil
+}
+
+func (s *recordingFeedSession) Interrupt() error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.interrupt++
+	return nil
+}
+
+func (s *recordingFeedSession) Close() error { return nil }
+
+func (s *recordingFeedSession) snapshot() ([]media.AudioChunk, int) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return append([]media.AudioChunk(nil), s.chunks...), s.interrupt
+}
+
+func feedAudioPart(t *testing.T, data string, format *media.AudioFormat) message.Part {
+	t.Helper()
+	source, err := media.NewAudioBytes([]byte(data), "audio/pcm")
+	if err != nil {
+		t.Fatalf("NewAudioBytes: %v", err)
+	}
+	return message.AudioPart{Source: source, Format: format}
+}
+
+func TestFeedTranscriptionPumpsAudioPartsWithSequence(t *testing.T) {
+	session := &recordingFeedSession{}
+	pipe := message.NewPartPipe(3)
+	for i, data := range []string{"aa", "bb", "cc"} {
+		var format *media.AudioFormat
+		if i == 0 {
+			format = &feedTestFormat
+		}
+		pipe.Send(feedAudioPart(t, data, format))
+	}
+	pipe.Close()
+	if err := FeedTranscription(
+		context.Background(), session, feedTestFormat, pipe,
+	); err != nil {
+		t.Fatalf("FeedTranscription: %v", err)
+	}
+	chunks, interrupts := session.snapshot()
+	if interrupts != 0 {
+		t.Fatalf("Interrupt calls = %d, want 0", interrupts)
+	}
+	if len(chunks) != 3 {
+		t.Fatalf("chunks = %d, want 3", len(chunks))
+	}
+	for i, want := range []string{"aa", "bb", "cc"} {
+		if got := string(chunks[i].Data); got != want {
+			t.Fatalf("chunk %d data = %q, want %q", i, got, want)
+		}
+		if chunks[i].Sequence != uint64(i) {
+			t.Fatalf("chunk %d sequence = %d, want %d", i, chunks[i].Sequence, i)
+		}
+	}
+}
+
+func TestFeedTranscriptionEOFEndsNormally(t *testing.T) {
+	session := &recordingFeedSession{}
+	pipe := message.NewPartPipe(0)
+	pipe.Close()
+	if err := FeedTranscription(
+		context.Background(), session, feedTestFormat, pipe,
+	); err != nil {
+		t.Fatalf("FeedTranscription: %v", err)
+	}
+	chunks, interrupts := session.snapshot()
+	if len(chunks) != 0 || interrupts != 0 {
+		t.Fatalf("chunks = %d, interrupts = %d, want 0/0", len(chunks), interrupts)
+	}
+}
+
+func TestFeedTranscriptionRejectsUnexpectedItems(t *testing.T) {
+	session := &recordingFeedSession{}
+	pipe := message.NewPartPipe(1)
+	pipe.Send(message.TextPart{Text: "not audio"})
+	pipe.Close()
+	err := FeedTranscription(
+		context.Background(), session, feedTestFormat, pipe,
+	)
+	if err == nil || !strings.Contains(err.Error(), "want audio part") {
+		t.Fatalf("FeedTranscription = %v, want audio-part error", err)
+	}
+	if _, interrupts := session.snapshot(); interrupts != 0 {
+		t.Fatal("session was interrupted for an item-shape error")
+	}
+}
+
+func TestFeedTranscriptionRejectsNonInlineAudio(t *testing.T) {
+	session := &recordingFeedSession{}
+	source, err := media.NewAudioURL("https://example.com/audio", "audio/mpeg")
+	if err != nil {
+		t.Fatalf("NewAudioURL: %v", err)
+	}
+	pipe := message.NewPartPipe(1)
+	pipe.Send(message.AudioPart{Source: source})
+	pipe.Close()
+	err = FeedTranscription(
+		context.Background(), session, feedTestFormat, pipe,
+	)
+	if err == nil || !strings.Contains(err.Error(), "inline bytes") {
+		t.Fatalf("FeedTranscription = %v, want inline-bytes error", err)
+	}
+}
+
+func TestFeedTranscriptionRejectsFormatMismatch(t *testing.T) {
+	session := &recordingFeedSession{}
+	other := media.AudioFormat{
+		Encoding:     media.AudioEncodingPCM16,
+		SampleRateHz: 8000,
+		Channels:     1,
+	}
+	pipe := message.NewPartPipe(1)
+	pipe.Send(feedAudioPart(t, "aa", &other))
+	pipe.Close()
+	err := FeedTranscription(
+		context.Background(), session, feedTestFormat, pipe,
+	)
+	if err == nil || !strings.Contains(err.Error(), "does not match") {
+		t.Fatalf("FeedTranscription = %v, want format-mismatch error", err)
+	}
+}
+
+func TestFeedTranscriptionInterruptsSessionOnStreamFailure(t *testing.T) {
+	session := &recordingFeedSession{}
+	pipe := message.NewPartPipe(1)
+	pipe.Send(feedAudioPart(t, "aa", nil))
+	pipe.Interrupt()
+	err := FeedTranscription(
+		context.Background(), session, feedTestFormat, pipe,
+	)
+	if err == nil || !errors.Is(err, context.Canceled) {
+		t.Fatalf("FeedTranscription = %v, want context.Canceled", err)
+	}
+	if _, interrupts := session.snapshot(); interrupts != 1 {
+		t.Fatalf("Interrupt calls = %d, want 1", interrupts)
+	}
+}
+
+func TestFeedTranscriptionRejectsNilInputs(t *testing.T) {
+	if err := FeedTranscription(
+		context.Background(), nil, feedTestFormat, message.NewPartPipe(0),
+	); err == nil {
+		t.Fatal("FeedTranscription accepted a nil session")
+	}
+	if err := FeedTranscription(
+		context.Background(), &recordingFeedSession{}, feedTestFormat, nil,
+	); err == nil {
+		t.Fatal("FeedTranscription accepted a nil stream")
+	}
+}

--- a/core/message/stream.go
+++ b/core/message/stream.go
@@ -162,6 +162,10 @@ func materializeAudioPart(ctx context.Context, part AudioPart) ([]Part, error) {
 	if data.Len() == 0 {
 		return nil, fmt.Errorf("materialize audio: stream produced no audio data")
 	}
+	// Stream items may omit the format when the enclosing part declared it.
+	if format == nil {
+		format = clonePointer(part.Format)
+	}
 	mediaType := ""
 	if format != nil {
 		mediaType = format.Encoding.MediaType()

--- a/core/message/stream_test.go
+++ b/core/message/stream_test.go
@@ -79,6 +79,36 @@ func TestMaterializeAudioStreamIntoInlinePart(t *testing.T) {
 	}
 }
 
+func TestMaterializeAudioStreamFallsBackToPartFormat(t *testing.T) {
+	format := media.AudioFormat{
+		Encoding:     media.AudioEncodingPCM16,
+		SampleRateHz: 1000,
+		Channels:     1,
+	}
+	pipe := message.NewPartPipe(1)
+	itemSource, err := media.NewAudioBytes([]byte("abcd"), "audio/pcm")
+	if err != nil {
+		t.Fatalf("NewAudioBytes: %v", err)
+	}
+	pipe.Send(message.AudioPart{Source: itemSource})
+	pipe.Close()
+	streamSource, err := media.NewAudioStream(pipe, "audio/pcm")
+	if err != nil {
+		t.Fatalf("NewAudioStream: %v", err)
+	}
+	materialized, err := message.MaterializeContent(context.Background(),
+		message.Content{Parts: []message.Part{
+			message.AudioPart{Source: streamSource, Format: &format},
+		}})
+	if err != nil {
+		t.Fatalf("MaterializeContent: %v", err)
+	}
+	audio := materialized.Parts[0].(message.AudioPart)
+	if audio.Format == nil || *audio.Format != format {
+		t.Fatalf("materialized format = %v, want part format %v", audio.Format, format)
+	}
+}
+
 func TestMaterializeVideoStreamIntoInlinePart(t *testing.T) {
 	chunk := func(data string) message.Part {
 		source, err := media.NewVideoBytes([]byte(data), "video/mp4")

--- a/docs/guides/inference.md
+++ b/docs/guides/inference.md
@@ -57,4 +57,52 @@ reg.MustRegister(inference.Factory{})
 `GenerateStream` returns a stream of deltas plus the final result. Streaming
 is provider-neutral; each driver adapts its native protocol.
 
+## Media streams
+
+Live media input is a first-class transport, not a new DTO: a stream is a
+sequence of ordinary `message.Part`s. The media layer owns the generic
+pull contract (`media.Stream[T]` / `media.Pipe[T]`); `message.Stream` is
+that contract instantiated over `Part`, and `message.NewPartPipe` builds a
+bounded pipe whose `Send` blocks when the buffer is full — that is the
+backpressure contract. `Interrupt` aborts a stream (barge-in, error), while
+`Close` ends it normally; after `Interrupt`, `Read` returns
+`context.Canceled` even if buffered parts remain.
+
+An `AudioSource` or `VideoSource` can carry a live stream via
+`message.NewAudioStream` / `message.NewVideoStream` (source kind
+`stream`). Stream sources are valid only while a message is in flight:
+
+- Unary `Generate` rejects stream sources in both context and input — a
+  model call receives complete parts, never a live handle.
+- Stream sources cannot be serialized, so they never cross the wire as a
+  value.
+- When a message becomes history (the run commits), the runtime
+  materializes each stream source into the existing inline-byte part:
+  audio chunks become one `AudioPart` with inline bytes, video chunks one
+  `VideoPart`. This mirrors how `GenerateStream` accumulates deltas and
+  materializes them at the terminal result.
+
+## Transcription
+
+Speech recognition is a first-class workload with two execution shapes:
+
+- `Transcribe` recognizes one complete audio source (`media.AudioSource`)
+  and returns the transcript, with optional segments and timestamps.
+- `TranscribeSession` opens a duplex session: the caller negotiates
+  `input_format` at open, feeds `media.AudioChunk`s through `Send`, and
+  drains partial/final transcript events through `Next`. `Interrupt`
+  terminates a session abnormally (barge-in); draining to `io.EOF` and
+  calling `Result` yields the final transcript.
+
+Both shapes address the same `ModelRef` and share the Transcription route
+pools. Drivers that only serve one shape leave the other opener nil and the
+assembly reports `UnsupportedOperation` for it.
+
+Live input rides the part-stream transport: `FeedTranscription` pumps a
+`message.Stream[Part]` into an open session (audio parts become chunks with
+monotonic sequence; EOF ends feeding; a stream failure interrupts the
+session), and `TranscribeStream` is the one-shot open + feed + drain +
+result form. Unary `Transcribe` rejects stream sources — whole-file
+recognition takes complete audio, live audio goes through a session.
+
 See [graph.md](graph.md) for the inference node.


### PR DESCRIPTION
## Summary

Transcription joins Generate/Embed as a first-class `core/inference` workload — same `ModelRef` addressing, route pools, telemetry, and agent bindings — and live media input rides the part-stream transport (media.Stream/Pipe, already landed in #361).

- Unary `Transcribe` + duplex `TranscribeSession` (partial/final events, barge-in `Interrupt`, `Result`), provider SPI via `Openers.Transcribe`, assembly/route integration with retry, circuit breaker, and session telemetry.
- Live input: `FeedTranscription` pumps a `message.Stream[Part]` into an open session; `TranscribeStream` (Assembly + Router) is the one-shot open + feed + drain + result form.
- Boundaries: unary `Transcribe` and Generate context/input reject stream sources; A2A conversion rejects them explicitly.
- Agent bindings: `transcribe` / `explainTranscribe` / `transcribeSession` plus route variants; script-facing `send(chunk)` stays the session input surface.
- Tests: inferencetest fakes + conformance suites, feed unit tests, route failure paths (same-target retry, circuit breaker, fallback after retry exhausted), bridge extensions round-trips.

## Scope

- Driver transcription adapters (bytedance/openai/azure) are intentionally not included — follow-up work.
- Realtime stays reserved in the operation enum with no surface yet.
- The media stream transport itself (media.Stream/Pipe, MaterializeContent) shipped in #361.

## Gates

`make ci`, `make lint`, `make release-check`, `git diff --check` all pass.