### PR TITLE
chore(release): add core v0.1.28 changeset

### DIFF
--- a/.release/core-v0.1.28.json
+++ b/.release/core-v0.1.28.json
@@ -1,0 +1,9 @@
+{
+  "summary": "fix(core/runtime/session): preserve optional host capabilities in ephemeral sessions — ephemeralHost now implements agent.HostUnwrapper so agent.CapabilityFromHost traversal reaches the wrapped turn host's optional capabilities (delegation service, event bus) instead of stopping at the opaque wrapper, which previously made delegation.ServiceFromHost fail and delegate/delegation_status report 'host has no delegation service' (and broke nested delegation, since non-persistent subagent turns also run ephemeral); checkpoint suppression is unchanged, and a regression test asserts both delegation-service-style capability resolution and checkpoint suppression through the ephemeral wrapper",
+  "releases": [
+    {
+      "module": "core",
+      "bump": "patch"
+    }
+  ]
+}


### PR DESCRIPTION
Adds the immutable core changeset for the fix merged in #427 (ephemeral session host wrapper hides optional host capabilities).

Planned release:
- `core`: 0.1.27 → 0.1.28 (patch), tag `core/v0.1.28`

Validated with `make release-check` (releasegate tests + changeset validation + release plan).