### PR TITLE
chore(deps): bump core to v0.2.0 in drivers and backends

### DIFF
--- a/backends/checkpoint/go.mod
+++ b/backends/checkpoint/go.mod
@@ -3,7 +3,7 @@ module github.com/GizClaw/flowcraft/backends/checkpoint
 go 1.26.0
 
 require (
-	github.com/GizClaw/flowcraft/core v0.1.33
+	github.com/GizClaw/flowcraft/core v0.2.0
 	modernc.org/sqlite v1.56.0
 )
 

--- a/backends/checkpoint/go.sum
+++ b/backends/checkpoint/go.sum
@@ -1,5 +1,5 @@
-github.com/GizClaw/flowcraft/core v0.1.33 h1:dQrsEe0TvwVguuLOCs6PbizAKItAEosd+7lp1UHTvvI=
-github.com/GizClaw/flowcraft/core v0.1.33/go.mod h1:2EZ+ZFBICJse3GS48m7S+IpXy2s8j/xEy/O7dN5VB+U=
+github.com/GizClaw/flowcraft/core v0.2.0 h1:t2W4W4LtMT7SH4ZPyzTv3Tosu3fP6afxu/d4J8rI8rA=
+github.com/GizClaw/flowcraft/core v0.2.0/go.mod h1:2EZ+ZFBICJse3GS48m7S+IpXy2s8j/xEy/O7dN5VB+U=
 github.com/cenkalti/backoff/v5 v5.0.3 h1:ZN+IMa753KfX5hd8vVaMixjnqRZ3y8CuJKRKj1xcsSM=
 github.com/cenkalti/backoff/v5 v5.0.3/go.mod h1:rkhZdG3JZukswDf7f0cwqPNk4K0sa+F97BxZthm/crw=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=

--- a/backends/plugin/go.mod
+++ b/backends/plugin/go.mod
@@ -3,7 +3,7 @@ module github.com/GizClaw/flowcraft/backends/plugin
 go 1.26.0
 
 require (
-	github.com/GizClaw/flowcraft/core v0.1.33
+	github.com/GizClaw/flowcraft/core v0.2.0
 	golang.org/x/mod v0.35.0
 )
 

--- a/backends/plugin/go.sum
+++ b/backends/plugin/go.sum
@@ -1,5 +1,5 @@
-github.com/GizClaw/flowcraft/core v0.1.33 h1:dQrsEe0TvwVguuLOCs6PbizAKItAEosd+7lp1UHTvvI=
-github.com/GizClaw/flowcraft/core v0.1.33/go.mod h1:2EZ+ZFBICJse3GS48m7S+IpXy2s8j/xEy/O7dN5VB+U=
+github.com/GizClaw/flowcraft/core v0.2.0 h1:t2W4W4LtMT7SH4ZPyzTv3Tosu3fP6afxu/d4J8rI8rA=
+github.com/GizClaw/flowcraft/core v0.2.0/go.mod h1:2EZ+ZFBICJse3GS48m7S+IpXy2s8j/xEy/O7dN5VB+U=
 github.com/cenkalti/backoff/v5 v5.0.3 h1:ZN+IMa753KfX5hd8vVaMixjnqRZ3y8CuJKRKj1xcsSM=
 github.com/cenkalti/backoff/v5 v5.0.3/go.mod h1:rkhZdG3JZukswDf7f0cwqPNk4K0sa+F97BxZthm/crw=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=

--- a/driver/anthropic/go.mod
+++ b/driver/anthropic/go.mod
@@ -3,7 +3,7 @@ module github.com/GizClaw/flowcraft/driver/anthropic
 go 1.25.0
 
 require (
-	github.com/GizClaw/flowcraft/core v0.1.34
+	github.com/GizClaw/flowcraft/core v0.2.0
 	github.com/anthropics/anthropic-sdk-go v1.61.0
 	go.opentelemetry.io/otel/log v0.19.0
 )

--- a/driver/anthropic/go.sum
+++ b/driver/anthropic/go.sum
@@ -1,5 +1,5 @@
-github.com/GizClaw/flowcraft/core v0.1.34 h1:nziR9vsMNd6+eVEmabHS7f8+qZBIumpmPgh50k/U/Sw=
-github.com/GizClaw/flowcraft/core v0.1.34/go.mod h1:2EZ+ZFBICJse3GS48m7S+IpXy2s8j/xEy/O7dN5VB+U=
+github.com/GizClaw/flowcraft/core v0.2.0 h1:t2W4W4LtMT7SH4ZPyzTv3Tosu3fP6afxu/d4J8rI8rA=
+github.com/GizClaw/flowcraft/core v0.2.0/go.mod h1:2EZ+ZFBICJse3GS48m7S+IpXy2s8j/xEy/O7dN5VB+U=
 github.com/anthropics/anthropic-sdk-go v1.61.0 h1:JRTnm1tPqn5xo1xd1zfrcFDlcoWXVMvV1K68YmhpZKw=
 github.com/anthropics/anthropic-sdk-go v1.61.0/go.mod h1:3EfIfmFqxH6rbiLcIP4tPFyXL/IHakx2wDG4OU+TIEI=
 github.com/bahlo/generic-list-go v0.2.0 h1:5sz/EEAK+ls5wF+NeqDpk5+iNdMDXrh3z3nPnH1Wvgk=

