### PR TITLE
docs(core): fix main channel literal and sync flowcraft-config skill to v0.1.28

### DIFF
--- a/docs/guides/graph.md
+++ b/docs/guides/graph.md
@@ -34,14 +34,14 @@ A `*Graph` is an `agent.Engine`.
         "model": {
           "id": { "provider": "deepseek", "name": "deepseek-v4-flash" }
         },
-        "messages_channel": "main"
+        "messages_channel": "__main_channel"
       }
     },
     {
       "id": "tools",
       "type": "tool",
       "config": {
-        "messages_channel": "main",
+        "messages_channel": "__main_channel",
         "results_key": "tool_results"
       }
     }
@@ -131,7 +131,7 @@ onto `tool_pending_key` and the graph routes onward.
 | ---------------------------------------- | ----------------------------------------------------------------------------------------------------------------- |
 | `model`                                  | explicit target `{id: {provider, name}, profile?}`; absent defers selection to the wired router                   |
 | `model_hint`                             | per-call model preference for the router: `provider/name` or a bare name (e.g. `${board.model}`); the hinted target is tried first, and on failure fallback restarts at the head of the default chain |
-| `messages_channel`                       | board channel holding the conversation; empty means the main channel                                              |
+| `messages_channel`                       | board channel holding the conversation; empty means the main channel (`__main_channel`)                          |
 | `system_prompt`                          | prepended system message when the context does not already start with one (may be `{file: ...}` / `{embed: ...}`) |
 | `output_key`                             | board var receiving the full assistant `Message`                                                                  |
 | `usage_key`                              | board var receiving the call's `inference.Usage`                                                                  |
@@ -228,7 +228,7 @@ results as one `role=tool` message — again a valid tail for `inference`.
 
 | Config field       | Meaning                                                                        |
 | ------------------ | ------------------------------------------------------------------------------ |
-| `messages_channel` | channel whose tail holds pending tool calls; empty means the main channel      |
+| `messages_channel` | channel whose tail holds pending tool calls; empty means the main channel (`__main_channel`) |
 | `results_key`      | board var receiving the raw `[]message.Result` for downstream nodes/conditions |
 
 Behavior:
@@ -624,7 +624,7 @@ busy VM degrades to a `not_available` signal instead of panicking.
       "id": "chat",
       "type": "inference",
       "config": {
-        "messages_channel": "main",
+        "messages_channel": "__main_channel",
         "tool_pending_key": "tool_pending",
         "tools": ["read_file", "list_dir", "grep"]
       }
@@ -633,7 +633,7 @@ busy VM degrades to a `not_available` signal instead of panicking.
       "id": "tools",
       "type": "tool",
       "config": {
-        "messages_channel": "main",
+        "messages_channel": "__main_channel",
         "results_key": "tool_results"
       }
     },

--- a/docs/guides/memory.md
+++ b/docs/guides/memory.md
@@ -102,7 +102,7 @@ agents:
             user_id: user-1
             agent_id: assistant
           conversation_id: conv-1   # optional; defaults to the request ContextID
