### PR TITLE
chore(deps): bump core to v0.1.33 across dependents

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,3 +68,4 @@
 **/.idea/
 **/.vscode/
 **/__debug_bin*
+skills/flowcraft-config/scripts/validator/validator

--- a/backends/checkpoint/go.mod
+++ b/backends/checkpoint/go.mod
@@ -3,7 +3,7 @@ module github.com/GizClaw/flowcraft/backends/checkpoint
 go 1.26.0
 
 require (
-	github.com/GizClaw/flowcraft/core v0.1.0
+	github.com/GizClaw/flowcraft/core v0.1.33
 	modernc.org/sqlite v1.56.0
 )
 

--- a/backends/checkpoint/go.sum
+++ b/backends/checkpoint/go.sum
@@ -1,5 +1,5 @@
-github.com/GizClaw/flowcraft/core v0.1.0 h1:h0jqPm0Qn34eXtIBdFaYnITSw2S7m2RKDC7UC9pH9lI=
-github.com/GizClaw/flowcraft/core v0.1.0/go.mod h1:t4e1E55RSCsZTDGLCKLeg0Qags72Y2Yz2ZtL3EyGy1k=
+github.com/GizClaw/flowcraft/core v0.1.33 h1:dQrsEe0TvwVguuLOCs6PbizAKItAEosd+7lp1UHTvvI=
+github.com/GizClaw/flowcraft/core v0.1.33/go.mod h1:2EZ+ZFBICJse3GS48m7S+IpXy2s8j/xEy/O7dN5VB+U=
 github.com/cenkalti/backoff/v5 v5.0.3 h1:ZN+IMa753KfX5hd8vVaMixjnqRZ3y8CuJKRKj1xcsSM=
 github.com/cenkalti/backoff/v5 v5.0.3/go.mod h1:rkhZdG3JZukswDf7f0cwqPNk4K0sa+F97BxZthm/crw=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=

--- a/backends/plugin/go.mod
+++ b/backends/plugin/go.mod
@@ -3,7 +3,7 @@ module github.com/GizClaw/flowcraft/backends/plugin
 go 1.26.0
 
 require (
-	github.com/GizClaw/flowcraft/core v0.1.5
+	github.com/GizClaw/flowcraft/core v0.1.33
 	golang.org/x/mod v0.35.0
 )
 

--- a/backends/plugin/go.sum
+++ b/backends/plugin/go.sum
@@ -1,5 +1,5 @@
-github.com/GizClaw/flowcraft/core v0.1.5 h1:WxcJ3i2LSo0OWqesCWzcGV4RRMqeLq6AZNwLjDU/A+Q=
-github.com/GizClaw/flowcraft/core v0.1.5/go.mod h1:t4e1E55RSCsZTDGLCKLeg0Qags72Y2Yz2ZtL3EyGy1k=
+github.com/GizClaw/flowcraft/core v0.1.33 h1:dQrsEe0TvwVguuLOCs6PbizAKItAEosd+7lp1UHTvvI=
+github.com/GizClaw/flowcraft/core v0.1.33/go.mod h1:2EZ+ZFBICJse3GS48m7S+IpXy2s8j/xEy/O7dN5VB+U=
 github.com/cenkalti/backoff/v5 v5.0.3 h1:ZN+IMa753KfX5hd8vVaMixjnqRZ3y8CuJKRKj1xcsSM=
 github.com/cenkalti/backoff/v5 v5.0.3/go.mod h1:rkhZdG3JZukswDf7f0cwqPNk4K0sa+F97BxZthm/crw=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=

--- a/driver/anthropic/go.mod
+++ b/driver/anthropic/go.mod
@@ -3,7 +3,7 @@ module github.com/GizClaw/flowcraft/driver/anthropic
 go 1.25.0
 
 require (
-	github.com/GizClaw/flowcraft/core v0.1.22
+	github.com/GizClaw/flowcraft/core v0.1.33
 	github.com/anthropics/anthropic-sdk-go v1.61.0
 	go.opentelemetry.io/otel/log v0.19.0
 )

