### PR TITLE
feat(driver/azure): support image-to-image edits and mask inpainting

### DIFF
--- a/driver/azure/conformance_test.go
+++ b/driver/azure/conformance_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/GizClaw/flowcraft/core/inference"
 	"github.com/GizClaw/flowcraft/core/inference/inferencetest"
 	"github.com/GizClaw/flowcraft/core/message"
+	"github.com/GizClaw/flowcraft/core/message/media"
 )
 
 func conformanceTextRequest() inference.GenerateRequest {
@@ -180,5 +181,160 @@ func TestConformanceEmbedUnary(t *testing.T) {
 		},
 		Driver:         driver,
 		TransportCalls: calls.Load,
+	})
+}
+
+func TestConformanceImageCompiler(t *testing.T) {
+	imageRequest := func() inference.GenerateRequest {
+		return inference.GenerateRequest{
+			Input: inference.GenerateInput{
+				Role: inference.InputRoleUser,
+				Content: inference.InputContent{
+					Content: message.Content{Parts: []message.Part{
+						message.TextPart{Text: "draw a rocket"},
+					}},
+					Intent: inference.Intent{Image: &inference.ImageIntent{}},
+				},
+			},
+		}
+	}
+
+	inferencetest.RunGenerateCompiler(t, inferencetest.GenerateCompilerSuite[imageWire]{
+		Model:   conformanceModel("gpt-image-1"),
+		Shape:   inference.GenerateExecutionUnary,
+		Request: imageRequest,
+		Snapshot: func(request inference.GenerateRequest) any {
+			return request.Clone()
+		},
+		Compile: compileImage("gpt-image-1"),
+		AssertWire: func(t *testing.T, wire imageWire) {
+			if wire.model != "gpt-image-1" || wire.prompt != "draw a rocket" {
+				t.Fatalf("wire = %+v", wire)
+			}
+			if len(wire.images) != 0 || wire.mask.Kind() != "" {
+				t.Fatalf("wire reference images = %d, mask = %q",
+					len(wire.images), wire.mask.Kind())
+			}
+		},
+		Rejections: []inferencetest.CompilerRejection[inference.GenerateRequest]{
+			{
+				Name: "seed has no parameter",
+				Request: func() inference.GenerateRequest {
+					request := imageRequest()
+					seed := int64(7)
+					request.Input.Content.Intent.Image.Seed = &seed
+					return request
+				},
+				Field: inference.FieldGenerateIntentImageSeed,
+				Kind:  inference.UnsupportedFeature,
+			},
+			{
+				Name: "size outside the enum",
+				Request: func() inference.GenerateRequest {
+					request := imageRequest()
+					request.Input.Content.Intent.Image.Size = &media.ImageSize{
+						Width: 800, Height: 600,
+					}
+					return request
+				},
+				Field: inference.FieldGenerateIntentImageSize,
+				Kind:  inference.UnsupportedFeature,
+			},
+			{
+				Name: "URL delivery",
+				Request: func() inference.GenerateRequest {
+					request := imageRequest()
+					request.Input.Content.Intent.Image.Delivery = media.SourceURL
+					return request
+				},
+				Field: inference.FieldGenerateIntentImageDelivery,
+				Kind:  inference.UnsupportedFeature,
+			},
+			{
+				Name: "URL reference image has no upload channel",
+				Request: func() inference.GenerateRequest {
+					request := imageRequest()
+					source, err := media.NewImageURL(
+						"https://example.com/reference.png",
+						"image/png",
+					)
+					if err != nil {
+						t.Fatalf("NewImageURL: %v", err)
+					}
+					request.Input.Content.Parts = append(
+						request.Input.Content.Parts,
+						message.ImagePart{Source: source},
+					)
+					return request
+				},
+				Field: inference.FieldGenerateInputImage,
+				Kind:  inference.UnsupportedFeature,
+			},
+			{
+				Name: "text intent alongside image",
+				Request: func() inference.GenerateRequest {
+					request := imageRequest()
+					request.Input.Content.Intent.Text = &inference.TextIntent{}
+					return request
+				},
+				Field: inference.FieldGenerateIntentText,
+				Kind:  inference.UnsupportedFeature,
+			},
+			{
+				Name: "mask requires an inline reference image",
+				Request: func() inference.GenerateRequest {
+					request := imageRequest()
+					mask, err := media.NewImageBytes(testPNG, "image/png")
+					if err != nil {
+						t.Fatalf("NewImageBytes: %v", err)
+					}
+					request.Extensions = inference.Extensions{
+						ImageOptions{Mask: &mask},
+					}
+					return request
+				},
+				Field: inference.ExtensionField("mask").Qualify(ImageOptions{}),
+				Kind:  inference.InvalidExtension,
+			},
+			{
+				Name: "URL-sourced mask has no upload channel",
+				Request: func() inference.GenerateRequest {
+					request := imageRequest()
+					source, err := media.NewImageBytes(testPNG, "image/png")
+					if err != nil {
+						t.Fatalf("NewImageBytes: %v", err)
+					}
+					request.Input.Content.Parts = append(
+						request.Input.Content.Parts,
+						message.ImagePart{Source: source},
+					)
+					mask, err := media.NewImageURL(
+						"https://example.com/mask.png",
+						"image/png",
+					)
+					if err != nil {
+						t.Fatalf("NewImageURL: %v", err)
+					}
+					request.Extensions = inference.Extensions{
+						ImageOptions{Mask: &mask},
+					}
+					return request
+				},
+				Field: inference.ExtensionField("mask").Qualify(ImageOptions{}),
+				Kind:  inference.InvalidExtension,
+			},
+			{
+				Name: "generate extension does not apply to image generation",
+				Request: func() inference.GenerateRequest {
+					request := imageRequest()
+					request.Extensions = inference.Extensions{
+						GenerateOptions{WebSearch: &GenerateWebSearch{}},
+					}
+					return request
+				},
+				Field: inference.ExtensionField("web_search").Qualify(GenerateOptions{}),
+				Kind:  inference.InvalidExtension,
+			},
+		},
 	})
 }

