### PR TITLE
chore(release): add core v0.1.25 changeset

### DIFF
--- a/.release/core-v0.1.25.json
+++ b/.release/core-v0.1.25.json
@@ -1,0 +1,9 @@
+{
+  "summary": "feat(core/delegation): resume parked delegated runs on identical retry — persistent-session delegations now check Session.ParkedRequest and replay the parked run from its checkpoint under the original run id when the retried request matches (same message and metadata inputs), with any resume or probe failure (missing checkpoint, unreadable parked state, transient store errors, non-resumable engine) degrading to a fresh start with a warning instead of failing the retry, and a successful run clearing the parked marker; fix(core/delegation): delegation_targets accepts empty-object and null arguments as a no-argument call — the parameterless tool now admits \"\", whitespace, {}, and JSON null, rejects non-empty objects, arrays, and scalars as no-arguments-expected, and reports malformed or trailing JSON as a parse error",
+  "releases": [
+    {
+      "module": "core",
+      "bump": "patch"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Adds the immutable changeset for core v0.1.25 (patch), covering the accumulated delta since core/v0.1.24:

- feat(core/delegation): retried delegations on persistent sessions resume the parked run from its checkpoint on an identical retry, degrading to a fresh start on any resume/probe failure
- fix(core/delegation): delegation_targets accepts empty-object and null arguments as a no-argument call

Planned tag: `core/v0.1.25`

Merging this PR triggers the release-modules workflow: it generates the changelog PR, then after that merges, the CI gate (tidy/build/vet/test -race) runs and tags core/v0.1.25.

Verified: make release-plan / release-check / release-preflight, make ci, make lint all pass.
