### PR TITLE
fix(core/delegation): accept empty-object arguments in delegation_targets tool

### DIFF
--- a/core/delegation/tool/delegation.go
+++ b/core/delegation/tool/delegation.go
@@ -217,8 +217,8 @@ func (t targetsTool) Definition() message.ToolDefinition {
 }
 
 func (t targetsTool) Execute(ctx context.Context, arguments string) (string, error) {
-	if strings.TrimSpace(arguments) != "" {
-		return "", errdefs.Validationf("%s: no arguments expected", TargetsToolName)
+	if err := rejectUnexpectedArguments(arguments); err != nil {
+		return "", err
 	}
 	if t.directory == nil {
 		return "", errdefs.NotAvailablef("%s: no directory wired", TargetsToolName)
@@ -234,6 +234,20 @@ func (t targetsTool) Execute(ctx context.Context, arguments string) (string, err
 		return "", errdefs.Internal(fmt.Errorf("%s: encode targets: %w", TargetsToolName, err))
 	}
 	return string(raw), nil
+}
+
+// rejectUnexpectedArguments accepts the empty string, JSON null, and the
+// empty object as a no-argument call and rejects anything else. Models
+// routinely emit {} when invoking a parameterless tool, so the guard
+// admits exactly what the tool schema already allows.
+func rejectUnexpectedArguments(arguments string) error {
+	if strings.TrimSpace(arguments) == "" {
+		return nil
+	}
+	if err := decodeStrict(arguments, &struct{}{}); err != nil {
+		return errdefs.Validationf("%s: no arguments expected", TargetsToolName)
+	}
+	return nil
 }
 
 func serviceFromContext(ctx context.Context) (sdkdelegation.Service, error) {

--- a/core/delegation/tool/delegation.go
+++ b/core/delegation/tool/delegation.go
@@ -239,12 +239,19 @@ func (t targetsTool) Execute(ctx context.Context, arguments string) (string, err
 // rejectUnexpectedArguments accepts the empty string, JSON null, and the
 // empty object as a no-argument call and rejects anything else. Models
 // routinely emit {} when invoking a parameterless tool, so the guard
-// admits exactly what the tool schema already allows.
+// admits exactly what the tool schema already allows. Malformed JSON is
+// reported as a parse error, distinct from valid JSON that carries
+// unexpected arguments.
 func rejectUnexpectedArguments(arguments string) error {
-	if strings.TrimSpace(arguments) == "" {
+	trimmed := strings.TrimSpace(arguments)
+	if trimmed == "" {
 		return nil
 	}
-	if err := decodeStrict(arguments, &struct{}{}); err != nil {
+	var probe any
+	if err := json.Unmarshal([]byte(trimmed), &probe); err != nil {
+		return errdefs.Validationf("%s: parse arguments: %v", TargetsToolName, err)
+	}
+	if err := decodeStrict(trimmed, &struct{}{}); err != nil {
 		return errdefs.Validationf("%s: no arguments expected", TargetsToolName)
 	}
 	return nil

--- a/core/delegation/tool/delegation_test.go
+++ b/core/delegation/tool/delegation_test.go
@@ -322,10 +322,35 @@ func TestTargetsToolListsCurrentTargets(t *testing.T) {
 	}
 }
 
+func TestTargetsToolAcceptsNoArgumentForms(t *testing.T) {
+	directory := &fakeDirectory{targets: []sdkdelegation.Target{{ID: "billing"}}}
+	targets := tooldelegation.NewTargets(directory)
+	for name, arguments := range map[string]string{
+		"empty":        "",
+		"blank":        "   ",
+		"empty object": "{}",
+		"null":         "null",
+	} {
+		t.Run(name, func(t *testing.T) {
+			out, err := targets.Execute(context.Background(), arguments)
+			if err != nil {
+				t.Fatalf("Execute(%q): %v", arguments, err)
+			}
+			if !strings.Contains(out, `"billing"`) {
+				t.Fatalf("output = %s, want billing", out)
+			}
+		})
+	}
+}
+
 func TestTargetsToolRejectsArgumentsAndMissingDirectory(t *testing.T) {
 	if _, err := (tooldelegation.NewTargets(&fakeDirectory{})).Execute(
-		context.Background(), `{}`); !errdefs.IsValidation(err) {
+		context.Background(), `{"target":"billing"}`); !errdefs.IsValidation(err) {
 		t.Fatalf("Execute with args = %v, want Validation", err)
+	}
+	if _, err := (tooldelegation.NewTargets(&fakeDirectory{})).Execute(
+		context.Background(), `[]`); !errdefs.IsValidation(err) {
+		t.Fatalf("Execute with array args = %v, want Validation", err)
 	}
 	if _, err := (tooldelegation.NewTargets(nil)).Execute(
 		context.Background(), ""); !errdefs.IsNotAvailable(err) {

--- a/core/delegation/tool/delegation_test.go
+++ b/core/delegation/tool/delegation_test.go
@@ -344,16 +344,40 @@ func TestTargetsToolAcceptsNoArgumentForms(t *testing.T) {
 }
 
 func TestTargetsToolRejectsArgumentsAndMissingDirectory(t *testing.T) {
-	if _, err := (tooldelegation.NewTargets(&fakeDirectory{})).Execute(
-		context.Background(), `{"target":"billing"}`); !errdefs.IsValidation(err) {
-		t.Fatalf("Execute with args = %v, want Validation", err)
-	}
-	if _, err := (tooldelegation.NewTargets(&fakeDirectory{})).Execute(
-		context.Background(), `[]`); !errdefs.IsValidation(err) {
-		t.Fatalf("Execute with array args = %v, want Validation", err)
+	for name, arguments := range map[string]string{
+		"object":    `{"target":"billing"}`,
+		"array":     `[]`,
+		"malformed": `{`,
+		"trailing":  `{} {}`,
+	} {
+		t.Run(name, func(t *testing.T) {
+			if _, err := (tooldelegation.NewTargets(&fakeDirectory{})).Execute(
+				context.Background(), arguments); !errdefs.IsValidation(err) {
+				t.Fatalf("Execute(%q) = %v, want Validation", arguments, err)
+			}
+		})
 	}
 	if _, err := (tooldelegation.NewTargets(nil)).Execute(
 		context.Background(), ""); !errdefs.IsNotAvailable(err) {
 		t.Fatalf("Execute without directory = %v, want NotAvailable", err)
+	}
+}
+
+func TestTargetsToolArgumentErrorsDistinguishMalformedJSON(t *testing.T) {
+	targets := tooldelegation.NewTargets(&fakeDirectory{})
+	for name, arguments := range map[string]string{
+		"malformed": `{`,
+		"trailing":  `{} {}`,
+	} {
+		t.Run(name, func(t *testing.T) {
+			_, err := targets.Execute(context.Background(), arguments)
+			if err == nil || !strings.Contains(err.Error(), "parse arguments") {
+				t.Fatalf("error = %v, want parse arguments", err)
+			}
+		})
+	}
+	_, err := targets.Execute(context.Background(), `{"target":"billing"}`)
+	if err == nil || !strings.Contains(err.Error(), "no arguments expected") {
+		t.Fatalf("unexpected arguments error = %v, want no arguments expected", err)
 	}
 }


### PR DESCRIPTION
## Summary

delegation_targets now accepts empty-object and null arguments as a no-argument call, matching what models routinely emit when invoking a parameterless tool.

Closes #410

## Behavior

- Empty string, whitespace, JSON null, and {} -> lists the available targets as before.
- Valid JSON carrying unexpected arguments (non-empty objects, arrays, scalars) -> Validation error: no arguments expected.
- Malformed or trailing JSON (e.g. { or {} {}) -> Validation error: parse arguments, so callers can tell invalid JSON apart from extra arguments.

## Changes

- core/delegation/tool: targetsTool.Execute now admits no-argument forms via the existing strict decoder; a JSON syntax probe distinguishes parse errors from unexpected-argument rejections.
- Tests: acceptance table for "", whitespace, {}, and null; rejection cases for non-empty objects, arrays, malformed JSON, and trailing JSON; explicit assertions that malformed JSON reports parse arguments.

## Verification

- make ci: pass
- make lint: 0 issues
- make release-check: pass
