### PR TITLE
fix(driver): drop unsupported image quality instead of failing

### DIFF
--- a/driver/bytedance/image.go
+++ b/driver/bytedance/image.go
@@ -178,7 +178,7 @@ func compileImage(
 				}
 			}
 			if image.Quality != "" {
-				ledger.reject(
+				ledger.drop(
 					inference.FieldGenerateIntentImageQuality,
 					"seedream has no quality parameter; quality is set by model and resolution tier",
 				)

--- a/driver/bytedance/image_test.go
+++ b/driver/bytedance/image_test.go
@@ -209,18 +209,27 @@ func TestCompileImageBackgroundRejects(t *testing.T) {
 	}
 }
 
-func TestCompileImageQualityRejects(t *testing.T) {
+func TestCompileImageQualityDrops(t *testing.T) {
 	request := compileImageRequest(
 		[]message.Part{message.TextPart{Text: "a red circle"}},
 		ImageOptions{},
 	)
 	request.Input.Content.Intent.Image.Quality = media.ImageQualityHigh
 	_, report, err := compileImageWire(t, request)
-	if err == nil {
-		t.Fatal("compile succeeded, want quality rejection")
+	if err != nil {
+		t.Fatalf("compile: %v, want quality dropped with success", err)
 	}
-	if reason := rejectedReason(report, inference.FieldGenerateIntentImageQuality); !strings.Contains(reason, "no quality parameter") {
-		t.Fatalf("rejected reason = %q, want seedream no-quality rejection", reason)
+	found := false
+	for _, decision := range report.Decisions {
+		if decision.Field == inference.FieldGenerateIntentImageQuality &&
+			decision.Disposition == inference.Dropped &&
+			strings.Contains(decision.Reason, "no quality parameter") {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("report decisions = %+v, want quality dropped with reason",
+			report.Decisions)
 	}
 }
 

--- a/driver/minimax/image.go
+++ b/driver/minimax/image.go
@@ -173,7 +173,7 @@ func compileImage(
 				wire.delivery = "base64"
 			}
 			if image.Quality != "" {
-				ledger.reject(
+				ledger.drop(
 					inference.FieldGenerateIntentImageQuality,
 					"image-01 has no quality parameter",
 				)

--- a/driver/minimax/image_test.go
+++ b/driver/minimax/image_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/GizClaw/flowcraft/core/message/media"
 )
 
-func TestCompileImageQualityRejects(t *testing.T) {
+func TestCompileImageQualityDrops(t *testing.T) {
 	request := inference.GenerateRequest{
 		Input: inference.GenerateInput{
 			Role: inference.InputRoleUser,
@@ -32,19 +32,19 @@ func TestCompileImageQualityRejects(t *testing.T) {
 		request,
 		inference.GenerateExecutionUnary,
 	)
-	if err == nil {
-		t.Fatal("compile succeeded, want quality rejection")
+	if err != nil {
+		t.Fatalf("compile: %v, want quality dropped with success", err)
 	}
 	found := false
 	for _, decision := range compiled.Report.Decisions {
 		if decision.Field == inference.FieldGenerateIntentImageQuality &&
-			decision.Disposition == inference.Rejected &&
+			decision.Disposition == inference.Dropped &&
 			strings.Contains(decision.Reason, "no quality parameter") {
 			found = true
 		}
 	}
 	if !found {
-		t.Fatalf("report decisions = %+v, want image-01 no-quality rejection",
+		t.Fatalf("report decisions = %+v, want image-01 no-quality drop",
 			compiled.Report.Decisions)
 	}
 }


### PR DESCRIPTION
Fixes the behavior when `ImageIntent.Quality` is set but the provider has no native quality parameter.

**Before**: bytedance seedream and minimax image-01 rejected the field at compile time (`UnsupportedFeature`) and the generation failed.

**After**: the field compiles to a `Dropped` decision with a reason — generation proceeds at the provider default quality, and the drop is auditable via `Explain` and `response.Metadata.Decisions` (e.g. `{field: ...image.quality, disposition: dropped, reason: "seedream has no quality parameter; quality is set by model and resolution tier"}`).

This matches the existing soft-knob precedent in the repo: reasoning fields a model cannot consume are dropped with a reason rather than rejected.

azure/openai are unaffected (quality maps natively to the wire).

Verified: targeted tests updated and passing; `make ci`, `make lint`, `git diff --check` green.