### PR TITLE
chore(release): add core v0.2.1 changeset

### DIFF
--- a/.release/core-v0.2.1.json
+++ b/.release/core-v0.2.1.json
@@ -1,0 +1,9 @@
+{
+  "summary": "fix(core): roll back the failed turn's partial text from the messages channel on undefined-tool recovery, so the recovered round cannot leave adjacent assistant messages that violate provider reasoning round-trip rules (DeepSeek thinking mode 400 'reasoning_text must be passed back'); adds Board.PopChannelMessage",
+  "releases": [
+    {
+      "module": "core",
+      "bump": "patch"
+    }
+  ]
+}


### PR DESCRIPTION
Adds the `.release/core-v0.2.1.json` changeset for the accumulated core delta since `core/v0.2.0`:

- `fix(core): roll back failed turn text on undefined-tool recovery (#478)` — rolled-back recovery removes the failed stream's partial assistant text from the channel, preventing adjacent assistant messages that break DeepSeek thinking-mode round-trips; adds `Board.PopChannelMessage`.

Plan: `core 0.2.0 → 0.2.1 (patch)`, tag `core/v0.2.1`.

After this merges to `main`, the Release modules workflow opens/refreshes the `automation/release-changelog` PR; merging that PR creates the tag.