### PR TITLE
feat(core): inherit caller stream sinks into delegated subagent sessions

### DIFF
--- a/core/delegation/service.go
+++ b/core/delegation/service.go
@@ -749,7 +749,7 @@ func (s *LocalService) runAt(ctx context.Context, req AsyncRequest, reuseSlot bo
 		}
 	}()
 
-	opts := s.delegationStartOptions(persistent)
+	opts := s.delegationStartOptions(execCtx, persistent)
 	request := agent.Request{
 		ContextID: key.ContextID,
 		Message:   message.NewTextMessage(message.RoleUser, req.Request.Input),
@@ -947,15 +947,21 @@ func responseFromTurn(result *agent.Result, contextID string) Response {
 }
 
 // delegationStartOptions builds the session options for a delegated
-// subagent turn: questions to the user are refused (never block), and
-// non-persistent identities run the turn ephemeral so no session state or
-// run checkpoint is ever written.
-func (s *LocalService) delegationStartOptions(persistent bool) []session.StartOption {
+// subagent turn: questions to the user are refused (never block),
+// non-persistent identities run the turn ephemeral so no session state
+// or run checkpoint is ever written, and stream sinks are inherited
+// from the caller turn when the caller's stream policy is inheritable.
+// Async worker runs do not inherit here: the caller context does not
+// cross the backend queue, and the worker is not a live UI consumer.
+func (s *LocalService) delegationStartOptions(ctx context.Context, persistent bool) []session.StartOption {
 	options := []session.StartOption{
 		session.WithAskUserOverride(refuseSubagentAskUser),
 	}
 	if !persistent {
 		options = append(options, session.WithEphemeral())
+	}
+	if policy, ok := session.StreamPolicyFromContext(ctx); ok && policy.Inheritable && len(policy.Sinks) > 0 {
+		options = append(options, session.WithSinks(policy.Sinks...))
 	}
 	return options
 }

--- a/core/delegation/session_provider_test.go
+++ b/core/delegation/session_provider_test.go
@@ -883,3 +883,92 @@ func TestRunAtSessionPathPersistentWritesState(t *testing.T) {
 		t.Fatal("persistent delegation wrote no checkpoints, want session state")
 	}
 }
+
+// streamEngine emits one stream delta on the run's canonical stream
+// subject before completing, so an attached sink has something to
+// observe.
+func streamEngine(output string) agent.Engine {
+	return agent.EngineFunc(func(
+		ctx context.Context,
+		run agent.Run,
+		host agent.Host,
+		board *agent.Board,
+	) (*agent.Board, error) {
+		if err := agent.EmitStreamPart(
+			ctx, host, run.RunID, "writer.node.work",
+			message.TextPart{Text: output}); err != nil {
+			return nil, err
+		}
+		board.AppendChannelMessage(agent.MainChannel,
+			message.NewTextMessage(message.RoleAssistant, output))
+		return board, nil
+	})
+}
+
+func TestSyncDelegationInheritsCallerStreamSinks(t *testing.T) {
+	received := make(chan agent.StreamDeltaPayload, 8)
+	sink := agent.StreamSinkFunc(func(
+		_ context.Context,
+		_ event.Envelope,
+		delta agent.StreamDeltaPayload,
+	) error {
+		received <- delta
+		return nil
+	})
+	service, _ := newSessionPathService(t, streamEngine("progress"), nil)
+	ctx := session.WithStreamPolicy(context.Background(), session.StreamPolicy{
+		Sinks: []session.SinkSpec{{
+			ID:   "caller",
+			Sink: sink,
+		}},
+		Inheritable: true,
+	})
+	response, err := service.Delegate(ctx, syncRequest("writer"))
+	if err != nil {
+		t.Fatalf("Delegate: %v", err)
+	}
+	if response.Status != StatusSucceeded {
+		t.Fatalf("response status = %q, want succeeded", response.Status)
+	}
+	select {
+	case delta := <-received:
+		part, ok := delta.Part.(message.TextPart)
+		if !ok || part.Text != "progress" {
+			t.Fatalf("delta part = %#v, want text %q", delta.Part, "progress")
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("inherited sink received no subagent stream delta")
+	}
+}
+
+func TestSyncDelegationSkipsNonInheritableStreamPolicy(t *testing.T) {
+	received := make(chan agent.StreamDeltaPayload, 8)
+	sink := agent.StreamSinkFunc(func(
+		_ context.Context,
+		_ event.Envelope,
+		delta agent.StreamDeltaPayload,
+	) error {
+		received <- delta
+		return nil
+	})
+	service, _ := newSessionPathService(t, streamEngine("progress"), nil)
+	ctx := session.WithStreamPolicy(context.Background(), session.StreamPolicy{
+		Sinks: []session.SinkSpec{{
+			ID:   "caller",
+			Sink: sink,
+		}},
+		Inheritable: false,
+	})
+	response, err := service.Delegate(ctx, syncRequest("writer"))
+	if err != nil {
+		t.Fatalf("Delegate: %v", err)
+	}
+	if response.Status != StatusSucceeded {
+		t.Fatalf("response status = %q, want succeeded", response.Status)
+	}
+	select {
+	case delta := <-received:
+		t.Fatalf("non-inheritable policy still delivered delta: %#v", delta)
+	case <-time.After(300 * time.Millisecond):
+	}
+}

--- a/core/runtime/session/session.go
+++ b/core/runtime/session/session.go
@@ -428,6 +428,16 @@ func (s *Session) startTurnLocked(
 	turn.resumeCtx = resumeCtx
 	turn.snapshot = snapshot
 	turn.askUserOverride = config.askUser
+	// Nested sessions started inside this turn (e.g. delegated subagents)
+	// inherit the turn's stream sinks, so the caller's stream policy
+	// follows the execution without explicit wiring. Both Start and
+	// Resume flow through here, and the subagent turn stamps its own
+	// (inherited) policy again, so nested delegations propagate
+	// transitively.
+	turn.runCtx = WithStreamPolicy(turn.runCtx, StreamPolicy{
+		Sinks:       config.sinks,
+		Inheritable: true,
+	})
 	instance, ok := deps.Resolver.Instance(s.key.AgentID)
 	if !ok {
 		turn.cancel()

--- a/core/runtime/session/stream_policy.go
+++ b/core/runtime/session/stream_policy.go
@@ -1,0 +1,34 @@
+package session
+
+import "context"
+
+// streamPolicyKey is the context key for a turn's inherited stream
+// policy.
+type streamPolicyKey struct{}
+
+// StreamPolicy describes how a turn's stream sinks are inherited by
+// sessions started within the turn's execution (for example delegated
+// subagent runs). Session starts stamp their attached sinks so nested
+// runs inherit the caller's stream without any explicit wiring.
+type StreamPolicy struct {
+	// Sinks are attached to every nested session started inside the
+	// turn when Inheritable is true.
+	Sinks []SinkSpec
+	// Inheritable reports whether nested sessions should inherit Sinks.
+	// Session starts stamp the policy with Inheritable=true; callers may
+	// stamp false to stop inheritance at a boundary.
+	Inheritable bool
+}
+
+// WithStreamPolicy returns a context that carries policy to nested
+// sessions started within the turn's execution.
+func WithStreamPolicy(ctx context.Context, policy StreamPolicy) context.Context {
+	return context.WithValue(ctx, streamPolicyKey{}, policy)
+}
+
+// StreamPolicyFromContext returns the nearest stream policy carried by
+// ctx, if any.
+func StreamPolicyFromContext(ctx context.Context) (StreamPolicy, bool) {
+	policy, ok := ctx.Value(streamPolicyKey{}).(StreamPolicy)
+	return policy, ok
+}

--- a/core/runtime/session/stream_policy_test.go
+++ b/core/runtime/session/stream_policy_test.go
@@ -1,0 +1,84 @@
+package session
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"github.com/GizClaw/flowcraft/core/agent"
+	"github.com/GizClaw/flowcraft/core/message"
+)
+
+func TestStreamPolicyContextRoundTrip(t *testing.T) {
+	policy := StreamPolicy{
+		Sinks:       []SinkSpec{{ID: "s1", Sink: discardSink{}}},
+		Inheritable: true,
+	}
+
+	ctx := WithStreamPolicy(context.Background(), policy)
+	got, ok := StreamPolicyFromContext(ctx)
+	if !ok {
+		t.Fatal("StreamPolicyFromContext: policy missing")
+	}
+	if !got.Inheritable || len(got.Sinks) != 1 || got.Sinks[0].ID != "s1" {
+		t.Fatalf("StreamPolicyFromContext = %+v, want %+v", got, policy)
+	}
+
+	if _, ok := StreamPolicyFromContext(context.Background()); ok {
+		t.Fatal("StreamPolicyFromContext reported a policy on a plain context")
+	}
+
+	// A nested stamp replaces the outer policy (nearest wins).
+	inner := StreamPolicy{Sinks: nil, Inheritable: false}
+	ctx = WithStreamPolicy(ctx, inner)
+	got, ok = StreamPolicyFromContext(ctx)
+	if !ok || got.Inheritable || len(got.Sinks) != 0 {
+		t.Fatalf("nested policy = %+v, %v; want Inheritable=false with no sinks", got, ok)
+	}
+}
+
+func TestStartStampsStreamPolicyIntoRunContext(t *testing.T) {
+	var mu sync.Mutex
+	var got StreamPolicy
+	engine := agent.EngineFunc(func(
+		ctx context.Context,
+		_ agent.Run,
+		_ agent.Host,
+		board *agent.Board,
+	) (*agent.Board, error) {
+		policy, ok := StreamPolicyFromContext(ctx)
+		if ok {
+			mu.Lock()
+			got = policy
+			mu.Unlock()
+		}
+		board.AppendChannelMessage(agent.MainChannel,
+			message.NewTextMessage(message.RoleAssistant, "done"))
+		return board, nil
+	})
+	_, sess, _, _ := newTurnSession(t, engine, turnHostFactory)
+	turn, err := sess.StartWithOptions(
+		context.Background(),
+		agent.Request{Message: message.NewTextMessage(message.RoleUser, "hi")},
+		WithSinks(SinkSpec{ID: "s1", Sink: discardSink{}}),
+	)
+	if err != nil {
+		t.Fatalf("StartWithOptions: %v", err)
+	}
+	result, err := turn.Wait(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Status != agent.StatusCompleted {
+		t.Fatalf("result status = %q, want completed", result.Status)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if !got.Inheritable {
+		t.Fatal("stamped policy Inheritable = false, want true")
+	}
+	if len(got.Sinks) != 1 || got.Sinks[0].ID != "s1" {
+		t.Fatalf("stamped sinks = %+v, want [s1]", got.Sinks)
+	}
+}


### PR DESCRIPTION
Closes #431

## Summary

Delegated subagent turns run as first-class sessions through the session manager, but the delegation service started them without any stream sink. Subagent stream deltas (reasoning, tool calls, intermediate text) were dropped, so a sync `delegate` call blocked the caller with zero visible progress until the final response arrived.

This PR fixes that with context-based stream policy inheritance, so the subagent run naturally carries the caller turn's stream:

- **`core/runtime/session`**: new `StreamPolicy` context API (`WithStreamPolicy` / `StreamPolicyFromContext`). `startTurnLocked` stamps the turn's attached sinks into the turn execution context as an inheritable policy. Both `Start` and `Resume` flow through this path, and each subagent turn re-stamps its inherited policy, so nested delegations propagate transitively.
- **`core/delegation`**: `delegationStartOptions(ctx, persistent)` reads the caller stream policy from the execution context and forwards inheritable sinks via `session.WithSinks`. Default behavior (no policy / non-inheritable policy) is unchanged — delegated sessions stay sink-free.

Async worker runs intentionally do not inherit: the caller context does not cross the backend queue, and the worker is not a live UI consumer. Async activity visibility remains a separate follow-up.

## Tests

- `StreamPolicy` context round-trip and nearest-wins semantics
- Session start stamps its sinks into the run context (Start path)
- Sync delegation with an inheritable policy delivers subagent stream deltas to the inherited sink
- Non-inheritable policy is skipped (no sink attached)

## Verification

- `make ci` ✅
- `make lint` ✅
- `make release-check` ✅ (no pending releases, no changeset added)
- `git diff --check` ✅
- `go test -race` on new tests ✅