### PR TITLE
feat(core): record inference request ids and token usage in OTel telemetry

### DIFF
--- a/core/graph/nodes/inference.go
+++ b/core/graph/nodes/inference.go
@@ -143,6 +143,12 @@ func runInference(ec graph.ExecutionContext, board *agent.Board, cfg InferenceCo
 	if err != nil {
 		return err
 	}
+	// Mirror the provider request / response identifiers and token
+	// usage onto the node span after a successful call so
+	// llm.request.id / llm.response.id / llm.tokens.* are visible in
+	// otel even when the call did not go through a router (failure ids
+	// already ride the error chain via execute.go).
+	inference.RecordLLMTelemetry(ec.Context, resp.Metadata, resp.Usage, nil)
 	if len(cfg.Tools) > 0 || cfg.AllTools {
 		if catalog := roundCatalog(ec.Context, cfg, deps); catalog != nil {
 			if advancer, ok := catalog.(roundAdvancer); ok {

--- a/core/graph/nodes/inference_test.go
+++ b/core/graph/nodes/inference_test.go
@@ -18,7 +18,12 @@ import (
 	"github.com/GizClaw/flowcraft/core/inference/inferencetest"
 	"github.com/GizClaw/flowcraft/core/inference/route"
 	"github.com/GizClaw/flowcraft/core/message"
+	"github.com/GizClaw/flowcraft/core/telemetry"
 	"github.com/GizClaw/flowcraft/core/tool"
+
+	"go.opentelemetry.io/otel"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
 )
 
 // The node tests run full Build→Execute cycles over the canned
@@ -922,5 +927,95 @@ func TestInferenceNode_StreamResultFailureCommitsPartialExactlyOnce(t *testing.T
 	}
 	if msgs[1].Role != message.RoleAssistant || msgs[1].Content.Text() != "partial" {
 		t.Fatalf("partial message = %+v", msgs[1])
+	}
+}
+
+func TestInferenceNode_SuccessRecordsRequestIDOnNodeSpan(t *testing.T) {
+	prev := otel.GetTracerProvider()
+	rec := tracetest.NewSpanRecorder()
+	tp := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(rec))
+	otel.SetTracerProvider(tp)
+	t.Cleanup(func() {
+		_ = tp.Shutdown(context.Background())
+		otel.SetTracerProvider(prev)
+	})
+
+	fake := &inferencetest.GenerateFake{
+		Respond: func(inference.GenerateRequest) inference.GenerateResponse {
+			return inference.GenerateResponse{
+				Message: message.Message{
+					Role:    message.RoleAssistant,
+					Content: message.Content{Parts: []message.Part{message.TextPart{Text: "ok"}}},
+				},
+				FinishReason: inference.FinishCompleted,
+				Metadata: inference.Metadata{
+					RequestID:  "req-node-ok",
+					ResponseID: "resp-node-ok",
+				},
+				Usage: inference.Usage{
+					InputTokens:  10,
+					OutputTokens: 3,
+					TotalTokens:  13,
+					Model:        inferencetest.DefaultFakeModel,
+				},
+			}
+		},
+	}
+	// Routed path: the assembly-level telemetry records onto the route
+	// span, so request/response ids reaching the node span must come
+	// from the node's own RecordLLMIDs call.
+	runtime := fake.Assembly(t)
+	reg := inferenceRegistry(t, InferenceNodeDeps{Router: fakeRouter(t, runtime)})
+	g := singleNodeGraph(t, reg, "inference", InferenceConfig{})
+	if err := executeGraph(t, g, agent.NoopHost{}, userBoard()); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+
+	var nodeSpan sdktrace.ReadOnlySpan
+	for _, span := range rec.Ended() {
+		if span.Name() == "node.inference.execute" {
+			nodeSpan = span
+			break
+		}
+	}
+	if nodeSpan == nil {
+		t.Fatal("node span not found")
+	}
+	var requestID, responseID string
+	var haveRequest, haveResponse bool
+	for _, kv := range nodeSpan.Attributes() {
+		switch kv.Key {
+		case telemetry.AttrLLMRequestID:
+			requestID, haveRequest = kv.Value.AsString(), true
+		case telemetry.AttrLLMResponseID:
+			responseID, haveResponse = kv.Value.AsString(), true
+		}
+	}
+	if !haveRequest || requestID != "req-node-ok" {
+		t.Fatalf("node span llm.request.id = %q/%v, want req-node-ok", requestID, haveRequest)
+	}
+	if !haveResponse || responseID != "resp-node-ok" {
+		t.Fatalf("node span llm.response.id = %q/%v, want resp-node-ok", responseID, haveResponse)
+	}
+	var inputTokens, outputTokens, totalTokens int64
+	var haveInput, haveOutput, haveTotal bool
+	for _, kv := range nodeSpan.Attributes() {
+		switch kv.Key {
+		case telemetry.AttrLLMInputTokens:
+			inputTokens, haveInput = kv.Value.AsInt64(), true
+		case telemetry.AttrLLMOutputTokens:
+			outputTokens, haveOutput = kv.Value.AsInt64(), true
+		case telemetry.AttrLLMTotalTokens:
+			totalTokens, haveTotal = kv.Value.AsInt64(), true
+		}
+	}
+	if !haveInput || inputTokens != 10 {
+		t.Fatalf("node span llm.tokens.input = %d/%v, want 10", inputTokens, haveInput)
+	}
+	if !haveOutput || outputTokens != 3 {
+		t.Fatalf("node span llm.tokens.output = %d/%v, want 3", outputTokens, haveOutput)
+	}
+	if !haveTotal || totalTokens != 13 {
+		t.Fatalf("node span llm.tokens.total = %d/%v, want 13", totalTokens, haveTotal)
 	}
 }

--- a/core/inference/assembly.go
+++ b/core/inference/assembly.go
@@ -120,7 +120,11 @@ func (a *Assembly) Generate(
 			UnsupportedOperation, OperationGenerate, "",
 			fmt.Errorf("model %q has no unary generate driver", ref.ID.Name))
 	}
-	return operations.Unary.Execute(ctx, ref, req)
+	ctx, call := startInferenceCall(ctx, OperationGenerate, ref)
+	response, err := operations.Unary.Execute(ctx, ref, req)
+	call.stampUsage(&response.Usage)
+	call.finish(response.Metadata, response.Usage, err)
+	return response, err
 }
 
 // ExplainGenerate runs the compiler for a unary generate request
