### PR TITLE
fix(core): allow array-rooted structured generate responses

### DIFF
--- a/.release/core-v0.1.21.json
+++ b/.release/core-v0.1.21.json
@@ -1,0 +1,9 @@
+{
+  "summary": "fix(core): allow array-rooted structured generate responses — json_schema output validation no longer forces the top-level JSON value to be an object; schemas rooted at other shapes such as arrays of objects now validate output against the schema directly, while json_object continues to require a top-level object",
+  "releases": [
+    {
+      "module": "core",
+      "bump": "patch"
+    }
+  ]
+}

--- a/core/graph/nodes/inference_test.go
+++ b/core/graph/nodes/inference_test.go
@@ -774,6 +774,14 @@ func TestInferenceNode_ResponseFormat_Enforced(t *testing.T) {
 		want    string
 	}{
 		{
+			name:    "json_object rejects array",
+			respond: `["a","b"]`,
+			format: &inference.ResponseFormat{
+				Kind: inference.ResponseJSONObject,
+			},
+			want: "structured generate response must be a JSON object",
+		},
+		{
 			name:    "json_object rejects plain text",
 			respond: "ok",
 			format: &inference.ResponseFormat{
@@ -789,6 +797,18 @@ func TestInferenceNode_ResponseFormat_Enforced(t *testing.T) {
 				Name: "answer",
 				Schema: json.RawMessage(
 					`{"type":"object","properties":{"answer":{"type":"string"}},"required":["answer"]}`,
+				),
+			},
+			want: "does not match requested JSON schema",
+		},
+		{
+			name:    "json_schema array root rejects object",
+			respond: `{"a":"b"}`,
+			format: &inference.ResponseFormat{
+				Kind: inference.ResponseJSONSchema,
+				Name: "answer",
+				Schema: json.RawMessage(
+					`{"type":"array","items":{"type":"string"}}`,
 				),
 			},
 			want: "does not match requested JSON schema",
@@ -819,6 +839,42 @@ func TestInferenceNode_ResponseFormat_Enforced(t *testing.T) {
 				t.Fatalf("Execute error = %v, want containing %q", err, tc.want)
 			}
 		})
+	}
+}
+
+func TestInferenceNode_ResponseFormat_ArraySchema(t *testing.T) {
+	fake := &inferencetest.GenerateFake{
+		Respond: func(inference.GenerateRequest) inference.GenerateResponse {
+			return inference.GenerateResponse{
+				Message: message.Message{
+					Role: message.RoleAssistant,
+					Content: message.Content{Parts: []message.Part{
+						message.TextPart{Text: `["a","b"]`},
+					}},
+				},
+				FinishReason: inference.FinishCompleted,
+			}
+		},
+	}
+	reg := inferenceRegistry(t, InferenceNodeDeps{Assembly: fake.Assembly(t)})
+	g := singleNodeGraph(t, reg, "inference", InferenceConfig{
+		Model: ptr(inferencetest.DefaultFakeModel),
+		ResponseFormat: &inference.ResponseFormat{
+			Kind: inference.ResponseJSONSchema,
+			Name: "answer",
+			Schema: json.RawMessage(
+				`{"type":"array","items":{"type":"string"}}`,
+			),
+		},
+	})
+	board := userBoard()
+	if err := executeGraph(t, g, agent.NoopHost{}, board); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	msgs := board.Channel(agent.MainChannel)
+	if text, ok := msgs[len(msgs)-1].Content.Parts[0].(message.TextPart); !ok ||
+		text.Text != `["a","b"]` {
+		t.Fatalf("assistant message = %+v, want array JSON", msgs[len(msgs)-1].Content.Parts[0])
 	}
 }
 

