### PR TITLE
docs(core): sync guides and flowcraft-config skill with core v0.1.23

### DIFF
--- a/core/runtime/reload.go
+++ b/core/runtime/reload.go
@@ -33,8 +33,11 @@ type ReloadResult struct {
 //
 //  1. Validates the document and decodes the runtime config.
 //  2. Builds the new deploy.Result (rollback on failure).
-//  3. Asserts the system resources (event_bus, checkpoint_store,
-//     sessions.resume) are unchanged — they are pinned per Runtime.
+//  3. Resolves the new generation's event_bus / checkpoint_store and
+//     validates the resume contract. Each generation owns its values,
+//     so the document may change their configuration or implementation
+//     freely; a reload whose event_bus factory returns the current
+//     generation's bus (a shared singleton) is rejected.
 //  4. Rebuilds the host factory with the same decorator.
 //  5. Re-binds every dynamic agent against the new result; any failure
 //     aborts the whole reload.

--- a/docs/guides/delegation.md
+++ b/docs/guides/delegation.md
@@ -1,0 +1,86 @@
+---
+layout: default
+title: Delegation
+---
+# Delegation Guide
+
+`core/delegation` defines backend-neutral contracts for assigning work to
+another agent or execution target. `Directory` owns discovery; `Service`
+owns execution and status lookup. Delegation is synchronous or
+asynchronous, and the local implementation executes delegated work
+through the same session lifecycle as a user turn.
+
+## Deployment
+
+The three core resources:
+
+```yaml
+resources:
+  dir:
+    kind: delegation.Directory
+    impl: local    # no settings; binds the deployment's agents at wire time
+
+  svc:
+    kind: delegation.Service
+    impl: local
+    deps:
+      directory: dir
+      # backend: async            # optional; absent = sync-only service
+      # session_provider: prov    # optional identity policy
+    settings:
+      max_concurrency: 4          # positive; default 4
+      max_depth: 8                # positive; default 8
+      timeout: 5m                 # Go duration; zero leaves the caller's context
+      idempotency_retention: 24h  # positive; how long responses stay replayable
+      defer_workers: true         # start async workers on Start instead of at build
+
+  prov:
+    kind: delegation.SessionProvider
+    impl: random   # no settings; fresh ContextID per delegation, never persists
+```
+
+The directory is required and is bound to the assembled deployment during
+the deploy wire phase, so every generation delegates against its own
+agents. The backend and session provider deps are optional: without a
+backend the service is sync-only, and without a session provider each
+delegation mints a fresh `ContextID`.
+
+## Exposing delegation to agents
+
+Turn hosts expose the service through
+`runtime.Builder.WithResultHostFactory` plus `delegation/hostwrap`; the
+service is then available to execution-time consumers via
+`ServiceFromHost`. The model-facing delegation tools come from a
+`tool.Source` resource:
+
+```yaml
+resources:
+  dtools:
+    kind: tool.Source
+    impl: delegation
+    deps:
+      directory: dir   # no settings; delegate / delegation_status / delegation_targets
+```
+
+The tools discover their targets from the same generation-bound directory
+on every call, so each generation's tools see that generation's agents.
+
+## Lifecycle
+
+- Sync mode waits for the delegated work and returns its terminal
+  response; async mode admits work and returns immediately, with status
+  lookup through `delegation_status`.
+- Successful responses stay replayable for `idempotency_retention`, so
+  retried delegation does not re-execute completed work.
+- A `Reload` re-binds the directory and service to the new generation,
+  so in-flight delegation completes on the generation it started on.
+
+See [runtime.md](runtime.md) for `WithResultHostFactory` and reload, and
+[tool.md](tool.md) for tool sources.
+
+## Sources of truth
+
+`core/delegation/delegation.go`, `core/delegation/service.go`,
+`core/delegation/directory.go`, `core/delegation/host.go`,
+`core/delegation/hostwrap/`, `core/delegation/resource.go`,
+`core/delegation/tool/`.

--- a/docs/guides/event.md
+++ b/docs/guides/event.md
@@ -44,6 +44,8 @@ resources:
   events:
     kind: event.Bus
     impl: memory
+    settings:
+      route_cache_size: 1024  # optional: positive caps the subject route cache, zero disables it
 ```
 
 The runtime host exposes the bus through `agent.EventBusProvider`.
@@ -52,5 +54,6 @@ without resolving the resource themselves; the prompt lifecycle events
 are documented in [prompt.md](prompt.md). Runtime agent lifecycle events
 (`runtime.agent.<id>.registered` / `.removed`, subscribe with
 `PatternAgentLifecycle()`) live in a separate namespace and are published
-on successful dynamic registration/removal (see
-[runtime.md](runtime.md)).
+on successful dynamic registration/removal, and generation reloads publish
+`runtime.rebuild.started` / `.completed` / `.failed` (`PatternRuntimeRebuild()`)
+— see [runtime.md](runtime.md).

--- a/docs/guides/graph.md
+++ b/docs/guides/graph.md
@@ -91,6 +91,33 @@ Engine deps are derived from the definition: an inference node needs the
 node needs `tools`, a script node needs `script_runtime`. `workspace` and
 `sandbox` are optional and unlock the script `fs` / `shell` globals (below).
 
+## Script runtimes
+
+Script nodes run on a bound `agent.ScriptRuntime` resource named by the
+engine's `script_runtime_name` (default `js`). The core runtimes:
+
+```yaml
+resources:
+  js:
+    kind: agent.ScriptRuntime
+    impl: js
+    settings:
+      pool_size: 4              # positive; number of pooled VMs
+      max_call_stack_size: 512  # js only; positive call-stack bound
+      max_exec_time: 30s        # Go duration; zero disables the cap
+
+  lua:
+    kind: agent.ScriptRuntime
+    impl: lua
+    settings:
+      pool_size: 4
+      max_exec_time: 30s
+```
+
+Implementations live in `core/agent/scriptrt/{jsrt,luart}`. A runtime that
+cannot nest sub-scripts degrades `runtime.execScript` to a `not_available`
+signal instead of panicking (see below).
+
 ## Node types
 
 ### `inference` — single-shot generation
@@ -300,10 +327,16 @@ Direct read/write of the engine board.
 | `board.deleteVar(key)`           | —                                                                 |
 | `board.getVars()`                | `map`                                                             |
 | `board.hasVar(key)`              | `bool`                                                            |
+| `board.resolve(str)`             | `any` — typed `${board.*}` expansion                              |
+| `board.resolveString(str)`       | `string` — text `${board.*}` expansion                            |
 | `board.channel(name)`            | `array` of message objects (never null)                           |
 | `board.setChannel(name, msgs)`   | throws on validation errors                                       |
 | `board.appendChannel(name, msg)` | throws on validation errors                                       |
 | `board.MAIN_CHANNEL`             | the reserved default channel name (use it instead of the literal) |
+
+`resolve` / `resolveString` run the same `${board.*}` expansion the
+engine applies to node config strings: missing references error unless a
+default is given, and `resolveString` renders non-string values to text.
 
 Messages use the inference wire format: `{role, content: {parts: [...]}}`
 with parts like `{"type": "text", "text": "..."}` or
@@ -419,10 +452,24 @@ script-land (check `finish_reason`, call the message's tool parts via
 | `inference.explainEmbed(request)` / `inference.routeExplainEmbed(request)`   | embedding twins of explain/routeExplain                                 |
 | `inference.explainStream(request)` / `inference.routeExplainStream(request)` | local stream preflight without opening a provider stream                |
 | `inference.stream(request)` / `inference.routeStream(request)`               | streaming twins returning `{next, result, close}`                       |
+| `inference.transcribe(request)` / `inference.routeTranscribe(request)`       | whole-audio transcription; route twin gains `trace`                     |
+| `inference.explainTranscribe(request)` / `inference.routeExplainTranscribe(request)` | transcription preflight (exact model vs router); route twin returns `{explanation, decision, limits}` |
+| `inference.transcribeSession(request)` / `inference.routeTranscribeSession(request)` | duplex session handle `{send, next, result, interrupt, finish, close}`; route twin attaches `trace` to the result |
 
 Stream handle: `next()` returns one event or `null` at EOF, `result()`
 returns the accumulated `GenerateResponse` after `next()` returned `null`,
 and `close()` abandons a stream early (idempotent).
+
+Transcription session handle:
+
+| Method              | Behavior                                                                                    |
+| ------------------- | ------------------------------------------------------------------------------------------- |
+| `session.send(chunk)`   | feeds one `media.AudioChunk` wire JSON (`{data, sequence}`); fails once the session ended    |
+| `session.next()`        | one `TranscriptionSessionEvent`, or `null` at normal end; errors terminate the iteration     |
+| `session.result()`      | the accumulated `TranscriptionResponse` (same shape as `transcribe`); only after `next()` → `null` |
+| `session.interrupt()`   | terminates abnormally (barge-in); surfaces from the next `next()` / `result()`               |
+| `session.finish()`      | explicit end-of-input (`FinishInput`); errors when the provider session lacks the capability |
+| `session.close()`       | idempotent early exit                                                                        |
 
 Extensions ride a bridge-level `extensions` array of
 `{provider, id, fields}`, resolved through decoders the host registered

--- a/docs/guides/inference.md
+++ b/docs/guides/inference.md
@@ -21,7 +21,11 @@ model := inference.ModelRef{
 ```
 
 The runtime never picks or replaces a model. Optional routing is provided by
-`core/inference/route`.
+`core/inference/route`. Route selection consults the providers' declared
+model capabilities: targets whose declared output kinds cannot serve the
+request intent are skipped, while models with undeclared capabilities are
+treated as undeclared (not unsupported) — preflight remains the final
+arbiter for those.
 
 ## Deployment config
 
@@ -44,13 +48,72 @@ resources:
       provider: provider
 ```
 
-Provider implementations live in `driver/<name>` modules. The application
-registers the desired provider factories:
+Provider implementations are registered by the application from provider
+driver modules:
 
 ```go
 reg.MustRegister(deepseek.NewFactory())
 reg.MustRegister(inference.Factory{})
 ```
+
+## Routing
+
+Optional target selection is an `inference.Router` resource. It consumes
+one `inference.Assembly` as its `target` dep and reads the route policy
+from its own `settings`:
+
+```yaml
+resources:
+  router:
+    kind: inference.Router
+    impl: unified
+    deps:
+      target: infer
+    settings:
+      generate:
+        - tier: fast
+          targets:
+            - model: {id: {provider: deepseek, name: deepseek-v4-flash}}
+              score: {quality: 0.8, speed: 0.9}
+      retry:
+        generate:
+          max_attempts: 2
+          max_total_attempts: 5
+          backoff:
+            kind: exponential   # fixed | exponential (default)
+            initial: 100ms
+            max: 2s
+            multiplier: 2
+            jitter: full        # none | equal | full (default)
+          retryable: [rate_limit, timeout, unavailable]
+          fallback_on_retry_exhausted: true
+      circuit_breaker:
+        failure_threshold: 5      # consecutive transient failures; default 5
+        recovery_window: 30s      # open-circuit window; default 30s
+        half_open_max_probes: 1   # concurrent probes while half-open; default 1
+```
+
+The policy has three operation areas — `generate`, `embed`, and
+`transcription` — each a list of `tier` pools. A pool is an allowlist of
+exact `model` targets plus optional normalized `score` signals
+(`quality` / `economy` / `speed` / `reliability`, all in `[0, 1]`).
+Scores guide selection only; they never claim a request is executable.
+
+- Route selection is capability-aware: targets whose declared output kinds
+  cannot serve the request intent are skipped, while targets with
+  undeclared capabilities are treated as undeclared (not unsupported) —
+  preflight remains the final arbiter.
+- The `retry` section configures per-operation retries (same-target), each
+  with `max_attempts`, an optional `max_total_attempts`, a `backoff`
+  curve, an explicit `retryable` class list (`rate_limit`, `timeout`,
+  `unavailable`), and `fallback_on_retry_exhausted`. A retry section
+  requires its operation to have pools.
+- `circuit_breaker` opens a per-target circuit after consecutive transient
+  failures, probes while half-open, and skips attempts while open.
+- At build time every configured target is validated against the assembly:
+  it must exist, not be retired, and expose the operation. A graph engine
+  wires the router through its `router` dep when inference nodes omit an
+  explicit `model`.
 
 ## Streaming
 

--- a/docs/guides/memory.md
+++ b/docs/guides/memory.md
@@ -39,7 +39,7 @@ implementation-owned:
 resources:
   memories:
     kind: memory.Assembly
-    impl: flowcraft
+    impl: mymemory        # app-registered implementation; name is yours
     deps:
       workspace: ws/project
       inference: infer
@@ -48,5 +48,64 @@ resources:
 ```
 
 Hooks bind the whole assembly as their `memory` dependency.
+
+### `memory.context` seed hook (`hook.prepare`)
+
+Prepares each turn's board with recalled context. The `query` section
+must select exactly one source: `literal` text, a board var (`board`),
+the current request message (`current_message`), or the recall window
+(`recent_only`). Recalled items land in the board var named by `output`,
+and an optional renderer writes rendered text to a second board var:
+
+```yaml
+agents:
+  assistant:
+    prepare:
+      - type: memory.context
+        deps:
+          memory: memories
+        settings:
+          query:
+            literal: "relevant prior conversation"  # or board / current_message / recent_only
+          scope:
+            runtime_id: memories
+            user_id: user-1
+            agent_id: assistant
+          conversation_id: conv-1        # optional; defaults to the request ContextID
+          dataset_ids: [docs]            # optional
+          budget: {max_tokens: 2000, max_items: 50, max_chars: 8000}  # optional
+          min_score: 0.5                 # optional; [0, 1]
+          output: memory_items           # required; non-reserved board var
+          render:
+            output: memory_text          # must differ from output
+            gotmpl: {template: "{{ range .Items }}{{ contentText .Content }}\n{{ end }}", max_chars: 8000}
+```
+
+`scope` hard-partitions recall by `runtime_id` + `user_id` + `agent_id`
+(see Scope above). `output` (and `render.output`) must be a non-reserved
+board variable name — the `__` prefix is reserved for the engine.
+
+### `memory.turn` commit hook (`hook.commit`)
+
+Pushes each completed turn's channel into the assembly as durable memory:
+
+```yaml
+agents:
+  assistant:
+    commit:
+      - type: memory.turn
+        deps:
+          memory: memories
+        settings:
+          scope:
+            runtime_id: memories
+            user_id: user-1
+            agent_id: assistant
+          conversation_id: conv-1   # optional; defaults to the request ContextID
+          channel: main             # optional; defaults to the main channel
+```
+
+Committed turns are idempotent per run id, so retried turns do not
+duplicate memory.
 
 See [deploy.md](deploy.md) and [resource.md](resource.md).

--- a/docs/guides/runtime.md
+++ b/docs/guides/runtime.md
@@ -99,8 +99,31 @@ Rules:
 - `dynamic_catalog.tools` maps agent IDs to `tool.Assembly` resources.
   The reserved `default` key is an optional fallback. The mapping is
   live: dynamically registered agents may attach a tool assembly at
-  registration time (see below).
+  registration time (see below). Every mapping key must name a deployed
+  agent — an unknown key fails the build (`no such deployed agent`).
 - Buffer and concurrency fields are validated against hard upper bounds.
+
+## Checkpoint stores
+
+`checkpoint_store` names a resource implementing `agent.CheckpointStore`.
+The core backend is the workspace store:
+
+```yaml
+resources:
+  cps:
+    kind: checkpoint.Store
+    impl: workspace
+    deps:
+      workspace: ws
+    settings:
+      prefix: agent/checkpoints  # optional; default "agent/checkpoints"
+```
+
+Checkpoint files live under the workspace's `prefix` directory.
+`sessions.resume: true` requires a store, and reloads additionally require
+it to implement `agent.CheckpointDeleter` (the core workspace store does).
+Concrete alternative backends are app-registered outside `core/` and own
+their settings schema.
 
 ## Sessions
 
@@ -178,6 +201,44 @@ Semantics:
 
 `Manager.RemoveAgent` / `Manager.ReopenAgent` are the session-manager
 level primitives behind removal and re-registration.
+
+## Reload
+
+`Runtime.Reload` transactionally replaces the deployment document without
+rebuilding the runtime:
+
+```go
+result, err := app.Reload(ctx, newDoc)
+if err != nil {
+    // the previous generation keeps serving
+    return err
+}
+_ = result.GenerationID
+```
+
+Semantics:
+
+- The new generation is built, validated, and swapped atomically; any
+  failure aborts before the swap and the current generation stays in
+  service. In-flight turns always complete on the generation they started
+  on; the next `Start` uses the new generation.
+- Each generation owns its `event_bus` / `checkpoint_store` values, and
+  the router subscribes to every live generation's bus, so the document
+  may change their configuration or implementation freely. Continuity of
+  durable session state across a store change is the host's
+  responsibility (same backing storage or migration). A reload whose
+  `event_bus` factory returns the current generation's bus (a shared
+  singleton) is rejected.
+- Dynamically registered agents are re-bound against the new result;
+  agents removed by the new document have their sessions drained before
+  the swap. `Reload` is serialized with `RegisterAgent` /
+  `UnregisterAgent` / `Close`.
+- Progress is published as `runtime.rebuild.started` / `.completed` /
+  `.failed` events (`SubjectRuntimeRebuild*`, subscribe with
+  `PatternRuntimeRebuild()`); the `RuntimeRebuildEvent` payload carries
+  `generation_id`, `previous_generation_id`, `rebound_agents`,
+  `drained_agents`, and `error` (on failure). See [event.md](event.md)
+  for the event namespaces.
 
 ## Host decorators
 