--- a/driver/azure/go.mod
+++ b/driver/azure/go.mod
@@ -3,7 +3,7 @@ module github.com/GizClaw/flowcraft/driver/azure
 go 1.25.0
 
 require (
-	github.com/GizClaw/flowcraft/core v0.1.34
+	github.com/GizClaw/flowcraft/core v0.2.0
 	github.com/openai/openai-go/v3 v3.50.0
 	go.opentelemetry.io/otel/log v0.19.0
 )

--- a/driver/azure/go.sum
+++ b/driver/azure/go.sum
@@ -6,8 +6,8 @@ github.com/Azure/azure-sdk-for-go/sdk/internal v1.12.0 h1:fhqpLE3UEXi9lPaBRpQ6Xu
 github.com/Azure/azure-sdk-for-go/sdk/internal v1.12.0/go.mod h1:7dCRMLwisfRH3dBupKeNCioWYUZ4SS09Z14H+7i8ZoY=
 github.com/AzureAD/microsoft-authentication-library-for-go v1.7.2 h1:RHK7bS+HQMslb1sZpAokUt+zTVmue0hKSs2C791hhzU=
 github.com/AzureAD/microsoft-authentication-library-for-go v1.7.2/go.mod h1:HKpQxkWaGLJ+D/5H8QRpyQXA1eKjxkFlOMwck5+33Jk=
-github.com/GizClaw/flowcraft/core v0.1.34 h1:nziR9vsMNd6+eVEmabHS7f8+qZBIumpmPgh50k/U/Sw=
-github.com/GizClaw/flowcraft/core v0.1.34/go.mod h1:2EZ+ZFBICJse3GS48m7S+IpXy2s8j/xEy/O7dN5VB+U=
+github.com/GizClaw/flowcraft/core v0.2.0 h1:t2W4W4LtMT7SH4ZPyzTv3Tosu3fP6afxu/d4J8rI8rA=
+github.com/GizClaw/flowcraft/core v0.2.0/go.mod h1:2EZ+ZFBICJse3GS48m7S+IpXy2s8j/xEy/O7dN5VB+U=
 github.com/cenkalti/backoff/v5 v5.0.3 h1:ZN+IMa753KfX5hd8vVaMixjnqRZ3y8CuJKRKj1xcsSM=
 github.com/cenkalti/backoff/v5 v5.0.3/go.mod h1:rkhZdG3JZukswDf7f0cwqPNk4K0sa+F97BxZthm/crw=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=

--- a/driver/bytedance/go.mod
+++ b/driver/bytedance/go.mod
@@ -3,7 +3,7 @@ module github.com/GizClaw/flowcraft/driver/bytedance
 go 1.25.0
 
 require (
-	github.com/GizClaw/flowcraft/core v0.1.34
+	github.com/GizClaw/flowcraft/core v0.2.0
 	github.com/volcengine/volcengine-go-sdk v1.2.48
 	go.opentelemetry.io/otel/log v0.19.0
 )

--- a/driver/bytedance/go.sum
+++ b/driver/bytedance/go.sum
@@ -1,7 +1,7 @@
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
-github.com/GizClaw/flowcraft/core v0.1.34 h1:nziR9vsMNd6+eVEmabHS7f8+qZBIumpmPgh50k/U/Sw=
-github.com/GizClaw/flowcraft/core v0.1.34/go.mod h1:2EZ+ZFBICJse3GS48m7S+IpXy2s8j/xEy/O7dN5VB+U=
+github.com/GizClaw/flowcraft/core v0.2.0 h1:t2W4W4LtMT7SH4ZPyzTv3Tosu3fP6afxu/d4J8rI8rA=
+github.com/GizClaw/flowcraft/core v0.2.0/go.mod h1:2EZ+ZFBICJse3GS48m7S+IpXy2s8j/xEy/O7dN5VB+U=
 github.com/avast/retry-go v3.0.0+incompatible/go.mod h1:XtSnn+n/sHqQIpZ10K1qAevBhOOCWBLXXy3hyiqqBrY=
 github.com/cenkalti/backoff/v5 v5.0.3 h1:ZN+IMa753KfX5hd8vVaMixjnqRZ3y8CuJKRKj1xcsSM=
 github.com/cenkalti/backoff/v5 v5.0.3/go.mod h1:rkhZdG3JZukswDf7f0cwqPNk4K0sa+F97BxZthm/crw=

