### PR TITLE
chore(release): add core v0.1.20 changeset

### DIFF
--- a/.release/core-v0.1.20.json
+++ b/.release/core-v0.1.20.json
@@ -1,0 +1,9 @@
+{
+  "summary": "fix(core): skip session drain wait without sinks and surface missing run-end — the stream coordinator no longer waits the drain timeout when a turn has no sinks, and a timed-out drain records session.finalize_error plus a telemetry warning instead of silently swallowing the missing run-end; feat(core): record inference request ids and token usage in OTel telemetry — per-call Assembly instrumentation emitting executions.total, errors.total, duration.seconds, tokens.input, tokens.output, and tokens.input.cached metrics plus llm.request.id / llm.response.id, llm.tokens.*, llm.latency.ms, llm.cost.micros, inference.error_kind, inference.embed.items, and inference.audio.duration_ms span attributes, with usage Model/LatencyMs stamped at the Assembly boundary and the graph inference node mirroring ids and usage onto its node span on success",
+  "releases": [
+    {
+      "module": "core",
+      "bump": "patch"
+    }
+  ]
+}


### PR DESCRIPTION
Adds the immutable `.release/core-v0.1.20.json` changeset covering the full core delta since `core/v0.1.19`:

- `fix(core)`: skip session drain wait without sinks and surface missing run-end (#375)
- `feat(core)`: record inference request ids and token usage in OTel telemetry (#376)

`make release-plan` confirms the planned release:

- core: 0.1.19 -> 0.1.20 (patch), tag `core/v0.1.20`
- `make release-check` and `make release-preflight` pass.

After this reaches main, the Release modules workflow will aggregate the changeset, open the changelog Release PR, and tag `core/v0.1.20` once all gates pass.