--- a/core/inference/generate.go
+++ b/core/inference/generate.go
@@ -631,10 +631,10 @@ func validateGenerateText(output string, format *ResponseFormat) error {
 	if err := decodeStrict([]byte(output), &value); err != nil {
 		return fmt.Errorf("structured generate response is not valid JSON: %w", err)
 	}
-	if _, ok := value.(map[string]any); !ok {
-		return fmt.Errorf("structured generate response must be a JSON object")
-	}
-	if format.Kind != ResponseJSONSchema {
+	if format.Kind == ResponseJSONObject {
+		if _, ok := value.(map[string]any); !ok {
+			return fmt.Errorf("structured generate response must be a JSON object")
+		}
 		return nil
 	}
 	compiler := newInMemoryJSONSchemaCompiler()

--- a/core/inference/generate_test.go
+++ b/core/inference/generate_test.go
@@ -1,0 +1,92 @@
+package inference
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestValidateGenerateText(t *testing.T) {
+	arraySchema := json.RawMessage(
+		`{"type":"array","items":{"type":"string"}}`,
+	)
+	cases := []struct {
+		name    string
+		output  string
+		format  *ResponseFormat
+		wantErr string
+	}{
+		{
+			name:   "no format skips validation",
+			output: `["a","b"]`,
+		},
+		{
+			name:   "text format skips validation",
+			output: `["a","b"]`,
+			format: &ResponseFormat{Kind: ResponseText},
+		},
+		{
+			name:   "json_object accepts object",
+			output: `{"answer":"42"}`,
+			format: &ResponseFormat{Kind: ResponseJSONObject},
+		},
+		{
+			name:    "json_object rejects array",
+			output:  `["a","b"]`,
+			format:  &ResponseFormat{Kind: ResponseJSONObject},
+			wantErr: "structured generate response must be a JSON object",
+		},
+		{
+			name:   "json_schema accepts array root",
+			output: `["a","b"]`,
+			format: &ResponseFormat{
+				Kind:   ResponseJSONSchema,
+				Name:   "answer",
+				Schema: arraySchema,
+			},
+		},
+		{
+			name:    "json_schema array root rejects object",
+			output:  `{"a":"b"}`,
+			format:  &ResponseFormat{Kind: ResponseJSONSchema, Name: "answer", Schema: arraySchema},
+			wantErr: "does not match requested JSON schema",
+		},
+		{
+			name:   "json_schema rejects non-conforming object",
+			output: `{"answer":42}`,
+			format: &ResponseFormat{
+				Kind: ResponseJSONSchema,
+				Name: "answer",
+				Schema: json.RawMessage(
+					`{"type":"object","properties":{"answer":{"type":"string"}},"required":["answer"]}`,
+				),
+			},
+			wantErr: "does not match requested JSON schema",
+		},
+		{
+			name:    "json_schema rejects invalid JSON",
+			output:  "not json",
+			format:  &ResponseFormat{Kind: ResponseJSONSchema, Name: "answer", Schema: arraySchema},
+			wantErr: "structured generate response is not valid JSON",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.format != nil {
+				if err := tc.format.Validate(); err != nil {
+					t.Fatalf("format Validate: %v", err)
+				}
+			}
+			err := validateGenerateText(tc.output, tc.format)
+			if tc.wantErr == "" {
+				if err != nil {
+					t.Fatalf("validateGenerateText = %v, want nil", err)
+				}
+				return
+			}
+			if err == nil || !strings.Contains(err.Error(), tc.wantErr) {
+				t.Fatalf("validateGenerateText error = %v, want containing %q", err, tc.wantErr)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What

Structured `json_schema` generate responses no longer require the top-level JSON value to be an object. Output is validated directly against the requested schema, so array-rooted schemas (e.g. `{"type":"array","items":{"type":"object",...}}`) now accept bare arrays like `[{"photo_id":"p1","comment":"nice"}]`.

`json_object` keeps requiring a top-level object; `text` is unchanged.

## Why

The previous `validateGenerateText` check rejected any non-object top-level value before schema validation ran, so valid array-rooted schemas passed request validation but could never produce a passing response.

## Verification

- Unit tests in `core/inference/generate_test.go` covering both modes and array-rooted schemas
- End-to-end graph node tests for array output and object rejection
- `make ci`, `make lint`, `make release-check`, `git diff --check` all pass

## Release

Adds `.release/core-v0.1.21.json` (patch). After this PR merges to `main`, the `Release modules` workflow opens the `automation/release-changelog` PR; merging that PR gates and publishes `core/v0.1.21` automatically.