### PR TITLE
feat(core): stream image generation and add image quality

### DIFF
--- a/core/inference/decision.go
+++ b/core/inference/decision.go
@@ -44,6 +44,7 @@ const (
 	FieldGenerateIntentImageSeed             FieldID = "generate.input.content.intent.image.seed"
 	FieldGenerateIntentImageOutputFormat     FieldID = "generate.input.content.intent.image.output_format"
 	FieldGenerateIntentImageDelivery         FieldID = "generate.input.content.intent.image.delivery"
+	FieldGenerateIntentImageQuality          FieldID = "generate.input.content.intent.image.quality"
 	FieldGenerateIntentAudio                 FieldID = "generate.input.content.intent.audio"
 	FieldGenerateIntentAudioVoice            FieldID = "generate.input.content.intent.audio.voice"
 	FieldGenerateIntentAudioVoiceID          FieldID = "generate.input.content.intent.audio.voice.id"

--- a/core/inference/generate.go
+++ b/core/inference/generate.go
@@ -291,6 +291,9 @@ func appendGenerateIntentFields(fields []FieldID, intent Intent) []FieldID {
 		if intent.Image.Delivery != "" {
 			fields = append(fields, FieldGenerateIntentImageDelivery)
 		}
+		if intent.Image.Quality != "" {
+			fields = append(fields, FieldGenerateIntentImageQuality)
+		}
 	}
 	if intent.Audio != nil {
 		fields = append(fields, FieldGenerateIntentAudio, FieldGenerateIntentAudioVoice)

--- a/core/inference/generate_intent.go
+++ b/core/inference/generate_intent.go
@@ -188,12 +188,13 @@ func (i TextIntent) Validate() error {
 }
 
 type ImageIntent struct {
-	Size         *media.ImageSize  `json:"size,omitempty"`
-	AspectRatio  media.AspectRatio `json:"aspect_ratio,omitempty"`
-	Count        *int              `json:"count,omitempty"`
-	Seed         *int64            `json:"seed,omitempty"`
-	OutputFormat media.ImageFormat `json:"output_format,omitempty"`
-	Delivery     media.SourceKind  `json:"delivery,omitempty"`
+	Size         *media.ImageSize   `json:"size,omitempty"`
+	AspectRatio  media.AspectRatio  `json:"aspect_ratio,omitempty"`
+	Count        *int               `json:"count,omitempty"`
+	Seed         *int64             `json:"seed,omitempty"`
+	OutputFormat media.ImageFormat  `json:"output_format,omitempty"`
+	Delivery     media.SourceKind   `json:"delivery,omitempty"`
+	Quality      media.ImageQuality `json:"quality,omitempty"`
 }
 
 func (i ImageIntent) Clone() ImageIntent {
@@ -227,6 +228,11 @@ func (i ImageIntent) Validate() error {
 	}
 	if i.Delivery != "" {
 		if err := i.Delivery.Validate(); err != nil {
+			return err
+		}
+	}
+	if i.Quality != "" {
+		if err := i.Quality.Validate(); err != nil {
 			return err
 		}
 	}

--- a/core/inference/generate_intent_test.go
+++ b/core/inference/generate_intent_test.go
@@ -1,0 +1,34 @@
+package inference
+
+import (
+	"testing"
+
+	"github.com/GizClaw/flowcraft/core/message/media"
+)
+
+func TestImageIntentQualityValidate(t *testing.T) {
+	intent := Intent{
+		Image: &ImageIntent{Quality: media.ImageQualityHigh},
+	}
+	if err := intent.Validate(); err != nil {
+		t.Fatalf("high quality Validate() = %v, want nil", err)
+	}
+	intent.Image.Quality = media.ImageQuality("ultra")
+	if err := intent.Validate(); err == nil {
+		t.Fatal("unknown image quality was accepted")
+	}
+}
+
+func TestImageIntentCloneCopiesQuality(t *testing.T) {
+	intent := Intent{
+		Image: &ImageIntent{Quality: media.ImageQualityLow},
+	}
+	cloned := intent.Clone()
+	if cloned.Image.Quality != media.ImageQualityLow {
+		t.Fatalf("clone quality = %q, want low", cloned.Image.Quality)
+	}
+	cloned.Image.Quality = media.ImageQualityHigh
+	if intent.Image.Quality != media.ImageQualityLow {
+		t.Fatal("clone mutated the source intent")
+	}
+}

--- a/core/inference/generate_stream.go
+++ b/core/inference/generate_stream.go
@@ -107,9 +107,17 @@ func (d AudioPartDelta) validateGenerateDelta() error {
 func (AudioPartDelta) inferencePartDelta() {}
 
 // ImagePartDelta carries one complete image. Images are not incrementally
-// assembled by the generic runtime.
+// assembled by the generic runtime. A delta marked Interim is a progress
+// snapshot: it replaces any image previously accumulated at the same part
+// index, and the terminal image for that index (a delta without Interim)
+// replaces the last snapshot. Interim deltas surface to stream consumers as
+// progress, while the final result keeps only the last image per index.
 type ImagePartDelta struct {
 	Part message.ImagePart `json:"part"`
+	// Interim marks the delta as a progress snapshot that replaces any
+	// previously accumulated image at the same part index. A part index
+	// must end with a non-Interim delta to be included in the result.
+	Interim bool `json:"interim,omitempty"`
 }
 
 func (ImagePartDelta) Kind() message.PartKind { return message.PartImage }
@@ -222,6 +230,7 @@ type generatePartAccumulator struct {
 	audioFormat   *media.AudioFormat
 	audioDuration *int64
 	completeImage *message.ImagePart
+	imageInterim  bool
 
 	reasoningSignature string
 	reasoningID        string
@@ -399,11 +408,12 @@ func (p *generatePartAccumulator) add(delta PartDelta) error {
 		}
 		_, _ = p.audio.Write(value.Data)
 	case ImagePartDelta:
-		if p.completeImage != nil {
+		if !value.Interim && p.completeImage != nil && !p.imageInterim {
 			return fmt.Errorf("image emitted more than one complete value")
 		}
 		image := value.Part
 		p.completeImage = &image
+		p.imageInterim = value.Interim
 	case ReasoningDelta:
 		p.text.WriteString(value.Text)
 		if value.Signature != "" {

--- a/core/inference/generate_stream_image_test.go
+++ b/core/inference/generate_stream_image_test.go
@@ -1,0 +1,65 @@
+package inference
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/GizClaw/flowcraft/core/message"
+	"github.com/GizClaw/flowcraft/core/message/media"
+)
+
+func streamImagePart(t *testing.T, data []byte) message.ImagePart {
+	t.Helper()
+	source, err := media.NewImageBytes(data, "image/png")
+	if err != nil {
+		t.Fatalf("NewImageBytes: %v", err)
+	}
+	return message.ImagePart{Source: source}
+}
+
+// TestImagePartAccumulatorInterimSnapshots guards the progress-snapshot
+// semantics of ImagePartDelta: interim deltas replace the previous image at
+// the same part index, and the terminal delta replaces the last snapshot.
+func TestImagePartAccumulatorInterimSnapshots(t *testing.T) {
+	previewA := streamImagePart(t, []byte("preview-a"))
+	previewB := streamImagePart(t, []byte("preview-b"))
+	final := streamImagePart(t, []byte("final"))
+
+	acc := &generatePartAccumulator{kind: message.PartImage}
+	if err := acc.add(ImagePartDelta{Part: previewA, Interim: true}); err != nil {
+		t.Fatalf("add interim preview A: %v", err)
+	}
+	if err := acc.add(ImagePartDelta{Part: previewB, Interim: true}); err != nil {
+		t.Fatalf("add interim preview B: %v", err)
+	}
+	if err := acc.add(ImagePartDelta{Part: final}); err != nil {
+		t.Fatalf("add final image: %v", err)
+	}
+	part, err := acc.result()
+	if err != nil {
+		t.Fatalf("result: %v", err)
+	}
+	image, ok := part.(message.ImagePart)
+	if !ok {
+		t.Fatalf("result part = %T, want ImagePart", part)
+	}
+	if got := image.Source.Bytes(); !bytes.Equal(got, []byte("final")) {
+		t.Fatalf("result image bytes = %q, want final image", got)
+	}
+}
+
+// TestImagePartAccumulatorRejectsDuplicateFinal guards the terminal-image
+// rule: a part index that already holds a final image rejects another final
+// delta, while interim snapshots may keep replacing it.
+func TestImagePartAccumulatorRejectsDuplicateFinal(t *testing.T) {
+	first := streamImagePart(t, []byte("first"))
+	second := streamImagePart(t, []byte("second"))
+
+	acc := &generatePartAccumulator{kind: message.PartImage}
+	if err := acc.add(ImagePartDelta{Part: first}); err != nil {
+		t.Fatalf("add first final image: %v", err)
+	}
+	if err := acc.add(ImagePartDelta{Part: second}); err == nil {
+		t.Fatal("second final image at the same part index succeeded, want error")
+	}
+}

--- a/core/message/media/image.go
+++ b/core/message/media/image.go
@@ -69,3 +69,29 @@ func (f ImageFormat) MediaType() string {
 		return ""
 	}
 }
+
+// ImageQuality is the canonical generation quality tier. The values mirror
+// the gpt-image family's quality parameter — the only image provider that
+// exposes a per-request quality knob. Providers without a native quality
+// parameter reject the field at compile time rather than approximate it.
+type ImageQuality string
+
+const (
+	// ImageQualityAuto defers to the provider's default quality.
+	ImageQualityAuto ImageQuality = "auto"
+	// ImageQualityLow trades quality for speed.
+	ImageQualityLow ImageQuality = "low"
+	// ImageQualityMedium is the middle quality tier.
+	ImageQualityMedium ImageQuality = "medium"
+	// ImageQualityHigh is the best quality tier.
+	ImageQualityHigh ImageQuality = "high"
+)
+
+func (q ImageQuality) Validate() error {
+	switch q {
+	case ImageQualityAuto, ImageQualityLow, ImageQualityMedium, ImageQualityHigh:
+		return nil
+	default:
+		return fmt.Errorf("unknown image quality %q", q)
+	}
+}

--- a/core/message/media/image_test.go
+++ b/core/message/media/image_test.go
@@ -21,4 +21,17 @@ func TestImageGeometryAndFormatValidate(t *testing.T) {
 	if err := ImageFormat("bitmap").Validate(); err == nil {
 		t.Fatal("unknown image format was accepted")
 	}
+	for _, quality := range []ImageQuality{
+		ImageQualityAuto,
+		ImageQualityLow,
+		ImageQualityMedium,
+		ImageQualityHigh,
+	} {
+		if err := quality.Validate(); err != nil {
+			t.Errorf("ImageQuality(%q).Validate: %v", quality, err)
+		}
+	}
+	if err := ImageQuality("ultra").Validate(); err == nil {
+		t.Fatal("unknown image quality was accepted")
+	}
 }

--- a/docs/guides/graph.md
+++ b/docs/guides/graph.md
@@ -169,7 +169,7 @@ Behavior:
   generation modality: text controls (`response`, `max_output_tokens`,
   `tools`, `tool_choice`, `temperature`, `top_p`, `reasoning_enabled`,
   `reasoning_effort`), image (`size`, `aspect_ratio`, `count`, `seed`,
-  `output_format`, `delivery`), audio/tts (`voice`, `format`, `speed`,
+  `output_format`, `delivery`, `quality`), audio/tts (`voice`, `format`, `speed`,
   `count`), and video (`duration_millis`, `resolution`, `aspect_ratio`,
   `seed`, `watermark`). When `intent` is absent the node defaults to plain
   text generation. `tools` / `all_tools` / `tool_choice` remain node-level

--- a/driver/azure/doc.go
+++ b/driver/azure/doc.go
@@ -5,9 +5,10 @@
 //
 //   - Generate: Responses API over chat deployments, unary + SSE stream.
 //   - Embed: embeddings deployments.
-//   - Image: gpt-image generation and image-to-image edits, unary only;
-//     inline reference images route to images/edits, and the image_options
-//     extension carries a mask for local inpainting.
+//   - Image: gpt-image generation and image-to-image edits, unary + SSE
+//     stream with optional partial-image previews; inline reference images
+//     route to images/edits, and the image_options extension carries a mask
+//     for local inpainting plus the partial_images preview count.
 //   - Audio generation: speech deployments, unary + raw byte stream.
 //
 // Transcription is intentionally absent: core/inference does not expose the

--- a/driver/azure/extensions.go
+++ b/driver/azure/extensions.go
@@ -143,6 +143,13 @@ type ImageOptions struct {
 	// reference image only; the mask itself must be inline bytes because
 	// images/edits uploads multipart files.
 	Mask *media.ImageSource `json:"mask,omitempty"`
+	// PartialImages sets the number of progress previews streamed before
+	// the final image when the request runs in the stream execution shape.
+	// It must be between 0 and 3: 0 delivers the final image in a single
+	// stream event, and 1-3 deliver interim previews as they are generated.
+	// Nil keeps the provider default (0). It has no effect on the unary
+	// execution shape.
+	PartialImages *int `json:"partial_images,omitempty"`
 }
 
 func (o ImageOptions) ProviderID() string  { return extensionProvider(o.Provider) }
@@ -153,15 +160,25 @@ func (o ImageOptions) ActiveFields() []inference.ExtensionField {
 	if o.Mask != nil {
 		fields = append(fields, "mask")
 	}
+	if o.PartialImages != nil {
+		fields = append(fields, "partial_images")
+	}
 	return fields
 }
 
 func (o ImageOptions) Validate() error {
-	if o.Mask == nil {
-		return nil
+	if mask := o.Mask; mask != nil {
+		if base := mask.BaseMediaType(); base != "image/png" {
+			return fmt.Errorf("mask must be a PNG image, not %q", base)
+		}
 	}
-	if base := o.Mask.BaseMediaType(); base != "image/png" {
-		return fmt.Errorf("mask must be a PNG image, not %q", base)
+	if partial := o.PartialImages; partial != nil {
+		if *partial < 0 || *partial > 3 {
+			return fmt.Errorf(
+				"partial_images must be between 0 and 3, not %d",
+				*partial,
+			)
+		}
 	}
 	return nil
 }
@@ -171,6 +188,7 @@ func (o ImageOptions) Clone() inference.Extension {
 		mask := o.Mask.Clone()
 		o.Mask = &mask
 	}
+	o.PartialImages = clonePointer(o.PartialImages)
 	return o
 }
 

--- a/driver/azure/extensions_test.go
+++ b/driver/azure/extensions_test.go
@@ -16,9 +16,17 @@ func TestImageOptionsActiveFields(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewImageBytes: %v", err)
 	}
-	fields := (ImageOptions{Mask: &mask}).ActiveFields()
-	if len(fields) != 1 || string(fields[0]) != "mask" {
-		t.Fatalf("ActiveFields = %#v, want [mask]", fields)
+	if fields := (ImageOptions{Mask: &mask}).ActiveFields(); len(fields) != 1 ||
+		string(fields[0]) != "mask" {
+		t.Fatalf("mask ActiveFields = %#v, want [mask]", fields)
+	}
+	two := 2
+	if fields := (ImageOptions{PartialImages: &two}).ActiveFields(); len(fields) != 1 ||
+		string(fields[0]) != "partial_images" {
+		t.Fatalf("partial_images ActiveFields = %#v, want [partial_images]", fields)
+	}
+	if fields := (ImageOptions{Mask: &mask, PartialImages: &two}).ActiveFields(); len(fields) != 2 {
+		t.Fatalf("combined ActiveFields = %#v, want [mask partial_images]", fields)
 	}
 }
 
@@ -43,12 +51,29 @@ func TestImageOptionsValidateMask(t *testing.T) {
 	}
 }
 
+func TestImageOptionsValidatePartialImages(t *testing.T) {
+	for _, count := range []int{0, 1, 2, 3} {
+		value := count
+		if err := (ImageOptions{PartialImages: &value}).Validate(); err != nil {
+			t.Errorf("partial_images=%d Validate() = %v, want nil", count, err)
+		}
+	}
+	for _, count := range []int{-1, 4, 9} {
+		value := count
+		err := (ImageOptions{PartialImages: &value}).Validate()
+		if err == nil || !strings.Contains(err.Error(), "partial_images") {
+			t.Errorf("partial_images=%d Validate() = %v, want range error", count, err)
+		}
+	}
+}
+
 func TestImageOptionsCloneDeepCopiesMask(t *testing.T) {
 	mask, err := media.NewImageBytes(testPNG, "image/png")
 	if err != nil {
 		t.Fatalf("NewImageBytes: %v", err)
 	}
-	options := ImageOptions{Mask: &mask}
+	partial := 3
+	options := ImageOptions{Mask: &mask, PartialImages: &partial}
 	cloned, ok := options.Clone().(ImageOptions)
 	if !ok {
 		t.Fatalf("Clone() type = %T, want ImageOptions", options.Clone())
@@ -58,5 +83,11 @@ func TestImageOptionsCloneDeepCopiesMask(t *testing.T) {
 	}
 	if !bytes.Equal(cloned.Mask.Bytes(), options.Mask.Bytes()) {
 		t.Fatal("Clone() lost the mask bytes")
+	}
+	if cloned.PartialImages == nil || cloned.PartialImages == options.PartialImages {
+		t.Fatal("Clone() must deep-copy partial_images")
+	}
+	if *cloned.PartialImages != 3 {
+		t.Fatalf("Clone() partial_images = %d, want 3", *cloned.PartialImages)
 	}
 }

--- a/driver/azure/image.go
+++ b/driver/azure/image.go
@@ -6,14 +6,20 @@ import (
 	"encoding/base64"
 	"fmt"
 	"io"
+	"net/http"
+	"strconv"
 	"strings"
 
+	"github.com/GizClaw/flowcraft/core/errdefs"
 	"github.com/GizClaw/flowcraft/core/inference"
 	"github.com/GizClaw/flowcraft/core/message"
 	"github.com/GizClaw/flowcraft/core/message/media"
 
 	"github.com/openai/openai-go/v3"
+	"github.com/openai/openai-go/v3/option"
 	"github.com/openai/openai-go/v3/packages/param"
+	"github.com/openai/openai-go/v3/packages/respjson"
+	"github.com/openai/openai-go/v3/packages/ssestream"
 )
 
 // Image generation runs on the images endpoint (gpt-image). Text-only
@@ -27,11 +33,13 @@ import (
 // delivery has no native channel and is rejected.
 
 type imageWire struct {
-	model  string
-	prompt string
-	size   string // WxH; gpt-image-2-family models accept arbitrary sizes
-	count  int
-	format string // png | jpeg | webp
+	model         string
+	prompt        string
+	size          string // WxH; gpt-image-2-family models accept arbitrary sizes
+	count         int
+	format        string // png | jpeg | webp
+	quality       string // auto | low | medium | high
+	partialImages int    // 0-3 progress previews before the final image (stream only)
 	// images are inline reference images for image-to-image edits; empty
 	// means a text-only generation.
 	images []wireImage
@@ -67,6 +75,8 @@ type imageRaw struct {
 	inputTokens  int64
 	outputTokens int64
 	totalTokens  int64
+	requestID    string
+	responseID   string
 }
 
 // imageSize validates one canonical size against the gpt-image-2-family
@@ -111,12 +121,6 @@ func compileImage(
 			request.ActiveFieldsFor(shape),
 		)
 		wire := imageWire{model: model, count: 1}
-		if shape == inference.GenerateExecutionStream {
-			ledger.reject(
-				inference.FieldGenerateExecutionStream,
-				"image generation is unary on this provider",
-			)
-		}
 
 		var prompt []string
 		collect := func(parts []message.Part, fields map[message.PartKind]inference.FieldID) {
@@ -212,10 +216,47 @@ func compileImage(
 					"gpt-image returns inline payloads only; URL delivery has no channel",
 				)
 			}
+			if image.Quality != "" {
+				switch image.Quality {
+				case media.ImageQualityAuto,
+					media.ImageQualityLow,
+					media.ImageQualityMedium,
+					media.ImageQualityHigh:
+					wire.quality = string(image.Quality)
+				default:
+					ledger.reject(
+						inference.FieldGenerateIntentImageQuality,
+						fmt.Sprintf(
+							"image quality %q is not supported",
+							image.Quality,
+						),
+					)
+				}
+			}
 		}
 		options, other := operationExtensions[ImageOptions](request.Extensions)
 		rejectOtherExtensions("image generation", other, ledger)
 		compileImageOptions(&wire, options, ledger)
+		if partial := options.PartialImages; partial != nil {
+			field := inference.ExtensionField("partial_images").Qualify(options)
+			switch {
+			case shape != inference.GenerateExecutionStream:
+				ledger.reject(
+					field,
+					"partial_images applies to the stream execution shape",
+				)
+			case *partial < 0 || *partial > 3:
+				ledger.reject(
+					field,
+					fmt.Sprintf(
+						"partial_images must be between 0 and 3, not %d",
+						*partial,
+					),
+				)
+			default:
+				wire.partialImages = *partial
+			}
+		}
 		if intent.Audio != nil {
 			ledger.reject(
 				inference.FieldGenerateIntentAudio,
@@ -274,46 +315,19 @@ func transportImage(
 	return func(ctx context.Context, wire imageWire) (imageRaw, error) {
 		var response *openai.ImagesResponse
 		var err error
+		var requestID string
 		if len(wire.images) == 0 {
-			params := openai.ImageGenerateParams{
-				Model:  wire.model,
-				Prompt: wire.prompt,
-				N:      param.NewOpt(int64(wire.count)),
-			}
-			if wire.size != "" {
-				params.Size = openai.ImageGenerateParamsSize(wire.size)
-			}
-			if wire.format != "" {
-				params.OutputFormat = openai.ImageGenerateParamsOutputFormat(wire.format)
-			}
-			response, err = client.Images.Generate(ctx, params)
+			response, err = client.Images.Generate(
+				ctx,
+				imageGenerateParams(wire),
+				captureRequestID(&requestID),
+			)
 		} else {
-			readers := make([]io.Reader, 0, len(wire.images))
-			for _, image := range wire.images {
-				readers = append(readers, imageFile{
-					Reader:      bytes.NewReader(image.data),
-					contentType: image.mediaType,
-				})
-			}
-			params := openai.ImageEditParams{
-				Model:  openai.ImageModel(wire.model),
-				Prompt: wire.prompt,
-				N:      param.NewOpt(int64(wire.count)),
-				Image:  openai.ImageEditParamsImageUnion{OfFileArray: readers},
-			}
-			if wire.size != "" {
-				params.Size = openai.ImageEditParamsSize(wire.size)
-			}
-			if wire.format != "" {
-				params.OutputFormat = openai.ImageEditParamsOutputFormat(wire.format)
-			}
-			if len(wire.mask.data) > 0 {
-				params.Mask = imageFile{
-					Reader:      bytes.NewReader(wire.mask.data),
-					contentType: wire.mask.mediaType,
-				}
-			}
-			response, err = client.Images.Edit(ctx, params)
+			response, err = client.Images.Edit(
+				ctx,
+				imageEditParams(wire),
+				captureRequestID(&requestID),
+			)
 		}
 		if err != nil {
 			return imageRaw{}, classifyError(err)
@@ -323,6 +337,8 @@ func transportImage(
 			inputTokens:  response.Usage.InputTokens,
 			outputTokens: response.Usage.OutputTokens,
 			totalTokens:  response.Usage.TotalTokens,
+			requestID:    requestID,
+			responseID:   responseBodyID(response.JSON.ExtraFields),
 		}
 		for index, image := range response.Data {
 			data, err := base64.StdEncoding.DecodeString(image.B64JSON)
@@ -337,6 +353,103 @@ func transportImage(
 		}
 		return raw, nil
 	}
+}
+
+// captureRequestID returns a per-call request option whose middleware
+// records the provider's request-id response header. The middleware runs on
+// every HTTP attempt, so the last attempt's header wins. Azure OpenAI
+// echoes the request identifier as x-request-id, with apim-request-id as an
+// API Management fallback.
+func captureRequestID(target *string) option.RequestOption {
+	return option.WithMiddleware(func(
+		req *http.Request,
+		next option.MiddlewareNext,
+	) (*http.Response, error) {
+		response, err := next(req)
+		if err != nil || response == nil {
+			return response, err
+		}
+		if id := response.Header.Get("x-request-id"); id != "" {
+			*target = id
+		} else if id := response.Header.Get("apim-request-id"); id != "" {
+			*target = id
+		}
+		return response, err
+	})
+}
+
+// responseBodyID extracts a response-object id the SDK does not model from
+// the decoded body's extra fields, when the provider echoes one.
+func responseBodyID(fields map[string]respjson.Field) string {
+	field, ok := fields["id"]
+	if !ok || field.Raw() == "" {
+		return ""
+	}
+	id, err := strconv.Unquote(field.Raw())
+	if err != nil {
+		return ""
+	}
+	return id
+}
+
+// imageGenerateParams renders the images/generations request body. Both the
+// unary and streaming transports share it; partialImages stays zero off the
+// stream shape, so unary requests never carry the streaming-only parameter.
+func imageGenerateParams(wire imageWire) openai.ImageGenerateParams {
+	params := openai.ImageGenerateParams{
+		Model:  wire.model,
+		Prompt: wire.prompt,
+		N:      param.NewOpt(int64(wire.count)),
+	}
+	if wire.size != "" {
+		params.Size = openai.ImageGenerateParamsSize(wire.size)
+	}
+	if wire.format != "" {
+		params.OutputFormat = openai.ImageGenerateParamsOutputFormat(wire.format)
+	}
+	if wire.quality != "" {
+		params.Quality = openai.ImageGenerateParamsQuality(wire.quality)
+	}
+	if wire.partialImages > 0 {
+		params.PartialImages = param.NewOpt(int64(wire.partialImages))
+	}
+	return params
+}
+
+// imageEditParams renders the images/edits multipart request body.
+func imageEditParams(wire imageWire) openai.ImageEditParams {
+	readers := make([]io.Reader, 0, len(wire.images))
+	for _, image := range wire.images {
+		readers = append(readers, imageFile{
+			Reader:      bytes.NewReader(image.data),
+			contentType: image.mediaType,
+		})
+	}
+	params := openai.ImageEditParams{
+		Model:  openai.ImageModel(wire.model),
+		Prompt: wire.prompt,
+		N:      param.NewOpt(int64(wire.count)),
+		Image:  openai.ImageEditParamsImageUnion{OfFileArray: readers},
+	}
+	if wire.size != "" {
+		params.Size = openai.ImageEditParamsSize(wire.size)
+	}
+	if wire.format != "" {
+		params.OutputFormat = openai.ImageEditParamsOutputFormat(wire.format)
+	}
+	if wire.quality != "" {
+		params.Quality = openai.ImageEditParamsQuality(wire.quality)
+	}
+	if wire.partialImages > 0 {
+		params.PartialImages = param.NewOpt(int64(wire.partialImages))
+	}
+	if len(wire.mask.data) > 0 {
+		params.Mask = imageFile{
+			Reader:      bytes.NewReader(wire.mask.data),
+			contentType: wire.mask.mediaType,
+		}
+	}
+	return params
 }
 
 func decodeImage(
@@ -374,6 +487,10 @@ func decodeImage(
 			Role:    message.RoleAssistant,
 			Content: message.Content{Parts: parts},
 		},
+		Metadata: inference.Metadata{
+			RequestID:  raw.requestID,
+			ResponseID: raw.responseID,
+		},
 		FinishReason: inference.FinishCompleted,
 		Usage: inference.Usage{
 			InputTokens:     raw.inputTokens,
@@ -399,18 +516,258 @@ func sniffImageMediaType(data []byte) string {
 	return ""
 }
 
+// ---------------------------------------------------------------------------
+// Streaming.
+// ---------------------------------------------------------------------------
+
+// imageStreamRaw is one event from the image streaming surface after part
+// index assignment. interim marks a progress preview; the final image for
+// an output arrives with interim false and carries the cumulative usage.
+type imageStreamRaw struct {
+	partIndex    int
+	interim      bool
+	b64          string
+	outputFormat string
+	usage        inference.Usage
+	requestID    string
+}
+
+// imageStreamEvent is the driver-side view of one SDK image stream event.
+// The SDK exposes generation and edit streams as two sealed unions with
+// identical shapes; this view keeps both behind one concrete surface for
+// the stream wrapper and decoder.
+type imageStreamEvent struct {
+	b64          string
+	outputFormat string
+	usage        inference.Usage
+	partial      bool
+	completed    bool
+	rawType      string
+}
+
+// imageSDKStream is the small SDK surface the wrapper needs. The SDK stream
+// types are concrete, so generation and edit streams each adapt it.
+type imageSDKStream interface {
+	Next() bool
+	Current() imageStreamEvent
+	Err() error
+	Close() error
+}
+
+type imageGenSDKStream struct {
+	stream *ssestream.Stream[openai.ImageGenStreamEventUnion]
+}
+
+func (s imageGenSDKStream) Next() bool { return s.stream.Next() }
+func (s imageGenSDKStream) Err() error { return s.stream.Err() }
+func (s imageGenSDKStream) Close() error {
+	return s.stream.Close()
+}
+
+func (s imageGenSDKStream) Current() imageStreamEvent {
+	event := s.stream.Current()
+	return imageStreamEvent{
+		b64:          event.B64JSON,
+		outputFormat: event.OutputFormat,
+		usage: inference.Usage{
+			InputTokens:  event.Usage.InputTokens,
+			OutputTokens: event.Usage.OutputTokens,
+			TotalTokens:  event.Usage.TotalTokens,
+		},
+		partial:   event.Type == "image_generation.partial_image",
+		completed: event.Type == "image_generation.completed",
+		rawType:   event.Type,
+	}
+}
+
+type imageEditSDKStream struct {
+	stream *ssestream.Stream[openai.ImageEditStreamEventUnion]
+}
+
+func (s imageEditSDKStream) Next() bool { return s.stream.Next() }
+func (s imageEditSDKStream) Err() error { return s.stream.Err() }
+func (s imageEditSDKStream) Close() error {
+	return s.stream.Close()
+}
+
+func (s imageEditSDKStream) Current() imageStreamEvent {
+	event := s.stream.Current()
+	return imageStreamEvent{
+		b64:          event.B64JSON,
+		outputFormat: event.OutputFormat,
+		usage: inference.Usage{
+			InputTokens:  event.Usage.InputTokens,
+			OutputTokens: event.Usage.OutputTokens,
+			TotalTokens:  event.Usage.TotalTokens,
+		},
+		partial:   event.Type == "image_edit.partial_image",
+		completed: event.Type == "image_edit.completed",
+		rawType:   event.Type,
+	}
+}
+
+// imageStream adapts the SDK image SSE reader to ProviderStream[imageStreamRaw].
+// It assigns canonical part indices: progress previews and the final image
+// for one output share one index, so the terminal result keeps only the
+// last image per output. The SDK events carry no per-image index, so the
+// wrapper assumes the API streams outputs sequentially.
+type imageStream struct {
+	sdk       imageSDKStream
+	nextPart  int
+	requestID string
+}
+
+func (s *imageStream) Next(
+	ctx context.Context,
+) (imageStreamRaw, error) {
+	if err := ctx.Err(); err != nil {
+		return imageStreamRaw{}, errdefs.FromContext(err)
+	}
+	for {
+		if !s.sdk.Next() {
+			if err := s.sdk.Err(); err != nil {
+				classified := classifyError(err)
+				logInferenceStream(ctx, "generate", "", classified, "")
+				return imageStreamRaw{}, classified
+			}
+			return imageStreamRaw{}, io.EOF
+		}
+		event := s.sdk.Current()
+		switch {
+		case event.partial:
+			return imageStreamRaw{
+				partIndex:    s.nextPart,
+				interim:      true,
+				b64:          event.b64,
+				outputFormat: event.outputFormat,
+			}, nil
+		case event.completed:
+			raw := imageStreamRaw{
+				partIndex:    s.nextPart,
+				b64:          event.b64,
+				outputFormat: event.outputFormat,
+				usage:        event.usage,
+				requestID:    s.requestID,
+			}
+			s.nextPart++
+			return raw, nil
+		default:
+			return imageStreamRaw{}, fmt.Errorf(
+				"azure: unknown image stream event type %q",
+				event.rawType,
+			)
+		}
+	}
+}
+
+func (s *imageStream) Close() error {
+	if s.sdk == nil {
+		return nil
+	}
+	return classifyError(s.sdk.Close())
+}
+
+func transportImageStream(
+	client openai.Client,
+) inference.Transport[imageWire, inference.ProviderStream[imageStreamRaw]] {
+	return func(
+		ctx context.Context,
+		wire imageWire,
+	) (inference.ProviderStream[imageStreamRaw], error) {
+		var sdk imageSDKStream
+		var requestID string
+		if len(wire.images) == 0 {
+			sdk = imageGenSDKStream{
+				stream: client.Images.GenerateStreaming(
+					ctx,
+					imageGenerateParams(wire),
+					captureRequestID(&requestID),
+				),
+			}
+		} else {
+			sdk = imageEditSDKStream{
+				stream: client.Images.EditStreaming(
+					ctx,
+					imageEditParams(wire),
+					captureRequestID(&requestID),
+				),
+			}
+		}
+		if err := sdk.Err(); err != nil {
+			classified := classifyError(err)
+			logInferenceStream(ctx, "generate", wire.model, classified, "")
+			return nil, classified
+		}
+		logInferenceStream(ctx, "generate", wire.model, nil, "")
+		return &imageStream{sdk: sdk, requestID: requestID}, nil
+	}
+}
+
+func decodeImageStream(
+	_ context.Context,
+	raw imageStreamRaw,
+) (inference.GenerateStreamEvent, error) {
+	image, err := streamImagePart(raw.b64, raw.outputFormat)
+	if err != nil {
+		return inference.GenerateStreamEvent{}, err
+	}
+	event := inference.GenerateStreamEvent{
+		PartIndex: raw.partIndex,
+		Delta: inference.ImagePartDelta{
+			Part:    image,
+			Interim: raw.interim,
+		},
+	}
+	if !raw.interim {
+		event.Usage = &raw.usage
+		event.FinishReason = inference.FinishCompleted
+		event.RequestID = raw.requestID
+	}
+	return event, nil
+}
+
+func streamImagePart(
+	b64Data string,
+	outputFormat string,
+) (message.ImagePart, error) {
+	data, err := base64.StdEncoding.DecodeString(b64Data)
+	if err != nil {
+		return message.ImagePart{}, fmt.Errorf(
+			"azure: decode image stream payload: %w",
+			err,
+		)
+	}
+	mediaType := media.ImageFormat(outputFormat).MediaType()
+	if mediaType == "" {
+		// The stream events echo the negotiated output format; sniff the
+		// container when it is absent or unknown.
+		mediaType = sniffImageMediaType(data)
+		if mediaType == "" {
+			return message.ImagePart{}, fmt.Errorf(
+				"azure: image stream payload has unrecognized format",
+			)
+		}
+	}
+	source, err := media.NewImageBytes(data, mediaType)
+	if err != nil {
+		return message.ImagePart{}, fmt.Errorf(
+			"azure: image stream data: %w",
+			err,
+		)
+	}
+	return message.ImagePart{Source: source}, nil
+}
+
 func openImage(
 	cls *clients,
 	id inference.ModelID,
 	_ string,
 ) (inference.GenerateOperations, error) {
-	unary, err := inference.BindGenerate(
+	return inference.BindGenerateOperations(
 		compileImage(id.Name),
 		transportImage(cls.api),
 		decodeImage,
+		transportImageStream(cls.api),
+		decodeImageStream,
 	)
-	if err != nil {
-		return inference.GenerateOperations{}, err
-	}
-	return inference.GenerateOperations{Unary: unary}, nil
 }

--- a/driver/azure/image_test.go
+++ b/driver/azure/image_test.go
@@ -130,7 +130,17 @@ func TestImageTransport(t *testing.T) {
 		if fmt.Sprint(body["output_format"]) != "png" {
 			t.Errorf("output_format = %v", body["output_format"])
 		}
-		imageResponse(w, 11)
+		if quality, _ := body["quality"].(string); quality != "high" {
+			t.Errorf("quality = %v, want high", body["quality"])
+		}
+		w.Header().Set("x-request-id", "req_azure_1")
+		w.Header().Set("Content-Type", "application/json")
+		payload, _ := json.Marshal(map[string]any{
+			"id":    "img_resp_1",
+			"data":  []map[string]any{{"b64_json": base64.StdEncoding.EncodeToString(testPNG)}},
+			"usage": map[string]any{"input_tokens": 11, "output_tokens": 0},
+		})
+		_, _ = fmt.Fprint(w, string(payload))
 	})
 	defer server.Close()
 	cls := azureImageClients(t, server)
@@ -145,6 +155,7 @@ func TestImageTransport(t *testing.T) {
 				Intent: inference.Intent{Image: &inference.ImageIntent{
 					Size:         &media.ImageSize{Width: 1728, Height: 2304},
 					OutputFormat: media.ImageFormatPNG,
+					Quality:      media.ImageQualityHigh,
 				}},
 			},
 		},
@@ -177,7 +188,438 @@ func TestImageTransport(t *testing.T) {
 		!bytes.Equal(part.Source.Bytes(), testPNG) {
 		t.Fatalf("image source bytes mismatch")
 	}
+	if response.Metadata.RequestID != "req_azure_1" {
+		t.Errorf("metadata request_id = %q, want req_azure_1",
+			response.Metadata.RequestID)
+	}
+	if response.Metadata.ResponseID != "img_resp_1" {
+		t.Errorf("metadata response_id = %q, want img_resp_1",
+			response.Metadata.ResponseID)
+	}
 	_ = capture.body(0)
+}
+
+// ---------------------------------------------------------------------------
+// Streaming.
+// ---------------------------------------------------------------------------
+
+func imageGenPartialEvent(b64 string, index int) string {
+	return fmt.Sprintf(
+		`{"type":"image_generation.partial_image","b64_json":%q,`+
+			`"output_format":"png","partial_image_index":%d,`+
+			`"created_at":1,"size":"1024x1024","quality":"high","background":"auto"}`,
+		b64,
+		index,
+	)
+}
+
+func imageGenCompletedEvent(
+	b64 string,
+	inputTokens, outputTokens, totalTokens int64,
+) string {
+	return fmt.Sprintf(
+		`{"type":"image_generation.completed","b64_json":%q,`+
+			`"output_format":"png","created_at":2,"size":"1024x1024",`+
+			`"quality":"high","background":"auto",`+
+			`"usage":{"input_tokens":%d,"output_tokens":%d,"total_tokens":%d}}`,
+		b64,
+		inputTokens,
+		outputTokens,
+		totalTokens,
+	)
+}
+
+func imageEditPartialEvent(b64 string, index int) string {
+	return fmt.Sprintf(
+		`{"type":"image_edit.partial_image","b64_json":%q,`+
+			`"output_format":"png","partial_image_index":%d,`+
+			`"created_at":1,"size":"1024x1024","quality":"high","background":"auto"}`,
+		b64,
+		index,
+	)
+}
+
+func imageEditCompletedEvent(b64 string) string {
+	return fmt.Sprintf(
+		`{"type":"image_edit.completed","b64_json":%q,`+
+			`"output_format":"png","created_at":2,"size":"1024x1024",`+
+			`"quality":"high","background":"auto",`+
+			`"usage":{"input_tokens":4,"output_tokens":9,"total_tokens":13}}`,
+		b64,
+	)
+}
+
+func writeImageSSE(w http.ResponseWriter, events ...string) {
+	w.Header().Set("Content-Type", "text/event-stream")
+	for _, event := range events {
+		_, _ = fmt.Fprintf(w, "data: %s\n\n", event)
+	}
+}
+
+func TestImageStreamTransport(t *testing.T) {
+	server, capture := newCapturedAzure(t, func(
+		w http.ResponseWriter,
+		_ *http.Request,
+		body map[string]any,
+	) {
+		if stream, _ := body["stream"].(bool); !stream {
+			t.Errorf("stream = %v, want true", body["stream"])
+		}
+		if partial, _ := body["partial_images"].(float64); partial != 2 {
+			t.Errorf("partial_images = %v, want 2", body["partial_images"])
+		}
+		if prompt, _ := body["prompt"].(string); prompt != "a red circle" {
+			t.Errorf("prompt = %v", body["prompt"])
+		}
+		w.Header().Set("x-request-id", "req_azure_stream_1")
+		b64 := base64.StdEncoding.EncodeToString(testPNG)
+		writeImageSSE(
+			w,
+			imageGenPartialEvent(b64, 0),
+			imageGenPartialEvent(b64, 1),
+			imageGenCompletedEvent(b64, 7, 13, 20),
+			imageGenCompletedEvent(b64, 7, 13, 20),
+		)
+	})
+	defer server.Close()
+	cls := azureImageClients(t, server)
+
+	two := 2
+	request := inference.GenerateRequest{
+		Input: inference.GenerateInput{
+			Role: inference.InputRoleUser,
+			Content: inference.InputContent{
+				Content: message.Content{Parts: []message.Part{
+					message.TextPart{Text: "a red circle"},
+				}},
+				Intent: inference.Intent{Image: &inference.ImageIntent{}},
+			},
+		},
+		Extensions: inference.Extensions{
+			ImageOptions{PartialImages: &two},
+		},
+	}
+	compiled, err := compileImage("gpt-image-1")(
+		context.Background(),
+		azureImageModel("gpt-image-1"),
+		request,
+		inference.GenerateExecutionStream,
+	)
+	if err != nil {
+		t.Fatalf("compileImage stream: %v", err)
+	}
+	if compiled.Wire.partialImages != 2 {
+		t.Fatalf("wire partial_images = %d, want 2", compiled.Wire.partialImages)
+	}
+
+	rawStream, err := transportImageStream(cls.api)(
+		context.Background(),
+		compiled.Wire,
+	)
+	if err != nil {
+		t.Fatalf("transportImageStream: %v", err)
+	}
+	var events []inference.GenerateStreamEvent
+	for {
+		raw, err := rawStream.Next(context.Background())
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			t.Fatalf("Next: %v", err)
+		}
+		event, err := decodeImageStream(context.Background(), raw)
+		if err != nil {
+			t.Fatalf("decodeImageStream: %v", err)
+		}
+		events = append(events, event)
+	}
+	if len(events) != 4 {
+		t.Fatalf("events = %d, want 4", len(events))
+	}
+	assertImageStreamEvent := func(
+		index int,
+		partIndex int,
+		interim bool,
+		finish inference.FinishReason,
+	) {
+		t.Helper()
+		event := events[index]
+		if event.PartIndex != partIndex {
+			t.Errorf("event %d part index = %d, want %d", index, event.PartIndex, partIndex)
+		}
+		delta, ok := event.Delta.(inference.ImagePartDelta)
+		if !ok {
+			t.Errorf("event %d delta = %T, want ImagePartDelta", index, event.Delta)
+			return
+		}
+		if delta.Interim != interim {
+			t.Errorf("event %d interim = %v, want %v", index, delta.Interim, interim)
+		}
+		if !bytes.Equal(delta.Part.Source.Bytes(), testPNG) {
+			t.Errorf("event %d image bytes mismatch", index)
+		}
+		if event.FinishReason != finish {
+			t.Errorf("event %d finish = %q, want %q", index, event.FinishReason, finish)
+		}
+	}
+	assertImageStreamEvent(0, 0, true, "")
+	assertImageStreamEvent(1, 0, true, "")
+	assertImageStreamEvent(2, 0, false, inference.FinishCompleted)
+	assertImageStreamEvent(3, 1, false, inference.FinishCompleted)
+
+	if usage := events[2].Usage; usage == nil ||
+		usage.InputTokens != 7 || usage.OutputTokens != 13 || usage.TotalTokens != 20 {
+		t.Fatalf("completed usage = %+v, want 7/13/20", events[2].Usage)
+	}
+	if events[0].Usage != nil {
+		t.Fatalf("partial event carried usage %+v, want none", events[0].Usage)
+	}
+	for _, index := range []int{0, 1} {
+		if events[index].RequestID != "" {
+			t.Errorf("partial event %d request_id = %q, want empty",
+				index, events[index].RequestID)
+		}
+	}
+	for _, index := range []int{2, 3} {
+		if events[index].RequestID != "req_azure_stream_1" {
+			t.Errorf("completed event %d request_id = %q, want req_azure_stream_1",
+				index, events[index].RequestID)
+		}
+	}
+	_ = capture.body(0)
+}
+
+func TestImageEditStreamTransport(t *testing.T) {
+	source, err := media.NewImageBytes(testPNG, "image/png")
+	if err != nil {
+		t.Fatalf("NewImageBytes: %v", err)
+	}
+	server, capture := newCapturedAzure(t, func(
+		w http.ResponseWriter,
+		r *http.Request,
+		_ map[string]any,
+	) {
+		if r.URL.Path != "/openai/deployments/gpt-image-1/images/edits" {
+			t.Errorf("path = %s, want /openai/deployments/gpt-image-1/images/edits",
+				r.URL.Path)
+		}
+		if err := r.ParseMultipartForm(1 << 20); err != nil {
+			t.Errorf("parse multipart: %v", err)
+			return
+		}
+		if stream := r.MultipartForm.Value["stream"]; len(stream) != 1 ||
+			stream[0] != "true" {
+			t.Errorf("stream form field = %v, want [true]", stream)
+		}
+		if partial := r.MultipartForm.Value["partial_images"]; len(partial) != 1 ||
+			partial[0] != "2" {
+			t.Errorf("partial_images form field = %v, want [2]", partial)
+		}
+		if prompt := r.MultipartForm.Value["prompt"]; len(prompt) != 1 ||
+			prompt[0] != "make it a red circle" {
+			t.Errorf("prompt = %v", r.MultipartForm.Value["prompt"])
+		}
+		w.Header().Set("apim-request-id", "req_azure_edit_1")
+		b64 := base64.StdEncoding.EncodeToString(testPNG)
+		writeImageSSE(
+			w,
+			imageEditPartialEvent(b64, 0),
+			imageEditCompletedEvent(b64),
+		)
+	})
+	defer server.Close()
+	cls := azureImageClients(t, server)
+
+	two := 2
+	request := inference.GenerateRequest{
+		Input: inference.GenerateInput{
+			Role: inference.InputRoleUser,
+			Content: inference.InputContent{
+				Content: message.Content{Parts: []message.Part{
+					message.TextPart{Text: "make it a red circle"},
+					message.ImagePart{Source: source},
+				}},
+				Intent: inference.Intent{Image: &inference.ImageIntent{}},
+			},
+		},
+		Extensions: inference.Extensions{
+			ImageOptions{PartialImages: &two},
+		},
+	}
+	compiled, err := compileImage("gpt-image-1")(
+		context.Background(),
+		azureImageModel("gpt-image-1"),
+		request,
+		inference.GenerateExecutionStream,
+	)
+	if err != nil {
+		t.Fatalf("compileImage stream: %v", err)
+	}
+	rawStream, err := transportImageStream(cls.api)(
+		context.Background(),
+		compiled.Wire,
+	)
+	if err != nil {
+		t.Fatalf("transportImageStream: %v", err)
+	}
+	var events []inference.GenerateStreamEvent
+	for {
+		raw, err := rawStream.Next(context.Background())
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			t.Fatalf("Next: %v", err)
+		}
+		event, err := decodeImageStream(context.Background(), raw)
+		if err != nil {
+			t.Fatalf("decodeImageStream: %v", err)
+		}
+		events = append(events, event)
+	}
+	if len(events) != 2 {
+		t.Fatalf("events = %d, want 2", len(events))
+	}
+	if events[0].PartIndex != 0 ||
+		events[0].Delta.(inference.ImagePartDelta).Interim != true {
+		t.Fatalf("partial event = %+v, want part 0 interim", events[0])
+	}
+	if events[1].PartIndex != 0 ||
+		events[1].Delta.(inference.ImagePartDelta).Interim != false ||
+		events[1].FinishReason != inference.FinishCompleted {
+		t.Fatalf("completed event = %+v, want part 0 final", events[1])
+	}
+	if events[1].RequestID != "req_azure_edit_1" {
+		t.Errorf("completed request_id = %q, want req_azure_edit_1",
+			events[1].RequestID)
+	}
+	_ = capture.body(0)
+}
+
+func TestImageCompilerStreamShape(t *testing.T) {
+	compile := func(shape inference.GenerateExecutionShape, partial *int) (
+		imageWire,
+		error,
+	) {
+		t.Helper()
+		request := inference.GenerateRequest{
+			Input: inference.GenerateInput{
+				Role: inference.InputRoleUser,
+				Content: inference.InputContent{
+					Content: message.Content{Parts: []message.Part{
+						message.TextPart{Text: "a red circle"},
+					}},
+					Intent: inference.Intent{Image: &inference.ImageIntent{}},
+				},
+			},
+		}
+		if partial != nil {
+			request.Extensions = inference.Extensions{
+				ImageOptions{PartialImages: partial},
+			}
+		}
+		compiled, err := compileImage("gpt-image-1")(
+			context.Background(),
+			azureImageModel("gpt-image-1"),
+			request,
+			shape,
+		)
+		if err != nil {
+			return imageWire{}, err
+		}
+		return compiled.Wire, nil
+	}
+
+	if _, err := compile(inference.GenerateExecutionStream, nil); err != nil {
+		t.Fatalf("stream compile without extension: %v", err)
+	}
+	two := 2
+	wire, err := compile(inference.GenerateExecutionStream, &two)
+	if err != nil {
+		t.Fatalf("stream compile with partial_images: %v", err)
+	}
+	if wire.partialImages != 2 {
+		t.Fatalf("wire partial_images = %d, want 2", wire.partialImages)
+	}
+
+	// partial_images is stream-only: the unary shape rejects it.
+	if _, err := compile(inference.GenerateExecutionUnary, &two); err == nil {
+		t.Fatal("unary compile with partial_images succeeded, want rejection")
+	} else {
+		var inferenceErr *inference.Error
+		if !errors.As(err, &inferenceErr) ||
+			inferenceErr.Field != inference.ExtensionField("partial_images").Qualify(ImageOptions{}) {
+			t.Fatalf("unary partial_images error = %v, want partial_images field", err)
+		}
+	}
+
+	// Out-of-range preview counts are rejected at compile time.
+	four := 4
+	if _, err := compile(inference.GenerateExecutionStream, &four); err == nil {
+		t.Fatal("partial_images=4 compile succeeded, want rejection")
+	} else {
+		var inferenceErr *inference.Error
+		if !errors.As(err, &inferenceErr) ||
+			inferenceErr.Field != inference.ExtensionField("partial_images").Qualify(ImageOptions{}) {
+			t.Fatalf("partial_images=4 error = %v, want partial_images field", err)
+		}
+	}
+}
+
+func TestImageCompilerQuality(t *testing.T) {
+	compile := func(quality media.ImageQuality) (string, error) {
+		t.Helper()
+		request := inference.GenerateRequest{
+			Input: inference.GenerateInput{
+				Role: inference.InputRoleUser,
+				Content: inference.InputContent{
+					Content: message.Content{Parts: []message.Part{
+						message.TextPart{Text: "a red circle"},
+					}},
+					Intent: inference.Intent{Image: &inference.ImageIntent{
+						Quality: quality,
+					}},
+				},
+			},
+		}
+		compiled, err := compileImage("gpt-image-1")(
+			context.Background(),
+			azureImageModel("gpt-image-1"),
+			request,
+			inference.GenerateExecutionUnary,
+		)
+		if err != nil {
+			return "", err
+		}
+		return compiled.Wire.quality, nil
+	}
+
+	for _, quality := range []media.ImageQuality{
+		media.ImageQualityAuto,
+		media.ImageQualityLow,
+		media.ImageQualityMedium,
+		media.ImageQualityHigh,
+	} {
+		got, err := compile(quality)
+		if err != nil {
+			t.Errorf("quality %q: compile = %v", quality, err)
+			continue
+		}
+		if got != string(quality) {
+			t.Errorf("quality %q: wire = %q", quality, got)
+		}
+	}
+
+	_, err := compile(media.ImageQuality("ultra"))
+	if err == nil {
+		t.Fatal("unknown quality compiled, want rejection")
+	}
+	var inferenceErr *inference.Error
+	if !errors.As(err, &inferenceErr) ||
+		inferenceErr.Field != inference.FieldGenerateIntentImageQuality {
+		t.Fatalf("unknown quality error = %v, want image quality field", err)
+	}
 }
 
 func TestImageCompilerSizeRules(t *testing.T) {
@@ -256,18 +698,20 @@ func TestImageCompilerSizeRules(t *testing.T) {
 
 // TestImageOpsBind guards the core binding contract: the image wire must
 // stay concrete (no media sources, whose stream field is an interface), so
-// opening image operations succeeds.
+// opening image operations succeeds for both execution shapes.
 func TestImageOpsBind(t *testing.T) {
-	driver, err := inference.BindGenerate(
+	operations, err := inference.BindGenerateOperations(
 		compileImage("gpt-image-1"),
 		transportImage(openai.Client{}),
 		decodeImage,
+		transportImageStream(openai.Client{}),
+		decodeImageStream,
 	)
 	if err != nil {
-		t.Fatalf("BindGenerate: %v", err)
+		t.Fatalf("BindGenerateOperations: %v", err)
 	}
-	if driver == nil {
-		t.Fatal("BindGenerate returned a nil driver")
+	if operations.Unary == nil || operations.Stream == nil {
+		t.Fatal("BindGenerateOperations must bind unary and stream drivers")
 	}
 }
 

--- a/driver/bytedance/image.go
+++ b/driver/bytedance/image.go
@@ -177,6 +177,12 @@ func compileImage(
 					wire.delivery = "b64_json"
 				}
 			}
+			if image.Quality != "" {
+				ledger.reject(
+					inference.FieldGenerateIntentImageQuality,
+					"seedream has no quality parameter; quality is set by model and resolution tier",
+				)
+			}
 		}
 		if wire.seed != nil && wire.count > 1 {
 			ledger.reject(

--- a/driver/bytedance/image_test.go
+++ b/driver/bytedance/image_test.go
@@ -209,6 +209,21 @@ func TestCompileImageBackgroundRejects(t *testing.T) {
 	}
 }
 
+func TestCompileImageQualityRejects(t *testing.T) {
+	request := compileImageRequest(
+		[]message.Part{message.TextPart{Text: "a red circle"}},
+		ImageOptions{},
+	)
+	request.Input.Content.Intent.Image.Quality = media.ImageQualityHigh
+	_, report, err := compileImageWire(t, request)
+	if err == nil {
+		t.Fatal("compile succeeded, want quality rejection")
+	}
+	if reason := rejectedReason(report, inference.FieldGenerateIntentImageQuality); !strings.Contains(reason, "no quality parameter") {
+		t.Fatalf("rejected reason = %q, want seedream no-quality rejection", reason)
+	}
+}
+
 func mustImageSource(t *testing.T) media.ImageSource {
 	t.Helper()
 	source, err := media.NewImageURL("https://example.com/input1.png", "image/png")

--- a/driver/minimax/image.go
+++ b/driver/minimax/image.go
@@ -172,6 +172,12 @@ func compileImage(
 			case media.SourceInline:
 				wire.delivery = "base64"
 			}
+			if image.Quality != "" {
+				ledger.reject(
+					inference.FieldGenerateIntentImageQuality,
+					"image-01 has no quality parameter",
+				)
+			}
 		}
 		rejectOtherExtensions("image generation", request.Extensions, ledger)
 

--- a/driver/minimax/image_test.go
+++ b/driver/minimax/image_test.go
@@ -1,0 +1,50 @@
+package minimax
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/GizClaw/flowcraft/core/inference"
+	"github.com/GizClaw/flowcraft/core/message"
+	"github.com/GizClaw/flowcraft/core/message/media"
+)
+
+func TestCompileImageQualityRejects(t *testing.T) {
+	request := inference.GenerateRequest{
+		Input: inference.GenerateInput{
+			Role: inference.InputRoleUser,
+			Content: inference.InputContent{
+				Content: message.Content{Parts: []message.Part{
+					message.TextPart{Text: "a red circle"},
+				}},
+				Intent: inference.Intent{Image: &inference.ImageIntent{
+					Quality: media.ImageQualityHigh,
+				}},
+			},
+		},
+	}
+	compiled, err := compileImage("ep-test")(
+		context.Background(),
+		inference.ModelRef{
+			ID: inference.ModelID{Provider: driverID, Name: "image-01"},
+		},
+		request,
+		inference.GenerateExecutionUnary,
+	)
+	if err == nil {
+		t.Fatal("compile succeeded, want quality rejection")
+	}
+	found := false
+	for _, decision := range compiled.Report.Decisions {
+		if decision.Field == inference.FieldGenerateIntentImageQuality &&
+			decision.Disposition == inference.Rejected &&
+			strings.Contains(decision.Reason, "no quality parameter") {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("report decisions = %+v, want image-01 no-quality rejection",
+			compiled.Report.Decisions)
+	}
+}

--- a/driver/openai/doc.go
+++ b/driver/openai/doc.go
@@ -20,7 +20,9 @@
 //     GenerateOptions.WebSearch attaches OpenAI's hosted web_search tool;
 //     web_search_call items and url_citation annotations surface on
 //     GenerateResponse.ProviderOutputs (never inside Message).
-//   - Generate ImageIntent: Images API (gpt-image models).
+//   - Generate ImageIntent: Images API (gpt-image models), unary + SSE
+//     stream with optional partial-image previews via
+//     ImageOptions.PartialImages.
 //   - Generate AudioIntent: speech API (gpt-4o-mini-tts and friends).
 //   - Embed: embeddings API (text-embedding-3 family).
 //

--- a/driver/openai/extensions.go
+++ b/driver/openai/extensions.go
@@ -10,7 +10,10 @@ import (
 // driverID namespaces every extension this package defines.
 const driverID = "openai"
 
-const extensionGenerate = "generate_options"
+const (
+	extensionGenerate = "generate_options"
+	extensionImage    = "image_options"
+)
 
 // extensionProvider resolves the deployment provider ID an extension targets,
 // defaulting to the driver name.
@@ -120,6 +123,52 @@ func (o GenerateOptions) Clone() inference.Extension {
 		search.ToolChoice = clonePointer(search.ToolChoice)
 		o.WebSearch = &search
 	}
+	return o
+}
+
+// ---------------------------------------------------------------------------
+// Image (gpt-image).
+// ---------------------------------------------------------------------------
+
+// ImageOptions carries images API settings beyond the canonical image
+// intent.
+type ImageOptions struct {
+	// Provider targets a deployment provider ID other than "openai".
+	Provider string `json:"-"`
+	// PartialImages sets the number of progress previews streamed before
+	// the final image when the request runs in the stream execution shape.
+	// It must be between 0 and 3: 0 delivers the final image in a single
+	// stream event, and 1-3 deliver interim previews as they are generated.
+	// Nil keeps the provider default (0). It has no effect on the unary
+	// execution shape.
+	PartialImages *int `json:"partial_images,omitempty"`
+}
+
+func (o ImageOptions) ProviderID() string  { return extensionProvider(o.Provider) }
+func (o ImageOptions) ExtensionID() string { return extensionImage }
+
+func (o ImageOptions) ActiveFields() []inference.ExtensionField {
+	var fields []inference.ExtensionField
+	if o.PartialImages != nil {
+		fields = append(fields, "partial_images")
+	}
+	return fields
+}
+
+func (o ImageOptions) Validate() error {
+	if partial := o.PartialImages; partial != nil {
+		if *partial < 0 || *partial > 3 {
+			return fmt.Errorf(
+				"partial_images must be between 0 and 3, not %d",
+				*partial,
+			)
+		}
+	}
+	return nil
+}
+
+func (o ImageOptions) Clone() inference.Extension {
+	o.PartialImages = clonePointer(o.PartialImages)
 	return o
 }
 

--- a/driver/openai/extensions_test.go
+++ b/driver/openai/extensions_test.go
@@ -1,0 +1,48 @@
+package openai
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestImageOptionsActiveFields(t *testing.T) {
+	if fields := (ImageOptions{}).ActiveFields(); len(fields) != 0 {
+		t.Fatalf("empty ImageOptions ActiveFields = %#v, want none", fields)
+	}
+	two := 2
+	fields := (ImageOptions{PartialImages: &two}).ActiveFields()
+	if len(fields) != 1 || string(fields[0]) != "partial_images" {
+		t.Fatalf("ActiveFields = %#v, want [partial_images]", fields)
+	}
+}
+
+func TestImageOptionsValidatePartialImages(t *testing.T) {
+	for _, count := range []int{0, 1, 2, 3} {
+		value := count
+		if err := (ImageOptions{PartialImages: &value}).Validate(); err != nil {
+			t.Errorf("partial_images=%d Validate() = %v, want nil", count, err)
+		}
+	}
+	for _, count := range []int{-1, 4, 9} {
+		value := count
+		err := (ImageOptions{PartialImages: &value}).Validate()
+		if err == nil || !strings.Contains(err.Error(), "partial_images") {
+			t.Errorf("partial_images=%d Validate() = %v, want range error", count, err)
+		}
+	}
+}
+
+func TestImageOptionsCloneDeepCopiesPartialImages(t *testing.T) {
+	three := 3
+	options := ImageOptions{PartialImages: &three}
+	cloned, ok := options.Clone().(ImageOptions)
+	if !ok {
+		t.Fatalf("Clone() type = %T, want ImageOptions", options.Clone())
+	}
+	if cloned.PartialImages == nil || cloned.PartialImages == options.PartialImages {
+		t.Fatal("Clone() must deep-copy partial_images")
+	}
+	if *cloned.PartialImages != 3 {
+		t.Fatalf("Clone() partial_images = %d, want 3", *cloned.PartialImages)
+	}
+}

--- a/driver/openai/generate_openai_operations_test.go
+++ b/driver/openai/generate_openai_operations_test.go
@@ -145,8 +145,13 @@ func TestImageTransport(t *testing.T) {
 		if fmt.Sprint(body["output_format"]) != "png" {
 			t.Errorf("output_format = %v", body["output_format"])
 		}
+		if quality, _ := body["quality"].(string); quality != "high" {
+			t.Errorf("quality = %v, want high", body["quality"])
+		}
+		w.Header().Set("x-request-id", "req_openai_1")
 		w.Header().Set("Content-Type", "application/json")
 		payload, _ := json.Marshal(map[string]any{
+			"id":    "img_resp_1",
 			"data":  []map[string]any{{"b64_json": base64.StdEncoding.EncodeToString(png)}},
 			"usage": map[string]any{"input_tokens": 11, "output_tokens": 0},
 		})
@@ -165,6 +170,7 @@ func TestImageTransport(t *testing.T) {
 				Intent: inference.Intent{Image: &inference.ImageIntent{
 					Size:         &media.ImageSize{Width: 1728, Height: 2304},
 					OutputFormat: media.ImageFormatPNG,
+					Quality:      media.ImageQualityHigh,
 				}},
 			},
 		},
@@ -195,6 +201,14 @@ func TestImageTransport(t *testing.T) {
 	}
 	if part.Source.Kind() != media.SourceInline || len(part.Source.Bytes()) != len(png) {
 		t.Fatalf("image source = %v bytes", len(part.Source.Bytes()))
+	}
+	if response.Metadata.RequestID != "req_openai_1" {
+		t.Errorf("metadata request_id = %q, want req_openai_1",
+			response.Metadata.RequestID)
+	}
+	if response.Metadata.ResponseID != "img_resp_1" {
+		t.Errorf("metadata response_id = %q, want img_resp_1",
+			response.Metadata.ResponseID)
 	}
 	_ = capture.body(0)
 }
@@ -275,18 +289,20 @@ func TestImageCompilerSizeRules(t *testing.T) {
 
 // TestImageOpsBind guards the core binding contract: the image wire must
 // stay concrete (no media sources, whose stream field is an interface), so
-// opening image operations succeeds.
+// opening image operations succeeds for both execution shapes.
 func TestImageOpsBind(t *testing.T) {
-	driver, err := inference.BindGenerate(
+	operations, err := inference.BindGenerateOperations(
 		compileImage("gpt-image-2"),
 		transportImage(openai.Client{}),
 		decodeImage,
+		transportImageStream(openai.Client{}),
+		decodeImageStream,
 	)
 	if err != nil {
-		t.Fatalf("BindGenerate: %v", err)
+		t.Fatalf("BindGenerateOperations: %v", err)
 	}
-	if driver == nil {
-		t.Fatal("BindGenerate returned a nil driver")
+	if operations.Unary == nil || operations.Stream == nil {
+		t.Fatal("BindGenerateOperations must bind unary and stream drivers")
 	}
 }
 
@@ -386,6 +402,440 @@ func TestImageEditTransport(t *testing.T) {
 		t.Fatalf("parts = %d", len(response.Message.Content.Parts))
 	}
 	_ = capture.body(0)
+}
+
+// ---------------------------------------------------------------------------
+// Image streaming.
+// ---------------------------------------------------------------------------
+
+func openaiImagePartialEvent(b64 string, index int) string {
+	return fmt.Sprintf(
+		`{"type":"image_generation.partial_image","b64_json":%q,`+
+			`"output_format":"png","partial_image_index":%d,`+
+			`"created_at":1,"size":"1024x1024","quality":"high","background":"auto"}`,
+		b64,
+		index,
+	)
+}
+
+func openaiImageCompletedEvent(
+	b64 string,
+	inputTokens, outputTokens, totalTokens int64,
+) string {
+	return fmt.Sprintf(
+		`{"type":"image_generation.completed","b64_json":%q,`+
+			`"output_format":"png","created_at":2,"size":"1024x1024",`+
+			`"quality":"high","background":"auto",`+
+			`"usage":{"input_tokens":%d,"output_tokens":%d,"total_tokens":%d}}`,
+		b64,
+		inputTokens,
+		outputTokens,
+		totalTokens,
+	)
+}
+
+func openaiImageEditPartialEvent(b64 string, index int) string {
+	return fmt.Sprintf(
+		`{"type":"image_edit.partial_image","b64_json":%q,`+
+			`"output_format":"png","partial_image_index":%d,`+
+			`"created_at":1,"size":"1024x1024","quality":"high","background":"auto"}`,
+		b64,
+		index,
+	)
+}
+
+func openaiImageEditCompletedEvent(b64 string) string {
+	return fmt.Sprintf(
+		`{"type":"image_edit.completed","b64_json":%q,`+
+			`"output_format":"png","created_at":2,"size":"1024x1024",`+
+			`"quality":"high","background":"auto",`+
+			`"usage":{"input_tokens":4,"output_tokens":9,"total_tokens":13}}`,
+		b64,
+	)
+}
+
+func writeOpenAIImageSSE(w http.ResponseWriter, events ...string) {
+	w.Header().Set("Content-Type", "text/event-stream")
+	for _, event := range events {
+		_, _ = fmt.Fprintf(w, "data: %s\n\n", event)
+	}
+}
+
+func TestImageStreamTransport(t *testing.T) {
+	png, err := base64.StdEncoding.DecodeString(
+		"iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNkYPhfDwAChwGA60e6kgAAAABJRU5ErkJggg==",
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	server, capture := newCapturedOpenAI(t, func(
+		w http.ResponseWriter,
+		_ *http.Request,
+		body map[string]any,
+	) {
+		if stream, _ := body["stream"].(bool); !stream {
+			t.Errorf("stream = %v, want true", body["stream"])
+		}
+		if partial, _ := body["partial_images"].(float64); partial != 2 {
+			t.Errorf("partial_images = %v, want 2", body["partial_images"])
+		}
+		if prompt, _ := body["prompt"].(string); prompt != "a red circle" {
+			t.Errorf("prompt = %v", body["prompt"])
+		}
+		w.Header().Set("x-request-id", "req_openai_stream_1")
+		b64 := base64.StdEncoding.EncodeToString(png)
+		writeOpenAIImageSSE(
+			w,
+			openaiImagePartialEvent(b64, 0),
+			openaiImagePartialEvent(b64, 1),
+			openaiImageCompletedEvent(b64, 7, 13, 20),
+			openaiImageCompletedEvent(b64, 7, 13, 20),
+		)
+	})
+	defer server.Close()
+	cls := testClients(t, server)
+
+	two := 2
+	request := inference.GenerateRequest{
+		Input: inference.GenerateInput{
+			Role: inference.InputRoleUser,
+			Content: inference.InputContent{
+				Content: message.Content{Parts: []message.Part{
+					message.TextPart{Text: "a red circle"},
+				}},
+				Intent: inference.Intent{Image: &inference.ImageIntent{}},
+			},
+		},
+		Extensions: inference.Extensions{
+			ImageOptions{PartialImages: &two},
+		},
+	}
+	compiled, err := compileImage("gpt-image-2")(
+		context.Background(),
+		openaiModel("gpt-image-2"),
+		request,
+		inference.GenerateExecutionStream,
+	)
+	if err != nil {
+		t.Fatalf("compileImage stream: %v", err)
+	}
+	if compiled.Wire.partialImages != 2 {
+		t.Fatalf("wire partial_images = %d, want 2", compiled.Wire.partialImages)
+	}
+
+	rawStream, err := transportImageStream(cls.api)(
+		context.Background(),
+		compiled.Wire,
+	)
+	if err != nil {
+		t.Fatalf("transportImageStream: %v", err)
+	}
+	var events []inference.GenerateStreamEvent
+	for {
+		raw, err := rawStream.Next(context.Background())
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			t.Fatalf("Next: %v", err)
+		}
+		event, err := decodeImageStream(context.Background(), raw)
+		if err != nil {
+			t.Fatalf("decodeImageStream: %v", err)
+		}
+		events = append(events, event)
+	}
+	if len(events) != 4 {
+		t.Fatalf("events = %d, want 4", len(events))
+	}
+	assertOpenAIImageStreamEvent := func(
+		index int,
+		partIndex int,
+		interim bool,
+		finish inference.FinishReason,
+	) {
+		t.Helper()
+		event := events[index]
+		if event.PartIndex != partIndex {
+			t.Errorf("event %d part index = %d, want %d", index, event.PartIndex, partIndex)
+		}
+		delta, ok := event.Delta.(inference.ImagePartDelta)
+		if !ok {
+			t.Errorf("event %d delta = %T, want ImagePartDelta", index, event.Delta)
+			return
+		}
+		if delta.Interim != interim {
+			t.Errorf("event %d interim = %v, want %v", index, delta.Interim, interim)
+		}
+		if !bytes.Equal(delta.Part.Source.Bytes(), png) {
+			t.Errorf("event %d image bytes mismatch", index)
+		}
+		if event.FinishReason != finish {
+			t.Errorf("event %d finish = %q, want %q", index, event.FinishReason, finish)
+		}
+	}
+	assertOpenAIImageStreamEvent(0, 0, true, "")
+	assertOpenAIImageStreamEvent(1, 0, true, "")
+	assertOpenAIImageStreamEvent(2, 0, false, inference.FinishCompleted)
+	assertOpenAIImageStreamEvent(3, 1, false, inference.FinishCompleted)
+
+	if usage := events[2].Usage; usage == nil ||
+		usage.InputTokens != 7 || usage.OutputTokens != 13 || usage.TotalTokens != 20 {
+		t.Fatalf("completed usage = %+v, want 7/13/20", events[2].Usage)
+	}
+	if events[0].Usage != nil {
+		t.Fatalf("partial event carried usage %+v, want none", events[0].Usage)
+	}
+	for _, index := range []int{0, 1} {
+		if events[index].RequestID != "" {
+			t.Errorf("partial event %d request_id = %q, want empty",
+				index, events[index].RequestID)
+		}
+	}
+	for _, index := range []int{2, 3} {
+		if events[index].RequestID != "req_openai_stream_1" {
+			t.Errorf("completed event %d request_id = %q, want req_openai_stream_1",
+				index, events[index].RequestID)
+		}
+	}
+	_ = capture.body(0)
+}
+
+func TestImageEditStreamTransport(t *testing.T) {
+	png, err := base64.StdEncoding.DecodeString(
+		"iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNkYPhfDwAChwGA60e6kgAAAABJRU5ErkJggg==",
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	source, err := media.NewImageBytes(png, "image/png")
+	if err != nil {
+		t.Fatalf("NewImageBytes: %v", err)
+	}
+	server, capture := newCapturedOpenAI(t, func(
+		w http.ResponseWriter,
+		r *http.Request,
+		_ map[string]any,
+	) {
+		if r.URL.Path != "/images/edits" {
+			t.Errorf("path = %s, want /images/edits", r.URL.Path)
+		}
+		if err := r.ParseMultipartForm(1 << 20); err != nil {
+			t.Errorf("parse multipart: %v", err)
+			return
+		}
+		if stream := r.MultipartForm.Value["stream"]; len(stream) != 1 ||
+			stream[0] != "true" {
+			t.Errorf("stream form field = %v, want [true]", stream)
+		}
+		if partial := r.MultipartForm.Value["partial_images"]; len(partial) != 1 ||
+			partial[0] != "2" {
+			t.Errorf("partial_images form field = %v, want [2]", partial)
+		}
+		if prompt := r.MultipartForm.Value["prompt"]; len(prompt) != 1 ||
+			prompt[0] != "make it a red circle" {
+			t.Errorf("prompt = %v", r.MultipartForm.Value["prompt"])
+		}
+		w.Header().Set("apim-request-id", "req_openai_edit_1")
+		b64 := base64.StdEncoding.EncodeToString(png)
+		writeOpenAIImageSSE(
+			w,
+			openaiImageEditPartialEvent(b64, 0),
+			openaiImageEditCompletedEvent(b64),
+		)
+	})
+	defer server.Close()
+	cls := testClients(t, server)
+
+	two := 2
+	request := inference.GenerateRequest{
+		Input: inference.GenerateInput{
+			Role: inference.InputRoleUser,
+			Content: inference.InputContent{
+				Content: message.Content{Parts: []message.Part{
+					message.TextPart{Text: "make it a red circle"},
+					message.ImagePart{Source: source},
+				}},
+				Intent: inference.Intent{Image: &inference.ImageIntent{}},
+			},
+		},
+		Extensions: inference.Extensions{
+			ImageOptions{PartialImages: &two},
+		},
+	}
+	compiled, err := compileImage("gpt-image-2")(
+		context.Background(),
+		openaiModel("gpt-image-2"),
+		request,
+		inference.GenerateExecutionStream,
+	)
+	if err != nil {
+		t.Fatalf("compileImage stream: %v", err)
+	}
+	rawStream, err := transportImageStream(cls.api)(
+		context.Background(),
+		compiled.Wire,
+	)
+	if err != nil {
+		t.Fatalf("transportImageStream: %v", err)
+	}
+	var events []inference.GenerateStreamEvent
+	for {
+		raw, err := rawStream.Next(context.Background())
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			t.Fatalf("Next: %v", err)
+		}
+		event, err := decodeImageStream(context.Background(), raw)
+		if err != nil {
+			t.Fatalf("decodeImageStream: %v", err)
+		}
+		events = append(events, event)
+	}
+	if len(events) != 2 {
+		t.Fatalf("events = %d, want 2", len(events))
+	}
+	if events[0].PartIndex != 0 ||
+		events[0].Delta.(inference.ImagePartDelta).Interim != true {
+		t.Fatalf("partial event = %+v, want part 0 interim", events[0])
+	}
+	if events[1].PartIndex != 0 ||
+		events[1].Delta.(inference.ImagePartDelta).Interim != false ||
+		events[1].FinishReason != inference.FinishCompleted {
+		t.Fatalf("completed event = %+v, want part 0 final", events[1])
+	}
+	if events[1].RequestID != "req_openai_edit_1" {
+		t.Errorf("completed request_id = %q, want req_openai_edit_1",
+			events[1].RequestID)
+	}
+	_ = capture.body(0)
+}
+
+func TestImageCompilerStreamShape(t *testing.T) {
+	compile := func(shape inference.GenerateExecutionShape, partial *int) (
+		imageWire,
+		error,
+	) {
+		t.Helper()
+		request := inference.GenerateRequest{
+			Input: inference.GenerateInput{
+				Role: inference.InputRoleUser,
+				Content: inference.InputContent{
+					Content: message.Content{Parts: []message.Part{
+						message.TextPart{Text: "a red circle"},
+					}},
+					Intent: inference.Intent{Image: &inference.ImageIntent{}},
+				},
+			},
+		}
+		if partial != nil {
+			request.Extensions = inference.Extensions{
+				ImageOptions{PartialImages: partial},
+			}
+		}
+		compiled, err := compileImage("gpt-image-2")(
+			context.Background(),
+			openaiModel("gpt-image-2"),
+			request,
+			shape,
+		)
+		if err != nil {
+			return imageWire{}, err
+		}
+		return compiled.Wire, nil
+	}
+
+	if _, err := compile(inference.GenerateExecutionStream, nil); err != nil {
+		t.Fatalf("stream compile without extension: %v", err)
+	}
+	two := 2
+	wire, err := compile(inference.GenerateExecutionStream, &two)
+	if err != nil {
+		t.Fatalf("stream compile with partial_images: %v", err)
+	}
+	if wire.partialImages != 2 {
+		t.Fatalf("wire partial_images = %d, want 2", wire.partialImages)
+	}
+
+	// partial_images is stream-only: the unary shape rejects it.
+	if _, err := compile(inference.GenerateExecutionUnary, &two); err == nil {
+		t.Fatal("unary compile with partial_images succeeded, want rejection")
+	} else {
+		var inferenceErr *inference.Error
+		if !errors.As(err, &inferenceErr) ||
+			inferenceErr.Field != inference.ExtensionField("partial_images").Qualify(ImageOptions{}) {
+			t.Fatalf("unary partial_images error = %v, want partial_images field", err)
+		}
+	}
+
+	// Out-of-range preview counts are rejected at compile time.
+	four := 4
+	if _, err := compile(inference.GenerateExecutionStream, &four); err == nil {
+		t.Fatal("partial_images=4 compile succeeded, want rejection")
+	} else {
+		var inferenceErr *inference.Error
+		if !errors.As(err, &inferenceErr) ||
+			inferenceErr.Field != inference.ExtensionField("partial_images").Qualify(ImageOptions{}) {
+			t.Fatalf("partial_images=4 error = %v, want partial_images field", err)
+		}
+	}
+}
+
+func TestImageCompilerQuality(t *testing.T) {
+	compile := func(quality media.ImageQuality) (string, error) {
+		t.Helper()
+		request := inference.GenerateRequest{
+			Input: inference.GenerateInput{
+				Role: inference.InputRoleUser,
+				Content: inference.InputContent{
+					Content: message.Content{Parts: []message.Part{
+						message.TextPart{Text: "a red circle"},
+					}},
+					Intent: inference.Intent{Image: &inference.ImageIntent{
+						Quality: quality,
+					}},
+				},
+			},
+		}
+		compiled, err := compileImage("gpt-image-2")(
+			context.Background(),
+			openaiModel("gpt-image-2"),
+			request,
+			inference.GenerateExecutionUnary,
+		)
+		if err != nil {
+			return "", err
+		}
+		return compiled.Wire.quality, nil
+	}
+
+	for _, quality := range []media.ImageQuality{
+		media.ImageQualityAuto,
+		media.ImageQualityLow,
+		media.ImageQualityMedium,
+		media.ImageQualityHigh,
+	} {
+		got, err := compile(quality)
+		if err != nil {
+			t.Errorf("quality %q: compile = %v", quality, err)
+			continue
+		}
+		if got != string(quality) {
+			t.Errorf("quality %q: wire = %q", quality, got)
+		}
+	}
+
+	_, err := compile(media.ImageQuality("ultra"))
+	if err == nil {
+		t.Fatal("unknown quality compiled, want rejection")
+	}
+	var inferenceErr *inference.Error
+	if !errors.As(err, &inferenceErr) ||
+		inferenceErr.Field != inference.FieldGenerateIntentImageQuality {
+		t.Fatalf("unknown quality error = %v, want image quality field", err)
+	}
 }
 
 func TestTTSTransport(t *testing.T) {

--- a/driver/openai/image.go
+++ b/driver/openai/image.go
@@ -6,14 +6,20 @@ import (
 	"encoding/base64"
 	"fmt"
 	"io"
+	"net/http"
+	"strconv"
 	"strings"
 
+	"github.com/GizClaw/flowcraft/core/errdefs"
 	"github.com/GizClaw/flowcraft/core/inference"
 	"github.com/GizClaw/flowcraft/core/message"
 	"github.com/GizClaw/flowcraft/core/message/media"
 
 	"github.com/openai/openai-go/v3"
+	"github.com/openai/openai-go/v3/option"
 	"github.com/openai/openai-go/v3/packages/param"
+	"github.com/openai/openai-go/v3/packages/respjson"
+	"github.com/openai/openai-go/v3/packages/ssestream"
 )
 
 // Image generation runs on the images endpoint (gpt-image). Text-only
@@ -25,11 +31,13 @@ import (
 // is rejected.
 
 type imageWire struct {
-	model  string
-	prompt string
-	size   string // WxH; gpt-image-2-family models accept arbitrary sizes
-	count  int
-	format string // png | jpeg | webp
+	model         string
+	prompt        string
+	size          string // WxH; gpt-image-2-family models accept arbitrary sizes
+	count         int
+	format        string // png | jpeg | webp
+	quality       string // auto | low | medium | high
+	partialImages int    // 0-3 progress previews before the final image (stream only)
 	// images are inline reference images for image-to-image edits; empty
 	// means a text-only generation.
 	images []wireImage
@@ -62,6 +70,8 @@ type imageRaw struct {
 	inputTokens  int64
 	outputTokens int64
 	totalTokens  int64
+	requestID    string
+	responseID   string
 }
 
 // imageSize validates one canonical size against the gpt-image-2-family
@@ -106,12 +116,6 @@ func compileImage(
 			request.ActiveFieldsFor(shape),
 		)
 		wire := imageWire{model: model, count: 1}
-		if shape == inference.GenerateExecutionStream {
-			ledger.reject(
-				inference.FieldGenerateExecutionStream,
-				"image generation is unary on this provider",
-			)
-		}
 
 		var prompt []string
 		collect := func(parts []message.Part, fields map[message.PartKind]inference.FieldID) {
@@ -207,9 +211,45 @@ func compileImage(
 					"gpt-image returns inline payloads only; URL delivery has no channel",
 				)
 			}
+			if image.Quality != "" {
+				switch image.Quality {
+				case media.ImageQualityAuto,
+					media.ImageQualityLow,
+					media.ImageQualityMedium,
+					media.ImageQualityHigh:
+					wire.quality = string(image.Quality)
+				default:
+					ledger.reject(
+						inference.FieldGenerateIntentImageQuality,
+						fmt.Sprintf(
+							"image quality %q is not supported",
+							image.Quality,
+						),
+					)
+				}
+			}
 		}
-		for _, field := range request.Extensions.ActiveFields() {
-			ledger.reject(field, "openai image generation supports no extensions")
+		options, other := operationExtensions[ImageOptions](request.Extensions)
+		rejectOtherExtensions("image generation", other, ledger)
+		if partial := options.PartialImages; partial != nil {
+			field := inference.ExtensionField("partial_images").Qualify(options)
+			switch {
+			case shape != inference.GenerateExecutionStream:
+				ledger.reject(
+					field,
+					"partial_images applies to the stream execution shape",
+				)
+			case *partial < 0 || *partial > 3:
+				ledger.reject(
+					field,
+					fmt.Sprintf(
+						"partial_images must be between 0 and 3, not %d",
+						*partial,
+					),
+				)
+			default:
+				wire.partialImages = *partial
+			}
 		}
 		if intent.Audio != nil {
 			ledger.reject(
@@ -237,40 +277,19 @@ func transportImage(
 	return func(ctx context.Context, wire imageWire) (imageRaw, error) {
 		var response *openai.ImagesResponse
 		var err error
+		var requestID string
 		if len(wire.images) == 0 {
-			params := openai.ImageGenerateParams{
-				Model:  wire.model,
-				Prompt: wire.prompt,
-				N:      param.NewOpt(int64(wire.count)),
-			}
-			if wire.size != "" {
-				params.Size = openai.ImageGenerateParamsSize(wire.size)
-			}
-			if wire.format != "" {
-				params.OutputFormat = openai.ImageGenerateParamsOutputFormat(wire.format)
-			}
-			response, err = client.Images.Generate(ctx, params)
+			response, err = client.Images.Generate(
+				ctx,
+				imageGenerateParams(wire),
+				captureRequestID(&requestID),
+			)
 		} else {
-			readers := make([]io.Reader, 0, len(wire.images))
-			for _, image := range wire.images {
-				readers = append(readers, imageFile{
-					Reader:      bytes.NewReader(image.data),
-					contentType: image.mediaType,
-				})
-			}
-			params := openai.ImageEditParams{
-				Model:  openai.ImageModel(wire.model),
-				Prompt: wire.prompt,
-				N:      param.NewOpt(int64(wire.count)),
-				Image:  openai.ImageEditParamsImageUnion{OfFileArray: readers},
-			}
-			if wire.size != "" {
-				params.Size = openai.ImageEditParamsSize(wire.size)
-			}
-			if wire.format != "" {
-				params.OutputFormat = openai.ImageEditParamsOutputFormat(wire.format)
-			}
-			response, err = client.Images.Edit(ctx, params)
+			response, err = client.Images.Edit(
+				ctx,
+				imageEditParams(wire),
+				captureRequestID(&requestID),
+			)
 		}
 		if err != nil {
 			return imageRaw{}, classifyError(err)
@@ -280,6 +299,8 @@ func transportImage(
 			inputTokens:  response.Usage.InputTokens,
 			outputTokens: response.Usage.OutputTokens,
 			totalTokens:  response.Usage.TotalTokens,
+			requestID:    requestID,
+			responseID:   responseBodyID(response.JSON.ExtraFields),
 		}
 		for index, image := range response.Data {
 			data, err := base64.StdEncoding.DecodeString(image.B64JSON)
@@ -294,6 +315,97 @@ func transportImage(
 		}
 		return raw, nil
 	}
+}
+
+// captureRequestID returns a per-call request option whose middleware
+// records the provider's request-id response header. The middleware runs on
+// every HTTP attempt, so the last attempt's header wins. OpenAI echoes the
+// request identifier as x-request-id; apim-request-id covers Azure-backed
+// deployments of the same protocol.
+func captureRequestID(target *string) option.RequestOption {
+	return option.WithMiddleware(func(
+		req *http.Request,
+		next option.MiddlewareNext,
+	) (*http.Response, error) {
+		response, err := next(req)
+		if err != nil || response == nil {
+			return response, err
+		}
+		if id := response.Header.Get("x-request-id"); id != "" {
+			*target = id
+		} else if id := response.Header.Get("apim-request-id"); id != "" {
+			*target = id
+		}
+		return response, err
+	})
+}
+
+// responseBodyID extracts a response-object id the SDK does not model from
+// the decoded body's extra fields, when the provider echoes one.
+func responseBodyID(fields map[string]respjson.Field) string {
+	field, ok := fields["id"]
+	if !ok || field.Raw() == "" {
+		return ""
+	}
+	id, err := strconv.Unquote(field.Raw())
+	if err != nil {
+		return ""
+	}
+	return id
+}
+
+// imageGenerateParams renders the images/generations request body. Both the
+// unary and streaming transports share it; partialImages stays zero off the
+// stream shape, so unary requests never carry the streaming-only parameter.
+func imageGenerateParams(wire imageWire) openai.ImageGenerateParams {
+	params := openai.ImageGenerateParams{
+		Model:  wire.model,
+		Prompt: wire.prompt,
+		N:      param.NewOpt(int64(wire.count)),
+	}
+	if wire.size != "" {
+		params.Size = openai.ImageGenerateParamsSize(wire.size)
+	}
+	if wire.format != "" {
+		params.OutputFormat = openai.ImageGenerateParamsOutputFormat(wire.format)
+	}
+	if wire.quality != "" {
+		params.Quality = openai.ImageGenerateParamsQuality(wire.quality)
+	}
+	if wire.partialImages > 0 {
+		params.PartialImages = param.NewOpt(int64(wire.partialImages))
+	}
+	return params
+}
+
+// imageEditParams renders the images/edits multipart request body.
+func imageEditParams(wire imageWire) openai.ImageEditParams {
+	readers := make([]io.Reader, 0, len(wire.images))
+	for _, image := range wire.images {
+		readers = append(readers, imageFile{
+			Reader:      bytes.NewReader(image.data),
+			contentType: image.mediaType,
+		})
+	}
+	params := openai.ImageEditParams{
+		Model:  openai.ImageModel(wire.model),
+		Prompt: wire.prompt,
+		N:      param.NewOpt(int64(wire.count)),
+		Image:  openai.ImageEditParamsImageUnion{OfFileArray: readers},
+	}
+	if wire.size != "" {
+		params.Size = openai.ImageEditParamsSize(wire.size)
+	}
+	if wire.format != "" {
+		params.OutputFormat = openai.ImageEditParamsOutputFormat(wire.format)
+	}
+	if wire.quality != "" {
+		params.Quality = openai.ImageEditParamsQuality(wire.quality)
+	}
+	if wire.partialImages > 0 {
+		params.PartialImages = param.NewOpt(int64(wire.partialImages))
+	}
+	return params
 }
 
 func decodeImage(
@@ -331,6 +443,10 @@ func decodeImage(
 			Role:    message.RoleAssistant,
 			Content: message.Content{Parts: parts},
 		},
+		Metadata: inference.Metadata{
+			RequestID:  raw.requestID,
+			ResponseID: raw.responseID,
+		},
 		FinishReason: inference.FinishCompleted,
 		Usage: inference.Usage{
 			InputTokens:     raw.inputTokens,
@@ -356,18 +472,258 @@ func sniffImageMediaType(data []byte) string {
 	return ""
 }
 
+// ---------------------------------------------------------------------------
+// Streaming.
+// ---------------------------------------------------------------------------
+
+// imageStreamRaw is one event from the image streaming surface after part
+// index assignment. interim marks a progress preview; the final image for
+// an output arrives with interim false and carries the cumulative usage.
+type imageStreamRaw struct {
+	partIndex    int
+	interim      bool
+	b64          string
+	outputFormat string
+	usage        inference.Usage
+	requestID    string
+}
+
+// imageStreamEvent is the driver-side view of one SDK image stream event.
+// The SDK exposes generation and edit streams as two sealed unions with
+// identical shapes; this view keeps both behind one concrete surface for
+// the stream wrapper and decoder.
+type imageStreamEvent struct {
+	b64          string
+	outputFormat string
+	usage        inference.Usage
+	partial      bool
+	completed    bool
+	rawType      string
+}
+
+// imageSDKStream is the small SDK surface the wrapper needs. The SDK stream
+// types are concrete, so generation and edit streams each adapt it.
+type imageSDKStream interface {
+	Next() bool
+	Current() imageStreamEvent
+	Err() error
+	Close() error
+}
+
+type imageGenSDKStream struct {
+	stream *ssestream.Stream[openai.ImageGenStreamEventUnion]
+}
+
+func (s imageGenSDKStream) Next() bool { return s.stream.Next() }
+func (s imageGenSDKStream) Err() error { return s.stream.Err() }
+func (s imageGenSDKStream) Close() error {
+	return s.stream.Close()
+}
+
+func (s imageGenSDKStream) Current() imageStreamEvent {
+	event := s.stream.Current()
+	return imageStreamEvent{
+		b64:          event.B64JSON,
+		outputFormat: event.OutputFormat,
+		usage: inference.Usage{
+			InputTokens:  event.Usage.InputTokens,
+			OutputTokens: event.Usage.OutputTokens,
+			TotalTokens:  event.Usage.TotalTokens,
+		},
+		partial:   event.Type == "image_generation.partial_image",
+		completed: event.Type == "image_generation.completed",
+		rawType:   event.Type,
+	}
+}
+
+type imageEditSDKStream struct {
+	stream *ssestream.Stream[openai.ImageEditStreamEventUnion]
+}
+
+func (s imageEditSDKStream) Next() bool { return s.stream.Next() }
+func (s imageEditSDKStream) Err() error { return s.stream.Err() }
+func (s imageEditSDKStream) Close() error {
+	return s.stream.Close()
+}
+
+func (s imageEditSDKStream) Current() imageStreamEvent {
+	event := s.stream.Current()
+	return imageStreamEvent{
+		b64:          event.B64JSON,
+		outputFormat: event.OutputFormat,
+		usage: inference.Usage{
+			InputTokens:  event.Usage.InputTokens,
+			OutputTokens: event.Usage.OutputTokens,
+			TotalTokens:  event.Usage.TotalTokens,
+		},
+		partial:   event.Type == "image_edit.partial_image",
+		completed: event.Type == "image_edit.completed",
+		rawType:   event.Type,
+	}
+}
+
+// imageStream adapts the SDK image SSE reader to ProviderStream[imageStreamRaw].
+// It assigns canonical part indices: progress previews and the final image
+// for one output share one index, so the terminal result keeps only the
+// last image per output. The SDK events carry no per-image index, so the
+// wrapper assumes the API streams outputs sequentially.
+type imageStream struct {
+	sdk       imageSDKStream
+	nextPart  int
+	requestID string
+}
+
+func (s *imageStream) Next(
+	ctx context.Context,
+) (imageStreamRaw, error) {
+	if err := ctx.Err(); err != nil {
+		return imageStreamRaw{}, errdefs.FromContext(err)
+	}
+	for {
+		if !s.sdk.Next() {
+			if err := s.sdk.Err(); err != nil {
+				classified := classifyError(err)
+				logInferenceStream(ctx, "generate", "", classified, "")
+				return imageStreamRaw{}, classified
+			}
+			return imageStreamRaw{}, io.EOF
+		}
+		event := s.sdk.Current()
+		switch {
+		case event.partial:
+			return imageStreamRaw{
+				partIndex:    s.nextPart,
+				interim:      true,
+				b64:          event.b64,
+				outputFormat: event.outputFormat,
+			}, nil
+		case event.completed:
+			raw := imageStreamRaw{
+				partIndex:    s.nextPart,
+				b64:          event.b64,
+				outputFormat: event.outputFormat,
+				usage:        event.usage,
+				requestID:    s.requestID,
+			}
+			s.nextPart++
+			return raw, nil
+		default:
+			return imageStreamRaw{}, fmt.Errorf(
+				"openai: unknown image stream event type %q",
+				event.rawType,
+			)
+		}
+	}
+}
+
+func (s *imageStream) Close() error {
+	if s.sdk == nil {
+		return nil
+	}
+	return classifyError(s.sdk.Close())
+}
+
+func transportImageStream(
+	client openai.Client,
+) inference.Transport[imageWire, inference.ProviderStream[imageStreamRaw]] {
+	return func(
+		ctx context.Context,
+		wire imageWire,
+	) (inference.ProviderStream[imageStreamRaw], error) {
+		var sdk imageSDKStream
+		var requestID string
+		if len(wire.images) == 0 {
+			sdk = imageGenSDKStream{
+				stream: client.Images.GenerateStreaming(
+					ctx,
+					imageGenerateParams(wire),
+					captureRequestID(&requestID),
+				),
+			}
+		} else {
+			sdk = imageEditSDKStream{
+				stream: client.Images.EditStreaming(
+					ctx,
+					imageEditParams(wire),
+					captureRequestID(&requestID),
+				),
+			}
+		}
+		if err := sdk.Err(); err != nil {
+			classified := classifyError(err)
+			logInferenceStream(ctx, "generate", wire.model, classified, "")
+			return nil, classified
+		}
+		logInferenceStream(ctx, "generate", wire.model, nil, "")
+		return &imageStream{sdk: sdk, requestID: requestID}, nil
+	}
+}
+
+func decodeImageStream(
+	_ context.Context,
+	raw imageStreamRaw,
+) (inference.GenerateStreamEvent, error) {
+	image, err := streamImagePart(raw.b64, raw.outputFormat)
+	if err != nil {
+		return inference.GenerateStreamEvent{}, err
+	}
+	event := inference.GenerateStreamEvent{
+		PartIndex: raw.partIndex,
+		Delta: inference.ImagePartDelta{
+			Part:    image,
+			Interim: raw.interim,
+		},
+	}
+	if !raw.interim {
+		event.Usage = &raw.usage
+		event.FinishReason = inference.FinishCompleted
+		event.RequestID = raw.requestID
+	}
+	return event, nil
+}
+
+func streamImagePart(
+	b64Data string,
+	outputFormat string,
+) (message.ImagePart, error) {
+	data, err := base64.StdEncoding.DecodeString(b64Data)
+	if err != nil {
+		return message.ImagePart{}, fmt.Errorf(
+			"openai: decode image stream payload: %w",
+			err,
+		)
+	}
+	mediaType := media.ImageFormat(outputFormat).MediaType()
+	if mediaType == "" {
+		// The stream events echo the negotiated output format; sniff the
+		// container when it is absent or unknown.
+		mediaType = sniffImageMediaType(data)
+		if mediaType == "" {
+			return message.ImagePart{}, fmt.Errorf(
+				"openai: image stream payload has unrecognized format",
+			)
+		}
+	}
+	source, err := media.NewImageBytes(data, mediaType)
+	if err != nil {
+		return message.ImagePart{}, fmt.Errorf(
+			"openai: image stream data: %w",
+			err,
+		)
+	}
+	return message.ImagePart{Source: source}, nil
+}
+
 func openImage(
 	cls *clients,
 	id inference.ModelID,
 	_ string,
 ) (inference.GenerateOperations, error) {
-	unary, err := inference.BindGenerate(
+	return inference.BindGenerateOperations(
 		compileImage(id.Name),
 		transportImage(cls.api),
 		decodeImage,
+		transportImageStream(cls.api),
+		decodeImageStream,
 	)
-	if err != nil {
-		return inference.GenerateOperations{}, err
-	}
-	return inference.GenerateOperations{Unary: unary}, nil
 }


### PR DESCRIPTION
Closes #462

## Summary

Adds streaming image generation, a canonical image quality knob, and request/response id metadata to the image surface.

### core
- `ImagePartDelta.Interim`: progress snapshots replace rather than accumulate at the same part index; the terminal result keeps only the final image per index (`GeneratedImages` stays correct).
- `ImageIntent.Quality` (`auto` / `low` / `medium` / `high`) with `FieldGenerateIntentImageQuality` ledger wiring.

### driver/azure + driver/openai (kept in sync)
- Image generation and edits now bind unary + SSE stream (`GenerateStreaming`/`EditStreaming`); partial-image previews are controlled by `image_options.partial_images` (0–3) on the stream shape.
- `quality` maps 1:1 to the wire parameter for both generations and edits.
- `request_id` is captured from `x-request-id`/`apim-request-id` response headers and `response_id` from the body `id`; both surface in `Metadata` for unary and streaming paths (fixes the empty-id gap on azure image calls).

### driver/bytedance + driver/minimax
- Reject canonical `quality` at compile time (no native quality parameter; seedream expresses quality via model/resolution tiers, image-01 via model).

## Verification
- `make ci`, `make lint`, `make release-check`, `git diff --check` all pass.
- New tests cover streaming transports (generation + edits), quality mapping/rejection, metadata ids, and interim snapshot semantics.