### PR TITLE
chore(driver/minimax): tidy go.mod for release

### DIFF
--- a/driver/minimax/go.mod
+++ b/driver/minimax/go.mod
@@ -5,6 +5,7 @@ go 1.25.0
 require (
 	github.com/GizClaw/flowcraft/core v0.1.22
 	github.com/anthropics/anthropic-sdk-go v1.61.0
+	go.opentelemetry.io/otel/log v0.16.0
 )
 
 require (
@@ -31,7 +32,6 @@ require (
 	go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp v1.40.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.40.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.40.0 // indirect
-	go.opentelemetry.io/otel/log v0.16.0 // indirect
 	go.opentelemetry.io/otel/metric v1.43.0 // indirect
 	go.opentelemetry.io/otel/sdk v1.43.0 // indirect
 	go.opentelemetry.io/otel/sdk/log v0.16.0 // indirect


### PR DESCRIPTION
Promotes `go.opentelemetry.io/otel/log` to a direct requirement so the module passes the release gate's tidy check before tagging `driver/minimax/v0.1.7`.