### PR TITLE
fix(core): complete delegation stream lineage and escrow lifecycle

### DIFF
--- a/core/agent/a2a/engine.go
+++ b/core/agent/a2a/engine.go
@@ -107,6 +107,10 @@ func (e *Engine) Execute(ctx context.Context, run agent.Run, host agent.Host, bo
 		board = agent.NewBoard()
 	}
 	retBoard = board
+	// Run identity is ambient: stream helpers (EmitStreamDelta) read it
+	// from the context, so stamp it once at the run boundary like the
+	// other engines do.
+	ctx = agent.WithRunInfo(ctx, run.Info())
 
 	spanAttrs := []attribute.KeyValue{
 		attribute.String(telemetry.AttrEngineKind, engineKind),
@@ -874,6 +878,7 @@ func publishRunEvent(ctx context.Context, host agent.Host, run agent.Run, subjec
 	}
 	env.SetAgentID(run.AgentID)
 	env.SetRunID(run.RunID)
+	stampLineage(&env, run)
 	return host.Publish(ctx, env)
 }
 
@@ -897,10 +902,24 @@ func publishStepEvent(ctx context.Context, host agent.Host, run agent.Run, subje
 	}
 	env.SetAgentID(run.AgentID)
 	env.SetRunID(run.RunID)
+	stampLineage(&env, run)
 	if err := host.Publish(ctx, env); err != nil {
 		telemetry.WarnErr(ctx, "a2a: step event publish failed", err,
 			otellog.String("event.subject", string(env.Subject)),
 			otellog.String(telemetry.AttrRunID, run.RunID))
+	}
+}
+
+// stampLineage projects run lineage onto a freshly minted envelope: the
+// parent run id (when this run was spawned by another run) and the
+// creating tool call id (when this run was spawned by a tool). Empty
+// values are skipped so top-level runs stay header-free.
+func stampLineage(env *event.Envelope, run agent.Run) {
+	if run.ParentRunID != "" {
+		env.SetParentRunID(run.ParentRunID)
+	}
+	if callID := run.Attribute(telemetry.AttrToolCallID); callID != "" {
+		env.SetToolCallID(callID)
 	}
 }
 

