### PR TITLE
feat(driver/bytedance): add streaming ASR transcription

### DIFF
--- a/core/agent/bindings/bridge_inference.go
+++ b/core/agent/bindings/bridge_inference.go
@@ -90,6 +90,7 @@ func WithExtensionDecoder(provider, id string, decoder inference.ExtensionDecode
 //
 //     var s = inference.transcribeSession(req)   // input_format + model
 //     s.send({data: <base64>, sequence: 1})      // media.AudioChunk
+//     s.finish()                                 // end-of-input (optional)
 //     var ev
 //     while ((ev = s.next()) !== null) { ... }   // partial/final events
 //     var resp = s.result()                      // TranscriptionResponse
@@ -97,10 +98,13 @@ func WithExtensionDecoder(provider, id string, decoder inference.ExtensionDecode
 //     s.close()
 //
 //     send() feeds audio chunks; next() projects TranscriptionSessionEvent
-//     wire JSON and returns null at EOF; result() yields the accumulated
-//     TranscriptionResponse; interrupt() terminates the session abnormally;
-//     close() exits early. routeTranscribeSession attaches "trace" to the
-//     result object, mirroring routeTranscribe.
+//     wire JSON and returns null at EOF; finish() signals that no more audio
+//     is coming where the provider supports it (a no-op otherwise), which is
+//     how continuous sessions reach EOF after multiple final events;
+//     result() yields the accumulated TranscriptionResponse; interrupt()
+//     terminates the session abnormally; close() exits early.
+//     routeTranscribeSession attaches "trace" to the result object, mirroring
+//     routeTranscribe.
 //
 //   - explainStream(request) / routeExplainStream(request): the
 //     Generate-stream twins of explain/routeExplain — local stream
@@ -697,6 +701,18 @@ func newTranscriptionSessionHandle(
 		},
 		"interrupt": func() error {
 			return session.Interrupt()
+		},
+		"finish": func() error {
+			if done {
+				return nil
+			}
+			finisher, ok := session.(inference.TranscriptionSessionFinisher)
+			if !ok {
+				return errdefs.Validationf(
+					"inference.transcribeSession.finish: session does not support explicit end-of-input",
+				)
+			}
+			return finisher.FinishInput(ctx)
 		},
 		"close": func() error {
 			done = true

--- a/core/inference/transcribe.go
+++ b/core/inference/transcribe.go
@@ -224,6 +224,16 @@ type TranscriptionSession interface {
 	Close() error
 }
 
+// TranscriptionSessionFinisher is an optional session capability: after the
+// caller has no more audio, FinishInput asks the provider to finalize the
+// session so draining Next reaches io.EOF and Result yields the accumulated
+// transcript. Providers whose wire protocol ends sessions on its own need
+// not implement it — callers detect support with a type assertion, and
+// calling FinishInput on a session without the capability is a no-op.
+type TranscriptionSessionFinisher interface {
+	FinishInput(context.Context) error
+}
+
 // TranscriptionSessionDecoder converts provider-native session events into
 // canonical TranscriptionSessionEvents. Implementations must support
 // concurrent calls; sessions serialize decoder use themselves.
@@ -582,6 +592,41 @@ func (s *decodedTranscriptionSession[RawEvent]) Send(
 	}
 	s.mu.Unlock()
 	return s.raw.Send(ctx, chunk)
+}
+
+// FinishInput tells the provider no more audio will arrive so it can
+// finalize the session; callers then drain Next to io.EOF before Result.
+// Providers without the capability keep the call a no-op.
+func (s *decodedTranscriptionSession[RawEvent]) FinishInput(
+	ctx context.Context,
+) error {
+	s.mu.Lock()
+	if s.done {
+		err := s.resultErr
+		if err == nil {
+			err = NewError(
+				OperationInterrupted,
+				OperationTranscription,
+				"",
+				fmt.Errorf("transcription session ended"),
+			)
+		}
+		s.mu.Unlock()
+		return err
+	}
+	s.mu.Unlock()
+	finisher, ok := s.raw.(TranscriptionSessionFinisher)
+	if !ok {
+		return nil
+	}
+	if err := finisher.FinishInput(ctx); err != nil {
+		return newProviderError(
+			OperationTranscription,
+			s.model.ID.Provider,
+			err,
+		)
+	}
+	return nil
 }
 
 func (s *decodedTranscriptionSession[RawEvent]) Next(

--- a/core/inference/transcribe_finish_test.go
+++ b/core/inference/transcribe_finish_test.go
@@ -1,0 +1,162 @@
+package inference_test
+
+import (
+	"context"
+	"io"
+	"sync/atomic"
+	"testing"
+
+	"github.com/GizClaw/flowcraft/core/inference"
+	"github.com/GizClaw/flowcraft/core/inference/inferencetest"
+	"github.com/GizClaw/flowcraft/core/message/media"
+)
+
+// finishRecordingProviderSession is a provider session that records
+// FinishInput calls so the wrapper delegation is observable.
+type finishRecordingProviderSession struct {
+	finishCalls atomic.Int64
+}
+
+func (*finishRecordingProviderSession) Send(context.Context, media.AudioChunk) error {
+	return nil
+}
+func (*finishRecordingProviderSession) Next(context.Context) (inference.TranscriptionSessionEvent, error) {
+	return inference.TranscriptionSessionEvent{}, io.EOF
+}
+func (*finishRecordingProviderSession) Interrupt() error { return nil }
+func (*finishRecordingProviderSession) Close() error     { return nil }
+func (s *finishRecordingProviderSession) FinishInput(context.Context) error {
+	s.finishCalls.Add(1)
+	return nil
+}
+
+// plainProviderSession is a provider session without the finisher
+// capability.
+type plainProviderSession struct{}
+
+func (*plainProviderSession) Send(context.Context, media.AudioChunk) error {
+	return nil
+}
+func (*plainProviderSession) Next(context.Context) (inference.TranscriptionSessionEvent, error) {
+	return inference.TranscriptionSessionEvent{}, io.EOF
+}
+func (*plainProviderSession) Interrupt() error { return nil }
+func (*plainProviderSession) Close() error     { return nil }
+
+func transcriptionSessionDriver[
+	RawEvent any,
+](
+	t *testing.T,
+	raw inference.ProviderSession[RawEvent],
+) inference.TranscriptionSessionDriver {
+	t.Helper()
+	compile := inference.Compiler[inference.TranscriptionSessionRequest, string](
+		func(
+			_ context.Context,
+			_ inference.ModelRef,
+			request inference.TranscriptionSessionRequest,
+		) (inference.Compiled[string], error) {
+			return inference.Compiled[string]{
+				Wire: "wire",
+				Report: inferencetest.NativeReport(
+					inference.OperationTranscription,
+					request.ActiveFields()...,
+				),
+			}, nil
+		},
+	)
+	transport := inference.TranscriptionSessionTransport[string, RawEvent](
+		func(
+			_ context.Context,
+			_ string,
+		) (inference.ProviderSession[RawEvent], error) {
+			return raw, nil
+		},
+	)
+	decode := inference.TranscriptionSessionDecoder[RawEvent](
+		func(
+			_ context.Context,
+			event RawEvent,
+		) (inference.TranscriptionSessionEvent, error) {
+			return any(event).(inference.TranscriptionSessionEvent), nil
+		},
+	)
+	driver, err := inference.BindTranscribeSession(
+		compile,
+		transport,
+		decode,
+	)
+	if err != nil {
+		t.Fatalf("BindTranscribeSession: %v", err)
+	}
+	return driver
+}
+
+func openTranscriptionSession(
+	t *testing.T,
+	driver inference.TranscriptionSessionDriver,
+) inference.TranscriptionSession {
+	t.Helper()
+	session, err := driver.Open(
+		context.Background(),
+		inferencetest.DefaultFakeTranscribeModel,
+		inference.TranscriptionSessionRequest{
+			InputFormat: media.AudioFormat{
+				Encoding:     media.AudioEncodingPCM16,
+				SampleRateHz: 16000,
+				Channels:     1,
+			},
+		},
+	)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	return session
+}
+
+func TestTranscriptionSessionFinishInputDelegates(t *testing.T) {
+	raw := &finishRecordingProviderSession{}
+	driver := transcriptionSessionDriver(
+		t,
+		raw,
+	)
+	session := openTranscriptionSession(t, driver)
+
+	finisher, ok := session.(inference.TranscriptionSessionFinisher)
+	if !ok {
+		t.Fatalf("session %T does not expose TranscriptionSessionFinisher", session)
+	}
+	if err := finisher.FinishInput(context.Background()); err != nil {
+		t.Fatalf("FinishInput: %v", err)
+	}
+	if calls := raw.finishCalls.Load(); calls != 1 {
+		t.Fatalf("finish calls = %d, want 1", calls)
+	}
+
+	for {
+		if _, err := session.Next(context.Background()); err == io.EOF {
+			break
+		} else if err != nil {
+			t.Fatalf("Next: %v", err)
+		}
+	}
+	if _, err := session.Result(); err != nil {
+		t.Fatalf("Result: %v", err)
+	}
+}
+
+func TestTranscriptionSessionFinishInputNoopWhenUnsupported(t *testing.T) {
+	driver := transcriptionSessionDriver(
+		t,
+		&plainProviderSession{},
+	)
+	session := openTranscriptionSession(t, driver)
+
+	finisher, ok := session.(inference.TranscriptionSessionFinisher)
+	if !ok {
+		t.Fatalf("session %T does not expose TranscriptionSessionFinisher", session)
+	}
+	if err := finisher.FinishInput(context.Background()); err != nil {
+		t.Fatalf("FinishInput on unsupported session: %v", err)
+	}
+}

--- a/core/inference/transcribe_stream.go
+++ b/core/inference/transcribe_stream.go
@@ -85,7 +85,10 @@ func FeedTranscription(
 // TranscribeStream opens a duplex transcription session against the model
 // addressed by ref, feeds the live part stream into it, drains the session
 // to EOF, and returns the final transcript. Callers that want partials as
-// they arrive use TranscribeSession plus FeedTranscription directly.
+// they arrive use TranscribeSession plus FeedTranscription directly. When
+// the session supports explicit end-of-input (TranscriptionSessionFinisher),
+// the stream's end is signaled before draining so continuous sessions
+// terminate deterministically.
 func (a *Assembly) TranscribeStream(
 	ctx context.Context,
 	ref ModelRef,
@@ -98,6 +101,14 @@ func (a *Assembly) TranscribeStream(
 	}
 	if err := FeedTranscription(ctx, session, req.InputFormat, stream); err != nil {
 		return TranscriptionResponse{}, err
+	}
+	if finisher, ok := session.(TranscriptionSessionFinisher); ok {
+		if err := finisher.FinishInput(ctx); err != nil {
+			return TranscriptionResponse{}, fmt.Errorf(
+				"transcribe stream finish input: %w",
+				err,
+			)
+		}
 	}
 	for {
 		if _, err := session.Next(ctx); err != nil {

--- a/docs/guides/inference.md
+++ b/docs/guides/inference.md
@@ -98,6 +98,13 @@ Both shapes address the same `ModelRef` and share the Transcription route
 pools. Drivers that only serve one shape leave the other opener nil and the
 assembly reports `UnsupportedOperation` for it.
 
+Sessions may emit multiple `Final` events for continuous recognition. A
+provider session can expose the optional `TranscriptionSessionFinisher`
+capability: callers that have no more audio call `FinishInput`, then drain
+`Next` to `io.EOF` and read `Result`. `TranscribeStream` performs that
+end-of-input handshake automatically after the source stream ends; the
+script bridge exposes it as the session handle's `finish()`.
+
 Live input rides the part-stream transport: `FeedTranscription` pumps a
 `message.Stream[Part]` into an open session (audio parts become chunks with
 monotonic sequence; EOF ends feeding; a stream failure interrupts the

--- a/driver/bytedance/catalog.go
+++ b/driver/bytedance/catalog.go
@@ -58,12 +58,20 @@ type catalogEntry struct {
 // Unknown models fail closed: the factory only exposes models listed here or
 // declared via Spec.Models.
 var catalog = map[string]catalogEntry{
+	// Doubao Seed Evolving (2026-07) — rapidly iterating Coding & Agent
+	// line, updated weekly. Long 1M context; natively multimodal with
+	// thinking and the full hosted tool surface.
+	"doubao-seed-evolving": {kind: kindGenerate, vision: true, video: true, reasoning: true, webSearch: true, maxInputTokens: 1_024_000},
+
 	// Seed 2.1 (2026-06) — current flagship tier. The whole Seed 2.x line is
 	// natively multimodal (text/image/video in) with thinking support.
 	"doubao-seed-2-1-pro":   {kind: kindGenerate, vision: true, video: true, reasoning: true, webSearch: true, maxInputTokens: 256_000},
 	"doubao-seed-2-1-turbo": {kind: kindGenerate, vision: true, video: true, reasoning: true, webSearch: true, maxInputTokens: 256_000},
 
 	// Seed 2.0 (2026-02) — general agent line plus the code-tuned variant.
+	// The 260215 lite revision retired in 2026-05, but the 260428 revision
+	// stays live (and is Ark's recommended audio-understanding model), so
+	// the stable family name remains routable.
 	"doubao-seed-2-0-pro":  {kind: kindGenerate, vision: true, video: true, reasoning: true, webSearch: true, maxInputTokens: 256_000},
 	"doubao-seed-2-0-lite": {kind: kindGenerate, vision: true, video: true, reasoning: true, webSearch: true, maxInputTokens: 256_000},
 	"doubao-seed-2-0-mini": {kind: kindGenerate, vision: true, video: true, reasoning: true, webSearch: true, maxInputTokens: 256_000},
@@ -76,28 +84,19 @@ var catalog = map[string]catalogEntry{
 		deprecated: true, replacement: "doubao-seed-2-0-lite",
 		maxInputTokens: 256_000,
 	},
-	"doubao-seed-1-6": {
-		kind: kindGenerate, reasoning: true, webSearch: true,
-		deprecated: true, replacement: "doubao-seed-2-0-mini",
-		maxInputTokens: 256_000,
-	},
 	"doubao-seed-1-6-vision": {
 		kind: kindGenerate, vision: true, reasoning: true, webSearch: true,
 		deprecated: true, replacement: "doubao-seed-2-0-lite",
-		maxInputTokens: 256_000,
-	},
-	"doubao-seed-1-6-flash": {
-		kind: kindGenerate, reasoning: true, webSearch: true,
-		deprecated: true, replacement: "doubao-seed-2-0-mini",
 		maxInputTokens: 256_000,
 	},
 
 	"doubao-embedding-large":  {kind: kindEmbed, dimensions: true, maxInputTokens: 4_095},
 	"doubao-embedding-vision": {kind: kindEmbed, imageInput: true, dimensions: true, maxInputTokens: 8_191},
 
-	// Seedream image generation; 5.0/4.5 current, 4.0 superseded.
-	"doubao-seedream-5-0": {kind: kindImage},
-	"doubao-seedream-4-5": {kind: kindImage},
+	// Seedream image generation; 5.0-pro/5.0/4.5 current, 4.0 superseded.
+	"doubao-seedream-5-0-pro": {kind: kindImage},
+	"doubao-seedream-5-0":     {kind: kindImage},
+	"doubao-seedream-4-5":     {kind: kindImage},
 	"doubao-seedream-4-0": {
 		kind:       kindImage,
 		deprecated: true, replacement: "doubao-seedream-5-0",
@@ -105,7 +104,9 @@ var catalog = map[string]catalogEntry{
 
 	// Seedance video generation, served by the async content-generation task
 	// API behind the unary contract. 2.0 is the current line; fast/mini cap
-	// at 720p. 1.x stays routable for existing deployments.
+	// at 720p. 2.5 is the current flagship (1080p, 30s narrative). 1.x
+	// stays routable for existing deployments.
+	"doubao-seedance-2-5":      {kind: kindVideo, maxResolution: "1080p"},
 	"doubao-seedance-2-0":      {kind: kindVideo, maxResolution: "4k"},
 	"doubao-seedance-2-0-fast": {kind: kindVideo, maxResolution: "720p"},
 	"doubao-seedance-2-0-mini": {kind: kindVideo, maxResolution: "720p"},
@@ -127,9 +128,12 @@ var catalog = map[string]catalogEntry{
 	},
 
 	// Logical names for speech families; the wire address (resource ID or
-	// fixed upstream model version) is resolved per driver. ASR and realtime
-	// families are absent until core exposes those operation surfaces.
-	"doubao-tts-2-0": {kind: kindTTS},
+	// fixed upstream model version) is resolved per driver. The ASR family
+	// defaults to the SAUC V2 streaming endpoint when the profile does not
+	// map the model to an account resource ID; realtime remains absent until
+	// core exposes that operation surface.
+	"doubao-tts-2-0":  {kind: kindTTS},
+	"doubao-seed-asr": {kind: kindASR},
 }
 
 // mergedCatalog overlays Spec.Models onto the built-in catalog and returns

--- a/driver/bytedance/catalog_test.go
+++ b/driver/bytedance/catalog_test.go
@@ -28,6 +28,7 @@ func TestCatalogDeclaresMaxInputTokens(t *testing.T) {
 		}
 	}
 	checks := map[string]int{
+		"doubao-seed-evolving":    1_024_000,
 		"doubao-seed-2-1-pro":     256_000,
 		"doubao-seed-1-6-vision":  256_000,
 		"doubao-embedding-large":  4_095,

--- a/driver/bytedance/doc.go
+++ b/driver/bytedance/doc.go
@@ -22,8 +22,15 @@
 //   - Generate AudioIntent: Doubao TTS 2.0 HTTP chunked synthesis (seed-tts).
 //   - Embed: Ark embeddings (doubao-embedding text; multimodal embedding for
 //     vision-capable variants).
-//   - Transcription and realtime are intentionally absent: core/inference
-//     does not expose those operation surfaces yet.
+//   - Transcription: Doubao ASR V2 SAUC WebSocket recognition (seed-asr).
+//     Whole-file Transcribe feeds the complete inline audio into a streaming
+//     session inside the transport; TranscribeSession is the duplex live
+//     form with continuous multi-utterance partial/final events, word
+//     timing, and barge-in Interrupt. Sessions stay open across finals;
+//     explicit end-of-input (FinishInput / the bridge's finish()) sends the
+//     ASR final packet so draining terminates and Result returns the
+//     accumulated transcript. Realtime is intentionally absent:
+//     core/inference does not expose that operation surface yet.
 //
 // Provider-specific settings ride on requests as typed extensions, one
 // options struct per operation family: GenerateOptions (service tier,

--- a/driver/bytedance/go.mod
+++ b/driver/bytedance/go.mod
@@ -4,7 +4,7 @@ go 1.26.0
 
 require (
 	github.com/GizClaw/doubao-speech-go v0.0.0-20260723152315-fe8153366feb
-	github.com/GizClaw/flowcraft/core v0.1.16
+	github.com/GizClaw/flowcraft/core v0.1.17
 	github.com/volcengine/volcengine-go-sdk v1.2.14
 )
 

--- a/driver/bytedance/go.sum
+++ b/driver/bytedance/go.sum
@@ -2,8 +2,8 @@ cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMT
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/GizClaw/doubao-speech-go v0.0.0-20260723152315-fe8153366feb h1:iS4tRKtteioA1ZDrUqn2tGkBjM4fiQeRoqJx6E3dD34=
 github.com/GizClaw/doubao-speech-go v0.0.0-20260723152315-fe8153366feb/go.mod h1:4R3wUAZkYk1BSgzv+QVF+2SZPu3VDy8NvaQdNRYGgBs=
-github.com/GizClaw/flowcraft/core v0.1.16 h1:a8v02ZCekmjH6oofdgqjATy+Q+z4otgXv3j23/cS57g=
-github.com/GizClaw/flowcraft/core v0.1.16/go.mod h1:t4e1E55RSCsZTDGLCKLeg0Qags72Y2Yz2ZtL3EyGy1k=
+github.com/GizClaw/flowcraft/core v0.1.17 h1:E51v2sRzAKUY/cCI7GTamO5/26ZCtezrmZaZxCap64o=
+github.com/GizClaw/flowcraft/core v0.1.17/go.mod h1:ivaKWysWMtv3j0fj4059RWiSP8kNXBFDYDaFD80Gr74=
 github.com/avast/retry-go v3.0.0+incompatible/go.mod h1:XtSnn+n/sHqQIpZ10K1qAevBhOOCWBLXXy3hyiqqBrY=
 github.com/cenkalti/backoff/v5 v5.0.3 h1:ZN+IMa753KfX5hd8vVaMixjnqRZ3y8CuJKRKj1xcsSM=
 github.com/cenkalti/backoff/v5 v5.0.3/go.mod h1:rkhZdG3JZukswDf7f0cwqPNk4K0sa+F97BxZthm/crw=

--- a/driver/bytedance/resource.go
+++ b/driver/bytedance/resource.go
@@ -106,7 +106,7 @@ func buildProvider(settings ResourceSettings) (inference.ProviderDefinition, err
 	slices.Sort(names)
 	for _, name := range names {
 		entry := models[name]
-		if entry.kind == kindASR || entry.kind == kindRealtime {
+		if entry.kind == kindRealtime {
 			return inference.ProviderDefinition{}, fmt.Errorf(
 				"bytedance provider %q: model %q kind %q is not supported by core inference yet",
 				settings.ID,
@@ -225,6 +225,19 @@ func openersFor(
 					return inference.GenerateOperations{}, err
 				}
 				return openTTS(cls, spec, id, model.Profile)
+			},
+		}
+	case kindASR:
+		return inference.Openers{
+			Transcribe: func(
+				_ context.Context,
+				model inference.ModelRef,
+			) (inference.TranscribeOperations, error) {
+				cls, err := open(model.Profile)
+				if err != nil {
+					return inference.TranscribeOperations{}, err
+				}
+				return openASR(cls, id, model.Profile)
 			},
 		}
 	}

--- a/driver/bytedance/resource_test.go
+++ b/driver/bytedance/resource_test.go
@@ -3,6 +3,7 @@ package bytedance
 import (
 	"context"
 	"encoding/json"
+	"strings"
 	"testing"
 
 	"github.com/GizClaw/flowcraft/core/inference"
@@ -33,21 +34,94 @@ func TestResourceFactoryBuildsProvider(t *testing.T) {
 	}
 }
 
-func TestResourceFactoryRejectsASRAndRealtime(t *testing.T) {
-	for _, kind := range []string{"asr", "realtime"} {
-		_, err := Factory().New(context.Background(), resource.Input{
-			Settings: json.RawMessage(`{
-				"id": "bytedance",
-				"spec": {"models": [{"name": "model", "kind": "` + kind + `"}]},
-				"profiles": [{
-					"id": "default",
-					"secrets": {"api_key": "sk-test"}
-				}]
-			}`),
-		})
-		if err == nil {
-			t.Fatalf("New accepted kind %q before core transcription/realtime", kind)
+func TestResourceFactoryRejectsRealtime(t *testing.T) {
+	_, err := Factory().New(context.Background(), resource.Input{
+		Settings: json.RawMessage(`{
+			"id": "bytedance",
+			"spec": {"models": [{"name": "model", "kind": "realtime"}]},
+			"profiles": [{
+				"id": "default",
+				"secrets": {"api_key": "sk-test"}
+			}]
+		}`),
+	})
+	if err == nil {
+		t.Fatalf("New accepted kind realtime before core exposes that surface")
+	}
+}
+
+func TestResourceFactoryBuildsASRModel(t *testing.T) {
+	value, err := Factory().New(context.Background(), resource.Input{
+		Settings: json.RawMessage(`{
+			"id": "bytedance",
+			"spec": {},
+			"profiles": [{
+				"id": "default",
+				"secrets": {"speech_api_key": "sk-test"},
+				"spec": {"app_id": "app-test"}
+			}]
+		}`),
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	provider := value.(inference.ProviderDefinition)
+	var model *inference.ModelImplementation
+	for index := range provider.Models {
+		if provider.Models[index].Descriptor.ID.Name == "doubao-seed-asr" {
+			model = &provider.Models[index]
+			break
 		}
+	}
+	if model == nil {
+		t.Fatalf("doubao-seed-asr missing from catalog")
+	}
+	if model.Openers.Transcribe == nil {
+		t.Fatalf("doubao-seed-asr has no Transcribe opener")
+	}
+	operations, err := model.Openers.Transcribe(context.Background(), inference.ModelRef{
+		ID:      model.Descriptor.ID,
+		Profile: "default",
+	})
+	if err != nil {
+		t.Fatalf("open ASR: %v", err)
+	}
+	if err := operations.Validate(); err != nil {
+		t.Fatalf("operations: %v", err)
+	}
+}
+
+func TestResourceFactoryASROpenRequiresSpeech(t *testing.T) {
+	value, err := Factory().New(context.Background(), resource.Input{
+		Settings: json.RawMessage(`{
+			"id": "bytedance",
+			"spec": {},
+			"profiles": [{
+				"id": "default",
+				"secrets": {"api_key": "sk-test"}
+			}]
+		}`),
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	provider := value.(inference.ProviderDefinition)
+	var model *inference.ModelImplementation
+	for index := range provider.Models {
+		if provider.Models[index].Descriptor.ID.Name == "doubao-seed-asr" {
+			model = &provider.Models[index]
+			break
+		}
+	}
+	if model == nil || model.Openers.Transcribe == nil {
+		t.Fatalf("doubao-seed-asr opener missing")
+	}
+	_, err = model.Openers.Transcribe(context.Background(), inference.ModelRef{
+		ID:      model.Descriptor.ID,
+		Profile: "default",
+	})
+	if err == nil || !strings.Contains(err.Error(), "app_id") {
+		t.Fatalf("open ASR error = %v, want app_id requirement", err)
 	}
 }
 

--- a/driver/bytedance/spec.go
+++ b/driver/bytedance/spec.go
@@ -161,8 +161,8 @@ func (m ModelSpec) Validate() error {
 		return fmt.Errorf("invalid model name %q", m.Name)
 	}
 	switch modelKind(m.Kind) {
-	case kindGenerate, kindEmbed, kindImage, kindVideo, kindTTS:
-	case kindASR, kindRealtime:
+	case kindGenerate, kindEmbed, kindImage, kindVideo, kindTTS, kindASR:
+	case kindRealtime:
 		return fmt.Errorf("model %q kind %q is not supported by core inference yet", m.Name, m.Kind)
 	default:
 		return fmt.Errorf("model %q has unknown kind %q", m.Name, m.Kind)

--- a/driver/bytedance/transcribe.go
+++ b/driver/bytedance/transcribe.go
@@ -1,0 +1,615 @@
+package bytedance
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"iter"
+	"sync"
+
+	"github.com/GizClaw/flowcraft/core/inference"
+	"github.com/GizClaw/flowcraft/core/message/media"
+
+	doubaospeech "github.com/GizClaw/doubao-speech-go"
+)
+
+// Speech recognition runs on the Doubao ASR V2 SAUC WebSocket endpoint
+// (ASRV2.OpenStreamSession). The upstream API is bidirectional streaming
+// only — there is no unary HTTP recognition — so the unary contract is
+// served by opening a session, feeding the complete inline audio in
+// fixed-size packets (final packet flagged), and draining the accumulated
+// result inside the transport.
+//
+// Session semantics are continuous: partial and final events flow for as
+// many utterances as the caller sends. When the caller has no more audio,
+// FinishInput sends the final negative packet; the provider session then
+// reports the resulting final event, io.EOF, and closes the wire session.
+// TranscribeStream and the script-bridge finish() drive this lifecycle, so
+// one-shot and live flows both terminate deterministically.
+
+const (
+	// asrChunkSize paces unary whole-file recognition. At the SDK's
+	// recommended 16 kHz mono PCM profile this is ~100 ms per packet.
+	asrChunkSize = 3200
+	// asrResultTypeFull asks for full-result frames: every server response
+	// carries the accumulated hypothesis plus utterance timing.
+	asrResultTypeFull = "full"
+)
+
+// transcribeWire is the shared provider request for both transcription
+// shapes. audio is set by the unary compiler; the session compiler carries
+// format/sample-rate/channel/bits instead.
+type transcribeWire struct {
+	resourceID string
+	format     doubaospeech.AudioFormat
+	sampleRate doubaospeech.SampleRate
+	channel    int
+	bits       int
+	language   doubaospeech.Language
+	audio      []byte
+}
+
+// transcribeRaw is the unary transport's aggregated provider result.
+type transcribeRaw struct {
+	text       string
+	utterances []doubaospeech.ASRV2Utterance
+	duration   int
+	requestID  string
+}
+
+// compileTranscribe lowers a whole-file transcription request. The audio
+// must be inline: URL sources are not fetched in v1 and stream sources are
+// rejected by the canonical request validation anyway.
+func compileTranscribe(
+	endpoint string,
+) inference.Compiler[inference.TranscriptionRequest, transcribeWire] {
+	return func(
+		_ context.Context,
+		_ inference.ModelRef,
+		request inference.TranscriptionRequest,
+	) (inference.Compiled[transcribeWire], error) {
+		ledger := newLedger(
+			inference.OperationTranscription,
+			request.ActiveFields(),
+		)
+		wire := transcribeWire{resourceID: endpoint}
+		compileTranscribeControls(&wire, request.Language, request.Prompt, ledger)
+		for _, field := range request.Extensions.ActiveFields() {
+			ledger.reject(field, "bytedance transcription supports no extensions")
+		}
+		switch request.Audio.Kind() {
+		case media.SourceInline:
+			wire.audio = request.Audio.Bytes()
+			format, err := asrFormatForMediaType(
+				request.Audio.BaseMediaType(),
+			)
+			if err != nil {
+				ledger.reject(inference.FieldTranscriptionAudio, err.Error())
+			} else {
+				wire.format = format
+			}
+		case media.SourceURL:
+			ledger.reject(
+				inference.FieldTranscriptionAudio,
+				"bytedance ASR needs inline audio; URL sources are not fetched",
+			)
+		case media.SourceStream:
+			ledger.reject(
+				inference.FieldTranscriptionAudio,
+				"whole-file transcription rejects live stream audio; use TranscribeSession",
+			)
+		}
+
+		report := ledger.report()
+		if len(ledger.order) > 0 {
+			return inference.Compiled[transcribeWire]{Report: report}, ledger.err()
+		}
+		return inference.Compiled[transcribeWire]{Wire: wire, Report: report}, nil
+	}
+}
+
+// compileTranscribeSession lowers the open-time session request: the
+// canonical input format maps onto the ASR audio config, and the remaining
+// controls share the unary handling.
+func compileTranscribeSession(
+	endpoint string,
+) inference.Compiler[inference.TranscriptionSessionRequest, transcribeWire] {
+	return func(
+		_ context.Context,
+		_ inference.ModelRef,
+		request inference.TranscriptionSessionRequest,
+	) (inference.Compiled[transcribeWire], error) {
+		ledger := newLedger(
+			inference.OperationTranscription,
+			request.ActiveFields(),
+		)
+		wire := transcribeWire{resourceID: endpoint}
+		compileTranscribeControls(&wire, request.Language, request.Prompt, ledger)
+		for _, field := range request.Extensions.ActiveFields() {
+			ledger.reject(field, "bytedance transcription supports no extensions")
+		}
+		compileASRFormat(&wire, request.InputFormat, ledger)
+
+		report := ledger.report()
+		if len(ledger.order) > 0 {
+			return inference.Compiled[transcribeWire]{Report: report}, ledger.err()
+		}
+		return inference.Compiled[transcribeWire]{Wire: wire, Report: report}, nil
+	}
+}
+
+// compileTranscribeControls maps the canonical language and prompt controls
+// shared by both transcription shapes. Timestamps are native (utterances and
+// words always carry timing) and need no wire field.
+func compileTranscribeControls(
+	wire *transcribeWire,
+	language string,
+	prompt string,
+	ledger *ledger,
+) {
+	if prompt != "" {
+		ledger.reject(
+			inference.FieldTranscriptionPrompt,
+			"bytedance ASR has no prompt control",
+		)
+	}
+	if language == "" {
+		return
+	}
+	lang, ok := asrLanguage(language)
+	if !ok {
+		ledger.reject(
+			inference.FieldTranscriptionLanguage,
+			fmt.Sprintf("unsupported language %q", language),
+		)
+		return
+	}
+	wire.language = lang
+}
+
+// asrLanguage maps canonical language strings to the SDK's published set.
+func asrLanguage(language string) (doubaospeech.Language, bool) {
+	switch language {
+	case "zh-CN", "en-US", "ja-JP", "ko-KR":
+		return doubaospeech.Language(language), true
+	default:
+		return "", false
+	}
+}
+
+// compileASRFormat maps the canonical session input format onto the ASR
+// audio config. Raw PCM carries its sample rate, channel count, and bit
+// depth explicitly; compressed encodings are self-describing upstream, so
+// absent rates/channels resolve to the SDK defaults.
+func compileASRFormat(
+	wire *transcribeWire,
+	format media.AudioFormat,
+	ledger *ledger,
+) {
+	switch format.Encoding {
+	case media.AudioEncodingPCM16:
+		wire.format = doubaospeech.FormatPCM
+		wire.bits = 16
+	case media.AudioEncodingMP3:
+		wire.format = doubaospeech.FormatMP3
+	case media.AudioEncodingOpus:
+		wire.format = doubaospeech.FormatOGG
+	case media.AudioEncodingAAC:
+		wire.format = doubaospeech.FormatAAC
+	default:
+		ledger.reject(
+			inference.FieldTranscriptionInputFormat,
+			fmt.Sprintf("audio encoding %q has no native ASR token", format.Encoding),
+		)
+		return
+	}
+	if format.SampleRateHz != 0 {
+		switch format.SampleRateHz {
+		case 8000, 16000, 22050, 24000, 32000, 44100, 48000:
+			wire.sampleRate = doubaospeech.SampleRate(format.SampleRateHz)
+		default:
+			ledger.reject(
+				inference.FieldTranscriptionInputFormat,
+				fmt.Sprintf(
+					"sample rate %d is outside the provider's published set",
+					format.SampleRateHz,
+				),
+			)
+			return
+		}
+	}
+	if format.Channels > 2 {
+		ledger.reject(
+			inference.FieldTranscriptionInputFormat,
+			fmt.Sprintf(
+				"provider supports 1 or 2 channels, not %d",
+				format.Channels,
+			),
+		)
+		return
+	}
+	wire.channel = format.Channels
+}
+
+// asrFormatForMediaType derives the ASR wire format from a whole-file audio
+// source's media type. Raw PCM cannot carry its sample rate or channel count
+// through the canonical request, so unary PCM assumes the SDK defaults
+// (16 kHz, 16-bit, mono).
+func asrFormatForMediaType(mediaType string) (doubaospeech.AudioFormat, error) {
+	switch mediaType {
+	case "audio/pcm":
+		return doubaospeech.FormatPCM, nil
+	case "audio/mpeg":
+		return doubaospeech.FormatMP3, nil
+	case "audio/opus":
+		return doubaospeech.FormatOGG, nil
+	case "audio/aac":
+		return doubaospeech.FormatAAC, nil
+	case "audio/wav", "audio/x-wav", "audio/wave":
+		return doubaospeech.FormatWAV, nil
+	default:
+		return "", fmt.Errorf("media type %q has no native ASR token", mediaType)
+	}
+}
+
+// transportTranscribe serves the unary contract on the streaming wire: open
+// an ASR V2 session, feed the complete audio in fixed packets with the final
+// packet flagged, and return once the final result arrives.
+func transportTranscribe(
+	client *doubaospeech.Client,
+) inference.Transport[transcribeWire, transcribeRaw] {
+	return func(
+		ctx context.Context,
+		wire transcribeWire,
+	) (transcribeRaw, error) {
+		if len(wire.audio) == 0 {
+			return transcribeRaw{}, fmt.Errorf("bytedance: transcription audio is empty")
+		}
+		session, err := client.ASRV2.OpenStreamSession(
+			ctx,
+			asrConfig(wire),
+		)
+		if err != nil {
+			return transcribeRaw{}, classifyError(err)
+		}
+		defer func() { _ = session.Close() }()
+
+		for offset := 0; offset < len(wire.audio); offset += asrChunkSize {
+			end := min(offset+asrChunkSize, len(wire.audio))
+			isLast := end == len(wire.audio)
+			if err := session.SendAudio(
+				ctx,
+				wire.audio[offset:end],
+				isLast,
+			); err != nil {
+				return transcribeRaw{}, classifyError(err)
+			}
+		}
+
+		raw := transcribeRaw{}
+		for result, err := range session.Recv() {
+			if err != nil {
+				return transcribeRaw{}, classifyError(err)
+			}
+			if result == nil {
+				continue
+			}
+			raw = transcribeRaw{
+				text:       result.Text,
+				utterances: result.Utterances,
+				duration:   result.Duration,
+				requestID:  result.ReqID,
+			}
+			if result.IsFinal {
+				return raw, nil
+			}
+		}
+		if raw.text == "" && len(raw.utterances) == 0 {
+			return transcribeRaw{}, fmt.Errorf(
+				"bytedance: transcription produced no result",
+			)
+		}
+		return raw, nil
+	}
+}
+
+// transportTranscribeSession opens the provider-native duplex session.
+func transportTranscribeSession(
+	client *doubaospeech.Client,
+) inference.TranscriptionSessionTransport[transcribeWire, *doubaospeech.ASRV2Result] {
+	return func(
+		ctx context.Context,
+		wire transcribeWire,
+	) (inference.ProviderSession[*doubaospeech.ASRV2Result], error) {
+		session, err := client.ASRV2.OpenStreamSession(
+			ctx,
+			asrConfig(wire),
+		)
+		if err != nil {
+			return nil, classifyError(err)
+		}
+		pull, stop := iter.Pull2(session.Recv())
+		return &asrProviderSession{
+			sdk:       session,
+			pull:      pull,
+			stop:      stop,
+			sendAudio: session.SendAudio,
+		}, nil
+	}
+}
+
+// asrConfig renders the SDK session configuration from the compiled wire.
+func asrConfig(wire transcribeWire) *doubaospeech.ASRV2Config {
+	return &doubaospeech.ASRV2Config{
+		Format:     wire.format,
+		SampleRate: wire.sampleRate,
+		Channel:    wire.channel,
+		Bits:       wire.bits,
+		Language:   wire.language,
+		ResourceID: wire.resourceID,
+		ResultType: asrResultTypeFull,
+	}
+}
+
+// asrProviderSession adapts the SDK session to the canonical provider
+// session. It stays open across final results for continuous recognition;
+// FinishInput marks the end of input and the next final result ends the
+// session (io.EOF) and closes the underlying WebSocket so callers that never
+// call Close (TranscribeStream) do not leak it.
+type asrProviderSession struct {
+	sdk  *doubaospeech.ASRV2Session
+	pull func() (*doubaospeech.ASRV2Result, error, bool)
+	stop func()
+	// sendAudio is the SDK session's SendAudio; injectable for tests.
+	sendAudio func(context.Context, []byte, bool) error
+
+	mu        sync.Mutex
+	done      bool
+	endedErr  error
+	finished  bool // FinishInput called: no more audio will arrive
+	finalSeen bool // post-finish final delivered; next Next returns EOF
+}
+
+func (s *asrProviderSession) Send(
+	ctx context.Context,
+	chunk media.AudioChunk,
+) error {
+	s.mu.Lock()
+	if s.finished {
+		s.mu.Unlock()
+		return fmt.Errorf("bytedance: session input already finished")
+	}
+	s.mu.Unlock()
+	if err := s.sdk.SendAudio(ctx, chunk.Data, false); err != nil {
+		return classifyError(err)
+	}
+	return nil
+}
+
+// FinishInput sends the final negative audio packet. The server responds
+// with the accumulated final result and closes the session; the next final
+// event is delivered, then Next returns io.EOF.
+func (s *asrProviderSession) FinishInput(ctx context.Context) error {
+	s.mu.Lock()
+	if s.done {
+		s.mu.Unlock()
+		return fmt.Errorf("bytedance: transcription session ended")
+	}
+	if s.finished {
+		s.mu.Unlock()
+		return nil
+	}
+	s.mu.Unlock()
+
+	// Empty payload with isLast=true encodes the final negative packet.
+	if err := s.sendAudio(ctx, nil, true); err != nil {
+		return classifyError(err)
+	}
+	s.mu.Lock()
+	s.finished = true
+	s.mu.Unlock()
+	return nil
+}
+
+func (s *asrProviderSession) Next(
+	ctx context.Context,
+) (*doubaospeech.ASRV2Result, error) {
+	s.mu.Lock()
+	if s.done {
+		s.mu.Unlock()
+		if s.endedErr != nil {
+			return nil, s.endedErr
+		}
+		return nil, io.EOF
+	}
+	if s.finalSeen {
+		s.done = true
+		_ = s.closeWireLocked()
+		s.mu.Unlock()
+		return nil, io.EOF
+	}
+	s.mu.Unlock()
+
+	for {
+		result, err, ok := s.pull()
+		if err != nil {
+			classified := classifyError(err)
+			s.finish(classified)
+			return nil, classified
+		}
+		if !ok {
+			s.finish(nil)
+			return nil, io.EOF
+		}
+		if result == nil {
+			continue // intermediate control frame
+		}
+		if result.IsFinal {
+			s.mu.Lock()
+			if s.finished {
+				s.finalSeen = true
+				s.mu.Unlock()
+				return result, nil
+			}
+			s.mu.Unlock()
+		}
+		return result, nil
+	}
+}
+
+func (s *asrProviderSession) Interrupt() error {
+	s.mu.Lock()
+	if s.done {
+		s.mu.Unlock()
+		return nil
+	}
+	s.done = true
+	_ = s.closeWireLocked()
+	s.mu.Unlock()
+	return nil
+}
+
+func (s *asrProviderSession) Close() error {
+	s.mu.Lock()
+	if s.done {
+		s.mu.Unlock()
+		return nil
+	}
+	s.done = true
+	err := s.closeWireLocked()
+	s.mu.Unlock()
+	if err != nil {
+		return classifyError(err)
+	}
+	return nil
+}
+
+// finish records the terminal state for Next. err nil means normal EOF.
+func (s *asrProviderSession) finish(err error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.done {
+		return
+	}
+	s.done = true
+	s.endedErr = err
+	_ = s.closeWireLocked()
+}
+
+// closeWireLocked releases the pull iterator and the WebSocket. Callers hold
+// s.mu. The SDK close is idempotent and best-effort here: a one-shot end
+// must not surface close noise as a session error.
+func (s *asrProviderSession) closeWireLocked() error {
+	if s.stop != nil {
+		s.stop()
+		s.stop = nil
+	}
+	if s.sdk == nil {
+		return nil
+	}
+	return s.sdk.Close()
+}
+
+// decodeTranscribe maps the unary provider result onto the canonical
+// response. Utterances become segments with word-level timing; the joined
+// transcript text echoes the provider's accumulated hypothesis.
+func decodeTranscribe(
+	_ context.Context,
+	raw transcribeRaw,
+) (inference.TranscriptionResponse, error) {
+	segments := make(
+		[]inference.TranscriptionSegment,
+		0,
+		len(raw.utterances),
+	)
+	for _, utterance := range raw.utterances {
+		segment := inference.TranscriptionSegment{
+			Text:        utterance.Text,
+			StartMillis: int64(utterance.StartTime),
+			EndMillis:   int64(utterance.EndTime),
+		}
+		for _, word := range utterance.Words {
+			segment.Words = append(segment.Words, inference.TranscriptionWord{
+				Word:        word.Text,
+				StartMillis: int64(word.StartTime),
+				EndMillis:   int64(word.EndTime),
+			})
+		}
+		segments = append(segments, segment)
+	}
+	response := inference.TranscriptionResponse{
+		Text:     raw.text,
+		Segments: segments,
+		Metadata: inference.Metadata{RequestID: raw.requestID},
+	}
+	if raw.duration > 0 {
+		duration := int64(raw.duration)
+		response.DurationMillis = &duration
+	}
+	return response, nil
+}
+
+// decodeTranscribeSessionEvent maps one provider result onto a canonical
+// session event: partials carry the current hypothesis, the final result
+// carries the completed utterance as a segment with word timing.
+func decodeTranscribeSessionEvent(
+	_ context.Context,
+	raw *doubaospeech.ASRV2Result,
+) (inference.TranscriptionSessionEvent, error) {
+	if raw == nil {
+		return inference.TranscriptionSessionEvent{}, fmt.Errorf(
+			"bytedance: empty ASR session result",
+		)
+	}
+	event := inference.TranscriptionSessionEvent{
+		Text:      raw.Text,
+		RequestID: raw.ReqID,
+	}
+	if !raw.IsFinal || len(raw.Utterances) == 0 {
+		return event, nil
+	}
+	utterance := raw.Utterances[len(raw.Utterances)-1]
+	segment := inference.TranscriptionSegment{
+		Text:        utterance.Text,
+		StartMillis: int64(utterance.StartTime),
+		EndMillis:   int64(utterance.EndTime),
+	}
+	for _, word := range utterance.Words {
+		segment.Words = append(segment.Words, inference.TranscriptionWord{
+			Word:        word.Text,
+			StartMillis: int64(word.StartTime),
+			EndMillis:   int64(word.EndTime),
+		})
+	}
+	// Providers choose one event style, never both: a final segment replaces
+	// the hypothesis text on the event.
+	return inference.TranscriptionSessionEvent{
+		Final:      true,
+		Segment:    &segment,
+		RequestID:  raw.ReqID,
+		ResponseID: raw.ConnectID,
+	}, nil
+}
+
+// openASR materializes the unary and duplex transcription drivers for one
+// ASR model. The wire address resolves through the profile endpoints map,
+// exactly like TTS resource IDs.
+func openASR(
+	cls *clients,
+	id inference.ModelID,
+	profile string,
+) (inference.TranscribeOperations, error) {
+	speech, err := cls.requireSpeech(profile)
+	if err != nil {
+		return inference.TranscribeOperations{}, err
+	}
+	endpoint := cls.endpoint(id.Name)
+	return inference.BindTranscribeOperations(
+		compileTranscribe(endpoint),
+		transportTranscribe(speech),
+		decodeTranscribe,
+		compileTranscribeSession(endpoint),
+		transportTranscribeSession(speech),
+		decodeTranscribeSessionEvent,
+	)
+}

--- a/driver/bytedance/transcribe_test.go
+++ b/driver/bytedance/transcribe_test.go
@@ -1,0 +1,770 @@
+package bytedance
+
+import (
+	"context"
+	"errors"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/GizClaw/flowcraft/core/inference"
+	"github.com/GizClaw/flowcraft/core/inference/inferencetest"
+	"github.com/GizClaw/flowcraft/core/message/media"
+
+	doubaospeech "github.com/GizClaw/doubao-speech-go"
+)
+
+func transcribeAudio(t *testing.T) media.AudioSource {
+	t.Helper()
+	source, err := media.NewAudioBytes(
+		[]byte{0x00, 0x01, 0x02, 0x03},
+		"audio/pcm",
+	)
+	if err != nil {
+		t.Fatalf("NewAudioBytes: %v", err)
+	}
+	return source
+}
+
+func compileTranscribeWire(
+	t *testing.T,
+	request inference.TranscriptionRequest,
+) (transcribeWire, inference.CompileReport, error) {
+	t.Helper()
+	compiled, err := compileTranscribe("doubao-seed-asr")(
+		context.Background(),
+		conformanceModel("doubao-seed-asr"),
+		request,
+	)
+	return compiled.Wire, compiled.Report, err
+}
+
+func compileTranscribeSessionWire(
+	t *testing.T,
+	request inference.TranscriptionSessionRequest,
+) (transcribeWire, inference.CompileReport, error) {
+	t.Helper()
+	compiled, err := compileTranscribeSession("doubao-seed-asr")(
+		context.Background(),
+		conformanceModel("doubao-seed-asr"),
+		request,
+	)
+	return compiled.Wire, compiled.Report, err
+}
+
+func TestCompileTranscribe(t *testing.T) {
+	wire, report, err := compileTranscribeWire(t, inference.TranscriptionRequest{
+		Audio:      transcribeAudio(t),
+		Language:   "zh-CN",
+		Timestamps: true,
+	})
+	if err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+	if wire.resourceID != "doubao-seed-asr" {
+		t.Fatalf("resourceID = %q", wire.resourceID)
+	}
+	if wire.format != doubaospeech.FormatPCM {
+		t.Fatalf("format = %q, want pcm", wire.format)
+	}
+	if wire.language != doubaospeech.LanguageZhCN {
+		t.Fatalf("language = %q, want zh-CN", wire.language)
+	}
+	if string(wire.audio) != string([]byte{0x00, 0x01, 0x02, 0x03}) {
+		t.Fatalf("audio = %x", wire.audio)
+	}
+	for _, field := range []inference.FieldID{
+		inference.FieldTranscriptionAudio,
+		inference.FieldTranscriptionLanguage,
+		inference.FieldTranscriptionTimestamps,
+	} {
+		if reason := rejectedReason(report, field); reason != "" {
+			t.Fatalf("field %s rejected: %s", field, reason)
+		}
+	}
+}
+
+func TestCompileTranscribeRejects(t *testing.T) {
+	t.Run("prompt", func(t *testing.T) {
+		_, report, err := compileTranscribeWire(t, inference.TranscriptionRequest{
+			Audio:  transcribeAudio(t),
+			Prompt: "hint",
+		})
+		if reason := rejectedReason(
+			report,
+			inference.FieldTranscriptionPrompt,
+		); !strings.Contains(reason, "no prompt control") {
+			t.Fatalf("prompt reason = %q", reason)
+		}
+		if err == nil {
+			t.Fatalf("compile succeeded, want prompt rejection")
+		}
+	})
+	t.Run("unknown language", func(t *testing.T) {
+		_, report, err := compileTranscribeWire(t, inference.TranscriptionRequest{
+			Audio:    transcribeAudio(t),
+			Language: "xx-YY",
+		})
+		if reason := rejectedReason(
+			report,
+			inference.FieldTranscriptionLanguage,
+		); !strings.Contains(reason, "unsupported language") {
+			t.Fatalf("language reason = %q", reason)
+		}
+		if err == nil {
+			t.Fatalf("compile succeeded, want language rejection")
+		}
+	})
+	t.Run("url audio", func(t *testing.T) {
+		source, err := media.NewAudioURL(
+			"https://example.com/input.wav",
+			"audio/wav",
+		)
+		if err != nil {
+			t.Fatalf("NewAudioURL: %v", err)
+		}
+		_, report, err := compileTranscribeWire(t, inference.TranscriptionRequest{
+			Audio: source,
+		})
+		if reason := rejectedReason(
+			report,
+			inference.FieldTranscriptionAudio,
+		); !strings.Contains(reason, "inline audio") {
+			t.Fatalf("audio reason = %q", reason)
+		}
+		if err == nil {
+			t.Fatalf("compile succeeded, want URL rejection")
+		}
+	})
+	t.Run("extension", func(t *testing.T) {
+		_, report, err := compileTranscribeWire(t, inference.TranscriptionRequest{
+			Audio: transcribeAudio(t),
+			Extensions: inference.Extensions{
+				GenerateOptions{Provider: driverID, ServiceTier: "auto"},
+			},
+		})
+		rejected := false
+		for _, decision := range report.Decisions {
+			if decision.Disposition == inference.Rejected &&
+				strings.HasPrefix(string(decision.Field), "extension.") {
+				rejected = true
+			}
+		}
+		if !rejected {
+			t.Fatalf("extension field not rejected: %+v", report.Decisions)
+		}
+		if err == nil {
+			t.Fatalf("compile succeeded, want extension rejection")
+		}
+	})
+}
+
+func TestCompileTranscribeMediaTypes(t *testing.T) {
+	tests := []struct {
+		mediaType string
+		format    doubaospeech.AudioFormat
+		wantErr   bool
+	}{
+		{"audio/pcm", doubaospeech.FormatPCM, false},
+		{"audio/mpeg", doubaospeech.FormatMP3, false},
+		{"audio/opus", doubaospeech.FormatOGG, false},
+		{"audio/aac", doubaospeech.FormatAAC, false},
+		{"audio/wav", doubaospeech.FormatWAV, false},
+		{"audio/x-wav", doubaospeech.FormatWAV, false},
+		{"audio/flac", "", true},
+		{"audio/ogg", "", true},
+	}
+	for _, test := range tests {
+		t.Run(test.mediaType, func(t *testing.T) {
+			source, err := media.NewAudioBytes([]byte{1}, test.mediaType)
+			if err != nil {
+				t.Fatalf("NewAudioBytes: %v", err)
+			}
+			wire, _, err := compileTranscribeWire(t, inference.TranscriptionRequest{
+				Audio: source,
+			})
+			if test.wantErr {
+				if err == nil {
+					t.Fatalf("compile succeeded, want media type rejection")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("compile: %v", err)
+			}
+			if wire.format != test.format {
+				t.Fatalf("format = %q, want %q", wire.format, test.format)
+			}
+		})
+	}
+}
+
+func TestCompileTranscribeSession(t *testing.T) {
+	request := func(format media.AudioFormat) inference.TranscriptionSessionRequest {
+		return inference.TranscriptionSessionRequest{InputFormat: format}
+	}
+	tests := []struct {
+		name        string
+		format      media.AudioFormat
+		wire        transcribeWire
+		wantErr     bool
+		errFragment string
+	}{
+		{
+			name: "pcm16 mono",
+			format: media.AudioFormat{
+				Encoding:     media.AudioEncodingPCM16,
+				SampleRateHz: 16000,
+				Channels:     1,
+			},
+			wire: transcribeWire{
+				format:     doubaospeech.FormatPCM,
+				sampleRate: 16000,
+				channel:    1,
+				bits:       16,
+			},
+		},
+		{
+			name: "pcm16 stereo",
+			format: media.AudioFormat{
+				Encoding:     media.AudioEncodingPCM16,
+				SampleRateHz: 48000,
+				Channels:     2,
+			},
+			wire: transcribeWire{
+				format:     doubaospeech.FormatPCM,
+				sampleRate: 48000,
+				channel:    2,
+				bits:       16,
+			},
+		},
+		{
+			name:   "mp3",
+			format: media.AudioFormat{Encoding: media.AudioEncodingMP3},
+			wire:   transcribeWire{format: doubaospeech.FormatMP3},
+		},
+		{
+			name:   "opus",
+			format: media.AudioFormat{Encoding: media.AudioEncodingOpus},
+			wire:   transcribeWire{format: doubaospeech.FormatOGG},
+		},
+		{
+			name:   "aac",
+			format: media.AudioFormat{Encoding: media.AudioEncodingAAC},
+			wire:   transcribeWire{format: doubaospeech.FormatAAC},
+		},
+		{
+			name:        "flac",
+			format:      media.AudioFormat{Encoding: media.AudioEncodingFLAC},
+			wantErr:     true,
+			errFragment: "no native ASR token",
+		},
+		{
+			name: "pcm24",
+			format: media.AudioFormat{
+				Encoding:     media.AudioEncodingPCM24,
+				SampleRateHz: 16000,
+				Channels:     1,
+			},
+			wantErr:     true,
+			errFragment: "no native ASR token",
+		},
+		{
+			name: "unsupported sample rate",
+			format: media.AudioFormat{
+				Encoding:     media.AudioEncodingPCM16,
+				SampleRateHz: 11025,
+				Channels:     1,
+			},
+			wantErr:     true,
+			errFragment: "outside the provider's published set",
+		},
+		{
+			name: "too many channels",
+			format: media.AudioFormat{
+				Encoding:     media.AudioEncodingPCM16,
+				SampleRateHz: 16000,
+				Channels:     3,
+			},
+			wantErr:     true,
+			errFragment: "supports 1 or 2 channels",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			wire, _, err := compileTranscribeSessionWire(t, request(test.format))
+			if test.wantErr {
+				if err == nil {
+					t.Fatalf("compile succeeded, want %q", test.errFragment)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("compile: %v", err)
+			}
+			if wire.format != test.wire.format ||
+				wire.sampleRate != test.wire.sampleRate ||
+				wire.channel != test.wire.channel ||
+				wire.bits != test.wire.bits {
+				t.Fatalf(
+					"wire = {format:%s rate:%d channel:%d bits:%d}, want {format:%s rate:%d channel:%d bits:%d}",
+					wire.format, wire.sampleRate, wire.channel, wire.bits,
+					test.wire.format, test.wire.sampleRate,
+					test.wire.channel, test.wire.bits,
+				)
+			}
+		})
+	}
+}
+
+func TestCompileTranscribeSessionControls(t *testing.T) {
+	wire, _, err := compileTranscribeSessionWire(t,
+		inference.TranscriptionSessionRequest{
+			InputFormat: media.AudioFormat{
+				Encoding:     media.AudioEncodingPCM16,
+				SampleRateHz: 16000,
+				Channels:     1,
+			},
+			Language: "en-US",
+		},
+	)
+	if err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+	if wire.language != doubaospeech.LanguageEnUS {
+		t.Fatalf("language = %q, want en-US", wire.language)
+	}
+
+	_, _, err = compileTranscribeSessionWire(t,
+		inference.TranscriptionSessionRequest{
+			InputFormat: media.AudioFormat{
+				Encoding:     media.AudioEncodingPCM16,
+				SampleRateHz: 16000,
+				Channels:     1,
+			},
+			Prompt: "hint",
+		},
+	)
+	if err == nil {
+		t.Fatalf("compile succeeded, want prompt rejection")
+	}
+}
+
+func TestDecodeTranscribe(t *testing.T) {
+	raw := transcribeRaw{
+		text: "hello",
+		utterances: []doubaospeech.ASRV2Utterance{{
+			Text:      "hello",
+			StartTime: 100,
+			EndTime:   900,
+			Words: []doubaospeech.ASRV2Word{
+				{Text: "hello", StartTime: 100, EndTime: 900},
+			},
+		}},
+		duration:  800,
+		requestID: "req-1",
+	}
+	response, err := decodeTranscribe(context.Background(), raw)
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if response.Text != "hello" || len(response.Segments) != 1 {
+		t.Fatalf("response = %+v", response)
+	}
+	segment := response.Segments[0]
+	if segment.Text != "hello" ||
+		segment.StartMillis != 100 ||
+		segment.EndMillis != 900 ||
+		len(segment.Words) != 1 {
+		t.Fatalf("segment = %+v", segment)
+	}
+	if word := segment.Words[0]; word.Word != "hello" ||
+		word.StartMillis != 100 || word.EndMillis != 900 {
+		t.Fatalf("word = %+v", word)
+	}
+	if response.DurationMillis == nil || *response.DurationMillis != 800 {
+		t.Fatalf("duration = %v", response.DurationMillis)
+	}
+	if response.Metadata.RequestID != "req-1" {
+		t.Fatalf("request id = %q", response.Metadata.RequestID)
+	}
+}
+
+func TestDecodeTranscribeSessionEvent(t *testing.T) {
+	partial, err := decodeTranscribeSessionEvent(
+		context.Background(),
+		&doubaospeech.ASRV2Result{Text: "par"},
+	)
+	if err != nil {
+		t.Fatalf("decode partial: %v", err)
+	}
+	if partial.Text != "par" || partial.Final || partial.Segment != nil {
+		t.Fatalf("partial event = %+v", partial)
+	}
+
+	final, err := decodeTranscribeSessionEvent(
+		context.Background(),
+		&doubaospeech.ASRV2Result{
+			Text:    "full",
+			IsFinal: true,
+			Utterances: []doubaospeech.ASRV2Utterance{{
+				Text:      "full",
+				StartTime: 50,
+				EndTime:   600,
+				Words: []doubaospeech.ASRV2Word{
+					{Text: "full", StartTime: 50, EndTime: 600},
+				},
+			}},
+			ReqID:     "req-2",
+			ConnectID: "conn-2",
+		},
+	)
+	if err != nil {
+		t.Fatalf("decode final: %v", err)
+	}
+	if !final.Final || final.Text != "" || final.Segment == nil ||
+		final.RequestID != "req-2" || final.ResponseID != "conn-2" {
+		t.Fatalf("final event = %+v", final)
+	}
+	if segment := final.Segment; segment.Text != "full" ||
+		segment.StartMillis != 50 || segment.EndMillis != 600 ||
+		len(segment.Words) != 1 {
+		t.Fatalf("final segment = %+v", segment)
+	}
+
+	if _, err := decodeTranscribeSessionEvent(
+		context.Background(),
+		nil,
+	); err == nil {
+		t.Fatalf("nil raw decoded without error")
+	}
+}
+
+func TestASRProviderSessionNext(t *testing.T) {
+	results := []*doubaospeech.ASRV2Result{
+		{Text: "partial", IsFinal: false},
+		{Text: "final", IsFinal: true},
+	}
+	index := 0
+	pull := func() (*doubaospeech.ASRV2Result, error, bool) {
+		if index >= len(results) {
+			return nil, nil, false
+		}
+		result := results[index]
+		index++
+		return result, nil, true
+	}
+	session := &asrProviderSession{pull: pull}
+
+	first, err := session.Next(context.Background())
+	if err != nil || first.Text != "partial" || first.IsFinal {
+		t.Fatalf("first = %+v, %v", first, err)
+	}
+	second, err := session.Next(context.Background())
+	if err != nil || !second.IsFinal || second.Text != "final" {
+		t.Fatalf("second = %+v, %v", second, err)
+	}
+	if _, err := session.Next(context.Background()); err != io.EOF {
+		t.Fatalf("third = %v, want io.EOF", err)
+	}
+}
+
+func TestASRProviderSessionContinuous(t *testing.T) {
+	results := []*doubaospeech.ASRV2Result{
+		{Text: "one", IsFinal: false},
+		{Text: "one", IsFinal: true},
+		{Text: "two", IsFinal: false},
+		{Text: "two", IsFinal: true},
+	}
+	index := 0
+	pull := func() (*doubaospeech.ASRV2Result, error, bool) {
+		if index >= len(results) {
+			return nil, nil, false
+		}
+		result := results[index]
+		index++
+		return result, nil, true
+	}
+	session := &asrProviderSession{pull: pull}
+	for _, want := range results {
+		got, err := session.Next(context.Background())
+		if err != nil || got != want {
+			t.Fatalf("Next = %+v, %v; want %+v", got, err, want)
+		}
+	}
+	if _, err := session.Next(context.Background()); err != io.EOF {
+		t.Fatalf("Next after results = %v, want io.EOF", err)
+	}
+}
+
+func TestASRProviderSessionFinishInput(t *testing.T) {
+	results := []*doubaospeech.ASRV2Result{
+		{Text: "partial", IsFinal: false},
+		{Text: "one", IsFinal: true},
+		{Text: "two", IsFinal: true},
+	}
+	index := 0
+	pull := func() (*doubaospeech.ASRV2Result, error, bool) {
+		if index >= len(results) {
+			return nil, nil, false
+		}
+		result := results[index]
+		index++
+		return result, nil, true
+	}
+	var lastFlags []bool
+	sendAudio := func(_ context.Context, _ []byte, isLast bool) error {
+		lastFlags = append(lastFlags, isLast)
+		return nil
+	}
+	session := &asrProviderSession{
+		pull:      pull,
+		sendAudio: sendAudio,
+	}
+
+	first, err := session.Next(context.Background())
+	if err != nil || first.IsFinal {
+		t.Fatalf("first = %+v, %v", first, err)
+	}
+	second, err := session.Next(context.Background())
+	if err != nil || !second.IsFinal || second.Text != "one" {
+		t.Fatalf("second = %+v, %v; want continuous final", second, err)
+	}
+
+	if err := session.FinishInput(context.Background()); err != nil {
+		t.Fatalf("FinishInput: %v", err)
+	}
+	if len(lastFlags) != 1 || !lastFlags[0] {
+		t.Fatalf("finish frame = %v, want one isLast=true send", lastFlags)
+	}
+	// Idempotent: a second finish must not re-send the frame.
+	if err := session.FinishInput(context.Background()); err != nil {
+		t.Fatalf("second FinishInput: %v", err)
+	}
+	if len(lastFlags) != 1 {
+		t.Fatalf("finish frames = %d, want 1", len(lastFlags))
+	}
+	// No more audio may arrive after finish.
+	if err := session.Send(
+		context.Background(),
+		media.AudioChunk{Data: []byte{1}},
+	); err == nil {
+		t.Fatalf("Send after FinishInput succeeded")
+	}
+
+	third, err := session.Next(context.Background())
+	if err != nil || !third.IsFinal || third.Text != "two" {
+		t.Fatalf("post-finish final = %+v, %v", third, err)
+	}
+	if _, err := session.Next(context.Background()); err != io.EOF {
+		t.Fatalf("Next after post-finish final = %v, want io.EOF", err)
+	}
+}
+
+func TestASRProviderSessionFinishEndsWithoutFinal(t *testing.T) {
+	exhausted := false
+	pull := func() (*doubaospeech.ASRV2Result, error, bool) {
+		if exhausted {
+			return nil, nil, false
+		}
+		exhausted = true
+		return &doubaospeech.ASRV2Result{Text: "partial"}, nil, true
+	}
+	session := &asrProviderSession{
+		pull:      pull,
+		sendAudio: func(context.Context, []byte, bool) error { return nil },
+	}
+	first, err := session.Next(context.Background())
+	if err != nil || first.Text != "partial" {
+		t.Fatalf("first = %+v, %v", first, err)
+	}
+	if err := session.FinishInput(context.Background()); err != nil {
+		t.Fatalf("FinishInput: %v", err)
+	}
+	if _, err := session.Next(context.Background()); err != io.EOF {
+		t.Fatalf("Next after finish = %v, want io.EOF", err)
+	}
+}
+
+func TestASRProviderSessionPullError(t *testing.T) {
+	pullErr := errors.New("wire failure")
+	session := &asrProviderSession{
+		pull: func() (*doubaospeech.ASRV2Result, error, bool) {
+			return nil, pullErr, true
+		},
+	}
+	first, err := session.Next(context.Background())
+	if first != nil || err == nil {
+		t.Fatalf("Next = %+v, %v", first, err)
+	}
+	if _, err := session.Next(context.Background()); err == nil {
+		t.Fatalf("second Next succeeded after failure")
+	}
+}
+
+func TestASRProviderSessionCloseAndInterrupt(t *testing.T) {
+	session := &asrProviderSession{
+		pull: func() (*doubaospeech.ASRV2Result, error, bool) {
+			return nil, nil, false
+		},
+	}
+	if err := session.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	if err := session.Interrupt(); err != nil {
+		t.Fatalf("Interrupt after Close: %v", err)
+	}
+	if _, err := session.Next(context.Background()); err != io.EOF {
+		t.Fatalf("Next after Close = %v, want io.EOF", err)
+	}
+}
+
+func conformanceTranscribeRaw() transcribeRaw {
+	return transcribeRaw{
+		text: "ok",
+		utterances: []doubaospeech.ASRV2Utterance{{
+			Text: "ok",
+		}},
+		requestID: "req-1",
+	}
+}
+
+func TestConformanceTranscribeUnary(t *testing.T) {
+	calls := &inferencetest.Counter{}
+	driver, err := inference.BindTranscribe(
+		compileTranscribe("doubao-seed-asr"),
+		countingTransport(calls, func(
+			_ context.Context,
+			_ transcribeWire,
+		) (transcribeRaw, error) {
+			return conformanceTranscribeRaw(), nil
+		}),
+		decodeTranscribe,
+	)
+	if err != nil {
+		t.Fatalf("BindTranscribe: %v", err)
+	}
+	inferencetest.RunTranscribeUnary(t, inferencetest.TranscriptionUnarySuite{
+		Model: conformanceModel("doubao-seed-asr"),
+		Request: func() inference.TranscriptionRequest {
+			return inference.TranscriptionRequest{Audio: transcribeAudio(t)}
+		},
+		Driver:         driver,
+		TransportCalls: calls.Load,
+	})
+}
+
+// conformanceASRSession plays back provider results for the session
+// conformance suite without touching the network.
+type conformanceASRSession struct {
+	results []*doubaospeech.ASRV2Result
+	index   int
+	sends   int
+}
+
+func (s *conformanceASRSession) Send(
+	context.Context,
+	media.AudioChunk,
+) error {
+	s.sends++
+	return nil
+}
+
+func (s *conformanceASRSession) Next(
+	context.Context,
+) (*doubaospeech.ASRV2Result, error) {
+	if s.index >= len(s.results) {
+		return nil, io.EOF
+	}
+	result := s.results[s.index]
+	s.index++
+	return result, nil
+}
+
+func (*conformanceASRSession) Interrupt() error { return nil }
+func (*conformanceASRSession) Close() error     { return nil }
+
+func countingTranscribeSessionTransport(
+	calls *inferencetest.Counter,
+	next inference.TranscriptionSessionTransport[
+		transcribeWire,
+		*doubaospeech.ASRV2Result,
+	],
+) inference.TranscriptionSessionTransport[
+	transcribeWire,
+	*doubaospeech.ASRV2Result,
+] {
+	return func(
+		ctx context.Context,
+		wire transcribeWire,
+	) (inference.ProviderSession[*doubaospeech.ASRV2Result], error) {
+		calls.Inc()
+		return next(ctx, wire)
+	}
+}
+
+func TestConformanceTranscribeSession(t *testing.T) {
+	calls := &inferencetest.Counter{}
+	driver, err := inference.BindTranscribeSession(
+		compileTranscribeSession("doubao-seed-asr"),
+		countingTranscribeSessionTransport(
+			calls,
+			func(
+				_ context.Context,
+				_ transcribeWire,
+			) (inference.ProviderSession[*doubaospeech.ASRV2Result], error) {
+				return &conformanceASRSession{results: []*doubaospeech.ASRV2Result{
+					{Text: "partial", IsFinal: false},
+					{
+						Text:    "ok",
+						IsFinal: true,
+						Utterances: []doubaospeech.ASRV2Utterance{{
+							Text:      "ok",
+							StartTime: 0,
+							EndTime:   300,
+						}},
+						ReqID: "req-1",
+					},
+				}}, nil
+			},
+		),
+		decodeTranscribeSessionEvent,
+	)
+	if err != nil {
+		t.Fatalf("BindTranscribeSession: %v", err)
+	}
+	inferencetest.RunTranscribeSession(t, inferencetest.TranscriptionSessionSuite{
+		Model: conformanceModel("doubao-seed-asr"),
+		Request: func() inference.TranscriptionSessionRequest {
+			return inference.TranscriptionSessionRequest{
+				InputFormat: media.AudioFormat{
+					Encoding:     media.AudioEncodingPCM16,
+					SampleRateHz: 16000,
+					Channels:     1,
+				},
+			}
+		},
+		Driver:         driver,
+		TransportCalls: calls.Load,
+		AssertEvent: func(t *testing.T, event inference.TranscriptionSessionEvent) {
+			t.Helper()
+			if event.Text == "partial" {
+				return
+			}
+			if !event.Final || event.Segment == nil ||
+				event.Segment.Text != "ok" {
+				t.Fatalf("event = %+v", event)
+			}
+		},
+		AssertResult: func(t *testing.T, response inference.TranscriptionResponse) {
+			t.Helper()
+			if response.Text != "ok" || len(response.Segments) != 1 ||
+				response.Segments[0].Text != "ok" {
+				t.Fatalf("result = %+v", response)
+			}
+			if response.Metadata.RequestID != "req-1" {
+				t.Fatalf("request id = %q", response.Metadata.RequestID)
+			}
+		},
+	})
+}


### PR DESCRIPTION
Adds ByteDance streaming ASR (doubao-seed-asr) plus the core session contract it needs, and refreshes the bytedance model catalog against the official Ark model list.

Core
- New optional TranscriptionSessionFinisher capability: FinishInput signals end-of-input on an open transcription session; TranscribeStream performs the handshake automatically after the source stream ends.
- Script bridge transcription session handles gain finish(); providers without the capability return a Validation error.

driver/bytedance
- doubao-seed-asr: unary Transcribe (whole-file via an internal ASR V2 WebSocket session) and duplex TranscribeSession with continuous multi-utterance recognition.
- Sessions stay open across Final events; FinishInput sends the ASR final packet and the next final closes the session.
- Media mapping (pcm16/mp3/opus to ogg_opus/aac), sample-rate and channel validation, language allow-list; prompt and extension fields are rejected truthfully.
- Catalog refresh: add doubao-seed-evolving (1M context), doubao-seedream-5-0-pro, doubao-seedance-2-5; remove doubao-seed-1-6 and doubao-seed-1-6-flash. doubao-seed-2-0-lite stays: only the 260215 revision retired, the 260428 revision remains live and is the recommended audio-understanding model on Ark.

Validation: make ci, make lint, git diff --check, and go test -race on the touched modules all pass locally.

Note: no release changeset in this PR. Core exposes a new interface, so core needs a follow-up release (v0.1.18) before driver/bytedance can bump its dependency and publish.