### PR TITLE
feat(core/delegation): stream async delegation envelopes to caller sinks

### DIFF
--- a/core/delegation/kanban/card.go
+++ b/core/delegation/kanban/card.go
@@ -41,12 +41,16 @@ type Result struct {
 // Card is an operational snapshot of one delegation backend entry.
 // Backend callers normally use only the id returned by Submit and Status.
 type Card struct {
-	ID        string            `json:"id"`
-	Producer  string            `json:"producer,omitempty"`
-	Consumer  string            `json:"consumer,omitempty"`
-	Status    Status            `json:"status"`
-	Task      *Task             `json:"task"`
-	Result    *Result           `json:"result,omitempty"`
+	ID       string  `json:"id"`
+	Producer string  `json:"producer,omitempty"`
+	Consumer string  `json:"consumer,omitempty"`
+	Status   Status  `json:"status"`
+	Task     *Task   `json:"task"`
+	Result   *Result `json:"result,omitempty"`
+	// RunID is the subagent run id recorded while the card is
+	// running (see Board.NoteRunID); empty until the worker starts
+	// the run. The terminal Result.Response.ID carries the same value.
+	RunID     string            `json:"run_id,omitempty"`
 	ResumeRef string            `json:"resume_ref,omitempty"`
 	CreatedAt time.Time         `json:"created_at"`
 	UpdatedAt time.Time         `json:"updated_at"`
@@ -98,6 +102,7 @@ func (c *Card) clone() *Card {
 		out.Result = &Result{Response: cloneResponse(c.Result.Response)}
 	}
 	out.Meta = cloneMetadata(c.Meta)
+	out.RunID = c.RunID
 	return &out
 }
 

--- a/core/delegation/kanban/events.go
+++ b/core/delegation/kanban/events.go
@@ -48,6 +48,7 @@ type CardEvent struct {
 	Status    Status                   `json:"status"`
 	Producer  string                   `json:"producer,omitempty"`
 	Consumer  string                   `json:"consumer,omitempty"`
+	RunID     string                   `json:"run_id,omitempty"`
 	Request   *delegation.AsyncRequest `json:"request,omitempty"`
 	Response  *delegation.Response     `json:"response,omitempty"`
 	ResumeRef string                   `json:"resume_ref,omitempty"`
@@ -92,6 +93,7 @@ func (b *Board) publish(ctx context.Context, snapshot *Card) {
 		Status:    snapshot.Status,
 		Producer:  snapshot.Producer,
 		Consumer:  snapshot.Consumer,
+		RunID:     snapshot.RunID,
 		ResumeRef: snapshot.ResumeRef,
 		ElapsedMs: snapshot.Elapsed().Milliseconds(),
 		Meta:      cloneMetadata(snapshot.Meta),

--- a/core/delegation/kanban/kanban.go
+++ b/core/delegation/kanban/kanban.go
@@ -464,6 +464,39 @@ func (b *Board) Complete(
 	return nil
 }
 
+// NoteRunID implements delegation.RunIDNotifier: it records the
+// subagent run id on the claimed card whose stream escrow ref matches,
+// so operational views can correlate a delegation id with its run
+// before the terminal response arrives. Unknown refs, cards not in the
+// claimed state, and repeated identical updates are no-ops; the
+// recorded run id is re-published through the ordinary claimed card
+// event.
+func (b *Board) NoteRunID(ctx context.Context, ref, runID string) error {
+	if ref == "" || runID == "" {
+		return errdefs.Validationf(
+			"delegation kanban: stream ref and run id are required")
+	}
+	b.mu.Lock()
+	var card *Card
+	for _, c := range b.cards {
+		if c.Task != nil && c.Task.Request.Stream != nil &&
+			c.Task.Request.Stream.Ref == ref {
+			card = c
+			break
+		}
+	}
+	if card == nil || card.Status != StatusClaimed || card.RunID == runID {
+		b.mu.Unlock()
+		return nil
+	}
+	card.RunID = runID
+	card.UpdatedAt = time.Now()
+	snapshot := card.clone()
+	b.mu.Unlock()
+	b.afterTransition(snapshot)
+	return nil
+}
+
 // ClaimCard applies an explicit operational claim to one pending card.
 func (b *Board) ClaimCard(id, consumer string) bool {
 	b.mu.Lock()
@@ -765,7 +798,11 @@ func responseForCard(card *Card) delegation.Response {
 	if card.Status == StatusClaimed {
 		status = delegation.StatusRunning
 	}
-	return delegation.Response{ID: card.ID, Status: status}
+	response := delegation.Response{ID: card.ID, Status: status}
+	if len(card.Meta) > 0 {
+		response.Metadata = cloneMetadata(card.Meta)
+	}
+	return response
 }
 
 func newCardID() (string, error) {
@@ -787,5 +824,6 @@ func newLeaseToken() (string, error) {
 var (
 	_ delegation.AsyncBackend                 = (*Board)(nil)
 	_ delegation.IdempotencyRetentionProvider = (*Board)(nil)
+	_ delegation.RunIDNotifier                = (*Board)(nil)
 	_ delegation.WorkSource                   = (*Board)(nil)
 )

--- a/core/delegation/kanban/kanban_test.go
+++ b/core/delegation/kanban/kanban_test.go
@@ -76,6 +76,71 @@ func TestAsyncBackendSubmitAndStatus(t *testing.T) {
 	}
 }
 
+func TestBoardRunningStatusCarriesMeta(t *testing.T) {
+	board := newBoard(t)
+	id := submit(t, board, "worker")
+
+	accepted, err := board.Status(context.Background(), id)
+	if err != nil {
+		t.Fatalf("Status: %v", err)
+	}
+	if accepted.Status != delegation.StatusAccepted || accepted.Metadata["tenant"] != "acme" {
+		t.Fatalf("pending status = %+v", accepted)
+	}
+
+	work, err := board.Claim(context.Background())
+	if err != nil {
+		t.Fatalf("Claim: %v", err)
+	}
+	if work.ID != id {
+		t.Fatalf("claimed work id = %q, want %q", work.ID, id)
+	}
+	running, err := board.Status(context.Background(), id)
+	if err != nil {
+		t.Fatalf("Status: %v", err)
+	}
+	if running.Status != delegation.StatusRunning || running.Metadata["tenant"] != "acme" {
+		t.Fatalf("running status = %+v", running)
+	}
+}
+
+func TestBoardNoteRunIDRecordsAndPublishesRunID(t *testing.T) {
+	board := newBoard(t)
+	req := request("worker")
+	req.Stream = &delegation.StreamRef{Ref: "escrow-1"}
+	id, err := board.Submit(context.Background(), req)
+	if err != nil {
+		t.Fatalf("Submit: %v", err)
+	}
+	work, err := board.Claim(context.Background())
+	if err != nil {
+		t.Fatalf("Claim: %v", err)
+	}
+	if work.ID != id {
+		t.Fatalf("claimed work id = %q, want %q", work.ID, id)
+	}
+
+	if err := board.NoteRunID(context.Background(), "escrow-1", "run-sub-1"); err != nil {
+		t.Fatalf("NoteRunID: %v", err)
+	}
+	card, ok := board.Card(id)
+	if !ok || card.RunID != "run-sub-1" {
+		t.Fatalf("card RunID = %q (ok %v), want run-sub-1", card.RunID, ok)
+	}
+	// Repeated identical update is a no-op.
+	if err := board.NoteRunID(context.Background(), "escrow-1", "run-sub-1"); err != nil {
+		t.Fatalf("repeated NoteRunID: %v", err)
+	}
+	// Unknown ref is a no-op.
+	if err := board.NoteRunID(context.Background(), "missing", "run-x"); err != nil {
+		t.Fatalf("unknown ref NoteRunID: %v", err)
+	}
+	// Empty inputs are validation errors.
+	if err := board.NoteRunID(context.Background(), "", "run-x"); !errdefs.IsValidation(err) {
+		t.Fatalf("empty ref error = %v, want validation", err)
+	}
+}
+
 func TestAsyncBackendSubmitIdempotency(t *testing.T) {
 	board := newBoard(t)
 	req := request("worker")

--- a/core/delegation/service.go
+++ b/core/delegation/service.go
@@ -25,6 +25,11 @@ const (
 	defaultMaxConcurrency       = 4
 	defaultMaxDepth             = 8
 	defaultIdempotencyRetention = time.Hour
+	// defaultStreamEscrowTTL bounds how long an async delegation's
+	// stream escrow survives without a claim; claimed entries are
+	// refreshed and released at terminal completion, so the TTL is a
+	// leak backstop, not a run-duration cap.
+	defaultStreamEscrowTTL = time.Hour
 
 	workerRetryInitial     = 10 * time.Millisecond
 	workerRetryMax         = 250 * time.Millisecond
@@ -38,6 +43,22 @@ type AsyncRequest struct {
 	Request Request `json:"request"`
 	Caller  string  `json:"caller,omitempty"`
 	Depth   int     `json:"depth"`
+
+	// ParentRunID is the run id of the delegating agent's run. Sync
+	// delegations derive it from the ambient execution context;
+	// async delegations persist it here so it survives the queue.
+	ParentRunID string `json:"parent_run_id,omitempty"`
+
+	// CallID is the delegate tool call id that started the
+	// delegation. Like ParentRunID it is derived from the caller's
+	// execution context and persisted across the queue for async.
+	CallID string `json:"call_id,omitempty"`
+
+	// Stream is the queue-crossing reference to the caller's stream
+	// sinks. Nil means the delegation carries no live stream (the
+	// caller had no inheritable sinks, or the deployment does not
+	// support async streaming).
+	Stream *StreamRef `json:"stream,omitempty"`
 }
 
 // Work is one claimed asynchronous request. LeaseToken uniquely identifies
@@ -92,8 +113,10 @@ type serviceConfig struct {
 	maxDepth             int
 	timeout              time.Duration
 	idempotencyRetention time.Duration
+	streamEscrowTTL      time.Duration
 	workerHost           agent.Host
 	sessionProvider      SessionProvider
+	streamResolver       StreamTargetResolver
 	deferWorkers         bool
 }
 
@@ -108,6 +131,14 @@ type idempotencyResult struct {
 	request  Request
 	response Response
 	expires  time.Time
+}
+
+// streamEscrowEntry is one async delegation's stream attachment: the
+// caller's live sinks (already downgraded to observers) plus a claim
+// backstop deadline.
+type streamEscrowEntry struct {
+	specs   []session.SinkSpec
+	expires time.Time
 }
 
 // WithMaxConcurrency bounds all local agent executions, including sync calls
@@ -171,6 +202,36 @@ func WithWorkerHost(host agent.Host) Option {
 	}
 }
 
+// WithStreamEscrowTTL bounds how long an async delegation's stream
+// escrow may sit unclaimed (or between claims) before the service
+// drops it. Claimed entries are refreshed and released at terminal
+// completion, so a long-running job is unaffected by a short TTL; the
+// TTL only guards abandoned entries. Zero uses the service default.
+func WithStreamEscrowTTL(ttl time.Duration) Option {
+	return func(config *serviceConfig) error {
+		if ttl < 0 {
+			return errdefs.Validationf("local delegation: stream escrow ttl cannot be negative")
+		}
+		config.streamEscrowTTL = ttl
+		return nil
+	}
+}
+
+// WithStreamTargetResolver registers the worker-side resolver that
+// materializes a serializable [StreamTarget] (persisted in an async
+// AsyncRequest) into a live stream sink. Resolvers MUST whitelist
+// target kinds; the resolver is only consulted when no in-process
+// escrow entry exists for the request.
+func WithStreamTargetResolver(resolver StreamTargetResolver) Option {
+	return func(config *serviceConfig) error {
+		if resolver == nil {
+			return errdefs.Validationf("local delegation: stream target resolver is nil")
+		}
+		config.streamResolver = resolver
+		return nil
+	}
+}
+
 // WithSessionProvider sets the identity policy for delegated subagent
 // sessions. When nil and a session manager is bound, the service mints a
 // fresh ContextID per delegation.
@@ -219,6 +280,14 @@ type LocalService struct {
 	workerCtx    context.Context
 	cancelWorker context.CancelFunc
 	workerHost   agent.Host
+	// streamEscrow holds the caller's live (downgraded) sink specs for
+	// in-flight async delegations, keyed by the StreamRef.Ref carried
+	// in the persisted AsyncRequest. Entries are released at terminal
+	// completion, refreshed on claim, and swept by TTL as a backstop.
+	streamEscrowMu  sync.Mutex
+	streamEscrow    map[string]streamEscrowEntry
+	streamEscrowTTL time.Duration
+	streamResolver  StreamTargetResolver
 	// sessionProvider is the identity policy for subagent sessions. It is
 	// immutable after construction.
 	sessionProvider SessionProvider
@@ -258,6 +327,9 @@ func NewService(directory *LocalDirectory, backend AsyncBackend, opts ...Option)
 			}
 		}
 	}
+	if config.streamEscrowTTL <= 0 {
+		config.streamEscrowTTL = defaultStreamEscrowTTL
+	}
 
 	workerCtx, cancelWorker := context.WithCancel(context.Background())
 	asyncRetention := config.idempotencyRetention
@@ -278,6 +350,9 @@ func NewService(directory *LocalDirectory, backend AsyncBackend, opts ...Option)
 		asyncRetention:       asyncRetention,
 		idempotencyCalls:     make(map[string]*idempotencyCall),
 		idempotencyCache:     make(map[string]idempotencyResult),
+		streamEscrow:         make(map[string]streamEscrowEntry),
+		streamEscrowTTL:      config.streamEscrowTTL,
+		streamResolver:       config.streamResolver,
 		workerCtx:            workerCtx,
 		cancelWorker:         cancelWorker,
 	}
@@ -379,10 +454,13 @@ func (s *LocalService) delegate(
 	switch req.Mode {
 	case ModeSync:
 		meta := metadataFromContext(ctx)
+		parentRunID, callID := lineageFromContext(ctx)
 		return s.runAt(ctx, AsyncRequest{
-			Request: req,
-			Caller:  meta.caller,
-			Depth:   meta.depth + 1,
+			Request:     req,
+			Caller:      meta.caller,
+			Depth:       meta.depth + 1,
+			ParentRunID: parentRunID,
+			CallID:      callID,
 		}, meta.leased)
 	case ModeAsync:
 		if s.backend == nil {
@@ -393,11 +471,39 @@ func (s *LocalService) delegate(
 		if err := s.checkDepth(depth); err != nil {
 			return Response{}, err
 		}
-		id, err := s.backend.Submit(ctx, AsyncRequest{
-			Request: cloneRequest(req),
-			Caller:  meta.caller,
-			Depth:   depth,
-		})
+		parentRunID, callID := lineageFromContext(ctx)
+		asyncReq := AsyncRequest{
+			Request:     cloneRequest(req),
+			Caller:      meta.caller,
+			Depth:       depth,
+			ParentRunID: parentRunID,
+			CallID:      callID,
+		}
+		// Surface lineage on operational views (kanban cards,
+		// delegation_status) through the portable metadata channel;
+		// the injected keys are service-owned, not user input.
+		asyncReq.Request.Metadata = injectDelegationLineage(
+			asyncReq.Request.Metadata, parentRunID, callID)
+		if specs, ok := s.asyncStreamSpecs(ctx); ok {
+			ref := "escrow-" + newID()
+			release := s.storeStreamEscrow(ref, specs)
+			asyncReq.Stream = &StreamRef{
+				Ref:    ref,
+				Policy: streamPolicySnapshot(specs),
+			}
+			id, err := s.backend.Submit(ctx, asyncReq)
+			if err != nil {
+				release()
+				return Response{}, err
+			}
+			if id == "" {
+				release()
+				return Response{}, errdefs.Internalf(
+					"local delegation: async backend returned an empty id")
+			}
+			return Response{ID: id, Status: StatusAccepted}, nil
+		}
+		id, err := s.backend.Submit(ctx, asyncReq)
 		if err != nil {
 			return Response{}, err
 		}
@@ -579,6 +685,9 @@ func (s *LocalService) Close() error {
 		s.cancelWorker()
 		s.workers.Wait()
 		s.active.Wait()
+		s.streamEscrowMu.Lock()
+		s.streamEscrow = nil
+		s.streamEscrowMu.Unlock()
 		s.stateMu.Lock()
 		s.closeErr = errors.Join(s.workerErrs...)
 		s.stateMu.Unlock()
@@ -629,6 +738,7 @@ func (s *LocalService) worker() {
 			s.recordWorkerError(err)
 			return
 		}
+		s.releaseStreamEscrow(streamRefOf(work.Request.Stream))
 	}
 }
 
@@ -678,6 +788,10 @@ func (s *LocalService) runAt(ctx context.Context, req AsyncRequest, reuseSlot bo
 	if err := s.checkDepth(req.Depth); err != nil {
 		return Response{}, err
 	}
+	// Async work carries its stream attachment through the queue; the
+	// worker restores the caller's sinks (or a resolver target) as an
+	// inheritable policy before the session turn starts.
+	ctx = s.inheritAsyncStreams(ctx, req)
 	instance, err := s.directory.Lookup(ctx, req.Request.Target)
 	if err != nil {
 		return Response{}, err
@@ -751,13 +865,19 @@ func (s *LocalService) runAt(ctx context.Context, req AsyncRequest, reuseSlot bo
 	}()
 
 	opts := s.delegationStartOptions(execCtx, persistent)
-	parentRunID, lineageAttrs := lineageFromContext(execCtx)
+	parentRunID, callID := lineageFromContext(execCtx)
+	if req.ParentRunID != "" {
+		parentRunID = req.ParentRunID
+	}
+	if req.CallID != "" {
+		callID = req.CallID
+	}
 	request := agent.Request{
 		ContextID:   key.ContextID,
 		Message:     message.NewTextMessage(message.RoleUser, req.Request.Input),
 		Inputs:      metadataInputs(req),
 		ParentRunID: parentRunID,
-		Attributes:  lineageAttrs,
+		Attributes:  lineageAttributes(callID),
 	}
 
 	// Resume path: a persistent session retried with the identical
@@ -794,6 +914,7 @@ func (s *LocalService) runAt(ctx context.Context, req AsyncRequest, reuseSlot bo
 			return Response{}, err
 		}
 	}
+	s.notifyRunStarted(execCtx, req, turn)
 
 	result, err := waitTurnCancelOnDone(execCtx, turn)
 	if err != nil {
@@ -838,11 +959,17 @@ func (s *LocalService) runAtLegacy(
 		}
 	}
 
-	parentRunID, lineageAttrs := lineageFromContext(execCtx)
+	parentRunID, callID := lineageFromContext(execCtx)
+	if req.ParentRunID != "" {
+		parentRunID = req.ParentRunID
+	}
+	if req.CallID != "" {
+		callID = req.CallID
+	}
 	agentRequest := agent.Request{
 		Message:     message.NewTextMessage(message.RoleUser, req.Request.Input),
 		ParentRunID: parentRunID,
-		Attributes:  lineageAttrs,
+		Attributes:  lineageAttributes(callID),
 	}
 	if hasKey {
 		agentRequest.ContextID = key.ContextID
@@ -876,14 +1003,200 @@ func (s *LocalService) runAtLegacy(
 // RunInfo, and direct service calls carry no tool call id — in which
 // case the corresponding lineage slot stays empty and the subagent
 // runs exactly as it does today.
-func lineageFromContext(ctx context.Context) (parentRunID string, attrs map[string]string) {
+func lineageFromContext(ctx context.Context) (parentRunID, callID string) {
 	if info, ok := agent.RunInfoFromContext(ctx); ok {
 		parentRunID = info.RunID
 	}
-	if callID, ok := tool.CallIDFromContext(ctx); ok {
-		attrs = map[string]string{telemetry.AttrToolCallID: callID}
+	callID, _ = tool.CallIDFromContext(ctx)
+	return parentRunID, callID
+}
+
+// lineageAttributes maps a delegate tool call id onto the subagent
+// run attribute consumed by the envelope projection. Nil when the
+// call id is absent.
+func lineageAttributes(callID string) map[string]string {
+	if callID == "" {
+		return nil
 	}
-	return parentRunID, attrs
+	return map[string]string{telemetry.AttrToolCallID: callID}
+}
+
+// injectDelegationLineage adds the service-owned lineage metadata keys
+// to an async request's portable metadata so operational views
+// surface parent run + call id without per-view plumbing. Returns the
+// (possibly newly allocated) metadata map.
+func injectDelegationLineage(metadata map[string]string, parentRunID, callID string) map[string]string {
+	if parentRunID == "" && callID == "" {
+		return metadata
+	}
+	if metadata == nil {
+		metadata = make(map[string]string, 2)
+	}
+	if parentRunID != "" {
+		metadata[ParentRunMetadataKey] = parentRunID
+	}
+	if callID != "" {
+		metadata[CallIDMetadataKey] = callID
+	}
+	return metadata
+}
+
+// streamRefOf returns the escrow ref carried by a StreamRef, or "".
+func streamRefOf(ref *StreamRef) string {
+	if ref == nil {
+		return ""
+	}
+	return ref.Ref
+}
+
+// asyncStreamSpecs captures the caller's inheritable stream sinks for
+// an async delegation, downgraded to observers exactly like the sync
+// inheritance path. ok=false means there is nothing to stream.
+func (s *LocalService) asyncStreamSpecs(ctx context.Context) ([]session.SinkSpec, bool) {
+	policy, ok := session.StreamPolicyFromContext(ctx)
+	if !ok || !policy.Inheritable || len(policy.Sinks) == 0 {
+		return nil, false
+	}
+	return inheritedSinkSpecs(policy.Sinks), true
+}
+
+// streamPolicySnapshot projects an inherited sink set onto the
+// serializable policy snapshot carried by AsyncRequest.Stream. It is
+// populated from the first spec; with multiple sinks the snapshot
+// reflects the first attachment's tuning (authority/ack fields are
+// informational — inherited attachments always downgrade to observers).
+func streamPolicySnapshot(specs []session.SinkSpec) StreamPolicySnapshot {
+	var snapshot StreamPolicySnapshot
+	if len(specs) == 0 {
+		return snapshot
+	}
+	spec := specs[0]
+	snapshot.Visibility = spec.Visibility
+	snapshot.Authority = spec.Authority
+	snapshot.AckMode = spec.AckMode
+	snapshot.MaxUnacked = spec.MaxUnacked
+	snapshot.QueueSize = spec.QueueSize
+	snapshot.DeliveryTimeout = spec.DeliveryTimeout.Milliseconds()
+	return snapshot
+}
+
+// storeStreamEscrow records the caller's live sink specs for one async
+// delegation and returns a release func that must run when the
+// delegation reaches its terminal state (or immediately on submit
+// failure). Entries are swept by TTL as a backstop.
+func (s *LocalService) storeStreamEscrow(ref string, specs []session.SinkSpec) func() {
+	s.streamEscrowMu.Lock()
+	defer s.streamEscrowMu.Unlock()
+	s.sweepStreamEscrowLocked()
+	s.streamEscrow[ref] = streamEscrowEntry{
+		specs:   append([]session.SinkSpec(nil), specs...),
+		expires: time.Now().Add(s.streamEscrowTTL),
+	}
+	return func() { s.releaseStreamEscrow(ref) }
+}
+
+// takeStreamEscrow resolves an escrow ref to the caller's live sink
+// specs, refreshing the entry's claim backstop. Missing and expired
+// entries report ok=false so the worker degrades to the resolver (or
+// no stream at all).
+func (s *LocalService) takeStreamEscrow(ref string) ([]session.SinkSpec, bool) {
+	if ref == "" {
+		return nil, false
+	}
+	s.streamEscrowMu.Lock()
+	defer s.streamEscrowMu.Unlock()
+	s.sweepStreamEscrowLocked()
+	entry, ok := s.streamEscrow[ref]
+	if !ok {
+		return nil, false
+	}
+	entry.expires = time.Now().Add(s.streamEscrowTTL)
+	s.streamEscrow[ref] = entry
+	return append([]session.SinkSpec(nil), entry.specs...), true
+}
+
+// releaseStreamEscrow drops an escrow entry. Idempotent; missing refs
+// are no-ops.
+func (s *LocalService) releaseStreamEscrow(ref string) {
+	if ref == "" {
+		return
+	}
+	s.streamEscrowMu.Lock()
+	delete(s.streamEscrow, ref)
+	s.streamEscrowMu.Unlock()
+}
+
+// sweepStreamEscrowLocked drops expired entries. Callers hold
+// streamEscrowMu.
+func (s *LocalService) sweepStreamEscrowLocked() {
+	now := time.Now()
+	for ref, entry := range s.streamEscrow {
+		if now.After(entry.expires) {
+			delete(s.streamEscrow, ref)
+		}
+	}
+}
+
+// inheritAsyncStreams restores an async work item's stream attachment
+// on the worker side. In-process escrow wins; a resolver target is the
+// cross-process fallback. The restored attachment is stamped as an
+// inheritable stream policy so the session turn (and any nested
+// delegation) picks it up through the ordinary sync inheritance path.
+func (s *LocalService) inheritAsyncStreams(ctx context.Context, req AsyncRequest) context.Context {
+	if req.Stream == nil {
+		return ctx
+	}
+	if specs, ok := s.takeStreamEscrow(req.Stream.Ref); ok {
+		return session.WithStreamPolicy(ctx, session.StreamPolicy{
+			Sinks:       specs,
+			Inheritable: true,
+		})
+	}
+	if s.streamResolver != nil && req.Stream.Target != nil {
+		sink, err := s.streamResolver(ctx, *req.Stream.Target)
+		if err != nil {
+			telemetry.WarnErr(ctx, "local delegation: stream target resolution failed",
+				err, otellog.String("delegation.stream_target", req.Stream.Target.ID))
+			return ctx
+		}
+		if isNilInterface(sink) {
+			return ctx
+		}
+		spec := session.SinkSpec{
+			ID:              req.Stream.Target.ID,
+			Sink:            sink,
+			Visibility:      req.Stream.Policy.Visibility,
+			Authority:       req.Stream.Policy.Authority,
+			AckMode:         req.Stream.Policy.AckMode,
+			MaxUnacked:      req.Stream.Policy.MaxUnacked,
+			QueueSize:       req.Stream.Policy.QueueSize,
+			DeliveryTimeout: time.Duration(req.Stream.Policy.DeliveryTimeout) * time.Millisecond,
+		}
+		return session.WithStreamPolicy(ctx, session.StreamPolicy{
+			Sinks:       inheritedSinkSpecs([]session.SinkSpec{spec}),
+			Inheritable: true,
+		})
+	}
+	return ctx
+}
+
+// notifyRunStarted records the subagent run id on the async backend
+// (when it supports RunIDNotifier) as soon as the turn exists, so
+// operational views can correlate delegation ids with runs before the
+// terminal response. Best-effort: failures are logged, never fatal.
+func (s *LocalService) notifyRunStarted(ctx context.Context, req AsyncRequest, turn *session.Turn) {
+	ref := streamRefOf(req.Stream)
+	if ref == "" || turn == nil {
+		return
+	}
+	notifier, ok := s.backend.(RunIDNotifier)
+	if !ok || isNilInterface(notifier) {
+		return
+	}
+	if err := notifier.NoteRunID(ctx, ref, turn.RunID()); err != nil {
+		telemetry.WarnErr(ctx, "local delegation: note run id failed", err,
+			otellog.String(telemetry.AttrDelegationTarget, req.Request.Target))
+	}
 }
 
 func (s *LocalService) begin() error {

--- a/core/delegation/stream.go
+++ b/core/delegation/stream.go
@@ -1,0 +1,84 @@
+package delegation
+
+import (
+	"context"
+
+	"github.com/GizClaw/flowcraft/core/agent"
+	"github.com/GizClaw/flowcraft/core/runtime/session"
+)
+
+// Metadata keys injected service-side into an async delegation's
+// Request.Metadata so operational views (kanban cards, delegation
+// status) surface run lineage without any per-view plumbing. They are
+// set by the service, not accepted from user-supplied delegate
+// arguments; callers must not treat them as authoritative input.
+const (
+	// ParentRunMetadataKey carries the parent (caller) run id.
+	ParentRunMetadataKey = "delegation.parent_run"
+	// CallIDMetadataKey carries the delegate tool call id that
+	// started the delegation.
+	CallIDMetadataKey = "delegation.call_id"
+)
+
+// StreamTarget is a serializable description of where an async
+// subagent's stream envelopes should be delivered. It replaces the
+// live (non-serializable) sink across the queue boundary: the caller's
+// runtime knows how to describe its sinks as targets, and the worker's
+// runtime resolves them back into live sinks through
+// [StreamTargetResolver].
+type StreamTarget struct {
+	// Kind is the target vocabulary understood by the resolver
+	// (e.g. "conversation", "bus"). Resolvers MUST reject unknown
+	// kinds — targets originate from persisted backend records and
+	// must never drive arbitrary sink construction.
+	Kind string `json:"kind"`
+	// ID is the resolver-specific destination identifier.
+	ID string `json:"id"`
+}
+
+// StreamPolicySnapshot is a serializable projection of the caller's
+// stream attachment policy, carried alongside a [StreamTarget] so the
+// worker can materialize the attachment with the same tuning. It is
+// populated from the caller's first sink spec; authority/ack fields
+// are informational and the worker always downgrades inherited
+// attachments to observers (see inheritedSinkSpecs).
+type StreamPolicySnapshot struct {
+	Visibility      session.Visibility `json:"visibility,omitempty"`
+	Authority       session.Authority  `json:"authority,omitempty"`
+	AckMode         session.AckMode    `json:"ack_mode,omitempty"`
+	MaxUnacked      int                `json:"max_unacked,omitempty"`
+	QueueSize       int                `json:"queue_size,omitempty"`
+	DeliveryTimeout int64              `json:"delivery_timeout_ms,omitempty"`
+}
+
+// StreamRef is the queue-crossing reference to an async delegation's
+// stream attachment. In-process backends use Ref (an escrow key that
+// the service resolves to the caller's live sinks); cross-process
+// backends use Target with a runtime-provided resolver.
+type StreamRef struct {
+	// Ref is the service-side escrow key. Empty when no in-process
+	// escrow exists.
+	Ref string `json:"ref,omitempty"`
+	// Policy snapshots the caller's attachment tuning.
+	Policy StreamPolicySnapshot `json:"policy,omitempty"`
+	// Target describes the delivery destination for resolver-based
+	// materialization. Empty when the escrow path is used.
+	Target *StreamTarget `json:"target,omitempty"`
+}
+
+// StreamTargetResolver materializes a live stream sink for a
+// serializable [StreamTarget] on the worker side. Resolvers MUST
+// whitelist target kinds and never construct sinks from free-form
+// persisted data.
+type StreamTargetResolver func(ctx context.Context, target StreamTarget) (agent.StreamSink, error)
+
+// RunIDNotifier is an optional AsyncBackend capability: it lets a
+// claimed async work item record the subagent run id as soon as the
+// run starts, so operational views can correlate a delegation id with
+// its run before the terminal response arrives.
+type RunIDNotifier interface {
+	// NoteRunID records runID for the work item identified by its
+	// stream escrow ref. Unknown refs are no-ops; errors are
+	// best-effort (recorded, never fail the run).
+	NoteRunID(ctx context.Context, ref, runID string) error
+}

--- a/core/delegation/stream_escrow_test.go
+++ b/core/delegation/stream_escrow_test.go
@@ -1,0 +1,386 @@
+package delegation
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/GizClaw/flowcraft/core/agent"
+	"github.com/GizClaw/flowcraft/core/event"
+	"github.com/GizClaw/flowcraft/core/message"
+	"github.com/GizClaw/flowcraft/core/runtime/session"
+	"github.com/GizClaw/flowcraft/core/tool"
+)
+
+func TestStreamEscrowStoreTakeRelease(t *testing.T) {
+	service, err := NewService(boundDirectory(t, completedEngine("unused")), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = service.Close() })
+
+	sink := agent.StreamSinkFunc(func(context.Context, event.Envelope, agent.StreamDeltaPayload) error {
+		return nil
+	})
+	specs := []session.SinkSpec{{ID: "caller", Sink: sink}}
+	release := service.storeStreamEscrow("ref-1", specs)
+
+	got, ok := service.takeStreamEscrow("ref-1")
+	if !ok || len(got) != 1 || got[0].ID != "caller" {
+		t.Fatalf("takeStreamEscrow = %v, %v; want caller spec", got, ok)
+	}
+	// take returns a defensive copy.
+	got[0].ID = "mutated"
+	if again, _ := service.takeStreamEscrow("ref-1"); again[0].ID != "caller" {
+		t.Fatalf("escrow was mutated by caller: %+v", again)
+	}
+	release()
+	if _, ok := service.takeStreamEscrow("ref-1"); ok {
+		t.Fatal("escrow survived release")
+	}
+	service.releaseStreamEscrow("ref-1") // idempotent
+	service.releaseStreamEscrow("")      // no-op
+}
+
+func TestStreamEscrowExpiresByTTL(t *testing.T) {
+	service, err := NewService(boundDirectory(t, completedEngine("unused")), nil,
+		WithStreamEscrowTTL(20*time.Millisecond))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = service.Close() })
+
+	sink := agent.StreamSinkFunc(func(context.Context, event.Envelope, agent.StreamDeltaPayload) error {
+		return nil
+	})
+	service.storeStreamEscrow("ref-ttl", []session.SinkSpec{{ID: "caller", Sink: sink}})
+	time.Sleep(40 * time.Millisecond)
+	if _, ok := service.takeStreamEscrow("ref-ttl"); ok {
+		t.Fatal("expired escrow entry still resolvable")
+	}
+}
+
+type captureAsyncBackend struct {
+	submitted chan AsyncRequest
+	submitErr error
+}
+
+func (b *captureAsyncBackend) Submit(_ context.Context, req AsyncRequest) (string, error) {
+	if b.submitErr != nil {
+		return "", b.submitErr
+	}
+	b.submitted <- req
+	return "async-1", nil
+}
+
+func (b *captureAsyncBackend) Status(context.Context, string) (Response, error) {
+	return Response{Status: StatusRunning}, nil
+}
+
+func TestDelegateAsyncStampsLineageStreamRefAndEscrow(t *testing.T) {
+	backend := &captureAsyncBackend{submitted: make(chan AsyncRequest, 1)}
+	service, err := NewService(boundDirectory(t, completedEngine("unused")), backend)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = service.Close() })
+
+	sink := agent.StreamSinkFunc(func(context.Context, event.Envelope, agent.StreamDeltaPayload) error {
+		return nil
+	})
+	ctx := session.WithStreamPolicy(context.Background(), session.StreamPolicy{
+		Sinks: []session.SinkSpec{{
+			ID:              "caller",
+			Sink:            sink,
+			QueueSize:       7,
+			DeliveryTimeout: time.Minute,
+			Visibility:      session.VisibilityConfirmed,
+			Authority:       session.AuthorityAuthoritative,
+			AckMode:         session.AckExplicit,
+			MaxUnacked:      3,
+		}},
+		Inheritable: true,
+	})
+	ctx = agent.WithRunInfo(ctx, agent.RunInfo{
+		Identity: agent.Identity{AgentID: "caller-agent", RunID: "run-caller"},
+	})
+	ctx = tool.WithCallID(ctx, "call-delegate-1")
+	request := syncRequest("writer")
+	request.Mode = ModeAsync
+	response, err := service.Delegate(ctx, request)
+	if err != nil {
+		t.Fatalf("Delegate: %v", err)
+	}
+	if response.Status != StatusAccepted {
+		t.Fatalf("response status = %q, want accepted", response.Status)
+	}
+
+	submitted := <-backend.submitted
+	if submitted.ParentRunID != "run-caller" || submitted.CallID != "call-delegate-1" {
+		t.Fatalf("submitted lineage = parent %q call %q", submitted.ParentRunID, submitted.CallID)
+	}
+	if submitted.Request.Metadata[ParentRunMetadataKey] != "run-caller" ||
+		submitted.Request.Metadata[CallIDMetadataKey] != "call-delegate-1" {
+		t.Fatalf("submitted metadata lineage = %+v", submitted.Request.Metadata)
+	}
+	if submitted.Stream == nil || submitted.Stream.Ref == "" {
+		t.Fatalf("submitted stream ref = %+v, want escrow ref", submitted.Stream)
+	}
+	if submitted.Stream.Policy.QueueSize != 7 ||
+		submitted.Stream.Policy.DeliveryTimeout != time.Minute.Milliseconds() ||
+		submitted.Stream.Policy.Visibility != session.VisibilityConfirmed {
+		t.Fatalf("stream policy snapshot = %+v", submitted.Stream.Policy)
+	}
+	service.streamEscrowMu.Lock()
+	_, escrowed := service.streamEscrow[submitted.Stream.Ref]
+	service.streamEscrowMu.Unlock()
+	if !escrowed {
+		t.Fatal("async submit did not leave an escrow entry")
+	}
+}
+
+func TestDelegateAsyncSubmitFailureReleasesEscrow(t *testing.T) {
+	backend := &captureAsyncBackend{submitErr: errors.New("backend down")}
+	service, err := NewService(boundDirectory(t, completedEngine("unused")), backend)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = service.Close() })
+
+	sink := agent.StreamSinkFunc(func(context.Context, event.Envelope, agent.StreamDeltaPayload) error {
+		return nil
+	})
+	ctx := session.WithStreamPolicy(context.Background(), session.StreamPolicy{
+		Sinks:       []session.SinkSpec{{ID: "caller", Sink: sink}},
+		Inheritable: true,
+	})
+	request := syncRequest("writer")
+	request.Mode = ModeAsync
+	if _, err := service.Delegate(ctx, request); err == nil {
+		t.Fatal("Delegate succeeded, want submit failure")
+	}
+	service.streamEscrowMu.Lock()
+	n := len(service.streamEscrow)
+	service.streamEscrowMu.Unlock()
+	if n != 0 {
+		t.Fatalf("failed submit left %d escrow entries", n)
+	}
+}
+
+func TestDelegateAsyncWithoutStreamPolicyHasNoStreamRef(t *testing.T) {
+	backend := &captureAsyncBackend{submitted: make(chan AsyncRequest, 1)}
+	service, err := NewService(boundDirectory(t, completedEngine("unused")), backend)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = service.Close() })
+
+	request := syncRequest("writer")
+	request.Mode = ModeAsync
+	if _, err := service.Delegate(context.Background(), request); err != nil {
+		t.Fatalf("Delegate: %v", err)
+	}
+	submitted := <-backend.submitted
+	if submitted.Stream != nil {
+		t.Fatalf("submitted stream = %+v, want nil without stream policy", submitted.Stream)
+	}
+}
+
+// TestAsyncDelegationStreamsLineageToCallerSinks is the async analogue
+// of the sync inheritance test: the worker restores the caller's live
+// sinks from the escrow, and the subagent's stream envelopes carry the
+// same lineage headers, in real time, on the caller's sink instance.
+func TestAsyncDelegationStreamsLineageToCallerSinks(t *testing.T) {
+	received := make(chan event.Envelope, 16)
+	sink := agent.StreamSinkFunc(func(
+		_ context.Context,
+		env event.Envelope,
+		_ agent.StreamDeltaPayload,
+	) error {
+		received <- env
+		return nil
+	})
+	engine := agent.EngineFunc(func(
+		ctx context.Context,
+		run agent.Run,
+		host agent.Host,
+		board *agent.Board,
+	) (*agent.Board, error) {
+		ctx = agent.WithRunInfo(ctx, run.Info())
+		if err := agent.EmitStreamPart(
+			ctx, host, run.RunID, "writer.node.work",
+			message.TextPart{Text: "async progress"}); err != nil {
+			return nil, err
+		}
+		board.AppendChannelMessage(agent.MainChannel,
+			message.NewTextMessage(message.RoleAssistant, "done"))
+		return board, nil
+	})
+	backend := newQueueBackend()
+	result := buildResult(t, delegationWithRunEnd(engine))
+	directory := NewDirectory()
+	if err := directory.Bind(result); err != nil {
+		t.Fatal(err)
+	}
+	service, err := NewService(directory, backend,
+		WithMaxConcurrency(1), WithDeferredWorkers())
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = service.Close() })
+	manager := newTestSessionManagerForResult(t, result)
+	if err := service.BindSessionManager(manager); err != nil {
+		t.Fatal(err)
+	}
+	if err := service.Start(); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	ctx := session.WithStreamPolicy(context.Background(), session.StreamPolicy{
+		Sinks: []session.SinkSpec{{
+			ID:   "caller",
+			Sink: sink,
+		}},
+		Inheritable: true,
+	})
+	ctx = agent.WithRunInfo(ctx, agent.RunInfo{
+		Identity: agent.Identity{AgentID: "caller-agent", RunID: "run-caller"},
+	})
+	ctx = tool.WithCallID(ctx, "call-delegate-1")
+	request := syncRequest("writer")
+	request.Mode = ModeAsync
+	accepted, err := service.Delegate(ctx, request)
+	if err != nil {
+		t.Fatalf("Delegate: %v", err)
+	}
+	if accepted.Status != StatusAccepted {
+		t.Fatalf("response status = %q, want accepted", accepted.Status)
+	}
+
+	select {
+	case completed := <-backend.completed:
+		if completed.Status != StatusSucceeded {
+			t.Fatalf("completed = %+v", completed)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("worker did not complete async work")
+	}
+
+	deadline := time.After(5 * time.Second)
+	for {
+		select {
+		case env := <-received:
+			if env.ParentRunID() != "run-caller" || env.ToolCallID() != "call-delegate-1" {
+				t.Fatalf("lineage headers = %+v", env.Headers)
+			}
+			goto released
+		case <-deadline:
+			t.Fatal("lineage-stamped async stream envelope never received")
+		}
+	}
+released:
+	waitUntil(t, 5*time.Second, func() bool {
+		service.streamEscrowMu.Lock()
+		defer service.streamEscrowMu.Unlock()
+		return len(service.streamEscrow) == 0
+	})
+}
+
+// TestAsyncDelegationResolverMaterializesTarget exercises the
+// cross-process fallback: with no in-process escrow entry, the worker
+// resolves a serializable StreamTarget through the registered resolver
+// and attaches the resulting sink to the subagent turn.
+func TestAsyncDelegationResolverMaterializesTarget(t *testing.T) {
+	received := make(chan event.Envelope, 8)
+	resolver := func(_ context.Context, target StreamTarget) (agent.StreamSink, error) {
+		if target.Kind != "test" || target.ID != "chan-1" {
+			t.Fatalf("resolver target = %+v", target)
+		}
+		return agent.StreamSinkFunc(func(
+			_ context.Context,
+			env event.Envelope,
+			_ agent.StreamDeltaPayload,
+		) error {
+			received <- env
+			return nil
+		}), nil
+	}
+	engine := agent.EngineFunc(func(
+		ctx context.Context,
+		run agent.Run,
+		host agent.Host,
+		board *agent.Board,
+	) (*agent.Board, error) {
+		ctx = agent.WithRunInfo(ctx, run.Info())
+		if err := agent.EmitStreamPart(
+			ctx, host, run.RunID, "writer.node.work",
+			message.TextPart{Text: "resolved"}); err != nil {
+			return nil, err
+		}
+		board.AppendChannelMessage(agent.MainChannel,
+			message.NewTextMessage(message.RoleAssistant, "done"))
+		return board, nil
+	})
+	result := buildResult(t, delegationWithRunEnd(engine))
+	directory := NewDirectory()
+	if err := directory.Bind(result); err != nil {
+		t.Fatal(err)
+	}
+	service, err := NewService(directory, nil, WithStreamTargetResolver(resolver))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = service.Close() })
+	manager := newTestSessionManagerForResult(t, result)
+	if err := service.BindSessionManager(manager); err != nil {
+		t.Fatal(err)
+	}
+
+	ctx := agent.WithRunInfo(context.Background(), agent.RunInfo{
+		Identity: agent.Identity{AgentID: "caller-agent", RunID: "run-caller"},
+	})
+	ctx = tool.WithCallID(ctx, "call-delegate-2")
+	req := AsyncRequest{
+		Request: syncRequest("writer"),
+		Depth:   1,
+		Stream: &StreamRef{
+			Target: &StreamTarget{Kind: "test", ID: "chan-1"},
+		},
+	}
+	req.Request.Mode = ModeAsync
+	response, err := service.Run(ctx, req)
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if response.Status != StatusSucceeded {
+		t.Fatalf("response status = %q, want succeeded", response.Status)
+	}
+	deadline := time.After(5 * time.Second)
+	for {
+		select {
+		case env := <-received:
+			if env.ParentRunID() != "run-caller" || env.ToolCallID() != "call-delegate-2" {
+				t.Fatalf("lineage headers = %+v", env.Headers)
+			}
+			return
+		case <-deadline:
+			t.Fatal("resolved-sink stream envelope never received")
+		}
+	}
+}
+
+func waitUntil(t *testing.T, timeout time.Duration, cond func() bool) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if cond() {
+			return
+		}
+		time.Sleep(time.Millisecond)
+	}
+	if cond() {
+		return
+	}
+	t.Fatal("condition not met before deadline")
+}