--- a/docs/guides/sandbox.md
+++ b/docs/guides/sandbox.md
@@ -32,10 +32,32 @@ resources:
       root: ./sandbox
 ```
 
-Platform backends are registered from integration modules:
+Platform backends are registered from core subpackages:
 
 - `core/sandbox/bwrap` for Linux namespace isolation.
 - `core/sandbox/seatbelt` for macOS confinement.
+
+Both isolation backends share the same settings shape:
+
+```yaml
+resources:
+  box:
+    kind: sandbox.Runner
+    impl: bwrap            # or seatbelt
+    settings:
+      root: ./sandbox
+      binary: /usr/bin/bwrap    # optional; resolved against the root
+      writable_paths: [./out]   # optional; paths the sandbox may write
+      extra_flags: [--die-with-parent]  # bwrap only; policy-downgrading flags are rejected
+```
+
+`root` is required and scopes the sandbox filesystem. `binary` overrides
+the backend binary and is resolved against the root; `writable_paths`
+opt into write access; `extra_flags` (bwrap only) passes additional
+bwrap flags, with any flag that could weaken the policy (e.g. `--ro-bind`
+or `--args`) rejected at build time. The local runner is a no-isolation
+backend for trusted workflows; bwrap/seatbelt enforce the isolation
+boundary and reject policies they cannot honor.
 
 ## Policy groups
 

--- a/docs/guides/tool.md
+++ b/docs/guides/tool.md
@@ -70,6 +70,60 @@ registry the moment it connects. A server that dies later is
 reconnected the same way; its tools stay registered and calls fail with
 a per-server `NotAvailable` error until the connection is restored.
 Configuration errors (a rejected connection, an invalid spec) still
-fail the deployment. Middleware lives in `core/tool/middleware`.
+fail the deployment. The settings subtree declares one or more servers:
+
+```yaml
+resources:
+  sim:
+    kind: tool.Source
+    impl: mcp
+    settings:
+      servers:
+        - name: filesystem
+          transport: stdio           # stdio | http
+          command: npx
+          args: ["-y", "@modelcontextprotocol/server-filesystem"]
+          env: {TOKEN: ${env:MCP_TOKEN}}
+          prefix: fs                  # tool namespace; default "<name>__"
+          resources: true             # bridge list_resources / read_resource tools
+          required: true              # host should WaitReady before serving
+        - name: remote
+          transport: http
+          url: https://mcp.example.com/mcp
+          headers: {Authorization: "Bearer ${env:MCP_TOKEN}"}
+          http_timeout: 30s
+```
+
+`required: true` marks a server the host cannot start without; hosts
+await `Source.WaitReady` so a background give-up surfaces as an error
+instead of a silent missing tool set. Middleware lives in
+`core/tool/middleware`.
+
+## Middleware chain
+
+`tool.Assembly/middleware` is the memory assembly plus a
+settings-declared middleware chain:
+
+```yaml
+resources:
+  tools:
+    kind: tool.Assembly
+    impl: middleware
+    deps:
+      tool: sim
+    settings:
+      middlewares:
+        recover: {enabled: true}
+        timeout: {default: 30s}
+        concurrency: {limit: 8}
+```
+
+Each entry is optional; absent entries are skipped. `recover` converts a
+panicking tool (or inner middleware) into an `IsError` result instead of
+crashing the caller's goroutine; `timeout.default` bounds each call with a
+Go duration (calls that already carry a deadline pass through);
+`concurrency.limit` caps in-flight executions, with excess callers waiting
+(respecting context cancellation). The plain `memory` impl rejects the
+`middlewares` key.
 
 See [runtime.md](runtime.md) for per-session dynamic catalogs.

--- a/skills/flowcraft-config/SKILL.md
+++ b/skills/flowcraft-config/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: flowcraft-config
-description: Author, validate, and troubleshoot complete FlowCraft deployment configuration (deploy.yaml with the runtime section, inference/workspace/sandbox/tool sub-documents, core/memory contracts, and graph JSON node wiring). Use when writing or reviewing FlowCraft configs, assembling an agent deployment, adding runtime/session settings, building graph definitions, resolving config build failures ("not registered", dead configuration, route policy missing, graph node errors), or copying a minimal runnable FlowCraft deployment template.
+description: "Author, validate, and troubleshoot complete FlowCraft deployment configuration (deploy.yaml with the runtime section, inference/workspace/sandbox/tool sub-documents, core/memory contracts, and graph JSON node wiring). Use when writing or reviewing FlowCraft configs, assembling an agent deployment, adding runtime/session settings, building graph definitions, resolving config build failures (\"not registered\", dead configuration, route policy missing, graph node errors), or copying a minimal runnable FlowCraft deployment template."
 ---
 
 # FlowCraft Config Authoring
@@ -13,7 +13,7 @@ the L2 structural validator and fix errors against the reference cards.
 
 1. **Scope the deployment.** Collect the agents, capabilities (chat,
    tools, memory, scripts, sandboxing), and runtime needs (sessions,
-   resume, event bus, scheduler, backends).
+   resume, event bus, checkpoint stores).
 2. **Draft the deployment document.** `deploy.yaml` is the convention
    but any filename works; pass whatever path you choose to the
    validator. Read
@@ -103,7 +103,7 @@ workflow.
 ## Compatibility and versioning
 
 One skill version pins one FlowCraft version. The validator's `go.mod`
-requires exactly `github.com/GizClaw/flowcraft/core v0.1.13`; the schema
+requires exactly `github.com/GizClaw/flowcraft/core v0.1.23`; the schema
 cards in this skill document that release (no `driver/*` or `backends/*`
 modules are required, since the validator never constructs factories).
 When FlowCraft releases a new version, bump the pin and reconcile the
@@ -115,9 +115,9 @@ their factories and settings schemas live in the host application.
 - [deploy.md](references/deploy.md) — deploy document schema, dep refs,
   first-party kinds, registration.
 - [runtime.md](references/runtime.md) — runtime section, sessions,
-  backends.
+  dynamic registration, reload.
 - [resources.md](references/resources.md) — inference/memory/workspace/
-  sandbox/tool/event/scheduler/checkpoint sub-documents.
+  sandbox/tool/event/checkpoint/delegation/script-runtime sub-documents.
 - [graph.md](references/graph.md) — graph JSON, node configs, engine
   build settings.
 - [pitfalls.md](references/pitfalls.md) — known drift points and the

--- a/skills/flowcraft-config/references/deploy.md
+++ b/skills/flowcraft-config/references/deploy.md
@@ -69,17 +69,18 @@ the core schema. Agent hooks use factory kind `hook.<slot>`.
 | `event.Bus` | `memory` | `core/event` |
 | `workspace.Workspace` | `local` | `core/workspace` |
 | `sandbox.Runner` | `local`, `bwrap`, `seatbelt` | `core/sandbox/{local,bwrap,seatbelt}` |
-| `inference.Provider` | `openai`, `deepseek`, `qwen`, ... | `driver/<name>` |
+| `inference.Provider` | `openai`, `deepseek`, `qwen`, ... | core contract; impls registered from provider drivers |
 | `inference.Assembly` | `unified` | `core/inference` |
 | `inference.Router` | `unified` | `core/inference/route` |
 | `tool.Registry` | `memory` | `core/tool` |
 | `tool.Source` | app/provider-specific | host/app |
-| `tool.Assembly` | `memory` | `core/tool` |
+| `tool.Assembly` | `memory`, `middleware` | `core/tool`, `core/tool/middleware` |
 | `agent.ScriptRuntime` | `js`, `lua` | `core/agent/scriptrt/{jsrt,luart}` |
 | `agent.Engine` | `graph` | `core/graph/resource` |
 | `delegation.Service` | `local` | `core/delegation` |
+| `delegation.Directory` | `local` | `core/delegation` |
+| `delegation.SessionProvider` | `random` | `core/delegation` |
 | `checkpoint.Store` | `workspace` | `core/agent/checkpoint/workspace` |
-| `agent.CheckpointStore` | `sqlite` | `backends/checkpoint/sqlite` |
 
 The table is informational: the validator accepts any kind that fits the
 resource envelope, and only the host build can construct these factories.

--- a/skills/flowcraft-config/references/graph.md
+++ b/skills/flowcraft-config/references/graph.md
@@ -83,10 +83,21 @@ appended to the same channel. The node never executes tool calls — a
 | `stream` | stream deltas incrementally; the board still gets one assembled message |
 | `tools` / `all_tools` | named catalog tools, or the catalog's entire visible set |
 | `tool_choice` | constrain when/which tools are called |
-| `temperature` / `top_p` / `max_output_tokens` | sampling knobs |
-| `reasoning_enabled` / `reasoning_effort` | reasoning switch / depth |
-| `response_format` | `text`, `json_object`, or `json_schema` (re-validated) |
+| `intent` | canonical execution envelope `{text, image, audio, video}` with per-modality controls (see below) |
 | `extensions` | provider knobs `{provider, id, fields}` |
+
+`intent` is authoritative and covers every generation modality: text
+controls (`response`, `max_output_tokens`, `tools`, `tool_choice`,
+`temperature`, `top_p`, `reasoning_enabled`, `reasoning_effort`), image
+(`size`, `aspect_ratio`, `count`, `seed`, `output_format`, `delivery`),
+audio/tts (`voice`, `format`, `speed`, `count`), and video
+(`duration_millis`, `resolution`, `aspect_ratio`, `seed`, `watermark`).
+When `intent` is absent the node defaults to plain text generation.
+`tools` / `all_tools` / `tool_choice` remain node-level sugar: they resolve
+the wired catalog into `intent.text.tools` / `intent.text.tool_choice` and
+may not be combined with an intent that declares those fields itself.
+Legacy node-level sampling/reasoning/response-format keys were removed —
+strict decode rejects them; put them under `intent.text` instead.
 
 ### `tool` — batch tool execution
 
@@ -134,10 +145,84 @@ graph-layer bridges). Availability depends on engine deps:
 | `shell` | `sandbox` dep | sandboxed command execution |
 | `runtime` | always | nested sub-script execution |
 
+### Custom node types (`graph.NodeType`)
+
+Beyond the three built-ins, node types are deployment resources. A resource
+of kind `graph.NodeType` produces a value implementing
+`graph.NodeTypeRegistrar`; the graph engine factory registers every
+`node_type` dependency into the engine's registry before `Build`, so the
+graph definition can reference the type by name. Custom node types
+participate in the normal resource DAG (own deps, built once, shareable
+across agents); the engine accepts deps under `node_type` or
+`node_type.<suffix>` (the `Many` dep form, like `tool.*` sources).
+
+The built-in script impl (`graph.NodeType/script`) defines the node
+behaviour as an embedded script on the bound `agent.ScriptRuntime` with the
+same bridges as the built-in `script` node; the node's config in the graph
+definition becomes the script's `config` global.
+
+| Settings field | Meaning |
+| --- | --- |
+| `type` | node type name graphs reference (must not collide with built-ins or other mounted types) |
+| `source` | handler source: inline string or `{file: ...}` / `{embed: ...}` (required) |
+| `desc` | optional human-readable type description |
+| `reads` / `writes` | static I/O roles (`kind: var\|messages`, `name` or `config_key`, `required`); enforced at Build and invocation |
+
+Deps of `graph.NodeType/script`: `script_runtime` (required), plus optional
+`tools`, `inference`, `router`, `workspace`, `sandbox` enabling the same
+globals the built-in script node unlocks.
+
+```yaml
+resources:
+  greet:
+    kind: graph.NodeType
+    impl: script
+    deps:
+      script_runtime: js
+    settings:
+      type: greet
+      source: board.setVar("greeting", "hi " + config.name)
+      writes:
+        - kind: var
+          name: greeting
+          required: true
+```
+
+Wire the type into the engine with a `node_type` dep, then reference it by
+name in the graph:
+
+```yaml
+agents:
+  asst:
+    engine:
+      kind: agent.Engine
+      impl: graph
+      deps:
+        node_type.greet: greet
+```
+
+```json
+{
+  "name": "greeter",
+  "entry": "hello",
+  "nodes": [
+    {"id": "hello", "type": "greet", "config": {"name": "${board.user}"}}
+  ],
+  "edges": []
+}
+```
+
+Go-backed custom node types follow the same contract: a host or plugin
+registers a `graph.NodeType` resource factory whose value implements
+`graph.NodeTypeRegistrar` (typically by calling `graph.RegisterType` with a
+closure capturing the resource's deps).
+
 ### `board`
 
 - `getVar(key)`, `setVar(key, value)`, `deleteVar(key)`, `getVars()`,
   `hasVar(key)`
+- `resolve(str)` → `any`, `resolveString(str)` → `string` — typed / text
+  `${board.*}` expansion (missing references error unless a default is given)
 - `channel(name)` → message objects (never null); `setChannel(name, msgs)`,
   `appendChannel(name, msg)` throw on validation errors
 - `MAIN_CHANNEL` — the reserved default channel constant
@@ -161,7 +246,12 @@ Every method returns nil/`""` on a no-op host.
 `host.emit` event types in the graph script node: `token` (text delta),
 `tool_call` (`{id, name, arguments}`), `tool_result`
 (`{tool_call_id, content, is_error}`), `part` (canonical part wire object),
-or a passthrough type. Emission is fire-and-forget.
+`finish` (`{finish_reason, request_id?, response_id?}` — typed finish
+delta), `provider_outputs` (`[{provider, extension, value}]` —
+provider_outputs delta), or a passthrough type. Emission is fire-and-forget;
+payloads that do not decode into the type's required shape (e.g. a
+`tool_call` without `id`, a `finish` without `finish_reason`, an empty
+`provider_outputs`) are skipped instead of published as empty deltas.
 
 ### `run`
 
@@ -203,6 +293,13 @@ loops live in script-land (`tools.callAll`, then `input.role = "tool"`).
   preflight without opening a provider stream
 - `stream(request)` / `routeStream(request)` — streaming twins returning
   `{next, result, close}`
+- `transcribe(request)` / `routeTranscribe(request)` — whole-audio
+  transcription; the route twin gains `trace`
+- `explainTranscribe(request)` / `routeExplainTranscribe(request)` —
+  transcription preflight; the route twin returns `{explanation, decision, limits}`
+- `transcribeSession(request)` / `routeTranscribeSession(request)` — duplex
+  session handle `{send, next, result, interrupt, finish, close}`; the route
+  twin attaches `trace` to the result
 
 Extensions ride an `extensions` array of `{provider, id, fields}`, resolved
 through host-registered decoders.
@@ -243,5 +340,6 @@ nest.
 
 `core/graph/definition.go`, `core/graph/nodes/inference.go`,
 `core/graph/nodes/tool.go`, `core/graph/nodes/script/`,
-`core/graph/resource/resource.go`, `core/agent/bindings/`,
+`core/graph/resource/resource.go`, `core/graph/resource/node_type.go`,
+`core/agent/bindings/`,
 `docs/guides/graph.md`.

--- a/skills/flowcraft-config/references/resources.md
+++ b/skills/flowcraft-config/references/resources.md
@@ -13,7 +13,14 @@ spec:
   api: chat             # "chat" (default) or "responses"
   base_url: https://api.deepseek.com   # optional override
   models:               # optional: declare/override catalog models
-    - {name: deepseek-v4-flash, kind: generate, reasoning: true, responses: true}
+    - name: deepseek-v4-flash
+      kind: generate
+      capabilities:     # optional: content kinds, hosted web search, reasoning control
+        inputs: [text, data, tool_call, tool_result]
+        outputs: [text]
+        reasoning: toggle   # "always" or "toggle"
+        hosted_web_search: true
+      responses: true
 profiles:
   - secrets:
       api_key: ${env:DEEPSEEK_API_KEY}
@@ -22,7 +29,11 @@ profiles:
 Provider IDs and profile IDs must be identifiers. Secret values use the
 settings expansion syntax (`${env:NAME}` for an environment variable,
 `${base:rel}` / `~` / `${home:rel}` for paths); a missing variable fails
-the build. Provider drivers are registered from `driver/<name>`.
+the build. Model capabilities mirror the built-in catalog shape and are
+validated by the driver; routing prefers targets whose declared outputs
+cover the request intent and skips declared-incompatible tiers. Provider
+drivers are registered by the host application from provider driver
+modules (outside `core/`).
 
 ## inference assembly
 
@@ -36,8 +47,46 @@ infer:
     provider: provider
 ```
 
-Routing settings are factory-owned; optional route policy is configured in the
-assembly settings.
+Routing is an optional `inference.Router` resource; see below.
+
+## inference router
+
+The router consumes one assembly as its `target` dep and reads the route
+policy from its own `settings`:
+
+```yaml
+router:
+  kind: inference.Router
+  impl: unified
+  deps:
+    target: infer
+  settings:
+    generate:
+      - tier: fast
+        targets:
+          - model: {id: {provider: deepseek, name: deepseek-v4-flash}}
+            score: {quality: 0.8, speed: 0.9}
+    retry:
+      generate:
+        max_attempts: 2
+        max_total_attempts: 5
+        backoff: {kind: exponential, initial: 100ms, max: 2s, multiplier: 2, jitter: full}
+        retryable: [rate_limit, timeout, unavailable]
+        fallback_on_retry_exhausted: true
+    circuit_breaker:
+      failure_threshold: 5      # consecutive transient failures; default 5
+      recovery_window: 30s      # default 30s
+      half_open_max_probes: 1   # default 1
+```
+
+`generate` / `embed` / `transcription` each list `tier` pools of exact
+`model` targets plus optional `score` signals (`quality` / `economy` /
+`speed` / `reliability`, all in `[0, 1]`); scores guide selection only.
+Selection skips targets whose declared output capabilities cannot serve
+the request intent; undeclared capabilities are treated as undeclared, not
+unsupported. `retry` (per-operation, requires pools) and `circuit_breaker`
+configure resilience. Build-time validation checks every target exists,
+is not retired, and exposes the operation.
 
 ## workspace
 
@@ -55,11 +104,26 @@ Relative roots resolve against the deployment loader's base directory.
 ## sandbox
 
 ```yaml
-root: ./sandbox
+box:
+  kind: sandbox.Runner
+  impl: local
+  settings:
+    root: ./sandbox
 ```
 
-The local runner accepts a root. Platform backends (`bwrap`, `seatbelt`) are
-registered from `core/sandbox/{bwrap,seatbelt}`.
+The local runner is no-isolation and takes only `root`. The isolation
+backends (`bwrap`, `seatbelt`) share a larger settings surface:
+
+```yaml
+box:
+  kind: sandbox.Runner
+  impl: bwrap            # or seatbelt
+  settings:
+    root: ./sandbox
+    binary: /usr/bin/bwrap    # optional; resolved against the root
+    writable_paths: [./out]   # optional; paths the sandbox may write
+    extra_flags: [--die-with-parent]  # bwrap only; policy-downgrading flags are rejected
+```
 
 ## tool source / assembly
 
@@ -79,10 +143,174 @@ tools:
         tool_search: always
 ```
 
+The `middleware` impl is the same assembly with a settings-declared
+middleware chain; the `memory` impl rejects the `middlewares` key:
+
+```yaml
+tools:
+  kind: tool.Assembly
+  impl: middleware
+  deps:
+    tool: sim
+  settings:
+    middlewares:
+      recover: {enabled: true}
+      timeout: {default: 30s}
+      concurrency: {limit: 8}
+    dynamic: {default: deferred, exposures: {tool_search: always}}
+```
+
+Each middleware entry is optional; absent entries are skipped. `recover`
+converts tool panics into error results, `timeout.default` bounds each
+call (calls that already carry a deadline pass through), and
+`concurrency.limit` caps in-flight executions.
+
+MCP servers attach as a `tool.Source/mcp` resource; attach is best-effort
+with background reconnection, and `required: true` marks a server the host
+should `WaitReady` on:
+
+```yaml
+sim:
+  kind: tool.Source
+  impl: mcp
+  settings:
+    servers:
+      - name: filesystem
+        transport: stdio           # stdio | http
+        command: npx
+        args: ["-y", "@modelcontextprotocol/server-filesystem"]
+        env: {TOKEN: ${env:MCP_TOKEN}}
+        prefix: fs                  # tool namespace; default "<name>__"
+        resources: true             # bridge list_resources / read_resource tools
+        required: true
+      - name: remote
+        transport: http
+        url: https://mcp.example.com/mcp
+        headers: {Authorization: "Bearer ${env:MCP_TOKEN}"}
+        http_timeout: 30s
+```
+
 ## memory
 
 Memory implementations are app-registered. `core/memory` supplies contracts
-and hooks; each implementation owns its settings document.
+and hooks; each implementation owns its settings document. The core hooks
+bind the whole assembly as their `memory` dep:
+
+```yaml
+agents:
+  assistant:
+    prepare:
+      - type: memory.context       # hook.prepare seed hook
+        deps:
+          memory: memories
+        settings:
+          query: {literal: "relevant prior conversation"}  # or board / current_message / recent_only
+          scope: {runtime_id: memories, user_id: user-1, agent_id: assistant}
+          conversation_id: conv-1  # optional; defaults to the request ContextID
+          dataset_ids: [docs]      # optional
+          budget: {max_tokens: 2000, max_items: 50, max_chars: 8000}
+          min_score: 0.5
+          output: memory_items     # required; non-reserved board var
+          render: {output: memory_text, gotmpl: {max_chars: 8000}}
+    commit:
+      - type: memory.turn          # hook.commit durable finalizer
+        deps:
+          memory: memories
+        settings:
+          scope: {runtime_id: memories, user_id: user-1, agent_id: assistant}
+          conversation_id: conv-1  # optional; defaults to the request ContextID
+          channel: main            # optional; defaults to the main channel
+```
+
+`memory.context` requires exactly one `query` source and a non-reserved
+`output` var; recall is hard-partitioned by scope. `memory.turn` commits
+the turn's channel idempotently per run id.
+
+## event bus
+
+```yaml
+events:
+  kind: event.Bus
+  impl: memory
+  settings:
+    route_cache_size: 1024  # optional: positive caps the route cache, zero disables it
+```
+
+## script runtime
+
+```yaml
+js:
+  kind: agent.ScriptRuntime
+  impl: js
+  settings:
+    pool_size: 4              # positive; number of pooled VMs
+    max_call_stack_size: 512  # js only; positive call-stack bound
+    max_exec_time: 30s        # Go duration; zero disables the cap
+
+lua:
+  kind: agent.ScriptRuntime
+  impl: lua
+  settings:
+    pool_size: 4
+    max_exec_time: 30s
+```
+
+Script runtimes are wired into a graph engine as the `script_runtime` dep
+(see [graph.md](graph.md)).
+
+## delegation
+
+```yaml
+dir:
+  kind: delegation.Directory
+  impl: local   # no settings; binds the deployment's agents at wire time
+
+prov:
+  kind: delegation.SessionProvider
+  impl: random  # no settings; fresh ContextID per delegation, never persists
+
+svc:
+  kind: delegation.Service
+  impl: local
+  deps:
+    directory: dir
+    # backend: async            # optional delegation.AsyncBackend; absent = sync-only
+    # session_provider: prov    # optional identity policy
+  settings:
+    max_concurrency: 4          # positive; default 4
+    max_depth: 8                # positive; default 8
+    timeout: 5m                 # Go duration; zero leaves the caller's context
+    idempotency_retention: 24h  # positive; how long responses stay replayable
+    defer_workers: true         # start async workers on Start instead of at build
+
+dtools:
+  kind: tool.Source
+  impl: delegation
+  deps:
+    directory: dir  # no settings; exposes delegate / delegation_status / delegation_targets
+```
+
+Expose the service on every turn host with
+`runtime.Builder.WithResultHostFactory` plus `delegation/hostwrap`; the
+directory binds the current deployment generation, so reloads delegate
+against the new generation's agents.
+
+## checkpoint store
+
+```yaml
+cps:
+  kind: checkpoint.Store
+  impl: workspace
+  deps:
+    workspace: ws
+  settings:
+    prefix: agent/checkpoints  # optional; default "agent/checkpoints"
+```
+
+`runtime.checkpoint_store` names a resource implementing the
+`agent.CheckpointStore` contract; `sessions.resume` requires one (see
+[runtime.md](runtime.md)). Alternative backends are app-registered outside
+`core/` and own their settings schema.
 
 ## graph
 

--- a/skills/flowcraft-config/references/runtime.md
+++ b/skills/flowcraft-config/references/runtime.md
@@ -29,8 +29,9 @@ runtime:
   the name against the built resources).
 - `checkpoint_store`, when present, must name a resource whose built
   value implements the `agent.CheckpointStore` contract — the document
-  kind can be `checkpoint.Store` (workspace) or `agent.CheckpointStore`
-  (sqlite) (host build resolves it; the validator checks `resume` rules).
+  kind is `checkpoint.Store` (workspace) in core; alternative backends
+  are app-registered outside `core/` (host build resolves it; the
+  validator checks `resume` rules).
 - `sessions.resume: true` requires `checkpoint_store` — **validator**.
 - `sessions.sink_buffer`, `delivery_concurrency`,
   `speculative_buffer_events`, and `speculative_buffer_bytes` are validated
@@ -39,9 +40,11 @@ runtime:
 - `dynamic_catalog.tools` maps agent IDs to `tool.Assembly` resources; the
   reserved `default` key is an optional fallback. Every deployed agent must
   be mapped directly or covered by `default` (host build/runtime
-  registration; the validator only checks the map is non-empty). The
-  mapping is live: agents registered at runtime attach a tool assembly via
-  `WithToolAssembly` (see below) or fall back to `default`.
+  registration; the validator only checks the map is non-empty). Mapping
+  keys must name deployed agents — an unknown key fails the build
+  (`no such deployed agent`). The mapping is live: agents registered at
+  runtime attach a tool assembly via `WithToolAssembly` (see below) or
+  fall back to `default`.
 
 ## Dynamic agent registration (core/v0.1.11+)
 
@@ -80,7 +83,18 @@ Rules:
 - `runtime.agent.<id>.registered` / `.removed` lifecycle events are
   published on success (subscribe with `PatternAgentLifecycle()`).
 
+## Runtime reload (core/v0.1.14+)
+
+`Runtime.Reload` transactionally replaces the deployment document without
+rebuilding the runtime: the previous generation keeps serving until the
+new one is built and swapped. Progress is published as
+`runtime.rebuild.started` / `.completed` / `.failed` events
+(`SubjectRuntimeRebuild*`, subscribe with `PatternRuntimeRebuild()`); a
+failed reload aborts before any swap and the old generation stays in
+service.
+
 ## Sources of truth
 
-`core/runtime/config.go`, `core/runtime/doc.go`, `core/runtime/lifecycle.go`,
+`core/runtime/config.go`, `core/runtime/lifecycle.go`,
+`core/runtime/reload.go`, `core/runtime/events.go`,
 `docs/guides/runtime.md`.

--- a/skills/flowcraft-config/scripts/validator/go.mod
+++ b/skills/flowcraft-config/scripts/validator/go.mod
@@ -2,7 +2,7 @@ module github.com/GizClaw/flowcraft/skills/flowcraft-config/scripts/validator
 
 go 1.26.0
 
-require github.com/GizClaw/flowcraft/core v0.1.13
+require github.com/GizClaw/flowcraft/core v0.1.23
 
 require (
 	github.com/cenkalti/backoff/v5 v5.0.3 // indirect

--- a/skills/flowcraft-config/scripts/validator/go.sum
+++ b/skills/flowcraft-config/scripts/validator/go.sum
@@ -1,5 +1,5 @@
-github.com/GizClaw/flowcraft/core v0.1.13 h1:Ld0Kmxr3GPsDFwX3sb8bKDeznjiJKgMm2I6yZiDJTSk=
-github.com/GizClaw/flowcraft/core v0.1.13/go.mod h1:t4e1E55RSCsZTDGLCKLeg0Qags72Y2Yz2ZtL3EyGy1k=
+github.com/GizClaw/flowcraft/core v0.1.23 h1:mqu3DB6Ibub77Q3bm1vBCvEWkam40GNU5+MIvO5uhac=
+github.com/GizClaw/flowcraft/core v0.1.23/go.mod h1:ivaKWysWMtv3j0fj4059RWiSP8kNXBFDYDaFD80Gr74=
 github.com/cenkalti/backoff/v5 v5.0.3 h1:ZN+IMa753KfX5hd8vVaMixjnqRZ3y8CuJKRKj1xcsSM=
 github.com/cenkalti/backoff/v5 v5.0.3/go.mod h1:rkhZdG3JZukswDf7f0cwqPNk4K0sa+F97BxZthm/crw=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=


### PR DESCRIPTION
## Summary

Syncs `docs/guides/` and the `flowcraft-config` skill with the current core module (v0.1.23) and fills documentation gaps found by reviewing resource settings and script bridges against the code.

## Changes

- **Validator pin**: bump `skills/flowcraft-config/scripts/validator` from core v0.1.13 to v0.1.23 (go.mod/go.sum regenerated; minimal-deploy still validates).
- **Skill reference cards aligned with current schemas**: inference node `intent` envelope (legacy sampling/reasoning/response-format keys removed), `finish`/`provider_outputs` emit types, custom `graph.NodeType` resources, provider model `capabilities`, route policy, MCP servers, bwrap/seatbelt sandbox, memory hooks, delegation/checkpoint resources.
- **Guides**: new Routing section (`inference.Router` policy: pools/retry/circuit-breaker), MCP and sandbox backend settings, memory `memory.context`/`memory.turn` hook settings, script runtimes, runtime `Reload` + `runtime.rebuild.*` events, new Delegation guide; document `board.resolve`/`resolveString` and the `inference.transcribe*` script bridge methods.
- **Docs scoped to core/**: removed `backends/` module content (sqlite checkpoint) and non-core path references from guides/skill.
- **Fix**: correct the stale `core/runtime/reload.go` doc comment (system resources are per-generation, not pinned).

## Validation

- `make ci` ✓ (vet + test across all modules)
- `make release-check` ✓ (no pending releases; no changeset added — no module is tagged)
- `git diff --check` ✓
- `make lint` fails locally with a golangci-lint v2.12.2 panic (`file requires newer Go version go1.27`); reproduced on clean `main`, so it is a local toolchain mismatch unrelated to this PR (CI runs its own lint lane).
- `validate-config.sh` passes against `assets/minimal-deploy` with the bumped pin.