### PR TITLE
feat(core/delegation): resume parked delegated runs on identical retry

### DIFF
--- a/core/delegation/service.go
+++ b/core/delegation/service.go
@@ -749,13 +749,36 @@ func (s *LocalService) runAt(ctx context.Context, req AsyncRequest, reuseSlot bo
 		}
 	}()
 
-	turn, err := lease.Session().StartWithOptions(execCtx, agent.Request{
+	opts := s.delegationStartOptions(persistent)
+	request := agent.Request{
 		ContextID: key.ContextID,
 		Message:   message.NewTextMessage(message.RoleUser, req.Request.Input),
 		Inputs:    metadataInputs(req),
-	}, s.delegationStartOptions(persistent)...)
-	if err != nil {
-		return Response{}, err
+	}
+
+	// Resume path: a persistent session retried with the identical
+	// request replays the parked run from its checkpoint instead of
+	// starting fresh. Anything that cannot resume — no parked request,
+	// a mismatched retry request, a missing checkpoint, or an engine
+	// that cannot resume — falls through to a fresh Start.
+	var turn *session.Turn
+	if persistent {
+		if parked, ok, err := lease.Session().ParkedRequest(execCtx); err != nil {
+			return Response{}, err
+		} else if ok && sameDelegationRequest(request, parked) {
+			if resumed, err := lease.Session().ResumeWithOptions(execCtx, opts...); err == nil {
+				turn = resumed
+			} else if !errdefs.IsNotFound(err) && !errdefs.IsNotAvailable(err) {
+				return Response{}, err
+			}
+		}
+	}
+	if turn == nil {
+		var err error
+		turn, err = lease.Session().StartWithOptions(execCtx, request, opts...)
+		if err != nil {
+			return Response{}, err
+		}
 	}
 
 	result, err := waitTurnCancelOnDone(execCtx, turn)
@@ -925,6 +948,16 @@ func (s *LocalService) delegationStartOptions(persistent bool) []session.StartOp
 		options = append(options, session.WithEphemeral())
 	}
 	return options
+}
+
+// sameDelegationRequest reports whether two delegation requests are
+// identical for resume purposes: the same user message and the same
+// metadata inputs. ContextID and RunID are session plumbing stamped by
+// the service and are ignored.
+func sameDelegationRequest(a, b agent.Request) bool {
+	return a.Message.Role == b.Message.Role &&
+		a.Message.Content.Text() == b.Message.Content.Text() &&
+		reflect.DeepEqual(a.Inputs, b.Inputs)
 }
 
 // refuseSubagentAskUser is the default subagent asker: subagents never

