### PR TITLE
fix(core): inherit caller stream sinks into delegated subagent sessions

### DIFF
--- a/core/delegation/service.go
+++ b/core/delegation/service.go
@@ -951,6 +951,7 @@ func responseFromTurn(result *agent.Result, contextID string) Response {
 // non-persistent identities run the turn ephemeral so no session state
 // or run checkpoint is ever written, and stream sinks are inherited
 // from the caller turn when the caller's stream policy is inheritable.
+// Inherited sinks are downgraded to observers (see inheritedSinkSpecs).
 // Async worker runs do not inherit here: the caller context does not
 // cross the backend queue, and the worker is not a live UI consumer.
 func (s *LocalService) delegationStartOptions(ctx context.Context, persistent bool) []session.StartOption {
@@ -961,9 +962,28 @@ func (s *LocalService) delegationStartOptions(ctx context.Context, persistent bo
 		options = append(options, session.WithEphemeral())
 	}
 	if policy, ok := session.StreamPolicyFromContext(ctx); ok && policy.Inheritable && len(policy.Sinks) > 0 {
-		options = append(options, session.WithSinks(policy.Sinks...))
+		options = append(options, session.WithSinks(inheritedSinkSpecs(policy.Sinks)...))
 	}
 	return options
+}
+
+// inheritedSinkSpecs adapts the caller's sink specs for a subagent turn.
+// The subagent turn is a different session whose Turn handle is never
+// exposed to the inherited sink, so authoritative and explicit-ack
+// obligations cannot be fulfilled there: inherited sinks always attach
+// as observers with ack-on-delivery and no unacked window (an unacked
+// authoritative attachment would otherwise be detached with a
+// BudgetExceeded once its window fills). Visibility is preserved so
+// consumers keep the delivery granularity they chose.
+func inheritedSinkSpecs(specs []session.SinkSpec) []session.SinkSpec {
+	out := make([]session.SinkSpec, 0, len(specs))
+	for _, spec := range specs {
+		spec.Authority = session.AuthorityObserver
+		spec.AckMode = session.AckOnDelivery
+		spec.MaxUnacked = 0
+		out = append(out, spec)
+	}
+	return out
 }
 
 // sameDelegationRequest reports whether two delegation requests are

--- a/core/delegation/service.go
+++ b/core/delegation/service.go
@@ -749,7 +749,7 @@ func (s *LocalService) runAt(ctx context.Context, req AsyncRequest, reuseSlot bo
 		}
 	}()
 
-	opts := s.delegationStartOptions(persistent)
+	opts := s.delegationStartOptions(execCtx, persistent)
 	request := agent.Request{
 		ContextID: key.ContextID,
 		Message:   message.NewTextMessage(message.RoleUser, req.Request.Input),
@@ -947,15 +947,21 @@ func responseFromTurn(result *agent.Result, contextID string) Response {
 }
 
 // delegationStartOptions builds the session options for a delegated
-// subagent turn: questions to the user are refused (never block), and
-// non-persistent identities run the turn ephemeral so no session state or
-// run checkpoint is ever written.
-func (s *LocalService) delegationStartOptions(persistent bool) []session.StartOption {
+// subagent turn: questions to the user are refused (never block),
+// non-persistent identities run the turn ephemeral so no session state
+// or run checkpoint is ever written, and stream sinks are inherited
+// from the caller turn when the caller's stream policy is inheritable.
+// Async worker runs do not inherit here: the caller context does not
+// cross the backend queue, and the worker is not a live UI consumer.
+func (s *LocalService) delegationStartOptions(ctx context.Context, persistent bool) []session.StartOption {
 	options := []session.StartOption{
 		session.WithAskUserOverride(refuseSubagentAskUser),
 	}
 	if !persistent {
 		options = append(options, session.WithEphemeral())
+	}
+	if policy, ok := session.StreamPolicyFromContext(ctx); ok && policy.Inheritable && len(policy.Sinks) > 0 {
+		options = append(options, session.WithSinks(policy.Sinks...))
 	}
 	return options
 }

--- a/core/delegation/session_provider_test.go
+++ b/core/delegation/session_provider_test.go
@@ -905,6 +905,24 @@ func streamEngine(output string) agent.Engine {
 	})
 }
 
