### PR TITLE
chore(release): add core v0.1.34 changeset

### DIFF
--- a/.release/core-v0.1.34.json
+++ b/.release/core-v0.1.34.json
@@ -1,0 +1,9 @@
+{
+  "summary": "feat(core): image generation streaming and quality — ImagePartDelta gains Interim progress snapshots that replace rather than accumulate at the same part index, so partial-image previews stream as progress while the terminal result keeps only the final image per index (GeneratedImages stays correct); ImageIntent gains a canonical Quality field (auto|low|medium|high via media.ImageQuality) wired through the generate ledger, giving azure/openai image generation a quality knob and letting bytedance/minimax reject it at compile time",
+  "releases": [
+    {
+      "module": "core",
+      "bump": "patch"
+    }
+  ]
+}


### PR DESCRIPTION
Adds the core v0.1.34 patch changeset covering the image generation streaming + quality delta shipped in #463.

- module: core
- bump: patch
- current: 0.1.33 → next: 0.1.34
- tag: core/v0.1.34

Validated with `make release-check` and `make release-plan` (both pass). After merge, release-modules CI will tag `core/v0.1.34`.