### PR TITLE
feat(core): recover from undefined tool calls instead of failing the turn

### DIFF
--- a/core/graph/nodes/inference.go
+++ b/core/graph/nodes/inference.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 
 	"github.com/GizClaw/flowcraft/core/agent"
@@ -44,6 +45,22 @@ type InferenceConfig struct {
 	// tool_calls — the boolean condition edges branch on to route
 	// through a tool node and loop back.
 	ToolPendingKey string `json:"tool_pending_key,omitempty"`
+	// UndefinedToolRecovery converts a generate rejection for a tool
+	// call absent from the exposed definitions into in-conversation
+	// feedback instead of failing the node: the rejected call is
+	// replayed as an assistant tool_call paired with a tool result
+	// telling the model the tool is not exposed and to use tool_search.
+	// The graph routes on RecoverPendingKey back to inference — never
+	// through a tool node, which would execute the call. Strict
+	// deployments leave this disabled and keep failing hard.
+	UndefinedToolRecovery *UndefinedToolRecoveryConfig `json:"undefined_tool_recovery,omitempty"`
+	// RecoverPendingKey, when set, receives whether the current round
+	// was recovered from an undefined-tool response. Graph conditions
+	// route on it to loop back to inference.
+	RecoverPendingKey string `json:"recover_pending_key,omitempty"`
+	// RecoverCountKey, when set, receives the per-run recovery counter.
+	// The node hard-fails once it reaches MaxPerRun.
+	RecoverCountKey string `json:"recover_count_key,omitempty"`
 
 	// Stream opens a GenerateStream and publishes text and reasoning
 	// deltas as token stream events. Reasoning fragments arrive as
@@ -82,6 +99,26 @@ type InferenceConfig struct {
 	Extensions []inference.ExtensionEntry `json:"extensions,omitempty"`
 }
 
+// UndefinedToolRecoveryConfig configures the inference node's
+// recoverable handling of undefined-tool responses.
+type UndefinedToolRecoveryConfig struct {
+	// Enabled turns recovery on. Defaults to false: undefined tool
+	// calls fail the node exactly as before.
+	Enabled bool `json:"enabled,omitempty"`
+	// MaxPerRun caps how many undefined-tool responses one graph run
+	// converts into feedback before failing hard. Zero falls back to 2.
+	MaxPerRun int `json:"max_per_run,omitempty"`
+}
+
+// defaultUndefinedToolMaxRecoveries bounds how many undefined-tool
+// responses one graph run converts into feedback before failing hard.
+const defaultUndefinedToolMaxRecoveries = 2
+
+// undefinedToolFeedback is the model-readable rejection appended as a
+// tool result when a response names a tool the model was never shown.
+const undefinedToolFeedback = "tool %q is not exposed in this round's tool set; " +
+	"call tool_search to find and select it before calling it again"
+
 // InferenceNodeDeps wires the inference node's collaborators. Runtime
 // serves configs carrying an explicit model; Router serves configs
 // without one. Either may be nil if no graph needs it — the error
@@ -115,6 +152,8 @@ func Inference(deps InferenceNodeDeps) graph.NodeType[InferenceConfig] {
 				{Kind: graph.RoleVar, ConfigKey: "output_key"},
 				{Kind: graph.RoleVar, ConfigKey: "usage_key"},
 				{Kind: graph.RoleVar, ConfigKey: "tool_pending_key"},
+				{Kind: graph.RoleVar, ConfigKey: "recover_pending_key"},
+				{Kind: graph.RoleVar, ConfigKey: "recover_count_key"},
 			},
 		},
 		Handler: func(ec graph.ExecutionContext, board *agent.Board, cfg InferenceConfig) error {
@@ -133,6 +172,11 @@ func runInference(ec graph.ExecutionContext, board *agent.Board, cfg InferenceCo
 	if channel == "" {
 		channel = agent.MainChannel
 	}
+	if cfg.UndefinedToolRecovery != nil && cfg.UndefinedToolRecovery.Enabled &&
+		(cfg.RecoverPendingKey == "" || cfg.RecoverCountKey == "") {
+		return errdefs.Validationf(
+			"inference node: undefined_tool_recovery requires recover_pending_key and recover_count_key")
+	}
 	req, err := buildGenerateRequest(ec, board, channel, cfg, deps)
 	if err != nil {
 		return err
@@ -140,7 +184,12 @@ func runInference(ec graph.ExecutionContext, board *agent.Board, cfg InferenceCo
 
 	resp, err := executeGenerate(ec, board, cfg, deps, req)
 	if err != nil {
-		return err
+		return recoverUndefinedTool(ec, board, channel, cfg, err)
+	}
+	if cfg.RecoverPendingKey != "" {
+		// A successful round clears the recovery marker so the loop
+		// returns to its normal edges.
+		board.SetVar(cfg.RecoverPendingKey, false)
 	}
 	// Mirror the provider request / response identifiers and token
 	// usage onto the node span after a successful call so
@@ -198,6 +247,74 @@ func runInference(ec graph.ExecutionContext, board *agent.Board, cfg InferenceCo
 		return err
 	}
 	return nil
+}
+
+// recoverUndefinedTool converts an undefined-tool generate failure into
+// in-conversation feedback when the node is configured to recover. The
+// rejected call is replayed as an assistant tool_call paired with a tool
+// result explaining how to expose the tool — the message shape providers
+// require — but the graph must route back to inference, never through a
+// tool node, or the call would be executed for real. The original error
+// is returned when recovery is disabled, the failure is not an
+// undefined-tool rejection, or the per-run budget is exhausted.
+func recoverUndefinedTool(ec graph.ExecutionContext, board *agent.Board, channel string, cfg InferenceConfig, err error) error {
+	if cfg.UndefinedToolRecovery == nil || !cfg.UndefinedToolRecovery.Enabled {
+		return err
+	}
+	var infErr *inference.Error
+	if !errors.As(err, &infErr) ||
+		infErr.Kind != inference.UndefinedTool ||
+		infErr.UndefinedToolCall == nil {
+		return err
+	}
+	max := cfg.UndefinedToolRecovery.MaxPerRun
+	if max <= 0 {
+		max = defaultUndefinedToolMaxRecoveries
+	}
+	count := recoveryCount(board, cfg)
+	if count >= max {
+		return err
+	}
+	call := *infErr.UndefinedToolCall
+	board.AppendChannelMessage(channel, message.Message{
+		Role: message.RoleAssistant,
+		Content: message.Content{Parts: []message.Part{
+			message.ToolCallPart{Call: call},
+		}},
+	})
+	board.AppendChannelMessage(channel, message.Message{
+		Role: message.RoleTool,
+		Content: message.Content{Parts: []message.Part{
+			message.ToolResultPart{Result: message.ToolResult{
+				CallID:  call.ID,
+				Content: fmt.Sprintf(undefinedToolFeedback, call.Name),
+				IsError: true,
+			}},
+		}},
+	})
+	if cfg.ToolPendingKey != "" {
+		board.SetVar(cfg.ToolPendingKey, false)
+	}
+	board.SetVar(cfg.RecoverPendingKey, true)
+	board.SetVar(cfg.RecoverCountKey, count+1)
+	telemetry.Warn(ec.Context, "inference node: recovered undefined tool call",
+		otellog.String("node.type", "inference"),
+		otellog.String("tool.name", call.Name),
+		otellog.Int("recovery.count", count+1))
+	return nil
+}
+
+// recoveryCount reads the per-run undefined-tool recovery counter.
+func recoveryCount(board *agent.Board, cfg InferenceConfig) int {
+	count, ok := board.GetVar(cfg.RecoverCountKey)
+	if !ok {
+		return 0
+	}
+	n, ok := count.(int)
+	if !ok {
+		return 0
+	}
+	return n
 }
 
 // emitGenerationTerminal publishes the terminal stream deltas of one

--- a/core/graph/nodes/inference_test.go
+++ b/core/graph/nodes/inference_test.go
@@ -501,6 +501,167 @@ func TestInferenceNode_UndefinedToolRecoveryKeepsNamedChoiceStrict(t *testing.T)
 	}
 }
 
+func undefinedToolResponse(name string) inference.GenerateResponse {
+	return inference.GenerateResponse{
+		Message: message.Message{
+			Role: message.RoleAssistant,
+			Content: message.Content{Parts: []message.Part{
+				message.ToolCallPart{Call: message.ToolCall{
+					ID: "call-1", Name: name, Arguments: json.RawMessage(`{}`),
+				}},
+			}},
+		},
+		FinishReason: inference.FinishToolCalls,
+	}
+}
+
+func textResponse(text string) inference.GenerateResponse {
+	return inference.GenerateResponse{
+		Message: message.Message{
+			Role:    message.RoleAssistant,
+			Content: message.Content{Parts: []message.Part{message.TextPart{Text: text}}},
+		},
+		FinishReason: inference.FinishCompleted,
+	}
+}
+
+// TestInferenceGraph_UndefinedToolRecoveryLoop proves the full recovery
+// cycle at graph level: the recovered round loops back to the inference
+// node on recover_pending, the next round succeeds, the marker is cleared,
+// and the per-run recovery counter survives to the end of the run.
+func TestInferenceGraph_UndefinedToolRecoveryLoop(t *testing.T) {
+	var (
+		mu    sync.Mutex
+		calls int
+	)
+	fake := &inferencetest.GenerateFake{
+		Respond: func(inference.GenerateRequest) inference.GenerateResponse {
+			mu.Lock()
+			calls++
+			n := calls
+			mu.Unlock()
+			if n == 1 {
+				return undefinedToolResponse("ghost")
+			}
+			return textResponse("ok")
+		},
+	}
+	reg := inferenceRegistry(t, InferenceNodeDeps{
+		Assembly: fake.Assembly(t),
+		Catalog:  toolCatalog(t, stubTool{name: "known", desc: "a known tool"}),
+	})
+	g, err := graph.Build(&graph.GraphDefinition{
+		Name:  "recovery-loop",
+		Entry: "llm",
+		Nodes: []graph.NodeDefinition{{
+			ID: "llm", Type: "inference",
+			Config: mustConfig(t, InferenceConfig{
+				Model:                 ptr(inferencetest.DefaultFakeModel),
+				Tools:                 []string{"known"},
+				ToolPendingKey:        "tool_pending",
+				UndefinedToolRecovery: &UndefinedToolRecoveryConfig{Enabled: true, MaxPerRun: 2},
+				RecoverPendingKey:     "recover_pending",
+				RecoverCountKey:       "recover_count",
+			}),
+		}},
+		Edges: []graph.EdgeDefinition{
+			{From: "llm", To: "llm", Condition: "recover_pending == true"},
+			{From: "llm", To: graph.END,
+				Condition: "tool_pending == false && recover_pending != true"},
+		},
+	}, reg)
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	board := userBoard()
+	if err := executeGraph(t, g, agent.NoopHost{}, board); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+
+	requests := fake.Requests()
+	if len(requests) != 2 {
+		t.Fatalf("llm rounds = %d, want 2 (recovered round + success round)", len(requests))
+	}
+	// The recovered round's feedback must ride into the next request:
+	// the fabricated assistant call sits in context and the rejection is
+	// the tool-role input.
+	if len(requests[1].Context) != 2 {
+		t.Fatalf("second round context length = %d, want 2", len(requests[1].Context))
+	}
+	call, ok := requests[1].Context[1].Content.Parts[0].(message.ToolCallPart)
+	if !ok || call.Call.Name != "ghost" {
+		t.Fatalf("second round context call = %+v", requests[1].Context[1].Content.Parts[0])
+	}
+	result, ok := requests[1].Input.Content.Parts[0].(message.ToolResultPart)
+	if !ok || !result.Result.IsError || !strings.Contains(result.Result.Content, "tool_search") {
+		t.Fatalf("second round input = %+v", requests[1].Input.Content.Parts[0])
+	}
+
+	msgs := board.Channel(agent.MainChannel)
+	if len(msgs) != 4 {
+		t.Fatalf("channel length = %d, want 4 (user, recovered pair, final answer)", len(msgs))
+	}
+	if text, ok := msgs[3].Content.Parts[0].(message.TextPart); !ok || text.Text != "ok" {
+		t.Fatalf("final assistant message = %+v, want text %q", msgs[3], "ok")
+	}
+	if v, _ := board.GetVar("recover_pending"); v != false {
+		t.Fatalf("recover_pending = %v, want false after success round", v)
+	}
+	if v, _ := board.GetVar("recover_count"); v != 1 {
+		t.Fatalf("recover_count = %v, want 1 retained to run end", v)
+	}
+}
+
+// TestInferenceGraph_UndefinedToolRecoveryWithoutLoopRouteEnds documents
+// the routing contract: with a standard tool-pending graph (llm ends when
+// tool_pending is false) and no recover loop-back edge, a recovered round
+// terminates the run after appending the feedback — the model never gets
+// another round. Recovery therefore needs an explicit route back to the
+// inference node (or a graph whose tool loop already routes llm back
+// unconditionally).
+func TestInferenceGraph_UndefinedToolRecoveryWithoutLoopRouteEnds(t *testing.T) {
+	fake := &inferencetest.GenerateFake{
+		Respond: func(inference.GenerateRequest) inference.GenerateResponse {
+			return undefinedToolResponse("ghost")
+		},
+	}
+	reg := inferenceRegistry(t, InferenceNodeDeps{
+		Assembly: fake.Assembly(t),
+		Catalog:  toolCatalog(t, stubTool{name: "known", desc: "a known tool"}),
+	})
+	g, err := graph.Build(&graph.GraphDefinition{
+		Name:  "recovery-no-route",
+		Entry: "llm",
+		Nodes: []graph.NodeDefinition{{
+			ID: "llm", Type: "inference",
+			Config: mustConfig(t, InferenceConfig{
+				Model:                 ptr(inferencetest.DefaultFakeModel),
+				Tools:                 []string{"known"},
+				ToolPendingKey:        "tool_pending",
+				UndefinedToolRecovery: &UndefinedToolRecoveryConfig{Enabled: true, MaxPerRun: 2},
+				RecoverPendingKey:     "recover_pending",
+				RecoverCountKey:       "recover_count",
+			}),
+		}},
+		Edges: []graph.EdgeDefinition{
+			{From: "llm", To: graph.END, Condition: "tool_pending == false"},
+		},
+	}, reg)
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	board := userBoard()
+	if err := executeGraph(t, g, agent.NoopHost{}, board); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if requests := fake.Requests(); len(requests) != 1 {
+		t.Fatalf("llm rounds = %d, want 1 (run ends after the recovered round)", len(requests))
+	}
+	if msgs := board.Channel(agent.MainChannel); len(msgs) != 3 {
+		t.Fatalf("channel length = %d, want 3 (feedback appended, no final answer)", len(msgs))
+	}
+}
+
 // fakeVisibleCatalog is a minimal stand-in for a catalog whose
 // Definitions are the final model-visible set (the dynamic injection
 // view being one such implementation): it accepts RequiredByName

--- a/core/graph/nodes/inference_test.go
+++ b/core/graph/nodes/inference_test.go
@@ -121,6 +121,17 @@ func toolCatalog(t *testing.T, tools ...tool.Tool) *tool.Registry {
 	return reg
 }
 
+// stubTool is a minimal catalog tool for node tests.
+type stubTool struct {
+	name, desc string
+}
+
+func (t stubTool) Definition() message.ToolDefinition {
+	return message.DefineSchema(t.name, t.desc).Build()
+}
+
+func (stubTool) Execute(context.Context, string) (string, error) { return "ok", nil }
+
 func inferenceRegistry(t *testing.T, deps InferenceNodeDeps) *graph.Registry {
 	t.Helper()
 	reg := graph.NewRegistry()
@@ -284,6 +295,209 @@ func TestInferenceNode_UnknownToolRejected(t *testing.T) {
 	})
 	if err := executeGraph(t, g, agent.NoopHost{}, userBoard()); err == nil || !errdefs.IsValidation(err) {
 		t.Fatalf("unknown tool error = %v, want validation-classified", err)
+	}
+}
+
+func TestInferenceNode_UndefinedToolRecovery(t *testing.T) {
+	fake := &inferencetest.GenerateFake{
+		Respond: func(inference.GenerateRequest) inference.GenerateResponse {
+			return inference.GenerateResponse{
+				Message: message.Message{
+					Role: message.RoleAssistant,
+					Content: message.Content{Parts: []message.Part{
+						message.ToolCallPart{Call: message.ToolCall{
+							ID: "call-1", Name: "ghost", Arguments: json.RawMessage(`{}`),
+						}},
+					}},
+				},
+				FinishReason: inference.FinishToolCalls,
+			}
+		},
+	}
+	reg := inferenceRegistry(t, InferenceNodeDeps{
+		Assembly: fake.Assembly(t),
+		Catalog:  toolCatalog(t, stubTool{name: "known", desc: "a known tool"}),
+	})
+	g := singleNodeGraph(t, reg, "inference", InferenceConfig{
+		Model:                 ptr(inferencetest.DefaultFakeModel),
+		Tools:                 []string{"known"},
+		ToolPendingKey:        "tool_pending",
+		UndefinedToolRecovery: &UndefinedToolRecoveryConfig{Enabled: true, MaxPerRun: 2},
+		RecoverPendingKey:     "recover_pending",
+		RecoverCountKey:       "recover_count",
+	})
+	board := userBoard()
+	if err := executeGraph(t, g, agent.NoopHost{}, board); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+
+	msgs := board.Channel(agent.MainChannel)
+	if len(msgs) != 3 {
+		t.Fatalf("channel length = %d, want 3 (user + assistant call + tool rejection)", len(msgs))
+	}
+	call, ok := msgs[1].Content.Parts[0].(message.ToolCallPart)
+	if !ok || msgs[1].Role != message.RoleAssistant || call.Call.Name != "ghost" {
+		t.Fatalf("recovered assistant message = %+v", msgs[1])
+	}
+	result, ok := msgs[2].Content.Parts[0].(message.ToolResultPart)
+	if !ok || msgs[2].Role != message.RoleTool || !result.Result.IsError ||
+		result.Result.CallID != "call-1" || !strings.Contains(result.Result.Content, "tool_search") {
+		t.Fatalf("recovered tool message = %+v", msgs[2])
+	}
+	if v, _ := board.GetVar("recover_pending"); v != true {
+		t.Fatalf("recover_pending = %v, want true", v)
+	}
+	if v, _ := board.GetVar("recover_count"); v != 1 {
+		t.Fatalf("recover_count = %v, want 1", v)
+	}
+	if v, _ := board.GetVar("tool_pending"); v != false {
+		t.Fatalf("tool_pending = %v, want false", v)
+	}
+}
+
+func TestInferenceNode_UndefinedToolRecoveryDisabled(t *testing.T) {
+	fake := &inferencetest.GenerateFake{
+		Respond: func(inference.GenerateRequest) inference.GenerateResponse {
+			return inference.GenerateResponse{
+				Message: message.Message{
+					Role: message.RoleAssistant,
+					Content: message.Content{Parts: []message.Part{
+						message.ToolCallPart{Call: message.ToolCall{
+							ID: "call-1", Name: "ghost", Arguments: json.RawMessage(`{}`),
+						}},
+					}},
+				},
+				FinishReason: inference.FinishToolCalls,
+			}
+		},
+	}
+	reg := inferenceRegistry(t, InferenceNodeDeps{
+		Assembly: fake.Assembly(t),
+		Catalog:  toolCatalog(t, stubTool{name: "known", desc: "a known tool"}),
+	})
+	g := singleNodeGraph(t, reg, "inference", InferenceConfig{
+		Model: ptr(inferencetest.DefaultFakeModel),
+		Tools: []string{"known"},
+	})
+	board := userBoard()
+	err := executeGraph(t, g, agent.NoopHost{}, board)
+	var infErr *inference.Error
+	if !errors.As(err, &infErr) || infErr.Kind != inference.UndefinedTool {
+		t.Fatalf("error = %v, want undefined_tool", err)
+	}
+	if msgs := board.Channel(agent.MainChannel); len(msgs) != 1 {
+		t.Fatalf("channel length = %d, want 1 (no feedback when recovery disabled)", len(msgs))
+	}
+}
+
+func TestInferenceNode_UndefinedToolRecoveryBudget(t *testing.T) {
+	fake := &inferencetest.GenerateFake{
+		Respond: func(inference.GenerateRequest) inference.GenerateResponse {
+			return inference.GenerateResponse{
+				Message: message.Message{
+					Role: message.RoleAssistant,
+					Content: message.Content{Parts: []message.Part{
+						message.ToolCallPart{Call: message.ToolCall{
+							ID: "call-1", Name: "ghost", Arguments: json.RawMessage(`{}`),
+						}},
+					}},
+				},
+				FinishReason: inference.FinishToolCalls,
+			}
+		},
+	}
+	reg := inferenceRegistry(t, InferenceNodeDeps{
+		Assembly: fake.Assembly(t),
+		Catalog:  toolCatalog(t, stubTool{name: "known", desc: "a known tool"}),
+	})
+	g := singleNodeGraph(t, reg, "inference", InferenceConfig{
+		Model:                 ptr(inferencetest.DefaultFakeModel),
+		Tools:                 []string{"known"},
+		UndefinedToolRecovery: &UndefinedToolRecoveryConfig{Enabled: true, MaxPerRun: 1},
+		RecoverPendingKey:     "recover_pending",
+		RecoverCountKey:       "recover_count",
+	})
+	board := userBoard()
+	board.SetVar("recover_count", 1) // one recovery already spent this run
+	err := executeGraph(t, g, agent.NoopHost{}, board)
+	var infErr *inference.Error
+	if !errors.As(err, &infErr) || infErr.Kind != inference.UndefinedTool {
+		t.Fatalf("error = %v, want undefined_tool past budget", err)
+	}
+	if msgs := board.Channel(agent.MainChannel); len(msgs) != 1 {
+		t.Fatalf("channel length = %d, want 1 (no feedback past budget)", len(msgs))
+	}
+}
+
+func TestInferenceNode_UndefinedToolRecoveryRequiresKeys(t *testing.T) {
+	fake := &inferencetest.GenerateFake{}
+	reg := inferenceRegistry(t, InferenceNodeDeps{Assembly: fake.Assembly(t)})
+	g := singleNodeGraph(t, reg, "inference", InferenceConfig{
+		Model:                 ptr(inferencetest.DefaultFakeModel),
+		UndefinedToolRecovery: &UndefinedToolRecoveryConfig{Enabled: true},
+	})
+	err := executeGraph(t, g, agent.NoopHost{}, userBoard())
+	if err == nil || !errdefs.IsValidation(err) {
+		t.Fatalf("missing keys error = %v, want validation", err)
+	}
+}
+
+func TestInferenceNode_UndefinedToolRecoveryClearsMarker(t *testing.T) {
+	fake := &inferencetest.GenerateFake{}
+	reg := inferenceRegistry(t, InferenceNodeDeps{Assembly: fake.Assembly(t)})
+	g := singleNodeGraph(t, reg, "inference", InferenceConfig{
+		Model:             ptr(inferencetest.DefaultFakeModel),
+		RecoverPendingKey: "recover_pending",
+	})
+	board := userBoard()
+	board.SetVar("recover_pending", true)
+	if err := executeGraph(t, g, agent.NoopHost{}, board); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if v, _ := board.GetVar("recover_pending"); v != false {
+		t.Fatalf("recover_pending = %v, want false after success", v)
+	}
+}
+
+func TestInferenceNode_UndefinedToolRecoveryKeepsNamedChoiceStrict(t *testing.T) {
+	fake := &inferencetest.GenerateFake{
+		Respond: func(inference.GenerateRequest) inference.GenerateResponse {
+			return inference.GenerateResponse{
+				Message: message.Message{
+					Role: message.RoleAssistant,
+					Content: message.Content{Parts: []message.Part{
+						message.ToolCallPart{Call: message.ToolCall{
+							ID: "call-1", Name: "other", Arguments: json.RawMessage(`{}`),
+						}},
+					}},
+				},
+				FinishReason: inference.FinishToolCalls,
+			}
+		},
+	}
+	reg := inferenceRegistry(t, InferenceNodeDeps{
+		Assembly: fake.Assembly(t),
+		Catalog: toolCatalog(t,
+			stubTool{name: "known", desc: "the named-choice tool"},
+			stubTool{name: "other", desc: "a defined but unchosen tool"},
+		),
+	})
+	g := singleNodeGraph(t, reg, "inference", InferenceConfig{
+		Model:                 ptr(inferencetest.DefaultFakeModel),
+		Tools:                 []string{"known", "other"},
+		ToolChoice:            &inference.ToolChoice{Kind: inference.ToolChoiceNamed, Name: "known"},
+		UndefinedToolRecovery: &UndefinedToolRecoveryConfig{Enabled: true, MaxPerRun: 2},
+		RecoverPendingKey:     "recover_pending",
+		RecoverCountKey:       "recover_count",
+	})
+	board := userBoard()
+	err := executeGraph(t, g, agent.NoopHost{}, board)
+	var infErr *inference.Error
+	if !errors.As(err, &infErr) || infErr.Kind != inference.InvalidProviderResponse {
+		t.Fatalf("error = %v, want invalid_provider_response for named-choice violation", err)
+	}
+	if msgs := board.Channel(agent.MainChannel); len(msgs) != 1 {
+		t.Fatalf("channel length = %d, want 1 (named choice never recovered)", len(msgs))
 	}
 }
 

