### PR TITLE
fix(core): skip session drain wait without sinks and surface missing run-end

### DIFF
--- a/core/runtime/attach_test.go
+++ b/core/runtime/attach_test.go
@@ -51,7 +51,7 @@ func TestRuntimeAttachDeliversPromptLifecycle(t *testing.T) {
 	})
 	reg := resource.NewRegistry()
 	reg.MustRegister(event.NewFactory())
-	reg.MustRegister(attachEngineFactory{engine: engine})
+	reg.MustRegister(attachEngineFactory{engine: withRunEnd(engine)})
 
 	doc := parseRuntimeDoc(t, `version: v1
 resources:
@@ -154,14 +154,14 @@ func TestRuntimeAttachFailsAfterClose(t *testing.T) {
 
 	reg := resource.NewRegistry()
 	reg.MustRegister(event.NewFactory())
-	reg.MustRegister(attachEngineFactory{engine: agent.EngineFunc(func(
+	reg.MustRegister(attachEngineFactory{engine: withRunEnd(agent.EngineFunc(func(
 		_ context.Context,
 		_ agent.Run,
 		_ agent.Host,
 		board *agent.Board,
 	) (*agent.Board, error) {
 		return board, nil
-	})})
+	}))})
 
 	doc := parseRuntimeDoc(t, `version: v1
 resources:

--- a/core/runtime/builder_test.go
+++ b/core/runtime/builder_test.go
@@ -220,7 +220,7 @@ func TestBuildRejectsInvalidCheckpointStore(t *testing.T) {
 
 func TestBuildWiresCheckpointStoreResource(t *testing.T) {
 	store := &recordingCheckpointStore{}
-	engine := agent.EngineFunc(func(
+	engine := withRunEnd(agent.EngineFunc(func(
 		ctx context.Context,
 		run agent.Run,
 		host agent.Host,
@@ -234,7 +234,7 @@ func TestBuildWiresCheckpointStoreResource(t *testing.T) {
 			return board, err
 		}
 		return board, nil
-	})
+	}))
 	reg := newBaseRegistry(t, event.NewMemoryBus(), store, engine)
 	app, err := NewBuilder(reg).Build(context.Background(), baseRuntimeDoc(t))
 	if err != nil {
@@ -255,7 +255,7 @@ func TestBuildWiresCheckpointStoreResource(t *testing.T) {
 }
 
 func TestWithHostFactoryWrapsBaseHostAndReportsUsage(t *testing.T) {
-	engine := agent.EngineFunc(func(
+	engine := withRunEnd(agent.EngineFunc(func(
 		ctx context.Context,
 		_ agent.Run,
 		host agent.Host,
@@ -269,7 +269,7 @@ func TestWithHostFactoryWrapsBaseHostAndReportsUsage(t *testing.T) {
 			return board, err
 		}
 		return board, nil
-	})
+	}))
 	reg := newBaseRegistry(t, event.NewMemoryBus(), &recordingCheckpointStore{}, engine)
 	builder := NewBuilder(reg)
 
@@ -400,7 +400,7 @@ func (s *fakeDelegationService) Get(context.Context, string) (delegation.Respons
 func TestBuildWrapsDelegationServiceWhenRequested(t *testing.T) {
 	service := &fakeDelegationService{id: "local"}
 	var got delegation.Service
-	engine := agent.EngineFunc(func(
+	engine := withRunEnd(agent.EngineFunc(func(
 		_ context.Context,
 		_ agent.Run,
 		host agent.Host,
@@ -412,7 +412,7 @@ func TestBuildWrapsDelegationServiceWhenRequested(t *testing.T) {
 		}
 		got = svc
 		return board, nil
-	})
+	}))
 	reg := newBaseRegistry(t, event.NewMemoryBus(), &recordingCheckpointStore{}, engine)
 	reg.MustRegister(testResourceFactory{
 		spec:  resource.Spec{Kind: delegation.ServiceKind, Impl: "local"},
@@ -448,7 +448,7 @@ func TestBuildWrapsDelegationServiceWhenRequested(t *testing.T) {
 
 func TestBuildWithoutResultHostFactoryLeavesHostUnexposed(t *testing.T) {
 	service := &fakeDelegationService{id: "local"}
-	engine := agent.EngineFunc(func(
+	engine := withRunEnd(agent.EngineFunc(func(
 		_ context.Context,
 		_ agent.Run,
 		host agent.Host,
@@ -458,7 +458,7 @@ func TestBuildWithoutResultHostFactoryLeavesHostUnexposed(t *testing.T) {
 			return board, errors.New("delegation service unexpectedly exposed on host")
 		}
 		return board, nil
-	})
+	}))
 	reg := newBaseRegistry(t, event.NewMemoryBus(), &recordingCheckpointStore{}, engine)
 	reg.MustRegister(testResourceFactory{
 		spec:  resource.Spec{Kind: delegation.ServiceKind, Impl: "local"},

--- a/core/runtime/dynamic_test.go
+++ b/core/runtime/dynamic_test.go
@@ -50,7 +50,7 @@ runtime:
 
 func catalogEngine(t *testing.T, got chan<- []string) agent.Engine {
 	t.Helper()
-	return agent.EngineFunc(func(
+	return withRunEnd(agent.EngineFunc(func(
 		ctx context.Context,
 		_ agent.Run,
 		_ agent.Host,
@@ -67,7 +67,7 @@ func catalogEngine(t *testing.T, got chan<- []string) agent.Engine {
 		}
 		got <- names
 		return board, nil
-	})
+	}))
 }
 
 func TestBuild_DynamicCatalogMapsToolsPerAgent(t *testing.T) {

--- a/core/runtime/helpers_test.go
+++ b/core/runtime/helpers_test.go
@@ -24,15 +24,36 @@ const (
 	testStoreImpl  = "test"
 )
 
+// withRunEnd wraps an engine so it publishes the engine contract's
+// required run-end event after Execute returns. Stub engines built
+// from agent.EngineFunc never publish it themselves, and without the
+// event the session's stream coordinator waits out its full drain
+// budget on every turn.
+func withRunEnd(engine agent.Engine) agent.Engine {
+	return agent.EngineFunc(func(ctx context.Context, run agent.Run, host agent.Host, board *agent.Board) (*agent.Board, error) {
+		board, err := engine.Execute(ctx, run, host, board)
+		publishCtx := context.WithoutCancel(ctx)
+		envelope, envelopeErr := event.NewEnvelope(publishCtx, agent.SubjectRunEnd(run.RunID), nil)
+		if envelopeErr == nil {
+			envelope.SetRunID(run.RunID)
+			envelopeErr = host.Publish(publishCtx, envelope)
+		}
+		if err != nil {
+			return board, err
+		}
+		return board, envelopeErr
+	})
+}
+
 func noopEngine() agent.Engine {
-	return agent.EngineFunc(func(
+	return withRunEnd(agent.EngineFunc(func(
 		_ context.Context,
 		_ agent.Run,
 		_ agent.Host,
 		board *agent.Board,
 	) (*agent.Board, error) {
 		return board, nil
-	})
+	}))
 }
 
 type testEngineFactory struct {

--- a/core/runtime/session/coordinator.go
+++ b/core/runtime/session/coordinator.go
@@ -223,6 +223,13 @@ type logicalRunEndPayload struct {
 // finalize emits the one externally visible logical run end. It is
 // idempotent because finish and shutdown paths may converge.
 func (c *streamCoordinator) finalize(ctx context.Context, result *agent.Result, runErr error) error {
+	// With no raw or confirmed sinks there is nothing to drain and no
+	// consumer for the logical run end, so the attempt wait is pure
+	// overhead: an engine that never publishes run-end would otherwise
+	// stall the turn by the full drain budget with no observable effect.
+	if len(c.raw) == 0 && len(c.confirmed) == 0 {
+		return nil
+	}
 	expectedAttempts := 1
 	if result != nil && result.Attempts > 0 {
 		expectedAttempts = result.Attempts

--- a/core/runtime/session/coordinator_test.go
+++ b/core/runtime/session/coordinator_test.go
@@ -402,9 +402,24 @@ func TestTurnWithoutAuthorityDoesNotRetainConfirmedTokens(t *testing.T) {
 	}
 }
 
-func TestStreamCoordinatorFinalizeTimesOutWithoutAttemptBoundary(t *testing.T) {
+func TestStreamCoordinatorFinalizeWithoutSinksDoesNotWait(t *testing.T) {
 	turn := newTurn(nil, "run-missing-attempt-end", context.Background())
 	coordinator := newStreamCoordinator(turn, nil, nil, 8, 1024)
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Millisecond)
+	defer cancel()
+	err := coordinator.finalize(ctx, &agent.Result{
+		Status:   agent.StatusCompleted,
+		Attempts: 1,
+	}, nil)
+	if err != nil {
+		t.Fatalf("finalize with no sinks returned error = %v, want nil", err)
+	}
+}
+
+func TestStreamCoordinatorFinalizeTimesOutWithSinksWithoutAttemptBoundary(t *testing.T) {
+	turn := newTurn(nil, "run-missing-attempt-end", context.Background())
+	sink := &queuedSink{spec: SinkSpec{ID: "confirmed", QueueSize: 8}}
+	coordinator := newStreamCoordinator(turn, nil, []*queuedSink{sink}, 8, 1024)
 	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Millisecond)
 	defer cancel()
 	err := coordinator.finalize(ctx, &agent.Result{

--- a/core/runtime/session/lifecycle_test.go
+++ b/core/runtime/session/lifecycle_test.go
@@ -299,6 +299,72 @@ func TestTurnWaitDrainsSinkThroughRunEnd(t *testing.T) {
 	}
 }
 
+func TestTurnRecordsFinalizeTimeoutWhenEngineOmitsRunEnd(t *testing.T) {
+	engine := agent.EngineFunc(func(_ context.Context, _ agent.Run, _ agent.Host, board *agent.Board) (*agent.Board, error) {
+		return board, nil
+	})
+	bus := event.NewMemoryBus()
+	router := event.NewRouter(bus)
+	instance := &agent.Agent{ID: "agent-a", Engine: engine}
+	manager, err := NewManager(
+		&testResolver{instances: map[string]*agent.Agent{"agent-a": instance}},
+		turnHostFactory(bus),
+		router,
+		WithIdleTimeout(time.Minute),
+		WithSinkBufferSize(8),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	lease, err := manager.Open(context.Background(), Key{AgentID: "agent-a", ContextID: "ctx"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		_ = lease.Close()
+		_ = manager.Close()
+		_ = router.Close()
+		_ = bus.Close()
+	})
+
+	detached := make(chan error, 1)
+	turn, err := lease.Session().Start(
+		context.Background(),
+		agent.Request{Message: message.NewTextMessage(message.RoleUser, "hi")},
+		SinkSpec{
+			ID:        "drain",
+			QueueSize: 8,
+			Sink: agent.StreamSinkFunc(func(context.Context, event.Envelope, agent.StreamDeltaPayload) error {
+				return nil
+			}),
+			OnDetach: func(err error) { detached <- err },
+		},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), defaultAttemptDrainTimeout+2*time.Second)
+	defer cancel()
+	result, err := turn.Wait(ctx)
+	if err != nil {
+		t.Fatalf("Wait: %v", err)
+	}
+	if result.Status != agent.StatusCompleted {
+		t.Fatalf("status = %q, want completed", result.Status)
+	}
+	if result.State == nil || result.State[finalizeErrorStateKey] == nil {
+		t.Fatalf("result state missing %q: %#v", finalizeErrorStateKey, result.State)
+	}
+	select {
+	case detachErr := <-detached:
+		if !errdefs.IsTimeout(detachErr) {
+			t.Fatalf("sink detach error = %v, want timeout", detachErr)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("sink was not detached after missing run-end")
+	}
+}
+
 func TestTurnWaitDoesNotBlockForeverOnStuckSink(t *testing.T) {
 	engine := agent.EngineFunc(func(_ context.Context, _ agent.Run, _ agent.Host, board *agent.Board) (*agent.Board, error) {
 		return board, nil

--- a/core/runtime/session/turn.go
+++ b/core/runtime/session/turn.go
@@ -7,10 +7,20 @@ import (
 	"sync"
 	"unicode/utf8"
 
+	otellog "go.opentelemetry.io/otel/log"
+
 	"github.com/GizClaw/flowcraft/core/agent"
 	"github.com/GizClaw/flowcraft/core/errdefs"
 	"github.com/GizClaw/flowcraft/core/message"
+	"github.com/GizClaw/flowcraft/core/telemetry"
 )
+
+// finalizeErrorStateKey is recorded on the turn result state when the
+// engine never published its required run-end event, so the stream
+// drain budget was consumed and the turn's sinks were detached without
+// seeing the logical run end. Callers can distinguish this contract
+// violation from a healthy turn by checking the key.
+const finalizeErrorStateKey = "session.finalize_error"
 
 // Turn is one asynchronous execution owned by a Session.
 type Turn struct {
@@ -299,6 +309,9 @@ func (t *Turn) finish(result *agent.Result, err error) {
 		)
 		finalizeErr = coordinator.finalize(finalizeCtx, result, err)
 		cancel()
+		if finalizeErr != nil {
+			t.recordFinalizeTimeout(result, finalizeErr)
+		}
 	}
 	for _, attachment := range attachments {
 		if result == nil || runEndFailed || finalizeErr != nil {
@@ -326,6 +339,24 @@ func (t *Turn) finish(result *agent.Result, err error) {
 		t.release()
 	}
 	close(t.done)
+}
+
+// recordFinalizeTimeout makes a missing run-end diagnosable: the engine
+// did not publish its required terminal event within the drain budget,
+// so the turn result carries the reason and telemetry emits a warning.
+// The drain timeout itself is not returned from Wait because the turn
+// outcome (result/status) already settled; it is recorded instead.
+func (t *Turn) recordFinalizeTimeout(result *agent.Result, finalizeErr error) {
+	if result.State == nil {
+		result.State = make(map[string]any)
+	}
+	result.State[finalizeErrorStateKey] = finalizeErr.Error()
+	telemetry.WarnErr(
+		context.WithoutCancel(t.runCtx),
+		"runtime session: engine did not publish run-end; turn stream drain timed out",
+		finalizeErr,
+		otellog.String(telemetry.AttrRunID, t.runID),
+	)
 }
 
 func (t *Turn) configureAuthority(spec SinkSpec, queueSize int, sink *queuedSink) {


### PR DESCRIPTION
## Summary

Fixes #372. Every session turn waited the full `defaultAttemptDrainTimeout` (5s) in `streamCoordinator.finalize` when the engine never published `agent.SubjectRunEnd` — the wait was silent, and it happened even when the turn had zero stream sinks. This made non-conforming engines (e.g. plain `agent.EngineFunc`) pay a hidden 5s per turn.

## Changes

1. **No sinks ⇒ no drain wait** — `finalize` returns immediately when there are no raw/confirmed sinks. With zero sinks there is nothing to drain and no consumer for the logical run-end, so the attempt wait is pure overhead. Ordering between the engine's raw run-end and the coordinator's logical run-end is preserved whenever any sink exists.
2. **Missing run-end is now observable** — when sinks exist and the drain times out, the turn result records `result.State["session.finalize_error"]` and telemetry emits a warning (with run id). The turn still completes normally; the contract violation is just no longer swallowed.
3. **Conforming test engines** — added a `withRunEnd` helper in the runtime package and wrapped the stub engines (`noopEngine`, attach/builder/dynamic test engines), so runtime tests no longer stall on the drain budget.

## Verification

- `core/runtime`: 66.9s → **1.1s**
- `core/runtime/session`: 41.6s → **6.8s** (includes one new intentional 5s observability test)
- New tests: `TestStreamCoordinatorFinalizeWithoutSinksDoesNotWait`, `TestStreamCoordinatorFinalizeTimesOutWithSinksWithoutAttemptBoundary`, `TestTurnRecordsFinalizeTimeoutWhenEngineOmitsRunEnd`
- `make ci`, `make lint`, `make release-check`, `git diff --check` all pass

No `.release/` changeset added (no module release in this PR).