--- a/driver/anthropic/go.sum
+++ b/driver/anthropic/go.sum
@@ -1,5 +1,5 @@
-github.com/GizClaw/flowcraft/core v0.1.22 h1:b5X1OHWk6y8Zcqw+QsqgAlDUCj8kDvNdv09epEeyISY=
-github.com/GizClaw/flowcraft/core v0.1.22/go.mod h1:ivaKWysWMtv3j0fj4059RWiSP8kNXBFDYDaFD80Gr74=
+github.com/GizClaw/flowcraft/core v0.1.33 h1:dQrsEe0TvwVguuLOCs6PbizAKItAEosd+7lp1UHTvvI=
+github.com/GizClaw/flowcraft/core v0.1.33/go.mod h1:2EZ+ZFBICJse3GS48m7S+IpXy2s8j/xEy/O7dN5VB+U=
 github.com/anthropics/anthropic-sdk-go v1.61.0 h1:JRTnm1tPqn5xo1xd1zfrcFDlcoWXVMvV1K68YmhpZKw=
 github.com/anthropics/anthropic-sdk-go v1.61.0/go.mod h1:3EfIfmFqxH6rbiLcIP4tPFyXL/IHakx2wDG4OU+TIEI=
 github.com/bahlo/generic-list-go v0.2.0 h1:5sz/EEAK+ls5wF+NeqDpk5+iNdMDXrh3z3nPnH1Wvgk=

--- a/driver/azure/go.mod
+++ b/driver/azure/go.mod
@@ -3,7 +3,7 @@ module github.com/GizClaw/flowcraft/driver/azure
 go 1.25.0
 
 require (
-	github.com/GizClaw/flowcraft/core v0.1.22
+	github.com/GizClaw/flowcraft/core v0.1.33
 	github.com/openai/openai-go/v3 v3.50.0
 	go.opentelemetry.io/otel/log v0.19.0
 )

--- a/driver/azure/go.sum
+++ b/driver/azure/go.sum
@@ -6,8 +6,8 @@ github.com/Azure/azure-sdk-for-go/sdk/internal v1.12.0 h1:fhqpLE3UEXi9lPaBRpQ6Xu
 github.com/Azure/azure-sdk-for-go/sdk/internal v1.12.0/go.mod h1:7dCRMLwisfRH3dBupKeNCioWYUZ4SS09Z14H+7i8ZoY=
 github.com/AzureAD/microsoft-authentication-library-for-go v1.7.2 h1:RHK7bS+HQMslb1sZpAokUt+zTVmue0hKSs2C791hhzU=
 github.com/AzureAD/microsoft-authentication-library-for-go v1.7.2/go.mod h1:HKpQxkWaGLJ+D/5H8QRpyQXA1eKjxkFlOMwck5+33Jk=
-github.com/GizClaw/flowcraft/core v0.1.22 h1:b5X1OHWk6y8Zcqw+QsqgAlDUCj8kDvNdv09epEeyISY=
-github.com/GizClaw/flowcraft/core v0.1.22/go.mod h1:ivaKWysWMtv3j0fj4059RWiSP8kNXBFDYDaFD80Gr74=
+github.com/GizClaw/flowcraft/core v0.1.33 h1:dQrsEe0TvwVguuLOCs6PbizAKItAEosd+7lp1UHTvvI=
+github.com/GizClaw/flowcraft/core v0.1.33/go.mod h1:2EZ+ZFBICJse3GS48m7S+IpXy2s8j/xEy/O7dN5VB+U=
 github.com/cenkalti/backoff/v5 v5.0.3 h1:ZN+IMa753KfX5hd8vVaMixjnqRZ3y8CuJKRKj1xcsSM=
 github.com/cenkalti/backoff/v5 v5.0.3/go.mod h1:rkhZdG3JZukswDf7f0cwqPNk4K0sa+F97BxZthm/crw=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=