--- a/driver/azure/doc.go
+++ b/driver/azure/doc.go
@@ -5,7 +5,9 @@
 //
 //   - Generate: Responses API over chat deployments, unary + SSE stream.
 //   - Embed: embeddings deployments.
-//   - Image: gpt-image generation deployments, unary only.
+//   - Image: gpt-image generation and image-to-image edits, unary only;
+//     inline reference images route to images/edits, and the image_options
+//     extension carries a mask for local inpainting.
 //   - Audio generation: speech deployments, unary + raw byte stream.
 //
 // Transcription is intentionally absent: core/inference does not expose the

--- a/driver/azure/extensions.go
+++ b/driver/azure/extensions.go
@@ -5,12 +5,16 @@ import (
 	"slices"
 
 	"github.com/GizClaw/flowcraft/core/inference"
+	"github.com/GizClaw/flowcraft/core/message/media"
 )
 
 // driverID namespaces every extension this package defines.
 const driverID = "azure"
 
-const extensionGenerate = "generate_options"
+const (
+	extensionGenerate = "generate_options"
+	extensionImage    = "image_options"
+)
 
 // extensionProvider resolves the deployment provider ID an extension targets,
 // defaulting to the driver name.
@@ -119,6 +123,53 @@ func (o GenerateOptions) Clone() inference.Extension {
 		search.ExternalWebAccess = clonePointer(search.ExternalWebAccess)
 		search.ToolChoice = clonePointer(search.ToolChoice)
 		o.WebSearch = &search
+	}
+	return o
+}
+
+// ---------------------------------------------------------------------------
+// Image (gpt-image edits).
+// ---------------------------------------------------------------------------
+
+// ImageOptions carries images API settings beyond the canonical image
+// intent.
+type ImageOptions struct {
+	// Provider targets a deployment provider ID other than "azure".
+	Provider string `json:"-"`
+	// Mask is an inline PNG whose fully transparent areas (alpha zero)
+	// mark where the first reference image should be edited (local
+	// inpainting). The endpoint requires a valid PNG with the same
+	// dimensions as the reference image and applies the mask to the first
+	// reference image only; the mask itself must be inline bytes because
+	// images/edits uploads multipart files.
+	Mask *media.ImageSource `json:"mask,omitempty"`
+}
+
+func (o ImageOptions) ProviderID() string  { return extensionProvider(o.Provider) }
+func (o ImageOptions) ExtensionID() string { return extensionImage }
+
+func (o ImageOptions) ActiveFields() []inference.ExtensionField {
+	var fields []inference.ExtensionField
+	if o.Mask != nil {
+		fields = append(fields, "mask")
+	}
+	return fields
+}
+
+func (o ImageOptions) Validate() error {
+	if o.Mask == nil {
+		return nil
+	}
+	if base := o.Mask.BaseMediaType(); base != "image/png" {
+		return fmt.Errorf("mask must be a PNG image, not %q", base)
+	}
+	return nil
+}
+
+func (o ImageOptions) Clone() inference.Extension {
+	if o.Mask != nil {
+		mask := o.Mask.Clone()
+		o.Mask = &mask
 	}
 	return o
 }

