### PR TITLE
feat(core): wire delegation subagents through session lifecycle

### DIFF
--- a/core/delegation/directory.go
+++ b/core/delegation/directory.go
@@ -87,6 +87,21 @@ func (d *LocalDirectory) Bind(result Deployment) error {
 	return nil
 }
 
+// BindDeployment implements resource.DeploymentBinder: the directory
+// resource binds itself to the assembled deployment once agents are
+// ready. Binding is idempotent per instance (see Bind).
+func (d *LocalDirectory) BindDeployment(deployment any) error {
+	if d == nil {
+		return errdefs.Validationf("local delegation directory: nil receiver")
+	}
+	view, ok := deployment.(Deployment)
+	if !ok || isNilInterface(deployment) {
+		return errdefs.Validationf(
+			"local delegation directory: deployment is not a read-only deployment view")
+	}
+	return d.Bind(view)
+}
+
 // List returns targets in deploy.Result.InstanceNames order.
 func (d *LocalDirectory) List(context.Context) ([]Target, error) {
 	if d == nil {

--- a/core/delegation/resource.go
+++ b/core/delegation/resource.go
@@ -14,8 +14,20 @@ const (
 	// ServiceKind is the deployment resource kind of the local
 	// delegation service.
 	ServiceKind = "delegation.Service"
+	// DirectoryKind is the deployment resource kind of the local
+	// delegation directory.
+	DirectoryKind = "delegation.Directory"
+	// SessionProviderKind is the deployment resource kind of a delegation
+	// session identity policy.
+	SessionProviderKind = "delegation.SessionProvider"
 	// BackendDep is the optional async backend dependency.
 	BackendDep = "backend"
+	// DirectoryDep is the required directory dependency shared by the
+	// service and the delegation tool source.
+	DirectoryDep = "directory"
+	// SessionProviderDep is the optional session identity policy
+	// dependency.
+	SessionProviderDep = "session_provider"
 )
 
 // ServiceSettings is the strict settings subtree of the local service
@@ -29,25 +41,24 @@ type ServiceSettings struct {
 }
 
 type serviceFactory struct {
-	directory *LocalDirectory
-	options   []Option
+	options []Option
 }
 
 // NewServiceFactory returns a deployment factory for the local
-// delegation service. directory is app-owned and may be bound to a
-// deploy result after assembly (it cannot be a DAG dep: it bridges to
-// the deploy result itself). Options inject app-owned behavior the
-// document cannot express (e.g. [delegation.WithWorkerHost]); the
-// declarative settings are applied after them.
-func NewServiceFactory(directory *LocalDirectory, opts ...Option) res.Factory {
+// delegation service. The service resolves its directory and optional
+// session provider from deploy dependencies, so every deployment
+// generation gets its own bound directory. Options inject app-owned
+// behavior the document cannot express (e.g. [delegation.WithWorkerHost]);
+// the declarative settings are applied after them.
+func NewServiceFactory(opts ...Option) res.Factory {
 	return &serviceFactory{
-		directory: directory,
-		options:   append([]Option(nil), opts...),
+		options: append([]Option(nil), opts...),
 	}
 }
 
 // Spec implements res.Factory. The backend dep is optional: a service
-// without one is sync-only.
+// without one is sync-only. The directory dep is required and binds the
+// assembled deployment per generation.
 func (f *serviceFactory) Spec() res.Spec {
 	return res.Spec{
 		Kind: ServiceKind,
@@ -55,15 +66,22 @@ func (f *serviceFactory) Spec() res.Spec {
 		Deps: []res.DepSpec{{
 			Name: BackendDep,
 			Type: "delegation.AsyncBackend",
+		}, {
+			Name:     DirectoryDep,
+			Type:     "delegation.Directory",
+			Required: true,
+		}, {
+			Name: SessionProviderDep,
+			Type: "delegation.SessionProvider",
 		}},
 	}
 }
 
 // New implements res.Factory.
 func (f *serviceFactory) New(_ context.Context, in res.Input) (any, error) {
-	if f == nil || f.directory == nil {
+	if f == nil {
 		return nil, errdefs.Validationf(
-			"delegation service resource: directory is required")
+			"delegation service resource: nil factory")
 	}
 	settings, err := res.DecodeTyped[ServiceSettings](in.Settings)
 	if err != nil {
@@ -108,6 +126,21 @@ func (f *serviceFactory) New(_ context.Context, in res.Input) (any, error) {
 		options = append(options, WithDeferredWorkers())
 	}
 
+	var directory *LocalDirectory
+	if value, ok := in.Dep(DirectoryDep); ok {
+		dir, ok := value.(*LocalDirectory)
+		if !ok || dir == nil {
+			return nil, errdefs.Validationf(
+				"delegation service resource: dep %q is %T, want *delegation.LocalDirectory",
+				DirectoryDep, value)
+		}
+		directory = dir
+	}
+	if directory == nil {
+		return nil, errdefs.Validationf(
+			"delegation service resource: dep %q is required", DirectoryDep)
+	}
+
 	var backend AsyncBackend
 	if value, ok := in.Dep(BackendDep); ok {
 		b, ok := value.(AsyncBackend)
@@ -118,7 +151,18 @@ func (f *serviceFactory) New(_ context.Context, in res.Input) (any, error) {
 		}
 		backend = b
 	}
-	return NewService(f.directory, backend, options...)
+
+	if value, ok := in.Dep(SessionProviderDep); ok {
+		provider, ok := value.(SessionProvider)
+		if !ok || isNilInterface(provider) {
+			return nil, errdefs.Validationf(
+				"delegation service resource: dep %q is %T, want delegation.SessionProvider",
+				SessionProviderDep, value)
+		}
+		options = append(options, WithSessionProvider(provider))
+	}
+
+	return NewService(directory, backend, options...)
 }
 
 func isNilBackend(backend AsyncBackend) bool {
@@ -142,4 +186,72 @@ func parseServiceDuration(field, value string) (time.Duration, error) {
 			"delegation service resource: %s: %w", field, err))
 	}
 	return d, nil
+}
+
+// directoryFactory builds a per-generation LocalDirectory that binds
+// itself to the assembled deployment during the deploy wire phase.
+type directoryFactory struct{}
+
+// NewDirectoryFactory returns a deployment factory for the local
+// delegation directory resource. Each deployment generation builds and
+// binds its own directory, so reloads always delegate against the current
+// generation's agents.
+func NewDirectoryFactory() res.Factory {
+	return directoryFactory{}
+}
+
+// Spec implements res.Factory.
+func (directoryFactory) Spec() res.Spec {
+	return res.Spec{
+		Kind: DirectoryKind,
+		Impl: "local",
+	}
+}
+
+// New implements res.Factory: a directory takes no settings and starts
+// unbound; the deploy wire phase binds it to its generation's result.
+func (directoryFactory) New(_ context.Context, in res.Input) (any, error) {
+	if _, err := res.DecodeTyped[struct{}](in.Settings); err != nil {
+		return nil, errdefs.Validationf(
+			"delegation directory resource: decode settings: %v", err)
+	}
+	return NewDirectory(), nil
+}
+
+// RegisterDirectory adds the local directory resource factory to r.
+func RegisterDirectory(r *res.Registry) error {
+	return r.Register(NewDirectoryFactory())
+}
+
+// randomSessionProviderFactory builds the default ephemeral identity
+// policy.
+type randomSessionProviderFactory struct{}
+
+// NewRandomSessionProviderFactory returns a deployment factory for the
+// default delegation session provider: every delegation mints a fresh
+// ContextID and never persists.
+func NewRandomSessionProviderFactory() res.Factory {
+	return randomSessionProviderFactory{}
+}
+
+// Spec implements res.Factory.
+func (randomSessionProviderFactory) Spec() res.Spec {
+	return res.Spec{
+		Kind: SessionProviderKind,
+		Impl: "random",
+	}
+}
+
+// New implements res.Factory.
+func (randomSessionProviderFactory) New(_ context.Context, in res.Input) (any, error) {
+	if _, err := res.DecodeTyped[struct{}](in.Settings); err != nil {
+		return nil, errdefs.Validationf(
+			"delegation session provider resource: decode settings: %v", err)
+	}
+	return RandomSessionProvider{}, nil
+}
+
+// RegisterSessionProvider adds the random session provider factory to r.
+func RegisterSessionProvider(r *res.Registry) error {
+	return r.Register(NewRandomSessionProviderFactory())
 }

--- a/core/delegation/resource_test.go
+++ b/core/delegation/resource_test.go
@@ -10,14 +10,14 @@ import (
 )
 
 func TestServiceFactoryRequiresDirectory(t *testing.T) {
-	_, err := (delegation.NewServiceFactory(nil)).New(context.Background(), resource.Input{})
+	_, err := (delegation.NewServiceFactory()).New(context.Background(), resource.Input{})
 	if !errdefs.IsValidation(err) {
 		t.Fatalf("New without directory = %v, want Validation", err)
 	}
 }
 
 func TestServiceFactoryAppliesSettings(t *testing.T) {
-	factory := delegation.NewServiceFactory(delegation.NewDirectory())
+	factory := delegation.NewServiceFactory()
 	value, err := factory.New(context.Background(), resource.Input{
 		Settings: []byte(`{
 			"max_concurrency": 2,
@@ -26,6 +26,9 @@ func TestServiceFactoryAppliesSettings(t *testing.T) {
 			"idempotency_retention": "30m",
 			"defer_workers": true
 		}`),
+		Deps: map[string]any{
+			delegation.DirectoryDep: delegation.NewDirectory(),
+		},
 	})
 	if err != nil {
 		t.Fatalf("New: %v", err)
@@ -40,7 +43,7 @@ func TestServiceFactoryAppliesSettings(t *testing.T) {
 }
 
 func TestServiceFactoryRejectsBadSettings(t *testing.T) {
-	factory := delegation.NewServiceFactory(delegation.NewDirectory())
+	factory := delegation.NewServiceFactory()
 	for name, input := range map[string]string{
 		"negative concurrency": `{"max_concurrency":0}`,
 		"negative depth":       `{"max_depth":0}`,
@@ -60,11 +63,95 @@ func TestServiceFactoryRejectsBadSettings(t *testing.T) {
 }
 
 func TestServiceFactoryRejectsWrongBackend(t *testing.T) {
-	factory := delegation.NewServiceFactory(delegation.NewDirectory())
+	factory := delegation.NewServiceFactory()
 	_, err := factory.New(context.Background(), resource.Input{
-		Deps: map[string]any{delegation.BackendDep: "not a backend"},
+		Deps: map[string]any{
+			delegation.DirectoryDep: delegation.NewDirectory(),
+			delegation.BackendDep:   "not a backend",
+		},
 	})
 	if !errdefs.IsValidation(err) {
 		t.Fatalf("New with wrong backend = %v, want Validation", err)
+	}
+}
+
+func TestServiceFactoryRejectsWrongDirectory(t *testing.T) {
+	factory := delegation.NewServiceFactory()
+	_, err := factory.New(context.Background(), resource.Input{
+		Deps: map[string]any{delegation.DirectoryDep: "not a directory"},
+	})
+	if !errdefs.IsValidation(err) {
+		t.Fatalf("New with wrong directory = %v, want Validation", err)
+	}
+}
+
+func TestServiceFactoryAcceptsSessionProvider(t *testing.T) {
+	factory := delegation.NewServiceFactory()
+	value, err := factory.New(context.Background(), resource.Input{
+		Deps: map[string]any{
+			delegation.DirectoryDep:       delegation.NewDirectory(),
+			delegation.SessionProviderDep: delegation.RandomSessionProvider{},
+		},
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	service := value.(*delegation.LocalService)
+	if err := service.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+}
+
+func TestServiceFactoryRejectsWrongSessionProvider(t *testing.T) {
+	factory := delegation.NewServiceFactory()
+	_, err := factory.New(context.Background(), resource.Input{
+		Deps: map[string]any{
+			delegation.DirectoryDep:       delegation.NewDirectory(),
+			delegation.SessionProviderDep: "not a provider",
+		},
+	})
+	if !errdefs.IsValidation(err) {
+		t.Fatalf("New with wrong provider = %v, want Validation", err)
+	}
+}
+
+func TestDirectoryFactoryBuildsUnboundDirectory(t *testing.T) {
+	factory := delegation.NewDirectoryFactory()
+	value, err := factory.New(context.Background(), resource.Input{})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	directory, ok := value.(*delegation.LocalDirectory)
+	if !ok {
+		t.Fatalf("New returned %T, want *delegation.LocalDirectory", value)
+	}
+	if _, err := directory.List(context.Background()); !errdefs.IsNotAvailable(err) {
+		t.Fatalf("unbound directory List error = %v, want not available", err)
+	}
+}
+
+func TestRandomSessionProviderFactory(t *testing.T) {
+	factory := delegation.NewRandomSessionProviderFactory()
+	value, err := factory.New(context.Background(), resource.Input{})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	provider, ok := value.(delegation.SessionProvider)
+	if !ok {
+		t.Fatalf("New returned %T, want delegation.SessionProvider", value)
+	}
+	if provider.Persistent() {
+		t.Fatal("random provider must not be persistent")
+	}
+	first, err := provider.CreateContextID(context.Background(), delegation.AsyncRequest{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	second, err := provider.CreateContextID(context.Background(), delegation.AsyncRequest{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if first == "" || first == second {
+		t.Fatalf("random context ids = %q %q, want unique non-empty", first, second)
 	}
 }

--- a/core/delegation/service.go
+++ b/core/delegation/service.go
@@ -8,12 +8,14 @@ import (
 	"fmt"
 	"maps"
 	"reflect"
+	"strings"
 	"sync"
 	"time"
 
 	"github.com/GizClaw/flowcraft/core/agent"
 	"github.com/GizClaw/flowcraft/core/errdefs"
 	"github.com/GizClaw/flowcraft/core/message"
+	"github.com/GizClaw/flowcraft/core/runtime/session"
 )
 
 const (
@@ -88,6 +90,7 @@ type serviceConfig struct {
 	timeout              time.Duration
 	idempotencyRetention time.Duration
 	workerHost           agent.Host
+	sessionProvider      SessionProvider
 	deferWorkers         bool
 }
 
@@ -165,6 +168,19 @@ func WithWorkerHost(host agent.Host) Option {
 	}
 }
 
+// WithSessionProvider sets the identity policy for delegated subagent
+// sessions. When nil and a session manager is bound, the service mints a
+// fresh ContextID per delegation.
+func WithSessionProvider(provider SessionProvider) Option {
+	return func(config *serviceConfig) error {
+		if isNilInterface(provider) {
+			return errdefs.Validationf("local delegation: session provider is nil")
+		}
+		config.sessionProvider = provider
+		return nil
+	}
+}
+
 // WithDeferredWorkers defers asynchronous worker startup until Start. This is
 // useful when a lifecycle owner must finish binding all dependencies before
 // background work begins.
@@ -200,7 +216,13 @@ type LocalService struct {
 	workerCtx    context.Context
 	cancelWorker context.CancelFunc
 	workerHost   agent.Host
-	workers      sync.WaitGroup
+	// sessionProvider is the identity policy for subagent sessions. It is
+	// immutable after construction.
+	sessionProvider SessionProvider
+	// sessionManager is bound by the runtime through ManagerBinder before
+	// the service serves traffic; writes are serialized by stateMu.
+	sessionManager *session.Manager
+	workers        sync.WaitGroup
 
 	closeOnce  sync.Once
 	closeErr   error
@@ -247,6 +269,7 @@ func NewService(directory *LocalDirectory, backend AsyncBackend, opts ...Option)
 		maxConcurrency:       config.maxConcurrency,
 		maxDepth:             config.maxDepth,
 		timeout:              config.timeout,
+		sessionProvider:      config.sessionProvider,
 		slots:                make(chan struct{}, config.maxConcurrency),
 		idempotencyRetention: config.idempotencyRetention,
 		asyncRetention:       asyncRetention,
@@ -271,23 +294,36 @@ func NewService(directory *LocalDirectory, backend AsyncBackend, opts ...Option)
 	return service, nil
 }
 
-// BindDeployment implements resource.DeploymentBinder: it binds the
-// assembled deployment into the service's directory once agents are
-// ready. The deployment view is the read-only interface exposed by
-// *deploy.Result; binding is idempotent.
-func (s *LocalService) BindDeployment(deployment any) error {
+// BindSessionManager implements session.ManagerBinder: the runtime hands
+// this service the session manager that owns subagent session lifecycle.
+// Binding is set-once: a second bind is a conflict. The write is
+// serialized by stateMu; reads happen through sessionManager.
+func (s *LocalService) BindSessionManager(manager *session.Manager) error {
 	if s == nil {
 		return errdefs.Validationf("local delegation: nil service")
 	}
-	if s.directory == nil {
-		return errdefs.Internalf("local delegation: service has no directory")
+	if manager == nil {
+		return errdefs.Validationf("local delegation: session manager is nil")
 	}
-	view, ok := deployment.(Deployment)
-	if !ok || isNilInterface(deployment) {
-		return errdefs.Validationf(
-			"local delegation: deployment is not a read-only deployment view")
+	s.stateMu.Lock()
+	defer s.stateMu.Unlock()
+	if s.sessionManager != nil {
+		return errdefs.Conflictf(
+			"local delegation: session manager is already bound")
 	}
-	return s.directory.Bind(view)
+	s.sessionManager = manager
+	return nil
+}
+
+// boundSessionManager returns the bound session manager, or nil when the
+// runtime never bound one (legacy execution path).
+func (s *LocalService) boundSessionManager() *session.Manager {
+	if s == nil {
+		return nil
+	}
+	s.stateMu.Lock()
+	defer s.stateMu.Unlock()
+	return s.sessionManager
 }
 
 // Start begins asynchronous workers when the backend supports WorkSource.
@@ -628,6 +664,94 @@ func (s *LocalService) runAt(ctx context.Context, req AsyncRequest, reuseSlot bo
 	if err := s.checkDepth(req.Depth); err != nil {
 		return Response{}, err
 	}
+	if _, err := s.directory.Lookup(ctx, req.Request.Target); err != nil {
+		return Response{}, err
+	}
+
+	// Identity rule: with no provider and no bound manager the ContextID
+	// stays empty (legacy, fully compatible); with a provider, or once a
+	// manager is bound, a ContextID is always set.
+	manager := s.boundSessionManager()
+	key, hasKey, persistent := session.Key{}, false, false
+	if provider := s.sessionProvider; provider != nil {
+		contextID, err := provider.CreateContextID(ctx, req)
+		if err != nil {
+			return Response{}, err
+		}
+		if strings.TrimSpace(contextID) == "" {
+			return Response{}, errdefs.Validationf(
+				"local delegation: session provider returned an empty context id")
+		}
+		key = session.Key{AgentID: req.Request.Target, ContextID: contextID}
+		hasKey = true
+		persistent = provider.Persistent()
+	}
+	if manager == nil {
+		return s.runAtLegacy(ctx, req, reuseSlot, key, hasKey)
+	}
+	if !hasKey {
+		key = session.Key{AgentID: req.Request.Target, ContextID: newContextID()}
+	}
+
+	// Timeout and delegation metadata (caller/depth) both hang off
+	// execCtx; Start must see them so nested delegations keep their depth
+	// and the service timeout bounds the subagent turn.
+	execCtx := context.WithValue(ctx, delegationContextKey{}, delegationMetadata{
+		caller: req.Request.Target,
+		depth:  req.Depth,
+		leased: true,
+	})
+	cancel := func() {}
+	if s.timeout > 0 {
+		execCtx, cancel = context.WithTimeout(execCtx, s.timeout)
+	}
+	defer cancel()
+
+	if !reuseSlot {
+		select {
+		case s.slots <- struct{}{}:
+			defer func() { <-s.slots }()
+		case <-execCtx.Done():
+			return canceledResponse("", execCtx.Err()), nil
+		}
+	}
+
+	lease, err := manager.GetOrCreate(execCtx, key)
+	if err != nil {
+		return Response{}, err
+	}
+	defer func() { _ = lease.Close() }()
+
+	turn, err := lease.Session().StartWithOptions(execCtx, agent.Request{
+		ContextID: key.ContextID,
+		Message:   message.NewTextMessage(message.RoleUser, req.Request.Input),
+		Inputs:    metadataInputs(req),
+	}, s.delegationStartOptions(persistent)...)
+	if err != nil {
+		return Response{}, err
+	}
+
+	result, err := waitTurnCancelOnDone(execCtx, turn)
+	if err != nil {
+		return canceledOrFailedResponse(err), nil
+	}
+	return responseFromTurn(result, key.ContextID), nil
+}
+
+// runAtLegacy executes a delegated run without session lifecycle: plain
+// agent.Execute with an empty ContextID unless the identity policy
+// supplied one. It keeps the historical host-propagation behavior (sync
+// inherits the caller host, async uses the worker host).
+func (s *LocalService) runAtLegacy(
+	ctx context.Context,
+	req AsyncRequest,
+	reuseSlot bool,
+	key session.Key,
+	hasKey bool,
+) (Response, error) {
+	if err := s.checkDepth(req.Depth); err != nil {
+		return Response{}, err
+	}
 	instance, err := s.directory.Lookup(ctx, req.Request.Target)
 	if err != nil {
 		return Response{}, err
@@ -655,6 +779,9 @@ func (s *LocalService) runAt(ctx context.Context, req AsyncRequest, reuseSlot bo
 
 	agentRequest := agent.Request{
 		Message: message.NewTextMessage(message.RoleUser, req.Request.Input),
+	}
+	if hasKey {
+		agentRequest.ContextID = key.ContextID
 	}
 	if len(req.Request.Metadata) > 0 {
 		agentRequest.Inputs = make(map[string]any, len(req.Request.Metadata))
@@ -748,6 +875,109 @@ func responseFromAgent(result *agent.Result) Response {
 		}
 	}
 	return response
+}
+
+// responseFromTurn maps a session turn's terminal result to a delegation
+// response, mirroring responseFromAgent and backfilling the subagent
+// session identity for boards and resume tooling.
+func responseFromTurn(result *agent.Result, contextID string) Response {
+	response := responseFromAgent(result)
+	if response.Metadata == nil {
+		response.Metadata = make(map[string]string, 1)
+	}
+	response.Metadata["delegation.session_id"] = contextID
+	return response
+}
+
+// delegationStartOptions builds the session options for a delegated
+// subagent turn: questions to the user are refused (never block), and
+// non-persistent identities run the turn ephemeral so no session state or
+// run checkpoint is ever written.
+func (s *LocalService) delegationStartOptions(persistent bool) []session.StartOption {
+	options := []session.StartOption{
+		session.WithAskUserOverride(refuseSubagentAskUser),
+	}
+	if !persistent {
+		options = append(options, session.WithEphemeral())
+	}
+	return options
+}
+
+// refuseSubagentAskUser is the default subagent asker: subagents never
+// interrupt the user, so questions fail fast instead of blocking forever
+// on an unattended prompt.
+func refuseSubagentAskUser(context.Context, agent.UserPrompt) (agent.UserReply, error) {
+	return agent.UserReply{}, errdefs.NotAvailablef(
+		"local delegation: subagent cannot ask the user")
+}
+
+// turnCancelWaitTimeout bounds how long a canceled delegation turn may
+// take to reach its terminal state before the caller gives up.
+const turnCancelWaitTimeout = 5 * time.Second
+
+// waitTurnCancelOnDone waits for a turn's terminal result. On ctx
+// cancellation it explicitly cancels the turn and waits again with a
+// fresh context (Turn.Wait with the canceled ctx would return
+// immediately), so the caller maps a settled canceled result instead of
+// leaking the raw context error. A turn that already settled with a real
+// terminal error (e.g. a seed or referee infrastructure failure) is
+// final and is returned as-is, never relabeled as a canceled wait.
+func waitTurnCancelOnDone(ctx context.Context, turn *session.Turn) (*agent.Result, error) {
+	result, err := turn.Wait(ctx)
+	if err == nil {
+		return result, nil
+	}
+	if isTerminalTurn(turn) {
+		waitCtx, cancel := context.WithTimeout(
+			context.Background(), turnCancelWaitTimeout)
+		defer cancel()
+		return turn.Wait(waitCtx)
+	}
+	turn.Cancel()
+	waitCtx, cancel := context.WithTimeout(context.Background(), turnCancelWaitTimeout)
+	defer cancel()
+	result, err = turn.Wait(waitCtx)
+	if err != nil {
+		return nil, fmt.Errorf(
+			"local delegation: wait for canceled turn: %w", err)
+	}
+	return result, nil
+}
+
+// isTerminalTurn reports whether the turn reached a settled terminal
+// state. session.TurnState's terminal predicate is unexported, so the
+// stable exported state constants are checked here.
+func isTerminalTurn(turn *session.Turn) bool {
+	switch turn.State() {
+	case session.TurnCompleted, session.TurnInterrupted,
+		session.TurnCanceled, session.TurnFailed, session.TurnAborted:
+		return true
+	default:
+		return false
+	}
+}
+
+// canceledOrFailedResponse classifies a session-path failure: context
+// cancellation or timeout maps to a canceled response; anything else
+// (e.g. a session that closed mid-run) maps to a failed response.
+func canceledOrFailedResponse(err error) Response {
+	if errdefs.IsAborted(err) || errdefs.IsTimeout(err) ||
+		errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return canceledResponse("", err)
+	}
+	return Response{ID: newID(), Status: StatusFailed, Error: err.Error()}
+}
+
+// metadataInputs converts request metadata into agent request inputs.
+func metadataInputs(req AsyncRequest) map[string]any {
+	if len(req.Request.Metadata) == 0 {
+		return nil
+	}
+	inputs := make(map[string]any, len(req.Request.Metadata))
+	for key, value := range req.Request.Metadata {
+		inputs[key] = value
+	}
+	return inputs
 }
 
 func canceledResponse(id string, cause error) Response {

--- a/core/delegation/service.go
+++ b/core/delegation/service.go
@@ -16,6 +16,8 @@ import (
 	"github.com/GizClaw/flowcraft/core/errdefs"
 	"github.com/GizClaw/flowcraft/core/message"
 	"github.com/GizClaw/flowcraft/core/runtime/session"
+	"github.com/GizClaw/flowcraft/core/telemetry"
+	otellog "go.opentelemetry.io/otel/log"
 )
 
 const (
@@ -664,9 +666,17 @@ func (s *LocalService) runAt(ctx context.Context, req AsyncRequest, reuseSlot bo
 	if err := s.checkDepth(req.Depth); err != nil {
 		return Response{}, err
 	}
-	if _, err := s.directory.Lookup(ctx, req.Request.Target); err != nil {
+	instance, err := s.directory.Lookup(ctx, req.Request.Target)
+	if err != nil {
 		return Response{}, err
 	}
+	telemetry.Info(ctx, "local delegation: run started",
+		otellog.String(telemetry.AttrAgentID, instance.ID),
+		otellog.String(telemetry.AttrDelegationTarget, req.Request.Target),
+		otellog.String(telemetry.AttrDelegationMode, string(req.Request.Mode)),
+		otellog.Int(telemetry.AttrDelegationDepth, req.Depth),
+		otellog.String(telemetry.AttrDelegationCaller, req.Caller),
+	)
 
 	// Identity rule: with no provider and no bound manager the ContextID
 	// stays empty (legacy, fully compatible); with a provider, or once a
@@ -687,7 +697,7 @@ func (s *LocalService) runAt(ctx context.Context, req AsyncRequest, reuseSlot bo
 		persistent = provider.Persistent()
 	}
 	if manager == nil {
-		return s.runAtLegacy(ctx, req, reuseSlot, key, hasKey)
+		return s.runAtLegacy(ctx, req, reuseSlot, key, hasKey, instance)
 	}
 	if !hasKey {
 		key = session.Key{AgentID: req.Request.Target, ContextID: newContextID()}
@@ -748,12 +758,9 @@ func (s *LocalService) runAtLegacy(
 	reuseSlot bool,
 	key session.Key,
 	hasKey bool,
+	instance *agent.Agent,
 ) (Response, error) {
 	if err := s.checkDepth(req.Depth); err != nil {
-		return Response{}, err
-	}
-	instance, err := s.directory.Lookup(ctx, req.Request.Target)
-	if err != nil {
 		return Response{}, err
 	}
 

--- a/core/delegation/service_test.go
+++ b/core/delegation/service_test.go
@@ -132,22 +132,16 @@ func TestDirectoryBindListGetLookup(t *testing.T) {
 	}
 }
 
-func TestLocalServiceBindDeployment(t *testing.T) {
+func TestLocalDirectoryBindDeployment(t *testing.T) {
 	directory := NewDirectory()
-	service, err := NewService(directory, nil)
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer func() { _ = service.Close() }()
-
-	if err := service.BindDeployment("not a deployment"); !errdefs.IsValidation(err) {
+	if err := directory.BindDeployment("not a deployment"); !errdefs.IsValidation(err) {
 		t.Fatalf("BindDeployment(wrong type) error = %v, want validation", err)
 	}
 	result := buildResult(t, completedEngine("ok"))
-	if err := service.BindDeployment(result); err != nil {
+	if err := directory.BindDeployment(result); err != nil {
 		t.Fatalf("BindDeployment: %v", err)
 	}
-	if err := service.BindDeployment(result); err != nil {
+	if err := directory.BindDeployment(result); err != nil {
 		t.Fatalf("repeated BindDeployment error = %v, want idempotent success", err)
 	}
 	targets, err := directory.List(context.Background())
@@ -156,6 +150,26 @@ func TestLocalServiceBindDeployment(t *testing.T) {
 	}
 	if len(targets) != 2 || targets[0].ID != "researcher" {
 		t.Fatalf("bound targets = %+v", targets)
+	}
+}
+
+func TestLocalServiceBindSessionManagerSetOnce(t *testing.T) {
+	directory := NewDirectory()
+	service, err := NewService(directory, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = service.Close() }()
+
+	if err := service.BindSessionManager(nil); !errdefs.IsValidation(err) {
+		t.Fatalf("BindSessionManager(nil) error = %v, want validation", err)
+	}
+	manager := newTestSessionManagerForResult(t, buildResult(t, completedEngine("ok")))
+	if err := service.BindSessionManager(manager); err != nil {
+		t.Fatalf("BindSessionManager: %v", err)
+	}
+	if err := service.BindSessionManager(manager); !errdefs.IsConflict(err) {
+		t.Fatalf("second BindSessionManager error = %v, want conflict", err)
 	}
 }
 

--- a/core/delegation/session.go
+++ b/core/delegation/session.go
@@ -1,0 +1,51 @@
+package delegation
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"fmt"
+	"time"
+)
+
+// SessionProvider decides a delegated subagent's session ContextID and
+// whether that identity is stable and needs persistence. Implementations
+// are injected by the application. A nil provider falls back to the
+// service default: mint a fresh ContextID per delegation, but only when a
+// session manager is bound (see LocalService.runAt).
+type SessionProvider interface {
+	// CreateContextID returns the subagent session's ContextID. AgentID is
+	// filled by the service from the validated request target, so a
+	// provider can never introduce an identity mismatch. Returning an
+	// error fails the delegation; returning an empty ContextID is a
+	// validation error.
+	CreateContextID(ctx context.Context, req AsyncRequest) (string, error)
+
+	// Persistent reports whether the provider's ContextID is stable and
+	// should survive as a resumable session. Providers deriving stable
+	// ContextIDs (e.g. by caller+target) return true; providers minting a
+	// fresh ContextID per delegation return false.
+	Persistent() bool
+}
+
+// RandomSessionProvider mints a unique ContextID for every delegation and
+// never persists: each delegated run is an ephemeral session with no
+// history or resume state.
+type RandomSessionProvider struct{}
+
+// CreateContextID implements SessionProvider.
+func (RandomSessionProvider) CreateContextID(context.Context, AsyncRequest) (string, error) {
+	return newContextID(), nil
+}
+
+// Persistent implements SessionProvider.
+func (RandomSessionProvider) Persistent() bool { return false }
+
+// newContextID mints a unique, non-empty session ContextID.
+func newContextID() string {
+	var bytes [12]byte
+	if _, err := rand.Read(bytes[:]); err == nil {
+		return "ctx-" + hex.EncodeToString(bytes[:])
+	}
+	return fmt.Sprintf("ctx-%d", time.Now().UnixNano())
+}

--- a/core/delegation/session_provider_test.go
+++ b/core/delegation/session_provider_test.go
@@ -14,6 +14,9 @@ import (
 	"github.com/GizClaw/flowcraft/core/event"
 	"github.com/GizClaw/flowcraft/core/message"
 	"github.com/GizClaw/flowcraft/core/runtime/session"
+	"github.com/GizClaw/flowcraft/core/telemetry"
+	logglobal "go.opentelemetry.io/otel/log/global"
+	sdklog "go.opentelemetry.io/otel/sdk/log"
 )
 
 type testSessionProvider struct {
@@ -511,6 +514,59 @@ func (s *delegationRecordingStore) count() int {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	return s.saved
+}
+
+type lockedBuffer struct {
+	mu sync.Mutex
+	b  strings.Builder
+}
+
+func (b *lockedBuffer) Write(p []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.b.Write(p)
+}
+
+func (b *lockedBuffer) String() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.b.String()
+}
+
+func TestRunAtSessionPathEmitsDelegationTelemetry(t *testing.T) {
+	var out lockedBuffer
+	exporter := telemetry.NewPlainTextExporter(&out)
+	provider := sdklog.NewLoggerProvider(
+		sdklog.WithProcessor(sdklog.NewSimpleProcessor(exporter)))
+	previous := logglobal.GetLoggerProvider()
+	logglobal.SetLoggerProvider(provider)
+	t.Cleanup(func() {
+		logglobal.SetLoggerProvider(previous)
+		_ = provider.Shutdown(context.Background())
+	})
+
+	service, _ := newSessionPathService(t,
+		completedEngine("ok"),
+		&testSessionProvider{contextID: "telemetry-ctx", persistent: true})
+	response, err := service.Delegate(context.Background(), syncRequest("writer"))
+	if err != nil {
+		t.Fatalf("Delegate: %v", err)
+	}
+	if response.Status != StatusSucceeded {
+		t.Fatalf("response status = %q, want succeeded", response.Status)
+	}
+	got := out.String()
+	for _, want := range []string{
+		"local delegation: run started",
+		"agent.id=writer",
+		"delegation.target=writer",
+		"delegation.mode=sync",
+		"delegation.depth=1",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("telemetry output missing %q:\n%s", want, got)
+		}
+	}
 }
 
 func TestRunAtSessionPathEphemeralWritesNoState(t *testing.T) {

--- a/core/delegation/session_provider_test.go
+++ b/core/delegation/session_provider_test.go
@@ -1,0 +1,555 @@
+package delegation
+
+import (
+	"context"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/GizClaw/flowcraft/core/agent"
+	"github.com/GizClaw/flowcraft/core/deploy"
+	"github.com/GizClaw/flowcraft/core/errdefs"
+	"github.com/GizClaw/flowcraft/core/event"
+	"github.com/GizClaw/flowcraft/core/message"
+	"github.com/GizClaw/flowcraft/core/runtime/session"
+)
+
+type testSessionProvider struct {
+	contextID  string
+	err        error
+	persistent bool
+}
+
+func (p *testSessionProvider) CreateContextID(context.Context, AsyncRequest) (string, error) {
+	return p.contextID, p.err
+}
+
+func (p *testSessionProvider) Persistent() bool { return p.persistent }
+
+type delegationTestResolver struct {
+	result *deploy.Result
+}
+
+func (r delegationTestResolver) Instance(id string) (*agent.Agent, bool) {
+	return r.result.Agent(id)
+}
+
+// nilEngineResolver serves an agent with no engine so agent.Execute fails
+// with an infrastructure validation error inside the turn.
+type nilEngineResolver struct{}
+
+func (nilEngineResolver) Instance(id string) (*agent.Agent, bool) {
+	return &agent.Agent{ID: id}, true
+}
+
+type delegationTestHost struct {
+	agent.NoopHost
+	bus event.Bus
+}
+
+func (h delegationTestHost) Publish(ctx context.Context, env event.Envelope) error {
+	return h.bus.Publish(ctx, env)
+}
+
+// delegationWithRunEnd wraps an engine so it publishes the run-end event
+// the session stream coordinator waits for.
+func delegationWithRunEnd(engine agent.Engine) agent.Engine {
+	return agent.EngineFunc(func(
+		ctx context.Context,
+		run agent.Run,
+		host agent.Host,
+		board *agent.Board,
+	) (*agent.Board, error) {
+		board, err := engine.Execute(ctx, run, host, board)
+		publishCtx := context.WithoutCancel(ctx)
+		envelope, envelopeErr := event.NewEnvelope(
+			publishCtx, agent.SubjectRunEnd(run.RunID), nil)
+		if envelopeErr == nil {
+			envelope.SetRunID(run.RunID)
+			envelopeErr = host.Publish(publishCtx, envelope)
+		}
+		if err != nil {
+			return board, err
+		}
+		return board, envelopeErr
+	})
+}
+
+func newTestSessionManagerForResult(
+	t *testing.T,
+	result *deploy.Result,
+	options ...session.ManagerOption,
+) *session.Manager {
+	return newTestSessionManagerForResolver(
+		t, delegationTestResolver{result: result}, options...)
+}
+
+func newTestSessionManagerForResolver(
+	t *testing.T,
+	resolver session.InstanceResolver,
+	options ...session.ManagerOption,
+) *session.Manager {
+	t.Helper()
+	bus := event.NewMemoryBus()
+	router := event.NewRouter(bus)
+	factory := session.HostFactoryFunc(func(
+		_ context.Context,
+		request session.HostRequest,
+	) (agent.Host, error) {
+		return agent.HostFuncs{
+			Inner:        delegationTestHost{bus: bus},
+			InterruptsFn: func() <-chan agent.Interrupt { return request.Interrupts },
+			AskUserFn:    request.AskUser,
+		}, nil
+	})
+	manager, err := session.NewManager(
+		resolver,
+		factory,
+		router,
+		append([]session.ManagerOption{
+			session.WithIdleTimeout(time.Minute),
+			session.WithSinkBufferSize(8),
+		}, options...)...,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		_ = manager.Close()
+		_ = router.Close()
+		_ = bus.Close()
+	})
+	return manager
+}
+
+func TestWaitTurnCancelOnDoneSurfacesInfraError(t *testing.T) {
+	manager := newTestSessionManagerForResolver(t, nilEngineResolver{})
+	ctx := context.Background()
+	lease, err := manager.GetOrCreate(ctx, session.Key{
+		AgentID: "writer", ContextID: "infra-ctx",
+	})
+	if err != nil {
+		t.Fatalf("GetOrCreate: %v", err)
+	}
+	defer func() { _ = lease.Close() }()
+	turn, err := lease.Session().StartWithOptions(ctx, agent.Request{
+		Message: message.NewTextMessage(message.RoleUser, "hi"),
+	})
+	if err != nil {
+		t.Fatalf("StartWithOptions: %v", err)
+	}
+	result, err := waitTurnCancelOnDone(ctx, turn)
+	if err == nil {
+		t.Fatalf("waitTurnCancelOnDone = %+v, nil error; want infra error", result)
+	}
+	if strings.Contains(err.Error(), "wait for canceled turn") {
+		t.Fatalf("infra error was relabeled as a canceled wait: %v", err)
+	}
+	if !strings.Contains(err.Error(), "nil engine") {
+		t.Fatalf("error = %v, want the raw nil-engine failure", err)
+	}
+	if response := canceledOrFailedResponse(err); response.Status != StatusFailed {
+		t.Fatalf("response status = %q, want failed", response.Status)
+	}
+}
+
+func TestRunAtSessionPathInfraErrorSurfacesRaw(t *testing.T) {
+	result := buildResult(t, completedEngine("ok"))
+	directory := NewDirectory()
+	if err := directory.Bind(result); err != nil {
+		t.Fatal(err)
+	}
+	service, err := NewService(directory, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = service.Close() }()
+	manager := newTestSessionManagerForResolver(t, nilEngineResolver{})
+	if err := service.BindSessionManager(manager); err != nil {
+		t.Fatal(err)
+	}
+	response, err := service.Delegate(context.Background(), syncRequest("writer"))
+	if err != nil {
+		t.Fatalf("Delegate: %v", err)
+	}
+	if response.Status != StatusFailed {
+		t.Fatalf("response status = %q, want failed", response.Status)
+	}
+	if strings.Contains(response.Error, "wait for canceled turn") {
+		t.Fatalf("infra error was relabeled as a canceled wait: %v", response.Error)
+	}
+	if !strings.Contains(response.Error, "nil engine") {
+		t.Fatalf("response error = %q, want the raw nil-engine failure", response.Error)
+	}
+}
+
+// newSessionPathService builds a service bound to a session manager over
+// the same deployment result as its directory.
+func newSessionPathService(
+	t *testing.T,
+	engine agent.Engine,
+	provider SessionProvider,
+	managerOptions ...session.ManagerOption,
+) (*LocalService, *deploy.Result) {
+	t.Helper()
+	result := buildResult(t, delegationWithRunEnd(engine))
+	directory := NewDirectory()
+	if err := directory.Bind(result); err != nil {
+		t.Fatal(err)
+	}
+	options := []Option{}
+	if provider != nil {
+		options = append(options, WithSessionProvider(provider))
+	}
+	service, err := NewService(directory, nil, options...)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = service.Close() })
+	manager := newTestSessionManagerForResult(t, result, managerOptions...)
+	if err := service.BindSessionManager(manager); err != nil {
+		t.Fatal(err)
+	}
+	return service, result
+}
+
+func TestRunAtSessionPathSetsContextIDAndSessionID(t *testing.T) {
+	var gotContextID string
+	engine := agent.EngineFunc(func(
+		_ context.Context,
+		run agent.Run,
+		_ agent.Host,
+		board *agent.Board,
+	) (*agent.Board, error) {
+		gotContextID = run.ConversationID
+		board.AppendChannelMessage(agent.MainChannel,
+			message.NewTextMessage(message.RoleAssistant, "done"))
+		return board, nil
+	})
+	service, _ := newSessionPathService(
+		t, engine, &testSessionProvider{contextID: "stable-ctx", persistent: true})
+	response, err := service.Delegate(context.Background(), syncRequest("writer"))
+	if err != nil {
+		t.Fatalf("Delegate: %v", err)
+	}
+	if response.Status != StatusSucceeded {
+		t.Fatalf("response status = %q, want succeeded", response.Status)
+	}
+	if response.Metadata["delegation.session_id"] != "stable-ctx" {
+		t.Fatalf("session_id = %q, want stable-ctx", response.Metadata["delegation.session_id"])
+	}
+	if gotContextID != "stable-ctx" {
+		t.Fatalf("subagent ContextID = %q, want stable-ctx", gotContextID)
+	}
+}
+
+func TestRunAtSessionPathDefaultMint(t *testing.T) {
+	var gotContextID string
+	engine := agent.EngineFunc(func(
+		_ context.Context,
+		run agent.Run,
+		_ agent.Host,
+		board *agent.Board,
+	) (*agent.Board, error) {
+		gotContextID = run.ConversationID
+		return board, nil
+	})
+	service, _ := newSessionPathService(t, engine, nil)
+	response, err := service.Delegate(context.Background(), syncRequest("writer"))
+	if err != nil {
+		t.Fatalf("Delegate: %v", err)
+	}
+	sessionID := response.Metadata["delegation.session_id"]
+	if response.Status != StatusSucceeded || sessionID == "" {
+		t.Fatalf("response = %+v, want succeeded with a session id", response)
+	}
+	if gotContextID != sessionID {
+		t.Fatalf("subagent ContextID = %q, want %q", gotContextID, sessionID)
+	}
+}
+
+func TestRunAtLegacyWithoutManagerKeepsEmptyContextID(t *testing.T) {
+	var gotContextID string
+	engine := agent.EngineFunc(func(
+		_ context.Context,
+		run agent.Run,
+		_ agent.Host,
+		board *agent.Board,
+	) (*agent.Board, error) {
+		gotContextID = run.ConversationID
+		return board, nil
+	})
+	directory := boundDirectory(t, engine)
+	service, err := NewService(directory, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = service.Close() }()
+	if _, err := service.Delegate(context.Background(), syncRequest("writer")); err != nil {
+		t.Fatalf("Delegate: %v", err)
+	}
+	if gotContextID != "" {
+		t.Fatalf("legacy subagent ContextID = %q, want empty", gotContextID)
+	}
+}
+
+func TestRunAtProviderWithoutManagerSetsContextID(t *testing.T) {
+	var gotContextID string
+	engine := agent.EngineFunc(func(
+		_ context.Context,
+		run agent.Run,
+		_ agent.Host,
+		board *agent.Board,
+	) (*agent.Board, error) {
+		gotContextID = run.ConversationID
+		return board, nil
+	})
+	directory := boundDirectory(t, engine)
+	service, err := NewService(directory, nil,
+		WithSessionProvider(&testSessionProvider{contextID: "ctx-1"}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = service.Close() }()
+	if _, err := service.Delegate(context.Background(), syncRequest("writer")); err != nil {
+		t.Fatalf("Delegate: %v", err)
+	}
+	if gotContextID != "ctx-1" {
+		t.Fatalf("legacy subagent ContextID = %q, want ctx-1", gotContextID)
+	}
+}
+
+func TestRunAtSessionProviderErrorFails(t *testing.T) {
+	service, _ := newSessionPathService(t, completedEngine("ok"),
+		&testSessionProvider{err: errdefs.Internalf("provider down")})
+	if _, err := service.Delegate(context.Background(), syncRequest("writer")); err == nil {
+		t.Fatal("Delegate with failing provider = nil error, want error")
+	}
+}
+
+func TestRunAtSessionProviderEmptyContextIDRejected(t *testing.T) {
+	service, _ := newSessionPathService(t, completedEngine("ok"),
+		&testSessionProvider{contextID: ""})
+	if _, err := service.Delegate(context.Background(), syncRequest("writer")); !errdefs.IsValidation(err) {
+		t.Fatalf("Delegate with empty context id = %v, want validation", err)
+	}
+}
+
+func TestRunAtSessionPathCanceled(t *testing.T) {
+	started := make(chan struct{})
+	engine := agent.EngineFunc(func(
+		ctx context.Context,
+		_ agent.Run,
+		_ agent.Host,
+		board *agent.Board,
+	) (*agent.Board, error) {
+		close(started)
+		<-ctx.Done()
+		return board, ctx.Err()
+	})
+	service, _ := newSessionPathService(t, engine,
+		&testSessionProvider{contextID: "cancel-ctx", persistent: true})
+	ctx, cancel := context.WithCancel(context.Background())
+	type result struct {
+		response Response
+		err      error
+	}
+	done := make(chan result, 1)
+	go func() {
+		response, err := service.Delegate(ctx, syncRequest("writer"))
+		done <- result{response: response, err: err}
+	}()
+	<-started
+	cancel()
+	got := <-done
+	if got.err != nil {
+		t.Fatalf("Delegate: %v", got.err)
+	}
+	if got.response.Status != StatusCanceled {
+		t.Fatalf("response status = %q, want canceled", got.response.Status)
+	}
+}
+
+func TestRunAtSessionPathPreservesDepth(t *testing.T) {
+	var gotDepth int
+	engine := agent.EngineFunc(func(
+		ctx context.Context,
+		_ agent.Run,
+		_ agent.Host,
+		board *agent.Board,
+	) (*agent.Board, error) {
+		gotDepth = metadataFromContext(ctx).depth
+		return board, nil
+	})
+	service, _ := newSessionPathService(t, engine,
+		&testSessionProvider{contextID: "depth-ctx", persistent: true})
+	response, err := service.runAt(context.Background(), AsyncRequest{
+		Request: Request{Mode: ModeSync, Target: "writer", Input: "do it"},
+		Caller:  "parent",
+		Depth:   3,
+	}, false)
+	if err != nil {
+		t.Fatalf("runAt: %v", err)
+	}
+	if response.Status != StatusSucceeded {
+		t.Fatalf("response status = %q, want succeeded", response.Status)
+	}
+	if gotDepth != 3 {
+		t.Fatalf("subagent depth = %d, want 3 (metadata must cross the session boundary)", gotDepth)
+	}
+}
+
+func TestRunAtSessionPathMaxDepthEnforced(t *testing.T) {
+	service, _ := newSessionPathService(t, completedEngine("ok"),
+		&testSessionProvider{contextID: "depth-ctx", persistent: true})
+	service.maxDepth = 1
+	if _, err := service.runAt(context.Background(), AsyncRequest{
+		Request: Request{Mode: ModeSync, Target: "writer", Input: "do it"},
+		Depth:   2,
+	}, false); !errdefs.IsPolicyDenied(err) {
+		t.Fatalf("runAt over depth = %v, want policy denied", err)
+	}
+}
+
+func TestRunAtSameKeySecondDelegationInterruptsFirst(t *testing.T) {
+	started := make(chan struct{}, 2)
+	var runs atomic.Int64
+	engine := agent.EngineFunc(func(
+		ctx context.Context,
+		_ agent.Run,
+		host agent.Host,
+		board *agent.Board,
+	) (*agent.Board, error) {
+		started <- struct{}{}
+		if runs.Add(1) > 1 {
+			return board, nil
+		}
+		select {
+		case interrupt := <-host.Interrupts():
+			return board, agent.Interrupted(interrupt)
+		case <-ctx.Done():
+			return board, ctx.Err()
+		}
+	})
+	service, _ := newSessionPathService(t, engine,
+		&testSessionProvider{contextID: "same-ctx", persistent: true})
+
+	first := make(chan Response, 1)
+	go func() {
+		response, err := service.Delegate(context.Background(), syncRequest("writer"))
+		if err != nil {
+			t.Errorf("first Delegate: %v", err)
+			return
+		}
+		first <- response
+	}()
+	<-started
+	second, err := service.Delegate(context.Background(), syncRequest("writer"))
+	if err != nil {
+		t.Fatalf("second Delegate: %v", err)
+	}
+	firstResponse := <-first
+	if firstResponse.Status != StatusCanceled {
+		t.Fatalf("first response status = %q, want canceled", firstResponse.Status)
+	}
+	if second.Status != StatusSucceeded {
+		t.Fatalf("second response status = %q, want succeeded", second.Status)
+	}
+}
+
+func TestRunAtSessionPathAsyncRun(t *testing.T) {
+	engine := agent.EngineFunc(func(
+		_ context.Context,
+		_ agent.Run,
+		_ agent.Host,
+		board *agent.Board,
+	) (*agent.Board, error) {
+		board.AppendChannelMessage(agent.MainChannel,
+			message.NewTextMessage(message.RoleAssistant, "async done"))
+		return board, nil
+	})
+	service, _ := newSessionPathService(t, engine,
+		&testSessionProvider{contextID: "async-ctx", persistent: true})
+	response, err := service.Run(context.Background(), AsyncRequest{
+		Request: Request{Mode: ModeAsync, Target: "writer", Input: "do it"},
+		Depth:   1,
+	})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if response.Status != StatusSucceeded {
+		t.Fatalf("response status = %q, want succeeded", response.Status)
+	}
+	if response.Metadata["delegation.session_id"] != "async-ctx" {
+		t.Fatalf("session_id = %q, want async-ctx", response.Metadata["delegation.session_id"])
+	}
+}
+
+type delegationRecordingStore struct {
+	mu    sync.Mutex
+	saved int
+}
+
+func (s *delegationRecordingStore) Save(context.Context, agent.Checkpoint) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.saved++
+	return nil
+}
+
+func (s *delegationRecordingStore) Load(context.Context, string) (*agent.Checkpoint, error) {
+	return nil, nil
+}
+
+func (s *delegationRecordingStore) Delete(context.Context, string) error {
+	return nil
+}
+
+func (s *delegationRecordingStore) count() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.saved
+}
+
+func TestRunAtSessionPathEphemeralWritesNoState(t *testing.T) {
+	engine := agent.EngineFunc(func(
+		_ context.Context,
+		_ agent.Run,
+		_ agent.Host,
+		board *agent.Board,
+	) (*agent.Board, error) {
+		return board, nil
+	})
+	store := &delegationRecordingStore{}
+	service, _ := newSessionPathService(t, engine, nil,
+		session.WithResume(true), session.WithCheckpointStore(store))
+	if _, err := service.Delegate(context.Background(), syncRequest("writer")); err != nil {
+		t.Fatalf("Delegate: %v", err)
+	}
+	if got := store.count(); got != 0 {
+		t.Fatalf("ephemeral delegation wrote %d checkpoints, want none", got)
+	}
+}
+
+func TestRunAtSessionPathPersistentWritesState(t *testing.T) {
+	engine := agent.EngineFunc(func(
+		_ context.Context,
+		_ agent.Run,
+		_ agent.Host,
+		board *agent.Board,
+	) (*agent.Board, error) {
+		return board, nil
+	})
+	store := &delegationRecordingStore{}
+	service, _ := newSessionPathService(t, engine,
+		&testSessionProvider{contextID: "persist-ctx", persistent: true},
+		session.WithResume(true), session.WithCheckpointStore(store))
+	if _, err := service.Delegate(context.Background(), syncRequest("writer")); err != nil {
+		t.Fatalf("Delegate: %v", err)
+	}
+	if got := store.count(); got == 0 {
+		t.Fatal("persistent delegation wrote no checkpoints, want session state")
+	}
+}

--- a/core/delegation/tool/resource.go
+++ b/core/delegation/tool/resource.go
@@ -2,6 +2,7 @@ package delegation
 
 import (
 	"context"
+	"reflect"
 
 	sdkdelegation "github.com/GizClaw/flowcraft/core/delegation"
 	"github.com/GizClaw/flowcraft/core/errdefs"
@@ -12,16 +13,14 @@ import (
 // SourceImpl is the tool.Source impl name for the delegation tools.
 const SourceImpl = "delegation"
 
-type sourceFactory struct {
-	directory sdkdelegation.Directory
-}
+type sourceFactory struct{}
 
 // NewSourceFactory returns a tool.Source factory whose tools are the
-// delegate + delegation_status pair. directory is app-owned and may be
-// bound to a deploy result after assembly; the tools discover targets
-// from it at call time.
-func NewSourceFactory(directory sdkdelegation.Directory) res.Factory {
-	return &sourceFactory{directory: directory}
+// delegate + delegation_status pair. The directory is resolved from the
+// deploy dependency, so every deployment generation's tools see that
+// generation's targets at call time.
+func NewSourceFactory() res.Factory {
+	return &sourceFactory{}
 }
 
 // Spec implements res.Factory.
@@ -29,20 +28,46 @@ func (sourceFactory) Spec() res.Spec {
 	return res.Spec{
 		Kind: "tool.Source",
 		Impl: SourceImpl,
+		Deps: []res.DepSpec{{
+			Name:     sdkdelegation.DirectoryDep,
+			Type:     "delegation.Directory",
+			Required: true,
+		}},
 	}
 }
 
 // New implements res.Factory: the source takes no settings.
-func (f *sourceFactory) New(_ context.Context, in res.Input) (any, error) {
+func (sourceFactory) New(_ context.Context, in res.Input) (any, error) {
 	if _, err := res.DecodeTyped[struct{}](in.Settings); err != nil {
 		return nil, errdefs.Validationf(
 			"delegation tool resource: decode settings: %v", err)
 	}
-	if f == nil || f.directory == nil {
+	value, ok := in.Dep(sdkdelegation.DirectoryDep)
+	if !ok {
 		return nil, errdefs.Validationf(
-			"delegation tool resource: directory is required")
+			"delegation tool resource: dep %q is required", sdkdelegation.DirectoryDep)
 	}
-	return &source{directory: f.directory}, nil
+	directory, ok := value.(sdkdelegation.Directory)
+	if !ok || isNilInterface(directory) {
+		return nil, errdefs.Validationf(
+			"delegation tool resource: dep %q is %T, want delegation.Directory",
+			sdkdelegation.DirectoryDep, value)
+	}
+	return &source{directory: directory}, nil
+}
+
+func isNilInterface(value any) bool {
+	if value == nil {
+		return true
+	}
+	rv := reflect.ValueOf(value)
+	switch rv.Kind() {
+	case reflect.Chan, reflect.Func, reflect.Interface, reflect.Map,
+		reflect.Pointer, reflect.Slice:
+		return rv.IsNil()
+	default:
+		return false
+	}
 }
 
 // source is the tool.Source value contributing the delegation tools.

--- a/core/delegation/tool/resource_test.go
+++ b/core/delegation/tool/resource_test.go
@@ -12,16 +12,17 @@ import (
 )
 
 func TestSourceFactoryRequiresDirectory(t *testing.T) {
-	_, err := (tooldelegation.NewSourceFactory(nil)).New(context.Background(), resource.Input{})
+	_, err := (tooldelegation.NewSourceFactory()).New(context.Background(), resource.Input{})
 	if !errdefs.IsValidation(err) {
 		t.Fatalf("New without directory = %v, want Validation", err)
 	}
 }
 
 func TestSourceFactoryRejectsSettings(t *testing.T) {
-	_, err := (tooldelegation.NewSourceFactory(&fakeDirectory{})).New(
+	_, err := (tooldelegation.NewSourceFactory()).New(
 		context.Background(), resource.Input{
 			Settings: []byte(`{"unknown":true}`),
+			Deps:     map[string]any{delegation.DirectoryDep: &fakeDirectory{}},
 		})
 	if !errdefs.IsValidation(err) {
 		t.Fatalf("New with settings = %v, want Validation", err)
@@ -29,8 +30,10 @@ func TestSourceFactoryRejectsSettings(t *testing.T) {
 }
 
 func TestSourceFactoryBuildsTools(t *testing.T) {
-	value, err := (tooldelegation.NewSourceFactory(&fakeDirectory{})).New(
-		context.Background(), resource.Input{})
+	value, err := (tooldelegation.NewSourceFactory()).New(
+		context.Background(), resource.Input{
+			Deps: map[string]any{delegation.DirectoryDep: &fakeDirectory{}},
+		})
 	if err != nil {
 		t.Fatalf("New: %v", err)
 	}
@@ -56,8 +59,10 @@ func TestSourceFactoryBuildsTools(t *testing.T) {
 }
 
 func TestSourceWorksInToolRegistry(t *testing.T) {
-	value, err := (tooldelegation.NewSourceFactory(&fakeDirectory{})).New(
-		context.Background(), resource.Input{})
+	value, err := (tooldelegation.NewSourceFactory()).New(
+		context.Background(), resource.Input{
+			Deps: map[string]any{delegation.DirectoryDep: &fakeDirectory{}},
+		})
 	if err != nil {
 		t.Fatalf("New: %v", err)
 	}

--- a/core/runtime/bind_test.go
+++ b/core/runtime/bind_test.go
@@ -1,0 +1,217 @@
+package runtime
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"github.com/GizClaw/flowcraft/core/delegation"
+	"github.com/GizClaw/flowcraft/core/deploy"
+	"github.com/GizClaw/flowcraft/core/errdefs"
+	"github.com/GizClaw/flowcraft/core/event"
+	"github.com/GizClaw/flowcraft/core/resource"
+	"github.com/GizClaw/flowcraft/core/runtime/session"
+)
+
+const (
+	testBinderKind = "runtime.SessionManagerBinder"
+	testBinderImpl = "test"
+)
+
+// freshBusFactory builds a new bus per generation so reloads satisfy the
+// "each generation owns its bus" constraint.
+type freshBusFactory struct{}
+
+func (freshBusFactory) Spec() resource.Spec {
+	return resource.Spec{Kind: testEventKind, Impl: testEventImpl}
+}
+
+func (freshBusFactory) New(context.Context, resource.Input) (any, error) {
+	return event.NewMemoryBus(), nil
+}
+
+// newBindRegistry registers the test engine, a per-generation bus, a
+// shared checkpoint store, and the given extra factories.
+func newBindRegistry(t *testing.T, extras ...resource.Factory) *resource.Registry {
+	t.Helper()
+	reg := resource.NewRegistry()
+	reg.MustRegister(testEngineFactory{engine: noopEngine()})
+	reg.MustRegister(freshBusFactory{})
+	reg.MustRegister(testResourceFactory{
+		spec:  resource.Spec{Kind: testStoreKind, Impl: testStoreImpl},
+		value: &recordingCheckpointStore{},
+	})
+	for _, factory := range extras {
+		if factory != nil {
+			reg.MustRegister(factory)
+		}
+	}
+	return reg
+}
+
+type recordingBinder struct {
+	mu      sync.Mutex
+	manager *session.Manager
+}
+
+func (b *recordingBinder) BindSessionManager(manager *session.Manager) error {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if b.manager != nil {
+		return errdefs.Conflictf("recording binder: already bound")
+	}
+	b.manager = manager
+	return nil
+}
+
+func (b *recordingBinder) bound() *session.Manager {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.manager
+}
+
+type binderFactory struct {
+	mu      sync.Mutex
+	created []*recordingBinder
+}
+
+func (f *binderFactory) Spec() resource.Spec {
+	return resource.Spec{Kind: testBinderKind, Impl: testBinderImpl}
+}
+
+func (f *binderFactory) New(context.Context, resource.Input) (any, error) {
+	binder := &recordingBinder{}
+	f.mu.Lock()
+	f.created = append(f.created, binder)
+	f.mu.Unlock()
+	return binder, nil
+}
+
+func (f *binderFactory) all() []*recordingBinder {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return append([]*recordingBinder(nil), f.created...)
+}
+
+func binderDoc(t *testing.T, extra string) deploy.Document {
+	t.Helper()
+	doc := baseRuntimeDoc(t)
+	doc.Resources["binder"] = resource.Resource{
+		Kind: testBinderKind, Impl: testBinderImpl,
+	}
+	if extra != "" {
+		doc.Resources["binder2"] = resource.Resource{
+			Kind: testBinderKind, Impl: testBinderImpl,
+		}
+	}
+	return doc
+}
+
+func TestBuildBindsSessionManager(t *testing.T) {
+	factory := &binderFactory{}
+	reg := newBindRegistry(t, factory)
+	app, err := NewBuilder(reg).Build(context.Background(), binderDoc(t, ""))
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	defer func() { _ = app.Close() }()
+
+	created := factory.all()
+	if len(created) != 1 {
+		t.Fatalf("created binders = %d, want 1", len(created))
+	}
+	if got := created[0].bound(); got != app.Sessions() {
+		t.Fatal("binder did not receive the runtime session manager")
+	}
+}
+
+func TestBuildRejectsMultipleBinders(t *testing.T) {
+	factory := &binderFactory{}
+	reg := newBindRegistry(t, factory)
+	if _, err := NewBuilder(reg).Build(context.Background(), binderDoc(t, "extra")); !errdefs.IsConflict(err) {
+		t.Fatalf("Build with two binders = %v, want conflict", err)
+	}
+}
+
+func TestReloadRebindsNewGeneration(t *testing.T) {
+	factory := &binderFactory{}
+	reg := newBindRegistry(t, factory)
+	doc := binderDoc(t, "")
+	app, err := NewBuilder(reg).Build(context.Background(), doc)
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	defer func() { _ = app.Close() }()
+
+	if _, err := app.Reload(context.Background(), doc); err != nil {
+		t.Fatalf("Reload: %v", err)
+	}
+	created := factory.all()
+	if len(created) != 2 {
+		t.Fatalf("created binders = %d, want 2 (one per generation)", len(created))
+	}
+	for _, binder := range created {
+		if got := binder.bound(); got != app.Sessions() {
+			t.Fatal("every generation's binder must receive the same runtime manager")
+		}
+	}
+}
+
+func TestReloadWithoutBinderDoesNotBind(t *testing.T) {
+	factory := &binderFactory{}
+	reg := newBindRegistry(t, factory)
+	doc := binderDoc(t, "")
+	app, err := NewBuilder(reg).Build(context.Background(), doc)
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	defer func() { _ = app.Close() }()
+
+	withoutBinder := baseRuntimeDoc(t)
+	if _, err := app.Reload(context.Background(), withoutBinder); err != nil {
+		t.Fatalf("Reload without binder: %v", err)
+	}
+	if got := len(factory.all()); got != 1 {
+		t.Fatalf("created binders = %d, want 1 (new generation has no binder)", got)
+	}
+}
+
+func TestBuildDelegationServiceSessionPath(t *testing.T) {
+	reg := newBaseRegistry(t, event.NewMemoryBus(), &recordingCheckpointStore{}, noopEngine())
+	reg.MustRegister(delegation.NewDirectoryFactory())
+	reg.MustRegister(delegation.NewServiceFactory())
+	doc := baseRuntimeDoc(t)
+	doc.Resources["delegation_directory"] = resource.Resource{
+		Kind: delegation.DirectoryKind, Impl: "local",
+	}
+	doc.Resources["delegation"] = resource.Resource{
+		Kind: delegation.ServiceKind, Impl: "local",
+		Deps: resource.Deps{"directory": "delegation_directory"},
+	}
+	app, err := NewBuilder(reg).Build(context.Background(), doc)
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	defer func() { _ = app.Close() }()
+
+	value, _ := app.Resource("delegation")
+	service, ok := value.(*delegation.LocalService)
+	if !ok {
+		t.Fatalf("delegation resource = %T, want *delegation.LocalService",
+			value)
+	}
+	response, err := service.Delegate(context.Background(), delegation.Request{
+		Mode:   delegation.ModeSync,
+		Target: "bot",
+		Input:  "do it",
+	})
+	if err != nil {
+		t.Fatalf("Delegate: %v", err)
+	}
+	if response.Status != delegation.StatusSucceeded {
+		t.Fatalf("response status = %q, want succeeded", response.Status)
+	}
+	if response.Metadata["delegation.session_id"] == "" {
+		t.Fatal("session-path delegation returned no delegation.session_id")
+	}
+}

--- a/core/runtime/builder.go
+++ b/core/runtime/builder.go
@@ -248,6 +248,12 @@ func (b *Builder) Build(ctx context.Context, doc deploy.Document) (*Runtime, err
 		_ = result.Close()
 		return nil, fmt.Errorf("runtime create session manager: %w", err)
 	}
+	if err := bindSessionManagers(manager, result); err != nil {
+		_ = manager.Close()
+		_ = router.Close()
+		_ = result.Close()
+		return nil, fmt.Errorf("runtime bind session managers: %w", err)
+	}
 	return &Runtime{
 		manager:             manager,
 		router:              router,
@@ -262,6 +268,40 @@ func (b *Builder) Build(ctx context.Context, doc deploy.Document) (*Runtime, err
 		current:             initial,
 		nextGenID:           1,
 	}, nil
+}
+
+// bindSessionManagers hands the Runtime's single session manager to every
+// deployment value that needs it (e.g. the delegation service). At most
+// one binder is allowed per deployment (v1 constraint, aligned with
+// delegation hostwrap's single-service rule), and each binder accepts the
+// manager exactly once.
+func bindSessionManagers(manager *session.Manager, result *deploy.Result) error {
+	if manager == nil || result == nil {
+		return errdefs.Internalf(
+			"runtime: bind session managers requires a manager and result")
+	}
+	var bound string
+	for _, name := range result.Names() {
+		value, ok := result.Value(name)
+		if !ok {
+			continue
+		}
+		binder, ok := value.(session.ManagerBinder)
+		if !ok {
+			continue
+		}
+		if bound != "" {
+			return errdefs.Conflictf(
+				"runtime: multiple session manager binders (%s and %s)",
+				bound, name)
+		}
+		if err := binder.BindSessionManager(manager); err != nil {
+			return fmt.Errorf(
+				"runtime: bind session manager to %q: %w", name, err)
+		}
+		bound = name
+	}
+	return nil
 }
 
 func resolveValue[T any](result *deploy.Result, name, field string) (T, error) {

--- a/core/runtime/builder_test.go
+++ b/core/runtime/builder_test.go
@@ -481,12 +481,16 @@ func TestBuildWithoutResultHostFactoryLeavesHostUnexposed(t *testing.T) {
 }
 
 func TestBuildBindsDelegationDirectory(t *testing.T) {
-	directory := delegation.NewDirectory()
 	reg := newBaseRegistry(t, event.NewMemoryBus(), &recordingCheckpointStore{}, noopEngine())
-	reg.MustRegister(delegation.NewServiceFactory(directory))
+	reg.MustRegister(delegation.NewDirectoryFactory())
+	reg.MustRegister(delegation.NewServiceFactory())
 	doc := baseRuntimeDoc(t)
+	doc.Resources["delegation_directory"] = resource.Resource{
+		Kind: delegation.DirectoryKind, Impl: "local",
+	}
 	doc.Resources["delegation"] = resource.Resource{
 		Kind: delegation.ServiceKind, Impl: "local",
+		Deps: resource.Deps{"directory": "delegation_directory"},
 	}
 
 	app, err := NewBuilder(reg).Build(context.Background(), doc)
@@ -495,6 +499,12 @@ func TestBuildBindsDelegationDirectory(t *testing.T) {
 	}
 	defer func() { _ = app.Close() }()
 
+	directoryValue, _ := app.Resource("delegation_directory")
+	directory, ok := directoryValue.(*delegation.LocalDirectory)
+	if !ok {
+		t.Fatalf("delegation directory resource = %T, want *delegation.LocalDirectory",
+			directoryValue)
+	}
 	targets, err := directory.List(context.Background())
 	if err != nil {
 		t.Fatalf("directory was not bound: %v", err)

--- a/core/runtime/reload.go
+++ b/core/runtime/reload.go
@@ -124,6 +124,14 @@ func (r *Runtime) Reload(
 		return err
 	}
 
+	// Hand the runtime's session manager to the new generation's
+	// consumers (e.g. the delegation service). Binding runs before the
+	// swap so a failure aborts the reload without touching the live
+	// generation; each generation's service instance binds exactly once.
+	if err := bindSessionManagers(r.manager, newResult); err != nil {
+		return nil, abort(err)
+	}
+
 	// Resolve the new generation's system resources and validate the
 	// resume contract. The bus and checkpoint store may change
 	// configuration (or implementation) freely: each generation owns

--- a/core/runtime/session/binder.go
+++ b/core/runtime/session/binder.go
@@ -1,0 +1,10 @@
+package session
+
+// ManagerBinder receives the Runtime's session manager when a deployment
+// generation is built or rebuilt. Consumers such as the delegation
+// service implement it to upgrade subagent execution from the legacy
+// bare-run path to session lifecycle. Binding is set-once: a second bind
+// must return an error so the runtime can roll back a reload.
+type ManagerBinder interface {
+	BindSessionManager(manager *Manager) error
+}

--- a/core/runtime/session/prompt.go
+++ b/core/runtime/session/prompt.go
@@ -80,6 +80,9 @@ func (t *Turn) Reply(ctx context.Context, promptID string, reply agent.UserReply
 }
 
 func (t *Turn) askUser(ctx context.Context, prompt agent.UserPrompt) (agent.UserReply, error) {
+	if t.askUserOverride != nil {
+		return t.askUserOverride(ctx, prompt)
+	}
 	if ctx == nil {
 		return agent.UserReply{}, errdefs.Validationf("runtime session: AskUser context is required")
 	}

--- a/core/runtime/session/session.go
+++ b/core/runtime/session/session.go
@@ -36,15 +36,20 @@ type Session struct {
 	speculativeBytes    int
 	deliveryConcurrency int
 
-	startMu        sync.Mutex
-	mu             sync.Mutex
-	activeTurns    int
-	activePrompts  int
-	attachedSinks  int
-	active         *Turn
-	closing        bool
-	catalog        sdktool.Session
-	catalogEpoch   uint64
+	startMu       sync.Mutex
+	mu            sync.Mutex
+	activeTurns   int
+	activePrompts int
+	attachedSinks int
+	active        *Turn
+	closing       bool
+	catalog       sdktool.Session
+	catalogEpoch  uint64
+	// ephemeral is a session-level property fixed by the first Start:
+	// ephemeral sessions never persist session state or run checkpoints.
+	// Writes happen under startMu; reads use mu (see isEphemeral).
+	ephemeral      bool
+	ephemeralSet   bool
 	activityNotify func(*Session)
 	observer       SessionObserver
 	closeOnce      sync.Once
@@ -78,18 +83,39 @@ func newSession(
 // Start installs and asynchronously executes a new turn. A previous turn is
 // interrupted and fully finalized before the replacement is constructed.
 func (s *Session) Start(ctx context.Context, request agent.Request, sinks ...SinkSpec) (*Turn, error) {
+	return s.start(ctx, request, startConfig{sinks: sinks})
+}
+
+// StartWithOptions is Start with option-based configuration: stream sinks,
+// an AskUser override, and the ephemeral session property. The plain Start
+// signature is unchanged for existing callers.
+func (s *Session) StartWithOptions(ctx context.Context, request agent.Request, opts ...StartOption) (*Turn, error) {
+	config, err := applyStartOptions(opts)
+	if err != nil {
+		return nil, err
+	}
+	return s.start(ctx, request, config)
+}
+
+func (s *Session) start(ctx context.Context, request agent.Request, config startConfig) (*Turn, error) {
 	if s == nil {
 		return nil, ErrSessionClosed
 	}
 	if ctx == nil {
 		return nil, errdefs.Validationf("runtime session: Start context is required")
 	}
-	if err := validateSinks(sinks); err != nil {
+	if err := validateSinks(config.sinks); err != nil {
 		return nil, err
 	}
 
 	s.startMu.Lock()
 	defer s.startMu.Unlock()
+
+	// The ephemeral property is fixed by the first Start and must be set
+	// before loadSessionState so seeding and host wrapping can rely on it.
+	if err := s.setEphemeralProperty(config.ephemeral); err != nil {
+		return nil, err
+	}
 
 	// Pin this turn to one epoch: every dependency the turn uses comes
 	// from this snapshot, so a concurrent generation swap cannot tear it.
@@ -119,18 +145,20 @@ func (s *Session) Start(ctx context.Context, request agent.Request, sinks ...Sin
 	if err != nil {
 		return nil, err
 	}
-	state, err := s.loadSessionState(ctx, deps.Checkpoints, deps.Resume)
-	if err != nil {
-		return nil, err
-	}
 	var snapshot *agent.BoardSnapshot
-	if state != nil {
-		snapshot = state.Board
+	if !s.isEphemeral() {
+		state, err := s.loadSessionState(ctx, deps.Checkpoints, deps.Resume)
+		if err != nil {
+			return nil, err
+		}
+		if state != nil {
+			snapshot = state.Board
+		}
 	}
 	request.ContextID = s.key.ContextID
 	request.RunID = runID
 	turn, err := s.startTurnLocked(
-		ctx, request, runID, deps, epochRelease, nil, nil, snapshot, sinks)
+		ctx, request, runID, deps, epochRelease, nil, nil, snapshot, &config)
 	if err != nil {
 		return nil, err
 	}
@@ -146,18 +174,41 @@ func (s *Session) Start(ctx context.Context, request agent.Request, sinks ...Sin
 // fresh. A new user message MUST go through Start — Resume does not
 // carry a request.
 func (s *Session) Resume(ctx context.Context, sinks ...SinkSpec) (*Turn, error) {
+	return s.resume(ctx, startConfig{sinks: sinks})
+}
+
+// ResumeWithOptions is Resume with option-based configuration. WithEphemeral
+// is rejected: the session ephemeral property is fixed by the first Start.
+func (s *Session) ResumeWithOptions(ctx context.Context, opts ...StartOption) (*Turn, error) {
+	config, err := applyStartOptions(opts)
+	if err != nil {
+		return nil, err
+	}
+	if config.ephemeralSet {
+		return nil, errdefs.Validationf(
+			"runtime session: ResumeWithOptions cannot change the session ephemeral property")
+	}
+	return s.resume(ctx, config)
+}
+
+func (s *Session) resume(ctx context.Context, config startConfig) (*Turn, error) {
 	if s == nil {
 		return nil, ErrSessionClosed
 	}
 	if ctx == nil {
 		return nil, errdefs.Validationf("runtime session: Resume context is required")
 	}
-	if err := validateSinks(sinks); err != nil {
+	if err := validateSinks(config.sinks); err != nil {
 		return nil, err
 	}
 
 	s.startMu.Lock()
 	defer s.startMu.Unlock()
+
+	if s.isEphemeral() {
+		return nil, errdefs.NotFoundf(
+			"runtime session: ephemeral session has no resumable state")
+	}
 
 	deps, epochRelease, err := s.manager.beginEpoch()
 	if err != nil {
@@ -221,7 +272,7 @@ func (s *Session) Resume(ctx context.Context, sinks ...SinkSpec) (*Turn, error) 
 	request.ContextID = s.key.ContextID
 	request.RunID = runID
 	turn, err := s.startTurnLocked(
-		ctx, request, runID, deps, epochRelease, resumeFrom, resumeCtx, nil, sinks)
+		ctx, request, runID, deps, epochRelease, resumeFrom, resumeCtx, nil, &config)
 	if err != nil {
 		return nil, err
 	}
@@ -234,6 +285,9 @@ func (s *Session) Resume(ctx context.Context, sinks ...SinkSpec) (*Turn, error) 
 // and can be replayed via Resume. It returns the parked run id.
 func (s *Session) Resumable(ctx context.Context) (string, bool, error) {
 	if s == nil {
+		return "", false, nil
+	}
+	if s.isEphemeral() {
 		return "", false, nil
 	}
 	deps := s.manager.currentDeps()
@@ -317,7 +371,7 @@ func (s *Session) startTurnLocked(
 	resumeFrom *agent.Checkpoint,
 	resumeCtx *agent.ResumeContext,
 	snapshot *agent.BoardSnapshot,
-	sinks []SinkSpec,
+	config *startConfig,
 ) (*Turn, error) {
 	turn := newTurn(s, runID, ctx)
 	turn.release = epochRelease
@@ -326,6 +380,7 @@ func (s *Session) startTurnLocked(
 	turn.resumeFrom = resumeFrom
 	turn.resumeCtx = resumeCtx
 	turn.snapshot = snapshot
+	turn.askUserOverride = config.askUser
 	instance, ok := deps.Resolver.Instance(s.key.AgentID)
 	if !ok {
 		turn.cancel()
@@ -371,12 +426,15 @@ func (s *Session) startTurnLocked(
 		epochRelease()
 		return nil, errdefs.Internalf("runtime session: HostFactory returned nil Host")
 	}
+	if s.isEphemeral() {
+		host = ephemeralHost{Host: host}
+	}
 	turn.host = host
 
-	attachments := make([]*queuedSink, 0, len(sinks))
-	raw := make([]*queuedSink, 0, len(sinks))
-	confirmed := make([]*queuedSink, 0, len(sinks))
-	for _, spec := range sinks {
+	attachments := make([]*queuedSink, 0, len(config.sinks))
+	raw := make([]*queuedSink, 0, len(config.sinks))
+	confirmed := make([]*queuedSink, 0, len(config.sinks))
+	for _, spec := range config.sinks {
 		size := spec.QueueSize
 		if size == 0 {
 			size = s.sinkBuffer
@@ -567,7 +625,7 @@ func (s *Session) clearParkedRun(
 //     can replay them. The committed board is left untouched.
 func (s *Session) afterTurn(turn *Turn, result *agent.Result) {
 	if s == nil || turn == nil ||
-		!turn.resume || turn.checkpoints == nil {
+		s.isEphemeral() || !turn.resume || turn.checkpoints == nil {
 		return
 	}
 	ctx, cancel := context.WithTimeout(
@@ -715,6 +773,34 @@ func (s *Session) isIdle() bool {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	return s.idleLocked()
+}
+
+// isEphemeral reports whether the session was created as an ephemeral
+// session: no session-state or run-checkpoint persistence, no history
+// seeding, and no resumable state.
+func (s *Session) isEphemeral() bool {
+	if s == nil {
+		return false
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.ephemeral
+}
+
+// setEphemeralProperty fixes the session ephemeral property. It must be
+// called with startMu held, before loadSessionState. Mixing ephemeral and
+// persistent starts on the same session is rejected so a later turn can
+// never resurrect state a session chose to discard.
+func (s *Session) setEphemeralProperty(ephemeral bool) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.ephemeralSet && s.ephemeral != ephemeral {
+		return errdefs.Validationf(
+			"runtime session: mixing ephemeral and persistent starts on the same session is not allowed")
+	}
+	s.ephemeral = ephemeral
+	s.ephemeralSet = true
+	return nil
 }
 
 func (s *Session) idleLocked() bool {

--- a/core/runtime/session/start_options.go
+++ b/core/runtime/session/start_options.go
@@ -1,0 +1,81 @@
+package session
+
+import (
+	"context"
+
+	"github.com/GizClaw/flowcraft/core/agent"
+	"github.com/GizClaw/flowcraft/core/errdefs"
+)
+
+// StartOption configures one StartWithOptions / ResumeWithOptions call.
+// Existing callers of Start / Resume never see these options.
+type StartOption func(*startConfig) error
+
+type startConfig struct {
+	sinks        []SinkSpec
+	askUser      AskUserFunc
+	ephemeral    bool
+	ephemeralSet bool
+}
+
+// WithSinks attaches stream sinks, mirroring the variadic sinks of
+// Session.Start for the option-based entry point.
+func WithSinks(sinks ...SinkSpec) StartOption {
+	return func(config *startConfig) error {
+		config.sinks = append(config.sinks, sinks...)
+		return nil
+	}
+}
+
+// WithAskUserOverride replaces the turn's default PromptRequested-based
+// asker. The override is invoked directly by the turn host without
+// publishing prompt lifecycle events or blocking for a reply.
+func WithAskUserOverride(askUser AskUserFunc) StartOption {
+	return func(config *startConfig) error {
+		if isNil(askUser) {
+			return errdefs.Validationf(
+				"runtime session: AskUser override must not be nil")
+		}
+		config.askUser = askUser
+		return nil
+	}
+}
+
+// WithEphemeral marks the session ephemeral (fixed by the first Start):
+// no session-state or run-checkpoint writes, no history seeding, canceled
+// turns never park, and Resume reports not found. Mixing ephemeral and
+// persistent starts on the same session is rejected.
+func WithEphemeral() StartOption {
+	return func(config *startConfig) error {
+		config.ephemeral = true
+		config.ephemeralSet = true
+		return nil
+	}
+}
+
+func applyStartOptions(options []StartOption) (startConfig, error) {
+	config := startConfig{}
+	for _, option := range options {
+		if isNil(option) {
+			return startConfig{}, errdefs.Validationf(
+				"runtime session: StartOption must not be nil")
+		}
+		if err := option(&config); err != nil {
+			return startConfig{}, err
+		}
+	}
+	return config, nil
+}
+
+// ephemeralHost wraps a turn Host so run checkpoints are never written:
+// ephemeral sessions must not leave any durable trace in the checkpoint
+// store.
+type ephemeralHost struct {
+	agent.Host
+}
+
+func (ephemeralHost) Checkpoint(context.Context, agent.Checkpoint) error {
+	return nil
+}
+
+var _ agent.Checkpointer = ephemeralHost{}

--- a/core/runtime/session/start_options_test.go
+++ b/core/runtime/session/start_options_test.go
@@ -1,0 +1,322 @@
+package session
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/GizClaw/flowcraft/core/agent"
+	"github.com/GizClaw/flowcraft/core/errdefs"
+	"github.com/GizClaw/flowcraft/core/event"
+	"github.com/GizClaw/flowcraft/core/message"
+)
+
+// sessionRecordingStore is a minimal CheckpointDeleter that records every
+// saved checkpoint, distinguishing session-state records from run
+// checkpoints.
+type sessionRecordingStore struct {
+	mu    sync.Mutex
+	saved []agent.Checkpoint
+}
+
+func (s *sessionRecordingStore) Save(_ context.Context, cp agent.Checkpoint) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.saved = append(s.saved, cp.Clone())
+	return nil
+}
+
+func (s *sessionRecordingStore) Load(context.Context, string) (*agent.Checkpoint, error) {
+	return nil, nil
+}
+
+func (s *sessionRecordingStore) Delete(context.Context, string) error {
+	return nil
+}
+
+func (s *sessionRecordingStore) count() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return len(s.saved)
+}
+
+func (s *sessionRecordingStore) isEmpty() bool {
+	return s.count() == 0
+}
+
+func TestStartWithOptionsAttachesSinks(t *testing.T) {
+	engine := agent.EngineFunc(func(
+		_ context.Context,
+		_ agent.Run,
+		_ agent.Host,
+		board *agent.Board,
+	) (*agent.Board, error) {
+		board.AppendChannelMessage(agent.MainChannel,
+			message.NewTextMessage(message.RoleAssistant, "done"))
+		return board, nil
+	})
+	_, session, _, _ := newTurnSession(t, engine, turnHostFactory)
+	turn, err := session.StartWithOptions(
+		context.Background(),
+		agent.Request{Message: message.NewTextMessage(message.RoleUser, "hi")},
+		WithSinks(SinkSpec{ID: "s1", Sink: discardSink{}}),
+	)
+	if err != nil {
+		t.Fatalf("StartWithOptions: %v", err)
+	}
+	result, err := turn.Wait(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Status != agent.StatusCompleted {
+		t.Fatalf("result status = %q, want completed", result.Status)
+	}
+}
+
+func TestStartWithOptionsRejectsNilOption(t *testing.T) {
+	_, session, _, _ := newTurnSession(t, noopTestEngine(), turnHostFactory)
+	if _, err := session.StartWithOptions(
+		context.Background(),
+		agent.Request{Message: message.NewTextMessage(message.RoleUser, "hi")},
+		nil,
+	); !errdefs.IsValidation(err) {
+		t.Fatalf("nil option error = %v, want validation", err)
+	}
+}
+
+func TestEphemeralSessionPropertyFixedOnFirstStart(t *testing.T) {
+	_, session, _, _ := newTurnSession(t, noopTestEngine(), turnHostFactory)
+	if err := session.setEphemeralProperty(false); err != nil {
+		t.Fatalf("first set: %v", err)
+	}
+	if err := session.setEphemeralProperty(true); !errdefs.IsValidation(err) {
+		t.Fatalf("mixing set error = %v, want validation", err)
+	}
+
+	// A plain Start on an ephemeral session is an implicit non-ephemeral
+	// start and must be rejected.
+	_, session2, _, _ := newTurnSession(t, noopTestEngine(), turnHostFactory)
+	turn, err := session2.StartWithOptions(
+		context.Background(),
+		agent.Request{Message: message.NewTextMessage(message.RoleUser, "hi")},
+		WithEphemeral(),
+	)
+	if err != nil {
+		t.Fatalf("ephemeral start: %v", err)
+	}
+	if _, err := turn.Wait(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := session2.Start(
+		context.Background(),
+		agent.Request{Message: message.NewTextMessage(message.RoleUser, "again")},
+	); !errdefs.IsValidation(err) {
+		t.Fatalf("mixing Start error = %v, want validation", err)
+	}
+}
+
+func TestEphemeralSessionWritesNoState(t *testing.T) {
+	store := &sessionRecordingStore{}
+	engine := agent.EngineFunc(func(
+		_ context.Context,
+		_ agent.Run,
+		host agent.Host,
+		board *agent.Board,
+	) (*agent.Board, error) {
+		// The engine checkpoints mid-run; the ephemeral host must swallow it.
+		if checkpointer, ok := host.(agent.Checkpointer); ok {
+			ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+			defer cancel()
+			_ = checkpointer.Checkpoint(ctx, agent.Checkpoint{
+				ExecID: "run-checkpoint",
+			})
+		}
+		board.AppendChannelMessage(agent.MainChannel,
+			message.NewTextMessage(message.RoleAssistant, "done"))
+		return board, nil
+	})
+	_, session, _, _ := newTurnSession(t, engine, turnHostFactory,
+		WithResume(true), WithCheckpointStore(store))
+	turn, err := session.StartWithOptions(
+		context.Background(),
+		agent.Request{Message: message.NewTextMessage(message.RoleUser, "hi")},
+		WithEphemeral(),
+	)
+	if err != nil {
+		t.Fatalf("StartWithOptions: %v", err)
+	}
+	if _, err := turn.Wait(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if !store.isEmpty() {
+		t.Fatalf("ephemeral session wrote %d checkpoints, want none", store.count())
+	}
+	if _, ok, _ := session.Resumable(context.Background()); ok {
+		t.Fatal("ephemeral session reports resumable state")
+	}
+	if _, err := session.Resume(context.Background()); !errdefs.IsNotFound(err) {
+		t.Fatalf("Resume on ephemeral session error = %v, want not found", err)
+	}
+}
+
+func TestEphemeralCanceledTurnNeverParks(t *testing.T) {
+	store := &sessionRecordingStore{}
+	blocking := make(chan struct{})
+	engine := agent.EngineFunc(func(ctx context.Context, _ agent.Run, _ agent.Host, board *agent.Board) (*agent.Board, error) {
+		select {
+		case <-blocking:
+		case <-ctx.Done():
+			return board, ctx.Err()
+		}
+		return board, nil
+	})
+	_, session, _, _ := newTurnSession(t, engine, turnHostFactory,
+		WithResume(true), WithCheckpointStore(store))
+	ctx, cancel := context.WithCancel(context.Background())
+	turn, err := session.StartWithOptions(ctx,
+		agent.Request{Message: message.NewTextMessage(message.RoleUser, "hi")},
+		WithEphemeral(),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cancel()
+	if _, err := turn.Wait(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if !store.isEmpty() {
+		t.Fatalf("canceled ephemeral turn wrote %d checkpoints, want none", store.count())
+	}
+	if _, ok, _ := session.Resumable(context.Background()); ok {
+		t.Fatal("canceled ephemeral turn left a parked run")
+	}
+}
+
+func TestEphemeralSessionSkipsHistorySeeding(t *testing.T) {
+	store := &sessionRecordingStore{}
+	var sawHistory bool
+	engine := agent.EngineFunc(func(
+		_ context.Context,
+		_ agent.Run,
+		_ agent.Host,
+		board *agent.Board,
+	) (*agent.Board, error) {
+		for _, msg := range board.Channel(agent.MainChannel) {
+			if msg.Content.Text() == "old history" {
+				sawHistory = true
+				break
+			}
+		}
+		return board, nil
+	})
+	_, session, _, _ := newTurnSession(t, engine, turnHostFactory,
+		WithResume(true), WithCheckpointStore(store))
+	// Pre-seed a durable record under the session key; an ephemeral Start
+	// must ignore it entirely.
+	board := agent.NewBoard()
+	board.AppendChannelMessage(agent.MainChannel,
+		message.NewTextMessage(message.RoleUser, "old history"))
+	state := sessionState{Board: board.Snapshot()}
+	session.saveSessionState(&state, store, true)
+
+	turn, err := session.StartWithOptions(
+		context.Background(),
+		agent.Request{Message: message.NewTextMessage(message.RoleUser, "hi")},
+		WithEphemeral(),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := turn.Wait(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if sawHistory {
+		t.Fatal("ephemeral session seeded history from persisted state")
+	}
+}
+
+func TestResumeWithOptionsRejectsEphemeral(t *testing.T) {
+	store := &sessionRecordingStore{}
+	engine := agent.EngineFunc(func(
+		_ context.Context,
+		_ agent.Run,
+		_ agent.Host,
+		board *agent.Board,
+	) (*agent.Board, error) {
+		return board, nil
+	})
+	_, session, _, _ := newTurnSession(t, engine, turnHostFactory,
+		WithResume(true), WithCheckpointStore(store))
+	if _, err := session.ResumeWithOptions(
+		context.Background(),
+		WithEphemeral(),
+	); !errdefs.IsValidation(err) {
+		t.Fatalf("ResumeWithOptions(WithEphemeral) error = %v, want validation", err)
+	}
+}
+
+func TestWithAskUserOverride(t *testing.T) {
+	engine := agent.EngineFunc(func(
+		_ context.Context,
+		_ agent.Run,
+		host agent.Host,
+		board *agent.Board,
+	) (*agent.Board, error) {
+		reply, err := host.AskUser(context.Background(), agent.UserPrompt{Source: "override"})
+		if err != nil {
+			return board, err
+		}
+		if len(reply.Parts) != 1 {
+			return board, errdefs.Internalf("unexpected reply parts: %d", len(reply.Parts))
+		}
+		text, ok := reply.Parts[0].(message.TextPart)
+		if !ok {
+			return board, errdefs.Internalf("reply part is %T, want TextPart", reply.Parts[0])
+		}
+		board.AppendChannelMessage(agent.MainChannel,
+			message.NewTextMessage(message.RoleAssistant, text.Text))
+		return board, nil
+	})
+	_, session, _, _ := newTurnSession(t, engine, turnHostFactory)
+	turn, err := session.StartWithOptions(
+		context.Background(),
+		agent.Request{Message: message.NewTextMessage(message.RoleUser, "hi")},
+		WithAskUserOverride(func(context.Context, agent.UserPrompt) (agent.UserReply, error) {
+			return agent.UserReply{Parts: []message.Part{
+				message.TextPart{Text: "override-reply"},
+			}}, nil
+		}),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	result, err := turn.Wait(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Status != agent.StatusCompleted || result.Text() != "override-reply" {
+		t.Fatalf("result = %q %q", result.Status, result.Text())
+	}
+}
+
+func noopTestEngine() agent.Engine {
+	return agent.EngineFunc(func(
+		_ context.Context,
+		_ agent.Run,
+		_ agent.Host,
+		board *agent.Board,
+	) (*agent.Board, error) {
+		return board, nil
+	})
+}
+
+type discardSink struct{}
+
+func (discardSink) OnDelta(
+	context.Context,
+	event.Envelope,
+	agent.StreamDeltaPayload,
+) error {
+	return nil
+}

--- a/core/runtime/session/turn.go
+++ b/core/runtime/session/turn.go
@@ -52,6 +52,7 @@ type Turn struct {
 	err               error
 	interrupt         *agent.Interrupt
 	host              agent.Host
+	askUserOverride   AskUserFunc
 	prompts           map[string]*promptEntry
 	attachments       []*queuedSink
 	coordinator       *streamCoordinator

--- a/core/telemetry/attrs.go
+++ b/core/telemetry/attrs.go
@@ -158,6 +158,26 @@ const (
 	// dimension.
 	AttrConversationID = "conversation.id"
 
+	// ----- Delegation -----
+
+	// AttrDelegationTarget is the delegation target id as requested by
+	// the caller (delegation.Request.Target). It can differ from
+	// AttrAgentID when the directory normalizes the target to a
+	// different canonical agent id.
+	AttrDelegationTarget = "delegation.target"
+
+	// AttrDelegationMode is the requested execution mode
+	// (delegation.ModeSync or delegation.ModeAsync).
+	AttrDelegationMode = "delegation.mode"
+
+	// AttrDelegationDepth is the delegation nesting depth: 1 for a
+	// top-level delegation, incremented per subagent hop.
+	AttrDelegationDepth = "delegation.depth"
+
+	// AttrDelegationCaller identifies the delegating agent's id;
+	// empty for top-level delegations.
+	AttrDelegationCaller = "delegation.caller"
+
 	// ----- Errors -----
 
 	// AttrErrorMessage carries the human-readable error string on

--- a/core/telemetry/attrs_test.go
+++ b/core/telemetry/attrs_test.go
@@ -32,6 +32,10 @@ func TestAttrConstants_StableNames(t *testing.T) {
 		{AttrLLMRequestID, "llm.request.id"},
 		{AttrLLMResponseID, "llm.response.id"},
 		{AttrConversationID, "conversation.id"},
+		{AttrDelegationTarget, "delegation.target"},
+		{AttrDelegationMode, "delegation.mode"},
+		{AttrDelegationDepth, "delegation.depth"},
+		{AttrDelegationCaller, "delegation.caller"},
 		{AttrErrorMessage, "error.message"},
 	}
 	for _, tc := range cases {
@@ -54,6 +58,8 @@ func TestAttrConstants_Unique(t *testing.T) {
 		AttrLLMTotalTokens, AttrLLMCachedInputTokens, AttrLLMCostMicros, AttrLLMLatencyMs,
 		AttrLLMRequestID, AttrLLMResponseID,
 		AttrConversationID, AttrErrorMessage,
+		AttrDelegationTarget, AttrDelegationMode,
+		AttrDelegationDepth, AttrDelegationCaller,
 	}
 	seen := make(map[string]struct{}, len(all))
 	for _, k := range all {


### PR DESCRIPTION
## Summary

Upgrades delegated subagent execution from the legacy bare-run path to the runtime session lifecycle, and turns the delegation directory into a per-generation deployment resource.

### What changed

- **Delegation directory as a deploy resource**: new `delegation.Directory` and `delegation.SessionProvider` resource factories; the service and delegation tool source now resolve the directory from DAG dependencies, so every deployment generation gets its own bound directory and reloads always delegate against the current generation's agents.
- **`BindDeployment` moved** from `LocalService` to `LocalDirectory` (the deploy wire phase binds the directory).
- **Session manager binding**: new `session.ManagerBinder`; the runtime binds its single session manager to the delegation service at Build and Reload (set-once per generation, before the swap so failures abort cleanly).
- **Session-path delegation** (`runAt` with a bound manager): minted ContextID per delegation (or provider-supplied), ask-user refused for subagents, ephemeral sessions for non-persistent identities (no session-state/run-checkpoint writes, no resume), timeout and caller/depth metadata crossing the session boundary. The legacy path (no manager) is unchanged.
- **New session options**: `StartWithOptions` / `ResumeWithOptions` (`WithSinks`, `WithAskUserOverride`, `WithEphemeral`); the ephemeral property is fixed by the first start and mixing is rejected.
- **Error handling fix**: `waitTurnCancelOnDone` no longer relabels genuine terminal infrastructure errors as canceled-turn waits.

### Verification

- `make ci` passes for core (azure test lane fails only due to unrelated unstaged WIP, verified green at HEAD)
- `make lint` — 0 issues
- `make release-check` — changesets valid, no pending releases
- `git diff --check` clean; tests (incl. `-race`) green for `core/delegation/...` and `core/runtime/...`