### PR TITLE
chore(driver/bytedance): require core v0.1.18

### DIFF
--- a/driver/bytedance/go.mod
+++ b/driver/bytedance/go.mod
@@ -4,7 +4,7 @@ go 1.26.0
 
 require (
 	github.com/GizClaw/doubao-speech-go v0.0.0-20260723152315-fe8153366feb
-	github.com/GizClaw/flowcraft/core v0.1.17
+	github.com/GizClaw/flowcraft/core v0.1.18
 	github.com/volcengine/volcengine-go-sdk v1.2.14
 )
 

--- a/driver/bytedance/go.sum
+++ b/driver/bytedance/go.sum
@@ -2,8 +2,8 @@ cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMT
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/GizClaw/doubao-speech-go v0.0.0-20260723152315-fe8153366feb h1:iS4tRKtteioA1ZDrUqn2tGkBjM4fiQeRoqJx6E3dD34=
 github.com/GizClaw/doubao-speech-go v0.0.0-20260723152315-fe8153366feb/go.mod h1:4R3wUAZkYk1BSgzv+QVF+2SZPu3VDy8NvaQdNRYGgBs=
-github.com/GizClaw/flowcraft/core v0.1.17 h1:E51v2sRzAKUY/cCI7GTamO5/26ZCtezrmZaZxCap64o=
-github.com/GizClaw/flowcraft/core v0.1.17/go.mod h1:ivaKWysWMtv3j0fj4059RWiSP8kNXBFDYDaFD80Gr74=
+github.com/GizClaw/flowcraft/core v0.1.18 h1:n3xIwuC2m8ASXKfiecc639ptjXXGvsp8qeUPPRgbnZA=
+github.com/GizClaw/flowcraft/core v0.1.18/go.mod h1:ivaKWysWMtv3j0fj4059RWiSP8kNXBFDYDaFD80Gr74=
 github.com/avast/retry-go v3.0.0+incompatible/go.mod h1:XtSnn+n/sHqQIpZ10K1qAevBhOOCWBLXXy3hyiqqBrY=
 github.com/cenkalti/backoff/v5 v5.0.3 h1:ZN+IMa753KfX5hd8vVaMixjnqRZ3y8CuJKRKj1xcsSM=
 github.com/cenkalti/backoff/v5 v5.0.3/go.mod h1:rkhZdG3JZukswDf7f0cwqPNk4K0sa+F97BxZthm/crw=


### PR DESCRIPTION
Bumps the bytedance driver to core v0.1.18, which the streaming ASR transcription work depends on (TranscriptionSessionFinisher / FinishInput shipped in that release).

Validated locally with GOWORK=off against the published core v0.1.18: go mod tidy and go test ./... pass.