### PR TITLE
fix(core): preserve optional host capabilities in ephemeral sessions

### DIFF
--- a/core/runtime/session/start_options.go
+++ b/core/runtime/session/start_options.go
@@ -78,4 +78,11 @@ func (ephemeralHost) Checkpoint(context.Context, agent.Checkpoint) error {
 	return nil
 }
 
+// UnwrapHost preserves optional capabilities of the wrapped turn Host:
+// ephemeral sessions only suppress checkpoint writes and must not hide
+// the inner host's capabilities (delegation service, event bus, ...) from
+// agent.CapabilityFromHost traversal.
+func (h ephemeralHost) UnwrapHost() agent.Host { return h.Host }
+
 var _ agent.Checkpointer = ephemeralHost{}
+var _ agent.HostUnwrapper = ephemeralHost{}

--- a/core/runtime/session/start_options_test.go
+++ b/core/runtime/session/start_options_test.go
@@ -160,6 +160,51 @@ func TestEphemeralSessionWritesNoState(t *testing.T) {
 	}
 }
 
+func TestEphemeralHostPreservesOptionalCapabilities(t *testing.T) {
+	store := &sessionRecordingStore{}
+	var busFound bool
+	engine := agent.EngineFunc(func(
+		_ context.Context,
+		_ agent.Run,
+		host agent.Host,
+		board *agent.Board,
+	) (*agent.Board, error) {
+		// The ephemeral wrapper must not hide optional host capabilities
+		// (delegation service, event bus, ...) from CapabilityFromHost.
+		_, busFound = agent.EventBusFromHost(host)
+		// Checkpoint suppression must still hold through the wrapper.
+		if checkpointer, ok := host.(agent.Checkpointer); ok {
+			ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+			defer cancel()
+			_ = checkpointer.Checkpoint(ctx, agent.Checkpoint{
+				ExecID: "run-checkpoint",
+			})
+		}
+		board.AppendChannelMessage(agent.MainChannel,
+			message.NewTextMessage(message.RoleAssistant, "done"))
+		return board, nil
+	})
+	_, session, _, _ := newTurnSession(t, engine, turnHostFactory,
+		WithResume(true), WithCheckpointStore(store))
+	turn, err := session.StartWithOptions(
+		context.Background(),
+		agent.Request{Message: message.NewTextMessage(message.RoleUser, "hi")},
+		WithEphemeral(),
+	)
+	if err != nil {
+		t.Fatalf("StartWithOptions: %v", err)
+	}
+	if _, err := turn.Wait(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if !busFound {
+		t.Fatal("EventBusFromHost(ephemeral host) = not found, want the inner host's bus")
+	}
+	if !store.isEmpty() {
+		t.Fatalf("ephemeral host wrote %d checkpoints, want none", store.count())
+	}
+}
+
 func TestEphemeralCanceledTurnNeverParks(t *testing.T) {
 	store := &sessionRecordingStore{}
 	blocking := make(chan struct{})

--- a/core/runtime/session/start_options_test.go
+++ b/core/runtime/session/start_options_test.go
@@ -3,6 +3,7 @@ package session
 import (
 	"context"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -160,18 +161,62 @@ func TestEphemeralSessionWritesNoState(t *testing.T) {
 	}
 }
 
+// delegationService is a minimal stand-in for core/delegation.Service. The
+// session package cannot import core/delegation (it imports session), so the
+// regression asserts the same capability shape that delegation.ServiceFromHost
+// resolves through agent.CapabilityFromHost.
+type delegationService struct{ id string }
+
+// delegationServiceProvider mirrors core/delegation.ServiceProvider.
+type delegationServiceProvider interface {
+	DelegationService() delegationService
+}
+
+// delegationHost mirrors core/delegation.serviceHost: it exposes the
+// capability and unwraps to the underlying host.
+type delegationHost struct {
+	agent.Host
+	service delegationService
+}
+
+func (h delegationHost) DelegationService() delegationService { return h.service }
+
+func (h delegationHost) UnwrapHost() agent.Host { return h.Host }
+
+// delegationCapabilityHostFactory mirrors delegation hostwrap: the capability
+// wraps the runtime host, and the session wraps the result in ephemeralHost
+// for ephemeral starts.
+func delegationCapabilityHostFactory(bus event.Bus) HostFactory {
+	return HostFactoryFunc(func(_ context.Context, request HostRequest) (agent.Host, error) {
+		return delegationHost{
+			Host: agent.HostFuncs{
+				Inner:        testHost{bus: bus},
+				InterruptsFn: func() <-chan agent.Interrupt { return request.Interrupts },
+				AskUserFn:    request.AskUser,
+			},
+			service: delegationService{id: "delegate"},
+		}, nil
+	})
+}
+
 func TestEphemeralHostPreservesOptionalCapabilities(t *testing.T) {
 	store := &sessionRecordingStore{}
-	var busFound bool
+	var busFound atomic.Bool
+	var serviceFound atomic.Bool
 	engine := agent.EngineFunc(func(
 		_ context.Context,
 		_ agent.Run,
 		host agent.Host,
 		board *agent.Board,
 	) (*agent.Board, error) {
-		// The ephemeral wrapper must not hide optional host capabilities
-		// (delegation service, event bus, ...) from CapabilityFromHost.
-		_, busFound = agent.EventBusFromHost(host)
+		// The ephemeral wrapper must not hide optional host capabilities:
+		// the delegation service (the #426 regression, ServiceFromHost) and
+		// the event bus must both survive CapabilityFromHost traversal.
+		_, ok := agent.EventBusFromHost(host)
+		busFound.Store(ok)
+		if provider, ok := agent.CapabilityFromHost[delegationServiceProvider](host); ok {
+			serviceFound.Store(provider.DelegationService().id == "delegate")
+		}
 		// Checkpoint suppression must still hold through the wrapper.
 		if checkpointer, ok := host.(agent.Checkpointer); ok {
 			ctx, cancel := context.WithTimeout(context.Background(), time.Second)
@@ -184,7 +229,7 @@ func TestEphemeralHostPreservesOptionalCapabilities(t *testing.T) {
 			message.NewTextMessage(message.RoleAssistant, "done"))
 		return board, nil
 	})
-	_, session, _, _ := newTurnSession(t, engine, turnHostFactory,
+	_, session, _, _ := newTurnSession(t, engine, delegationCapabilityHostFactory,
 		WithResume(true), WithCheckpointStore(store))
 	turn, err := session.StartWithOptions(
 		context.Background(),
@@ -197,8 +242,11 @@ func TestEphemeralHostPreservesOptionalCapabilities(t *testing.T) {
 	if _, err := turn.Wait(context.Background()); err != nil {
 		t.Fatal(err)
 	}
-	if !busFound {
+	if !busFound.Load() {
 		t.Fatal("EventBusFromHost(ephemeral host) = not found, want the inner host's bus")
+	}
+	if !serviceFound.Load() {
+		t.Fatal("delegation capability (ServiceFromHost) = not found, want the inner host's service")
 	}
 	if !store.isEmpty() {
 		t.Fatalf("ephemeral host wrote %d checkpoints, want none", store.count())


### PR DESCRIPTION
Fixes #426

## Summary

`ephemeralHost` (`core/runtime/session/start_options.go`) wrapped the turn host opaquely: it embeds `agent.Host` but did not implement `agent.HostUnwrapper`, so `agent.CapabilityFromHost` stopped at the wrapper and optional host capabilities attached below (delegation service, event bus, ...) became unreachable in ephemeral sessions. This made `delegation.ServiceFromHost` fail and the `delegate` / `delegation_status` tools report `host has no delegation service`; nested delegation failed the same way because non-persistent subagent turns also run ephemeral.

This change implements `UnwrapHost` on `ephemeralHost` so capability traversal reaches the inner host, while `Checkpoint` remains suppressed — the wrapper replaces no authoritative capability surface, so unwrapping is safe (matching `serviceHost` / `tracingHost`).

## Test

Added `TestEphemeralHostPreservesOptionalCapabilities`: runs an ephemeral session whose host carries an `EventBusProvider` below the wrapper and asserts `EventBusFromHost` resolves while checkpoints are still swallowed. Verified it fails without the fix.

## Validation

- `make ci` ✓
- `make lint` ✓
- `git diff --check` ✓