### PR TITLE
chore(release): add core v0.1.17 changeset

### DIFF
--- a/.release/core-v0.1.17.json
+++ b/.release/core-v0.1.17.json
@@ -1,0 +1,9 @@
+{
+  "summary": "feat(core): add first-class transcription with live part-stream input — unary Transcribe and duplex TranscribeSession join Generate/Embed as core/inference workloads with ModelRef addressing, route pools, retries, circuit breakers, session telemetry, provider SPI via Openers.Transcribe, agent bindings (transcribe/explainTranscribe/transcribeSession), and live message.Stream[Part] input through FeedTranscription/TranscribeStream, backed by the live media-stream transport (media.Stream/media.Pipe, stream-backed audio/video sources, MaterializeContent conversion) with stream subscription projection; feat(core): first-class finish and provider_outputs script emit types decode into typed StreamDeltaFinish/StreamDeltaProviderOutputs envelopes, with invalid payloads skipping emission; fix(core): keep raw payloads on script bridge host.emit deltas (StreamDeltaPayload.payload) instead of dropping them, and skip invalid tool_call/tool_result/part payloads rather than publishing empty deltas; chore(core): lower module Go version to 1.25 to match the dependency floor",
+  "releases": [
+    {
+      "module": "core",
+      "bump": "patch"
+    }
+  ]
+}


### PR DESCRIPTION
Adds the core v0.1.17 release changeset covering the accumulated core delta since core/v0.1.16:

- feat(core): first-class transcription with live part-stream input (#364)
- feat(core): first-class finish and provider_outputs script emit types (#363)
- chore(core): lower module Go version to 1.25 (#362)
- fix(core): keep payloads on script bridge emit channel (#361)

`make release-check` passes and `make release-plan` plans core `0.1.16 -> 0.1.17 (patch)` with tag `core/v0.1.17`. After this merges, the Release modules workflow will prepare the changelog and, once the Release PR is merged, CI creates `core/v0.1.17`.