### PR TITLE
feat(core/delegation): steer models toward async for long-running work

### DIFF
--- a/core/delegation/tool/delegation.go
+++ b/core/delegation/tool/delegation.go
@@ -83,7 +83,7 @@ func NewTargets(directory sdkdelegation.Directory) tool.Tool {
 
 func (t delegateTool) Definition() message.ToolDefinition {
 	targets := t.targets()
-	description := "Delegate work to another available target. Supports synchronous results, interaction handoff, and asynchronous execution."
+	description := "Delegate work to another available target. Supports synchronous results, interaction handoff, and asynchronous execution. Prefer async mode for long-running or background work so the calling turn is not blocked."
 	if len(targets) > 0 {
 		var listed strings.Builder
 		listed.WriteString(" Available targets: ")
@@ -309,7 +309,7 @@ func definition(name, description string, targets []sdkdelegation.Target) messag
 		name,
 		description,
 		message.ToolEnumProperty(
-			"mode", "string", "Delegation lifecycle mode.",
+			"mode", "string", "Delegation lifecycle mode: sync blocks the caller's turn until the delegated work finishes and returns its terminal response; async admits the work immediately and returns a delegation_id to poll with delegation_status. Prefer async for long-running or background work.",
 			string(sdkdelegation.ModeSync),
 			string(sdkdelegation.ModeAsync)),
 		targetProperty,

--- a/core/delegation/tool/delegation_test.go
+++ b/core/delegation/tool/delegation_test.go
@@ -101,6 +101,34 @@ func TestDelegateDefinitionBoundsDirectoryLookup(t *testing.T) {
 	}
 }
 
+func TestDelegateDefinitionGuidesAsyncForLongRunningWork(t *testing.T) {
+	delegate := tooldelegation.NewDelegate(&fakeDirectory{
+		targets: []sdkdelegation.Target{{ID: "billing"}},
+	})
+	definition := delegate.Definition()
+	var schema struct {
+		Properties map[string]struct {
+			Description string `json:"description"`
+		} `json:"properties"`
+	}
+	if err := json.Unmarshal(definition.InputSchema, &schema); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(definition.Description, "Prefer async") {
+		t.Fatalf("tool description = %q, want async guidance", definition.Description)
+	}
+	modeDescription := schema.Properties["mode"].Description
+	for _, want := range []string{
+		"sync blocks",
+		"delegation_status",
+		"Prefer async",
+	} {
+		if !strings.Contains(modeDescription, want) {
+			t.Fatalf("mode description = %q, want substring %q", modeDescription, want)
+		}
+	}
+}
+
 func TestDelegateExecuteModesAndNoteMetadata(t *testing.T) {
 	service := &fakeService{delegate: func(req sdkdelegation.Request) (sdkdelegation.Response, error) {
 		switch req.Mode {


### PR DESCRIPTION
Closes #438

## Summary

The `delegate` tool schema gave models no guidance about choosing between sync and async mode, so models had no signal that `mode: sync` blocks the caller's turn until the delegated work fully completes.

- Tool description now ends with a one-liner steering long-running or background work toward async.
- `mode` property description now spells out the lifecycle semantics: sync blocks until the terminal response; async admits immediately and returns a `delegation_id` to poll with `delegation_status`, with an explicit preference for async on long-running work.

## Tests

- New `TestDelegateDefinitionGuidesAsyncForLongRunningWork` asserts the tool and mode descriptions carry the async guidance.

## Verification

- `make ci` ✅
- `make lint` ✅
- `make release-check` ✅ (no pending releases, no changeset added)
- `git diff --check` ✅