### PR TITLE
feat(core): carry request metadata through inference drivers

### DIFF
--- a/core/graph/nodes/inference.go
+++ b/core/graph/nodes/inference.go
@@ -114,6 +114,11 @@ type InferenceConfig struct {
 	// provider-carried: the deploy path aggregates them from the wired
 	// inference assembly, so only configured providers are available.
 	Extensions []inference.ExtensionEntry `json:"extensions,omitempty"`
+
+	// RequestMetadata is copied onto the canonical GenerateRequest as an
+	// opaque metadata bag. Keys are deployment-defined; core does not
+	// reserve or interpret any key name.
+	RequestMetadata map[string]string `json:"request_metadata,omitempty"`
 }
 
 // UndefinedToolRecoveryConfig configures the inference node's
@@ -469,8 +474,9 @@ func buildGenerateRequest(ec graph.ExecutionContext, board *agent.Board, channel
 					Intent:  intent,
 				},
 			},
-			Extensions: extensions,
-			ModelHint:  cfg.ModelHint,
+			Extensions:      extensions,
+			ModelHint:       cfg.ModelHint,
+			RequestMetadata: cfg.RequestMetadata,
 		}, nil
 	}
 
@@ -504,8 +510,9 @@ func buildGenerateRequest(ec graph.ExecutionContext, board *agent.Board, channel
 				Intent:  intent,
 			},
 		},
-		Extensions: extensions,
-		ModelHint:  cfg.ModelHint,
+		Extensions:      extensions,
+		ModelHint:       cfg.ModelHint,
+		RequestMetadata: cfg.RequestMetadata,
 	}, nil
 }
 

--- a/core/graph/nodes/inference_test.go
+++ b/core/graph/nodes/inference_test.go
@@ -199,6 +199,26 @@ func TestInferenceNode_Unary_WritesMessageAndVars(t *testing.T) {
 	}
 }
 
+func TestInferenceNode_RequestMetadataCopiedToGenerateRequest(t *testing.T) {
+	fake := &inferencetest.GenerateFake{}
+	reg := inferenceRegistry(t, InferenceNodeDeps{Assembly: fake.Assembly(t)})
+	want := map[string]string{
+		"session_id": "oc-session-1",
+		"turn_id":    "oc-turn-1",
+	}
+	g := singleNodeGraph(t, reg, "inference", InferenceConfig{
+		Model:           ptr(inferencetest.DefaultFakeModel),
+		RequestMetadata: want,
+	})
+	if err := executeGraph(t, g, agent.NoopHost{}, userBoard()); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	got := fake.LastRequest().RequestMetadata
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("request metadata = %v, want %v", got, want)
+	}
+}
+
 func TestInferenceNode_SystemPromptPrepended(t *testing.T) {
 	fake := &inferencetest.GenerateFake{}
 	reg := inferenceRegistry(t, InferenceNodeDeps{Assembly: fake.Assembly(t)})

--- a/core/inference/decision.go
+++ b/core/inference/decision.go
@@ -70,6 +70,7 @@ const (
 	FieldGenerateIntentReasoning             FieldID = "generate.input.content.intent.text.reasoning"
 	FieldGenerateIntentReasoningEnabled      FieldID = "generate.input.content.intent.text.reasoning_enabled"
 	FieldGenerateIntentReasoningEffort       FieldID = "generate.input.content.intent.text.reasoning_effort"
+	FieldGenerateRequestMetadata             FieldID = "generate.request.metadata"
 	FieldEmbedItems                          FieldID = "embed.items"
 	FieldEmbedItemText                       FieldID = "embed.items.content.text"
 	FieldEmbedItemImage                      FieldID = "embed.items.content.image"

--- a/core/inference/generate.go
+++ b/core/inference/generate.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"maps"
 	"strings"
 
 	"github.com/GizClaw/flowcraft/core/message"
@@ -101,6 +102,13 @@ type GenerateRequest struct {
 	// to the default policy. Providers never interpret the hint — it is
 	// routing metadata, not a provider knob.
 	ModelHint string `json:"model_hint,omitempty"`
+
+	// RequestMetadata carries opaque caller/host metadata whose keys and
+	// values are deployment-defined (for example conversation or turn
+	// identifiers). Core treats it as an opaque bag: it never interprets
+	// keys, and each provider driver decides whether and how to surface
+	// it on the provider request (metadata, client_metadata, or none).
+	RequestMetadata map[string]string `json:"request_metadata,omitempty"`
 }
 
 func (r GenerateRequest) Clone() GenerateRequest {
@@ -111,6 +119,7 @@ func (r GenerateRequest) Clone() GenerateRequest {
 	}
 	clone.Input = r.Input.Clone()
 	clone.Extensions = r.Extensions.Clone()
+	clone.RequestMetadata = maps.Clone(r.RequestMetadata)
 	return clone
 }
 
@@ -146,6 +155,9 @@ func (r GenerateRequest) ActiveFields() []FieldID {
 	}
 	fields = appendGenerateInputPartFields(fields, r.Input.Content.Parts)
 	fields = appendGenerateIntentFields(fields, r.Input.Content.Intent)
+	if len(r.RequestMetadata) > 0 {
+		fields = append(fields, FieldGenerateRequestMetadata)
+	}
 	return r.Extensions.AppendActiveFields(fields)
 }
 

--- a/core/inference/generate_test.go
+++ b/core/inference/generate_test.go
@@ -70,6 +70,65 @@ func TestGenerateRequestModelHintCloneValidateAndJSON(t *testing.T) {
 	}
 }
 
