### PR TITLE
feat(core): capability-aware routing with declared model content capabilities

### DIFF
--- a/core/inference/generate.go
+++ b/core/inference/generate.go
@@ -394,6 +394,10 @@ func (r GenerateResponse) ValidateFor(request GenerateRequest) error {
 	}
 	intent := request.Input.Content.Intent
 	toolsRequested := intent.Text != nil && intent.Text.toolsRequested()
+	requested := make(map[message.PartKind]struct{}, 4)
+	for _, kind := range intent.OutputKinds() {
+		requested[kind] = struct{}{}
+	}
 	var text strings.Builder
 	textParts := 0
 	var images []message.ImagePart
@@ -407,13 +411,13 @@ func (r GenerateResponse) ValidateFor(request GenerateRequest) error {
 		}
 		switch value := normalized.(type) {
 		case message.TextPart:
-			if intent.Text == nil {
+			if _, ok := requested[message.PartText]; !ok {
 				return fmt.Errorf("generate response contains unrequested text")
 			}
 			textParts++
 			text.WriteString(value.Text)
 		case message.ImagePart:
-			if intent.Image == nil {
+			if _, ok := requested[message.PartImage]; !ok {
 				return fmt.Errorf("generate response contains unrequested image")
 			}
 			images = append(images, value)
@@ -421,7 +425,7 @@ func (r GenerateResponse) ValidateFor(request GenerateRequest) error {
 				return fmt.Errorf("generate image %d: %w", len(images)-1, err)
 			}
 		case message.AudioPart:
-			if intent.Audio == nil {
+			if _, ok := requested[message.PartAudio]; !ok {
 				return fmt.Errorf("generate response contains unrequested audio")
 			}
 			audio = append(audio, value)
@@ -429,7 +433,7 @@ func (r GenerateResponse) ValidateFor(request GenerateRequest) error {
 				return fmt.Errorf("generate audio %d: %w", len(audio)-1, err)
 			}
 		case message.VideoPart:
-			if intent.Video == nil {
+			if _, ok := requested[message.PartVideo]; !ok {
 				return fmt.Errorf("generate response contains unrequested video")
 			}
 			videos = append(videos, value)

--- a/core/inference/generate_intent.go
+++ b/core/inference/generate_intent.go
@@ -61,6 +61,27 @@ func (i Intent) Validate() error {
 	return nil
 }
 
+// OutputKinds returns the output content kinds this intent requests, in
+// canonical part order: text, image, audio, video. It is the single mapping
+// from the intent structure to the message content vocabulary; response
+// validation and capability-aware routing share it.
+func (i Intent) OutputKinds() []message.PartKind {
+	kinds := make([]message.PartKind, 0, 4)
+	if i.Text != nil {
+		kinds = append(kinds, message.PartText)
+	}
+	if i.Image != nil {
+		kinds = append(kinds, message.PartImage)
+	}
+	if i.Audio != nil {
+		kinds = append(kinds, message.PartAudio)
+	}
+	if i.Video != nil {
+		kinds = append(kinds, message.PartVideo)
+	}
+	return kinds
+}
+
 // TextIntent declares text output and owns every control that governs
 // text generation: response shaping, tool calling, sampling, and the
 // reasoning trace. A TextIntent carrying only tools is the tools-first

--- a/core/inference/generate_test.go
+++ b/core/inference/generate_test.go
@@ -2,9 +2,39 @@ package inference
 
 import (
 	"encoding/json"
+	"reflect"
 	"strings"
 	"testing"
+
+	"github.com/GizClaw/flowcraft/core/message"
 )
+
+func TestIntentOutputKinds(t *testing.T) {
+	if kinds := (Intent{}).OutputKinds(); len(kinds) != 0 {
+		t.Fatalf("empty intent kinds = %v, want none", kinds)
+	}
+	if kinds := (Intent{Text: &TextIntent{}}).OutputKinds(); !reflect.DeepEqual(
+		kinds,
+		[]message.PartKind{message.PartText},
+	) {
+		t.Fatalf("text intent kinds = %v", kinds)
+	}
+	all := Intent{
+		Text:  &TextIntent{},
+		Image: &ImageIntent{},
+		Audio: &AudioIntent{},
+		Video: &VideoIntent{},
+	}
+	want := []message.PartKind{
+		message.PartText,
+		message.PartImage,
+		message.PartAudio,
+		message.PartVideo,
+	}
+	if kinds := all.OutputKinds(); !reflect.DeepEqual(kinds, want) {
+		t.Fatalf("all intent kinds = %v, want %v", kinds, want)
+	}
+}
 
 func TestValidateGenerateText(t *testing.T) {
 	arraySchema := json.RawMessage(

--- a/core/inference/model.go
+++ b/core/inference/model.go
@@ -3,6 +3,8 @@ package inference
 import (
 	"fmt"
 	"time"
+
+	"github.com/GizClaw/flowcraft/core/message"
 )
 
 type Operation string
@@ -102,15 +104,127 @@ func (l ModelLifecycle) ValidateFor(model ModelID) error {
 	return nil
 }
 
-// ModelCapabilities describes optional feature bits a model can serve.
-// Zero is the conservative declaration: every feature the struct omits is
-// treated as unsupported until a provider declares it.
+// ReasoningKind declares a model's reasoning control capability. Zero is the
+// conservative declaration: a model without a declared reasoning capability
+// has no reasoning channel or reasoning controls.
+type ReasoningKind string
+
+const (
+	ReasoningNone   ReasoningKind = ""
+	ReasoningAlways ReasoningKind = "always"
+	ReasoningToggle ReasoningKind = "toggle"
+)
+
+func (k ReasoningKind) Validate() error {
+	switch k {
+	case ReasoningNone, ReasoningAlways, ReasoningToggle:
+		return nil
+	default:
+		return fmt.Errorf("unknown reasoning kind %q", k)
+	}
+}
+
+// ModelCapabilities describes optional feature bits and content kinds a model
+// can serve. Zero is the conservative declaration: every feature the struct
+// omits is treated as unsupported until a provider declares it.
 type ModelCapabilities struct {
+	// Inputs lists the canonical content part kinds the model accepts as
+	// request input (text, image, audio, video, tool calls, ...). Providers
+	// that do not declare inputs leave the capability unknown rather than
+	// asserted absent; routing falls back to operation support and preflight
+	// remains the final arbiter.
+	Inputs []message.PartKind `json:"inputs,omitempty"`
+	// Outputs lists the canonical content part kinds the model can produce as
+	// output. Only the output modalities (text, image, audio, video) are
+	// representable; routing prefers targets whose declared outputs cover the
+	// request intent and skips declared-incompatible tiers. Empty outputs are
+	// undeclared and do not filter routing.
+	Outputs []message.PartKind `json:"outputs,omitempty"`
+	// Reasoning declares the model's reasoning control capability: whether it
+	// has a reasoning channel and whether reasoning can be switched or its
+	// effort adjusted. Empty (ReasoningNone) is the conservative default.
+	Reasoning ReasoningKind `json:"reasoning,omitempty"`
 	// HostedWebSearch marks provider-side web_search tool support. It is
 	// discovery metadata for hosts; the search configuration itself still
 	// rides on GenerateRequest.Extensions as a provider GenerateOptions
 	// extension.
 	HostedWebSearch bool `json:"hosted_web_search,omitempty"`
+}
+
+// Clone returns a defensive copy of the capabilities: the returned value
+// shares no backing array with the receiver.
+func (c ModelCapabilities) Clone() ModelCapabilities {
+	c.Inputs = append([]message.PartKind(nil), c.Inputs...)
+	c.Outputs = append([]message.PartKind(nil), c.Outputs...)
+	return c
+}
+
+// WithInputs returns a copy of the capabilities with the given input content
+// kinds appended. The result shares no backing array with the receiver, so
+// calls compose safely.
+func (c ModelCapabilities) WithInputs(kinds ...message.PartKind) ModelCapabilities {
+	c.Inputs = append(append([]message.PartKind(nil), c.Inputs...), kinds...)
+	return c
+}
+
+// WithOutputs returns a copy of the capabilities with the given output
+// content kinds appended. The result shares no backing array with the
+// receiver, so calls compose safely.
+func (c ModelCapabilities) WithOutputs(kinds ...message.PartKind) ModelCapabilities {
+	c.Outputs = append(append([]message.PartKind(nil), c.Outputs...), kinds...)
+	return c
+}
+
+// WithReasoning returns a copy of the capabilities with the reasoning control
+// capability set.
+func (c ModelCapabilities) WithReasoning(kind ReasoningKind) ModelCapabilities {
+	c.Reasoning = kind
+	return c
+}
+
+// WithHostedWebSearch returns a copy of the capabilities with hosted web
+// search marked supported.
+func (c ModelCapabilities) WithHostedWebSearch() ModelCapabilities {
+	c.HostedWebSearch = true
+	return c
+}
+
+func (c ModelCapabilities) Validate() error {
+	if err := c.Reasoning.Validate(); err != nil {
+		return err
+	}
+	seenInputs := make(map[message.PartKind]struct{}, len(c.Inputs))
+	for _, kind := range c.Inputs {
+		if err := kind.Validate(); err != nil {
+			return fmt.Errorf("input content kind: %w", err)
+		}
+		if _, ok := seenInputs[kind]; ok {
+			return fmt.Errorf("duplicate input content kind %q", kind)
+		}
+		seenInputs[kind] = struct{}{}
+	}
+	seenOutputs := make(map[message.PartKind]struct{}, len(c.Outputs))
+	for _, kind := range c.Outputs {
+		if !isOutputModality(kind) {
+			return fmt.Errorf("output content kind %q is not a representable output modality", kind)
+		}
+		if _, ok := seenOutputs[kind]; ok {
+			return fmt.Errorf("duplicate output content kind %q", kind)
+		}
+		seenOutputs[kind] = struct{}{}
+	}
+	return nil
+}
+
+// isOutputModality reports whether the content kind is a representable output
+// modality: the four kinds the generate intent can request.
+func isOutputModality(kind message.PartKind) bool {
+	switch kind {
+	case message.PartText, message.PartImage, message.PartAudio, message.PartVideo:
+		return true
+	default:
+		return false
+	}
 }
 
 // ModelLimits declares numeric capacity limits of a model. A nil field
@@ -150,6 +264,7 @@ type ModelDescriptor struct {
 
 func (d ModelDescriptor) Clone() ModelDescriptor {
 	d.Operations = append([]Operation(nil), d.Operations...)
+	d.Capabilities = d.Capabilities.Clone()
 	d.Limits = d.Limits.Clone()
 	d.Lifecycle = d.Lifecycle.Clone()
 	return d
@@ -175,6 +290,9 @@ func (d ModelDescriptor) Validate() error {
 				"hosted web search requires the generate operation",
 			)
 		}
+	}
+	if err := d.Capabilities.Validate(); err != nil {
+		return err
 	}
 	if err := d.Limits.Validate(); err != nil {
 		return err

--- a/core/inference/model_test.go
+++ b/core/inference/model_test.go
@@ -2,10 +2,12 @@ package inference_test
 
 import (
 	"encoding/json"
+	"reflect"
 	"strings"
 	"testing"
 
 	"github.com/GizClaw/flowcraft/core/inference"
+	"github.com/GizClaw/flowcraft/core/message"
 )
 
 func TestModelLimitsValidate(t *testing.T) {
@@ -56,6 +58,153 @@ func TestModelDescriptorClonePreservesLimits(t *testing.T) {
 			"clone shares max input tokens pointer: original = %d",
 			*original.Limits.MaxInputTokens,
 		)
+	}
+}
+
+func TestModelCapabilitiesValidate(t *testing.T) {
+	capabilities := inference.ModelCapabilities{
+		Inputs:  []message.PartKind{message.PartText, message.PartImage},
+		Outputs: []message.PartKind{message.PartText},
+	}
+	if err := capabilities.Validate(); err != nil {
+		t.Fatalf("valid capabilities: %v", err)
+	}
+
+	for _, outputs := range [][]message.PartKind{
+		{message.PartToolCall},
+		{message.PartFile, message.PartImage},
+		{message.PartText, message.PartText},
+		{message.PartImage, message.PartText, message.PartImage},
+	} {
+		if err := (inference.ModelCapabilities{Outputs: outputs}).Validate(); err == nil {
+			t.Fatalf("outputs %v unexpectedly accepted", outputs)
+		}
+	}
+
+	for _, inputs := range [][]message.PartKind{
+		{message.PartText, message.PartText},
+		{"unknown_kind"},
+	} {
+		if err := (inference.ModelCapabilities{Inputs: inputs}).Validate(); err == nil {
+			t.Fatalf("inputs %v unexpectedly accepted", inputs)
+		}
+	}
+
+	for _, reasoning := range []inference.ReasoningKind{
+		inference.ReasoningAlways,
+		inference.ReasoningToggle,
+	} {
+		if err := (inference.ModelCapabilities{
+			Reasoning: reasoning,
+		}).Validate(); err != nil {
+			t.Fatalf("reasoning %q: %v", reasoning, err)
+		}
+	}
+	if err := (inference.ModelCapabilities{
+		Reasoning: "sometimes",
+	}).Validate(); err == nil {
+		t.Fatal("unknown reasoning kind unexpectedly accepted")
+	}
+}
+
+func TestReasoningKindValidate(t *testing.T) {
+	for _, kind := range []inference.ReasoningKind{
+		inference.ReasoningNone,
+		inference.ReasoningAlways,
+		inference.ReasoningToggle,
+	} {
+		if err := kind.Validate(); err != nil {
+			t.Fatalf("kind %q: %v", kind, err)
+		}
+	}
+	if err := (inference.ReasoningKind("sometimes")).Validate(); err == nil {
+		t.Fatal("unknown reasoning kind unexpectedly accepted")
+	}
+}
+
+func TestModelCapabilitiesCloneDoesNotShareSlices(t *testing.T) {
+	original := inference.ModelCapabilities{
+		Inputs:  []message.PartKind{message.PartText, message.PartImage},
+		Outputs: []message.PartKind{message.PartText},
+	}
+	clone := original.Clone()
+	clone.Inputs[0] = message.PartAudio
+	clone.Outputs[0] = message.PartImage
+	if original.Inputs[0] != message.PartText || original.Outputs[0] != message.PartText {
+		t.Fatalf(
+			"clone shares capability slices: original = %+v",
+			original,
+		)
+	}
+}
+
+func TestModelCapabilitiesBuilders(t *testing.T) {
+	capabilities := inference.ModelCapabilities{}.
+		WithInputs(message.PartText, message.PartImage).
+		WithInputs(message.PartData).
+		WithOutputs(message.PartText).
+		WithReasoning(inference.ReasoningAlways).
+		WithHostedWebSearch()
+	wantInputs := []message.PartKind{
+		message.PartText,
+		message.PartImage,
+		message.PartData,
+	}
+	if !reflect.DeepEqual(capabilities.Inputs, wantInputs) {
+		t.Fatalf("inputs = %v, want %v", capabilities.Inputs, wantInputs)
+	}
+	if !reflect.DeepEqual(capabilities.Outputs, []message.PartKind{message.PartText}) {
+		t.Fatalf("outputs = %v", capabilities.Outputs)
+	}
+	if capabilities.Reasoning != inference.ReasoningAlways ||
+		!capabilities.HostedWebSearch {
+		t.Fatalf("capabilities = %+v", capabilities)
+	}
+	if err := capabilities.Validate(); err != nil {
+		t.Fatalf("Validate: %v", err)
+	}
+}
+
+func TestModelCapabilitiesBuildersDoNotAlias(t *testing.T) {
+	base := inference.ModelCapabilities{}.WithInputs(message.PartText)
+	extended := base.WithInputs(message.PartImage)
+	if len(base.Inputs) != 1 || base.Inputs[0] != message.PartText {
+		t.Fatalf("base inputs mutated by builder: %v", base.Inputs)
+	}
+	_ = extended
+}
+
+func TestModelDescriptorClonePreservesCapabilities(t *testing.T) {
+	original := inference.ModelDescriptor{
+		ID:         inference.ModelID{Provider: "openai", Name: "gpt-x"},
+		Operations: []inference.Operation{inference.OperationGenerate},
+		Capabilities: inference.ModelCapabilities{
+			Inputs:  []message.PartKind{message.PartText, message.PartImage},
+			Outputs: []message.PartKind{message.PartText},
+		},
+	}
+	clone := original.Clone()
+	clone.Capabilities.Inputs[1] = message.PartAudio
+	clone.Capabilities.Outputs[0] = message.PartImage
+	if original.Capabilities.Inputs[1] != message.PartImage ||
+		original.Capabilities.Outputs[0] != message.PartText {
+		t.Fatalf(
+			"descriptor clone shares capability slices: original = %+v",
+			original.Capabilities,
+		)
+	}
+}
+
+func TestModelDescriptorValidateRejectsNonOutputModality(t *testing.T) {
+	descriptor := inference.ModelDescriptor{
+		ID:         inference.ModelID{Provider: "openai", Name: "gpt-x"},
+		Operations: []inference.Operation{inference.OperationGenerate},
+		Capabilities: inference.ModelCapabilities{
+			Outputs: []message.PartKind{message.PartToolCall},
+		},
+	}
+	if err := descriptor.Validate(); err == nil {
+		t.Fatal("tool_call output unexpectedly accepted")
 	}
 }
 

--- a/core/inference/route/resource.go
+++ b/core/inference/route/resource.go
@@ -46,7 +46,7 @@ func (Factory) New(_ context.Context, in resource.Input) (any, error) {
 	if err != nil {
 		return nil, err
 	}
-	router, err := New(target, policy.Selectors(), options...)
+	router, err := New(target, policy.Selectors(target), options...)
 	if err != nil {
 		return nil, errdefs.Validationf("inference router: %v", err)
 	}

--- a/core/inference/route/route_test.go
+++ b/core/inference/route/route_test.go
@@ -67,16 +67,49 @@ func routeDecode() inference.Decoder[routeRaw, inference.GenerateResponse] {
 	}
 }
 
+func imageRouteDecode() inference.Decoder[routeRaw, inference.GenerateResponse] {
+	return func(_ context.Context, _ routeRaw) (inference.GenerateResponse, error) {
+		source, err := media.NewImageURL("https://example.com/out.png", "image/png")
+		if err != nil {
+			return inference.GenerateResponse{}, err
+		}
+		return inference.GenerateResponse{
+			Message: message.Message{
+				Role: message.RoleAssistant,
+				Content: message.Content{Parts: []message.Part{
+					message.ImagePart{Source: source},
+				}},
+			},
+			FinishReason: inference.FinishCompleted,
+			Usage: inference.Usage{
+				InputTokens:  3,
+				OutputTokens: 4,
+				TotalTokens:  7,
+			},
+		}, nil
+	}
+}
+
 func providerDefinition(
 	t *testing.T,
 	id string,
 	fail bool,
 ) inference.ProviderDefinition {
+	return providerDefinitionWithOutputs(t, id, fail, nil, routeDecode())
+}
+
+func providerDefinitionWithOutputs(
+	t *testing.T,
+	id string,
+	fail bool,
+	outputs []message.PartKind,
+	decode inference.Decoder[routeRaw, inference.GenerateResponse],
+) inference.ProviderDefinition {
 	t.Helper()
 	driver, err := inference.BindGenerate(
 		routeCompiler(),
 		routeTransport(fail),
-		routeDecode(),
+		decode,
 	)
 	if err != nil {
 		t.Fatalf("BindGenerate: %v", err)
@@ -85,7 +118,8 @@ func providerDefinition(
 		ID: id,
 		Models: []inference.ModelImplementation{{
 			Descriptor: inference.ModelDescriptor{
-				ID: inference.ModelID{Provider: id, Name: "model-1"},
+				ID:           inference.ModelID{Provider: id, Name: "model-1"},
+				Capabilities: inference.ModelCapabilities{Outputs: outputs},
 			},
 			Openers: inference.Openers{
 				Generate: func(
@@ -100,12 +134,24 @@ func providerDefinition(
 
 func newRouteAssembly(t *testing.T) *inference.Assembly {
 	t.Helper()
+	return assemblyWithProviders(t, map[string]inference.ProviderDefinition{
+		"provider.bad":  providerDefinition(t, "bad", true),
+		"provider.good": providerDefinition(t, "good", false),
+	})
+}
+
+func assemblyWithProviders(
+	t *testing.T,
+	providers map[string]inference.ProviderDefinition,
+) *inference.Assembly {
+	t.Helper()
+	deps := make(map[string]any, len(providers))
+	for name, definition := range providers {
+		deps[name] = definition
+	}
 	factory := inference.Factory{}
 	value, err := factory.New(context.Background(), resource.Input{
-		Deps: map[string]any{
-			"provider.bad":  providerDefinition(t, "bad", true),
-			"provider.good": providerDefinition(t, "good", false),
-		},
+		Deps: deps,
 	})
 	if err != nil {
 		t.Fatalf("build assembly: %v", err)
@@ -152,7 +198,7 @@ func TestRouterGenerateFallsBackAcrossPools(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Options: %v", err)
 	}
-	router, err := New(assembly, policy.Selectors(), options...)
+	router, err := New(assembly, policy.Selectors(assembly), options...)
 	if err != nil {
 		t.Fatalf("New: %v", err)
 	}
@@ -496,7 +542,7 @@ func TestRouterTranscribeFallsBackAcrossPools(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Options: %v", err)
 	}
-	router, err := New(assembly, policy.Selectors(), options...)
+	router, err := New(assembly, policy.Selectors(assembly), options...)
 	if err != nil {
 		t.Fatalf("New: %v", err)
 	}
@@ -529,7 +575,7 @@ func TestRouterTranscribeSessionOpens(t *testing.T) {
 			}},
 		}},
 	}
-	router, err := New(assembly, policy.Selectors())
+	router, err := New(assembly, policy.Selectors(assembly))
 	if err != nil {
 		t.Fatalf("New: %v", err)
 	}
@@ -612,7 +658,7 @@ func TestRouterTranscribeStream(t *testing.T) {
 			}},
 		}},
 	}
-	router, err := New(assembly, policy.Selectors())
+	router, err := New(assembly, policy.Selectors(assembly))
 	if err != nil {
 		t.Fatalf("New: %v", err)
 	}
@@ -669,7 +715,7 @@ func TestRouterTranscribeRetriesSameTarget(t *testing.T) {
 	}
 	router, err := New(
 		assembly,
-		policy.Selectors(),
+		policy.Selectors(assembly),
 		append(options, noopSleeper())...,
 	)
 	if err != nil {
@@ -723,7 +769,7 @@ func TestRouterTranscribeCircuitBreakerSkipsOpenTarget(t *testing.T) {
 	}
 	router, err := New(
 		assembly,
-		policy.Selectors(),
+		policy.Selectors(assembly),
 		append(options, noopSleeper())...,
 	)
 	if err != nil {
@@ -752,6 +798,215 @@ func TestRouterTranscribeCircuitBreakerSkipsOpenTarget(t *testing.T) {
 		trace.Attempts[0].Outcome != AttemptOutcomeSkipped ||
 		trace.Attempts[0].Circuit != "open" {
 		t.Fatalf("second attempts = %+v, want circuit-open skip", trace.Attempts)
+	}
+}
+
+func TestRouterGenerateSelectsCapableTargetForIntent(t *testing.T) {
+	assembly := assemblyWithProviders(t, map[string]inference.ProviderDefinition{
+		"provider.text": providerDefinitionWithOutputs(
+			t, "text", false,
+			[]message.PartKind{message.PartText},
+			routeDecode(),
+		),
+		"provider.image": providerDefinitionWithOutputs(
+			t, "image", false,
+			[]message.PartKind{message.PartImage},
+			imageRouteDecode(),
+		),
+	})
+	policy := Policy{
+		Generate: []Pool{
+			{Tier: "text", Targets: []Target{{
+				Model: inference.ModelRef{
+					ID: inference.ModelID{Provider: "text", Name: "model-1"},
+				},
+			}}},
+			{Tier: "image", Targets: []Target{{
+				Model: inference.ModelRef{
+					ID: inference.ModelID{Provider: "image", Name: "model-1"},
+				},
+			}}},
+		},
+	}
+	router, err := New(assembly, policy.Selectors(assembly))
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	textResponse, textTrace, err := router.Generate(
+		context.Background(), routeRequest(),
+	)
+	if err != nil {
+		t.Fatalf("text Generate: %v", err)
+	}
+	if textResponse.Usage.TotalTokens != 7 {
+		t.Fatalf("text usage = %+v", textResponse.Usage)
+	}
+	if textTrace.Executed.ID.Provider != "text" {
+		t.Fatalf("text executed = %+v, want the text model", textTrace.Executed)
+	}
+
+	imageRequest := routeRequest()
+	imageRequest.Input.Content.Intent = inference.Intent{Image: &inference.ImageIntent{}}
+	imageResponse, imageTrace, err := router.Generate(
+		context.Background(), imageRequest,
+	)
+	if err != nil {
+		t.Fatalf("image Generate: %v", err)
+	}
+	if imageResponse.Usage.TotalTokens != 7 {
+		t.Fatalf("image usage = %+v", imageResponse.Usage)
+	}
+	if imageTrace.Executed.ID.Provider != "image" {
+		t.Fatalf(
+			"image executed = %+v, want the image model without fallback",
+			imageTrace.Executed,
+		)
+	}
+	if len(imageTrace.Fallbacks) != 0 {
+		t.Fatalf("image fallbacks = %+v, want none", imageTrace.Fallbacks)
+	}
+}
+
+func TestRouterGenerateUndeclaredOutputsKeepsDeclaredOrder(t *testing.T) {
+	assembly := assemblyWithProviders(t, map[string]inference.ProviderDefinition{
+		"provider.first":  providerDefinition(t, "first", false),
+		"provider.second": providerDefinition(t, "second", false),
+	})
+	policy := Policy{
+		Generate: []Pool{
+			{Tier: "primary", Targets: []Target{{
+				Model: inference.ModelRef{
+					ID: inference.ModelID{Provider: "first", Name: "model-1"},
+				},
+			}}},
+			{Tier: "fallback", Targets: []Target{{
+				Model: inference.ModelRef{
+					ID: inference.ModelID{Provider: "second", Name: "model-1"},
+				},
+			}}},
+		},
+	}
+	router, err := New(assembly, policy.Selectors(assembly))
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	response, trace, err := router.Generate(context.Background(), routeRequest())
+	if err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+	if response.Usage.TotalTokens != 7 {
+		t.Fatalf("usage = %+v", response.Usage)
+	}
+	if trace.Executed.ID.Provider != "first" {
+		t.Fatalf(
+			"executed = %+v, want the first declared target (undeclared outputs do not filter)",
+			trace.Executed,
+		)
+	}
+}
+
+func TestRouterGenerateDedupsRepeatedModelsAcrossTiers(t *testing.T) {
+	assembly := assemblyWithProviders(t, map[string]inference.ProviderDefinition{
+		"provider.bad": providerDefinition(t, "bad", true),
+		"provider.good": providerDefinitionWithOutputs(
+			t, "good", false,
+			[]message.PartKind{message.PartText},
+			routeDecode(),
+		),
+	})
+	repeated := inference.ModelRef{
+		ID: inference.ModelID{Provider: "bad", Name: "model-1"},
+	}
+	good := inference.ModelRef{
+		ID: inference.ModelID{Provider: "good", Name: "model-1"},
+	}
+	policy := Policy{
+		Generate: []Pool{
+			{Tier: "high", Targets: []Target{{Model: repeated}}},
+			{Tier: "medium", Targets: []Target{{Model: repeated}}},
+			{Tier: "low", Targets: []Target{{Model: repeated}}},
+			{Tier: "image", Targets: []Target{{Model: good}}},
+		},
+		Retry: &RetryConfig{
+			Generate: &RetryPolicyConfig{
+				MaxAttempts:              1,
+				Retryable:                []RetryableClass{RetryableUnavailable},
+				FallbackOnRetryExhausted: true,
+			},
+		},
+	}
+	options, err := policy.Options()
+	if err != nil {
+		t.Fatalf("Options: %v", err)
+	}
+	router, err := New(assembly, policy.Selectors(assembly), options...)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	response, trace, err := router.Generate(context.Background(), routeRequest())
+	if err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+	if response.Usage.TotalTokens != 7 {
+		t.Fatalf("usage = %+v, want fallback response", response.Usage)
+	}
+	if len(trace.Fallbacks) != 1 ||
+		trace.Fallbacks[0].From.ID.Provider != "bad" ||
+		trace.Fallbacks[0].To.ID.Provider != "good" {
+		t.Fatalf(
+			"fallbacks = %+v, want one hop from the repeated model to the distinct target",
+			trace.Fallbacks,
+		)
+	}
+	if trace.Executed.ID.Provider != "good" {
+		t.Fatalf(
+			"executed = %+v, want the distinct good target",
+			trace.Executed,
+		)
+	}
+	badExecutions := 0
+	for _, attempt := range trace.Attempts {
+		if attempt.Phase != AttemptPhaseExecute {
+			continue
+		}
+		if attempt.Target.ID.Provider == "bad" {
+			badExecutions++
+		}
+	}
+	if badExecutions != 1 {
+		t.Fatalf(
+			"bad model executed %d times, want exactly once (duplicates collapsed)",
+			badExecutions,
+		)
+	}
+}
+
+func TestRouterGenerateNoRouteWhenNoDeclaredTargetServesIntent(t *testing.T) {
+	assembly := assemblyWithProviders(t, map[string]inference.ProviderDefinition{
+		"provider.text": providerDefinitionWithOutputs(
+			t, "text", false,
+			[]message.PartKind{message.PartText},
+			routeDecode(),
+		),
+	})
+	policy := Policy{
+		Generate: []Pool{
+			{Tier: "text", Targets: []Target{{
+				Model: inference.ModelRef{
+					ID: inference.ModelID{Provider: "text", Name: "model-1"},
+				},
+			}}},
+		},
+	}
+	router, err := New(assembly, policy.Selectors(assembly))
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	request := routeRequest()
+	request.Input.Content.Intent = inference.Intent{Image: &inference.ImageIntent{}}
+	if _, _, err := router.Generate(context.Background(), request); !IsKind(err, NoRoute) {
+		t.Fatalf("Generate = %v, want no-route", err)
 	}
 }
 
@@ -785,7 +1040,7 @@ func TestRouterTranscribeSessionRetriesOpen(t *testing.T) {
 	}
 	router, err := New(
 		assembly,
-		policy.Selectors(),
+		policy.Selectors(assembly),
 		append(options, noopSleeper())...,
 	)
 	if err != nil {
@@ -847,7 +1102,7 @@ func TestRouterTranscribeSessionFallsBackAfterRetryExhausted(t *testing.T) {
 	}
 	router, err := New(
 		assembly,
-		policy.Selectors(),
+		policy.Selectors(assembly),
 		append(options, noopSleeper())...,
 	)
 	if err != nil {
@@ -893,7 +1148,7 @@ func TestRouterTranscribeSessionCircuitBreakerSkipsOpenTarget(t *testing.T) {
 	}
 	router, err := New(
 		assembly,
-		policy.Selectors(),
+		policy.Selectors(assembly),
 		append(options, noopSleeper())...,
 	)
 	if err != nil {

--- a/core/inference/route/router_policy.go
+++ b/core/inference/route/router_policy.go
@@ -3,25 +3,33 @@ package route
 import (
 	"context"
 	"fmt"
+	"slices"
 
 	"github.com/GizClaw/flowcraft/core/inference"
+	"github.com/GizClaw/flowcraft/core/message"
 )
 
 // Selectors derives routing behavior from the policy using declared order:
-// every selector picks the first target of the operation's first pool, and
-// every fallback policy advances to the next declared target, crossing pool
-// boundaries. Scores remain deployment metadata for custom selectors and do
-// not affect this behavior. The Transcription pools serve both the unary
-// Transcribe selector and the transcription session selector.
+// every selector picks the first compatible target of the operation's pools,
+// and every fallback policy advances to the next declared target, crossing
+// pool boundaries. Generate selection consults assembly descriptors and skips
+// targets whose declared output capabilities cannot serve the request intent;
+// Embed/Transcribe selection stays order-based. Repeated model references
+// across tiers are collapsed at build time so fallback never returns a
+// previously attempted target. Scores remain deployment metadata for custom
+// selectors and do not affect this behavior. The Transcription pools serve
+// both the unary Transcribe selector and the transcription session selector.
 //
 // The returned Selectors hold flattened copies of the policy's targets, so
 // later mutation of the Policy does not affect routing. An operation with no
 // configured pools yields selectors that fail with NoRoute at call time;
 // callers are expected to Validate (or ValidateFor) the policy first.
-func (p Policy) Selectors() Selectors {
-	generate := newPolicyRoute(inference.OperationGenerate, p.Generate)
-	embed := newPolicyRoute(inference.OperationEmbed, p.Embed)
-	transcribe := newPolicyRoute(inference.OperationTranscription, p.Transcription)
+// assembly is the same inference assembly the router executes against; it may
+// be nil to disable capability filtering (order-only selection).
+func (p Policy) Selectors(assembly *inference.Assembly) Selectors {
+	generate := newPolicyRoute(inference.OperationGenerate, p.Generate, assembly)
+	embed := newPolicyRoute(inference.OperationEmbed, p.Embed, assembly)
+	transcribe := newPolicyRoute(inference.OperationTranscription, p.Transcription, assembly)
 	return Selectors{
 		Generate:                  generate,
 		GenerateFallback:          generate,
@@ -39,6 +47,7 @@ func (p Policy) Selectors() Selectors {
 type policyRoute struct {
 	operation inference.Operation
 	targets   []policyTarget
+	target    *inference.Assembly
 }
 
 type policyTarget struct {
@@ -49,10 +58,16 @@ type policyTarget struct {
 func newPolicyRoute(
 	operation inference.Operation,
 	pools []Pool,
+	assembly *inference.Assembly,
 ) *policyRoute {
-	route := &policyRoute{operation: operation}
+	route := &policyRoute{operation: operation, target: assembly}
+	seen := make(map[inference.ModelRef]struct{})
 	for _, pool := range pools {
 		for _, target := range pool.Targets {
+			if _, ok := seen[target.Model]; ok {
+				continue
+			}
+			seen[target.Model] = struct{}{}
 			route.targets = append(route.targets, policyTarget{
 				tier:  pool.Tier,
 				model: target.Model,
@@ -98,10 +113,69 @@ func (r *policyRoute) nextTarget(
 }
 
 func (r *policyRoute) SelectGenerate(
-	context.Context,
-	inference.GenerateRequest,
+	_ context.Context,
+	request inference.GenerateRequest,
 ) (Decision, error) {
-	return r.selectTarget()
+	if len(r.targets) == 0 {
+		return Decision{}, NewError(
+			NoRoute,
+			r.operation,
+			fmt.Errorf("route policy has no %s pools", r.operation),
+		)
+	}
+	requested := request.Input.Content.Intent.OutputKinds()
+	for _, target := range r.targets {
+		supported, err := r.supportsOutputs(target.model, requested)
+		if err != nil {
+			return Decision{}, err
+		}
+		if !supported {
+			continue
+		}
+		return Decision{
+			Operation: r.operation,
+			Tier:      target.tier,
+			Proposed:  target.model,
+			Selected:  target.model,
+		}, nil
+	}
+	return Decision{}, NewError(
+		NoRoute,
+		r.operation,
+		fmt.Errorf(
+			"no %s pool target declares output kinds %v",
+			r.operation,
+			requested,
+		),
+	)
+}
+
+// supportsOutputs reports whether the model can serve every requested output
+// kind. Targets whose descriptor declares no output capabilities are treated
+// as undeclared rather than unsupported: filtering would break deployments
+// until every provider publishes capabilities, and preflight remains the
+// final arbiter for undeclared models.
+func (r *policyRoute) supportsOutputs(
+	model inference.ModelRef,
+	requested []message.PartKind,
+) (bool, error) {
+	if r.target == nil || len(requested) == 0 {
+		return true, nil
+	}
+	descriptor, err := r.target.InspectModel(model)
+	if err != nil {
+		return false, err
+	}
+	outputs := descriptor.Capabilities.Outputs
+	if len(outputs) == 0 {
+		return true, nil
+	}
+	for _, kind := range requested {
+		if !slices.Contains(outputs, kind) {
+			return false, nil
+		}
+	}
+	return true, nil
 }
 
 func (r *policyRoute) NextGenerate(

--- a/core/message/parts.go
+++ b/core/message/parts.go
@@ -22,6 +22,17 @@ const (
 	PartReasoning  PartKind = "reasoning"
 )
 
+// Validate reports whether k is one of the canonical content part kinds.
+func (k PartKind) Validate() error {
+	switch k {
+	case PartText, PartImage, PartAudio, PartVideo, PartFile, PartData,
+		PartToolCall, PartToolResult, PartReasoning:
+		return nil
+	default:
+		return fmt.Errorf("unknown content part kind %q", k)
+	}
+}
+
 // Part is the sealed canonical content union. Each operation validates which
 // kinds it accepts; for example, Embed currently accepts only text and image.
 type Part interface {

--- a/core/message/parts_test.go
+++ b/core/message/parts_test.go
@@ -415,3 +415,24 @@ func TestNormalizePart(t *testing.T) {
 		}
 	})
 }
+
+func TestPartKindValidate(t *testing.T) {
+	for _, kind := range []message.PartKind{
+		message.PartText,
+		message.PartImage,
+		message.PartAudio,
+		message.PartVideo,
+		message.PartFile,
+		message.PartData,
+		message.PartToolCall,
+		message.PartToolResult,
+		message.PartReasoning,
+	} {
+		if err := kind.Validate(); err != nil {
+			t.Fatalf("kind %q: %v", kind, err)
+		}
+	}
+	if err := (message.PartKind("audio_cassette")).Validate(); err == nil {
+		t.Fatal("unknown kind unexpectedly accepted")
+	}
+}

--- a/driver/openai/catalog.go
+++ b/driver/openai/catalog.go
@@ -1,8 +1,19 @@
 package openai
 
-import "maps"
+import (
+	"fmt"
+	"maps"
+	"slices"
 
-// modelKind classifies catalog models by the operation family they serve.
+	"github.com/GizClaw/flowcraft/core/inference"
+	"github.com/GizClaw/flowcraft/core/message"
+)
+
+// modelKind classifies catalog models by the compiler family that serves
+// them. It is an implementation discriminator — which wire compiler to bind —
+// not a capability declaration: the content kinds a model serves are declared
+// explicitly in catalogEntry.capabilities and validated against the family
+// contract in validate.
 type modelKind string
 
 const (
@@ -20,17 +31,18 @@ const (
 	apiChat      apiMode = "chat"
 )
 
-// catalogEntry is one model in the built-in catalog. Capability flags mirror
-// ModelSpec so deployment-declared models behave identically.
+// catalogEntry is one model in the built-in catalog. capabilities is the
+// single capability fact source: input/output content kinds, hosted web
+// search, and the reasoning control capability. dimensions is the one
+// remaining control capability that no capability kind expresses (embed
+// custom output dimensions) and stays a separate flag. ModelSpec mirrors this
+// shape so deployment-declared models behave identically.
 type catalogEntry struct {
-	kind      modelKind
-	api       apiMode
-	vision    bool
-	reasoning bool
-	// webSearch (generate) accepts the hosted web_search tool. Model
-	// support is per model per the OpenAI model documentation; see
-	// https://developers.openai.com/api/docs/models.
-	webSearch   bool
+	kind         modelKind
+	api          apiMode
+	capabilities inference.ModelCapabilities
+	// dimensions (embed) allows custom output dimensions. Control
+	// capability, likewise not a content kind.
 	dimensions  bool
 	deprecated  bool
 	replacement string
@@ -41,40 +53,112 @@ type catalogEntry struct {
 	maxInputTokens int
 }
 
+// validate enforces the family contract: the compiler bound by kind can only
+// serve the output modalities it produces, so kind and capabilities cannot
+// drift.
+func (e catalogEntry) validate() error {
+	if err := e.capabilities.Validate(); err != nil {
+		return err
+	}
+	switch e.kind {
+	case kindGenerate:
+		if !slices.Contains(e.capabilities.Outputs, message.PartText) {
+			return fmt.Errorf("generate family must declare text output")
+		}
+	case kindImage:
+		if !slices.Contains(e.capabilities.Outputs, message.PartImage) {
+			return fmt.Errorf("image family must declare image output")
+		}
+	case kindTTS:
+		if !slices.Contains(e.capabilities.Outputs, message.PartAudio) {
+			return fmt.Errorf("tts family must declare audio output")
+		}
+	case kindEmbed:
+		if len(e.capabilities.Outputs) != 0 {
+			return fmt.Errorf("embed family declares no generate output")
+		}
+	}
+	return nil
+}
+
+// generateChatCapabilities is the common capability declaration for the
+// text chat/responses compiler family. Individual entries add image input
+// when the model has vision and the reasoning kind when the model reasons;
+// hosted web search rides on the capabilities bit.
+func generateChatCapabilities() inference.ModelCapabilities {
+	return inference.ModelCapabilities{
+		Inputs: []message.PartKind{
+			message.PartText,
+			message.PartData,
+			message.PartToolCall,
+			message.PartToolResult,
+		},
+		Outputs: []message.PartKind{message.PartText},
+	}
+}
+
 // catalog is the built-in model list, aligned with the OpenAI model lineup
 // of July 2026 (GPT-5.6 family flagship). Deployments extend or override it
 // via Spec.Models.
 var catalog = map[string]catalogEntry{
 	// Generate — GPT-5.6 flagship family (reasoning + vision).
-	"gpt-5.6-sol":   {kind: kindGenerate, vision: true, reasoning: true, webSearch: true, maxInputTokens: 1_050_000},
-	"gpt-5.6-terra": {kind: kindGenerate, vision: true, reasoning: true, webSearch: true, maxInputTokens: 1_050_000},
-	"gpt-5.6-luna":  {kind: kindGenerate, vision: true, reasoning: true, webSearch: true, maxInputTokens: 1_050_000},
+	"gpt-5.6-sol": {
+		kind:           kindGenerate,
+		capabilities:   generateChatCapabilities().WithInputs(message.PartImage).WithHostedWebSearch().WithReasoning(inference.ReasoningAlways),
+		maxInputTokens: 1_050_000,
+	},
+	"gpt-5.6-terra": {
+		kind:           kindGenerate,
+		capabilities:   generateChatCapabilities().WithInputs(message.PartImage).WithHostedWebSearch().WithReasoning(inference.ReasoningAlways),
+		maxInputTokens: 1_050_000,
+	},
+	"gpt-5.6-luna": {
+		kind:           kindGenerate,
+		capabilities:   generateChatCapabilities().WithInputs(message.PartImage).WithHostedWebSearch().WithReasoning(inference.ReasoningAlways),
+		maxInputTokens: 1_050_000,
+	},
 	// Generate — previous generations, superseded but available.
 	"gpt-5.5": {
-		kind: kindGenerate, vision: true, reasoning: true, webSearch: true,
-		deprecated: true, replacement: "gpt-5.6-sol",
+		kind:         kindGenerate,
+		capabilities: generateChatCapabilities().WithInputs(message.PartImage).WithHostedWebSearch().WithReasoning(inference.ReasoningAlways),
+		deprecated:   true, replacement: "gpt-5.6-sol",
 		maxInputTokens: 1_050_000,
 	},
 	"gpt-5.4": {
-		kind: kindGenerate, vision: true, reasoning: true, webSearch: true,
-		deprecated: true, replacement: "gpt-5.6-sol",
+		kind:         kindGenerate,
+		capabilities: generateChatCapabilities().WithInputs(message.PartImage).WithHostedWebSearch().WithReasoning(inference.ReasoningAlways),
+		deprecated:   true, replacement: "gpt-5.6-sol",
 		maxInputTokens: 1_050_000,
 	},
 	"gpt-5.4-mini": {
-		kind: kindGenerate, vision: true, reasoning: true, webSearch: true,
-		deprecated: true, replacement: "gpt-5.6-terra",
+		kind:         kindGenerate,
+		capabilities: generateChatCapabilities().WithInputs(message.PartImage).WithHostedWebSearch().WithReasoning(inference.ReasoningAlways),
+		deprecated:   true, replacement: "gpt-5.6-terra",
 		maxInputTokens: 400_000,
 	},
 	"gpt-5.4-nano": {
-		kind: kindGenerate, vision: true, reasoning: true, webSearch: true,
-		deprecated: true, replacement: "gpt-5.6-luna",
+		kind:         kindGenerate,
+		capabilities: generateChatCapabilities().WithInputs(message.PartImage).WithHostedWebSearch().WithReasoning(inference.ReasoningAlways),
+		deprecated:   true, replacement: "gpt-5.6-luna",
 		maxInputTokens: 400_000,
 	},
 	// Generate — GPT-4.1 line: vision without the reasoning control.
-	"gpt-4.1":      {kind: kindGenerate, vision: true, webSearch: true, maxInputTokens: 1_047_576},
-	"gpt-4.1-mini": {kind: kindGenerate, vision: true, webSearch: true, maxInputTokens: 1_047_576},
+	"gpt-4.1": {
+		kind:           kindGenerate,
+		capabilities:   generateChatCapabilities().WithInputs(message.PartImage).WithHostedWebSearch(),
+		maxInputTokens: 1_047_576,
+	},
+	"gpt-4.1-mini": {
+		kind:           kindGenerate,
+		capabilities:   generateChatCapabilities().WithInputs(message.PartImage).WithHostedWebSearch(),
+		maxInputTokens: 1_047_576,
+	},
 	// gpt-4.1-nano has no hosted web_search tool.
-	"gpt-4.1-nano": {kind: kindGenerate, vision: true, maxInputTokens: 1_047_576},
+	"gpt-4.1-nano": {
+		kind:           kindGenerate,
+		capabilities:   generateChatCapabilities().WithInputs(message.PartImage),
+		maxInputTokens: 1_047_576,
+	},
 
 	// Embed.
 	"text-embedding-3-small": {kind: kindEmbed, dimensions: true, maxInputTokens: 8_192},
@@ -86,20 +170,39 @@ var catalog = map[string]catalogEntry{
 	},
 
 	// Image.
-	"gpt-image-2": {kind: kindImage},
+	"gpt-image-2": {
+		kind: kindImage,
+		capabilities: inference.ModelCapabilities{}.
+			WithInputs(message.PartText).
+			WithOutputs(message.PartImage),
+	},
 	"gpt-image-1": {
-		kind:       kindImage,
+		kind: kindImage,
+		capabilities: inference.ModelCapabilities{}.
+			WithInputs(message.PartText).
+			WithOutputs(message.PartImage),
 		deprecated: true, replacement: "gpt-image-2",
 	},
 
 	// TTS.
-	"gpt-4o-mini-tts": {kind: kindTTS},
+	"gpt-4o-mini-tts": {
+		kind: kindTTS,
+		capabilities: inference.ModelCapabilities{}.
+			WithInputs(message.PartText).
+			WithOutputs(message.PartAudio),
+	},
 	"tts-1": {
-		kind:       kindTTS,
+		kind: kindTTS,
+		capabilities: inference.ModelCapabilities{}.
+			WithInputs(message.PartText).
+			WithOutputs(message.PartAudio),
 		deprecated: true, replacement: "gpt-4o-mini-tts",
 	},
 	"tts-1-hd": {
-		kind:       kindTTS,
+		kind: kindTTS,
+		capabilities: inference.ModelCapabilities{}.
+			WithInputs(message.PartText).
+			WithOutputs(message.PartAudio),
 		deprecated: true, replacement: "gpt-4o-mini-tts",
 	},
 }
@@ -111,11 +214,14 @@ func mergedCatalog(spec Spec) (map[string]catalogEntry, error) {
 	maps.Copy(models, catalog)
 	for _, model := range spec.Models {
 		models[model.Name] = catalogEntry{
-			kind:       modelKind(model.Kind),
-			vision:     model.Vision,
-			reasoning:  model.Reasoning,
-			webSearch:  model.WebSearch,
-			dimensions: model.Dimensions,
+			kind:         modelKind(model.Kind),
+			capabilities: model.Capabilities,
+			dimensions:   model.Dimensions,
+		}
+	}
+	for name, entry := range models {
+		if err := entry.validate(); err != nil {
+			return nil, fmt.Errorf("catalog model %q: %w", name, err)
 		}
 	}
 	return models, nil

--- a/driver/openai/catalog_test.go
+++ b/driver/openai/catalog_test.go
@@ -1,9 +1,12 @@
 package openai
 
 import (
+	"reflect"
+	"slices"
 	"testing"
 
 	"github.com/GizClaw/flowcraft/core/inference"
+	"github.com/GizClaw/flowcraft/core/message"
 )
 
 func TestCatalogDeclaresMaxInputTokens(t *testing.T) {
@@ -43,5 +46,101 @@ func TestCatalogDeclaresMaxInputTokens(t *testing.T) {
 			t.Errorf("model %q: max input tokens = %v, want %d",
 				name, descriptor.Limits.MaxInputTokens, want)
 		}
+	}
+}
+
+func TestCatalogPublishesCapabilities(t *testing.T) {
+	provider, err := buildProvider(ResourceSettings{ID: "openai"})
+	if err != nil {
+		t.Fatalf("buildProvider: %v", err)
+	}
+	descriptors := make(map[string]inference.ModelDescriptor, len(provider.Models))
+	for _, model := range provider.Models {
+		descriptors[model.Descriptor.ID.Name] = model.Descriptor
+	}
+
+	flagship := descriptors["gpt-5.6-sol"]
+	if !reflect.DeepEqual(
+		flagship.Capabilities.Outputs,
+		[]message.PartKind{message.PartText},
+	) {
+		t.Fatalf("gpt-5.6-sol outputs = %v, want text", flagship.Capabilities.Outputs)
+	}
+	if !slices.Contains(flagship.Capabilities.Inputs, message.PartImage) {
+		t.Fatalf("gpt-5.6-sol inputs = %v, want image input", flagship.Capabilities.Inputs)
+	}
+	if !flagship.Capabilities.HostedWebSearch {
+		t.Fatal("gpt-5.6-sol must declare hosted web search")
+	}
+	if flagship.Capabilities.Reasoning != inference.ReasoningAlways {
+		t.Fatalf(
+			"gpt-5.6-sol reasoning = %q, want always",
+			flagship.Capabilities.Reasoning,
+		)
+	}
+
+	nano := descriptors["gpt-4.1-nano"]
+	if nano.Capabilities.HostedWebSearch {
+		t.Fatal("gpt-4.1-nano must not declare hosted web search")
+	}
+	if !slices.Contains(nano.Capabilities.Inputs, message.PartImage) {
+		t.Fatalf("gpt-4.1-nano inputs = %v, want image input", nano.Capabilities.Inputs)
+	}
+	if nano.Capabilities.Reasoning != inference.ReasoningNone {
+		t.Fatalf(
+			"gpt-4.1-nano reasoning = %q, want none",
+			nano.Capabilities.Reasoning,
+		)
+	}
+
+	image := descriptors["gpt-image-2"]
+	if !reflect.DeepEqual(
+		image.Capabilities.Outputs,
+		[]message.PartKind{message.PartImage},
+	) || !reflect.DeepEqual(
+		image.Capabilities.Inputs,
+		[]message.PartKind{message.PartText},
+	) {
+		t.Fatalf("gpt-image-2 capabilities = %+v", image.Capabilities)
+	}
+
+	tts := descriptors["gpt-4o-mini-tts"]
+	if !reflect.DeepEqual(
+		tts.Capabilities.Outputs,
+		[]message.PartKind{message.PartAudio},
+	) {
+		t.Fatalf("gpt-4o-mini-tts outputs = %v, want audio", tts.Capabilities.Outputs)
+	}
+
+	embed := descriptors["text-embedding-3-small"]
+	if len(embed.Capabilities.Outputs) != 0 {
+		t.Fatalf("embed model outputs = %v, want none", embed.Capabilities.Outputs)
+	}
+}
+
+func TestMergedCatalogRejectsFamilyContractViolation(t *testing.T) {
+	cases := []struct {
+		name string
+		spec string
+	}{
+		{"image without image output",
+			`{"models":[{"name":"m","kind":"image","capabilities":{"outputs":["text"]}}]}`},
+		{"generate without text output",
+			`{"models":[{"name":"m","kind":"generate"}]}`},
+		{"tts without audio output",
+			`{"models":[{"name":"m","kind":"tts","capabilities":{"outputs":["text"]}}]}`},
+		{"embed with generate output",
+			`{"models":[{"name":"m","kind":"embed","capabilities":{"outputs":["text"]}}]}`},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			spec, err := decodeSpec([]byte(tc.spec))
+			if err != nil {
+				t.Fatalf("decodeSpec: %v", err)
+			}
+			if _, err := mergedCatalog(spec); err == nil {
+				t.Fatal("mergedCatalog unexpectedly accepted contract violation")
+			}
+		})
 	}
 }

--- a/driver/openai/conformance_test.go
+++ b/driver/openai/conformance_test.go
@@ -266,7 +266,7 @@ func TestConformanceGenerateDataPartLowersToText(t *testing.T) {
 // a complete ledger on plain text.
 func TestConformanceGenerateCompilerPlainModel(t *testing.T) {
 	spec, err := decodeSpec([]byte(
-		`{"models":[{"name":"my-plain-model","kind":"generate"}]}`,
+		`{"models":[{"name":"my-plain-model","kind":"generate","capabilities":{"outputs":["text"]}}]}`,
 	))
 	if err != nil {
 		t.Fatalf("decodeSpec: %v", err)

--- a/driver/openai/generate.go
+++ b/driver/openai/generate.go
@@ -5,6 +5,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"slices"
 	"strings"
 
 	"github.com/GizClaw/flowcraft/core/inference"
@@ -320,9 +321,10 @@ func compileGenerate(
 			request.ActiveFieldsFor(shape),
 		)
 		wire := generateWire{
-			model:            model,
-			stream:           shape == inference.GenerateExecutionStream,
-			includeReasoning: entry.reasoning && entry.api != apiChat,
+			model:  model,
+			stream: shape == inference.GenerateExecutionStream,
+			includeReasoning: entry.capabilities.Reasoning != inference.ReasoningNone &&
+				entry.api != apiChat,
 		}
 
 		// Context messages → items. System stays a native system-role item;
@@ -377,7 +379,7 @@ func compileGenerateOptions(
 		)
 		return
 	}
-	if !entry.webSearch {
+	if !entry.capabilities.HostedWebSearch {
 		ledger.reject(
 			inference.ExtensionField("web_search").Qualify(options),
 			"model does not support hosted web search",
@@ -427,7 +429,7 @@ func compileMessage(
 		case message.TextPart:
 			content = append(content, wireContent{kind: wireContentText, text: value.Text})
 		case message.ImagePart:
-			if !entry.vision {
+			if !slices.Contains(entry.capabilities.Inputs, message.PartImage) {
 				ledger.reject(fields[message.PartImage], "model does not accept image input")
 				continue
 			}
@@ -487,7 +489,7 @@ func compileReasoning(
 		ledger.reject(field, "reasoning parts belong to assistant context")
 		return
 	}
-	if !entry.reasoning {
+	if entry.capabilities.Reasoning == inference.ReasoningNone {
 		ledger.drop(field, "model has no reasoning channel")
 		return
 	}
@@ -602,21 +604,30 @@ func compileIntent(
 	wire.topP = text.TopP
 	if text.ReasoningEnabled != nil {
 		switch {
-		case !entry.reasoning:
+		case entry.capabilities.Reasoning == inference.ReasoningNone:
 			ledger.reject(
 				inference.FieldGenerateIntentReasoningEnabled,
 				"model has no reasoning to switch",
 			)
-		case !*text.ReasoningEnabled:
+		case entry.capabilities.Reasoning == inference.ReasoningAlways &&
+			!*text.ReasoningEnabled:
 			ledger.reject(
 				inference.FieldGenerateIntentReasoningEnabled,
 				"openai reasoning models cannot disable reasoning",
+			)
+		case entry.capabilities.Reasoning == inference.ReasoningToggle &&
+			!*text.ReasoningEnabled:
+			// No OpenAI surface exposes a reasoning-off switch yet; reject
+			// until a toggle-capable model and wire channel land.
+			ledger.reject(
+				inference.FieldGenerateIntentReasoningEnabled,
+				"reasoning cannot be disabled through this provider",
 			)
 		}
 		// enabled == true is a no-op: reasoning models reason by default.
 	}
 	if text.ReasoningEffort != "" {
-		if !entry.reasoning {
+		if entry.capabilities.Reasoning == inference.ReasoningNone {
 			ledger.reject(
 				inference.FieldGenerateIntentReasoningEffort,
 				"model has no reasoning effort control",

--- a/driver/openai/generate_chat_test.go
+++ b/driver/openai/generate_chat_test.go
@@ -19,7 +19,9 @@ func TestChatCompileRejectsWebSearch(t *testing.T) {
 		GenerateOptions{WebSearch: &GenerateWebSearch{}},
 	}
 	compiled, err := compileGenerate("gpt-5.6-sol", catalogEntry{
-		kind: kindGenerate, api: apiChat, webSearch: true,
+		kind:         kindGenerate,
+		api:          apiChat,
+		capabilities: inference.ModelCapabilities{HostedWebSearch: true},
 	})(context.Background(), openaiModel("gpt-5.6-sol"), request, inference.GenerateExecutionUnary)
 	if err == nil || !strings.Contains(err.Error(), "web_search") {
 		t.Fatalf("compile error = %v, want web_search rejection", err)

--- a/driver/openai/generate_openai_test.go
+++ b/driver/openai/generate_openai_test.go
@@ -274,7 +274,7 @@ func TestFactoryCustomModelWebSearchCapability(t *testing.T) {
 	input := ResourceSettings{
 		ID: "openai",
 		Spec: json.RawMessage(
-			`{"models":[{"name":"my-search","kind":"generate","web_search":true}]}`,
+			`{"models":[{"name":"my-search","kind":"generate","capabilities":{"hosted_web_search":true,"outputs":["text"]}}]}`,
 		),
 		Profiles: []ProfileSettings{{
 			ID:      "default",
@@ -610,7 +610,7 @@ func TestCompileReasoningDispositions(t *testing.T) {
 
 	t.Run("reasoning on model without reasoning channel drops", func(t *testing.T) {
 		spec, err := decodeSpec([]byte(
-			`{"models":[{"name":"my-plain-model","kind":"generate"}]}`,
+			`{"models":[{"name":"my-plain-model","kind":"generate","capabilities":{"outputs":["text"]}}]}`,
 		))
 		if err != nil {
 			t.Fatalf("decodeSpec: %v", err)

--- a/driver/openai/resource.go
+++ b/driver/openai/resource.go
@@ -121,10 +121,8 @@ func buildProvider(settings ResourceSettings) (inference.ProviderDefinition, err
 		entry.api = spec.apiMode()
 		id := inference.ModelID{Provider: settings.ID, Name: name}
 		descriptor := inference.ModelDescriptor{
-			ID: id,
-			Capabilities: inference.ModelCapabilities{
-				HostedWebSearch: entry.webSearch,
-			},
+			ID:           id,
+			Capabilities: entry.capabilities,
 		}
 		if entry.deprecated {
 			descriptor.Lifecycle.Status = inference.ModelStatusDeprecated

--- a/driver/openai/spec.go
+++ b/driver/openai/spec.go
@@ -5,6 +5,7 @@ import (
 	"regexp"
 	"strings"
 
+	"github.com/GizClaw/flowcraft/core/inference"
 	"github.com/GizClaw/flowcraft/core/resource"
 )
 
@@ -40,17 +41,17 @@ type Spec struct {
 	Models []ModelSpec `json:"models,omitempty"`
 }
 
-// ModelSpec declares one model outside the built-in catalog. Capability
-// flags are only meaningful for the matching kind.
+// ModelSpec declares one model outside the built-in catalog. Capabilities
+// mirror the built-in catalog shape: content kinds, hosted web search, and
+// the reasoning control capability (validated against the kind's compiler
+// contract at merge time). Dimensions is the one control capability that no
+// capability kind expresses and stays a separate flag.
 type ModelSpec struct {
 	Name string `json:"name"`
 	Kind string `json:"kind"`
-	// Vision (generate) allows image input parts.
-	Vision bool `json:"vision,omitempty"`
-	// Reasoning (generate) enables the reasoning effort control.
-	Reasoning bool `json:"reasoning,omitempty"`
-	// WebSearch (generate) enables the hosted web_search tool.
-	WebSearch bool `json:"web_search,omitempty"`
+	// Capabilities declares the model's input/output content kinds, hosted
+	// web search support, and reasoning control capability.
+	Capabilities inference.ModelCapabilities `json:"capabilities,omitempty"`
 	// Dimensions (embed) allows custom output dimensions.
 	Dimensions bool `json:"dimensions,omitempty"`
 }
@@ -111,7 +112,7 @@ func (m ModelSpec) Validate() error {
 	default:
 		return fmt.Errorf("model %q has unknown kind %q", m.Name, m.Kind)
 	}
-	return nil
+	return m.Capabilities.Validate()
 }
 
 func decodeSpec(raw []byte) (Spec, error) {


### PR DESCRIPTION
## Summary

Implements capability-aware routing for mixed-modality deployments (issue #384).

- **core/inference**: `ModelCapabilities` now declares input/output content kinds (`message.PartKind`), a `ReasoningKind` control capability, and fluent `With*` composition methods. `PartKind.Validate` and `Intent.OutputKinds` centralize the content vocabulary shared by response validation and routing.
- **core/inference/route**: generate selection inspects model descriptors and skips targets whose declared outputs cannot serve the request intent; repeated model references across tiers are collapsed at build time so fallback no longer deadlocks with `fallback_contract_violation`.
- **driver/openai**: catalog and `Spec.Models` declare explicit capabilities (inputs / outputs / hosted web search / reasoning). The old `vision`, `web_search`, and `reasoning` spec flags are removed; `kind` stays as the compiler-family discriminator with a contract check against declared outputs.

## Behavior

- An `ImageIntent` now routes directly to a model declaring image output (e.g. `gpt-image-2`) instead of failing preflight on a text model.
- Empty (undeclared) capabilities keep order-based selection; preflight remains the final arbiter until every provider publishes declarations.
- Breaking config change: `Spec.Models` `vision` / `web_search` / `reasoning` move into `capabilities`, e.g. `{"capabilities":{"inputs":["text","image"],"outputs":["text"],"hosted_web_search":true,"reasoning":"always"}}`.

## Commits

- feat(core): declare model content capabilities and reasoning kind
- feat(core): route generate by declared output capabilities
- feat(driver/openai): declare explicit model capabilities

Closes #384