### PR TITLE
chore(deps): bump core to v0.2.3 in drivers

### DIFF
--- a/driver/anthropic/go.mod
+++ b/driver/anthropic/go.mod
@@ -3,7 +3,7 @@ module github.com/GizClaw/flowcraft/driver/anthropic
 go 1.25.0
 
 require (
-	github.com/GizClaw/flowcraft/core v0.2.0
+	github.com/GizClaw/flowcraft/core v0.2.3
 	github.com/anthropics/anthropic-sdk-go v1.61.0
 	go.opentelemetry.io/otel/log v0.19.0
 )

--- a/driver/anthropic/go.sum
+++ b/driver/anthropic/go.sum
@@ -1,5 +1,5 @@
-github.com/GizClaw/flowcraft/core v0.2.0 h1:t2W4W4LtMT7SH4ZPyzTv3Tosu3fP6afxu/d4J8rI8rA=
-github.com/GizClaw/flowcraft/core v0.2.0/go.mod h1:2EZ+ZFBICJse3GS48m7S+IpXy2s8j/xEy/O7dN5VB+U=
+github.com/GizClaw/flowcraft/core v0.2.3 h1:spEXJ1cfzEILXGB8ERMC9QJSmiuwxHFCiaiUB9s2Slw=
+github.com/GizClaw/flowcraft/core v0.2.3/go.mod h1:hL61rLjDQOXKMMQOJUVT8ZFOoP1gs37c6uxzECZUBh4=
 github.com/anthropics/anthropic-sdk-go v1.61.0 h1:JRTnm1tPqn5xo1xd1zfrcFDlcoWXVMvV1K68YmhpZKw=
 github.com/anthropics/anthropic-sdk-go v1.61.0/go.mod h1:3EfIfmFqxH6rbiLcIP4tPFyXL/IHakx2wDG4OU+TIEI=
 github.com/bahlo/generic-list-go v0.2.0 h1:5sz/EEAK+ls5wF+NeqDpk5+iNdMDXrh3z3nPnH1Wvgk=

--- a/driver/azure/go.mod
+++ b/driver/azure/go.mod
@@ -3,7 +3,7 @@ module github.com/GizClaw/flowcraft/driver/azure
 go 1.25.0
 
 require (
-	github.com/GizClaw/flowcraft/core v0.2.0
+	github.com/GizClaw/flowcraft/core v0.2.3
 	github.com/openai/openai-go/v3 v3.50.0
 	go.opentelemetry.io/otel/log v0.19.0
 )

--- a/driver/azure/go.sum
+++ b/driver/azure/go.sum
@@ -6,8 +6,8 @@ github.com/Azure/azure-sdk-for-go/sdk/internal v1.12.0 h1:fhqpLE3UEXi9lPaBRpQ6Xu
 github.com/Azure/azure-sdk-for-go/sdk/internal v1.12.0/go.mod h1:7dCRMLwisfRH3dBupKeNCioWYUZ4SS09Z14H+7i8ZoY=
 github.com/AzureAD/microsoft-authentication-library-for-go v1.7.2 h1:RHK7bS+HQMslb1sZpAokUt+zTVmue0hKSs2C791hhzU=
 github.com/AzureAD/microsoft-authentication-library-for-go v1.7.2/go.mod h1:HKpQxkWaGLJ+D/5H8QRpyQXA1eKjxkFlOMwck5+33Jk=
