### PR TITLE
feat(core/sandbox): SOCKS5 proxy channel, deny reasons, and WFP fence verify

### DIFF
--- a/core/sandbox/bwrap/doc.go
+++ b/core/sandbox/bwrap/doc.go
@@ -63,7 +63,11 @@
 // connection over a unix socket to a host-side enforcement proxy
 // (core/utils/net) that evaluates the allow-list or
 // forwards to the configured upstream. The bridge injects
-// HTTP(S)_PROXY / ALL_PROXY and strips NO_PROXY.
+// HTTP(S)_PROXY -> http://loopback:port and ALL_PROXY ->
+// socks5://loopback:port and strips NO_PROXY. The proxy listener
+// multiplexes HTTP and SOCKS5, so SOCKS5-aware non-HTTP clients
+// (curl --socks5-hostname, ssh ProxyCommand with nc -X 5, tools that
+// honor ALL_PROXY) traverse the same allow-list / upstream policy.
 //
 // The bridge is not a separate executable. The runner re-executes the
 // host binary itself with a reserved marker argument
@@ -80,11 +84,13 @@
 // (docker.sock, dbus, systemd, ...) directly. NetDefault keeps the
 // host /run so host DNS (systemd's stub-resolv.conf) keeps working.
 //
-// Limitations (v1): only proxy-aware clients (HTTP(S)_PROXY) are
-// supported — raw TCP/UDP applications fail closed; there is no UDP
-// proxying; AllowHosts matches hostname suffixes or exact IP literals
-// with all ports allowed. DNS resolution happens in the host proxy, so
-// the child needs no resolver route.
+// Limitations (v1): clients that neither honor HTTP(S)_PROXY nor speak
+// SOCKS5 fail closed — raw UDP is never proxied and raw TCP without a
+// proxy client has no egress at all. AllowHosts matches hostname
+// suffixes or exact IP literals, with an optional ":port" suffix on
+// rules and allow-list entries; entries without a port match any port.
+// DNS resolution happens in the host proxy, so the child needs no
+// resolver route.
 //
 // # Resource-cap caveat
 //

