### PR TITLE
fix(driver/bytedance): surface image request id in response metadata

### DIFF
--- a/driver/bytedance/go.mod
+++ b/driver/bytedance/go.mod
@@ -5,7 +5,7 @@ go 1.26.0
 require (
 	github.com/GizClaw/doubao-speech-go v0.0.0-20260723152315-fe8153366feb
 	github.com/GizClaw/flowcraft/core v0.1.22
-	github.com/volcengine/volcengine-go-sdk v1.2.14
+	github.com/volcengine/volcengine-go-sdk v1.2.48
 )
 
 require (
@@ -17,6 +17,7 @@ require (
 	github.com/gorilla/websocket v1.5.3 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.27.7 // indirect
 	github.com/jmespath/go-jmespath v0.4.0 // indirect
+	github.com/klauspost/compress v1.13.5 // indirect
 	github.com/santhosh-tekuri/jsonschema/v5 v5.3.1 // indirect
 	github.com/volcengine/volc-sdk-golang v1.0.23 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect

--- a/driver/bytedance/go.sum
+++ b/driver/bytedance/go.sum
@@ -55,6 +55,8 @@ github.com/jmespath/go-jmespath v0.4.0 h1:BEgLn5cpjn8UN1mAw4NjwDrS35OdebyEtFe+9Y
 github.com/jmespath/go-jmespath v0.4.0/go.mod h1:T8mJZnbsbmF+m6zOOFylbeCJqk5+pHWvzYPziyZiYoo=
 github.com/jmespath/go-jmespath/internal/testify v1.5.1 h1:shLQSRRSCCPj3f2gpwzGwWFoC7ycTf1rcQZHOlsJ6N8=
 github.com/jmespath/go-jmespath/internal/testify v1.5.1/go.mod h1:L3OGu8Wl2/fWfCI6z80xFu9LTZmf1ZRjMHUOPmWr69U=
+github.com/klauspost/compress v1.13.5 h1:9O69jUPDcsT9fEm74W92rZL9FQY7rCdaXVneq+yyzl4=
+github.com/klauspost/compress v1.13.5/go.mod h1:/3/Vjq9QcHkK5uEr5lBEmyoZ1iFhe47etQ6QUkpK6sk=
 github.com/kr/pretty v0.2.0/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
 github.com/kr/pretty v0.3.1/go.mod h1:hoEshYVHaxMs3cyo3Yncou5ZscifuDolrwPKZanG3xk=
@@ -78,8 +80,8 @@ github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 github.com/volcengine/volc-sdk-golang v1.0.23 h1:anOslb2Qp6ywnsbyq9jqR0ljuO63kg9PY+4OehIk5R8=
 github.com/volcengine/volc-sdk-golang v1.0.23/go.mod h1:AfG/PZRUkHJ9inETvbjNifTDgut25Wbkm2QoYBTbvyU=
-github.com/volcengine/volcengine-go-sdk v1.2.14 h1:X1ELgWel2VQ8MviN7Qwh55COQeuvJ45tYbPs6AEDNA0=
-github.com/volcengine/volcengine-go-sdk v1.2.14/go.mod h1:oxoVo+A17kvkwPkIeIHPVLjSw7EQAm+l/Vau1YGHN+A=
+github.com/volcengine/volcengine-go-sdk v1.2.48 h1:RyADovt3Zfs7MQng/RxBBM+Nv9PqRyInXZQ58WJxRUg=
+github.com/volcengine/volcengine-go-sdk v1.2.48/go.mod h1:5duonraYH9kPPB5/Ke2y63atELLRymBSgCo9ItIZqEM=
 go.opentelemetry.io/auto/sdk v1.2.1 h1:jXsnJ4Lmnqd11kwkBV2LgLoFMZKizbCi5fNZ/ipaZ64=
 go.opentelemetry.io/auto/sdk v1.2.1/go.mod h1:KRTj+aOaElaLi+wW1kO/DZRXwkF4C5xPbEe3ZiIhN7Y=
 go.opentelemetry.io/contrib/instrumentation/runtime v0.65.0 h1:n8qdwrebNEHF/zHpueuZ4OacdJ8CdSaP7xef9WRZXTQ=

--- a/driver/bytedance/image.go
+++ b/driver/bytedance/image.go
@@ -60,7 +60,11 @@ type imageRaw struct {
 	images []rawImage
 	// mediaType is the negotiated output format's media type; the provider
 	// does not echo it, so the compiler-negotiated value is the truthful one.
-	mediaType    string
+	mediaType string
+	// requestID is the provider-echoed request identifier from the response
+	// header (X-Client-Request-Id). Empty when the endpoint does not return
+	// one.
+	requestID    string
 	inputTokens  int64
 	outputTokens int64
 	totalTokens  int64
@@ -314,6 +318,7 @@ func transportImage(cls *clients) inference.Transport[imageWire, imageRaw] {
 			raw.inputTokens += single.inputTokens
 			raw.outputTokens += single.outputTokens
 			raw.totalTokens += single.totalTokens
+			raw.requestID = single.requestID
 		}
 		return raw, nil
 	}
@@ -421,7 +426,7 @@ func imageRawFromResponse(response arkmodel.ImagesResponse) (imageRaw, error) {
 	if failure := response.Error; failure != nil {
 		return imageRaw{}, classifyResponseError(failure.Code, failure.Message)
 	}
-	raw := imageRaw{}
+	raw := imageRaw{requestID: response.Header().Get(arkmodel.ClientRequestHeader)}
 	for _, image := range response.Data {
 		raw.images = append(raw.images, rawImage{
 			url: derefString(image.Url),
@@ -478,6 +483,9 @@ func (c *clients) postImagesRaw(
 			fmt.Errorf("bytedance: decode image response: %w", err),
 		)
 	}
+	// The SDK path attaches response headers onto the decoded struct; do the
+	// same here so the caller can read the echoed request id uniformly.
+	images.SetHeader(response.Header)
 	return images, nil
 }
 
@@ -540,6 +548,7 @@ func decodeImage(
 			TotalTokens:     raw.totalTokens,
 			GeneratedImages: &generated,
 		},
+		Metadata: inference.Metadata{RequestID: raw.requestID},
 	}, nil
 }
 

--- a/driver/bytedance/image_test.go
+++ b/driver/bytedance/image_test.go
@@ -12,6 +12,9 @@ import (
 	"github.com/GizClaw/flowcraft/core/inference"
 	"github.com/GizClaw/flowcraft/core/message"
 	"github.com/GizClaw/flowcraft/core/message/media"
+
+	"github.com/volcengine/volcengine-go-sdk/service/arkruntime"
+	arkmodel "github.com/volcengine/volcengine-go-sdk/service/arkruntime/model"
 )
 
 func compileImageRequest(parts []message.Part, options ImageOptions) inference.GenerateRequest {
@@ -261,6 +264,7 @@ func TestTransportImageRawCarriesExtendedFields(t *testing.T) {
 		if request.Header.Get("Authorization") != "Bearer sk-test" {
 			t.Errorf("Authorization = %q, want Bearer sk-test", request.Header.Get("Authorization"))
 		}
+		writer.Header().Set(arkmodel.ClientRequestHeader, "req-raw")
 		writer.Header().Set("Content-Type", "application/json")
 		_, _ = writer.Write([]byte(`{
 			"model": "ep-test",
@@ -291,8 +295,64 @@ func TestTransportImageRawCarriesExtendedFields(t *testing.T) {
 	if len(raw.images) != 1 || raw.images[0].url != "https://example.com/out.png" {
 		t.Fatalf("raw.images = %#v, want one url image", raw.images)
 	}
+	if raw.requestID != "req-raw" {
+		t.Fatalf("raw.requestID = %q, want req-raw", raw.requestID)
+	}
 	if raw.outputTokens != 100 || raw.totalTokens != 100 {
 		t.Fatalf("usage = %#v, want 100/100", raw)
+	}
+}
+
+func TestTransportImageSDKRequestID(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		if request.URL.Path != generateImagesPath {
+			t.Errorf("path = %q, want %q", request.URL.Path, generateImagesPath)
+		}
+		writer.Header().Set(arkmodel.ClientRequestHeader, "req-sdk")
+		writer.Header().Set("Content-Type", "application/json")
+		_, _ = writer.Write([]byte(`{
+			"model": "ep-test",
+			"created": 1,
+			"data": [{"url": "https://example.com/out.png", "size": "2048x2048"}],
+			"usage": {"generated_images": 1, "output_tokens": 100, "total_tokens": 100}
+		}`))
+	}))
+	defer server.Close()
+
+	client := arkruntime.NewClientWithApiKey(
+		"sk-test",
+		arkruntime.WithBaseUrl(server.URL),
+		arkruntime.WithHTTPClient(server.Client()),
+		arkruntime.WithRetryTimes(0),
+	)
+	cls := &clients{ark: client}
+	raw, err := transportImage(cls)(context.Background(), imageWire{
+		model:    "ep-test",
+		prompt:   "a cat",
+		count:    1,
+		delivery: "url",
+	})
+	if err != nil {
+		t.Fatalf("transport: %v", err)
+	}
+	if raw.requestID != "req-sdk" {
+		t.Fatalf("raw.requestID = %q, want req-sdk", raw.requestID)
+	}
+}
+
+func TestDecodeImageMetadata(t *testing.T) {
+	raw := imageRaw{
+		images:      []rawImage{{url: "https://example.com/out.png"}},
+		mediaType:   "image/png",
+		requestID:   "req-test",
+		inputTokens: 1,
+	}
+	response, err := decodeImage(context.Background(), raw)
+	if err != nil {
+		t.Fatalf("decodeImage: %v", err)
+	}
+	if response.Metadata.RequestID != "req-test" {
+		t.Fatalf("metadata request id = %q, want req-test", response.Metadata.RequestID)
 	}
 }
 


### PR DESCRIPTION
## Summary

Successful image generations on the bytedance driver now populate `GenerateResponse.Metadata.RequestID`, so callers and the `llm.request.id` telemetry attribute can correlate with provider-side logs. Previously `decodeImage` left Metadata empty on success.

The request id is the echoed `X-Client-Request-Id` response header — the same value the SDK uses for error envelopes and stream correlation.

## Changes

- `imageRaw` gains `requestID`; `imageRawFromResponse` reads it from `response.Header().Get(arkmodel.ClientRequestHeader)`.
- The raw POST path (`postImagesRaw`) now attaches response headers to the decoded SDK struct (`images.SetHeader(response.Header)`), so both SDK and raw paths read the id uniformly.
- `decodeImage` fills `Metadata: inference.Metadata{RequestID: raw.requestID}`.
- Fan-out transport keeps the last request id, matching the existing TTS/transcribe stream convention.
- Bumps `volcengine-go-sdk` v1.2.14 → v1.2.48 (ImagesResponse shape unchanged; no response id exists on this endpoint).

## Tests

- `TestTransportImageRawCarriesExtendedFields` now asserts `raw.requestID` from the response header.
- `TestTransportImageSDKRequestID` covers the SDK path through a real arkruntime client against an httptest server.
- `TestDecodeImageMetadata` asserts `response.Metadata.RequestID`.

## Validation

`make ci`, `make lint`, `make release-check` (`changesets valid`, `no pending releases`), and `git diff --check` all pass.

No changeset added — not tagging in this PR; a new tag will be cut manually after merge.