--- a/driver/bytedance/go.mod
+++ b/driver/bytedance/go.mod
@@ -3,7 +3,7 @@ module github.com/GizClaw/flowcraft/driver/bytedance
 go 1.25.0
 
 require (
-	github.com/GizClaw/flowcraft/core v0.1.22
+	github.com/GizClaw/flowcraft/core v0.1.33
 	github.com/volcengine/volcengine-go-sdk v1.2.48
 	go.opentelemetry.io/otel/log v0.19.0
 )

--- a/driver/bytedance/go.sum
+++ b/driver/bytedance/go.sum
@@ -1,7 +1,7 @@
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
-github.com/GizClaw/flowcraft/core v0.1.22 h1:b5X1OHWk6y8Zcqw+QsqgAlDUCj8kDvNdv09epEeyISY=
-github.com/GizClaw/flowcraft/core v0.1.22/go.mod h1:ivaKWysWMtv3j0fj4059RWiSP8kNXBFDYDaFD80Gr74=
+github.com/GizClaw/flowcraft/core v0.1.33 h1:dQrsEe0TvwVguuLOCs6PbizAKItAEosd+7lp1UHTvvI=
+github.com/GizClaw/flowcraft/core v0.1.33/go.mod h1:2EZ+ZFBICJse3GS48m7S+IpXy2s8j/xEy/O7dN5VB+U=
 github.com/avast/retry-go v3.0.0+incompatible/go.mod h1:XtSnn+n/sHqQIpZ10K1qAevBhOOCWBLXXy3hyiqqBrY=
 github.com/cenkalti/backoff/v5 v5.0.3 h1:ZN+IMa753KfX5hd8vVaMixjnqRZ3y8CuJKRKj1xcsSM=
 github.com/cenkalti/backoff/v5 v5.0.3/go.mod h1:rkhZdG3JZukswDf7f0cwqPNk4K0sa+F97BxZthm/crw=

--- a/driver/deepseek/go.mod
+++ b/driver/deepseek/go.mod
@@ -3,7 +3,7 @@ module github.com/GizClaw/flowcraft/driver/deepseek
 go 1.25.0
 
 require (
-	github.com/GizClaw/flowcraft/core v0.1.22
+	github.com/GizClaw/flowcraft/core v0.1.33
 	github.com/openai/openai-go/v3 v3.50.0
 	go.opentelemetry.io/otel/log v0.19.0
 )

--- a/driver/deepseek/go.sum
+++ b/driver/deepseek/go.sum
@@ -1,5 +1,5 @@
-github.com/GizClaw/flowcraft/core v0.1.22 h1:b5X1OHWk6y8Zcqw+QsqgAlDUCj8kDvNdv09epEeyISY=
-github.com/GizClaw/flowcraft/core v0.1.22/go.mod h1:ivaKWysWMtv3j0fj4059RWiSP8kNXBFDYDaFD80Gr74=
+github.com/GizClaw/flowcraft/core v0.1.33 h1:dQrsEe0TvwVguuLOCs6PbizAKItAEosd+7lp1UHTvvI=
+github.com/GizClaw/flowcraft/core v0.1.33/go.mod h1:2EZ+ZFBICJse3GS48m7S+IpXy2s8j/xEy/O7dN5VB+U=
 github.com/cenkalti/backoff/v5 v5.0.3 h1:ZN+IMa753KfX5hd8vVaMixjnqRZ3y8CuJKRKj1xcsSM=
 github.com/cenkalti/backoff/v5 v5.0.3/go.mod h1:rkhZdG3JZukswDf7f0cwqPNk4K0sa+F97BxZthm/crw=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=

--- a/driver/kimi/go.mod
+++ b/driver/kimi/go.mod
@@ -3,7 +3,7 @@ module github.com/GizClaw/flowcraft/driver/kimi
 go 1.25.0
 
 require (
-	github.com/GizClaw/flowcraft/core v0.1.22
+	github.com/GizClaw/flowcraft/core v0.1.33
 	go.opentelemetry.io/otel/log v0.19.0
 )
 

