### PR TITLE
feat: delete session state by key + per-turn model hint for the router

### DIFF
--- a/core/graph/nodes/inference.go
+++ b/core/graph/nodes/inference.go
@@ -27,6 +27,14 @@ type InferenceConfig struct {
 	// absent the node defers target selection to the wired Router.
 	Model *inference.ModelRef `json:"model,omitempty"`
 
+	// ModelHint is an optional per-call model preference passed to the
+	// wired Router's generate selection: "provider/name" or a bare model
+	// name (e.g. "${board.model}"). The router honors it only when it
+	// names a configured target that can serve the request; otherwise it
+	// falls back to the default routing policy. Ignored when Model is
+	// set, since a static model bypasses the router entirely.
+	ModelHint string `json:"model_hint,omitempty"`
+
 	// MessagesChannel names the board channel holding the
 	// conversation; empty means the main channel. The channel's tail
 	// message is the current turn's input and must have role user or
@@ -404,6 +412,7 @@ func buildGenerateRequest(ec graph.ExecutionContext, board *agent.Board, channel
 			},
 		},
 		Extensions: extensions,
+		ModelHint:  cfg.ModelHint,
 	}, nil
 }
 

--- a/core/graph/nodes/inference_test.go
+++ b/core/graph/nodes/inference_test.go
@@ -811,6 +811,71 @@ func TestInferenceNode_RouterPathWhenNoModel(t *testing.T) {
 	}
 }
 
+func TestInferenceNode_ModelHintFromBoard(t *testing.T) {
+	fake := &inferencetest.GenerateFake{}
+	runtime := fake.Assembly(t)
+	reg := inferenceRegistry(t, InferenceNodeDeps{Router: fakeRouter(t, runtime)})
+	g := singleNodeGraph(t, reg, "inference", InferenceConfig{
+		ModelHint: "${board.model}",
+	})
+	board := userBoard()
+	board.SetVar("model", "deepseek/deepseek-v4-flash")
+	if err := executeGraph(t, g, agent.NoopHost{}, board); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if req := fake.LastRequest(); req.ModelHint != "deepseek/deepseek-v4-flash" {
+		t.Fatalf("routed request model_hint = %q, want board value", req.ModelHint)
+	}
+}
+
+func TestInferenceNode_ModelHintMissingBoardFallsBack(t *testing.T) {
+	fake := &inferencetest.GenerateFake{}
+	runtime := fake.Assembly(t)
+	reg := inferenceRegistry(t, InferenceNodeDeps{Router: fakeRouter(t, runtime)})
+	g := singleNodeGraph(t, reg, "inference", InferenceConfig{
+		ModelHint: "${board.model:}",
+	})
+	if err := executeGraph(t, g, agent.NoopHost{}, userBoard()); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if req := fake.LastRequest(); req.ModelHint != "" {
+		t.Fatalf("routed request model_hint = %q, want empty when board var is absent", req.ModelHint)
+	}
+}
+
+func TestInferenceNode_ModelHintStatic(t *testing.T) {
+	fake := &inferencetest.GenerateFake{}
+	runtime := fake.Assembly(t)
+	reg := inferenceRegistry(t, InferenceNodeDeps{Router: fakeRouter(t, runtime)})
+	g := singleNodeGraph(t, reg, "inference", InferenceConfig{
+		ModelHint: "good/model-1",
+	})
+	if err := executeGraph(t, g, agent.NoopHost{}, userBoard()); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if req := fake.LastRequest(); req.ModelHint != "good/model-1" {
+		t.Fatalf("routed request model_hint = %q, want static config value", req.ModelHint)
+	}
+}
+
+func TestInferenceNode_StreamCarriesModelHint(t *testing.T) {
+	fake := &inferencetest.GenerateFake{}
+	runtime := fake.Assembly(t)
+	reg := inferenceRegistry(t, InferenceNodeDeps{Router: fakeRouter(t, runtime)})
+	g := singleNodeGraph(t, reg, "inference", InferenceConfig{
+		ModelHint: "${board.model}",
+		Stream:    true,
+	})
+	board := userBoard()
+	board.SetVar("model", "deepseek/deepseek-v4-flash")
+	if err := executeGraph(t, g, agent.NoopHost{}, board); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if req := fake.LastRequest(); req.ModelHint != "deepseek/deepseek-v4-flash" {
+		t.Fatalf("stream request model_hint = %q, want board value", req.ModelHint)
+	}
+}
+
 func TestInferenceNode_NotAvailable(t *testing.T) {
 	reg := inferenceRegistry(t, InferenceNodeDeps{})
 

--- a/core/inference/generate.go
+++ b/core/inference/generate.go
@@ -93,6 +93,14 @@ type GenerateRequest struct {
 	Context    []message.Message `json:"context,omitempty" ledger:"generate.context.*.role"`
 	Input      GenerateInput     `json:"input" ledger:"generate.input.role"`
 	Extensions Extensions        `json:"-" ledger:"extension"`
+
+	// ModelHint is an optional per-call model preference consumed by the
+	// inference router's generate selection: "provider/name" or a bare
+	// model name. The router honors it only when it names a configured
+	// target that can serve the request; otherwise selection falls back
+	// to the default policy. Providers never interpret the hint — it is
+	// routing metadata, not a provider knob.
+	ModelHint string `json:"model_hint,omitempty"`
 }
 
 func (r GenerateRequest) Clone() GenerateRequest {

--- a/core/inference/generate_test.go
+++ b/core/inference/generate_test.go
@@ -38,6 +38,38 @@ func TestIntentOutputKinds(t *testing.T) {
 	}
 }
 
+func TestGenerateRequestModelHintCloneValidateAndJSON(t *testing.T) {
+	request := GenerateRequest{
+		Input: GenerateInput{
+			Role: InputRoleUser,
+			Content: InputContent{
+				Content: message.Content{Parts: []message.Part{
+					message.TextPart{Text: "hi"},
+				}},
+				Intent: Intent{Text: &TextIntent{}},
+			},
+		},
+		ModelHint: "good/model-1",
+	}
+	if err := request.Validate(); err != nil {
+		t.Fatalf("Validate: %v", err)
+	}
+	if clone := request.Clone(); clone.ModelHint != request.ModelHint {
+		t.Fatalf("Clone().ModelHint = %q, want %q", clone.ModelHint, request.ModelHint)
+	}
+	raw, err := json.Marshal(request)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	var decoded GenerateRequest
+	if err := json.Unmarshal(raw, &decoded); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if decoded.ModelHint != request.ModelHint {
+		t.Fatalf("JSON round-trip ModelHint = %q, want %q", decoded.ModelHint, request.ModelHint)
+	}
+}
+
 func TestValidateGenerateText(t *testing.T) {
 	arraySchema := json.RawMessage(
 		`{"type":"array","items":{"type":"string"}}`,

--- a/core/inference/route/route_test.go
+++ b/core/inference/route/route_test.go
@@ -1183,3 +1183,220 @@ func TestRouterTranscribeSessionCircuitBreakerSkipsOpenTarget(t *testing.T) {
 		t.Fatalf("second attempts = %+v, want circuit-open skip", trace.Attempts)
 	}
 }
+
+func providerDefinitionNamed(
+	t *testing.T,
+	id, name string,
+	fail bool,
+	outputs []message.PartKind,
+) inference.ProviderDefinition {
+	t.Helper()
+	driver, err := inference.BindGenerate(
+		routeCompiler(),
+		routeTransport(fail),
+		routeDecode(),
+	)
+	if err != nil {
+		t.Fatalf("BindGenerate: %v", err)
+	}
+	return inference.ProviderDefinition{
+		ID: id,
+		Models: []inference.ModelImplementation{{
+			Descriptor: inference.ModelDescriptor{
+				ID: inference.ModelID{Provider: id, Name: name},
+				Capabilities: inference.ModelCapabilities{
+					Outputs: outputs,
+				},
+			},
+			Openers: inference.Openers{
+				Generate: func(
+					context.Context, inference.ModelRef,
+				) (inference.GenerateOperations, error) {
+					return inference.GenerateOperations{Unary: driver}, nil
+				},
+			},
+		}},
+	}
+}
+
+func hintedRequest(hint string) inference.GenerateRequest {
+	request := routeRequest()
+	request.ModelHint = hint
+	return request
+}
+
+func TestPolicyGenerateHintSelectsConfiguredTarget(t *testing.T) {
+	good := inference.ModelRef{
+		ID:      inference.ModelID{Provider: "good", Name: "model-1"},
+		Profile: "prod",
+	}
+	policy := Policy{Generate: []Pool{
+		{Tier: "primary", Targets: []Target{{Model: inference.ModelRef{
+			ID: inference.ModelID{Provider: "bad", Name: "model-1"},
+		}}}},
+		{Tier: "fallback", Targets: []Target{{Model: good}}},
+	}}
+	selectors := policy.Selectors(nil)
+	decision, err := selectors.Generate.SelectGenerate(
+		context.Background(),
+		hintedRequest("good/model-1"),
+	)
+	if err != nil {
+		t.Fatalf("SelectGenerate: %v", err)
+	}
+	if decision.Selected != good {
+		t.Fatalf("Selected = %+v, want hinted target %+v", decision.Selected, good)
+	}
+	if decision.Tier != "fallback" {
+		t.Fatalf("Tier = %q, want hinted target's tier", decision.Tier)
+	}
+}
+
+func TestPolicyGenerateHintUnknownOrEmptyFallsBack(t *testing.T) {
+	first := inference.ModelRef{
+		ID: inference.ModelID{Provider: "bad", Name: "model-1"},
+	}
+	policy := Policy{Generate: []Pool{
+		{Tier: "primary", Targets: []Target{{Model: first}}},
+		{Tier: "fallback", Targets: []Target{{Model: inference.ModelRef{
+			ID: inference.ModelID{Provider: "good", Name: "model-1"},
+		}}}},
+	}}
+	selectors := policy.Selectors(nil)
+	for _, hint := range []string{"", "nope/model-1", "bad/model-2", "/model-1", "bad/"} {
+		decision, err := selectors.Generate.SelectGenerate(
+			context.Background(),
+			hintedRequest(hint),
+		)
+		if err != nil {
+			t.Fatalf("hint %q: SelectGenerate: %v", hint, err)
+		}
+		if decision.Selected != first {
+			t.Fatalf("hint %q: Selected = %+v, want default %+v", hint, decision.Selected, first)
+		}
+	}
+}
+
+func TestPolicyGenerateHintBareNameUniqueAndAmbiguous(t *testing.T) {
+	first := inference.ModelRef{
+		ID: inference.ModelID{Provider: "provider-a", Name: "model-a"},
+	}
+	second := inference.ModelRef{
+		ID: inference.ModelID{Provider: "provider-b", Name: "model-b"},
+	}
+	policy := Policy{Generate: []Pool{{
+		Tier: "primary",
+		Targets: []Target{
+			{Model: first},
+			{Model: second},
+		},
+	}}}
+	selectors := policy.Selectors(nil)
+
+	decision, err := selectors.Generate.SelectGenerate(
+		context.Background(),
+		hintedRequest("model-b"),
+	)
+	if err != nil {
+		t.Fatalf("SelectGenerate(bare unique): %v", err)
+	}
+	if decision.Selected != second {
+		t.Fatalf("bare hint Selected = %+v, want %+v", decision.Selected, second)
+	}
+
+	ambiguous := Policy{Generate: []Pool{{
+		Tier: "primary",
+		Targets: []Target{
+			{Model: inference.ModelRef{
+				ID: inference.ModelID{Provider: "provider-a", Name: "shared"},
+			}},
+			{Model: inference.ModelRef{
+				ID: inference.ModelID{Provider: "provider-b", Name: "shared"},
+			}},
+		},
+	}}}
+	ambiguousSelectors := ambiguous.Selectors(nil)
+	decision, err = ambiguousSelectors.Generate.SelectGenerate(
+		context.Background(),
+		hintedRequest("shared"),
+	)
+	if err != nil {
+		t.Fatalf("SelectGenerate(ambiguous): %v", err)
+	}
+	wantFirst := inference.ModelRef{
+		ID: inference.ModelID{Provider: "provider-a", Name: "shared"},
+	}
+	if decision.Selected != wantFirst {
+		t.Fatalf("ambiguous bare hint Selected = %+v, want first target", decision.Selected)
+	}
+}
+
+func TestPolicyGenerateHintTargetUnsupportedOutputsFallsBack(t *testing.T) {
+	assembly := assemblyWithProviders(t, map[string]inference.ProviderDefinition{
+		"provider.image": providerDefinitionNamed(t, "image-only", "model-1", false, []message.PartKind{message.PartImage}),
+		"provider.text":  providerDefinitionNamed(t, "text-only", "model-1", false, []message.PartKind{message.PartText}),
+	})
+	textRef := inference.ModelRef{
+		ID: inference.ModelID{Provider: "text-only", Name: "model-1"},
+	}
+	policy := Policy{Generate: []Pool{{
+		Tier: "primary",
+		Targets: []Target{
+			{Model: inference.ModelRef{
+				ID: inference.ModelID{Provider: "image-only", Name: "model-1"},
+			}},
+			{Model: textRef},
+		},
+	}}}
+	selectors := policy.Selectors(assembly)
+	decision, err := selectors.Generate.SelectGenerate(
+		context.Background(),
+		hintedRequest("image-only/model-1"),
+	)
+	if err != nil {
+		t.Fatalf("SelectGenerate: %v", err)
+	}
+	if decision.Selected != textRef {
+		t.Fatalf("Selected = %+v, want capability-compatible fallback %+v",
+			decision.Selected, textRef)
+	}
+}
+
+func TestRouterGenerateHintSelectsTargetWithoutFallback(t *testing.T) {
+	assembly := newRouteAssembly(t)
+	goodRef := inference.ModelRef{
+		ID: inference.ModelID{Provider: "good", Name: "model-1"},
+	}
+	policy := Policy{
+		Generate: []Pool{
+			{Tier: "primary", Targets: []Target{{Model: inference.ModelRef{
+				ID: inference.ModelID{Provider: "bad", Name: "model-1"},
+			}}}},
+			{Tier: "fallback", Targets: []Target{{Model: goodRef}}},
+		},
+	}
+	options, err := policy.Options()
+	if err != nil {
+		t.Fatalf("Options: %v", err)
+	}
+	router, err := New(assembly, policy.Selectors(assembly), options...)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	response, trace, err := router.Generate(
+		context.Background(),
+		hintedRequest("good/model-1"),
+	)
+	if err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+	if response.Usage.TotalTokens != 7 {
+		t.Fatalf("usage = %+v, want hinted target response", response.Usage)
+	}
+	if len(trace.Fallbacks) != 0 {
+		t.Fatalf("fallbacks = %+v, want none (hint picked the good target first)", trace.Fallbacks)
+	}
+	if trace.Executed != goodRef {
+		t.Fatalf("executed = %+v, want %+v", trace.Executed, goodRef)
+	}
+}

--- a/core/inference/route/route_test.go
+++ b/core/inference/route/route_test.go
@@ -1263,7 +1263,7 @@ func TestPolicyGenerateHintUnknownOrEmptyFallsBack(t *testing.T) {
 		}}}},
 	}}
 	selectors := policy.Selectors(nil)
