### PR TITLE
chore(skills): sync flowcraft-config validator to core v0.2.4

### DIFF
--- a/skills/flowcraft-config/SKILL.md
+++ b/skills/flowcraft-config/SKILL.md
@@ -106,7 +106,7 @@ workflow.
 ## Compatibility and versioning
 
 One skill version pins one FlowCraft version. The validator's `go.mod`
-requires exactly `github.com/GizClaw/flowcraft/core v0.2.3`; the schema
+requires exactly `github.com/GizClaw/flowcraft/core v0.2.4`; the schema
 cards in this skill document that release (no `driver/*` or `backends/*`
 modules are required, since the validator never constructs factories).
 When FlowCraft releases a new version, bump the pin and reconcile the

--- a/skills/flowcraft-config/scripts/validator/go.mod
+++ b/skills/flowcraft-config/scripts/validator/go.mod
@@ -2,7 +2,7 @@ module github.com/GizClaw/flowcraft/skills/flowcraft-config/scripts/validator
 
 go 1.26.0
 
-require github.com/GizClaw/flowcraft/core v0.2.3
+require github.com/GizClaw/flowcraft/core v0.2.4
 
 require (
 	github.com/cenkalti/backoff/v5 v5.0.3 // indirect

--- a/skills/flowcraft-config/scripts/validator/go.sum
+++ b/skills/flowcraft-config/scripts/validator/go.sum
@@ -1,5 +1,5 @@
-github.com/GizClaw/flowcraft/core v0.2.3 h1:spEXJ1cfzEILXGB8ERMC9QJSmiuwxHFCiaiUB9s2Slw=
-github.com/GizClaw/flowcraft/core v0.2.3/go.mod h1:hL61rLjDQOXKMMQOJUVT8ZFOoP1gs37c6uxzECZUBh4=
+github.com/GizClaw/flowcraft/core v0.2.4 h1:LnBC7iKyr6v9AJTvbZCgBT5n0ifx4xb2zdNwCvs3mPE=
+github.com/GizClaw/flowcraft/core v0.2.4/go.mod h1:oM890ls+7bEtnG6LfBcDfrmKSm+hQPNzutRpQf3hscI=
 github.com/cenkalti/backoff/v5 v5.0.3 h1:ZN+IMa753KfX5hd8vVaMixjnqRZ3y8CuJKRKj1xcsSM=
 github.com/cenkalti/backoff/v5 v5.0.3/go.mod h1:rkhZdG3JZukswDf7f0cwqPNk4K0sa+F97BxZthm/crw=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=


### PR DESCRIPTION
Syncs the flowcraft-config skill to the released core v0.2.4:

- Bumps `scripts/validator/go.mod` + `go.sum` from core v0.2.3 to v0.2.4.
- Updates the core pin claim in `SKILL.md` Compatibility and versioning.

Verified: validator builds, vets, and validates `assets/minimal-deploy/deploy.yaml`; `git diff --check` clean. No release changesets included.