### PR TITLE
chore(release): add core v0.1.33 changeset

### DIFF
--- a/.release/core-v0.1.33.json
+++ b/.release/core-v0.1.33.json
@@ -1,0 +1,9 @@
+{
+  "summary": "fix(core): bump OTLP HTTP exporters past GO-2026-4985 — otlptracehttp/otlpmetrichttp to v1.43.0 and otlploghttp to v0.19.0 (with otel/log and sdk/log at v0.19.0, otlptrace at v1.43.0) so oversized collector response bodies are size-limited instead of exhausting memory, aligning the same dependencies across all drivers, backends, examples, and the flowcraft-config validator",
+  "releases": [
+    {
+      "module": "core",
+      "bump": "patch"
+    }
+  ]
+}


### PR DESCRIPTION
Adds `.release/core-v0.1.33.json` (patch) covering the core delta since `core/v0.1.32`: bump OTLP HTTP exporters past GO-2026-4985 (`otlptracehttp`/`otlpmetrichttp` v1.43.0, `otlploghttp` v0.19.0, with `otel/log`/`sdk/log` v0.19.0 and `otlptrace` v1.43.0).

Merging this PR lets the `Release modules` workflow plan `core/v0.1.33`, update the changelog, and publish the tag.