--- a/core/agent/a2a/lineage_test.go
+++ b/core/agent/a2a/lineage_test.go
@@ -1,0 +1,92 @@
+package a2a
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"github.com/GizClaw/flowcraft/core/agent"
+	"github.com/GizClaw/flowcraft/core/event"
+	"github.com/GizClaw/flowcraft/core/telemetry"
+)
+
+// TestEngineStampsRunLineageOnEvents verifies the A2A engine's own mint
+// points (run start/end, step lifecycle) carry the run's delegation
+// lineage headers, so envelopes published by an A2A-executed subagent
+// preserve the run tree like the graph engine's do.
+func TestEngineStampsRunLineageOnEvents(t *testing.T) {
+	var mu sync.Mutex
+	var envelopes []event.Envelope
+	host := agent.HostFuncs{
+		Inner: agent.NoopHost{},
+		PublishFn: func(_ context.Context, env event.Envelope) error {
+			mu.Lock()
+			envelopes = append(envelopes, env)
+			mu.Unlock()
+			return nil
+		},
+	}
+	eng, err := New(context.Background(), testCard(), WithStreamMode(StreamModeOff))
+	if err != nil {
+		t.Fatal(err)
+	}
+	run := agent.Run{
+		Identity: agent.Identity{
+			AgentID:     "a2a-agent",
+			RunID:       "run-a2a",
+			ParentRunID: "caller-run",
+		},
+		Attributes: map[string]string{telemetry.AttrToolCallID: "call-delegate-1"},
+	}
+	// An empty board completes as a local no-op without network I/O but
+	// still exercises the run/step event mint points.
+	if _, err := eng.Execute(context.Background(), run, host, agent.NewBoard()); err != nil {
+		t.Fatal(err)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(envelopes) == 0 {
+		t.Fatal("engine published no envelopes")
+	}
+	for _, env := range envelopes {
+		if env.ParentRunID() != "caller-run" || env.ToolCallID() != "call-delegate-1" {
+			t.Fatalf("envelope %q lineage headers = %+v", env.Subject, env.Headers)
+		}
+	}
+}
+
+// TestEngineKeepsTopLevelRunHeaderFreeOnEvents guards the inverse: run
+// events for a top-level run must stay free of parent/tool-call headers.
+func TestEngineKeepsTopLevelRunHeaderFreeOnEvents(t *testing.T) {
+	var mu sync.Mutex
+	var envelopes []event.Envelope
+	host := agent.HostFuncs{
+		Inner: agent.NoopHost{},
+		PublishFn: func(_ context.Context, env event.Envelope) error {
+			mu.Lock()
+			envelopes = append(envelopes, env)
+			mu.Unlock()
+			return nil
+		},
+	}
+	eng, err := New(context.Background(), testCard(), WithStreamMode(StreamModeOff))
+	if err != nil {
+		t.Fatal(err)
+	}
+	run := agent.Run{Identity: agent.Identity{AgentID: "a2a-agent", RunID: "run-a2a"}}
+	if _, err := eng.Execute(context.Background(), run, host, agent.NewBoard()); err != nil {
+		t.Fatal(err)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(envelopes) == 0 {
+		t.Fatal("engine published no envelopes")
+	}
+	for _, env := range envelopes {
+		if env.ParentRunID() != "" || env.ToolCallID() != "" {
+			t.Fatalf("envelope %q lineage headers = %+v, want none", env.Subject, env.Headers)
+		}
+	}
+}

--- a/core/delegation/service.go
+++ b/core/delegation/service.go
@@ -534,7 +534,7 @@ func (s *LocalService) delegate(
 			// The work item is durably queued; re-arm the escrow TTL
 			// from now so a slow Submit cannot expire the entry before
 			// the worker claims it.
-			s.touchStreamEscrow(ref)
+			s.rearmStreamEscrow(ref, specs)
 			return Response{ID: id, Status: StatusAccepted}, nil
 		}
 		id, err := s.backend.Submit(ctx, asyncReq)
@@ -1220,11 +1220,22 @@ func (s *LocalService) takeStreamEscrow(ref string) ([]session.SinkSpec, bool) {
 	return append([]session.SinkSpec(nil), entry.specs...), true
 }
 
-// touchStreamEscrow re-arms an escrow entry's TTL without consuming it.
-// It is called once the work item is durably queued, so a slow Submit
-// cannot expire the entry before the worker claims it. Missing refs are
-// no-ops.
-func (s *LocalService) touchStreamEscrow(ref string) {
+// rearmStreamEscrow extends the TTL of a queued work item's stream
+// escrow, re-storing the attachment when the periodic sweep already
+// dropped the expired entry while Submit was slow. It is called once the
+// work item is durably queued, so the escrow survives long enough for
+// the worker to claim it. Re-storing is safe here: the only way the
+// entry can be missing at this point is an expiry sweep (release only
+// runs on the submit-failure paths, which return earlier).
+//
+// Residual window: a worker could claim between Submit returning and
+// this re-arm running, and take's own sweep would delete the expired
+// entry before re-arm re-stores it. With the default 1h TTL (sweep
+// interval capped at 1m) that requires Submit itself to have taken
+// longer than the TTL; a short custom TTL plus a slow backend can widen
+// it. The submit side's exporter/resolver fallback is the backstop for
+// that case.
+func (s *LocalService) rearmStreamEscrow(ref string, specs []session.SinkSpec) {
 	if ref == "" {
 		return
 	}
@@ -1232,6 +1243,11 @@ func (s *LocalService) touchStreamEscrow(ref string) {
 	if entry, ok := s.streamEscrow[ref]; ok {
 		entry.expires = time.Now().Add(s.streamEscrowTTL)
 		s.streamEscrow[ref] = entry
+	} else {
+		s.streamEscrow[ref] = streamEscrowEntry{
+			specs:   append([]session.SinkSpec(nil), specs...),
+			expires: time.Now().Add(s.streamEscrowTTL),
+		}
 	}
 	s.streamEscrowMu.Unlock()
 }

--- a/core/delegation/service.go
+++ b/core/delegation/service.go
@@ -379,6 +379,8 @@ func NewService(directory *LocalDirectory, backend AsyncBackend, opts ...Option)
 	service.workerHost = WithService(config.workerHost, service)
 	service.workers.Add(1)
 	go service.idempotencyJanitor()
+	service.workers.Add(1)
+	go service.sweepStreamEscrowLoop()
 	if source, ok := backend.(WorkSource); ok && !isNilInterface(source) {
 		service.work = source
 		if !config.deferWorkers {
@@ -529,6 +531,10 @@ func (s *LocalService) delegate(
 				return Response{}, errdefs.Internalf(
 					"local delegation: async backend returned an empty id")
 			}
+			// The work item is durably queued; re-arm the escrow TTL
+			// from now so a slow Submit cannot expire the entry before
+			// the worker claims it.
+			s.touchStreamEscrow(ref)
 			return Response{ID: id, Status: StatusAccepted}, nil
 		}
 		id, err := s.backend.Submit(ctx, asyncReq)
@@ -650,6 +656,35 @@ func (s *LocalService) idempotencyJanitor() {
 	}
 }
 
+// sweepStreamEscrowLoop periodically drops expired stream escrow
+// entries so a quiet service cannot accumulate abandoned attachments
+// indefinitely. store/take also sweep opportunistically; this loop only
+// bounds memory between operations and is a leak backstop, not a
+// run-duration cap (claimed entries are refreshed on take and released
+// at terminal completion).
+func (s *LocalService) sweepStreamEscrowLoop() {
+	defer s.workers.Done()
+	interval := s.streamEscrowTTL / 2
+	if interval < time.Second {
+		interval = time.Second
+	}
+	if interval > time.Minute {
+		interval = time.Minute
+	}
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-s.workerCtx.Done():
+			return
+		case <-ticker.C:
+			s.streamEscrowMu.Lock()
+			s.sweepStreamEscrowLocked()
+			s.streamEscrowMu.Unlock()
+		}
+	}
+}
+
 func sameRequest(left, right Request) bool {
 	return left.Mode == right.Mode &&
 		left.Target == right.Target &&
@@ -762,11 +797,16 @@ func (s *LocalService) worker() {
 			}
 		}
 		response.ID = work.ID
-		if err := s.complete(work.ID, work.LeaseToken, response); err != nil {
-			s.recordWorkerError(err)
+		completeErr := s.complete(work.ID, work.LeaseToken, response)
+		// Release the caller's escrowed stream attachment on every
+		// terminal path — including a failed Complete, where the
+		// service is about to stop and the entry would otherwise linger
+		// until the TTL sweep.
+		s.releaseStreamEscrow(streamRefOf(work.Request.Stream))
+		if completeErr != nil {
+			s.recordWorkerError(completeErr)
 			return
 		}
-		s.releaseStreamEscrow(streamRefOf(work.Request.Stream))
 	}
 }
 
@@ -1180,6 +1220,22 @@ func (s *LocalService) takeStreamEscrow(ref string) ([]session.SinkSpec, bool) {
 	return append([]session.SinkSpec(nil), entry.specs...), true
 }
 
+// touchStreamEscrow re-arms an escrow entry's TTL without consuming it.
+// It is called once the work item is durably queued, so a slow Submit
+// cannot expire the entry before the worker claims it. Missing refs are
+// no-ops.
+func (s *LocalService) touchStreamEscrow(ref string) {
+	if ref == "" {
+		return
+	}
+	s.streamEscrowMu.Lock()
+	if entry, ok := s.streamEscrow[ref]; ok {
+		entry.expires = time.Now().Add(s.streamEscrowTTL)
+		s.streamEscrow[ref] = entry
+	}
+	s.streamEscrowMu.Unlock()
+}
+
 // releaseStreamEscrow drops an escrow entry. Idempotent; missing refs
 // are no-ops.
 func (s *LocalService) releaseStreamEscrow(ref string) {
@@ -1225,6 +1281,8 @@ func (s *LocalService) inheritAsyncStreams(ctx context.Context, req AsyncRequest
 			return ctx
 		}
 		if isNilInterface(sink) {
+			telemetry.Warn(ctx, "local delegation: stream resolver returned nil sink",
+				otellog.String("delegation.stream_target", req.Stream.Target.ID))
 			return ctx
 		}
 		spec := session.SinkSpec{
@@ -1242,6 +1300,14 @@ func (s *LocalService) inheritAsyncStreams(ctx context.Context, req AsyncRequest
 			Inheritable: true,
 		})
 	}
+	// A stream attachment was expected (the submit side stored one) but
+	// neither the in-process escrow nor a resolver target materialized
+	// it — TTL expiry, a restart, or a worker in another process without
+	// a registered resolver. Surface the loss instead of silently
+	// degrading the subagent stream.
+	telemetry.Warn(ctx, "local delegation: stream attachment unavailable; "+
+		"subagent stream will not reach caller sinks",
+		otellog.String("delegation.stream_ref", req.Stream.Ref))
 	return ctx
 }
 