+// awaitStreamText waits until a stream delta carrying the given text
+// arrives. Raw/confirmed sinks may observe other run events first, so
+// assertions must scan rather than expect a specific first delta.
+func awaitStreamText(t *testing.T, received <-chan agent.StreamDeltaPayload, want string) {
+	t.Helper()
+	deadline := time.After(5 * time.Second)
+	for {
+		select {
+		case delta := <-received:
+			if part, ok := delta.Part.(message.TextPart); ok && part.Text == want {
+				return
+			}
+		case <-deadline:
+			t.Fatalf("stream delta with text %q never received", want)
+		}
+	}
+}
+
 func TestSyncDelegationInheritsCallerStreamSinks(t *testing.T) {
 	received := make(chan agent.StreamDeltaPayload, 8)
 	sink := agent.StreamSinkFunc(func(
@@ -930,15 +948,7 @@ func TestSyncDelegationInheritsCallerStreamSinks(t *testing.T) {
 	if response.Status != StatusSucceeded {
 		t.Fatalf("response status = %q, want succeeded", response.Status)
 	}
-	select {
-	case delta := <-received:
-		part, ok := delta.Part.(message.TextPart)
-		if !ok || part.Text != "progress" {
-			t.Fatalf("delta part = %#v, want text %q", delta.Part, "progress")
-		}
-	case <-time.After(5 * time.Second):
-		t.Fatal("inherited sink received no subagent stream delta")
-	}
+	awaitStreamText(t, received, "progress")
 }
 
 func TestSyncDelegationSkipsNonInheritableStreamPolicy(t *testing.T) {
@@ -966,9 +976,259 @@ func TestSyncDelegationSkipsNonInheritableStreamPolicy(t *testing.T) {
 	if response.Status != StatusSucceeded {
 		t.Fatalf("response status = %q, want succeeded", response.Status)
 	}
+	// Delegate returns only after the subagent turn finalizes, and
+	// finalize drains then detaches every attached sink — any delivery
+	// caused by a buggy attachment would already be queued. The select
+	// below is a bounded absence check on that flushed state, not a race.
 	select {
 	case delta := <-received:
 		t.Fatalf("non-inheritable policy still delivered delta: %#v", delta)
-	case <-time.After(300 * time.Millisecond):
+	case <-time.After(time.Second):
 	}
+}
+
+func TestInheritedSinkSpecsDowngradeAuthorityAndAck(t *testing.T) {
+	sink := agent.StreamSinkFunc(func(
+		context.Context, event.Envelope, agent.StreamDeltaPayload,
+	) error {
+		return nil
+	})
+	spec := session.SinkSpec{
+		ID:              "authority",
+		Sink:            sink,
+		QueueSize:       7,
+		DeliveryTimeout: time.Minute,
+		Visibility:      session.VisibilityConfirmed,
+		Authority:       session.AuthorityAuthoritative,
+		AckMode:         session.AckExplicit,
+		MaxUnacked:      3,
+	}
+	got := inheritedSinkSpecs([]session.SinkSpec{spec})
+	if len(got) != 1 {
+		t.Fatalf("inherited specs = %d, want 1", len(got))
+	}
+	inherited := got[0]
+	if inherited.Authority != session.AuthorityObserver {
+		t.Fatalf("inherited Authority = %q, want observer", inherited.Authority)
+	}
+	if inherited.AckMode != session.AckOnDelivery {
+		t.Fatalf("inherited AckMode = %q, want ack-on-delivery", inherited.AckMode)
+	}
+	if inherited.MaxUnacked != 0 {
+		t.Fatalf("inherited MaxUnacked = %d, want 0", inherited.MaxUnacked)
+	}
+	if inherited.ID != spec.ID || inherited.Sink == nil ||
+		inherited.Visibility != spec.Visibility ||
+		inherited.QueueSize != spec.QueueSize ||
+		inherited.DeliveryTimeout != spec.DeliveryTimeout {
+		t.Fatalf("inherited spec dropped fields: %+v", inherited)
+	}
+}
+
+func TestSyncDelegationInheritsAuthoritativeSinkAsObserver(t *testing.T) {
+	const deltas = 40
+	received := make(chan agent.StreamDeltaPayload, deltas*2)
+	sink := agent.StreamSinkFunc(func(
+		_ context.Context,
+		_ event.Envelope,
+		delta agent.StreamDeltaPayload,
+	) error {
+		received <- delta
+		return nil
+	})
+	engine := agent.EngineFunc(func(
+		ctx context.Context,
+		run agent.Run,
+		host agent.Host,
+		board *agent.Board,
+	) (*agent.Board, error) {
+		for range deltas {
+			if err := agent.EmitStreamPart(
+				ctx, host, run.RunID, "writer.node.work",
+				message.TextPart{Text: "p"}); err != nil {
+				return nil, err
+			}
+		}
+		board.AppendChannelMessage(agent.MainChannel,
+			message.NewTextMessage(message.RoleAssistant, "done"))
+		return board, nil
+	})
+	service, _ := newSessionPathService(t, engine, nil)
+	ctx := session.WithStreamPolicy(context.Background(), session.StreamPolicy{
+		Sinks: []session.SinkSpec{{
+			ID:         "authority",
+			Sink:       sink,
+			QueueSize:  64,
+			Visibility: session.VisibilityConfirmed,
+			Authority:  session.AuthorityAuthoritative,
+			AckMode:    session.AckExplicit,
+			MaxUnacked: 10,
+		}},
+		Inheritable: true,
+	})
+	response, err := service.Delegate(ctx, syncRequest("writer"))
+	if err != nil {
+		t.Fatalf("Delegate: %v", err)
+	}
+	if response.Status != StatusSucceeded {
+		t.Fatalf("response status = %q, want succeeded", response.Status)
+	}
+	// The spec carries an explicit MaxUnacked window of 10 with no ack
+	// source: an un-downgraded authoritative attachment would be detached
+	// with BudgetExceeded after ~10 deliveries, dropping the tail.
+	// Observer inheritance must deliver every delta. The queue (64) is
+	// sized so queue-full backpressure cannot mask the distinction.
+	deadline := time.After(5 * time.Second)
+	for i := 0; i < deltas; i++ {
+		select {
+		case delta := <-received:
+			if part, ok := delta.Part.(message.TextPart); !ok || part.Text != "p" {
+				t.Fatalf("delta part = %#v, want text %q", delta.Part, "p")
+			}
+		case <-deadline:
+			t.Fatalf("inherited sink received %d of %d subagent deltas", i, deltas)
+		}
+	}
+}
+
+func TestSyncDelegationPropagatesStreamSinksTransitively(t *testing.T) {
+	received := make(chan agent.StreamDeltaPayload, 8)
+	sink := agent.StreamSinkFunc(func(
+		_ context.Context,
+		_ event.Envelope,
+		delta agent.StreamDeltaPayload,
+	) error {
+		received <- delta
+		return nil
+	})
+	var service *LocalService
+	engine := agent.EngineFunc(func(
+		ctx context.Context,
+		run agent.Run,
+		host agent.Host,
+		board *agent.Board,
+	) (*agent.Board, error) {
+		switch run.AgentID {
+		case "writer":
+			// The writer is itself a delegated subagent; delegating from
+			// inside its engine exercises the full context chain instead
+			// of stamping the policy on the caller context directly.
+			response, err := service.Delegate(ctx, syncRequest("researcher"))
+			if err != nil {
+				return board, err
+			}
+			if response.Status != StatusSucceeded {
+				return board, errdefs.Internalf(
+					"nested delegate status = %q, want succeeded", response.Status)
+			}
+			board.AppendChannelMessage(agent.MainChannel,
+				message.NewTextMessage(message.RoleAssistant, "writer-done"))
+			return board, nil
+		case "researcher":
+			if err := agent.EmitStreamPart(
+				ctx, host, run.RunID, "researcher.node.work",
+				message.TextPart{Text: "grandchild"}); err != nil {
+				return nil, err
+			}
+			board.AppendChannelMessage(agent.MainChannel,
+				message.NewTextMessage(message.RoleAssistant, "researcher-done"))
+			return board, nil
+		default:
+			return board, errdefs.Internalf("unexpected agent %q", run.AgentID)
+		}
+	})
+	service, _ = newSessionPathService(t, engine, nil)
+	ctx := session.WithStreamPolicy(context.Background(), session.StreamPolicy{
+		Sinks: []session.SinkSpec{{
+			ID:   "caller",
+			Sink: sink,
+		}},
+		Inheritable: true,
+	})
+	response, err := service.Delegate(ctx, syncRequest("writer"))
+	if err != nil {
+		t.Fatalf("Delegate: %v", err)
+	}
+	if response.Status != StatusSucceeded {
+		t.Fatalf("response status = %q, want succeeded", response.Status)
+	}
+	awaitStreamText(t, received, "grandchild")
+}
+
+// resumeStreamEngine fails the first attempt after writing a checkpoint
+// and, on the resumed attempt, emits one stream delta before completing.
+type resumeStreamEngine struct {
+	mu       sync.Mutex
+	attempts int
+	store    *delegationCheckpointStore
+}
+
+func (e *resumeStreamEngine) Execute(
+	ctx context.Context,
+	run agent.Run,
+	host agent.Host,
+	board *agent.Board,
+) (*agent.Board, error) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	e.attempts++
+	if e.attempts == 1 {
+		if err := e.store.Save(ctx, agent.Checkpoint{
+			ExecID:            run.RunID,
+			Steps:             []string{"wave-1"},
+			Board:             board.Snapshot(),
+			Timestamp:         time.Now(),
+			OriginalStartedAt: time.Now(),
+			SpecVersion:       "v1",
+		}); err != nil {
+			return board, err
+		}
+		return board, errdefs.Internalf("first attempt fails")
+	}
+	if err := agent.EmitStreamPart(
+		ctx, host, run.RunID, "writer.node.work",
+		message.TextPart{Text: "resumed"}); err != nil {
+		return board, err
+	}
+	board.AppendChannelMessage(agent.MainChannel,
+		message.NewTextMessage(message.RoleAssistant, "done"))
+	return board, nil
+}
+
+func (*resumeStreamEngine) CanResume(agent.Checkpoint) error { return nil }
+
+func TestResumeInheritsStreamSinks(t *testing.T) {
+	store := newDelegationCheckpointStore()
+	engine := &resumeStreamEngine{store: store}
+	service, _ := newSessionPathService(t, engine,
+		&testSessionProvider{contextID: "resume-sink-ctx", persistent: true},
+		session.WithResume(true), session.WithCheckpointStore(store))
+	received := make(chan agent.StreamDeltaPayload, 8)
+	sink := agent.StreamSinkFunc(func(
+		_ context.Context,
+		_ event.Envelope,
+		delta agent.StreamDeltaPayload,
+	) error {
+		received <- delta
+		return nil
+	})
+	ctx := session.WithStreamPolicy(context.Background(), session.StreamPolicy{
+		Sinks: []session.SinkSpec{{
+			ID:   "caller",
+			Sink: sink,
+		}},
+		Inheritable: true,
+	})
+	first, err := service.Delegate(ctx, syncRequest("writer"))
+	if err != nil || first.Status != StatusFailed {
+		t.Fatalf("first = (%+v, %v), want failed", first, err)
+	}
+	second, err := service.Delegate(ctx, syncRequest("writer"))
+	if err != nil {
+		t.Fatalf("retry Delegate: %v", err)
+	}
+	if second.Status != StatusSucceeded {
+		t.Fatalf("retry status = %q, want succeeded", second.Status)
+	}
+	awaitStreamText(t, received, "resumed")
 }

--- a/core/delegation/session_provider_test.go
+++ b/core/delegation/session_provider_test.go
@@ -883,3 +883,92 @@ func TestRunAtSessionPathPersistentWritesState(t *testing.T) {
 		t.Fatal("persistent delegation wrote no checkpoints, want session state")
 	}
 }
+
+// streamEngine emits one stream delta on the run's canonical stream
+// subject before completing, so an attached sink has something to
+// observe.
+func streamEngine(output string) agent.Engine {
+	return agent.EngineFunc(func(
+		ctx context.Context,
+		run agent.Run,
+		host agent.Host,
+		board *agent.Board,
+	) (*agent.Board, error) {
+		if err := agent.EmitStreamPart(
+			ctx, host, run.RunID, "writer.node.work",
+			message.TextPart{Text: output}); err != nil {
+			return nil, err
+		}
+		board.AppendChannelMessage(agent.MainChannel,
+			message.NewTextMessage(message.RoleAssistant, output))
+		return board, nil
+	})
+}
+
+func TestSyncDelegationInheritsCallerStreamSinks(t *testing.T) {
+	received := make(chan agent.StreamDeltaPayload, 8)
+	sink := agent.StreamSinkFunc(func(
+		_ context.Context,
+		_ event.Envelope,
+		delta agent.StreamDeltaPayload,
+	) error {
+		received <- delta
+		return nil
+	})
+	service, _ := newSessionPathService(t, streamEngine("progress"), nil)
+	ctx := session.WithStreamPolicy(context.Background(), session.StreamPolicy{
+		Sinks: []session.SinkSpec{{
+			ID:   "caller",
+			Sink: sink,
+		}},
+		Inheritable: true,
+	})
+	response, err := service.Delegate(ctx, syncRequest("writer"))
+	if err != nil {
+		t.Fatalf("Delegate: %v", err)
+	}
+	if response.Status != StatusSucceeded {
+		t.Fatalf("response status = %q, want succeeded", response.Status)
+	}
+	select {
+	case delta := <-received:
+		part, ok := delta.Part.(message.TextPart)
+		if !ok || part.Text != "progress" {
+			t.Fatalf("delta part = %#v, want text %q", delta.Part, "progress")
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("inherited sink received no subagent stream delta")
+	}
+}
+
+func TestSyncDelegationSkipsNonInheritableStreamPolicy(t *testing.T) {
+	received := make(chan agent.StreamDeltaPayload, 8)
+	sink := agent.StreamSinkFunc(func(
+		_ context.Context,
+		_ event.Envelope,
+		delta agent.StreamDeltaPayload,
+	) error {
+		received <- delta
+		return nil
+	})
+	service, _ := newSessionPathService(t, streamEngine("progress"), nil)
+	ctx := session.WithStreamPolicy(context.Background(), session.StreamPolicy{
+		Sinks: []session.SinkSpec{{
+			ID:   "caller",
+			Sink: sink,
+		}},
+		Inheritable: false,
+	})
+	response, err := service.Delegate(ctx, syncRequest("writer"))
+	if err != nil {
+		t.Fatalf("Delegate: %v", err)
+	}
+	if response.Status != StatusSucceeded {
+		t.Fatalf("response status = %q, want succeeded", response.Status)
+	}
+	select {
+	case delta := <-received:
+		t.Fatalf("non-inheritable policy still delivered delta: %#v", delta)
+	case <-time.After(300 * time.Millisecond):
+	}
+}

--- a/core/runtime/session/contracts.go
+++ b/core/runtime/session/contracts.go
@@ -86,7 +86,11 @@ func DeliveryCursorFromEnvelope(env event.Envelope) (DeliveryCursor, error) {
 
 // SinkSpec describes one independently buffered stream attachment.
 type SinkSpec struct {
-	ID        string
+	ID string
+	// Sink receives stream deltas for this attachment. A Sink may be
+	// shared across sessions: session inheritance (see StreamPolicy)
+	// attaches the caller's sink to delegated subagent turns as well,
+	// so implementations must be safe for concurrent OnDelta calls.
 	Sink      agent.StreamSink
 	QueueSize int
 	// DeliveryTimeout bounds each Sink.OnDelta call. Zero uses the 30-second

--- a/core/runtime/session/session.go
+++ b/core/runtime/session/session.go
@@ -428,6 +428,16 @@ func (s *Session) startTurnLocked(
 	turn.resumeCtx = resumeCtx
 	turn.snapshot = snapshot
 	turn.askUserOverride = config.askUser
+	// Nested sessions started inside this turn (e.g. delegated subagents)
+	// inherit the turn's stream sinks, so the caller's stream policy
+	// follows the execution without explicit wiring. Both Start and
+	// Resume flow through here, and the subagent turn stamps its own
+	// (inherited) policy again, so nested delegations propagate
+	// transitively.
+	turn.runCtx = WithStreamPolicy(turn.runCtx, StreamPolicy{
+		Sinks:       config.sinks,
+		Inheritable: true,
+	})
 	instance, ok := deps.Resolver.Instance(s.key.AgentID)
 	if !ok {
 		turn.cancel()

--- a/core/runtime/session/stream_policy.go
+++ b/core/runtime/session/stream_policy.go
@@ -1,0 +1,34 @@
+package session
+
+import "context"
+
+// streamPolicyKey is the context key for a turn's inherited stream
+// policy.
+type streamPolicyKey struct{}
+
+// StreamPolicy describes how a turn's stream sinks are inherited by
+// sessions started within the turn's execution (for example delegated
+// subagent runs). Session starts stamp their attached sinks so nested
+// runs inherit the caller's stream without any explicit wiring.
+type StreamPolicy struct {
+	// Sinks are attached to every nested session started inside the
+	// turn when Inheritable is true.
+	Sinks []SinkSpec
+	// Inheritable reports whether nested sessions should inherit Sinks.
+	// Session starts stamp the policy with Inheritable=true; callers may
+	// stamp false to stop inheritance at a boundary.
+	Inheritable bool
+}
+
+// WithStreamPolicy returns a context that carries policy to nested
+// sessions started within the turn's execution.
+func WithStreamPolicy(ctx context.Context, policy StreamPolicy) context.Context {
+	return context.WithValue(ctx, streamPolicyKey{}, policy)
+}
+
+// StreamPolicyFromContext returns the nearest stream policy carried by
+// ctx, if any.
+func StreamPolicyFromContext(ctx context.Context) (StreamPolicy, bool) {
+	policy, ok := ctx.Value(streamPolicyKey{}).(StreamPolicy)
+	return policy, ok
+}

--- a/core/runtime/session/stream_policy.go
+++ b/core/runtime/session/stream_policy.go
@@ -10,9 +10,16 @@ type streamPolicyKey struct{}
 // sessions started within the turn's execution (for example delegated
 // subagent runs). Session starts stamp their attached sinks so nested
 // runs inherit the caller's stream without any explicit wiring.
+//
+// Inheritance shares the same Sink instance across sessions: a delegated
+// turn attaches the caller's sinks too, so a sink must be safe for
+// concurrent OnDelta calls. The delegation boundary downgrades inherited
+// specs to observers (no authority, no explicit acks), because the
+// subagent turn is never handed to the sink.
 type StreamPolicy struct {
 	// Sinks are attached to every nested session started inside the
-	// turn when Inheritable is true.
+	// turn when Inheritable is true. Delegation attaches them as
+	// observers.
 	Sinks []SinkSpec
 	// Inheritable reports whether nested sessions should inherit Sinks.
 	// Session starts stamp the policy with Inheritable=true; callers may

--- a/core/runtime/session/stream_policy_test.go
+++ b/core/runtime/session/stream_policy_test.go
@@ -1,0 +1,84 @@
+package session
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"github.com/GizClaw/flowcraft/core/agent"
+	"github.com/GizClaw/flowcraft/core/message"
+)
+
+func TestStreamPolicyContextRoundTrip(t *testing.T) {
+	policy := StreamPolicy{
+		Sinks:       []SinkSpec{{ID: "s1", Sink: discardSink{}}},
+		Inheritable: true,
+	}
+
+	ctx := WithStreamPolicy(context.Background(), policy)
+	got, ok := StreamPolicyFromContext(ctx)
+	if !ok {
+		t.Fatal("StreamPolicyFromContext: policy missing")
+	}
+	if !got.Inheritable || len(got.Sinks) != 1 || got.Sinks[0].ID != "s1" {
+		t.Fatalf("StreamPolicyFromContext = %+v, want %+v", got, policy)
+	}
+
+	if _, ok := StreamPolicyFromContext(context.Background()); ok {
+		t.Fatal("StreamPolicyFromContext reported a policy on a plain context")
+	}
+
+	// A nested stamp replaces the outer policy (nearest wins).
+	inner := StreamPolicy{Sinks: nil, Inheritable: false}
+	ctx = WithStreamPolicy(ctx, inner)
+	got, ok = StreamPolicyFromContext(ctx)
+	if !ok || got.Inheritable || len(got.Sinks) != 0 {
+		t.Fatalf("nested policy = %+v, %v; want Inheritable=false with no sinks", got, ok)
+	}
+}
+
+func TestStartStampsStreamPolicyIntoRunContext(t *testing.T) {
+	var mu sync.Mutex
+	var got StreamPolicy
+	engine := agent.EngineFunc(func(
+		ctx context.Context,
+		_ agent.Run,
+		_ agent.Host,
+		board *agent.Board,
+	) (*agent.Board, error) {
+		policy, ok := StreamPolicyFromContext(ctx)
+		if ok {
+			mu.Lock()
+			got = policy
+			mu.Unlock()
+		}
+		board.AppendChannelMessage(agent.MainChannel,
+			message.NewTextMessage(message.RoleAssistant, "done"))
+		return board, nil
+	})
+	_, sess, _, _ := newTurnSession(t, engine, turnHostFactory)
+	turn, err := sess.StartWithOptions(
+		context.Background(),
+		agent.Request{Message: message.NewTextMessage(message.RoleUser, "hi")},
+		WithSinks(SinkSpec{ID: "s1", Sink: discardSink{}}),
+	)
+	if err != nil {
+		t.Fatalf("StartWithOptions: %v", err)
+	}
+	result, err := turn.Wait(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Status != agent.StatusCompleted {
+		t.Fatalf("result status = %q, want completed", result.Status)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if !got.Inheritable {
+		t.Fatal("stamped policy Inheritable = false, want true")
+	}
+	if len(got.Sinks) != 1 || got.Sinks[0].ID != "s1" {
+		t.Fatalf("stamped sinks = %+v, want [s1]", got.Sinks)
+	}
+}

--- a/docs/guides/runtime.md
+++ b/docs/guides/runtime.md
@@ -150,6 +150,14 @@ result, err := turn.Wait(ctx)
 `SinkSpec` controls streaming delivery, visibility, authority, and queue
 size. `delivery_concurrency` bounds in-flight sink callbacks.
 
+Delegated subagent sessions inherit the caller turn's stream sinks: the
+turn execution context carries the caller's stream policy, and the
+delegation service attaches those sinks to subagent runs as observers
+(authority and explicit-ack semantics are downgraded because the sink has
+no handle to the subagent turn). An inherited sink may be invoked
+concurrently from multiple sessions and must be safe for concurrent
+`OnDelta` calls.
+
 ### DeleteSession
 
 `app.Sessions().DeleteSession(ctx, key)` removes one session's durable


### PR DESCRIPTION
Closes #431

## Summary

Delegated subagent turns run as first-class sessions through the session manager, but the delegation service started them without any stream sink. Subagent stream deltas (reasoning, tool calls, intermediate text) were dropped, so a sync `delegate` call blocked the caller with zero visible progress until the final response arrived.

This PR fixes that with context-based stream policy inheritance, so the subagent run naturally carries the caller turn's stream:

- **`core/runtime/session`**: new `StreamPolicy` context API (`WithStreamPolicy` / `StreamPolicyFromContext`). `startTurnLocked` stamps the turn's attached sinks into the turn execution context as an inheritable policy. Both `Start` and `Resume` flow through this path, and each subagent turn re-stamps its inherited policy, so nested delegations propagate transitively.
- **`core/delegation`**: `delegationStartOptions(ctx, persistent)` reads the caller stream policy from the execution context and forwards inheritable sinks via `session.WithSinks`. Default behavior (no policy / non-inheritable policy) is unchanged — delegated sessions stay sink-free.

Async worker runs intentionally do not inherit: the caller context does not cross the backend queue, and the worker is not a live UI consumer. Async activity visibility remains a separate follow-up.

## Tests

- `StreamPolicy` context round-trip and nearest-wins semantics
- Session start stamps its sinks into the run context (Start path)
- Sync delegation with an inheritable policy delivers subagent stream deltas to the inherited sink
- Non-inheritable policy is skipped (no sink attached)

## Verification

- `make ci` ✅
- `make lint` ✅
- `make release-check` ✅ (no pending releases, no changeset added)
- `git diff --check` ✅
- `go test -race` on new tests ✅