--- a/core/delegation/service.go
+++ b/core/delegation/service.go
@@ -758,18 +758,28 @@ func (s *LocalService) runAt(ctx context.Context, req AsyncRequest, reuseSlot bo
 
 	// Resume path: a persistent session retried with the identical
 	// request replays the parked run from its checkpoint instead of
-	// starting fresh. Anything that cannot resume — no parked request,
-	// a mismatched retry request, a missing checkpoint, or an engine
-	// that cannot resume — falls through to a fresh Start.
+	// starting fresh. Resume is best-effort for a retry: any failure to
+	// probe or replay — transient checkpoint-store errors, unreadable
+	// parked state, a missing checkpoint, or an engine that cannot
+	// resume — degrades to a fresh Start with a warning rather than
+	// failing the retry. Start re-validates the session and surfaces
+	// real failures.
 	var turn *session.Turn
 	if persistent {
-		if parked, ok, err := lease.Session().ParkedRequest(execCtx); err != nil {
-			return Response{}, err
+		parked, ok, err := lease.Session().ParkedRequest(execCtx)
+		if err != nil {
+			telemetry.WarnErr(execCtx,
+				"local delegation: cannot inspect parked run, starting fresh", err,
+				otellog.String(telemetry.AttrAgentID, key.AgentID),
+				otellog.String(telemetry.AttrConversationID, key.ContextID))
 		} else if ok && sameDelegationRequest(request, parked) {
 			if resumed, err := lease.Session().ResumeWithOptions(execCtx, opts...); err == nil {
 				turn = resumed
-			} else if !errdefs.IsNotFound(err) && !errdefs.IsNotAvailable(err) {
-				return Response{}, err
+			} else {
+				telemetry.WarnErr(execCtx,
+					"local delegation: resume parked run failed, starting fresh", err,
+					otellog.String(telemetry.AttrAgentID, key.AgentID),
+					otellog.String(telemetry.AttrConversationID, key.ContextID))
 			}
 		}
 	}

--- a/core/delegation/session_provider_test.go
+++ b/core/delegation/session_provider_test.go
@@ -56,28 +56,39 @@ func (h delegationTestHost) Publish(ctx context.Context, env event.Envelope) err
 	return h.bus.Publish(ctx, env)
 }
 
+// runEndEngine wraps an engine so it publishes the run-end event the
+// session stream coordinator waits for. Unwrap keeps decorated
+// capabilities (e.g. Resumer) visible to host-side probes.
+type runEndEngine struct {
+	inner agent.Engine
+}
+
+func (e runEndEngine) Execute(
+	ctx context.Context,
+	run agent.Run,
+	host agent.Host,
+	board *agent.Board,
+) (*agent.Board, error) {
+	board, err := e.inner.Execute(ctx, run, host, board)
+	publishCtx := context.WithoutCancel(ctx)
+	envelope, envelopeErr := event.NewEnvelope(
+		publishCtx, agent.SubjectRunEnd(run.RunID), nil)
+	if envelopeErr == nil {
+		envelope.SetRunID(run.RunID)
+		envelopeErr = host.Publish(publishCtx, envelope)
+	}
+	if err != nil {
+		return board, err
+	}
+	return board, envelopeErr
+}
+
+func (e runEndEngine) Unwrap() agent.Engine { return e.inner }
+
 // delegationWithRunEnd wraps an engine so it publishes the run-end event
 // the session stream coordinator waits for.
 func delegationWithRunEnd(engine agent.Engine) agent.Engine {
-	return agent.EngineFunc(func(
-		ctx context.Context,
-		run agent.Run,
-		host agent.Host,
-		board *agent.Board,
-	) (*agent.Board, error) {
-		board, err := engine.Execute(ctx, run, host, board)
-		publishCtx := context.WithoutCancel(ctx)
-		envelope, envelopeErr := event.NewEnvelope(
-			publishCtx, agent.SubjectRunEnd(run.RunID), nil)
-		if envelopeErr == nil {
-			envelope.SetRunID(run.RunID)
-			envelopeErr = host.Publish(publishCtx, envelope)
-		}
-		if err != nil {
-			return board, err
-		}
-		return board, envelopeErr
-	})
+	return runEndEngine{inner: engine}
 }
 
 func newTestSessionManagerForResult(
@@ -487,6 +498,234 @@ func TestRunAtSessionPathAsyncRun(t *testing.T) {
 	}
 	if response.Metadata["delegation.session_id"] != "async-ctx" {
 		t.Fatalf("session_id = %q, want async-ctx", response.Metadata["delegation.session_id"])
+	}
+}
+
+// delegationCheckpointStore is a minimal in-memory CheckpointDeleter
+// used to exercise the delegation resume path end to end.
+type delegationCheckpointStore struct {
+	mu  sync.Mutex
+	cps map[string]agent.Checkpoint
+}
+
+func newDelegationCheckpointStore() *delegationCheckpointStore {
+	return &delegationCheckpointStore{cps: make(map[string]agent.Checkpoint)}
+}
+
+func (s *delegationCheckpointStore) Save(_ context.Context, cp agent.Checkpoint) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.cps[cp.ExecID] = cp.Clone()
+	return nil
+}
+
+func (s *delegationCheckpointStore) Load(_ context.Context, execID string) (*agent.Checkpoint, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	cp, ok := s.cps[execID]
+	if !ok {
+		return nil, nil
+	}
+	clone := cp.Clone()
+	return &clone, nil
+}
+
+func (s *delegationCheckpointStore) Delete(_ context.Context, execID string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	delete(s.cps, execID)
+	return nil
+}
+
+// resumeAwareDelegationEngine fails the first attempt (optionally after
+// writing a checkpoint) and succeeds on the next, recording whether the
+// second attempt was a resume under the original run id.
+type resumeAwareDelegationEngine struct {
+	mu              sync.Mutex
+	attempts        int
+	resumed         bool
+	runIDs          []string
+	store           *delegationCheckpointStore
+	writeCheckpoint bool
+}
+
+func (e *resumeAwareDelegationEngine) Execute(
+	ctx context.Context,
+	run agent.Run,
+	_ agent.Host,
+	board *agent.Board,
+) (*agent.Board, error) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	e.attempts++
+	e.runIDs = append(e.runIDs, run.RunID)
+	if e.attempts == 1 {
+		if e.writeCheckpoint {
+			if err := e.store.Save(ctx, agent.Checkpoint{
+				ExecID:            run.RunID,
+				Steps:             []string{"wave-1"},
+				Board:             board.Snapshot(),
+				Timestamp:         time.Now(),
+				OriginalStartedAt: time.Now(),
+				SpecVersion:       "v1",
+			}); err != nil {
+				return board, err
+			}
+		}
+		return board, errdefs.Internalf("first attempt fails")
+	}
+	e.resumed = run.ResumeFrom != nil
+	board.AppendChannelMessage(agent.MainChannel,
+		message.NewTextMessage(message.RoleAssistant, "done"))
+	return board, nil
+}
+
+func (*resumeAwareDelegationEngine) CanResume(agent.Checkpoint) error { return nil }
+
+func TestRunAtPersistentRetryResumesParkedRun(t *testing.T) {
+	store := newDelegationCheckpointStore()
+	engine := &resumeAwareDelegationEngine{store: store, writeCheckpoint: true}
+	service, _ := newSessionPathService(t, engine,
+		&testSessionProvider{contextID: "resume-ctx", persistent: true},
+		session.WithResume(true), session.WithCheckpointStore(store))
+
+	first, err := service.Delegate(context.Background(), syncRequest("writer"))
+	if err != nil {
+		t.Fatalf("first Delegate: %v", err)
+	}
+	if first.Status != StatusFailed {
+		t.Fatalf("first status = %q, want failed", first.Status)
+	}
+
+	second, err := service.Delegate(context.Background(), syncRequest("writer"))
+	if err != nil {
+		t.Fatalf("retry Delegate: %v", err)
+	}
+	if second.Status != StatusSucceeded {
+		t.Fatalf("retry status = %q, want succeeded", second.Status)
+	}
+
+	engine.mu.Lock()
+	defer engine.mu.Unlock()
+	if engine.attempts != 2 {
+		t.Fatalf("engine attempts = %d, want 2", engine.attempts)
+	}
+	if !engine.resumed {
+		t.Fatal("retry did not resume the parked run")
+	}
+	if len(engine.runIDs) != 2 || engine.runIDs[0] != engine.runIDs[1] {
+		t.Fatalf("retry run ids = %v, want original id replayed on both attempts", engine.runIDs)
+	}
+}
+
+func TestRunAtPersistentDifferentRequestStartsFresh(t *testing.T) {
+	store := newDelegationCheckpointStore()
+	engine := &resumeAwareDelegationEngine{store: store, writeCheckpoint: true}
+	service, _ := newSessionPathService(t, engine,
+		&testSessionProvider{contextID: "fresh-ctx", persistent: true},
+		session.WithResume(true), session.WithCheckpointStore(store))
+
+	first, err := service.Delegate(context.Background(), syncRequest("writer"))
+	if err != nil || first.Status != StatusFailed {
+		t.Fatalf("first = (%+v, %v), want failed", first, err)
+	}
+
+	second, err := service.Delegate(context.Background(), Request{
+		Mode:   ModeSync,
+		Target: "writer",
+		Input:  "different job",
+	})
+	if err != nil {
+		t.Fatalf("retry Delegate: %v", err)
+	}
+	if second.Status != StatusSucceeded {
+		t.Fatalf("retry status = %q, want succeeded", second.Status)
+	}
+
+	engine.mu.Lock()
+	defer engine.mu.Unlock()
+	if engine.attempts != 2 {
+		t.Fatalf("engine attempts = %d, want 2", engine.attempts)
+	}
+	if engine.resumed {
+		t.Fatal("different request must not resume the parked run")
+	}
+	if len(engine.runIDs) == 2 && engine.runIDs[0] == engine.runIDs[1] {
+		t.Fatalf("different request reused parked run id %q", engine.runIDs[0])
+	}
+}
+
+func TestRunAtPersistentRetryFallsBackWhenCheckpointMissing(t *testing.T) {
+	store := newDelegationCheckpointStore()
+	engine := &resumeAwareDelegationEngine{store: store}
+	service, _ := newSessionPathService(t, engine,
+		&testSessionProvider{contextID: "missing-cp", persistent: true},
+		session.WithResume(true), session.WithCheckpointStore(store))
+
+	first, err := service.Delegate(context.Background(), syncRequest("writer"))
+	if err != nil || first.Status != StatusFailed {
+		t.Fatalf("first = (%+v, %v), want failed", first, err)
+	}
+
+	second, err := service.Delegate(context.Background(), syncRequest("writer"))
+	if err != nil {
+		t.Fatalf("retry Delegate: %v", err)
+	}
+	if second.Status != StatusSucceeded {
+		t.Fatalf("retry status = %q, want succeeded", second.Status)
+	}
+
+	engine.mu.Lock()
+	defer engine.mu.Unlock()
+	if engine.attempts != 2 {
+		t.Fatalf("engine attempts = %d, want 2", engine.attempts)
+	}
+	if engine.resumed {
+		t.Fatal("retry with a missing checkpoint must fall back to a fresh start")
+	}
+}
+
+func TestRunAtPersistentRetryFallsBackWhenEngineCannotResume(t *testing.T) {
+	store := newDelegationCheckpointStore()
+	var attempts int
+	engine := agent.EngineFunc(func(
+		ctx context.Context,
+		run agent.Run,
+		_ agent.Host,
+		board *agent.Board,
+	) (*agent.Board, error) {
+		attempts++
+		if attempts == 1 {
+			if err := store.Save(ctx, agent.Checkpoint{
+				ExecID:      run.RunID,
+				Steps:       []string{"wave-1"},
+				Board:       board.Snapshot(),
+				SpecVersion: "v1",
+			}); err != nil {
+				return board, err
+			}
+			return board, errdefs.Internalf("first attempt fails")
+		}
+		return board, nil
+	})
+	service, _ := newSessionPathService(t, engine,
+		&testSessionProvider{contextID: "no-resume-engine", persistent: true},
+		session.WithResume(true), session.WithCheckpointStore(store))
+
+	first, err := service.Delegate(context.Background(), syncRequest("writer"))
+	if err != nil || first.Status != StatusFailed {
+		t.Fatalf("first = (%+v, %v), want failed", first, err)
+	}
+
+	second, err := service.Delegate(context.Background(), syncRequest("writer"))
+	if err != nil {
+		t.Fatalf("retry Delegate: %v", err)
+	}
+	if second.Status != StatusSucceeded {
+		t.Fatalf("retry status = %q, want succeeded", second.Status)
+	}
+	if attempts != 2 {
+		t.Fatalf("engine attempts = %d, want 2", attempts)
 	}
 }
 