--- a/driver/kimi/go.sum
+++ b/driver/kimi/go.sum
@@ -1,5 +1,5 @@
-github.com/GizClaw/flowcraft/core v0.1.22 h1:b5X1OHWk6y8Zcqw+QsqgAlDUCj8kDvNdv09epEeyISY=
-github.com/GizClaw/flowcraft/core v0.1.22/go.mod h1:ivaKWysWMtv3j0fj4059RWiSP8kNXBFDYDaFD80Gr74=
+github.com/GizClaw/flowcraft/core v0.1.33 h1:dQrsEe0TvwVguuLOCs6PbizAKItAEosd+7lp1UHTvvI=
+github.com/GizClaw/flowcraft/core v0.1.33/go.mod h1:2EZ+ZFBICJse3GS48m7S+IpXy2s8j/xEy/O7dN5VB+U=
 github.com/cenkalti/backoff/v5 v5.0.3 h1:ZN+IMa753KfX5hd8vVaMixjnqRZ3y8CuJKRKj1xcsSM=
 github.com/cenkalti/backoff/v5 v5.0.3/go.mod h1:rkhZdG3JZukswDf7f0cwqPNk4K0sa+F97BxZthm/crw=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=

--- a/driver/minimax/go.mod
+++ b/driver/minimax/go.mod
@@ -3,7 +3,7 @@ module github.com/GizClaw/flowcraft/driver/minimax
 go 1.25.0
 
 require (
-	github.com/GizClaw/flowcraft/core v0.1.22
+	github.com/GizClaw/flowcraft/core v0.1.33
 	github.com/anthropics/anthropic-sdk-go v1.61.0
 	go.opentelemetry.io/otel/log v0.19.0
 )

--- a/driver/minimax/go.sum
+++ b/driver/minimax/go.sum
@@ -1,5 +1,5 @@
-github.com/GizClaw/flowcraft/core v0.1.22 h1:b5X1OHWk6y8Zcqw+QsqgAlDUCj8kDvNdv09epEeyISY=
-github.com/GizClaw/flowcraft/core v0.1.22/go.mod h1:ivaKWysWMtv3j0fj4059RWiSP8kNXBFDYDaFD80Gr74=
+github.com/GizClaw/flowcraft/core v0.1.33 h1:dQrsEe0TvwVguuLOCs6PbizAKItAEosd+7lp1UHTvvI=
+github.com/GizClaw/flowcraft/core v0.1.33/go.mod h1:2EZ+ZFBICJse3GS48m7S+IpXy2s8j/xEy/O7dN5VB+U=
 github.com/anthropics/anthropic-sdk-go v1.61.0 h1:JRTnm1tPqn5xo1xd1zfrcFDlcoWXVMvV1K68YmhpZKw=
 github.com/anthropics/anthropic-sdk-go v1.61.0/go.mod h1:3EfIfmFqxH6rbiLcIP4tPFyXL/IHakx2wDG4OU+TIEI=
 github.com/bahlo/generic-list-go v0.2.0 h1:5sz/EEAK+ls5wF+NeqDpk5+iNdMDXrh3z3nPnH1Wvgk=

--- a/driver/openai/go.mod
+++ b/driver/openai/go.mod
@@ -3,7 +3,7 @@ module github.com/GizClaw/flowcraft/driver/openai
 go 1.25.0
 
 require (
-	github.com/GizClaw/flowcraft/core v0.1.22
+	github.com/GizClaw/flowcraft/core v0.1.33
 	github.com/openai/openai-go/v3 v3.50.0
 	go.opentelemetry.io/otel/log v0.19.0
 )

