### PR TITLE
fix(driver): keep image wire types concrete for core binding

### DIFF
--- a/driver/azure/conformance_test.go
+++ b/driver/azure/conformance_test.go
@@ -211,9 +211,9 @@ func TestConformanceImageCompiler(t *testing.T) {
 			if wire.model != "gpt-image-1" || wire.prompt != "draw a rocket" {
 				t.Fatalf("wire = %+v", wire)
 			}
-			if len(wire.images) != 0 || wire.mask.Kind() != "" {
+			if len(wire.images) != 0 || len(wire.mask.data) != 0 {
 				t.Fatalf("wire reference images = %d, mask = %q",
-					len(wire.images), wire.mask.Kind())
+					len(wire.images), len(wire.mask.data))
 			}
 		},
 		Rejections: []inferencetest.CompilerRejection[inference.GenerateRequest]{

--- a/driver/azure/image.go
+++ b/driver/azure/image.go
@@ -34,11 +34,30 @@ type imageWire struct {
 	format string // png | jpeg | webp
 	// images are inline reference images for image-to-image edits; empty
 	// means a text-only generation.
-	images []media.ImageSource
+	images []wireImage
 	// mask is an inline PNG whose transparent areas mark where the first
-	// reference image should be edited; zero when absent.
-	mask media.ImageSource
+	// reference image should be edited; empty data when absent.
+	mask wireImage
 }
+
+// wireImage is a concrete inline image payload: raw bytes plus the media
+// type the compiler validated. Only inline sources reach the wire — URL and
+// stream sources are rejected at compile time — so the source kind is
+// constant and stays off the wire to satisfy the concrete-wire binding
+// contract (core rejects wires containing interface values).
+type wireImage struct {
+	data      []byte
+	mediaType string
+}
+
+// imageFile is a multipart file part that carries the image's media type;
+// the openai-go multipart encoder reads ContentType() when present.
+type imageFile struct {
+	*bytes.Reader
+	contentType string
+}
+
+func (f imageFile) ContentType() string { return f.contentType }
 
 type imageRaw struct {
 	images [][]byte
@@ -113,7 +132,10 @@ func compileImage(
 						)
 						continue
 					}
-					wire.images = append(wire.images, value.Source)
+					wire.images = append(wire.images, wireImage{
+						data:      value.Source.Bytes(),
+						mediaType: value.Source.BaseMediaType(),
+					})
 				default:
 					ledger.reject(
 						fields[part.Kind()],
@@ -240,7 +262,10 @@ func compileImageOptions(
 		)
 		return
 	}
-	wire.mask = options.Mask.Clone()
+	wire.mask = wireImage{
+		data:      options.Mask.Bytes(),
+		mediaType: options.Mask.BaseMediaType(),
+	}
 }
 
 func transportImage(
@@ -264,8 +289,11 @@ func transportImage(
 			response, err = client.Images.Generate(ctx, params)
 		} else {
 			readers := make([]io.Reader, 0, len(wire.images))
-			for _, source := range wire.images {
-				readers = append(readers, bytes.NewReader(source.Bytes()))
+			for _, image := range wire.images {
+				readers = append(readers, imageFile{
+					Reader:      bytes.NewReader(image.data),
+					contentType: image.mediaType,
+				})
 			}
 			params := openai.ImageEditParams{
 				Model:  openai.ImageModel(wire.model),
@@ -279,8 +307,11 @@ func transportImage(
 			if wire.format != "" {
 				params.OutputFormat = openai.ImageEditParamsOutputFormat(wire.format)
 			}
-			if wire.mask.Kind() != "" {
-				params.Mask = bytes.NewReader(wire.mask.Bytes())
+			if len(wire.mask.data) > 0 {
+				params.Mask = imageFile{
+					Reader:      bytes.NewReader(wire.mask.data),
+					contentType: wire.mask.mediaType,
+				}
 			}
 			response, err = client.Images.Edit(ctx, params)
 		}

--- a/driver/azure/image_test.go
+++ b/driver/azure/image_test.go
@@ -17,6 +17,8 @@ import (
 	"github.com/GizClaw/flowcraft/core/inference"
 	"github.com/GizClaw/flowcraft/core/message"
 	"github.com/GizClaw/flowcraft/core/message/media"
+
+	"github.com/openai/openai-go/v3"
 )
 
 // ---------------------------------------------------------------------------
@@ -252,6 +254,23 @@ func TestImageCompilerSizeRules(t *testing.T) {
 	}
 }
 
+// TestImageOpsBind guards the core binding contract: the image wire must
+// stay concrete (no media sources, whose stream field is an interface), so
+// opening image operations succeeds.
+func TestImageOpsBind(t *testing.T) {
+	driver, err := inference.BindGenerate(
+		compileImage("gpt-image-1"),
+		transportImage(openai.Client{}),
+		decodeImage,
+	)
+	if err != nil {
+		t.Fatalf("BindGenerate: %v", err)
+	}
+	if driver == nil {
+		t.Fatal("BindGenerate returned a nil driver")
+	}
+}
+
 func TestImageEditTransport(t *testing.T) {
 	source, err := media.NewImageBytes(testPNG, "image/png")
 	if err != nil {
@@ -274,6 +293,9 @@ func TestImageEditTransport(t *testing.T) {
 		if len(files) != 1 {
 			t.Errorf("image files = %d, want 1", len(files))
 			return
+		}
+		if contentType := files[0].Header.Get("Content-Type"); contentType != "image/png" {
+			t.Errorf("image content type = %q, want image/png", contentType)
 		}
 		file, err := files[0].Open()
 		if err != nil {
@@ -364,6 +386,12 @@ func TestImageEditTransportMask(t *testing.T) {
 			t.Errorf("mask files = %d, want 1", len(masks))
 			return
 		}
+		if contentType := files[0].Header.Get("Content-Type"); contentType != "image/png" {
+			t.Errorf("image content type = %q, want image/png", contentType)
+		}
+		if contentType := masks[0].Header.Get("Content-Type"); contentType != "image/png" {
+			t.Errorf("mask content type = %q, want image/png", contentType)
+		}
 		readPart := func(header *multipart.FileHeader) []byte {
 			t.Helper()
 			file, err := header.Open()
@@ -423,9 +451,10 @@ func TestImageEditTransportMask(t *testing.T) {
 	if len(compiled.Wire.images) != 1 {
 		t.Fatalf("wire images = %d, want 1", len(compiled.Wire.images))
 	}
-	if compiled.Wire.mask.Kind() != media.SourceInline ||
-		!bytes.Equal(compiled.Wire.mask.Bytes(), testPNG) {
-		t.Fatalf("wire mask = %+v", compiled.Wire.mask)
+	if !bytes.Equal(compiled.Wire.mask.data, testPNG) ||
+		compiled.Wire.mask.mediaType != "image/png" {
+		t.Fatalf("wire mask = %d bytes / %q, want %d bytes / image/png",
+			len(compiled.Wire.mask.data), compiled.Wire.mask.mediaType, len(testPNG))
 	}
 	raw, err := transportImage(cls.api)(context.Background(), compiled.Wire)
 	if err != nil {

--- a/driver/openai/generate_openai_operations_test.go
+++ b/driver/openai/generate_openai_operations_test.go
@@ -18,6 +18,8 @@ import (
 	"github.com/GizClaw/flowcraft/core/inference"
 	"github.com/GizClaw/flowcraft/core/message"
 	"github.com/GizClaw/flowcraft/core/message/media"
+
+	"github.com/openai/openai-go/v3"
 )
 
 func TestGenerateUnaryToolCalls(t *testing.T) {
@@ -271,6 +273,23 @@ func TestImageCompilerSizeRules(t *testing.T) {
 	}
 }
 
+// TestImageOpsBind guards the core binding contract: the image wire must
+// stay concrete (no media sources, whose stream field is an interface), so
+// opening image operations succeeds.
+func TestImageOpsBind(t *testing.T) {
+	driver, err := inference.BindGenerate(
+		compileImage("gpt-image-2"),
+		transportImage(openai.Client{}),
+		decodeImage,
+	)
+	if err != nil {
+		t.Fatalf("BindGenerate: %v", err)
+	}
+	if driver == nil {
+		t.Fatal("BindGenerate returned a nil driver")
+	}
+}
+
 func TestImageEditTransport(t *testing.T) {
 	// 1x1 transparent PNG reference image.
 	png, err := base64.StdEncoding.DecodeString(
@@ -295,6 +314,9 @@ func TestImageEditTransport(t *testing.T) {
 		if len(files) != 1 {
 			t.Errorf("image files = %d, want 1", len(files))
 			return
+		}
+		if contentType := files[0].Header.Get("Content-Type"); contentType != "image/png" {
+			t.Errorf("image content type = %q, want image/png", contentType)
 		}
 		file, err := files[0].Open()
 		if err != nil {

--- a/driver/openai/image.go
+++ b/driver/openai/image.go
@@ -32,8 +32,27 @@ type imageWire struct {
 	format string // png | jpeg | webp
 	// images are inline reference images for image-to-image edits; empty
 	// means a text-only generation.
-	images []media.ImageSource
+	images []wireImage
 }
+
+// wireImage is a concrete inline image payload: raw bytes plus the media
+// type the compiler validated. Only inline sources reach the wire — URL and
+// stream sources are rejected at compile time — so the source kind is
+// constant and stays off the wire to satisfy the concrete-wire binding
+// contract (core rejects wires containing interface values).
+type wireImage struct {
+	data      []byte
+	mediaType string
+}
+
+// imageFile is a multipart file part that carries the image's media type;
+// the openai-go multipart encoder reads ContentType() when present.
+type imageFile struct {
+	*bytes.Reader
+	contentType string
+}
+
+func (f imageFile) ContentType() string { return f.contentType }
 
 type imageRaw struct {
 	images [][]byte
@@ -108,7 +127,10 @@ func compileImage(
 						)
 						continue
 					}
-					wire.images = append(wire.images, value.Source)
+					wire.images = append(wire.images, wireImage{
+						data:      value.Source.Bytes(),
+						mediaType: value.Source.BaseMediaType(),
+					})
 				default:
 					ledger.reject(
 						fields[part.Kind()],
@@ -230,8 +252,11 @@ func transportImage(
 			response, err = client.Images.Generate(ctx, params)
 		} else {
 			readers := make([]io.Reader, 0, len(wire.images))
-			for _, source := range wire.images {
-				readers = append(readers, bytes.NewReader(source.Bytes()))
+			for _, image := range wire.images {
+				readers = append(readers, imageFile{
+					Reader:      bytes.NewReader(image.data),
+					contentType: image.mediaType,
+				})
 			}
 			params := openai.ImageEditParams{
 				Model:  openai.ImageModel(wire.model),


### PR DESCRIPTION
## Problem

Opening image operations fails at bind time:

```
open image ops error: provider wire type must be concrete and must not contain canonical or open interface values
```

`imageWire` carried `media.ImageSource` (and for azure a mask source), whose embedded `stream any` field makes the wire non-concrete; core's bind validation rejects wires containing interface values.

## Fix

Carry a concrete `wireImage` struct (`data []byte` + `mediaType string`) in the wire instead. Only inline sources reach the wire — URL/stream sources are rejected at compile time — so no source kind is lost. The media type now rides the multipart `Content-Type` via the openai-go reader interface instead of being dropped to `application/octet-stream`.

Applies to both driver/azure (reference images + mask) and driver/openai (reference images). Adds a bind regression test (`TestImageOpsBind`) to each driver, plus multipart Content-Type assertions.

## Gates

- driver/azure + driver/openai: gofmt, tests, vet, golangci-lint, diff check all pass.

## Release

After merge, tag both modules on the merge commit: `driver/azure/v0.1.9`, `driver/openai/v0.1.8`.