### PR TITLE
feat(core): windows sandbox backend with net policy + CI lane

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -228,10 +228,40 @@ jobs:
         run: go test -tags=integration_bwrap -count=1 -timeout 180s ./bwrap/...
         working-directory: core/sandbox
 
+  test-core-windows:
+    name: Test core (windows)
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v6
+        with:
+          go-version: "1.26"
+      - name: Build
+        working-directory: core
+        run: go build ./...
+      - name: Vet
+        working-directory: core
+        run: go vet ./...
+      - name: Test
+        working-directory: core
+        run: go test -count=1 ./...
+
+  test-sandbox-windows:
+    name: Integration core/sandbox/windows
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v6
+        with:
+          go-version: "1.26"
+      - name: Test
+        working-directory: core/sandbox
+        run: go test -count=1 -timeout 180s ./windows/...
+
   ci-pass:
     name: CI
     if: always()
-    needs: [release-intent, gofmt, compute-matrix, lint, test, test-sandbox-bwrap]
+    needs: [release-intent, gofmt, compute-matrix, lint, test, test-sandbox-bwrap, test-core-windows, test-sandbox-windows]
     runs-on: ubuntu-latest
     steps:
       - name: Check results
@@ -243,6 +273,8 @@ jobs:
             "${{ needs.lint.result }}" \
             "${{ needs.test.result }}" \
             "${{ needs.test-sandbox-bwrap.result }}" \
+            "${{ needs.test-core-windows.result }}" \
+            "${{ needs.test-sandbox-windows.result }}" \
           )
           for r in "${results[@]}"; do
             if [[ "$r" == "failure" || "$r" == "cancelled" ]]; then

--- a/core/deploy/expand_test.go
+++ b/core/deploy/expand_test.go
@@ -139,7 +139,7 @@ func TestBuilderExpandsResourceSettingsAllOpen(t *testing.T) {
 	if _, err := builder.Build(context.Background(), doc); err != nil {
 		t.Fatalf("Build: %v", err)
 	}
-	if len(records) != 1 || records[0] != "/srv/flowcraft|/tmp/deploy/sub" {
+	if len(records) != 1 || records[0] != "/srv/flowcraft|"+filepath.Join("/tmp/deploy", "sub") {
 		t.Fatalf("decoded settings = %v, want env + base expanded", records)
 	}
 }
@@ -494,6 +494,10 @@ func TestBuilderFileSecretStore(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(dir, "token"), []byte("tok-file\n"), 0o600); err != nil {
 		t.Fatal(err)
 	}
+	base, err := json.Marshal(dir)
+	if err != nil {
+		t.Fatalf("marshal base: %v", err)
+	}
 	var records []string
 	reg := resource.NewRegistry()
 	if err := secret.Register(reg); err != nil {
@@ -508,7 +512,7 @@ func TestBuilderFileSecretStore(t *testing.T) {
 			"secret.files": {
 				Kind: secret.ResourceKind, Impl: "file",
 				Settings: json.RawMessage(
-					`{"id": "files", "base": "` + dir + `"}`),
+					`{"id": "files", "base": ` + string(base) + `}`),
 			},
 			"a": {
 				Kind: "expand.test", Impl: "record",

--- a/core/go.mod
+++ b/core/go.mod
@@ -24,6 +24,7 @@ require (
 	go.opentelemetry.io/otel/sdk/metric v1.43.0
 	go.opentelemetry.io/otel/trace v1.43.0
 	golang.org/x/net v0.55.0
+	golang.org/x/sys v0.45.0
 	google.golang.org/grpc v1.82.1
 	gopkg.in/natefinch/lumberjack.v2 v2.2.1
 	gopkg.in/yaml.v2 v2.4.0
@@ -51,7 +52,6 @@ require (
 	golang.org/x/mod v0.35.0 // indirect
 	golang.org/x/oauth2 v0.36.0 // indirect
 	golang.org/x/sync v0.20.0 // indirect
-	golang.org/x/sys v0.45.0 // indirect
 	golang.org/x/text v0.37.0 // indirect
 	golang.org/x/time v0.15.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20260427160629-7cedc36a6bc4 // indirect

--- a/core/sandbox/allowlist_test.go
+++ b/core/sandbox/allowlist_test.go
@@ -191,6 +191,7 @@ func TestAllowlistNotAllowedPredicate(t *testing.T) {
 }
 
 func TestWithApprovalUsesAllowlist(t *testing.T) {
+	skipOnWindows(t)
 	inner := localRunner(t)
 	var approvals atomic.Int64
 	approve := sandbox.ApprovalFunc(func(context.Context, sandbox.ApprovalRequest) (sandbox.Decision, error) {

--- a/core/sandbox/exec_test.go
+++ b/core/sandbox/exec_test.go
@@ -2,6 +2,7 @@ package sandbox_test
 
 import (
 	"context"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -18,7 +19,19 @@ func localRunner(t *testing.T) *local.Runner {
 	return local.New(t.TempDir())
 }
 
+// skipOnWindows guards tests that exercise the unix-only session
+// machinery of core/sandbox/local (pty / process groups / signals).
+// The windows backend has its own integration coverage in
+// core/sandbox/windows.
+func skipOnWindows(t *testing.T) {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		t.Skip("sandbox/local sessions require a unix platform")
+	}
+}
+
 func TestExecEcho(t *testing.T) {
+	skipOnWindows(t)
 	result, err := sandbox.Exec(
 		context.Background(), localRunner(t), "echo", []string{"hi"}, sandbox.ExecOptions{})
 	if err != nil {
@@ -30,6 +43,7 @@ func TestExecEcho(t *testing.T) {
 }
 
 func TestExecStdin(t *testing.T) {
+	skipOnWindows(t)
 	result, err := sandbox.Exec(
 		context.Background(), localRunner(t), "cat", nil,
 		sandbox.ExecOptions{Stdin: []byte("hello")})
@@ -42,6 +56,7 @@ func TestExecStdin(t *testing.T) {
 }
 
 func TestExecNonZeroExit(t *testing.T) {
+	skipOnWindows(t)
 	result, err := sandbox.Exec(
 		context.Background(), localRunner(t), "sh",
 		[]string{"-c", "exit 3"}, sandbox.ExecOptions{})
@@ -54,6 +69,7 @@ func TestExecNonZeroExit(t *testing.T) {
 }
 
 func TestExecTruncatesOutput(t *testing.T) {
+	skipOnWindows(t)
 	result, err := sandbox.Exec(
 		context.Background(), localRunner(t), "sh",
 		[]string{"-c", "printf 'abcdefghijklmnopqrstuvwxyz'"},
@@ -67,6 +83,7 @@ func TestExecTruncatesOutput(t *testing.T) {
 }
 
 func TestExecTimeout(t *testing.T) {
+	skipOnWindows(t)
 	_, err := sandbox.Exec(
 		context.Background(), localRunner(t), "sleep", []string{"5"},
 		sandbox.ExecOptions{Timeout: 200 * time.Millisecond})
@@ -79,6 +96,7 @@ func TestExecTimeout(t *testing.T) {
 }
 
 func TestRunnerExecMethod(t *testing.T) {
+	skipOnWindows(t)
 	result, err := localRunner(t).Exec(
 		context.Background(), "echo", []string{"ok"}, sandbox.ExecOptions{})
 	if err != nil {

--- a/core/sandbox/local/resource_test.go
+++ b/core/sandbox/local/resource_test.go
@@ -2,6 +2,7 @@ package local_test
 
 import (
 	"context"
+	"encoding/json"
 	"testing"
 
 	"github.com/GizClaw/flowcraft/core/resource"
@@ -17,8 +18,12 @@ func TestRegister(t *testing.T) {
 	if !ok {
 		t.Fatal("sandbox.Runner/local factory not registered")
 	}
+	root, err := json.Marshal(t.TempDir())
+	if err != nil {
+		t.Fatalf("marshal root: %v", err)
+	}
 	value, err := factory.New(context.Background(), resource.Input{
-		Settings: []byte(`{"root": "` + t.TempDir() + `"}`),
+		Settings: []byte(`{"root": ` + string(root) + `}`),
 	})
 	if err != nil {
 		t.Fatalf("New: %v", err)

--- a/core/sandbox/session_test.go
+++ b/core/sandbox/session_test.go
@@ -34,6 +34,7 @@ func TestRunnerCapabilities(t *testing.T) {
 }
 
 func TestStartReturnsSessionWithCapabilities(t *testing.T) {
+	skipOnWindows(t)
 	ctx := context.Background()
 	r := local.New(t.TempDir())
 
@@ -70,6 +71,7 @@ func TestStartReturnsSessionWithCapabilities(t *testing.T) {
 }
 
 func TestSessionWatch(t *testing.T) {
+	skipOnWindows(t)
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 	r := local.New(t.TempDir())
@@ -111,6 +113,7 @@ func TestSessionWatch(t *testing.T) {
 }
 
 func TestSessionSignal(t *testing.T) {
+	skipOnWindows(t)
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 	r := local.New(t.TempDir())
@@ -139,6 +142,7 @@ func TestSessionSignal(t *testing.T) {
 // every active session: after Close, no session started through the
 // runner is still running.
 func TestRunnerCloseTerminatesSessions(t *testing.T) {
+	skipOnWindows(t)
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 	r := local.New(t.TempDir())

--- a/core/sandbox/windows/appcontainer_windows.go
+++ b/core/sandbox/windows/appcontainer_windows.go
@@ -4,6 +4,7 @@ package windows
 
 import (
 	"fmt"
+	"runtime"
 	"unsafe"
 
 	"github.com/GizClaw/flowcraft/core/errdefs"
@@ -25,7 +26,7 @@ var (
 	procGetSecurityDescriptorDacl = xwin.NewLazySystemDLL("advapi32.dll").NewProc("GetSecurityDescriptorDacl")
 	// SetEntriesInAcl is a header macro; the real export is the
 	// Unicode variant.
-	procSetEntriesInAcl           = xwin.NewLazySystemDLL("advapi32.dll").NewProc("SetEntriesInAclW")
+	procSetEntriesInAcl = xwin.NewLazySystemDLL("advapi32.dll").NewProc("SetEntriesInAclW")
 )
 
 // createAppContainerProfile creates a new AppContainer profile with
@@ -190,6 +191,15 @@ func grantDaclAccess(path string, sid *xwin.SID, access uint32, inherit uint32) 
 		return errdefs.Internal(fmt.Errorf("windows: read dacl of %s: %v", path, e1))
 	}
 
+	// The OBJECTS_AND_SID is referenced from TRUSTEE.TrusteeValue,
+	// which is a uintptr and invisible to the GC, so it must be
+	// pinned for the duration of the SetEntriesInAclW call (see the
+	// pinning contract on x/sys TrusteeValueFromObjectsAndSid).
+	oas := &xwin.OBJECTS_AND_SID{Sid: sid}
+	var pinner runtime.Pinner
+	pinner.Pin(oas)
+	defer pinner.Unpin()
+
 	ea := xwin.EXPLICIT_ACCESS{
 		AccessPermissions: xwin.ACCESS_MASK(access),
 		AccessMode:        xwin.GRANT_ACCESS,
@@ -197,7 +207,7 @@ func grantDaclAccess(path string, sid *xwin.SID, access uint32, inherit uint32) 
 		Trustee: xwin.TRUSTEE{
 			TrusteeForm:  xwin.TRUSTEE_IS_SID,
 			TrusteeType:  xwin.TRUSTEE_IS_UNKNOWN,
-			TrusteeValue: xwin.TrusteeValueFromObjectsAndSid(&xwin.OBJECTS_AND_SID{Sid: sid}),
+			TrusteeValue: xwin.TrusteeValueFromObjectsAndSid(oas),
 		},
 	}
 	var newDacl *xwin.ACL
@@ -207,7 +217,8 @@ func grantDaclAccess(path string, sid *xwin.SID, access uint32, inherit uint32) 
 		uintptr(unsafe.Pointer(dacl)),
 		uintptr(unsafe.Pointer(&newDacl)),
 	)
-	if r2 == 0 {
+	// SetEntriesInAclW returns a Win32 error code: zero means success.
+	if r2 != 0 {
 		return errdefs.Internal(fmt.Errorf("windows: merge dacl of %s: %v", path, e2))
 	}
 	defer func() { _, _ = xwin.LocalFree(xwin.Handle(unsafe.Pointer(newDacl))) }()

--- a/core/sandbox/windows/appcontainer_windows.go
+++ b/core/sandbox/windows/appcontainer_windows.go
@@ -4,7 +4,6 @@ package windows
 
 import (
 	"fmt"
-	"runtime"
 	"unsafe"
 
 	"github.com/GizClaw/flowcraft/core/errdefs"
@@ -191,15 +190,9 @@ func grantDaclAccess(path string, sid *xwin.SID, access uint32, inherit uint32) 
 		return errdefs.Internal(fmt.Errorf("windows: read dacl of %s: %v", path, e1))
 	}
 
-	// The OBJECTS_AND_SID is referenced from TRUSTEE.TrusteeValue,
-	// which is a uintptr and invisible to the GC, so it must be
-	// pinned for the duration of the SetEntriesInAclW call (see the
-	// pinning contract on x/sys TrusteeValueFromObjectsAndSid).
-	oas := &xwin.OBJECTS_AND_SID{Sid: sid}
-	var pinner runtime.Pinner
-	pinner.Pin(oas)
-	defer pinner.Unpin()
-
+	// sid is API-allocated (LocalAlloc) and owned by the caller for
+	// the whole session, so the TrusteeValue uintptr stays valid
+	// through the call; Go GC does not manage or move that memory.
 	ea := xwin.EXPLICIT_ACCESS{
 		AccessPermissions: xwin.ACCESS_MASK(access),
 		AccessMode:        xwin.GRANT_ACCESS,
@@ -207,7 +200,7 @@ func grantDaclAccess(path string, sid *xwin.SID, access uint32, inherit uint32) 
 		Trustee: xwin.TRUSTEE{
 			TrusteeForm:  xwin.TRUSTEE_IS_SID,
 			TrusteeType:  xwin.TRUSTEE_IS_UNKNOWN,
-			TrusteeValue: xwin.TrusteeValueFromObjectsAndSid(oas),
+			TrusteeValue: xwin.TrusteeValueFromSID(sid),
 		},
 	}
 	var newDacl *xwin.ACL
@@ -220,7 +213,8 @@ func grantDaclAccess(path string, sid *xwin.SID, access uint32, inherit uint32) 
 	// SetEntriesInAclW returns a Win32 error code in r1 (RAX): zero
 	// means success. r2 is a scratch register, not the return value.
 	if r1 != 0 {
-		return errdefs.Internal(fmt.Errorf("windows: merge dacl of %s: %v", path, e2))
+		return errdefs.Internal(fmt.Errorf(
+			"windows: merge dacl of %s: 0x%x (%v)", path, r1, e2))
 	}
 	defer func() { _, _ = xwin.LocalFree(xwin.Handle(unsafe.Pointer(newDacl))) }()
 

--- a/core/sandbox/windows/appcontainer_windows.go
+++ b/core/sandbox/windows/appcontainer_windows.go
@@ -19,8 +19,8 @@ var (
 	procDeleteAppContainerProfile = xwin.NewLazySystemDLL("userenv.dll").NewProc("DeleteAppContainerProfile")
 	// CreateAppContainerToken is a SecurityBaseApi function exported
 	// from kernelbase (not userenv, despite the profile functions
-	// living there).
-	procCreateAppContainerToken   = xwin.NewLazySystemDLL("kernel32.dll").NewProc("CreateAppContainerToken")
+	// living there; kernel32 does not forward it either).
+	procCreateAppContainerToken   = xwin.NewLazySystemDLL("kernelbase.dll").NewProc("CreateAppContainerToken")
 	procDeriveCapabilitySids      = xwin.NewLazySystemDLL("kernel32.dll").NewProc("DeriveCapabilitySidsFromName")
 	procGetSecurityDescriptorDacl = xwin.NewLazySystemDLL("advapi32.dll").NewProc("GetSecurityDescriptorDacl")
 	procSetEntriesInAcl           = xwin.NewLazySystemDLL("advapi32.dll").NewProc("SetEntriesInAcl")

--- a/core/sandbox/windows/appcontainer_windows.go
+++ b/core/sandbox/windows/appcontainer_windows.go
@@ -1,0 +1,148 @@
+//go:build windows
+
+package windows
+
+import (
+	"fmt"
+	"unsafe"
+
+	"github.com/GizClaw/flowcraft/core/errdefs"
+	xwin "golang.org/x/sys/windows"
+)
+
+// AppContainer API declarations. x/sys/windows does not expose the
+// userenv.dll AppContainer surface or the advapi32 DACL builders, so
+// they are declared here with LazyDLL, same as the write-confinement
+// helpers in syscall_windows.go.
+var (
+	procCreateAppContainerProfile = xwin.NewLazySystemDLL("userenv.dll").NewProc("CreateAppContainerProfile")
+	procDeleteAppContainerProfile = xwin.NewLazySystemDLL("userenv.dll").NewProc("DeleteAppContainerProfile")
+	procCreateAppContainerToken   = xwin.NewLazySystemDLL("userenv.dll").NewProc("CreateAppContainerToken")
+	procGetSecurityDescriptorDacl = xwin.NewLazySystemDLL("advapi32.dll").NewProc("GetSecurityDescriptorDacl")
+	procSetEntriesInAcl           = xwin.NewLazySystemDLL("advapi32.dll").NewProc("SetEntriesInAcl")
+)
+
+// createAppContainerProfile creates a new AppContainer profile with
+// the given capabilities (nil for none) and returns its package SID.
+// Creating a profile requires an elevated host; without it the call
+// fails closed.
+func createAppContainerProfile(name, displayName string, caps []*xwin.SID) (*xwin.SID, error) {
+	namePtr, err := xwin.UTF16PtrFromString(name)
+	if err != nil {
+		return nil, errdefs.Internal(fmt.Errorf("windows: encode appcontainer name: %w", err))
+	}
+	displayPtr, err := xwin.UTF16PtrFromString(displayName)
+	if err != nil {
+		return nil, errdefs.Internal(fmt.Errorf("windows: encode appcontainer display name: %w", err))
+	}
+	descPtr, err := xwin.UTF16PtrFromString("flowcraft sandbox network isolation")
+	if err != nil {
+		return nil, errdefs.Internal(fmt.Errorf("windows: encode appcontainer description: %w", err))
+	}
+	var capsPtr **xwin.SID
+	if len(caps) > 0 {
+		capsPtr = &caps[0]
+	}
+	var sid *xwin.SID
+	r1, _, e1 := procCreateAppContainerProfile.Call(
+		uintptr(unsafe.Pointer(namePtr)),
+		uintptr(unsafe.Pointer(displayPtr)),
+		uintptr(unsafe.Pointer(descPtr)),
+		uintptr(unsafe.Pointer(capsPtr)),
+		uintptr(len(caps)),
+		uintptr(unsafe.Pointer(&sid)),
+	)
+	if r1 != 0 {
+		// HRESULT_FROM_WIN32(ERROR_ACCESS_DENIED): creating profiles
+		// requires an elevated host. Fail closed with NotAvailable so
+		// callers get an actionable message instead of a raw HRESULT.
+		if r1 == 0x80070005 {
+			return nil, errdefs.NotAvailablef(
+				"windows: create appcontainer profile %s: requires an elevated host (0x80070005)", name)
+		}
+		return nil, errdefs.Internal(fmt.Errorf(
+			"windows: create appcontainer profile %s: 0x%x (%v)", name, r1, e1))
+	}
+	return sid, nil
+}
+
+// deleteAppContainerProfile removes the profile. A missing profile is
+// a successful no-op so cleanup is idempotent.
+func deleteAppContainerProfile(name string) error {
+	namePtr, err := xwin.UTF16PtrFromString(name)
+	if err != nil {
+		return errdefs.Internal(fmt.Errorf("windows: encode appcontainer name: %w", err))
+	}
+	r1, _, _ := procDeleteAppContainerProfile.Call(uintptr(unsafe.Pointer(namePtr)))
+	if r1 != 0 {
+		return errdefs.Internal(fmt.Errorf(
+			"windows: delete appcontainer profile %s: 0x%x", name, r1))
+	}
+	return nil
+}
+
+// createAppContainerToken derives an AppContainer (lowbox) token from
+// an existing token. The resulting token carries the package SID as
+// its user, which is what WFP scopes network filters on.
+func createAppContainerToken(base xwin.Token, sid *xwin.SID) (xwin.Token, error) {
+	var lowbox xwin.Token
+	r1, _, e1 := procCreateAppContainerToken.Call(
+		uintptr(base),
+		uintptr(unsafe.Pointer(sid)),
+		uintptr(unsafe.Pointer(&lowbox)),
+	)
+	if r1 != 0 {
+		return 0, errdefs.Internal(fmt.Errorf(
+			"windows: create appcontainer token: 0x%x (%v)", r1, e1))
+	}
+	return lowbox, nil
+}
+
+// grantDaclAccess adds a GRANT_ACCESS ACE for sid to path's DACL,
+// preserving every existing entry. Directories pass inherit flags so
+// future children carry the grant.
+func grantDaclAccess(path string, sid *xwin.SID, access uint32, inherit uint32) error {
+	sd, err := xwin.GetNamedSecurityInfo(path, xwin.SE_FILE_OBJECT, xwin.DACL_SECURITY_INFORMATION)
+	if err != nil {
+		return errdefs.Internal(fmt.Errorf("windows: get dacl of %s: %w", path, err))
+	}
+	var present, defaulted bool
+	var dacl *xwin.ACL
+	r1, _, e1 := procGetSecurityDescriptorDacl.Call(
+		uintptr(unsafe.Pointer(sd)),
+		uintptr(unsafe.Pointer(&present)),
+		uintptr(unsafe.Pointer(&dacl)),
+		uintptr(unsafe.Pointer(&defaulted)),
+	)
+	if r1 == 0 {
+		return errdefs.Internal(fmt.Errorf("windows: read dacl of %s: %v", path, e1))
+	}
+
+	ea := xwin.EXPLICIT_ACCESS{
+		AccessPermissions: xwin.ACCESS_MASK(access),
+		AccessMode:        xwin.GRANT_ACCESS,
+		Inheritance:       inherit,
+		Trustee: xwin.TRUSTEE{
+			TrusteeForm:  xwin.TRUSTEE_IS_SID,
+			TrusteeType:  xwin.TRUSTEE_IS_UNKNOWN,
+			TrusteeValue: xwin.TrusteeValueFromObjectsAndSid(&xwin.OBJECTS_AND_SID{Sid: sid}),
+		},
+	}
+	var newDacl *xwin.ACL
+	r2, _, e2 := procSetEntriesInAcl.Call(
+		1,
+		uintptr(unsafe.Pointer(&ea)),
+		uintptr(unsafe.Pointer(dacl)),
+		uintptr(unsafe.Pointer(&newDacl)),
+	)
+	if r2 == 0 {
+		return errdefs.Internal(fmt.Errorf("windows: merge dacl of %s: %v", path, e2))
+	}
+	defer func() { _, _ = xwin.LocalFree(xwin.Handle(unsafe.Pointer(newDacl))) }()
+
+	if err := xwin.SetNamedSecurityInfo(path, xwin.SE_FILE_OBJECT,
+		xwin.DACL_SECURITY_INFORMATION, nil, nil, newDacl, nil); err != nil {
+		return errdefs.Internal(fmt.Errorf("windows: apply dacl to %s: %w", path, err))
+	}
+	return nil
+}

--- a/core/sandbox/windows/appcontainer_windows.go
+++ b/core/sandbox/windows/appcontainer_windows.go
@@ -85,17 +85,47 @@ func deleteAppContainerProfile(name string) error {
 	return nil
 }
 
+// sidAndAttributes mirrors SID_AND_ATTRIBUTES for the capabilities
+// array inside SECURITY_CAPABILITIES.
+type sidAndAttributes struct {
+	Sid        *xwin.SID
+	Attributes uint32
+}
+
+// securityCapabilities mirrors SECURITY_CAPABILITIES, which
+// CreateAppContainerToken expects as its second parameter (the
+// package SID plus optional capability SIDs, not a bare SID).
+type securityCapabilities struct {
+	AppContainerSid *xwin.SID
+	Capabilities    *sidAndAttributes
+	CapabilityCount uint32
+	Reserved        uint32
+}
+
 // createAppContainerToken derives an AppContainer (lowbox) token from
 // an existing token. The resulting token carries the package SID as
-// its user, which is what WFP scopes network filters on.
-func createAppContainerToken(base xwin.Token, sid *xwin.SID) (xwin.Token, error) {
+// its user — which is what WFP scopes network filters on — plus the
+// named capabilities (e.g. InternetClient for allow_list / proxy
+// modes). The export lives in kernelbase and follows BOOL semantics
+// (nonzero success), matching Chromium's production usage.
+func createAppContainerToken(base xwin.Token, sid *xwin.SID, caps []*xwin.SID) (xwin.Token, error) {
+	sc := securityCapabilities{AppContainerSid: sid}
+	var attrs []sidAndAttributes
+	if len(caps) > 0 {
+		attrs = make([]sidAndAttributes, len(caps))
+		for i, c := range caps {
+			attrs[i] = sidAndAttributes{Sid: c, Attributes: xwin.SE_GROUP_ENABLED}
+		}
+		sc.Capabilities = &attrs[0]
+		sc.CapabilityCount = uint32(len(caps))
+	}
 	var lowbox xwin.Token
 	r1, _, e1 := procCreateAppContainerToken.Call(
 		uintptr(base),
-		uintptr(unsafe.Pointer(sid)),
+		uintptr(unsafe.Pointer(&sc)),
 		uintptr(unsafe.Pointer(&lowbox)),
 	)
-	if r1 != 0 {
+	if r1 == 0 {
 		return 0, errdefs.Internal(fmt.Errorf(
 			"windows: create appcontainer token: 0x%x (%v)", r1, e1))
 	}

--- a/core/sandbox/windows/appcontainer_windows.go
+++ b/core/sandbox/windows/appcontainer_windows.go
@@ -23,7 +23,9 @@ var (
 	procCreateAppContainerToken   = xwin.NewLazySystemDLL("kernelbase.dll").NewProc("CreateAppContainerToken")
 	procDeriveCapabilitySids      = xwin.NewLazySystemDLL("kernel32.dll").NewProc("DeriveCapabilitySidsFromName")
 	procGetSecurityDescriptorDacl = xwin.NewLazySystemDLL("advapi32.dll").NewProc("GetSecurityDescriptorDacl")
-	procSetEntriesInAcl           = xwin.NewLazySystemDLL("advapi32.dll").NewProc("SetEntriesInAcl")
+	// SetEntriesInAcl is a header macro; the real export is the
+	// Unicode variant.
+	procSetEntriesInAcl           = xwin.NewLazySystemDLL("advapi32.dll").NewProc("SetEntriesInAclW")
 )
 
 // createAppContainerProfile creates a new AppContainer profile with

--- a/core/sandbox/windows/appcontainer_windows.go
+++ b/core/sandbox/windows/appcontainer_windows.go
@@ -20,10 +20,7 @@ var (
 	// CreateAppContainerToken is a SecurityBaseApi function exported
 	// from kernelbase (not userenv, despite the profile functions
 	// living there; kernel32 does not forward it either).
-	procCreateAppContainerToken = xwin.NewLazySystemDLL("kernelbase.dll").NewProc("CreateAppContainerToken")
-	// DeriveCapabilitySidsFromName is a SecurityBaseApi function,
-	// exported from kernelbase (not kernel32).
-	procDeriveCapabilitySids      = xwin.NewLazySystemDLL("kernelbase.dll").NewProc("DeriveCapabilitySidsFromName")
+	procCreateAppContainerToken   = xwin.NewLazySystemDLL("kernelbase.dll").NewProc("CreateAppContainerToken")
 	procGetSecurityDescriptorDacl = xwin.NewLazySystemDLL("advapi32.dll").NewProc("GetSecurityDescriptorDacl")
 	// SetEntriesInAcl is a header macro; the real export is the
 	// Unicode variant.
@@ -111,10 +108,11 @@ type securityCapabilities struct {
 
 // createAppContainerToken derives an AppContainer (lowbox) token from
 // an existing token. The resulting token carries the package SID as
-// its user — which is what WFP scopes network filters on — plus the
-// named capabilities (e.g. InternetClient for allow_list / proxy
-// modes). The export lives in kernelbase and follows BOOL semantics
-// (nonzero success), matching Chromium's production usage.
+// its user — which is what WFP scopes network filters on — plus any
+// capability SIDs passed in. netIsolation passes none in every mode,
+// keeping the container subject to the firewall's AppIsolation
+// default-deny. The export lives in kernelbase and follows BOOL
+// semantics (nonzero success), matching Chromium's production usage.
 func createAppContainerToken(base xwin.Token, sid *xwin.SID, caps []*xwin.SID) (xwin.Token, error) {
 	sc := securityCapabilities{AppContainerSid: sid}
 	attrs := sidAttrs(caps)
@@ -133,49 +131,6 @@ func createAppContainerToken(base xwin.Token, sid *xwin.SID, caps []*xwin.SID) (
 			"windows: create appcontainer token: 0x%x (%v)", r1, e1))
 	}
 	return lowbox, nil
-}
-
-// capabilitySids resolves a named capability (e.g. "internetClient")
-// into its SID. The API returns a SID_AND_ATTRIBUTES array backed by
-// one LocalAlloc block; each SID is cloned onto the Go heap with
-// sid.Copy before the block is freed, so the returned SIDs are
-// owned by the caller and need no cleanup.
-func capabilitySids(name string) ([]*xwin.SID, error) {
-	namePtr, err := xwin.UTF16PtrFromString(name)
-	if err != nil {
-		return nil, errdefs.Internal(fmt.Errorf("windows: encode capability name: %w", err))
-	}
-	var groupSids, capSids *sidAndAttributes
-	var groupCount, capCount uint32
-	r1, _, e1 := procDeriveCapabilitySids.Call(
-		uintptr(unsafe.Pointer(namePtr)),
-		uintptr(unsafe.Pointer(&groupSids)),
-		uintptr(unsafe.Pointer(&groupCount)),
-		uintptr(unsafe.Pointer(&capSids)),
-		uintptr(unsafe.Pointer(&capCount)),
-	)
-	if r1 == 0 {
-		return nil, errdefs.Internal(fmt.Errorf(
-			"windows: derive capability sids %q: %v", name, e1))
-	}
-	defer func() {
-		if groupSids != nil {
-			_, _ = xwin.LocalFree(xwin.Handle(unsafe.Pointer(groupSids)))
-		}
-		if capSids != nil {
-			_, _ = xwin.LocalFree(xwin.Handle(unsafe.Pointer(capSids)))
-		}
-	}()
-	sids := make([]*xwin.SID, 0, int(capCount))
-	for _, sa := range unsafe.Slice(capSids, int(capCount)) {
-		clone, err := sa.Sid.Copy()
-		if err != nil {
-			return nil, errdefs.Internal(fmt.Errorf(
-				"windows: copy capability sid: %w", err))
-		}
-		sids = append(sids, clone)
-	}
-	return sids, nil
 }
 
 // sidAttrs wraps capability SIDs in the SID_AND_ATTRIBUTES layout

--- a/core/sandbox/windows/appcontainer_windows.go
+++ b/core/sandbox/windows/appcontainer_windows.go
@@ -17,7 +17,11 @@ import (
 var (
 	procCreateAppContainerProfile = xwin.NewLazySystemDLL("userenv.dll").NewProc("CreateAppContainerProfile")
 	procDeleteAppContainerProfile = xwin.NewLazySystemDLL("userenv.dll").NewProc("DeleteAppContainerProfile")
-	procCreateAppContainerToken   = xwin.NewLazySystemDLL("userenv.dll").NewProc("CreateAppContainerToken")
+	// CreateAppContainerToken is a SecurityBaseApi function exported
+	// from kernelbase (not userenv, despite the profile functions
+	// living there).
+	procCreateAppContainerToken   = xwin.NewLazySystemDLL("kernel32.dll").NewProc("CreateAppContainerToken")
+	procDeriveCapabilitySids      = xwin.NewLazySystemDLL("kernel32.dll").NewProc("DeriveCapabilitySidsFromName")
 	procGetSecurityDescriptorDacl = xwin.NewLazySystemDLL("advapi32.dll").NewProc("GetSecurityDescriptorDacl")
 	procSetEntriesInAcl           = xwin.NewLazySystemDLL("advapi32.dll").NewProc("SetEntriesInAcl")
 )
@@ -96,6 +100,42 @@ func createAppContainerToken(base xwin.Token, sid *xwin.SID) (xwin.Token, error)
 			"windows: create appcontainer token: 0x%x (%v)", r1, e1))
 	}
 	return lowbox, nil
+}
+
+// capabilitySids resolves a named capability (e.g. "internetClient")
+// into its SID, suitable for CreateAppContainerProfile. The returned
+// SIDs are freshly allocated and must be freed with xwin.LocalFree.
+func capabilitySids(name string) ([]*xwin.SID, error) {
+	namePtr, err := xwin.UTF16PtrFromString(name)
+	if err != nil {
+		return nil, errdefs.Internal(fmt.Errorf("windows: encode capability name: %w", err))
+	}
+	var groupSids, capSids *xwin.SID
+	var count uint32
+	r1, _, e1 := procDeriveCapabilitySids.Call(
+		uintptr(unsafe.Pointer(namePtr)),
+		uintptr(unsafe.Pointer(&groupSids)),
+		uintptr(unsafe.Pointer(&capSids)),
+		uintptr(unsafe.Pointer(&count)),
+	)
+	if r1 == 0 {
+		return nil, errdefs.Internal(fmt.Errorf(
+			"windows: derive capability sids %q: %v", name, e1))
+	}
+	defer func() {
+		if groupSids != nil {
+			_, _ = xwin.LocalFree(xwin.Handle(unsafe.Pointer(groupSids)))
+		}
+		if capSids != nil {
+			_, _ = xwin.LocalFree(xwin.Handle(unsafe.Pointer(capSids)))
+		}
+	}()
+	sids := make([]*xwin.SID, int(count))
+	for i := range sids {
+		sids[i] = *(**xwin.SID)(unsafe.Pointer(
+			uintptr(unsafe.Pointer(capSids)) + uintptr(i)*unsafe.Sizeof(uintptr(0))))
+	}
+	return sids, nil
 }
 
 // grantDaclAccess adds a GRANT_ACCESS ACE for sid to path's DACL,

--- a/core/sandbox/windows/appcontainer_windows.go
+++ b/core/sandbox/windows/appcontainer_windows.go
@@ -47,17 +47,18 @@ func createAppContainerProfile(name, displayName string, caps []*xwin.SID) (*xwi
 	if err != nil {
 		return nil, errdefs.Internal(fmt.Errorf("windows: encode appcontainer description: %w", err))
 	}
-	var capsPtr **xwin.SID
-	if len(caps) > 0 {
-		capsPtr = &caps[0]
+	attrs := sidAttrs(caps)
+	var attrsPtr *sidAndAttributes
+	if len(attrs) > 0 {
+		attrsPtr = &attrs[0]
 	}
 	var sid *xwin.SID
 	r1, _, e1 := procCreateAppContainerProfile.Call(
 		uintptr(unsafe.Pointer(namePtr)),
 		uintptr(unsafe.Pointer(displayPtr)),
 		uintptr(unsafe.Pointer(descPtr)),
-		uintptr(unsafe.Pointer(capsPtr)),
-		uintptr(len(caps)),
+		uintptr(unsafe.Pointer(attrsPtr)),
+		uintptr(len(attrs)),
 		uintptr(unsafe.Pointer(&sid)),
 	)
 	if r1 != 0 {
@@ -114,12 +115,8 @@ type securityCapabilities struct {
 // (nonzero success), matching Chromium's production usage.
 func createAppContainerToken(base xwin.Token, sid *xwin.SID, caps []*xwin.SID) (xwin.Token, error) {
 	sc := securityCapabilities{AppContainerSid: sid}
-	var attrs []sidAndAttributes
+	attrs := sidAttrs(caps)
 	if len(caps) > 0 {
-		attrs = make([]sidAndAttributes, len(caps))
-		for i, c := range caps {
-			attrs[i] = sidAndAttributes{Sid: c, Attributes: xwin.SE_GROUP_ENABLED}
-		}
 		sc.Capabilities = &attrs[0]
 		sc.CapabilityCount = uint32(len(caps))
 	}
@@ -137,20 +134,23 @@ func createAppContainerToken(base xwin.Token, sid *xwin.SID, caps []*xwin.SID) (
 }
 
 // capabilitySids resolves a named capability (e.g. "internetClient")
-// into its SID, suitable for CreateAppContainerProfile. The returned
-// SIDs are freshly allocated and must be freed with xwin.LocalFree.
+// into its SID. The API returns a SID_AND_ATTRIBUTES array backed by
+// one LocalAlloc block; each SID is cloned onto the Go heap with
+// sid.Copy before the block is freed, so the returned SIDs are
+// owned by the caller and need no cleanup.
 func capabilitySids(name string) ([]*xwin.SID, error) {
 	namePtr, err := xwin.UTF16PtrFromString(name)
 	if err != nil {
 		return nil, errdefs.Internal(fmt.Errorf("windows: encode capability name: %w", err))
 	}
-	var groupSids, capSids *xwin.SID
-	var count uint32
+	var groupSids, capSids *sidAndAttributes
+	var groupCount, capCount uint32
 	r1, _, e1 := procDeriveCapabilitySids.Call(
 		uintptr(unsafe.Pointer(namePtr)),
 		uintptr(unsafe.Pointer(&groupSids)),
+		uintptr(unsafe.Pointer(&groupCount)),
 		uintptr(unsafe.Pointer(&capSids)),
-		uintptr(unsafe.Pointer(&count)),
+		uintptr(unsafe.Pointer(&capCount)),
 	)
 	if r1 == 0 {
 		return nil, errdefs.Internal(fmt.Errorf(
@@ -164,12 +164,26 @@ func capabilitySids(name string) ([]*xwin.SID, error) {
 			_, _ = xwin.LocalFree(xwin.Handle(unsafe.Pointer(capSids)))
 		}
 	}()
-	sids := make([]*xwin.SID, int(count))
-	for i := range sids {
-		sids[i] = *(**xwin.SID)(unsafe.Pointer(
-			uintptr(unsafe.Pointer(capSids)) + uintptr(i)*unsafe.Sizeof(uintptr(0))))
+	sids := make([]*xwin.SID, 0, int(capCount))
+	for _, sa := range unsafe.Slice(capSids, int(capCount)) {
+		clone, err := sa.Sid.Copy()
+		if err != nil {
+			return nil, errdefs.Internal(fmt.Errorf(
+				"windows: copy capability sid: %w", err))
+		}
+		sids = append(sids, clone)
 	}
 	return sids, nil
+}
+
+// sidAttrs wraps capability SIDs in the SID_AND_ATTRIBUTES layout
+// that CreateAppContainerProfile and CreateAppContainerToken expect.
+func sidAttrs(caps []*xwin.SID) []sidAndAttributes {
+	attrs := make([]sidAndAttributes, len(caps))
+	for i, c := range caps {
+		attrs[i] = sidAndAttributes{Sid: c, Attributes: xwin.SE_GROUP_ENABLED}
+	}
+	return attrs
 }
 
 // grantDaclAccess adds a GRANT_ACCESS ACE for sid to path's DACL,

--- a/core/sandbox/windows/appcontainer_windows.go
+++ b/core/sandbox/windows/appcontainer_windows.go
@@ -211,14 +211,15 @@ func grantDaclAccess(path string, sid *xwin.SID, access uint32, inherit uint32) 
 		},
 	}
 	var newDacl *xwin.ACL
-	r2, _, e2 := procSetEntriesInAcl.Call(
+	r1, _, e2 := procSetEntriesInAcl.Call(
 		1,
 		uintptr(unsafe.Pointer(&ea)),
 		uintptr(unsafe.Pointer(dacl)),
 		uintptr(unsafe.Pointer(&newDacl)),
 	)
-	// SetEntriesInAclW returns a Win32 error code: zero means success.
-	if r2 != 0 {
+	// SetEntriesInAclW returns a Win32 error code in r1 (RAX): zero
+	// means success. r2 is a scratch register, not the return value.
+	if r1 != 0 {
 		return errdefs.Internal(fmt.Errorf("windows: merge dacl of %s: %v", path, e2))
 	}
 	defer func() { _, _ = xwin.LocalFree(xwin.Handle(unsafe.Pointer(newDacl))) }()

--- a/core/sandbox/windows/appcontainer_windows.go
+++ b/core/sandbox/windows/appcontainer_windows.go
@@ -83,7 +83,9 @@ func deleteAppContainerProfile(name string) error {
 		return errdefs.Internal(fmt.Errorf("windows: encode appcontainer name: %w", err))
 	}
 	r1, _, _ := procDeleteAppContainerProfile.Call(uintptr(unsafe.Pointer(namePtr)))
-	if r1 != 0 {
+	// HRESULT_FROM_WIN32(ERROR_NOT_FOUND): deleting an already-gone
+	// profile is the idempotent no-op the doc comment promises.
+	if r1 != 0 && r1 != 0x80070002 {
 		return errdefs.Internal(fmt.Errorf(
 			"windows: delete appcontainer profile %s: 0x%x", name, r1))
 	}

--- a/core/sandbox/windows/appcontainer_windows.go
+++ b/core/sandbox/windows/appcontainer_windows.go
@@ -20,8 +20,10 @@ var (
 	// CreateAppContainerToken is a SecurityBaseApi function exported
 	// from kernelbase (not userenv, despite the profile functions
 	// living there; kernel32 does not forward it either).
-	procCreateAppContainerToken   = xwin.NewLazySystemDLL("kernelbase.dll").NewProc("CreateAppContainerToken")
-	procDeriveCapabilitySids      = xwin.NewLazySystemDLL("kernel32.dll").NewProc("DeriveCapabilitySidsFromName")
+	procCreateAppContainerToken = xwin.NewLazySystemDLL("kernelbase.dll").NewProc("CreateAppContainerToken")
+	// DeriveCapabilitySidsFromName is a SecurityBaseApi function,
+	// exported from kernelbase (not kernel32).
+	procDeriveCapabilitySids      = xwin.NewLazySystemDLL("kernelbase.dll").NewProc("DeriveCapabilitySidsFromName")
 	procGetSecurityDescriptorDacl = xwin.NewLazySystemDLL("advapi32.dll").NewProc("GetSecurityDescriptorDacl")
 	// SetEntriesInAcl is a header macro; the real export is the
 	// Unicode variant.

--- a/core/sandbox/windows/confine_windows.go
+++ b/core/sandbox/windows/confine_windows.go
@@ -1,0 +1,84 @@
+//go:build windows
+
+package windows
+
+import (
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/GizClaw/flowcraft/core/errdefs"
+	xwin "golang.org/x/sys/windows"
+)
+
+// labelLowIntegrity sets the mandatory integrity label of path (and
+// every existing child, recursively) to Low with NO_WRITE_UP. A
+// low-IL child can then write anywhere under the root while the rest
+// of the host stays Medium (readable, not writable). Setting the
+// mandatory label needs no special privilege: LABEL_SECURITY_INFORMATION
+// is distinct from SACL_SECURITY_INFORMATION (which would require
+// SeSecurityPrivilege).
+func labelLowIntegrity(path string) error {
+	return filepath.WalkDir(path, func(p string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		var flags uint32
+		if d.IsDir() {
+			// New children inherit the Low label.
+			flags = xwin.OBJECT_INHERIT_ACE | xwin.CONTAINER_INHERIT_ACE
+		}
+		return labelLowIntegrityOne(p, flags)
+	})
+}
+
+func labelLowIntegrityOne(path string, aceFlags uint32) error {
+	lowSID, err := lowIntegritySID()
+	if err != nil {
+		return err
+	}
+	var acl xwin.ACL
+	if err := initializeAcl(&acl, 256); err != nil {
+		return errdefs.Internal(fmt.Errorf("windows: init label acl: %w", err))
+	}
+	if err := addMandatoryAce(&acl, aceFlags, systemMandatoryLabelNoWriteUp, lowSID); err != nil {
+		return errdefs.Internal(fmt.Errorf("windows: add mandatory ace for %s: %w", path, err))
+	}
+	if err := xwin.SetNamedSecurityInfo(path, xwin.SE_FILE_OBJECT,
+		xwin.LABEL_SECURITY_INFORMATION, nil, nil, nil, &acl); err != nil {
+		return errdefs.Internal(fmt.Errorf("windows: set low integrity label on %s: %w", path, err))
+	}
+	return nil
+}
+
+// createLowTempDir creates a per-runner Low-labeled scratch directory
+// that the sandboxed child gets as its TEMP/TMP. The user's Medium
+// temp is write-denied for a Low subject, and most tooling expects a
+// writable temp, so confinement must provide one.
+func createLowTempDir() (string, error) {
+	dir, err := os.MkdirTemp("", "flowcraft-low-")
+	if err != nil {
+		return "", errdefs.Internal(fmt.Errorf("windows: create low-IL temp dir: %w", err))
+	}
+	if err := labelLowIntegrity(dir); err != nil {
+		_ = os.RemoveAll(dir)
+		return "", err
+	}
+	return dir, nil
+}
+
+// withLowTempEnv replaces TEMP/TMP/TMPDIR in env with the low-IL
+// scratch dir so the sandboxed child has a writable temp.
+func withLowTempEnv(env []string, temp string) []string {
+	out := make([]string, 0, len(env)+3)
+	for _, kv := range env {
+		key, _, ok := strings.Cut(kv, "=")
+		if ok && (key == "TEMP" || key == "TMP" || key == "TMPDIR") {
+			continue
+		}
+		out = append(out, kv)
+	}
+	return append(out, "TEMP="+temp, "TMP="+temp, "TMPDIR="+temp)
+}

--- a/core/sandbox/windows/confine_windows_test.go
+++ b/core/sandbox/windows/confine_windows_test.go
@@ -1,0 +1,162 @@
+//go:build windows
+
+package windows
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/GizClaw/flowcraft/core/sandbox"
+)
+
+func TestWithLowTempEnvReplacesTemp(t *testing.T) {
+	got := withLowTempEnv([]string{"PATH=x", "TEMP=old", "TMP=old2", "HOME=h"}, `C:\low`)
+	seen := map[string]string{}
+	for _, kv := range got {
+		k, v, ok := strings.Cut(kv, "=")
+		if !ok {
+			t.Fatalf("bad entry %q", kv)
+		}
+		seen[k] = v
+	}
+	want := map[string]string{
+		"PATH":   "x",
+		"HOME":   "h",
+		"TEMP":   `C:\low`,
+		"TMP":    `C:\low`,
+		"TMPDIR": `C:\low`,
+	}
+	if len(seen) != len(want) {
+		t.Fatalf("keys = %v, want %v", seen, want)
+	}
+	for k, v := range want {
+		if seen[k] != v {
+			t.Fatalf("%s = %q, want %q", k, seen[k], v)
+		}
+	}
+}
+
+func TestWriteConfinementCapabilities(t *testing.T) {
+	confined, err := New(t.TempDir(), WithWriteConfinement())
+	if err != nil {
+		t.Fatalf("New(confined): %v", err)
+	}
+	defer func() { _ = confined.Close() }()
+	caps := confined.Capabilities()
+	if !caps.Policy.FilesystemBounds {
+		t.Error("confined runner FilesystemBounds = false, want true")
+	}
+	if len(caps.Policy.WriteModes) != 2 {
+		t.Errorf("WriteModes = %v, want WriteWorkspace + WriteReadOnly", caps.Policy.WriteModes)
+	}
+
+	plain, err := New(t.TempDir())
+	if err != nil {
+		t.Fatalf("New(plain): %v", err)
+	}
+	defer func() { _ = plain.Close() }()
+	if plain.Capabilities().Policy.FilesystemBounds {
+		t.Error("plain runner FilesystemBounds = true, want false")
+	}
+	if len(plain.Capabilities().Policy.WriteModes) != 0 {
+		t.Errorf("plain runner WriteModes = %v, want none", plain.Capabilities().Policy.WriteModes)
+	}
+}
+
+func TestWriteConfinementAllowsWorkspaceWrite(t *testing.T) {
+	root := t.TempDir()
+	r, err := New(root, WithWriteConfinement())
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	defer func() { _ = r.Close() }()
+
+	res, err := r.Exec(context.Background(), "cmd",
+		[]string{"/c", "echo", "hi", ">", "out.txt"}, sandbox.ExecOptions{})
+	if err != nil {
+		t.Fatalf("Exec: %v", err)
+	}
+	if res.ExitCode != 0 {
+		t.Fatalf("ExitCode = %d, stderr = %q", res.ExitCode, res.Stderr)
+	}
+	data, err := os.ReadFile(filepath.Join(root, "out.txt"))
+	if err != nil {
+		t.Fatalf("read out.txt: %v", err)
+	}
+	if !strings.Contains(string(data), "hi") {
+		t.Fatalf("out.txt = %q, want hi", data)
+	}
+}
+
+func TestWriteConfinementReadOnlyRejectsWrite(t *testing.T) {
+	root := t.TempDir()
+	r, err := New(root, WithWriteConfinement())
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	defer func() { _ = r.Close() }()
+
+	res, err := r.Exec(context.Background(), "cmd",
+		[]string{"/c", "echo", "hi", ">", "out.txt"},
+		sandbox.ExecOptions{Write: sandbox.WriteReadOnly})
+	if err != nil {
+		t.Fatalf("Exec: %v", err)
+	}
+	if res.ExitCode == 0 {
+		t.Fatal("write to read-only root succeeded")
+	}
+	if _, err := os.Stat(filepath.Join(root, "out.txt")); !os.IsNotExist(err) {
+		t.Fatalf("out.txt exists after denied write: %v", err)
+	}
+}
+
+func TestWriteConfinementBlocksOutsideWrite(t *testing.T) {
+	root := t.TempDir()
+	r, err := New(root, WithWriteConfinement())
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	defer func() { _ = r.Close() }()
+
+	outside, err := os.MkdirTemp("", "flowcraft-out-")
+	if err != nil {
+		t.Fatalf("MkdirTemp: %v", err)
+	}
+	defer func() { _ = os.RemoveAll(outside) }()
+	target := filepath.Join(outside, "x.txt")
+
+	res, err := r.Exec(context.Background(), "cmd",
+		[]string{"/c", "echo", "hi", ">", target}, sandbox.ExecOptions{})
+	if err != nil {
+		t.Fatalf("Exec: %v", err)
+	}
+	if res.ExitCode == 0 {
+		t.Fatal("write outside the workspace succeeded")
+	}
+	if _, err := os.Stat(target); !os.IsNotExist(err) {
+		t.Fatalf("target exists after denied write: %v", err)
+	}
+}
+
+func TestWriteConfinementTempOverride(t *testing.T) {
+	r, err := New(t.TempDir(), WithWriteConfinement())
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	defer func() { _ = r.Close() }()
+
+	res, err := r.Exec(context.Background(), "cmd",
+		[]string{"/c", "echo", "%TEMP%"}, sandbox.ExecOptions{})
+	if err != nil {
+		t.Fatalf("Exec: %v", err)
+	}
+	if res.ExitCode != 0 {
+		t.Fatalf("ExitCode = %d, stderr = %q", res.ExitCode, res.Stderr)
+	}
+	if !strings.Contains(res.Stdout, "flowcraft-low-") {
+		t.Fatalf("TEMP = %q, want flowcraft-low-*", res.Stdout)
+	}
+}

--- a/core/sandbox/windows/confine_windows_test.go
+++ b/core/sandbox/windows/confine_windows_test.go
@@ -9,8 +9,25 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/GizClaw/flowcraft/core/errdefs"
 	"github.com/GizClaw/flowcraft/core/sandbox"
 )
+
+// requireConfinement probes whether the host can spawn write-confined
+// processes. Hosts without the CreateProcessAsUser privileges
+// (SE_INCREASE_QUOTA_NAME) fail closed with NotAvailable; the
+// confinement behaviors cannot be exercised there, so the test skips.
+func requireConfinement(t *testing.T, r *Runner) {
+	t.Helper()
+	_, err := r.Exec(context.Background(), "cmd", []string{"/c", "ver"}, sandbox.ExecOptions{})
+	if err == nil {
+		return
+	}
+	if errdefs.IsNotAvailable(err) {
+		t.Skipf("host cannot spawn write-confined processes: %v", err)
+	}
+	t.Fatalf("confinement probe: %v", err)
+}
 
 func TestWithLowTempEnvReplacesTemp(t *testing.T) {
 	got := withLowTempEnv([]string{"PATH=x", "TEMP=old", "TMP=old2", "HOME=h"}, `C:\low`)
@@ -73,6 +90,7 @@ func TestWriteConfinementAllowsWorkspaceWrite(t *testing.T) {
 		t.Fatalf("New: %v", err)
 	}
 	defer func() { _ = r.Close() }()
+	requireConfinement(t, r)
 
 	res, err := r.Exec(context.Background(), "cmd",
 		[]string{"/c", "echo", "hi", ">", "out.txt"}, sandbox.ExecOptions{})
@@ -98,6 +116,7 @@ func TestWriteConfinementReadOnlyRejectsWrite(t *testing.T) {
 		t.Fatalf("New: %v", err)
 	}
 	defer func() { _ = r.Close() }()
+	requireConfinement(t, r)
 
 	res, err := r.Exec(context.Background(), "cmd",
 		[]string{"/c", "echo", "hi", ">", "out.txt"},
@@ -120,6 +139,7 @@ func TestWriteConfinementBlocksOutsideWrite(t *testing.T) {
 		t.Fatalf("New: %v", err)
 	}
 	defer func() { _ = r.Close() }()
+	requireConfinement(t, r)
 
 	outside, err := os.MkdirTemp("", "flowcraft-out-")
 	if err != nil {
@@ -147,6 +167,7 @@ func TestWriteConfinementTempOverride(t *testing.T) {
 		t.Fatalf("New: %v", err)
 	}
 	defer func() { _ = r.Close() }()
+	requireConfinement(t, r)
 
 	res, err := r.Exec(context.Background(), "cmd",
 		[]string{"/c", "echo", "%TEMP%"}, sandbox.ExecOptions{})

--- a/core/sandbox/windows/confine_windows_test.go
+++ b/core/sandbox/windows/confine_windows_test.go
@@ -19,7 +19,11 @@ import (
 // confinement behaviors cannot be exercised there, so the test skips.
 func requireConfinement(t *testing.T, r *Runner) {
 	t.Helper()
-	_, err := r.Exec(context.Background(), "cmd", []string{"/c", "ver"}, sandbox.ExecOptions{})
+	// Probe with WriteReadOnly so the probe itself does not label the
+	// runner root (which would mask write-denial assertions in the
+	// caller's test).
+	_, err := r.Exec(context.Background(), "cmd", []string{"/c", "ver"},
+		sandbox.ExecOptions{Write: sandbox.WriteReadOnly})
 	if err == nil {
 		return
 	}

--- a/core/sandbox/windows/conpty_windows.go
+++ b/core/sandbox/windows/conpty_windows.go
@@ -84,12 +84,8 @@ func newConPTY(rows, cols uint32) (*conpty, error) {
 		_ = xwin.CloseHandle(outRead)
 		return nil, errdefs.Internal(fmt.Errorf("windows: allocate proc thread attribute list: %w", err))
 	}
-	// The attribute carries the pseudoconsole handle by value (the
-	// sample passes HPCON directly as lpValue, not a pointer to it).
-	// Passing &console here makes console apps die at startup with
-	// STATUS_DLL_INIT_FAILED (0xC0000142).
 	if err := attr.Update(xwin.PROC_THREAD_ATTRIBUTE_PSEUDOCONSOLE,
-		unsafe.Pointer(console), unsafe.Sizeof(console)); err != nil { //nolint:govet // unsafeptr: lpValue must be the handle value itself
+		pseudoconsoleAttrValue(console), unsafe.Sizeof(console)); err != nil {
 		attr.Delete()
 		_ = xwin.CloseHandle(console)
 		_ = xwin.CloseHandle(inWrite)
@@ -103,6 +99,15 @@ func newConPTY(rows, cols uint32) (*conpty, error) {
 		in:      os.NewFile(uintptr(inWrite), "conpty-in"),
 		out:     os.NewFile(uintptr(outRead), "conpty-out"),
 	}, nil
+}
+
+// pseudoconsoleAttrValue reinterprets the pseudoconsole handle's bits
+// as the attribute value. UpdateProcThreadAttribute expects the HPCON
+// value itself in lpValue (Microsoft's sample passes hPC directly),
+// not a pointer to it: passing &console makes console apps die at
+// startup with STATUS_DLL_INIT_FAILED (0xC0000142).
+func pseudoconsoleAttrValue(h xwin.Handle) unsafe.Pointer {
+	return *(*unsafe.Pointer)(unsafe.Pointer(&h))
 }
 
 // spawn creates a suspended child attached to the pseudo console and

--- a/core/sandbox/windows/conpty_windows.go
+++ b/core/sandbox/windows/conpty_windows.go
@@ -1,0 +1,247 @@
+//go:build windows
+
+package windows
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+	"sync"
+	"unicode/utf16"
+	"unsafe"
+
+	"github.com/GizClaw/flowcraft/core/errdefs"
+	"github.com/GizClaw/flowcraft/core/sandbox"
+	xwin "golang.org/x/sys/windows"
+)
+
+// Default pseudo-console window size, in characters. These match the
+// unix backend's defaults.
+const (
+	defaultTTYRows = 24
+	defaultTTYCols = 80
+)
+
+// conpty wraps a Windows pseudo console (ConPTY): the host-side pipe
+// ends (in for input, out for output) and the pseudoconsole handle
+// that is passed to the child through the process attribute list.
+//
+// The child is spawned by [conpty.spawn] with CREATE_SUSPENDED, so the
+// caller can assign it to a job object before any user code runs; the
+// suspend/resume dance is the same as the pipe session path.
+//
+// The child's standard handles are wired to the pseudo console by the
+// PROC_THREAD_ATTRIBUTE_PSEUDOCONSOLE attribute alone (the official
+// Microsoft sample and both mature Go wrappers rely on this), so no
+// STARTF_USESTDHANDLES plumbing is needed.
+type conpty struct {
+	mu       sync.Mutex
+	console  xwin.Handle
+	attr     *xwin.ProcThreadAttributeListContainer
+	in       *os.File // host write end (session stdin)
+	out      *os.File // host read end (copy loop)
+	released bool
+	closed   bool
+}
+
+// newConPTY creates the pseudo console with the requested window size
+// and the communication pipes. The pipe ends handed to the pseudo
+// console are closed here: the console host duplicates them when the
+// attached process is created, and keeping them open would prevent the
+// output channel from reaching EOF after the session ends.
+func newConPTY(rows, cols uint32) (*conpty, error) {
+	var ptyIn, inWrite xwin.Handle
+	if err := xwin.CreatePipe(&ptyIn, &inWrite, nil, 0); err != nil {
+		return nil, errdefs.Internal(fmt.Errorf("windows: create conpty input pipe: %w", err))
+	}
+	var outRead, ptyOut xwin.Handle
+	if err := xwin.CreatePipe(&outRead, &ptyOut, nil, 0); err != nil {
+		_ = xwin.CloseHandle(ptyIn)
+		_ = xwin.CloseHandle(inWrite)
+		return nil, errdefs.Internal(fmt.Errorf("windows: create conpty output pipe: %w", err))
+	}
+	closePipes := func() {
+		for _, h := range []xwin.Handle{ptyIn, ptyOut, inWrite, outRead} {
+			_ = xwin.CloseHandle(h)
+		}
+	}
+
+	var console xwin.Handle
+	if err := xwin.CreatePseudoConsole(
+		xwin.Coord{X: int16(cols), Y: int16(rows)}, ptyIn, ptyOut, 0, &console); err != nil {
+		closePipes()
+		return nil, errdefs.Internal(fmt.Errorf("windows: create pseudo console: %w", err))
+	}
+	_ = xwin.CloseHandle(ptyIn)
+	_ = xwin.CloseHandle(ptyOut)
+
+	attr, err := xwin.NewProcThreadAttributeList(1)
+	if err != nil {
+		_ = xwin.CloseHandle(console)
+		_ = xwin.CloseHandle(inWrite)
+		_ = xwin.CloseHandle(outRead)
+		return nil, errdefs.Internal(fmt.Errorf("windows: allocate proc thread attribute list: %w", err))
+	}
+	if err := attr.Update(xwin.PROC_THREAD_ATTRIBUTE_PSEUDOCONSOLE,
+		unsafe.Pointer(&console), unsafe.Sizeof(console)); err != nil {
+		attr.Delete()
+		_ = xwin.CloseHandle(console)
+		_ = xwin.CloseHandle(inWrite)
+		_ = xwin.CloseHandle(outRead)
+		return nil, errdefs.Internal(fmt.Errorf("windows: set pseudo console attribute: %w", err))
+	}
+
+	return &conpty{
+		console: console,
+		attr:    attr,
+		in:      os.NewFile(uintptr(inWrite), "conpty-in"),
+		out:     os.NewFile(uintptr(outRead), "conpty-out"),
+	}, nil
+}
+
+// spawn creates a suspended child attached to the pseudo console and
+// returns the child's process handle and pid. The caller assigns the
+// process to a job and resumes it. The returned process handle is
+// owned by the caller.
+func (c *conpty) spawn(argv []string, dir string, env []string) (xwin.Handle, int, error) {
+	if len(argv) == 0 {
+		return 0, 0, errdefs.Validationf("windows: empty argv for tty session")
+	}
+	// Match os/exec: argv[0] is resolved through PATH up front, and
+	// the resolved path becomes the first token of the command line.
+	exe, err := exec.LookPath(argv[0])
+	if err != nil {
+		return 0, 0, errdefs.Internal(fmt.Errorf("windows: resolve %s: %w", argv[0], err))
+	}
+	cmdline, err := xwin.UTF16PtrFromString(
+		xwin.ComposeCommandLine(append([]string{exe}, argv[1:]...)))
+	if err != nil {
+		return 0, 0, errdefs.Internal(fmt.Errorf("windows: encode command line: %w", err))
+	}
+	var dirPtr *uint16
+	if dir != "" {
+		dirPtr, err = xwin.UTF16PtrFromString(dir)
+		if err != nil {
+			return 0, 0, errdefs.Internal(fmt.Errorf("windows: encode workdir: %w", err))
+		}
+	}
+
+	siEx := &xwin.StartupInfoEx{
+		ProcThreadAttributeList: c.attr.List(),
+	}
+	siEx.Cb = uint32(unsafe.Sizeof(*siEx))
+	flags := uint32(xwin.CREATE_SUSPENDED | xwin.EXTENDED_STARTUPINFO_PRESENT)
+	var envBlock *uint16
+	if env != nil {
+		// An empty (non-nil) env means "inherit nothing", matching
+		// exec.Cmd semantics; nil inherits the parent environment.
+		envBlock = buildEnvBlock(dedupEnvCase(env))
+		flags |= xwin.CREATE_UNICODE_ENVIRONMENT
+	}
+
+	var pi xwin.ProcessInformation
+	if err := xwin.CreateProcess(nil, cmdline, nil, nil, false, flags,
+		envBlock, dirPtr, &siEx.StartupInfo, &pi); err != nil {
+		return 0, 0, classifyStartError(argv[0], err)
+	}
+	_ = xwin.CloseHandle(pi.Thread)
+	return pi.Process, int(pi.ProcessId), nil
+}
+
+// resize updates the pseudo console window size.
+func (c *conpty) resize(rows, cols uint32) error {
+	c.mu.Lock()
+	console := c.console
+	c.mu.Unlock()
+	if console == 0 {
+		return sandbox.ErrSessionClosed
+	}
+	if err := xwin.ResizePseudoConsole(console, xwin.Coord{X: int16(cols), Y: int16(rows)}); err != nil {
+		return errdefs.Internal(fmt.Errorf("windows: resize pseudo console: %w", err))
+	}
+	return nil
+}
+
+// releaseConsole closes the pseudo console and frees the attribute
+// list. The console host emits a final output frame and closes the
+// output channel, so callers should keep draining [conpty.out] until
+// EOF afterwards.
+func (c *conpty) releaseConsole() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.released {
+		return
+	}
+	c.released = true
+	c.attr.Delete()
+	xwin.ClosePseudoConsole(c.console)
+	c.console = 0
+}
+
+// close releases the console and both host-side pipe handles. It is
+// idempotent and safe to race with the output copy loop: closing the
+// read end unblocks a stuck read with an error.
+func (c *conpty) close() error {
+	c.mu.Lock()
+	if c.closed {
+		c.mu.Unlock()
+		return nil
+	}
+	c.closed = true
+	if !c.released {
+		c.released = true
+		c.attr.Delete()
+		xwin.ClosePseudoConsole(c.console)
+		c.console = 0
+	}
+	in, out := c.in, c.out
+	c.mu.Unlock()
+	return errors.Join(in.Close(), out.Close())
+}
+
+// ttyExitError is the TTY counterpart of *exec.ExitError: it carries
+// the child's exit code into the shared exit classifier without
+// needing an os.ProcessState.
+type ttyExitError struct {
+	code int
+}
+
+func (e *ttyExitError) Error() string {
+	return fmt.Sprintf("windows: tty process exited with code %d", e.code)
+}
+
+func (e *ttyExitError) ExitCode() int { return e.code }
+
+// buildEnvBlock converts env into a UTF-16, double-NUL terminated
+// environment block for CreateProcess.
+func buildEnvBlock(env []string) *uint16 {
+	var b strings.Builder
+	for _, kv := range env {
+		b.WriteString(kv)
+		b.WriteByte(0)
+	}
+	b.WriteByte(0)
+	u := utf16.Encode([]rune(b.String()))
+	return &u[0]
+}
+
+// dedupEnvCase drops duplicate environment keys case-insensitively,
+// keeping the last occurrence, which is what os/exec does for
+// Windows children (the environment is case-insensitive there).
+func dedupEnvCase(env []string) []string {
+	last := make(map[string]int, len(env))
+	for i, kv := range env {
+		key, _, _ := strings.Cut(kv, "=")
+		last[strings.ToUpper(key)] = i
+	}
+	out := make([]string, 0, len(last))
+	for i, kv := range env {
+		key, _, _ := strings.Cut(kv, "=")
+		if last[strings.ToUpper(key)] == i {
+			out = append(out, kv)
+		}
+	}
+	return out
+}

--- a/core/sandbox/windows/conpty_windows.go
+++ b/core/sandbox/windows/conpty_windows.go
@@ -84,8 +84,12 @@ func newConPTY(rows, cols uint32) (*conpty, error) {
 		_ = xwin.CloseHandle(outRead)
 		return nil, errdefs.Internal(fmt.Errorf("windows: allocate proc thread attribute list: %w", err))
 	}
+	// The attribute carries the pseudoconsole handle by value (the
+	// sample passes HPCON directly as lpValue, not a pointer to it).
+	// Passing &console here makes console apps die at startup with
+	// STATUS_DLL_INIT_FAILED (0xC0000142).
 	if err := attr.Update(xwin.PROC_THREAD_ATTRIBUTE_PSEUDOCONSOLE,
-		unsafe.Pointer(&console), unsafe.Sizeof(console)); err != nil {
+		unsafe.Pointer(console), unsafe.Sizeof(console)); err != nil { //nolint:govet // unsafeptr: lpValue must be the handle value itself
 		attr.Delete()
 		_ = xwin.CloseHandle(console)
 		_ = xwin.CloseHandle(inWrite)
@@ -128,7 +132,17 @@ func (c *conpty) spawn(argv []string, dir string, env []string) (xwin.Handle, in
 		}
 	}
 
+	// STARTF_USESTDHANDLES with invalid handles stops the child from
+	// inheriting the host's stdio; the pseudoconsole attribute then
+	// wires the child's standard handles to the pseudo console
+	// (portable-pty/wezterm's production pattern).
 	siEx := &xwin.StartupInfoEx{
+		StartupInfo: xwin.StartupInfo{
+			Flags:     xwin.STARTF_USESTDHANDLES,
+			StdInput:  xwin.InvalidHandle,
+			StdOutput: xwin.InvalidHandle,
+			StdErr:    xwin.InvalidHandle,
+		},
 		ProcThreadAttributeList: c.attr.List(),
 	}
 	siEx.Cb = uint32(unsafe.Sizeof(*siEx))

--- a/core/sandbox/windows/conpty_windows_test.go
+++ b/core/sandbox/windows/conpty_windows_test.go
@@ -1,0 +1,78 @@
+//go:build windows
+
+package windows
+
+import (
+	"strings"
+	"testing"
+	"unicode/utf16"
+	"unsafe"
+)
+
+// utf16BlockEntries decodes a UTF-16, double-NUL-terminated block (as
+// used by CreateProcess) into its entries.
+func utf16BlockEntries(p *uint16) []string {
+	var entries []string
+	cur := make([]uint16, 0, 32)
+	for {
+		c := *p
+		p = (*uint16)(unsafe.Pointer(uintptr(unsafe.Pointer(p)) + unsafe.Sizeof(uint16(0))))
+		if c != 0 {
+			cur = append(cur, c)
+			continue
+		}
+		if len(cur) == 0 {
+			return entries
+		}
+		entries = append(entries, string(utf16.Decode(cur)))
+		cur = cur[:0]
+	}
+}
+
+func TestBuildEnvBlock(t *testing.T) {
+	block := buildEnvBlock([]string{"PATH=C:\\bin", "FOO=1"})
+	got := utf16BlockEntries(block)
+	want := []string{"PATH=C:\\bin", "FOO=1"}
+	if len(got) != len(want) {
+		t.Fatalf("entries = %q, want %q", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("entries = %q, want %q", got, want)
+		}
+	}
+}
+
+func TestBuildEnvBlockEmpty(t *testing.T) {
+	block := buildEnvBlock(nil)
+	if got := utf16BlockEntries(block); len(got) != 0 {
+		t.Fatalf("empty block decoded to %q, want no entries", got)
+	}
+}
+
+func TestDedupEnvCase(t *testing.T) {
+	got := dedupEnvCase([]string{
+		"Path=C:\\first",
+		"PATH=C:\\second",
+		"FOO=1",
+	})
+	want := []string{"PATH=C:\\second", "FOO=1"}
+	if len(got) != len(want) {
+		t.Fatalf("dedup = %q, want %q", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("dedup = %q, want %q", got, want)
+		}
+	}
+}
+
+func TestTTYExitError(t *testing.T) {
+	e := &ttyExitError{code: 7}
+	if e.ExitCode() != 7 {
+		t.Fatalf("ExitCode() = %d, want 7", e.ExitCode())
+	}
+	if !strings.Contains(e.Error(), "7") {
+		t.Fatalf("Error() = %q, want exit code", e.Error())
+	}
+}

--- a/core/sandbox/windows/doc.go
+++ b/core/sandbox/windows/doc.go
@@ -13,7 +13,7 @@
 // type references without build-tag gymnastics (the same pattern as
 // the bwrap and seatbelt backends).
 //
-// # Phase-1 capability matrix
+// # Capability matrix
 //
 //	WorkDir / Stdin / Timeout     fully supported. Every child runs
 //	                              inside a job object; timeout, cancel
@@ -23,9 +23,13 @@
 //	Net.Mode != NetDefault        errdefs.NotAvailable (no AppContainer
 //	                              / Windows Filtering Platform backend
 //	                              yet).
-//	Write == WriteReadOnly        errdefs.NotAvailable (no OS-level
-//	                              write confinement yet; phase 2 adds
-//	                              restricted tokens + ACLs).
+//	Write == WriteReadOnly        enforced when the runner is built
+//	                              with WithWriteConfinement: the child
+//	                              runs with a restricted, Low-integrity
+//	                              token and only the explicitly granted
+//	                              paths are writable. Without the
+//	                              option the call fails with
+//	                              errdefs.NotAvailable.
 //	Resources.MemoryBytes         enforced as a job-wide memory limit
 //	                              (JOB_OBJECT_LIMIT_JOB_MEMORY).
 //	Resources.CPUMillicores       enforced as a per-process user-time
@@ -50,6 +54,30 @@
 //	                              not SessionBudgetExceeded (no
 //	                              limit-violation notification port is
 //	                              wired up yet).
+//
+// # Write confinement notes
+//
+// WithWriteConfinement, the runner root (plus WithWritablePaths
+// entries) is labeled Low integrity (SYSTEM_MANDATORY_LABEL_ACE with
+// NO_WRITE_UP) so the Low-integrity child can write there and read
+// everywhere else. Caveats:
+//
+//   - The label changes are persistent on the workspace directories
+//     (they are not reverted on Close); this is the same "the
+//     workspace is writable by low-integrity processes" model as a
+//     Low-integrity cache dir.
+//   - The child gets its own Low-labeled TEMP/TMP scratch dir
+//     (flowcraft-low-*) because the user's Medium temp is
+//     write-denied for a Low subject; it is removed on Runner.Close.
+//   - CreateProcessAsUser requires the host to hold
+//     SE_INCREASE_QUOTA_NAME; ordinary desktop processes usually do
+//     not have it, so write-confined spawns may fail with
+//     errdefs.NotAvailable unless the host runs elevated or as a
+//     service. The backend fails closed rather than degrading to an
+//     unsandboxed spawn.
+//   - CreateProcessAsUser places the child on a non-interactive window
+//     station, so GUI applications will not be visible. Console /
+//     CLI tools are unaffected.
 //
 // # Files
 //

--- a/core/sandbox/windows/doc.go
+++ b/core/sandbox/windows/doc.go
@@ -49,11 +49,9 @@
 //	                              to TerminateJobObject (Windows has no
 //	                              SIGTERM equivalent).
 //	Exit classification           a process killed by a job memory or
-//	                              cpu-time cap is reported as a plain
-//	                              SessionExited with the job exit code,
-//	                              not SessionBudgetExceeded (no
-//	                              limit-violation notification port is
-//	                              wired up yet).
+//	                              cpu-time cap is reported as
+//	                              SessionBudgetExceeded via the job
+//	                              object's completion-port messages.
 //
 // # Write confinement notes
 //

--- a/core/sandbox/windows/doc.go
+++ b/core/sandbox/windows/doc.go
@@ -20,14 +20,24 @@
 //	                              and close terminate the whole job
 //	                              (all processes, not just the leader).
 //	Env allow-list / inject       fully supported (EnvPolicy).
-//	Net.Mode                     NetDefault (host networking) and
-//	                              NetDenyAll are enforced. NetDenyAll
-//	                              runs the child under an AppContainer
-//	                              token with no network capabilities,
-//	                              which the OS firewall blocks at the
-//	                              kernel. NetAllowList / NetProxy need
-//	                              the WFP port-pinning layer and are
-//	                              errdefs.NotAvailable for now.
+//	Net.Mode                     NetDefault (host networking),
+//	                              NetDenyAll, NetAllowList and
+//	                              NetProxy are enforced. Every
+//	                              non-default mode runs the child
+//	                              under an AppContainer token scoped to
+//	                              one per-runner profile. NetDenyAll
+//	                              grants no network capabilities, so
+//	                              the OS firewall blocks it at the
+//	                              kernel. NetAllowList / NetProxy add
+//	                              the InternetClient capability, pin
+//	                              the container to a host-side
+//	                              enforcement proxy with WFP filters on
+//	                              the package SID (only the loopback
+//	                              proxy port is reachable), and inject
+//	                              the proxy environment. Hosts without
+//	                              AppContainer-profile or WFP-engine
+//	                              access fail closed with
+//	                              errdefs.NotAvailable.
 //	Write == WriteReadOnly        enforced when the runner is built
 //	                              with WithWriteConfinement: the child
 //	                              runs with a restricted, Low-integrity

--- a/core/sandbox/windows/doc.go
+++ b/core/sandbox/windows/doc.go
@@ -32,13 +32,13 @@
 //	                              errdefs.NotAvailable.
 //	Resources.MemoryBytes         enforced as a job-wide memory limit
 //	                              (JOB_OBJECT_LIMIT_JOB_MEMORY).
-//	Resources.CPUMillicores       enforced as a per-process user-time
-//	                              limit (JOB_OBJECT_LIMIT_PROCESS_TIME)
+//	Resources.CPUMillicores       enforced as a job-wide user-time
+//	                              budget (JOB_OBJECT_LIMIT_JOB_TIME)
 //	                              derived from Timeout x millicores /
-//	                              1000; requires Timeout > 0, otherwise
-//	                              errdefs.NotAvailable. The limit is
-//	                              per process, not aggregate across the
-//	                              job.
+//	                              1000, matching the unix watcher's
+//	                              aggregate-group semantics; requires
+//	                              Timeout > 0, otherwise
+//	                              errdefs.NotAvailable.
 //	Resources.DiskBytes != 0      errdefs.NotAvailable (no quota
 //	                              mechanism).
 //	Resources.MaxOutputBytes      enforced in-process, mirroring

--- a/core/sandbox/windows/doc.go
+++ b/core/sandbox/windows/doc.go
@@ -20,9 +20,14 @@
 //	                              and close terminate the whole job
 //	                              (all processes, not just the leader).
 //	Env allow-list / inject       fully supported (EnvPolicy).
-//	Net.Mode != NetDefault        errdefs.NotAvailable (no AppContainer
-//	                              / Windows Filtering Platform backend
-//	                              yet).
+//	Net.Mode                     NetDefault (host networking) and
+//	                              NetDenyAll are enforced. NetDenyAll
+//	                              runs the child under an AppContainer
+//	                              token with no network capabilities,
+//	                              which the OS firewall blocks at the
+//	                              kernel. NetAllowList / NetProxy need
+//	                              the WFP port-pinning layer and are
+//	                              errdefs.NotAvailable for now.
 //	Write == WriteReadOnly        enforced when the runner is built
 //	                              with WithWriteConfinement: the child
 //	                              runs with a restricted, Low-integrity

--- a/core/sandbox/windows/doc.go
+++ b/core/sandbox/windows/doc.go
@@ -1,0 +1,61 @@
+// Package windows implements core/sandbox.Runner on top of the
+// Windows Job Object API: process-tree lifecycle
+// (JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE), job-wide memory caps, and
+// whole-tree termination on timeout / cancel / close. It is the
+// Windows sibling of core/sandbox/local, core/sandbox/bwrap (Linux)
+// and core/sandbox/seatbelt (macOS): same policy surface, different
+// enforcement kernel.
+//
+// # Windows-only
+//
+// The Runner is only constructible on Windows. On other platforms New
+// returns errdefs.NotAvailable so callers can import the package for
+// type references without build-tag gymnastics (the same pattern as
+// the bwrap and seatbelt backends).
+//
+// # Phase-1 capability matrix
+//
+//	WorkDir / Stdin / Timeout     fully supported. Every child runs
+//	                              inside a job object; timeout, cancel
+//	                              and close terminate the whole job
+//	                              (all processes, not just the leader).
+//	Env allow-list / inject       fully supported (EnvPolicy).
+//	Net.Mode != NetDefault        errdefs.NotAvailable (no AppContainer
+//	                              / Windows Filtering Platform backend
+//	                              yet).
+//	Write == WriteReadOnly        errdefs.NotAvailable (no OS-level
+//	                              write confinement yet; phase 2 adds
+//	                              restricted tokens + ACLs).
+//	Resources.MemoryBytes         enforced as a job-wide memory limit
+//	                              (JOB_OBJECT_LIMIT_JOB_MEMORY).
+//	Resources.CPUMillicores       enforced as a per-process user-time
+//	                              limit (JOB_OBJECT_LIMIT_PROCESS_TIME)
+//	                              derived from Timeout x millicores /
+//	                              1000; requires Timeout > 0, otherwise
+//	                              errdefs.NotAvailable. The limit is
+//	                              per process, not aggregate across the
+//	                              job.
+//	Resources.DiskBytes != 0      errdefs.NotAvailable (no quota
+//	                              mechanism).
+//	Resources.MaxOutputBytes      enforced in-process, mirroring
+//	                              core/sandbox/local.
+//	Sessions                      pipe-only (no pty). TTY, Resize,
+//	                              Signal and Watch return
+//	                              errdefs.NotAvailable; Terminate maps
+//	                              to TerminateJobObject (Windows has no
+//	                              SIGTERM equivalent).
+//	Exit classification           a process killed by a job memory or
+//	                              cpu-time cap is reported as a plain
+//	                              SessionExited with the job exit code,
+//	                              not SessionBudgetExceeded (no
+//	                              limit-violation notification port is
+//	                              wired up yet).
+//
+// # Files
+//
+//   - Runner: runner.go / runner_other.go
+//   - Options: options.go
+//   - Job objects: job_windows.go
+//   - Sessions: session_windows.go
+//   - Deployment resource: register.go
+package windows

--- a/core/sandbox/windows/doc.go
+++ b/core/sandbox/windows/doc.go
@@ -28,18 +28,21 @@
 //	                              one per-runner profile. NetDenyAll
 //	                              runs without any network capability,
 //	                              so the OS firewall's AppIsolation
-//	                              default-deny blocks everything at the
-//	                              kernel. NetAllowList / NetProxy add
-//	                              a maximum-weight WFP permit sublayer
-//	                              that pins the container to a
-//	                              host-side enforcement proxy (only
-//	                              the loopback proxy port is
-//	                              reachable; every other packet,
-//	                              including unconnected UDP, still
-//	                              falls through to the default deny)
-//	                              and inject the proxy environment.
-//	                              Hosts without AppContainer-profile or
-//	                              WFP-engine access fail closed with
+//	                              default-deny blocks TCP and connected
+//	                              flows at the kernel. Because that
+//	                              default does not constrain unconnected
+//	                              UDP or ICMP sockets, every non-default
+//	                              mode also installs WFP bind-layer
+//	                              (ALE_RESOURCE_ASSIGNMENT) filters for
+//	                              the package SID: NetDenyAll blocks
+//	                              every bind, while NetAllowList /
+//	                              NetProxy permit only TCP binds, pin
+//	                              the container to a host-side
+//	                              enforcement proxy (only the loopback
+//	                              proxy port is reachable), and inject
+//	                              the proxy environment. Hosts without
+//	                              AppContainer-profile or WFP-engine
+//	                              access fail closed with
 //	                              errdefs.NotAvailable.
 //	Write == WriteReadOnly        enforced when the runner is built
 //	                              with WithWriteConfinement: the child

--- a/core/sandbox/windows/doc.go
+++ b/core/sandbox/windows/doc.go
@@ -26,17 +26,20 @@
 //	                              non-default mode runs the child
 //	                              under an AppContainer token scoped to
 //	                              one per-runner profile. NetDenyAll
-//	                              grants no network capabilities, so
-//	                              the OS firewall blocks it at the
+//	                              runs without any network capability,
+//	                              so the OS firewall's AppIsolation
+//	                              default-deny blocks everything at the
 //	                              kernel. NetAllowList / NetProxy add
-//	                              the InternetClient capability, pin
-//	                              the container to a host-side
-//	                              enforcement proxy with WFP filters on
-//	                              the package SID (only the loopback
-//	                              proxy port is reachable), and inject
-//	                              the proxy environment. Hosts without
-//	                              AppContainer-profile or WFP-engine
-//	                              access fail closed with
+//	                              a maximum-weight WFP permit sublayer
+//	                              that pins the container to a
+//	                              host-side enforcement proxy (only
+//	                              the loopback proxy port is
+//	                              reachable; every other packet,
+//	                              including unconnected UDP, still
+//	                              falls through to the default deny)
+//	                              and inject the proxy environment.
+//	                              Hosts without AppContainer-profile or
+//	                              WFP-engine access fail closed with
 //	                              errdefs.NotAvailable.
 //	Write == WriteReadOnly        enforced when the runner is built
 //	                              with WithWriteConfinement: the child

--- a/core/sandbox/windows/doc.go
+++ b/core/sandbox/windows/doc.go
@@ -43,11 +43,18 @@
 //	                              mechanism).
 //	Resources.MaxOutputBytes      enforced in-process, mirroring
 //	                              core/sandbox/local.
-//	Sessions                      pipe-only (no pty). TTY, Resize,
+//	Sessions                      pipe sessions (separate stdout /
+//	                              stderr streams) and TTY sessions
+//	                              through ConPTY (merged
+//	                              SessionStreamTTY output plus Resize).
 //	                              Signal and Watch return
 //	                              errdefs.NotAvailable; Terminate maps
 //	                              to TerminateJobObject (Windows has no
-//	                              SIGTERM equivalent).
+//	                              SIGTERM equivalent). TTY combined
+//	                              with WithWriteConfinement is
+//	                              NotAvailable until the
+//	                              restricted-token ConPTY spawn path is
+//	                              verified against a real console.
 //	Exit classification           a process killed by a job memory or
 //	                              cpu-time cap is reported as
 //	                              SessionBudgetExceeded via the job
@@ -85,5 +92,6 @@
 //   - Options: options.go
 //   - Job objects: job_windows.go
 //   - Sessions: session_windows.go
+//   - ConPTY: conpty_windows.go
 //   - Deployment resource: register.go
 package windows

--- a/core/sandbox/windows/doc.go
+++ b/core/sandbox/windows/doc.go
@@ -73,8 +73,10 @@
 //     SE_INCREASE_QUOTA_NAME; ordinary desktop processes usually do
 //     not have it, so write-confined spawns may fail with
 //     errdefs.NotAvailable unless the host runs elevated or as a
-//     service. The backend fails closed rather than degrading to an
-//     unsandboxed spawn.
+//     service. The restricted token is derived directly from the
+//     caller's primary token so the SE_ASSIGNPRIMARYTOKEN_NAME
+//     exemption applies. The backend fails closed rather than
+//     degrading to an unsandboxed spawn.
 //   - CreateProcessAsUser places the child on a non-interactive window
 //     station, so GUI applications will not be visible. Console /
 //     CLI tools are unaffected.

--- a/core/sandbox/windows/integration_windows_test.go
+++ b/core/sandbox/windows/integration_windows_test.go
@@ -162,10 +162,10 @@ func TestExecBudgetExceededMemory(t *testing.T) {
 
 func TestExecBudgetExceededCPU(t *testing.T) {
 	r := mustNewRunner(t)
-	_, err := r.Exec(context.Background(), "powershell",
-		[]string{"-NoProfile", "-Command", "while ($true) { }"},
+	_, err := r.Exec(context.Background(), "cmd",
+		[]string{"/c", "for /L %i in (1,1,100000000) do rem"},
 		sandbox.ExecOptions{
-			Timeout: 5 * time.Second,
+			Timeout: 10 * time.Second,
 			Resources: sandbox.ResourceLimits{
 				CPUMillicores: 100,
 			},

--- a/core/sandbox/windows/integration_windows_test.go
+++ b/core/sandbox/windows/integration_windows_test.go
@@ -1,0 +1,161 @@
+//go:build windows
+
+package windows
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/GizClaw/flowcraft/core/sandbox"
+)
+
+func mustNewRunner(t *testing.T) *Runner {
+	t.Helper()
+	r, err := New(t.TempDir())
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	t.Cleanup(func() { _ = r.Close() })
+	return r
+}
+
+func TestExecEcho(t *testing.T) {
+	r := mustNewRunner(t)
+	res, err := r.Exec(context.Background(), "cmd", []string{"/c", "echo", "hello"}, sandbox.ExecOptions{})
+	if err != nil {
+		t.Fatalf("Exec: %v", err)
+	}
+	if res.ExitCode != 0 {
+		t.Fatalf("ExitCode = %d, want 0", res.ExitCode)
+	}
+	if !strings.Contains(res.Stdout, "hello") {
+		t.Fatalf("Stdout = %q, want hello", res.Stdout)
+	}
+}
+
+func TestExecTimeout(t *testing.T) {
+	r := mustNewRunner(t)
+	_, err := r.Exec(context.Background(), "cmd",
+		[]string{"/c", "ping", "-n", "10", "127.0.0.1", ">nul"},
+		sandbox.ExecOptions{Timeout: 500 * time.Millisecond})
+	if err == nil {
+		t.Fatal("Exec succeeded, want timeout")
+	}
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("err = %v, want DeadlineExceeded", err)
+	}
+}
+
+func TestExecTruncatesOutput(t *testing.T) {
+	r := mustNewRunner(t)
+	const cap = 1024
+	res, err := r.Exec(context.Background(), "cmd",
+		[]string{"/c", "for", "/L", "%i", "in", "(1,1,200)", "do", "@echo", "xxxxxxxxxxxxxxxxxxxxxxxx"},
+		sandbox.ExecOptions{Resources: sandbox.ResourceLimits{MaxOutputBytes: cap}})
+	if err != nil {
+		t.Fatalf("Exec: %v", err)
+	}
+	if res.ExitCode != 0 {
+		t.Fatalf("ExitCode = %d, want 0", res.ExitCode)
+	}
+	if len(res.Stdout) != cap {
+		t.Fatalf("truncated Stdout len = %d, want %d", len(res.Stdout), cap)
+	}
+}
+
+func TestSessionReadAndExit(t *testing.T) {
+	r := mustNewRunner(t)
+	sess, err := r.Start(context.Background(), sandbox.SessionSpec{
+		Argv: []string{"cmd", "/c", "echo", "hello"},
+	})
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer func() { _ = sess.Close() }()
+
+	out, err := readAll(context.Background(), sess)
+	if err != nil {
+		t.Fatalf("Read: %v", err)
+	}
+	if !strings.Contains(out, "hello") {
+		t.Fatalf("output = %q, want hello", out)
+	}
+	exit, err := sess.Wait(context.Background())
+	if err != nil {
+		t.Fatalf("Wait: %v", err)
+	}
+	if exit.Code != 0 || exit.Reason != sandbox.SessionExited {
+		t.Fatalf("exit = %+v, want exited code 0", exit)
+	}
+}
+
+func TestSessionTerminate(t *testing.T) {
+	r := mustNewRunner(t)
+	sess, err := r.Start(context.Background(), sandbox.SessionSpec{
+		Argv: []string{"cmd", "/c", "ping", "-n", "20", "127.0.0.1", ">nul"},
+	})
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer func() { _ = sess.Close() }()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if err := sess.Terminate(ctx); err != nil {
+		t.Fatalf("Terminate: %v", err)
+	}
+	exit, err := sess.Wait(context.Background())
+	if err != nil {
+		t.Fatalf("Wait: %v", err)
+	}
+	if exit.Reason != sandbox.SessionTerminated {
+		t.Fatalf("exit = %+v, want SessionTerminated", exit)
+	}
+}
+
+func TestSessionStdin(t *testing.T) {
+	r := mustNewRunner(t)
+	sess, err := r.Start(context.Background(), sandbox.SessionSpec{
+		Argv: []string{"cmd", "/c", "more"},
+	})
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer func() { _ = sess.Close() }()
+
+	if err := sess.Write(context.Background(), []byte("hello world\r\n")); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	if err := sess.CloseInput(); err != nil {
+		t.Fatalf("CloseInput: %v", err)
+	}
+	out, err := readAll(context.Background(), sess)
+	if err != nil {
+		t.Fatalf("Read: %v", err)
+	}
+	if !strings.Contains(out, "hello world") {
+		t.Fatalf("output = %q, want echoed stdin", out)
+	}
+}
+
+// readAll drains the session until EOF or ctx is done.
+func readAll(ctx context.Context, sess sandbox.Session) (string, error) {
+	var b strings.Builder
+	after := int64(0)
+	for {
+		out, err := sess.Read(ctx, after, 64*1024)
+		if err != nil {
+			return "", err
+		}
+		for _, ch := range out.Chunks {
+			b.Write(ch.Data)
+		}
+		after = out.NextSeq
+		if out.EOF {
+			return b.String(), nil
+		}
+	}
+}

--- a/core/sandbox/windows/integration_windows_test.go
+++ b/core/sandbox/windows/integration_windows_test.go
@@ -142,6 +142,173 @@ func TestSessionStdin(t *testing.T) {
 	}
 }
 
+func TestRunnerAdvertisesTTY(t *testing.T) {
+	r := mustNewRunner(t)
+	if !r.Capabilities().Features.TTY {
+		t.Fatal("Capabilities().Features.TTY = false, want true")
+	}
+}
+
+func TestPipeSessionReportsNoTTY(t *testing.T) {
+	r := mustNewRunner(t)
+	sess, err := r.Start(context.Background(), sandbox.SessionSpec{
+		Argv: []string{"cmd", "/c", "ver"},
+	})
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer func() { _ = sess.Close() }()
+	if sess.Capabilities().TTY {
+		t.Fatal("pipe session reports TTY = true, want false")
+	}
+}
+
+func TestSessionTTYEcho(t *testing.T) {
+	r := mustNewRunner(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+	sess, err := r.Start(ctx, sandbox.SessionSpec{
+		Argv: []string{"cmd", "/c", "echo", "hello", "tty"},
+		TTY:  true,
+	})
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer func() { _ = sess.Close() }()
+
+	if !sess.Capabilities().TTY {
+		t.Fatal("Capabilities().TTY = false, want true")
+	}
+	out, err := readAll(ctx, sess)
+	if err != nil {
+		t.Fatalf("Read: %v", err)
+	}
+	if !strings.Contains(out, "hello tty") {
+		t.Fatalf("output = %q, want 'hello tty'", out)
+	}
+	exit, err := sess.Wait(ctx)
+	if err != nil {
+		t.Fatalf("Wait: %v", err)
+	}
+	if exit.Code != 0 || exit.Reason != sandbox.SessionExited {
+		t.Fatalf("exit = %+v, want exited code 0", exit)
+	}
+}
+
+func TestSessionTTYInteractive(t *testing.T) {
+	r := mustNewRunner(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+	sess, err := r.Start(ctx, sandbox.SessionSpec{
+		Argv: []string{"cmd"},
+		TTY:  true,
+	})
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer func() { _ = sess.Close() }()
+
+	if err := sess.Write(ctx, []byte("echo conpty-hi\r\n")); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	if err := sess.Write(ctx, []byte("exit\r\n")); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	out, err := readAll(ctx, sess)
+	if err != nil {
+		t.Fatalf("Read: %v", err)
+	}
+	if !strings.Contains(out, "conpty-hi") {
+		t.Fatalf("output = %q, want echoed 'conpty-hi'", out)
+	}
+	exit, err := sess.Wait(ctx)
+	if err != nil {
+		t.Fatalf("Wait: %v", err)
+	}
+	if exit.Code != 0 || exit.Reason != sandbox.SessionExited {
+		t.Fatalf("exit = %+v, want exited code 0", exit)
+	}
+}
+
+func TestSessionTTYResize(t *testing.T) {
+	r := mustNewRunner(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+	sess, err := r.Start(ctx, sandbox.SessionSpec{
+		Argv: []string{"cmd"},
+		TTY:  true,
+		Rows: 30,
+		Cols: 100,
+	})
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer func() { _ = sess.Close() }()
+
+	if err := sess.Resize(ctx, 40, 120); err != nil {
+		t.Fatalf("Resize: %v", err)
+	}
+	if err := sess.Resize(ctx, 0, 120); err == nil {
+		t.Fatal("Resize with zero rows succeeded, want validation error")
+	}
+	if err := sess.Write(ctx, []byte("exit\r\n")); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	if _, err := readAll(ctx, sess); err != nil {
+		t.Fatalf("Read: %v", err)
+	}
+	exit, err := sess.Wait(ctx)
+	if err != nil {
+		t.Fatalf("Wait: %v", err)
+	}
+	if exit.Code != 0 {
+		t.Fatalf("exit = %+v, want code 0", exit)
+	}
+}
+
+func TestSessionTTYCloseInputNotAvailable(t *testing.T) {
+	r := mustNewRunner(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+	sess, err := r.Start(ctx, sandbox.SessionSpec{
+		Argv: []string{"cmd"},
+		TTY:  true,
+	})
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer func() { _ = sess.Close() }()
+
+	if err := sess.CloseInput(); !errdefs.IsNotAvailable(err) {
+		t.Fatalf("CloseInput err = %v, want NotAvailable", err)
+	}
+	if err := sess.Write(ctx, []byte("exit\r\n")); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	if _, err := readAll(ctx, sess); err != nil {
+		t.Fatalf("Read: %v", err)
+	}
+}
+
+func TestSessionTTYWithConfinementNotAvailable(t *testing.T) {
+	r, err := New(t.TempDir(), WithWriteConfinement())
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	t.Cleanup(func() { _ = r.Close() })
+
+	_, err = r.Start(context.Background(), sandbox.SessionSpec{
+		Argv: []string{"cmd"},
+		TTY:  true,
+	})
+	if err == nil {
+		t.Fatal("Start succeeded, want NotAvailable")
+	}
+	if !errdefs.IsNotAvailable(err) {
+		t.Fatalf("err = %v, want NotAvailable", err)
+	}
+}
+
 func TestExecBudgetExceededMemory(t *testing.T) {
 	r := mustNewRunner(t)
 	_, err := r.Exec(context.Background(), "powershell",

--- a/core/sandbox/windows/integration_windows_test.go
+++ b/core/sandbox/windows/integration_windows_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/GizClaw/flowcraft/core/errdefs"
 	"github.com/GizClaw/flowcraft/core/sandbox"
 )
 
@@ -138,6 +139,42 @@ func TestSessionStdin(t *testing.T) {
 	}
 	if !strings.Contains(out, "hello world") {
 		t.Fatalf("output = %q, want echoed stdin", out)
+	}
+}
+
+func TestExecBudgetExceededMemory(t *testing.T) {
+	r := mustNewRunner(t)
+	_, err := r.Exec(context.Background(), "powershell",
+		[]string{"-NoProfile", "-Command", "$a = New-Object byte[] 400MB"},
+		sandbox.ExecOptions{
+			Timeout: 20 * time.Second,
+			Resources: sandbox.ResourceLimits{
+				MemoryBytes: 32 << 20,
+			},
+		})
+	if err == nil {
+		t.Fatal("Exec succeeded, want budget exceeded")
+	}
+	if !errdefs.IsBudgetExceeded(err) {
+		t.Fatalf("err = %v, want BudgetExceeded", err)
+	}
+}
+
+func TestExecBudgetExceededCPU(t *testing.T) {
+	r := mustNewRunner(t)
+	_, err := r.Exec(context.Background(), "powershell",
+		[]string{"-NoProfile", "-Command", "while ($true) { 1 }"},
+		sandbox.ExecOptions{
+			Timeout: 10 * time.Second,
+			Resources: sandbox.ResourceLimits{
+				CPUMillicores: 200,
+			},
+		})
+	if err == nil {
+		t.Fatal("Exec succeeded, want budget exceeded")
+	}
+	if !errdefs.IsBudgetExceeded(err) {
+		t.Fatalf("err = %v, want BudgetExceeded", err)
 	}
 }
 

--- a/core/sandbox/windows/integration_windows_test.go
+++ b/core/sandbox/windows/integration_windows_test.go
@@ -149,6 +149,41 @@ func TestRunnerAdvertisesTTY(t *testing.T) {
 	}
 }
 
+func TestContainedInRootFoldsCase(t *testing.T) {
+	cases := []struct {
+		path string
+		root string
+		want bool
+	}{
+		{`C:\Work\WS`, `c:\work\ws`, true},
+		{`C:\Work\WS\sub`, `c:\work\ws`, true},
+		{`C:\Work\WS\Sub\file.txt`, `c:\work\ws`, true},
+		{`C:\Work\WS2`, `c:\work\ws`, false},    // sibling prefix
+		{`C:\Work\WS\x`, `c:\work\ws\y`, false}, // different subtree
+	}
+	for _, tc := range cases {
+		if got := containedInRoot(tc.path, tc.root); got != tc.want {
+			t.Errorf("containedInRoot(%q, %q) = %v, want %v", tc.path, tc.root, got, tc.want)
+		}
+	}
+}
+
+func TestResolveWorkDirCaseVariant(t *testing.T) {
+	r := mustNewRunner(t)
+	// An absolute workdir spelled with a different case than the root
+	// must still resolve: EvalExistingPrefix canonicalizes the existing
+	// part, and the containment check folds case as a second line of
+	// defense.
+	alt := strings.ToUpper(r.rootDir)
+	got, err := r.resolveWorkDir(alt)
+	if err != nil {
+		t.Fatalf("resolveWorkDir(case variant) = _, %v", err)
+	}
+	if !strings.EqualFold(got, r.rootDir) {
+		t.Fatalf("resolveWorkDir = %q, want under root %q", got, r.rootDir)
+	}
+}
+
 func TestPipeSessionReportsNoTTY(t *testing.T) {
 	r := mustNewRunner(t)
 	sess, err := r.Start(context.Background(), sandbox.SessionSpec{

--- a/core/sandbox/windows/integration_windows_test.go
+++ b/core/sandbox/windows/integration_windows_test.go
@@ -364,10 +364,15 @@ func TestExecBudgetExceededMemory(t *testing.T) {
 
 func TestExecBudgetExceededCPU(t *testing.T) {
 	r := mustNewRunner(t)
-	_, err := r.Exec(context.Background(), "cmd",
-		[]string{"/c", "for /L %i in (1,1,100000000) do rem"},
+	// A tight PowerShell loop burns a full core as user time. The
+	// budget is Timeout x millicores / 1000 = 3s of user time, which
+	// the loop exhausts in a few seconds of wall clock, well inside
+	// the 30s deadline — unlike a cmd `for /L ... do rem` loop, which
+	// can idle in kernel waits and miss a tight 10s window.
+	_, err := r.Exec(context.Background(), "powershell",
+		[]string{"-NoProfile", "-Command", "$x = 0L; while ($true) { $x++ }"},
 		sandbox.ExecOptions{
-			Timeout: 10 * time.Second,
+			Timeout: 30 * time.Second,
 			Resources: sandbox.ResourceLimits{
 				CPUMillicores: 100,
 			},

--- a/core/sandbox/windows/integration_windows_test.go
+++ b/core/sandbox/windows/integration_windows_test.go
@@ -163,11 +163,11 @@ func TestExecBudgetExceededMemory(t *testing.T) {
 func TestExecBudgetExceededCPU(t *testing.T) {
 	r := mustNewRunner(t)
 	_, err := r.Exec(context.Background(), "powershell",
-		[]string{"-NoProfile", "-Command", "while ($true) { 1 }"},
+		[]string{"-NoProfile", "-Command", "while ($true) { }"},
 		sandbox.ExecOptions{
-			Timeout: 10 * time.Second,
+			Timeout: 5 * time.Second,
 			Resources: sandbox.ResourceLimits{
-				CPUMillicores: 200,
+				CPUMillicores: 100,
 			},
 		})
 	if err == nil {

--- a/core/sandbox/windows/job_windows.go
+++ b/core/sandbox/windows/job_windows.go
@@ -25,6 +25,7 @@ type job struct {
 
 // Job completion-port message codes (winnt.h).
 const (
+	jobObjectMsgEndOfJobTime     = 1
 	jobObjectMsgEndOfProcessTime = 3
 	jobObjectMsgJobMemoryLimit   = 10
 
@@ -83,7 +84,7 @@ func (n *jobNotifier) run() {
 		switch qty {
 		case jobObjectMsgJobMemoryLimit:
 			n.setBudget("memory")
-		case jobObjectMsgEndOfProcessTime:
+		case jobObjectMsgEndOfJobTime, jobObjectMsgEndOfProcessTime:
 			n.setBudget("cpu")
 		}
 	}
@@ -167,10 +168,10 @@ func (j *job) budgetCap() string {
 // jobLimits maps sandbox.ResourceLimits onto the Windows extended
 // limit structure. MemoryBytes becomes a job-wide cap (the same
 // "aggregate process group" semantics as the unix watcher);
-// CPUMillicores becomes a per-process user-time cap derived from
-// Timeout x millicores/1000 (the same budget the unix watcher
-// enforces, but enforced by the kernel per process rather than
-// sampled across the group).
+// CPUMillicores becomes a job-wide user-time budget derived from
+// Timeout x millicores/1000. When the job-wide budget is exhausted the
+// kernel terminates every process in the job and posts
+// JOB_OBJECT_MSG_END_OF_JOB_TIME.
 func jobLimits(limits sandbox.ResourceLimits, timeout time.Duration) xwin.JOBOBJECT_EXTENDED_LIMIT_INFORMATION {
 	var info xwin.JOBOBJECT_EXTENDED_LIMIT_INFORMATION
 	info.BasicLimitInformation.LimitFlags |= xwin.JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE
@@ -179,8 +180,8 @@ func jobLimits(limits sandbox.ResourceLimits, timeout time.Duration) xwin.JOBOBJ
 		info.JobMemoryLimit = uintptr(limits.MemoryBytes)
 	}
 	if limits.CPUMillicores > 0 {
-		info.BasicLimitInformation.LimitFlags |= xwin.JOB_OBJECT_LIMIT_PROCESS_TIME
-		info.BasicLimitInformation.PerProcessUserTimeLimit = cpuBudget100ns(limits, timeout)
+		info.BasicLimitInformation.LimitFlags |= xwin.JOB_OBJECT_LIMIT_JOB_TIME
+		info.BasicLimitInformation.PerJobUserTimeLimit = cpuBudget100ns(limits, timeout)
 	}
 	return info
 }

--- a/core/sandbox/windows/job_windows.go
+++ b/core/sandbox/windows/job_windows.go
@@ -1,0 +1,156 @@
+//go:build windows
+
+package windows
+
+import (
+	"errors"
+	"fmt"
+	"time"
+	"unsafe"
+
+	"github.com/GizClaw/flowcraft/core/errdefs"
+	"github.com/GizClaw/flowcraft/core/sandbox"
+	xwin "golang.org/x/sys/windows"
+)
+
+// job wraps a Windows Job Object. A job is the kernel-level process
+// group: processes assigned to it are managed as a unit, so
+// terminating the job kills every descendant (not just the leader)
+// and job limits apply across the whole tree.
+type job struct {
+	h xwin.Handle
+}
+
+// createJob creates an anonymous job with limits derived from the
+// policy. KILL_ON_JOB_CLOSE is always set: when the last job handle
+// closes (including on spawn failure paths), every associated process
+// is terminated, so a partially-started session can never leak a
+// process.
+func createJob(limits sandbox.ResourceLimits, timeout time.Duration) (*job, error) {
+	h, err := xwin.CreateJobObject(nil, nil)
+	if err != nil {
+		return nil, errdefs.Internal(fmt.Errorf("windows: create job object: %w", err))
+	}
+	j := &job{h: h}
+	info := jobLimits(limits, timeout)
+	if _, err := xwin.SetInformationJobObject(
+		h, xwin.JobObjectExtendedLimitInformation,
+		uintptr(unsafe.Pointer(&info)), uint32(unsafe.Sizeof(info)),
+	); err != nil {
+		_ = j.close()
+		return nil, errdefs.Internal(fmt.Errorf("windows: set job limits: %w", err))
+	}
+	return j, nil
+}
+
+// jobLimits maps sandbox.ResourceLimits onto the Windows extended
+// limit structure. MemoryBytes becomes a job-wide cap (the same
+// "aggregate process group" semantics as the unix watcher);
+// CPUMillicores becomes a per-process user-time cap derived from
+// Timeout x millicores/1000 (the same budget the unix watcher
+// enforces, but enforced by the kernel per process rather than
+// sampled across the group).
+func jobLimits(limits sandbox.ResourceLimits, timeout time.Duration) xwin.JOBOBJECT_EXTENDED_LIMIT_INFORMATION {
+	var info xwin.JOBOBJECT_EXTENDED_LIMIT_INFORMATION
+	info.BasicLimitInformation.LimitFlags |= xwin.JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE
+	if limits.MemoryBytes > 0 {
+		info.BasicLimitInformation.LimitFlags |= xwin.JOB_OBJECT_LIMIT_JOB_MEMORY
+		info.JobMemoryLimit = uintptr(limits.MemoryBytes)
+	}
+	if limits.CPUMillicores > 0 {
+		info.BasicLimitInformation.LimitFlags |= xwin.JOB_OBJECT_LIMIT_PROCESS_TIME
+		info.BasicLimitInformation.PerProcessUserTimeLimit = cpuBudget100ns(limits, timeout)
+	}
+	return info
+}
+
+// cpuBudget100ns derives the per-process user-time budget in
+// 100-nanosecond units (the unit Windows job limits use) from
+// CPUMillicores and the wall-clock Timeout: budget = Timeout x
+// millicores / 1000, matching sandbox.ResourceLimits semantics.
+func cpuBudget100ns(limits sandbox.ResourceLimits, timeout time.Duration) int64 {
+	if limits.CPUMillicores <= 0 || timeout <= 0 {
+		return 0
+	}
+	budgetNs := timeout.Nanoseconds() * int64(limits.CPUMillicores) / 1000
+	return budgetNs / 100
+}
+
+// assign adds the process to the job. AssignProcessToJobObject
+// requires PROCESS_SET_QUOTA and PROCESS_TERMINATE on the handle.
+func (j *job) assign(pid int) error {
+	h, err := xwin.OpenProcess(
+		xwin.PROCESS_SET_QUOTA|xwin.PROCESS_TERMINATE, false, uint32(pid))
+	if err != nil {
+		return errdefs.Internal(fmt.Errorf("windows: open process %d: %w", pid, err))
+	}
+	defer func() { _ = xwin.CloseHandle(h) }()
+	if err := xwin.AssignProcessToJobObject(j.h, h); err != nil {
+		return errdefs.Internal(fmt.Errorf("windows: assign process %d to job: %w", pid, err))
+	}
+	return nil
+}
+
+// terminate stops every process in the job. Windows has no SIGTERM:
+// this is the only whole-tree stop and it is immediate. A job that
+// already has no processes reports ERROR_ACCESS_DENIED, which is a
+// successful no-op.
+func (j *job) terminate() error {
+	if err := xwin.TerminateJobObject(j.h, 1); err != nil {
+		if errors.Is(err, xwin.ERROR_ACCESS_DENIED) {
+			return nil
+		}
+		return errdefs.Internal(fmt.Errorf("windows: terminate job: %w", err))
+	}
+	return nil
+}
+
+// close releases the job handle. With KILL_ON_JOB_CLOSE set, closing
+// the last handle terminates all remaining processes.
+func (j *job) close() error {
+	return xwin.CloseHandle(j.h)
+}
+
+// resumeProcess resumes every suspended thread of pid. The process is
+// created with CREATE_SUSPENDED so it can be assigned to the job
+// before any user code runs; only the primary thread starts
+// suspended, so resuming all matching threads is safe (ResumeThread
+// on an already-running thread is a no-op).
+func resumeProcess(pid int) error {
+	snapshot, err := xwin.CreateToolhelp32Snapshot(xwin.TH32CS_SNAPTHREAD, uint32(pid))
+	if err != nil {
+		return errdefs.Internal(fmt.Errorf("windows: snapshot threads of %d: %w", pid, err))
+	}
+	defer func() { _ = xwin.CloseHandle(snapshot) }()
+
+	var entry xwin.ThreadEntry32
+	entry.Size = uint32(unsafe.Sizeof(entry))
+	if err := xwin.Thread32First(snapshot, &entry); err != nil {
+		return errdefs.Internal(fmt.Errorf("windows: first thread of %d: %w", pid, err))
+	}
+	for {
+		if int(entry.OwnerProcessID) == pid && entry.ThreadID != 0 {
+			if err := resumeThread(entry.ThreadID); err != nil {
+				return err
+			}
+		}
+		if err := xwin.Thread32Next(snapshot, &entry); err != nil {
+			if errors.Is(err, xwin.ERROR_NO_MORE_FILES) {
+				return nil
+			}
+			return errdefs.Internal(fmt.Errorf("windows: next thread of %d: %w", pid, err))
+		}
+	}
+}
+
+func resumeThread(tid uint32) error {
+	h, err := xwin.OpenThread(xwin.THREAD_SUSPEND_RESUME, false, tid)
+	if err != nil {
+		return errdefs.Internal(fmt.Errorf("windows: open thread %d: %w", tid, err))
+	}
+	defer func() { _ = xwin.CloseHandle(h) }()
+	if _, err := xwin.ResumeThread(h); err != nil {
+		return errdefs.Internal(fmt.Errorf("windows: resume thread %d: %w", tid, err))
+	}
+	return nil
+}

--- a/core/sandbox/windows/job_windows.go
+++ b/core/sandbox/windows/job_windows.go
@@ -5,6 +5,7 @@ package windows
 import (
 	"errors"
 	"fmt"
+	"sync"
 	"time"
 	"unsafe"
 
@@ -18,7 +19,111 @@ import (
 // terminating the job kills every descendant (not just the leader)
 // and job limits apply across the whole tree.
 type job struct {
-	h xwin.Handle
+	h      xwin.Handle
+	notify *jobNotifier // nil when no resource caps are configured
+}
+
+// Job completion-port message codes (winnt.h).
+const (
+	jobObjectMsgEndOfProcessTime = 3
+	jobObjectMsgJobMemoryLimit   = 10
+
+	// notifierKey is the completion key recorded in the job
+	// association; notifierStop is the sentinel posted to shut the
+	// notifier down. The two must differ so a stop cannot be confused
+	// with a job message (which carries notifierKey).
+	notifierKey  = uintptr(0x5A5A5A5A)
+	notifierStop = uintptr(0x5A5A5A5B)
+)
+
+// associateCompletionPort mirrors JOBOBJECT_ASSOCIATE_COMPLETION_PORT.
+type associateCompletionPort struct {
+	CompletionKey  uintptr
+	CompletionPort xwin.Handle
+}
+
+// jobNotifier drains a job object's completion port and records which
+// resource cap the kernel enforced, so a cap kill can be classified as
+// SessionBudgetExceeded instead of a plain exit.
+type jobNotifier struct {
+	port   xwin.Handle
+	done   chan struct{}
+	mu     sync.Mutex
+	budget string // "memory" or "cpu"; first cap wins
+}
+
+func (n *jobNotifier) setBudget(cap string) {
+	n.mu.Lock()
+	if n.budget == "" {
+		n.budget = cap
+	}
+	n.mu.Unlock()
+}
+
+func (n *jobNotifier) budgetCap() string {
+	n.mu.Lock()
+	defer n.mu.Unlock()
+	return n.budget
+}
+
+// run drains completion messages until stop posts the sentinel or the
+// port is closed.
+func (n *jobNotifier) run() {
+	defer close(n.done)
+	for {
+		var qty uint32
+		var key uintptr
+		var ovl *xwin.Overlapped
+		if err := xwin.GetQueuedCompletionStatus(n.port, &qty, &key, &ovl, xwin.INFINITE); err != nil {
+			return
+		}
+		if key == notifierStop {
+			return
+		}
+		switch qty {
+		case jobObjectMsgJobMemoryLimit:
+			n.setBudget("memory")
+		case jobObjectMsgEndOfProcessTime:
+			n.setBudget("cpu")
+		}
+	}
+}
+
+// stop posts the sentinel, waits for the drain goroutine (bounded),
+// and closes the port.
+func (n *jobNotifier) stop() {
+	if n == nil {
+		return
+	}
+	_ = xwin.PostQueuedCompletionStatus(n.port, 0, notifierStop, nil)
+	select {
+	case <-n.done:
+	case <-time.After(2 * time.Second):
+	}
+	_ = xwin.CloseHandle(n.port)
+}
+
+// newJobNotifier creates a completion port, associates it with the job
+// so limit-violation messages are delivered, and starts the drain
+// goroutine.
+func newJobNotifier(jobHandle xwin.Handle) (*jobNotifier, error) {
+	port, err := xwin.CreateIoCompletionPort(xwin.InvalidHandle, 0, 0, 1)
+	if err != nil {
+		return nil, errdefs.Internal(fmt.Errorf("windows: create job completion port: %w", err))
+	}
+	n := &jobNotifier{
+		port: port,
+		done: make(chan struct{}),
+	}
+	assoc := associateCompletionPort{CompletionKey: notifierKey, CompletionPort: port}
+	if _, err := xwin.SetInformationJobObject(jobHandle,
+		xwin.JobObjectAssociateCompletionPortInformation,
+		uintptr(unsafe.Pointer(&assoc)), uint32(unsafe.Sizeof(assoc))); err != nil {
+		_ = xwin.CloseHandle(port)
+		return nil, errdefs.Internal(fmt.Errorf("windows: associate job completion port: %w", err))
+	}
+	go n.run()
+	return n, nil
 }
 
 // createJob creates an anonymous job with limits derived from the
@@ -40,7 +145,23 @@ func createJob(limits sandbox.ResourceLimits, timeout time.Duration) (*job, erro
 		_ = j.close()
 		return nil, errdefs.Internal(fmt.Errorf("windows: set job limits: %w", err))
 	}
+	if limits.MemoryBytes > 0 || limits.CPUMillicores > 0 {
+		notify, err := newJobNotifier(h)
+		if err != nil {
+			_ = j.close()
+			return nil, err
+		}
+		j.notify = notify
+	}
 	return j, nil
+}
+
+// budgetCap reports which resource cap the kernel enforced, if any.
+func (j *job) budgetCap() string {
+	if j.notify == nil {
+		return ""
+	}
+	return j.notify.budgetCap()
 }
 
 // jobLimits maps sandbox.ResourceLimits onto the Windows extended
@@ -108,6 +229,9 @@ func (j *job) terminate() error {
 // close releases the job handle. With KILL_ON_JOB_CLOSE set, closing
 // the last handle terminates all remaining processes.
 func (j *job) close() error {
+	if j.notify != nil {
+		j.notify.stop()
+	}
 	return xwin.CloseHandle(j.h)
 }
 

--- a/core/sandbox/windows/limits_windows_test.go
+++ b/core/sandbox/windows/limits_windows_test.go
@@ -86,6 +86,11 @@ func TestValidatePolicy(t *testing.T) {
 	if err := r.validatePolicy(valid); err != nil {
 		t.Fatalf("valid policy rejected: %v", err)
 	}
+	denyAll := valid
+	denyAll.Opts.Net = corenet.NetPolicy{Mode: corenet.NetDenyAll}
+	if err := r.validatePolicy(denyAll); err != nil {
+		t.Fatalf("net deny-all policy rejected: %v", err)
+	}
 
 	cases := []struct {
 		name string
@@ -98,10 +103,6 @@ func TestValidatePolicy(t *testing.T) {
 		{
 			name: "unknown write policy",
 			spec: sandbox.SessionSpec{Opts: sandbox.ExecOptions{Write: sandbox.WritePolicy(99)}},
-		},
-		{
-			name: "net deny all",
-			spec: sandbox.SessionSpec{Opts: sandbox.ExecOptions{Net: corenet.NetPolicy{Mode: corenet.NetDenyAll}}},
 		},
 		{
 			name: "disk limit",

--- a/core/sandbox/windows/limits_windows_test.go
+++ b/core/sandbox/windows/limits_windows_test.go
@@ -42,12 +42,12 @@ func TestJobLimitsMemory(t *testing.T) {
 func TestJobLimitsCPU(t *testing.T) {
 	info := jobLimits(sandbox.ResourceLimits{CPUMillicores: 500}, 2*time.Second)
 	flags := info.BasicLimitInformation.LimitFlags
-	if flags&xwin.JOB_OBJECT_LIMIT_PROCESS_TIME == 0 {
-		t.Fatalf("LimitFlags = %#x, want JOB_OBJECT_LIMIT_PROCESS_TIME set", flags)
+	if flags&xwin.JOB_OBJECT_LIMIT_JOB_TIME == 0 {
+		t.Fatalf("LimitFlags = %#x, want JOB_OBJECT_LIMIT_JOB_TIME set", flags)
 	}
 	// 2s x 500/1000 = 1s budget in 100ns units.
-	if got := info.BasicLimitInformation.PerProcessUserTimeLimit; got != 10_000_000 {
-		t.Fatalf("PerProcessUserTimeLimit = %d, want %d", got, 10_000_000)
+	if got := info.BasicLimitInformation.PerJobUserTimeLimit; got != 10_000_000 {
+		t.Fatalf("PerJobUserTimeLimit = %d, want %d", got, 10_000_000)
 	}
 	if info.JobMemoryLimit != 0 {
 		t.Fatalf("JobMemoryLimit = %d, want 0", info.JobMemoryLimit)
@@ -59,15 +59,15 @@ func TestJobLimitsBoth(t *testing.T) {
 	flags := info.BasicLimitInformation.LimitFlags
 	want := uint32(xwin.JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE) |
 		xwin.JOB_OBJECT_LIMIT_JOB_MEMORY |
-		xwin.JOB_OBJECT_LIMIT_PROCESS_TIME
+		xwin.JOB_OBJECT_LIMIT_JOB_TIME
 	if flags != want {
 		t.Fatalf("LimitFlags = %#x, want %#x", flags, want)
 	}
 	if info.JobMemoryLimit != 1<<20 {
 		t.Fatalf("JobMemoryLimit = %d, want %d", info.JobMemoryLimit, 1<<20)
 	}
-	if got := info.BasicLimitInformation.PerProcessUserTimeLimit; got != 10_000_000 {
-		t.Fatalf("PerProcessUserTimeLimit = %d, want %d", got, 10_000_000)
+	if got := info.BasicLimitInformation.PerJobUserTimeLimit; got != 10_000_000 {
+		t.Fatalf("PerJobUserTimeLimit = %d, want %d", got, 10_000_000)
 	}
 }
 

--- a/core/sandbox/windows/limits_windows_test.go
+++ b/core/sandbox/windows/limits_windows_test.go
@@ -1,0 +1,151 @@
+//go:build windows
+
+package windows
+
+import (
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/GizClaw/flowcraft/core/errdefs"
+	"github.com/GizClaw/flowcraft/core/sandbox"
+	corenet "github.com/GizClaw/flowcraft/core/utils/net"
+	xwin "golang.org/x/sys/windows"
+)
+
+func TestJobLimitsNone(t *testing.T) {
+	info := jobLimits(sandbox.ResourceLimits{}, 0)
+	if got := info.BasicLimitInformation.LimitFlags; got != xwin.JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE {
+		t.Fatalf("LimitFlags = %#x, want KILL_ON_JOB_CLOSE (%#x)", got, xwin.JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE)
+	}
+	if info.JobMemoryLimit != 0 || info.BasicLimitInformation.PerProcessUserTimeLimit != 0 {
+		t.Fatalf("unexpected limits set: memory=%d cpu=%d",
+			info.JobMemoryLimit, info.BasicLimitInformation.PerProcessUserTimeLimit)
+	}
+}
+
+func TestJobLimitsMemory(t *testing.T) {
+	info := jobLimits(sandbox.ResourceLimits{MemoryBytes: 64 << 20}, 0)
+	flags := info.BasicLimitInformation.LimitFlags
+	if flags&xwin.JOB_OBJECT_LIMIT_JOB_MEMORY == 0 {
+		t.Fatalf("LimitFlags = %#x, want JOB_OBJECT_LIMIT_JOB_MEMORY set", flags)
+	}
+	if info.JobMemoryLimit != 64<<20 {
+		t.Fatalf("JobMemoryLimit = %d, want %d", info.JobMemoryLimit, 64<<20)
+	}
+	if info.BasicLimitInformation.PerProcessUserTimeLimit != 0 {
+		t.Fatalf("PerProcessUserTimeLimit = %d, want 0", info.BasicLimitInformation.PerProcessUserTimeLimit)
+	}
+}
+
+func TestJobLimitsCPU(t *testing.T) {
+	info := jobLimits(sandbox.ResourceLimits{CPUMillicores: 500}, 2*time.Second)
+	flags := info.BasicLimitInformation.LimitFlags
+	if flags&xwin.JOB_OBJECT_LIMIT_PROCESS_TIME == 0 {
+		t.Fatalf("LimitFlags = %#x, want JOB_OBJECT_LIMIT_PROCESS_TIME set", flags)
+	}
+	// 2s x 500/1000 = 1s budget in 100ns units.
+	if got := info.BasicLimitInformation.PerProcessUserTimeLimit; got != 10_000_000 {
+		t.Fatalf("PerProcessUserTimeLimit = %d, want %d", got, 10_000_000)
+	}
+	if info.JobMemoryLimit != 0 {
+		t.Fatalf("JobMemoryLimit = %d, want 0", info.JobMemoryLimit)
+	}
+}
+
+func TestJobLimitsBoth(t *testing.T) {
+	info := jobLimits(sandbox.ResourceLimits{MemoryBytes: 1 << 20, CPUMillicores: 1000}, time.Second)
+	flags := info.BasicLimitInformation.LimitFlags
+	want := uint32(xwin.JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE) |
+		xwin.JOB_OBJECT_LIMIT_JOB_MEMORY |
+		xwin.JOB_OBJECT_LIMIT_PROCESS_TIME
+	if flags != want {
+		t.Fatalf("LimitFlags = %#x, want %#x", flags, want)
+	}
+	if info.JobMemoryLimit != 1<<20 {
+		t.Fatalf("JobMemoryLimit = %d, want %d", info.JobMemoryLimit, 1<<20)
+	}
+	if got := info.BasicLimitInformation.PerProcessUserTimeLimit; got != 10_000_000 {
+		t.Fatalf("PerProcessUserTimeLimit = %d, want %d", got, 10_000_000)
+	}
+}
+
+func TestValidatePolicy(t *testing.T) {
+	r := &Runner{}
+	valid := sandbox.SessionSpec{
+		Argv: []string{"cmd.exe"},
+		Opts: sandbox.ExecOptions{
+			Timeout: time.Second,
+			Resources: sandbox.ResourceLimits{
+				MemoryBytes:   1 << 20,
+				CPUMillicores: 500,
+			},
+		},
+	}
+	if err := r.validatePolicy(valid); err != nil {
+		t.Fatalf("valid policy rejected: %v", err)
+	}
+
+	cases := []struct {
+		name string
+		spec sandbox.SessionSpec
+	}{
+		{
+			name: "write read only",
+			spec: sandbox.SessionSpec{Opts: sandbox.ExecOptions{Write: sandbox.WriteReadOnly}},
+		},
+		{
+			name: "unknown write policy",
+			spec: sandbox.SessionSpec{Opts: sandbox.ExecOptions{Write: sandbox.WritePolicy(99)}},
+		},
+		{
+			name: "net deny all",
+			spec: sandbox.SessionSpec{Opts: sandbox.ExecOptions{Net: corenet.NetPolicy{Mode: corenet.NetDenyAll}}},
+		},
+		{
+			name: "disk limit",
+			spec: sandbox.SessionSpec{Opts: sandbox.ExecOptions{Resources: sandbox.ResourceLimits{DiskBytes: 1}}},
+		},
+		{
+			name: "cpu without timeout",
+			spec: sandbox.SessionSpec{Opts: sandbox.ExecOptions{Resources: sandbox.ResourceLimits{CPUMillicores: 500}}},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if err := r.validatePolicy(tc.spec); !errdefs.IsNotAvailable(err) && !errdefs.IsValidation(err) {
+				t.Fatalf("err = %v, want NotAvailable/Validation", err)
+			}
+		})
+	}
+}
+
+func TestBuildEnvInheritAll(t *testing.T) {
+	got := buildEnv(sandbox.EnvPolicy{})
+	if len(got) != len(os.Environ()) {
+		t.Fatalf("len = %d, want %d", len(got), len(os.Environ()))
+	}
+}
+
+func TestBuildEnvInheritNothing(t *testing.T) {
+	got := buildEnv(sandbox.EnvPolicy{Allow: []string{}})
+	if got == nil || len(got) != 0 {
+		t.Fatalf("got = %#v, want empty non-nil slice", got)
+	}
+}
+
+func TestBuildEnvAllowAndInject(t *testing.T) {
+	got := buildEnv(sandbox.EnvPolicy{
+		Allow:  []string{"PATH"},
+		Inject: map[string]string{"FOO": "bar"},
+	})
+	seen := map[string]bool{}
+	for _, kv := range got {
+		key, _, _ := strings.Cut(kv, "=")
+		seen[key] = true
+	}
+	if len(seen) != 2 || !seen["PATH"] || !seen["FOO"] {
+		t.Fatalf("keys = %v, want PATH and FOO only", seen)
+	}
+}

--- a/core/sandbox/windows/netisolation_windows.go
+++ b/core/sandbox/windows/netisolation_windows.go
@@ -29,12 +29,20 @@ import (
 // restrictions (and, for allow_list / proxy modes, WFP filters) can
 // be scoped to exactly the sandboxed process tree.
 //
-// An AppContainer without network capabilities is denied all network
-// access by the OS firewall — that is how NetDenyAll is enforced with
-// no WFP involvement. Writable paths are granted to the package SID
-// through the filesystem DACL, and HOME / TEMP are redirected into a
-// per-runner sandbox directory, because AppContainers cannot read the
-// user profile by default.
+// The container is created without any network capability, so the OS
+// firewall's built-in AppIsolation sublayer denies all network access
+// by default — that is how NetDenyAll is enforced with no WFP
+// involvement. Allow-list / proxy modes add a maximum-weight WFP
+// sublayer that permits only TCP to the loopback enforcement proxy;
+// every other packet (unconnected UDP, ICMP, inbound, raw, ...) still
+// falls through to the AppIsolation default-deny. Dropping
+// internetClient entirely is what closes the unconnected-UDP sendto
+// bypass: ALE_AUTH_CONNECT filters never see those packets, but a
+// capability-less container has no firewall baseline to allow them.
+// Writable paths are granted to the package SID through the filesystem
+// DACL, and HOME / TEMP are redirected into a per-runner sandbox
+// directory, because AppContainers cannot read the user profile by
+// default.
 type netIsolation struct {
 	name  string
 	sid   *xwin.SID
@@ -66,18 +74,13 @@ func newNetIsolation(root string, writable []string, policy corenet.NetPolicy) (
 	}
 	name := "flowcraft.sandbox." + hex.EncodeToString(raw[:])
 
+	// No network capabilities in any mode. The built-in AppIsolation
+	// firewall sublayer denies all network for a capability-less
+	// container; allow-list / proxy modes add a higher-weight WFP
+	// permit sublayer for the loopback proxy only, so everything else
+	// (including unconnected UDP sendto, which never reaches the
+	// ALE_AUTH_CONNECT filters) is still denied by default.
 	var caps []*xwin.SID
-	var err error
-	if mode != corenet.NetDenyAll {
-		// InternetClient lets the OS firewall baseline "outbound
-		// allowed"; the WFP filters below pin it to the proxy port.
-		caps, err = capabilitySids("internetClient")
-		if err != nil {
-			return nil, err
-		}
-	}
-	// NetDenyAll gets no capabilities, so the firewall blocks all
-	// network for the container with no WFP involvement.
 	sid, err := createAppContainerProfile(name, "flowcraft sandbox", caps)
 	if err != nil {
 		return nil, err
@@ -154,9 +157,14 @@ func (n *netIsolation) setupHome() error {
 
 // setupProxy starts the host-side enforcement proxy on a loopback
 // port and pins the container's network to it with WFP filters: only
-// TCP to 127.0.0.1 / ::1 on that port is permitted, everything else
-// is blocked at the ALE_AUTH_CONNECT layer for this package SID. The
-// proxy applies the allow-list / upstream decisions.
+// TCP to 127.0.0.1 / ::1 on that port is permitted at the
+// ALE_AUTH_CONNECT layer for this package SID; an explicit block
+// filter covers every other connect, and everything the filters do
+// not see (unconnected UDP, ICMP, inbound) is denied by the
+// AppIsolation default of the capability-less container. The permit
+// filters live in the maximum-weight sublayer, so they are evaluated
+// before AppIsolation and the proxy stays reachable. The proxy applies
+// the allow-list / upstream decisions.
 func (n *netIsolation) setupProxy() error {
 	proxy, err := corenet.Start(corenet.ProxyConfig{
 		Mode:        n.policy.Mode,

--- a/core/sandbox/windows/netisolation_windows.go
+++ b/core/sandbox/windows/netisolation_windows.go
@@ -7,7 +7,9 @@ import (
 	"crypto/rand"
 	"encoding/hex"
 	"fmt"
+	"io"
 	"io/fs"
+	"net"
 	"os"
 	"path/filepath"
 	"strings"
@@ -15,6 +17,7 @@ import (
 	"github.com/GizClaw/flowcraft/core/errdefs"
 	"github.com/GizClaw/flowcraft/core/telemetry"
 	corenet "github.com/GizClaw/flowcraft/core/utils/net"
+	"github.com/GizClaw/flowcraft/core/utils/net/mitm"
 
 	otellog "go.opentelemetry.io/otel/log"
 	xwin "golang.org/x/sys/windows"
@@ -37,14 +40,23 @@ type netIsolation struct {
 	sid   *xwin.SID
 	token xwin.Token
 	home  string
+
+	policy    corenet.NetPolicy
+	wfp       *wfpIsolation // allow_list / proxy modes
+	proxy     *corenet.Proxy
+	proxyPort int
+	bundle    string // MITM CA bundle staged inside home
 }
 
 // newNetIsolation creates the AppContainer profile, derives the lowbox
-// token, and grants the package SID write access to the same path set
-// the write-policy would allow. Hosts without the privilege to create
-// AppContainer profiles fail closed with NotAvailable.
-func newNetIsolation(root string, writable []string, mode corenet.NetMode) (*netIsolation, error) {
-	if mode != corenet.NetDenyAll {
+// token, grants the package SID write access to the same path set the
+// write-policy would allow, and (for allow_list / proxy modes) pins
+// the container's network to the enforcement proxy with WFP. Hosts
+// without the privilege to create AppContainer profiles or open a WFP
+// engine fail closed with NotAvailable.
+func newNetIsolation(root string, writable []string, policy corenet.NetPolicy) (*netIsolation, error) {
+	mode := policy.Mode
+	if mode != corenet.NetDenyAll && mode != corenet.NetAllowList && mode != corenet.NetProxy {
 		return nil, errdefs.NotAvailablef(
 			"windows: net mode %d is not implemented yet", int(mode))
 	}
@@ -54,10 +66,19 @@ func newNetIsolation(root string, writable []string, mode corenet.NetMode) (*net
 	}
 	name := "flowcraft.sandbox." + hex.EncodeToString(raw[:])
 
-	// No capabilities: the firewall blocks all network for the
-	// container. allow_list / proxy modes add InternetClient and WFP
-	// filters instead.
-	sid, err := createAppContainerProfile(name, "flowcraft sandbox", nil)
+	var caps []*xwin.SID
+	var err error
+	if mode != corenet.NetDenyAll {
+		// InternetClient lets the OS firewall baseline "outbound
+		// allowed"; the WFP filters below pin it to the proxy port.
+		caps, err = capabilitySids("internetClient")
+		if err != nil {
+			return nil, err
+		}
+	}
+	// NetDenyAll gets no capabilities, so the firewall blocks all
+	// network for the container with no WFP involvement.
+	sid, err := createAppContainerProfile(name, "flowcraft sandbox", caps)
 	if err != nil {
 		return nil, err
 	}
@@ -74,7 +95,7 @@ func newNetIsolation(root string, writable []string, mode corenet.NetMode) (*net
 		cleanup()
 		return nil, errdefs.Internal(fmt.Errorf("windows: net isolation token: %w", err))
 	}
-	iso := &netIsolation{name: name, sid: sid, token: lowbox}
+	iso := &netIsolation{name: name, sid: sid, token: lowbox, policy: policy}
 	if err := iso.setupHome(); err != nil {
 		_ = iso.Close()
 		return nil, err
@@ -88,6 +109,12 @@ func newNetIsolation(root string, writable []string, mode corenet.NetMode) (*net
 			continue
 		}
 		if err := grantPathTree(p, sid, containerWriteAccess); err != nil {
+			_ = iso.Close()
+			return nil, err
+		}
+	}
+	if mode != corenet.NetDenyAll {
+		if err := iso.setupProxy(); err != nil {
 			_ = iso.Close()
 			return nil, err
 		}
@@ -125,10 +152,110 @@ func (n *netIsolation) setupHome() error {
 	return nil
 }
 
+// setupProxy starts the host-side enforcement proxy on a loopback
+// port and pins the container's network to it with WFP filters: only
+// TCP to 127.0.0.1 / ::1 on that port is permitted, everything else
+// is blocked at the ALE_AUTH_CONNECT layer for this package SID. The
+// proxy applies the allow-list / upstream decisions.
+func (n *netIsolation) setupProxy() error {
+	proxy, err := corenet.Start(corenet.ProxyConfig{
+		Mode:        n.policy.Mode,
+		AllowHosts:  n.policy.AllowHosts,
+		Rules:       n.policy.Rules,
+		Upstream:    n.policy.Proxy,
+		TCPLoopback: true,
+		MITM:        n.policy.MITM,
+		MITMFactory: mitm.New,
+	})
+	if err != nil {
+		return errdefs.Internal(fmt.Errorf("windows: start enforcement proxy: %w", err))
+	}
+	addr, ok := proxy.Addr().(*net.TCPAddr)
+	if !ok {
+		_ = proxy.Close()
+		return errdefs.Internal(fmt.Errorf(
+			"windows: enforcement proxy bound %T, want TCP loopback", proxy.Addr()))
+	}
+	port := addr.Port
+
+	w, err := newWFPIsolation()
+	if err != nil {
+		_ = proxy.Close()
+		return err
+	}
+	permitV4 := []wfpCondition{
+		sidCondition(n.sid),
+		v4AddrCondition(0x7f000001), // 127.0.0.1
+		portCondition(uint16(port)),
+		tcpProtocolCondition(),
+	}
+	permitV6 := []wfpCondition{
+		sidCondition(n.sid),
+		v6LoopbackCondition(), // ::1
+		portCondition(uint16(port)),
+		tcpProtocolCondition(),
+	}
+	block := []wfpCondition{sidCondition(n.sid)}
+	for _, layer := range []xwin.GUID{fwpmLayerAleAuthConnectV4, fwpmLayerAleAuthConnectV6} {
+		conds := permitV4
+		if layer == fwpmLayerAleAuthConnectV6 {
+			conds = permitV6
+		}
+		if err := w.wfpAddFilter(layer, "flowcraft permit enforcement proxy",
+			wfpActionPermit, 0xffffffff, conds); err != nil {
+			w.Close()
+			_ = proxy.Close()
+			return err
+		}
+		if err := w.wfpAddFilter(layer, "flowcraft block sandbox egress",
+			wfpActionBlock, 0xfffffffe, block); err != nil {
+			w.Close()
+			_ = proxy.Close()
+			return err
+		}
+	}
+
+	n.wfp = w
+	n.proxy = proxy
+	n.proxyPort = port
+
+	if n.policy.MITM != nil && n.policy.MITM.Enabled {
+		path, cleanup, err := mitm.WriteBundle(proxy.CAPEM())
+		if err != nil {
+			return errdefs.Internal(fmt.Errorf("windows: write mitm bundle: %w", err))
+		}
+		defer cleanup()
+		dst := filepath.Join(n.home, "flowcraft-ca.pem")
+		if err := copyFile(path, dst); err != nil {
+			return errdefs.Internal(fmt.Errorf("windows: stage mitm bundle: %w", err))
+		}
+		n.bundle = dst
+	}
+	return nil
+}
+
+func copyFile(src, dst string) error {
+	in, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = in.Close() }()
+	out, err := os.Create(dst)
+	if err != nil {
+		return err
+	}
+	if _, err := io.Copy(out, in); err != nil {
+		_ = out.Close()
+		return err
+	}
+	return out.Close()
+}
+
 // env redirects the child's environment away from the user profile,
 // which an AppContainer cannot read, into the sandbox home. Existing
 // keys are replaced case-insensitively (Windows environment is
-// case-insensitive).
+// case-insensitive). allow_list / proxy modes also inject the proxy
+// environment the way the seatbelt backend does.
 func (n *netIsolation) env(env []string) []string {
 	repl := map[string]string{
 		"HOME":         n.home,
@@ -138,6 +265,19 @@ func (n *netIsolation) env(env []string) []string {
 		"TEMP":         filepath.Join(n.home, "Temp"),
 		"TMP":          filepath.Join(n.home, "Temp"),
 		"TMPDIR":       filepath.Join(n.home, "Temp"),
+	}
+	if n.proxyPort > 0 {
+		proxy := fmt.Sprintf("http://127.0.0.1:%d", n.proxyPort)
+		for _, k := range []string{
+			"HTTP_PROXY", "http_proxy", "HTTPS_PROXY", "https_proxy", "ALL_PROXY", "all_proxy",
+		} {
+			repl[k] = proxy
+		}
+		repl["NO_PROXY"] = ""
+		repl["no_proxy"] = ""
+	}
+	if n.bundle != "" {
+		repl["SSL_CERT_FILE"] = n.bundle
 	}
 	upper := make(map[string]string, len(repl))
 	for k, v := range repl {
@@ -166,10 +306,21 @@ func (n *netIsolation) env(env []string) []string {
 	return out
 }
 
-// Close removes the AppContainer profile and the sandbox home. It is
-// safe to call more than once.
+// Close removes the WFP filters, the enforcement proxy, the
+// AppContainer profile, and the sandbox home. It is safe to call more
+// than once.
 func (n *netIsolation) Close() error {
 	var errs []error
+	if n.wfp != nil {
+		n.wfp.Close()
+		n.wfp = nil
+	}
+	if n.proxy != nil {
+		if err := n.proxy.Close(); err != nil {
+			errs = append(errs, err)
+		}
+		n.proxy = nil
+	}
 	if n.name != "" {
 		if err := deleteAppContainerProfile(n.name); err != nil {
 			errs = append(errs, err)

--- a/core/sandbox/windows/netisolation_windows.go
+++ b/core/sandbox/windows/netisolation_windows.go
@@ -1,0 +1,212 @@
+//go:build windows
+
+package windows
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/GizClaw/flowcraft/core/errdefs"
+	"github.com/GizClaw/flowcraft/core/telemetry"
+	corenet "github.com/GizClaw/flowcraft/core/utils/net"
+
+	otellog "go.opentelemetry.io/otel/log"
+	xwin "golang.org/x/sys/windows"
+)
+
+// netIsolation is the AppContainer-backed network isolation for one
+// runner. The child runs with an AppContainer (lowbox) token whose
+// package SID is unique to this runner, so kernel-level network
+// restrictions (and, for allow_list / proxy modes, WFP filters) can
+// be scoped to exactly the sandboxed process tree.
+//
+// An AppContainer without network capabilities is denied all network
+// access by the OS firewall — that is how NetDenyAll is enforced with
+// no WFP involvement. Writable paths are granted to the package SID
+// through the filesystem DACL, and HOME / TEMP are redirected into a
+// per-runner sandbox directory, because AppContainers cannot read the
+// user profile by default.
+type netIsolation struct {
+	name  string
+	sid   *xwin.SID
+	token xwin.Token
+	home  string
+}
+
+// newNetIsolation creates the AppContainer profile, derives the lowbox
+// token, and grants the package SID write access to the same path set
+// the write-policy would allow. Hosts without the privilege to create
+// AppContainer profiles fail closed with NotAvailable.
+func newNetIsolation(root string, writable []string, mode corenet.NetMode) (*netIsolation, error) {
+	if mode != corenet.NetDenyAll {
+		return nil, errdefs.NotAvailablef(
+			"windows: net mode %d is not implemented yet", int(mode))
+	}
+	var raw [8]byte
+	if _, err := rand.Read(raw[:]); err != nil {
+		return nil, errdefs.Internal(fmt.Errorf("windows: net isolation entropy: %w", err))
+	}
+	name := "flowcraft.sandbox." + hex.EncodeToString(raw[:])
+
+	// No capabilities: the firewall blocks all network for the
+	// container. allow_list / proxy modes add InternetClient and WFP
+	// filters instead.
+	sid, err := createAppContainerProfile(name, "flowcraft sandbox", nil)
+	if err != nil {
+		return nil, err
+	}
+	cleanup := func() { _ = deleteAppContainerProfile(name) }
+
+	var current xwin.Token
+	if err := xwin.OpenProcessToken(xwin.CurrentProcess(), xwin.TOKEN_ALL_ACCESS, &current); err != nil {
+		cleanup()
+		return nil, errdefs.Internal(fmt.Errorf("windows: open current token: %w", err))
+	}
+	lowbox, err := createAppContainerToken(current, sid)
+	_ = current.Close()
+	if err != nil {
+		cleanup()
+		return nil, errdefs.Internal(fmt.Errorf("windows: net isolation token: %w", err))
+	}
+	iso := &netIsolation{name: name, sid: sid, token: lowbox}
+	if err := iso.setupHome(); err != nil {
+		_ = iso.Close()
+		return nil, err
+	}
+	if err := grantPathTree(root, sid, containerWriteAccess); err != nil {
+		_ = iso.Close()
+		return nil, err
+	}
+	for _, p := range writable {
+		if p == "" || p == root {
+			continue
+		}
+		if err := grantPathTree(p, sid, containerWriteAccess); err != nil {
+			_ = iso.Close()
+			return nil, err
+		}
+	}
+	return iso, nil
+}
+
+// containerWriteAccess is the access a sandboxed child needs inside
+// its workspace: read, write, execute, and delete, mirroring what the
+// owning user has.
+const containerWriteAccess = xwin.FILE_GENERIC_READ |
+	xwin.FILE_GENERIC_WRITE | xwin.FILE_GENERIC_EXECUTE | xwin.DELETE
+
+// setupHome creates the per-runner sandbox home (used for HOME, TEMP,
+// APPDATA, ...) and grants the package SID write access to it.
+func (n *netIsolation) setupHome() error {
+	home, err := os.MkdirTemp("", "flowcraft-ac-")
+	if err != nil {
+		return errdefs.Internal(fmt.Errorf("windows: net isolation home: %w", err))
+	}
+	for _, sub := range []string{
+		"AppData", filepath.Join("AppData", "Roaming"),
+		filepath.Join("AppData", "Local"), "Temp",
+	} {
+		if err := os.MkdirAll(filepath.Join(home, sub), 0o755); err != nil {
+			_ = os.RemoveAll(home)
+			return errdefs.Internal(fmt.Errorf("windows: net isolation home dirs: %w", err))
+		}
+	}
+	if err := grantPathTree(home, n.sid, containerWriteAccess); err != nil {
+		_ = os.RemoveAll(home)
+		return err
+	}
+	n.home = home
+	return nil
+}
+
+// env redirects the child's environment away from the user profile,
+// which an AppContainer cannot read, into the sandbox home. Existing
+// keys are replaced case-insensitively (Windows environment is
+// case-insensitive).
+func (n *netIsolation) env(env []string) []string {
+	repl := map[string]string{
+		"HOME":         n.home,
+		"USERPROFILE":  n.home,
+		"APPDATA":      filepath.Join(n.home, "AppData", "Roaming"),
+		"LOCALAPPDATA": filepath.Join(n.home, "AppData", "Local"),
+		"TEMP":         filepath.Join(n.home, "Temp"),
+		"TMP":          filepath.Join(n.home, "Temp"),
+		"TMPDIR":       filepath.Join(n.home, "Temp"),
+	}
+	upper := make(map[string]string, len(repl))
+	for k, v := range repl {
+		upper[strings.ToUpper(k)] = v
+	}
+	out := make([]string, 0, len(env)+len(repl))
+	seen := make(map[string]bool, len(repl))
+	for _, kv := range env {
+		key, _, ok := strings.Cut(kv, "=")
+		if !ok {
+			out = append(out, kv)
+			continue
+		}
+		if v, ok := upper[strings.ToUpper(key)]; ok {
+			out = append(out, key+"="+v)
+			seen[strings.ToUpper(key)] = true
+			continue
+		}
+		out = append(out, kv)
+	}
+	for k, v := range upper {
+		if !seen[k] {
+			out = append(out, k+"="+v)
+		}
+	}
+	return out
+}
+
+// Close removes the AppContainer profile and the sandbox home. It is
+// safe to call more than once.
+func (n *netIsolation) Close() error {
+	var errs []error
+	if n.name != "" {
+		if err := deleteAppContainerProfile(n.name); err != nil {
+			errs = append(errs, err)
+		}
+		n.name = ""
+	}
+	if n.token != 0 {
+		if err := n.token.Close(); err != nil {
+			errs = append(errs, err)
+		}
+		n.token = 0
+	}
+	if n.home != "" {
+		if err := os.RemoveAll(n.home); err != nil {
+			telemetry.WarnErr(context.Background(), "windows: remove net isolation home failed", err,
+				otellog.String("windows.isolation_home", n.home))
+		}
+		n.home = ""
+	}
+	if len(errs) > 0 {
+		return fmt.Errorf("windows: close net isolation: %w", errs[0])
+	}
+	return nil
+}
+
+// grantPathTree adds a DACL grant ACE for sid to path and every
+// existing child, recursively. Directories carry the inherit flags so
+// new children receive the grant automatically.
+func grantPathTree(path string, sid *xwin.SID, access uint32) error {
+	return filepath.WalkDir(path, func(p string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		var inherit uint32
+		if d.IsDir() {
+			inherit = xwin.OBJECT_INHERIT_ACE | xwin.CONTAINER_INHERIT_ACE
+		}
+		return grantDaclAccess(p, sid, access, inherit)
+	})
+}

--- a/core/sandbox/windows/netisolation_windows.go
+++ b/core/sandbox/windows/netisolation_windows.go
@@ -89,7 +89,7 @@ func newNetIsolation(root string, writable []string, policy corenet.NetPolicy) (
 		cleanup()
 		return nil, errdefs.Internal(fmt.Errorf("windows: open current token: %w", err))
 	}
-	lowbox, err := createAppContainerToken(current, sid)
+	lowbox, err := createAppContainerToken(current, sid, caps)
 	_ = current.Close()
 	if err != nil {
 		cleanup()

--- a/core/sandbox/windows/netisolation_windows.go
+++ b/core/sandbox/windows/netisolation_windows.go
@@ -31,18 +31,16 @@ import (
 //
 // The container is created without any network capability, so the OS
 // firewall's built-in AppIsolation sublayer denies all network access
-// by default — that is how NetDenyAll is enforced with no WFP
-// involvement. Allow-list / proxy modes add a maximum-weight WFP
-// sublayer that permits only TCP to the loopback enforcement proxy;
-// every other packet (unconnected UDP, ICMP, inbound, raw, ...) still
-// falls through to the AppIsolation default-deny. Dropping
-// internetClient entirely is what closes the unconnected-UDP sendto
-// bypass: ALE_AUTH_CONNECT filters never see those packets, but a
-// capability-less container has no firewall baseline to allow them.
-// Writable paths are granted to the package SID through the filesystem
-// DACL, and HOME / TEMP are redirected into a per-runner sandbox
-// directory, because AppContainers cannot read the user profile by
-// default.
+// by default. That default only covers ALE_AUTH_CONNECT-classified
+// flows (TCP and connected UDP); unconnected UDP sendto and ICMP are
+// not constrained by it, so every non-default mode also installs WFP
+// bind-layer (ALE_RESOURCE_ASSIGNMENT) filters for the package SID.
+// NetDenyAll blocks every bind; allow-list / proxy modes permit only
+// TCP binds (still pinned to the loopback enforcement proxy at
+// ALE_AUTH_CONNECT) and block everything else. Writable paths are
+// granted to the package SID through the filesystem DACL, and HOME /
+// TEMP are redirected into a per-runner sandbox directory, because
+// AppContainers cannot read the user profile by default.
 type netIsolation struct {
 	name  string
 	sid   *xwin.SID
@@ -74,12 +72,9 @@ func newNetIsolation(root string, writable []string, policy corenet.NetPolicy) (
 	}
 	name := "flowcraft.sandbox." + hex.EncodeToString(raw[:])
 
-	// No network capabilities in any mode. The built-in AppIsolation
-	// firewall sublayer denies all network for a capability-less
-	// container; allow-list / proxy modes add a higher-weight WFP
-	// permit sublayer for the loopback proxy only, so everything else
-	// (including unconnected UDP sendto, which never reaches the
-	// ALE_AUTH_CONNECT filters) is still denied by default.
+	// No network capabilities in any mode: the AppIsolation default
+	// deny covers AUTH_CONNECT-classified flows, and the bind-layer
+	// filters below cover everything it misses (UDP/ICMP).
 	var caps []*xwin.SID
 	sid, err := createAppContainerProfile(name, "flowcraft sandbox", caps)
 	if err != nil {
@@ -121,6 +116,9 @@ func newNetIsolation(root string, writable []string, policy corenet.NetPolicy) (
 			_ = iso.Close()
 			return nil, err
 		}
+	} else if err := iso.setupDenyAll(); err != nil {
+		_ = iso.Close()
+		return nil, err
 	}
 	return iso, nil
 }
@@ -155,16 +153,41 @@ func (n *netIsolation) setupHome() error {
 	return nil
 }
 
+// setupDenyAll closes the AppIsolation coverage gap with a WFP
+// bind-layer block: the OS default deny does not constrain unconnected
+// UDP or ICMP sockets, so every bind by the package SID is explicitly
+// blocked at ALE_RESOURCE_ASSIGNMENT (TCP included — the deny-all
+// container needs no sockets at all).
+func (n *netIsolation) setupDenyAll() error {
+	w, err := newWFPIsolation()
+	if err != nil {
+		return err
+	}
+	block := []wfpCondition{sidCondition(n.sid)}
+	for _, layer := range []xwin.GUID{
+		fwpmLayerAleResourceAssignmentV4, fwpmLayerAleResourceAssignmentV6,
+	} {
+		if err := w.wfpAddFilter(layer, "flowcraft block sandbox socket bind",
+			wfpActionBlock, 0xffffffff, block); err != nil {
+			w.Close()
+			return err
+		}
+	}
+	n.wfp = w
+	return nil
+}
+
 // setupProxy starts the host-side enforcement proxy on a loopback
 // port and pins the container's network to it with WFP filters: only
-// TCP to 127.0.0.1 / ::1 on that port is permitted at the
-// ALE_AUTH_CONNECT layer for this package SID; an explicit block
-// filter covers every other connect, and everything the filters do
-// not see (unconnected UDP, ICMP, inbound) is denied by the
-// AppIsolation default of the capability-less container. The permit
-// filters live in the maximum-weight sublayer, so they are evaluated
-// before AppIsolation and the proxy stays reachable. The proxy applies
-// the allow-list / upstream decisions.
+// TCP to 127.0.0.1 / ::1 on the proxy port is permitted at the
+// ALE_AUTH_CONNECT layer for this package SID, and an explicit block
+// filter covers every other connect. Because the AppIsolation default
+// does not cover UDP/ICMP, the bind layer (ALE_RESOURCE_ASSIGNMENT)
+// permits only TCP binds and blocks every other socket type, so no
+// UDP or raw datagram can leave the container at all. All filters live
+// in the maximum-weight sublayer and are evaluated before AppIsolation,
+// keeping the proxy reachable. The proxy applies the allow-list /
+// upstream decisions.
 func (n *netIsolation) setupProxy() error {
 	proxy, err := corenet.Start(corenet.ProxyConfig{
 		Mode:        n.policy.Mode,
@@ -217,6 +240,25 @@ func (n *netIsolation) setupProxy() error {
 		}
 		if err := w.wfpAddFilter(layer, "flowcraft block sandbox egress",
 			wfpActionBlock, 0xfffffffe, block); err != nil {
+			w.Close()
+			_ = proxy.Close()
+			return err
+		}
+	}
+
+	bindPermit := []wfpCondition{sidCondition(n.sid), tcpProtocolCondition()}
+	bindBlock := []wfpCondition{sidCondition(n.sid)}
+	for _, layer := range []xwin.GUID{
+		fwpmLayerAleResourceAssignmentV4, fwpmLayerAleResourceAssignmentV6,
+	} {
+		if err := w.wfpAddFilter(layer, "flowcraft permit tcp bind",
+			wfpActionPermit, 0xffffffff, bindPermit); err != nil {
+			w.Close()
+			_ = proxy.Close()
+			return err
+		}
+		if err := w.wfpAddFilter(layer, "flowcraft block non-tcp bind",
+			wfpActionBlock, 0xfffffffe, bindBlock); err != nil {
 			w.Close()
 			_ = proxy.Close()
 			return err

--- a/core/sandbox/windows/netpolicy_windows_test.go
+++ b/core/sandbox/windows/netpolicy_windows_test.go
@@ -150,6 +150,42 @@ func TestNetAllowListPinsToProxy(t *testing.T) {
 	}
 }
 
+// TestNetAllowListBlocksUDP is the differential UDP check: ALE
+// filters classify the first send from an unconnected UDP socket at
+// AUTH_CONNECT, so a raw UDP sendto under allow-list must fail even
+// though the container carries the internetClient capability (DNS
+// tunneling via unconnected UDP is not a valid egress path).
+func TestNetAllowListBlocksUDP(t *testing.T) {
+	requireNetIsolation(t)
+	requireWFP(t)
+	r := mustNewRunner(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	send := []string{"-NoProfile", "-NonInteractive", "-Command",
+		"$u = New-Object Net.Sockets.UdpClient; try { $u.Send([byte[]](0),1,'1.1.1.1',53); Write-Output ok } catch { Write-Output fail; exit 1 }"}
+
+	ctrl, err := r.Exec(ctx, "powershell", send, sandbox.ExecOptions{Timeout: 20 * time.Second})
+	if err != nil {
+		t.Fatalf("control Exec: %v", err)
+	}
+	if ctrl.ExitCode != 0 || !strings.Contains(ctrl.Stdout, "ok") {
+		t.Skipf("host cannot send UDP without a policy (exit=%d out=%q); skipping", ctrl.ExitCode, ctrl.Stdout)
+	}
+
+	denied, err := r.Exec(ctx, "powershell", send,
+		sandbox.ExecOptions{Timeout: 20 * time.Second, Net: corenet.NetPolicy{
+			Mode:       corenet.NetAllowList,
+			AllowHosts: []string{"1.1.1.1"},
+		}})
+	if err != nil {
+		t.Fatalf("allow-list Exec: %v", err)
+	}
+	if denied.ExitCode == 0 && strings.Contains(denied.Stdout, "ok") {
+		t.Fatalf("allow-list exec sent UDP externally: stdout=%q", denied.Stdout)
+	}
+}
+
 func TestExecNetProxy(t *testing.T) {
 	requireNetIsolation(t)
 	requireWFP(t)

--- a/core/sandbox/windows/netpolicy_windows_test.go
+++ b/core/sandbox/windows/netpolicy_windows_test.go
@@ -4,7 +4,6 @@ package windows
 
 import (
 	"context"
-	"fmt"
 	"strings"
 	"testing"
 	"time"
@@ -22,7 +21,7 @@ func requireNetIsolation(t *testing.T) {
 	iso, err := newNetIsolation(t.TempDir(), nil, corenet.NetPolicy{Mode: corenet.NetDenyAll})
 	if err != nil {
 		if errdefs.IsNotAvailable(err) {
-			t.Skipf("host cannot create appcontainer profiles: %v", err)
+			t.Skipf("host cannot create appcontainer profiles or open the WFP engine: %v", err)
 		}
 		t.Fatalf("net isolation probe: %v", err)
 	}
@@ -48,6 +47,7 @@ func requireWFP(t *testing.T) {
 
 func TestExecNetDenyAll(t *testing.T) {
 	requireNetIsolation(t)
+	requireWFP(t)
 	r := mustNewRunner(t)
 	res, err := r.Exec(context.Background(), "cmd",
 		[]string{"/c", "echo", "deny-ok"},
@@ -68,6 +68,7 @@ func TestExecNetDenyAll(t *testing.T) {
 // NetDenyAll, proving the AppContainer has no network reach.
 func TestExecNetDenyAllBlocksNetwork(t *testing.T) {
 	requireNetIsolation(t)
+	requireWFP(t)
 	r := mustNewRunner(t)
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
@@ -152,12 +153,13 @@ func TestNetAllowListPinsToProxy(t *testing.T) {
 	}
 }
 
-// TestNetAllowListBlocksUDP is the differential UDP check. The probe
-// prints "ok" when the send call succeeds; whether that means the
-// datagram actually egressed is what the deny-all control arm
-// discriminates: if AppIsolation drops the packet without failing the
-// send call, the deny-all arm also reports ok and the probe is not
-// delivery-proving.
+// TestNetAllowListBlocksUDP verifies UDP egress is fully closed for
+// both NetDenyAll and NetAllowList. The AppIsolation default only
+// covers AUTH_CONNECT-classified flows, so unconnected UDP sendto
+// slips past it; the backend closes that gap by blocking every
+// non-TCP bind at ALE_RESOURCE_ASSIGNMENT. The deny-all arm doubles
+// as the probe sanity check: a blocked send must fail the send call,
+// so "ok" in a sandboxed arm means real egress.
 func TestNetAllowListBlocksUDP(t *testing.T) {
 	requireNetIsolation(t)
 	requireWFP(t)
@@ -169,28 +171,31 @@ func TestNetAllowListBlocksUDP(t *testing.T) {
 		"$u = New-Object Net.Sockets.UdpClient; try { $u.Send([byte[]](0),1,'1.1.1.1',53); Write-Output ok } catch { Write-Output fail; exit 1 }"}
 	sendConn := []string{"-NoProfile", "-NonInteractive", "-Command",
 		"$u = New-Object Net.Sockets.UdpClient; try { $u.Connect('1.1.1.1',53); $n = $u.Send([byte[]](0),1); Write-Output ok } catch { Write-Output fail; exit 1 }"}
-	dialTCP := []string{"-NoProfile", "-NonInteractive", "-Command",
-		"try { (New-Object Net.Sockets.TcpClient).Connect('1.1.1.1',80); Write-Output ok } catch { Write-Output fail; exit 1 }"}
 
-	run := func(label string, argv []string, net corenet.NetPolicy) string {
-		opts := sandbox.ExecOptions{Timeout: 20 * time.Second}
-		if net.Mode != corenet.NetDefault {
-			opts.Net = net
-		}
-		res, err := r.Exec(ctx, "powershell", argv, opts)
-		if err != nil {
-			return "exec-error: " + err.Error()
-		}
-		return strings.TrimSpace(res.Stdout)
+	ctrl, err := r.Exec(ctx, "powershell", send, sandbox.ExecOptions{Timeout: 20 * time.Second})
+	if err != nil {
+		t.Fatalf("control Exec: %v", err)
+	}
+	if ctrl.ExitCode != 0 || !strings.Contains(ctrl.Stdout, "ok") {
+		t.Skipf("host cannot send UDP without a policy (exit=%d out=%q); skipping", ctrl.ExitCode, ctrl.Stdout)
 	}
 
-	var sb strings.Builder
-	fmt.Fprintf(&sb, "control-unconnected-udp=%s\n", run("ctrl", send, corenet.NetPolicy{Mode: corenet.NetDefault}))
-	fmt.Fprintf(&sb, "denyall-unconnected-udp=%s\n", run("deny", send, corenet.NetPolicy{Mode: corenet.NetDenyAll}))
-	fmt.Fprintf(&sb, "allow-unconnected-udp=%s\n", run("allow-udp", send, corenet.NetPolicy{Mode: corenet.NetAllowList, AllowHosts: []string{"1.1.1.1"}}))
-	fmt.Fprintf(&sb, "allow-connected-udp=%s\n", run("allow-udpc", sendConn, corenet.NetPolicy{Mode: corenet.NetAllowList, AllowHosts: []string{"1.1.1.1"}}))
-	fmt.Fprintf(&sb, "allow-tcp=%s\n", run("allow-tcp", dialTCP, corenet.NetPolicy{Mode: corenet.NetAllowList, AllowHosts: []string{"1.1.1.1"}}))
-	t.Fatalf("probe results:\n%s", sb.String())
+	assertBlocked := func(label string, argv []string, net corenet.NetPolicy) {
+		t.Helper()
+		res, err := r.Exec(ctx, "powershell", argv,
+			sandbox.ExecOptions{Timeout: 20 * time.Second, Net: net})
+		if err != nil {
+			t.Fatalf("%s Exec: %v", label, err)
+		}
+		if res.ExitCode == 0 && strings.Contains(res.Stdout, "ok") {
+			t.Fatalf("%s exec sent UDP: stdout=%q", label, res.Stdout)
+		}
+	}
+	assertBlocked("deny-all", send, corenet.NetPolicy{Mode: corenet.NetDenyAll})
+	assertBlocked("allow-list unconnected", send,
+		corenet.NetPolicy{Mode: corenet.NetAllowList, AllowHosts: []string{"1.1.1.1"}})
+	assertBlocked("allow-list connected", sendConn,
+		corenet.NetPolicy{Mode: corenet.NetAllowList, AllowHosts: []string{"1.1.1.1"}})
 }
 
 func TestExecNetProxy(t *testing.T) {

--- a/core/sandbox/windows/netpolicy_windows_test.go
+++ b/core/sandbox/windows/netpolicy_windows_test.go
@@ -127,7 +127,8 @@ func TestExecNetAllowList(t *testing.T) {
 // TestNetAllowListPinsToProxy verifies the WFP layer: with
 // allow_list mode the container may only reach the enforcement proxy
 // port, so a raw outbound TCP dial (which ignores proxy env) fails
-// even though the container carries the InternetClient capability.
+// even though the container would otherwise be reachable through the
+// proxy.
 func TestNetAllowListPinsToProxy(t *testing.T) {
 	requireNetIsolation(t)
 	requireWFP(t)
@@ -150,11 +151,11 @@ func TestNetAllowListPinsToProxy(t *testing.T) {
 	}
 }
 
-// TestNetAllowListBlocksUDP is the differential UDP check: ALE
-// filters classify the first send from an unconnected UDP socket at
-// AUTH_CONNECT, so a raw UDP sendto under allow-list must fail even
-// though the container carries the internetClient capability (DNS
-// tunneling via unconnected UDP is not a valid egress path).
+// TestNetAllowListBlocksUDP is the differential UDP check: unconnected
+// UDP sendto is classified at ALE_AUTH_SEND, which carries no filters,
+// so the block relies on the AppIsolation default-deny of the
+// capability-less container rather than the WFP filters (DNS tunneling
+// via unconnected UDP must not be a valid egress path).
 func TestNetAllowListBlocksUDP(t *testing.T) {
 	requireNetIsolation(t)
 	requireWFP(t)

--- a/core/sandbox/windows/netpolicy_windows_test.go
+++ b/core/sandbox/windows/netpolicy_windows_test.go
@@ -1,0 +1,138 @@
+//go:build windows
+
+package windows
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/GizClaw/flowcraft/core/errdefs"
+	"github.com/GizClaw/flowcraft/core/sandbox"
+	corenet "github.com/GizClaw/flowcraft/core/utils/net"
+)
+
+// requireNetIsolation probes whether the host can create AppContainer
+// profiles. Non-elevated hosts fail closed with NotAvailable; the
+// net-policy behaviors cannot be exercised there, so the test skips.
+func requireNetIsolation(t *testing.T) {
+	t.Helper()
+	iso, err := newNetIsolation(t.TempDir(), nil, corenet.NetDenyAll)
+	if err != nil {
+		if errdefs.IsNotAvailable(err) {
+			t.Skipf("host cannot create appcontainer profiles: %v", err)
+		}
+		t.Fatalf("net isolation probe: %v", err)
+	}
+	if err := iso.Close(); err != nil {
+		t.Fatalf("net isolation probe close: %v", err)
+	}
+}
+
+func TestExecNetDenyAll(t *testing.T) {
+	requireNetIsolation(t)
+	r := mustNewRunner(t)
+	res, err := r.Exec(context.Background(), "cmd",
+		[]string{"/c", "echo", "deny-ok"},
+		sandbox.ExecOptions{Net: corenet.NetPolicy{Mode: corenet.NetDenyAll}})
+	if err != nil {
+		t.Fatalf("Exec: %v", err)
+	}
+	if res.ExitCode != 0 {
+		t.Fatalf("ExitCode = %d, want 0", res.ExitCode)
+	}
+	if !strings.Contains(res.Stdout, "deny-ok") {
+		t.Fatalf("Stdout = %q, want deny-ok", res.Stdout)
+	}
+}
+
+// TestExecNetDenyAllBlocksNetwork is the differential check: the same
+// outbound TCP dial succeeds without a policy and fails under
+// NetDenyAll, proving the AppContainer has no network reach.
+func TestExecNetDenyAllBlocksNetwork(t *testing.T) {
+	requireNetIsolation(t)
+	r := mustNewRunner(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	dial := []string{"-NoProfile", "-NonInteractive", "-Command",
+		"try { (New-Object Net.Sockets.TcpClient).Connect('1.1.1.1',80); Write-Output ok } catch { Write-Output fail; exit 1 }"}
+
+	ctrl, err := r.Exec(ctx, "powershell", dial, sandbox.ExecOptions{Timeout: 20 * time.Second})
+	if err != nil {
+		t.Fatalf("control Exec: %v", err)
+	}
+	if ctrl.ExitCode != 0 || !strings.Contains(ctrl.Stdout, "ok") {
+		t.Skipf("host cannot reach the internet without a policy (exit=%d out=%q); skipping", ctrl.ExitCode, ctrl.Stdout)
+	}
+
+	denied, err := r.Exec(ctx, "powershell", dial,
+		sandbox.ExecOptions{Timeout: 20 * time.Second, Net: corenet.NetPolicy{Mode: corenet.NetDenyAll}})
+	if err != nil {
+		t.Fatalf("deny-all Exec: %v", err)
+	}
+	if denied.ExitCode == 0 && strings.Contains(denied.Stdout, "ok") {
+		t.Fatalf("NetDenyAll exec reached the network: stdout=%q", denied.Stdout)
+	}
+}
+
+func TestNetPolicyTTYNotAvailable(t *testing.T) {
+	r := mustNewRunner(t)
+	_, err := r.Start(context.Background(), sandbox.SessionSpec{
+		Argv: []string{"cmd"},
+		TTY:  true,
+		Opts: sandbox.ExecOptions{Net: corenet.NetPolicy{Mode: corenet.NetDenyAll}},
+	})
+	if err == nil {
+		t.Fatal("Start succeeded, want NotAvailable")
+	}
+	if !errdefs.IsNotAvailable(err) {
+		t.Fatalf("err = %v, want NotAvailable", err)
+	}
+}
+
+func TestNetPolicyUnsupportedModeNotAvailable(t *testing.T) {
+	r := mustNewRunner(t)
+	_, err := r.Exec(context.Background(), "cmd", []string{"/c", "ver"},
+		sandbox.ExecOptions{Net: corenet.NetPolicy{Mode: corenet.NetAllowList}})
+	if err == nil {
+		t.Fatal("Exec succeeded, want NotAvailable")
+	}
+	if !errdefs.IsNotAvailable(err) {
+		t.Fatalf("err = %v, want NotAvailable", err)
+	}
+}
+
+func TestNetIsolationEnvRedirect(t *testing.T) {
+	iso := &netIsolation{home: `C:\ac-home`}
+	env := iso.env([]string{
+		"PATH=C:\\bin",
+		"TEMP=C:\\Users\\me\\Temp",
+		"HOME=C:\\Users\\me",
+		"KEEP=1",
+	})
+	got := map[string]string{}
+	for _, kv := range env {
+		k, v, ok := strings.Cut(kv, "=")
+		if !ok {
+			t.Fatalf("bad env entry %q", kv)
+		}
+		got[k] = v
+	}
+	want := map[string]string{
+		"PATH":         "C:\\bin",
+		"KEEP":         "1",
+		"TEMP":         `C:\ac-home\Temp`,
+		"TMP":          `C:\ac-home\Temp`,
+		"HOME":         `C:\ac-home`,
+		"USERPROFILE":  `C:\ac-home`,
+		"APPDATA":      `C:\ac-home\AppData\Roaming`,
+		"LOCALAPPDATA": `C:\ac-home\AppData\Local`,
+	}
+	for k, v := range want {
+		if got[k] != v {
+			t.Errorf("%s = %q, want %q (env %v)", k, got[k], v, env)
+		}
+	}
+}

--- a/core/sandbox/windows/netpolicy_windows_test.go
+++ b/core/sandbox/windows/netpolicy_windows_test.go
@@ -4,6 +4,7 @@ package windows
 
 import (
 	"context"
+	"fmt"
 	"strings"
 	"testing"
 	"time"
@@ -151,11 +152,12 @@ func TestNetAllowListPinsToProxy(t *testing.T) {
 	}
 }
 
-// TestNetAllowListBlocksUDP is the differential UDP check: unconnected
-// UDP sendto is classified at ALE_AUTH_SEND, which carries no filters,
-// so the block relies on the AppIsolation default-deny of the
-// capability-less container rather than the WFP filters (DNS tunneling
-// via unconnected UDP must not be a valid egress path).
+// TestNetAllowListBlocksUDP is the differential UDP check. The probe
+// prints "ok" when the send call succeeds; whether that means the
+// datagram actually egressed is what the deny-all control arm
+// discriminates: if AppIsolation drops the packet without failing the
+// send call, the deny-all arm also reports ok and the probe is not
+// delivery-proving.
 func TestNetAllowListBlocksUDP(t *testing.T) {
 	requireNetIsolation(t)
 	requireWFP(t)
@@ -165,26 +167,30 @@ func TestNetAllowListBlocksUDP(t *testing.T) {
 
 	send := []string{"-NoProfile", "-NonInteractive", "-Command",
 		"$u = New-Object Net.Sockets.UdpClient; try { $u.Send([byte[]](0),1,'1.1.1.1',53); Write-Output ok } catch { Write-Output fail; exit 1 }"}
+	sendConn := []string{"-NoProfile", "-NonInteractive", "-Command",
+		"$u = New-Object Net.Sockets.UdpClient; try { $u.Connect('1.1.1.1',53); $n = $u.Send([byte[]](0),1); Write-Output ok } catch { Write-Output fail; exit 1 }"}
+	dialTCP := []string{"-NoProfile", "-NonInteractive", "-Command",
+		"try { (New-Object Net.Sockets.TcpClient).Connect('1.1.1.1',80); Write-Output ok } catch { Write-Output fail; exit 1 }"}
 
-	ctrl, err := r.Exec(ctx, "powershell", send, sandbox.ExecOptions{Timeout: 20 * time.Second})
-	if err != nil {
-		t.Fatalf("control Exec: %v", err)
-	}
-	if ctrl.ExitCode != 0 || !strings.Contains(ctrl.Stdout, "ok") {
-		t.Skipf("host cannot send UDP without a policy (exit=%d out=%q); skipping", ctrl.ExitCode, ctrl.Stdout)
+	run := func(label string, argv []string, net corenet.NetPolicy) string {
+		opts := sandbox.ExecOptions{Timeout: 20 * time.Second}
+		if net.Mode != corenet.NetDefault {
+			opts.Net = net
+		}
+		res, err := r.Exec(ctx, "powershell", argv, opts)
+		if err != nil {
+			return "exec-error: " + err.Error()
+		}
+		return strings.TrimSpace(res.Stdout)
 	}
 
-	denied, err := r.Exec(ctx, "powershell", send,
-		sandbox.ExecOptions{Timeout: 20 * time.Second, Net: corenet.NetPolicy{
-			Mode:       corenet.NetAllowList,
-			AllowHosts: []string{"1.1.1.1"},
-		}})
-	if err != nil {
-		t.Fatalf("allow-list Exec: %v", err)
-	}
-	if denied.ExitCode == 0 && strings.Contains(denied.Stdout, "ok") {
-		t.Fatalf("allow-list exec sent UDP externally: stdout=%q", denied.Stdout)
-	}
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "control-unconnected-udp=%s\n", run("ctrl", send, corenet.NetPolicy{Mode: corenet.NetDefault}))
+	fmt.Fprintf(&sb, "denyall-unconnected-udp=%s\n", run("deny", send, corenet.NetPolicy{Mode: corenet.NetDenyAll}))
+	fmt.Fprintf(&sb, "allow-unconnected-udp=%s\n", run("allow-udp", send, corenet.NetPolicy{Mode: corenet.NetAllowList, AllowHosts: []string{"1.1.1.1"}}))
+	fmt.Fprintf(&sb, "allow-connected-udp=%s\n", run("allow-udpc", sendConn, corenet.NetPolicy{Mode: corenet.NetAllowList, AllowHosts: []string{"1.1.1.1"}}))
+	fmt.Fprintf(&sb, "allow-tcp=%s\n", run("allow-tcp", dialTCP, corenet.NetPolicy{Mode: corenet.NetAllowList, AllowHosts: []string{"1.1.1.1"}}))
+	t.Fatalf("probe results:\n%s", sb.String())
 }
 
 func TestExecNetProxy(t *testing.T) {

--- a/core/sandbox/windows/netpolicy_windows_test.go
+++ b/core/sandbox/windows/netpolicy_windows_test.go
@@ -18,7 +18,7 @@ import (
 // net-policy behaviors cannot be exercised there, so the test skips.
 func requireNetIsolation(t *testing.T) {
 	t.Helper()
-	iso, err := newNetIsolation(t.TempDir(), nil, corenet.NetDenyAll)
+	iso, err := newNetIsolation(t.TempDir(), nil, corenet.NetPolicy{Mode: corenet.NetDenyAll})
 	if err != nil {
 		if errdefs.IsNotAvailable(err) {
 			t.Skipf("host cannot create appcontainer profiles: %v", err)
@@ -28,6 +28,21 @@ func requireNetIsolation(t *testing.T) {
 	if err := iso.Close(); err != nil {
 		t.Fatalf("net isolation probe close: %v", err)
 	}
+}
+
+// requireWFP probes whether the host can open the WFP engine, which
+// allow_list / proxy modes need. Non-elevated hosts fail closed with
+// NotAvailable.
+func requireWFP(t *testing.T) {
+	t.Helper()
+	w, err := newWFPIsolation()
+	if err != nil {
+		if errdefs.IsNotAvailable(err) {
+			t.Skipf("host cannot open the WFP engine: %v", err)
+		}
+		t.Fatalf("wfp probe: %v", err)
+	}
+	w.Close()
 }
 
 func TestExecNetDenyAll(t *testing.T) {
@@ -92,15 +107,63 @@ func TestNetPolicyTTYNotAvailable(t *testing.T) {
 	}
 }
 
-func TestNetPolicyUnsupportedModeNotAvailable(t *testing.T) {
+func TestExecNetAllowList(t *testing.T) {
+	requireNetIsolation(t)
+	requireWFP(t)
 	r := mustNewRunner(t)
-	_, err := r.Exec(context.Background(), "cmd", []string{"/c", "ver"},
-		sandbox.ExecOptions{Net: corenet.NetPolicy{Mode: corenet.NetAllowList}})
-	if err == nil {
-		t.Fatal("Exec succeeded, want NotAvailable")
+	res, err := r.Exec(context.Background(), "cmd", []string{"/c", "echo", "allow-ok"},
+		sandbox.ExecOptions{Net: corenet.NetPolicy{
+			Mode:       corenet.NetAllowList,
+			AllowHosts: []string{"1.1.1.1"},
+		}})
+	if err != nil {
+		t.Fatalf("Exec: %v", err)
 	}
-	if !errdefs.IsNotAvailable(err) {
-		t.Fatalf("err = %v, want NotAvailable", err)
+	if res.ExitCode != 0 || !strings.Contains(res.Stdout, "allow-ok") {
+		t.Fatalf("exit=%d stdout=%q, want allow-ok", res.ExitCode, res.Stdout)
+	}
+}
+
+// TestNetAllowListPinsToProxy verifies the WFP layer: with
+// allow_list mode the container may only reach the enforcement proxy
+// port, so a raw outbound TCP dial (which ignores proxy env) fails
+// even though the container carries the InternetClient capability.
+func TestNetAllowListPinsToProxy(t *testing.T) {
+	requireNetIsolation(t)
+	requireWFP(t)
+	r := mustNewRunner(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	dial := []string{"-NoProfile", "-NonInteractive", "-Command",
+		"try { (New-Object Net.Sockets.TcpClient).Connect('1.1.1.1',80); Write-Output ok } catch { Write-Output fail; exit 1 }"}
+	res, err := r.Exec(ctx, "powershell", dial,
+		sandbox.ExecOptions{Timeout: 20 * time.Second, Net: corenet.NetPolicy{
+			Mode:       corenet.NetAllowList,
+			AllowHosts: []string{"1.1.1.1"},
+		}})
+	if err != nil {
+		t.Fatalf("Exec: %v", err)
+	}
+	if res.ExitCode == 0 && strings.Contains(res.Stdout, "ok") {
+		t.Fatalf("allow-list exec reached the network directly: stdout=%q", res.Stdout)
+	}
+}
+
+func TestExecNetProxy(t *testing.T) {
+	requireNetIsolation(t)
+	requireWFP(t)
+	r := mustNewRunner(t)
+	res, err := r.Exec(context.Background(), "cmd", []string{"/c", "echo", "proxy-ok"},
+		sandbox.ExecOptions{Net: corenet.NetPolicy{
+			Mode:  corenet.NetProxy,
+			Proxy: "http://127.0.0.1:1",
+		}})
+	if err != nil {
+		t.Fatalf("Exec: %v", err)
+	}
+	if res.ExitCode != 0 || !strings.Contains(res.Stdout, "proxy-ok") {
+		t.Fatalf("exit=%d stdout=%q, want proxy-ok", res.ExitCode, res.Stdout)
 	}
 }
 

--- a/core/sandbox/windows/options.go
+++ b/core/sandbox/windows/options.go
@@ -1,0 +1,27 @@
+package windows
+
+import "math"
+
+// Option configures a Runner at construction time.
+type Option func(*runnerConfig)
+
+// runnerConfig is the resolved set of options. It lives in the
+// platform-neutral file so the option functions type-check on every
+// OS even though Runner itself is Windows-only.
+type runnerConfig struct {
+	defaultMaxOutput int64
+}
+
+// WithMaxOutputBytes sets the default per-call MaxOutputBytes used
+// when sandbox.ExecOptions.Resources.MaxOutputBytes is zero. Pass a
+// non-positive value to disable truncation (i.e. allow up to
+// math.MaxInt64 bytes).
+func WithMaxOutputBytes(n int64) Option {
+	return func(c *runnerConfig) {
+		if n <= 0 {
+			c.defaultMaxOutput = math.MaxInt64
+		} else {
+			c.defaultMaxOutput = n
+		}
+	}
+}

--- a/core/sandbox/windows/options.go
+++ b/core/sandbox/windows/options.go
@@ -10,6 +10,8 @@ type Option func(*runnerConfig)
 // OS even though Runner itself is Windows-only.
 type runnerConfig struct {
 	defaultMaxOutput int64
+	writeConfine     bool
+	writable         []string // extra writable paths (write confinement)
 }
 
 // WithMaxOutputBytes sets the default per-call MaxOutputBytes used
@@ -23,5 +25,31 @@ func WithMaxOutputBytes(n int64) Option {
 		} else {
 			c.defaultMaxOutput = n
 		}
+	}
+}
+
+// WithWriteConfinement enables OS-level write confinement: every child
+// runs with a restricted, Low-integrity token, and the runner root
+// (plus any WithWritablePaths entries) is labeled Low so the child can
+// write only there. Everything else on the host stays Medium:
+// readable, not writable. The child gets its own Low-labeled TEMP/TMP.
+//
+// Confinement is opt-in: without it the backend is the phase-1
+// lifecycle-only sandbox and WriteReadOnly is rejected with
+// NotAvailable.
+func WithWriteConfinement() Option {
+	return func(c *runnerConfig) {
+		c.writeConfine = true
+	}
+}
+
+// WithWritablePaths grants write access to additional existing paths
+// beyond rootDir when write confinement is enabled. Explicit writable
+// paths remain writable even for a WriteReadOnly call, mirroring the
+// bwrap / seatbelt semantics. Paths are resolved to absolute form at
+// construction.
+func WithWritablePaths(paths ...string) Option {
+	return func(c *runnerConfig) {
+		c.writable = append(c.writable, paths...)
 	}
 }

--- a/core/sandbox/windows/register.go
+++ b/core/sandbox/windows/register.go
@@ -2,6 +2,7 @@ package windows
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/GizClaw/flowcraft/core/errdefs"
 	"github.com/GizClaw/flowcraft/core/resource"
@@ -16,7 +17,9 @@ const ResourceKind = "sandbox.Runner"
 const BackendName = "windows"
 
 type settings struct {
-	Root string `json:"root"`
+	Root          string   `json:"root"`
+	WriteConfine  bool     `json:"write_confine,omitempty"`
+	WritablePaths []string `json:"writable_paths,omitempty"`
 }
 
 type factory struct{}
@@ -39,7 +42,18 @@ func (factory) New(ctx context.Context, in resource.Input) (any, error) {
 	if s.Root == "" {
 		return nil, errdefs.Validationf("windows settings.root is required")
 	}
-	runner, err := New(s.Root)
+	var options []Option
+	if s.WriteConfine {
+		options = append(options, WithWriteConfinement())
+	}
+	writable, err := sandbox.ResolveMany(s.Root, s.WritablePaths)
+	if err != nil {
+		return nil, fmt.Errorf("windows settings.writable_paths: %w", err)
+	}
+	if writable != nil {
+		options = append(options, WithWritablePaths(writable...))
+	}
+	runner, err := New(s.Root, options...)
 	if err != nil {
 		return nil, err
 	}

--- a/core/sandbox/windows/register.go
+++ b/core/sandbox/windows/register.go
@@ -1,0 +1,52 @@
+package windows
+
+import (
+	"context"
+
+	"github.com/GizClaw/flowcraft/core/errdefs"
+	"github.com/GizClaw/flowcraft/core/resource"
+	"github.com/GizClaw/flowcraft/core/sandbox"
+)
+
+// ResourceKind is the deployment resource kind implemented by this
+// package.
+const ResourceKind = "sandbox.Runner"
+
+// BackendName is the sandbox impl name for the windows backend.
+const BackendName = "windows"
+
+type settings struct {
+	Root string `json:"root"`
+}
+
+type factory struct{}
+
+// NewFactory returns a deployment resource factory for the windows
+// backend.
+func NewFactory() resource.Factory { return factory{} }
+
+// Spec implements resource.Factory.
+func (factory) Spec() resource.Spec {
+	return resource.Spec{Kind: ResourceKind, Impl: BackendName}
+}
+
+// New implements resource.Factory.
+func (factory) New(ctx context.Context, in resource.Input) (any, error) {
+	s, err := resource.DecodeTyped[settings](ctx, in.Settings)
+	if err != nil {
+		return nil, errdefs.Validationf("decode windows settings: %v", err)
+	}
+	if s.Root == "" {
+		return nil, errdefs.Validationf("windows settings.root is required")
+	}
+	runner, err := New(s.Root)
+	if err != nil {
+		return nil, err
+	}
+	return sandbox.Runner(runner), nil
+}
+
+// Register adds the windows factory to r.
+func Register(r *resource.Registry) error {
+	return r.Register(NewFactory())
+}

--- a/core/sandbox/windows/register_test.go
+++ b/core/sandbox/windows/register_test.go
@@ -1,0 +1,27 @@
+package windows
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/GizClaw/flowcraft/core/resource"
+)
+
+func TestRegisterAddsWindowsFactory(t *testing.T) {
+	reg := resource.NewRegistry()
+	if err := Register(reg); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+	if _, ok := reg.Lookup(ResourceKind, BackendName); !ok {
+		t.Fatalf("factory %s/%s missing", ResourceKind, BackendName)
+	}
+}
+
+func TestNewRequiresRoot(t *testing.T) {
+	if _, err := NewFactory().New(context.Background(), resource.Input{
+		Settings: json.RawMessage(`{"root": ""}`),
+	}); err == nil {
+		t.Fatal("New accepted missing root")
+	}
+}

--- a/core/sandbox/windows/runner.go
+++ b/core/sandbox/windows/runner.go
@@ -34,6 +34,10 @@ const defaultMaxOutputBytes int64 = 10 * 1024 * 1024
 //   - WorkDir / Stdin / Timeout: fully supported. Every child runs in
 //     its own job; timeout/cancel closes the job and kills the whole
 //     tree, not just the leader.
+//   - TTY sessions: supported via ConPTY (merged SessionStreamTTY,
+//     Resize). Signal stays NotAvailable. TTY combined with
+//     WithWriteConfinement is NotAvailable until the restricted-token
+//     spawn path is verified against a real pseudo console.
 //   - Env: fully supported (see sandbox.EnvPolicy doc).
 //   - Net.Mode != corenet.NetDefault: errdefs.NotAvailable.
 //   - Write == WriteReadOnly: errdefs.NotAvailable (no OS boundary to
@@ -89,8 +93,8 @@ func New(rootDir string, opts ...Option) (*Runner, error) {
 // Capabilities declares the honest surface: env allow-lists and
 // job-object resource caps are always enforced; filesystem write
 // bounds are enforced when the runner was constructed with
-// WithWriteConfinement. Sessions are pipe-only (no TTY / signal /
-// event features).
+// WithWriteConfinement. TTY sessions are supported through ConPTY;
+// signal and event features are not.
 func (r *Runner) Capabilities() sandbox.Capabilities {
 	policy := sandbox.Enforcement{
 		EnvAllowList: true,
@@ -106,7 +110,7 @@ func (r *Runner) Capabilities() sandbox.Capabilities {
 	}
 	return sandbox.Capabilities{
 		Policy:   policy,
-		Features: sandbox.SessionFeatures{},
+		Features: sandbox.SessionFeatures{TTY: true},
 	}
 }
 
@@ -167,10 +171,6 @@ func (r *Runner) spawnProcess(ctx context.Context, spec sandbox.SessionSpec) (sa
 	if err := r.validatePolicy(spec); err != nil {
 		return nil, err
 	}
-	if spec.TTY {
-		return nil, errdefs.NotAvailablef(
-			"windows: TTY sessions are not supported (pipe sessions only)")
-	}
 	workDir, err := r.resolveWorkDir(spec.Opts.WorkDir)
 	if err != nil {
 		return nil, err
@@ -181,9 +181,22 @@ func (r *Runner) spawnProcess(ctx context.Context, spec sandbox.SessionSpec) (sa
 	}
 	spec.Opts.Resources.MaxOutputBytes = maxOut
 
+	env := buildEnv(spec.Opts.Env)
+	if spec.TTY {
+		if r.cfg.writeConfine {
+			return nil, errdefs.NotAvailablef(
+				"windows: TTY sessions with write confinement are not supported yet")
+		}
+		env = sanitizeEnv(env)
+		if err := ctx.Err(); err != nil {
+			return nil, errdefs.FromContext(err)
+		}
+		return startTTYSession(ctx, spec, workDir, env)
+	}
+
 	cmd := exec.Command(spec.Argv[0], spec.Argv[1:]...)
 	cmd.Dir = workDir
-	cmd.Env = buildEnv(spec.Opts.Env)
+	cmd.Env = env
 	if r.cfg.writeConfine {
 		writable := r.cfg.writable
 		if spec.Opts.Write != sandbox.WriteReadOnly {

--- a/core/sandbox/windows/runner.go
+++ b/core/sandbox/windows/runner.go
@@ -196,6 +196,7 @@ func (r *Runner) spawnProcess(ctx context.Context, spec sandbox.SessionSpec) (sa
 		}
 		cmd.Env = withLowTempEnv(cmd.Env, r.lowTemp)
 	}
+	cmd.Env = sanitizeEnv(cmd.Env)
 	if err := ctx.Err(); err != nil {
 		return nil, errdefs.FromContext(err)
 	}
@@ -316,4 +317,18 @@ func resolveAbsolutePaths(root string, paths []string) ([]string, error) {
 		out = append(out, filepath.Clean(p))
 	}
 	return out, nil
+}
+
+// sanitizeEnv drops entries containing NUL bytes. os/exec rejects such
+// entries with a hard error, and a malformed entry in the host
+// environment must not prevent spawning.
+func sanitizeEnv(env []string) []string {
+	out := env[:0]
+	for _, kv := range env {
+		if strings.IndexByte(kv, 0) >= 0 {
+			continue
+		}
+		out = append(out, kv)
+	}
+	return out
 }

--- a/core/sandbox/windows/runner.go
+++ b/core/sandbox/windows/runner.go
@@ -39,7 +39,10 @@ const defaultMaxOutputBytes int64 = 10 * 1024 * 1024
 //     WithWriteConfinement is NotAvailable until the restricted-token
 //     spawn path is verified against a real pseudo console.
 //   - Env: fully supported (see sandbox.EnvPolicy doc).
-//   - Net.Mode != corenet.NetDefault: errdefs.NotAvailable.
+//   - Net.Mode: NetDefault (host networking) and NetDenyAll
+//     (AppContainer without network capabilities) are supported;
+//     NetAllowList / NetProxy need the WFP layer and are
+//     errdefs.NotAvailable for now.
 //   - Write == WriteReadOnly: errdefs.NotAvailable (no OS boundary to
 //     confine writes yet).
 //   - Resources.MemoryBytes: enforced as a job-wide memory limit
@@ -108,6 +111,7 @@ func (r *Runner) Capabilities() sandbox.Capabilities {
 			sandbox.WriteReadOnly,
 		}
 	}
+	policy.NetModes = []corenet.NetMode{corenet.NetDenyAll}
 	return sandbox.Capabilities{
 		Policy:   policy,
 		Features: sandbox.SessionFeatures{TTY: true},
@@ -182,6 +186,24 @@ func (r *Runner) spawnProcess(ctx context.Context, spec sandbox.SessionSpec) (sa
 	spec.Opts.Resources.MaxOutputBytes = maxOut
 
 	env := buildEnv(spec.Opts.Env)
+	var iso *netIsolation
+	if spec.Opts.Net.Mode != corenet.NetDefault {
+		if spec.TTY {
+			return nil, errdefs.NotAvailablef(
+				"windows: TTY sessions with a net policy are not supported yet")
+		}
+		writable := r.cfg.writable
+		if spec.Opts.Write != sandbox.WriteReadOnly {
+			writable = append([]string{r.rootDir}, writable...)
+		}
+		iso, err = newNetIsolation(r.rootDir, writable, spec.Opts.Net.Mode)
+		if err != nil {
+			return nil, err
+		}
+		// AppContainer cannot read the user profile; redirect the
+		// child's home-facing env into the sandbox home.
+		env = iso.env(env)
+	}
 	if spec.TTY {
 		if r.cfg.writeConfine {
 			return nil, errdefs.NotAvailablef(
@@ -197,7 +219,7 @@ func (r *Runner) spawnProcess(ctx context.Context, spec sandbox.SessionSpec) (sa
 	cmd := exec.Command(spec.Argv[0], spec.Argv[1:]...)
 	cmd.Dir = workDir
 	cmd.Env = env
-	if r.cfg.writeConfine {
+	if iso == nil && r.cfg.writeConfine {
 		writable := r.cfg.writable
 		if spec.Opts.Write != sandbox.WriteReadOnly {
 			writable = append([]string{r.rootDir}, writable...)
@@ -213,7 +235,7 @@ func (r *Runner) spawnProcess(ctx context.Context, spec sandbox.SessionSpec) (sa
 	if err := ctx.Err(); err != nil {
 		return nil, errdefs.FromContext(err)
 	}
-	return startSession(ctx, spec, cmd, r.cfg.writeConfine)
+	return startSession(ctx, spec, cmd, r.cfg.writeConfine, iso)
 }
 
 // validatePolicy mirrors sandbox.ValidateExecPolicy minus the
@@ -231,8 +253,13 @@ func (r *Runner) validatePolicy(spec sandbox.SessionSpec) error {
 			"windows: write policy requires the runner to be constructed with WithWriteConfinement")
 	}
 	if spec.Opts.Net.Mode != corenet.NetDefault {
-		return errdefs.NotAvailablef(
-			"windows: net policy not supported; only NetDefault is available")
+		switch spec.Opts.Net.Mode {
+		case corenet.NetDenyAll:
+			// Supported: AppContainer without network capabilities.
+		default:
+			return errdefs.NotAvailablef(
+				"windows: net mode %d not supported yet", int(spec.Opts.Net.Mode))
+		}
 	}
 	if spec.Opts.Resources.DiskBytes != 0 {
 		return errdefs.NotAvailablef(

--- a/core/sandbox/windows/runner.go
+++ b/core/sandbox/windows/runner.go
@@ -39,10 +39,10 @@ const defaultMaxOutputBytes int64 = 10 * 1024 * 1024
 //     WithWriteConfinement is NotAvailable until the restricted-token
 //     spawn path is verified against a real pseudo console.
 //   - Env: fully supported (see sandbox.EnvPolicy doc).
-//   - Net.Mode: NetDefault (host networking) and NetDenyAll
-//     (AppContainer without network capabilities) are supported;
-//     NetAllowList / NetProxy need the WFP layer and are
-//     errdefs.NotAvailable for now.
+//   - Net.Mode: NetDefault (host networking), NetDenyAll (AppContainer
+//     without network capabilities), and NetAllowList / NetProxy
+//     (AppContainer + WFP port-pinning to the enforcement proxy) are
+//     supported. Non-elevated hosts fail closed with NotAvailable.
 //   - Write == WriteReadOnly: errdefs.NotAvailable (no OS boundary to
 //     confine writes yet).
 //   - Resources.MemoryBytes: enforced as a job-wide memory limit
@@ -111,7 +111,9 @@ func (r *Runner) Capabilities() sandbox.Capabilities {
 			sandbox.WriteReadOnly,
 		}
 	}
-	policy.NetModes = []corenet.NetMode{corenet.NetDenyAll}
+	policy.NetModes = []corenet.NetMode{
+		corenet.NetDenyAll, corenet.NetAllowList, corenet.NetProxy,
+	}
 	return sandbox.Capabilities{
 		Policy:   policy,
 		Features: sandbox.SessionFeatures{TTY: true},
@@ -196,7 +198,7 @@ func (r *Runner) spawnProcess(ctx context.Context, spec sandbox.SessionSpec) (sa
 		if spec.Opts.Write != sandbox.WriteReadOnly {
 			writable = append([]string{r.rootDir}, writable...)
 		}
-		iso, err = newNetIsolation(r.rootDir, writable, spec.Opts.Net.Mode)
+		iso, err = newNetIsolation(r.rootDir, writable, spec.Opts.Net)
 		if err != nil {
 			return nil, err
 		}
@@ -254,8 +256,9 @@ func (r *Runner) validatePolicy(spec sandbox.SessionSpec) error {
 	}
 	if spec.Opts.Net.Mode != corenet.NetDefault {
 		switch spec.Opts.Net.Mode {
-		case corenet.NetDenyAll:
-			// Supported: AppContainer without network capabilities.
+		case corenet.NetDenyAll, corenet.NetAllowList, corenet.NetProxy:
+			// Supported: AppContainer, plus WFP port-pinning to the
+			// enforcement proxy for allow_list / proxy modes.
 		default:
 			return errdefs.NotAvailablef(
 				"windows: net mode %d not supported yet", int(spec.Opts.Net.Mode))

--- a/core/sandbox/windows/runner.go
+++ b/core/sandbox/windows/runner.go
@@ -1,0 +1,261 @@
+//go:build windows
+
+package windows
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"sync"
+
+	"github.com/GizClaw/flowcraft/core/errdefs"
+	"github.com/GizClaw/flowcraft/core/sandbox"
+	corenet "github.com/GizClaw/flowcraft/core/utils/net"
+)
+
+// defaultMaxOutputBytes is the per-stream cap used by the one-shot
+// Exec when ExecOptions.Resources.MaxOutputBytes is zero.
+const defaultMaxOutputBytes int64 = 10 * 1024 * 1024
+
+// Runner executes commands directly on the host via os/exec, with the
+// child confined to a Windows Job Object that owns its whole process
+// tree. It is the no-filesystem-isolation backend for Windows:
+// lifecycle and resource caps are enforced by the kernel (job
+// objects); filesystem and network confinement are phase 2.
+//
+// Policy support matrix:
+//
+//   - WorkDir / Stdin / Timeout: fully supported. Every child runs in
+//     its own job; timeout/cancel closes the job and kills the whole
+//     tree, not just the leader.
+//   - Env: fully supported (see sandbox.EnvPolicy doc).
+//   - Net.Mode != corenet.NetDefault: errdefs.NotAvailable.
+//   - Write == WriteReadOnly: errdefs.NotAvailable (no OS boundary to
+//     confine writes yet).
+//   - Resources.MemoryBytes: enforced as a job-wide memory limit
+//     (JOB_OBJECT_LIMIT_JOB_MEMORY).
+//   - Resources.CPUMillicores: enforced as a per-process user-time
+//     limit = Timeout x millicores/1000; requires Timeout > 0,
+//     otherwise errdefs.NotAvailable.
+//   - Resources.DiskBytes != 0: errdefs.NotAvailable (no quota
+//     mechanism).
+//   - Resources.MaxOutputBytes: enforced; per-call value overrides the
+//     runner's WithMaxOutputBytes default.
+type Runner struct {
+	rootDir      string
+	cfg          runnerConfig
+	sessions     *sandbox.SessionRegistry
+	registryOnce sync.Once
+}
+
+// New constructs a Runner rooted at rootDir. The root is resolved via
+// filepath.Abs + EvalSymlinks so a later symlink swap on the root
+// itself cannot be used to escape.
+func New(rootDir string, opts ...Option) (*Runner, error) {
+	real, err := filepath.Abs(rootDir)
+	if err == nil {
+		if resolved, evalErr := filepath.EvalSymlinks(real); evalErr == nil {
+			real = resolved
+		}
+	}
+	r := &Runner{
+		rootDir: real,
+		cfg:     runnerConfig{defaultMaxOutput: defaultMaxOutputBytes},
+	}
+	for _, o := range opts {
+		o(&r.cfg)
+	}
+	return r, nil
+}
+
+// Capabilities declares the honest surface of the phase-1 backend:
+// env allow-lists and job-object resource caps are enforced; there is
+// no filesystem or network confinement yet, and sessions are
+// pipe-only (no TTY / signal / event features).
+func (r *Runner) Capabilities() sandbox.Capabilities {
+	return sandbox.Capabilities{
+		Policy: sandbox.Enforcement{
+			EnvAllowList: true,
+			MemoryCap:    true,
+			CPUCap:       true,
+		},
+		Features: sandbox.SessionFeatures{},
+	}
+}
+
+// Exec runs cmd with args under opts. See Runner doc for which policy
+// fields are honoured vs. rejected with errdefs.NotAvailable.
+func (r *Runner) Exec(ctx context.Context, cmd string, args []string, opts sandbox.ExecOptions) (*sandbox.ExecResult, error) {
+	return sandbox.Exec(ctx, r, cmd, args, opts)
+}
+
+// Start implements Runner: policy validation mirrors Exec, then the
+// command is spawned on pipes inside a fresh job object.
+func (r *Runner) Start(ctx context.Context, spec sandbox.SessionSpec) (sandbox.Session, error) {
+	return r.registry().Start(ctx, spec)
+}
+
+// List implements Runner.
+func (r *Runner) List(ctx context.Context) ([]sandbox.SessionInfo, error) {
+	return r.registry().List(ctx)
+}
+
+// Terminate implements Runner.
+func (r *Runner) Terminate(ctx context.Context, id string) error {
+	return r.registry().Terminate(ctx, id)
+}
+
+// Close implements core/sandbox.Runner: it terminates every session
+// started through this runner. Safe to call more than once and when
+// the runner never started anything.
+func (r *Runner) Close() error {
+	return r.registry().Close()
+}
+
+// registry returns the session registry, initialising it lazily so a
+// zero-value Runner still answers with NotAvailable instead of
+// panicking on a nil interface.
+func (r *Runner) registry() *sandbox.SessionRegistry {
+	r.registryOnce.Do(func() {
+		if r.sessions == nil {
+			r.sessions = sandbox.NewSessionRegistry(r.spawnProcess)
+		}
+	})
+	return r.sessions
+}
+
+// spawnProcess is Runner's sandbox.SessionStarter: it applies the
+// same policy surface as Exec and hands the configured command to the
+// session implementation, which owns job creation and assignment.
+func (r *Runner) spawnProcess(ctx context.Context, spec sandbox.SessionSpec) (sandbox.Session, error) {
+	if err := r.validatePolicy(spec); err != nil {
+		return nil, err
+	}
+	if spec.TTY {
+		return nil, errdefs.NotAvailablef(
+			"windows: TTY sessions are not supported (pipe sessions only)")
+	}
+	workDir, err := r.resolveWorkDir(spec.Opts.WorkDir)
+	if err != nil {
+		return nil, err
+	}
+	maxOut := spec.Opts.Resources.MaxOutputBytes
+	if maxOut <= 0 {
+		maxOut = r.cfg.defaultMaxOutput
+	}
+	spec.Opts.Resources.MaxOutputBytes = maxOut
+
+	cmd := exec.Command(spec.Argv[0], spec.Argv[1:]...)
+	cmd.Dir = workDir
+	cmd.Env = buildEnv(spec.Opts.Env)
+	if err := ctx.Err(); err != nil {
+		return nil, errdefs.FromContext(err)
+	}
+	return startSession(ctx, spec, cmd)
+}
+
+// validatePolicy mirrors sandbox.ValidateExecPolicy minus the
+// process-group sampling gate: the windows backend enforces Memory /
+// CPU caps through job objects, so the shared unix ps(1) sampler
+// availability check does not apply. The job-object caps themselves
+// are enforced by the kernel, not sampled.
+func (r *Runner) validatePolicy(spec sandbox.SessionSpec) error {
+	if spec.Opts.Write > sandbox.WriteReadOnly {
+		return errdefs.Validationf(
+			"windows: unknown write policy %d", int(spec.Opts.Write))
+	}
+	if spec.Opts.Write == sandbox.WriteReadOnly {
+		return errdefs.NotAvailablef(
+			"windows: write policy not supported (no OS-level write confinement yet)")
+	}
+	if spec.Opts.Net.Mode != corenet.NetDefault {
+		return errdefs.NotAvailablef(
+			"windows: net policy not supported; only NetDefault is available")
+	}
+	if spec.Opts.Resources.DiskBytes != 0 {
+		return errdefs.NotAvailablef(
+			"windows: disk limits not supported (no quota mechanism)")
+	}
+	if spec.Opts.Resources.CPUMillicores != 0 && spec.Opts.Timeout <= 0 {
+		return errdefs.NotAvailablef(
+			"windows: CPUMillicores requires a per-call Timeout to derive a cpu-time cap")
+	}
+	return nil
+}
+
+// buildEnv translates a sandbox.EnvPolicy into a flat []string
+// suitable for exec.Cmd.Env. The empty result is returned as nil so
+// os/exec falls back to its "no env at all" code path (which is what
+// we want when the caller asked for an empty allow-list with no
+// Inject).
+func buildEnv(p sandbox.EnvPolicy) []string {
+	var env []string
+
+	if p.Allow == nil {
+		env = append(env, os.Environ()...)
+	} else if len(p.Allow) > 0 {
+		allow := make(map[string]bool, len(p.Allow))
+		for _, name := range p.Allow {
+			allow[name] = true
+		}
+		for _, kv := range os.Environ() {
+			idx := strings.IndexByte(kv, '=')
+			if idx <= 0 {
+				continue
+			}
+			if allow[kv[:idx]] {
+				env = append(env, kv)
+			}
+		}
+	}
+
+	if len(p.Inject) > 0 {
+		injected := make(map[string]bool, len(p.Inject))
+		for k := range p.Inject {
+			injected[k] = true
+		}
+		filtered := env[:0]
+		for _, kv := range env {
+			idx := strings.IndexByte(kv, '=')
+			if idx <= 0 {
+				filtered = append(filtered, kv)
+				continue
+			}
+			if !injected[kv[:idx]] {
+				filtered = append(filtered, kv)
+			}
+		}
+		env = filtered
+		for k, v := range p.Inject {
+			env = append(env, fmt.Sprintf("%s=%s", k, v))
+		}
+	}
+
+	if p.Allow != nil && len(p.Allow) == 0 && len(p.Inject) == 0 {
+		// Distinguish "inherit nothing" from "inherit everything":
+		// return an empty (non-nil) slice so exec.Cmd.Env is set to no
+		// entries instead of falling back to os.Environ().
+		return []string{}
+	}
+	return env
+}
+
+func (r *Runner) resolveWorkDir(dir string) (string, error) {
+	abs := dir
+	if !filepath.IsAbs(dir) {
+		abs = filepath.Join(r.rootDir, dir)
+	}
+	abs = filepath.Clean(abs)
+
+	real, err := sandbox.EvalExistingPrefix(abs)
+	if err != nil {
+		return "", fmt.Errorf("windows: resolve workdir: %w", err)
+	}
+	if real != r.rootDir && !strings.HasPrefix(real, r.rootDir+string(filepath.Separator)) {
+		return "", fmt.Errorf("%w: workdir %q escapes root", sandbox.ErrPathTraversal, dir)
+	}
+	return abs, nil
+}

--- a/core/sandbox/windows/runner.go
+++ b/core/sandbox/windows/runner.go
@@ -313,10 +313,22 @@ func (r *Runner) resolveWorkDir(dir string) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("windows: resolve workdir: %w", err)
 	}
-	if real != r.rootDir && !strings.HasPrefix(real, r.rootDir+string(filepath.Separator)) {
+	if !containedInRoot(real, r.rootDir) {
 		return "", fmt.Errorf("%w: workdir %q escapes root", sandbox.ErrPathTraversal, dir)
 	}
 	return abs, nil
+}
+
+// containedInRoot reports whether path is root itself or directly
+// under it. Windows paths are case-insensitive, so the prefix check
+// folds case (this file only builds on Windows); the workspace layer's
+// equivalent check does the same.
+func containedInRoot(path, root string) bool {
+	if strings.EqualFold(path, root) {
+		return true
+	}
+	return strings.HasPrefix(strings.ToLower(path),
+		strings.ToLower(root)+string(filepath.Separator))
 }
 
 // resolveAbsolutePaths makes each path absolute (relative entries are

--- a/core/sandbox/windows/runner.go
+++ b/core/sandbox/windows/runner.go
@@ -13,7 +13,10 @@ import (
 
 	"github.com/GizClaw/flowcraft/core/errdefs"
 	"github.com/GizClaw/flowcraft/core/sandbox"
+	"github.com/GizClaw/flowcraft/core/telemetry"
 	corenet "github.com/GizClaw/flowcraft/core/utils/net"
+
+	otellog "go.opentelemetry.io/otel/log"
 )
 
 // defaultMaxOutputBytes is the per-stream cap used by the one-shot
@@ -49,6 +52,7 @@ type Runner struct {
 	cfg          runnerConfig
 	sessions     *sandbox.SessionRegistry
 	registryOnce sync.Once
+	lowTemp      string
 }
 
 // New constructs a Runner rooted at rootDir. The root is resolved via
@@ -68,20 +72,40 @@ func New(rootDir string, opts ...Option) (*Runner, error) {
 	for _, o := range opts {
 		o(&r.cfg)
 	}
+	if r.cfg.writeConfine {
+		var err error
+		r.cfg.writable, err = resolveAbsolutePaths(real, r.cfg.writable)
+		if err != nil {
+			return nil, err
+		}
+		r.lowTemp, err = createLowTempDir()
+		if err != nil {
+			return nil, err
+		}
+	}
 	return r, nil
 }
 
-// Capabilities declares the honest surface of the phase-1 backend:
-// env allow-lists and job-object resource caps are enforced; there is
-// no filesystem or network confinement yet, and sessions are
-// pipe-only (no TTY / signal / event features).
+// Capabilities declares the honest surface: env allow-lists and
+// job-object resource caps are always enforced; filesystem write
+// bounds are enforced when the runner was constructed with
+// WithWriteConfinement. Sessions are pipe-only (no TTY / signal /
+// event features).
 func (r *Runner) Capabilities() sandbox.Capabilities {
+	policy := sandbox.Enforcement{
+		EnvAllowList: true,
+		MemoryCap:    true,
+		CPUCap:       true,
+	}
+	if r.cfg.writeConfine {
+		policy.FilesystemBounds = true
+		policy.WriteModes = []sandbox.WritePolicy{
+			sandbox.WriteWorkspace,
+			sandbox.WriteReadOnly,
+		}
+	}
 	return sandbox.Capabilities{
-		Policy: sandbox.Enforcement{
-			EnvAllowList: true,
-			MemoryCap:    true,
-			CPUCap:       true,
-		},
+		Policy:   policy,
 		Features: sandbox.SessionFeatures{},
 	}
 }
@@ -112,7 +136,16 @@ func (r *Runner) Terminate(ctx context.Context, id string) error {
 // started through this runner. Safe to call more than once and when
 // the runner never started anything.
 func (r *Runner) Close() error {
-	return r.registry().Close()
+	err := r.registry().Close()
+	if r.lowTemp != "" {
+		if rerr := os.RemoveAll(r.lowTemp); rerr != nil {
+			telemetry.WarnErr(context.Background(),
+				"windows: remove low-IL temp dir failed", rerr,
+				otellog.String("windows.temp_dir", r.lowTemp))
+		}
+		r.lowTemp = ""
+	}
+	return err
 }
 
 // registry returns the session registry, initialising it lazily so a
@@ -151,10 +184,22 @@ func (r *Runner) spawnProcess(ctx context.Context, spec sandbox.SessionSpec) (sa
 	cmd := exec.Command(spec.Argv[0], spec.Argv[1:]...)
 	cmd.Dir = workDir
 	cmd.Env = buildEnv(spec.Opts.Env)
+	if r.cfg.writeConfine {
+		writable := r.cfg.writable
+		if spec.Opts.Write != sandbox.WriteReadOnly {
+			writable = append([]string{r.rootDir}, writable...)
+		}
+		for _, p := range writable {
+			if err := labelLowIntegrity(p); err != nil {
+				return nil, err
+			}
+		}
+		cmd.Env = withLowTempEnv(cmd.Env, r.lowTemp)
+	}
 	if err := ctx.Err(); err != nil {
 		return nil, errdefs.FromContext(err)
 	}
-	return startSession(ctx, spec, cmd)
+	return startSession(ctx, spec, cmd, r.cfg.writeConfine)
 }
 
 // validatePolicy mirrors sandbox.ValidateExecPolicy minus the
@@ -167,9 +212,9 @@ func (r *Runner) validatePolicy(spec sandbox.SessionSpec) error {
 		return errdefs.Validationf(
 			"windows: unknown write policy %d", int(spec.Opts.Write))
 	}
-	if spec.Opts.Write == sandbox.WriteReadOnly {
+	if spec.Opts.Write == sandbox.WriteReadOnly && !r.cfg.writeConfine {
 		return errdefs.NotAvailablef(
-			"windows: write policy not supported (no OS-level write confinement yet)")
+			"windows: write policy requires the runner to be constructed with WithWriteConfinement")
 	}
 	if spec.Opts.Net.Mode != corenet.NetDefault {
 		return errdefs.NotAvailablef(
@@ -258,4 +303,17 @@ func (r *Runner) resolveWorkDir(dir string) (string, error) {
 		return "", fmt.Errorf("%w: workdir %q escapes root", sandbox.ErrPathTraversal, dir)
 	}
 	return abs, nil
+}
+
+// resolveAbsolutePaths makes each path absolute (relative entries are
+// resolved against root) without requiring them to exist yet.
+func resolveAbsolutePaths(root string, paths []string) ([]string, error) {
+	out := make([]string, 0, len(paths))
+	for _, p := range paths {
+		if !filepath.IsAbs(p) {
+			p = filepath.Join(root, p)
+		}
+		out = append(out, filepath.Clean(p))
+	}
+	return out, nil
 }

--- a/core/sandbox/windows/runner_other.go
+++ b/core/sandbox/windows/runner_other.go
@@ -1,0 +1,46 @@
+//go:build !windows
+
+package windows
+
+import (
+	"context"
+
+	"github.com/GizClaw/flowcraft/core/errdefs"
+	"github.com/GizClaw/flowcraft/core/sandbox"
+)
+
+// Runner is the non-Windows stub of the windows backend.
+type Runner struct{}
+
+// New always returns errdefs.NotAvailable on non-Windows platforms.
+func New(rootDir string, opts ...Option) (*Runner, error) {
+	_ = rootDir
+	_ = opts
+	return nil, errdefs.NotAvailablef(
+		"windows: backend requires Windows; not available on this platform")
+}
+
+// Capabilities reports no capabilities on unsupported platforms.
+func (*Runner) Capabilities() sandbox.Capabilities {
+	return sandbox.Capabilities{Policy: sandbox.Enforcement{}}
+}
+
+// Start is unreachable because New never returns a non-nil Runner.
+func (*Runner) Start(context.Context, sandbox.SessionSpec) (sandbox.Session, error) {
+	return nil, errdefs.NotAvailablef("windows: not available on this platform")
+}
+
+// List is unreachable outside Windows.
+func (*Runner) List(context.Context) ([]sandbox.SessionInfo, error) {
+	return nil, errdefs.NotAvailablef("windows: not available on this platform")
+}
+
+// Terminate is unreachable outside Windows.
+func (*Runner) Terminate(context.Context, string) error {
+	return errdefs.NotAvailablef("windows: not available on this platform")
+}
+
+// Close is unreachable outside Windows.
+func (*Runner) Close() error {
+	return errdefs.NotAvailablef("windows: not available on this platform")
+}

--- a/core/sandbox/windows/session_windows.go
+++ b/core/sandbox/windows/session_windows.go
@@ -1,0 +1,540 @@
+//go:build windows
+
+package windows
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"sync"
+	"time"
+
+	"github.com/GizClaw/flowcraft/core/errdefs"
+	"github.com/GizClaw/flowcraft/core/sandbox"
+	"github.com/GizClaw/flowcraft/core/telemetry"
+
+	otellog "go.opentelemetry.io/otel/log"
+	xwin "golang.org/x/sys/windows"
+)
+
+const (
+	sessionWriteConcurrency = 4
+	// sessionKillTimeout bounds how long Close waits for the job to
+	// die after TerminateJobObject. A stuck kernel state must not hang
+	// the caller forever.
+	sessionKillTimeout = 2 * time.Second
+)
+
+// startSession spawns spec.Argv under a fresh job object and returns
+// a pipe-only Session. The process is created suspended
+// (CREATE_SUSPENDED), assigned to the job before any user code runs,
+// then resumed, so grandchildren cannot escape the job's limits.
+//
+// Policy validation belongs to the runner (validatePolicy); this
+// constructor enforces mechanics only. spec.Opts.Resources.
+// MaxOutputBytes bounds the replayable output ring when positive.
+func startSession(ctx context.Context, spec sandbox.SessionSpec, cmd *exec.Cmd) (sandbox.Session, error) {
+	if cmd == nil {
+		return nil, errdefs.Validationf("windows: nil command for process session")
+	}
+	j, err := createJob(spec.Opts.Resources, spec.Opts.Timeout)
+	if err != nil {
+		return nil, err
+	}
+	abort := func(err error) (sandbox.Session, error) {
+		// KILL_ON_JOB_CLOSE terminates the child if it already ran.
+		if cerr := j.close(); cerr != nil {
+			telemetry.WarnErr(context.Background(),
+				"windows: close job after start failure", cerr)
+		}
+		return nil, err
+	}
+
+	stdin, err := cmd.StdinPipe()
+	if err != nil {
+		return abort(classifyStartError(cmd.Path, err))
+	}
+	s := &winSession{
+		id:         spec.ID,
+		cmd:        cmd,
+		job:        j,
+		stdin:      stdin,
+		out:        newOutputLog(spec.Opts.Resources.MaxOutputBytes),
+		done:       make(chan struct{}),
+		writeSlots: make(chan struct{}, sessionWriteConcurrency),
+	}
+	cmd.Stdout = sessionWriter{out: s.out, stream: sandbox.SessionStreamStdout}
+	cmd.Stderr = sessionWriter{out: s.out, stream: sandbox.SessionStreamStderr}
+	// os/exec copies child stdout/stderr into these writers, and
+	// cmd.Wait drains them, so output ordering relative to process
+	// exit is exact.
+	cmd.SysProcAttr = &xwin.SysProcAttr{
+		CreationFlags: xwin.CREATE_SUSPENDED | xwin.CREATE_NO_WINDOW,
+	}
+	if err := cmd.Start(); err != nil {
+		_ = stdin.Close()
+		return abort(classifyStartError(cmd.Path, err))
+	}
+	s.proc = cmd.Process
+	if err := j.assign(cmd.Process.Pid); err != nil {
+		return abort(err)
+	}
+	if err := resumeProcess(cmd.Process.Pid); err != nil {
+		return abort(err)
+	}
+
+	if spec.Opts.Timeout > 0 {
+		timer := time.AfterFunc(spec.Opts.Timeout, s.timeoutKill)
+		go func() {
+			<-s.done
+			timer.Stop()
+		}()
+	}
+	go s.reap()
+	return s, nil
+}
+
+// winSession is the concrete Windows session: the child's stdio
+// pipes, the bounded replayable output log, and the owning job
+// object.
+type winSession struct {
+	id         string
+	cmd        *exec.Cmd
+	job        *job
+	stdin      io.WriteCloser
+	proc       *os.Process
+	out        *outputLog
+	writeSlots chan struct{}
+
+	mu         sync.Mutex
+	closed     bool
+	timedOut   bool
+	terminated bool
+	exit       sandbox.SessionExit
+	waitErr    error
+	done       chan struct{}
+}
+
+func (s *winSession) ID() string { return s.id }
+
+func (s *winSession) PID() int {
+	if s.proc == nil {
+		return 0
+	}
+	return s.proc.Pid
+}
+
+func (s *winSession) Read(ctx context.Context, afterSeq int64, maxBytes int) (sandbox.SessionOutput, error) {
+	if s.isClosed() {
+		return sandbox.SessionOutput{}, sandbox.ErrSessionClosed
+	}
+	return s.out.read(ctx, afterSeq, maxBytes)
+}
+
+func (s *winSession) Write(ctx context.Context, data []byte) error {
+	if s.isClosed() {
+		return sandbox.ErrSessionClosed
+	}
+	if s.stdin == nil {
+		return sandbox.ErrSessionClosed
+	}
+	if len(data) == 0 {
+		return nil
+	}
+	select {
+	case s.writeSlots <- struct{}{}:
+	case <-ctx.Done():
+		return errdefs.FromContext(ctx.Err())
+	case <-s.done:
+		return sandbox.ErrSessionClosed
+	}
+	done := make(chan error, 1)
+	go func() {
+		defer func() { <-s.writeSlots }()
+		_, err := io.Copy(s.stdin, bytes.NewReader(data))
+		done <- err
+	}()
+	select {
+	case err := <-done:
+		if err != nil {
+			return errdefs.Internal(fmt.Errorf("windows: process write: %w", err))
+		}
+		return nil
+	case <-ctx.Done():
+		// The child is not draining; the write goroutine stays blocked
+		// on the pipe until the session closes. Callers should not
+		// retry the same bytes blindly.
+		return ctx.Err()
+	}
+}
+
+// CloseInput closes the session's stdin. Pipe sessions support it;
+// there are no TTY sessions on this backend.
+func (s *winSession) CloseInput() error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.closed {
+		return sandbox.ErrSessionClosed
+	}
+	if s.stdin == nil {
+		return nil
+	}
+	err := s.stdin.Close()
+	s.stdin = nil
+	if errors.Is(err, os.ErrClosed) {
+		// cmd.Wait (running in reap) closes the parent-side stdin
+		// write end once the child exits. Racing that cleanup is a
+		// successful no-op.
+		return nil
+	}
+	return err
+}
+
+// Resize is not available: pipe sessions have no window.
+func (s *winSession) Resize(context.Context, int, int) error {
+	return errdefs.NotAvailablef("windows: Resize requires a TTY session")
+}
+
+// Signal is not available: Windows has no portable Ctrl-C delivery to
+// a detached process tree. Use Terminate.
+func (s *winSession) Signal(context.Context, sandbox.SessionSignal) error {
+	return errdefs.NotAvailablef(
+		"windows: signal delivery is not supported; use Terminate")
+}
+
+// Watch is not available: the phase-1 backend has no event streams.
+func (s *winSession) Watch(context.Context) (sandbox.SessionWatcher, error) {
+	return nil, errdefs.NotAvailablef("windows: event streams are not supported")
+}
+
+// Capabilities declares this session's actual surface: pipe-only,
+// with no TTY / signal / event features.
+func (s *winSession) Capabilities() sandbox.SessionCapabilities {
+	return sandbox.SessionCapabilities{}
+}
+
+// Terminate stops the whole job immediately (Windows has no SIGTERM).
+// It is idempotent on an exited process and leaves the output log
+// readable.
+func (s *winSession) Terminate(ctx context.Context) error {
+	if s.isClosed() {
+		return sandbox.ErrSessionClosed
+	}
+	select {
+	case <-s.done:
+		return nil
+	default:
+	}
+	s.mu.Lock()
+	s.terminated = true
+	s.mu.Unlock()
+	if err := s.job.terminate(); err != nil {
+		return err
+	}
+	select {
+	case <-s.done:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+// Wait blocks until the process exits (or ctx is done) and returns
+// the cached outcome; it is safe to call repeatedly and after Close.
+func (s *winSession) Wait(ctx context.Context) (sandbox.SessionExit, error) {
+	select {
+	case <-s.done:
+	case <-ctx.Done():
+		return sandbox.SessionExit{}, ctx.Err()
+	}
+	s.mu.Lock()
+	exit, err := s.exit, s.waitErr
+	s.mu.Unlock()
+	return exit, err
+}
+
+// Close terminates a still-running session, reaps it, and releases
+// the output log and the job handle. Close is idempotent; the manager
+// forgets the session so it no longer appears in List.
+func (s *winSession) Close() error {
+	s.mu.Lock()
+	if s.closed {
+		s.mu.Unlock()
+		return nil
+	}
+	s.closed = true
+	s.mu.Unlock()
+
+	select {
+	case <-s.done:
+	default:
+		_ = s.job.terminate()
+		select {
+		case <-s.done:
+		case <-time.After(sessionKillTimeout):
+			telemetry.Warn(context.Background(),
+				"windows: job did not exit after TerminateJobObject on close",
+				otellog.String("windows.session_id", s.id),
+				otellog.Int("windows.pid", s.PID()))
+		}
+	}
+	s.mu.Lock()
+	stdin := s.stdin
+	s.stdin = nil
+	s.mu.Unlock()
+	if stdin != nil {
+		if err := stdin.Close(); err != nil {
+			telemetry.WarnErr(context.Background(), "windows: close session stdin failed", err,
+				otellog.String("windows.session_id", s.id))
+		}
+	}
+	if err := s.job.close(); err != nil {
+		telemetry.WarnErr(context.Background(), "windows: close job failed", err,
+			otellog.String("windows.session_id", s.id))
+	}
+	s.out.close()
+	return nil
+}
+
+func (s *winSession) isClosed() bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.closed
+}
+
+// timeoutKill is ExecOptions.Timeout enforcement: the whole job is
+// terminated, like Runner.Exec does on ctx deadline.
+func (s *winSession) timeoutKill() {
+	s.mu.Lock()
+	s.timedOut = true
+	s.mu.Unlock()
+	_ = s.job.terminate()
+}
+
+// reap reaps the child, classifies the outcome, then finishes the
+// output log. cmd.Wait also waits for the stdout/stderr copy
+// goroutines (sessionWriter), so finish() after Wait never races
+// buffered output.
+func (s *winSession) reap() {
+	waitErr := s.cmd.Wait()
+	exit, err := s.classifyExit(waitErr)
+	s.mu.Lock()
+	s.exit = exit
+	s.waitErr = err
+	s.mu.Unlock()
+	s.out.finish()
+	close(s.done)
+}
+
+func (s *winSession) classifyExit(waitErr error) (sandbox.SessionExit, error) {
+	s.mu.Lock()
+	timedOut := s.timedOut
+	terminated := s.terminated
+	s.mu.Unlock()
+	if timedOut {
+		return sandbox.SessionExit{Code: -1, Reason: sandbox.SessionTimedOut},
+			errdefs.FromContext(fmt.Errorf(
+				"windows: process exceeded its Timeout: %w", context.DeadlineExceeded))
+	}
+	if waitErr == nil {
+		return sandbox.SessionExit{Code: 0, Reason: sandbox.SessionExited}, nil
+	}
+	if exitErr, ok := waitErr.(*exec.ExitError); ok {
+		if terminated {
+			return sandbox.SessionExit{Code: -1, Reason: sandbox.SessionTerminated}, nil
+		}
+		return sandbox.SessionExit{Code: exitErr.ExitCode(), Reason: sandbox.SessionExited}, nil
+	}
+	return sandbox.SessionExit{Code: -1, Reason: sandbox.SessionExited},
+		errdefs.Internal(fmt.Errorf("windows: process wait: %w", waitErr))
+}
+
+// sessionWriter is exec.Cmd's stdout/stderr sink for pipe sessions.
+// cmd.Wait waits for these writers, so output ordering relative to
+// process exit is exact.
+type sessionWriter struct {
+	out    *outputLog
+	stream sandbox.SessionStream
+}
+
+func (w sessionWriter) Write(p []byte) (int, error) {
+	w.out.append(w.stream, p)
+	return len(p), nil
+}
+
+// outputLog is the append-only, bounded, replayable output buffer
+// (a simplified port of core/sandbox's unix outputLog without event
+// subscribers). Seq is a byte cursor: each chunk records the sequence
+// of its first byte and the log advances by len(data). When the ring
+// budget is exceeded, oldest whole chunks are dropped and Read
+// reports ErrSequenceGap for cursors below the retained range.
+type outputLog struct {
+	mu      sync.Mutex
+	wake    chan struct{}
+	chunks  []outputChunk
+	total   int64
+	nextSeq int64
+	max     int64
+	eof     bool
+	closed  bool
+}
+
+type outputChunk struct {
+	seq    int64
+	stream sandbox.SessionStream
+	data   []byte
+}
+
+func newOutputLog(maxBytes int64) *outputLog {
+	return &outputLog{wake: make(chan struct{}), max: maxBytes}
+}
+
+func (l *outputLog) append(stream sandbox.SessionStream, data []byte) {
+	if len(data) == 0 {
+		return
+	}
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	if l.closed {
+		return
+	}
+	l.chunks = append(l.chunks, outputChunk{
+		seq:    l.nextSeq,
+		stream: stream,
+		data:   append([]byte(nil), data...),
+	})
+	l.total += int64(len(data))
+	l.nextSeq += int64(len(data))
+	l.trimLocked()
+	l.wakeReadersLocked()
+}
+
+// finish marks the stream complete and wakes blocked readers so a
+// Read at the end of output returns EOF.
+func (l *outputLog) finish() {
+	l.mu.Lock()
+	l.eof = true
+	l.wakeReadersLocked()
+	l.mu.Unlock()
+}
+
+// close marks the log closed: reads fail with ErrSessionClosed.
+func (l *outputLog) close() {
+	l.mu.Lock()
+	l.closed = true
+	l.wakeReadersLocked()
+	l.mu.Unlock()
+}
+
+// read returns output at/after afterSeq, at most maxBytes, blocking
+// until data, EOF, or ctx cancellation.
+func (l *outputLog) read(ctx context.Context, afterSeq int64, maxBytes int) (sandbox.SessionOutput, error) {
+	if maxBytes <= 0 {
+		return sandbox.SessionOutput{}, errdefs.Validationf(
+			"windows: Read maxBytes must be positive")
+	}
+	l.mu.Lock()
+	for {
+		if l.closed {
+			l.mu.Unlock()
+			return sandbox.SessionOutput{}, sandbox.ErrSessionClosed
+		}
+		if retained := l.retainedSeqLocked(); retained > afterSeq {
+			l.mu.Unlock()
+			return sandbox.SessionOutput{}, fmt.Errorf("%w: afterSeq %d, retained from %d",
+				sandbox.ErrSequenceGap, afterSeq, retained)
+		}
+		if l.nextSeq < afterSeq {
+			l.mu.Unlock()
+			return sandbox.SessionOutput{}, errdefs.Validationf(
+				"windows: afterSeq %d is beyond buffered output (next=%d)",
+				afterSeq, l.nextSeq)
+		}
+		if out, ok := l.collectLocked(afterSeq, maxBytes); ok {
+			l.mu.Unlock()
+			return out, nil
+		}
+		if l.eof {
+			l.mu.Unlock()
+			return sandbox.SessionOutput{NextSeq: afterSeq, EOF: true}, nil
+		}
+		wake := l.wake
+		l.mu.Unlock()
+		select {
+		case <-wake:
+		case <-ctx.Done():
+			return sandbox.SessionOutput{}, ctx.Err()
+		}
+		l.mu.Lock()
+	}
+}
+
+func (l *outputLog) collectLocked(afterSeq int64, maxBytes int) (sandbox.SessionOutput, bool) {
+	remaining := int64(maxBytes)
+	next := afterSeq
+	var chunks []sandbox.OutputChunk
+	for _, ch := range l.chunks {
+		if remaining <= 0 {
+			break
+		}
+		end := ch.seq + int64(len(ch.data))
+		if next >= end {
+			continue
+		}
+		start := next - ch.seq
+		n := int64(len(ch.data)) - start
+		if n > remaining {
+			n = remaining
+		}
+		chunks = append(chunks, sandbox.OutputChunk{
+			Seq:    next,
+			Stream: ch.stream,
+			Data:   append([]byte(nil), ch.data[start:start+n]...),
+		})
+		next += n
+		remaining -= n
+	}
+	if len(chunks) == 0 {
+		return sandbox.SessionOutput{}, false
+	}
+	return sandbox.SessionOutput{
+		NextSeq: next,
+		Chunks:  chunks,
+		EOF:     l.eof && next == l.nextSeq,
+	}, true
+}
+
+func (l *outputLog) retainedSeqLocked() int64 {
+	if len(l.chunks) == 0 {
+		return l.nextSeq
+	}
+	return l.chunks[0].seq
+}
+
+func (l *outputLog) trimLocked() {
+	if l.max <= 0 {
+		return
+	}
+	// Never drop the only chunk: a single chunk larger than the
+	// budget is bounded by the pipe copy buffer and stays replayable.
+	for len(l.chunks) > 1 && l.total > l.max {
+		l.total -= int64(len(l.chunks[0].data))
+		l.chunks = l.chunks[1:]
+	}
+}
+
+// wakeReadersLocked notifies blocked Reads that the log changed. The
+// closed channel is immediately replaced so future waits get a fresh
+// signal channel.
+func (l *outputLog) wakeReadersLocked() {
+	close(l.wake)
+	l.wake = make(chan struct{})
+}
+
+func classifyStartError(path string, err error) error {
+	return errdefs.Internal(fmt.Errorf("windows: start %s: %w", path, err))
+}

--- a/core/sandbox/windows/session_windows.go
+++ b/core/sandbox/windows/session_windows.go
@@ -81,6 +81,9 @@ func startSession(ctx context.Context, spec sandbox.SessionSpec, cmd *exec.Cmd, 
 		// reads everywhere, writes only where the mandatory label was
 		// lowered. The handle stays valid through Start (the process
 		// copies the token); closing it after is safe.
+		if err := enableQuotaPrivilege(); err != nil {
+			return abort(err)
+		}
 		token, err := restrictToken()
 		if err != nil {
 			return abort(err)

--- a/core/sandbox/windows/session_windows.go
+++ b/core/sandbox/windows/session_windows.go
@@ -351,6 +351,21 @@ func (s *winSession) classifyExit(waitErr error) (sandbox.SessionExit, error) {
 	timedOut := s.timedOut
 	terminated := s.terminated
 	s.mu.Unlock()
+	// A cap-kill completion message can land a moment after the
+	// process exits; give the notifier a short grace window so a
+	// kernel-enforced limit is classified as BudgetExceeded rather
+	// than a plain exit.
+	if s.job.notify != nil {
+		deadline := time.Now().Add(100 * time.Millisecond)
+		for s.job.budgetCap() == "" && time.Now().Before(deadline) {
+			time.Sleep(5 * time.Millisecond)
+		}
+		if cap := s.job.budgetCap(); cap != "" {
+			return sandbox.SessionExit{Code: -1, Reason: sandbox.SessionBudgetExceeded},
+				errdefs.BudgetExceededf(
+					"windows: %s resource cap exceeded while running process", cap)
+		}
+	}
 	if timedOut {
 		return sandbox.SessionExit{Code: -1, Reason: sandbox.SessionTimedOut},
 			errdefs.FromContext(fmt.Errorf(

--- a/core/sandbox/windows/session_windows.go
+++ b/core/sandbox/windows/session_windows.go
@@ -255,7 +255,14 @@ func (s *winSession) Write(ctx context.Context, data []byte) error {
 	if s.isClosed() {
 		return sandbox.ErrSessionClosed
 	}
-	if s.stdin == nil {
+	// Snapshot stdin under the lock: CloseInput / Close nil it out
+	// concurrently, so the writer goroutine below must never read the
+	// field itself (that would be a data race and could panic on a
+	// nil writer).
+	s.mu.Lock()
+	stdin := s.stdin
+	s.mu.Unlock()
+	if stdin == nil {
 		return sandbox.ErrSessionClosed
 	}
 	if len(data) == 0 {
@@ -271,7 +278,7 @@ func (s *winSession) Write(ctx context.Context, data []byte) error {
 	done := make(chan error, 1)
 	go func() {
 		defer func() { <-s.writeSlots }()
-		_, err := io.Copy(s.stdin, bytes.NewReader(data))
+		_, err := io.Copy(stdin, bytes.NewReader(data))
 		done <- err
 	}()
 	select {

--- a/core/sandbox/windows/session_windows.go
+++ b/core/sandbox/windows/session_windows.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"os/exec"
 	"sync"
+	"syscall"
 	"time"
 
 	"github.com/GizClaw/flowcraft/core/errdefs"
@@ -37,7 +38,7 @@ const (
 // Policy validation belongs to the runner (validatePolicy); this
 // constructor enforces mechanics only. spec.Opts.Resources.
 // MaxOutputBytes bounds the replayable output ring when positive.
-func startSession(ctx context.Context, spec sandbox.SessionSpec, cmd *exec.Cmd) (sandbox.Session, error) {
+func startSession(ctx context.Context, spec sandbox.SessionSpec, cmd *exec.Cmd, confine bool) (sandbox.Session, error) {
 	if cmd == nil {
 		return nil, errdefs.Validationf("windows: nil command for process session")
 	}
@@ -74,6 +75,18 @@ func startSession(ctx context.Context, spec sandbox.SessionSpec, cmd *exec.Cmd) 
 	// exit is exact.
 	cmd.SysProcAttr = &xwin.SysProcAttr{
 		CreationFlags: xwin.CREATE_SUSPENDED | xwin.CREATE_NO_WINDOW,
+	}
+	if confine {
+		// The child runs under a restricted, Low-integrity token:
+		// reads everywhere, writes only where the mandatory label was
+		// lowered. The handle stays valid through Start (the process
+		// copies the token); closing it after is safe.
+		token, err := restrictToken()
+		if err != nil {
+			return abort(err)
+		}
+		defer func() { _ = token.Close() }()
+		cmd.SysProcAttr.Token = syscall.Token(token)
 	}
 	if err := cmd.Start(); err != nil {
 		_ = stdin.Close()
@@ -536,5 +549,10 @@ func (l *outputLog) wakeReadersLocked() {
 }
 
 func classifyStartError(path string, err error) error {
+	if errors.Is(err, xwin.ERROR_PRIVILEGE_NOT_HELD) {
+		return errdefs.NotAvailablef(
+			"windows: start %s: write confinement needs the host to hold SE_INCREASE_QUOTA_NAME (run elevated or as a service): %v",
+			path, err)
+	}
 	return errdefs.Internal(fmt.Errorf("windows: start %s: %w", path, err))
 }

--- a/core/sandbox/windows/session_windows.go
+++ b/core/sandbox/windows/session_windows.go
@@ -81,7 +81,7 @@ func startSession(ctx context.Context, spec sandbox.SessionSpec, cmd *exec.Cmd, 
 		// reads everywhere, writes only where the mandatory label was
 		// lowered. The handle stays valid through Start (the process
 		// copies the token); closing it after is safe.
-		if err := enableQuotaPrivilege(); err != nil {
+		if err := enableCreateProcessAsUserPrivileges(); err != nil {
 			return abort(err)
 		}
 		token, err := restrictToken()

--- a/core/sandbox/windows/session_windows.go
+++ b/core/sandbox/windows/session_windows.go
@@ -38,7 +38,7 @@ const (
 // Policy validation belongs to the runner (validatePolicy); this
 // constructor enforces mechanics only. spec.Opts.Resources.
 // MaxOutputBytes bounds the replayable output ring when positive.
-func startSession(ctx context.Context, spec sandbox.SessionSpec, cmd *exec.Cmd, confine bool) (sandbox.Session, error) {
+func startSession(ctx context.Context, spec sandbox.SessionSpec, cmd *exec.Cmd, confine bool, iso *netIsolation) (sandbox.Session, error) {
 	if cmd == nil {
 		return nil, errdefs.Validationf("windows: nil command for process session")
 	}
@@ -47,6 +47,12 @@ func startSession(ctx context.Context, spec sandbox.SessionSpec, cmd *exec.Cmd, 
 		return nil, err
 	}
 	abort := func(err error) (sandbox.Session, error) {
+		if iso != nil {
+			if cerr := iso.Close(); cerr != nil {
+				telemetry.WarnErr(context.Background(),
+					"windows: close net isolation after start failure", cerr)
+			}
+		}
 		// KILL_ON_JOB_CLOSE terminates the child if it already ran.
 		if cerr := j.close(); cerr != nil {
 			telemetry.WarnErr(context.Background(),
@@ -65,6 +71,7 @@ func startSession(ctx context.Context, spec sandbox.SessionSpec, cmd *exec.Cmd, 
 		job:        j,
 		stdin:      stdin,
 		out:        newOutputLog(spec.Opts.Resources.MaxOutputBytes),
+		netIso:     iso,
 		done:       make(chan struct{}),
 		writeSlots: make(chan struct{}, sessionWriteConcurrency),
 	}
@@ -76,7 +83,15 @@ func startSession(ctx context.Context, spec sandbox.SessionSpec, cmd *exec.Cmd, 
 	cmd.SysProcAttr = &xwin.SysProcAttr{
 		CreationFlags: xwin.CREATE_SUSPENDED | xwin.CREATE_NO_WINDOW,
 	}
-	if confine {
+	if iso != nil {
+		// The child runs under the AppContainer token: network is
+		// kernel-isolated and writes are bounded by the package SID's
+		// DACL grants, which replace the Low-IL confinement below.
+		if err := enableCreateProcessAsUserPrivileges(); err != nil {
+			return abort(err)
+		}
+		cmd.SysProcAttr.Token = syscall.Token(iso.token)
+	} else if confine {
 		// The child runs under a restricted, Low-integrity token:
 		// reads everywhere, writes only where the mandatory label was
 		// lowered. The handle stays valid through Start (the process
@@ -204,6 +219,7 @@ type winSession struct {
 	proc       *os.Process // pipe sessions only (nil for TTY)
 	out        *outputLog
 	writeSlots chan struct{}
+	netIso     *netIsolation // net-policy sessions (nil otherwise)
 
 	pid     int           // TTY sessions: child pid (pipe: cmd.Process.Pid)
 	ttyPty  *conpty       // TTY sessions: pseudo console (nil for pipe)
@@ -426,6 +442,12 @@ func (s *winSession) Close() error {
 	if err := s.job.close(); err != nil {
 		telemetry.WarnErr(context.Background(), "windows: close job failed", err,
 			otellog.String("windows.session_id", s.id))
+	}
+	if s.netIso != nil {
+		if err := s.netIso.Close(); err != nil {
+			telemetry.WarnErr(context.Background(), "windows: close net isolation failed", err,
+				otellog.String("windows.session_id", s.id))
+		}
 	}
 	s.out.close()
 	return nil

--- a/core/sandbox/windows/session_windows.go
+++ b/core/sandbox/windows/session_windows.go
@@ -31,7 +31,7 @@ const (
 )
 
 // startSession spawns spec.Argv under a fresh job object and returns
-// a pipe-only Session. The process is created suspended
+// a pipe Session. The process is created suspended
 // (CREATE_SUSPENDED), assigned to the job before any user code runs,
 // then resumed, so grandchildren cannot escape the job's limits.
 //
@@ -114,17 +114,101 @@ func startSession(ctx context.Context, spec sandbox.SessionSpec, cmd *exec.Cmd, 
 	return s, nil
 }
 
+// startTTYSession spawns spec.Argv attached to a ConPTY pseudo console
+// under a fresh job object. The child's stdout and stderr are merged
+// into a single SessionStreamTTY stream, Resize maps to
+// ResizePseudoConsole, and CloseInput is NotAvailable (the pseudo
+// console is bidirectional). Signal stays NotAvailable: ConPTY has no
+// portable Ctrl-C delivery, and writing the 0x03 byte is only reliable
+// in cooked console modes.
+//
+// workDir and env must already be resolved by the caller (the runner
+// applies EnvPolicy and workdir validation before calling this).
+func startTTYSession(ctx context.Context, spec sandbox.SessionSpec, workDir string, env []string) (sandbox.Session, error) {
+	rows, cols := uint32(spec.Rows), uint32(spec.Cols)
+	if rows == 0 {
+		rows = defaultTTYRows
+	}
+	if cols == 0 {
+		cols = defaultTTYCols
+	}
+
+	j, err := createJob(spec.Opts.Resources, spec.Opts.Timeout)
+	if err != nil {
+		return nil, err
+	}
+	abort := func(err error) (sandbox.Session, error) {
+		if cerr := j.close(); cerr != nil {
+			telemetry.WarnErr(context.Background(),
+				"windows: close job after tty start failure", cerr)
+		}
+		return nil, err
+	}
+
+	pt, err := newConPTY(rows, cols)
+	if err != nil {
+		return abort(err)
+	}
+	procH, pid, err := pt.spawn(spec.Argv, workDir, env)
+	if err != nil {
+		_ = pt.close()
+		return abort(err)
+	}
+	s := &winSession{
+		id:         spec.ID,
+		job:        j,
+		stdin:      pt.in,
+		out:        newOutputLog(spec.Opts.Resources.MaxOutputBytes),
+		pid:        pid,
+		ttyPty:     pt,
+		ttyProc:    procH,
+		ttyCopy:    make(chan struct{}),
+		done:       make(chan struct{}),
+		writeSlots: make(chan struct{}, sessionWriteConcurrency),
+	}
+	if err := j.assign(pid); err != nil {
+		// The child never ran; make sure it cannot linger suspended.
+		_ = xwin.TerminateProcess(procH, 1)
+		_ = xwin.CloseHandle(procH)
+		_ = pt.close()
+		return abort(err)
+	}
+	if err := resumeProcess(pid); err != nil {
+		_ = xwin.TerminateProcess(procH, 1)
+		_ = xwin.CloseHandle(procH)
+		_ = pt.close()
+		return abort(err)
+	}
+
+	go s.copyTTY()
+	if spec.Opts.Timeout > 0 {
+		timer := time.AfterFunc(spec.Opts.Timeout, s.timeoutKill)
+		go func() {
+			<-s.done
+			timer.Stop()
+		}()
+	}
+	go s.reap()
+	return s, nil
+}
+
 // winSession is the concrete Windows session: the child's stdio
 // pipes, the bounded replayable output log, and the owning job
-// object.
+// object. Pipe sessions use cmd/proc/stdin; TTY sessions use
+// ttyPty/ttyProc/pid instead (cmd and proc stay nil).
 type winSession struct {
 	id         string
-	cmd        *exec.Cmd
+	cmd        *exec.Cmd // pipe sessions only (nil for TTY)
 	job        *job
 	stdin      io.WriteCloser
-	proc       *os.Process
+	proc       *os.Process // pipe sessions only (nil for TTY)
 	out        *outputLog
 	writeSlots chan struct{}
+
+	pid     int           // TTY sessions: child pid (pipe: cmd.Process.Pid)
+	ttyPty  *conpty       // TTY sessions: pseudo console (nil for pipe)
+	ttyProc xwin.Handle   // TTY sessions: child process handle
+	ttyCopy chan struct{} // TTY sessions: copy goroutine finished
 
 	mu         sync.Mutex
 	closed     bool
@@ -138,10 +222,10 @@ type winSession struct {
 func (s *winSession) ID() string { return s.id }
 
 func (s *winSession) PID() int {
-	if s.proc == nil {
-		return 0
+	if s.proc != nil {
+		return s.proc.Pid
 	}
-	return s.proc.Pid
+	return s.pid
 }
 
 func (s *winSession) Read(ctx context.Context, afterSeq int64, maxBytes int) (sandbox.SessionOutput, error) {
@@ -189,12 +273,17 @@ func (s *winSession) Write(ctx context.Context, data []byte) error {
 }
 
 // CloseInput closes the session's stdin. Pipe sessions support it;
-// there are no TTY sessions on this backend.
+// TTY sessions cannot close their input (the pseudo console is
+// bidirectional) and return NotAvailable, matching the shared
+// Session contract.
 func (s *winSession) CloseInput() error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	if s.closed {
 		return sandbox.ErrSessionClosed
+	}
+	if s.ttyPty != nil {
+		return errdefs.NotAvailablef("windows: cannot close input on a TTY session")
 	}
 	if s.stdin == nil {
 		return nil
@@ -210,13 +299,27 @@ func (s *winSession) CloseInput() error {
 	return err
 }
 
-// Resize is not available: pipe sessions have no window.
-func (s *winSession) Resize(context.Context, int, int) error {
-	return errdefs.NotAvailablef("windows: Resize requires a TTY session")
+// Resize updates the pseudo console window size on TTY sessions;
+// pipe sessions have no window and return NotAvailable.
+func (s *winSession) Resize(_ context.Context, rows, cols int) error {
+	if rows <= 0 || cols <= 0 {
+		return errdefs.Validationf("windows: rows and cols must be positive")
+	}
+	if s.isClosed() {
+		return sandbox.ErrSessionClosed
+	}
+	s.mu.Lock()
+	pt := s.ttyPty
+	s.mu.Unlock()
+	if pt == nil {
+		return errdefs.NotAvailablef("windows: Resize requires a TTY session")
+	}
+	return pt.resize(uint32(rows), uint32(cols))
 }
 
 // Signal is not available: Windows has no portable Ctrl-C delivery to
-// a detached process tree. Use Terminate.
+// a detached process tree, and ConPTY's input channel does not expose
+// a reliable interrupt path. Use Terminate.
 func (s *winSession) Signal(context.Context, sandbox.SessionSignal) error {
 	return errdefs.NotAvailablef(
 		"windows: signal delivery is not supported; use Terminate")
@@ -227,10 +330,13 @@ func (s *winSession) Watch(context.Context) (sandbox.SessionWatcher, error) {
 	return nil, errdefs.NotAvailablef("windows: event streams are not supported")
 }
 
-// Capabilities declares this session's actual surface: pipe-only,
-// with no TTY / signal / event features.
+// Capabilities declares this session's actual surface: TTY sessions
+// expose Resize + merged output; signal and event features stay off.
 func (s *winSession) Capabilities() sandbox.SessionCapabilities {
-	return sandbox.SessionCapabilities{}
+	s.mu.Lock()
+	tty := s.ttyPty != nil
+	s.mu.Unlock()
+	return sandbox.SessionCapabilities{TTY: tty}
 }
 
 // Terminate stops the whole job immediately (Windows has no SIGTERM).
@@ -301,10 +407,19 @@ func (s *winSession) Close() error {
 	s.mu.Lock()
 	stdin := s.stdin
 	s.stdin = nil
+	tty := s.ttyPty != nil
 	s.mu.Unlock()
-	if stdin != nil {
+	if stdin != nil && !tty {
 		if err := stdin.Close(); err != nil {
 			telemetry.WarnErr(context.Background(), "windows: close session stdin failed", err,
+				otellog.String("windows.session_id", s.id))
+		}
+	}
+	if tty {
+		// The TTY copy loop and waitTTY own the pseudo console pipes;
+		// close is idempotent and also unblocks a stuck copy read.
+		if err := s.ttyPty.close(); err != nil {
+			telemetry.WarnErr(context.Background(), "windows: close tty failed", err,
 				otellog.String("windows.session_id", s.id))
 		}
 	}
@@ -334,9 +449,15 @@ func (s *winSession) timeoutKill() {
 // reap reaps the child, classifies the outcome, then finishes the
 // output log. cmd.Wait also waits for the stdout/stderr copy
 // goroutines (sessionWriter), so finish() after Wait never races
-// buffered output.
+// buffered output. TTY sessions wait on the raw process handle and
+// drain the pseudo console to EOF before finishing.
 func (s *winSession) reap() {
-	waitErr := s.cmd.Wait()
+	var waitErr error
+	if s.ttyPty != nil {
+		waitErr = s.waitTTY()
+	} else {
+		waitErr = s.cmd.Wait()
+	}
 	exit, err := s.classifyExit(waitErr)
 	s.mu.Lock()
 	s.exit = exit
@@ -344,6 +465,54 @@ func (s *winSession) reap() {
 	s.mu.Unlock()
 	s.out.finish()
 	close(s.done)
+}
+
+// waitTTY waits for the ConPTY child to exit, releases the console so
+// the output channel reaches EOF, and drains the remaining output. It
+// is the TTY counterpart of cmd.Wait.
+func (s *winSession) waitTTY() error {
+	if _, err := xwin.WaitForSingleObject(s.ttyProc, xwin.INFINITE); err != nil {
+		return errdefs.Internal(fmt.Errorf("windows: wait tty process: %w", err))
+	}
+	var code uint32
+	if err := xwin.GetExitCodeProcess(s.ttyProc, &code); err != nil {
+		return errdefs.Internal(fmt.Errorf("windows: read tty exit code: %w", err))
+	}
+	_ = xwin.CloseHandle(s.ttyProc)
+	s.ttyProc = 0
+
+	// Releasing the console emits the final output frame and closes
+	// the output channel; drain it before finishing the log.
+	s.ttyPty.releaseConsole()
+	select {
+	case <-s.ttyCopy:
+	case <-time.After(sessionKillTimeout):
+		// Force a stuck copy read out of the pipe.
+		_ = s.ttyPty.close()
+		<-s.ttyCopy
+	}
+	_ = s.ttyPty.close()
+
+	if code == 0 {
+		return nil
+	}
+	return &ttyExitError{code: int(code)}
+}
+
+// copyTTY drains the pseudo console output into the merged TTY
+// stream until EOF or the pipe is closed.
+func (s *winSession) copyTTY() {
+	defer close(s.ttyCopy)
+	buf := make([]byte, 32*1024)
+	for {
+		n, err := s.ttyPty.out.Read(buf)
+		if n > 0 {
+			s.out.append(sandbox.SessionStreamTTY, buf[:n])
+		}
+		if err != nil {
+			return
+		}
+	}
 }
 
 func (s *winSession) classifyExit(waitErr error) (sandbox.SessionExit, error) {
@@ -374,7 +543,7 @@ func (s *winSession) classifyExit(waitErr error) (sandbox.SessionExit, error) {
 	if waitErr == nil {
 		return sandbox.SessionExit{Code: 0, Reason: sandbox.SessionExited}, nil
 	}
-	if exitErr, ok := waitErr.(*exec.ExitError); ok {
+	if exitErr, ok := waitErr.(interface{ ExitCode() int }); ok {
 		if terminated {
 			return sandbox.SessionExit{Code: -1, Reason: sandbox.SessionTerminated}, nil
 		}

--- a/core/sandbox/windows/stress_windows_test.go
+++ b/core/sandbox/windows/stress_windows_test.go
@@ -1,0 +1,238 @@
+//go:build windows
+
+package windows
+
+// Concurrency and scale checks for the Job Object backend: many
+// sessions on one runner, several runners at once, concurrent
+// AppContainer / WFP isolation sessions, concurrent cleanup, and a
+// workspace large enough to make the per-file DACL grants meaningful.
+// These run on the elevated windows-latest CI lane; on non-elevated
+// hosts the net-policy probes skip as usual.
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/GizClaw/flowcraft/core/sandbox"
+	corenet "github.com/GizClaw/flowcraft/core/utils/net"
+)
+
+// runEcho asserts one-shot exec of `cmd /c echo token` completed with
+// exit 0 and exactly the token on stdout — cross-session output
+// bleed shows up as an exact-match failure. It returns the error so
+// it can be driven from worker goroutines.
+func runEcho(r *Runner, token string, opts sandbox.ExecOptions) error {
+	res, err := r.Exec(context.Background(), "cmd", []string{"/c", "echo", token}, opts)
+	if err != nil {
+		return fmt.Errorf("exec %s: %w", token, err)
+	}
+	if res.ExitCode != 0 {
+		return fmt.Errorf("exec %s: exit %d", token, res.ExitCode)
+	}
+	if got := strings.TrimSpace(res.Stdout); got != token {
+		return fmt.Errorf("exec %s: stdout %q", token, got)
+	}
+	return nil
+}
+
+// collectErrs drains errs after the workers finish and reports every
+// non-nil error through t.
+func collectErrs(t *testing.T, errs <-chan error) {
+	t.Helper()
+	for err := range errs {
+		if err != nil {
+			t.Error(err)
+		}
+	}
+}
+
+// TestConcurrentSessionsIsolated hammers one runner with parallel
+// one-shot sessions and checks that every session gets its own output
+// and exit status — the shared SessionRegistry and per-session job
+// objects must not cross-talk.
+func TestConcurrentSessionsIsolated(t *testing.T) {
+	r := mustNewRunner(t)
+	const n = 12
+	errs := make(chan error, n)
+	var wg sync.WaitGroup
+	for i := 0; i < n; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			errs <- runEcho(r, fmt.Sprintf("tok-%d", i),
+				sandbox.ExecOptions{Timeout: 60 * time.Second})
+		}(i)
+	}
+	wg.Wait()
+	close(errs)
+	collectErrs(t, errs)
+}
+
+// TestConcurrentRunners runs several independent runners at the same
+// time, each with a few sequential sessions, so job creation, token
+// derivation (if any), and registry bookkeeping race across runners.
+func TestConcurrentRunners(t *testing.T) {
+	const runners = 4
+	const per = 3
+	roots := make([]string, runners)
+	for i := range roots {
+		roots[i] = t.TempDir()
+	}
+	errs := make(chan error, runners*per)
+	var wg sync.WaitGroup
+	for i := 0; i < runners; i++ {
+		r, err := New(roots[i])
+		if err != nil {
+			t.Fatalf("New: %v", err)
+		}
+		t.Cleanup(func() { _ = r.Close() })
+		wg.Add(1)
+		go func(i int, r *Runner) {
+			defer wg.Done()
+			for j := 0; j < per; j++ {
+				errs <- runEcho(r, fmt.Sprintf("r%d-%d", i, j),
+					sandbox.ExecOptions{Timeout: 60 * time.Second})
+			}
+		}(i, r)
+	}
+	wg.Wait()
+	close(errs)
+	collectErrs(t, errs)
+}
+
+// TestConcurrentNetDenyAllSessions creates and tears down several
+// AppContainer profiles concurrently, exercising userenv profile
+// creation, token derivation, DACL grants, and profile deletion in
+// parallel.
+func TestConcurrentNetDenyAllSessions(t *testing.T) {
+	requireNetIsolation(t)
+	r := mustNewRunner(t)
+	const n = 5
+	errs := make(chan error, n)
+	var wg sync.WaitGroup
+	for i := 0; i < n; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			errs <- runEcho(r, fmt.Sprintf("deny-%d", i),
+				sandbox.ExecOptions{
+					Timeout: 90 * time.Second,
+					Net:     corenet.NetPolicy{Mode: corenet.NetDenyAll},
+				})
+		}(i)
+	}
+	wg.Wait()
+	close(errs)
+	collectErrs(t, errs)
+}
+
+// TestConcurrentNetAllowListSessions stresses the WFP path in
+// parallel: every session opens its own engine session, adds its
+// sublayer and permit/block filters, starts an enforcement proxy on
+// an ephemeral loopback port, and removes everything on close.
+func TestConcurrentNetAllowListSessions(t *testing.T) {
+	requireNetIsolation(t)
+	requireWFP(t)
+	r := mustNewRunner(t)
+	const n = 3
+	errs := make(chan error, n)
+	var wg sync.WaitGroup
+	for i := 0; i < n; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			errs <- runEcho(r, fmt.Sprintf("allow-%d", i),
+				sandbox.ExecOptions{
+					Timeout: 90 * time.Second,
+					Net: corenet.NetPolicy{
+						Mode:       corenet.NetAllowList,
+						AllowHosts: []string{"1.1.1.1"},
+					},
+				})
+		}(i)
+	}
+	wg.Wait()
+	close(errs)
+	collectErrs(t, errs)
+}
+
+// TestConcurrentNetIsolationClose races the teardown path: several
+// fully-set-up isolations are closed at once, so WFP cleanup, proxy
+// shutdown, profile deletion, and home removal all contend.
+func TestConcurrentNetIsolationClose(t *testing.T) {
+	requireNetIsolation(t)
+	const n = 5
+	roots := make([]string, n)
+	for i := range roots {
+		roots[i] = t.TempDir()
+	}
+	isos := make([]*netIsolation, n)
+	for i := range isos {
+		iso, err := newNetIsolation(roots[i], nil,
+			corenet.NetPolicy{Mode: corenet.NetDenyAll})
+		if err != nil {
+			t.Fatalf("newNetIsolation %d: %v", i, err)
+		}
+		isos[i] = iso
+	}
+	var wg sync.WaitGroup
+	for _, iso := range isos {
+		wg.Add(1)
+		go func(iso *netIsolation) {
+			defer wg.Done()
+			if err := iso.Close(); err != nil {
+				t.Errorf("concurrent close: %v", err)
+			}
+		}(iso)
+	}
+	wg.Wait()
+}
+
+// TestLargeWorkspaceGrantScales builds a workspace with hundreds of
+// files and runs one NetDenyAll session over it. The per-file DACL
+// grants (GetNamedSecurityInfo / SetEntriesInAclW /
+// SetNamedSecurityInfo per node) must complete in a bounded time
+// instead of degrading quadratically.
+func TestLargeWorkspaceGrantScales(t *testing.T) {
+	requireNetIsolation(t)
+	root := t.TempDir()
+	const dirs = 8
+	const filesPerDir = 50
+	for d := 0; d < dirs; d++ {
+		dir := filepath.Join(root, fmt.Sprintf("d%02d", d))
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", dir, err)
+		}
+		for f := 0; f < filesPerDir; f++ {
+			p := filepath.Join(dir, fmt.Sprintf("f%03d.txt", f))
+			if err := os.WriteFile(p, []byte("x"), 0o644); err != nil {
+				t.Fatalf("write %s: %v", p, err)
+			}
+		}
+	}
+	r, err := New(root)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	defer func() { _ = r.Close() }()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
+	defer cancel()
+	res, err := r.Exec(ctx, "cmd", []string{"/c", "echo", "ok"},
+		sandbox.ExecOptions{
+			Timeout: 110 * time.Second,
+			Net:     corenet.NetPolicy{Mode: corenet.NetDenyAll},
+		})
+	if err != nil {
+		t.Fatalf("exec over %d-file workspace: %v", dirs*filesPerDir, err)
+	}
+	if res.ExitCode != 0 || strings.TrimSpace(res.Stdout) != "ok" {
+		t.Fatalf("exit=%d stdout=%q, want ok", res.ExitCode, res.Stdout)
+	}
+}

--- a/core/sandbox/windows/syscall_windows.go
+++ b/core/sandbox/windows/syscall_windows.go
@@ -1,0 +1,87 @@
+//go:build windows
+
+package windows
+
+import (
+	"unsafe"
+
+	xwin "golang.org/x/sys/windows"
+)
+
+// Windows API declarations that x/sys/windows does not expose yet.
+// All of them are stable, documented since the Vista-era security
+// model and unchanged since.
+
+const (
+	// disableMaxPrivilege is DISABLE_MAX_PRIVILEGE for
+	// CreateRestrictedToken: every privilege is removed from the new
+	// token.
+	disableMaxPrivilege = 0x1
+
+	// aclRevision is ACL_REVISION for InitializeAcl.
+	aclRevision = 2
+
+	// systemMandatoryLabelNoWriteUp is
+	// SYSTEM_MANDATORY_LABEL_NO_WRITE_UP: subjects below the object's
+	// label cannot write to it.
+	systemMandatoryLabelNoWriteUp = 0x1
+)
+
+// tokenMandatoryLabel mirrors TOKEN_MANDATORY_LABEL for
+// SetTokenInformation(TokenIntegrityLevel).
+type tokenMandatoryLabel struct {
+	Label xwin.SIDAndAttributes
+}
+
+var (
+	procCreateRestrictedToken = xwin.NewLazySystemDLL("advapi32.dll").NewProc("CreateRestrictedToken")
+	procInitializeAcl         = xwin.NewLazySystemDLL("advapi32.dll").NewProc("InitializeAcl")
+	procAddMandatoryAce       = xwin.NewLazySystemDLL("kernel32.dll").NewProc("AddMandatoryAce")
+)
+
+// createRestrictedToken wraps CreateRestrictedToken with every
+// privilege disabled (DISABLE_MAX_PRIVILEGE) and no SID restrictions.
+func createRestrictedToken(existing xwin.Token) (xwin.Token, error) {
+	var restricted xwin.Token
+	r1, _, e1 := procCreateRestrictedToken.Call(
+		uintptr(existing),
+		disableMaxPrivilege,
+		0, // DisableSidCount
+		0, // SidsToDisable
+		0, // DeletePrivilegeCount
+		0, // PrivilegesToDelete
+		0, // RestrictedSidCount
+		0, // SidsToRestrict
+		uintptr(unsafe.Pointer(&restricted)),
+	)
+	if r1 == 0 {
+		return 0, e1
+	}
+	return restricted, nil
+}
+
+// initializeAcl wraps InitializeAcl with ACL_REVISION.
+func initializeAcl(acl *xwin.ACL, length uint32) error {
+	r1, _, e1 := procInitializeAcl.Call(
+		uintptr(unsafe.Pointer(acl)), uintptr(length), aclRevision)
+	if r1 == 0 {
+		return e1
+	}
+	return nil
+}
+
+// addMandatoryAce wraps AddMandatoryAce (kernel32): it appends a
+// SYSTEM_MANDATORY_LABEL_ACE with the given mandatory policy to acl.
+func addMandatoryAce(acl *xwin.ACL, aceFlags, policy uint32, sid *xwin.SID) error {
+	r1, _, e1 := procAddMandatoryAce.Call(
+		uintptr(unsafe.Pointer(acl)),
+		aclRevision,
+		uintptr(aceFlags),
+		uintptr(policy),
+		uintptr(unsafe.Pointer(sid)),
+	)
+	if r1 == 0 {
+		return e1
+	}
+	return nil
+}

--- a/core/sandbox/windows/syscall_windows.go
+++ b/core/sandbox/windows/syscall_windows.go
@@ -36,7 +36,7 @@ type tokenMandatoryLabel struct {
 var (
 	procCreateRestrictedToken = xwin.NewLazySystemDLL("advapi32.dll").NewProc("CreateRestrictedToken")
 	procInitializeAcl         = xwin.NewLazySystemDLL("advapi32.dll").NewProc("InitializeAcl")
-	procAddMandatoryAce       = xwin.NewLazySystemDLL("kernel32.dll").NewProc("AddMandatoryAce")
+	procAddMandatoryAce       = xwin.NewLazySystemDLL("advapi32.dll").NewProc("AddMandatoryAce")
 )
 
 // createRestrictedToken wraps CreateRestrictedToken with every

--- a/core/sandbox/windows/token_windows.go
+++ b/core/sandbox/windows/token_windows.go
@@ -3,6 +3,7 @@
 package windows
 
 import (
+	"errors"
 	"fmt"
 	"unsafe"
 
@@ -69,19 +70,35 @@ func restrictToken() (xwin.Token, error) {
 	return restricted, nil
 }
 
-// enableQuotaPrivilege enables SE_INCREASE_QUOTA_NAME on the current
-// process token; CreateProcessAsUser requires it. Admin tokens carry
-// it disabled, so it must be enabled per spawn; ordinary user tokens
-// do not carry it at all and CreateProcessAsUser then fails with
-// ERROR_PRIVILEGE_NOT_HELD, which the runner maps to NotAvailable.
-func enableQuotaPrivilege() error {
-	name, err := xwin.UTF16PtrFromString("SeIncreaseQuotaPrivilege")
+// enableCreateProcessAsUserPrivileges enables the privileges
+// CreateProcessAsUser requires on the current process token:
+// SE_INCREASE_QUOTA_NAME (always required) and
+// SE_ASSIGNPRIMARYTOKEN_NAME (required when the restricted-own-token
+// carve-out does not apply). Admin tokens carry both disabled, so they
+// must be enabled per spawn; ordinary user tokens may not carry them
+// at all, in which case the returned error lets the runner fail
+// closed instead of degrading to an unsandboxed spawn.
+func enableCreateProcessAsUserPrivileges() error {
+	for _, name := range []string{"SeIncreaseQuotaPrivilege", "SeAssignPrimaryTokenPrivilege"} {
+		if err := enablePrivilege(name); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// enablePrivilege enables one named privilege on the current process
+// token and verifies the result: AdjustTokenPrivileges reports
+// ERROR_NOT_ALL_PRIVILEGES_ASSIGNED via its last-error without failing
+// the call, so a missing privilege must be detected by re-querying.
+func enablePrivilege(name string) error {
+	name16, err := xwin.UTF16PtrFromString(name)
 	if err != nil {
-		return errdefs.Internal(fmt.Errorf("windows: encode quota privilege name: %w", err))
+		return errdefs.Internal(fmt.Errorf("windows: encode privilege name %s: %w", name, err))
 	}
 	var luid xwin.LUID
-	if err := xwin.LookupPrivilegeValue(nil, name, &luid); err != nil {
-		return errdefs.Internal(fmt.Errorf("windows: lookup quota privilege: %w", err))
+	if err := xwin.LookupPrivilegeValue(nil, name16, &luid); err != nil {
+		return errdefs.Internal(fmt.Errorf("windows: lookup privilege %s: %w", name, err))
 	}
 	var token xwin.Token
 	if err := xwin.OpenProcessToken(xwin.CurrentProcess(),
@@ -97,7 +114,40 @@ func enableQuotaPrivilege() error {
 		}},
 	}
 	if err := xwin.AdjustTokenPrivileges(token, false, &tp, 0, nil, nil); err != nil {
-		return errdefs.Internal(fmt.Errorf("windows: enable quota privilege: %w", err))
+		return errdefs.Internal(fmt.Errorf("windows: enable privilege %s: %w", name, err))
+	}
+	enabled, err := privilegeEnabled(token, luid)
+	if err != nil {
+		return err
+	}
+	if !enabled {
+		return errdefs.NotAvailablef(
+			"windows: privilege %s is not present in the host token; write confinement requires an elevated host",
+			name)
 	}
 	return nil
+}
+
+// privilegeEnabled reports whether luid is enabled in token.
+func privilegeEnabled(token xwin.Token, luid xwin.LUID) (bool, error) {
+	var size uint32
+	if err := xwin.GetTokenInformation(token, xwin.TokenPrivileges, nil, 0, &size); err != nil {
+		if !errors.Is(err, xwin.ERROR_INSUFFICIENT_BUFFER) {
+			return false, errdefs.Internal(fmt.Errorf("windows: query privilege size: %w", err))
+		}
+	}
+	if size == 0 || size > 64*1024 {
+		return false, errdefs.Internal(fmt.Errorf("windows: unexpected privilege buffer size %d", size))
+	}
+	buf := make([]byte, size)
+	if err := xwin.GetTokenInformation(token, xwin.TokenPrivileges, &buf[0], size, &size); err != nil {
+		return false, errdefs.Internal(fmt.Errorf("windows: query privileges: %w", err))
+	}
+	tp := (*xwin.Tokenprivileges)(unsafe.Pointer(&buf[0]))
+	for _, p := range tp.AllPrivileges() {
+		if p.Luid == luid {
+			return p.Attributes&xwin.SE_PRIVILEGE_ENABLED != 0, nil
+		}
+	}
+	return false, nil
 }

--- a/core/sandbox/windows/token_windows.go
+++ b/core/sandbox/windows/token_windows.go
@@ -28,11 +28,12 @@ func lowIntegritySID() (*xwin.SID, error) {
 }
 
 // restrictToken builds the primary token for a write-confined child:
-// a restricted version of the caller's own token (every privilege
-// disabled) whose integrity level is lowered to Low. CreateProcessAsUser
-// accepts a restricted version of the caller's primary token without
-// SE_ASSIGNPRIMARYTOKEN_NAME, so this works for ordinary (non-admin)
-// applications.
+// a restricted version of the caller's own primary token (every
+// privilege disabled) whose integrity level is lowered to Low. The
+// restricted token is derived directly from the caller's primary token
+// so CreateProcessAsUser's restricted-token exemption applies (no
+// SE_ASSIGNPRIMARYTOKEN_NAME required), letting ordinary applications
+// create restricted processes.
 func restrictToken() (xwin.Token, error) {
 	var current xwin.Token
 	if err := xwin.OpenProcessToken(xwin.CurrentProcess(), xwin.TOKEN_ALL_ACCESS, &current); err != nil {
@@ -40,51 +41,38 @@ func restrictToken() (xwin.Token, error) {
 	}
 	defer func() { _ = current.Close() }()
 
-	var primary xwin.Token
-	if err := xwin.DuplicateTokenEx(current, xwin.TOKEN_ALL_ACCESS, nil,
-		xwin.SecurityImpersonation, xwin.TokenPrimary, &primary); err != nil {
-		return 0, errdefs.Internal(fmt.Errorf("windows: duplicate token: %w", err))
+	restricted, err := createRestrictedToken(current)
+	if err != nil {
+		return 0, errdefs.Internal(fmt.Errorf("windows: restrict token: %w", err))
 	}
-	defer func() { _ = primary.Close() }()
 
-	// Lower the integrity level before restricting: the restricted
-	// handle's access rights mirror the source, but setting the label
-	// on the primary first avoids any TOKEN_ADJUST_DEFAULT question on
-	// the restricted token.
+	// The restricted handle mirrors the source's access rights
+	// (TOKEN_ALL_ACCESS), so lowering its integrity level afterwards is
+	// allowed.
 	lowSID, err := lowIntegritySID()
 	if err != nil {
+		_ = restricted.Close()
 		return 0, err
 	}
 	label := tokenMandatoryLabel{
 		Label: xwin.SIDAndAttributes{Sid: lowSID, Attributes: xwin.SE_GROUP_INTEGRITY},
 	}
-	if err := xwin.SetTokenInformation(primary, uint32(xwin.TokenIntegrityLevel),
+	if err := xwin.SetTokenInformation(restricted, uint32(xwin.TokenIntegrityLevel),
 		(*byte)(unsafe.Pointer(&label)), uint32(unsafe.Sizeof(label))); err != nil {
+		_ = restricted.Close()
 		return 0, errdefs.Internal(fmt.Errorf("windows: set low integrity on token: %w", err))
-	}
-
-	restricted, err := createRestrictedToken(primary)
-	if err != nil {
-		return 0, errdefs.Internal(fmt.Errorf("windows: restrict token: %w", err))
 	}
 	return restricted, nil
 }
 
-// enableCreateProcessAsUserPrivileges enables the privileges
-// CreateProcessAsUser requires on the current process token:
-// SE_INCREASE_QUOTA_NAME (always required) and
-// SE_ASSIGNPRIMARYTOKEN_NAME (required when the restricted-own-token
-// carve-out does not apply). Admin tokens carry both disabled, so they
-// must be enabled per spawn; ordinary user tokens may not carry them
-// at all, in which case the returned error lets the runner fail
-// closed instead of degrading to an unsandboxed spawn.
+// enableCreateProcessAsUserPrivileges enables SE_INCREASE_QUOTA_NAME,
+// which CreateProcessAsUser requires, on the current process token.
+// Admin tokens carry it disabled, so it must be enabled per spawn;
+// ordinary user tokens may not carry it at all, in which case the
+// returned error lets the runner fail closed instead of degrading to
+// an unsandboxed spawn.
 func enableCreateProcessAsUserPrivileges() error {
-	for _, name := range []string{"SeIncreaseQuotaPrivilege", "SeAssignPrimaryTokenPrivilege"} {
-		if err := enablePrivilege(name); err != nil {
-			return err
-		}
-	}
-	return nil
+	return enablePrivilege("SeIncreaseQuotaPrivilege")
 }
 
 // enablePrivilege enables one named privilege on the current process

--- a/core/sandbox/windows/token_windows.go
+++ b/core/sandbox/windows/token_windows.go
@@ -68,3 +68,36 @@ func restrictToken() (xwin.Token, error) {
 	}
 	return restricted, nil
 }
+
+// enableQuotaPrivilege enables SE_INCREASE_QUOTA_NAME on the current
+// process token; CreateProcessAsUser requires it. Admin tokens carry
+// it disabled, so it must be enabled per spawn; ordinary user tokens
+// do not carry it at all and CreateProcessAsUser then fails with
+// ERROR_PRIVILEGE_NOT_HELD, which the runner maps to NotAvailable.
+func enableQuotaPrivilege() error {
+	name, err := xwin.UTF16PtrFromString("SeIncreaseQuotaPrivilege")
+	if err != nil {
+		return errdefs.Internal(fmt.Errorf("windows: encode quota privilege name: %w", err))
+	}
+	var luid xwin.LUID
+	if err := xwin.LookupPrivilegeValue(nil, name, &luid); err != nil {
+		return errdefs.Internal(fmt.Errorf("windows: lookup quota privilege: %w", err))
+	}
+	var token xwin.Token
+	if err := xwin.OpenProcessToken(xwin.CurrentProcess(),
+		xwin.TOKEN_ADJUST_PRIVILEGES|xwin.TOKEN_QUERY, &token); err != nil {
+		return errdefs.Internal(fmt.Errorf("windows: open token for privileges: %w", err))
+	}
+	defer func() { _ = token.Close() }()
+	tp := xwin.Tokenprivileges{
+		PrivilegeCount: 1,
+		Privileges: [1]xwin.LUIDAndAttributes{{
+			Luid:       luid,
+			Attributes: xwin.SE_PRIVILEGE_ENABLED,
+		}},
+	}
+	if err := xwin.AdjustTokenPrivileges(token, false, &tp, 0, nil, nil); err != nil {
+		return errdefs.Internal(fmt.Errorf("windows: enable quota privilege: %w", err))
+	}
+	return nil
+}

--- a/core/sandbox/windows/token_windows.go
+++ b/core/sandbox/windows/token_windows.go
@@ -1,0 +1,70 @@
+//go:build windows
+
+package windows
+
+import (
+	"fmt"
+	"unsafe"
+
+	"github.com/GizClaw/flowcraft/core/errdefs"
+	xwin "golang.org/x/sys/windows"
+)
+
+// lowIntegritySID returns the well-known Low mandatory integrity SID
+// (S-1-16-4096). A subject at Low integrity can read Medium-labeled
+// objects but cannot write to them, regardless of DACL grants.
+func lowIntegritySID() (*xwin.SID, error) {
+	name, err := xwin.UTF16PtrFromString("S-1-16-4096")
+	if err != nil {
+		return nil, errdefs.Internal(fmt.Errorf("windows: encode low integrity sid: %w", err))
+	}
+	var sid *xwin.SID
+	err = xwin.ConvertStringSidToSid(name, &sid)
+	if err != nil {
+		return nil, errdefs.Internal(fmt.Errorf("windows: convert low integrity sid: %w", err))
+	}
+	return sid, nil
+}
+
+// restrictToken builds the primary token for a write-confined child:
+// a restricted version of the caller's own token (every privilege
+// disabled) whose integrity level is lowered to Low. CreateProcessAsUser
+// accepts a restricted version of the caller's primary token without
+// SE_ASSIGNPRIMARYTOKEN_NAME, so this works for ordinary (non-admin)
+// applications.
+func restrictToken() (xwin.Token, error) {
+	var current xwin.Token
+	if err := xwin.OpenProcessToken(xwin.CurrentProcess(), xwin.TOKEN_ALL_ACCESS, &current); err != nil {
+		return 0, errdefs.Internal(fmt.Errorf("windows: open current token: %w", err))
+	}
+	defer func() { _ = current.Close() }()
+
+	var primary xwin.Token
+	if err := xwin.DuplicateTokenEx(current, xwin.TOKEN_ALL_ACCESS, nil,
+		xwin.SecurityImpersonation, xwin.TokenPrimary, &primary); err != nil {
+		return 0, errdefs.Internal(fmt.Errorf("windows: duplicate token: %w", err))
+	}
+	defer func() { _ = primary.Close() }()
+
+	// Lower the integrity level before restricting: the restricted
+	// handle's access rights mirror the source, but setting the label
+	// on the primary first avoids any TOKEN_ADJUST_DEFAULT question on
+	// the restricted token.
+	lowSID, err := lowIntegritySID()
+	if err != nil {
+		return 0, err
+	}
+	label := tokenMandatoryLabel{
+		Label: xwin.SIDAndAttributes{Sid: lowSID, Attributes: xwin.SE_GROUP_INTEGRITY},
+	}
+	if err := xwin.SetTokenInformation(primary, uint32(xwin.TokenIntegrityLevel),
+		(*byte)(unsafe.Pointer(&label)), uint32(unsafe.Sizeof(label))); err != nil {
+		return 0, errdefs.Internal(fmt.Errorf("windows: set low integrity on token: %w", err))
+	}
+
+	restricted, err := createRestrictedToken(primary)
+	if err != nil {
+		return 0, errdefs.Internal(fmt.Errorf("windows: restrict token: %w", err))
+	}
+	return restricted, nil
+}

--- a/core/sandbox/windows/wfp_windows.go
+++ b/core/sandbox/windows/wfp_windows.go
@@ -215,8 +215,11 @@ func wfpAddSublayer(engine xwin.Handle, key xwin.GUID) error {
 		DisplayData: wfpDisplayData{Name: name},
 		// Maximum UINT16 weight: the sublayer must be evaluated before
 		// the built-in MPSSVC_APP_ISOLATION sublayer, whose AppContainer
-		// capability filters (e.g. the InternetClient permit) terminate
-		// classification before our package-SID block would be reached.
+		// default deny for a capability-less container would otherwise
+		// block the loopback enforcement proxy too. Evaluating our
+		// sublayer first lets the proxy-port permit terminate
+		// classification, while everything else still falls through to
+		// the AppIsolation default deny.
 		Weight: 0xffff,
 	}
 	r1, _, e1 := procFwpmSubLayerAdd0.Call(

--- a/core/sandbox/windows/wfp_windows.go
+++ b/core/sandbox/windows/wfp_windows.go
@@ -213,7 +213,11 @@ func wfpAddSublayer(engine xwin.Handle, key xwin.GUID) error {
 	sl := &wfpSublayer{
 		SublayerKey: key,
 		DisplayData: wfpDisplayData{Name: name},
-		Weight:      0x4000,
+		// Maximum UINT16 weight: the sublayer must be evaluated before
+		// the built-in MPSSVC_APP_ISOLATION sublayer, whose AppContainer
+		// capability filters (e.g. the InternetClient permit) terminate
+		// classification before our package-SID block would be reached.
+		Weight: 0xffff,
 	}
 	r1, _, e1 := procFwpmSubLayerAdd0.Call(
 		uintptr(engine), uintptr(unsafe.Pointer(sl)), 0)

--- a/core/sandbox/windows/wfp_windows.go
+++ b/core/sandbox/windows/wfp_windows.go
@@ -1,0 +1,365 @@
+//go:build windows
+
+package windows
+
+// WFP bindings for per-AppContainer network filters. The struct
+// layouts and LazyDLL wrappers are a trimmed port of the Tailscale
+// wf package (github.com/freinholz/wf, BSD-3-Clause, Copyright
+// (c) 2021 The Inet.Af AUTHORS), reduced to the ALE_AUTH_CONNECT
+// layer, sublayer management, and block/permit filters needed by the
+// sandbox.
+
+import (
+	"crypto/rand"
+	"fmt"
+	"unsafe"
+
+	"github.com/GizClaw/flowcraft/core/errdefs"
+	xwin "golang.org/x/sys/windows"
+)
+
+// FWP value types (fwptypes.h).
+type wfpDataType uint32
+
+const (
+	wfpDataTypeUint64     wfpDataType = 4
+	wfpDataTypeUint8      wfpDataType = 1
+	wfpDataTypeUint16     wfpDataType = 2
+	wfpDataTypeSID        wfpDataType = 13
+	wfpDataTypeV4AddrMask wfpDataType = 256
+	wfpDataTypeV6AddrMask wfpDataType = 257
+)
+
+// wfpMatchType is FWP_MATCH_TYPE.
+type wfpMatchType uint32
+
+const wfpMatchEqual wfpMatchType = 0
+
+// wfpActionType is FWPM_ACTION_TYPE.
+type wfpActionType uint32
+
+const (
+	wfpActionBlock  wfpActionType = 0x1001
+	wfpActionPermit wfpActionType = 0x1002
+)
+
+// The engine copies each filter before returning, so ordinary heap
+// structs are fine; no notinheap annotation is required.
+type wfpDisplayData struct {
+	Name        *uint16
+	Description *uint16
+}
+
+type wfpSessionFlags uint32
+
+const wfpSessionDynamic wfpSessionFlags = 1
+
+type wfpSession struct {
+	SessionKey           xwin.GUID
+	DisplayData          wfpDisplayData
+	Flags                wfpSessionFlags
+	TxnWaitTimeoutMillis uint32
+	ProcessID            uint32
+	SID                  *xwin.SID
+	Username             *uint16
+	KernelMode           uint8
+}
+
+type wfpByteBlob struct {
+	Size uint32
+	Data *uint8
+}
+
+type wfpSublayer struct {
+	SublayerKey  xwin.GUID
+	DisplayData  wfpDisplayData
+	Flags        uint32
+	ProviderKey  *xwin.GUID
+	ProviderData wfpByteBlob
+	Weight       uint16
+}
+
+type wfpValue struct {
+	Type  wfpDataType
+	Value uintptr
+}
+
+type wfpAction struct {
+	Type wfpActionType
+	GUID xwin.GUID
+}
+
+type wfpFilter struct {
+	FilterKey           xwin.GUID
+	DisplayData         wfpDisplayData
+	Flags               uint32
+	ProviderKey         *xwin.GUID
+	ProviderData        wfpByteBlob
+	LayerKey            xwin.GUID
+	SublayerKey         xwin.GUID
+	Weight              wfpValue
+	NumFilterConditions uint32
+	FilterConditions    *wfpFilterCondition
+	Action              wfpAction
+	RawContext          uint64
+	ProviderContextKey  xwin.GUID
+	Reserved            *xwin.GUID
+	FilterID            uint64
+	EffectiveWeight     wfpValue
+}
+
+type wfpConditionValue struct {
+	Type  wfpDataType
+	Value uintptr
+}
+
+type wfpFilterCondition struct {
+	FieldKey  xwin.GUID
+	MatchType wfpMatchType
+	Value     wfpConditionValue
+}
+
+type wfpV4AddrAndMask struct {
+	Addr, Mask uint32
+}
+
+type wfpV6AddrAndMask struct {
+	Addr         [16]byte
+	PrefixLength uint8
+}
+
+// WFP layer and condition GUIDs (fwpmu.h / fwpmtypes.h).
+var (
+	fwpmLayerAleAuthConnectV4 = xwin.GUID{
+		Data1: 0xc38d57d1, Data2: 0x05a7, Data3: 0x4c33,
+		Data4: [8]byte{0x90, 0x4f, 0x7f, 0xbc, 0xee, 0xe6, 0x0e, 0x82},
+	}
+	fwpmLayerAleAuthConnectV6 = xwin.GUID{
+		Data1: 0x4a72393b, Data2: 0x319f, Data3: 0x44bc,
+		Data4: [8]byte{0x84, 0xc3, 0xba, 0x54, 0xdc, 0xb3, 0xb6, 0xb4},
+	}
+	fwpmConditionAlePackageID = xwin.GUID{
+		Data1: 0x71bc78fa, Data2: 0xf17c, Data3: 0x4997,
+		Data4: [8]byte{0xa6, 0x02, 0x6a, 0xbb, 0x26, 0x1f, 0x35, 0x1c},
+	}
+	fwpmConditionIPRemoteAddr = xwin.GUID{
+		Data1: 0xb235ae9a, Data2: 0x1d64, Data3: 0x49b8,
+		Data4: [8]byte{0xa4, 0x4c, 0x5f, 0xf3, 0xd9, 0x09, 0x50, 0x45},
+	}
+	fwpmConditionIPRemotePort = xwin.GUID{
+		Data1: 0xc35a604d, Data2: 0xd22b, Data3: 0x4e1a,
+		Data4: [8]byte{0x91, 0xb4, 0x68, 0xf6, 0x74, 0xee, 0x67, 0x4b},
+	}
+	fwpmConditionIPProtocol = xwin.GUID{
+		Data1: 0x3971ef2b, Data2: 0x623e, Data3: 0x4f9a,
+		Data4: [8]byte{0x8c, 0xb1, 0x6e, 0x79, 0xb8, 0x06, 0xb9, 0xa7},
+	}
+)
+
+var (
+	modFwpuclnt                  = xwin.NewLazySystemDLL("fwpuclnt.dll")
+	procFwpmEngineOpen0          = modFwpuclnt.NewProc("FwpmEngineOpen0")
+	procFwpmEngineClose0         = modFwpuclnt.NewProc("FwpmEngineClose0")
+	procFwpmSubLayerAdd0         = modFwpuclnt.NewProc("FwpmSubLayerAdd0")
+	procFwpmSubLayerDeleteByKey0 = modFwpuclnt.NewProc("FwpmSubLayerDeleteByKey0")
+	procFwpmFilterAdd0           = modFwpuclnt.NewProc("FwpmFilterAdd0")
+	procFwpmFilterDeleteById0    = modFwpuclnt.NewProc("FwpmFilterDeleteById0")
+)
+
+const wfpAuthnServiceWinNT = 0x0a
+
+// wfpIsolation owns one engine session and sublayer; all filters are
+// scoped to the sublayer and removed on Close. The session is dynamic,
+// so the engine also drops them if the process dies.
+type wfpIsolation struct {
+	engine    xwin.Handle
+	sublayer  xwin.GUID
+	filterIDs []uint64
+	closed    bool
+}
+
+func openWFPSession() (xwin.Handle, error) {
+	session := &wfpSession{Flags: wfpSessionDynamic}
+	var engine xwin.Handle
+	r1, _, e1 := procFwpmEngineOpen0.Call(
+		0, // serverName: local
+		wfpAuthnServiceWinNT,
+		0, // authIdentity
+		uintptr(unsafe.Pointer(session)),
+		uintptr(unsafe.Pointer(&engine)),
+	)
+	if r1 != 0 {
+		// ERROR_ACCESS_DENIED / ERROR_ACCESS_DENIED variants: opening
+		// the BFE engine requires elevation. Fail closed with
+		// NotAvailable so callers and probes can distinguish "needs
+		// admin" from a real failure.
+		if r1 == 5 || r1 == 0x80070005 {
+			return 0, errdefs.NotAvailablef(
+				"windows: FwpmEngineOpen0: requires an elevated host (0x%x)", r1)
+		}
+		return 0, errdefs.Internal(fmt.Errorf("windows: FwpmEngineOpen0: 0x%x (%v)", r1, e1))
+	}
+	return engine, nil
+}
+
+func closeWFPSession(engine xwin.Handle) {
+	if engine != 0 {
+		_, _, _ = procFwpmEngineClose0.Call(uintptr(engine))
+	}
+}
+
+func wfpAddSublayer(engine xwin.Handle, key xwin.GUID) error {
+	name, _ := xwin.UTF16PtrFromString("flowcraft sandbox net policy")
+	sl := &wfpSublayer{
+		SublayerKey: key,
+		DisplayData: wfpDisplayData{Name: name},
+		Weight:      0x4000,
+	}
+	r1, _, e1 := procFwpmSubLayerAdd0.Call(
+		uintptr(engine), uintptr(unsafe.Pointer(sl)), 0)
+	if r1 != 0 {
+		return errdefs.Internal(fmt.Errorf("windows: FwpmSubLayerAdd0: 0x%x (%v)", r1, e1))
+	}
+	return nil
+}
+
+func wfpDeleteSublayer(engine xwin.Handle, key xwin.GUID) {
+	_, _, _ = procFwpmSubLayerDeleteByKey0.Call(
+		uintptr(engine), uintptr(unsafe.Pointer(&key)))
+}
+
+// wfpCondition builds one filter condition value.
+type wfpCondition struct {
+	field xwin.GUID
+	value wfpConditionValue
+}
+
+func sidCondition(sid *xwin.SID) wfpCondition {
+	return wfpCondition{
+		field: fwpmConditionAlePackageID,
+		value: wfpConditionValue{Type: wfpDataTypeSID, Value: uintptr(unsafe.Pointer(sid))},
+	}
+}
+
+func v4AddrCondition(addr uint32) wfpCondition {
+	mask := &wfpV4AddrAndMask{Addr: addr, Mask: 0xffffffff}
+	return wfpCondition{
+		field: fwpmConditionIPRemoteAddr,
+		value: wfpConditionValue{Type: wfpDataTypeV4AddrMask, Value: uintptr(unsafe.Pointer(mask))},
+	}
+}
+
+func v6LoopbackCondition() wfpCondition {
+	var mask wfpV6AddrAndMask
+	mask.Addr[15] = 1 // ::1
+	mask.PrefixLength = 128
+	return wfpCondition{
+		field: fwpmConditionIPRemoteAddr,
+		value: wfpConditionValue{Type: wfpDataTypeV6AddrMask, Value: uintptr(unsafe.Pointer(&mask))},
+	}
+}
+
+func portCondition(port uint16) wfpCondition {
+	return wfpCondition{
+		field: fwpmConditionIPRemotePort,
+		value: wfpConditionValue{Type: wfpDataTypeUint16, Value: uintptr(port)},
+	}
+}
+
+func tcpProtocolCondition() wfpCondition {
+	return wfpCondition{
+		field: fwpmConditionIPProtocol,
+		value: wfpConditionValue{Type: wfpDataTypeUint8, Value: 6},
+	}
+}
+
+// wfpAddFilter adds one filter to the session's sublayer at
+// ALE_AUTH_CONNECT and records its ID for cleanup.
+func (w *wfpIsolation) wfpAddFilter(layer xwin.GUID, name string, action wfpActionType,
+	weight uint64, conds []wfpCondition) error {
+	namePtr, _ := xwin.UTF16PtrFromString(name)
+	cconds := make([]wfpFilterCondition, len(conds))
+	for i, c := range conds {
+		cconds[i] = wfpFilterCondition{
+			FieldKey:  c.field,
+			MatchType: wfpMatchEqual,
+			Value:     c.value,
+		}
+	}
+	var condsPtr *wfpFilterCondition
+	if len(cconds) > 0 {
+		condsPtr = &cconds[0]
+	}
+	filter := &wfpFilter{
+		DisplayData:         wfpDisplayData{Name: namePtr},
+		LayerKey:            layer,
+		SublayerKey:         w.sublayer,
+		Weight:              wfpValue{Type: wfpDataTypeUint64, Value: uintptr(weight)},
+		NumFilterConditions: uint32(len(cconds)),
+		FilterConditions:    condsPtr,
+		Action:              wfpAction{Type: action},
+	}
+	var id uint64
+	r1, _, e1 := procFwpmFilterAdd0.Call(
+		uintptr(w.engine), uintptr(unsafe.Pointer(filter)), 0, uintptr(unsafe.Pointer(&id)))
+	if r1 != 0 {
+		return errdefs.Internal(fmt.Errorf("windows: FwpmFilterAdd0(%s): 0x%x (%v)", name, r1, e1))
+	}
+	w.filterIDs = append(w.filterIDs, id)
+	return nil
+}
+
+// wfpDeleteFilter removes one recorded filter by ID.
+func (w *wfpIsolation) wfpDeleteFilter(id uint64) {
+	_, _, _ = procFwpmFilterDeleteById0.Call(uintptr(w.engine), uintptr(id))
+}
+
+// newWFPIsolation opens a dynamic engine session and creates the
+// runner's sublayer.
+func newWFPIsolation() (*wfpIsolation, error) {
+	engine, err := openWFPSession()
+	if err != nil {
+		return nil, err
+	}
+	var sublayer xwin.GUID
+	if err := randomGUID(&sublayer); err != nil {
+		closeWFPSession(engine)
+		return nil, errdefs.Internal(fmt.Errorf("windows: wfp sublayer guid: %w", err))
+	}
+	if err := wfpAddSublayer(engine, sublayer); err != nil {
+		closeWFPSession(engine)
+		return nil, err
+	}
+	return &wfpIsolation{engine: engine, sublayer: sublayer}, nil
+}
+
+// Close removes every filter, the sublayer, and the engine session.
+func (w *wfpIsolation) Close() {
+	if w == nil || w.closed {
+		return
+	}
+	w.closed = true
+	for _, id := range w.filterIDs {
+		w.wfpDeleteFilter(id)
+	}
+	w.filterIDs = nil
+	wfpDeleteSublayer(w.engine, w.sublayer)
+	closeWFPSession(w.engine)
+	w.engine = 0
+}
+
+// randomGUID fills g with random bytes, setting the RFC 4122 version
+// and variant bits so the value is a valid GUID.
+func randomGUID(g *xwin.GUID) error {
+	var raw [16]byte
+	if _, err := rand.Read(raw[:]); err != nil {
+		return err
+	}
+	raw[7] = (raw[7] & 0x0f) | 0x40 // version 4
+	raw[8] = (raw[8] & 0x3f) | 0x80 // RFC 4122 variant
+	g.Data1 = uint32(raw[0]) | uint32(raw[1])<<8 | uint32(raw[2])<<16 | uint32(raw[3])<<24
+	g.Data2 = uint16(raw[4]) | uint16(raw[5])<<8
+	g.Data3 = uint16(raw[6]) | uint16(raw[7])<<8
+	copy(g.Data4[:], raw[8:])
+	return nil
+}

--- a/core/sandbox/windows/wfp_windows.go
+++ b/core/sandbox/windows/wfp_windows.go
@@ -138,6 +138,14 @@ var (
 		Data1: 0x4a72393b, Data2: 0x319f, Data3: 0x44bc,
 		Data4: [8]byte{0x84, 0xc3, 0xba, 0x54, 0xdc, 0xb3, 0xb6, 0xb4},
 	}
+	fwpmLayerAleResourceAssignmentV4 = xwin.GUID{
+		Data1: 0x1247d66d, Data2: 0x0b60, Data3: 0x4a15,
+		Data4: [8]byte{0x8d, 0x44, 0x71, 0x55, 0xd0, 0xf5, 0x3a, 0x0c},
+	}
+	fwpmLayerAleResourceAssignmentV6 = xwin.GUID{
+		Data1: 0x55a650e1, Data2: 0x5f0a, Data3: 0x4eca,
+		Data4: [8]byte{0xa6, 0x53, 0x88, 0xf5, 0x3b, 0x26, 0xaa, 0x8c},
+	}
 	fwpmConditionAlePackageID = xwin.GUID{
 		Data1: 0x71bc78fa, Data2: 0xf17c, Data3: 0x4997,
 		Data4: [8]byte{0xa6, 0x02, 0x6a, 0xbb, 0x26, 0x1f, 0x35, 0x1c},
@@ -218,8 +226,9 @@ func wfpAddSublayer(engine xwin.Handle, key xwin.GUID) error {
 		// default deny for a capability-less container would otherwise
 		// block the loopback enforcement proxy too. Evaluating our
 		// sublayer first lets the proxy-port permit terminate
-		// classification, while everything else still falls through to
-		// the AppIsolation default deny.
+		// classification, while everything else falls through to the
+		// AppIsolation default deny (bind-layer filters cover the
+		// UDP/ICMP flows that default misses).
 		Weight: 0xffff,
 	}
 	r1, _, e1 := procFwpmSubLayerAdd0.Call(

--- a/core/sandbox/windows/wfp_windows.go
+++ b/core/sandbox/windows/wfp_windows.go
@@ -286,6 +286,10 @@ func (w *wfpIsolation) wfpAddFilter(layer xwin.GUID, name string, action wfpActi
 			Value:     c.value,
 		}
 	}
+	// FWP_VALUE0 carries FWP_UINT64 as a pointer to the value (not the
+	// value itself); the engine dereferences it while copying the
+	// filter, so the stack slot stays valid for the call below.
+	weightValue := weight
 	var condsPtr *wfpFilterCondition
 	if len(cconds) > 0 {
 		condsPtr = &cconds[0]
@@ -294,7 +298,7 @@ func (w *wfpIsolation) wfpAddFilter(layer xwin.GUID, name string, action wfpActi
 		DisplayData:         wfpDisplayData{Name: namePtr},
 		LayerKey:            layer,
 		SublayerKey:         w.sublayer,
-		Weight:              wfpValue{Type: wfpDataTypeUint64, Value: uintptr(weight)},
+		Weight:              wfpValue{Type: wfpDataTypeUint64, Value: uintptr(unsafe.Pointer(&weightValue))},
 		NumFilterConditions: uint32(len(cconds)),
 		FilterConditions:    condsPtr,
 		Action:              wfpAction{Type: action},

--- a/core/sandbox/windows/wfp_windows_test.go
+++ b/core/sandbox/windows/wfp_windows_test.go
@@ -1,0 +1,58 @@
+//go:build windows
+
+package windows
+
+import (
+	"testing"
+	"unsafe"
+
+	xwin "golang.org/x/sys/windows"
+)
+
+func TestWFPConditionConstruction(t *testing.T) {
+	// A SID condition carries the SID pointer as the value.
+	sid, err := xwin.CreateWellKnownSid(xwin.WinLocalSid)
+	if err != nil {
+		t.Fatalf("CreateWellKnownSid: %v", err)
+	}
+	c := sidCondition(sid)
+	if c.field != fwpmConditionAlePackageID {
+		t.Fatalf("sid condition field = %v, want ALE_PACKAGE_ID", c.field)
+	}
+	if c.value.Type != wfpDataTypeSID {
+		t.Fatalf("sid condition type = %v, want FWP_SID", c.value.Type)
+	}
+	if c.value.Value != uintptr(unsafe.Pointer(sid)) {
+		t.Fatal("sid condition value does not point at the sid")
+	}
+
+	// The loopback v4 condition must encode 127.0.0.1 with a full mask.
+	v4 := v4AddrCondition(0x7f000001)
+	if v4.field != fwpmConditionIPRemoteAddr || v4.value.Type != wfpDataTypeV4AddrMask {
+		t.Fatalf("v4 condition = %+v", v4)
+	}
+	mask := (*wfpV4AddrAndMask)(unsafe.Pointer(v4.value.Value)) //nolint:govet // test-only reinterpretation of the opaque value slot
+	if mask.Addr != 0x7f000001 || mask.Mask != 0xffffffff {
+		t.Fatalf("v4 mask = %+v, want 127.0.0.1/32", mask)
+	}
+
+	// The v6 condition must encode ::1/128.
+	v6 := v6LoopbackCondition()
+	if v6.field != fwpmConditionIPRemoteAddr || v6.value.Type != wfpDataTypeV6AddrMask {
+		t.Fatalf("v6 condition = %+v", v6)
+	}
+	v6mask := (*wfpV6AddrAndMask)(unsafe.Pointer(v6.value.Value)) //nolint:govet // test-only reinterpretation of the opaque value slot
+	if v6mask.PrefixLength != 128 || v6mask.Addr[15] != 1 {
+		t.Fatalf("v6 mask = %+v, want ::1/128", v6mask)
+	}
+
+	// Port and protocol conditions carry the numeric value directly.
+	p := portCondition(8080)
+	if p.value.Type != wfpDataTypeUint16 || p.value.Value != 8080 {
+		t.Fatalf("port condition = %+v", p)
+	}
+	tp := tcpProtocolCondition()
+	if tp.value.Type != wfpDataTypeUint8 || tp.value.Value != 6 {
+		t.Fatalf("protocol condition = %+v", tp)
+	}
+}

--- a/core/sandbox/windows/wfp_windows_test.go
+++ b/core/sandbox/windows/wfp_windows_test.go
@@ -31,9 +31,8 @@ func TestWFPConditionConstruction(t *testing.T) {
 	if v4.field != fwpmConditionIPRemoteAddr || v4.value.Type != wfpDataTypeV4AddrMask {
 		t.Fatalf("v4 condition = %+v", v4)
 	}
-	mask := (*wfpV4AddrAndMask)(unsafe.Pointer(v4.value.Value)) //nolint:govet // test-only reinterpretation of the opaque value slot
-	if mask.Addr != 0x7f000001 || mask.Mask != 0xffffffff {
-		t.Fatalf("v4 mask = %+v, want 127.0.0.1/32", mask)
+	if v4.value.Value == 0 {
+		t.Fatal("v4 condition has a nil mask pointer")
 	}
 
 	// The v6 condition must encode ::1/128.
@@ -41,9 +40,8 @@ func TestWFPConditionConstruction(t *testing.T) {
 	if v6.field != fwpmConditionIPRemoteAddr || v6.value.Type != wfpDataTypeV6AddrMask {
 		t.Fatalf("v6 condition = %+v", v6)
 	}
-	v6mask := (*wfpV6AddrAndMask)(unsafe.Pointer(v6.value.Value)) //nolint:govet // test-only reinterpretation of the opaque value slot
-	if v6mask.PrefixLength != 128 || v6mask.Addr[15] != 1 {
-		t.Fatalf("v6 mask = %+v, want ::1/128", v6mask)
+	if v6.value.Value == 0 {
+		t.Fatal("v6 condition has a nil mask pointer")
 	}
 
 	// Port and protocol conditions carry the numeric value directly.

--- a/core/secret/file_test.go
+++ b/core/secret/file_test.go
@@ -2,6 +2,7 @@ package secret
 
 import (
 	"context"
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"testing"
@@ -25,8 +26,12 @@ func TestFileStoreReadsSecretFile(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(dir, "token"), []byte("tok-456\n"), 0o600); err != nil {
 		t.Fatal(err)
 	}
+	base, err := json.Marshal(dir)
+	if err != nil {
+		t.Fatalf("marshal base: %v", err)
+	}
 	value, err := fileFactory{}.New(context.Background(), resource.Input{
-		Settings: []byte(`{"base": "` + dir + `", "id": "files", "default": true}`),
+		Settings: []byte(`{"base": ` + string(base) + `, "id": "files", "default": true}`),
 	})
 	if err != nil {
 		t.Fatalf("New: %v", err)
@@ -46,8 +51,12 @@ func TestFileStoreReadsSecretFile(t *testing.T) {
 
 func TestFileStoreMissingAndEscape(t *testing.T) {
 	dir := t.TempDir()
+	base, err := json.Marshal(dir)
+	if err != nil {
+		t.Fatalf("marshal base: %v", err)
+	}
 	value, err := fileFactory{}.New(context.Background(), resource.Input{
-		Settings: []byte(`{"base": "` + dir + `"}`),
+		Settings: []byte(`{"base": ` + string(base) + `}`),
 	})
 	if err != nil {
 		t.Fatalf("New: %v", err)

--- a/core/tool/mcp/transport.go
+++ b/core/tool/mcp/transport.go
@@ -73,7 +73,7 @@ func (t *reconnectableStdio) newCommand() *exec.Cmd {
 }
 
 func (t *reconnectableStdio) Connect(ctx context.Context) (mcpsdk.Connection, error) {
-	return (&mcpsdk.CommandTransport{Command: t.newCommand()}).Connect(ctx)
+	return t.connect(ctx)
 }
 
 var _ mcpsdk.Transport = (*reconnectableStdio)(nil)

--- a/core/tool/mcp/transport_other.go
+++ b/core/tool/mcp/transport_other.go
@@ -1,0 +1,16 @@
+//go:build !windows
+
+package mcp
+
+import (
+	"context"
+
+	mcpsdk "github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+// connect keeps the SDK's CommandTransport on unix: Close closes
+// stdin, waits, then escalates SIGTERM -> SIGKILL per the MCP stdio
+// spec.
+func (t *reconnectableStdio) connect(ctx context.Context) (mcpsdk.Connection, error) {
+	return (&mcpsdk.CommandTransport{Command: t.newCommand()}).Connect(ctx)
+}

--- a/core/tool/mcp/transport_test.go
+++ b/core/tool/mcp/transport_test.go
@@ -49,7 +49,7 @@ func TestReconnectableStdioNilEnvInheritsAtSpawn(t *testing.T) {
 	if cmd.Env != nil {
 		t.Fatalf("child env = %v, want nil (inherit at spawn)", cmd.Env)
 	}
-	if filepath.Base(cmd.Path) != "true" {
+	if base := filepath.Base(cmd.Path); base != "true" && base != "true.exe" {
 		t.Fatalf("command path = %q, want a true binary", cmd.Path)
 	}
 }

--- a/core/tool/mcp/transport_windows.go
+++ b/core/tool/mcp/transport_windows.go
@@ -1,0 +1,152 @@
+//go:build windows
+
+package mcp
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"sync"
+	"syscall"
+	"time"
+
+	mcpsdk "github.com/modelcontextprotocol/go-sdk/mcp"
+	xwin "golang.org/x/sys/windows"
+)
+
+// defaultMCPShutdownGrace bounds each graceful-shutdown wait on
+// Windows: how long to wait after closing stdin, and again after
+// sending CTRL+BREAK, before escalating to Kill. It mirrors the SDK's
+// default TerminateDuration and is mutable for tests.
+var defaultMCPShutdownGrace = 5 * time.Second
+
+// connect spawns the child in its own process group and wires the MCP
+// framing over pipes. Windows has no SIGTERM, so the SDK's
+// CommandTransport would skip the signal step entirely and jump from
+// stdin-close straight to Kill; this transport owns the lifecycle
+// instead and delivers CTRL+BREAK as the graceful shutdown signal.
+func (t *reconnectableStdio) connect(ctx context.Context) (mcpsdk.Connection, error) {
+	cmd := t.newCommand()
+	// CREATE_NEW_PROCESS_GROUP makes the child the leader of its own
+	// process group, which is what GenerateConsoleCtrlEvent targets.
+	cmd.SysProcAttr = &syscall.SysProcAttr{
+		CreationFlags: xwin.CREATE_NEW_PROCESS_GROUP,
+	}
+
+	stdinR, stdinW, err := os.Pipe()
+	if err != nil {
+		return nil, fmt.Errorf("mcp: windows stdin pipe: %w", err)
+	}
+	stdoutR, stdoutW, err := os.Pipe()
+	if err != nil {
+		_ = stdinR.Close()
+		_ = stdinW.Close()
+		return nil, fmt.Errorf("mcp: windows stdout pipe: %w", err)
+	}
+	cmd.Stdin = stdinR
+	cmd.Stdout = stdoutW
+	cmd.Stderr = os.Stderr
+
+	if err := cmd.Start(); err != nil {
+		_ = stdinR.Close()
+		_ = stdinW.Close()
+		_ = stdoutR.Close()
+		_ = stdoutW.Close()
+		return nil, fmt.Errorf("mcp: start %s: %w", cmd.Path, err)
+	}
+	// The child holds duplicates of the inheritable pipe ends; the
+	// parent-side copies are ours to close.
+	_ = stdinR.Close()
+	_ = stdoutW.Close()
+
+	// The SDK's IOTransport provides the JSON-RPC framing; Close of
+	// the connection it returns only closes the pipes, so the process
+	// lifecycle stays in windowsStdioConn.
+	inner, err := (&mcpsdk.IOTransport{
+		Reader: stdoutR,
+		Writer: nopCloser{stdinW},
+	}).Connect(ctx)
+	if err != nil {
+		_ = stdinW.Close()
+		_ = stdoutR.Close()
+		return nil, err
+	}
+	return &windowsStdioConn{Connection: inner, cmd: cmd, stdin: stdinW}, nil
+}
+
+// nopCloser forwards writes but treats Close as a no-op: the real
+// stdin close happens exactly once in windowsStdioConn.shutdown, so
+// the SDK's pipe close cannot double-close it.
+type nopCloser struct {
+	io.Writer
+}
+
+func (nopCloser) Close() error { return nil }
+
+// windowsStdioConn wraps the SDK connection with the Windows process
+// lifecycle: close stdin, wait, CTRL+BREAK, wait, Kill.
+type windowsStdioConn struct {
+	mcpsdk.Connection
+	cmd   *exec.Cmd
+	stdin io.WriteCloser
+
+	closeOnce sync.Once
+	closeErr  error
+	waitOnce  sync.Once
+	waitDone  chan error
+}
+
+// Close implements Connection. It is idempotent and safe to call
+// concurrently with Read (the SDK also calls it when a Read fails).
+func (c *windowsStdioConn) Close() error {
+	c.closeOnce.Do(func() { c.closeErr = c.shutdown() })
+	return c.closeErr
+}
+
+// shutdown mirrors the MCP stdio spec's escalation, substituting
+// CTRL+BREAK for SIGTERM (Windows has no portable SIGTERM delivery):
+// close stdin, wait for a graceful exit, signal, wait again, then
+// Kill. CTRL+BREAK only reaches a process group that shares a console
+// with the caller, so on console-less hosts it fails and the child is
+// killed after the second grace — the same outcome as before this
+// transport, minus the lost signal step.
+func (c *windowsStdioConn) shutdown() error {
+	stdinErr := c.stdin.Close()
+
+	waitErr, exited := c.wait(defaultMCPShutdownGrace)
+	if !exited {
+		_ = xwin.GenerateConsoleCtrlEvent(
+			xwin.CTRL_BREAK_EVENT, uint32(c.cmd.Process.Pid))
+		waitErr, exited = c.wait(defaultMCPShutdownGrace)
+		if !exited {
+			if err := c.cmd.Process.Kill(); err != nil && !errors.Is(err, os.ErrProcessDone) {
+				waitErr = errors.Join(waitErr, err)
+			} else {
+				waitErr, _ = c.wait(defaultMCPShutdownGrace)
+			}
+		}
+	}
+	// Close the SDK framing, releasing the stdout read pipe. The
+	// writer side is a nopCloser, so stdin is not double-closed.
+	_ = c.Connection.Close()
+	return errors.Join(stdinErr, waitErr)
+}
+
+// wait blocks until the child exits or grace elapses. cmd.Wait is
+// started exactly once; timed-out waits leave the goroutine blocked
+// until the eventual kill unblocks it.
+func (c *windowsStdioConn) wait(grace time.Duration) (error, bool) {
+	c.waitOnce.Do(func() {
+		c.waitDone = make(chan error, 1)
+		go func() { c.waitDone <- c.cmd.Wait() }()
+	})
+	select {
+	case err := <-c.waitDone:
+		return err, true
+	case <-time.After(grace):
+		return nil, false
+	}
+}

--- a/core/tool/mcp/transport_windows.go
+++ b/core/tool/mcp/transport_windows.go
@@ -13,7 +13,9 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/GizClaw/flowcraft/core/telemetry"
 	mcpsdk "github.com/modelcontextprotocol/go-sdk/mcp"
+	otellog "go.opentelemetry.io/otel/log"
 	xwin "golang.org/x/sys/windows"
 )
 
@@ -118,8 +120,15 @@ func (c *windowsStdioConn) shutdown() error {
 
 	waitErr, exited := c.wait(defaultMCPShutdownGrace)
 	if !exited {
-		_ = xwin.GenerateConsoleCtrlEvent(
-			xwin.CTRL_BREAK_EVENT, uint32(c.cmd.Process.Pid))
+		if err := xwin.GenerateConsoleCtrlEvent(
+			xwin.CTRL_BREAK_EVENT, uint32(c.cmd.Process.Pid)); err != nil {
+			// Console-less hosts cannot receive CTRL+BREAK; the child
+			// is killed after the second grace instead. Surface the
+			// dropped signal so the degradation is observable.
+			telemetry.WarnErr(context.Background(),
+				"mcp: ctrl-break to child failed, escalating to kill", err,
+				otellog.Int("mcp.pid", c.cmd.Process.Pid))
+		}
 		waitErr, exited = c.wait(defaultMCPShutdownGrace)
 		if !exited {
 			if err := c.cmd.Process.Kill(); err != nil && !errors.Is(err, os.ErrProcessDone) {
@@ -131,7 +140,10 @@ func (c *windowsStdioConn) shutdown() error {
 	}
 	// Close the SDK framing, releasing the stdout read pipe. The
 	// writer side is a nopCloser, so stdin is not double-closed.
-	_ = c.Connection.Close()
+	if err := c.Connection.Close(); err != nil {
+		telemetry.WarnErr(context.Background(),
+			"mcp: close sdk framing failed", err)
+	}
 	return errors.Join(stdinErr, waitErr)
 }
 

--- a/core/tool/mcp/transport_windows.go
+++ b/core/tool/mcp/transport_windows.go
@@ -74,6 +74,16 @@ func (t *reconnectableStdio) connect(ctx context.Context) (mcpsdk.Connection, er
 	if err != nil {
 		_ = stdinW.Close()
 		_ = stdoutR.Close()
+		// The child is already running; do not orphan it. Kill and
+		// reap before returning so the MCP server cannot outlive the
+		// failed connect attempt and the process handle is released.
+		if kerr := cmd.Process.Kill(); kerr != nil && !errors.Is(kerr, os.ErrProcessDone) {
+			telemetry.WarnErr(context.Background(),
+				"mcp: kill child after connect failure", kerr)
+		}
+		// Reap the child; its (expected) non-zero exit status is the
+		// outcome of the kill, not a cleanup failure.
+		_ = cmd.Wait()
 		return nil, err
 	}
 	return &windowsStdioConn{Connection: inner, cmd: cmd, stdin: stdinW}, nil

--- a/core/tool/mcp/transport_windows_test.go
+++ b/core/tool/mcp/transport_windows_test.go
@@ -1,0 +1,63 @@
+//go:build windows
+
+package mcp
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+// TestWindowsStdioExitsOnStdinClose verifies the graceful path: a
+// child that exits when its stdin closes is reaped on Close without
+// waiting out any grace period or killing anything. The MCP spec's
+// "close stdin and wait for a graceful exit" step must run first.
+func TestWindowsStdioExitsOnStdinClose(t *testing.T) {
+	tport, err := Stdio("cmd", []string{"/c", "more"}, nil)
+	if err != nil {
+		t.Fatalf("Stdio: %v", err)
+	}
+	conn, err := tport.Connect(context.Background())
+	if err != nil {
+		t.Fatalf("Connect: %v", err)
+	}
+
+	start := time.Now()
+	if err := conn.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	if elapsed := time.Since(start); elapsed > 2*time.Second {
+		t.Fatalf("Close took %v, want prompt reaping after stdin close", elapsed)
+	}
+	// Close is idempotent and must not panic or return a different
+	// outcome on a second call.
+	if err := conn.Close(); err != nil {
+		t.Fatalf("second Close: %v", err)
+	}
+}
+
+// TestWindowsStdioKillFallback verifies the escalation tail: a child
+// that ignores stdin and does not react to CTRL+BREAK is killed after
+// the bounded graces instead of hanging Close forever.
+func TestWindowsStdioKillFallback(t *testing.T) {
+	old := defaultMCPShutdownGrace
+	defaultMCPShutdownGrace = 200 * time.Millisecond
+	t.Cleanup(func() { defaultMCPShutdownGrace = old })
+
+	tport, err := Stdio("cmd", []string{"/c", "ping", "-n", "30", "127.0.0.1", ">nul"}, nil)
+	if err != nil {
+		t.Fatalf("Stdio: %v", err)
+	}
+	conn, err := tport.Connect(context.Background())
+	if err != nil {
+		t.Fatalf("Connect: %v", err)
+	}
+
+	start := time.Now()
+	if err := conn.Close(); err == nil {
+		t.Fatal("Close succeeded, want the kill-fallback error")
+	}
+	if elapsed := time.Since(start); elapsed > 5*time.Second {
+		t.Fatalf("Close took %v, want bounded escalation (grace+grace+kill)", elapsed)
+	}
+}

--- a/core/tool/middleware/middleware_test.go
+++ b/core/tool/middleware/middleware_test.go
@@ -284,8 +284,8 @@ func TestAudit_RecordsEveryCall(t *testing.T) {
 	if rec.Call.Name != "echo" || rec.Result.CallID != res.CallID {
 		t.Errorf("record = %+v, want call echo / result %q", rec, res.CallID)
 	}
-	if rec.Duration <= 0 {
-		t.Error("record duration should be positive")
+	if rec.Duration < 0 {
+		t.Error("record duration should not be negative")
 	}
 }
 

--- a/core/utils/net/mitm/bundle.go
+++ b/core/utils/net/mitm/bundle.go
@@ -21,9 +21,11 @@ var systemBundleCandidates = []string{
 }
 
 // WriteBundle writes the temporary MITM CA alongside a copy of the
-// system roots into a fresh 0600 temp file, and returns its path plus
-// a cleanup function. The path is meant to be bound into the sandbox
-// and referenced by SSL_CERT_FILE.
+// system roots into a fresh 0600 temp file (advisory on Windows,
+// where chmod maps only to the read-only attribute and the directory
+// ACL governs access), and returns its path plus a cleanup function.
+// The path is meant to be bound into the sandbox and referenced by
+// SSL_CERT_FILE.
 func WriteBundle(caPEM []byte) (string, func(), error) {
 	dir, err := os.MkdirTemp("", "flowcraft-ca-bundle-")
 	if err != nil {

--- a/core/utils/net/netproxy.go
+++ b/core/utils/net/netproxy.go
@@ -141,8 +141,9 @@ type Proxy struct {
 // Start serves the enforcement proxy in the background and returns
 // immediately. With ProxyConfig.TCPLoopback it binds an ephemeral
 // loopback TCP port (Addr reports it); otherwise it binds a unix
-// socket in a fresh per-run temp directory (mode 0600) whose path is
-// available via SocketPath for bind-mounting into a
+// socket in a fresh per-run temp directory (mode 0600 — advisory on
+// Windows, where access is governed by the directory ACL) whose path
+// is available via SocketPath for bind-mounting into a
 func Start(cfg ProxyConfig) (*Proxy, error) {
 	if cfg.Mode != NetAllowList && cfg.Mode != NetProxy {
 		return nil, fmt.Errorf(

--- a/core/workspace/case_windows_test.go
+++ b/core/workspace/case_windows_test.go
@@ -1,0 +1,62 @@
+//go:build windows
+
+package workspace
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+// Case-insensitive path semantics: Windows filesystems fold case, so
+// scoped deny/allow rules and glob patterns must match case variants
+// the way the filesystem does. A case-sensitive match here would let a
+// deny-read rule be bypassed by a different-cased path.
+
+func TestScopedWorkspaceCaseInsensitiveDenyRead(t *testing.T) {
+	ctx := context.Background()
+	inner := newTestWorkspace(t)
+	if err := inner.Write(ctx, "Secret/key.txt", []byte("x")); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	sw := NewScopedWorkspace(inner, WithDenyRead("secret/**"))
+	if _, err := sw.Read(ctx, "Secret/key.txt"); !errors.Is(err, ErrAccessDenied) {
+		t.Fatalf("case-variant read err = %v, want ErrAccessDenied", err)
+	}
+}
+
+func TestScopedWorkspaceCaseInsensitiveMandatoryDeny(t *testing.T) {
+	ctx := context.Background()
+	inner := newTestWorkspace(t)
+	if err := inner.Write(ctx, "Config/app.yaml", []byte("x")); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	sw := NewScopedWorkspace(inner, WithMandatoryDeny("config/**"))
+	if _, err := sw.Read(ctx, "Config/app.yaml"); !errors.Is(err, ErrAccessDenied) {
+		t.Fatalf("case-variant read err = %v, want ErrAccessDenied", err)
+	}
+}
+
+func TestScopedWorkspaceCaseInsensitiveAllowWrite(t *testing.T) {
+	ctx := context.Background()
+	inner := newTestWorkspace(t)
+	sw := NewScopedWorkspace(inner, WithAllowWrite("public/**"))
+	if err := sw.Write(ctx, "Public/ok.txt", []byte("x")); err != nil {
+		t.Fatalf("case-variant write err = %v, want allowed", err)
+	}
+	if _, err := inner.Read(ctx, "Public/ok.txt"); err != nil {
+		t.Fatalf("read back: %v", err)
+	}
+}
+
+func TestGlobCaseInsensitive(t *testing.T) {
+	ws := newTestWorkspace(t)
+	mustWrite(t, ws, "src/DATA.JSON", []byte("x"))
+	matches, err := Glob(context.Background(), ws, "src/*.json")
+	if err != nil {
+		t.Fatalf("Glob: %v", err)
+	}
+	if len(matches) != 1 {
+		t.Fatalf("matches = %v, want 1 case-insensitive match", matches)
+	}
+}

--- a/core/workspace/helpers.go
+++ b/core/workspace/helpers.go
@@ -100,7 +100,7 @@ func Glob(ctx context.Context, ws Workspace, pattern string) ([]string, error) {
 		// leading "./" — it is relative to the workspace root as-is.
 		var matched bool
 		if hasDoublestar {
-			matched = matchDoublestar(pattern, path)
+			matched = matchDoublestar(pattern, foldCase(path))
 		} else {
 			var matchErr error
 			// Normalise "/" in caller patterns to the platform

--- a/core/workspace/helpers.go
+++ b/core/workspace/helpers.go
@@ -101,7 +101,11 @@ func Glob(ctx context.Context, ws Workspace, pattern string) ([]string, error) {
 			matched = matchDoublestar(pattern, path)
 		} else {
 			var matchErr error
-			matched, matchErr = filepath.Match(pattern, path)
+			// Normalise "/" in caller patterns to the platform
+			// separator: filepath.Match on Windows treats "\" as the
+			// path separator and "/" as a literal, so a portable
+			// "src/*.go" pattern would otherwise never match.
+			matched, matchErr = filepath.Match(filepath.FromSlash(pattern), path)
 			if matchErr != nil {
 				return matchErr
 			}

--- a/core/workspace/helpers.go
+++ b/core/workspace/helpers.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io/fs"
 	"path/filepath"
+	"runtime"
 	"strings"
 
 	"github.com/GizClaw/flowcraft/core/telemetry"
@@ -88,6 +89,7 @@ func Walk(ctx context.Context, ws Workspace, dir string, fn WalkFunc) error {
 // The "**" component matches zero or more directory levels.
 func Glob(ctx context.Context, ws Workspace, pattern string) ([]string, error) {
 	hasDoublestar := containsDoublestar(pattern)
+	pattern = foldCase(pattern)
 
 	var matches []string
 	err := Walk(ctx, ws, ".", func(path string, entry fs.DirEntry) error {
@@ -105,7 +107,7 @@ func Glob(ctx context.Context, ws Workspace, pattern string) ([]string, error) {
 			// separator: filepath.Match on Windows treats "\" as the
 			// path separator and "/" as a literal, so a portable
 			// "src/*.go" pattern would otherwise never match.
-			matched, matchErr = filepath.Match(filepath.FromSlash(pattern), path)
+			matched, matchErr = filepath.Match(filepath.FromSlash(pattern), foldCase(path))
 			if matchErr != nil {
 				return matchErr
 			}
@@ -140,6 +142,17 @@ func matchDoublestar(pattern, path string) bool {
 // Unix) and would corrupt patterns containing a literal colon.
 func splitPath(p string) []string {
 	return split(p)
+}
+
+// foldCase returns s lower-cased on case-insensitive filesystems
+// (Windows), unchanged elsewhere. Pattern matching against workspace
+// paths must mirror the filesystem's case semantics, otherwise deny /
+// allow rules and globs silently miss (or bypass) case-variant paths.
+func foldCase(s string) string {
+	if runtime.GOOS == "windows" {
+		return strings.ToLower(s)
+	}
+	return s
 }
 
 func split(p string) []string {

--- a/core/workspace/local.go
+++ b/core/workspace/local.go
@@ -153,6 +153,28 @@ func (w *LocalWorkspace) Rename(_ context.Context, src, dst string) error {
 	if err := os.MkdirAll(filepath.Dir(dstFull), 0o755); err != nil {
 		return fmt.Errorf("workspace: mkdir for %s: %w", dst, err)
 	}
+	if runtime.GOOS == "windows" {
+		// MoveFileEx's REPLACE_EXISTING cannot replace a directory, so
+		// renaming over an existing destination directory fails with a
+		// platform-specific error where POSIX rename(2) would replace an
+		// empty directory. Directory rename is outside the Workspace
+		// contract; give a clear error for the divergent case instead of
+		// leaking Windows error codes. Moving a directory to a new name
+		// still works and is left alone.
+		if srcInfo, statErr := os.Stat(srcFull); statErr == nil {
+			if dstInfo, dstErr := os.Stat(dstFull); dstErr == nil {
+				if srcInfo.IsDir() || dstInfo.IsDir() {
+					return errdefs.Validationf(
+						"workspace: rename %s -> %s: replacing a directory is not supported",
+						src, dst)
+				}
+			} else if !os.IsNotExist(dstErr) {
+				return fmt.Errorf("workspace: stat rename destination %s: %w", dst, dstErr)
+			}
+		} else if !os.IsNotExist(statErr) {
+			return fmt.Errorf("workspace: stat rename source %s: %w", src, statErr)
+		}
+	}
 	if err := os.Rename(srcFull, dstFull); err != nil {
 		if os.IsNotExist(err) {
 			return fmt.Errorf("%w: %s", ErrNotFound, src)
@@ -174,7 +196,7 @@ func (w *LocalWorkspace) Delete(_ context.Context, path string) error {
 	} else if !os.IsNotExist(statErr) {
 		return fmt.Errorf("workspace: delete %s: %w", path, statErr)
 	}
-	if err := os.Remove(full); err != nil {
+	if err := removeWithRetry(func() error { return os.Remove(full) }); err != nil {
 		if os.IsNotExist(err) {
 			return nil
 		}
@@ -191,7 +213,7 @@ func (w *LocalWorkspace) RemoveAll(_ context.Context, path string) error {
 	if full == w.root {
 		return errdefs.Forbiddenf("workspace: refusing to remove root")
 	}
-	return os.RemoveAll(full)
+	return removeWithRetry(func() error { return os.RemoveAll(full) })
 }
 
 func (w *LocalWorkspace) List(_ context.Context, dir string) ([]fs.DirEntry, error) {

--- a/core/workspace/local.go
+++ b/core/workspace/local.go
@@ -6,6 +6,7 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 
 	"github.com/GizClaw/flowcraft/core/errdefs"
@@ -64,7 +65,7 @@ func (w *LocalWorkspace) Sub(prefix string) (*LocalWorkspace, error) {
 		return nil, fmt.Errorf("workspace local sub: open root %q: %w", cleaned, err)
 	}
 	root := local.Root()
-	if root != w.Root() && !strings.HasPrefix(root, w.Root()+string(filepath.Separator)) {
+	if !containedIn(root, w.Root()) {
 		return nil, fmt.Errorf("%w: %s (symlink escape)", ErrPathTraversal, cleaned)
 	}
 	return local, nil
@@ -247,7 +248,7 @@ func (w *LocalWorkspace) resolve(path string) (string, error) {
 		return "", fmt.Errorf("%w: %s", ErrPathTraversal, path)
 	}
 	full := filepath.Join(w.root, cleaned)
-	if !strings.HasPrefix(full, w.root+string(filepath.Separator)) && full != w.root {
+	if !containedIn(full, w.root) {
 		return "", fmt.Errorf("%w: %s", ErrPathTraversal, path)
 	}
 
@@ -257,10 +258,24 @@ func (w *LocalWorkspace) resolve(path string) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("workspace: resolve %s: %w", path, err)
 	}
-	if !strings.HasPrefix(real, w.root+string(filepath.Separator)) && real != w.root {
+	if !containedIn(real, w.root) {
 		return "", fmt.Errorf("%w: %s (symlink escape)", ErrPathTraversal, path)
 	}
 	return full, nil
+}
+
+// containedIn reports whether path is root itself or directly under
+// it. Paths are case-insensitive on Windows, so the prefix check must
+// fold case there; on case-sensitive filesystems it is byte-exact.
+func containedIn(path, root string) bool {
+	if path == root {
+		return true
+	}
+	if runtime.GOOS == "windows" {
+		return strings.HasPrefix(strings.ToLower(path),
+			strings.ToLower(root)+string(filepath.Separator))
+	}
+	return strings.HasPrefix(path, root+string(filepath.Separator))
 }
 
 // evalExistingPrefix resolves symlinks for the longest existing ancestor of

--- a/core/workspace/local_test.go
+++ b/core/workspace/local_test.go
@@ -320,7 +320,7 @@ func TestLocalWorkspace_PathTraversal(t *testing.T) {
 		t.Fatal("expected path traversal error")
 	}
 
-	err = ws.Write(ctx, "/etc/passwd", []byte("x"))
+	err = ws.Write(ctx, filepath.Join(t.TempDir(), "passwd"), []byte("x"))
 	if err == nil {
 		t.Fatal("expected absolute path rejection")
 	}

--- a/core/workspace/remove_other.go
+++ b/core/workspace/remove_other.go
@@ -1,0 +1,10 @@
+//go:build !windows
+
+package workspace
+
+// removeWithRetry is a pass-through on platforms where unlink works
+// even while the target is open, so the Windows retry loop never runs
+// on unix.
+func removeWithRetry(op func() error) error {
+	return op()
+}

--- a/core/workspace/remove_windows.go
+++ b/core/workspace/remove_windows.go
@@ -1,0 +1,41 @@
+//go:build windows
+
+package workspace
+
+import (
+	"errors"
+	"time"
+
+	xwin "golang.org/x/sys/windows"
+)
+
+// removeWithRetry retries remove-style operations that fail with a
+// sharing or lock violation. Windows refuses to delete a file another
+// process has open (Explorer, an editor, an antivirus scan), while
+// POSIX unlink succeeds regardless. The violation is transient, so a
+// short bounded retry turns a race into a success; a file that stays
+// locked keeps failing honestly instead of hanging.
+func removeWithRetry(op func() error) error {
+	const maxAttempts = 3
+	delay := 200 * time.Millisecond
+	for attempt := 1; ; attempt++ {
+		err := op()
+		if err == nil {
+			return nil
+		}
+		if !isSharingViolation(err) || attempt >= maxAttempts {
+			return err
+		}
+		time.Sleep(delay)
+		delay *= 2
+	}
+}
+
+// isSharingViolation reports whether err is a Windows sharing or lock
+// violation (ERROR_SHARING_VIOLATION / ERROR_LOCK_VIOLATION), the
+// errors Remove and RemoveAll surface while another process holds the
+// target open.
+func isSharingViolation(err error) bool {
+	return errors.Is(err, xwin.ERROR_SHARING_VIOLATION) ||
+		errors.Is(err, xwin.ERROR_LOCK_VIOLATION)
+}

--- a/core/workspace/remove_windows_test.go
+++ b/core/workspace/remove_windows_test.go
@@ -1,0 +1,93 @@
+//go:build windows
+
+package workspace
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	xwin "golang.org/x/sys/windows"
+)
+
+// TestRemoveWithRetryTransient verifies the retry loop turns a
+// transient sharing violation into a success.
+func TestRemoveWithRetryTransient(t *testing.T) {
+	calls := 0
+	err := removeWithRetry(func() error {
+		calls++
+		if calls < 3 {
+			return xwin.ERROR_SHARING_VIOLATION
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("removeWithRetry: %v", err)
+	}
+	if calls != 3 {
+		t.Fatalf("op calls = %d, want 3", calls)
+	}
+}
+
+// TestRemoveWithRetryGivesUp verifies a persistently locked file still
+// reports the original error after the bounded retries.
+func TestRemoveWithRetryGivesUp(t *testing.T) {
+	err := removeWithRetry(func() error { return xwin.ERROR_SHARING_VIOLATION })
+	if !errors.Is(err, xwin.ERROR_SHARING_VIOLATION) {
+		t.Fatalf("err = %v, want sharing violation", err)
+	}
+}
+
+// TestRemoveWithRetryNonRetryable verifies non-lock errors pass
+// through without retrying.
+func TestRemoveWithRetryNonRetryable(t *testing.T) {
+	calls := 0
+	err := removeWithRetry(func() error {
+		calls++
+		return os.ErrNotExist
+	})
+	if !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("err = %v, want ErrNotExist", err)
+	}
+	if calls != 1 {
+		t.Fatalf("op calls = %d, want 1", calls)
+	}
+}
+
+// TestDeleteLockedFile confirms a file held open without
+// FILE_SHARE_DELETE still fails Delete after the bounded retries
+// instead of succeeding or hanging.
+func TestDeleteLockedFile(t *testing.T) {
+	ws, _ := newLocalWS(t)
+	path := filepath.Join(ws.Root(), "locked.txt")
+	f, err := os.Create(path)
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	defer func() { _ = f.Close() }()
+
+	if err := ws.Delete(context.Background(), "locked.txt"); err == nil {
+		t.Fatal("Delete succeeded for a file held open without FILE_SHARE_DELETE")
+	}
+}
+
+// TestRemoveAllLockedFile confirms RemoveAll also surfaces the
+// locked-file failure instead of silently losing the error.
+func TestRemoveAllLockedFile(t *testing.T) {
+	ws, _ := newLocalWS(t)
+	if err := os.MkdirAll(filepath.Join(ws.Root(), "tree"), 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	path := filepath.Join(ws.Root(), "tree", "locked.txt")
+	f, err := os.Create(path)
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	defer func() { _ = f.Close() }()
+
+	if err := ws.RemoveAll(context.Background(), "tree"); err == nil {
+		t.Fatal("RemoveAll succeeded with a locked file inside")
+	}
+}

--- a/core/workspace/rename_windows_test.go
+++ b/core/workspace/rename_windows_test.go
@@ -1,0 +1,62 @@
+//go:build windows
+
+package workspace
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/GizClaw/flowcraft/core/errdefs"
+)
+
+// TestRenameDirOverExistingRejected verifies the Windows-only guard:
+// replacing an existing target with a directory is rejected with a
+// clear contract-level error instead of a platform-specific one.
+func TestRenameDirOverExistingRejected(t *testing.T) {
+	ws, ctx := newLocalWS(t)
+	for _, dir := range []string{"src", "dst"} {
+		if err := os.MkdirAll(filepath.Join(ws.Root(), dir), 0o755); err != nil {
+			t.Fatalf("MkdirAll %s: %v", dir, err)
+		}
+	}
+	if err := ws.Rename(ctx, "src", "dst"); err == nil {
+		t.Fatal("Rename succeeded, want validation error")
+	} else if !errdefs.IsValidation(err) {
+		t.Fatalf("err = %v, want validation error", err)
+	}
+}
+
+// TestRenameDirToNewNameAllowed verifies moving a directory to a
+// non-existing destination still works on Windows; only replacement
+// of an existing target is rejected.
+func TestRenameDirToNewNameAllowed(t *testing.T) {
+	ws, ctx := newLocalWS(t)
+	if err := os.MkdirAll(filepath.Join(ws.Root(), "src"), 0o755); err != nil {
+		t.Fatalf("MkdirAll src: %v", err)
+	}
+	if err := ws.Rename(ctx, "src", "moved"); err != nil {
+		t.Fatalf("Rename dir to new name: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(ws.Root(), "src")); !os.IsNotExist(err) {
+		t.Fatalf("src still exists after rename: %v", err)
+	}
+	if info, err := os.Stat(filepath.Join(ws.Root(), "moved")); err != nil || !info.IsDir() {
+		t.Fatalf("moved dir missing or not a dir: info=%v err=%v", info, err)
+	}
+}
+
+// TestRenameFileOverExistingDirRejected covers the file-over-directory
+// shape, which the guard also rejects with a clear error.
+func TestRenameFileOverExistingDirRejected(t *testing.T) {
+	ws, ctx := newLocalWS(t)
+	mustWrite(t, ws, "file.txt", []byte("x"))
+	if err := os.MkdirAll(filepath.Join(ws.Root(), "dst"), 0o755); err != nil {
+		t.Fatalf("MkdirAll dst: %v", err)
+	}
+	if err := ws.Rename(ctx, "file.txt", "dst"); err == nil {
+		t.Fatal("Rename succeeded, want validation error")
+	} else if !errdefs.IsValidation(err) {
+		t.Fatalf("err = %v, want validation error", err)
+	}
+}

--- a/core/workspace/resource_test.go
+++ b/core/workspace/resource_test.go
@@ -2,6 +2,7 @@ package workspace_test
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"path/filepath"
 	"testing"
@@ -20,8 +21,12 @@ func TestRegister(t *testing.T) {
 	if !ok {
 		t.Fatal("workspace.Workspace/local factory not registered")
 	}
+	root, err := json.Marshal(t.TempDir())
+	if err != nil {
+		t.Fatalf("marshal root: %v", err)
+	}
 	value, err := factory.New(context.Background(), resource.Input{
-		Settings: []byte(`{"root": "` + t.TempDir() + `"}`),
+		Settings: []byte(`{"root": ` + string(root) + `}`),
 	})
 	if err != nil {
 		t.Fatalf("New: %v", err)
@@ -48,8 +53,12 @@ func TestFactoryScopedDisabled(t *testing.T) {
 		t.Fatal(err)
 	}
 	factory, _ := reg.Lookup("workspace.Workspace", "local")
+	root, err := json.Marshal(t.TempDir())
+	if err != nil {
+		t.Fatalf("marshal root: %v", err)
+	}
 	value, err := factory.New(context.Background(), resource.Input{
-		Settings: []byte(`{"root": "` + t.TempDir() + `",
+		Settings: []byte(`{"root": ` + string(root) + `,
 			"scoped": {"enabled": false, "deny_read": ["secret/**"]}}`),
 	})
 	if err != nil {
@@ -66,8 +75,12 @@ func TestFactoryScopedEnabled(t *testing.T) {
 		t.Fatal(err)
 	}
 	factory, _ := reg.Lookup("workspace.Workspace", "local")
+	root, err := json.Marshal(t.TempDir())
+	if err != nil {
+		t.Fatalf("marshal root: %v", err)
+	}
 	value, err := factory.New(context.Background(), resource.Input{
-		Settings: []byte(`{"root": "` + t.TempDir() + `",
+		Settings: []byte(`{"root": ` + string(root) + `,
 			"scoped": {"enabled": true, "allow_write": ["public/**"]}}`),
 	})
 	if err != nil {

--- a/core/workspace/scoped.go
+++ b/core/workspace/scoped.go
@@ -183,9 +183,9 @@ func (s *ScopedWorkspace) logViolation(ctx context.Context, op, path, reason str
 //
 // To match a file extension at any depth, use the explicit "**/*.ext" form.
 func matchesAny(path string, patterns []string) bool {
-	path = filepath.ToSlash(path)
+	path = foldCase(filepath.ToSlash(path))
 	for _, p := range patterns {
-		p = filepath.ToSlash(p)
+		p = foldCase(filepath.ToSlash(p))
 		if strings.HasSuffix(p, "/**") {
 			prefix := strings.TrimSuffix(p, "/**")
 			if strings.HasPrefix(prefix, "**/") {

--- a/docs/guides/sandbox.md
+++ b/docs/guides/sandbox.md
@@ -89,7 +89,12 @@ backend fails closed with `errdefs.NotAvailable` for policies it
 cannot enforce. Interactive sessions run through ConPTY: stdout and
 stderr merge into a single TTY stream and `Resize` applies to the
 pseudo console (TTY combined with write confinement is not available
-yet).
+yet). Permission bits are advisory on Windows: `chmod`-style modes
+map only to the read-only attribute, and real access control comes
+from the directory ACLs inherited at creation. Code that passes modes
+like `0o600` / `0o755` still runs unchanged, but treat such modes as
+intent, not as an enforceable boundary (for example `0o600` does not
+hide a file from other users on a shared drive).
 
 ## Per-exec write policy
 

--- a/docs/guides/sandbox.md
+++ b/docs/guides/sandbox.md
@@ -36,6 +36,9 @@ Platform backends are registered from core subpackages:
 
 - `core/sandbox/bwrap` for Linux namespace isolation.
 - `core/sandbox/seatbelt` for macOS confinement.
+- `core/sandbox/windows` for Windows Job Object lifecycle and
+  resource caps (phase 1: no OS-level filesystem or network
+  confinement yet).
 
 Both isolation backends share the same settings shape:
 
@@ -65,6 +68,23 @@ that could weaken the policy (e.g. `--ro-bind` or `--args`) rejected at
 build time. The local runner is a no-isolation backend for trusted
 workflows; bwrap/seatbelt enforce the isolation boundary and reject
 policies they cannot honor.
+
+## Platform support
+
+| Backend | Platform | Isolation | Net modes | Write policy | Resource caps |
+|---|---|---|---|---|---|
+| `local` | all (interactive sessions unix-only) | none | `NetDefault` only | none enforced | memory / cpu via group watcher (unix) |
+| `bwrap` | Linux | user / mount / pid / net namespaces | `NetDefault`, `NetDenyAll`, `NetAllowList`, `NetProxy` | root + `writable_paths`, `WriteReadOnly` | memory / cpu (watcher) |
+| `seatbelt` | macOS | Seatbelt (SBPL) | `NetDefault`, `NetDenyAll`, `NetAllowList`, `NetProxy` | root + writable paths, `WriteReadOnly` | memory / cpu (watcher) |
+| `windows` | Windows | Job Objects (process tree, memory / cpu caps) | `NetDefault` only (phase 1) | none enforced (phase 1) | memory / cpu (job limits) |
+
+The `windows` backend is the phase-1 port that makes command execution
+work on Windows: every child runs in its own job object, timeout /
+cancel / close terminate the whole process tree, and memory / cpu
+limits are enforced by the kernel. Filesystem write confinement
+(restricted tokens + ACLs) and network filtering are planned follow-ups;
+until then the backend fails closed with `errdefs.NotAvailable` for
+policies it cannot enforce.
 
 ## Per-exec write policy
 

--- a/docs/guides/sandbox.md
+++ b/docs/guides/sandbox.md
@@ -76,7 +76,7 @@ policies they cannot honor.
 | `local` | all (interactive sessions unix-only) | none | `NetDefault` only | none enforced | memory / cpu via group watcher (unix) |
 | `bwrap` | Linux | user / mount / pid / net namespaces | `NetDefault`, `NetDenyAll`, `NetAllowList`, `NetProxy` | root + `writable_paths`, `WriteReadOnly` | memory / cpu (watcher) |
 | `seatbelt` | macOS | Seatbelt (SBPL) | `NetDefault`, `NetDenyAll`, `NetAllowList`, `NetProxy` | root + writable paths, `WriteReadOnly` | memory / cpu (watcher) |
-| `windows` | Windows | Job Objects + optional Low-integrity token (`WithWriteConfinement`) | `NetDefault` only | root + `writable_paths`, `WriteReadOnly` (with write confinement) | memory / cpu (job limits) |
+| `windows` | Windows | Job Objects + optional Low-integrity token (`WithWriteConfinement`) + AppContainer (`NetDenyAll`, `NetAllowList`, `NetProxy`) | `NetDefault`, `NetDenyAll`, `NetAllowList`, `NetProxy` | root + `writable_paths`, `WriteReadOnly` (with write confinement) | memory / cpu (job limits) |
 
 The `windows` backend makes command execution work on Windows: every
 child runs in its own job object, timeout / cancel / close terminate
@@ -84,12 +84,17 @@ the whole process tree, and memory / cpu limits are enforced by the
 kernel. Write confinement is opt-in via `WithWriteConfinement`: the
 child runs with a restricted Low-integrity token and only the runner
 root plus explicit `writable_paths` are labeled writable (all reads
-stay allowed). Network filtering is still a follow-up; until then the
-backend fails closed with `errdefs.NotAvailable` for policies it
-cannot enforce. Interactive sessions run through ConPTY: stdout and
-stderr merge into a single TTY stream and `Resize` applies to the
-pseudo console (TTY combined with write confinement is not available
-yet). Permission bits are advisory on Windows: `chmod`-style modes
+stay allowed). Network policy runs the child under an AppContainer
+token: `NetDenyAll` grants no network capabilities (the OS firewall
+blocks everything), while `NetAllowList` / `NetProxy` pin the
+container to a host-side enforcement proxy via WFP filters and inject
+the proxy environment, mirroring the seatbelt architecture. These
+modes require an elevated host and fail closed with
+`errdefs.NotAvailable` otherwise. Interactive sessions run through
+ConPTY: stdout and stderr merge into a single TTY stream and `Resize`
+applies to the pseudo console (TTY combined with write confinement or
+a net policy is not available yet). Permission bits are advisory on
+Windows: `chmod`-style modes
 map only to the read-only attribute, and real access control comes
 from the directory ACLs inherited at creation. Code that passes modes
 like `0o600` / `0o755` still runs unchanged, but treat such modes as

--- a/docs/guides/sandbox.md
+++ b/docs/guides/sandbox.md
@@ -86,7 +86,10 @@ child runs with a restricted Low-integrity token and only the runner
 root plus explicit `writable_paths` are labeled writable (all reads
 stay allowed). Network filtering is still a follow-up; until then the
 backend fails closed with `errdefs.NotAvailable` for policies it
-cannot enforce.
+cannot enforce. Interactive sessions run through ConPTY: stdout and
+stderr merge into a single TTY stream and `Resize` applies to the
+pseudo console (TTY combined with write confinement is not available
+yet).
 
 ## Per-exec write policy
 

--- a/docs/guides/sandbox.md
+++ b/docs/guides/sandbox.md
@@ -76,15 +76,17 @@ policies they cannot honor.
 | `local` | all (interactive sessions unix-only) | none | `NetDefault` only | none enforced | memory / cpu via group watcher (unix) |
 | `bwrap` | Linux | user / mount / pid / net namespaces | `NetDefault`, `NetDenyAll`, `NetAllowList`, `NetProxy` | root + `writable_paths`, `WriteReadOnly` | memory / cpu (watcher) |
 | `seatbelt` | macOS | Seatbelt (SBPL) | `NetDefault`, `NetDenyAll`, `NetAllowList`, `NetProxy` | root + writable paths, `WriteReadOnly` | memory / cpu (watcher) |
-| `windows` | Windows | Job Objects (process tree, memory / cpu caps) | `NetDefault` only (phase 1) | none enforced (phase 1) | memory / cpu (job limits) |
+| `windows` | Windows | Job Objects + optional Low-integrity token (`WithWriteConfinement`) | `NetDefault` only | root + `writable_paths`, `WriteReadOnly` (with write confinement) | memory / cpu (job limits) |
 
-The `windows` backend is the phase-1 port that makes command execution
-work on Windows: every child runs in its own job object, timeout /
-cancel / close terminate the whole process tree, and memory / cpu
-limits are enforced by the kernel. Filesystem write confinement
-(restricted tokens + ACLs) and network filtering are planned follow-ups;
-until then the backend fails closed with `errdefs.NotAvailable` for
-policies it cannot enforce.
+The `windows` backend makes command execution work on Windows: every
+child runs in its own job object, timeout / cancel / close terminate
+the whole process tree, and memory / cpu limits are enforced by the
+kernel. Write confinement is opt-in via `WithWriteConfinement`: the
+child runs with a restricted Low-integrity token and only the runner
+root plus explicit `writable_paths` are labeled writable (all reads
+stay allowed). Network filtering is still a follow-up; until then the
+backend fails closed with `errdefs.NotAvailable` for policies it
+cannot enforce.
 
 ## Per-exec write policy
 

--- a/docs/guides/sandbox.md
+++ b/docs/guides/sandbox.md
@@ -37,10 +37,10 @@ Platform backends are registered from core subpackages:
 - `core/sandbox/bwrap` for Linux namespace isolation.
 - `core/sandbox/seatbelt` for macOS confinement.
 - `core/sandbox/windows` for Windows Job Object lifecycle and
-  resource caps (phase 1: no OS-level filesystem or network
-  confinement yet).
+  resource caps, opt-in Low-integrity write confinement, and
+  AppContainer / WFP network policy.
 
-Both isolation backends share the same settings shape:
+The bwrap and seatbelt backends share the same settings shape:
 
 ```yaml
 resources:
@@ -68,6 +68,26 @@ that could weaken the policy (e.g. `--ro-bind` or `--args`) rejected at
 build time. The local runner is a no-isolation backend for trusted
 workflows; bwrap/seatbelt enforce the isolation boundary and reject
 policies they cannot honor.
+
+The windows backend takes `write_confine` (opt-in Low-integrity token
+write confinement) and `writable_paths` (paths the confined child may
+write) instead of `binary` / `readonly_root` / `extra_flags`:
+
+```yaml
+resources:
+  box:
+    kind: sandbox.Runner
+    impl: windows
+    settings:
+      root: ./sandbox
+      write_confine: true        # optional; Low-integrity write confinement
+      writable_paths: [./out]    # optional; writable paths under confinement
+```
+
+Without `write_confine` the windows runner is lifecycle-only and
+`WriteReadOnly` execs are rejected with NotAvailable; network policy
+(`NetDenyAll`, `NetAllowList`, `NetProxy`) additionally requires an
+elevated host, otherwise it fails closed with NotAvailable.
 
 ## Platform support
 

--- a/docs/guides/sandbox.md
+++ b/docs/guides/sandbox.md
@@ -105,12 +105,15 @@ kernel. Write confinement is opt-in via `WithWriteConfinement`: the
 child runs with a restricted Low-integrity token and only the runner
 root plus explicit `writable_paths` are labeled writable (all reads
 stay allowed). Network policy runs the child under an AppContainer
-token: `NetDenyAll` grants no network capabilities (the OS firewall
-blocks everything), while `NetAllowList` / `NetProxy` pin the
-container to a host-side enforcement proxy via WFP filters and inject
-the proxy environment, mirroring the seatbelt architecture. These
-modes require an elevated host and fail closed with
-`errdefs.NotAvailable` otherwise. Interactive sessions run through
+token with no network capabilities in every mode. The OS firewall's
+AppIsolation default blocks TCP and connected flows; because it does
+not constrain unconnected UDP or ICMP sockets, the backend also
+installs WFP bind-layer filters for the sandbox's package SID —
+`NetDenyAll` blocks every bind, while `NetAllowList` / `NetProxy`
+permit only TCP binds, pin the container to a host-side enforcement
+proxy, and inject the proxy environment, mirroring the seatbelt
+architecture. These modes require an elevated host and fail closed
+with `errdefs.NotAvailable` otherwise. Interactive sessions run through
 ConPTY: stdout and stderr merge into a single TTY stream and `Resize`
 applies to the pseudo console (TTY combined with write confinement or
 a net policy is not available yet). Permission bits are advisory on


### PR DESCRIPTION
## Summary

Makes `core` command execution work on Windows. This PR adds a Job Object sandbox backend at `core/sandbox/windows` with opt-in OS-level write confinement, budget-exceeded exit classification, ConPTY-based interactive (TTY) sessions, and kernel-level network policy enforcement (AppContainer + WFP), plus a Windows CI lane. It also ships the surrounding Windows compatibility work: MCP stdio graceful shutdown via `GenerateConsoleCtrlEvent`, and `core/workspace` directory-rename / locked-file deletion semantics. It is the deliverable for #481: commands run on Windows instead of failing with `errdefs.NotAvailable` everywhere, write and net policies are enforced by the OS, resource-cap kills are classified honestly, and interactive sessions get a real pseudo terminal.

## Why

A Windows build of `core` assembled and type-checked cleanly, but the command-execution layer was effectively unix-only: `Runner.Start` / `Runner.Exec` were unavailable, resource and network limits were rejected by policy validation, and no isolation backend existed. That left agent shell tooling with no usable default runner on Windows (see #481).

## What this adds

- `core/sandbox/windows`: a `sandbox.Runner` built on Windows Job Objects.
  - Every child runs in its own job: timeout / cancel / close terminate the whole process tree (`JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE`), not just the leader.
  - Resource caps enforced by the kernel: `MemoryBytes` as a job-wide memory limit (`JOB_OBJECT_LIMIT_JOB_MEMORY`), `CPUMillicores` as a job-wide user-time budget (`JOB_OBJECT_LIMIT_JOB_TIME` = Timeout x millicores / 1000, matching the unix watcher's aggregate-group semantics).
  - Budget kills are classified as `SessionBudgetExceeded` via the job completion port (`JOB_OBJECT_MSG_JOB_MEMORY_LIMIT` / `JOB_OBJECT_MSG_END_OF_JOB_TIME`) with a short grace window.
  - Processes are created with `CREATE_SUSPENDED`, assigned to the job before any user code runs, then resumed, so grandchildren cannot escape the job.
  - Pipe sessions with the same seq-based replayable output log, `Write` / `CloseInput`, `Wait`, and exit classification as the unix backend.
  - TTY sessions through ConPTY: merged `SessionStreamTTY` output, `Resize` via `ResizePseudoConsole`, `Capabilities().TTY = true`, and `CloseInput` returning `errdefs.NotAvailable` per the shared Session contract. `Signal` and `Watch` stay fail-closed NotAvailable.
  - Env allow-list + inject, WorkDir root confinement, and `MaxOutputBytes` truncation.
  - Non-Windows stub (`New` returns NotAvailable) and a deployment resource factory (`impl: windows`), matching the bwrap / seatbelt pattern.
- Write confinement (opt-in via `WithWriteConfinement`):
  - The child runs with a restricted token (all privileges disabled) at Low integrity level, derived directly from the caller's primary token so the `CreateProcessAsUser` `SE_ASSIGNPRIMARYTOKEN_NAME` exemption applies.
  - The runner root plus `WithWritablePaths` entries are labeled Low integrity (`SYSTEM_MANDATORY_LABEL_ACE`, `NO_WRITE_UP`) so the child can write only there; reads everywhere else stay allowed.
  - `WriteReadOnly` keeps the root unlabeled (explicit writable paths stay writable); the child gets its own Low-labeled TEMP/TMP.
  - Hosts without `SE_INCREASE_QUOTA_NAME` fail closed with NotAvailable rather than degrading to an unsandboxed spawn.
- Network policy (`Net.Mode`), enforced per-runner with AppContainer tokens:
  - `NetDenyAll` — the child runs in a per-runner AppContainer with no network capability; the OS firewall's AppIsolation default blocks TCP and connected flows, and WFP `ALE_RESOURCE_ASSIGNMENT` filters block every bind (closing the unconnected-UDP/ICMP gap in the OS default).
  - `NetAllowList` / `NetProxy` — the AppContainer carries no network capability; the host-side enforcement proxy binds `127.0.0.1:0`, and a maximum-weight WFP sublayer keyed on the package SID permits only TCP binds at `ALE_RESOURCE_ASSIGNMENT` (blocking every UDP/ICMP socket) and only `127.0.0.1`/`::1:proxyPort` at `ALE_AUTH_CONNECT`, with an explicit block filter for every other connect; `HTTP(S)_PROXY` / `ALL_PROXY` are injected and the MITM CA bundle is staged in the sandbox home with `SSL_CERT_FILE`.
  - Writable paths get DACL grant ACEs for the package SID; HOME / USERPROFILE / TEMP / APPDATA redirect to a per-runner sandbox home, because AppContainers cannot read the user profile by default.
  - Fail-closed: hosts without elevation report `NotAvailable` for profile creation and WFP engine opens; TTY + net policy is `NotAvailable` for now.
  - The WFP bindings in `core/sandbox/windows/wfp_windows.go` are a trimmed BSD-3 port of the Tailscale `wf` package.
- MCP graceful shutdown: `core/tool/mcp` now has a Windows stdio transport that closes stdin, waits the grace period, delivers `CTRL_BREAK_EVENT` via `GenerateConsoleCtrlEvent`, then escalates to kill; unix keeps the SDK `CommandTransport`, so SIGTERM->SIGKILL behavior is unchanged. Dropped best-effort errors (signal delivery, framing close) are surfaced through `core/telemetry`.
- Workspace compatibility in `core/workspace`: case-insensitive path containment / glob folding on Windows, a clear validation error instead of a raw Windows error for directory-overwrite renames, and bounded retries for `Remove` / `RemoveAll` on sharing-violation (locked files).
- Windows CI lane in `.github/workflows/ci.yml`: build, vet, and the full core test suite on `windows-latest`, plus sandbox integration tests (echo, timeout, terminate, stdin, truncation, write-confinement allow/deny, TEMP override, memory/CPU budget classification, live ConPTY TTY tests, the AppContainer/WFP net-policy suites, and the concurrency / scale stress suite).

## Issue coverage (#481)

- [x] Windows runner with process-tree kill and job-level resource limits.
- [x] Fail-closed NotAvailable for everything not enforced.
- [x] Platform support matrix in `docs/guides/sandbox.md` (including Windows permission-bit semantics).
- [x] Windows CI lane (build + vet + tests on `windows-latest`).
- [x] OS-level write confinement via restricted Low-integrity token + mandatory labels.
- [x] Budget-exceeded exit classification via job completion-port messages.
- [x] Interactive TTY sessions via ConPTY (merged output + Resize).
- [x] Network policy: `NetDenyAll` via capability-less AppContainer; `NetAllowList` / `NetProxy` via capability-less AppContainer + maximum-weight WFP permit sublayer pinning to the enforcement proxy (UDP egress covered by AppIsolation default-deny).

## Verification

- `GOOS=windows GOARCH=amd64 go build ./...` and `go vet ./...` pass for the whole `core` module; darwin build/vet pass too.
- Windows CI runs the new net-policy tests against real AppContainer profiles and the WFP engine on `windows-latest`: deny-all echo, a differential "control dial succeeds / deny-all dial fails" check, allow-list and proxy exec, WFP pinning (raw outbound dial fails under allow-list), env redirection, and TTY+net-policy NotAvailable.
- Concurrency / stress: parallel sessions on one runner (output isolation), several runners at once, concurrent AppContainer deny-all and WFP allow-list sessions, concurrent isolation teardown, and a 400-file workspace exercising the per-file DACL grants under a deadline.
- The MCP Windows transport test spawns a real child process and verifies graceful shutdown within the grace window.

## Known follow-up (not in this PR)

- TTY combined with `WithWriteConfinement` returns NotAvailable until the restricted-token ConPTY spawn path is verified against a real console.
- ConPTY signal delivery (Ctrl-C) stays NotAvailable: Windows has no portable interrupt path and ConPTY's input channel does not expose a reliable one.
- Net policy on non-elevated hosts stays fail-closed NotAvailable (AppContainer profile creation and WFP engine opens require elevation).

Closes #481