--- a/core/sandbox/bwrap/internal/bridge/bridge.go
+++ b/core/sandbox/bwrap/internal/bridge/bridge.go
@@ -128,7 +128,8 @@ func run(argv []string, stdin io.Reader, stdout, stderr io.Writer) int {
 // would deny anyway. Building the env explicitly (instead of mutating
 // the bridge's own env) keeps the logic testable in-process.
 func childEnv(port int) []string {
-	proxy := fmt.Sprintf("http://127.0.0.1:%d", port)
+	httpProxy := fmt.Sprintf("http://127.0.0.1:%d", port)
+	socksProxy := fmt.Sprintf("socks5://127.0.0.1:%d", port)
 	var env []string
 	for _, kv := range os.Environ() {
 		name, _, ok := strings.Cut(kv, "=")
@@ -142,9 +143,13 @@ func childEnv(port int) []string {
 		env = append(env, kv)
 	}
 	env = append(env,
-		"HTTP_PROXY="+proxy, "http_proxy="+proxy,
-		"HTTPS_PROXY="+proxy, "https_proxy="+proxy,
-		"ALL_PROXY="+proxy, "all_proxy="+proxy,
+		"HTTP_PROXY="+httpProxy, "http_proxy="+httpProxy,
+		"HTTPS_PROXY="+httpProxy, "https_proxy="+httpProxy,
+		// ALL_PROXY speaks SOCKS5 on the same port: non-HTTP TCP
+		// clients that honor it (curl, ssh ProxyCommand with
+		// -X 5, explicit --socks5-hostname) stay inside the
+		// allow-list / upstream fence.
+		"ALL_PROXY="+socksProxy, "all_proxy="+socksProxy,
 		"NO_PROXY=", "no_proxy=",
 	)
 	return env

--- a/core/sandbox/bwrap/internal/bridge/bridge_test.go
+++ b/core/sandbox/bwrap/internal/bridge/bridge_test.go
@@ -1,0 +1,52 @@
+//go:build linux
+
+package bridge
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestChildEnvProxySplit verifies the bridge injects HTTP_PROXY as an
+// http:// URL and ALL_PROXY as a socks5:// URL on the same loopback
+// port, strips NO_PROXY, and preserves every other variable.
+func TestChildEnvProxySplit(t *testing.T) {
+	t.Setenv("HTTP_PROXY", "http://corp:1")
+	t.Setenv("HTTPS_PROXY", "http://corp:1")
+	t.Setenv("ALL_PROXY", "http://corp:1")
+	t.Setenv("NO_PROXY", "corp")
+	t.Setenv("KEEP", "1")
+
+	env := childEnv(32123)
+	got := map[string]string{}
+	for _, kv := range env {
+		k, v, ok := strings.Cut(kv, "=")
+		if !ok {
+			t.Fatalf("bad env entry %q", kv)
+		}
+		got[k] = v
+	}
+	if got["HTTP_PROXY"] != "http://127.0.0.1:32123" {
+		t.Errorf("HTTP_PROXY = %q, want http://127.0.0.1:32123", got["HTTP_PROXY"])
+	}
+	if got["HTTPS_PROXY"] != "http://127.0.0.1:32123" {
+		t.Errorf("HTTPS_PROXY = %q, want http://127.0.0.1:32123", got["HTTPS_PROXY"])
+	}
+	if got["ALL_PROXY"] != "socks5://127.0.0.1:32123" {
+		t.Errorf("ALL_PROXY = %q, want socks5://127.0.0.1:32123", got["ALL_PROXY"])
+	}
+	if got["NO_PROXY"] != "" {
+		t.Errorf("NO_PROXY = %q, want empty", got["NO_PROXY"])
+	}
+	if got["KEEP"] != "1" {
+		t.Errorf("KEEP = %q, want 1", got["KEEP"])
+	}
+	// os.Environ() is read inside childEnv; the t.Setenv values above
+	// must not leak into the returned list as stale proxy entries.
+	for _, kv := range env {
+		if strings.HasPrefix(kv, "HTTP_PROXY=http://corp") ||
+			strings.HasPrefix(kv, "NO_PROXY=corp") {
+			t.Errorf("stale env entry %q", kv)
+		}
+	}
+}

--- a/core/sandbox/seatbelt/doc.go
+++ b/core/sandbox/seatbelt/doc.go
@@ -59,8 +59,12 @@
 // allow-list (NetAllowList) or forwards to the configured upstream
 // (NetProxy); it resolves hostnames on the host, so the child needs no
 // resolver route. The child env is forced onto the proxy loopback
-// (HTTP(S)_PROXY / ALL_PROXY) and NO_PROXY is stripped, so proxy-aware
-// clients use the single enforced egress.
+// (HTTP(S)_PROXY -> http://loopback:port, ALL_PROXY ->
+// socks5://loopback:port) and NO_PROXY is stripped, so proxy-aware
+// clients use the single enforced egress. The proxy listener
+// multiplexes HTTP and SOCKS5, so SOCKS5-aware non-HTTP clients
+// (curl --socks5-hostname, ssh ProxyCommand with nc -X 5, tools that
+// honor ALL_PROXY) traverse the same allow-list / upstream policy.
 //
 // The blanket network deny also covers the Mach / AF_SYSTEM sockets
 // macOS needs for TLS and network configuration, so the restricted
@@ -68,12 +72,14 @@
 // (SecurityServer, trustd, configd, networkd, ...). See
 // writeRestrictedNetwork.
 //
-// Limitations (v1): only proxy-aware clients (HTTP(S)_PROXY) are
-// supported — raw TCP/UDP applications fail closed; there is no UDP
-// proxying; AllowHosts matches hostname suffixes or exact IP literals
-// with all ports allowed. SBPL network rules do not confine unix-domain
-// sockets; the macOS sensitive-UDS surface is small, so this is a
-// documented boundary rather than a broad file-read deny.
+// Limitations (v1): clients that neither honor HTTP(S)_PROXY nor speak
+// SOCKS5 fail closed — raw UDP is never proxied and raw TCP without a
+// proxy client has no egress at all. AllowHosts matches hostname
+// suffixes or exact IP literals, with an optional ":port" suffix on
+// rules and allow-list entries; entries without a port match any port.
+// SBPL network rules do not confine unix-domain sockets; the macOS
+// sensitive-UDS surface is small, so this is a documented boundary
+// rather than a broad file-read deny.
 //
 // Note: sandbox-exec is formally deprecated by Apple yet remains
 // functional and is the same primitive Chrome and Anthropic's
@@ -90,14 +96,15 @@
 //
 // # Proxy enhancements
 //
-// The host-side enforcement proxy supports rule-based allow/deny,
-// socks5:// upstreams, MITM (TLS termination + hooks) with
-// SSL_CERT_FILE injection, and per-decision audit callbacks. MITM
-// terminates both HTTP/1.1 and HTTP/2 clients (ALPN h2 + http/1.1);
-// MITMPolicy.Hosts / ExcludeHosts select which CONNECT tunnels are
-// terminated, so cert-pinning destinations can be raw-tunnelled
-// explicitly. Unix socket allow-lists are not enforceable under SBPL,
-// so any non-empty UnixSockets policy is rejected with
+// The host-side enforcement proxy supports rule-based allow/deny with
+// model-facing deny reasons (NetRule.Reason, surfaced in HTTP denial
+// bodies and audit records), socks5:// upstreams, MITM (TLS
+// termination + hooks) with SSL_CERT_FILE injection, and per-decision
+// audit callbacks. MITM terminates both HTTP/1.1 and HTTP/2 clients
+// (ALPN h2 + http/1.1); MITMPolicy.Hosts / ExcludeHosts select which
+// CONNECT tunnels are terminated, so cert-pinning destinations can be
+// raw-tunnelled explicitly. Unix socket allow-lists are not enforceable
+// under SBPL, so any non-empty UnixSockets policy is rejected with
 // errdefs.NotAvailable.
 //
 // macOS CA-injection caveat: Go and curl on macOS use the Security

--- a/core/sandbox/seatbelt/env_darwin_test.go
+++ b/core/sandbox/seatbelt/env_darwin_test.go
@@ -1,0 +1,45 @@
+//go:build darwin
+
+package seatbelt
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/GizClaw/flowcraft/core/sandbox"
+)
+
+// TestBuildEnvProxySplit verifies allow-list / proxy modes inject
+// HTTP_PROXY (http://) and ALL_PROXY (socks5://) to the same loopback
+// port and strip NO_PROXY.
+func TestBuildEnvProxySplit(t *testing.T) {
+	t.Setenv("HTTP_PROXY", "http://corp:1")
+	t.Setenv("HTTPS_PROXY", "http://corp:1")
+	t.Setenv("ALL_PROXY", "http://corp:1")
+	t.Setenv("NO_PROXY", "corp")
+	t.Setenv("KEEP", "1")
+
+	env := buildEnv(sandbox.EnvPolicy{Allow: []string{
+		"HTTP_PROXY", "HTTPS_PROXY", "ALL_PROXY", "NO_PROXY", "KEEP",
+	}}, 12345)
+	got := map[string]string{}
+	for _, kv := range env {
+		k, v, ok := strings.Cut(kv, "=")
+		if !ok {
+			t.Fatalf("bad env entry %q", kv)
+		}
+		got[k] = v
+	}
+	if got["HTTP_PROXY"] != "http://127.0.0.1:12345" {
+		t.Errorf("HTTP_PROXY = %q, want http://127.0.0.1:12345", got["HTTP_PROXY"])
+	}
+	if got["ALL_PROXY"] != "socks5://127.0.0.1:12345" {
+		t.Errorf("ALL_PROXY = %q, want socks5://127.0.0.1:12345", got["ALL_PROXY"])
+	}
+	if got["NO_PROXY"] != "" {
+		t.Errorf("NO_PROXY = %q, want empty", got["NO_PROXY"])
+	}
+	if got["KEEP"] != "1" {
+		t.Errorf("KEEP = %q, want 1", got["KEEP"])
+	}
+}

--- a/core/sandbox/seatbelt/runner_darwin.go
+++ b/core/sandbox/seatbelt/runner_darwin.go
@@ -387,13 +387,17 @@ func buildEnv(policy sandbox.EnvPolicy, proxyPort int) []string {
 		values[key] = value
 	}
 	if proxyPort > 0 {
-		proxy := fmt.Sprintf("http://127.0.0.1:%d", proxyPort)
-		for _, name := range []string{
-			"HTTP_PROXY", "http_proxy",
-			"HTTPS_PROXY", "https_proxy",
-			"ALL_PROXY", "all_proxy",
-		} {
-			values[name] = proxy
+		httpProxy := fmt.Sprintf("http://127.0.0.1:%d", proxyPort)
+		socksProxy := fmt.Sprintf("socks5://127.0.0.1:%d", proxyPort)
+		for _, name := range []string{"HTTP_PROXY", "http_proxy", "HTTPS_PROXY", "https_proxy"} {
+			values[name] = httpProxy
+		}
+		// ALL_PROXY points at the same port speaking SOCKS5, so
+		// non-HTTP TCP clients that honor ALL_PROXY (curl, tools
+		// configured with --socks5-hostname or an explicit
+		// ProxyCommand) go through the same allow-list / upstream.
+		for _, name := range []string{"ALL_PROXY", "all_proxy"} {
+			values[name] = socksProxy
 		}
 		delete(values, "NO_PROXY")
 		delete(values, "no_proxy")

--- a/core/sandbox/windows/doc.go
+++ b/core/sandbox/windows/doc.go
@@ -46,7 +46,14 @@
 //	                              listener multiplexes both protocols,
 //	                              so SOCKS5-aware non-HTTP clients
 //	                              traverse the same allow-list /
-//	                              upstream). Every non-default mode
+//	                              upstream). The proxy-port permit is
+//	                              installed at both ALE_AUTH_CONNECT
+//	                              and ALE_AUTH_RECV_ACCEPT: the latter
+//	                              layer is where the built-in
+//	                              AppContainerLoopback block lives, so
+//	                              a connect-layer permit alone would
+//	                              make the proxy connection time out.
+//	                              Every non-default mode
 //	                              also runs a behavioral fence probe
 //	                              under the container token before the
 //	                              isolation is handed out: a dial to a

--- a/core/sandbox/windows/doc.go
+++ b/core/sandbox/windows/doc.go
@@ -51,7 +51,9 @@
 //	                              under the container token before the
 //	                              isolation is handed out: a dial to a
 //	                              non-proxy loopback port must be
-//	                              blocked, and in allow-list / proxy
+//	                              blocked, an unconnected UDP send must
+//	                              be blocked (covering the bind-layer
+//	                              filters), and in allow-list / proxy
 //	                              modes a dial to the proxy port must
 //	                              succeed. A mismatch fails closed.
 //	                              Hosts without AppContainer-profile or

--- a/core/sandbox/windows/doc.go
+++ b/core/sandbox/windows/doc.go
@@ -40,9 +40,22 @@
 //	                              the container to a host-side
 //	                              enforcement proxy (only the loopback
 //	                              proxy port is reachable), and inject
-//	                              the proxy environment. Hosts without
-//	                              AppContainer-profile or WFP-engine
-//	                              access fail closed with
+//	                              the proxy environment
+//	                              (HTTP(S)_PROXY -> http://loopback,
+//	                              ALL_PROXY -> socks5://loopback; the
+//	                              listener multiplexes both protocols,
+//	                              so SOCKS5-aware non-HTTP clients
+//	                              traverse the same allow-list /
+//	                              upstream). Every non-default mode
+//	                              also runs a behavioral fence probe
+//	                              under the container token before the
+//	                              isolation is handed out: a dial to a
+//	                              non-proxy loopback port must be
+//	                              blocked, and in allow-list / proxy
+//	                              modes a dial to the proxy port must
+//	                              succeed. A mismatch fails closed.
+//	                              Hosts without AppContainer-profile or
+//	                              WFP-engine access fail closed with
 //	                              errdefs.NotAvailable.
 //	Write == WriteReadOnly        enforced when the runner is built
 //	                              with WithWriteConfinement: the child

--- a/core/sandbox/windows/netisolation_windows.go
+++ b/core/sandbox/windows/netisolation_windows.go
@@ -187,13 +187,18 @@ func (n *netIsolation) setupDenyAll() error {
 // port and pins the container's network to it with WFP filters: only
 // TCP to 127.0.0.1 / ::1 on the proxy port is permitted at the
 // ALE_AUTH_CONNECT layer for this package SID, and an explicit block
-// filter covers every other connect. Because the AppIsolation default
-// does not cover UDP/ICMP, the bind layer (ALE_RESOURCE_ASSIGNMENT)
-// permits only TCP binds and blocks every other socket type, so no
-// UDP or raw datagram can leave the container at all. All filters live
-// in the maximum-weight sublayer and are evaluated before AppIsolation,
-// keeping the proxy reachable. The proxy applies the allow-list /
-// upstream decisions.
+// filter covers every other connect. The same TCP-to-proxy-port
+// permit is repeated at ALE_AUTH_RECV_ACCEPT with an IsLoopback
+// condition: the built-in AppContainerLoopback block lives in that
+// layer, so a connect-layer permit alone would authorize the connect
+// and then let the loopback block silently drop the proxy connection.
+// Because the AppIsolation default does not cover UDP/ICMP, the bind
+// layer (ALE_RESOURCE_ASSIGNMENT) permits only TCP binds and blocks
+// every other socket type, so no UDP or raw datagram can leave the
+// container at all. All filters live in the maximum-weight sublayer,
+// evaluated before AppIsolation and Defender, and every permit is hard
+// (CLEAR_ACTION_RIGHT) so the built-in blocks cannot override it. The
+// proxy applies the allow-list / upstream decisions.
 func (n *netIsolation) setupProxy() error {
 	proxy, err := corenet.Start(corenet.ProxyConfig{
 		Mode:        n.policy.Mode,
@@ -249,6 +254,27 @@ func (n *netIsolation) setupProxy() error {
 		}
 		if err := w.wfpAddFilter(layer, "flowcraft block sandbox egress",
 			wfpActionBlock, 0xfffffffe, 0, block); err != nil {
+			w.Close()
+			_ = proxy.Close()
+			return err
+		}
+	}
+
+	// Loopback into the proxy must also be permitted at the
+	// AUTH_RECV_ACCEPT layers, where the built-in AppContainerLoopback
+	// filter blocks AppContainer loopback (and, per Project Zero's
+	// analysis, makes blocked loopback connects time out rather than
+	// fail fast). Scope the exemption to the proxy remote port so the
+	// sandbox still cannot reach arbitrary host loopback services.
+	for _, layer := range []xwin.GUID{fwpmLayerAleAuthRecvAcceptV4, fwpmLayerAleAuthRecvAcceptV6} {
+		if err := w.wfpAddFilter(layer, "flowcraft permit loopback proxy",
+			wfpActionPermit, 0xffffffff, wfpFilterFlagClearActionRight,
+			[]wfpCondition{
+				sidCondition(n.sid),
+				loopbackCondition(),
+				portCondition(uint16(port)),
+				tcpProtocolCondition(),
+			}); err != nil {
 			w.Close()
 			_ = proxy.Close()
 			return err

--- a/core/sandbox/windows/netisolation_windows.go
+++ b/core/sandbox/windows/netisolation_windows.go
@@ -187,11 +187,13 @@ func (n *netIsolation) setupDenyAll() error {
 // port and pins the container's network to it with WFP filters: only
 // TCP to 127.0.0.1 / ::1 on the proxy port is permitted at the
 // ALE_AUTH_CONNECT layer for this package SID, and an explicit block
-// filter covers every other connect. The same TCP-to-proxy-port
-// permit is repeated at ALE_AUTH_RECV_ACCEPT with an IsLoopback
-// condition: the built-in AppContainerLoopback block lives in that
-// layer, so a connect-layer permit alone would authorize the connect
-// and then let the loopback block silently drop the proxy connection.
+// filter covers every other connect. The proxy-port permit is
+// repeated at ALE_AUTH_RECV_ACCEPT with IsLoopback conditions on both
+// endpoints: the built-in AppContainerLoopback block lives in that
+// layer and matches both the AppContainer client and the host
+// listener, so a connect-layer permit alone would authorize the
+// connect and then let the loopback block silently drop the proxy
+// connection on either side.
 // Because the AppIsolation default does not cover UDP/ICMP, the bind
 // layer (ALE_RESOURCE_ASSIGNMENT) permits only TCP binds and blocks
 // every other socket type, so no UDP or raw datagram can leave the
@@ -264,15 +266,31 @@ func (n *netIsolation) setupProxy() error {
 	// AUTH_RECV_ACCEPT layers, where the built-in AppContainerLoopback
 	// filter blocks AppContainer loopback (and, per Project Zero's
 	// analysis, makes blocked loopback connects time out rather than
-	// fail fast). Scope the exemption to the proxy remote port so the
-	// sandbox still cannot reach arbitrary host loopback services.
+	// fail fast). The block's user-ID condition matches both the
+	// AppContainer client and the host listener, so two permits are
+	// needed: one scoped to the sandbox SID on the client side (remote
+	// port == proxy), and one on the host listener side (local port ==
+	// proxy, no SID condition because the listener runs as the host
+	// user). Both are still pinned to the loopback proxy TCP port, so
+	// the sandbox cannot reach arbitrary host loopback services.
 	for _, layer := range []xwin.GUID{fwpmLayerAleAuthRecvAcceptV4, fwpmLayerAleAuthRecvAcceptV6} {
-		if err := w.wfpAddFilter(layer, "flowcraft permit loopback proxy",
+		if err := w.wfpAddFilter(layer, "flowcraft permit loopback proxy (client)",
 			wfpActionPermit, 0xffffffff, wfpFilterFlagClearActionRight,
 			[]wfpCondition{
 				sidCondition(n.sid),
 				loopbackCondition(),
 				portCondition(uint16(port)),
+				tcpProtocolCondition(),
+			}); err != nil {
+			w.Close()
+			_ = proxy.Close()
+			return err
+		}
+		if err := w.wfpAddFilter(layer, "flowcraft permit loopback proxy (host)",
+			wfpActionPermit, 0xffffffff, wfpFilterFlagClearActionRight,
+			[]wfpCondition{
+				loopbackCondition(),
+				localPortCondition(uint16(port)),
 				tcpProtocolCondition(),
 			}); err != nil {
 			w.Close()

--- a/core/sandbox/windows/netisolation_windows.go
+++ b/core/sandbox/windows/netisolation_windows.go
@@ -174,7 +174,7 @@ func (n *netIsolation) setupDenyAll() error {
 		fwpmLayerAleResourceAssignmentV4, fwpmLayerAleResourceAssignmentV6,
 	} {
 		if err := w.wfpAddFilter(layer, "flowcraft block sandbox socket bind",
-			wfpActionBlock, 0xffffffff, block); err != nil {
+			wfpActionBlock, 0xffffffff, 0, block); err != nil {
 			w.Close()
 			return err
 		}
@@ -238,14 +238,17 @@ func (n *netIsolation) setupProxy() error {
 		if layer == fwpmLayerAleAuthConnectV6 {
 			conds = permitV6
 		}
+		// The proxy-port permit must survive the AppIsolation default
+		// deny: a soft permit loses to the built-in block regardless of
+		// sublayer order, so this one is made hard (CLEAR_ACTION_RIGHT).
 		if err := w.wfpAddFilter(layer, "flowcraft permit enforcement proxy",
-			wfpActionPermit, 0xffffffff, conds); err != nil {
+			wfpActionPermit, 0xffffffff, wfpFilterFlagClearActionRight, conds); err != nil {
 			w.Close()
 			_ = proxy.Close()
 			return err
 		}
 		if err := w.wfpAddFilter(layer, "flowcraft block sandbox egress",
-			wfpActionBlock, 0xfffffffe, block); err != nil {
+			wfpActionBlock, 0xfffffffe, 0, block); err != nil {
 			w.Close()
 			_ = proxy.Close()
 			return err
@@ -258,13 +261,13 @@ func (n *netIsolation) setupProxy() error {
 		fwpmLayerAleResourceAssignmentV4, fwpmLayerAleResourceAssignmentV6,
 	} {
 		if err := w.wfpAddFilter(layer, "flowcraft permit tcp bind",
-			wfpActionPermit, 0xffffffff, bindPermit); err != nil {
+			wfpActionPermit, 0xffffffff, 0, bindPermit); err != nil {
 			w.Close()
 			_ = proxy.Close()
 			return err
 		}
 		if err := w.wfpAddFilter(layer, "flowcraft block non-tcp bind",
-			wfpActionBlock, 0xfffffffe, bindBlock); err != nil {
+			wfpActionBlock, 0xfffffffe, 0, bindBlock); err != nil {
 			w.Close()
 			_ = proxy.Close()
 			return err

--- a/core/sandbox/windows/netisolation_windows.go
+++ b/core/sandbox/windows/netisolation_windows.go
@@ -120,6 +120,12 @@ func newNetIsolation(root string, writable []string, policy corenet.NetPolicy) (
 		_ = iso.Close()
 		return nil, err
 	}
+	// Behavioral WFP check before the isolation is handed out: filter
+	// install success alone does not prove the fence is effective.
+	if err := iso.verifyFence(); err != nil {
+		_ = iso.Close()
+		return nil, err
+	}
 	return iso, nil
 }
 
@@ -317,11 +323,16 @@ func (n *netIsolation) env(env []string) []string {
 		"TMPDIR":       filepath.Join(n.home, "Temp"),
 	}
 	if n.proxyPort > 0 {
-		proxy := fmt.Sprintf("http://127.0.0.1:%d", n.proxyPort)
-		for _, k := range []string{
-			"HTTP_PROXY", "http_proxy", "HTTPS_PROXY", "https_proxy", "ALL_PROXY", "all_proxy",
-		} {
-			repl[k] = proxy
+		httpProxy := fmt.Sprintf("http://127.0.0.1:%d", n.proxyPort)
+		socksProxy := fmt.Sprintf("socks5://127.0.0.1:%d", n.proxyPort)
+		for _, k := range []string{"HTTP_PROXY", "http_proxy", "HTTPS_PROXY", "https_proxy"} {
+			repl[k] = httpProxy
+		}
+		// ALL_PROXY speaks SOCKS5 on the same loopback port; the WFP
+		// permit covers TCP to that port regardless of protocol, so
+		// SOCKS5-aware non-HTTP clients stay inside the fence too.
+		for _, k := range []string{"ALL_PROXY", "all_proxy"} {
+			repl[k] = socksProxy
 		}
 		repl["NO_PROXY"] = ""
 		repl["no_proxy"] = ""

--- a/core/sandbox/windows/netpolicy_windows_test.go
+++ b/core/sandbox/windows/netpolicy_windows_test.go
@@ -247,3 +247,31 @@ func TestNetIsolationEnvRedirect(t *testing.T) {
 		}
 	}
 }
+
+// TestNetIsolationProxyEnvSplit verifies allow-list / proxy modes
+// inject HTTP_PROXY (http://) and ALL_PROXY (socks5://) to the same
+// loopback port, so HTTP and SOCKS5-aware clients share one fence.
+func TestNetIsolationProxyEnvSplit(t *testing.T) {
+	iso := &netIsolation{home: `C:\ac-home`, proxyPort: 45678}
+	env := iso.env([]string{"PATH=C:\\bin"})
+	got := map[string]string{}
+	for _, kv := range env {
+		k, v, ok := strings.Cut(kv, "=")
+		if !ok {
+			t.Fatalf("bad env entry %q", kv)
+		}
+		got[k] = v
+	}
+	if got["HTTP_PROXY"] != "http://127.0.0.1:45678" {
+		t.Errorf("HTTP_PROXY = %q, want http://127.0.0.1:45678", got["HTTP_PROXY"])
+	}
+	if got["HTTPS_PROXY"] != "http://127.0.0.1:45678" {
+		t.Errorf("HTTPS_PROXY = %q, want http://127.0.0.1:45678", got["HTTPS_PROXY"])
+	}
+	if got["ALL_PROXY"] != "socks5://127.0.0.1:45678" {
+		t.Errorf("ALL_PROXY = %q, want socks5://127.0.0.1:45678", got["ALL_PROXY"])
+	}
+	if got["NO_PROXY"] != "" {
+		t.Errorf("NO_PROXY = %q, want empty", got["NO_PROXY"])
+	}
+}

--- a/core/sandbox/windows/verify_windows.go
+++ b/core/sandbox/windows/verify_windows.go
@@ -99,7 +99,9 @@ func (n *netIsolation) verifyFence() error {
 	case <-ctx.Done():
 		_ = cmd.Process.Kill()
 		<-done
-		return errdefs.Internal(fmt.Errorf("windows: fence probe timed out"))
+		return errdefs.Internal(fmt.Errorf(
+			"windows: fence probe timed out (partial output %q, want %q)",
+			strings.TrimSpace(out.String()), want))
 	case err := <-done:
 		if err != nil {
 			// A probe that cannot run must not be treated as a pass.

--- a/core/sandbox/windows/verify_windows.go
+++ b/core/sandbox/windows/verify_windows.go
@@ -1,0 +1,116 @@
+//go:build windows
+
+package windows
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"fmt"
+	"net"
+	"os"
+	"os/exec"
+	"strings"
+	"syscall"
+	"time"
+	"unicode/utf16"
+
+	"github.com/GizClaw/flowcraft/core/errdefs"
+
+	xwin "golang.org/x/sys/windows"
+)
+
+// verifyFenceTimeout bounds one behavioral probe (two TCP dials under
+// the AppContainer token). PowerShell startup dominates the cost.
+const verifyFenceTimeout = 15 * time.Second
+
+// verifyFence behaviorally confirms the WFP fence is effective after
+// filter installation. BFE enumeration is restricted to administrators,
+// and even an elevated add-filter call does not prove the kernel
+// evaluates the filter with the intended precedence, so the probe runs
+// real connections under the container token:
+//
+//   - a dial to a host-side loopback listener that is NOT the proxy
+//     port must be blocked (catches a missing or mis-ordered egress
+//     block, or an over-broad loopback exemption);
+//   - in allow-list / proxy modes a dial to the enforcement proxy port
+//     must succeed (without a working permit, the AppIsolation default
+//     deny would make the sandbox unusable and the failure would only
+//     surface later, inside the sandboxed command).
+//
+// A mismatch fails closed: the isolation is never handed to a caller
+// whose fence cannot be trusted. This mirrors srt-win's `wfp verify`
+// (the sandbox-runtime Windows helper) rather than trusting filter
+// install success alone.
+func (n *netIsolation) verifyFence() error {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		return errdefs.Internal(fmt.Errorf("windows: fence probe listener: %w", err))
+	}
+	defer func() { _ = ln.Close() }()
+	probePort := ln.Addr().(*net.TCPAddr).Port
+
+	// PowerShell is the only guaranteed dial-capable builtin on
+	// Windows; the net-policy integration tests already rely on it
+	// under the same AppContainer token.
+	want := "blocked"
+	script := fmt.Sprintf(
+		"$r=@(); foreach($p in @(%d)){ try{ $c=New-Object Net.Sockets.TcpClient; $c.Connect('127.0.0.1',$p); $c.Close(); $r+='ok' } catch { $r+='blocked' } }; [string]::Join(',',$r)",
+		probePort)
+	if n.proxyPort > 0 {
+		want = "blocked,ok"
+		script = fmt.Sprintf(
+			"$r=@(); foreach($p in @(%d,%d)){ try{ $c=New-Object Net.Sockets.TcpClient; $c.Connect('127.0.0.1',$p); $c.Close(); $r+='ok' } catch { $r+='blocked' } }; [string]::Join(',',$r)",
+			probePort, n.proxyPort)
+	}
+
+	cmd := exec.Command("powershell",
+		"-NoProfile", "-NonInteractive", "-EncodedCommand", encodeCommand(script))
+	cmd.SysProcAttr = &xwin.SysProcAttr{
+		CreationFlags: xwin.CREATE_NO_WINDOW,
+		Token:         syscall.Token(n.token),
+	}
+	cmd.Env = n.env(os.Environ())
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := enableCreateProcessAsUserPrivileges(); err != nil {
+		return err
+	}
+	if err := cmd.Start(); err != nil {
+		return errdefs.Internal(fmt.Errorf("windows: fence probe start: %w", err))
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), verifyFenceTimeout)
+	defer cancel()
+	done := make(chan error, 1)
+	go func() { done <- cmd.Wait() }()
+	select {
+	case <-ctx.Done():
+		_ = cmd.Process.Kill()
+		<-done
+		return errdefs.Internal(fmt.Errorf("windows: fence probe timed out"))
+	case err := <-done:
+		if err != nil {
+			// A probe that cannot run must not be treated as a pass.
+			return errdefs.Internal(fmt.Errorf("windows: fence probe exit: %w", err))
+		}
+	}
+	got := strings.TrimSpace(out.String())
+	if got != want {
+		return errdefs.Internal(fmt.Errorf(
+			"windows: WFP fence verify failed: got %q, want %q", got, want))
+	}
+	return nil
+}
+
+// encodeCommand wraps a PowerShell script in an -EncodedCommand blob
+// (UTF-16LE base64), avoiding argument-quoting fragility entirely.
+func encodeCommand(script string) string {
+	u := utf16.Encode([]rune(script))
+	b := make([]byte, len(u)*2)
+	for i, v := range u {
+		b[i*2] = byte(v)
+		b[i*2+1] = byte(v >> 8)
+	}
+	return base64.StdEncoding.EncodeToString(b)
+}

--- a/core/sandbox/windows/verify_windows.go
+++ b/core/sandbox/windows/verify_windows.go
@@ -34,6 +34,9 @@ const verifyFenceTimeout = 15 * time.Second
 //   - a dial to a host-side loopback listener that is NOT the proxy
 //     port must be blocked (catches a missing or mis-ordered egress
 //     block, or an over-broad loopback exemption);
+//   - an unconnected UDP send must be blocked: the AppIsolation default
+//     does not constrain unconnected UDP, so a passing send proves the
+//     bind-layer (ALE_RESOURCE_ASSIGNMENT) block is actually installed;
 //   - in allow-list / proxy modes a dial to the enforcement proxy port
 //     must succeed (without a working permit, the AppIsolation default
 //     deny would make the sandbox unusable and the failure would only
@@ -54,15 +57,22 @@ func (n *netIsolation) verifyFence() error {
 	// PowerShell is the only guaranteed dial-capable builtin on
 	// Windows; the net-policy integration tests already rely on it
 	// under the same AppContainer token.
-	want := "blocked"
+	want := "blocked,blocked"
 	script := fmt.Sprintf(
-		"$ProgressPreference='SilentlyContinue'; $r=@(); foreach($p in @(%d)){ try{ $c=New-Object Net.Sockets.TcpClient; $c.Connect('127.0.0.1',$p); $c.Close(); $r+='ok' } catch { $r+='blocked' } }; [string]::Join(',',$r)",
-		probePort)
+		"$ProgressPreference='SilentlyContinue'; $r=@(); "+
+			"try{ $c=New-Object Net.Sockets.TcpClient; $c.Connect('127.0.0.1',%d); $c.Close(); $r+='ok' } catch { $r+='blocked' }; "+
+			"try{ $u=New-Object Net.Sockets.UdpClient; $null=$u.Send([byte[]](0),1,'127.0.0.1',%d); $u.Close(); $r+='ok' } catch { $r+='blocked' }; "+
+			"[string]::Join(',',$r)",
+		probePort, probePort)
 	if n.proxyPort > 0 {
-		want = "blocked,ok"
+		want = "blocked,blocked,ok"
 		script = fmt.Sprintf(
-			"$ProgressPreference='SilentlyContinue'; $r=@(); foreach($p in @(%d,%d)){ try{ $c=New-Object Net.Sockets.TcpClient; $c.Connect('127.0.0.1',$p); $c.Close(); $r+='ok' } catch { $r+='blocked' } }; [string]::Join(',',$r)",
-			probePort, n.proxyPort)
+			"$ProgressPreference='SilentlyContinue'; $r=@(); "+
+				"try{ $c=New-Object Net.Sockets.TcpClient; $c.Connect('127.0.0.1',%d); $c.Close(); $r+='ok' } catch { $r+='blocked' }; "+
+				"try{ $u=New-Object Net.Sockets.UdpClient; $null=$u.Send([byte[]](0),1,'127.0.0.1',%d); $u.Close(); $r+='ok' } catch { $r+='blocked' }; "+
+				"try{ $c=New-Object Net.Sockets.TcpClient; $c.Connect('127.0.0.1',%d); $c.Close(); $r+='ok' } catch { $r+='blocked' }; "+
+				"[string]::Join(',',$r)",
+			probePort, probePort, n.proxyPort)
 	}
 
 	cmd := exec.Command("powershell",
@@ -115,8 +125,9 @@ func (n *netIsolation) verifyFence() error {
 }
 
 // probeResultRE matches the single machine-readable probe result line
-// ("blocked" or "blocked,ok"), ignoring PowerShell CLIXML noise.
-var probeResultRE = regexp.MustCompile(`(?m)^(blocked(?:,ok)?)[\r\n]*$`)
+// ("blocked,blocked" or "blocked,blocked,ok"), ignoring PowerShell
+// CLIXML noise.
+var probeResultRE = regexp.MustCompile(`(?m)^(blocked(?:,blocked)?(?:,ok)?)[\r\n]*$`)
 
 // encodeCommand wraps a PowerShell script in an -EncodedCommand blob
 // (UTF-16LE base64), avoiding argument-quoting fragility entirely.

--- a/core/sandbox/windows/verify_windows.go
+++ b/core/sandbox/windows/verify_windows.go
@@ -10,6 +10,7 @@ import (
 	"net"
 	"os"
 	"os/exec"
+	"regexp"
 	"strings"
 	"syscall"
 	"time"
@@ -55,12 +56,12 @@ func (n *netIsolation) verifyFence() error {
 	// under the same AppContainer token.
 	want := "blocked"
 	script := fmt.Sprintf(
-		"$r=@(); foreach($p in @(%d)){ try{ $c=New-Object Net.Sockets.TcpClient; $c.Connect('127.0.0.1',$p); $c.Close(); $r+='ok' } catch { $r+='blocked' } }; [string]::Join(',',$r)",
+		"$ProgressPreference='SilentlyContinue'; $r=@(); foreach($p in @(%d)){ try{ $c=New-Object Net.Sockets.TcpClient; $c.Connect('127.0.0.1',$p); $c.Close(); $r+='ok' } catch { $r+='blocked' } }; [string]::Join(',',$r)",
 		probePort)
 	if n.proxyPort > 0 {
 		want = "blocked,ok"
 		script = fmt.Sprintf(
-			"$r=@(); foreach($p in @(%d,%d)){ try{ $c=New-Object Net.Sockets.TcpClient; $c.Connect('127.0.0.1',$p); $c.Close(); $r+='ok' } catch { $r+='blocked' } }; [string]::Join(',',$r)",
+			"$ProgressPreference='SilentlyContinue'; $r=@(); foreach($p in @(%d,%d)){ try{ $c=New-Object Net.Sockets.TcpClient; $c.Connect('127.0.0.1',$p); $c.Close(); $r+='ok' } catch { $r+='blocked' } }; [string]::Join(',',$r)",
 			probePort, n.proxyPort)
 	}
 
@@ -95,13 +96,27 @@ func (n *netIsolation) verifyFence() error {
 			return errdefs.Internal(fmt.Errorf("windows: fence probe exit: %w", err))
 		}
 	}
-	got := strings.TrimSpace(out.String())
+	// PowerShell may interleave progress records (serialized as
+	// CLIXML) with the probe result even with $ProgressPreference
+	// silenced, so match the machine-readable line instead of the
+	// whole buffer.
+	m := probeResultRE.FindStringSubmatch(out.String())
+	if m == nil {
+		return errdefs.Internal(fmt.Errorf(
+			"windows: WFP fence verify failed: unexpected probe output %q, want %q",
+			strings.TrimSpace(out.String()), want))
+	}
+	got := m[1]
 	if got != want {
 		return errdefs.Internal(fmt.Errorf(
 			"windows: WFP fence verify failed: got %q, want %q", got, want))
 	}
 	return nil
 }
+
+// probeResultRE matches the single machine-readable probe result line
+// ("blocked" or "blocked,ok"), ignoring PowerShell CLIXML noise.
+var probeResultRE = regexp.MustCompile(`(?m)^(blocked(?:,ok)?)[\r\n]*$`)
 
 // encodeCommand wraps a PowerShell script in an -EncodedCommand blob
 // (UTF-16LE base64), avoiding argument-quoting fragility entirely.

--- a/core/sandbox/windows/wfp_windows.go
+++ b/core/sandbox/windows/wfp_windows.go
@@ -25,6 +25,7 @@ const (
 	wfpDataTypeUint64     wfpDataType = 4
 	wfpDataTypeUint8      wfpDataType = 1
 	wfpDataTypeUint16     wfpDataType = 2
+	wfpDataTypeUint32     wfpDataType = 3
 	wfpDataTypeSID        wfpDataType = 13
 	wfpDataTypeV4AddrMask wfpDataType = 256
 	wfpDataTypeV6AddrMask wfpDataType = 257
@@ -33,7 +34,17 @@ const (
 // wfpMatchType is FWP_MATCH_TYPE.
 type wfpMatchType uint32
 
-const wfpMatchEqual wfpMatchType = 0
+const (
+	wfpMatchEqual        wfpMatchType = 0
+	wfpMatchFlagsAllSet  wfpMatchType = 6
+	wfpMatchFlagsAnySet  wfpMatchType = 7
+	wfpMatchFlagsNoneSet wfpMatchType = 8
+)
+
+// wfpConditionFlag is FWP_CONDITION_FLAG_*; only IS_LOOPBACK is needed.
+type wfpConditionFlag uint32
+
+const wfpConditionFlagIsLoopback wfpConditionFlag = 0x00000001
 
 // wfpActionType is FWPM_ACTION_TYPE.
 type wfpActionType uint32
@@ -146,6 +157,14 @@ var (
 		Data1: 0x4a72393b, Data2: 0x319f, Data3: 0x44bc,
 		Data4: [8]byte{0x84, 0xc3, 0xba, 0x54, 0xdc, 0xb3, 0xb6, 0xb4},
 	}
+	fwpmLayerAleAuthRecvAcceptV4 = xwin.GUID{
+		Data1: 0xe1cd9fe7, Data2: 0xf4b5, Data3: 0x4273,
+		Data4: [8]byte{0x96, 0xc0, 0x59, 0x2e, 0x48, 0x7b, 0x86, 0x50},
+	}
+	fwpmLayerAleAuthRecvAcceptV6 = xwin.GUID{
+		Data1: 0xa3b42c97, Data2: 0x9f04, Data3: 0x4672,
+		Data4: [8]byte{0xb8, 0x7e, 0xce, 0xe9, 0xc4, 0x83, 0x25, 0x7f},
+	}
 	fwpmLayerAleResourceAssignmentV4 = xwin.GUID{
 		Data1: 0x1247d66d, Data2: 0x0b60, Data3: 0x4a15,
 		Data4: [8]byte{0x8d, 0x44, 0x71, 0x55, 0xd0, 0xf5, 0x3a, 0x0c},
@@ -169,6 +188,10 @@ var (
 	fwpmConditionIPProtocol = xwin.GUID{
 		Data1: 0x3971ef2b, Data2: 0x623e, Data3: 0x4f9a,
 		Data4: [8]byte{0x8c, 0xb1, 0x6e, 0x79, 0xb8, 0x06, 0xb9, 0xa7},
+	}
+	fwpmConditionFlags = xwin.GUID{
+		Data1: 0x632ce23b, Data2: 0x5167, Data3: 0x435c,
+		Data4: [8]byte{0x86, 0xd7, 0xe9, 0x03, 0x68, 0x4a, 0xa8, 0x0c},
 	}
 )
 
@@ -233,7 +256,9 @@ func wfpAddSublayer(engine xwin.Handle, key xwin.GUID) error {
 		// the built-in MPSSVC_APP_ISOLATION sublayer, whose AppContainer
 		// default deny for a capability-less container would otherwise
 		// block the loopback enforcement proxy too. A soft permit in
-		// our sublayer still loses to that AppIsolation block, so the
+		// our sublayer still loses to a lower-priority Block — the
+		// AppIsolation default deny at AUTH_CONNECT, and the built-in
+		// AppContainerLoopback Block at AUTH_RECV_ACCEPT — so every
 		// proxy-port permit is added with CLEAR_ACTION_RIGHT to make it
 		// a hard permit that terminates classification; everything else
 		// falls through to the AppIsolation default deny (bind-layer
@@ -256,6 +281,7 @@ func wfpDeleteSublayer(engine xwin.Handle, key xwin.GUID) {
 // wfpCondition builds one filter condition value.
 type wfpCondition struct {
 	field xwin.GUID
+	match wfpMatchType
 	value wfpConditionValue
 }
 
@@ -298,6 +324,17 @@ func tcpProtocolCondition() wfpCondition {
 	}
 }
 
+// loopbackCondition matches the FWP_CONDITION_FLAGS IsLoopback flag,
+// which the built-in AppContainerLoopback filters use to scope their
+// loopback block at the AUTH_RECV_ACCEPT layers.
+func loopbackCondition() wfpCondition {
+	return wfpCondition{
+		field: fwpmConditionFlags,
+		match: wfpMatchFlagsAllSet,
+		value: wfpConditionValue{Type: wfpDataTypeUint32, Value: uintptr(wfpConditionFlagIsLoopback)},
+	}
+}
+
 // wfpAddFilter adds one filter to the session's sublayer and records
 // its ID for cleanup. flags are FWPM_FILTER_FLAG_* values; pass
 // wfpFilterFlagClearActionRight to make a permit hard (see the const
@@ -309,7 +346,7 @@ func (w *wfpIsolation) wfpAddFilter(layer xwin.GUID, name string, action wfpActi
 	for i, c := range conds {
 		cconds[i] = wfpFilterCondition{
 			FieldKey:  c.field,
-			MatchType: wfpMatchEqual,
+			MatchType: c.match,
 			Value:     c.value,
 		}
 	}

--- a/core/sandbox/windows/wfp_windows.go
+++ b/core/sandbox/windows/wfp_windows.go
@@ -185,6 +185,10 @@ var (
 		Data1: 0xc35a604d, Data2: 0xd22b, Data3: 0x4e1a,
 		Data4: [8]byte{0x91, 0xb4, 0x68, 0xf6, 0x74, 0xee, 0x67, 0x4b},
 	}
+	fwpmConditionIPLocalPort = xwin.GUID{
+		Data1: 0x0c1ba1af, Data2: 0x5765, Data3: 0x453f,
+		Data4: [8]byte{0xaf, 0x22, 0xa8, 0xf7, 0x91, 0xac, 0x77, 0x5b},
+	}
 	fwpmConditionIPProtocol = xwin.GUID{
 		Data1: 0x3971ef2b, Data2: 0x623e, Data3: 0x4f9a,
 		Data4: [8]byte{0x8c, 0xb1, 0x6e, 0x79, 0xb8, 0x06, 0xb9, 0xa7},
@@ -313,6 +317,13 @@ func v6LoopbackCondition() wfpCondition {
 func portCondition(port uint16) wfpCondition {
 	return wfpCondition{
 		field: fwpmConditionIPRemotePort,
+		value: wfpConditionValue{Type: wfpDataTypeUint16, Value: uintptr(port)},
+	}
+}
+
+func localPortCondition(port uint16) wfpCondition {
+	return wfpCondition{
+		field: fwpmConditionIPLocalPort,
 		value: wfpConditionValue{Type: wfpDataTypeUint16, Value: uintptr(port)},
 	}
 }

--- a/core/sandbox/windows/wfp_windows.go
+++ b/core/sandbox/windows/wfp_windows.go
@@ -43,6 +43,14 @@ const (
 	wfpActionPermit wfpActionType = 0x1002
 )
 
+// wfpFilterFlagClearActionRight is FWPM_FILTER_FLAG_CLEAR_ACTION_RIGHT:
+// the filter's action becomes "hard". A hard permit cannot be vetoed by
+// a lower-priority sublayer's Block filter (only by a callout Veto),
+// which is exactly what the proxy-port permit needs to survive the
+// AppIsolation default-deny — a plain permit would be soft and the
+// AppIsolation block would win regardless of sublayer order.
+const wfpFilterFlagClearActionRight = 0x8
+
 // The engine copies each filter before returning, so ordinary heap
 // structs are fine; no notinheap annotation is required.
 type wfpDisplayData struct {
@@ -224,11 +232,12 @@ func wfpAddSublayer(engine xwin.Handle, key xwin.GUID) error {
 		// Maximum UINT16 weight: the sublayer must be evaluated before
 		// the built-in MPSSVC_APP_ISOLATION sublayer, whose AppContainer
 		// default deny for a capability-less container would otherwise
-		// block the loopback enforcement proxy too. Evaluating our
-		// sublayer first lets the proxy-port permit terminate
-		// classification, while everything else falls through to the
-		// AppIsolation default deny (bind-layer filters cover the
-		// UDP/ICMP flows that default misses).
+		// block the loopback enforcement proxy too. A soft permit in
+		// our sublayer still loses to that AppIsolation block, so the
+		// proxy-port permit is added with CLEAR_ACTION_RIGHT to make it
+		// a hard permit that terminates classification; everything else
+		// falls through to the AppIsolation default deny (bind-layer
+		// filters cover the UDP/ICMP flows that default misses).
 		Weight: 0xffff,
 	}
 	r1, _, e1 := procFwpmSubLayerAdd0.Call(
@@ -289,10 +298,12 @@ func tcpProtocolCondition() wfpCondition {
 	}
 }
 
-// wfpAddFilter adds one filter to the session's sublayer at
-// ALE_AUTH_CONNECT and records its ID for cleanup.
+// wfpAddFilter adds one filter to the session's sublayer and records
+// its ID for cleanup. flags are FWPM_FILTER_FLAG_* values; pass
+// wfpFilterFlagClearActionRight to make a permit hard (see the const
+// doc).
 func (w *wfpIsolation) wfpAddFilter(layer xwin.GUID, name string, action wfpActionType,
-	weight uint64, conds []wfpCondition) error {
+	weight uint64, flags uint32, conds []wfpCondition) error {
 	namePtr, _ := xwin.UTF16PtrFromString(name)
 	cconds := make([]wfpFilterCondition, len(conds))
 	for i, c := range conds {
@@ -312,6 +323,7 @@ func (w *wfpIsolation) wfpAddFilter(layer xwin.GUID, name string, action wfpActi
 	}
 	filter := &wfpFilter{
 		DisplayData:         wfpDisplayData{Name: namePtr},
+		Flags:               flags,
 		LayerKey:            layer,
 		SublayerKey:         w.sublayer,
 		Weight:              wfpValue{Type: wfpDataTypeUint64, Value: uintptr(unsafe.Pointer(&weightValue))},

--- a/core/sandbox/windows/wfp_windows_test.go
+++ b/core/sandbox/windows/wfp_windows_test.go
@@ -53,4 +53,17 @@ func TestWFPConditionConstruction(t *testing.T) {
 	if tp.value.Type != wfpDataTypeUint8 || tp.value.Value != 6 {
 		t.Fatalf("protocol condition = %+v", tp)
 	}
+
+	// The loopback condition must ask for the IsLoopback flag with
+	// FWP_MATCH_FLAGS_ALL_SET on the FLAGS field.
+	lb := loopbackCondition()
+	if lb.field != fwpmConditionFlags {
+		t.Fatalf("loopback condition field = %v, want FLAGS", lb.field)
+	}
+	if lb.match != wfpMatchFlagsAllSet {
+		t.Fatalf("loopback condition match = %v, want FWP_MATCH_FLAGS_ALL_SET", lb.match)
+	}
+	if lb.value.Type != wfpDataTypeUint32 || lb.value.Value != uintptr(wfpConditionFlagIsLoopback) {
+		t.Fatalf("loopback condition = %+v", lb)
+	}
 }

--- a/core/sandbox/windows/wfp_windows_test.go
+++ b/core/sandbox/windows/wfp_windows_test.go
@@ -49,6 +49,10 @@ func TestWFPConditionConstruction(t *testing.T) {
 	if p.value.Type != wfpDataTypeUint16 || p.value.Value != 8080 {
 		t.Fatalf("port condition = %+v", p)
 	}
+	lp := localPortCondition(8080)
+	if lp.field != fwpmConditionIPLocalPort || lp.value.Type != wfpDataTypeUint16 || lp.value.Value != 8080 {
+		t.Fatalf("local port condition = %+v", lp)
+	}
 	tp := tcpProtocolCondition()
 	if tp.value.Type != wfpDataTypeUint8 || tp.value.Value != 6 {
 		t.Fatalf("protocol condition = %+v", tp)

--- a/core/utils/net/doc.go
+++ b/core/utils/net/doc.go
@@ -7,8 +7,15 @@
 //     types that describe a sandbox's outbound-network posture;
 //   - host-pattern compilation and matching (hostmatch plus the
 //     higher-level Matcher over NetRule);
-//   - the host-side enforcement Proxy used by bwrap and seatbelt for
-//     allow-list and proxy modes;
+//   - the host-side enforcement Proxy used by the bwrap, seatbelt, and
+//     windows backends for allow-list and proxy modes. One listener
+//     multiplexes HTTP (plain requests and CONNECT) with SOCKS5
+//     (CONNECT only, no auth), so HTTP clients and SOCKS5-aware
+//     non-HTTP clients (ssh ProxyCommand, curl --socks5-hostname, tools
+//     honoring ALL_PROXY=socks5://...) all traverse the same allow-list
+//     / upstream policy;
+//   - model-facing deny reasons on rules (NetRule.Reason), surfaced in
+//     HTTP denial bodies and audit records;
 //   - the MITM seam interfaces consumed by the proxy, with the
 //     implementation living in the mitm subpackage.
 //

--- a/core/utils/net/matcher.go
+++ b/core/utils/net/matcher.go
@@ -2,7 +2,9 @@ package net
 
 import (
 	"fmt"
+	"net"
 	"net/netip"
+	"strconv"
 	"strings"
 
 	"github.com/GizClaw/flowcraft/core/errdefs"
@@ -18,6 +20,9 @@ import (
 //   - "example.com": the bare domain and every subdomain
 //     (domain-and-descendants, matching the legacy AllowHosts
 //     behaviour).
+//   - "example.com:443" / "[::1]:8443": an optional ":port" suffix
+//     restricts the rule to one destination port; entries without a
+//     suffix match any port (same grammar as srt's allowedDomains).
 //   - "*.example.com": subdomains only, any depth; never the bare
 //     domain.
 //   - "1.2.3.4" / "10.0.0.0/8": IP / CIDR, evaluated by MatchIP
@@ -37,6 +42,7 @@ type compiledRule struct {
 	action NetAction
 	port   int
 	desc   string
+	reason string
 	host   *Pattern
 }
 
@@ -77,8 +83,10 @@ func (m *Matcher) HasIPRules() bool { return m.hasIPRules }
 
 // Match evaluates hostname rules for host:port. It never resolves DNS;
 // callers apply IP/CIDR rules separately via MatchIP. The returned
-// rule string describes the decisive rule ("" when nothing matched).
-func (m *Matcher) Match(host string, port int) (NetAction, string, bool) {
+// rule string describes the decisive rule ("" when nothing matched)
+// and reason is the optional model-facing explanation attached to a
+// deny rule.
+func (m *Matcher) Match(host string, port int) (NetAction, string, string, bool) {
 	host = normalizeHost(host)
 	for _, r := range m.rules {
 		if r.host.IsIP() || !r.host.Match(host) {
@@ -88,7 +96,7 @@ func (m *Matcher) Match(host string, port int) (NetAction, string, bool) {
 			continue
 		}
 		if r.action == NetDeny {
-			return NetDeny, r.desc, true
+			return NetDeny, r.desc, r.reason, true
 		}
 	}
 	for _, r := range m.rules {
@@ -98,13 +106,13 @@ func (m *Matcher) Match(host string, port int) (NetAction, string, bool) {
 		if !portMatches(r.port, port) {
 			continue
 		}
-		return NetAllow, r.desc, true
+		return NetAllow, r.desc, r.reason, true
 	}
-	return NetAllow, "", false
+	return NetAllow, "", "", false
 }
 
 // MatchIP evaluates IP/CIDR rules against one resolved address.
-func (m *Matcher) MatchIP(ip netip.Addr, port int) (NetAction, string, bool) {
+func (m *Matcher) MatchIP(ip netip.Addr, port int) (NetAction, string, string, bool) {
 	for _, r := range m.rules {
 		if !r.host.MatchIP(ip) {
 			continue
@@ -113,7 +121,7 @@ func (m *Matcher) MatchIP(ip netip.Addr, port int) (NetAction, string, bool) {
 			continue
 		}
 		if r.action == NetDeny {
-			return NetDeny, r.desc, true
+			return NetDeny, r.desc, r.reason, true
 		}
 	}
 	for _, r := range m.rules {
@@ -123,23 +131,43 @@ func (m *Matcher) MatchIP(ip netip.Addr, port int) (NetAction, string, bool) {
 		if !portMatches(r.port, port) {
 			continue
 		}
-		return NetAllow, r.desc, true
+		return NetAllow, r.desc, r.reason, true
 	}
-	return NetAllow, "", false
+	return NetAllow, "", "", false
 }
 
 func compileRule(rule NetRule) (compiledRule, error) {
-	c := compiledRule{action: rule.Action, port: rule.Port}
-	pattern, err := Compile(rule.Host)
+	host, port, err := splitRuleHostPort(rule.Host, rule.Port)
+	if err != nil {
+		return compiledRule{}, err
+	}
+	c := compiledRule{action: rule.Action, port: port, reason: rule.Reason}
+	pattern, err := Compile(host)
 	if err != nil {
 		return c, err
 	}
 	c.host = pattern
-	c.desc = fmt.Sprintf("%s %s", c.action, rule.Host)
+	c.desc = fmt.Sprintf("%s %s", c.action, host)
 	if c.port != 0 {
 		c.desc += fmt.Sprintf(":%d", c.port)
 	}
 	return c, nil
+}
+
+// splitRuleHostPort parses an optional ":port" suffix on a rule host
+// ("example.com:443", "[::1]:8443", "10.0.0.0/8:53"). Bare hosts and
+// bare IPv6 literals without brackets fall through unchanged; a
+// malformed numeric port is a validation error. An explicit suffix
+// overrides the rule's Port field.
+func splitRuleHostPort(host string, port int) (string, int, error) {
+	if h, p, err := net.SplitHostPort(host); err == nil {
+		n, err := strconv.Atoi(p)
+		if err != nil || n < 0 || n > 65535 {
+			return "", 0, fmt.Errorf("invalid port suffix %q", host)
+		}
+		return h, n, nil
+	}
+	return host, port, nil
 }
 
 func portMatches(rulePort, port int) bool {

--- a/core/utils/net/matcher_test.go
+++ b/core/utils/net/matcher_test.go
@@ -1,0 +1,78 @@
+package net
+
+import (
+	"net/netip"
+	"testing"
+)
+
+// TestMatcherPortSuffixAndReason covers the srt-style ":port" suffix
+// grammar on both AllowHosts entries and explicit rules, plus
+// model-facing deny reasons.
+func TestMatcherPortSuffixAndReason(t *testing.T) {
+	m, err := NewMatcher(NetPolicy{
+		Mode: NetAllowList,
+		AllowHosts: []string{
+			"example.com:443",
+			"[::1]:8443",
+			"10.0.0.0/8:53",
+			"bare.example.com",
+		},
+		Rules: []NetRule{
+			{Action: NetDeny, Host: "evil.example", Reason: "known malware domain"},
+			{Action: NetDeny, Host: "example.com", Port: 22, Reason: "ssh egress is blocked"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("NewMatcher: %v", err)
+	}
+
+	action, rule, reason, matched := m.Match("example.com", 443)
+	if !matched || action != NetAllow || rule != "allow example.com:443" || reason != "" {
+		t.Fatalf("example.com:443 = (%v, %q, %q, %v)", action, rule, reason, matched)
+	}
+	action, _, reason, matched = m.Match("www.example.com", 443)
+	if !matched || action != NetAllow || reason != "" {
+		t.Fatalf("www.example.com:443 (domain-and-descendants) = (%v, %q, %v)", action, reason, matched)
+	}
+	action, _, _, matched = m.Match("example.com", 80)
+	if matched || action != NetAllow {
+		t.Fatalf("example.com:80 should not match the :443 allow rule (matched=%v)", matched)
+	}
+	action, _, reason, matched = m.Match("example.com", 22)
+	if !matched || action != NetDeny || reason != "ssh egress is blocked" {
+		t.Fatalf("example.com:22 = (%v, %q, %v)", action, reason, matched)
+	}
+	action, _, reason, matched = m.Match("evil.example", 80)
+	if !matched || action != NetDeny || reason != "known malware domain" {
+		t.Fatalf("evil.example:80 = (%v, %q, %v)", action, reason, matched)
+	}
+	action, _, _, matched = m.Match("bare.example.com", 9999)
+	if !matched || action != NetAllow {
+		t.Fatalf("bare.example.com:9999 should match with any port")
+	}
+
+	action, _, _, matched = m.MatchIP(netip.MustParseAddr("10.1.2.3"), 53)
+	if !matched || action != NetAllow {
+		t.Fatalf("10.1.2.3:53 should match the CIDR:port rule")
+	}
+	action, _, _, matched = m.MatchIP(netip.MustParseAddr("10.1.2.3"), 54)
+	if matched {
+		t.Fatalf("10.1.2.3:54 should not match the CIDR:53 rule")
+	}
+	action, _, _, matched = m.MatchIP(netip.MustParseAddr("::1"), 8443)
+	if !matched || action != NetAllow {
+		t.Fatalf("[::1]:8443 should match")
+	}
+}
+
+// TestMatcherAllowHostsPortSuffixValidation rejects malformed numeric
+// ports instead of silently treating them as hostnames.
+func TestMatcherAllowHostsPortSuffixValidation(t *testing.T) {
+	_, err := NewMatcher(NetPolicy{
+		Mode:       NetAllowList,
+		AllowHosts: []string{"example.com:not-a-port"},
+	})
+	if err == nil {
+		t.Fatal("NewMatcher accepted a non-numeric port suffix")
+	}
+}

--- a/core/utils/net/matcher_test.go
+++ b/core/utils/net/matcher_test.go
@@ -55,7 +55,7 @@ func TestMatcherPortSuffixAndReason(t *testing.T) {
 	if !matched || action != NetAllow {
 		t.Fatalf("10.1.2.3:53 should match the CIDR:port rule")
 	}
-	action, _, _, matched = m.MatchIP(netip.MustParseAddr("10.1.2.3"), 54)
+	_, _, _, matched = m.MatchIP(netip.MustParseAddr("10.1.2.3"), 54)
 	if matched {
 		t.Fatalf("10.1.2.3:54 should not match the CIDR:53 rule")
 	}

--- a/core/utils/net/netproxy.go
+++ b/core/utils/net/netproxy.go
@@ -116,6 +116,9 @@ type ProxyDecision struct {
 	Action NetAction
 	Mode   NetMode
 	Rule   string
+	// Reason is the deny rule's model-facing explanation ("" when the
+	// mode default or an allow rule decided).
+	Reason string
 }
 
 // Proxy is a host-side enforcement proxy listening on a unix socket
@@ -129,6 +132,8 @@ type Proxy struct {
 	upstream  *url.URL
 	socksDial proxy.ContextDialer
 	mitm      MITMEngine
+
+	mux *muxListener
 
 	matcherOnce sync.Once
 	compiled    *Matcher
@@ -230,12 +235,144 @@ func Start(cfg ProxyConfig) (*Proxy, error) {
 		p.path = path
 	}
 	p.srv = &http.Server{Handler: p}
+	p.mux = newMuxListener(p.ln.Addr())
+	go p.acceptLoop()
 	go func() {
-		if err := p.srv.Serve(p.ln); err != nil && !errors.Is(err, http.ErrServerClosed) {
+		if err := p.srv.Serve(p.mux); err != nil &&
+			!errors.Is(err, http.ErrServerClosed) && !errors.Is(err, net.ErrClosed) {
 			telemetry.WarnErr(context.Background(), "netproxy: serve failed", err)
 		}
 	}()
 	return p, nil
+}
+
+// acceptLoop accepts raw connections, classifies the first byte, and
+// routes SOCKS5 (0x05) to the SOCKS5 handler while handing every
+// other byte stream to http.Server through the mux listener. One
+// listener serves both protocols, so the seatbelt loopback hole and
+// the Windows WFP proxy-port permit stay single-port.
+func (p *Proxy) acceptLoop() {
+	for {
+		c, err := p.ln.Accept()
+		if err != nil {
+			p.mux.Close()
+			if !errors.Is(err, net.ErrClosed) {
+				telemetry.WarnErr(context.Background(), "netproxy: accept failed", err)
+			}
+			return
+		}
+		go p.handleConn(c)
+	}
+}
+
+// handleConn peeks the first byte to split SOCKS5 from HTTP on the
+// shared listener.
+func (p *Proxy) handleConn(c net.Conn) {
+	br := bufio.NewReader(c)
+	b, err := br.Peek(1)
+	if err != nil {
+		_ = c.Close()
+		return
+	}
+	if b[0] == socks5Version {
+		p.serveSOCKS5(c, br)
+		return
+	}
+	if !p.mux.enqueue(&bufferedConn{Conn: c, r: br}) {
+		_ = c.Close()
+	}
+}
+
+// serveSOCKS5 runs a SOCKS5 session on a connection whose first byte
+// was 0x05. br carries any classifier-buffered bytes. CONNECT targets
+// go through the same policy decision, audit, OnConnect hook, and dial
+// path as HTTP CONNECT, so allow-list and upstream modes behave
+// identically for SOCKS5-aware clients (ssh ProxyCommand, curl
+// --socks5-hostname, tools that honor ALL_PROXY=socks5://...).
+func (p *Proxy) serveSOCKS5(conn net.Conn, br *bufio.Reader) {
+	srv := &socks5Server{connect: func(ctx context.Context, hostport string) (net.Conn, error) {
+		host, port := splitHostPort(hostport, 0)
+		action, rule, reason, dialHost, err := p.decide(ctx, hostport, 0)
+		if err != nil {
+			p.audit(host, port, NetDeny, rule, reason)
+			return nil, err
+		}
+		p.audit(host, port, action, rule, reason)
+		if action != NetAllow {
+			return nil, errDestinationNotAllowed
+		}
+		if p.cfg.Hooks != nil {
+			if err := p.cfg.Hooks.OnConnect(ctx, &MITMConnectInfo{Host: host, Port: port}); err != nil {
+				return nil, err
+			}
+		}
+		return p.dialTarget(ctx, dialHost)
+	}}
+	srv.Serve(conn, br)
+}
+
+// errDestinationNotAllowed marks a policy-denied SOCKS5 CONNECT; the
+// socks5 server maps it to a generic failure reply.
+var errDestinationNotAllowed = errors.New("netproxy: destination not allowed")
+
+// denyReasonSuffix appends a deny rule's model-facing reason to an
+// HTTP denial body.
+func denyReasonSuffix(reason string) string {
+	if reason == "" {
+		return ""
+	}
+	return ": " + reason
+}
+
+// bufferedConn replays classifier-buffered bytes so http.Server sees
+// the complete request stream.
+type bufferedConn struct {
+	net.Conn
+	r *bufio.Reader
+}
+
+func (c *bufferedConn) Read(p []byte) (int, error) { return c.r.Read(p) }
+
+// muxListener delivers HTTP-classified connections to http.Server.
+// SOCKS5 connections never enter the channel. Accept fails with
+// net.ErrClosed once the accept loop exits, so Close unblocks Serve.
+type muxListener struct {
+	addr net.Addr
+	ch   chan net.Conn
+	done chan struct{}
+	once sync.Once
+}
+
+func newMuxListener(addr net.Addr) *muxListener {
+	return &muxListener{addr: addr, ch: make(chan net.Conn), done: make(chan struct{})}
+}
+
+func (l *muxListener) Accept() (net.Conn, error) {
+	select {
+	case c := <-l.ch:
+		return c, nil
+	case <-l.done:
+		return nil, net.ErrClosed
+	}
+}
+
+func (l *muxListener) Close() error {
+	l.once.Do(func() { close(l.done) })
+	return nil
+}
+
+func (l *muxListener) Addr() net.Addr { return l.addr }
+
+// enqueue delivers one HTTP-classified connection to http.Server,
+// closing it if the server is already shut down.
+func (l *muxListener) enqueue(c net.Conn) bool {
+	select {
+	case l.ch <- c:
+		return true
+	case <-l.done:
+		_ = c.Close()
+		return false
+	}
 }
 
 // SocketPath returns the unix socket path to bind into the
@@ -265,6 +402,9 @@ func (p *Proxy) Close() error {
 	if err := p.ln.Close(); err != nil && !errors.Is(err, net.ErrClosed) {
 		telemetry.WarnErr(context.Background(), "netproxy: close listener failed", err)
 	}
+	if p.mux != nil {
+		_ = p.mux.Close()
+	}
 	p.transport.CloseIdleConnections()
 	if p.dir != "" {
 		err := os.RemoveAll(p.dir)
@@ -288,14 +428,14 @@ func (p *Proxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 func (p *Proxy) serveHTTP(w http.ResponseWriter, r *http.Request) {
 	host, port := splitHostPort(r.URL.Host, 80)
-	action, rule, dialHost, err := p.decide(r.Context(), r.URL.Host, 80)
+	action, rule, reason, dialHost, err := p.decide(r.Context(), r.URL.Host, 80)
 	if err != nil {
 		http.Error(w, "netproxy: "+err.Error(), http.StatusBadGateway)
 		return
 	}
-	p.audit(host, port, action, rule)
+	p.audit(host, port, action, rule, reason)
 	if action != NetAllow {
-		http.Error(w, "netproxy: destination not allowed", http.StatusForbidden)
+		http.Error(w, "netproxy: destination not allowed"+denyReasonSuffix(reason), http.StatusForbidden)
 		return
 	}
 	out := r
@@ -325,14 +465,14 @@ func (p *Proxy) serveHTTP(w http.ResponseWriter, r *http.Request) {
 
 func (p *Proxy) serveConnect(w http.ResponseWriter, r *http.Request) {
 	host, port := splitHostPort(r.Host, 443)
-	action, rule, dialHost, err := p.decide(r.Context(), r.Host, 443)
+	action, rule, reason, dialHost, err := p.decide(r.Context(), r.Host, 443)
 	if err != nil {
 		http.Error(w, "netproxy: "+err.Error(), http.StatusBadGateway)
 		return
 	}
-	p.audit(host, port, action, rule)
+	p.audit(host, port, action, rule, reason)
 	if action != NetAllow {
-		http.Error(w, "netproxy: destination not allowed", http.StatusForbidden)
+		http.Error(w, "netproxy: destination not allowed"+denyReasonSuffix(reason), http.StatusForbidden)
 		return
 	}
 	if p.cfg.Hooks != nil {
@@ -388,55 +528,55 @@ func (p *Proxy) serveConnect(w http.ResponseWriter, r *http.Request) {
 }
 
 // decide evaluates the policy for one destination. It returns the
-// verdict, the decisive rule description ("" = mode default), and the
-// concrete dial target. When IP/CIDR rules exist the hostname is
-// resolved locally and the dial target is pinned to a validated IP so
-// neither the upstream nor a rebinding DNS response can bypass the
-// rule set.
-func (p *Proxy) decide(ctx context.Context, hostport string, defaultPort int) (NetAction, string, string, error) {
+// verdict, the decisive rule description ("" = mode default), the
+// deny rule's model-facing reason ("" = none), and the concrete dial
+// target. When IP/CIDR rules exist the hostname is resolved locally
+// and the dial target is pinned to a validated IP so neither the
+// upstream nor a rebinding DNS response can bypass the rule set.
+func (p *Proxy) decide(ctx context.Context, hostport string, defaultPort int) (NetAction, string, string, string, error) {
 	host, port := splitHostPort(hostport, defaultPort)
 	dialHost := hostport
 	m := p.matcher()
 	if m == nil {
-		return NetDeny, "", dialHost, fmt.Errorf("netproxy: policy matcher unavailable")
+		return NetDeny, "", "", dialHost, fmt.Errorf("netproxy: policy matcher unavailable")
 	}
 	if ip, err := netip.ParseAddr(host); err == nil {
-		action, rule, matched := m.MatchIP(ip.Unmap(), port)
+		action, rule, reason, matched := m.MatchIP(ip.Unmap(), port)
 		if action == NetDeny {
-			return action, rule, dialHost, nil
+			return action, rule, reason, dialHost, nil
 		}
 		if matched {
-			return action, rule, dialHost, nil
+			return action, rule, reason, dialHost, nil
 		}
 		if p.cfg.Mode == NetAllowList {
-			return NetDeny, "", dialHost, nil
+			return NetDeny, "", "", dialHost, nil
 		}
-		return NetAllow, "", dialHost, nil
+		return NetAllow, "", "", dialHost, nil
 	}
 
-	action, rule, matched := m.Match(host, port)
+	action, rule, reason, matched := m.Match(host, port)
 	if action == NetDeny {
-		return action, rule, dialHost, nil
+		return action, rule, reason, dialHost, nil
 	}
 	if m.HasIPRules() {
 		addrs, err := net.DefaultResolver.LookupNetIP(ctx, "ip", host)
 		if err != nil {
 			// With IP rules present we cannot prove the destination is
 			// not denied, so we fail closed.
-			return NetDeny, "", dialHost, fmt.Errorf(
+			return NetDeny, "", "", dialHost, fmt.Errorf(
 				"netproxy: resolve %s for IP rules: %w", host, err)
 		}
 		chosen := netip.Addr{}
 		ipAllow := false
 		for _, addr := range addrs {
 			addr = addr.Unmap()
-			if ipAction, ipRule, ipMatched := m.MatchIP(addr, port); ipMatched && ipAction == NetDeny {
-				return NetDeny, ipRule, dialHost, nil
+			if ipAction, ipRule, ipReason, ipMatched := m.MatchIP(addr, port); ipMatched && ipAction == NetDeny {
+				return NetDeny, ipRule, ipReason, dialHost, nil
 			}
 			if !chosen.IsValid() {
 				chosen = addr
 			}
-			if ipAction, _, ipMatched := m.MatchIP(addr, port); ipMatched && ipAction == NetAllow {
+			if ipAction, _, _, ipMatched := m.MatchIP(addr, port); ipMatched && ipAction == NetAllow {
 				ipAllow = true
 			}
 		}
@@ -444,24 +584,24 @@ func (p *Proxy) decide(ctx context.Context, hostport string, defaultPort int) (N
 			dialHost = net.JoinHostPort(chosen.String(), strconv.Itoa(port))
 		}
 		if matched || ipAllow {
-			return NetAllow, rule, dialHost, nil
+			return NetAllow, rule, reason, dialHost, nil
 		}
 		if p.cfg.Mode == NetAllowList {
-			return NetDeny, "", dialHost, nil
+			return NetDeny, "", "", dialHost, nil
 		}
-		return NetAllow, "", dialHost, nil
+		return NetAllow, "", "", dialHost, nil
 	}
 	if matched {
-		return NetAllow, rule, dialHost, nil
+		return NetAllow, rule, reason, dialHost, nil
 	}
 	if p.cfg.Mode == NetAllowList {
-		return NetDeny, "", dialHost, nil
+		return NetDeny, "", "", dialHost, nil
 	}
-	return NetAllow, "", dialHost, nil
+	return NetAllow, "", "", dialHost, nil
 }
 
 // audit emits one decision record when OnDecision is configured.
-func (p *Proxy) audit(host string, port int, action NetAction, rule string) {
+func (p *Proxy) audit(host string, port int, action NetAction, rule, reason string) {
 	if p.cfg.OnDecision != nil {
 		p.cfg.OnDecision(ProxyDecision{
 			Host:   host,
@@ -469,6 +609,7 @@ func (p *Proxy) audit(host string, port int, action NetAction, rule string) {
 			Action: action,
 			Mode:   p.cfg.Mode,
 			Rule:   rule,
+			Reason: reason,
 		})
 	}
 }

--- a/core/utils/net/netproxy.go
+++ b/core/utils/net/netproxy.go
@@ -255,7 +255,7 @@ func (p *Proxy) acceptLoop() {
 	for {
 		c, err := p.ln.Accept()
 		if err != nil {
-			p.mux.Close()
+			_ = p.mux.Close()
 			if !errors.Is(err, net.ErrClosed) {
 				telemetry.WarnErr(context.Background(), "netproxy: accept failed", err)
 			}

--- a/core/utils/net/netproxy_socks_test.go
+++ b/core/utils/net/netproxy_socks_test.go
@@ -1,0 +1,306 @@
+package net
+
+import (
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+// TestProxySocks5AndHTTPShareListener proves the enforcement proxy
+// multiplexes SOCKS5 and HTTP on one address: a SOCKS5 CONNECT
+// tunnel, an HTTP GET through the same port, and the unix-socket
+// listener (the bwrap bridge path) all enforce the same allow-list.
+func TestProxySocks5AndHTTPShareListener(t *testing.T) {
+	echo := newEchoServer(t)
+	defer echo.Close()
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.WriteString(w, "upstream-ok")
+	}))
+	defer upstream.Close()
+	upURL, err := url.Parse(upstream.URL)
+	if err != nil {
+		t.Fatalf("parse upstream url: %v", err)
+	}
+	upHost, upPort := splitHostPort(upURL.Host, 80)
+	echoHost, echoPort := splitHostPort(echo.Addr().String(), 0)
+
+	var decisions []ProxyDecision
+	var mu sync.Mutex
+	proxy, err := Start(ProxyConfig{
+		Mode: NetAllowList,
+		Rules: []NetRule{
+			{Action: NetAllow, Host: upHost, Port: upPort},
+			{Action: NetAllow, Host: echoHost, Port: echoPort},
+			{Action: NetDeny, Host: "blocked.example", Reason: "denied by test"},
+		},
+		TCPLoopback: true,
+		OnDecision: func(d ProxyDecision) {
+			mu.Lock()
+			decisions = append(decisions, d)
+			mu.Unlock()
+		},
+	})
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer proxy.Close()
+
+	// SOCKS5 tunnel to the allow-listed upstream.
+	conn, err := socks5Dial(proxy.Addr().String(), echo.Addr().String())
+	if err != nil {
+		t.Fatalf("socks5 dial: %v", err)
+	}
+	defer conn.Close()
+	if _, err := conn.Write([]byte("socks-ok")); err != nil {
+		t.Fatalf("socks write: %v", err)
+	}
+	got := make([]byte, len("socks-ok"))
+	if _, err := io.ReadFull(conn, got); err != nil {
+		t.Fatalf("socks read: %v", err)
+	}
+	if string(got) != "socks-ok" {
+		t.Fatalf("echo = %q, want socks-ok", got)
+	}
+
+	// SOCKS5 CONNECT to a denied host must be refused.
+	denied, err := socks5DialCode(proxy.Addr().String(), "blocked.example:443")
+	if err != nil {
+		t.Fatalf("denied dial: %v", err)
+	}
+	defer denied.Close()
+	code, err := readSocks5ReplyCode(denied)
+	if err != nil {
+		t.Fatalf("denied reply: %v", err)
+	}
+	if code != socks5Failure {
+		t.Fatalf("denied code = 0x%02x, want 0x01", code)
+	}
+
+	// Plain HTTP through the same listener.
+	httpProxy, err := url.Parse("http://" + proxy.Addr().String())
+	if err != nil {
+		t.Fatalf("parse http proxy: %v", err)
+	}
+	client := &http.Client{Transport: &http.Transport{Proxy: http.ProxyURL(httpProxy)}}
+	resp, err := client.Get(upstream.URL)
+	if err != nil {
+		t.Fatalf("http through proxy: %v", err)
+	}
+	body, _ := io.ReadAll(resp.Body)
+	resp.Body.Close()
+	if string(body) != "upstream-ok" {
+		t.Fatalf("http body = %q, want upstream-ok", body)
+	}
+
+	// Unix-socket listener (bwrap bridge path) serves SOCKS5 too.
+	udsProxy, err := Start(ProxyConfig{
+		Mode: NetAllowList,
+		Rules: []NetRule{
+			{Action: NetAllow, Host: echoHost, Port: echoPort},
+		},
+		OnDecision: func(ProxyDecision) {},
+	})
+	if err != nil {
+		t.Fatalf("Start uds: %v", err)
+	}
+	defer udsProxy.Close()
+	udsConn, err := socks5DialUnix(udsProxy.SocketPath(), echo.Addr().String())
+	if err != nil {
+		t.Fatalf("uds socks5 dial: %v", err)
+	}
+	defer udsConn.Close()
+	if _, err := udsConn.Write([]byte("uds-ok")); err != nil {
+		t.Fatalf("uds write: %v", err)
+	}
+	gotUDS := make([]byte, len("uds-ok"))
+	if _, err := io.ReadFull(udsConn, gotUDS); err != nil {
+		t.Fatalf("uds read: %v", err)
+	}
+	if string(gotUDS) != "uds-ok" {
+		t.Fatalf("uds echo = %q, want uds-ok", gotUDS)
+	}
+
+	// The deny decision carried the rule's model-facing reason.
+	mu.Lock()
+	defer mu.Unlock()
+	var deny *ProxyDecision
+	for i := range decisions {
+		if decisions[i].Action == NetDeny && decisions[i].Rule != "" {
+			deny = &decisions[i]
+		}
+	}
+	if deny == nil {
+		t.Fatalf("no deny decision recorded: %+v", decisions)
+	}
+	if deny.Reason != "denied by test" {
+		t.Fatalf("deny reason = %q, want denied by test", deny.Reason)
+	}
+}
+
+// TestProxySocks5DenyReasonBody proves an HTTP denial response carries
+// the deny rule's reason (srt's deniedDomainReasons behavior).
+func TestProxySocks5DenyReasonBody(t *testing.T) {
+	proxy, err := Start(ProxyConfig{
+		Mode: NetAllowList,
+		Rules: []NetRule{
+			{Action: NetDeny, Host: "blocked.example", Reason: "blocked for the demo"},
+		},
+		TCPLoopback: true,
+	})
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer proxy.Close()
+
+	httpProxy, err := url.Parse("http://" + proxy.Addr().String())
+	if err != nil {
+		t.Fatalf("parse proxy: %v", err)
+	}
+	client := &http.Client{
+		Transport: &http.Transport{Proxy: http.ProxyURL(httpProxy)},
+		CheckRedirect: func(req *http.Request, via []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
+	}
+	resp, err := client.Get("http://blocked.example/")
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+	if !strings.Contains(string(body), "blocked for the demo") {
+		t.Fatalf("deny body = %q, want reason", body)
+	}
+}
+
+// socks5Dial opens a SOCKS5 tunnel to hostport through the proxy at
+// proxyAddr, asserting the server accepted it.
+func socks5Dial(proxyAddr, hostport string) (net.Conn, error) {
+	conn, err := net.DialTimeout("tcp", proxyAddr, 5*time.Second)
+	if err != nil {
+		return nil, err
+	}
+	if err := writeSocks5Greeting(conn); err != nil {
+		conn.Close()
+		return nil, err
+	}
+	host, port, err := net.SplitHostPort(hostport)
+	if err != nil {
+		conn.Close()
+		return nil, err
+	}
+	portNum, err := strconv.Atoi(port)
+	if err != nil {
+		conn.Close()
+		return nil, fmt.Errorf("bad port %q: %w", port, err)
+	}
+	if err := writeSocks5Connect(conn, host, portNum); err != nil {
+		conn.Close()
+		return nil, err
+	}
+	code, err := readSocks5ReplyCode(conn)
+	if err != nil {
+		conn.Close()
+		return nil, err
+	}
+	if code != socks5Success {
+		conn.Close()
+		return nil, fmt.Errorf("socks5 connect refused: code 0x%02x", code)
+	}
+	return conn, nil
+}
+
+// socks5DialCode is socks5Dial without the success assertion: the
+// caller reads the reply code itself.
+func socks5DialCode(proxyAddr, hostport string) (net.Conn, error) {
+	conn, err := net.DialTimeout("tcp", proxyAddr, 5*time.Second)
+	if err != nil {
+		return nil, err
+	}
+	if err := writeSocks5Greeting(conn); err != nil {
+		conn.Close()
+		return nil, err
+	}
+	host, port, err := net.SplitHostPort(hostport)
+	if err != nil {
+		conn.Close()
+		return nil, err
+	}
+	portNum, err := strconv.Atoi(port)
+	if err != nil {
+		conn.Close()
+		return nil, fmt.Errorf("bad port %q: %w", port, err)
+	}
+	if err := writeSocks5Connect(conn, host, portNum); err != nil {
+		conn.Close()
+		return nil, err
+	}
+	return conn, nil
+}
+
+// socks5DialUnix is socks5Dial over a unix socket.
+func socks5DialUnix(sockPath, hostport string) (net.Conn, error) {
+	conn, err := net.DialTimeout("unix", sockPath, 5*time.Second)
+	if err != nil {
+		return nil, err
+	}
+	if err := writeSocks5Greeting(conn); err != nil {
+		conn.Close()
+		return nil, err
+	}
+	host, port, err := net.SplitHostPort(hostport)
+	if err != nil {
+		conn.Close()
+		return nil, err
+	}
+	portNum, err := strconv.Atoi(port)
+	if err != nil {
+		conn.Close()
+		return nil, fmt.Errorf("bad port %q: %w", port, err)
+	}
+	if err := writeSocks5Connect(conn, host, portNum); err != nil {
+		conn.Close()
+		return nil, err
+	}
+	code, err := readSocks5ReplyCode(conn)
+	if err != nil {
+		conn.Close()
+		return nil, err
+	}
+	if code != socks5Success {
+		conn.Close()
+		return nil, fmt.Errorf("socks5 connect refused: code 0x%02x", code)
+	}
+	return conn, nil
+}
+
+// newEchoServer starts a TCP echo server on loopback.
+func newEchoServer(t *testing.T) net.Listener {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("echo listen: %v", err)
+	}
+	go func() {
+		for {
+			c, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			go func() {
+				defer c.Close()
+				_, _ = io.Copy(c, c)
+			}()
+		}
+	}()
+	return ln
+}

--- a/core/utils/net/netproxy_socks_test.go
+++ b/core/utils/net/netproxy_socks_test.go
@@ -20,7 +20,7 @@ import (
 // listener (the bwrap bridge path) all enforce the same allow-list.
 func TestProxySocks5AndHTTPShareListener(t *testing.T) {
 	echo := newEchoServer(t)
-	defer echo.Close()
+	defer func() { _ = echo.Close() }()
 
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		_, _ = io.WriteString(w, "upstream-ok")
@@ -52,14 +52,14 @@ func TestProxySocks5AndHTTPShareListener(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Start: %v", err)
 	}
-	defer proxy.Close()
+	defer func() { _ = proxy.Close() }()
 
 	// SOCKS5 tunnel to the allow-listed upstream.
 	conn, err := socks5Dial(proxy.Addr().String(), echo.Addr().String())
 	if err != nil {
 		t.Fatalf("socks5 dial: %v", err)
 	}
-	defer conn.Close()
+	defer func() { _ = conn.Close() }()
 	if _, err := conn.Write([]byte("socks-ok")); err != nil {
 		t.Fatalf("socks write: %v", err)
 	}
@@ -76,7 +76,7 @@ func TestProxySocks5AndHTTPShareListener(t *testing.T) {
 	if err != nil {
 		t.Fatalf("denied dial: %v", err)
 	}
-	defer denied.Close()
+	defer func() { _ = denied.Close() }()
 	code, err := readSocks5ReplyCode(denied)
 	if err != nil {
 		t.Fatalf("denied reply: %v", err)
@@ -96,7 +96,7 @@ func TestProxySocks5AndHTTPShareListener(t *testing.T) {
 		t.Fatalf("http through proxy: %v", err)
 	}
 	body, _ := io.ReadAll(resp.Body)
-	resp.Body.Close()
+	_ = resp.Body.Close()
 	if string(body) != "upstream-ok" {
 		t.Fatalf("http body = %q, want upstream-ok", body)
 	}
@@ -112,12 +112,12 @@ func TestProxySocks5AndHTTPShareListener(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Start uds: %v", err)
 	}
-	defer udsProxy.Close()
+	defer func() { _ = udsProxy.Close() }()
 	udsConn, err := socks5DialUnix(udsProxy.SocketPath(), echo.Addr().String())
 	if err != nil {
 		t.Fatalf("uds socks5 dial: %v", err)
 	}
-	defer udsConn.Close()
+	defer func() { _ = udsConn.Close() }()
 	if _, err := udsConn.Write([]byte("uds-ok")); err != nil {
 		t.Fatalf("uds write: %v", err)
 	}
@@ -159,7 +159,7 @@ func TestProxySocks5DenyReasonBody(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Start: %v", err)
 	}
-	defer proxy.Close()
+	defer func() { _ = proxy.Close() }()
 
 	httpProxy, err := url.Parse("http://" + proxy.Addr().String())
 	if err != nil {
@@ -175,7 +175,7 @@ func TestProxySocks5DenyReasonBody(t *testing.T) {
 	if err != nil {
 		t.Fatalf("get: %v", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 	body, _ := io.ReadAll(resp.Body)
 	if !strings.Contains(string(body), "blocked for the demo") {
 		t.Fatalf("deny body = %q, want reason", body)
@@ -190,30 +190,30 @@ func socks5Dial(proxyAddr, hostport string) (net.Conn, error) {
 		return nil, err
 	}
 	if err := writeSocks5Greeting(conn); err != nil {
-		conn.Close()
+		_ = conn.Close()
 		return nil, err
 	}
 	host, port, err := net.SplitHostPort(hostport)
 	if err != nil {
-		conn.Close()
+		_ = conn.Close()
 		return nil, err
 	}
 	portNum, err := strconv.Atoi(port)
 	if err != nil {
-		conn.Close()
+		_ = conn.Close()
 		return nil, fmt.Errorf("bad port %q: %w", port, err)
 	}
 	if err := writeSocks5Connect(conn, host, portNum); err != nil {
-		conn.Close()
+		_ = conn.Close()
 		return nil, err
 	}
 	code, err := readSocks5ReplyCode(conn)
 	if err != nil {
-		conn.Close()
+		_ = conn.Close()
 		return nil, err
 	}
 	if code != socks5Success {
-		conn.Close()
+		_ = conn.Close()
 		return nil, fmt.Errorf("socks5 connect refused: code 0x%02x", code)
 	}
 	return conn, nil
@@ -227,21 +227,21 @@ func socks5DialCode(proxyAddr, hostport string) (net.Conn, error) {
 		return nil, err
 	}
 	if err := writeSocks5Greeting(conn); err != nil {
-		conn.Close()
+		_ = conn.Close()
 		return nil, err
 	}
 	host, port, err := net.SplitHostPort(hostport)
 	if err != nil {
-		conn.Close()
+		_ = conn.Close()
 		return nil, err
 	}
 	portNum, err := strconv.Atoi(port)
 	if err != nil {
-		conn.Close()
+		_ = conn.Close()
 		return nil, fmt.Errorf("bad port %q: %w", port, err)
 	}
 	if err := writeSocks5Connect(conn, host, portNum); err != nil {
-		conn.Close()
+		_ = conn.Close()
 		return nil, err
 	}
 	return conn, nil
@@ -254,30 +254,30 @@ func socks5DialUnix(sockPath, hostport string) (net.Conn, error) {
 		return nil, err
 	}
 	if err := writeSocks5Greeting(conn); err != nil {
-		conn.Close()
+		_ = conn.Close()
 		return nil, err
 	}
 	host, port, err := net.SplitHostPort(hostport)
 	if err != nil {
-		conn.Close()
+		_ = conn.Close()
 		return nil, err
 	}
 	portNum, err := strconv.Atoi(port)
 	if err != nil {
-		conn.Close()
+		_ = conn.Close()
 		return nil, fmt.Errorf("bad port %q: %w", port, err)
 	}
 	if err := writeSocks5Connect(conn, host, portNum); err != nil {
-		conn.Close()
+		_ = conn.Close()
 		return nil, err
 	}
 	code, err := readSocks5ReplyCode(conn)
 	if err != nil {
-		conn.Close()
+		_ = conn.Close()
 		return nil, err
 	}
 	if code != socks5Success {
-		conn.Close()
+		_ = conn.Close()
 		return nil, fmt.Errorf("socks5 connect refused: code 0x%02x", code)
 	}
 	return conn, nil
@@ -297,7 +297,7 @@ func newEchoServer(t *testing.T) net.Listener {
 				return
 			}
 			go func() {
-				defer c.Close()
+				defer func() { _ = c.Close() }()
 				_, _ = io.Copy(c, c)
 			}()
 		}

--- a/core/utils/net/netproxy_socks_test.go
+++ b/core/utils/net/netproxy_socks_test.go
@@ -182,6 +182,66 @@ func TestProxySocks5DenyReasonBody(t *testing.T) {
 	}
 }
 
+// TestProxySocks5PipelinedData covers the classifier path the unit
+// test cannot: handleConn's br.Peek(1) fills the buffer with every
+// byte available in the first read, so a client that pipelines the
+// CONNECT request and its first payload in one write exercises the
+// buffered-bytes handoff into the tunnel.
+func TestProxySocks5PipelinedData(t *testing.T) {
+	echo := newEchoServer(t)
+	defer func() { _ = echo.Close() }()
+	echoHost, echoPort := splitHostPort(echo.Addr().String(), 0)
+	proxy, err := Start(ProxyConfig{
+		Mode: NetAllowList,
+		Rules: []NetRule{
+			{Action: NetAllow, Host: echoHost, Port: echoPort},
+		},
+		TCPLoopback: true,
+	})
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer func() { _ = proxy.Close() }()
+
+	conn, err := net.DialTimeout("tcp", proxy.Addr().String(), 5*time.Second)
+	if err != nil {
+		t.Fatalf("dial proxy: %v", err)
+	}
+	defer func() { _ = conn.Close() }()
+
+	payload := []byte("pipelined-through-proxy")
+	req := []byte{socks5Version, 0x01, socks5NoAuth}
+	req = append(req, socks5Version, socks5CmdConnect, 0x00, socks5AtypIPv4)
+	req = append(req, net.ParseIP(echoHost).To4()...)
+	req = append(req, byte(echoPort>>8), byte(echoPort))
+	req = append(req, payload...)
+	if _, err := conn.Write(req); err != nil {
+		t.Fatalf("write pipelined request: %v", err)
+	}
+
+	greet := make([]byte, 2)
+	if _, err := io.ReadFull(conn, greet); err != nil {
+		t.Fatalf("greeting reply: %v", err)
+	}
+	if greet[1] != socks5NoAuth {
+		t.Fatalf("greeting reply = 0x%02x, want 0x00", greet[1])
+	}
+	code, err := readSocks5ReplyCode(conn)
+	if err != nil {
+		t.Fatalf("connect reply: %v", err)
+	}
+	if code != socks5Success {
+		t.Fatalf("reply code = 0x%02x, want 0x00", code)
+	}
+	got := make([]byte, len(payload))
+	if _, err := io.ReadFull(conn, got); err != nil {
+		t.Fatalf("echo: %v", err)
+	}
+	if string(got) != string(payload) {
+		t.Fatalf("echo = %q, want %q", got, payload)
+	}
+}
+
 // socks5Dial opens a SOCKS5 tunnel to hostport through the proxy at
 // proxyAddr, asserting the server accepted it.
 func socks5Dial(proxyAddr, hostport string) (net.Conn, error) {

--- a/core/utils/net/policy.go
+++ b/core/utils/net/policy.go
@@ -24,7 +24,11 @@ const (
 
 // NetPolicy controls outbound networking for the child process.
 type NetPolicy struct {
-	Mode        NetMode
+	Mode NetMode
+	// AllowHosts is the legacy allow-list: hostname suffixes and exact
+	// IP literals. Entries support an optional ":port" suffix
+	// ("api.example.com:443", "[::1]:8443"); entries without a suffix
+	// match any port. Prefer Rules for new configurations.
 	AllowHosts  []string
 	Rules       []NetRule
 	Proxy       string
@@ -56,6 +60,11 @@ type NetRule struct {
 	Action NetAction
 	Host   string
 	Port   int
+	// Reason is an optional model-facing explanation attached to a
+	// deny rule. It is surfaced in proxy denial responses and audit
+	// records so an agent can see what was blocked and why (mirrors
+	// srt's deniedDomainReasons). Allow-rule reasons are ignored.
+	Reason string
 }
 
 // MITMPolicy enables TLS termination and content hooks for CONNECT
@@ -99,6 +108,12 @@ func (p NetPolicy) Validate() error {
 		}
 		if rule.Port < 0 || rule.Port > 65535 {
 			return errdefs.Validationf("net: net rule %d port %d out of range", i, rule.Port)
+		}
+		if strings.TrimSpace(rule.Reason) != rule.Reason {
+			return errdefs.Validationf("net: net rule %d reason has leading or trailing whitespace", i)
+		}
+		if strings.ContainsAny(rule.Reason, "\r\n") {
+			return errdefs.Validationf("net: net rule %d reason must be a single line", i)
 		}
 	}
 	for _, path := range p.UnixSockets {

--- a/core/utils/net/socks5.go
+++ b/core/utils/net/socks5.go
@@ -35,6 +35,13 @@ const (
 // variable (not a const) so tests can shrink it.
 var socks5HandshakeTimeout = 15 * time.Second
 
+// socks5DialTimeout bounds one policy-enforced dial. The dial happens
+// before the tunnel exists, so a client that disconnects during a
+// black-holed target would otherwise leave the dial waiting on the
+// system TCP timeout (minutes). Once the tunnel is up, the copy
+// goroutines observe the client side directly.
+const socks5DialTimeout = 30 * time.Second
+
 // socks5Request is one parsed CONNECT request.
 type socks5Request struct {
 	host string
@@ -72,7 +79,9 @@ func (s *socks5Server) Serve(conn net.Conn, br *bufio.Reader) {
 	_ = conn.SetDeadline(time.Time{})
 
 	hostport := net.JoinHostPort(req.host, strconv.Itoa(req.port))
-	up, err := s.connect(context.Background(), hostport)
+	ctx, cancel := context.WithTimeout(context.Background(), socks5DialTimeout)
+	defer cancel()
+	up, err := s.connect(ctx, hostport)
 	if err != nil {
 		_ = writeSocks5Reply(conn, socks5Failure, nil)
 		return
@@ -82,7 +91,12 @@ func (s *socks5Server) Serve(conn net.Conn, br *bufio.Reader) {
 		return
 	}
 	go func() {
-		_, _ = io.Copy(up, conn)
+		// Read through br: the classifier's Peek (and the handshake
+		// parser) may have buffered bytes beyond the CONNECT request —
+		// a client that pipelines the request and its first payload in
+		// one write would otherwise have those bytes silently dropped.
+		_, _ = io.Copy(up, br)
+		cancel()
 		_ = up.Close()
 	}()
 	_, _ = io.Copy(conn, up)

--- a/core/utils/net/socks5.go
+++ b/core/utils/net/socks5.go
@@ -1,0 +1,205 @@
+package net
+
+import (
+	"bufio"
+	"context"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"strconv"
+	"time"
+)
+
+// SOCKS5 protocol constants (RFC 1928), kept in one place because the
+// proxy multiplexes SOCKS5 and HTTP on the same listener.
+const (
+	socks5Version    = 0x05
+	socks5NoAuth     = 0x00
+	socks5NoAccept   = 0xff
+	socks5CmdConnect = 0x01
+	socks5CmdBind    = 0x02
+	socks5CmdUDP     = 0x03
+	socks5AtypIPv4   = 0x01
+	socks5AtypDomain = 0x03
+	socks5AtypIPv6   = 0x04
+	socks5Success    = 0x00
+	socks5Failure    = 0x01
+	socks5CmdUnsup   = 0x07
+)
+
+// socks5HandshakeTimeout bounds how long a client may take to send the
+// greeting and CONNECT request. Once the request is parsed the deadline
+// is cleared: the tunnel itself is unbounded like HTTP CONNECT. It is a
+// variable (not a const) so tests can shrink it.
+var socks5HandshakeTimeout = 15 * time.Second
+
+// socks5Request is one parsed CONNECT request.
+type socks5Request struct {
+	host string
+	port int
+}
+
+// socks5Server serves one SOCKS5 session: no-auth greeting, CONNECT
+// only, policy enforcement delegated to the connect callback. It is
+// protocol-only — allow/deny, auditing, upstream selection, and the
+// HTTP OnConnect hook all live in the proxy's connect closure.
+type socks5Server struct {
+	// connect dials a policy-allowed CONNECT target. A non-nil error
+	// is reported to the client as a generic SOCKS5 failure.
+	connect func(ctx context.Context, hostport string) (net.Conn, error)
+}
+
+// Serve runs the SOCKS5 handshake on conn (reading through br, which
+// may already hold classifier-buffered bytes) and proxies the tunnel.
+// conn is always closed before Serve returns.
+func (s *socks5Server) Serve(conn net.Conn, br *bufio.Reader) {
+	defer func() { _ = conn.Close() }()
+	if s.connect == nil {
+		return
+	}
+	if br == nil {
+		br = bufio.NewReader(conn)
+	}
+	if err := conn.SetDeadline(time.Now().Add(socks5HandshakeTimeout)); err != nil {
+		return
+	}
+	req, err := readSocks5Request(conn, br)
+	if err != nil {
+		return
+	}
+	_ = conn.SetDeadline(time.Time{})
+
+	hostport := net.JoinHostPort(req.host, strconv.Itoa(req.port))
+	up, err := s.connect(context.Background(), hostport)
+	if err != nil {
+		_ = writeSocks5Reply(conn, socks5Failure, nil)
+		return
+	}
+	defer func() { _ = up.Close() }()
+	if err := writeSocks5Reply(conn, socks5Success, up.LocalAddr()); err != nil {
+		return
+	}
+	go func() {
+		_, _ = io.Copy(up, conn)
+		_ = up.Close()
+	}()
+	_, _ = io.Copy(conn, up)
+}
+
+// readSocks5Request performs the no-auth SOCKS5 greeting and parses
+// the CONNECT request. Non-CONNECT commands get an explicit
+// "command not supported" reply before the connection is dropped.
+func readSocks5Request(conn net.Conn, br *bufio.Reader) (socks5Request, error) {
+	var req socks5Request
+
+	// Greeting: VER, NMETHODS, METHODS[].
+	ver, err := br.ReadByte()
+	if err != nil {
+		return req, err
+	}
+	if ver != socks5Version {
+		return req, fmt.Errorf("socks5: bad version 0x%02x", ver)
+	}
+	nmethods, err := br.ReadByte()
+	if err != nil {
+		return req, err
+	}
+	methods := make([]byte, int(nmethods))
+	if _, err := io.ReadFull(br, methods); err != nil {
+		return req, err
+	}
+	reply := []byte{socks5Version, socks5NoAccept}
+	for _, m := range methods {
+		if m == socks5NoAuth {
+			reply = []byte{socks5Version, socks5NoAuth}
+			break
+		}
+	}
+	if _, err := conn.Write(reply); err != nil {
+		return req, err
+	}
+	if reply[1] != socks5NoAuth {
+		return req, errors.New("socks5: no acceptable auth method")
+	}
+
+	// Request: VER, CMD, RSV, ATYP, DST.ADDR, DST.PORT.
+	head := make([]byte, 3)
+	if _, err := io.ReadFull(br, head); err != nil {
+		return req, err
+	}
+	if head[0] != socks5Version {
+		return req, fmt.Errorf("socks5: bad request version 0x%02x", head[0])
+	}
+	if head[1] != socks5CmdConnect {
+		_ = writeSocks5Reply(conn, socks5CmdUnsup, nil)
+		return req, fmt.Errorf("socks5: unsupported command 0x%02x", head[1])
+	}
+	atyp, err := br.ReadByte()
+	if err != nil {
+		return req, err
+	}
+	switch atyp {
+	case socks5AtypIPv4:
+		b := make([]byte, 4)
+		if _, err := io.ReadFull(br, b); err != nil {
+			return req, err
+		}
+		req.host = net.IPv4(b[0], b[1], b[2], b[3]).String()
+	case socks5AtypDomain:
+		n, err := br.ReadByte()
+		if err != nil {
+			return req, err
+		}
+		if n == 0 {
+			return req, errors.New("socks5: empty domain")
+		}
+		b := make([]byte, int(n))
+		if _, err := io.ReadFull(br, b); err != nil {
+			return req, err
+		}
+		req.host = string(b)
+	case socks5AtypIPv6:
+		b := make([]byte, 16)
+		if _, err := io.ReadFull(br, b); err != nil {
+			return req, err
+		}
+		req.host = net.IP(b).String()
+	default:
+		return req, fmt.Errorf("socks5: unsupported address type 0x%02x", atyp)
+	}
+	portBytes := make([]byte, 2)
+	if _, err := io.ReadFull(br, portBytes); err != nil {
+		return req, err
+	}
+	req.port = int(binary.BigEndian.Uint16(portBytes))
+	if req.port == 0 {
+		return req, errors.New("socks5: zero destination port")
+	}
+	return req, nil
+}
+
+// writeSocks5Reply sends one SOCKS5 reply. When bind is non-nil its
+// TCP address is reported as the bound address; otherwise 0.0.0.0:0
+// is used (clients ignore BND.ADDR for CONNECT).
+func writeSocks5Reply(w io.Writer, code byte, bind net.Addr) error {
+	atyp := byte(socks5AtypIPv4)
+	addr := []byte{0, 0, 0, 0}
+	port := uint16(0)
+	if tcp, ok := bind.(*net.TCPAddr); ok {
+		if ip4 := tcp.IP.To4(); ip4 != nil {
+			addr = ip4
+		} else if ip6 := tcp.IP.To16(); ip6 != nil {
+			atyp = socks5AtypIPv6
+			addr = ip6
+		}
+		port = uint16(tcp.Port)
+	}
+	buf := make([]byte, 0, 10)
+	buf = append(buf, socks5Version, code, 0x00, atyp)
+	buf = append(buf, addr...)
+	buf = append(buf, byte(port>>8), byte(port))
+	_, err := w.Write(buf)
+	return err
+}

--- a/core/utils/net/socks5_test.go
+++ b/core/utils/net/socks5_test.go
@@ -16,8 +16,8 @@ import (
 // every address type.
 func TestReadSocks5Request(t *testing.T) {
 	client, server := net.Pipe()
-	defer client.Close()
-	defer server.Close()
+	defer func() { _ = client.Close() }()
+	defer func() { _ = server.Close() }()
 
 	done := make(chan struct{})
 	go func() {
@@ -44,8 +44,8 @@ func TestReadSocks5Request(t *testing.T) {
 
 func TestReadSocks5RequestIPv6AndCIDRHost(t *testing.T) {
 	client, server := net.Pipe()
-	defer client.Close()
-	defer server.Close()
+	defer func() { _ = client.Close() }()
+	defer func() { _ = server.Close() }()
 
 	done := make(chan struct{})
 	go func() {
@@ -77,8 +77,8 @@ func TestReadSocks5RequestIPv6AndCIDRHost(t *testing.T) {
 
 func TestReadSocks5RequestRejectsBadVersion(t *testing.T) {
 	client, server := net.Pipe()
-	defer client.Close()
-	defer server.Close()
+	defer func() { _ = client.Close() }()
+	defer func() { _ = server.Close() }()
 
 	done := make(chan struct{})
 	go func() {
@@ -97,8 +97,8 @@ func TestReadSocks5RequestRejectsBadVersion(t *testing.T) {
 
 func TestReadSocks5RequestRejectsNonConnectCommand(t *testing.T) {
 	client, server := net.Pipe()
-	defer client.Close()
-	defer server.Close()
+	defer func() { _ = client.Close() }()
+	defer func() { _ = server.Close() }()
 
 	done := make(chan struct{})
 	go func() {
@@ -131,8 +131,8 @@ func TestReadSocks5RequestRejectsNonConnectCommand(t *testing.T) {
 
 func TestReadSocks5RequestRejectsNoAuthMethod(t *testing.T) {
 	client, server := net.Pipe()
-	defer client.Close()
-	defer server.Close()
+	defer func() { _ = client.Close() }()
+	defer func() { _ = server.Close() }()
 
 	done := make(chan struct{})
 	go func() {
@@ -163,7 +163,7 @@ func TestSocks5ServerTunnel(t *testing.T) {
 	if err != nil {
 		t.Fatalf("echo listen: %v", err)
 	}
-	defer echo.Close()
+	defer func() { _ = echo.Close() }()
 	go func() {
 		for {
 			c, err := echo.Accept()
@@ -171,7 +171,7 @@ func TestSocks5ServerTunnel(t *testing.T) {
 				return
 			}
 			go func() {
-				defer c.Close()
+				defer func() { _ = c.Close() }()
 				_, _ = io.Copy(c, c)
 			}()
 		}
@@ -179,8 +179,8 @@ func TestSocks5ServerTunnel(t *testing.T) {
 	target := echo.Addr().String()
 
 	client, server := net.Pipe()
-	defer client.Close()
-	defer server.Close()
+	defer func() { _ = client.Close() }()
+	defer func() { _ = server.Close() }()
 	srv := &socks5Server{connect: func(_ context.Context, hostport string) (net.Conn, error) {
 		if hostport != target {
 			return nil, fmt.Errorf("dial %q, want %q", hostport, target)
@@ -219,8 +219,8 @@ func TestSocks5ServerTunnel(t *testing.T) {
 // as a generic SOCKS5 failure reply.
 func TestSocks5ServerDenied(t *testing.T) {
 	client, server := net.Pipe()
-	defer client.Close()
-	defer server.Close()
+	defer func() { _ = client.Close() }()
+	defer func() { _ = server.Close() }()
 	srv := &socks5Server{connect: func(_ context.Context, _ string) (net.Conn, error) {
 		return nil, errDestinationNotAllowed
 	}}
@@ -246,8 +246,8 @@ func TestSocks5ServerHandshakeTimeout(t *testing.T) {
 	socks5HandshakeTimeout = 100 * time.Millisecond
 	defer func() { socks5HandshakeTimeout = old }()
 	client, server := net.Pipe()
-	defer client.Close()
-	defer server.Close()
+	defer func() { _ = client.Close() }()
+	defer func() { _ = server.Close() }()
 	srv := &socks5Server{connect: func(_ context.Context, _ string) (net.Conn, error) {
 		return nil, errors.New("must not dial")
 	}}
@@ -304,9 +304,10 @@ func readSocks5ReplyCode(c net.Conn) (byte, error) {
 	}
 	atyp := buf[3]
 	addrLen := 4
-	if atyp == socks5AtypIPv6 {
+	switch atyp {
+	case socks5AtypIPv6:
 		addrLen = 16
-	} else if atyp == socks5AtypDomain {
+	case socks5AtypDomain:
 		addrLen = 1
 	}
 	skip := make([]byte, addrLen+2)
@@ -320,8 +321,8 @@ func readSocks5ReplyCode(c net.Conn) (byte, error) {
 // layout used by readSocks5ReplyCode in the session tests.
 func TestWriteSocks5ReplyShape(t *testing.T) {
 	c, s := net.Pipe()
-	defer c.Close()
-	defer s.Close()
+	defer func() { _ = c.Close() }()
+	defer func() { _ = s.Close() }()
 	done := make(chan byte, 1)
 	go func() {
 		code, err := readSocks5ReplyCode(c)

--- a/core/utils/net/socks5_test.go
+++ b/core/utils/net/socks5_test.go
@@ -1,0 +1,339 @@
+package net
+
+import (
+	"bufio"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestReadSocks5Request covers the greeting and CONNECT parsing for
+// every address type.
+func TestReadSocks5Request(t *testing.T) {
+	client, server := net.Pipe()
+	defer client.Close()
+	defer server.Close()
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		br := bufio.NewReader(server)
+		req, err := readSocks5Request(server, br)
+		if err != nil {
+			t.Errorf("readSocks5Request: %v", err)
+			return
+		}
+		if req.host != "example.com" || req.port != 443 {
+			t.Errorf("req = %+v, want example.com:443", req)
+		}
+	}()
+
+	if err := writeSocks5Greeting(client); err != nil {
+		t.Fatalf("greeting: %v", err)
+	}
+	if err := writeSocks5Connect(client, "example.com", 443); err != nil {
+		t.Fatalf("connect request: %v", err)
+	}
+	<-done
+}
+
+func TestReadSocks5RequestIPv6AndCIDRHost(t *testing.T) {
+	client, server := net.Pipe()
+	defer client.Close()
+	defer server.Close()
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		br := bufio.NewReader(server)
+		req, err := readSocks5Request(server, br)
+		if err != nil {
+			t.Errorf("readSocks5Request: %v", err)
+			return
+		}
+		if req.host != "2001:db8::1" || req.port != 8443 {
+			t.Errorf("req = %+v, want [2001:db8::1]:8443", req)
+		}
+	}()
+
+	if err := writeSocks5Greeting(client); err != nil {
+		t.Fatalf("greeting: %v", err)
+	}
+	req := []byte{
+		socks5Version, socks5CmdConnect, 0x00, socks5AtypIPv6,
+		0x20, 0x01, 0x0d, 0xb8, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1,
+		0x20, 0xfb, // 8443
+	}
+	if _, err := client.Write(req); err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	<-done
+}
+
+func TestReadSocks5RequestRejectsBadVersion(t *testing.T) {
+	client, server := net.Pipe()
+	defer client.Close()
+	defer server.Close()
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		br := bufio.NewReader(server)
+		_, err := readSocks5Request(server, br)
+		if err == nil || !strings.Contains(err.Error(), "bad version") {
+			t.Errorf("err = %v, want bad version", err)
+		}
+	}()
+	if _, err := client.Write([]byte{0x04, 0x01, 0x00}); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	<-done
+}
+
+func TestReadSocks5RequestRejectsNonConnectCommand(t *testing.T) {
+	client, server := net.Pipe()
+	defer client.Close()
+	defer server.Close()
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		br := bufio.NewReader(server)
+		_, err := readSocks5Request(server, br)
+		if err == nil || !strings.Contains(err.Error(), "unsupported command") {
+			t.Errorf("err = %v, want unsupported command", err)
+		}
+	}()
+
+	if err := writeSocks5Greeting(client); err != nil {
+		t.Fatalf("greeting: %v", err)
+	}
+	if _, err := client.Write([]byte{
+		socks5Version, socks5CmdUDP, 0x00, socks5AtypIPv4,
+		127, 0, 0, 1, 0, 53,
+	}); err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	reply := make([]byte, 10)
+	if _, err := io.ReadFull(client, reply); err != nil {
+		t.Fatalf("read command reply: %v", err)
+	}
+	if reply[1] != socks5CmdUnsup {
+		t.Fatalf("reply code = 0x%02x, want 0x07", reply[1])
+	}
+	<-done
+}
+
+func TestReadSocks5RequestRejectsNoAuthMethod(t *testing.T) {
+	client, server := net.Pipe()
+	defer client.Close()
+	defer server.Close()
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		br := bufio.NewReader(server)
+		_, err := readSocks5Request(server, br)
+		if err == nil || !strings.Contains(err.Error(), "no acceptable auth") {
+			t.Errorf("err = %v, want no acceptable auth", err)
+		}
+	}()
+	if _, err := client.Write([]byte{socks5Version, 0x01, 0x02}); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	reply := make([]byte, 2)
+	if _, err := io.ReadFull(client, reply); err != nil {
+		t.Fatalf("read method reply: %v", err)
+	}
+	if reply[1] != socks5NoAccept {
+		t.Fatalf("method reply = 0x%02x, want 0xff", reply[1])
+	}
+	<-done
+}
+
+// TestSocks5ServerTunnel drives a full SOCKS5 session through the
+// connect callback and verifies bytes flow both ways.
+func TestSocks5ServerTunnel(t *testing.T) {
+	echo, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("echo listen: %v", err)
+	}
+	defer echo.Close()
+	go func() {
+		for {
+			c, err := echo.Accept()
+			if err != nil {
+				return
+			}
+			go func() {
+				defer c.Close()
+				_, _ = io.Copy(c, c)
+			}()
+		}
+	}()
+	target := echo.Addr().String()
+
+	client, server := net.Pipe()
+	defer client.Close()
+	defer server.Close()
+	srv := &socks5Server{connect: func(_ context.Context, hostport string) (net.Conn, error) {
+		if hostport != target {
+			return nil, fmt.Errorf("dial %q, want %q", hostport, target)
+		}
+		return net.Dial("tcp", target)
+	}}
+	go srv.Serve(server, bufio.NewReader(server))
+
+	if err := writeSocks5Greeting(client); err != nil {
+		t.Fatalf("greeting: %v", err)
+	}
+	if err := writeSocks5Connect(client, "127.0.0.1", echo.Addr().(*net.TCPAddr).Port); err != nil {
+		t.Fatalf("connect: %v", err)
+	}
+	code, err := readSocks5ReplyCode(client)
+	if err != nil {
+		t.Fatalf("reply: %v", err)
+	}
+	if code != socks5Success {
+		t.Fatalf("reply code = 0x%02x, want 0x00", code)
+	}
+
+	if _, err := client.Write([]byte("ping")); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	got := make([]byte, 4)
+	if _, err := io.ReadFull(client, got); err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if string(got) != "ping" {
+		t.Fatalf("echo = %q, want ping", got)
+	}
+}
+
+// TestSocks5ServerDenied verifies a failed connect callback surfaces
+// as a generic SOCKS5 failure reply.
+func TestSocks5ServerDenied(t *testing.T) {
+	client, server := net.Pipe()
+	defer client.Close()
+	defer server.Close()
+	srv := &socks5Server{connect: func(_ context.Context, _ string) (net.Conn, error) {
+		return nil, errDestinationNotAllowed
+	}}
+	go srv.Serve(server, bufio.NewReader(server))
+
+	if err := writeSocks5Greeting(client); err != nil {
+		t.Fatalf("greeting: %v", err)
+	}
+	if err := writeSocks5Connect(client, "blocked.example", 443); err != nil {
+		t.Fatalf("connect: %v", err)
+	}
+	code, err := readSocks5ReplyCode(client)
+	if err != nil {
+		t.Fatalf("reply: %v", err)
+	}
+	if code != socks5Failure {
+		t.Fatalf("reply code = 0x%02x, want 0x01", code)
+	}
+}
+
+func TestSocks5ServerHandshakeTimeout(t *testing.T) {
+	old := socks5HandshakeTimeout
+	socks5HandshakeTimeout = 100 * time.Millisecond
+	defer func() { socks5HandshakeTimeout = old }()
+	client, server := net.Pipe()
+	defer client.Close()
+	defer server.Close()
+	srv := &socks5Server{connect: func(_ context.Context, _ string) (net.Conn, error) {
+		return nil, errors.New("must not dial")
+	}}
+	done := make(chan struct{})
+	go func() {
+		srv.Serve(server, bufio.NewReader(server))
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Serve did not close an idle connection")
+	}
+}
+
+// writeSocks5Greeting sends a no-auth greeting and reads the method
+// selection reply.
+func writeSocks5Greeting(c net.Conn) error {
+	if _, err := c.Write([]byte{socks5Version, 0x01, socks5NoAuth}); err != nil {
+		return err
+	}
+	reply := make([]byte, 2)
+	if _, err := io.ReadFull(c, reply); err != nil {
+		return err
+	}
+	if reply[0] != socks5Version || reply[1] != socks5NoAuth {
+		return fmt.Errorf("greeting reply = %v", reply)
+	}
+	return nil
+}
+
+// writeSocks5Connect sends a domain or IPv4 CONNECT request.
+func writeSocks5Connect(c net.Conn, host string, port int) error {
+	var req []byte
+	if ip := net.ParseIP(host); ip != nil && ip.To4() != nil {
+		req = []byte{socks5Version, socks5CmdConnect, 0x00, socks5AtypIPv4}
+		req = append(req, ip.To4()...)
+	} else {
+		req = []byte{socks5Version, socks5CmdConnect, 0x00, socks5AtypDomain, byte(len(host))}
+		req = append(req, host...)
+	}
+	req = append(req, byte(port>>8), byte(port))
+	_, err := c.Write(req)
+	return err
+}
+
+func readSocks5ReplyCode(c net.Conn) (byte, error) {
+	buf := make([]byte, 4)
+	if _, err := io.ReadFull(c, buf); err != nil {
+		return 0, err
+	}
+	if buf[0] != socks5Version {
+		return 0, fmt.Errorf("reply version = 0x%02x", buf[0])
+	}
+	atyp := buf[3]
+	addrLen := 4
+	if atyp == socks5AtypIPv6 {
+		addrLen = 16
+	} else if atyp == socks5AtypDomain {
+		addrLen = 1
+	}
+	skip := make([]byte, addrLen+2)
+	if _, err := io.ReadFull(c, skip); err != nil {
+		return 0, err
+	}
+	return buf[1], nil
+}
+
+// TestWriteSocks5ReplyShape is a tiny sanity check for the reply
+// layout used by readSocks5ReplyCode in the session tests.
+func TestWriteSocks5ReplyShape(t *testing.T) {
+	c, s := net.Pipe()
+	defer c.Close()
+	defer s.Close()
+	done := make(chan byte, 1)
+	go func() {
+		code, err := readSocks5ReplyCode(c)
+		if err != nil {
+			t.Errorf("read reply: %v", err)
+		}
+		done <- code
+	}()
+	if err := writeSocks5Reply(s, socks5Success, nil); err != nil {
+		t.Fatalf("write reply: %v", err)
+	}
+	if code := <-done; code != socks5Success {
+		t.Fatalf("code = 0x%02x, want 0x00", code)
+	}
+}

--- a/core/utils/net/socks5_test.go
+++ b/core/utils/net/socks5_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"net"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -212,6 +213,79 @@ func TestSocks5ServerTunnel(t *testing.T) {
 	}
 	if string(got) != "ping" {
 		t.Fatalf("echo = %q, want ping", got)
+	}
+}
+
+// TestSocks5ServerTunnelPipelinedData sends the greeting, CONNECT
+// request, and the first payload bytes in a single write, exactly as a
+// client that does not wait for the success reply would. The payload
+// must reach the upstream — regresses the classifier-buffered-byte
+// drop where the tunnel copied from conn instead of br.
+func TestSocks5ServerTunnelPipelinedData(t *testing.T) {
+	echo, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("echo listen: %v", err)
+	}
+	defer func() { _ = echo.Close() }()
+	go func() {
+		for {
+			c, err := echo.Accept()
+			if err != nil {
+				return
+			}
+			go func() {
+				defer func() { _ = c.Close() }()
+				_, _ = io.Copy(c, c)
+			}()
+		}
+	}()
+
+	client, server := net.Pipe()
+	defer func() { _ = client.Close() }()
+	defer func() { _ = server.Close() }()
+	srv := &socks5Server{connect: func(_ context.Context, hostport string) (net.Conn, error) {
+		return net.Dial("tcp", hostport)
+	}}
+	go srv.Serve(server, bufio.NewReader(server))
+
+	payload := []byte("pipelined-payload")
+	host, portStr, err := net.SplitHostPort(echo.Addr().String())
+	if err != nil {
+		t.Fatalf("split echo addr: %v", err)
+	}
+	port, err := strconv.Atoi(portStr)
+	if err != nil {
+		t.Fatalf("echo port: %v", err)
+	}
+	req := []byte{socks5Version, 0x01, socks5NoAuth}
+	req = append(req, socks5Version, socks5CmdConnect, 0x00, socks5AtypIPv4)
+	req = append(req, net.ParseIP(host).To4()...)
+	req = append(req, byte(port>>8), byte(port))
+	req = append(req, payload...)
+	if _, err := client.Write(req); err != nil {
+		t.Fatalf("write pipelined request: %v", err)
+	}
+
+	greet := make([]byte, 2)
+	if _, err := io.ReadFull(client, greet); err != nil {
+		t.Fatalf("greeting reply: %v", err)
+	}
+	if greet[1] != socks5NoAuth {
+		t.Fatalf("greeting reply = 0x%02x, want 0x00", greet[1])
+	}
+	code, err := readSocks5ReplyCode(client)
+	if err != nil {
+		t.Fatalf("connect reply: %v", err)
+	}
+	if code != socks5Success {
+		t.Fatalf("reply code = 0x%02x, want 0x00", code)
+	}
+	got := make([]byte, len(payload))
+	if _, err := io.ReadFull(client, got); err != nil {
+		t.Fatalf("echo: %v", err)
+	}
+	if string(got) != string(payload) {
+		t.Fatalf("echo = %q, want %q", got, payload)
 	}
 }
 


### PR DESCRIPTION
## Summary

Borrow three capabilities from [Anthropic's sandbox-runtime](https://github.com/anthropic-experimental/sandbox-runtime), which is the closest OSS project to our `core/sandbox` architecture (native OS primitives + host-side enforcement proxy, no containers):

### 1. SOCKS5 channel on the enforcement proxy
The proxy now multiplexes HTTP (plain + CONNECT) and SOCKS5 (CONNECT only, no-auth) on **one listener**, so non-HTTP TCP clients that honor `ALL_PROXY=socks5://...`, use `--socks5-hostname`, or an ssh `ProxyCommand` traverse the **same allow-list / upstream policy** as HTTP. Previously only proxy-aware HTTP clients were supported; raw TCP/UDP failed closed.

- Backends inject `HTTP(S)_PROXY=http://loopback:port` and `ALL_PROXY=socks5://loopback:port` (same port), so the bwrap bridge, the seatbelt loopback hole, and the Windows WFP proxy-port permit are unchanged.
- SOCKS5 requests go through the same `decide` → audit → `OnConnect` hook → dial path as HTTP CONNECT.

### 2. Deny reasons + port granularity
- `NetRule.Reason` (srt's `deniedDomainReasons`): model-facing explanation surfaced in HTTP denial bodies and `ProxyDecision` audit records.
- Rules and legacy `AllowHosts` entries support an optional `:port` suffix (`api.example.com:443`, `[::1]:8443`), matching srt's `allowedDomains` grammar.

### 3. Windows WFP behavioral fence verify
Mirroring `srt-win wfp verify`: after filter install, the isolation runs a real probe under the AppContainer token — a dial to a non-proxy loopback port must be blocked, and (allow-list/proxy modes) a dial to the proxy port must succeed. A mismatch fails closed before the isolation is handed out. This also closes a real test blind spot: existing Windows tests proved direct egress is blocked but never proved the proxy port is actually reachable through the WFP permit.

## Follow-ups (not in this PR)
- `denyRead`/`allowRead` filesystem semantics (read deny-then-allow surface).
- Violation attribution + stderr annotation keyed by exec/command.

## Testing
- New unit tests: SOCKS5 protocol (all address types, command/version rejection, timeout), matcher (`:port` suffix + reasons), env injection split on all three backends.
- New integration test: SOCKS5 + HTTP + unix-socket listener sharing one enforcement proxy, with deny-reason audit assertions.
- Local: `make ci`, `make lint`, `make release-check` all pass; Windows cross-compile/vet pass. The Windows lane will exercise `verifyFence` on every net-policy test.