### PR TITLE
feat(core): custom graph node types as deployment resources

### DIFF
--- a/.release/core-v0.1.19.json
+++ b/.release/core-v0.1.19.json
@@ -1,0 +1,9 @@
+{
+  "summary": "feat(core): custom graph node types as deployment resources — new graph.NodeType resource kind with a script impl (declarative type/source/reads/writes and the full script bridge surface via the shared RunScript helper), the agent.Engine/graph factory mounts custom types through an optional node_type Many dep and registers them before Build with typed-nil and duplicate-mount guards, NodeTypeRegistrar/ConfigFileRefFields contracts let host/plugin Go node types opt into registration and config file-ref materialization, and Role gains JSON tags for declarative I/O roles",
+  "releases": [
+    {
+      "module": "core",
+      "bump": "patch"
+    }
+  ]
+}

--- a/core/graph/node.go
+++ b/core/graph/node.go
@@ -47,10 +47,10 @@ const (
 // means non-empty (reads) resp. grown since invocation (writes).
 // Missing optional slots are skipped silently.
 type Role struct {
-	Kind      RoleKind
-	Name      string
-	ConfigKey string
-	Required  bool
+	Kind      RoleKind `json:"kind"`
+	Name      string   `json:"name,omitempty"`
+	ConfigKey string   `json:"config_key,omitempty"`
+	Required  bool     `json:"required,omitempty"`
 }
 
 // Meta is the static descriptor of a node type, supplied once at

--- a/core/graph/nodes/script/node.go
+++ b/core/graph/nodes/script/node.go
@@ -89,40 +89,53 @@ func NewNode(deps ScriptNodeDeps) graph.NodeType[ScriptConfig] {
 			if name == "" {
 				name = ec.NodeID
 			}
-			info, _ := agent.RunInfoFromContext(ec.Context)
-
-			// Subscriptions opened mid-script are bound to the script's
-			// lifetime: the cleanup registry rides the context the
-			// bridges bind against and Exec receives, then flushes when
-			// Exec returns — subscriptions never outlive the node
-			// invocation.
-			execCtx, cleanups := withStreamCleanup(ec.Context)
-			defer cleanups.flush()
-
-			env := bindings.NewEnvBuilder(cfg.Config).
-				Add(
-					bindings.NewBoardBridge(board),
-					bindings.NewExprBridge(),
-					bindings.NewHostBridge(ec.Host, name, scriptEmitter{ec}),
-					bindings.NewRunInfoBridge(),
-					bindings.NewToolBridge(deps.ToolDispatcher, deps.ToolCatalog, deps.ToolOptions...),
-					bindings.NewInferenceBridge(deps.InferenceAssembly, deps.InferenceRouter, deps.InferenceOptions...),
-					newNodeBridge(ec.NodeID, ec.NodeType),
-					newStreamBridge(info.RunID, ec.Host),
-					newParallelBridge(),
-				).
-				AddIf(deps.Workspace != nil, bindings.NewFSBridge(deps.Workspace)).
-				AddIf(deps.CommandRunner != nil, bindings.NewShellBridge(deps.CommandRunner, deps.ShellOptions...)).
-				AddLate(bindings.NewRuntimeBridge(runtime)).
-				Build(execCtx)
-
-			sig, err := runtime.Exec(execCtx, name, cfg.Source, env)
-			if err != nil {
-				return err
-			}
-			return agent.SignalToError(sig)
+			return RunScript(ec, board, deps, runtime, name, cfg.Source, cfg.Config)
 		},
 	}
