### PR TITLE
feat: add telemetry log records across core and driver inference paths

### DIFF
--- a/core/agent/a2a/engine.go
+++ b/core/agent/a2a/engine.go
@@ -118,20 +118,46 @@ func (e *Engine) Execute(ctx context.Context, run agent.Run, host agent.Host, bo
 	}
 	ctx, span := telemetry.Tracer().Start(ctx, "a2a.execute", trace.WithAttributes(spanAttrs...))
 	started := time.Now()
+	runLogAttrs := []otellog.KeyValue{
+		otellog.String(telemetry.AttrEngineKind, engineKind),
+		otellog.String(telemetry.AttrRunID, run.RunID),
+		otellog.String(telemetry.AttrAgentID, run.AgentID),
+	}
+	if run.TaskID != "" {
+		runLogAttrs = append(runLogAttrs, otellog.String(telemetry.AttrTaskID, run.TaskID))
+	}
+	telemetry.Info(ctx, "a2a run started", runLogAttrs...)
 	defer func() {
 		status := execStatus(runErr)
 		span.SetAttributes(attribute.String(telemetry.AttrRunStatus, status))
-		if runErr != nil && !errdefs.IsInterrupted(runErr) {
-			span.RecordError(runErr)
-			span.SetStatus(codes.Error, runErr.Error())
+		if runErr != nil {
+			attrs := append([]otellog.KeyValue(nil), runLogAttrs...)
+			attrs = append(attrs, otellog.String(telemetry.AttrRunStatus, status))
+			switch {
+			case errdefs.IsInterrupted(runErr):
+				span.SetStatus(codes.Ok, status)
+				telemetry.Warn(ctx, "a2a run interrupted", attrs...)
+			case errors.Is(runErr, context.Canceled), errors.Is(runErr, context.DeadlineExceeded):
+				span.SetStatus(codes.Ok, status)
+				telemetry.Warn(ctx, "a2a run canceled", attrs...)
+			default:
+				span.RecordError(runErr)
+				span.SetStatus(codes.Error, runErr.Error())
+				attrs = append(attrs, otellog.String(telemetry.AttrErrorMessage, runErr.Error()))
+				telemetry.Error(ctx, "a2a run failed", attrs...)
+			}
 		} else {
 			span.SetStatus(codes.Ok, status)
+			telemetry.Info(ctx, "a2a run completed", append([]otellog.KeyValue(nil), runLogAttrs...)...)
 		}
 		span.End()
 		recordExec(ctx, run, status, time.Since(started))
 	}()
 
-	_ = publishRunEvent(ctx, host, run, agent.SubjectRunStart(run.RunID), nil)
+	if err := publishRunEvent(ctx, host, run, agent.SubjectRunStart(run.RunID), nil); err != nil {
+		telemetry.WarnErr(ctx, "a2a: run start event publish failed", err,
+			otellog.String(telemetry.AttrRunID, run.RunID))
+	}
 	defer func() {
 		publishCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), runEndPublishTimeout)
 		defer cancel()
@@ -140,6 +166,8 @@ func (e *Engine) Execute(ctx context.Context, run agent.Run, host agent.Host, bo
 				attribute.String("event.kind", "run_end"),
 				attribute.String(telemetry.AttrRunID, run.RunID),
 			))
+			telemetry.WarnErr(ctx, "a2a: run end event publish failed", err,
+				otellog.String(telemetry.AttrRunID, run.RunID))
 		}
 	}()
 
@@ -382,7 +410,12 @@ func (x *executor) cancelRemote() {
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), cancelTimeout)
 	defer cancel()
-	_, _ = x.client.CancelTask(x.eng.opts.rpcCtx(ctx), &a2aprotocol.CancelTaskRequest{ID: x.taskID})
+	_, err := x.client.CancelTask(x.eng.opts.rpcCtx(ctx), &a2aprotocol.CancelTaskRequest{ID: x.taskID})
+	if err != nil {
+		telemetry.WarnErr(ctx, "a2a: best-effort remote task cancel failed", err,
+			otellog.String(telemetry.AttrRunID, x.run.RunID),
+			otellog.String("a2a.task_id", string(x.taskID)))
+	}
 }
 
 // handleEvent dispatches one streaming event.
@@ -632,9 +665,12 @@ func (x *executor) appendAgentMessage(ctx context.Context, m *a2aprotocol.Messag
 	if x.streaming {
 		for _, p := range parts {
 			if tp, ok := p.(message.TextPart); ok {
-				_ = agent.EmitStreamDelta(ctx, x.host, x.run.RunID,
+				if err := agent.EmitStreamDelta(ctx, x.host, x.run.RunID,
 					stepActorFor(x.run.AgentID),
-					agent.StreamDeltaPayload{Type: agent.StreamDeltaPart, Part: tp})
+					agent.StreamDeltaPayload{Type: agent.StreamDeltaPart, Part: tp}); err != nil {
+					telemetry.WarnErr(ctx, "a2a: stream delta publish failed", err,
+						otellog.String(telemetry.AttrRunID, x.run.RunID))
+				}
 			}
 		}
 	}
@@ -665,7 +701,8 @@ func (x *executor) checkpoint(ctx context.Context) {
 		Seen:      seenIDs(x.seen),
 	})
 	if err != nil {
-		telemetry.Warn(ctx, "a2a: failed to encode checkpoint payload", otellog.String("error", err.Error()))
+		telemetry.Warn(ctx, "a2a: failed to encode checkpoint payload",
+			otellog.String(telemetry.AttrErrorMessage, err.Error()))
 		return
 	}
 	cp := agent.Checkpoint{
@@ -682,7 +719,8 @@ func (x *executor) checkpoint(ctx context.Context) {
 		cp.OriginalStartedAt = time.Now()
 	}
 	if err := x.host.Checkpoint(ctx, cp); err != nil {
-		telemetry.Warn(ctx, "a2a: checkpoint rejected by host", otellog.String("error", err.Error()))
+		telemetry.Warn(ctx, "a2a: checkpoint rejected by host",
+			otellog.String(telemetry.AttrErrorMessage, err.Error()))
 	}
 }
 
@@ -859,7 +897,11 @@ func publishStepEvent(ctx context.Context, host agent.Host, run agent.Run, subje
 	}
 	env.SetAgentID(run.AgentID)
 	env.SetRunID(run.RunID)
-	_ = host.Publish(ctx, env)
+	if err := host.Publish(ctx, env); err != nil {
+		telemetry.WarnErr(ctx, "a2a: step event publish failed", err,
+			otellog.String("event.subject", string(env.Subject)),
+			otellog.String(telemetry.AttrRunID, run.RunID))
+	}
 }
 
 // ---------- telemetry ----------

--- a/core/agent/checkpoint/workspace/workspace.go
+++ b/core/agent/checkpoint/workspace/workspace.go
@@ -22,7 +22,10 @@ import (
 
 	"github.com/GizClaw/flowcraft/core/agent"
 	"github.com/GizClaw/flowcraft/core/errdefs"
+	"github.com/GizClaw/flowcraft/core/telemetry"
 	"github.com/GizClaw/flowcraft/core/workspace"
+
+	otellog "go.opentelemetry.io/otel/log"
 )
 
 const defaultPrefix = "agent/checkpoints"
@@ -87,7 +90,10 @@ func (s *Store) Save(ctx context.Context, cp agent.Checkpoint) error {
 		return fmt.Errorf("workspace checkpoint: write temp: %w", err)
 	}
 	if err := s.ws.Rename(ctx, tmp, s.livePath(cp.ExecID)); err != nil {
-		_ = s.ws.Delete(ctx, tmp)
+		if derr := s.ws.Delete(ctx, tmp); derr != nil {
+			telemetry.WarnErr(ctx, "workspace checkpoint: cleanup temp after publish failure failed", derr,
+				otellog.String("workspace.checkpoint.exec", cp.ExecID))
+		}
 		return fmt.Errorf("workspace checkpoint: publish %s: %w", cp.ExecID, err)
 	}
 	return nil

--- a/core/agent/close.go
+++ b/core/agent/close.go
@@ -1,8 +1,13 @@
 package agent
 
 import (
+	"context"
 	"errors"
 	"io"
+
+	"github.com/GizClaw/flowcraft/core/telemetry"
+
+	otellog "go.opentelemetry.io/otel/log"
 )
 
 // Close releases the resources held by the agent's engine and lifecycle
