### PR TITLE
chore(release): add core v0.2.5 changeset

### DIFF
--- a/.release/core-v0.2.5.json
+++ b/.release/core-v0.2.5.json
@@ -1,0 +1,9 @@
+{
+  "summary": "feat(core): add runtime drain API for offline replacement — Runtime.Drain(ctx) quiesces a running Runtime for offline replacement, serialized with RegisterAgent/UnregisterAgent/Reload/Close; it refuses new session leases and new Starts on already-open leases through session.Manager.Idle/WaitIdle/Drain and ErrManagerDraining, waits for active turns to finish naturally within ctx without interrupting them, stays drained after success or timeout so callers can retry or proceed to Close, and closes the race where a Start that already acquired an epoch could install a new turn after Drain observed the manager idle; runtime and manager drain tests plus the runtime guide cover the flow; fix(core/inference): accept dropped decisions in failed compile reports — CompileReport.ValidateFailure no longer treats a Dropped disposition as a contract violation, so a driver that drops one field with a reason while rejecting another in the same compile surfaces its structured rejection instead of CompilerContractViolation, unreasoned drops in failed reports stay rejected, and the Dropped/ValidateSuccess docs are aligned",
+  "releases": [
+    {
+      "module": "core",
+      "bump": "patch"
+    }
+  ]
+}


### PR DESCRIPTION
Adds the immutable `.release/core-v0.2.5.json` changeset for the core module.

Pending plan (`make release-plan`):

```json
{
  "modules": [
    {
      "module": "core",
      "bump": "patch",
      "current": "0.2.4",
      "next": "0.2.5",
      "tag": "core/v0.2.5"
    }
  ],
  "tags": ["core/v0.2.5"]
}
```

The summary covers the accumulated core delta since `core/v0.2.4`: the runtime drain API (#499) and the inference compile-report fix for dropped decisions (#501).

After this merges, the Release modules workflow will open/refresh the `automation/release-changelog` PR; merging that publishes `core/v0.2.5`.