@@ -1356,8 +1422,10 @@ func responseFromTurn(result *agent.Result, contextID string) Response {
 // or run checkpoint is ever written, and stream sinks are inherited
 // from the caller turn when the caller's stream policy is inheritable.
 // Inherited sinks are downgraded to observers (see inheritedSinkSpecs).
-// Async worker runs do not inherit here: the caller context does not
-// cross the backend queue, and the worker is not a live UI consumer.
+// Async worker runs restore the caller's stream attachment before this
+// runs (see inheritAsyncStreams), so the same inheritance applies there
+// too — the worker context does not cross the queue, but the restored
+// policy does.
 func (s *LocalService) delegationStartOptions(ctx context.Context, persistent bool) []session.StartOption {
 	options := []session.StartOption{
 		session.WithAskUserOverride(refuseSubagentAskUser),

--- a/core/delegation/stream_escrow_test.go
+++ b/core/delegation/stream_escrow_test.go
@@ -62,7 +62,7 @@ func TestStreamEscrowExpiresByTTL(t *testing.T) {
 	}
 }
 
-func TestStreamEscrowTouchRearmsTTL(t *testing.T) {
+func TestStreamEscrowRearmExtendsTTLAndRestoresSweptEntry(t *testing.T) {
 	service, err := NewService(boundDirectory(t, completedEngine("unused")), nil,
 		WithStreamEscrowTTL(200*time.Millisecond))
 	if err != nil {
@@ -73,17 +73,33 @@ func TestStreamEscrowTouchRearmsTTL(t *testing.T) {
 	sink := agent.StreamSinkFunc(func(context.Context, event.Envelope, agent.StreamDeltaPayload) error {
 		return nil
 	})
-	service.storeStreamEscrow("ref-touch", []session.SinkSpec{{ID: "caller", Sink: sink}})
+	specs := []session.SinkSpec{{ID: "caller", Sink: sink}}
+
+	// Extend: an entry still present gets a fresh expiry.
+	service.storeStreamEscrow("ref-rearm", specs)
 	time.Sleep(120 * time.Millisecond)
-	service.touchStreamEscrow("ref-touch")
+	service.rearmStreamEscrow("ref-rearm", specs)
 	time.Sleep(120 * time.Millisecond)
-	// 240ms elapsed > the 200ms TTL: only the touch (which re-armed the
-	// expiry at 120ms) keeps the entry resolvable.
-	if _, ok := service.takeStreamEscrow("ref-touch"); !ok {
-		t.Fatal("touch did not re-arm the escrow TTL")
+	// 240ms elapsed > the 200ms TTL: only the re-arm (which refreshed
+	// the expiry at 120ms) keeps the entry resolvable.
+	if _, ok := service.takeStreamEscrow("ref-rearm"); !ok {
+		t.Fatal("rearm did not extend the escrow TTL")
 	}
-	service.touchStreamEscrow("")        // no-op
-	service.touchStreamEscrow("missing") // no-op
+	service.releaseStreamEscrow("ref-rearm")
+
+	// Restore: an entry already swept while Submit was slow is re-stored
+	// so the worker can still claim the attachment.
+	service.storeStreamEscrow("ref-restore", specs)
+	time.Sleep(250 * time.Millisecond)
+	if _, ok := service.takeStreamEscrow("ref-restore"); ok {
+		t.Fatal("expired entry still resolvable before rearm")
+	}
+	service.rearmStreamEscrow("ref-restore", specs)
+	got, ok := service.takeStreamEscrow("ref-restore")
+	if !ok || len(got) != 1 || got[0].ID != "caller" {
+		t.Fatalf("rearm did not restore the swept entry: %v, %v", got, ok)
+	}
+	service.rearmStreamEscrow("", specs) // no-op
 }
 
 type failingCompleteBackend struct {

--- a/core/delegation/stream_escrow_test.go
+++ b/core/delegation/stream_escrow_test.go
@@ -62,6 +62,90 @@ func TestStreamEscrowExpiresByTTL(t *testing.T) {
 	}
 }
 
+func TestStreamEscrowTouchRearmsTTL(t *testing.T) {
+	service, err := NewService(boundDirectory(t, completedEngine("unused")), nil,
+		WithStreamEscrowTTL(200*time.Millisecond))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = service.Close() })
+
+	sink := agent.StreamSinkFunc(func(context.Context, event.Envelope, agent.StreamDeltaPayload) error {
+		return nil
+	})
+	service.storeStreamEscrow("ref-touch", []session.SinkSpec{{ID: "caller", Sink: sink}})
+	time.Sleep(120 * time.Millisecond)
+	service.touchStreamEscrow("ref-touch")
+	time.Sleep(120 * time.Millisecond)
+	// 240ms elapsed > the 200ms TTL: only the touch (which re-armed the
+	// expiry at 120ms) keeps the entry resolvable.
+	if _, ok := service.takeStreamEscrow("ref-touch"); !ok {
+		t.Fatal("touch did not re-arm the escrow TTL")
+	}
+	service.touchStreamEscrow("")        // no-op
+	service.touchStreamEscrow("missing") // no-op
+}
+
+type failingCompleteBackend struct {
+	*queueBackend
+	err error
+}
+
+func (b *failingCompleteBackend) Complete(
+	ctx context.Context,
+	id, leaseToken string,
+	response Response,
+) error {
+	if b.err != nil {
+		return b.err
+	}
+	return b.queueBackend.Complete(ctx, id, leaseToken, response)
+}
+
+func TestWorkerReleasesStreamEscrowOnCompleteFailure(t *testing.T) {
+	backend := &failingCompleteBackend{
+		queueBackend: newQueueBackend(),
+		err:          errors.New("complete boom"),
+	}
+	service, err := NewService(boundDirectory(t, completedEngine("done")), backend,
+		WithMaxConcurrency(1), WithDeferredWorkers())
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = service.Close() })
+
+	sink := agent.StreamSinkFunc(func(context.Context, event.Envelope, agent.StreamDeltaPayload) error {
+		return nil
+	})
+	ctx := session.WithStreamPolicy(context.Background(), session.StreamPolicy{
+		Sinks:       []session.SinkSpec{{ID: "caller", Sink: sink}},
+		Inheritable: true,
+	})
+	request := syncRequest("writer")
+	request.Mode = ModeAsync
+	if _, err := service.Delegate(ctx, request); err != nil {
+		t.Fatalf("Delegate: %v", err)
+	}
+	service.streamEscrowMu.Lock()
+	if len(service.streamEscrow) == 0 {
+		service.streamEscrowMu.Unlock()
+		t.Fatal("escrow entry missing after async submit")
+	}
+	service.streamEscrowMu.Unlock()
+
+	if err := service.Start(); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	// The worker claims, runs, fails to Complete, and must release the
+	// escrow before stopping — the entry must not linger until the TTL
+	// sweep.
+	waitUntil(t, 5*time.Second, func() bool {
+		service.streamEscrowMu.Lock()
+		defer service.streamEscrowMu.Unlock()
+		return len(service.streamEscrow) == 0
+	})
+}
+
 type captureAsyncBackend struct {
 	submitted chan AsyncRequest
 	submitErr error

--- a/core/runtime/session/coordinator.go
+++ b/core/runtime/session/coordinator.go
@@ -270,6 +270,7 @@ func (c *streamCoordinator) finalize(ctx context.Context, result *agent.Result, 
 	}
 	env := event.MustEnvelope(ctx, c.runEnd, payload)
 	env.SetRunID(c.turn.runID)
+	stampTurnLineage(&env, c.turn)
 
 	c.mu.Lock()
 	if c.finalized {

--- a/core/runtime/session/lineage_test.go
+++ b/core/runtime/session/lineage_test.go
@@ -1,0 +1,118 @@
+package session
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/GizClaw/flowcraft/core/agent"
+	"github.com/GizClaw/flowcraft/core/event"
+	"github.com/GizClaw/flowcraft/core/message"
+	"github.com/GizClaw/flowcraft/core/telemetry"
+)
+
+// TestDelegatedTurnLineageOnSessionEnvelopes verifies the session-level
+// mint points (the logical run end) carry the turn's delegation lineage,
+// so every envelope a sink observes preserves the run tree. The engine's
+// own run-end is consumed by the coordinator as an attempt delimiter, so
+// without this stamp the sink would see a lineage-free terminal event.
+func TestDelegatedTurnLineageOnSessionEnvelopes(t *testing.T) {
+	received := make(chan event.Envelope, 16)
+	sink := agent.StreamSinkFunc(func(
+		_ context.Context,
+		env event.Envelope,
+		_ agent.StreamDeltaPayload,
+	) error {
+		received <- env
+		return nil
+	})
+	engine := agent.EngineFunc(func(
+		ctx context.Context,
+		_ agent.Run,
+		_ agent.Host,
+		board *agent.Board,
+	) (*agent.Board, error) {
+		board.AppendChannelMessage(agent.MainChannel,
+			message.NewTextMessage(message.RoleAssistant, "done"))
+		return board, nil
+	})
+	_, sess, _, _ := newTurnSession(t, engine, turnHostFactory)
+	turn, err := sess.StartWithOptions(context.Background(), agent.Request{
+		ParentRunID: "caller-run",
+		Attributes:  map[string]string{telemetry.AttrToolCallID: "call-delegate-1"},
+		Message:     message.NewTextMessage(message.RoleUser, "hi"),
+	}, WithSinks(SinkSpec{ID: "s1", Sink: sink}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := turn.Wait(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+
+	deadline := time.After(5 * time.Second)
+	for {
+		select {
+		case env := <-received:
+			if env.Subject != agent.SubjectRunEnd(turn.RunID()) {
+				continue
+			}
+			if env.ParentRunID() != "caller-run" || env.ToolCallID() != "call-delegate-1" {
+				t.Fatalf("run-end lineage headers = %+v", env.Headers)
+			}
+			return
+		case <-deadline:
+			t.Fatal("lineage-stamped run-end envelope never reached the sink")
+		}
+	}
+}
+
+// TestTopLevelTurnStaysHeaderFreeOnSessionEnvelopes guards the inverse:
+// a turn started without lineage must not stamp empty parent/tool-call
+// headers on the session-level run end.
+func TestTopLevelTurnStaysHeaderFreeOnSessionEnvelopes(t *testing.T) {
+	received := make(chan event.Envelope, 16)
+	sink := agent.StreamSinkFunc(func(
+		_ context.Context,
+		env event.Envelope,
+		_ agent.StreamDeltaPayload,
+	) error {
+		received <- env
+		return nil
+	})
+	engine := agent.EngineFunc(func(
+		ctx context.Context,
+		_ agent.Run,
+		_ agent.Host,
+		board *agent.Board,
+	) (*agent.Board, error) {
+		board.AppendChannelMessage(agent.MainChannel,
+			message.NewTextMessage(message.RoleAssistant, "done"))
+		return board, nil
+	})
+	_, sess, _, _ := newTurnSession(t, engine, turnHostFactory)
+	turn, err := sess.StartWithOptions(context.Background(), agent.Request{
+		Message: message.NewTextMessage(message.RoleUser, "hi"),
+	}, WithSinks(SinkSpec{ID: "s1", Sink: sink}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := turn.Wait(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+
+	deadline := time.After(5 * time.Second)
+	for {
+		select {
+		case env := <-received:
+			if env.Subject != agent.SubjectRunEnd(turn.RunID()) {
+				continue
+			}
+			if env.ParentRunID() != "" || env.ToolCallID() != "" {
+				t.Fatalf("top-level run-end lineage headers = %+v, want none", env.Headers)
+			}
+			return
+		case <-deadline:
+			t.Fatal("run-end envelope never reached the sink")
+		}
+	}
+}

--- a/core/runtime/session/lineage_test.go
+++ b/core/runtime/session/lineage_test.go
@@ -116,3 +116,86 @@ func TestTopLevelTurnStaysHeaderFreeOnSessionEnvelopes(t *testing.T) {
 		}
 	}
 }
+
+// TestDelegatedTurnLineageOnPromptEnvelopes verifies the session-level
+// prompt mint points (prompt_requested / prompt_resolved) carry the
+// turn's delegation lineage as well, not just the logical run end.
+func TestDelegatedTurnLineageOnPromptEnvelopes(t *testing.T) {
+	engine := agent.EngineFunc(func(
+		ctx context.Context,
+		_ agent.Run,
+		host agent.Host,
+		board *agent.Board,
+	) (*agent.Board, error) {
+		reply, err := host.AskUser(ctx, agent.UserPrompt{Source: "lineage"})
+		if err != nil {
+			return board, err
+		}
+		board.AppendChannelMessage(agent.MainChannel,
+			message.NewTextMessage(message.RoleUser, reply.Metadata["source"]))
+		return board, nil
+	})
+	_, sess, _, bus := newTurnSession(t, engine, turnHostFactory)
+	sub, err := bus.Subscribe(context.Background(), agent.PatternAllRuns())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = sub.Close() }()
+
+	turn, err := sess.StartWithOptions(context.Background(), agent.Request{
+		ParentRunID: "caller-run",
+		Attributes:  map[string]string{telemetry.AttrToolCallID: "call-delegate-1"},
+		Message:     message.NewTextMessage(message.RoleUser, "hi"),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// PromptRequested must carry the lineage.
+	deadline := time.After(5 * time.Second)
+	var promptID string
+	for {
+		select {
+		case env := <-sub.C():
+			if env.Subject != SubjectPromptRequested(turn.RunID()) {
+				continue
+			}
+			if env.ParentRunID() != "caller-run" || env.ToolCallID() != "call-delegate-1" {
+				t.Fatalf("prompt requested lineage headers = %+v", env.Headers)
+			}
+			var requested PromptRequested
+			if err := env.Decode(&requested); err != nil {
+				t.Fatal(err)
+			}
+			promptID = requested.PromptID
+			goto requested
+		case <-deadline:
+			t.Fatal("prompt requested envelope never published")
+		}
+	}
+requested:
+	if err := turn.Reply(context.Background(), promptID, agent.UserReply{
+		Metadata: map[string]string{"source": "lineage"},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	// PromptResolved must carry the same lineage.
+	for {
+		select {
+		case env := <-sub.C():
+			if env.Subject != SubjectPromptResolved(turn.RunID()) {
+				continue
+			}
+			if env.ParentRunID() != "caller-run" || env.ToolCallID() != "call-delegate-1" {
+				t.Fatalf("prompt resolved lineage headers = %+v", env.Headers)
+			}
+			if _, err := turn.Wait(context.Background()); err != nil {
+				t.Fatal(err)
+			}
+			return
+		case <-deadline:
+			t.Fatal("prompt resolved envelope never published")
+		}
+	}
+}

--- a/core/runtime/session/prompt.go
+++ b/core/runtime/session/prompt.go
@@ -122,6 +122,7 @@ func (t *Turn) askUser(ctx context.Context, prompt agent.UserPrompt) (agent.User
 	if err == nil {
 		envelope.SetRunID(t.runID)
 		envelope.SetAgentID(t.session.key.AgentID)
+		stampTurnLineage(&envelope, t)
 		err = host.Publish(ctx, envelope)
 	}
 	if err != nil {
@@ -225,6 +226,7 @@ func (t *Turn) publishPromptResolved(host agent.Host, promptID string, status Pr
 	if t.session != nil {
 		envelope.SetAgentID(t.session.key.AgentID)
 	}
+	stampTurnLineage(&envelope, t)
 	if err := host.Publish(ctx, envelope); err != nil {
 		telemetry.WarnErr(ctx, "runtime session: prompt resolved event publish failed", err,
 			otellog.String(telemetry.AttrRunID, t.runID),

--- a/core/runtime/session/turn.go
+++ b/core/runtime/session/turn.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/GizClaw/flowcraft/core/agent"
 	"github.com/GizClaw/flowcraft/core/errdefs"
+	"github.com/GizClaw/flowcraft/core/event"
 	"github.com/GizClaw/flowcraft/core/message"
 	"github.com/GizClaw/flowcraft/core/telemetry"
 )
@@ -106,6 +107,26 @@ func (t *Turn) RunID() string {
 		return ""
 	}
 	return t.runID
+}
+
+// stampLineage projects the turn's run lineage onto a freshly minted
+// envelope: the parent run id (when this turn was dispatched by another
+// run, e.g. a delegated subagent) and the creating tool call id (when
+// this turn was spawned by a tool, e.g. a delegate tool call). Empty
+// values are skipped so top-level turns stay header-free. It is applied
+// at the session-level mint points (logical run end, prompt events) so
+// the lineage invariant holds for every envelope a sink observes, not
+// just the engine's own events.
+func stampTurnLineage(env *event.Envelope, t *Turn) {
+	if t == nil {
+		return
+	}
+	if parentRunID := t.request.ParentRunID; parentRunID != "" {
+		env.SetParentRunID(parentRunID)
+	}
+	if callID := t.request.Attributes[telemetry.AttrToolCallID]; callID != "" {
+		env.SetToolCallID(callID)
+	}
 }
 
 // State returns the current lifecycle state.


### PR DESCRIPTION
## Summary

Follow-up review fixes on top of the delegation stream-lineage work (`core/v0.1.29` .. HEAD, PRs #440–#443). Closes the gaps found in review:

1. **Session-level envelope lineage** — the logical run-end (and prompt_requested / prompt_resolved) envelopes delivered to sinks now carry `parent_run_id` / `tool_call_id`. Previously the engine's lineage-stamped run end was consumed by the stream coordinator as an attempt delimiter, so the final run-end a sink saw had no lineage.
2. **A2A engine lineage** — `publishRunEvent` / `publishStepEvent` stamp lineage, and `Execute` injects ambient `RunInfo` so stream deltas inherit it.
3. **Async escrow lifecycle** — periodic TTL sweep; TTL re-armed (and the attachment re-stored when the sweep already dropped the expired entry during a slow `Submit`) once the work is durably queued; escrow released on failed `Complete` too; warning when an expected stream attachment cannot be materialized.
4. **Docs/comment** — fixed the stale `delegationStartOptions` comment that claimed async workers never inherit; documented the residual worker-claims-before-rearm window with the exporter/resolver fallback as backstop.

## Tests

- session: delegated turn's run-end and prompt_requested / prompt_resolved carry lineage; top-level turn stays header-free.
- a2a: run/step events carry lineage; top-level stays header-free.
- delegation: `rearmStreamEscrow` extends TTL and restores a swept entry; worker releases escrow on `Complete` failure.

## Verification

- `make ci` ✅
- `make lint` ✅
- `make release-check` ✅ (no pending releases, no changeset added)
- `git diff --check` ✅
- `go test -race` on delegation / runtime/session / agent/a2a ✅