@@ -158,7 +162,16 @@ func (a *Assembly) GenerateStream(
 			UnsupportedOperation, OperationGenerate, "",
 			fmt.Errorf("model %q has no streaming generate driver", ref.ID.Name))
 	}
-	return operations.Stream.Stream(ctx, ref, req)
+	ctx, call := startInferenceCall(ctx, OperationGenerate, ref)
+	stream, err := operations.Stream.Stream(ctx, ref, req)
+	if err != nil {
+		call.finish(Metadata{}, Usage{}, err)
+		return nil, err
+	}
+	return &telemetryGenerateStream{
+		inner: stream,
+		tel:   call,
+	}, nil
 }
 
 // ExplainGenerateStream runs the compiler for a generate stream
@@ -191,7 +204,11 @@ func (a *Assembly) Embed(
 	if err != nil {
 		return EmbedResponse{}, err
 	}
-	return driver.Execute(ctx, ref, req)
+	ctx, call := startInferenceCall(ctx, OperationEmbed, ref)
+	response, err := driver.Execute(ctx, ref, req)
+	call.recordEmbedUsage(ctx, response.Usage)
+	call.finish(response.Metadata, Usage{}, err)
+	return response, err
 }
 
 // ExplainEmbed runs the compiler for an embedding request without
@@ -225,7 +242,11 @@ func (a *Assembly) Transcribe(
 			fmt.Errorf("model %q has no unary transcription driver", ref.ID.Name),
 		)
 	}
-	return operations.Unary.Execute(ctx, ref, req)
+	ctx, call := startInferenceCall(ctx, OperationTranscription, ref)
+	response, err := operations.Unary.Execute(ctx, ref, req)
+	call.stampUsage(&response.Usage)
+	call.finish(response.Metadata, response.Usage, err)
+	return response, err
 }
 
 // ExplainTranscribe runs the compiler for a unary transcription request
@@ -265,7 +286,16 @@ func (a *Assembly) TranscribeSession(
 			fmt.Errorf("model %q has no transcription session driver", ref.ID.Name),
 		)
 	}
-	return operations.Session.Open(ctx, ref, req)
+	ctx, call := startInferenceCall(ctx, OperationTranscription, ref)
+	session, err := operations.Session.Open(ctx, ref, req)
+	if err != nil {
+		call.finish(Metadata{}, Usage{}, err)
+		return nil, err
+	}
+	return &telemetryTranscriptionSession{
+		inner: session,
+		tel:   call,
+	}, nil
 }
 
 // ExplainTranscribeSession compiles a transcription session request without

