### PR TITLE
feat(driver/minimax): add MiniMax-H3 v2 video and H3-Context-IR

### DIFF
--- a/driver/minimax/catalog.go
+++ b/driver/minimax/catalog.go
@@ -13,27 +13,43 @@ import (
 type modelKind string
 
 const (
-	kindGenerate modelKind = "generate"
-	kindImage    modelKind = "image"
-	kindTTS      modelKind = "tts"
-	kindVideo    modelKind = "video"
-	kindMusic    modelKind = "music"
+	kindGenerate  modelKind = "generate"
+	kindImage     modelKind = "image"
+	kindTTS       modelKind = "tts"
+	kindVideo     modelKind = "video"
+	kindMusic     modelKind = "music"
+	kindContextIR modelKind = "context_ir"
 )
 
 // catalogEntry declares what one catalog model accepts. capabilities is the
-// single capability fact source: input/output content kinds and the reasoning
-// control capability. video10s, videoHD, and videoI2VOnly are control
-// capabilities that no capability kind expresses and stay separate flags.
+// single capability fact source: input/output content kinds and the
+// reasoning control capability. video10s, videoHD, video512P,
+// videoLastFrame, videoI2VOnly, and videoV2 are control capabilities that
+// no capability kind expresses and stay separate flags.
 type catalogEntry struct {
 	kind         modelKind
 	capabilities inference.ModelCapabilities
+	// wireModel overrides the model token sent to the API when the
+	// catalog name is a deployment-side alias (e.g. MiniMax-H3-Context-IR
+	// still speaks to the MiniMax-H3 model). Empty uses the catalog name.
+	wireModel string
 	// video10s accepts 10-second durations at 768P.
 	video10s bool
 	// videoHD accepts 1080P resolution.
 	videoHD bool
+	// video512P accepts 512P resolution; MiniMax-Hailuo-02 serves it on
+	// the image-to-video surface only.
+	video512P bool
+	// videoLastFrame accepts a second input image as the closing frame
+	// (first_frame_image + last_frame_image); MiniMax-Hailuo-02 only.
+	videoLastFrame bool
 	// videoI2VOnly marks image-to-video models: the request must carry a
 	// first-frame image.
 	videoI2VOnly bool
+	// videoV2 routes the model to the v2 video task API (MiniMax-H3):
+	// a multimodal content array, 768P/2K tiers, 4-15s durations, and
+	// ratio control. The Hailuo 2.x/02 trio rides the flat v1 API.
+	videoV2 bool
 	// maxInputTokens caps the input context in tokens; zero means
 	// undeclared. M3 holds the 1M context and the M2.x series holds
 	// 204,800 per https://platform.minimaxi.com/docs/guides/text-generation.
@@ -64,6 +80,10 @@ func (e catalogEntry) validate() error {
 		if !slices.Contains(e.capabilities.Outputs, message.PartVideo) {
 			return fmt.Errorf("video family must declare video output")
 		}
+	case kindContextIR:
+		if !slices.Contains(e.capabilities.Outputs, message.PartText) {
+			return fmt.Errorf("context_ir family must declare text output")
+		}
 	default:
 		return fmt.Errorf("unsupported kind %q", e.kind)
 	}
@@ -89,6 +109,7 @@ func generateChatCapabilities() inference.ModelCapabilities {
 //   - https://platform.minimaxi.com/docs/api-reference/api-overview
 //   - https://platform.minimaxi.com/docs/api-reference/speech-t2a-http
 //   - https://platform.minimaxi.com/docs/api-reference/video-generation-t2v
+//   - https://platform.minimaxi.com/docs/api-reference/video-generation-v2-create
 //   - https://platform.minimaxi.com/docs/api-reference/image-generation-t2i
 //
 // All generate entries speak the binary-thinking dialect: any requested
@@ -200,8 +221,13 @@ var catalog = map[string]catalogEntry{
 			WithOutputs(message.PartImage),
 	},
 
-	// Video generation (async task API). Hailuo-2.3-Fast is image-to-video
-	// only; the 2.3/02 pair runs 10s at 768P and 6s at 1080P.
+	// Video generation (async task API). MiniMax-H3 rides the v2 API: a
+	// multimodal content array (text/image/video/audio items with
+	// first_frame/last_frame/reference_* roles), 768P/2K, 4-15s durations,
+	// ratio control, and a direct content.url on query. The Hailuo trio
+	// rides the flat v1 API: 6s everywhere, 10s at 768P, 1080P at 6s.
+	// Hailuo-2.3-Fast is image-to-video only; Hailuo-02 adds 512P
+	// (image-to-video) and first/last-frame input.
 	"MiniMax-Hailuo-2.3": {
 		kind: kindVideo,
 		capabilities: inference.ModelCapabilities{}.
@@ -216,14 +242,47 @@ var catalog = map[string]catalogEntry{
 			WithInputs(message.PartText, message.PartImage).
 			WithOutputs(message.PartVideo),
 		videoI2VOnly: true,
+		video10s:     true,
+		videoHD:      true,
 	},
 	"MiniMax-Hailuo-02": {
 		kind: kindVideo,
 		capabilities: inference.ModelCapabilities{}.
 			WithInputs(message.PartText, message.PartImage).
 			WithOutputs(message.PartVideo),
-		video10s: true,
-		videoHD:  true,
+		video10s:       true,
+		videoHD:        true,
+		video512P:      true,
+		videoLastFrame: true,
+	},
+	"MiniMax-H3": {
+		kind: kindVideo,
+		capabilities: inference.ModelCapabilities{}.
+			WithInputs(
+				message.PartText,
+				message.PartImage,
+				message.PartVideo,
+				message.PartAudio,
+			).
+			WithOutputs(message.PartVideo),
+		videoV2: true,
+	},
+
+	// H3-Context-IR deep-reads the multimodal context and returns an
+	// enhanced video prompt (text), never a video. It rides the v2 task
+	// API: same content roles as MiniMax-H3 video, duration 4-15s, and an
+	// optional ratio; the target duration/ratio ride ContextIROptions.
+	"MiniMax-H3-Context-IR": {
+		kind:      kindContextIR,
+		wireModel: "MiniMax-H3",
+		capabilities: inference.ModelCapabilities{}.
+			WithInputs(
+				message.PartText,
+				message.PartImage,
+				message.PartVideo,
+				message.PartAudio,
+			).
+			WithOutputs(message.PartText),
 	},
 
 	// Music generation (text-to-music; music-cover stays out — see
@@ -266,10 +325,28 @@ func mergedCatalog(spec Spec) (map[string]catalogEntry, error) {
 			kind:         modelKind(declared.Kind),
 			capabilities: declared.Capabilities,
 		}
-		if entry.kind == "" {
-			if existing, exists := models[declared.Name]; exists {
+		if existing, exists := models[declared.Name]; exists {
+			if entry.kind == "" {
 				entry.kind = existing.kind
-			} else {
+			}
+			if entry.kind == existing.kind {
+				// Redeclaring a built-in model under the same kind keeps
+				// the family's control flags and limits; only capabilities
+				// come from the declaration. Without this, a spec entry for
+				// MiniMax-H3 would silently fall back to the v1 video API
+				// and a redeclared Hailuo model would lose its 10s/1080P
+				// support.
+				entry.wireModel = existing.wireModel
+				entry.video10s = existing.video10s
+				entry.videoHD = existing.videoHD
+				entry.video512P = existing.video512P
+				entry.videoLastFrame = existing.videoLastFrame
+				entry.videoI2VOnly = existing.videoI2VOnly
+				entry.videoV2 = existing.videoV2
+				entry.maxInputTokens = existing.maxInputTokens
+			}
+		} else {
+			if entry.kind == "" {
 				entry.kind = kindGenerate
 			}
 		}
@@ -281,6 +358,16 @@ func mergedCatalog(spec Spec) (map[string]catalogEntry, error) {
 		}
 	}
 	return models, nil
+}
+
+// wireModel returns the model token sent on the wire: the catalog name
+// unless the entry declares a wireModel override (e.g. the Context-IR
+// alias still addresses the MiniMax-H3 model).
+func wireModel(name string, entry catalogEntry) string {
+	if entry.wireModel != "" {
+		return entry.wireModel
+	}
+	return name
 }
 
 // sortedNames returns catalog names in deterministic order so factory

--- a/driver/minimax/catalog_test.go
+++ b/driver/minimax/catalog_test.go
@@ -78,6 +78,20 @@ func TestCatalogPublishesCapabilities(t *testing.T) {
 		t.Fatalf("video outputs = %v, want video", video.Capabilities.Outputs)
 	}
 
+	h3 := descriptors["MiniMax-H3"]
+	if !reflect.DeepEqual(h3.Capabilities.Outputs, []message.PartKind{message.PartVideo}) ||
+		!slices.Contains(h3.Capabilities.Inputs, message.PartVideo) ||
+		!slices.Contains(h3.Capabilities.Inputs, message.PartAudio) {
+		t.Fatalf("H3 capabilities = %+v", h3.Capabilities)
+	}
+
+	contextIR := descriptors["MiniMax-H3-Context-IR"]
+	if !reflect.DeepEqual(contextIR.Capabilities.Outputs, []message.PartKind{message.PartText}) ||
+		!slices.Contains(contextIR.Capabilities.Inputs, message.PartVideo) ||
+		!slices.Contains(contextIR.Capabilities.Inputs, message.PartAudio) {
+		t.Fatalf("Context-IR capabilities = %+v", contextIR.Capabilities)
+	}
+
 	tts := descriptors["speech-2.8-hd"]
 	if !reflect.DeepEqual(tts.Capabilities.Outputs, []message.PartKind{message.PartAudio}) {
 		t.Fatalf("tts outputs = %v, want audio", tts.Capabilities.Outputs)
@@ -98,5 +112,50 @@ func TestMergedCatalogRejectsFamilyContractViolation(t *testing.T) {
 	}
 	if _, err := mergedCatalog(spec); err == nil {
 		t.Fatal("mergedCatalog unexpectedly accepted contract violation")
+	}
+}
+
+func TestMergedCatalogPreservesBuiltInVideoFlags(t *testing.T) {
+	spec, err := decodeSpec([]byte(
+		`{"models":[{"name":"MiniMax-H3","kind":"video","capabilities":{"inputs":["text"],"outputs":["video"]}}]}`,
+	))
+	if err != nil {
+		t.Fatalf("decodeSpec: %v", err)
+	}
+	models, err := mergedCatalog(spec)
+	if err != nil {
+		t.Fatalf("mergedCatalog: %v", err)
+	}
+	if entry := models["MiniMax-H3"]; !entry.videoV2 {
+		t.Fatal("redeclared MiniMax-H3 lost the v2 flag")
+	}
+
+	spec, err = decodeSpec([]byte(
+		`{"models":[{"name":"MiniMax-Hailuo-02","kind":"video","capabilities":{"inputs":["text","image"],"outputs":["video"]}}]}`,
+	))
+	if err != nil {
+		t.Fatalf("decodeSpec: %v", err)
+	}
+	models, err = mergedCatalog(spec)
+	if err != nil {
+		t.Fatalf("mergedCatalog: %v", err)
+	}
+	entry := models["MiniMax-Hailuo-02"]
+	if !entry.video10s || !entry.videoHD || !entry.video512P || !entry.videoLastFrame {
+		t.Fatalf("redeclared MiniMax-Hailuo-02 flags = %+v", entry)
+	}
+
+	spec, err = decodeSpec([]byte(
+		`{"models":[{"name":"MiniMax-H3-Context-IR","kind":"context_ir","capabilities":{"inputs":["text"],"outputs":["text"]}}]}`,
+	))
+	if err != nil {
+		t.Fatalf("decodeSpec: %v", err)
+	}
+	models, err = mergedCatalog(spec)
+	if err != nil {
+		t.Fatalf("mergedCatalog: %v", err)
+	}
+	if entry := models["MiniMax-H3-Context-IR"]; entry.wireModel != "MiniMax-H3" {
+		t.Fatalf("redeclared Context-IR wireModel = %q, want MiniMax-H3", entry.wireModel)
 	}
 }

--- a/driver/minimax/context_ir.go
+++ b/driver/minimax/context_ir.go
@@ -1,0 +1,294 @@
+package minimax
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/GizClaw/flowcraft/core/inference"
+	"github.com/GizClaw/flowcraft/core/message"
+)
+
+// H3-Context-IR runs on the same v2 async task pipeline as video
+// generation, but its output is a text artifact: the task deeply
+// understands the multimodal context and returns a structured, richer
+// video prompt (task_type=h3_context_ir, modality=text). It never creates
+// a video. The content input, duration, ratio, and callback_url semantics
+// are identical to the v2 video API, so the compiler shares the content
+// role mapping (compileV2Inputs) and the transport shares the poll loop
+// (pollV2Task); only the create endpoint and the succeeded content field
+// differ.
+//
+// The canonical surface is a TextIntent — the enhanced prompt is the
+// requested output. The target video's duration and ratio have no
+// canonical intent home, so they ride the ContextIROptions extension;
+// both default like the video API does (6s; 16:9 for text-only tasks,
+// adaptive otherwise).
+
+type contextIRWire struct {
+	model  string
+	prompt string
+	v2Content
+	duration    int // seconds; default 6
+	ratio       string
+	callbackURL string
+}
+
+type contextIRRaw struct {
+	prompt       string
+	inputTokens  int64
+	outputTokens int64
+	totalTokens  int64
+	requestID    string
+}
+
+func compileContextIR(
+	endpoint string,
+	entry catalogEntry,
+) inference.GenerateCompiler[contextIRWire] {
+	return func(
+		_ context.Context,
+		model inference.ModelRef,
+		request inference.GenerateRequest,
+		shape inference.GenerateExecutionShape,
+	) (inference.Compiled[contextIRWire], error) {
+		ledger := newLedger(
+			inference.OperationGenerate,
+			request.ActiveFieldsFor(shape),
+		)
+		wire := contextIRWire{model: endpoint}
+		if shape == inference.GenerateExecutionStream {
+			ledger.reject(
+				inference.FieldGenerateExecutionStream,
+				"context-IR is a unary task on this provider",
+			)
+		}
+
+		prompt, images, videos, audios := collectTaskParts(request, ledger)
+		wire.prompt = strings.Join(prompt, "\n")
+		compileV2Inputs(&wire.v2Content, images, videos, audios, ledger)
+		rejectPromptLength(
+			request,
+			ledger,
+			len(wire.prompt),
+			7000,
+			fmt.Sprintf("MiniMax-H3 prompts are at most 7000 characters, not %d", len(wire.prompt)),
+		)
+		if wire.prompt == "" {
+			reason := fmt.Sprintf("%s requires a non-empty text prompt", endpoint)
+			if len(prompt) > 0 {
+				ledger.reject(inference.FieldGenerateInputText, reason)
+			} else if intent := request.Input.Content.Intent; intent.Text != nil {
+				ledger.reject(inference.FieldGenerateIntentText, reason)
+			} else {
+				ledger.reject(inference.FieldGenerateInputRole, reason)
+			}
+		}
+
+		intent := request.Input.Content.Intent
+		if text := intent.Text; text != nil {
+			// Context-IR has no tool, sampling, token-cap, or response
+			// shaping controls: the output is one fixed enhanced prompt.
+			rejectTextControls(text, ledger,
+				"context-IR tasks do not call tools",
+				"context-IR has no sampling controls",
+				"context-IR has no thinking control",
+			)
+			if text.MaxOutputTokens != nil {
+				ledger.reject(
+					inference.FieldGenerateIntentTextMaxOutputTokens,
+					"context-IR returns a fixed enhanced prompt; no token cap applies",
+				)
+			}
+			if text.Response != nil {
+				ledger.reject(
+					inference.FieldGenerateIntentTextResponse,
+					"context-IR returns a plain enhanced prompt",
+				)
+			}
+		}
+		if intent.Image != nil {
+			ledger.reject(
+				inference.FieldGenerateIntentImage,
+				"context-IR returns an enhanced prompt, not an image",
+			)
+		}
+		if intent.Audio != nil {
+			ledger.reject(
+				inference.FieldGenerateIntentAudio,
+				"context-IR returns an enhanced prompt, not audio",
+			)
+		}
+		if intent.Video != nil {
+			ledger.reject(
+				inference.FieldGenerateIntentVideo,
+				"context-IR returns an enhanced prompt, not a video; use the Hailuo/H3 video models to generate",
+			)
+		}
+		if intent.Text == nil {
+			ledger.reject(
+				inference.FieldGenerateInputRole,
+				"context-IR requires the text output intent; it returns an enhanced prompt",
+			)
+		}
+
+		options, other := operationExtensions[ContextIROptions](request.Extensions)
+		compileContextIROptions(&wire, options, endpoint, ledger)
+		rejectOtherExtensions("context-IR", other, ledger)
+
+		report := ledger.report()
+		if len(ledger.order) > 0 {
+			return inference.Compiled[contextIRWire]{Report: report}, ledger.err()
+		}
+		return inference.Compiled[contextIRWire]{Wire: wire, Report: report}, nil
+	}
+}
+
+// compileContextIROptions lowers ContextIROptions onto the wire and
+// enforces the target-video constraints shared with the v2 video API.
+func compileContextIROptions(
+	wire *contextIRWire,
+	options ContextIROptions,
+	endpoint string,
+	ledger *ledger,
+) {
+	field := func(name string) inference.FieldID {
+		return inference.ExtensionField(name).Qualify(options)
+	}
+	wire.callbackURL = options.CallbackURL
+	// The schema requires duration; the driver defaults to the same 6s
+	// the v2 video API uses when the caller leaves it open.
+	wire.duration = 6
+	if options.DurationMillis != nil {
+		millis := *options.DurationMillis
+		if millis%1000 != 0 {
+			ledger.reject(
+				field("duration_millis"),
+				fmt.Sprintf("minimax durations are whole seconds, not %dms", millis),
+			)
+		} else {
+			seconds := int(millis / 1000)
+			if seconds < 4 || seconds > 15 {
+				ledger.reject(
+					field("duration_millis"),
+					fmt.Sprintf("MiniMax-H3 durations are 4-15s, not %ds", seconds),
+				)
+			} else {
+				wire.duration = seconds
+			}
+		}
+	}
+	if options.Ratio != "" {
+		if !v2RatioValues[options.Ratio] {
+			ledger.reject(
+				field("ratio"),
+				fmt.Sprintf(
+					"MiniMax-H3 ratios are adaptive/21:9/16:9/4:3/1:1/3:4/9:16, not %q",
+					options.Ratio,
+				),
+			)
+		} else {
+			wire.ratio = options.Ratio
+		}
+	} else if v2TextOnly(&wire.v2Content) {
+		// Text-only tasks require an explicit non-adaptive ratio; 16:9 is
+		// the driver default, mirroring the video compiler.
+		wire.ratio = "16:9"
+	}
+	if wire.ratio == "adaptive" && v2TextOnly(&wire.v2Content) {
+		ledger.reject(
+			field("ratio"),
+			"text-only context-IR requires an explicit ratio; adaptive is not allowed",
+		)
+	}
+}
+
+func transportContextIR(
+	client *mediaClient,
+	pollInterval time.Duration,
+) inference.Transport[contextIRWire, contextIRRaw] {
+	return func(ctx context.Context, wire contextIRWire) (contextIRRaw, error) {
+		request := map[string]any{
+			"model":    wire.model,
+			"content":  v2ContentItems(wire.prompt, wire.v2Content),
+			"duration": wire.duration,
+		}
+		if wire.ratio != "" {
+			request["ratio"] = wire.ratio
+		}
+		if wire.callbackURL != "" {
+			request["callback_url"] = wire.callbackURL
+		}
+
+		var created videoV2CreateResponse
+		if err := client.postJSON(ctx, "/v2/h3_context_ir", request, &created); err != nil {
+			return contextIRRaw{}, err
+		}
+		if created.TaskID == "" {
+			return contextIRRaw{}, fmt.Errorf(
+				"minimax: context-IR task creation returned no task_id",
+			)
+		}
+		task, err := pollV2Task(ctx, client, created.TaskID, pollInterval)
+		if err != nil {
+			return contextIRRaw{}, err
+		}
+		if task.prompt == "" {
+			return contextIRRaw{}, fmt.Errorf(
+				"minimax: succeeded context-IR task %q carries no prompt",
+				created.TaskID,
+			)
+		}
+		return contextIRRaw{
+			prompt:       task.prompt,
+			inputTokens:  task.usage.inputTokens,
+			outputTokens: task.usage.outputTokens,
+			totalTokens:  task.usage.totalTokens,
+			requestID:    task.id,
+		}, nil
+	}
+}
+
+func decodeContextIR(
+	_ context.Context,
+	raw contextIRRaw,
+) (inference.GenerateResponse, error) {
+	if raw.prompt == "" {
+		return inference.GenerateResponse{}, fmt.Errorf(
+			"minimax: context-IR task returned no prompt",
+		)
+	}
+	return inference.GenerateResponse{
+		Message: message.Message{
+			Role: message.RoleAssistant,
+			Content: message.Content{
+				Parts: []message.Part{message.TextPart{Text: raw.prompt}},
+			},
+		},
+		FinishReason: inference.FinishCompleted,
+		Usage: inference.Usage{
+			InputTokens:  raw.inputTokens,
+			OutputTokens: raw.outputTokens,
+			TotalTokens:  raw.totalTokens,
+		},
+		Metadata: inference.Metadata{RequestID: raw.requestID},
+	}, nil
+}
+
+func openContextIR(
+	cls *clients,
+	spec Spec,
+	entry catalogEntry,
+	id inference.ModelID,
+) (inference.GenerateOperations, error) {
+	unary, err := inference.BindGenerate(
+		compileContextIR(wireModel(id.Name, entry), entry),
+		transportContextIR(cls.media, spec.videoPollInterval()),
+		decodeContextIR,
+	)
+	if err != nil {
+		return inference.GenerateOperations{}, err
+	}
+	return inference.GenerateOperations{Unary: unary}, nil
+}

--- a/driver/minimax/context_ir_test.go
+++ b/driver/minimax/context_ir_test.go
@@ -1,0 +1,487 @@
+package minimax
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/GizClaw/flowcraft/core/inference"
+	"github.com/GizClaw/flowcraft/core/message"
+)
+
+func contextIRRequest(
+	parts []message.Part,
+	options ContextIROptions,
+) inference.GenerateRequest {
+	var extensions inference.Extensions
+	extensions = append(extensions, options)
+	return inference.GenerateRequest{
+		Input: inference.GenerateInput{
+			Role: inference.InputRoleUser,
+			Content: inference.InputContent{
+				Content: message.Content{Parts: parts},
+				Intent:  inference.Intent{Text: &inference.TextIntent{}},
+			},
+		},
+		Extensions: extensions,
+	}
+}
+
+func compileContextIRWire(
+	t *testing.T,
+	model string,
+	request inference.GenerateRequest,
+) (contextIRWire, inference.CompileReport, error) {
+	t.Helper()
+	entry, ok := catalog[model]
+	if !ok {
+		t.Fatalf("catalog model %q missing", model)
+	}
+	compiled, err := compileContextIR(wireModel(model, entry), entry)(
+		context.Background(),
+		inference.ModelRef{ID: inference.ModelID{Provider: driverID, Name: model}},
+		request,
+		inference.GenerateExecutionUnary,
+	)
+	if err != nil {
+		return contextIRWire{}, compiled.Report, err
+	}
+	return compiled.Wire, compiled.Report, nil
+}
+
+func contextIRField(name string) inference.FieldID {
+	return inference.ExtensionField(name).Qualify(ContextIROptions{})
+}
+
+func TestCompileContextIRDefaults(t *testing.T) {
+	request := contextIRRequest(
+		[]message.Part{message.TextPart{Text: "a boy playing basketball"}},
+		ContextIROptions{},
+	)
+	wire, report, err := compileContextIRWire(t, "MiniMax-H3-Context-IR", request)
+	if err != nil {
+		t.Fatalf("compile: %v; report = %+v", err, report)
+	}
+	if wire.model != "MiniMax-H3" {
+		t.Fatalf("wire.model = %q, want MiniMax-H3", wire.model)
+	}
+	if wire.prompt != "a boy playing basketball" {
+		t.Fatalf("wire.prompt = %q", wire.prompt)
+	}
+	if wire.duration != 6 {
+		t.Fatalf("wire.duration = %d, want 6", wire.duration)
+	}
+	if wire.ratio != "16:9" {
+		t.Fatalf("wire.ratio = %q, want 16:9", wire.ratio)
+	}
+}
+
+func TestCompileContextIROptions(t *testing.T) {
+	fiveSeconds := int64(5_000)
+	request := contextIRRequest(
+		[]message.Part{message.TextPart{Text: "a cinematic scene"}},
+		ContextIROptions{
+			DurationMillis: &fiveSeconds,
+			Ratio:          "21:9",
+			CallbackURL:    "https://example.com/callback",
+		},
+	)
+	wire, report, err := compileContextIRWire(t, "MiniMax-H3-Context-IR", request)
+	if err != nil {
+		t.Fatalf("compile: %v; report = %+v", err, report)
+	}
+	if wire.duration != 5 || wire.ratio != "21:9" ||
+		wire.callbackURL != "https://example.com/callback" {
+		t.Fatalf("wire = %+v", wire)
+	}
+}
+
+func TestCompileContextIRGatesOptions(t *testing.T) {
+	threeSeconds := int64(3_000)
+	sixteenSeconds := int64(16_000)
+	fractional := int64(1_500)
+	adaptive := "adaptive"
+
+	cases := []struct {
+		name    string
+		options ContextIROptions
+		parts   []message.Part
+		field   inference.FieldID
+		reason  string
+	}{
+		{
+			name:    "duration below minimum",
+			options: ContextIROptions{DurationMillis: &threeSeconds},
+			field:   contextIRField("duration_millis"),
+			reason:  "4-15s",
+		},
+		{
+			name:    "duration above maximum",
+			options: ContextIROptions{DurationMillis: &sixteenSeconds},
+			field:   contextIRField("duration_millis"),
+			reason:  "4-15s",
+		},
+		{
+			name:    "fractional duration",
+			options: ContextIROptions{DurationMillis: &fractional},
+			field:   contextIRField("duration_millis"),
+			reason:  "whole seconds",
+		},
+		{
+			name:    "ratio outside official set",
+			options: ContextIROptions{Ratio: "2:1"},
+			field:   contextIRField("ratio"),
+			reason:  "ratios are adaptive",
+		},
+		{
+			name:    "adaptive ratio on text-only task",
+			options: ContextIROptions{Ratio: adaptive},
+			field:   contextIRField("ratio"),
+			reason:  "explicit ratio",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			parts := tc.parts
+			if parts == nil {
+				parts = []message.Part{message.TextPart{Text: "a cinematic scene"}}
+			}
+			_, report, err := compileContextIRWire(
+				t,
+				"MiniMax-H3-Context-IR",
+				contextIRRequest(parts, tc.options),
+			)
+			if err == nil {
+				t.Fatalf("compile unexpectedly succeeded; report = %+v", report)
+			}
+			reason := rejectedReason(report, tc.field)
+			if reason == "" {
+				t.Fatalf("field %q not rejected; report = %+v", tc.field, report)
+			}
+			if !strings.Contains(reason, tc.reason) {
+				t.Errorf("rejection reason = %q, want substring %q", reason, tc.reason)
+			}
+		})
+	}
+
+	t.Run("adaptive ratio accepted with image input", func(t *testing.T) {
+		wire, report, err := compileContextIRWire(
+			t,
+			"MiniMax-H3-Context-IR",
+			contextIRRequest(
+				[]message.Part{
+					message.TextPart{Text: "a scene"},
+					videoImagePart(t, "https://example.com/a.png"),
+				},
+				ContextIROptions{Ratio: adaptive},
+			),
+		)
+		if err != nil {
+			t.Fatalf("compile: %v; report = %+v", err, report)
+		}
+		if wire.ratio != "adaptive" || wire.firstFrame != "https://example.com/a.png" {
+			t.Fatalf("wire = %+v", wire)
+		}
+	})
+}
+
+func TestCompileContextIRInputs(t *testing.T) {
+	rejected := []struct {
+		name   string
+		parts  []message.Part
+		field  inference.FieldID
+		reason string
+	}{
+		{
+			name: "first/last frame mixed with reference inputs",
+			parts: []message.Part{
+				videoImagePart(t, "https://example.com/a.png"),
+				videoImagePart(t, "https://example.com/b.png"),
+				videoClipPart(t, "https://example.com/clip.mp4"),
+			},
+			field:  inference.FieldGenerateInputImage,
+			reason: "mutually exclusive",
+		},
+		{
+			name: "too many reference images",
+			parts: func() []message.Part {
+				parts := make([]message.Part, 0, 11)
+				for i := 0; i < 10; i++ {
+					parts = append(parts, videoImagePart(t, "https://example.com/x.png"))
+				}
+				return parts
+			}(),
+			field:  inference.FieldGenerateInputImage,
+			reason: "at most 9",
+		},
+		{
+			name:   "missing text prompt",
+			parts:  []message.Part{},
+			field:  inference.FieldGenerateIntentText,
+			reason: "non-empty text prompt",
+		},
+	}
+	for _, tc := range rejected {
+		t.Run(tc.name, func(t *testing.T) {
+			parts := tc.parts
+			if parts == nil {
+				parts = []message.Part{}
+			}
+			_, report, err := compileContextIRWire(
+				t,
+				"MiniMax-H3-Context-IR",
+				contextIRRequest(parts, ContextIROptions{}),
+			)
+			if err == nil {
+				t.Fatalf("compile unexpectedly succeeded; report = %+v", report)
+			}
+			reason := rejectedReason(report, tc.field)
+			if reason == "" {
+				t.Fatalf("field %q not rejected; report = %+v", tc.field, report)
+			}
+			if !strings.Contains(reason, tc.reason) {
+				t.Errorf("rejection reason = %q, want substring %q", reason, tc.reason)
+			}
+		})
+	}
+
+	t.Run("first and last frame map onto content", func(t *testing.T) {
+		wire, report, err := compileContextIRWire(
+			t,
+			"MiniMax-H3-Context-IR",
+			contextIRRequest(
+				[]message.Part{
+					message.TextPart{Text: "a scene"},
+					videoImagePart(t, "https://example.com/a.png"),
+					videoImagePart(t, "https://example.com/b.png"),
+				},
+				ContextIROptions{},
+			),
+		)
+		if err != nil {
+			t.Fatalf("compile: %v; report = %+v", err, report)
+		}
+		if wire.firstFrame != "https://example.com/a.png" ||
+			wire.lastFrame != "https://example.com/b.png" {
+			t.Fatalf("frames = %q / %q", wire.firstFrame, wire.lastFrame)
+		}
+	})
+}
+
+func TestCompileContextIRPromptLength(t *testing.T) {
+	request := contextIRRequest(
+		[]message.Part{message.TextPart{Text: strings.Repeat("a", 7001)}},
+		ContextIROptions{},
+	)
+	_, report, err := compileContextIRWire(t, "MiniMax-H3-Context-IR", request)
+	if err == nil {
+		t.Fatalf("compile unexpectedly succeeded; report = %+v", report)
+	}
+	reason := rejectedReason(report, inference.FieldGenerateInputText)
+	if !strings.Contains(reason, "at most 7000 characters") {
+		t.Errorf("rejection reason = %q", reason)
+	}
+
+	request = contextIRRequest(
+		[]message.Part{message.TextPart{Text: strings.Repeat("a", 7000)}},
+		ContextIROptions{},
+	)
+	if _, report, err := compileContextIRWire(t, "MiniMax-H3-Context-IR", request); err != nil {
+		t.Fatalf("7000-char prompt rejected: %v; report = %+v", err, report)
+	}
+}
+
+func TestCompileContextIRIntents(t *testing.T) {
+	temperature := 0.7
+	maxTokens := 100
+	callback := "https://example.com/callback"
+	parts := []message.Part{message.TextPart{Text: "a cinematic scene"}}
+
+	cases := []struct {
+		name    string
+		request inference.GenerateRequest
+		field   inference.FieldID
+		reason  string
+	}{
+		{
+			name: "video intent rejected",
+			request: func() inference.GenerateRequest {
+				request := contextIRRequest(parts, ContextIROptions{})
+				request.Input.Content.Intent = inference.Intent{Video: &inference.VideoIntent{}}
+				return request
+			}(),
+			field:  inference.FieldGenerateIntentVideo,
+			reason: "not a video",
+		},
+		{
+			name: "image intent rejected",
+			request: func() inference.GenerateRequest {
+				request := contextIRRequest(parts, ContextIROptions{})
+				request.Input.Content.Intent = inference.Intent{Image: &inference.ImageIntent{}}
+				return request
+			}(),
+			field:  inference.FieldGenerateIntentImage,
+			reason: "not an image",
+		},
+		{
+			name: "audio intent rejected",
+			request: func() inference.GenerateRequest {
+				request := contextIRRequest(parts, ContextIROptions{})
+				request.Input.Content.Intent = inference.Intent{Audio: &inference.AudioIntent{}}
+				return request
+			}(),
+			field:  inference.FieldGenerateIntentAudio,
+			reason: "not audio",
+		},
+		{
+			name: "sampling control rejected",
+			request: func() inference.GenerateRequest {
+				request := contextIRRequest(parts, ContextIROptions{})
+				request.Input.Content.Intent.Text.Temperature = &temperature
+				return request
+			}(),
+			field:  inference.FieldGenerateIntentTemperature,
+			reason: "no sampling controls",
+		},
+		{
+			name: "token cap rejected",
+			request: func() inference.GenerateRequest {
+				request := contextIRRequest(parts, ContextIROptions{})
+				request.Input.Content.Intent.Text.MaxOutputTokens = &maxTokens
+				return request
+			}(),
+			field:  inference.FieldGenerateIntentTextMaxOutputTokens,
+			reason: "no token cap",
+		},
+		{
+			name: "response shaping rejected",
+			request: func() inference.GenerateRequest {
+				request := contextIRRequest(parts, ContextIROptions{})
+				request.Input.Content.Intent.Text.Response = &inference.ResponseFormat{
+					Kind: inference.ResponseJSONObject,
+				}
+				return request
+			}(),
+			field:  inference.FieldGenerateIntentTextResponse,
+			reason: "plain enhanced prompt",
+		},
+		{
+			name: "video options extension rejected",
+			request: func() inference.GenerateRequest {
+				request := contextIRRequest(parts, ContextIROptions{})
+				request.Extensions = append(request.Extensions,
+					VideoOptions{CallbackURL: callback})
+				return request
+			}(),
+			field:  videoOptionsField("callback_url"),
+			reason: "does not consume video_options",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, report, err := compileContextIRWire(t, "MiniMax-H3-Context-IR", tc.request)
+			if err == nil {
+				t.Fatalf("compile unexpectedly succeeded; report = %+v", report)
+			}
+			reason := rejectedReason(report, tc.field)
+			if reason == "" {
+				t.Fatalf("field %q not rejected; report = %+v", tc.field, report)
+			}
+			if !strings.Contains(reason, tc.reason) {
+				t.Errorf("rejection reason = %q, want substring %q", reason, tc.reason)
+			}
+		})
+	}
+}
+
+func TestTransportContextIR(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		writer.Header().Set("Content-Type", "application/json")
+		switch {
+		case request.Method == http.MethodPost && request.URL.Path == "/v2/h3_context_ir":
+			var body map[string]any
+			if err := json.NewDecoder(request.Body).Decode(&body); err != nil {
+				t.Errorf("decode create body: %v", err)
+			}
+			if body["model"] != "MiniMax-H3" ||
+				body["duration"] != float64(5) ||
+				body["ratio"] != "21:9" ||
+				body["callback_url"] != "https://example.com/callback" {
+				t.Errorf("create body = %#v", body)
+			}
+			content, ok := body["content"].([]any)
+			if !ok || len(content) != 2 {
+				t.Fatalf("content = %#v", body["content"])
+			}
+			text := content[0].(map[string]any)
+			image := content[1].(map[string]any)
+			if text["type"] != "text" || text["text"] != "a scene" ||
+				image["type"] != "image_url" || image["role"] != "first_frame" {
+				t.Errorf("content items = %#v / %#v", text, image)
+			}
+			_, _ = io.WriteString(writer, `{"task_id":"t-ir"}`)
+		case request.Method == http.MethodGet &&
+			request.URL.Path == "/v2/query/video_generation/t-ir":
+			_, _ = io.WriteString(writer, `{
+				"task": {
+					"id": "t-ir",
+					"status": "succeeded",
+					"content": {"prompt": "integrated_multimodal_description: [Shot 1] wide shot"},
+					"usage": {"total_tokens": 100, "prompt_tokens": 40, "completion_tokens": 60}
+				}
+			}`)
+		default:
+			t.Errorf("unexpected request %s %s", request.Method, request.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	client := newMediaClient("sk-test", server.URL, Spec{})
+	raw, err := transportContextIR(client, time.Millisecond)(context.Background(), contextIRWire{
+		model:    "MiniMax-H3",
+		prompt:   "a scene",
+		duration: 5,
+		ratio:    "21:9",
+		v2Content: v2Content{
+			firstFrame: "https://example.com/a.png",
+		},
+		callbackURL: "https://example.com/callback",
+	})
+	if err != nil {
+		t.Fatalf("transport: %v", err)
+	}
+	if !strings.Contains(raw.prompt, "[Shot 1]") ||
+		raw.inputTokens != 40 || raw.outputTokens != 60 ||
+		raw.totalTokens != 100 || raw.requestID != "t-ir" {
+		t.Fatalf("raw = %+v", raw)
+	}
+}
+
+func TestTransportContextIRRequiresPrompt(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		writer.Header().Set("Content-Type", "application/json")
+		switch request.Method {
+		case http.MethodPost:
+			_, _ = io.WriteString(writer, `{"task_id":"t-ir"}`)
+		case http.MethodGet:
+			_, _ = io.WriteString(writer,
+				`{"task":{"id":"t-ir","status":"succeeded","content":{}}}`)
+		}
+	}))
+	defer server.Close()
+
+	client := newMediaClient("sk-test", server.URL, Spec{})
+	_, err := transportContextIR(client, time.Millisecond)(context.Background(), contextIRWire{
+		model:    "MiniMax-H3",
+		prompt:   "a scene",
+		duration: 6,
+	})
+	if err == nil || !strings.Contains(err.Error(), "carries no prompt") {
+		t.Fatalf("err = %v, want missing-prompt error", err)
+	}
+}