-github.com/GizClaw/flowcraft/core v0.2.0 h1:t2W4W4LtMT7SH4ZPyzTv3Tosu3fP6afxu/d4J8rI8rA=
-github.com/GizClaw/flowcraft/core v0.2.0/go.mod h1:2EZ+ZFBICJse3GS48m7S+IpXy2s8j/xEy/O7dN5VB+U=
+github.com/GizClaw/flowcraft/core v0.2.3 h1:spEXJ1cfzEILXGB8ERMC9QJSmiuwxHFCiaiUB9s2Slw=
+github.com/GizClaw/flowcraft/core v0.2.3/go.mod h1:hL61rLjDQOXKMMQOJUVT8ZFOoP1gs37c6uxzECZUBh4=
 github.com/cenkalti/backoff/v5 v5.0.3 h1:ZN+IMa753KfX5hd8vVaMixjnqRZ3y8CuJKRKj1xcsSM=
 github.com/cenkalti/backoff/v5 v5.0.3/go.mod h1:rkhZdG3JZukswDf7f0cwqPNk4K0sa+F97BxZthm/crw=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=

--- a/driver/bytedance/go.mod
+++ b/driver/bytedance/go.mod
@@ -3,7 +3,7 @@ module github.com/GizClaw/flowcraft/driver/bytedance
 go 1.25.0
 
 require (
-	github.com/GizClaw/flowcraft/core v0.2.0
+	github.com/GizClaw/flowcraft/core v0.2.3
 	github.com/volcengine/volcengine-go-sdk v1.2.48
 	go.opentelemetry.io/otel/log v0.19.0
 )

--- a/driver/bytedance/go.sum
+++ b/driver/bytedance/go.sum
@@ -1,7 +1,7 @@
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
-github.com/GizClaw/flowcraft/core v0.2.0 h1:t2W4W4LtMT7SH4ZPyzTv3Tosu3fP6afxu/d4J8rI8rA=
-github.com/GizClaw/flowcraft/core v0.2.0/go.mod h1:2EZ+ZFBICJse3GS48m7S+IpXy2s8j/xEy/O7dN5VB+U=
+github.com/GizClaw/flowcraft/core v0.2.3 h1:spEXJ1cfzEILXGB8ERMC9QJSmiuwxHFCiaiUB9s2Slw=
+github.com/GizClaw/flowcraft/core v0.2.3/go.mod h1:hL61rLjDQOXKMMQOJUVT8ZFOoP1gs37c6uxzECZUBh4=
 github.com/avast/retry-go v3.0.0+incompatible/go.mod h1:XtSnn+n/sHqQIpZ10K1qAevBhOOCWBLXXy3hyiqqBrY=
 github.com/cenkalti/backoff/v5 v5.0.3 h1:ZN+IMa753KfX5hd8vVaMixjnqRZ3y8CuJKRKj1xcsSM=
 github.com/cenkalti/backoff/v5 v5.0.3/go.mod h1:rkhZdG3JZukswDf7f0cwqPNk4K0sa+F97BxZthm/crw=

--- a/driver/deepseek/go.mod
+++ b/driver/deepseek/go.mod
@@ -3,7 +3,7 @@ module github.com/GizClaw/flowcraft/driver/deepseek
 go 1.25.0
 
 require (
-	github.com/GizClaw/flowcraft/core v0.2.0
+	github.com/GizClaw/flowcraft/core v0.2.3
 	github.com/openai/openai-go/v3 v3.50.0
 	go.opentelemetry.io/otel/log v0.19.0
 )

--- a/driver/deepseek/go.sum
+++ b/driver/deepseek/go.sum
@@ -1,5 +1,5 @@
-github.com/GizClaw/flowcraft/core v0.2.0 h1:t2W4W4LtMT7SH4ZPyzTv3Tosu3fP6afxu/d4J8rI8rA=
-github.com/GizClaw/flowcraft/core v0.2.0/go.mod h1:2EZ+ZFBICJse3GS48m7S+IpXy2s8j/xEy/O7dN5VB+U=
+github.com/GizClaw/flowcraft/core v0.2.3 h1:spEXJ1cfzEILXGB8ERMC9QJSmiuwxHFCiaiUB9s2Slw=
+github.com/GizClaw/flowcraft/core v0.2.3/go.mod h1:hL61rLjDQOXKMMQOJUVT8ZFOoP1gs37c6uxzECZUBh4=
 github.com/cenkalti/backoff/v5 v5.0.3 h1:ZN+IMa753KfX5hd8vVaMixjnqRZ3y8CuJKRKj1xcsSM=
 github.com/cenkalti/backoff/v5 v5.0.3/go.mod h1:rkhZdG3JZukswDf7f0cwqPNk4K0sa+F97BxZthm/crw=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=

