### PR TITLE
feat(core/runtime): whitelisted stream target resolver and exporter

### DIFF
--- a/core/delegation/service.go
+++ b/core/delegation/service.go
@@ -507,13 +507,18 @@ func (s *LocalService) delegate(
 		if specs, ok := s.asyncStreamSpecs(ctx); ok {
 			ref := "escrow-" + newID()
 			release := s.storeStreamEscrow(ref, specs)
-			asyncReq.Stream = &StreamRef{
+			stream := &StreamRef{
 				Ref:    ref,
-				Policy: streamPolicySnapshot(specs),
+				Policy: streamPolicySnapshotOf(specs[0]),
 			}
-			if target, ok := s.exportStreamTarget(specs); ok {
-				asyncReq.Stream.Target = &target
+			if target, spec, ok := s.exportStreamTarget(specs); ok {
+				stream.Target = &target
+				// The persisted policy describes the same sink the
+				// target came from, so the worker re-materializes the
+				// attachment with matching tuning.
+				stream.Policy = streamPolicySnapshotOf(spec)
 			}
+			asyncReq.Stream = stream
 			id, err := s.backend.Submit(ctx, asyncReq)
 			if err != nil {
 				release()
@@ -1084,31 +1089,52 @@ func (s *LocalService) asyncStreamSpecs(ctx context.Context) ([]session.SinkSpec
 }
 
 // exportStreamTarget runs the configured exporter over an inherited
-// sink set and returns the first describable target. ok=false when no
-// exporter is configured or no sink carries a durable destination.
-func (s *LocalService) exportStreamTarget(specs []session.SinkSpec) (StreamTarget, bool) {
+// sink set and returns the chosen target together with the spec it was
+// derived from (so the persisted policy snapshot stays aligned with the
+// target). Broadcast (bus) targets are preferred: cross-process
+// delivery restores exactly one destination, and a bus reaches every
+// subscriber. ok=false when no exporter is configured or no sink is
+// describable — with an exporter configured that silent degradation is
+// logged, because cross-process streaming then silently disappears.
+func (s *LocalService) exportStreamTarget(
+	specs []session.SinkSpec,
+) (StreamTarget, session.SinkSpec, bool) {
 	if s.streamExporter == nil {
-		return StreamTarget{}, false
+		return StreamTarget{}, session.SinkSpec{}, false
 	}
+	var first StreamTarget
+	var firstSpec session.SinkSpec
+	var firstOK bool
 	for _, spec := range specs {
-		if target, ok := s.streamExporter(spec); ok {
-			return target, true
+		target, ok := s.streamExporter(spec)
+		if !ok {
+			continue
+		}
+		if target.Kind == StreamTargetKindBus {
+			return target, spec, true
+		}
+		if !firstOK {
+			first, firstSpec, firstOK = target, spec, true
 		}
 	}
-	return StreamTarget{}, false
+	if !firstOK {
+		telemetry.Warn(context.Background(),
+			"local delegation: stream exporter matched no sink; "+
+				"cross-process streaming will be unavailable",
+			otellog.Int("delegation.stream_sinks", len(specs)))
+		return StreamTarget{}, session.SinkSpec{}, false
+	}
+	return first, firstSpec, true
 }
 
-// streamPolicySnapshot projects an inherited sink set onto the
-// serializable policy snapshot carried by AsyncRequest.Stream. It is
-// populated from the first spec; with multiple sinks the snapshot
-// reflects the first attachment's tuning (authority/ack fields are
-// informational — inherited attachments always downgrade to observers).
-func streamPolicySnapshot(specs []session.SinkSpec) StreamPolicySnapshot {
+// streamPolicySnapshotOf projects one sink spec onto the serializable
+// policy snapshot carried by AsyncRequest.Stream. The snapshot is
+// derived from the same spec that produced the persisted target, so
+// worker-side re-materialization applies matching tuning. Authority and
+// ack fields are informational — inherited attachments always downgrade
+// to observers.
+func streamPolicySnapshotOf(spec session.SinkSpec) StreamPolicySnapshot {
 	var snapshot StreamPolicySnapshot
-	if len(specs) == 0 {
-		return snapshot
-	}
-	spec := specs[0]
 	snapshot.Visibility = spec.Visibility
 	snapshot.Authority = spec.Authority
 	snapshot.AckMode = spec.AckMode

--- a/core/delegation/service.go
+++ b/core/delegation/service.go
@@ -117,6 +117,7 @@ type serviceConfig struct {
 	workerHost           agent.Host
 	sessionProvider      SessionProvider
 	streamResolver       StreamTargetResolver
+	streamExporter       StreamTargetExporter
 	deferWorkers         bool
 }
 
@@ -232,6 +233,23 @@ func WithStreamTargetResolver(resolver StreamTargetResolver) Option {
 	}
 }
 
+// WithStreamTargetExporter registers the caller-side exporter that
+// describes live sinks as serializable [StreamTarget]s on async
+// submit. When set, the exporter is consulted for each inherited sink
+// and the first describable target is persisted alongside the escrow
+// ref, so cross-process workers can re-materialize the destination
+// through [WithStreamTargetResolver] even when no in-process escrow
+// entry survives.
+func WithStreamTargetExporter(exporter StreamTargetExporter) Option {
+	return func(config *serviceConfig) error {
+		if exporter == nil {
+			return errdefs.Validationf("local delegation: stream target exporter is nil")
+		}
+		config.streamExporter = exporter
+		return nil
+	}
+}
+
 // WithSessionProvider sets the identity policy for delegated subagent
 // sessions. When nil and a session manager is bound, the service mints a
 // fresh ContextID per delegation.
@@ -288,6 +306,7 @@ type LocalService struct {
 	streamEscrow    map[string]streamEscrowEntry
 	streamEscrowTTL time.Duration
 	streamResolver  StreamTargetResolver
+	streamExporter  StreamTargetExporter
 	// sessionProvider is the identity policy for subagent sessions. It is
 	// immutable after construction.
 	sessionProvider SessionProvider
@@ -353,6 +372,7 @@ func NewService(directory *LocalDirectory, backend AsyncBackend, opts ...Option)
 		streamEscrow:         make(map[string]streamEscrowEntry),
 		streamEscrowTTL:      config.streamEscrowTTL,
 		streamResolver:       config.streamResolver,
+		streamExporter:       config.streamExporter,
 		workerCtx:            workerCtx,
 		cancelWorker:         cancelWorker,
 	}
@@ -490,6 +510,9 @@ func (s *LocalService) delegate(
 			asyncReq.Stream = &StreamRef{
 				Ref:    ref,
 				Policy: streamPolicySnapshot(specs),
+			}
+			if target, ok := s.exportStreamTarget(specs); ok {
+				asyncReq.Stream.Target = &target
 			}
 			id, err := s.backend.Submit(ctx, asyncReq)
 			if err != nil {
@@ -1058,6 +1081,21 @@ func (s *LocalService) asyncStreamSpecs(ctx context.Context) ([]session.SinkSpec
 		return nil, false
 	}
 	return inheritedSinkSpecs(policy.Sinks), true
+}
+
+// exportStreamTarget runs the configured exporter over an inherited
+// sink set and returns the first describable target. ok=false when no
+// exporter is configured or no sink carries a durable destination.
+func (s *LocalService) exportStreamTarget(specs []session.SinkSpec) (StreamTarget, bool) {
+	if s.streamExporter == nil {
+		return StreamTarget{}, false
+	}
+	for _, spec := range specs {
+		if target, ok := s.streamExporter(spec); ok {
+			return target, true
+		}
+	}
+	return StreamTarget{}, false
 }
 
 // streamPolicySnapshot projects an inherited sink set onto the

--- a/core/delegation/service.go
+++ b/core/delegation/service.go
@@ -511,7 +511,7 @@ func (s *LocalService) delegate(
 				Ref:    ref,
 				Policy: streamPolicySnapshotOf(specs[0]),
 			}
-			if target, spec, ok := s.exportStreamTarget(specs); ok {
+			if target, spec, ok := s.exportStreamTarget(ctx, specs); ok {
 				stream.Target = &target
 				// The persisted policy describes the same sink the
 				// target came from, so the worker re-materializes the
@@ -1097,6 +1097,7 @@ func (s *LocalService) asyncStreamSpecs(ctx context.Context) ([]session.SinkSpec
 // describable — with an exporter configured that silent degradation is
 // logged, because cross-process streaming then silently disappears.
 func (s *LocalService) exportStreamTarget(
+	ctx context.Context,
 	specs []session.SinkSpec,
 ) (StreamTarget, session.SinkSpec, bool) {
 	if s.streamExporter == nil {
@@ -1118,7 +1119,7 @@ func (s *LocalService) exportStreamTarget(
 		}
 	}
 	if !firstOK {
-		telemetry.Warn(context.Background(),
+		telemetry.Warn(ctx,
 			"local delegation: stream exporter matched no sink; "+
 				"cross-process streaming will be unavailable",
 			otellog.Int("delegation.stream_sinks", len(specs)))

--- a/core/delegation/stream.go
+++ b/core/delegation/stream.go
@@ -20,12 +20,33 @@ const (
 	CallIDMetadataKey = "delegation.call_id"
 )
 
+// Stream target kinds. The vocabulary is part of the delegation
+// contract so the submit side (exporter) and the worker side
+// (resolver) agree without importing the runtime.
+const (
+	// StreamTargetKindConversation routes envelopes to a live,
+	// conversation-scoped sink. Reachability is same-process: the
+	// resolving registry must hold the registered sink, so this kind
+	// recovers streams when the in-process escrow was lost (TTL,
+	// release) but does not deliver across processes.
+	StreamTargetKindConversation = "conversation"
+	// StreamTargetKindBus routes envelopes onto a named event bus.
+	// This is the kind capable of true cross-process delivery, as
+	// long as the bus implementation itself spans the processes.
+	StreamTargetKindBus = "bus"
+)
+
 // StreamTarget is a serializable description of where an async
 // subagent's stream envelopes should be delivered. It replaces the
 // live (non-serializable) sink across the queue boundary: the caller's
 // runtime knows how to describe its sinks as targets, and the worker's
 // runtime resolves them back into live sinks through
 // [StreamTargetResolver].
+//
+// AsyncRequest.Stream.Target is single-valued (see [StreamRef]): the
+// in-process escrow preserves every inherited sink, but the
+// cross-process path can restore exactly one destination. The exporter
+// prefers broadcast (bus) targets when several sinks are describable.
 type StreamTarget struct {
 	// Kind is the target vocabulary understood by the resolver
 	// (e.g. "conversation", "bus"). Resolvers MUST reject unknown
@@ -62,7 +83,9 @@ type StreamRef struct {
 	// Policy snapshots the caller's attachment tuning.
 	Policy StreamPolicySnapshot `json:"policy,omitempty"`
 	// Target describes the delivery destination for resolver-based
-	// materialization. Empty when the escrow path is used.
+	// materialization. Empty when the escrow path is used. At most
+	// one target is persisted: cross-process delivery is
+	// single-destination by contract.
 	Target *StreamTarget `json:"target,omitempty"`
 }
 
@@ -72,11 +95,22 @@ type StreamRef struct {
 // persisted data.
 type StreamTargetResolver func(ctx context.Context, target StreamTarget) (agent.StreamSink, error)
 
+// StreamTargetProvider is implemented by stream sinks that can describe
+// their durable destination as a serializable [StreamTarget].
+// [StreamTargetExporter]s recognize providers instead of concrete sink
+// types, so decorators (logging middleware, proxies) can pass the
+// description through without breaking recognition.
+type StreamTargetProvider interface {
+	StreamTarget() (StreamTarget, bool)
+}
+
 // StreamTargetExporter describes a caller-side live sink as a
 // serializable [StreamTarget] at async submit time, so cross-process
 // backends can re-materialize the same destination worker-side through
-// a [StreamTargetResolver]. It returns ok=false for sinks it cannot
-// describe (e.g. plain closures with no durable destination).
+// a [StreamTargetResolver]. It returns ok=false for sinks that are not
+// [StreamTargetProvider]s (e.g. plain closures with no durable
+// destination). Cross-process delivery restores at most one target —
+// see [StreamTarget].
 type StreamTargetExporter func(spec session.SinkSpec) (StreamTarget, bool)
 
 // RunIDNotifier is an optional AsyncBackend capability: it lets a

--- a/core/delegation/stream.go
+++ b/core/delegation/stream.go
@@ -72,6 +72,13 @@ type StreamRef struct {
 // persisted data.
 type StreamTargetResolver func(ctx context.Context, target StreamTarget) (agent.StreamSink, error)
 
+// StreamTargetExporter describes a caller-side live sink as a
+// serializable [StreamTarget] at async submit time, so cross-process
+// backends can re-materialize the same destination worker-side through
+// a [StreamTargetResolver]. It returns ok=false for sinks it cannot
+// describe (e.g. plain closures with no durable destination).
+type StreamTargetExporter func(spec session.SinkSpec) (StreamTarget, bool)
+
 // RunIDNotifier is an optional AsyncBackend capability: it lets a
 // claimed async work item record the subagent run id as soon as the
 // run starts, so operational views can correlate a delegation id with

--- a/core/delegation/stream_escrow_test.go
+++ b/core/delegation/stream_escrow_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/GizClaw/flowcraft/core/agent"
+	"github.com/GizClaw/flowcraft/core/errdefs"
 	"github.com/GizClaw/flowcraft/core/event"
 	"github.com/GizClaw/flowcraft/core/message"
 	"github.com/GizClaw/flowcraft/core/runtime/session"
@@ -127,6 +128,9 @@ func TestDelegateAsyncStampsLineageStreamRefAndEscrow(t *testing.T) {
 	if submitted.Stream == nil || submitted.Stream.Ref == "" {
 		t.Fatalf("submitted stream ref = %+v, want escrow ref", submitted.Stream)
 	}
+	if submitted.Stream.Target != nil {
+		t.Fatalf("submitted stream target = %+v, want nil without exporter", submitted.Stream.Target)
+	}
 	if submitted.Stream.Policy.QueueSize != 7 ||
 		submitted.Stream.Policy.DeliveryTimeout != time.Minute.Milliseconds() ||
 		submitted.Stream.Policy.Visibility != session.VisibilityConfirmed {
@@ -137,6 +141,54 @@ func TestDelegateAsyncStampsLineageStreamRefAndEscrow(t *testing.T) {
 	service.streamEscrowMu.Unlock()
 	if !escrowed {
 		t.Fatal("async submit did not leave an escrow entry")
+	}
+}
+
+func TestDelegateAsyncExporterPopulatesTarget(t *testing.T) {
+	backend := &captureAsyncBackend{submitted: make(chan AsyncRequest, 1)}
+	exporter := func(spec session.SinkSpec) (StreamTarget, bool) {
+		if spec.ID == "caller" {
+			return StreamTarget{Kind: "conversation", ID: "ctx-1"}, true
+		}
+		return StreamTarget{}, false
+	}
+	service, err := NewService(boundDirectory(t, completedEngine("unused")), backend,
+		WithStreamTargetExporter(exporter))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = service.Close() })
+
+	sink := agent.StreamSinkFunc(func(context.Context, event.Envelope, agent.StreamDeltaPayload) error {
+		return nil
+	})
+	ctx := session.WithStreamPolicy(context.Background(), session.StreamPolicy{
+		Sinks: []session.SinkSpec{{
+			ID:   "caller",
+			Sink: sink,
+		}},
+		Inheritable: true,
+	})
+	request := syncRequest("writer")
+	request.Mode = ModeAsync
+	if _, err := service.Delegate(ctx, request); err != nil {
+		t.Fatalf("Delegate: %v", err)
+	}
+	submitted := <-backend.submitted
+	if submitted.Stream == nil || submitted.Stream.Target == nil {
+		t.Fatalf("submitted stream = %+v, want escrow ref + conversation target", submitted.Stream)
+	}
+	if submitted.Stream.Target.Kind != "conversation" || submitted.Stream.Target.ID != "ctx-1" {
+		t.Fatalf("exported target = %+v", submitted.Stream.Target)
+	}
+}
+
+func TestWithStreamTargetExporterRejectsNil(t *testing.T) {
+	if _, err := NewService(
+		boundDirectory(t, completedEngine("unused")), nil,
+		WithStreamTargetExporter(nil),
+	); !errdefs.IsValidation(err) {
+		t.Fatalf("nil exporter error = %v, want validation", err)
 	}
 }
 

--- a/core/delegation/stream_escrow_test.go
+++ b/core/delegation/stream_escrow_test.go
@@ -162,11 +162,23 @@ func TestDelegateAsyncExporterPopulatesTarget(t *testing.T) {
 	sink := agent.StreamSinkFunc(func(context.Context, event.Envelope, agent.StreamDeltaPayload) error {
 		return nil
 	})
+	// The describable sink is NOT specs[0]: the persisted policy
+	// snapshot must come from the sink that produced the target.
 	ctx := session.WithStreamPolicy(context.Background(), session.StreamPolicy{
-		Sinks: []session.SinkSpec{{
-			ID:   "caller",
-			Sink: sink,
-		}},
+		Sinks: []session.SinkSpec{
+			{
+				ID:              "plain",
+				Sink:            sink,
+				QueueSize:       1,
+				DeliveryTimeout: time.Second,
+			},
+			{
+				ID:              "caller",
+				Sink:            sink,
+				QueueSize:       9,
+				DeliveryTimeout: 30 * time.Second,
+			},
+		},
 		Inheritable: true,
 	})
 	request := syncRequest("writer")
@@ -180,6 +192,51 @@ func TestDelegateAsyncExporterPopulatesTarget(t *testing.T) {
 	}
 	if submitted.Stream.Target.Kind != "conversation" || submitted.Stream.Target.ID != "ctx-1" {
 		t.Fatalf("exported target = %+v", submitted.Stream.Target)
+	}
+	if submitted.Stream.Policy.QueueSize != 9 ||
+		submitted.Stream.Policy.DeliveryTimeout != 30*time.Second.Milliseconds() {
+		t.Fatalf("policy snapshot not aligned with target sink: %+v", submitted.Stream.Policy)
+	}
+}
+
+func TestDelegateAsyncExporterPrefersBusTarget(t *testing.T) {
+	backend := &captureAsyncBackend{submitted: make(chan AsyncRequest, 1)}
+	exporter := func(spec session.SinkSpec) (StreamTarget, bool) {
+		switch spec.ID {
+		case "conversation":
+			return StreamTarget{Kind: "conversation", ID: "ctx-1"}, true
+		case "bus":
+			return StreamTarget{Kind: "bus", ID: "events"}, true
+		default:
+			return StreamTarget{}, false
+		}
+	}
+	service, err := NewService(boundDirectory(t, completedEngine("unused")), backend,
+		WithStreamTargetExporter(exporter))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = service.Close() })
+
+	sink := agent.StreamSinkFunc(func(context.Context, event.Envelope, agent.StreamDeltaPayload) error {
+		return nil
+	})
+	ctx := session.WithStreamPolicy(context.Background(), session.StreamPolicy{
+		Sinks: []session.SinkSpec{
+			{ID: "conversation", Sink: sink},
+			{ID: "bus", Sink: sink},
+		},
+		Inheritable: true,
+	})
+	request := syncRequest("writer")
+	request.Mode = ModeAsync
+	if _, err := service.Delegate(ctx, request); err != nil {
+		t.Fatalf("Delegate: %v", err)
+	}
+	submitted := <-backend.submitted
+	if submitted.Stream == nil || submitted.Stream.Target == nil ||
+		submitted.Stream.Target.Kind != "bus" || submitted.Stream.Target.ID != "events" {
+		t.Fatalf("exported target = %+v, want bus target preferred", submitted.Stream.Target)
 	}
 }
 

--- a/core/runtime/stream_export.go
+++ b/core/runtime/stream_export.go
@@ -1,0 +1,195 @@
+package runtime
+
+import (
+	"context"
+	"maps"
+	"sync"
+
+	"github.com/GizClaw/flowcraft/core/agent"
+	"github.com/GizClaw/flowcraft/core/delegation"
+	"github.com/GizClaw/flowcraft/core/errdefs"
+	"github.com/GizClaw/flowcraft/core/event"
+	"github.com/GizClaw/flowcraft/core/runtime/session"
+)
+
+// Stream target kinds understood by [StreamExportRegistry]. The
+// registry only ever resolves targets whose kind appears here; unknown
+// kinds from persisted backend records are rejected outright.
+const (
+	// StreamTargetConversation routes envelopes to a live,
+	// conversation-scoped sink registered by the UI/runtime (the
+	// destination survives the individual caller turn).
+	StreamTargetConversation = "conversation"
+	// StreamTargetBus forwards envelopes onto a runtime-owned event
+	// bus under their original subject, so any subscriber (SSE
+	// relay, dashboard) can consume async subagent streams.
+	StreamTargetBus = "bus"
+)
+
+// StreamExportRegistry is the runtime-owned bridge between the
+// serializable stream targets persisted in async delegation records
+// and the runtime's live stream transports.
+//
+// It implements both halves of the delegation stream contract:
+//   - Exporter describes sinks the runtime attached to a turn as
+//     serializable targets at async submit time;
+//   - Resolver re-materializes those targets worker-side when no
+//     in-process escrow entry survives (cross-process backends).
+//
+// Resolver is whitelisted by construction: it only accepts the kinds
+// declared above, and conversation sinks come from the registry's own
+// registered set — never from request data.
+type StreamExportRegistry struct {
+	mu            sync.Mutex
+	conversations map[string]agent.StreamSink
+	buses         map[string]event.Bus
+}
+
+// NewStreamExportRegistry builds a registry over the given whitelist
+// of named event buses. conversations is empty until the UI attaches
+// through RegisterConversation.
+func NewStreamExportRegistry(buses map[string]event.Bus) *StreamExportRegistry {
+	return &StreamExportRegistry{
+		conversations: make(map[string]agent.StreamSink),
+		buses:         maps.Clone(buses),
+	}
+}
+
+// RegisterConversation attaches a live, conversation-scoped sink that
+// outlives individual turns. UI layers call this when they open a
+// conversation and UnregisterConversation when they detach. Nil sinks
+// are ignored.
+func (r *StreamExportRegistry) RegisterConversation(contextID string, sink agent.StreamSink) {
+	if contextID == "" || isNil(sink) {
+		return
+	}
+	wrapped := conversationStreamSink{contextID: contextID, inner: sink}
+	r.mu.Lock()
+	r.conversations[contextID] = wrapped
+	r.mu.Unlock()
+}
+
+// UnregisterConversation removes the conversation's sink. Idempotent.
+func (r *StreamExportRegistry) UnregisterConversation(contextID string) {
+	if contextID == "" {
+		return
+	}
+	r.mu.Lock()
+	delete(r.conversations, contextID)
+	r.mu.Unlock()
+}
+
+// ConversationSink returns the registered live sink for a conversation,
+// wrapped with its context id so [StreamExportRegistry.Exporter] can
+// describe it. Turn attachment should use this instance as the
+// SinkSpec.Sink so the async exporter recognizes the destination.
+// ok=false when the conversation is not attached.
+func (r *StreamExportRegistry) ConversationSink(contextID string) (agent.StreamSink, bool) {
+	if contextID == "" {
+		return nil, false
+	}
+	r.mu.Lock()
+	sink, ok := r.conversations[contextID]
+	r.mu.Unlock()
+	if !ok || isNil(sink) {
+		return nil, false
+	}
+	return sink, true
+}
+
+// Exporter implements delegation.StreamTargetExporter: it recognizes
+// sinks registered through RegisterConversation (and only those) and
+// describes them as conversation targets. All other sinks report
+// ok=false.
+func (r *StreamExportRegistry) Exporter(spec session.SinkSpec) (delegation.StreamTarget, bool) {
+	sink, ok := spec.Sink.(conversationStreamSink)
+	if !ok || isNil(sink.inner) {
+		return delegation.StreamTarget{}, false
+	}
+	return delegation.StreamTarget{
+		Kind: StreamTargetConversation,
+		ID:   sink.contextID,
+	}, true
+}
+
+// Resolver implements delegation.StreamTargetResolver with a strict
+// kind whitelist. conversation targets resolve to the registered live
+// sink; bus targets resolve to a fixed forwarder onto the named bus.
+// Unknown kinds are policy-denied; known kinds with unknown ids are
+// not-found or validation errors. No sink is ever constructed from
+// free-form persisted data.
+func (r *StreamExportRegistry) Resolver(
+	ctx context.Context,
+	target delegation.StreamTarget,
+) (agent.StreamSink, error) {
+	switch target.Kind {
+	case StreamTargetConversation:
+		if target.ID == "" {
+			return nil, errdefs.Validationf(
+				"runtime stream export: conversation target id is required")
+		}
+		r.mu.Lock()
+		sink, ok := r.conversations[target.ID]
+		r.mu.Unlock()
+		if !ok || isNil(sink) {
+			return nil, errdefs.NotAvailablef(
+				"runtime stream export: conversation %q has no attached sink",
+				target.ID)
+		}
+		return sink, nil
+	case StreamTargetBus:
+		if target.ID == "" {
+			return nil, errdefs.Validationf(
+				"runtime stream export: bus target id is required")
+		}
+		r.mu.Lock()
+		bus, ok := r.buses[target.ID]
+		r.mu.Unlock()
+		if !ok || isNil(bus) {
+			return nil, errdefs.Validationf(
+				"runtime stream export: unknown bus %q", target.ID)
+		}
+		return busStreamSink{busName: target.ID, bus: bus}, nil
+	default:
+		return nil, errdefs.PolicyDeniedf(
+			"runtime stream export: target kind %q is not whitelisted",
+			target.Kind)
+	}
+}
+
+// conversationStreamSink wraps a conversation-scoped sink with its
+// context id so [StreamExportRegistry.Exporter] can recognize it.
+// OnDelta forwards to the wrapped sink unchanged.
+type conversationStreamSink struct {
+	contextID string
+	inner     agent.StreamSink
+}
+
+func (s conversationStreamSink) OnDelta(
+	ctx context.Context,
+	env event.Envelope,
+	delta agent.StreamDeltaPayload,
+) error {
+	return s.inner.OnDelta(ctx, env, delta)
+}
+
+// busStreamSink forwards every stream envelope onto a named bus under
+// its original subject, so subscribers can pick up async subagent
+// streams without a live per-turn sink.
+type busStreamSink struct {
+	busName string
+	bus     event.Bus
+}
+
+func (s busStreamSink) OnDelta(
+	ctx context.Context,
+	env event.Envelope,
+	_ agent.StreamDeltaPayload,
+) error {
+	return s.bus.Publish(ctx, env)
+}
+
+var (
+	_ agent.StreamSink = conversationStreamSink{}
+	_ agent.StreamSink = busStreamSink{}
+)

--- a/core/runtime/stream_export.go
+++ b/core/runtime/stream_export.go
@@ -10,20 +10,9 @@ import (
 	"github.com/GizClaw/flowcraft/core/errdefs"
 	"github.com/GizClaw/flowcraft/core/event"
 	"github.com/GizClaw/flowcraft/core/runtime/session"
-)
+	"github.com/GizClaw/flowcraft/core/telemetry"
 
-// Stream target kinds understood by [StreamExportRegistry]. The
-// registry only ever resolves targets whose kind appears here; unknown
-// kinds from persisted backend records are rejected outright.
-const (
-	// StreamTargetConversation routes envelopes to a live,
-	// conversation-scoped sink registered by the UI/runtime (the
-	// destination survives the individual caller turn).
-	StreamTargetConversation = "conversation"
-	// StreamTargetBus forwards envelopes onto a runtime-owned event
-	// bus under their original subject, so any subscriber (SSE
-	// relay, dashboard) can consume async subagent streams.
-	StreamTargetBus = "bus"
+	otellog "go.opentelemetry.io/otel/log"
 )
 
 // StreamExportRegistry is the runtime-owned bridge between the
@@ -32,13 +21,23 @@ const (
 //
 // It implements both halves of the delegation stream contract:
 //   - Exporter describes sinks the runtime attached to a turn as
-//     serializable targets at async submit time;
+//     serializable targets at async submit time. It recognizes sinks
+//     that implement delegation.StreamTargetProvider (the registry's
+//     conversation sinks do), so decorators wrapping a conversation
+//     sink can pass the description through;
 //   - Resolver re-materializes those targets worker-side when no
-//     in-process escrow entry survives (cross-process backends).
+//     in-process escrow entry survives.
 //
 // Resolver is whitelisted by construction: it only accepts the kinds
-// declared above, and conversation sinks come from the registry's own
-// registered set — never from request data.
+// declared by the delegation contract (conversation, bus), and
+// conversation sinks come from the registry's own registered set —
+// never from request data.
+//
+// Reachability: conversation targets resolve to a live sink registered
+// in the resolving process's registry, so they recover streams when
+// the in-process escrow was lost but do NOT deliver across processes.
+// Bus targets resolve to a named bus and are the kind capable of true
+// cross-process delivery (when the bus transport spans processes).
 type StreamExportRegistry struct {
 	mu            sync.Mutex
 	conversations map[string]agent.StreamSink
@@ -65,6 +64,11 @@ func (r *StreamExportRegistry) RegisterConversation(contextID string, sink agent
 	}
 	wrapped := conversationStreamSink{contextID: contextID, inner: sink}
 	r.mu.Lock()
+	if _, existing := r.conversations[contextID]; existing {
+		telemetry.Debug(context.Background(),
+			"runtime stream export: replacing conversation sink",
+			otellog.String("runtime.stream_export.context", contextID))
+	}
 	r.conversations[contextID] = wrapped
 	r.mu.Unlock()
 }
@@ -98,18 +102,16 @@ func (r *StreamExportRegistry) ConversationSink(contextID string) (agent.StreamS
 }
 
 // Exporter implements delegation.StreamTargetExporter: it recognizes
-// sinks registered through RegisterConversation (and only those) and
-// describes them as conversation targets. All other sinks report
-// ok=false.
+// sinks that implement delegation.StreamTargetProvider (the registry's
+// conversation sinks do, and decorators may pass the description
+// through) and describes them as conversation targets. All other sinks
+// report ok=false.
 func (r *StreamExportRegistry) Exporter(spec session.SinkSpec) (delegation.StreamTarget, bool) {
-	sink, ok := spec.Sink.(conversationStreamSink)
-	if !ok || isNil(sink.inner) {
+	provider, ok := spec.Sink.(delegation.StreamTargetProvider)
+	if !ok {
 		return delegation.StreamTarget{}, false
 	}
-	return delegation.StreamTarget{
-		Kind: StreamTargetConversation,
-		ID:   sink.contextID,
-	}, true
+	return provider.StreamTarget()
 }
 
 // Resolver implements delegation.StreamTargetResolver with a strict
@@ -123,7 +125,7 @@ func (r *StreamExportRegistry) Resolver(
 	target delegation.StreamTarget,
 ) (agent.StreamSink, error) {
 	switch target.Kind {
-	case StreamTargetConversation:
+	case delegation.StreamTargetKindConversation:
 		if target.ID == "" {
 			return nil, errdefs.Validationf(
 				"runtime stream export: conversation target id is required")
@@ -137,11 +139,15 @@ func (r *StreamExportRegistry) Resolver(
 				target.ID)
 		}
 		return sink, nil
-	case StreamTargetBus:
+	case delegation.StreamTargetKindBus:
 		if target.ID == "" {
 			return nil, errdefs.Validationf(
 				"runtime stream export: bus target id is required")
 		}
+		// Unknown bus names are Validation (static runtime
+		// configuration fixed at construction), while an unattached
+		// conversation is NotAvailable (a dynamic resource the UI
+		// registers at runtime).
 		r.mu.Lock()
 		bus, ok := r.buses[target.ID]
 		r.mu.Unlock()
@@ -158,11 +164,22 @@ func (r *StreamExportRegistry) Resolver(
 }
 
 // conversationStreamSink wraps a conversation-scoped sink with its
-// context id so [StreamExportRegistry.Exporter] can recognize it.
-// OnDelta forwards to the wrapped sink unchanged.
+// context id. It implements [delegation.StreamTargetProvider] so
+// [StreamExportRegistry.Exporter] recognizes it without a concrete
+// type assertion, and OnDelta forwards to the wrapped sink unchanged.
 type conversationStreamSink struct {
 	contextID string
 	inner     agent.StreamSink
+}
+
+func (s conversationStreamSink) StreamTarget() (delegation.StreamTarget, bool) {
+	if s.contextID == "" || isNil(s.inner) {
+		return delegation.StreamTarget{}, false
+	}
+	return delegation.StreamTarget{
+		Kind: delegation.StreamTargetKindConversation,
+		ID:   s.contextID,
+	}, true
 }
 
 func (s conversationStreamSink) OnDelta(

--- a/core/runtime/stream_export_test.go
+++ b/core/runtime/stream_export_test.go
@@ -2,15 +2,20 @@ package runtime
 
 import (
 	"context"
+	"strconv"
+	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/GizClaw/flowcraft/core/agent"
 	"github.com/GizClaw/flowcraft/core/delegation"
+	"github.com/GizClaw/flowcraft/core/deploy"
 	"github.com/GizClaw/flowcraft/core/errdefs"
 	"github.com/GizClaw/flowcraft/core/event"
 	"github.com/GizClaw/flowcraft/core/message"
+	"github.com/GizClaw/flowcraft/core/resource"
 	"github.com/GizClaw/flowcraft/core/runtime/session"
+	"github.com/GizClaw/flowcraft/core/tool"
 )
 
 func TestStreamExportRegistry_ConversationLifecycle(t *testing.T) {
@@ -36,7 +41,7 @@ func TestStreamExportRegistry_ConversationLifecycle(t *testing.T) {
 
 	// Exporter describes the registry's own sinks.
 	target, ok := reg.Exporter(session.SinkSpec{ID: "conv", Sink: sink})
-	if !ok || target.Kind != StreamTargetConversation || target.ID != "ctx-1" {
+	if !ok || target.Kind != delegation.StreamTargetKindConversation || target.ID != "ctx-1" {
 		t.Fatalf("Exporter = %+v, %v; want conversation target ctx-1", target, ok)
 	}
 	// Exporter ignores foreign sinks.
@@ -94,30 +99,77 @@ func TestStreamExportRegistry_ResolverWhitelist(t *testing.T) {
 		t.Fatalf("unknown kind error = %v, want policy denied", err)
 	}
 	if _, err := reg.Resolver(context.Background(), delegation.StreamTarget{
-		Kind: StreamTargetConversation,
+		Kind: delegation.StreamTargetKindConversation,
 	}); !errdefs.IsValidation(err) {
 		t.Fatalf("empty conversation id error = %v, want validation", err)
 	}
 	if _, err := reg.Resolver(context.Background(), delegation.StreamTarget{
-		Kind: StreamTargetConversation, ID: "nope",
+		Kind: delegation.StreamTargetKindConversation, ID: "nope",
 	}); !errdefs.IsNotAvailable(err) {
 		t.Fatalf("unknown conversation error = %v, want not available", err)
 	}
 	if _, err := reg.Resolver(context.Background(), delegation.StreamTarget{
-		Kind: StreamTargetBus,
+		Kind: delegation.StreamTargetKindBus,
 	}); !errdefs.IsValidation(err) {
 		t.Fatalf("empty bus id error = %v, want validation", err)
 	}
 	if _, err := reg.Resolver(context.Background(), delegation.StreamTarget{
-		Kind: StreamTargetBus, ID: "missing-bus",
+		Kind: delegation.StreamTargetKindBus, ID: "missing-bus",
 	}); !errdefs.IsValidation(err) {
 		t.Fatalf("unknown bus error = %v, want validation", err)
 	}
 	if _, err := reg.Resolver(context.Background(), delegation.StreamTarget{
-		Kind: StreamTargetBus, ID: "events",
+		Kind: delegation.StreamTargetKindBus, ID: "events",
 	}); err != nil {
 		t.Fatalf("known bus error = %v", err)
 	}
+}
+
+// TestStreamExportRegistry_ExporterAcceptsDecoratedProviders verifies
+// the exporter recognizes sinks through the StreamTargetProvider
+// interface, so a decorator wrapping the registry's conversation sink
+// does not silently break cross-process streaming.
+func TestStreamExportRegistry_ExporterAcceptsDecoratedProviders(t *testing.T) {
+	reg := NewStreamExportRegistry(nil)
+	inner := agent.StreamSinkFunc(func(context.Context, event.Envelope, agent.StreamDeltaPayload) error {
+		return nil
+	})
+	reg.RegisterConversation("ctx-9", inner)
+	convSink, ok := reg.ConversationSink("ctx-9")
+	if !ok {
+		t.Fatal("conversation sink not registered")
+	}
+
+	decorated := decoratedProviderSink{StreamSink: convSink}
+	target, ok := reg.Exporter(session.SinkSpec{ID: "ui", Sink: decorated})
+	if !ok || target.Kind != delegation.StreamTargetKindConversation || target.ID != "ctx-9" {
+		t.Fatalf("Exporter over decorated provider = %+v, %v", target, ok)
+	}
+	// A decorator that does not forward the provider is opaque again.
+	opaque := agent.StreamSinkFunc(func(context.Context, event.Envelope, agent.StreamDeltaPayload) error {
+		return nil
+	})
+	if _, ok := reg.Exporter(session.SinkSpec{ID: "ui", Sink: opaque}); ok {
+		t.Fatal("Exporter described an opaque sink")
+	}
+}
+
+// decoratedProviderSink wraps a provider sink and passes the
+// description through, the recommended way for UI decorators to stay
+// recognizable.
+type decoratedProviderSink struct {
+	agent.StreamSink
+	provider delegation.StreamTargetProvider
+}
+
+func (s decoratedProviderSink) StreamTarget() (delegation.StreamTarget, bool) {
+	if s.provider != nil {
+		return s.provider.StreamTarget()
+	}
+	if p, ok := s.StreamSink.(delegation.StreamTargetProvider); ok {
+		return p.StreamTarget()
+	}
+	return delegation.StreamTarget{}, false
 }
 
 func TestStreamExportRegistry_BusForwardsEnvelopes(t *testing.T) {
@@ -132,7 +184,7 @@ func TestStreamExportRegistry_BusForwardsEnvelopes(t *testing.T) {
 	}
 
 	sink, err := reg.Resolver(context.Background(), delegation.StreamTarget{
-		Kind: StreamTargetBus, ID: "events",
+		Kind: delegation.StreamTargetKindBus, ID: "events",
 	})
 	if err != nil {
 		t.Fatalf("Resolver: %v", err)
@@ -149,4 +201,261 @@ func TestStreamExportRegistry_BusForwardsEnvelopes(t *testing.T) {
 	case <-time.After(time.Second):
 		t.Fatal("bus sink did not forward envelope to subscribers")
 	}
+}
+
+// TestStreamExportFullChainRegistryToWorker verifies the complete seam
+// end-to-end: a sink attached to the submit context through the
+// registry's ConversationSink is recognized by the registry exporter,
+// the target is persisted in AsyncRequest, and after the in-process
+// escrow is gone (simulated cross-process/restart) the worker resolves
+// the target back through the registry resolver and the subagent's
+// stream deltas reach the registered conversation sink with lineage
+// headers.
+func TestStreamExportFullChainRegistryToWorker(t *testing.T) {
+	received := make(chan event.Envelope, 16)
+	reg := NewStreamExportRegistry(nil)
+	reg.RegisterConversation("ctx-1", agent.StreamSinkFunc(func(
+		_ context.Context,
+		env event.Envelope,
+		_ agent.StreamDeltaPayload,
+	) error {
+		received <- env
+		return nil
+	}))
+
+	engine := agent.EngineFunc(func(
+		ctx context.Context,
+		run agent.Run,
+		host agent.Host,
+		board *agent.Board,
+	) (*agent.Board, error) {
+		ctx = agent.WithRunInfo(ctx, run.Info())
+		if err := agent.EmitStreamPart(ctx, host, run.RunID,
+			"writer.node.work", message.TextPart{Text: "async hi"}); err != nil {
+			return nil, err
+		}
+		board.AppendChannelMessage(agent.MainChannel,
+			message.NewTextMessage(message.RoleAssistant, "done"))
+		if err := publishRunEvent(ctx, host, agent.SubjectRunEnd(run.RunID), run); err != nil {
+			return nil, err
+		}
+		return board, nil
+	})
+	result := buildStreamExportDeployment(t, engine)
+	directory := delegation.NewDirectory()
+	if err := directory.Bind(result); err != nil {
+		t.Fatal(err)
+	}
+	backend := newStreamExportQueueBackend()
+	service, err := delegation.NewService(directory, backend,
+		delegation.WithStreamTargetResolver(reg.Resolver),
+		delegation.WithStreamTargetExporter(reg.Exporter),
+		delegation.WithStreamEscrowTTL(20*time.Millisecond),
+		delegation.WithMaxConcurrency(1),
+		delegation.WithDeferredWorkers(),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = service.Close() })
+	if err := service.BindSessionManager(newStreamExportSessionManager(t, result)); err != nil {
+		t.Fatal(err)
+	}
+
+	convSink, ok := reg.ConversationSink("ctx-1")
+	if !ok {
+		t.Fatal("conversation sink missing after register")
+	}
+	ctx := session.WithStreamPolicy(context.Background(), session.StreamPolicy{
+		Sinks: []session.SinkSpec{{
+			ID:   "ui",
+			Sink: convSink,
+		}},
+		Inheritable: true,
+	})
+	ctx = agent.WithRunInfo(ctx, agent.RunInfo{
+		Identity: agent.Identity{AgentID: "caller-agent", RunID: "run-caller"},
+	})
+	ctx = tool.WithCallID(ctx, "call-delegate-1")
+	accepted, err := service.Delegate(ctx, delegation.Request{
+		Mode: delegation.ModeAsync, Target: "writer", Input: "do it",
+	})
+	if err != nil {
+		t.Fatalf("Delegate: %v", err)
+	}
+	if accepted.Status != delegation.StatusAccepted {
+		t.Fatalf("status = %q, want accepted", accepted.Status)
+	}
+	submitted := <-backend.submitted
+	if submitted.Stream == nil || submitted.Stream.Target == nil ||
+		submitted.Stream.Target.Kind != delegation.StreamTargetKindConversation ||
+		submitted.Stream.Target.ID != "ctx-1" {
+		t.Fatalf("exporter seam: stream = %+v", submitted.Stream)
+	}
+
+	// Simulate a worker that lost the in-process escrow (TTL expiry,
+	// restart): start workers only after the escrow entry expired so
+	// the resolver path is exercised.
+	time.Sleep(80 * time.Millisecond)
+	if err := service.Start(); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	select {
+	case completed := <-backend.completed:
+		if completed.Status != delegation.StatusSucceeded {
+			t.Fatalf("completed = %+v", completed)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("worker did not complete async work")
+	}
+
+	deadline := time.After(5 * time.Second)
+	for {
+		select {
+		case env := <-received:
+			if env.ParentRunID() != "run-caller" || env.ToolCallID() != "call-delegate-1" {
+				t.Fatalf("lineage headers = %+v", env.Headers)
+			}
+			return
+		case <-deadline:
+			t.Fatal("registry-resolved stream envelope never received")
+		}
+	}
+}
+
+// streamExportEngineFactory builds the "writer" agent used by the
+// full-chain test.
+type streamExportEngineFactory struct {
+	engine agent.Engine
+}
+
+func (f streamExportEngineFactory) Spec() resource.Spec {
+	return resource.Spec{Kind: "agent.Engine", Impl: "stream-export-test"}
+}
+
+func (f streamExportEngineFactory) New(context.Context, resource.Input) (any, error) {
+	return f.engine, nil
+}
+
+func buildStreamExportDeployment(t *testing.T, engine agent.Engine) *deploy.Result {
+	t.Helper()
+	reg := resource.NewRegistry()
+	if err := reg.Register(streamExportEngineFactory{engine: engine}); err != nil {
+		t.Fatal(err)
+	}
+	doc := deploy.Document{
+		Version: "v1",
+		Agents: map[string]agent.Definition{
+			"writer": {
+				Card:   agent.AgentCard{Name: "Writer", Description: "Writes"},
+				Engine: agent.EngineRef{Kind: "agent.Engine", Impl: "stream-export-test"},
+			},
+		},
+	}
+	result, err := deploy.NewBuilder(reg).Deploy(context.Background(), doc)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = result.Close() })
+	return result
+}
+
+type streamExportResultResolver struct {
+	result *deploy.Result
+}
+
+func (r streamExportResultResolver) Instance(id string) (*agent.Agent, bool) {
+	return r.result.Agent(id)
+}
+
+type streamExportTestHost struct {
+	agent.NoopHost
+	bus event.Bus
+}
+
+func (h streamExportTestHost) Publish(ctx context.Context, env event.Envelope) error {
+	return h.bus.Publish(ctx, env)
+}
+
+func newStreamExportSessionManager(t *testing.T, result *deploy.Result) *session.Manager {
+	t.Helper()
+	bus := event.NewMemoryBus()
+	router := event.NewRouter(bus)
+	factory := session.HostFactoryFunc(func(
+		_ context.Context,
+		request session.HostRequest,
+	) (agent.Host, error) {
+		return agent.HostFuncs{
+			Inner:        streamExportTestHost{bus: bus},
+			InterruptsFn: func() <-chan agent.Interrupt { return request.Interrupts },
+			AskUserFn:    request.AskUser,
+		}, nil
+	})
+	manager, err := session.NewManager(
+		streamExportResultResolver{result: result},
+		factory,
+		router,
+		session.WithIdleTimeout(time.Minute),
+		session.WithSinkBufferSize(8),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		_ = manager.Close()
+		_ = router.Close()
+		_ = bus.Close()
+	})
+	return manager
+}
+
+type streamExportQueueBackend struct {
+	submitted chan delegation.AsyncRequest
+	work      chan delegation.Work
+	completed chan delegation.Response
+	next      atomic.Int64
+}
+
+func newStreamExportQueueBackend() *streamExportQueueBackend {
+	return &streamExportQueueBackend{
+		submitted: make(chan delegation.AsyncRequest, 4),
+		work:      make(chan delegation.Work, 4),
+		completed: make(chan delegation.Response, 4),
+	}
+}
+
+func (b *streamExportQueueBackend) Submit(
+	_ context.Context,
+	req delegation.AsyncRequest,
+) (string, error) {
+	id := "async-" + strconv.Itoa(int(b.next.Add(1)))
+	b.submitted <- req
+	b.work <- delegation.Work{ID: id, LeaseToken: "lease-" + id, Request: req}
+	return id, nil
+}
+
+func (b *streamExportQueueBackend) Status(
+	context.Context,
+	string,
+) (delegation.Response, error) {
+	return delegation.Response{Status: delegation.StatusRunning}, nil
+}
+
+func (b *streamExportQueueBackend) Claim(ctx context.Context) (delegation.Work, error) {
+	select {
+	case work := <-b.work:
+		return work, nil
+	case <-ctx.Done():
+		return delegation.Work{}, ctx.Err()
+	}
+}
+
+func (b *streamExportQueueBackend) Complete(
+	_ context.Context,
+	_ string,
+	_ string,
+	response delegation.Response,
+) error {
+	b.completed <- response
+	return nil
 }

--- a/core/runtime/stream_export_test.go
+++ b/core/runtime/stream_export_test.go
@@ -1,0 +1,152 @@
+package runtime
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/GizClaw/flowcraft/core/agent"
+	"github.com/GizClaw/flowcraft/core/delegation"
+	"github.com/GizClaw/flowcraft/core/errdefs"
+	"github.com/GizClaw/flowcraft/core/event"
+	"github.com/GizClaw/flowcraft/core/message"
+	"github.com/GizClaw/flowcraft/core/runtime/session"
+)
+
+func TestStreamExportRegistry_ConversationLifecycle(t *testing.T) {
+	reg := NewStreamExportRegistry(nil)
+	received := make(chan agent.StreamDeltaPayload, 4)
+	inner := agent.StreamSinkFunc(func(
+		_ context.Context,
+		_ event.Envelope,
+		delta agent.StreamDeltaPayload,
+	) error {
+		received <- delta
+		return nil
+	})
+
+	reg.RegisterConversation("ctx-1", inner)
+	sink, ok := reg.ConversationSink("ctx-1")
+	if !ok {
+		t.Fatal("ConversationSink missing after register")
+	}
+	if _, ok := sink.(conversationStreamSink); !ok {
+		t.Fatalf("registered sink type = %T, want conversationStreamSink", sink)
+	}
+
+	// Exporter describes the registry's own sinks.
+	target, ok := reg.Exporter(session.SinkSpec{ID: "conv", Sink: sink})
+	if !ok || target.Kind != StreamTargetConversation || target.ID != "ctx-1" {
+		t.Fatalf("Exporter = %+v, %v; want conversation target ctx-1", target, ok)
+	}
+	// Exporter ignores foreign sinks.
+	if _, ok := reg.Exporter(session.SinkSpec{
+		ID: "foreign", Sink: agent.StreamSinkFunc(func(
+			context.Context, event.Envelope, agent.StreamDeltaPayload,
+		) error {
+			return nil
+		}),
+	}); ok {
+		t.Fatal("Exporter described a foreign sink")
+	}
+
+	// Resolver returns the registered sink and it forwards deltas.
+	resolved, err := reg.Resolver(context.Background(), target)
+	if err != nil {
+		t.Fatalf("Resolver: %v", err)
+	}
+	if err := resolved.OnDelta(context.Background(), event.Envelope{},
+		agent.StreamDeltaPayload{Type: agent.StreamDeltaPart,
+			Part: message.TextPart{Text: "x"}}); err != nil {
+		t.Fatalf("OnDelta: %v", err)
+	}
+	select {
+	case delta := <-received:
+		if delta.Type != agent.StreamDeltaPart {
+			t.Fatalf("delta = %+v", delta)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("resolved sink did not forward delta to inner sink")
+	}
+
+	reg.UnregisterConversation("ctx-1")
+	if _, ok := reg.ConversationSink("ctx-1"); ok {
+		t.Fatal("ConversationSink still present after unregister")
+	}
+	if _, err := reg.Resolver(context.Background(), target); !errdefs.IsNotAvailable(err) {
+		t.Fatalf("Resolver after unregister error = %v, want not available", err)
+	}
+	reg.UnregisterConversation("ctx-1")    // idempotent
+	reg.RegisterConversation("ctx-1", nil) // ignored
+	if _, ok := reg.ConversationSink("ctx-1"); ok {
+		t.Fatal("nil register attached a sink")
+	}
+}
+
+func TestStreamExportRegistry_ResolverWhitelist(t *testing.T) {
+	bus := event.NewMemoryBus()
+	t.Cleanup(func() { _ = bus.Close() })
+	reg := NewStreamExportRegistry(map[string]event.Bus{"events": bus})
+
+	if _, err := reg.Resolver(context.Background(), delegation.StreamTarget{
+		Kind: "unknown", ID: "x",
+	}); !errdefs.IsPolicyDenied(err) {
+		t.Fatalf("unknown kind error = %v, want policy denied", err)
+	}
+	if _, err := reg.Resolver(context.Background(), delegation.StreamTarget{
+		Kind: StreamTargetConversation,
+	}); !errdefs.IsValidation(err) {
+		t.Fatalf("empty conversation id error = %v, want validation", err)
+	}
+	if _, err := reg.Resolver(context.Background(), delegation.StreamTarget{
+		Kind: StreamTargetConversation, ID: "nope",
+	}); !errdefs.IsNotAvailable(err) {
+		t.Fatalf("unknown conversation error = %v, want not available", err)
+	}
+	if _, err := reg.Resolver(context.Background(), delegation.StreamTarget{
+		Kind: StreamTargetBus,
+	}); !errdefs.IsValidation(err) {
+		t.Fatalf("empty bus id error = %v, want validation", err)
+	}
+	if _, err := reg.Resolver(context.Background(), delegation.StreamTarget{
+		Kind: StreamTargetBus, ID: "missing-bus",
+	}); !errdefs.IsValidation(err) {
+		t.Fatalf("unknown bus error = %v, want validation", err)
+	}
+	if _, err := reg.Resolver(context.Background(), delegation.StreamTarget{
+		Kind: StreamTargetBus, ID: "events",
+	}); err != nil {
+		t.Fatalf("known bus error = %v", err)
+	}
+}
+
+func TestStreamExportRegistry_BusForwardsEnvelopes(t *testing.T) {
+	bus := event.NewMemoryBus()
+	t.Cleanup(func() { _ = bus.Close() })
+	reg := NewStreamExportRegistry(map[string]event.Bus{"events": bus})
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	sub, err := bus.Subscribe(ctx, event.Pattern("nrun.>"))
+	if err != nil {
+		t.Fatalf("Subscribe: %v", err)
+	}
+
+	sink, err := reg.Resolver(context.Background(), delegation.StreamTarget{
+		Kind: StreamTargetBus, ID: "events",
+	})
+	if err != nil {
+		t.Fatalf("Resolver: %v", err)
+	}
+	env := event.Envelope{Subject: "nrun.run-1.agent-x.node.work"}
+	if err := sink.OnDelta(context.Background(), env, agent.StreamDeltaPayload{}); err != nil {
+		t.Fatalf("OnDelta: %v", err)
+	}
+	select {
+	case got := <-sub.C():
+		if got.Subject != env.Subject {
+			t.Fatalf("forwarded subject = %q, want %q", got.Subject, env.Subject)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("bus sink did not forward envelope to subscribers")
+	}
+}

--- a/docs/guides/delegation.md
+++ b/docs/guides/delegation.md
@@ -119,9 +119,37 @@ detach the attachment mid-run). Visibility is preserved.
 
 An inherited sink may be invoked concurrently from multiple sessions
 (the caller turn plus parallel subagents) and must be safe for concurrent
-`OnDelta` calls. Async delegation does not inherit: the caller context
-does not cross the backend queue, and the worker is not a live UI
-consumer.
+`OnDelta` calls.
+
+Async delegation inherits the same way, across the queue boundary:
+
+- **In-process (escrow):** the submit side stores the caller's live sink
+  specs in a service-side escrow referenced by `AsyncRequest.Stream.Ref`;
+  the worker restores them and attaches them, so deltas reach the exact
+  sink instances the caller's UI is listening on. Entries are released
+  at terminal completion and swept by TTL as a backstop.
+- **Cross-process (target + resolver):** the submit side also persists a
+  serializable `StreamTarget` (`AsyncRequest.Stream.Target`) describing
+  the destination. When no escrow entry survives (TTL expiry, restart, a
+  worker in another process), the worker resolves the target through the
+  runtime's whitelisted `StreamTargetResolver`
+  (`runtime.StreamExportRegistry`).
+- **Reachability:** `conversation` targets resolve to a live sink
+  registered in the resolving process's registry — they recover streams
+  in-process but do not deliver across processes. `bus` targets forward
+  onto a named event bus and are the kind capable of true cross-process
+  delivery, as long as the bus transport spans the processes.
+- **Single-destination caveat:** `StreamRef.Target` is single-valued.
+  The in-process escrow preserves every inherited sink; the
+  cross-process path restores exactly one. The exporter prefers
+  broadcast (bus) targets when several sinks are describable. Sinks
+  describe themselves by implementing `delegation.StreamTargetProvider`,
+  so UI decorators can pass the description through without breaking
+  recognition.
+- **Lifecycle:** async stream deltas carry lineage headers (`run_id`,
+  `parent_run_id`, `tool_call_id`, `agent_id`) but the sink sees no
+  explicit EOF; terminal state is reported through kanban card events
+  and `delegation_status`.
 
 See [runtime.md](runtime.md) for `WithResultHostFactory` and reload, and
 [tool.md](tool.md) for tool sources.

--- a/skills/flowcraft-config/references/resources.md
+++ b/skills/flowcraft-config/references/resources.md
@@ -295,6 +295,39 @@ Expose the service on every turn host with
 directory binds the current deployment generation, so reloads delegate
 against the new generation's agents.
 
+### Async streaming
+
+Async delegations stream subagent deltas to the caller's live sinks by
+default: the submit side stores the caller's sinks in a service-side
+escrow and the worker restores them, so no YAML settings are needed.
+Streams carry lineage headers (`run_id`, `parent_run_id`, `tool_call_id`,
+`agent_id`).
+
+Cross-process delivery (worker without the escrow: TTL expiry, restart,
+separate process) is wired in Go, not YAML — build a
+`runtime.StreamExportRegistry`, register its resolver/exporter on the
+delegation service factory, and expose the service on turn hosts:
+
+```go
+reg := runtime.NewStreamExportRegistry(map[string]event.Bus{"events": bus})
+delegation.NewServiceFactory(
+    delegation.WithStreamTargetResolver(reg.Resolver),
+    delegation.WithStreamTargetExporter(reg.Exporter),
+)
+// + runtime.Builder.WithResultHostFactory(hostwrap.Wrap)
+```
+
+Target reachability: `conversation` targets resolve to a live sink
+registered in the resolving process's registry (same-process recovery
+only); `bus` targets forward onto a named event bus and are the
+cross-process option. `StreamRef.Target` is single-valued — the
+in-process escrow keeps every sink, the cross-process path restores
+exactly one, and the exporter prefers bus targets. Sinks describe
+themselves via `delegation.StreamTargetProvider`, so UI decorators can
+pass the description through. See
+[docs/guides/delegation.md](../../../docs/guides/delegation.md) for the
+full lifecycle.
+
 ## checkpoint store
 
 ```yaml


### PR DESCRIPTION
Follow-up to #442 (async delegation streaming): implements the runtime half of the stream-target contract.

## Summary

The delegation service already persists a serializable `StreamTarget` and resolves it worker-side when no in-process escrow entry survives (`WithStreamTargetResolver`). This PR supplies the runtime-owned, **whitelisted** implementation of both halves:

- **Submit side**: `delegation.WithStreamTargetExporter` — the caller runtime describes its live sinks as serializable targets, so `AsyncRequest.Stream.Target` is populated in production (it was dead code before).
- **Worker side**: `runtime.StreamExportRegistry.Resolver` — whitelisted by construction, resolving exactly two kinds:
  - `conversation`: ID = ContextID → a runtime-registered, conversation-scoped live sink that outlives individual turns (`RegisterConversation` / `UnregisterConversation` / `ConversationSink`). Sinks come only from the registry's own set, never from request data.
  - `bus`: ID = a runtime-owned named bus → a fixed forwarder that publishes each envelope under its original subject, so any subscriber (SSE relay, dashboard) can consume async subagent streams.
  - Unknown kinds → `PolicyDenied`; empty ids → validation; unknown conversation → not-available.

## Changes

- `core/delegation`: `StreamTargetExporter` type + `WithStreamTargetExporter` option; async submit persists the first describable target alongside the escrow ref.
- `core/runtime/stream_export.go`: `StreamExportRegistry` with `RegisterConversation` / `UnregisterConversation` / `ConversationSink` / `Exporter` / `Resolver`, plus `conversationStreamSink` and `busStreamSink` adapters.
- Tests: registry conversation lifecycle (register → export → resolve → forward → unregister), resolver whitelist per kind, bus forwarding to subscribers, delegation exporter target population + nil validation.
- Gates: `make ci`, `make lint`, `make release-check`, `git diff --check` all pass.

## Wiring note

Deployments opt in by constructing the delegation service factory with the registry's resolver and exporter, e.g.:

```go
reg := runtime.NewStreamExportRegistry(map[string]event.Bus{"events": bus})
delegation.NewServiceFactory(
    delegation.WithStreamTargetResolver(reg.Resolver),
    delegation.WithStreamTargetExporter(reg.Exporter),
)
```

Forge UI wiring was deliberately left out of scope per request.