+}
+
+// RunScript assembles a fresh script environment with the standard
+// bridges — board, expr, host, run, tools, inference, node, stream,
+// parallel — plus the opt-in fs/shell globals when deps wire
+// Workspace/CommandRunner, executes source, and maps control signals
+// to Go errors via agent.SignalToError.
+//
+// It is shared by the built-in "script" node and script-backed custom
+// node types (core/graph/resource's graph.NodeType/script), so custom
+// nodes get exactly the same bridge surface as the built-in script
+// node.
+func RunScript(ec graph.ExecutionContext, board *agent.Board, deps ScriptNodeDeps, runtime agent.ScriptRuntime, name, source string, config map[string]any) error {
+	info, _ := agent.RunInfoFromContext(ec.Context)
+
+	// Subscriptions opened mid-script are bound to the script's
+	// lifetime: the cleanup registry rides the context the bridges
+	// bind against and Exec receives, then flushes when Exec returns —
+	// subscriptions never outlive the node invocation.
+	execCtx, cleanups := withStreamCleanup(ec.Context)
+	defer cleanups.flush()
+
+	env := bindings.NewEnvBuilder(config).
+		Add(
+			bindings.NewBoardBridge(board),
+			bindings.NewExprBridge(),
+			bindings.NewHostBridge(ec.Host, name, scriptEmitter{ec}),
+			bindings.NewRunInfoBridge(),
+			bindings.NewToolBridge(deps.ToolDispatcher, deps.ToolCatalog, deps.ToolOptions...),
+			bindings.NewInferenceBridge(deps.InferenceAssembly, deps.InferenceRouter, deps.InferenceOptions...),
+			newNodeBridge(ec.NodeID, ec.NodeType),
+			newStreamBridge(info.RunID, ec.Host),
+			newParallelBridge(),
+		).
+		AddIf(deps.Workspace != nil, bindings.NewFSBridge(deps.Workspace)).
+		AddIf(deps.CommandRunner != nil, bindings.NewShellBridge(deps.CommandRunner, deps.ShellOptions...)).
+		AddLate(bindings.NewRuntimeBridge(runtime)).
+		Build(execCtx)
+
+	sig, err := runtime.Exec(execCtx, name, source, env)
+	if err != nil {
+		return err
+	}
+	return agent.SignalToError(sig)
 }
 
 func Register(reg *graph.Registry, deps ScriptNodeDeps) error {

--- a/core/graph/registry.go
+++ b/core/graph/registry.go
@@ -26,6 +26,31 @@ type Registry struct {
 	fallback FallbackHandler
 }
 
+// NodeTypeRegistrar binds one or more node types into a Registry.
+//
+// It is the contract between the graph kernel and resource-built
+// custom node types: a value implementing this interface can be
+// produced by any resource factory (core/graph/resource's
+// "graph.NodeType" kind, a host package, a plugin) and mounted into
+// the graph engine as a "node_type" dependency. The engine factory
+// calls Register on every such dependency before Build, so custom
+// node types participate in the normal resource DAG — they can carry
+// their own deps, be shared across agents, and be validated at
+// deployment time like any other resource.
+type NodeTypeRegistrar interface {
+	Register(*Registry) error
+}
+
+// ConfigFileRefFields is implemented by [NodeTypeRegistrar]s whose
+// node configs may carry structured source references ({"file": ...}
+// or {"embed": ...}). The graph engine factory materializes those
+// references before Build so the kernel stays filesystem-free.
+type ConfigFileRefFields interface {
+	// FileRefFields returns, per registered node type name, the config
+	// field names that may hold a source reference.
+	FileRefFields() map[string][]string
+}
+
 // NewRegistry returns an empty Registry.
 func NewRegistry() *Registry {
 	return &Registry{types: make(map[string]*erasedType)}

--- a/core/graph/resource/node_type.go
+++ b/core/graph/resource/node_type.go
@@ -1,0 +1,153 @@
+// Custom graph node types as deployment resources.
+package resource
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/GizClaw/flowcraft/core/agent"
+	"github.com/GizClaw/flowcraft/core/errdefs"
+	coregraph "github.com/GizClaw/flowcraft/core/graph"
+	scriptnode "github.com/GizClaw/flowcraft/core/graph/nodes/script"
+	res "github.com/GizClaw/flowcraft/core/resource"
+)
+
+// NodeTypeKind is the deployment resource kind of a custom graph node
+// type. Factory values implement [coregraph.NodeTypeRegistrar]; the
+// graph engine factory registers every "node_type" dep before Build,
+// so custom node types participate in the resource DAG like any other
+// collaborator — they can declare their own deps (runtime, workspace,
+// tools, ...), be shared across agents, and are built exactly once.
+const NodeTypeKind = "graph.NodeType"
+
+// ScriptNodeTypeSettings is the strict settings subtree of the
+// script-backed impl.
+type ScriptNodeTypeSettings struct {
+	// Type is the node type name graphs reference in
+	// NodeDefinition.Type (e.g. "extract"). It must not collide with
+	// the built-in "inference", "tool", or "script" types or with
+	// another mounted custom type.
+	Type string `json:"type"`
+
+	// Source is the handler source: an inline string, or a
+	// structured {"file": ...} / {"embed": ...} reference resolved
+	// through the deployment loader.
+	Source json.RawMessage `json:"source"`
+
+	// Desc is the optional human-readable node type description.
+	Desc string `json:"desc,omitempty"`
+
+	// Reads and Writes declare the node type's static I/O roles. They
+	// are resolved at Build time and enforced at invocation exactly
+	// like the built-in types' roles; a ConfigKey-bound role reads
+	// the key from the node's own config.
+	Reads  []coregraph.Role `json:"reads,omitempty"`
+	Writes []coregraph.Role `json:"writes,omitempty"`
+}
+
+// ScriptNodeTypeFactory builds a script-backed custom node type: each
+// graph node of the type runs the declared source on the wired
+// script runtime with the standard script bridges (board, expr, host,
+// run, tools, inference, node, stream, parallel, fs, shell, runtime).
+// The node's config is the script's "config" global, so config values
+// may carry ${board.*} references like any other node config.
+type ScriptNodeTypeFactory struct{}
+
+// Spec implements res.Factory.
+func (ScriptNodeTypeFactory) Spec() res.Spec {
+	return res.Spec{
+		Kind: NodeTypeKind,
+		Impl: "script",
+		Deps: []res.DepSpec{
+			{Name: DepScriptRuntime, Type: "agent.ScriptRuntime", Required: true},
+			{Name: DepTools, Type: "tool.Assembly"},
+			{Name: DepInference, Type: "inference.Assembly"},
+			{Name: DepRouter, Type: "inference.Router"},
+			{Name: DepWorkspace, Type: "workspace.Workspace"},
+			{Name: DepSandbox, Type: "sandbox.Runner"},
+		},
+	}
+}
+
+// New implements res.Factory.
+func (ScriptNodeTypeFactory) New(ctx context.Context, in res.Input) (any, error) {
+	settings, err := res.DecodeTyped[ScriptNodeTypeSettings](in.Settings)
+	if err != nil {
+		return nil, errdefs.Validationf("graph node type: decode settings: %v", err)
+	}
+	if settings.Type == "" {
+		return nil, errdefs.Validationf("graph node type: settings.type is required")
+	}
+	if len(settings.Source) == 0 {
+		return nil, errdefs.Validationf(
+			"graph node type %q: settings.source is required", settings.Type)
+	}
+	src, err := res.ParseSource(settings.Source)
+	if err != nil {
+		return nil, errdefs.Validationf(
+			"graph node type %q: settings.source: %v", settings.Type, err)
+	}
+	data, err := resolveSource(ctx, in, src)
+	if err != nil {
+		return nil, fmt.Errorf("graph node type %q: settings.source: %w", settings.Type, err)
+	}
+	if len(data) == 0 {
+		return nil, errdefs.Validationf(
+			"graph node type %q: settings.source is empty", settings.Type)
+	}
+
+	deps, err := decodeDependencies(in.Deps)
+	if err != nil {
+		return nil, err
+	}
+	if deps.script == nil {
+		return nil, errdefs.NotFoundf(
+			"graph node type %q: requires dep %q", settings.Type, DepScriptRuntime)
+	}
+
+	scriptDeps := scriptnode.ScriptNodeDeps{
+		Workspace:     deps.workspace,
+		CommandRunner: deps.sandbox,
+	}
+	if deps.inference != nil {
+		scriptDeps.InferenceAssembly = deps.inference
+	}
+	if deps.router != nil {
+		scriptDeps.InferenceRouter = deps.router
+	}
+	if deps.tools != nil {
+		scriptDeps.ToolDispatcher = deps.tools
+		scriptDeps.ToolCatalog = deps.tools.Catalog()
+	}
+
+	desc := settings.Desc
+	if desc == "" {
+		desc = "custom script-backed node type"
+	}
+	source := string(data)
+	runtime := deps.script
+	node := coregraph.NodeType[map[string]any]{
+		Meta: coregraph.Meta{
+			Desc:   desc,
+			Reads:  settings.Reads,
+			Writes: settings.Writes,
+		},
+		Handler: func(ec coregraph.ExecutionContext, board *agent.Board, cfg map[string]any) error {
+			return scriptnode.RunScript(ec, board, scriptDeps, runtime, ec.NodeID, source, cfg)
+		},
+	}
+	return &scriptNodeType{typeName: settings.Type, node: node}, nil
+}
+
+// scriptNodeType is the resource-built value the graph engine factory
+// registers into its registry.
+type scriptNodeType struct {
+	typeName string
+	node     coregraph.NodeType[map[string]any]
+}
+
+// Register implements coregraph.NodeTypeRegistrar.
+func (s *scriptNodeType) Register(reg *coregraph.Registry) error {
+	return coregraph.RegisterType(reg, s.typeName, s.node)
+}

--- a/core/graph/resource/node_type_test.go
+++ b/core/graph/resource/node_type_test.go
@@ -1,0 +1,351 @@
+package resource_test
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/GizClaw/flowcraft/core/agent"
+	"github.com/GizClaw/flowcraft/core/errdefs"
+	coregraph "github.com/GizClaw/flowcraft/core/graph"
+	graphresource "github.com/GizClaw/flowcraft/core/graph/resource"
+	"github.com/GizClaw/flowcraft/core/message"
+	"github.com/GizClaw/flowcraft/core/resource"
+)
+
+// scriptRuntimeStub stubs the one-method agent.ScriptRuntime contract.
+type scriptRuntimeStub struct {
+	exec func(ctx context.Context, name, source string, env *agent.ScriptEnv) (*agent.ScriptSignal, error)
+}
+
+func (s scriptRuntimeStub) Exec(ctx context.Context, name, source string, env *agent.ScriptEnv) (*agent.ScriptSignal, error) {
+	return s.exec(ctx, name, source, env)
+}
+
+func buildScriptNodeType(t *testing.T, settings string, deps map[string]any) coregraph.NodeTypeRegistrar {
+	t.Helper()
+	value, err := (graphresource.ScriptNodeTypeFactory{}).New(context.Background(), resource.Input{
+		Settings: []byte(settings),
+		Deps:     deps,
+	})
+	if err != nil {
+		t.Fatalf("ScriptNodeTypeFactory.New: %v", err)
+	}
+	registrar, ok := value.(coregraph.NodeTypeRegistrar)
+	if !ok {
+		t.Fatalf("ScriptNodeTypeFactory.New returned %T, want graph.NodeTypeRegistrar", value)
+	}
+	return registrar
+}
+
+func customNodeDefinition(t *testing.T, nodeType string, config any) []byte {
+	t.Helper()
+	def, err := json.Marshal(map[string]any{
+		"name":  "g",
+		"entry": "n1",
+		"nodes": []any{
+			map[string]any{
+				"id":     "n1",
+				"type":   nodeType,
+				"config": config,
+			},
+		},
+		"edges": []any{},
+	})
+	if err != nil {
+		t.Fatalf("marshal graph: %v", err)
+	}
+	return def
+}
+
+func buildCustomEngine(t *testing.T, def []byte, deps map[string]any) *coregraph.Graph {
+	t.Helper()
+	value, err := (graphresource.Factory{}).New(context.Background(), resource.Input{
+		Settings: []byte(`{"graph": ` + string(def) + `}`),
+		Deps:     deps,
+	})
+	if err != nil {
+		t.Fatalf("engine New: %v", err)
+	}
+	engine, ok := value.(*coregraph.Graph)
+	if !ok {
+		t.Fatalf("engine New returned %T, want *coregraph.Graph", value)
+	}
+	return engine
+}
+
+func runCustomEngine(t *testing.T, g *coregraph.Graph, board *agent.Board) error {
+	t.Helper()
+	if board == nil {
+		board = agent.NewBoard()
+	}
+	board.AppendChannelMessage(agent.MainChannel,
+		message.NewTextMessage(message.RoleUser, "hi"))
+	_, err := g.Execute(context.Background(),
+		agent.Run{Identity: agent.Identity{AgentID: "test-agent", RunID: "run-1"}},
+		agent.NoopHost{}, board)
+	return err
+}
+
+func TestEngineMountsCustomScriptNode(t *testing.T) {
+	var gotName, gotSource string
+	var gotEnv *agent.ScriptEnv
+	rt := scriptRuntimeStub{exec: func(_ context.Context, name, source string, env *agent.ScriptEnv) (*agent.ScriptSignal, error) {
+		gotName, gotSource, gotEnv = name, source, env
+		board := env.Bindings["board"].(map[string]any)
+		board["setVar"].(func(string, any))("greeting", "hi "+env.Config["name"].(string))
+		return nil, nil
+	}}
+	registrar := buildScriptNodeType(t, `{
+		"type": "greet",
+		"source": "fake source",
+		"desc": "greets a name",
+		"writes": [{"kind": "var", "name": "greeting", "required": true}]
+	}`, map[string]any{"script_runtime": rt})
+
+	// The node config payload reaches the script as its config global,
+	// with ${board.*} references resolved first.
+	board := agent.NewBoard()
+	board.SetVar("who", "world")
+	engine := buildCustomEngine(t,
+		customNodeDefinition(t, "greet", map[string]any{"name": "${board.who}"}),
+		map[string]any{"node_type": registrar})
+
+	if err := runCustomEngine(t, engine, board); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if gotName != "n1" {
+		t.Fatalf("name = %q, want the node id", gotName)
+	}
+	if gotSource != "fake source" {
+		t.Fatalf("source = %q", gotSource)
+	}
+	if gotEnv.Config["name"] != "world" {
+		t.Fatalf("env.Config = %v, want board-resolved name", gotEnv.Config)
+	}
+	if v, _ := board.GetVar("greeting"); v != "hi world" {
+		t.Fatalf("greeting = %v, want the script's write", v)
+	}
+}
+
+func TestEngineMountsCustomNodeTypesViaManyDeps(t *testing.T) {
+	rt := scriptRuntimeStub{exec: func(_ context.Context, _ string, _ string, env *agent.ScriptEnv) (*agent.ScriptSignal, error) {
+		board := env.Bindings["board"].(map[string]any)
+		board["setVar"].(func(string, any))("seen", env.Config["value"])
+		return nil, nil
+	}}
+	registrar := buildScriptNodeType(t, `{
+		"type": "passthrough",
+		"source": "fake source",
+		"writes": [{"kind": "var", "name": "seen", "required": true}]
+	}`, map[string]any{"script_runtime": rt})
+
+	engine := buildCustomEngine(t,
+		customNodeDefinition(t, "passthrough", map[string]any{"value": 7}),
+		map[string]any{"node_type.passthrough": registrar})
+
+	board := agent.NewBoard()
+	if err := runCustomEngine(t, engine, board); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if v, _ := board.GetVar("seen"); v != float64(7) {
+		t.Fatalf("seen = %v, want 7", v)
+	}
+}
+
+func TestCustomNodeConfigKeyRoles(t *testing.T) {
+	rt := scriptRuntimeStub{exec: func(_ context.Context, _ string, _ string, env *agent.ScriptEnv) (*agent.ScriptSignal, error) {
+		board := env.Bindings["board"].(map[string]any)
+		input := board["getVar"].(func(string) any)("doc")
+		board["setVar"].(func(string, any))("out", "processed:"+input.(string))
+		return nil, nil
+	}}
+	registrar := buildScriptNodeType(t, `{
+		"type": "transform",
+		"source": "fake source",
+		"reads":  [{"kind": "var", "config_key": "input_key", "required": true}],
+		"writes": [{"kind": "var", "config_key": "result_key", "required": true}]
+	}`, map[string]any{"script_runtime": rt})
+
+	engine := buildCustomEngine(t,
+		customNodeDefinition(t, "transform", map[string]any{"input_key": "doc", "result_key": "out"}),
+		map[string]any{"node_type.transform": registrar})
+
+	board := agent.NewBoard()
+	board.SetVar("doc", "payload")
+	if err := runCustomEngine(t, engine, board); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if v, _ := board.GetVar("out"); v != "processed:payload" {
+		t.Fatalf("out = %v, want processed payload", v)
+	}
+
+	// Required read roles are enforced at invocation: a board without
+	// the bound var fails the run.
+	missing := agent.NewBoard()
+	if err := runCustomEngine(t, engine, missing); err == nil || !errdefs.IsValidation(err) {
+		t.Fatalf("Execute without required read = %v, want Validation", err)
+	}
+}
+
+func TestEngineRejectsNonRegistrarNodeTypeDep(t *testing.T) {
+	def := customNodeDefinition(t, "whatever", map[string]any{})
+	_, err := (graphresource.Factory{}).New(context.Background(), resource.Input{
+		Settings: []byte(`{"graph": ` + string(def) + `}`),
+		Deps:     map[string]any{"node_type": "not a registrar"},
+	})
+	if err == nil || !errdefs.IsValidation(err) {
+		t.Fatalf("New = %v, want Validation for non-registrar node_type dep", err)
+	}
+}
+
+type nilRegistrar struct{}
+
+func (*nilRegistrar) Register(*coregraph.Registry) error { return nil }
+
+func TestEngineRejectsTypedNilNodeTypeDep(t *testing.T) {
+	def := customNodeDefinition(t, "whatever", map[string]any{})
+	var registrar *nilRegistrar // typed nil
+	_, err := (graphresource.Factory{}).New(context.Background(), resource.Input{
+		Settings: []byte(`{"graph": ` + string(def) + `}`),
+		Deps:     map[string]any{"node_type": registrar},
+	})
+	if err == nil || !errdefs.IsValidation(err) {
+		t.Fatalf("New = %v, want Validation for typed-nil node_type dep", err)
+	}
+}
+
+func TestEngineRejectsDuplicateMount(t *testing.T) {
+	rt := scriptRuntimeStub{exec: func(context.Context, string, string, *agent.ScriptEnv) (*agent.ScriptSignal, error) {
+		return nil, nil
+	}}
+	registrar := buildScriptNodeType(t, `{"type": "dup", "source": "s"}`, map[string]any{"script_runtime": rt})
+
+	def := customNodeDefinition(t, "dup", map[string]any{})
+	_, err := (graphresource.Factory{}).New(context.Background(), resource.Input{
+		Settings: []byte(`{"graph": ` + string(def) + `}`),
+		Deps: map[string]any{
+			"node_type.a": registrar,
+			"node_type.b": registrar,
+		},
+	})
+	if err == nil || !errdefs.IsConflict(err) {
+		t.Fatalf("New = %v, want Conflict for duplicate mount", err)
+	}
+	if !strings.Contains(err.Error(), "node_type.a") || !strings.Contains(err.Error(), "node_type.b") {
+		t.Fatalf("New error = %v, want both dep keys named", err)
+	}
+}
+
+func TestEngineRejectsDuplicateCustomNodeType(t *testing.T) {
+	rt := scriptRuntimeStub{exec: func(context.Context, string, string, *agent.ScriptEnv) (*agent.ScriptSignal, error) {
+		return nil, nil
+	}}
+	first := buildScriptNodeType(t, `{"type": "dup", "source": "s1"}`, map[string]any{"script_runtime": rt})
+	second := buildScriptNodeType(t, `{"type": "dup", "source": "s2"}`, map[string]any{"script_runtime": rt})
+
+	def := customNodeDefinition(t, "dup", map[string]any{})
+	_, err := (graphresource.Factory{}).New(context.Background(), resource.Input{
+		Settings: []byte(`{"graph": ` + string(def) + `}`),
+		Deps: map[string]any{
+			"node_type.a": first,
+			"node_type.b": second,
+		},
+	})
+	if err == nil || !errdefs.IsConflict(err) {
+		t.Fatalf("New = %v, want Conflict for duplicate custom type", err)
+	}
+}
+
+type goEchoConfig struct {
+	Prompt    string `json:"prompt"`
+	OutputKey string `json:"output_key"`
+}
+
+// goEchoRegistrar is a host-defined Go node type: it registers a
+// typed node via graph.RegisterType and opts into config file-ref
+// materialization via ConfigFileRefFields.
+type goEchoRegistrar struct {
+	got *goEchoConfig
+}
+
+func (r goEchoRegistrar) Register(reg *coregraph.Registry) error {
+	return coregraph.RegisterType(reg, "go_echo", coregraph.NodeType[goEchoConfig]{
+		Meta: coregraph.Meta{
+			Writes: []coregraph.Role{{
+				Kind: coregraph.RoleVar, ConfigKey: "output_key", Required: true,
+			}},
+		},
+		Handler: func(_ coregraph.ExecutionContext, board *agent.Board, cfg goEchoConfig) error {
+			*r.got = cfg
+			board.SetVar(cfg.OutputKey, cfg.Prompt)
+			return nil
+		},
+	})
+}
+
+func (r goEchoRegistrar) FileRefFields() map[string][]string {
+	return map[string][]string{"go_echo": {"prompt"}}
+}
+
+func TestEngineMountsGoBackedNodeTypeWithFileRefs(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "prompt.txt"), []byte("hello from file"), 0o600); err != nil {
+		t.Fatalf("write prompt file: %v", err)
+	}
+	loader := resource.NewLoader(resource.WithBaseDir(dir))
+
+	var got goEchoConfig
+	registrar := goEchoRegistrar{got: &got}
+	def := customNodeDefinition(t, "go_echo", map[string]any{
+		"prompt":     map[string]any{"file": "prompt.txt"},
+		"output_key": "out",
+	})
+	value, err := (graphresource.Factory{}).New(context.Background(), resource.Input{
+		Settings: []byte(`{"graph": ` + string(def) + `}`),
+		Deps:     map[string]any{"node_type.go_echo": registrar},
+		Loader:   loader,
+	})
+	if err != nil {
+		t.Fatalf("engine New: %v", err)
+	}
+
+	board := agent.NewBoard()
+	if err := runCustomEngine(t, value.(*coregraph.Graph), board); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if got.Prompt != "hello from file" {
+		t.Fatalf("handler received prompt %q, want materialized file content", got.Prompt)
+	}
+	if v, _ := board.GetVar("out"); v != "hello from file" {
+		t.Fatalf("out = %v, want file content", v)
+	}
+}
+
+func TestScriptNodeTypeFactoryValidation(t *testing.T) {
+	rt := scriptRuntimeStub{exec: func(context.Context, string, string, *agent.ScriptEnv) (*agent.ScriptSignal, error) {
+		return nil, nil
+	}}
+	cases := []struct {
+		name     string
+		settings string
+	}{
+		{"missing type", `{"source": "s"}`},
+		{"missing source", `{"type": "x"}`},
+		{"unknown field", `{"type": "x", "source": "s", "bogus": 1}`},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := (graphresource.ScriptNodeTypeFactory{}).New(context.Background(), resource.Input{
+				Settings: []byte(tc.settings),
+				Deps:     map[string]any{"script_runtime": rt},
+			})
+			if err == nil || !errdefs.IsValidation(err) {
+				t.Fatalf("New = %v, want Validation", err)
+			}
+		})
+	}
+}

