### PR TITLE
feat(core): per-exec write policy and read-only sandbox mode

### DIFF
--- a/core/sandbox/bwrap/doc.go
+++ b/core/sandbox/bwrap/doc.go
@@ -48,7 +48,10 @@
 // rootDir is bind-mounted read-write at the same absolute path, /tmp
 // is a private writable tmpfs, and /proc plus a minimal /dev are
 // freshly mounted. Additional existing paths may be opened for writing
-// with [WithWritablePaths]. Mount-affecting [WithExtraFlags] values
+// with [WithWritablePaths]. [WithReadOnlyRoot] (or per-exec
+// sandbox.WriteReadOnly) ro-binds rootDir instead, so the workspace is
+// inspect-only while /tmp stays a private writable tmpfs — writes
+// there never reach the host. Mount-affecting [WithExtraFlags] values
 // are rejected so callers cannot silently disable the boundary
 // reported by sandbox.Enforcement.FilesystemBounds.
 //

--- a/core/sandbox/bwrap/flags.go
+++ b/core/sandbox/bwrap/flags.go
@@ -53,17 +53,22 @@ func buildFlags(opts sandbox.ExecOptions, hostEnv []string) ([]string, error) {
 //
 //   - bind the host root read-only, preserving access to toolchains;
 //   - mount a private writable tmpfs at /tmp;
-//   - bind rootDir and explicit exceptions read-write at the same path;
+//   - bind rootDir (read-write, or read-only with readOnlyRoot) and
+//     explicit exceptions read-write at the same path;
 //   - mount fresh procfs and a minimal /dev.
 //
 // Writable binds follow the /tmp mount intentionally: when rootDir is
 // itself under /tmp (common in tests and CI), the later nested bind
 // makes the workspace visible inside the otherwise-private tmpfs.
-func filesystemFlags(rootDir string, writable []string) []string {
+func filesystemFlags(rootDir string, writable []string, readOnlyRoot bool) []string {
+	rootBind := "--bind"
+	if readOnlyRoot {
+		rootBind = "--ro-bind"
+	}
 	flags := []string{
 		"--ro-bind", "/", "/",
 		"--tmpfs", "/tmp",
-		"--bind", rootDir, rootDir,
+		rootBind, rootDir, rootDir,
 	}
 	for _, path := range writable {
 		if path == "" || path == rootDir {

--- a/core/sandbox/bwrap/flags_linux_test.go
+++ b/core/sandbox/bwrap/flags_linux_test.go
@@ -1,0 +1,83 @@
+//go:build linux
+
+package bwrap
+
+import (
+	"os"
+	"path/filepath"
+	"slices"
+	"testing"
+)
+
+func containsSeq(flags []string, seq ...string) bool {
+	for i := 0; i+len(seq) <= len(flags); i++ {
+		if slices.Equal(flags[i:i+len(seq)], seq) {
+			return true
+		}
+	}
+	return false
+}
+
+func TestFilesystemFlagsRootWritableByDefault(t *testing.T) {
+	flags := filesystemFlags("/srv/root", []string{"/srv/cache"}, false)
+	if !containsSeq(flags, "--bind", "/srv/root", "/srv/root") {
+		t.Fatalf("default flags must bind the root read-write: %v", flags)
+	}
+	if containsSeq(flags, "--ro-bind", "/srv/root", "/srv/root") {
+		t.Fatalf("default flags must not ro-bind the root: %v", flags)
+	}
+	if !containsSeq(flags, "--bind", "/srv/cache", "/srv/cache") {
+		t.Fatalf("explicit writable paths must stay writable: %v", flags)
+	}
+}
+
+func TestFilesystemFlagsReadOnlyRoot(t *testing.T) {
+	flags := filesystemFlags("/srv/root", []string{"/srv/cache"}, true)
+	if !containsSeq(flags, "--ro-bind", "/srv/root", "/srv/root") {
+		t.Fatalf("read-only flags must ro-bind the root: %v", flags)
+	}
+	if containsSeq(flags, "--bind", "/srv/root", "/srv/root") {
+		t.Fatalf("read-only flags must not bind the root read-write: %v", flags)
+	}
+	if !containsSeq(flags, "--bind", "/srv/cache", "/srv/cache") {
+		t.Fatalf("explicit writable paths must stay writable: %v", flags)
+	}
+}
+
+func TestFilesystemFlagsReadOnlyRootUnderTmp(t *testing.T) {
+	flags := filesystemFlags("/tmp/ws", nil, true)
+	tmpfs := slices.Index(flags, "--tmpfs")
+	roBind := slices.Index(flags, "--ro-bind")
+	if tmpfs < 0 || roBind < 0 || roBind < tmpfs {
+		t.Fatalf("read-only root bind must follow the /tmp tmpfs: %v", flags)
+	}
+	if !containsSeq(flags, "--ro-bind", "/tmp/ws", "/tmp/ws") {
+		t.Fatalf("root under /tmp must be re-exposed read-only: %v", flags)
+	}
+}
+
+// TestNewReadOnlyRootOption checks the option wiring into the Runner.
+// The binary is a throwaway executable so New does not need bwrap
+// installed to reach the option application.
+func TestNewReadOnlyRootOption(t *testing.T) {
+	binary := filepath.Join(t.TempDir(), "bwrap-fake")
+	if err := os.WriteFile(binary, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+		t.Fatalf("write fake binary: %v", err)
+	}
+
+	runner, err := New(t.TempDir(), WithBinary(binary))
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	if runner.readOnlyRoot {
+		t.Fatal("default runner must keep the root writable")
+	}
+
+	ro, err := New(t.TempDir(), WithBinary(binary), WithReadOnlyRoot())
+	if err != nil {
+		t.Fatalf("New(WithReadOnlyRoot): %v", err)
+	}
+	if !ro.readOnlyRoot {
+		t.Fatal("WithReadOnlyRoot must mark the runner read-only")
+	}
+}

--- a/core/sandbox/bwrap/flags_linux_test.go
+++ b/core/sandbox/bwrap/flags_linux_test.go
@@ -7,15 +7,21 @@ import (
 	"path/filepath"
 	"slices"
 	"testing"
+
+	"github.com/GizClaw/flowcraft/core/sandbox"
 )
 
 func containsSeq(flags []string, seq ...string) bool {
+	return indexSeq(flags, seq...) >= 0
+}
+
+func indexSeq(flags []string, seq ...string) int {
 	for i := 0; i+len(seq) <= len(flags); i++ {
 		if slices.Equal(flags[i:i+len(seq)], seq) {
-			return true
+			return i
 		}
 	}
-	return false
+	return -1
 }
 
 func TestFilesystemFlagsRootWritableByDefault(t *testing.T) {
@@ -47,7 +53,8 @@ func TestFilesystemFlagsReadOnlyRoot(t *testing.T) {
 func TestFilesystemFlagsReadOnlyRootUnderTmp(t *testing.T) {
 	flags := filesystemFlags("/tmp/ws", nil, true)
 	tmpfs := slices.Index(flags, "--tmpfs")
-	roBind := slices.Index(flags, "--ro-bind")
+	// The first --ro-bind is the host root; find the workspace bind.
+	roBind := indexSeq(flags, "--ro-bind", "/tmp/ws", "/tmp/ws")
 	if tmpfs < 0 || roBind < 0 || roBind < tmpfs {
 		t.Fatalf("read-only root bind must follow the /tmp tmpfs: %v", flags)
 	}
@@ -79,5 +86,63 @@ func TestNewReadOnlyRootOption(t *testing.T) {
 	}
 	if !ro.readOnlyRoot {
 		t.Fatal("WithReadOnlyRoot must mark the runner read-only")
+	}
+}
+
+// TestNewRejectsWritableRootWithReadOnlyRoot pins the documented
+// contract: an explicit writable path that resolves to the runner root
+// conflicts with readonly_root and must fail construction instead of
+// being silently dropped.
+func TestNewRejectsWritableRootWithReadOnlyRoot(t *testing.T) {
+	binary := filepath.Join(t.TempDir(), "bwrap-fake")
+	if err := os.WriteFile(binary, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+		t.Fatalf("write fake binary: %v", err)
+	}
+	root := t.TempDir()
+
+	if _, err := New(root, WithBinary(binary), WithReadOnlyRoot(), WithWritablePaths(root)); err == nil {
+		t.Fatal("New must reject a writable path that is the read-only runner root")
+	}
+	// Without readonly_root the root is already writable by default,
+	// so listing it is redundant but harmless.
+	runner, err := New(root, WithBinary(binary), WithWritablePaths(root))
+	if err != nil {
+		t.Fatalf("New(WithWritablePaths(root)): %v", err)
+	}
+	if len(runner.writablePaths) != 0 {
+		t.Fatalf("root must not be duplicated in writablePaths: %v", runner.writablePaths)
+	}
+}
+
+// TestFilesystemFlagsForPerCallReadOnly is the direct assertion that a
+// per-call WriteReadOnly keeps the construction-time writable root
+// read-only while explicit writable paths stay writable.
+func TestFilesystemFlagsForPerCallReadOnly(t *testing.T) {
+	binary := filepath.Join(t.TempDir(), "bwrap-fake")
+	if err := os.WriteFile(binary, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+		t.Fatalf("write fake binary: %v", err)
+	}
+	root := t.TempDir()
+	cache := t.TempDir()
+	runner, err := New(root, WithBinary(binary), WithWritablePaths(cache))
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	workspace := runner.filesystemFlagsFor(sandbox.WriteWorkspace)
+	if !containsSeq(workspace, "--bind", runner.rootDir, runner.rootDir) {
+		t.Fatalf("workspace call must bind the root read-write: %v", workspace)
+	}
+
+	readOnly := runner.filesystemFlagsFor(sandbox.WriteReadOnly)
+	if !containsSeq(readOnly, "--ro-bind", runner.rootDir, runner.rootDir) {
+		t.Fatalf("per-call read-only must ro-bind the root: %v", readOnly)
+	}
+	if containsSeq(readOnly, "--bind", runner.rootDir, runner.rootDir) {
+		t.Fatalf("per-call read-only must not bind the root read-write: %v", readOnly)
+	}
+	if len(runner.writablePaths) != 1 ||
+		!containsSeq(readOnly, "--bind", runner.writablePaths[0], runner.writablePaths[0]) {
+		t.Fatalf("explicit writable paths must stay writable: %v", readOnly)
 	}
 }

--- a/core/sandbox/bwrap/register.go
+++ b/core/sandbox/bwrap/register.go
@@ -21,6 +21,7 @@ type settings struct {
 	Binary        string   `json:"binary,omitempty"`
 	WritablePaths []string `json:"writable_paths,omitempty"`
 	ExtraFlags    []string `json:"extra_flags,omitempty"`
+	ReadOnlyRoot  bool     `json:"readonly_root,omitempty"`
 }
 
 type factory struct{}
@@ -59,6 +60,9 @@ func (factory) New(_ context.Context, in resource.Input) (any, error) {
 	}
 	if s.ExtraFlags != nil {
 		options = append(options, WithExtraFlags(s.ExtraFlags...))
+	}
+	if s.ReadOnlyRoot {
+		options = append(options, WithReadOnlyRoot())
 	}
 	runner, err := New(s.Root, options...)
 	if err != nil {

--- a/core/sandbox/bwrap/runner.go
+++ b/core/sandbox/bwrap/runner.go
@@ -13,12 +13,13 @@ type RunnerOption func(*runnerConfig)
 // It lives in the platform-neutral file so the option functions
 // type-check on every OS even though Runner itself is Linux-only.
 type runnerConfig struct {
-	binFrom  string   // raw value supplied to WithBinary, "" if defaulted
-	extra    []string // extra bwrap flags injected before the "--" separator
-	writable []string // additional explicitly writable host paths
-	decision func(net.ProxyDecision)
-	hooks    net.MITMHooks
-	roots    *x509.CertPool
+	binFrom      string   // raw value supplied to WithBinary, "" if defaulted
+	extra        []string // extra bwrap flags injected before the "--" separator
+	writable     []string // additional explicitly writable host paths
+	readOnlyRoot bool     // keep the runner root read-only for every exec
+	decision     func(net.ProxyDecision)
+	hooks        net.MITMHooks
+	roots        *x509.CertPool
 }
 
 // WithBinary overrides the bwrap binary path. By default the Runner
@@ -54,6 +55,17 @@ func WithExtraFlags(flags ...string) RunnerOption {
 func WithWritablePaths(paths ...string) RunnerOption {
 	return func(c *runnerConfig) {
 		c.writable = append(c.writable, paths...)
+	}
+}
+
+// WithReadOnlyRoot keeps the runner root read-only for every exec
+// spawned through this runner, instead of the default (root writable).
+// Explicit [WithWritablePaths] exceptions remain writable, and
+// per-exec sandbox.WriteReadOnly can only keep the root read-only —
+// it cannot re-enable writes on a runner constructed with this option.
+func WithReadOnlyRoot() RunnerOption {
+	return func(c *runnerConfig) {
+		c.readOnlyRoot = true
 	}
 }
 

--- a/core/sandbox/bwrap/runner_linux.go
+++ b/core/sandbox/bwrap/runner_linux.go
@@ -34,6 +34,7 @@ type Runner struct {
 	binary           string
 	extraFlags       []string
 	writablePaths    []string
+	readOnlyRoot     bool
 	defaultMaxOutput int64
 	sessions         *sandbox.SessionRegistry
 	decision         func(net.ProxyDecision)
@@ -54,6 +55,7 @@ func (r *Runner) Enforcement() sandbox.Enforcement {
 		MemoryCap:        caps,
 		CPUCap:           caps,
 		FilesystemBounds: true,
+		WriteModes:       []sandbox.WritePolicy{sandbox.WriteWorkspace, sandbox.WriteReadOnly},
 	}
 }
 
@@ -108,6 +110,7 @@ func New(rootDir string, opts ...RunnerOption) (*Runner, error) {
 		binary:           binary,
 		extraFlags:       append([]string(nil), cfg.extra...),
 		writablePaths:    writable,
+		readOnlyRoot:     cfg.readOnlyRoot,
 		defaultMaxOutput: defaultMaxOutputBytes,
 		decision:         cfg.decision,
 		hooks:            cfg.hooks,
@@ -231,7 +234,11 @@ func (r *Runner) spawnProcess(
 		abortBundle()
 		return nil, err
 	}
-	fsFlags := filesystemFlags(r.rootDir, r.writablePaths)
+	fsFlags := filesystemFlags(
+		r.rootDir,
+		r.writablePaths,
+		r.readOnlyRoot || spec.Opts.Write == sandbox.WriteReadOnly,
+	)
 	fsFlags = append(fsFlags, netIsolationFlags(spec.Opts.Net.Mode)...)
 	if bundlePath != "" {
 		fsFlags = append(fsFlags, "--ro-bind", bundlePath, bundlePath)

--- a/core/sandbox/bwrap/runner_linux.go
+++ b/core/sandbox/bwrap/runner_linux.go
@@ -99,6 +99,17 @@ func New(rootDir string, opts ...RunnerOption) (*Runner, error) {
 		if err != nil {
 			return nil, err
 		}
+		if resolved == abs {
+			if cfg.readOnlyRoot {
+				return nil, errdefs.Validationf(
+					"bwrap: writable path %q is the read-only runner root; drop the path or disable readonly_root",
+					path,
+				)
+			}
+			// Redundant with the default (root writable); keep the
+			// explicit list free of duplicates.
+			continue
+		}
 		if !seenWritable[resolved] {
 			seenWritable[resolved] = true
 			writable = append(writable, resolved)
@@ -234,11 +245,7 @@ func (r *Runner) spawnProcess(
 		abortBundle()
 		return nil, err
 	}
-	fsFlags := filesystemFlags(
-		r.rootDir,
-		r.writablePaths,
-		r.readOnlyRoot || spec.Opts.Write == sandbox.WriteReadOnly,
-	)
+	fsFlags := r.filesystemFlagsFor(spec.Opts.Write)
 	fsFlags = append(fsFlags, netIsolationFlags(spec.Opts.Net.Mode)...)
 	if bundlePath != "" {
 		fsFlags = append(fsFlags, "--ro-bind", bundlePath, bundlePath)
@@ -309,6 +316,14 @@ func (r *Runner) spawnProcess(
 		return &sessionHandle{Session: sess, cleanup: cleanup}, nil
 	}
 	return sess, nil
+}
+
+// filesystemFlagsFor renders the mount flags for a single spawn: the
+// runner root is read-only when pinned at construction or by the
+// per-call write policy.
+func (r *Runner) filesystemFlagsFor(write sandbox.WritePolicy) []string {
+	return filesystemFlags(r.rootDir, r.writablePaths,
+		r.readOnlyRoot || write == sandbox.WriteReadOnly)
 }
 
 // closeProxy best-effort closes the enforcement proxy, leaving the

--- a/core/sandbox/decorator.go
+++ b/core/sandbox/decorator.go
@@ -107,11 +107,11 @@ func (r *allowCommandsRunner) Close() error {
 //   - Net: defaults wins entirely. Caller Net is ignored — the
 //     network posture is sandbox-level policy.
 //   - Write: the caller may narrow the boundary to WriteReadOnly for a
-//     single call; defaults may pin WriteReadOnly for the whole chain.
-//     Since WriteReadOnly is the strictest mode and there is no
-//     widening mode, "either side is read-only" is the whole merge
-//     rule. An unknown caller value is preserved so backend validation
-//     rejects it instead of silently degrading to WriteWorkspace.
+//     single call; defaults pin the policy for the whole chain. Since
+//     WriteReadOnly is the strictest mode and there is no widening
+//     mode, "either side is read-only" is the whole merge rule. An
+//     unknown value on either side is preserved — never silently
+//     degraded to WriteWorkspace — so backend validation rejects it.
 //   - Resources: defaults wins entirely. Caller cannot raise caps;
 //     and narrowing CPU/Mem/Disk per call is not actionable for a
 //     local runner today (those fields are advisory until a real
@@ -192,8 +192,12 @@ func (r *defaultsRunner) merge(caller ExecOptions) ExecOptions {
 		Write:     caller.Write,
 		Resources: r.defaults.Resources,
 	}
-	if r.defaults.Write == WriteReadOnly {
-		merged.Write = WriteReadOnly
+	// Any non-workspace default pins the policy: WriteReadOnly narrows
+	// every call, and an unknown value is preserved so backend
+	// validation rejects it instead of being silently swallowed when
+	// the caller passes the zero-value WriteWorkspace.
+	if r.defaults.Write != WriteWorkspace {
+		merged.Write = r.defaults.Write
 	}
 	if merged.WorkDir == "" {
 		merged.WorkDir = r.defaults.WorkDir

--- a/core/sandbox/decorator.go
+++ b/core/sandbox/decorator.go
@@ -106,6 +106,12 @@ func (r *allowCommandsRunner) Close() error {
 //     sandbox's static injections.
 //   - Net: defaults wins entirely. Caller Net is ignored — the
 //     network posture is sandbox-level policy.
+//   - Write: the caller may narrow the boundary to WriteReadOnly for a
+//     single call; defaults may pin WriteReadOnly for the whole chain.
+//     Since WriteReadOnly is the strictest mode and there is no
+//     widening mode, "either side is read-only" is the whole merge
+//     rule. An unknown caller value is preserved so backend validation
+//     rejects it instead of silently degrading to WriteWorkspace.
 //   - Resources: defaults wins entirely. Caller cannot raise caps;
 //     and narrowing CPU/Mem/Disk per call is not actionable for a
 //     local runner today (those fields are advisory until a real
@@ -183,7 +189,11 @@ func (r *defaultsRunner) merge(caller ExecOptions) ExecOptions {
 		Timeout:   mergeTimeout(caller.Timeout, r.defaults.Timeout),
 		Env:       mergeEnv(caller.Env, r.defaults.Env),
 		Net:       r.defaults.Net,
+		Write:     caller.Write,
 		Resources: r.defaults.Resources,
+	}
+	if r.defaults.Write == WriteReadOnly {
+		merged.Write = WriteReadOnly
 	}
 	if merged.WorkDir == "" {
 		merged.WorkDir = r.defaults.WorkDir

--- a/core/sandbox/doc.go
+++ b/core/sandbox/doc.go
@@ -16,7 +16,7 @@
 // sessions and releases backend-owned resources, and the decorators
 // forward it so wrapping never hides the backend's cleanup.
 //
-// ExecOptions carries three policy groups beyond the obvious WorkDir /
+// ExecOptions carries four policy groups beyond the obvious WorkDir /
 // Stdin / Timeout knobs:
 //
 //   - Env (EnvPolicy): explicit allow-list of host environment variables
@@ -26,6 +26,10 @@
 //     only accepts NetDefault; non-default modes require a sandboxing
 //     backend (namespace-based, container-based, or microVM-based) that
 //     can actually enforce the policy at the kernel level.
+//   - Write (WritePolicy): per-call filesystem write mode. The zero
+//     value applies the runner's construction-time boundary;
+//     WriteReadOnly keeps the runner root read-only for that call.
+//     sandbox/local has no OS boundary and rejects WriteReadOnly.
 //   - Resources (ResourceLimits): CPU / memory / disk caps plus
 //     MaxOutputBytes. On unix, sandbox/local enforces group-wide memory
 //     and cpu-time caps with a sampling watcher and kills the whole

--- a/core/sandbox/enforcement.go
+++ b/core/sandbox/enforcement.go
@@ -35,6 +35,12 @@ import corenet "github.com/GizClaw/flowcraft/core/utils/net"
 //     OS level (Seatbelt profile, namespace mounts). sandbox/local's
 //     WorkDir check is call-time validation only — once the child is
 //     running it can chdir anywhere — so it does not qualify.
+//   - WriteModes: the set of WritePolicy values this backend can
+//     enforce per call. Isolation backends list WriteWorkspace (writes
+//     confined to the root plus explicit writable paths) and
+//     WriteReadOnly (root read-only). sandbox/local reports none —
+//     "unrestricted" is not an enforced mode, and WriteReadOnly is
+//     rejected with NotAvailable there.
 type Enforcement struct {
 	EnvAllowList     bool
 	NetModes         []corenet.NetMode
@@ -45,6 +51,7 @@ type Enforcement struct {
 	CPUCap           bool
 	DiskCap          bool
 	FilesystemBounds bool
+	WriteModes       []WritePolicy
 }
 
 // GroupCapsSupported reports whether the shared process-group watcher

--- a/core/sandbox/exec.go
+++ b/core/sandbox/exec.go
@@ -28,6 +28,9 @@ const defaultMaxOutputBytes int64 = 10 * 1024 * 1024
 //   - Env: see EnvPolicy. Replaces the historical "inherit everything"
 //     behaviour while staying back-compat when EnvPolicy.Allow is nil.
 //   - Net: see NetPolicy. The local runner only accepts NetDefault.
+//   - Write: see WritePolicy. Zero value keeps the runner's
+//     construction-time write boundary; WriteReadOnly narrows it for
+//     this call only (root not writable, explicit writable paths stay).
 //   - Resources: see ResourceLimits. The local runner enforces MemoryBytes,
 //     CPUMillicores (with Timeout), and MaxOutputBytes; DiskBytes is
 //     still errdefs.NotAvailable.
@@ -37,6 +40,7 @@ type ExecOptions struct {
 	Timeout   time.Duration
 	Env       EnvPolicy
 	Net       corenet.NetPolicy
+	Write     WritePolicy
 	Resources ResourceLimits
 }
 

--- a/core/sandbox/local/local.go
+++ b/core/sandbox/local/local.go
@@ -47,6 +47,8 @@ func WithMaxOutputBytes(n int64) Option {
 //     just the leader.
 //   - Env: fully supported (see sandbox.EnvPolicy doc).
 //   - Net.Mode != corenet.NetDefault: returns errdefs.NotAvailable.
+//   - Write == WriteReadOnly: returns errdefs.NotAvailable (no OS
+//     boundary to confine writes).
 //   - Resources.MemoryBytes: enforced by a sampling watcher on aggregate
 //     group RSS; overflow kills the whole group.
 //   - Resources.CPUMillicores: enforced by the same watcher as group

--- a/core/sandbox/local/session_unix.go
+++ b/core/sandbox/local/session_unix.go
@@ -26,6 +26,10 @@ func (r *Runner) spawnProcess(ctx context.Context, spec sandbox.SessionSpec) (sa
 		return nil, errdefs.NotAvailablef(
 			"sandbox: net policy not supported by local runner; requires a kernel-level isolation backend")
 	}
+	if spec.Opts.Write == sandbox.WriteReadOnly {
+		return nil, errdefs.NotAvailablef(
+			"sandbox: write policy not supported by local runner; requires a kernel-level isolation backend")
+	}
 	workDir, err := r.resolveWorkDir(spec.Opts.WorkDir)
 	if err != nil {
 		return nil, err

--- a/core/sandbox/policy.go
+++ b/core/sandbox/policy.go
@@ -23,6 +23,29 @@ type EnvPolicy struct {
 	Inject map[string]string
 }
 
+// WritePolicy controls how much filesystem write access a single Exec
+// call gets on top of the runner's construction-time boundary (runner
+// root plus explicit [RunnerOption] writable paths).
+//
+//   - WriteWorkspace (zero value): the runner root plus explicit
+//     writable paths are writable — the current behavior and the
+//     back-compat default. With the seatbelt / bwrap backends this is
+//     enforced at the OS level; sandbox/local has no OS boundary and
+//     reports no write modes in Capabilities.
+//   - WriteReadOnly: the runner root is not writable for this call.
+//     Explicitly configured writable paths remain writable, and
+//     platform escape hatches such as /dev/null stay open.
+//
+// There is deliberately no "wider" value: a call can narrow the
+// construction-time boundary, never widen it. A runner constructed
+// read-only (e.g. WithReadOnlyRoot) stays read-only for every call.
+type WritePolicy uint8
+
+const (
+	WriteWorkspace WritePolicy = iota
+	WriteReadOnly
+)
+
 // ResourceLimits caps how much the child process may consume.
 //
 // MemoryBytes caps aggregate resident memory used by the child process
@@ -62,10 +85,17 @@ type ResourceLimits struct {
 //   - MemoryBytes / CPUMillicores ride the shared process-group
 //     sampler; where that sampler cannot run, honouring the request
 //     would silently run without caps, so it is rejected instead.
+//   - Write must be a known WritePolicy value; anything else is
+//     rejected so an unsupported mode cannot silently degrade to the
+//     runner default.
 //
 // Backend-specific posture checks (which Net modes a runner enforces,
 // WorkDir confinement) stay in each backend.
 func ValidateExecPolicy(opts ExecOptions) error {
+	if opts.Write > WriteReadOnly {
+		return errdefs.Validationf(
+			"sandbox: unknown write policy %d", int(opts.Write))
+	}
 	if opts.Resources.DiskBytes != 0 {
 		return errdefs.NotAvailablef(
 			"sandbox: disk limits not supported (no quota mechanism)")

--- a/core/sandbox/safe_readonly.go
+++ b/core/sandbox/safe_readonly.go
@@ -8,10 +8,10 @@ import (
 // ClassifySafeReadOnly reports whether req is a known read-only command
 // under the codex-rs-style heuristic: a small set of base commands
 // plus argument-aware checks for the commands whose write potential
-// depends on their flags (find / rg / git / sed). "sh -c" / "bash -lc"
-// wrappers are unwrapped exactly like allowlist matching, so a simple
-// `sh -c "ls"` classifies as safe while any composite script falls
-// through to false.
+// depends on their flags (find / rg / git / sed / sort). "sh -c" /
+// "bash -lc" wrappers are unwrapped exactly like allowlist matching,
+// so a simple `sh -c "ls"` classifies as safe while any composite
+// script falls through to false.
 //
 // The classifier is deliberately conservative: false means "not
 // proven read-only", and should route to the human approver, never to
@@ -40,6 +40,8 @@ func ClassifySafeReadOnly(req ExecRequest) bool {
 		return gitIsReadOnly(tokens[1:])
 	case "sed":
 		return sedIsReadOnly(tokens[1:])
+	case "sort":
+		return sortIsReadOnly(tokens[1:])
 	default:
 		return safeReadOnlyBases[name]
 	}
@@ -49,20 +51,24 @@ func ClassifySafeReadOnly(req ExecRequest) bool {
 // every form. Commands that can execute other programs or write files
 // (env, xargs, awk, tar, package managers, compilers, interpreters)
 // are deliberately absent: an unrecognized command is a false negative
-// that goes to the approver, which is safe.
+// that goes to the approver, which is safe. date and hostname are also
+// absent: `date -s` changes the system clock and `hostname newname`
+// changes the host name — non-file state writes that neither seatbelt
+// nor bwrap can block, so they must never auto-approve (codex-rs
+// omits them for the same reason).
 var safeReadOnlyBases = map[string]bool{
 	"basename": true, "cat": true, "cmp": true, "comm": true,
-	"cut": true, "date": true, "df": true, "diff": true,
+	"cut": true, "df": true, "diff": true,
 	"dirname": true, "du": true, "echo": true, "file": true,
 	"grep": true, "egrep": true, "fgrep": true, "groups": true,
-	"head": true, "hexdump": true, "hostname": true, "id": true,
+	"head": true, "hexdump": true, "id": true,
 	"less": true, "ls": true, "man": true, "md5sum": true,
 	"more": true, "od": true, "printenv": true, "printf": true,
 	"pwd": true, "readlink": true, "realpath": true, "sha1sum": true,
-	"sha256sum": true, "sort": true, "stat": true, "strings": true,
-	"tail": true, "tree": true, "tr": true, "true": true,
-	"false": true, "type": true, "uname": true, "uniq": true,
-	"wc": true, "which": true, "whoami": true,
+	"sha256sum": true, "stat": true, "strings": true, "tail": true,
+	"tree": true, "tr": true, "true": true, "false": true,
+	"type": true, "uname": true, "uniq": true, "wc": true,
+	"which": true, "whoami": true,
 }
 
 // findWriteActions are find predicates/actions that write files or
@@ -88,16 +94,40 @@ func findIsReadOnly(args []string) bool {
 	return true
 }
 
+// sortIsReadOnly rejects output redirection (`-o`, `--output`) in any
+// form, including short-flag groups like `sort -ro out`, so the sorted
+// result cannot be written to a file.
+func sortIsReadOnly(args []string) bool {
+	for _, arg := range args {
+		if arg == "-o" || arg == "--output" || strings.HasPrefix(arg, "--output=") {
+			return false
+		}
+		// -o is the only sort short flag containing 'o'; a group like
+		// -ro is equivalent to -r -o and must be treated the same way.
+		if strings.HasPrefix(arg, "-") && !strings.HasPrefix(arg, "--") &&
+			strings.Contains(arg, "o") {
+			return false
+		}
+	}
+	return true
+}
+
+// rgIsReadOnly rejects the ripgrep options that can execute arbitrary
+// commands (--pre, --pre-glob, --hostname-bin) or call out to other
+// decompression tools (--search-zip, -z), mirroring codex-rs's fix for
+// CVE-2025-54558. Short-flag groups may combine -z with other letters
+// (e.g. -lz), so any single-dash group containing 'z' is rejected too.
 func rgIsReadOnly(args []string) bool {
 	for _, arg := range args {
 		if arg == "-z" || arg == "--null-data" ||
-			arg == "--pre" || arg == "--pre-glob" {
+			arg == "--pre" || arg == "--pre-glob" ||
+			arg == "--search-zip" || arg == "--hostname-bin" {
 			return false
 		}
-		if strings.HasPrefix(arg, "--pre=") || strings.HasPrefix(arg, "--pre-glob=") {
+		if strings.HasPrefix(arg, "--pre=") || strings.HasPrefix(arg, "--pre-glob=") ||
+			strings.HasPrefix(arg, "--hostname-bin=") {
 			return false
 		}
-		// Short-flag groups may combine -z with other letters (e.g. -lz).
 		if strings.HasPrefix(arg, "-") && !strings.HasPrefix(arg, "--") &&
 			strings.Contains(arg, "z") {
 			return false
@@ -107,8 +137,9 @@ func rgIsReadOnly(args []string) bool {
 }
 
 // gitSafeSubcommands are git subcommands whose every form is
-// read-only. Subcommands with write variants (branch, tag, remote,
-// config, stash, reflog, fsck, archive, ...) are absent on purpose.
+// read-only once their options are checked (see gitWriteVariantFlags).
+// Subcommands with write variants (branch, tag, remote, config, stash,
+// reflog, fsck, archive, ...) are absent on purpose.
 var gitSafeSubcommands = map[string]bool{
 	"blame": true, "cat-file": true, "check-attr": true,
 	"check-ignore": true, "check-ref-format": true, "count-objects": true,
@@ -117,6 +148,14 @@ var gitSafeSubcommands = map[string]bool{
 	"ls-tree": true, "name-rev": true, "rev-parse": true,
 	"shortlog": true, "show": true, "status": true,
 	"verify-commit": true, "verify-tag": true, "whatchanged": true,
+}
+
+// gitWriteVariantFlags are diff/log/show options that write the output
+// to a file (--output) or run external programs (--ext-diff, --textconv,
+// --exec); any occurrence after the subcommand makes the invocation
+// unsafe. Aligned with codex-rs's UNSAFE_GIT_SUBCOMMAND_OPTIONS.
+var gitWriteVariantFlags = []string{
+	"--output", "--ext-diff", "--textconv", "--exec",
 }
 
 // gitValueFlags take a separate value argument and must be skipped
@@ -128,6 +167,7 @@ var gitValueFlags = map[string]bool{
 
 func gitIsReadOnly(args []string) bool {
 	var subcommand string
+	rest := args
 	for i := 0; i < len(args); i++ {
 		arg := args[i]
 		switch {
@@ -144,60 +184,71 @@ func gitIsReadOnly(args []string) bool {
 			continue
 		}
 		subcommand = arg
+		rest = args[i+1:]
 		break
 	}
 	// Bare "git" (or "git --version") prints help/version: read-only.
-	return subcommand == "" || gitSafeSubcommands[subcommand]
-}
-
-func sedIsReadOnly(args []string) bool {
-	scriptSeen := false
-	for i := 0; i < len(args); i++ {
-		arg := args[i]
-		if arg == "--in-place" || strings.HasPrefix(arg, "-i") {
+	if subcommand == "" {
+		return true
+	}
+	if !gitSafeSubcommands[subcommand] {
+		return false
+	}
+	for _, arg := range rest {
+		if arg == "--output" || strings.HasPrefix(arg, "--output=") {
 			return false
 		}
-		switch arg {
-		case "-e", "--expression", "-f", "--file":
-			if i+1 < len(args) {
-				if sedScriptWrites(args[i+1]) {
-					return false
-				}
-				i++
-			}
-			continue
-		}
-		if strings.HasPrefix(arg, "-") {
-			continue
-		}
-		// The first positional non-flag argument is the script;
-		// the rest are input files.
-		if !scriptSeen {
-			if sedScriptWrites(arg) {
+		for _, flag := range gitWriteVariantFlags {
+			if arg == flag || strings.HasPrefix(arg, flag+"=") {
 				return false
 			}
-			scriptSeen = true
 		}
 	}
 	return true
 }
 
-// sedScriptWrites reports whether a sed script contains a write
-// command: a 'w' at a command boundary (start of script, after ';' /
-// '{' / newline) or as the trailing flag group of a substitution
-// ("s/a/b/w file", where the previous character is the delimiter).
-func sedScriptWrites(script string) bool {
-	for i := 0; i < len(script); i++ {
-		if script[i] != 'w' {
-			continue
-		}
-		if i == 0 {
-			return true
-		}
-		switch script[i-1] {
-		case ';', '{', '\n', '/', '|', '#', ':':
-			return true
+// sedIsReadOnly follows codex-rs: only `sed -n <addr>p [file]` is
+// auto-approved, where <addr> is `N` or `N,M` of decimal digits.
+// Every other script form — substitution, `w` writes (including
+// address-form `sed '1w file'` / `sed '2,5w file'`), `-e`, `-i`,
+// multiple files — routes to the approver, since a conservative
+// script parser cannot prove them write-free.
+func sedIsReadOnly(args []string) bool {
+	if len(args) < 2 || len(args) > 3 {
+		return false
+	}
+	if args[0] != "-n" {
+		return false
+	}
+	return isSedPrintAddress(args[1])
+}
+
+// isSedPrintAddress reports whether s is a decimal line-address range
+// ending in `p` (`Np` or `N,Mp`), matching codex-rs's /^(\d+,)?\d+p$/.
+func isSedPrintAddress(s string) bool {
+	core, ok := strings.CutSuffix(s, "p")
+	if !ok || core == "" {
+		return false
+	}
+	if !strings.Contains(core, ",") {
+		return allDigits(core)
+	}
+	parts := strings.Split(core, ",")
+	if len(parts) != 2 {
+		return false
+	}
+	return parts[0] != "" && parts[1] != "" &&
+		allDigits(parts[0]) && allDigits(parts[1])
+}
+
+func allDigits(s string) bool {
+	if s == "" {
+		return false
+	}
+	for i := 0; i < len(s); i++ {
+		if s[i] < '0' || s[i] > '9' {
+			return false
 		}
 	}
-	return false
+	return true
 }

--- a/core/sandbox/safe_readonly.go
+++ b/core/sandbox/safe_readonly.go
@@ -1,0 +1,203 @@
+package sandbox
+
+import (
+	"path/filepath"
+	"strings"
+)
+
+// ClassifySafeReadOnly reports whether req is a known read-only command
+// under the codex-rs-style heuristic: a small set of base commands
+// plus argument-aware checks for the commands whose write potential
+// depends on their flags (find / rg / git / sed). "sh -c" / "bash -lc"
+// wrappers are unwrapped exactly like allowlist matching, so a simple
+// `sh -c "ls"` classifies as safe while any composite script falls
+// through to false.
+//
+// The classifier is deliberately conservative: false means "not
+// proven read-only", and should route to the human approver, never to
+// an automatic deny or allow. It pairs with the per-exec write policy:
+//
+//	if req.Opts.Write == sandbox.WriteReadOnly &&
+//		sandbox.ClassifySafeReadOnly(req.Exec) {
+//		return sandbox.Allow, nil
+//	}
+//
+// Like every command predicate, this is a tripwire, not a wall: the
+// OS-level read-only enforcement of the backend remains the security
+// boundary.
+func ClassifySafeReadOnly(req ExecRequest) bool {
+	tokens := NormaliseExec(req)
+	if len(tokens) == 0 {
+		return false
+	}
+	name := filepath.Base(tokens[0])
+	switch name {
+	case "find":
+		return findIsReadOnly(tokens[1:])
+	case "rg", "ripgrep":
+		return rgIsReadOnly(tokens[1:])
+	case "git":
+		return gitIsReadOnly(tokens[1:])
+	case "sed":
+		return sedIsReadOnly(tokens[1:])
+	default:
+		return safeReadOnlyBases[name]
+	}
+}
+
+// safeReadOnlyBases is the set of commands treated as read-only in
+// every form. Commands that can execute other programs or write files
+// (env, xargs, awk, tar, package managers, compilers, interpreters)
+// are deliberately absent: an unrecognized command is a false negative
+// that goes to the approver, which is safe.
+var safeReadOnlyBases = map[string]bool{
+	"basename": true, "cat": true, "cmp": true, "comm": true,
+	"cut": true, "date": true, "df": true, "diff": true,
+	"dirname": true, "du": true, "echo": true, "file": true,
+	"grep": true, "egrep": true, "fgrep": true, "groups": true,
+	"head": true, "hexdump": true, "hostname": true, "id": true,
+	"less": true, "ls": true, "man": true, "md5sum": true,
+	"more": true, "od": true, "printenv": true, "printf": true,
+	"pwd": true, "readlink": true, "realpath": true, "sha1sum": true,
+	"sha256sum": true, "sort": true, "stat": true, "strings": true,
+	"tail": true, "tree": true, "tr": true, "true": true,
+	"false": true, "type": true, "uname": true, "uniq": true,
+	"wc": true, "which": true, "whoami": true,
+}
+
+// findWriteActions are find predicates/actions that write files or
+// execute programs. Any occurrence makes the invocation unsafe.
+var findWriteActions = map[string]bool{
+	"-delete":  true,
+	"-exec":    true,
+	"-execdir": true,
+	"-ok":      true,
+	"-okdir":   true,
+	"-fls":     true,
+	"-fprint":  true,
+	"-fprint0": true,
+	"-fprintf": true,
+}
+
+func findIsReadOnly(args []string) bool {
+	for _, arg := range args {
+		if findWriteActions[arg] {
+			return false
+		}
+	}
+	return true
+}
+
+func rgIsReadOnly(args []string) bool {
+	for _, arg := range args {
+		if arg == "-z" || arg == "--null-data" ||
+			arg == "--pre" || arg == "--pre-glob" {
+			return false
+		}
+		if strings.HasPrefix(arg, "--pre=") || strings.HasPrefix(arg, "--pre-glob=") {
+			return false
+		}
+		// Short-flag groups may combine -z with other letters (e.g. -lz).
+		if strings.HasPrefix(arg, "-") && !strings.HasPrefix(arg, "--") &&
+			strings.Contains(arg, "z") {
+			return false
+		}
+	}
+	return true
+}
+
+// gitSafeSubcommands are git subcommands whose every form is
+// read-only. Subcommands with write variants (branch, tag, remote,
+// config, stash, reflog, fsck, archive, ...) are absent on purpose.
+var gitSafeSubcommands = map[string]bool{
+	"blame": true, "cat-file": true, "check-attr": true,
+	"check-ignore": true, "check-ref-format": true, "count-objects": true,
+	"describe": true, "diff": true, "for-each-ref": true,
+	"grep": true, "help": true, "log": true, "ls-files": true,
+	"ls-tree": true, "name-rev": true, "rev-parse": true,
+	"shortlog": true, "show": true, "status": true,
+	"verify-commit": true, "verify-tag": true, "whatchanged": true,
+}
+
+// gitValueFlags take a separate value argument and must be skipped
+// when locating the subcommand (git -C dir status).
+var gitValueFlags = map[string]bool{
+	"--exec-path": true, "--git-dir": true, "--namespace": true,
+	"--work-tree": true,
+}
+
+func gitIsReadOnly(args []string) bool {
+	var subcommand string
+	for i := 0; i < len(args); i++ {
+		arg := args[i]
+		switch {
+		case strings.HasPrefix(arg, "--"):
+			if gitValueFlags[arg] && i+1 < len(args) {
+				i++
+			}
+			continue
+		case strings.HasPrefix(arg, "-"):
+			// -C and -c take a value; the rest are boolean flags.
+			if (arg == "-C" || arg == "-c") && i+1 < len(args) {
+				i++
+			}
+			continue
+		}
+		subcommand = arg
+		break
+	}
+	// Bare "git" (or "git --version") prints help/version: read-only.
+	return subcommand == "" || gitSafeSubcommands[subcommand]
+}
+
+func sedIsReadOnly(args []string) bool {
+	scriptSeen := false
+	for i := 0; i < len(args); i++ {
+		arg := args[i]
+		if arg == "--in-place" || strings.HasPrefix(arg, "-i") {
+			return false
+		}
+		switch arg {
+		case "-e", "--expression", "-f", "--file":
+			if i+1 < len(args) {
+				if sedScriptWrites(args[i+1]) {
+					return false
+				}
+				i++
+			}
+			continue
+		}
+		if strings.HasPrefix(arg, "-") {
+			continue
+		}
+		// The first positional non-flag argument is the script;
+		// the rest are input files.
+		if !scriptSeen {
+			if sedScriptWrites(arg) {
+				return false
+			}
+			scriptSeen = true
+		}
+	}
+	return true
+}
+
+// sedScriptWrites reports whether a sed script contains a write
+// command: a 'w' at a command boundary (start of script, after ';' /
+// '{' / newline) or as the trailing flag group of a substitution
+// ("s/a/b/w file", where the previous character is the delimiter).
+func sedScriptWrites(script string) bool {
+	for i := 0; i < len(script); i++ {
+		if script[i] != 'w' {
+			continue
+		}
+		if i == 0 {
+			return true
+		}
+		switch script[i-1] {
+		case ';', '{', '\n', '/', '|', '#', ':':
+			return true
+		}
+	}
+	return false
+}

--- a/core/sandbox/safe_readonly_test.go
+++ b/core/sandbox/safe_readonly_test.go
@@ -21,6 +21,21 @@ func TestClassifySafeReadOnly(t *testing.T) {
 		{name: "wc", req: sandbox.ExecRequest{Command: "wc", Args: []string{"-l", "f"}}, want: true},
 		{name: "echo", req: sandbox.ExecRequest{Command: "echo", Args: []string{"hi"}}, want: true},
 
+		// date / hostname: non-file state writes (clock, hostname)
+		// escape the OS file sandbox, so every form routes to the
+		// approver.
+		{name: "date", req: sandbox.ExecRequest{Command: "date", Args: []string{"+%Y-%m-%d"}}, want: false},
+		{name: "date -s", req: sandbox.ExecRequest{Command: "date", Args: []string{"-s", "2026-01-01"}}, want: false},
+		{name: "hostname", req: sandbox.ExecRequest{Command: "hostname"}, want: false},
+		{name: "hostname set", req: sandbox.ExecRequest{Command: "hostname", Args: []string{"newname"}}, want: false},
+
+		// sort: -o / --output write the sorted result to a file.
+		{name: "sort read", req: sandbox.ExecRequest{Command: "sort", Args: []string{"-u", "f"}}, want: true},
+		{name: "sort -o", req: sandbox.ExecRequest{Command: "sort", Args: []string{"-o", "out", "f"}}, want: false},
+		{name: "sort --output=", req: sandbox.ExecRequest{Command: "sort", Args: []string{"--output=out", "f"}}, want: false},
+		{name: "sort --output", req: sandbox.ExecRequest{Command: "sort", Args: []string{"--output", "out", "f"}}, want: false},
+		{name: "sort grouped -ro", req: sandbox.ExecRequest{Command: "sort", Args: []string{"-ro", "out", "f"}}, want: false},
+
 		// find: read-only forms safe, write/exec actions unsafe.
 		{name: "find print", req: sandbox.ExecRequest{Command: "find", Args: []string{".", "-name", "*.go", "-print"}}, want: true},
 		{name: "find delete", req: sandbox.ExecRequest{Command: "find", Args: []string{".", "-delete"}}, want: false},
@@ -37,6 +52,9 @@ func TestClassifySafeReadOnly(t *testing.T) {
 		{name: "rg pre", req: sandbox.ExecRequest{Command: "rg", Args: []string{"--pre", "cat", "pattern"}}, want: false},
 		{name: "rg pre-glob", req: sandbox.ExecRequest{Command: "rg", Args: []string{"--pre-glob", "*.md", "pattern"}}, want: false},
 		{name: "rg combined short", req: sandbox.ExecRequest{Command: "rg", Args: []string{"-lz", "pattern"}}, want: false},
+		{name: "rg search-zip", req: sandbox.ExecRequest{Command: "rg", Args: []string{"--search-zip", "pattern"}}, want: false},
+		{name: "rg hostname-bin", req: sandbox.ExecRequest{Command: "rg", Args: []string{"--hostname-bin", "sh", "pattern"}}, want: false},
+		{name: "rg hostname-bin=", req: sandbox.ExecRequest{Command: "rg", Args: []string{"--hostname-bin=sh", "pattern"}}, want: false},
 
 		// git: subcommand whitelist.
 		{name: "git bare", req: sandbox.ExecRequest{Command: "git"}, want: true},
@@ -52,13 +70,27 @@ func TestClassifySafeReadOnly(t *testing.T) {
 		{name: "git remote add", req: sandbox.ExecRequest{Command: "git", Args: []string{"remote", "add", "origin", "u"}}, want: false},
 		{name: "git push", req: sandbox.ExecRequest{Command: "git", Args: []string{"push"}}, want: false},
 		{name: "git checkout", req: sandbox.ExecRequest{Command: "git", Args: []string{"checkout", "x"}}, want: false},
+		{name: "git diff output=", req: sandbox.ExecRequest{Command: "git", Args: []string{"diff", "--output=/tmp/out"}}, want: false},
+		{name: "git diff output", req: sandbox.ExecRequest{Command: "git", Args: []string{"diff", "--output", "/tmp/out"}}, want: false},
+		{name: "git show output=", req: sandbox.ExecRequest{Command: "git", Args: []string{"show", "--output=/tmp/out", "HEAD"}}, want: false},
+		{name: "git log output=", req: sandbox.ExecRequest{Command: "git", Args: []string{"log", "--output=/tmp/out", "-1"}}, want: false},
+		{name: "git diff ext-diff", req: sandbox.ExecRequest{Command: "git", Args: []string{"diff", "--ext-diff"}}, want: false},
 
-		// sed: -i and script write commands unsafe.
+		// sed: only `-n <addr>p [file]` is auto-approved (codex-rs
+		// alignment); substitutions, -i, and address-form writes are
+		// all routed to the approver.
 		{name: "sed -n", req: sandbox.ExecRequest{Command: "sed", Args: []string{"-n", "1,5p", "f"}}, want: true},
-		{name: "sed plain", req: sandbox.ExecRequest{Command: "sed", Args: []string{"s/a/b/", "f"}}, want: true},
+		{name: "sed -n single", req: sandbox.ExecRequest{Command: "sed", Args: []string{"-n", "5p", "f"}}, want: true},
+		{name: "sed -n no file", req: sandbox.ExecRequest{Command: "sed", Args: []string{"-n", "1,5p"}}, want: true},
+		{name: "sed plain", req: sandbox.ExecRequest{Command: "sed", Args: []string{"s/a/b/", "f"}}, want: false},
 		{name: "sed -i", req: sandbox.ExecRequest{Command: "sed", Args: []string{"-i", "s/a/b/", "f"}}, want: false},
 		{name: "sed in-place long", req: sandbox.ExecRequest{Command: "sed", Args: []string{"--in-place", "s/a/b/", "f"}}, want: false},
 		{name: "sed script write", req: sandbox.ExecRequest{Command: "sed", Args: []string{"s/a/b/w /tmp/out", "f"}}, want: false},
+		{name: "sed address write", req: sandbox.ExecRequest{Command: "sed", Args: []string{"1w /tmp/out", "f"}}, want: false},
+		{name: "sed range write", req: sandbox.ExecRequest{Command: "sed", Args: []string{"2,5w /tmp/out", "f"}}, want: false},
+		{name: "sed -e print", req: sandbox.ExecRequest{Command: "sed", Args: []string{"-n", "-e", "1,5p", "f"}}, want: false},
+		{name: "sed two files", req: sandbox.ExecRequest{Command: "sed", Args: []string{"-n", "1,5p", "a", "b"}}, want: false},
+		{name: "sed non-numeric addr", req: sandbox.ExecRequest{Command: "sed", Args: []string{"-n", "a,5p", "f"}}, want: false},
 
 		// Shell unwrapping: simple scripts safe, composites unsafe.
 		{name: "sh -c ls", req: sandbox.ExecRequest{Command: "sh", Args: []string{"-c", "ls"}}, want: true},

--- a/core/sandbox/safe_readonly_test.go
+++ b/core/sandbox/safe_readonly_test.go
@@ -1,0 +1,85 @@
+package sandbox_test
+
+import (
+	"testing"
+
+	"github.com/GizClaw/flowcraft/core/sandbox"
+)
+
+func TestClassifySafeReadOnly(t *testing.T) {
+	tests := []struct {
+		name string
+		req  sandbox.ExecRequest
+		want bool
+	}{
+		// Base read-only commands.
+		{name: "ls", req: sandbox.ExecRequest{Command: "ls", Args: []string{"-la"}}, want: true},
+		{name: "cat", req: sandbox.ExecRequest{Command: "cat", Args: []string{"file"}}, want: true},
+		{name: "pwd", req: sandbox.ExecRequest{Command: "pwd"}, want: true},
+		{name: "grep", req: sandbox.ExecRequest{Command: "grep", Args: []string{"-n", "x", "."}}, want: true},
+		{name: "head", req: sandbox.ExecRequest{Command: "/usr/bin/head", Args: []string{"-5", "f"}}, want: true},
+		{name: "wc", req: sandbox.ExecRequest{Command: "wc", Args: []string{"-l", "f"}}, want: true},
+		{name: "echo", req: sandbox.ExecRequest{Command: "echo", Args: []string{"hi"}}, want: true},
+
+		// find: read-only forms safe, write/exec actions unsafe.
+		{name: "find print", req: sandbox.ExecRequest{Command: "find", Args: []string{".", "-name", "*.go", "-print"}}, want: true},
+		{name: "find delete", req: sandbox.ExecRequest{Command: "find", Args: []string{".", "-delete"}}, want: false},
+		{name: "find exec", req: sandbox.ExecRequest{Command: "find", Args: []string{".", "-exec", "rm", "{}", ";"}}, want: false},
+		{name: "find execdir", req: sandbox.ExecRequest{Command: "find", Args: []string{".", "-execdir", "echo", "{}", "+"}}, want: false},
+		{name: "find ok", req: sandbox.ExecRequest{Command: "find", Args: []string{".", "-ok", "rm", "{}", ";"}}, want: false},
+		{name: "find fprintf", req: sandbox.ExecRequest{Command: "find", Args: []string{".", "-fprintf", "out", "%p"}}, want: false},
+
+		// rg: -z / --pre and friends unsafe.
+		{name: "rg plain", req: sandbox.ExecRequest{Command: "rg", Args: []string{"pattern", "."}}, want: true},
+		{name: "rg -l", req: sandbox.ExecRequest{Command: "rg", Args: []string{"-l", "pattern"}}, want: true},
+		{name: "rg -z", req: sandbox.ExecRequest{Command: "rg", Args: []string{"-z", "pattern"}}, want: false},
+		{name: "rg null-data", req: sandbox.ExecRequest{Command: "rg", Args: []string{"--null-data", "pattern"}}, want: false},
+		{name: "rg pre", req: sandbox.ExecRequest{Command: "rg", Args: []string{"--pre", "cat", "pattern"}}, want: false},
+		{name: "rg pre-glob", req: sandbox.ExecRequest{Command: "rg", Args: []string{"--pre-glob", "*.md", "pattern"}}, want: false},
+		{name: "rg combined short", req: sandbox.ExecRequest{Command: "rg", Args: []string{"-lz", "pattern"}}, want: false},
+
+		// git: subcommand whitelist.
+		{name: "git bare", req: sandbox.ExecRequest{Command: "git"}, want: true},
+		{name: "git --version", req: sandbox.ExecRequest{Command: "git", Args: []string{"--version"}}, want: true},
+		{name: "git status", req: sandbox.ExecRequest{Command: "git", Args: []string{"status", "--porcelain"}}, want: true},
+		{name: "git diff", req: sandbox.ExecRequest{Command: "git", Args: []string{"diff", "--cached"}}, want: true},
+		{name: "git log", req: sandbox.ExecRequest{Command: "git", Args: []string{"log", "--oneline", "-5"}}, want: true},
+		{name: "git -C", req: sandbox.ExecRequest{Command: "git", Args: []string{"-C", "/tmp", "status"}}, want: true},
+		{name: "git --git-dir", req: sandbox.ExecRequest{Command: "git", Args: []string{"--git-dir", "/tmp/.git", "status"}}, want: true},
+		{name: "git show", req: sandbox.ExecRequest{Command: "git", Args: []string{"show", "HEAD"}}, want: true},
+		{name: "git add", req: sandbox.ExecRequest{Command: "git", Args: []string{"add", "."}}, want: false},
+		{name: "git branch -d", req: sandbox.ExecRequest{Command: "git", Args: []string{"branch", "-d", "x"}}, want: false},
+		{name: "git remote add", req: sandbox.ExecRequest{Command: "git", Args: []string{"remote", "add", "origin", "u"}}, want: false},
+		{name: "git push", req: sandbox.ExecRequest{Command: "git", Args: []string{"push"}}, want: false},
+		{name: "git checkout", req: sandbox.ExecRequest{Command: "git", Args: []string{"checkout", "x"}}, want: false},
+
+		// sed: -i and script write commands unsafe.
+		{name: "sed -n", req: sandbox.ExecRequest{Command: "sed", Args: []string{"-n", "1,5p", "f"}}, want: true},
+		{name: "sed plain", req: sandbox.ExecRequest{Command: "sed", Args: []string{"s/a/b/", "f"}}, want: true},
+		{name: "sed -i", req: sandbox.ExecRequest{Command: "sed", Args: []string{"-i", "s/a/b/", "f"}}, want: false},
+		{name: "sed in-place long", req: sandbox.ExecRequest{Command: "sed", Args: []string{"--in-place", "s/a/b/", "f"}}, want: false},
+		{name: "sed script write", req: sandbox.ExecRequest{Command: "sed", Args: []string{"s/a/b/w /tmp/out", "f"}}, want: false},
+
+		// Shell unwrapping: simple scripts safe, composites unsafe.
+		{name: "sh -c ls", req: sandbox.ExecRequest{Command: "sh", Args: []string{"-c", "ls"}}, want: true},
+		{name: "bash -lc pwd", req: sandbox.ExecRequest{Command: "bash", Args: []string{"-lc", "pwd"}}, want: true},
+		{name: "sh -c composite", req: sandbox.ExecRequest{Command: "sh", Args: []string{"-c", "ls; rm x"}}, want: false},
+		{name: "sh -c pipe", req: sandbox.ExecRequest{Command: "sh", Args: []string{"-c", "ls | grep x"}}, want: false},
+
+		// Unknown / dangerous commands: conservative false.
+		{name: "rm", req: sandbox.ExecRequest{Command: "rm", Args: []string{"-rf", "x"}}, want: false},
+		{name: "xargs", req: sandbox.ExecRequest{Command: "xargs", Args: []string{"rm"}}, want: false},
+		{name: "env exec", req: sandbox.ExecRequest{Command: "env", Args: []string{"FOO=1", "rm", "x"}}, want: false},
+		{name: "tar extract", req: sandbox.ExecRequest{Command: "tar", Args: []string{"xf", "x.tar"}}, want: false},
+		{name: "python", req: sandbox.ExecRequest{Command: "python", Args: []string{"x.py"}}, want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := sandbox.ClassifySafeReadOnly(tt.req); got != tt.want {
+				t.Fatalf("ClassifySafeReadOnly(%v) = %v, want %v",
+					tt.req, got, tt.want)
+			}
+		})
+	}
+}

--- a/core/sandbox/seatbelt/doc.go
+++ b/core/sandbox/seatbelt/doc.go
@@ -30,6 +30,7 @@
 //	Net.Mode == NetDenyAll      (deny network*)
 //	Net.Mode == NetAllowList    loopback-only profile + host enforcement proxy (hostname allow-list)
 //	Net.Mode == NetProxy        loopback-only profile + host enforcement proxy (upstream)
+//	Write == WriteReadOnly      root left out of the writable set for this call
 //	Resources.MemoryBytes       group watcher (core/sandbox.GroupCapsWatcher)
 //	Resources.CPUMillicores     group watcher, cpu-time = Timeout x millicores/1000
 //	Resources.DiskBytes         errdefs.NotAvailable (no quota mechanism)
@@ -41,10 +42,14 @@
 // re-allow the workspace": reads and process execution are unrestricted
 // (a local agent must reach the real toolchain), file writes are denied
 // machine-wide except the runner root and /dev/null. Dedicated temp
-// or cache paths may be added explicitly with WithWritablePaths. This
-// is the containment posture the local-sandbox PRD
-// calls blast-radius: not total isolation, but an honest boundary
-// around the workspace.
+// or cache paths may be added explicitly with WithWritablePaths.
+// [WithReadOnlyRoot] drops the runner root from the writable set for
+// every exec, and per-exec sandbox.WriteReadOnly does the same for a
+// single call — explicit writable paths and /dev/null stay allowed, so
+// on seatbelt read-only means no host writes beyond those exceptions
+// (there is no private tmpfs to fall back on). This is the
+// containment posture the local-sandbox PRD calls blast-radius: not
+// total isolation, but an honest boundary around the workspace.
 //
 // # NetAllowList / NetProxy enforcement
 //

--- a/core/sandbox/seatbelt/readonly_darwin_test.go
+++ b/core/sandbox/seatbelt/readonly_darwin_test.go
@@ -1,0 +1,106 @@
+//go:build darwin
+
+package seatbelt
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/GizClaw/flowcraft/core/resource"
+	corenet "github.com/GizClaw/flowcraft/core/utils/net"
+)
+
+func TestBuildProfileRootWritableByDefault(t *testing.T) {
+	profile, err := buildProfile(
+		[]string{"/srv/root", "/srv/cache"},
+		corenet.NetPolicy{Mode: corenet.NetDefault},
+		0,
+	)
+	if err != nil {
+		t.Fatalf("buildProfile: %v", err)
+	}
+	for _, want := range []string{
+		"(deny file-write*)",
+		`(allow file-write* (subpath "/srv/root"))`,
+		`(allow file-write* (subpath "/srv/cache"))`,
+		`(allow file-write* (literal "/dev/null"))`,
+	} {
+		if !strings.Contains(profile, want) {
+			t.Errorf("profile missing %q:\n%s", want, profile)
+		}
+	}
+}
+
+func TestBuildProfileReadOnlyOmitsRoot(t *testing.T) {
+	profile, err := buildProfile(
+		[]string{"/srv/cache"},
+		corenet.NetPolicy{Mode: corenet.NetDefault},
+		0,
+	)
+	if err != nil {
+		t.Fatalf("buildProfile: %v", err)
+	}
+	if !strings.Contains(profile, "(deny file-write*)") {
+		t.Errorf("profile must deny file writes:\n%s", profile)
+	}
+	if strings.Contains(profile, `(allow file-write* (subpath "/srv/root"))`) {
+		t.Errorf("read-only profile must not allow the runner root:\n%s", profile)
+	}
+	if !strings.Contains(profile, `(allow file-write* (subpath "/srv/cache"))`) {
+		t.Errorf("read-only profile must keep explicit writable paths:\n%s", profile)
+	}
+}
+
+func TestNewReadOnlyRootOption(t *testing.T) {
+	root := t.TempDir()
+
+	runner, err := New(root)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	if !runner.rootWritable {
+		t.Fatal("default runner must keep the root writable")
+	}
+
+	ro, err := New(root, WithReadOnlyRoot())
+	if err != nil {
+		t.Fatalf("New(WithReadOnlyRoot): %v", err)
+	}
+	if ro.rootWritable {
+		t.Fatal("WithReadOnlyRoot must make the root read-only")
+	}
+	if len(ro.extraWritable) != 0 {
+		t.Fatalf("unexpected extra writable paths: %v", ro.extraWritable)
+	}
+}
+
+func TestRegisterReadOnlyRootSettings(t *testing.T) {
+	root := t.TempDir()
+	for _, tc := range []struct {
+		name     string
+		settings string
+		wantRO   bool
+	}{
+		{name: "default", settings: `{"root": "` + root + `"}`},
+		{name: "readonly_root false", settings: `{"root": "` + root + `", "readonly_root": false}`},
+		{name: "readonly_root true", settings: `{"root": "` + root + `", "readonly_root": true}`, wantRO: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := NewFactory().New(context.Background(), resource.Input{
+				Settings: json.RawMessage(tc.settings),
+			})
+			if err != nil {
+				t.Fatalf("NewFactory().New: %v", err)
+			}
+			runner, ok := got.(*Runner)
+			if !ok {
+				t.Fatalf("factory returned %T, want *Runner", got)
+			}
+			if runner.rootWritable != !tc.wantRO {
+				t.Fatalf("rootWritable = %v, want %v", runner.rootWritable, !tc.wantRO)
+			}
+		})
+	}
+}

--- a/core/sandbox/seatbelt/readonly_darwin_test.go
+++ b/core/sandbox/seatbelt/readonly_darwin_test.go
@@ -5,10 +5,12 @@ package seatbelt
 import (
 	"context"
 	"encoding/json"
+	"slices"
 	"strings"
 	"testing"
 
 	"github.com/GizClaw/flowcraft/core/resource"
+	"github.com/GizClaw/flowcraft/core/sandbox"
 	corenet "github.com/GizClaw/flowcraft/core/utils/net"
 )
 
@@ -60,7 +62,7 @@ func TestNewReadOnlyRootOption(t *testing.T) {
 	if err != nil {
 		t.Fatalf("New: %v", err)
 	}
-	if !runner.rootWritable {
+	if runner.readOnlyRoot {
 		t.Fatal("default runner must keep the root writable")
 	}
 
@@ -68,11 +70,55 @@ func TestNewReadOnlyRootOption(t *testing.T) {
 	if err != nil {
 		t.Fatalf("New(WithReadOnlyRoot): %v", err)
 	}
-	if ro.rootWritable {
+	if !ro.readOnlyRoot {
 		t.Fatal("WithReadOnlyRoot must make the root read-only")
 	}
 	if len(ro.extraWritable) != 0 {
 		t.Fatalf("unexpected extra writable paths: %v", ro.extraWritable)
+	}
+}
+
+// TestNewRejectsWritableRootWithReadOnlyRoot pins the documented
+// contract: an explicit writable path that resolves to the runner root
+// conflicts with readonly_root and must fail construction instead of
+// being silently dropped.
+func TestNewRejectsWritableRootWithReadOnlyRoot(t *testing.T) {
+	root := t.TempDir()
+	if _, err := New(root, WithReadOnlyRoot(), WithWritablePaths(root)); err == nil {
+		t.Fatal("New must reject a writable path that is the read-only runner root")
+	}
+	// Without readonly_root the root is already writable by default,
+	// so listing it is redundant but harmless.
+	runner, err := New(root, WithWritablePaths(root))
+	if err != nil {
+		t.Fatalf("New(WithWritablePaths(root)): %v", err)
+	}
+	if len(runner.extraWritable) != 0 {
+		t.Fatalf("root must not be duplicated in extraWritable: %v", runner.extraWritable)
+	}
+}
+
+// TestWritablePathsForPerCallReadOnly is the direct assertion that a
+// per-call WriteReadOnly keeps the construction-time writable root out
+// of the writable set while explicit writable paths stay writable.
+func TestWritablePathsForPerCallReadOnly(t *testing.T) {
+	root := t.TempDir()
+	cache := t.TempDir()
+	runner, err := New(root, WithWritablePaths(cache))
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	if writes := runner.writablePathsFor(sandbox.WriteWorkspace); !slices.Contains(writes, runner.rootDir) {
+		t.Fatalf("workspace call must keep the root writable: %v", writes)
+	}
+
+	writes := runner.writablePathsFor(sandbox.WriteReadOnly)
+	if slices.Contains(writes, runner.rootDir) {
+		t.Fatalf("per-call read-only must drop the root from the writable set: %v", writes)
+	}
+	if len(runner.extraWritable) != 1 || !slices.Contains(writes, runner.extraWritable[0]) {
+		t.Fatalf("explicit writable paths must stay writable: %v", writes)
 	}
 }
 
@@ -98,8 +144,8 @@ func TestRegisterReadOnlyRootSettings(t *testing.T) {
 			if !ok {
 				t.Fatalf("factory returned %T, want *Runner", got)
 			}
-			if runner.rootWritable != !tc.wantRO {
-				t.Fatalf("rootWritable = %v, want %v", runner.rootWritable, !tc.wantRO)
+			if runner.readOnlyRoot != tc.wantRO {
+				t.Fatalf("readOnlyRoot = %v, want %v", runner.readOnlyRoot, tc.wantRO)
 			}
 		})
 	}

--- a/core/sandbox/seatbelt/register.go
+++ b/core/sandbox/seatbelt/register.go
@@ -20,6 +20,7 @@ type settings struct {
 	Root          string   `json:"root"`
 	Binary        string   `json:"binary,omitempty"`
 	WritablePaths []string `json:"writable_paths,omitempty"`
+	ReadOnlyRoot  bool     `json:"readonly_root,omitempty"`
 }
 
 type factory struct{}
@@ -55,6 +56,9 @@ func (factory) New(_ context.Context, in resource.Input) (any, error) {
 	}
 	if writable != nil {
 		options = append(options, WithWritablePaths(writable...))
+	}
+	if s.ReadOnlyRoot {
+		options = append(options, WithReadOnlyRoot())
 	}
 	runner, err := New(s.Root, options...)
 	if err != nil {

--- a/core/sandbox/seatbelt/runner.go
+++ b/core/sandbox/seatbelt/runner.go
@@ -13,11 +13,12 @@ type RunnerOption func(*runnerConfig)
 // It lives in the platform-neutral file so the option functions
 // type-check on every OS even though Runner itself is darwin-only.
 type runnerConfig struct {
-	binFrom  string   // raw value supplied to WithBinary, "" if defaulted
-	writable []string // extra writable paths, resolved at construction
-	decision func(net.ProxyDecision)
-	hooks    net.MITMHooks
-	roots    *x509.CertPool
+	binFrom      string   // raw value supplied to WithBinary, "" if defaulted
+	writable     []string // extra writable paths, resolved at construction
+	readOnlyRoot bool     // keep the runner root read-only for every exec
+	decision     func(net.ProxyDecision)
+	hooks        net.MITMHooks
+	roots        *x509.CertPool
 }
 
 // WithBinary overrides the sandbox-exec binary path. By default the
@@ -41,6 +42,17 @@ func WithBinary(path string) RunnerOption {
 func WithWritablePaths(paths ...string) RunnerOption {
 	return func(c *runnerConfig) {
 		c.writable = append(c.writable, paths...)
+	}
+}
+
+// WithReadOnlyRoot keeps the runner root read-only for every exec
+// spawned through this runner, instead of the default (root writable).
+// Explicit [WithWritablePaths] exceptions remain writable, and
+// per-exec sandbox.WriteReadOnly can only keep the root read-only —
+// it cannot re-enable writes on a runner constructed with this option.
+func WithReadOnlyRoot() RunnerOption {
+	return func(c *runnerConfig) {
+		c.readOnlyRoot = true
 	}
 }
 

--- a/core/sandbox/seatbelt/runner_darwin.go
+++ b/core/sandbox/seatbelt/runner_darwin.go
@@ -28,7 +28,8 @@ const defaultMaxOutputBytes int64 = 10 * 1024 * 1024
 type Runner struct {
 	rootDir          string
 	binary           string
-	writable         []string
+	extraWritable    []string // explicit writable paths beyond the root
+	rootWritable     bool     // false when constructed with WithReadOnlyRoot
 	defaultMaxOutput int64
 	sessions         *sandbox.SessionRegistry
 	decision         func(corenet.ProxyDecision)
@@ -64,19 +65,22 @@ func New(rootDir string, opts ...RunnerOption) (*Runner, error) {
 	if err != nil {
 		return nil, err
 	}
-	writable := []string{root}
+	extraWritable := make([]string, 0, len(cfg.writable))
 	for _, path := range cfg.writable {
 		resolved, err := resolveRoot(path)
 		if err != nil {
 			return nil, fmt.Errorf("seatbelt: resolve writable path %q: %w", path, err)
 		}
-		writable = append(writable, resolved)
+		if resolved != root {
+			extraWritable = append(extraWritable, resolved)
+		}
 	}
 
 	runner := &Runner{
 		rootDir:          root,
 		binary:           binary,
-		writable:         dedupe(writable),
+		extraWritable:    dedupe(extraWritable),
+		rootWritable:     !cfg.readOnlyRoot,
 		defaultMaxOutput: defaultMaxOutputBytes,
 		decision:         cfg.decision,
 		hooks:            cfg.hooks,
@@ -98,6 +102,7 @@ func (r *Runner) Capabilities() sandbox.Capabilities {
 			MemoryCap:        caps,
 			CPUCap:           caps,
 			FilesystemBounds: true,
+			WriteModes:       []sandbox.WritePolicy{sandbox.WriteWorkspace, sandbox.WriteReadOnly},
 		},
 		Features: sandbox.SessionFeatures{
 			TTY:    true,
@@ -213,7 +218,11 @@ func (r *Runner) spawnProcess(
 		}
 	}
 
-	profile, err := buildProfile(r.writable, spec.Opts.Net, proxyPort)
+	writes := append([]string(nil), r.extraWritable...)
+	if r.rootWritable && spec.Opts.Write != sandbox.WriteReadOnly {
+		writes = append(writes, r.rootDir)
+	}
+	profile, err := buildProfile(writes, spec.Opts.Net, proxyPort)
 	if err != nil {
 		closeProxy(ctx, proxy)
 		abortBundle()

--- a/core/sandbox/seatbelt/runner_darwin.go
+++ b/core/sandbox/seatbelt/runner_darwin.go
@@ -29,7 +29,7 @@ type Runner struct {
 	rootDir          string
 	binary           string
 	extraWritable    []string // explicit writable paths beyond the root
-	rootWritable     bool     // false when constructed with WithReadOnlyRoot
+	readOnlyRoot     bool     // keep the runner root read-only for every exec
 	defaultMaxOutput int64
 	sessions         *sandbox.SessionRegistry
 	decision         func(corenet.ProxyDecision)
@@ -71,16 +71,25 @@ func New(rootDir string, opts ...RunnerOption) (*Runner, error) {
 		if err != nil {
 			return nil, fmt.Errorf("seatbelt: resolve writable path %q: %w", path, err)
 		}
-		if resolved != root {
-			extraWritable = append(extraWritable, resolved)
+		if resolved == root {
+			if cfg.readOnlyRoot {
+				return nil, errdefs.Validationf(
+					"seatbelt: writable path %q is the read-only runner root; drop the path or disable readonly_root",
+					path,
+				)
+			}
+			// Redundant with the default (root writable); keep the
+			// explicit list free of duplicates.
+			continue
 		}
+		extraWritable = append(extraWritable, resolved)
 	}
 
 	runner := &Runner{
 		rootDir:          root,
 		binary:           binary,
 		extraWritable:    dedupe(extraWritable),
-		rootWritable:     !cfg.readOnlyRoot,
+		readOnlyRoot:     cfg.readOnlyRoot,
 		defaultMaxOutput: defaultMaxOutputBytes,
 		decision:         cfg.decision,
 		hooks:            cfg.hooks,
@@ -218,10 +227,7 @@ func (r *Runner) spawnProcess(
 		}
 	}
 
-	writes := append([]string(nil), r.extraWritable...)
-	if r.rootWritable && spec.Opts.Write != sandbox.WriteReadOnly {
-		writes = append(writes, r.rootDir)
-	}
+	writes := r.writablePathsFor(spec.Opts.Write)
 	profile, err := buildProfile(writes, spec.Opts.Net, proxyPort)
 	if err != nil {
 		closeProxy(ctx, proxy)
@@ -262,6 +268,17 @@ func (r *Runner) spawnProcess(
 		return &sessionHandle{Session: sess, cleanup: cleanup}, nil
 	}
 	return sess, nil
+}
+
+// writablePathsFor returns the writable set for a single spawn: the
+// configured extra paths always, plus the runner root unless it was
+// pinned read-only at construction or by the per-call write policy.
+func (r *Runner) writablePathsFor(write sandbox.WritePolicy) []string {
+	writes := append([]string(nil), r.extraWritable...)
+	if !r.readOnlyRoot && write != sandbox.WriteReadOnly {
+		writes = append(writes, r.rootDir)
+	}
+	return writes
 }
 
 // closeProxy best-effort closes the enforcement proxy, leaving the

--- a/core/sandbox/write_policy_test.go
+++ b/core/sandbox/write_policy_test.go
@@ -1,0 +1,76 @@
+package sandbox_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/GizClaw/flowcraft/core/sandbox"
+)
+
+// captureRunner records the ExecOptions each Start receives so tests
+// can observe how decorators rewrite per-call policy.
+type captureRunner struct {
+	opts []sandbox.ExecOptions
+}
+
+func (r *captureRunner) Close() error                       { return nil }
+func (r *captureRunner) Capabilities() sandbox.Capabilities { return sandbox.Capabilities{} }
+func (r *captureRunner) List(context.Context) ([]sandbox.SessionInfo, error) {
+	return nil, nil
+}
+func (r *captureRunner) Terminate(context.Context, string) error { return nil }
+func (r *captureRunner) Start(_ context.Context, spec sandbox.SessionSpec) (sandbox.Session, error) {
+	r.opts = append(r.opts, spec.Opts)
+	return nil, nil
+}
+
+// TestWithDefaultsWriteMerge pins the security-biased merge rule:
+// either side being read-only wins, an unknown caller value is
+// preserved for backend validation, and a read-only default can never
+// be widened.
+func TestWithDefaultsWriteMerge(t *testing.T) {
+	tests := []struct {
+		name     string
+		caller   sandbox.WritePolicy
+		def      sandbox.WritePolicy
+		expected sandbox.WritePolicy
+	}{
+		{name: "defaults workspace", expected: sandbox.WriteWorkspace},
+		{name: "caller narrows", caller: sandbox.WriteReadOnly, expected: sandbox.WriteReadOnly},
+		{name: "default pins read-only", def: sandbox.WriteReadOnly, expected: sandbox.WriteReadOnly},
+		{name: "both read-only", caller: sandbox.WriteReadOnly, def: sandbox.WriteReadOnly, expected: sandbox.WriteReadOnly},
+		{name: "unknown caller preserved", caller: sandbox.WritePolicy(7), expected: sandbox.WritePolicy(7)},
+		{name: "unknown caller cannot widen pinned default", caller: sandbox.WritePolicy(7), def: sandbox.WriteReadOnly, expected: sandbox.WriteReadOnly},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			inner := &captureRunner{}
+			runner := sandbox.WithDefaults(inner, sandbox.ExecOptions{Write: tt.def})
+			if _, err := runner.Start(context.Background(), sandbox.SessionSpec{
+				Opts: sandbox.ExecOptions{Write: tt.caller},
+			}); err != nil {
+				t.Fatalf("Start: %v", err)
+			}
+			if len(inner.opts) != 1 {
+				t.Fatalf("captured %d calls, want 1", len(inner.opts))
+			}
+			if got := inner.opts[0].Write; got != tt.expected {
+				t.Fatalf("merged Write = %d, want %d", int(got), int(tt.expected))
+			}
+		})
+	}
+}
+
+// TestValidateExecPolicyWriteMode ensures the known write modes pass
+// validation and unknown values fail closed instead of silently
+// degrading to the runner default.
+func TestValidateExecPolicyWriteMode(t *testing.T) {
+	for _, mode := range []sandbox.WritePolicy{sandbox.WriteWorkspace, sandbox.WriteReadOnly} {
+		if err := sandbox.ValidateExecPolicy(sandbox.ExecOptions{Write: mode}); err != nil {
+			t.Fatalf("Write %d rejected: %v", int(mode), err)
+		}
+	}
+	if err := sandbox.ValidateExecPolicy(sandbox.ExecOptions{Write: sandbox.WritePolicy(7)}); err == nil {
+		t.Fatal("unknown write policy accepted")
+	}
+}

--- a/core/sandbox/write_policy_test.go
+++ b/core/sandbox/write_policy_test.go
@@ -25,9 +25,9 @@ func (r *captureRunner) Start(_ context.Context, spec sandbox.SessionSpec) (sand
 }
 
 // TestWithDefaultsWriteMerge pins the security-biased merge rule:
-// either side being read-only wins, an unknown caller value is
-// preserved for backend validation, and a read-only default can never
-// be widened.
+// either side being read-only wins, an unknown value on either side is
+// preserved for backend validation (never silently degraded to
+// WriteWorkspace), and a pinned default can never be widened.
 func TestWithDefaultsWriteMerge(t *testing.T) {
 	tests := []struct {
 		name     string
@@ -41,6 +41,8 @@ func TestWithDefaultsWriteMerge(t *testing.T) {
 		{name: "both read-only", caller: sandbox.WriteReadOnly, def: sandbox.WriteReadOnly, expected: sandbox.WriteReadOnly},
 		{name: "unknown caller preserved", caller: sandbox.WritePolicy(7), expected: sandbox.WritePolicy(7)},
 		{name: "unknown caller cannot widen pinned default", caller: sandbox.WritePolicy(7), def: sandbox.WriteReadOnly, expected: sandbox.WriteReadOnly},
+		{name: "unknown default preserved", def: sandbox.WritePolicy(7), expected: sandbox.WritePolicy(7)},
+		{name: "unknown default cannot be widened", caller: sandbox.WriteReadOnly, def: sandbox.WritePolicy(7), expected: sandbox.WritePolicy(7)},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/docs/guides/sandbox.md
+++ b/docs/guides/sandbox.md
@@ -48,16 +48,45 @@ resources:
       root: ./sandbox
       binary: /usr/bin/bwrap    # optional; resolved against the root
       writable_paths: [./out]   # optional; paths the sandbox may write
+      readonly_root: true       # optional; keep the runner root read-only
       extra_flags: [--die-with-parent]  # bwrap only; policy-downgrading flags are rejected
 ```
 
 `root` is required and scopes the sandbox filesystem. `binary` overrides
 the backend binary and is resolved against the root; `writable_paths`
-opt into write access; `extra_flags` (bwrap only) passes additional
-bwrap flags, with any flag that could weaken the policy (e.g. `--ro-bind`
-or `--args`) rejected at build time. The local runner is a no-isolation
-backend for trusted workflows; bwrap/seatbelt enforce the isolation
-boundary and reject policies they cannot honor.
+opt into write access; `readonly_root` keeps the runner root read-only
+for every exec (explicit `writable_paths` stay writable);
+`extra_flags` (bwrap only) passes additional bwrap flags, with any flag
+that could weaken the policy (e.g. `--ro-bind` or `--args`) rejected at
+build time. The local runner is a no-isolation backend for trusted
+workflows; bwrap/seatbelt enforce the isolation boundary and reject
+policies they cannot honor.
+
+## Per-exec write policy
+
+`ExecOptions.Write` narrows the filesystem boundary for a single call
+without changing the runner. `WriteReadOnly` keeps the runner root
+read-only for that exec (explicit `writable_paths` and platform escape
+hatches like `/dev/null` remain allowed); `WriteWorkspace` (zero value)
+keeps the runner root writable — the current behavior. There is no
+widening mode — a call can only request a stricter boundary than the
+runner was constructed with, and `WithDefaults` follows the same rule
+(either side read-only wins). The local runner has no OS boundary and
+reports no write modes in `Capabilities`.
+
+For read-only auto-approval, `ClassifySafeReadOnly` implements the
+codex-rs-style heuristic (base read-only commands plus argument-aware
+checks for `find` / `rg` / `git` / `sed`, with `sh -c` / `bash -lc`
+unwrap). It is a caller-side helper — the host's `ApprovalFunc` decides:
+
+```go
+if req.Opts.Write == sandbox.WriteReadOnly && sandbox.ClassifySafeReadOnly(req.Exec) {
+    return sandbox.Allow, nil
+}
+```
+
+It never denies and never widens policy; unrecognized commands return
+`false` and route to the human approver.
 
 ## Policy groups
 

--- a/docs/guides/sandbox.md
+++ b/docs/guides/sandbox.md
@@ -56,6 +56,10 @@ resources:
 the backend binary and is resolved against the root; `writable_paths`
 opt into write access; `readonly_root` keeps the runner root read-only
 for every exec (explicit `writable_paths` stay writable);
+`writable_paths` entries that resolve to the runner root conflict with
+`readonly_root: true` and are rejected at build time instead of being
+silently dropped (without `readonly_root` such an entry is redundant
+and ignored);
 `extra_flags` (bwrap only) passes additional bwrap flags, with any flag
 that could weaken the policy (e.g. `--ro-bind` or `--args`) rejected at
 build time. The local runner is a no-isolation backend for trusted
@@ -71,13 +75,19 @@ hatches like `/dev/null` remain allowed); `WriteWorkspace` (zero value)
 keeps the runner root writable — the current behavior. There is no
 widening mode — a call can only request a stricter boundary than the
 runner was constructed with, and `WithDefaults` follows the same rule
-(either side read-only wins). The local runner has no OS boundary and
+(either side read-only wins; an unknown value on either side is
+preserved so backend validation rejects it instead of silently
+degrading to `WriteWorkspace`). The local runner has no OS boundary and
 reports no write modes in `Capabilities`.
 
 For read-only auto-approval, `ClassifySafeReadOnly` implements the
 codex-rs-style heuristic (base read-only commands plus argument-aware
-checks for `find` / `rg` / `git` / `sed`, with `sh -c` / `bash -lc`
-unwrap). It is a caller-side helper — the host's `ApprovalFunc` decides:
+checks for `find` / `rg` / `git` / `sed` / `sort`, with `sh -c` /
+`bash -lc` unwrap). `date` and `hostname` are deliberately not
+auto-approved: `date -s` changes the system clock and
+`hostname newname` changes the host name — non-file writes the OS
+sandbox cannot block. It is a caller-side helper — the host's
+`ApprovalFunc` decides:
 
 ```go
 if req.Opts.Write == sandbox.WriteReadOnly && sandbox.ClassifySafeReadOnly(req.Exec) {

--- a/skills/flowcraft-config/references/pitfalls.md
+++ b/skills/flowcraft-config/references/pitfalls.md
@@ -23,13 +23,18 @@ builds the deployment with its own factory registry, or at runtime.
    source — host build.
 10. Local sandbox is a no-isolation backend and should not be used for
     untrusted production execution.
-11. Runtime registration cannot reuse a deployed agent name (`Conflict`);
+11. `readonly_root` (or per-call `WriteReadOnly`) does not mean "no
+    writes at all": explicit `writable_paths` stay writable, and on
+    bwrap the private `/tmp` tmpfs is still writable (host-invisible,
+    dies with the sandbox). Seatbelt has no tmpfs fallback, so it
+    denies every write outside `writable_paths` and `/dev/null`.
+12. Runtime registration cannot reuse a deployed agent name (`Conflict`);
     deployed agents can only be removed by changing the deployment
     document — runtime API.
-12. With `dynamic_catalog` configured and no `default`, runtime
+13. With `dynamic_catalog` configured and no `default`, runtime
     registration must pass `WithToolAssembly`; otherwise registration is
     rejected up front — runtime API.
-13. `UnregisterAgent` waits for active turns; a stuck engine times out
+14. `UnregisterAgent` waits for active turns; a stuck engine times out
     (`WithRemoveTimeout` / ctx deadline) and the agent is left registered
     — retry, don't assume removal happened — runtime API.
 

--- a/skills/flowcraft-config/references/pitfalls.md
+++ b/skills/flowcraft-config/references/pitfalls.md
@@ -27,7 +27,10 @@ builds the deployment with its own factory registry, or at runtime.
     writes at all": explicit `writable_paths` stay writable, and on
     bwrap the private `/tmp` tmpfs is still writable (host-invisible,
     dies with the sandbox). Seatbelt has no tmpfs fallback, so it
-    denies every write outside `writable_paths` and `/dev/null`.
+    denies every write outside `writable_paths` and `/dev/null`. A
+    `writable_paths` entry resolving to the runner root is rejected at
+    build time when `readonly_root: true` — the combination is not
+    silently downgraded.
 12. Runtime registration cannot reuse a deployed agent name (`Conflict`);
     deployed agents can only be removed by changing the deployment
     document — runtime API.

--- a/skills/flowcraft-config/references/resources.md
+++ b/skills/flowcraft-config/references/resources.md
@@ -122,8 +122,15 @@ box:
     root: ./sandbox
     binary: /usr/bin/bwrap    # optional; resolved against the root
     writable_paths: [./out]   # optional; paths the sandbox may write
+    readonly_root: true       # optional; keep the runner root read-only
     extra_flags: [--die-with-parent]  # bwrap only; policy-downgrading flags are rejected
 ```
+
+`readonly_root` keeps the runner root read-only for every exec; explicit
+`writable_paths` stay writable. The per-call counterpart is
+`ExecOptions.Write` (`WriteWorkspace` zero value / `WriteReadOnly`) —
+host code narrows a single call to read-only without changing settings;
+`WriteReadOnly` on `sandbox/local` is rejected as unavailable.
 
 ## tool source / assembly
 

--- a/skills/flowcraft-config/references/resources.md
+++ b/skills/flowcraft-config/references/resources.md
@@ -132,6 +132,11 @@ box:
 host code narrows a single call to read-only without changing settings;
 `WriteReadOnly` on `sandbox/local` is rejected as unavailable.
 
+`writable_paths` entries that resolve to the runner root conflict with
+`readonly_root: true`: the host build rejects the combination instead of
+silently dropping the entry (without `readonly_root` such an entry is
+redundant and ignored).
+
 ## tool source / assembly
 
 ```yaml


### PR DESCRIPTION
## Summary

Implements the design from #447: a per-call write policy on `ExecOptions` (the enforcement half of a codex-rs-style read-only sandbox mode), plus the runner-level default and the read-only command classifier for caller-owned auto-approval.

## What changed

- `sandbox.WritePolicy` (`WriteWorkspace` zero value / `WriteReadOnly`) added to `ExecOptions`; `ValidateExecPolicy` rejects unknown modes (fail closed).
- `WithDefaults` merge rule: either side read-only wins; an unknown value on either side is preserved so backend validation rejects it — never silently degraded to `WriteWorkspace`.
- seatbelt: `WithReadOnlyRoot()` / `settings.readonly_root`; when read-only (runner default or per-call), the runner root is omitted from the SBPL writable set — `(deny file-write*)` stays, only explicit `writable_paths` and `/dev/null` are re-allowed.
- bwrap: same option/settings; `filesystemFlags` emits `--ro-bind rootDir rootDir` instead of `--bind` (kept after the `/tmp` tmpfs mount).
- sandbox/local: `WriteReadOnly` returns `errdefs.NotAvailable` (no OS boundary to enforce it), matching the existing NetDefault-only posture.
- `Enforcement.WriteModes`: seatbelt/bwrap advertise `[WriteWorkspace, WriteReadOnly]`; local reports none.
- `ClassifySafeReadOnly(req)`: conservative codex-rs-style heuristic (base read-only commands; argument-aware `find` / `rg` / `git` / `sed` / `sort`; `sh -c` / `bash -lc` unwrap via existing `NormaliseExec`). Caller-side helper for `ApprovalFunc` — never denies, false routes to the human approver.

## Review follow-up (b931f25f)

Addresses the #447 review findings:

- `date` / `hostname` removed from the read-only base set — `date -s` changes the system clock and `hostname newname` changes the host name, non-file state writes neither seatbelt nor bwrap can block (codex-rs omits both).
- `sort`: `-o` / `--output` rejected, including short-flag groups like `-ro`.
- `rg`: `--search-zip` and `--hostname-bin` (with `=` form) now rejected, matching codex-rs's CVE-2025-54558 fix.
- `git`: `--output`, `--ext-diff`, `--textconv`, `--exec` rejected on whitelisted subcommands (diff/log/show write variants).
- `sed`: aligned with codex-rs — only `sed -n <addr>p [file]` is auto-approved, closing address-form writes like `sed '1w file'` / `sed '2,5w file'`.
- seatbelt/bwrap: a `writable_paths` entry resolving to the runner root is rejected at build time when `readonly_root: true` (was silently dropped); polarity unified on `readOnlyRoot`; per-call write merging extracted (`writablePathsFor` / `filesystemFlagsFor`) and covered by direct tests.
- Fixed `TestFilesystemFlagsReadOnlyRootUnderTmp`, which matched the host-root `--ro-bind` instead of the workspace bind.

## Backward compatibility

`WriteWorkspace` is the zero value, so every existing call keeps the current behavior (runner root + `writable_paths` writable). New settings key is optional; default deployments are unchanged.

## Testing

- Platform-neutral: `WithDefaults` merge table (incl. unknown defaults), `ValidateExecPolicy` fail-closed, classifier matrix (~65 cases incl. date/hostname/sort/sed/git/rg write variants).
- macOS (seatbelt): profile default/read-only/explicit-paths, option + settings wiring, writable-root conflict rejection, per-call `WriteReadOnly` override.
- Linux (bwrap): flags default/read-only/root-under-/tmp, option wiring, writable-root conflict rejection, per-call `WriteReadOnly` override (run in a Linux container; CI green).
- `make ci`, `make lint`, `make release-check`, `git diff --check` all pass.

Closes #447
