### PR TITLE
chore(release): add core v0.1.31 changeset

### DIFF
--- a/.release/core-v0.1.31.json
+++ b/.release/core-v0.1.31.json
@@ -1,0 +1,9 @@
+{
+  "summary": "feat(core): per-exec write policy and read-only sandbox mode — sandbox.WritePolicy (WriteWorkspace / WriteReadOnly) on ExecOptions narrows the filesystem boundary per call, WithReadOnlyRoot() / settings.readonly_root provide the runner-level default, seatbelt omits the runner root from the SBPL writable set and bwrap ro-binds rootDir in read-only mode, sandbox/local rejects WriteReadOnly as unavailable, backends advertise the write modes they enforce, and ClassifySafeReadOnly supplies the codex-rs-style read-only command heuristic for caller-owned auto-approval; review hardening closes classifier gaps (date/hostname dropped from the base set, sort -o, rg --search-zip/--hostname-bin, git diff/log/show write variants, and sed address-form writes rejected), pins unknown default write policies so they reach backend validation instead of being silently swallowed, rejects writable_paths resolving to the runner root when readonly_root is set, and unifies polarity naming with extracted per-call write merging covered by direct tests",
+  "releases": [
+    {
+      "module": "core",
+      "bump": "patch"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Adds the immutable release intent for `core` v0.1.31 (patch bump from v0.1.30), covering the accumulated delta since the previous tag:

- #448 per-exec write policy and read-only sandbox mode (closes #447): `sandbox.WritePolicy` on `ExecOptions`, `WithReadOnlyRoot()` / `settings.readonly_root` runner default, seatbelt/bwrap read-only enforcement, backend write-mode advertisement, and `ClassifySafeReadOnly` for caller-owned read-only auto-approval
- Review hardening (`b931f25f`): read-only classifier gap fixes (date/hostname, `sort -o`, `rg --search-zip`/`--hostname-bin`, git write variants, sed address-form writes), unknown default write-policy pinning, `writable_paths` vs `readonly_root` conflict rejection, and per-call write merging refactor with direct tests

## Verification

- `make release-check` → changesets valid, `core: 0.1.30 -> 0.1.31 (patch), tag core/v0.1.31`
- `make release-plan` → single module `core`, tag `core/v0.1.31`