--- a/driver/minimax/doc.go
+++ b/driver/minimax/doc.go
@@ -32,9 +32,13 @@
 //     HD and turbo tiers), unary hex payloads and SSE hex streaming.
 //   - Generate ImageIntent: image_generation (image-01, image-01-live),
 //     unary; URL deliveries expire after 24 hours on the provider side.
-//   - Generate VideoIntent: the async video task pipeline
-//     (MiniMax-Hailuo-2.3, 2.3-Fast, 02) — create, poll, retrieve; the
-//     download URL expires one hour after retrieval.
+//   - Generate VideoIntent: the async video task pipeline. The Hailuo
+//     2.3/2.3-Fast/02 trio rides the v1 API (create, poll, retrieve; the
+//     download URL expires one hour after retrieval); MiniMax-H3 rides the
+//     v2 API and returns the artifact URL from the query directly.
+//   - Generate TextIntent on MiniMax-H3-Context-IR: the v2 H3-Context-IR
+//     task returns an enhanced video prompt (text), never a video. The
+//     target duration/ratio ride the ContextIROptions extension.
 //   - Generate AudioIntent without a voice: music_generation
 //     (music-3.0/2.6 and their -free tiers). The canonical voice is
 //     optional: speech models require one, music models reject one.
@@ -48,8 +52,9 @@
 // 2026-07: MiniMax-M3 (1M context, image input) and the M2.x series
 // (M2.7, M2.5, M2.1 and their highspeed twins, plus M2 — 204,800
 // context, text-only), the speech-2.8/2.6/02 speech models, image-01 and
