### PR TITLE
feat(core): add runtime drain API for offline replacement

### DIFF
--- a/core/runtime/drain_test.go
+++ b/core/runtime/drain_test.go
@@ -1,0 +1,95 @@
+package runtime
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/GizClaw/flowcraft/core/agent"
+	"github.com/GizClaw/flowcraft/core/errdefs"
+	"github.com/GizClaw/flowcraft/core/runtime/session"
+)
+
+func TestRuntimeDrainQuiescesAndWaitsForActiveTurn(t *testing.T) {
+	release := make(chan struct{})
+	var releaseOnce sync.Once
+	defer releaseOnce.Do(func() { close(release) })
+	app, _ := buildLifecycleApp(t, lifecycleDoc(t), blockingRunEngine(release))
+
+	lease, err := app.Sessions().Open(context.Background(), session.Key{
+		AgentID: "bot", ContextID: "ctx",
+	})
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer func() { _ = lease.Close() }()
+	turn, err := lease.Session().Start(context.Background(), agent.Request{})
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	drained := make(chan error, 1)
+	go func() {
+		drained <- app.Drain(context.Background())
+	}()
+
+	// Wait until the manager has entered its draining state so the
+	// quiesce assertions cannot race the goroutine above. Opens succeed
+	// before drain begins and are closed again immediately.
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		if time.Now().After(deadline) {
+			t.Fatal("Runtime.Drain did not start draining")
+		}
+		probe, err := app.Sessions().Open(context.Background(), session.Key{
+			AgentID: "bot", ContextID: "probe",
+		})
+		if err != nil {
+			if !errors.Is(err, session.ErrManagerDraining) {
+				t.Fatalf("Open while waiting for drain error = %v, want ErrManagerDraining", err)
+			}
+			break
+		}
+		_ = probe.Close()
+		time.Sleep(time.Millisecond)
+	}
+
+	if _, err := app.Sessions().Open(context.Background(), session.Key{
+		AgentID: "bot", ContextID: "quiesced",
+	}); !errors.Is(err, session.ErrManagerDraining) {
+		t.Fatalf("Open during runtime drain error = %v, want ErrManagerDraining", err)
+	}
+	if _, err := lease.Session().Start(context.Background(), agent.Request{}); !errors.Is(err, session.ErrManagerDraining) {
+		t.Fatalf("Start during runtime drain error = %v, want ErrManagerDraining", err)
+	}
+
+	releaseOnce.Do(func() { close(release) })
+	select {
+	case err := <-drained:
+		if err != nil {
+			t.Fatalf("Runtime.Drain: %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("Runtime.Drain did not return after turn finished")
+	}
+	if _, err := turn.Wait(context.Background()); err != nil {
+		t.Fatalf("turn Wait: %v", err)
+	}
+	if !app.manager.Idle() {
+		t.Fatal("runtime manager not idle after Runtime.Drain returned")
+	}
+
+	// The old runtime stays quiesced until Close; Close must still work
+	// after a successful drain.
+	if err := app.Drain(context.Background()); err != nil {
+		t.Fatalf("second Runtime.Drain: %v", err)
+	}
+	if err := app.Close(); err != nil {
+		t.Fatalf("Close after Drain: %v", err)
+	}
+	if err := app.Drain(context.Background()); !errdefs.IsNotAvailable(err) {
+		t.Fatalf("Runtime.Drain after Close error = %v, want not available", err)
+	}
+}

--- a/core/runtime/runtime.go
+++ b/core/runtime/runtime.go
@@ -132,6 +132,29 @@ func (r *Runtime) Resource(name string) (any, bool) {
 	return r.current.result.Value(name)
 }
 
+// Drain quiesces the runtime for offline replacement. It is serialized
+// with RegisterAgent / UnregisterAgent / Reload / Close and delegates
+// to the session manager's Drain: new session leases and new Starts on
+// already-open leases are refused, while active turns finish naturally
+// (bounded by ctx). Drain never interrupts running turns; after it
+// returns the runtime stays drained and the caller should Close it once
+// its replacement is ready. A drained Runtime cannot serve new work,
+// so a timed-out Drain may be retried or followed by Close.
+func (r *Runtime) Drain(ctx context.Context) error {
+	if r == nil {
+		return nil
+	}
+	if isNilContext(ctx) {
+		return errdefs.Validationf("runtime: Drain context is required")
+	}
+	r.lifecycleMu.Lock()
+	defer r.lifecycleMu.Unlock()
+	if r.closed {
+		return errdefs.NotAvailablef("runtime: closed")
+	}
+	return r.manager.Drain(ctx)
+}
+
 // Close stops new session work, waits for active turns, and releases
 // all owned objects. Concurrent callers wait for and receive the same
 // aggregate result.

--- a/core/runtime/session/drain_test.go
+++ b/core/runtime/session/drain_test.go
@@ -1,0 +1,203 @@
+package session
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/GizClaw/flowcraft/core/agent"
+	"github.com/GizClaw/flowcraft/core/event"
+)
+
+func TestManagerIdleAndWaitIdleImmediate(t *testing.T) {
+	manager, _ := newTestManager(t, time.Hour)
+	if !manager.Idle() {
+		t.Fatal("Idle() = false, want true with no live sessions")
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	if err := manager.WaitIdle(ctx); err != nil {
+		t.Fatalf("WaitIdle() error = %v, want nil", err)
+	}
+}
+
+func TestManagerWaitIdleBlocksUntilActiveTurnFinishes(t *testing.T) {
+	release := make(chan struct{})
+	manager, session, _, _ := newTurnSession(
+		t,
+		withRunEnd(blockingEngine(release)),
+		func(bus event.Bus) HostFactory {
+			return HostFactoryFunc(func(_ context.Context, _ HostRequest) (agent.Host, error) {
+				return testHost{bus: bus}, nil
+			})
+		},
+	)
+
+	if _, err := session.Start(context.Background(), agent.Request{}); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	eventually(t, time.Second, func() bool { return !manager.Idle() })
+
+	waited := make(chan error, 1)
+	go func() {
+		waited <- manager.WaitIdle(context.Background())
+	}()
+	select {
+	case err := <-waited:
+		t.Fatalf("WaitIdle returned before turn finished: %v", err)
+	case <-time.After(20 * time.Millisecond):
+	}
+
+	close(release)
+	select {
+	case err := <-waited:
+		if err != nil {
+			t.Fatalf("WaitIdle: %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("WaitIdle did not return after turn finished")
+	}
+}
+
+func TestManagerDrainRejectsNewWorkAndWaitsForActiveTurn(t *testing.T) {
+	release := make(chan struct{})
+	manager, session, _, _ := newTurnSession(
+		t,
+		withRunEnd(blockingEngine(release)),
+		func(bus event.Bus) HostFactory {
+			return HostFactoryFunc(func(_ context.Context, _ HostRequest) (agent.Host, error) {
+				return testHost{bus: bus}, nil
+			})
+		},
+	)
+
+	turn, err := session.Start(context.Background(), agent.Request{})
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	drained := make(chan error, 1)
+	go func() {
+		drained <- manager.Drain(context.Background())
+	}()
+
+	// Wait until the drain has quiesced the manager, then verify both
+	// new leases and new Starts on the held lease are refused.
+	eventually(t, time.Second, func() bool {
+		manager.mu.Lock()
+		defer manager.mu.Unlock()
+		return manager.draining
+	})
+	if _, err := manager.Open(context.Background(), Key{
+		AgentID: "agent-a", ContextID: "c2",
+	}); !errors.Is(err, ErrManagerDraining) {
+		t.Fatalf("Open during drain error = %v, want ErrManagerDraining", err)
+	}
+	if _, err := session.Start(context.Background(), agent.Request{}); !errors.Is(err, ErrManagerDraining) {
+		t.Fatalf("Start during drain error = %v, want ErrManagerDraining", err)
+	}
+	if manager.Idle() {
+		t.Fatal("Idle() = true while the active turn is still running")
+	}
+
+	close(release)
+	select {
+	case err := <-drained:
+		if err != nil {
+			t.Fatalf("Drain: %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("Drain did not return after turn finished")
+	}
+	if _, err := turn.Wait(context.Background()); err != nil {
+		t.Fatalf("turn Wait: %v", err)
+	}
+	if !manager.Idle() {
+		t.Fatal("Idle() = false after drain completed")
+	}
+
+	// Drain is terminal: the manager must keep refusing new work until
+	// the caller closes it.
+	if _, err := manager.Open(context.Background(), Key{
+		AgentID: "agent-a", ContextID: "c3",
+	}); !errors.Is(err, ErrManagerDraining) {
+		t.Fatalf("Open after drain error = %v, want ErrManagerDraining", err)
+	}
+	if _, err := session.Start(context.Background(), agent.Request{}); !errors.Is(err, ErrManagerDraining) {
+		t.Fatalf("Start after drain error = %v, want ErrManagerDraining", err)
+	}
+}
+
+func TestManagerDrainTimeoutKeepsSessionsAndCanBeRetried(t *testing.T) {
+	release := make(chan struct{})
+	manager, session, _, _ := newTurnSession(
+		t,
+		withRunEnd(blockingEngine(release)),
+		func(bus event.Bus) HostFactory {
+			return HostFactoryFunc(func(_ context.Context, _ HostRequest) (agent.Host, error) {
+				return testHost{bus: bus}, nil
+			})
+		},
+	)
+
+	if _, err := session.Start(context.Background(), agent.Request{}); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+	if err := manager.Drain(ctx); !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("Drain error = %v, want DeadlineExceeded", err)
+	}
+	if _, err := manager.Open(context.Background(), Key{
+		AgentID: "agent-a", ContextID: "c2",
+	}); !errors.Is(err, ErrManagerDraining) {
+		t.Fatalf("Open after timeout error = %v, want ErrManagerDraining", err)
+	}
+	if _, err := session.Start(context.Background(), agent.Request{}); !errors.Is(err, ErrManagerDraining) {
+		t.Fatalf("Start after timeout error = %v, want ErrManagerDraining", err)
+	}
+
+	manager.mu.Lock()
+	entry := manager.entries[Key{AgentID: "agent-a", ContextID: "ctx"}]
+	manager.mu.Unlock()
+	if entry == nil || entry.session == nil {
+		t.Fatal("session was removed despite drain timeout")
+	}
+
+	close(release)
+	if err := manager.Drain(context.Background()); err != nil {
+		t.Fatalf("retry Drain: %v", err)
+	}
+	if !manager.Idle() {
+		t.Fatal("manager not idle after successful retry")
+	}
+}
+
+func TestManagerDrainRejectsStartThatAlreadyAcquiredEpoch(t *testing.T) {
+	manager, session, _, _ := newTurnSession(
+		t,
+		withRunEnd(agent.EngineFunc(func(
+			context.Context, agent.Run, agent.Host, *agent.Board,
+		) (*agent.Board, error) {
+			return agent.NewBoard(), nil
+		})),
+		turnHostFactory,
+	)
+
+	// Start checks the manager's draining flag again after beginEpoch,
+	// so a drain that lands in the beginEpoch -> interruptActive window
+	// must still refuse the turn instead of installing it after Drain
+	// observed an idle manager.
+	manager.mu.Lock()
+	manager.draining = true
+	manager.mu.Unlock()
+
+	if _, err := session.interruptActive(context.Background()); !errors.Is(err, ErrManagerDraining) {
+		t.Fatalf("interruptActive during drain error = %v, want ErrManagerDraining", err)
+	}
+	if !manager.Idle() {
+		t.Fatal("interruptActive leaked an activity slot after drain rejection")
+	}
+}

--- a/core/runtime/session/epoch.go
+++ b/core/runtime/session/epoch.go
@@ -42,6 +42,10 @@ type epochState struct {
 // surfaced as an error rather than handed to the caller as empty deps.
 func (m *Manager) beginEpoch() (Deps, func(), error) {
 	m.mu.Lock()
+	if m.draining {
+		m.mu.Unlock()
+		return Deps{}, func() {}, ErrManagerDraining
+	}
 	state := m.epochs[m.epochSeq]
 	if state == nil {
 		m.mu.Unlock()

--- a/core/runtime/session/manager.go
+++ b/core/runtime/session/manager.go
@@ -17,7 +17,10 @@ import (
 	otellog "go.opentelemetry.io/otel/log"
 )
 
-var ErrManagerClosed = errdefs.NotAvailablef("runtime session: manager is closed")
+var (
+	ErrManagerClosed   = errdefs.NotAvailablef("runtime session: manager is closed")
+	ErrManagerDraining = errdefs.NotAvailablef("runtime session: manager is draining")
+)
 
 // InstanceResolver is the minimum borrowed deployment view needed by Manager.
 type InstanceResolver interface {
@@ -54,13 +57,14 @@ type Manager struct {
 	entries   map[Key]*managerEntry
 	removed   map[string]struct{}
 	deleting  map[Key]struct{}
+	draining  bool
 	closed    bool
 	closeOnce sync.Once
 	closeErr  error
 }
 
-// agentDrainPollInterval is how often RemoveAgent re-checks whether
-// the target agent's sessions have become idle while draining.
+// agentDrainPollInterval is how often RemoveAgent, WaitIdle, and Drain
+// re-check whether the relevant sessions have become idle.
 const agentDrainPollInterval = 10 * time.Millisecond
 
 // NewManager constructs a Session manager over borrowed runtime dependencies.
@@ -168,6 +172,64 @@ func (m *Manager) GetOrCreate(ctx context.Context, key Key) (*Lease, error) {
 	return m.open(ctx, key)
 }
 
+// Idle reports whether no live Session currently has an active turn,
+// prompt, or sink. A manager with no live Sessions is idle.
+func (m *Manager) Idle() bool {
+	if m == nil {
+		return true
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.allIdleLocked()
+}
+
+func (m *Manager) isDraining() bool {
+	if m == nil {
+		return false
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.draining
+}
+
+// WaitIdle blocks until no live Session has an active turn, prompt, or
+// sink, bounded by ctx. It is a pure wait and never changes manager
+// state; a manager with no live Sessions returns immediately. The
+// error is nil on success or the ctx error when the deadline is
+// exceeded or the context is cancelled.
+func (m *Manager) WaitIdle(ctx context.Context) error {
+	if m == nil {
+		return nil
+	}
+	if isNil(ctx) {
+		return errdefs.Validationf("runtime session: context is required")
+	}
+	return m.waitIdle(ctx)
+}
+
+// Drain quiesces the manager for offline replacement: it refuses new
+// Opens, new GetOrCreate calls, and new Starts on already-open leases,
+// then waits (bounded by ctx) for every live Session to finish its
+// active turns, prompts, and sinks naturally. Drain never interrupts
+// running turns. After Drain returns, the manager stays draining and
+// the caller may retry a timed-out Drain or proceed to Close.
+func (m *Manager) Drain(ctx context.Context) error {
+	if m == nil {
+		return nil
+	}
+	if isNil(ctx) {
+		return errdefs.Validationf("runtime session: context is required")
+	}
+	m.mu.Lock()
+	if m.closed {
+		m.mu.Unlock()
+		return ErrManagerClosed
+	}
+	m.draining = true
+	m.mu.Unlock()
+	return m.waitIdle(ctx)
+}
+
 func (m *Manager) open(ctx context.Context, key Key) (*Lease, error) {
 	if m == nil {
 		return nil, ErrManagerClosed
@@ -186,6 +248,9 @@ func (m *Manager) open(ctx context.Context, key Key) (*Lease, error) {
 	defer m.mu.Unlock()
 	if m.closed {
 		return nil, ErrManagerClosed
+	}
+	if m.draining {
+		return nil, ErrManagerDraining
 	}
 	if _, deleting := m.deleting[key]; deleting {
 		return nil, errdefs.NotAvailablef(
@@ -557,6 +622,37 @@ func (m *Manager) awaitKeyIdle(ctx context.Context, key Key) error {
 		case <-ticker.C:
 		}
 	}
+}
+
+func (m *Manager) waitIdle(ctx context.Context) error {
+	ticker := time.NewTicker(agentDrainPollInterval)
+	defer ticker.Stop()
+	for {
+		if m.Idle() {
+			return nil
+		}
+		select {
+		case <-ctx.Done():
+			return errdefs.FromContext(ctx.Err())
+		case <-ticker.C:
+		}
+	}
+}
+
+func (m *Manager) allIdleLocked() bool {
+	for _, entry := range m.entries {
+		if entry.session.isIdle() {
+			continue
+		}
+		// A closing session whose turn already stopped never reports
+		// idle (isIdle requires !closing), but there is nothing left to
+		// drain. Mirror the keyIdle contract.
+		if entry.session.isClosing() && !entry.session.hasActiveTurn() {
+			continue
+		}
+		return false
+	}
+	return true
 }
 
 func (m *Manager) keyIdle(key Key) bool {

--- a/core/runtime/session/session.go
+++ b/core/runtime/session/session.go
@@ -356,6 +356,11 @@ func (s *Session) interruptActive(ctx context.Context) (func(), error) {
 	s.changeActivity(activityTurn, 1)
 	release := func() { s.changeActivity(activityTurn, -1) }
 
+	if s.manager.isDraining() {
+		release()
+		return nil, ErrManagerDraining
+	}
+
 	s.mu.Lock()
 	if s.closing {
 		s.mu.Unlock()

--- a/docs/guides/runtime.md
+++ b/docs/guides/runtime.md
@@ -171,6 +171,33 @@ drained (bounded by ctx) before store entries are removed, and on ctx
 expiry the delete marker rolls back with no partial removal — the call is
 retryable and repeated calls are idempotent.
 
+### Draining a runtime offline
+
+`Runtime.Drain(ctx)` quiesces a runtime whose object is about to be
+replaced (for example a blue-green rebuild that `Reload` cannot express):
+new session leases and new turns on already-open leases are refused, and
+the runtime waits (bounded by `ctx`) for active turns to finish naturally.
+It never interrupts running turns. After `Drain` returns, the runtime stays
+drained; retry a timed-out drain or proceed to `Close` once the replacement
+is ready:
+
+```go
+if err := old.Drain(ctx); err != nil {
+    return err // runtime stays drained; retry or force Close
+}
+if err := old.Close(); err != nil {
+    return err
+}
+newApp, err := runtime.NewBuilder(reg).Build(ctx, doc)
+```
+
+The session manager exposes the same primitives for embedded use:
+`Manager.Idle()` reports whether any session still has active turns,
+prompts, or sinks; `Manager.WaitIdle(ctx)` waits without changing state;
+`Manager.Drain(ctx)` quiesces and waits. Prefer `Runtime.Drain` when the
+application owns a `Runtime`, since it serializes against
+`RegisterAgent` / `UnregisterAgent` / `Reload` / `Close`.
+
 ## Dynamic agent registry
 
 Agents are normally declared in the deployment document and fixed for the


### PR DESCRIPTION
## Summary

Adds a public quiesce/drain path for taking a `core/runtime.Runtime` offline before replacing it with a new one:

- `session.Manager.Idle()` / `WaitIdle(ctx)` / `Drain(ctx)` and `ErrManagerDraining`
- `Runtime.Drain(ctx)`, serialized with `RegisterAgent` / `UnregisterAgent` / `Reload` / `Close`

`Drain` refuses new session leases and new turns on already-open leases, then waits (bounded by ctx) for active turns to finish naturally without interrupting them. After a successful or timed-out drain the runtime stays drained; callers can retry or proceed to `Close`.

A race guard in `Session.interruptActive` prevents a Start that already acquired an epoch from installing a new turn after Drain observed the manager idle.

## Tests

- Added manager-level drain tests and a runtime end-to-end drain test
- `make ci`, `make lint`, `make release-check`, `git diff --check` all pass
- No release changeset added (no module release in this PR)