### PR TITLE
docs(core): document delegated stream inheritance and Realtime status

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ the core and depend on it, never the reverse.
 
 ### Unified inference runtime (`core/inference` + `driver/*`)
 
-- One runtime for Generate / Embed / Transcription / Realtime, with exact
+- One runtime for Generate / Embed / Transcription (Realtime reserved), with exact
   `ModelRef` addressing and compile-time capability checks.
 - Providers registered as factories: Anthropic, Azure, ByteDance, DeepSeek,
   Kimi, MiniMax, OpenAI, and Qwen.
@@ -200,7 +200,7 @@ pkg.go.dev. Topic guides live in [`docs/guides/`](docs/guides/):
   boundary, env / net / resources policy, runners (local / seatbelt /
   bwrap), decorators, and approval.
 - [Inference Runtime](docs/guides/inference.md) — unified Generate / Embed /
-  Transcription / Realtime: deployment config, routing, extensions,
+  Transcription (Realtime reserved): deployment config, routing, extensions,
   streaming, media intents, hot reload.
 - [Deployment Assembly](docs/guides/deploy.md) — `core/deploy`: one YAML
   document + one `Build` call to wire shared resources, named agents,

--- a/docs/guides/delegation.md
+++ b/docs/guides/delegation.md
@@ -107,6 +107,22 @@ checkpoint board. Preparers with side effects (uploads, live-progress
 resets) must be idempotent or detect the replay via `agent.ResumeContext`
 / `Run.ResumeFrom` and skip.
 
+## Stream inheritance
+
+Delegated subagent turns inherit the caller turn's stream sinks: the turn
+execution context carries the caller's stream policy, and the delegation
+service attaches those sinks to the subagent session as observers.
+Authority and explicit-ack semantics are downgraded on inheritance — the
+subagent turn is never handed to the inherited sink, so it cannot fulfil
+authoritative/explicit-ack obligations (an unacked window would otherwise
+detach the attachment mid-run). Visibility is preserved.
+
+An inherited sink may be invoked concurrently from multiple sessions
+(the caller turn plus parallel subagents) and must be safe for concurrent
+`OnDelta` calls. Async delegation does not inherit: the caller context
+does not cross the backend queue, and the worker is not a live UI
+consumer.
+
 See [runtime.md](runtime.md) for `WithResultHostFactory` and reload, and
 [tool.md](tool.md) for tool sources.
 

--- a/docs/guides/inference.md
+++ b/docs/guides/inference.md
@@ -5,7 +5,9 @@ title: Inference Runtime
 # Inference Runtime Guide
 
 `core/inference` is the unified, instance-owned runtime for model inference.
-All workloads are one of `Generate`, `Embed`, `Transcription`, or `Realtime`.
+Active workloads are `Generate`, `Embed`, and `Transcription`. `Realtime`
+is reserved in the operation enum and field ledger but has no request or
+session surface yet — it lands in a later milestone.
 
 ## Exact addressing
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -41,7 +41,7 @@ retrieval, runtime orchestration, and voice. Source on
 ### Assembly
 
 - [Inference Runtime](guides/inference.md) — unified Generate / Embed /
-  Transcription / Realtime: deployment config, routing, extensions,
+  Transcription (Realtime reserved): deployment config, routing, extensions,
   streaming, media intents, hot reload.
 - [Deployment Assembly](guides/deploy.md) — `core/deploy`: one YAML
   document + one `Build` call to wire shared resources, named agents,


### PR DESCRIPTION
Doc gap follow-up after the #434 merge: a docs/guides + skills consistency audit found two gaps, both fixed here.

## Changes

- **docs/guides/delegation.md** — new "Stream inheritance" section: delegated subagent turns inherit the caller turn's stream sinks as observers (authority / explicit-ack downgraded because the sink has no handle to the subagent turn), inherited sinks must be safe for concurrent `OnDelta` calls, and async delegation does not inherit (caller context does not cross the backend queue). Links to runtime.md.
- **docs/guides/inference.md / docs/index.md / README.md** — `Realtime` is reserved in the operation enum and field ledger but has no request/session surface yet; the guides no longer present it as an active workload.

## Scope

Docs only; no code changes. `git diff --check` passes. The `skills/flowcraft-config` skill is intentionally pinned to core v0.1.28 and documents that release, so it is unaffected by this post-release change (its pin bumps on the next core release).