--- a/driver/deepseek/go.mod
+++ b/driver/deepseek/go.mod
@@ -3,7 +3,7 @@ module github.com/GizClaw/flowcraft/driver/deepseek
 go 1.25.0
 
 require (
-	github.com/GizClaw/flowcraft/core v0.1.34
+	github.com/GizClaw/flowcraft/core v0.2.0
 	github.com/openai/openai-go/v3 v3.50.0
 	go.opentelemetry.io/otel/log v0.19.0
 )

--- a/driver/deepseek/go.sum
+++ b/driver/deepseek/go.sum
@@ -1,5 +1,5 @@
-github.com/GizClaw/flowcraft/core v0.1.34 h1:nziR9vsMNd6+eVEmabHS7f8+qZBIumpmPgh50k/U/Sw=
-github.com/GizClaw/flowcraft/core v0.1.34/go.mod h1:2EZ+ZFBICJse3GS48m7S+IpXy2s8j/xEy/O7dN5VB+U=
+github.com/GizClaw/flowcraft/core v0.2.0 h1:t2W4W4LtMT7SH4ZPyzTv3Tosu3fP6afxu/d4J8rI8rA=
+github.com/GizClaw/flowcraft/core v0.2.0/go.mod h1:2EZ+ZFBICJse3GS48m7S+IpXy2s8j/xEy/O7dN5VB+U=
 github.com/cenkalti/backoff/v5 v5.0.3 h1:ZN+IMa753KfX5hd8vVaMixjnqRZ3y8CuJKRKj1xcsSM=
 github.com/cenkalti/backoff/v5 v5.0.3/go.mod h1:rkhZdG3JZukswDf7f0cwqPNk4K0sa+F97BxZthm/crw=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=

--- a/driver/kimi/go.mod
+++ b/driver/kimi/go.mod
@@ -3,7 +3,7 @@ module github.com/GizClaw/flowcraft/driver/kimi
 go 1.25.0
 
 require (
-	github.com/GizClaw/flowcraft/core v0.1.34
+	github.com/GizClaw/flowcraft/core v0.2.0
 	go.opentelemetry.io/otel/log v0.19.0
 )
 

--- a/driver/kimi/go.sum
+++ b/driver/kimi/go.sum
@@ -1,5 +1,5 @@
-github.com/GizClaw/flowcraft/core v0.1.34 h1:nziR9vsMNd6+eVEmabHS7f8+qZBIumpmPgh50k/U/Sw=
-github.com/GizClaw/flowcraft/core v0.1.34/go.mod h1:2EZ+ZFBICJse3GS48m7S+IpXy2s8j/xEy/O7dN5VB+U=
+github.com/GizClaw/flowcraft/core v0.2.0 h1:t2W4W4LtMT7SH4ZPyzTv3Tosu3fP6afxu/d4J8rI8rA=
+github.com/GizClaw/flowcraft/core v0.2.0/go.mod h1:2EZ+ZFBICJse3GS48m7S+IpXy2s8j/xEy/O7dN5VB+U=
 github.com/cenkalti/backoff/v5 v5.0.3 h1:ZN+IMa753KfX5hd8vVaMixjnqRZ3y8CuJKRKj1xcsSM=
 github.com/cenkalti/backoff/v5 v5.0.3/go.mod h1:rkhZdG3JZukswDf7f0cwqPNk4K0sa+F97BxZthm/crw=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=

--- a/driver/minimax/go.mod
+++ b/driver/minimax/go.mod
@@ -3,7 +3,7 @@ module github.com/GizClaw/flowcraft/driver/minimax
 go 1.25.0
 
 require (
-	github.com/GizClaw/flowcraft/core v0.1.34
+	github.com/GizClaw/flowcraft/core v0.2.0
 	github.com/anthropics/anthropic-sdk-go v1.61.0
 	go.opentelemetry.io/otel/log v0.19.0
 )

--- a/driver/minimax/go.sum
+++ b/driver/minimax/go.sum
@@ -1,5 +1,5 @@
-github.com/GizClaw/flowcraft/core v0.1.34 h1:nziR9vsMNd6+eVEmabHS7f8+qZBIumpmPgh50k/U/Sw=
-github.com/GizClaw/flowcraft/core v0.1.34/go.mod h1:2EZ+ZFBICJse3GS48m7S+IpXy2s8j/xEy/O7dN5VB+U=
+github.com/GizClaw/flowcraft/core v0.2.0 h1:t2W4W4LtMT7SH4ZPyzTv3Tosu3fP6afxu/d4J8rI8rA=
+github.com/GizClaw/flowcraft/core v0.2.0/go.mod h1:2EZ+ZFBICJse3GS48m7S+IpXy2s8j/xEy/O7dN5VB+U=
 github.com/anthropics/anthropic-sdk-go v1.61.0 h1:JRTnm1tPqn5xo1xd1zfrcFDlcoWXVMvV1K68YmhpZKw=
 github.com/anthropics/anthropic-sdk-go v1.61.0/go.mod h1:3EfIfmFqxH6rbiLcIP4tPFyXL/IHakx2wDG4OU+TIEI=
 github.com/bahlo/generic-list-go v0.2.0 h1:5sz/EEAK+ls5wF+NeqDpk5+iNdMDXrh3z3nPnH1Wvgk=

