### PR TITLE
fix(driver/azure): allow gpt-image-2 arbitrary image sizes

### DIFF
--- a/driver/azure/conformance_test.go
+++ b/driver/azure/conformance_test.go
@@ -229,7 +229,7 @@ func TestConformanceImageCompiler(t *testing.T) {
 				Kind:  inference.UnsupportedFeature,
 			},
 			{
-				Name: "size outside the enum",
+				Name: "size outside the gpt-image-2 resolution rules",
 				Request: func() inference.GenerateRequest {
 					request := imageRequest()
 					request.Input.Content.Intent.Image.Size = &media.ImageSize{

--- a/driver/azure/image.go
+++ b/driver/azure/image.go
@@ -29,7 +29,7 @@ import (
 type imageWire struct {
 	model  string
 	prompt string
-	size   string // 1024x1024 | 1536x1024 | 1024x1536
+	size   string // WxH; gpt-image-2-family models accept arbitrary sizes
 	count  int
 	format string // png | jpeg | webp
 	// images are inline reference images for image-to-image edits; empty
@@ -50,11 +50,32 @@ type imageRaw struct {
 	totalTokens  int64
 }
 
-// imageSizes are the only dimensions the endpoint accepts.
-var imageSizes = map[string]struct{}{
-	"1024x1024": {},
-	"1536x1024": {},
-	"1024x1536": {},
+// imageSize validates one canonical size against the gpt-image-2-family
+// arbitrary resolution rules: both edges must be divisible by 16, the
+// aspect ratio must stay between 1:3 and 3:1, and the resolution must not
+// exceed the documented 3840x2160 maximum (long edge 3840, short edge
+// 2160). The standard 1024x1024, 1536x1024, and 1024x1536 sizes satisfy
+// the same rules. Resolutions above 2560x1440 are experimental but valid.
+// On success the returned size is the canonical WxH wire string; the reason
+// is non-empty when the size is rejected.
+func imageSize(width, height int) (size, reason string) {
+	if width <= 0 || height <= 0 {
+		return "", "image dimensions must be positive"
+	}
+	if width%16 != 0 || height%16 != 0 {
+		return "", "image width and height must both be divisible by 16"
+	}
+	max, min := width, height
+	if max < min {
+		max, min = min, max
+	}
+	if max > 3*min {
+		return "", "image aspect ratio must be between 1:3 and 3:1"
+	}
+	if max > 3840 || min > 2160 {
+		return "", "image resolution must not exceed 3840x2160"
+	}
+	return fmt.Sprintf("%dx%d", width, height), ""
 }
 
 func compileImage(
@@ -128,13 +149,12 @@ func compileImage(
 		}
 		if image := intent.Image; image != nil {
 			if image.Size != nil {
-				size := fmt.Sprintf("%dx%d", image.Size.Width, image.Size.Height)
-				if _, ok := imageSizes[size]; ok {
+				if size, reason := imageSize(image.Size.Width, image.Size.Height); reason == "" {
 					wire.size = size
 				} else {
 					ledger.reject(
 						inference.FieldGenerateIntentImageSize,
-						"the images API accepts 1024x1024, 1536x1024, or 1024x1536 only",
+						reason,
 					)
 				}
 			}

--- a/driver/azure/image_test.go
+++ b/driver/azure/image_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"mime/multipart"
@@ -121,7 +122,7 @@ func TestImageTransport(t *testing.T) {
 		_ *http.Request,
 		body map[string]any,
 	) {
-		if size, _ := body["size"].(string); size != "1536x1024" {
+		if size, _ := body["size"].(string); size != "1728x2304" {
 			t.Errorf("size = %v", body["size"])
 		}
 		if fmt.Sprint(body["output_format"]) != "png" {
@@ -140,7 +141,7 @@ func TestImageTransport(t *testing.T) {
 					message.TextPart{Text: "a red circle"},
 				}},
 				Intent: inference.Intent{Image: &inference.ImageIntent{
-					Size:         &media.ImageSize{Width: 1536, Height: 1024},
+					Size:         &media.ImageSize{Width: 1728, Height: 2304},
 					OutputFormat: media.ImageFormatPNG,
 				}},
 			},
@@ -175,6 +176,80 @@ func TestImageTransport(t *testing.T) {
 		t.Fatalf("image source bytes mismatch")
 	}
 	_ = capture.body(0)
+}
+
+func TestImageCompilerSizeRules(t *testing.T) {
+	compile := func(width, height int) (string, error) {
+		t.Helper()
+		request := inference.GenerateRequest{
+			Input: inference.GenerateInput{
+				Role: inference.InputRoleUser,
+				Content: inference.InputContent{
+					Content: message.Content{Parts: []message.Part{
+						message.TextPart{Text: "a red circle"},
+					}},
+					Intent: inference.Intent{Image: &inference.ImageIntent{
+						Size: &media.ImageSize{Width: width, Height: height},
+					}},
+				},
+			},
+		}
+		compiled, err := compileImage("gpt-image-2")(
+			context.Background(),
+			azureImageModel("gpt-image-2"),
+			request,
+			inference.GenerateExecutionUnary,
+		)
+		if err != nil {
+			return "", err
+		}
+		return compiled.Wire.size, nil
+	}
+
+	for _, size := range []struct {
+		width, height int
+		want          string
+	}{
+		{1024, 1024, "1024x1024"},
+		{1536, 1024, "1536x1024"},
+		{1024, 1536, "1024x1536"},
+		{1728, 2304, "1728x2304"},
+		{864, 1072, "864x1072"},
+		{2160, 3840, "2160x3840"},
+	} {
+		got, err := compile(size.width, size.height)
+		if err != nil {
+			t.Errorf("%dx%d: compile = %v, want size %q", size.width, size.height, err, size.want)
+			continue
+		}
+		if got != size.want {
+			t.Errorf("%dx%d: wire size = %q, want %q", size.width, size.height, got, size.want)
+		}
+	}
+
+	for _, size := range []struct {
+		width, height int
+	}{
+		{800, 600},   // not divisible by 16
+		{1025, 1024}, // width not divisible by 16
+		{4096, 512},  // aspect ratio 8:1
+		{512, 4096},  // aspect ratio 1:8
+		{3840, 3840}, // short edge above 2160
+		{0, 1024},    // non-positive
+		{-1, -1},     // non-positive
+	} {
+		_, err := compile(size.width, size.height)
+		if err == nil {
+			t.Errorf("%dx%d: compile succeeded, want size rejection", size.width, size.height)
+			continue
+		}
+		var inferenceErr *inference.Error
+		if !errors.As(err, &inferenceErr) ||
+			inferenceErr.Field != inference.FieldGenerateIntentImageSize {
+			t.Errorf("%dx%d: error = %v, want field %q",
+				size.width, size.height, err, inference.FieldGenerateIntentImageSize)
+		}
+	}
 }
 
 func TestImageEditTransport(t *testing.T) {


### PR DESCRIPTION
## Summary

v0.1.7 still rejected sizes beyond `1024x1024` / `1536x1024` / `1024x1536`. gpt-image-2-family models accept arbitrary resolutions, so the size whitelist is replaced with the documented rules:

- width and height both divisible by 16;
- aspect ratio between 1:3 and 3:1;
- resolution at most 3840x2160 (long edge 3840, short edge 2160).

Examples now accepted: `1728x2304`, `864x1072`, `2160x3840`. Standard sizes still pass the same rules.

## Gates

- driver/azure tests (incl. size rules table), vet, golangci-lint, diff check pass.

## Release

After merge, tag `driver/azure/v0.1.8` directly on the merge commit.