### PR TITLE
feat(core): stamp delegation run lineage on stream envelopes

### DIFF
--- a/core/agent/execute.go
+++ b/core/agent/execute.go
@@ -110,6 +110,9 @@ func Execute(
 		TaskID:         req.TaskID,
 		ConversationID: req.ContextID,
 	}
+	if id.ParentRunID == "" {
+		id.ParentRunID = req.ParentRunID
+	}
 
 	host := rc.host
 	if host == nil {
@@ -183,10 +186,12 @@ func Execute(
 		// / hosts can correlate retries in their telemetry. RunID
 		// stays constant across attempts so observers / dashboards
 		// see one logical run with N attempts, not N separate runs.
-		attemptAttrs := maps.Clone(rc.attributes)
-		if attemptAttrs == nil {
-			attemptAttrs = map[string]string{}
-		}
+		attemptAttrs := make(map[string]string, len(req.Attributes)+len(rc.attributes)+1)
+		maps.Copy(attemptAttrs, req.Attributes)
+		// Explicit WithAttributes options win per key over Request
+		// attributes; the attempt index is engine-owned and always
+		// wins over both.
+		maps.Copy(attemptAttrs, rc.attributes)
 		attemptAttrs["agent.attempt"] = itoa(attempt)
 		engRun := Run{
 			Identity:      id,

--- a/core/agent/execute_request.go
+++ b/core/agent/execute_request.go
@@ -33,6 +33,18 @@ type Request struct {
 	// stylistic consistency.
 	RunID string `json:"runId,omitempty"`
 
+	// ParentRunID identifies the parent run when this turn was
+	// dispatched by another agent (multi-agent call chains). Empty for
+	// top-level runs. WithParentRunID wins when both are supplied.
+	// Not part of the A2A wire schema — internal correlation key.
+	ParentRunID string `json:"parentRunId,omitempty"`
+
+	// Attributes carries host-supplied metadata for this turn that
+	// should flow into Run.Attributes (and from there into telemetry
+	// spans and event headers): tenant id, feature flags, delegation
+	// lineage, ... WithAttributes wins per key on conflict.
+	Attributes map[string]string `json:"attributes,omitempty"`
+
 	// Message is the user's turn input (text, parts, attachments).
 	Message message.Message `json:"message"`
 

--- a/core/agent/execute_test.go
+++ b/core/agent/execute_test.go
@@ -1593,6 +1593,79 @@ func TestRun_WithParentRunID_EmptyIsNoop(t *testing.T) {
 	}
 }
 
+// TestRun_RequestParentRunID_PropagatesToEngineRun verifies the
+// Request-level lineage slot: the runtime session path assembles its
+// own ExecuteOptions, so delegated subagents must be able to carry the
+// parent run id on agent.Request instead of a per-call option.
+func TestRun_RequestParentRunID_PropagatesToEngineRun(t *testing.T) {
+	var observed string
+	eng := agent.EngineFunc(func(_ context.Context, run agent.Run, _ agent.Host, b *agent.Board) (*agent.Board, error) {
+		observed = run.ParentRunID
+		b.AppendChannelMessage(agent.MainChannel,
+			message.NewTextMessage(message.RoleAssistant, "ok"))
+		return b, nil
+	})
+
+	req := newReq("hi")
+	req.ParentRunID = "run-parent-request"
+	if _, err := agent.Execute(context.Background(), agent.Agent{ID: "child"}, eng, req); err != nil {
+		t.Fatalf("agent.Run: %v", err)
+	}
+	if observed != "run-parent-request" {
+		t.Fatalf("Run.ParentRunID = %q, want %q", observed, "run-parent-request")
+	}
+}
+
+// TestRun_RequestParentRunID_OptionWins documents precedence: an
+// explicit WithParentRunID option wins over Request.ParentRunID.
+func TestRun_RequestParentRunID_OptionWins(t *testing.T) {
+	var observed string
+	eng := agent.EngineFunc(func(_ context.Context, run agent.Run, _ agent.Host, b *agent.Board) (*agent.Board, error) {
+		observed = run.ParentRunID
+		return b, nil
+	})
+
+	req := newReq("hi")
+	req.ParentRunID = "run-parent-request"
+	if _, err := agent.Execute(context.Background(), agent.Agent{ID: "child"}, eng, req,
+		agent.WithParentRunID("run-parent-option")); err != nil {
+		t.Fatalf("agent.Run: %v", err)
+	}
+	if observed != "run-parent-option" {
+		t.Fatalf("Run.ParentRunID = %q, want option value", observed)
+	}
+}
+
+// TestRun_RequestAttributes_PropagateAndOptionWins verifies the
+// Request-level attributes slot merges into Run.Attributes and that an
+// explicit WithAttributes option wins per key.
+func TestRun_RequestAttributes_PropagateAndOptionWins(t *testing.T) {
+	var got agent.Run
+	eng := agent.EngineFunc(func(_ context.Context, run agent.Run, _ agent.Host, b *agent.Board) (*agent.Board, error) {
+		got = run
+		return b, nil
+	})
+
+	req := newReq("hi")
+	req.Attributes = map[string]string{
+		telemetry.AttrToolCallID: "call-from-request",
+		"tenant":                 "request",
+	}
+	if _, err := agent.Execute(context.Background(), agent.Agent{ID: "a"}, eng, req,
+		agent.WithAttributes(map[string]string{"tenant": "option"})); err != nil {
+		t.Fatalf("agent.Run: %v", err)
+	}
+	if got.Attribute(telemetry.AttrToolCallID) != "call-from-request" {
+		t.Fatalf("Run tool.call_id = %q, want request value", got.Attribute(telemetry.AttrToolCallID))
+	}
+	if got.Attribute("tenant") != "option" {
+		t.Fatalf("Run tenant = %q, want option value", got.Attribute("tenant"))
+	}
+	if got.Attribute("agent.attempt") != "1" {
+		t.Fatalf("Run agent.attempt = %q, want 1", got.Attribute("agent.attempt"))
+	}
+}
+
 // TestRun_WithArtifactChannels_HarvestsRegisteredChannels is the
 // regression for contract-audit #6. Result.Artifacts had been
 // promised since v0.1 ("engines store them in a board channel;

--- a/core/agent/stream.go
+++ b/core/agent/stream.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/GizClaw/flowcraft/core/event"
 	"github.com/GizClaw/flowcraft/core/message"
+	"github.com/GizClaw/flowcraft/core/telemetry"
 )
 
 // ---------- StreamDelta emit ----------
@@ -101,6 +102,20 @@ func EmitStreamDelta(ctx context.Context, pub Publisher, runID, stepActor string
 	}
 	if nodeID != "" {
 		env.SetNodeID(nodeID)
+	}
+	// Lineage projection: when the ambient run identity carries a
+	// parent run or a creating tool call (e.g. a delegated subagent
+	// started by a delegate tool call), stamp them onto the envelope
+	// so consumers can build the run tree without a separate join.
+	// Outside an engine run the ambient identity is absent and both
+	// headers are simply skipped.
+	if info, ok := RunInfoFromContext(ctx); ok {
+		if info.ParentRunID != "" {
+			env.SetParentRunID(info.ParentRunID)
+		}
+		if callID := info.Attribute(telemetry.AttrToolCallID); callID != "" {
+			env.SetToolCallID(callID)
+		}
 	}
 	return pub.Publish(ctx, env)
 }

--- a/core/agent/stream_internal_test.go
+++ b/core/agent/stream_internal_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/GizClaw/flowcraft/core/event"
 	"github.com/GizClaw/flowcraft/core/message"
 	"github.com/GizClaw/flowcraft/core/message/media"
+	"github.com/GizClaw/flowcraft/core/telemetry"
 )
 
 // capturePublisher records every envelope it receives; tests inspect the