-// image-01-live, the Hailuo video trio, and the music-3.0/2.6 music
-// models. Custom models declare
+// image-01-live, the Hailuo video trio plus MiniMax-H3, the
+// MiniMax-H3-Context-IR prompt-enhancement task, and the music-3.0/2.6
+// music models. Custom models declare
 // through the spec's models list; unknown channels stay fail closed.
 //
 // # Behavior mapping
@@ -81,9 +86,20 @@
 //     Image parts compile into character subject references
 //     (image-to-image); custom sizes must be 512–2048 and divisible
 //     by 8.
-//   - Video durations are model-bound: 6s everywhere, 10s at 768P on
-//     the Hailuo-2.3/02 pair; Hailuo-2.3-Fast is image-to-video only.
-//     The task API has no aspect-ratio or seed knob — both reject.
+//   - Video durations are model-bound. The Hailuo trio serves 6s, and 10s
+//     at 768P on the 2.3/2.3-Fast/02 models; Hailuo-2.3-Fast is
+//     image-to-video only, and Hailuo-02 adds 512P (single-first-frame
+//     image-to-video only; first/last-frame tasks cap at 768P/1080P) and
+//     first/last-frame input. MiniMax-H3 rides the v2 API: 4-15s
+//     durations, 768P/2K, a ratio knob (text-only tasks default to 16:9
+//     and reject adaptive), and multimodal reference inputs. The v1-only
+//     prompt_optimizer / fast_pretreatment controls and the shared
+//     callback_url ride the VideoOptions extension, which also carries
+//     last_frame_only to mark a single v2 input image as the closing
+//     frame. The task APIs have no seed knob — it rejects.
+//   - H3-Context-IR shares the v2 content roles and the 4-15s duration /
+//     ratio rules, but returns an enhanced video prompt as text; the
+//     target duration/ratio ride ContextIROptions.
 //   - Music encodes mp3 or 16-bit pcm at 16/24/32/44.1kHz; bitrate and
 //     channel layout are model-fixed, so those canonical knobs reject.
 //     Speech synthesis requires a voice; music generation requires none.

--- a/driver/minimax/extensions.go
+++ b/driver/minimax/extensions.go
@@ -2,6 +2,7 @@ package minimax
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/GizClaw/flowcraft/core/inference"
 )
