### PR TITLE
chore(release): add core v0.1.29 changeset

### DIFF
--- a/.release/core-v0.1.29.json
+++ b/.release/core-v0.1.29.json
@@ -1,0 +1,9 @@
+{
+  "summary": "fix(core): inherit caller stream sinks into delegated subagent sessions — session turns now stamp their attached stream sinks as an inheritable StreamPolicy on the run context (new session.StreamPolicy/WithStreamPolicy/StreamPolicyFromContext, with SinkSpec documenting that a shared sink must tolerate concurrent OnDelta calls), and delegation attaches the caller's sinks to subagent turns when the policy is inheritable; inherited specs are downgraded to observers with ack-on-delivery and no unacked window because the subagent turn is never exposed to the inherited sink (an unacked authoritative attachment would otherwise be detached with BudgetExceeded once its window fills), while visibility, queue size, and delivery timeout are preserved, nested delegations propagate transitively, non-inheritable policies and async worker runs (whose caller context does not cross the backend queue) are not inherited, and tests cover sync delegation delivery, the non-inheritable skip, observer downgrade field preservation, and a 40-delta authoritative sink staying attached",
+  "releases": [
+    {
+      "module": "core",
+      "bump": "patch"
+    }
+  ]
+}


### PR DESCRIPTION
## What

Adds the immutable `.release/core-v0.1.29.json` changeset for the next core release.

## Why

Since tag `core/v0.1.28`, the only core-module change shipped is #434 (inherit caller stream sinks into delegated subagent sessions, downgraded to observers). A patch changeset is required so the `Release modules` workflow tags `core/v0.1.29`.

## Validation

- `make release-check` — `changesets valid`
- `make release-plan` — `core: 0.1.28 -> 0.1.29 (patch), tag core/v0.1.29`