### PR TITLE
docs(skills): update flowcraft-config skill for core v0.2.0

### DIFF
--- a/skills/flowcraft-config/SKILL.md
+++ b/skills/flowcraft-config/SKILL.md
@@ -27,8 +27,11 @@ the L2 structural validator and fix errors against the reference cards.
    app-registered — omit implementation examples; `core/memory` contracts
    and hooks are fine to use.
 4. **Write graph JSON.** Read [references/graph.md](references/graph.md).
-   Model refs must use the nested `id` form; script nodes need `runtime`
-   and `source`; wire edges back to the inference node after tool nodes.
+   Prefer routing: wire the `inference.Router` into the graph engine and
+   omit `model` in inference nodes; pin `model` only when no router is
+   wired. Model refs must use the nested `id` form; script nodes need
+   `runtime` and `source`; wire edges back to the inference node after
+   tool nodes.
 5. **Validate structurally with L2.** Run
    `skills/flowcraft-config/scripts/validate-config.sh <deployment-file>`
    (or the installed copy's script). The validator pins the FlowCraft

--- a/skills/flowcraft-config/references/deploy.md
+++ b/skills/flowcraft-config/references/deploy.md
@@ -87,3 +87,43 @@ resource envelope, and only the host build can construct these factories.
 
 Engine dependencies must match the graph engine's declared dep names:
 `inference`, `router`, `tools`, `workspace`, `sandbox`, `script_runtime`.
+
+### Inference routing
+
+Declare an `inference.Router` over the assembly and wire it into the graph
+engine so inference nodes can omit `model`:
+
+```yaml
+resources:
+  infer:
+    kind: inference.Assembly
+    impl: unified
+    deps: {provider: provider}
+  router:
+    kind: inference.Router
+    impl: unified
+    deps: {target: infer}
+    settings:
+      generate:
+        - tier: fast
+          targets:
+            - model: {id: {provider: deepseek, name: deepseek-v4-flash}}
+              score: {speed: 0.9}
+        - tier: capable
+          targets:
+            - model: {id: {provider: openai, name: gpt-5.2}}
+              score: {quality: 0.95}
+
+agents:
+  assistant:
+    card: {name: Assistant}
+    engine:
+      kind: agent.Engine
+      impl: graph
+      deps: {inference: infer, router: router}
+```
+
+Prefer routing for production deployments: the router selects per request,
+filters by declared capabilities, and applies tier fallback, retry, and
+circuit-breaker policy. Pin `model` in inference nodes only when the router
+is not wired (tests, single-target demos).

--- a/skills/flowcraft-config/references/graph.md
+++ b/skills/flowcraft-config/references/graph.md
@@ -76,18 +76,27 @@ appended to the same channel. The node never executes tool calls — a
 
 | Config field | Meaning |
 | --- | --- |
-| `model` | explicit target `{id: {provider, name}, profile?}`; absent defers to the wired router |
-| `model_hint` | per-call router preference: `provider/name` or a bare name (e.g. `${board.model}`); ignored when `model` is set |
+| `model` | explicit target `{id: {provider, name}, profile?}`; omit in favor of the wired router — pin only for tests or single-target demos |
+| `model_hint` | per-call router preference: `provider/name` or a bare name (e.g. `${board:model}`); ignored when `model` is set |
 | `messages_channel` | board channel holding the conversation; empty means the main channel (`__main_channel`) |
 | `system_prompt` | prepended system message when the context does not start with one (may be `{file: ...}` / `{embed: ...}`) |
 | `output_key` / `usage_key` / `tool_pending_key` | board vars receiving the message / usage / tool-pending flag |
-| `undefined_tool_recovery` | `{enabled, max_per_run}`: replay undefined-tool rejections as in-conversation feedback; disabled by default |
-| `recover_pending_key` / `recover_count_key` | board vars receiving the recovery marker / per-run recovery counter |
+| `undefined_tool_recovery` | `{enabled, max_per_run}`: store undefined-tool rejections as board feedback (never in the transcript); disabled by default |
+| `recover_pending_key` / `recover_count_key` / `recover_feedback_key` | board vars receiving the recovery marker / per-run counter / feedback text (feedback defaults to `__recover_feedback.<node id>`) |
 | `stream` | stream deltas incrementally; the board still gets one assembled message |
 | `tools` / `all_tools` | named catalog tools, or the catalog's entire visible set |
 | `tool_choice` | constrain when/which tools are called |
 | `intent` | canonical execution envelope `{text, image, audio, video}` with per-modality controls (see below) |
 | `extensions` | provider knobs `{provider, id, fields}` |
+
+**Model selection: prefer the router.** Inference nodes should omit
+`model` and rely on the wired `inference.Router`: the router's policy
+(tiers of `{model, score}` targets plus retry / circuit-breaker) selects
+per request, filters targets by their declared capabilities, and falls back
+across tiers. Hardcoding `model` pins the node to one provider/model and
+bypasses routing — keep it only for tests or single-target deployments.
+Use `model_hint` (e.g. `${board:model}` from user input) for per-call
+preferences against the router.
 
 `intent` is authoritative and covers every generation modality: text
 controls (`response`, `max_output_tokens`, `tools`, `tool_choice`,
@@ -106,11 +115,13 @@ strict decode rejects them; put them under `intent.text` instead.
 never bypasses routing and falls back to the default policy when the hint
 is unknown, malformed, or ambiguous. A response naming tools absent from
 the exposed definitions fails with a distinguishable `undefined_tool`
-error; with `undefined_tool_recovery` enabled the node replays the
-rejection as feedback (assistant `tool_call` paired with a `tool` result),
-sets `recover_pending_key` (clearing `tool_pending_key`), and returns
-success. The graph must route the recovered round back to inference —
-never to a tool node, which would execute the replayed call.
+error; with `undefined_tool_recovery` enabled the node stores a user-role
+feedback text under `recover_feedback_key` (defaulting to the reserved
+per-node `__recover_feedback.<node id>` var), sets `recover_pending_key`
+(clearing `tool_pending_key`), and returns success. The feedback never
+enters the messages channel; the recovered round consumes the stored text
+as its current input. The graph must route the recovered round back to
+inference — never to a tool node, which would execute the rejected call.
 `max_per_run` defaults to 2; past it the rejection fails the node.
 
 ### `tool` — batch tool execution
@@ -220,7 +231,7 @@ agents:
   "name": "greeter",
   "entry": "hello",
   "nodes": [
-    {"id": "hello", "type": "greet", "config": {"name": "${board.user}"}}
+    {"id": "hello", "type": "greet", "config": {"name": "${board:user}"}}
   ],
   "edges": []
 }

--- a/skills/flowcraft-config/references/pitfalls.md
+++ b/skills/flowcraft-config/references/pitfalls.md
@@ -10,7 +10,9 @@ builds the deployment with its own factory registry, or at runtime.
    `agent.deps` — **validator** (unknown field).
 2. `runtime.event_bus` is required when `runtime` exists — **validator**.
 3. `sessions.resume: true` requires `checkpoint_store` — **validator**.
-4. Graph model refs must use `model: {id: {provider, name}}` — host build.
+4. Graph model refs must use `model: {id: {provider, name}}`; prefer
+   omitting `model` and wiring the `inference.Router` so selection runs
+   per request — host build.
 5. Script nodes need `runtime` and `source`; `runtime` must match the bound
    script runtime — host build.
 6. Resource settings file/embed refs must be the whole settings subtree —
@@ -40,6 +42,11 @@ builds the deployment with its own factory registry, or at runtime.
 14. `UnregisterAgent` waits for active turns; a stuck engine times out
     (`WithRemoveTimeout` / ctx deadline) and the agent is left registered
     — retry, don't assume removal happened — runtime API.
+15. Hardcoding `model` in inference nodes bypasses the router: no tier
+    fallback, capability filtering, retry, or circuit-breaker policy
+    applies. Wire `inference.Router` into the graph engine and omit
+    `model` unless the deployment intentionally pins a target — host
+    build/runtime.
 
 ## Error map
 

--- a/skills/flowcraft-config/references/resources.md
+++ b/skills/flowcraft-config/references/resources.md
@@ -27,9 +27,12 @@ profiles:
 ```
 
 Provider IDs and profile IDs must be identifiers. Secret values use the
-settings expansion syntax (`${env:NAME}` for an environment variable,
-`${base:rel}` / `~` / `${home:rel}` for paths); a missing variable fails
-the build. Model capabilities mirror the built-in catalog shape and are
+unified settings reference syntax (`${env:NAME}` for an environment
+variable, `${base:rel}` / `~` / `${home:rel}` for paths, `${secret:NAME}`
+or `${secret:store.NAME}` for declared `secret.Store` backends); a missing
+variable fails the build. The deploy builder expands every settings
+subtree with env/home/base enabled by default — literal `${` must be
+escaped as `\${...}`. Model capabilities mirror the built-in catalog shape and are
 validated by the driver; routing prefers targets whose declared outputs
 cover the request intent and skips declared-incompatible tiers. Provider
 drivers are registered by the host application from provider driver

--- a/skills/flowcraft-config/scripts/validator/go.mod
+++ b/skills/flowcraft-config/scripts/validator/go.mod
@@ -2,7 +2,7 @@ module github.com/GizClaw/flowcraft/skills/flowcraft-config/scripts/validator
 
 go 1.26.0
 
-require github.com/GizClaw/flowcraft/core v0.1.33
+require github.com/GizClaw/flowcraft/core v0.2.0
 
 require (
 	github.com/cenkalti/backoff/v5 v5.0.3 // indirect

--- a/skills/flowcraft-config/scripts/validator/go.sum
+++ b/skills/flowcraft-config/scripts/validator/go.sum
@@ -1,5 +1,5 @@
-github.com/GizClaw/flowcraft/core v0.1.33 h1:dQrsEe0TvwVguuLOCs6PbizAKItAEosd+7lp1UHTvvI=
-github.com/GizClaw/flowcraft/core v0.1.33/go.mod h1:2EZ+ZFBICJse3GS48m7S+IpXy2s8j/xEy/O7dN5VB+U=
+github.com/GizClaw/flowcraft/core v0.2.0 h1:t2W4W4LtMT7SH4ZPyzTv3Tosu3fP6afxu/d4J8rI8rA=
+github.com/GizClaw/flowcraft/core v0.2.0/go.mod h1:2EZ+ZFBICJse3GS48m7S+IpXy2s8j/xEy/O7dN5VB+U=
 github.com/cenkalti/backoff/v5 v5.0.3 h1:ZN+IMa753KfX5hd8vVaMixjnqRZ3y8CuJKRKj1xcsSM=
 github.com/cenkalti/backoff/v5 v5.0.3/go.mod h1:rkhZdG3JZukswDf7f0cwqPNk4K0sa+F97BxZthm/crw=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=

--- a/skills/flowcraft-config/scripts/validator/main.go
+++ b/skills/flowcraft-config/scripts/validator/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"encoding/json"
 	"flag"
 	"fmt"
@@ -75,7 +76,7 @@ func validateDeploy(data []byte) error {
 		return err
 	}
 	if doc.Runtime != nil {
-		if _, err := runtime.DecodeConfig(doc); err != nil {
+		if _, err := runtime.DecodeConfig(context.Background(), doc); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
Updates the in-repo `skills/flowcraft-config` skill to match core v0.2.0:

- **Validator**: use the ctx-first `runtime.DecodeConfig(context.Background(), doc)` signature and bump the validator module's core dependency to v0.2.0 (compile fix).
- **Board syntax**: migrate remaining `${board.xxx}` references to the unified `${board:xxx}` grammar.
- **Undefined-tool recovery**: refresh stale docs (board feedback via `recover_feedback_key`, never in the transcript) that still described the old in-conversation replay.
- **Router guidance**: guide config authors to prefer the `inference.Router` (omit `model` in inference nodes; pin only for tests/single-target demos), with a full wiring example in deploy.md and a new pitfall entry.

Note: the same fixes were already applied to the installed copies at `~/.codex/skills` and `~/.agents/skills`; this PR brings the tracked project source in sync. Verified: validator builds against core v0.2.0 and passes the forge werewolf deploy document.