--- a/driver/openai/go.mod
+++ b/driver/openai/go.mod
@@ -3,7 +3,7 @@ module github.com/GizClaw/flowcraft/driver/openai
 go 1.25.0
 
 require (
-	github.com/GizClaw/flowcraft/core v0.1.34
+	github.com/GizClaw/flowcraft/core v0.2.0
 	github.com/openai/openai-go/v3 v3.50.0
 	go.opentelemetry.io/otel/log v0.19.0
 )

--- a/driver/openai/go.sum
+++ b/driver/openai/go.sum
@@ -1,5 +1,5 @@
-github.com/GizClaw/flowcraft/core v0.1.34 h1:nziR9vsMNd6+eVEmabHS7f8+qZBIumpmPgh50k/U/Sw=
-github.com/GizClaw/flowcraft/core v0.1.34/go.mod h1:2EZ+ZFBICJse3GS48m7S+IpXy2s8j/xEy/O7dN5VB+U=
+github.com/GizClaw/flowcraft/core v0.2.0 h1:t2W4W4LtMT7SH4ZPyzTv3Tosu3fP6afxu/d4J8rI8rA=
+github.com/GizClaw/flowcraft/core v0.2.0/go.mod h1:2EZ+ZFBICJse3GS48m7S+IpXy2s8j/xEy/O7dN5VB+U=
 github.com/cenkalti/backoff/v5 v5.0.3 h1:ZN+IMa753KfX5hd8vVaMixjnqRZ3y8CuJKRKj1xcsSM=
 github.com/cenkalti/backoff/v5 v5.0.3/go.mod h1:rkhZdG3JZukswDf7f0cwqPNk4K0sa+F97BxZthm/crw=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=

--- a/driver/qwen/go.mod
+++ b/driver/qwen/go.mod
@@ -3,7 +3,7 @@ module github.com/GizClaw/flowcraft/driver/qwen
 go 1.25.0
 
 require (
-	github.com/GizClaw/flowcraft/core v0.1.34
+	github.com/GizClaw/flowcraft/core v0.2.0
 	go.opentelemetry.io/otel/log v0.19.0
 )
 

--- a/driver/qwen/go.sum
+++ b/driver/qwen/go.sum
@@ -1,5 +1,5 @@
-github.com/GizClaw/flowcraft/core v0.1.34 h1:nziR9vsMNd6+eVEmabHS7f8+qZBIumpmPgh50k/U/Sw=
-github.com/GizClaw/flowcraft/core v0.1.34/go.mod h1:2EZ+ZFBICJse3GS48m7S+IpXy2s8j/xEy/O7dN5VB+U=
+github.com/GizClaw/flowcraft/core v0.2.0 h1:t2W4W4LtMT7SH4ZPyzTv3Tosu3fP6afxu/d4J8rI8rA=
+github.com/GizClaw/flowcraft/core v0.2.0/go.mod h1:2EZ+ZFBICJse3GS48m7S+IpXy2s8j/xEy/O7dN5VB+U=
 github.com/cenkalti/backoff/v5 v5.0.3 h1:ZN+IMa753KfX5hd8vVaMixjnqRZ3y8CuJKRKj1xcsSM=
 github.com/cenkalti/backoff/v5 v5.0.3/go.mod h1:rkhZdG3JZukswDf7f0cwqPNk4K0sa+F97BxZthm/crw=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=


### PR DESCRIPTION
## What
Bumps `github.com/GizClaw/flowcraft/core` to v0.2.0 in the eight driver modules and the checkpoint/plugin backends. The modules on `main` already use the new core APIs (typed lazy secrets, ctx-first settings decode, no factory-local expansion), so their go.mod pins must match the released core for standalone (`GOWORK=off`) builds to resolve.

## Verification
- `GOWORK=off go build ./...` green for all ten modules
- `make ci`, `make lint`, `make release-check` green (no pending releases)

## Release
Per repo convention only core ships `.release` changesets. After merge, the maintainers tag: `driver/*/v0.2.0` (8 drivers, minor — `ProfileSettings.Secrets` became `map[string]resource.Secret`) and `backends/*/v0.1.2` (2 backends, patch). `examples/forge` pins are bumped in a follow-up once the new tags exist.