--- a/core/delegation/session_provider_test.go
+++ b/core/delegation/session_provider_test.go
@@ -504,8 +504,9 @@ func TestRunAtSessionPathAsyncRun(t *testing.T) {
 // delegationCheckpointStore is a minimal in-memory CheckpointDeleter
 // used to exercise the delegation resume path end to end.
 type delegationCheckpointStore struct {
-	mu  sync.Mutex
-	cps map[string]agent.Checkpoint
+	mu             sync.Mutex
+	cps            map[string]agent.Checkpoint
+	loadFailPrefix string
 }
 
 func newDelegationCheckpointStore() *delegationCheckpointStore {
@@ -522,6 +523,9 @@ func (s *delegationCheckpointStore) Save(_ context.Context, cp agent.Checkpoint)
 func (s *delegationCheckpointStore) Load(_ context.Context, execID string) (*agent.Checkpoint, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
+	if s.loadFailPrefix != "" && strings.HasPrefix(execID, s.loadFailPrefix) {
+		return nil, errdefs.Fmt("delegation test store: read failed for %s", execID)
+	}
 	cp, ok := s.cps[execID]
 	if !ok {
 		return nil, nil
@@ -726,6 +730,37 @@ func TestRunAtPersistentRetryFallsBackWhenEngineCannotResume(t *testing.T) {
 	}
 	if attempts != 2 {
 		t.Fatalf("engine attempts = %d, want 2", attempts)
+	}
+}
+
+func TestRunAtPersistentRetryFallsBackWhenResumeReadFails(t *testing.T) {
+	store := newDelegationCheckpointStore()
+	store.loadFailPrefix = "run-"
+	engine := &resumeAwareDelegationEngine{store: store, writeCheckpoint: true}
+	service, _ := newSessionPathService(t, engine,
+		&testSessionProvider{contextID: "store-flaky", persistent: true},
+		session.WithResume(true), session.WithCheckpointStore(store))
+
+	first, err := service.Delegate(context.Background(), syncRequest("writer"))
+	if err != nil || first.Status != StatusFailed {
+		t.Fatalf("first = (%+v, %v), want failed", first, err)
+	}
+
+	second, err := service.Delegate(context.Background(), syncRequest("writer"))
+	if err != nil {
+		t.Fatalf("retry Delegate: %v", err)
+	}
+	if second.Status != StatusSucceeded {
+		t.Fatalf("retry status = %q, want succeeded", second.Status)
+	}
+
+	engine.mu.Lock()
+	defer engine.mu.Unlock()
+	if engine.attempts != 2 {
+		t.Fatalf("engine attempts = %d, want 2", engine.attempts)
+	}
+	if engine.resumed {
+		t.Fatal("retry with an unreadable checkpoint must fall back to a fresh start")
 	}
 }
 

--- a/core/runtime/session/resume_test.go
+++ b/core/runtime/session/resume_test.go
@@ -264,6 +264,48 @@ func TestSessionResume_ResumeWithoutParkedRun(t *testing.T) {
 	}
 }
 
+func TestSessionResume_ParkedRequest(t *testing.T) {
+	engine := &resumeProbeEngine{reply: "done"}
+	store := &resumeTestStore{cps: make(map[string]agent.Checkpoint)}
+	session := newResumeSession(t, engine, store)
+
+	// Fresh session: nothing parked.
+	if req, ok, err := session.ParkedRequest(context.Background()); err != nil || ok {
+		t.Fatalf("ParkedRequest before park = (%+v, %v, %v), want no request", req, ok, err)
+	}
+
+	runID := "run-" + strings.Repeat("p", 16)
+	parkRun(t, session, store, runID, time.Now().Add(-time.Hour),
+		&agent.Request{
+			TaskID:  "task-9",
+			Message: message.NewTextMessage(message.RoleUser, "continue"),
+			Inputs:  map[string]any{"pipeline": "image"},
+		})
+
+	got, ok, err := session.ParkedRequest(context.Background())
+	if err != nil || !ok {
+		t.Fatalf("ParkedRequest after park = (%+v, %v, %v), want parked request", got, ok, err)
+	}
+	if got.TaskID != "task-9" || got.Message.Content.Text() != "continue" {
+		t.Fatalf("ParkedRequest = %+v, want task-9 / 'continue'", got)
+	}
+	if got.Inputs["pipeline"] != "image" {
+		t.Fatalf("ParkedRequest.Inputs = %+v, want pipeline=image", got.Inputs)
+	}
+
+	// A committed resume clears the parked marker and request.
+	turn, err := session.Resume(context.Background())
+	if err != nil {
+		t.Fatalf("Resume: %v", err)
+	}
+	if _, err := turn.Wait(context.Background()); err != nil {
+		t.Fatalf("Wait: %v", err)
+	}
+	if req, ok, err := session.ParkedRequest(context.Background()); err != nil || ok {
+		t.Fatalf("ParkedRequest after commit = (%+v, %v, %v), want cleared", req, ok, err)
+	}
+}
+
 func TestSessionResume_RejectsNonResumableEngine(t *testing.T) {
 	engine := agent.EngineFunc(func(
 		_ context.Context,

--- a/core/runtime/session/session.go
+++ b/core/runtime/session/session.go
@@ -293,28 +293,58 @@ func (s *Session) resume(ctx context.Context, config startConfig) (*Turn, error)
 // Resumable reports whether a previous turn ended without committing
 // and can be replayed via Resume. It returns the parked run id.
 func (s *Session) Resumable(ctx context.Context) (string, bool, error) {
-	if s == nil {
-		return "", false, nil
-	}
-	if s.isEphemeral() {
-		return "", false, nil
-	}
-	deps := s.manager.currentDeps()
-	if !deps.Resume || deps.Checkpoints == nil {
-		return "", false, nil
-	}
-	if ctx == nil {
-		return "", false, errdefs.Validationf(
-			"runtime session: Resumable context is required")
-	}
-	state, err := s.loadSessionState(ctx, deps.Checkpoints, deps.Resume)
+	state, err := s.parkedRunState(ctx)
 	if err != nil {
 		return "", false, err
 	}
-	if state == nil || state.ResumableRunID == "" {
+	if state == nil {
 		return "", false, nil
 	}
 	return state.ResumableRunID, true, nil
+}
+
+// ParkedRequest returns the original request of the session's parked
+// interrupted run, when one exists and its request was stored. ok is
+// false whenever there is nothing to resume: a fresh or committed
+// session, an ephemeral session, resume not configured, or a parked
+// marker without a stored request. The returned request is a copy.
+func (s *Session) ParkedRequest(ctx context.Context) (agent.Request, bool, error) {
+	state, err := s.parkedRunState(ctx)
+	if err != nil {
+		return agent.Request{}, false, err
+	}
+	if state == nil || state.Request == nil {
+		return agent.Request{}, false, nil
+	}
+	return *state.Request, true, nil
+}
+
+// parkedRunState loads the parked-run session state, or returns nil
+// when there is nothing to resume: a nil session, an ephemeral
+// session, resume not configured, or no persisted state.
+func (s *Session) parkedRunState(ctx context.Context) (*sessionState, error) {
+	if s == nil {
+		return nil, nil
+	}
+	if s.isEphemeral() {
+		return nil, nil
+	}
+	deps := s.manager.currentDeps()
+	if !deps.Resume || deps.Checkpoints == nil {
+		return nil, nil
+	}
+	if ctx == nil {
+		return nil, errdefs.Validationf(
+			"runtime session: parked run context is required")
+	}
+	state, err := s.loadSessionState(ctx, deps.Checkpoints, deps.Resume)
+	if err != nil {
+		return nil, err
+	}
+	if state == nil || state.ResumableRunID == "" {
+		return nil, nil
+	}
+	return state, nil
 }
 
 // interruptActive stops any running turn and reserves one activity slot

--- a/docs/guides/delegation.md
+++ b/docs/guides/delegation.md
@@ -92,8 +92,10 @@ request and the session key match:
   checkpoint under the original run id (`runtime.sessions.resume` and a
   `checkpoint_store` are required);
 - a different message or inputs → a fresh turn starts on the same session;
-- a parked marker with no checkpoint, or an engine that cannot resume,
-  falls back to a fresh start rather than failing the retry.
+- any failure to replay — a missing checkpoint, unreadable parked state,
+  transient checkpoint-store read errors, or an engine that cannot
+  resume — falls back to a fresh start with a warning rather than
+  failing the retry.
 
 Resume replays the request stored with the parked run; callers retrying a
 job should send the exact same message and inputs. After a successful run

--- a/docs/guides/delegation.md
+++ b/docs/guides/delegation.md
@@ -75,6 +75,36 @@ on every call, so each generation's tools see that generation's agents.
 - A `Reload` re-binds the directory and service to the new generation,
   so in-flight delegation completes on the generation it started on.
 
+## Session identity and resume
+
+When a session manager is bound, delegated work runs through the runtime
+session lifecycle. `SessionProvider.Persistent()` is provider-wide: a
+persistent provider's `ContextID` is stable, durable, and resumable, while
+providers that mint a fresh `ContextID` per delegation (e.g. `random`) are
+ephemeral and never write state. A one-shot target behind a persistent
+provider can therefore still opt out by returning a fresh `ContextID`.
+
+A retried delegation with the same `ContextID` resumes the parked run from
+its last checkpoint instead of starting fresh, but only when **both** the
+request and the session key match:
+
+- identical message and metadata inputs → the turn replays from the
+  checkpoint under the original run id (`runtime.sessions.resume` and a
+  `checkpoint_store` are required);
+- a different message or inputs → a fresh turn starts on the same session;
+- a parked marker with no checkpoint, or an engine that cannot resume,
+  falls back to a fresh start rather than failing the retry.
+
+Resume replays the request stored with the parked run; callers retrying a
+job should send the exact same message and inputs. After a successful run
+the parked marker is cleared, so a later delegation of the same key starts
+fresh.
+
+Agent preparers run again on resume before the engine restores the
+checkpoint board. Preparers with side effects (uploads, live-progress
+resets) must be idempotent or detect the replay via `agent.ResumeContext`
+/ `Run.ResumeFrom` and skip.
+
 See [runtime.md](runtime.md) for `WithResultHostFactory` and reload, and
 [tool.md](tool.md) for tool sources.
 


### PR DESCRIPTION
## Summary

Delegated subagents on persistent sessions now resume the parked run from its checkpoint when the same session key is retried with an identical request, instead of always starting fresh.

Closes #408

## Behavior

- Persistent session + parked run + identical retry request (same message and metadata inputs) -> Session.ResumeWithOptions replays from the checkpoint under the original run id.
- Resume is best-effort for retries: no parked request, mismatched retry request, missing checkpoint, unreadable parked state, transient checkpoint-store read errors, or an engine that cannot resume -> logs a warning and falls back to a fresh StartWithOptions rather than failing the retry.
- After a successful run the parked marker is cleared, so later delegations of the same key start fresh.

## Changes

- core/runtime/session: new Session.ParkedRequest API plus a shared parked-state helper; Resumable refactored onto it.
- core/delegation: runAt resume decision with a request-equality guard, degrading to fresh start on any resume or probe failure.
- Tests: session ParkedRequest test; delegation end-to-end tests for same-request resume, different-request fresh start, missing-checkpoint fallback, non-resumable-engine fallback, and checkpoint read-failure fallback.
- docs/guides/delegation.md: document the session identity / resume contract.

## Verification

- make ci: pass
- make lint: 0 issues
- make release-check: pass