--- a/driver/openai/go.sum
+++ b/driver/openai/go.sum
@@ -1,5 +1,5 @@
-github.com/GizClaw/flowcraft/core v0.1.22 h1:b5X1OHWk6y8Zcqw+QsqgAlDUCj8kDvNdv09epEeyISY=
-github.com/GizClaw/flowcraft/core v0.1.22/go.mod h1:ivaKWysWMtv3j0fj4059RWiSP8kNXBFDYDaFD80Gr74=
+github.com/GizClaw/flowcraft/core v0.1.33 h1:dQrsEe0TvwVguuLOCs6PbizAKItAEosd+7lp1UHTvvI=
+github.com/GizClaw/flowcraft/core v0.1.33/go.mod h1:2EZ+ZFBICJse3GS48m7S+IpXy2s8j/xEy/O7dN5VB+U=
 github.com/cenkalti/backoff/v5 v5.0.3 h1:ZN+IMa753KfX5hd8vVaMixjnqRZ3y8CuJKRKj1xcsSM=
 github.com/cenkalti/backoff/v5 v5.0.3/go.mod h1:rkhZdG3JZukswDf7f0cwqPNk4K0sa+F97BxZthm/crw=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=

--- a/driver/qwen/go.mod
+++ b/driver/qwen/go.mod
@@ -3,7 +3,7 @@ module github.com/GizClaw/flowcraft/driver/qwen
 go 1.25.0
 
 require (
-	github.com/GizClaw/flowcraft/core v0.1.22
+	github.com/GizClaw/flowcraft/core v0.1.33
 	go.opentelemetry.io/otel/log v0.19.0
 )
 

--- a/driver/qwen/go.sum
+++ b/driver/qwen/go.sum
@@ -1,5 +1,5 @@
-github.com/GizClaw/flowcraft/core v0.1.22 h1:b5X1OHWk6y8Zcqw+QsqgAlDUCj8kDvNdv09epEeyISY=
-github.com/GizClaw/flowcraft/core v0.1.22/go.mod h1:ivaKWysWMtv3j0fj4059RWiSP8kNXBFDYDaFD80Gr74=
+github.com/GizClaw/flowcraft/core v0.1.33 h1:dQrsEe0TvwVguuLOCs6PbizAKItAEosd+7lp1UHTvvI=
+github.com/GizClaw/flowcraft/core v0.1.33/go.mod h1:2EZ+ZFBICJse3GS48m7S+IpXy2s8j/xEy/O7dN5VB+U=
 github.com/cenkalti/backoff/v5 v5.0.3 h1:ZN+IMa753KfX5hd8vVaMixjnqRZ3y8CuJKRKj1xcsSM=
 github.com/cenkalti/backoff/v5 v5.0.3/go.mod h1:rkhZdG3JZukswDf7f0cwqPNk4K0sa+F97BxZthm/crw=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=