--- a/driver/azure/extensions_test.go
+++ b/driver/azure/extensions_test.go
@@ -1,0 +1,62 @@
+package azure
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/GizClaw/flowcraft/core/message/media"
+)
+
+func TestImageOptionsActiveFields(t *testing.T) {
+	if fields := (ImageOptions{}).ActiveFields(); len(fields) != 0 {
+		t.Fatalf("empty ImageOptions ActiveFields = %#v, want none", fields)
+	}
+	mask, err := media.NewImageBytes(testPNG, "image/png")
+	if err != nil {
+		t.Fatalf("NewImageBytes: %v", err)
+	}
+	fields := (ImageOptions{Mask: &mask}).ActiveFields()
+	if len(fields) != 1 || string(fields[0]) != "mask" {
+		t.Fatalf("ActiveFields = %#v, want [mask]", fields)
+	}
+}
+
+func TestImageOptionsValidateMask(t *testing.T) {
+	if err := (ImageOptions{}).Validate(); err != nil {
+		t.Fatalf("empty Validate() = %v, want nil", err)
+	}
+	png, err := media.NewImageBytes(testPNG, "image/png")
+	if err != nil {
+		t.Fatalf("NewImageBytes: %v", err)
+	}
+	if err := (ImageOptions{Mask: &png}).Validate(); err != nil {
+		t.Fatalf("PNG mask Validate() = %v, want nil", err)
+	}
+	jpeg, err := media.NewImageBytes(testPNG, "image/jpeg")
+	if err != nil {
+		t.Fatalf("NewImageBytes: %v", err)
+	}
+	err = (ImageOptions{Mask: &jpeg}).Validate()
+	if err == nil || !strings.Contains(err.Error(), "PNG") {
+		t.Fatalf("JPEG mask Validate() = %v, want PNG constraint", err)
+	}
+}
+
+func TestImageOptionsCloneDeepCopiesMask(t *testing.T) {
+	mask, err := media.NewImageBytes(testPNG, "image/png")
+	if err != nil {
+		t.Fatalf("NewImageBytes: %v", err)
+	}
+	options := ImageOptions{Mask: &mask}
+	cloned, ok := options.Clone().(ImageOptions)
+	if !ok {
+		t.Fatalf("Clone() type = %T, want ImageOptions", options.Clone())
+	}
+	if cloned.Mask == nil || cloned.Mask == options.Mask {
+		t.Fatal("Clone() must deep-copy the mask source")
+	}
+	if !bytes.Equal(cloned.Mask.Bytes(), options.Mask.Bytes()) {
+		t.Fatal("Clone() lost the mask bytes")
+	}
+}