--- a/core/inference/telemetry.go
+++ b/core/inference/telemetry.go
@@ -1,0 +1,389 @@
+package inference
+
+import (
+	"context"
+	"errors"
+	"io"
+	"math"
+	"sync"
+	"time"
+
+	"github.com/GizClaw/flowcraft/core/errdefs"
+	"github.com/GizClaw/flowcraft/core/message/media"
+	"github.com/GizClaw/flowcraft/core/telemetry"
+
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/metric"
+	"go.opentelemetry.io/otel/trace"
+)
+
+// Assembly operations are instrumented at the funnel: every provider
+// round trip emits execution/duration/token metrics and mirrors the
+// provider request/response ids and token usage onto a span. When the
+// caller already runs inside a span (a graph node span, a route span,
+// a script node span) that span is reused so identifiers and usage
+// land on the caller's span without nesting a second inference span
+// per provider round trip; otherwise a dedicated
+// "inference.<operation>" span is created and the call owns ending it.
+// Explain* methods perform no provider I/O and stay silent.
+var (
+	inferenceMeter = telemetry.MeterWithSuffix("inference")
+
+	inferenceExecCount, _ = inferenceMeter.Int64Counter(
+		"executions.total",
+		metric.WithDescription("Total inference operation executions"))
+	inferenceDuration, _ = inferenceMeter.Float64Histogram(
+		"duration.seconds",
+		metric.WithDescription("Inference operation duration"))
+	inferenceErrorCount, _ = inferenceMeter.Int64Counter(
+		"errors.total",
+		metric.WithDescription("Total inference operation errors by kind"))
+	inferenceInputTokens, _ = inferenceMeter.Int64Counter(
+		"tokens.input",
+		metric.WithDescription("Input tokens consumed by generate operations"))
+	inferenceOutputTokens, _ = inferenceMeter.Int64Counter(
+		"tokens.output",
+		metric.WithDescription("Output tokens produced by generate operations"))
+	inferenceCachedTokens, _ = inferenceMeter.Int64Counter(
+		"tokens.input.cached",
+		metric.WithDescription("Input tokens served from provider prompt caches"))
+)
+
+// inferenceCall carries one instrumented operation call: its span,
+// start time, and the identity attributes shared by span and metrics.
+type inferenceCall struct {
+	ctx   context.Context
+	span  trace.Span
+	start time.Time
+	op    Operation
+	model ModelRef
+	reuse bool
+}
+
+// startInferenceCall opens the instrumentation for one operation call.
+// It reuses the caller's active span when present (see package doc);
+// otherwise it starts a dedicated inference.<operation> span. The call
+// owner closes the instrumentation via finish.
+func startInferenceCall(
+	ctx context.Context,
+	op Operation,
+	ref ModelRef,
+) (context.Context, inferenceCall) {
+	if trace.SpanContextFromContext(ctx).IsValid() {
+		return ctx, inferenceCall{
+			ctx:   ctx,
+			span:  trace.SpanFromContext(ctx),
+			start: time.Now(),
+			op:    op,
+			model: ref,
+			reuse: true,
+		}
+	}
+	ctx, span := telemetry.Tracer().Start(ctx, "inference."+string(op),
+		trace.WithAttributes(
+			attribute.String("inference.operation", string(op)),
+			attribute.String(telemetry.AttrLLMProvider, ref.ID.Provider),
+			attribute.String(telemetry.AttrLLMModel, ref.ID.Name),
+		))
+	return ctx, inferenceCall{
+		ctx:   ctx,
+		span:  span,
+		start: time.Now(),
+		op:    op,
+		model: ref,
+	}
+}
+
+func (c inferenceCall) metricAttrs(extra ...attribute.KeyValue) metric.MeasurementOption {
+	base := []attribute.KeyValue{
+		attribute.String("inference.operation", string(c.op)),
+		attribute.String(telemetry.AttrLLMProvider, c.model.ID.Provider),
+		attribute.String(telemetry.AttrLLMModel, c.model.ID.Name),
+	}
+	return metric.WithAttributes(append(base, extra...)...)
+}
+
+// stampUsage fills the call-context envelope on a usage value about to
+// cross the Assembly boundary. The envelope is runtime-owned by
+// contract, but stamping is fill-if-absent: a provider that explicitly
+// reports server-side latency or a more specific model identity knows
+// better than the wall clock.
+func (c inferenceCall) stampUsage(usage *Usage) {
+	if usage == nil {
+		return
+	}
+	if usage.Model == (ModelRef{}) {
+		usage.Model = c.model
+	}
+	if usage.LatencyMs == 0 {
+		usage.LatencyMs = time.Since(c.start).Milliseconds()
+	}
+}
+
+// finish closes out one operation call: duration and execution
+// metrics, token counters, span attributes, and (for self-created
+// spans) status and lifetime. err == nil records a success. Reused
+// spans only gain attributes; the owner controls status and lifetime.
+func (c inferenceCall) finish(metadata Metadata, usage Usage, err error) {
+	recordLLMAttrs(c.span, metadata, usage, err)
+	recordUsageMetrics(c.ctx, usage, c.metricAttrs())
+	inferenceDuration.Record(c.ctx, time.Since(c.start).Seconds(), c.metricAttrs())
+	if err == nil {
+		inferenceExecCount.Add(c.ctx, 1, c.metricAttrs(attribute.String("status", "success")))
+		if !c.reuse {
+			c.span.SetStatus(codes.Ok, "OK")
+			c.span.End()
+		}
+		return
+	}
+	kind := classifyInferenceError(err)
+	c.span.SetAttributes(attribute.String("inference.error_kind", kind))
+	inferenceExecCount.Add(c.ctx, 1, c.metricAttrs(attribute.String("status", "error")))
+	inferenceErrorCount.Add(c.ctx, 1, c.metricAttrs(attribute.String("error_kind", kind)))
+	if !c.reuse {
+		c.span.RecordError(err)
+		c.span.SetStatus(codes.Error, err.Error())
+		c.span.End()
+		return
+	}
+}
+
+// recordEmbedUsage mirrors embed usage onto the span and the input
+// token counter. Item counts stay span-only: they describe request
+// shape, not spend.
+func (c inferenceCall) recordEmbedUsage(ctx context.Context, usage EmbedUsage) {
+	if usage.InputTokens > 0 {
+		inferenceInputTokens.Add(ctx, usage.InputTokens, c.metricAttrs())
+	}
+	c.span.SetAttributes(
+		attribute.Int64(telemetry.AttrLLMInputTokens, usage.InputTokens),
+		attribute.Int("inference.embed.items", usage.ItemCount),
+	)
+}
+
+// recordLLMAttrs mirrors request/response ids and usage dimensions
+// onto span (attrs only; metrics are emitted by the call owner).
+func recordLLMAttrs(span trace.Span, metadata Metadata, usage Usage, err error) {
+	if span == nil {
+		return
+	}
+	if metadata.RequestID != "" {
+		span.SetAttributes(attribute.String(telemetry.AttrLLMRequestID, metadata.RequestID))
+	}
+	if metadata.ResponseID != "" {
+		span.SetAttributes(attribute.String(telemetry.AttrLLMResponseID, metadata.ResponseID))
+	}
+	recordInferenceUsage(span, usage)
+	if err != nil {
+		if requestID, ok := errdefs.RequestID(err); ok {
+			span.SetAttributes(attribute.String(telemetry.AttrLLMRequestID, requestID))
+		}
+	}
+}
+
+// RecordLLMTelemetry mirrors the provider request / response
+// identifiers and token usage of a completed inference call onto the
+// span active in ctx. It is a no-op when ctx carries no span or the
+// values are empty; err is consulted for a request id wrapped via
+// errdefs.WithRequestID when metadata carries none. Host code that
+// performs its own inference bookkeeping (e.g. the graph inference
+// node) uses it to surface ids and usage on its own span after a call.
+func RecordLLMTelemetry(ctx context.Context, metadata Metadata, usage Usage, err error) {
+	span := trace.SpanFromContext(ctx)
+	if span == nil || !span.SpanContext().IsValid() {
+		return
+	}
+	recordLLMAttrs(span, metadata, usage, err)
+}
+
+// recordInferenceUsage mirrors an inference.Usage envelope onto span as
+// llm.* attributes. Zero-valued optional dimensions are omitted, so
+// spans stay slim on the common path and dashboards can rely on
+// presence rather than zero-sentinel values.
+func recordInferenceUsage(span trace.Span, usage Usage) {
+	if span == nil {
+		return
+	}
+	if usage.Model.ID.Provider != "" {
+		span.SetAttributes(attribute.String(telemetry.AttrLLMProvider, usage.Model.ID.Provider))
+	}
+	if usage.Model.ID.Name != "" {
+		span.SetAttributes(attribute.String(telemetry.AttrLLMModel, usage.Model.ID.Name))
+	}
+	if usage.InputTokens > 0 {
+		span.SetAttributes(attribute.Int64(telemetry.AttrLLMInputTokens, usage.InputTokens))
+	}
+	if usage.OutputTokens > 0 {
+		span.SetAttributes(attribute.Int64(telemetry.AttrLLMOutputTokens, usage.OutputTokens))
+	}
+	if usage.TotalTokens > 0 {
+		span.SetAttributes(attribute.Int64(telemetry.AttrLLMTotalTokens, usage.TotalTokens))
+	}
+	if usage.Input.CacheReadTokens != nil && *usage.Input.CacheReadTokens > 0 {
+		span.SetAttributes(attribute.Int64(
+			telemetry.AttrLLMCachedInputTokens, *usage.Input.CacheReadTokens))
+	}
+	if usage.LatencyMs > 0 {
+		span.SetAttributes(attribute.Int64(telemetry.AttrLLMLatencyMs, usage.LatencyMs))
+	}
+	if usage.AudioDurationMillis != nil && *usage.AudioDurationMillis > 0 {
+		span.SetAttributes(attribute.Int64(
+			"inference.audio.duration_ms", *usage.AudioDurationMillis))
+	}
+	if usage.Billing != nil && usage.Billing.Cost != nil {
+		if micros, ok := costMicros(*usage.Billing.Cost); ok {
+			span.SetAttributes(attribute.Int64(telemetry.AttrLLMCostMicros, micros))
+		}
+	}
+}
+
+// recordUsageMetrics emits the token counters for a generate /
+// transcription usage envelope. Zero values stay out of counters (no
+// cache hit reported is not a hit-rate of zero); the cached counter
+// only moves when the provider reports cache reads.
+func recordUsageMetrics(
+	ctx context.Context,
+	usage Usage,
+	opts metric.MeasurementOption,
+) {
+	if usage.InputTokens > 0 {
+		inferenceInputTokens.Add(ctx, usage.InputTokens, opts)
+	}
+	if usage.OutputTokens > 0 {
+		inferenceOutputTokens.Add(ctx, usage.OutputTokens, opts)
+	}
+	if usage.Input.CacheReadTokens != nil && *usage.Input.CacheReadTokens > 0 {
+		inferenceCachedTokens.Add(ctx, *usage.Input.CacheReadTokens, opts)
+	}
+}
+
+// classifyInferenceError extracts the structured ErrorKind when the
+// failure carries one; anything else is an unclassified provider-side
+// or transport failure.
+func classifyInferenceError(err error) string {
+	var inferenceErr *Error
+	if errors.As(err, &inferenceErr) {
+		return string(inferenceErr.Kind)
+	}
+	return "unclassified"
+}
+
+// costMicros converts a Money (Units / 10^Scale) into the integer
+// micro-unit representation the AttrLLMCostMicros attribute uses. It
+// reports ok=false when converting would overflow or a sub-micro
+// remainder floors to zero.
+func costMicros(money Money) (int64, bool) {
+	if money.Scale > 18 {
+		return 0, false
+	}
+	if money.Scale > 6 {
+		micros := money.Units / pow10(money.Scale-6)
+		return micros, micros > 0
+	}
+	factor := pow10(6 - money.Scale)
+	if money.Units > math.MaxInt64/factor {
+		return 0, false
+	}
+	return money.Units * factor, true
+}
+
+// pow10 returns exactly 10^n for n in [0, 18], matching Money.Scale's
+// validated range.
+func pow10(n uint8) int64 {
+	var value int64 = 1
+	for i := uint8(0); i < n; i++ {
+		value *= 10
+	}
+	return value
+}
+
+// telemetryGenerateStream wraps a GenerateStream so the provider
+// request / response identifiers — only known once the stream reaches
+// its terminal result — and the final usage snapshot are recorded when
+// the call completes. finish runs once: the first terminal path
+// (Result, mid-stream error, or Close) owns the recorded outcome.
+type telemetryGenerateStream struct {
+	inner GenerateStream
+	tel   inferenceCall
+	once  sync.Once
+}
+
+func (s *telemetryGenerateStream) finish(metadata Metadata, usage Usage, err error) {
+	s.once.Do(func() {
+		s.tel.finish(metadata, usage, err)
+	})
+}
+
+func (s *telemetryGenerateStream) Next(ctx context.Context) (GenerateStreamEvent, error) {
+	event, err := s.inner.Next(ctx)
+	if err == nil && event.Usage != nil {
+		// Stamp before returning so the recorded snapshot and the
+		// caller-visible event carry the same envelope.
+		s.tel.stampUsage(event.Usage)
+	}
+	if err != nil && !errors.Is(err, io.EOF) {
+		s.finish(Metadata{}, Usage{}, err)
+	}
+	return event, err
+}
+
+func (s *telemetryGenerateStream) Result() (GenerateResponse, error) {
+	response, err := s.inner.Result()
+	s.tel.stampUsage(&response.Usage)
+	s.finish(response.Metadata, response.Usage, err)
+	return response, err
+}
+
+func (s *telemetryGenerateStream) Close() error {
+	err := s.inner.Close()
+	s.finish(Metadata{}, Usage{}, errdefs.Validationf(
+		"inference: generate stream closed before completion"))
+	return err
+}
+
+// telemetryTranscriptionSession mirrors telemetryGenerateStream for
+// duplex transcription sessions.
+type telemetryTranscriptionSession struct {
+	inner TranscriptionSession
+	tel   inferenceCall
+	once  sync.Once
+}
+
+func (s *telemetryTranscriptionSession) finish(metadata Metadata, usage Usage, err error) {
+	s.once.Do(func() {
+		s.tel.finish(metadata, usage, err)
+	})
+}
+
+func (s *telemetryTranscriptionSession) Send(ctx context.Context, chunk media.AudioChunk) error {
+	return s.inner.Send(ctx, chunk)
+}
+
+func (s *telemetryTranscriptionSession) Next(ctx context.Context) (TranscriptionSessionEvent, error) {
+	event, err := s.inner.Next(ctx)
+	if err != nil && !errors.Is(err, io.EOF) {
+		s.finish(Metadata{}, Usage{}, err)
+	}
+	return event, err
+}
+
+func (s *telemetryTranscriptionSession) Result() (TranscriptionResponse, error) {
+	response, err := s.inner.Result()
+	s.tel.stampUsage(&response.Usage)
+	s.finish(response.Metadata, response.Usage, err)
+	return response, err
+}
+
+func (s *telemetryTranscriptionSession) Interrupt() error {
+	err := s.inner.Interrupt()
+	s.finish(Metadata{}, Usage{}, err)
+	return err
+}
+
+func (s *telemetryTranscriptionSession) Close() error {
+	err := s.inner.Close()
+	s.finish(Metadata{}, Usage{}, errdefs.Validationf(
+		"inference: transcription session closed before completion"))
+	return err
+}