@@ -20,7 +25,17 @@ func (a *Agent) Close() error {
 	closeSlice(&errs, a.Observe)
 	closeSlice(&errs, a.Referees)
 	closeSlice(&errs, a.Commit)
-	return errors.Join(errs...)
+	err := errors.Join(errs...)
+	if err != nil {
+		attrs := []otellog.KeyValue{
+			otellog.String(telemetry.AttrErrorMessage, err.Error()),
+		}
+		if a.ID != "" {
+			attrs = append(attrs, otellog.String(telemetry.AttrAgentID, a.ID))
+		}
+		telemetry.Error(context.Background(), "agent close failed", attrs...)
+	}
+	return err
 }
 
 func closeSlice[T any](errs *[]error, values []T) {

--- a/core/agent/execute.go
+++ b/core/agent/execute.go
@@ -11,6 +11,9 @@ import (
 
 	"github.com/GizClaw/flowcraft/core/errdefs"
 	"github.com/GizClaw/flowcraft/core/message"
+	"github.com/GizClaw/flowcraft/core/telemetry"
+
+	otellog "go.opentelemetry.io/otel/log"
 )
 
 // Execute executes one turn of ag against eng with the given req.
@@ -124,6 +127,21 @@ func Execute(
 	toolAllowList = append([]string(nil), toolAllowList...)
 	obs := composeObservers(rc.hooks)
 
+	runLogAttrs := func() []otellog.KeyValue {
+		attrs := []otellog.KeyValue{
+			otellog.String(telemetry.AttrAgentID, id.AgentID),
+			otellog.String(telemetry.AttrRunID, id.RunID),
+		}
+		if id.TaskID != "" {
+			attrs = append(attrs, otellog.String(telemetry.AttrTaskID, id.TaskID))
+		}
+		if id.ConversationID != "" {
+			attrs = append(attrs, otellog.String(telemetry.AttrConversationID, id.ConversationID))
+		}
+		return attrs
+	}
+	telemetry.Info(ctx, "agent run started", runLogAttrs()...)
+
 	// Revise loop: each iteration is one Execute attempt
 	// followed by Referee chain. Loop exits when a Referee does
 	// not ask for revise OR the attempt counter reaches the
@@ -147,9 +165,11 @@ func Execute(
 		// error so callers do not silently see stale Messages.
 		board, err := seedBoard(ctx, id, &req, rc.preparers)
 		if err != nil {
+			logRunError(ctx, id, "agent run seed failed", err)
 			return nil, fmt.Errorf("agent: seed board (attempt %d): %w", attempt, err)
 		}
 		if board == nil {
+			logRunError(ctx, id, "agent run seed returned nil board", errdefs.Validationf("agent: Preparer chain returned nil board"))
 			return nil, errdefs.Validationf("agent: Preparer chain returned nil board")
 		}
 		// Messages at or before this index are seed/context, never output
@@ -267,6 +287,10 @@ func Execute(
 		if obs != nil {
 			obs.OnRunRevise(ctx, id, res, attempt+1)
 		}
+		attrs := append(runLogAttrs(),
+			otellog.Int("agent.attempt", attempt),
+			otellog.String(telemetry.AttrRunStatus, string(res.Status)))
+		telemetry.Warn(ctx, "agent run revised and will retry", attrs...)
 	}
 
 	if execDecided {
@@ -275,6 +299,7 @@ func Execute(
 		if obs != nil {
 			obs.OnRunEnd(ctx, id, res)
 		}
+		logRunError(ctx, id, "agent run referee failed", decErr)
 		return res, decErr
 	}
 
@@ -296,6 +321,7 @@ func Execute(
 			if obs != nil {
 				obs.OnRunEnd(ctx, id, res)
 			}
+			logRunError(ctx, id, "agent run history materialize failed", err)
 			return res, fmt.Errorf("agent: materialize history: %w", err)
 		}
 	}
@@ -309,6 +335,7 @@ func Execute(
 				if obs != nil {
 					obs.OnRunEnd(ctx, id, res)
 				}
+				logRunError(ctx, id, "agent run commit view failed", err)
 				return res, fmt.Errorf("agent: provide commit view: %w", err)
 			}
 			if view.LastBoard == nil {
@@ -317,6 +344,8 @@ func Execute(
 				if obs != nil {
 					obs.OnRunEnd(ctx, id, res)
 				}
+				logRunError(ctx, id, "agent run commit view returned nil board",
+					errdefs.Validationf("agent: CommitViewProvider returned nil board"))
 				return res, errdefs.Validationf("agent: CommitViewProvider returned nil board")
 			}
 			if err := materializeHistory(ctx, view.LastBoard); err != nil {
@@ -325,6 +354,7 @@ func Execute(
 				if obs != nil {
 					obs.OnRunEnd(ctx, id, res)
 				}
+				logRunError(ctx, id, "agent run commit view materialize failed", err)
 				return res, fmt.Errorf("agent: materialize commit view: %w", err)
 			}
 			projected := *res
@@ -340,6 +370,7 @@ func Execute(
 			if obs != nil {
 				obs.OnRunEnd(ctx, id, res)
 			}
+			logRunError(ctx, id, "agent run commit failed", err)
 			return res, fmt.Errorf("agent: commit result: %w", err)
 		}
 	}
@@ -347,8 +378,57 @@ func Execute(
 	if obs != nil {
 		obs.OnRunEnd(ctx, id, res)
 	}
+	logRunOutcome(ctx, id, res, runLogAttrs)
 
 	return res, nil
+}
+
+// logRunError records an infrastructure failure that turns Execute into
+// a (nil/partial result, err) return. Callers already receive the error,
+// so the log record carries the correlation attributes for dashboards.
+func logRunError(ctx context.Context, id Identity, msg string, err error) {
+	if err == nil {
+		return
+	}
+	attrs := []otellog.KeyValue{
+		otellog.String(telemetry.AttrAgentID, id.AgentID),
+		otellog.String(telemetry.AttrRunID, id.RunID),
+		otellog.String(telemetry.AttrErrorMessage, err.Error()),
+	}
+	if id.TaskID != "" {
+		attrs = append(attrs, otellog.String(telemetry.AttrTaskID, id.TaskID))
+	}
+	telemetry.Error(ctx, msg, attrs...)
+}
+
+// logRunOutcome records the terminal status of one Execute call so the
+// agent layer is visible in logs even when the engine logs nothing.
+func logRunOutcome(ctx context.Context, id Identity, res *Result, base func() []otellog.KeyValue) {
+	if res == nil {
+		return
+	}
+	attrs := append(base(), otellog.String(telemetry.AttrRunStatus, string(res.Status)))
+	attrs = append(attrs,
+		otellog.Int("agent.attempts", res.Attempts),
+		otellog.Bool("agent.committed", res.Committed))
+	if res.Err != nil {
+		attrs = append(attrs, otellog.String(telemetry.AttrErrorMessage, res.Err.Error()))
+	}
+	switch res.Status {
+	case StatusCompleted:
+		telemetry.Info(ctx, "agent run completed", attrs...)
+	case StatusInterrupted:
+		if res.Cause != "" {
+			attrs = append(attrs, otellog.String("agent.cause", string(res.Cause)))
+		}
+		telemetry.Warn(ctx, "agent run interrupted", attrs...)
+	case StatusCanceled:
+		telemetry.Warn(ctx, "agent run canceled", attrs...)
+	case StatusAborted:
+		telemetry.Error(ctx, "agent run aborted", attrs...)
+	default:
+		telemetry.Error(ctx, "agent run failed", attrs...)
+	}
 }
 
 // materializeResult derives every board-backed Result field from board.

--- a/core/delegation/kanban/events.go
+++ b/core/delegation/kanban/events.go
@@ -6,6 +6,9 @@ import (
 
 	"github.com/GizClaw/flowcraft/core/delegation"
 	"github.com/GizClaw/flowcraft/core/event"
+	"github.com/GizClaw/flowcraft/core/telemetry"
+
+	otellog "go.opentelemetry.io/otel/log"
 )
 
 const (
@@ -106,7 +109,11 @@ func (b *Board) publish(ctx context.Context, snapshot *Card) {
 	if b.scopeID != "" {
 		SetKanbanScopeID(&envelope, b.scopeID)
 	}
-	_ = b.bus.Publish(ctx, envelope)
+	if err := b.bus.Publish(ctx, envelope); err != nil {
+		telemetry.WarnErr(ctx, "delegation kanban: card event publish failed", err,
+			otellog.String("event.subject", string(envelope.Subject)),
+			otellog.String("delegation.card", snapshot.ID))
+	}
 }
 
 const cardSubjectPrefix = "delegation.kanban.card."

--- a/core/delegation/kanban/kanban.go
+++ b/core/delegation/kanban/kanban.go
@@ -12,6 +12,9 @@ import (
 	"github.com/GizClaw/flowcraft/core/delegation"
 	"github.com/GizClaw/flowcraft/core/errdefs"
 	"github.com/GizClaw/flowcraft/core/event"
+	"github.com/GizClaw/flowcraft/core/telemetry"
+
+	otellog "go.opentelemetry.io/otel/log"
 )
 
 const (
@@ -609,6 +612,9 @@ func (b *Board) evictLocked() {
 			if card.Status.IsTerminal() && now.Sub(card.UpdatedAt) > b.cardTTL {
 				b.removeCardLocked(card)
 				b.statusCount[card.Status]--
+				telemetry.Debug(b.ctx, "delegation kanban: card evicted by ttl",
+					otellog.String("delegation.scope", b.scopeID),
+					otellog.String("delegation.card", card.ID))
 				continue
 			}
 			kept = append(kept, card)
@@ -624,6 +630,9 @@ func (b *Board) evictLocked() {
 		if excess > 0 && card.Status.IsTerminal() {
 			b.removeCardLocked(card)
 			b.statusCount[card.Status]--
+			telemetry.Debug(b.ctx, "delegation kanban: card evicted by card cap",
+				otellog.String("delegation.scope", b.scopeID),
+				otellog.String("delegation.card", card.ID))
 			excess--
 			continue
 		}
@@ -676,6 +685,9 @@ func (b *Board) expireRetainedLocked(now time.Time) {
 		if key != "" && b.idempotency[key] == retained {
 			delete(b.idempotency, key)
 		}
+		telemetry.Debug(b.ctx, "delegation kanban: retained result expired",
+			otellog.String("delegation.scope", b.scopeID),
+			otellog.String("delegation.card", id))
 	}
 }
 

--- a/core/delegation/service.go
+++ b/core/delegation/service.go
@@ -601,6 +601,9 @@ func (s *LocalService) worker() {
 				return
 			}
 			claimFailures++
+			telemetry.Warn(s.workerCtx, "local delegation: claim work failed, will retry",
+				otellog.Int("delegation.claim_failures", claimFailures),
+				otellog.String(telemetry.AttrErrorMessage, err.Error()))
 			continue
 		}
 		claimFailures = 0
@@ -649,6 +652,8 @@ func (s *LocalService) recordWorkerError(err error) {
 	if err == nil {
 		return
 	}
+	telemetry.Error(context.Background(), "local delegation: worker stopped after error",
+		otellog.String(telemetry.AttrErrorMessage, err.Error()))
 	s.stateMu.Lock()
 	s.workerErrs = append(s.workerErrs, err)
 	s.closed = true
@@ -730,7 +735,13 @@ func (s *LocalService) runAt(ctx context.Context, req AsyncRequest, reuseSlot bo
 	if err != nil {
 		return Response{}, err
 	}
-	defer func() { _ = lease.Close() }()
+	defer func() {
+		if cerr := lease.Close(); cerr != nil {
+			telemetry.WarnErr(execCtx, "local delegation: close session lease failed", cerr,
+				otellog.String(telemetry.AttrAgentID, key.AgentID),
+				otellog.String(telemetry.AttrConversationID, key.ContextID))
+		}
+	}()
 
 	turn, err := lease.Session().StartWithOptions(execCtx, agent.Request{
 		ContextID: key.ContextID,

--- a/core/deploy/builder.go
+++ b/core/deploy/builder.go
@@ -12,6 +12,7 @@ import (
 	"github.com/GizClaw/flowcraft/core/agent"
 	"github.com/GizClaw/flowcraft/core/errdefs"
 	"github.com/GizClaw/flowcraft/core/resource"
+	"github.com/GizClaw/flowcraft/core/telemetry"
 	"github.com/GizClaw/flowcraft/core/utils"
 )
 
@@ -72,27 +73,27 @@ func (b *Builder) Build(ctx context.Context, doc Document) (*Result, error) {
 		res := doc.Resources[name]
 		factory, ok := b.registry.Lookup(res.Kind, res.Impl)
 		if !ok {
-			_ = closeAll(values, order, nil)
+			logCleanup(ctx, values, order)
 			return nil, errdefs.Validationf(
 				"deploy: resource %q: no factory for %s/%s",
 				name, res.Kind, res.Impl)
 		}
 		if err := validateDeps(factory, res.Deps); err != nil {
-			_ = closeAll(values, order, nil)
+			logCleanup(ctx, values, order)
 			return nil, errdefs.Validationf("deploy: resource %q: %v", name, err)
 		}
 		settings := res.Settings
 		if b.loader != nil {
 			settings, err = resolveSettings(ctx, b.loader, settings)
 			if err != nil {
-				_ = closeAll(values, order, nil)
+				logCleanup(ctx, values, order)
 				return nil, errdefs.Validationf(
 					"deploy: resource %q: %v", name, err)
 			}
 		}
 		deps, err := resolveDeps(values, res.Deps)
 		if err != nil {
-			_ = closeAll(values, order, nil)
+			logCleanup(ctx, values, order)
 			return nil, errdefs.Validationf("deploy: resource %q: %v", name, err)
 		}
 		value, err := factory.New(ctx, resource.Input{
@@ -101,7 +102,7 @@ func (b *Builder) Build(ctx context.Context, doc Document) (*Result, error) {
 			Loader:   b.loader,
 		})
 		if err != nil {
-			_ = closeAll(values, order, nil)
+			logCleanup(ctx, values, order)
 			return nil, errdefs.Validationf("deploy: resource %q: %v", name, err)
 		}
 		values[name] = value
@@ -195,10 +196,20 @@ func (b *Builder) Deploy(ctx context.Context, doc Document) (*Result, error) {
 		return nil, err
 	}
 	if err := b.Wire(ctx, result, doc); err != nil {
-		_ = result.Close()
+		if cerr := result.Close(); cerr != nil {
+			telemetry.WarnErr(ctx, "deploy: close built deployment after wire failure", cerr)
+		}
 		return nil, err
 	}
 	return result, nil
+}
+
+// logCleanup rolls back partially built resources on a Build failure
+// and leaves any close error visible to telemetry.
+func logCleanup(ctx context.Context, values map[string]any, order []string) {
+	if err := closeAll(values, order, nil); err != nil {
+		telemetry.WarnErr(ctx, "deploy: close partially built resources after failure", err)
+	}
 }
 
 // bindAgents constructs every [agent.Agent] from its Definition and
@@ -396,7 +407,10 @@ func closeAgentParts(values []any) {
 			continue
 		}
 		if closer, ok := value.(io.Closer); ok {
-			_ = closer.Close()
+			if err := closer.Close(); err != nil {
+				telemetry.WarnErr(context.Background(),
+					"deploy: close agent part failed", err)
+			}
 		}
 	}
 }

--- a/core/event/memory.go
+++ b/core/event/memory.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 	"math/rand/v2"
+	"sort"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -385,7 +387,7 @@ func (b *MemoryBus) Publish(ctx context.Context, env Envelope) error {
 			case <-ctx.Done():
 				sub.senders.Done()
 				// Re-acquire to keep the loop invariant before bailing.
-				b.fireObserver(env, delivers, drops)
+				b.fireObserver(ctx, env, delivers, drops)
 				return errdefs.FromContext(ctx.Err())
 			}
 			sub.senders.Done()
@@ -393,7 +395,7 @@ func (b *MemoryBus) Publish(ctx context.Context, env Envelope) error {
 			// b.closed may have flipped; if so, stop scanning.
 			if b.closed {
 				b.mu.RUnlock()
-				b.fireObserver(env, delivers, drops)
+				b.fireObserver(ctx, env, delivers, drops)
 				return ErrBusClosed
 			}
 			continue
@@ -452,13 +454,22 @@ func (b *MemoryBus) Publish(ctx context.Context, env Envelope) error {
 	}
 	b.mu.RUnlock()
 
-	b.fireObserver(env, delivers, drops)
+	b.fireObserver(ctx, env, delivers, drops)
 	return nil
 }
 
 // fireObserver invokes the configured observer outside any bus lock.
-func (b *MemoryBus) fireObserver(env Envelope, delivers []deliverCb, drops []dropCb) {
+func (b *MemoryBus) fireObserver(ctx context.Context, env Envelope, delivers []deliverCb, drops []dropCb) {
 	if b.observer == nil {
+		// Without an observer the drop is otherwise invisible: log a
+		// Debug record so buffer-full / closed drops stay diagnosable
+		// without paying the cost on the hot path.
+		if len(drops) > 0 {
+			telemetry.Debug(ctx, "event memory: envelope dropped, no observer attached",
+				otellog.String("event.subject", string(env.Subject)),
+				otellog.Int("event.drops", len(drops)),
+				otellog.String("event.drop_reasons", summarizeDropReasons(drops)))
+		}
 		return
 	}
 	b.observer.OnPublish(env)
@@ -468,6 +479,23 @@ func (b *MemoryBus) fireObserver(env Envelope, delivers []deliverCb, drops []dro
 	for _, d := range drops {
 		b.observer.OnDrop(d.subID, env, d.reason)
 	}
+}
+
+func summarizeDropReasons(drops []dropCb) string {
+	seen := make(map[DropReason]int, len(drops))
+	for _, d := range drops {
+		seen[d.reason]++
+	}
+	keys := make([]DropReason, 0, len(seen))
+	for reason := range seen {
+		keys = append(keys, reason)
+	}
+	sort.Slice(keys, func(i, j int) bool { return keys[i] < keys[j] })
+	var parts []string
+	for _, reason := range keys {
+		parts = append(parts, fmt.Sprintf("%s=%d", reason, seen[reason]))
+	}
+	return strings.Join(parts, ",")
 }
 
 // Subscribe creates a subscription. pattern is validated; ctx cancellation

--- a/core/event/router.go
+++ b/core/event/router.go
@@ -6,6 +6,9 @@ import (
 	"sync"
 
 	"github.com/GizClaw/flowcraft/core/errdefs"
+	"github.com/GizClaw/flowcraft/core/telemetry"
+
+	otellog "go.opentelemetry.io/otel/log"
 )
 
 // Sink receives one envelope from a Router attachment. Implementations
@@ -151,7 +154,7 @@ func (r *Router) AddBus(bus Bus) error {
 		sub, err := bus.Subscribe(a.ctx, a.pattern, a.subOpts...)
 		if err != nil {
 			for _, bs := range subs {
-				_ = bs.sub.Close()
+				logSubClose(bs.sub)
 			}
 			r.mu.Unlock()
 			return err
@@ -197,7 +200,7 @@ func (r *Router) RemoveBus(bus Bus) error {
 	}
 	r.mu.Unlock()
 	for _, sub := range closed {
-		_ = sub.Close()
+		logSubClose(sub)
 	}
 	return nil
 }
@@ -263,7 +266,7 @@ func (r *Router) Attach(
 		sub, err := bus.Subscribe(ctx, pattern, subOpts...)
 		if err != nil {
 			for _, bs := range subs {
-				_ = bs.sub.Close()
+				logSubClose(bs.sub)
 			}
 			delete(r.attachments, a.id)
 			r.mu.Unlock()
@@ -305,7 +308,7 @@ func (r *Router) Close() error {
 	r.mu.Unlock()
 
 	for _, sub := range subs {
-		_ = sub.Close()
+		logSubClose(sub)
 	}
 	r.wg.Wait()
 	return nil
@@ -322,12 +325,25 @@ func (r *Router) detach(a *routerAttachment, cause error) {
 		a.subs = nil
 		r.mu.Unlock()
 		for _, bs := range subs {
-			_ = bs.sub.Close()
+			logSubClose(bs.sub)
 		}
 		if cause != nil && a.onDetach != nil {
 			a.onDetach(cause)
 		}
 	})
+}
+
+// logSubClose best-effort closes a subscription and leaves a failed
+// close visible to telemetry.
+func logSubClose(sub Subscription) {
+	if sub == nil {
+		return
+	}
+	if err := sub.Close(); err != nil {
+		telemetry.WarnErr(context.Background(),
+			"event router: close subscription failed", err,
+			otellog.String("event.subscription", string(sub.ID())))
+	}
 }
 
 type routerAttachment struct {

--- a/core/graph/execute.go
+++ b/core/graph/execute.go
@@ -70,6 +70,24 @@ func (g *Graph) Execute(ctx context.Context, run agent.Run, host agent.Host, boa
 		} else {
 			span.SetStatus(codes.Ok, status)
 		}
+		if runErr != nil {
+			runLogAttrs := []otellog.KeyValue{
+				otellog.String(telemetry.AttrGraphName, g.name),
+				otellog.String(telemetry.AttrRunID, run.RunID),
+				otellog.String(telemetry.AttrErrorMessage, runErr.Error()),
+			}
+			runLogAttrs = append(runLogAttrs, runScopeLogAttrs(run)...)
+			switch {
+			case isInterruptedErr(runErr):
+				telemetry.Warn(ctx, "graph execution interrupted", runLogAttrs...)
+			case errdefs.IsTimeout(runErr):
+				telemetry.Warn(ctx, "graph execution timed out", runLogAttrs...)
+			case errdefs.IsAborted(runErr):
+				telemetry.Error(ctx, "graph execution aborted", runLogAttrs...)
+			default:
+				telemetry.Error(ctx, "graph execution failed", runLogAttrs...)
+			}
+		}
 		span.End()
 		recordGraphExec(ctx, g, run, status, time.Since(graphStart))
 	}()
@@ -80,7 +98,11 @@ func (g *Graph) Execute(ctx context.Context, run agent.Run, host agent.Host, boa
 		defer cancel()
 	}
 
-	_ = publishRunEvent(ctx, host, g, run, agent.SubjectRunStart(run.RunID), nil)
+	if err := publishRunEvent(ctx, host, g, run, agent.SubjectRunStart(run.RunID), nil); err != nil {
+		telemetry.WarnErr(ctx, "graph: run start event publish failed", err,
+			otellog.String(telemetry.AttrGraphName, g.name),
+			otellog.String(telemetry.AttrRunID, run.RunID))
+	}
 	defer func() {
 		publishCtx, cancel := context.WithTimeout(
 			context.WithoutCancel(ctx),
@@ -160,13 +182,6 @@ func (g *Graph) Execute(ctx context.Context, run agent.Run, host agent.Host, boa
 				g.name, g.maxIterations)
 		}
 		if err := g.executeWave(ctx, run, host, board, wave, iterations); err != nil {
-			errorLogAttrs := []otellog.KeyValue{
-				otellog.String(telemetry.AttrGraphName, g.name),
-				otellog.String(telemetry.AttrRunID, run.RunID),
-				otellog.String(telemetry.AttrErrorMessage, err.Error()),
-			}
-			errorLogAttrs = append(errorLogAttrs, runScopeLogAttrs(run)...)
-			telemetry.Error(ctx, "graph execution failed", errorLogAttrs...)
 			return retBoard, err
 		}
 		if ctx.Err() != nil {
@@ -295,6 +310,11 @@ func (g *Graph) invokeNode(ctx context.Context, run agent.Run, host agent.Host, 
 		if invokeErr == nil || !isRetryable(invokeErr) || attempt >= g.maxNodeRetries {
 			break
 		}
+		telemetry.Debug(ctx, "graph node attempt failed, will retry",
+			otellog.String(telemetry.AttrGraphName, g.name),
+			otellog.String(telemetry.AttrNodeID, nodeID),
+			otellog.Int("graph.node.attempt", attempt+1),
+			otellog.String(telemetry.AttrErrorMessage, invokeErr.Error()))
 		// Roll the board back to the pre-attempt state so a retried
 		// node never sees its own half-written vars or duplicated
 		// messages. The final attempt's writes stay for diagnostics.

--- a/core/graph/nodes/script/bridge_stream.go
+++ b/core/graph/nodes/script/bridge_stream.go
@@ -28,10 +28,11 @@ type streamCleanupKey struct{}
 type streamCleanupRegistry struct {
 	mu       sync.Mutex
 	cleanups []func() error
+	ctx      context.Context
 }
 
 func withStreamCleanup(ctx context.Context) (context.Context, *streamCleanupRegistry) {
-	reg := &streamCleanupRegistry{}
+	reg := &streamCleanupRegistry{ctx: ctx}
 	return context.WithValue(ctx, streamCleanupKey{}, reg), reg
 }
 
@@ -60,7 +61,9 @@ func (r *streamCleanupRegistry) flush() {
 	r.cleanups = nil
 	r.mu.Unlock()
 	for i := len(cleanups) - 1; i >= 0; i-- {
-		_ = cleanups[i]()
+		if err := cleanups[i](); err != nil {
+			telemetry.WarnErr(r.ctx, "script stream: cleanup failed", err)
+		}
 	}
 }
 

--- a/core/graph/nodes/script/node.go
+++ b/core/graph/nodes/script/node.go
@@ -12,8 +12,11 @@ import (
 	"github.com/GizClaw/flowcraft/core/inference/route"
 	"github.com/GizClaw/flowcraft/core/message"
 	"github.com/GizClaw/flowcraft/core/sandbox"
+	"github.com/GizClaw/flowcraft/core/telemetry"
 	"github.com/GizClaw/flowcraft/core/tool"
 	"github.com/GizClaw/flowcraft/core/workspace"
+
+	otellog "go.opentelemetry.io/otel/log"
 )
 
 // ScriptConfig is the config of the "script" node type. Decoding is
@@ -166,23 +169,30 @@ func decodeScriptConfig(raw json.RawMessage) (ScriptConfig, error) {
 // skipped entirely rather than published as empty deltas.
 type scriptEmitter struct{ ec graph.ExecutionContext }
 
+func (e scriptEmitter) emit(delta agent.StreamDeltaPayload) {
+	if err := e.ec.EmitStreamDelta(delta); err != nil {
+		telemetry.WarnErr(e.ec.Context, "script node: stream delta publish failed", err,
+			otellog.String(telemetry.AttrNodeID, e.ec.NodeID))
+	}
+}
+
 func (e scriptEmitter) Emit(eventType string, payload any) {
 	switch eventType {
 	case "token":
-		_ = e.ec.EmitStreamDelta(agent.StreamDeltaPayload{
+		e.emit(agent.StreamDeltaPayload{
 			Type: agent.StreamDeltaPart,
 			Part: message.TextPart{Text: stringifyPayload(payload)},
 		})
 	case "tool_call":
 		if call, ok := payloadToToolCall(payload); ok {
-			_ = e.ec.EmitStreamDelta(agent.StreamDeltaPayload{
+			e.emit(agent.StreamDeltaPayload{
 				Type: agent.StreamDeltaPart,
 				Part: message.ToolCallPart{Call: call},
 			})
 		}
 	case "tool_result":
 		if result, ok := payloadToToolResult(payload); ok {
-			_ = e.ec.EmitStreamDelta(agent.StreamDeltaPayload{
+			e.emit(agent.StreamDeltaPayload{
 				Type: agent.StreamDeltaPart,
 				Part: message.ToolResultPart{Result: result},
 			})
@@ -192,7 +202,7 @@ func (e scriptEmitter) Emit(eventType string, payload any) {
 		// object (e.g. {"type":"image","source":...}), so scripts can
 		// emit any message.Part kind.
 		if part, ok := payloadToPart(payload); ok {
-			_ = e.ec.EmitStreamDelta(agent.StreamDeltaPayload{
+			e.emit(agent.StreamDeltaPayload{
 				Type: agent.StreamDeltaPart,
 				Part: part,
 			})
@@ -202,13 +212,13 @@ func (e scriptEmitter) Emit(eventType string, payload any) {
 		// finish delta so stream consumers see finish_reason /
 		// request_id / response_id at the top level.
 		if delta, ok := payloadToFinish(payload); ok {
-			_ = e.ec.EmitStreamDelta(delta)
+			e.emit(delta)
 		}
 	case "provider_outputs":
 		// Final provider-owned observational outputs, one envelope per
 		// output — the same shape the inference node emits.
 		if outputs, ok := payloadToProviderOutputs(payload); ok {
-			_ = e.ec.EmitStreamDelta(agent.StreamDeltaPayload{
+			e.emit(agent.StreamDeltaPayload{
 				Type:            agent.StreamDeltaProviderOutputs,
 				ProviderOutputs: outputs,
 			})
@@ -227,7 +237,7 @@ func (e scriptEmitter) Emit(eventType string, payload any) {
 		if payload != nil {
 			delta.Payload = raw
 		}
-		_ = e.ec.EmitStreamDelta(delta)
+		e.emit(delta)
 	}
 }
 

--- a/core/inference/route/router.go
+++ b/core/inference/route/router.go
@@ -9,6 +9,9 @@ import (
 
 	"github.com/GizClaw/flowcraft/core/errdefs"
 	"github.com/GizClaw/flowcraft/core/inference"
+	"github.com/GizClaw/flowcraft/core/telemetry"
+
+	otellog "go.opentelemetry.io/otel/log"
 )
 
 type Selectors struct {
@@ -324,13 +327,17 @@ func executeWithFallback[Request any, Response any](
 			gate := r.breaker.begin(ctx, key)
 			breakerAllowed = gate.allowed
 			if !breakerAllowed {
-				trace.Attempts = append(trace.Attempts, Attempt{
+				skipped := Attempt{
 					Target: target, Phase: AttemptPhaseExecute, Trigger: trigger,
 					Outcome: AttemptOutcomeSkipped, Circuit: string(gate.state),
-				})
+				}
+				trace.Attempts = append(trace.Attempts, skipped)
+				logRouteAttempt(telemetry.Warn, ctx, operation,
+					"inference route: target circuit open, skipping",
+					skipped, inference.ModelRef{}, nil)
 				next, ok, fallbackErr := nextFallbackTarget(r,
 					ctx, operation, snapshot, clone,
-					Attempt{Target: target, Phase: AttemptPhaseExecute, Trigger: trigger, Outcome: AttemptOutcomeSkipped},
+					skipped,
 					&trace, seen, fallbackNext, true, false, AttemptPhaseExecute,
 				)
 				if fallbackErr != nil {
@@ -400,6 +407,9 @@ func executeWithFallback[Request any, Response any](
 						if !ok {
 							return zero, trace, err
 						}
+						logRouteAttempt(telemetry.Warn, ctx, operation,
+							"inference route: falling back to another target",
+							attempt, next, err)
 						target, trigger = next, AttemptTriggerFallback
 						break
 					}
@@ -407,6 +417,9 @@ func executeWithFallback[Request any, Response any](
 						operation, AttemptPhasePreflight, attemptTrigger, err, attemptNumber,
 					)
 					if retryEligible(ctx, &policy, decision) {
+						logRouteAttempt(telemetry.Debug, ctx, operation,
+							"inference route: attempt failed, will retry",
+							attempt, inference.ModelRef{}, err)
 						lastErr = err
 						continue
 					}
@@ -421,6 +434,9 @@ func executeWithFallback[Request any, Response any](
 					if !ok {
 						return zero, trace, err
 					}
+					logRouteAttempt(telemetry.Warn, ctx, operation,
+						"inference route: falling back after retries exhausted",
+						attempt, next, err)
 					target, trigger = next, AttemptTriggerFallback
 					break
 				}
@@ -448,6 +464,9 @@ func executeWithFallback[Request any, Response any](
 					operation, AttemptPhaseExecute, attemptTrigger, err, attemptNumber,
 				)
 				if retryEligible(ctx, &policy, decision) {
+					logRouteAttempt(telemetry.Debug, ctx, operation,
+						"inference route: attempt failed, will retry",
+						attempt, inference.ModelRef{}, err)
 					lastErr = err
 					continue
 				}
@@ -462,6 +481,9 @@ func executeWithFallback[Request any, Response any](
 				if !ok {
 					return zero, trace, err
 				}
+				logRouteAttempt(telemetry.Warn, ctx, operation,
+					"inference route: falling back after retries exhausted",
+					attempt, next, err)
 				target, trigger = next, AttemptTriggerFallback
 				break
 			}
@@ -532,13 +554,17 @@ func openSessionWithFallback[Request any, Session any](
 			gate := r.breaker.begin(ctx, key)
 			breakerAllowed = gate.allowed
 			if !breakerAllowed {
-				trace.Attempts = append(trace.Attempts, Attempt{
+				skipped := Attempt{
 					Target: target, Phase: skipPhase, Trigger: trigger,
 					Outcome: AttemptOutcomeSkipped, Circuit: string(gate.state),
-				})
+				}
+				trace.Attempts = append(trace.Attempts, skipped)
+				logRouteAttempt(telemetry.Warn, ctx, operation,
+					"inference route: target circuit open, skipping",
+					skipped, inference.ModelRef{}, nil)
 				next, ok, fallbackErr := nextFallbackTarget(r,
 					ctx, operation, snapshot, clone,
-					Attempt{Target: target, Phase: skipPhase, Trigger: trigger, Outcome: AttemptOutcomeSkipped},
+					skipped,
 					&trace, seen, fallbackNext, true, false, skipPhase,
 				)
 				if fallbackErr != nil {
@@ -608,12 +634,18 @@ func openSessionWithFallback[Request any, Session any](
 						if !ok {
 							return zero, trace, err
 						}
+						logRouteAttempt(telemetry.Warn, ctx, operation,
+							"inference route: falling back to another target",
+							attempt, next, err)
 						target, trigger = next, AttemptTriggerFallback
 						break
 					}
 					if retryEligible(ctx, &policy, retryDecision(
 						operation, AttemptPhasePreflight, attemptTrigger, err, attemptNumber,
 					)) {
+						logRouteAttempt(telemetry.Debug, ctx, operation,
+							"inference route: attempt failed, will retry",
+							attempt, inference.ModelRef{}, err)
 						lastErr = err
 						continue
 					}
@@ -628,6 +660,9 @@ func openSessionWithFallback[Request any, Session any](
 					if !ok {
 						return zero, trace, err
 					}
+					logRouteAttempt(telemetry.Warn, ctx, operation,
+						"inference route: falling back after retries exhausted",
+						attempt, next, err)
 					target, trigger = next, AttemptTriggerFallback
 					break
 				}
@@ -654,6 +689,9 @@ func openSessionWithFallback[Request any, Session any](
 				if retryEligible(ctx, &policy, retryDecision(
 					operation, AttemptPhaseOpen, attemptTrigger, err, attemptNumber,
 				)) {
+					logRouteAttempt(telemetry.Debug, ctx, operation,
+						"inference route: attempt failed, will retry",
+						attempt, inference.ModelRef{}, err)
 					lastErr = err
 					continue
 				}
@@ -668,6 +706,9 @@ func openSessionWithFallback[Request any, Session any](
 				if !ok {
 					return zero, trace, err
 				}
+				logRouteAttempt(telemetry.Warn, ctx, operation,
+					"inference route: falling back after retries exhausted",
+					attempt, next, err)
 				target, trigger = next, AttemptTriggerFallback
 				break
 			}
@@ -943,4 +984,44 @@ func isNilInterface(value any) bool {
 	default:
 		return false
 	}
+}
+
+// logRouteAttempt emits one log record for a retry / fallback / circuit
+// event. Retry noise stays at Debug; fallback and circuit skips are Warn
+// because operators should be able to search for them in log queries.
+func logRouteAttempt(
+	log func(context.Context, string, ...otellog.KeyValue),
+	ctx context.Context,
+	operation inference.Operation,
+	msg string,
+	attempt Attempt,
+	next inference.ModelRef,
+	err error,
+) {
+	attrs := []otellog.KeyValue{
+		otellog.String("inference.operation", string(operation)),
+		otellog.String(telemetry.AttrLLMProvider, attempt.Target.ID.Provider),
+		otellog.String(telemetry.AttrLLMModel, attempt.Target.ID.Name),
+		otellog.String("phase", string(attempt.Phase)),
+		otellog.String("trigger", string(attempt.Trigger)),
+		otellog.String("outcome", string(attempt.Outcome)),
+	}
+	if attempt.Number > 0 {
+		attrs = append(attrs, otellog.Int("attempt", attempt.Number))
+	}
+	if attempt.ErrorKind != "" {
+		attrs = append(attrs, otellog.String("error_kind", string(attempt.ErrorKind)))
+	}
+	if attempt.Circuit != "" {
+		attrs = append(attrs, otellog.String("circuit", attempt.Circuit))
+	}
+	if next.ID != (inference.ModelID{}) {
+		attrs = append(attrs,
+			otellog.String("next.provider", next.ID.Provider),
+			otellog.String("next.model", next.ID.Name))
+	}
+	if err != nil {
+		attrs = append(attrs, otellog.String(telemetry.AttrErrorMessage, err.Error()))
+	}
+	log(ctx, msg, attrs...)
 }

--- a/core/inference/route/telemetry.go
+++ b/core/inference/route/telemetry.go
@@ -13,6 +13,7 @@ import (
 
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
+	otellog "go.opentelemetry.io/otel/log"
 	"go.opentelemetry.io/otel/metric"
 	"go.opentelemetry.io/otel/trace"
 )
@@ -122,6 +123,19 @@ func recordRoute(
 			span.SetAttributes(
 				attribute.String(telemetry.AttrLLMRequestID, requestID))
 		}
+		logAttrs := []otellog.KeyValue{
+			otellog.String("inference.operation", string(operation)),
+			otellog.String(telemetry.AttrErrorMessage, err.Error()),
+		}
+		if executed := routeTrace.Executed; executed.ID != (inference.ModelID{}) {
+			logAttrs = append(logAttrs,
+				otellog.String(telemetry.AttrLLMProvider, executed.ID.Provider),
+				otellog.String(telemetry.AttrLLMModel, executed.ID.Name))
+		}
+		if requestID, ok := errdefs.RequestID(err); ok {
+			logAttrs = append(logAttrs, otellog.String(telemetry.AttrLLMRequestID, requestID))
+		}
+		telemetry.Warn(ctx, "inference route failed", logAttrs...)
 		span.SetStatus(codes.Error, err.Error())
 		span.End()
 		return

--- a/core/resource/loader.go
+++ b/core/resource/loader.go
@@ -11,6 +11,9 @@ import (
 	"strings"
 
 	"github.com/GizClaw/flowcraft/core/errdefs"
+	"github.com/GizClaw/flowcraft/core/telemetry"
+
+	otellog "go.opentelemetry.io/otel/log"
 )
 
 const defaultMaxBytes = 1 << 20
@@ -77,7 +80,7 @@ func (l *Loader) Load(ctx context.Context, src Source) ([]byte, error) {
 	}
 }
 
-func (l *Loader) loadFile(_ context.Context, name string) ([]byte, error) {
+func (l *Loader) loadFile(ctx context.Context, name string) ([]byte, error) {
 	if l.baseDir == "" {
 		return nil, errdefs.Validationf(
 			"resource loader: file source requires a base dir")
@@ -97,7 +100,12 @@ func (l *Loader) loadFile(_ context.Context, name string) ([]byte, error) {
 		return nil, errdefs.Forbiddenf(
 			"resource loader: open base dir: %v", err)
 	}
-	defer func() { _ = root.Close() }()
+	defer func() {
+		if cerr := root.Close(); cerr != nil {
+			telemetry.WarnErr(ctx, "resource loader: close base dir failed", cerr,
+				otellog.String("resource.source", name))
+		}
+	}()
 	data, err := root.ReadFile(clean)
 	if err != nil {
 		if errors.Is(err, fs.ErrNotExist) {

--- a/core/runtime/builder.go
+++ b/core/runtime/builder.go
@@ -12,6 +12,7 @@ import (
 	"github.com/GizClaw/flowcraft/core/event"
 	"github.com/GizClaw/flowcraft/core/resource"
 	"github.com/GizClaw/flowcraft/core/runtime/session"
+	"github.com/GizClaw/flowcraft/core/telemetry"
 )
 
 // HostFactoryDecorator wraps the runtime's built-in base host factory.
@@ -153,7 +154,7 @@ func (b *Builder) Build(ctx context.Context, doc deploy.Document) (*Runtime, err
 
 	bus, err := resolveValue[event.Bus](result, cfg.EventBus, "event_bus")
 	if err != nil {
-		_ = result.Close()
+		logBuildCleanup(ctx, "close partial deployment", result.Close())
 		return nil, err
 	}
 	var checkpoints agent.CheckpointStore
@@ -161,25 +162,25 @@ func (b *Builder) Build(ctx context.Context, doc deploy.Document) (*Runtime, err
 		checkpoints, err = resolveValue[agent.CheckpointStore](
 			result, cfg.CheckpointStore, "checkpoint_store")
 		if err != nil {
-			_ = result.Close()
+			logBuildCleanup(ctx, "close partial deployment", result.Close())
 			return nil, err
 		}
 	}
 
 	baseHostFactory, err := newBaseHostFactory(bus, checkpoints)
 	if err != nil {
-		_ = result.Close()
+		logBuildCleanup(ctx, "close partial deployment", result.Close())
 		return nil, err
 	}
 	hostFactory := baseHostFactory
 	if b.hostDecorator != nil {
 		hostFactory, err = b.hostDecorator(baseHostFactory)
 		if err != nil {
-			_ = result.Close()
+			logBuildCleanup(ctx, "close partial deployment", result.Close())
 			return nil, fmt.Errorf("runtime decorate base host factory: %w", err)
 		}
 		if isNil(hostFactory) {
-			_ = result.Close()
+			logBuildCleanup(ctx, "close partial deployment", result.Close())
 			return nil, errdefs.Internalf(
 				"runtime host factory decorator returned nil")
 		}
@@ -187,11 +188,11 @@ func (b *Builder) Build(ctx context.Context, doc deploy.Document) (*Runtime, err
 	if b.resultHostDecorator != nil {
 		hostFactory, err = b.resultHostDecorator(result, hostFactory)
 		if err != nil {
-			_ = result.Close()
+			logBuildCleanup(ctx, "close partial deployment", result.Close())
 			return nil, fmt.Errorf("runtime decorate host factory with deployment: %w", err)
 		}
 		if isNil(hostFactory) {
-			_ = result.Close()
+			logBuildCleanup(ctx, "close partial deployment", result.Close())
 			return nil, errdefs.Internalf(
 				"runtime result host factory decorator returned nil")
 		}
@@ -203,7 +204,7 @@ func (b *Builder) Build(ctx context.Context, doc deploy.Document) (*Runtime, err
 		assemblies, resolveErr := resolveDynamicCatalogAssemblies(
 			doc, result, cfg.DynamicCatalog)
 		if resolveErr != nil {
-			_ = result.Close()
+			logBuildCleanup(ctx, "close partial deployment", result.Close())
 			return nil, resolveErr
 		}
 		liveCatalog = newCatalogRegistry(assemblies)
@@ -244,14 +245,14 @@ func (b *Builder) Build(ctx context.Context, doc deploy.Document) (*Runtime, err
 	}
 	manager, err := session.NewManager(initial.resolver, hostFactory, router, managerOptions...)
 	if err != nil {
-		_ = router.Close()
-		_ = result.Close()
+		logBuildCleanup(ctx, "close partial router", router.Close())
+		logBuildCleanup(ctx, "close partial deployment", result.Close())
 		return nil, fmt.Errorf("runtime create session manager: %w", err)
 	}
 	if err := bindSessionManagers(manager, result); err != nil {
-		_ = manager.Close()
-		_ = router.Close()
-		_ = result.Close()
+		logBuildCleanup(ctx, "close partial session manager", manager.Close())
+		logBuildCleanup(ctx, "close partial router", router.Close())
+		logBuildCleanup(ctx, "close partial deployment", result.Close())
 		return nil, fmt.Errorf("runtime bind session managers: %w", err)
 	}
 	return &Runtime{
@@ -340,4 +341,13 @@ func isNil(value any) bool {
 	default:
 		return false
 	}
+}
+
+// logBuildCleanup records a best-effort teardown error on a failed Build
+// so partially constructed resources are visible in telemetry.
+func logBuildCleanup(ctx context.Context, msg string, err error) {
+	if err == nil {
+		return
+	}
+	telemetry.WarnErr(ctx, "runtime build: "+msg, err)
 }

--- a/core/runtime/events.go
+++ b/core/runtime/events.go
@@ -2,10 +2,12 @@ package runtime
 
 import (
 	"context"
-	"log"
 
 	"github.com/GizClaw/flowcraft/core/agent"
 	"github.com/GizClaw/flowcraft/core/event"
+	"github.com/GizClaw/flowcraft/core/telemetry"
+
+	otellog "go.opentelemetry.io/otel/log"
 )
 
 // agentLifecyclePrefix is the subject root for runtime agent lifecycle
@@ -92,10 +94,12 @@ func (r *Runtime) publishLifecycleEvent(
 	}
 	envelope, err := event.NewEnvelope(ctx, subject, payload)
 	if err != nil {
-		log.Printf("runtime: lifecycle event %q: %v", subject, err)
+		telemetry.WarnErr(ctx, "runtime: lifecycle event envelope failed", err,
+			otellog.String("event.subject", string(subject)))
 		return
 	}
 	if err := r.bus.Publish(ctx, envelope); err != nil {
-		log.Printf("runtime: lifecycle event %q: %v", subject, err)
+		telemetry.WarnErr(ctx, "runtime: lifecycle event publish failed", err,
+			otellog.String("event.subject", string(subject)))
 	}
 }

--- a/core/runtime/lifecycle.go
+++ b/core/runtime/lifecycle.go
@@ -8,7 +8,10 @@ import (
 	"github.com/GizClaw/flowcraft/core/agent"
 	"github.com/GizClaw/flowcraft/core/deploy"
 	"github.com/GizClaw/flowcraft/core/errdefs"
+	"github.com/GizClaw/flowcraft/core/telemetry"
 	"github.com/GizClaw/flowcraft/core/tool"
+
+	otellog "go.opentelemetry.io/otel/log"
 )
 
 type registerOptions struct {
@@ -111,18 +114,24 @@ func (r *Runtime) RegisterAgent(
 	if err != nil {
 		return nil, err
 	}
+	closeInstance := func() {
+		if cerr := instance.Close(); cerr != nil {
+			telemetry.WarnErr(ctx, "runtime: close agent after registration failure", cerr,
+				otellog.String(telemetry.AttrAgentID, name))
+		}
+	}
 
 	var assembly *tool.Assembly
 	if options.toolResource != "" {
 		if r.liveCatalog == nil {
-			_ = instance.Close()
+			closeInstance()
 			return nil, errdefs.Validationf(
 				"runtime: dynamic catalog is not configured; cannot attach tool assembly %q",
 				options.toolResource)
 		}
 		value, ok := r.result.Value(options.toolResource)
 		if !ok {
-			_ = instance.Close()
+			closeInstance()
 			return nil, errdefs.NotFoundf(
 				"runtime: tool assembly resource %q not found",
 				options.toolResource)
@@ -130,7 +139,7 @@ func (r *Runtime) RegisterAgent(
 		var typeOK bool
 		assembly, typeOK = value.(*tool.Assembly)
 		if !typeOK || assembly == nil {
-			_ = instance.Close()
+			closeInstance()
 			return nil, errdefs.Validationf(
 				"runtime: tool assembly resource %q is %T, want *tool.Assembly",
 				options.toolResource, value)
@@ -138,7 +147,7 @@ func (r *Runtime) RegisterAgent(
 	} else if r.liveCatalog != nil && !r.liveCatalog.hasDefault() {
 		// Mirrors the build-time rule: with a dynamic catalog every
 		// agent must have an explicit tool assembly or a default.
-		_ = instance.Close()
+		closeInstance()
 		return nil, errdefs.Validationf(
 			"runtime: dynamic catalog has no default; agent %q needs WithToolAssembly",
 			name)
@@ -153,7 +162,7 @@ func (r *Runtime) RegisterAgent(
 		definition:   def,
 		toolAssembly: options.toolResource,
 	}); err != nil {
-		_ = instance.Close()
+		closeInstance()
 		return nil, err
 	}
 	r.publishLifecycleEvent(ctx, SubjectAgentRegistered(name), AgentLifecycleEvent{
@@ -161,6 +170,9 @@ func (r *Runtime) RegisterAgent(
 		Name:        def.Card.Name,
 		Description: def.Card.Description,
 	})
+	telemetry.Info(ctx, "runtime agent registered",
+		otellog.String(telemetry.AttrAgentID, name),
+		otellog.String("agent.card.name", def.Card.Name))
 	return instance, nil
 }
 
@@ -223,13 +235,22 @@ func (r *Runtime) UnregisterAgent(
 		// Drain failed (usually a deadline): keep the tombstone so new
 		// sessions stay blocked, restore the agent so the registration
 		// is still visible, and let the caller retry.
-		_ = r.registry.Put(name, entry)
+		if rerr := r.registry.Put(name, entry); rerr != nil {
+			telemetry.WarnErr(ctx, "runtime: restore agent after remove drain failed", rerr,
+				otellog.String(telemetry.AttrAgentID, name))
+		}
+		telemetry.Error(ctx, "runtime agent removal failed",
+			otellog.String(telemetry.AttrAgentID, name),
+			otellog.String(telemetry.AttrErrorMessage, err.Error()))
 		return err
 	}
 	if r.liveCatalog != nil {
 		r.liveCatalog.Delete(name)
 	}
 	if err := entry.instance.Close(); err != nil {
+		telemetry.Error(ctx, "runtime agent removal failed",
+			otellog.String(telemetry.AttrAgentID, name),
+			otellog.String(telemetry.AttrErrorMessage, err.Error()))
 		return err
 	}
 	r.publishLifecycleEvent(ctx, SubjectAgentRemoved(name), AgentLifecycleEvent{
@@ -237,6 +258,9 @@ func (r *Runtime) UnregisterAgent(
 		Name:        entry.instance.Card.Name,
 		Description: entry.instance.Card.Description,
 	})
+	telemetry.Info(ctx, "runtime agent removed",
+		otellog.String(telemetry.AttrAgentID, name),
+		otellog.String("agent.card.name", entry.instance.Card.Name))
 	return nil
 }
 

--- a/core/runtime/reload.go
+++ b/core/runtime/reload.go
@@ -10,7 +10,10 @@ import (
 	"github.com/GizClaw/flowcraft/core/errdefs"
 	"github.com/GizClaw/flowcraft/core/event"
 	"github.com/GizClaw/flowcraft/core/runtime/session"
+	"github.com/GizClaw/flowcraft/core/telemetry"
 	"github.com/GizClaw/flowcraft/core/tool"
+
+	otellog "go.opentelemetry.io/otel/log"
 )
 
 type reloadOptions struct{}
@@ -89,9 +92,15 @@ func (r *Runtime) Reload(
 	}
 	r.publishLifecycleEvent(ctx, SubjectRuntimeRebuildStarted(),
 		RuntimeRebuildEvent{GenerationID: newGenID})
+	telemetry.Info(ctx, "runtime reload started",
+		otellog.Int64("runtime.generation.id", int64(newGenID)),
+		otellog.Int64("runtime.generation.previous", int64(previousID)))
 	fail := func(err error) (*ReloadResult, error) {
 		r.publishLifecycleEvent(ctx, SubjectRuntimeRebuildFailed(),
 			RuntimeRebuildEvent{GenerationID: newGenID, Error: err.Error()})
+		telemetry.Error(ctx, "runtime reload failed",
+			otellog.Int64("runtime.generation.id", int64(newGenID)),
+			otellog.String(telemetry.AttrErrorMessage, err.Error()))
 		return nil, err
 	}
 	if err := doc.Validate(); err != nil {
@@ -121,9 +130,15 @@ func (r *Runtime) Reload(
 		for _, name := range drainAttempted {
 			r.manager.ReopenAgent(name)
 		}
-		_ = newResult.Close()
+		if cerr := newResult.Close(); cerr != nil {
+			telemetry.WarnErr(ctx, "runtime reload: close partial deployment after abort", cerr,
+				otellog.Int64("runtime.generation.id", int64(newGenID)))
+		}
 		r.publishLifecycleEvent(ctx, SubjectRuntimeRebuildFailed(),
 			RuntimeRebuildEvent{GenerationID: newGenID, Error: err.Error()})
+		telemetry.Error(ctx, "runtime reload aborted",
+			otellog.Int64("runtime.generation.id", int64(newGenID)),
+			otellog.String(telemetry.AttrErrorMessage, err.Error()))
 		return err
 	}
 
@@ -224,7 +239,11 @@ func (r *Runtime) Reload(
 	newEntries := make(map[string]dynamicAgentEntry, len(entries))
 	closeRebound := func() {
 		for _, name := range sortedKeys(rebound) {
-			_ = rebound[name].Close()
+			if cerr := rebound[name].Close(); cerr != nil {
+				telemetry.WarnErr(ctx, "runtime reload: close rebound agent after abort", cerr,
+					otellog.String(telemetry.AttrAgentID, name),
+					otellog.Int64("runtime.generation.id", int64(newGenID)))
+			}
 		}
 	}
 	for _, name := range sortedKeys(entries) {
@@ -341,7 +360,10 @@ func (r *Runtime) Reload(
 		// Belt and braces: AddBus is all-or-nothing, so the new bus is
 		// never attached on error; removing it here keeps the invariant
 		// even if a future router change makes AddBus partial.
-		_ = r.router.RemoveBus(newBus)
+		if rerr := r.router.RemoveBus(newBus); rerr != nil {
+			telemetry.WarnErr(ctx, "runtime reload: remove unattached bus after abort", rerr,
+				otellog.Int64("runtime.generation.id", int64(newGenID)))
+		}
 		r.registry.Replace(entries, oldGen.result)
 		closeRebound()
 		return nil, abort(fmt.Errorf("runtime reload attach bus: %w", err))
@@ -359,15 +381,24 @@ func (r *Runtime) Reload(
 	}
 	if err := r.manager.SwapDeps(deps, func(_ uint64, _ session.Deps) {
 		if oldGen != nil && oldGen.bus != nil {
-			_ = r.router.RemoveBus(oldGen.bus)
+			if rerr := r.router.RemoveBus(oldGen.bus); rerr != nil {
+				telemetry.WarnErr(ctx, "runtime reload: unsubscribe retired generation bus", rerr,
+					otellog.Int64("runtime.generation.id", int64(newGenID)))
+			}
 		}
-		_ = oldGen.close()
+		if cerr := oldGen.close(); cerr != nil {
+			telemetry.WarnErr(ctx, "runtime reload: close retired generation", cerr,
+				otellog.Int64("runtime.generation.id", int64(newGenID)))
+		}
 	}); err != nil {
 		// Unreachable under lifecycleMu (Close holds it); roll back.
 		if oldGen != nil {
 			oldGen.unfreeze()
 		}
-		_ = r.router.RemoveBus(newBus)
+		if rerr := r.router.RemoveBus(newBus); rerr != nil {
+			telemetry.WarnErr(ctx, "runtime reload: remove new bus after swap failure", rerr,
+				otellog.Int64("runtime.generation.id", int64(newGenID)))
+		}
 		r.registry.Replace(entries, oldGen.result)
 		closeRebound()
 		return nil, abort(errdefs.Internalf(
@@ -389,6 +420,11 @@ func (r *Runtime) Reload(
 			ReboundAgents:        reboundNames,
 			DrainedAgents:        drained,
 		})
+	telemetry.Info(ctx, "runtime reload completed",
+		otellog.Int64("runtime.generation.id", int64(newGenID)),
+		otellog.Int64("runtime.generation.previous", int64(previousID)),
+		otellog.Int("runtime.reload.rebound_agents", len(reboundNames)),
+		otellog.Int("runtime.reload.drained_agents", len(drained)))
 	return &ReloadResult{
 		GenerationID:  newGenID,
 		PreviousID:    previousID,

--- a/core/runtime/runtime.go
+++ b/core/runtime/runtime.go
@@ -12,6 +12,9 @@ import (
 	"github.com/GizClaw/flowcraft/core/event"
 	"github.com/GizClaw/flowcraft/core/resource"
 	"github.com/GizClaw/flowcraft/core/runtime/session"
+	"github.com/GizClaw/flowcraft/core/telemetry"
+
+	otellog "go.opentelemetry.io/otel/log"
 )
 
 // Runtime owns the complete application object graph built by Builder.
@@ -145,6 +148,10 @@ func (r *Runtime) Close() error {
 		}
 		r.closeErr = closeOwned(r.manager, r.router, r.current)
 	})
+	if r.closeErr != nil {
+		telemetry.Error(context.Background(), "runtime close failed",
+			otellog.String(telemetry.AttrErrorMessage, r.closeErr.Error()))
+	}
 	return r.closeErr
 }
 

--- a/core/runtime/session/coordinator.go
+++ b/core/runtime/session/coordinator.go
@@ -10,6 +10,9 @@ import (
 	"github.com/GizClaw/flowcraft/core/agent"
 	"github.com/GizClaw/flowcraft/core/errdefs"
 	"github.com/GizClaw/flowcraft/core/event"
+	"github.com/GizClaw/flowcraft/core/telemetry"
+
+	otellog "go.opentelemetry.io/otel/log"
 )
 
 const defaultAttemptDrainTimeout = 5 * time.Second
@@ -292,6 +295,12 @@ func (c *streamCoordinator) failConfirmedLocked(err error) {
 	if c.confirmedDead {
 		return
 	}
+	telemetry.WarnErr(
+		context.WithoutCancel(c.turn.runCtx),
+		"runtime session: confirmed stream failed and detached",
+		err,
+		otellog.String(telemetry.AttrRunID, c.turn.runID),
+	)
 	c.confirmedDead = true
 	c.branches = nil
 	c.pendingEvents, c.pendingBytes = 0, 0

--- a/core/runtime/session/manager.go
+++ b/core/runtime/session/manager.go
@@ -10,6 +10,9 @@ import (
 	"github.com/GizClaw/flowcraft/core/agent"
 	"github.com/GizClaw/flowcraft/core/errdefs"
 	"github.com/GizClaw/flowcraft/core/event"
+	"github.com/GizClaw/flowcraft/core/telemetry"
+
+	otellog "go.opentelemetry.io/otel/log"
 )
 
 var ErrManagerClosed = errdefs.NotAvailablef("runtime session: manager is closed")
@@ -295,7 +298,15 @@ func (m *Manager) reclaim(key Key, session *Session, generation uint64) {
 	delete(m.entries, key)
 	entry.timer = nil
 	m.mu.Unlock()
-	_ = session.close()
+	if err := session.close(); err != nil {
+		telemetry.WarnErr(context.Background(), "runtime session: close idle-reclaimed session failed", err,
+			otellog.String(telemetry.AttrAgentID, key.AgentID),
+			otellog.String(telemetry.AttrConversationID, key.ContextID))
+		return
+	}
+	telemetry.Debug(context.Background(), "runtime session: idle session reclaimed",
+		otellog.String(telemetry.AttrAgentID, key.AgentID),
+		otellog.String(telemetry.AttrConversationID, key.ContextID))
 }
 
 // RemoveAgent blocks new session activity for the named agent and
@@ -333,6 +344,9 @@ func (m *Manager) RemoveAgent(ctx context.Context, name string) error {
 	m.mu.Unlock()
 
 	if err := m.awaitAgentIdle(ctx, name); err != nil {
+		telemetry.Error(ctx, "runtime session: agent drain timed out",
+			otellog.String(telemetry.AttrAgentID, name),
+			otellog.String(telemetry.AttrErrorMessage, err.Error()))
 		return err
 	}
 
@@ -436,6 +450,10 @@ func (m *Manager) Close() error {
 		}
 		m.closeErr = errors.Join(closeErrors...)
 	})
+	if m.closeErr != nil {
+		telemetry.Error(context.Background(), "runtime session: manager close failed",
+			otellog.String(telemetry.AttrErrorMessage, m.closeErr.Error()))
+	}
 	return m.closeErr
 }
 

--- a/core/runtime/session/prompt.go
+++ b/core/runtime/session/prompt.go
@@ -10,6 +10,9 @@ import (
 	"github.com/GizClaw/flowcraft/core/agent"
 	"github.com/GizClaw/flowcraft/core/errdefs"
 	"github.com/GizClaw/flowcraft/core/event"
+	"github.com/GizClaw/flowcraft/core/telemetry"
+
+	otellog "go.opentelemetry.io/otel/log"
 )
 
 type promptState uint8
@@ -222,7 +225,11 @@ func (t *Turn) publishPromptResolved(host agent.Host, promptID string, status Pr
 	if t.session != nil {
 		envelope.SetAgentID(t.session.key.AgentID)
 	}
-	_ = host.Publish(ctx, envelope)
+	if err := host.Publish(ctx, envelope); err != nil {
+		telemetry.WarnErr(ctx, "runtime session: prompt resolved event publish failed", err,
+			otellog.String(telemetry.AttrRunID, t.runID),
+			otellog.String("event.subject", string(SubjectPromptResolved(t.runID))))
+	}
 }
 
 func randomID() (string, error) {

--- a/core/runtime/session/session.go
+++ b/core/runtime/session/session.go
@@ -14,7 +14,10 @@ import (
 	"github.com/GizClaw/flowcraft/core/agent"
 	"github.com/GizClaw/flowcraft/core/errdefs"
 	"github.com/GizClaw/flowcraft/core/event"
+	"github.com/GizClaw/flowcraft/core/telemetry"
 	sdktool "github.com/GizClaw/flowcraft/core/tool"
+
+	otellog "go.opentelemetry.io/otel/log"
 )
 
 type activityKind uint8
@@ -325,8 +328,15 @@ func (s *Session) interruptActive(ctx context.Context) (func(), error) {
 	old := s.active
 	s.mu.Unlock()
 	if old != nil {
-		_ = old.Interrupt(agent.Interrupt{Cause: agent.CauseUserInput})
-		_, _ = old.Wait(ctx)
+		if err := old.Interrupt(agent.Interrupt{Cause: agent.CauseUserInput}); err != nil {
+			telemetry.WarnErr(ctx, "runtime session: interrupt active turn failed", err,
+				otellog.String(telemetry.AttrRunID, old.runID))
+		}
+		if _, err := old.Wait(ctx); err != nil {
+			telemetry.Debug(ctx, "runtime session: active turn wait after interrupt",
+				otellog.String(telemetry.AttrRunID, old.runID),
+				otellog.String(telemetry.AttrErrorMessage, err.Error()))
+		}
 	}
 	if err := ctx.Err(); err != nil {
 		release()
@@ -597,7 +607,10 @@ func (s *Session) saveSessionState(
 	ctx, cancel := context.WithTimeout(
 		context.WithoutCancel(context.Background()), 5*time.Second)
 	defer cancel()
-	_ = checkpoints.Save(ctx, cp)
+	if err := checkpoints.Save(ctx, cp); err != nil {
+		telemetry.WarnErr(ctx, "runtime session: save session state checkpoint failed", err,
+			otellog.String("runtime.session.id", sessionStateID(s.key)))
+	}
 }
 
 // clearParkedRun drops the resumable marker (e.g. the parked run's
@@ -671,7 +684,10 @@ func (s *Session) deleteCheckpoint(
 	ctx, cancel := context.WithTimeout(
 		context.WithoutCancel(context.Background()), 5*time.Second)
 	defer cancel()
-	_ = deleter.Delete(ctx, runID)
+	if err := deleter.Delete(ctx, runID); err != nil {
+		telemetry.WarnErr(ctx, "runtime session: delete parked-run checkpoint failed", err,
+			otellog.String(telemetry.AttrRunID, runID))
+	}
 }
 
 // loadResumableCheckpoint loads and validates the parked run's

--- a/core/runtime/session/sink.go
+++ b/core/runtime/session/sink.go
@@ -8,6 +8,9 @@ import (
 
 	"github.com/GizClaw/flowcraft/core/agent"
 	"github.com/GizClaw/flowcraft/core/event"
+	"github.com/GizClaw/flowcraft/core/telemetry"
+
+	otellog "go.opentelemetry.io/otel/log"
 )
 
 const (
@@ -143,6 +146,20 @@ func (s *queuedSink) detach(err error) {
 	if s.detached {
 		s.mu.Unlock()
 		return
+	}
+	if err != nil {
+		attrs := []otellog.KeyValue{
+			otellog.String("runtime.session.sink", string(s.spec.ID)),
+			otellog.String("event.subject", string(s.runEnd)),
+		}
+		if s.session != nil {
+			attrs = append(attrs,
+				otellog.String(telemetry.AttrAgentID, s.session.key.AgentID),
+				otellog.String(telemetry.AttrConversationID, s.session.key.ContextID))
+		}
+		telemetry.WarnErr(context.Background(),
+			"runtime session: stream sink detached due to delivery failure",
+			err, attrs...)
 	}
 	cleanup := s.markDetachedLocked(err)
 	s.mu.Unlock()

--- a/core/runtime/session/turn.go
+++ b/core/runtime/session/turn.go
@@ -565,5 +565,9 @@ func terminalState(result *agent.Result, err error) TurnState {
 }
 
 func (t *Turn) shutdown() {
-	_ = t.Interrupt(agent.Interrupt{Cause: agent.CauseHostShutdown})
+	if err := t.Interrupt(agent.Interrupt{Cause: agent.CauseHostShutdown}); err != nil {
+		telemetry.WarnErr(context.WithoutCancel(t.runCtx),
+			"runtime session: interrupt turn on host shutdown failed", err,
+			otellog.String(telemetry.AttrRunID, t.runID))
+	}
 }

--- a/core/sandbox/bwrap/internal/bridge/bridge.go
+++ b/core/sandbox/bwrap/internal/bridge/bridge.go
@@ -100,7 +100,7 @@ func run(argv []string, stdin io.Reader, stdout, stderr io.Writer) int {
 		return 127
 	}
 
-	go acceptLoop(ln, *sock)
+	go acceptLoop(ln, *sock, stderr)
 
 	// Propagate the command's exit status (bash-compatible 128+signal).
 	if err := c.Wait(); err != nil {
@@ -152,19 +152,19 @@ func childEnv(port int) []string {
 
 // acceptLoop forwards each accepted loopback connection over a fresh
 // unix-socket connection to the host proxy.
-func acceptLoop(ln net.Listener, sock string) {
+func acceptLoop(ln net.Listener, sock string, stderr io.Writer) {
 	for {
 		conn, err := ln.Accept()
 		if err != nil {
 			return
 		}
-		go forward(conn, sock)
+		go forward(conn, sock, stderr)
 	}
 }
 
 // forward pipes one TCP connection to one UDS connection (the host
 // proxy treats each UDS connection as one client connection).
-func forward(tcp net.Conn, sock string) {
+func forward(tcp net.Conn, sock string, stderr io.Writer) {
 	defer func() {
 		if err := tcp.Close(); err != nil {
 			_, _ = fmt.Fprintf(stderr, "bridge: close tcp: %v\n", err)

--- a/core/sandbox/bwrap/internal/bridge/bridge.go
+++ b/core/sandbox/bwrap/internal/bridge/bridge.go
@@ -165,12 +165,25 @@ func acceptLoop(ln net.Listener, sock string) {
 // forward pipes one TCP connection to one UDS connection (the host
 // proxy treats each UDS connection as one client connection).
 func forward(tcp net.Conn, sock string) {
-	defer func() { _ = tcp.Close() }()
+	defer func() {
+		if err := tcp.Close(); err != nil {
+			_, _ = fmt.Fprintf(stderr, "bridge: close tcp: %v\n", err)
+		}
+	}()
 	uds, err := net.Dial("unix", sock)
 	if err != nil {
 		return
 	}
-	defer func() { _ = uds.Close() }()
-	go func() { _, _ = io.Copy(uds, tcp); _ = uds.Close() }()
+	defer func() {
+		if err := uds.Close(); err != nil {
+			_, _ = fmt.Fprintf(stderr, "bridge: close uds: %v\n", err)
+		}
+	}()
+	go func() {
+		_, _ = io.Copy(uds, tcp)
+		if err := uds.Close(); err != nil {
+			_, _ = fmt.Fprintf(stderr, "bridge: close uds after copy: %v\n", err)
+		}
+	}()
 	_, _ = io.Copy(tcp, uds)
 }

--- a/core/sandbox/bwrap/runner_linux.go
+++ b/core/sandbox/bwrap/runner_linux.go
@@ -16,6 +16,7 @@ import (
 	"github.com/GizClaw/flowcraft/core/errdefs"
 	"github.com/GizClaw/flowcraft/core/sandbox"
 	"github.com/GizClaw/flowcraft/core/sandbox/bwrap/internal/bridge"
+	"github.com/GizClaw/flowcraft/core/telemetry"
 	"github.com/GizClaw/flowcraft/core/utils/net"
 	"github.com/GizClaw/flowcraft/core/utils/net/mitm"
 )
@@ -208,7 +209,7 @@ func (r *Runner) spawnProcess(
 		}
 		bundlePath, bundleCleanup, err = mitm.WriteBundle(proxy.CAPEM())
 		if err != nil {
-			_ = proxy.Close()
+			closeProxy(ctx, proxy)
 			return nil, errdefs.Internalf("bwrap: write CA bundle: %v", err)
 		}
 		if spec.Opts.Env.Inject == nil {
@@ -226,9 +227,7 @@ func (r *Runner) spawnProcess(
 
 	flags, err := buildFlags(spec.Opts, os.Environ())
 	if err != nil {
-		if proxy != nil {
-			_ = proxy.Close()
-		}
+		closeProxy(ctx, proxy)
 		abortBundle()
 		return nil, err
 	}
@@ -239,9 +238,7 @@ func (r *Runner) spawnProcess(
 	}
 	for _, path := range spec.Opts.Net.UnixSockets {
 		if _, statErr := os.Stat(path); statErr != nil {
-			if proxy != nil {
-				_ = proxy.Close()
-			}
+			closeProxy(ctx, proxy)
 			abortBundle()
 			return nil, errdefs.NotFoundf(
 				"bwrap: allowed unix socket %q does not exist: %v", path, statErr)
@@ -253,9 +250,7 @@ func (r *Runner) spawnProcess(
 	if proxyMode {
 		exe, err := os.Executable()
 		if err != nil {
-			if proxy != nil {
-				_ = proxy.Close()
-			}
+			closeProxy(ctx, proxy)
 			abortBundle()
 			return nil, errdefs.Internalf(
 				"bwrap: resolve host binary for in-netns bridge: %v", err)
@@ -291,15 +286,13 @@ func (r *Runner) spawnProcess(
 
 	sess, err := sandbox.StartSession(ctx, spec, c)
 	if err != nil {
-		if proxy != nil {
-			_ = proxy.Close()
-		}
+		closeProxy(ctx, proxy)
 		abortBundle()
 		return nil, err
 	}
 	if proxy != nil {
 		cleanup := &sessionCleanup{cleanup: func() {
-			_ = proxy.Close()
+			closeProxy(context.Background(), proxy)
 			abortBundle()
 		}}
 		go func() {
@@ -309,6 +302,18 @@ func (r *Runner) spawnProcess(
 		return &sessionHandle{Session: sess, cleanup: cleanup}, nil
 	}
 	return sess, nil
+}
+
+// closeProxy best-effort closes the enforcement proxy, leaving the
+// error visible to telemetry. It is nil-safe for uniform use on every
+// spawnProcess teardown path.
+func closeProxy(ctx context.Context, proxy *net.Proxy) {
+	if proxy == nil {
+		return
+	}
+	if err := proxy.Close(); err != nil {
+		telemetry.WarnErr(ctx, "bwrap: close enforcement proxy failed", err)
+	}
 }
 
 // sessionHandle keeps a core Session's side resources (the host

--- a/core/sandbox/exec.go
+++ b/core/sandbox/exec.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/GizClaw/flowcraft/core/errdefs"
+	"github.com/GizClaw/flowcraft/core/telemetry"
 	corenet "github.com/GizClaw/flowcraft/core/utils/net"
 )
 
@@ -87,7 +88,11 @@ func Exec(
 	if err != nil {
 		return nil, err
 	}
-	defer func() { _ = sess.Close() }()
+	defer func() {
+		if cerr := sess.Close(); cerr != nil {
+			telemetry.WarnErr(ctx, "sandbox: close session after exec failed", cerr)
+		}
+	}()
 
 	if len(opts.Stdin) > 0 {
 		if err := sess.Write(ctx, opts.Stdin); err != nil {

--- a/core/sandbox/seatbelt/runner_darwin.go
+++ b/core/sandbox/seatbelt/runner_darwin.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/GizClaw/flowcraft/core/errdefs"
 	"github.com/GizClaw/flowcraft/core/sandbox"
+	"github.com/GizClaw/flowcraft/core/telemetry"
 	corenet "github.com/GizClaw/flowcraft/core/utils/net"
 	"github.com/GizClaw/flowcraft/core/utils/net/mitm"
 )
@@ -180,7 +181,7 @@ func (r *Runner) spawnProcess(
 		}
 		addr, ok := proxy.Addr().(*net.TCPAddr)
 		if !ok {
-			_ = proxy.Close()
+			closeProxy(ctx, proxy)
 			return nil, errdefs.Internalf(
 				"seatbelt: proxy bound %T, want TCP loopback", proxy.Addr())
 		}
@@ -196,7 +197,7 @@ func (r *Runner) spawnProcess(
 		}
 		bundlePath, bundleCleanup, err = mitm.WriteBundle(proxy.CAPEM())
 		if err != nil {
-			_ = proxy.Close()
+			closeProxy(ctx, proxy)
 			return nil, errdefs.Internalf("seatbelt: write CA bundle: %v", err)
 		}
 		if spec.Opts.Env.Inject == nil {
@@ -214,9 +215,7 @@ func (r *Runner) spawnProcess(
 
 	profile, err := buildProfile(r.writable, spec.Opts.Net, proxyPort)
 	if err != nil {
-		if proxy != nil {
-			_ = proxy.Close()
-		}
+		closeProxy(ctx, proxy)
 		abortBundle()
 		return nil, err
 	}
@@ -238,15 +237,13 @@ func (r *Runner) spawnProcess(
 
 	sess, err := sandbox.StartSession(ctx, spec, c)
 	if err != nil {
-		if proxy != nil {
-			_ = proxy.Close()
-		}
+		closeProxy(ctx, proxy)
 		abortBundle()
 		return nil, err
 	}
 	if proxy != nil {
 		cleanup := &sessionCleanup{cleanup: func() {
-			_ = proxy.Close()
+			closeProxy(context.Background(), proxy)
 			abortBundle()
 		}}
 		go func() {
@@ -256,6 +253,18 @@ func (r *Runner) spawnProcess(
 		return &sessionHandle{Session: sess, cleanup: cleanup}, nil
 	}
 	return sess, nil
+}
+
+// closeProxy best-effort closes the enforcement proxy, leaving the
+// error visible to telemetry. It is nil-safe for uniform use on every
+// spawnProcess teardown path.
+func closeProxy(ctx context.Context, proxy *corenet.Proxy) {
+	if proxy == nil {
+		return
+	}
+	if err := proxy.Close(); err != nil {
+		telemetry.WarnErr(ctx, "seatbelt: close enforcement proxy failed", err)
+	}
 }
 
 // sessionHandle keeps a core Session's side resources alive.

--- a/core/sandbox/session_unix.go
+++ b/core/sandbox/session_unix.go
@@ -15,9 +15,11 @@ import (
 	"time"
 
 	"github.com/GizClaw/flowcraft/core/errdefs"
+	"github.com/GizClaw/flowcraft/core/telemetry"
 
 	"github.com/creack/pty"
 	"github.com/rs/xid"
+	otellog "go.opentelemetry.io/otel/log"
 )
 
 const (
@@ -106,7 +108,10 @@ func StartSession(ctx context.Context, spec SessionSpec, cmd *exec.Cmd) (Session
 		// ctx kill — the session lives until Terminate/Close.
 		cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
 		if err := cmd.Start(); err != nil {
-			_ = stdin.Close()
+			if cerr := stdin.Close(); cerr != nil {
+				telemetry.WarnErr(ctx, "sandbox: close stdin pipe after start failure", cerr,
+					otellog.String("sandbox.session_id", s.id))
+			}
 			return nil, classifyStartError(cmd.Path, err)
 		}
 		s.stdin = stdin
@@ -390,7 +395,7 @@ func (s *localSession) Close() error {
 	select {
 	case <-s.done:
 	default:
-		_ = syscall.Kill(-s.pgid, syscall.SIGKILL)
+		s.killGroup(syscall.SIGKILL, "sandbox: SIGKILL process group on close failed")
 		<-s.done
 	}
 	s.mu.Lock()
@@ -398,14 +403,20 @@ func (s *localSession) Close() error {
 	s.ptmx = nil
 	s.mu.Unlock()
 	if ptmx != nil {
-		_ = ptmx.Close()
+		if err := ptmx.Close(); err != nil {
+			telemetry.WarnErr(context.Background(), "sandbox: close pty master failed", err,
+				otellog.String("sandbox.session_id", s.id))
+		}
 	}
 	s.mu.Lock()
 	stdin := s.stdin
 	s.stdin = nil
 	s.mu.Unlock()
 	if stdin != nil && stdin != ptmx {
-		_ = stdin.Close()
+		if err := stdin.Close(); err != nil {
+			telemetry.WarnErr(context.Background(), "sandbox: close session stdin failed", err,
+				otellog.String("sandbox.session_id", s.id))
+		}
 	}
 	s.out.close()
 	return nil
@@ -431,10 +442,10 @@ func (s *localSession) timeoutKill() {
 // bounded by ctx.
 func (s *localSession) signal(ctx context.Context, force bool) error {
 	if force {
-		_ = syscall.Kill(-s.pgid, syscall.SIGKILL)
+		s.killGroup(syscall.SIGKILL, "sandbox: SIGKILL process group failed")
 		return nil
 	}
-	_ = syscall.Kill(-s.pgid, syscall.SIGTERM)
+	s.killGroup(syscall.SIGTERM, "sandbox: SIGTERM process group failed")
 
 	grace := sessionTerminateGrace
 	if deadline, ok := ctx.Deadline(); ok {
@@ -443,7 +454,7 @@ func (s *localSession) signal(ctx context.Context, force bool) error {
 		}
 	}
 	if grace <= 0 {
-		_ = syscall.Kill(-s.pgid, syscall.SIGKILL)
+		s.killGroup(syscall.SIGKILL, "sandbox: SIGKILL process group after grace failed")
 		return ctx.Err()
 	}
 	timer := time.NewTimer(grace)
@@ -452,11 +463,23 @@ func (s *localSession) signal(ctx context.Context, force bool) error {
 	case <-s.done:
 		return nil
 	case <-timer.C:
-		_ = syscall.Kill(-s.pgid, syscall.SIGKILL)
+		s.killGroup(syscall.SIGKILL, "sandbox: SIGKILL process group on grace timeout failed")
 		return nil
 	case <-ctx.Done():
-		_ = syscall.Kill(-s.pgid, syscall.SIGKILL)
+		s.killGroup(syscall.SIGKILL, "sandbox: SIGKILL process group on cancel failed")
 		return ctx.Err()
+	}
+}
+
+// killGroup delivers sig to the process group and leaves a failed
+// delivery visible to telemetry. Kill failures during teardown are
+// best-effort by contract (the child may already be gone), so they are
+// never propagated to callers.
+func (s *localSession) killGroup(sig syscall.Signal, msg string) {
+	if err := syscall.Kill(-s.pgid, sig); err != nil {
+		telemetry.WarnErr(context.Background(), msg, err,
+			otellog.String("sandbox.session_id", s.id),
+			otellog.Int("sandbox.pgid", s.pgid))
 	}
 }
 
@@ -473,7 +496,10 @@ func (s *localSession) reap() {
 	s.ptmx = nil
 	s.mu.Unlock()
 	if ptmx != nil {
-		_ = ptmx.Close()
+		if err := ptmx.Close(); err != nil {
+			telemetry.WarnErr(context.Background(), "sandbox: close pty after reap failed", err,
+				otellog.String("sandbox.session_id", s.id))
+		}
 	}
 	// The pty copier may still hold bytes read before the child's last
 	// write flushed; wait for it so EOF is never reported early.

--- a/core/sandbox/watcher_unix.go
+++ b/core/sandbox/watcher_unix.go
@@ -175,19 +175,33 @@ func (w *GroupCapsWatcher) run() {
 func (w *GroupCapsWatcher) killGroup() {
 	// The child leads its own group (Setpgid), so pid == pgid.
 	//
+	// The kill itself is the enforcement event: a memory/CPU cap trip or
+	// a sampling failure silently stopping the group is exactly what an
+	// operator needs to see in logs, so record it before delivery.
+	attrs := []otellog.KeyValue{
+		otellog.String("sandbox.pgid", strconv.Itoa(w.pgid)),
+	}
+	if rp := w.killReason.Load(); rp != nil {
+		attrs = append(attrs, otellog.String("sandbox.kill_reason", *rp))
+	}
+	if sp := w.sampleErr.Load(); sp != nil {
+		attrs = append(attrs, otellog.String(telemetry.AttrErrorMessage, (*sp).Error()))
+	}
+	telemetry.Warn(w.ctx, "sandbox: process group killed by resource watcher", attrs...)
+
 	// A failed SIGKILL is rare but consequential: the cap we tripped
 	// then stops being enforced. Surface it as a warning so an operator
 	// can see the child was left running unconstrained.
 	if err := syscall.Kill(-w.pgid, syscall.SIGKILL); err != nil {
-		attrs := []otellog.KeyValue{
+		killAttrs := []otellog.KeyValue{
 			otellog.String("sandbox.pgid", strconv.Itoa(w.pgid)),
 		}
 		if rp := w.killReason.Load(); rp != nil {
-			attrs = append(attrs, otellog.String("sandbox.kill_reason", *rp))
+			killAttrs = append(killAttrs, otellog.String("sandbox.kill_reason", *rp))
 		}
 		telemetry.WarnErr(w.ctx,
 			"sandbox: failed to deliver SIGKILL to process group",
-			err, attrs...)
+			err, killAttrs...)
 	}
 }
 

--- a/core/tool/mcp/config.go
+++ b/core/tool/mcp/config.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/GizClaw/flowcraft/core/errdefs"
 	"github.com/GizClaw/flowcraft/core/resource"
+	"github.com/GizClaw/flowcraft/core/telemetry"
 	"github.com/GizClaw/flowcraft/core/utils"
 	mcpsdk "github.com/modelcontextprotocol/go-sdk/mcp"
 )
@@ -90,11 +91,15 @@ func (f Factory) New(ctx context.Context, in resource.Input) (any, error) {
 	for _, srv := range parsed.Servers {
 		transport, err := srv.transport(f.httpClient)
 		if err != nil {
-			_ = source.Close()
+			if cerr := source.Close(); cerr != nil {
+				telemetry.WarnErr(ctx, "mcp: close partial source after transport failure", cerr)
+			}
 			return nil, err
 		}
 		if err := source.AddServer(ctx, srv.Name, transport, srv.options()...); err != nil {
-			_ = source.Close()
+			if cerr := source.Close(); cerr != nil {
+				telemetry.WarnErr(ctx, "mcp: close partial source after attach failure", cerr)
+			}
 			return nil, fmt.Errorf("mcp: attach server %q: %w", srv.Name, err)
 		}
 	}

--- a/core/tool/mcp/source.go
+++ b/core/tool/mcp/source.go
@@ -511,18 +511,18 @@ func (s *Source) attachSession(
 	srv.mu.Unlock()
 
 	if err := s.reconcile(ctx, srv); err != nil {
-		abandonAttach(srv, session)
+		abandonAttach(ctx, srv, session)
 		return err
 	}
 
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	if s.closed {
-		abandonAttach(srv, session)
+		abandonAttach(ctx, srv, session)
 		return errdefs.NotAvailablef("mcp: source is closed")
 	}
 	if other, exists := s.servers[srv.name]; exists && other != srv {
-		abandonAttach(srv, session)
+		abandonAttach(ctx, srv, session)
 		return errdefs.Validationf("mcp: server %q is already attached", srv.name)
 	}
 	s.servers[srv.name] = srv
@@ -533,13 +533,16 @@ func (s *Source) attachSession(
 // srv.session when it still points at the failed session and then
 // closes it, so every attachSession error path releases the connection
 // exactly once.
-func abandonAttach(srv *server, session *mcpsdk.ClientSession) {
+func abandonAttach(ctx context.Context, srv *server, session *mcpsdk.ClientSession) {
 	srv.mu.Lock()
 	if srv.session == session {
 		srv.session = nil
 	}
 	srv.mu.Unlock()
-	_ = session.Close()
+	if err := session.Close(); err != nil {
+		telemetry.WarnErr(ctx, "mcp: close abandoned server session failed", err,
+			otellog.String("mcp.server", srv.name))
+	}
 }
 
 // reconcile re-lists the server's tools and updates its projection,

--- a/core/tool/middleware/middleware_recover.go
+++ b/core/tool/middleware/middleware_recover.go
@@ -5,7 +5,10 @@ import (
 	"fmt"
 
 	"github.com/GizClaw/flowcraft/core/message"
+	"github.com/GizClaw/flowcraft/core/telemetry"
 	"github.com/GizClaw/flowcraft/core/tool"
+
+	otellog "go.opentelemetry.io/otel/log"
 )
 
 // Recover converts a panicking tool (or inner middleware) into an
@@ -17,6 +20,10 @@ func Recover() tool.Middleware {
 		return func(ctx context.Context, call message.ToolCall) (res message.ToolResult) {
 			defer func() {
 				if rv := recover(); rv != nil {
+					telemetry.Warn(ctx, "tool panicked",
+						otellog.String(telemetry.AttrToolName, call.Name),
+						otellog.String(telemetry.AttrToolCallID, call.ID),
+						otellog.String(telemetry.AttrErrorMessage, fmt.Sprint(rv)))
 					res = message.ToolResult{
 						CallID:  call.ID,
 						Content: fmt.Sprintf("tool %q panicked: %v", call.Name, rv),

--- a/core/tool/registry.go
+++ b/core/tool/registry.go
@@ -10,6 +10,9 @@ import (
 
 	"github.com/GizClaw/flowcraft/core/errdefs"
 	"github.com/GizClaw/flowcraft/core/message"
+	"github.com/GizClaw/flowcraft/core/telemetry"
+
+	otellog "go.opentelemetry.io/otel/log"
 )
 
 // ConflictPolicy decides what happens when two sources contribute a
@@ -132,7 +135,10 @@ func (r *Registry) Remove(name string) {
 	}
 	r.mu.Unlock()
 	if c, ok := t.(io.Closer); ok {
-		_ = c.Close()
+		if err := c.Close(); err != nil {
+			telemetry.WarnErr(context.Background(), "tool registry: close removed tool failed", err,
+				otellog.String(telemetry.AttrToolName, name))
+		}
 	}
 }
 
@@ -295,6 +301,10 @@ func (p *lazyProxy) load(ctx context.Context) (Tool, error) {
 	}
 	p.inner, p.err = p.spec.Load(ctx)
 	p.loaded = true
+	if p.err != nil {
+		telemetry.WarnErr(ctx, "tool registry: lazy tool load failed", p.err,
+			otellog.String(telemetry.AttrToolName, p.spec.Name))
+	}
 	return p.inner, p.err
 }
 

--- a/core/tool/session.go
+++ b/core/tool/session.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/GizClaw/flowcraft/core/errdefs"
 	"github.com/GizClaw/flowcraft/core/message"
+	"github.com/GizClaw/flowcraft/core/telemetry"
 )
 
 // Session is the per-run / per-conversation injection view over a
@@ -114,13 +115,17 @@ func (s *dynamicSession) AdvanceTurn() {
 
 func (s *dynamicSession) Search(ctx context.Context, query string, limit int) ([]SearchHit, error) {
 	if s.policy.SearchWithLoad {
-		_ = s.Load(ctx)
+		if err := s.Load(ctx); err != nil {
+			telemetry.WarnErr(ctx, "tool session: preload for search failed", err)
+		}
 	}
 	return s.search(ctx, query, limit)
 }
 
 func (s *dynamicSession) SearchWithLoad(ctx context.Context, query string, limit int) ([]SearchHit, error) {
-	_ = s.Load(ctx)
+	if err := s.Load(ctx); err != nil {
+		telemetry.WarnErr(ctx, "tool session: preload for search failed", err)
+	}
 	return s.search(ctx, query, limit)
 }
 

--- a/core/utils/httpkit.go
+++ b/core/utils/httpkit.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"github.com/GizClaw/flowcraft/core/errdefs"
+	"github.com/GizClaw/flowcraft/core/telemetry"
 
 	"golang.org/x/net/http2"
 )
@@ -298,7 +299,10 @@ func (t *retryTransport) RoundTrip(request *http.Request) (*http.Response, error
 		if response != nil && response.Body != nil {
 			// Drain so the pooled connection can be reused.
 			_, _ = io.Copy(io.Discard, io.LimitReader(response.Body, 4*1024))
-			_ = response.Body.Close()
+			if err := response.Body.Close(); err != nil {
+				telemetry.WarnErr(request.Context(),
+					"httpkit: close drained response body failed", err)
+			}
 		}
 
 		delay := t.backoff(attempt, response)

--- a/core/utils/net/mitm/bundle.go
+++ b/core/utils/net/mitm/bundle.go
@@ -1,8 +1,12 @@
 package mitm
 
 import (
+	"context"
+	"fmt"
 	"os"
 	"path/filepath"
+
+	"github.com/GizClaw/flowcraft/core/telemetry"
 )
 
 // systemBundleCandidates are the common system CA bundle locations on
@@ -25,22 +29,39 @@ func WriteBundle(caPEM []byte) (string, func(), error) {
 	if err != nil {
 		return "", nil, err
 	}
-	cleanup := func() { _ = os.RemoveAll(dir) }
+	cleanup := func() {
+		if err := os.RemoveAll(dir); err != nil {
+			telemetry.WarnErr(context.Background(),
+				"mitm: remove CA bundle temp dir failed", err)
+		}
+	}
 	path := filepath.Join(dir, "ca-bundle.pem")
 	f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o600)
 	if err != nil {
 		cleanup()
 		return "", nil, err
 	}
+	var writeErr error
 	for _, candidate := range systemBundleCandidates {
 		data, readErr := os.ReadFile(candidate)
 		if readErr != nil {
 			continue
 		}
-		_, _ = f.Write(data)
-		_, _ = f.Write([]byte("\n"))
+		if _, err := f.Write(data); err != nil && writeErr == nil {
+			writeErr = err
+		}
+		if _, err := f.Write([]byte("\n")); err != nil && writeErr == nil {
+			writeErr = err
+		}
 	}
-	_, _ = f.Write(caPEM)
+	if _, err := f.Write(caPEM); err != nil && writeErr == nil {
+		writeErr = err
+	}
+	if writeErr != nil {
+		_ = f.Close()
+		cleanup()
+		return "", nil, fmt.Errorf("mitm: write CA bundle: %w", writeErr)
+	}
 	if err := f.Close(); err != nil {
 		cleanup()
 		return "", nil, err

--- a/core/utils/net/mitm/engine.go
+++ b/core/utils/net/mitm/engine.go
@@ -13,6 +13,7 @@ import (
 	"net/http"
 	"net/netip"
 
+	"github.com/GizClaw/flowcraft/core/telemetry"
 	corenet "github.com/GizClaw/flowcraft/core/utils/net"
 	"golang.org/x/net/http2"
 )
@@ -121,7 +122,11 @@ func (e *Engine) Serve(client net.Conn, serverName, dialHostport string) error {
 	if err := tlsConn.Handshake(); err != nil {
 		return fmt.Errorf("mitm: client handshake: %w", err)
 	}
-	defer func() { _ = tlsConn.Close() }()
+	defer func() {
+		if err := tlsConn.Close(); err != nil {
+			telemetry.WarnErr(context.Background(), "mitm: close client tls conn failed", err)
+		}
+	}()
 
 	transport := e.newTransport(serverName, dialHostport)
 	defer transport.CloseIdleConnections()
@@ -185,7 +190,11 @@ func (e *Engine) serveH2(w http.ResponseWriter, r *http.Request, transport *http
 		http.Error(w, "mitm: upstream request failed", http.StatusBadGateway)
 		return
 	}
-	defer func() { _ = resp.Body.Close() }()
+	defer func() {
+		if err := resp.Body.Close(); err != nil {
+			telemetry.WarnErr(r.Context(), "mitm: close upstream response body failed", err)
+		}
+	}()
 	copyResponse(w, resp)
 }
 
@@ -212,12 +221,16 @@ func (e *Engine) forward(req *http.Request, transport *http.Transport, serverNam
 	}
 	respInfo, err := e.inspectResponse(resp)
 	if err != nil {
-		_ = resp.Body.Close()
+		if cerr := resp.Body.Close(); cerr != nil {
+			telemetry.WarnErr(context.Background(), "mitm: close inspected response body failed", cerr)
+		}
 		return nil, err
 	}
 	if e.hooks != nil && respInfo != nil {
 		if err := e.hooks.OnResponse(context.Background(), respInfo); err != nil {
-			_ = resp.Body.Close()
+			if cerr := resp.Body.Close(); cerr != nil {
+				telemetry.WarnErr(context.Background(), "mitm: close response body after hook failure", cerr)
+			}
 			return nil, errBlocked
 		}
 	}
@@ -325,7 +338,9 @@ func (e *Engine) dialTLS(ctx context.Context, hostport, serverName string) (net.
 		MinVersion: tls.VersionTLS12,
 	})
 	if err := tlsConn.HandshakeContext(ctx); err != nil {
-		_ = raw.Close()
+		if cerr := raw.Close(); cerr != nil {
+			telemetry.WarnErr(ctx, "mitm: close upstream conn after handshake failure", cerr)
+		}
 		return nil, fmt.Errorf("mitm: upstream handshake: %w", err)
 	}
 	return tlsConn, nil

--- a/core/utils/net/netproxy.go
+++ b/core/utils/net/netproxy.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"crypto/x509"
 	"encoding/base64"
+	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -17,6 +18,9 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/GizClaw/flowcraft/core/telemetry"
+
+	otellog "go.opentelemetry.io/otel/log"
 	"golang.org/x/net/proxy"
 )
 
@@ -203,12 +207,21 @@ func Start(cfg ProxyConfig) (*Proxy, error) {
 		path := filepath.Join(dir, "proxy.sock")
 		ln, err := net.Listen("unix", path)
 		if err != nil {
-			_ = os.RemoveAll(dir)
+			if rerr := os.RemoveAll(dir); rerr != nil {
+				telemetry.WarnErr(context.Background(),
+					"netproxy: remove temp dir after listen failure", rerr)
+			}
 			return nil, fmt.Errorf("netproxy: listen: %w", err)
 		}
 		if err := os.Chmod(path, 0o600); err != nil {
-			_ = ln.Close()
-			_ = os.RemoveAll(dir)
+			if cerr := ln.Close(); cerr != nil {
+				telemetry.WarnErr(context.Background(),
+					"netproxy: close listener after chmod failure", cerr)
+			}
+			if rerr := os.RemoveAll(dir); rerr != nil {
+				telemetry.WarnErr(context.Background(),
+					"netproxy: remove temp dir after chmod failure", rerr)
+			}
 			return nil, fmt.Errorf("netproxy: chmod socket: %w", err)
 		}
 		p.ln = ln
@@ -216,7 +229,11 @@ func Start(cfg ProxyConfig) (*Proxy, error) {
 		p.path = path
 	}
 	p.srv = &http.Server{Handler: p}
-	go func() { _ = p.srv.Serve(p.ln) }()
+	go func() {
+		if err := p.srv.Serve(p.ln); err != nil && !errors.Is(err, http.ErrServerClosed) {
+			telemetry.WarnErr(context.Background(), "netproxy: serve failed", err)
+		}
+	}()
 	return p, nil
 }
 
@@ -241,11 +258,19 @@ func (p *Proxy) CAPEM() []byte {
 // Close stops the server, closes the listener, and removes the temp
 // directory (including the socket file) when one was created.
 func (p *Proxy) Close() error {
-	_ = p.srv.Close()
-	_ = p.ln.Close()
+	if err := p.srv.Close(); err != nil && !errors.Is(err, http.ErrServerClosed) {
+		telemetry.WarnErr(context.Background(), "netproxy: close server failed", err)
+	}
+	if err := p.ln.Close(); err != nil && !errors.Is(err, net.ErrClosed) {
+		telemetry.WarnErr(context.Background(), "netproxy: close listener failed", err)
+	}
 	p.transport.CloseIdleConnections()
 	if p.dir != "" {
-		return os.RemoveAll(p.dir)
+		err := os.RemoveAll(p.dir)
+		if err != nil {
+			telemetry.WarnErr(context.Background(), "netproxy: remove temp dir failed", err)
+		}
+		return err
 	}
 	return nil
 }
@@ -287,7 +312,11 @@ func (p *Proxy) serveHTTP(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "netproxy: "+err.Error(), http.StatusBadGateway)
 		return
 	}
-	defer func() { _ = resp.Body.Close() }()
+	defer func() {
+		if err := resp.Body.Close(); err != nil {
+			telemetry.WarnErr(r.Context(), "netproxy: close upstream response body failed", err)
+		}
+	}()
 	copyHeader(w.Header(), resp.Header)
 	w.WriteHeader(resp.StatusCode)
 	_, _ = io.Copy(w, resp.Body)
@@ -320,7 +349,11 @@ func (p *Proxy) serveConnect(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		return
 	}
-	defer func() { _ = client.Close() }()
+	defer func() {
+		if err := client.Close(); err != nil {
+			telemetry.WarnErr(r.Context(), "netproxy: close hijacked client failed", err)
+		}
+	}()
 
 	if _, err := client.Write([]byte("HTTP/1.1 200 Connection Established\r\n\r\n")); err != nil {
 		return
@@ -336,8 +369,20 @@ func (p *Proxy) serveConnect(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		return
 	}
-	defer func() { _ = target.Close() }()
-	go func() { _, _ = io.Copy(target, client); _ = target.Close() }()
+	defer func() {
+		if err := target.Close(); err != nil {
+			telemetry.WarnErr(r.Context(), "netproxy: close tunnel target failed", err)
+		}
+	}()
+	go func() {
+		if _, err := io.Copy(target, client); err != nil {
+			telemetry.Debug(r.Context(), "netproxy: tunnel upstream copy ended with error",
+				otellog.String(telemetry.AttrErrorMessage, err.Error()))
+		}
+		if err := target.Close(); err != nil {
+			telemetry.WarnErr(r.Context(), "netproxy: close tunnel target after copy failed", err)
+		}
+	}()
 	_, _ = io.Copy(client, target)
 }
 
@@ -447,17 +492,23 @@ func (p *Proxy) dialTarget(ctx context.Context, hostport string) (net.Conn, erro
 			}
 			req += "\r\n\r\n"
 			if _, err := io.WriteString(up, req); err != nil {
-				_ = up.Close()
+				if cerr := up.Close(); cerr != nil {
+					telemetry.WarnErr(ctx, "netproxy: close upstream after write failure", cerr)
+				}
 				return nil, err
 			}
 			br := bufio.NewReader(up)
 			resp, err := http.ReadResponse(br, &http.Request{Method: http.MethodConnect})
 			if err != nil {
-				_ = up.Close()
+				if cerr := up.Close(); cerr != nil {
+					telemetry.WarnErr(ctx, "netproxy: close upstream after response failure", cerr)
+				}
 				return nil, err
 			}
 			if resp.StatusCode != http.StatusOK {
-				_ = up.Close()
+				if cerr := up.Close(); cerr != nil {
+					telemetry.WarnErr(ctx, "netproxy: close upstream after refusal", cerr)
+				}
 				return nil, fmt.Errorf("netproxy: upstream refused CONNECT: %d", resp.StatusCode)
 			}
 			return up, nil

--- a/driver/anthropic/generate_anthropic.go
+++ b/driver/anthropic/generate_anthropic.go
@@ -178,9 +178,17 @@ func transportGenerate(
 	return func(ctx context.Context, wire generateWire) (generateRaw, error) {
 		message, err := client.Messages.New(ctx, wireToParams(wire))
 		if err != nil {
-			return generateRaw{}, classifyError(err)
+			classified := classifyError(err)
+			logInferenceCall(ctx, "generate", wire.model, classified, "", "")
+			return generateRaw{}, classified
 		}
-		return messageToRaw(message)
+		raw, err := messageToRaw(message)
+		if err != nil {
+			logInferenceCall(ctx, "generate", wire.model, err, "", "")
+			return generateRaw{}, err
+		}
+		logInferenceCall(ctx, "generate", wire.model, nil, "", raw.id)
+		return raw, nil
 	}
 }
 

--- a/driver/anthropic/generate_stream.go
+++ b/driver/anthropic/generate_stream.go
@@ -42,8 +42,11 @@ func transportGenerateStream(
 	) (inference.ProviderStream[streamRaw], error) {
 		stream := client.Messages.NewStreaming(ctx, wireToParams(wire))
 		if err := stream.Err(); err != nil {
-			return nil, classifyError(err)
+			classified := classifyError(err)
+			logInferenceStream(ctx, "generate", wire.model, classified, "")
+			return nil, classified
 		}
+		logInferenceStream(ctx, "generate", wire.model, nil, "")
 		return &messagesStream{
 			stream: stream,
 			parts:  make(map[int64]*streamPart),
@@ -65,7 +68,9 @@ func (s *messagesStream) Next(ctx context.Context) (streamRaw, error) {
 	for {
 		if !s.stream.Next() {
 			if err := s.stream.Err(); err != nil {
-				return streamRaw{}, classifyError(err)
+				classified := classifyError(err)
+				logInferenceStream(ctx, "generate", "", classified, "")
+				return streamRaw{}, classified
 			}
 			return streamRaw{}, io.EOF
 		}
@@ -239,7 +244,7 @@ func (s *messagesStream) finishEvent(
 // decodeGenerateStream is pure: streamRaw already carries canonical part
 // indices assigned by the stateful transport.
 func decodeGenerateStream(
-	_ context.Context,
+	ctx context.Context,
 	raw streamRaw,
 ) (inference.GenerateStreamEvent, error) {
 	switch raw.kind {
@@ -270,6 +275,7 @@ func decodeGenerateStream(
 			FinishReason: raw.finish,
 			ResponseID:   raw.responseID,
 		}
+		logInferenceStreamEnd(ctx, "generate", raw.responseID)
 		if raw.usage != nil {
 			usage := rawUsageCanonical(*raw.usage)
 			event.Usage = &usage

--- a/driver/anthropic/telemetry.go
+++ b/driver/anthropic/telemetry.go
@@ -1,0 +1,79 @@
+package anthropic
+
+import (
+	"context"
+
+	"github.com/GizClaw/flowcraft/core/errdefs"
+	"github.com/GizClaw/flowcraft/core/telemetry"
+
+	otellog "go.opentelemetry.io/otel/log"
+)
+
+// providerID is the stable telemetry token for this provider, matching
+// the inference.ModelID.Provider values in the catalog.
+const providerID = "anthropic"
+
+func logInferenceCall(
+	ctx context.Context,
+	op, model string,
+	err error,
+	requestID, responseID string,
+) {
+	attrs := inferenceAttrs(op, model, err, requestID, responseID)
+	if err != nil {
+		telemetry.Warn(ctx, "anthropic inference request failed", attrs...)
+		return
+	}
+	telemetry.Debug(ctx, "anthropic inference request completed", attrs...)
+}
+
+func logInferenceStream(
+	ctx context.Context,
+	op, model string,
+	err error,
+	requestID string,
+) {
+	attrs := inferenceAttrs(op, model, err, requestID, "")
+	if err != nil {
+		telemetry.Warn(ctx, "anthropic inference stream failed", attrs...)
+		return
+	}
+	telemetry.Debug(ctx, "anthropic inference stream opened", attrs...)
+}
+
+func logInferenceStreamEnd(ctx context.Context, op, responseID string) {
+	if responseID == "" {
+		return
+	}
+	telemetry.Debug(ctx, "anthropic inference stream completed",
+		inferenceAttrs(op, "", nil, "", responseID)...)
+}
+
+func inferenceAttrs(
+	op, model string,
+	err error,
+	requestID, responseID string,
+) []otellog.KeyValue {
+	attrs := []otellog.KeyValue{
+		otellog.String(telemetry.AttrLLMProvider, providerID),
+	}
+	if op != "" {
+		attrs = append(attrs, otellog.String("inference.operation", op))
+	}
+	if model != "" {
+		attrs = append(attrs, otellog.String(telemetry.AttrLLMModel, model))
+	}
+	if requestID == "" {
+		requestID, _ = errdefs.RequestID(err)
+	}
+	if requestID != "" {
+		attrs = append(attrs, otellog.String(telemetry.AttrLLMRequestID, requestID))
+	}
+	if responseID != "" {
+		attrs = append(attrs, otellog.String(telemetry.AttrLLMResponseID, responseID))
+	}
+	if err != nil {
+		attrs = append(attrs, otellog.String(telemetry.AttrErrorMessage, err.Error()))
+	}
+	return attrs
+}

--- a/driver/azure/embed.go
+++ b/driver/azure/embed.go
@@ -128,7 +128,9 @@ func transportEmbed(
 		}
 		response, err := client.Embeddings.New(ctx, params)
 		if err != nil {
-			return embedRaw{}, classifyError(err)
+			classified := classifyError(err)
+			logInferenceCall(ctx, "embed", wire.model, classified, "", "")
+			return embedRaw{}, classified
 		}
 		vectors := make([][]float32, len(response.Data))
 		for _, item := range response.Data {
@@ -144,10 +146,12 @@ func transportEmbed(
 			}
 			vectors[item.Index] = vector
 		}
-		return embedRaw{
+		raw := embedRaw{
 			vectors:     vectors,
 			inputTokens: response.Usage.TotalTokens,
-		}, nil
+		}
+		logInferenceCall(ctx, "embed", wire.model, nil, "", "")
+		return raw, nil
 	}
 }
 

--- a/driver/azure/generate_openai.go
+++ b/driver/azure/generate_openai.go
@@ -233,9 +233,17 @@ func transportGenerate(
 	return func(ctx context.Context, wire generateWire) (generateRaw, error) {
 		response, err := client.Responses.New(ctx, wireToParams(wire))
 		if err != nil {
-			return generateRaw{}, classifyError(err)
+			classified := classifyError(err)
+			logInferenceCall(ctx, "generate", wire.model, classified, "", "")
+			return generateRaw{}, classified
 		}
-		return responseToRaw(response)
+		raw, err := responseToRaw(response)
+		if err != nil {
+			logInferenceCall(ctx, "generate", wire.model, err, "", "")
+			return generateRaw{}, err
+		}
+		logInferenceCall(ctx, "generate", wire.model, nil, "", raw.id)
+		return raw, nil
 	}
 }
 

--- a/driver/azure/generate_stream.go
+++ b/driver/azure/generate_stream.go
@@ -51,8 +51,11 @@ func transportGenerateStream(
 	) (inference.ProviderStream[streamRaw], error) {
 		stream := client.Responses.NewStreaming(ctx, wireToParams(wire))
 		if err := stream.Err(); err != nil {
-			return nil, classifyError(err)
+			classified := classifyError(err)
+			logInferenceStream(ctx, "generate", wire.model, classified, "")
+			return nil, classified
 		}
+		logInferenceStream(ctx, "generate", wire.model, nil, "")
 		return &responsesStream{
 			stream: stream,
 			parts:  make(map[int64]*streamPart),
@@ -74,7 +77,9 @@ func (s *responsesStream) Next(ctx context.Context) (streamRaw, error) {
 	for {
 		if !s.stream.Next() {
 			if err := s.stream.Err(); err != nil {
-				return streamRaw{}, classifyError(err)
+				classified := classifyError(err)
+				logInferenceStream(ctx, "generate", "", classified, "")
+				return streamRaw{}, classified
 			}
 			return streamRaw{}, io.EOF
 		}
@@ -361,7 +366,7 @@ func openaiAnnotationCitation(annotation any) (inference.Citation, bool) {
 // decodeGenerateStream is pure: streamRaw already carries canonical part
 // indices assigned by the stateful transport.
 func decodeGenerateStream(
-	_ context.Context,
+	ctx context.Context,
 	raw streamRaw,
 ) (inference.GenerateStreamEvent, error) {
 	switch raw.kind {
@@ -398,6 +403,7 @@ func decodeGenerateStream(
 			ResponseID:      raw.responseID,
 			ProviderOutputs: raw.providerOutputs.Clone(),
 		}
+		logInferenceStreamEnd(ctx, "generate", raw.responseID)
 		if raw.usage != nil {
 			usage := rawUsageCanonical(*raw.usage)
 			event.Usage = &usage

--- a/driver/azure/telemetry.go
+++ b/driver/azure/telemetry.go
@@ -1,0 +1,79 @@
+package azure
+
+import (
+	"context"
+
+	"github.com/GizClaw/flowcraft/core/errdefs"
+	"github.com/GizClaw/flowcraft/core/telemetry"
+
+	otellog "go.opentelemetry.io/otel/log"
+)
+
+// providerID is the stable telemetry token for this provider, matching
+// the inference.ModelID.Provider values in the catalog.
+const providerID = "azure"
+
+func logInferenceCall(
+	ctx context.Context,
+	op, model string,
+	err error,
+	requestID, responseID string,
+) {
+	attrs := inferenceAttrs(op, model, err, requestID, responseID)
+	if err != nil {
+		telemetry.Warn(ctx, "azure inference request failed", attrs...)
+		return
+	}
+	telemetry.Debug(ctx, "azure inference request completed", attrs...)
+}
+
+func logInferenceStream(
+	ctx context.Context,
+	op, model string,
+	err error,
+	requestID string,
+) {
+	attrs := inferenceAttrs(op, model, err, requestID, "")
+	if err != nil {
+		telemetry.Warn(ctx, "azure inference stream failed", attrs...)
+		return
+	}
+	telemetry.Debug(ctx, "azure inference stream opened", attrs...)
+}
+
+func logInferenceStreamEnd(ctx context.Context, op, responseID string) {
+	if responseID == "" {
+		return
+	}
+	telemetry.Debug(ctx, "azure inference stream completed",
+		inferenceAttrs(op, "", nil, "", responseID)...)
+}
+
+func inferenceAttrs(
+	op, model string,
+	err error,
+	requestID, responseID string,
+) []otellog.KeyValue {
+	attrs := []otellog.KeyValue{
+		otellog.String(telemetry.AttrLLMProvider, providerID),
+	}
+	if op != "" {
+		attrs = append(attrs, otellog.String("inference.operation", op))
+	}
+	if model != "" {
+		attrs = append(attrs, otellog.String(telemetry.AttrLLMModel, model))
+	}
+	if requestID == "" {
+		requestID, _ = errdefs.RequestID(err)
+	}
+	if requestID != "" {
+		attrs = append(attrs, otellog.String(telemetry.AttrLLMRequestID, requestID))
+	}
+	if responseID != "" {
+		attrs = append(attrs, otellog.String(telemetry.AttrLLMResponseID, responseID))
+	}
+	if err != nil {
+		attrs = append(attrs, otellog.String(telemetry.AttrErrorMessage, err.Error()))
+	}
+	return attrs
+}

--- a/driver/bytedance/embed.go
+++ b/driver/bytedance/embed.go
@@ -167,10 +167,19 @@ func transportEmbed(
 	client *arkruntime.Client,
 ) inference.Transport[embedWire, embedRaw] {
 	return func(ctx context.Context, wire embedWire) (embedRaw, error) {
+		var raw embedRaw
+		var err error
 		if wire.multimodal {
-			return transportEmbedMultimodal(ctx, client, wire)
+			raw, err = transportEmbedMultimodal(ctx, client, wire)
+		} else {
+			raw, err = transportEmbedText(ctx, client, wire)
 		}
-		return transportEmbedText(ctx, client, wire)
+		if err != nil {
+			logInferenceCall(ctx, "embed", wire.model, err, "", "")
+			return raw, err
+		}
+		logInferenceCall(ctx, "embed", wire.model, nil, "", "")
+		return raw, nil
 	}
 }
 

--- a/driver/bytedance/generate_ark.go
+++ b/driver/bytedance/generate_ark.go
@@ -309,9 +309,17 @@ func transportGenerate(client *arkruntime.Client) inference.Transport[generateWi
 	return func(ctx context.Context, wire generateWire) (generateRaw, error) {
 		response, err := client.CreateResponses(ctx, wireToArk(wire))
 		if err != nil {
-			return generateRaw{}, classifyError(err)
+			classified := classifyError(err)
+			logInferenceCall(ctx, "generate", wire.model, classified, "", "")
+			return generateRaw{}, classified
 		}
-		return arkToRaw(response)
+		raw, err := arkToRaw(response)
+		if err != nil {
+			logInferenceCall(ctx, "generate", wire.model, err, "", "")
+			return generateRaw{}, err
+		}
+		logInferenceCall(ctx, "generate", wire.model, nil, "", raw.id)
+		return raw, nil
 	}
 }
 

--- a/driver/bytedance/generate_stream.go
+++ b/driver/bytedance/generate_stream.go
@@ -49,8 +49,11 @@ func transportGenerateStream(
 	) (inference.ProviderStream[streamRaw], error) {
 		reader, err := client.CreateResponsesStream(ctx, wireToArk(wire))
 		if err != nil {
-			return nil, classifyError(err)
+			classified := classifyError(err)
+			logInferenceStream(ctx, "generate", wire.model, classified, "")
+			return nil, classified
 		}
+		logInferenceStream(ctx, "generate", wire.model, nil, "")
 		return &responsesStream{
 			reader: reader,
 			parts:  make(map[int64]*streamPart),
@@ -75,7 +78,9 @@ func (s *responsesStream) Next(ctx context.Context) (streamRaw, error) {
 			if errors.Is(err, io.EOF) {
 				return streamRaw{}, io.EOF
 			}
-			return streamRaw{}, classifyError(err)
+			classified := classifyError(err)
+			logInferenceStream(ctx, "generate", "", classified, "")
+			return streamRaw{}, classified
 		}
 		if event == nil {
 			continue
@@ -391,7 +396,7 @@ func arkIncompleteFinish(reason string) inference.FinishReason {
 // decodeGenerateStream is pure: streamRaw already carries canonical part
 // indices assigned by the stateful transport.
 func decodeGenerateStream(
-	_ context.Context,
+	ctx context.Context,
 	raw streamRaw,
 ) (inference.GenerateStreamEvent, error) {
 	switch raw.kind {
@@ -427,6 +432,7 @@ func decodeGenerateStream(
 			ResponseID:      raw.responseID,
 			ProviderOutputs: raw.providerOutputs.Clone(),
 		}
+		logInferenceStreamEnd(ctx, "generate", raw.responseID)
 		if raw.usage != nil {
 			usage := rawUsageCanonical(*raw.usage)
 			event.Usage = &usage

--- a/driver/bytedance/telemetry.go
+++ b/driver/bytedance/telemetry.go
@@ -1,0 +1,79 @@
+package bytedance
+
+import (
+	"context"
+
+	"github.com/GizClaw/flowcraft/core/errdefs"
+	"github.com/GizClaw/flowcraft/core/telemetry"
+
+	otellog "go.opentelemetry.io/otel/log"
+)
+
+// providerID is the stable telemetry token for this provider, matching
+// the inference.ModelID.Provider values in the catalog.
+const providerID = "bytedance"
+
+func logInferenceCall(
+	ctx context.Context,
+	op, model string,
+	err error,
+	requestID, responseID string,
+) {
+	attrs := inferenceAttrs(op, model, err, requestID, responseID)
+	if err != nil {
+		telemetry.Warn(ctx, "bytedance inference request failed", attrs...)
+		return
+	}
+	telemetry.Debug(ctx, "bytedance inference request completed", attrs...)
+}
+
+func logInferenceStream(
+	ctx context.Context,
+	op, model string,
+	err error,
+	requestID string,
+) {
+	attrs := inferenceAttrs(op, model, err, requestID, "")
+	if err != nil {
+		telemetry.Warn(ctx, "bytedance inference stream failed", attrs...)
+		return
+	}
+	telemetry.Debug(ctx, "bytedance inference stream opened", attrs...)
+}
+
+func logInferenceStreamEnd(ctx context.Context, op, responseID string) {
+	if responseID == "" {
+		return
+	}
+	telemetry.Debug(ctx, "bytedance inference stream completed",
+		inferenceAttrs(op, "", nil, "", responseID)...)
+}
+
+func inferenceAttrs(
+	op, model string,
+	err error,
+	requestID, responseID string,
+) []otellog.KeyValue {
+	attrs := []otellog.KeyValue{
+		otellog.String(telemetry.AttrLLMProvider, providerID),
+	}
+	if op != "" {
+		attrs = append(attrs, otellog.String("inference.operation", op))
+	}
+	if model != "" {
+		attrs = append(attrs, otellog.String(telemetry.AttrLLMModel, model))
+	}
+	if requestID == "" {
+		requestID, _ = errdefs.RequestID(err)
+	}
+	if requestID != "" {
+		attrs = append(attrs, otellog.String(telemetry.AttrLLMRequestID, requestID))
+	}
+	if responseID != "" {
+		attrs = append(attrs, otellog.String(telemetry.AttrLLMResponseID, responseID))
+	}
+	if err != nil {
+		attrs = append(attrs, otellog.String(telemetry.AttrErrorMessage, err.Error()))
+	}
+	return attrs
+}

--- a/driver/bytedance/transcribe.go
+++ b/driver/bytedance/transcribe.go
@@ -9,8 +9,10 @@ import (
 
 	"github.com/GizClaw/flowcraft/core/inference"
 	"github.com/GizClaw/flowcraft/core/message/media"
+	"github.com/GizClaw/flowcraft/core/telemetry"
 
 	doubaospeech "github.com/GizClaw/doubao-speech-go"
+	otellog "go.opentelemetry.io/otel/log"
 )
 
 // Speech recognition runs on the Doubao ASR V2 SAUC WebSocket endpoint
@@ -270,9 +272,16 @@ func transportTranscribe(
 			asrConfig(wire),
 		)
 		if err != nil {
-			return transcribeRaw{}, classifyError(err)
+			classified := classifyError(err)
+			logInferenceCall(ctx, "transcribe", "", classified, "", "")
+			return transcribeRaw{}, classified
 		}
-		defer func() { _ = session.Close() }()
+		defer func() {
+			if cerr := session.Close(); cerr != nil {
+				telemetry.WarnErr(ctx, "bytedance: close transcription session failed", cerr,
+					otellog.String(telemetry.AttrLLMProvider, providerID))
+			}
+		}()
 
 		for offset := 0; offset < len(wire.audio); offset += asrChunkSize {
 			end := min(offset+asrChunkSize, len(wire.audio))
@@ -282,14 +291,18 @@ func transportTranscribe(
 				wire.audio[offset:end],
 				isLast,
 			); err != nil {
-				return transcribeRaw{}, classifyError(err)
+				classified := classifyError(err)
+				logInferenceCall(ctx, "transcribe", "", classified, "", "")
+				return transcribeRaw{}, classified
 			}
 		}
 
 		raw := transcribeRaw{}
 		for result, err := range session.Recv() {
 			if err != nil {
-				return transcribeRaw{}, classifyError(err)
+				classified := classifyError(err)
+				logInferenceCall(ctx, "transcribe", "", classified, "", "")
+				return transcribeRaw{}, classified
 			}
 			if result == nil {
 				continue
@@ -301,14 +314,18 @@ func transportTranscribe(
 				requestID:  result.ReqID,
 			}
 			if result.IsFinal {
+				logInferenceCall(ctx, "transcribe", "", nil, raw.requestID, "")
 				return raw, nil
 			}
 		}
 		if raw.text == "" && len(raw.utterances) == 0 {
-			return transcribeRaw{}, fmt.Errorf(
+			noResultErr := fmt.Errorf(
 				"bytedance: transcription produced no result",
 			)
+			logInferenceCall(ctx, "transcribe", "", noResultErr, "", "")
+			return transcribeRaw{}, noResultErr
 		}
+		logInferenceCall(ctx, "transcribe", "", nil, raw.requestID, "")
 		return raw, nil
 	}
 }

--- a/driver/deepseek/generate.go
+++ b/driver/deepseek/generate.go
@@ -272,7 +272,7 @@ func rawUsageCanonical(raw rawUsage) inference.Usage {
 // decodeGenerateStream is the pure stage: streamRaw already carries
 // canonical part indices assigned by the stateful transport.
 func decodeGenerateStream(
-	_ context.Context,
+	ctx context.Context,
 	raw streamRaw,
 ) (inference.GenerateStreamEvent, error) {
 	switch raw.kind {
@@ -308,6 +308,7 @@ func decodeGenerateStream(
 			ResponseID:      raw.responseID,
 			ProviderOutputs: raw.providerOutputs.Clone(),
 		}
+		logInferenceStreamEnd(ctx, "generate", raw.responseID)
 		if raw.usage != nil {
 			usage := rawUsageCanonical(*raw.usage)
 			event.Usage = &usage

--- a/driver/deepseek/generate_chat.go
+++ b/driver/deepseek/generate_chat.go
@@ -494,9 +494,17 @@ func transportChatGenerate(
 		params, overrides := wireToChatParams(wire)
 		response, err := client.Chat.Completions.New(ctx, params, overrides...)
 		if err != nil {
-			return generateRaw{}, classifyError(err)
+			classified := classifyError(err)
+			logInferenceCall(ctx, "generate", wire.model, classified, "", "")
+			return generateRaw{}, classified
 		}
-		return chatCompletionToRaw(response)
+		raw, err := chatCompletionToRaw(response)
+		if err != nil {
+			logInferenceCall(ctx, "generate", wire.model, err, "", "")
+			return generateRaw{}, err
+		}
+		logInferenceCall(ctx, "generate", wire.model, nil, "", raw.id)
+		return raw, nil
 	}
 }
 
@@ -633,8 +641,11 @@ func transportChatGenerateStream(
 				"deepseek: nil stream handle (provider misbehaviour)")
 		}
 		if err := stream.Err(); err != nil {
-			return nil, classifyError(err)
+			classified := classifyError(err)
+			logInferenceStream(ctx, "generate", wire.model, classified, "")
+			return nil, classified
 		}
+		logInferenceStream(ctx, "generate", wire.model, nil, "")
 		return &chatStream{
 			stream:        stream,
 			reasoningPart: -1,
@@ -666,7 +677,9 @@ func (s *chatStream) Next(ctx context.Context) (streamRaw, error) {
 		}
 		if !s.stream.Next() {
 			if err := s.stream.Err(); err != nil {
-				return streamRaw{}, classifyError(err)
+				classified := classifyError(err)
+				logInferenceStream(ctx, "generate", "", classified, "")
+				return streamRaw{}, classified
 			}
 			s.end()
 			continue

--- a/driver/deepseek/generate_responses.go
+++ b/driver/deepseek/generate_responses.go
@@ -631,9 +631,17 @@ func transportResponsesGenerate(
 	return func(ctx context.Context, wire responseWire) (generateRaw, error) {
 		response, err := client.Responses.New(ctx, wireToResponseParams(wire))
 		if err != nil {
-			return generateRaw{}, classifyError(err)
+			classified := classifyError(err)
+			logInferenceCall(ctx, "generate", wire.model, classified, "", "")
+			return generateRaw{}, classified
 		}
-		return responsesToRaw(response)
+		raw, err := responsesToRaw(response)
+		if err != nil {
+			logInferenceCall(ctx, "generate", wire.model, err, "", "")
+			return generateRaw{}, err
+		}
+		logInferenceCall(ctx, "generate", wire.model, nil, "", raw.id)
+		return raw, nil
 	}
 }
 
@@ -840,8 +848,11 @@ func transportResponsesGenerateStream(
 	) (inference.ProviderStream[streamRaw], error) {
 		stream := client.Responses.NewStreaming(ctx, wireToResponseParams(wire))
 		if err := stream.Err(); err != nil {
-			return nil, classifyError(err)
+			classified := classifyError(err)
+			logInferenceStream(ctx, "generate", wire.model, classified, "")
+			return nil, classified
 		}
+		logInferenceStream(ctx, "generate", wire.model, nil, "")
 		return &deepseekStream{
 			stream: stream,
 			parts:  make(map[int64]*deepseekStreamPart),
@@ -863,7 +874,9 @@ func (s *deepseekStream) Next(ctx context.Context) (streamRaw, error) {
 	for {
 		if !s.stream.Next() {
 			if err := s.stream.Err(); err != nil {
-				return streamRaw{}, classifyError(err)
+				classified := classifyError(err)
+				logInferenceStream(ctx, "generate", "", classified, "")
+				return streamRaw{}, classified
 			}
 			return streamRaw{}, io.EOF
 		}

--- a/driver/deepseek/telemetry.go
+++ b/driver/deepseek/telemetry.go
@@ -1,0 +1,79 @@
+package deepseek
+
+import (
+	"context"
+
+	"github.com/GizClaw/flowcraft/core/errdefs"
+	"github.com/GizClaw/flowcraft/core/telemetry"
+
+	otellog "go.opentelemetry.io/otel/log"
+)
+
+// providerID is the stable telemetry token for this provider, matching
+// the inference.ModelID.Provider values in the catalog.
+const providerID = "deepseek"
+
+func logInferenceCall(
+	ctx context.Context,
+	op, model string,
+	err error,
+	requestID, responseID string,
+) {
+	attrs := inferenceAttrs(op, model, err, requestID, responseID)
+	if err != nil {
+		telemetry.Warn(ctx, "deepseek inference request failed", attrs...)
+		return
+	}
+	telemetry.Debug(ctx, "deepseek inference request completed", attrs...)
+}
+
+func logInferenceStream(
+	ctx context.Context,
+	op, model string,
+	err error,
+	requestID string,
+) {
+	attrs := inferenceAttrs(op, model, err, requestID, "")
+	if err != nil {
+		telemetry.Warn(ctx, "deepseek inference stream failed", attrs...)
+		return
+	}
+	telemetry.Debug(ctx, "deepseek inference stream opened", attrs...)
+}
+
+func logInferenceStreamEnd(ctx context.Context, op, responseID string) {
+	if responseID == "" {
+		return
+	}
+	telemetry.Debug(ctx, "deepseek inference stream completed",
+		inferenceAttrs(op, "", nil, "", responseID)...)
+}
+
+func inferenceAttrs(
+	op, model string,
+	err error,
+	requestID, responseID string,
+) []otellog.KeyValue {
+	attrs := []otellog.KeyValue{
+		otellog.String(telemetry.AttrLLMProvider, providerID),
+	}
+	if op != "" {
+		attrs = append(attrs, otellog.String("inference.operation", op))
+	}
+	if model != "" {
+		attrs = append(attrs, otellog.String(telemetry.AttrLLMModel, model))
+	}
+	if requestID == "" {
+		requestID, _ = errdefs.RequestID(err)
+	}
+	if requestID != "" {
+		attrs = append(attrs, otellog.String(telemetry.AttrLLMRequestID, requestID))
+	}
+	if responseID != "" {
+		attrs = append(attrs, otellog.String(telemetry.AttrLLMResponseID, responseID))
+	}
+	if err != nil {
+		attrs = append(attrs, otellog.String(telemetry.AttrErrorMessage, err.Error()))
+	}
+	return attrs
+}

--- a/driver/kimi/client.go
+++ b/driver/kimi/client.go
@@ -12,7 +12,10 @@ import (
 	"time"
 
 	"github.com/GizClaw/flowcraft/core/errdefs"
+	"github.com/GizClaw/flowcraft/core/telemetry"
 	"github.com/GizClaw/flowcraft/core/utils"
+
+	otellog "go.opentelemetry.io/otel/log"
 )
 
 const defaultBaseURL = "https://api.moonshot.cn/v1"
@@ -106,7 +109,12 @@ func (c *kimiClient) postJSON(ctx context.Context, body any, out any) error {
 	if err != nil {
 		return classifyError(err)
 	}
-	defer func() { _ = response.Body.Close() }()
+	defer func() {
+		if cerr := response.Body.Close(); cerr != nil {
+			telemetry.WarnErr(ctx, "kimi: close response body failed", cerr,
+				otellog.String(telemetry.AttrLLMProvider, providerID))
+		}
+	}()
 	payload, err := io.ReadAll(response.Body)
 	if err != nil {
 		return errdefs.NotAvailable(fmt.Errorf("kimi: read response: %w", err))

--- a/driver/kimi/generate_chat.go
+++ b/driver/kimi/generate_chat.go
@@ -89,9 +89,16 @@ func transportGenerate(client *kimiClient) inference.Transport[generateWire, gen
 		wire.Stream = false
 		var envelope completionEnvelope
 		if err := client.postJSON(ctx, wire, &envelope); err != nil {
+			logInferenceCall(ctx, "generate", wire.Model, err, "", "")
 			return generateRaw{}, err
 		}
-		return completionToRaw(&envelope)
+		raw, err := completionToRaw(&envelope)
+		if err != nil {
+			logInferenceCall(ctx, "generate", wire.Model, err, "", "")
+			return generateRaw{}, err
+		}
+		logInferenceCall(ctx, "generate", wire.Model, nil, "", raw.id)
+		return raw, nil
 	}
 }
 

--- a/driver/kimi/generate_stream.go
+++ b/driver/kimi/generate_stream.go
@@ -7,7 +7,10 @@ import (
 
 	"github.com/GizClaw/flowcraft/core/errdefs"
 	"github.com/GizClaw/flowcraft/core/inference"
+	"github.com/GizClaw/flowcraft/core/telemetry"
 	"github.com/GizClaw/flowcraft/core/utils"
+
+	otellog "go.opentelemetry.io/otel/log"
 )
 
 // chunkEnvelope is one streaming chunk: delta content, optional finish
@@ -93,24 +96,35 @@ func transportGenerateStream(client *kimiClient) inference.Transport[generateWir
 		wire.Stream = true
 		request, err := client.newRequest(ctx, wire, true)
 		if err != nil {
+			logInferenceStream(ctx, "generate", wire.Model, err, "")
 			return nil, err
 		}
 		response, err := client.http.Do(request)
 		if err != nil {
-			return nil, classifyError(err)
+			classified := classifyError(err)
+			logInferenceStream(ctx, "generate", wire.Model, classified, "")
+			return nil, classified
 		}
 		if response.StatusCode < 200 || response.StatusCode >= 300 {
-			defer func() { _ = response.Body.Close() }()
+			defer func() {
+				if cerr := response.Body.Close(); cerr != nil {
+					telemetry.WarnErr(ctx, "kimi: close error response body failed", cerr,
+						otellog.String(telemetry.AttrLLMProvider, providerID))
+				}
+			}()
 			payload, _ := io.ReadAll(response.Body)
-			return nil, errdefs.WithRetryCount(
+			classified := errdefs.WithRetryCount(
 				errdefs.WithRetryAfter(
 					classifyHTTPError(ctx, response.StatusCode, payload),
 					errdefs.ParseRetryAfter(response.Header.Get("Retry-After")),
 				),
 				utils.RetryCountOf(response),
 			)
+			logInferenceStream(ctx, "generate", wire.Model, classified, "")
+			return nil, classified
 		}
 		streamCtx, cancel := context.WithCancel(ctx)
+		logInferenceStream(ctx, "generate", wire.Model, nil, "")
 		return &chatStream{
 			body:          response.Body,
 			events:        sseEvents(streamCtx, response.Body),
@@ -142,6 +156,7 @@ func (s *chatStream) Next(ctx context.Context) (streamRaw, error) {
 				continue
 			}
 			if err := s.apply(event.data); err != nil {
+				logInferenceStream(ctx, "generate", "", err, "")
 				return streamRaw{}, err
 			}
 		case <-ctx.Done():
@@ -248,7 +263,7 @@ func (s *chatStream) textIndex() int {
 
 // decodeGenerateStream is the pure stage: raw stream events become
 // canonical stream events.
-func decodeGenerateStream(_ context.Context, raw streamRaw) (inference.GenerateStreamEvent, error) {
+func decodeGenerateStream(ctx context.Context, raw streamRaw) (inference.GenerateStreamEvent, error) {
 	switch raw.kind {
 	case streamRawText:
 		return inference.GenerateStreamEvent{
@@ -274,6 +289,7 @@ func decodeGenerateStream(_ context.Context, raw streamRaw) (inference.GenerateS
 			FinishReason: raw.finish,
 			ResponseID:   raw.responseID,
 		}
+		logInferenceStreamEnd(ctx, "generate", raw.responseID)
 		if raw.usage != nil {
 			usage := rawUsageCanonical(*raw.usage)
 			event.Usage = &usage

--- a/driver/kimi/telemetry.go
+++ b/driver/kimi/telemetry.go
@@ -1,0 +1,79 @@
+package kimi
+
+import (
+	"context"
+
+	"github.com/GizClaw/flowcraft/core/errdefs"
+	"github.com/GizClaw/flowcraft/core/telemetry"
+
+	otellog "go.opentelemetry.io/otel/log"
+)
+
+// providerID is the stable telemetry token for this provider, matching
+// the inference.ModelID.Provider values in the catalog.
+const providerID = "kimi"
+
+func logInferenceCall(
+	ctx context.Context,
+	op, model string,
+	err error,
+	requestID, responseID string,
+) {
+	attrs := inferenceAttrs(op, model, err, requestID, responseID)
+	if err != nil {
+		telemetry.Warn(ctx, "kimi inference request failed", attrs...)
+		return
+	}
+	telemetry.Debug(ctx, "kimi inference request completed", attrs...)
+}
+
+func logInferenceStream(
+	ctx context.Context,
+	op, model string,
+	err error,
+	requestID string,
+) {
+	attrs := inferenceAttrs(op, model, err, requestID, "")
+	if err != nil {
+		telemetry.Warn(ctx, "kimi inference stream failed", attrs...)
+		return
+	}
+	telemetry.Debug(ctx, "kimi inference stream opened", attrs...)
+}
+
+func logInferenceStreamEnd(ctx context.Context, op, responseID string) {
+	if responseID == "" {
+		return
+	}
+	telemetry.Debug(ctx, "kimi inference stream completed",
+		inferenceAttrs(op, "", nil, "", responseID)...)
+}
+
+func inferenceAttrs(
+	op, model string,
+	err error,
+	requestID, responseID string,
+) []otellog.KeyValue {
+	attrs := []otellog.KeyValue{
+		otellog.String(telemetry.AttrLLMProvider, providerID),
+	}
+	if op != "" {
+		attrs = append(attrs, otellog.String("inference.operation", op))
+	}
+	if model != "" {
+		attrs = append(attrs, otellog.String(telemetry.AttrLLMModel, model))
+	}
+	if requestID == "" {
+		requestID, _ = errdefs.RequestID(err)
+	}
+	if requestID != "" {
+		attrs = append(attrs, otellog.String(telemetry.AttrLLMRequestID, requestID))
+	}
+	if responseID != "" {
+		attrs = append(attrs, otellog.String(telemetry.AttrLLMResponseID, responseID))
+	}
+	if err != nil {
+		attrs = append(attrs, otellog.String(telemetry.AttrErrorMessage, err.Error()))
+	}
+	return attrs
+}

--- a/driver/minimax/generate_anthropic.go
+++ b/driver/minimax/generate_anthropic.go
@@ -181,9 +181,17 @@ func transportGenerate(
 	return func(ctx context.Context, wire generateWire) (generateRaw, error) {
 		message, err := client.Messages.New(ctx, wireToParams(wire))
 		if err != nil {
-			return generateRaw{}, classifyError(err)
+			classified := classifyError(err)
+			logInferenceCall(ctx, "generate", wire.model, classified, "", "")
+			return generateRaw{}, classified
 		}
-		return messageToRaw(message)
+		raw, err := messageToRaw(message)
+		if err != nil {
+			logInferenceCall(ctx, "generate", wire.model, err, "", "")
+			return generateRaw{}, err
+		}
+		logInferenceCall(ctx, "generate", wire.model, nil, "", raw.id)
+		return raw, nil
 	}
 }
 

--- a/driver/minimax/generate_stream.go
+++ b/driver/minimax/generate_stream.go
@@ -42,8 +42,11 @@ func transportGenerateStream(
 	) (inference.ProviderStream[streamRaw], error) {
 		stream := client.Messages.NewStreaming(ctx, wireToParams(wire))
 		if err := stream.Err(); err != nil {
-			return nil, classifyError(err)
+			classified := classifyError(err)
+			logInferenceStream(ctx, "generate", wire.model, classified, "")
+			return nil, classified
 		}
+		logInferenceStream(ctx, "generate", wire.model, nil, "")
 		return &messagesStream{
 			stream: stream,
 			parts:  make(map[int64]*streamPart),
@@ -65,7 +68,9 @@ func (s *messagesStream) Next(ctx context.Context) (streamRaw, error) {
 	for {
 		if !s.stream.Next() {
 			if err := s.stream.Err(); err != nil {
-				return streamRaw{}, classifyError(err)
+				classified := classifyError(err)
+				logInferenceStream(ctx, "generate", "", classified, "")
+				return streamRaw{}, classified
 			}
 			return streamRaw{}, io.EOF
 		}
@@ -239,7 +244,7 @@ func (s *messagesStream) finishEvent(
 // decodeGenerateStream is pure: streamRaw already carries canonical part
 // indices assigned by the stateful transport.
 func decodeGenerateStream(
-	_ context.Context,
+	ctx context.Context,
 	raw streamRaw,
 ) (inference.GenerateStreamEvent, error) {
 	switch raw.kind {
@@ -270,6 +275,7 @@ func decodeGenerateStream(
 			FinishReason: raw.finish,
 			ResponseID:   raw.responseID,
 		}
+		logInferenceStreamEnd(ctx, "generate", raw.responseID)
 		if raw.usage != nil {
 			usage := rawUsageCanonical(*raw.usage)
 			event.Usage = &usage

--- a/driver/minimax/telemetry.go
+++ b/driver/minimax/telemetry.go
@@ -1,0 +1,79 @@
+package minimax
+
+import (
+	"context"
+
+	"github.com/GizClaw/flowcraft/core/errdefs"
+	"github.com/GizClaw/flowcraft/core/telemetry"
+
+	otellog "go.opentelemetry.io/otel/log"
+)
+
+// providerID is the stable telemetry token for this provider, matching
+// the inference.ModelID.Provider values in the catalog.
+const providerID = "minimax"
+
+func logInferenceCall(
+	ctx context.Context,
+	op, model string,
+	err error,
+	requestID, responseID string,
+) {
+	attrs := inferenceAttrs(op, model, err, requestID, responseID)
+	if err != nil {
+		telemetry.Warn(ctx, "minimax inference request failed", attrs...)
+		return
+	}
+	telemetry.Debug(ctx, "minimax inference request completed", attrs...)
+}
+
+func logInferenceStream(
+	ctx context.Context,
+	op, model string,
+	err error,
+	requestID string,
+) {
+	attrs := inferenceAttrs(op, model, err, requestID, "")
+	if err != nil {
+		telemetry.Warn(ctx, "minimax inference stream failed", attrs...)
+		return
+	}
+	telemetry.Debug(ctx, "minimax inference stream opened", attrs...)
+}
+
+func logInferenceStreamEnd(ctx context.Context, op, responseID string) {
+	if responseID == "" {
+		return
+	}
+	telemetry.Debug(ctx, "minimax inference stream completed",
+		inferenceAttrs(op, "", nil, "", responseID)...)
+}
+
+func inferenceAttrs(
+	op, model string,
+	err error,
+	requestID, responseID string,
+) []otellog.KeyValue {
+	attrs := []otellog.KeyValue{
+		otellog.String(telemetry.AttrLLMProvider, providerID),
+	}
+	if op != "" {
+		attrs = append(attrs, otellog.String("inference.operation", op))
+	}
+	if model != "" {
+		attrs = append(attrs, otellog.String(telemetry.AttrLLMModel, model))
+	}
+	if requestID == "" {
+		requestID, _ = errdefs.RequestID(err)
+	}
+	if requestID != "" {
+		attrs = append(attrs, otellog.String(telemetry.AttrLLMRequestID, requestID))
+	}
+	if responseID != "" {
+		attrs = append(attrs, otellog.String(telemetry.AttrLLMResponseID, responseID))
+	}
+	if err != nil {
+		attrs = append(attrs, otellog.String(telemetry.AttrErrorMessage, err.Error()))
+	}
+	return attrs
+}

--- a/driver/openai/embed.go
+++ b/driver/openai/embed.go
@@ -128,7 +128,9 @@ func transportEmbed(
 		}
 		response, err := client.Embeddings.New(ctx, params)
 		if err != nil {
-			return embedRaw{}, classifyError(err)
+			classified := classifyError(err)
+			logInferenceCall(ctx, "embed", wire.model, classified, "", "")
+			return embedRaw{}, classified
 		}
 		vectors := make([][]float32, len(response.Data))
 		for _, item := range response.Data {
@@ -144,10 +146,12 @@ func transportEmbed(
 			}
 			vectors[item.Index] = vector
 		}
-		return embedRaw{
+		raw := embedRaw{
 			vectors:     vectors,
 			inputTokens: response.Usage.TotalTokens,
-		}, nil
+		}
+		logInferenceCall(ctx, "embed", wire.model, nil, "", "")
+		return raw, nil
 	}
 }
 

--- a/driver/openai/generate_chat.go
+++ b/driver/openai/generate_chat.go
@@ -197,9 +197,17 @@ func transportChatGenerate(client openai.Client) inference.Transport[generateWir
 	return func(ctx context.Context, wire generateWire) (generateRaw, error) {
 		response, err := client.Chat.Completions.New(ctx, wireToChatParams(wire))
 		if err != nil {
-			return generateRaw{}, classifyError(err)
+			classified := classifyError(err)
+			logInferenceCall(ctx, "generate", wire.model, classified, "", "")
+			return generateRaw{}, classified
 		}
-		return chatCompletionToRaw(response)
+		raw, err := chatCompletionToRaw(response)
+		if err != nil {
+			logInferenceCall(ctx, "generate", wire.model, err, "", "")
+			return generateRaw{}, err
+		}
+		logInferenceCall(ctx, "generate", wire.model, nil, "", raw.id)
+		return raw, nil
 	}
 }
 
@@ -304,8 +312,11 @@ func transportChatGenerateStream(
 				"openai: nil chat stream handle (provider misbehaviour)")
 		}
 		if err := stream.Err(); err != nil {
-			return nil, classifyError(err)
+			classified := classifyError(err)
+			logInferenceStream(ctx, "generate", wire.model, classified, "")
+			return nil, classified
 		}
+		logInferenceStream(ctx, "generate", wire.model, nil, "")
 		return &chatStream{
 			stream:    stream,
 			textPart:  -1,
@@ -336,7 +347,9 @@ func (s *chatStream) Next(ctx context.Context) (streamRaw, error) {
 		}
 		if !s.stream.Next() {
 			if err := s.stream.Err(); err != nil {
-				return streamRaw{}, classifyError(err)
+				classified := classifyError(err)
+				logInferenceStream(ctx, "generate", "", classified, "")
+				return streamRaw{}, classified
 			}
 			s.end()
 			continue

--- a/driver/openai/generate_openai.go
+++ b/driver/openai/generate_openai.go
@@ -233,9 +233,17 @@ func transportGenerate(
 	return func(ctx context.Context, wire generateWire) (generateRaw, error) {
 		response, err := client.Responses.New(ctx, wireToParams(wire))
 		if err != nil {
-			return generateRaw{}, classifyError(err)
+			classified := classifyError(err)
+			logInferenceCall(ctx, "generate", wire.model, classified, "", "")
+			return generateRaw{}, classified
 		}
-		return responseToRaw(response)
+		raw, err := responseToRaw(response)
+		if err != nil {
+			logInferenceCall(ctx, "generate", wire.model, err, "", "")
+			return generateRaw{}, err
+		}
+		logInferenceCall(ctx, "generate", wire.model, nil, "", raw.id)
+		return raw, nil
 	}
 }
 

--- a/driver/openai/generate_stream.go
+++ b/driver/openai/generate_stream.go
@@ -51,8 +51,11 @@ func transportGenerateStream(
 	) (inference.ProviderStream[streamRaw], error) {
 		stream := client.Responses.NewStreaming(ctx, wireToParams(wire))
 		if err := stream.Err(); err != nil {
-			return nil, classifyError(err)
+			classified := classifyError(err)
+			logInferenceStream(ctx, "generate", wire.model, classified, "")
+			return nil, classified
 		}
+		logInferenceStream(ctx, "generate", wire.model, nil, "")
 		return &responsesStream{
 			stream: stream,
 			parts:  make(map[int64]*streamPart),
@@ -74,7 +77,9 @@ func (s *responsesStream) Next(ctx context.Context) (streamRaw, error) {
 	for {
 		if !s.stream.Next() {
 			if err := s.stream.Err(); err != nil {
-				return streamRaw{}, classifyError(err)
+				classified := classifyError(err)
+				logInferenceStream(ctx, "generate", "", classified, "")
+				return streamRaw{}, classified
 			}
 			return streamRaw{}, io.EOF
 		}
@@ -361,7 +366,7 @@ func openaiAnnotationCitation(annotation any) (inference.Citation, bool) {
 // decodeGenerateStream is pure: streamRaw already carries canonical part
 // indices assigned by the stateful transport.
 func decodeGenerateStream(
-	_ context.Context,
+	ctx context.Context,
 	raw streamRaw,
 ) (inference.GenerateStreamEvent, error) {
 	switch raw.kind {
@@ -398,6 +403,7 @@ func decodeGenerateStream(
 			ResponseID:      raw.responseID,
 			ProviderOutputs: raw.providerOutputs.Clone(),
 		}
+		logInferenceStreamEnd(ctx, "generate", raw.responseID)
 		if raw.usage != nil {
 			usage := rawUsageCanonical(*raw.usage)
 			event.Usage = &usage

--- a/driver/openai/telemetry.go
+++ b/driver/openai/telemetry.go
@@ -1,0 +1,89 @@
+package openai
+
+import (
+	"context"
+
+	"github.com/GizClaw/flowcraft/core/errdefs"
+	"github.com/GizClaw/flowcraft/core/telemetry"
+
+	otellog "go.opentelemetry.io/otel/log"
+)
+
+// providerID is the stable telemetry token for this provider, matching
+// the inference.ModelID.Provider values in the catalog.
+const providerID = "openai"
+
+// logInferenceCall records one provider round trip at the transport
+// boundary. Failures are Warn (with error.message and the provider
+// request id when the error chain carries one); successes are Debug so
+// per-call correlation stays cheap. responseID is only populated where
+// the wire response exposes an identifier.
+func logInferenceCall(
+	ctx context.Context,
+	op, model string,
+	err error,
+	requestID, responseID string,
+) {
+	attrs := inferenceAttrs(op, model, err, requestID, responseID)
+	if err != nil {
+		telemetry.Warn(ctx, "openai inference request failed", attrs...)
+		return
+	}
+	telemetry.Debug(ctx, "openai inference request completed", attrs...)
+}
+
+// logInferenceStream records stream open and terminal failure. The
+// terminal response id is logged separately via logInferenceStreamEnd
+// once the adapter assembles it.
+func logInferenceStream(
+	ctx context.Context,
+	op, model string,
+	err error,
+	requestID string,
+) {
+	attrs := inferenceAttrs(op, model, err, requestID, "")
+	if err != nil {
+		telemetry.Warn(ctx, "openai inference stream failed", attrs...)
+		return
+	}
+	telemetry.Debug(ctx, "openai inference stream opened", attrs...)
+}
+
+// logInferenceStreamEnd records the terminal stream event carrying the
+// provider response id for correlation.
+func logInferenceStreamEnd(ctx context.Context, op, responseID string) {
+	if responseID == "" {
+		return
+	}
+	telemetry.Debug(ctx, "openai inference stream completed",
+		inferenceAttrs(op, "", nil, "", responseID)...)
+}
+
+func inferenceAttrs(
+	op, model string,
+	err error,
+	requestID, responseID string,
+) []otellog.KeyValue {
+	attrs := []otellog.KeyValue{
+		otellog.String(telemetry.AttrLLMProvider, providerID),
+	}
+	if op != "" {
+		attrs = append(attrs, otellog.String("inference.operation", op))
+	}
+	if model != "" {
+		attrs = append(attrs, otellog.String(telemetry.AttrLLMModel, model))
+	}
+	if requestID == "" {
+		requestID, _ = errdefs.RequestID(err)
+	}
+	if requestID != "" {
+		attrs = append(attrs, otellog.String(telemetry.AttrLLMRequestID, requestID))
+	}
+	if responseID != "" {
+		attrs = append(attrs, otellog.String(telemetry.AttrLLMResponseID, responseID))
+	}
+	if err != nil {
+		attrs = append(attrs, otellog.String(telemetry.AttrErrorMessage, err.Error()))
+	}
+	return attrs
+}

--- a/driver/qwen/client.go
+++ b/driver/qwen/client.go
@@ -110,7 +110,12 @@ func (c *dashClient) request(
 		return nil, fmt.Errorf("qwen: post %s: %w", path, err)
 	}
 	if resp.StatusCode != http.StatusOK {
-		defer func() { _ = resp.Body.Close() }()
+		defer func() {
+			if cerr := resp.Body.Close(); cerr != nil {
+				telemetry.WarnErr(ctx, "qwen: close error response body failed", cerr,
+					otellog.String(telemetry.AttrLLMProvider, providerID))
+			}
+		}()
 		var failure struct {
 			Code      string `json:"code"`
 			Message   string `json:"message"`
@@ -152,7 +157,12 @@ func (c *dashClient) postJSON(
 	if err != nil {
 		return err
 	}
-	defer func() { _ = resp.Body.Close() }()
+	defer func() {
+		if cerr := resp.Body.Close(); cerr != nil {
+			telemetry.WarnErr(ctx, "qwen: close response body failed", cerr,
+				otellog.String(telemetry.AttrLLMProvider, providerID))
+		}
+	}()
 	if err := json.NewDecoder(resp.Body).Decode(out); err != nil {
 		return fmt.Errorf("qwen: decode %s response: %w", path, err)
 	}

--- a/driver/qwen/embed.go
+++ b/driver/qwen/embed.go
@@ -305,15 +305,24 @@ func transportEmbed(
 	client *dashClient,
 ) inference.Transport[embedWire, embedRaw] {
 	return func(ctx context.Context, wire embedWire) (embedRaw, error) {
+		var raw embedRaw
+		var err error
 		switch wire.Shape {
 		case embedShapeText:
-			return transportEmbedText(ctx, client, wire)
+			raw, err = transportEmbedText(ctx, client, wire)
 		case embedShapeIndependent:
-			return transportEmbedIndependent(ctx, client, wire)
+			raw, err = transportEmbedIndependent(ctx, client, wire)
 		case embedShapeFusion:
-			return transportEmbedFusion(ctx, client, wire)
+			raw, err = transportEmbedFusion(ctx, client, wire)
+		default:
+			err = fmt.Errorf("qwen: unknown embed shape %d", wire.Shape)
 		}
-		return embedRaw{}, fmt.Errorf("qwen: unknown embed shape %d", wire.Shape)
+		if err != nil {
+			logInferenceCall(ctx, "embed", wire.Model, err, "", "")
+			return raw, err
+		}
+		logInferenceCall(ctx, "embed", wire.Model, nil, raw.requestID, "")
+		return raw, nil
 	}
 }
 

--- a/driver/qwen/generate.go
+++ b/driver/qwen/generate.go
@@ -796,13 +796,16 @@ func transportGenerate(
 		defaultPreserveThinking(&wire)
 		var envelope dashResponse
 		if err := client.postJSON(ctx, wire.Path, wire, &envelope); err != nil {
+			logInferenceCall(ctx, "generate", wire.Model, err, "", "")
 			return dashResponse{}, err
 		}
 		if err := classifyEnvelope(
 			envelope.Code, envelope.Message, envelope.RequestID,
 		); err != nil {
+			logInferenceCall(ctx, "generate", wire.Model, err, "", "")
 			return dashResponse{}, err
 		}
+		logInferenceCall(ctx, "generate", wire.Model, nil, envelope.RequestID, "")
 		return envelope, nil
 	}
 }

--- a/driver/qwen/generate_stream.go
+++ b/driver/qwen/generate_stream.go
@@ -11,6 +11,9 @@ import (
 
 	"github.com/GizClaw/flowcraft/core/errdefs"
 	"github.com/GizClaw/flowcraft/core/inference"
+	"github.com/GizClaw/flowcraft/core/telemetry"
+
+	otellog "go.opentelemetry.io/otel/log"
 )
 
 // streamFragment is the raw stream event: one indivisible delta extracted
@@ -50,7 +53,7 @@ const (
 
 // decodeStreamFragment maps one raw fragment onto one canonical event.
 func decodeStreamFragment(
-	_ context.Context,
+	ctx context.Context,
 	fragment streamFragment,
 ) (inference.GenerateStreamEvent, error) {
 	switch fragment.kind {
@@ -87,6 +90,7 @@ func decodeStreamFragment(
 			FinishReason: finishReason(fragment.finish),
 			RequestID:    fragment.requestID,
 		}
+		logInferenceStreamEnd(ctx, "generate", fragment.requestID)
 		if fragment.usage != nil {
 			usage := fragment.usage.canonical()
 			event.Usage = &usage
@@ -120,10 +124,12 @@ func transportGenerateStream(
 		defaultPreserveThinking(&wire)
 		body, err := client.postSSE(ctx, wire.Path, wire)
 		if err != nil {
+			logInferenceStream(ctx, "generate", wire.Model, err, "")
 			return nil, err
 		}
 		scanner := bufio.NewScanner(body)
 		scanner.Buffer(make([]byte, 0, 1<<20), 16<<20)
+		logInferenceStream(ctx, "generate", wire.Model, nil, "")
 		return &sseStream{body: body, scanner: scanner}, nil
 	}
 }
@@ -139,7 +145,10 @@ func (s *sseStream) Next(ctx context.Context) (streamFragment, error) {
 	go func() {
 		select {
 		case <-ctx.Done():
-			_ = s.closeBody()
+			if cerr := s.closeBody(); cerr != nil {
+				telemetry.WarnErr(ctx, "qwen: close sse body on cancel failed", cerr,
+					otellog.String(telemetry.AttrLLMProvider, providerID))
+			}
 		case <-stopWatch:
 		}
 	}()
@@ -160,9 +169,11 @@ func (s *sseStream) Next(ctx context.Context) (streamFragment, error) {
 				if ctxErr := ctx.Err(); ctxErr != nil {
 					return streamFragment{}, errdefs.FromContext(ctxErr)
 				}
-				return streamFragment{}, fmt.Errorf(
+				readErr := fmt.Errorf(
 					"qwen: read event stream: %w", err,
 				)
+				logInferenceStream(ctx, "generate", "", readErr, "")
+				return streamFragment{}, readErr
 			}
 			return streamFragment{}, io.EOF
 		}
@@ -182,6 +193,7 @@ func (s *sseStream) Next(ctx context.Context) (streamFragment, error) {
 			s.mu.Lock()
 			s.done = true
 			s.mu.Unlock()
+			logInferenceStream(ctx, "generate", "", err, "")
 			return streamFragment{}, err
 		}
 		s.queue = fragments

--- a/driver/qwen/telemetry.go
+++ b/driver/qwen/telemetry.go
@@ -1,0 +1,81 @@
+package qwen
+
+import (
+	"context"
+
+	"github.com/GizClaw/flowcraft/core/errdefs"
+	"github.com/GizClaw/flowcraft/core/telemetry"
+
+	otellog "go.opentelemetry.io/otel/log"
+)
+
+// providerID is the stable telemetry token for this provider, matching
+// the inference.ModelID.Provider values in the catalog.
+const providerID = "qwen"
+
+func logInferenceCall(
+	ctx context.Context,
+	op, model string,
+	err error,
+	requestID, responseID string,
+) {
+	attrs := inferenceAttrs(op, model, err, requestID, responseID)
+	if err != nil {
+		telemetry.Warn(ctx, "qwen inference request failed", attrs...)
+		return
+	}
+	telemetry.Debug(ctx, "qwen inference request completed", attrs...)
+}
+
+func logInferenceStream(
+	ctx context.Context,
+	op, model string,
+	err error,
+	requestID string,
+) {
+	attrs := inferenceAttrs(op, model, err, requestID, "")
+	if err != nil {
+		telemetry.Warn(ctx, "qwen inference stream failed", attrs...)
+		return
+	}
+	telemetry.Debug(ctx, "qwen inference stream opened", attrs...)
+}
+
+// logInferenceStreamEnd records the terminal stream event. DashScope
+// streams identify the call by request_id rather than a response id.
+func logInferenceStreamEnd(ctx context.Context, op, requestID string) {
+	if requestID == "" {
+		return
+	}
+	telemetry.Debug(ctx, "qwen inference stream completed",
+		inferenceAttrs(op, "", nil, requestID, "")...)
+}
+
+func inferenceAttrs(
+	op, model string,
+	err error,
+	requestID, responseID string,
+) []otellog.KeyValue {
+	attrs := []otellog.KeyValue{
+		otellog.String(telemetry.AttrLLMProvider, providerID),
+	}
+	if op != "" {
+		attrs = append(attrs, otellog.String("inference.operation", op))
+	}
+	if model != "" {
+		attrs = append(attrs, otellog.String(telemetry.AttrLLMModel, model))
+	}
+	if requestID == "" {
+		requestID, _ = errdefs.RequestID(err)
+	}
+	if requestID != "" {
+		attrs = append(attrs, otellog.String(telemetry.AttrLLMRequestID, requestID))
+	}
+	if responseID != "" {
+		attrs = append(attrs, otellog.String(telemetry.AttrLLMResponseID, responseID))
+	}
+	if err != nil {
+		attrs = append(attrs, otellog.String(telemetry.AttrErrorMessage, err.Error()))
+	}
+	return attrs
+}


### PR DESCRIPTION
## Summary

Adds OpenTelemetry log records (via `core/telemetry`) to paths that were previously only visible through spans, events or not at all, and instruments the driver providers' inference calls.

### Core

- **agent / a2a**: run lifecycle logs (`started`, `completed`, `interrupted`, `canceled`, `aborted`, `failed`) with correlation attrs (`agent.id`, `run.id`, `task.id`, `run.status`, attempts, committed); infrastructure failures and aggregated `Close` errors are logged; a2a terminal outcomes now emit log records matching the agent vocabulary.
- **runtime / session**: Reload, RegisterAgent/UnregisterAgent, idle session reclamation, drain timeouts, manager close, stream coordinator deaths and sink delivery failures, checkpoint save/delete and prompt/event publish failures are logged.
- **graph**: one run-level terminal record per execution (classified by outcome), run-start publish failures, node retry attempts, script emitter and stream cleanup failures.
- **inference/route**: retries (Debug), fallbacks, circuit-open skips and final route failure (Warn) with provider/model/attempt/error-kind attrs.
- **delegation**: worker claim failures, worker-stopped errors, kanban eviction/expiry and card event publish failures.
- **tool**: tool panics (Recover), lazy load and search preload failures, MCP teardown close errors.
- **event**: router subscription close failures; MemoryBus drop summary when no observer is attached.
- **sandbox**: resource-watcher kill events (pgid + reason), session signal/close/pty/stdin failures, bwrap/seatbelt proxy cleanup failures.
- **deploy / resource / utils**: rollback close failures are logged; MITM CA bundle write errors now surface instead of producing a truncated bundle; netproxy/mitm connection and listener close failures are logged (expected double-close errors excluded).

### Drivers

Each provider (`openai`, `anthropic`, `azure`, `bytedance`, `deepseek`, `kimi`, `minimax`, `qwen`) gains a `telemetry.go` helper and transport-level records for generate (unary + stream), embed and transcribe:

- Failure → `Warn` with `error.message` + `llm.request.id` (pulled from the error chain via `errdefs.RequestID` when not explicit) + provider/model/operation.
- Success → `Debug` with `llm.response.id` where available (DashScope streams identified by `llm.request.id`).
- Stream open/terminal events logged at Debug/Warn respectively.

## Verification

- `make ci` (vet + test, all modules) — pass
- `make lint` (golangci-lint) — 0 issues
- `make release-check` — valid, no pending releases
- `gofmt` / `git diff --check` — clean