### PR TITLE
chore(release): add core v0.1.23 changeset

### DIFF
--- a/.release/core-v0.1.23.json
+++ b/.release/core-v0.1.23.json
@@ -1,0 +1,9 @@
+{
+  "summary": "feat(core): wire delegation subagents through session lifecycle — the delegation service and tool source resolve a per-generation delegation.Directory dependency (new directory and session-provider resource factories), the directory binds the assembled deployment during the deploy wire phase, and the runtime hands its single session manager to the service via session.ManagerBinder (set-once, before the generation swap); delegated runs execute through the session lifecycle with a minted ContextID, refused ask-user, ephemeral sessions for non-persistent identities (no state, checkpoint, or resume), and caller/depth/timeout metadata crossing the session boundary, while the legacy bare-run path is preserved when no manager is bound; feat(core): emit delegation run telemetry and reuse resolved target — runAt logs the resolved subagent target through OpenTelemetry (agent.id, delegation.target/mode/depth/caller attributes) and passes the directory-resolved instance into the legacy path, removing a duplicate lookup",
+  "releases": [
+    {
+      "module": "core",
+      "bump": "patch"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Adds the pending release changeset for core v0.1.23 (patch bump).

The changeset covers the full accumulated core delta since `core/v0.1.22`:
- `feat(core): wire delegation subagents through session lifecycle` (#393)
- `feat(core): emit delegation run telemetry and reuse resolved target`

## Verification

- `make release-check` — changesets valid
- `make release-plan` — core 0.1.22 -> 0.1.23 (patch), tag `core/v0.1.23`
- No `core/go.mod` / `core/go.sum` delta since the previous tag, so no `release-preflight` tidy is needed