### PR TITLE
chore(release): add core v0.2.2 changeset

### DIFF
--- a/.release/core-v0.2.2.json
+++ b/.release/core-v0.2.2.json
@@ -1,0 +1,9 @@
+{
+  "summary": "feat(core): windows sandbox backend — job-object process-tree lifecycle (kill-on-close, job-wide memory and CPU budgets, completion-port kill classification), ConPTY interactive sessions, opt-in write confinement with restricted low-integrity tokens, windows workspace path adaptation (case-insensitive matching, delete retry, rename guard, advisory permission-bit semantics), and MCP windows stdio transport with ctrl-break graceful shutdown; AppContainer-backed network policy on windows — NetDenyAll and NetAllowList/NetProxy via a capability-less lowbox token, WFP bind-layer (ALE_RESOURCE_ASSIGNMENT) TCP permit/block filters closing UDP/ICMP egress, hard ALE_AUTH_CONNECT / ALE_AUTH_RECV_ACCEPT permits pinning the container to a host-side loopback enforcement proxy (IsLoopback-scoped, deny reasons, host:port allow rules), a SOCKS5 proxy channel with HTTP(S)_PROXY/ALL_PROXY env injection, behavioral WFP fence verification, and a windows concurrency/stress test suite",
+  "releases": [
+    {
+      "module": "core",
+      "bump": "patch"
+    }
+  ]
+}


### PR DESCRIPTION
Adds the immutable `.release/core-v0.2.2.json` changeset for the next core release (0.2.1 -> 0.2.2, patch), covering the accumulated delta since `core/v0.2.1`:

- Windows sandbox backend: job-object lifecycle, ConPTY sessions, write confinement, workspace path adaptation, MCP stdio transport
- AppContainer-backed network policy: NetDenyAll / NetAllowList / NetProxy, WFP bind-layer and ALE permits, SOCKS5 proxy channel, deny reasons, WFP fence verify
- Windows concurrency/stress test suite

`make release-check` passes; `make release-plan` confirms tag `core/v0.2.2`. After this lands on main, the Release modules workflow will open the changelog PR; merging that publishes the tag.