### PR TITLE
feat(driver/bytedance): support audio input on seed 2.0 lite/mini

### DIFF
--- a/driver/bytedance/catalog.go
+++ b/driver/bytedance/catalog.go
@@ -135,9 +135,9 @@ var catalog = map[string]catalogEntry{
 	},
 
 	// Seed 2.0 (2026-02) — general agent line plus the code-tuned variant.
-	// The 260215 lite revision retired in 2026-05, but the 260428 revision
-	// stays live (and is Ark's recommended audio-understanding model), so
-	// the stable family name remains routable.
+	// The 260215 revisions retired in 2026-05, but the 260428 lite/mini
+	// revisions stay live and are Ark's recommended audio-understanding
+	// models, so the stable family names remain routable.
 	"doubao-seed-2-0-pro": {
 		kind: kindGenerate,
 		capabilities: generateChatCapabilities().
@@ -149,7 +149,7 @@ var catalog = map[string]catalogEntry{
 	"doubao-seed-2-0-lite": {
 		kind: kindGenerate,
 		capabilities: generateChatCapabilities().
-			WithInputs(message.PartImage, message.PartVideo).
+			WithInputs(message.PartImage, message.PartVideo, message.PartAudio).
 			WithHostedWebSearch().
 			WithReasoning(inference.ReasoningToggle),
 		maxInputTokens: 256_000,
@@ -157,7 +157,7 @@ var catalog = map[string]catalogEntry{
 	"doubao-seed-2-0-mini": {
 		kind: kindGenerate,
 		capabilities: generateChatCapabilities().
-			WithInputs(message.PartImage, message.PartVideo).
+			WithInputs(message.PartImage, message.PartVideo, message.PartAudio).
 			WithHostedWebSearch().
 			WithReasoning(inference.ReasoningToggle),
 		maxInputTokens: 256_000,

--- a/driver/bytedance/catalog_test.go
+++ b/driver/bytedance/catalog_test.go
@@ -101,6 +101,35 @@ func TestCatalogPublishesCapabilities(t *testing.T) {
 	}
 }
 
+func TestCatalogDeclaresAudioInput(t *testing.T) {
+	provider, err := buildProvider(ResourceSettings{ID: "bytedance"})
+	if err != nil {
+		t.Fatalf("buildProvider: %v", err)
+	}
+	descriptors := make(map[string]inference.ModelDescriptor, len(provider.Models))
+	for _, model := range provider.Models {
+		descriptors[model.Descriptor.ID.Name] = model.Descriptor
+	}
+	// Ark's audio-understanding line is the 260428 lite/mini revisions;
+	// the rest of the generate family does not take audio input.
+	checks := map[string]bool{
+		"doubao-seed-2-0-lite": true,
+		"doubao-seed-2-0-mini": true,
+		"doubao-seed-2-0-pro":  false,
+		"doubao-seed-2-1-pro":  false,
+		"doubao-seed-evolving": false,
+	}
+	for name, want := range checks {
+		descriptor, ok := descriptors[name]
+		if !ok {
+			t.Fatalf("model %q missing from provider", name)
+		}
+		if has := slices.Contains(descriptor.Capabilities.Inputs, message.PartAudio); has != want {
+			t.Errorf("model %q: audio input = %v, want %v", name, has, want)
+		}
+	}
+}
+
 func TestMergedCatalogRejectsFamilyContractViolation(t *testing.T) {
 	spec, err := decodeSpec([]byte(
 		`{"models":[{"name":"m","kind":"image","capabilities":{"outputs":["text"]}}]}`,

--- a/driver/bytedance/generate.go
+++ b/driver/bytedance/generate.go
@@ -87,6 +87,7 @@ const (
 	wireContentText  wireContentKind = "text"
 	wireContentImage wireContentKind = "image"
 	wireContentVideo wireContentKind = "video"
+	wireContentAudio wireContentKind = "audio"
 )
 
 type wireContent struct {
@@ -475,7 +476,14 @@ func compileMessage(
 				uri:  videoSourceURI(value.Source),
 			})
 		case message.AudioPart:
-			ledger.reject(fields[message.PartAudio], "audio input is not supported by generate models")
+			if !slices.Contains(entry.capabilities.Inputs, message.PartAudio) {
+				ledger.reject(fields[message.PartAudio], "model does not accept audio input")
+				continue
+			}
+			content = append(content, wireContent{
+				kind: wireContentAudio,
+				uri:  audioSourceURI(value.Source),
+			})
 		case message.FilePart:
 			ledger.reject(fields[message.PartFile], "file references are not supported")
 		case message.DataPart:
@@ -670,6 +678,14 @@ func sourceURI(source media.ImageSource) string {
 }
 
 func videoSourceURI(source media.VideoSource) string {
+	if source.Kind() == media.SourceURL {
+		return source.URL()
+	}
+	return "data:" + source.MediaType() + ";base64," +
+		base64.StdEncoding.EncodeToString(source.Bytes())
+}
+
+func audioSourceURI(source media.AudioSource) string {
 	if source.Kind() == media.SourceURL {
 		return source.URL()
 	}

--- a/driver/bytedance/generate_ark.go
+++ b/driver/bytedance/generate_ark.go
@@ -239,6 +239,15 @@ func arkMessageContent(content []wireContent) *arkresponses.MessageContent {
 					},
 				},
 			})
+		case wireContentAudio:
+			items = append(items, &arkresponses.ContentItem{
+				Union: &arkresponses.ContentItem_Audio{
+					Audio: &arkresponses.ContentItemAudio{
+						Type:     arkresponses.ContentItemType_input_audio,
+						AudioUrl: part.uri,
+					},
+				},
+			})
 		}
 	}
 	return &arkresponses.MessageContent{

--- a/driver/bytedance/generate_audio_test.go
+++ b/driver/bytedance/generate_audio_test.go
@@ -1,0 +1,124 @@
+package bytedance
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/GizClaw/flowcraft/core/inference"
+	"github.com/GizClaw/flowcraft/core/message"
+	"github.com/GizClaw/flowcraft/core/message/media"
+
+	arkresponses "github.com/volcengine/volcengine-go-sdk/service/arkruntime/model/responses"
+)
+
+func audioRequest(source media.AudioSource) inference.GenerateRequest {
+	return inference.GenerateRequest{Input: inference.GenerateInput{
+		Role: inference.InputRoleUser,
+		Content: inference.InputContent{
+			Content: message.Content{Parts: []message.Part{message.AudioPart{Source: source}}},
+			Intent:  inference.Intent{Text: &inference.TextIntent{}},
+		},
+	}}
+}
+
+func TestCompileGenerateAudioInputURL(t *testing.T) {
+	source, err := media.NewAudioURL("https://example.com/audio.mp3", "audio/mpeg")
+	if err != nil {
+		t.Fatalf("NewAudioURL: %v", err)
+	}
+	compiled, err := compileGenerate("doubao-seed-2-0-lite", catalog["doubao-seed-2-0-lite"])(
+		context.Background(),
+		conformanceModel("doubao-seed-2-0-lite"),
+		audioRequest(source),
+		inference.GenerateExecutionUnary,
+	)
+	if err != nil {
+		t.Fatalf("compileGenerate: %v", err)
+	}
+	item := compiled.Wire.items[0]
+	if item.kind != wireItemMessage || item.role != "user" {
+		t.Fatalf("item = %+v, want user message", item)
+	}
+	if len(item.content) != 1 ||
+		item.content[0].kind != wireContentAudio ||
+		item.content[0].uri != "https://example.com/audio.mp3" {
+		t.Fatalf("content = %+v, want audio url content", item.content)
+	}
+}
+
+func TestCompileGenerateAudioInputInline(t *testing.T) {
+	source, err := media.NewAudioBytes([]byte{0x00, 0x01, 0x02}, "audio/mpeg")
+	if err != nil {
+		t.Fatalf("NewAudioBytes: %v", err)
+	}
+	compiled, err := compileGenerate("doubao-seed-2-0-mini", catalog["doubao-seed-2-0-mini"])(
+		context.Background(),
+		conformanceModel("doubao-seed-2-0-mini"),
+		audioRequest(source),
+		inference.GenerateExecutionUnary,
+	)
+	if err != nil {
+		t.Fatalf("compileGenerate: %v", err)
+	}
+	content := compiled.Wire.items[0].content
+	if len(content) != 1 || content[0].kind != wireContentAudio {
+		t.Fatalf("content = %+v, want audio content", content)
+	}
+	if want := "data:audio/mpeg;base64,AAEC"; content[0].uri != want {
+		t.Fatalf("audio uri = %q, want %q", content[0].uri, want)
+	}
+}
+
+func TestCompileGenerateRejectsAudioWithoutCapability(t *testing.T) {
+	source, err := media.NewAudioURL("https://example.com/audio.mp3", "audio/mpeg")
+	if err != nil {
+		t.Fatalf("NewAudioURL: %v", err)
+	}
+	compiled, err := compileGenerate("doubao-seed-2-1-pro", catalog["doubao-seed-2-1-pro"])(
+		context.Background(),
+		conformanceModel("doubao-seed-2-1-pro"),
+		audioRequest(source),
+		inference.GenerateExecutionUnary,
+	)
+	if err == nil {
+		t.Fatal("compileGenerate unexpectedly accepted audio input")
+	}
+	var compileErr *inference.Error
+	if !errors.As(err, &compileErr) {
+		t.Fatalf("error type = %T, want *inference.Error", err)
+	}
+	if compileErr.Kind != inference.UnsupportedFeature ||
+		compileErr.Field != inference.FieldGenerateInputAudio {
+		t.Fatalf("compile error = %+v, want input audio rejection", compileErr)
+	}
+	if !compiled.Report.Rejects(inference.FieldGenerateInputAudio) {
+		t.Fatalf("report = %+v, want input audio rejected", compiled.Report)
+	}
+}
+
+func TestWireToArkAudioContent(t *testing.T) {
+	request := wireToArk(generateWire{items: []wireItem{{
+		kind:    wireItemMessage,
+		role:    "user",
+		content: []wireContent{{kind: wireContentAudio, uri: "https://example.com/audio.mp3"}},
+	}}})
+	items := request.GetInput().GetListValue().GetListValue()
+	if len(items) != 1 {
+		t.Fatalf("input items = %d, want 1", len(items))
+	}
+	content := items[0].GetEasyMessage().GetContent().GetListValue().GetListValue()
+	if len(content) != 1 {
+		t.Fatalf("content items = %d, want 1", len(content))
+	}
+	audio := content[0].GetAudio()
+	if audio == nil {
+		t.Fatal("content item has no audio union")
+	}
+	if audio.GetType() != arkresponses.ContentItemType_input_audio {
+		t.Fatalf("audio type = %v, want input_audio", audio.GetType())
+	}
+	if audio.GetAudioUrl() != "https://example.com/audio.mp3" {
+		t.Fatalf("audio url = %q", audio.GetAudioUrl())
+	}
+}


### PR DESCRIPTION
Per the Volcengine Ark model list, the Seed 2.0 260428 lite/mini revisions are the audio-understanding models. The driver previously rejected `message.AudioPart` unconditionally, so audio input could not reach those models.

Changes:
- catalog: declare `audio` input capability on `doubao-seed-2-0-lite` / `doubao-seed-2-0-mini`
- compiler: lower `AudioPart` to an audio content item when the model supports it; keep field-precise rejection for models without the capability
- transport: map audio content to the Ark Responses `ContentItem_Audio` (`input_audio`) — streaming inherits this via the shared `wireToArk`
- tests: catalog capability assertions plus compile/transport coverage for URL and inline audio

Verified: `make ci`, `make lint`, `make release-check`, `git diff --check` all clean.