### PR TITLE
chore(release): add core v0.1.22 changeset

### DIFF
--- a/.release/core-v0.1.22.json
+++ b/.release/core-v0.1.22.json
@@ -1,0 +1,9 @@
+{
+  "summary": "feat(core): declare model content capabilities and reasoning kind — ModelCapabilities gains explicit input/output content kinds (message.PartKind), a ReasoningKind control capability, and fluent With* composition, with PartKind validation and Intent.OutputKinds centralizing intent-to-content mapping while undeclared providers keep order-based routing; feat(core): route generate by declared output capabilities — the unified generate selector skips targets whose declared outputs cannot serve the request intent, and repeated model references across tiers collapse at build time so fallback never reattempts a failed target; feat(core): expose canonical intent envelope on graph inference node — the node accepts the canonical inference.Intent wire form (text/image/audio/video) through an intent config field, removing the TextIntent sugar knobs in favor of intent.text.* (BREAKING CHANGE: legacy text knobs are rejected at build time)",
+  "releases": [
+    {
+      "module": "core",
+      "bump": "patch"
+    }
+  ]
+}


### PR DESCRIPTION
Adds the immutable changeset for the next core release (`core/v0.1.22`, patch).

The summary covers the full delta since `core/v0.1.21`:
- feat(core): declare model content capabilities and reasoning kind (#386)
- feat(core): route generate by declared output capabilities (#386)
- feat(core): expose canonical intent envelope on graph inference node (#383)

Merging this PR triggers the Release modules workflow, which opens the changelog PR; merging that publishes `core/v0.1.22`.