### PR TITLE
fix(core): keep undefined-tool recovery feedback out of the transcript

### DIFF
--- a/.release/core-v0.1.35.json
+++ b/.release/core-v0.1.35.json
@@ -1,0 +1,9 @@
+{
+  "summary": "fix(core): keep undefined-tool recovery feedback out of the messages channel — recoverUndefinedTool no longer appends a user-role rejection to the transcript; the feedback text is stored on the board under the optional recover_feedback_key config (defaulting to a reserved per-node __recover_feedback.<node id> var), the recovered inference round consumes it as its current input with the whole channel as context, and a successful round clears the pending marker and deletes the feedback var; recovery-enabled nodes get isolated per-node slots and unrelated nodes never delete another node's pending feedback",
+  "releases": [
+    {
+      "module": "core",
+      "bump": "patch"
+    }
+  ]
+}

--- a/core/graph/nodes/inference.go
+++ b/core/graph/nodes/inference.go
@@ -54,12 +54,13 @@ type InferenceConfig struct {
 	// through a tool node and loop back.
 	ToolPendingKey string `json:"tool_pending_key,omitempty"`
 	// UndefinedToolRecovery converts a generate rejection for a tool
-	// call absent from the exposed definitions into in-conversation
-	// feedback instead of failing the node: the rejected call is
-	// replayed as an assistant tool_call paired with a tool result
-	// telling the model the tool is not exposed and to use tool_search.
-	// The graph routes on RecoverPendingKey back to inference — never
-	// through a tool node, which would execute the call. Strict
+	// call absent from the exposed definitions into recoverable
+	// feedback instead of failing the node. The rejected call is not
+	// replayed: the node stores a user-role feedback text under
+	// RecoverFeedbackKey (or the reserved defaultRecoverFeedbackKey var
+	// when unset) and the graph routes on RecoverPendingKey back to
+	// inference, where the stored feedback becomes the next round's
+	// input without ever being written to the messages channel. Strict
 	// deployments leave this disabled and keep failing hard.
 	UndefinedToolRecovery *UndefinedToolRecoveryConfig `json:"undefined_tool_recovery,omitempty"`
 	// RecoverPendingKey, when set, receives whether the current round
@@ -69,6 +70,14 @@ type InferenceConfig struct {
 	// RecoverCountKey, when set, receives the per-run recovery counter.
 	// The node hard-fails once it reaches MaxPerRun.
 	RecoverCountKey string `json:"recover_count_key,omitempty"`
+	// RecoverFeedbackKey, when set, receives the user-role feedback
+	// text describing the rejected tool call. The stored text becomes
+	// the recovered round's current input while the messages channel
+	// stays free of engine-generated turns, so UIs render a pure user
+	// transcript. Empty defaults to a reserved per-node var named
+	// "__recover_feedback.<node id>", so concurrent recovery on
+	// different inference nodes never shares a slot.
+	RecoverFeedbackKey string `json:"recover_feedback_key,omitempty"`
 
 	// Stream opens a GenerateStream and publishes text and reasoning
 	// deltas as token stream events. Reasoning fragments arrive as
@@ -122,6 +131,14 @@ type UndefinedToolRecoveryConfig struct {
 // responses one graph run converts into feedback before failing hard.
 const defaultUndefinedToolMaxRecoveries = 2
 
+// defaultRecoverFeedbackPrefix is the reserved board-var prefix the
+// recovery flow uses when RecoverFeedbackKey is not configured; the
+// recovering node's id is appended (e.g. "__recover_feedback.llm"), so
+// the slot is scoped per node. It lives in the engine's "__" namespace
+// (see agent.MainChannel); user-domain code must not introduce keys
+// with that prefix.
+const defaultRecoverFeedbackPrefix = "__recover_feedback."
+
 // undefinedToolFeedback is the model-readable rejection appended as a
 // user feedback message when a response names a tool the model was
 // never shown.
@@ -163,6 +180,7 @@ func Inference(deps InferenceNodeDeps) graph.NodeType[InferenceConfig] {
 				{Kind: graph.RoleVar, ConfigKey: "tool_pending_key"},
 				{Kind: graph.RoleVar, ConfigKey: "recover_pending_key"},
 				{Kind: graph.RoleVar, ConfigKey: "recover_count_key"},
+				{Kind: graph.RoleVar, ConfigKey: "recover_feedback_key"},
 			},
 		},
 		Handler: func(ec graph.ExecutionContext, board *agent.Board, cfg InferenceConfig) error {
@@ -193,12 +211,20 @@ func runInference(ec graph.ExecutionContext, board *agent.Board, cfg InferenceCo
 
 	resp, err := executeGenerate(ec, board, cfg, deps, req)
 	if err != nil {
-		return recoverUndefinedTool(ec, board, channel, cfg, err)
+		return recoverUndefinedTool(ec, board, cfg, err)
 	}
 	if cfg.RecoverPendingKey != "" {
 		// A successful round clears the recovery marker so the loop
 		// returns to its normal edges.
 		board.SetVar(cfg.RecoverPendingKey, false)
+	}
+	if cfg.UndefinedToolRecovery != nil && cfg.UndefinedToolRecovery.Enabled {
+		// Stale feedback from a previous recovery must not leak into a
+		// later round once the loop has returned to its normal edges.
+		// Only nodes participating in recovery touch their own slot, so
+		// an unrelated node's success never clears another node's
+		// pending feedback.
+		board.DeleteVar(recoverFeedbackKey(ec, cfg))
 	}
 	// Mirror the provider request / response identifiers and token
 	// usage onto the node span after a successful call so
@@ -259,19 +285,25 @@ func runInference(ec graph.ExecutionContext, board *agent.Board, cfg InferenceCo
 }
 
 // recoverUndefinedTool converts an undefined-tool generate failure into
-// in-conversation feedback when the node is configured to recover. The
-// rejection is appended as a single user-role text message explaining how
-// to expose the tool. The rejected call is deliberately not replayed as a
+// recoverable feedback when the node is configured to recover. The
+// rejection is stored as a user-role feedback text under
+// RecoverFeedbackKey (or the per-node reserved
+// "__recover_feedback.<node id>" var) — it is deliberately NOT appended
+// to the messages channel, so the user-visible transcript never shows
+// an engine-generated turn. The recovered round (routed back to
+// inference on RecoverPendingKey) consumes the stored text as its
+// current input with the whole channel as context; see
+// buildGenerateRequest. The rejected call is never replayed as a
 // synthetic assistant tool_call: that would fabricate a turn the model
 // never produced, violate provider reasoning round-trip rules (DeepSeek
-// thinking mode requires reasoning_content on assistant tool-call turns),
-// and leave an undefined function reference in history for providers that
-// validate calls against the request tool set. The graph must still route
-// back to inference, never through a tool node, or the call would be
-// executed for real. The original error is returned when recovery is
-// disabled, the failure is not an undefined-tool rejection, or the
-// per-run budget is exhausted.
-func recoverUndefinedTool(ec graph.ExecutionContext, board *agent.Board, channel string, cfg InferenceConfig, err error) error {
+// thinking mode requires reasoning_content on assistant tool-call
+// turns), and leave an undefined function reference in history for
+// providers that validate calls against the request tool set. The graph
+// must still route back to inference, never through a tool node, or the
+// call would be executed for real. The original error is returned when
+// recovery is disabled, the failure is not an undefined-tool rejection,
+// or the per-run budget is exhausted.
+func recoverUndefinedTool(ec graph.ExecutionContext, board *agent.Board, cfg InferenceConfig, err error) error {
 	if cfg.UndefinedToolRecovery == nil || !cfg.UndefinedToolRecovery.Enabled {
 		return err
 	}
@@ -290,12 +322,7 @@ func recoverUndefinedTool(ec graph.ExecutionContext, board *agent.Board, channel
 		return err
 	}
 	call := *infErr.UndefinedToolCall
-	board.AppendChannelMessage(channel, message.Message{
-		Role: message.RoleUser,
-		Content: message.Content{Parts: []message.Part{
-			message.TextPart{Text: fmt.Sprintf(undefinedToolFeedback, call.Name)},
-		}},
-	})
+	board.SetVar(recoverFeedbackKey(ec, cfg), fmt.Sprintf(undefinedToolFeedback, call.Name))
 	if cfg.ToolPendingKey != "" {
 		board.SetVar(cfg.ToolPendingKey, false)
 	}
@@ -367,6 +394,53 @@ func buildGenerateRequest(ec graph.ExecutionContext, board *agent.Board, channel
 	if len(messages) == 0 {
 		return req, errdefs.Validationf("inference node: messages channel %q is empty", channel)
 	}
+
+	intent, err := resolveIntent(ec.Context, cfg, deps)
+	if err != nil {
+		return req, err
+	}
+
+	extensions, err := inference.DecodeExtensions(cfg.Extensions, deps.Extensions, "inference node extensions")
+	if err != nil {
+		return req, err
+	}
+
+	// A recovered round feeds the stored feedback as its current input
+	// instead of a channel tail: the feedback is engine-generated and
+	// never written to the user-visible transcript. The whole channel
+	// (including the rejected assistant tool_calls turn) is the
+	// context, with the system prompt prepended exactly as on a normal
+	// round.
+	if recoveryPending(board, cfg) {
+		feedbackKey := recoverFeedbackKey(ec, cfg)
+		feedback := board.GetVarString(feedbackKey)
+		if feedback == "" {
+			return req, errdefs.Validationf(
+				"inference node: recovery pending but var %q holds no feedback text",
+				feedbackKey)
+		}
+		contextMessages := messages
+		if cfg.SystemPrompt != "" &&
+			(len(contextMessages) == 0 || contextMessages[0].Role != message.RoleSystem) {
+			contextMessages = append(
+				[]message.Message{message.NewTextMessage(message.RoleSystem, cfg.SystemPrompt)},
+				contextMessages...,
+			)
+		}
+		return inference.GenerateRequest{
+			Context: contextMessages,
+			Input: inference.GenerateInput{
+				Role: inference.InputRoleUser,
+				Content: inference.InputContent{
+					Content: message.NewTextMessage(message.RoleUser, feedback).Content,
+					Intent:  intent,
+				},
+			},
+			Extensions: extensions,
+			ModelHint:  cfg.ModelHint,
+		}, nil
+	}
+
 	last := messages[len(messages)-1]
 	var inputRole inference.InputRole
 	switch last.Role {
@@ -388,16 +462,6 @@ func buildGenerateRequest(ec graph.ExecutionContext, board *agent.Board, channel
 		)
 	}
 
-	intent, err := resolveIntent(ec.Context, cfg, deps)
-	if err != nil {
-		return req, err
-	}
-
-	extensions, err := inference.DecodeExtensions(cfg.Extensions, deps.Extensions, "inference node extensions")
-	if err != nil {
-		return req, err
-	}
-
 	return inference.GenerateRequest{
 		Context: contextMessages,
 		Input: inference.GenerateInput{
@@ -410,6 +474,30 @@ func buildGenerateRequest(ec graph.ExecutionContext, board *agent.Board, channel
 		Extensions: extensions,
 		ModelHint:  cfg.ModelHint,
 	}, nil
+}
+
+// recoveryPending reports whether the board is mid-recovery: the
+// previous round was converted into feedback and the graph looped back
+// to this node. The feedback var must be configured for recovery, so an
+// empty key makes this never match (the guard also covers validation
+// failures at node start).
+func recoveryPending(board *agent.Board, cfg InferenceConfig) bool {
+	if cfg.UndefinedToolRecovery == nil || !cfg.UndefinedToolRecovery.Enabled ||
+		cfg.RecoverPendingKey == "" {
+		return false
+	}
+	pending, ok := board.GetVar(cfg.RecoverPendingKey)
+	return ok && pending == true
+}
+
+// recoverFeedbackKey returns the configured feedback var, falling back
+// to the engine-reserved per-node default
+// ("__recover_feedback.<node id>") when the config leaves it unset.
+func recoverFeedbackKey(ec graph.ExecutionContext, cfg InferenceConfig) string {
+	if cfg.RecoverFeedbackKey != "" {
+		return cfg.RecoverFeedbackKey
+	}
+	return defaultRecoverFeedbackPrefix + ec.NodeID
 }
 
 // resolveIntent assembles the invocation's canonical execution

--- a/core/graph/nodes/inference_test.go
+++ b/core/graph/nodes/inference_test.go
@@ -325,21 +325,22 @@ func TestInferenceNode_UndefinedToolRecovery(t *testing.T) {
 		UndefinedToolRecovery: &UndefinedToolRecoveryConfig{Enabled: true, MaxPerRun: 2},
 		RecoverPendingKey:     "recover_pending",
 		RecoverCountKey:       "recover_count",
+		RecoverFeedbackKey:    "recover_feedback",
 	})
 	board := userBoard()
 	if err := executeGraph(t, g, agent.NoopHost{}, board); err != nil {
 		t.Fatalf("Execute: %v", err)
 	}
 
+	// The feedback rides the board, never the transcript: the channel
+	// still holds only the original user turn.
 	msgs := board.Channel(agent.MainChannel)
-	if len(msgs) != 2 {
-		t.Fatalf("channel length = %d, want 2 (user + text feedback)", len(msgs))
+	if len(msgs) != 1 {
+		t.Fatalf("channel length = %d, want 1 (feedback must not enter the transcript)", len(msgs))
 	}
-	feedback, ok := msgs[1].Content.Parts[0].(message.TextPart)
-	if !ok || msgs[1].Role != message.RoleUser ||
-		!strings.Contains(feedback.Text, "ghost") ||
-		!strings.Contains(feedback.Text, "tool_search") {
-		t.Fatalf("recovered feedback message = %+v", msgs[1])
+	feedback := board.GetVarString("recover_feedback")
+	if !strings.Contains(feedback, "ghost") || !strings.Contains(feedback, "tool_search") {
+		t.Fatalf("recover_feedback var = %q, want ghost + tool_search text", feedback)
 	}
 	if v, _ := board.GetVar("recover_pending"); v != true {
 		t.Fatalf("recover_pending = %v, want true", v)
@@ -413,6 +414,7 @@ func TestInferenceNode_UndefinedToolRecoveryBudget(t *testing.T) {
 		UndefinedToolRecovery: &UndefinedToolRecoveryConfig{Enabled: true, MaxPerRun: 1},
 		RecoverPendingKey:     "recover_pending",
 		RecoverCountKey:       "recover_count",
+		RecoverFeedbackKey:    "recover_feedback",
 	})
 	board := userBoard()
 	board.SetVar("recover_count", 1) // one recovery already spent this run
@@ -439,20 +441,173 @@ func TestInferenceNode_UndefinedToolRecoveryRequiresKeys(t *testing.T) {
 	}
 }
 
+// TestInferenceNode_UndefinedToolRecoveryDefaultFeedbackKey proves the
+// feedback var defaults to the reserved per-node
+// "__recover_feedback.<node id>" slot: the rejection lands there, the
+// recovered round consumes it as input, and a successful round deletes
+// it — all without configuring recover_feedback_key.
+func TestInferenceNode_UndefinedToolRecoveryDefaultFeedbackKey(t *testing.T) {
+	var (
+		mu    sync.Mutex
+		calls int
+	)
+	fake := &inferencetest.GenerateFake{
+		Respond: func(inference.GenerateRequest) inference.GenerateResponse {
+			mu.Lock()
+			calls++
+			n := calls
+			mu.Unlock()
+			if n == 1 {
+				return undefinedToolResponse("ghost")
+			}
+			return textResponse("ok")
+		},
+	}
+	reg := inferenceRegistry(t, InferenceNodeDeps{
+		Assembly: fake.Assembly(t),
+		Catalog:  toolCatalog(t, stubTool{name: "known", desc: "a known tool"}),
+	})
+	config := InferenceConfig{
+		Model:                 ptr(inferencetest.DefaultFakeModel),
+		Tools:                 []string{"known"},
+		ToolPendingKey:        "tool_pending",
+		UndefinedToolRecovery: &UndefinedToolRecoveryConfig{Enabled: true, MaxPerRun: 2},
+		RecoverPendingKey:     "recover_pending",
+		RecoverCountKey:       "recover_count",
+	}
+	g := singleNodeGraph(t, reg, "inference", config)
+	board := userBoard()
+	if err := executeGraph(t, g, agent.NoopHost{}, board); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+
+	feedback := board.GetVarString("__recover_feedback.n")
+	if !strings.Contains(feedback, "ghost") || !strings.Contains(feedback, "tool_search") {
+		t.Fatalf("__recover_feedback var = %q, want ghost + tool_search text", feedback)
+	}
+	if msgs := board.Channel(agent.MainChannel); len(msgs) != 1 {
+		t.Fatalf("channel length = %d, want 1 (feedback must not enter the transcript)", len(msgs))
+	}
+
+	// The recovered round (pending marker set) consumes the default var
+	// as its current input, then clears both the marker and the var.
+	board.SetVar("recover_pending", true)
+	if err := executeGraph(t, g, agent.NoopHost{}, board); err != nil {
+		t.Fatalf("Execute recovered round: %v", err)
+	}
+	req := fake.LastRequest()
+	if req.Input.Role != inference.InputRoleUser {
+		t.Fatalf("input role = %q, want user", req.Input.Role)
+	}
+	if text, ok := req.Input.Content.Parts[0].(message.TextPart); !ok ||
+		!strings.Contains(text.Text, "ghost") {
+		t.Fatalf("recovered input = %+v, want stored feedback", req.Input.Content.Parts[0])
+	}
+	if v, _ := board.GetVar("recover_pending"); v != false {
+		t.Fatalf("recover_pending = %v, want false after success", v)
+	}
+	if _, ok := board.GetVar("__recover_feedback.n"); ok {
+		t.Fatalf("__recover_feedback.n var still present, want deleted after success")
+	}
+}
+
+// TestInferenceGraph_UndefinedToolRecoveryScopesDefaultFeedbackByNode
+// proves two recovery-enabled inference nodes never share the default
+// feedback slot: each rejection lands in its own
+// "__recover_feedback.<node id>" var, and neither node's success path
+// deletes the other node's pending feedback.
+func TestInferenceGraph_UndefinedToolRecoveryScopesDefaultFeedbackByNode(t *testing.T) {
+	var (
+		mu    sync.Mutex
+		calls int
+	)
+	fake := &inferencetest.GenerateFake{
+		Respond: func(inference.GenerateRequest) inference.GenerateResponse {
+			mu.Lock()
+			calls++
+			n := calls
+			mu.Unlock()
+			if n == 1 {
+				return undefinedToolResponse("ghost-a")
+			}
+			return undefinedToolResponse("ghost-b")
+		},
+	}
+	reg := inferenceRegistry(t, InferenceNodeDeps{
+		Assembly: fake.Assembly(t),
+		Catalog:  toolCatalog(t, stubTool{name: "known", desc: "a known tool"}),
+	})
+	config := func(pending, count string) json.RawMessage {
+		return mustConfig(t, InferenceConfig{
+			Model:                 ptr(inferencetest.DefaultFakeModel),
+			Tools:                 []string{"known"},
+			UndefinedToolRecovery: &UndefinedToolRecoveryConfig{Enabled: true, MaxPerRun: 2},
+			RecoverPendingKey:     pending,
+			RecoverCountKey:       count,
+		})
+	}
+	g, err := graph.Build(&graph.GraphDefinition{
+		Name:  "recovery-scope",
+		Entry: "a",
+		Nodes: []graph.NodeDefinition{
+			{ID: "a", Type: "inference", Config: config("recover_pending_a", "recover_count_a")},
+			{ID: "b", Type: "inference", Config: config("recover_pending_b", "recover_count_b")},
+		},
+		Edges: []graph.EdgeDefinition{
+			{From: "a", To: "b"},
+			{From: "b", To: graph.END},
+		},
+	}, reg)
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	board := userBoard()
+	if err := executeGraph(t, g, agent.NoopHost{}, board); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+
+	if fa := board.GetVarString("__recover_feedback.a"); !strings.Contains(fa, "ghost-a") {
+		t.Fatalf("__recover_feedback.a = %q, want node a's own rejection", fa)
+	}
+	if fb := board.GetVarString("__recover_feedback.b"); !strings.Contains(fb, "ghost-b") {
+		t.Fatalf("__recover_feedback.b = %q, want node b's own rejection", fb)
+	}
+	if msgs := board.Channel(agent.MainChannel); len(msgs) != 1 {
+		t.Fatalf("channel length = %d, want 1 (no feedback in transcript)", len(msgs))
+	}
+}
+
 func TestInferenceNode_UndefinedToolRecoveryClearsMarker(t *testing.T) {
 	fake := &inferencetest.GenerateFake{}
 	reg := inferenceRegistry(t, InferenceNodeDeps{Assembly: fake.Assembly(t)})
 	g := singleNodeGraph(t, reg, "inference", InferenceConfig{
-		Model:             ptr(inferencetest.DefaultFakeModel),
-		RecoverPendingKey: "recover_pending",
+		Model:                 ptr(inferencetest.DefaultFakeModel),
+		UndefinedToolRecovery: &UndefinedToolRecoveryConfig{Enabled: true},
+		RecoverPendingKey:     "recover_pending",
+		RecoverCountKey:       "recover_count",
+		RecoverFeedbackKey:    "recover_feedback",
 	})
 	board := userBoard()
 	board.SetVar("recover_pending", true)
+	board.SetVar("recover_feedback", `tool "ghost" is not exposed`)
 	if err := executeGraph(t, g, agent.NoopHost{}, board); err != nil {
 		t.Fatalf("Execute: %v", err)
 	}
+	// The recovered round consumes the stored feedback as its current
+	// input even though the channel tail is the original user turn.
+	req := fake.LastRequest()
+	if req.Input.Role != inference.InputRoleUser {
+		t.Fatalf("input role = %q, want user", req.Input.Role)
+	}
+	if text, ok := req.Input.Content.Parts[0].(message.TextPart); !ok ||
+		!strings.Contains(text.Text, "ghost") {
+		t.Fatalf("recovered input = %+v, want stored feedback", req.Input.Content.Parts[0])
+	}
 	if v, _ := board.GetVar("recover_pending"); v != false {
 		t.Fatalf("recover_pending = %v, want false after success", v)
+	}
+	if _, ok := board.GetVar("recover_feedback"); ok {
+		t.Fatalf("recover_feedback var still present, want deleted after success")
 	}
 }
 
@@ -486,6 +641,7 @@ func TestInferenceNode_UndefinedToolRecoveryKeepsNamedChoiceStrict(t *testing.T)
 		UndefinedToolRecovery: &UndefinedToolRecoveryConfig{Enabled: true, MaxPerRun: 2},
 		RecoverPendingKey:     "recover_pending",
 		RecoverCountKey:       "recover_count",
+		RecoverFeedbackKey:    "recover_feedback",
 	})
 	board := userBoard()
 	err := executeGraph(t, g, agent.NoopHost{}, board)
@@ -554,11 +710,13 @@ func TestInferenceGraph_UndefinedToolRecoveryLoop(t *testing.T) {
 			ID: "llm", Type: "inference",
 			Config: mustConfig(t, InferenceConfig{
 				Model:                 ptr(inferencetest.DefaultFakeModel),
+				SystemPrompt:          "be nice",
 				Tools:                 []string{"known"},
 				ToolPendingKey:        "tool_pending",
 				UndefinedToolRecovery: &UndefinedToolRecoveryConfig{Enabled: true, MaxPerRun: 2},
 				RecoverPendingKey:     "recover_pending",
 				RecoverCountKey:       "recover_count",
+				RecoverFeedbackKey:    "recover_feedback",
 			}),
 		}},
 		Edges: []graph.EdgeDefinition{
@@ -581,9 +739,14 @@ func TestInferenceGraph_UndefinedToolRecoveryLoop(t *testing.T) {
 	}
 	// The recovered round's feedback must ride into the next request as
 	// the current input: a single user-role text message, with no
-	// fabricated assistant tool_call in context.
-	if len(requests[1].Context) != 1 {
-		t.Fatalf("second round context length = %d, want 1", len(requests[1].Context))
+	// fabricated assistant tool_call in context, and the system prompt
+	// still prepended. The whole channel (user turn only — feedback is
+	// never appended) becomes the context.
+	if len(requests[1].Context) != 2 {
+		t.Fatalf("second round context length = %d, want 2 (system + user)", len(requests[1].Context))
+	}
+	if requests[1].Context[0].Role != message.RoleSystem {
+		t.Fatalf("second round context[0] role = %q, want system prompt", requests[1].Context[0].Role)
 	}
 	if requests[1].Input.Role != inference.InputRoleUser {
 		t.Fatalf("second round input role = %q, want user", requests[1].Input.Role)
@@ -595,11 +758,11 @@ func TestInferenceGraph_UndefinedToolRecoveryLoop(t *testing.T) {
 	}
 
 	msgs := board.Channel(agent.MainChannel)
-	if len(msgs) != 3 {
-		t.Fatalf("channel length = %d, want 3 (user, feedback, final answer)", len(msgs))
+	if len(msgs) != 2 {
+		t.Fatalf("channel length = %d, want 2 (user, final answer; no feedback)", len(msgs))
 	}
-	if text, ok := msgs[2].Content.Parts[0].(message.TextPart); !ok || text.Text != "ok" {
-		t.Fatalf("final assistant message = %+v, want text %q", msgs[2], "ok")
+	if text, ok := msgs[1].Content.Parts[0].(message.TextPart); !ok || text.Text != "ok" {
+		t.Fatalf("final assistant message = %+v, want text %q", msgs[1], "ok")
 	}
 	if v, _ := board.GetVar("recover_pending"); v != false {
 		t.Fatalf("recover_pending = %v, want false after success round", v)
@@ -607,15 +770,18 @@ func TestInferenceGraph_UndefinedToolRecoveryLoop(t *testing.T) {
 	if v, _ := board.GetVar("recover_count"); v != 1 {
 		t.Fatalf("recover_count = %v, want 1 retained to run end", v)
 	}
+	if _, ok := board.GetVar("recover_feedback"); ok {
+		t.Fatalf("recover_feedback var still present, want deleted after success round")
+	}
 }
 
 // TestInferenceGraph_UndefinedToolRecoveryWithoutLoopRouteEnds documents
 // the routing contract: with a standard tool-pending graph (llm ends when
 // tool_pending is false) and no recover loop-back edge, a recovered round
-// terminates the run after appending the feedback — the model never gets
-// another round. Recovery therefore needs an explicit route back to the
-// inference node (or a graph whose tool loop already routes llm back
-// unconditionally).
+// terminates the run with the feedback stored on the board — the model
+// never gets another round. Recovery therefore needs an explicit route
+// back to the inference node (or a graph whose tool loop already routes
+// llm back unconditionally).
 func TestInferenceGraph_UndefinedToolRecoveryWithoutLoopRouteEnds(t *testing.T) {
 	fake := &inferencetest.GenerateFake{
 		Respond: func(inference.GenerateRequest) inference.GenerateResponse {
@@ -638,6 +804,7 @@ func TestInferenceGraph_UndefinedToolRecoveryWithoutLoopRouteEnds(t *testing.T) 
 				UndefinedToolRecovery: &UndefinedToolRecoveryConfig{Enabled: true, MaxPerRun: 2},
 				RecoverPendingKey:     "recover_pending",
 				RecoverCountKey:       "recover_count",
+				RecoverFeedbackKey:    "recover_feedback",
 			}),
 		}},
 		Edges: []graph.EdgeDefinition{
@@ -654,8 +821,11 @@ func TestInferenceGraph_UndefinedToolRecoveryWithoutLoopRouteEnds(t *testing.T) 
 	if requests := fake.Requests(); len(requests) != 1 {
 		t.Fatalf("llm rounds = %d, want 1 (run ends after the recovered round)", len(requests))
 	}
-	if msgs := board.Channel(agent.MainChannel); len(msgs) != 2 {
-		t.Fatalf("channel length = %d, want 2 (feedback appended, no final answer)", len(msgs))
+	if msgs := board.Channel(agent.MainChannel); len(msgs) != 1 {
+		t.Fatalf("channel length = %d, want 1 (feedback never enters the transcript)", len(msgs))
+	}
+	if feedback := board.GetVarString("recover_feedback"); !strings.Contains(feedback, "ghost") {
+		t.Fatalf("recover_feedback var = %q, want stored rejection text", feedback)
 	}
 }
 

--- a/core/inference/errors.go
+++ b/core/inference/errors.go
@@ -59,7 +59,7 @@ type Error struct {
 	// UndefinedToolCall is the first tool call rejected because its name
 	// was absent from the request's definitions. Populated only for
 	// UndefinedTool errors; a recovering caller uses it to reconstruct the
-	// call for in-conversation feedback.
+	// call for the stored recovery feedback.
 	UndefinedToolCall *message.ToolCall
 	cause             error
 }

--- a/docs/guides/graph.md
+++ b/docs/guides/graph.md
@@ -136,9 +136,10 @@ onto `tool_pending_key` and the graph routes onward.
 | `output_key`                             | board var receiving the full assistant `Message`                                                                  |
 | `usage_key`                              | board var receiving the call's `inference.Usage`                                                                  |
 | `tool_pending_key`                       | board var receiving `finish_reason == tool_calls` (the condition edges branch on)                                 |
-| `undefined_tool_recovery`                | `{enabled, max_per_run}`: convert an undefined-tool rejection into in-conversation feedback instead of failing the node; disabled by default |
+| `undefined_tool_recovery`                | `{enabled, max_per_run}`: convert an undefined-tool rejection into recoverable board feedback instead of failing the node; disabled by default |
 | `recover_pending_key`                    | board var receiving whether the round was recovered from an undefined-tool response (loop-back condition)             |
 | `recover_count_key`                      | board var receiving the per-run recovery counter (node hard-fails past `max_per_run`)                               |
+| `recover_feedback_key`                   | board var receiving the user-role feedback text for the recovered round; the recovered inference round consumes it as its current input; defaults to the reserved per-node `__recover_feedback.<node id>` var when unset |
 | `stream`                                 | open a `GenerateStream`; text/reasoning deltas stream incrementally, the board still gets one assembled message   |
 | `tools`                                  | named catalog tools the model may call this turn                                                                  |
 | `all_tools`                              | send the catalog's entire visible set; with `tools`, names are declared `RequiredByName` and must exist           |
@@ -183,27 +184,32 @@ Behavior:
 - A response whose tool calls name tools absent from the exposed definitions
   is rejected by the engine with a distinguishable `undefined_tool` error
   (not the generic `invalid_provider_response`). When
-  `undefined_tool_recovery` is enabled, the node replays the rejected call
-  as an assistant `tool_call` paired with a `tool` result telling the model
-  the tool is not exposed and to use `tool_search`, sets
-  `recover_pending_key` to true (`tool_pending_key` to false), and returns
-  success. The graph must route the recovered round back to inference: the
+  `undefined_tool_recovery` is enabled, the node stores a user-role
+  feedback text under `recover_feedback_key` (defaulting to the reserved
+  per-node `__recover_feedback.<node id>` var) — telling the model the
+  tool is not exposed and to use `tool_search` — sets `recover_pending_key` to true
+  (`tool_pending_key` to false), and returns success. The feedback is
+  deliberately never appended to the messages channel: the transcript stays
+  a pure user/assistant conversation, so UIs do not need to filter
+  engine-generated turns. On the recovered round the stored text becomes
+  the current input (user role) with the whole channel as context, so the
+  model sees the same sequence it would have seen from an appended
+  message. The graph must route the recovered round back to inference: the
   `recover_pending_key` marker is the explicit hook for an edge back into
   the tool loop (e.g. `llm -> compact` conditioned on
   `recover_pending == true`). With a standard tool-pending graph whose
   `llm -> __end__` edge fires when `tool_pending == false`, a recovered
-  round without a loop-back edge terminates the run right after appending
-  the feedback — the model never gets another round. A graph whose tool
+  round without a loop-back edge terminates the run with the feedback left
+  on the board — the model never gets another round. A graph whose tool
   loop already routes the inference node back unconditionally can omit the
-  marker, but the feedback tail must reach an inference node, never a tool
-  node: a tool node would execute the replayed call, and a miswired
-  recover edge can execute deferred-but-registered tools with real side
-  effects. Validate graph edges when enabling recovery. `max_per_run`
+  marker. Because the feedback is never a channel message, no tool node can
+  execute the rejected call by accident; a successful round clears
+  `recover_pending_key` and deletes the feedback var. `max_per_run`
   (default 2) bounds recoveries per graph run; past it the rejection fails
   the node as before, keeping strict deployments intact. One rejection
   discards the whole round's response — the other tool calls in the same
-  response are dropped, and only the offending call is replayed as
-  feedback. `tool_choice` `named`/`required` violations are never
+  response are dropped, and only the offending call is described in the
+  stored feedback. `tool_choice` `named`/`required` violations are never
   recovered.
 - Usage is reported to the host on every call. In stream mode a mid-stream
   failure commits the buffered partial text to the board and reports the

--- a/docs/guides/tool.md
+++ b/docs/guides/tool.md
@@ -129,8 +129,9 @@ Go duration (calls that already carry a deadline pass through);
 A model that calls a deferred tool before `tool_search` has exposed it is
 rejected at response validation with a distinguishable `undefined_tool`
 error rather than the generic `invalid_provider_response`. The inference
-node's `undefined_tool_recovery` config turns that rejection into
-in-conversation feedback that sends the model back to `tool_search`; see
-[graph.md](graph.md) for the recovery loop.
+node's `undefined_tool_recovery` config turns that rejection into board
+feedback that sends the model back to `tool_search` on the next round,
+without writing an engine-generated turn into the conversation transcript;
+see [graph.md](graph.md) for the recovery loop.
 
 See [runtime.md](runtime.md) for per-session dynamic catalogs.


### PR DESCRIPTION
Fixes #468

## What
`recoverUndefinedTool` no longer appends a user-role rejection to the messages channel. Undefined-tool recovery feedback is now carried on the board:

- new optional `recover_feedback_key` config; when unset it defaults to a reserved per-node `__recover_feedback.<node id>` var, so multiple recovery-enabled inference nodes never share a slot
- the recovered inference round consumes the stored text as its current input (user role) with the whole channel as context — the model sees the same sequence as before
- a successful round clears the pending marker and deletes the feedback var
- `undefined_tool_recovery` still requires `recover_pending_key` + `recover_count_key`; existing graphs keep working unchanged

## Why
UIs render the conversation transcript from the channel and had no way to distinguish the recovery rejection from a real user message (it appears as a right-aligned user bubble). The feedback must stay model-visible, so instead of tagging it, this change keeps engine-generated turns out of the user-visible transcript entirely.

## Verification
- `make ci`, `make lint`, `make release-check` — all green
- `make release-plan`: `core 0.1.34 -> 0.1.35 (patch)`, tag `core/v0.1.35`
- New tests: default per-node feedback slot, two-node isolation, feedback consumed as input and cleaned up after success

## Release
Changeset `.release/core-v0.1.35.json` added. Merging to `main` runs the Release modules workflow, which opens the changelog PR; once its CI passes, the workflow tags `core/v0.1.35` automatically.
