### PR TITLE
feat(driver/*): declare model capabilities across all providers

### DIFF
--- a/driver/anthropic/catalog.go
+++ b/driver/anthropic/catalog.go
@@ -1,66 +1,145 @@
 package anthropic
 
-import "maps"
+import (
+	"fmt"
+	"maps"
+	"slices"
+
+	"github.com/GizClaw/flowcraft/core/inference"
+	"github.com/GizClaw/flowcraft/core/message"
+)
 
 // catalogEntry describes one model's compile-time capabilities.
+// capabilities is the single capability fact source: input/output content
+// kinds and the reasoning control capability. reasoningLevels is a control
+// capability that no capability kind expresses and stays a separate flag.
 type catalogEntry struct {
-	vision           bool
-	reasoning        bool
-	deprecated       bool
-	replacement      string
-	reasoningLevels  bool
-	reasoningDisable bool
+	capabilities inference.ModelCapabilities
+	// reasoningLevels marks models whose thinking endpoint accepts effort
+	// levels; models without it enable thinking at platform-chosen depth.
+	reasoningLevels bool
+	deprecated      bool
+	replacement     string
 	// maxInputTokens caps the input context (system + messages + tools)
 	// in tokens; zero means undeclared. Values mirror the context window
 	// published on https://platform.claude.com/docs/en/about-claude/models.
 	maxInputTokens int
 }
 
+// validate enforces the generate family contract: Claude compilers only
+// serve text output.
+func (e catalogEntry) validate() error {
+	if err := e.capabilities.Validate(); err != nil {
+		return err
+	}
+	if !slices.Contains(e.capabilities.Outputs, message.PartText) {
+		return fmt.Errorf("generate family must declare text output")
+	}
+	return nil
+}
+
+// generateChatCapabilities is the common capability declaration for the
+// Claude text compiler family.
+func generateChatCapabilities() inference.ModelCapabilities {
+	return inference.ModelCapabilities{
+		Inputs: []message.PartKind{
+			message.PartText,
+			message.PartData,
+			message.PartToolCall,
+			message.PartToolResult,
+		},
+		Outputs: []message.PartKind{message.PartText},
+	}
+}
+
 // catalog is the built-in model list, aligned with the Claude lineup of
-// July 2026.
+// July 2026. Fable 5 and Mythos 5 keep adaptive thinking always on (the API
+// rejects thinking: disabled); the rest of the family can toggle thinking.
 var catalog = map[string]catalogEntry{
-	"claude-fable-5":  {vision: true, reasoning: true, reasoningLevels: true, reasoningDisable: true, maxInputTokens: 1_000_000},
-	"claude-opus-5":   {vision: true, reasoning: true, reasoningLevels: true, reasoningDisable: true, maxInputTokens: 1_000_000},
-	"claude-sonnet-5": {vision: true, reasoning: true, reasoningLevels: true, reasoningDisable: true, maxInputTokens: 1_000_000},
+	"claude-fable-5": {
+		capabilities: generateChatCapabilities().
+			WithInputs(message.PartImage).
+			WithReasoning(inference.ReasoningAlways),
+		reasoningLevels: true,
+		maxInputTokens:  1_000_000,
+	},
+	// claude-mythos-5 shares Fable 5's capabilities and always-on adaptive
+	// thinking; it is a limited-release model (Project Glasswing), so
+	// deployments must supply access explicitly.
+	"claude-mythos-5": {
+		capabilities: generateChatCapabilities().
+			WithInputs(message.PartImage).
+			WithReasoning(inference.ReasoningAlways),
+		reasoningLevels: true,
+		maxInputTokens:  1_000_000,
+	},
+	"claude-opus-5": {
+		capabilities: generateChatCapabilities().
+			WithInputs(message.PartImage).
+			WithReasoning(inference.ReasoningToggle),
+		reasoningLevels: true,
+		maxInputTokens:  1_000_000,
+	},
+	"claude-sonnet-5": {
+		capabilities: generateChatCapabilities().
+			WithInputs(message.PartImage).
+			WithReasoning(inference.ReasoningToggle),
+		reasoningLevels: true,
+		maxInputTokens:  1_000_000,
+	},
 	"claude-haiku-4-5": {
-		vision: true, reasoning: true,
-		reasoningLevels: true, reasoningDisable: true,
-		maxInputTokens: 200_000,
+		capabilities: generateChatCapabilities().
+			WithInputs(message.PartImage).
+			WithReasoning(inference.ReasoningToggle),
+		reasoningLevels: true,
+		maxInputTokens:  200_000,
 	},
 	"claude-haiku-4-5-20251001": {
-		vision: true, reasoning: true,
-		reasoningLevels: true, reasoningDisable: true,
-		maxInputTokens: 200_000,
+		capabilities: generateChatCapabilities().
+			WithInputs(message.PartImage).
+			WithReasoning(inference.ReasoningToggle),
+		reasoningLevels: true,
+		maxInputTokens:  200_000,
 	},
 
 	"claude-opus-4-8": {
-		vision: true, reasoning: true,
-		reasoningLevels: true, reasoningDisable: true,
-		deprecated: true, replacement: "claude-opus-5",
+		capabilities: generateChatCapabilities().
+			WithInputs(message.PartImage).
+			WithReasoning(inference.ReasoningToggle),
+		reasoningLevels: true,
+		deprecated:      true, replacement: "claude-opus-5",
 		maxInputTokens: 1_000_000,
 	},
 	"claude-opus-4-7": {
-		vision: true, reasoning: true,
-		reasoningLevels: true, reasoningDisable: true,
-		deprecated: true, replacement: "claude-opus-5",
+		capabilities: generateChatCapabilities().
+			WithInputs(message.PartImage).
+			WithReasoning(inference.ReasoningToggle),
+		reasoningLevels: true,
+		deprecated:      true, replacement: "claude-opus-5",
 		maxInputTokens: 1_000_000,
 	},
 	"claude-sonnet-4-6": {
-		vision: true, reasoning: true,
-		reasoningLevels: true, reasoningDisable: true,
-		deprecated: true, replacement: "claude-sonnet-5",
+		capabilities: generateChatCapabilities().
+			WithInputs(message.PartImage).
+			WithReasoning(inference.ReasoningToggle),
+		reasoningLevels: true,
+		deprecated:      true, replacement: "claude-sonnet-5",
 		maxInputTokens: 1_000_000,
 	},
 	"claude-sonnet-4-5": {
-		vision: true, reasoning: true,
-		reasoningLevels: true, reasoningDisable: true,
-		deprecated: true, replacement: "claude-sonnet-5",
+		capabilities: generateChatCapabilities().
+			WithInputs(message.PartImage).
+			WithReasoning(inference.ReasoningToggle),
+		reasoningLevels: true,
+		deprecated:      true, replacement: "claude-sonnet-5",
 		maxInputTokens: 200_000,
 	},
 	"claude-opus-4-1": {
-		vision: true, reasoning: true,
-		reasoningLevels: true, reasoningDisable: true,
-		deprecated: true, replacement: "claude-opus-5",
+		capabilities: generateChatCapabilities().
+			WithInputs(message.PartImage).
+			WithReasoning(inference.ReasoningToggle),
+		reasoningLevels: true,
+		deprecated:      true, replacement: "claude-opus-5",
 		maxInputTokens: 200_000,
 	},
 }
@@ -71,10 +150,12 @@ func mergedCatalog(spec Spec) (map[string]catalogEntry, error) {
 	maps.Copy(models, catalog)
 	for _, model := range spec.Models {
 		models[model.Name] = catalogEntry{
-			vision:           model.Vision,
-			reasoning:        model.Reasoning,
-			reasoningLevels:  model.Reasoning,
-			reasoningDisable: model.Reasoning,
+			capabilities: model.Capabilities,
+		}
+	}
+	for name, entry := range models {
+		if err := entry.validate(); err != nil {
+			return nil, fmt.Errorf("model %q: %w", name, err)
 		}
 	}
 	return models, nil

--- a/driver/anthropic/catalog_test.go
+++ b/driver/anthropic/catalog_test.go
@@ -1,9 +1,12 @@
 package anthropic
 
 import (
+	"reflect"
+	"slices"
 	"testing"
 
 	"github.com/GizClaw/flowcraft/core/inference"
+	"github.com/GizClaw/flowcraft/core/message"
 )
 
 func TestCatalogDeclaresMaxInputTokens(t *testing.T) {
@@ -40,5 +43,42 @@ func TestCatalogDeclaresMaxInputTokens(t *testing.T) {
 			t.Errorf("model %q: max input tokens = %v, want %d",
 				name, descriptor.Limits.MaxInputTokens, want)
 		}
+	}
+}
+
+func TestCatalogPublishesCapabilities(t *testing.T) {
+	provider, err := buildProvider(ResourceSettings{ID: "anthropic"})
+	if err != nil {
+		t.Fatalf("buildProvider: %v", err)
+	}
+	for _, model := range provider.Models {
+		capabilities := model.Descriptor.Capabilities
+		if !reflect.DeepEqual(capabilities.Outputs, []message.PartKind{message.PartText}) {
+			t.Fatalf("%s outputs = %v, want text", model.Descriptor.ID.Name, capabilities.Outputs)
+		}
+		if !slices.Contains(capabilities.Inputs, message.PartImage) {
+			t.Fatalf("%s inputs = %v, want image input", model.Descriptor.ID.Name, capabilities.Inputs)
+		}
+		want := inference.ReasoningToggle
+		switch model.Descriptor.ID.Name {
+		case "claude-fable-5", "claude-mythos-5":
+			want = inference.ReasoningAlways
+		}
+		if capabilities.Reasoning != want {
+			t.Fatalf("%s reasoning = %q, want %q",
+				model.Descriptor.ID.Name, capabilities.Reasoning, want)
+		}
+	}
+}
+
+func TestMergedCatalogRejectsMissingTextOutput(t *testing.T) {
+	spec, err := decodeSpec([]byte(
+		`{"models":[{"name":"m","capabilities":{"inputs":["text"]}}]}`,
+	))
+	if err != nil {
+		t.Fatalf("decodeSpec: %v", err)
+	}
+	if _, err := mergedCatalog(spec); err == nil {
+		t.Fatal("mergedCatalog unexpectedly accepted a model without text output")
 	}
 }

--- a/driver/anthropic/generate.go
+++ b/driver/anthropic/generate.go
@@ -5,6 +5,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"slices"
 	"strings"
 
 	"github.com/GizClaw/flowcraft/core/inference"
@@ -422,7 +423,7 @@ func compileMessage(
 		case message.TextPart:
 			wire.appendBlock(role, wireBlock{kind: wireBlockText, text: value.Text})
 		case message.ImagePart:
-			if !entry.vision {
+			if !slices.Contains(entry.capabilities.Inputs, message.PartImage) {
 				ledger.reject(fields[message.PartImage], "model does not accept image input")
 				continue
 			}
@@ -598,12 +599,13 @@ func compileIntent(
 	wire.topP = text.TopP
 	if text.ReasoningEnabled != nil {
 		switch {
-		case !entry.reasoning:
+		case entry.capabilities.Reasoning == inference.ReasoningNone:
 			ledger.reject(
 				inference.FieldGenerateIntentReasoningEnabled,
 				"model has no thinking to switch",
 			)
-		case !*text.ReasoningEnabled && !entry.reasoningDisable:
+		case entry.capabilities.Reasoning == inference.ReasoningAlways &&
+			!*text.ReasoningEnabled:
 			ledger.reject(
 				inference.FieldGenerateIntentReasoningEnabled,
 				"model cannot disable thinking",
@@ -615,7 +617,7 @@ func compileIntent(
 	}
 	if text.ReasoningEffort != "" {
 		switch {
-		case !entry.reasoning:
+		case entry.capabilities.Reasoning == inference.ReasoningNone:
 			ledger.reject(
 				inference.FieldGenerateIntentReasoningEffort,
 				"model has no reasoning effort control",

--- a/driver/anthropic/resource.go
+++ b/driver/anthropic/resource.go
@@ -94,7 +94,10 @@ func buildProvider(settings ResourceSettings) (inference.ProviderDefinition, err
 	for _, name := range names {
 		entry := models[name]
 		id := inference.ModelID{Provider: settings.ID, Name: name}
-		descriptor := inference.ModelDescriptor{ID: id}
+		descriptor := inference.ModelDescriptor{
+			ID:           id,
+			Capabilities: entry.capabilities,
+		}
 		if entry.deprecated {
 			descriptor.Lifecycle.Status = inference.ModelStatusDeprecated
 			if entry.replacement != "" {

--- a/driver/anthropic/spec.go
+++ b/driver/anthropic/spec.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/GizClaw/flowcraft/core/inference"
 	"github.com/GizClaw/flowcraft/core/resource"
 )
 
@@ -21,10 +22,9 @@ type Spec struct {
 // ModelSpec declares one catalog overlay entry.
 type ModelSpec struct {
 	Name string `json:"name"`
-	// Vision accepts image input parts.
-	Vision bool `json:"vision,omitempty"`
-	// Reasoning accepts the reasoning effort knob.
-	Reasoning bool `json:"reasoning,omitempty"`
+	// Capabilities declares the model's input/output content kinds and the
+	// reasoning control capability.
+	Capabilities inference.ModelCapabilities `json:"capabilities,omitempty"`
 }
 
 func (s Spec) Validate() error {

--- a/driver/azure/catalog.go
+++ b/driver/azure/catalog.go
@@ -1,24 +1,58 @@
 package azure
 
+import (
+	"fmt"
+	"slices"
+
+	"github.com/GizClaw/flowcraft/core/inference"
+	"github.com/GizClaw/flowcraft/core/message"
+)
+
 // catalogEntry is one deployment's compile-time capability declaration.
 // Azure routes by deployment name, so the spec's models list is the whole
 // catalog: the factory maps each declared deployment onto an entry, and the
-// compiler rejects every channel the entry omits.
+// compiler rejects every channel the entry omits. capabilities is the single
+// capability fact source; dimensions is the one control capability that no
+// capability kind expresses and stays a separate flag.
 type catalogEntry struct {
-	kind       modelKind
-	vision     bool
-	reasoning  bool
-	webSearch  bool
-	dimensions bool
+	kind         modelKind
+	capabilities inference.ModelCapabilities
+	dimensions   bool
 }
 
 // entryFor lowers one declared deployment into a compiler entry.
 func entryFor(model ModelSpec) catalogEntry {
 	return catalogEntry{
-		kind:       modelKind(model.Kind),
-		vision:     model.Vision,
-		reasoning:  model.Reasoning,
-		webSearch:  model.WebSearch,
-		dimensions: model.Dimensions,
+		kind:         modelKind(model.Kind),
+		capabilities: model.Capabilities,
+		dimensions:   model.Dimensions,
 	}
+}
+
+// validate enforces the family contract: the compiler bound by kind can only
+// serve the output modalities it produces, so kind and capabilities cannot
+// drift.
+func (e catalogEntry) validate() error {
+	if err := e.capabilities.Validate(); err != nil {
+		return err
+	}
+	switch e.kind {
+	case kindGenerate:
+		if !slices.Contains(e.capabilities.Outputs, message.PartText) {
+			return fmt.Errorf("generate family must declare text output")
+		}
+	case kindImage:
+		if !slices.Contains(e.capabilities.Outputs, message.PartImage) {
+			return fmt.Errorf("image family must declare image output")
+		}
+	case kindTTS:
+		if !slices.Contains(e.capabilities.Outputs, message.PartAudio) {
+			return fmt.Errorf("tts family must declare audio output")
+		}
+	case kindEmbed:
+		if len(e.capabilities.Outputs) != 0 {
+			return fmt.Errorf("embed family declares no generate output")
+		}
+	}
+	return nil
 }

--- a/driver/azure/generate.go
+++ b/driver/azure/generate.go
@@ -5,6 +5,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"slices"
 	"strings"
 
 	"github.com/GizClaw/flowcraft/core/inference"
@@ -318,7 +319,7 @@ func compileGenerate(
 		wire := generateWire{
 			model:            model,
 			stream:           shape == inference.GenerateExecutionStream,
-			includeReasoning: entry.reasoning,
+			includeReasoning: entry.capabilities.Reasoning != inference.ReasoningNone,
 		}
 
 		// Context messages → items. System stays a native system-role item;
@@ -366,7 +367,7 @@ func compileGenerateOptions(
 	if options.WebSearch == nil {
 		return
 	}
-	if !entry.webSearch {
+	if !entry.capabilities.HostedWebSearch {
 		ledger.reject(
 			inference.ExtensionField("web_search").Qualify(options),
 			"model does not support hosted web search",
@@ -416,7 +417,7 @@ func compileMessage(
 		case message.TextPart:
 			content = append(content, wireContent{kind: wireContentText, text: value.Text})
 		case message.ImagePart:
-			if !entry.vision {
+			if !slices.Contains(entry.capabilities.Inputs, message.PartImage) {
 				ledger.reject(fields[message.PartImage], "model does not accept image input")
 				continue
 			}
@@ -476,7 +477,7 @@ func compileReasoning(
 		ledger.reject(field, "reasoning parts belong to assistant context")
 		return
 	}
-	if !entry.reasoning {
+	if entry.capabilities.Reasoning == inference.ReasoningNone {
 		ledger.drop(field, "model has no reasoning channel")
 		return
 	}
@@ -591,21 +592,28 @@ func compileIntent(
 	wire.topP = text.TopP
 	if text.ReasoningEnabled != nil {
 		switch {
-		case !entry.reasoning:
+		case entry.capabilities.Reasoning == inference.ReasoningNone:
 			ledger.reject(
 				inference.FieldGenerateIntentReasoningEnabled,
 				"model has no reasoning to switch",
 			)
-		case !*text.ReasoningEnabled:
+		case entry.capabilities.Reasoning == inference.ReasoningAlways &&
+			!*text.ReasoningEnabled:
 			ledger.reject(
 				inference.FieldGenerateIntentReasoningEnabled,
 				"openai reasoning models cannot disable reasoning",
+			)
+		case entry.capabilities.Reasoning == inference.ReasoningToggle &&
+			!*text.ReasoningEnabled:
+			ledger.reject(
+				inference.FieldGenerateIntentReasoningEnabled,
+				"reasoning cannot be disabled through this provider",
 			)
 		}
 		// enabled == true is a no-op: reasoning models reason by default.
 	}
 	if text.ReasoningEffort != "" {
-		if !entry.reasoning {
+		if entry.capabilities.Reasoning == inference.ReasoningNone {
 			ledger.reject(
 				inference.FieldGenerateIntentReasoningEffort,
 				"model has no reasoning effort control",

--- a/driver/azure/resource.go
+++ b/driver/azure/resource.go
@@ -89,14 +89,13 @@ func buildProvider(settings ResourceSettings) (inference.ProviderDefinition, err
 	}
 	for _, model := range spec.Models {
 		id := inference.ModelID{Provider: settings.ID, Name: model.Name}
+		entry := entryFor(model)
 		provider.Models = append(provider.Models, inference.ModelImplementation{
 			Descriptor: inference.ModelDescriptor{
-				ID: id,
-				Capabilities: inference.ModelCapabilities{
-					HostedWebSearch: model.WebSearch,
-				},
+				ID:           id,
+				Capabilities: entry.capabilities,
 			},
-			Openers: openersFor(spec, model, profiles, id),
+			Openers: openersFor(spec, entry, profiles, id),
 		})
 	}
 	return provider, nil
@@ -106,7 +105,7 @@ func buildProvider(settings ResourceSettings) (inference.ProviderDefinition, err
 // through the self-hosted kernel drivers with the profile's Azure client.
 func openersFor(
 	spec Spec,
-	model ModelSpec,
+	entry catalogEntry,
 	profiles map[string]profileMaterial,
 	id inference.ModelID,
 ) inference.Openers {
@@ -121,7 +120,6 @@ func openersFor(
 		}
 		return material.newClients(spec), nil
 	}
-	entry := entryFor(model)
 	switch entry.kind {
 	case kindGenerate:
 		return inference.Openers{

--- a/driver/azure/resource_test.go
+++ b/driver/azure/resource_test.go
@@ -3,9 +3,12 @@ package azure
 import (
 	"context"
 	"encoding/json"
+	"reflect"
+	"slices"
 	"testing"
 
 	"github.com/GizClaw/flowcraft/core/inference"
+	"github.com/GizClaw/flowcraft/core/message"
 	"github.com/GizClaw/flowcraft/core/resource"
 )
 
@@ -16,7 +19,7 @@ func TestResourceFactoryBuildsProvider(t *testing.T) {
 			"id": "azure",
 			"spec": {
 				"endpoint": "https://example.openai.azure.com",
-				"models": [{"name": "gpt-5", "kind": "generate"}]
+				"models": [{"name": "gpt-5", "kind": "generate", "capabilities": {"outputs": ["text"]}}]
 			},
 			"profiles": [{
 				"id": "default",
@@ -71,7 +74,7 @@ func TestProviderCarriesGenerateOptionsDecoder(t *testing.T) {
 			"id": "azure",
 			"spec": {
 				"endpoint": "https://example.openai.azure.com",
-				"models": [{"name": "gpt-5", "kind": "generate"}]
+				"models": [{"name": "gpt-5", "kind": "generate", "capabilities": {"outputs": ["text"]}}]
 			},
 			"profiles": [{"id": "default", "secrets": {"api_key": "sk-test"}}]
 		}`),
@@ -112,7 +115,7 @@ func TestProviderCarriesGenerateOptionsDecoder(t *testing.T) {
 			"id": "az-prod",
 			"spec": {
 				"endpoint": "https://example.openai.azure.com",
-				"models": [{"name": "gpt-5", "kind": "generate"}]
+				"models": [{"name": "gpt-5", "kind": "generate", "capabilities": {"outputs": ["text"]}}]
 			},
 			"profiles": [{"id": "default", "secrets": {"api_key": "sk-test"}}]
 		}`),
@@ -132,5 +135,65 @@ func TestProviderCarriesGenerateOptionsDecoder(t *testing.T) {
 	}
 	if options := extensions[0].(*GenerateOptions); options.ProviderID() != "az-prod" {
 		t.Fatalf("ProviderID = %q, want %q", options.ProviderID(), "az-prod")
+	}
+}
+
+func TestModelCapabilitiesPublish(t *testing.T) {
+	t.Setenv("AZURE_TEST_KEY", "sk-test")
+	value, err := Factory().New(context.Background(), resource.Input{
+		Settings: json.RawMessage(`{
+			"id": "azure",
+			"spec": {
+				"endpoint": "https://example.openai.azure.com",
+				"models": [{
+					"name": "gpt-5",
+					"kind": "generate",
+					"capabilities": {
+						"inputs": ["text", "image", "data", "tool_call", "tool_result"],
+						"outputs": ["text"],
+						"hosted_web_search": true,
+						"reasoning": "always"
+					}
+				}]
+			},
+			"profiles": [{
+				"id": "default",
+				"secrets": {"api_key": "${env:AZURE_TEST_KEY}"}
+			}]
+		}`),
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	provider := value.(inference.ProviderDefinition)
+	capabilities := provider.Models[0].Descriptor.Capabilities
+	if !reflect.DeepEqual(capabilities.Outputs, []message.PartKind{message.PartText}) ||
+		!slices.Contains(capabilities.Inputs, message.PartImage) ||
+		!capabilities.HostedWebSearch ||
+		capabilities.Reasoning != inference.ReasoningAlways {
+		t.Fatalf("capabilities = %+v", capabilities)
+	}
+}
+
+func TestSpecRejectsFamilyContractViolation(t *testing.T) {
+	_, err := Factory().New(context.Background(), resource.Input{
+		Settings: json.RawMessage(`{
+			"id": "azure",
+			"spec": {
+				"endpoint": "https://example.openai.azure.com",
+				"models": [{
+					"name": "img",
+					"kind": "image",
+					"capabilities": {"outputs": ["text"]}
+				}]
+			},
+			"profiles": [{
+				"id": "default",
+				"secrets": {"api_key": "sk-test"}
+			}]
+		}`),
+	})
+	if err == nil {
+		t.Fatal("image deployment with text output unexpectedly accepted")
 	}
 }

--- a/driver/azure/spec.go
+++ b/driver/azure/spec.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/GizClaw/flowcraft/core/inference"
 	"github.com/GizClaw/flowcraft/core/resource"
 )
 
@@ -31,12 +32,10 @@ type Spec struct {
 type ModelSpec struct {
 	Name string `json:"name"`
 	Kind string `json:"kind"` // generate | embed | image | tts
-	// Vision accepts image input parts (generate only).
-	Vision bool `json:"vision,omitempty"`
-	// Reasoning accepts reasoning effort and summary knobs (generate only).
-	Reasoning bool `json:"reasoning,omitempty"`
-	// WebSearch accepts the hosted web_search tool (generate only).
-	WebSearch bool `json:"web_search,omitempty"`
+	// Capabilities declares the deployment's input/output content kinds,
+	// hosted web search support, and reasoning control capability, validated
+	// against the kind's compiler contract.
+	Capabilities inference.ModelCapabilities `json:"capabilities,omitempty"`
 	// Dimensions accepts the embed dimensions knob (embed only).
 	Dimensions bool `json:"dimensions,omitempty"`
 }
@@ -87,33 +86,15 @@ func (s Spec) Validate() error {
 				model.Kind,
 			)
 		}
-		if model.Vision && modelKind(model.Kind) != kindGenerate {
-			return fmt.Errorf(
-				"azure: deployment %q sets vision on kind %q",
-				model.Name,
-				model.Kind,
-			)
-		}
-		if model.Reasoning && modelKind(model.Kind) != kindGenerate {
-			return fmt.Errorf(
-				"azure: deployment %q sets reasoning on kind %q",
-				model.Name,
-				model.Kind,
-			)
-		}
-		if model.WebSearch && modelKind(model.Kind) != kindGenerate {
-			return fmt.Errorf(
-				"azure: deployment %q sets web_search on kind %q",
-				model.Name,
-				model.Kind,
-			)
-		}
 		if model.Dimensions && modelKind(model.Kind) != kindEmbed {
 			return fmt.Errorf(
 				"azure: deployment %q sets dimensions on kind %q",
 				model.Name,
 				model.Kind,
 			)
+		}
+		if err := entryFor(model).validate(); err != nil {
+			return fmt.Errorf("azure: deployment %q: %w", model.Name, err)
 		}
 	}
 	return nil

--- a/driver/bytedance/catalog.go
+++ b/driver/bytedance/catalog.go
@@ -1,6 +1,13 @@
 package bytedance
 
-import "maps"
+import (
+	"fmt"
+	"maps"
+	"slices"
+
+	"github.com/GizClaw/flowcraft/core/inference"
+	"github.com/GizClaw/flowcraft/core/message"
+)
 
 // modelKind groups models by the service family that serves them. The kind,
 // not the model name, selects the compiler and transport.
@@ -13,26 +20,16 @@ const (
 	kindVideo    modelKind = "video"
 	kindTTS      modelKind = "tts"
 	kindASR      modelKind = "asr"
-	kindRealtime modelKind = "realtime"
 )
 
-// catalogEntry is one model's declared capability set. Capability flags only
-// apply to the kinds they document; other kinds leave them zero.
+// catalogEntry is one model's declared capability set. capabilities is the
+// single capability fact source: input/output content kinds, hosted web
+// search, and the reasoning control capability. dimensions and maxResolution
+// are control capabilities that no capability kind expresses and stay
+// separate flags.
 type catalogEntry struct {
-	kind modelKind
-	// generate: accepts image input parts.
-	vision bool
-	// generate: accepts video input parts.
-	video bool
-	// generate: supports the thinking control behind reasoning effort.
-	reasoning bool
-	// webSearch (generate) accepts the hosted Web Search (联网内容插件)
-	// tool. Support is per model per the Ark tool-calling capability
-	// matrix; see
-	// https://www.volcengine.com/docs/82379/1330310#f44ceef7.
-	webSearch bool
-	// embed: accepts image items (multimodal embedding).
-	imageInput bool
+	kind         modelKind
+	capabilities inference.ModelCapabilities
 	// embed: accepts custom output dimensions.
 	dimensions bool
 	// video: highest supported resolution tier ("720p", "1080p", "4k");
@@ -51,6 +48,54 @@ type catalogEntry struct {
 	maxInputTokens int
 }
 
+// validate enforces the family contract: the compiler bound by kind can only
+// serve the output modalities it produces, so kind and capabilities cannot
+// drift.
+func (e catalogEntry) validate() error {
+	if err := e.capabilities.Validate(); err != nil {
+		return err
+	}
+	switch e.kind {
+	case kindGenerate:
+		if !slices.Contains(e.capabilities.Outputs, message.PartText) {
+			return fmt.Errorf("generate family must declare text output")
+		}
+	case kindImage:
+		if !slices.Contains(e.capabilities.Outputs, message.PartImage) {
+			return fmt.Errorf("image family must declare image output")
+		}
+	case kindVideo:
+		if !slices.Contains(e.capabilities.Outputs, message.PartVideo) {
+			return fmt.Errorf("video family must declare video output")
+		}
+	case kindTTS:
+		if !slices.Contains(e.capabilities.Outputs, message.PartAudio) {
+			return fmt.Errorf("tts family must declare audio output")
+		}
+	case kindEmbed, kindASR:
+		if len(e.capabilities.Outputs) != 0 {
+			return fmt.Errorf("%s family declares no generate output", e.kind)
+		}
+	}
+	return nil
+}
+
+// generateChatCapabilities is the common capability declaration for the Ark
+// text compiler family. Individual entries add image/video input, hosted web
+// search, and the reasoning control capability. Ark consumes no reasoning
+// input, so PartReasoning is deliberately absent.
+func generateChatCapabilities() inference.ModelCapabilities {
+	return inference.ModelCapabilities{
+		Inputs: []message.PartKind{
+			message.PartText,
+			message.PartData,
+			message.PartToolCall,
+			message.PartToolResult,
+		},
+		Outputs: []message.PartKind{message.PartText},
+	}
+}
+
 // catalog is the built-in model registry. Names are stable Volcengine model
 // families; deployment-specific endpoint IDs (ep-xxx or dated revisions like
 // doubao-seed-2-1-pro-260628) belong in Spec.Endpoints.
@@ -61,44 +106,130 @@ var catalog = map[string]catalogEntry{
 	// Doubao Seed Evolving (2026-07) — rapidly iterating Coding & Agent
 	// line, updated weekly. Long 1M context; natively multimodal with
 	// thinking and the full hosted tool surface.
-	"doubao-seed-evolving": {kind: kindGenerate, vision: true, video: true, reasoning: true, webSearch: true, maxInputTokens: 1_024_000},
+	"doubao-seed-evolving": {
+		kind: kindGenerate,
+		capabilities: generateChatCapabilities().
+			WithInputs(message.PartImage, message.PartVideo).
+			WithHostedWebSearch().
+			WithReasoning(inference.ReasoningToggle),
+		maxInputTokens: 1_024_000,
+	},
 
 	// Seed 2.1 (2026-06) — current flagship tier. The whole Seed 2.x line is
 	// natively multimodal (text/image/video in) with thinking support.
-	"doubao-seed-2-1-pro":   {kind: kindGenerate, vision: true, video: true, reasoning: true, webSearch: true, maxInputTokens: 256_000},
-	"doubao-seed-2-1-turbo": {kind: kindGenerate, vision: true, video: true, reasoning: true, webSearch: true, maxInputTokens: 256_000},
+	"doubao-seed-2-1-pro": {
+		kind: kindGenerate,
+		capabilities: generateChatCapabilities().
+			WithInputs(message.PartImage, message.PartVideo).
+			WithHostedWebSearch().
+			WithReasoning(inference.ReasoningToggle),
+		maxInputTokens: 256_000,
+	},
+	"doubao-seed-2-1-turbo": {
+		kind: kindGenerate,
+		capabilities: generateChatCapabilities().
+			WithInputs(message.PartImage, message.PartVideo).
+			WithHostedWebSearch().
+			WithReasoning(inference.ReasoningToggle),
+		maxInputTokens: 256_000,
+	},
 
 	// Seed 2.0 (2026-02) — general agent line plus the code-tuned variant.
 	// The 260215 lite revision retired in 2026-05, but the 260428 revision
 	// stays live (and is Ark's recommended audio-understanding model), so
 	// the stable family name remains routable.
-	"doubao-seed-2-0-pro":  {kind: kindGenerate, vision: true, video: true, reasoning: true, webSearch: true, maxInputTokens: 256_000},
-	"doubao-seed-2-0-lite": {kind: kindGenerate, vision: true, video: true, reasoning: true, webSearch: true, maxInputTokens: 256_000},
-	"doubao-seed-2-0-mini": {kind: kindGenerate, vision: true, video: true, reasoning: true, webSearch: true, maxInputTokens: 256_000},
-	"doubao-seed-2-0-code": {kind: kindGenerate, vision: true, reasoning: true, webSearch: true, maxInputTokens: 256_000},
+	"doubao-seed-2-0-pro": {
+		kind: kindGenerate,
+		capabilities: generateChatCapabilities().
+			WithInputs(message.PartImage, message.PartVideo).
+			WithHostedWebSearch().
+			WithReasoning(inference.ReasoningToggle),
+		maxInputTokens: 256_000,
+	},
+	"doubao-seed-2-0-lite": {
+		kind: kindGenerate,
+		capabilities: generateChatCapabilities().
+			WithInputs(message.PartImage, message.PartVideo).
+			WithHostedWebSearch().
+			WithReasoning(inference.ReasoningToggle),
+		maxInputTokens: 256_000,
+	},
+	"doubao-seed-2-0-mini": {
+		kind: kindGenerate,
+		capabilities: generateChatCapabilities().
+			WithInputs(message.PartImage, message.PartVideo).
+			WithHostedWebSearch().
+			WithReasoning(inference.ReasoningToggle),
+		maxInputTokens: 256_000,
+	},
+	"doubao-seed-2-0-code": {
+		kind: kindGenerate,
+		capabilities: generateChatCapabilities().
+			WithInputs(message.PartImage).
+			WithHostedWebSearch().
+			WithReasoning(inference.ReasoningToggle),
+		maxInputTokens: 256_000,
+	},
 
 	// Seed 1.x — superseded by the 2.x line; kept routable for existing
 	// deployments, announced as deprecated with a replacement.
 	"doubao-seed-1-8": {
-		kind: kindGenerate, vision: true, video: true, reasoning: true, webSearch: true,
+		kind: kindGenerate,
+		capabilities: generateChatCapabilities().
+			WithInputs(message.PartImage, message.PartVideo).
+			WithHostedWebSearch().
+			WithReasoning(inference.ReasoningToggle),
 		deprecated: true, replacement: "doubao-seed-2-0-lite",
 		maxInputTokens: 256_000,
 	},
 	"doubao-seed-1-6-vision": {
-		kind: kindGenerate, vision: true, reasoning: true, webSearch: true,
+		kind: kindGenerate,
+		capabilities: generateChatCapabilities().
+			WithInputs(message.PartImage).
+			WithHostedWebSearch().
+			WithReasoning(inference.ReasoningToggle),
 		deprecated: true, replacement: "doubao-seed-2-0-lite",
 		maxInputTokens: 256_000,
 	},
 
-	"doubao-embedding-large":  {kind: kindEmbed, dimensions: true, maxInputTokens: 4_095},
-	"doubao-embedding-vision": {kind: kindEmbed, imageInput: true, dimensions: true, maxInputTokens: 8_191},
+	"doubao-embedding-large": {
+		kind:           kindEmbed,
+		capabilities:   inference.ModelCapabilities{}.WithInputs(message.PartText),
+		dimensions:     true,
+		maxInputTokens: 4_095,
+	},
+	"doubao-embedding-vision": {
+		kind: kindEmbed,
+		capabilities: inference.ModelCapabilities{}.
+			WithInputs(message.PartText, message.PartImage),
+		dimensions:     true,
+		maxInputTokens: 8_191,
+	},
 
 	// Seedream image generation; 5.0-pro/5.0/4.5 current, 4.0 superseded.
-	"doubao-seedream-5-0-pro": {kind: kindImage},
-	"doubao-seedream-5-0":     {kind: kindImage},
-	"doubao-seedream-4-5":     {kind: kindImage},
+	"doubao-seedream-5-0-pro": {
+		kind: kindImage,
+		capabilities: inference.ModelCapabilities{}.
+			WithInputs(message.PartText, message.PartImage).
+			WithOutputs(message.PartImage),
+	},
+	"doubao-seedream-5-0": {
+		kind: kindImage,
+		capabilities: inference.ModelCapabilities{}.
+			WithInputs(message.PartText, message.PartImage).
+			WithOutputs(message.PartImage),
+	},
+	"doubao-seedream-4-5": {
+		kind: kindImage,
+		capabilities: inference.ModelCapabilities{}.
+			WithInputs(message.PartText, message.PartImage).
+			WithOutputs(message.PartImage),
+	},
 	"doubao-seedream-4-0": {
-		kind:       kindImage,
+		kind: kindImage,
+		capabilities: inference.ModelCapabilities{}.
+			WithInputs(message.PartText, message.PartImage).
+			WithOutputs(message.PartImage),
 		deprecated: true, replacement: "doubao-seedream-5-0",
 	},
 
@@ -106,25 +237,65 @@ var catalog = map[string]catalogEntry{
 	// API behind the unary contract. 2.0 is the current line; fast/mini cap
 	// at 720p. 2.5 is the current flagship (1080p, 30s narrative). 1.x
 	// stays routable for existing deployments.
-	"doubao-seedance-2-5":      {kind: kindVideo, maxResolution: "1080p"},
-	"doubao-seedance-2-0":      {kind: kindVideo, maxResolution: "4k"},
-	"doubao-seedance-2-0-fast": {kind: kindVideo, maxResolution: "720p"},
-	"doubao-seedance-2-0-mini": {kind: kindVideo, maxResolution: "720p"},
+	"doubao-seedance-2-5": {
+		kind: kindVideo,
+		capabilities: inference.ModelCapabilities{}.
+			WithInputs(message.PartText, message.PartImage).
+			WithOutputs(message.PartVideo),
+		maxResolution: "1080p",
+	},
+	"doubao-seedance-2-0": {
+		kind: kindVideo,
+		capabilities: inference.ModelCapabilities{}.
+			WithInputs(message.PartText, message.PartImage).
+			WithOutputs(message.PartVideo),
+		maxResolution: "4k",
+	},
+	"doubao-seedance-2-0-fast": {
+		kind: kindVideo,
+		capabilities: inference.ModelCapabilities{}.
+			WithInputs(message.PartText, message.PartImage).
+			WithOutputs(message.PartVideo),
+		maxResolution: "720p",
+	},
+	"doubao-seedance-2-0-mini": {
+		kind: kindVideo,
+		capabilities: inference.ModelCapabilities{}.
+			WithInputs(message.PartText, message.PartImage).
+			WithOutputs(message.PartVideo),
+		maxResolution: "720p",
+	},
 	"doubao-seedance-1-5-pro": {
-		kind: kindVideo, maxResolution: "1080p",
-		deprecated: true, replacement: "doubao-seedance-2-0",
+		kind: kindVideo,
+		capabilities: inference.ModelCapabilities{}.
+			WithInputs(message.PartText, message.PartImage).
+			WithOutputs(message.PartVideo),
+		maxResolution: "1080p",
+		deprecated:    true, replacement: "doubao-seedance-2-0",
 	},
 	"doubao-seedance-1-0-pro": {
-		kind: kindVideo, maxResolution: "1080p",
-		deprecated: true, replacement: "doubao-seedance-2-0",
+		kind: kindVideo,
+		capabilities: inference.ModelCapabilities{}.
+			WithInputs(message.PartText, message.PartImage).
+			WithOutputs(message.PartVideo),
+		maxResolution: "1080p",
+		deprecated:    true, replacement: "doubao-seedance-2-0",
 	},
 	"doubao-seedance-1-0-lite-t2v": {
-		kind: kindVideo, maxResolution: "720p",
-		deprecated: true, replacement: "doubao-seedance-2-0-fast",
+		kind: kindVideo,
+		capabilities: inference.ModelCapabilities{}.
+			WithInputs(message.PartText, message.PartImage).
+			WithOutputs(message.PartVideo),
+		maxResolution: "720p",
+		deprecated:    true, replacement: "doubao-seedance-2-0-fast",
 	},
 	"doubao-seedance-1-0-lite-i2v": {
-		kind: kindVideo, maxResolution: "720p",
-		deprecated: true, replacement: "doubao-seedance-2-0-fast",
+		kind: kindVideo,
+		capabilities: inference.ModelCapabilities{}.
+			WithInputs(message.PartText, message.PartImage).
+			WithOutputs(message.PartVideo),
+		maxResolution: "720p",
+		deprecated:    true, replacement: "doubao-seedance-2-0-fast",
 	},
 
 	// Logical names for speech families; the wire address (resource ID or
@@ -132,7 +303,12 @@ var catalog = map[string]catalogEntry{
 	// defaults to the SAUC V2 streaming endpoint when the profile does not
 	// map the model to an account resource ID; realtime remains absent until
 	// core exposes that operation surface.
-	"doubao-tts-2-0":  {kind: kindTTS},
+	"doubao-tts-2-0": {
+		kind: kindTTS,
+		capabilities: inference.ModelCapabilities{}.
+			WithInputs(message.PartText).
+			WithOutputs(message.PartAudio),
+	},
 	"doubao-seed-asr": {kind: kindASR},
 }
 
@@ -144,13 +320,14 @@ func mergedCatalog(spec Spec) (map[string]catalogEntry, error) {
 	for _, model := range spec.Models {
 		merged[model.Name] = catalogEntry{
 			kind:          modelKind(model.Kind),
-			vision:        model.Vision,
-			video:         model.Video,
-			reasoning:     model.Reasoning,
-			webSearch:     model.WebSearch,
-			imageInput:    model.ImageInput,
+			capabilities:  model.Capabilities,
 			dimensions:    model.Dimensions,
 			maxResolution: model.MaxResolution,
+		}
+	}
+	for name, entry := range merged {
+		if err := entry.validate(); err != nil {
+			return nil, fmt.Errorf("catalog model %q: %w", name, err)
 		}
 	}
 	return merged, nil

--- a/driver/bytedance/catalog_test.go
+++ b/driver/bytedance/catalog_test.go
@@ -1,9 +1,12 @@
 package bytedance
 
 import (
+	"reflect"
+	"slices"
 	"testing"
 
 	"github.com/GizClaw/flowcraft/core/inference"
+	"github.com/GizClaw/flowcraft/core/message"
 )
 
 func TestCatalogDeclaresMaxInputTokens(t *testing.T) {
@@ -44,5 +47,68 @@ func TestCatalogDeclaresMaxInputTokens(t *testing.T) {
 			t.Errorf("model %q: max input tokens = %v, want %d",
 				name, descriptor.Limits.MaxInputTokens, want)
 		}
+	}
+}
+
+func TestCatalogPublishesCapabilities(t *testing.T) {
+	provider, err := buildProvider(ResourceSettings{ID: "bytedance"})
+	if err != nil {
+		t.Fatalf("buildProvider: %v", err)
+	}
+	descriptors := make(map[string]inference.ModelDescriptor, len(provider.Models))
+	for _, model := range provider.Models {
+		descriptors[model.Descriptor.ID.Name] = model.Descriptor
+	}
+
+	chat := descriptors["doubao-seed-2-1-pro"]
+	if !reflect.DeepEqual(chat.Capabilities.Outputs, []message.PartKind{message.PartText}) {
+		t.Fatalf("chat outputs = %v, want text", chat.Capabilities.Outputs)
+	}
+	if !slices.Contains(chat.Capabilities.Inputs, message.PartImage) ||
+		!slices.Contains(chat.Capabilities.Inputs, message.PartVideo) {
+		t.Fatalf("chat inputs = %v, want image and video input", chat.Capabilities.Inputs)
+	}
+	if !chat.Capabilities.HostedWebSearch ||
+		chat.Capabilities.Reasoning != inference.ReasoningToggle {
+		t.Fatalf("chat capabilities = %+v", chat.Capabilities)
+	}
+
+	image := descriptors["doubao-seedream-5-0"]
+	if !reflect.DeepEqual(image.Capabilities.Outputs, []message.PartKind{message.PartImage}) ||
+		!reflect.DeepEqual(
+			image.Capabilities.Inputs,
+			[]message.PartKind{message.PartText, message.PartImage},
+		) {
+		t.Fatalf("image capabilities = %+v", image.Capabilities)
+	}
+
+	video := descriptors["doubao-seedance-2-0"]
+	if !reflect.DeepEqual(video.Capabilities.Outputs, []message.PartKind{message.PartVideo}) {
+		t.Fatalf("video outputs = %v, want video", video.Capabilities.Outputs)
+	}
+
+	tts := descriptors["doubao-tts-2-0"]
+	if !reflect.DeepEqual(tts.Capabilities.Outputs, []message.PartKind{message.PartAudio}) {
+		t.Fatalf("tts outputs = %v, want audio", tts.Capabilities.Outputs)
+	}
+
+	embed := descriptors["doubao-embedding-vision"]
+	if !slices.Contains(embed.Capabilities.Inputs, message.PartImage) {
+		t.Fatalf("multimodal embed inputs = %v, want image input", embed.Capabilities.Inputs)
+	}
+	if len(embed.Capabilities.Outputs) != 0 {
+		t.Fatalf("embed outputs = %v, want none", embed.Capabilities.Outputs)
+	}
+}
+
+func TestMergedCatalogRejectsFamilyContractViolation(t *testing.T) {
+	spec, err := decodeSpec([]byte(
+		`{"models":[{"name":"m","kind":"image","capabilities":{"outputs":["text"]}}]}`,
+	))
+	if err != nil {
+		t.Fatalf("decodeSpec: %v", err)
+	}
+	if _, err := mergedCatalog(spec); err == nil {
+		t.Fatal("mergedCatalog unexpectedly accepted contract violation")
 	}
 }

--- a/driver/bytedance/embed.go
+++ b/driver/bytedance/embed.go
@@ -3,6 +3,7 @@ package bytedance
 import (
 	"context"
 	"fmt"
+	"slices"
 	"strings"
 
 	"github.com/GizClaw/flowcraft/core/inference"
@@ -60,7 +61,7 @@ func compileEmbed(
 		ledger := newLedger(inference.OperationEmbed, request.ActiveFields())
 		wire := embedWire{
 			model:      endpoint,
-			multimodal: entry.imageInput,
+			multimodal: slices.Contains(entry.capabilities.Inputs, message.PartImage),
 			dimensions: request.Dimensions,
 		}
 		if request.Dimensions != nil && !entry.dimensions {
@@ -94,7 +95,7 @@ func compileEmbed(
 					}
 					text.WriteString(string(value.Value))
 				case message.ImagePart:
-					if !entry.imageInput {
+					if !slices.Contains(entry.capabilities.Inputs, message.PartImage) {
 						ledger.reject(
 							inference.FieldEmbedItemImage,
 							"model embeds text only",

--- a/driver/bytedance/generate.go
+++ b/driver/bytedance/generate.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/base64"
 	"fmt"
+	"slices"
 	"strings"
 
 	"github.com/GizClaw/flowcraft/core/inference"
@@ -407,7 +408,7 @@ func compileGenerateOptions(
 		wire.maxToolCalls = options.MaxToolCalls
 	}
 	if options.WebSearch != nil {
-		if !entry.webSearch {
+		if !entry.capabilities.HostedWebSearch {
 			ledger.reject(
 				inference.ExtensionField("web_search").Qualify(options),
 				"model does not support hosted web search",
@@ -456,7 +457,7 @@ func compileMessage(
 		case message.TextPart:
 			content = append(content, wireContent{kind: wireContentText, text: value.Text})
 		case message.ImagePart:
-			if !entry.vision {
+			if !slices.Contains(entry.capabilities.Inputs, message.PartImage) {
 				ledger.reject(fields[message.PartImage], "model does not accept image input")
 				continue
 			}
@@ -465,7 +466,7 @@ func compileMessage(
 				uri:  sourceURI(value.Source),
 			})
 		case message.VideoPart:
-			if !entry.video {
+			if !slices.Contains(entry.capabilities.Inputs, message.PartVideo) {
 				ledger.reject(fields[message.PartVideo], "model does not accept video input")
 				continue
 			}
@@ -602,17 +603,24 @@ func compileIntent(
 	wire.temperature = text.Temperature
 	wire.topP = text.TopP
 	if text.ReasoningEnabled != nil {
-		if !entry.reasoning {
+		switch {
+		case entry.capabilities.Reasoning == inference.ReasoningNone:
 			ledger.reject(
 				inference.FieldGenerateIntentReasoningEnabled,
 				"model has no thinking control",
 			)
-		} else {
+		case entry.capabilities.Reasoning == inference.ReasoningAlways &&
+			!*text.ReasoningEnabled:
+			ledger.reject(
+				inference.FieldGenerateIntentReasoningEnabled,
+				"model cannot disable thinking",
+			)
+		default:
 			wire.thinking = text.ReasoningEnabled
 		}
 	}
 	if text.ReasoningEffort != "" {
-		if !entry.reasoning {
+		if entry.capabilities.Reasoning == inference.ReasoningNone {
 			ledger.reject(
 				inference.FieldGenerateIntentReasoningEffort,
 				"model has no thinking control",

--- a/driver/bytedance/resource.go
+++ b/driver/bytedance/resource.go
@@ -106,20 +106,10 @@ func buildProvider(settings ResourceSettings) (inference.ProviderDefinition, err
 	slices.Sort(names)
 	for _, name := range names {
 		entry := models[name]
-		if entry.kind == kindRealtime {
-			return inference.ProviderDefinition{}, fmt.Errorf(
-				"bytedance provider %q: model %q kind %q is not supported by core inference yet",
-				settings.ID,
-				name,
-				entry.kind,
-			)
-		}
 		id := inference.ModelID{Provider: settings.ID, Name: name}
 		descriptor := inference.ModelDescriptor{
-			ID: id,
-			Capabilities: inference.ModelCapabilities{
-				HostedWebSearch: entry.webSearch,
-			},
+			ID:           id,
+			Capabilities: entry.capabilities,
 		}
 		if entry.deprecated {
 			descriptor.Lifecycle.Status = inference.ModelStatusDeprecated

--- a/driver/bytedance/spec.go
+++ b/driver/bytedance/spec.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/GizClaw/flowcraft/core/inference"
 	"github.com/GizClaw/flowcraft/core/resource"
 )
 
@@ -54,24 +55,19 @@ type Spec struct {
 	Models []ModelSpec `json:"models,omitempty"`
 }
 
-// ModelSpec declares one model outside the built-in catalog. Capability
-// flags are only meaningful for the matching kind. Addressing a custom model
-// at a deployment endpoint works exactly like catalog models: map its name
-// in Spec.Endpoints.
+// ModelSpec declares one model outside the built-in catalog. Capabilities
+// mirror the built-in catalog shape: content kinds, hosted web search, and
+// the reasoning control capability (validated against the kind's compiler
+// contract at merge time). Dimensions and max resolution are control
+// capabilities that no capability kind expresses and stay separate flags.
+// Addressing a custom model at a deployment endpoint works exactly like
+// catalog models: map its name in Spec.Endpoints.
 type ModelSpec struct {
 	Name string `json:"name"`
 	Kind string `json:"kind"`
-	// Vision (generate) allows image input parts.
-	Vision bool `json:"vision,omitempty"`
-	// Video (generate) allows video input parts.
-	Video bool `json:"video,omitempty"`
-	// Reasoning (generate) enables the reasoning effort control.
-	Reasoning bool `json:"reasoning,omitempty"`
-	// WebSearch (generate) enables the hosted Web Search (联网内容插件)
-	// tool.
-	WebSearch bool `json:"web_search,omitempty"`
-	// ImageInput (embed) allows image items via multimodal embedding.
-	ImageInput bool `json:"image_input,omitempty"`
+	// Capabilities declares the model's input/output content kinds, hosted
+	// web search support, and reasoning control capability.
+	Capabilities inference.ModelCapabilities `json:"capabilities,omitempty"`
 	// Dimensions (embed) allows custom output dimensions.
 	Dimensions bool `json:"dimensions,omitempty"`
 	// MaxResolution (video) caps the supported resolution tier, e.g. "720p"
@@ -162,12 +158,10 @@ func (m ModelSpec) Validate() error {
 	}
 	switch modelKind(m.Kind) {
 	case kindGenerate, kindEmbed, kindImage, kindVideo, kindTTS, kindASR:
-	case kindRealtime:
-		return fmt.Errorf("model %q kind %q is not supported by core inference yet", m.Name, m.Kind)
 	default:
 		return fmt.Errorf("model %q has unknown kind %q", m.Name, m.Kind)
 	}
-	return nil
+	return m.Capabilities.Validate()
 }
 
 func decodeSpec(raw []byte) (Spec, error) {

--- a/driver/deepseek/catalog.go
+++ b/driver/deepseek/catalog.go
@@ -3,7 +3,11 @@ package deepseek
 import (
 	"fmt"
 	"maps"
+	"slices"
 	"sort"
+
+	"github.com/GizClaw/flowcraft/core/inference"
+	"github.com/GizClaw/flowcraft/core/message"
 )
 
 type modelKind string
@@ -18,28 +22,55 @@ const (
 	apiResponses apiMode = "responses"
 )
 
-// catalogEntry declares what one catalog model accepts. The zero value is
-// the bare text surface: the compiler rejects every channel the entry
-// omits, so a model never silently accepts a feature it may not serve.
+// catalogEntry declares what one catalog model accepts. capabilities is the
+// single capability fact source: input/output content kinds, hosted web
+// search, and the reasoning control capability. api, declared, and responses
+// are wire-surface facts, not content capabilities, and stay separate flags.
 type catalogEntry struct {
-	kind modelKind
+	kind         modelKind
+	capabilities inference.ModelCapabilities
 	// api is the provider-level generate surface selected by Spec.API.
 	api apiMode
 	// declared marks a Spec.Models entry (as opposed to a built-in catalog
 	// model). Responses-mode filtering treats declared entries fail-fast.
 	declared bool
-	// reasoning accepts the thinking/effort knobs and emits reasoning
-	// traces.
-	reasoning bool
 	// responses accepts the Responses API surface. Chat completions work
 	// for every catalog model; responses is per-model.
 	responses bool
-	// webSearch accepts the hosted web_search tool on the Responses API.
-	webSearch bool
 	// maxInputTokens caps the input context in tokens; zero means
 	// undeclared. Both V4 models carry the 1M context published on
 	// https://api-docs.deepseek.com/quick_start/pricing.
 	maxInputTokens int
+}
+
+// validate enforces the generate family contract: the compiler only serves
+// text output, so kind and capabilities cannot drift.
+func (e catalogEntry) validate() error {
+	if err := e.capabilities.Validate(); err != nil {
+		return err
+	}
+	if e.kind != kindGenerate {
+		return fmt.Errorf("unsupported kind %q", e.kind)
+	}
+	if !slices.Contains(e.capabilities.Outputs, message.PartText) {
+		return fmt.Errorf("generate family must declare text output")
+	}
+	return nil
+}
+
+// generateChatCapabilities is the capability declaration for the DeepSeek
+// text compiler family: text/data/tool parts in, text out. DeepSeek
+// consumes no image/audio/video input.
+func generateChatCapabilities() inference.ModelCapabilities {
+	return inference.ModelCapabilities{
+		Inputs: []message.PartKind{
+			message.PartText,
+			message.PartData,
+			message.PartToolCall,
+			message.PartToolResult,
+		},
+		Outputs: []message.PartKind{message.PartText},
+	}
 }
 
 // catalog reflects DeepSeek's public API as of 2026-08.
@@ -55,17 +86,19 @@ type catalogEntry struct {
 // landed after the initial flash-only launch.
 var catalog = map[string]catalogEntry{
 	"deepseek-v4-flash": {
-		kind:           kindGenerate,
-		reasoning:      true,
+		kind: kindGenerate,
+		capabilities: generateChatCapabilities().
+			WithHostedWebSearch().
+			WithReasoning(inference.ReasoningToggle),
 		responses:      true,
-		webSearch:      true,
 		maxInputTokens: 1_000_000,
 	},
 	"deepseek-v4-pro": {
-		kind:           kindGenerate,
-		reasoning:      true,
+		kind: kindGenerate,
+		capabilities: generateChatCapabilities().
+			WithHostedWebSearch().
+			WithReasoning(inference.ReasoningToggle),
 		responses:      true,
-		webSearch:      true,
 		maxInputTokens: 1_000_000,
 	},
 }
@@ -79,11 +112,10 @@ func mergedCatalog(spec Spec) (map[string]catalogEntry, error) {
 	maps.Copy(models, catalog)
 	for _, declared := range spec.Models {
 		entry := catalogEntry{
-			kind:      modelKind(declared.Kind),
-			reasoning: declared.Reasoning,
-			responses: declared.Responses,
-			webSearch: declared.WebSearch,
-			declared:  true,
+			kind:         modelKind(declared.Kind),
+			capabilities: declared.Capabilities,
+			responses:    declared.Responses,
+			declared:     true,
 		}
 		if entry.kind == "" {
 			if existing, exists := models[declared.Name]; exists {
@@ -92,19 +124,14 @@ func mergedCatalog(spec Spec) (map[string]catalogEntry, error) {
 				entry.kind = kindGenerate
 			}
 		}
-		if err := entry.validate(); err != nil {
-			return nil, fmt.Errorf("model %q: %w", declared.Name, err)
-		}
 		models[declared.Name] = entry
 	}
-	return models, nil
-}
-
-func (e catalogEntry) validate() error {
-	if e.kind != kindGenerate {
-		return fmt.Errorf("unsupported kind %q", e.kind)
+	for name, entry := range models {
+		if err := entry.validate(); err != nil {
+			return nil, fmt.Errorf("model %q: %w", name, err)
+		}
 	}
-	return nil
+	return models, nil
 }
 
 // sortedNames returns catalog names in deterministic order so factory

--- a/driver/deepseek/catalog_test.go
+++ b/driver/deepseek/catalog_test.go
@@ -1,7 +1,12 @@
 package deepseek
 
 import (
+	"reflect"
+	"slices"
 	"testing"
+
+	"github.com/GizClaw/flowcraft/core/inference"
+	"github.com/GizClaw/flowcraft/core/message"
 )
 
 func TestCatalogDeclaresMaxInputTokens(t *testing.T) {
@@ -19,5 +24,37 @@ func TestCatalogDeclaresMaxInputTokens(t *testing.T) {
 			t.Errorf("model %q: max input tokens = %v, want 1000000",
 				name, model.Descriptor.Limits.MaxInputTokens)
 		}
+	}
+}
+
+func TestCatalogPublishesCapabilities(t *testing.T) {
+	provider, err := buildProvider(ResourceSettings{ID: "deepseek"})
+	if err != nil {
+		t.Fatalf("buildProvider: %v", err)
+	}
+	for _, model := range provider.Models {
+		capabilities := model.Descriptor.Capabilities
+		if !reflect.DeepEqual(capabilities.Outputs, []message.PartKind{message.PartText}) {
+			t.Fatalf("%s outputs = %v, want text", model.Descriptor.ID.Name, capabilities.Outputs)
+		}
+		if !slices.Contains(capabilities.Inputs, message.PartToolCall) {
+			t.Fatalf("%s inputs = %v, want tool input", model.Descriptor.ID.Name, capabilities.Inputs)
+		}
+		if !capabilities.HostedWebSearch ||
+			capabilities.Reasoning != inference.ReasoningToggle {
+			t.Fatalf("%s capabilities = %+v", model.Descriptor.ID.Name, capabilities)
+		}
+	}
+}
+
+func TestMergedCatalogRejectsMissingTextOutput(t *testing.T) {
+	spec, err := decodeSpec([]byte(
+		`{"models":[{"name":"m","kind":"generate"}]}`,
+	))
+	if err != nil {
+		t.Fatalf("decodeSpec: %v", err)
+	}
+	if _, err := mergedCatalog(spec); err == nil {
+		t.Fatal("mergedCatalog unexpectedly accepted a generate model without text output")
 	}
 }

--- a/driver/deepseek/generate_chat.go
+++ b/driver/deepseek/generate_chat.go
@@ -323,17 +323,24 @@ func compileChatIntent(
 	wire.temperature = clonePointer(text.Temperature)
 	wire.topP = clonePointer(text.TopP)
 	if text.ReasoningEnabled != nil {
-		if !entry.reasoning {
+		switch {
+		case entry.capabilities.Reasoning == inference.ReasoningNone:
 			ledger.reject(
 				inference.FieldGenerateIntentReasoningEnabled,
 				"model has no thinking control",
 			)
-		} else {
+		case entry.capabilities.Reasoning == inference.ReasoningAlways &&
+			!*text.ReasoningEnabled:
+			ledger.reject(
+				inference.FieldGenerateIntentReasoningEnabled,
+				"model cannot disable thinking",
+			)
+		default:
 			wire.thinking = clonePointer(text.ReasoningEnabled)
 		}
 	}
 	if text.ReasoningEffort != "" {
-		if !entry.reasoning {
+		if entry.capabilities.Reasoning == inference.ReasoningNone {
 			ledger.reject(
 				inference.FieldGenerateIntentReasoningEffort,
 				"model has no thinking control",

--- a/driver/deepseek/generate_responses.go
+++ b/driver/deepseek/generate_responses.go
@@ -254,7 +254,7 @@ func compileResponsesReasoning(
 		ledger.reject(field, "reasoning parts belong to assistant context")
 		return
 	}
-	if !entry.reasoning {
+	if entry.capabilities.Reasoning == inference.ReasoningNone {
 		ledger.drop(field, "model has no reasoning channel")
 		return
 	}
@@ -365,18 +365,26 @@ func compileResponsesIntent(
 	wire.temperature = clonePointer(text.Temperature)
 	wire.topP = clonePointer(text.TopP)
 	if text.ReasoningEnabled != nil {
-		if !entry.reasoning {
+		switch {
+		case entry.capabilities.Reasoning == inference.ReasoningNone:
 			ledger.reject(
 				inference.FieldGenerateIntentReasoningEnabled,
 				"model has no thinking control",
 			)
-		} else if !*text.ReasoningEnabled {
+		case entry.capabilities.Reasoning == inference.ReasoningAlways &&
+			!*text.ReasoningEnabled:
+			ledger.reject(
+				inference.FieldGenerateIntentReasoningEnabled,
+				"model cannot disable thinking",
+			)
+		case entry.capabilities.Reasoning == inference.ReasoningToggle &&
+			!*text.ReasoningEnabled:
 			wire.reasoning = "none"
 		}
 		// enabled == true is a no-op: DeepSeek thinks by default.
 	}
 	if text.ReasoningEffort != "" {
-		if !entry.reasoning {
+		if entry.capabilities.Reasoning == inference.ReasoningNone {
 			ledger.reject(
 				inference.FieldGenerateIntentReasoningEffort,
 				"model has no thinking control",
@@ -396,7 +404,7 @@ func compileResponsesGenerateOptions(
 	if options.WebSearch == nil {
 		return
 	}
-	if !entry.webSearch {
+	if !entry.capabilities.HostedWebSearch {
 		ledger.reject(
 			inference.ExtensionField("web_search").Qualify(options),
 			"model does not support hosted web search",

--- a/driver/deepseek/generate_test.go
+++ b/driver/deepseek/generate_test.go
@@ -84,19 +84,18 @@ func (s *capturedServer) captured() map[string]any {
 
 func chatEntry() catalogEntry {
 	return catalogEntry{
-		kind:      kindGenerate,
-		api:       apiChat,
-		reasoning: true,
+		kind:         kindGenerate,
+		api:          apiChat,
+		capabilities: generateChatCapabilities().WithReasoning(inference.ReasoningToggle),
 	}
 }
 
 func responsesEntry() catalogEntry {
 	return catalogEntry{
-		kind:      kindGenerate,
-		api:       apiResponses,
-		reasoning: true,
-		responses: true,
-		webSearch: true,
+		kind:         kindGenerate,
+		api:          apiResponses,
+		capabilities: generateChatCapabilities().WithHostedWebSearch().WithReasoning(inference.ReasoningToggle),
+		responses:    true,
 	}
 }
 

--- a/driver/deepseek/resource.go
+++ b/driver/deepseek/resource.go
@@ -143,10 +143,8 @@ func buildProvider(settings ResourceSettings) (inference.ProviderDefinition, err
 		entry.api = spec.apiMode()
 		id := inference.ModelID{Provider: settings.ID, Name: name}
 		descriptor := inference.ModelDescriptor{
-			ID: id,
-			Capabilities: inference.ModelCapabilities{
-				HostedWebSearch: entry.api == apiResponses && entry.webSearch,
-			},
+			ID:           id,
+			Capabilities: entry.capabilities,
 		}
 		if entry.maxInputTokens > 0 {
 			descriptor.Limits.MaxInputTokens = &entry.maxInputTokens

--- a/driver/deepseek/resource_test.go
+++ b/driver/deepseek/resource_test.go
@@ -82,7 +82,10 @@ func TestResponsesProviderAllowsDeclaredOverride(t *testing.T) {
 					"name": "deepseek-v4-flash",
 					"kind": "generate",
 					"responses": true,
-					"web_search": true
+					"capabilities": {
+						"outputs": ["text"],
+						"hosted_web_search": true
+					}
 				}]
 			},
 			"profiles": [{

--- a/driver/deepseek/spec.go
+++ b/driver/deepseek/spec.go
@@ -5,6 +5,7 @@ import (
 	"regexp"
 	"strings"
 
+	"github.com/GizClaw/flowcraft/core/inference"
 	"github.com/GizClaw/flowcraft/core/resource"
 )
 
@@ -32,19 +33,19 @@ type Spec struct {
 	Models []ModelSpec `json:"models,omitempty"`
 }
 
-// ModelSpec declares one model the deployment serves. Kind is the only
-// discriminator the compiler needs beyond the catalog defaults; the
-// capability flags describe the deployment's declared model.
+// ModelSpec declares one model the deployment serves. Capabilities mirror
+// the built-in catalog shape: content kinds, hosted web search, and the
+// reasoning control capability. Responses is a wire-surface fact and stays a
+// separate flag.
 type ModelSpec struct {
 	Name string `json:"name"`
 	Kind string `json:"kind"`
-	// Reasoning enables the thinking/effort controls and reasoning traces.
-	Reasoning bool `json:"reasoning,omitempty"`
+	// Capabilities declares the model's input/output content kinds, hosted
+	// web search support, and reasoning control capability.
+	Capabilities inference.ModelCapabilities `json:"capabilities,omitempty"`
 	// Responses declares Responses API support (deepseek-v4-flash and
 	// deepseek-v4-pro).
 	Responses bool `json:"responses,omitempty"`
-	// WebSearch declares hosted web_search support on the Responses API.
-	WebSearch bool `json:"web_search,omitempty"`
 }
 
 var modelNamePattern = regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9._-]*$`)
@@ -57,7 +58,7 @@ func (m ModelSpec) Validate() error {
 	if m.Kind != "" && m.Kind != string(kindGenerate) {
 		return fmt.Errorf("model %q declares unsupported kind %q", m.Name, m.Kind)
 	}
-	return nil
+	return m.Capabilities.Validate()
 }
 
 // Validate checks the provider spec for structural sanity.

--- a/driver/kimi/catalog.go
+++ b/driver/kimi/catalog.go
@@ -3,31 +3,28 @@ package kimi
 import (
 	"fmt"
 	"maps"
+	"slices"
 	"sort"
+
+	"github.com/GizClaw/flowcraft/core/inference"
+	"github.com/GizClaw/flowcraft/core/message"
 )
 
 type modelKind string
 
 const kindGenerate modelKind = "generate"
 
-// catalogEntry declares what one catalog model accepts. The zero value is
-// the bare text surface: the compiler rejects every channel the entry
-// omits, so a model never silently accepts a feature it may not serve.
+// catalogEntry declares what one catalog model accepts. capabilities is the
+// single capability fact source: input/output content kinds and the reasoning
+// control capability. sampling, reasoningEffort, keepThinking, and
+// keepThinkingAlways are control capabilities that no capability kind
+// expresses and stay separate flags.
 type catalogEntry struct {
-	kind modelKind
-	// vision accepts image input parts (URL or Base64 data URI).
-	vision bool
-	// video accepts video input parts (URL or Base64 data URI).
-	video bool
+	kind         modelKind
+	capabilities inference.ModelCapabilities
 	// sampling accepts the moonshot-v1 sampling knobs (temperature,
 	// top_p); the K3 / K2.x request schemas carry none.
 	sampling bool
-	// reasoning accepts the thinking control (enabled/disabled toggle, or
-	// the always-on k3 effort dial) and emits reasoning_content traces.
-	reasoning bool
-	// reasoningAlways marks models whose thinking cannot be switched off:
-	// ReasoningEnabled=false rejects (kimi-k3, kimi-k2.7-code).
-	reasoningAlways bool
 	// reasoningEffort marks models with the top-level reasoning_effort
 	// dial (kimi-k3 only); elsewhere an explicit effort drops with a
 	// reason.
@@ -53,74 +50,96 @@ type catalogEntry struct {
 //
 // The retired kimi-k2 series (offline 2026-05-25) and kimi-latest /
 // kimi-thinking-preview are deliberately absent. Video input is declared
-// for kimi-k3 only: the K2.x multimodal entries are documented for image
-// understanding, and video comprehension is a k3 capability.
+// for kimi-k3, kimi-k2.7-code, and kimi-k2.6 (official docs: "均支持文本、
+// 图片与视频输入"); kimi-k2.5 and the moonshot-v1 family are documented
+// for image understanding only.
 var catalog = map[string]catalogEntry{
 	"kimi-k3": {
-		kind:               kindGenerate,
-		vision:             true,
-		video:              true,
-		reasoning:          true,
-		reasoningAlways:    true,
+		kind: kindGenerate,
+		capabilities: generateChatCapabilities().
+			WithInputs(message.PartImage, message.PartVideo).
+			WithReasoning(inference.ReasoningAlways),
 		reasoningEffort:    true,
 		keepThinkingAlways: true,
 		maxInputTokens:     1_000_000,
 	},
 	"kimi-k2.7-code": {
-		kind:               kindGenerate,
-		vision:             true,
-		reasoning:          true,
-		reasoningAlways:    true,
+		kind: kindGenerate,
+		capabilities: generateChatCapabilities().
+			WithInputs(message.PartImage, message.PartVideo).
+			WithReasoning(inference.ReasoningAlways),
 		keepThinkingAlways: true,
 		maxInputTokens:     256_000,
 	},
 	"kimi-k2.7-code-highspeed": {
-		kind:               kindGenerate,
-		vision:             true,
-		reasoning:          true,
-		reasoningAlways:    true,
+		kind: kindGenerate,
+		capabilities: generateChatCapabilities().
+			WithInputs(message.PartImage, message.PartVideo).
+			WithReasoning(inference.ReasoningAlways),
 		keepThinkingAlways: true,
 		maxInputTokens:     256_000,
 	},
 	"kimi-k2.6": {
-		kind:           kindGenerate,
-		vision:         true,
-		reasoning:      true,
+		kind: kindGenerate,
+		capabilities: generateChatCapabilities().
+			WithInputs(message.PartImage, message.PartVideo).
+			WithReasoning(inference.ReasoningToggle),
 		keepThinking:   true,
 		maxInputTokens: 256_000,
 	},
 	"kimi-k2.5": {
-		kind:           kindGenerate,
-		vision:         true,
-		reasoning:      true,
+		kind: kindGenerate,
+		capabilities: generateChatCapabilities().
+			WithInputs(message.PartImage).
+			WithReasoning(inference.ReasoningToggle),
 		maxInputTokens: 256_000,
 	},
 
 	// moonshot-v1: text generation plus vision previews; the only family
 	// with sampling knobs and the only one without thinking.
-	"moonshot-v1-8k":                  {kind: kindGenerate, sampling: true, maxInputTokens: 8_192},
-	"moonshot-v1-32k":                 {kind: kindGenerate, sampling: true, maxInputTokens: 32_768},
-	"moonshot-v1-128k":                {kind: kindGenerate, sampling: true, maxInputTokens: 131_072},
-	"moonshot-v1-8k-vision-preview":   {kind: kindGenerate, sampling: true, vision: true, maxInputTokens: 8_192},
-	"moonshot-v1-32k-vision-preview":  {kind: kindGenerate, sampling: true, vision: true, maxInputTokens: 32_768},
-	"moonshot-v1-128k-vision-preview": {kind: kindGenerate, sampling: true, vision: true, maxInputTokens: 131_072},
+	"moonshot-v1-8k":                  {kind: kindGenerate, capabilities: generateChatCapabilities(), sampling: true, maxInputTokens: 8_192},
+	"moonshot-v1-32k":                 {kind: kindGenerate, capabilities: generateChatCapabilities(), sampling: true, maxInputTokens: 32_768},
+	"moonshot-v1-128k":                {kind: kindGenerate, capabilities: generateChatCapabilities(), sampling: true, maxInputTokens: 131_072},
+	"moonshot-v1-8k-vision-preview":   {kind: kindGenerate, capabilities: generateChatCapabilities().WithInputs(message.PartImage), sampling: true, maxInputTokens: 8_192},
+	"moonshot-v1-32k-vision-preview":  {kind: kindGenerate, capabilities: generateChatCapabilities().WithInputs(message.PartImage), sampling: true, maxInputTokens: 32_768},
+	"moonshot-v1-128k-vision-preview": {kind: kindGenerate, capabilities: generateChatCapabilities().WithInputs(message.PartImage), sampling: true, maxInputTokens: 131_072},
 }
 
 func (e catalogEntry) validate() error {
 	if e.kind != kindGenerate {
 		return fmt.Errorf("unsupported kind %q", e.kind)
 	}
-	if e.keepThinkingAlways && !e.reasoningAlways {
+	if err := e.capabilities.Validate(); err != nil {
+		return err
+	}
+	if !slices.Contains(e.capabilities.Outputs, message.PartText) {
+		return fmt.Errorf("generate family must declare text output")
+	}
+	if e.keepThinkingAlways && e.capabilities.Reasoning != inference.ReasoningAlways {
 		return fmt.Errorf("always-preserved thinking requires always-on thinking")
 	}
-	if e.reasoningEffort && !e.reasoning {
+	if e.reasoningEffort && e.capabilities.Reasoning == inference.ReasoningNone {
 		return fmt.Errorf("reasoning effort requires reasoning")
 	}
 	return nil
 }
 
+// generateChatCapabilities is the capability declaration for the Kimi text
+// compiler family: text/data/tool parts in, text out.
+func generateChatCapabilities() inference.ModelCapabilities {
+	return inference.ModelCapabilities{
+		Inputs: []message.PartKind{
+			message.PartText,
+			message.PartData,
+			message.PartToolCall,
+			message.PartToolResult,
+		},
+		Outputs: []message.PartKind{message.PartText},
+	}
+}
+
 // mergedCatalog overlays the built-in catalog with the spec's model
-// declarations: capability flags OR onto the same-named catalog entry,
+// declarations: capability lists union onto the same-named catalog entry,
 // and unknown names extend the catalog as bare generate models.
 func mergedCatalog(spec Spec) (map[string]catalogEntry, error) {
 	models := make(map[string]catalogEntry, len(catalog)+len(spec.Models))
@@ -136,15 +155,38 @@ func mergedCatalog(spec Spec) (map[string]catalogEntry, error) {
 		if entry.kind == "" {
 			entry.kind = kindGenerate
 		}
-		entry.vision = entry.vision || declared.Vision
-		entry.video = entry.video || declared.Video
-		entry.reasoning = entry.reasoning || declared.Reasoning
+		entry.capabilities.Inputs = unionKinds(
+			entry.capabilities.Inputs,
+			declared.Capabilities.Inputs,
+		)
+		entry.capabilities.Outputs = unionKinds(
+			entry.capabilities.Outputs,
+			declared.Capabilities.Outputs,
+		)
+		entry.capabilities.HostedWebSearch =
+			entry.capabilities.HostedWebSearch || declared.Capabilities.HostedWebSearch
+		if declared.Capabilities.Reasoning != inference.ReasoningNone {
+			entry.capabilities.Reasoning = declared.Capabilities.Reasoning
+		}
 		if err := entry.validate(); err != nil {
 			return nil, fmt.Errorf("model %q: %w", declared.Name, err)
 		}
 		models[declared.Name] = entry
 	}
 	return models, nil
+}
+
+// unionKinds appends any kind from addition that is not already present in
+// base, preserving base order. Spec declarations overlay catalog entries
+// additively.
+func unionKinds(base, addition []message.PartKind) []message.PartKind {
+	result := append([]message.PartKind(nil), base...)
+	for _, kind := range addition {
+		if !slices.Contains(result, kind) {
+			result = append(result, kind)
+		}
+	}
+	return result
 }
 
 // sortedNames returns catalog names in deterministic order so factory

--- a/driver/kimi/catalog_test.go
+++ b/driver/kimi/catalog_test.go
@@ -1,9 +1,12 @@
 package kimi
 
 import (
+	"reflect"
+	"slices"
 	"testing"
 
 	"github.com/GizClaw/flowcraft/core/inference"
+	"github.com/GizClaw/flowcraft/core/message"
 )
 
 func TestCatalogDeclaresMaxInputTokens(t *testing.T) {
@@ -39,5 +42,54 @@ func TestCatalogDeclaresMaxInputTokens(t *testing.T) {
 			t.Errorf("model %q: max input tokens = %v, want %d",
 				name, descriptor.Limits.MaxInputTokens, want)
 		}
+	}
+}
+
+func TestCatalogPublishesCapabilities(t *testing.T) {
+	provider, err := buildProvider(ResourceSettings{ID: "kimi"})
+	if err != nil {
+		t.Fatalf("buildProvider: %v", err)
+	}
+	descriptors := make(map[string]inference.ModelDescriptor, len(provider.Models))
+	for _, model := range provider.Models {
+		descriptors[model.Descriptor.ID.Name] = model.Descriptor
+	}
+
+	k3 := descriptors["kimi-k3"]
+	if !reflect.DeepEqual(k3.Capabilities.Outputs, []message.PartKind{message.PartText}) ||
+		!slices.Contains(k3.Capabilities.Inputs, message.PartImage) ||
+		!slices.Contains(k3.Capabilities.Inputs, message.PartVideo) ||
+		k3.Capabilities.Reasoning != inference.ReasoningAlways {
+		t.Fatalf("kimi-k3 capabilities = %+v", k3.Capabilities)
+	}
+
+	k26 := descriptors["kimi-k2.6"]
+	if !slices.Contains(k26.Capabilities.Inputs, message.PartVideo) ||
+		k26.Capabilities.Reasoning != inference.ReasoningToggle {
+		t.Fatalf("kimi-k2.6 capabilities = %+v", k26.Capabilities)
+	}
+
+	k27code := descriptors["kimi-k2.7-code"]
+	if !slices.Contains(k27code.Capabilities.Inputs, message.PartVideo) ||
+		k27code.Capabilities.Reasoning != inference.ReasoningAlways {
+		t.Fatalf("kimi-k2.7-code capabilities = %+v", k27code.Capabilities)
+	}
+
+	moonshot := descriptors["moonshot-v1-8k"]
+	if moonshot.Capabilities.Reasoning != inference.ReasoningNone ||
+		len(moonshot.Capabilities.Inputs) == 0 {
+		t.Fatalf("moonshot-v1-8k capabilities = %+v", moonshot.Capabilities)
+	}
+}
+
+func TestMergedCatalogRejectsMissingTextOutput(t *testing.T) {
+	spec, err := decodeSpec([]byte(
+		`{"models":[{"name":"m","kind":"generate"}]}`,
+	))
+	if err != nil {
+		t.Fatalf("decodeSpec: %v", err)
+	}
+	if _, err := mergedCatalog(spec); err == nil {
+		t.Fatal("mergedCatalog unexpectedly accepted a generate model without text output")
 	}
 }

--- a/driver/kimi/generate.go
+++ b/driver/kimi/generate.go
@@ -5,6 +5,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"slices"
 	"strings"
 
 	"github.com/GizClaw/flowcraft/core/inference"
@@ -318,7 +319,7 @@ func compileTurnMessage(
 		case message.TextPart:
 			appendText(value.Text)
 		case message.ImagePart:
-			if !entry.vision {
+			if !slices.Contains(entry.capabilities.Inputs, message.PartImage) {
 				ledger.reject(fields[message.PartImage], "model does not accept image input")
 				continue
 			}
@@ -336,7 +337,7 @@ func compileTurnMessage(
 				ImageURL: &wireMediaURL{URL: imageValue(value.Source)},
 			})
 		case message.VideoPart:
-			if !entry.video {
+			if !slices.Contains(entry.capabilities.Inputs, message.PartVideo) {
 				ledger.reject(fields[message.PartVideo], "model does not accept video input")
 				continue
 			}
@@ -497,11 +498,12 @@ func compileIntent(wire *generateWire, intent inference.Intent, entry catalogEnt
 func compileReasoning(wire *generateWire, text *inference.TextIntent, entry catalogEntry, ledger *ledger) {
 	if text.ReasoningEnabled != nil {
 		switch {
-		case !entry.reasoning:
+		case entry.capabilities.Reasoning == inference.ReasoningNone:
 			ledger.reject(inference.FieldGenerateIntentReasoningEnabled, "model has no thinking control")
-		case entry.reasoningAlways && !*text.ReasoningEnabled:
+		case entry.capabilities.Reasoning == inference.ReasoningAlways &&
+			!*text.ReasoningEnabled:
 			ledger.reject(inference.FieldGenerateIntentReasoningEnabled, "model always thinks; thinking cannot be disabled")
-		case entry.reasoningAlways:
+		case entry.capabilities.Reasoning == inference.ReasoningAlways:
 			// k3 / k2.7-code think unconditionally: an explicit true is a
 			// no-op, no wire field needed.
 		default:
@@ -514,7 +516,7 @@ func compileReasoning(wire *generateWire, text *inference.TextIntent, entry cata
 	}
 	if text.ReasoningEffort != "" {
 		switch {
-		case !entry.reasoning:
+		case entry.capabilities.Reasoning == inference.ReasoningNone:
 			ledger.reject(inference.FieldGenerateIntentReasoningEffort, "model has no thinking control")
 		case !entry.reasoningEffort:
 			ledger.drop(inference.FieldGenerateIntentReasoningEffort, "model's thinking is binary; no effort dial exists")

--- a/driver/kimi/resource.go
+++ b/driver/kimi/resource.go
@@ -94,7 +94,10 @@ func buildProvider(settings ResourceSettings) (inference.ProviderDefinition, err
 	for _, name := range sortedNames(models) {
 		entry := models[name]
 		id := inference.ModelID{Provider: settings.ID, Name: name}
-		descriptor := inference.ModelDescriptor{ID: id}
+		descriptor := inference.ModelDescriptor{
+			ID:           id,
+			Capabilities: entry.capabilities,
+		}
 		if entry.maxInputTokens > 0 {
 			descriptor.Limits.MaxInputTokens = &entry.maxInputTokens
 		}

--- a/driver/kimi/spec.go
+++ b/driver/kimi/spec.go
@@ -5,6 +5,7 @@ import (
 	"regexp"
 	"strings"
 
+	"github.com/GizClaw/flowcraft/core/inference"
 	"github.com/GizClaw/flowcraft/core/resource"
 )
 
@@ -27,16 +28,16 @@ type Spec struct {
 	Models []ModelSpec `json:"models,omitempty"`
 }
 
-// ModelSpec declares one model the deployment serves. Capability flags OR
+// ModelSpec declares one model the deployment serves. Capability lists union
 // onto the catalog entry of the same name (or a fresh generate entry for
-// unknown names): a spec model can widen a model's surface, never narrow
-// it below what the catalog already promises.
+// unknown names): a spec model can widen a model's surface, never narrow it
+// below what the catalog already promises.
 type ModelSpec struct {
-	Name      string `json:"name"`
-	Kind      string `json:"kind"`
-	Vision    bool   `json:"vision,omitempty"`
-	Video     bool   `json:"video,omitempty"`
-	Reasoning bool   `json:"reasoning,omitempty"`
+	Name string `json:"name"`
+	Kind string `json:"kind"`
+	// Capabilities declares the model's input/output content kinds and the
+	// reasoning control capability.
+	Capabilities inference.ModelCapabilities `json:"capabilities,omitempty"`
 }
 
 var modelNamePattern = regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9._-]*$`)
@@ -49,7 +50,7 @@ func (m ModelSpec) Validate() error {
 	if m.Kind != "" && m.Kind != string(kindGenerate) {
 		return fmt.Errorf("model %q declares unsupported kind %q", m.Name, m.Kind)
 	}
-	return nil
+	return m.Capabilities.Validate()
 }
 
 // Validate checks the provider spec for structural sanity.

--- a/driver/minimax/catalog.go
+++ b/driver/minimax/catalog.go
@@ -3,7 +3,11 @@ package minimax
 import (
 	"fmt"
 	"maps"
+	"slices"
 	"sort"
+
+	"github.com/GizClaw/flowcraft/core/inference"
+	"github.com/GizClaw/flowcraft/core/message"
 )
 
 type modelKind string
@@ -16,22 +20,13 @@ const (
 	kindMusic    modelKind = "music"
 )
 
-// catalogEntry declares what one catalog model accepts. The zero value is
-// the bare text surface: the compiler rejects every channel the entry
-// omits, so a model never silently accepts a feature it may not serve.
+// catalogEntry declares what one catalog model accepts. capabilities is the
+// single capability fact source: input/output content kinds and the reasoning
+// control capability. video10s, videoHD, and videoI2VOnly are control
+// capabilities that no capability kind expresses and stay separate flags.
 type catalogEntry struct {
-	kind modelKind
-	// vision accepts image input parts (MiniMax-M3 only; M2.x is
-	// text-only).
-	vision bool
-	// reasoning accepts the reasoning intent and emits thinking traces.
-	// Every M-series model reasons; M3 keeps thinking off unless asked,
-	// M2.x thinks unconditionally.
-	reasoning bool
-	// reasoningDisable can force thinking off: MiniMax-M3 honors
-	// thinking: {type: "disabled"}, the M2.x series does not and rejects
-	// a disable request at compile time.
-	reasoningDisable bool
+	kind         modelKind
+	capabilities inference.ModelCapabilities
 	// video10s accepts 10-second durations at 768P.
 	video10s bool
 	// videoHD accepts 1080P resolution.
@@ -45,6 +40,51 @@ type catalogEntry struct {
 	maxInputTokens int
 }
 
+// validate enforces the family contract: the compiler bound by kind can only
+// serve the output modalities it produces, so kind and capabilities cannot
+// drift.
+func (e catalogEntry) validate() error {
+	if err := e.capabilities.Validate(); err != nil {
+		return err
+	}
+	switch e.kind {
+	case kindGenerate:
+		if !slices.Contains(e.capabilities.Outputs, message.PartText) {
+			return fmt.Errorf("generate family must declare text output")
+		}
+	case kindImage:
+		if !slices.Contains(e.capabilities.Outputs, message.PartImage) {
+			return fmt.Errorf("image family must declare image output")
+		}
+	case kindTTS, kindMusic:
+		if !slices.Contains(e.capabilities.Outputs, message.PartAudio) {
+			return fmt.Errorf("%s family must declare audio output", e.kind)
+		}
+	case kindVideo:
+		if !slices.Contains(e.capabilities.Outputs, message.PartVideo) {
+			return fmt.Errorf("video family must declare video output")
+		}
+	default:
+		return fmt.Errorf("unsupported kind %q", e.kind)
+	}
+	return nil
+}
+
+// generateChatCapabilities is the common capability declaration for the
+// MiniMax Messages compiler family. Individual entries add image input when
+// the model has vision and the reasoning kind the model serves.
+func generateChatCapabilities() inference.ModelCapabilities {
+	return inference.ModelCapabilities{
+		Inputs: []message.PartKind{
+			message.PartText,
+			message.PartData,
+			message.PartToolCall,
+			message.PartToolResult,
+		},
+		Outputs: []message.PartKind{message.PartText},
+	}
+}
+
 // catalog reflects MiniMax's lineup as of 2026-07. Sources:
 //   - https://platform.minimaxi.com/docs/api-reference/api-overview
 //   - https://platform.minimaxi.com/docs/api-reference/speech-t2a-http
@@ -54,43 +94,164 @@ type catalogEntry struct {
 // All generate entries speak the binary-thinking dialect: any requested
 // reasoning effort compiles to thinking: {type: "adaptive"} — the endpoint
 // has no effort levels. MiniMax-M3 holds a 1M token context; the M2.x
-// series holds 204,800. Music generation (music-3.0) is deliberately
-// absent: the canonical audio intent is voice-shaped and has no honest
-// surface for lyrics/instrumental control.
+// series holds 204,800. Music generation (music-3.0) serves the canonical
+// audio intent with lyrics/format through MusicOptions; music-cover stays
+// out because it has no honest surface in that intent.
 var catalog = map[string]catalogEntry{
-	"MiniMax-M3":             {kind: kindGenerate, vision: true, reasoning: true, reasoningDisable: true, maxInputTokens: 1_000_000},
-	"MiniMax-M2.7":           {kind: kindGenerate, reasoning: true, maxInputTokens: 204_800},
-	"MiniMax-M2.7-highspeed": {kind: kindGenerate, reasoning: true, maxInputTokens: 204_800},
-	"MiniMax-M2.5":           {kind: kindGenerate, reasoning: true, maxInputTokens: 204_800},
-	"MiniMax-M2.5-highspeed": {kind: kindGenerate, reasoning: true, maxInputTokens: 204_800},
-	"MiniMax-M2.1":           {kind: kindGenerate, reasoning: true, maxInputTokens: 204_800},
-	"MiniMax-M2.1-highspeed": {kind: kindGenerate, reasoning: true, maxInputTokens: 204_800},
-	"MiniMax-M2":             {kind: kindGenerate, reasoning: true, maxInputTokens: 204_800},
+	"MiniMax-M3": {
+		kind: kindGenerate,
+		capabilities: generateChatCapabilities().
+			WithInputs(message.PartImage).
+			WithReasoning(inference.ReasoningToggle),
+		maxInputTokens: 1_000_000,
+	},
+	"MiniMax-M2.7": {
+		kind: kindGenerate,
+		capabilities: generateChatCapabilities().
+			WithReasoning(inference.ReasoningAlways),
+		maxInputTokens: 204_800,
+	},
+	"MiniMax-M2.7-highspeed": {
+		kind: kindGenerate,
+		capabilities: generateChatCapabilities().
+			WithReasoning(inference.ReasoningAlways),
+		maxInputTokens: 204_800,
+	},
+	"MiniMax-M2.5": {
+		kind: kindGenerate,
+		capabilities: generateChatCapabilities().
+			WithReasoning(inference.ReasoningAlways),
+		maxInputTokens: 204_800,
+	},
+	"MiniMax-M2.5-highspeed": {
+		kind: kindGenerate,
+		capabilities: generateChatCapabilities().
+			WithReasoning(inference.ReasoningAlways),
+		maxInputTokens: 204_800,
+	},
+	"MiniMax-M2.1": {
+		kind: kindGenerate,
+		capabilities: generateChatCapabilities().
+			WithReasoning(inference.ReasoningAlways),
+		maxInputTokens: 204_800,
+	},
+	"MiniMax-M2.1-highspeed": {
+		kind: kindGenerate,
+		capabilities: generateChatCapabilities().
+			WithReasoning(inference.ReasoningAlways),
+		maxInputTokens: 204_800,
+	},
+	"MiniMax-M2": {
+		kind: kindGenerate,
+		capabilities: generateChatCapabilities().
+			WithReasoning(inference.ReasoningAlways),
+		maxInputTokens: 204_800,
+	},
 
 	// Speech synthesis (t2a_v2): HD and turbo tiers.
-	"speech-2.8-hd":    {kind: kindTTS},
-	"speech-2.8-turbo": {kind: kindTTS},
-	"speech-2.6-hd":    {kind: kindTTS},
-	"speech-2.6-turbo": {kind: kindTTS},
-	"speech-02-hd":     {kind: kindTTS},
-	"speech-02-turbo":  {kind: kindTTS},
+	"speech-2.8-hd": {
+		kind: kindTTS,
+		capabilities: inference.ModelCapabilities{}.
+			WithInputs(message.PartText).
+			WithOutputs(message.PartAudio),
+	},
+	"speech-2.8-turbo": {
+		kind: kindTTS,
+		capabilities: inference.ModelCapabilities{}.
+			WithInputs(message.PartText).
+			WithOutputs(message.PartAudio),
+	},
+	"speech-2.6-hd": {
+		kind: kindTTS,
+		capabilities: inference.ModelCapabilities{}.
+			WithInputs(message.PartText).
+			WithOutputs(message.PartAudio),
+	},
+	"speech-2.6-turbo": {
+		kind: kindTTS,
+		capabilities: inference.ModelCapabilities{}.
+			WithInputs(message.PartText).
+			WithOutputs(message.PartAudio),
+	},
+	"speech-02-hd": {
+		kind: kindTTS,
+		capabilities: inference.ModelCapabilities{}.
+			WithInputs(message.PartText).
+			WithOutputs(message.PartAudio),
+	},
+	"speech-02-turbo": {
+		kind: kindTTS,
+		capabilities: inference.ModelCapabilities{}.
+			WithInputs(message.PartText).
+			WithOutputs(message.PartAudio),
+	},
 
 	// Image generation.
-	"image-01":      {kind: kindImage},
-	"image-01-live": {kind: kindImage},
+	"image-01": {
+		kind: kindImage,
+		capabilities: inference.ModelCapabilities{}.
+			WithInputs(message.PartText, message.PartImage).
+			WithOutputs(message.PartImage),
+	},
+	"image-01-live": {
+		kind: kindImage,
+		capabilities: inference.ModelCapabilities{}.
+			WithInputs(message.PartText, message.PartImage).
+			WithOutputs(message.PartImage),
+	},
 
 	// Video generation (async task API). Hailuo-2.3-Fast is image-to-video
 	// only; the 2.3/02 pair runs 10s at 768P and 6s at 1080P.
-	"MiniMax-Hailuo-2.3":      {kind: kindVideo, video10s: true, videoHD: true},
-	"MiniMax-Hailuo-2.3-Fast": {kind: kindVideo, videoI2VOnly: true},
-	"MiniMax-Hailuo-02":       {kind: kindVideo, video10s: true, videoHD: true},
+	"MiniMax-Hailuo-2.3": {
+		kind: kindVideo,
+		capabilities: inference.ModelCapabilities{}.
+			WithInputs(message.PartText, message.PartImage).
+			WithOutputs(message.PartVideo),
+		video10s: true,
+		videoHD:  true,
+	},
+	"MiniMax-Hailuo-2.3-Fast": {
+		kind: kindVideo,
+		capabilities: inference.ModelCapabilities{}.
+			WithInputs(message.PartText, message.PartImage).
+			WithOutputs(message.PartVideo),
+		videoI2VOnly: true,
+	},
+	"MiniMax-Hailuo-02": {
+		kind: kindVideo,
+		capabilities: inference.ModelCapabilities{}.
+			WithInputs(message.PartText, message.PartImage).
+			WithOutputs(message.PartVideo),
+		video10s: true,
+		videoHD:  true,
+	},
 
 	// Music generation (text-to-music; music-cover stays out — see
 	// music.go). The -free tiers are rate-limited gratis twins.
-	"music-3.0":      {kind: kindMusic},
-	"music-3.0-free": {kind: kindMusic},
-	"music-2.6":      {kind: kindMusic},
-	"music-2.6-free": {kind: kindMusic},
+	"music-3.0": {
+		kind: kindMusic,
+		capabilities: inference.ModelCapabilities{}.
+			WithInputs(message.PartText).
+			WithOutputs(message.PartAudio),
+	},
+	"music-3.0-free": {
+		kind: kindMusic,
+		capabilities: inference.ModelCapabilities{}.
+			WithInputs(message.PartText).
+			WithOutputs(message.PartAudio),
+	},
+	"music-2.6": {
+		kind: kindMusic,
+		capabilities: inference.ModelCapabilities{}.
+			WithInputs(message.PartText).
+			WithOutputs(message.PartAudio),
+	},
+	"music-2.6-free": {
+		kind: kindMusic,
+		capabilities: inference.ModelCapabilities{}.
+			WithInputs(message.PartText).
+			WithOutputs(message.PartAudio),
+	},
 }
 
 // mergedCatalog overlays the built-in catalog with the spec's model
@@ -102,9 +263,8 @@ func mergedCatalog(spec Spec) (map[string]catalogEntry, error) {
 	maps.Copy(models, catalog)
 	for _, declared := range spec.Models {
 		entry := catalogEntry{
-			kind:      modelKind(declared.Kind),
-			vision:    declared.Vision,
-			reasoning: declared.Reasoning,
+			kind:         modelKind(declared.Kind),
+			capabilities: declared.Capabilities,
 		}
 		if entry.kind == "" {
 			if existing, exists := models[declared.Name]; exists {
@@ -113,21 +273,14 @@ func mergedCatalog(spec Spec) (map[string]catalogEntry, error) {
 				entry.kind = kindGenerate
 			}
 		}
-		if err := entry.validate(); err != nil {
-			return nil, fmt.Errorf("model %q: %w", declared.Name, err)
-		}
 		models[declared.Name] = entry
 	}
-	return models, nil
-}
-
-func (e catalogEntry) validate() error {
-	switch e.kind {
-	case kindGenerate, kindImage, kindTTS, kindVideo, kindMusic:
-		return nil
-	default:
-		return fmt.Errorf("unsupported kind %q", e.kind)
+	for name, entry := range models {
+		if err := entry.validate(); err != nil {
+			return nil, fmt.Errorf("model %q: %w", name, err)
+		}
 	}
+	return models, nil
 }
 
 // sortedNames returns catalog names in deterministic order so factory

--- a/driver/minimax/catalog_test.go
+++ b/driver/minimax/catalog_test.go
@@ -1,9 +1,12 @@
 package minimax
 
 import (
+	"reflect"
+	"slices"
 	"testing"
 
 	"github.com/GizClaw/flowcraft/core/inference"
+	"github.com/GizClaw/flowcraft/core/message"
 )
 
 func TestCatalogDeclaresMaxInputTokens(t *testing.T) {
@@ -36,5 +39,64 @@ func TestCatalogDeclaresMaxInputTokens(t *testing.T) {
 			t.Errorf("model %q: max input tokens = %v, want %d",
 				name, descriptor.Limits.MaxInputTokens, want)
 		}
+	}
+}
+
+func TestCatalogPublishesCapabilities(t *testing.T) {
+	provider, err := buildProvider(ResourceSettings{ID: "minimax"})
+	if err != nil {
+		t.Fatalf("buildProvider: %v", err)
+	}
+	descriptors := make(map[string]inference.ModelDescriptor, len(provider.Models))
+	for _, model := range provider.Models {
+		descriptors[model.Descriptor.ID.Name] = model.Descriptor
+	}
+
+	m3 := descriptors["MiniMax-M3"]
+	if !reflect.DeepEqual(m3.Capabilities.Outputs, []message.PartKind{message.PartText}) ||
+		!slices.Contains(m3.Capabilities.Inputs, message.PartImage) ||
+		m3.Capabilities.Reasoning != inference.ReasoningToggle {
+		t.Fatalf("M3 capabilities = %+v", m3.Capabilities)
+	}
+
+	m2 := descriptors["MiniMax-M2.7"]
+	if m2.Capabilities.Reasoning != inference.ReasoningAlways {
+		t.Fatalf("M2.7 reasoning = %q, want always", m2.Capabilities.Reasoning)
+	}
+
+	image := descriptors["image-01"]
+	if !reflect.DeepEqual(image.Capabilities.Outputs, []message.PartKind{message.PartImage}) ||
+		!reflect.DeepEqual(
+			image.Capabilities.Inputs,
+			[]message.PartKind{message.PartText, message.PartImage},
+		) {
+		t.Fatalf("image capabilities = %+v", image.Capabilities)
+	}
+
+	video := descriptors["MiniMax-Hailuo-2.3"]
+	if !reflect.DeepEqual(video.Capabilities.Outputs, []message.PartKind{message.PartVideo}) {
+		t.Fatalf("video outputs = %v, want video", video.Capabilities.Outputs)
+	}
+
+	tts := descriptors["speech-2.8-hd"]
+	if !reflect.DeepEqual(tts.Capabilities.Outputs, []message.PartKind{message.PartAudio}) {
+		t.Fatalf("tts outputs = %v, want audio", tts.Capabilities.Outputs)
+	}
+
+	music := descriptors["music-3.0"]
+	if !reflect.DeepEqual(music.Capabilities.Outputs, []message.PartKind{message.PartAudio}) {
+		t.Fatalf("music outputs = %v, want audio", music.Capabilities.Outputs)
+	}
+}
+
+func TestMergedCatalogRejectsFamilyContractViolation(t *testing.T) {
+	spec, err := decodeSpec([]byte(
+		`{"models":[{"name":"m","kind":"video","capabilities":{"outputs":["text"]}}]}`,
+	))
+	if err != nil {
+		t.Fatalf("decodeSpec: %v", err)
+	}
+	if _, err := mergedCatalog(spec); err == nil {
+		t.Fatal("mergedCatalog unexpectedly accepted contract violation")
 	}
 }

--- a/driver/minimax/generate.go
+++ b/driver/minimax/generate.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/json"
+	"slices"
 
 	"github.com/GizClaw/flowcraft/core/inference"
 	"github.com/GizClaw/flowcraft/core/message"
@@ -300,7 +301,7 @@ func compileMessage(
 		case message.TextPart:
 			wire.appendBlock(role, wireBlock{kind: wireBlockText, text: value.Text})
 		case message.ImagePart:
-			if !entry.vision {
+			if !slices.Contains(entry.capabilities.Inputs, message.PartImage) {
 				ledger.reject(fields[message.PartImage], "model does not accept image input")
 				continue
 			}
@@ -476,12 +477,13 @@ func compileIntent(
 	wire.topP = text.TopP
 	if text.ReasoningEnabled != nil {
 		switch {
-		case !entry.reasoning:
+		case entry.capabilities.Reasoning == inference.ReasoningNone:
 			ledger.reject(
 				inference.FieldGenerateIntentReasoningEnabled,
 				"model has no thinking to switch",
 			)
-		case !*text.ReasoningEnabled && !entry.reasoningDisable:
+		case entry.capabilities.Reasoning == inference.ReasoningAlways &&
+			!*text.ReasoningEnabled:
 			ledger.reject(
 				inference.FieldGenerateIntentReasoningEnabled,
 				"model cannot disable thinking",
@@ -492,13 +494,12 @@ func compileIntent(
 		}
 	}
 	if text.ReasoningEffort != "" {
-		switch {
-		case !entry.reasoning:
+		if entry.capabilities.Reasoning == inference.ReasoningNone {
 			ledger.reject(
 				inference.FieldGenerateIntentReasoningEffort,
 				"model has no reasoning effort control",
 			)
-		default:
+		} else {
 			// MiniMax's Messages dialect is binary thinking: the level
 			// cannot be honored, but the request for reasoning itself is —
 			// turn thinking on and report the loss.

--- a/driver/minimax/generate_open.go
+++ b/driver/minimax/generate_open.go
@@ -20,8 +20,6 @@ func openGenerate(
 	return bindGenerate(
 		cls.api,
 		id.Name,
-		entry.vision,
-		entry.reasoning,
-		entry.reasoningDisable,
+		entry.capabilities,
 	)
 }

--- a/driver/minimax/kernel.go
+++ b/driver/minimax/kernel.go
@@ -14,14 +14,12 @@ import (
 func bindGenerate(
 	client anthropicgo.Client,
 	model string,
-	vision, reasoning, reasoningDisable bool,
+	capabilities inference.ModelCapabilities,
 ) (inference.GenerateOperations, error) {
 	return inference.BindGenerateOperations(
 		compileGenerate(model, catalogEntry{
-			kind:             kindGenerate,
-			vision:           vision,
-			reasoning:        reasoning,
-			reasoningDisable: reasoningDisable,
+			kind:         kindGenerate,
+			capabilities: capabilities,
 		}),
 		transportGenerate(client),
 		decodeGenerate,

--- a/driver/minimax/resource.go
+++ b/driver/minimax/resource.go
@@ -95,7 +95,10 @@ func buildProvider(settings ResourceSettings) (inference.ProviderDefinition, err
 	for _, name := range sortedNames(models) {
 		entry := models[name]
 		id := inference.ModelID{Provider: settings.ID, Name: name}
-		descriptor := inference.ModelDescriptor{ID: id}
+		descriptor := inference.ModelDescriptor{
+			ID:           id,
+			Capabilities: entry.capabilities,
+		}
 		if entry.maxInputTokens > 0 {
 			descriptor.Limits.MaxInputTokens = &entry.maxInputTokens
 		}

--- a/driver/minimax/spec.go
+++ b/driver/minimax/spec.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/GizClaw/flowcraft/core/inference"
 	"github.com/GizClaw/flowcraft/core/resource"
 )
 
@@ -36,10 +37,12 @@ type Spec struct {
 
 // ModelSpec declares one model the deployment serves.
 type ModelSpec struct {
-	Name      string `json:"name"`
-	Kind      string `json:"kind"`
-	Vision    bool   `json:"vision,omitempty"`
-	Reasoning bool   `json:"reasoning,omitempty"`
+	Name string `json:"name"`
+	Kind string `json:"kind"`
+	// Capabilities declares the model's input/output content kinds and the
+	// reasoning control capability, validated against the kind's compiler
+	// contract at merge time.
+	Capabilities inference.ModelCapabilities `json:"capabilities,omitempty"`
 }
 
 var modelNamePattern = regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9._-]*$`)
@@ -56,7 +59,7 @@ func (m ModelSpec) Validate() error {
 		modelKind(m.Kind) != kindMusic {
 		return fmt.Errorf("model %q declares unsupported kind %q", m.Name, m.Kind)
 	}
-	return nil
+	return m.Capabilities.Validate()
 }
 
 // Validate checks the provider spec for structural sanity.

--- a/driver/openai/catalog.go
+++ b/driver/openai/catalog.go
@@ -104,17 +104,17 @@ var catalog = map[string]catalogEntry{
 	// Generate — GPT-5.6 flagship family (reasoning + vision).
 	"gpt-5.6-sol": {
 		kind:           kindGenerate,
-		capabilities:   generateChatCapabilities().WithInputs(message.PartImage).WithHostedWebSearch().WithReasoning(inference.ReasoningAlways),
+		capabilities:   generateChatCapabilities().WithInputs(message.PartImage).WithHostedWebSearch().WithReasoning(inference.ReasoningToggle),
 		maxInputTokens: 1_050_000,
 	},
 	"gpt-5.6-terra": {
 		kind:           kindGenerate,
-		capabilities:   generateChatCapabilities().WithInputs(message.PartImage).WithHostedWebSearch().WithReasoning(inference.ReasoningAlways),
+		capabilities:   generateChatCapabilities().WithInputs(message.PartImage).WithHostedWebSearch().WithReasoning(inference.ReasoningToggle),
 		maxInputTokens: 1_050_000,
 	},
 	"gpt-5.6-luna": {
 		kind:           kindGenerate,
-		capabilities:   generateChatCapabilities().WithInputs(message.PartImage).WithHostedWebSearch().WithReasoning(inference.ReasoningAlways),
+		capabilities:   generateChatCapabilities().WithInputs(message.PartImage).WithHostedWebSearch().WithReasoning(inference.ReasoningToggle),
 		maxInputTokens: 1_050_000,
 	},
 	// Generate — previous generations, superseded but available.
@@ -157,6 +157,7 @@ var catalog = map[string]catalogEntry{
 	"gpt-4.1-nano": {
 		kind:           kindGenerate,
 		capabilities:   generateChatCapabilities().WithInputs(message.PartImage),
+		deprecated:     true, replacement: "gpt-5.6-luna",
 		maxInputTokens: 1_047_576,
 	},
 
@@ -173,7 +174,7 @@ var catalog = map[string]catalogEntry{
 	"gpt-image-2": {
 		kind: kindImage,
 		capabilities: inference.ModelCapabilities{}.
-			WithInputs(message.PartText).
+			WithInputs(message.PartText, message.PartImage).
 			WithOutputs(message.PartImage),
 	},
 	"gpt-image-1": {

--- a/driver/openai/catalog.go
+++ b/driver/openai/catalog.go
@@ -155,9 +155,9 @@ var catalog = map[string]catalogEntry{
 	},
 	// gpt-4.1-nano has no hosted web_search tool.
 	"gpt-4.1-nano": {
-		kind:           kindGenerate,
-		capabilities:   generateChatCapabilities().WithInputs(message.PartImage),
-		deprecated:     true, replacement: "gpt-5.6-luna",
+		kind:         kindGenerate,
+		capabilities: generateChatCapabilities().WithInputs(message.PartImage),
+		deprecated:   true, replacement: "gpt-5.6-luna",
 		maxInputTokens: 1_047_576,
 	},
 

--- a/driver/openai/catalog_test.go
+++ b/driver/openai/catalog_test.go
@@ -72,9 +72,9 @@ func TestCatalogPublishesCapabilities(t *testing.T) {
 	if !flagship.Capabilities.HostedWebSearch {
 		t.Fatal("gpt-5.6-sol must declare hosted web search")
 	}
-	if flagship.Capabilities.Reasoning != inference.ReasoningAlways {
+	if flagship.Capabilities.Reasoning != inference.ReasoningToggle {
 		t.Fatalf(
-			"gpt-5.6-sol reasoning = %q, want always",
+			"gpt-5.6-sol reasoning = %q, want toggle",
 			flagship.Capabilities.Reasoning,
 		)
 	}
@@ -82,6 +82,11 @@ func TestCatalogPublishesCapabilities(t *testing.T) {
 	nano := descriptors["gpt-4.1-nano"]
 	if nano.Capabilities.HostedWebSearch {
 		t.Fatal("gpt-4.1-nano must not declare hosted web search")
+	}
+	if nano.Lifecycle.Status != inference.ModelStatusDeprecated ||
+		nano.Lifecycle.Replacement == nil ||
+		nano.Lifecycle.Replacement.Name != "gpt-5.6-luna" {
+		t.Fatalf("gpt-4.1-nano lifecycle = %+v", nano.Lifecycle)
 	}
 	if !slices.Contains(nano.Capabilities.Inputs, message.PartImage) {
 		t.Fatalf("gpt-4.1-nano inputs = %v, want image input", nano.Capabilities.Inputs)
@@ -99,7 +104,7 @@ func TestCatalogPublishesCapabilities(t *testing.T) {
 		[]message.PartKind{message.PartImage},
 	) || !reflect.DeepEqual(
 		image.Capabilities.Inputs,
-		[]message.PartKind{message.PartText},
+		[]message.PartKind{message.PartText, message.PartImage},
 	) {
 		t.Fatalf("gpt-image-2 capabilities = %+v", image.Capabilities)
 	}

--- a/driver/openai/conformance_test.go
+++ b/driver/openai/conformance_test.go
@@ -528,6 +528,26 @@ func TestConformanceImageCompiler(t *testing.T) {
 				Kind:  inference.UnsupportedFeature,
 			},
 			{
+				Name: "URL reference image has no upload channel",
+				Request: func() inference.GenerateRequest {
+					request := imageRequest()
+					source, err := media.NewImageURL(
+						"https://example.com/reference.png",
+						"image/png",
+					)
+					if err != nil {
+						t.Fatalf("NewImageURL: %v", err)
+					}
+					request.Input.Content.Parts = append(
+						request.Input.Content.Parts,
+						message.ImagePart{Source: source},
+					)
+					return request
+				},
+				Field: inference.FieldGenerateInputImage,
+				Kind:  inference.UnsupportedFeature,
+			},
+			{
 				Name: "text intent alongside image",
 				Request: func() inference.GenerateRequest {
 					request := imageRequest()

--- a/driver/openai/generate_openai_operations_test.go
+++ b/driver/openai/generate_openai_operations_test.go
@@ -5,6 +5,7 @@ package openai
 // decoding are both exercised.
 
 import (
+	"bytes"
 	"context"
 	"encoding/base64"
 	"encoding/json"
@@ -191,6 +192,101 @@ func TestImageTransport(t *testing.T) {
 	}
 	if part.Source.Kind() != media.SourceInline || len(part.Source.Bytes()) != len(png) {
 		t.Fatalf("image source = %v bytes", len(part.Source.Bytes()))
+	}
+	_ = capture.body(0)
+}
+
+func TestImageEditTransport(t *testing.T) {
+	// 1x1 transparent PNG reference image.
+	png, err := base64.StdEncoding.DecodeString(
+		"iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNkYPhfDwAChwGA60e6kgAAAABJRU5ErkJggg==",
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	server, capture := newCapturedOpenAI(t, func(
+		w http.ResponseWriter,
+		r *http.Request,
+		body map[string]any,
+	) {
+		if r.URL.Path != "/images/edits" {
+			t.Errorf("path = %s, want /images/edits", r.URL.Path)
+		}
+		if err := r.ParseMultipartForm(1 << 20); err != nil {
+			t.Errorf("parse multipart: %v", err)
+			return
+		}
+		files := r.MultipartForm.File["image[]"]
+		if len(files) != 1 {
+			t.Errorf("image files = %d, want 1", len(files))
+			return
+		}
+		file, err := files[0].Open()
+		if err != nil {
+			t.Errorf("open image file: %v", err)
+			return
+		}
+		defer func() { _ = file.Close() }()
+		data, err := io.ReadAll(file)
+		if err != nil {
+			t.Errorf("read image file: %v", err)
+			return
+		}
+		if !bytes.Equal(data, png) {
+			t.Errorf("uploaded image bytes = %d, want %d", len(data), len(png))
+		}
+		if prompt := r.MultipartForm.Value["prompt"]; len(prompt) != 1 ||
+			prompt[0] != "make it a red circle" {
+			t.Errorf("prompt = %v", r.MultipartForm.Value["prompt"])
+		}
+		w.Header().Set("Content-Type", "application/json")
+		payload, _ := json.Marshal(map[string]any{
+			"data":  []map[string]any{{"b64_json": base64.StdEncoding.EncodeToString(png)}},
+			"usage": map[string]any{"input_tokens": 12, "output_tokens": 0},
+		})
+		_, _ = fmt.Fprint(w, string(payload))
+	})
+	defer server.Close()
+	cls := testClients(t, server)
+
+	source, err := media.NewImageBytes(png, "image/png")
+	if err != nil {
+		t.Fatalf("NewImageBytes: %v", err)
+	}
+	request := inference.GenerateRequest{
+		Input: inference.GenerateInput{
+			Role: inference.InputRoleUser,
+			Content: inference.InputContent{
+				Content: message.Content{Parts: []message.Part{
+					message.TextPart{Text: "make it a red circle"},
+					message.ImagePart{Source: source},
+				}},
+				Intent: inference.Intent{Image: &inference.ImageIntent{}},
+			},
+		},
+	}
+	compiled, err := compileImage("gpt-image-2")(
+		context.Background(),
+		openaiModel("gpt-image-2"),
+		request,
+		inference.GenerateExecutionUnary,
+	)
+	if err != nil {
+		t.Fatalf("compileImage: %v", err)
+	}
+	if len(compiled.Wire.images) != 1 {
+		t.Fatalf("wire images = %d, want 1", len(compiled.Wire.images))
+	}
+	raw, err := transportImage(cls.api)(context.Background(), compiled.Wire)
+	if err != nil {
+		t.Fatalf("transportImage: %v", err)
+	}
+	response, err := decodeImage(context.Background(), raw)
+	if err != nil {
+		t.Fatalf("decodeImage: %v", err)
+	}
+	if len(response.Message.Content.Parts) != 1 {
+		t.Fatalf("parts = %d", len(response.Message.Content.Parts))
 	}
 	_ = capture.body(0)
 }

--- a/driver/openai/image.go
+++ b/driver/openai/image.go
@@ -1,9 +1,11 @@
 package openai
 
 import (
+	"bytes"
 	"context"
 	"encoding/base64"
 	"fmt"
+	"io"
 	"strings"
 
 	"github.com/GizClaw/flowcraft/core/inference"
@@ -14,11 +16,13 @@ import (
 	"github.com/openai/openai-go/v3/packages/param"
 )
 
-// Image generation runs on the images endpoint (gpt-image). The prompt is
-// the request's text; the endpoint takes no reference images on this
-// driver — image-to-image edits live on a separate API shape and are
-// rejected truthfully. gpt-image always returns base64 payloads, so URL
-// delivery has no native channel and is rejected.
+// Image generation runs on the images endpoint (gpt-image). Text-only
+// requests go to images/generations; requests that carry inline reference
+// images go to images/edits, which uploads the bytes as multipart files
+// (the official gpt-image-2 editing surface). URL-sourced reference images
+// have no upload channel — callers must materialize them inline. gpt-image
+// always returns base64 payloads, so URL delivery has no native channel and
+// is rejected.
 
 type imageWire struct {
 	model  string
@@ -26,6 +30,9 @@ type imageWire struct {
 	size   string // 1024x1024 | 1536x1024 | 1024x1536
 	count  int
 	format string // png | jpeg | webp
+	// images are inline reference images for image-to-image edits; empty
+	// means a text-only generation.
+	images []media.ImageSource
 }
 
 type imageRaw struct {
@@ -73,10 +80,14 @@ func compileImage(
 				case message.TextPart:
 					prompt = append(prompt, value.Text)
 				case message.ImagePart:
-					ledger.reject(
-						fields[message.PartImage],
-						"image edits have no channel on this driver; text prompts only",
-					)
+					if value.Source.Kind() != media.SourceInline {
+						ledger.reject(
+							fields[message.PartImage],
+							"images/edits uploads inline bytes; URL-sourced reference images have no channel",
+						)
+						continue
+					}
+					wire.images = append(wire.images, value.Source)
 				default:
 					ledger.reject(
 						fields[part.Kind()],
@@ -182,18 +193,40 @@ func transportImage(
 	client openai.Client,
 ) inference.Transport[imageWire, imageRaw] {
 	return func(ctx context.Context, wire imageWire) (imageRaw, error) {
-		params := openai.ImageGenerateParams{
-			Model:  wire.model,
-			Prompt: wire.prompt,
-			N:      param.NewOpt(int64(wire.count)),
+		var response *openai.ImagesResponse
+		var err error
+		if len(wire.images) == 0 {
+			params := openai.ImageGenerateParams{
+				Model:  wire.model,
+				Prompt: wire.prompt,
+				N:      param.NewOpt(int64(wire.count)),
+			}
+			if wire.size != "" {
+				params.Size = openai.ImageGenerateParamsSize(wire.size)
+			}
+			if wire.format != "" {
+				params.OutputFormat = openai.ImageGenerateParamsOutputFormat(wire.format)
+			}
+			response, err = client.Images.Generate(ctx, params)
+		} else {
+			readers := make([]io.Reader, 0, len(wire.images))
+			for _, source := range wire.images {
+				readers = append(readers, bytes.NewReader(source.Bytes()))
+			}
+			params := openai.ImageEditParams{
+				Model:  openai.ImageModel(wire.model),
+				Prompt: wire.prompt,
+				N:      param.NewOpt(int64(wire.count)),
+				Image:  openai.ImageEditParamsImageUnion{OfFileArray: readers},
+			}
+			if wire.size != "" {
+				params.Size = openai.ImageEditParamsSize(wire.size)
+			}
+			if wire.format != "" {
+				params.OutputFormat = openai.ImageEditParamsOutputFormat(wire.format)
+			}
+			response, err = client.Images.Edit(ctx, params)
 		}
-		if wire.size != "" {
-			params.Size = openai.ImageGenerateParamsSize(wire.size)
-		}
-		if wire.format != "" {
-			params.OutputFormat = openai.ImageGenerateParamsOutputFormat(wire.format)
-		}
-		response, err := client.Images.Generate(ctx, params)
 		if err != nil {
 			return imageRaw{}, classifyError(err)
 		}

--- a/driver/qwen/catalog.go
+++ b/driver/qwen/catalog.go
@@ -2,6 +2,10 @@ package qwen
 
 import (
 	"fmt"
+	"slices"
+
+	"github.com/GizClaw/flowcraft/core/inference"
+	"github.com/GizClaw/flowcraft/core/message"
 )
 
 type modelKind string
@@ -11,21 +15,14 @@ const (
 	kindEmbed    modelKind = "embed"
 )
 
-// catalogEntry declares what one catalog model accepts. The zero value is
-// the bare text surface: the compiler rejects every channel the entry
-// omits, so a model never silently accepts a feature it may not serve.
+// catalogEntry declares what one catalog model accepts. capabilities is the
+// single capability fact source: input/output content kinds and the reasoning
+// control capability. reasoningEffort, preserveThinking, thinkingStreamOnly,
+// and embedDimensions are control capabilities that no capability kind
+// expresses and stay separate flags.
 type catalogEntry struct {
-	kind modelKind
-	// vision accepts image input parts; multimodal models ride the
-	// multimodal-generation endpoint rather than text-generation, and the
-	// multimodal-embedding endpoint rather than text-embedding.
-	vision bool
-	// video accepts video input parts (frame lists or files) on the
-	// multimodal endpoint.
-	video bool
-	// reasoning accepts the thinking switch (enable_thinking) and emits
-	// reasoning_content traces.
-	reasoning bool
+	kind         modelKind
+	capabilities inference.ModelCapabilities
 	// reasoningEffort accepts the reasoning_effort levels
 	// (qwen3.8-max-preview only); other thinking models take
 	// thinking_budget through the extension instead.
@@ -52,33 +49,83 @@ type catalogEntry struct {
 //   - https://www.alibabacloud.com/help/zh/model-studio/models
 //
 // The qwen3.7/qwen3.8 commercial models are multimodal and hybrid-thinking;
-// thinking mode is stream-only server-side, so unary compiles with
-// thinking on reject the shape. The legacy qwen-plus/turbo/flash/max
-// names stay text-only here — custom models declare through the spec.
+// qwen3.8-max-preview is thinking-only (DashScope rejects enable_thinking
+// false with a 400), while the rest can toggle. Thinking mode is stream-only
+// server-side, so unary compiles with thinking on reject the shape. The
+// legacy qwen-plus/turbo/flash/max names stay text-only here — custom models
+// declare through the spec.
 var catalog = map[string]catalogEntry{
-	"qwen3.8-max-preview": {kind: kindGenerate, vision: true, video: true, reasoning: true, reasoningEffort: true, preserveThinking: true, thinkingStreamOnly: true, maxInputTokens: 983_616},
-	"qwen3.7-max":         {kind: kindGenerate, vision: true, video: true, reasoning: true, preserveThinking: true, thinkingStreamOnly: true, maxInputTokens: 991_808},
-	"qwen3.7-plus":        {kind: kindGenerate, vision: true, video: true, reasoning: true, preserveThinking: true, thinkingStreamOnly: true, maxInputTokens: 991_808},
-	"qwen3.7-flash":       {kind: kindGenerate, vision: true, video: true, reasoning: true, preserveThinking: true, thinkingStreamOnly: true, maxInputTokens: 991_808},
-	"qwen3-vl-plus":       {kind: kindGenerate, vision: true, video: true, reasoning: true, thinkingStreamOnly: true, maxInputTokens: 260_096},
-	"qwen3-vl-flash":      {kind: kindGenerate, vision: true, video: true, reasoning: true, thinkingStreamOnly: true, maxInputTokens: 260_096},
+	"qwen3.8-max-preview": {
+		kind: kindGenerate,
+		capabilities: generateChatCapabilities().
+			WithInputs(message.PartImage, message.PartVideo).
+			WithReasoning(inference.ReasoningAlways),
+		reasoningEffort:    true,
+		preserveThinking:   true,
+		thinkingStreamOnly: true,
+		maxInputTokens:     983_616,
+	},
+	"qwen3.7-max": {
+		kind: kindGenerate,
+		capabilities: generateChatCapabilities().
+			WithInputs(message.PartImage, message.PartVideo).
+			WithReasoning(inference.ReasoningToggle),
+		preserveThinking:   true,
+		thinkingStreamOnly: true,
+		maxInputTokens:     991_808,
+	},
+	"qwen3.7-plus": {
+		kind: kindGenerate,
+		capabilities: generateChatCapabilities().
+			WithInputs(message.PartImage, message.PartVideo).
+			WithReasoning(inference.ReasoningToggle),
+		preserveThinking:   true,
+		thinkingStreamOnly: true,
+		maxInputTokens:     991_808,
+	},
+	"qwen3.7-flash": {
+		kind: kindGenerate,
+		capabilities: generateChatCapabilities().
+			WithInputs(message.PartImage, message.PartVideo).
+			WithReasoning(inference.ReasoningToggle),
+		preserveThinking:   true,
+		thinkingStreamOnly: true,
+		maxInputTokens:     991_808,
+	},
+	"qwen3-vl-plus": {
+		kind: kindGenerate,
+		capabilities: generateChatCapabilities().
+			WithInputs(message.PartImage, message.PartVideo).
+			WithReasoning(inference.ReasoningToggle),
+		thinkingStreamOnly: true,
+		maxInputTokens:     260_096,
+	},
+	"qwen3-vl-flash": {
+		kind: kindGenerate,
+		capabilities: generateChatCapabilities().
+			WithInputs(message.PartImage, message.PartVideo).
+			WithReasoning(inference.ReasoningToggle),
+		thinkingStreamOnly: true,
+		maxInputTokens:     260_096,
+	},
 
-	"qwen-plus":  {kind: kindGenerate, maxInputTokens: 997_952},
-	"qwen-turbo": {kind: kindGenerate, maxInputTokens: 98_304},
-	"qwen-flash": {kind: kindGenerate, maxInputTokens: 997_952},
-	"qwen-max":   {kind: kindGenerate, maxInputTokens: 30_720},
+	"qwen-plus":  {kind: kindGenerate, capabilities: generateChatCapabilities(), maxInputTokens: 997_952},
+	"qwen-turbo": {kind: kindGenerate, capabilities: generateChatCapabilities(), maxInputTokens: 98_304},
+	"qwen-flash": {kind: kindGenerate, capabilities: generateChatCapabilities(), maxInputTokens: 997_952},
+	"qwen-max":   {kind: kindGenerate, capabilities: generateChatCapabilities(), maxInputTokens: 30_720},
 
 	// Embeddings. The multimodal model is served in the Beijing region
 	// only; text-embedding-v4 batches at most 10 rows per request.
 	"text-embedding-v4": {
 		kind:            kindEmbed,
+		capabilities:    inference.ModelCapabilities{}.WithInputs(message.PartText),
 		embedDimensions: []int{2048, 1536, 1024, 768, 512, 256, 128, 64},
 		maxInputTokens:  8_192,
 	},
 	"qwen3-vl-embedding": {
-		kind:            kindEmbed,
-		vision:          true,
-		video:           true,
+		kind: kindEmbed,
+		capabilities: inference.ModelCapabilities{}.
+			WithInputs(message.PartText, message.PartImage, message.PartVideo),
 		embedDimensions: []int{2560, 2048, 1536, 1024, 768, 512, 256},
 		maxInputTokens:  32_000,
 	},
@@ -88,15 +135,44 @@ func (e catalogEntry) validate() error {
 	if e.kind != kindGenerate && e.kind != kindEmbed {
 		return fmt.Errorf("unsupported kind %q", e.kind)
 	}
-	if e.kind == kindEmbed && (e.reasoning || e.reasoningEffort || e.preserveThinking || e.thinkingStreamOnly) {
+	if err := e.capabilities.Validate(); err != nil {
+		return err
+	}
+	if e.kind == kindGenerate && !slices.Contains(e.capabilities.Outputs, message.PartText) {
+		return fmt.Errorf("generate family must declare text output")
+	}
+	if e.kind == kindEmbed && len(e.capabilities.Outputs) != 0 {
+		return fmt.Errorf("embed family declares no generate output")
+	}
+	if e.kind == kindEmbed && e.capabilities.Reasoning != inference.ReasoningNone {
+		return fmt.Errorf("embed model cannot declare reasoning")
+	}
+	if e.kind == kindEmbed && (e.reasoningEffort || e.preserveThinking || e.thinkingStreamOnly) {
 		return fmt.Errorf("embed model cannot declare thinking flags")
 	}
 	return nil
 }
 
+// generateChatCapabilities is the capability declaration for the Qwen text
+// compiler family: text/data/tool parts in, text out.
+func generateChatCapabilities() inference.ModelCapabilities {
+	return inference.ModelCapabilities{
+		Inputs: []message.PartKind{
+			message.PartText,
+			message.PartData,
+			message.PartToolCall,
+			message.PartToolResult,
+		},
+		Outputs: []message.PartKind{message.PartText},
+	}
+}
+
 // multimodal reports whether the model rides the multimodal-generation
 // endpoint rather than text-generation.
-func (e catalogEntry) multimodal() bool { return e.vision || e.video }
+func (e catalogEntry) multimodal() bool {
+	return slices.Contains(e.capabilities.Inputs, message.PartImage) ||
+		slices.Contains(e.capabilities.Inputs, message.PartVideo)
+}
 
 // mergedCatalog overlays the spec's declared models on the built-in
 // catalog. Unknown kinds are rejected at build time; custom models get the
@@ -123,12 +199,36 @@ func mergedCatalog(spec Spec) (map[string]catalogEntry, error) {
 				entry.kind = kindGenerate
 			}
 		}
-		entry.vision = entry.vision || model.Vision
-		entry.reasoning = entry.reasoning || model.Reasoning
+		entry.capabilities.Inputs = unionKinds(
+			entry.capabilities.Inputs,
+			model.Capabilities.Inputs,
+		)
+		entry.capabilities.Outputs = unionKinds(
+			entry.capabilities.Outputs,
+			model.Capabilities.Outputs,
+		)
+		entry.capabilities.HostedWebSearch =
+			entry.capabilities.HostedWebSearch || model.Capabilities.HostedWebSearch
+		if model.Capabilities.Reasoning != inference.ReasoningNone {
+			entry.capabilities.Reasoning = model.Capabilities.Reasoning
+		}
 		if err := entry.validate(); err != nil {
 			return nil, fmt.Errorf("model %q: %w", model.Name, err)
 		}
 		merged[model.Name] = entry
 	}
 	return merged, nil
+}
+
+// unionKinds appends any kind from addition that is not already present in
+// base, preserving base order. Spec declarations overlay catalog entries
+// additively.
+func unionKinds(base, addition []message.PartKind) []message.PartKind {
+	result := append([]message.PartKind(nil), base...)
+	for _, kind := range addition {
+		if !slices.Contains(result, kind) {
+			result = append(result, kind)
+		}
+	}
+	return result
 }

--- a/driver/qwen/catalog_test.go
+++ b/driver/qwen/catalog_test.go
@@ -1,9 +1,12 @@
 package qwen
 
 import (
+	"reflect"
+	"slices"
 	"testing"
 
 	"github.com/GizClaw/flowcraft/core/inference"
+	"github.com/GizClaw/flowcraft/core/message"
 )
 
 func TestCatalogDeclaresMaxInputTokens(t *testing.T) {
@@ -39,5 +42,48 @@ func TestCatalogDeclaresMaxInputTokens(t *testing.T) {
 			t.Errorf("model %q: max input tokens = %v, want %d",
 				name, descriptor.Limits.MaxInputTokens, want)
 		}
+	}
+}
+
+func TestCatalogPublishesCapabilities(t *testing.T) {
+	provider, err := buildProvider(ResourceSettings{ID: "qwen"})
+	if err != nil {
+		t.Fatalf("buildProvider: %v", err)
+	}
+	descriptors := make(map[string]inference.ModelDescriptor, len(provider.Models))
+	for _, model := range provider.Models {
+		descriptors[model.Descriptor.ID.Name] = model.Descriptor
+	}
+
+	thinking := descriptors["qwen3.8-max-preview"]
+	if !reflect.DeepEqual(thinking.Capabilities.Outputs, []message.PartKind{message.PartText}) ||
+		!slices.Contains(thinking.Capabilities.Inputs, message.PartImage) ||
+		!slices.Contains(thinking.Capabilities.Inputs, message.PartVideo) ||
+		thinking.Capabilities.Reasoning != inference.ReasoningAlways {
+		t.Fatalf("thinking model capabilities = %+v", thinking.Capabilities)
+	}
+
+	plain := descriptors["qwen-plus"]
+	if plain.Capabilities.Reasoning != inference.ReasoningNone ||
+		len(plain.Capabilities.Inputs) == 0 {
+		t.Fatalf("plain model capabilities = %+v", plain.Capabilities)
+	}
+
+	embed := descriptors["qwen3-vl-embedding"]
+	if !slices.Contains(embed.Capabilities.Inputs, message.PartImage) ||
+		len(embed.Capabilities.Outputs) != 0 {
+		t.Fatalf("multimodal embed capabilities = %+v", embed.Capabilities)
+	}
+}
+
+func TestMergedCatalogRejectsEmbedReasoning(t *testing.T) {
+	spec, err := decodeSpec([]byte(
+		`{"models":[{"name":"m","kind":"embed","capabilities":{"reasoning":"toggle","inputs":["text"]}}]}`,
+	))
+	if err != nil {
+		t.Fatalf("decodeSpec: %v", err)
+	}
+	if _, err := mergedCatalog(spec); err == nil {
+		t.Fatal("mergedCatalog unexpectedly accepted an embed model with reasoning")
 	}
 }

--- a/driver/qwen/doc.go
+++ b/driver/qwen/doc.go
@@ -62,7 +62,7 @@
 // qwen3.8 hybrid-thinking multimodal models, the Qwen3-VL pair, and the
 // legacy text-only qwen-plus / turbo / flash / max, plus the two
 // embedding models above. Deployments declare additional models through
-// the spec (name, kind, vision, reasoning). Media output (image /
+// the spec (name, kind, capabilities). Media output (image /
 // speech / video generation) lives in dedicated DashScope SKUs, not this
 // driver.
 //

--- a/driver/qwen/generate.go
+++ b/driver/qwen/generate.go
@@ -5,6 +5,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"slices"
 	"strings"
 
 	"github.com/GizClaw/flowcraft/core/inference"
@@ -279,7 +280,7 @@ func (c *compiler) userMessage(
 			text := typed.Text
 			items = append(items, wireContentItem{Text: &text})
 		case message.ImagePart:
-			if !c.entry.vision {
+			if !slices.Contains(c.entry.capabilities.Inputs, message.PartImage) {
 				c.ledger.reject(
 					partFields[message.PartImage],
 					fmt.Sprintf("model %s does not accept image input", c.model),
@@ -288,7 +289,7 @@ func (c *compiler) userMessage(
 			}
 			items = append(items, wireContentItem{Image: imageValue(typed.Source)})
 		case message.VideoPart:
-			if !c.entry.video {
+			if !slices.Contains(c.entry.capabilities.Inputs, message.PartVideo) {
 				c.ledger.reject(
 					partFields[message.PartVideo],
 					fmt.Sprintf("model %s does not accept video input", c.model),
@@ -502,12 +503,19 @@ func (c *compiler) tools(text *inference.TextIntent) {
 // rejects the switch field itself.
 func (c *compiler) reasoning(text *inference.TextIntent) {
 	if text.ReasoningEnabled != nil {
-		if !c.entry.reasoning {
+		switch {
+		case c.entry.capabilities.Reasoning == inference.ReasoningNone:
 			c.ledger.reject(
 				inference.FieldGenerateIntentReasoningEnabled,
 				fmt.Sprintf("model %s has no thinking mode", c.model),
 			)
-		} else {
+		case c.entry.capabilities.Reasoning == inference.ReasoningAlways &&
+			!*text.ReasoningEnabled:
+			c.ledger.reject(
+				inference.FieldGenerateIntentReasoningEnabled,
+				fmt.Sprintf("model %s always thinks; thinking cannot be disabled", c.model),
+			)
+		default:
 			if *text.ReasoningEnabled && c.entry.thinkingStreamOnly && !c.stream {
 				c.ledger.reject(
 					inference.FieldGenerateIntentReasoningEnabled,
@@ -520,7 +528,7 @@ func (c *compiler) reasoning(text *inference.TextIntent) {
 	}
 	if text.ReasoningEffort != "" {
 		switch {
-		case !c.entry.reasoning:
+		case c.entry.capabilities.Reasoning == inference.ReasoningNone:
 			c.ledger.reject(
 				inference.FieldGenerateIntentReasoningEffort,
 				fmt.Sprintf("model %s has no thinking mode", c.model),
@@ -585,7 +593,7 @@ func (c *compiler) intents(request inference.GenerateRequest) {
 func (c *compiler) extensions() {
 	o := c.options
 	if o.ThinkingBudget != nil {
-		if !c.entry.reasoning {
+		if c.entry.capabilities.Reasoning == inference.ReasoningNone {
 			c.ledger.reject(
 				inference.ExtensionField("thinking_budget").Qualify(o),
 				fmt.Sprintf("model %s has no thinking budget", c.model),

--- a/driver/qwen/resource.go
+++ b/driver/qwen/resource.go
@@ -98,7 +98,10 @@ func buildProvider(settings ResourceSettings) (inference.ProviderDefinition, err
 	for _, name := range sortedNames(models) {
 		entry := models[name]
 		id := inference.ModelID{Provider: settings.ID, Name: name}
-		descriptor := inference.ModelDescriptor{ID: id}
+		descriptor := inference.ModelDescriptor{
+			ID:           id,
+			Capabilities: entry.capabilities,
+		}
 		if entry.maxInputTokens > 0 {
 			descriptor.Limits.MaxInputTokens = &entry.maxInputTokens
 		}

--- a/driver/qwen/spec.go
+++ b/driver/qwen/spec.go
@@ -5,6 +5,7 @@ import (
 	"regexp"
 	"strings"
 
+	"github.com/GizClaw/flowcraft/core/inference"
 	"github.com/GizClaw/flowcraft/core/resource"
 )
 
@@ -35,10 +36,12 @@ type Spec struct {
 
 // ModelSpec declares one model the deployment serves.
 type ModelSpec struct {
-	Name      string `json:"name"`
-	Kind      string `json:"kind"`
-	Vision    bool   `json:"vision,omitempty"`
-	Reasoning bool   `json:"reasoning,omitempty"`
+	Name string `json:"name"`
+	Kind string `json:"kind"`
+	// Capabilities declares the model's input/output content kinds and the
+	// reasoning control capability. Spec declarations overlay catalog
+	// entries additively (inputs/outputs union, reasoning overrides).
+	Capabilities inference.ModelCapabilities `json:"capabilities,omitempty"`
 }
 
 // ProfileSpec carries per-profile overrides; currently empty.
@@ -55,7 +58,7 @@ func (m ModelSpec) Validate() error {
 	default:
 		return fmt.Errorf("model %q declares unsupported kind %q", m.Name, m.Kind)
 	}
-	return nil
+	return m.Capabilities.Validate()
 }
 
 func (s Spec) Validate() error {


### PR DESCRIPTION
## Overview

Following core #386 (capability-aware routing), migrate all 8 driver built-in model catalogs to explicit `ModelCapabilities{Inputs, Outputs, HostedWebSearch, Reasoning}`, removing the legacy `vision` / `web_search` / `reasoning` derived flags and adding family contract validation (kind cannot drift from declared outputs).

One commit per driver, with model lineups aligned to each vendor's official docs:

- **openai**: GPT-5.6 family is `ReasoningToggle` (official `reasoning.effort` supports `none`); gpt-image-2 gains image input (inline reference images route to `images/edits`, URL sources rejected truthfully); gpt-4.1-nano marked deprecated (official shutdown 2026-10-23).
- **anthropic**: claude-fable-5 has always-on thinking (`ReasoningAlways`); adds claude-mythos-5 (same specs, limited release).
- **deepseek**: both V4 models declare server-side web search; the Responses API is declared per model (officially supported by both).
- **kimi**: kimi-k3 / k2.7-code / k2.7-code-highspeed / k2.6 declare video input (per official docs).
- **qwen**: qwen3.8-max-preview has always-on thinking (DashScope rejects `enable_thinking: false`).
- **minimax**: M3 keeps switchable thinking; M2.x thinking cannot be disabled.
- **bytedance**: removes the unused `kindRealtime`; lineup matches the official Volcengine Ark model list.
- **azure**: deployment spec migrated to `capabilities` declarations.

## Gates

`make ci`, `make lint`, `make release-check`, and `git diff --check` all pass.