@@ -22,6 +23,10 @@ import (
 const driverID = "minimax"
 
 const extensionMusic = "music_options"
+
+const extensionVideo = "video_options"
+
+const extensionContextIR = "context_ir_options"
 
 // extensionProvider resolves the deployment provider ID an extension targets,
 // defaulting to the driver name.
@@ -85,6 +90,128 @@ func (o MusicOptions) Validate() error {
 func (o MusicOptions) Clone() inference.Extension {
 	o.Instrumental = clonePointer(o.Instrumental)
 	o.Watermark = clonePointer(o.Watermark)
+	return o
+}
+
+// VideoOptions carries video task settings that have no canonical
+// representation. callback_url applies to both API generations;
+// prompt_optimizer and fast_pretreatment are v1-only prompt controls —
+// the v2 API has no optimizer knobs, so those fields reject on
+// MiniMax-H3.
+type VideoOptions struct {
+	// Provider targets a deployment provider ID other than "minimax".
+	// Attempts for any other provider leave the extension inert rather
+	// than rejecting it, so mixed-provider routes keep working.
+	Provider string `json:"-"`
+	// CallbackURL receives asynchronous task status updates after a
+	// challenge handshake; the driver still polls as its primary path.
+	CallbackURL string `json:"callback_url,omitempty"`
+	// PromptOptimizer asks the provider to rewrite the prompt before
+	// generation (v1 API only; defaults to true server-side).
+	PromptOptimizer *bool `json:"prompt_optimizer,omitempty"`
+	// FastPretreatment shortens the optimizer's rewrite time (v1 API
+	// only; applies to the Hailuo 2.3/2.3-Fast/02 models).
+	FastPretreatment *bool `json:"fast_pretreatment,omitempty"`
+	// LastFrameOnly marks a single input image as the closing frame
+	// (role=last_frame) instead of the opening one. v2 API only; requires
+	// exactly one image — the official last-frame-only i2v scenario.
+	LastFrameOnly *bool `json:"last_frame_only,omitempty"`
+}
+
+func (o VideoOptions) ProviderID() string  { return extensionProvider(o.Provider) }
+func (o VideoOptions) ExtensionID() string { return extensionVideo }
+
+func (o VideoOptions) ActiveFields() []inference.ExtensionField {
+	var fields []inference.ExtensionField
+	if o.CallbackURL != "" {
+		fields = append(fields, "callback_url")
+	}
+	if o.PromptOptimizer != nil {
+		fields = append(fields, "prompt_optimizer")
+	}
+	if o.FastPretreatment != nil {
+		fields = append(fields, "fast_pretreatment")
+	}
+	if o.LastFrameOnly != nil {
+		fields = append(fields, "last_frame_only")
+	}
+	return fields
+}
+
+func (o VideoOptions) Validate() error {
+	if o.CallbackURL != "" &&
+		!strings.HasPrefix(o.CallbackURL, "https://") &&
+		!strings.HasPrefix(o.CallbackURL, "http://") {
+		return fmt.Errorf("callback_url must be an http(s) URL")
+	}
+	return nil
+}
+
+func (o VideoOptions) Clone() inference.Extension {
+	o.PromptOptimizer = clonePointer(o.PromptOptimizer)
+	o.FastPretreatment = clonePointer(o.FastPretreatment)
+	o.LastFrameOnly = clonePointer(o.LastFrameOnly)
+	return o
+}
+
+// ContextIROptions carries H3-Context-IR task settings that have no
+// canonical representation. The target video's duration and ratio shape
+// the enhanced prompt, and callback_url receives async status updates;
+// the content itself rides the request's multimodal parts.
+type ContextIROptions struct {
+	// Provider targets a deployment provider ID other than "minimax".
+	// Attempts for any other provider leave the extension inert rather
+	// than rejecting it, so mixed-provider routes keep working.
+	Provider string `json:"-"`
+	// DurationMillis is the target video length; defaults to 6s, valid
+	// whole seconds within [4, 15].
+	DurationMillis *int64 `json:"duration_millis,omitempty"`
+	// Ratio is the target video's aspect ratio: adaptive/21:9/16:9/4:3/
+	// 1:1/3:4/9:16. Text-only tasks require an explicit non-adaptive
+	// ratio (default 16:9); image/reference tasks default to adaptive.
+	Ratio string `json:"ratio,omitempty"`
+	// CallbackURL receives asynchronous task status updates after a
+	// challenge handshake; the driver still polls as its primary path.
+	CallbackURL string `json:"callback_url,omitempty"`
+}
+
+func (o ContextIROptions) ProviderID() string  { return extensionProvider(o.Provider) }
+func (o ContextIROptions) ExtensionID() string { return extensionContextIR }
+
+func (o ContextIROptions) ActiveFields() []inference.ExtensionField {
+	var fields []inference.ExtensionField
+	if o.DurationMillis != nil {
+		fields = append(fields, "duration_millis")
+	}
+	if o.Ratio != "" {
+		fields = append(fields, "ratio")
+	}
+	if o.CallbackURL != "" {
+		fields = append(fields, "callback_url")
+	}
+	return fields
+}
+
+func (o ContextIROptions) Validate() error {
+	if o.DurationMillis != nil && *o.DurationMillis <= 0 {
+		return fmt.Errorf("duration_millis must be positive")
+	}
+	if o.Ratio != "" && !v2RatioValues[o.Ratio] {
+		return fmt.Errorf(
+			"ratio must be one of adaptive/21:9/16:9/4:3/1:1/3:4/9:16, not %q",
+			o.Ratio,
+		)
+	}
+	if o.CallbackURL != "" &&
+		!strings.HasPrefix(o.CallbackURL, "https://") &&
+		!strings.HasPrefix(o.CallbackURL, "http://") {
+		return fmt.Errorf("callback_url must be an http(s) URL")
+	}
+	return nil
+}
+
+func (o ContextIROptions) Clone() inference.Extension {
+	o.DurationMillis = clonePointer(o.DurationMillis)
 	return o
 }
 

--- a/driver/minimax/resource.go
+++ b/driver/minimax/resource.go
@@ -81,6 +81,12 @@ func buildProvider(settings ResourceSettings) (inference.ProviderDefinition, err
 			extensionMusic: inference.ExtensionDecoderFor(func() *MusicOptions {
 				return &MusicOptions{Provider: settings.ID}
 			}),
+			extensionVideo: inference.ExtensionDecoderFor(func() *VideoOptions {
+				return &VideoOptions{Provider: settings.ID}
+			}),
+			extensionContextIR: inference.ExtensionDecoderFor(func() *ContextIROptions {
+				return &ContextIROptions{Provider: settings.ID}
+			}),
 		},
 	}
 	for _, profile := range settings.Profiles {
@@ -140,6 +146,8 @@ func openersFor(
 			return openTTS(cls, entry, id)
 		case kindVideo:
 			return openVideo(cls, spec, entry, id)
+		case kindContextIR:
+			return openContextIR(cls, spec, entry, id)
 		case kindMusic:
 			return openMusic(cls, entry, id)
 		default:

--- a/driver/minimax/resource_test.go
+++ b/driver/minimax/resource_test.go
@@ -98,3 +98,78 @@ func TestProviderCarriesMusicOptionsDecoder(t *testing.T) {
 		t.Fatalf("ProviderID = %q, want %q", options.ProviderID(), "mm-prod")
 	}
 }
+
+func TestProviderCarriesVideoOptionsDecoder(t *testing.T) {
+	value, err := Factory().New(context.Background(), resource.Input{
+		Settings: json.RawMessage(`{
+			"id": "minimax",
+			"profiles": [{"id": "default", "secrets": {"api_key": "sk-test"}}]
+		}`),
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	provider := value.(inference.ProviderDefinition)
+	decoder, ok := provider.ExtensionDecoders[extensionVideo]
+	if !ok {
+		t.Fatalf("ExtensionDecoders = %#v, want %q", provider.ExtensionDecoders, extensionVideo)
+	}
+
+	extensions, err := inference.DecodeExtensions([]inference.ExtensionEntry{{
+		Provider: "minimax",
+		ID:       extensionVideo,
+		Fields: json.RawMessage(
+			`{"callback_url":"https://example.com/cb","prompt_optimizer":false,"last_frame_only":true}`,
+		),
+	}}, map[string]inference.ExtensionDecoder{
+		"minimax/" + extensionVideo: decoder,
+	}, "extensions")
+	if err != nil {
+		t.Fatalf("DecodeExtensions: %v", err)
+	}
+	options := extensions[0].(*VideoOptions)
+	if options.ProviderID() != "minimax" ||
+		options.CallbackURL != "https://example.com/cb" ||
+		options.PromptOptimizer == nil || *options.PromptOptimizer ||
+		options.LastFrameOnly == nil || !*options.LastFrameOnly {
+		t.Fatalf("decoded options = %#v", options)
+	}
+}
+
+func TestProviderCarriesContextIROptionsDecoder(t *testing.T) {
+	value, err := Factory().New(context.Background(), resource.Input{
+		Settings: json.RawMessage(`{
+			"id": "minimax",
+			"profiles": [{"id": "default", "secrets": {"api_key": "sk-test"}}]
+		}`),
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	provider := value.(inference.ProviderDefinition)
+	decoder, ok := provider.ExtensionDecoders[extensionContextIR]
+	if !ok {
+		t.Fatalf("ExtensionDecoders = %#v, want %q",
+			provider.ExtensionDecoders, extensionContextIR)
+	}
+
+	extensions, err := inference.DecodeExtensions([]inference.ExtensionEntry{{
+		Provider: "minimax",
+		ID:       extensionContextIR,
+		Fields: json.RawMessage(
+			`{"duration_millis":5000,"ratio":"16:9","callback_url":"https://example.com/cb"}`,
+		),
+	}}, map[string]inference.ExtensionDecoder{
+		"minimax/" + extensionContextIR: decoder,
+	}, "extensions")
+	if err != nil {
+		t.Fatalf("DecodeExtensions: %v", err)
+	}
+	options := extensions[0].(*ContextIROptions)
+	if options.ProviderID() != "minimax" ||
+		options.DurationMillis == nil || *options.DurationMillis != 5_000 ||
+		options.Ratio != "16:9" ||
+		options.CallbackURL != "https://example.com/cb" {
+		t.Fatalf("decoded options = %#v", options)
+	}
+}

--- a/driver/minimax/spec.go
+++ b/driver/minimax/spec.go
@@ -56,6 +56,7 @@ func (m ModelSpec) Validate() error {
 		modelKind(m.Kind) != kindImage &&
 		modelKind(m.Kind) != kindTTS &&
 		modelKind(m.Kind) != kindVideo &&
+		modelKind(m.Kind) != kindContextIR &&
 		modelKind(m.Kind) != kindMusic {
 		return fmt.Errorf("model %q declares unsupported kind %q", m.Name, m.Kind)
 	}

--- a/driver/minimax/video.go
+++ b/driver/minimax/video.go
@@ -2,6 +2,7 @@ package minimax
 
 import (
 	"context"
+	"encoding/base64"
 	"fmt"
 	"net/url"
 	"strings"
@@ -14,26 +15,67 @@ import (
 )
 
 // Video generation runs on MiniMax's async task pipeline: create the task,
-// poll its status, then retrieve the finished file's download URL. The
-// download URL expires one hour after retrieval, so the response carries it
-// verbatim — downloading and persisting is the caller's job. Durations are
-// model-bound (6s everywhere, 10s at 768P on the Hailuo-2.3/02 pair), and
-// the endpoint has no aspect-ratio or seed knob, so those intents reject.
-// Hailuo-2.3-Fast is image-to-video only: without a first-frame image the
-// compile rejects rather than letting the API invent one.
+// poll its status, then surface the finished artifact's URL. The download
+// URL expires one hour after retrieval, so the response carries it verbatim
+// — downloading and persisting is the caller's job.
+//
+// Two task APIs exist:
+//
+//   - v1 (/v1/video_generation) serves the Hailuo 2.3/2.3-Fast/02 trio with
+//     flat fields: prompt, first/last-frame images, duration (6s, or 10s at
+//     768P), resolution (768P/1080P; 512P for 02 image-to-video),
+//     aigc_watermark, and the prompt_optimizer / fast_pretreatment /
+//     callback_url knobs. There is no aspect-ratio or seed control, so
+//     those intents reject. Hailuo-2.3-Fast is image-to-video only.
+//
+//   - v2 (/v2/video_generation) serves MiniMax-H3 with a multimodal content
+//     array (text/image/video/audio items carrying first_frame/last_frame/
+//     reference_* roles), a required resolution (768P/2K) and duration
+//     (4-15s), an optional ratio (text-only tasks default to 16:9 and
+//     reject adaptive; image tasks default to adaptive server-side), and
+//     aigc_watermark/callback_url. Its query endpoint returns the artifact
+//     URL directly, so there is no file-retrieval hop. H3-Context-IR
+//     (context_ir.go) rides the same query endpoint and shares the content
+//     role mapping and poll loop.
+//
+// Inline media become data URIs carrying their source media type; absolute
+// URLs pass through verbatim.
+
+// v2Content holds the multimodal input roles both v2 task APIs understand:
+// first/last-frame images and reference image/video/audio items. The v2
+// video and H3-Context-IR compilers share it so the content mapping and
+// its limits stay in one place.
+type v2Content struct {
+	firstFrame      string
+	lastFrame       string
+	referenceImages []string
+	referenceVideos []string
+	referenceAudios []string
+}
 
 type videoWire struct {
-	model      string
-	prompt     string
-	firstFrame string
-	duration   int // seconds: 6 or 10
-	resolution string
-	watermark  *bool
+	model  string
+	prompt string
+	v2Content
+	duration         *int // seconds; nil = provider default (v1)
+	resolution       string
+	ratio            string
+	watermark        *bool
+	promptOptimizer  *bool // v1 only
+	fastPretreatment *bool // v1 only
+	callbackURL      string
 }
 
 type videoRaw struct {
 	videoURL  string
 	requestID string
+}
+
+// v2RatioValues are the official v2 ratio values. adaptive is the server
+// default for image/reference tasks and invalid for text-only tasks.
+var v2RatioValues = map[string]bool{
+	"adaptive": true, "21:9": true, "16:9": true, "4:3": true,
+	"1:1": true, "3:4": true, "9:16": true,
 }
 
 func compileVideo(
@@ -58,41 +100,32 @@ func compileVideo(
 			)
 		}
 
-		var prompt []string
-		collect := func(parts []message.Part, fields map[message.PartKind]inference.FieldID) {
-			for _, part := range parts {
-				switch value := part.(type) {
-				case message.TextPart:
-					prompt = append(prompt, value.Text)
-				case message.ImagePart:
-					if wire.firstFrame != "" {
-						ledger.reject(
-							fields[part.Kind()],
-							"video generation accepts a single first-frame image",
-						)
-						continue
-					}
-					wire.firstFrame = imageSourceValue(value.Source)
-				default:
-					ledger.reject(
-						fields[part.Kind()],
-						fmt.Sprintf("video generation accepts text and image parts, not %s", part.Kind()),
-					)
-				}
-			}
-		}
-		for _, turn := range request.Context {
-			if turn.Role != message.RoleUser {
-				ledger.reject(
-					inference.FieldGenerateContextRole,
-					"video generation keeps user context only; assistant, system, and tool turns have no native channel",
-				)
-				continue
-			}
-			collect(turn.Content.Parts, contextPartFields)
-		}
-		collect(request.Input.Content.Parts, inputPartFields)
+		prompt, images, videos, audios := collectTaskParts(request, ledger)
 		wire.prompt = strings.Join(prompt, "\n")
+
+		compileVideoInputs(&wire, images, videos, audios, entry, model, ledger)
+		limit, label := 2000, "minimax v1 prompts"
+		if entry.videoV2 {
+			limit, label = 7000, "MiniMax-H3 prompts"
+		}
+		rejectPromptLength(
+			request,
+			ledger,
+			len(wire.prompt),
+			limit,
+			fmt.Sprintf("%s are at most %d characters, not %d", label, limit, len(wire.prompt)),
+		)
+		if entry.videoV2 && wire.prompt == "" {
+			// The v2 schema requires a non-empty text item in content.
+			reason := fmt.Sprintf("%s requires a non-empty text prompt", endpoint)
+			if len(prompt) > 0 {
+				ledger.reject(inference.FieldGenerateInputText, reason)
+			} else if intent := request.Input.Content.Intent; intent.Video != nil {
+				ledger.reject(inference.FieldGenerateIntentVideo, reason)
+			} else {
+				ledger.reject(inference.FieldGenerateInputRole, reason)
+			}
+		}
 		if entry.videoI2VOnly && wire.firstFrame == "" {
 			// A missing first frame is a required-input absence, so no part
 			// field is active to reject; the rejection lands on the closest
@@ -134,75 +167,11 @@ func compileVideo(
 			)
 		}
 		if video := intent.Video; video != nil {
-			if video.DurationMillis != nil {
-				millis := *video.DurationMillis
-				switch {
-				case millis%1000 != 0:
-					ledger.reject(
-						inference.FieldGenerateIntentVideoDuration,
-						fmt.Sprintf("minimax video durations are whole seconds, not %dms", millis),
-					)
-				default:
-					seconds := int(millis / 1000)
-					switch {
-					case seconds == 6:
-						wire.duration = 6
-					case seconds == 10 && !entry.video10s:
-						ledger.reject(
-							inference.FieldGenerateIntentVideoDuration,
-							fmt.Sprintf("%s serves 6-second videos only", endpoint),
-						)
-					case seconds == 10:
-						wire.duration = 10
-					default:
-						ledger.reject(
-							inference.FieldGenerateIntentVideoDuration,
-							fmt.Sprintf("minimax video durations are 6s or 10s, not %ds", seconds),
-						)
-					}
-				}
-			}
-			if video.Resolution != "" {
-				switch strings.ToUpper(video.Resolution) {
-				case "768P":
-					wire.resolution = "768P"
-				case "1080P":
-					if !entry.videoHD {
-						ledger.reject(
-							inference.FieldGenerateIntentVideoResolution,
-							fmt.Sprintf("%s serves 768P only", endpoint),
-						)
-					} else {
-						wire.resolution = "1080P"
-					}
-				default:
-					ledger.reject(
-						inference.FieldGenerateIntentVideoResolution,
-						fmt.Sprintf("%s serves 768P/1080P tiers, not %q", endpoint, video.Resolution),
-					)
-				}
-			}
-			if wire.duration == 10 && wire.resolution == "1080P" {
-				ledger.reject(
-					inference.FieldGenerateIntentVideoDuration,
-					"10-second videos require 768P",
-				)
-			}
-			if video.AspectRatio != "" {
-				ledger.reject(
-					inference.FieldGenerateIntentVideoAspectRatio,
-					"the task API has no aspect-ratio control; resolution tiers are fixed-ratio",
-				)
-			}
-			if video.Seed != nil {
-				ledger.reject(
-					inference.FieldGenerateIntentVideoSeed,
-					"the task API has no seed control",
-				)
-			}
-			wire.watermark = video.Watermark
+			compileVideoIntent(&wire, video, entry, endpoint, ledger)
 		}
-		rejectOtherExtensions("video generation", request.Extensions, ledger)
+		options, other := operationExtensions[VideoOptions](request.Extensions)
+		compileVideoOptions(&wire, options, entry, endpoint, ledger)
+		rejectOtherExtensions("video generation", other, ledger)
 
 		report := ledger.report()
 		if len(ledger.order) > 0 {
@@ -212,13 +181,414 @@ func compileVideo(
 	}
 }
 
-// videoCreateResponse is the create-task envelope.
+// collectTaskParts gathers text/image/video/audio parts from the user
+// context turns and the request input, rendering media the way the task
+// APIs expect them (URL passthrough or data URIs). Non-media parts reject.
+// Both the video and H3-Context-IR compilers share it.
+func collectTaskParts(
+	request inference.GenerateRequest,
+	ledger *ledger,
+) (prompt []string, images, videos, audios []string) {
+	collect := func(parts []message.Part, fields map[message.PartKind]inference.FieldID) {
+		for _, part := range parts {
+			switch value := part.(type) {
+			case message.TextPart:
+				prompt = append(prompt, value.Text)
+			case message.ImagePart:
+				images = append(images, videoImageValue(value.Source))
+			case message.VideoPart:
+				videos = append(videos, videoSourceURI(value.Source))
+			case message.AudioPart:
+				audios = append(audios, audioSourceURI(value.Source))
+			default:
+				ledger.reject(
+					fields[part.Kind()],
+					fmt.Sprintf(
+						"the task accepts text, image, video, and audio parts, not %s",
+						part.Kind(),
+					),
+				)
+			}
+		}
+	}
+	for _, turn := range request.Context {
+		if turn.Role != message.RoleUser {
+			ledger.reject(
+				inference.FieldGenerateContextRole,
+				"task generation keeps user context only; assistant, system, and tool turns have no native channel",
+			)
+			continue
+		}
+		collect(turn.Content.Parts, contextPartFields)
+	}
+	collect(request.Input.Content.Parts, inputPartFields)
+	return
+}
+
+// rejectPromptLength rejects a prompt that exceeds the official character
+// limit, landing on the most precise active text field: the input text
+// when the request input carries text, otherwise a context text field,
+// otherwise the input role.
+func rejectPromptLength(
+	request inference.GenerateRequest,
+	ledger *ledger,
+	length, limit int,
+	reason string,
+) {
+	if length <= limit {
+		return
+	}
+	if containsTextPart(request.Input.Content.Parts) {
+		ledger.reject(inference.FieldGenerateInputText, reason)
+		return
+	}
+	for _, turn := range request.Context {
+		if containsTextPart(turn.Content.Parts) {
+			ledger.reject(inference.FieldGenerateContextText, reason)
+			return
+		}
+	}
+	ledger.reject(inference.FieldGenerateInputRole, reason)
+}
+
+func containsTextPart(parts []message.Part) bool {
+	for _, part := range parts {
+		if part != nil && part.Kind() == message.PartText {
+			return true
+		}
+	}
+	return false
+}
+
+// compileVideoInputs lowers the collected media parts onto the wire. The
+// v2 API understands every input role (first/last frame and reference_*);
+// v1 understands first/last-frame images only, on the models that declare
+// the capability.
+func compileVideoInputs(
+	wire *videoWire,
+	images, videos, audios []string,
+	entry catalogEntry,
+	model inference.ModelRef,
+	ledger *ledger,
+) {
+	if entry.videoV2 {
+		compileV2Inputs(&wire.v2Content, images, videos, audios, ledger)
+		return
+	}
+	switch {
+	case len(images) == 1:
+		wire.firstFrame = images[0]
+	case len(images) == 2 && entry.videoLastFrame:
+		wire.firstFrame, wire.lastFrame = images[0], images[1]
+	case len(images) > 0:
+		if entry.videoLastFrame {
+			ledger.reject(
+				inference.FieldGenerateInputImage,
+				fmt.Sprintf(
+					"%s accepts a first-frame and a last-frame image, not %d",
+					model.ID.Name, len(images),
+				),
+			)
+		} else {
+			ledger.reject(
+				inference.FieldGenerateInputImage,
+				fmt.Sprintf(
+					"%s accepts a single first-frame image, not %d",
+					model.ID.Name, len(images),
+				),
+			)
+		}
+	}
+	if len(videos) > 0 {
+		ledger.reject(
+			inference.FieldGenerateInputVideo,
+			fmt.Sprintf("%s does not accept reference-video input", model.ID.Name),
+		)
+	}
+	if len(audios) > 0 {
+		ledger.reject(
+			inference.FieldGenerateInputAudio,
+			fmt.Sprintf("%s does not accept reference-audio input", model.ID.Name),
+		)
+	}
+}
+
+// compileV2Inputs maps media parts onto the v2 content roles. One image is
+// the first frame, two are first/last frames, and more than two — or any
+// video/audio part — switch the task to multimodal reference generation;
+// the two scenarios are mutually exclusive, mirroring the official content
+// rules.
+func compileV2Inputs(
+	wire *v2Content,
+	images, videos, audios []string,
+	ledger *ledger,
+) {
+	firstLast := len(images) == 1 || len(images) == 2
+	reference := len(images) > 2 || len(videos) > 0 || len(audios) > 0
+	if firstLast && reference {
+		ledger.reject(
+			inference.FieldGenerateInputImage,
+			"MiniMax-H3 treats first/last-frame input and reference inputs as mutually exclusive",
+		)
+		return
+	}
+	switch {
+	case len(images) == 1:
+		wire.firstFrame = images[0]
+	case len(images) == 2:
+		wire.firstFrame, wire.lastFrame = images[0], images[1]
+	case len(images) > 9:
+		ledger.reject(
+			inference.FieldGenerateInputImage,
+			"MiniMax-H3 accepts at most 9 reference images",
+		)
+	case len(images) > 2:
+		wire.referenceImages = images
+	}
+	if len(videos) > 3 {
+		ledger.reject(
+			inference.FieldGenerateInputVideo,
+			"MiniMax-H3 accepts at most 3 reference videos",
+		)
+	} else {
+		wire.referenceVideos = videos
+	}
+	if len(audios) > 3 {
+		ledger.reject(
+			inference.FieldGenerateInputAudio,
+			"MiniMax-H3 accepts at most 3 reference audio clips",
+		)
+	} else {
+		wire.referenceAudios = audios
+	}
+}
+
+// compileVideoIntent lowers VideoIntent controls onto the wire and enforces
+// the official per-model constraints.
+func compileVideoIntent(
+	wire *videoWire,
+	video *inference.VideoIntent,
+	entry catalogEntry,
+	endpoint string,
+	ledger *ledger,
+) {
+	if video.DurationMillis != nil {
+		millis := *video.DurationMillis
+		if millis%1000 != 0 {
+			ledger.reject(
+				inference.FieldGenerateIntentVideoDuration,
+				fmt.Sprintf("minimax video durations are whole seconds, not %dms", millis),
+			)
+		} else {
+			seconds := int(millis / 1000)
+			if entry.videoV2 {
+				if seconds < 4 || seconds > 15 {
+					ledger.reject(
+						inference.FieldGenerateIntentVideoDuration,
+						fmt.Sprintf("MiniMax-H3 durations are 4-15s, not %ds", seconds),
+					)
+				} else {
+					wire.duration = &seconds
+				}
+			} else {
+				switch {
+				case seconds == 6:
+					wire.duration = &seconds
+				case seconds == 10 && !entry.video10s:
+					ledger.reject(
+						inference.FieldGenerateIntentVideoDuration,
+						fmt.Sprintf("%s serves 6-second videos only", endpoint),
+					)
+				case seconds == 10:
+					wire.duration = &seconds
+				default:
+					ledger.reject(
+						inference.FieldGenerateIntentVideoDuration,
+						fmt.Sprintf("minimax video durations are 6s or 10s, not %ds", seconds),
+					)
+				}
+			}
+		}
+	} else if entry.videoV2 {
+		// The v2 schema requires duration; the driver defaults to the same
+		// 6s the v1 API uses when the intent leaves it open.
+		seconds := 6
+		wire.duration = &seconds
+	}
+
+	if video.Resolution != "" {
+		switch strings.ToUpper(video.Resolution) {
+		case "768P":
+			wire.resolution = "768P"
+		case "2K":
+			if !entry.videoV2 {
+				ledger.reject(
+					inference.FieldGenerateIntentVideoResolution,
+					fmt.Sprintf("%s serves 768P/1080P tiers, not %q", endpoint, video.Resolution),
+				)
+			} else {
+				wire.resolution = "2K"
+			}
+		case "1080P":
+			if entry.videoV2 {
+				ledger.reject(
+					inference.FieldGenerateIntentVideoResolution,
+					fmt.Sprintf("%s serves 768P/2K tiers, not %q", endpoint, video.Resolution),
+				)
+			} else if !entry.videoHD {
+				ledger.reject(
+					inference.FieldGenerateIntentVideoResolution,
+					fmt.Sprintf("%s serves 768P only", endpoint),
+				)
+			} else {
+				wire.resolution = "1080P"
+			}
+		case "512P":
+			// 512P exists on the v1 image-to-video surface for
+			// MiniMax-Hailuo-02 only: single-first-frame tasks only.
+			// Text-to-video and first/last-frame (fl2v) tasks cap at
+			// 768P/1080P per the official docs.
+			if !entry.video512P || wire.firstFrame == "" || wire.lastFrame != "" {
+				ledger.reject(
+					inference.FieldGenerateIntentVideoResolution,
+					fmt.Sprintf("%s serves 768P/1080P tiers, not %q", endpoint, video.Resolution),
+				)
+			} else {
+				wire.resolution = "512P"
+			}
+		default:
+			tiers := "768P/1080P"
+			if entry.videoV2 {
+				tiers = "768P/2K"
+			}
+			ledger.reject(
+				inference.FieldGenerateIntentVideoResolution,
+				fmt.Sprintf("%s serves %s tiers, not %q", endpoint, tiers, video.Resolution),
+			)
+		}
+	} else if entry.videoV2 {
+		// The v2 schema requires resolution; 768P is the default tier.
+		wire.resolution = "768P"
+	}
+	if !entry.videoV2 && wire.duration != nil && *wire.duration == 10 &&
+		wire.resolution == "1080P" {
+		ledger.reject(
+			inference.FieldGenerateIntentVideoDuration,
+			"10-second videos require 768P",
+		)
+	}
+
+	if video.AspectRatio != "" {
+		if !entry.videoV2 {
+			ledger.reject(
+				inference.FieldGenerateIntentVideoAspectRatio,
+				"the v1 task API has no aspect-ratio control; resolution tiers are fixed-ratio",
+			)
+		} else if !v2RatioValues[string(video.AspectRatio)] {
+			ledger.reject(
+				inference.FieldGenerateIntentVideoAspectRatio,
+				fmt.Sprintf(
+					"MiniMax-H3 ratios are adaptive/21:9/16:9/4:3/1:1/3:4/9:16, not %q",
+					video.AspectRatio,
+				),
+			)
+		} else {
+			wire.ratio = string(video.AspectRatio)
+		}
+	} else if entry.videoV2 && v2TextOnly(&wire.v2Content) {
+		// Text-only tasks require an explicit non-adaptive ratio; 16:9 is
+		// the driver default.
+		wire.ratio = "16:9"
+	}
+	if entry.videoV2 && wire.ratio == "adaptive" && v2TextOnly(&wire.v2Content) {
+		ledger.reject(
+			inference.FieldGenerateIntentVideoAspectRatio,
+			"text-to-video requires an explicit ratio; adaptive is not allowed",
+		)
+	}
+	if video.Seed != nil {
+		ledger.reject(
+			inference.FieldGenerateIntentVideoSeed,
+			"the minimax task APIs have no seed control",
+		)
+	}
+	wire.watermark = video.Watermark
+}
+
+// v2TextOnly reports whether the content carries no image or reference
+// input, i.e. the request is a text-only (t2v) task.
+func v2TextOnly(content *v2Content) bool {
+	return content.firstFrame == "" && content.lastFrame == "" &&
+		len(content.referenceImages) == 0 &&
+		len(content.referenceVideos) == 0 && len(content.referenceAudios) == 0
+}
+
+// compileVideoOptions lowers VideoOptions onto the wire and rejects the
+// v1-only prompt controls on the v2 API, where they do not exist.
+func compileVideoOptions(
+	wire *videoWire,
+	options VideoOptions,
+	entry catalogEntry,
+	endpoint string,
+	ledger *ledger,
+) {
+	field := func(name string) inference.FieldID {
+		return inference.ExtensionField(name).Qualify(options)
+	}
+	wire.callbackURL = options.CallbackURL
+	if options.PromptOptimizer != nil {
+		if entry.videoV2 {
+			ledger.reject(
+				field("prompt_optimizer"),
+				fmt.Sprintf("%s does not support prompt_optimizer; the v2 API has no prompt optimizer", endpoint),
+			)
+		} else {
+			wire.promptOptimizer = options.PromptOptimizer
+		}
+	}
+	if options.FastPretreatment != nil {
+		if entry.videoV2 {
+			ledger.reject(
+				field("fast_pretreatment"),
+				fmt.Sprintf("%s does not support fast_pretreatment; the v2 API has no prompt optimizer", endpoint),
+			)
+		} else {
+			wire.fastPretreatment = options.FastPretreatment
+		}
+	}
+	if options.LastFrameOnly != nil && *options.LastFrameOnly {
+		if !entry.videoV2 {
+			ledger.reject(
+				field("last_frame_only"),
+				fmt.Sprintf("%s does not support last_frame_only; the v1 API has no last-frame-only task", endpoint),
+			)
+		} else if wire.firstFrame == "" || wire.lastFrame != "" {
+			ledger.reject(
+				field("last_frame_only"),
+				"last_frame_only requires exactly one input image",
+			)
+		} else {
+			// Mark the single image as the closing frame
+			// (role=last_frame) instead of the opening one.
+			wire.lastFrame = wire.firstFrame
+			wire.firstFrame = ""
+		}
+	}
+}
+
+// videoCreateResponse is the v1 create-task envelope.
 type videoCreateResponse struct {
 	TaskID   string   `json:"task_id"`
 	BaseResp baseResp `json:"base_resp"`
 }
 
-// videoQueryResponse is the task-status envelope.
+// videoV2CreateResponse is the v2 create-task envelope; v2 errors ride
+// HTTP status codes rather than base_resp.
+type videoV2CreateResponse struct {
+	TaskID string `json:"task_id"`
+}
+
+// videoQueryResponse is the v1 task-status envelope.
 type videoQueryResponse struct {
 	TaskID   string   `json:"task_id"`
 	Status   string   `json:"status"`
@@ -226,7 +596,88 @@ type videoQueryResponse struct {
 	BaseResp baseResp `json:"base_resp"`
 }
 
-// videoFileResponse is the file-retrieval envelope.
+// videoV2QueryResponse is the shared v2 task-status envelope. Video tasks
+// carry the artifact URL in content.url; H3-Context-IR tasks carry the
+// enhanced prompt in content.prompt.
+type videoV2QueryResponse struct {
+	Task struct {
+		ID      string `json:"id"`
+		Status  string `json:"status"`
+		Content struct {
+			URL    string `json:"url"`
+			Prompt string `json:"prompt"`
+		} `json:"content"`
+		Usage struct {
+			TotalTokens      int64 `json:"total_tokens"`
+			PromptTokens     int64 `json:"prompt_tokens"`
+			CompletionTokens int64 `json:"completion_tokens"`
+		} `json:"usage"`
+	} `json:"task"`
+}
+
+// v2TaskUsage carries the token accounting a succeeded v2 task reports.
+type v2TaskUsage struct {
+	inputTokens  int64
+	outputTokens int64
+	totalTokens  int64
+}
+
+// v2TaskResult is the succeeded v2 task content; exactly one of url and
+// prompt is populated, depending on the task type.
+type v2TaskResult struct {
+	id     string
+	url    string
+	prompt string
+	usage  v2TaskUsage
+}
+
+// pollV2Task polls the shared v2 query endpoint until the task reaches a
+// terminal state. Video generation and H3-Context-IR both ride it; the
+// caller validates the content field its task type requires.
+func pollV2Task(
+	ctx context.Context,
+	client *mediaClient,
+	taskID string,
+	pollInterval time.Duration,
+) (v2TaskResult, error) {
+	queryPath := "/v2/query/video_generation/" + url.PathEscape(taskID)
+	for {
+		var task videoV2QueryResponse
+		if err := client.getJSON(ctx, queryPath, nil, &task); err != nil {
+			return v2TaskResult{}, err
+		}
+		switch strings.ToLower(task.Task.Status) {
+		case "succeeded":
+			return v2TaskResult{
+				id:     task.Task.ID,
+				url:    task.Task.Content.URL,
+				prompt: task.Task.Content.Prompt,
+				usage: v2TaskUsage{
+					inputTokens:  task.Task.Usage.PromptTokens,
+					outputTokens: task.Task.Usage.CompletionTokens,
+					totalTokens:  task.Task.Usage.TotalTokens,
+				},
+			}, nil
+		case "failed":
+			return v2TaskResult{}, errdefs.NotAvailable(fmt.Errorf(
+				"minimax: task %q failed server-side",
+				taskID,
+			))
+		case "cancelled":
+			return v2TaskResult{}, errdefs.NotAvailable(fmt.Errorf(
+				"minimax: task %q was cancelled server-side",
+				taskID,
+			))
+		}
+		select {
+		case <-ctx.Done():
+			return v2TaskResult{}, ctx.Err()
+		case <-time.After(pollInterval):
+		}
+	}
+}
+
+// videoFileResponse is the v1 file-retrieval envelope.
 type videoFileResponse struct {
 	File struct {
 		DownloadURL string `json:"download_url"`
@@ -234,7 +685,7 @@ type videoFileResponse struct {
 	BaseResp baseResp `json:"base_resp"`
 }
 
-func transportVideo(
+func transportVideoV1(
 	client *mediaClient,
 	pollInterval time.Duration,
 ) inference.Transport[videoWire, videoRaw] {
@@ -246,14 +697,26 @@ func transportVideo(
 		if wire.firstFrame != "" {
 			request["first_frame_image"] = wire.firstFrame
 		}
-		if wire.duration != 0 {
-			request["duration"] = wire.duration
+		if wire.lastFrame != "" {
+			request["last_frame_image"] = wire.lastFrame
+		}
+		if wire.duration != nil {
+			request["duration"] = *wire.duration
 		}
 		if wire.resolution != "" {
 			request["resolution"] = wire.resolution
 		}
 		if wire.watermark != nil {
 			request["aigc_watermark"] = *wire.watermark
+		}
+		if wire.promptOptimizer != nil {
+			request["prompt_optimizer"] = *wire.promptOptimizer
+		}
+		if wire.fastPretreatment != nil {
+			request["fast_pretreatment"] = *wire.fastPretreatment
+		}
+		if wire.callbackURL != "" {
+			request["callback_url"] = wire.callbackURL
 		}
 
 		var created videoCreateResponse
@@ -323,12 +786,98 @@ func transportVideo(
 	}
 }
 
+func transportVideoV2(
+	client *mediaClient,
+	pollInterval time.Duration,
+) inference.Transport[videoWire, videoRaw] {
+	return func(ctx context.Context, wire videoWire) (videoRaw, error) {
+		request := map[string]any{
+			"model":      wire.model,
+			"content":    v2ContentItems(wire.prompt, wire.v2Content),
+			"resolution": wire.resolution,
+		}
+		if wire.duration != nil {
+			request["duration"] = *wire.duration
+		}
+		if wire.ratio != "" {
+			request["ratio"] = wire.ratio
+		}
+		if wire.watermark != nil {
+			request["aigc_watermark"] = *wire.watermark
+		}
+		if wire.callbackURL != "" {
+			request["callback_url"] = wire.callbackURL
+		}
+
+		var created videoV2CreateResponse
+		if err := client.postJSON(ctx, "/v2/video_generation", request, &created); err != nil {
+			return videoRaw{}, err
+		}
+		if created.TaskID == "" {
+			return videoRaw{}, fmt.Errorf(
+				"minimax: video task creation returned no task_id",
+			)
+		}
+		task, err := pollV2Task(ctx, client, created.TaskID, pollInterval)
+		if err != nil {
+			return videoRaw{}, err
+		}
+		if task.url == "" {
+			return videoRaw{}, fmt.Errorf(
+				"minimax: succeeded video task %q carries no content url",
+				created.TaskID,
+			)
+		}
+		return videoRaw{
+			videoURL:  task.url,
+			requestID: task.id,
+		}, nil
+	}
+}
+
+// v2ContentItems renders the official v2 content array for a task: the
+// mandatory text item first, then images and reference media with their
+// roles.
+func v2ContentItems(prompt string, content v2Content) []map[string]any {
+	items := make([]map[string]any, 0,
+		1+len(content.referenceImages)+len(content.referenceVideos)+len(content.referenceAudios))
+	items = append(items, map[string]any{
+		"type": "text",
+		"text": prompt,
+	})
+	item := func(itemType, value, role string) map[string]any {
+		return map[string]any{
+			"type": itemType,
+			itemType: map[string]any{
+				"url": value,
+			},
+			"role": role,
+		}
+	}
+	if content.firstFrame != "" {
+		items = append(items, item("image_url", content.firstFrame, "first_frame"))
+	}
+	if content.lastFrame != "" {
+		items = append(items, item("image_url", content.lastFrame, "last_frame"))
+	}
+	for _, value := range content.referenceImages {
+		items = append(items, item("image_url", value, "reference_image"))
+	}
+	for _, value := range content.referenceVideos {
+		items = append(items, item("video_url", value, "reference_video"))
+	}
+	for _, value := range content.referenceAudios {
+		items = append(items, item("audio_url", value, "reference_audio"))
+	}
+	return items
+}
+
 func decodeVideo(
 	_ context.Context,
 	raw videoRaw,
 ) (inference.GenerateResponse, error) {
-	// Hailuo tasks deliver mp4 files; the URL carries no explicit media
-	// type, so the compiler-known container is the truthful one.
+	// MiniMax video tasks deliver mp4 files; the URL carries no explicit
+	// media type, so the compiler-known container is the truthful one.
 	source, err := media.NewVideoURL(raw.videoURL, "video/mp4")
 	if err != nil {
 		return inference.GenerateResponse{}, fmt.Errorf("minimax: video url: %w", err)
@@ -353,13 +902,47 @@ func openVideo(
 	entry catalogEntry,
 	id inference.ModelID,
 ) (inference.GenerateOperations, error) {
+	var transport inference.Transport[videoWire, videoRaw]
+	if entry.videoV2 {
+		transport = transportVideoV2(cls.media, spec.videoPollInterval())
+	} else {
+		transport = transportVideoV1(cls.media, spec.videoPollInterval())
+	}
 	unary, err := inference.BindGenerate(
-		compileVideo(id.Name, entry),
-		transportVideo(cls.media, spec.videoPollInterval()),
+		compileVideo(wireModel(id.Name, entry), entry),
+		transport,
 		decodeVideo,
 	)
 	if err != nil {
 		return inference.GenerateOperations{}, err
 	}
 	return inference.GenerateOperations{Unary: unary}, nil
+}
+
+// videoImageValue renders an input image the way the video task APIs expect:
+// absolute URLs pass through, inline bytes become a data URI carrying the
+// source media type. (image_generation's subject_reference surface uses raw
+// base64 instead — see imageSourceValue.)
+func videoImageValue(source media.ImageSource) string {
+	if source.Kind() == media.SourceURL {
+		return source.URL()
+	}
+	return "data:" + source.MediaType() + ";base64," +
+		base64.StdEncoding.EncodeToString(source.Bytes())
+}
+
+func videoSourceURI(source media.VideoSource) string {
+	if source.Kind() == media.SourceURL {
+		return source.URL()
+	}
+	return "data:" + source.MediaType() + ";base64," +
+		base64.StdEncoding.EncodeToString(source.Bytes())
+}
+
+func audioSourceURI(source media.AudioSource) string {
+	if source.Kind() == media.SourceURL {
+		return source.URL()
+	}
+	return "data:" + source.MediaType() + ";base64," +
+		base64.StdEncoding.EncodeToString(source.Bytes())
 }

--- a/driver/minimax/video_test.go
+++ b/driver/minimax/video_test.go
@@ -1,0 +1,897 @@
+package minimax
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/GizClaw/flowcraft/core/inference"
+	"github.com/GizClaw/flowcraft/core/message"
+	"github.com/GizClaw/flowcraft/core/message/media"
+)
+
+func compileVideoRequest(
+	parts []message.Part,
+	options VideoOptions,
+) inference.GenerateRequest {
+	var extensions inference.Extensions
+	extensions = append(extensions, options)
+	return inference.GenerateRequest{
+		Input: inference.GenerateInput{
+			Role: inference.InputRoleUser,
+			Content: inference.InputContent{
+				Content: message.Content{Parts: parts},
+				Intent:  inference.Intent{Video: &inference.VideoIntent{}},
+			},
+		},
+		Extensions: extensions,
+	}
+}
+
+func compileVideoWire(
+	t *testing.T,
+	model string,
+	request inference.GenerateRequest,
+) (videoWire, inference.CompileReport, error) {
+	t.Helper()
+	entry, ok := catalog[model]
+	if !ok {
+		t.Fatalf("catalog model %q missing", model)
+	}
+	compiled, err := compileVideo("ep-test", entry)(
+		context.Background(),
+		inference.ModelRef{ID: inference.ModelID{Provider: driverID, Name: model}},
+		request,
+		inference.GenerateExecutionUnary,
+	)
+	if err != nil {
+		return videoWire{}, compiled.Report, err
+	}
+	return compiled.Wire, compiled.Report, nil
+}
+
+func rejectedReason(report inference.CompileReport, field inference.FieldID) string {
+	for _, decision := range report.Decisions {
+		if decision.Field == field && decision.Disposition == inference.Rejected {
+			return decision.Reason
+		}
+	}
+	return ""
+}
+
+func videoOptionsField(name string) inference.FieldID {
+	return inference.ExtensionField(name).Qualify(VideoOptions{})
+}
+
+func videoImagePart(t *testing.T, url string) message.ImagePart {
+	t.Helper()
+	source, err := media.NewImageURL(url, "image/png")
+	if err != nil {
+		t.Fatalf("NewImageURL: %v", err)
+	}
+	return message.ImagePart{Source: source}
+}
+
+func videoInlineImagePart(t *testing.T, data []byte) message.ImagePart {
+	t.Helper()
+	source, err := media.NewImageBytes(data, "image/png")
+	if err != nil {
+		t.Fatalf("NewImageBytes: %v", err)
+	}
+	return message.ImagePart{Source: source}
+}
+
+func videoClipPart(t *testing.T, url string) message.VideoPart {
+	t.Helper()
+	source, err := media.NewVideoURL(url, "video/mp4")
+	if err != nil {
+		t.Fatalf("NewVideoURL: %v", err)
+	}
+	return message.VideoPart{Source: source}
+}
+
+func videoAudioPart(t *testing.T, url string) message.AudioPart {
+	t.Helper()
+	source, err := media.NewAudioURL(url, "audio/mpeg")
+	if err != nil {
+		t.Fatalf("NewAudioURL: %v", err)
+	}
+	return message.AudioPart{Source: source}
+}
+
+func TestCompileVideoV2Defaults(t *testing.T) {
+	request := compileVideoRequest(
+		[]message.Part{message.TextPart{Text: "a boy playing basketball"}},
+		VideoOptions{},
+	)
+	wire, report, err := compileVideoWire(t, "MiniMax-H3", request)
+	if err != nil {
+		t.Fatalf("compile: %v; report = %+v", err, report)
+	}
+	if wire.duration == nil || *wire.duration != 6 {
+		t.Fatalf("wire.duration = %v, want 6", wire.duration)
+	}
+	if wire.resolution != "768P" {
+		t.Fatalf("wire.resolution = %q, want 768P", wire.resolution)
+	}
+	if wire.ratio != "16:9" {
+		t.Fatalf("wire.ratio = %q, want 16:9", wire.ratio)
+	}
+	if wire.prompt != "a boy playing basketball" {
+		t.Fatalf("wire.prompt = %q", wire.prompt)
+	}
+}
+
+func TestCompileVideoV2GatesControls(t *testing.T) {
+	threeSeconds := int64(3_000)
+	sixteenSeconds := int64(16_000)
+	seed := int64(11)
+	optimizer := true
+	pretreatment := true
+
+	cases := []struct {
+		name    string
+		options VideoOptions
+		intent  func(*inference.VideoIntent)
+		field   inference.FieldID
+		reason  string
+	}{
+		{
+			name:   "duration below minimum",
+			intent: func(i *inference.VideoIntent) { i.DurationMillis = &threeSeconds },
+			field:  inference.FieldGenerateIntentVideoDuration,
+			reason: "4-15s",
+		},
+		{
+			name:   "duration above maximum",
+			intent: func(i *inference.VideoIntent) { i.DurationMillis = &sixteenSeconds },
+			field:  inference.FieldGenerateIntentVideoDuration,
+			reason: "4-15s",
+		},
+		{
+			name:   "resolution 1080P unsupported",
+			intent: func(i *inference.VideoIntent) { i.Resolution = "1080P" },
+			field:  inference.FieldGenerateIntentVideoResolution,
+			reason: "768P/2K",
+		},
+		{
+			name:   "ratio outside official set",
+			intent: func(i *inference.VideoIntent) { i.AspectRatio = "2:1" },
+			field:  inference.FieldGenerateIntentVideoAspectRatio,
+			reason: "ratios are adaptive",
+		},
+		{
+			name:   "ratio adaptive on text-only task",
+			intent: func(i *inference.VideoIntent) { i.AspectRatio = "adaptive" },
+			field:  inference.FieldGenerateIntentVideoAspectRatio,
+			reason: "explicit ratio",
+		},
+		{
+			name:   "seed unsupported",
+			intent: func(i *inference.VideoIntent) { i.Seed = &seed },
+			field:  inference.FieldGenerateIntentVideoSeed,
+			reason: "no seed control",
+		},
+		{
+			name:    "prompt_optimizer is v1-only",
+			options: VideoOptions{PromptOptimizer: &optimizer},
+			field:   videoOptionsField("prompt_optimizer"),
+			reason:  "no prompt optimizer",
+		},
+		{
+			name:    "fast_pretreatment is v1-only",
+			options: VideoOptions{FastPretreatment: &pretreatment},
+			field:   videoOptionsField("fast_pretreatment"),
+			reason:  "no prompt optimizer",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			request := compileVideoRequest(
+				[]message.Part{message.TextPart{Text: "a cinematic scene"}},
+				tc.options,
+			)
+			if tc.intent != nil {
+				tc.intent(request.Input.Content.Intent.Video)
+			}
+			_, report, err := compileVideoWire(t, "MiniMax-H3", request)
+			if err == nil {
+				t.Fatalf("compile unexpectedly succeeded; report = %+v", report)
+			}
+			reason := rejectedReason(report, tc.field)
+			if reason == "" {
+				t.Fatalf("field %q not rejected; report = %+v", tc.field, report)
+			}
+			if !strings.Contains(reason, tc.reason) {
+				t.Errorf("rejection reason = %q, want substring %q", reason, tc.reason)
+			}
+		})
+	}
+}
+
+func TestCompileVideoV2AcceptsControls(t *testing.T) {
+	fifteenSeconds := int64(15_000)
+	watermark := false
+	request := compileVideoRequest(
+		[]message.Part{message.TextPart{Text: "a cinematic scene"}},
+		VideoOptions{CallbackURL: "https://example.com/callback"},
+	)
+	video := request.Input.Content.Intent.Video
+	video.DurationMillis = &fifteenSeconds
+	video.Resolution = "2k"
+	video.AspectRatio = "21:9"
+	video.Watermark = &watermark
+
+	wire, report, err := compileVideoWire(t, "MiniMax-H3", request)
+	if err != nil {
+		t.Fatalf("compile: %v; report = %+v", err, report)
+	}
+	if wire.duration == nil || *wire.duration != 15 {
+		t.Fatalf("wire.duration = %v, want 15", wire.duration)
+	}
+	if wire.resolution != "2K" {
+		t.Fatalf("wire.resolution = %q, want 2K", wire.resolution)
+	}
+	if wire.ratio != "21:9" {
+		t.Fatalf("wire.ratio = %q, want 21:9", wire.ratio)
+	}
+	if wire.watermark == nil || *wire.watermark {
+		t.Fatalf("wire.watermark = %v, want false", wire.watermark)
+	}
+	if wire.callbackURL != "https://example.com/callback" {
+		t.Fatalf("wire.callbackURL = %q", wire.callbackURL)
+	}
+}
+
+func TestCompileVideoV2Inputs(t *testing.T) {
+	url1 := "https://example.com/a.png"
+	url2 := "https://example.com/b.png"
+	url3 := "https://example.com/c.png"
+	clip := "https://example.com/clip.mp4"
+	audio := "https://example.com/track.mp3"
+
+	accepted := []struct {
+		name  string
+		parts []message.Part
+		check func(*testing.T, videoWire)
+	}{
+		{
+			name:  "single image is the first frame",
+			parts: []message.Part{videoImagePart(t, url1)},
+			check: func(t *testing.T, wire videoWire) {
+				if wire.firstFrame != url1 || wire.lastFrame != "" {
+					t.Fatalf("frames = %q / %q, want first %q", wire.firstFrame, wire.lastFrame, url1)
+				}
+			},
+		},
+		{
+			name:  "two images are first and last frame",
+			parts: []message.Part{videoImagePart(t, url1), videoImagePart(t, url2)},
+			check: func(t *testing.T, wire videoWire) {
+				if wire.firstFrame != url1 || wire.lastFrame != url2 {
+					t.Fatalf("frames = %q / %q", wire.firstFrame, wire.lastFrame)
+				}
+			},
+		},
+		{
+			name:  "three images become reference images",
+			parts: []message.Part{videoImagePart(t, url1), videoImagePart(t, url2), videoImagePart(t, url3)},
+			check: func(t *testing.T, wire videoWire) {
+				if len(wire.referenceImages) != 3 || wire.firstFrame != "" {
+					t.Fatalf("referenceImages = %v, firstFrame = %q", wire.referenceImages, wire.firstFrame)
+				}
+			},
+		},
+		{
+			name: "reference images, videos, and audios",
+			parts: []message.Part{
+				videoImagePart(t, url1), videoImagePart(t, url2), videoImagePart(t, url3),
+				videoClipPart(t, clip), videoAudioPart(t, audio),
+			},
+			check: func(t *testing.T, wire videoWire) {
+				if len(wire.referenceImages) != 3 ||
+					len(wire.referenceVideos) != 1 ||
+					len(wire.referenceAudios) != 1 {
+					t.Fatalf("references = %v / %v / %v",
+						wire.referenceImages, wire.referenceVideos, wire.referenceAudios)
+				}
+			},
+		},
+	}
+	for _, tc := range accepted {
+		t.Run(tc.name, func(t *testing.T) {
+			wire, report, err := compileVideoWire(
+				t,
+				"MiniMax-H3",
+				compileVideoRequest(
+					append([]message.Part{message.TextPart{Text: "a scene"}}, tc.parts...),
+					VideoOptions{},
+				),
+			)
+			if err != nil {
+				t.Fatalf("compile: %v; report = %+v", err, report)
+			}
+			tc.check(t, wire)
+		})
+	}
+
+	rejected := []struct {
+		name   string
+		parts  []message.Part
+		field  inference.FieldID
+		reason string
+	}{
+		{
+			name:   "first/last frame mixed with reference inputs",
+			parts:  []message.Part{videoImagePart(t, url1), videoImagePart(t, url2), videoClipPart(t, clip)},
+			field:  inference.FieldGenerateInputImage,
+			reason: "mutually exclusive",
+		},
+		{
+			name: "too many reference images",
+			parts: func() []message.Part {
+				parts := make([]message.Part, 0, 10)
+				for i := 0; i < 10; i++ {
+					parts = append(parts, videoImagePart(t, "https://example.com/x.png"))
+				}
+				return parts
+			}(),
+			field:  inference.FieldGenerateInputImage,
+			reason: "at most 9",
+		},
+		{
+			name: "too many reference videos",
+			parts: func() []message.Part {
+				parts := make([]message.Part, 0, 5)
+				for i := 0; i < 4; i++ {
+					parts = append(parts, videoClipPart(t, "https://example.com/clip.mp4"))
+				}
+				return parts
+			}(),
+			field:  inference.FieldGenerateInputVideo,
+			reason: "at most 3 reference videos",
+		},
+		{
+			name: "too many reference audios",
+			parts: func() []message.Part {
+				parts := make([]message.Part, 0, 5)
+				for i := 0; i < 4; i++ {
+					parts = append(parts, videoAudioPart(t, "https://example.com/track.mp3"))
+				}
+				return parts
+			}(),
+			field:  inference.FieldGenerateInputAudio,
+			reason: "at most 3 reference audio",
+		},
+		{
+			name:   "missing text prompt",
+			parts:  nil,
+			field:  inference.FieldGenerateIntentVideo,
+			reason: "non-empty text prompt",
+		},
+	}
+	for _, tc := range rejected {
+		t.Run(tc.name, func(t *testing.T) {
+			parts := tc.parts
+			if parts == nil {
+				parts = []message.Part{}
+			}
+			_, report, err := compileVideoWire(
+				t,
+				"MiniMax-H3",
+				compileVideoRequest(parts, VideoOptions{}),
+			)
+			if err == nil {
+				t.Fatalf("compile unexpectedly succeeded; report = %+v", report)
+			}
+			reason := rejectedReason(report, tc.field)
+			if reason == "" {
+				t.Fatalf("field %q not rejected; report = %+v", tc.field, report)
+			}
+			if !strings.Contains(reason, tc.reason) {
+				t.Errorf("rejection reason = %q, want substring %q", reason, tc.reason)
+			}
+		})
+	}
+}
+
+func TestCompileVideoV1MatchesOfficialMatrix(t *testing.T) {
+	tenSeconds := int64(10_000)
+	optimizer := true
+	pretreatment := false
+
+	with := func(model string, parts []message.Part, mutate func(*inference.VideoIntent)) videoWire {
+		t.Helper()
+		request := compileVideoRequest(parts, VideoOptions{
+			PromptOptimizer:  &optimizer,
+			FastPretreatment: &pretreatment,
+			CallbackURL:      "https://example.com/callback",
+		})
+		if mutate != nil {
+			mutate(request.Input.Content.Intent.Video)
+		}
+		wire, report, err := compileVideoWire(t, model, request)
+		if err != nil {
+			t.Fatalf("compile %s: %v; report = %+v", model, err, report)
+		}
+		return wire
+	}
+
+	t.Run("fast accepts 10s at 768P and 1080P at 6s", func(t *testing.T) {
+		parts := []message.Part{
+			message.TextPart{Text: "a scene"},
+			videoImagePart(t, "https://example.com/a.png"),
+		}
+		wire := with("MiniMax-Hailuo-2.3-Fast", parts, func(i *inference.VideoIntent) {
+			i.DurationMillis = &tenSeconds
+			i.Resolution = "768P"
+		})
+		if wire.duration == nil || *wire.duration != 10 || wire.resolution != "768P" {
+			t.Fatalf("wire = %+v", wire)
+		}
+		if wire.promptOptimizer == nil || !*wire.promptOptimizer {
+			t.Fatal("prompt_optimizer not set")
+		}
+		if wire.fastPretreatment == nil || *wire.fastPretreatment {
+			t.Fatal("fast_pretreatment not set to false")
+		}
+		if wire.callbackURL != "https://example.com/callback" {
+			t.Fatalf("callbackURL = %q", wire.callbackURL)
+		}
+	})
+
+	t.Run("hailuo 02 accepts 512P for single first-frame i2v", func(t *testing.T) {
+		wire := with("MiniMax-Hailuo-02", []message.Part{
+			message.TextPart{Text: "a scene"},
+			videoImagePart(t, "https://example.com/a.png"),
+		}, func(i *inference.VideoIntent) {
+			i.DurationMillis = &tenSeconds
+			i.Resolution = "512P"
+		})
+		if wire.firstFrame != "https://example.com/a.png" || wire.lastFrame != "" ||
+			wire.resolution != "512P" || wire.duration == nil || *wire.duration != 10 {
+			t.Fatalf("wire = %+v", wire)
+		}
+	})
+}
+
+func TestCompileVideoV1RejectsOutOfMatrix(t *testing.T) {
+	tenSeconds := int64(10_000)
+	image := videoImagePart(t, "https://example.com/a.png")
+
+	cases := []struct {
+		name   string
+		model  string
+		parts  []message.Part
+		intent func(*inference.VideoIntent)
+		field  inference.FieldID
+		reason string
+	}{
+		{
+			name:   "fast without first frame",
+			model:  "MiniMax-Hailuo-2.3-Fast",
+			parts:  []message.Part{message.TextPart{Text: "a scene"}},
+			field:  inference.FieldGenerateIntentVideo,
+			reason: "image-to-video only",
+		},
+		{
+			name:  "fast 10s at 1080P",
+			model: "MiniMax-Hailuo-2.3-Fast",
+			parts: []message.Part{message.TextPart{Text: "a scene"}, image},
+			intent: func(i *inference.VideoIntent) {
+				i.DurationMillis = &tenSeconds
+				i.Resolution = "1080P"
+			},
+			field:  inference.FieldGenerateIntentVideoDuration,
+			reason: "10-second videos require 768P",
+		},
+		{
+			name:  "hailuo 02 512P on text-to-video",
+			model: "MiniMax-Hailuo-02",
+			parts: []message.Part{message.TextPart{Text: "a scene"}},
+			intent: func(i *inference.VideoIntent) {
+				i.Resolution = "512P"
+			},
+			field:  inference.FieldGenerateIntentVideoResolution,
+			reason: "768P/1080P tiers",
+		},
+		{
+			name:  "hailuo 02 512P with first and last frame",
+			model: "MiniMax-Hailuo-02",
+			parts: []message.Part{
+				message.TextPart{Text: "a scene"},
+				videoImagePart(t, "https://example.com/a.png"),
+				videoImagePart(t, "https://example.com/b.png"),
+			},
+			intent: func(i *inference.VideoIntent) {
+				i.Resolution = "512P"
+			},
+			field:  inference.FieldGenerateIntentVideoResolution,
+			reason: "768P/1080P tiers",
+		},
+		{
+			name:  "hailuo 02 rejects three images",
+			model: "MiniMax-Hailuo-02",
+			parts: []message.Part{
+				message.TextPart{Text: "a scene"},
+				videoImagePart(t, "https://example.com/a.png"),
+				videoImagePart(t, "https://example.com/b.png"),
+				videoImagePart(t, "https://example.com/c.png"),
+			},
+			field:  inference.FieldGenerateInputImage,
+			reason: "first-frame and a last-frame image",
+		},
+		{
+			name:  "hailuo 2.3 rejects two images",
+			model: "MiniMax-Hailuo-2.3",
+			parts: []message.Part{
+				message.TextPart{Text: "a scene"},
+				videoImagePart(t, "https://example.com/a.png"),
+				videoImagePart(t, "https://example.com/b.png"),
+			},
+			field:  inference.FieldGenerateInputImage,
+			reason: "single first-frame image",
+		},
+		{
+			name:  "hailuo 2.3 rejects video reference",
+			model: "MiniMax-Hailuo-2.3",
+			parts: []message.Part{
+				message.TextPart{Text: "a scene"},
+				videoClipPart(t, "https://example.com/clip.mp4"),
+			},
+			field:  inference.FieldGenerateInputVideo,
+			reason: "does not accept reference-video",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			request := compileVideoRequest(tc.parts, VideoOptions{})
+			if tc.intent != nil {
+				tc.intent(request.Input.Content.Intent.Video)
+			}
+			_, report, err := compileVideoWire(t, tc.model, request)
+			if err == nil {
+				t.Fatalf("compile unexpectedly succeeded; report = %+v", report)
+			}
+			reason := rejectedReason(report, tc.field)
+			if reason == "" {
+				t.Fatalf("field %q not rejected; report = %+v", tc.field, report)
+			}
+			if !strings.Contains(reason, tc.reason) {
+				t.Errorf("rejection reason = %q, want substring %q", reason, tc.reason)
+			}
+		})
+	}
+}
+
+func TestCompileVideoPromptLengthLimits(t *testing.T) {
+	reject := func(
+		t *testing.T,
+		model string,
+		parts []message.Part,
+		field inference.FieldID,
+		reason string,
+	) {
+		t.Helper()
+		_, report, err := compileVideoWire(
+			t,
+			model,
+			compileVideoRequest(parts, VideoOptions{}),
+		)
+		if err == nil {
+			t.Fatalf("compile unexpectedly succeeded; report = %+v", report)
+		}
+		got := rejectedReason(report, field)
+		if !strings.Contains(got, reason) {
+			t.Errorf("rejection reason = %q, want substring %q", got, reason)
+		}
+	}
+
+	t.Run("v1 caps at 2000 characters", func(t *testing.T) {
+		reject(
+			t,
+			"MiniMax-Hailuo-2.3",
+			[]message.Part{message.TextPart{Text: strings.Repeat("a", 2001)}},
+			inference.FieldGenerateInputText,
+			"at most 2000 characters",
+		)
+		request := compileVideoRequest(
+			[]message.Part{message.TextPart{Text: strings.Repeat("a", 2000)}},
+			VideoOptions{},
+		)
+		if _, report, err := compileVideoWire(t, "MiniMax-Hailuo-2.3", request); err != nil {
+			t.Fatalf("2000-char prompt rejected: %v; report = %+v", err, report)
+		}
+	})
+
+	t.Run("v2 caps at 7000 characters", func(t *testing.T) {
+		reject(
+			t,
+			"MiniMax-H3",
+			[]message.Part{message.TextPart{Text: strings.Repeat("a", 7001)}},
+			inference.FieldGenerateInputText,
+			"at most 7000 characters",
+		)
+		request := compileVideoRequest(
+			[]message.Part{message.TextPart{Text: strings.Repeat("a", 7000)}},
+			VideoOptions{},
+		)
+		if _, report, err := compileVideoWire(t, "MiniMax-H3", request); err != nil {
+			t.Fatalf("7000-char prompt rejected: %v; report = %+v", err, report)
+		}
+	})
+
+	t.Run("oversized context text rejects on context field", func(t *testing.T) {
+		request := compileVideoRequest(
+			[]message.Part{videoImagePart(t, "https://example.com/a.png")},
+			VideoOptions{},
+		)
+		request.Context = []message.Message{{
+			Role: message.RoleUser,
+			Content: message.Content{
+				Parts: []message.Part{message.TextPart{Text: strings.Repeat("b", 2001)}},
+			},
+		}}
+		_, report, err := compileVideoWire(t, "MiniMax-Hailuo-2.3", request)
+		if err == nil {
+			t.Fatalf("compile unexpectedly succeeded; report = %+v", report)
+		}
+		got := rejectedReason(report, inference.FieldGenerateContextText)
+		if !strings.Contains(got, "at most 2000 characters") {
+			t.Errorf("rejection reason = %q", got)
+		}
+	})
+}
+
+func TestCompileVideoLastFrameOnly(t *testing.T) {
+	lastOnly := true
+	image := videoImagePart(t, "https://example.com/a.png")
+
+	t.Run("v2 single image becomes the last frame", func(t *testing.T) {
+		request := compileVideoRequest(
+			[]message.Part{message.TextPart{Text: "a scene"}, image},
+			VideoOptions{LastFrameOnly: &lastOnly},
+		)
+		wire, report, err := compileVideoWire(t, "MiniMax-H3", request)
+		if err != nil {
+			t.Fatalf("compile: %v; report = %+v", err, report)
+		}
+		if wire.firstFrame != "" || wire.lastFrame != "https://example.com/a.png" {
+			t.Fatalf("frames = %q / %q, want last-frame-only", wire.firstFrame, wire.lastFrame)
+		}
+	})
+
+	t.Run("v2 requires exactly one image", func(t *testing.T) {
+		request := compileVideoRequest(
+			[]message.Part{
+				message.TextPart{Text: "a scene"},
+				videoImagePart(t, "https://example.com/a.png"),
+				videoImagePart(t, "https://example.com/b.png"),
+			},
+			VideoOptions{LastFrameOnly: &lastOnly},
+		)
+		_, report, err := compileVideoWire(t, "MiniMax-H3", request)
+		if err == nil {
+			t.Fatalf("compile unexpectedly succeeded; report = %+v", report)
+		}
+		reason := rejectedReason(report, videoOptionsField("last_frame_only"))
+		if !strings.Contains(reason, "exactly one input image") {
+			t.Errorf("rejection reason = %q", reason)
+		}
+	})
+
+	t.Run("v1 rejects last-frame-only tasks", func(t *testing.T) {
+		request := compileVideoRequest(
+			[]message.Part{message.TextPart{Text: "a scene"}, image},
+			VideoOptions{LastFrameOnly: &lastOnly},
+		)
+		_, report, err := compileVideoWire(t, "MiniMax-Hailuo-02", request)
+		if err == nil {
+			t.Fatalf("compile unexpectedly succeeded; report = %+v", report)
+		}
+		reason := rejectedReason(report, videoOptionsField("last_frame_only"))
+		if !strings.Contains(reason, "no last-frame-only task") {
+			t.Errorf("rejection reason = %q", reason)
+		}
+	})
+}
+
+func TestVideoImageValueDataURI(t *testing.T) {
+	payload := []byte{0x89, 'P', 'N', 'G'}
+	inline := videoInlineImagePart(t, payload)
+	got := videoImageValue(inline.Source)
+	want := "data:image/png;base64," + base64.StdEncoding.EncodeToString(payload)
+	if got != want {
+		t.Fatalf("videoImageValue = %q, want %q", got, want)
+	}
+
+	remote := videoImagePart(t, "https://example.com/a.png")
+	if got := videoImageValue(remote.Source); got != "https://example.com/a.png" {
+		t.Fatalf("videoImageValue(URL) = %q", got)
+	}
+}
+
+func TestTransportVideoV2(t *testing.T) {
+	var polls int
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		writer.Header().Set("Content-Type", "application/json")
+		switch {
+		case request.Method == http.MethodPost && request.URL.Path == "/v2/video_generation":
+			var body map[string]any
+			if err := json.NewDecoder(request.Body).Decode(&body); err != nil {
+				t.Errorf("decode create body: %v", err)
+			}
+			if body["model"] != "MiniMax-H3" ||
+				body["resolution"] != "768P" ||
+				body["duration"] != float64(6) ||
+				body["ratio"] != "16:9" ||
+				body["aigc_watermark"] != true ||
+				body["callback_url"] != "https://example.com/callback" {
+				t.Errorf("create body = %#v", body)
+			}
+			content, ok := body["content"].([]any)
+			if !ok || len(content) != 2 {
+				t.Fatalf("content = %#v", body["content"])
+			}
+			text := content[0].(map[string]any)
+			image := content[1].(map[string]any)
+			if text["type"] != "text" || text["text"] != "a scene" ||
+				image["type"] != "image_url" || image["role"] != "first_frame" {
+				t.Errorf("content items = %#v / %#v", text, image)
+			}
+			_, _ = io.WriteString(writer, `{"task_id":"t-v2"}`)
+		case request.Method == http.MethodGet &&
+			request.URL.Path == "/v2/query/video_generation/t-v2":
+			polls++
+			if polls < 2 {
+				_, _ = io.WriteString(writer, `{"task":{"id":"t-v2","status":"running"}}`)
+			} else {
+				_, _ = io.WriteString(writer,
+					`{"task":{"id":"t-v2","status":"succeeded","content":{"url":"https://cdn.example/v2.mp4"}}}`)
+			}
+		default:
+			t.Errorf("unexpected request %s %s", request.Method, request.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	client := newMediaClient("sk-test", server.URL, Spec{})
+	watermark := true
+	raw, err := transportVideoV2(client, time.Millisecond)(context.Background(), videoWire{
+		model:  "MiniMax-H3",
+		prompt: "a scene",
+		v2Content: v2Content{
+			firstFrame: "https://example.com/a.png",
+		},
+		duration:    intPointer(6),
+		resolution:  "768P",
+		ratio:       "16:9",
+		watermark:   &watermark,
+		callbackURL: "https://example.com/callback",
+	})
+	if err != nil {
+		t.Fatalf("transport: %v", err)
+	}
+	if raw.videoURL != "https://cdn.example/v2.mp4" || raw.requestID != "t-v2" {
+		t.Fatalf("raw = %+v", raw)
+	}
+	if polls != 2 {
+		t.Fatalf("polls = %d, want 2", polls)
+	}
+}
+
+func TestTransportVideoV2TerminalErrors(t *testing.T) {
+	cases := []struct {
+		name    string
+		status  string
+		wantErr string
+	}{
+		{name: "failed", status: "failed", wantErr: "failed server-side"},
+		{name: "cancelled", status: "cancelled", wantErr: "cancelled server-side"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+				writer.Header().Set("Content-Type", "application/json")
+				switch request.Method {
+				case http.MethodPost:
+					_, _ = io.WriteString(writer, `{"task_id":"t-v2"}`)
+				case http.MethodGet:
+					_, _ = io.WriteString(writer, `{"task":{"id":"t-v2","status":"`+tc.status+`"}}`)
+				}
+			}))
+			defer server.Close()
+
+			client := newMediaClient("sk-test", server.URL, Spec{})
+			_, err := transportVideoV2(client, time.Millisecond)(context.Background(), videoWire{
+				model:      "MiniMax-H3",
+				prompt:     "a scene",
+				duration:   intPointer(6),
+				resolution: "768P",
+			})
+			if err == nil || !strings.Contains(err.Error(), tc.wantErr) {
+				t.Fatalf("err = %v, want substring %q", err, tc.wantErr)
+			}
+		})
+	}
+}
+
+func TestTransportVideoV1WireBody(t *testing.T) {
+	inline := videoInlineImagePart(t, []byte{0x89, 'P', 'N', 'G'})
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		writer.Header().Set("Content-Type", "application/json")
+		switch {
+		case request.Method == http.MethodPost && request.URL.Path == "/v1/video_generation":
+			var body map[string]any
+			if err := json.NewDecoder(request.Body).Decode(&body); err != nil {
+				t.Errorf("decode create body: %v", err)
+			}
+			if body["model"] != "MiniMax-Hailuo-02" ||
+				body["duration"] != float64(10) ||
+				body["resolution"] != "512P" ||
+				body["aigc_watermark"] != false ||
+				body["prompt_optimizer"] != true ||
+				body["fast_pretreatment"] != false ||
+				body["callback_url"] != "https://example.com/callback" {
+				t.Errorf("create body = %#v", body)
+			}
+			firstFrame, _ := body["first_frame_image"].(string)
+			if !strings.HasPrefix(firstFrame, "data:image/png;base64,") {
+				t.Errorf("first_frame_image = %q, want data URI", firstFrame)
+			}
+			if body["last_frame_image"] != "https://example.com/b.png" {
+				t.Errorf("last_frame_image = %#v", body["last_frame_image"])
+			}
+			_, _ = io.WriteString(writer,
+				`{"task_id":"t1","base_resp":{"status_code":0,"status_msg":"success"}}`)
+		case request.Method == http.MethodGet &&
+			request.URL.Path == "/v1/query/video_generation" &&
+			request.URL.Query().Get("task_id") == "t1":
+			_, _ = io.WriteString(writer,
+				`{"task_id":"t1","status":"Success","file_id":"f1","base_resp":{"status_code":0,"status_msg":"success"}}`)
+		case request.Method == http.MethodGet &&
+			request.URL.Path == "/v1/files/retrieve" &&
+			request.URL.Query().Get("file_id") == "f1":
+			_, _ = io.WriteString(writer,
+				`{"file":{"download_url":"https://cdn.example/v1.mp4"},"base_resp":{"status_code":0,"status_msg":"success"}}`)
+		default:
+			t.Errorf("unexpected request %s %s", request.Method, request.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	client := newMediaClient("sk-test", server.URL, Spec{})
+	watermark := false
+	optimizer := true
+	pretreatment := false
+	raw, err := transportVideoV1(client, time.Millisecond)(context.Background(), videoWire{
+		model:  "MiniMax-Hailuo-02",
+		prompt: "a scene",
+		v2Content: v2Content{
+			firstFrame: videoImageValue(inline.Source),
+			lastFrame:  "https://example.com/b.png",
+		},
+		duration:         intPointer(10),
+		resolution:       "512P",
+		watermark:        &watermark,
+		promptOptimizer:  &optimizer,
+		fastPretreatment: &pretreatment,
+		callbackURL:      "https://example.com/callback",
+	})
+	if err != nil {
+		t.Fatalf("transport: %v", err)
+	}
+	if raw.videoURL != "https://cdn.example/v1.mp4" || raw.requestID != "t1" {
+		t.Fatalf("raw = %+v", raw)
+	}
+}
+
+func intPointer(value int) *int {
+	return &value
+}


### PR DESCRIPTION
## Summary

Adds MiniMax-H3 **v2 video generation** and the **H3-Context-IR** prompt-enhancement task to the MiniMax driver, and aligns the v1 Hailuo matrix with the official API docs.

### v2 video generation (MiniMax-H3)

- `POST /v2/video_generation` with the multimodal `content` array (text/image/video/audio items carrying `first_frame` / `last_frame` / `reference_*` roles), `resolution` (768P/2K), `duration` (4–15s), `ratio`, `aigc_watermark`, `callback_url`.
- Polls `GET /v2/query/video_generation/{task_id}`; success returns `content.url` directly (no file-retrieval hop). Statuses include `queued/running/succeeded/failed/cancelled`.
- Content role mapping and limits match the official rules: 1 image = first frame, 2 = first+last, >2 or any video/audio = reference inputs (images ≤9, videos ≤3, audios ≤3); first/last-frame and reference inputs are mutually exclusive.
- Text-only tasks default ratio to 16:9 and reject `adaptive`; image/reference tasks default to server-side adaptive.

### H3-Context-IR

- New `context_ir` model kind (`MiniMax-H3-Context-IR`) returning an enhanced video prompt as text via `POST /v2/h3_context_ir`, sharing the content mapping and the v2 poll loop; `usage` tokens map onto the response.
- Target `duration_millis` / `ratio` / `callback_url` ride the new `ContextIROptions` extension.

### v1 alignment fixes

- `MiniMax-Hailuo-2.3-Fast` now serves 10s@768P and 1080P@6s (i2v-only).
- `MiniMax-Hailuo-02` serves 512P on single-first-frame i2v and first/last-frame input; first/last-frame tasks cap at 768P/1080P per the fl2v docs.
- Inline media are now sent as data URIs carrying the source media type, honoring the official `first_frame_image` requirement.
- `VideoOptions` adds `callback_url`, v1 `prompt_optimizer` / `fast_pretreatment`, and v2 `last_frame_only` (single-image closing-frame tasks).
- Prompt length limits (v1 2000 / v2 7000 chars) validate at compile time.
- `mergedCatalog` preserves built-in model control flags when a spec redeclares a model under the same kind.

## Validation

- `make ci`, `make lint`, `make release-check`, `git diff --check` all pass.
- New tests cover compile gating, wire bodies, poll/terminal states, and the official per-model matrices.

## Notes

- No `.release/` changeset added (no module tag in this batch).