+func TestGenerateRequestRequestMetadataCloneAndJSON(t *testing.T) {
+	request := GenerateRequest{
+		Input: GenerateInput{
+			Role: InputRoleUser,
+			Content: InputContent{
+				Content: message.Content{Parts: []message.Part{
+					message.TextPart{Text: "hi"},
+				}},
+				Intent: Intent{Text: &TextIntent{}},
+			},
+		},
+		RequestMetadata: map[string]string{
+			"session_id": "s-1",
+			"turn_id":    "turn-1",
+		},
+	}
+	if err := request.Validate(); err != nil {
+		t.Fatalf("Validate: %v", err)
+	}
+
+	clone := request.Clone()
+	clone.RequestMetadata["session_id"] = "mutated"
+	if request.RequestMetadata["session_id"] != "s-1" {
+		t.Fatalf(
+			"clone aliases RequestMetadata: source session_id = %q, want s-1",
+			request.RequestMetadata["session_id"],
+		)
+	}
+	if clone.RequestMetadata["turn_id"] != "turn-1" {
+		t.Fatalf("Clone().RequestMetadata turn_id = %q, want turn-1", clone.RequestMetadata["turn_id"])
+	}
+
+	raw, err := json.Marshal(request)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	var decoded GenerateRequest
+	if err := json.Unmarshal(raw, &decoded); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if !reflect.DeepEqual(decoded.RequestMetadata, request.RequestMetadata) {
+		t.Fatalf(
+			"JSON round-trip RequestMetadata = %v, want %v",
+			decoded.RequestMetadata,
+			request.RequestMetadata,
+		)
+	}
+	sawLedger := false
+	for _, field := range request.ActiveFieldsFor(GenerateExecutionUnary) {
+		if field == FieldGenerateRequestMetadata {
+			sawLedger = true
+			break
+		}
+	}
+	if !sawLedger {
+		t.Fatal("RequestMetadata did not enter ActiveFields")
+	}
+}
+
 func TestValidateGenerateText(t *testing.T) {
 	arraySchema := json.RawMessage(
 		`{"type":"array","items":{"type":"string"}}`,

--- a/docs/guides/graph.md
+++ b/docs/guides/graph.md
@@ -146,6 +146,7 @@ onto `tool_pending_key` and the graph routes onward.
 | `tool_choice`                            | constrain when/which tools are called                                                                             |
 | `intent`                                 | canonical execution envelope: `{text, image, audio, video}` with per-modality controls (see below)                |
 | `extensions`                             | provider knobs in the `{provider, id, fields}` wire form, resolved via the assembly's decoders                    |
+| `request_metadata`                       | opaque `map[string]string` copied onto the canonical `GenerateRequest`; keys are deployment-defined and core never interprets them |
 
 Behavior:
 

--- a/docs/guides/inference.md
+++ b/docs/guides/inference.md
@@ -134,6 +134,44 @@ Scores guide selection only; they never claim a request is executable.
   wires the router through its `router` dep when inference nodes omit an
   explicit `model`.
 
+## Request metadata
+
+`GenerateRequest.RequestMetadata` is an opaque `map[string]string` carried
+with every call. Core never interprets its keys; callers and hosts decide
+the vocabulary (conversation identifiers, turn identifiers, installation
+metadata, ...). Graph inference nodes expose the same field as
+`request_metadata` node config, and script/direct callers can set it on the
+canonical request.
+
+Drivers forward the bag only when their deployment enables it, because each
+provider API has a different legal shape. Provider specs accept:
+
+```yaml
+settings:
+  spec:
+    request_metadata:
+      envelope: metadata          # any non-empty top-level field name; empty disables
+```
+
+OpenAI-compatible drivers map `metadata` onto the native OpenAI metadata
+object; `client_metadata` is emitted as a passthrough object for gateways
+that speak the Codex convention. An empty configuration never sends
+anything, and core keys are forwarded verbatim.
+
+`request_metadata` forwarding is implemented by the DeepSeek, OpenAI, and
+Azure drivers. Anthropic, MiniMax, Bytedance, Kimi, and Qwen are the current
+exceptions: their official Messages/Ark/DashScope surfaces do not model
+arbitrary request metadata and the drivers deliberately keep their native
+transport paths, so canonical metadata is not forwarded until those
+SDKs/providers add a native channel.
+
+Because `RequestMetadata` is part of the compile ledger, drivers that cannot
+forward it report a `dropped` decision instead of silently ignoring it.
+Drivers that forward it report `native` when their deployment enables an
+envelope. The envelope is an arbitrary non-empty string naming the top-level
+body field; providers that type `metadata` natively lower that name through
+their SDK types, while other names ride as passthrough JSON fields.
+
 ## Streaming
 
 `GenerateStream` returns a stream of deltas plus the final result. Streaming

--- a/driver/anthropic/generate.go
+++ b/driver/anthropic/generate.go
@@ -309,6 +309,12 @@ func compileGenerate(
 			stream:    shape == inference.GenerateExecutionStream,
 			maxTokens: DefaultMaxTokens,
 		}
+		if len(request.RequestMetadata) > 0 {
+			ledger.drop(
+				inference.FieldGenerateRequestMetadata,
+				"anthropic Messages API has no arbitrary request metadata channel",
+			)
+		}
 
 		// Context messages. The system channel joins the request's system
 		// blocks; everything else becomes user/assistant turns.

--- a/driver/anthropic/request_metadata_ledger_test.go
+++ b/driver/anthropic/request_metadata_ledger_test.go
@@ -1,0 +1,45 @@
+package anthropic
+
+import (
+	"context"
+	"testing"
+
+	"github.com/GizClaw/flowcraft/core/inference"
+	"github.com/GizClaw/flowcraft/core/message"
+)
+
+func TestRequestMetadataDroppedByLedger(t *testing.T) {
+	request := inference.GenerateRequest{
+		Input: inference.GenerateInput{
+			Role: inference.InputRoleUser,
+			Content: inference.InputContent{
+				Content: message.Content{Parts: []message.Part{
+					message.TextPart{Text: "hi"},
+				}},
+				Intent: inference.Intent{Text: &inference.TextIntent{}},
+			},
+		},
+		RequestMetadata: map[string]string{"session_id": "s-1"},
+	}
+	compiled, err := compileGenerate("claude-sonnet-5", catalog["claude-sonnet-5"])(
+		context.Background(),
+		inference.ModelRef{ID: inference.ModelID{Provider: "anthropic", Name: "claude-sonnet-5"}},
+		request,
+		inference.GenerateExecutionUnary,
+	)
+	if err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+	if disposition := requestMetadataDisposition(compiled.Report); disposition != inference.Dropped {
+		t.Fatalf("metadata disposition = %q, want dropped", disposition)
+	}
+}
+
+func requestMetadataDisposition(report inference.CompileReport) inference.Disposition {
+	for _, decision := range report.Decisions {
+		if decision.Field == inference.FieldGenerateRequestMetadata {
+			return decision.Disposition
+		}
+	}
+	return ""
+}

--- a/driver/azure/catalog.go
+++ b/driver/azure/catalog.go
@@ -21,6 +21,9 @@ type catalogEntry struct {
 	// effortNone marks generate deployments whose reasoning.effort accepts
 	// "none" to disable reasoning; without it a disable request rejects.
 	effortNone bool
+	// requestMetadataEnvelope is the provider-level lowering policy for
+	// canonical GenerateRequest.RequestMetadata ("" disables forwarding).
+	requestMetadataEnvelope string
 }
 
 // entryFor lowers one declared deployment into a compiler entry.

--- a/driver/azure/generate.go
+++ b/driver/azure/generate.go
@@ -5,6 +5,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"maps"
 	"slices"
 	"strings"
 
@@ -39,6 +40,12 @@ type generateWire struct {
 	// the include on plain chat models, so it must follow the capability
 	// declaration instead of being unconditional.
 	includeReasoning bool
+
+	// requestMetadataEnvelope names the top-level body field that carries
+	// canonical request metadata; empty disables forwarding.
+	requestMetadataEnvelope string
+	// requestMetadata is the opaque metadata bag forwarded verbatim.
+	requestMetadata map[string]string
 }
 
 type wireItemKind string
@@ -320,6 +327,15 @@ func compileGenerate(
 			model:            model,
 			stream:           shape == inference.GenerateExecutionStream,
 			includeReasoning: entry.capabilities.Reasoning.Kind != inference.ReasoningNone,
+		}
+		if entry.requestMetadataEnvelope != "" && len(request.RequestMetadata) > 0 {
+			wire.requestMetadataEnvelope = entry.requestMetadataEnvelope
+			wire.requestMetadata = maps.Clone(request.RequestMetadata)
+		} else if len(request.RequestMetadata) > 0 {
+			ledger.drop(
+				inference.FieldGenerateRequestMetadata,
+				"azure request_metadata forwarding is disabled (set spec.request_metadata.envelope)",
+			)
 		}
 
 		// Context messages → items. System stays a native system-role item;

--- a/driver/azure/generate_openai.go
+++ b/driver/azure/generate_openai.go
@@ -11,6 +11,7 @@ import (
 	"github.com/GizClaw/flowcraft/core/message"
 
 	"github.com/openai/openai-go/v3"
+	"github.com/openai/openai-go/v3/option"
 	"github.com/openai/openai-go/v3/packages/param"
 	"github.com/openai/openai-go/v3/responses"
 	"github.com/openai/openai-go/v3/shared"
@@ -123,7 +124,21 @@ func wireToParams(wire generateWire) responses.ResponseNewParams {
 			OfToolChoiceMode: param.NewOpt(responses.ToolChoiceOptionsRequired),
 		}
 	}
+	if wire.requestMetadataEnvelope == "metadata" && len(wire.requestMetadata) > 0 {
+		params.Metadata = wire.requestMetadata
+	}
 	return params
+}
+
+func requestMetadataOptions(wire generateWire) []option.RequestOption {
+	if wire.requestMetadataEnvelope == "" ||
+		wire.requestMetadataEnvelope == "metadata" ||
+		len(wire.requestMetadata) == 0 {
+		return nil
+	}
+	return []option.RequestOption{
+		option.WithJSONSet(wire.requestMetadataEnvelope, wire.requestMetadata),
+	}
 }
 
 func webSearchToolParam(search *wireWebSearch) responses.WebSearchToolParam {
@@ -231,7 +246,11 @@ func transportGenerate(
 	client openai.Client,
 ) inference.Transport[generateWire, generateRaw] {
 	return func(ctx context.Context, wire generateWire) (generateRaw, error) {
-		response, err := client.Responses.New(ctx, wireToParams(wire))
+		response, err := client.Responses.New(
+			ctx,
+			wireToParams(wire),
+			requestMetadataOptions(wire)...,
+		)
 		if err != nil {
 			classified := classifyError(err)
 			logInferenceCall(ctx, "generate", wire.model, classified, "", "")

--- a/driver/azure/generate_stream.go
+++ b/driver/azure/generate_stream.go
@@ -49,7 +49,11 @@ func transportGenerateStream(
 		ctx context.Context,
 		wire generateWire,
 	) (inference.ProviderStream[streamRaw], error) {
-		stream := client.Responses.NewStreaming(ctx, wireToParams(wire))
+		stream := client.Responses.NewStreaming(
+			ctx,
+			wireToParams(wire),
+			requestMetadataOptions(wire)...,
+		)
 		if err := stream.Err(); err != nil {
 			classified := classifyError(err)
 			logInferenceStream(ctx, "generate", wire.model, classified, "")

--- a/driver/azure/request_metadata_test.go
+++ b/driver/azure/request_metadata_test.go
@@ -1,0 +1,110 @@
+package azure
+
+import (
+	"context"
+	"testing"
+
+	"github.com/GizClaw/flowcraft/core/inference"
+	"github.com/GizClaw/flowcraft/core/message"
+)
+
+func TestRequestMetadataCompilesAndLoweringOptions(t *testing.T) {
+	entry := entryFor(ModelSpec{
+		Name: "gpt-test",
+		Kind: "generate",
+		Capabilities: inference.ModelCapabilities{
+			Inputs:  []message.PartKind{message.PartText},
+			Outputs: []message.PartKind{message.PartText},
+		},
+	})
+	request := inference.GenerateRequest{
+		Input: inference.GenerateInput{
+			Role: inference.InputRoleUser,
+			Content: inference.InputContent{
+				Content: message.Content{Parts: []message.Part{
+					message.TextPart{Text: "hi"},
+				}},
+				Intent: inference.Intent{Text: &inference.TextIntent{}},
+			},
+		},
+		RequestMetadata: map[string]string{
+			"session_id": "s-1",
+			"turn_id":    "t-1",
+		},
+	}
+
+	typed := entry
+	typed.requestMetadataEnvelope = "metadata"
+	compiled, err := compileGenerate("gpt-test", typed)(
+		context.Background(),
+		inference.ModelRef{ID: inference.ModelID{Provider: "azure", Name: "gpt-test"}},
+		request,
+		inference.GenerateExecutionUnary,
+	)
+	if err != nil {
+		t.Fatalf("compile metadata: %v", err)
+	}
+	params := wireToParams(compiled.Wire)
+	if params.Metadata["session_id"] != "s-1" ||
+		params.Metadata["turn_id"] != "t-1" {
+		t.Fatalf("metadata = %v, want session + turn", params.Metadata)
+	}
+	if disposition := metadataDisposition(compiled.Report); disposition != inference.Native {
+		t.Fatalf("metadata disposition = %q, want native", disposition)
+	}
+
+	client := entry
+	client.requestMetadataEnvelope = "client_metadata"
+	compiled, err = compileGenerate("gpt-test", client)(
+		context.Background(),
+		inference.ModelRef{ID: inference.ModelID{Provider: "azure", Name: "gpt-test"}},
+		request,
+		inference.GenerateExecutionUnary,
+	)
+	if err != nil {
+		t.Fatalf("compile client_metadata: %v", err)
+	}
+	if options := requestMetadataOptions(compiled.Wire); len(options) != 1 {
+		t.Fatalf("client_metadata options = %d, want 1", len(options))
+	}
+	if disposition := metadataDisposition(compiled.Report); disposition != inference.Native {
+		t.Fatalf("metadata disposition = %q, want native", disposition)
+	}
+
+	custom := entry
+	custom.requestMetadataEnvelope = "request_fields"
+	compiled, err = compileGenerate("gpt-test", custom)(
+		context.Background(),
+		inference.ModelRef{ID: inference.ModelID{Provider: "azure", Name: "gpt-test"}},
+		request,
+		inference.GenerateExecutionUnary,
+	)
+	if err != nil {
+		t.Fatalf("compile custom envelope: %v", err)
+	}
+	if options := requestMetadataOptions(compiled.Wire); len(options) != 1 {
+		t.Fatalf("custom envelope options = %d, want 1", len(options))
+	}
+
+	compiled, err = compileGenerate("gpt-test", entry)(
+		context.Background(),
+		inference.ModelRef{ID: inference.ModelID{Provider: "azure", Name: "gpt-test"}},
+		request,
+		inference.GenerateExecutionUnary,
+	)
+	if err != nil {
+		t.Fatalf("compile disabled metadata: %v", err)
+	}
+	if disposition := metadataDisposition(compiled.Report); disposition != inference.Dropped {
+		t.Fatalf("metadata disposition = %q, want dropped", disposition)
+	}
+}
+
+func metadataDisposition(report inference.CompileReport) inference.Disposition {
+	for _, decision := range report.Decisions {
+		if decision.Field == inference.FieldGenerateRequestMetadata {
+			return decision.Disposition
+		}
+	}
+	return ""
+}

--- a/driver/azure/resource.go
+++ b/driver/azure/resource.go
@@ -92,6 +92,7 @@ func buildProvider(ctx context.Context, settings ResourceSettings, secrets *reso
 	for _, model := range spec.Models {
 		id := inference.ModelID{Provider: settings.ID, Name: model.Name}
 		entry := entryFor(model)
+		entry.requestMetadataEnvelope = spec.requestMetadataEnvelope()
 		provider.Models = append(provider.Models, inference.ModelImplementation{
 			Descriptor: inference.ModelDescriptor{
 				ID:           id,

--- a/driver/azure/spec.go
+++ b/driver/azure/spec.go
@@ -23,8 +23,27 @@ type Spec struct {
 	// HTTPRetries bounds wire-level retries inside one logical inference
 	// attempt, including the first.
 	HTTPRetries *resource.Int `json:"http_retries,omitempty"`
+	// RequestMetadata controls how canonical GenerateRequest metadata is
+	// projected onto the provider request body. The empty value disables
+	// forwarding; any non-empty value names the top-level body field that
+	// receives the bag. "metadata" uses the native metadata object and
+	// "client_metadata" uses the Codex-style passthrough, but other names
+	// are allowed for gateways.
+	RequestMetadata *RequestMetadataSpec `json:"request_metadata,omitempty"`
 	// Models declares the deployments to expose; at least one is required.
 	Models []ModelSpec `json:"models"`
+}
+
+// RequestMetadataSpec is the provider-level lowering policy for canonical
+// GenerateRequest.RequestMetadata. Keys and the envelope are opaque and
+// forwarded verbatim.
+type RequestMetadataSpec struct {
+	Envelope string `json:"envelope,omitempty"`
+}
+
+// Validate checks the request metadata forwarding policy.
+func (s RequestMetadataSpec) Validate() error {
+	return nil
 }
 
 // ModelSpec declares one deployment: its name is the model identity, kind
@@ -61,6 +80,11 @@ func (s Spec) Validate() error {
 	}
 	if s.HTTPRetries != nil && *s.HTTPRetries < 0 {
 		return fmt.Errorf("azure: http_retries must not be negative")
+	}
+	if s.RequestMetadata != nil {
+		if err := s.RequestMetadata.Validate(); err != nil {
+			return err
+		}
 	}
 	if len(s.Models) == 0 {
 		return fmt.Errorf(
@@ -142,4 +166,11 @@ func decodeSpec(ctx context.Context, raw []byte) (Spec, error) {
 		return Spec{}, fmt.Errorf("azure spec: %w", err)
 	}
 	return spec, nil
+}
+
+func (s Spec) requestMetadataEnvelope() string {
+	if s.RequestMetadata == nil {
+		return ""
+	}
+	return s.RequestMetadata.Envelope
 }

--- a/driver/bytedance/generate.go
+++ b/driver/bytedance/generate.go
@@ -327,6 +327,12 @@ func compileGenerate(
 			model:  endpoint,
 			stream: shape == inference.GenerateExecutionStream,
 		}
+		if len(request.RequestMetadata) > 0 {
+			ledger.drop(
+				inference.FieldGenerateRequestMetadata,
+				"bytedance Ark SDK has no arbitrary request metadata channel",
+			)
+		}
 
 		// Context messages → items. System text folds into the native
 		// instructions field; non-text system parts have no native home.

--- a/driver/bytedance/request_metadata_ledger_test.go
+++ b/driver/bytedance/request_metadata_ledger_test.go
@@ -1,0 +1,34 @@
+package bytedance
+
+import (
+	"context"
+	"testing"
+
+	"github.com/GizClaw/flowcraft/core/inference"
+)
+
+func TestRequestMetadataDroppedByLedger(t *testing.T) {
+	request := conformanceTextRequest()
+	request.RequestMetadata = map[string]string{"session_id": "s-1"}
+	compiled, err := compileGenerate("doubao-seed-2-0-lite", catalog["doubao-seed-2-0-lite"])(
+		context.Background(),
+		conformanceModel("doubao-seed-2-0-lite"),
+		request,
+		inference.GenerateExecutionUnary,
+	)
+	if err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+	if disposition := requestMetadataDisposition(compiled.Report); disposition != inference.Dropped {
+		t.Fatalf("metadata disposition = %q, want dropped", disposition)
+	}
+}
+
+func requestMetadataDisposition(report inference.CompileReport) inference.Disposition {
+	for _, decision := range report.Decisions {
+		if decision.Field == inference.FieldGenerateRequestMetadata {
+			return decision.Disposition
+		}
+	}
+	return ""
+}

--- a/driver/deepseek/catalog.go
+++ b/driver/deepseek/catalog.go
@@ -41,6 +41,9 @@ type catalogEntry struct {
 	// undeclared. Both V4 models carry the 1M context published on
 	// https://api-docs.deepseek.com/quick_start/pricing.
 	maxInputTokens int
+	// requestMetadataEnvelope is the provider-level lowering policy for
+	// canonical GenerateRequest.RequestMetadata ("" disables forwarding).
+	requestMetadataEnvelope string
 }
 
 // deepseekEffortMap is the canonical-to-wire map the V4 family declares.
@@ -157,6 +160,11 @@ func mergedCatalog(spec Spec) (map[string]catalogEntry, error) {
 			}
 		}
 		models[declared.Name] = entry
+	}
+	envelope := spec.requestMetadataEnvelope()
+	for name, entry := range models {
+		entry.requestMetadataEnvelope = envelope
+		models[name] = entry
 	}
 	for name, entry := range models {
 		if err := entry.validate(); err != nil {

--- a/driver/deepseek/catalog_test.go
+++ b/driver/deepseek/catalog_test.go
@@ -2,6 +2,7 @@ package deepseek
 
 import (
 	"context"
+	"fmt"
 	"reflect"
 	"slices"
 	"testing"
@@ -87,5 +88,29 @@ func TestMergedCatalogRejectsMissingTextOutput(t *testing.T) {
 	}
 	if _, err := mergedCatalog(spec); err == nil {
 		t.Fatal("mergedCatalog unexpectedly accepted a generate model without text output")
+	}
+}
+
+func TestRequestMetadataEnvelopeValidationAndCatalogPropagation(t *testing.T) {
+	for _, envelope := range []string{"", "metadata", "client_metadata", "request_fields"} {
+		raw := `{}`
+		if envelope != "" {
+			raw = fmt.Sprintf(`{"request_metadata":{"envelope":%q}}`, envelope)
+		}
+		spec, err := decodeSpec(context.Background(), []byte(raw))
+		if err != nil {
+			t.Fatalf("decodeSpec(envelope %q): %v", envelope, err)
+		}
+		models, err := mergedCatalog(spec)
+		if err != nil {
+			t.Fatalf("mergedCatalog(envelope %q): %v", envelope, err)
+		}
+		if got := models["deepseek-v4-flash"].requestMetadataEnvelope; got != envelope {
+			t.Fatalf(
+				"catalog envelope = %q, want %q",
+				got,
+				envelope,
+			)
+		}
 	}
 }

--- a/driver/deepseek/generate_chat.go
+++ b/driver/deepseek/generate_chat.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"maps"
 	"slices"
 	"strings"
 
@@ -33,6 +34,12 @@ type chatWire struct {
 	effort      string
 	thinking    *bool
 	stream      bool
+
+	// requestMetadataEnvelope names the top-level body field that carries
+	// canonical request metadata; empty disables forwarding.
+	requestMetadataEnvelope string
+	// requestMetadata is the opaque metadata bag forwarded verbatim.
+	requestMetadata map[string]string
 }
 
 type wireChatMessage struct {
@@ -89,6 +96,15 @@ func compileChatGenerate(
 		wire := chatWire{
 			model:  model,
 			stream: shape == inference.GenerateExecutionStream,
+		}
+		if entry.requestMetadataEnvelope != "" && len(request.RequestMetadata) > 0 {
+			wire.requestMetadataEnvelope = entry.requestMetadataEnvelope
+			wire.requestMetadata = maps.Clone(request.RequestMetadata)
+		} else if len(request.RequestMetadata) > 0 {
+			ledger.drop(
+				inference.FieldGenerateRequestMetadata,
+				"deepseek request_metadata forwarding is disabled (set spec.request_metadata.envelope)",
+			)
 		}
 
 		for _, turn := range request.Context {
@@ -484,8 +500,19 @@ func wireToChatParams(
 			IncludeUsage: openaigo.Bool(true),
 		}
 	}
+	if wire.requestMetadataEnvelope == "metadata" && len(wire.requestMetadata) > 0 {
+		params.Metadata = wire.requestMetadata
+	}
 
 	var overrides []option.RequestOption
+	if wire.requestMetadataEnvelope != "" &&
+		wire.requestMetadataEnvelope != "metadata" &&
+		len(wire.requestMetadata) > 0 {
+		overrides = append(overrides, option.WithJSONSet(
+			wire.requestMetadataEnvelope,
+			wire.requestMetadata,
+		))
+	}
 	if wire.thinking != nil {
 		kind := "disabled"
 		if *wire.thinking {

--- a/driver/deepseek/generate_responses.go
+++ b/driver/deepseek/generate_responses.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"maps"
 	"slices"
 	"strings"
 
@@ -13,6 +14,7 @@ import (
 	"github.com/GizClaw/flowcraft/core/message"
 
 	"github.com/openai/openai-go/v3"
+	"github.com/openai/openai-go/v3/option"
 	"github.com/openai/openai-go/v3/packages/param"
 	"github.com/openai/openai-go/v3/packages/ssestream"
 	"github.com/openai/openai-go/v3/responses"
@@ -35,6 +37,12 @@ type responseWire struct {
 	toolChoice  *wireToolChoice
 	webSearch   *wireWebSearch
 	stream      bool
+
+	// requestMetadataEnvelope names the top-level body field that carries
+	// canonical request metadata; empty disables forwarding.
+	requestMetadataEnvelope string
+	// requestMetadata is the opaque metadata bag forwarded verbatim.
+	requestMetadata map[string]string
 }
 
 type responseWireItemKind string
@@ -117,6 +125,15 @@ func compileResponsesGenerate(
 		wire := responseWire{
 			model:  model,
 			stream: shape == inference.GenerateExecutionStream,
+		}
+		if entry.requestMetadataEnvelope != "" && len(request.RequestMetadata) > 0 {
+			wire.requestMetadataEnvelope = entry.requestMetadataEnvelope
+			wire.requestMetadata = maps.Clone(request.RequestMetadata)
+		} else if len(request.RequestMetadata) > 0 {
+			ledger.drop(
+				inference.FieldGenerateRequestMetadata,
+				"deepseek request_metadata forwarding is disabled (set spec.request_metadata.envelope)",
+			)
 		}
 
 		for _, turn := range request.Context {
@@ -557,7 +574,26 @@ func wireToResponseParams(wire responseWire) responses.ResponseNewParams {
 			OfToolChoiceMode: param.NewOpt(responses.ToolChoiceOptionsRequired),
 		}
 	}
+	if wire.requestMetadataEnvelope == "metadata" && len(wire.requestMetadata) > 0 {
+		params.Metadata = wire.requestMetadata
+	}
 	return params
+}
+
+// responseMetadataOptions returns the per-request options that project
+// canonical request metadata onto nonstandard body fields. The standard
+// "metadata" envelope is typed by the SDK and is set in
+// wireToResponseParams; "client_metadata" has no SDK type, so it rides
+// option.WithJSONSet like DeepSeek's other extra fields.
+func responseMetadataOptions(wire responseWire) []option.RequestOption {
+	if wire.requestMetadataEnvelope == "" ||
+		wire.requestMetadataEnvelope == "metadata" ||
+		len(wire.requestMetadata) == 0 {
+		return nil
+	}
+	return []option.RequestOption{
+		option.WithJSONSet(wire.requestMetadataEnvelope, wire.requestMetadata),
+	}
 }
 
 func responseWebSearchToolParam(search *wireWebSearch) *responses.WebSearchToolParam {
@@ -679,7 +715,11 @@ func transportResponsesGenerate(
 	client openai.Client,
 ) inference.Transport[responseWire, generateRaw] {
 	return func(ctx context.Context, wire responseWire) (generateRaw, error) {
-		response, err := client.Responses.New(ctx, wireToResponseParams(wire))
+		response, err := client.Responses.New(
+			ctx,
+			wireToResponseParams(wire),
+			responseMetadataOptions(wire)...,
+		)
 		if err != nil {
 			classified := classifyError(err)
 			logInferenceCall(ctx, "generate", wire.model, classified, "", "")
@@ -896,7 +936,11 @@ func transportResponsesGenerateStream(
 		ctx context.Context,
 		wire responseWire,
 	) (inference.ProviderStream[streamRaw], error) {
-		stream := client.Responses.NewStreaming(ctx, wireToResponseParams(wire))
+		stream := client.Responses.NewStreaming(
+			ctx,
+			wireToResponseParams(wire),
+			responseMetadataOptions(wire)...,
+		)
 		if err := stream.Err(); err != nil {
 			classified := classifyError(err)
 			logInferenceStream(ctx, "generate", wire.model, classified, "")

--- a/driver/deepseek/generate_test.go
+++ b/driver/deepseek/generate_test.go
@@ -97,6 +97,12 @@ func chatEntry() catalogEntry {
 	}
 }
 
+func chatEntryWithMetadata(envelope string) catalogEntry {
+	entry := chatEntry()
+	entry.requestMetadataEnvelope = envelope
+	return entry
+}
+
 func responsesEntry() catalogEntry {
 	return catalogEntry{
 		kind:         kindGenerate,
@@ -104,6 +110,21 @@ func responsesEntry() catalogEntry {
 		capabilities: generateChatCapabilities().WithHostedWebSearch().WithReasoning(inference.ReasoningToggle),
 		responses:    true,
 	}
+}
+
+func responsesEntryWithMetadata(envelope string) catalogEntry {
+	entry := responsesEntry()
+	entry.requestMetadataEnvelope = envelope
+	return entry
+}
+
+func metadataTextRequest(text string) inference.GenerateRequest {
+	request := simpleTextRequest(text)
+	request.RequestMetadata = map[string]string{
+		"session_id": "oc-session-1",
+		"turn_id":    "oc-turn-1",
+	}
+	return request
 }
 
 func chatCompletionJSON(reasoning string) string {
@@ -228,6 +249,61 @@ func TestChatUnaryReasoning(t *testing.T) {
 	}
 }
 
+func TestChatMetadataEnvelopeTypedCompiles(t *testing.T) {
+	compiled, err := compileChatGenerate(
+		"deepseek-v4-flash",
+		chatEntryWithMetadata("metadata"),
+	)(
+		context.Background(),
+		deepseekModel("deepseek-v4-flash"),
+		metadataTextRequest("hi"),
+		inference.GenerateExecutionUnary,
+	)
+	if err != nil {
+		t.Fatalf("Compile: %v", err)
+	}
+	params, overrides := wireToChatParams(compiled.Wire)
+	if params.Metadata["session_id"] != "oc-session-1" ||
+		params.Metadata["turn_id"] != "oc-turn-1" {
+		t.Fatalf("metadata = %v, want session + turn", params.Metadata)
+	}
+	if len(overrides) != 0 {
+		t.Fatalf("overrides = %d, want none for typed metadata", len(overrides))
+	}
+}
+
+func TestChatClientMetadataForwardedOnUnaryBody(t *testing.T) {
+	server := newCapturedServer(t, func(w http.ResponseWriter, _ map[string]any) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = fmt.Fprint(w, chatCompletionJSON(""))
+	})
+	cls := testClients(t, server.Server)
+	operations, err := openGenerate(
+		cls,
+		chatEntryWithMetadata("client_metadata"),
+		deepseekModel("deepseek-v4-flash").ID,
+		"default",
+	)
+	if err != nil {
+		t.Fatalf("openGenerate: %v", err)
+	}
+	if _, err := operations.Unary.Execute(
+		context.Background(),
+		deepseekModel("deepseek-v4-flash"),
+		metadataTextRequest("hi"),
+	); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	metadata, ok := server.captured()["client_metadata"].(map[string]any)
+	if !ok {
+		t.Fatalf("captured body = %v, want client_metadata object", server.captured())
+	}
+	if metadata["session_id"] != "oc-session-1" ||
+		metadata["turn_id"] != "oc-turn-1" {
+		t.Fatalf("client_metadata = %v, want session + turn", metadata)
+	}
+}
+
 func TestChatReasoningRoundTrip(t *testing.T) {
 	server := newCapturedServer(t, func(w http.ResponseWriter, _ map[string]any) {
 		w.Header().Set("Content-Type", "application/json")
@@ -329,6 +405,130 @@ func TestResponsesUnaryReasoningAndText(t *testing.T) {
 	if response.Usage.Input.CacheReadTokens == nil ||
 		*response.Usage.Input.CacheReadTokens != 3 {
 		t.Fatalf("cache = %+v", response.Usage.Input)
+	}
+}
+
+func TestResponsesMetadataEnvelopeTypedCompiles(t *testing.T) {
+	compiled, err := compileResponsesGenerate(
+		"deepseek-v4-flash",
+		responsesEntryWithMetadata("metadata"),
+	)(
+		context.Background(),
+		deepseekModel("deepseek-v4-flash"),
+		metadataTextRequest("hi"),
+		inference.GenerateExecutionUnary,
+	)
+	if err != nil {
+		t.Fatalf("Compile: %v", err)
+	}
+	params := wireToResponseParams(compiled.Wire)
+	if params.Metadata["session_id"] != "oc-session-1" ||
+		params.Metadata["turn_id"] != "oc-turn-1" {
+		t.Fatalf("metadata = %v, want session + turn", params.Metadata)
+	}
+	if len(responseMetadataOptions(compiled.Wire)) != 0 {
+		t.Fatal("client_metadata options present for typed metadata envelope")
+	}
+}
+
+func TestResponsesClientMetadataForwardedOnUnaryBody(t *testing.T) {
+	server := newCapturedServer(t, func(w http.ResponseWriter, _ map[string]any) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = fmt.Fprint(w, responsesResponseJSON([]map[string]any{
+			textOutputItem("answer"),
+		}))
+	})
+	cls := testClients(t, server.Server)
+	operations, err := openGenerate(
+		cls,
+		responsesEntryWithMetadata("client_metadata"),
+		deepseekModel("deepseek-v4-flash").ID,
+		"default",
+	)
+	if err != nil {
+		t.Fatalf("openGenerate: %v", err)
+	}
+	if _, err := operations.Unary.Execute(
+		context.Background(),
+		deepseekModel("deepseek-v4-flash"),
+		metadataTextRequest("hi"),
+	); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	metadata, ok := server.captured()["client_metadata"].(map[string]any)
+	if !ok {
+		t.Fatalf("captured body = %v, want client_metadata object", server.captured())
+	}
+	if metadata["session_id"] != "oc-session-1" ||
+		metadata["turn_id"] != "oc-turn-1" {
+		t.Fatalf("client_metadata = %v, want session + turn", metadata)
+	}
+}
+
+func TestResponsesClientMetadataForwardedOnStreamBody(t *testing.T) {
+	server := newCapturedServer(t, func(w http.ResponseWriter, _ map[string]any) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = fmt.Fprint(w, sseBody(
+			map[string]any{
+				"type": "response.output_item.added", "output_index": 0,
+				"item": map[string]any{"type": "message"},
+			},
+			map[string]any{
+				"type":         "response.output_text.delta",
+				"output_index": 0, "delta": "answer",
+			},
+			map[string]any{
+				"type": "response.output_item.done", "output_index": 0,
+				"item": textOutputItem("answer"),
+			},
+			map[string]any{
+				"type": "response.completed",
+				"response": map[string]any{
+					"id": "resp_1", "status": "completed",
+					"usage": map[string]any{
+						"input_tokens":          1,
+						"output_tokens":         1,
+						"total_tokens":          2,
+						"input_tokens_details":  map[string]any{"cached_tokens": 0},
+						"output_tokens_details": map[string]any{"reasoning_tokens": 0},
+					},
+				},
+			},
+		))
+	})
+	cls := testClients(t, server.Server)
+	operations, err := openGenerate(
+		cls,
+		responsesEntryWithMetadata("client_metadata"),
+		deepseekModel("deepseek-v4-flash").ID,
+		"default",
+	)
+	if err != nil {
+		t.Fatalf("openGenerate: %v", err)
+	}
+	stream, err := operations.Stream.Stream(
+		context.Background(),
+		deepseekModel("deepseek-v4-flash"),
+		metadataTextRequest("hi"),
+	)
+	if err != nil {
+		t.Fatalf("Stream: %v", err)
+	}
+	defer func() { _ = stream.Close() }()
+	for {
+		if _, err := stream.Next(context.Background()); err == io.EOF {
+			break
+		} else if err != nil {
+			t.Fatalf("Next: %v", err)
+		}
+	}
+	metadata, ok := server.captured()["client_metadata"].(map[string]any)
+	if !ok {
+		t.Fatalf("captured body = %v, want client_metadata object", server.captured())
+	}
+	if metadata["session_id"] != "oc-session-1" ||
+		metadata["turn_id"] != "oc-turn-1" {
+		t.Fatalf("client_metadata = %v, want session + turn", metadata)
 	}
 }
 

--- a/driver/deepseek/request_metadata_ledger_test.go
+++ b/driver/deepseek/request_metadata_ledger_test.go
@@ -1,0 +1,69 @@
+package deepseek
+
+import (
+	"context"
+	"testing"
+
+	"github.com/GizClaw/flowcraft/core/inference"
+)
+
+func TestRequestMetadataLedgerDisposition(t *testing.T) {
+	request := metadataTextRequest("hi")
+
+	disabled := chatEntry()
+	compiled, err := compileChatGenerate("deepseek-v4-flash", disabled)(
+		context.Background(),
+		deepseekModel("deepseek-v4-flash"),
+		request,
+		inference.GenerateExecutionUnary,
+	)
+	if err != nil {
+		t.Fatalf("compile disabled: %v", err)
+	}
+	if disposition := requestMetadataDisposition(compiled.Report); disposition != inference.Dropped {
+		t.Fatalf("chat disposition = %q, want dropped", disposition)
+	}
+
+	enabled := chatEntryWithMetadata("custom_fields")
+	compiled, err = compileChatGenerate("deepseek-v4-flash", enabled)(
+		context.Background(),
+		deepseekModel("deepseek-v4-flash"),
+		request,
+		inference.GenerateExecutionUnary,
+	)
+	if err != nil {
+		t.Fatalf("compile enabled: %v", err)
+	}
+	if disposition := requestMetadataDisposition(compiled.Report); disposition != inference.Native {
+		t.Fatalf("chat disposition = %q, want native", disposition)
+	}
+	if _, overrides := wireToChatParams(compiled.Wire); len(overrides) != 1 {
+		t.Fatalf("chat overrides = %d, want 1", len(overrides))
+	}
+
+	enabledResponses := responsesEntryWithMetadata("custom_fields")
+	responsesCompiled, err := compileResponsesGenerate("deepseek-v4-flash", enabledResponses)(
+		context.Background(),
+		deepseekModel("deepseek-v4-flash"),
+		request,
+		inference.GenerateExecutionUnary,
+	)
+	if err != nil {
+		t.Fatalf("compile responses enabled: %v", err)
+	}
+	if disposition := requestMetadataDisposition(responsesCompiled.Report); disposition != inference.Native {
+		t.Fatalf("responses disposition = %q, want native", disposition)
+	}
+	if options := responseMetadataOptions(responsesCompiled.Wire); len(options) != 1 {
+		t.Fatalf("responses options = %d, want 1", len(options))
+	}
+}
+
+func requestMetadataDisposition(report inference.CompileReport) inference.Disposition {
+	for _, decision := range report.Decisions {
+		if decision.Field == inference.FieldGenerateRequestMetadata {
+			return decision.Disposition
+		}
+	}
+	return ""
+}

--- a/driver/deepseek/spec.go
+++ b/driver/deepseek/spec.go
@@ -29,9 +29,31 @@ type Spec struct {
 	// the route Router owns the full retry budget; nil keeps the openai-go
 	// default (two retries).
 	HTTPRetries *resource.Int `json:"http_retries,omitempty"`
+	// RequestMetadata controls how canonical GenerateRequest metadata is
+	// projected onto the provider request body. The empty value disables
+	// forwarding entirely (the official DeepSeek API does not accept
+	// request metadata); any non-empty value names the top-level body
+	// field that receives the bag. "metadata" is the OpenAI-compatible
+	// typed metadata object and "client_metadata" is the Codex-style
+	// passthrough, but deployments may use other names for gateways.
+	RequestMetadata *RequestMetadataSpec `json:"request_metadata,omitempty"`
 	// Models declares models outside the built-in catalog or overrides
 	// catalog entries by name.
 	Models []ModelSpec `json:"models,omitempty"`
+}
+
+// RequestMetadataSpec is the provider-level lowering policy for canonical
+// GenerateRequest.RequestMetadata. Core keys and the envelope name are
+// opaque; the driver forwards the whole bag without interpreting entries.
+type RequestMetadataSpec struct {
+	// Envelope names the top-level body field that receives the metadata
+	// object. "" disables forwarding; any non-empty string is accepted.
+	Envelope string `json:"envelope,omitempty"`
+}
+
+// Validate checks the request metadata forwarding policy.
+func (s RequestMetadataSpec) Validate() error {
+	return nil
 }
 
 // ModelSpec declares one model the deployment serves. Capabilities mirror
@@ -77,6 +99,11 @@ func (s Spec) Validate() error {
 	if s.HTTPRetries != nil && *s.HTTPRetries < 0 {
 		return fmt.Errorf("http_retries must not be negative")
 	}
+	if s.RequestMetadata != nil {
+		if err := s.RequestMetadata.Validate(); err != nil {
+			return err
+		}
+	}
 	seen := make(map[string]struct{}, len(s.Models))
 	for _, model := range s.Models {
 		if err := model.Validate(); err != nil {
@@ -96,6 +123,15 @@ func (s Spec) apiMode() apiMode {
 		return apiChat
 	}
 	return apiMode(s.API)
+}
+
+// requestMetadataEnvelope returns the configured forwarding envelope, or ""
+// when forwarding is disabled.
+func (s Spec) requestMetadataEnvelope() string {
+	if s.RequestMetadata == nil {
+		return ""
+	}
+	return s.RequestMetadata.Envelope
 }
 
 // ProfileSpec is the profile-level configuration surface. DeepSeek scopes

--- a/driver/kimi/generate.go
+++ b/driver/kimi/generate.go
@@ -241,6 +241,12 @@ func compileGenerate(model string, entry catalogEntry) inference.GenerateCompile
 	return func(_ context.Context, _ inference.ModelRef, request inference.GenerateRequest, shape inference.GenerateExecutionShape) (inference.Compiled[generateWire], error) {
 		ledger := newLedger(inference.OperationGenerate, request.ActiveFieldsFor(shape))
 		wire := generateWire{Model: model, Stream: shape == inference.GenerateExecutionStream}
+		if len(request.RequestMetadata) > 0 {
+			ledger.drop(
+				inference.FieldGenerateRequestMetadata,
+				"kimi driver does not forward request metadata",
+			)
+		}
 
 		options, other := operationExtensions[GenerateOptions](request.Extensions)
 		rejectOtherExtensions("generate", other, ledger)

--- a/driver/kimi/request_metadata_ledger_test.go
+++ b/driver/kimi/request_metadata_ledger_test.go
@@ -1,0 +1,45 @@
+package kimi
+
+import (
+	"context"
+	"testing"
+
+	"github.com/GizClaw/flowcraft/core/inference"
+	"github.com/GizClaw/flowcraft/core/message"
+)
+
+func TestRequestMetadataDroppedByLedger(t *testing.T) {
+	request := inference.GenerateRequest{
+		Input: inference.GenerateInput{
+			Role: inference.InputRoleUser,
+			Content: inference.InputContent{
+				Content: message.Content{Parts: []message.Part{
+					message.TextPart{Text: "hi"},
+				}},
+				Intent: inference.Intent{Text: &inference.TextIntent{}},
+			},
+		},
+		RequestMetadata: map[string]string{"session_id": "s-1"},
+	}
+	compiled, err := compileGenerate("kimi-k3", catalog["kimi-k3"])(
+		context.Background(),
+		inference.ModelRef{ID: inference.ModelID{Provider: "kimi", Name: "kimi-k3"}},
+		request,
+		inference.GenerateExecutionUnary,
+	)
+	if err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+	if disposition := requestMetadataDisposition(compiled.Report); disposition != inference.Dropped {
+		t.Fatalf("metadata disposition = %q, want dropped", disposition)
+	}
+}
+
+func requestMetadataDisposition(report inference.CompileReport) inference.Disposition {
+	for _, decision := range report.Decisions {
+		if decision.Field == inference.FieldGenerateRequestMetadata {
+			return decision.Disposition
+		}
+	}
+	return ""
+}

--- a/driver/minimax/generate.go
+++ b/driver/minimax/generate.go
@@ -193,6 +193,12 @@ func compileGenerate(
 			stream:    shape == inference.GenerateExecutionStream,
 			maxTokens: DefaultMaxTokens,
 		}
+		if len(request.RequestMetadata) > 0 {
+			ledger.drop(
+				inference.FieldGenerateRequestMetadata,
+				"minimax Messages API has no arbitrary request metadata channel",
+			)
+		}
 
 		// Context messages. The system channel joins the request's system
 		// blocks; everything else becomes user/assistant turns.

--- a/driver/minimax/request_metadata_ledger_test.go
+++ b/driver/minimax/request_metadata_ledger_test.go
@@ -1,0 +1,45 @@
+package minimax
+
+import (
+	"context"
+	"testing"
+
+	"github.com/GizClaw/flowcraft/core/inference"
+	"github.com/GizClaw/flowcraft/core/message"
+)
+
+func TestRequestMetadataDroppedByLedger(t *testing.T) {
+	request := inference.GenerateRequest{
+		Input: inference.GenerateInput{
+			Role: inference.InputRoleUser,
+			Content: inference.InputContent{
+				Content: message.Content{Parts: []message.Part{
+					message.TextPart{Text: "hi"},
+				}},
+				Intent: inference.Intent{Text: &inference.TextIntent{}},
+			},
+		},
+		RequestMetadata: map[string]string{"session_id": "s-1"},
+	}
+	compiled, err := compileGenerate("MiniMax-M3", catalog["MiniMax-M3"])(
+		context.Background(),
+		inference.ModelRef{ID: inference.ModelID{Provider: "minimax", Name: "MiniMax-M3"}},
+		request,
+		inference.GenerateExecutionUnary,
+	)
+	if err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+	if disposition := requestMetadataDisposition(compiled.Report); disposition != inference.Dropped {
+		t.Fatalf("metadata disposition = %q, want dropped", disposition)
+	}
+}
+
+func requestMetadataDisposition(report inference.CompileReport) inference.Disposition {
+	for _, decision := range report.Decisions {
+		if decision.Field == inference.FieldGenerateRequestMetadata {
+			return decision.Disposition
+		}
+	}
+	return ""
+}

--- a/driver/openai/catalog.go
+++ b/driver/openai/catalog.go
@@ -56,6 +56,9 @@ type catalogEntry struct {
 	// window on https://developers.openai.com/api/docs/models; embedding
 	// values mirror the per-request input limit.
 	maxInputTokens int
+	// requestMetadataEnvelope is the provider-level lowering policy for
+	// canonical GenerateRequest.RequestMetadata ("" disables forwarding).
+	requestMetadataEnvelope string
 }
 
 // validate enforces the family contract: the compiler bound by kind can only
@@ -238,6 +241,11 @@ func mergedCatalog(spec Spec) (map[string]catalogEntry, error) {
 			dimensions:   model.Dimensions,
 			effortNone:   model.EffortNone,
 		}
+	}
+	envelope := spec.requestMetadataEnvelope()
+	for name, entry := range models {
+		entry.requestMetadataEnvelope = envelope
+		models[name] = entry
 	}
 	for name, entry := range models {
 		if err := entry.validate(); err != nil {

--- a/driver/openai/generate.go
+++ b/driver/openai/generate.go
@@ -5,6 +5,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"maps"
 	"slices"
 	"strings"
 
@@ -39,6 +40,12 @@ type generateWire struct {
 	// the include on plain chat models, so it must follow the capability
 	// declaration instead of being unconditional.
 	includeReasoning bool
+
+	// requestMetadataEnvelope names the top-level body field that carries
+	// canonical request metadata; empty disables forwarding.
+	requestMetadataEnvelope string
+	// requestMetadata is the opaque metadata bag forwarded verbatim.
+	requestMetadata map[string]string
 }
 
 type wireItemKind string
@@ -325,6 +332,15 @@ func compileGenerate(
 			stream: shape == inference.GenerateExecutionStream,
 			includeReasoning: entry.capabilities.Reasoning.Kind != inference.ReasoningNone &&
 				entry.api != apiChat,
+		}
+		if entry.requestMetadataEnvelope != "" && len(request.RequestMetadata) > 0 {
+			wire.requestMetadataEnvelope = entry.requestMetadataEnvelope
+			wire.requestMetadata = maps.Clone(request.RequestMetadata)
+		} else if len(request.RequestMetadata) > 0 {
+			ledger.drop(
+				inference.FieldGenerateRequestMetadata,
+				"openai request_metadata forwarding is disabled (set spec.request_metadata.envelope)",
+			)
 		}
 
 		// Context messages → items. System stays a native system-role item;

--- a/driver/openai/generate_chat.go
+++ b/driver/openai/generate_chat.go
@@ -58,6 +58,9 @@ func wireToChatParams(wire generateWire) openai.ChatCompletionNewParams {
 			IncludeUsage: openai.Bool(true),
 		}
 	}
+	if wire.requestMetadataEnvelope == "metadata" && len(wire.requestMetadata) > 0 {
+		params.Metadata = wire.requestMetadata
+	}
 	return params
 }
 
@@ -195,7 +198,11 @@ func chatToolChoice(choice *wireToolChoice) openai.ChatCompletionToolChoiceOptio
 // completions endpoint.
 func transportChatGenerate(client openai.Client) inference.Transport[generateWire, generateRaw] {
 	return func(ctx context.Context, wire generateWire) (generateRaw, error) {
-		response, err := client.Chat.Completions.New(ctx, wireToChatParams(wire))
+		response, err := client.Chat.Completions.New(
+			ctx,
+			wireToChatParams(wire),
+			requestMetadataOptions(wire)...,
+		)
 		if err != nil {
 			classified := classifyError(err)
 			logInferenceCall(ctx, "generate", wire.model, classified, "", "")
@@ -306,7 +313,11 @@ func transportChatGenerateStream(
 		ctx context.Context,
 		wire generateWire,
 	) (inference.ProviderStream[streamRaw], error) {
-		stream := client.Chat.Completions.NewStreaming(ctx, wireToChatParams(wire))
+		stream := client.Chat.Completions.NewStreaming(
+			ctx,
+			wireToChatParams(wire),
+			requestMetadataOptions(wire)...,
+		)
 		if stream == nil {
 			return nil, errdefs.NotAvailablef(
 				"openai: nil chat stream handle (provider misbehaviour)")

--- a/driver/openai/generate_openai.go
+++ b/driver/openai/generate_openai.go
@@ -11,6 +11,7 @@ import (
 	"github.com/GizClaw/flowcraft/core/message"
 
 	"github.com/openai/openai-go/v3"
+	"github.com/openai/openai-go/v3/option"
 	"github.com/openai/openai-go/v3/packages/param"
 	"github.com/openai/openai-go/v3/responses"
 	"github.com/openai/openai-go/v3/shared"
@@ -123,7 +124,24 @@ func wireToParams(wire generateWire) responses.ResponseNewParams {
 			OfToolChoiceMode: param.NewOpt(responses.ToolChoiceOptionsRequired),
 		}
 	}
+	if wire.requestMetadataEnvelope == "metadata" && len(wire.requestMetadata) > 0 {
+		params.Metadata = wire.requestMetadata
+	}
 	return params
+}
+
+// requestMetadataOptions returns per-request options for metadata that the
+// SDK does not type ("client_metadata"); the standard metadata envelope is
+// typed and set in wireToParams.
+func requestMetadataOptions(wire generateWire) []option.RequestOption {
+	if wire.requestMetadataEnvelope == "" ||
+		wire.requestMetadataEnvelope == "metadata" ||
+		len(wire.requestMetadata) == 0 {
+		return nil
+	}
+	return []option.RequestOption{
+		option.WithJSONSet(wire.requestMetadataEnvelope, wire.requestMetadata),
+	}
 }
 
 func webSearchToolParam(search *wireWebSearch) responses.WebSearchToolParam {
@@ -231,7 +249,11 @@ func transportGenerate(
 	client openai.Client,
 ) inference.Transport[generateWire, generateRaw] {
 	return func(ctx context.Context, wire generateWire) (generateRaw, error) {
-		response, err := client.Responses.New(ctx, wireToParams(wire))
+		response, err := client.Responses.New(
+			ctx,
+			wireToParams(wire),
+			requestMetadataOptions(wire)...,
+		)
 		if err != nil {
 			classified := classifyError(err)
 			logInferenceCall(ctx, "generate", wire.model, classified, "", "")

--- a/driver/openai/generate_stream.go
+++ b/driver/openai/generate_stream.go
@@ -49,7 +49,11 @@ func transportGenerateStream(
 		ctx context.Context,
 		wire generateWire,
 	) (inference.ProviderStream[streamRaw], error) {
-		stream := client.Responses.NewStreaming(ctx, wireToParams(wire))
+		stream := client.Responses.NewStreaming(
+			ctx,
+			wireToParams(wire),
+			requestMetadataOptions(wire)...,
+		)
 		if err := stream.Err(); err != nil {
 			classified := classifyError(err)
 			logInferenceStream(ctx, "generate", wire.model, classified, "")

--- a/driver/openai/request_metadata_test.go
+++ b/driver/openai/request_metadata_test.go
@@ -1,0 +1,134 @@
+package openai
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/GizClaw/flowcraft/core/inference"
+)
+
+func TestRequestMetadataTypedAndClientEnvelopes(t *testing.T) {
+	request := simpleTextRequest("hi")
+	request.RequestMetadata = map[string]string{
+		"session_id": "s-1",
+		"turn_id":    "t-1",
+	}
+
+	typed := catalog["gpt-5.6-sol"]
+	typed.requestMetadataEnvelope = "metadata"
+	compiled, err := compileGenerate("gpt-5.6-sol", typed)(
+		context.Background(),
+		openaiModel("gpt-5.6-sol"),
+		request,
+		inference.GenerateExecutionUnary,
+	)
+	if err != nil {
+		t.Fatalf("compile metadata: %v", err)
+	}
+	params := wireToParams(compiled.Wire)
+	if params.Metadata["session_id"] != "s-1" ||
+		params.Metadata["turn_id"] != "t-1" {
+		t.Fatalf("metadata = %v, want session + turn", params.Metadata)
+	}
+	if disposition := metadataDisposition(compiled.Report); disposition != inference.Native {
+		t.Fatalf("metadata disposition = %q, want native", disposition)
+	}
+
+	client := catalog["gpt-5.6-sol"]
+	client.requestMetadataEnvelope = "client_metadata"
+	compiled, err = compileGenerate("gpt-5.6-sol", client)(
+		context.Background(),
+		openaiModel("gpt-5.6-sol"),
+		request,
+		inference.GenerateExecutionUnary,
+	)
+	if err != nil {
+		t.Fatalf("compile client_metadata: %v", err)
+	}
+	if options := requestMetadataOptions(compiled.Wire); len(options) != 1 {
+		t.Fatalf("client_metadata options = %d, want 1", len(options))
+	}
+	if disposition := metadataDisposition(compiled.Report); disposition != inference.Native {
+		t.Fatalf("metadata disposition = %q, want native", disposition)
+	}
+
+	custom := catalog["gpt-5.6-sol"]
+	custom.requestMetadataEnvelope = "request_fields"
+	compiled, err = compileGenerate("gpt-5.6-sol", custom)(
+		context.Background(),
+		openaiModel("gpt-5.6-sol"),
+		request,
+		inference.GenerateExecutionUnary,
+	)
+	if err != nil {
+		t.Fatalf("compile custom envelope: %v", err)
+	}
+	if options := requestMetadataOptions(compiled.Wire); len(options) != 1 {
+		t.Fatalf("custom envelope options = %d, want 1", len(options))
+	}
+
+	disabled := catalog["gpt-5.6-sol"]
+	compiled, err = compileGenerate("gpt-5.6-sol", disabled)(
+		context.Background(),
+		openaiModel("gpt-5.6-sol"),
+		request,
+		inference.GenerateExecutionUnary,
+	)
+	if err != nil {
+		t.Fatalf("compile disabled metadata: %v", err)
+	}
+	if disposition := metadataDisposition(compiled.Report); disposition != inference.Dropped {
+		t.Fatalf("metadata disposition = %q, want dropped", disposition)
+	}
+}
+
+func metadataDisposition(report inference.CompileReport) inference.Disposition {
+	for _, decision := range report.Decisions {
+		if decision.Field == inference.FieldGenerateRequestMetadata {
+			return decision.Disposition
+		}
+	}
+	return ""
+}
+
+func TestRequestMetadataClientForwardedUnaryBody(t *testing.T) {
+	server, capture := newCapturedOpenAI(t, func(
+		w http.ResponseWriter,
+		_ *http.Request,
+		_ map[string]any,
+	) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(responsesResponseJSON([]map[string]any{
+			textOutputItem("ok"),
+		})))
+	})
+	cls := testClients(t, server)
+	entry := catalog["gpt-5.6-sol"]
+	entry.requestMetadataEnvelope = "client_metadata"
+	operations, err := openGenerate(
+		cls,
+		entry,
+		openaiModel("gpt-5.6-sol").ID,
+		"default",
+	)
+	if err != nil {
+		t.Fatalf("openGenerate: %v", err)
+	}
+	request := simpleTextRequest("hi")
+	request.RequestMetadata = map[string]string{
+		"session_id": "s-1",
+		"turn_id":    "t-1",
+	}
+	if _, err := operations.Unary.Execute(
+		context.Background(),
+		openaiModel("gpt-5.6-sol"),
+		request,
+	); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	metadata, ok := capture.body(0)["client_metadata"].(map[string]any)
+	if !ok || metadata["session_id"] != "s-1" || metadata["turn_id"] != "t-1" {
+		t.Fatalf("client_metadata = %v, want session + turn", capture.body(0)["client_metadata"])
+	}
+}

--- a/driver/openai/spec.go
+++ b/driver/openai/spec.go
@@ -37,9 +37,28 @@ type Spec struct {
 	// the route Router owns the full retry budget; nil keeps the openai-go
 	// default (two retries).
 	HTTPRetries *resource.Int `json:"http_retries,omitempty"`
+	// RequestMetadata controls how canonical GenerateRequest metadata is
+	// projected onto the provider request body. The empty value disables
+	// forwarding; any non-empty value names the top-level body field that
+	// receives the bag. "metadata" uses the native OpenAI metadata object
+	// and "client_metadata" uses the Codex-style passthrough, but other
+	// names are allowed for gateways.
+	RequestMetadata *RequestMetadataSpec `json:"request_metadata,omitempty"`
 	// Models declares additional models beyond the built-in catalog or
 	// overrides catalog entries by name.
 	Models []ModelSpec `json:"models,omitempty"`
+}
+
+// RequestMetadataSpec is the provider-level lowering policy for canonical
+// GenerateRequest.RequestMetadata. Keys and the envelope are opaque and
+// forwarded verbatim.
+type RequestMetadataSpec struct {
+	Envelope string `json:"envelope,omitempty"`
+}
+
+// Validate checks the request metadata forwarding policy.
+func (s RequestMetadataSpec) Validate() error {
+	return nil
 }
 
 // ModelSpec declares one model outside the built-in catalog. Capabilities
@@ -87,6 +106,11 @@ func (s Spec) Validate() error {
 	if s.HTTPRetries != nil && *s.HTTPRetries < 0 {
 		return fmt.Errorf("http_retries must not be negative")
 	}
+	if s.RequestMetadata != nil {
+		if err := s.RequestMetadata.Validate(); err != nil {
+			return err
+		}
+	}
 	seen := make(map[string]struct{}, len(s.Models))
 	for index, model := range s.Models {
 		if err := model.Validate(); err != nil {
@@ -106,6 +130,13 @@ func (s Spec) apiMode() apiMode {
 		return apiResponses
 	}
 	return apiMode(s.API)
+}
+
+func (s Spec) requestMetadataEnvelope() string {
+	if s.RequestMetadata == nil {
+		return ""
+	}
+	return s.RequestMetadata.Envelope
 }
 
 func (m ModelSpec) Validate() error {

--- a/driver/qwen/generate.go
+++ b/driver/qwen/generate.go
@@ -179,6 +179,12 @@ func compileGenerate(
 			Model:      model,
 			Parameters: wireParameters{ResultFormat: "message"},
 		}
+		if len(request.RequestMetadata) > 0 {
+			c.ledger.drop(
+				inference.FieldGenerateRequestMetadata,
+				"qwen driver does not forward request metadata",
+			)
+		}
 		if entry.multimodal() {
 			c.wire.Path = pathMultimodalGeneration
 		} else {

--- a/driver/qwen/request_metadata_ledger_test.go
+++ b/driver/qwen/request_metadata_ledger_test.go
@@ -1,0 +1,45 @@
+package qwen
+
+import (
+	"context"
+	"testing"
+
+	"github.com/GizClaw/flowcraft/core/inference"
+	"github.com/GizClaw/flowcraft/core/message"
+)
+
+func TestRequestMetadataDroppedByLedger(t *testing.T) {
+	request := inference.GenerateRequest{
+		Input: inference.GenerateInput{
+			Role: inference.InputRoleUser,
+			Content: inference.InputContent{
+				Content: message.Content{Parts: []message.Part{
+					message.TextPart{Text: "hi"},
+				}},
+				Intent: inference.Intent{Text: &inference.TextIntent{}},
+			},
+		},
+		RequestMetadata: map[string]string{"session_id": "s-1"},
+	}
+	compiled, err := compileGenerate("qwen3.7-max", catalog["qwen3.7-max"])(
+		context.Background(),
+		inference.ModelRef{ID: inference.ModelID{Provider: "qwen", Name: "qwen3.7-max"}},
+		request,
+		inference.GenerateExecutionUnary,
+	)
+	if err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+	if disposition := requestMetadataDisposition(compiled.Report); disposition != inference.Dropped {
+		t.Fatalf("metadata disposition = %q, want dropped", disposition)
+	}
+}
+
+func requestMetadataDisposition(report inference.CompileReport) inference.Disposition {
+	for _, decision := range report.Decisions {
+		if decision.Field == inference.FieldGenerateRequestMetadata {
+			return decision.Disposition
+		}
+	}
+	return ""
+}


### PR DESCRIPTION
## Summary

Add a canonical `RequestMetadata` carrier to inference requests and make its disposition observable through the compile ledger.

- `GenerateRequest.RequestMetadata` (opaque `map[string]string`) now enters `ActiveFields` as `generate.request.metadata`.
- Graph inference nodes expose `request_metadata` node config, copied onto every generate request (normal and recovery paths).
- DeepSeek, OpenAI, and Azure forward the bag under a provider-configured top-level envelope. `metadata` uses the typed SDK field; any other non-empty envelope name rides `option.WithJSONSet` for compatible gateways.
- Anthropic, MiniMax, Bytedance, Kimi, and Qwen keep their native transport paths and explicitly report `dropped` when request metadata is present, so no metadata loss is silent.

## Tests

- Core: metadata clone/JSON round-trip and active-field ledger coverage.
- DeepSeek/OpenAI/Azure: native + dropped dispositions and custom envelope coverage.
- All remaining drivers: dropped-disposition coverage.
- Ran `make ci`, `make lint`, `make release-check`, and `git diff --check`.