### PR TITLE
fix(core): undefined-tool recovery must not replay a synthetic assistant tool_call

### DIFF
--- a/.release/core-v0.1.32.json
+++ b/.release/core-v0.1.32.json
@@ -1,0 +1,9 @@
+{
+  "summary": "fix(core/graph): undefined-tool recovery appends a user-role text feedback message instead of replaying a synthetic assistant tool_call paired with a tool result — no fabricated conversation turn, no provider reasoning round-trip exposure (DeepSeek thinking mode rejects assistant tool-call turns without reasoning_content), and no undefined function reference left in context; recovery markers and the llm->compact->llm loop are unchanged",
+  "releases": [
+    {
+      "module": "core",
+      "bump": "patch"
+    }
+  ]
+}

--- a/core/graph/nodes/inference.go
+++ b/core/graph/nodes/inference.go
@@ -123,7 +123,8 @@ type UndefinedToolRecoveryConfig struct {
 const defaultUndefinedToolMaxRecoveries = 2
 
 // undefinedToolFeedback is the model-readable rejection appended as a
-// tool result when a response names a tool the model was never shown.
+// user feedback message when a response names a tool the model was
+// never shown.
 const undefinedToolFeedback = "tool %q is not exposed in this round's tool set; " +
 	"call tool_search to find and select it before calling it again"
 
@@ -259,12 +260,17 @@ func runInference(ec graph.ExecutionContext, board *agent.Board, cfg InferenceCo
 
 // recoverUndefinedTool converts an undefined-tool generate failure into
 // in-conversation feedback when the node is configured to recover. The
-// rejected call is replayed as an assistant tool_call paired with a tool
-// result explaining how to expose the tool — the message shape providers
-// require — but the graph must route back to inference, never through a
-// tool node, or the call would be executed for real. The original error
-// is returned when recovery is disabled, the failure is not an
-// undefined-tool rejection, or the per-run budget is exhausted.
+// rejection is appended as a single user-role text message explaining how
+// to expose the tool. The rejected call is deliberately not replayed as a
+// synthetic assistant tool_call: that would fabricate a turn the model
+// never produced, violate provider reasoning round-trip rules (DeepSeek
+// thinking mode requires reasoning_content on assistant tool-call turns),
+// and leave an undefined function reference in history for providers that
+// validate calls against the request tool set. The graph must still route
+// back to inference, never through a tool node, or the call would be
+// executed for real. The original error is returned when recovery is
+// disabled, the failure is not an undefined-tool rejection, or the
+// per-run budget is exhausted.
 func recoverUndefinedTool(ec graph.ExecutionContext, board *agent.Board, channel string, cfg InferenceConfig, err error) error {
 	if cfg.UndefinedToolRecovery == nil || !cfg.UndefinedToolRecovery.Enabled {
 		return err
@@ -285,19 +291,9 @@ func recoverUndefinedTool(ec graph.ExecutionContext, board *agent.Board, channel
 	}
 	call := *infErr.UndefinedToolCall
 	board.AppendChannelMessage(channel, message.Message{
-		Role: message.RoleAssistant,
+		Role: message.RoleUser,
 		Content: message.Content{Parts: []message.Part{
-			message.ToolCallPart{Call: call},
-		}},
-	})
-	board.AppendChannelMessage(channel, message.Message{
-		Role: message.RoleTool,
-		Content: message.Content{Parts: []message.Part{
-			message.ToolResultPart{Result: message.ToolResult{
-				CallID:  call.ID,
-				Content: fmt.Sprintf(undefinedToolFeedback, call.Name),
-				IsError: true,
-			}},
+			message.TextPart{Text: fmt.Sprintf(undefinedToolFeedback, call.Name)},
 		}},
 	})
 	if cfg.ToolPendingKey != "" {

--- a/core/graph/nodes/inference_test.go
+++ b/core/graph/nodes/inference_test.go
@@ -332,17 +332,14 @@ func TestInferenceNode_UndefinedToolRecovery(t *testing.T) {
 	}
 
 	msgs := board.Channel(agent.MainChannel)
-	if len(msgs) != 3 {
-		t.Fatalf("channel length = %d, want 3 (user + assistant call + tool rejection)", len(msgs))
+	if len(msgs) != 2 {
+		t.Fatalf("channel length = %d, want 2 (user + text feedback)", len(msgs))
 	}
-	call, ok := msgs[1].Content.Parts[0].(message.ToolCallPart)
-	if !ok || msgs[1].Role != message.RoleAssistant || call.Call.Name != "ghost" {
-		t.Fatalf("recovered assistant message = %+v", msgs[1])
-	}
-	result, ok := msgs[2].Content.Parts[0].(message.ToolResultPart)
-	if !ok || msgs[2].Role != message.RoleTool || !result.Result.IsError ||
-		result.Result.CallID != "call-1" || !strings.Contains(result.Result.Content, "tool_search") {
-		t.Fatalf("recovered tool message = %+v", msgs[2])
+	feedback, ok := msgs[1].Content.Parts[0].(message.TextPart)
+	if !ok || msgs[1].Role != message.RoleUser ||
+		!strings.Contains(feedback.Text, "ghost") ||
+		!strings.Contains(feedback.Text, "tool_search") {
+		t.Fatalf("recovered feedback message = %+v", msgs[1])
 	}
 	if v, _ := board.GetVar("recover_pending"); v != true {
 		t.Fatalf("recover_pending = %v, want true", v)
@@ -582,27 +579,27 @@ func TestInferenceGraph_UndefinedToolRecoveryLoop(t *testing.T) {
 	if len(requests) != 2 {
 		t.Fatalf("llm rounds = %d, want 2 (recovered round + success round)", len(requests))
 	}
-	// The recovered round's feedback must ride into the next request:
-	// the fabricated assistant call sits in context and the rejection is
-	// the tool-role input.
-	if len(requests[1].Context) != 2 {
-		t.Fatalf("second round context length = %d, want 2", len(requests[1].Context))
+	// The recovered round's feedback must ride into the next request as
+	// the current input: a single user-role text message, with no
+	// fabricated assistant tool_call in context.
+	if len(requests[1].Context) != 1 {
+		t.Fatalf("second round context length = %d, want 1", len(requests[1].Context))
 	}
-	call, ok := requests[1].Context[1].Content.Parts[0].(message.ToolCallPart)
-	if !ok || call.Call.Name != "ghost" {
-		t.Fatalf("second round context call = %+v", requests[1].Context[1].Content.Parts[0])
+	if requests[1].Input.Role != inference.InputRoleUser {
+		t.Fatalf("second round input role = %q, want user", requests[1].Input.Role)
 	}
-	result, ok := requests[1].Input.Content.Parts[0].(message.ToolResultPart)
-	if !ok || !result.Result.IsError || !strings.Contains(result.Result.Content, "tool_search") {
+	feedback, ok := requests[1].Input.Content.Parts[0].(message.TextPart)
+	if !ok || !strings.Contains(feedback.Text, "ghost") ||
+		!strings.Contains(feedback.Text, "tool_search") {
 		t.Fatalf("second round input = %+v", requests[1].Input.Content.Parts[0])
 	}
 
 	msgs := board.Channel(agent.MainChannel)
-	if len(msgs) != 4 {
-		t.Fatalf("channel length = %d, want 4 (user, recovered pair, final answer)", len(msgs))
+	if len(msgs) != 3 {
+		t.Fatalf("channel length = %d, want 3 (user, feedback, final answer)", len(msgs))
 	}
-	if text, ok := msgs[3].Content.Parts[0].(message.TextPart); !ok || text.Text != "ok" {
-		t.Fatalf("final assistant message = %+v, want text %q", msgs[3], "ok")
+	if text, ok := msgs[2].Content.Parts[0].(message.TextPart); !ok || text.Text != "ok" {
+		t.Fatalf("final assistant message = %+v, want text %q", msgs[2], "ok")
 	}
 	if v, _ := board.GetVar("recover_pending"); v != false {
 		t.Fatalf("recover_pending = %v, want false after success round", v)
@@ -657,8 +654,8 @@ func TestInferenceGraph_UndefinedToolRecoveryWithoutLoopRouteEnds(t *testing.T) 
 	if requests := fake.Requests(); len(requests) != 1 {
 		t.Fatalf("llm rounds = %d, want 1 (run ends after the recovered round)", len(requests))
 	}
-	if msgs := board.Channel(agent.MainChannel); len(msgs) != 3 {
-		t.Fatalf("channel length = %d, want 3 (feedback appended, no final answer)", len(msgs))
+	if msgs := board.Channel(agent.MainChannel); len(msgs) != 2 {
+		t.Fatalf("channel length = %d, want 2 (feedback appended, no final answer)", len(msgs))
 	}
 }
 


### PR DESCRIPTION
Fixes #451

`recoverUndefinedTool` previously appended a synthetic assistant `ToolCallPart` + `ToolResultPart` pair to the channel when a model called a tool outside the current round's tool set. That fabricated turn:

- carries no reasoning part, violating provider reasoning round-trip rules (DeepSeek thinking mode rejects assistant tool-call turns without `reasoning_content`);
- leaves an undefined function reference in history, fragile for providers that validate calls against the request tool set.

This change replaces the two appended messages with a single user-role text feedback message (the existing `undefinedToolFeedback` text). `tool_pending` / `recover_pending` / `recover_count` behavior and the `llm -> compact -> llm` recovery loop are unchanged.

## Changes

- `core/graph/nodes/inference.go`: append one user text message instead of the synthetic assistant + tool pair; update doc comments.
- `core/graph/nodes/inference_test.go`: update the three recovery tests to assert the new feedback shape (channel `user + feedback`, feedback rides as the next round's input).

## Verification

- `make ci` — passed
- `make lint` — passed
- `make release-check` — changesets valid
- `make release-plan` — core `0.1.31 -> 0.1.32 (patch)`, tag `core/v0.1.32`

Release changeset: `.release/core-v0.1.32.json`