### PR TITLE
feat(core/inference): per-model reasoning effort maps

### DIFF
--- a/core/inference/decision.go
+++ b/core/inference/decision.go
@@ -137,6 +137,17 @@ func (r CompileReport) Rejects(field FieldID) bool {
 	return false
 }
 
+// Dropped reports whether the field was dropped with a reason while the
+// compile otherwise succeeded.
+func (r CompileReport) Dropped(field FieldID) bool {
+	for _, decision := range r.Decisions {
+		if decision.Field == field && decision.Disposition == Dropped {
+			return true
+		}
+	}
+	return false
+}
+
 func (r CompileReport) Metadata(model ModelRef) Metadata {
 	return Metadata{
 		Model:     model.ID,

--- a/core/inference/generate_intent.go
+++ b/core/inference/generate_intent.go
@@ -321,10 +321,9 @@ func (i VideoIntent) Validate() error {
 // knob. It is a wire-level string enum, but it is an inference concept
 // (not a message part, not a tool DTO) so it lives here rather than in
 // [github.com/GizClaw/flowcraft/core/message]. The five constants are the
-// portable ordinal ladder every request may name; each driver maps the
-// canonical levels onto its own model dialects privately (see
-// ResolveReasoningEffort), so no model-declared mode vocabulary lives in
-// the platform capability model.
+// portable ordinal ladder every request may name; each model declares how
+// the canonical levels map onto its own wire levels in
+// ModelCapabilities.Reasoning.EffortMap.
 type ReasoningEffort string
 
 const (
@@ -334,68 +333,6 @@ const (
 	ReasoningHigh    ReasoningEffort = "high"
 	ReasoningXHigh   ReasoningEffort = "xhigh"
 )
-
-// ResolveReasoningEffort maps a canonical reasoning effort onto a model's
-// private depth ladder. The ladder is the ordered set of wire tokens the
-// model accepts (for example ["low", "high", "max"] on kimi-k3); each
-// driver owns its ladder, so the same canonical effort can resolve to
-// different wire tokens per provider. Canonical tokens carry fixed ladder
-// ranks (minimal=0, low=1, medium=2, high=3, xhigh=4); a non-canonical
-// ladder entry gets one rung above its predecessor. A canonical effort
-// resolves to the first rung at or above its rank, or the top rung when it
-// sits above the whole ladder. The second result reports whether the
-// resolution is exact; a false value means the driver should report the
-// quantization (for example through the field ledger). An empty ladder or
-// a non-canonical effort resolves to ("", false).
-func ResolveReasoningEffort(
-	effort ReasoningEffort,
-	ladder []ReasoningEffort,
-) (ReasoningEffort, bool) {
-	target, ok := reasoningRank(effort)
-	if !ok || len(ladder) == 0 {
-		return "", false
-	}
-	for _, rung := range ladder {
-		if rung == effort {
-			return effort, true
-		}
-	}
-	anchor := -1
-	previous := -1
-	for index, rung := range ladder {
-		rank := previous + 1
-		if fixed, ok := reasoningRank(rung); ok {
-			rank = fixed
-		}
-		if anchor < 0 && rank >= target {
-			anchor = index
-		}
-		previous = rank
-	}
-	if anchor < 0 {
-		anchor = len(ladder) - 1
-	}
-	return ladder[anchor], false
-}
-
-// reasoningRank returns a canonical effort's fixed position on the
-// portable ladder.
-func reasoningRank(effort ReasoningEffort) (int, bool) {
-	switch effort {
-	case ReasoningMinimal:
-		return 0, true
-	case ReasoningLow:
-		return 1, true
-	case ReasoningMedium:
-		return 2, true
-	case ReasoningHigh:
-		return 3, true
-	case ReasoningXHigh:
-		return 4, true
-	default:
-		return 0, false
-	}
-}
 
 // FinishReason tells the caller why a generate call stopped. It is
 // part of the inference response envelope, not a property of a

--- a/core/inference/generate_intent.go
+++ b/core/inference/generate_intent.go
@@ -177,7 +177,8 @@ func (i TextIntent) Validate() error {
 		return fmt.Errorf("top_p must be between 0 and 1")
 	}
 	switch i.ReasoningEffort {
-	case "", ReasoningLow, ReasoningMedium, ReasoningHigh:
+	case "", ReasoningMinimal, ReasoningLow, ReasoningMedium,
+		ReasoningHigh, ReasoningXHigh:
 	default:
 		return fmt.Errorf("unknown reasoning effort %q", i.ReasoningEffort)
 	}
@@ -317,16 +318,84 @@ func (i VideoIntent) Validate() error {
 }
 
 // ReasoningEffort is the request-side "how hard should the model think"
-// knob. It is a wire-level string enum, but it is an inference
-// concept (not a message part, not a tool DTO) so it lives here
-// rather than in [github.com/GizClaw/flowcraft/core/message].
+// knob. It is a wire-level string enum, but it is an inference concept
+// (not a message part, not a tool DTO) so it lives here rather than in
+// [github.com/GizClaw/flowcraft/core/message]. The five constants are the
+// portable ordinal ladder every request may name; each driver maps the
+// canonical levels onto its own model dialects privately (see
+// ResolveReasoningEffort), so no model-declared mode vocabulary lives in
+// the platform capability model.
 type ReasoningEffort string
 
 const (
-	ReasoningLow    ReasoningEffort = "low"
-	ReasoningMedium ReasoningEffort = "medium"
-	ReasoningHigh   ReasoningEffort = "high"
+	ReasoningMinimal ReasoningEffort = "minimal"
+	ReasoningLow     ReasoningEffort = "low"
+	ReasoningMedium  ReasoningEffort = "medium"
+	ReasoningHigh    ReasoningEffort = "high"
+	ReasoningXHigh   ReasoningEffort = "xhigh"
 )
+
+// ResolveReasoningEffort maps a canonical reasoning effort onto a model's
+// private depth ladder. The ladder is the ordered set of wire tokens the
+// model accepts (for example ["low", "high", "max"] on kimi-k3); each
+// driver owns its ladder, so the same canonical effort can resolve to
+// different wire tokens per provider. Canonical tokens carry fixed ladder
+// ranks (minimal=0, low=1, medium=2, high=3, xhigh=4); a non-canonical
+// ladder entry gets one rung above its predecessor. A canonical effort
+// resolves to the first rung at or above its rank, or the top rung when it
+// sits above the whole ladder. The second result reports whether the
+// resolution is exact; a false value means the driver should report the
+// quantization (for example through the field ledger). An empty ladder or
+// a non-canonical effort resolves to ("", false).
+func ResolveReasoningEffort(
+	effort ReasoningEffort,
+	ladder []ReasoningEffort,
+) (ReasoningEffort, bool) {
+	target, ok := reasoningRank(effort)
+	if !ok || len(ladder) == 0 {
+		return "", false
+	}
+	for _, rung := range ladder {
+		if rung == effort {
+			return effort, true
+		}
+	}
+	anchor := -1
+	previous := -1
+	for index, rung := range ladder {
+		rank := previous + 1
+		if fixed, ok := reasoningRank(rung); ok {
+			rank = fixed
+		}
+		if anchor < 0 && rank >= target {
+			anchor = index
+		}
+		previous = rank
+	}
+	if anchor < 0 {
+		anchor = len(ladder) - 1
+	}
+	return ladder[anchor], false
+}
+
+// reasoningRank returns a canonical effort's fixed position on the
+// portable ladder.
+func reasoningRank(effort ReasoningEffort) (int, bool) {
+	switch effort {
+	case ReasoningMinimal:
+		return 0, true
+	case ReasoningLow:
+		return 1, true
+	case ReasoningMedium:
+		return 2, true
+	case ReasoningHigh:
+		return 3, true
+	case ReasoningXHigh:
+		return 4, true
+	default:
+		return 0, false
+	}
+}
 
 // FinishReason tells the caller why a generate call stopped. It is
 // part of the inference response envelope, not a property of a

--- a/core/inference/generate_intent_test.go
+++ b/core/inference/generate_intent_test.go
@@ -68,101 +68,92 @@ func TestTextIntentReasoningEffortValidation(t *testing.T) {
 	}
 }
 
-func TestResolveReasoningEffort(t *testing.T) {
-	for _, tc := range []struct {
-		name   string
-		effort ReasoningEffort
-		ladder []ReasoningEffort
-		want   ReasoningEffort
-		exact  bool
-	}{
-		{
-			name:   "openai ladder is the canonical five",
-			effort: ReasoningXHigh,
-			ladder: []ReasoningEffort{
-				ReasoningMinimal, ReasoningLow, ReasoningMedium,
-				ReasoningHigh, ReasoningXHigh,
+func TestReasoningCapabilityValidate(t *testing.T) {
+	kimiMap := map[ReasoningEffort]string{
+		ReasoningMinimal: "low",
+		ReasoningLow:     "low",
+		ReasoningMedium:  "high",
+		ReasoningHigh:    "high",
+		ReasoningXHigh:   "max",
+	}
+	if err := (ReasoningCapability{
+		Kind:      ReasoningAlways,
+		EffortMap: kimiMap,
+	}).Validate(); err != nil {
+		t.Fatalf("valid capability: %v", err)
+	}
+	if err := (ReasoningCapability{Kind: ReasoningToggle}).Validate(); err != nil {
+		t.Fatalf("binary capability: %v", err)
+	}
+	for name, capability := range map[string]ReasoningCapability{
+		"map without kind": {
+			EffortMap: kimiMap,
+		},
+		"missing canonical key": {
+			Kind: ReasoningAlways,
+			EffortMap: map[ReasoningEffort]string{
+				ReasoningMinimal: "low",
+				ReasoningLow:     "low",
+				ReasoningMedium:  "high",
+				ReasoningHigh:    "high",
 			},
-			want:  ReasoningXHigh,
-			exact: true,
 		},
-		{
-			name:   "kimi ladder exact low and high",
-			effort: ReasoningLow,
-			ladder: []ReasoningEffort{ReasoningLow, ReasoningHigh, "max"},
-			want:   ReasoningLow,
-			exact:  true,
-		},
-		{
-			name:   "kimi ladder maps minimal to low",
-			effort: ReasoningMinimal,
-			ladder: []ReasoningEffort{ReasoningLow, ReasoningHigh, "max"},
-			want:   ReasoningLow,
-		},
-		{
-			name:   "kimi ladder maps medium to high",
-			effort: ReasoningMedium,
-			ladder: []ReasoningEffort{ReasoningLow, ReasoningHigh, "max"},
-			want:   ReasoningHigh,
-		},
-		{
-			name:   "kimi ladder maps xhigh to max",
-			effort: ReasoningXHigh,
-			ladder: []ReasoningEffort{ReasoningLow, ReasoningHigh, "max"},
-			want:   "max",
-		},
-		{
-			name:   "qwen ladder maps high to xhigh",
-			effort: ReasoningHigh,
-			ladder: []ReasoningEffort{
-				ReasoningLow, ReasoningMedium, ReasoningXHigh,
+		"non-canonical key": {
+			Kind: ReasoningAlways,
+			EffortMap: map[ReasoningEffort]string{
+				ReasoningMinimal: "low",
+				ReasoningLow:     "low",
+				ReasoningMedium:  "high",
+				ReasoningHigh:    "high",
+				ReasoningXHigh:   "max",
+				"max":            "max",
 			},
-			want: ReasoningXHigh,
 		},
-		{
-			name:   "qwen ladder maps minimal to low",
-			effort: ReasoningMinimal,
-			ladder: []ReasoningEffort{
-				ReasoningLow, ReasoningMedium, ReasoningXHigh,
+		"invalid value": {
+			Kind: ReasoningAlways,
+			EffortMap: map[ReasoningEffort]string{
+				ReasoningMinimal: "",
+				ReasoningLow:     "low",
+				ReasoningMedium:  "high",
+				ReasoningHigh:    "high",
+				ReasoningXHigh:   "max",
 			},
-			want: ReasoningLow,
-		},
-		{
-			name:   "deepseek ladder drops minimal to low",
-			effort: ReasoningMinimal,
-			ladder: []ReasoningEffort{
-				ReasoningLow, ReasoningMedium, ReasoningHigh, ReasoningXHigh,
-			},
-			want: ReasoningLow,
-		},
-		{
-			name:   "anthropic ladder keeps xhigh exact",
-			effort: ReasoningXHigh,
-			ladder: []ReasoningEffort{
-				ReasoningLow, ReasoningMedium, ReasoningHigh,
-				ReasoningXHigh, "max",
-			},
-			want:  ReasoningXHigh,
-			exact: true,
-		},
-		{
-			name:   "effort above ladder falls back to the top",
-			effort: ReasoningXHigh,
-			ladder: []ReasoningEffort{ReasoningLow, ReasoningMedium},
-			want:   ReasoningMedium,
-		},
-		{
-			name:   "empty ladder resolves nothing",
-			effort: ReasoningHigh,
-			want:   "",
 		},
 	} {
-		got, exact := ResolveReasoningEffort(tc.effort, tc.ladder)
-		if got != tc.want || exact != tc.exact {
+		if err := capability.Validate(); err == nil {
+			t.Fatalf("%s unexpectedly accepted", name)
+		}
+	}
+}
+
+func TestReasoningCapabilityResolveEffort(t *testing.T) {
+	capability := ReasoningCapability{
+		Kind: ReasoningAlways,
+		EffortMap: map[ReasoningEffort]string{
+			ReasoningMinimal: "low",
+			ReasoningLow:     "low",
+			ReasoningMedium:  "high",
+			ReasoningHigh:    "high",
+			ReasoningXHigh:   "max",
+		},
+	}
+	for _, tc := range []struct {
+		effort ReasoningEffort
+		want   string
+	}{
+		{effort: ReasoningMinimal, want: "low"},
+		{effort: ReasoningMedium, want: "high"},
+		{effort: ReasoningXHigh, want: "max"},
+	} {
+		mode, ok := capability.ResolveEffort(tc.effort)
+		if !ok || mode != tc.want {
 			t.Fatalf(
-				"%s: resolve(%q) = (%q, %v), want (%q, %v)",
-				tc.name, tc.effort, got, exact, tc.want, tc.exact,
+				"resolve(%q) = (%q, %v), want (%q, true)",
+				tc.effort, mode, ok, tc.want,
 			)
 		}
+	}
+	if _, ok := capability.ResolveEffort("bogus"); ok {
+		t.Fatal("non-canonical effort unexpectedly resolved")
 	}
 }

--- a/core/inference/generate_intent_test.go
+++ b/core/inference/generate_intent_test.go
@@ -32,3 +32,137 @@ func TestImageIntentCloneCopiesQuality(t *testing.T) {
 		t.Fatal("clone mutated the source intent")
 	}
 }
+
+func TestTextIntentReasoningEffortValidation(t *testing.T) {
+	for _, effort := range []ReasoningEffort{
+		"",
+		ReasoningMinimal,
+		ReasoningLow,
+		ReasoningMedium,
+		ReasoningHigh,
+		ReasoningXHigh,
+	} {
+		intent := TextIntent{ReasoningEffort: effort}
+		if err := intent.Validate(); err != nil {
+			t.Fatalf("effort %q: %v", effort, err)
+		}
+	}
+	for _, effort := range []ReasoningEffort{
+		"max",
+		"bogus",
+		" ",
+		"low high",
+	} {
+		intent := TextIntent{ReasoningEffort: effort}
+		if err := intent.Validate(); err == nil {
+			t.Fatalf("effort %q unexpectedly accepted", effort)
+		}
+	}
+	disabled := false
+	intent := TextIntent{
+		ReasoningEnabled: &disabled,
+		ReasoningEffort:  ReasoningHigh,
+	}
+	if err := intent.Validate(); err == nil {
+		t.Fatal("disabled reasoning with an effort unexpectedly accepted")
+	}
+}
+
+func TestResolveReasoningEffort(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		effort ReasoningEffort
+		ladder []ReasoningEffort
+		want   ReasoningEffort
+		exact  bool
+	}{
+		{
+			name:   "openai ladder is the canonical five",
+			effort: ReasoningXHigh,
+			ladder: []ReasoningEffort{
+				ReasoningMinimal, ReasoningLow, ReasoningMedium,
+				ReasoningHigh, ReasoningXHigh,
+			},
+			want:  ReasoningXHigh,
+			exact: true,
+		},
+		{
+			name:   "kimi ladder exact low and high",
+			effort: ReasoningLow,
+			ladder: []ReasoningEffort{ReasoningLow, ReasoningHigh, "max"},
+			want:   ReasoningLow,
+			exact:  true,
+		},
+		{
+			name:   "kimi ladder maps minimal to low",
+			effort: ReasoningMinimal,
+			ladder: []ReasoningEffort{ReasoningLow, ReasoningHigh, "max"},
+			want:   ReasoningLow,
+		},
+		{
+			name:   "kimi ladder maps medium to high",
+			effort: ReasoningMedium,
+			ladder: []ReasoningEffort{ReasoningLow, ReasoningHigh, "max"},
+			want:   ReasoningHigh,
+		},
+		{
+			name:   "kimi ladder maps xhigh to max",
+			effort: ReasoningXHigh,
+			ladder: []ReasoningEffort{ReasoningLow, ReasoningHigh, "max"},
+			want:   "max",
+		},
+		{
+			name:   "qwen ladder maps high to xhigh",
+			effort: ReasoningHigh,
+			ladder: []ReasoningEffort{
+				ReasoningLow, ReasoningMedium, ReasoningXHigh,
+			},
+			want: ReasoningXHigh,
+		},
+		{
+			name:   "qwen ladder maps minimal to low",
+			effort: ReasoningMinimal,
+			ladder: []ReasoningEffort{
+				ReasoningLow, ReasoningMedium, ReasoningXHigh,
+			},
+			want: ReasoningLow,
+		},
+		{
+			name:   "deepseek ladder drops minimal to low",
+			effort: ReasoningMinimal,
+			ladder: []ReasoningEffort{
+				ReasoningLow, ReasoningMedium, ReasoningHigh, ReasoningXHigh,
+			},
+			want: ReasoningLow,
+		},
+		{
+			name:   "anthropic ladder keeps xhigh exact",
+			effort: ReasoningXHigh,
+			ladder: []ReasoningEffort{
+				ReasoningLow, ReasoningMedium, ReasoningHigh,
+				ReasoningXHigh, "max",
+			},
+			want:  ReasoningXHigh,
+			exact: true,
+		},
+		{
+			name:   "effort above ladder falls back to the top",
+			effort: ReasoningXHigh,
+			ladder: []ReasoningEffort{ReasoningLow, ReasoningMedium},
+			want:   ReasoningMedium,
+		},
+		{
+			name:   "empty ladder resolves nothing",
+			effort: ReasoningHigh,
+			want:   "",
+		},
+	} {
+		got, exact := ResolveReasoningEffort(tc.effort, tc.ladder)
+		if got != tc.want || exact != tc.exact {
+			t.Fatalf(
+				"%s: resolve(%q) = (%q, %v), want (%q, %v)",
+				tc.name, tc.effort, got, exact, tc.want, tc.exact,
+			)
+		}
+	}
+}

--- a/core/inference/model.go
+++ b/core/inference/model.go
@@ -234,6 +234,21 @@ func (r *ReasoningCapability) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+// MarshalJSON keeps the legacy string form when no effort map is declared,
+// so a deployment that decoded `reasoning: "toggle"` re-serializes to the
+// same string instead of leaking the new object shape. Capabilities with an
+// effort map marshal as the object form.
+func (r ReasoningCapability) MarshalJSON() ([]byte, error) {
+	if r.IsZero() {
+		return []byte(`{}`), nil
+	}
+	if len(r.EffortMap) == 0 {
+		return json.Marshal(r.Kind)
+	}
+	type alias ReasoningCapability
+	return json.Marshal(alias(r))
+}
+
 // validateEffortToken checks that a wire-level token is well-formed:
 // non-empty, at most 64 characters, and free of whitespace and control
 // characters.

--- a/core/inference/model.go
+++ b/core/inference/model.go
@@ -1,8 +1,11 @@
 package inference
 
 import (
+	"encoding/json"
 	"fmt"
+	"maps"
 	"time"
+	"unicode"
 
 	"github.com/GizClaw/flowcraft/core/message"
 )
@@ -133,6 +136,125 @@ func (k ReasoningKind) Validate() error {
 	}
 }
 
+// ReasoningCapability declares a model's reasoning control surface. Kind
+// keeps the switch semantics (none / always / toggle); EffortMap declares
+// exactly how the five canonical ReasoningEffort levels map onto this
+// model's own wire levels (for example kimi-k3 maps xhigh to "max"). A
+// non-nil EffortMap must cover all five canonical levels; an empty map on
+// a reasoning model means binary thinking with no depth dial.
+type ReasoningCapability struct {
+	Kind ReasoningKind `json:"kind,omitempty"`
+	// EffortMap maps each canonical ReasoningEffort onto the model's wire
+	// level token. Values may be model-specific (for example "max" on
+	// kimi-k3); a value different from its key means the canonical level
+	// folds onto another level and compilers report the drop.
+	EffortMap map[ReasoningEffort]string `json:"effort_map,omitempty"`
+}
+
+// IsZero reports whether the capability is the zero declaration.
+func (r ReasoningCapability) IsZero() bool {
+	return r.Kind == "" && len(r.EffortMap) == 0
+}
+
+// Validate checks the capability for coherence: the kind must be valid, a
+// none kind cannot carry an effort map, and a non-empty map must cover all
+// five canonical levels with well-formed wire tokens.
+func (r ReasoningCapability) Validate() error {
+	if err := r.Kind.Validate(); err != nil {
+		return err
+	}
+	if len(r.EffortMap) == 0 {
+		return nil
+	}
+	if r.Kind == ReasoningNone {
+		return fmt.Errorf("reasoning effort map requires a reasoning capability")
+	}
+	for _, effort := range []ReasoningEffort{
+		ReasoningMinimal,
+		ReasoningLow,
+		ReasoningMedium,
+		ReasoningHigh,
+		ReasoningXHigh,
+	} {
+		mode, ok := r.EffortMap[effort]
+		if !ok {
+			return fmt.Errorf(
+				"reasoning effort map misses canonical level %q",
+				effort,
+			)
+		}
+		if err := validateEffortToken(mode); err != nil {
+			return fmt.Errorf(
+				"reasoning effort map %q: %w",
+				effort,
+				err,
+			)
+		}
+	}
+	for effort := range r.EffortMap {
+		switch effort {
+		case ReasoningMinimal, ReasoningLow, ReasoningMedium,
+			ReasoningHigh, ReasoningXHigh:
+		default:
+			return fmt.Errorf(
+				"reasoning effort map has non-canonical key %q",
+				effort,
+			)
+		}
+	}
+	return nil
+}
+
+// ResolveEffort returns the wire level this model declares for a canonical
+// effort. The boolean reports whether the map declares the level at all;
+// validated maps always do.
+func (r ReasoningCapability) ResolveEffort(
+	effort ReasoningEffort,
+) (string, bool) {
+	mode, ok := r.EffortMap[effort]
+	return mode, ok
+}
+
+// UnmarshalJSON accepts both the legacy string form ("toggle") and the
+// object form ({"kind":"toggle","effort_map":{...}}) so existing
+// deployment specs keep decoding.
+func (r *ReasoningCapability) UnmarshalJSON(data []byte) error {
+	var kind ReasoningKind
+	if err := json.Unmarshal(data, &kind); err == nil {
+		r.Kind = kind
+		r.EffortMap = nil
+		return nil
+	}
+	type alias ReasoningCapability
+	var decoded alias
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		return err
+	}
+	*r = ReasoningCapability(decoded)
+	return nil
+}
+
+// validateEffortToken checks that a wire-level token is well-formed:
+// non-empty, at most 64 characters, and free of whitespace and control
+// characters.
+func validateEffortToken(token string) error {
+	if token == "" {
+		return fmt.Errorf("reasoning level must not be empty")
+	}
+	if len(token) > 64 {
+		return fmt.Errorf("reasoning level %q exceeds 64 characters", token)
+	}
+	for _, r := range token {
+		if unicode.IsSpace(r) || unicode.IsControl(r) {
+			return fmt.Errorf(
+				"reasoning level %q contains whitespace or control characters",
+				token,
+			)
+		}
+	}
+	return nil
+}
+
 // ModelCapabilities describes optional feature bits and content kinds a model
 // can serve. Zero is the conservative declaration: every feature the struct
 // omits is treated as unsupported until a provider declares it.
@@ -151,8 +273,10 @@ type ModelCapabilities struct {
 	Outputs []message.PartKind `json:"outputs,omitempty"`
 	// Reasoning declares the model's reasoning control capability: whether it
 	// has a reasoning channel and whether reasoning can be switched or its
-	// effort adjusted. Empty (ReasoningNone) is the conservative default.
-	Reasoning ReasoningKind `json:"reasoning,omitempty"`
+	// effort adjusted, and how the canonical effort levels map onto the
+	// model's own wire levels. Empty (ReasoningNone) is the conservative
+	// default.
+	Reasoning ReasoningCapability `json:"reasoning,omitzero"`
 	// HostedWebSearch marks provider-side web_search tool support. It is
 	// discovery metadata for hosts; the search configuration itself still
 	// rides on GenerateRequest.Extensions as a provider GenerateOptions
@@ -187,7 +311,20 @@ func (c ModelCapabilities) WithOutputs(kinds ...message.PartKind) ModelCapabilit
 // WithReasoning returns a copy of the capabilities with the reasoning control
 // capability set.
 func (c ModelCapabilities) WithReasoning(kind ReasoningKind) ModelCapabilities {
-	c.Reasoning = kind
+	c.Reasoning.Kind = kind
+	return c
+}
+
+// WithReasoningEffortMap returns a copy of the capabilities with the model's
+// canonical-to-wire effort map set. The result shares no backing map with
+// the receiver or the caller.
+func (c ModelCapabilities) WithReasoningEffortMap(
+	efforts map[ReasoningEffort]string,
+) ModelCapabilities {
+	if efforts != nil {
+		efforts = maps.Clone(efforts)
+	}
+	c.Reasoning.EffortMap = efforts
 	return c
 }
 

--- a/core/inference/model.go
+++ b/core/inference/model.go
@@ -289,6 +289,9 @@ type ModelCapabilities struct {
 func (c ModelCapabilities) Clone() ModelCapabilities {
 	c.Inputs = append([]message.PartKind(nil), c.Inputs...)
 	c.Outputs = append([]message.PartKind(nil), c.Outputs...)
+	if c.Reasoning.EffortMap != nil {
+		c.Reasoning.EffortMap = maps.Clone(c.Reasoning.EffortMap)
+	}
 	return c
 }
 

--- a/core/inference/model_test.go
+++ b/core/inference/model_test.go
@@ -95,13 +95,13 @@ func TestModelCapabilitiesValidate(t *testing.T) {
 		inference.ReasoningToggle,
 	} {
 		if err := (inference.ModelCapabilities{
-			Reasoning: reasoning,
+			Reasoning: inference.ReasoningCapability{Kind: reasoning},
 		}).Validate(); err != nil {
 			t.Fatalf("reasoning %q: %v", reasoning, err)
 		}
 	}
 	if err := (inference.ModelCapabilities{
-		Reasoning: "sometimes",
+		Reasoning: inference.ReasoningCapability{Kind: "sometimes"},
 	}).Validate(); err == nil {
 		t.Fatal("unknown reasoning kind unexpectedly accepted")
 	}
@@ -156,12 +156,80 @@ func TestModelCapabilitiesBuilders(t *testing.T) {
 	if !reflect.DeepEqual(capabilities.Outputs, []message.PartKind{message.PartText}) {
 		t.Fatalf("outputs = %v", capabilities.Outputs)
 	}
-	if capabilities.Reasoning != inference.ReasoningAlways ||
+	if capabilities.Reasoning.Kind != inference.ReasoningAlways ||
 		!capabilities.HostedWebSearch {
 		t.Fatalf("capabilities = %+v", capabilities)
 	}
 	if err := capabilities.Validate(); err != nil {
 		t.Fatalf("Validate: %v", err)
+	}
+}
+
+func TestReasoningCapabilityJSONBackwardCompat(t *testing.T) {
+	var legacy inference.ReasoningCapability
+	if err := json.Unmarshal(
+		[]byte(`"toggle"`),
+		&legacy,
+	); err != nil {
+		t.Fatalf("legacy string form: %v", err)
+	}
+	if legacy.Kind != inference.ReasoningToggle ||
+		len(legacy.EffortMap) != 0 {
+		t.Fatalf("legacy decode = %+v", legacy)
+	}
+
+	var object inference.ReasoningCapability
+	if err := json.Unmarshal([]byte(`{
+		"kind": "always",
+		"effort_map": {
+			"minimal": "low",
+			"low": "low",
+			"medium": "high",
+			"high": "high",
+			"xhigh": "max"
+		}
+	}`), &object); err != nil {
+		t.Fatalf("object form: %v", err)
+	}
+	if object.Kind != inference.ReasoningAlways ||
+		object.EffortMap[inference.ReasoningXHigh] != "max" {
+		t.Fatalf("object decode = %+v", object)
+	}
+	if err := object.Validate(); err != nil {
+		t.Fatalf("object Validate: %v", err)
+	}
+
+	encoded, err := json.Marshal(inference.ModelCapabilities{
+		Reasoning: object,
+	})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if !strings.Contains(string(encoded), `"kind":"always"`) ||
+		!strings.Contains(string(encoded), `"xhigh":"max"`) {
+		t.Fatalf("marshal object = %s", encoded)
+	}
+	if encodedZero, err := json.Marshal(inference.ModelCapabilities{}); err != nil ||
+		strings.Contains(string(encodedZero), `"reasoning"`) {
+		t.Fatalf("zero reasoning should be omitted, got %s", encodedZero)
+	}
+}
+
+func TestModelCapabilitiesLegacyReasoningJSON(t *testing.T) {
+	var capabilities inference.ModelCapabilities
+	if err := json.Unmarshal([]byte(`{
+		"inputs": ["text"],
+		"outputs": ["text"],
+		"reasoning": "toggle"
+	}`), &capabilities); err != nil {
+		t.Fatalf("legacy capabilities decode: %v", err)
+	}
+	if capabilities.Reasoning.Kind != inference.ReasoningToggle ||
+		len(capabilities.Reasoning.EffortMap) != 0 {
+		t.Fatalf("legacy capabilities decode = %+v", capabilities.Reasoning)
+	}
+	if err := capabilities.Validate(); err != nil {
+		t.Fatalf("legacy capabilities Validate: %v", err)
 	}
 }
 

--- a/core/inference/model_test.go
+++ b/core/inference/model_test.go
@@ -242,6 +242,26 @@ func TestModelCapabilitiesBuildersDoNotAlias(t *testing.T) {
 	_ = extended
 }
 
+func TestModelCapabilitiesCloneDoesNotAliasEffortMap(t *testing.T) {
+	capabilities := inference.ModelCapabilities{
+		Reasoning: inference.ReasoningCapability{
+			Kind: inference.ReasoningToggle,
+			EffortMap: map[inference.ReasoningEffort]string{
+				inference.ReasoningMinimal: "low",
+				inference.ReasoningLow:     "low",
+				inference.ReasoningMedium:  "high",
+				inference.ReasoningHigh:    "high",
+				inference.ReasoningXHigh:   "max",
+			},
+		},
+	}
+	clone := capabilities.Clone()
+	clone.Reasoning.EffortMap[inference.ReasoningLow] = "max"
+	if got := capabilities.Reasoning.EffortMap[inference.ReasoningLow]; got != "low" {
+		t.Fatalf("clone mutated original effort map: low = %q, want low", got)
+	}
+}
+
 func TestModelDescriptorClonePreservesCapabilities(t *testing.T) {
 	original := inference.ModelDescriptor{
 		ID:         inference.ModelID{Provider: "openai", Name: "gpt-x"},

--- a/core/inference/model_test.go
+++ b/core/inference/model_test.go
@@ -177,6 +177,13 @@ func TestReasoningCapabilityJSONBackwardCompat(t *testing.T) {
 		len(legacy.EffortMap) != 0 {
 		t.Fatalf("legacy decode = %+v", legacy)
 	}
+	legacyEncoded, err := json.Marshal(legacy)
+	if err != nil {
+		t.Fatalf("legacy marshal: %v", err)
+	}
+	if string(legacyEncoded) != `"toggle"` {
+		t.Fatalf("legacy marshal = %s, want \"toggle\"", legacyEncoded)
+	}
 
 	var object inference.ReasoningCapability
 	if err := json.Unmarshal([]byte(`{
@@ -230,6 +237,13 @@ func TestModelCapabilitiesLegacyReasoningJSON(t *testing.T) {
 	}
 	if err := capabilities.Validate(); err != nil {
 		t.Fatalf("legacy capabilities Validate: %v", err)
+	}
+	encoded, err := json.Marshal(capabilities)
+	if err != nil {
+		t.Fatalf("legacy capabilities marshal: %v", err)
+	}
+	if !strings.Contains(string(encoded), `"reasoning":"toggle"`) {
+		t.Fatalf("legacy capabilities marshal = %s, want string reasoning", encoded)
 	}
 }
 

--- a/docs/guides/graph.md
+++ b/docs/guides/graph.md
@@ -169,7 +169,8 @@ Behavior:
 - `intent` is the authoritative execution envelope and covers every
   generation modality: text controls (`response`, `max_output_tokens`,
   `tools`, `tool_choice`, `temperature`, `top_p`, `reasoning_enabled`,
-  `reasoning_effort`), image (`size`, `aspect_ratio`, `count`, `seed`,
+  `reasoning_effort` (`minimal|low|medium|high|xhigh`), image (`size`,
+  `aspect_ratio`, `count`, `seed`,
   `output_format`, `delivery`, `quality`), audio/tts (`voice`, `format`, `speed`,
   `count`), and video (`duration_millis`, `resolution`, `aspect_ratio`,
   `seed`, `watermark`). When `intent` is absent the node defaults to plain

--- a/driver/anthropic/catalog.go
+++ b/driver/anthropic/catalog.go
@@ -11,15 +11,17 @@ import (
 
 // catalogEntry describes one model's compile-time capabilities.
 // capabilities is the single capability fact source: input/output content
-// kinds and the reasoning control capability. reasoningLevels is a control
-// capability that no capability kind expresses and stays a separate flag.
+// kinds and the reasoning control capability. efforts is the model's
+// private reasoning-effort dial: the wire tokens the thinking endpoint
+// accepts, ordered as an ascending depth ladder.
 type catalogEntry struct {
 	capabilities inference.ModelCapabilities
-	// reasoningLevels marks models whose thinking endpoint accepts effort
-	// levels; models without it enable thinking at platform-chosen depth.
-	reasoningLevels bool
-	deprecated      bool
-	replacement     string
+	// efforts lists the effort tokens this model's thinking endpoint
+	// accepts (low/medium/high/xhigh/max per the Claude docs); nil means
+	// binary thinking at platform-chosen depth.
+	efforts     []inference.ReasoningEffort
+	deprecated  bool
+	replacement string
 	// maxInputTokens caps the input context (system + messages + tools)
 	// in tokens; zero means undeclared. Values mirror the context window
 	// published on https://platform.claude.com/docs/en/about-claude/models.
@@ -52,6 +54,18 @@ func generateChatCapabilities() inference.ModelCapabilities {
 	}
 }
 
+// claudeEfforts is the effort dial shared by every Claude model that
+// accepts effort levels, aligned with the adaptive-thinking effort
+// parameter (low/medium/high/xhigh/max). "max" is a model-side extra
+// beyond the canonical ladder and is never requested by name.
+var claudeEfforts = []inference.ReasoningEffort{
+	inference.ReasoningLow,
+	inference.ReasoningMedium,
+	inference.ReasoningHigh,
+	inference.ReasoningXHigh,
+	"max",
+}
+
 // catalog is the built-in model list, aligned with the Claude lineup of
 // July 2026. Fable 5 and Mythos 5 keep adaptive thinking always on (the API
 // rejects thinking: disabled); the rest of the family can toggle thinking.
@@ -60,8 +74,8 @@ var catalog = map[string]catalogEntry{
 		capabilities: generateChatCapabilities().
 			WithInputs(message.PartImage).
 			WithReasoning(inference.ReasoningAlways),
-		reasoningLevels: true,
-		maxInputTokens:  1_000_000,
+		efforts:        claudeEfforts,
+		maxInputTokens: 1_000_000,
 	},
 	// claude-mythos-5 shares Fable 5's capabilities and always-on adaptive
 	// thinking; it is a limited-release model (Project Glasswing), so
@@ -70,76 +84,76 @@ var catalog = map[string]catalogEntry{
 		capabilities: generateChatCapabilities().
 			WithInputs(message.PartImage).
 			WithReasoning(inference.ReasoningAlways),
-		reasoningLevels: true,
-		maxInputTokens:  1_000_000,
+		efforts:        claudeEfforts,
+		maxInputTokens: 1_000_000,
 	},
 	"claude-opus-5": {
 		capabilities: generateChatCapabilities().
 			WithInputs(message.PartImage).
 			WithReasoning(inference.ReasoningToggle),
-		reasoningLevels: true,
-		maxInputTokens:  1_000_000,
+		efforts:        claudeEfforts,
+		maxInputTokens: 1_000_000,
 	},
 	"claude-sonnet-5": {
 		capabilities: generateChatCapabilities().
 			WithInputs(message.PartImage).
 			WithReasoning(inference.ReasoningToggle),
-		reasoningLevels: true,
-		maxInputTokens:  1_000_000,
+		efforts:        claudeEfforts,
+		maxInputTokens: 1_000_000,
 	},
 	"claude-haiku-4-5": {
 		capabilities: generateChatCapabilities().
 			WithInputs(message.PartImage).
 			WithReasoning(inference.ReasoningToggle),
-		reasoningLevels: true,
-		maxInputTokens:  200_000,
+		efforts:        claudeEfforts,
+		maxInputTokens: 200_000,
 	},
 	"claude-haiku-4-5-20251001": {
 		capabilities: generateChatCapabilities().
 			WithInputs(message.PartImage).
 			WithReasoning(inference.ReasoningToggle),
-		reasoningLevels: true,
-		maxInputTokens:  200_000,
+		efforts:        claudeEfforts,
+		maxInputTokens: 200_000,
 	},
 
 	"claude-opus-4-8": {
 		capabilities: generateChatCapabilities().
 			WithInputs(message.PartImage).
 			WithReasoning(inference.ReasoningToggle),
-		reasoningLevels: true,
-		deprecated:      true, replacement: "claude-opus-5",
+		efforts:    claudeEfforts,
+		deprecated: true, replacement: "claude-opus-5",
 		maxInputTokens: 1_000_000,
 	},
 	"claude-opus-4-7": {
 		capabilities: generateChatCapabilities().
 			WithInputs(message.PartImage).
 			WithReasoning(inference.ReasoningToggle),
-		reasoningLevels: true,
-		deprecated:      true, replacement: "claude-opus-5",
+		efforts:    claudeEfforts,
+		deprecated: true, replacement: "claude-opus-5",
 		maxInputTokens: 1_000_000,
 	},
 	"claude-sonnet-4-6": {
 		capabilities: generateChatCapabilities().
 			WithInputs(message.PartImage).
 			WithReasoning(inference.ReasoningToggle),
-		reasoningLevels: true,
-		deprecated:      true, replacement: "claude-sonnet-5",
+		efforts:    claudeEfforts,
+		deprecated: true, replacement: "claude-sonnet-5",
 		maxInputTokens: 1_000_000,
 	},
 	"claude-sonnet-4-5": {
 		capabilities: generateChatCapabilities().
 			WithInputs(message.PartImage).
 			WithReasoning(inference.ReasoningToggle),
-		reasoningLevels: true,
-		deprecated:      true, replacement: "claude-sonnet-5",
+		efforts:    claudeEfforts,
+		deprecated: true, replacement: "claude-sonnet-5",
 		maxInputTokens: 200_000,
 	},
 	"claude-opus-4-1": {
 		capabilities: generateChatCapabilities().
 			WithInputs(message.PartImage).
 			WithReasoning(inference.ReasoningToggle),
-		reasoningLevels: true,
-		deprecated:      true, replacement: "claude-opus-5",
+		efforts:    claudeEfforts,
+		deprecated: true, replacement: "claude-opus-5",
 		maxInputTokens: 200_000,
 	},
 }

--- a/driver/anthropic/catalog.go
+++ b/driver/anthropic/catalog.go
@@ -11,17 +11,12 @@ import (
 
 // catalogEntry describes one model's compile-time capabilities.
 // capabilities is the single capability fact source: input/output content
-// kinds and the reasoning control capability. efforts is the model's
-// private reasoning-effort dial: the wire tokens the thinking endpoint
-// accepts, ordered as an ascending depth ladder.
+// kinds and the reasoning control capability (switch kind plus the
+// canonical-to-wire effort map).
 type catalogEntry struct {
 	capabilities inference.ModelCapabilities
-	// efforts lists the effort tokens this model's thinking endpoint
-	// accepts (low/medium/high/xhigh/max per the Claude docs); nil means
-	// binary thinking at platform-chosen depth.
-	efforts     []inference.ReasoningEffort
-	deprecated  bool
-	replacement string
+	deprecated   bool
+	replacement  string
 	// maxInputTokens caps the input context (system + messages + tools)
 	// in tokens; zero means undeclared. Values mirror the context window
 	// published on https://platform.claude.com/docs/en/about-claude/models.
@@ -54,16 +49,16 @@ func generateChatCapabilities() inference.ModelCapabilities {
 	}
 }
 
-// claudeEfforts is the effort dial shared by every Claude model that
-// accepts effort levels, aligned with the adaptive-thinking effort
-// parameter (low/medium/high/xhigh/max). "max" is a model-side extra
-// beyond the canonical ladder and is never requested by name.
-var claudeEfforts = []inference.ReasoningEffort{
-	inference.ReasoningLow,
-	inference.ReasoningMedium,
-	inference.ReasoningHigh,
-	inference.ReasoningXHigh,
-	"max",
+// claudeEffortMap is the canonical-to-wire effort map shared by every
+// Claude model that accepts effort levels, aligned with the
+// adaptive-thinking effort parameter (low/medium/high/xhigh; "max" is a
+// model-side extra beyond the canonical ladder and is never mapped to).
+var claudeEffortMap = map[inference.ReasoningEffort]string{
+	inference.ReasoningMinimal: string(inference.ReasoningLow),
+	inference.ReasoningLow:     string(inference.ReasoningLow),
+	inference.ReasoningMedium:  string(inference.ReasoningMedium),
+	inference.ReasoningHigh:    string(inference.ReasoningHigh),
+	inference.ReasoningXHigh:   string(inference.ReasoningXHigh),
 }
 
 // catalog is the built-in model list, aligned with the Claude lineup of
@@ -73,8 +68,8 @@ var catalog = map[string]catalogEntry{
 	"claude-fable-5": {
 		capabilities: generateChatCapabilities().
 			WithInputs(message.PartImage).
-			WithReasoning(inference.ReasoningAlways),
-		efforts:        claudeEfforts,
+			WithReasoning(inference.ReasoningAlways).
+			WithReasoningEffortMap(claudeEffortMap),
 		maxInputTokens: 1_000_000,
 	},
 	// claude-mythos-5 shares Fable 5's capabilities and always-on adaptive
@@ -83,76 +78,76 @@ var catalog = map[string]catalogEntry{
 	"claude-mythos-5": {
 		capabilities: generateChatCapabilities().
 			WithInputs(message.PartImage).
-			WithReasoning(inference.ReasoningAlways),
-		efforts:        claudeEfforts,
+			WithReasoning(inference.ReasoningAlways).
+			WithReasoningEffortMap(claudeEffortMap),
 		maxInputTokens: 1_000_000,
 	},
 	"claude-opus-5": {
 		capabilities: generateChatCapabilities().
 			WithInputs(message.PartImage).
-			WithReasoning(inference.ReasoningToggle),
-		efforts:        claudeEfforts,
+			WithReasoning(inference.ReasoningToggle).
+			WithReasoningEffortMap(claudeEffortMap),
 		maxInputTokens: 1_000_000,
 	},
 	"claude-sonnet-5": {
 		capabilities: generateChatCapabilities().
 			WithInputs(message.PartImage).
-			WithReasoning(inference.ReasoningToggle),
-		efforts:        claudeEfforts,
+			WithReasoning(inference.ReasoningToggle).
+			WithReasoningEffortMap(claudeEffortMap),
 		maxInputTokens: 1_000_000,
 	},
 	"claude-haiku-4-5": {
 		capabilities: generateChatCapabilities().
 			WithInputs(message.PartImage).
-			WithReasoning(inference.ReasoningToggle),
-		efforts:        claudeEfforts,
+			WithReasoning(inference.ReasoningToggle).
+			WithReasoningEffortMap(claudeEffortMap),
 		maxInputTokens: 200_000,
 	},
 	"claude-haiku-4-5-20251001": {
 		capabilities: generateChatCapabilities().
 			WithInputs(message.PartImage).
-			WithReasoning(inference.ReasoningToggle),
-		efforts:        claudeEfforts,
+			WithReasoning(inference.ReasoningToggle).
+			WithReasoningEffortMap(claudeEffortMap),
 		maxInputTokens: 200_000,
 	},
 
 	"claude-opus-4-8": {
 		capabilities: generateChatCapabilities().
 			WithInputs(message.PartImage).
-			WithReasoning(inference.ReasoningToggle),
-		efforts:    claudeEfforts,
+			WithReasoning(inference.ReasoningToggle).
+			WithReasoningEffortMap(claudeEffortMap),
 		deprecated: true, replacement: "claude-opus-5",
 		maxInputTokens: 1_000_000,
 	},
 	"claude-opus-4-7": {
 		capabilities: generateChatCapabilities().
 			WithInputs(message.PartImage).
-			WithReasoning(inference.ReasoningToggle),
-		efforts:    claudeEfforts,
+			WithReasoning(inference.ReasoningToggle).
+			WithReasoningEffortMap(claudeEffortMap),
 		deprecated: true, replacement: "claude-opus-5",
 		maxInputTokens: 1_000_000,
 	},
 	"claude-sonnet-4-6": {
 		capabilities: generateChatCapabilities().
 			WithInputs(message.PartImage).
-			WithReasoning(inference.ReasoningToggle),
-		efforts:    claudeEfforts,
+			WithReasoning(inference.ReasoningToggle).
+			WithReasoningEffortMap(claudeEffortMap),
 		deprecated: true, replacement: "claude-sonnet-5",
 		maxInputTokens: 1_000_000,
 	},
 	"claude-sonnet-4-5": {
 		capabilities: generateChatCapabilities().
 			WithInputs(message.PartImage).
-			WithReasoning(inference.ReasoningToggle),
-		efforts:    claudeEfforts,
+			WithReasoning(inference.ReasoningToggle).
+			WithReasoningEffortMap(claudeEffortMap),
 		deprecated: true, replacement: "claude-sonnet-5",
 		maxInputTokens: 200_000,
 	},
 	"claude-opus-4-1": {
 		capabilities: generateChatCapabilities().
 			WithInputs(message.PartImage).
-			WithReasoning(inference.ReasoningToggle),
-		efforts:    claudeEfforts,
+			WithReasoning(inference.ReasoningToggle).
+			WithReasoningEffortMap(claudeEffortMap),
 		deprecated: true, replacement: "claude-opus-5",
 		maxInputTokens: 200_000,
 	},

--- a/driver/anthropic/catalog_test.go
+++ b/driver/anthropic/catalog_test.go
@@ -65,7 +65,7 @@ func TestCatalogPublishesCapabilities(t *testing.T) {
 		case "claude-fable-5", "claude-mythos-5":
 			want = inference.ReasoningAlways
 		}
-		if capabilities.Reasoning != want {
+		if capabilities.Reasoning.Kind != want {
 			t.Fatalf("%s reasoning = %q, want %q",
 				model.Descriptor.ID.Name, capabilities.Reasoning, want)
 		}

--- a/driver/anthropic/generate.go
+++ b/driver/anthropic/generate.go
@@ -599,12 +599,12 @@ func compileIntent(
 	wire.topP = text.TopP
 	if text.ReasoningEnabled != nil {
 		switch {
-		case entry.capabilities.Reasoning == inference.ReasoningNone:
+		case entry.capabilities.Reasoning.Kind == inference.ReasoningNone:
 			ledger.reject(
 				inference.FieldGenerateIntentReasoningEnabled,
 				"model has no thinking to switch",
 			)
-		case entry.capabilities.Reasoning == inference.ReasoningAlways &&
+		case entry.capabilities.Reasoning.Kind == inference.ReasoningAlways &&
 			!*text.ReasoningEnabled:
 			ledger.reject(
 				inference.FieldGenerateIntentReasoningEnabled,
@@ -617,12 +617,12 @@ func compileIntent(
 	}
 	if text.ReasoningEffort != "" {
 		switch {
-		case entry.capabilities.Reasoning == inference.ReasoningNone:
+		case entry.capabilities.Reasoning.Kind == inference.ReasoningNone:
 			ledger.reject(
 				inference.FieldGenerateIntentReasoningEffort,
 				"model has no reasoning effort control",
 			)
-		case len(entry.efforts) == 0:
+		case len(entry.capabilities.Reasoning.EffortMap) == 0:
 			// The platform's thinking is binary: the level cannot be
 			// honored, but the request for reasoning itself is — turn
 			// thinking on and report the loss.
@@ -633,16 +633,15 @@ func compileIntent(
 				"platform thinking has no effort levels; enabled at platform-chosen depth",
 			)
 		default:
-			mode, exact := inference.ResolveReasoningEffort(
+			mode, _ := entry.capabilities.Reasoning.ResolveEffort(
 				text.ReasoningEffort,
-				entry.efforts,
 			)
-			wire.effort = string(mode)
-			if !exact {
+			wire.effort = mode
+			if mode != string(text.ReasoningEffort) {
 				ledger.drop(
 					inference.FieldGenerateIntentReasoningEffort,
 					fmt.Sprintf(
-						"model quantizes reasoning effort %q to %q",
+						"model maps reasoning effort %q to %q",
 						text.ReasoningEffort,
 						mode,
 					),

--- a/driver/anthropic/generate.go
+++ b/driver/anthropic/generate.go
@@ -622,7 +622,7 @@ func compileIntent(
 				inference.FieldGenerateIntentReasoningEffort,
 				"model has no reasoning effort control",
 			)
-		case !entry.reasoningLevels:
+		case len(entry.efforts) == 0:
 			// The platform's thinking is binary: the level cannot be
 			// honored, but the request for reasoning itself is — turn
 			// thinking on and report the loss.
@@ -633,7 +633,21 @@ func compileIntent(
 				"platform thinking has no effort levels; enabled at platform-chosen depth",
 			)
 		default:
-			wire.effort = string(text.ReasoningEffort)
+			mode, exact := inference.ResolveReasoningEffort(
+				text.ReasoningEffort,
+				entry.efforts,
+			)
+			wire.effort = string(mode)
+			if !exact {
+				ledger.drop(
+					inference.FieldGenerateIntentReasoningEffort,
+					fmt.Sprintf(
+						"model quantizes reasoning effort %q to %q",
+						text.ReasoningEffort,
+						mode,
+					),
+				)
+			}
 		}
 	}
 }

--- a/driver/anthropic/reasoning_test.go
+++ b/driver/anthropic/reasoning_test.go
@@ -1,0 +1,81 @@
+package anthropic
+
+import (
+	"context"
+	"testing"
+
+	"github.com/GizClaw/flowcraft/core/inference"
+)
+
+func TestClaudeReasoningEffortResolvesAgainstPrivateDial(t *testing.T) {
+	compile := compileGenerate("claude-fable-5", catalog["claude-fable-5"])
+	model := conformanceModel("claude-fable-5")
+	field := inference.FieldGenerateIntentReasoningEffort
+
+	for _, tc := range []struct {
+		effort  inference.ReasoningEffort
+		want    inference.ReasoningEffort
+		dropped bool
+	}{
+		{effort: inference.ReasoningMinimal, want: inference.ReasoningLow, dropped: true},
+		{effort: inference.ReasoningLow, want: inference.ReasoningLow},
+		{effort: inference.ReasoningMedium, want: inference.ReasoningMedium},
+		{effort: inference.ReasoningHigh, want: inference.ReasoningHigh},
+		{effort: inference.ReasoningXHigh, want: inference.ReasoningXHigh},
+	} {
+		request := conformanceTextRequest()
+		request.Input.Content.Intent.Text = &inference.TextIntent{
+			ReasoningEffort: tc.effort,
+		}
+		compiled, err := compile(
+			context.Background(),
+			model,
+			request,
+			inference.GenerateExecutionUnary,
+		)
+		if err != nil {
+			t.Fatalf("effort %q: compile: %v", tc.effort, err)
+		}
+		if compiled.Wire.effort != string(tc.want) {
+			t.Fatalf(
+				"effort %q: wire = %q, want %q",
+				tc.effort,
+				compiled.Wire.effort,
+				tc.want,
+			)
+		}
+		if got := compiled.Report.Dropped(field); got != tc.dropped {
+			t.Fatalf("effort %q: dropped = %v, want %v", tc.effort, got, tc.dropped)
+		}
+	}
+}
+
+func TestBinaryThinkingEffortDropsAndEnablesThinking(t *testing.T) {
+	entry := catalogEntry{
+		capabilities: generateChatCapabilities().
+			WithReasoning(inference.ReasoningToggle),
+	}
+	compile := compileGenerate("binary", entry)
+	request := conformanceTextRequest()
+	request.Input.Content.Intent.Text = &inference.TextIntent{
+		ReasoningEffort: inference.ReasoningHigh,
+	}
+	compiled, err := compile(
+		context.Background(),
+		conformanceModel("binary"),
+		request,
+		inference.GenerateExecutionUnary,
+	)
+	if err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+	if !compiled.Report.Dropped(inference.FieldGenerateIntentReasoningEffort) {
+		t.Fatal("binary thinking model must drop the effort with a reason")
+	}
+	if compiled.Wire.thinking == nil || !*compiled.Wire.thinking {
+		t.Fatalf("binary drop must enable thinking, got %v", compiled.Wire.thinking)
+	}
+	if compiled.Wire.effort != "" {
+		t.Fatalf("wire effort = %q, want empty", compiled.Wire.effort)
+	}
+}

--- a/driver/azure/catalog.go
+++ b/driver/azure/catalog.go
@@ -12,12 +12,15 @@ import (
 // Azure routes by deployment name, so the spec's models list is the whole
 // catalog: the factory maps each declared deployment onto an entry, and the
 // compiler rejects every channel the entry omits. capabilities is the single
-// capability fact source; dimensions is the one control capability that no
-// capability kind expresses and stays a separate flag.
+// capability fact source; dimensions and effortNone are control capabilities
+// that no capability kind expresses and stay separate flags.
 type catalogEntry struct {
 	kind         modelKind
 	capabilities inference.ModelCapabilities
 	dimensions   bool
+	// effortNone marks generate deployments whose reasoning.effort accepts
+	// "none" to disable reasoning; without it a disable request rejects.
+	effortNone bool
 }
 
 // entryFor lowers one declared deployment into a compiler entry.
@@ -26,6 +29,7 @@ func entryFor(model ModelSpec) catalogEntry {
 		kind:         modelKind(model.Kind),
 		capabilities: model.Capabilities,
 		dimensions:   model.Dimensions,
+		effortNone:   model.EffortNone,
 	}
 }
 

--- a/driver/azure/doc.go
+++ b/driver/azure/doc.go
@@ -16,6 +16,8 @@
 //
 // Deployments are the catalog: Azure routes by deployment name, so every
 // model in spec.models declares one deployment plus the operation kind and
-// optional capability flags. Credentials live per profile under api_key;
-// the resource endpoint and api-version live on the provider Spec.
+// optional capability flags (including effort_none for reasoning
+// deployments that accept effort "none" to disable thinking). Credentials
+// live per profile under api_key; the resource endpoint and api-version
+// live on the provider Spec.
 package azure

--- a/driver/azure/generate.go
+++ b/driver/azure/generate.go
@@ -624,12 +624,10 @@ func compileIntent(
 				"model has no reasoning effort control",
 			)
 		case len(entry.capabilities.Reasoning.EffortMap) == 0:
-			// Deployments without a declared effort map are treated as
-			// binary: the level cannot be represented.
-			ledger.drop(
-				inference.FieldGenerateIntentReasoningEffort,
-				"model's thinking is binary; no effort dial exists",
-			)
+			// Legacy spec deployments without an explicit map keep the
+			// pass-through behavior: Azure's reasoning.effort accepts the
+			// canonical effort tokens verbatim.
+			wire.reasoning = string(text.ReasoningEffort)
 		default:
 			mode, _ := entry.capabilities.Reasoning.ResolveEffort(
 				text.ReasoningEffort,

--- a/driver/azure/generate.go
+++ b/driver/azure/generate.go
@@ -319,7 +319,7 @@ func compileGenerate(
 		wire := generateWire{
 			model:            model,
 			stream:           shape == inference.GenerateExecutionStream,
-			includeReasoning: entry.capabilities.Reasoning != inference.ReasoningNone,
+			includeReasoning: entry.capabilities.Reasoning.Kind != inference.ReasoningNone,
 		}
 
 		// Context messages → items. System stays a native system-role item;
@@ -477,7 +477,7 @@ func compileReasoning(
 		ledger.reject(field, "reasoning parts belong to assistant context")
 		return
 	}
-	if entry.capabilities.Reasoning == inference.ReasoningNone {
+	if entry.capabilities.Reasoning.Kind == inference.ReasoningNone {
 		ledger.drop(field, "model has no reasoning channel")
 		return
 	}
@@ -592,18 +592,18 @@ func compileIntent(
 	wire.topP = text.TopP
 	if text.ReasoningEnabled != nil {
 		switch {
-		case entry.capabilities.Reasoning == inference.ReasoningNone:
+		case entry.capabilities.Reasoning.Kind == inference.ReasoningNone:
 			ledger.reject(
 				inference.FieldGenerateIntentReasoningEnabled,
 				"model has no reasoning to switch",
 			)
-		case entry.capabilities.Reasoning == inference.ReasoningAlways &&
+		case entry.capabilities.Reasoning.Kind == inference.ReasoningAlways &&
 			!*text.ReasoningEnabled:
 			ledger.reject(
 				inference.FieldGenerateIntentReasoningEnabled,
 				"openai reasoning models cannot disable reasoning",
 			)
-		case entry.capabilities.Reasoning == inference.ReasoningToggle &&
+		case entry.capabilities.Reasoning.Kind == inference.ReasoningToggle &&
 			!*text.ReasoningEnabled:
 			if entry.effortNone {
 				wire.reasoning = "none"
@@ -617,13 +617,34 @@ func compileIntent(
 		// enabled == true is a no-op: reasoning models reason by default.
 	}
 	if text.ReasoningEffort != "" {
-		if entry.capabilities.Reasoning == inference.ReasoningNone {
+		switch {
+		case entry.capabilities.Reasoning.Kind == inference.ReasoningNone:
 			ledger.reject(
 				inference.FieldGenerateIntentReasoningEffort,
 				"model has no reasoning effort control",
 			)
-		} else {
-			wire.reasoning = string(text.ReasoningEffort)
+		case len(entry.capabilities.Reasoning.EffortMap) == 0:
+			// Deployments without a declared effort map are treated as
+			// binary: the level cannot be represented.
+			ledger.drop(
+				inference.FieldGenerateIntentReasoningEffort,
+				"model's thinking is binary; no effort dial exists",
+			)
+		default:
+			mode, _ := entry.capabilities.Reasoning.ResolveEffort(
+				text.ReasoningEffort,
+			)
+			wire.reasoning = mode
+			if mode != string(text.ReasoningEffort) {
+				ledger.drop(
+					inference.FieldGenerateIntentReasoningEffort,
+					fmt.Sprintf(
+						"model maps reasoning effort %q to %q",
+						text.ReasoningEffort,
+						mode,
+					),
+				)
+			}
 		}
 	}
 }

--- a/driver/azure/generate.go
+++ b/driver/azure/generate.go
@@ -605,6 +605,10 @@ func compileIntent(
 			)
 		case entry.capabilities.Reasoning == inference.ReasoningToggle &&
 			!*text.ReasoningEnabled:
+			if entry.effortNone {
+				wire.reasoning = "none"
+				break
+			}
 			ledger.reject(
 				inference.FieldGenerateIntentReasoningEnabled,
 				"reasoning cannot be disabled through this provider",

--- a/driver/azure/reasoning_none_test.go
+++ b/driver/azure/reasoning_none_test.go
@@ -65,3 +65,32 @@ func TestToggleFalseRejectsWithoutEffortNone(t *testing.T) {
 		t.Fatal("disable request was not rejected on the reasoning_enabled field")
 	}
 }
+
+func TestLegacyToggleWithoutMapPassesEffortThrough(t *testing.T) {
+	entry := catalogEntry{
+		kind: kindGenerate,
+		capabilities: inference.ModelCapabilities{
+			Outputs:   []message.PartKind{message.PartText},
+			Reasoning: inference.ReasoningCapability{Kind: inference.ReasoningToggle},
+		},
+	}
+	compile := compileGenerate("deploy-legacy-effort", entry)
+	request := conformanceTextRequest()
+	request.Input.Content.Intent.Text.ReasoningEffort = inference.ReasoningHigh
+
+	compiled, err := compile(
+		context.Background(),
+		conformanceModel("deploy-legacy-effort"),
+		request,
+		inference.GenerateExecutionUnary,
+	)
+	if err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+	if compiled.Wire.reasoning != "high" {
+		t.Fatalf("wire reasoning = %q, want high", compiled.Wire.reasoning)
+	}
+	if compiled.Report.Dropped(inference.FieldGenerateIntentReasoningEffort) {
+		t.Fatal("legacy spec effort unexpectedly dropped")
+	}
+}

--- a/driver/azure/reasoning_none_test.go
+++ b/driver/azure/reasoning_none_test.go
@@ -1,0 +1,67 @@
+package azure
+
+import (
+	"context"
+	"testing"
+
+	"github.com/GizClaw/flowcraft/core/inference"
+	"github.com/GizClaw/flowcraft/core/message"
+)
+
+func TestToggleFalseCompilesToEffortNone(t *testing.T) {
+	entry := catalogEntry{
+		kind: kindGenerate,
+		capabilities: inference.ModelCapabilities{
+			Outputs:   []message.PartKind{message.PartText},
+			Reasoning: inference.ReasoningToggle,
+		},
+		effortNone: true,
+	}
+	compile := compileGenerate("deploy-none", entry)
+	request := conformanceTextRequest()
+	disabled := false
+	request.Input.Content.Intent.Text.ReasoningEnabled = &disabled
+
+	compiled, err := compile(
+		context.Background(),
+		conformanceModel("deploy-none"),
+		request,
+		inference.GenerateExecutionUnary,
+	)
+	if err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+	if compiled.Wire.reasoning != "none" {
+		t.Fatalf("wire reasoning = %q, want none", compiled.Wire.reasoning)
+	}
+	if compiled.Report.Rejects(inference.FieldGenerateIntentReasoningEnabled) {
+		t.Fatal("disable request unexpectedly rejected on an effort_none deployment")
+	}
+}
+
+func TestToggleFalseRejectsWithoutEffortNone(t *testing.T) {
+	entry := catalogEntry{
+		kind: kindGenerate,
+		capabilities: inference.ModelCapabilities{
+			Outputs:   []message.PartKind{message.PartText},
+			Reasoning: inference.ReasoningToggle,
+		},
+	}
+	compile := compileGenerate("deploy-legacy", entry)
+	request := conformanceTextRequest()
+	disabled := false
+	request.Input.Content.Intent.Text.ReasoningEnabled = &disabled
+
+	compiled, err := compile(
+		context.Background(),
+		conformanceModel("deploy-legacy"),
+		request,
+		inference.GenerateExecutionUnary,
+	)
+	if err == nil {
+		t.Fatal("disable request unexpectedly accepted without effort_none")
+	}
+	if !compiled.Report.Rejects(inference.FieldGenerateIntentReasoningEnabled) {
+		t.Fatal("disable request was not rejected on the reasoning_enabled field")
+	}
+}

--- a/driver/azure/reasoning_none_test.go
+++ b/driver/azure/reasoning_none_test.go
@@ -13,7 +13,7 @@ func TestToggleFalseCompilesToEffortNone(t *testing.T) {
 		kind: kindGenerate,
 		capabilities: inference.ModelCapabilities{
 			Outputs:   []message.PartKind{message.PartText},
-			Reasoning: inference.ReasoningToggle,
+			Reasoning: inference.ReasoningCapability{Kind: inference.ReasoningToggle},
 		},
 		effortNone: true,
 	}
@@ -44,7 +44,7 @@ func TestToggleFalseRejectsWithoutEffortNone(t *testing.T) {
 		kind: kindGenerate,
 		capabilities: inference.ModelCapabilities{
 			Outputs:   []message.PartKind{message.PartText},
-			Reasoning: inference.ReasoningToggle,
+			Reasoning: inference.ReasoningCapability{Kind: inference.ReasoningToggle},
 		},
 	}
 	compile := compileGenerate("deploy-legacy", entry)

--- a/driver/azure/resource_test.go
+++ b/driver/azure/resource_test.go
@@ -250,7 +250,7 @@ func TestModelCapabilitiesPublish(t *testing.T) {
 	if !reflect.DeepEqual(capabilities.Outputs, []message.PartKind{message.PartText}) ||
 		!slices.Contains(capabilities.Inputs, message.PartImage) ||
 		!capabilities.HostedWebSearch ||
-		capabilities.Reasoning != inference.ReasoningAlways {
+		capabilities.Reasoning.Kind != inference.ReasoningAlways {
 		t.Fatalf("capabilities = %+v", capabilities)
 	}
 }

--- a/driver/azure/spec.go
+++ b/driver/azure/spec.go
@@ -39,6 +39,10 @@ type ModelSpec struct {
 	Capabilities inference.ModelCapabilities `json:"capabilities,omitempty"`
 	// Dimensions accepts the embed dimensions knob (embed only).
 	Dimensions bool `json:"dimensions,omitempty"`
+	// EffortNone marks generate deployments whose reasoning.effort accepts
+	// "none" to disable reasoning (gpt-5.1+ deployments); deployments
+	// without it reject a ReasoningEnabled=false request.
+	EffortNone bool `json:"effort_none,omitempty"`
 }
 
 func (s Spec) Validate() error {

--- a/driver/bytedance/catalog.go
+++ b/driver/bytedance/catalog.go
@@ -28,6 +28,10 @@ const (
 type catalogEntry struct {
 	kind         modelKind
 	capabilities inference.ModelCapabilities
+	// efforts is the reasoning_effort dial the Ark responses surface
+	// accepts (low/medium/high in the SDK enum); minimal and xhigh are
+	// not wire levels here and resolve onto low/high.
+	efforts []inference.ReasoningEffort
 	// embed: accepts custom output dimensions.
 	dimensions bool
 	// video: highest supported resolution tier ("720p", "1080p", "4k");
@@ -136,6 +140,16 @@ func generateChatCapabilities() inference.ModelCapabilities {
 	}
 }
 
+// arkEfforts is the effort dial shared by the Ark thinking models. The
+// SDK's reasoning_effort enum carries low/medium/high only; Doubao's
+// documented minimal level is its no-thinking mode, which the canonical
+// ReasoningEnabled switch covers instead.
+var arkEfforts = []inference.ReasoningEffort{
+	inference.ReasoningLow,
+	inference.ReasoningMedium,
+	inference.ReasoningHigh,
+}
+
 // catalog is the built-in model registry. Names are stable Volcengine model
 // families; deployment-specific endpoint IDs (ep-xxx or dated revisions like
 // doubao-seed-2-1-pro-260628) belong in Spec.Endpoints.
@@ -152,6 +166,7 @@ var catalog = map[string]catalogEntry{
 			WithInputs(message.PartImage, message.PartVideo).
 			WithHostedWebSearch().
 			WithReasoning(inference.ReasoningToggle),
+		efforts:        arkEfforts,
 		maxInputTokens: 1_024_000,
 	},
 
@@ -163,6 +178,7 @@ var catalog = map[string]catalogEntry{
 			WithInputs(message.PartImage, message.PartVideo).
 			WithHostedWebSearch().
 			WithReasoning(inference.ReasoningToggle),
+		efforts:        arkEfforts,
 		maxInputTokens: 256_000,
 	},
 	"doubao-seed-2-1-turbo": {
@@ -171,6 +187,7 @@ var catalog = map[string]catalogEntry{
 			WithInputs(message.PartImage, message.PartVideo).
 			WithHostedWebSearch().
 			WithReasoning(inference.ReasoningToggle),
+		efforts:        arkEfforts,
 		maxInputTokens: 256_000,
 	},
 
@@ -184,6 +201,7 @@ var catalog = map[string]catalogEntry{
 			WithInputs(message.PartImage, message.PartVideo).
 			WithHostedWebSearch().
 			WithReasoning(inference.ReasoningToggle),
+		efforts:        arkEfforts,
 		maxInputTokens: 256_000,
 	},
 	"doubao-seed-2-0-lite": {
@@ -192,6 +210,7 @@ var catalog = map[string]catalogEntry{
 			WithInputs(message.PartImage, message.PartVideo, message.PartAudio).
 			WithHostedWebSearch().
 			WithReasoning(inference.ReasoningToggle),
+		efforts:        arkEfforts,
 		maxInputTokens: 256_000,
 	},
 	"doubao-seed-2-0-mini": {
@@ -200,6 +219,7 @@ var catalog = map[string]catalogEntry{
 			WithInputs(message.PartImage, message.PartVideo, message.PartAudio).
 			WithHostedWebSearch().
 			WithReasoning(inference.ReasoningToggle),
+		efforts:        arkEfforts,
 		maxInputTokens: 256_000,
 	},
 	"doubao-seed-2-0-code": {
@@ -208,6 +228,7 @@ var catalog = map[string]catalogEntry{
 			WithInputs(message.PartImage).
 			WithHostedWebSearch().
 			WithReasoning(inference.ReasoningToggle),
+		efforts:        arkEfforts,
 		maxInputTokens: 256_000,
 	},
 
@@ -219,6 +240,7 @@ var catalog = map[string]catalogEntry{
 			WithInputs(message.PartImage, message.PartVideo).
 			WithHostedWebSearch().
 			WithReasoning(inference.ReasoningToggle),
+		efforts:    arkEfforts,
 		deprecated: true, replacement: "doubao-seed-2-0-lite",
 		maxInputTokens: 256_000,
 	},
@@ -228,6 +250,7 @@ var catalog = map[string]catalogEntry{
 			WithInputs(message.PartImage).
 			WithHostedWebSearch().
 			WithReasoning(inference.ReasoningToggle),
+		efforts:    arkEfforts,
 		deprecated: true, replacement: "doubao-seed-2-0-lite",
 		maxInputTokens: 256_000,
 	},

--- a/driver/bytedance/catalog.go
+++ b/driver/bytedance/catalog.go
@@ -28,10 +28,6 @@ const (
 type catalogEntry struct {
 	kind         modelKind
 	capabilities inference.ModelCapabilities
-	// efforts is the reasoning_effort dial the Ark responses surface
-	// accepts (low/medium/high in the SDK enum); minimal and xhigh are
-	// not wire levels here and resolve onto low/high.
-	efforts []inference.ReasoningEffort
 	// embed: accepts custom output dimensions.
 	dimensions bool
 	// video: highest supported resolution tier ("720p", "1080p", "4k");
@@ -140,14 +136,17 @@ func generateChatCapabilities() inference.ModelCapabilities {
 	}
 }
 
-// arkEfforts is the effort dial shared by the Ark thinking models. The
-// SDK's reasoning_effort enum carries low/medium/high only; Doubao's
+// arkEffortMap is the canonical-to-wire map shared by the Ark thinking
+// models. The SDK's reasoning_effort enum carries low/medium/high only, so
+// canonical minimal folds onto low and xhigh folds onto high; Doubao's
 // documented minimal level is its no-thinking mode, which the canonical
 // ReasoningEnabled switch covers instead.
-var arkEfforts = []inference.ReasoningEffort{
-	inference.ReasoningLow,
-	inference.ReasoningMedium,
-	inference.ReasoningHigh,
+var arkEffortMap = map[inference.ReasoningEffort]string{
+	inference.ReasoningMinimal: string(inference.ReasoningLow),
+	inference.ReasoningLow:     string(inference.ReasoningLow),
+	inference.ReasoningMedium:  string(inference.ReasoningMedium),
+	inference.ReasoningHigh:    string(inference.ReasoningHigh),
+	inference.ReasoningXHigh:   string(inference.ReasoningHigh),
 }
 
 // catalog is the built-in model registry. Names are stable Volcengine model
@@ -165,8 +164,8 @@ var catalog = map[string]catalogEntry{
 		capabilities: generateChatCapabilities().
 			WithInputs(message.PartImage, message.PartVideo).
 			WithHostedWebSearch().
-			WithReasoning(inference.ReasoningToggle),
-		efforts:        arkEfforts,
+			WithReasoning(inference.ReasoningToggle).
+			WithReasoningEffortMap(arkEffortMap),
 		maxInputTokens: 1_024_000,
 	},
 
@@ -177,8 +176,8 @@ var catalog = map[string]catalogEntry{
 		capabilities: generateChatCapabilities().
 			WithInputs(message.PartImage, message.PartVideo).
 			WithHostedWebSearch().
-			WithReasoning(inference.ReasoningToggle),
-		efforts:        arkEfforts,
+			WithReasoning(inference.ReasoningToggle).
+			WithReasoningEffortMap(arkEffortMap),
 		maxInputTokens: 256_000,
 	},
 	"doubao-seed-2-1-turbo": {
@@ -186,8 +185,8 @@ var catalog = map[string]catalogEntry{
 		capabilities: generateChatCapabilities().
 			WithInputs(message.PartImage, message.PartVideo).
 			WithHostedWebSearch().
-			WithReasoning(inference.ReasoningToggle),
-		efforts:        arkEfforts,
+			WithReasoning(inference.ReasoningToggle).
+			WithReasoningEffortMap(arkEffortMap),
 		maxInputTokens: 256_000,
 	},
 
@@ -200,8 +199,8 @@ var catalog = map[string]catalogEntry{
 		capabilities: generateChatCapabilities().
 			WithInputs(message.PartImage, message.PartVideo).
 			WithHostedWebSearch().
-			WithReasoning(inference.ReasoningToggle),
-		efforts:        arkEfforts,
+			WithReasoning(inference.ReasoningToggle).
+			WithReasoningEffortMap(arkEffortMap),
 		maxInputTokens: 256_000,
 	},
 	"doubao-seed-2-0-lite": {
@@ -209,8 +208,8 @@ var catalog = map[string]catalogEntry{
 		capabilities: generateChatCapabilities().
 			WithInputs(message.PartImage, message.PartVideo, message.PartAudio).
 			WithHostedWebSearch().
-			WithReasoning(inference.ReasoningToggle),
-		efforts:        arkEfforts,
+			WithReasoning(inference.ReasoningToggle).
+			WithReasoningEffortMap(arkEffortMap),
 		maxInputTokens: 256_000,
 	},
 	"doubao-seed-2-0-mini": {
@@ -218,8 +217,8 @@ var catalog = map[string]catalogEntry{
 		capabilities: generateChatCapabilities().
 			WithInputs(message.PartImage, message.PartVideo, message.PartAudio).
 			WithHostedWebSearch().
-			WithReasoning(inference.ReasoningToggle),
-		efforts:        arkEfforts,
+			WithReasoning(inference.ReasoningToggle).
+			WithReasoningEffortMap(arkEffortMap),
 		maxInputTokens: 256_000,
 	},
 	"doubao-seed-2-0-code": {
@@ -227,8 +226,8 @@ var catalog = map[string]catalogEntry{
 		capabilities: generateChatCapabilities().
 			WithInputs(message.PartImage).
 			WithHostedWebSearch().
-			WithReasoning(inference.ReasoningToggle),
-		efforts:        arkEfforts,
+			WithReasoning(inference.ReasoningToggle).
+			WithReasoningEffortMap(arkEffortMap),
 		maxInputTokens: 256_000,
 	},
 
@@ -239,8 +238,8 @@ var catalog = map[string]catalogEntry{
 		capabilities: generateChatCapabilities().
 			WithInputs(message.PartImage, message.PartVideo).
 			WithHostedWebSearch().
-			WithReasoning(inference.ReasoningToggle),
-		efforts:    arkEfforts,
+			WithReasoning(inference.ReasoningToggle).
+			WithReasoningEffortMap(arkEffortMap),
 		deprecated: true, replacement: "doubao-seed-2-0-lite",
 		maxInputTokens: 256_000,
 	},
@@ -249,8 +248,8 @@ var catalog = map[string]catalogEntry{
 		capabilities: generateChatCapabilities().
 			WithInputs(message.PartImage).
 			WithHostedWebSearch().
-			WithReasoning(inference.ReasoningToggle),
-		efforts:    arkEfforts,
+			WithReasoning(inference.ReasoningToggle).
+			WithReasoningEffortMap(arkEffortMap),
 		deprecated: true, replacement: "doubao-seed-2-0-lite",
 		maxInputTokens: 256_000,
 	},

--- a/driver/bytedance/catalog_test.go
+++ b/driver/bytedance/catalog_test.go
@@ -70,7 +70,7 @@ func TestCatalogPublishesCapabilities(t *testing.T) {
 		t.Fatalf("chat inputs = %v, want image and video input", chat.Capabilities.Inputs)
 	}
 	if !chat.Capabilities.HostedWebSearch ||
-		chat.Capabilities.Reasoning != inference.ReasoningToggle {
+		chat.Capabilities.Reasoning.Kind != inference.ReasoningToggle {
 		t.Fatalf("chat capabilities = %+v", chat.Capabilities)
 	}
 

--- a/driver/bytedance/generate.go
+++ b/driver/bytedance/generate.go
@@ -612,12 +612,12 @@ func compileIntent(
 	wire.topP = text.TopP
 	if text.ReasoningEnabled != nil {
 		switch {
-		case entry.capabilities.Reasoning == inference.ReasoningNone:
+		case entry.capabilities.Reasoning.Kind == inference.ReasoningNone:
 			ledger.reject(
 				inference.FieldGenerateIntentReasoningEnabled,
 				"model has no thinking control",
 			)
-		case entry.capabilities.Reasoning == inference.ReasoningAlways &&
+		case entry.capabilities.Reasoning.Kind == inference.ReasoningAlways &&
 			!*text.ReasoningEnabled:
 			ledger.reject(
 				inference.FieldGenerateIntentReasoningEnabled,
@@ -629,12 +629,12 @@ func compileIntent(
 	}
 	if text.ReasoningEffort != "" {
 		switch {
-		case entry.capabilities.Reasoning == inference.ReasoningNone:
+		case entry.capabilities.Reasoning.Kind == inference.ReasoningNone:
 			ledger.reject(
 				inference.FieldGenerateIntentReasoningEffort,
 				"model has no thinking control",
 			)
-		case len(entry.efforts) == 0:
+		case len(entry.capabilities.Reasoning.EffortMap) == 0:
 			// Spec-declared reasoning models without a dial: honor the
 			// request for reasoning itself and report the lost level.
 			on := true
@@ -644,16 +644,15 @@ func compileIntent(
 				"model's thinking is binary; no effort dial exists",
 			)
 		default:
-			mode, exact := inference.ResolveReasoningEffort(
+			mode, _ := entry.capabilities.Reasoning.ResolveEffort(
 				text.ReasoningEffort,
-				entry.efforts,
 			)
-			wire.reasoning = &wireReasoning{effort: string(mode)}
-			if !exact {
+			wire.reasoning = &wireReasoning{effort: mode}
+			if mode != string(text.ReasoningEffort) {
 				ledger.drop(
 					inference.FieldGenerateIntentReasoningEffort,
 					fmt.Sprintf(
-						"model quantizes reasoning effort %q to %q",
+						"model maps reasoning effort %q to %q",
 						text.ReasoningEffort,
 						mode,
 					),

--- a/driver/bytedance/generate.go
+++ b/driver/bytedance/generate.go
@@ -628,13 +628,37 @@ func compileIntent(
 		}
 	}
 	if text.ReasoningEffort != "" {
-		if entry.capabilities.Reasoning == inference.ReasoningNone {
+		switch {
+		case entry.capabilities.Reasoning == inference.ReasoningNone:
 			ledger.reject(
 				inference.FieldGenerateIntentReasoningEffort,
 				"model has no thinking control",
 			)
-		} else {
-			wire.reasoning = &wireReasoning{effort: string(text.ReasoningEffort)}
+		case len(entry.efforts) == 0:
+			// Spec-declared reasoning models without a dial: honor the
+			// request for reasoning itself and report the lost level.
+			on := true
+			wire.thinking = &on
+			ledger.drop(
+				inference.FieldGenerateIntentReasoningEffort,
+				"model's thinking is binary; no effort dial exists",
+			)
+		default:
+			mode, exact := inference.ResolveReasoningEffort(
+				text.ReasoningEffort,
+				entry.efforts,
+			)
+			wire.reasoning = &wireReasoning{effort: string(mode)}
+			if !exact {
+				ledger.drop(
+					inference.FieldGenerateIntentReasoningEffort,
+					fmt.Sprintf(
+						"model quantizes reasoning effort %q to %q",
+						text.ReasoningEffort,
+						mode,
+					),
+				)
+			}
 		}
 	}
 }

--- a/driver/bytedance/reasoning_test.go
+++ b/driver/bytedance/reasoning_test.go
@@ -1,0 +1,82 @@
+package bytedance
+
+import (
+	"context"
+	"testing"
+
+	"github.com/GizClaw/flowcraft/core/inference"
+)
+
+func TestDoubaoReasoningEffortResolvesAgainstPrivateDial(t *testing.T) {
+	compile := compileGenerate("doubao-seed-2-1-pro", catalog["doubao-seed-2-1-pro"])
+	model := conformanceModel("doubao-seed-2-1-pro")
+	field := inference.FieldGenerateIntentReasoningEffort
+
+	for _, tc := range []struct {
+		effort  inference.ReasoningEffort
+		want    inference.ReasoningEffort
+		dropped bool
+	}{
+		{effort: inference.ReasoningMinimal, want: inference.ReasoningLow, dropped: true},
+		{effort: inference.ReasoningLow, want: inference.ReasoningLow},
+		{effort: inference.ReasoningMedium, want: inference.ReasoningMedium},
+		{effort: inference.ReasoningHigh, want: inference.ReasoningHigh},
+		{effort: inference.ReasoningXHigh, want: inference.ReasoningHigh, dropped: true},
+	} {
+		request := conformanceTextRequest()
+		request.Input.Content.Intent.Text = &inference.TextIntent{
+			ReasoningEffort: tc.effort,
+		}
+		compiled, err := compile(
+			context.Background(),
+			model,
+			request,
+			inference.GenerateExecutionUnary,
+		)
+		if err != nil {
+			t.Fatalf("effort %q: compile: %v", tc.effort, err)
+		}
+		if compiled.Wire.reasoning == nil ||
+			compiled.Wire.reasoning.effort != string(tc.want) {
+			t.Fatalf(
+				"effort %q: wire = %+v, want %q",
+				tc.effort,
+				compiled.Wire.reasoning,
+				tc.want,
+			)
+		}
+		if got := compiled.Report.Dropped(field); got != tc.dropped {
+			t.Fatalf("effort %q: dropped = %v, want %v", tc.effort, got, tc.dropped)
+		}
+	}
+}
+
+func TestSpecBinaryReasoningEffortDropsAndEnablesThinking(t *testing.T) {
+	entry := catalogEntry{
+		kind:         kindGenerate,
+		capabilities: generateChatCapabilities().WithReasoning(inference.ReasoningToggle),
+	}
+	compile := compileGenerate("spec-binary", entry)
+	request := conformanceTextRequest()
+	request.Input.Content.Intent.Text = &inference.TextIntent{
+		ReasoningEffort: inference.ReasoningHigh,
+	}
+	compiled, err := compile(
+		context.Background(),
+		conformanceModel("spec-binary"),
+		request,
+		inference.GenerateExecutionUnary,
+	)
+	if err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+	if !compiled.Report.Dropped(inference.FieldGenerateIntentReasoningEffort) {
+		t.Fatal("binary thinking model must drop the effort with a reason")
+	}
+	if compiled.Wire.thinking == nil || !*compiled.Wire.thinking {
+		t.Fatalf("binary drop must enable thinking, got %v", compiled.Wire.thinking)
+	}
+	if compiled.Wire.reasoning != nil {
+		t.Fatalf("wire reasoning = %+v, want nil", compiled.Wire.reasoning)
+	}
+}

--- a/driver/deepseek/catalog.go
+++ b/driver/deepseek/catalog.go
@@ -29,6 +29,11 @@ const (
 type catalogEntry struct {
 	kind         modelKind
 	capabilities inference.ModelCapabilities
+	// efforts is the reasoning_effort dial both V4 models accept
+	// (low/medium/high/xhigh per the DeepSeek docs; the API aliases
+	// medium to high and xhigh to max). Minimal is not a DeepSeek wire
+	// level and resolves to low.
+	efforts []inference.ReasoningEffort
 	// api is the provider-level generate surface selected by Spec.API.
 	api apiMode
 	// declared marks a Spec.Models entry (as opposed to a built-in catalog
@@ -90,6 +95,12 @@ var catalog = map[string]catalogEntry{
 		capabilities: generateChatCapabilities().
 			WithHostedWebSearch().
 			WithReasoning(inference.ReasoningToggle),
+		efforts: []inference.ReasoningEffort{
+			inference.ReasoningLow,
+			inference.ReasoningMedium,
+			inference.ReasoningHigh,
+			inference.ReasoningXHigh,
+		},
 		responses:      true,
 		maxInputTokens: 1_000_000,
 	},
@@ -98,6 +109,12 @@ var catalog = map[string]catalogEntry{
 		capabilities: generateChatCapabilities().
 			WithHostedWebSearch().
 			WithReasoning(inference.ReasoningToggle),
+		efforts: []inference.ReasoningEffort{
+			inference.ReasoningLow,
+			inference.ReasoningMedium,
+			inference.ReasoningHigh,
+			inference.ReasoningXHigh,
+		},
 		responses:      true,
 		maxInputTokens: 1_000_000,
 	},

--- a/driver/deepseek/catalog.go
+++ b/driver/deepseek/catalog.go
@@ -29,11 +29,6 @@ const (
 type catalogEntry struct {
 	kind         modelKind
 	capabilities inference.ModelCapabilities
-	// efforts is the reasoning_effort dial both V4 models accept
-	// (low/medium/high/xhigh per the DeepSeek docs; the API aliases
-	// medium to high and xhigh to max). Minimal is not a DeepSeek wire
-	// level and resolves to low.
-	efforts []inference.ReasoningEffort
 	// api is the provider-level generate surface selected by Spec.API.
 	api apiMode
 	// declared marks a Spec.Models entry (as opposed to a built-in catalog
@@ -46,6 +41,21 @@ type catalogEntry struct {
 	// undeclared. Both V4 models carry the 1M context published on
 	// https://api-docs.deepseek.com/quick_start/pricing.
 	maxInputTokens int
+}
+
+// deepseekEffortMap is the canonical-to-wire map the V4 family declares.
+// DeepSeek's public thinking-mode ladder is low/high/max: low stays low,
+// medium folds onto high, and the canonical top level is sent as the
+// provider's max wire level (DeepSeek's own xhigh request token folds to
+// high, so max is how this capability exposes the top tier). Minimal is
+// not a DeepSeek wire level and folds onto low. Both deepseek-v4-flash
+// and deepseek-v4-pro publish the same mapping.
+var deepseekEffortMap = map[inference.ReasoningEffort]string{
+	inference.ReasoningMinimal: string(inference.ReasoningLow),
+	inference.ReasoningLow:     string(inference.ReasoningLow),
+	inference.ReasoningMedium:  string(inference.ReasoningHigh),
+	inference.ReasoningHigh:    string(inference.ReasoningHigh),
+	inference.ReasoningXHigh:   "max",
 }
 
 // validate enforces the generate family contract: the compiler only serves
@@ -64,8 +74,9 @@ func (e catalogEntry) validate() error {
 }
 
 // generateChatCapabilities is the capability declaration for the DeepSeek
-// text compiler family: text/data/tool parts in, text out. DeepSeek
-// consumes no image/audio/video input.
+// text compiler family: text/data/tool parts in, text out. The base family
+// consumes no image/audio/video input; the vision model extends it with
+// image input.
 func generateChatCapabilities() inference.ModelCapabilities {
 	return inference.ModelCapabilities{
 		Inputs: []message.PartKind{
@@ -83,24 +94,23 @@ func generateChatCapabilities() inference.ModelCapabilities {
 //   - https://api-docs.deepseek.com/quick_start/pricing
 //   - https://api-docs.deepseek.com/guides/responses_api
 //   - https://api-docs.deepseek.com/guides/thinking_mode
+//   - https://api-docs.deepseek.com/news/news260821
 //
 // The legacy `deepseek-chat` / `deepseek-reasoner` aliases retired on
 // 2026-07-24 and are deliberately absent. Both V4 models are hybrid
 // thinking models (thinking enabled by default) with a 1M token context.
 // The Responses API serves both V4 models; deepseek-v4-pro support
-// landed after the initial flash-only launch.
+// landed after the initial flash-only launch. The experimental vision
+// model matches V4-Flash's text/agent capabilities, adds image input
+// (JPEG/PNG/GIF/WebP via URL or base64), and supports the same Responses
+// surface and hosted web search. It has no video or audio input.
 var catalog = map[string]catalogEntry{
 	"deepseek-v4-flash": {
 		kind: kindGenerate,
 		capabilities: generateChatCapabilities().
 			WithHostedWebSearch().
-			WithReasoning(inference.ReasoningToggle),
-		efforts: []inference.ReasoningEffort{
-			inference.ReasoningLow,
-			inference.ReasoningMedium,
-			inference.ReasoningHigh,
-			inference.ReasoningXHigh,
-		},
+			WithReasoning(inference.ReasoningToggle).
+			WithReasoningEffortMap(deepseekEffortMap),
 		responses:      true,
 		maxInputTokens: 1_000_000,
 	},
@@ -108,13 +118,18 @@ var catalog = map[string]catalogEntry{
 		kind: kindGenerate,
 		capabilities: generateChatCapabilities().
 			WithHostedWebSearch().
-			WithReasoning(inference.ReasoningToggle),
-		efforts: []inference.ReasoningEffort{
-			inference.ReasoningLow,
-			inference.ReasoningMedium,
-			inference.ReasoningHigh,
-			inference.ReasoningXHigh,
-		},
+			WithReasoning(inference.ReasoningToggle).
+			WithReasoningEffortMap(deepseekEffortMap),
+		responses:      true,
+		maxInputTokens: 1_000_000,
+	},
+	"deepseek-v4-flash-vision-exp": {
+		kind: kindGenerate,
+		capabilities: generateChatCapabilities().
+			WithInputs(message.PartImage).
+			WithHostedWebSearch().
+			WithReasoning(inference.ReasoningToggle).
+			WithReasoningEffortMap(deepseekEffortMap),
 		responses:      true,
 		maxInputTokens: 1_000_000,
 	},

--- a/driver/deepseek/catalog_test.go
+++ b/driver/deepseek/catalog_test.go
@@ -42,10 +42,40 @@ func TestCatalogPublishesCapabilities(t *testing.T) {
 			t.Fatalf("%s inputs = %v, want tool input", model.Descriptor.ID.Name, capabilities.Inputs)
 		}
 		if !capabilities.HostedWebSearch ||
-			capabilities.Reasoning != inference.ReasoningToggle {
+			capabilities.Reasoning.Kind != inference.ReasoningToggle {
 			t.Fatalf("%s capabilities = %+v", model.Descriptor.ID.Name, capabilities)
 		}
 	}
+}
+
+func TestVisionCatalogDeclaresImageInput(t *testing.T) {
+	provider, err := buildProvider(context.Background(), ResourceSettings{ID: "deepseek"}, nil)
+	if err != nil {
+		t.Fatalf("buildProvider: %v", err)
+	}
+	for _, model := range provider.Models {
+		if model.Descriptor.ID.Name != "deepseek-v4-flash-vision-exp" {
+			continue
+		}
+		if !slices.Contains(
+			model.Descriptor.Capabilities.Inputs,
+			message.PartImage,
+		) {
+			t.Fatalf(
+				"vision model inputs = %v, want image input",
+				model.Descriptor.Capabilities.Inputs,
+			)
+		}
+		if !model.Descriptor.Capabilities.HostedWebSearch ||
+			model.Descriptor.Capabilities.Reasoning.Kind != inference.ReasoningToggle {
+			t.Fatalf(
+				"vision model capabilities = %+v",
+				model.Descriptor.Capabilities,
+			)
+		}
+		return
+	}
+	t.Fatal("vision model missing from provider catalog")
 }
 
 func TestMergedCatalogRejectsMissingTextOutput(t *testing.T) {

--- a/driver/deepseek/doc.go
+++ b/driver/deepseek/doc.go
@@ -6,12 +6,16 @@
 //   - Chat Completions (`api: chat`, the default): text, tool calling,
 //     json_object output, thinking control, reasoning_effort, and the
 //     DeepSeek reasoning_content round-trip that thinking-mode tool loops
-//     require. json_schema output is not available on this surface.
+//     require. json_schema output is not available on this surface. The
+//     deepseek-v4-flash-vision-exp model additionally accepts image input
+//     (URL or base64) in user messages on this surface.
 //   - Responses (`api: responses`): OpenAI-compatible Responses API on
-//     https://api.deepseek.com/responses. Both deepseek-v4-flash and
-//     deepseek-v4-pro support it. The surface adds json_schema output,
-//     hosted web_search, and plain-text reasoning item round-trips.
-//     `include` is intentionally never sent: DeepSeek does not support it.
+//     https://api.deepseek.com/responses. deepseek-v4-flash,
+//     deepseek-v4-pro, and deepseek-v4-flash-vision-exp support it. The
+//     surface adds json_schema output, hosted web_search, and plain-text
+//     reasoning item round-trips. The vision model carries input_image
+//     parts in user messages here too. `include` is intentionally never
+//     sent: DeepSeek does not support it.
 //
 // Credentials come exclusively from resource profiles: `api_key`
 // authenticates every surface, and secret values may reference the

--- a/driver/deepseek/generate.go
+++ b/driver/deepseek/generate.go
@@ -2,6 +2,7 @@ package deepseek
 
 import (
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"strings"
@@ -9,6 +10,7 @@ import (
 	"github.com/GizClaw/flowcraft/core/errdefs"
 	"github.com/GizClaw/flowcraft/core/inference"
 	"github.com/GizClaw/flowcraft/core/message"
+	"github.com/GizClaw/flowcraft/core/message/media"
 )
 
 // generateRaw is the transport stage's normalized completion shared by the
@@ -37,6 +39,17 @@ type rawToolCall struct {
 	id   string
 	name string
 	args []byte
+}
+
+// deepseekImageValue renders one image input for the provider's OpenAI
+// compatible surfaces: inline bytes become a base64 data URL, and URL
+// sources pass through verbatim.
+func deepseekImageValue(source media.ImageSource) string {
+	if source.Kind() == media.SourceInline {
+		return "data:" + source.MediaType() + ";base64," +
+			base64.StdEncoding.EncodeToString(source.Bytes())
+	}
+	return source.URL()
 }
 
 type rawUsage struct {

--- a/driver/deepseek/generate_chat.go
+++ b/driver/deepseek/generate_chat.go
@@ -3,6 +3,7 @@ package deepseek
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"io"
 	"strings"
 
@@ -340,16 +341,36 @@ func compileChatIntent(
 		}
 	}
 	if text.ReasoningEffort != "" {
-		if entry.capabilities.Reasoning == inference.ReasoningNone {
+		switch {
+		case entry.capabilities.Reasoning == inference.ReasoningNone:
 			ledger.reject(
 				inference.FieldGenerateIntentReasoningEffort,
 				"model has no thinking control",
 			)
-		} else {
-			// DeepSeek documents low/medium as aliases for high and
-			// xhigh for max: pass the canonical effort through verbatim
-			// and let the API normalize it.
-			wire.effort = string(text.ReasoningEffort)
+		case len(entry.efforts) == 0:
+			// Spec-declared reasoning models without a dial think by
+			// default, so the request for reasoning itself is honored;
+			// only the level is lost.
+			ledger.drop(
+				inference.FieldGenerateIntentReasoningEffort,
+				"model thinks by default but has no effort dial",
+			)
+		default:
+			mode, exact := inference.ResolveReasoningEffort(
+				text.ReasoningEffort,
+				entry.efforts,
+			)
+			wire.effort = string(mode)
+			if !exact {
+				ledger.drop(
+					inference.FieldGenerateIntentReasoningEffort,
+					fmt.Sprintf(
+						"model quantizes reasoning effort %q to %q",
+						text.ReasoningEffort,
+						mode,
+					),
+				)
+			}
 		}
 	}
 }

--- a/driver/deepseek/generate_chat.go
+++ b/driver/deepseek/generate_chat.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"slices"
 	"strings"
 
 	"github.com/GizClaw/flowcraft/core/errdefs"
@@ -37,6 +38,9 @@ type chatWire struct {
 type wireChatMessage struct {
 	role string // system | user | assistant | tool
 	text string
+	// content carries ordered user content parts when the message mixes
+	// text and images; it stays nil for plain text messages.
+	content []wireContent
 	// reasoning carries the assistant turn's reasoning_content round-trip.
 	// DeepSeek requires it verbatim on every assistant turn that performed
 	// tool calls while thinking ran, so the compiler attaches it natively
@@ -177,21 +181,66 @@ func compileChatMessage(
 		reasoning    strings.Builder
 		sawReasoning bool
 		toolCalls    []wireToolCall
+		content      []wireContent
 	)
+	mediaSeen := false
+	appendText := func(value string) {
+		if mediaSeen {
+			content = append(content, wireContent{
+				kind: wireContentText,
+				text: value,
+			})
+			return
+		}
+		text.WriteString(value)
+	}
 	for _, part := range parts {
 		switch value := part.(type) {
 		case message.TextPart:
-			text.WriteString(value.Text)
+			appendText(value.Text)
 		case message.ImagePart:
-			ledger.reject(fields[message.PartImage], "deepseek models are text-only")
+			if !slices.Contains(entry.capabilities.Inputs, message.PartImage) {
+				ledger.reject(
+					fields[message.PartImage],
+					"model does not accept image input",
+				)
+				continue
+			}
+			if role != "user" {
+				ledger.reject(
+					fields[message.PartImage],
+					"deepseek accepts images in user messages only",
+				)
+				continue
+			}
+			if !mediaSeen {
+				mediaSeen = true
+				if text.Len() > 0 {
+					content = append(content, wireContent{
+						kind: wireContentText,
+						text: text.String(),
+					})
+					text.Reset()
+				}
+			}
+			content = append(content, wireContent{
+				kind: wireContentImage,
+				uri:  deepseekImageValue(value.Source),
+			})
 		case message.VideoPart:
-			ledger.reject(fields[message.PartVideo], "deepseek models are text-only")
+			ledger.reject(
+				fields[message.PartVideo],
+				"deepseek models do not accept video input",
+			)
 		case message.AudioPart:
-			ledger.reject(fields[message.PartAudio], "deepseek models are text-only")
+			ledger.reject(
+				fields[message.PartAudio],
+				"deepseek models do not accept audio input",
+			)
 		case message.FilePart:
 			ledger.reject(fields[message.PartFile], "file references are not supported")
 		case message.DataPart:
-			text.WriteString("\n" + string(value.Value) + "\n")
+			appendText("\n" + string(value.Value) + "\n")
 		case message.ToolCallPart:
 			toolCalls = append(toolCalls, wireToolCall{
 				id:   value.Call.ID,
@@ -226,6 +275,7 @@ func compileChatMessage(
 	wireMsg := wireChatMessage{
 		role:      role,
 		text:      text.String(),
+		content:   content,
 		toolCalls: toolCalls,
 	}
 	if sawReasoning {
@@ -325,12 +375,12 @@ func compileChatIntent(
 	wire.topP = clonePointer(text.TopP)
 	if text.ReasoningEnabled != nil {
 		switch {
-		case entry.capabilities.Reasoning == inference.ReasoningNone:
+		case entry.capabilities.Reasoning.Kind == inference.ReasoningNone:
 			ledger.reject(
 				inference.FieldGenerateIntentReasoningEnabled,
 				"model has no thinking control",
 			)
-		case entry.capabilities.Reasoning == inference.ReasoningAlways &&
+		case entry.capabilities.Reasoning.Kind == inference.ReasoningAlways &&
 			!*text.ReasoningEnabled:
 			ledger.reject(
 				inference.FieldGenerateIntentReasoningEnabled,
@@ -342,12 +392,12 @@ func compileChatIntent(
 	}
 	if text.ReasoningEffort != "" {
 		switch {
-		case entry.capabilities.Reasoning == inference.ReasoningNone:
+		case entry.capabilities.Reasoning.Kind == inference.ReasoningNone:
 			ledger.reject(
 				inference.FieldGenerateIntentReasoningEffort,
 				"model has no thinking control",
 			)
-		case len(entry.efforts) == 0:
+		case len(entry.capabilities.Reasoning.EffortMap) == 0:
 			// Spec-declared reasoning models without a dial think by
 			// default, so the request for reasoning itself is honored;
 			// only the level is lost.
@@ -356,16 +406,15 @@ func compileChatIntent(
 				"model thinks by default but has no effort dial",
 			)
 		default:
-			mode, exact := inference.ResolveReasoningEffort(
+			mode, _ := entry.capabilities.Reasoning.ResolveEffort(
 				text.ReasoningEffort,
-				entry.efforts,
 			)
-			wire.effort = string(mode)
-			if !exact {
+			wire.effort = mode
+			if mode != string(text.ReasoningEffort) {
 				ledger.drop(
 					inference.FieldGenerateIntentReasoningEffort,
 					fmt.Sprintf(
-						"model quantizes reasoning effort %q to %q",
+						"model maps reasoning effort %q to %q",
 						text.ReasoningEffort,
 						mode,
 					),
@@ -500,10 +549,45 @@ func wireChatMessagesToParams(
 				openaigo.ChatCompletionMessageParamUnion{OfAssistant: &assistant},
 			)
 		default:
-			out = append(out, openaigo.UserMessage(message.text))
+			if len(message.content) > 0 {
+				out = append(out, openaigo.UserMessage(
+					chatUserContent(message.content),
+				))
+			} else {
+				out = append(out, openaigo.UserMessage(message.text))
+			}
 		}
 	}
 	return out
+}
+
+func chatUserContent(
+	content []wireContent,
+) []openaigo.ChatCompletionContentPartUnionParam {
+	parts := make(
+		[]openaigo.ChatCompletionContentPartUnionParam,
+		0,
+		len(content),
+	)
+	for _, part := range content {
+		switch part.kind {
+		case wireContentText:
+			parts = append(parts, openaigo.ChatCompletionContentPartUnionParam{
+				OfText: &openaigo.ChatCompletionContentPartTextParam{
+					Text: part.text,
+				},
+			})
+		case wireContentImage:
+			parts = append(parts, openaigo.ChatCompletionContentPartUnionParam{
+				OfImageURL: &openaigo.ChatCompletionContentPartImageParam{
+					ImageURL: openaigo.ChatCompletionContentPartImageImageURLParam{
+						URL: part.uri,
+					},
+				},
+			})
+		}
+	}
+	return parts
 }
 
 // transportChatGenerate executes the compiled request against the chat

--- a/driver/deepseek/generate_chat.go
+++ b/driver/deepseek/generate_chat.go
@@ -398,12 +398,15 @@ func compileChatIntent(
 				"model has no thinking control",
 			)
 		case len(entry.capabilities.Reasoning.EffortMap) == 0:
-			// Spec-declared reasoning models without a dial think by
-			// default, so the request for reasoning itself is honored;
-			// only the level is lost.
+			// Spec-declared reasoning models without a dial: honor the
+			// request for reasoning itself at the default depth and report
+			// the lost level. Built-in DeepSeek models think by default,
+			// but a custom spec model has no such guarantee.
+			on := true
+			wire.thinking = &on
 			ledger.drop(
 				inference.FieldGenerateIntentReasoningEffort,
-				"model thinks by default but has no effort dial",
+				"model has no effort dial; thinking enabled at default depth",
 			)
 		default:
 			mode, _ := entry.capabilities.Reasoning.ResolveEffort(

--- a/driver/deepseek/generate_responses.go
+++ b/driver/deepseek/generate_responses.go
@@ -410,12 +410,14 @@ func compileResponsesIntent(
 				"model has no thinking control",
 			)
 		case len(entry.capabilities.Reasoning.EffortMap) == 0:
-			// Spec-declared reasoning models without a dial think by
-			// default, so the request for reasoning itself is honored;
-			// only the level is lost.
+			// Spec-declared reasoning models without a dial: honor the
+			// request for reasoning itself at the documented default depth
+			// and report the lost level. Built-in DeepSeek models think by
+			// default, but a custom spec model has no such guarantee.
+			wire.reasoning = "high"
 			ledger.drop(
 				inference.FieldGenerateIntentReasoningEffort,
-				"model thinks by default but has no effort dial",
+				"model has no effort dial; thinking enabled at default depth",
 			)
 		default:
 			mode, _ := entry.capabilities.Reasoning.ResolveEffort(

--- a/driver/deepseek/generate_responses.go
+++ b/driver/deepseek/generate_responses.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"slices"
 	"strings"
 
 	"github.com/GizClaw/flowcraft/core/errdefs"
@@ -70,6 +71,9 @@ const (
 type wireContent struct {
 	kind wireContentKind
 	text string
+	// uri carries an absolute URL or a data: URI assembled from inline
+	// bytes. It is only populated for image content.
+	uri string
 }
 
 type wireTextFormat struct {
@@ -94,7 +98,8 @@ type wireWebSearch struct {
 // compileResponsesGenerate lowers a canonical request into the DeepSeek
 // Responses wire. DeepSeek's surface is OpenAI-compatible but has its own
 // rules: plain-text reasoning items (no encrypted payload), no include,
-// text-only input, and hosted web_search on supported models.
+// image input on the vision model (user messages only), and hosted
+// web_search on supported models.
 func compileResponsesGenerate(
 	model string,
 	entry catalogEntry,
@@ -198,10 +203,24 @@ func compileResponsesMessage(
 				text: "\n" + string(value.Value) + "\n",
 			})
 		case message.ImagePart:
-			ledger.reject(
-				fields[message.PartImage],
-				"deepseek responses models are text-only",
-			)
+			if !slices.Contains(entry.capabilities.Inputs, message.PartImage) {
+				ledger.reject(
+					fields[message.PartImage],
+					"model does not accept image input",
+				)
+				continue
+			}
+			if role != "user" {
+				ledger.reject(
+					fields[message.PartImage],
+					"deepseek responses accepts images in user messages only",
+				)
+				continue
+			}
+			content = append(content, wireContent{
+				kind: wireContentImage,
+				uri:  deepseekImageValue(value.Source),
+			})
 		case message.AudioPart:
 			ledger.reject(
 				fields[message.PartAudio],
@@ -254,7 +273,7 @@ func compileResponsesReasoning(
 		ledger.reject(field, "reasoning parts belong to assistant context")
 		return
 	}
-	if entry.capabilities.Reasoning == inference.ReasoningNone {
+	if entry.capabilities.Reasoning.Kind == inference.ReasoningNone {
 		ledger.drop(field, "model has no reasoning channel")
 		return
 	}
@@ -366,18 +385,18 @@ func compileResponsesIntent(
 	wire.topP = clonePointer(text.TopP)
 	if text.ReasoningEnabled != nil {
 		switch {
-		case entry.capabilities.Reasoning == inference.ReasoningNone:
+		case entry.capabilities.Reasoning.Kind == inference.ReasoningNone:
 			ledger.reject(
 				inference.FieldGenerateIntentReasoningEnabled,
 				"model has no thinking control",
 			)
-		case entry.capabilities.Reasoning == inference.ReasoningAlways &&
+		case entry.capabilities.Reasoning.Kind == inference.ReasoningAlways &&
 			!*text.ReasoningEnabled:
 			ledger.reject(
 				inference.FieldGenerateIntentReasoningEnabled,
 				"model cannot disable thinking",
 			)
-		case entry.capabilities.Reasoning == inference.ReasoningToggle &&
+		case entry.capabilities.Reasoning.Kind == inference.ReasoningToggle &&
 			!*text.ReasoningEnabled:
 			wire.reasoning = "none"
 		}
@@ -385,12 +404,12 @@ func compileResponsesIntent(
 	}
 	if text.ReasoningEffort != "" {
 		switch {
-		case entry.capabilities.Reasoning == inference.ReasoningNone:
+		case entry.capabilities.Reasoning.Kind == inference.ReasoningNone:
 			ledger.reject(
 				inference.FieldGenerateIntentReasoningEffort,
 				"model has no thinking control",
 			)
-		case len(entry.efforts) == 0:
+		case len(entry.capabilities.Reasoning.EffortMap) == 0:
 			// Spec-declared reasoning models without a dial think by
 			// default, so the request for reasoning itself is honored;
 			// only the level is lost.
@@ -399,16 +418,15 @@ func compileResponsesIntent(
 				"model thinks by default but has no effort dial",
 			)
 		default:
-			mode, exact := inference.ResolveReasoningEffort(
+			mode, _ := entry.capabilities.Reasoning.ResolveEffort(
 				text.ReasoningEffort,
-				entry.efforts,
 			)
-			wire.reasoning = string(mode)
-			if !exact {
+			wire.reasoning = mode
+			if mode != string(text.ReasoningEffort) {
 				ledger.drop(
 					inference.FieldGenerateIntentReasoningEffort,
 					fmt.Sprintf(
-						"model quantizes reasoning effort %q to %q",
+						"model maps reasoning effort %q to %q",
 						text.ReasoningEffort,
 						mode,
 					),
@@ -585,6 +603,13 @@ func responseMessageContent(
 		case wireContentText:
 			list = append(list, responses.ResponseInputContentUnionParam{
 				OfInputText: &responses.ResponseInputTextParam{Text: part.text},
+			})
+		case wireContentImage:
+			list = append(list, responses.ResponseInputContentUnionParam{
+				OfInputImage: &responses.ResponseInputImageParam{
+					Detail:   responses.ResponseInputImageDetailAuto,
+					ImageURL: param.NewOpt(part.uri),
+				},
 			})
 		}
 	}

--- a/driver/deepseek/generate_responses.go
+++ b/driver/deepseek/generate_responses.go
@@ -384,13 +384,36 @@ func compileResponsesIntent(
 		// enabled == true is a no-op: DeepSeek thinks by default.
 	}
 	if text.ReasoningEffort != "" {
-		if entry.capabilities.Reasoning == inference.ReasoningNone {
+		switch {
+		case entry.capabilities.Reasoning == inference.ReasoningNone:
 			ledger.reject(
 				inference.FieldGenerateIntentReasoningEffort,
 				"model has no thinking control",
 			)
-		} else {
-			wire.reasoning = string(text.ReasoningEffort)
+		case len(entry.efforts) == 0:
+			// Spec-declared reasoning models without a dial think by
+			// default, so the request for reasoning itself is honored;
+			// only the level is lost.
+			ledger.drop(
+				inference.FieldGenerateIntentReasoningEffort,
+				"model thinks by default but has no effort dial",
+			)
+		default:
+			mode, exact := inference.ResolveReasoningEffort(
+				text.ReasoningEffort,
+				entry.efforts,
+			)
+			wire.reasoning = string(mode)
+			if !exact {
+				ledger.drop(
+					inference.FieldGenerateIntentReasoningEffort,
+					fmt.Sprintf(
+						"model quantizes reasoning effort %q to %q",
+						text.ReasoningEffort,
+						mode,
+					),
+				)
+			}
 		}
 	}
 }

--- a/driver/deepseek/reasoning_test.go
+++ b/driver/deepseek/reasoning_test.go
@@ -1,0 +1,117 @@
+package deepseek
+
+import (
+	"context"
+	"testing"
+
+	"github.com/GizClaw/flowcraft/core/inference"
+)
+
+func TestDeepSeekReasoningEffortResolvesAgainstPrivateDial(t *testing.T) {
+	compile := compileChatGenerate("deepseek-v4-flash", catalog["deepseek-v4-flash"])
+	model := conformanceModel("deepseek-v4-flash")
+	field := inference.FieldGenerateIntentReasoningEffort
+
+	for _, tc := range []struct {
+		effort  inference.ReasoningEffort
+		want    inference.ReasoningEffort
+		dropped bool
+	}{
+		{effort: inference.ReasoningMinimal, want: inference.ReasoningLow, dropped: true},
+		{effort: inference.ReasoningLow, want: inference.ReasoningLow},
+		{effort: inference.ReasoningMedium, want: inference.ReasoningMedium},
+		{effort: inference.ReasoningHigh, want: inference.ReasoningHigh},
+		{effort: inference.ReasoningXHigh, want: inference.ReasoningXHigh},
+	} {
+		request := conformanceTextRequest()
+		request.Input.Content.Intent.Text = &inference.TextIntent{
+			ReasoningEffort: tc.effort,
+		}
+		compiled, err := compile(
+			context.Background(),
+			model,
+			request,
+			inference.GenerateExecutionUnary,
+		)
+		if err != nil {
+			t.Fatalf("effort %q: compile: %v", tc.effort, err)
+		}
+		if compiled.Wire.effort != string(tc.want) {
+			t.Fatalf(
+				"effort %q: wire = %q, want %q",
+				tc.effort,
+				compiled.Wire.effort,
+				tc.want,
+			)
+		}
+		if got := compiled.Report.Dropped(field); got != tc.dropped {
+			t.Fatalf("effort %q: dropped = %v, want %v", tc.effort, got, tc.dropped)
+		}
+	}
+}
+
+func TestDeepSeekResponsesReasoningEffortResolvesAgainstPrivateDial(t *testing.T) {
+	compile := compileResponsesGenerate("deepseek-v4-flash", catalog["deepseek-v4-flash"])
+	model := conformanceModel("deepseek-v4-flash")
+	field := inference.FieldGenerateIntentReasoningEffort
+
+	for _, tc := range []struct {
+		effort  inference.ReasoningEffort
+		want    inference.ReasoningEffort
+		dropped bool
+	}{
+		{effort: inference.ReasoningMinimal, want: inference.ReasoningLow, dropped: true},
+		{effort: inference.ReasoningLow, want: inference.ReasoningLow},
+		{effort: inference.ReasoningMedium, want: inference.ReasoningMedium},
+		{effort: inference.ReasoningHigh, want: inference.ReasoningHigh},
+		{effort: inference.ReasoningXHigh, want: inference.ReasoningXHigh},
+	} {
+		request := conformanceTextRequest()
+		request.Input.Content.Intent.Text = &inference.TextIntent{
+			ReasoningEffort: tc.effort,
+		}
+		compiled, err := compile(
+			context.Background(),
+			model,
+			request,
+			inference.GenerateExecutionUnary,
+		)
+		if err != nil {
+			t.Fatalf("effort %q: compile: %v", tc.effort, err)
+		}
+		if compiled.Wire.reasoning != string(tc.want) {
+			t.Fatalf(
+				"effort %q: wire = %q, want %q",
+				tc.effort,
+				compiled.Wire.reasoning,
+				tc.want,
+			)
+		}
+		if got := compiled.Report.Dropped(field); got != tc.dropped {
+			t.Fatalf("effort %q: dropped = %v, want %v", tc.effort, got, tc.dropped)
+		}
+	}
+}
+
+func TestChatSpecBinaryReasoningEffortDrops(t *testing.T) {
+	compile := compileChatGenerate("spec-binary", chatEntry())
+	request := conformanceTextRequest()
+	request.Input.Content.Intent.Text = &inference.TextIntent{
+		ReasoningEffort: inference.ReasoningHigh,
+	}
+	compiled, err := compile(
+		context.Background(),
+		conformanceModel("spec-binary"),
+		request,
+		inference.GenerateExecutionUnary,
+	)
+	if err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+	if !compiled.Report.Dropped(inference.FieldGenerateIntentReasoningEffort) {
+		t.Fatal("binary model must drop the effort with a reason")
+	}
+	if compiled.Wire.effort != "" {
+		t.Fatalf("wire effort = %q, want empty", compiled.Wire.effort)
+	}
+}

--- a/driver/deepseek/reasoning_test.go
+++ b/driver/deepseek/reasoning_test.go
@@ -93,7 +93,7 @@ func TestDeepSeekResponsesReasoningEffortResolvesFromCapabilityMap(t *testing.T)
 	}
 }
 
-func TestChatSpecBinaryReasoningEffortDrops(t *testing.T) {
+func TestChatSpecBinaryReasoningEffortEnablesThinkingAndDrops(t *testing.T) {
 	compile := compileChatGenerate("spec-binary", chatEntry())
 	request := conformanceTextRequest()
 	request.Input.Content.Intent.Text = &inference.TextIntent{
@@ -113,5 +113,31 @@ func TestChatSpecBinaryReasoningEffortDrops(t *testing.T) {
 	}
 	if compiled.Wire.effort != "" {
 		t.Fatalf("wire effort = %q, want empty", compiled.Wire.effort)
+	}
+	if compiled.Wire.thinking == nil || !*compiled.Wire.thinking {
+		t.Fatalf("wire thinking = %v, want enabled", compiled.Wire.thinking)
+	}
+}
+
+func TestResponsesSpecBinaryReasoningEffortEnablesThinkingAndDrops(t *testing.T) {
+	compile := compileResponsesGenerate("spec-binary", responsesEntry())
+	request := conformanceTextRequest()
+	request.Input.Content.Intent.Text = &inference.TextIntent{
+		ReasoningEffort: inference.ReasoningHigh,
+	}
+	compiled, err := compile(
+		context.Background(),
+		conformanceModel("spec-binary"),
+		request,
+		inference.GenerateExecutionUnary,
+	)
+	if err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+	if !compiled.Report.Dropped(inference.FieldGenerateIntentReasoningEffort) {
+		t.Fatal("binary model must drop the effort with a reason")
+	}
+	if compiled.Wire.reasoning != "high" {
+		t.Fatalf("wire reasoning = %q, want high", compiled.Wire.reasoning)
 	}
 }

--- a/driver/deepseek/reasoning_test.go
+++ b/driver/deepseek/reasoning_test.go
@@ -7,21 +7,21 @@ import (
 	"github.com/GizClaw/flowcraft/core/inference"
 )
 
-func TestDeepSeekReasoningEffortResolvesAgainstPrivateDial(t *testing.T) {
+func TestDeepSeekChatReasoningEffortResolvesFromCapabilityMap(t *testing.T) {
 	compile := compileChatGenerate("deepseek-v4-flash", catalog["deepseek-v4-flash"])
 	model := conformanceModel("deepseek-v4-flash")
 	field := inference.FieldGenerateIntentReasoningEffort
 
 	for _, tc := range []struct {
 		effort  inference.ReasoningEffort
-		want    inference.ReasoningEffort
+		want    string
 		dropped bool
 	}{
-		{effort: inference.ReasoningMinimal, want: inference.ReasoningLow, dropped: true},
-		{effort: inference.ReasoningLow, want: inference.ReasoningLow},
-		{effort: inference.ReasoningMedium, want: inference.ReasoningMedium},
-		{effort: inference.ReasoningHigh, want: inference.ReasoningHigh},
-		{effort: inference.ReasoningXHigh, want: inference.ReasoningXHigh},
+		{effort: inference.ReasoningMinimal, want: "low", dropped: true},
+		{effort: inference.ReasoningLow, want: "low"},
+		{effort: inference.ReasoningMedium, want: "high", dropped: true},
+		{effort: inference.ReasoningHigh, want: "high"},
+		{effort: inference.ReasoningXHigh, want: "max", dropped: true},
 	} {
 		request := conformanceTextRequest()
 		request.Input.Content.Intent.Text = &inference.TextIntent{
@@ -36,7 +36,7 @@ func TestDeepSeekReasoningEffortResolvesAgainstPrivateDial(t *testing.T) {
 		if err != nil {
 			t.Fatalf("effort %q: compile: %v", tc.effort, err)
 		}
-		if compiled.Wire.effort != string(tc.want) {
+		if compiled.Wire.effort != tc.want {
 			t.Fatalf(
 				"effort %q: wire = %q, want %q",
 				tc.effort,
@@ -50,21 +50,21 @@ func TestDeepSeekReasoningEffortResolvesAgainstPrivateDial(t *testing.T) {
 	}
 }
 
-func TestDeepSeekResponsesReasoningEffortResolvesAgainstPrivateDial(t *testing.T) {
+func TestDeepSeekResponsesReasoningEffortResolvesFromCapabilityMap(t *testing.T) {
 	compile := compileResponsesGenerate("deepseek-v4-flash", catalog["deepseek-v4-flash"])
 	model := conformanceModel("deepseek-v4-flash")
 	field := inference.FieldGenerateIntentReasoningEffort
 
 	for _, tc := range []struct {
 		effort  inference.ReasoningEffort
-		want    inference.ReasoningEffort
+		want    string
 		dropped bool
 	}{
-		{effort: inference.ReasoningMinimal, want: inference.ReasoningLow, dropped: true},
-		{effort: inference.ReasoningLow, want: inference.ReasoningLow},
-		{effort: inference.ReasoningMedium, want: inference.ReasoningMedium},
-		{effort: inference.ReasoningHigh, want: inference.ReasoningHigh},
-		{effort: inference.ReasoningXHigh, want: inference.ReasoningXHigh},
+		{effort: inference.ReasoningMinimal, want: "low", dropped: true},
+		{effort: inference.ReasoningLow, want: "low"},
+		{effort: inference.ReasoningMedium, want: "high", dropped: true},
+		{effort: inference.ReasoningHigh, want: "high"},
+		{effort: inference.ReasoningXHigh, want: "max", dropped: true},
 	} {
 		request := conformanceTextRequest()
 		request.Input.Content.Intent.Text = &inference.TextIntent{
@@ -79,7 +79,7 @@ func TestDeepSeekResponsesReasoningEffortResolvesAgainstPrivateDial(t *testing.T
 		if err != nil {
 			t.Fatalf("effort %q: compile: %v", tc.effort, err)
 		}
-		if compiled.Wire.reasoning != string(tc.want) {
+		if compiled.Wire.reasoning != tc.want {
 			t.Fatalf(
 				"effort %q: wire = %q, want %q",
 				tc.effort,

--- a/driver/deepseek/resource.go
+++ b/driver/deepseek/resource.go
@@ -157,7 +157,7 @@ func buildProvider(ctx context.Context, settings ResourceSettings, secrets *reso
 }
 
 // openersFor binds one catalog model to the generate opener for its kind.
-// DeepSeek exposes only text generate today.
+// DeepSeek exposes only text-output generate today.
 func openersFor(
 	spec Spec,
 	entry catalogEntry,

--- a/driver/deepseek/resource_test.go
+++ b/driver/deepseek/resource_test.go
@@ -103,12 +103,12 @@ func TestResponsesProviderAllowsDeclaredOverride(t *testing.T) {
 		t.Fatalf("New: %v", err)
 	}
 	provider, ok := value.(inference.ProviderDefinition)
-	if !ok || len(provider.Models) != 2 {
+	if !ok || len(provider.Models) != 3 {
 		t.Fatalf("provider = %+v", provider)
 	}
 }
 
-func TestResponsesProviderBuildsBothV4Models(t *testing.T) {
+func TestResponsesProviderBuildsV4Family(t *testing.T) {
 	value, err := Factory().New(context.Background(), resource.Input{
 		Settings: json.RawMessage(`{
 			"id": "deepseek",
@@ -130,8 +130,13 @@ func TestResponsesProviderBuildsBothV4Models(t *testing.T) {
 	for _, model := range provider.Models {
 		names[model.Descriptor.ID.Name] = true
 	}
-	if !names["deepseek-v4-flash"] || !names["deepseek-v4-pro"] {
-		t.Fatalf("responses provider models = %v, want flash + pro", names)
+	if !names["deepseek-v4-flash"] ||
+		!names["deepseek-v4-pro"] ||
+		!names["deepseek-v4-flash-vision-exp"] {
+		t.Fatalf(
+			"responses provider models = %v, want flash + pro + vision",
+			names,
+		)
 	}
 }
 

--- a/driver/deepseek/spec.go
+++ b/driver/deepseek/spec.go
@@ -44,8 +44,8 @@ type ModelSpec struct {
 	// Capabilities declares the model's input/output content kinds, hosted
 	// web search support, and reasoning control capability.
 	Capabilities inference.ModelCapabilities `json:"capabilities,omitempty"`
-	// Responses declares Responses API support (deepseek-v4-flash and
-	// deepseek-v4-pro).
+	// Responses declares Responses API support (deepseek-v4-flash,
+	// deepseek-v4-pro, and deepseek-v4-flash-vision-exp).
 	Responses bool `json:"responses,omitempty"`
 }
 

--- a/driver/deepseek/vision_test.go
+++ b/driver/deepseek/vision_test.go
@@ -1,0 +1,236 @@
+package deepseek
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/GizClaw/flowcraft/core/inference"
+	"github.com/GizClaw/flowcraft/core/message"
+	"github.com/GizClaw/flowcraft/core/message/media"
+)
+
+func visionModel() string { return "deepseek-v4-flash-vision-exp" }
+
+func visionRequest() inference.GenerateRequest {
+	source, err := media.NewImageURL(
+		"https://example.com/cat.png",
+		"image/png",
+	)
+	if err != nil {
+		panic(err)
+	}
+	request := conformanceTextRequest()
+	request.Input.Content.Parts = []message.Part{
+		message.TextPart{Text: "describe this"},
+		message.ImagePart{Source: source},
+	}
+	return request
+}
+
+func TestVisionChatAcceptsImageInput(t *testing.T) {
+	compiled, err := compileChatGenerate(
+		visionModel(),
+		catalog[visionModel()],
+	)(
+		context.Background(),
+		conformanceModel(visionModel()),
+		visionRequest(),
+		inference.GenerateExecutionUnary,
+	)
+	if err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+	last := compiled.Wire.messages[len(compiled.Wire.messages)-1]
+	if len(last.content) != 2 {
+		t.Fatalf("user content parts = %d, want 2", len(last.content))
+	}
+	if last.content[0].kind != wireContentText ||
+		last.content[0].text != "describe this" {
+		t.Fatalf("first content part = %+v, want text", last.content[0])
+	}
+	if last.content[1].kind != wireContentImage ||
+		last.content[1].uri != "https://example.com/cat.png" {
+		t.Fatalf("second content part = %+v, want image URL", last.content[1])
+	}
+}
+
+func TestVisionResponsesAcceptsImageInput(t *testing.T) {
+	compiled, err := compileResponsesGenerate(
+		visionModel(),
+		catalog[visionModel()],
+	)(
+		context.Background(),
+		conformanceModel(visionModel()),
+		visionRequest(),
+		inference.GenerateExecutionUnary,
+	)
+	if err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+	last := compiled.Wire.items[len(compiled.Wire.items)-1]
+	if last.kind != responseWireItemMessage ||
+		last.role != "user" ||
+		len(last.content) != 2 {
+		t.Fatalf("last item = %+v, want user message with two parts", last)
+	}
+	if last.content[1].kind != wireContentImage ||
+		last.content[1].uri != "https://example.com/cat.png" {
+		t.Fatalf("image content = %+v, want image URL", last.content[1])
+	}
+}
+
+func TestVisionChatInlineImageBecomesDataURL(t *testing.T) {
+	source, err := media.NewImageBytes(
+		[]byte{0x89, 'P', 'N', 'G'},
+		"image/png",
+	)
+	if err != nil {
+		t.Fatalf("NewImageBytes: %v", err)
+	}
+	request := conformanceTextRequest()
+	request.Input.Content.Parts = []message.Part{
+		message.ImagePart{Source: source},
+	}
+	compiled, err := compileChatGenerate(
+		visionModel(),
+		catalog[visionModel()],
+	)(
+		context.Background(),
+		conformanceModel(visionModel()),
+		request,
+		inference.GenerateExecutionUnary,
+	)
+	if err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+	last := compiled.Wire.messages[len(compiled.Wire.messages)-1]
+	if len(last.content) != 1 {
+		t.Fatalf("user content parts = %d, want 1", len(last.content))
+	}
+	if !strings.HasPrefix(
+		last.content[0].uri,
+		"data:image/png;base64,",
+	) {
+		t.Fatalf("inline image uri = %q, want base64 data URL", last.content[0].uri)
+	}
+}
+
+func TestChatUserContentBuildsImagePart(t *testing.T) {
+	parts := chatUserContent([]wireContent{
+		{kind: wireContentText, text: "describe"},
+		{kind: wireContentImage, uri: "https://example.com/cat.png"},
+	})
+	if len(parts) != 2 {
+		t.Fatalf("content parts = %d, want 2", len(parts))
+	}
+	if parts[0].OfText == nil || parts[0].OfText.Text != "describe" {
+		t.Fatalf("first content part = %+v, want text", parts[0])
+	}
+	if parts[1].OfImageURL == nil ||
+		parts[1].OfImageURL.ImageURL.URL != "https://example.com/cat.png" {
+		t.Fatalf("second content part = %+v, want image URL", parts[1])
+	}
+}
+
+func TestTextModelsRejectImageInput(t *testing.T) {
+	request := visionRequest()
+	if _, err := compileChatGenerate(
+		"deepseek-v4-flash",
+		catalog["deepseek-v4-flash"],
+	)(
+		context.Background(),
+		conformanceModel("deepseek-v4-flash"),
+		request,
+		inference.GenerateExecutionUnary,
+	); err == nil {
+		t.Fatal("chat compiler accepted an image on a text-only model")
+	}
+	if _, err := compileResponsesGenerate(
+		"deepseek-v4-flash",
+		catalog["deepseek-v4-flash"],
+	)(
+		context.Background(),
+		conformanceModel("deepseek-v4-flash"),
+		request,
+		inference.GenerateExecutionUnary,
+	); err == nil {
+		t.Fatal("responses compiler accepted an image on a text-only model")
+	}
+}
+
+func TestVisionRejectsImagesOutsideUserMessages(t *testing.T) {
+	image := visionRequest().Input.Content.Parts[1]
+	contextTurn := message.Message{
+		Role: message.RoleAssistant,
+		Content: message.Content{Parts: []message.Part{
+			message.TextPart{Text: "ok"},
+			image,
+		}},
+	}
+	for name, compile := range map[string]inference.GenerateCompiler[chatWire]{
+		"chat": compileChatGenerate(visionModel(), catalog[visionModel()]),
+	} {
+		request := conformanceTextRequest()
+		request.Context = []message.Message{contextTurn}
+		if _, err := compile(
+			context.Background(),
+			conformanceModel(visionModel()),
+			request,
+			inference.GenerateExecutionUnary,
+		); err == nil {
+			t.Fatalf("%s compiler accepted an image in an assistant turn", name)
+		}
+	}
+
+	request := conformanceTextRequest()
+	request.Context = []message.Message{contextTurn}
+	if _, err := compileResponsesGenerate(
+		visionModel(),
+		catalog[visionModel()],
+	)(
+		context.Background(),
+		conformanceModel(visionModel()),
+		request,
+		inference.GenerateExecutionUnary,
+	); err == nil {
+		t.Fatal("responses compiler accepted an image in an assistant turn")
+	}
+}
+
+func TestVisionRejectsVideoInput(t *testing.T) {
+	source, err := media.NewVideoURL(
+		"https://example.com/clip.mp4",
+		"video/mp4",
+	)
+	if err != nil {
+		t.Fatalf("NewVideoURL: %v", err)
+	}
+	request := conformanceTextRequest()
+	request.Input.Content.Parts = []message.Part{
+		message.VideoPart{Source: source},
+	}
+	for name, compile := range map[string]inference.GenerateCompiler[chatWire]{
+		"chat": compileChatGenerate(visionModel(), catalog[visionModel()]),
+	} {
+		if _, err := compile(
+			context.Background(),
+			conformanceModel(visionModel()),
+			request,
+			inference.GenerateExecutionUnary,
+		); err == nil {
+			t.Fatalf("%s compiler accepted video input", name)
+		}
+	}
+	if _, err := compileResponsesGenerate(
+		visionModel(),
+		catalog[visionModel()],
+	)(
+		context.Background(),
+		conformanceModel(visionModel()),
+		request,
+		inference.GenerateExecutionUnary,
+	); err == nil {
+		t.Fatal("responses compiler accepted video input")
+	}
+}

--- a/driver/deepseek/vision_test.go
+++ b/driver/deepseek/vision_test.go
@@ -116,6 +116,42 @@ func TestVisionChatInlineImageBecomesDataURL(t *testing.T) {
 	}
 }
 
+func TestVisionResponsesInlineImageBecomesDataURL(t *testing.T) {
+	source, err := media.NewImageBytes(
+		[]byte{0x89, 'P', 'N', 'G'},
+		"image/png",
+	)
+	if err != nil {
+		t.Fatalf("NewImageBytes: %v", err)
+	}
+	request := conformanceTextRequest()
+	request.Input.Content.Parts = []message.Part{
+		message.ImagePart{Source: source},
+	}
+	compiled, err := compileResponsesGenerate(
+		visionModel(),
+		catalog[visionModel()],
+	)(
+		context.Background(),
+		conformanceModel(visionModel()),
+		request,
+		inference.GenerateExecutionUnary,
+	)
+	if err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+	last := compiled.Wire.items[len(compiled.Wire.items)-1]
+	if len(last.content) != 1 {
+		t.Fatalf("user content parts = %d, want 1", len(last.content))
+	}
+	if !strings.HasPrefix(
+		last.content[0].uri,
+		"data:image/png;base64,",
+	) {
+		t.Fatalf("inline image uri = %q, want base64 data URL", last.content[0].uri)
+	}
+}
+
 func TestChatUserContentBuildsImagePart(t *testing.T) {
 	parts := chatUserContent([]wireContent{
 		{kind: wireContentText, text: "describe"},

--- a/driver/kimi/catalog.go
+++ b/driver/kimi/catalog.go
@@ -16,19 +16,19 @@ const kindGenerate modelKind = "generate"
 
 // catalogEntry declares what one catalog model accepts. capabilities is the
 // single capability fact source: input/output content kinds and the reasoning
-// control capability. sampling, reasoningEffort, keepThinking, and
-// keepThinkingAlways are control capabilities that no capability kind
-// expresses and stay separate flags.
+// control capability. efforts, sampling, keepThinking, and keepThinkingAlways
+// are control capabilities that no capability kind expresses and stay
+// separate flags.
 type catalogEntry struct {
 	kind         modelKind
 	capabilities inference.ModelCapabilities
 	// sampling accepts the moonshot-v1 sampling knobs (temperature,
 	// top_p); the K3 / K2.x request schemas carry none.
 	sampling bool
-	// reasoningEffort marks models with the top-level reasoning_effort
-	// dial (kimi-k3 only); elsewhere an explicit effort drops with a
-	// reason.
-	reasoningEffort bool
+	// efforts is the top-level reasoning_effort dial (kimi-k3 only:
+	// low/high/max per the Kimi docs); nil elsewhere, where an explicit
+	// effort drops with a reason.
+	efforts []inference.ReasoningEffort
 	// keepThinking marks models that optionally re-ingest history
 	// reasoning_content via thinking.keep="all" (kimi-k2.6).
 	keepThinking bool
@@ -59,7 +59,11 @@ var catalog = map[string]catalogEntry{
 		capabilities: generateChatCapabilities().
 			WithInputs(message.PartImage, message.PartVideo).
 			WithReasoning(inference.ReasoningAlways),
-		reasoningEffort:    true,
+		efforts: []inference.ReasoningEffort{
+			inference.ReasoningLow,
+			inference.ReasoningHigh,
+			"max",
+		},
 		keepThinkingAlways: true,
 		maxInputTokens:     1_000_000,
 	},
@@ -117,9 +121,6 @@ func (e catalogEntry) validate() error {
 	}
 	if e.keepThinkingAlways && e.capabilities.Reasoning != inference.ReasoningAlways {
 		return fmt.Errorf("always-preserved thinking requires always-on thinking")
-	}
-	if e.reasoningEffort && e.capabilities.Reasoning == inference.ReasoningNone {
-		return fmt.Errorf("reasoning effort requires reasoning")
 	}
 	return nil
 }

--- a/driver/kimi/catalog.go
+++ b/driver/kimi/catalog.go
@@ -16,19 +16,15 @@ const kindGenerate modelKind = "generate"
 
 // catalogEntry declares what one catalog model accepts. capabilities is the
 // single capability fact source: input/output content kinds and the reasoning
-// control capability. efforts, sampling, keepThinking, and keepThinkingAlways
-// are control capabilities that no capability kind expresses and stay
-// separate flags.
+// control capability (switch kind plus the canonical-to-wire effort map).
+// sampling, keepThinking, and keepThinkingAlways are control capabilities
+// that no capability kind expresses and stay separate flags.
 type catalogEntry struct {
 	kind         modelKind
 	capabilities inference.ModelCapabilities
 	// sampling accepts the moonshot-v1 sampling knobs (temperature,
 	// top_p); the K3 / K2.x request schemas carry none.
 	sampling bool
-	// efforts is the top-level reasoning_effort dial (kimi-k3 only:
-	// low/high/max per the Kimi docs); nil elsewhere, where an explicit
-	// effort drops with a reason.
-	efforts []inference.ReasoningEffort
 	// keepThinking marks models that optionally re-ingest history
 	// reasoning_content via thinking.keep="all" (kimi-k2.6).
 	keepThinking bool
@@ -41,6 +37,17 @@ type catalogEntry struct {
 	// https://platform.kimi.com/docs/models (moonshot-v1 variants state
 	// 8k/32k/128k).
 	maxInputTokens int
+}
+
+// kimiK3EffortMap is kimi-k3's canonical-to-wire effort map per the Kimi
+// docs (low/high/max): canonical minimal and medium fold onto low/high,
+// and xhigh reaches the model's top level "max".
+var kimiK3EffortMap = map[inference.ReasoningEffort]string{
+	inference.ReasoningMinimal: string(inference.ReasoningLow),
+	inference.ReasoningLow:     string(inference.ReasoningLow),
+	inference.ReasoningMedium:  string(inference.ReasoningHigh),
+	inference.ReasoningHigh:    string(inference.ReasoningHigh),
+	inference.ReasoningXHigh:   "max",
 }
 
 // catalog reflects Kimi's public API as of 2026-07.
@@ -58,12 +65,8 @@ var catalog = map[string]catalogEntry{
 		kind: kindGenerate,
 		capabilities: generateChatCapabilities().
 			WithInputs(message.PartImage, message.PartVideo).
-			WithReasoning(inference.ReasoningAlways),
-		efforts: []inference.ReasoningEffort{
-			inference.ReasoningLow,
-			inference.ReasoningHigh,
-			"max",
-		},
+			WithReasoning(inference.ReasoningAlways).
+			WithReasoningEffortMap(kimiK3EffortMap),
 		keepThinkingAlways: true,
 		maxInputTokens:     1_000_000,
 	},
@@ -119,7 +122,7 @@ func (e catalogEntry) validate() error {
 	if !slices.Contains(e.capabilities.Outputs, message.PartText) {
 		return fmt.Errorf("generate family must declare text output")
 	}
-	if e.keepThinkingAlways && e.capabilities.Reasoning != inference.ReasoningAlways {
+	if e.keepThinkingAlways && e.capabilities.Reasoning.Kind != inference.ReasoningAlways {
 		return fmt.Errorf("always-preserved thinking requires always-on thinking")
 	}
 	return nil
@@ -166,7 +169,7 @@ func mergedCatalog(spec Spec) (map[string]catalogEntry, error) {
 		)
 		entry.capabilities.HostedWebSearch =
 			entry.capabilities.HostedWebSearch || declared.Capabilities.HostedWebSearch
-		if declared.Capabilities.Reasoning != inference.ReasoningNone {
+		if declared.Capabilities.Reasoning.Kind != inference.ReasoningNone {
 			entry.capabilities.Reasoning = declared.Capabilities.Reasoning
 		}
 		if err := entry.validate(); err != nil {

--- a/driver/kimi/catalog_test.go
+++ b/driver/kimi/catalog_test.go
@@ -60,24 +60,24 @@ func TestCatalogPublishesCapabilities(t *testing.T) {
 	if !reflect.DeepEqual(k3.Capabilities.Outputs, []message.PartKind{message.PartText}) ||
 		!slices.Contains(k3.Capabilities.Inputs, message.PartImage) ||
 		!slices.Contains(k3.Capabilities.Inputs, message.PartVideo) ||
-		k3.Capabilities.Reasoning != inference.ReasoningAlways {
+		k3.Capabilities.Reasoning.Kind != inference.ReasoningAlways {
 		t.Fatalf("kimi-k3 capabilities = %+v", k3.Capabilities)
 	}
 
 	k26 := descriptors["kimi-k2.6"]
 	if !slices.Contains(k26.Capabilities.Inputs, message.PartVideo) ||
-		k26.Capabilities.Reasoning != inference.ReasoningToggle {
+		k26.Capabilities.Reasoning.Kind != inference.ReasoningToggle {
 		t.Fatalf("kimi-k2.6 capabilities = %+v", k26.Capabilities)
 	}
 
 	k27code := descriptors["kimi-k2.7-code"]
 	if !slices.Contains(k27code.Capabilities.Inputs, message.PartVideo) ||
-		k27code.Capabilities.Reasoning != inference.ReasoningAlways {
+		k27code.Capabilities.Reasoning.Kind != inference.ReasoningAlways {
 		t.Fatalf("kimi-k2.7-code capabilities = %+v", k27code.Capabilities)
 	}
 
 	moonshot := descriptors["moonshot-v1-8k"]
-	if moonshot.Capabilities.Reasoning != inference.ReasoningNone ||
+	if moonshot.Capabilities.Reasoning.Kind != inference.ReasoningNone ||
 		len(moonshot.Capabilities.Inputs) == 0 {
 		t.Fatalf("moonshot-v1-8k capabilities = %+v", moonshot.Capabilities)
 	}

--- a/driver/kimi/doc.go
+++ b/driver/kimi/doc.go
@@ -19,7 +19,10 @@
 // # Reasoning dialects
 //
 // Three model families think differently, and the compiler maps the
-// canonical ReasoningEnabled / ReasoningEffort onto each:
+// canonical ReasoningEnabled / ReasoningEffort onto each. Effort resolves
+// against the model's private dial (kimi-k3 declares low/high/max):
+// canonical minimal maps to low, medium to high, and xhigh to max, each
+// quantization reported as a drop.
 //
 //   - kimi-k3 always thinks and always preserves history reasoning. It
 //     takes top-level reasoning_effort ("low" | "high" | "max", default

--- a/driver/kimi/doc.go
+++ b/driver/kimi/doc.go
@@ -20,9 +20,9 @@
 //
 // Three model families think differently, and the compiler maps the
 // canonical ReasoningEnabled / ReasoningEffort onto each. Effort resolves
-// against the model's private dial (kimi-k3 declares low/high/max):
-// canonical minimal maps to low, medium to high, and xhigh to max, each
-// quantization reported as a drop.
+// against the model's declared effort map in capabilities (kimi-k3 maps
+// low/high/max): canonical minimal maps to low, medium to high, and xhigh
+// to max, each fold reported as a drop.
 //
 //   - kimi-k3 always thinks and always preserves history reasoning. It
 //     takes top-level reasoning_effort ("low" | "high" | "max", default

--- a/driver/kimi/generate.go
+++ b/driver/kimi/generate.go
@@ -498,12 +498,12 @@ func compileIntent(wire *generateWire, intent inference.Intent, entry catalogEnt
 func compileReasoning(wire *generateWire, text *inference.TextIntent, entry catalogEntry, ledger *ledger) {
 	if text.ReasoningEnabled != nil {
 		switch {
-		case entry.capabilities.Reasoning == inference.ReasoningNone:
+		case entry.capabilities.Reasoning.Kind == inference.ReasoningNone:
 			ledger.reject(inference.FieldGenerateIntentReasoningEnabled, "model has no thinking control")
-		case entry.capabilities.Reasoning == inference.ReasoningAlways &&
+		case entry.capabilities.Reasoning.Kind == inference.ReasoningAlways &&
 			!*text.ReasoningEnabled:
 			ledger.reject(inference.FieldGenerateIntentReasoningEnabled, "model always thinks; thinking cannot be disabled")
-		case entry.capabilities.Reasoning == inference.ReasoningAlways:
+		case entry.capabilities.Reasoning.Kind == inference.ReasoningAlways:
 			// k3 / k2.7-code think unconditionally: an explicit true is a
 			// no-op, no wire field needed.
 		default:
@@ -516,25 +516,24 @@ func compileReasoning(wire *generateWire, text *inference.TextIntent, entry cata
 	}
 	if text.ReasoningEffort != "" {
 		switch {
-		case entry.capabilities.Reasoning == inference.ReasoningNone:
+		case entry.capabilities.Reasoning.Kind == inference.ReasoningNone:
 			ledger.reject(inference.FieldGenerateIntentReasoningEffort, "model has no thinking control")
-		case len(entry.efforts) == 0:
+		case len(entry.capabilities.Reasoning.EffortMap) == 0:
 			// The model's thinking is binary: the level cannot be honored,
 			// but the request for reasoning itself is — turn thinking on
 			// and report the loss.
 			wire.Thinking = &thinkingOn{Type: "enabled"}
 			ledger.drop(inference.FieldGenerateIntentReasoningEffort, "model's thinking is binary; no effort dial exists")
 		default:
-			mode, exact := inference.ResolveReasoningEffort(
+			mode, _ := entry.capabilities.Reasoning.ResolveEffort(
 				text.ReasoningEffort,
-				entry.efforts,
 			)
-			wire.Effort = string(mode)
-			if !exact {
+			wire.Effort = mode
+			if mode != string(text.ReasoningEffort) {
 				ledger.drop(
 					inference.FieldGenerateIntentReasoningEffort,
 					fmt.Sprintf(
-						"model quantizes reasoning effort %q to %q",
+						"model maps reasoning effort %q to %q",
 						text.ReasoningEffort,
 						mode,
 					),

--- a/driver/kimi/generate.go
+++ b/driver/kimi/generate.go
@@ -518,17 +518,27 @@ func compileReasoning(wire *generateWire, text *inference.TextIntent, entry cata
 		switch {
 		case entry.capabilities.Reasoning == inference.ReasoningNone:
 			ledger.reject(inference.FieldGenerateIntentReasoningEffort, "model has no thinking control")
-		case !entry.reasoningEffort:
+		case len(entry.efforts) == 0:
+			// The model's thinking is binary: the level cannot be honored,
+			// but the request for reasoning itself is — turn thinking on
+			// and report the loss.
+			wire.Thinking = &thinkingOn{Type: "enabled"}
 			ledger.drop(inference.FieldGenerateIntentReasoningEffort, "model's thinking is binary; no effort dial exists")
 		default:
-			switch text.ReasoningEffort {
-			case inference.ReasoningLow:
-				wire.Effort = "low"
-			case inference.ReasoningMedium:
-				wire.Effort = "high"
-				ledger.drop(inference.FieldGenerateIntentReasoningEffort, "kimi-k3 quantizes medium effort to high")
-			case inference.ReasoningHigh:
-				wire.Effort = "high"
+			mode, exact := inference.ResolveReasoningEffort(
+				text.ReasoningEffort,
+				entry.efforts,
+			)
+			wire.Effort = string(mode)
+			if !exact {
+				ledger.drop(
+					inference.FieldGenerateIntentReasoningEffort,
+					fmt.Sprintf(
+						"model quantizes reasoning effort %q to %q",
+						text.ReasoningEffort,
+						mode,
+					),
+				)
 			}
 		}
 	}

--- a/driver/kimi/reasoning_test.go
+++ b/driver/kimi/reasoning_test.go
@@ -1,0 +1,77 @@
+package kimi
+
+import (
+	"context"
+	"testing"
+
+	"github.com/GizClaw/flowcraft/core/inference"
+)
+
+func TestK3ReasoningEffortResolvesAgainstPrivateDial(t *testing.T) {
+	compile := compileGenerate("kimi-k3", catalog["kimi-k3"])
+	model := conformanceModel("kimi-k3")
+	field := inference.FieldGenerateIntentReasoningEffort
+
+	for _, tc := range []struct {
+		effort  inference.ReasoningEffort
+		want    inference.ReasoningEffort
+		dropped bool
+	}{
+		{effort: inference.ReasoningMinimal, want: inference.ReasoningLow, dropped: true},
+		{effort: inference.ReasoningLow, want: inference.ReasoningLow},
+		{effort: inference.ReasoningMedium, want: inference.ReasoningHigh, dropped: true},
+		{effort: inference.ReasoningHigh, want: inference.ReasoningHigh},
+		{effort: inference.ReasoningXHigh, want: "max", dropped: true},
+	} {
+		request := conformanceTextRequest()
+		request.Input.Content.Intent.Text = &inference.TextIntent{
+			ReasoningEffort: tc.effort,
+		}
+		compiled, err := compile(
+			context.Background(),
+			model,
+			request,
+			inference.GenerateExecutionUnary,
+		)
+		if err != nil {
+			t.Fatalf("effort %q: compile: %v", tc.effort, err)
+		}
+		if compiled.Wire.Effort != string(tc.want) {
+			t.Fatalf(
+				"effort %q: wire = %q, want %q",
+				tc.effort,
+				compiled.Wire.Effort,
+				tc.want,
+			)
+		}
+		if got := compiled.Report.Dropped(field); got != tc.dropped {
+			t.Fatalf("effort %q: dropped = %v, want %v", tc.effort, got, tc.dropped)
+		}
+	}
+}
+
+func TestK2xReasoningEffortDropsOnBinaryThinking(t *testing.T) {
+	compile := compileGenerate("kimi-k2.6", catalog["kimi-k2.6"])
+	request := conformanceTextRequest()
+	request.Input.Content.Intent.Text = &inference.TextIntent{
+		ReasoningEffort: inference.ReasoningHigh,
+	}
+	compiled, err := compile(
+		context.Background(),
+		conformanceModel("kimi-k2.6"),
+		request,
+		inference.GenerateExecutionUnary,
+	)
+	if err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+	if !compiled.Report.Dropped(inference.FieldGenerateIntentReasoningEffort) {
+		t.Fatal("binary thinking model must drop the effort with a reason")
+	}
+	if compiled.Wire.Effort != "" {
+		t.Fatalf("wire effort = %q, want empty", compiled.Wire.Effort)
+	}
+	if compiled.Wire.Thinking == nil || compiled.Wire.Thinking.Type != "enabled" {
+		t.Fatalf("binary drop must enable thinking, got %+v", compiled.Wire.Thinking)
+	}
+}

--- a/driver/minimax/catalog.go
+++ b/driver/minimax/catalog.go
@@ -114,15 +114,17 @@ func generateChatCapabilities() inference.ModelCapabilities {
 //
 // All generate entries speak the binary-thinking dialect: any requested
 // reasoning effort compiles to thinking: {type: "adaptive"} — the endpoint
-// has no effort levels. MiniMax-M3 holds a 1M token context; the M2.x
-// series holds 204,800. Music generation (music-3.0) serves the canonical
-// audio intent with lyrics/format through MusicOptions; music-cover stays
-// out because it has no honest surface in that intent.
+// has no effort levels. MiniMax-M3 is natively multimodal (text, image,
+// video) with a 1M token context; the M2.x series is text-only with tool
+// calls per the official docs and holds a 204,800-token context. Music
+// generation (music-3.0) serves the canonical audio intent with
+// lyrics/format through MusicOptions; music-cover stays out because it has
+// no honest surface in that intent.
 var catalog = map[string]catalogEntry{
 	"MiniMax-M3": {
 		kind: kindGenerate,
 		capabilities: generateChatCapabilities().
-			WithInputs(message.PartImage).
+			WithInputs(message.PartImage, message.PartVideo).
 			WithReasoning(inference.ReasoningToggle),
 		maxInputTokens: 1_000_000,
 	},

--- a/driver/minimax/catalog_test.go
+++ b/driver/minimax/catalog_test.go
@@ -56,13 +56,16 @@ func TestCatalogPublishesCapabilities(t *testing.T) {
 	m3 := descriptors["MiniMax-M3"]
 	if !reflect.DeepEqual(m3.Capabilities.Outputs, []message.PartKind{message.PartText}) ||
 		!slices.Contains(m3.Capabilities.Inputs, message.PartImage) ||
+		!slices.Contains(m3.Capabilities.Inputs, message.PartVideo) ||
 		m3.Capabilities.Reasoning != inference.ReasoningToggle {
 		t.Fatalf("M3 capabilities = %+v", m3.Capabilities)
 	}
 
 	m2 := descriptors["MiniMax-M2.7"]
-	if m2.Capabilities.Reasoning != inference.ReasoningAlways {
-		t.Fatalf("M2.7 reasoning = %q, want always", m2.Capabilities.Reasoning)
+	if m2.Capabilities.Reasoning != inference.ReasoningAlways ||
+		slices.Contains(m2.Capabilities.Inputs, message.PartImage) ||
+		slices.Contains(m2.Capabilities.Inputs, message.PartVideo) {
+		t.Fatalf("M2.7 capabilities = %+v", m2.Capabilities)
 	}
 
 	image := descriptors["image-01"]

--- a/driver/minimax/catalog_test.go
+++ b/driver/minimax/catalog_test.go
@@ -57,12 +57,12 @@ func TestCatalogPublishesCapabilities(t *testing.T) {
 	if !reflect.DeepEqual(m3.Capabilities.Outputs, []message.PartKind{message.PartText}) ||
 		!slices.Contains(m3.Capabilities.Inputs, message.PartImage) ||
 		!slices.Contains(m3.Capabilities.Inputs, message.PartVideo) ||
-		m3.Capabilities.Reasoning != inference.ReasoningToggle {
+		m3.Capabilities.Reasoning.Kind != inference.ReasoningToggle {
 		t.Fatalf("M3 capabilities = %+v", m3.Capabilities)
 	}
 
 	m2 := descriptors["MiniMax-M2.7"]
-	if m2.Capabilities.Reasoning != inference.ReasoningAlways ||
+	if m2.Capabilities.Reasoning.Kind != inference.ReasoningAlways ||
 		slices.Contains(m2.Capabilities.Inputs, message.PartImage) ||
 		slices.Contains(m2.Capabilities.Inputs, message.PartVideo) {
 		t.Fatalf("M2.7 capabilities = %+v", m2.Capabilities)

--- a/driver/minimax/doc.go
+++ b/driver/minimax/doc.go
@@ -72,9 +72,9 @@
 //     back, and unsigned reasoning drops — the self-hosted kernel's
 //     policy, which matches MiniMax's requirement to preserve thinking
 //     blocks unchanged across tool-use turns.
-//   - Image input compiles for MiniMax-M3 (URL or base64) and rejects on
-//     the text-only M2.x series. Video input has no wire support in the
-//     kernel and rejects everywhere for now.
+//   - Image and video input compile for MiniMax-M3 (URL or base64; the
+//     video content block rides a raw union until the SDK models it) and
+//     reject on the text-only M2.x series.
 //   - MiniMax ignores top_k and stop_sequences on this endpoint; the
 //     canonical request has no surface for either, so nothing is lost.
 //   - service_tier (standard/priority) is MiniMax-specific and has no

--- a/driver/minimax/generate.go
+++ b/driver/minimax/generate.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/json"
+	"fmt"
 	"slices"
 
 	"github.com/GizClaw/flowcraft/core/inference"
@@ -499,12 +500,12 @@ func compileIntent(
 	wire.topP = text.TopP
 	if text.ReasoningEnabled != nil {
 		switch {
-		case entry.capabilities.Reasoning == inference.ReasoningNone:
+		case entry.capabilities.Reasoning.Kind == inference.ReasoningNone:
 			ledger.reject(
 				inference.FieldGenerateIntentReasoningEnabled,
 				"model has no thinking to switch",
 			)
-		case entry.capabilities.Reasoning == inference.ReasoningAlways &&
+		case entry.capabilities.Reasoning.Kind == inference.ReasoningAlways &&
 			!*text.ReasoningEnabled:
 			ledger.reject(
 				inference.FieldGenerateIntentReasoningEnabled,
@@ -516,12 +517,13 @@ func compileIntent(
 		}
 	}
 	if text.ReasoningEffort != "" {
-		if entry.capabilities.Reasoning == inference.ReasoningNone {
+		switch {
+		case entry.capabilities.Reasoning.Kind == inference.ReasoningNone:
 			ledger.reject(
 				inference.FieldGenerateIntentReasoningEffort,
 				"model has no reasoning effort control",
 			)
-		} else {
+		case len(entry.capabilities.Reasoning.EffortMap) == 0:
 			// MiniMax's Messages dialect is binary thinking: the level
 			// cannot be honored, but the request for reasoning itself is —
 			// turn thinking on and report the loss.
@@ -531,6 +533,21 @@ func compileIntent(
 				inference.FieldGenerateIntentReasoningEffort,
 				"platform thinking has no effort levels; enabled at platform-chosen depth",
 			)
+		default:
+			mode, _ := entry.capabilities.Reasoning.ResolveEffort(
+				text.ReasoningEffort,
+			)
+			wire.effort = mode
+			if mode != string(text.ReasoningEffort) {
+				ledger.drop(
+					inference.FieldGenerateIntentReasoningEffort,
+					fmt.Sprintf(
+						"model maps reasoning effort %q to %q",
+						text.ReasoningEffort,
+						mode,
+					),
+				)
+			}
 		}
 	}
 }

--- a/driver/minimax/generate.go
+++ b/driver/minimax/generate.go
@@ -53,6 +53,7 @@ type wireBlockKind string
 const (
 	wireBlockText             wireBlockKind = "text"
 	wireBlockImage            wireBlockKind = "image"
+	wireBlockVideo            wireBlockKind = "video"
 	wireBlockToolUse          wireBlockKind = "tool_use"
 	wireBlockToolResult       wireBlockKind = "tool_result"
 	wireBlockThinking         wireBlockKind = "thinking"
@@ -66,6 +67,10 @@ type wireBlock struct {
 	imageURL  string
 	imageData []byte
 	imageType string
+	// video carries an absolute URL or base64 bytes with a media type.
+	videoURL  string
+	videoData []byte
+	videoType string
 	// tool_use / tool_result.
 	callID string
 	name   string // tool_use
@@ -309,7 +314,11 @@ func compileMessage(
 		case message.AudioPart:
 			ledger.reject(fields[message.PartAudio], "audio input is not supported by messages models")
 		case message.VideoPart:
-			ledger.reject(fields[message.PartVideo], "video input is not supported by messages models")
+			if !slices.Contains(entry.capabilities.Inputs, message.PartVideo) {
+				ledger.reject(fields[message.PartVideo], "model does not accept video input")
+				continue
+			}
+			wire.appendBlock(role, videoBlock(value.Source))
 		case message.FilePart:
 			ledger.reject(fields[message.PartFile], "file references are not supported")
 		case message.DataPart:
@@ -406,6 +415,19 @@ func imageBlock(source media.ImageSource) wireBlock {
 		kind:      wireBlockImage,
 		imageData: bytesClone(source.Bytes()),
 		imageType: source.MediaType(),
+	}
+}
+
+// videoBlock lowers a video source: URLs pass through, inline bytes carry
+// their raw data plus media type for base64 encoding at the transport.
+func videoBlock(source media.VideoSource) wireBlock {
+	if source.Kind() == media.SourceURL {
+		return wireBlock{kind: wireBlockVideo, videoURL: source.URL()}
+	}
+	return wireBlock{
+		kind:      wireBlockVideo,
+		videoData: bytesClone(source.Bytes()),
+		videoType: source.MediaType(),
 	}
 }
 

--- a/driver/minimax/generate.go
+++ b/driver/minimax/generate.go
@@ -311,12 +311,26 @@ func compileMessage(
 				ledger.reject(fields[message.PartImage], "model does not accept image input")
 				continue
 			}
+			if value.Source.Kind() == media.SourceStream {
+				ledger.reject(
+					fields[message.PartImage],
+					"stream media sources must be materialized before generate",
+				)
+				continue
+			}
 			wire.appendBlock(role, imageBlock(value.Source))
 		case message.AudioPart:
 			ledger.reject(fields[message.PartAudio], "audio input is not supported by messages models")
 		case message.VideoPart:
 			if !slices.Contains(entry.capabilities.Inputs, message.PartVideo) {
 				ledger.reject(fields[message.PartVideo], "model does not accept video input")
+				continue
+			}
+			if value.Source.Kind() == media.SourceStream {
+				ledger.reject(
+					fields[message.PartVideo],
+					"stream media sources must be materialized before generate",
+				)
 				continue
 			}
 			wire.appendBlock(role, videoBlock(value.Source))

--- a/driver/minimax/generate_anthropic.go
+++ b/driver/minimax/generate_anthropic.go
@@ -95,6 +95,25 @@ func blockToParam(block wireBlock) anthropicgo.ContentBlockParamUnion {
 			MediaType: anthropicgo.Base64ImageSourceMediaType(block.imageType),
 			Data:      base64Encode(block.imageData),
 		})
+	case wireBlockVideo:
+		// The SDK has no video content block yet, so the block rides a
+		// raw union: {"type":"video","source":{...}}.
+		source := map[string]any{"type": "url", "url": block.videoURL}
+		if block.videoURL == "" {
+			source = map[string]any{
+				"type":       "base64",
+				"media_type": block.videoType,
+				"data":       base64Encode(block.videoData),
+			}
+		}
+		// json.Marshal cannot fail here: the map holds plain strings only.
+		raw, _ := json.Marshal(map[string]any{
+			"type":   "video",
+			"source": source,
+		})
+		return param.Override[anthropicgo.ContentBlockParamUnion](
+			json.RawMessage(raw),
+		)
 	case wireBlockToolUse:
 		return anthropicgo.NewToolUseBlock(block.callID, argsValue(block.args), block.name)
 	case wireBlockToolResult:

--- a/driver/minimax/generate_video_input_test.go
+++ b/driver/minimax/generate_video_input_test.go
@@ -125,3 +125,29 @@ func TestM3InlineVideoBlockRendersBase64(t *testing.T) {
 		t.Fatalf("inline video block not rendered as base64: %s", rendered)
 	}
 }
+
+func TestM3VideoStreamSourceRejectsBeforeEncoding(t *testing.T) {
+	pipe := media.NewPipe[string](1)
+	source, err := media.NewVideoStream(pipe, "video/mp4")
+	if err != nil {
+		t.Fatalf("NewVideoStream: %v", err)
+	}
+	compile := compileGenerate("MiniMax-M3", catalog["MiniMax-M3"])
+	request := conformanceTextRequest()
+	request.Input.Content.Parts = append(
+		request.Input.Content.Parts,
+		message.VideoPart{Source: source},
+	)
+	compiled, err := compile(
+		context.Background(),
+		conformanceModel("MiniMax-M3"),
+		request,
+		inference.GenerateExecutionUnary,
+	)
+	if err == nil {
+		t.Fatal("stream video input unexpectedly compiled")
+	}
+	if !compiled.Report.Rejects(inference.FieldGenerateInputVideo) {
+		t.Fatal("stream video input was not rejected on the input video field")
+	}
+}

--- a/driver/minimax/generate_video_input_test.go
+++ b/driver/minimax/generate_video_input_test.go
@@ -1,0 +1,127 @@
+package minimax
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/GizClaw/flowcraft/core/inference"
+	"github.com/GizClaw/flowcraft/core/message"
+	"github.com/GizClaw/flowcraft/core/message/media"
+
+	anthropicgo "github.com/anthropics/anthropic-sdk-go"
+)
+
+func renderMessageParams(t *testing.T, params anthropicgo.MessageNewParams) string {
+	t.Helper()
+	raw, err := json.Marshal(params)
+	if err != nil {
+		t.Fatalf("marshal params: %v", err)
+	}
+	return string(raw)
+}
+
+func TestM3VideoInputCompiles(t *testing.T) {
+	compile := compileGenerate("MiniMax-M3", catalog["MiniMax-M3"])
+	request := conformanceTextRequest()
+	request.Input.Content.Parts = append(
+		request.Input.Content.Parts,
+		videoClipPart(t, "https://example.com/clip.mp4"),
+	)
+	compiled, err := compile(
+		context.Background(),
+		conformanceModel("MiniMax-M3"),
+		request,
+		inference.GenerateExecutionUnary,
+	)
+	if err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+	blocks := compiled.Wire.messages[0].blocks
+	found := false
+	for _, block := range blocks {
+		if block.kind == wireBlockVideo {
+			found = true
+			if block.videoURL != "https://example.com/clip.mp4" {
+				t.Fatalf("video block URL = %q", block.videoURL)
+			}
+		}
+	}
+	if !found {
+		t.Fatalf("no video block in wire: %+v", blocks)
+	}
+}
+
+func TestM2xVideoInputRejects(t *testing.T) {
+	compile := compileGenerate("MiniMax-M2.7", catalog["MiniMax-M2.7"])
+	request := conformanceTextRequest()
+	request.Input.Content.Parts = append(
+		request.Input.Content.Parts,
+		videoClipPart(t, "https://example.com/clip.mp4"),
+	)
+	compiled, err := compile(
+		context.Background(),
+		conformanceModel("MiniMax-M2.7"),
+		request,
+		inference.GenerateExecutionUnary,
+	)
+	if err == nil {
+		t.Fatal("video input on text-only M2.x unexpectedly accepted")
+	}
+	if !compiled.Report.Rejects(inference.FieldGenerateInputVideo) {
+		t.Fatal("video input was not rejected on the input video field")
+	}
+}
+
+func TestM3VideoBlockRendersRawUnion(t *testing.T) {
+	compile := compileGenerate("MiniMax-M3", catalog["MiniMax-M3"])
+	request := conformanceTextRequest()
+	request.Input.Content.Parts = append(
+		request.Input.Content.Parts,
+		videoClipPart(t, "https://example.com/clip.mp4"),
+	)
+	compiled, err := compile(
+		context.Background(),
+		conformanceModel("MiniMax-M3"),
+		request,
+		inference.GenerateExecutionUnary,
+	)
+	if err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+	params := wireToParams(compiled.Wire)
+	rendered := renderMessageParams(t, params)
+	if !strings.Contains(rendered, `"type":"video"`) ||
+		!strings.Contains(rendered, `"url":"https://example.com/clip.mp4"`) {
+		t.Fatalf("video block not rendered as a raw video content block: %s", rendered)
+	}
+}
+
+func TestM3InlineVideoBlockRendersBase64(t *testing.T) {
+	compile := compileGenerate("MiniMax-M3", catalog["MiniMax-M3"])
+	source, err := media.NewVideoBytes([]byte("clip-bytes"), "video/mp4")
+	if err != nil {
+		t.Fatalf("NewVideoBytes: %v", err)
+	}
+	request := conformanceTextRequest()
+	request.Input.Content.Parts = append(
+		request.Input.Content.Parts,
+		message.VideoPart{Source: source},
+	)
+	compiled, err := compile(
+		context.Background(),
+		conformanceModel("MiniMax-M3"),
+		request,
+		inference.GenerateExecutionUnary,
+	)
+	if err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+	params := wireToParams(compiled.Wire)
+	rendered := renderMessageParams(t, params)
+	if !strings.Contains(rendered, `"type":"base64"`) ||
+		!strings.Contains(rendered, `"data":"Y2xpcC1ieXRlcw=="`) {
+		t.Fatalf("inline video block not rendered as base64: %s", rendered)
+	}
+}

--- a/driver/minimax/image.go
+++ b/driver/minimax/image.go
@@ -75,6 +75,13 @@ func compileImage(
 				case message.TextPart:
 					prompt = append(prompt, value.Text)
 				case message.ImagePart:
+					if value.Source.Kind() == media.SourceStream {
+						ledger.reject(
+							fields[message.PartImage],
+							"stream media sources must be materialized before generate",
+						)
+						continue
+					}
 					wire.references = append(wire.references, imageSourceValue(value.Source))
 				default:
 					ledger.reject(

--- a/driver/minimax/video.go
+++ b/driver/minimax/video.go
@@ -195,10 +195,31 @@ func collectTaskParts(
 			case message.TextPart:
 				prompt = append(prompt, value.Text)
 			case message.ImagePart:
+				if value.Source.Kind() == media.SourceStream {
+					ledger.reject(
+						fields[message.PartImage],
+						"stream media sources must be materialized before generate",
+					)
+					continue
+				}
 				images = append(images, videoImageValue(value.Source))
 			case message.VideoPart:
+				if value.Source.Kind() == media.SourceStream {
+					ledger.reject(
+						fields[message.PartVideo],
+						"stream media sources must be materialized before generate",
+					)
+					continue
+				}
 				videos = append(videos, videoSourceURI(value.Source))
 			case message.AudioPart:
+				if value.Source.Kind() == media.SourceStream {
+					ledger.reject(
+						fields[message.PartAudio],
+						"stream media sources must be materialized before generate",
+					)
+					continue
+				}
 				audios = append(audios, audioSourceURI(value.Source))
 			default:
 				ledger.reject(

--- a/driver/minimax/video_test.go
+++ b/driver/minimax/video_test.go
@@ -717,6 +717,24 @@ func TestVideoImageValueDataURI(t *testing.T) {
 	}
 }
 
+func TestVideoTaskStreamSourceRejects(t *testing.T) {
+	pipe := media.NewPipe[string](1)
+	source, err := media.NewVideoStream(pipe, "video/mp4")
+	if err != nil {
+		t.Fatalf("NewVideoStream: %v", err)
+	}
+	_, report, err := compileVideoWire(t, "MiniMax-H3", compileVideoRequest(
+		[]message.Part{message.VideoPart{Source: source}},
+		VideoOptions{},
+	))
+	if err == nil {
+		t.Fatal("video task accepted a stream video source")
+	}
+	if !report.Rejects(inference.FieldGenerateInputVideo) {
+		t.Fatal("video task did not reject the stream on the input video field")
+	}
+}
+
 func TestTransportVideoV2(t *testing.T) {
 	var polls int
 	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {

--- a/driver/openai/catalog.go
+++ b/driver/openai/catalog.go
@@ -33,17 +33,22 @@ const (
 
 // catalogEntry is one model in the built-in catalog. capabilities is the
 // single capability fact source: input/output content kinds, hosted web
-// search, and the reasoning control capability. dimensions is the one
-// remaining control capability that no capability kind expresses (embed
-// custom output dimensions) and stays a separate flag. ModelSpec mirrors this
-// shape so deployment-declared models behave identically.
+// search, and the reasoning control capability. dimensions and effortNone
+// are control capabilities that no capability kind expresses (embed custom
+// output dimensions, and effort "none" to disable reasoning) and stay
+// separate flags. ModelSpec mirrors this shape so deployment-declared
+// models behave identically.
 type catalogEntry struct {
 	kind         modelKind
 	api          apiMode
 	capabilities inference.ModelCapabilities
 	// dimensions (embed) allows custom output dimensions. Control
 	// capability, likewise not a content kind.
-	dimensions  bool
+	dimensions bool
+	// effortNone marks reasoning models whose reasoning.effort accepts
+	// "none" to disable reasoning (gpt-5.1+ per the OpenAI docs); models
+	// without it reject a disable request.
+	effortNone  bool
 	deprecated  bool
 	replacement string
 	// maxInputTokens caps the input context (prompt plus prior turns) in
@@ -105,16 +110,19 @@ var catalog = map[string]catalogEntry{
 	"gpt-5.6-sol": {
 		kind:           kindGenerate,
 		capabilities:   generateChatCapabilities().WithInputs(message.PartImage).WithHostedWebSearch().WithReasoning(inference.ReasoningToggle),
+		effortNone:     true,
 		maxInputTokens: 1_050_000,
 	},
 	"gpt-5.6-terra": {
 		kind:           kindGenerate,
 		capabilities:   generateChatCapabilities().WithInputs(message.PartImage).WithHostedWebSearch().WithReasoning(inference.ReasoningToggle),
+		effortNone:     true,
 		maxInputTokens: 1_050_000,
 	},
 	"gpt-5.6-luna": {
 		kind:           kindGenerate,
 		capabilities:   generateChatCapabilities().WithInputs(message.PartImage).WithHostedWebSearch().WithReasoning(inference.ReasoningToggle),
+		effortNone:     true,
 		maxInputTokens: 1_050_000,
 	},
 	// Generate — previous generations, superseded but available.
@@ -218,6 +226,7 @@ func mergedCatalog(spec Spec) (map[string]catalogEntry, error) {
 			kind:         modelKind(model.Kind),
 			capabilities: model.Capabilities,
 			dimensions:   model.Dimensions,
+			effortNone:   model.EffortNone,
 		}
 	}
 	for name, entry := range models {

--- a/driver/openai/catalog.go
+++ b/driver/openai/catalog.go
@@ -102,6 +102,16 @@ func generateChatCapabilities() inference.ModelCapabilities {
 	}
 }
 
+// openaiEffortMap is the canonical-to-wire identity map: OpenAI's
+// reasoning.effort accepts the canonical five verbatim.
+var openaiEffortMap = map[inference.ReasoningEffort]string{
+	inference.ReasoningMinimal: string(inference.ReasoningMinimal),
+	inference.ReasoningLow:     string(inference.ReasoningLow),
+	inference.ReasoningMedium:  string(inference.ReasoningMedium),
+	inference.ReasoningHigh:    string(inference.ReasoningHigh),
+	inference.ReasoningXHigh:   string(inference.ReasoningXHigh),
+}
+
 // catalog is the built-in model list, aligned with the OpenAI model lineup
 // of July 2026 (GPT-5.6 family flagship). Deployments extend or override it
 // via Spec.Models.
@@ -109,44 +119,44 @@ var catalog = map[string]catalogEntry{
 	// Generate — GPT-5.6 flagship family (reasoning + vision).
 	"gpt-5.6-sol": {
 		kind:           kindGenerate,
-		capabilities:   generateChatCapabilities().WithInputs(message.PartImage).WithHostedWebSearch().WithReasoning(inference.ReasoningToggle),
+		capabilities:   generateChatCapabilities().WithInputs(message.PartImage).WithHostedWebSearch().WithReasoning(inference.ReasoningToggle).WithReasoningEffortMap(openaiEffortMap),
 		effortNone:     true,
 		maxInputTokens: 1_050_000,
 	},
 	"gpt-5.6-terra": {
 		kind:           kindGenerate,
-		capabilities:   generateChatCapabilities().WithInputs(message.PartImage).WithHostedWebSearch().WithReasoning(inference.ReasoningToggle),
+		capabilities:   generateChatCapabilities().WithInputs(message.PartImage).WithHostedWebSearch().WithReasoning(inference.ReasoningToggle).WithReasoningEffortMap(openaiEffortMap),
 		effortNone:     true,
 		maxInputTokens: 1_050_000,
 	},
 	"gpt-5.6-luna": {
 		kind:           kindGenerate,
-		capabilities:   generateChatCapabilities().WithInputs(message.PartImage).WithHostedWebSearch().WithReasoning(inference.ReasoningToggle),
+		capabilities:   generateChatCapabilities().WithInputs(message.PartImage).WithHostedWebSearch().WithReasoning(inference.ReasoningToggle).WithReasoningEffortMap(openaiEffortMap),
 		effortNone:     true,
 		maxInputTokens: 1_050_000,
 	},
 	// Generate — previous generations, superseded but available.
 	"gpt-5.5": {
 		kind:         kindGenerate,
-		capabilities: generateChatCapabilities().WithInputs(message.PartImage).WithHostedWebSearch().WithReasoning(inference.ReasoningAlways),
+		capabilities: generateChatCapabilities().WithInputs(message.PartImage).WithHostedWebSearch().WithReasoning(inference.ReasoningAlways).WithReasoningEffortMap(openaiEffortMap),
 		deprecated:   true, replacement: "gpt-5.6-sol",
 		maxInputTokens: 1_050_000,
 	},
 	"gpt-5.4": {
 		kind:         kindGenerate,
-		capabilities: generateChatCapabilities().WithInputs(message.PartImage).WithHostedWebSearch().WithReasoning(inference.ReasoningAlways),
+		capabilities: generateChatCapabilities().WithInputs(message.PartImage).WithHostedWebSearch().WithReasoning(inference.ReasoningAlways).WithReasoningEffortMap(openaiEffortMap),
 		deprecated:   true, replacement: "gpt-5.6-sol",
 		maxInputTokens: 1_050_000,
 	},
 	"gpt-5.4-mini": {
 		kind:         kindGenerate,
-		capabilities: generateChatCapabilities().WithInputs(message.PartImage).WithHostedWebSearch().WithReasoning(inference.ReasoningAlways),
+		capabilities: generateChatCapabilities().WithInputs(message.PartImage).WithHostedWebSearch().WithReasoning(inference.ReasoningAlways).WithReasoningEffortMap(openaiEffortMap),
 		deprecated:   true, replacement: "gpt-5.6-terra",
 		maxInputTokens: 400_000,
 	},
 	"gpt-5.4-nano": {
 		kind:         kindGenerate,
-		capabilities: generateChatCapabilities().WithInputs(message.PartImage).WithHostedWebSearch().WithReasoning(inference.ReasoningAlways),
+		capabilities: generateChatCapabilities().WithInputs(message.PartImage).WithHostedWebSearch().WithReasoning(inference.ReasoningAlways).WithReasoningEffortMap(openaiEffortMap),
 		deprecated:   true, replacement: "gpt-5.6-luna",
 		maxInputTokens: 400_000,
 	},

--- a/driver/openai/catalog_test.go
+++ b/driver/openai/catalog_test.go
@@ -73,7 +73,7 @@ func TestCatalogPublishesCapabilities(t *testing.T) {
 	if !flagship.Capabilities.HostedWebSearch {
 		t.Fatal("gpt-5.6-sol must declare hosted web search")
 	}
-	if flagship.Capabilities.Reasoning != inference.ReasoningToggle {
+	if flagship.Capabilities.Reasoning.Kind != inference.ReasoningToggle {
 		t.Fatalf(
 			"gpt-5.6-sol reasoning = %q, want toggle",
 			flagship.Capabilities.Reasoning,
@@ -92,7 +92,7 @@ func TestCatalogPublishesCapabilities(t *testing.T) {
 	if !slices.Contains(nano.Capabilities.Inputs, message.PartImage) {
 		t.Fatalf("gpt-4.1-nano inputs = %v, want image input", nano.Capabilities.Inputs)
 	}
-	if nano.Capabilities.Reasoning != inference.ReasoningNone {
+	if nano.Capabilities.Reasoning.Kind != inference.ReasoningNone {
 		t.Fatalf(
 			"gpt-4.1-nano reasoning = %q, want none",
 			nano.Capabilities.Reasoning,

--- a/driver/openai/doc.go
+++ b/driver/openai/doc.go
@@ -11,8 +11,10 @@
 //     round-trips and rejects the hosted web_search tool at compile time;
 //     the rest of the generate surface (tools, vision, JSON formats,
 //     streaming) is equivalent.
-//     Reasoning models cannot switch reasoning off: reasoning_enabled:
-//     false rejects at compile time; true is a no-op (the default).
+//     Reasoning_enabled: true is a no-op (the default). False rejects at
+//     compile time unless the model declares effort_none (gpt-5.1+,
+//     per-model via the spec flag): those models compile reasoning_enabled:
+//     false to reasoning.effort: "none" on the Responses surface.
 //     Reasoning items decode into canonical reasoning parts (summary text,
 //     encrypted payload in the Signature slot, item id) and round-trip
 //     through context when id and payload survive; the request always

--- a/driver/openai/generate.go
+++ b/driver/openai/generate.go
@@ -636,12 +636,10 @@ func compileIntent(
 				"model has no reasoning effort control",
 			)
 		case len(entry.capabilities.Reasoning.EffortMap) == 0:
-			// Spec-declared reasoning models without a declared map are
-			// treated as binary: the level cannot be represented.
-			ledger.drop(
-				inference.FieldGenerateIntentReasoningEffort,
-				"model's thinking is binary; no effort dial exists",
-			)
+			// Spec-declared reasoning models without an explicit map keep
+			// the legacy pass-through behavior: OpenAI's reasoning.effort
+			// accepts the canonical effort tokens verbatim.
+			wire.reasoning = string(text.ReasoningEffort)
 		default:
 			mode, _ := entry.capabilities.Reasoning.ResolveEffort(
 				text.ReasoningEffort,

--- a/driver/openai/generate.go
+++ b/driver/openai/generate.go
@@ -617,8 +617,10 @@ func compileIntent(
 			)
 		case entry.capabilities.Reasoning == inference.ReasoningToggle &&
 			!*text.ReasoningEnabled:
-			// No OpenAI surface exposes a reasoning-off switch yet; reject
-			// until a toggle-capable model and wire channel land.
+			if entry.effortNone && entry.api != apiChat {
+				wire.reasoning = "none"
+				break
+			}
 			ledger.reject(
 				inference.FieldGenerateIntentReasoningEnabled,
 				"reasoning cannot be disabled through this provider",

--- a/driver/openai/generate.go
+++ b/driver/openai/generate.go
@@ -323,7 +323,7 @@ func compileGenerate(
 		wire := generateWire{
 			model:  model,
 			stream: shape == inference.GenerateExecutionStream,
-			includeReasoning: entry.capabilities.Reasoning != inference.ReasoningNone &&
+			includeReasoning: entry.capabilities.Reasoning.Kind != inference.ReasoningNone &&
 				entry.api != apiChat,
 		}
 
@@ -489,7 +489,7 @@ func compileReasoning(
 		ledger.reject(field, "reasoning parts belong to assistant context")
 		return
 	}
-	if entry.capabilities.Reasoning == inference.ReasoningNone {
+	if entry.capabilities.Reasoning.Kind == inference.ReasoningNone {
 		ledger.drop(field, "model has no reasoning channel")
 		return
 	}
@@ -604,18 +604,18 @@ func compileIntent(
 	wire.topP = text.TopP
 	if text.ReasoningEnabled != nil {
 		switch {
-		case entry.capabilities.Reasoning == inference.ReasoningNone:
+		case entry.capabilities.Reasoning.Kind == inference.ReasoningNone:
 			ledger.reject(
 				inference.FieldGenerateIntentReasoningEnabled,
 				"model has no reasoning to switch",
 			)
-		case entry.capabilities.Reasoning == inference.ReasoningAlways &&
+		case entry.capabilities.Reasoning.Kind == inference.ReasoningAlways &&
 			!*text.ReasoningEnabled:
 			ledger.reject(
 				inference.FieldGenerateIntentReasoningEnabled,
 				"openai reasoning models cannot disable reasoning",
 			)
-		case entry.capabilities.Reasoning == inference.ReasoningToggle &&
+		case entry.capabilities.Reasoning.Kind == inference.ReasoningToggle &&
 			!*text.ReasoningEnabled:
 			if entry.effortNone && entry.api != apiChat {
 				wire.reasoning = "none"
@@ -629,13 +629,34 @@ func compileIntent(
 		// enabled == true is a no-op: reasoning models reason by default.
 	}
 	if text.ReasoningEffort != "" {
-		if entry.capabilities.Reasoning == inference.ReasoningNone {
+		switch {
+		case entry.capabilities.Reasoning.Kind == inference.ReasoningNone:
 			ledger.reject(
 				inference.FieldGenerateIntentReasoningEffort,
 				"model has no reasoning effort control",
 			)
-		} else {
-			wire.reasoning = string(text.ReasoningEffort)
+		case len(entry.capabilities.Reasoning.EffortMap) == 0:
+			// Spec-declared reasoning models without a declared map are
+			// treated as binary: the level cannot be represented.
+			ledger.drop(
+				inference.FieldGenerateIntentReasoningEffort,
+				"model's thinking is binary; no effort dial exists",
+			)
+		default:
+			mode, _ := entry.capabilities.Reasoning.ResolveEffort(
+				text.ReasoningEffort,
+			)
+			wire.reasoning = mode
+			if mode != string(text.ReasoningEffort) {
+				ledger.drop(
+					inference.FieldGenerateIntentReasoningEffort,
+					fmt.Sprintf(
+						"model maps reasoning effort %q to %q",
+						text.ReasoningEffort,
+						mode,
+					),
+				)
+			}
 		}
 	}
 }

--- a/driver/openai/reasoning_none_test.go
+++ b/driver/openai/reasoning_none_test.go
@@ -1,0 +1,82 @@
+package openai
+
+import (
+	"context"
+	"testing"
+
+	"github.com/GizClaw/flowcraft/core/inference"
+)
+
+func TestToggleFalseCompilesToEffortNone(t *testing.T) {
+	compile := compileGenerate("gpt-5.6-sol", catalog["gpt-5.6-sol"])
+	request := simpleTextRequest("hi")
+	disabled := false
+	request.Input.Content.Intent.Text.ReasoningEnabled = &disabled
+
+	compiled, err := compile(
+		context.Background(),
+		openaiModel("gpt-5.6-sol"),
+		request,
+		inference.GenerateExecutionUnary,
+	)
+	if err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+	if compiled.Wire.reasoning != "none" {
+		t.Fatalf("wire reasoning = %q, want none", compiled.Wire.reasoning)
+	}
+	if compiled.Report.Rejects(inference.FieldGenerateIntentReasoningEnabled) {
+		t.Fatal("disable request unexpectedly rejected on an effort_none model")
+	}
+}
+
+func TestToggleFalseRejectsWithoutEffortNone(t *testing.T) {
+	entry := catalogEntry{
+		kind:         kindGenerate,
+		api:          apiResponses,
+		capabilities: generateChatCapabilities().WithReasoning(inference.ReasoningToggle),
+	}
+	compile := compileGenerate("legacy-toggle", entry)
+	request := simpleTextRequest("hi")
+	disabled := false
+	request.Input.Content.Intent.Text.ReasoningEnabled = &disabled
+
+	compiled, err := compile(
+		context.Background(),
+		openaiModel("legacy-toggle"),
+		request,
+		inference.GenerateExecutionUnary,
+	)
+	if err == nil {
+		t.Fatal("disable request unexpectedly accepted without effort_none")
+	}
+	if !compiled.Report.Rejects(inference.FieldGenerateIntentReasoningEnabled) {
+		t.Fatal("disable request was not rejected on the reasoning_enabled field")
+	}
+}
+
+func TestChatModeToggleFalseStillRejects(t *testing.T) {
+	entry := catalogEntry{
+		kind:         kindGenerate,
+		api:          apiChat,
+		capabilities: generateChatCapabilities().WithReasoning(inference.ReasoningToggle),
+		effortNone:   true,
+	}
+	compile := compileGenerate("chat-toggle", entry)
+	request := simpleTextRequest("hi")
+	disabled := false
+	request.Input.Content.Intent.Text.ReasoningEnabled = &disabled
+
+	compiled, err := compile(
+		context.Background(),
+		openaiModel("chat-toggle"),
+		request,
+		inference.GenerateExecutionUnary,
+	)
+	if err == nil {
+		t.Fatal("disable request unexpectedly accepted in chat mode")
+	}
+	if !compiled.Report.Rejects(inference.FieldGenerateIntentReasoningEnabled) {
+		t.Fatal("disable request was not rejected in chat mode")
+	}
+}

--- a/driver/openai/reasoning_none_test.go
+++ b/driver/openai/reasoning_none_test.go
@@ -80,3 +80,30 @@ func TestChatModeToggleFalseStillRejects(t *testing.T) {
 		t.Fatal("disable request was not rejected in chat mode")
 	}
 }
+
+func TestSpecToggleWithoutMapPassesEffortThrough(t *testing.T) {
+	entry := catalogEntry{
+		kind:         kindGenerate,
+		api:          apiResponses,
+		capabilities: generateChatCapabilities().WithReasoning(inference.ReasoningToggle),
+	}
+	compile := compileGenerate("spec-toggle", entry)
+	request := simpleTextRequest("hi")
+	request.Input.Content.Intent.Text.ReasoningEffort = inference.ReasoningHigh
+
+	compiled, err := compile(
+		context.Background(),
+		openaiModel("spec-toggle"),
+		request,
+		inference.GenerateExecutionUnary,
+	)
+	if err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+	if compiled.Wire.reasoning != "high" {
+		t.Fatalf("wire reasoning = %q, want high", compiled.Wire.reasoning)
+	}
+	if compiled.Report.Dropped(inference.FieldGenerateIntentReasoningEffort) {
+		t.Fatal("legacy spec effort unexpectedly dropped")
+	}
+}

--- a/driver/openai/spec.go
+++ b/driver/openai/spec.go
@@ -45,8 +45,8 @@ type Spec struct {
 // ModelSpec declares one model outside the built-in catalog. Capabilities
 // mirror the built-in catalog shape: content kinds, hosted web search, and
 // the reasoning control capability (validated against the kind's compiler
-// contract at merge time). Dimensions is the one control capability that no
-// capability kind expresses and stays a separate flag.
+// contract at merge time). Dimensions and EffortNone are control
+// capabilities that no capability kind expresses and stay separate flags.
 type ModelSpec struct {
 	Name string `json:"name"`
 	Kind string `json:"kind"`
@@ -55,6 +55,10 @@ type ModelSpec struct {
 	Capabilities inference.ModelCapabilities `json:"capabilities,omitempty"`
 	// Dimensions (embed) allows custom output dimensions.
 	Dimensions bool `json:"dimensions,omitempty"`
+	// EffortNone marks generate models whose reasoning.effort accepts
+	// "none" to disable reasoning (gpt-5.1+); models without it reject a
+	// ReasoningEnabled=false request.
+	EffortNone bool `json:"effort_none,omitempty"`
 }
 
 // ProfileSpec is the per-credential-profile configuration. OpenAI addresses

--- a/driver/qwen/catalog.go
+++ b/driver/qwen/catalog.go
@@ -17,16 +17,12 @@ const (
 
 // catalogEntry declares what one catalog model accepts. capabilities is the
 // single capability fact source: input/output content kinds and the reasoning
-// control capability. efforts, preserveThinking, thinkingStreamOnly, and
-// embedDimensions are control capabilities that no capability kind expresses
-// and stay separate flags.
+// control capability (switch kind plus the canonical-to-wire effort map).
+// preserveThinking, thinkingStreamOnly, and embedDimensions are control
+// capabilities that no capability kind expresses and stay separate flags.
 type catalogEntry struct {
 	kind         modelKind
 	capabilities inference.ModelCapabilities
-	// efforts is the reasoning_effort dial (qwen3.8-max-preview only:
-	// low/medium/xhigh per the DashScope docs); other thinking models
-	// take thinking_budget through the extension instead.
-	efforts []inference.ReasoningEffort
 	// preserveThinking can re-ingest reasoning_content history
 	// (preserve_thinking); models without it drop round-trip traces.
 	preserveThinking bool
@@ -41,6 +37,17 @@ type catalogEntry struct {
 	// (最大输入长度) on the per-model pages at
 	// https://www.alibabacloud.com/help/zh/model-studio/models.
 	maxInputTokens int
+}
+
+// qwenMaxPreviewEffortMap is qwen3.8-max-preview's canonical-to-wire map
+// per the DashScope docs (low/medium/xhigh): canonical minimal folds onto
+// low and canonical high reaches the top level "xhigh".
+var qwenMaxPreviewEffortMap = map[inference.ReasoningEffort]string{
+	inference.ReasoningMinimal: string(inference.ReasoningLow),
+	inference.ReasoningLow:     string(inference.ReasoningLow),
+	inference.ReasoningMedium:  string(inference.ReasoningMedium),
+	inference.ReasoningHigh:    string(inference.ReasoningXHigh),
+	inference.ReasoningXHigh:   string(inference.ReasoningXHigh),
 }
 
 // catalog reflects the DashScope commercial lineup as of 2026-07.
@@ -59,12 +66,8 @@ var catalog = map[string]catalogEntry{
 		kind: kindGenerate,
 		capabilities: generateChatCapabilities().
 			WithInputs(message.PartImage, message.PartVideo).
-			WithReasoning(inference.ReasoningAlways),
-		efforts: []inference.ReasoningEffort{
-			inference.ReasoningLow,
-			inference.ReasoningMedium,
-			inference.ReasoningXHigh,
-		},
+			WithReasoning(inference.ReasoningAlways).
+			WithReasoningEffortMap(qwenMaxPreviewEffortMap),
 		preserveThinking:   true,
 		thinkingStreamOnly: true,
 		maxInputTokens:     983_616,
@@ -148,7 +151,7 @@ func (e catalogEntry) validate() error {
 	if e.kind == kindEmbed && len(e.capabilities.Outputs) != 0 {
 		return fmt.Errorf("embed family declares no generate output")
 	}
-	if e.kind == kindEmbed && e.capabilities.Reasoning != inference.ReasoningNone {
+	if e.kind == kindEmbed && e.capabilities.Reasoning.Kind != inference.ReasoningNone {
 		return fmt.Errorf("embed model cannot declare reasoning")
 	}
 	if e.kind == kindEmbed && (e.preserveThinking || e.thinkingStreamOnly) {
@@ -213,7 +216,7 @@ func mergedCatalog(spec Spec) (map[string]catalogEntry, error) {
 		)
 		entry.capabilities.HostedWebSearch =
 			entry.capabilities.HostedWebSearch || model.Capabilities.HostedWebSearch
-		if model.Capabilities.Reasoning != inference.ReasoningNone {
+		if model.Capabilities.Reasoning.Kind != inference.ReasoningNone {
 			entry.capabilities.Reasoning = model.Capabilities.Reasoning
 		}
 		if err := entry.validate(); err != nil {

--- a/driver/qwen/catalog.go
+++ b/driver/qwen/catalog.go
@@ -17,16 +17,16 @@ const (
 
 // catalogEntry declares what one catalog model accepts. capabilities is the
 // single capability fact source: input/output content kinds and the reasoning
-// control capability. reasoningEffort, preserveThinking, thinkingStreamOnly,
-// and embedDimensions are control capabilities that no capability kind
-// expresses and stay separate flags.
+// control capability. efforts, preserveThinking, thinkingStreamOnly, and
+// embedDimensions are control capabilities that no capability kind expresses
+// and stay separate flags.
 type catalogEntry struct {
 	kind         modelKind
 	capabilities inference.ModelCapabilities
-	// reasoningEffort accepts the reasoning_effort levels
-	// (qwen3.8-max-preview only); other thinking models take
-	// thinking_budget through the extension instead.
-	reasoningEffort bool
+	// efforts is the reasoning_effort dial (qwen3.8-max-preview only:
+	// low/medium/xhigh per the DashScope docs); other thinking models
+	// take thinking_budget through the extension instead.
+	efforts []inference.ReasoningEffort
 	// preserveThinking can re-ingest reasoning_content history
 	// (preserve_thinking); models without it drop round-trip traces.
 	preserveThinking bool
@@ -60,7 +60,11 @@ var catalog = map[string]catalogEntry{
 		capabilities: generateChatCapabilities().
 			WithInputs(message.PartImage, message.PartVideo).
 			WithReasoning(inference.ReasoningAlways),
-		reasoningEffort:    true,
+		efforts: []inference.ReasoningEffort{
+			inference.ReasoningLow,
+			inference.ReasoningMedium,
+			inference.ReasoningXHigh,
+		},
 		preserveThinking:   true,
 		thinkingStreamOnly: true,
 		maxInputTokens:     983_616,
@@ -147,7 +151,7 @@ func (e catalogEntry) validate() error {
 	if e.kind == kindEmbed && e.capabilities.Reasoning != inference.ReasoningNone {
 		return fmt.Errorf("embed model cannot declare reasoning")
 	}
-	if e.kind == kindEmbed && (e.reasoningEffort || e.preserveThinking || e.thinkingStreamOnly) {
+	if e.kind == kindEmbed && (e.preserveThinking || e.thinkingStreamOnly) {
 		return fmt.Errorf("embed model cannot declare thinking flags")
 	}
 	return nil

--- a/driver/qwen/catalog_test.go
+++ b/driver/qwen/catalog_test.go
@@ -60,12 +60,12 @@ func TestCatalogPublishesCapabilities(t *testing.T) {
 	if !reflect.DeepEqual(thinking.Capabilities.Outputs, []message.PartKind{message.PartText}) ||
 		!slices.Contains(thinking.Capabilities.Inputs, message.PartImage) ||
 		!slices.Contains(thinking.Capabilities.Inputs, message.PartVideo) ||
-		thinking.Capabilities.Reasoning != inference.ReasoningAlways {
+		thinking.Capabilities.Reasoning.Kind != inference.ReasoningAlways {
 		t.Fatalf("thinking model capabilities = %+v", thinking.Capabilities)
 	}
 
 	plain := descriptors["qwen-plus"]
-	if plain.Capabilities.Reasoning != inference.ReasoningNone ||
+	if plain.Capabilities.Reasoning.Kind != inference.ReasoningNone ||
 		len(plain.Capabilities.Inputs) == 0 {
 		t.Fatalf("plain model capabilities = %+v", plain.Capabilities)
 	}

--- a/driver/qwen/doc.go
+++ b/driver/qwen/doc.go
@@ -23,12 +23,12 @@
 //   - Thinking mode is stream-only server-side, so a unary compile with
 //     thinking on rejects generate.input.content.intent.text.
 //     reasoning_enabled.
-//   - Effort levels (reasoning_effort) exist only on qwen3.8-max-preview
-//     (low/medium/xhigh per the DashScope docs); the canonical high
-//     resolves to xhigh (DashScope's top level) and the quantization is
-//     reported as a drop. On other thinking models an explicit effort
-//     drops with a reason and the GenerateOptions.ThinkingBudget
-//     extension bounds the trace instead.
+//   - Effort levels (reasoning_effort) exist only on qwen3.8-max-preview,
+//     whose capability effort map declares low/medium/xhigh per the
+//     DashScope docs; the canonical high resolves to xhigh (DashScope's
+//     top level) and the fold is reported as a drop. On other thinking
+//     models an explicit effort drops with a reason and the
+//     GenerateOptions.ThinkingBudget extension bounds the trace instead.
 //
 // Reasoning history round-trips through preserve_thinking: assistant
 // reasoning parts compile to reasoning_content on models that declare the

--- a/driver/qwen/doc.go
+++ b/driver/qwen/doc.go
@@ -23,10 +23,12 @@
 //   - Thinking mode is stream-only server-side, so a unary compile with
 //     thinking on rejects generate.input.content.intent.text.
 //     reasoning_enabled.
-//   - Effort levels (reasoning_effort) exist only on qwen3.8-max-preview;
-//     on other thinking models an explicit effort drops with a reason and
-//     the GenerateOptions.ThinkingBudget extension bounds the trace
-//     instead.
+//   - Effort levels (reasoning_effort) exist only on qwen3.8-max-preview
+//     (low/medium/xhigh per the DashScope docs); the canonical high
+//     resolves to xhigh (DashScope's top level) and the quantization is
+//     reported as a drop. On other thinking models an explicit effort
+//     drops with a reason and the GenerateOptions.ThinkingBudget
+//     extension bounds the trace instead.
 //
 // Reasoning history round-trips through preserve_thinking: assistant
 // reasoning parts compile to reasoning_content on models that declare the

--- a/driver/qwen/generate.go
+++ b/driver/qwen/generate.go
@@ -495,8 +495,8 @@ func (c *compiler) tools(text *inference.TextIntent) {
 	}
 }
 
-// reasoning compiles the reasoning switch and effort. The effort levels
-// exist only on qwen3.8-max-preview (reasoningEffort); other thinking
+// reasoning compiles the reasoning switch and effort. The effort dial
+// exists only on qwen3.8-max-preview (low/medium/xhigh); other thinking
 // models take thinking_budget through the extension instead, so an
 // explicit effort drops with a reason. Thinking mode is stream-only on
 // the commercial thinking models, so a unary compile with thinking on
@@ -533,36 +533,33 @@ func (c *compiler) reasoning(text *inference.TextIntent) {
 				inference.FieldGenerateIntentReasoningEffort,
 				fmt.Sprintf("model %s has no thinking mode", c.model),
 			)
-		case !c.entry.reasoningEffort:
+		case len(c.entry.efforts) == 0:
 			c.ledger.drop(
 				inference.FieldGenerateIntentReasoningEffort,
-				fmt.Sprintf("model %s has no effort levels; bound the trace with the thinking_budget extension", c.model),
+				fmt.Sprintf(
+					"model %s has no effort dial; enable thinking with reasoning_enabled on a stream or bound the trace with the thinking_budget extension",
+					c.model,
+				),
 			)
 		default:
-			if level, ok := effortLevel(text.ReasoningEffort); ok {
-				c.wire.Parameters.ReasoningEffort = level
-			} else {
-				c.ledger.reject(
+			mode, exact := inference.ResolveReasoningEffort(
+				text.ReasoningEffort,
+				c.entry.efforts,
+			)
+			c.wire.Parameters.ReasoningEffort = string(mode)
+			if !exact {
+				c.ledger.drop(
 					inference.FieldGenerateIntentReasoningEffort,
-					fmt.Sprintf("reasoning effort %q is not a DashScope level", text.ReasoningEffort),
+					fmt.Sprintf(
+						"model %s quantizes reasoning effort %q to %q",
+						c.model,
+						text.ReasoningEffort,
+						mode,
+					),
 				)
 			}
 		}
 	}
-}
-
-// effortLevel maps canonical effort onto DashScope's low/medium/xhigh
-// scale: high lands on xhigh (DashScope's top level).
-func effortLevel(effort inference.ReasoningEffort) (string, bool) {
-	switch effort {
-	case inference.ReasoningLow:
-		return "low", true
-	case inference.ReasoningMedium:
-		return "medium", true
-	case inference.ReasoningHigh:
-		return "xhigh", true
-	}
-	return "", false
 }
 
 // intents rejects the non-text modality intents: this package serves

--- a/driver/qwen/generate.go
+++ b/driver/qwen/generate.go
@@ -504,12 +504,12 @@ func (c *compiler) tools(text *inference.TextIntent) {
 func (c *compiler) reasoning(text *inference.TextIntent) {
 	if text.ReasoningEnabled != nil {
 		switch {
-		case c.entry.capabilities.Reasoning == inference.ReasoningNone:
+		case c.entry.capabilities.Reasoning.Kind == inference.ReasoningNone:
 			c.ledger.reject(
 				inference.FieldGenerateIntentReasoningEnabled,
 				fmt.Sprintf("model %s has no thinking mode", c.model),
 			)
-		case c.entry.capabilities.Reasoning == inference.ReasoningAlways &&
+		case c.entry.capabilities.Reasoning.Kind == inference.ReasoningAlways &&
 			!*text.ReasoningEnabled:
 			c.ledger.reject(
 				inference.FieldGenerateIntentReasoningEnabled,
@@ -528,12 +528,12 @@ func (c *compiler) reasoning(text *inference.TextIntent) {
 	}
 	if text.ReasoningEffort != "" {
 		switch {
-		case c.entry.capabilities.Reasoning == inference.ReasoningNone:
+		case c.entry.capabilities.Reasoning.Kind == inference.ReasoningNone:
 			c.ledger.reject(
 				inference.FieldGenerateIntentReasoningEffort,
 				fmt.Sprintf("model %s has no thinking mode", c.model),
 			)
-		case len(c.entry.efforts) == 0:
+		case len(c.entry.capabilities.Reasoning.EffortMap) == 0:
 			c.ledger.drop(
 				inference.FieldGenerateIntentReasoningEffort,
 				fmt.Sprintf(
@@ -542,16 +542,15 @@ func (c *compiler) reasoning(text *inference.TextIntent) {
 				),
 			)
 		default:
-			mode, exact := inference.ResolveReasoningEffort(
+			mode, _ := c.entry.capabilities.Reasoning.ResolveEffort(
 				text.ReasoningEffort,
-				c.entry.efforts,
 			)
-			c.wire.Parameters.ReasoningEffort = string(mode)
-			if !exact {
+			c.wire.Parameters.ReasoningEffort = mode
+			if mode != string(text.ReasoningEffort) {
 				c.ledger.drop(
 					inference.FieldGenerateIntentReasoningEffort,
 					fmt.Sprintf(
-						"model %s quantizes reasoning effort %q to %q",
+						"model %s maps reasoning effort %q to %q",
 						c.model,
 						text.ReasoningEffort,
 						mode,
@@ -590,7 +589,7 @@ func (c *compiler) intents(request inference.GenerateRequest) {
 func (c *compiler) extensions() {
 	o := c.options
 	if o.ThinkingBudget != nil {
-		if c.entry.capabilities.Reasoning == inference.ReasoningNone {
+		if c.entry.capabilities.Reasoning.Kind == inference.ReasoningNone {
 			c.ledger.reject(
 				inference.ExtensionField("thinking_budget").Qualify(o),
 				fmt.Sprintf("model %s has no thinking budget", c.model),

--- a/driver/qwen/reasoning_test.go
+++ b/driver/qwen/reasoning_test.go
@@ -1,0 +1,83 @@
+package qwen
+
+import (
+	"context"
+	"testing"
+
+	"github.com/GizClaw/flowcraft/core/inference"
+)
+
+func TestMaxPreviewReasoningEffortResolvesAgainstPrivateDial(t *testing.T) {
+	compile := compileGenerate("qwen3.8-max-preview", catalog["qwen3.8-max-preview"])
+	model := conformanceModel("qwen3.8-max-preview")
+	field := inference.FieldGenerateIntentReasoningEffort
+
+	for _, tc := range []struct {
+		effort  inference.ReasoningEffort
+		want    inference.ReasoningEffort
+		dropped bool
+	}{
+		{effort: inference.ReasoningMinimal, want: inference.ReasoningLow, dropped: true},
+		{effort: inference.ReasoningLow, want: inference.ReasoningLow},
+		{effort: inference.ReasoningMedium, want: inference.ReasoningMedium},
+		{effort: inference.ReasoningHigh, want: inference.ReasoningXHigh, dropped: true},
+		{effort: inference.ReasoningXHigh, want: inference.ReasoningXHigh},
+	} {
+		request := conformanceTextRequest()
+		request.Input.Content.Intent.Text = &inference.TextIntent{
+			ReasoningEffort: tc.effort,
+		}
+		compiled, err := compile(
+			context.Background(),
+			model,
+			request,
+			inference.GenerateExecutionUnary,
+		)
+		if err != nil {
+			t.Fatalf("effort %q: compile: %v", tc.effort, err)
+		}
+		if compiled.Wire.Parameters.ReasoningEffort != string(tc.want) {
+			t.Fatalf(
+				"effort %q: wire = %q, want %q",
+				tc.effort,
+				compiled.Wire.Parameters.ReasoningEffort,
+				tc.want,
+			)
+		}
+		if got := compiled.Report.Dropped(field); got != tc.dropped {
+			t.Fatalf("effort %q: dropped = %v, want %v", tc.effort, got, tc.dropped)
+		}
+	}
+}
+
+func TestQwenBinaryThinkingDropsEffortWithoutEnabling(t *testing.T) {
+	compile := compileGenerate("qwen3.7-max", catalog["qwen3.7-max"])
+	request := conformanceTextRequest()
+	request.Input.Content.Intent.Text = &inference.TextIntent{
+		ReasoningEffort: inference.ReasoningHigh,
+	}
+	compiled, err := compile(
+		context.Background(),
+		conformanceModel("qwen3.7-max"),
+		request,
+		inference.GenerateExecutionUnary,
+	)
+	if err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+	if !compiled.Report.Dropped(inference.FieldGenerateIntentReasoningEffort) {
+		t.Fatal("binary thinking model must drop the effort with a reason")
+	}
+	if compiled.Wire.Parameters.ReasoningEffort != "" {
+		t.Fatalf(
+			"wire effort = %q, want empty",
+			compiled.Wire.Parameters.ReasoningEffort,
+		)
+	}
+	if compiled.Wire.Parameters.EnableThinking != nil {
+		t.Fatalf(
+			"binary unary compile must not force stream-only thinking, got %v",
+			*compiled.Wire.Parameters.EnableThinking,
+		)
+	}
+}

--- a/skills/flowcraft-config/references/graph.md
+++ b/skills/flowcraft-config/references/graph.md
@@ -100,7 +100,8 @@ preferences against the router.
 
 `intent` is authoritative and covers every generation modality: text
 controls (`response`, `max_output_tokens`, `tools`, `tool_choice`,
-`temperature`, `top_p`, `reasoning_enabled`, `reasoning_effort`), image
+`temperature`, `top_p`, `reasoning_enabled`, `reasoning_effort`
+(`minimal|low|medium|high|xhigh`), image
 (`size`, `aspect_ratio`, `count`, `seed`, `output_format`, `delivery`),
 audio/tts (`voice`, `format`, `speed`, `count`), and video
 (`duration_millis`, `resolution`, `aspect_ratio`, `seed`, `watermark`).

--- a/skills/flowcraft-config/references/resources.md
+++ b/skills/flowcraft-config/references/resources.md
@@ -18,7 +18,14 @@ spec:
       capabilities:     # optional: content kinds, hosted web search, reasoning control
         inputs: [text, data, tool_call, tool_result]
         outputs: [text]
-        reasoning: toggle   # "always" or "toggle"
+        reasoning:
+          kind: toggle     # "always" or "toggle"; legacy string "toggle" is still accepted
+          effort_map:      # optional: canonical effort -> model wire level
+            minimal: low
+            low: low
+            medium: high
+            high: high
+            xhigh: max
         hosted_web_search: true
       responses: true
 profiles:


### PR DESCRIPTION
## Summary

Replace the private per-driver reasoning effort ladders with a public capability declaration: each model now owns `ReasoningCapability{Kind, EffortMap}` in `ModelCapabilities`.

- Canonical effort ladder stays `minimal/low/medium/high/xhigh`.
- `EffortMap` maps canonical levels to each model's wire tokens; a missing map on a reasoning model means binary thinking.
- JSON stays backward compatible: legacy `reasoning: "toggle"` strings still decode and re-serialize as the same string when no effort map is declared.
- Built-in catalogs migrated (OpenAI, Anthropic, Kimi, Qwen, Bytedance, DeepSeek, MiniMax).

## Breaking change

- Go API: `ModelCapabilities.Reasoning` changed from `ReasoningKind` to `ReasoningCapability` (`{kind, effort_map}`). Code that assigns `Reasoning: inference.ReasoningToggle` must migrate to `ReasoningCapability{Kind: ...}`.
- Deployment JSON/YAML using the legacy `reasoning: "toggle"` string form remains compatible: it decodes, validates, and re-serializes as the legacy string when no effort map is present.

## DeepSeek

- Aligns `deepseek-v4-flash` / `deepseek-v4-pro` with the official thinking-mode ladder (`low/high/max`; `medium -> high`, canonical top tier -> `max`).
- Adds `deepseek-v4-flash-vision-exp`: image input (URL/base64) in user messages on Chat Completions and Responses, hosted web search, thinking toggle + effort map, 1M context. Video/audio remain rejected.
- Spec-declared reasoning models without an effort dial now explicitly enable thinking (chat `thinking=true`, responses `effort=high`) instead of silently dropping the effort request.

## Other review fixes

- `ModelCapabilities.Clone()` deep-copies `Reasoning.EffortMap` and has an alias test.
- `ReasoningCapability` keeps the legacy string JSON shape when no effort map is declared.
- OpenAI/Azure spec-declared reasoning models without an explicit map keep the legacy canonical effort pass-through instead of dropping it.
- MiniMax compilers reject stream-backed media sources before lowering them into empty inline bytes.
- DeepSeek Responses inline image data-URL path has a dedicated regression test.
- `flowcraft-config` resources docs now show the object form and note legacy string compatibility.

## Checks

- `make ci`, `make lint`, `make release-check`, and `git diff --check` pass.
- No `.release` changeset in this PR.