### PR TITLE
fix(core/inference): accept dropped decisions in failed compile reports

### DIFF
--- a/core/inference/decision.go
+++ b/core/inference/decision.go
@@ -106,10 +106,11 @@ const (
 	Native Disposition = "native"
 	// Rejected means the field cannot be honored and the compile failed.
 	Rejected Disposition = "rejected"
-	// Dropped means the compiler intentionally discarded the field while
-	// succeeding: the value cannot round-trip or has no channel, and the
-	// Reason states why. Consumers audit drops through the report; nothing
-	// is discarded silently.
+	// Dropped means the compiler intentionally discarded the field: the
+	// value cannot round-trip or has no channel, and the Reason states why.
+	// Drops are field-level audits and may appear on a successful compile
+	// or alongside a rejection on a failed one; consumers audit them
+	// through the report, so nothing is discarded silently.
 	Dropped Disposition = "dropped"
 )
 
@@ -157,8 +158,9 @@ func (r CompileReport) Metadata(model ModelRef) Metadata {
 	}
 }
 
-// ValidateSuccess proves that every active canonical field has exactly one
-// Native terminal disposition.
+// ValidateSuccess proves that a successful compile covers every active
+// canonical field with exactly one terminal disposition: Native, or Dropped
+// with a reason. Rejections invalidate a successful report.
 func (r CompileReport) ValidateSuccess(operation Operation, active []FieldID) error {
 	if r.Operation != operation {
 		return contractViolation(operation, "", "compiler reported the wrong operation")
@@ -197,7 +199,11 @@ func (r CompileReport) ValidateSuccess(operation Operation, active []FieldID) er
 }
 
 // ValidateFailure proves that a failed compile rejects at least one active
-// field and contains no duplicate or out-of-ledger decisions.
+// field and contains no duplicate or out-of-ledger decisions. Dropped
+// decisions are field-level audits: a driver may both reject one field
+// and drop another (for example an image input rejected by a text model
+// while the reasoning effort folds onto the model's wire level), so a
+// valid dropped disposition with a reason does not invalidate the report.
 func (r CompileReport) ValidateFailure(operation Operation, active []FieldID) error {
 	if r.Operation != operation {
 		return contractViolation(operation, "", "compiler reported the wrong operation")
@@ -218,6 +224,10 @@ func (r CompileReport) ValidateFailure(operation Operation, active []FieldID) er
 		seen[decision.Field] = struct{}{}
 		switch decision.Disposition {
 		case Native:
+		case Dropped:
+			if decision.Reason == "" {
+				return contractViolation(operation, decision.Field, "dropped field carries no reason")
+			}
 		case Rejected:
 			if decision.Reason == "" {
 				return contractViolation(operation, decision.Field, "rejected disposition requires a reason")

--- a/core/inference/decision_test.go
+++ b/core/inference/decision_test.go
@@ -1,0 +1,52 @@
+package inference
+
+import "testing"
+
+func TestValidateFailureAllowsDroppedAlongsideRejection(t *testing.T) {
+	active := []FieldID{
+		FieldGenerateInputImage,
+		FieldGenerateIntentReasoningEffort,
+	}
+	report := CompileReport{
+		Operation: OperationGenerate,
+		Decisions: []Decision{
+			{
+				Field:       FieldGenerateIntentReasoningEffort,
+				Disposition: Dropped,
+				Reason:      `model maps reasoning effort "medium" to "high"`,
+			},
+			{
+				Field:       FieldGenerateInputImage,
+				Disposition: Rejected,
+				Reason:      "model does not accept image input",
+			},
+		},
+	}
+	if err := report.ValidateFailure(OperationGenerate, active); err != nil {
+		t.Fatalf("ValidateFailure rejected a valid drop+reject report: %v", err)
+	}
+}
+
+func TestValidateFailureRejectsUnreasonedDrop(t *testing.T) {
+	report := CompileReport{
+		Operation: OperationGenerate,
+		Decisions: []Decision{
+			{
+				Field:       FieldGenerateIntentReasoningEffort,
+				Disposition: Dropped,
+			},
+			{
+				Field:       FieldGenerateInputImage,
+				Disposition: Rejected,
+				Reason:      "model does not accept image input",
+			},
+		},
+	}
+	err := report.ValidateFailure(
+		OperationGenerate,
+		[]FieldID{FieldGenerateInputImage, FieldGenerateIntentReasoningEffort},
+	)
+	if err == nil {
+		t.Fatal("ValidateFailure accepted a dropped field without a reason")
+	}
+}

--- a/driver/deepseek/vision_test.go
+++ b/driver/deepseek/vision_test.go
@@ -2,6 +2,7 @@ package deepseek
 
 import (
 	"context"
+	"errors"
 	"strings"
 	"testing"
 
@@ -192,6 +193,53 @@ func TestTextModelsRejectImageInput(t *testing.T) {
 		inference.GenerateExecutionUnary,
 	); err == nil {
 		t.Fatal("responses compiler accepted an image on a text-only model")
+	}
+}
+
+// TestTextModelRejectsImageWhileDroppingEffort covers a failure report that
+// carries both a rejection and a field-level drop (the medium effort maps
+// to the model's "high" wire level): ValidateFailure must accept the report
+// and the structured image rejection must survive.
+func TestTextModelRejectsImageWhileDroppingEffort(t *testing.T) {
+	request := visionRequest()
+	request.Input.Content.Intent.Text = &inference.TextIntent{
+		ReasoningEffort: inference.ReasoningMedium,
+	}
+	compiled, err := compileChatGenerate(
+		"deepseek-v4-flash",
+		catalog["deepseek-v4-flash"],
+	)(
+		context.Background(),
+		conformanceModel("deepseek-v4-flash"),
+		request,
+		inference.GenerateExecutionUnary,
+	)
+	if err == nil {
+		t.Fatal("chat compiler accepted an image on a text-only model")
+	}
+	active := request.ActiveFieldsFor(inference.GenerateExecutionUnary)
+	if reportErr := compiled.Report.ValidateFailure(
+		inference.OperationGenerate,
+		active,
+	); reportErr != nil {
+		t.Fatalf("drop+reject failure report must validate: %v", reportErr)
+	}
+	var inferenceErr *inference.Error
+	if !errors.As(err, &inferenceErr) ||
+		inferenceErr.Operation != inference.OperationGenerate ||
+		inferenceErr.Field != inference.FieldGenerateInputImage {
+		t.Fatalf(
+			"compile error = %+v, want structured rejection of %q",
+			err,
+			inference.FieldGenerateInputImage,
+		)
+	}
+	if !compiled.Report.Rejects(inference.FieldGenerateInputImage) ||
+		!compiled.Report.Dropped(inference.FieldGenerateIntentReasoningEffort) {
+		t.Fatalf(
+			"report = %+v, want image rejection with effort drop",
+			compiled.Report,
+		)
 	}
 }
 


### PR DESCRIPTION
## Summary

`CompileReport.ValidateFailure` treated any `Dropped` disposition as an unknown disposition and returned a contract violation. A driver that both drops one field and rejects another in the same compile — e.g. an image input rejected by a text model while a reasoning effort folds onto the model's wire level — therefore surfaced `CompilerContractViolation` instead of the driver's structured rejection (`UnsupportedFeature` on the actual field).

Dropped decisions are field-level audits: a failed report may legitimately carry drops alongside its rejection, as long as every drop states a reason.

## Changes

- `core/inference/decision.go`: allow `Dropped` (with a reason) in failed compile reports; align `Dropped` and `ValidateSuccess` docs.
- `core/inference/decision_test.go`: unit tests for drop+reject failure reports and unreasoned drops.
- `driver/deepseek/vision_test.go`: regression test where a text-only model rejects an image while dropping the reasoning effort with a reason.

## Verification

- `make ci` ✓
- `make lint` ✓ (0 issues)
- `make release-check` ✓
- `git diff --check` ✓