### PR DESCRIPTION
Closes #439 (async half; sync half landed in #441).

## Summary

Async delegated subagents now emit **real-time** stream envelopes on the caller's live sink instances, carrying the same `parent_run_id` + `tool_call_id` lineage headers as sync delegations. The stream protocol is identical for sync and async; the difference is only how the live sinks cross the queue boundary.

## Design

Per the local plan `docs/plans/delegation-stream-lineage.md` §6:

- **`AsyncRequest` contract** (`core/delegation`): new `ParentRunID` / `CallID` / `Stream` fields, all JSON-serializable and backend-neutral. Sync and async both fill lineage at the boundary; async persists it across the queue.
- **In-process stream escrow** (`LocalService`): the caller's live sink specs (downgraded to observers, same as sync inheritance) are stored keyed by a pre-submit `StreamRef.Ref`. Workers restore them as an inheritable `StreamPolicy`, so the ordinary sync inheritance path (`delegationStartOptions` + `WithSinks`) attaches them — the worker's envelopes reach the exact same sink instance the caller's UI is listening on.
  - Lifecycle: released at terminal completion, refreshed on claim, swept by TTL (`WithStreamEscrowTTL`) as a leak backstop, released on submit failure and on `Close`.
  - No race on submit: the escrow key is generated before `Submit`, so a worker can claim and attach immediately.