-          channel: main             # optional; defaults to the main channel
+          channel: __main_channel   # optional; defaults to the main channel
 ```
 
 Committed turns are idempotent per run id, so retried turns do not

--- a/docs/guides/runtime.md
+++ b/docs/guides/runtime.md
@@ -150,6 +150,19 @@ result, err := turn.Wait(ctx)
 `SinkSpec` controls streaming delivery, visibility, authority, and queue
 size. `delivery_concurrency` bounds in-flight sink callbacks.
 
+### DeleteSession
+
+`app.Sessions().DeleteSession(ctx, key)` removes one session's durable
+state by key (agent id + context id) and closes its live session — the
+by-key counterpart of `UnregisterAgent` for delete/archive-a-conversation
+workflows. After it returns, the checkpoint store no longer carries the
+key's committed history, parked-run checkpoint, or resumable request; a
+later `Open` starts with empty history. Semantics mirror removal: new
+opens for the key are refused until deletion finishes, the live session is
+drained (bounded by ctx) before store entries are removed, and on ctx
+expiry the delete marker rolls back with no partial removal — the call is
+retryable and repeated calls are idempotent.
+
 ## Dynamic agent registry
 
 Agents are normally declared in the deployment document and fixed for the

--- a/skills/flowcraft-config/SKILL.md
+++ b/skills/flowcraft-config/SKILL.md
@@ -103,7 +103,7 @@ workflow.
 ## Compatibility and versioning
 
 One skill version pins one FlowCraft version. The validator's `go.mod`
-requires exactly `github.com/GizClaw/flowcraft/core v0.1.23`; the schema
+requires exactly `github.com/GizClaw/flowcraft/core v0.1.28`; the schema
 cards in this skill document that release (no `driver/*` or `backends/*`
 modules are required, since the validator never constructs factories).
 When FlowCraft releases a new version, bump the pin and reconcile the

--- a/skills/flowcraft-config/assets/minimal-deploy/graphs/assistant.json
+++ b/skills/flowcraft-config/assets/minimal-deploy/graphs/assistant.json
@@ -10,7 +10,7 @@
         "model": {
           "id": {"provider": "deepseek", "name": "deepseek-v4-flash"}
         },
-        "messages_channel": "main",
+        "messages_channel": "__main_channel",
         "system_prompt": "You are a helpful assistant.",
         "tool_pending_key": "tool_pending",
         "stream": true

--- a/skills/flowcraft-config/references/graph.md
+++ b/skills/flowcraft-config/references/graph.md
@@ -12,10 +12,10 @@ File definitions are capped at 1 MiB.
   "nodes": [
     {"id": "chat", "type": "inference", "config": {
       "model": {"id": {"provider": "deepseek", "name": "deepseek-v4-flash"}},
-      "messages_channel": "main"
+      "messages_channel": "__main_channel"
     }},
     {"id": "tools", "type": "tool", "config": {
-      "messages_channel": "main",
+      "messages_channel": "__main_channel",
       "results_key": "tool_results"
     }}
   ],
@@ -77,9 +77,12 @@ appended to the same channel. The node never executes tool calls — a
 | Config field | Meaning |
 | --- | --- |
 | `model` | explicit target `{id: {provider, name}, profile?}`; absent defers to the wired router |
-| `messages_channel` | board channel holding the conversation; empty means the main channel |
+| `model_hint` | per-call router preference: `provider/name` or a bare name (e.g. `${board.model}`); ignored when `model` is set |
+| `messages_channel` | board channel holding the conversation; empty means the main channel (`__main_channel`) |
 | `system_prompt` | prepended system message when the context does not start with one (may be `{file: ...}` / `{embed: ...}`) |
 | `output_key` / `usage_key` / `tool_pending_key` | board vars receiving the message / usage / tool-pending flag |
+| `undefined_tool_recovery` | `{enabled, max_per_run}`: replay undefined-tool rejections as in-conversation feedback; disabled by default |
+| `recover_pending_key` / `recover_count_key` | board vars receiving the recovery marker / per-run recovery counter |
 | `stream` | stream deltas incrementally; the board still gets one assembled message |
 | `tools` / `all_tools` | named catalog tools, or the catalog's entire visible set |
 | `tool_choice` | constrain when/which tools are called |
@@ -99,6 +102,17 @@ may not be combined with an intent that declares those fields itself.
 Legacy node-level sampling/reasoning/response-format keys were removed —
 strict decode rejects them; put them under `intent.text` instead.
 
+`model_hint` is a request-level preference consumed only by the router: it
+never bypasses routing and falls back to the default policy when the hint
+is unknown, malformed, or ambiguous. A response naming tools absent from
+the exposed definitions fails with a distinguishable `undefined_tool`
+error; with `undefined_tool_recovery` enabled the node replays the
+rejection as feedback (assistant `tool_call` paired with a `tool` result),
+sets `recover_pending_key` (clearing `tool_pending_key`), and returns
+success. The graph must route the recovered round back to inference —
+never to a tool node, which would execute the replayed call.
+`max_per_run` defaults to 2; past it the rejection fails the node.
+
 ### `tool` — batch tool execution
 
 Reads the `tool_call` parts off the channel tail's assistant message,
@@ -107,7 +121,7 @@ and appends the results as one `role=tool` message.
 
 | Config field | Meaning |
 | --- | --- |
-| `messages_channel` | channel whose tail holds pending tool calls; empty means the main channel |
+| `messages_channel` | channel whose tail holds pending tool calls; empty means the main channel (`__main_channel`) |
 | `results_key` | board var receiving the raw `[]message.Result` |
 
 Allow-listing/approval policy lives in the dispatcher's middleware, not the

--- a/skills/flowcraft-config/references/resources.md
+++ b/skills/flowcraft-config/references/resources.md
@@ -219,7 +219,7 @@ agents:
         settings:
           scope: {runtime_id: memories, user_id: user-1, agent_id: assistant}
           conversation_id: conv-1  # optional; defaults to the request ContextID
-          channel: main            # optional; defaults to the main channel
+          channel: __main_channel  # optional; defaults to the main channel
 ```
 
 `memory.context` requires exactly one `query` source and a non-reserved

--- a/skills/flowcraft-config/references/runtime.md
+++ b/skills/flowcraft-config/references/runtime.md
@@ -69,6 +69,17 @@ if err := app.UnregisterAgent(ctx, "qa",
 }
 ```
 
+## Session deletion (core/v0.1.27+)
+
+`app.Sessions().DeleteSession(ctx, key)` removes one session's durable
+state (committed history, parked-run checkpoint, resumable request) and
+closes its live session — the by-key counterpart of `UnregisterAgent` for
+delete/archive workflows. Semantics mirror removal: new opens for the key
+are refused until deletion finishes, the live session is drained (bounded
+by ctx), and on ctx expiry the delete marker rolls back with no partial
+removal — retryable, idempotent, and a later `Open` starts with empty
+history.
+
 Rules:
 
 - `RegisterAgent` uses the same assembly path as deployment

--- a/skills/flowcraft-config/scripts/validator/go.mod
+++ b/skills/flowcraft-config/scripts/validator/go.mod
@@ -2,7 +2,7 @@ module github.com/GizClaw/flowcraft/skills/flowcraft-config/scripts/validator
 
 go 1.26.0
 
-require github.com/GizClaw/flowcraft/core v0.1.23
+require github.com/GizClaw/flowcraft/core v0.1.28
 
 require (
 	github.com/cenkalti/backoff/v5 v5.0.3 // indirect

--- a/skills/flowcraft-config/scripts/validator/go.sum
+++ b/skills/flowcraft-config/scripts/validator/go.sum
@@ -1,5 +1,5 @@
-github.com/GizClaw/flowcraft/core v0.1.23 h1:mqu3DB6Ibub77Q3bm1vBCvEWkam40GNU5+MIvO5uhac=
-github.com/GizClaw/flowcraft/core v0.1.23/go.mod h1:ivaKWysWMtv3j0fj4059RWiSP8kNXBFDYDaFD80Gr74=
+github.com/GizClaw/flowcraft/core v0.1.28 h1:8ds1G6mCbc7nyXf+JCDLS5XkziXyEKWjXw3bCGIewIc=
+github.com/GizClaw/flowcraft/core v0.1.28/go.mod h1:ivaKWysWMtv3j0fj4059RWiSP8kNXBFDYDaFD80Gr74=
 github.com/cenkalti/backoff/v5 v5.0.3 h1:ZN+IMa753KfX5hd8vVaMixjnqRZ3y8CuJKRKj1xcsSM=
 github.com/cenkalti/backoff/v5 v5.0.3/go.mod h1:rkhZdG3JZukswDf7f0cwqPNk4K0sa+F97BxZthm/crw=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=


### PR DESCRIPTION
## Summary

Fixes two documentation/skill defects surfaced while investigating the `validateReads` / empty-channel question:

1. **Main channel literal**: examples and templates used `"messages_channel": "main"` / `channel: main`, but the reserved main channel constant is `__main_channel` (`core/agent/board.go`). Pointing `messages_channel` at the literal `"main"` reads a separate empty channel, so copied examples fail with `inference node: messages channel "main" is empty`. Updated the graph guide examples, skill reference cards, memory hook example, and the minimal-deploy template.

2. **flowcraft-config skill pinned to core v0.1.23 while the repo is at v0.1.28**: bumped the validator pin and go.sum, and added the inference config fields shipped after v0.1.23 — `model_hint`, `undefined_tool_recovery`, `recover_pending_key`, `recover_count_key` — plus a compact behavior note. Also documented `DeleteSession` (core/v0.1.27+) in the runtime guides.

## Verification

- `make ci` — pass
- `make lint` — 0 issues
- `make release-check` — changesets valid, no pending releases
- `git diff --check` — clean
- Validator rebuilt with `GOWORK=off` against core v0.1.28; the minimal-deploy template validates as a deployment document and as a graph definition

No release changeset added (docs-only, no module release intent).