--- a/examples/forge/go.mod
+++ b/examples/forge/go.mod
@@ -4,7 +4,7 @@ go 1.26.0
 
 require (
 	github.com/GizClaw/flowcraft/backends/plugin v0.1.0
-	github.com/GizClaw/flowcraft/core v0.1.5
+	github.com/GizClaw/flowcraft/core v0.1.33
 	github.com/GizClaw/flowcraft/driver/deepseek v0.1.0
 	github.com/GizClaw/flowcraft/driver/openai v0.1.0
 	github.com/charmbracelet/bubbles v1.0.0

--- a/examples/forge/go.sum
+++ b/examples/forge/go.sum
@@ -1,7 +1,7 @@
 github.com/GizClaw/flowcraft/backends/plugin v0.1.0 h1:gGiSJhbxIUciXsL8Ody7yVG8Yop3mAewB8oCr977H6M=
 github.com/GizClaw/flowcraft/backends/plugin v0.1.0/go.mod h1:6zHbc3tu+QOYDXfz56d3SDFX78AlHprU11Wd+SpbaFg=
-github.com/GizClaw/flowcraft/core v0.1.5 h1:WxcJ3i2LSo0OWqesCWzcGV4RRMqeLq6AZNwLjDU/A+Q=
-github.com/GizClaw/flowcraft/core v0.1.5/go.mod h1:t4e1E55RSCsZTDGLCKLeg0Qags72Y2Yz2ZtL3EyGy1k=
+github.com/GizClaw/flowcraft/core v0.1.33 h1:dQrsEe0TvwVguuLOCs6PbizAKItAEosd+7lp1UHTvvI=
+github.com/GizClaw/flowcraft/core v0.1.33/go.mod h1:2EZ+ZFBICJse3GS48m7S+IpXy2s8j/xEy/O7dN5VB+U=
 github.com/GizClaw/flowcraft/driver/deepseek v0.1.0 h1:e5wLHDQ0Tn64v61k6tDxYmXcPPGupLgRYbEN4AoytkE=
 github.com/GizClaw/flowcraft/driver/deepseek v0.1.0/go.mod h1:XmMdDsBx4ERJrIfcs87w7nSZsXXQe2BzWgIfbni0Rrw=
 github.com/GizClaw/flowcraft/driver/openai v0.1.0 h1:SeuCDzYCM6t78RSaS2Kl82DVLwqMjlWf+wfPJ2+5WNw=

--- a/skills/flowcraft-config/scripts/validator/go.mod
+++ b/skills/flowcraft-config/scripts/validator/go.mod
@@ -2,7 +2,7 @@ module github.com/GizClaw/flowcraft/skills/flowcraft-config/scripts/validator
 
 go 1.26.0
 
-require github.com/GizClaw/flowcraft/core v0.1.28
+require github.com/GizClaw/flowcraft/core v0.1.33
 
 require (
 	github.com/cenkalti/backoff/v5 v5.0.3 // indirect

--- a/skills/flowcraft-config/scripts/validator/go.sum
+++ b/skills/flowcraft-config/scripts/validator/go.sum
@@ -1,5 +1,5 @@
-github.com/GizClaw/flowcraft/core v0.1.28 h1:8ds1G6mCbc7nyXf+JCDLS5XkziXyEKWjXw3bCGIewIc=
-github.com/GizClaw/flowcraft/core v0.1.28/go.mod h1:ivaKWysWMtv3j0fj4059RWiSP8kNXBFDYDaFD80Gr74=
+github.com/GizClaw/flowcraft/core v0.1.33 h1:dQrsEe0TvwVguuLOCs6PbizAKItAEosd+7lp1UHTvvI=
+github.com/GizClaw/flowcraft/core v0.1.33/go.mod h1:2EZ+ZFBICJse3GS48m7S+IpXy2s8j/xEy/O7dN5VB+U=
 github.com/cenkalti/backoff/v5 v5.0.3 h1:ZN+IMa753KfX5hd8vVaMixjnqRZ3y8CuJKRKj1xcsSM=
 github.com/cenkalti/backoff/v5 v5.0.3/go.mod h1:rkhZdG3JZukswDf7f0cwqPNk4K0sa+F97BxZthm/crw=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=


### PR DESCRIPTION
Bumps `github.com/GizClaw/flowcraft/core` to v0.1.33 in every module that depends on it:

- drivers: openai, deepseek, azure, anthropic, minimax, qwen, kimi, bytedance (v0.1.22 → v0.1.33)
- backends: checkpoint (v0.1.0), plugin (v0.1.5) → v0.1.33
- examples/forge (v0.1.5 → v0.1.33)
- skills/flowcraft-config/scripts/validator (v0.1.28 → v0.1.33)

So standalone (`GOWORK=off`) builds of these modules resolve the released core, which carries the GO-2026-4985 OTLP HTTP exporter fix (otlptracehttp/otlpmetrichttp v1.43.0, otlploghttp v0.19.0).

Verified: `go mod tidy -diff` clean in workspace and `GOWORK=off` modes for all 12 modules; `GOWORK=off go build ./...` passes everywhere; `make ci` green; no changesets added (core is already released at v0.1.33).