--- a/core/inference/errors.go
+++ b/core/inference/errors.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/GizClaw/flowcraft/core/errdefs"
+	"github.com/GizClaw/flowcraft/core/message"
 )
 
 type ErrorKind string
@@ -23,6 +24,12 @@ const (
 	CompilerContractViolation ErrorKind = "compiler_contract_violation"
 	ProviderFailure           ErrorKind = "provider_failure"
 	InvalidProviderResponse   ErrorKind = "invalid_provider_response"
+	// UndefinedTool marks a response whose tool calls name tools absent
+	// from the request's definitions. It is distinct from
+	// InvalidProviderResponse so callers can offer a recoverable path
+	// (e.g. feedback that sends the model back to tool_search) without
+	// weakening the contract for genuinely corrupt responses.
+	UndefinedTool ErrorKind = "undefined_tool"
 )
 
 // Error carries safe structural context. Error() deliberately excludes the
@@ -49,7 +56,12 @@ type Error struct {
 	// Runtime telemetry mirrors it onto error spans and logs as
 	// llm.request.id.
 	RequestID string
-	cause     error
+	// UndefinedToolCall is the first tool call rejected because its name
+	// was absent from the request's definitions. Populated only for
+	// UndefinedTool errors; a recovering caller uses it to reconstruct the
+	// call for in-conversation feedback.
+	UndefinedToolCall *message.ToolCall
+	cause             error
 }
 
 func NewError(kind ErrorKind, operation Operation, field FieldID, cause error) *Error {
@@ -129,6 +141,12 @@ func (kind ErrorKind) classify(cause error) error {
 		return errdefs.Aborted(classified)
 	case CompilerContractViolation, InvalidProviderResponse:
 		return errdefs.Internal(cause)
+	case UndefinedTool:
+		// Deterministic response violation: the model referenced a tool
+		// it was never shown. Retrying the same request cannot help, so
+		// it classifies as validation (non-retryable) rather than
+		// internal.
+		return errdefs.Validation(cause)
 	case ProviderFailure:
 		classified := errdefs.FromContext(cause)
 		if errdefs.HasClassification(classified) {
@@ -138,4 +156,19 @@ func (kind ErrorKind) classify(cause error) error {
 	default:
 		return errdefs.Internal(fmt.Errorf("unknown inference error kind %q: %w", kind, cause))
 	}
+}
+
+// newResponseValidationError classifies a GenerateResponse.ValidateFor
+// failure. Undefined tool calls become UndefinedTool (deterministic,
+// potentially recoverable); every other contract violation stays
+// InvalidProviderResponse (provider-side corruption).
+func newResponseValidationError(operation Operation, err error) *Error {
+	var ute *undefinedToolError
+	if errors.As(err, &ute) {
+		out := NewError(UndefinedTool, operation, "", err)
+		call := ute.Call
+		out.UndefinedToolCall = &call
+		return out
+	}
+	return NewError(InvalidProviderResponse, operation, "", err)
 }

--- a/core/inference/generate.go
+++ b/core/inference/generate.go
@@ -387,6 +387,20 @@ func (r GenerateResponse) Validate() error {
 	return nil
 }
 
+// undefinedToolError reports a tool call whose name is absent from the
+// request's tool definitions. ValidateFor returns it instead of a plain
+// error so callers can distinguish "the model called a tool it was never
+// shown" (deterministic, potentially recoverable via tool_search) from
+// other response corruption.
+type undefinedToolError struct {
+	Index int
+	Call  message.ToolCall
+}
+
+func (e *undefinedToolError) Error() string {
+	return fmt.Sprintf("generate tool call %d names undefined tool %q", e.Index, e.Call.Name)
+}
+
 func (r GenerateResponse) ValidateFor(request GenerateRequest) error {
 	deriveGenerateUsage(request, &r)
 	if err := r.Validate(); err != nil {
@@ -459,7 +473,7 @@ func (r GenerateResponse) ValidateFor(request GenerateRequest) error {
 		}
 		for index, call := range toolCalls {
 			if _, ok := definitions[call.Call.Name]; !ok {
-				return fmt.Errorf("generate tool call %d names undefined tool %q", index, call.Call.Name)
+				return &undefinedToolError{Index: index, Call: call.Call}
 			}
 		}
 		if choice := intent.Text.ToolChoice; choice != nil {

--- a/core/inference/generate_stream.go
+++ b/core/inference/generate_stream.go
@@ -463,7 +463,7 @@ func (s *decodedGenerateStream[RawEvent]) finishResult() {
 	response.Usage.Model = s.model
 	response.Usage.LatencyMs = time.Since(s.startedAt).Milliseconds()
 	if err := response.ValidateFor(s.request); err != nil {
-		s.resultErr = NewError(InvalidProviderResponse, OperationGenerate, "", err)
+		s.resultErr = newResponseValidationError(OperationGenerate, err)
 		return
 	}
 	s.result = response

--- a/core/inference/generate_test.go
+++ b/core/inference/generate_test.go
@@ -2,10 +2,12 @@ package inference
 
 import (
 	"encoding/json"
+	"errors"
 	"reflect"
 	"strings"
 	"testing"
 
+	"github.com/GizClaw/flowcraft/core/errdefs"
 	"github.com/GizClaw/flowcraft/core/message"
 )
 
@@ -118,5 +120,79 @@ func TestValidateGenerateText(t *testing.T) {
 				t.Fatalf("validateGenerateText error = %v, want containing %q", err, tc.wantErr)
 			}
 		})
+	}
+}
+
+func TestValidateForUndefinedTool(t *testing.T) {
+	req := GenerateRequest{
+		Input: GenerateInput{
+			Role: InputRoleUser,
+			Content: InputContent{
+				Content: message.Content{Parts: []message.Part{message.TextPart{Text: "hi"}}},
+				Intent: Intent{Text: &TextIntent{
+					Tools: []message.ToolDefinition{message.DefineSchema("known", "a known tool").Build()},
+				}},
+			},
+		},
+	}
+	resp := GenerateResponse{
+		Message: message.Message{
+			Role: message.RoleAssistant,
+			Content: message.Content{Parts: []message.Part{
+				message.ToolCallPart{Call: message.ToolCall{
+					ID: "call-1", Name: "ghost", Arguments: json.RawMessage(`{}`),
+				}},
+			}},
+		},
+		FinishReason: FinishToolCalls,
+	}
+	err := resp.ValidateFor(req)
+	var ute *undefinedToolError
+	if !errors.As(err, &ute) {
+		t.Fatalf("ValidateFor error = %v, want *undefinedToolError", err)
+	}
+	if ute.Index != 0 || ute.Call.Name != "ghost" {
+		t.Fatalf("undefined tool error = %+v, want call 0 ghost", ute)
+	}
+
+	wrapped := newResponseValidationError(OperationGenerate, err)
+	if wrapped.Kind != UndefinedTool {
+		t.Fatalf("wrapped kind = %q, want %q", wrapped.Kind, UndefinedTool)
+	}
+	if wrapped.UndefinedToolCall == nil ||
+		wrapped.UndefinedToolCall.ID != "call-1" ||
+		wrapped.UndefinedToolCall.Name != "ghost" {
+		t.Fatalf("wrapped call = %+v, want call-1/ghost", wrapped.UndefinedToolCall)
+	}
+	if !errdefs.IsValidation(wrapped) {
+		t.Fatalf("wrapped error must classify as validation, got %v", wrapped)
+	}
+}
+
+func TestValidateForKnownToolCall(t *testing.T) {
+	req := GenerateRequest{
+		Input: GenerateInput{
+			Role: InputRoleUser,
+			Content: InputContent{
+				Content: message.Content{Parts: []message.Part{message.TextPart{Text: "hi"}}},
+				Intent: Intent{Text: &TextIntent{
+					Tools: []message.ToolDefinition{message.DefineSchema("known", "a known tool").Build()},
+				}},
+			},
+		},
+	}
+	resp := GenerateResponse{
+		Message: message.Message{
+			Role: message.RoleAssistant,
+			Content: message.Content{Parts: []message.Part{
+				message.ToolCallPart{Call: message.ToolCall{
+					ID: "call-1", Name: "known", Arguments: json.RawMessage(`{}`),
+				}},
+			}},
+		},
+		FinishReason: FinishToolCalls,
+	}
+	if err := resp.ValidateFor(req); err != nil {
+		t.Fatalf("ValidateFor known tool call: %v", err)
 	}
 }

--- a/core/inference/provider.go
+++ b/core/inference/provider.go
@@ -350,7 +350,7 @@ func (p *pipeline[Req, Wire, Raw, Resp]) execute(
 		return zero, compiled.Report, NewError(InvalidProviderResponse, p.operation, "", err)
 	}
 	if err := p.validateResponse(request, response); err != nil {
-		return zero, compiled.Report, NewError(InvalidProviderResponse, p.operation, "", err)
+		return zero, compiled.Report, newResponseValidationError(p.operation, err)
 	}
 	return response, compiled.Report, nil
 }

--- a/core/inference/route/resilience.go
+++ b/core/inference/route/resilience.go
@@ -143,7 +143,8 @@ func nonRetryableKind(kind inference.ErrorKind) bool {
 		inference.PolicyDenied,
 		inference.OperationInterrupted,
 		inference.CompilerContractViolation,
-		inference.InvalidProviderResponse:
+		inference.InvalidProviderResponse,
+		inference.UndefinedTool:
 		return true
 	default:
 		return false

--- a/core/inference/route/resilience_test.go
+++ b/core/inference/route/resilience_test.go
@@ -1,0 +1,19 @@
+package route
+
+import (
+	"testing"
+
+	"github.com/GizClaw/flowcraft/core/inference"
+)
+
+func TestNonRetryableKindUndefinedTool(t *testing.T) {
+	if !nonRetryableKind(inference.UndefinedTool) {
+		t.Fatal("undefined tool rejections must be non-retryable")
+	}
+	if !nonRetryableKind(inference.InvalidProviderResponse) {
+		t.Fatal("invalid provider responses must stay non-retryable")
+	}
+	if nonRetryableKind(inference.ProviderFailure) {
+		t.Fatal("provider failures must remain retryable candidates")
+	}
+}

--- a/docs/guides/graph.md
+++ b/docs/guides/graph.md
@@ -173,11 +173,24 @@ Behavior:
   as an assistant `tool_call` paired with a `tool` result telling the model
   the tool is not exposed and to use `tool_search`, sets
   `recover_pending_key` to true (`tool_pending_key` to false), and returns
-  success. The graph must route on `recover_pending_key` back to inference —
-  never through a tool node, which would execute the call. `max_per_run`
+  success. The graph must route the recovered round back to inference: the
+  `recover_pending_key` marker is the explicit hook for an edge back into
+  the tool loop (e.g. `llm -> compact` conditioned on
+  `recover_pending == true`). With a standard tool-pending graph whose
+  `llm -> __end__` edge fires when `tool_pending == false`, a recovered
+  round without a loop-back edge terminates the run right after appending
+  the feedback — the model never gets another round. A graph whose tool
+  loop already routes the inference node back unconditionally can omit the
+  marker, but the feedback tail must reach an inference node, never a tool
+  node: a tool node would execute the replayed call, and a miswired
+  recover edge can execute deferred-but-registered tools with real side
+  effects. Validate graph edges when enabling recovery. `max_per_run`
   (default 2) bounds recoveries per graph run; past it the rejection fails
-  the node as before, keeping strict deployments intact. `tool_choice`
-  `named`/`required` violations are never recovered.
+  the node as before, keeping strict deployments intact. One rejection
+  discards the whole round's response — the other tool calls in the same
+  response are dropped, and only the offending call is replayed as
+  feedback. `tool_choice` `named`/`required` violations are never
+  recovered.
 - Usage is reported to the host on every call. In stream mode a mid-stream
   failure commits the buffered partial text to the board and reports the
   last usage snapshot before propagating the error.

--- a/docs/guides/graph.md
+++ b/docs/guides/graph.md
@@ -135,6 +135,9 @@ onto `tool_pending_key` and the graph routes onward.
 | `output_key`                             | board var receiving the full assistant `Message`                                                                  |
 | `usage_key`                              | board var receiving the call's `inference.Usage`                                                                  |
 | `tool_pending_key`                       | board var receiving `finish_reason == tool_calls` (the condition edges branch on)                                 |
+| `undefined_tool_recovery`                | `{enabled, max_per_run}`: convert an undefined-tool rejection into in-conversation feedback instead of failing the node; disabled by default |
+| `recover_pending_key`                    | board var receiving whether the round was recovered from an undefined-tool response (loop-back condition)             |
+| `recover_count_key`                      | board var receiving the per-run recovery counter (node hard-fails past `max_per_run`)                               |
 | `stream`                                 | open a `GenerateStream`; text/reasoning deltas stream incrementally, the board still gets one assembled message   |
 | `tools`                                  | named catalog tools the model may call this turn                                                                  |
 | `all_tools`                              | send the catalog's entire visible set; with `tools`, names are declared `RequiredByName` and must exist           |
@@ -163,6 +166,18 @@ Behavior:
   the provider's compiler.
 - With `tools`/`all_tools` configured the tools dep's catalog must be wired;
   unknown names fail the node.
+- A response whose tool calls name tools absent from the exposed definitions
+  is rejected by the engine with a distinguishable `undefined_tool` error
+  (not the generic `invalid_provider_response`). When
+  `undefined_tool_recovery` is enabled, the node replays the rejected call
+  as an assistant `tool_call` paired with a `tool` result telling the model
+  the tool is not exposed and to use `tool_search`, sets
+  `recover_pending_key` to true (`tool_pending_key` to false), and returns
+  success. The graph must route on `recover_pending_key` back to inference —
+  never through a tool node, which would execute the call. `max_per_run`
+  (default 2) bounds recoveries per graph run; past it the rejection fails
+  the node as before, keeping strict deployments intact. `tool_choice`
+  `named`/`required` violations are never recovered.
 - Usage is reported to the host on every call. In stream mode a mid-stream
   failure commits the buffered partial text to the board and reports the
   last usage snapshot before propagating the error.

--- a/docs/guides/tool.md
+++ b/docs/guides/tool.md
@@ -126,4 +126,11 @@ Go duration (calls that already carry a deadline pass through);
 (respecting context cancellation). The plain `memory` impl rejects the
 `middlewares` key.
 
+A model that calls a deferred tool before `tool_search` has exposed it is
+rejected at response validation with a distinguishable `undefined_tool`
+error rather than the generic `invalid_provider_response`. The inference
+node's `undefined_tool_recovery` config turns that rejection into
+in-conversation feedback that sends the model back to `tool_search`; see
+[graph.md](graph.md) for the recovery loop.
+
 See [runtime.md](runtime.md) for per-session dynamic catalogs.


### PR DESCRIPTION
## Summary

Fixes #414. When a model calls a tool that is not in the current turn's exposed definitions, the inference layer rejected the response as `invalid_provider_response` and the whole turn failed with no recovery path — the model never saw an explanation and could not learn to use `tool_search`. With deferred exposure this made legitimate workflows (create → delegate → status → unregister) intermittently unusable.

This PR splits the rejection into a distinguishable, deterministic error kind and adds an opt-in graph-node recovery path.

## Changes

- **`core/inference`**: new `UndefinedTool` error kind, classified non-retryable (no more blind node/route retries). `ValidateFor` returns a typed error carrying the offending call; unary and stream wrap sites classify it distinctly from `invalid_provider_response`.
- **`core/graph/nodes/inference`**: new `undefined_tool_recovery {enabled, max_per_run}` config. When enabled, an undefined-tool rejection replays the call as an assistant `tool_call` paired with a `tool` result telling the model the tool is not exposed and to use `tool_search`, sets `recover_pending_key` (and `tool_pending_key=false`), and returns success so the graph can route back to inference — never through a tool node, which would execute the call.
- **Budget**: `max_per_run` (default 2) caps recoveries per graph run; past it the rejection fails the node exactly as before. Strict deployments leave the config off and keep hard-failing. `named`/`required` `tool_choice` violations are never recovered.
- **Docs**: inference node config table and behavior in `docs/guides/graph.md`; note in `docs/guides/tool.md`.

## Verification

- `make ci`, `make lint`, `make release-check`, `git diff --check` all clean.
- New tests: engine classification (`TestValidateForUndefinedTool`, `TestValidateForKnownToolCall`), route non-retryability (`TestNonRetryableKindUndefinedTool`), node recovery, disabled/strict, budget exhaustion, missing-key config, marker clearing, and named-choice strictness (`TestInferenceNode_UndefinedToolRecovery*`).

## Follow-up (not in this PR)

The opencraft deployment wiring (three YAML config lines + one loop-back edge) lands when a new core version is released and opencraft bumps its pinned dependency.