- **Cross-process fallback**: `WithStreamTargetResolver` resolves a serializable `StreamTarget` (persisted in `AsyncRequest`) into a live sink when no escrow entry exists. Resolvers must whitelist target kinds.
- **Run-id correlation**: `RunIDNotifier` lets the worker record the subagent run id on the backend as soon as the turn starts (`Board.NoteRunID` re-publishes the claimed card event with `run_id`).
- **Operational visibility**: lineage is injected into the async `Request.Metadata` (`delegation.parent_run` / `delegation.call_id`) so kanban cards and `delegation_status` surface it without per-view plumbing; running/pending status responses now carry card metadata.

## Testing

- Escrow lifecycle: store/take (defensive copy) / release / TTL expiry.
- Async submit: lineage + stream ref + policy snapshot + metadata injection; escrow release on submit failure; no stream ref without an inheritable policy.
- End-to-end: async delegation streams lineage-stamped envelopes to the caller's sink in real time, and the escrow is released after completion.
- Resolver path: worker materializes a target through `WithStreamTargetResolver` when no escrow entry exists.
- Kanban: `NoteRunID` records/re-publishes run id (no-ops for unknown refs / duplicates), running status carries metadata.
- Gates: `make ci`, `make lint`, `make release-check`, `git diff --check` all pass.

## Follow-up (out of scope)

- Runtime-side whitelisted resolver implementations for cross-process backends (the interface and option are in place).