--- a/driver/kimi/go.mod
+++ b/driver/kimi/go.mod
@@ -3,7 +3,7 @@ module github.com/GizClaw/flowcraft/driver/kimi
 go 1.25.0
 
 require (
-	github.com/GizClaw/flowcraft/core v0.2.0
+	github.com/GizClaw/flowcraft/core v0.2.3
 	go.opentelemetry.io/otel/log v0.19.0
 )
 

--- a/driver/kimi/go.sum
+++ b/driver/kimi/go.sum
@@ -1,5 +1,5 @@
-github.com/GizClaw/flowcraft/core v0.2.0 h1:t2W4W4LtMT7SH4ZPyzTv3Tosu3fP6afxu/d4J8rI8rA=
-github.com/GizClaw/flowcraft/core v0.2.0/go.mod h1:2EZ+ZFBICJse3GS48m7S+IpXy2s8j/xEy/O7dN5VB+U=
+github.com/GizClaw/flowcraft/core v0.2.3 h1:spEXJ1cfzEILXGB8ERMC9QJSmiuwxHFCiaiUB9s2Slw=
+github.com/GizClaw/flowcraft/core v0.2.3/go.mod h1:hL61rLjDQOXKMMQOJUVT8ZFOoP1gs37c6uxzECZUBh4=
 github.com/cenkalti/backoff/v5 v5.0.3 h1:ZN+IMa753KfX5hd8vVaMixjnqRZ3y8CuJKRKj1xcsSM=
 github.com/cenkalti/backoff/v5 v5.0.3/go.mod h1:rkhZdG3JZukswDf7f0cwqPNk4K0sa+F97BxZthm/crw=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=

--- a/driver/minimax/go.mod
+++ b/driver/minimax/go.mod
@@ -3,7 +3,7 @@ module github.com/GizClaw/flowcraft/driver/minimax
 go 1.25.0
 
 require (
-	github.com/GizClaw/flowcraft/core v0.2.0
+	github.com/GizClaw/flowcraft/core v0.2.3
 	github.com/anthropics/anthropic-sdk-go v1.61.0
 	go.opentelemetry.io/otel/log v0.19.0
 )

--- a/driver/minimax/go.sum
+++ b/driver/minimax/go.sum
@@ -1,5 +1,5 @@
-github.com/GizClaw/flowcraft/core v0.2.0 h1:t2W4W4LtMT7SH4ZPyzTv3Tosu3fP6afxu/d4J8rI8rA=
-github.com/GizClaw/flowcraft/core v0.2.0/go.mod h1:2EZ+ZFBICJse3GS48m7S+IpXy2s8j/xEy/O7dN5VB+U=
+github.com/GizClaw/flowcraft/core v0.2.3 h1:spEXJ1cfzEILXGB8ERMC9QJSmiuwxHFCiaiUB9s2Slw=
+github.com/GizClaw/flowcraft/core v0.2.3/go.mod h1:hL61rLjDQOXKMMQOJUVT8ZFOoP1gs37c6uxzECZUBh4=
 github.com/anthropics/anthropic-sdk-go v1.61.0 h1:JRTnm1tPqn5xo1xd1zfrcFDlcoWXVMvV1K68YmhpZKw=
 github.com/anthropics/anthropic-sdk-go v1.61.0/go.mod h1:3EfIfmFqxH6rbiLcIP4tPFyXL/IHakx2wDG4OU+TIEI=
 github.com/bahlo/generic-list-go v0.2.0 h1:5sz/EEAK+ls5wF+NeqDpk5+iNdMDXrh3z3nPnH1Wvgk=

