### PR TITLE
chore(release): add core v0.1.26 changeset

### DIFF
--- a/.release/core-v0.1.26.json
+++ b/.release/core-v0.1.26.json
@@ -1,0 +1,9 @@
+{
+  "summary": "feat(core): recover from undefined tool calls instead of failing the turn — a model response that names a tool absent from the exposed definitions now rejects with a distinguishable undefined_tool inference error (deterministic and non-retryable) instead of invalid_provider_response, and the inference graph node gains opt-in undefined_tool_recovery config ({enabled, max_per_run}, default 2) that replays the rejected call as an assistant tool_call paired with a tool result telling the model the tool is not exposed and to use tool_search, sets recover_pending_key/recover_count_key board vars with tool_pending_key false, and returns success so the graph can route the round back to inference; recovery is bounded per graph run, strict deployments keep hard-failing, named/required tool_choice violations are never recovered, and one rejection discards the round's other tool calls; docs and graph-level tests cover the loop-back routing contract",
+  "releases": [
+    {
+      "module": "core",
+      "bump": "patch"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Adds the `.release/core-v0.1.26.json` changeset for the core module.

- Covers the accumulated delta since `core/v0.1.25`: PR #415 — recover from undefined tool calls instead of failing the turn (new `undefined_tool` error kind + opt-in inference-node recovery).
- Bump: `patch` — `core/v0.1.25 -> core/v0.1.26`, tag `core/v0.1.26`.

## Verification

- `make release-plan`: confirms `core: 0.1.25 -> 0.1.26 (patch), tag core/v0.1.26`.
- `make release-check`: changesets valid.

Merging this lets CI tag `core/v0.1.26`.