-	for _, hint := range []string{"", "nope/model-1", "bad/model-2", "/model-1", "bad/"} {
+	for _, hint := range []string{"", "nope/model-1", "bad/model-2", "/model-1", "bad/", "a/b/c"} {
 		decision, err := selectors.Generate.SelectGenerate(
 			context.Background(),
 			hintedRequest(hint),
@@ -1398,5 +1398,358 @@ func TestRouterGenerateHintSelectsTargetWithoutFallback(t *testing.T) {
 	}
 	if trace.Executed != goodRef {
 		t.Fatalf("executed = %+v, want %+v", trace.Executed, goodRef)
+	}
+}
+
+func hintFallbackRetryConfig() *RetryConfig {
+	return &RetryConfig{
+		Generate: &RetryPolicyConfig{
+			MaxAttempts:              1,
+			Retryable:                []RetryableClass{RetryableUnavailable},
+			FallbackOnRetryExhausted: true,
+		},
+	}
+}
+
+func TestRouterGenerateHintFallsBackToDefaultChain(t *testing.T) {
+	goodA := inference.ModelRef{
+		ID: inference.ModelID{Provider: "good-a", Name: "model-1"},
+	}
+	failB := inference.ModelRef{
+		ID: inference.ModelID{Provider: "fail-b", Name: "model-1"},
+	}
+	failC := inference.ModelRef{
+		ID: inference.ModelID{Provider: "fail-c", Name: "model-1"},
+	}
+	assembly := assemblyWithProviders(t, map[string]inference.ProviderDefinition{
+		"provider.good-a": providerDefinitionNamed(t, "good-a", "model-1", false, nil),
+		"provider.fail-b": providerDefinitionNamed(t, "fail-b", "model-1", true, nil),
+		"provider.fail-c": providerDefinitionNamed(t, "fail-c", "model-1", true, nil),
+	})
+	policy := Policy{
+		Generate: []Pool{
+			{Tier: "primary", Targets: []Target{{Model: goodA}}},
+			{Tier: "fallback", Targets: []Target{{Model: failB}, {Model: failC}}},
+		},
+		Retry: hintFallbackRetryConfig(),
+	}
+	options, err := policy.Options()
+	if err != nil {
+		t.Fatalf("Options: %v", err)
+	}
+	router, err := New(assembly, policy.Selectors(assembly), options...)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	// Hint picks C (the last declared target). C fails, and fallback must
+	// restart at the head of the declared order (A), skipping B — it must
+	// not fail just because C was last.
+	response, trace, err := router.Generate(
+		context.Background(),
+		hintedRequest("fail-c/model-1"),
+	)
+	if err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+	if response.Usage.TotalTokens != 7 {
+		t.Fatalf("usage = %+v, want default-chain response", response.Usage)
+	}
+	if trace.Executed != goodA {
+		t.Fatalf("executed = %+v, want %+v", trace.Executed, goodA)
+	}
+	if len(trace.Fallbacks) != 1 ||
+		trace.Fallbacks[0].From != failC ||
+		trace.Fallbacks[0].To != goodA {
+		t.Fatalf("fallbacks = %+v, want C -> A", trace.Fallbacks)
+	}
+	attempts := trace.Attempts
+	wantAttempts := []struct {
+		target  inference.ModelRef
+		phase   AttemptPhase
+		outcome AttemptOutcome
+	}{
+		{failC, AttemptPhasePreflight, AttemptOutcomeSucceeded},
+		{failC, AttemptPhaseExecute, AttemptOutcomeFailed},
+		{goodA, AttemptPhasePreflight, AttemptOutcomeSucceeded},
+		{goodA, AttemptPhaseExecute, AttemptOutcomeSucceeded},
+	}
+	if len(attempts) != len(wantAttempts) {
+		t.Fatalf("attempts = %+v, want %+v", attempts, wantAttempts)
+	}
+	for index, want := range wantAttempts {
+		if attempts[index].Target != want.target ||
+			attempts[index].Phase != want.phase ||
+			attempts[index].Outcome != want.outcome {
+			t.Fatalf("attempts = %+v, want %+v", attempts, wantAttempts)
+		}
+	}
+}
+
+func TestRouterGenerateHintFallbackNeverRevisitsHintedTarget(t *testing.T) {
+	failA := inference.ModelRef{
+		ID: inference.ModelID{Provider: "fail-a", Name: "model-1"},
+	}
+	goodB := inference.ModelRef{
+		ID: inference.ModelID{Provider: "good-b", Name: "model-1"},
+	}
+	failC := inference.ModelRef{
+		ID: inference.ModelID{Provider: "fail-c", Name: "model-1"},
+	}
+	assembly := assemblyWithProviders(t, map[string]inference.ProviderDefinition{
+		"provider.fail-a": providerDefinitionNamed(t, "fail-a", "model-1", true, nil),
+		"provider.good-b": providerDefinitionNamed(t, "good-b", "model-1", false, nil),
+		"provider.fail-c": providerDefinitionNamed(t, "fail-c", "model-1", true, nil),
+	})
+	policy := Policy{
+		Generate: []Pool{{
+			Tier: "primary",
+			Targets: []Target{
+				{Model: failA},
+				{Model: goodB},
+				{Model: failC},
+			},
+		}},
+		Retry: hintFallbackRetryConfig(),
+	}
+	options, err := policy.Options()
+	if err != nil {
+		t.Fatalf("Options: %v", err)
+	}
+	router, err := New(assembly, policy.Selectors(assembly), options...)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	// Hint picks C. C fails, then A fails; the chain stops at the healthy
+	// B and the hinted C is never re-attempted.
+	response, trace, err := router.Generate(
+		context.Background(),
+		hintedRequest("fail-c/model-1"),
+	)
+	if err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+	if response.Usage.TotalTokens != 7 {
+		t.Fatalf("usage = %+v, want B response", response.Usage)
+	}
+	if trace.Executed != goodB {
+		t.Fatalf("executed = %+v, want %+v", trace.Executed, goodB)
+	}
+	var targets []inference.ModelRef
+	for _, attempt := range trace.Attempts {
+		if attempt.Phase != AttemptPhaseExecute {
+			continue
+		}
+		targets = append(targets, attempt.Target)
+	}
+	want := []inference.ModelRef{failC, failA, goodB}
+	if len(targets) != len(want) {
+		t.Fatalf("attempt targets = %v, want %v", targets, want)
+	}
+	for index := range want {
+		if targets[index] != want[index] {
+			t.Fatalf("attempt targets = %v, want %v", targets, want)
+		}
+	}
+}
+
+func TestRouterGenerateHintCircuitOpenFallsBackToDefaultChain(t *testing.T) {
+	goodA := inference.ModelRef{
+		ID: inference.ModelID{Provider: "good-a", Name: "model-1"},
+	}
+	failC := inference.ModelRef{
+		ID: inference.ModelID{Provider: "fail-c", Name: "model-1"},
+	}
+	assembly := assemblyWithProviders(t, map[string]inference.ProviderDefinition{
+		"provider.good-a": providerDefinitionNamed(t, "good-a", "model-1", false, nil),
+		"provider.fail-c": providerDefinitionNamed(t, "fail-c", "model-1", true, nil),
+	})
+	policy := Policy{
+		Generate: []Pool{
+			{Tier: "primary", Targets: []Target{{Model: goodA}}},
+			{Tier: "fallback", Targets: []Target{{Model: failC}}},
+		},
+		Retry: hintFallbackRetryConfig(),
+		CircuitBreaker: &CircuitBreakerConfig{
+			FailureThreshold: 1,
+			RecoveryWindow:   time.Hour,
+		},
+	}
+	options, err := policy.Options()
+	if err != nil {
+		t.Fatalf("Options: %v", err)
+	}
+	router, err := New(
+		assembly,
+		policy.Selectors(assembly),
+		append(options, noopSleeper())...,
+	)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	// First call: the hinted C fails and opens its circuit, fallback
+	// restarts at A.
+	if _, trace, err := router.Generate(
+		context.Background(),
+		hintedRequest("fail-c/model-1"),
+	); err != nil {
+		t.Fatalf("first Generate: %v", err)
+	} else if trace.Executed != goodA ||
+		len(trace.Fallbacks) != 1 ||
+		trace.Fallbacks[0].From != failC {
+		t.Fatalf("first trace = %+v, want C -> A", trace)
+	}
+
+	// Second call: C is circuit-open, so the hinted target is skipped and
+	// A executes without touching C.
+	_, trace, err := router.Generate(
+		context.Background(),
+		hintedRequest("fail-c/model-1"),
+	)
+	if err != nil {
+		t.Fatalf("second Generate: %v", err)
+	}
+	if trace.Executed != goodA {
+		t.Fatalf("second executed = %+v, want %+v", trace.Executed, goodA)
+	}
+	if len(trace.Attempts) != 3 ||
+		trace.Attempts[0].Target != failC ||
+		trace.Attempts[0].Outcome != AttemptOutcomeSkipped ||
+		trace.Attempts[0].Circuit != "open" ||
+		trace.Attempts[1].Target != goodA ||
+		trace.Attempts[2].Outcome != AttemptOutcomeSucceeded {
+		t.Fatalf("second attempts = %+v, want C skipped (open) then A succeeded", trace.Attempts)
+	}
+}
+
+type routeEventStream struct {
+	events []inference.GenerateStreamEvent
+	index  int
+}
+
+func newRouteEventStream() *routeEventStream {
+	return &routeEventStream{events: []inference.GenerateStreamEvent{
+		{PartIndex: 0, Delta: inference.TextPartDelta{Text: "ok"}},
+		{FinishReason: inference.FinishCompleted},
+	}}
+}
+
+func (s *routeEventStream) Next(context.Context) (inference.GenerateStreamEvent, error) {
+	if s.index >= len(s.events) {
+		return inference.GenerateStreamEvent{}, io.EOF
+	}
+	event := s.events[s.index]
+	s.index++
+	return event, nil
+}
+
+func (*routeEventStream) Close() error { return nil }
+
+func streamProviderNamed(
+	t *testing.T,
+	id, name string,
+) inference.ProviderDefinition {
+	t.Helper()
+	streamTransport := inference.Transport[routeWire, inference.ProviderStream[inference.GenerateStreamEvent]](
+		func(context.Context, routeWire) (inference.ProviderStream[inference.GenerateStreamEvent], error) {
+			return newRouteEventStream(), nil
+		},
+	)
+	streamDecode := inference.GenerateStreamDecoder[inference.GenerateStreamEvent](
+		func(_ context.Context, event inference.GenerateStreamEvent) (inference.GenerateStreamEvent, error) {
+			return event, nil
+		},
+	)
+	operations, err := inference.BindGenerateOperations(
+		routeCompiler(),
+		routeTransport(false),
+		routeDecode(),
+		streamTransport,
+		streamDecode,
+	)
+	if err != nil {
+		t.Fatalf("BindGenerateOperations: %v", err)
+	}
+	return inference.ProviderDefinition{
+		ID: id,
+		Models: []inference.ModelImplementation{{
+			Descriptor: inference.ModelDescriptor{
+				ID: inference.ModelID{Provider: id, Name: name},
+			},
+			Openers: inference.Openers{
+				Generate: func(
+					context.Context, inference.ModelRef,
+				) (inference.GenerateOperations, error) {
+					return operations, nil
+				},
+			},
+		}},
+	}
+}
+
+func TestRouterGenerateStreamHintFallsBackAfterPreflight(t *testing.T) {
+	streamA := inference.ModelRef{
+		ID: inference.ModelID{Provider: "stream-a", Name: "model-1"},
+	}
+	unaryB := inference.ModelRef{
+		ID: inference.ModelID{Provider: "unary-b", Name: "model-1"},
+	}
+	assembly := assemblyWithProviders(t, map[string]inference.ProviderDefinition{
+		"provider.stream-a": streamProviderNamed(t, "stream-a", "model-1"),
+		"provider.unary-b":  providerDefinitionNamed(t, "unary-b", "model-1", false, nil),
+	})
+	policy := Policy{Generate: []Pool{
+		{Tier: "primary", Targets: []Target{{Model: streamA}}},
+		{Tier: "fallback", Targets: []Target{{Model: unaryB}}},
+	}}
+	options, err := policy.Options()
+	if err != nil {
+		t.Fatalf("Options: %v", err)
+	}
+	router, err := New(assembly, policy.Selectors(assembly), options...)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	// The hint names B, which has no stream opener: preflight fails with
+	// UnsupportedOperation and fallback restarts at the head of the
+	// declared order (A), which opens the stream.
+	stream, trace, err := router.GenerateStream(
+		context.Background(),
+		hintedRequest("unary-b/model-1"),
+	)
+	if err != nil {
+		t.Fatalf("GenerateStream: %v", err)
+	}
+	if trace.Executed != streamA {
+		t.Fatalf("executed = %+v, want %+v", trace.Executed, streamA)
+	}
+	if len(trace.Fallbacks) != 1 ||
+		trace.Fallbacks[0].From != unaryB ||
+		trace.Fallbacks[0].To != streamA {
+		t.Fatalf("fallbacks = %+v, want B -> A", trace.Fallbacks)
+	}
+	if len(trace.Attempts) != 3 ||
+		trace.Attempts[0].Target != unaryB ||
+		trace.Attempts[0].Phase != AttemptPhasePreflight ||
+		trace.Attempts[0].Outcome != AttemptOutcomeFailed ||
+		trace.Attempts[1].Target != streamA ||
+		trace.Attempts[2].Outcome != AttemptOutcomeOpened {
+		t.Fatalf("attempts = %+v, want B preflight failed, A preflight + opened", trace.Attempts)
+	}
+	defer func() { _ = stream.Close() }()
+	event, err := stream.Next(context.Background())
+	if err != nil {
+		t.Fatalf("Next: %v", err)
+	}
+	if event.PartIndex != 0 || event.Delta == nil {
+		t.Fatalf("first event = %+v, want text delta", event)
+	}
+	for {
+		if _, err := stream.Next(context.Background()); err == io.EOF {
+			break
+		}
 	}
 }

--- a/core/inference/route/router_policy.go
+++ b/core/inference/route/router_policy.go
@@ -95,22 +95,54 @@ func (r *policyRoute) selectTarget() (Decision, error) {
 	}, nil
 }
 
-// nextTarget advances past the attempted target in declared order. An attempt
-// target that never came from this policy — a custom selector mixed with the
-// policy fallback — stops fallback instead of guessing.
+// nextTarget advances past the attempted target in the effective fallback
+// order for the hint. The effective order places the hinted target first and
+// keeps every other target in declared order, so a hint elevates one model
+// without replacing the default chain: when the hinted target fails, fallback
+// restarts at the head of the declared order instead of continuing past the
+// hint's position. An attempt target that never came from this policy — a
+// custom selector mixed with the policy fallback — stops fallback instead of
+// guessing.
 func (r *policyRoute) nextTarget(
+	hint string,
 	attempt Attempt,
 ) (inference.ModelRef, bool, error) {
-	for index, target := range r.targets {
+	order := r.effectiveOrder(hint)
+	for index, target := range order {
 		if target.model != attempt.Target {
 			continue
 		}
-		if index+1 < len(r.targets) {
-			return r.targets[index+1].model, true, nil
+		if index+1 < len(order) {
+			return order[index+1].model, true, nil
 		}
 		return inference.ModelRef{}, false, nil
 	}
 	return inference.ModelRef{}, false, nil
+}
+
+// effectiveOrder returns the fallback order for one request: when the
+// optional model hint names a configured target, that target moves to the
+// front and every other target keeps its declared order. Without a hint (or
+// when the hint is unknown/ambiguous) the declared order is used unchanged.
+// The hinted target is never repeated in the order, so a failed hint cannot
+// be re-attempted by fallback.
+func (r *policyRoute) effectiveOrder(hint string) []policyTarget {
+	if hint == "" {
+		return r.targets
+	}
+	hinted := r.hintTarget(hint)
+	if hinted == nil {
+		return r.targets
+	}
+	order := make([]policyTarget, 0, len(r.targets))
+	order = append(order, *hinted)
+	for _, target := range r.targets {
+		if target.model.ID == hinted.model.ID {
+			continue
+		}
+		order = append(order, target)
+	}
+	return order
 }
 
 func (r *policyRoute) SelectGenerate(
@@ -171,15 +203,18 @@ func (r *policyRoute) SelectGenerate(
 // target, or nil when the hint is absent, malformed, or does not name a
 // unique configured target:
 //
-//   - "provider/name" matches the exact configured model id;
+//   - "provider/name" matches the configured model id by provider and name;
 //   - a bare "name" matches any configured target with that model name;
 //     when several targets share the name the hint is ambiguous and is
 //     ignored;
 //   - anything else (empty, unknown provider/name, malformed segments)
 //     is ignored.
 //
-// Matching ignores the target's credential profile: the hint selects the
-// model, and the deployment's configured profile stays authoritative.
+// Matching is deliberately profile-blind: the hint selects the model, and
+// the deployment's configured profile stays authoritative. A consequence is
+// that when one model id is configured under several profiles, a qualified
+// hint is ambiguous (all profile entries share the id) and falls back to the
+// default selection — a hint cannot distinguish profiles.
 func (r *policyRoute) hintTarget(hint string) *policyTarget {
 	if hint == "" {
 		return nil
@@ -236,10 +271,10 @@ func (r *policyRoute) supportsOutputs(
 
 func (r *policyRoute) NextGenerate(
 	_ context.Context,
-	_ inference.GenerateRequest,
+	request inference.GenerateRequest,
 	attempt Attempt,
 ) (inference.ModelRef, bool, error) {
-	return r.nextTarget(attempt)
+	return r.nextTarget(request.ModelHint, attempt)
 }
 
 func (r *policyRoute) SelectEmbed(
@@ -254,7 +289,7 @@ func (r *policyRoute) NextEmbed(
 	_ inference.EmbedRequest,
 	attempt Attempt,
 ) (inference.ModelRef, bool, error) {
-	return r.nextTarget(attempt)
+	return r.nextTarget("", attempt)
 }
 
 func (r *policyRoute) SelectTranscribe(
@@ -269,7 +304,7 @@ func (r *policyRoute) NextTranscribe(
 	_ inference.TranscriptionRequest,
 	attempt Attempt,
 ) (inference.ModelRef, bool, error) {
-	return r.nextTarget(attempt)
+	return r.nextTarget("", attempt)
 }
 
 func (r *policyRoute) SelectTranscribeSession(
@@ -284,5 +319,5 @@ func (r *policyRoute) NextTranscribeSession(
 	_ inference.TranscriptionSessionRequest,
 	attempt Attempt,
 ) (inference.ModelRef, bool, error) {
-	return r.nextTarget(attempt)
+	return r.nextTarget("", attempt)
 }

--- a/core/inference/route/router_policy.go
+++ b/core/inference/route/router_policy.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"slices"
+	"strings"
 
 	"github.com/GizClaw/flowcraft/core/inference"
 	"github.com/GizClaw/flowcraft/core/message"
@@ -124,6 +125,22 @@ func (r *policyRoute) SelectGenerate(
 		)
 	}
 	requested := request.Input.Content.Intent.OutputKinds()
+	if hinted := r.hintTarget(request.ModelHint); hinted != nil {
+		supported, err := r.supportsOutputs(hinted.model, requested)
+		if err != nil {
+			return Decision{}, err
+		}
+		if supported {
+			return Decision{
+				Operation: r.operation,
+				Tier:      hinted.tier,
+				Proposed:  hinted.model,
+				Selected:  hinted.model,
+			}, nil
+		}
+		// The hinted target exists but cannot serve this request's output
+		// kinds; fall through to the default capability-aware selection.
+	}
 	for _, target := range r.targets {
 		supported, err := r.supportsOutputs(target.model, requested)
 		if err != nil {
@@ -148,6 +165,45 @@ func (r *policyRoute) SelectGenerate(
 			requested,
 		),
 	)
+}
+
+// hintTarget resolves the optional per-call model hint to a configured
+// target, or nil when the hint is absent, malformed, or does not name a
+// unique configured target:
+//
+//   - "provider/name" matches the exact configured model id;
+//   - a bare "name" matches any configured target with that model name;
+//     when several targets share the name the hint is ambiguous and is
+//     ignored;
+//   - anything else (empty, unknown provider/name, malformed segments)
+//     is ignored.
+//
+// Matching ignores the target's credential profile: the hint selects the
+// model, and the deployment's configured profile stays authoritative.
+func (r *policyRoute) hintTarget(hint string) *policyTarget {
+	if hint == "" {
+		return nil
+	}
+	provider, name, qualified := strings.Cut(hint, "/")
+	if !qualified {
+		name = hint
+	}
+	var match *policyTarget
+	for index := range r.targets {
+		target := &r.targets[index]
+		if target.model.ID.Name != name {
+			continue
+		}
+		if qualified && target.model.ID.Provider != provider {
+			continue
+		}
+		if match != nil {
+			// Ambiguous bare-name hint: no unique configured target.
+			return nil
+		}
+		match = target
+	}
+	return match
 }
 
 // supportsOutputs reports whether the model can serve every requested output

--- a/core/runtime/session/delete_session_test.go
+++ b/core/runtime/session/delete_session_test.go
@@ -1,0 +1,440 @@
+package session
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/GizClaw/flowcraft/core/agent"
+	"github.com/GizClaw/flowcraft/core/errdefs"
+	"github.com/GizClaw/flowcraft/core/event"
+	"github.com/GizClaw/flowcraft/core/message"
+)
+
+// newDeleteManager builds a Manager with resume enabled over a
+// checkpoint store the test can inspect.
+func newDeleteManager(
+	t *testing.T,
+	engine agent.Engine,
+	store agent.CheckpointStore,
+) *Manager {
+	t.Helper()
+	bus := event.NewMemoryBus()
+	router := event.NewRouter(bus)
+	instance := &agent.Agent{ID: "agent-a", Engine: engine}
+	manager, err := NewManager(
+		&testResolver{instances: map[string]*agent.Agent{"agent-a": instance}},
+		HostFactoryFunc(func(_ context.Context, _ HostRequest) (agent.Host, error) {
+			return agent.HostFuncs{Inner: testHost{bus: bus}}, nil
+		}),
+		router,
+		WithIdleTimeout(time.Minute),
+		WithSinkBufferSize(8),
+		WithCheckpointStore(store),
+		WithResume(true),
+	)
+	if err != nil {
+		t.Fatalf("NewManager: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = manager.Close()
+		_ = router.Close()
+		_ = bus.Close()
+	})
+	return manager
+}
+
+const deleteAgentID = "agent-a"
+
+func deleteKey(contextID string) Key {
+	return Key{AgentID: deleteAgentID, ContextID: contextID}
+}
+
+func storeKeys(store *resumeTestStore) []string {
+	store.mu.Lock()
+	defer store.mu.Unlock()
+	keys := make([]string, 0, len(store.cps))
+	for key := range store.cps {
+		keys = append(keys, key)
+	}
+	return keys
+}
+
+func TestManagerDeleteSessionRemovesCommittedState(t *testing.T) {
+	engine := &resumeProbeEngine{reply: "hello"}
+	store := &resumeTestStore{cps: make(map[string]agent.Checkpoint)}
+	manager := newDeleteManager(t, engine, store)
+	key := deleteKey("ctx")
+
+	lease, err := manager.GetOrCreate(context.Background(), key)
+	if err != nil {
+		t.Fatalf("GetOrCreate: %v", err)
+	}
+	turn, err := lease.Session().Start(context.Background(),
+		agent.Request{Message: message.NewTextMessage(message.RoleUser, "hi")})
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	if _, err := turn.Wait(context.Background()); err != nil {
+		t.Fatalf("Wait: %v", err)
+	}
+	if err := lease.Close(); err != nil {
+		t.Fatalf("lease.Close: %v", err)
+	}
+
+	stateID := sessionStateID(key)
+	if _, ok := store.cps[stateID]; !ok {
+		t.Fatalf("committed turn did not persist session state under %q", stateID)
+	}
+
+	if err := manager.DeleteSession(context.Background(), key); err != nil {
+		t.Fatalf("DeleteSession: %v", err)
+	}
+	if keys := storeKeys(store); len(keys) != 0 {
+		t.Fatalf("checkpoint store still holds %v after delete", keys)
+	}
+	if err := manager.DeleteSession(context.Background(), key); err != nil {
+		t.Fatalf("second DeleteSession: %v", err)
+	}
+
+	// A new Open must start a fresh session: no persisted history.
+	fresh, err := manager.GetOrCreate(context.Background(), key)
+	if err != nil {
+		t.Fatalf("GetOrCreate after delete: %v", err)
+	}
+	defer func() { _ = fresh.Close() }()
+	engine.reply = "fresh"
+	turn, err = fresh.Session().Start(context.Background(),
+		agent.Request{Message: message.NewTextMessage(message.RoleUser, "again")})
+	if err != nil {
+		t.Fatalf("fresh Start: %v", err)
+	}
+	if _, err := turn.Wait(context.Background()); err != nil {
+		t.Fatalf("fresh Wait: %v", err)
+	}
+	got := engine.snapshot()
+	msgs := got.board.Channels[agent.MainChannel]
+	if len(msgs) != 1 {
+		t.Fatalf("fresh board has %d messages, want 1 (no seeded history)", len(msgs))
+	}
+	if runID, ok, err := fresh.Session().Resumable(context.Background()); err != nil || ok {
+		t.Fatalf("fresh Resumable = (%q, %v, %v), want no parked run", runID, ok, err)
+	}
+}
+
+func TestManagerDeleteSessionRemovesParkedRun(t *testing.T) {
+	engine := &resumeProbeEngine{reply: "hello", interrupt: true}
+	store := &resumeTestStore{cps: make(map[string]agent.Checkpoint)}
+	manager := newDeleteManager(t, engine, store)
+	key := deleteKey("ctx")
+
+	lease, err := manager.GetOrCreate(context.Background(), key)
+	if err != nil {
+		t.Fatalf("GetOrCreate: %v", err)
+	}
+	turn, err := lease.Session().Start(context.Background(),
+		agent.Request{Message: message.NewTextMessage(message.RoleUser, "hi")})
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	result, err := turn.Wait(context.Background())
+	if err != nil {
+		t.Fatalf("Wait: %v", err)
+	}
+	if result.Status != agent.StatusInterrupted {
+		t.Fatalf("Status = %q, want interrupted", result.Status)
+	}
+	runID := turn.RunID()
+	if err := lease.Close(); err != nil {
+		t.Fatalf("lease.Close: %v", err)
+	}
+
+	// A real engine checkpoints during execution; the probe engine does
+	// not, so seed the parked run's checkpoint the way resume_test does.
+	store.cps[runID] = agent.Checkpoint{
+		ExecID:  runID,
+		Board:   agent.NewBoard().Snapshot(),
+		Payload: []byte(`{"resumable_run_id":"` + runID + `"}`),
+	}
+	if _, ok := store.cps[sessionStateID(key)]; !ok {
+		t.Fatal("interrupted turn did not persist session state")
+	}
+
+	if err := manager.DeleteSession(context.Background(), key); err != nil {
+		t.Fatalf("DeleteSession: %v", err)
+	}
+	if keys := storeKeys(store); len(keys) != 0 {
+		t.Fatalf("checkpoint store still holds %v after delete", keys)
+	}
+}
+
+func TestManagerDeleteSessionDrainsActiveTurnAndTimesOut(t *testing.T) {
+	release := make(chan struct{})
+	var releaseOnce sync.Once
+	defer releaseOnce.Do(func() { close(release) })
+	store := &resumeTestStore{cps: make(map[string]agent.Checkpoint)}
+	manager := newDeleteManager(t, blockingEngine(release), store)
+	key := deleteKey("ctx")
+	stateID := sessionStateID(key)
+	// Pre-seed a durable session record so the timed-out delete can be
+	// observed not to touch it.
+	board := agent.NewBoard()
+	board.AppendChannelMessage(agent.MainChannel, message.NewTextMessage(message.RoleUser, "seed"))
+	store.cps[stateID] = agent.Checkpoint{
+		ExecID:  stateID,
+		Board:   board.Snapshot(),
+		Payload: []byte(`{"resumable_run_id":"run-kept"}`),
+	}
+
+	lease, err := manager.GetOrCreate(context.Background(), key)
+	if err != nil {
+		t.Fatalf("GetOrCreate: %v", err)
+	}
+	defer func() { _ = lease.Close() }()
+	turn, err := lease.Session().Start(context.Background(),
+		agent.Request{Message: message.NewTextMessage(message.RoleUser, "hi")})
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	drainCtx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+	deleteDone := make(chan error, 1)
+	go func() {
+		deleteDone <- manager.DeleteSession(drainCtx, key)
+	}()
+	deadline := time.Now().Add(time.Second)
+	for !manager.keyDeleting(key) {
+		if time.Now().After(deadline) {
+			t.Fatal("delete did not start within deadline")
+		}
+		time.Sleep(time.Millisecond)
+	}
+	// Opens are refused while the delete is in flight.
+	if _, err := manager.Open(context.Background(), key); !errdefs.IsNotAvailable(err) {
+		t.Fatalf("Open during delete error = %v, want not available", err)
+	}
+	err = <-deleteDone
+	if !errdefs.IsTimeout(err) {
+		t.Fatalf("DeleteSession with busy turn = %v, want timeout", err)
+	}
+
+	// Rolled back: the delete left both the session and its state intact,
+	// and the key is openable again.
+	if _, ok := store.cps[stateID]; !ok {
+		t.Fatal("timed-out delete removed persisted session state")
+	}
+	if again, err := manager.Open(context.Background(), key); err != nil {
+		t.Fatalf("Open after timed-out delete: %v", err)
+	} else {
+		_ = again.Close()
+	}
+
+	releaseOnce.Do(func() { close(release) })
+	if _, err := turn.Wait(context.Background()); err != nil {
+		t.Fatalf("Wait: %v", err)
+	}
+	if err := manager.DeleteSession(context.Background(), key); err != nil {
+		t.Fatalf("retry DeleteSession: %v", err)
+	}
+	if keys := storeKeys(store); len(keys) != 0 {
+		t.Fatalf("checkpoint store still holds %v after retried delete", keys)
+	}
+}
+
+func TestManagerDeleteSessionClosesLiveSession(t *testing.T) {
+	engine := &resumeProbeEngine{reply: "hello"}
+	store := &resumeTestStore{cps: make(map[string]agent.Checkpoint)}
+	manager := newDeleteManager(t, engine, store)
+	key := deleteKey("ctx")
+
+	lease, err := manager.GetOrCreate(context.Background(), key)
+	if err != nil {
+		t.Fatalf("GetOrCreate: %v", err)
+	}
+	if err := manager.DeleteSession(context.Background(), key); err != nil {
+		t.Fatalf("DeleteSession: %v", err)
+	}
+	if _, err := lease.Session().Start(context.Background(),
+		agent.Request{Message: message.NewTextMessage(message.RoleUser, "hi")},
+	); !errors.Is(err, ErrSessionClosed) {
+		t.Fatalf("Start on deleted session error = %v, want ErrSessionClosed", err)
+	}
+	if err := lease.Close(); err != nil {
+		t.Fatalf("lease.Close: %v", err)
+	}
+
+	fresh, err := manager.GetOrCreate(context.Background(), key)
+	if err != nil {
+		t.Fatalf("GetOrCreate after delete: %v", err)
+	}
+	defer func() { _ = fresh.Close() }()
+}
+
+func TestManagerDeleteSessionUnknownKeyIsNoop(t *testing.T) {
+	store := &resumeTestStore{cps: make(map[string]agent.Checkpoint)}
+	manager := newDeleteManager(t, &resumeProbeEngine{}, store)
+	if err := manager.DeleteSession(context.Background(), deleteKey("never-opened")); err != nil {
+		t.Fatalf("DeleteSession for unknown key: %v", err)
+	}
+	if keys := storeKeys(store); len(keys) != 0 {
+		t.Fatalf("checkpoint store mutated by no-op delete: %v", keys)
+	}
+}
+
+func TestManagerDeleteSessionValidation(t *testing.T) {
+	store := &resumeTestStore{cps: make(map[string]agent.Checkpoint)}
+	manager := newDeleteManager(t, &resumeProbeEngine{}, store)
+
+	if err := manager.DeleteSession(context.Background(), Key{}); !errdefs.IsValidation(err) {
+		t.Fatalf("DeleteSession with invalid key = %v, want validation", err)
+	}
+	//nolint:staticcheck // deliberate: nil Context must be rejected
+	if err := manager.DeleteSession(nil, deleteKey("ctx")); !errdefs.IsValidation(err) {
+		t.Fatalf("DeleteSession with nil ctx = %v, want validation", err)
+	}
+}
+
+func TestManagerDeleteSessionAgentScoped(t *testing.T) {
+	engine := &resumeProbeEngine{reply: "hello"}
+	store := &resumeTestStore{cps: make(map[string]agent.Checkpoint)}
+	manager := newDeleteManager(t, engine, store)
+
+	key := deleteKey("ctx")
+	other := Key{AgentID: deleteAgentID, ContextID: "other"}
+	lease, err := manager.GetOrCreate(context.Background(), key)
+	if err != nil {
+		t.Fatalf("GetOrCreate: %v", err)
+	}
+	turn, err := lease.Session().Start(context.Background(),
+		agent.Request{Message: message.NewTextMessage(message.RoleUser, "hi")})
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	if _, err := turn.Wait(context.Background()); err != nil {
+		t.Fatalf("Wait: %v", err)
+	}
+	if err := lease.Close(); err != nil {
+		t.Fatalf("lease.Close: %v", err)
+	}
+
+	otherLease, err := manager.GetOrCreate(context.Background(), other)
+	if err != nil {
+		t.Fatalf("GetOrCreate(other): %v", err)
+	}
+	defer func() { _ = otherLease.Close() }()
+	turn, err = otherLease.Session().Start(context.Background(),
+		agent.Request{Message: message.NewTextMessage(message.RoleUser, "hi")})
+	if err != nil {
+		t.Fatalf("other Start: %v", err)
+	}
+	if _, err := turn.Wait(context.Background()); err != nil {
+		t.Fatalf("other Wait: %v", err)
+	}
+
+	if err := manager.DeleteSession(context.Background(), key); err != nil {
+		t.Fatalf("DeleteSession: %v", err)
+	}
+	if _, ok := store.cps[sessionStateID(other)]; !ok {
+		t.Fatal("deleting one session removed another key's state")
+	}
+}
+
+func TestManagerDeleteSessionConcurrentDeleteRejected(t *testing.T) {
+	release := make(chan struct{})
+	store := &resumeTestStore{cps: make(map[string]agent.Checkpoint)}
+	manager := newDeleteManager(t, blockingEngine(release), store)
+	key := deleteKey("ctx")
+
+	lease, err := manager.GetOrCreate(context.Background(), key)
+	if err != nil {
+		t.Fatalf("GetOrCreate: %v", err)
+	}
+	defer func() { _ = lease.Close() }()
+	turn, err := lease.Session().Start(context.Background(),
+		agent.Request{Message: message.NewTextMessage(message.RoleUser, "hi")})
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	done := make(chan error, 1)
+	go func() {
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+		defer cancel()
+		done <- manager.DeleteSession(ctx, key)
+	}()
+	// Wait until the first delete is in flight.
+	deadline := time.Now().Add(time.Second)
+	for !manager.keyDeleting(key) {
+		if time.Now().After(deadline) {
+			t.Fatal("delete did not start within deadline")
+		}
+		time.Sleep(time.Millisecond)
+	}
+	err = manager.DeleteSession(context.Background(), key)
+	if !errdefs.IsNotAvailable(err) {
+		t.Fatalf("concurrent DeleteSession = %v, want not available", err)
+	}
+
+	close(release)
+	if _, err := turn.Wait(context.Background()); err != nil {
+		t.Fatalf("Wait: %v", err)
+	}
+	if err := <-done; err != nil {
+		t.Fatalf("in-flight DeleteSession: %v", err)
+	}
+}
+
+func (m *Manager) keyDeleting(key Key) bool {
+	if m == nil {
+		return false
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	_, ok := m.deleting[key]
+	return ok
+}
+
+func TestDeleteSessionRemovesResumableRequest(t *testing.T) {
+	engine := &resumeProbeEngine{reply: "hello", interrupt: true}
+	store := &resumeTestStore{cps: make(map[string]agent.Checkpoint)}
+	manager := newDeleteManager(t, engine, store)
+	key := deleteKey("ctx")
+
+	lease, err := manager.GetOrCreate(context.Background(), key)
+	if err != nil {
+		t.Fatalf("GetOrCreate: %v", err)
+	}
+	turn, err := lease.Session().Start(context.Background(), agent.Request{
+		Message: message.NewTextMessage(message.RoleUser, "hi"),
+		Inputs:  map[string]any{"model": "deepseek-v4-flash"},
+	})
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	if _, err := turn.Wait(context.Background()); err != nil {
+		t.Fatalf("Wait: %v", err)
+	}
+	if err := lease.Close(); err != nil {
+		t.Fatalf("lease.Close: %v", err)
+	}
+
+	stateID := sessionStateID(key)
+	cp, err := store.Load(context.Background(), stateID)
+	if err != nil || cp == nil {
+		t.Fatalf("Load session state = (%v, %v), want record", cp, err)
+	}
+	if !strings.Contains(string(cp.Payload), `"resumable_run_id"`) {
+		t.Fatalf("session state payload lacks resumable run marker: %s", cp.Payload)
+	}
+
+	if err := manager.DeleteSession(context.Background(), key); err != nil {
+		t.Fatalf("DeleteSession: %v", err)
+	}
+	if keys := storeKeys(store); len(keys) != 0 {
+		t.Fatalf("checkpoint store still holds %v after delete", keys)
+	}
+}

--- a/core/runtime/session/delete_session_test.go
+++ b/core/runtime/session/delete_session_test.go
@@ -388,6 +388,89 @@ func TestManagerDeleteSessionConcurrentDeleteRejected(t *testing.T) {
 	}
 }
 
+// ignoreCtxEngine blocks until release, ignoring context cancellation, so
+// Session.close's shutdown wait times out with the turn still running.
+func ignoreCtxEngine(release <-chan struct{}) agent.Engine {
+	return agent.EngineFunc(func(
+		_ context.Context,
+		_ agent.Run,
+		_ agent.Host,
+		board *agent.Board,
+	) (*agent.Board, error) {
+		<-release
+		return board, nil
+	})
+}
+
+func TestManagerDeleteSessionKeepsStateWhenCloseTimesOut(t *testing.T) {
+	release := make(chan struct{})
+	store := &resumeTestStore{cps: make(map[string]agent.Checkpoint)}
+	manager := newDeleteManager(t, ignoreCtxEngine(release), store)
+	key := deleteKey("ctx")
+	stateID := sessionStateID(key)
+	board := agent.NewBoard()
+	board.AppendChannelMessage(agent.MainChannel, message.NewTextMessage(message.RoleUser, "seed"))
+	store.cps[stateID] = agent.Checkpoint{
+		ExecID:  stateID,
+		Board:   board.Snapshot(),
+		Payload: []byte(`{}`),
+	}
+
+	originalCloseTimeout := sessionCloseTurnTimeout
+	sessionCloseTurnTimeout = 100 * time.Millisecond
+	t.Cleanup(func() { sessionCloseTurnTimeout = originalCloseTimeout })
+
+	lease, err := manager.GetOrCreate(context.Background(), key)
+	if err != nil {
+		t.Fatalf("GetOrCreate: %v", err)
+	}
+	turn, err := lease.Session().Start(context.Background(),
+		agent.Request{Message: message.NewTextMessage(message.RoleUser, "hi")})
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	// Simulate the drain->close race: the turn starts after the drain
+	// observed idle, then close()'s shutdown wait expires with the turn
+	// still running (close swallows the timeout and returns nil).
+	if err := lease.Session().close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+	if !lease.Session().hasActiveTurn() {
+		t.Fatal("turn stopped within close budget; test cannot exercise the timeout path")
+	}
+
+	// DeleteSession must refuse to delete durable state while the turn
+	// could still write it, and must keep the session observable for a
+	// retry.
+	err = manager.DeleteSession(context.Background(), key)
+	if !errdefs.IsNotAvailable(err) {
+		t.Fatalf("DeleteSession with active closing turn = %v, want not available", err)
+	}
+	if _, ok := store.cps[stateID]; !ok {
+		t.Fatal("DeleteSession removed durable state while the turn was still active")
+	}
+	if _, err := manager.Open(context.Background(), key); !errdefs.IsNotAvailable(err) {
+		t.Fatalf("Open on closing session = %v, want not available", err)
+	}
+
+	close(release)
+	if _, err := turn.Wait(context.Background()); err != nil {
+		t.Fatalf("Wait: %v", err)
+	}
+	// The finished turn writes its terminal state; a retry must now
+	// complete the deletion.
+	if err := manager.DeleteSession(context.Background(), key); err != nil {
+		t.Fatalf("retry DeleteSession: %v", err)
+	}
+	if keys := storeKeys(store); len(keys) != 0 {
+		t.Fatalf("checkpoint store still holds %v after retried delete", keys)
+	}
+	if err := lease.Close(); err != nil {
+		t.Fatalf("lease.Close: %v", err)
+	}
+}
+
 func (m *Manager) keyDeleting(key Key) bool {
 	if m == nil {
 		return false

--- a/core/runtime/session/manager.go
+++ b/core/runtime/session/manager.go
@@ -197,6 +197,11 @@ func (m *Manager) open(ctx context.Context, key Key) (*Lease, error) {
 			"runtime session: agent %q is not deployed", key.AgentID)
 	}
 	if entry := m.entries[key]; entry != nil {
+		if entry.session.isClosing() {
+			return nil, errdefs.NotAvailablef(
+				"runtime session: session %q/%q is closing",
+				key.AgentID, key.ContextID)
+		}
 		entry.leases++
 		entry.idleGeneration++
 		if entry.timer != nil {
@@ -414,9 +419,13 @@ func (m *Manager) ReopenAgent(name string) {
 //   - Repeated calls are idempotent: a key with no live Session and no
 //     persisted state deletes successfully.
 //
-// Deletion of the checkpoint store entries runs after the live Session
-// has closed, so a turn that started just before the close cannot
-// resurrect state underneath the delete. Store failures are returned
+// Deletion of the checkpoint store entries runs only after the live
+// Session confirms its active turn has stopped (afterTurn has run), so a
+// turn that started in the drain window cannot resurrect state underneath
+// the delete. Session.close's shutdown wait is budgeted: if it times out —
+// or the session is already closing with an active turn — DeleteSession
+// returns a retryable error with the durable state left in place, and the
+// caller retries once the turn has stopped. Store failures are returned
 // (joined with close errors) so callers can retry.
 func (m *Manager) DeleteSession(ctx context.Context, key Key) error {
 	if m == nil {
@@ -446,14 +455,26 @@ func (m *Manager) DeleteSession(ctx context.Context, key Key) error {
 	m.deleting[key] = struct{}{}
 	// Stop idle-reclamation timers and invalidate in-flight callbacks so
 	// the session is not reclaimed while we drain it.
-	if entry := m.entries[key]; entry != nil {
+	entry := m.entries[key]
+	if entry != nil {
 		entry.idleGeneration++
 		if entry.timer != nil {
 			entry.timer.Stop()
 			entry.timer = nil
 		}
 	}
+	closingWithTurn := entry != nil &&
+		entry.session.isClosing() && entry.session.hasActiveTurn()
 	m.mu.Unlock()
+
+	if closingWithTurn {
+		m.mu.Lock()
+		delete(m.deleting, key)
+		m.mu.Unlock()
+		return errdefs.NotAvailablef(
+			"runtime session: session %q/%q is already closing with an active turn; deletion incomplete, retry once the turn stops",
+			key.AgentID, key.ContextID)
+	}
 
 	if err := m.awaitKeyIdle(ctx, key); err != nil {
 		telemetry.Error(ctx, "runtime session: session drain timed out during delete",
@@ -475,7 +496,10 @@ func (m *Manager) DeleteSession(ctx context.Context, key Key) error {
 		if entry.session.markClosing() {
 			closing = entry.session
 		}
-		delete(m.entries, key)
+		// Keep the entry in place until the turn has fully stopped:
+		// close()'s shutdown wait is budgeted and may time out, and a
+		// retry (or Open) must be able to see a still-running turn. The
+		// entry is removed only after close confirms the session stopped.
 	}
 	m.mu.Unlock()
 
@@ -485,7 +509,24 @@ func (m *Manager) DeleteSession(ctx context.Context, key Key) error {
 		if err := closing.close(); err != nil {
 			errs = append(errs, err)
 		}
+		if closing.hasActiveTurn() {
+			// close()'s shutdown wait is budgeted and may have timed out:
+			// the turn can still be running and its afterTurn would write
+			// session state back after we delete it. Leave the durable
+			// state and the entry in place, roll back the delete marker,
+			// and ask the caller to retry once the turn has stopped.
+			errs = append(errs, errdefs.NotAvailablef(
+				"runtime session: session %q/%q still has an active turn after close; deletion incomplete, retry once the turn stops",
+				key.AgentID, key.ContextID))
+			m.mu.Lock()
+			delete(m.deleting, key)
+			m.mu.Unlock()
+			return errors.Join(errs...)
+		}
 	}
+	m.mu.Lock()
+	delete(m.entries, key)
+	m.mu.Unlock()
 	if err := m.deletePersistedState(key); err != nil {
 		errs = append(errs, err)
 	}
@@ -525,7 +566,13 @@ func (m *Manager) keyIdle(key Key) bool {
 	if entry == nil {
 		return true
 	}
-	return entry.session.isIdle()
+	if entry.session.isIdle() {
+		return true
+	}
+	// A closing session whose turn already stopped never reports idle
+	// (isIdle requires !closing), but there is nothing left to drain:
+	// close() is a no-op and the durable state can be removed safely.
+	return entry.session.isClosing() && !entry.session.hasActiveTurn()
 }
 
 // scheduleIdleTimerIfIdleLocked re-arms the idle-reclamation timer for a
@@ -546,7 +593,11 @@ func (m *Manager) scheduleIdleTimerIfIdleLocked(key Key, entry *managerEntry) {
 // session: the durable session-state record (committed board, parked
 // run marker, resumable request) and the parked run's checkpoint. Store
 // access is bounded with a background timeout so a slow store cannot
-// hold the caller's context hostage after the drain phase completed.
+// hold the caller's context hostage after the drain phase completed. The
+// store is resolved from the manager's current epoch: if a deployment
+// swaps checkpoint store instances between a session's writes and the
+// delete, cleanup lands on the current store (deployments sharing one
+// store singleton — the normal layout — are unaffected).
 func (m *Manager) deletePersistedState(key Key) error {
 	deps := m.currentDeps()
 	if !deps.Resume || deps.Checkpoints == nil {

--- a/core/runtime/session/manager.go
+++ b/core/runtime/session/manager.go
@@ -2,7 +2,9 @@ package session
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
+	"fmt"
 	"reflect"
 	"sync"
 	"time"
@@ -51,6 +53,7 @@ type Manager struct {
 	mu        sync.Mutex
 	entries   map[Key]*managerEntry
 	removed   map[string]struct{}
+	deleting  map[Key]struct{}
 	closed    bool
 	closeOnce sync.Once
 	closeErr  error
@@ -113,6 +116,7 @@ func NewManager(
 		observer:            opts.observer,
 		entries:             make(map[Key]*managerEntry),
 		removed:             make(map[string]struct{}),
+		deleting:            make(map[Key]struct{}),
 		epochSeq:            1,
 		epochs:              make(map[uint64]*epochState),
 	}
@@ -182,6 +186,11 @@ func (m *Manager) open(ctx context.Context, key Key) (*Lease, error) {
 	defer m.mu.Unlock()
 	if m.closed {
 		return nil, ErrManagerClosed
+	}
+	if _, deleting := m.deleting[key]; deleting {
+		return nil, errdefs.NotAvailablef(
+			"runtime session: session %q/%q is being deleted",
+			key.AgentID, key.ContextID)
 	}
 	if _, gone := m.removed[key.AgentID]; gone {
 		return nil, errdefs.NotFoundf(
@@ -385,6 +394,202 @@ func (m *Manager) ReopenAgent(name string) {
 	m.mu.Lock()
 	delete(m.removed, name)
 	m.mu.Unlock()
+}
+
+// DeleteSession removes one session's durable state and closes its live
+// Session, identified by key (agent id + context id). It is the
+// by-key counterpart of RemoveAgent for the desktop lifecycle
+// (delete/archive a conversation): after it returns, the checkpoint
+// store no longer carries the session's committed board (history),
+// parked run checkpoint, or resumable request for that key, and a
+// later Open starts a fresh session with empty history.
+//
+// Semantics mirror RemoveAgent:
+//
+//   - New opens for the key are refused until deletion finishes.
+//   - Any live Session is drained (bounded by ctx), then closed. On ctx
+//     expiry the delete marker is rolled back, the session is left
+//     intact, and no partial removal state is produced — callers may
+//     retry.
+//   - Repeated calls are idempotent: a key with no live Session and no
+//     persisted state deletes successfully.
+//
+// Deletion of the checkpoint store entries runs after the live Session
+// has closed, so a turn that started just before the close cannot
+// resurrect state underneath the delete. Store failures are returned
+// (joined with close errors) so callers can retry.
+func (m *Manager) DeleteSession(ctx context.Context, key Key) error {
+	if m == nil {
+		return nil
+	}
+	if isNil(ctx) {
+		return errdefs.Validationf("runtime session: context is required")
+	}
+	if err := key.Validate(); err != nil {
+		return err
+	}
+	if err := ctx.Err(); err != nil {
+		return errdefs.FromContext(err)
+	}
+
+	m.mu.Lock()
+	if m.closed {
+		m.mu.Unlock()
+		return ErrManagerClosed
+	}
+	if _, deleting := m.deleting[key]; deleting {
+		m.mu.Unlock()
+		return errdefs.NotAvailablef(
+			"runtime session: deletion already in progress for key %q/%q",
+			key.AgentID, key.ContextID)
+	}
+	m.deleting[key] = struct{}{}
+	// Stop idle-reclamation timers and invalidate in-flight callbacks so
+	// the session is not reclaimed while we drain it.
+	if entry := m.entries[key]; entry != nil {
+		entry.idleGeneration++
+		if entry.timer != nil {
+			entry.timer.Stop()
+			entry.timer = nil
+		}
+	}
+	m.mu.Unlock()
+
+	if err := m.awaitKeyIdle(ctx, key); err != nil {
+		telemetry.Error(ctx, "runtime session: session drain timed out during delete",
+			otellog.String(telemetry.AttrAgentID, key.AgentID),
+			otellog.String(telemetry.AttrConversationID, key.ContextID),
+			otellog.String(telemetry.AttrErrorMessage, err.Error()))
+		m.mu.Lock()
+		delete(m.deleting, key)
+		if entry := m.entries[key]; entry != nil {
+			m.scheduleIdleTimerIfIdleLocked(key, entry)
+		}
+		m.mu.Unlock()
+		return err
+	}
+
+	var closing *Session
+	m.mu.Lock()
+	if entry := m.entries[key]; entry != nil {
+		if entry.session.markClosing() {
+			closing = entry.session
+		}
+		delete(m.entries, key)
+	}
+	m.mu.Unlock()
+
+	var errs []error
+	if closing != nil {
+		closing.notifySessionClosing(true)
+		if err := closing.close(); err != nil {
+			errs = append(errs, err)
+		}
+	}
+	if err := m.deletePersistedState(key); err != nil {
+		errs = append(errs, err)
+	}
+
+	// Re-admit opens only after both the live Session and the durable
+	// state are gone, so a concurrent Open cannot load state that the
+	// delete is about to remove.
+	m.mu.Lock()
+	delete(m.deleting, key)
+	m.mu.Unlock()
+
+	return errors.Join(errs...)
+}
+
+// awaitKeyIdle waits (bounded by ctx) until the key's Session has no
+// active turns, prompts, or sinks. A key with no live Session is
+// immediately idle.
+func (m *Manager) awaitKeyIdle(ctx context.Context, key Key) error {
+	ticker := time.NewTicker(agentDrainPollInterval)
+	defer ticker.Stop()
+	for {
+		if m.keyIdle(key) {
+			return nil
+		}
+		select {
+		case <-ctx.Done():
+			return errdefs.FromContext(ctx.Err())
+		case <-ticker.C:
+		}
+	}
+}
+
+func (m *Manager) keyIdle(key Key) bool {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	entry := m.entries[key]
+	if entry == nil {
+		return true
+	}
+	return entry.session.isIdle()
+}
+
+// scheduleIdleTimerIfIdleLocked re-arms the idle-reclamation timer for a
+// session that still has no leases and is idle. Callers must hold mu.
+func (m *Manager) scheduleIdleTimerIfIdleLocked(key Key, entry *managerEntry) {
+	if m.closed || entry == nil {
+		return
+	}
+	if _, gone := m.removed[key.AgentID]; gone {
+		return
+	}
+	if entry.leases == 0 && entry.session.isIdle() {
+		m.scheduleIdleTimerLocked(key, entry)
+	}
+}
+
+// deletePersistedState removes the checkpoint-store entries for one
+// session: the durable session-state record (committed board, parked
+// run marker, resumable request) and the parked run's checkpoint. Store
+// access is bounded with a background timeout so a slow store cannot
+// hold the caller's context hostage after the drain phase completed.
+func (m *Manager) deletePersistedState(key Key) error {
+	deps := m.currentDeps()
+	if !deps.Resume || deps.Checkpoints == nil {
+		return nil
+	}
+	deleter, ok := deps.Checkpoints.(agent.CheckpointDeleter)
+	if !ok {
+		return nil
+	}
+	ctx, cancel := context.WithTimeout(
+		context.WithoutCancel(context.Background()), 5*time.Second)
+	defer cancel()
+
+	stateID := sessionStateID(key)
+	cp, err := deps.Checkpoints.Load(ctx, stateID)
+	if err != nil {
+		return fmt.Errorf("runtime session: load session state for delete: %w", err)
+	}
+	if cp == nil {
+		return nil
+	}
+	var state sessionState
+	if len(cp.Payload) > 0 {
+		if err := json.Unmarshal(cp.Payload, &state); err != nil {
+			// A corrupt record hides the parked run id; remove the
+			// session-state key anyway and report the decode failure so
+			// the caller knows cleanup may be incomplete.
+			return errors.Join(
+				fmt.Errorf("runtime session: decode session state for delete: %w", err),
+				deleter.Delete(ctx, stateID))
+		}
+	}
+	if state.ResumableRunID != "" {
+		if err := deleter.Delete(ctx, state.ResumableRunID); err != nil {
+			return fmt.Errorf(
+				"runtime session: delete parked run checkpoint %q: %w",
+				state.ResumableRunID, err)
+		}
+	}
+	if err := deleter.Delete(ctx, stateID); err != nil {
+		return fmt.Errorf("runtime session: delete session state: %w", err)
+	}
+	return nil
 }
 
 func (m *Manager) awaitAgentIdle(ctx context.Context, name string) error {

--- a/core/runtime/session/session.go
+++ b/core/runtime/session/session.go
@@ -26,13 +26,14 @@ const (
 	activityTurn activityKind = iota
 	activityPrompt
 	activitySink
-
-	// sessionCloseTurnTimeout bounds how long Session.close waits for
-	// the active turn to finish after shutdown (interrupt) is
-	// signalled. A non-cooperative engine must not hang Close (and
-	// with it Manager.Close / Runtime.Close) forever.
-	sessionCloseTurnTimeout = 30 * time.Second
 )
+
+// sessionCloseTurnTimeout bounds how long Session.close waits for
+// the active turn to finish after shutdown (interrupt) is
+// signalled. A non-cooperative engine must not hang Close (and
+// with it Manager.Close / Runtime.Close) forever. It is a variable
+// (not a const) so tests can shrink the budget.
+var sessionCloseTurnTimeout = 30 * time.Second
 
 // Session owns conversational activity for one Key while borrowing all
 // deployment and event-routing dependencies from the runtime.
@@ -825,6 +826,20 @@ func (s *Session) isIdle() bool {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	return s.idleLocked()
+}
+
+// hasActiveTurn reports whether a turn is still executing on the
+// session. Session.close bounds its shutdown wait and treats a timeout as
+// non-fatal, so a closed session can still have an active turn whose
+// afterTurn would write durable state; callers that delete that state
+// must confirm this returns false first.
+func (s *Session) hasActiveTurn() bool {
+	if s == nil {
+		return false
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.active != nil
 }
 
 // isEphemeral reports whether the session was created as an ephemeral

--- a/docs/guides/graph.md
+++ b/docs/guides/graph.md
@@ -130,6 +130,7 @@ onto `tool_pending_key` and the graph routes onward.
 | Config field                             | Meaning                                                                                                           |
 | ---------------------------------------- | ----------------------------------------------------------------------------------------------------------------- |
 | `model`                                  | explicit target `{id: {provider, name}, profile?}`; absent defers selection to the wired router                   |
+| `model_hint`                             | per-call model preference for the router: `provider/name` or a bare name (e.g. `${board.model}`); honored only when it names a configured target that can serve the request, otherwise the default policy applies |
 | `messages_channel`                       | board channel holding the conversation; empty means the main channel                                              |
 | `system_prompt`                          | prepended system message when the context does not already start with one (may be `{file: ...}` / `{embed: ...}`) |
 | `output_key`                             | board var receiving the full assistant `Message`                                                                  |
@@ -151,6 +152,15 @@ Behavior:
   the request context. An empty channel or wrong role is a validation error.
 - `model` uses the wired `inference.Assembly`; no `model` requires the
   `inference.Router` (selector/fallback chain picks the target).
+- `model_hint` is a request-level preference consumed only by the router:
+  it never bypasses the router or targets a model outside the configured
+  pools, and it is ignored when `model` is set. Board references resolve
+  per invocation, so a per-conversation choice can ride `agent.Request`
+  inputs (`inputs: {model: ...}`) and be read with `${board.model}` — pair
+  it with a default (`${board.model:}`) so turns without the input still
+  route with the default policy. A bare name is honored only when exactly
+  one configured target carries it; an unknown, malformed, or ambiguous
+  hint falls back to the default selection.
 - `intent` is the authoritative execution envelope and covers every
   generation modality: text controls (`response`, `max_output_tokens`,
   `tools`, `tool_choice`, `temperature`, `top_p`, `reasoning_enabled`,

--- a/docs/guides/graph.md
+++ b/docs/guides/graph.md
@@ -130,7 +130,7 @@ onto `tool_pending_key` and the graph routes onward.
 | Config field                             | Meaning                                                                                                           |
 | ---------------------------------------- | ----------------------------------------------------------------------------------------------------------------- |
 | `model`                                  | explicit target `{id: {provider, name}, profile?}`; absent defers selection to the wired router                   |
-| `model_hint`                             | per-call model preference for the router: `provider/name` or a bare name (e.g. `${board.model}`); honored only when it names a configured target that can serve the request, otherwise the default policy applies |
+| `model_hint`                             | per-call model preference for the router: `provider/name` or a bare name (e.g. `${board.model}`); the hinted target is tried first, and on failure fallback restarts at the head of the default chain |
 | `messages_channel`                       | board channel holding the conversation; empty means the main channel                                              |
 | `system_prompt`                          | prepended system message when the context does not already start with one (may be `{file: ...}` / `{embed: ...}`) |
 | `output_key`                             | board var receiving the full assistant `Message`                                                                  |
@@ -160,7 +160,11 @@ Behavior:
   it with a default (`${board.model:}`) so turns without the input still
   route with the default policy. A bare name is honored only when exactly
   one configured target carries it; an unknown, malformed, or ambiguous
-  hint falls back to the default selection.
+  hint falls back to the default selection. The hinted model is tried
+  first; if it fails (or its declared output kinds cannot serve the
+  request), fallback continues from the head of the declared order
+  without re-attempting the hint. Hints match by provider + model name —
+  profiles are not part of a hint.
 - `intent` is the authoritative execution envelope and covers every
   generation modality: text controls (`response`, `max_output_tokens`,
   `tools`, `tool_choice`, `temperature`, `top_p`, `reasoning_enabled`,

--- a/docs/guides/inference.md
+++ b/docs/guides/inference.md
@@ -105,13 +105,21 @@ Scores guide selection only; they never claim a request is executable.
   preflight remains the final arbiter.
 - Generate selection honors an optional per-call `model_hint` on the
   request (`provider/name`, or a bare name when exactly one configured
-  target carries it). The hint is a preference, not a bypass: it is
-  honored only when it names a configured target that can serve the
-  request, and any absent, unknown, malformed, or ambiguous hint falls
-  back to the default policy. A hint that selects a target in a lower
-  tier still falls back through the remaining declared targets if that
-  target fails. The hint is routing metadata — drivers never interpret
-  it — and it applies to both unary `Generate` and `GenerateStream`.
+  target carries it). The hint is a preference, not a bypass: a hinted
+  target that is absent, unknown, malformed, ambiguous, or whose declared
+  output kinds cannot serve the request is skipped, and selection falls
+  back to the default policy. When the hinted target is chosen but fails
+  at runtime, fallback restarts at the head of the declared order — the
+  hinted model is tried first and the rest of the chain keeps its normal
+  sequence, never re-attempting the failed hint. The hint matches by
+  provider + model name only; credential profiles are not part of the
+  hint, so a model configured under several profiles cannot be
+  distinguished per call (the deployment's configured profile stays
+  authoritative). A hinted target that the assembly reports as retired or
+  missing the operation is a selection error on both the hinted and
+  default paths (build-time policy validation already rejects such
+  targets). The hint is routing metadata — drivers never interpret it —
+  and it applies to both unary `Generate` and `GenerateStream`.
 - The `retry` section configures per-operation retries (same-target), each
   with `max_attempts`, an optional `max_total_attempts`, a `backoff`
   curve, an explicit `retryable` class list (`rate_limit`, `timeout`,

--- a/docs/guides/inference.md
+++ b/docs/guides/inference.md
@@ -103,6 +103,15 @@ Scores guide selection only; they never claim a request is executable.
   cannot serve the request intent are skipped, while targets with
   undeclared capabilities are treated as undeclared (not unsupported) —
   preflight remains the final arbiter.
+- Generate selection honors an optional per-call `model_hint` on the
+  request (`provider/name`, or a bare name when exactly one configured
+  target carries it). The hint is a preference, not a bypass: it is
+  honored only when it names a configured target that can serve the
+  request, and any absent, unknown, malformed, or ambiguous hint falls
+  back to the default policy. A hint that selects a target in a lower
+  tier still falls back through the remaining declared targets if that
+  target fails. The hint is routing metadata — drivers never interpret
+  it — and it applies to both unary `Generate` and `GenerateStream`.
 - The `retry` section configures per-operation retries (same-target), each
   with `max_attempts`, an optional `max_total_attempts`, a `backoff`
   curve, an explicit `retryable` class list (`rate_limit`, `timeout`,


### PR DESCRIPTION
Implements the two open feature requests:

**#421 - delete session state by key**
- Adds Manager.DeleteSession(ctx, key) in core/runtime/session: removes a session's durable checkpoint-store state (committed board/history, parked run checkpoint, resumable request) and closes any live Session for the key.
- Mirrors RemoveAgent semantics: opens are refused while deletion is in flight, active turns are drained (bounded by ctx, fully rolled back on timeout), repeated calls are idempotent, and store failures are surfaced for retry.

**#420 - per-turn model override for the router**
- Adds an optional model_hint to inference.GenerateRequest (provider/name or bare name), consumed only by the router's generate selection.
- The policy selector honors the hint when it names a configured target that can serve the request; unknown, malformed, ambiguous, or capability-incompatible hints fall back to the default policy.
- The inference graph node exposes a model_hint config that resolves board references per invocation (e.g. board.model), so a per-conversation choice can ride agent.Request inputs.

Docs: docs/guides/graph.md (node config) and docs/guides/inference.md (routing) updated.

Validation: make ci, make lint (0 issues), make release-check, git diff --check, and a race run of the session package all pass.

Closes #421
Closes #420