--- a/driver/azure/image.go
+++ b/driver/azure/image.go
@@ -1,9 +1,11 @@
 package azure
 
 import (
+	"bytes"
 	"context"
 	"encoding/base64"
 	"fmt"
+	"io"
 	"strings"
 
 	"github.com/GizClaw/flowcraft/core/inference"
@@ -14,10 +16,14 @@ import (
 	"github.com/openai/openai-go/v3/packages/param"
 )
 
-// Image generation runs on the images endpoint (gpt-image). The prompt is
-// the request's text; the endpoint takes no reference images on this
-// driver — image-to-image edits live on a separate API shape and are
-// rejected truthfully. gpt-image always returns base64 payloads, so URL
+// Image generation runs on the images endpoint (gpt-image). Text-only
+// requests go to images/generations; requests that carry inline reference
+// images go to images/edits, which uploads the bytes as multipart files
+// (the Azure image editing surface). A mask for local inpainting rides the
+// image_options extension and uploads alongside the reference images; the
+// endpoint applies the mask to the first reference image only. URL-sourced
+// reference images and masks have no upload channel — callers must
+// materialize them inline. gpt-image always returns base64 payloads, so URL
 // delivery has no native channel and is rejected.
 
 type imageWire struct {
@@ -26,6 +32,12 @@ type imageWire struct {
 	size   string // 1024x1024 | 1536x1024 | 1024x1536
 	count  int
 	format string // png | jpeg | webp
+	// images are inline reference images for image-to-image edits; empty
+	// means a text-only generation.
+	images []media.ImageSource
+	// mask is an inline PNG whose transparent areas mark where the first
+	// reference image should be edited; zero when absent.
+	mask media.ImageSource
 }
 
 type imageRaw struct {
@@ -73,10 +85,14 @@ func compileImage(
 				case message.TextPart:
 					prompt = append(prompt, value.Text)
 				case message.ImagePart:
-					ledger.reject(
-						fields[message.PartImage],
-						"image edits have no channel on this driver; text prompts only",
-					)
+					if value.Source.Kind() != media.SourceInline {
+						ledger.reject(
+							fields[message.PartImage],
+							"images/edits uploads inline bytes; URL-sourced reference images have no channel",
+						)
+						continue
+					}
+					wire.images = append(wire.images, value.Source)
 				default:
 					ledger.reject(
 						fields[part.Kind()],
@@ -155,9 +171,9 @@ func compileImage(
 				)
 			}
 		}
-		for _, field := range request.Extensions.ActiveFields() {
-			ledger.reject(field, "openai image generation supports no extensions")
-		}
+		options, other := operationExtensions[ImageOptions](request.Extensions)
+		rejectOtherExtensions("image generation", other, ledger)
+		compileImageOptions(&wire, options, ledger)
 		if intent.Audio != nil {
 			ledger.reject(
 				inference.FieldGenerateIntentAudio,
@@ -178,22 +194,76 @@ func compileImage(
 	}
 }
 
+// compileImageOptions lowers ImageOptions onto the wire. Settings that
+// collide with the request are rejected instead of overriding: the canonical
+// channel stays the single source of truth for what it covers.
+func compileImageOptions(
+	wire *imageWire,
+	options ImageOptions,
+	ledger *ledger,
+) {
+	if options.Mask == nil {
+		return
+	}
+	field := inference.ExtensionField("mask").Qualify(options)
+	if options.Mask.Kind() != media.SourceInline {
+		ledger.reject(
+			field,
+			"images/edits uploads inline bytes; URL-sourced masks have no channel",
+		)
+		return
+	}
+	if len(wire.images) == 0 {
+		ledger.reject(
+			field,
+			"mask requires at least one inline reference image",
+		)
+		return
+	}
+	wire.mask = options.Mask.Clone()
+}
+
 func transportImage(
 	client openai.Client,
 ) inference.Transport[imageWire, imageRaw] {
 	return func(ctx context.Context, wire imageWire) (imageRaw, error) {
-		params := openai.ImageGenerateParams{
-			Model:  wire.model,
-			Prompt: wire.prompt,
-			N:      param.NewOpt(int64(wire.count)),
+		var response *openai.ImagesResponse
+		var err error
+		if len(wire.images) == 0 {
+			params := openai.ImageGenerateParams{
+				Model:  wire.model,
+				Prompt: wire.prompt,
+				N:      param.NewOpt(int64(wire.count)),
+			}
+			if wire.size != "" {
+				params.Size = openai.ImageGenerateParamsSize(wire.size)
+			}
+			if wire.format != "" {
+				params.OutputFormat = openai.ImageGenerateParamsOutputFormat(wire.format)
+			}
+			response, err = client.Images.Generate(ctx, params)
+		} else {
+			readers := make([]io.Reader, 0, len(wire.images))
+			for _, source := range wire.images {
+				readers = append(readers, bytes.NewReader(source.Bytes()))
+			}
+			params := openai.ImageEditParams{
+				Model:  openai.ImageModel(wire.model),
+				Prompt: wire.prompt,
+				N:      param.NewOpt(int64(wire.count)),
+				Image:  openai.ImageEditParamsImageUnion{OfFileArray: readers},
+			}
+			if wire.size != "" {
+				params.Size = openai.ImageEditParamsSize(wire.size)
+			}
+			if wire.format != "" {
+				params.OutputFormat = openai.ImageEditParamsOutputFormat(wire.format)
+			}
+			if wire.mask.Kind() != "" {
+				params.Mask = bytes.NewReader(wire.mask.Bytes())
+			}
+			response, err = client.Images.Edit(ctx, params)
 		}
-		if wire.size != "" {
-			params.Size = openai.ImageGenerateParamsSize(wire.size)
-		}
-		if wire.format != "" {
-			params.OutputFormat = openai.ImageGenerateParamsOutputFormat(wire.format)
-		}
-		response, err := client.Images.Generate(ctx, params)
 		if err != nil {
 			return imageRaw{}, classifyError(err)
 		}

--- a/driver/azure/image_test.go
+++ b/driver/azure/image_test.go
@@ -1,0 +1,363 @@
+package azure
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+	"mime/multipart"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/GizClaw/flowcraft/core/inference"
+	"github.com/GizClaw/flowcraft/core/message"
+	"github.com/GizClaw/flowcraft/core/message/media"
+)
+
+// ---------------------------------------------------------------------------
+// Shared fixtures.
+// ---------------------------------------------------------------------------
+
+// capturedAzure serves the API surface used by the driver and records every
+// request body for assertion.
+type capturedAzure struct {
+	t *testing.T
+
+	bodies  []map[string]any
+	handler func(w http.ResponseWriter, r *http.Request, body map[string]any)
+}
+
+func newCapturedAzure(
+	t *testing.T,
+	handler func(w http.ResponseWriter, r *http.Request, body map[string]any),
+) (*httptest.Server, *capturedAzure) {
+	capture := &capturedAzure{t: t, handler: handler}
+	server := httptest.NewServer(http.HandlerFunc(func(
+		w http.ResponseWriter,
+		r *http.Request,
+	) {
+		payload, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Errorf("read body: %v", err)
+			return
+		}
+		// Restore the body so handlers can re-read multipart forms.
+		r.Body = io.NopCloser(bytes.NewReader(payload))
+		var body map[string]any
+		if len(payload) > 0 &&
+			strings.HasPrefix(r.Header.Get("Content-Type"), "application/json") {
+			if err := json.Unmarshal(payload, &body); err != nil {
+				t.Errorf("body is not JSON: %v", err)
+				return
+			}
+		}
+		capture.bodies = append(capture.bodies, body)
+		handler(w, r, body)
+	}))
+	return server, capture
+}
+
+func (c *capturedAzure) body(index int) map[string]any {
+	c.t.Helper()
+	if index >= len(c.bodies) {
+		c.t.Fatalf("only %d captured requests", len(c.bodies))
+	}
+	return c.bodies[index]
+}
+
+func azureImageClients(t *testing.T, server *httptest.Server) *clients {
+	t.Helper()
+	spec, err := decodeSpec([]byte(
+		fmt.Sprintf(`{
+			"endpoint": %q,
+			"models": [{"name": "gpt-image-1", "kind": "image",
+				"capabilities": {"outputs": ["image"]}}]
+		}`, server.URL),
+	))
+	if err != nil {
+		t.Fatalf("decodeSpec: %v", err)
+	}
+	return profileMaterial{apiKey: "test-key"}.newClients(spec)
+}
+
+func azureImageModel(name string) inference.ModelRef {
+	return inference.ModelRef{
+		ID:      inference.ModelID{Provider: driverID, Name: name},
+		Profile: "default",
+	}
+}
+
+// testPNG is a 1x1 transparent PNG used as reference image and mask.
+var testPNG = func() []byte {
+	data, err := base64.StdEncoding.DecodeString(
+		"iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNkYPhfDwAChwGA60e6kgAAAABJRU5ErkJggg==",
+	)
+	if err != nil {
+		panic(err)
+	}
+	return data
+}()
+
+func imageResponse(w http.ResponseWriter, inputTokens int64) {
+	w.Header().Set("Content-Type", "application/json")
+	payload, _ := json.Marshal(map[string]any{
+		"data":  []map[string]any{{"b64_json": base64.StdEncoding.EncodeToString(testPNG)}},
+		"usage": map[string]any{"input_tokens": inputTokens, "output_tokens": 0},
+	})
+	_, _ = fmt.Fprint(w, string(payload))
+}
+
+// ---------------------------------------------------------------------------
+// Transport.
+// ---------------------------------------------------------------------------
+
+func TestImageTransport(t *testing.T) {
+	server, capture := newCapturedAzure(t, func(
+		w http.ResponseWriter,
+		_ *http.Request,
+		body map[string]any,
+	) {
+		if size, _ := body["size"].(string); size != "1536x1024" {
+			t.Errorf("size = %v", body["size"])
+		}
+		if fmt.Sprint(body["output_format"]) != "png" {
+			t.Errorf("output_format = %v", body["output_format"])
+		}
+		imageResponse(w, 11)
+	})
+	defer server.Close()
+	cls := azureImageClients(t, server)
+
+	request := inference.GenerateRequest{
+		Input: inference.GenerateInput{
+			Role: inference.InputRoleUser,
+			Content: inference.InputContent{
+				Content: message.Content{Parts: []message.Part{
+					message.TextPart{Text: "a red circle"},
+				}},
+				Intent: inference.Intent{Image: &inference.ImageIntent{
+					Size:         &media.ImageSize{Width: 1536, Height: 1024},
+					OutputFormat: media.ImageFormatPNG,
+				}},
+			},
+		},
+	}
+	compiled, err := compileImage("gpt-image-1")(
+		context.Background(),
+		azureImageModel("gpt-image-1"),
+		request,
+		inference.GenerateExecutionUnary,
+	)
+	if err != nil {
+		t.Fatalf("compileImage: %v", err)
+	}
+	raw, err := transportImage(cls.api)(context.Background(), compiled.Wire)
+	if err != nil {
+		t.Fatalf("transportImage: %v", err)
+	}
+	response, err := decodeImage(context.Background(), raw)
+	if err != nil {
+		t.Fatalf("decodeImage: %v", err)
+	}
+	if len(response.Message.Content.Parts) != 1 {
+		t.Fatalf("parts = %d", len(response.Message.Content.Parts))
+	}
+	part, ok := response.Message.Content.Parts[0].(message.ImagePart)
+	if !ok {
+		t.Fatalf("part = %#v", response.Message.Content.Parts[0])
+	}
+	if part.Source.Kind() != media.SourceInline ||
+		!bytes.Equal(part.Source.Bytes(), testPNG) {
+		t.Fatalf("image source bytes mismatch")
+	}
+	_ = capture.body(0)
+}
+
+func TestImageEditTransport(t *testing.T) {
+	source, err := media.NewImageBytes(testPNG, "image/png")
+	if err != nil {
+		t.Fatalf("NewImageBytes: %v", err)
+	}
+	server, capture := newCapturedAzure(t, func(
+		w http.ResponseWriter,
+		r *http.Request,
+		_ map[string]any,
+	) {
+		if r.URL.Path != "/openai/deployments/gpt-image-1/images/edits" {
+			t.Errorf("path = %s, want /openai/deployments/gpt-image-1/images/edits",
+				r.URL.Path)
+		}
+		if err := r.ParseMultipartForm(1 << 20); err != nil {
+			t.Errorf("parse multipart: %v", err)
+			return
+		}
+		files := r.MultipartForm.File["image[]"]
+		if len(files) != 1 {
+			t.Errorf("image files = %d, want 1", len(files))
+			return
+		}
+		file, err := files[0].Open()
+		if err != nil {
+			t.Errorf("open image file: %v", err)
+			return
+		}
+		defer func() { _ = file.Close() }()
+		data, err := io.ReadAll(file)
+		if err != nil {
+			t.Errorf("read image file: %v", err)
+			return
+		}
+		if !bytes.Equal(data, testPNG) {
+			t.Errorf("uploaded image bytes = %d, want %d", len(data), len(testPNG))
+		}
+		if prompt := r.MultipartForm.Value["prompt"]; len(prompt) != 1 ||
+			prompt[0] != "make it a red circle" {
+			t.Errorf("prompt = %v", r.MultipartForm.Value["prompt"])
+		}
+		imageResponse(w, 12)
+	})
+	defer server.Close()
+	cls := azureImageClients(t, server)
+
+	request := inference.GenerateRequest{
+		Input: inference.GenerateInput{
+			Role: inference.InputRoleUser,
+			Content: inference.InputContent{
+				Content: message.Content{Parts: []message.Part{
+					message.TextPart{Text: "make it a red circle"},
+					message.ImagePart{Source: source},
+				}},
+				Intent: inference.Intent{Image: &inference.ImageIntent{}},
+			},
+		},
+	}
+	compiled, err := compileImage("gpt-image-1")(
+		context.Background(),
+		azureImageModel("gpt-image-1"),
+		request,
+		inference.GenerateExecutionUnary,
+	)
+	if err != nil {
+		t.Fatalf("compileImage: %v", err)
+	}
+	if len(compiled.Wire.images) != 1 {
+		t.Fatalf("wire images = %d, want 1", len(compiled.Wire.images))
+	}
+	raw, err := transportImage(cls.api)(context.Background(), compiled.Wire)
+	if err != nil {
+		t.Fatalf("transportImage: %v", err)
+	}
+	if _, err := decodeImage(context.Background(), raw); err != nil {
+		t.Fatalf("decodeImage: %v", err)
+	}
+	_ = capture.body(0)
+}
+
+func TestImageEditTransportMask(t *testing.T) {
+	source, err := media.NewImageBytes(testPNG, "image/png")
+	if err != nil {
+		t.Fatalf("NewImageBytes: %v", err)
+	}
+	mask, err := media.NewImageBytes(testPNG, "image/png")
+	if err != nil {
+		t.Fatalf("NewImageBytes: %v", err)
+	}
+	server, capture := newCapturedAzure(t, func(
+		w http.ResponseWriter,
+		r *http.Request,
+		_ map[string]any,
+	) {
+		if r.URL.Path != "/openai/deployments/gpt-image-1/images/edits" {
+			t.Errorf("path = %s, want /openai/deployments/gpt-image-1/images/edits",
+				r.URL.Path)
+		}
+		if err := r.ParseMultipartForm(1 << 20); err != nil {
+			t.Errorf("parse multipart: %v", err)
+			return
+		}
+		files := r.MultipartForm.File["image[]"]
+		if len(files) != 1 {
+			t.Errorf("image files = %d, want 1", len(files))
+			return
+		}
+		masks := r.MultipartForm.File["mask"]
+		if len(masks) != 1 {
+			t.Errorf("mask files = %d, want 1", len(masks))
+			return
+		}
+		readPart := func(header *multipart.FileHeader) []byte {
+			t.Helper()
+			file, err := header.Open()
+			if err != nil {
+				t.Errorf("open file: %v", err)
+				return nil
+			}
+			defer func() { _ = file.Close() }()
+			data, err := io.ReadAll(file)
+			if err != nil {
+				t.Errorf("read file: %v", err)
+				return nil
+			}
+			return data
+		}
+		if data := readPart(files[0]); !bytes.Equal(data, testPNG) {
+			t.Errorf("uploaded image bytes = %d, want %d", len(data), len(testPNG))
+		}
+		if data := readPart(masks[0]); !bytes.Equal(data, testPNG) {
+			t.Errorf("uploaded mask bytes = %d, want %d", len(data), len(testPNG))
+		}
+		if size := r.MultipartForm.Value["size"]; len(size) != 1 ||
+			size[0] != "1024x1024" {
+			t.Errorf("size = %v", r.MultipartForm.Value["size"])
+		}
+		imageResponse(w, 13)
+	})
+	defer server.Close()
+	cls := azureImageClients(t, server)
+
+	request := inference.GenerateRequest{
+		Input: inference.GenerateInput{
+			Role: inference.InputRoleUser,
+			Content: inference.InputContent{
+				Content: message.Content{Parts: []message.Part{
+					message.TextPart{Text: "replace the sky"},
+					message.ImagePart{Source: source},
+				}},
+				Intent: inference.Intent{Image: &inference.ImageIntent{
+					Size: &media.ImageSize{Width: 1024, Height: 1024},
+				}},
+			},
+		},
+		Extensions: inference.Extensions{
+			ImageOptions{Mask: &mask},
+		},
+	}
+	compiled, err := compileImage("gpt-image-1")(
+		context.Background(),
+		azureImageModel("gpt-image-1"),
+		request,
+		inference.GenerateExecutionUnary,
+	)
+	if err != nil {
+		t.Fatalf("compileImage: %v", err)
+	}
+	if len(compiled.Wire.images) != 1 {
+		t.Fatalf("wire images = %d, want 1", len(compiled.Wire.images))
+	}
+	if compiled.Wire.mask.Kind() != media.SourceInline ||
+		!bytes.Equal(compiled.Wire.mask.Bytes(), testPNG) {
+		t.Fatalf("wire mask = %+v", compiled.Wire.mask)
+	}
+	raw, err := transportImage(cls.api)(context.Background(), compiled.Wire)
+	if err != nil {
+		t.Fatalf("transportImage: %v", err)
+	}
+	if _, err := decodeImage(context.Background(), raw); err != nil {
+		t.Fatalf("decodeImage: %v", err)
+	}
+	_ = capture.body(0)
+}

--- a/driver/azure/resource.go
+++ b/driver/azure/resource.go
@@ -76,6 +76,9 @@ func buildProvider(settings ResourceSettings) (inference.ProviderDefinition, err
 			extensionGenerate: inference.ExtensionDecoderFor(func() *GenerateOptions {
 				return &GenerateOptions{Provider: settings.ID}
 			}),
+			extensionImage: inference.ExtensionDecoderFor(func() *ImageOptions {
+				return &ImageOptions{Provider: settings.ID}
+			}),
 		},
 	}
 	for _, profile := range settings.Profiles {

--- a/driver/azure/resource_test.go
+++ b/driver/azure/resource_test.go
@@ -1,6 +1,7 @@
 package azure
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"reflect"
@@ -9,6 +10,7 @@ import (
 
 	"github.com/GizClaw/flowcraft/core/inference"
 	"github.com/GizClaw/flowcraft/core/message"
+	"github.com/GizClaw/flowcraft/core/message/media"
 	"github.com/GizClaw/flowcraft/core/resource"
 )
 
@@ -134,6 +136,78 @@ func TestProviderCarriesGenerateOptionsDecoder(t *testing.T) {
 		t.Fatalf("DecodeExtensions: %v", err)
 	}
 	if options := extensions[0].(*GenerateOptions); options.ProviderID() != "az-prod" {
+		t.Fatalf("ProviderID = %q, want %q", options.ProviderID(), "az-prod")
+	}
+}
+
+func TestProviderCarriesImageOptionsDecoder(t *testing.T) {
+	value, err := Factory().New(context.Background(), resource.Input{
+		Settings: json.RawMessage(`{
+			"id": "azure",
+			"spec": {
+				"endpoint": "https://example.openai.azure.com",
+				"models": [{"name": "gpt-image-1", "kind": "image", "capabilities": {"outputs": ["image"]}}]
+			},
+			"profiles": [{"id": "default", "secrets": {"api_key": "sk-test"}}]
+		}`),
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	provider := value.(inference.ProviderDefinition)
+	decoder, ok := provider.ExtensionDecoders[extensionImage]
+	if !ok {
+		t.Fatalf("ExtensionDecoders = %#v, want %q", provider.ExtensionDecoders, extensionImage)
+	}
+
+	maskPNG := "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNkYPhfDwAChwGA60e6kgAAAABJRU5ErkJggg=="
+	extensions, err := inference.DecodeExtensions([]inference.ExtensionEntry{{
+		Provider: "azure",
+		ID:       extensionImage,
+		Fields: json.RawMessage(`{
+			"mask": {
+				"kind": "inline",
+				"data": "` + maskPNG + `",
+				"media_type": "image/png"
+			}
+		}`),
+	}}, map[string]inference.ExtensionDecoder{
+		"azure/" + extensionImage: decoder,
+	}, "extensions")
+	if err != nil {
+		t.Fatalf("DecodeExtensions: %v", err)
+	}
+	options := extensions[0].(*ImageOptions)
+	if options.ProviderID() != "azure" || options.Mask == nil ||
+		options.Mask.Kind() != media.SourceInline ||
+		!bytes.Equal(options.Mask.Bytes(), testPNG) {
+		t.Fatalf("decoded options = %#v", options)
+	}
+
+	value, err = Factory().New(context.Background(), resource.Input{
+		Settings: json.RawMessage(`{
+			"id": "az-prod",
+			"spec": {
+				"endpoint": "https://example.openai.azure.com",
+				"models": [{"name": "gpt-image-1", "kind": "image", "capabilities": {"outputs": ["image"]}}]
+			},
+			"profiles": [{"id": "default", "secrets": {"api_key": "sk-test"}}]
+		}`),
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	decoder = value.(inference.ProviderDefinition).ExtensionDecoders[extensionImage]
+	extensions, err = inference.DecodeExtensions([]inference.ExtensionEntry{{
+		Provider: "az-prod",
+		ID:       extensionImage,
+	}}, map[string]inference.ExtensionDecoder{
+		"az-prod/" + extensionImage: decoder,
+	}, "extensions")
+	if err != nil {
+		t.Fatalf("DecodeExtensions: %v", err)
+	}
+	if options := extensions[0].(*ImageOptions); options.ProviderID() != "az-prod" {
 		t.Fatalf("ProviderID = %q, want %q", options.ProviderID(), "az-prod")
 	}
 }


### PR DESCRIPTION
## Summary

- Image generation now routes to `images/edits` when the request carries inline reference images (image-to-image), ported from the openai driver; text-only requests keep going to `images/generations`.
- Adds the `azure/image_options` extension with a `mask` field (inline PNG) for local inpainting. Mask must be inline bytes, PNG media type, and requires at least one inline reference image; violations are rejected at compile time with field-qualified errors.
- Verified the Azure client rewrites `/images/edits` to `/openai/deployments/{deployment}/images/edits`.

## Gates

- `make ci`, `make lint`, `make release-check`, `git diff --check` all pass.
- driver/azure module tests (incl. `-race`) pass.

## Release

Driver modules do not use the release changeset workflow; after merge the tag will be created directly on the merge commit as `driver/azure/v0.1.7`.