### PR TITLE
docs: document request metadata forwarding

### DIFF
--- a/docs/guides/graph.md
+++ b/docs/guides/graph.md
@@ -152,6 +152,10 @@ Behavior:
 
 - The channel tail must have role `user` or `tool`; everything before it is
   the request context. An empty channel or wrong role is a validation error.
+- `request_metadata` is copied verbatim onto the canonical request. Only
+  drivers whose deployment sets `request_metadata.envelope` forward it;
+  unsupported or unconfigured drivers report a `dropped` compile decision
+  instead of failing the node silently.
 - `model` uses the wired `inference.Assembly`; no `model` requires the
   `inference.Router` (selector/fallback chain picks the target).
 - `model_hint` is a request-level preference consumed only by the router:

--- a/skills/flowcraft-config/references/graph.md
+++ b/skills/flowcraft-config/references/graph.md
@@ -88,6 +88,7 @@ appended to the same channel. The node never executes tool calls — a
 | `tool_choice` | constrain when/which tools are called |
 | `intent` | canonical execution envelope `{text, image, audio, video}` with per-modality controls (see below) |
 | `extensions` | provider knobs `{provider, id, fields}` |
+| `request_metadata` | opaque `map[string]string` copied onto the canonical generate request; keys are deployment-defined |
 
 **Model selection: prefer the router.** Inference nodes should omit
 `model` and rely on the wired `inference.Router`: the router's policy
@@ -111,6 +112,11 @@ the wired catalog into `intent.text.tools` / `intent.text.tool_choice` and
 may not be combined with an intent that declares those fields itself.
 Legacy node-level sampling/reasoning/response-format keys were removed —
 strict decode rejects them; put them under `intent.text` instead.
+
+`request_metadata` values are forwarded only when the selected driver's
+deployment configures `request_metadata.envelope`. Drivers without a native
+channel (or with forwarding disabled) report a `dropped` compile decision
+for the metadata field, so no metadata is silently ignored.
 
 `model_hint` is a request-level preference consumed only by the router: it
 never bypasses routing and falls back to the default policy when the hint

--- a/skills/flowcraft-config/references/pitfalls.md
+++ b/skills/flowcraft-config/references/pitfalls.md
@@ -47,6 +47,12 @@ builds the deployment with its own factory registry, or at runtime.
     applies. Wire `inference.Router` into the graph engine and omit
     `model` unless the deployment intentionally pins a target — host
     build/runtime.
+16. `request_metadata` is only forwarded when the selected provider driver
+    implements it and its spec configures `request_metadata.envelope`.
+    Unsupported/unconfigured drivers do not fail the request; the metadata
+    field is reported `dropped` in the compile report. Inspect
+    `response.metadata.decisions` (or `Explain`) when metadata seems
+    missing upstream — host build/runtime.
 
 ## Error map
 

--- a/skills/flowcraft-config/references/resources.md
+++ b/skills/flowcraft-config/references/resources.md
@@ -12,6 +12,8 @@ id: deepseek
 spec:
   api: chat             # "chat" (default) or "responses"
   base_url: https://api.deepseek.com   # optional override
+  request_metadata:     # optional; supported by deepseek/openai/azure
+    envelope: request_fields   # any non-empty top-level body field; empty disables
   models:               # optional: declare/override catalog models
     - name: deepseek-v4-flash
       kind: generate
@@ -44,6 +46,12 @@ validated by the driver; routing prefers targets whose declared outputs
 cover the request intent and skips declared-incompatible tiers. Provider
 drivers are registered by the host application from provider driver
 modules (outside `core/`).
+
+`request_metadata.envelope` names the top-level body field that receives
+canonical `GenerateRequest.RequestMetadata`. It is supported by the
+DeepSeek, OpenAI, and Azure drivers; other drivers (Anthropic, MiniMax,
+Bytedance, Kimi, Qwen) keep their native transports and report request
+metadata as `dropped` in the compile report.
 
 ## inference assembly
 


### PR DESCRIPTION
Follow-up documentation for request metadata forwarding:\n\n- docs/guides/graph.md: request_metadata node config row and dropped-decision behavior.\n- skills/flowcraft-config references: graph node config, provider resource example, and a pitfall for silently dropped metadata.\n\nNo code changes.