### PR TITLE
feat(driver/bytedance): align Seedance video generation with official Ark API

### DIFF
--- a/driver/bytedance/catalog.go
+++ b/driver/bytedance/catalog.go
@@ -61,6 +61,10 @@ type videoParams struct {
 	cameraFixed   bool // supports camera_fixed
 	flexTier      bool // supports service_tier=flex
 	generateAudio bool // supports generate_audio
+	priority      bool // supports priority
+	outputFormat  bool // supports output_format
+	omniReference bool // supports omni_reference_task_type
+	webSearch     bool // supports tools[web_search]
 	durationMin   *int64
 	durationMax   *int64
 	durationAuto  bool // supports duration=-1 (model picks the length)
@@ -281,6 +285,10 @@ var catalog = map[string]catalogEntry{
 		maxResolution: "1080p",
 		video: videoParams{
 			generateAudio:  true,
+			priority:       true,
+			outputFormat:   true,
+			omniReference:  true,
+			webSearch:      true,
 			durationMin:    videoSeconds(4),
 			durationMax:    videoSeconds(30),
 			durationAuto:   true,
@@ -302,6 +310,8 @@ var catalog = map[string]catalogEntry{
 		maxResolution: "4k",
 		video: videoParams{
 			generateAudio:  true,
+			priority:       true,
+			webSearch:      true,
 			durationMin:    videoSeconds(4),
 			durationMax:    videoSeconds(15),
 			durationAuto:   true,
@@ -323,6 +333,8 @@ var catalog = map[string]catalogEntry{
 		maxResolution: "720p",
 		video: videoParams{
 			generateAudio:  true,
+			priority:       true,
+			webSearch:      true,
 			durationMin:    videoSeconds(4),
 			durationMax:    videoSeconds(15),
 			durationAuto:   true,
@@ -344,6 +356,8 @@ var catalog = map[string]catalogEntry{
 		maxResolution: "720p",
 		video: videoParams{
 			generateAudio:  true,
+			priority:       true,
+			webSearch:      true,
 			durationMin:    videoSeconds(4),
 			durationMax:    videoSeconds(15),
 			durationAuto:   true,

--- a/driver/bytedance/catalog.go
+++ b/driver/bytedance/catalog.go
@@ -33,6 +33,8 @@ type catalogEntry struct {
 	// video: highest supported resolution tier ("720p", "1080p", "4k");
 	// empty leaves resolution unconstrained.
 	maxResolution string
+	// video: Seedance task-parameter support matrix (see videoParams).
+	video videoParams
 	// lifecycle: deprecated models stay routable but announce a replacement.
 	deprecated  bool
 	replacement string
@@ -45,6 +47,32 @@ type catalogEntry struct {
 	// bound. Embedding values mirror the documented per-input limit.
 	maxInputTokens int
 }
+
+// videoParams is the Seedance task-parameter support matrix for one video
+// model, transcribed from the official create-task API documentation
+// (https://www.volcengine.com/docs/82379/1520757): each field mirrors one
+// parameter's documented "model support" column, so the compiler can reject
+// parameters the strong-validation endpoint would otherwise fault on.
+// Zero values mean "undeclared": Spec.Models entries keep a zero matrix and
+// compile with syntax-only validation (the deployment declares the
+// capability); built-in entries declare the full matrix.
+type videoParams struct {
+	seed          bool // supports seed
+	cameraFixed   bool // supports camera_fixed
+	flexTier      bool // supports service_tier=flex
+	generateAudio bool // supports generate_audio
+	durationMin   *int64
+	durationMax   *int64
+	durationAuto  bool // supports duration=-1 (model picks the length)
+	// Reference-input caps; 0 means the model takes no reference inputs
+	// (image counts above the first/last-frame pair are rejected).
+	referenceImage int
+	referenceVideo int
+	referenceAudio int
+}
+
+// videoSeconds builds a *int64 for videoParams duration bounds.
+func videoSeconds(value int64) *int64 { return &value }
 
 // validate enforces the family contract: the compiler bound by kind can only
 // serve the output modalities it produces, so kind and capabilities cannot
@@ -237,6 +265,15 @@ var catalog = map[string]catalogEntry{
 			WithInputs(message.PartText, message.PartImage).
 			WithOutputs(message.PartVideo),
 		maxResolution: "1080p",
+		video: videoParams{
+			generateAudio:  true,
+			durationMin:    videoSeconds(4),
+			durationMax:    videoSeconds(30),
+			durationAuto:   true,
+			referenceImage: 30,
+			referenceVideo: 10,
+			referenceAudio: 10,
+		},
 	},
 	"doubao-seedance-2-0": {
 		kind: kindVideo,
@@ -244,6 +281,15 @@ var catalog = map[string]catalogEntry{
 			WithInputs(message.PartText, message.PartImage).
 			WithOutputs(message.PartVideo),
 		maxResolution: "4k",
+		video: videoParams{
+			generateAudio:  true,
+			durationMin:    videoSeconds(4),
+			durationMax:    videoSeconds(15),
+			durationAuto:   true,
+			referenceImage: 9,
+			referenceVideo: 3,
+			referenceAudio: 3,
+		},
 	},
 	"doubao-seedance-2-0-fast": {
 		kind: kindVideo,
@@ -251,6 +297,15 @@ var catalog = map[string]catalogEntry{
 			WithInputs(message.PartText, message.PartImage).
 			WithOutputs(message.PartVideo),
 		maxResolution: "720p",
+		video: videoParams{
+			generateAudio:  true,
+			durationMin:    videoSeconds(4),
+			durationMax:    videoSeconds(15),
+			durationAuto:   true,
+			referenceImage: 9,
+			referenceVideo: 3,
+			referenceAudio: 3,
+		},
 	},
 	"doubao-seedance-2-0-mini": {
 		kind: kindVideo,
@@ -258,6 +313,15 @@ var catalog = map[string]catalogEntry{
 			WithInputs(message.PartText, message.PartImage).
 			WithOutputs(message.PartVideo),
 		maxResolution: "720p",
+		video: videoParams{
+			generateAudio:  true,
+			durationMin:    videoSeconds(4),
+			durationMax:    videoSeconds(15),
+			durationAuto:   true,
+			referenceImage: 9,
+			referenceVideo: 3,
+			referenceAudio: 3,
+		},
 	},
 	"doubao-seedance-1-5-pro": {
 		kind: kindVideo,
@@ -265,7 +329,16 @@ var catalog = map[string]catalogEntry{
 			WithInputs(message.PartText, message.PartImage).
 			WithOutputs(message.PartVideo),
 		maxResolution: "1080p",
-		deprecated:    true, replacement: "doubao-seedance-2-0",
+		video: videoParams{
+			seed:          true,
+			cameraFixed:   true,
+			flexTier:      true,
+			generateAudio: true,
+			durationMin:   videoSeconds(4),
+			durationMax:   videoSeconds(12),
+			durationAuto:  true,
+		},
+		deprecated: true, replacement: "doubao-seedance-2-0",
 	},
 	"doubao-seedance-1-0-pro": {
 		kind: kindVideo,
@@ -273,7 +346,14 @@ var catalog = map[string]catalogEntry{
 			WithInputs(message.PartText, message.PartImage).
 			WithOutputs(message.PartVideo),
 		maxResolution: "1080p",
-		deprecated:    true, replacement: "doubao-seedance-2-0",
+		video: videoParams{
+			seed:        true,
+			cameraFixed: true,
+			flexTier:    true,
+			durationMin: videoSeconds(2),
+			durationMax: videoSeconds(12),
+		},
+		deprecated: true, replacement: "doubao-seedance-2-0",
 	},
 	"doubao-seedance-1-0-lite-t2v": {
 		kind: kindVideo,
@@ -281,7 +361,16 @@ var catalog = map[string]catalogEntry{
 			WithInputs(message.PartText, message.PartImage).
 			WithOutputs(message.PartVideo),
 		maxResolution: "720p",
-		deprecated:    true, replacement: "doubao-seedance-2-0-fast",
+		// Official docs list only the 1.0 pro/pro fast tiers; the lite
+		// entries approximate the 1.0 family support set.
+		video: videoParams{
+			seed:        true,
+			cameraFixed: true,
+			flexTier:    true,
+			durationMin: videoSeconds(2),
+			durationMax: videoSeconds(12),
+		},
+		deprecated: true, replacement: "doubao-seedance-2-0-fast",
 	},
 	"doubao-seedance-1-0-lite-i2v": {
 		kind: kindVideo,
@@ -289,7 +378,14 @@ var catalog = map[string]catalogEntry{
 			WithInputs(message.PartText, message.PartImage).
 			WithOutputs(message.PartVideo),
 		maxResolution: "720p",
-		deprecated:    true, replacement: "doubao-seedance-2-0-fast",
+		video: videoParams{
+			seed:        true,
+			cameraFixed: true,
+			flexTier:    true,
+			durationMin: videoSeconds(2),
+			durationMax: videoSeconds(12),
+		},
+		deprecated: true, replacement: "doubao-seedance-2-0-fast",
 	},
 }
 

--- a/driver/bytedance/catalog.go
+++ b/driver/bytedance/catalog.go
@@ -64,10 +64,15 @@ type videoParams struct {
 	priority      bool // supports priority
 	outputFormat  bool // supports output_format
 	omniReference bool // supports omni_reference_task_type
-	webSearch     bool // supports tools[web_search]
 	durationMin   *int64
 	durationMax   *int64
 	durationAuto  bool // supports duration=-1 (model picks the length)
+	// audioOnly allows audio-only input (2.5); other reference-capable
+	// models require at least one image or video alongside audio.
+	audioOnly bool
+	// frameRatioAdaptiveOnly restricts first/last-frame tasks to
+	// ratio=adaptive (2.5); explicit ratios are rejected for them.
+	frameRatioAdaptiveOnly bool
 	// Reference-input caps; 0 means the model takes no reference inputs
 	// (image counts above the first/last-frame pair are rejected).
 	referenceImage int
@@ -281,20 +286,22 @@ var catalog = map[string]catalogEntry{
 				message.PartVideo,
 				message.PartAudio,
 			).
-			WithOutputs(message.PartVideo),
+			WithOutputs(message.PartVideo).
+			WithHostedWebSearch(),
 		maxResolution: "1080p",
 		video: videoParams{
-			generateAudio:  true,
-			priority:       true,
-			outputFormat:   true,
-			omniReference:  true,
-			webSearch:      true,
-			durationMin:    videoSeconds(4),
-			durationMax:    videoSeconds(30),
-			durationAuto:   true,
-			referenceImage: 30,
-			referenceVideo: 10,
-			referenceAudio: 10,
+			generateAudio:          true,
+			priority:               true,
+			outputFormat:           true,
+			omniReference:          true,
+			durationMin:            videoSeconds(4),
+			durationMax:            videoSeconds(30),
+			durationAuto:           true,
+			audioOnly:              true,
+			frameRatioAdaptiveOnly: true,
+			referenceImage:         30,
+			referenceVideo:         10,
+			referenceAudio:         10,
 		},
 	},
 	"doubao-seedance-2-0": {
@@ -306,12 +313,12 @@ var catalog = map[string]catalogEntry{
 				message.PartVideo,
 				message.PartAudio,
 			).
-			WithOutputs(message.PartVideo),
+			WithOutputs(message.PartVideo).
+			WithHostedWebSearch(),
 		maxResolution: "4k",
 		video: videoParams{
 			generateAudio:  true,
 			priority:       true,
-			webSearch:      true,
 			durationMin:    videoSeconds(4),
 			durationMax:    videoSeconds(15),
 			durationAuto:   true,
@@ -329,12 +336,12 @@ var catalog = map[string]catalogEntry{
 				message.PartVideo,
 				message.PartAudio,
 			).
-			WithOutputs(message.PartVideo),
+			WithOutputs(message.PartVideo).
+			WithHostedWebSearch(),
 		maxResolution: "720p",
 		video: videoParams{
 			generateAudio:  true,
 			priority:       true,
-			webSearch:      true,
 			durationMin:    videoSeconds(4),
 			durationMax:    videoSeconds(15),
 			durationAuto:   true,
@@ -352,12 +359,12 @@ var catalog = map[string]catalogEntry{
 				message.PartVideo,
 				message.PartAudio,
 			).
-			WithOutputs(message.PartVideo),
+			WithOutputs(message.PartVideo).
+			WithHostedWebSearch(),
 		maxResolution: "720p",
 		video: videoParams{
 			generateAudio:  true,
 			priority:       true,
-			webSearch:      true,
 			durationMin:    videoSeconds(4),
 			durationMax:    videoSeconds(15),
 			durationAuto:   true,

--- a/driver/bytedance/catalog.go
+++ b/driver/bytedance/catalog.go
@@ -94,6 +94,15 @@ func (e catalogEntry) validate() error {
 		if !slices.Contains(e.capabilities.Outputs, message.PartVideo) {
 			return fmt.Errorf("video family must declare video output")
 		}
+		if e.video.referenceImage > 0 && !slices.Contains(e.capabilities.Inputs, message.PartImage) {
+			return fmt.Errorf("video family declaring reference images must accept image input")
+		}
+		if e.video.referenceVideo > 0 && !slices.Contains(e.capabilities.Inputs, message.PartVideo) {
+			return fmt.Errorf("video family declaring reference videos must accept video input")
+		}
+		if e.video.referenceAudio > 0 && !slices.Contains(e.capabilities.Inputs, message.PartAudio) {
+			return fmt.Errorf("video family declaring reference audio must accept audio input")
+		}
 	case kindEmbed:
 		if len(e.capabilities.Outputs) != 0 {
 			return fmt.Errorf("%s family declares no generate output", e.kind)
@@ -262,7 +271,12 @@ var catalog = map[string]catalogEntry{
 	"doubao-seedance-2-5": {
 		kind: kindVideo,
 		capabilities: inference.ModelCapabilities{}.
-			WithInputs(message.PartText, message.PartImage).
+			WithInputs(
+				message.PartText,
+				message.PartImage,
+				message.PartVideo,
+				message.PartAudio,
+			).
 			WithOutputs(message.PartVideo),
 		maxResolution: "1080p",
 		video: videoParams{
@@ -278,7 +292,12 @@ var catalog = map[string]catalogEntry{
 	"doubao-seedance-2-0": {
 		kind: kindVideo,
 		capabilities: inference.ModelCapabilities{}.
-			WithInputs(message.PartText, message.PartImage).
+			WithInputs(
+				message.PartText,
+				message.PartImage,
+				message.PartVideo,
+				message.PartAudio,
+			).
 			WithOutputs(message.PartVideo),
 		maxResolution: "4k",
 		video: videoParams{
@@ -294,7 +313,12 @@ var catalog = map[string]catalogEntry{
 	"doubao-seedance-2-0-fast": {
 		kind: kindVideo,
 		capabilities: inference.ModelCapabilities{}.
-			WithInputs(message.PartText, message.PartImage).
+			WithInputs(
+				message.PartText,
+				message.PartImage,
+				message.PartVideo,
+				message.PartAudio,
+			).
 			WithOutputs(message.PartVideo),
 		maxResolution: "720p",
 		video: videoParams{
@@ -310,7 +334,12 @@ var catalog = map[string]catalogEntry{
 	"doubao-seedance-2-0-mini": {
 		kind: kindVideo,
 		capabilities: inference.ModelCapabilities{}.
-			WithInputs(message.PartText, message.PartImage).
+			WithInputs(
+				message.PartText,
+				message.PartImage,
+				message.PartVideo,
+				message.PartAudio,
+			).
 			WithOutputs(message.PartVideo),
 		maxResolution: "720p",
 		video: videoParams{

--- a/driver/bytedance/catalog_test.go
+++ b/driver/bytedance/catalog_test.go
@@ -93,12 +93,20 @@ func TestCatalogPublishesCapabilities(t *testing.T) {
 			video.Capabilities.Inputs,
 		)
 	}
+	if !video.Capabilities.HostedWebSearch {
+		t.Fatal("seedance 2.0 must declare hosted web search")
+	}
+	flagship := descriptors["doubao-seedance-2-5"]
+	if !flagship.Capabilities.HostedWebSearch {
+		t.Fatal("seedance 2.5 must declare hosted web search")
+	}
 	legacy := descriptors["doubao-seedance-1-5-pro"]
 	if slices.Contains(legacy.Capabilities.Inputs, message.PartVideo) ||
-		slices.Contains(legacy.Capabilities.Inputs, message.PartAudio) {
+		slices.Contains(legacy.Capabilities.Inputs, message.PartAudio) ||
+		legacy.Capabilities.HostedWebSearch {
 		t.Fatalf(
-			"seedance 1.5 pro inputs = %v, want no reference inputs",
-			legacy.Capabilities.Inputs,
+			"seedance 1.5 pro capabilities = %+v, want no reference/web-search capabilities",
+			legacy.Capabilities,
 		)
 	}
 

--- a/driver/bytedance/catalog_test.go
+++ b/driver/bytedance/catalog_test.go
@@ -86,6 +86,21 @@ func TestCatalogPublishesCapabilities(t *testing.T) {
 	if !reflect.DeepEqual(video.Capabilities.Outputs, []message.PartKind{message.PartVideo}) {
 		t.Fatalf("video outputs = %v, want video", video.Capabilities.Outputs)
 	}
+	if !slices.Contains(video.Capabilities.Inputs, message.PartVideo) ||
+		!slices.Contains(video.Capabilities.Inputs, message.PartAudio) {
+		t.Fatalf(
+			"seedance 2.0 inputs = %v, want video/audio reference input",
+			video.Capabilities.Inputs,
+		)
+	}
+	legacy := descriptors["doubao-seedance-1-5-pro"]
+	if slices.Contains(legacy.Capabilities.Inputs, message.PartVideo) ||
+		slices.Contains(legacy.Capabilities.Inputs, message.PartAudio) {
+		t.Fatalf(
+			"seedance 1.5 pro inputs = %v, want no reference inputs",
+			legacy.Capabilities.Inputs,
+		)
+	}
 
 	embed := descriptors["doubao-embedding-vision"]
 	if !slices.Contains(embed.Capabilities.Inputs, message.PartImage) {

--- a/driver/bytedance/doc.go
+++ b/driver/bytedance/doc.go
@@ -17,8 +17,10 @@
 //   - Generate VideoIntent: Ark content-generation tasks (seedance models).
 //     The API is asynchronous — the transport creates a task and polls it to
 //     a terminal state inside the caller's context, so the unary contract
-//     holds. Input images map to first/last-frame roles; parameters the
-//     model does not support (seed, camera_fixed, flex tier, duration
+//     holds. Input images map to first/last-frame roles; the 2.0 series and
+//     2.5 additionally accept reference images (3+), reference videos, and
+//     reference audio under the official mutual-exclusion rules. Parameters
+//     the model does not support (seed, camera_fixed, flex tier, duration
 //     bounds) are rejected at compile time per the official per-model
 //     support matrix.
 //   - Embed: Ark embeddings (doubao-embedding text; multimodal embedding for

--- a/driver/bytedance/doc.go
+++ b/driver/bytedance/doc.go
@@ -32,7 +32,8 @@
 // web search), ImageOptions (guidance scale, watermark, prompt
 // optimization, grouped generation, named size tiers, web search),
 // VideoOptions (fixed camera, generated audio track, service tier, task
-// TTL). Every extension field is
+// TTL, queue priority, output format, omni-reference task type, hosted web
+// search, callback URL, safety identifier). Every extension field is
 // consumed explicitly by the matching compiler; an extension attached to the
 // wrong operation, or one colliding with a canonical channel, is rejected
 // with InvalidExtension.

--- a/driver/bytedance/doc.go
+++ b/driver/bytedance/doc.go
@@ -17,8 +17,10 @@
 //   - Generate VideoIntent: Ark content-generation tasks (seedance models).
 //     The API is asynchronous — the transport creates a task and polls it to
 //     a terminal state inside the caller's context, so the unary contract
-//     holds. Input images map to first/last-frame roles; video-reference
-//     input awaits SDK support and is rejected truthfully.
+//     holds. Input images map to first/last-frame roles; parameters the
+//     model does not support (seed, camera_fixed, flex tier, duration
+//     bounds) are rejected at compile time per the official per-model
+//     support matrix.
 //   - Embed: Ark embeddings (doubao-embedding text; multimodal embedding for
 //     vision-capable variants).
 //

--- a/driver/bytedance/extensions.go
+++ b/driver/bytedance/extensions.go
@@ -379,9 +379,11 @@ func (o VideoOptions) Validate() error {
 	default:
 		return fmt.Errorf("service_tier must be default or flex, not %q", o.ServiceTier)
 	}
-	if o.ExecutionExpiresAfter != nil && *o.ExecutionExpiresAfter <= 0 {
+	// Official range: [3600, 259200] seconds (default 172800).
+	if o.ExecutionExpiresAfter != nil &&
+		(*o.ExecutionExpiresAfter < 3600 || *o.ExecutionExpiresAfter > 259200) {
 		return fmt.Errorf(
-			"execution_expires_after must be positive, not %d",
+			"execution_expires_after must be within [3600, 259200], not %d",
 			*o.ExecutionExpiresAfter,
 		)
 	}

--- a/driver/bytedance/extensions.go
+++ b/driver/bytedance/extensions.go
@@ -351,6 +351,26 @@ type VideoOptions struct {
 	ServiceTier string `json:"service_tier,omitempty"`
 	// ExecutionExpiresAfter bounds the server-side task lifetime in seconds.
 	ExecutionExpiresAfter *int64 `json:"execution_expires_after,omitempty"`
+	// Priority raises the task's queue position; range [0, 9].
+	// Seedance 2.5 / 2.0 series only.
+	Priority *int32 `json:"priority,omitempty"`
+	// OutputFormat selects the container: "mp4" (default) or "mov".
+	// Seedance 2.5 only.
+	OutputFormat *string `json:"output_format,omitempty"`
+	// OmniReferenceTaskType hints the omni-reference subtask:
+	// "auto" (default), "reference", "edit", or "extend". Seedance 2.5
+	// only; edit/extend impose reference-video, ratio, and duration
+	// constraints checked at compile time.
+	OmniReferenceTaskType *string `json:"omni_reference_task_type,omitempty"`
+	// WebSearch attaches Ark's hosted web_search tool. Seedance 2.5 /
+	// 2.0 series only. Search counts are not surfaced: the pinned SDK
+	// response Usage has no tool_usage field.
+	WebSearch *bool `json:"web_search,omitempty"`
+	// CallbackURL receives task status webhook pushes; polling stays the
+	// fallback.
+	CallbackURL *string `json:"callback_url,omitempty"`
+	// SafetyIdentifier is the end-user identifier for abuse detection.
+	SafetyIdentifier *string `json:"safety_identifier,omitempty"`
 }
 
 func (o VideoOptions) ProviderID() string  { return extensionProvider(o.Provider) }
@@ -370,6 +390,24 @@ func (o VideoOptions) ActiveFields() []inference.ExtensionField {
 	if o.ExecutionExpiresAfter != nil {
 		fields = append(fields, "execution_expires_after")
 	}
+	if o.Priority != nil {
+		fields = append(fields, "priority")
+	}
+	if o.OutputFormat != nil {
+		fields = append(fields, "output_format")
+	}
+	if o.OmniReferenceTaskType != nil {
+		fields = append(fields, "omni_reference_task_type")
+	}
+	if o.WebSearch != nil {
+		fields = append(fields, "web_search")
+	}
+	if o.CallbackURL != nil {
+		fields = append(fields, "callback_url")
+	}
+	if o.SafetyIdentifier != nil {
+		fields = append(fields, "safety_identifier")
+	}
 	return fields
 }
 
@@ -387,6 +425,22 @@ func (o VideoOptions) Validate() error {
 			*o.ExecutionExpiresAfter,
 		)
 	}
+	if o.Priority != nil && (*o.Priority < 0 || *o.Priority > 9) {
+		return fmt.Errorf("priority must be within [0, 9], not %d", *o.Priority)
+	}
+	if o.OutputFormat != nil && *o.OutputFormat != "mp4" && *o.OutputFormat != "mov" {
+		return fmt.Errorf("output_format must be mp4 or mov, not %q", *o.OutputFormat)
+	}
+	if o.OmniReferenceTaskType != nil {
+		switch *o.OmniReferenceTaskType {
+		case "auto", "reference", "edit", "extend":
+		default:
+			return fmt.Errorf(
+				"omni_reference_task_type must be auto, reference, edit, or extend, not %q",
+				*o.OmniReferenceTaskType,
+			)
+		}
+	}
 	return nil
 }
 
@@ -394,6 +448,12 @@ func (o VideoOptions) Clone() inference.Extension {
 	o.CameraFixed = clonePointer(o.CameraFixed)
 	o.GenerateAudio = clonePointer(o.GenerateAudio)
 	o.ExecutionExpiresAfter = clonePointer(o.ExecutionExpiresAfter)
+	o.Priority = clonePointer(o.Priority)
+	o.OutputFormat = clonePointer(o.OutputFormat)
+	o.OmniReferenceTaskType = clonePointer(o.OmniReferenceTaskType)
+	o.WebSearch = clonePointer(o.WebSearch)
+	o.CallbackURL = clonePointer(o.CallbackURL)
+	o.SafetyIdentifier = clonePointer(o.SafetyIdentifier)
 	return o
 }
 

--- a/driver/bytedance/video.go
+++ b/driver/bytedance/video.go
@@ -27,8 +27,9 @@ import (
 // Input images map onto the frame roles the task API understands: the first
 // image is the first frame, the second is the last frame. More references
 // have no truthful canonical ordering, so the compiler rejects them instead
-// of guessing. Video-reference input (video_url content items) is not
-// exposed: the pinned SDK version cannot encode it.
+// of guessing. Video/audio-reference input (video_url/audio_url content
+// items) is likewise not yet exposed, but that is a scope decision, not an
+// SDK limitation: v1.2.48 encodes both content item types.
 
 type videoWire struct {
 	model      string
@@ -53,8 +54,16 @@ type videoRaw struct {
 }
 
 // defaultVideoPollInterval paces task polls when the deployment Spec does
-// not override it (Spec.video_poll_interval_millis).
-const defaultVideoPollInterval = 5 * time.Second
+// not override it (Spec.video_poll_interval_millis). The official docs
+// recommend polling no more often than every 10 seconds.
+const defaultVideoPollInterval = 10 * time.Second
+
+// statusExpired is the terminal state the task API reports when a task stays
+// queued/running past execution_expires_after (official docs: 任务超时...
+// 自动终止，并标记为 expired 状态). The pinned SDK defines no constant for
+// it — content_generation.go lists only succeeded/cancelled/failed/running/
+// queued — so the transport handles it locally.
+const statusExpired = "expired"
 
 func compileVideo(
 	endpoint string,
@@ -138,6 +147,18 @@ func compileVideo(
 					)
 				} else {
 					seconds := millis / 1000
+					if min := entry.video.durationMin; min != nil && seconds < *min {
+						ledger.reject(
+							inference.FieldGenerateIntentVideoDuration,
+							fmt.Sprintf("model %s requires a duration of at least %ds", model.ID.Name, *min),
+						)
+					}
+					if max := entry.video.durationMax; max != nil && seconds > *max {
+						ledger.reject(
+							inference.FieldGenerateIntentVideoDuration,
+							fmt.Sprintf("model %s caps duration at %ds", model.ID.Name, *max),
+						)
+					}
 					wire.duration = &seconds
 				}
 			}
@@ -152,13 +173,30 @@ func compileVideo(
 			}
 			if video.AspectRatio != "" {
 				wire.ratio = string(video.AspectRatio)
+				if !validVideoRatio(wire.ratio) {
+					ledger.reject(
+						inference.FieldGenerateIntentVideoAspectRatio,
+						fmt.Sprintf("unsupported video ratio %q", wire.ratio),
+					)
+				}
 			}
 			wire.seed = video.Seed
+			if wire.seed != nil && !entry.video.seed {
+				ledger.reject(
+					inference.FieldGenerateIntentVideoSeed,
+					fmt.Sprintf("model %s does not support seed", model.ID.Name),
+				)
+			} else if wire.seed != nil && (*wire.seed < -1 || *wire.seed > 2_147_483_647) {
+				ledger.reject(
+					inference.FieldGenerateIntentVideoSeed,
+					"seed must be within [-1, 2147483647]",
+				)
+			}
 			wire.watermark = video.Watermark
 		}
 		options, other := operationExtensions[VideoOptions](request.Extensions)
 		rejectOtherExtensions("video generation", other, ledger)
-		compileVideoOptions(&wire, options)
+		compileVideoOptions(&wire, options, entry, ledger, model.ID.Name)
 
 		if text := intent.Text; text != nil {
 			// Specific control rejections precede the wholesale text
@@ -193,14 +231,51 @@ func compileVideo(
 	}
 }
 
-// compileVideoOptions lowers VideoOptions onto the wire. None of the
-// extension fields overlap a canonical channel, so every value applies
-// directly.
-func compileVideoOptions(wire *videoWire, options VideoOptions) {
+// compileVideoOptions lowers VideoOptions onto the wire and rejects
+// extension settings the model does not support, per the official
+// documentation's per-model support matrix (catalogEntry.video).
+func compileVideoOptions(
+	wire *videoWire,
+	options VideoOptions,
+	entry catalogEntry,
+	ledger *ledger,
+	modelName string,
+) {
+	field := func(name string) inference.FieldID {
+		return inference.ExtensionField(name).Qualify(options)
+	}
+	if options.CameraFixed != nil && !entry.video.cameraFixed {
+		ledger.reject(
+			field("camera_fixed"),
+			fmt.Sprintf("model %s does not support camera_fixed", modelName),
+		)
+	}
+	if options.GenerateAudio != nil && !entry.video.generateAudio {
+		ledger.reject(
+			field("generate_audio"),
+			fmt.Sprintf("model %s does not support generate_audio", modelName),
+		)
+	}
+	if options.ServiceTier == "flex" && !entry.video.flexTier {
+		ledger.reject(
+			field("service_tier"),
+			fmt.Sprintf("model %s does not support service_tier=flex", modelName),
+		)
+	}
 	wire.cameraFixed = options.CameraFixed
 	wire.generateAudio = options.GenerateAudio
 	wire.serviceTier = options.ServiceTier
 	wire.executionExpiresAfter = options.ExecutionExpiresAfter
+}
+
+// validVideoRatio reports whether ratio is one of the official create-task
+// API values (16:9 / 4:3 / 1:1 / 3:4 / 9:16 / 21:9 / adaptive).
+func validVideoRatio(ratio string) bool {
+	switch ratio {
+	case "16:9", "4:3", "1:1", "3:4", "9:16", "21:9", "adaptive":
+		return true
+	}
+	return false
 }
 
 // resolutionWithin reports whether resolution fits inside the model's
@@ -302,6 +377,11 @@ func transportVideo(
 			case arkmodel.StatusCancelled:
 				return videoRaw{}, errdefs.NotAvailable(fmt.Errorf(
 					"bytedance: video task %q was cancelled server-side",
+					task.ID,
+				))
+			case statusExpired:
+				return videoRaw{}, errdefs.Timeout(fmt.Errorf(
+					"bytedance: video task %q expired server-side",
 					task.ID,
 				))
 			}

--- a/driver/bytedance/video.go
+++ b/driver/bytedance/video.go
@@ -210,6 +210,16 @@ func compileVideo(
 		default:
 			wire.referenceAudios = audios
 		}
+		if len(audios) > 0 && len(images) == 0 && len(videos) == 0 &&
+			!entry.video.audioOnly {
+			ledger.reject(
+				inference.FieldGenerateInputAudio,
+				fmt.Sprintf(
+					"model %s does not allow audio-only input; include at least one reference image or video",
+					model.ID.Name,
+				),
+			)
+		}
 
 		intent := request.Input.Content.Intent
 		if video := intent.Video; video != nil {
@@ -252,6 +262,16 @@ func compileVideo(
 					ledger.reject(
 						inference.FieldGenerateIntentVideoAspectRatio,
 						fmt.Sprintf("unsupported video ratio %q", wire.ratio),
+					)
+				} else if entry.video.frameRatioAdaptiveOnly &&
+					(wire.firstFrame != "" || wire.lastFrame != "") &&
+					wire.ratio != "adaptive" {
+					ledger.reject(
+						inference.FieldGenerateIntentVideoAspectRatio,
+						fmt.Sprintf(
+							"model %s supports only ratio=adaptive for first/last-frame tasks",
+							model.ID.Name,
+						),
 					)
 				}
 			}
@@ -355,7 +375,8 @@ func compileVideoOptions(
 			fmt.Sprintf("model %s does not support omni_reference_task_type", modelName),
 		)
 	}
-	if options.WebSearch != nil && *options.WebSearch && !entry.video.webSearch {
+	if options.WebSearch != nil && *options.WebSearch &&
+		!entry.capabilities.HostedWebSearch {
 		ledger.reject(
 			field("web_search"),
 			fmt.Sprintf("model %s does not support web_search", modelName),

--- a/driver/bytedance/video.go
+++ b/driver/bytedance/video.go
@@ -50,6 +50,12 @@ type videoWire struct {
 	generateAudio         *bool
 	serviceTier           string
 	executionExpiresAfter *int64
+	priority              *int32
+	outputFormat          string
+	omniReferenceTaskType string
+	webSearch             bool
+	callbackURL           string
+	safetyIdentifier      string
 }
 
 type videoRaw struct {
@@ -331,10 +337,65 @@ func compileVideoOptions(
 			fmt.Sprintf("model %s does not support service_tier=flex", modelName),
 		)
 	}
+	if options.Priority != nil && !entry.video.priority {
+		ledger.reject(
+			field("priority"),
+			fmt.Sprintf("model %s does not support priority", modelName),
+		)
+	}
+	if options.OutputFormat != nil && !entry.video.outputFormat {
+		ledger.reject(
+			field("output_format"),
+			fmt.Sprintf("model %s does not support output_format", modelName),
+		)
+	}
+	if options.OmniReferenceTaskType != nil && !entry.video.omniReference {
+		ledger.reject(
+			field("omni_reference_task_type"),
+			fmt.Sprintf("model %s does not support omni_reference_task_type", modelName),
+		)
+	}
+	if options.WebSearch != nil && *options.WebSearch && !entry.video.webSearch {
+		ledger.reject(
+			field("web_search"),
+			fmt.Sprintf("model %s does not support web_search", modelName),
+		)
+	}
+	if options.OmniReferenceTaskType != nil {
+		taskType := *options.OmniReferenceTaskType
+		if taskType == "edit" || taskType == "extend" {
+			// Official constraints: at least one reference_video;
+			// ratio=adaptive; edit additionally requires duration=-1.
+			if len(wire.referenceVideos) == 0 {
+				ledger.reject(
+					field("omni_reference_task_type"),
+					fmt.Sprintf("%s requires at least one reference video", taskType),
+				)
+			}
+			if wire.ratio != "adaptive" {
+				ledger.reject(
+					field("omni_reference_task_type"),
+					fmt.Sprintf("%s requires ratio=adaptive", taskType),
+				)
+			}
+			if taskType == "edit" && wire.duration != nil {
+				ledger.reject(
+					field("omni_reference_task_type"),
+					"edit requires duration=-1; omit the canonical duration",
+				)
+			}
+		}
+	}
 	wire.cameraFixed = options.CameraFixed
 	wire.generateAudio = options.GenerateAudio
 	wire.serviceTier = options.ServiceTier
 	wire.executionExpiresAfter = options.ExecutionExpiresAfter
+	wire.priority = options.Priority
+	wire.outputFormat = derefString(options.OutputFormat)
+	wire.omniReferenceTaskType = derefString(options.OmniReferenceTaskType)
+	wire.webSearch = options.WebSearch != nil && *options.WebSearch
+	wire.callbackURL = derefString(options.CallbackURL)
+	wire.safetyIdentifier = derefString(options.SafetyIdentifier)
 }
 
 // validVideoRatio reports whether ratio is one of the official create-task
@@ -414,6 +475,24 @@ func transportVideo(
 		}
 		if wire.serviceTier != "" {
 			request.ServiceTier = &wire.serviceTier
+		}
+		request.Priority = wire.priority
+		if wire.outputFormat != "" {
+			request.OutputFormat = &wire.outputFormat
+		}
+		if wire.omniReferenceTaskType != "" {
+			request.OmniReferenceTaskType = &wire.omniReferenceTaskType
+		}
+		if wire.webSearch {
+			request.Tools = []*arkmodel.ContentGenerationTool{{
+				Type: arkmodel.ToolTypeWebSearch,
+			}}
+		}
+		if wire.callbackURL != "" {
+			request.CallbackUrl = &wire.callbackURL
+		}
+		if wire.safetyIdentifier != "" {
+			request.SafetyIdentifier = &wire.safetyIdentifier
 		}
 		created, err := client.CreateContentGenerationTask(ctx, request)
 		if err != nil {

--- a/driver/bytedance/video.go
+++ b/driver/bytedance/video.go
@@ -24,23 +24,27 @@ import (
 // rather than deleted, because the SDK delete call is best-effort and a
 // cancelled caller no longer needs the artifact either way.
 //
-// Input images map onto the frame roles the task API understands: the first
-// image is the first frame, the second is the last frame. More references
-// have no truthful canonical ordering, so the compiler rejects them instead
-// of guessing. Video/audio-reference input (video_url/audio_url content
-// items) is likewise not yet exposed, but that is a scope decision, not an
-// SDK limitation: v1.2.48 encodes both content item types.
+// Inputs map onto the content roles the task API understands: the first
+// image is the first frame, the second is the last frame; any further
+// images and any video/audio parts become reference inputs
+// (reference_image / reference_video / reference_audio), which only the
+// 2.0 series and 2.5 support. First/last-frame input and reference inputs
+// are mutually exclusive, mirroring the official task scenarios.
 
 type videoWire struct {
 	model      string
 	prompt     string
 	firstFrame string
 	lastFrame  string
-	duration   *int64 // seconds
-	resolution string // 480p | 720p | 1080p | 4k
-	ratio      string // width:height, e.g. 16:9
-	seed       *int64
-	watermark  *bool
+	// Reference inputs (Seedance 2.0 series / 2.5 only).
+	referenceImages []string
+	referenceVideos []string
+	referenceAudios []string
+	duration        *int64 // seconds
+	resolution      string // 480p | 720p | 1080p | 4k
+	ratio           string // width:height, e.g. 16:9
+	seed            *int64
+	watermark       *bool
 	// Extension settings (VideoOptions).
 	cameraFixed           *bool
 	generateAudio         *bool
@@ -91,6 +95,8 @@ func compileVideo(
 
 		var prompt []string
 		var images []string
+		var videos []string
+		var audios []string
 		collect := func(parts []message.Part, fields map[message.PartKind]inference.FieldID) {
 			for _, part := range parts {
 				switch value := part.(type) {
@@ -99,14 +105,16 @@ func compileVideo(
 				case message.ImagePart:
 					images = append(images, sourceURI(value.Source))
 				case message.VideoPart:
-					ledger.reject(
-						fields[part.Kind()],
-						"video-reference input is not exposed by the pinned SDK",
-					)
+					videos = append(videos, value.Source.URL())
+				case message.AudioPart:
+					audios = append(audios, value.Source.URL())
 				default:
 					ledger.reject(
 						fields[part.Kind()],
-						fmt.Sprintf("video generation accepts text and image parts, not %s", part.Kind()),
+						fmt.Sprintf(
+							"video generation accepts text, image, video, and audio parts, not %s",
+							part.Kind(),
+						),
 					)
 				}
 			}
@@ -123,17 +131,78 @@ func compileVideo(
 		}
 		collect(request.Input.Content.Parts, inputPartFields)
 		wire.prompt = strings.Join(prompt, "\n")
-		switch len(images) {
-		case 0:
-		case 1:
+		referenceMode := len(images) > 2 || len(videos) > 0 || len(audios) > 0
+		switch {
+		case len(images) == 1:
+			if referenceMode {
+				ledger.reject(
+					inference.FieldGenerateInputImage,
+					"first/last-frame input and reference inputs are mutually exclusive",
+				)
+			}
 			wire.firstFrame = images[0]
-		case 2:
+		case len(images) == 2:
+			if referenceMode {
+				ledger.reject(
+					inference.FieldGenerateInputImage,
+					"first/last-frame input and reference inputs are mutually exclusive",
+				)
+			}
 			wire.firstFrame, wire.lastFrame = images[0], images[1]
-		default:
+		case len(images) > 2:
+			if entry.video.referenceImage == 0 {
+				ledger.reject(
+					inference.FieldGenerateInputImage,
+					fmt.Sprintf(
+						"model %s does not support reference-image input; it accepts at most a first-frame and a last-frame image",
+						model.ID.Name,
+					),
+				)
+			} else if len(images) > entry.video.referenceImage {
+				ledger.reject(
+					inference.FieldGenerateInputImage,
+					fmt.Sprintf(
+						"model %s supports at most %d reference images",
+						model.ID.Name, entry.video.referenceImage,
+					),
+				)
+			} else {
+				wire.referenceImages = images
+			}
+		}
+		switch {
+		case len(videos) > 0 && entry.video.referenceVideo == 0:
 			ledger.reject(
-				inference.FieldGenerateInputImage,
-				"video generation accepts at most a first-frame and a last-frame image",
+				inference.FieldGenerateInputVideo,
+				fmt.Sprintf("model %s does not support video-reference input", model.ID.Name),
 			)
+		case len(videos) > entry.video.referenceVideo:
+			ledger.reject(
+				inference.FieldGenerateInputVideo,
+				fmt.Sprintf(
+					"model %s supports at most %d reference videos",
+					model.ID.Name, entry.video.referenceVideo,
+				),
+			)
+		default:
+			wire.referenceVideos = videos
+		}
+		switch {
+		case len(audios) > 0 && entry.video.referenceAudio == 0:
+			ledger.reject(
+				inference.FieldGenerateInputAudio,
+				fmt.Sprintf("model %s does not support audio-reference input", model.ID.Name),
+			)
+		case len(audios) > entry.video.referenceAudio:
+			ledger.reject(
+				inference.FieldGenerateInputAudio,
+				fmt.Sprintf(
+					"model %s supports at most %d reference audio clips",
+					model.ID.Name, entry.video.referenceAudio,
+				),
+			)
+		default:
+			wire.referenceAudios = audios
 		}
 
 		intent := request.Input.Content.Intent
@@ -312,18 +381,20 @@ func transportVideo(
 			Type: arkmodel.ContentGenerationContentItemTypeText,
 			Text: &prompt,
 		}}
-		frame := func(url, role string) *arkmodel.CreateContentGenerationContentItem {
-			return &arkmodel.CreateContentGenerationContentItem{
-				Type:     arkmodel.ContentGenerationContentItemTypeImage,
-				ImageURL: &arkmodel.ImageURL{URL: url},
-				Role:     &role,
-			}
-		}
 		if wire.firstFrame != "" {
-			content = append(content, frame(wire.firstFrame, "first_frame"))
+			content = append(content, itemImage(wire.firstFrame, "first_frame"))
 		}
 		if wire.lastFrame != "" {
-			content = append(content, frame(wire.lastFrame, "last_frame"))
+			content = append(content, itemImage(wire.lastFrame, "last_frame"))
+		}
+		for _, url := range wire.referenceImages {
+			content = append(content, itemImage(url, "reference_image"))
+		}
+		for _, url := range wire.referenceVideos {
+			content = append(content, itemVideo(url, "reference_video"))
+		}
+		for _, url := range wire.referenceAudios {
+			content = append(content, itemAudio(url, "reference_audio"))
 		}
 		request := arkmodel.CreateContentGenerationTaskRequest{
 			Model:                 wire.model,
@@ -391,6 +462,33 @@ func transportVideo(
 			case <-time.After(pollInterval):
 			}
 		}
+	}
+}
+
+// itemImage / itemVideo / itemAudio build the official content items with
+// their role. The roles are fixed by the compiler: first/last frame for
+// bookend images, reference_* for every other input.
+func itemImage(url, role string) *arkmodel.CreateContentGenerationContentItem {
+	return &arkmodel.CreateContentGenerationContentItem{
+		Type:     arkmodel.ContentGenerationContentItemTypeImage,
+		ImageURL: &arkmodel.ImageURL{URL: url},
+		Role:     &role,
+	}
+}
+
+func itemVideo(url, role string) *arkmodel.CreateContentGenerationContentItem {
+	return &arkmodel.CreateContentGenerationContentItem{
+		Type:     arkmodel.ContentGenerationContentItemTypeVideo,
+		VideoURL: &arkmodel.VideoUrl{Url: url},
+		Role:     &role,
+	}
+}
+
+func itemAudio(url, role string) *arkmodel.CreateContentGenerationContentItem {
+	return &arkmodel.CreateContentGenerationContentItem{
+		Type:     arkmodel.ContentGenerationContentItemTypeAudio,
+		AudioURL: &arkmodel.AudioUrl{Url: url},
+		Role:     &role,
 	}
 }
 

--- a/driver/bytedance/video_test.go
+++ b/driver/bytedance/video_test.go
@@ -67,6 +67,10 @@ func TestCompileVideoGatesParamsByModel(t *testing.T) {
 	seed := int64(11)
 	cameraFixed := true
 	generateAudio := true
+	priority := int32(5)
+	outputFormat := "mov"
+	omniReference := "edit"
+	webSearch := true
 	oneSecond := int64(1_000)
 	thirteenSeconds := int64(13_000)
 	overMaxSeed := int64(2_147_483_648)
@@ -106,6 +110,34 @@ func TestCompileVideoGatesParamsByModel(t *testing.T) {
 			options: VideoOptions{ServiceTier: "flex"},
 			field:   videoOptionsField("service_tier"),
 			reason:  "does not support service_tier=flex",
+		},
+		{
+			name:    "priority unsupported on 1.5 pro",
+			model:   "doubao-seedance-1-5-pro",
+			options: VideoOptions{Priority: &priority},
+			field:   videoOptionsField("priority"),
+			reason:  "does not support priority",
+		},
+		{
+			name:    "output_format unsupported on 2.0",
+			model:   "doubao-seedance-2-0",
+			options: VideoOptions{OutputFormat: &outputFormat},
+			field:   videoOptionsField("output_format"),
+			reason:  "does not support output_format",
+		},
+		{
+			name:    "omni_reference_task_type unsupported on 2.0",
+			model:   "doubao-seedance-2-0",
+			options: VideoOptions{OmniReferenceTaskType: &omniReference},
+			field:   videoOptionsField("omni_reference_task_type"),
+			reason:  "does not support omni_reference_task_type",
+		},
+		{
+			name:    "web_search unsupported on 1.5 pro",
+			model:   "doubao-seedance-1-5-pro",
+			options: VideoOptions{WebSearch: &webSearch},
+			field:   videoOptionsField("web_search"),
+			reason:  "does not support web_search",
 		},
 		{
 			name:   "duration below 1.0 pro minimum",
@@ -213,6 +245,136 @@ func TestVideoOptionsValidateExecutionExpiresAfter(t *testing.T) {
 	}
 }
 
+func TestVideoOptionsValidateExtendedFields(t *testing.T) {
+	priority := int32(10)
+	if err := (VideoOptions{Priority: &priority}).Validate(); err == nil {
+		t.Error("priority=10: expected validation error")
+	}
+	priority = 9
+	if err := (VideoOptions{Priority: &priority}).Validate(); err != nil {
+		t.Errorf("priority=9: unexpected error %v", err)
+	}
+	for _, format := range []string{"gif", "mkv"} {
+		if err := (VideoOptions{OutputFormat: &format}).Validate(); err == nil {
+			t.Errorf("output_format=%q: expected validation error", format)
+		}
+	}
+	for _, taskType := range []string{"auto", "reference", "edit", "extend"} {
+		if err := (VideoOptions{OmniReferenceTaskType: &taskType}).Validate(); err != nil {
+			t.Errorf("omni_reference_task_type=%q: unexpected error %v", taskType, err)
+		}
+	}
+	taskType := "draft"
+	if err := (VideoOptions{OmniReferenceTaskType: &taskType}).Validate(); err == nil {
+		t.Error("omni_reference_task_type=draft: expected validation error")
+	}
+}
+
+func TestCompileVideoOmniReferenceTaskTypeLinkage(t *testing.T) {
+	edit := "edit"
+	extend := "extend"
+	fiveSeconds := int64(5_000)
+
+	requestWith := func(taskType *string, parts []message.Part, ratio string, duration *int64) inference.GenerateRequest {
+		request := compileVideoRequest(parts, VideoOptions{OmniReferenceTaskType: taskType})
+		video := request.Input.Content.Intent.Video
+		video.AspectRatio = media.AspectRatio(ratio)
+		video.DurationMillis = duration
+		return request
+	}
+
+	rejected := []struct {
+		name   string
+		req    inference.GenerateRequest
+		reason string
+	}{
+		{
+			name: "edit without reference video",
+			req: requestWith(
+				&edit,
+				[]message.Part{videoImagePart(t, "https://example.com/a.png")},
+				"adaptive", nil,
+			),
+			reason: "requires at least one reference video",
+		},
+		{
+			name: "edit with explicit ratio",
+			req: requestWith(
+				&edit,
+				[]message.Part{videoReferenceVideoPart(t, "https://example.com/clip.mp4")},
+				"16:9", nil,
+			),
+			reason: "requires ratio=adaptive",
+		},
+		{
+			name: "edit with explicit duration",
+			req: requestWith(
+				&edit,
+				[]message.Part{videoReferenceVideoPart(t, "https://example.com/clip.mp4")},
+				"adaptive", &fiveSeconds,
+			),
+			reason: "requires duration=-1",
+		},
+		{
+			name: "extend without reference video",
+			req: requestWith(
+				&extend,
+				[]message.Part{videoImagePart(t, "https://example.com/a.png")},
+				"adaptive", nil,
+			),
+			reason: "requires at least one reference video",
+		},
+	}
+	for _, tc := range rejected {
+		t.Run(tc.name, func(t *testing.T) {
+			_, report, err := compileVideoWire(t, "doubao-seedance-2-5", tc.req)
+			if err == nil {
+				t.Fatalf("compile unexpectedly succeeded; report = %+v", report)
+			}
+			reason := rejectedReason(report, videoOptionsField("omni_reference_task_type"))
+			if reason == "" {
+				t.Fatalf("omni_reference_task_type not rejected; report = %+v", report)
+			}
+			if !strings.Contains(reason, tc.reason) {
+				t.Errorf("rejection reason = %q, want substring %q", reason, tc.reason)
+			}
+		})
+	}
+
+	accepted := []struct {
+		name     string
+		taskType string
+		parts    []message.Part
+	}{
+		{
+			name:     "edit with reference video, adaptive, auto duration",
+			taskType: edit,
+			parts: []message.Part{
+				videoReferenceVideoPart(t, "https://example.com/clip.mp4"),
+			},
+		},
+		{
+			name:     "extend with reference video and adaptive",
+			taskType: extend,
+			parts: []message.Part{
+				videoReferenceVideoPart(t, "https://example.com/clip.mp4"),
+			},
+		},
+	}
+	for _, tc := range accepted {
+		t.Run(tc.name, func(t *testing.T) {
+			req := requestWith(&tc.taskType, tc.parts, "adaptive", nil)
+			wire, report, err := compileVideoWire(t, "doubao-seedance-2-5", req)
+			if err != nil {
+				t.Fatalf("compile: %v; report = %+v", err, report)
+			}
+			if wire.omniReferenceTaskType != tc.taskType {
+				t.Errorf("omniReferenceTaskType = %q, want %q", wire.omniReferenceTaskType, tc.taskType)
+			}
+		})
+	}
+}
+
 func TestCatalogVideoParamsMatchOfficialMatrix(t *testing.T) {
 	// Transcription guard: catalogEntry.video mirrors the official
 	// create-task API per-model support columns. Any drift here means the
@@ -220,6 +382,10 @@ func TestCatalogVideoParamsMatchOfficialMatrix(t *testing.T) {
 	checks := map[string]videoParams{
 		"doubao-seedance-2-5": {
 			generateAudio:  true,
+			priority:       true,
+			outputFormat:   true,
+			omniReference:  true,
+			webSearch:      true,
 			durationMin:    videoSeconds(4),
 			durationMax:    videoSeconds(30),
 			durationAuto:   true,
@@ -229,6 +395,8 @@ func TestCatalogVideoParamsMatchOfficialMatrix(t *testing.T) {
 		},
 		"doubao-seedance-2-0": {
 			generateAudio:  true,
+			priority:       true,
+			webSearch:      true,
 			durationMin:    videoSeconds(4),
 			durationMax:    videoSeconds(15),
 			durationAuto:   true,
@@ -238,6 +406,8 @@ func TestCatalogVideoParamsMatchOfficialMatrix(t *testing.T) {
 		},
 		"doubao-seedance-2-0-fast": {
 			generateAudio:  true,
+			priority:       true,
+			webSearch:      true,
 			durationMin:    videoSeconds(4),
 			durationMax:    videoSeconds(15),
 			durationAuto:   true,
@@ -608,5 +778,70 @@ func TestTransportVideoCarriesReferenceInputs(t *testing.T) {
 	}
 	if !reflect.DeepEqual(body.Content, want) {
 		t.Errorf("content = %#v, want %#v", body.Content, want)
+	}
+}
+
+func TestTransportVideoCarriesExtendedFields(t *testing.T) {
+	var body map[string]any
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		writer.Header().Set("Content-Type", "application/json")
+		switch {
+		case request.Method == http.MethodPost && request.URL.Path == videoTaskTestPath:
+			if err := json.NewDecoder(request.Body).Decode(&body); err != nil {
+				t.Errorf("decode body: %v", err)
+			}
+			_, _ = writer.Write([]byte(`{"id":"cgt-test"}`))
+		case request.Method == http.MethodGet && request.URL.Path == videoTaskTestPath+"/cgt-test":
+			_, _ = writer.Write([]byte(`{
+				"id": "cgt-test",
+				"status": "succeeded",
+				"content": {"video_url": "https://example.com/out.mp4"},
+				"usage": {"completion_tokens": 1}
+			}`))
+		default:
+			t.Errorf("unexpected request %s %s", request.Method, request.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	client := arkruntime.NewClientWithApiKey(
+		"sk-test",
+		arkruntime.WithBaseUrl(server.URL),
+		arkruntime.WithHTTPClient(server.Client()),
+		arkruntime.WithRetryTimes(0),
+	)
+	priority := int32(5)
+	_, err := transportVideo(client, time.Millisecond)(context.Background(), videoWire{
+		model:                 "ep-test",
+		prompt:                "a cinematic scene",
+		priority:              &priority,
+		outputFormat:          "mp4",
+		omniReferenceTaskType: "reference",
+		webSearch:             true,
+		callbackURL:           "https://example.com/hooks",
+		safetyIdentifier:      "user-42",
+	})
+	if err != nil {
+		t.Fatalf("transport: %v", err)
+	}
+	for key, want := range map[string]any{
+		"model":                    "ep-test",
+		"priority":                 float64(5),
+		"output_format":            "mp4",
+		"omni_reference_task_type": "reference",
+		"callback_url":             "https://example.com/hooks",
+		"safety_identifier":        "user-42",
+	} {
+		if body[key] != want {
+			t.Errorf("body[%q] = %#v, want %#v", key, body[key], want)
+		}
+	}
+	tools, ok := body["tools"].([]any)
+	if !ok || len(tools) != 1 {
+		t.Fatalf("tools = %#v, want one web_search tool", body["tools"])
+	}
+	tool := tools[0].(map[string]any)
+	if tool["type"] != "web_search" {
+		t.Errorf("tool type = %#v, want web_search", tool["type"])
 	}
 }

--- a/driver/bytedance/video_test.go
+++ b/driver/bytedance/video_test.go
@@ -2,6 +2,7 @@ package bytedance
 
 import (
 	"context"
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"reflect"
@@ -12,6 +13,7 @@ import (
 	"github.com/GizClaw/flowcraft/core/errdefs"
 	"github.com/GizClaw/flowcraft/core/inference"
 	"github.com/GizClaw/flowcraft/core/message"
+	"github.com/GizClaw/flowcraft/core/message/media"
 
 	"github.com/volcengine/volcengine-go-sdk/service/arkruntime"
 )
@@ -336,5 +338,275 @@ func TestTransportVideoSucceeded(t *testing.T) {
 	}
 	if raw.completionTokens != 12345 {
 		t.Fatalf("completionTokens = %d, want 12345", raw.completionTokens)
+	}
+}
+
+func videoImagePart(t *testing.T, url string) message.ImagePart {
+	t.Helper()
+	source, err := media.NewImageURL(url, "image/png")
+	if err != nil {
+		t.Fatalf("NewImageURL: %v", err)
+	}
+	return message.ImagePart{Source: source}
+}
+
+func videoReferenceVideoPart(t *testing.T, url string) message.VideoPart {
+	t.Helper()
+	source, err := media.NewVideoURL(url, "video/mp4")
+	if err != nil {
+		t.Fatalf("NewVideoURL: %v", err)
+	}
+	return message.VideoPart{Source: source}
+}
+
+func videoReferenceAudioPart(t *testing.T, url string) message.AudioPart {
+	t.Helper()
+	source, err := media.NewAudioURL(url, "audio/mpeg")
+	if err != nil {
+		t.Fatalf("NewAudioURL: %v", err)
+	}
+	return message.AudioPart{Source: source}
+}
+
+func TestCompileVideoReferenceInputs(t *testing.T) {
+	parts := func(kinds ...message.Part) []message.Part { return kinds }
+
+	accepted := []struct {
+		name       string
+		model      string
+		parts      []message.Part
+		wantFirst  string
+		wantLast   string
+		wantImages []string
+		wantVideos []string
+		wantAudios []string
+	}{
+		{
+			name:      "first frame",
+			model:     "doubao-seedance-2-0",
+			parts:     parts(videoImagePart(t, "https://example.com/a.png")),
+			wantFirst: "https://example.com/a.png",
+		},
+		{
+			name:  "first and last frames",
+			model: "doubao-seedance-2-0",
+			parts: parts(
+				videoImagePart(t, "https://example.com/a.png"),
+				videoImagePart(t, "https://example.com/b.png"),
+			),
+			wantFirst: "https://example.com/a.png",
+			wantLast:  "https://example.com/b.png",
+		},
+		{
+			name:  "reference images",
+			model: "doubao-seedance-2-0",
+			parts: parts(
+				videoImagePart(t, "https://example.com/a.png"),
+				videoImagePart(t, "https://example.com/b.png"),
+				videoImagePart(t, "https://example.com/c.png"),
+			),
+			wantImages: []string{
+				"https://example.com/a.png",
+				"https://example.com/b.png",
+				"https://example.com/c.png",
+			},
+		},
+		{
+			name:       "reference video",
+			model:      "doubao-seedance-2-0",
+			parts:      parts(videoReferenceVideoPart(t, "https://example.com/clip.mp4")),
+			wantVideos: []string{"https://example.com/clip.mp4"},
+		},
+		{
+			name:       "reference audio",
+			model:      "doubao-seedance-2-0",
+			parts:      parts(videoReferenceAudioPart(t, "https://example.com/track.mp3")),
+			wantAudios: []string{"https://example.com/track.mp3"},
+		},
+		{
+			name:       "audio only on 2.5",
+			model:      "doubao-seedance-2-5",
+			parts:      parts(videoReferenceAudioPart(t, "https://example.com/track.mp3")),
+			wantAudios: []string{"https://example.com/track.mp3"},
+		},
+	}
+	for _, tc := range accepted {
+		t.Run(tc.name, func(t *testing.T) {
+			wire, report, err := compileVideoWire(
+				t,
+				tc.model,
+				compileVideoRequest(tc.parts, VideoOptions{}),
+			)
+			if err != nil {
+				t.Fatalf("compile: %v; report = %+v", err, report)
+			}
+			if wire.firstFrame != tc.wantFirst {
+				t.Errorf("firstFrame = %q, want %q", wire.firstFrame, tc.wantFirst)
+			}
+			if wire.lastFrame != tc.wantLast {
+				t.Errorf("lastFrame = %q, want %q", wire.lastFrame, tc.wantLast)
+			}
+			if !reflect.DeepEqual(wire.referenceImages, tc.wantImages) {
+				t.Errorf("referenceImages = %v, want %v", wire.referenceImages, tc.wantImages)
+			}
+			if !reflect.DeepEqual(wire.referenceVideos, tc.wantVideos) {
+				t.Errorf("referenceVideos = %v, want %v", wire.referenceVideos, tc.wantVideos)
+			}
+			if !reflect.DeepEqual(wire.referenceAudios, tc.wantAudios) {
+				t.Errorf("referenceAudios = %v, want %v", wire.referenceAudios, tc.wantAudios)
+			}
+		})
+	}
+}
+
+func TestCompileVideoRejectsReferenceConflicts(t *testing.T) {
+	tenImages := make([]message.Part, 0, 10)
+	for i := range 10 {
+		tenImages = append(tenImages, videoImagePart(
+			t,
+			"https://example.com/"+string(rune('a'+i))+".png",
+		))
+	}
+	cases := []struct {
+		name   string
+		model  string
+		parts  []message.Part
+		field  inference.FieldID
+		reason string
+	}{
+		{
+			name:   "video reference unsupported on 1.5 pro",
+			model:  "doubao-seedance-1-5-pro",
+			parts:  []message.Part{videoReferenceVideoPart(t, "https://example.com/clip.mp4")},
+			field:  inference.FieldGenerateInputVideo,
+			reason: "does not support video-reference input",
+		},
+		{
+			name:  "reference images unsupported on 1.5 pro",
+			model: "doubao-seedance-1-5-pro",
+			parts: []message.Part{
+				videoImagePart(t, "https://example.com/a.png"),
+				videoImagePart(t, "https://example.com/b.png"),
+				videoImagePart(t, "https://example.com/c.png"),
+			},
+			field:  inference.FieldGenerateInputImage,
+			reason: "does not support reference-image input",
+		},
+		{
+			name:  "first frame and reference video conflict",
+			model: "doubao-seedance-2-0",
+			parts: []message.Part{
+				videoImagePart(t, "https://example.com/a.png"),
+				videoReferenceVideoPart(t, "https://example.com/clip.mp4"),
+			},
+			field:  inference.FieldGenerateInputImage,
+			reason: "mutually exclusive",
+		},
+		{
+			name:   "reference image count cap on 2.0",
+			model:  "doubao-seedance-2-0",
+			parts:  tenImages,
+			field:  inference.FieldGenerateInputImage,
+			reason: "supports at most 9 reference images",
+		},
+		{
+			name:  "reference video count cap on 2.0",
+			model: "doubao-seedance-2-0",
+			parts: []message.Part{
+				videoReferenceVideoPart(t, "https://example.com/1.mp4"),
+				videoReferenceVideoPart(t, "https://example.com/2.mp4"),
+				videoReferenceVideoPart(t, "https://example.com/3.mp4"),
+				videoReferenceVideoPart(t, "https://example.com/4.mp4"),
+			},
+			field:  inference.FieldGenerateInputVideo,
+			reason: "supports at most 3 reference videos",
+		},
+		{
+			name:  "reference audio count cap on 2.0",
+			model: "doubao-seedance-2-0",
+			parts: []message.Part{
+				videoReferenceAudioPart(t, "https://example.com/1.mp3"),
+				videoReferenceAudioPart(t, "https://example.com/2.mp3"),
+				videoReferenceAudioPart(t, "https://example.com/3.mp3"),
+				videoReferenceAudioPart(t, "https://example.com/4.mp3"),
+			},
+			field:  inference.FieldGenerateInputAudio,
+			reason: "supports at most 3 reference audio clips",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, report, err := compileVideoWire(
+				t,
+				tc.model,
+				compileVideoRequest(tc.parts, VideoOptions{}),
+			)
+			if err == nil {
+				t.Fatalf("compile unexpectedly succeeded; report = %+v", report)
+			}
+			reason := rejectedReason(report, tc.field)
+			if reason == "" {
+				t.Fatalf("field %q not rejected; report = %+v", tc.field, report)
+			}
+			if !strings.Contains(reason, tc.reason) {
+				t.Errorf("rejection reason = %q, want substring %q", reason, tc.reason)
+			}
+		})
+	}
+}
+
+func TestTransportVideoCarriesReferenceInputs(t *testing.T) {
+	var body struct {
+		Content []map[string]any `json:"content"`
+	}
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		writer.Header().Set("Content-Type", "application/json")
+		switch {
+		case request.Method == http.MethodPost && request.URL.Path == videoTaskTestPath:
+			if err := json.NewDecoder(request.Body).Decode(&body); err != nil {
+				t.Errorf("decode body: %v", err)
+			}
+			_, _ = writer.Write([]byte(`{"id":"cgt-test"}`))
+		case request.Method == http.MethodGet && request.URL.Path == videoTaskTestPath+"/cgt-test":
+			_, _ = writer.Write([]byte(`{
+				"id": "cgt-test",
+				"status": "succeeded",
+				"content": {"video_url": "https://example.com/out.mp4"},
+				"usage": {"completion_tokens": 1}
+			}`))
+		default:
+			t.Errorf("unexpected request %s %s", request.Method, request.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	client := arkruntime.NewClientWithApiKey(
+		"sk-test",
+		arkruntime.WithBaseUrl(server.URL),
+		arkruntime.WithHTTPClient(server.Client()),
+		arkruntime.WithRetryTimes(0),
+	)
+	_, err := transportVideo(client, time.Millisecond)(context.Background(), videoWire{
+		model:           "ep-test",
+		prompt:          "reference please",
+		firstFrame:      "https://example.com/first.png",
+		lastFrame:       "https://example.com/last.png",
+		referenceImages: []string{"https://example.com/ref1.png"},
+		referenceVideos: []string{"https://example.com/clip.mp4"},
+		referenceAudios: []string{"https://example.com/track.mp3"},
+	})
+	if err != nil {
+		t.Fatalf("transport: %v", err)
+	}
+	want := []map[string]any{
+		{"type": "text", "text": "reference please"},
+		{"type": "image_url", "image_url": map[string]any{"url": "https://example.com/first.png"}, "role": "first_frame"},
+		{"type": "image_url", "image_url": map[string]any{"url": "https://example.com/last.png"}, "role": "last_frame"},
+		{"type": "image_url", "image_url": map[string]any{"url": "https://example.com/ref1.png"}, "role": "reference_image"},
+		{"type": "video_url", "video_url": map[string]any{"url": "https://example.com/clip.mp4"}, "role": "reference_video"},
+		{"type": "audio_url", "audio_url": map[string]any{"url": "https://example.com/track.mp3"}, "role": "reference_audio"},
+	}
+	if !reflect.DeepEqual(body.Content, want) {
+		t.Errorf("content = %#v, want %#v", body.Content, want)
 	}
 }

--- a/driver/bytedance/video_test.go
+++ b/driver/bytedance/video_test.go
@@ -375,28 +375,123 @@ func TestCompileVideoOmniReferenceTaskTypeLinkage(t *testing.T) {
 	}
 }
 
+func TestCompileVideoFrameRatioRestriction(t *testing.T) {
+	rejected := []struct {
+		name   string
+		model  string
+		parts  []message.Part
+		ratio  string
+		reason string
+	}{
+		{
+			name:  "2.5 first frame with explicit ratio",
+			model: "doubao-seedance-2-5",
+			parts: []message.Part{
+				videoImagePart(t, "https://example.com/a.png"),
+			},
+			ratio:  "16:9",
+			reason: "supports only ratio=adaptive for first/last-frame tasks",
+		},
+		{
+			name:  "2.5 first and last frame with explicit ratio",
+			model: "doubao-seedance-2-5",
+			parts: []message.Part{
+				videoImagePart(t, "https://example.com/a.png"),
+				videoImagePart(t, "https://example.com/b.png"),
+			},
+			ratio:  "9:16",
+			reason: "supports only ratio=adaptive for first/last-frame tasks",
+		},
+	}
+	for _, tc := range rejected {
+		t.Run(tc.name, func(t *testing.T) {
+			request := compileVideoRequest(tc.parts, VideoOptions{})
+			request.Input.Content.Intent.Video.AspectRatio = media.AspectRatio(tc.ratio)
+			_, report, err := compileVideoWire(t, tc.model, request)
+			if err == nil {
+				t.Fatalf("compile unexpectedly succeeded; report = %+v", report)
+			}
+			reason := rejectedReason(report, inference.FieldGenerateIntentVideoAspectRatio)
+			if reason == "" {
+				t.Fatalf("aspect_ratio not rejected; report = %+v", report)
+			}
+			if !strings.Contains(reason, tc.reason) {
+				t.Errorf("rejection reason = %q, want substring %q", reason, tc.reason)
+			}
+		})
+	}
+
+	accepted := []struct {
+		name  string
+		model string
+		parts []message.Part
+		ratio string
+	}{
+		{
+			name:  "2.5 first frame with adaptive",
+			model: "doubao-seedance-2-5",
+			parts: []message.Part{
+				videoImagePart(t, "https://example.com/a.png"),
+			},
+			ratio: "adaptive",
+		},
+		{
+			name:  "2.5 first frame without ratio",
+			model: "doubao-seedance-2-5",
+			parts: []message.Part{
+				videoImagePart(t, "https://example.com/a.png"),
+			},
+		},
+		{
+			name:  "2.5 text-to-video with explicit ratio",
+			model: "doubao-seedance-2-5",
+			parts: []message.Part{
+				message.TextPart{Text: "a cinematic scene"},
+			},
+			ratio: "16:9",
+		},
+		{
+			name:  "2.0 first frame with explicit ratio",
+			model: "doubao-seedance-2-0",
+			parts: []message.Part{
+				videoImagePart(t, "https://example.com/a.png"),
+			},
+			ratio: "16:9",
+		},
+	}
+	for _, tc := range accepted {
+		t.Run(tc.name, func(t *testing.T) {
+			request := compileVideoRequest(tc.parts, VideoOptions{})
+			request.Input.Content.Intent.Video.AspectRatio = media.AspectRatio(tc.ratio)
+			if _, report, err := compileVideoWire(t, tc.model, request); err != nil {
+				t.Fatalf("compile: %v; report = %+v", err, report)
+			}
+		})
+	}
+}
+
 func TestCatalogVideoParamsMatchOfficialMatrix(t *testing.T) {
 	// Transcription guard: catalogEntry.video mirrors the official
 	// create-task API per-model support columns. Any drift here means the
 	// compiler gates the wrong model set.
 	checks := map[string]videoParams{
 		"doubao-seedance-2-5": {
-			generateAudio:  true,
-			priority:       true,
-			outputFormat:   true,
-			omniReference:  true,
-			webSearch:      true,
-			durationMin:    videoSeconds(4),
-			durationMax:    videoSeconds(30),
-			durationAuto:   true,
-			referenceImage: 30,
-			referenceVideo: 10,
-			referenceAudio: 10,
+			generateAudio:          true,
+			priority:               true,
+			outputFormat:           true,
+			omniReference:          true,
+			durationMin:            videoSeconds(4),
+			durationMax:            videoSeconds(30),
+			durationAuto:           true,
+			audioOnly:              true,
+			frameRatioAdaptiveOnly: true,
+			referenceImage:         30,
+			referenceVideo:         10,
+			referenceAudio:         10,
 		},
 		"doubao-seedance-2-0": {
 			generateAudio:  true,
 			priority:       true,
-			webSearch:      true,
 			durationMin:    videoSeconds(4),
 			durationMax:    videoSeconds(15),
 			durationAuto:   true,
@@ -407,7 +502,6 @@ func TestCatalogVideoParamsMatchOfficialMatrix(t *testing.T) {
 		"doubao-seedance-2-0-fast": {
 			generateAudio:  true,
 			priority:       true,
-			webSearch:      true,
 			durationMin:    videoSeconds(4),
 			durationMax:    videoSeconds(15),
 			durationAuto:   true,
@@ -588,9 +682,13 @@ func TestCompileVideoReferenceInputs(t *testing.T) {
 			wantVideos: []string{"https://example.com/clip.mp4"},
 		},
 		{
-			name:       "reference audio",
-			model:      "doubao-seedance-2-0",
-			parts:      parts(videoReferenceAudioPart(t, "https://example.com/track.mp3")),
+			name:  "reference video and audio",
+			model: "doubao-seedance-2-0",
+			parts: parts(
+				videoReferenceVideoPart(t, "https://example.com/clip.mp4"),
+				videoReferenceAudioPart(t, "https://example.com/track.mp3"),
+			),
+			wantVideos: []string{"https://example.com/clip.mp4"},
 			wantAudios: []string{"https://example.com/track.mp3"},
 		},
 		{
@@ -702,6 +800,15 @@ func TestCompileVideoRejectsReferenceConflicts(t *testing.T) {
 			},
 			field:  inference.FieldGenerateInputAudio,
 			reason: "supports at most 3 reference audio clips",
+		},
+		{
+			name:  "audio only on 2.0",
+			model: "doubao-seedance-2-0",
+			parts: []message.Part{
+				videoReferenceAudioPart(t, "https://example.com/track.mp3"),
+			},
+			field:  inference.FieldGenerateInputAudio,
+			reason: "does not allow audio-only input",
 		},
 	}
 	for _, tc := range cases {

--- a/driver/bytedance/video_test.go
+++ b/driver/bytedance/video_test.go
@@ -1,0 +1,340 @@
+package bytedance
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/GizClaw/flowcraft/core/errdefs"
+	"github.com/GizClaw/flowcraft/core/inference"
+	"github.com/GizClaw/flowcraft/core/message"
+
+	"github.com/volcengine/volcengine-go-sdk/service/arkruntime"
+)
+
+const videoTaskTestPath = "/contents/generations/tasks"
+
+func compileVideoRequest(parts []message.Part, options VideoOptions) inference.GenerateRequest {
+	var extensions inference.Extensions
+	extensions = append(extensions, options)
+	return inference.GenerateRequest{
+		Input: inference.GenerateInput{
+			Role: inference.InputRoleUser,
+			Content: inference.InputContent{
+				Content: message.Content{Parts: parts},
+				Intent:  inference.Intent{Video: &inference.VideoIntent{}},
+			},
+		},
+		Extensions: extensions,
+	}
+}
+
+func compileVideoWire(
+	t *testing.T,
+	model string,
+	request inference.GenerateRequest,
+) (videoWire, inference.CompileReport, error) {
+	t.Helper()
+	entry, ok := catalog[model]
+	if !ok {
+		t.Fatalf("catalog model %q missing", model)
+	}
+	compiled, err := compileVideo("ep-test", entry)(
+		context.Background(),
+		inference.ModelRef{ID: inference.ModelID{Provider: driverID, Name: model}},
+		request,
+		inference.GenerateExecutionUnary,
+	)
+	if err != nil {
+		return videoWire{}, compiled.Report, err
+	}
+	return compiled.Wire, compiled.Report, nil
+}
+
+// videoOptionsField qualifies one VideoOptions extension field the same way
+// the compiler does, so tests can assert the exact FieldID.
+func videoOptionsField(name string) inference.FieldID {
+	return inference.ExtensionField(name).Qualify(VideoOptions{})
+}
+
+func TestCompileVideoGatesParamsByModel(t *testing.T) {
+	seed := int64(11)
+	cameraFixed := true
+	generateAudio := true
+	oneSecond := int64(1_000)
+	thirteenSeconds := int64(13_000)
+	overMaxSeed := int64(2_147_483_648)
+
+	cases := []struct {
+		name    string
+		model   string
+		options VideoOptions
+		intent  func(*inference.VideoIntent)
+		field   inference.FieldID
+		reason  string
+	}{
+		{
+			name:   "seed unsupported on 2.0",
+			model:  "doubao-seedance-2-0",
+			intent: func(i *inference.VideoIntent) { i.Seed = &seed },
+			field:  inference.FieldGenerateIntentVideoSeed,
+			reason: "does not support seed",
+		},
+		{
+			name:    "camera_fixed unsupported on 2.0",
+			model:   "doubao-seedance-2-0",
+			options: VideoOptions{CameraFixed: &cameraFixed},
+			field:   videoOptionsField("camera_fixed"),
+			reason:  "does not support camera_fixed",
+		},
+		{
+			name:    "generate_audio unsupported on 1.0 pro",
+			model:   "doubao-seedance-1-0-pro",
+			options: VideoOptions{GenerateAudio: &generateAudio},
+			field:   videoOptionsField("generate_audio"),
+			reason:  "does not support generate_audio",
+		},
+		{
+			name:    "flex tier unsupported on 2.0",
+			model:   "doubao-seedance-2-0",
+			options: VideoOptions{ServiceTier: "flex"},
+			field:   videoOptionsField("service_tier"),
+			reason:  "does not support service_tier=flex",
+		},
+		{
+			name:   "duration below 1.0 pro minimum",
+			model:  "doubao-seedance-1-0-pro",
+			intent: func(i *inference.VideoIntent) { i.DurationMillis = &oneSecond },
+			field:  inference.FieldGenerateIntentVideoDuration,
+			reason: "requires a duration of at least 2s",
+		},
+		{
+			name:   "duration above 1.0 pro maximum",
+			model:  "doubao-seedance-1-0-pro",
+			intent: func(i *inference.VideoIntent) { i.DurationMillis = &thirteenSeconds },
+			field:  inference.FieldGenerateIntentVideoDuration,
+			reason: "caps duration at 12s",
+		},
+		{
+			name:   "invalid ratio",
+			model:  "doubao-seedance-2-0",
+			intent: func(i *inference.VideoIntent) { i.AspectRatio = "2:1" },
+			field:  inference.FieldGenerateIntentVideoAspectRatio,
+			reason: `unsupported video ratio "2:1"`,
+		},
+		{
+			name:   "seed above documented range on 1.5 pro",
+			model:  "doubao-seedance-1-5-pro",
+			intent: func(i *inference.VideoIntent) { i.Seed = &overMaxSeed },
+			field:  inference.FieldGenerateIntentVideoSeed,
+			reason: "seed must be within [-1, 2147483647]",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			request := compileVideoRequest(
+				[]message.Part{message.TextPart{Text: "a cinematic scene"}},
+				tc.options,
+			)
+			if tc.intent != nil {
+				tc.intent(request.Input.Content.Intent.Video)
+			}
+			_, report, err := compileVideoWire(t, tc.model, request)
+			if err == nil {
+				t.Fatalf("compile unexpectedly succeeded; report = %+v", report)
+			}
+			reason := rejectedReason(report, tc.field)
+			if reason == "" {
+				t.Fatalf("field %q not rejected; report = %+v", tc.field, report)
+			}
+			if !strings.Contains(reason, tc.reason) {
+				t.Errorf("rejection reason = %q, want substring %q", reason, tc.reason)
+			}
+		})
+	}
+}
+
+func TestCompileVideoAllowsSupportedParams(t *testing.T) {
+	seed := int64(11)
+	cameraFixed := true
+	generateAudio := true
+	fiveSeconds := int64(5_000)
+	request := compileVideoRequest(
+		[]message.Part{message.TextPart{Text: "a cinematic scene"}},
+		VideoOptions{
+			CameraFixed:   &cameraFixed,
+			GenerateAudio: &generateAudio,
+			ServiceTier:   "flex",
+		},
+	)
+	video := request.Input.Content.Intent.Video
+	video.DurationMillis = &fiveSeconds
+	video.AspectRatio = "16:9"
+	video.Seed = &seed
+
+	wire, report, err := compileVideoWire(t, "doubao-seedance-1-5-pro", request)
+	if err != nil {
+		t.Fatalf("compile: %v; report = %+v", err, report)
+	}
+	if wire.duration == nil || *wire.duration != 5 {
+		t.Fatalf("wire.duration = %v, want 5", wire.duration)
+	}
+	if wire.seed == nil || *wire.seed != seed {
+		t.Fatalf("wire.seed = %v, want %d", wire.seed, seed)
+	}
+	if wire.cameraFixed == nil || !*wire.cameraFixed {
+		t.Fatal("wire.cameraFixed not set")
+	}
+	if wire.generateAudio == nil || !*wire.generateAudio {
+		t.Fatal("wire.generateAudio not set")
+	}
+	if wire.serviceTier != "flex" {
+		t.Fatalf("wire.serviceTier = %q, want flex", wire.serviceTier)
+	}
+}
+
+func TestVideoOptionsValidateExecutionExpiresAfter(t *testing.T) {
+	for _, value := range []int64{600, 259_201} {
+		if err := (VideoOptions{ExecutionExpiresAfter: &value}).Validate(); err == nil {
+			t.Errorf("execution_expires_after=%d: expected validation error", value)
+		}
+	}
+	for _, value := range []int64{3600, 172_800, 259_200} {
+		if err := (VideoOptions{ExecutionExpiresAfter: &value}).Validate(); err != nil {
+			t.Errorf("execution_expires_after=%d: unexpected error %v", value, err)
+		}
+	}
+}
+
+func TestCatalogVideoParamsMatchOfficialMatrix(t *testing.T) {
+	// Transcription guard: catalogEntry.video mirrors the official
+	// create-task API per-model support columns. Any drift here means the
+	// compiler gates the wrong model set.
+	checks := map[string]videoParams{
+		"doubao-seedance-2-5": {
+			generateAudio:  true,
+			durationMin:    videoSeconds(4),
+			durationMax:    videoSeconds(30),
+			durationAuto:   true,
+			referenceImage: 30,
+			referenceVideo: 10,
+			referenceAudio: 10,
+		},
+		"doubao-seedance-2-0": {
+			generateAudio:  true,
+			durationMin:    videoSeconds(4),
+			durationMax:    videoSeconds(15),
+			durationAuto:   true,
+			referenceImage: 9,
+			referenceVideo: 3,
+			referenceAudio: 3,
+		},
+		"doubao-seedance-2-0-fast": {
+			generateAudio:  true,
+			durationMin:    videoSeconds(4),
+			durationMax:    videoSeconds(15),
+			durationAuto:   true,
+			referenceImage: 9,
+			referenceVideo: 3,
+			referenceAudio: 3,
+		},
+		"doubao-seedance-1-5-pro": {
+			seed:          true,
+			cameraFixed:   true,
+			flexTier:      true,
+			generateAudio: true,
+			durationMin:   videoSeconds(4),
+			durationMax:   videoSeconds(12),
+			durationAuto:  true,
+		},
+		"doubao-seedance-1-0-pro": {
+			seed:        true,
+			cameraFixed: true,
+			flexTier:    true,
+			durationMin: videoSeconds(2),
+			durationMax: videoSeconds(12),
+		},
+	}
+	for name, want := range checks {
+		if got := catalog[name].video; !reflect.DeepEqual(got, want) {
+			t.Errorf("model %q: video params = %+v, want %+v", name, got, want)
+		}
+	}
+}
+
+func TestTransportVideoExpired(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		writer.Header().Set("Content-Type", "application/json")
+		switch {
+		case request.Method == http.MethodPost && request.URL.Path == videoTaskTestPath:
+			_, _ = writer.Write([]byte(`{"id":"cgt-test"}`))
+		case request.Method == http.MethodGet && request.URL.Path == videoTaskTestPath+"/cgt-test":
+			_, _ = writer.Write([]byte(`{"id":"cgt-test","status":"expired"}`))
+		default:
+			t.Errorf("unexpected request %s %s", request.Method, request.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	client := arkruntime.NewClientWithApiKey(
+		"sk-test",
+		arkruntime.WithBaseUrl(server.URL),
+		arkruntime.WithHTTPClient(server.Client()),
+		arkruntime.WithRetryTimes(0),
+	)
+	_, err := transportVideo(client, time.Millisecond)(context.Background(), videoWire{
+		model:  "ep-test",
+		prompt: "a cinematic scene",
+	})
+	if err == nil {
+		t.Fatal("transport returned nil error for expired task")
+	}
+	if !errdefs.IsTimeout(err) {
+		t.Fatalf("expired task error = %v, want timeout classification", err)
+	}
+}
+
+func TestTransportVideoSucceeded(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		writer.Header().Set("Content-Type", "application/json")
+		switch {
+		case request.Method == http.MethodPost && request.URL.Path == videoTaskTestPath:
+			_, _ = writer.Write([]byte(`{"id":"cgt-test"}`))
+		case request.Method == http.MethodGet && request.URL.Path == videoTaskTestPath+"/cgt-test":
+			_, _ = writer.Write([]byte(`{
+				"id": "cgt-test",
+				"status": "succeeded",
+				"content": {"video_url": "https://example.com/out.mp4"},
+				"usage": {"completion_tokens": 12345}
+			}`))
+		default:
+			t.Errorf("unexpected request %s %s", request.Method, request.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	client := arkruntime.NewClientWithApiKey(
+		"sk-test",
+		arkruntime.WithBaseUrl(server.URL),
+		arkruntime.WithHTTPClient(server.Client()),
+		arkruntime.WithRetryTimes(0),
+	)
+	raw, err := transportVideo(client, time.Millisecond)(context.Background(), videoWire{
+		model:  "ep-test",
+		prompt: "a cinematic scene",
+	})
+	if err != nil {
+		t.Fatalf("transport: %v", err)
+	}
+	if raw.videoURL != "https://example.com/out.mp4" {
+		t.Fatalf("videoURL = %q", raw.videoURL)
+	}
+	if raw.completionTokens != 12345 {
+		t.Fatalf("completionTokens = %d, want 12345", raw.completionTokens)
+	}
+}


### PR DESCRIPTION
## Why

The `driver/bytedance` Seedance video generation path was reviewed against the official Volcengine Ark *Create Video Generation Task* API (`POST /contents/generations/tasks`) and the pinned `volcengine-go-sdk` v1.2.48. The review found:

- the terminal `expired` task status was never handled, so a task that timed out server-side was polled until the caller's context was cancelled;
- request parameters such as `seed`, `camera_fixed`, `generate_audio`, and `service_tier=flex` were forwarded to every video model even where the official per-model support matrix does not allow them, causing strong-validation errors from the endpoint instead of a local, actionable failure;
- reference inputs (`video_url` / `audio_url` / reference images) were rejected with a stale claim that the pinned SDK could not encode them, although v1.2.48 supports those content item types;
- several official request options (`priority`, `output_format`, `omni_reference_task_type`, `web_search`, `callback_url`, `safety_identifier`) were not exposed at all.

## What changed

**Polling and parameter gating**
- `expired` is now treated as a terminal state and surfaces as a `Timeout` error instead of polling forever.
- A per-model support matrix (`catalogEntry.video`) is transcribed from the official docs; the compiler rejects `seed`, `camera_fixed`, `generate_audio`, and `service_tier=flex` for models that do not support them, and validates duration bounds per model, ratio values, the `seed` range, and `execution_expires_after` (`[3600, 259200]`).
- Seedance 2.0 series audio-only input is rejected (official: audio must be accompanied by at least one reference image or video); only 2.5 allows audio-only.
- Seedance 2.5 first/last-frame tasks accept only `ratio=adaptive` per the official docs; explicit ratios are rejected for those tasks.

**Reference inputs**
- The 2.0 series and 2.5 now accept reference images (3+), reference videos, and reference audio through the official content roles (`reference_image` / `reference_video` / `reference_audio`); 2.5 additionally accepts audio-only input.
- First/last-frame input and reference inputs are mutually exclusive, per-model count caps are enforced (9/3/3 for 2.0 series, 30/10/10 for 2.5), and 1.x models keep rejecting the new input kinds with a model-capability message.

**Remaining official options**
- `VideoOptions` gains `priority` (2.5/2.0 series), `output_format` (2.5), `omni_reference_task_type` (2.5), `web_search` (2.5/2.0 series), `callback_url`, and `safety_identifier`, all gated by the support matrix and encoded through the pinned SDK (`web_search` via `tools[ContentGenerationTool]`).
- Web search support is declared through the existing `capabilities.HostedWebSearch` slot, matching how the chat/generate family gates it.
- `omni_reference_task_type=edit/extend` enforces the official linkage constraints (at least one reference video, `ratio=adaptive`, and `duration=-1` for `edit`), so invalid combinations fail locally instead of as server-side async errors.

## Verification

- New table-driven coverage in `driver/bytedance/video_test.go`: per-model gating matrix, `expired`/`succeeded` transport paths, reference-input mapping and conflicts, count caps, edit/extend linkage, extended-field JSON encoding, and a catalog matrix transcription guard.
- All CI checks pass (lint, driver tests, format, integration, release-intent validation).

## Known limitations

- The canonical `AspectRatio` type cannot express `adaptive`, so the `ratio=adaptive` constraint for `omni_reference_task_type=edit/extend` is enforced by rejecting non-adaptive values locally; those subtasks are not expressible through the canonical ratio channel yet.
- `usage.tool_usage.web_search` is not surfaced because the pinned SDK's response `Usage` struct has no `tool_usage` field.