### PR TITLE
feat(core): expose runtime-registered agents as delegation targets

### DIFF
--- a/core/delegation/directory.go
+++ b/core/delegation/directory.go
@@ -18,6 +18,13 @@ type LocalDirectory struct {
 	targets []Target
 	byID    map[string]Target
 	lookup  map[string]*agent.Agent
+
+	// dynamic is the live view of runtime-registered targets merged
+	// with the deployment snapshot; frozen replaces it once the
+	// generation retires so in-flight delegations keep resolving the
+	// exact instances that generation served.
+	dynamic TargetSource
+	frozen  map[string]*agent.Agent
 }
 
 // Deployment is the minimal read-only deployment view needed by
@@ -25,6 +32,38 @@ type LocalDirectory struct {
 type Deployment interface {
 	Agent(id string) (*agent.Agent, bool)
 	AgentNames() []string
+}
+
+// TargetSource is the live view of dynamically registered targets that
+// a directory merges with its deployment snapshot. The runtime's agent
+// registry implements it, so registration and unregistration take
+// effect without re-binding the directory. Implementations must be safe
+// for concurrent use.
+type TargetSource interface {
+	// Dynamic resolves one dynamic target by id. Deployment targets
+	// are served from the directory's own snapshot and never returned
+	// here.
+	Dynamic(id string) (*agent.Agent, bool)
+	// DynamicNames lists the dynamic target ids.
+	DynamicNames() []string
+}
+
+// TargetViewBinder is implemented by directory resources that want the
+// runtime's live target source attached. The runtime calls it once per
+// generation before the swap.
+type TargetViewBinder interface {
+	// BindTargetSource attaches the live dynamic source. It is
+	// set-once: a second bind returns a Conflict error.
+	BindTargetSource(source TargetSource) error
+}
+
+// TargetViewFreezer is implemented by directory resources that must pin
+// their dynamic view when the generation retires, so in-flight
+// delegations keep resolving the instances that generation served.
+type TargetViewFreezer interface {
+	// FreezeTargets replaces the live dynamic source with a fixed
+	// instance set. Idempotent.
+	FreezeTargets(instances map[string]*agent.Agent)
 }
 
 // NewDirectory creates an unbound directory.
@@ -67,14 +106,7 @@ func (d *LocalDirectory) Bind(result Deployment) error {
 		if _, duplicate := byID[id]; duplicate {
 			return errdefs.Conflictf("local delegation directory: duplicate target id %q", id)
 		}
-		target := Target{
-			ID:          id,
-			Description: instance.Card.Description,
-			Modes:       []Mode{ModeSync, ModeAsync},
-		}
-		if instance.Card.Name != "" {
-			target.Metadata = map[string]string{"name": instance.Card.Name}
-		}
+		target := targetFromAgent(name, instance)
 		targets = append(targets, target)
 		byID[id] = target
 		lookup[id] = instance
@@ -85,6 +117,52 @@ func (d *LocalDirectory) Bind(result Deployment) error {
 	d.lookup = lookup
 	d.bound = true
 	return nil
+}
+
+// BindTargetSource attaches the live dynamic target view. It is
+// set-once: binding twice returns a Conflict error.
+func (d *LocalDirectory) BindTargetSource(source TargetSource) error {
+	if d == nil {
+		return errdefs.Validationf("local delegation directory: nil receiver")
+	}
+	if isNilInterface(source) {
+		return errdefs.Validationf("local delegation directory: nil target source")
+	}
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	if d.dynamic != nil {
+		return errdefs.Conflictf("local delegation directory: target source already bound")
+	}
+	d.dynamic = source
+	return nil
+}
+
+// FreezeTargets replaces the live dynamic source with a fixed instance
+// set. Idempotent; used when a generation retires.
+func (d *LocalDirectory) FreezeTargets(instances map[string]*agent.Agent) {
+	if d == nil {
+		return
+	}
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	d.frozen = instances
+	d.dynamic = nil
+}
+
+func targetFromAgent(name string, instance *agent.Agent) Target {
+	id := instance.ID
+	if id == "" {
+		id = name
+	}
+	target := Target{
+		ID:          id,
+		Description: instance.Card.Description,
+		Modes:       []Mode{ModeSync, ModeAsync},
+	}
+	if instance.Card.Name != "" {
+		target.Metadata = map[string]string{"name": instance.Card.Name}
+	}
+	return target
 }
 
 // BindDeployment implements resource.DeploymentBinder: the directory
@@ -116,7 +194,7 @@ func (d *LocalDirectory) List(context.Context) ([]Target, error) {
 	for i, target := range d.targets {
 		out[i] = cloneTarget(target)
 	}
-	return out, nil
+	return append(out, d.dynamicTargetsLocked()...), nil
 }
 
 // Get returns one target by id.
@@ -128,6 +206,9 @@ func (d *LocalDirectory) Get(_ context.Context, id string) (Target, error) {
 	defer d.mu.RUnlock()
 	if !d.bound {
 		return Target{}, errdefs.NotAvailablef("local delegation directory: not bound")
+	}
+	if target, ok := d.dynamicTargetLocked(id); ok {
+		return cloneTarget(target), nil
 	}
 	target, ok := d.byID[id]
 	if !ok {
@@ -146,6 +227,15 @@ func (d *LocalDirectory) Lookup(_ context.Context, id string) (*agent.Agent, err
 	if !d.bound {
 		return nil, errdefs.NotAvailablef("local delegation directory: not bound")
 	}
+	if d.frozen != nil {
+		if instance, ok := d.frozen[id]; ok && instance != nil {
+			return instance, nil
+		}
+	} else if d.dynamic != nil {
+		if instance, ok := d.dynamic.Dynamic(id); ok && instance != nil {
+			return instance, nil
+		}
+	}
 	instance, ok := d.lookup[id]
 	if !ok {
 		return nil, TargetNotFound(id)
@@ -154,6 +244,67 @@ func (d *LocalDirectory) Lookup(_ context.Context, id string) (*agent.Agent, err
 		return nil, errdefs.Internalf("local delegation directory: target %q has no deploy instance", id)
 	}
 	return instance, nil
+}
+
+// dynamicTargetsLocked lists the merged dynamic targets: the frozen set
+// when the generation retired, otherwise the live source. Deployment
+// ids are excluded so the same agent is never listed twice.
+func (d *LocalDirectory) dynamicTargetsLocked() []Target {
+	if d.frozen != nil {
+		names := make([]string, 0, len(d.frozen))
+		for name := range d.frozen {
+			names = append(names, name)
+		}
+		slices.Sort(names)
+		out := make([]Target, 0, len(names))
+		for _, name := range names {
+			instance := d.frozen[name]
+			if instance == nil {
+				continue
+			}
+			if _, dup := d.byID[targetFromAgent(name, instance).ID]; dup {
+				continue
+			}
+			out = append(out, targetFromAgent(name, instance))
+		}
+		return out
+	}
+	if d.dynamic == nil {
+		return nil
+	}
+	names := d.dynamic.DynamicNames()
+	out := make([]Target, 0, len(names))
+	for _, name := range names {
+		instance, ok := d.dynamic.Dynamic(name)
+		if !ok || instance == nil {
+			continue
+		}
+		target := targetFromAgent(name, instance)
+		if _, dup := d.byID[target.ID]; dup {
+			continue
+		}
+		out = append(out, target)
+	}
+	return out
+}
+
+// dynamicTargetLocked resolves one dynamic target: frozen first, then
+// the live source.
+func (d *LocalDirectory) dynamicTargetLocked(id string) (Target, bool) {
+	if d.frozen != nil {
+		if instance, ok := d.frozen[id]; ok && instance != nil {
+			return targetFromAgent(id, instance), true
+		}
+		return Target{}, false
+	}
+	if d.dynamic == nil {
+		return Target{}, false
+	}
+	instance, ok := d.dynamic.Dynamic(id)
+	if !ok || instance == nil {
+		return Target{}, false
+	}
+	return targetFromAgent(id, instance), true
 }
 
 func cloneTarget(target Target) Target {

--- a/core/delegation/directory.go
+++ b/core/delegation/directory.go
@@ -23,6 +23,9 @@ type LocalDirectory struct {
 	// with the deployment snapshot; frozen replaces it once the
 	// generation retires so in-flight delegations keep resolving the
 	// exact instances that generation served.
+	// source retains the bound live view across FreezeTargets so
+	// UnfreezeTargets can restore it on reload rollback.
+	source  TargetSource
 	dynamic TargetSource
 	frozen  map[string]*agent.Agent
 }
@@ -42,9 +45,10 @@ type Deployment interface {
 type TargetSource interface {
 	// Dynamic resolves one dynamic target by id. Deployment targets
 	// are served from the directory's own snapshot and never returned
-	// here.
+	// here. The id is the AgentID — in the runtime path the
+	// registration name — and implementations must resolve it as such.
 	Dynamic(id string) (*agent.Agent, bool)
-	// DynamicNames lists the dynamic target ids.
+	// DynamicNames lists the dynamic target ids (AgentIDs).
 	DynamicNames() []string
 }
 
@@ -60,10 +64,24 @@ type TargetViewBinder interface {
 // TargetViewFreezer is implemented by directory resources that must pin
 // their dynamic view when the generation retires, so in-flight
 // delegations keep resolving the instances that generation served.
+//
+// Generation semantics: the delegation service uses the resolved
+// instance for target validation and telemetry only; actual execution
+// goes through the session manager's per-generation resolver. After a
+// reload the retired directory may therefore validate against a frozen
+// instance while the delegated turn starts on the new generation's
+// re-bound instance — "the generation is determined at Session.Start",
+// matching the runtime's resolver contract.
 type TargetViewFreezer interface {
-	// FreezeTargets replaces the live dynamic source with a fixed
-	// instance set. Idempotent.
+	// FreezeTargets pins the live dynamic source to a fixed instance
+	// set. Freezing is a one-shot commit: callers must guarantee that
+	// every later failure path can either proceed without the live
+	// view or pair the freeze with UnfreezeTargets, or the directory
+	// will silently diverge from the runtime registry.
 	FreezeTargets(instances map[string]*agent.Agent)
+	// UnfreezeTargets restores the live dynamic source after a
+	// rollback. Idempotent; safe to call on a never-frozen directory.
+	UnfreezeTargets()
 }
 
 // NewDirectory creates an unbound directory.
@@ -71,8 +89,11 @@ func NewDirectory() *LocalDirectory {
 	return &LocalDirectory{}
 }
 
-// Bind installs Build's instances. A directory is immutable after a successful
-// bind and borrows the instances; the result retains lifecycle ownership.
+// Bind installs Build's instances. The deployment snapshot is immutable
+// after a successful bind and borrows the instances; the result retains
+// lifecycle ownership. The directory as a whole is not frozen: the live
+// dynamic view may be attached once (BindTargetSource) and pinned on
+// generation retirement (FreezeTargets).
 func (d *LocalDirectory) Bind(result Deployment) error {
 	if d == nil {
 		return errdefs.Validationf("local delegation directory: nil receiver")
@@ -133,12 +154,14 @@ func (d *LocalDirectory) BindTargetSource(source TargetSource) error {
 	if d.dynamic != nil {
 		return errdefs.Conflictf("local delegation directory: target source already bound")
 	}
+	d.source = source
 	d.dynamic = source
 	return nil
 }
 
 // FreezeTargets replaces the live dynamic source with a fixed instance
-// set. Idempotent; used when a generation retires.
+// set. Idempotent; used when a generation retires. The bound source is
+// retained so UnfreezeTargets can restore it.
 func (d *LocalDirectory) FreezeTargets(instances map[string]*agent.Agent) {
 	if d == nil {
 		return
@@ -147,6 +170,18 @@ func (d *LocalDirectory) FreezeTargets(instances map[string]*agent.Agent) {
 	defer d.mu.Unlock()
 	d.frozen = instances
 	d.dynamic = nil
+}
+
+// UnfreezeTargets restores the live dynamic source bound by
+// BindTargetSource, discarding the frozen view. Idempotent.
+func (d *LocalDirectory) UnfreezeTargets() {
+	if d == nil {
+		return
+	}
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	d.frozen = nil
+	d.dynamic = d.source
 }
 
 func targetFromAgent(name string, instance *agent.Agent) Target {
@@ -180,7 +215,9 @@ func (d *LocalDirectory) BindDeployment(deployment any) error {
 	return d.Bind(view)
 }
 
-// List returns targets in deploy.Result.InstanceNames order.
+// List returns targets in deploy.Result.InstanceNames order followed by
+// the dynamic targets (frozen set when retired, otherwise the live
+// source) sorted by id.
 func (d *LocalDirectory) List(context.Context) ([]Target, error) {
 	if d == nil {
 		return nil, errdefs.NotAvailablef("local delegation directory: nil receiver")

--- a/core/delegation/directory.go
+++ b/core/delegation/directory.go
@@ -105,9 +105,10 @@ func (d *LocalDirectory) Bind(result Deployment) error {
 	d.mu.Lock()
 	defer d.mu.Unlock()
 	if d.bound {
-		// Binding is idempotent: a directory is immutable after a
-		// successful bind, so multiple resources may share one
-		// directory without failing the deployment.
+		// Binding the deployment snapshot is idempotent, so multiple
+		// resources may share one directory without failing the
+		// deployment. The live dynamic view is attached separately via
+		// BindTargetSource and is not part of this snapshot.
 		return nil
 	}
 
@@ -141,7 +142,9 @@ func (d *LocalDirectory) Bind(result Deployment) error {
 }
 
 // BindTargetSource attaches the live dynamic target view. It is
-// set-once: binding twice returns a Conflict error.
+// set-once for the directory's lifetime: binding twice — including
+// after FreezeTargets, which only swaps the active view and keeps the
+// bound source — returns a Conflict error.
 func (d *LocalDirectory) BindTargetSource(source TargetSource) error {
 	if d == nil {
 		return errdefs.Validationf("local delegation directory: nil receiver")
@@ -151,7 +154,7 @@ func (d *LocalDirectory) BindTargetSource(source TargetSource) error {
 	}
 	d.mu.Lock()
 	defer d.mu.Unlock()
-	if d.dynamic != nil {
+	if d.source != nil {
 		return errdefs.Conflictf("local delegation directory: target source already bound")
 	}
 	d.source = source

--- a/core/delegation/directory_test.go
+++ b/core/delegation/directory_test.go
@@ -1,0 +1,218 @@
+package delegation_test
+
+import (
+	"context"
+	"sort"
+	"sync"
+	"testing"
+
+	"github.com/GizClaw/flowcraft/core/agent"
+	"github.com/GizClaw/flowcraft/core/delegation"
+	"github.com/GizClaw/flowcraft/core/errdefs"
+)
+
+type fakeDeployment struct {
+	instances map[string]*agent.Agent
+	order     []string
+}
+
+func (d *fakeDeployment) Agent(id string) (*agent.Agent, bool) {
+	instance, ok := d.instances[id]
+	return instance, ok
+}
+
+func (d *fakeDeployment) AgentNames() []string {
+	return append([]string(nil), d.order...)
+}
+
+func testAgent(id, name, description string) *agent.Agent {
+	return &agent.Agent{
+		ID:   id,
+		Card: agent.AgentCard{Name: name, Description: description},
+	}
+}
+
+type fakeTargetSource struct {
+	mu     sync.Mutex
+	agents map[string]*agent.Agent
+}
+
+func newFakeTargetSource() *fakeTargetSource {
+	return &fakeTargetSource{agents: make(map[string]*agent.Agent)}
+}
+
+func (s *fakeTargetSource) Dynamic(id string) (*agent.Agent, bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	instance, ok := s.agents[id]
+	return instance, ok
+}
+
+func (s *fakeTargetSource) DynamicNames() []string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	names := make([]string, 0, len(s.agents))
+	for name := range s.agents {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
+}
+
+func (s *fakeTargetSource) set(id string, instance *agent.Agent) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.agents[id] = instance
+}
+
+func (s *fakeTargetSource) remove(id string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	delete(s.agents, id)
+}
+
+func TestDirectoryMergesDynamicTargets(t *testing.T) {
+	dir := delegation.NewDirectory()
+	deployment := &fakeDeployment{
+		instances: map[string]*agent.Agent{"alpha": testAgent("alpha", "Alpha", "deployed")},
+		order:     []string{"alpha"},
+	}
+	if err := dir.Bind(deployment); err != nil {
+		t.Fatalf("Bind: %v", err)
+	}
+	source := newFakeTargetSource()
+	source.set("omega", testAgent("omega", "Omega", "dynamic"))
+	if err := dir.BindTargetSource(source); err != nil {
+		t.Fatalf("BindTargetSource: %v", err)
+	}
+
+	ctx := context.Background()
+	targets, err := dir.List(ctx)
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(targets) != 2 || targets[0].ID != "alpha" || targets[1].ID != "omega" {
+		t.Fatalf("List = %+v, want [alpha omega]", targets)
+	}
+
+	omega, err := dir.Get(ctx, "omega")
+	if err != nil {
+		t.Fatalf("Get(omega): %v", err)
+	}
+	if omega.ID != "omega" || omega.Description != "dynamic" {
+		t.Fatalf("Get(omega) = %+v", omega)
+	}
+	instance, err := dir.Lookup(ctx, "omega")
+	if err != nil {
+		t.Fatalf("Lookup(omega): %v", err)
+	}
+	if instance.ID != "omega" {
+		t.Fatalf("Lookup(omega) instance ID = %q", instance.ID)
+	}
+}
+
+func TestDirectoryDynamicReflectsUnregister(t *testing.T) {
+	dir := delegation.NewDirectory()
+	if err := dir.Bind(&fakeDeployment{
+		instances: map[string]*agent.Agent{"alpha": testAgent("alpha", "Alpha", "")},
+		order:     []string{"alpha"},
+	}); err != nil {
+		t.Fatalf("Bind: %v", err)
+	}
+	source := newFakeTargetSource()
+	source.set("omega", testAgent("omega", "Omega", ""))
+	if err := dir.BindTargetSource(source); err != nil {
+		t.Fatalf("BindTargetSource: %v", err)
+	}
+
+	source.remove("omega")
+	ctx := context.Background()
+	targets, _ := dir.List(ctx)
+	if len(targets) != 1 || targets[0].ID != "alpha" {
+		t.Fatalf("List after remove = %+v, want [alpha]", targets)
+	}
+	if _, err := dir.Get(ctx, "omega"); !errdefs.IsNotFound(err) {
+		t.Fatalf("Get(omega) after remove error = %v, want not found", err)
+	}
+	if _, err := dir.Lookup(ctx, "omega"); !errdefs.IsNotFound(err) {
+		t.Fatalf("Lookup(omega) after remove error = %v, want not found", err)
+	}
+}
+
+func TestDirectoryBindTargetSourceSetOnce(t *testing.T) {
+	dir := delegation.NewDirectory()
+	if err := dir.Bind(&fakeDeployment{}); err != nil {
+		t.Fatalf("Bind: %v", err)
+	}
+	if err := dir.BindTargetSource(newFakeTargetSource()); err != nil {
+		t.Fatalf("first BindTargetSource: %v", err)
+	}
+	if err := dir.BindTargetSource(newFakeTargetSource()); !errdefs.IsConflict(err) {
+		t.Fatalf("second BindTargetSource error = %v, want conflict", err)
+	}
+}
+
+func TestDirectoryFreezeTargets(t *testing.T) {
+	dir := delegation.NewDirectory()
+	if err := dir.Bind(&fakeDeployment{
+		instances: map[string]*agent.Agent{"alpha": testAgent("alpha", "Alpha", "")},
+		order:     []string{"alpha"},
+	}); err != nil {
+		t.Fatalf("Bind: %v", err)
+	}
+	source := newFakeTargetSource()
+	source.set("omega", testAgent("omega", "Omega", ""))
+	if err := dir.BindTargetSource(source); err != nil {
+		t.Fatalf("BindTargetSource: %v", err)
+	}
+
+	dir.FreezeTargets(map[string]*agent.Agent{
+		"omega": testAgent("omega", "Omega", ""),
+	})
+	// A registration made after freeze must not be visible.
+	source.set("zeta", testAgent("zeta", "Zeta", ""))
+
+	ctx := context.Background()
+	targets, err := dir.List(ctx)
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(targets) != 2 || targets[0].ID != "alpha" || targets[1].ID != "omega" {
+		t.Fatalf("List after freeze = %+v, want [alpha omega]", targets)
+	}
+	if _, err := dir.Get(ctx, "zeta"); !errdefs.IsNotFound(err) {
+		t.Fatalf("Get(zeta) after freeze error = %v, want not found", err)
+	}
+	if _, err := dir.Lookup(ctx, "omega"); err != nil {
+		t.Fatalf("Lookup(omega) after freeze: %v", err)
+	}
+}
+
+func TestDirectoryDynamicDedupeWithDeployed(t *testing.T) {
+	dir := delegation.NewDirectory()
+	if err := dir.Bind(&fakeDeployment{
+		instances: map[string]*agent.Agent{"dup": testAgent("dup", "Dup", "deployed")},
+		order:     []string{"dup"},
+	}); err != nil {
+		t.Fatalf("Bind: %v", err)
+	}
+	source := newFakeTargetSource()
+	source.set("dup", testAgent("dup", "Dup", "dynamic"))
+	if err := dir.BindTargetSource(source); err != nil {
+		t.Fatalf("BindTargetSource: %v", err)
+	}
+
+	ctx := context.Background()
+	targets, _ := dir.List(ctx)
+	if len(targets) != 1 || targets[0].ID != "dup" {
+		t.Fatalf("List = %+v, want one dup", targets)
+	}
+	// Dynamic-first resolution.
+	instance, err := dir.Lookup(ctx, "dup")
+	if err != nil {
+		t.Fatalf("Lookup(dup): %v", err)
+	}
+	if instance.Card.Description != "dynamic" {
+		t.Fatalf("Lookup(dup) resolved %q, want the dynamic instance", instance.Card.Description)
+	}
+}

--- a/core/delegation/directory_test.go
+++ b/core/delegation/directory_test.go
@@ -188,6 +188,54 @@ func TestDirectoryFreezeTargets(t *testing.T) {
 	}
 }
 
+func TestDirectoryUnfreezeRestoresLiveSource(t *testing.T) {
+	dir := delegation.NewDirectory()
+	if err := dir.Bind(&fakeDeployment{
+		instances: map[string]*agent.Agent{"alpha": testAgent("alpha", "Alpha", "")},
+		order:     []string{"alpha"},
+	}); err != nil {
+		t.Fatalf("Bind: %v", err)
+	}
+	source := newFakeTargetSource()
+	source.set("omega", testAgent("omega", "Omega", "live"))
+	if err := dir.BindTargetSource(source); err != nil {
+		t.Fatalf("BindTargetSource: %v", err)
+	}
+	dir.FreezeTargets(map[string]*agent.Agent{
+		"omega": testAgent("omega", "Omega", "frozen"),
+	})
+	dir.UnfreezeTargets()
+
+	ctx := context.Background()
+	// The frozen instance must no longer pin resolution: the live
+	// source is authoritative again.
+	source.set("zeta", testAgent("zeta", "Zeta", ""))
+	targets, err := dir.List(ctx)
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(targets) != 3 || targets[1].ID != "omega" || targets[2].ID != "zeta" {
+		t.Fatalf("List after unfreeze = %+v, want [alpha omega zeta]", targets)
+	}
+	if _, err := dir.Lookup(ctx, "omega"); err != nil {
+		t.Fatalf("Lookup(omega) after unfreeze: %v", err)
+	}
+
+	source.remove("omega")
+	if _, err := dir.Get(ctx, "omega"); !errdefs.IsNotFound(err) {
+		t.Fatalf("Get(omega) after live remove error = %v, want not found", err)
+	}
+
+	// Unfreeze is idempotent.
+	dir.UnfreezeTargets()
+	if targets, err = dir.List(ctx); err != nil {
+		t.Fatalf("List after second unfreeze: %v", err)
+	}
+	if len(targets) != 2 {
+		t.Fatalf("List after second unfreeze = %+v, want [alpha zeta]", targets)
+	}
+}
+
 func TestDirectoryDynamicDedupeWithDeployed(t *testing.T) {
 	dir := delegation.NewDirectory()
 	if err := dir.Bind(&fakeDeployment{

--- a/core/delegation/directory_test.go
+++ b/core/delegation/directory_test.go
@@ -152,6 +152,28 @@ func TestDirectoryBindTargetSourceSetOnce(t *testing.T) {
 	}
 }
 
+func TestDirectoryBindTargetSourceAfterFreezeConflicts(t *testing.T) {
+	dir := delegation.NewDirectory()
+	if err := dir.Bind(&fakeDeployment{}); err != nil {
+		t.Fatalf("Bind: %v", err)
+	}
+	source := newFakeTargetSource()
+	if err := dir.BindTargetSource(source); err != nil {
+		t.Fatalf("BindTargetSource: %v", err)
+	}
+	dir.FreezeTargets(map[string]*agent.Agent{})
+
+	// Freeze only swaps the active view; the bound source remains, so a
+	// second bind must still conflict instead of silently overwriting it.
+	if err := dir.BindTargetSource(newFakeTargetSource()); !errdefs.IsConflict(err) {
+		t.Fatalf("BindTargetSource after freeze error = %v, want conflict", err)
+	}
+	dir.UnfreezeTargets()
+	if err := dir.BindTargetSource(newFakeTargetSource()); !errdefs.IsConflict(err) {
+		t.Fatalf("BindTargetSource after freeze/unfreeze error = %v, want conflict", err)
+	}
+}
+
 func TestDirectoryFreezeTargets(t *testing.T) {
 	dir := delegation.NewDirectory()
 	if err := dir.Bind(&fakeDeployment{

--- a/core/runtime/builder.go
+++ b/core/runtime/builder.go
@@ -7,6 +7,7 @@ import (
 	"sync"
 
 	"github.com/GizClaw/flowcraft/core/agent"
+	"github.com/GizClaw/flowcraft/core/delegation"
 	"github.com/GizClaw/flowcraft/core/deploy"
 	"github.com/GizClaw/flowcraft/core/errdefs"
 	"github.com/GizClaw/flowcraft/core/event"
@@ -255,6 +256,12 @@ func (b *Builder) Build(ctx context.Context, doc deploy.Document) (*Runtime, err
 		logBuildCleanup(ctx, "close partial deployment", result.Close())
 		return nil, fmt.Errorf("runtime bind session managers: %w", err)
 	}
+	if err := bindTargetSources(registry, result); err != nil {
+		logBuildCleanup(ctx, "close partial session manager", manager.Close())
+		logBuildCleanup(ctx, "close partial router", router.Close())
+		logBuildCleanup(ctx, "close partial deployment", result.Close())
+		return nil, fmt.Errorf("runtime bind delegation target sources: %w", err)
+	}
 	return &Runtime{
 		manager:             manager,
 		router:              router,
@@ -303,6 +310,58 @@ func bindSessionManagers(manager *session.Manager, result *deploy.Result) error 
 		bound = name
 	}
 	return nil
+}
+
+// bindTargetSources hands the Runtime's live agent registry to every
+// delegation directory resource that wants it, making dynamically
+// registered agents delegatable without re-binding. At most one binder
+// is allowed per deployment (v1 constraint, mirroring the session
+// manager binder rule).
+func bindTargetSources(registry *AgentRegistry, result *deploy.Result) error {
+	if registry == nil || result == nil {
+		return errdefs.Internalf(
+			"runtime: bind target sources requires a registry and result")
+	}
+	var bound string
+	for _, name := range result.Names() {
+		value, ok := result.Value(name)
+		if !ok {
+			continue
+		}
+		binder, ok := value.(delegation.TargetViewBinder)
+		if !ok {
+			continue
+		}
+		if bound != "" {
+			return errdefs.Conflictf(
+				"runtime: multiple delegation target view binders (%s and %s)",
+				bound, name)
+		}
+		if err := binder.BindTargetSource(registry); err != nil {
+			return fmt.Errorf(
+				"runtime: bind delegation target source to %q: %w", name, err)
+		}
+		bound = name
+	}
+	return nil
+}
+
+// freezeTargetViews pins the dynamic view of every delegation directory
+// in a retiring generation so in-flight delegations keep resolving the
+// instances that generation served.
+func freezeTargetViews(result *deploy.Result, instances map[string]*agent.Agent) {
+	if result == nil {
+		return
+	}
+	for _, name := range result.Names() {
+		value, ok := result.Value(name)
+		if !ok {
+			continue
+		}
+		if freezer, ok := value.(delegation.TargetViewFreezer); ok {
+			freezer.FreezeTargets(instances)
+		}
+	}
 }
 
 func resolveValue[T any](result *deploy.Result, name, field string) (T, error) {

--- a/core/runtime/builder.go
+++ b/core/runtime/builder.go
@@ -348,7 +348,11 @@ func bindTargetSources(registry *AgentRegistry, result *deploy.Result) error {
 
 // freezeTargetViews pins the dynamic view of every delegation directory
 // in a retiring generation so in-flight delegations keep resolving the
-// instances that generation served.
+// instances that generation served. Freezing is a one-shot commit
+// (paired with unfreezeTargetViews on every rollback path); the
+// single-binder constraint enforced by bindTargetSources guarantees at
+// most one directory per deployment, so iteration here cannot see a
+// conflicting set.
 func freezeTargetViews(result *deploy.Result, instances map[string]*agent.Agent) {
 	if result == nil {
 		return
@@ -360,6 +364,25 @@ func freezeTargetViews(result *deploy.Result, instances map[string]*agent.Agent)
 		}
 		if freezer, ok := value.(delegation.TargetViewFreezer); ok {
 			freezer.FreezeTargets(instances)
+		}
+	}
+}
+
+// unfreezeTargetViews restores the live dynamic view of every
+// delegation directory in a generation that a failed reload rolled
+// back, so the still-current directory keeps following RegisterAgent /
+// UnregisterAgent. It pairs with freezeTargetViews.
+func unfreezeTargetViews(result *deploy.Result) {
+	if result == nil {
+		return
+	}
+	for _, name := range result.Names() {
+		value, ok := result.Value(name)
+		if !ok {
+			continue
+		}
+		if freezer, ok := value.(delegation.TargetViewFreezer); ok {
+			freezer.UnfreezeTargets()
 		}
 	}
 }

--- a/core/runtime/registry.go
+++ b/core/runtime/registry.go
@@ -5,6 +5,7 @@ import (
 	"sync"
 
 	"github.com/GizClaw/flowcraft/core/agent"
+	"github.com/GizClaw/flowcraft/core/delegation"
 	"github.com/GizClaw/flowcraft/core/deploy"
 	"github.com/GizClaw/flowcraft/core/errdefs"
 )
@@ -93,6 +94,24 @@ func (r *AgentRegistry) Dynamic(id string) (*agent.Agent, bool) {
 	}
 	return entry.instance, true
 }
+
+// DynamicNames implements delegation.TargetSource: the sorted dynamic
+// registration ids.
+func (r *AgentRegistry) DynamicNames() []string {
+	if r == nil {
+		return nil
+	}
+	r.mu.RLock()
+	names := make([]string, 0, len(r.agents))
+	for name := range r.agents {
+		names = append(names, name)
+	}
+	r.mu.RUnlock()
+	sort.Strings(names)
+	return names
+}
+
+var _ delegation.TargetSource = (*AgentRegistry)(nil)
 
 // Entries returns a defensive copy of every dynamic registration.
 func (r *AgentRegistry) Entries() map[string]dynamicAgentEntry {

--- a/core/runtime/reload.go
+++ b/core/runtime/reload.go
@@ -149,6 +149,9 @@ func (r *Runtime) Reload(
 	if err := bindSessionManagers(r.manager, newResult); err != nil {
 		return nil, abort(err)
 	}
+	if err := bindTargetSources(r.registry, newResult); err != nil {
+		return nil, abort(err)
+	}
 
 	// Resolve the new generation's system resources and validate the
 	// resume contract. The bus and checkpoint store may change
@@ -327,7 +330,9 @@ func (r *Runtime) Reload(
 	// Freeze the retiring generation, swap the live view, and commit.
 	oldGen := r.current
 	if oldGen != nil {
-		oldGen.freeze(dynamicInstances(entries))
+		adopted := dynamicInstances(entries)
+		oldGen.freeze(adopted)
+		freezeTargetViews(oldGen.result, adopted)
 	}
 	newGen := &Generation{
 		id:          newGenID,

--- a/core/runtime/reload.go
+++ b/core/runtime/reload.go
@@ -361,6 +361,7 @@ func (r *Runtime) Reload(
 	if err := r.router.AddBus(newBus); err != nil {
 		if oldGen != nil {
 			oldGen.unfreeze()
+			unfreezeTargetViews(oldGen.result)
 		}
 		// Belt and braces: AddBus is all-or-nothing, so the new bus is
 		// never attached on error; removing it here keeps the invariant
@@ -399,6 +400,7 @@ func (r *Runtime) Reload(
 		// Unreachable under lifecycleMu (Close holds it); roll back.
 		if oldGen != nil {
 			oldGen.unfreeze()
+			unfreezeTargetViews(oldGen.result)
 		}
 		if rerr := r.router.RemoveBus(newBus); rerr != nil {
 			telemetry.WarnErr(ctx, "runtime reload: remove new bus after swap failure", rerr,

--- a/core/runtime/target_source_test.go
+++ b/core/runtime/target_source_test.go
@@ -1,0 +1,147 @@
+package runtime
+
+import (
+	"context"
+	"testing"
+
+	"github.com/GizClaw/flowcraft/core/agent"
+	"github.com/GizClaw/flowcraft/core/delegation"
+	"github.com/GizClaw/flowcraft/core/deploy"
+	"github.com/GizClaw/flowcraft/core/errdefs"
+	"github.com/GizClaw/flowcraft/core/event"
+	"github.com/GizClaw/flowcraft/core/resource"
+)
+
+func directoryDoc(t *testing.T, extra string) deploy.Document {
+	t.Helper()
+	doc := parseRuntimeDoc(t, `version: v1
+resources:
+  events: {kind: event.Bus, impl: test}
+  directory: {kind: delegation.Directory, impl: local}
+`+extra+`
+agents:
+  bot:
+    card: {name: Bot}
+    engine: {kind: agent.Engine, impl: test}
+runtime:
+  event_bus: events
+  sessions: {idle_timeout: 1h, sink_buffer: 8}
+`)
+	return doc
+}
+
+func buildDirectoryApp(t *testing.T, doc deploy.Document) *Runtime {
+	t.Helper()
+	bus := event.NewMemoryBus()
+	reg := resource.NewRegistry()
+	reg.MustRegister(testEngineFactory{engine: simpleRunEngine()})
+	reg.MustRegister(testResourceFactory{
+		spec:  resource.Spec{Kind: testEventKind, Impl: testEventImpl},
+		value: bus,
+	})
+	reg.MustRegister(delegation.NewDirectoryFactory())
+	app, err := NewBuilder(reg).Build(context.Background(), doc)
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	t.Cleanup(func() { _ = app.Close() })
+	return app
+}
+
+func TestRuntimeRegisterAgentBecomesDelegationTarget(t *testing.T) {
+	app := buildDirectoryApp(t, directoryDoc(t, ""))
+	value, ok := app.Resource("directory")
+	directory, typeOK := value.(*delegation.LocalDirectory)
+	if !ok || !typeOK || directory == nil {
+		t.Fatalf("directory resource = %v, want *delegation.LocalDirectory", value)
+	}
+
+	ctx := context.Background()
+	if _, err := app.RegisterAgent(ctx, "dyn", dynamicDefinition("Dyn")); err != nil {
+		t.Fatalf("RegisterAgent: %v", err)
+	}
+
+	targets, err := directory.List(ctx)
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(targets) != 2 || targets[0].ID != "bot" || targets[1].ID != "dyn" {
+		t.Fatalf("List = %+v, want [bot dyn]", targets)
+	}
+	if _, err := directory.Lookup(ctx, "dyn"); err != nil {
+		t.Fatalf("Lookup(dyn): %v", err)
+	}
+
+	if err := app.UnregisterAgent(ctx, "dyn"); err != nil {
+		t.Fatalf("UnregisterAgent: %v", err)
+	}
+	targets, err = directory.List(ctx)
+	if err != nil {
+		t.Fatalf("List after unregister: %v", err)
+	}
+	if len(targets) != 1 || targets[0].ID != "bot" {
+		t.Fatalf("List after unregister = %+v, want [bot]", targets)
+	}
+	if _, err := directory.Lookup(ctx, "dyn"); !errdefs.IsNotFound(err) {
+		t.Fatalf("Lookup(dyn) after unregister error = %v, want not found", err)
+	}
+}
+
+func TestRuntimeMultipleTargetViewBindersConflict(t *testing.T) {
+	doc := directoryDoc(t, `
+  directory2: {kind: delegation.Directory, impl: local}
+`)
+	bus := event.NewMemoryBus()
+	reg := resource.NewRegistry()
+	reg.MustRegister(testEngineFactory{engine: simpleRunEngine()})
+	reg.MustRegister(testResourceFactory{
+		spec:  resource.Spec{Kind: testEventKind, Impl: testEventImpl},
+		value: bus,
+	})
+	reg.MustRegister(delegation.NewDirectoryFactory())
+	app, err := NewBuilder(reg).Build(context.Background(), doc)
+	if err == nil {
+		_ = app.Close()
+		t.Fatal("Build with two target view binders succeeded, want conflict")
+	}
+	if !errdefs.IsConflict(err) {
+		t.Fatalf("Build error = %v, want conflict", err)
+	}
+}
+
+func TestFreezeTargetViewsPinsDynamicSet(t *testing.T) {
+	app := buildDirectoryApp(t, directoryDoc(t, ""))
+	value, ok := app.Resource("directory")
+	directory, typeOK := value.(*delegation.LocalDirectory)
+	if !ok || !typeOK {
+		t.Fatalf("directory resource = %v, want *delegation.LocalDirectory", value)
+	}
+
+	ctx := context.Background()
+	instance, err := app.RegisterAgent(ctx, "dyn", dynamicDefinition("Dyn"))
+	if err != nil {
+		t.Fatalf("RegisterAgent: %v", err)
+	}
+
+	// Pin the dynamic set exactly as generation retirement would.
+	freezeTargetViews(app.current.result, map[string]*agent.Agent{"dyn": instance})
+
+	// A registration made after the freeze must not appear in the
+	// retired generation's directory.
+	if _, err := app.RegisterAgent(ctx, "zeta", dynamicDefinition("Zeta")); err != nil {
+		t.Fatalf("RegisterAgent(zeta): %v", err)
+	}
+	targets, err := directory.List(ctx)
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(targets) != 2 || targets[0].ID != "bot" || targets[1].ID != "dyn" {
+		t.Fatalf("List after freeze = %+v, want [bot dyn]", targets)
+	}
+	if _, err := directory.Lookup(ctx, "dyn"); err != nil {
+		t.Fatalf("Lookup(dyn) after freeze: %v", err)
+	}
+	if _, err := directory.Lookup(ctx, "zeta"); !errdefs.IsNotFound(err) {
+		t.Fatalf("Lookup(zeta) after freeze error = %v, want not found", err)
+	}
+}

--- a/core/runtime/target_source_test.go
+++ b/core/runtime/target_source_test.go
@@ -2,7 +2,10 @@ package runtime
 
 import (
 	"context"
+	"fmt"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/GizClaw/flowcraft/core/agent"
 	"github.com/GizClaw/flowcraft/core/delegation"
@@ -143,5 +146,191 @@ func TestFreezeTargetViewsPinsDynamicSet(t *testing.T) {
 	}
 	if _, err := directory.Lookup(ctx, "zeta"); !errdefs.IsNotFound(err) {
 		t.Fatalf("Lookup(zeta) after freeze error = %v, want not found", err)
+	}
+}
+
+func TestFreezeUnfreezeTargetViewsRoundTrip(t *testing.T) {
+	app := buildDirectoryApp(t, directoryDoc(t, ""))
+	value, ok := app.Resource("directory")
+	directory, typeOK := value.(*delegation.LocalDirectory)
+	if !ok || !typeOK {
+		t.Fatalf("directory resource = %v, want *delegation.LocalDirectory", value)
+	}
+
+	ctx := context.Background()
+	instance, err := app.RegisterAgent(ctx, "dyn", dynamicDefinition("Dyn"))
+	if err != nil {
+		t.Fatalf("RegisterAgent: %v", err)
+	}
+
+	// Simulate a freeze at the swap point, then the rollback path.
+	freezeTargetViews(app.current.result, map[string]*agent.Agent{"dyn": instance})
+	unfreezeTargetViews(app.current.result)
+
+	if _, err := app.RegisterAgent(ctx, "zeta", dynamicDefinition("Zeta")); err != nil {
+		t.Fatalf("RegisterAgent(zeta) after unfreeze: %v", err)
+	}
+	targets, err := directory.List(ctx)
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(targets) != 3 || targets[0].ID != "bot" ||
+		targets[1].ID != "dyn" || targets[2].ID != "zeta" {
+		t.Fatalf("List after unfreeze = %+v, want [bot dyn zeta]", targets)
+	}
+	if _, err := directory.Lookup(ctx, "zeta"); err != nil {
+		t.Fatalf("Lookup(zeta) after unfreeze: %v", err)
+	}
+}
+
+func TestRuntimeReloadRetiredDirectoryFrozen(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	reg := resource.NewRegistry()
+	reg.MustRegister(testEngineFactory{engine: simpleRunEngine()})
+	reg.MustRegister(freshBusFactory{})
+	reg.MustRegister(delegation.NewDirectoryFactory())
+	app, err := NewBuilder(reg).Build(ctx, directoryDoc(t, ""))
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	t.Cleanup(func() { _ = app.Close() })
+
+	if _, err := app.RegisterAgent(ctx, "dyn", dynamicDefinition("Dyn")); err != nil {
+		t.Fatalf("RegisterAgent: %v", err)
+	}
+	oldValue, _ := app.current.result.Value("directory")
+	oldDirectory, ok := oldValue.(*delegation.LocalDirectory)
+	if !ok {
+		t.Fatalf("old directory resource = %T", oldValue)
+	}
+
+	if _, err := app.Reload(ctx, directoryDoc(t, "")); err != nil {
+		t.Fatalf("Reload: %v", err)
+	}
+	newValue, ok := app.Resource("directory")
+	newDirectory, typeOK := newValue.(*delegation.LocalDirectory)
+	if !ok || !typeOK {
+		t.Fatalf("new directory resource = %v, want *delegation.LocalDirectory", newValue)
+	}
+
+	// A registration after the swap is visible to the new generation
+	// only; the retired directory stays pinned to the frozen set.
+	if _, err := app.RegisterAgent(ctx, "zeta", dynamicDefinition("Zeta")); err != nil {
+		t.Fatalf("RegisterAgent(zeta): %v", err)
+	}
+	oldTargets, err := oldDirectory.List(ctx)
+	if err != nil {
+		t.Fatalf("old List: %v", err)
+	}
+	if len(oldTargets) != 2 || oldTargets[0].ID != "bot" || oldTargets[1].ID != "dyn" {
+		t.Fatalf("old List after reload = %+v, want [bot dyn]", oldTargets)
+	}
+	if _, err := oldDirectory.Lookup(ctx, "zeta"); !errdefs.IsNotFound(err) {
+		t.Fatalf("old Lookup(zeta) error = %v, want not found", err)
+	}
+	if _, err := oldDirectory.Lookup(ctx, "dyn"); err != nil {
+		t.Fatalf("old Lookup(dyn) (in-flight) : %v", err)
+	}
+
+	newTargets, err := newDirectory.List(ctx)
+	if err != nil {
+		t.Fatalf("new List: %v", err)
+	}
+	if len(newTargets) != 3 || newTargets[1].ID != "dyn" || newTargets[2].ID != "zeta" {
+		t.Fatalf("new List after reload = %+v, want [bot dyn zeta]", newTargets)
+	}
+}
+
+func TestRuntimeDynamicAgentDelegateEndToEnd(t *testing.T) {
+	ctx := context.Background()
+	reg := newBaseRegistry(t, event.NewMemoryBus(), &recordingCheckpointStore{}, noopEngine())
+	reg.MustRegister(delegation.NewDirectoryFactory())
+	reg.MustRegister(delegation.NewServiceFactory())
+	doc := baseRuntimeDoc(t)
+	doc.Resources["delegation_directory"] = resource.Resource{
+		Kind: delegation.DirectoryKind, Impl: "local",
+	}
+	doc.Resources["delegation"] = resource.Resource{
+		Kind: delegation.ServiceKind, Impl: "local",
+		Deps: resource.Deps{"directory": "delegation_directory"},
+	}
+	app, err := NewBuilder(reg).Build(ctx, doc)
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	t.Cleanup(func() { _ = app.Close() })
+
+	serviceValue, _ := app.Resource("delegation")
+	service, ok := serviceValue.(*delegation.LocalService)
+	if !ok {
+		t.Fatalf("delegation resource = %T, want *delegation.LocalService", serviceValue)
+	}
+
+	if _, err := app.RegisterAgent(ctx, "dyn", dynamicDefinition("Dyn")); err != nil {
+		t.Fatalf("RegisterAgent: %v", err)
+	}
+	response, err := service.Delegate(ctx, delegation.Request{
+		Mode:   delegation.ModeSync,
+		Target: "dyn",
+		Input:  "do it",
+	})
+	if err != nil {
+		t.Fatalf("Delegate to dynamic agent: %v", err)
+	}
+	if response.Status != delegation.StatusSucceeded {
+		t.Fatalf("response status = %q, want succeeded", response.Status)
+	}
+
+	if err := app.UnregisterAgent(ctx, "dyn"); err != nil {
+		t.Fatalf("UnregisterAgent: %v", err)
+	}
+	if _, err := service.Delegate(ctx, delegation.Request{
+		Mode:   delegation.ModeSync,
+		Target: "dyn",
+		Input:  "do it again",
+	}); !errdefs.IsNotFound(err) {
+		t.Fatalf("Delegate after unregister error = %v, want not found", err)
+	}
+}
+
+func TestDirectoryConcurrentSourceAccess(t *testing.T) {
+	app := buildDirectoryApp(t, directoryDoc(t, ""))
+	value, ok := app.Resource("directory")
+	directory, typeOK := value.(*delegation.LocalDirectory)
+	if !ok || !typeOK {
+		t.Fatalf("directory resource = %v, want *delegation.LocalDirectory", value)
+	}
+	ctx := context.Background()
+
+	var wg sync.WaitGroup
+	for i := 0; i < 8; i++ {
+		wg.Add(1)
+		go func(n int) {
+			defer wg.Done()
+			name := fmt.Sprintf("dyn-%d", n)
+			if _, err := app.RegisterAgent(ctx, name, dynamicDefinition(name)); err != nil {
+				t.Errorf("RegisterAgent(%s): %v", name, err)
+			}
+		}(i)
+	}
+	for i := 0; i < 8; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_, _ = directory.List(ctx)
+			_, _ = directory.Get(ctx, "bot")
+			_, _ = directory.Lookup(ctx, "dyn-3")
+		}()
+	}
+	wg.Wait()
+
+	targets, err := directory.List(ctx)
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(targets) != 9 {
+		t.Fatalf("List = %d targets, want 9 (bot + 8 dynamic)", len(targets))
 	}
 }

--- a/core/runtime/target_source_test.go
+++ b/core/runtime/target_source_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -240,6 +241,82 @@ func TestRuntimeReloadRetiredDirectoryFrozen(t *testing.T) {
 	}
 	if len(newTargets) != 3 || newTargets[1].ID != "dyn" || newTargets[2].ID != "zeta" {
 		t.Fatalf("new List after reload = %+v, want [bot dyn zeta]", newTargets)
+	}
+}
+
+// failingBusFactory builds a working bus for the first generation and a
+// closed bus (Subscribe always fails) for every later generation, so a
+// reload's router.AddBus fails after the swap-point freeze — the one
+// rollback path reachable through the public API.
+type failingBusFactory struct {
+	built atomic.Int64
+}
+
+func (*failingBusFactory) Spec() resource.Spec {
+	return resource.Spec{Kind: testEventKind, Impl: testEventImpl}
+}
+
+func (f *failingBusFactory) New(context.Context, resource.Input) (any, error) {
+	if f.built.Add(1) == 1 {
+		return event.NewMemoryBus(), nil
+	}
+	bus := event.NewMemoryBus()
+	_ = bus.Close()
+	return bus, nil
+}
+
+func TestRuntimeReloadRollbackUnfreezesDirectory(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	reg := resource.NewRegistry()
+	reg.MustRegister(testEngineFactory{engine: simpleRunEngine()})
+	reg.MustRegister(&failingBusFactory{})
+	reg.MustRegister(delegation.NewDirectoryFactory())
+	app, err := NewBuilder(reg).Build(ctx, directoryDoc(t, ""))
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	t.Cleanup(func() { _ = app.Close() })
+
+	value, ok := app.Resource("directory")
+	directory, typeOK := value.(*delegation.LocalDirectory)
+	if !ok || !typeOK {
+		t.Fatalf("directory resource = %v, want *delegation.LocalDirectory", value)
+	}
+	if _, err := app.RegisterAgent(ctx, "dyn", dynamicDefinition("Dyn")); err != nil {
+		t.Fatalf("RegisterAgent: %v", err)
+	}
+	// Give the router an attachment so AddBus actually subscribes on
+	// the new generation's bus and hits the closed-bus failure.
+	if _, err := app.router.Attach(ctx, event.Pattern("test.>"),
+		event.SinkFunc(func(context.Context, event.Envelope) error { return nil })); err != nil {
+		t.Fatalf("Attach: %v", err)
+	}
+
+	// The new generation's bus cannot be subscribed, so AddBus fails
+	// after the swap-point freeze and must roll the directory back to
+	// the live view.
+	if _, reloadErr := app.Reload(ctx, directoryDoc(t, "")); reloadErr == nil {
+		t.Fatal("Reload with failing bus succeeded, want error")
+	}
+	if app.current.id != 1 {
+		t.Fatalf("generation id after failed reload = %d, want 1", app.current.id)
+	}
+
+	if _, err := app.RegisterAgent(ctx, "zeta", dynamicDefinition("Zeta")); err != nil {
+		t.Fatalf("RegisterAgent(zeta) after failed reload: %v", err)
+	}
+	targets, err := directory.List(ctx)
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(targets) != 3 || targets[0].ID != "bot" ||
+		targets[1].ID != "dyn" || targets[2].ID != "zeta" {
+		t.Fatalf("List after failed reload = %+v, want [bot dyn zeta]", targets)
+	}
+	if _, err := directory.Lookup(ctx, "zeta"); err != nil {
+		t.Fatalf("Lookup(zeta) after failed reload: %v", err)
 	}
 }
 


### PR DESCRIPTION
## Summary

Fixes #403: dynamically registered agents (`Runtime.RegisterAgent`) are now visible as delegation targets, so "create an agent, then delegate to it" works without re-deploying.

### Approach (pull-based, reuses the existing single source of truth)

The session manager already resolves dynamic agents through `AgentRegistry` (dynamic-first, deployed fallback). The delegation directory now merges that same live view instead of duplicating dynamic state:

- **core/delegation**: `LocalDirectory` gains a `TargetSource` (live dynamic view) merged with its deployment snapshot — `List` appends sorted dynamic targets (deduped by id), `Get`/`Lookup` resolve dynamic-first. `BindTargetSource` is set-once for the directory's lifetime (keyed on the retained source, so freeze cannot bypass it); `FreezeTargets`/`UnfreezeTargets` pin and restore the dynamic view.
- **core/runtime**: `AgentRegistry` implements `delegation.TargetSource` (`Dynamic` + `DynamicNames`); `Build` and `Reload` attach it to every delegation directory via `bindTargetSources` (single-binder constraint, mirroring `bindSessionManagers`).

### Reload / retirement semantics

- At reload swap the retiring generation's directory is frozen with the same adopted instances as its resolver: in-flight delegations keep resolving the instances that generation served (validation/telemetry only; execution resolves through the session manager at `Session.Start`).
- **Rollback**: the AddBus and SwapDeps failure paths call `unfreezeTargetViews` alongside `oldGen.unfreeze()`, so a failed reload leaves the still-current directory live — later `RegisterAgent`/`UnregisterAgent` keep taking effect. (SwapDeps failure is documented as unreachable under `lifecycleMu`; the AddBus path is covered by a direct test.)

### Behavior

- `RegisterAgent` → target appears immediately in `delegation_targets` / `delegate`.
- `UnregisterAgent` → new delegates get `TargetNotFound`; in-flight delegations keep running (session manager drain).
- Reload → new generation sees the latest dynamic set; the retired generation's directory is frozen.

## Verification

- `make ci` (vet + test, all modules) — pass
- `make lint` (golangci-lint, all modules) — 0 issues
- `gofmt` / `git diff --check` — clean
- `go test -race` for runtime + delegation — pass
- New tests: directory merge/unregister/freeze/unfreeze/set-once-across-freeze/dedupe (`delegation`); runtime register→visible→unregister, delegate end-to-end for a dynamic agent, binder conflict, freeze, reload rollback via failing bus, concurrent access (`runtime`)