@@ -59,6 +60,46 @@ func TestEmitStreamPart_HappyPath(t *testing.T) {
 	text, ok := p.Part.(message.TextPart)
 	if !ok || text.Text != "hello" {
 		t.Fatalf("Part = %#v, want TextPart hello", p.Part)
+	}
+}
+
+// TestEmitStreamDelta_StampsLineageFromAmbientRunInfo verifies the
+// SDK path projects run lineage (parent run id + creating tool call
+// id) onto stream envelopes from the ambient RunInfo, and skips both
+// headers when the context carries no run identity.
+func TestEmitStreamDelta_StampsLineageFromAmbientRunInfo(t *testing.T) {
+	t.Parallel()
+	pub := &capturePublisher{}
+	ctx := WithRunInfo(context.Background(), RunInfo{
+		Identity: Identity{
+			AgentID:     "child",
+			RunID:       "run-child",
+			ParentRunID: "run-parent",
+		},
+		Attributes: map[string]string{telemetry.AttrToolCallID: "call-9"},
+	})
+	if err := EmitStreamPart(ctx, pub, "run-child", "child.node.work",
+		message.TextPart{Text: "x"}); err != nil {
+		t.Fatalf("EmitStreamPart: %v", err)
+	}
+	env := pub.got[0]
+	if got := env.Headers[event.HeaderParentRunID]; got != "run-parent" {
+		t.Errorf("HeaderParentRunID = %q, want run-parent", got)
+	}
+	if got := env.Headers[event.HeaderToolCallID]; got != "call-9" {
+		t.Errorf("HeaderToolCallID = %q, want call-9", got)
+	}
+
+	pub.got = nil
+	if err := EmitStreamPart(context.Background(), pub, "run-child", "child.node.work",
+		message.TextPart{Text: "x"}); err != nil {
+		t.Fatalf("EmitStreamPart: %v", err)
+	}
+	if _, ok := pub.got[0].Headers[event.HeaderParentRunID]; ok {
+		t.Error("HeaderParentRunID stamped without ambient RunInfo")
+	}
+	if _, ok := pub.got[0].Headers[event.HeaderToolCallID]; ok {
+		t.Error("HeaderToolCallID stamped without ambient RunInfo")
 	}
 }
 

