### PR TITLE
feat(core): add runtime external dependency injection

### DIFF
--- a/core/deploy/builder.go
+++ b/core/deploy/builder.go
@@ -23,10 +23,11 @@ import (
 // an explicit [resource.Registry]. The registry is owned by the caller;
 // Builder never touches global state.
 type Builder struct {
-	registry       *resource.Registry
-	loader         *resource.Loader
-	resolver       *resource.ReferenceResolver
-	secretCacheTTL time.Duration
+	registry          *resource.Registry
+	loader            *resource.Loader
+	resolver          *resource.ReferenceResolver
+	secretCacheTTL    time.Duration
+	externalResources []ExternalResource
 }
 
 // BuilderOption configures a Builder.
@@ -78,10 +79,19 @@ func (b *Builder) Build(ctx context.Context, doc Document) (*Result, error) {
 	if err := doc.Validate(); err != nil {
 		return nil, err
 	}
+	externals, err := normalizeExternalResources(b.externalResources)
+	if err != nil {
+		return nil, err
+	}
 
 	graph := resource.NewGraph()
 	for name, res := range doc.Resources {
 		if err := graph.Add(name, res); err != nil {
+			return nil, err
+		}
+	}
+	for name := range externals {
+		if err := graph.AddExternal(name); err != nil {
 			return nil, err
 		}
 	}
@@ -94,7 +104,8 @@ func (b *Builder) Build(ctx context.Context, doc Document) (*Result, error) {
 	// Secret stores are built first: their settings never reference
 	// secrets, and once assembled they feed the ${secret:...} scheme
 	// every other resource's expansion uses.
-	stores, defaultStore, err := b.buildSecretStores(ctx, doc, order, values, b.resolver)
+	stores, defaultStore, err := b.buildSecretStores(
+		ctx, doc, order, values, externals, b.resolver)
 	if err != nil {
 		logCleanup(ctx, values, order)
 		return nil, err
@@ -108,7 +119,8 @@ func (b *Builder) Build(ctx context.Context, doc Document) (*Result, error) {
 		if _, prebuilt := values[name]; prebuilt {
 			continue
 		}
-		value, err := b.buildResource(ctx, name, doc.Resources[name], values, resolver, secrets)
+		value, err := b.buildResource(
+			ctx, name, doc.Resources[name], values, externals, resolver, secrets)
 		if err != nil {
 			logCleanup(ctx, values, order)
 			return nil, errdefs.Validationf("deploy: resource %q: %v", name, err)
@@ -117,11 +129,12 @@ func (b *Builder) Build(ctx context.Context, doc Document) (*Result, error) {
 	}
 
 	return &Result{
-		values:   values,
-		order:    order,
-		agents:   make(map[string]*agent.Agent, len(doc.Agents)),
-		resolver: resolver,
-		secrets:  secrets,
+		values:    values,
+		order:     order,
+		agents:    make(map[string]*agent.Agent, len(doc.Agents)),
+		resolver:  resolver,
+		secrets:   secrets,
+		externals: externals,
 	}, nil
 }
 
@@ -134,6 +147,7 @@ func (b *Builder) buildResource(
 	name string,
 	res resource.Resource,
 	values map[string]any,
+	externals map[string]ExternalResource,
 	resolver *resource.ReferenceResolver,
 	secrets *resource.SecretResolver,
 ) (any, error) {
@@ -144,6 +158,9 @@ func (b *Builder) buildResource(
 			name, res.Kind, res.Impl)
 	}
 	if err := validateDeps(factory, res.Deps); err != nil {
+		return nil, errdefs.Validationf("deploy: resource %q: %v", name, err)
+	}
+	if err := validateExternalContracts(factory, res.Deps, externals); err != nil {
 		return nil, errdefs.Validationf("deploy: resource %q: %v", name, err)
 	}
 	settings := res.Settings
@@ -158,7 +175,7 @@ func (b *Builder) buildResource(
 	if err != nil {
 		return nil, errdefs.Validationf("deploy: resource %q: %v", name, err)
 	}
-	deps, err := resolveDeps(values, res.Deps)
+	deps, err := resolveDeps(values, externals, res.Deps)
 	if err != nil {
 		return nil, errdefs.Validationf("deploy: resource %q: %v", name, err)
 	}
@@ -180,6 +197,7 @@ func (b *Builder) buildSecretStores(
 	doc Document,
 	order []string,
 	values map[string]any,
+	externals map[string]ExternalResource,
 	resolver *resource.ReferenceResolver,
 ) (map[string]resource.SecretStore, string, error) {
 	stores := make(map[string]resource.SecretStore)
@@ -190,7 +208,8 @@ func (b *Builder) buildSecretStores(
 		if res.Kind != secret.ResourceKind {
 			continue
 		}
-		value, err := b.buildResource(ctx, name, res, values, resolver, nil)
+		value, err := b.buildResource(
+			ctx, name, res, values, externals, resolver, nil)
 		if err != nil {
 			return nil, "", errdefs.Validationf("deploy: resource %q: %v", name, err)
 		}
@@ -443,7 +462,11 @@ func BindAgent(
 	if err := validateDeps(engineFactory, def.Engine.Deps); err != nil {
 		return nil, errdefs.Validationf("deploy: agent %q engine: %v", name, err)
 	}
-	engineDeps, err := resolveDeps(result.values, def.Engine.Deps)
+	if err := validateExternalContracts(
+		engineFactory, def.Engine.Deps, result.externals); err != nil {
+		return nil, errdefs.Validationf("deploy: agent %q engine: %v", name, err)
+	}
+	engineDeps, err := resolveDeps(result.values, result.externals, def.Engine.Deps)
 	if err != nil {
 		return nil, errdefs.Validationf("deploy: agent %q: %v", name, err)
 	}
@@ -553,7 +576,12 @@ func buildHookList[T any](
 			return fail(errdefs.Validationf(
 				"deploy: agent %q: hook %s[%d]: %v", name, slot, i, err))
 		}
-		deps, err := resolveDeps(result.values, entry.Deps)
+		if err := validateExternalContracts(
+			factory, entry.Deps, result.externals); err != nil {
+			return fail(errdefs.Validationf(
+				"deploy: agent %q: hook %s[%d]: %v", name, slot, i, err))
+		}
+		deps, err := resolveDeps(result.values, result.externals, entry.Deps)
 		if err != nil {
 			return fail(errdefs.Validationf(
 				"deploy: agent %q: hook %s[%d]: %v", name, slot, i, err))
@@ -667,26 +695,84 @@ func validateDeps(factory resource.Factory, deps resource.Deps) error {
 	return nil
 }
 
+// validateExternalContracts checks that every dep reference pointing at
+// an external value declares a matching DepSpec.Type.
+func validateExternalContracts(
+	factory resource.Factory,
+	deps resource.Deps,
+	externals map[string]ExternalResource,
+) error {
+	if len(externals) == 0 {
+		return nil
+	}
+	spec := factory.Spec()
+	for key, ref := range deps {
+		ext, ok := externals[ref.ResourceName()]
+		if !ok {
+			continue
+		}
+		dep, ok := depSpecFor(spec, key)
+		if !ok {
+			// validateDeps reports undeclared deps; keep this helper
+			// focused on contract mismatches.
+			continue
+		}
+		if dep.Type != ext.Contract {
+			return errdefs.Validationf(
+				"dep %q external %q contract %q does not match declared type %q for %s/%s",
+				key, ext.Name, ext.Contract, dep.Type, spec.Kind, spec.Impl)
+		}
+	}
+	return nil
+}
+
+func depSpecFor(spec resource.Spec, key string) (resource.DepSpec, bool) {
+	for _, dep := range spec.Deps {
+		if dep.Name == key || (dep.Many && strings.HasPrefix(key, dep.Name+".")) {
+			return dep, true
+		}
+	}
+	return resource.DepSpec{}, false
+}
+
 // resolveDeps maps each declared dep to the built value, resolving
 // "resource/item" refs through the container's [resource.ItemResolver].
-func resolveDeps(values map[string]any, deps resource.Deps) (map[string]any, error) {
+func resolveDeps(
+	values map[string]any,
+	externals map[string]ExternalResource,
+	deps resource.Deps,
+) (map[string]any, error) {
 	resolved := make(map[string]any, len(deps))
 	for name, ref := range deps {
-		value, ok := values[ref.ResourceName()]
+		refName := ref.ResourceName()
+		value, ok := values[refName]
 		if !ok {
-			return nil, errdefs.Validationf(
-				"dep %q references unbuilt resource %q", name, ref.ResourceName())
+			ext, external := externals[refName]
+			if !external {
+				return nil, errdefs.Validationf(
+					"dep %q references unbuilt resource %q", name, refName)
+			}
+			if _, hasItem := ref.ItemName(); hasItem {
+				return nil, errdefs.Validationf(
+					"dep %q: external resource %q does not support item references",
+					name, refName)
+			}
+			value = ext.Value
+		}
+		if _, isExternal := externals[refName]; isExternal {
+			resolved[name] = value
+			continue
 		}
 		if item, hasItem := ref.ItemName(); hasItem {
 			resolver, ok := value.(resource.ItemResolver)
 			if !ok {
 				return nil, errdefs.Validationf(
-					"dep %q: resource %q does not expose items", name, ref.ResourceName())
+					"dep %q: resource %q does not expose items", name, refName)
 			}
 			itemValue, ok := resolver.ResolveItem(item)
 			if !ok {
 				return nil, errdefs.Validationf(
-					"dep %q: resource %q has no item %q", name, ref.ResourceName(), item)
+					"dep %q: resource %q has no item %q", name, refName, item)
 			}
 			value = itemValue
 		}
@@ -698,10 +784,11 @@ func resolveDeps(values map[string]any, deps resource.Deps) (map[string]any, err
 // Result owns the built resource values in construction order.
 // The caller closes it (or the runtime layer closes it) when done.
 type Result struct {
-	values   map[string]any
-	order    []string
-	agents   map[string]*agent.Agent
-	detached map[string]struct{}
+	values    map[string]any
+	order     []string
+	agents    map[string]*agent.Agent
+	detached  map[string]struct{}
+	externals map[string]ExternalResource
 	// resolver and secrets carry the effective expansion state from
 	// Build into Wire, so agent engine/hook settings expand with the
 	// same schemes (including ${secret:...}) and typed Secrets resolve.

--- a/core/deploy/external.go
+++ b/core/deploy/external.go
@@ -1,0 +1,83 @@
+package deploy
+
+import (
+	"strings"
+
+	"github.com/GizClaw/flowcraft/core/errdefs"
+)
+
+// External declares one caller-owned dependency supplied to the
+// deployment builder. Externals are visible to dependency resolution
+// but are never constructed, wired, or closed by deploy.
+type External struct {
+	// Name is the resource-ref name used in document deps, e.g. "db".
+	Name string `json:"name"`
+	// Contract is the expected DepSpec.Type of consuming factories,
+	// e.g. "db.Pool".
+	Contract string `json:"contract"`
+}
+
+// Validate checks the static fields of an External declaration.
+func (e External) Validate() error {
+	e.Name = strings.TrimSpace(e.Name)
+	e.Contract = strings.TrimSpace(e.Contract)
+	if e.Name == "" || strings.Contains(e.Name, "/") {
+		return errdefs.Validationf(
+			"deploy external: name must be non-empty and must not contain '/'")
+	}
+	if e.Contract == "" {
+		return errdefs.Validationf(
+			"deploy external %q: contract is required", e.Name)
+	}
+	return nil
+}
+
+// ExternalResource pairs one External declaration with the caller-owned
+// value that satisfies it.
+type ExternalResource struct {
+	External
+	Value any
+}
+
+// Validate checks the declaration and rejects nil values.
+func (e ExternalResource) Validate() error {
+	if err := e.External.Validate(); err != nil {
+		return err
+	}
+	if e.Value == nil || isNilValue(e.Value) {
+		return errdefs.Validationf(
+			"deploy external %q: value is required", e.Name)
+	}
+	return nil
+}
+
+// WithExternalResources configures the builder with caller-owned
+// dependency values. Values are copied by reference: deploy never
+// closes or mutates them. Multiple calls accumulate; duplicates are
+// rejected at Build time.
+func WithExternalResources(externals []ExternalResource) BuilderOption {
+	return func(b *Builder) {
+		b.externalResources = append(b.externalResources, externals...)
+	}
+}
+
+// normalizeExternalResources validates and deduplicates the builder's
+// external values into a lookup map.
+func normalizeExternalResources(
+	externals []ExternalResource,
+) (map[string]ExternalResource, error) {
+	out := make(map[string]ExternalResource, len(externals))
+	for _, ext := range externals {
+		ext.Name = strings.TrimSpace(ext.Name)
+		ext.Contract = strings.TrimSpace(ext.Contract)
+		if err := ext.Validate(); err != nil {
+			return nil, err
+		}
+		if _, dup := out[ext.Name]; dup {
+			return nil, errdefs.Conflictf(
+				"deploy external: duplicate dependency %q", ext.Name)
+		}
+		out[ext.Name] = ext
+	}
+	return out, nil
+}

--- a/core/deploy/external_test.go
+++ b/core/deploy/external_test.go
@@ -1,0 +1,368 @@
+package deploy
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/GizClaw/flowcraft/core/agent"
+	"github.com/GizClaw/flowcraft/core/errdefs"
+	"github.com/GizClaw/flowcraft/core/resource"
+)
+
+type externalPool struct {
+	closes int
+	wires  int
+	binds  int
+}
+
+func (p *externalPool) Close() error {
+	p.closes++
+	return nil
+}
+
+func (p *externalPool) Wire(context.Context) error {
+	p.wires++
+	return nil
+}
+
+func (p *externalPool) BindDeployment(any) error {
+	p.binds++
+	return nil
+}
+
+type externalConsumer struct {
+	pool   *externalPool
+	closed bool
+}
+
+func (c *externalConsumer) Close() error {
+	c.closed = true
+	return nil
+}
+
+type externalConsumerFactory struct{}
+
+func (externalConsumerFactory) Spec() resource.Spec {
+	return resource.Spec{
+		Kind: "test.ExternalConsumer",
+		Impl: "local",
+		Deps: []resource.DepSpec{{
+			Name: "db", Type: "db.Pool", Required: true,
+		}},
+	}
+}
+
+func (externalConsumerFactory) New(_ context.Context, in resource.Input) (any, error) {
+	value, ok := in.Dep("db")
+	if !ok {
+		return nil, errdefs.Validationf("consumer: db dep missing")
+	}
+	pool, ok := value.(*externalPool)
+	if !ok {
+		return nil, errdefs.Validationf("consumer: db dep has wrong type")
+	}
+	return &externalConsumer{pool: pool}, nil
+}
+
+type externalFailingFactory struct {
+	consumerType string
+}
+
+func (f externalFailingFactory) Spec() resource.Spec {
+	return resource.Spec{
+		Kind: "test.ExternalFail",
+		Impl: "local",
+		Deps: []resource.DepSpec{{
+			Name: "consumer", Type: f.consumerType, Required: true,
+		}},
+	}
+}
+
+func (externalFailingFactory) New(context.Context, resource.Input) (any, error) {
+	return nil, errors.New("boom")
+}
+
+type externalAgentEngineFactory struct{}
+
+func (externalAgentEngineFactory) Spec() resource.Spec {
+	return resource.Spec{
+		Kind: "engine.test",
+		Impl: "external",
+		Deps: []resource.DepSpec{{
+			Name: "db", Type: "db.Pool", Required: true,
+		}},
+	}
+}
+
+func (externalAgentEngineFactory) New(_ context.Context, in resource.Input) (any, error) {
+	value, ok := in.Dep("db")
+	if !ok {
+		return nil, errdefs.Validationf("engine: db dep missing")
+	}
+	if _, ok := value.(*externalPool); !ok {
+		return nil, errdefs.Validationf("engine: db dep has wrong type")
+	}
+	return agent.EngineFunc(func(
+		context.Context, agent.Run, agent.Host, *agent.Board,
+	) (*agent.Board, error) {
+		return agent.NewBoard(), nil
+	}), nil
+}
+
+type externalObserverHook struct {
+	agent.BaseObserver
+	pool *externalPool
+}
+
+type externalObserverHookFactory struct{}
+
+func (externalObserverHookFactory) Spec() resource.Spec {
+	return resource.Spec{
+		Kind: "hook.observe",
+		Impl: "external",
+		Deps: []resource.DepSpec{{
+			Name: "db", Type: "db.Pool", Required: true,
+		}},
+	}
+}
+
+func (externalObserverHookFactory) New(_ context.Context, in resource.Input) (any, error) {
+	value, ok := in.Dep("db")
+	if !ok {
+		return nil, errdefs.Validationf("hook: db dep missing")
+	}
+	pool, ok := value.(*externalPool)
+	if !ok {
+		return nil, errdefs.Validationf("hook: db dep has wrong type")
+	}
+	return &externalObserverHook{pool: pool}, nil
+}
+
+func externalDoc() Document {
+	return Document{
+		Version: "v1",
+		Resources: resource.Resources{
+			"consumer": {
+				Kind: "test.ExternalConsumer",
+				Impl: "local",
+				Deps: resource.Deps{"db": "db"},
+			},
+		},
+	}
+}
+
+func TestExternalResourceResolvesAsDependencyAndStaysUnmanaged(t *testing.T) {
+	pool := &externalPool{}
+	reg := resource.NewRegistry()
+	reg.MustRegister(externalConsumerFactory{})
+	builder := NewBuilder(
+		reg,
+		WithExternalResources([]ExternalResource{{
+			External: External{Name: "db", Contract: "db.Pool"},
+			Value:    pool,
+		}}),
+	)
+
+	result, err := builder.Deploy(context.Background(), externalDoc())
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	resultClosed := false
+	defer func() {
+		if !resultClosed {
+			_ = result.Close()
+		}
+	}()
+
+	if _, ok := result.Value("db"); ok {
+		t.Fatal("external db leaked into managed Value view")
+	}
+	for _, name := range result.Names() {
+		if name == "db" {
+			t.Fatal("external db leaked into managed Names view")
+		}
+	}
+	value, ok := result.Value("consumer")
+	if !ok {
+		t.Fatalf("consumer resource missing")
+	}
+	consumer := value.(*externalConsumer)
+	if consumer.pool != pool {
+		t.Fatal("consumer did not receive the injected external value")
+	}
+	if err := result.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	resultClosed = true
+	if pool.closes != 0 || pool.wires != 0 || pool.binds != 0 {
+		t.Fatalf(
+			"external was managed: closes=%d wires=%d binds=%d",
+			pool.closes, pool.wires, pool.binds)
+	}
+	if !consumer.closed {
+		t.Fatal("managed consumer was not closed")
+	}
+}
+
+func TestExternalResourceContractMismatch(t *testing.T) {
+	reg := resource.NewRegistry()
+	reg.MustRegister(externalConsumerFactory{})
+	_, err := NewBuilder(
+		reg,
+		WithExternalResources([]ExternalResource{{
+			External: External{Name: "db", Contract: "db.Other"},
+			Value:    &externalPool{},
+		}}),
+	).Build(context.Background(), externalDoc())
+	if !errdefs.IsValidation(err) ||
+		!strings.Contains(err.Error(), "does not match declared type") {
+		t.Fatalf("Build error = %v, want contract mismatch", err)
+	}
+}
+
+func TestExternalResourceRejectsItemRef(t *testing.T) {
+	doc := externalDoc()
+	consumer := doc.Resources["consumer"]
+	consumer.Deps = resource.Deps{"db": "db/item"}
+	doc.Resources["consumer"] = consumer
+	reg := resource.NewRegistry()
+	reg.MustRegister(externalConsumerFactory{})
+	_, err := NewBuilder(
+		reg,
+		WithExternalResources([]ExternalResource{{
+			External: External{Name: "db", Contract: "db.Pool"},
+			Value:    &externalPool{},
+		}}),
+	).Build(context.Background(), doc)
+	if !errdefs.IsValidation(err) ||
+		!strings.Contains(err.Error(), "does not support item references") {
+		t.Fatalf("Build error = %v, want item-ref rejection", err)
+	}
+}
+
+func TestExternalResourceNotClosedOnRollback(t *testing.T) {
+	pool := &externalPool{}
+	reg := resource.NewRegistry()
+	reg.MustRegister(externalConsumerFactory{})
+	reg.MustRegister(externalFailingFactory{consumerType: "test.ExternalConsumer"})
+	doc := externalDoc()
+	doc.Resources["z-fail"] = resource.Resource{
+		Kind: "test.ExternalFail",
+		Impl: "local",
+		Deps: resource.Deps{"consumer": "consumer"},
+	}
+	_, err := NewBuilder(
+		reg,
+		WithExternalResources([]ExternalResource{{
+			External: External{Name: "db", Contract: "db.Pool"},
+			Value:    pool,
+		}}),
+	).Build(context.Background(), doc)
+	if err == nil {
+		t.Fatal("Build unexpectedly succeeded")
+	}
+	if pool.closes != 0 {
+		t.Fatalf("external closed during rollback: %d times", pool.closes)
+	}
+}
+
+func TestExternalResourceResolvesForAgentEngineAndHook(t *testing.T) {
+	pool := &externalPool{}
+	reg := resource.NewRegistry()
+	reg.MustRegister(externalAgentEngineFactory{})
+	reg.MustRegister(externalObserverHookFactory{})
+	doc := Document{
+		Version: "v1",
+		Agents: map[string]agent.Definition{
+			"bot": {
+				Card: agent.AgentCard{Name: "Bot"},
+				Engine: agent.EngineRef{
+					Kind: "engine.test",
+					Impl: "external",
+					Deps: resource.Deps{"db": "db"},
+				},
+				Observe: []agent.Hook{{
+					Type: "external",
+					Deps: resource.Deps{"db": "db"},
+				}},
+			},
+		},
+	}
+	result, err := NewBuilder(
+		reg,
+		WithExternalResources([]ExternalResource{{
+			External: External{Name: "db", Contract: "db.Pool"},
+			Value:    pool,
+		}}),
+	).Deploy(context.Background(), doc)
+	if err != nil {
+		t.Fatalf("Deploy: %v", err)
+	}
+
+	instance, ok := result.Agent("bot")
+	if !ok {
+		t.Fatal("bot agent missing")
+	}
+	if len(instance.Observe) != 1 {
+		t.Fatalf("observe hooks = %d, want 1", len(instance.Observe))
+	}
+	hook, ok := instance.Observe[0].(*externalObserverHook)
+	if !ok {
+		t.Fatalf("hook type = %T, want *externalObserverHook", instance.Observe[0])
+	}
+	if hook.pool != pool {
+		t.Fatal("hook did not receive the injected external pool")
+	}
+	if err := result.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	if pool.closes != 0 {
+		t.Fatalf("external pool was closed %d times", pool.closes)
+	}
+}
+
+func TestExternalResourceValidation(t *testing.T) {
+	var typedNil *externalPool
+	tests := []struct {
+		name string
+		ext  ExternalResource
+	}{
+		{name: "missing name", ext: ExternalResource{
+			External: External{Contract: "db.Pool"}, Value: &externalPool{},
+		}},
+		{name: "name with slash", ext: ExternalResource{
+			External: External{Name: "db/item", Contract: "db.Pool"}, Value: &externalPool{},
+		}},
+		{name: "missing contract", ext: ExternalResource{
+			External: External{Name: "db"}, Value: &externalPool{},
+		}},
+		{name: "nil value", ext: ExternalResource{
+			External: External{Name: "db", Contract: "db.Pool"}, Value: nil,
+		}},
+		{name: "typed nil value", ext: ExternalResource{
+			External: External{Name: "db", Contract: "db.Pool"}, Value: typedNil,
+		}},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if err := test.ext.Validate(); !errdefs.IsValidation(err) {
+				t.Fatalf("Validate error = %v, want validation", err)
+			}
+			if _, err := normalizeExternalResources([]ExternalResource{test.ext}); !errdefs.IsValidation(err) {
+				t.Fatalf("normalize error = %v, want validation", err)
+			}
+		})
+	}
+
+	t.Run("duplicate", func(t *testing.T) {
+		_, err := normalizeExternalResources([]ExternalResource{
+			{External: External{Name: "db", Contract: "db.Pool"}, Value: &externalPool{}},
+			{External: External{Name: "db", Contract: "db.Pool"}, Value: &externalPool{}},
+		})
+		if !errdefs.IsConflict(err) {
+			t.Fatalf("normalize duplicate error = %v, want conflict", err)
+		}
+	})
+}

--- a/core/resource/dag.go
+++ b/core/resource/dag.go
@@ -2,6 +2,7 @@ package resource
 
 import (
 	"sort"
+	"strings"
 
 	"github.com/GizClaw/flowcraft/core/errdefs"
 )
@@ -9,12 +10,16 @@ import (
 // Graph is the resource dependency DAG of one deployment document.
 // Nodes are named resources; edges come from each resource's Deps.
 type Graph struct {
-	nodes map[string]Resource
+	nodes    map[string]Resource
+	external map[string]struct{}
 }
 
 // NewGraph returns an empty graph.
 func NewGraph() *Graph {
-	return &Graph{nodes: make(map[string]Resource)}
+	return &Graph{
+		nodes:    make(map[string]Resource),
+		external: make(map[string]struct{}),
+	}
 }
 
 // Add inserts a named resource, rejecting duplicates and invalid
@@ -23,10 +28,34 @@ func (g *Graph) Add(name string, res Resource) error {
 	if _, dup := g.nodes[name]; dup {
 		return errdefs.Conflictf("resource graph: duplicate node %q", name)
 	}
+	if _, dup := g.external[name]; dup {
+		return errdefs.Conflictf("resource graph: node %q duplicates an external node", name)
+	}
 	if err := res.Validate(); err != nil {
 		return errdefs.Validationf("resource graph: node %q: %v", name, err)
 	}
 	g.nodes[name] = res
+	return nil
+}
+
+// AddExternal inserts an externally supplied leaf dependency. External
+// nodes may be referenced by document resources but are never built,
+// wired, or returned by TopoOrder.
+func (g *Graph) AddExternal(name string) error {
+	name = strings.TrimSpace(name)
+	if name == "" || strings.Contains(name, "/") {
+		return errdefs.Validationf(
+			"resource graph: external node %q must be a non-empty resource name without '/'", name)
+	}
+	if _, dup := g.nodes[name]; dup {
+		return errdefs.Conflictf(
+			"resource graph: external node %q duplicates a resource", name)
+	}
+	if _, dup := g.external[name]; dup {
+		return errdefs.Conflictf(
+			"resource graph: duplicate external node %q", name)
+	}
+	g.external[name] = struct{}{}
 	return nil
 }
 
@@ -54,10 +83,13 @@ func (g *Graph) Validate() error {
 			return errdefs.Validationf("resource graph: node %q: %v", name, err)
 		}
 		for depName, ref := range res.Deps {
-			if _, ok := g.nodes[ref.ResourceName()]; !ok {
-				return errdefs.Validationf(
-					"resource graph: node %q dep %q references missing resource %q",
-					name, depName, ref.ResourceName())
+			refName := ref.ResourceName()
+			if _, ok := g.nodes[refName]; !ok {
+				if _, ok := g.external[refName]; !ok {
+					return errdefs.Validationf(
+						"resource graph: node %q dep %q references missing resource %q",
+						name, depName, refName)
+				}
 			}
 		}
 	}
@@ -82,7 +114,10 @@ func (g *Graph) TopoOrder() ([]string, error) {
 				dependents[ref.ResourceName()], name)
 		}
 	}
-	ready := make([]string, 0, len(g.nodes))
+	ready := make([]string, 0, len(g.nodes)+len(g.external))
+	for name := range g.external {
+		ready = append(ready, name)
+	}
 	for name, degree := range indegree {
 		if degree == 0 {
 			ready = append(ready, name)
@@ -93,6 +128,16 @@ func (g *Graph) TopoOrder() ([]string, error) {
 	for len(ready) > 0 {
 		name := ready[0]
 		ready = ready[1:]
+		if _, external := g.external[name]; external {
+			for _, dependent := range dependents[name] {
+				indegree[dependent]--
+				if indegree[dependent] == 0 {
+					ready = append(ready, dependent)
+					sort.Strings(ready)
+				}
+			}
+			continue
+		}
 		order = append(order, name)
 		for _, dependent := range dependents[name] {
 			indegree[dependent]--
@@ -121,6 +166,9 @@ func (g *Graph) findCycle() []string {
 		stack = append(stack, name)
 		for _, ref := range g.nodes[name].Deps {
 			next := ref.ResourceName()
+			if _, external := g.external[next]; external {
+				continue
+			}
 			switch state[next] {
 			case gray:
 				// Found a cycle: cut the stack at next.

--- a/core/resource/dag_test.go
+++ b/core/resource/dag_test.go
@@ -81,3 +81,50 @@ func TestGraphDuplicateNode(t *testing.T) {
 		t.Fatalf("duplicate Add error = %v, want conflict", err)
 	}
 }
+
+func TestGraphExternalLeafResolvesDepsWithoutEnteringOrder(t *testing.T) {
+	g := NewGraph()
+	if err := g.AddExternal("db"); err != nil {
+		t.Fatalf("AddExternal: %v", err)
+	}
+	if err := g.Add("consumer", resourceWithDeps(Deps{"db": "db"})); err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+	order, err := g.TopoOrder()
+	if err != nil {
+		t.Fatalf("TopoOrder: %v", err)
+	}
+	if len(order) != 1 || order[0] != "consumer" {
+		t.Fatalf("TopoOrder = %v, want [consumer] only", order)
+	}
+}
+
+func TestGraphExternalDuplicateAndResourceCollision(t *testing.T) {
+	g := NewGraph()
+	if err := g.AddExternal("db"); err != nil {
+		t.Fatalf("AddExternal: %v", err)
+	}
+	if err := g.AddExternal("db"); !errdefs.IsConflict(err) {
+		t.Fatalf("duplicate AddExternal error = %v, want conflict", err)
+	}
+	if err := g.Add("db", resourceWithDeps(nil)); !errdefs.IsConflict(err) {
+		t.Fatalf("Add over external error = %v, want conflict", err)
+	}
+
+	other := NewGraph()
+	if err := other.Add("db", resourceWithDeps(nil)); err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+	if err := other.AddExternal("db"); !errdefs.IsConflict(err) {
+		t.Fatalf("AddExternal over resource error = %v, want conflict", err)
+	}
+}
+
+func TestGraphExternalInvalidName(t *testing.T) {
+	g := NewGraph()
+	for _, name := range []string{"", "db/item", "  "} {
+		if err := g.AddExternal(name); !errdefs.IsValidation(err) {
+			t.Fatalf("AddExternal(%q) error = %v, want validation", name, err)
+		}
+	}
+}

--- a/core/runtime/builder.go
+++ b/core/runtime/builder.go
@@ -40,6 +40,7 @@ type Builder struct {
 	hostDecorator       HostFactoryDecorator
 	resultHostDecorator ResultHostFactoryDecorator
 	loader              *resource.Loader
+	externalResources   []ExternalResource
 }
 
 // NewBuilder creates a Runtime builder over a resource registry. The
@@ -115,6 +116,38 @@ func (b *Builder) WithLoader(loader *resource.Loader) error {
 	return nil
 }
 
+// WithExternalResource injects one caller-owned dependency value. The
+// name and contract must be declared in the deployment document's
+// runtime.external_deps before Build. It is rejected after Build
+// starts.
+func (b *Builder) WithExternalResource(ext ExternalResource) error {
+	return b.withExternalResources([]ExternalResource{ext})
+}
+
+// WithExternalResources injects caller-owned dependency values. See
+// WithExternalResource.
+func (b *Builder) WithExternalResources(externals []ExternalResource) error {
+	return b.withExternalResources(externals)
+}
+
+func (b *Builder) withExternalResources(externals []ExternalResource) error {
+	if b == nil {
+		return errdefs.Validationf("runtime Builder is nil")
+	}
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if b.used {
+		return ErrBuilderUsed
+	}
+	for _, ext := range externals {
+		if err := ext.Validate(); err != nil {
+			return err
+		}
+		b.externalResources = append(b.externalResources, ext)
+	}
+	return nil
+}
+
 // Build constructs one fully started Runtime. A Builder may be used for
 // exactly one Build attempt.
 func (b *Builder) Build(ctx context.Context, doc deploy.Document) (*Runtime, error) {
@@ -144,9 +177,26 @@ func (b *Builder) Build(ctx context.Context, doc deploy.Document) (*Runtime, err
 		return nil, err
 	}
 
-	deployBuilder := deploy.NewBuilder(reg)
+	injected, err := validateExternalResourceList(b.externalResources)
+	if err != nil {
+		return nil, err
+	}
+	effective, err := effectiveExternalResources(cfg.ExternalDeps, injected, false)
+	if err != nil {
+		return nil, err
+	}
+	var deployOptions []deploy.BuilderOption
+	if len(effective) > 0 {
+		deployValues := make([]deploy.ExternalResource, 0, len(effective))
+		for _, ext := range effective {
+			deployValues = append(deployValues, toDeployExternalResource(ext))
+		}
+		deployOptions = append(deployOptions, deploy.WithExternalResources(deployValues))
+	}
+	deployBuilder := deploy.NewBuilder(reg, deployOptions...)
 	if b.loader != nil {
-		deployBuilder = deploy.NewBuilder(reg, deploy.WithLoader(b.loader))
+		deployOptions = append(deployOptions, deploy.WithLoader(b.loader))
+		deployBuilder = deploy.NewBuilder(reg, deployOptions...)
 	}
 	result, err := deployBuilder.Deploy(ctx, doc)
 	if err != nil {
@@ -274,6 +324,7 @@ func (b *Builder) Build(ctx context.Context, doc deploy.Document) (*Runtime, err
 		hostDecorator:       b.hostDecorator,
 		resultHostDecorator: b.resultHostDecorator,
 		current:             initial,
+		externalResources:   injected,
 		nextGenID:           1,
 	}, nil
 }

--- a/core/runtime/config.go
+++ b/core/runtime/config.go
@@ -36,6 +36,9 @@ type Config struct {
 	// Sessions configures the runtime-owned session manager.
 	Sessions       SessionConfig
 	DynamicCatalog *DynamicCatalogConfig
+	// ExternalDeps declares caller-owned dependency values that the
+	// application injects through Builder.WithExternalResource.
+	ExternalDeps []ExternalDependency
 }
 
 // SessionConfig configures the runtime-owned session manager.
@@ -63,6 +66,12 @@ type configWire struct {
 	CheckpointStore string                    `json:"checkpoint_store,omitempty"`
 	Sessions        sessionConfigWire         `json:"sessions,omitempty"`
 	DynamicCatalog  *dynamicCatalogConfigWire `json:"dynamic_catalog,omitempty"`
+	ExternalDeps    []externalDependencyWire  `json:"external_deps,omitempty"`
+}
+
+type externalDependencyWire struct {
+	Name     string `json:"name"`
+	Contract string `json:"contract"`
 }
 
 type sessionConfigWire struct {
@@ -183,6 +192,38 @@ func DecodeConfig(ctx context.Context, doc deploy.Document) (Config, error) {
 				return Config{}, errdefs.Validationf(
 					"runtime config: dynamic_catalog.tools[%q] has an empty tool resource",
 					agentID)
+			}
+		}
+	}
+	for _, dep := range wire.ExternalDeps {
+		cfg.ExternalDeps = append(cfg.ExternalDeps, ExternalDependency{
+			Name:     strings.TrimSpace(dep.Name),
+			Contract: strings.TrimSpace(dep.Contract),
+		})
+	}
+	if _, err := validateExternalDependencyList(cfg.ExternalDeps); err != nil {
+		return Config{}, err
+	}
+	externalNames := make(map[string]struct{}, len(cfg.ExternalDeps))
+	for _, dep := range cfg.ExternalDeps {
+		externalNames[dep.Name] = struct{}{}
+	}
+	if _, reserved := externalNames[cfg.EventBus]; reserved {
+		return Config{}, errdefs.Validationf(
+			"runtime config: event_bus %q cannot be an external dependency",
+			cfg.EventBus)
+	}
+	if _, reserved := externalNames[cfg.CheckpointStore]; cfg.CheckpointStore != "" && reserved {
+		return Config{}, errdefs.Validationf(
+			"runtime config: checkpoint_store %q cannot be an external dependency",
+			cfg.CheckpointStore)
+	}
+	if cfg.DynamicCatalog != nil {
+		for agentID, resourceName := range cfg.DynamicCatalog.Tools {
+			if _, reserved := externalNames[resourceName]; reserved {
+				return Config{}, errdefs.Validationf(
+					"runtime config: dynamic_catalog.tools[%q] resource %q cannot be an external dependency",
+					agentID, resourceName)
 			}
 		}
 	}

--- a/core/runtime/config_test.go
+++ b/core/runtime/config_test.go
@@ -237,3 +237,59 @@ func TestDecodeConfigRejectsUnknownSessionField(t *testing.T) {
 		t.Fatalf("DecodeConfig error = %v, want unknown field mention", err)
 	}
 }
+
+func TestDecodeConfigExternalDeps(t *testing.T) {
+	t.Run("valid", func(t *testing.T) {
+		doc := parseRuntimeDocument(t, `  event_bus: events
+  external_deps:
+    - name: db
+      contract: db.Pool
+    - name: cache
+      contract: cache.Client
+`)
+		cfg, err := DecodeConfig(context.Background(), doc)
+		if err != nil {
+			t.Fatalf("DecodeConfig: %v", err)
+		}
+		if len(cfg.ExternalDeps) != 2 ||
+			cfg.ExternalDeps[0] != (ExternalDependency{Name: "db", Contract: "db.Pool"}) ||
+			cfg.ExternalDeps[1] != (ExternalDependency{Name: "cache", Contract: "cache.Client"}) {
+			t.Fatalf("ExternalDeps = %#v", cfg.ExternalDeps)
+		}
+	})
+
+	for name, runtimeYAML := range map[string]string{
+		"missing contract": `  event_bus: events
+  external_deps:
+    - name: db
+`,
+		"duplicate": `  event_bus: events
+  external_deps:
+    - {name: db, contract: db.Pool}
+    - {name: db, contract: db.Other}
+`,
+		"event bus conflict": `  event_bus: events
+  external_deps:
+    - {name: events, contract: event.Bus}
+`,
+		"checkpoint conflict": `  event_bus: events
+  checkpoint_store: cps
+  external_deps:
+    - {name: cps, contract: checkpoint.Store}
+`,
+		"dynamic catalog conflict": `  event_bus: events
+  external_deps:
+    - {name: tools, contract: tool.Assembly}
+  dynamic_catalog:
+    tools:
+      bot: tools
+`,
+	} {
+		t.Run(name, func(t *testing.T) {
+			doc := parseRuntimeDocument(t, runtimeYAML)
+			if _, err := DecodeConfig(context.Background(), doc); err == nil {
+				t.Fatal("DecodeConfig unexpectedly succeeded")
+			}
+		})
+	}
+}

--- a/core/runtime/external.go
+++ b/core/runtime/external.go
@@ -1,0 +1,144 @@
+package runtime
+
+import (
+	"strings"
+
+	"github.com/GizClaw/flowcraft/core/deploy"
+	"github.com/GizClaw/flowcraft/core/errdefs"
+)
+
+// ExternalDependency declares one caller-owned dependency in the
+// runtime section of a deployment document.
+type ExternalDependency struct {
+	// Name is the resource-ref name used in document deps, e.g. "db".
+	Name string `json:"name"`
+	// Contract is the expected DepSpec.Type of consuming factories,
+	// e.g. "db.Pool".
+	Contract string `json:"contract"`
+}
+
+// Validate checks one external dependency declaration.
+func (d ExternalDependency) Validate() error {
+	d.Name = strings.TrimSpace(d.Name)
+	d.Contract = strings.TrimSpace(d.Contract)
+	if d.Name == "" || strings.Contains(d.Name, "/") {
+		return errdefs.Validationf(
+			"runtime external_deps: name must be non-empty and must not contain '/'")
+	}
+	if d.Contract == "" {
+		return errdefs.Validationf(
+			"runtime external_deps: %q contract is required", d.Name)
+	}
+	return nil
+}
+
+// ExternalResource pairs one external dependency declaration with the
+// caller-owned value that satisfies it.
+type ExternalResource struct {
+	ExternalDependency
+	Value any
+}
+
+// Validate checks the declaration and rejects nil values.
+func (e ExternalResource) Validate() error {
+	if err := e.ExternalDependency.Validate(); err != nil {
+		return err
+	}
+	if e.Value == nil || isNil(e.Value) {
+		return errdefs.Validationf(
+			"runtime external_deps: %q value is required", e.Name)
+	}
+	return nil
+}
+
+func toDeployExternalResource(e ExternalResource) deploy.ExternalResource {
+	return deploy.ExternalResource{
+		External: deploy.External{
+			Name:     strings.TrimSpace(e.Name),
+			Contract: strings.TrimSpace(e.Contract),
+		},
+		Value: e.Value,
+	}
+}
+
+// validateExternalDependencyList validates declarations and rejects
+// duplicates.
+func validateExternalDependencyList(
+	deps []ExternalDependency,
+) (map[string]ExternalDependency, error) {
+	out := make(map[string]ExternalDependency, len(deps))
+	for _, dep := range deps {
+		dep.Name = strings.TrimSpace(dep.Name)
+		dep.Contract = strings.TrimSpace(dep.Contract)
+		if err := dep.Validate(); err != nil {
+			return nil, err
+		}
+		if _, dup := out[dep.Name]; dup {
+			return nil, errdefs.Conflictf(
+				"runtime external_deps: duplicate dependency %q", dep.Name)
+		}
+		out[dep.Name] = dep
+	}
+	return out, nil
+}
+
+// validateExternalResourceList validates injected values and rejects
+// duplicates.
+func validateExternalResourceList(
+	externals []ExternalResource,
+) (map[string]ExternalResource, error) {
+	out := make(map[string]ExternalResource, len(externals))
+	for _, ext := range externals {
+		ext.Name = strings.TrimSpace(ext.Name)
+		ext.Contract = strings.TrimSpace(ext.Contract)
+		if err := ext.Validate(); err != nil {
+			return nil, err
+		}
+		if _, dup := out[ext.Name]; dup {
+			return nil, errdefs.Conflictf(
+				"runtime external_deps: duplicate injected resource %q", ext.Name)
+		}
+		out[ext.Name] = ext
+	}
+	return out, nil
+}
+
+// effectiveExternalResources validates that every declaration is
+// covered by an injected value. injected is the set of available
+// injected resources; values not declared are allowed when allowExtra
+// is true (Reload may shrink the declaration set).
+func effectiveExternalResources(
+	declared []ExternalDependency,
+	injected map[string]ExternalResource,
+	allowExtra bool,
+) ([]ExternalResource, error) {
+	declaredMap, err := validateExternalDependencyList(declared)
+	if err != nil {
+		return nil, err
+	}
+	if !allowExtra {
+		for name := range injected {
+			if _, ok := declaredMap[name]; !ok {
+				return nil, errdefs.Validationf(
+					"runtime external_deps: injected resource %q is not declared in runtime config",
+					name)
+			}
+		}
+	}
+	out := make([]ExternalResource, 0, len(declaredMap))
+	for name, dep := range declaredMap {
+		ext, ok := injected[name]
+		if !ok {
+			return nil, errdefs.Validationf(
+				"runtime external_deps: %q is declared but no external resource was injected",
+				name)
+		}
+		if ext.Contract != dep.Contract {
+			return nil, errdefs.Validationf(
+				"runtime external_deps: %q contract %q does not match declared contract %q",
+				name, ext.Contract, dep.Contract)
+		}
+		out = append(out, ext)
+	}
+	return out, nil
+}

--- a/core/runtime/external_test.go
+++ b/core/runtime/external_test.go
@@ -1,0 +1,462 @@
+package runtime
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/GizClaw/flowcraft/core/agent"
+	"github.com/GizClaw/flowcraft/core/deploy"
+	"github.com/GizClaw/flowcraft/core/errdefs"
+	"github.com/GizClaw/flowcraft/core/event"
+	"github.com/GizClaw/flowcraft/core/resource"
+)
+
+type runtimeExternalPool struct {
+	closes int
+}
+
+func (p *runtimeExternalPool) Close() error {
+	p.closes++
+	return nil
+}
+
+type runtimeExternalConsumer struct {
+	pool   *runtimeExternalPool
+	closed bool
+}
+
+func (c *runtimeExternalConsumer) Close() error {
+	c.closed = true
+	return nil
+}
+
+type runtimeExternalConsumerFactory struct{}
+
+func (runtimeExternalConsumerFactory) Spec() resource.Spec {
+	return resource.Spec{
+		Kind: "test.ExternalConsumer",
+		Impl: "runtime",
+		Deps: []resource.DepSpec{{
+			Name: "db", Type: "db.Pool", Required: true,
+		}},
+	}
+}
+
+func (runtimeExternalConsumerFactory) New(_ context.Context, in resource.Input) (any, error) {
+	value, ok := in.Dep("db")
+	if !ok {
+		return nil, errdefs.Validationf("consumer: db dep missing")
+	}
+	pool, ok := value.(*runtimeExternalPool)
+	if !ok {
+		return nil, errdefs.Validationf("consumer: db dep has wrong type")
+	}
+	return &runtimeExternalConsumer{pool: pool}, nil
+}
+
+type runtimeExternalEngineFactory struct{}
+
+func (runtimeExternalEngineFactory) Spec() resource.Spec {
+	return resource.Spec{
+		Kind: "test.ExternalEngine",
+		Impl: "runtime",
+		Deps: []resource.DepSpec{{
+			Name: "db", Type: "db.Pool", Required: true,
+		}},
+	}
+}
+
+func (runtimeExternalEngineFactory) New(_ context.Context, in resource.Input) (any, error) {
+	value, ok := in.Dep("db")
+	if !ok {
+		return nil, errdefs.Validationf("engine: db dep missing")
+	}
+	if _, ok := value.(*runtimeExternalPool); !ok {
+		return nil, errdefs.Validationf("engine: db dep has wrong type")
+	}
+	return agent.EngineFunc(func(
+		ctx context.Context,
+		run agent.Run,
+		host agent.Host,
+		board *agent.Board,
+	) (*agent.Board, error) {
+		_ = publishRunEvent(ctx, host, agent.SubjectRunStart(run.RunID), run)
+		_ = publishRunEvent(ctx, host, agent.SubjectRunEnd(run.RunID), run)
+		return board, nil
+	}), nil
+}
+
+func runtimeExternalDoc(t *testing.T, declare bool) deploy.Document {
+	t.Helper()
+	external := ""
+	if declare {
+		external = `  external_deps:
+    - name: db
+      contract: db.Pool
+`
+	}
+	return parseRuntimeDoc(t, `version: v1
+resources:
+  events: {kind: event.Bus, impl: memory}
+  consumer:
+    kind: test.ExternalConsumer
+    impl: runtime
+    deps:
+      db: db
+agents:
+  bot:
+    card: {name: Bot}
+    engine: {kind: agent.Engine, impl: test}
+runtime:
+  event_bus: events
+  sessions: {idle_timeout: 1h, sink_buffer: 8}
+`+external)
+}
+
+func runtimeExternalBareDoc(t *testing.T) deploy.Document {
+	t.Helper()
+	return parseRuntimeDoc(t, `version: v1
+resources:
+  events: {kind: event.Bus, impl: memory}
+agents:
+  bot:
+    card: {name: Bot}
+    engine: {kind: agent.Engine, impl: test}
+runtime:
+  event_bus: events
+  sessions: {idle_timeout: 1h, sink_buffer: 8}
+  external_deps:
+    - name: db
+      contract: db.Pool
+`)
+}
+
+func newRuntimeExternalRegistry(t *testing.T) *resource.Registry {
+	t.Helper()
+	reg := resource.NewRegistry()
+	reg.MustRegister(testEngineFactory{engine: simpleRunEngine()})
+	reg.MustRegister(event.NewFactory())
+	reg.MustRegister(runtimeExternalConsumerFactory{})
+	reg.MustRegister(runtimeExternalEngineFactory{})
+	return reg
+}
+
+func buildRuntimeExternal(
+	t *testing.T,
+	doc deploy.Document,
+	pool *runtimeExternalPool,
+) *Runtime {
+	t.Helper()
+	builder := NewBuilder(newRuntimeExternalRegistry(t))
+	if err := builder.WithExternalResource(ExternalResource{
+		ExternalDependency: ExternalDependency{Name: "db", Contract: "db.Pool"},
+		Value:              pool,
+	}); err != nil {
+		t.Fatalf("WithExternalResource: %v", err)
+	}
+	app, err := builder.Build(context.Background(), doc)
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	return app
+}
+
+func TestRuntimeExternalResourceInjectedAsDependencyAndUnmanaged(t *testing.T) {
+	pool := &runtimeExternalPool{}
+	app := buildRuntimeExternal(t, runtimeExternalDoc(t, true), pool)
+
+	value, ok := app.Resource("consumer")
+	if !ok {
+		t.Fatalf("Resource(consumer) missing")
+	}
+	consumer := value.(*runtimeExternalConsumer)
+	if consumer.pool != pool {
+		t.Fatal("consumer did not receive the injected external pool")
+	}
+	if _, ok := app.Resource("db"); ok {
+		t.Fatal("Resource(db) exposed the external dependency")
+	}
+
+	if err := app.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	if pool.closes != 0 {
+		t.Fatalf("external pool was closed %d times", pool.closes)
+	}
+	if !consumer.closed {
+		t.Fatal("managed consumer was not closed")
+	}
+}
+
+func TestRuntimeExternalResourceSurvivesReload(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	pool := &runtimeExternalPool{}
+	doc := runtimeExternalDoc(t, true)
+	app := buildRuntimeExternal(t, doc, pool)
+
+	if _, err := app.Reload(ctx, doc); err != nil {
+		t.Fatalf("Reload: %v", err)
+	}
+	value, ok := app.Resource("consumer")
+	if !ok {
+		t.Fatalf("Resource(consumer) missing after reload")
+	}
+	if consumer := value.(*runtimeExternalConsumer); consumer.pool != pool {
+		t.Fatal("reloaded consumer did not receive the same external pool")
+	}
+	if _, ok := app.Resource("db"); ok {
+		t.Fatal("Resource(db) exposed the external dependency after reload")
+	}
+
+	if err := app.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	if pool.closes != 0 {
+		t.Fatalf("external pool was closed %d times across reload", pool.closes)
+	}
+}
+
+func TestRuntimeExternalResourceReloadCanDropDeclaration(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	pool := &runtimeExternalPool{}
+	app := buildRuntimeExternal(t, runtimeExternalDoc(t, true), pool)
+
+	dropDoc := parseRuntimeDoc(t, `version: v1
+resources:
+  events: {kind: event.Bus, impl: memory}
+agents:
+  bot:
+    card: {name: Bot}
+    engine: {kind: agent.Engine, impl: test}
+runtime:
+  event_bus: events
+  sessions: {idle_timeout: 1h, sink_buffer: 8}
+`)
+	if _, err := app.Reload(ctx, dropDoc); err != nil {
+		t.Fatalf("Reload dropping external declaration: %v", err)
+	}
+	if _, ok := app.Resource("consumer"); ok {
+		t.Fatal("old consumer leaked into the new generation")
+	}
+	if err := app.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	if pool.closes != 0 {
+		t.Fatalf("external pool was closed %d times after declaration was dropped", pool.closes)
+	}
+}
+
+func TestRuntimeExternalResourceDeclarationMismatch(t *testing.T) {
+	t.Run("declared but not injected", func(t *testing.T) {
+		builder := NewBuilder(newRuntimeExternalRegistry(t))
+		_, err := builder.Build(context.Background(), runtimeExternalDoc(t, true))
+		if err == nil || !strings.Contains(err.Error(), "declared but no external resource was injected") {
+			t.Fatalf("Build error = %v, want missing injection", err)
+		}
+	})
+
+	t.Run("injected but not declared", func(t *testing.T) {
+		builder := NewBuilder(newRuntimeExternalRegistry(t))
+		if err := builder.WithExternalResource(ExternalResource{
+			ExternalDependency: ExternalDependency{Name: "db", Contract: "db.Pool"},
+			Value:              &runtimeExternalPool{},
+		}); err != nil {
+			t.Fatalf("WithExternalResource: %v", err)
+		}
+		_, err := builder.Build(context.Background(), runtimeExternalDoc(t, false))
+		if err == nil || !strings.Contains(err.Error(), "is not declared in runtime config") {
+			t.Fatalf("Build error = %v, want undeclared injection", err)
+		}
+	})
+}
+
+func TestRuntimeExternalResourceReloadMissingInjectionRollsBack(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	pool := &runtimeExternalPool{}
+	app := buildRuntimeExternal(t, runtimeExternalDoc(t, true), pool)
+
+	reloadDoc := parseRuntimeDoc(t, `version: v1
+resources:
+  events: {kind: event.Bus, impl: memory}
+  consumer:
+    kind: test.ExternalConsumer
+    impl: runtime
+    deps:
+      db: db
+agents:
+  bot:
+    card: {name: Bot}
+    engine: {kind: agent.Engine, impl: test}
+runtime:
+  event_bus: events
+  sessions: {idle_timeout: 1h, sink_buffer: 8}
+  external_deps:
+    - name: db
+      contract: db.Pool
+    - name: cache
+      contract: cache.Client
+`)
+	if _, err := app.Reload(ctx, reloadDoc); err == nil ||
+		!strings.Contains(err.Error(), "declared but no external resource was injected") {
+		t.Fatalf("Reload error = %v, want missing injection", err)
+	}
+	value, ok := app.Resource("consumer")
+	if !ok || value.(*runtimeExternalConsumer).pool != pool {
+		t.Fatal("old generation stopped serving after failed reload")
+	}
+	if err := app.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	if pool.closes != 0 {
+		t.Fatalf("external pool was closed %d times after failed reload", pool.closes)
+	}
+}
+
+func TestRuntimeExternalResourceDynamicAgentDependency(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	pool := &runtimeExternalPool{}
+	doc := runtimeExternalDoc(t, true)
+	app := buildRuntimeExternal(t, doc, pool)
+
+	if _, err := app.RegisterAgent(ctx, "dyn", agent.Definition{
+		Card: agent.AgentCard{Name: "Dyn"},
+		Engine: agent.EngineRef{
+			Kind: "test.ExternalEngine",
+			Impl: "runtime",
+			Deps: resource.Deps{"db": "db"},
+		},
+	}); err != nil {
+		t.Fatalf("RegisterAgent: %v", err)
+	}
+	if result := runTurn(t, app.Sessions(), "dyn", "conv"); result.Status != agent.StatusCompleted {
+		t.Fatalf("dynamic turn status = %q", result.Status)
+	}
+
+	// Dynamic agents are re-bound against the new Result on Reload and
+	// must still resolve the same external dependency.
+	if _, err := app.Reload(ctx, doc); err != nil {
+		t.Fatalf("Reload: %v", err)
+	}
+	if result := runTurn(t, app.Sessions(), "dyn", "conv2"); result.Status != agent.StatusCompleted {
+		t.Fatalf("dynamic turn after reload status = %q", result.Status)
+	}
+
+	if err := app.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	if pool.closes != 0 {
+		t.Fatalf("external pool was closed %d times", pool.closes)
+	}
+}
+
+func TestRuntimeExternalResourceDeclarationAloneSupportsDynamicAgent(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	pool := &runtimeExternalPool{}
+	app := buildRuntimeExternal(t, runtimeExternalBareDoc(t), pool)
+
+	if _, err := app.RegisterAgent(ctx, "dyn", agent.Definition{
+		Card: agent.AgentCard{Name: "Dyn"},
+		Engine: agent.EngineRef{
+			Kind: "test.ExternalEngine",
+			Impl: "runtime",
+			Deps: resource.Deps{"db": "db"},
+		},
+	}); err != nil {
+		t.Fatalf("RegisterAgent: %v", err)
+	}
+	if result := runTurn(t, app.Sessions(), "dyn", "conv"); result.Status != agent.StatusCompleted {
+		t.Fatalf("dynamic turn status = %q", result.Status)
+	}
+	if _, ok := app.Resource("consumer"); ok {
+		t.Fatal("bare external document exposed a managed consumer")
+	}
+	if err := app.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	if pool.closes != 0 {
+		t.Fatalf("external pool was closed %d times", pool.closes)
+	}
+}
+
+func TestRuntimeExternalResourceBuilderValidation(t *testing.T) {
+	t.Run("invalid resource", func(t *testing.T) {
+		var typedNil *runtimeExternalPool
+		tests := []ExternalResource{
+			{ExternalDependency: ExternalDependency{Contract: "db.Pool"}, Value: &runtimeExternalPool{}},
+			{ExternalDependency: ExternalDependency{Name: "db/item", Contract: "db.Pool"}, Value: &runtimeExternalPool{}},
+			{ExternalDependency: ExternalDependency{Name: "db"}, Value: &runtimeExternalPool{}},
+			{ExternalDependency: ExternalDependency{Name: "db", Contract: "db.Pool"}, Value: nil},
+			{ExternalDependency: ExternalDependency{Name: "db", Contract: "db.Pool"}, Value: typedNil},
+		}
+		for _, ext := range tests {
+			if err := ext.Validate(); !errdefs.IsValidation(err) {
+				t.Fatalf("Validate(%#v) error = %v, want validation", ext, err)
+			}
+		}
+	})
+
+	t.Run("plural and used builder", func(t *testing.T) {
+		builder := NewBuilder(newRuntimeExternalRegistry(t))
+		if err := builder.WithExternalResources([]ExternalResource{{
+			ExternalDependency: ExternalDependency{Name: "db", Contract: "db.Pool"},
+			Value:              &runtimeExternalPool{},
+		}}); err != nil {
+			t.Fatalf("WithExternalResources: %v", err)
+		}
+		app, err := builder.Build(context.Background(), runtimeExternalDoc(t, true))
+		if err != nil {
+			t.Fatalf("Build: %v", err)
+		}
+		defer func() { _ = app.Close() }()
+
+		if err := builder.WithExternalResource(ExternalResource{
+			ExternalDependency: ExternalDependency{Name: "other", Contract: "other.Client"},
+			Value:              &runtimeExternalPool{},
+		}); !errors.Is(err, ErrBuilderUsed) {
+			t.Fatalf("WithExternalResource after Build error = %v, want ErrBuilderUsed", err)
+		}
+	})
+
+	t.Run("duplicate injection", func(t *testing.T) {
+		builder := NewBuilder(newRuntimeExternalRegistry(t))
+		for range 2 {
+			if err := builder.WithExternalResource(ExternalResource{
+				ExternalDependency: ExternalDependency{Name: "db", Contract: "db.Pool"},
+				Value:              &runtimeExternalPool{},
+			}); err != nil {
+				t.Fatalf("WithExternalResource: %v", err)
+			}
+		}
+		_, err := builder.Build(context.Background(), runtimeExternalDoc(t, true))
+		if err == nil || !strings.Contains(err.Error(), "duplicate injected resource") {
+			t.Fatalf("Build error = %v, want duplicate injection", err)
+		}
+	})
+
+	t.Run("contract mismatch", func(t *testing.T) {
+		builder := NewBuilder(newRuntimeExternalRegistry(t))
+		if err := builder.WithExternalResource(ExternalResource{
+			ExternalDependency: ExternalDependency{Name: "db", Contract: "cache.Client"},
+			Value:              &runtimeExternalPool{},
+		}); err != nil {
+			t.Fatalf("WithExternalResource: %v", err)
+		}
+		_, err := builder.Build(context.Background(), runtimeExternalDoc(t, true))
+		if err == nil || !strings.Contains(err.Error(), "does not match declared contract") {
+			t.Fatalf("Build error = %v, want contract mismatch", err)
+		}
+	})
+}

--- a/core/runtime/reload.go
+++ b/core/runtime/reload.go
@@ -113,10 +113,23 @@ func (r *Runtime) Reload(
 	}
 
 	// Build the new deployment result transactionally.
-	deployBuilder := deploy.NewBuilder(r.resources)
+	effective, err := effectiveExternalResources(
+		cfg.ExternalDeps, r.externalResources, true)
+	if err != nil {
+		return fail(err)
+	}
+	var deployOptions []deploy.BuilderOption
+	if len(effective) > 0 {
+		deployValues := make([]deploy.ExternalResource, 0, len(effective))
+		for _, ext := range effective {
+			deployValues = append(deployValues, toDeployExternalResource(ext))
+		}
+		deployOptions = append(deployOptions, deploy.WithExternalResources(deployValues))
+	}
+	deployBuilder := deploy.NewBuilder(r.resources, deployOptions...)
 	if r.loader != nil {
-		deployBuilder = deploy.NewBuilder(
-			r.resources, deploy.WithLoader(r.loader))
+		deployOptions = append(deployOptions, deploy.WithLoader(r.loader))
+		deployBuilder = deploy.NewBuilder(r.resources, deployOptions...)
 	}
 	newResult, err := deployBuilder.Deploy(ctx, doc)
 	if err != nil {

--- a/core/runtime/runtime.go
+++ b/core/runtime/runtime.go
@@ -45,6 +45,10 @@ type Runtime struct {
 	// current is the active deployment generation. Reload replaces it
 	// atomically; Close retires and closes it.
 	current *Generation
+	// externalResources are caller-owned dependency values injected by
+	// the Builder. They outlive every generation and are never closed
+	// by the Runtime.
+	externalResources map[string]ExternalResource
 	// nextGenID allocates generation ids.
 	nextGenID uint64
 

--- a/docs/guides/deploy.md
+++ b/docs/guides/deploy.md
@@ -172,6 +172,13 @@ can also be assembled individually at runtime via the exported
 `deploy.BindAgent` — the same path `core/runtime` uses for its live agent
 registry (see [runtime.md](runtime.md)).
 
+Caller-owned dependencies can be supplied with
+`deploy.WithExternalResources`; they are visible to dependency
+resolution but are never constructed, wired, or closed by deploy. The
+runtime layer exposes this through its `runtime.external_deps` document
+declaration and `runtime.Builder.WithExternalResource` (see
+[runtime.md](runtime.md)).
+
 ## Layered configuration
 
 `deploy.LoadLayers` loads multiple `Layer` values, merges them in ascending

--- a/docs/guides/runtime.md
+++ b/docs/guides/runtime.md
@@ -69,7 +69,60 @@ generation's values. Use this for access to deployment-built services
 such as a database pool. If the application must own a value's
 lifecycle or keep it across reloads, construct it outside the runtime
 and inject it through a resource factory registered in the registry
-instead.
+instead, or use the external dependency channel below.
+
+### External dependencies
+
+`runtime.external_deps` declares caller-owned dependency values that are
+built by the application and only consumed as resource/engine/hook
+dependencies:
+
+```yaml
+runtime:
+  event_bus: events
+  external_deps:
+    - name: db
+      contract: db.Pool
+  sessions:
+    idle_timeout: 10m
+```
+
+The application injects the matching value before building:
+
+```go
+builder := runtime.NewBuilder(reg)
+if err := builder.WithExternalResource(runtime.ExternalResource{
+    ExternalDependency: runtime.ExternalDependency{
+        Name:     "db",
+        Contract: "db.Pool",
+    },
+    Value: db,
+}); err != nil {
+    return err
+}
+app, err := builder.Build(ctx, doc)
+```
+
+Any resource, agent engine, or hook can then reference `db` in its
+`deps`; the consuming factory must declare `{name: db, type: db.Pool}`
+in its `resource.Spec.Deps` so deploy can check the contract.
+
+External values are borrowed, not owned:
+
+- They never participate in `Wire` / deployment binding, `Close`,
+  `Runtime.Drain`, or dynamic agent rebinding lifecycle.
+- They are not rebuilt or replaced by `Reload`; every generation
+  receives the same injected object.
+- They are hidden from `Runtime.Resource` and `Result.Names` — they
+  exist only as dependencies.
+- `Reload` may shrink the declared set, but may not require an external
+  value that was not injected when the Runtime was built.
+- The application is responsible for closing external values after all
+  Runtimes sharing them are closed.
+
+External dependencies cannot serve runtime-managed roles: `event_bus`,
+`checkpoint_store`, and `dynamic_catalog.tools` resource names must be
+regular deployment resources.
 
 ## Runtime config
 
@@ -77,6 +130,9 @@ instead.
 runtime:
   event_bus: events
   checkpoint_store: checkpoints   # optional
+  external_deps:                  # optional
+    - name: db
+      contract: db.Pool
   sessions:
     idle_timeout: 10m
     sink_buffer: 256


### PR DESCRIPTION
## Summary

Adds a first-class `external_deps` channel so a `core/runtime.Runtime` can accept caller-owned dependency values that are only consumed as resource/engine/hook dependencies:

- `runtime.external_deps` document declarations with `name` + `contract`
- `runtime.Builder.WithExternalResource(s)`
- `deploy.WithExternalResources` and `resource.Graph.AddExternal` as the underlying mechanism

External values are borrowed, not owned:

- never constructed, wired, deployment-bound, or closed by deploy/runtime
- never rebuilt or replaced by `Reload`; every generation receives the same injected object
- hidden from `Runtime.Resource` and `Result.Names`
- `Reload` may shrink the declared set, but may not require values that were not injected
- contract must match the consuming factory's `DepSpec.Type`
- external item refs are rejected in v1

Dynamic `RegisterAgent` engine/hook deps can also reference externals, including after Reload re-binds dynamic agents.

## Tests

- resource graph external leaf/conflict/invalid-name coverage
- deploy ownership, rollback, contract mismatch, item-ref rejection, resource/engine/hook dependency resolution
- runtime injection validation, Build/Reload semantics, declaration-only + dynamic agent use
- `make ci`, `make lint`, `make release-check`, `git diff --check` all pass
- No release changeset added