--- a/core/graph/resource/resource.go
+++ b/core/graph/resource/resource.go
@@ -9,6 +9,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"reflect"
+	"sort"
 	"strings"
 	"time"
 
@@ -34,6 +35,7 @@ const (
 	DepWorkspace     = "workspace"
 	DepSandbox       = "sandbox"
 	DepScriptRuntime = "script_runtime"
+	DepNodeType      = "node_type"
 
 	defaultScriptRuntimeName = "js"
 )
@@ -86,6 +88,7 @@ func (Factory) Spec() res.Spec {
 			{Name: DepWorkspace, Type: "workspace.Workspace"},
 			{Name: DepSandbox, Type: "sandbox.Runner"},
 			{Name: DepScriptRuntime, Type: "agent.ScriptRuntime"},
+			{Name: DepNodeType, Type: "graph.NodeTypeRegistrar", Many: true},
 		},
 	}
 }
@@ -103,11 +106,15 @@ func (Factory) New(ctx context.Context, in res.Input) (any, error) {
 	if err != nil {
 		return nil, errdefs.Validationf("graph engine: settings.graph: %v", err)
 	}
-	definition, err := loadDefinition(ctx, in, src)
+	deps, err := decodeDependencies(in.Deps)
 	if err != nil {
 		return nil, err
 	}
-	deps, err := decodeDependencies(in.Deps)
+	customs, err := collectNodeTypes(in)
+	if err != nil {
+		return nil, err
+	}
+	definition, err := loadDefinition(ctx, in, src, mergeFileRefFields(customs))
 	if err != nil {
 		return nil, err
 	}
@@ -164,6 +171,11 @@ func (Factory) New(ctx context.Context, in res.Input) (any, error) {
 	if err := scriptnode.Register(registry, scriptDeps); err != nil {
 		return nil, err
 	}
+	for _, custom := range customs {
+		if err := custom.registrar.Register(registry); err != nil {
+			return nil, err
+		}
+	}
 
 	options, err := settings.Build.options()
 	if err != nil {
@@ -174,10 +186,18 @@ func (Factory) New(ctx context.Context, in res.Input) (any, error) {
 
 // Register adds the graph engine factory to r.
 func Register(r *res.Registry) error {
-	return r.Register(Factory{})
+	if err := r.Register(Factory{}); err != nil {
+		return err
+	}
+	return r.Register(ScriptNodeTypeFactory{})
 }
 
-func loadDefinition(ctx context.Context, in res.Input, src res.Source) (*coregraph.GraphDefinition, error) {
+func loadDefinition(
+	ctx context.Context,
+	in res.Input,
+	src res.Source,
+	customFileFields map[string][]string,
+) (*coregraph.GraphDefinition, error) {
 	data, err := resolveSource(ctx, in, src)
 	if err != nil {
 		return nil, err
@@ -186,7 +206,7 @@ func loadDefinition(ctx context.Context, in res.Input, src res.Source) (*coregra
 	if err != nil {
 		return nil, errdefs.Validationf("graph engine: decode definition: %v", err)
 	}
-	if err := materializeConfigFileRefs(ctx, in, &definition); err != nil {
+	if err := materializeConfigFileRefs(ctx, in, &definition, customFileFields); err != nil {
 		return nil, err
 	}
 	return &definition, nil
@@ -220,20 +240,32 @@ func configFileFields(nodeType string) []string {
 	}
 }
 
-func materializeConfigFileRefs(ctx context.Context, in res.Input, definition *coregraph.GraphDefinition) error {
+func materializeConfigFileRefs(
+	ctx context.Context,
+	in res.Input,
+	definition *coregraph.GraphDefinition,
+	customFileFields map[string][]string,
+) error {
 	for index := range definition.Nodes {
 		node := &definition.Nodes[index]
 		if len(node.Config) == 0 {
 			continue
 		}
-		var fields map[string]json.RawMessage
-		if err := json.Unmarshal(node.Config, &fields); err != nil {
+		var configFields map[string]json.RawMessage
+		if err := json.Unmarshal(node.Config, &configFields); err != nil {
 			return errdefs.Validationf(
 				"graph engine: node %q config: %v", node.ID, err)
 		}
 		changed := false
-		for _, field := range configFileFields(node.Type) {
-			raw, ok := fields[field]
+		refFields := configFileFields(node.Type)
+		refFields = append(refFields, customFileFields[node.Type]...)
+		seen := make(map[string]bool, len(refFields))
+		for _, field := range refFields {
+			if seen[field] {
+				continue
+			}
+			seen[field] = true
+			raw, ok := configFields[field]
 			if !ok || len(raw) == 0 || raw[0] != '{' {
 				continue
 			}
@@ -255,11 +287,11 @@ func materializeConfigFileRefs(ctx context.Context, in res.Input, definition *co
 				return errdefs.Internalf(
 					"graph engine: node %q config.%s: %v", node.ID, field, err)
 			}
-			fields[field] = content
+			configFields[field] = content
 			changed = true
 		}
 		if changed {
-			merged, err := json.Marshal(fields)
+			merged, err := json.Marshal(configFields)
 			if err != nil {
 				return errdefs.Internalf(
 					"graph engine: node %q config: %v", node.ID, err)
@@ -286,6 +318,11 @@ func decodeDependencies(raw map[string]any) (dependencies, error) {
 		DepWorkspace: true, DepSandbox: true, DepScriptRuntime: true,
 	}
 	for name := range raw {
+		if name == DepNodeType || strings.HasPrefix(name, DepNodeType+".") {
+			// Custom node types ride the Many dep; the engine factory
+			// collects them separately in collectNodeTypes.
+			continue
+		}
 		if !known[name] {
 			return out, errdefs.Validationf("graph engine: unknown dep %q", name)
 		}
@@ -310,6 +347,86 @@ func decodeDependencies(raw map[string]any) (dependencies, error) {
 		return out, err
 	}
 	return out, nil
+}
+
+type customNodeType struct {
+	registrar coregraph.NodeTypeRegistrar
+	value     any
+}
+
+// collectNodeTypes validates the engine's Many "node_type" deps and
+// returns them in deterministic (sorted key) order. It rejects plain
+// and typed-nil registrars, and reports a node type resource that is
+// mounted under more than one dep key.
+func collectNodeTypes(in res.Input) ([]customNodeType, error) {
+	keys := make([]string, 0, len(in.Deps))
+	for key := range in.Deps {
+		if key == DepNodeType || strings.HasPrefix(key, DepNodeType+".") {
+			keys = append(keys, key)
+		}
+	}
+	sort.Strings(keys)
+
+	out := make([]customNodeType, 0, len(keys))
+	mounted := make(map[string]string) // registrar identity -> first dep key
+	for _, key := range keys {
+		value := in.Deps[key]
+		if value == nil {
+			return nil, errdefs.Validationf("graph engine: dep %q is nil", key)
+		}
+		registrar, ok := value.(coregraph.NodeTypeRegistrar)
+		if !ok {
+			return nil, errdefs.Validationf(
+				"graph engine: dep %q is %T, want graph.NodeTypeRegistrar", key, value)
+		}
+		if isNilValue(registrar) {
+			return nil, errdefs.Validationf("graph engine: dep %q is a typed nil", key)
+		}
+		if identity, has := registrarIdentity(value); has {
+			if first, dup := mounted[identity]; dup {
+				return nil, errdefs.Conflictf(
+					"graph engine: node type resource mounted twice (%s and %s)",
+					first, key)
+			}
+			mounted[identity] = key
+		}
+		out = append(out, customNodeType{registrar: registrar, value: value})
+	}
+	return out, nil
+}
+
+// registrarIdentity returns a stable identity for pointer-backed
+// registrar values, used to detect the same node type resource being
+// mounted under multiple dep keys. Non-pointer values (structs) have
+// no identity and fall back to duplicate-type-name detection at
+// registration time.
+func registrarIdentity(value any) (string, bool) {
+	rv := reflect.ValueOf(value)
+	switch rv.Kind() {
+	case reflect.Chan, reflect.Func, reflect.Map,
+		reflect.Pointer, reflect.Slice, reflect.UnsafePointer:
+		return fmt.Sprintf("%s:%d", rv.Type(), rv.Pointer()), true
+	default:
+		return "", false
+	}
+}
+
+// mergeFileRefFields collects, per custom node type name, the config
+// fields that may carry structured source references. Built-in types
+// are covered by configFileFields; custom registrars opt in via
+// [coregraph.ConfigFileRefFields].
+func mergeFileRefFields(customs []customNodeType) map[string][]string {
+	merged := make(map[string][]string)
+	for _, custom := range customs {
+		fields, ok := custom.value.(coregraph.ConfigFileRefFields)
+		if !ok {
+			continue
+		}
+		for typeName, names := range fields.FileRefFields() {
+			merged[typeName] = append(merged[typeName], names...)
+		}
+	}
+	return merged
 }
 
 func optionalDep[T any](raw map[string]any, name string) (T, error) {

--- a/core/graph/resource/resource_test.go
+++ b/core/graph/resource/resource_test.go
@@ -29,8 +29,8 @@ func TestRegister(t *testing.T) {
 	if spec.Kind != "agent.Engine" || spec.Impl != "graph" {
 		t.Fatalf("spec = %+v", spec)
 	}
-	if len(spec.Deps) != 6 {
-		t.Fatalf("deps = %+v, want 6", spec.Deps)
+	if len(spec.Deps) != 7 {
+		t.Fatalf("deps = %+v, want 7", spec.Deps)
 	}
 }
 

--- a/docs/guides/graph.md
+++ b/docs/guides/graph.md
@@ -190,6 +190,85 @@ depends on the engine's deps:
 | `shell`     | `sandbox` dep                           | sandboxed command execution          |
 | `runtime`   | always                                  | nested sub-script execution          |
 
+### Custom node types (`graph.NodeType`)
+
+Beyond the three built-ins, node types are deployment resources. A resource of
+kind `graph.NodeType` produces a value implementing
+`graph.NodeTypeRegistrar`; the graph engine factory registers every `node_type`
+dependency into the engine's registry before `Build`, so the graph definition
+can reference the type by name.
+
+Because a custom node type is a resource, it participates in the normal
+resource DAG: it can declare its own deps (script runtime, tools, workspace,
+...), is built exactly once, and can be shared by several agents. The engine
+accepts the deps under the `node_type` name or `node_type.<suffix>` keys (the
+`Many` dep form, like `tool.*` sources).
+
+#### Script-backed impl (`graph.NodeType/script`)
+
+The built-in script impl defines the node behaviour as an embedded script that
+runs on the bound `agent.ScriptRuntime` with exactly the same bridges as the
+built-in `script` node. The node's config in the graph definition is the
+script's `config` global (board references still resolve first), and the
+script writes/reads the board like any script node.
+
+| Settings field | Meaning                                                                       |
+| -------------- | ----------------------------------------------------------------------------- |
+| `type`         | the node type name graphs reference (must not collide with built-ins or other mounted types) |
+| `source`       | handler source: inline string or `{file: ...}` / `{embed: ...}` (required)    |
+| `desc`         | optional human-readable type description                                      |
+| `reads` / `writes` | static I/O roles (`kind: var|messages`, `name` or `config_key`, `required`); enforced at Build and invocation |
+
+Deps of `graph.NodeType/script`: `script_runtime` (required), plus optional
+`tools`, `inference`, `router`, `workspace`, `sandbox` enabling the same
+globals the built-in script node unlocks (`tools`, `inference`, `fs`, `shell`).
+
+```yaml
+resources:
+  greet:
+    kind: graph.NodeType
+    impl: script
+    deps:
+      script_runtime: js
+    settings:
+      type: greet
+      source: board.setVar("greeting", "hi " + config.name)
+      writes:
+        - kind: var
+          name: greeting
+          required: true
+
+agent:
+  asst:
+    engine:
+      kind: agent.Engine
+      impl: graph
+      deps:
+        node_type.greet: greet
+```
+
+The graph can then use the type like any other:
+
+```json
+{
+  "name": "greeter",
+  "entry": "hello",
+  "nodes": [
+    {
+      "id": "hello",
+      "type": "greet",
+      "config": { "name": "${board.user}" }
+    }
+  ],
+  "edges": []
+}
+```
+
+Go-backed custom node types follow the same contract: a host or plugin
+registers a `graph.NodeType` resource factory whose value implements
+`graph.NodeTypeRegistrar` (typically by calling `graph.RegisterType` with a
+closure capturing the resource's deps). The engine wires them identically.
+
 ### `board`
 
 Direct read/write of the engine board.


### PR DESCRIPTION
## Summary

Custom graph node types can now be authored as deployment resources and mounted into the graph engine, so they participate in the resource DAG (own deps, shared across agents, built once) instead of requiring host code to hand-wire registries.

- **`graph.NodeType` resource kind** with a script impl: `type`/`source` (inline or `{file:...}`/`{embed:...}`)/`reads`/`writes` settings; each node runs the source on the bound `agent.ScriptRuntime` with the full script bridge surface via the newly shared `scriptnode.RunScript`.
- **Engine mounting**: `agent.Engine/graph` accepts an optional Many `node_type` dep (`node_type` or `node_type.<suffix>` keys), validates each dep, and registers the types before `Build`.
- **Host/plugin Go nodes**: new `graph.NodeTypeRegistrar` contract; optional `graph.ConfigFileRefFields` lets a registrar declare config fields that carry source references, materialized by the engine factory before Build.
- **Hardening**: typed-nil registrars are rejected; mounting the same node type resource under two dep keys reports a Conflict naming both keys; `Role` gained JSON tags so `reads`/`writes` are declarative.
- Docs added to `docs/guides/graph.md`.

## Usage

```yaml
resources:
  greet:
    kind: graph.NodeType
    impl: script
    deps: { script_runtime: js }
    settings:
      type: greet
      source: board.setVar("greeting", "hi " + config.name)
      writes: [{ kind: var, name: greeting, required: true }]

agent:
  asst:
    engine:
      kind: agent.Engine
      impl: graph
      deps:
        node_type.greet: greet
```

```yaml
# graph.yaml
nodes:
- id: hello
  type: greet
  config: { name: "${board.user}" }
```

## Changeset

`.release/core-v0.1.19.json` (patch): `make release-check` confirms `core 0.1.18 -> 0.1.19`.

## Verification

- `make ci` — green (vet + tests across all modules)
- `make lint` — golangci-lint, 0 issues
- `make release-check` — green; plan `core: 0.1.18 -> 0.1.19 (patch), tag core/v0.1.19`
- `git diff --check` — clean

Unrelated: the runtime test timing investigation surfaced a separate latent defect (silent 5s/turn drain wait for engines that don't publish run-end) — tracked in #372, not part of this PR.