### PR TITLE
chore(release): add core v0.1.18 changeset

### DIFF
--- a/.release/core-v0.1.18.json
+++ b/.release/core-v0.1.18.json
@@ -1,0 +1,9 @@
+{
+  "summary": "feat(core): add transcription session finisher — transcription sessions expose the optional TranscriptionSessionFinisher capability: FinishInput signals end-of-input so continuous sessions reach io.EOF after multiple final events, decoded sessions pass it through as a no-op when the provider lacks the capability, TranscribeStream performs the handshake automatically after the source stream ends, and the script bridge inference.transcribeSession handle gains finish() with a Validation error when the provider lacks the capability",
+  "releases": [
+    {
+      "module": "core",
+      "bump": "patch"
+    }
+  ]
+}


### PR DESCRIPTION
Adds the immutable core v0.1.18 changeset covering the core delta since core/v0.1.17: the transcription session finisher (TranscriptionSessionFinisher / FinishInput, TranscribeStream end-of-input handshake, script bridge finish()).

Plan: core 0.1.17 -> 0.1.18 (patch), tag core/v0.1.18.

After this merges, the Release modules workflow opens the changelog PR; merging that publishes the tag. A follow-up PR bumps driver/bytedance to require core v0.1.18.