### PR TITLE
fix(core): roll back failed turn text on undefined-tool recovery

### DIFF
--- a/core/agent/board.go
+++ b/core/agent/board.go
@@ -225,6 +225,22 @@ func (b *Board) AppendChannelMessage(name string, msg message.Message) {
 	b.mu.Unlock()
 }
 
+// PopChannelMessage removes and returns the last message on a channel.
+// The boolean reports whether a message was removed; an empty or missing
+// channel yields the zero Message and false. The returned message is the
+// channel's stored copy and must not be mutated.
+func (b *Board) PopChannelMessage(name string) (message.Message, bool) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	msgs := b.channels[name]
+	if len(msgs) == 0 {
+		return message.Message{}, false
+	}
+	last := msgs[len(msgs)-1]
+	b.channels[name] = msgs[:len(msgs)-1]
+	return last, true
+}
+
 // ChannelsCopy returns a deep copy of all channel message lists. Used
 // by parallel branch execution to give each branch an independent
 // view that can later be merged.

--- a/core/agent/board_test.go
+++ b/core/agent/board_test.go
@@ -40,6 +40,24 @@ func TestBoard_AppendChannelMessage(t *testing.T) {
 	}
 }
 
+func TestBoard_PopChannelMessage(t *testing.T) {
+	b := agent.NewBoard()
+	b.AppendChannelMessage(agent.MainChannel, message.NewTextMessage(message.RoleUser, "first"))
+	b.AppendChannelMessage(agent.MainChannel, message.NewTextMessage(message.RoleUser, "second"))
+
+	popped, ok := b.PopChannelMessage(agent.MainChannel)
+	if !ok || popped.Content.Text() != "second" {
+		t.Fatalf("Pop = (%q, %v), want second/true", popped.Content.Text(), ok)
+	}
+	got := b.Channel(agent.MainChannel)
+	if len(got) != 1 || got[0].Content.Text() != "first" {
+		t.Fatalf("Channel = %+v, want [first]", got)
+	}
+	if _, ok := b.PopChannelMessage("missing"); ok {
+		t.Fatalf("Pop on missing channel must report false")
+	}
+}
+
 func TestBoard_SetChannel_DefensiveCopy(t *testing.T) {
 	b := agent.NewBoard()
 	in := []message.Message{

--- a/core/graph/nodes/inference.go
+++ b/core/graph/nodes/inference.go
@@ -211,7 +211,7 @@ func runInference(ec graph.ExecutionContext, board *agent.Board, cfg InferenceCo
 
 	resp, err := executeGenerate(ec, board, cfg, deps, req)
 	if err != nil {
-		return recoverUndefinedTool(ec, board, cfg, err)
+		return recoverUndefinedTool(ec, board, channel, cfg, err)
 	}
 	if cfg.RecoverPendingKey != "" {
 		// A successful round clears the recovery marker so the loop
@@ -303,7 +303,7 @@ func runInference(ec graph.ExecutionContext, board *agent.Board, cfg InferenceCo
 // call would be executed for real. The original error is returned when
 // recovery is disabled, the failure is not an undefined-tool rejection,
 // or the per-run budget is exhausted.
-func recoverUndefinedTool(ec graph.ExecutionContext, board *agent.Board, cfg InferenceConfig, err error) error {
+func recoverUndefinedTool(ec graph.ExecutionContext, board *agent.Board, channel string, cfg InferenceConfig, err error) error {
 	if cfg.UndefinedToolRecovery == nil || !cfg.UndefinedToolRecovery.Enabled {
 		return err
 	}
@@ -322,6 +322,18 @@ func recoverUndefinedTool(ec graph.ExecutionContext, board *agent.Board, cfg Inf
 		return err
 	}
 	call := *infErr.UndefinedToolCall
+
+	// The failed stream materialized its buffered text on the channel
+	// before the error propagated (see drainGenerateStream). The turn is
+	// being rolled back for a retry, so that rejected text must not stay
+	// in the transcript: the recovered round appends its own complete
+	// message right after it, leaving adjacent assistant messages that
+	// violate provider reasoning round-trip rules on the next request.
+	// Nothing is removed when the tail is not that text-only
+	// materialization (unary failures and streams that buffered no text
+	// never commit one).
+	rollbackFailedTurnText(board, channel)
+
 	board.SetVar(recoverFeedbackKey(ec, cfg), fmt.Sprintf(undefinedToolFeedback, call.Name))
 	if cfg.ToolPendingKey != "" {
 		board.SetVar(cfg.ToolPendingKey, false)
@@ -333,6 +345,27 @@ func recoverUndefinedTool(ec graph.ExecutionContext, board *agent.Board, cfg Inf
 		otellog.String("tool.name", call.Name),
 		otellog.Int("recovery.count", count+1))
 	return nil
+}
+
+// rollbackFailedTurnText removes the standalone text-only assistant
+// message a failed stream committed to the channel. It is a no-op when
+// the channel tail is not that exact materialization, so ordinary tails
+// (user, tool, tool result) are never touched.
+func rollbackFailedTurnText(board *agent.Board, channel string) {
+	msgs := board.Channel(channel)
+	if len(msgs) == 0 {
+		return
+	}
+	last := msgs[len(msgs)-1]
+	if last.Role != message.RoleAssistant {
+		return
+	}
+	for _, part := range last.Content.Parts {
+		if _, ok := part.(message.TextPart); !ok {
+			return
+		}
+	}
+	board.PopChannelMessage(channel)
 }
 
 // recoveryCount reads the per-run undefined-tool recovery counter.

--- a/core/graph/nodes/inference_test.go
+++ b/core/graph/nodes/inference_test.go
@@ -353,6 +353,95 @@ func TestInferenceNode_UndefinedToolRecovery(t *testing.T) {
 	}
 }
 
+// TestInferenceNode_UndefinedToolRecoveryStreamRollsBackPartial proves
+// that when a streamed generation is rejected for an undefined tool, the
+// recovery rolls back the text-only assistant message the failed stream
+// materialized on the channel. Without the rollback, the next round's
+// success appends a reasoning + tool-call assistant message right after
+// it, leaving adjacent assistant messages that violate provider
+// reasoning round-trip rules on the following request.
+func TestInferenceNode_UndefinedToolRecoveryStreamRollsBackPartial(t *testing.T) {
+	fake := &inferencetest.GenerateFake{
+		Events: []inference.GenerateStreamEvent{
+			{PartIndex: 0, Delta: inference.ReasoningDelta{Text: "think"}},
+			{PartIndex: 1, Delta: inference.TextPartDelta{Text: "partial"}},
+			{PartIndex: 2, Delta: inference.ToolCallDelta{ID: "call-1", Name: "ghost", ArgumentsFragment: `{}`}},
+			{FinishReason: inference.FinishToolCalls},
+		},
+	}
+	reg := inferenceRegistry(t, InferenceNodeDeps{
+		Assembly: fake.Assembly(t),
+		Catalog:  toolCatalog(t, stubTool{name: "known", desc: "a known tool"}),
+	})
+	g := singleNodeGraph(t, reg, "inference", InferenceConfig{
+		Model:                 ptr(inferencetest.DefaultFakeModel),
+		Tools:                 []string{"known"},
+		Stream:                true,
+		ToolPendingKey:        "tool_pending",
+		UndefinedToolRecovery: &UndefinedToolRecoveryConfig{Enabled: true, MaxPerRun: 2},
+		RecoverPendingKey:     "recover_pending",
+		RecoverCountKey:       "recover_count",
+		RecoverFeedbackKey:    "recover_feedback",
+	})
+	board := userBoard()
+	if err := executeGraph(t, g, agent.NoopHost{}, board); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+
+	// The failed stream's partial text was rolled back: the channel
+	// holds only the original user turn, not the rejected text.
+	msgs := board.Channel(agent.MainChannel)
+	if len(msgs) != 1 {
+		t.Fatalf("channel length = %d (%+v), want 1 (partial rolled back)", len(msgs), msgs)
+	}
+	feedback := board.GetVarString("recover_feedback")
+	if !strings.Contains(feedback, "ghost") || !strings.Contains(feedback, "tool_search") {
+		t.Fatalf("recover_feedback var = %q, want ghost + tool_search text", feedback)
+	}
+	if v, _ := board.GetVar("recover_pending"); v != true {
+		t.Fatalf("recover_pending = %v, want true", v)
+	}
+	if v, _ := board.GetVar("recover_count"); v != 1 {
+		t.Fatalf("recover_count = %v, want 1", v)
+	}
+}
+
+// TestInferenceNode_UndefinedToolRecoveryStreamNoTextKeepsTail proves
+// the rollback never touches the tail when the failed stream buffered no
+// text (nothing was committed to roll back).
+func TestInferenceNode_UndefinedToolRecoveryStreamNoTextKeepsTail(t *testing.T) {
+	fake := &inferencetest.GenerateFake{
+		Events: []inference.GenerateStreamEvent{
+			{PartIndex: 0, Delta: inference.ReasoningDelta{Text: "think"}},
+			{PartIndex: 1, Delta: inference.ToolCallDelta{ID: "call-1", Name: "ghost", ArgumentsFragment: `{}`}},
+			{FinishReason: inference.FinishToolCalls},
+		},
+	}
+	reg := inferenceRegistry(t, InferenceNodeDeps{
+		Assembly: fake.Assembly(t),
+		Catalog:  toolCatalog(t, stubTool{name: "known", desc: "a known tool"}),
+	})
+	g := singleNodeGraph(t, reg, "inference", InferenceConfig{
+		Model:                 ptr(inferencetest.DefaultFakeModel),
+		Tools:                 []string{"known"},
+		Stream:                true,
+		ToolPendingKey:        "tool_pending",
+		UndefinedToolRecovery: &UndefinedToolRecoveryConfig{Enabled: true, MaxPerRun: 2},
+		RecoverPendingKey:     "recover_pending",
+		RecoverCountKey:       "recover_count",
+		RecoverFeedbackKey:    "recover_feedback",
+	})
+	board := userBoard()
+	if err := executeGraph(t, g, agent.NoopHost{}, board); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+
+	msgs := board.Channel(agent.MainChannel)
+	if len(msgs) != 1 || msgs[0].Role != message.RoleUser {
+		t.Fatalf("channel = %+v, want [user] untouched", msgs)
+	}
+}
+
 func TestInferenceNode_UndefinedToolRecoveryDisabled(t *testing.T) {
 	fake := &inferencetest.GenerateFake{
 		Respond: func(inference.GenerateRequest) inference.GenerateResponse {


### PR DESCRIPTION
Fixes #477.

## Problem

A streamed generation rejected for an undefined tool (`undefined_tool`) materializes its buffered text as a standalone assistant message before the error propagates — the failure path in `drainGenerateStream` intentionally preserves progress. When recovery then retries the turn, the recovered round appends its own complete message (reasoning + text + tool call) right after that rejected text.

The channel therefore ends up with two adjacent assistant messages:

```
[user] [assistant: rejected text] [assistant: reasoning + tool_call] [tool output]
```

On the next round-trip the DeepSeek responses compiler emits `text → reasoning → function_call → function_call_output`, which the gateway rejects in thinking mode with `400 reasoning_text must be passed back`.

## Fix

Undefined-tool recovery already rolls the rejected turn back (feedback is kept out of the transcript, never replayed as a synthetic tool call). This change extends that rollback to the failed stream's side effect: when the channel tail is exactly the text-only partial the failed stream committed, it is popped before the feedback vars are set.

- `Board.PopChannelMessage` — atomic pop of the last channel message.
- `recoverUndefinedTool` — takes the resolved channel and calls `rollbackFailedTurnText` only when actually recovering (budget not exhausted).
- `rollbackFailedTurnText` — no-op unless the tail is an assistant message whose parts are all `TextPart` (the exact `MessageStream.Close` materialization). Unary failures and streams that buffered no text never commit one, so ordinary tails are untouched.

## Tests

- `TestBoard_PopChannelMessage`
- `TestInferenceNode_UndefinedToolRecoveryStreamRollsBackPartial` — streamed ghost tool call, asserts the partial is rolled back and recovery vars are set
- `TestInferenceNode_UndefinedToolRecoveryStreamNoTextKeepsTail` — no text buffered, tail untouched

Verified: `make ci`, `make lint`, `make release-check`, `git diff --check` all pass.