--- a/core/inference/telemetry_test.go
+++ b/core/inference/telemetry_test.go
@@ -1,0 +1,361 @@
+package inference
+
+import (
+	"context"
+	"errors"
+	"io"
+	"testing"
+
+	"github.com/GizClaw/flowcraft/core/errdefs"
+	"github.com/GizClaw/flowcraft/core/telemetry"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+)
+
+func installTestTracer(t *testing.T) *tracetest.SpanRecorder {
+	t.Helper()
+	prev := otel.GetTracerProvider()
+	rec := tracetest.NewSpanRecorder()
+	tp := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(rec))
+	otel.SetTracerProvider(tp)
+	t.Cleanup(func() {
+		_ = tp.Shutdown(context.Background())
+		otel.SetTracerProvider(prev)
+	})
+	return rec
+}
+
+func spanAttr(span sdktrace.ReadOnlySpan, key attribute.Key) (attribute.Value, bool) {
+	for _, kv := range span.Attributes() {
+		if kv.Key == key {
+			return kv.Value, true
+		}
+	}
+	return attribute.Value{}, false
+}
+
+func telemetryGenerateProvider(t *testing.T, respond func(GenerateRequest) (GenerateResponse, error)) *Assembly {
+	t.Helper()
+	return &Assembly{providers: map[string]ProviderDefinition{
+		"fake": {
+			ID: "fake",
+			Models: []ModelImplementation{{
+				Descriptor: ModelDescriptor{
+					ID: ModelID{Provider: "fake", Name: "model-1"},
+				},
+				Openers: Openers{
+					Generate: func(context.Context, ModelRef) (GenerateOperations, error) {
+						return GenerateOperations{Unary: errGenerateDriver{respond: respond}}, nil
+					},
+				},
+			}},
+		},
+	}}
+}
+
+type errGenerateDriver struct {
+	respond func(GenerateRequest) (GenerateResponse, error)
+}
+
+func (errGenerateDriver) inferenceGenerateDriver() {}
+
+func (d errGenerateDriver) Explain(
+	context.Context, ModelRef, GenerateRequest,
+) (Explanation, error) {
+	return Explanation{}, nil
+}
+
+func (d errGenerateDriver) Execute(
+	_ context.Context, _ ModelRef, req GenerateRequest,
+) (GenerateResponse, error) {
+	if d.respond != nil {
+		return d.respond(req)
+	}
+	return GenerateResponse{}, nil
+}
+
+func TestAssemblyGenerateSuccessRecordsIDsOnActiveSpan(t *testing.T) {
+	rec := installTestTracer(t)
+	assembly := telemetryGenerateProvider(t, func(GenerateRequest) (GenerateResponse, error) {
+		return GenerateResponse{
+			Metadata: Metadata{RequestID: "req-1", ResponseID: "resp-1"},
+			Usage:    testUsage(),
+		}, nil
+	})
+
+	ctx, outer := telemetry.Tracer().Start(context.Background(), "outer")
+	if _, err := assembly.Generate(ctx,
+		ModelRef{ID: ModelID{Provider: "fake", Name: "model-1"}},
+		GenerateRequest{}); err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+	outer.End()
+
+	spans := rec.Ended()
+	if len(spans) != 1 {
+		t.Fatalf("ended spans = %d, want 1 (outer only, no nested inference span)", len(spans))
+	}
+	if got, ok := spanAttr(spans[0], telemetry.AttrLLMRequestID); !ok || got.AsString() != "req-1" {
+		t.Fatalf("llm.request.id = %q/%v, want req-1", got, ok)
+	}
+	if got, ok := spanAttr(spans[0], telemetry.AttrLLMResponseID); !ok || got.AsString() != "resp-1" {
+		t.Fatalf("llm.response.id = %q/%v, want resp-1", got, ok)
+	}
+	assertUsageAttrs(t, spans[0])
+}
+
+func TestAssemblyGenerateFailureRecordsRequestIDOnActiveSpan(t *testing.T) {
+	rec := installTestTracer(t)
+	assembly := telemetryGenerateProvider(t, func(GenerateRequest) (GenerateResponse, error) {
+		return GenerateResponse{}, errdefs.WithRequestID(
+			errdefs.Validation(errors.New("boom")), "req-err-1")
+	})
+
+	ctx, outer := telemetry.Tracer().Start(context.Background(), "outer")
+	if _, err := assembly.Generate(ctx,
+		ModelRef{ID: ModelID{Provider: "fake", Name: "model-1"}},
+		GenerateRequest{}); !errdefs.IsValidation(err) {
+		t.Fatalf("Generate error = %v, want validation", err)
+	}
+	outer.End()
+
+	spans := rec.Ended()
+	if len(spans) != 1 {
+		t.Fatalf("ended spans = %d, want 1", len(spans))
+	}
+	if got, ok := spanAttr(spans[0], telemetry.AttrLLMRequestID); !ok || got.AsString() != "req-err-1" {
+		t.Fatalf("llm.request.id = %q/%v, want req-err-1", got, ok)
+	}
+	if _, ok := spanAttr(spans[0], telemetry.AttrLLMResponseID); ok {
+		t.Fatal("llm.response.id should be absent on failure")
+	}
+}
+
+func TestAssemblyGenerateStandaloneCreatesInferenceSpan(t *testing.T) {
+	rec := installTestTracer(t)
+	assembly := telemetryGenerateProvider(t, func(GenerateRequest) (GenerateResponse, error) {
+		return GenerateResponse{
+			Metadata: Metadata{RequestID: "req-1", ResponseID: "resp-1"},
+			Usage:    testUsage(),
+		}, nil
+	})
+
+	if _, err := assembly.Generate(context.Background(),
+		ModelRef{ID: ModelID{Provider: "fake", Name: "model-1"}},
+		GenerateRequest{}); err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+
+	spans := rec.Ended()
+	if len(spans) != 1 {
+		t.Fatalf("ended spans = %d, want 1", len(spans))
+	}
+	if spans[0].Name() != "inference.generate" {
+		t.Fatalf("span name = %q, want inference.generate", spans[0].Name())
+	}
+	if got, ok := spanAttr(spans[0], telemetry.AttrLLMRequestID); !ok || got.AsString() != "req-1" {
+		t.Fatalf("llm.request.id = %q/%v, want req-1", got, ok)
+	}
+	if got, ok := spanAttr(spans[0], telemetry.AttrLLMResponseID); !ok || got.AsString() != "resp-1" {
+		t.Fatalf("llm.response.id = %q/%v, want resp-1", got, ok)
+	}
+	if got, ok := spanAttr(spans[0], telemetry.AttrLLMProvider); !ok || got.AsString() != "fake" {
+		t.Fatalf("llm.provider = %q/%v, want fake", got, ok)
+	}
+	if got, ok := spanAttr(spans[0], telemetry.AttrLLMModel); !ok || got.AsString() != "model-1" {
+		t.Fatalf("llm.model = %q/%v, want model-1", got, ok)
+	}
+	assertUsageAttrs(t, spans[0])
+}
+
+func testUsage() Usage {
+	cacheRead := int64(8)
+	cacheWrite := int64(4)
+	return Usage{
+		InputTokens:  10,
+		OutputTokens: 3,
+		TotalTokens:  13,
+		Model:        ModelRef{ID: ModelID{Provider: "fake", Name: "model-1"}},
+		LatencyMs:    42,
+		Input: InputTokenUsage{
+			CacheReadTokens:  &cacheRead,
+			CacheWriteTokens: &cacheWrite,
+		},
+		Billing: &BillingUsage{Cost: &Money{Currency: "usd", Units: 150, Scale: 4}},
+	}
+}
+
+func assertUsageAttrs(t *testing.T, span sdktrace.ReadOnlySpan) {
+	t.Helper()
+	want := map[attribute.Key]int64{
+		telemetry.AttrLLMInputTokens:       10,
+		telemetry.AttrLLMOutputTokens:      3,
+		telemetry.AttrLLMTotalTokens:       13,
+		telemetry.AttrLLMCachedInputTokens: 8,
+		telemetry.AttrLLMLatencyMs:         42,
+		telemetry.AttrLLMCostMicros:        15000,
+	}
+	for key, wantValue := range want {
+		got, ok := spanAttr(span, key)
+		if !ok || got.AsInt64() != wantValue {
+			t.Errorf("attr %s = %v/%v, want %d", key, got, ok, wantValue)
+		}
+	}
+}
+
+type telemetryFakeStream struct {
+	events []GenerateStreamEvent
+	next   int
+	result GenerateResponse
+}
+
+func (s *telemetryFakeStream) Next(context.Context) (GenerateStreamEvent, error) {
+	if s.next < len(s.events) {
+		event := s.events[s.next]
+		s.next++
+		return event, nil
+	}
+	return GenerateStreamEvent{}, io.EOF
+}
+
+func (s *telemetryFakeStream) Result() (GenerateResponse, error) {
+	return s.result, nil
+}
+
+func (*telemetryFakeStream) Close() error { return nil }
+
+func TestTelemetryGenerateStreamRecordsIDsAtResult(t *testing.T) {
+	rec := installTestTracer(t)
+	_, call := startInferenceCall(
+		context.Background(), OperationGenerate,
+		ModelRef{ID: ModelID{Provider: "fake", Name: "model-1"}},
+	)
+	stream := &telemetryGenerateStream{
+		inner: &telemetryFakeStream{
+			events: []GenerateStreamEvent{{PartIndex: 0, Delta: TextPartDelta{Text: "hi"}}},
+			result: GenerateResponse{
+				Metadata: Metadata{RequestID: "req-1", ResponseID: "resp-1"},
+				Usage:    testUsage(),
+			},
+		},
+		tel: call,
+	}
+
+	for {
+		_, err := stream.Next(context.Background())
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		if err != nil {
+			t.Fatalf("Next: %v", err)
+		}
+	}
+	if _, err := stream.Result(); err != nil {
+		t.Fatalf("Result: %v", err)
+	}
+	if err := stream.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	spans := rec.Ended()
+	if len(spans) != 1 {
+		t.Fatalf("ended spans = %d, want 1", len(spans))
+	}
+	if got, ok := spanAttr(spans[0], telemetry.AttrLLMRequestID); !ok || got.AsString() != "req-1" {
+		t.Fatalf("llm.request.id = %q/%v, want req-1", got, ok)
+	}
+	if got, ok := spanAttr(spans[0], telemetry.AttrLLMResponseID); !ok || got.AsString() != "resp-1" {
+		t.Fatalf("llm.response.id = %q/%v, want resp-1", got, ok)
+	}
+	assertUsageAttrs(t, spans[0])
+}
+
+func TestAssemblyGenerateEmitsUsageMetrics(t *testing.T) {
+	prev := otel.GetMeterProvider()
+	reader := sdkmetric.NewManualReader()
+	mp := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+	otel.SetMeterProvider(mp)
+	t.Cleanup(func() {
+		_ = mp.Shutdown(context.Background())
+		otel.SetMeterProvider(prev)
+	})
+
+	assembly := telemetryGenerateProvider(t, func(GenerateRequest) (GenerateResponse, error) {
+		return GenerateResponse{Usage: testUsage()}, nil
+	})
+	ref := ModelRef{ID: ModelID{Provider: "fake", Name: "model-1"}}
+	if _, err := assembly.Generate(context.Background(), ref, GenerateRequest{}); err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+	failing := telemetryGenerateProvider(t, func(GenerateRequest) (GenerateResponse, error) {
+		return GenerateResponse{}, errdefs.WithRequestID(
+			errdefs.Validation(errors.New("boom")), "req-err-1")
+	})
+	if _, err := failing.Generate(context.Background(), ref, GenerateRequest{}); !errdefs.IsValidation(err) {
+		t.Fatalf("Generate error = %v, want validation", err)
+	}
+
+	var resources metricdata.ResourceMetrics
+	if err := reader.Collect(context.Background(), &resources); err != nil {
+		t.Fatalf("Collect: %v", err)
+	}
+	wantTokens := map[string]int64{
+		"tokens.input":        10,
+		"tokens.output":       3,
+		"tokens.input.cached": 8,
+	}
+	for name, want := range wantTokens {
+		if got := metricSum(resources, name, nil); got != want {
+			t.Errorf("metric %s = %d, want %d", name, got, want)
+		}
+	}
+	if got := metricSum(resources, "executions.total",
+		func(set attribute.Set) bool {
+			value, ok := set.Value(attribute.Key("status"))
+			return ok && value.AsString() == "success"
+		},
+	); got != 1 {
+		t.Errorf("executions.total success = %d, want 1", got)
+	}
+	if got := metricSum(resources, "executions.total",
+		func(set attribute.Set) bool {
+			value, ok := set.Value(attribute.Key("status"))
+			return ok && value.AsString() == "error"
+		},
+	); got != 1 {
+		t.Errorf("executions.total error = %d, want 1", got)
+	}
+	if got := metricSum(resources, "errors.total", nil); got != 1 {
+		t.Errorf("errors.total = %d, want 1", got)
+	}
+}
+
+func metricSum(
+	resources metricdata.ResourceMetrics,
+	name string,
+	filter func(attribute.Set) bool,
+) int64 {
+	var total int64
+	for _, scope := range resources.ScopeMetrics {
+		for _, m := range scope.Metrics {
+			if m.Name != name {
+				continue
+			}
+			sum, ok := m.Data.(metricdata.Sum[int64])
+			if !ok {
+				continue
+			}
+			for _, point := range sum.DataPoints {
+				if filter == nil || filter(point.Attributes) {
+					total += point.Value
+				}
+			}
+		}
+	}
+	return total
+}

