### PR TITLE
docs(core): complete guide index and correct stale module claims

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,8 +26,9 @@ start with the forge demo in `examples/forge` for a runnable local workspace.
   delegation contracts.
 - **`driver/*`** — Provider adapters built on `core`: Anthropic, Azure,
   ByteDance, DeepSeek, Kimi, MiniMax, OpenAI, and Qwen.
-- **`backends/*`** — Platform-specific implementations: object-store
-  workspaces, sandbox backends (`bwrap`, `seatbelt`), and SQLite checkpoints.
+- **`backends/*`** — Platform-specific implementations: SQLite checkpoints
+  (`backends/checkpoint`) and the plugin shell (`backends/plugin`); the
+  sandbox backends (`bwrap`, `seatbelt`) live in `core/sandbox`.
 - **`examples/forge`** — A runnable local workspace demo built on the current
   stack: native deploy/inference/memory scenario configs, an interactive TUI,
   scripted tests, and raid × persona simulation.
@@ -48,9 +49,10 @@ the GoTemplate context renderer.
 
 This mirrors the inference pattern: `core/inference` is generic, and
 each provider (`openai`, `deepseek`, …) is a registered factory. Memory
-implementations plug in the same way — `impl: flowcraft` selects the bundled
-implementation, and another implementation registers under its own name with
-its own parameters.
+implementations plug in the same way — each registers under its own
+`impl:` name with its own parameters (the flowcraft memory module is one
+such app-registered implementation); `core` owns only the contracts and
+glue.
 
 ## Quickstart
 
@@ -145,7 +147,7 @@ the core and depend on it, never the reverse.
 | ----------------------------------------------------- | ---------------------------------------------------------------------------------------- | -------------------- |
 | [`core`](core/)                                       | Agent, graph, tool, model, message, inference, memory, event, telemetry, deploy, runtime | Versioned Go module  |
 | [`driver`](driver/)                                   | Provider inference adapters                                                              | Versioned Go modules |
-| [`backends`](backends/)                       | Platform-specific sandbox/object-store/checkpoint backends                           | Versioned Go modules |
+| [`backends`](backends/)                       | SQLite checkpoints and plugin shell (sandbox backends live in `core/sandbox`)         | Versioned Go modules |
 | [`examples/forge`](examples/forge/)                   | Runnable local workspace demo                                                            | Examples             |
 | [`tools/releasegate`](tools/releasegate/)             | Release automation                                                                       | Tools                |
 | [`skills/flowcraft-config`](skills/flowcraft-config/) | Codex skill for authoring and validating FlowCraft configs                               | Codex skill          |
@@ -208,6 +210,11 @@ pkg.go.dev. Topic guides live in [`docs/guides/`](docs/guides/):
   streaming sessions above a built deployment.
 - [Memory Stack](docs/guides/memory.md) — the three-layer memory stack:
   `core/memory` contracts and deploy/runtime glue.
+- [Prompt Lifecycle Events](docs/guides/prompt.md) — the
+  `agent.run.<id>.prompt.*` lifecycle events UI consumers subscribe to.
+- [Delegation](docs/guides/delegation.md) — `core/delegation`: backend-neutral
+  target discovery, sync / async execution, and the session-bound
+  delegation lifecycle.
 
 ### Configuration authoring skill (`skills/flowcraft-config`)
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -20,6 +20,11 @@ retrieval, runtime orchestration, and voice. Source on
 - [Event Bus](guides/event.md) — `core/event`: subject-routed
   publish/subscribe, in-process `MemoryBus`, host capability
   wiring, backpressure policies.
+- [Application Runtime](guides/runtime.md) — `core/runtime` +
+  `core/runtime/session`: process-level services and leased,
+  interruptible streaming sessions above a built deployment.
+- [Prompt Lifecycle Events](guides/prompt.md) — the
+  `agent.run.<id>.prompt.*` lifecycle events UI consumers subscribe to.
 
 ### State and execution boundary
 