--- a/core/delegation/service.go
+++ b/core/delegation/service.go
@@ -17,6 +17,7 @@ import (
 	"github.com/GizClaw/flowcraft/core/message"
 	"github.com/GizClaw/flowcraft/core/runtime/session"
 	"github.com/GizClaw/flowcraft/core/telemetry"
+	"github.com/GizClaw/flowcraft/core/tool"
 	otellog "go.opentelemetry.io/otel/log"
 )
 
@@ -750,10 +751,13 @@ func (s *LocalService) runAt(ctx context.Context, req AsyncRequest, reuseSlot bo
 	}()
 
 	opts := s.delegationStartOptions(execCtx, persistent)
+	parentRunID, lineageAttrs := lineageFromContext(execCtx)
 	request := agent.Request{
-		ContextID: key.ContextID,
-		Message:   message.NewTextMessage(message.RoleUser, req.Request.Input),
-		Inputs:    metadataInputs(req),
+		ContextID:   key.ContextID,
+		Message:     message.NewTextMessage(message.RoleUser, req.Request.Input),
+		Inputs:      metadataInputs(req),
+		ParentRunID: parentRunID,
+		Attributes:  lineageAttrs,
 	}
 
 	// Resume path: a persistent session retried with the identical
@@ -834,8 +838,11 @@ func (s *LocalService) runAtLegacy(
 		}
 	}
 
+	parentRunID, lineageAttrs := lineageFromContext(execCtx)
 	agentRequest := agent.Request{
-		Message: message.NewTextMessage(message.RoleUser, req.Request.Input),
+		Message:     message.NewTextMessage(message.RoleUser, req.Request.Input),
+		ParentRunID: parentRunID,
+		Attributes:  lineageAttrs,
 	}
 	if hasKey {
 		agentRequest.ContextID = key.ContextID
@@ -858,6 +865,25 @@ func (s *LocalService) runAtLegacy(
 		return Response{}, err
 	}
 	return responseFromAgent(result), nil
+}
+
+// lineageFromContext derives the run lineage for a delegated subagent
+// from the caller's ambient execution context: the caller's run id
+// (agent.RunInfo, stamped by the graph engine at the node boundary)
+// and the id of the delegate tool call that started this delegation
+// (tool.CallIDFromContext, stamped by the tool executor). Either may
+// be absent — a tool executed outside an engine run has no ambient
+// RunInfo, and direct service calls carry no tool call id — in which
+// case the corresponding lineage slot stays empty and the subagent
+// runs exactly as it does today.
+func lineageFromContext(ctx context.Context) (parentRunID string, attrs map[string]string) {
+	if info, ok := agent.RunInfoFromContext(ctx); ok {
+		parentRunID = info.RunID
+	}
+	if callID, ok := tool.CallIDFromContext(ctx); ok {
+		attrs = map[string]string{telemetry.AttrToolCallID: callID}
+	}
+	return parentRunID, attrs
 }
 
 func (s *LocalService) begin() error {

--- a/core/delegation/session_provider_test.go
+++ b/core/delegation/session_provider_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/GizClaw/flowcraft/core/message"
 	"github.com/GizClaw/flowcraft/core/runtime/session"
 	"github.com/GizClaw/flowcraft/core/telemetry"
+	"github.com/GizClaw/flowcraft/core/tool"
 	logglobal "go.opentelemetry.io/otel/log/global"
 	sdklog "go.opentelemetry.io/otel/sdk/log"
 )
