### PR TITLE
feat(core): expose canonical intent envelope on graph inference node

### DIFF
--- a/core/graph/nodes/inference.go
+++ b/core/graph/nodes/inference.go
@@ -62,19 +62,18 @@ type InferenceConfig struct {
 	// set, the names are declared to the catalog as RequiredByName via
 	// an optional interface and must still exist.
 	AllTools bool `json:"all_tools,omitempty"`
-	// The remaining knobs ride the text intent verbatim.
-	ToolChoice       *inference.ToolChoice     `json:"tool_choice,omitempty"`
-	Temperature      *float64                  `json:"temperature,omitempty"`
-	TopP             *float64                  `json:"top_p,omitempty"`
-	MaxOutputTokens  *int                      `json:"max_output_tokens,omitempty"`
-	ReasoningEnabled *bool                     `json:"reasoning_enabled,omitempty"`
-	ReasoningEffort  inference.ReasoningEffort `json:"reasoning_effort,omitempty"`
+	// ToolChoice constrains when/which tools are called and rides the
+	// text intent next to Tools.
+	ToolChoice *inference.ToolChoice `json:"tool_choice,omitempty"`
 
-	// ResponseFormat shapes the model's reply: text, json_object, or
-	// json_schema (name + schema). Providers that cannot honor the
-	// shape reject the request at compile time; the runtime re-validates
-	// the generated text against the schema before returning it.
-	ResponseFormat *inference.ResponseFormat `json:"response_format,omitempty"`
+	// Intent is the canonical execution envelope: one or more of the
+	// text, image, audio, and video modalities with their controls
+	// (see inference.Intent). It is authoritative — when set, the
+	// node builds the request from it directly. Tools / AllTools /
+	// ToolChoice stay node-level sugar that resolves the wired catalog
+	// into intent.text.tools / intent.text.tool_choice. When Intent is
+	// absent the node defaults to plain text generation.
+	Intent *inference.Intent `json:"intent,omitempty"`
 
 	// Extensions names provider knobs in the shared {provider, id,
 	// fields} wire form (see inference.DecodeExtensions). Decoders are
@@ -107,7 +106,7 @@ type InferenceNodeDeps struct {
 func Inference(deps InferenceNodeDeps) graph.NodeType[InferenceConfig] {
 	return graph.NodeType[InferenceConfig]{
 		Meta: graph.Meta{
-			Desc: "single-shot LLM generation: channel tail in, one assistant message out",
+			Desc: "single-shot generation (text, image, audio, video): channel tail in, one assistant message out",
 			Reads: []graph.Role{
 				{Kind: graph.RoleMessages, ConfigKey: "messages_channel"},
 			},
@@ -240,7 +239,7 @@ func emitGenerationTerminal(ec graph.ExecutionContext, resp inference.GenerateRe
 
 // buildGenerateRequest splits the channel tail into context + current
 // input — the exact shape GenerateRequest demands — and attaches the
-// configured text intent and extensions.
+// configured intent and extensions.
 func buildGenerateRequest(ec graph.ExecutionContext, board *agent.Board, channel string, cfg InferenceConfig, deps InferenceNodeDeps) (inference.GenerateRequest, error) {
 	var req inference.GenerateRequest
 	messages := board.Channel(channel)
@@ -268,21 +267,9 @@ func buildGenerateRequest(ec graph.ExecutionContext, board *agent.Board, channel
 		)
 	}
 
-	text := &inference.TextIntent{
-		Response:         cfg.ResponseFormat,
-		ToolChoice:       cfg.ToolChoice,
-		Temperature:      cfg.Temperature,
-		TopP:             cfg.TopP,
-		MaxOutputTokens:  cfg.MaxOutputTokens,
-		ReasoningEnabled: cfg.ReasoningEnabled,
-		ReasoningEffort:  cfg.ReasoningEffort,
-	}
-	if len(cfg.Tools) > 0 || cfg.AllTools {
-		definitions, err := toolDefinitions(ec.Context, cfg.Tools, deps.Catalog, cfg.AllTools)
-		if err != nil {
-			return req, err
-		}
-		text.Tools = definitions
+	intent, err := resolveIntent(ec.Context, cfg, deps)
+	if err != nil {
+		return req, err
 	}
 
 	extensions, err := inference.DecodeExtensions(cfg.Extensions, deps.Extensions, "inference node extensions")
@@ -296,11 +283,51 @@ func buildGenerateRequest(ec graph.ExecutionContext, board *agent.Board, channel
 			Role: inputRole,
 			Content: inference.InputContent{
 				Content: last.Content,
-				Intent:  inference.Intent{Text: text},
+				Intent:  intent,
 			},
 		},
 		Extensions: extensions,
 	}, nil
+}
+
+// resolveIntent assembles the invocation's canonical execution
+// envelope. The intent config is authoritative; the legacy tools /
+// all_tools / tool_choice knobs are node-level sugar that resolve the
+// wired catalog into intent.text.tools / intent.text.tool_choice. When
+// no intent is configured the node keeps the historical behavior: a
+// text intent, tools-first when tools are configured. The assembled
+// intent is validated here so configuration errors surface before any
+// provider I/O.
+func resolveIntent(ctx context.Context, cfg InferenceConfig, deps InferenceNodeDeps) (inference.Intent, error) {
+	var intent inference.Intent
+	if cfg.Intent != nil {
+		intent = cfg.Intent.Clone()
+	} else {
+		// Default shape: plain text generation.
+		intent.Text = &inference.TextIntent{}
+	}
+	if len(cfg.Tools) > 0 || cfg.AllTools || cfg.ToolChoice != nil {
+		if intent.Text == nil {
+			return intent, errdefs.Validationf(
+				"inference node: tools/tool_choice configured but intent has no text modality")
+		}
+		if len(intent.Text.Tools) > 0 || intent.Text.ToolChoice != nil {
+			return intent, errdefs.Validationf(
+				"inference node: tools/tool_choice declared both in intent and via node config")
+		}
+		if len(cfg.Tools) > 0 || cfg.AllTools {
+			definitions, err := toolDefinitions(ctx, cfg.Tools, deps.Catalog, cfg.AllTools)
+			if err != nil {
+				return intent, err
+			}
+			intent.Text.Tools = definitions
+		}
+		intent.Text.ToolChoice = cfg.ToolChoice
+	}
+	if err := intent.Validate(); err != nil {
+		return intent, errdefs.Validationf("inference node: intent: %v", err)
+	}
+	return intent, nil
 }
 
 func toolDefinitions(ctx context.Context, names []string, catalog tool.Catalog, allTools bool) ([]message.ToolDefinition, error) {

--- a/core/graph/nodes/inference_test.go
+++ b/core/graph/nodes/inference_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/GizClaw/flowcraft/core/inference/inferencetest"
 	"github.com/GizClaw/flowcraft/core/inference/route"
 	"github.com/GizClaw/flowcraft/core/message"
+	"github.com/GizClaw/flowcraft/core/message/media"
 	"github.com/GizClaw/flowcraft/core/telemetry"
 	"github.com/GizClaw/flowcraft/core/tool"
 
@@ -740,12 +741,15 @@ func TestInferenceNode_ResponseFormat_ReachesRequest(t *testing.T) {
 	reg := inferenceRegistry(t, InferenceNodeDeps{Assembly: fake.Assembly(t)})
 	g := singleNodeGraph(t, reg, "inference", InferenceConfig{
 		Model: ptr(inferencetest.DefaultFakeModel),
-		ResponseFormat: &inference.ResponseFormat{
-			Kind: inference.ResponseJSONSchema,
-			Name: "answer",
-			Schema: json.RawMessage(
-				`{"type":"object","properties":{"answer":{"type":"string"}},"required":["answer"]}`,
-			),
+		Intent: &inference.Intent{Text: &inference.TextIntent{
+			Response: &inference.ResponseFormat{
+				Kind: inference.ResponseJSONSchema,
+				Name: "answer",
+				Schema: json.RawMessage(
+					`{"type":"object","properties":{"answer":{"type":"string"}},"required":["answer"]}`,
+				),
+			},
+		},
 		},
 	})
 	board := userBoard()
@@ -831,8 +835,10 @@ func TestInferenceNode_ResponseFormat_Enforced(t *testing.T) {
 			}
 			reg := inferenceRegistry(t, InferenceNodeDeps{Assembly: fake.Assembly(t)})
 			g := singleNodeGraph(t, reg, "inference", InferenceConfig{
-				Model:          ptr(inferencetest.DefaultFakeModel),
-				ResponseFormat: tc.format,
+				Model: ptr(inferencetest.DefaultFakeModel),
+				Intent: &inference.Intent{
+					Text: &inference.TextIntent{Response: tc.format},
+				},
 			})
 			err := executeGraph(t, g, agent.NoopHost{}, userBoard())
 			if err == nil || !strings.Contains(responseCause(err), tc.want) {
@@ -859,12 +865,15 @@ func TestInferenceNode_ResponseFormat_ArraySchema(t *testing.T) {
 	reg := inferenceRegistry(t, InferenceNodeDeps{Assembly: fake.Assembly(t)})
 	g := singleNodeGraph(t, reg, "inference", InferenceConfig{
 		Model: ptr(inferencetest.DefaultFakeModel),
-		ResponseFormat: &inference.ResponseFormat{
-			Kind: inference.ResponseJSONSchema,
-			Name: "answer",
-			Schema: json.RawMessage(
-				`{"type":"array","items":{"type":"string"}}`,
-			),
+		Intent: &inference.Intent{Text: &inference.TextIntent{
+			Response: &inference.ResponseFormat{
+				Kind: inference.ResponseJSONSchema,
+				Name: "answer",
+				Schema: json.RawMessage(
+					`{"type":"array","items":{"type":"string"}}`,
+				),
+			},
+		},
 		},
 	})
 	board := userBoard()
@@ -900,15 +909,229 @@ func TestInferenceNode_ResponseFormat_RejectsInvalidSchema(t *testing.T) {
 	reg := inferenceRegistry(t, InferenceNodeDeps{Assembly: fake.Assembly(t)})
 	g := singleNodeGraph(t, reg, "inference", InferenceConfig{
 		Model: ptr(inferencetest.DefaultFakeModel),
-		ResponseFormat: &inference.ResponseFormat{
-			Kind:   inference.ResponseJSONSchema,
-			Name:   "answer",
-			Schema: json.RawMessage(`{"type":1}`),
+		Intent: &inference.Intent{Text: &inference.TextIntent{
+			Response: &inference.ResponseFormat{
+				Kind:   inference.ResponseJSONSchema,
+				Name:   "answer",
+				Schema: json.RawMessage(`{"type":1}`),
+			},
+		},
 		},
 	})
 	err := executeGraph(t, g, agent.NoopHost{}, userBoard())
 	if err == nil || !strings.Contains(responseCause(err), "schema") {
 		t.Fatalf("Execute error = %v, want schema validation failure", err)
+	}
+}
+
+func TestInferenceNode_Intent_ImageReachesRequest(t *testing.T) {
+	fake := &inferencetest.GenerateFake{
+		Respond: func(inference.GenerateRequest) inference.GenerateResponse {
+			return inference.GenerateResponse{
+				Message: message.Message{
+					Role: message.RoleAssistant,
+					Content: message.Content{Parts: []message.Part{
+						imagePart(t, "https://x/1.png"),
+						imagePart(t, "https://x/2.png"),
+					}},
+				},
+				FinishReason: inference.FinishCompleted,
+			}
+		},
+	}
+	reg := inferenceRegistry(t, InferenceNodeDeps{Assembly: fake.Assembly(t)})
+	g := singleNodeGraph(t, reg, "inference", InferenceConfig{
+		Model: ptr(inferencetest.DefaultFakeModel),
+		Intent: &inference.Intent{
+			Image: &inference.ImageIntent{Count: ptr(2)},
+		},
+	})
+	if err := executeGraph(t, g, agent.NoopHost{}, userBoard()); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+
+	intent := fake.LastRequest().Input.Content.Intent
+	if intent.Image == nil || intent.Image.Count == nil || *intent.Image.Count != 2 {
+		t.Fatalf("image intent = %+v, want count 2", intent.Image)
+	}
+	if intent.Text != nil {
+		t.Fatalf("text intent = %+v, want nil for an image-only request", intent.Text)
+	}
+}
+
+func imagePart(t *testing.T, rawURL string) message.ImagePart {
+	t.Helper()
+	src, err := media.NewImageURL(rawURL, "image/png")
+	if err != nil {
+		t.Fatalf("NewImageURL: %v", err)
+	}
+	return message.ImagePart{Source: src}
+}
+
+func TestInferenceNode_Intent_TextControlsReachRequest(t *testing.T) {
+	fake := &inferencetest.GenerateFake{}
+	reg := inferenceRegistry(t, InferenceNodeDeps{Assembly: fake.Assembly(t)})
+	g := singleNodeGraph(t, reg, "inference", InferenceConfig{
+		Model: ptr(inferencetest.DefaultFakeModel),
+		Intent: &inference.Intent{Text: &inference.TextIntent{
+			Temperature:      ptr(0.7),
+			TopP:             ptr(0.9),
+			MaxOutputTokens:  ptr(512),
+			ReasoningEnabled: ptr(true),
+			ReasoningEffort:  inference.ReasoningHigh,
+		}},
+	})
+	if err := executeGraph(t, g, agent.NoopHost{}, userBoard()); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+
+	text := fake.LastRequest().Input.Content.Intent.Text
+	if text.Temperature == nil || *text.Temperature != 0.7 {
+		t.Fatalf("temperature = %+v, want 0.7", text.Temperature)
+	}
+	if text.TopP == nil || *text.TopP != 0.9 {
+		t.Fatalf("top_p = %+v, want 0.9", text.TopP)
+	}
+	if text.MaxOutputTokens == nil || *text.MaxOutputTokens != 512 {
+		t.Fatalf("max_output_tokens = %+v, want 512", text.MaxOutputTokens)
+	}
+	if text.ReasoningEnabled == nil || !*text.ReasoningEnabled {
+		t.Fatalf("reasoning_enabled = %+v, want true", text.ReasoningEnabled)
+	}
+	if text.ReasoningEffort != inference.ReasoningHigh {
+		t.Fatalf("reasoning_effort = %q, want high", text.ReasoningEffort)
+	}
+}
+
+func TestInferenceNode_Intent_ToolsMergeIntoTextIntent(t *testing.T) {
+	catalog := toolCatalog(t, tool.FuncTool(
+		message.ToolDefinition{
+			Name:        "search",
+			Description: "search the web",
+			InputSchema: json.RawMessage(`{"type":"object"}`),
+		},
+		func(_ context.Context, args string) (string, error) {
+			return "sunny:" + args, nil
+		},
+	))
+	fake := &inferencetest.GenerateFake{
+		Respond: func(inference.GenerateRequest) inference.GenerateResponse {
+			return inference.GenerateResponse{
+				Message: message.Message{
+					Role: message.RoleAssistant,
+					Content: message.Content{Parts: []message.Part{
+						message.ToolCallPart{Call: message.ToolCall{
+							ID:        "call_1",
+							Name:      "search",
+							Arguments: json.RawMessage(`{"q":"weather"}`),
+						}},
+					}},
+				},
+				FinishReason: inference.FinishToolCalls,
+			}
+		},
+	}
+	reg := inferenceRegistry(t, InferenceNodeDeps{Assembly: fake.Assembly(t), Catalog: catalog})
+	g := singleNodeGraph(t, reg, "inference", InferenceConfig{
+		Model: ptr(inferencetest.DefaultFakeModel),
+		Tools: []string{"search"},
+		ToolChoice: &inference.ToolChoice{
+			Kind: inference.ToolChoiceNamed,
+			Name: "search",
+		},
+		Intent: &inference.Intent{Text: &inference.TextIntent{
+			Temperature: ptr(0.7),
+		}},
+	})
+	if err := executeGraph(t, g, agent.NoopHost{}, userBoard()); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+
+	text := fake.LastRequest().Input.Content.Intent.Text
+	if text.Temperature == nil || *text.Temperature != 0.7 {
+		t.Fatalf("temperature = %+v, want 0.7", text.Temperature)
+	}
+	if len(text.Tools) != 1 || text.Tools[0].Name != "search" {
+		t.Fatalf("intent tools = %+v, want search", text.Tools)
+	}
+	if text.ToolChoice == nil || text.ToolChoice.Kind != inference.ToolChoiceNamed ||
+		text.ToolChoice.Name != "search" {
+		t.Fatalf("tool_choice = %+v, want named search", text.ToolChoice)
+	}
+}
+
+func TestInferenceNode_Intent_NonTextWithToolsRejected(t *testing.T) {
+	fake := &inferencetest.GenerateFake{}
+	reg := inferenceRegistry(t, InferenceNodeDeps{
+		Assembly: fake.Assembly(t),
+		Catalog:  toolCatalog(t),
+	})
+	g := singleNodeGraph(t, reg, "inference", InferenceConfig{
+		Model:  ptr(inferencetest.DefaultFakeModel),
+		Tools:  []string{"search"},
+		Intent: &inference.Intent{Image: &inference.ImageIntent{}},
+	})
+	err := executeGraph(t, g, agent.NoopHost{}, userBoard())
+	if err == nil || !errdefs.IsValidation(err) ||
+		!strings.Contains(err.Error(), "no text modality") {
+		t.Fatalf("Execute error = %v, want validation about missing text modality", err)
+	}
+}
+
+func TestInferenceNode_Intent_DoubleToolDeclarationRejected(t *testing.T) {
+	fake := &inferencetest.GenerateFake{}
+	reg := inferenceRegistry(t, InferenceNodeDeps{
+		Assembly: fake.Assembly(t),
+		Catalog:  toolCatalog(t),
+	})
+	g := singleNodeGraph(t, reg, "inference", InferenceConfig{
+		Model: ptr(inferencetest.DefaultFakeModel),
+		Tools: []string{"search"},
+		Intent: &inference.Intent{Text: &inference.TextIntent{
+			Tools: []message.ToolDefinition{{Name: "search"}},
+		}},
+	})
+	err := executeGraph(t, g, agent.NoopHost{}, userBoard())
+	if err == nil || !errdefs.IsValidation(err) ||
+		!strings.Contains(err.Error(), "declared both") {
+		t.Fatalf("Execute error = %v, want validation about double tool declaration", err)
+	}
+}
+
+func TestInferenceNode_Intent_EmptyRejected(t *testing.T) {
+	fake := &inferencetest.GenerateFake{}
+	reg := inferenceRegistry(t, InferenceNodeDeps{Assembly: fake.Assembly(t)})
+	g := singleNodeGraph(t, reg, "inference", InferenceConfig{
+		Model:  ptr(inferencetest.DefaultFakeModel),
+		Intent: &inference.Intent{},
+	})
+	err := executeGraph(t, g, agent.NoopHost{}, userBoard())
+	if err == nil || !errdefs.IsValidation(err) ||
+		!strings.Contains(err.Error(), "requires text, image, audio, or video") {
+		t.Fatalf("Execute error = %v, want validation about empty intent", err)
+	}
+}
+
+func TestInferenceNode_RejectsLegacyTextKnobs(t *testing.T) {
+	fake := &inferencetest.GenerateFake{}
+	reg := inferenceRegistry(t, InferenceNodeDeps{Assembly: fake.Assembly(t)})
+	_, err := graph.Build(&graph.GraphDefinition{
+		Name:  "test-graph",
+		Entry: "n",
+		Nodes: []graph.NodeDefinition{{
+			ID:   "n",
+			Type: "inference",
+			Config: mustConfig(t, map[string]any{
+				"model": map[string]any{
+					"id": map[string]any{"provider": "fake", "name": "fake-1"},
+				},
+				"temperature": 0.7,
+			}),
+		}},
+	}, reg)
+	if err == nil || !strings.Contains(err.Error(), "unknown config field") ||
+		!strings.Contains(err.Error(), "temperature") {
+		t.Fatalf("Build error = %v, want unknown-field rejection for temperature", err)
 	}
 }
 

--- a/core/graph/resource/resource_test.go
+++ b/core/graph/resource/resource_test.go
@@ -258,13 +258,17 @@ func TestFactoryWiresResponseFormatConfig(t *testing.T) {
 						"id":      map[string]any{"provider": "fake", "name": "echo"},
 						"profile": "default",
 					},
-					"response_format": map[string]any{
-						"kind": "json_schema",
-						"name": "answer",
-						"schema": map[string]any{
-							"type":       "object",
-							"properties": map[string]any{"answer": map[string]any{"type": "string"}},
-							"required":   []any{"answer"},
+					"intent": map[string]any{
+						"text": map[string]any{
+							"response": map[string]any{
+								"kind": "json_schema",
+								"name": "answer",
+								"schema": map[string]any{
+									"type":       "object",
+									"properties": map[string]any{"answer": map[string]any{"type": "string"}},
+									"required":   []any{"answer"},
+								},
+							},
 						},
 					},
 				},

--- a/docs/guides/graph.md
+++ b/docs/guides/graph.md
@@ -93,7 +93,7 @@ node needs `tools`, a script node needs `script_runtime`. `workspace` and
 
 ## Node types
 
-### `inference` — single-shot LLM generation
+### `inference` — single-shot generation
 
 Runs one `Generate` call: the channel tail is the current turn's input, the
 assistant message (tool calls included) is appended to the same channel.
@@ -112,10 +112,7 @@ onto `tool_pending_key` and the graph routes onward.
 | `tools`                                  | named catalog tools the model may call this turn                                                                  |
 | `all_tools`                              | send the catalog's entire visible set; with `tools`, names are declared `RequiredByName` and must exist           |
 | `tool_choice`                            | constrain when/which tools are called                                                                             |
-| `temperature` / `top_p`                  | sampling controls                                                                                                 |
-| `max_output_tokens`                      | output token cap                                                                                                  |
-| `reasoning_enabled` / `reasoning_effort` | universal reasoning switch / depth                                                                                |
-| `response_format`                        | `text`, `json_object`, or `json_schema` (name + schema); generated text is re-validated against the schema        |
+| `intent`                                 | canonical execution envelope: `{text, image, audio, video}` with per-modality controls (see below)                |
 | `extensions`                             | provider knobs in the `{provider, id, fields}` wire form, resolved via the assembly's decoders                    |
 
 Behavior:
@@ -124,11 +121,34 @@ Behavior:
   the request context. An empty channel or wrong role is a validation error.
 - `model` uses the wired `inference.Assembly`; no `model` requires the
   `inference.Router` (selector/fallback chain picks the target).
+- `intent` is the authoritative execution envelope and covers every
+  generation modality: text controls (`response`, `max_output_tokens`,
+  `tools`, `tool_choice`, `temperature`, `top_p`, `reasoning_enabled`,
+  `reasoning_effort`), image (`size`, `aspect_ratio`, `count`, `seed`,
+  `output_format`, `delivery`), audio/tts (`voice`, `format`, `speed`,
+  `count`), and video (`duration_millis`, `resolution`, `aspect_ratio`,
+  `seed`, `watermark`). When `intent` is absent the node defaults to plain
+  text generation. `tools` / `all_tools` / `tool_choice` remain node-level
+  sugar: they resolve the wired catalog into `intent.text.tools` /
+  `intent.text.tool_choice` and may not be combined with an intent that
+  declares those fields itself. Modality combinations a provider cannot
+  honor (image with sampling controls, tts with tools, …) are rejected by
+  the provider's compiler.
 - With `tools`/`all_tools` configured the tools dep's catalog must be wired;
   unknown names fail the node.
 - Usage is reported to the host on every call. In stream mode a mid-stream
   failure commits the buffered partial text to the board and reports the
   last usage snapshot before propagating the error.
+
+```json
+{
+  "type": "inference",
+  "model": { "id": { "provider": "openai", "name": "gpt-image-1" } },
+  "intent": {
+    "image": { "size": { "width": 1024, "height": 1024 }, "count": 2 }
+  }
+}
+```
 
 ### `tool` — batch tool execution
 

--- a/examples/forge/scenarios/raids/multi_role_storyteller/graphs/assistant.yaml
+++ b/examples/forge/scenarios/raids/multi_role_storyteller/graphs/assistant.yaml
@@ -78,18 +78,20 @@ nodes:
 - id: select_speaker
   type: inference
   config:
-    max_output_tokens: 1024
+    intent:
+      text:
+        max_output_tokens: 1024
+        reasoning_enabled: true
+        reasoning_effort: high
     messages_channel: speaker_select_channel
     model:
       id:
         name: deepseek-v4-flash
         provider: deepseek
     output_key: speaker_select_text
-    reasoning_enabled: true
     stream: false
     system_prompt:
       file: graphs/prompts/select_speaker.txt
-    reasoning_effort: high
 - id: shape_story_turn
   type: script
   config:
@@ -105,78 +107,88 @@ nodes:
 - id: narrator
   type: inference
   config:
-    max_output_tokens: 1024
+    intent:
+      text:
+        max_output_tokens: 1024
+        reasoning_enabled: true
+        reasoning_effort: high
     messages_channel: speech_channel
     model:
       id:
         name: deepseek-v4-flash
         provider: deepseek
     output_key: tmp_speech_text
-    reasoning_enabled: true
     stream: true
     system_prompt:
       file: graphs/prompts/narrator.txt
-    reasoning_effort: high
 - id: role_wukong
   type: inference
   config:
-    max_output_tokens: 1024
+    intent:
+      text:
+        max_output_tokens: 1024
+        reasoning_enabled: true
+        reasoning_effort: high
     messages_channel: speech_channel
     model:
       id:
         name: deepseek-v4-flash
         provider: deepseek
     output_key: tmp_speech_text
-    reasoning_enabled: true
     stream: true
     system_prompt:
       file: graphs/prompts/role_wukong.txt
-    reasoning_effort: high
 - id: role_tangseng
   type: inference
   config:
-    max_output_tokens: 1024
+    intent:
+      text:
+        max_output_tokens: 1024
+        reasoning_enabled: true
+        reasoning_effort: high
     messages_channel: speech_channel
     model:
       id:
         name: deepseek-v4-flash
         provider: deepseek
     output_key: tmp_speech_text
-    reasoning_enabled: true
     stream: true
     system_prompt:
       file: graphs/prompts/role_tangseng.txt
-    reasoning_effort: high
 - id: role_bajie
   type: inference
   config:
-    max_output_tokens: 1024
+    intent:
+      text:
+        max_output_tokens: 1024
+        reasoning_enabled: true
+        reasoning_effort: high
     messages_channel: speech_channel
     model:
       id:
         name: deepseek-v4-flash
         provider: deepseek
     output_key: tmp_speech_text
-    reasoning_enabled: true
     stream: true
     system_prompt:
       file: graphs/prompts/role_bajie.txt
-    reasoning_effort: high
 - id: role_monster
   type: inference
   config:
-    max_output_tokens: 1024
+    intent:
+      text:
+        max_output_tokens: 1024
+        reasoning_enabled: true
+        reasoning_effort: high
     messages_channel: speech_channel
     model:
       id:
         name: deepseek-v4-flash
         provider: deepseek
     output_key: tmp_speech_text
-    reasoning_enabled: true
     stream: true
     system_prompt:
       file: graphs/prompts/role_monster.txt
-    reasoning_effort: high
 - id: update_state
   type: script
   config:

--- a/examples/forge/scenarios/raids/werewolf/graphs/assistant.yaml
+++ b/examples/forge/scenarios/raids/werewolf/graphs/assistant.yaml
@@ -433,294 +433,336 @@ nodes:
 - id: wolf_discuss
   type: inference
   config:
+    intent:
+      text:
+        max_output_tokens: 2048
+        reasoning_enabled: true
+        reasoning_effort: high
     messages_channel: wolf_team_channel
     model:
       id:
         name: deepseek-v4-flash
         provider: deepseek
-    max_output_tokens: 2048
-    reasoning_enabled: true
-    reasoning_effort: high
     stream: false
     system_prompt:
       file: graphs/prompts/wolf_discuss.txt
 - id: wolf_decide
   type: inference
   config:
+    intent:
+      text:
+        max_output_tokens: 2048
+        reasoning_enabled: true
+        reasoning_effort: high
     messages_channel: wolf_team_channel
     model:
       id:
         name: deepseek-v4-flash
         provider: deepseek
-    max_output_tokens: 2048
-    reasoning_enabled: true
-    reasoning_effort: high
     stream: false
     system_prompt:
       file: graphs/prompts/wolf_decide.txt
 - id: witch_decide
   type: inference
   config:
+    intent:
+      text:
+        max_output_tokens: 2048
+        reasoning_enabled: true
+        reasoning_effort: high
     messages_channel: witch_channel
     model:
       id:
         name: deepseek-v4-flash
         provider: deepseek
-    max_output_tokens: 2048
-    reasoning_enabled: true
-    reasoning_effort: high
     stream: false
     system_prompt:
       file: graphs/prompts/witch_decide.txt
 - id: seer_decide
   type: inference
   config:
+    intent:
+      text:
+        max_output_tokens: 2048
+        reasoning_enabled: true
+        reasoning_effort: high
     messages_channel: seer_channel
     model:
       id:
         name: deepseek-v4-flash
         provider: deepseek
-    max_output_tokens: 2048
-    reasoning_enabled: true
-    reasoning_effort: high
     stream: false
     system_prompt:
       file: graphs/prompts/seer_decide.txt
 - id: hunter_decide
   type: inference
   config:
+    intent:
+      text:
+        max_output_tokens: 2048
+        reasoning_enabled: true
+        reasoning_effort: high
     messages_channel: hunter_channel
     model:
       id:
         name: deepseek-v4-flash
         provider: deepseek
-    max_output_tokens: 2048
-    reasoning_enabled: true
-    reasoning_effort: high
     stream: false
     system_prompt:
       file: graphs/prompts/hunter_decide.txt
 - id: seat_1_speak
   type: inference
   config:
+    intent:
+      text:
+        max_output_tokens: 2048
+        reasoning_enabled: true
+        reasoning_effort: high
     messages_channel: seat_1_channel
     model:
       id:
         name: deepseek-v4-flash
         provider: deepseek
-    max_output_tokens: 2048
-    reasoning_enabled: true
-    reasoning_effort: high
     stream: true
     system_prompt:
       file: graphs/prompts/seat_speak.txt
 - id: seat_2_speak
   type: inference
   config:
+    intent:
+      text:
+        max_output_tokens: 2048
+        reasoning_enabled: true
+        reasoning_effort: high
     messages_channel: seat_2_channel
     model:
       id:
         name: deepseek-v4-flash
         provider: deepseek
-    max_output_tokens: 2048
-    reasoning_enabled: true
-    reasoning_effort: high
     stream: true
     system_prompt:
       file: graphs/prompts/seat_speak.txt
 - id: seat_3_speak
   type: inference
   config:
+    intent:
+      text:
+        max_output_tokens: 2048
+        reasoning_enabled: true
+        reasoning_effort: high
     messages_channel: seat_3_channel
     model:
       id:
         name: deepseek-v4-flash
         provider: deepseek
-    max_output_tokens: 2048
-    reasoning_enabled: true
-    reasoning_effort: high
     stream: true
     system_prompt:
       file: graphs/prompts/seat_speak.txt
 - id: seat_4_speak
   type: inference
   config:
+    intent:
+      text:
+        max_output_tokens: 2048
+        reasoning_enabled: true
+        reasoning_effort: high
     messages_channel: seat_4_channel
     model:
       id:
         name: deepseek-v4-flash
         provider: deepseek
-    max_output_tokens: 2048
-    reasoning_enabled: true
-    reasoning_effort: high
     stream: true
     system_prompt:
       file: graphs/prompts/seat_speak.txt
 - id: seat_5_speak
   type: inference
   config:
+    intent:
+      text:
+        max_output_tokens: 2048
+        reasoning_enabled: true
+        reasoning_effort: high
     messages_channel: seat_5_channel
     model:
       id:
         name: deepseek-v4-flash
         provider: deepseek
-    max_output_tokens: 2048
-    reasoning_enabled: true
-    reasoning_effort: high
     stream: true
     system_prompt:
       file: graphs/prompts/seat_speak.txt
 - id: seat_6_speak
   type: inference
   config:
+    intent:
+      text:
+        max_output_tokens: 2048
+        reasoning_enabled: true
+        reasoning_effort: high
     messages_channel: seat_6_channel
     model:
       id:
         name: deepseek-v4-flash
         provider: deepseek
-    max_output_tokens: 2048
-    reasoning_enabled: true
-    reasoning_effort: high
     stream: true
     system_prompt:
       file: graphs/prompts/seat_speak.txt
 - id: seat_7_speak
   type: inference
   config:
+    intent:
+      text:
+        max_output_tokens: 2048
+        reasoning_enabled: true
+        reasoning_effort: high
     messages_channel: seat_7_channel
     model:
       id:
         name: deepseek-v4-flash
         provider: deepseek
-    max_output_tokens: 2048
-    reasoning_enabled: true
-    reasoning_effort: high
     stream: true
     system_prompt:
       file: graphs/prompts/seat_speak.txt
 - id: seat_8_speak
   type: inference
   config:
+    intent:
+      text:
+        max_output_tokens: 2048
+        reasoning_enabled: true
+        reasoning_effort: high
     messages_channel: seat_8_channel
     model:
       id:
         name: deepseek-v4-flash
         provider: deepseek
-    max_output_tokens: 2048
-    reasoning_enabled: true
-    reasoning_effort: high
     stream: true
     system_prompt:
       file: graphs/prompts/seat_speak.txt
 - id: seat_1_vote
   type: inference
   config:
+    intent:
+      text:
+        max_output_tokens: 2048
+        reasoning_enabled: true
+        reasoning_effort: high
     messages_channel: seat_1_vote_channel
     model:
       id:
         name: deepseek-v4-flash
         provider: deepseek
-    max_output_tokens: 2048
-    reasoning_enabled: true
-    reasoning_effort: high
     stream: false
     system_prompt:
       file: graphs/prompts/vote_decide.txt
 - id: seat_2_vote
   type: inference
   config:
+    intent:
+      text:
+        max_output_tokens: 2048
+        reasoning_enabled: true
+        reasoning_effort: high
     messages_channel: seat_2_vote_channel
     model:
       id:
         name: deepseek-v4-flash
         provider: deepseek
-    max_output_tokens: 2048
-    reasoning_enabled: true
-    reasoning_effort: high
     stream: false
     system_prompt:
       file: graphs/prompts/vote_decide.txt
 - id: seat_3_vote
   type: inference
   config:
+    intent:
+      text:
+        max_output_tokens: 2048
+        reasoning_enabled: true
+        reasoning_effort: high
     messages_channel: seat_3_vote_channel
     model:
       id:
         name: deepseek-v4-flash
         provider: deepseek
-    max_output_tokens: 2048
-    reasoning_enabled: true
-    reasoning_effort: high
     stream: false
     system_prompt:
       file: graphs/prompts/vote_decide.txt
 - id: seat_4_vote
   type: inference
   config:
+    intent:
+      text:
+        max_output_tokens: 2048
+        reasoning_enabled: true
+        reasoning_effort: high
     messages_channel: seat_4_vote_channel
     model:
       id:
         name: deepseek-v4-flash
         provider: deepseek
-    max_output_tokens: 2048
-    reasoning_enabled: true
-    reasoning_effort: high
     stream: false
     system_prompt:
       file: graphs/prompts/vote_decide.txt
 - id: seat_5_vote
   type: inference
   config:
+    intent:
+      text:
+        max_output_tokens: 2048
+        reasoning_enabled: true
+        reasoning_effort: high
     messages_channel: seat_5_vote_channel
     model:
       id:
         name: deepseek-v4-flash
         provider: deepseek
-    max_output_tokens: 2048
-    reasoning_enabled: true
-    reasoning_effort: high
     stream: false
     system_prompt:
       file: graphs/prompts/vote_decide.txt
 - id: seat_6_vote
   type: inference
   config:
+    intent:
+      text:
+        max_output_tokens: 2048
+        reasoning_enabled: true
+        reasoning_effort: high
     messages_channel: seat_6_vote_channel
     model:
       id:
         name: deepseek-v4-flash
         provider: deepseek
-    max_output_tokens: 2048
-    reasoning_enabled: true
-    reasoning_effort: high
     stream: false
     system_prompt:
       file: graphs/prompts/vote_decide.txt
 - id: seat_7_vote
   type: inference
   config:
+    intent:
+      text:
+        max_output_tokens: 2048
+        reasoning_enabled: true
+        reasoning_effort: high
     messages_channel: seat_7_vote_channel
     model:
       id:
         name: deepseek-v4-flash
         provider: deepseek
-    max_output_tokens: 2048
-    reasoning_enabled: true
-    reasoning_effort: high
     stream: false
     system_prompt:
       file: graphs/prompts/vote_decide.txt
 - id: seat_8_vote
   type: inference
   config:
+    intent:
+      text:
+        max_output_tokens: 2048
+        reasoning_enabled: true
+        reasoning_effort: high
     messages_channel: seat_8_vote_channel
     model:
       id:
         name: deepseek-v4-flash
         provider: deepseek
-    max_output_tokens: 2048
-    reasoning_enabled: true
-    reasoning_effort: high
     stream: false
     system_prompt:
       file: graphs/prompts/vote_decide.txt


### PR DESCRIPTION
## Summary

The graph `inference` node previously only exposed text-generation controls and hardcoded `Intent{Text: ...}` when building the request, so image generation / TTS / video were impossible through graph nodes even though the inference runtime and drivers fully support them (`inference.Intent` covers text, image, audio, video).

This PR gives the node the canonical `intent` config field and makes it the authoritative execution envelope:

- `intent` accepts the canonical `inference.Intent` wire form — `{text, image, audio, video}` with all per-modality controls. One field unlocks image generation (e.g. `gpt-image`), TTS (e.g. `gpt-4o-mini-tts`, including stream shape), video, and future modalities without per-modality config churn.
- Removed the pure `TextIntent` sugar knobs: `temperature`, `top_p`, `max_output_tokens`, `reasoning_enabled`, `reasoning_effort`, `response_format` — text controls now live under `intent.text.*`.
- `tools` / `all_tools` / `tool_choice` remain node-level sugar: they resolve the wired catalog into `intent.text.tools` / `intent.text.tool_choice`. Conflicts (non-text intent + tools, or double declaration) fail early as validation errors; the assembled intent is validated before any provider I/O.
- Output side needed no changes: the node already streams image/audio/file parts and appends the assembled message; usage already tracks generated images / audio / video.

## Migrations

- `docs/guides/graph.md`: config table + behavior notes + example.
- Forge scenarios: 27 inference nodes across `werewolf` and `multi_role_storyteller` moved to `intent.text.*` (their assemble tests load the graphs through the local core's strict decode).

## Breaking change

Graph configs using the removed text knobs fail at build time with `unknown config field` — configs must move those controls into `intent.text.*`.

## Verification

- `make ci` (vet + test, all modules) ✅
- `make lint` (all CI-gated modules) — 0 issues ✅
- `make release-check` — changesets valid, no pending releases ✅
- `git diff --check` ✅
- New tests cover: image intent reaching the request, text controls passthrough, tools merge into `intent.text`, non-text + tools rejection, double tool declaration rejection, empty intent rejection, and legacy knob rejection.