@@ -29,6 +34,9 @@ retrieval, runtime orchestration, and voice. Source on
 - [Sandbox](guides/sandbox.md) — `core/sandbox`: agent execution
   boundary, env / net / resources policy, runners (local /
   seatbelt / bwrap), decorators and approval.
+- [Memory Stack](guides/memory.md) — the three-layer memory stack:
+  `core/memory` contracts, deploy/runtime glue, and app-registered
+  implementations.
 
 ### Assembly
 
@@ -41,6 +49,12 @@ retrieval, runtime orchestration, and voice. Source on
 - [Resource Protocol](guides/resource.md) — `core/resource`: the
   provider-neutral factory, dependency DAG, loader, and lifecycle phases
   that every deployment resource uses.
+
+### Delegation
+
+- [Delegation](guides/delegation.md) — `core/delegation`: backend-neutral
+  target discovery, sync / async execution, and the session-bound
+  delegation lifecycle.
 
 ## Migrations
 
@@ -69,14 +83,14 @@ The repository is organised as independently released Go modules:
 ```
 core/            Platform module (contracts, deploy, runtime, built-in resources)
 driver/          Provider inference adapters
-backends/    Platform-specific sandbox, object-store, and checkpoint backends
+backends/        SQLite checkpoints and plugin shell (sandbox backends live in core/)
 examples/        Reference assemblies
 ```
 
 ## Getting started
 
 ```bash
-go get github.com/GizClaw/flowcraft/core@v0.1.0
+go get github.com/GizClaw/flowcraft/core@latest
 ```
 
 See the package-level `doc.go` files for runnable usage snippets:

--- a/skills/flowcraft-plugin/references/plugin.md
+++ b/skills/flowcraft-plugin/references/plugin.md
@@ -151,7 +151,8 @@ teardown remains the guaranteed release for runtime-managed providers.
 - **Env inheritance**: plugin processes do not inherit host secrets;
   declare credentials explicitly in the service artifact `env`.
 - **Strict decode**: unknown manifest fields, unknown artifact types,
-  and `protocol_version != 1` are load-time errors, not warnings.
+  and a `protocol_version` outside `{0, 1}` are load-time errors, not
+  warnings.
 - **Path safety**: layer and service file paths must stay inside the
   plugin directory; the resource loader rejects `..` and absolute paths.
 - **ProviderDefinition freezing**: per-handle close is not reached via


### PR DESCRIPTION
## Summary

Follow-up docs cleanup after #430 (merged). Fixes:

1. **Guide index completeness** — `docs/index.md` now links the four guides it was missing (`runtime.md`, `memory.md`, `delegation.md`, `prompt.md`); `README.md` adds the missing `delegation.md` and `prompt.md` links.

2. **Stale module descriptions** — `backends/*` was described as containing object-store workspaces and sandbox backends (`bwrap`, `seatbelt`); the directory actually holds only `checkpoint` + `plugin`, and the sandbox backends live in `core/sandbox`. Corrected in `README.md` (module list + module map) and `docs/index.md` (layout + getting-started now uses `@latest` instead of the stale `@v0.1.0` pin).

3. **Stale memory claim** — `README.md` said `impl: flowcraft` selects a bundled memory implementation; the flowcraft memory module is app-registered and core owns only the contracts/glue (`core/memory/assembly.go`).

4. **Plugin skill internal contradiction** — `skills/flowcraft-plugin` §8 said `protocol_version != 1` is a load-time error, but the manifest validator allows `0` (unset) or `1`; now says "outside `{0, 1}`".

Note: `AGENTS.md` (local-only, git-ignored) was also corrected to describe `backends/` instead of the non-existent `integrations/`; it is intentionally not part of this PR.

## Verification

- `make release-check` — pass (docs-only change; `make ci`/`make lint` unaffected by markdown edits)
- `git diff --check` — clean
- No `.release` changeset added