@@ -949,6 +950,89 @@ func TestSyncDelegationInheritsCallerStreamSinks(t *testing.T) {
 		t.Fatalf("response status = %q, want succeeded", response.Status)
 	}
 	awaitStreamText(t, received, "progress")
+}
+
+// TestSyncDelegationStampsLineageOnStreamEnvelopes verifies the full
+// sync lineage chain: the service derives the caller run id and the
+// delegate call id from the ambient execution context, stamps them
+// onto the subagent run's identity, and the subagent's stream
+// envelopes carry parent_run_id + tool_call_id so consumers can build
+// the run tree without a separate join.
+func TestSyncDelegationStampsLineageOnStreamEnvelopes(t *testing.T) {
+	received := make(chan event.Envelope, 8)
+	sink := agent.StreamSinkFunc(func(
+		_ context.Context,
+		env event.Envelope,
+		_ agent.StreamDeltaPayload,
+	) error {
+		received <- env
+		return nil
+	})
+	var subagentRun agent.Run
+	engine := agent.EngineFunc(func(
+		ctx context.Context,
+		run agent.Run,
+		host agent.Host,
+		board *agent.Board,
+	) (*agent.Board, error) {
+		subagentRun = run
+		// The graph engine stamps ambient RunInfo at the node
+		// boundary; mirror that so the SDK stream helper projects
+		// lineage onto the envelope like a real deployment.
+		ctx = agent.WithRunInfo(ctx, run.Info())
+		if err := agent.EmitStreamPart(
+			ctx, host, run.RunID, "writer.node.work",
+			message.TextPart{Text: "progress"}); err != nil {
+			return nil, err
+		}
+		board.AppendChannelMessage(agent.MainChannel,
+			message.NewTextMessage(message.RoleAssistant, "done"))
+		return board, nil
+	})
+	service, _ := newSessionPathService(t, engine, nil)
+	ctx := session.WithStreamPolicy(context.Background(), session.StreamPolicy{
+		Sinks: []session.SinkSpec{{
+			ID:   "caller",
+			Sink: sink,
+		}},
+		Inheritable: true,
+	})
+	ctx = agent.WithRunInfo(ctx, agent.RunInfo{
+		Identity: agent.Identity{AgentID: "caller-agent", RunID: "run-caller"},
+	})
+	ctx = tool.WithCallID(ctx, "call-delegate-1")
+	response, err := service.Delegate(ctx, syncRequest("writer"))
+	if err != nil {
+		t.Fatalf("Delegate: %v", err)
+	}
+	if response.Status != StatusSucceeded {
+		t.Fatalf("response status = %q, want succeeded", response.Status)
+	}
+	if subagentRun.ParentRunID != "run-caller" {
+		t.Fatalf("subagent Run.ParentRunID = %q, want run-caller", subagentRun.ParentRunID)
+	}
+	if subagentRun.Attribute(telemetry.AttrToolCallID) != "call-delegate-1" {
+		t.Fatalf("subagent tool.call_id = %q, want call-delegate-1",
+			subagentRun.Attribute(telemetry.AttrToolCallID))
+	}
+	deadline := time.After(5 * time.Second)
+	for {
+		select {
+		case env := <-received:
+			if env.ParentRunID() != "run-caller" {
+				continue
+			}
+			if env.RunID() != subagentRun.RunID {
+				t.Fatalf("envelope run_id = %q, want %q", env.RunID(), subagentRun.RunID)
+			}
+			if env.ToolCallID() != "call-delegate-1" {
+				t.Fatalf("envelope tool_call_id = %q, want call-delegate-1", env.ToolCallID())
+			}
+			return
+		case <-deadline:
+			t.Fatal("lineage-stamped stream envelope never received")
+		}
+	}
 }
 
 func TestSyncDelegationSkipsNonInheritableStreamPolicy(t *testing.T) {

--- a/core/event/envelope.go
+++ b/core/event/envelope.go
@@ -40,6 +40,11 @@ const (
 	HeaderRunID  = "run_id"
 	HeaderNodeID = "node_id"
 
+	// HeaderParentRunID identifies the run that spawned the run this
+	// envelope belongs to (multi-agent call chains / delegation).
+	// Absent on envelopes for top-level runs.
+	HeaderParentRunID = "parent_run_id"
+
 	// HeaderAgentID identifies the agent (core/agent.Agent.ID) that
 	// produced this envelope — i.e. the executor identity in
 	// engine-neutral terms. The producer end is core/agent.Run, which
@@ -48,6 +53,11 @@ const (
 	// header via SetAgentID. Consumers that need to fan-in / filter
 	// by "which agent did this" subscribe on this dimension.
 	HeaderAgentID = "agent_id"
+
+	// HeaderToolCallID identifies the tool call (message.ToolCall.ID)
+	// that created the run this envelope belongs to, when the run was
+	// spawned by a tool (e.g. a delegate tool starting a subagent).
+	HeaderToolCallID = "tool_call_id"
 
 	HeaderGraphID = "graph_id"
 	HeaderTenant  = "tenant"
@@ -149,6 +159,18 @@ func (e *Envelope) SetRunID(id string) { e.SetHeader(HeaderRunID, id) }
 
 // RunID returns the value of the well-known run_id header.
 func (e Envelope) RunID() string { return e.Header(HeaderRunID) }
+
+// SetParentRunID is a typed shorthand for SetHeader(HeaderParentRunID, id).
+func (e *Envelope) SetParentRunID(id string) { e.SetHeader(HeaderParentRunID, id) }
+
+// ParentRunID returns the value of the well-known parent_run_id header.
+func (e Envelope) ParentRunID() string { return e.Header(HeaderParentRunID) }
+
+// SetToolCallID is a typed shorthand for SetHeader(HeaderToolCallID, id).
+func (e *Envelope) SetToolCallID(id string) { e.SetHeader(HeaderToolCallID, id) }
+
+// ToolCallID returns the value of the well-known tool_call_id header.
+func (e Envelope) ToolCallID() string { return e.Header(HeaderToolCallID) }
 
 // SetNodeID is a typed shorthand for SetHeader(HeaderNodeID, id).
 func (e *Envelope) SetNodeID(id string) { e.SetHeader(HeaderNodeID, id) }

--- a/core/event/envelope_test.go
+++ b/core/event/envelope_test.go
@@ -70,17 +70,20 @@ func TestNewEnvelope_RejectsInvalidSubject(t *testing.T) {
 func TestEnvelope_HeadersHelpers(t *testing.T) {
 	var env Envelope
 	env.SetRunID("r1")
+	env.SetParentRunID("r0")
+	env.SetToolCallID("c1")
 	env.SetNodeID("n1")
 	env.SetAgentID("a1")
 	env.SetGraphID("g1")
 	env.SetTenant("t1")
 
-	if env.RunID() != "r1" || env.NodeID() != "n1" || env.AgentID() != "a1" || env.GraphID() != "g1" || env.Tenant() != "t1" {
+	if env.RunID() != "r1" || env.ParentRunID() != "r0" || env.ToolCallID() != "c1" ||
+		env.NodeID() != "n1" || env.AgentID() != "a1" || env.GraphID() != "g1" || env.Tenant() != "t1" {
 		t.Fatalf("typed accessors disagree: %+v", env.Headers)
 	}
 	// Zero envelope returns "" without panic.
 	var zero Envelope
-	if zero.RunID() != "" || zero.NodeID() != "" {
+	if zero.RunID() != "" || zero.ParentRunID() != "" || zero.ToolCallID() != "" || zero.NodeID() != "" {
 		t.Fatal("zero envelope should return empty strings")
 	}
 }

--- a/core/graph/subjects.go
+++ b/core/graph/subjects.go
@@ -6,6 +6,7 @@ import (
 	"github.com/GizClaw/flowcraft/core/agent"
 	"github.com/GizClaw/flowcraft/core/errdefs"
 	"github.com/GizClaw/flowcraft/core/event"
+	"github.com/GizClaw/flowcraft/core/telemetry"
 )
 
 // stepActorFor maps an agent and node id to its step actor — the middle
@@ -50,6 +51,7 @@ func publishRunEvent(ctx context.Context, host agent.Host, g *Graph, run agent.R
 	env.SetGraphID(g.name)
 	env.SetAgentID(run.AgentID)
 	env.SetRunID(run.RunID)
+	stampLineage(&env, run.ParentRunID, run.Attribute(telemetry.AttrToolCallID))
 	if err := host.Publish(ctx, env); err != nil {
 		recordPublishError(ctx, "run", run.Info(), "")
 		return err
@@ -121,6 +123,7 @@ func publishStep(ctx context.Context, host agent.Host, subject event.Subject, in
 	env.SetGraphID(payload.Graph)
 	env.SetAgentID(info.AgentID)
 	env.SetRunID(info.RunID)
+	stampLineage(&env, info.ParentRunID, info.Attribute(telemetry.AttrToolCallID))
 	if err := host.Publish(ctx, env); err != nil {
 		recordPublishError(ctx, "step", info, payload.NodeID)
 	}
@@ -162,6 +165,7 @@ func publishParallelWave(ctx context.Context, host agent.Host, g *Graph, info ag
 	env.SetGraphID(payload.Graph)
 	env.SetAgentID(info.AgentID)
 	env.SetRunID(info.RunID)
+	stampLineage(&env, info.ParentRunID, info.Attribute(telemetry.AttrToolCallID))
 	if err := host.Publish(ctx, env); err != nil {
 		recordPublishError(ctx, "parallel_wave", info, payload.ForkID)
 	}
@@ -187,7 +191,21 @@ func publishStreamDelta(ctx context.Context, host agent.Host, info agent.RunInfo
 	env.SetGraphID(graphID)
 	env.SetAgentID(info.AgentID)
 	env.SetRunID(info.RunID)
+	stampLineage(&env, info.ParentRunID, info.Attribute(telemetry.AttrToolCallID))
 	return host.Publish(ctx, env)
+}
+
+// stampLineage projects run lineage onto a freshly minted envelope:
+// the parent run id (when this run was spawned by another run) and
+// the creating tool call id (when this run was spawned by a tool).
+// Empty values are skipped so top-level runs stay header-free.
+func stampLineage(env *event.Envelope, parentRunID, toolCallID string) {
+	if parentRunID != "" {
+		env.SetParentRunID(parentRunID)
+	}
+	if toolCallID != "" {
+		env.SetToolCallID(toolCallID)
+	}
 }
 
 // publishBranchDelta emits a parallel branch accept/cancel stream

--- a/core/graph/subjects_test.go
+++ b/core/graph/subjects_test.go
@@ -7,6 +7,8 @@ import (
 
 	"github.com/GizClaw/flowcraft/core/agent"
 	"github.com/GizClaw/flowcraft/core/errdefs"
+	"github.com/GizClaw/flowcraft/core/message"
+	"github.com/GizClaw/flowcraft/core/telemetry"
 )
 
 func TestStepActorForIncludesAgentID(t *testing.T) {
@@ -58,6 +60,8 @@ func TestRunErrorPayloadCarriesRequestID(t *testing.T) {
 	host := &publishHost{}
 	g := &Graph{name: "g"}
 	run := testRun()
+	run.ParentRunID = "run-parent"
+	run.Attributes = map[string]string{telemetry.AttrToolCallID: "call-5"}
 	runErr := errdefs.WithRequestID(
 		errdefs.Validation(errors.New("boom")), "req-ui-2")
 
@@ -77,5 +81,66 @@ func TestRunErrorPayloadCarriesRequestID(t *testing.T) {
 	}
 	if payload.Error != "boom" || payload.RequestID != "req-ui-2" {
 		t.Fatalf("payload = %+v", payload)
+	}
+	if host.envs[0].ParentRunID() != "run-parent" || host.envs[0].ToolCallID() != "call-5" {
+		t.Fatalf("run envelope lineage headers = %+v", host.envs[0].Headers)
+	}
+}
+
+func TestPublishStreamDelta_StampsLineageHeaders(t *testing.T) {
+	host := &publishHost{}
+	info := agent.RunInfo{
+		Identity: agent.Identity{
+			AgentID:     "child",
+			RunID:       "run-child",
+			ParentRunID: "run-parent",
+		},
+		Attributes: map[string]string{telemetry.AttrToolCallID: "call-5"},
+	}
+	if err := publishStreamDelta(context.Background(), host, info, "g", "n1",
+		agent.StreamDeltaPayload{
+			Type: agent.StreamDeltaPart,
+			Part: message.TextPart{Text: "x"},
+		}); err != nil {
+		t.Fatalf("publishStreamDelta: %v", err)
+	}
+	env := host.envs[0]
+	if env.ParentRunID() != "run-parent" || env.ToolCallID() != "call-5" {
+		t.Fatalf("lineage headers = %+v", env.Headers)
+	}
+
+	// Top-level runs carry no lineage headers.
+	topHost := &publishHost{}
+	top := agent.RunInfo{Identity: agent.Identity{AgentID: "root", RunID: "run-root"}}
+	if err := publishStreamDelta(context.Background(), topHost, top, "g", "n1",
+		agent.StreamDeltaPayload{
+			Type: agent.StreamDeltaPart,
+			Part: message.TextPart{Text: "x"},
+		}); err != nil {
+		t.Fatalf("publishStreamDelta: %v", err)
+	}
+	if topEnv := topHost.envs[0]; topEnv.ParentRunID() != "" || topEnv.ToolCallID() != "" {
+		t.Fatalf("top-level run got lineage headers: %+v", topEnv.Headers)
+	}
+}
+
+func TestPublishStep_StampsLineageHeaders(t *testing.T) {
+	host := &publishHost{}
+	g := &Graph{name: "g"}
+	info := agent.RunInfo{
+		Identity: agent.Identity{
+			AgentID:     "child",
+			RunID:       "run-child",
+			ParentRunID: "run-parent",
+		},
+		Attributes: map[string]string{telemetry.AttrToolCallID: "call-5"},
+	}
+	publishStepStarted(context.Background(), host, g, info, "n1")
+	if len(host.envs) != 1 {
+		t.Fatalf("published = %d envelopes, want 1", len(host.envs))
+	}
+	env := host.envs[0]
+	if env.ParentRunID() != "run-parent" || env.ToolCallID() != "call-5" {
+		t.Fatalf("step envelope lineage headers = %+v", env.Headers)
 	}
 }

--- a/core/tool/call_context.go
+++ b/core/tool/call_context.go
@@ -1,0 +1,30 @@
+package tool
+
+import "context"
+
+// callIDCtxKey is the context key for the active tool call id.
+//
+// The tool executor stamps the id of the message.ToolCall currently
+// being executed onto the context handed to the middleware chain and
+// the tool implementation, so deep components (a delegate tool, a
+// script binding, audit middleware) can correlate a tool's side
+// effects with the model-issued call that triggered them.
+type callIDCtxKey struct{}
+
+// WithCallID returns a derived context carrying id as the active tool
+// call id.
+func WithCallID(ctx context.Context, id string) context.Context {
+	return context.WithValue(ctx, callIDCtxKey{}, id)
+}
+
+// CallIDFromContext returns the active tool call id carried by ctx.
+// ok=false means the caller is outside a tool execution (or the id
+// was empty); consumers should treat the zero value as "unknown"
+// rather than an error.
+func CallIDFromContext(ctx context.Context) (string, bool) {
+	if ctx == nil {
+		return "", false
+	}
+	id, _ := ctx.Value(callIDCtxKey{}).(string)
+	return id, id != ""
+}

--- a/core/tool/call_context_test.go
+++ b/core/tool/call_context_test.go
@@ -1,0 +1,99 @@
+package tool_test
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"github.com/GizClaw/flowcraft/core/message"
+	"github.com/GizClaw/flowcraft/core/tool"
+)
+
+func TestCallIDContext_RoundTrip(t *testing.T) {
+	ctx := tool.WithCallID(context.Background(), "call-42")
+	if id, ok := tool.CallIDFromContext(ctx); !ok || id != "call-42" {
+		t.Fatalf("CallIDFromContext = %q, %v; want call-42, true", id, ok)
+	}
+	if _, ok := tool.CallIDFromContext(context.Background()); ok {
+		t.Fatal("CallIDFromContext outside a call should report absent")
+	}
+	if _, ok := tool.CallIDFromContext(tool.WithCallID(context.Background(), "")); ok {
+		t.Fatal("empty call id should report absent")
+	}
+}
+
+// TestExecutor_ExecuteStampsCallID verifies the executor stamps the
+// active message.ToolCall.ID into the context handed to the tool
+// implementation and to middleware.
+func TestExecutor_ExecuteStampsCallID(t *testing.T) {
+	var toolSeen, middlewareSeen string
+	reg, err := tool.NewRegistry([]tool.Source{source{tools: []tool.Tool{
+		tool.FuncTool(
+			message.ToolDefinition{Name: "peek", InputSchema: []byte(`{"type":"object"}`)},
+			func(ctx context.Context, _ string) (string, error) {
+				toolSeen, _ = tool.CallIDFromContext(ctx)
+				return "ok", nil
+			},
+		),
+	}}})
+	if err != nil {
+		t.Fatalf("NewRegistry: %v", err)
+	}
+	mw := func(next tool.Dispatch) tool.Dispatch {
+		return func(ctx context.Context, call message.ToolCall) message.ToolResult {
+			middlewareSeen, _ = tool.CallIDFromContext(ctx)
+			return next(ctx, call)
+		}
+	}
+	exec := tool.NewExecutor(reg, mw)
+	res := exec.Execute(context.Background(),
+		message.ToolCall{ID: "call-7", Name: "peek", Arguments: []byte(`{}`)})
+	if res.IsError {
+		t.Fatalf("result = %+v", res)
+	}
+	if toolSeen != "call-7" {
+		t.Fatalf("tool saw call id %q, want call-7", toolSeen)
+	}
+	if middlewareSeen != "call-7" {
+		t.Fatalf("middleware saw call id %q, want call-7", middlewareSeen)
+	}
+}
+
+// TestExecutor_ExecuteAllStampsPerCallIDs verifies concurrent calls
+// each see their own call id.
+func TestExecutor_ExecuteAllStampsPerCallIDs(t *testing.T) {
+	reg, err := tool.NewRegistry([]tool.Source{source{tools: []tool.Tool{
+		tool.FuncTool(
+			message.ToolDefinition{Name: "peek", InputSchema: []byte(`{"type":"object"}`)},
+			func(ctx context.Context, _ string) (string, error) {
+				id, _ := tool.CallIDFromContext(ctx)
+				return id, nil
+			},
+		),
+	}}})
+	if err != nil {
+		t.Fatalf("NewRegistry: %v", err)
+	}
+	exec := tool.NewExecutor(reg)
+	calls := []message.ToolCall{
+		{ID: "a", Name: "peek", Arguments: []byte(`{}`)},
+		{ID: "b", Name: "peek", Arguments: []byte(`{}`)},
+		{ID: "c", Name: "peek", Arguments: []byte(`{}`)},
+	}
+	results := exec.ExecuteAll(context.Background(), calls)
+	var mu sync.Mutex
+	got := make(map[string]bool, len(calls))
+	for _, res := range results {
+		if res.IsError {
+			t.Fatalf("result = %+v", res)
+		}
+		mu.Lock()
+		got[res.Content] = true
+		mu.Unlock()
+	}
+	for _, call := range calls {
+		if !got[call.ID] {
+			t.Fatalf("call id %q not seen by any concurrent execution", call.ID)
+		}
+	}
+}

--- a/core/tool/executor.go
+++ b/core/tool/executor.go
@@ -54,7 +54,7 @@ func NewExecutor(catalog Catalog, mws ...Middleware) *Executor {
 // unknown tool, tool error — surface as Result with IsError=true,
 // never as a Go error.
 func (e *Executor) Execute(ctx context.Context, call message.ToolCall) message.ToolResult {
-	return e.dispatch(ctx, call)
+	return e.dispatch(WithCallID(ctx, call.ID), call)
 }
 
 // ExecuteAll runs every call concurrently through the chain and


### PR DESCRIPTION
Closes #439 (sync half).

## Summary

Subagent stream envelopes now carry `parent_run_id` + `tool_call_id` headers, so consumers can build the exact `caller run → delegate call → subagent run` tree without a separate join — critical for parallel sync delegations where the association is otherwise ambiguous.

Design (per local plan `docs/plans/delegation-stream-lineage.md`): lineage is run identity, projected by engines; delegation stays out of the stream protocol.

## Changes

- **`core/tool`**: executor stamps the active `message.ToolCall.ID` into the execution context (`tool.WithCallID` / `tool.CallIDFromContext`); visible to middleware and tool implementations, per-call in concurrent `ExecuteAll`.
- **`core/agent`**: `agent.Request` gains `ParentRunID` + `Attributes` so the runtime session path (which assembles its own options) can carry lineage; `Execute` merges them into `Identity` / `Run.Attributes` (`WithParentRunID` / `WithAttributes` win per key).
- **`core/event`**: new `parent_run_id` / `tool_call_id` header constants + typed helpers.
- **`core/graph` / `core/agent`**: envelope mint points (`publishStreamDelta`, `publishStep`, `publishRunEvent`, `publishParallelWave`, `EmitStreamDelta`) project lineage from run identity; top-level runs stay header-free.
- **`core/delegation`**: sync runs derive the caller run id (ambient `RunInfo`) and the delegate call id (tool context) at the boundary and stamp them onto the subagent request; nested delegations compose per hop.

## Testing

- New unit tests: tool call-id context (incl. parallel `ExecuteAll`), Request lineage propagation + precedence, event header helpers, graph/agent envelope projection, and an end-to-end sync delegation test asserting subagent `Run.ParentRunID` / `tool.call_id` attribute and the streamed envelope headers.
- Gates: `make ci`, `make lint`, `make release-check`, `git diff --check` all pass.

## Follow-ups (not in this PR)

- Async real-time stream envelopes (`AsyncRequest` lineage + stream ref/escrow) per the plan's Step 2.