--- a/driver/openai/go.mod
+++ b/driver/openai/go.mod
@@ -3,7 +3,7 @@ module github.com/GizClaw/flowcraft/driver/openai
 go 1.25.0
 
 require (
-	github.com/GizClaw/flowcraft/core v0.2.0
+	github.com/GizClaw/flowcraft/core v0.2.3
 	github.com/openai/openai-go/v3 v3.50.0
 	go.opentelemetry.io/otel/log v0.19.0
 )

--- a/driver/openai/go.sum
+++ b/driver/openai/go.sum
@@ -1,5 +1,5 @@
-github.com/GizClaw/flowcraft/core v0.2.0 h1:t2W4W4LtMT7SH4ZPyzTv3Tosu3fP6afxu/d4J8rI8rA=
-github.com/GizClaw/flowcraft/core v0.2.0/go.mod h1:2EZ+ZFBICJse3GS48m7S+IpXy2s8j/xEy/O7dN5VB+U=
+github.com/GizClaw/flowcraft/core v0.2.3 h1:spEXJ1cfzEILXGB8ERMC9QJSmiuwxHFCiaiUB9s2Slw=
+github.com/GizClaw/flowcraft/core v0.2.3/go.mod h1:hL61rLjDQOXKMMQOJUVT8ZFOoP1gs37c6uxzECZUBh4=
 github.com/cenkalti/backoff/v5 v5.0.3 h1:ZN+IMa753KfX5hd8vVaMixjnqRZ3y8CuJKRKj1xcsSM=
 github.com/cenkalti/backoff/v5 v5.0.3/go.mod h1:rkhZdG3JZukswDf7f0cwqPNk4K0sa+F97BxZthm/crw=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=

--- a/driver/qwen/go.mod
+++ b/driver/qwen/go.mod
@@ -3,7 +3,7 @@ module github.com/GizClaw/flowcraft/driver/qwen
 go 1.25.0
 
 require (
-	github.com/GizClaw/flowcraft/core v0.2.0
+	github.com/GizClaw/flowcraft/core v0.2.3
 	go.opentelemetry.io/otel/log v0.19.0
 )
 

--- a/driver/qwen/go.sum
+++ b/driver/qwen/go.sum
@@ -1,5 +1,5 @@
-github.com/GizClaw/flowcraft/core v0.2.0 h1:t2W4W4LtMT7SH4ZPyzTv3Tosu3fP6afxu/d4J8rI8rA=
-github.com/GizClaw/flowcraft/core v0.2.0/go.mod h1:2EZ+ZFBICJse3GS48m7S+IpXy2s8j/xEy/O7dN5VB+U=
+github.com/GizClaw/flowcraft/core v0.2.3 h1:spEXJ1cfzEILXGB8ERMC9QJSmiuwxHFCiaiUB9s2Slw=
+github.com/GizClaw/flowcraft/core v0.2.3/go.mod h1:hL61rLjDQOXKMMQOJUVT8ZFOoP1gs37c6uxzECZUBh4=
 github.com/cenkalti/backoff/v5 v5.0.3 h1:ZN+IMa753KfX5hd8vVaMixjnqRZ3y8CuJKRKj1xcsSM=
 github.com/cenkalti/backoff/v5 v5.0.3/go.mod h1:rkhZdG3JZukswDf7f0cwqPNk4K0sa+F97BxZthm/crw=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=


### PR DESCRIPTION
Bumps `github.com/GizClaw/flowcraft/core` from v0.2.0 to the just-released v0.2.3 in all 8 driver modules:

- anthropic, azure, bytedance, deepseek, kimi, minimax, openai, qwen

Each go.mod/go.sum was updated with `go get` + `go mod tidy` (GOWORK=off).

Checks run locally: `make ci`, `make lint`, `make release-check`, `git diff --check`, plus GOWORK=off tests for every driver against the released core v0.2.3. No release changesets are included in this PR.