--- a/driver/bytedance/transcribe.go
+++ b/driver/bytedance/transcribe.go
@@ -545,6 +545,9 @@ func decodeTranscribe(
 	if raw.duration > 0 {
 		duration := int64(raw.duration)
 		response.DurationMillis = &duration
+		// Mirror the spend dimension onto the usage envelope so
+		// inference telemetry emits inference.audio.duration_ms.
+		response.Usage.AudioDurationMillis = &duration
 	}
 	return response, nil
 }

--- a/driver/bytedance/transcribe_test.go
+++ b/driver/bytedance/transcribe_test.go
@@ -385,6 +385,10 @@ func TestDecodeTranscribe(t *testing.T) {
 	if response.DurationMillis == nil || *response.DurationMillis != 800 {
 		t.Fatalf("duration = %v", response.DurationMillis)
 	}
+	if response.Usage.AudioDurationMillis == nil ||
+		*response.Usage.AudioDurationMillis != 800 {
+		t.Fatalf("usage audio duration = %v", response.Usage.AudioDurationMillis)
+	}
 	if response.Metadata.RequestID != "req-1" {
 		t.Fatalf("request id = %q", response.Metadata.RequestID)
 	}


### PR DESCRIPTION
## What

Adds inference-level OpenTelemetry instrumentation so provider request/response ids and token usage are recorded for every LLM call regardless of success/failure or routing path.

### core/inference
- New `telemetry.go`: per-call instrumentation at the Assembly funnel. Emits `executions.total`, `errors.total`, `duration.seconds`, `tokens.input`, `tokens.output`, `tokens.input.cached` metrics, and mirrors `llm.request.id` / `llm.response.id`, `llm.tokens.*`, `llm.latency.ms`, `llm.cost.micros`, `inference.error_kind`, `inference.embed.items`, `inference.audio.duration_ms` onto spans.
- Reuses the caller active span (graph node / route / script node) when present; creates `inference.<operation>` spans only when none is active, so routed calls do not gain an extra nested span layer.
- `stampUsage` fills Model / LatencyMs on the usage envelope before it crosses the Assembly boundary.
- Graph inference node mirrors ids + usage onto the node span on success (failure ids already ride the error chain via `execute.go`).

### driver/bytedance
- Unary transcription now mirrors audio duration into `Usage.AudioDurationMillis` so `inference.audio.duration_ms` is emitted on the transcribe path.

### Notes
- `llm.cost.micros` stays empty until a host-side pricing catalog exists (providers do not return cost in responses).
- `TracingMiddleware` is kept as-is; downstream can read either layer.

## Checks
- `make ci`, `make lint`, `make release-check`, `git diff --check` all pass.