### PR TITLE
chore(skills): sync flowcraft-config validator to core v0.2.3

### DIFF
--- a/skills/flowcraft-config/SKILL.md
+++ b/skills/flowcraft-config/SKILL.md
@@ -106,7 +106,7 @@ workflow.
 ## Compatibility and versioning
 
 One skill version pins one FlowCraft version. The validator's `go.mod`
-requires exactly `github.com/GizClaw/flowcraft/core v0.1.28`; the schema
+requires exactly `github.com/GizClaw/flowcraft/core v0.2.3`; the schema
 cards in this skill document that release (no `driver/*` or `backends/*`
 modules are required, since the validator never constructs factories).
 When FlowCraft releases a new version, bump the pin and reconcile the

--- a/skills/flowcraft-config/scripts/validator/go.mod
+++ b/skills/flowcraft-config/scripts/validator/go.mod
@@ -2,7 +2,7 @@ module github.com/GizClaw/flowcraft/skills/flowcraft-config/scripts/validator
 
 go 1.26.0
 
-require github.com/GizClaw/flowcraft/core v0.2.0
+require github.com/GizClaw/flowcraft/core v0.2.3
 
 require (
 	github.com/cenkalti/backoff/v5 v5.0.3 // indirect

--- a/skills/flowcraft-config/scripts/validator/go.sum
+++ b/skills/flowcraft-config/scripts/validator/go.sum
@@ -1,5 +1,5 @@
-github.com/GizClaw/flowcraft/core v0.2.0 h1:t2W4W4LtMT7SH4ZPyzTv3Tosu3fP6afxu/d4J8rI8rA=
-github.com/GizClaw/flowcraft/core v0.2.0/go.mod h1:2EZ+ZFBICJse3GS48m7S+IpXy2s8j/xEy/O7dN5VB+U=
+github.com/GizClaw/flowcraft/core v0.2.3 h1:spEXJ1cfzEILXGB8ERMC9QJSmiuwxHFCiaiUB9s2Slw=
+github.com/GizClaw/flowcraft/core v0.2.3/go.mod h1:hL61rLjDQOXKMMQOJUVT8ZFOoP1gs37c6uxzECZUBh4=
 github.com/cenkalti/backoff/v5 v5.0.3 h1:ZN+IMa753KfX5hd8vVaMixjnqRZ3y8CuJKRKj1xcsSM=
 github.com/cenkalti/backoff/v5 v5.0.3/go.mod h1:rkhZdG3JZukswDf7f0cwqPNk4K0sa+F97BxZthm/crw=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=


### PR DESCRIPTION
Syncs the flowcraft-config skill to the released core v0.2.3:

- Bumps `scripts/validator/go.mod` + `go.sum` from core v0.2.0 to v0.2.3, so the L2 validator can decode the `reasoning: {kind, effort_map}` object form documented in `references/resources.md`.
- Fixes the stale `core v0.1.28` pin claim in `SKILL.md` Compatibility and versioning.

Verified: validator builds and validates `assets/minimal-deploy/deploy.yaml`; `make ci`, `make lint`, `make release-check`, and `git diff --check` pass. No release changesets included.