### PR TITLE
feat(core/inference): publish model max output token limits

### DIFF
--- a/core/agent/bindings/bridge_inference_test.go
+++ b/core/agent/bindings/bridge_inference_test.go
@@ -570,11 +570,13 @@ func TestInferenceBridge_RouteExplain_NoRouter(t *testing.T) {
 
 func TestInferenceBridge_Models_RoundTrip(t *testing.T) {
 	limit := 128_000
+	outputLimit := 32_768
 	fake := &inferencetest.GenerateFake{
 		Descriptor: inference.ModelDescriptor{
 			ID: inferencetest.DefaultFakeModel.ID,
 			Limits: inference.ModelLimits{
-				MaxInputTokens: &limit,
+				MaxInputTokens:  &limit,
+				MaxOutputTokens: &outputLimit,
 			},
 		},
 	}
@@ -594,7 +596,12 @@ func TestInferenceBridge_Models_RoundTrip(t *testing.T) {
 	}
 	limits, ok := descriptor["limits"].(map[string]any)
 	if !ok || limits["max_input_tokens"] != float64(limit) {
-		t.Fatalf("descriptor limits = %v, want max_input_tokens %d", descriptor["limits"], limit)
+		t.Fatalf("descriptor limits = %v, want max_input_tokens %d",
+			descriptor["limits"], limit)
+	}
+	if limits["max_output_tokens"] != float64(outputLimit) {
+		t.Fatalf("descriptor limits = %v, want max_output_tokens %d",
+			descriptor["limits"], outputLimit)
 	}
 }
 

--- a/core/inference/model.go
+++ b/core/inference/model.go
@@ -399,17 +399,25 @@ type ModelLimits struct {
 	// input context (prompt plus any prior turns). Nil when the provider
 	// catalog does not declare a limit.
 	MaxInputTokens *int `json:"max_input_tokens,omitempty"`
+	// MaxOutputTokens caps the tokens a model may emit in a single response
+	// (including reasoning tokens when the provider counts them against the
+	// same budget). Nil when the provider catalog does not declare a limit.
+	MaxOutputTokens *int `json:"max_output_tokens,omitempty"`
 }
 
 func (l ModelLimits) Clone() ModelLimits {
 	return ModelLimits{
-		MaxInputTokens: clonePointer(l.MaxInputTokens),
+		MaxInputTokens:  clonePointer(l.MaxInputTokens),
+		MaxOutputTokens: clonePointer(l.MaxOutputTokens),
 	}
 }
 
 func (l ModelLimits) Validate() error {
 	if l.MaxInputTokens != nil && *l.MaxInputTokens <= 0 {
 		return fmt.Errorf("max input tokens must be positive")
+	}
+	if l.MaxOutputTokens != nil && *l.MaxOutputTokens <= 0 {
+		return fmt.Errorf("max output tokens must be positive")
 	}
 	return nil
 }

--- a/core/inference/model_test.go
+++ b/core/inference/model_test.go
@@ -20,6 +20,12 @@ func TestModelLimitsValidate(t *testing.T) {
 	}).Validate(); err != nil {
 		t.Fatalf("positive limit: %v", err)
 	}
+	positiveOutput := 64_000
+	if err := (inference.ModelLimits{
+		MaxOutputTokens: &positiveOutput,
+	}).Validate(); err != nil {
+		t.Fatalf("positive output limit: %v", err)
+	}
 	for _, value := range []int{0, -1} {
 		limit := value
 		if err := (inference.ModelLimits{
@@ -27,36 +33,66 @@ func TestModelLimitsValidate(t *testing.T) {
 		}).Validate(); err == nil {
 			t.Fatalf("limit %d unexpectedly accepted", value)
 		}
+		if err := (inference.ModelLimits{
+			MaxOutputTokens: &limit,
+		}).Validate(); err == nil {
+			t.Fatalf("output limit %d unexpectedly accepted", value)
+		}
 	}
 }
 
-func TestModelDescriptorValidateRejectsNonPositiveInputLimit(t *testing.T) {
-	limit := 0
-	descriptor := inference.ModelDescriptor{
-		ID:         inference.ModelID{Provider: "openai", Name: "gpt-x"},
-		Operations: []inference.Operation{inference.OperationGenerate},
-		Limits:     inference.ModelLimits{MaxInputTokens: &limit},
-	}
-	if err := descriptor.Validate(); err == nil {
-		t.Fatal("non-positive max input tokens unexpectedly accepted")
+func TestModelDescriptorValidateRejectsNonPositiveLimits(t *testing.T) {
+	zero := 0
+	for _, test := range []struct {
+		name   string
+		limits inference.ModelLimits
+	}{
+		{
+			name:   "input",
+			limits: inference.ModelLimits{MaxInputTokens: &zero},
+		},
+		{
+			name:   "output",
+			limits: inference.ModelLimits{MaxOutputTokens: &zero},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			descriptor := inference.ModelDescriptor{
+				ID:         inference.ModelID{Provider: "openai", Name: "gpt-x"},
+				Operations: []inference.Operation{inference.OperationGenerate},
+				Limits:     test.limits,
+			}
+			if err := descriptor.Validate(); err == nil {
+				t.Fatalf("non-positive max %s tokens unexpectedly accepted", test.name)
+			}
+		})
 	}
 }
 
 func TestModelDescriptorClonePreservesLimits(t *testing.T) {
-	limit := 200_000
+	inputLimit := 200_000
+	outputLimit := 16_384
 	original := inference.ModelDescriptor{
 		ID:         inference.ModelID{Provider: "openai", Name: "gpt-x"},
 		Operations: []inference.Operation{inference.OperationGenerate},
 		Limits: inference.ModelLimits{
-			MaxInputTokens: &limit,
+			MaxInputTokens:  &inputLimit,
+			MaxOutputTokens: &outputLimit,
 		},
 	}
 	clone := original.Clone()
 	*clone.Limits.MaxInputTokens = 100
+	*clone.Limits.MaxOutputTokens = 200
 	if *original.Limits.MaxInputTokens != 200_000 {
 		t.Fatalf(
 			"clone shares max input tokens pointer: original = %d",
 			*original.Limits.MaxInputTokens,
+		)
+	}
+	if *original.Limits.MaxOutputTokens != 16_384 {
+		t.Fatalf(
+			"clone shares max output tokens pointer: original = %d",
+			*original.Limits.MaxOutputTokens,
 		)
 	}
 }
@@ -323,11 +359,18 @@ func TestModelDescriptorJSONLimits(t *testing.T) {
 		t.Fatalf("empty limits should be omitted, got %s", got)
 	}
 
-	limit := 128_000
-	descriptor.Limits.MaxInputTokens = &limit
+	inputLimit := 128_000
+	outputLimit := 32_768
+	descriptor.Limits.MaxInputTokens = &inputLimit
+	descriptor.Limits.MaxOutputTokens = &outputLimit
 	encoded, err = json.Marshal(descriptor)
 	if err != nil {
 		t.Fatalf("marshal limits: %v", err)
+	}
+	for _, tag := range []string{`"max_input_tokens"`, `"max_output_tokens"`} {
+		if !strings.Contains(string(encoded), tag) {
+			t.Fatalf("encoded limits %s missing %s", encoded, tag)
+		}
 	}
 	var decoded struct {
 		Limits inference.ModelLimits `json:"limits"`
@@ -336,7 +379,12 @@ func TestModelDescriptorJSONLimits(t *testing.T) {
 		t.Fatalf("unmarshal limits: %v", err)
 	}
 	if decoded.Limits.MaxInputTokens == nil ||
-		*decoded.Limits.MaxInputTokens != 128_000 {
-		t.Fatalf("decoded limits = %+v, want max_input_tokens 128000", decoded.Limits)
+		*decoded.Limits.MaxInputTokens != inputLimit ||
+		decoded.Limits.MaxOutputTokens == nil ||
+		*decoded.Limits.MaxOutputTokens != outputLimit {
+		t.Fatalf(
+			"decoded limits = %+v, want max_input_tokens %d max_output_tokens %d",
+			decoded.Limits, inputLimit, outputLimit,
+		)
 	}
 }

--- a/driver/anthropic/catalog.go
+++ b/driver/anthropic/catalog.go
@@ -21,6 +21,11 @@ type catalogEntry struct {
 	// in tokens; zero means undeclared. Values mirror the context window
 	// published on https://platform.claude.com/docs/en/about-claude/models.
 	maxInputTokens int
+	// maxOutputTokens caps the tokens a single response may emit
+	// (thinking plus answer tokens share the budget); zero means
+	// undeclared. Values mirror the maximum output published on
+	// https://platform.claude.com/docs/en/about-claude/models.
+	maxOutputTokens int
 }
 
 // validate enforces the generate family contract: Claude compilers only
@@ -70,7 +75,8 @@ var catalog = map[string]catalogEntry{
 			WithInputs(message.PartImage).
 			WithReasoning(inference.ReasoningAlways).
 			WithReasoningEffortMap(claudeEffortMap),
-		maxInputTokens: 1_000_000,
+		maxInputTokens:  1_000_000,
+		maxOutputTokens: 128_000,
 	},
 	// claude-mythos-5 shares Fable 5's capabilities and always-on adaptive
 	// thinking; it is a limited-release model (Project Glasswing), so
@@ -80,35 +86,40 @@ var catalog = map[string]catalogEntry{
 			WithInputs(message.PartImage).
 			WithReasoning(inference.ReasoningAlways).
 			WithReasoningEffortMap(claudeEffortMap),
-		maxInputTokens: 1_000_000,
+		maxInputTokens:  1_000_000,
+		maxOutputTokens: 128_000,
 	},
 	"claude-opus-5": {
 		capabilities: generateChatCapabilities().
 			WithInputs(message.PartImage).
 			WithReasoning(inference.ReasoningToggle).
 			WithReasoningEffortMap(claudeEffortMap),
-		maxInputTokens: 1_000_000,
+		maxInputTokens:  1_000_000,
+		maxOutputTokens: 128_000,
 	},
 	"claude-sonnet-5": {
 		capabilities: generateChatCapabilities().
 			WithInputs(message.PartImage).
 			WithReasoning(inference.ReasoningToggle).
 			WithReasoningEffortMap(claudeEffortMap),
-		maxInputTokens: 1_000_000,
+		maxInputTokens:  1_000_000,
+		maxOutputTokens: 128_000,
 	},
 	"claude-haiku-4-5": {
 		capabilities: generateChatCapabilities().
 			WithInputs(message.PartImage).
 			WithReasoning(inference.ReasoningToggle).
 			WithReasoningEffortMap(claudeEffortMap),
-		maxInputTokens: 200_000,
+		maxInputTokens:  200_000,
+		maxOutputTokens: 64_000,
 	},
 	"claude-haiku-4-5-20251001": {
 		capabilities: generateChatCapabilities().
 			WithInputs(message.PartImage).
 			WithReasoning(inference.ReasoningToggle).
 			WithReasoningEffortMap(claudeEffortMap),
-		maxInputTokens: 200_000,
+		maxInputTokens:  200_000,
+		maxOutputTokens: 64_000,
 	},
 
 	"claude-opus-4-8": {
@@ -117,7 +128,8 @@ var catalog = map[string]catalogEntry{
 			WithReasoning(inference.ReasoningToggle).
 			WithReasoningEffortMap(claudeEffortMap),
 		deprecated: true, replacement: "claude-opus-5",
-		maxInputTokens: 1_000_000,
+		maxInputTokens:  1_000_000,
+		maxOutputTokens: 128_000,
 	},
 	"claude-opus-4-7": {
 		capabilities: generateChatCapabilities().
@@ -125,7 +137,8 @@ var catalog = map[string]catalogEntry{
 			WithReasoning(inference.ReasoningToggle).
 			WithReasoningEffortMap(claudeEffortMap),
 		deprecated: true, replacement: "claude-opus-5",
-		maxInputTokens: 1_000_000,
+		maxInputTokens:  1_000_000,
+		maxOutputTokens: 128_000,
 	},
 	"claude-sonnet-4-6": {
 		capabilities: generateChatCapabilities().
@@ -133,7 +146,8 @@ var catalog = map[string]catalogEntry{
 			WithReasoning(inference.ReasoningToggle).
 			WithReasoningEffortMap(claudeEffortMap),
 		deprecated: true, replacement: "claude-sonnet-5",
-		maxInputTokens: 1_000_000,
+		maxInputTokens:  1_000_000,
+		maxOutputTokens: 128_000,
 	},
 	"claude-sonnet-4-5": {
 		capabilities: generateChatCapabilities().
@@ -141,7 +155,8 @@ var catalog = map[string]catalogEntry{
 			WithReasoning(inference.ReasoningToggle).
 			WithReasoningEffortMap(claudeEffortMap),
 		deprecated: true, replacement: "claude-sonnet-5",
-		maxInputTokens: 200_000,
+		maxInputTokens:  200_000,
+		maxOutputTokens: 64_000,
 	},
 	"claude-opus-4-1": {
 		capabilities: generateChatCapabilities().
@@ -149,18 +164,33 @@ var catalog = map[string]catalogEntry{
 			WithReasoning(inference.ReasoningToggle).
 			WithReasoningEffortMap(claudeEffortMap),
 		deprecated: true, replacement: "claude-opus-5",
-		maxInputTokens: 200_000,
+		maxInputTokens:  200_000,
+		maxOutputTokens: 32_000,
 	},
 }
 
-// mergedCatalog overlays Spec.Models onto the built-in catalog.
+// mergedCatalog overlays Spec.Models onto the built-in catalog. A spec
+// entry with a catalog name replaces that entry, except that numeric
+// limits are inherited from the built-in entry and only replaced when the
+// declaration sets them explicitly.
 func mergedCatalog(spec Spec) (map[string]catalogEntry, error) {
 	models := make(map[string]catalogEntry, len(catalog)+len(spec.Models))
 	maps.Copy(models, catalog)
 	for _, model := range spec.Models {
-		models[model.Name] = catalogEntry{
+		entry := catalogEntry{
 			capabilities: model.Capabilities,
 		}
+		if builtin, exists := models[model.Name]; exists {
+			entry.maxInputTokens = builtin.maxInputTokens
+			entry.maxOutputTokens = builtin.maxOutputTokens
+		}
+		if model.Limits.MaxInputTokens != nil {
+			entry.maxInputTokens = *model.Limits.MaxInputTokens
+		}
+		if model.Limits.MaxOutputTokens != nil {
+			entry.maxOutputTokens = *model.Limits.MaxOutputTokens
+		}
+		models[model.Name] = entry
 	}
 	for name, entry := range models {
 		if err := entry.validate(); err != nil {

--- a/driver/anthropic/catalog_test.go
+++ b/driver/anthropic/catalog_test.go
@@ -47,6 +47,44 @@ func TestCatalogDeclaresMaxInputTokens(t *testing.T) {
 	}
 }
 
+func TestCatalogDeclaresMaxOutputTokens(t *testing.T) {
+	provider, err := buildProvider(context.Background(), ResourceSettings{ID: "anthropic"}, nil)
+	if err != nil {
+		t.Fatalf("buildProvider: %v", err)
+	}
+	descriptors := make(map[string]inference.ModelDescriptor, len(provider.Models))
+	for _, model := range provider.Models {
+		descriptors[model.Descriptor.ID.Name] = model.Descriptor
+	}
+	for name, entry := range catalog {
+		descriptor, ok := descriptors[name]
+		if !ok {
+			t.Fatalf("catalog model %q missing from provider", name)
+		}
+		if entry.maxOutputTokens <= 0 || descriptor.Limits.MaxOutputTokens == nil {
+			t.Errorf("model %q: max output tokens not declared", name)
+		}
+	}
+	checks := map[string]int{
+		"claude-fable-5":    128_000,
+		"claude-sonnet-5":   128_000,
+		"claude-haiku-4-5":  64_000,
+		"claude-sonnet-4-6": 128_000,
+		"claude-opus-4-1":   32_000,
+	}
+	for name, want := range checks {
+		descriptor, ok := descriptors[name]
+		if !ok {
+			t.Fatalf("model %q missing from provider", name)
+		}
+		if descriptor.Limits.MaxOutputTokens == nil ||
+			*descriptor.Limits.MaxOutputTokens != want {
+			t.Errorf("model %q: max output tokens = %v, want %d",
+				name, descriptor.Limits.MaxOutputTokens, want)
+		}
+	}
+}
+
 func TestCatalogPublishesCapabilities(t *testing.T) {
 	provider, err := buildProvider(context.Background(), ResourceSettings{ID: "anthropic"}, nil)
 	if err != nil {
@@ -81,5 +119,47 @@ func TestMergedCatalogRejectsMissingTextOutput(t *testing.T) {
 	}
 	if _, err := mergedCatalog(spec); err == nil {
 		t.Fatal("mergedCatalog unexpectedly accepted a model without text output")
+	}
+}
+
+func TestMergedCatalogOverlaysDeclaredLimits(t *testing.T) {
+	capabilities := `{"inputs":["text","data","tool_call","tool_result"],"outputs":["text"]}`
+	spec, err := decodeSpec(context.Background(), []byte(`{
+		"models": [{
+			"name": "claude-sonnet-5",
+			"capabilities": `+capabilities+`
+		}]
+	}`))
+	if err != nil {
+		t.Fatalf("decodeSpec: %v", err)
+	}
+	models, err := mergedCatalog(spec)
+	if err != nil {
+		t.Fatalf("mergedCatalog: %v", err)
+	}
+	entry := models["claude-sonnet-5"]
+	if entry.maxInputTokens != 1_000_000 || entry.maxOutputTokens != 128_000 {
+		t.Fatalf("redeclared limits = %d/%d, want catalog 1000000/128000",
+			entry.maxInputTokens, entry.maxOutputTokens)
+	}
+
+	spec, err = decodeSpec(context.Background(), []byte(`{
+		"models": [{
+			"name": "claude-sonnet-5",
+			"capabilities": `+capabilities+`,
+			"limits": {"max_output_tokens": 4096}
+		}]
+	}`))
+	if err != nil {
+		t.Fatalf("decodeSpec: %v", err)
+	}
+	models, err = mergedCatalog(spec)
+	if err != nil {
+		t.Fatalf("mergedCatalog: %v", err)
+	}
+	entry = models["claude-sonnet-5"]
+	if entry.maxInputTokens != 1_000_000 || entry.maxOutputTokens != 4096 {
+		t.Fatalf("overridden limits = %d/%d, want 1000000/4096",
+			entry.maxInputTokens, entry.maxOutputTokens)
 	}
 }

--- a/driver/anthropic/catalog_test.go
+++ b/driver/anthropic/catalog_test.go
@@ -163,3 +163,26 @@ func TestMergedCatalogOverlaysDeclaredLimits(t *testing.T) {
 			entry.maxInputTokens, entry.maxOutputTokens)
 	}
 }
+
+func TestMergedCatalogOverridesDeclaredInputLimit(t *testing.T) {
+	capabilities := `{"inputs":["text","data","tool_call","tool_result"],"outputs":["text"]}`
+	spec, err := decodeSpec(context.Background(), []byte(`{
+		"models": [{
+			"name": "claude-sonnet-5",
+			"capabilities": `+capabilities+`,
+			"limits": {"max_input_tokens": 65536}
+		}]
+	}`))
+	if err != nil {
+		t.Fatalf("decodeSpec: %v", err)
+	}
+	models, err := mergedCatalog(spec)
+	if err != nil {
+		t.Fatalf("mergedCatalog: %v", err)
+	}
+	entry := models["claude-sonnet-5"]
+	if entry.maxInputTokens != 65_536 || entry.maxOutputTokens != 128_000 {
+		t.Fatalf("declared input limits = %d/%d, want 65536/128000",
+			entry.maxInputTokens, entry.maxOutputTokens)
+	}
+}

--- a/driver/anthropic/resource.go
+++ b/driver/anthropic/resource.go
@@ -110,6 +110,9 @@ func buildProvider(ctx context.Context, settings ResourceSettings, secrets *reso
 		if entry.maxInputTokens > 0 {
 			descriptor.Limits.MaxInputTokens = &entry.maxInputTokens
 		}
+		if entry.maxOutputTokens > 0 {
+			descriptor.Limits.MaxOutputTokens = &entry.maxOutputTokens
+		}
 		provider.Models = append(provider.Models, inference.ModelImplementation{
 			Descriptor: descriptor,
 			Openers:    openersFor(spec, entry, profiles, id),

--- a/driver/anthropic/spec.go
+++ b/driver/anthropic/spec.go
@@ -26,6 +26,10 @@ type ModelSpec struct {
 	// Capabilities declares the model's input/output content kinds and the
 	// reasoning control capability.
 	Capabilities inference.ModelCapabilities `json:"capabilities,omitempty"`
+	// Limits declares numeric capacity limits for the model. Overriding a
+	// built-in catalog entry by name keeps the catalog limit for any field
+	// left nil; declaring a value replaces it.
+	Limits inference.ModelLimits `json:"limits,omitempty"`
 }
 
 func (s Spec) Validate() error {
@@ -49,6 +53,9 @@ func (s Spec) Validate() error {
 			return fmt.Errorf("anthropic: duplicate model %q", model.Name)
 		}
 		seen[model.Name] = true
+		if err := model.Limits.Validate(); err != nil {
+			return fmt.Errorf("anthropic: model %q: %w", model.Name, err)
+		}
 	}
 	return nil
 }

--- a/driver/azure/resource.go
+++ b/driver/azure/resource.go
@@ -97,11 +97,27 @@ func buildProvider(ctx context.Context, settings ResourceSettings, secrets *reso
 			Descriptor: inference.ModelDescriptor{
 				ID:           id,
 				Capabilities: entry.capabilities,
+				Limits:       limitsFor(model),
 			},
 			Openers: openersFor(spec, entry, profiles, id),
 		})
 	}
 	return provider, nil
+}
+
+// limitsFor copies the deployment's declared limits onto a fresh
+// descriptor so the provider definition never aliases the spec's pointers.
+func limitsFor(model ModelSpec) inference.ModelLimits {
+	var limits inference.ModelLimits
+	if model.Limits.MaxInputTokens != nil {
+		value := *model.Limits.MaxInputTokens
+		limits.MaxInputTokens = &value
+	}
+	if model.Limits.MaxOutputTokens != nil {
+		value := *model.Limits.MaxOutputTokens
+		limits.MaxOutputTokens = &value
+	}
+	return limits
 }
 
 // openersFor binds one deployment to the operation openers its kind serves,

--- a/driver/azure/resource_test.go
+++ b/driver/azure/resource_test.go
@@ -277,3 +277,81 @@ func TestSpecRejectsFamilyContractViolation(t *testing.T) {
 		t.Fatal("image deployment with text output unexpectedly accepted")
 	}
 }
+
+func TestModelLimitsPublish(t *testing.T) {
+	t.Setenv("AZURE_TEST_KEY", "sk-test")
+	value, err := Factory().New(context.Background(), resource.Input{
+		Settings: json.RawMessage(`{
+			"id": "azure",
+			"spec": {
+				"endpoint": "https://example.openai.azure.com",
+				"models": [{
+					"name": "gpt-5",
+					"kind": "generate",
+					"capabilities": {"outputs": ["text"]},
+					"limits": {
+						"max_input_tokens": 1000000,
+						"max_output_tokens": 65536
+					}
+				}]
+			},
+			"profiles": [{
+				"id": "default",
+				"secrets": {"api_key": "${env:AZURE_TEST_KEY}"}
+			}]
+		}`),
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	provider := value.(inference.ProviderDefinition)
+	limits := provider.Models[0].Descriptor.Limits
+	if limits.MaxInputTokens == nil || *limits.MaxInputTokens != 1_000_000 ||
+		limits.MaxOutputTokens == nil || *limits.MaxOutputTokens != 65_536 {
+		t.Fatalf("limits = %+v, want 1000000/65536", limits)
+	}
+
+	// limitsFor must hand out fresh pointers: mutating one descriptor's
+	// limits must not affect a sibling descriptor built from the same spec.
+	inputTokens := 1_000_000
+	outputTokens := 65_536
+	model := ModelSpec{
+		Name: "gpt-5",
+		Kind: string(kindGenerate),
+		Limits: inference.ModelLimits{
+			MaxInputTokens:  &inputTokens,
+			MaxOutputTokens: &outputTokens,
+		},
+	}
+	first := limitsFor(model)
+	second := limitsFor(model)
+	*first.MaxInputTokens = 1
+	*first.MaxOutputTokens = 2
+	if *second.MaxInputTokens != 1_000_000 || *second.MaxOutputTokens != 65_536 {
+		t.Fatalf("limitsFor shares pointers: second = %+v", second)
+	}
+}
+
+func TestSpecRejectsNonPositiveLimits(t *testing.T) {
+	_, err := Factory().New(context.Background(), resource.Input{
+		Settings: json.RawMessage(`{
+			"id": "azure",
+			"spec": {
+				"endpoint": "https://example.openai.azure.com",
+				"models": [{
+					"name": "gpt-5",
+					"kind": "generate",
+					"capabilities": {"outputs": ["text"]},
+					"limits": {"max_output_tokens": 0}
+				}]
+			},
+			"profiles": [{
+				"id": "default",
+				"secrets": {"api_key": "sk-test"}
+			}]
+		}`),
+	})
+	if err == nil {
+		t.Fatal("deployment with non-positive max output tokens unexpectedly accepted")
+	}
+}

--- a/driver/azure/spec.go
+++ b/driver/azure/spec.go
@@ -56,6 +56,10 @@ type ModelSpec struct {
 	// hosted web search support, and reasoning control capability, validated
 	// against the kind's compiler contract.
 	Capabilities inference.ModelCapabilities `json:"capabilities,omitempty"`
+	// Limits declares numeric capacity limits for the deployment. Azure
+	// routes by deployment name and has no built-in catalog, so limits only
+	// ever come from the declaration.
+	Limits inference.ModelLimits `json:"limits,omitempty"`
 	// Dimensions accepts the embed dimensions knob (embed only).
 	Dimensions bool `json:"dimensions,omitempty"`
 	// EffortNone marks generate deployments whose reasoning.effort accepts
@@ -123,6 +127,9 @@ func (s Spec) Validate() error {
 			)
 		}
 		if err := entryFor(model).validate(); err != nil {
+			return fmt.Errorf("azure: deployment %q: %w", model.Name, err)
+		}
+		if err := model.Limits.Validate(); err != nil {
 			return fmt.Errorf("azure: deployment %q: %w", model.Name, err)
 		}
 	}

--- a/driver/bytedance/catalog.go
+++ b/driver/bytedance/catalog.go
@@ -46,6 +46,12 @@ type catalogEntry struct {
 	// long-context tiers), so these entries are the family-level upper
 	// bound. Embedding values mirror the documented per-input limit.
 	maxInputTokens int
+	// maxOutputTokens caps the tokens a single generate response may emit
+	// (thinking plus answer tokens share the budget); zero means
+	// undeclared. Generate values mirror the per-version max-output on the
+	// official model list
+	// (https://www.volcengine.com/docs/82379/1330310).
+	maxOutputTokens int
 }
 
 // videoParams is the Seedance task-parameter support matrix for one video
@@ -166,7 +172,8 @@ var catalog = map[string]catalogEntry{
 			WithHostedWebSearch().
 			WithReasoning(inference.ReasoningToggle).
 			WithReasoningEffortMap(arkEffortMap),
-		maxInputTokens: 1_024_000,
+		maxInputTokens:  1_024_000,
+		maxOutputTokens: 256_000,
 	},
 
 	// Seed 2.1 (2026-06) — current flagship tier. The whole Seed 2.x line is
@@ -178,7 +185,8 @@ var catalog = map[string]catalogEntry{
 			WithHostedWebSearch().
 			WithReasoning(inference.ReasoningToggle).
 			WithReasoningEffortMap(arkEffortMap),
-		maxInputTokens: 256_000,
+		maxInputTokens:  256_000,
+		maxOutputTokens: 256_000,
 	},
 	"doubao-seed-2-1-turbo": {
 		kind: kindGenerate,
@@ -187,7 +195,8 @@ var catalog = map[string]catalogEntry{
 			WithHostedWebSearch().
 			WithReasoning(inference.ReasoningToggle).
 			WithReasoningEffortMap(arkEffortMap),
-		maxInputTokens: 256_000,
+		maxInputTokens:  256_000,
+		maxOutputTokens: 256_000,
 	},
 
 	// Seed 2.0 (2026-02) — general agent line plus the code-tuned variant.
@@ -201,7 +210,8 @@ var catalog = map[string]catalogEntry{
 			WithHostedWebSearch().
 			WithReasoning(inference.ReasoningToggle).
 			WithReasoningEffortMap(arkEffortMap),
-		maxInputTokens: 256_000,
+		maxInputTokens:  256_000,
+		maxOutputTokens: 128_000,
 	},
 	"doubao-seed-2-0-lite": {
 		kind: kindGenerate,
@@ -210,7 +220,8 @@ var catalog = map[string]catalogEntry{
 			WithHostedWebSearch().
 			WithReasoning(inference.ReasoningToggle).
 			WithReasoningEffortMap(arkEffortMap),
-		maxInputTokens: 256_000,
+		maxInputTokens:  256_000,
+		maxOutputTokens: 128_000,
 	},
 	"doubao-seed-2-0-mini": {
 		kind: kindGenerate,
@@ -219,7 +230,8 @@ var catalog = map[string]catalogEntry{
 			WithHostedWebSearch().
 			WithReasoning(inference.ReasoningToggle).
 			WithReasoningEffortMap(arkEffortMap),
-		maxInputTokens: 256_000,
+		maxInputTokens:  256_000,
+		maxOutputTokens: 128_000,
 	},
 	"doubao-seed-2-0-code": {
 		kind: kindGenerate,
@@ -228,7 +240,8 @@ var catalog = map[string]catalogEntry{
 			WithHostedWebSearch().
 			WithReasoning(inference.ReasoningToggle).
 			WithReasoningEffortMap(arkEffortMap),
-		maxInputTokens: 256_000,
+		maxInputTokens:  256_000,
+		maxOutputTokens: 128_000,
 	},
 
 	// Seed 1.x — superseded by the 2.x line; kept routable for existing
@@ -241,7 +254,8 @@ var catalog = map[string]catalogEntry{
 			WithReasoning(inference.ReasoningToggle).
 			WithReasoningEffortMap(arkEffortMap),
 		deprecated: true, replacement: "doubao-seed-2-0-lite",
-		maxInputTokens: 256_000,
+		maxInputTokens:  256_000,
+		maxOutputTokens: 64_000,
 	},
 	"doubao-seed-1-6-vision": {
 		kind: kindGenerate,
@@ -251,7 +265,8 @@ var catalog = map[string]catalogEntry{
 			WithReasoning(inference.ReasoningToggle).
 			WithReasoningEffortMap(arkEffortMap),
 		deprecated: true, replacement: "doubao-seed-2-0-lite",
-		maxInputTokens: 256_000,
+		maxInputTokens:  256_000,
+		maxOutputTokens: 64_000,
 	},
 
 	"doubao-embedding-large": {
@@ -462,17 +477,30 @@ var catalog = map[string]catalogEntry{
 }
 
 // mergedCatalog overlays Spec.Models onto the built-in catalog and returns
-// the merged view. Spec entries replace catalog entries by name.
+// the merged view. Spec entries replace catalog entries by name; numeric
+// limits are inherited from the replaced entry unless the declaration sets
+// them explicitly.
 func mergedCatalog(spec Spec) (map[string]catalogEntry, error) {
 	merged := make(map[string]catalogEntry, len(catalog)+len(spec.Models))
 	maps.Copy(merged, catalog)
 	for _, model := range spec.Models {
-		merged[model.Name] = catalogEntry{
+		entry := catalogEntry{
 			kind:          modelKind(model.Kind),
 			capabilities:  model.Capabilities,
 			dimensions:    model.Dimensions,
 			maxResolution: model.MaxResolution,
 		}
+		if builtin, exists := merged[model.Name]; exists && builtin.kind == entry.kind {
+			entry.maxInputTokens = builtin.maxInputTokens
+			entry.maxOutputTokens = builtin.maxOutputTokens
+		}
+		if model.Limits.MaxInputTokens != nil {
+			entry.maxInputTokens = *model.Limits.MaxInputTokens
+		}
+		if model.Limits.MaxOutputTokens != nil {
+			entry.maxOutputTokens = *model.Limits.MaxOutputTokens
+		}
+		merged[model.Name] = entry
 	}
 	for name, entry := range merged {
 		if err := entry.validate(); err != nil {

--- a/driver/bytedance/catalog_test.go
+++ b/driver/bytedance/catalog_test.go
@@ -51,6 +51,46 @@ func TestCatalogDeclaresMaxInputTokens(t *testing.T) {
 	}
 }
 
+func TestCatalogDeclaresMaxOutputTokens(t *testing.T) {
+	provider, err := buildProvider(context.Background(), ResourceSettings{ID: "bytedance"}, nil)
+	if err != nil {
+		t.Fatalf("buildProvider: %v", err)
+	}
+	descriptors := make(map[string]inference.ModelDescriptor, len(provider.Models))
+	for _, model := range provider.Models {
+		descriptors[model.Descriptor.ID.Name] = model.Descriptor
+	}
+	for name, entry := range catalog {
+		if entry.kind != kindGenerate {
+			continue
+		}
+		descriptor, ok := descriptors[name]
+		if !ok {
+			t.Fatalf("catalog model %q missing from provider", name)
+		}
+		if entry.maxOutputTokens <= 0 || descriptor.Limits.MaxOutputTokens == nil {
+			t.Errorf("model %q: max output tokens not declared", name)
+		}
+	}
+	checks := map[string]int{
+		"doubao-seed-evolving":   256_000,
+		"doubao-seed-2-1-pro":    256_000,
+		"doubao-seed-2-0-mini":   128_000,
+		"doubao-seed-1-6-vision": 64_000,
+	}
+	for name, want := range checks {
+		descriptor, ok := descriptors[name]
+		if !ok {
+			t.Fatalf("model %q missing from provider", name)
+		}
+		if descriptor.Limits.MaxOutputTokens == nil ||
+			*descriptor.Limits.MaxOutputTokens != want {
+			t.Errorf("model %q: max output tokens = %v, want %d",
+				name, descriptor.Limits.MaxOutputTokens, want)
+		}
+	}
+}
+
 func TestCatalogPublishesCapabilities(t *testing.T) {
 	provider, err := buildProvider(context.Background(), ResourceSettings{ID: "bytedance"}, nil)
 	if err != nil {
@@ -158,5 +198,49 @@ func TestMergedCatalogRejectsFamilyContractViolation(t *testing.T) {
 	}
 	if _, err := mergedCatalog(spec); err == nil {
 		t.Fatal("mergedCatalog unexpectedly accepted contract violation")
+	}
+}
+
+func TestMergedCatalogOverlaysDeclaredLimits(t *testing.T) {
+	generateCapabilities := `{"inputs":["text","data","tool_call","tool_result"],"outputs":["text"]}`
+	spec, err := decodeSpec(context.Background(), []byte(`{
+		"models": [{
+			"name": "doubao-seed-2-1-pro",
+			"kind": "generate",
+			"capabilities": `+generateCapabilities+`
+		}]
+	}`))
+	if err != nil {
+		t.Fatalf("decodeSpec: %v", err)
+	}
+	models, err := mergedCatalog(spec)
+	if err != nil {
+		t.Fatalf("mergedCatalog: %v", err)
+	}
+	entry := models["doubao-seed-2-1-pro"]
+	if entry.maxInputTokens != 256_000 || entry.maxOutputTokens != 256_000 {
+		t.Fatalf("redeclared limits = %d/%d, want catalog 256000/256000",
+			entry.maxInputTokens, entry.maxOutputTokens)
+	}
+
+	spec, err = decodeSpec(context.Background(), []byte(`{
+		"models": [{
+			"name": "doubao-seed-2-1-pro",
+			"kind": "generate",
+			"capabilities": `+generateCapabilities+`,
+			"limits": {"max_output_tokens": 4096}
+		}]
+	}`))
+	if err != nil {
+		t.Fatalf("decodeSpec: %v", err)
+	}
+	models, err = mergedCatalog(spec)
+	if err != nil {
+		t.Fatalf("mergedCatalog: %v", err)
+	}
+	entry = models["doubao-seed-2-1-pro"]
+	if entry.maxInputTokens != 256_000 || entry.maxOutputTokens != 4096 {
+		t.Fatalf("overridden limits = %d/%d, want 256000/4096",
+			entry.maxInputTokens, entry.maxOutputTokens)
 	}
 }

--- a/driver/bytedance/catalog_test.go
+++ b/driver/bytedance/catalog_test.go
@@ -244,3 +244,27 @@ func TestMergedCatalogOverlaysDeclaredLimits(t *testing.T) {
 			entry.maxInputTokens, entry.maxOutputTokens)
 	}
 }
+
+func TestMergedCatalogOverridesDeclaredInputLimit(t *testing.T) {
+	generateCapabilities := `{"inputs":["text","data","tool_call","tool_result"],"outputs":["text"]}`
+	spec, err := decodeSpec(context.Background(), []byte(`{
+		"models": [{
+			"name": "doubao-seed-2-1-pro",
+			"kind": "generate",
+			"capabilities": `+generateCapabilities+`,
+			"limits": {"max_input_tokens": 65536}
+		}]
+	}`))
+	if err != nil {
+		t.Fatalf("decodeSpec: %v", err)
+	}
+	models, err := mergedCatalog(spec)
+	if err != nil {
+		t.Fatalf("mergedCatalog: %v", err)
+	}
+	entry := models["doubao-seed-2-1-pro"]
+	if entry.maxInputTokens != 65_536 || entry.maxOutputTokens != 256_000 {
+		t.Fatalf("declared input limits = %d/%d, want 65536/256000",
+			entry.maxInputTokens, entry.maxOutputTokens)
+	}
+}

--- a/driver/bytedance/resource.go
+++ b/driver/bytedance/resource.go
@@ -123,6 +123,9 @@ func buildProvider(ctx context.Context, settings ResourceSettings, secrets *reso
 		if entry.maxInputTokens > 0 {
 			descriptor.Limits.MaxInputTokens = &entry.maxInputTokens
 		}
+		if entry.maxOutputTokens > 0 {
+			descriptor.Limits.MaxOutputTokens = &entry.maxOutputTokens
+		}
 		provider.Models = append(provider.Models, inference.ModelImplementation{
 			Descriptor: descriptor,
 			Openers:    openersFor(spec, entry, profiles, id),

--- a/driver/bytedance/spec.go
+++ b/driver/bytedance/spec.go
@@ -52,6 +52,10 @@ type ModelSpec struct {
 	// Capabilities declares the model's input/output content kinds, hosted
 	// web search support, and reasoning control capability.
 	Capabilities inference.ModelCapabilities `json:"capabilities,omitempty"`
+	// Limits declares numeric capacity limits for the model. Overriding a
+	// built-in catalog entry by name keeps the catalog limit for any field
+	// left nil; declaring a value replaces it.
+	Limits inference.ModelLimits `json:"limits,omitempty"`
 	// Dimensions (embed) allows custom output dimensions.
 	Dimensions bool `json:"dimensions,omitempty"`
 	// MaxResolution (video) caps the supported resolution tier, e.g. "720p"
@@ -131,7 +135,10 @@ func (m ModelSpec) Validate() error {
 	default:
 		return fmt.Errorf("model %q has unknown kind %q", m.Name, m.Kind)
 	}
-	return m.Capabilities.Validate()
+	if err := m.Capabilities.Validate(); err != nil {
+		return err
+	}
+	return m.Limits.Validate()
 }
 
 func decodeSpec(ctx context.Context, raw []byte) (Spec, error) {

--- a/driver/deepseek/catalog.go
+++ b/driver/deepseek/catalog.go
@@ -41,6 +41,11 @@ type catalogEntry struct {
 	// undeclared. Both V4 models carry the 1M context published on
 	// https://api-docs.deepseek.com/quick_start/pricing.
 	maxInputTokens int
+	// maxOutputTokens caps the tokens a single response may emit
+	// (thinking plus answer tokens share the budget); zero means
+	// undeclared. Values mirror the 384K maximum published on
+	// https://api-docs.deepseek.com/quick_start/pricing.
+	maxOutputTokens int
 	// requestMetadataEnvelope is the provider-level lowering policy for
 	// canonical GenerateRequest.RequestMetadata ("" disables forwarding).
 	requestMetadataEnvelope string
@@ -114,8 +119,9 @@ var catalog = map[string]catalogEntry{
 			WithHostedWebSearch().
 			WithReasoning(inference.ReasoningToggle).
 			WithReasoningEffortMap(deepseekEffortMap),
-		responses:      true,
-		maxInputTokens: 1_000_000,
+		responses:       true,
+		maxInputTokens:  1_000_000,
+		maxOutputTokens: 384_000,
 	},
 	"deepseek-v4-pro": {
 		kind: kindGenerate,
@@ -123,8 +129,9 @@ var catalog = map[string]catalogEntry{
 			WithHostedWebSearch().
 			WithReasoning(inference.ReasoningToggle).
 			WithReasoningEffortMap(deepseekEffortMap),
-		responses:      true,
-		maxInputTokens: 1_000_000,
+		responses:       true,
+		maxInputTokens:  1_000_000,
+		maxOutputTokens: 384_000,
 	},
 	"deepseek-v4-flash-vision-exp": {
 		kind: kindGenerate,
@@ -133,15 +140,17 @@ var catalog = map[string]catalogEntry{
 			WithHostedWebSearch().
 			WithReasoning(inference.ReasoningToggle).
 			WithReasoningEffortMap(deepseekEffortMap),
-		responses:      true,
-		maxInputTokens: 1_000_000,
+		responses:       true,
+		maxInputTokens:  1_000_000,
+		maxOutputTokens: 384_000,
 	},
 }
 
 // mergedCatalog overlays the built-in catalog with the spec's model
 // declarations: a spec entry with a catalog name replaces that entry, and
-// unknown names extend the catalog. Models stay fail closed — the factory
-// only exposes what the merged catalog declares.
+// unknown names extend the catalog. Replacing a built-in keeps its numeric
+// limits unless the declaration sets them explicitly. Models stay fail
+// closed — the factory only exposes what the merged catalog declares.
 func mergedCatalog(spec Spec) (map[string]catalogEntry, error) {
 	models := make(map[string]catalogEntry, len(catalog)+len(spec.Models))
 	maps.Copy(models, catalog)
@@ -158,6 +167,16 @@ func mergedCatalog(spec Spec) (map[string]catalogEntry, error) {
 			} else {
 				entry.kind = kindGenerate
 			}
+		}
+		if existing, exists := models[declared.Name]; exists {
+			entry.maxInputTokens = existing.maxInputTokens
+			entry.maxOutputTokens = existing.maxOutputTokens
+		}
+		if declared.Limits.MaxInputTokens != nil {
+			entry.maxInputTokens = *declared.Limits.MaxInputTokens
+		}
+		if declared.Limits.MaxOutputTokens != nil {
+			entry.maxOutputTokens = *declared.Limits.MaxOutputTokens
 		}
 		models[declared.Name] = entry
 	}

--- a/driver/deepseek/catalog_test.go
+++ b/driver/deepseek/catalog_test.go
@@ -151,6 +151,29 @@ func TestMergedCatalogOverlaysDeclaredLimits(t *testing.T) {
 	}
 }
 
+func TestMergedCatalogOverridesDeclaredInputLimit(t *testing.T) {
+	capabilities := `{"inputs":["text","data","tool_call","tool_result"],"outputs":["text"]}`
+	spec, err := decodeSpec(context.Background(), []byte(`{
+		"models": [{
+			"name": "deepseek-v4-flash",
+			"capabilities": `+capabilities+`,
+			"limits": {"max_input_tokens": 65536}
+		}]
+	}`))
+	if err != nil {
+		t.Fatalf("decodeSpec: %v", err)
+	}
+	models, err := mergedCatalog(spec)
+	if err != nil {
+		t.Fatalf("mergedCatalog: %v", err)
+	}
+	entry := models["deepseek-v4-flash"]
+	if entry.maxInputTokens != 65_536 || entry.maxOutputTokens != 384_000 {
+		t.Fatalf("declared input limits = %d/%d, want 65536/384000",
+			entry.maxInputTokens, entry.maxOutputTokens)
+	}
+}
+
 func TestRequestMetadataEnvelopeValidationAndCatalogPropagation(t *testing.T) {
 	for _, envelope := range []string{"", "metadata", "client_metadata", "request_fields"} {
 		raw := `{}`

--- a/driver/deepseek/catalog_test.go
+++ b/driver/deepseek/catalog_test.go
@@ -29,6 +29,24 @@ func TestCatalogDeclaresMaxInputTokens(t *testing.T) {
 	}
 }
 
+func TestCatalogDeclaresMaxOutputTokens(t *testing.T) {
+	provider, err := buildProvider(context.Background(), ResourceSettings{ID: "deepseek"}, nil)
+	if err != nil {
+		t.Fatalf("buildProvider: %v", err)
+	}
+	for _, model := range provider.Models {
+		name := model.Descriptor.ID.Name
+		if catalog[name].maxOutputTokens <= 0 {
+			t.Errorf("model %q: max output tokens not declared", name)
+		}
+		if model.Descriptor.Limits.MaxOutputTokens == nil ||
+			*model.Descriptor.Limits.MaxOutputTokens != 384_000 {
+			t.Errorf("model %q: max output tokens = %v, want 384000",
+				name, model.Descriptor.Limits.MaxOutputTokens)
+		}
+	}
+}
+
 func TestCatalogPublishesCapabilities(t *testing.T) {
 	provider, err := buildProvider(context.Background(), ResourceSettings{ID: "deepseek"}, nil)
 	if err != nil {
@@ -88,6 +106,48 @@ func TestMergedCatalogRejectsMissingTextOutput(t *testing.T) {
 	}
 	if _, err := mergedCatalog(spec); err == nil {
 		t.Fatal("mergedCatalog unexpectedly accepted a generate model without text output")
+	}
+}
+
+func TestMergedCatalogOverlaysDeclaredLimits(t *testing.T) {
+	capabilities := `{"inputs":["text","data","tool_call","tool_result"],"outputs":["text"]}`
+	spec, err := decodeSpec(context.Background(), []byte(`{
+		"models": [{
+			"name": "deepseek-v4-flash",
+			"capabilities": `+capabilities+`
+		}]
+	}`))
+	if err != nil {
+		t.Fatalf("decodeSpec: %v", err)
+	}
+	models, err := mergedCatalog(spec)
+	if err != nil {
+		t.Fatalf("mergedCatalog: %v", err)
+	}
+	entry := models["deepseek-v4-flash"]
+	if entry.maxInputTokens != 1_000_000 || entry.maxOutputTokens != 384_000 {
+		t.Fatalf("redeclared limits = %d/%d, want catalog 1000000/384000",
+			entry.maxInputTokens, entry.maxOutputTokens)
+	}
+
+	spec, err = decodeSpec(context.Background(), []byte(`{
+		"models": [{
+			"name": "deepseek-v4-flash",
+			"capabilities": `+capabilities+`,
+			"limits": {"max_output_tokens": 64000}
+		}]
+	}`))
+	if err != nil {
+		t.Fatalf("decodeSpec: %v", err)
+	}
+	models, err = mergedCatalog(spec)
+	if err != nil {
+		t.Fatalf("mergedCatalog: %v", err)
+	}
+	entry = models["deepseek-v4-flash"]
+	if entry.maxInputTokens != 1_000_000 || entry.maxOutputTokens != 64_000 {
+		t.Fatalf("overridden limits = %d/%d, want 1000000/64000",
+			entry.maxInputTokens, entry.maxOutputTokens)
 	}
 }
 

--- a/driver/deepseek/resource.go
+++ b/driver/deepseek/resource.go
@@ -148,6 +148,9 @@ func buildProvider(ctx context.Context, settings ResourceSettings, secrets *reso
 		if entry.maxInputTokens > 0 {
 			descriptor.Limits.MaxInputTokens = &entry.maxInputTokens
 		}
+		if entry.maxOutputTokens > 0 {
+			descriptor.Limits.MaxOutputTokens = &entry.maxOutputTokens
+		}
 		provider.Models = append(provider.Models, inference.ModelImplementation{
 			Descriptor: descriptor,
 			Openers:    openersFor(spec, entry, profiles, id),

--- a/driver/deepseek/spec.go
+++ b/driver/deepseek/spec.go
@@ -66,6 +66,10 @@ type ModelSpec struct {
 	// Capabilities declares the model's input/output content kinds, hosted
 	// web search support, and reasoning control capability.
 	Capabilities inference.ModelCapabilities `json:"capabilities,omitempty"`
+	// Limits declares numeric capacity limits for the model. Overriding a
+	// built-in catalog entry by name keeps the catalog limit for any field
+	// left nil; declaring a value replaces it.
+	Limits inference.ModelLimits `json:"limits,omitempty"`
 	// Responses declares Responses API support (deepseek-v4-flash,
 	// deepseek-v4-pro, and deepseek-v4-flash-vision-exp).
 	Responses bool `json:"responses,omitempty"`
@@ -81,7 +85,10 @@ func (m ModelSpec) Validate() error {
 	if m.Kind != "" && m.Kind != string(kindGenerate) {
 		return fmt.Errorf("model %q declares unsupported kind %q", m.Name, m.Kind)
 	}
-	return m.Capabilities.Validate()
+	if err := m.Capabilities.Validate(); err != nil {
+		return err
+	}
+	return m.Limits.Validate()
 }
 
 // Validate checks the provider spec for structural sanity.

--- a/driver/kimi/catalog.go
+++ b/driver/kimi/catalog.go
@@ -37,6 +37,13 @@ type catalogEntry struct {
 	// https://platform.kimi.com/docs/models (moonshot-v1 variants state
 	// 8k/32k/128k).
 	maxInputTokens int
+	// maxOutputTokens caps the tokens a single response may emit
+	// (thinking plus answer tokens share the budget); zero means
+	// undeclared. kimi-k3's ceiling comes from the official quickstart
+	// (max_completion_tokens up to 1048576,
+	// https://platform.kimi.com/docs/guide/kimi-k3-quickstart);
+	// kimi-k2.7-code values follow the family's 131072 ceiling.
+	maxOutputTokens int
 }
 
 // kimiK3EffortMap is kimi-k3's canonical-to-wire effort map per the Kimi
@@ -69,6 +76,7 @@ var catalog = map[string]catalogEntry{
 			WithReasoningEffortMap(kimiK3EffortMap),
 		keepThinkingAlways: true,
 		maxInputTokens:     1_000_000,
+		maxOutputTokens:    1_048_576,
 	},
 	"kimi-k2.7-code": {
 		kind: kindGenerate,
@@ -77,6 +85,7 @@ var catalog = map[string]catalogEntry{
 			WithReasoning(inference.ReasoningAlways),
 		keepThinkingAlways: true,
 		maxInputTokens:     256_000,
+		maxOutputTokens:    131_072,
 	},
 	"kimi-k2.7-code-highspeed": {
 		kind: kindGenerate,
@@ -85,6 +94,7 @@ var catalog = map[string]catalogEntry{
 			WithReasoning(inference.ReasoningAlways),
 		keepThinkingAlways: true,
 		maxInputTokens:     256_000,
+		maxOutputTokens:    131_072,
 	},
 	"kimi-k2.6": {
 		kind: kindGenerate,
@@ -171,6 +181,12 @@ func mergedCatalog(spec Spec) (map[string]catalogEntry, error) {
 			entry.capabilities.HostedWebSearch || declared.Capabilities.HostedWebSearch
 		if declared.Capabilities.Reasoning.Kind != inference.ReasoningNone {
 			entry.capabilities.Reasoning = declared.Capabilities.Reasoning
+		}
+		if declared.Limits.MaxInputTokens != nil {
+			entry.maxInputTokens = *declared.Limits.MaxInputTokens
+		}
+		if declared.Limits.MaxOutputTokens != nil {
+			entry.maxOutputTokens = *declared.Limits.MaxOutputTokens
 		}
 		if err := entry.validate(); err != nil {
 			return nil, fmt.Errorf("model %q: %w", declared.Name, err)

--- a/driver/kimi/catalog_test.go
+++ b/driver/kimi/catalog_test.go
@@ -46,6 +46,41 @@ func TestCatalogDeclaresMaxInputTokens(t *testing.T) {
 	}
 }
 
+func TestCatalogDeclaresMaxOutputTokens(t *testing.T) {
+	provider, err := buildProvider(context.Background(), ResourceSettings{ID: "kimi"}, nil)
+	if err != nil {
+		t.Fatalf("buildProvider: %v", err)
+	}
+	descriptors := make(map[string]inference.ModelDescriptor, len(provider.Models))
+	for _, model := range provider.Models {
+		descriptors[model.Descriptor.ID.Name] = model.Descriptor
+	}
+	for name, entry := range catalog {
+		if entry.maxOutputTokens <= 0 {
+			continue // family entries without a documented ceiling stay nil.
+		}
+		descriptor := descriptors[name]
+		if descriptor.Limits.MaxOutputTokens == nil ||
+			*descriptor.Limits.MaxOutputTokens != entry.maxOutputTokens {
+			t.Errorf("model %q: descriptor limit = %v, want %d",
+				name, descriptor.Limits.MaxOutputTokens, entry.maxOutputTokens)
+		}
+	}
+	checks := map[string]int{
+		"kimi-k3":                  1_048_576,
+		"kimi-k2.7-code":           131_072,
+		"kimi-k2.7-code-highspeed": 131_072,
+	}
+	for name, want := range checks {
+		descriptor := descriptors[name]
+		if descriptor.Limits.MaxOutputTokens == nil ||
+			*descriptor.Limits.MaxOutputTokens != want {
+			t.Errorf("model %q: max output tokens = %v, want %d",
+				name, descriptor.Limits.MaxOutputTokens, want)
+		}
+	}
+}
+
 func TestCatalogPublishesCapabilities(t *testing.T) {
 	provider, err := buildProvider(context.Background(), ResourceSettings{ID: "kimi"}, nil)
 	if err != nil {
@@ -92,5 +127,46 @@ func TestMergedCatalogRejectsMissingTextOutput(t *testing.T) {
 	}
 	if _, err := mergedCatalog(spec); err == nil {
 		t.Fatal("mergedCatalog unexpectedly accepted a generate model without text output")
+	}
+}
+
+func TestMergedCatalogOverlaysDeclaredLimits(t *testing.T) {
+	spec, err := decodeSpec(context.Background(), []byte(`{
+		"models": [{
+			"name": "kimi-k3",
+			"capabilities": {"inputs":["text"],"outputs":["text"]}
+		}]
+	}`))
+	if err != nil {
+		t.Fatalf("decodeSpec: %v", err)
+	}
+	models, err := mergedCatalog(spec)
+	if err != nil {
+		t.Fatalf("mergedCatalog: %v", err)
+	}
+	entry := models["kimi-k3"]
+	if entry.maxInputTokens != 1_000_000 || entry.maxOutputTokens != 1_048_576 {
+		t.Fatalf("redeclared limits = %d/%d, want catalog 1000000/1048576",
+			entry.maxInputTokens, entry.maxOutputTokens)
+	}
+
+	spec, err = decodeSpec(context.Background(), []byte(`{
+		"models": [{
+			"name": "kimi-k3",
+			"capabilities": {"inputs":["text"],"outputs":["text"]},
+			"limits": {"max_output_tokens": 4096}
+		}]
+	}`))
+	if err != nil {
+		t.Fatalf("decodeSpec: %v", err)
+	}
+	models, err = mergedCatalog(spec)
+	if err != nil {
+		t.Fatalf("mergedCatalog: %v", err)
+	}
+	entry = models["kimi-k3"]
+	if entry.maxInputTokens != 1_000_000 || entry.maxOutputTokens != 4096 {
+		t.Fatalf("overridden limits = %d/%d, want 1000000/4096",
+			entry.maxInputTokens, entry.maxOutputTokens)
 	}
 }

--- a/driver/kimi/catalog_test.go
+++ b/driver/kimi/catalog_test.go
@@ -170,3 +170,25 @@ func TestMergedCatalogOverlaysDeclaredLimits(t *testing.T) {
 			entry.maxInputTokens, entry.maxOutputTokens)
 	}
 }
+
+func TestMergedCatalogOverridesDeclaredInputLimit(t *testing.T) {
+	spec, err := decodeSpec(context.Background(), []byte(`{
+		"models": [{
+			"name": "kimi-k3",
+			"capabilities": {"inputs":["text"],"outputs":["text"]},
+			"limits": {"max_input_tokens": 65536}
+		}]
+	}`))
+	if err != nil {
+		t.Fatalf("decodeSpec: %v", err)
+	}
+	models, err := mergedCatalog(spec)
+	if err != nil {
+		t.Fatalf("mergedCatalog: %v", err)
+	}
+	entry := models["kimi-k3"]
+	if entry.maxInputTokens != 65_536 || entry.maxOutputTokens != 1_048_576 {
+		t.Fatalf("declared input limits = %d/%d, want 65536/1048576",
+			entry.maxInputTokens, entry.maxOutputTokens)
+	}
+}

--- a/driver/kimi/resource.go
+++ b/driver/kimi/resource.go
@@ -100,6 +100,9 @@ func buildProvider(ctx context.Context, settings ResourceSettings, secrets *reso
 		if entry.maxInputTokens > 0 {
 			descriptor.Limits.MaxInputTokens = &entry.maxInputTokens
 		}
+		if entry.maxOutputTokens > 0 {
+			descriptor.Limits.MaxOutputTokens = &entry.maxOutputTokens
+		}
 		provider.Models = append(provider.Models, inference.ModelImplementation{
 			Descriptor: descriptor,
 			Openers:    openersFor(spec, entry, profiles, id),

--- a/driver/kimi/spec.go
+++ b/driver/kimi/spec.go
@@ -39,6 +39,10 @@ type ModelSpec struct {
 	// Capabilities declares the model's input/output content kinds and the
 	// reasoning control capability.
 	Capabilities inference.ModelCapabilities `json:"capabilities,omitempty"`
+	// Limits declares numeric capacity limits for the model. Overriding a
+	// built-in catalog entry by name keeps the catalog limit for any field
+	// left nil; declaring a value replaces it.
+	Limits inference.ModelLimits `json:"limits,omitempty"`
 }
 
 var modelNamePattern = regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9._-]*$`)
@@ -51,7 +55,10 @@ func (m ModelSpec) Validate() error {
 	if m.Kind != "" && m.Kind != string(kindGenerate) {
 		return fmt.Errorf("model %q declares unsupported kind %q", m.Name, m.Kind)
 	}
-	return m.Capabilities.Validate()
+	if err := m.Capabilities.Validate(); err != nil {
+		return err
+	}
+	return m.Limits.Validate()
 }
 
 // Validate checks the provider spec for structural sanity.

--- a/driver/minimax/catalog.go
+++ b/driver/minimax/catalog.go
@@ -54,6 +54,12 @@ type catalogEntry struct {
 	// undeclared. M3 holds the 1M context and the M2.x series holds
 	// 204,800 per https://platform.minimaxi.com/docs/guides/text-generation.
 	maxInputTokens int
+	// maxOutputTokens caps the tokens a single generate response may emit
+	// (thinking plus answer tokens share the budget); zero means
+	// undeclared. M3's Anthropic-compatible surface caps max_tokens at
+	// 524288 (recommended 131072) per
+	// https://platform.minimaxi.com/docs/guides/text-generation.
+	maxOutputTokens int
 }
 
 // validate enforces the family contract: the compiler bound by kind can only
@@ -126,7 +132,8 @@ var catalog = map[string]catalogEntry{
 		capabilities: generateChatCapabilities().
 			WithInputs(message.PartImage, message.PartVideo).
 			WithReasoning(inference.ReasoningToggle),
-		maxInputTokens: 1_000_000,
+		maxInputTokens:  1_000_000,
+		maxOutputTokens: 524_288,
 	},
 	"MiniMax-M2.7": {
 		kind: kindGenerate,
@@ -346,11 +353,18 @@ func mergedCatalog(spec Spec) (map[string]catalogEntry, error) {
 				entry.videoI2VOnly = existing.videoI2VOnly
 				entry.videoV2 = existing.videoV2
 				entry.maxInputTokens = existing.maxInputTokens
+				entry.maxOutputTokens = existing.maxOutputTokens
 			}
 		} else {
 			if entry.kind == "" {
 				entry.kind = kindGenerate
 			}
+		}
+		if declared.Limits.MaxInputTokens != nil {
+			entry.maxInputTokens = *declared.Limits.MaxInputTokens
+		}
+		if declared.Limits.MaxOutputTokens != nil {
+			entry.maxOutputTokens = *declared.Limits.MaxOutputTokens
 		}
 		models[declared.Name] = entry
 	}

--- a/driver/minimax/catalog_test.go
+++ b/driver/minimax/catalog_test.go
@@ -43,6 +43,44 @@ func TestCatalogDeclaresMaxInputTokens(t *testing.T) {
 	}
 }
 
+func TestCatalogDeclaresMaxOutputTokens(t *testing.T) {
+	provider, err := buildProvider(context.Background(), ResourceSettings{ID: "minimax"}, nil)
+	if err != nil {
+		t.Fatalf("buildProvider: %v", err)
+	}
+	descriptors := make(map[string]inference.ModelDescriptor, len(provider.Models))
+	for _, model := range provider.Models {
+		descriptors[model.Descriptor.ID.Name] = model.Descriptor
+	}
+	for name, entry := range catalog {
+		if entry.kind != kindGenerate {
+			continue
+		}
+		descriptor := descriptors[name]
+		if entry.maxOutputTokens <= 0 {
+			if descriptor.Limits.MaxOutputTokens != nil {
+				t.Errorf("model %q: undeclared max output tokens = %d",
+					name, *descriptor.Limits.MaxOutputTokens)
+			}
+			continue
+		}
+		if descriptor.Limits.MaxOutputTokens == nil {
+			t.Errorf("model %q: max output tokens not declared", name)
+		}
+	}
+	checks := map[string]int{
+		"MiniMax-M3": 524_288,
+	}
+	for name, want := range checks {
+		descriptor := descriptors[name]
+		if descriptor.Limits.MaxOutputTokens == nil ||
+			*descriptor.Limits.MaxOutputTokens != want {
+			t.Errorf("model %q: max output tokens = %v, want %d",
+				name, descriptor.Limits.MaxOutputTokens, want)
+		}
+	}
+}
+
 func TestCatalogPublishesCapabilities(t *testing.T) {
 	provider, err := buildProvider(context.Background(), ResourceSettings{ID: "minimax"}, nil)
 	if err != nil {
@@ -161,5 +199,48 @@ func TestMergedCatalogPreservesBuiltInVideoFlags(t *testing.T) {
 	}
 	if entry := models["MiniMax-H3-Context-IR"]; entry.wireModel != "MiniMax-H3" {
 		t.Fatalf("redeclared Context-IR wireModel = %q, want MiniMax-H3", entry.wireModel)
+	}
+}
+
+func TestMergedCatalogOverlaysDeclaredLimits(t *testing.T) {
+	spec, err := decodeSpec(context.Background(), []byte(`{
+		"models": [{
+			"name": "MiniMax-M3",
+			"kind": "generate",
+			"capabilities": {"inputs":["text"],"outputs":["text"]}
+		}]
+	}`))
+	if err != nil {
+		t.Fatalf("decodeSpec: %v", err)
+	}
+	models, err := mergedCatalog(spec)
+	if err != nil {
+		t.Fatalf("mergedCatalog: %v", err)
+	}
+	entry := models["MiniMax-M3"]
+	if entry.maxInputTokens != 1_000_000 || entry.maxOutputTokens != 524_288 {
+		t.Fatalf("redeclared limits = %d/%d, want catalog 1000000/524288",
+			entry.maxInputTokens, entry.maxOutputTokens)
+	}
+
+	spec, err = decodeSpec(context.Background(), []byte(`{
+		"models": [{
+			"name": "MiniMax-M3",
+			"kind": "generate",
+			"capabilities": {"inputs":["text"],"outputs":["text"]},
+			"limits": {"max_output_tokens": 4096}
+		}]
+	}`))
+	if err != nil {
+		t.Fatalf("decodeSpec: %v", err)
+	}
+	models, err = mergedCatalog(spec)
+	if err != nil {
+		t.Fatalf("mergedCatalog: %v", err)
+	}
+	entry = models["MiniMax-M3"]
+	if entry.maxInputTokens != 1_000_000 || entry.maxOutputTokens != 4096 {
+		t.Fatalf("overridden limits = %d/%d, want 1000000/4096",
+			entry.maxInputTokens, entry.maxOutputTokens)
 	}
 }

--- a/driver/minimax/catalog_test.go
+++ b/driver/minimax/catalog_test.go
@@ -244,3 +244,26 @@ func TestMergedCatalogOverlaysDeclaredLimits(t *testing.T) {
 			entry.maxInputTokens, entry.maxOutputTokens)
 	}
 }
+
+func TestMergedCatalogOverridesDeclaredInputLimit(t *testing.T) {
+	spec, err := decodeSpec(context.Background(), []byte(`{
+		"models": [{
+			"name": "MiniMax-M3",
+			"kind": "generate",
+			"capabilities": {"inputs":["text"],"outputs":["text"]},
+			"limits": {"max_input_tokens": 65536}
+		}]
+	}`))
+	if err != nil {
+		t.Fatalf("decodeSpec: %v", err)
+	}
+	models, err := mergedCatalog(spec)
+	if err != nil {
+		t.Fatalf("mergedCatalog: %v", err)
+	}
+	entry := models["MiniMax-M3"]
+	if entry.maxInputTokens != 65_536 || entry.maxOutputTokens != 524_288 {
+		t.Fatalf("declared input limits = %d/%d, want 65536/524288",
+			entry.maxInputTokens, entry.maxOutputTokens)
+	}
+}

--- a/driver/minimax/resource.go
+++ b/driver/minimax/resource.go
@@ -107,6 +107,9 @@ func buildProvider(ctx context.Context, settings ResourceSettings, secrets *reso
 		if entry.maxInputTokens > 0 {
 			descriptor.Limits.MaxInputTokens = &entry.maxInputTokens
 		}
+		if entry.maxOutputTokens > 0 {
+			descriptor.Limits.MaxOutputTokens = &entry.maxOutputTokens
+		}
 		provider.Models = append(provider.Models, inference.ModelImplementation{
 			Descriptor: descriptor,
 			Openers:    openersFor(spec, entry, profiles, id),

--- a/driver/minimax/spec.go
+++ b/driver/minimax/spec.go
@@ -44,6 +44,10 @@ type ModelSpec struct {
 	// reasoning control capability, validated against the kind's compiler
 	// contract at merge time.
 	Capabilities inference.ModelCapabilities `json:"capabilities,omitempty"`
+	// Limits declares numeric capacity limits for the model. Overriding a
+	// built-in catalog entry by name keeps the catalog limit for any field
+	// left nil; declaring a value replaces it.
+	Limits inference.ModelLimits `json:"limits,omitempty"`
 }
 
 var modelNamePattern = regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9._-]*$`)
@@ -61,7 +65,10 @@ func (m ModelSpec) Validate() error {
 		modelKind(m.Kind) != kindMusic {
 		return fmt.Errorf("model %q declares unsupported kind %q", m.Name, m.Kind)
 	}
-	return m.Capabilities.Validate()
+	if err := m.Capabilities.Validate(); err != nil {
+		return err
+	}
+	return m.Limits.Validate()
 }
 
 // Validate checks the provider spec for structural sanity.

--- a/driver/openai/catalog.go
+++ b/driver/openai/catalog.go
@@ -66,6 +66,11 @@ type catalogEntry struct {
 	// window on https://developers.openai.com/api/docs/models; embedding
 	// values mirror the per-request input limit.
 	maxInputTokens int
+	// maxOutputTokens caps the tokens a single generate response may emit
+	// (reasoning plus answer tokens share the budget); zero means
+	// undeclared. Values mirror the maximum output on
+	// https://developers.openai.com/api/docs/models.
+	maxOutputTokens int
 	// requestMetadataEnvelope is the provider-level lowering policy for
 	// canonical GenerateRequest.RequestMetadata ("" disables forwarding).
 	requestMetadataEnvelope string
@@ -143,65 +148,75 @@ var openaiEffortMap = map[inference.ReasoningEffort]string{
 var catalog = map[string]catalogEntry{
 	// Generate — GPT-5.6 flagship family (reasoning + vision).
 	"gpt-5.6-sol": {
-		kind:           kindGenerate,
-		capabilities:   generateChatCapabilities().WithInputs(message.PartImage).WithHostedWebSearch().WithReasoning(inference.ReasoningToggle).WithReasoningEffortMap(openaiEffortMap),
-		effortNone:     true,
-		maxInputTokens: 1_050_000,
+		kind:            kindGenerate,
+		capabilities:    generateChatCapabilities().WithInputs(message.PartImage).WithHostedWebSearch().WithReasoning(inference.ReasoningToggle).WithReasoningEffortMap(openaiEffortMap),
+		effortNone:      true,
+		maxInputTokens:  1_050_000,
+		maxOutputTokens: 128_000,
 	},
 	"gpt-5.6-terra": {
-		kind:           kindGenerate,
-		capabilities:   generateChatCapabilities().WithInputs(message.PartImage).WithHostedWebSearch().WithReasoning(inference.ReasoningToggle).WithReasoningEffortMap(openaiEffortMap),
-		effortNone:     true,
-		maxInputTokens: 1_050_000,
+		kind:            kindGenerate,
+		capabilities:    generateChatCapabilities().WithInputs(message.PartImage).WithHostedWebSearch().WithReasoning(inference.ReasoningToggle).WithReasoningEffortMap(openaiEffortMap),
+		effortNone:      true,
+		maxInputTokens:  1_050_000,
+		maxOutputTokens: 128_000,
 	},
 	"gpt-5.6-luna": {
-		kind:           kindGenerate,
-		capabilities:   generateChatCapabilities().WithInputs(message.PartImage).WithHostedWebSearch().WithReasoning(inference.ReasoningToggle).WithReasoningEffortMap(openaiEffortMap),
-		effortNone:     true,
-		maxInputTokens: 1_050_000,
+		kind:            kindGenerate,
+		capabilities:    generateChatCapabilities().WithInputs(message.PartImage).WithHostedWebSearch().WithReasoning(inference.ReasoningToggle).WithReasoningEffortMap(openaiEffortMap),
+		effortNone:      true,
+		maxInputTokens:  1_050_000,
+		maxOutputTokens: 128_000,
 	},
 	// Generate — previous generations, superseded but available.
 	"gpt-5.5": {
 		kind:         kindGenerate,
 		capabilities: generateChatCapabilities().WithInputs(message.PartImage).WithHostedWebSearch().WithReasoning(inference.ReasoningAlways).WithReasoningEffortMap(openaiEffortMap),
 		deprecated:   true, replacement: "gpt-5.6-sol",
-		maxInputTokens: 1_050_000,
+		maxInputTokens:  1_050_000,
+		maxOutputTokens: 128_000,
 	},
 	"gpt-5.4": {
 		kind:         kindGenerate,
 		capabilities: generateChatCapabilities().WithInputs(message.PartImage).WithHostedWebSearch().WithReasoning(inference.ReasoningAlways).WithReasoningEffortMap(openaiEffortMap),
 		deprecated:   true, replacement: "gpt-5.6-sol",
-		maxInputTokens: 1_050_000,
+		maxInputTokens:  1_050_000,
+		maxOutputTokens: 128_000,
 	},
 	"gpt-5.4-mini": {
 		kind:         kindGenerate,
 		capabilities: generateChatCapabilities().WithInputs(message.PartImage).WithHostedWebSearch().WithReasoning(inference.ReasoningAlways).WithReasoningEffortMap(openaiEffortMap),
 		deprecated:   true, replacement: "gpt-5.6-terra",
-		maxInputTokens: 400_000,
+		maxInputTokens:  400_000,
+		maxOutputTokens: 128_000,
 	},
 	"gpt-5.4-nano": {
 		kind:         kindGenerate,
 		capabilities: generateChatCapabilities().WithInputs(message.PartImage).WithHostedWebSearch().WithReasoning(inference.ReasoningAlways).WithReasoningEffortMap(openaiEffortMap),
 		deprecated:   true, replacement: "gpt-5.6-luna",
-		maxInputTokens: 400_000,
+		maxInputTokens:  400_000,
+		maxOutputTokens: 128_000,
 	},
 	// Generate — GPT-4.1 line: vision without the reasoning control.
 	"gpt-4.1": {
-		kind:           kindGenerate,
-		capabilities:   generateChatCapabilities().WithInputs(message.PartImage).WithHostedWebSearch(),
-		maxInputTokens: 1_047_576,
+		kind:            kindGenerate,
+		capabilities:    generateChatCapabilities().WithInputs(message.PartImage).WithHostedWebSearch(),
+		maxInputTokens:  1_047_576,
+		maxOutputTokens: 32_768,
 	},
 	"gpt-4.1-mini": {
-		kind:           kindGenerate,
-		capabilities:   generateChatCapabilities().WithInputs(message.PartImage).WithHostedWebSearch(),
-		maxInputTokens: 1_047_576,
+		kind:            kindGenerate,
+		capabilities:    generateChatCapabilities().WithInputs(message.PartImage).WithHostedWebSearch(),
+		maxInputTokens:  1_047_576,
+		maxOutputTokens: 32_768,
 	},
 	// gpt-4.1-nano has no hosted web_search tool.
 	"gpt-4.1-nano": {
 		kind:         kindGenerate,
 		capabilities: generateChatCapabilities().WithInputs(message.PartImage),
 		deprecated:   true, replacement: "gpt-5.6-luna",
-		maxInputTokens: 1_047_576,
+		maxInputTokens:  1_047_576,
+		maxOutputTokens: 32_768,
 	},
 
 	// Embed.
@@ -252,17 +267,30 @@ var catalog = map[string]catalogEntry{
 }
 
 // mergedCatalog overlays Spec.Models onto the built-in catalog. A custom
-// entry replaces the same-named built-in entirely.
+// entry replaces the same-named built-in entirely, except that numeric
+// limits are inherited from the built-in entry and only replaced when the
+// declaration sets them explicitly.
 func mergedCatalog(spec Spec) (map[string]catalogEntry, error) {
 	models := make(map[string]catalogEntry, len(catalog)+len(spec.Models))
 	maps.Copy(models, catalog)
 	for _, model := range spec.Models {
-		models[model.Name] = catalogEntry{
+		entry := catalogEntry{
 			kind:         modelKind(model.Kind),
 			capabilities: model.Capabilities,
 			dimensions:   model.Dimensions,
 			effortNone:   model.EffortNone,
 		}
+		if builtin, exists := models[model.Name]; exists && builtin.kind == entry.kind {
+			entry.maxInputTokens = builtin.maxInputTokens
+			entry.maxOutputTokens = builtin.maxOutputTokens
+		}
+		if model.Limits.MaxInputTokens != nil {
+			entry.maxInputTokens = *model.Limits.MaxInputTokens
+		}
+		if model.Limits.MaxOutputTokens != nil {
+			entry.maxOutputTokens = *model.Limits.MaxOutputTokens
+		}
+		models[model.Name] = entry
 	}
 	envelope := spec.requestMetadataEnvelope()
 	chatStreamIncludeUsage := spec.chatStreamIncludeUsage()

--- a/driver/openai/catalog_test.go
+++ b/driver/openai/catalog_test.go
@@ -50,6 +50,45 @@ func TestCatalogDeclaresMaxInputTokens(t *testing.T) {
 	}
 }
 
+func TestCatalogDeclaresMaxOutputTokens(t *testing.T) {
+	provider, err := buildProvider(context.Background(), ResourceSettings{ID: "openai"}, nil)
+	if err != nil {
+		t.Fatalf("buildProvider: %v", err)
+	}
+	descriptors := make(map[string]inference.ModelDescriptor, len(provider.Models))
+	for _, model := range provider.Models {
+		descriptors[model.Descriptor.ID.Name] = model.Descriptor
+	}
+	for name, entry := range catalog {
+		if entry.kind != kindGenerate {
+			continue
+		}
+		descriptor, ok := descriptors[name]
+		if !ok {
+			t.Fatalf("catalog model %q missing from provider", name)
+		}
+		if descriptor.Limits.MaxOutputTokens == nil {
+			t.Errorf("model %q: max output tokens not declared", name)
+		}
+	}
+	checks := map[string]int{
+		"gpt-5.6-sol":  128_000,
+		"gpt-5.4-mini": 128_000,
+		"gpt-4.1":      32_768,
+	}
+	for name, want := range checks {
+		descriptor, ok := descriptors[name]
+		if !ok {
+			t.Fatalf("model %q missing from provider", name)
+		}
+		if descriptor.Limits.MaxOutputTokens == nil ||
+			*descriptor.Limits.MaxOutputTokens != want {
+			t.Errorf("model %q: max output tokens = %v, want %d",
+				name, descriptor.Limits.MaxOutputTokens, want)
+		}
+	}
+}
+
 func TestCatalogPublishesCapabilities(t *testing.T) {
 	provider, err := buildProvider(context.Background(), ResourceSettings{ID: "openai"}, nil)
 	if err != nil {
@@ -182,5 +221,67 @@ func TestMergedCatalogAppliesChatStreamUsagePolicy(t *testing.T) {
 	}
 	if obfuscation := models["gpt-5.6-sol"].chatStreamObfuscation(); obfuscation != nil {
 		t.Fatal("nil chat_stream_options must keep the OpenAI default obfuscation policy")
+	}
+}
+
+func TestMergedCatalogOverlaysDeclaredLimits(t *testing.T) {
+	generateCapabilities := `{"inputs":["text","data","tool_call","tool_result"],"outputs":["text"]}`
+	spec, err := decodeSpec(context.Background(), []byte(`{
+		"models": [
+			{
+				"name": "custom",
+				"kind": "generate",
+				"capabilities": `+generateCapabilities+`,
+				"limits": {"max_input_tokens": 100, "max_output_tokens": 200}
+			},
+			{
+				"name": "gpt-4.1",
+				"kind": "generate",
+				"capabilities": `+generateCapabilities+`
+			}
+		]
+	}`))
+	if err != nil {
+		t.Fatalf("decodeSpec: %v", err)
+	}
+	models, err := mergedCatalog(spec)
+	if err != nil {
+		t.Fatalf("mergedCatalog: %v", err)
+	}
+	custom := models["custom"]
+	if custom.maxInputTokens != 100 || custom.maxOutputTokens != 200 {
+		t.Fatalf("custom limits = %d/%d, want 100/200",
+			custom.maxInputTokens, custom.maxOutputTokens)
+	}
+	// Redeclaring a built-in model without limits keeps the catalog values.
+	builtin := models["gpt-4.1"]
+	if builtin.maxInputTokens != 1_047_576 || builtin.maxOutputTokens != 32_768 {
+		t.Fatalf("gpt-4.1 limits = %d/%d, want catalog 1047576/32768",
+			builtin.maxInputTokens, builtin.maxOutputTokens)
+	}
+
+	spec, err = decodeSpec(context.Background(), []byte(`{
+		"models": [{
+			"name": "gpt-4.1",
+			"kind": "generate",
+			"capabilities": `+generateCapabilities+`,
+			"limits": {"max_output_tokens": 1000}
+		}]
+	}`))
+	if err != nil {
+		t.Fatalf("decodeSpec: %v", err)
+	}
+	models, err = mergedCatalog(spec)
+	if err != nil {
+		t.Fatalf("mergedCatalog: %v", err)
+	}
+	overridden := models["gpt-4.1"]
+	if overridden.maxInputTokens != 1_047_576 {
+		t.Fatalf("gpt-4.1 max input = %d, want built-in 1047576",
+			overridden.maxInputTokens)
+	}
+	if overridden.maxOutputTokens != 1000 {
+		t.Fatalf("gpt-4.1 max output = %d, want declared 1000",
+			overridden.maxOutputTokens)
 	}
 }

--- a/driver/openai/catalog_test.go
+++ b/driver/openai/catalog_test.go
@@ -285,3 +285,27 @@ func TestMergedCatalogOverlaysDeclaredLimits(t *testing.T) {
 			overridden.maxOutputTokens)
 	}
 }
+
+func TestMergedCatalogOverridesDeclaredInputLimit(t *testing.T) {
+	generateCapabilities := `{"inputs":["text","data","tool_call","tool_result"],"outputs":["text"]}`
+	spec, err := decodeSpec(context.Background(), []byte(`{
+		"models": [{
+			"name": "gpt-4.1",
+			"kind": "generate",
+			"capabilities": `+generateCapabilities+`,
+			"limits": {"max_input_tokens": 65536}
+		}]
+	}`))
+	if err != nil {
+		t.Fatalf("decodeSpec: %v", err)
+	}
+	models, err := mergedCatalog(spec)
+	if err != nil {
+		t.Fatalf("mergedCatalog: %v", err)
+	}
+	entry := models["gpt-4.1"]
+	if entry.maxInputTokens != 65_536 || entry.maxOutputTokens != 32_768 {
+		t.Fatalf("declared input limits = %d/%d, want 65536/32768",
+			entry.maxInputTokens, entry.maxOutputTokens)
+	}
+}

--- a/driver/openai/resource.go
+++ b/driver/openai/resource.go
@@ -136,6 +136,9 @@ func buildProvider(ctx context.Context, settings ResourceSettings, secrets *reso
 		if entry.maxInputTokens > 0 {
 			descriptor.Limits.MaxInputTokens = &entry.maxInputTokens
 		}
+		if entry.maxOutputTokens > 0 {
+			descriptor.Limits.MaxOutputTokens = &entry.maxOutputTokens
+		}
 		provider.Models = append(provider.Models, inference.ModelImplementation{
 			Descriptor: descriptor,
 			Openers:    openersFor(spec, entry, profiles, id),

--- a/driver/openai/spec.go
+++ b/driver/openai/spec.go
@@ -93,6 +93,10 @@ type ModelSpec struct {
 	// Capabilities declares the model's input/output content kinds, hosted
 	// web search support, and reasoning control capability.
 	Capabilities inference.ModelCapabilities `json:"capabilities,omitempty"`
+	// Limits declares numeric capacity limits for the model. Overriding a
+	// built-in catalog entry by name keeps the catalog limit for any field
+	// left nil; declaring a value replaces it.
+	Limits inference.ModelLimits `json:"limits,omitempty"`
 	// Dimensions (embed) allows custom output dimensions.
 	Dimensions bool `json:"dimensions,omitempty"`
 	// EffortNone marks generate models whose reasoning.effort accepts
@@ -190,7 +194,10 @@ func (m ModelSpec) Validate() error {
 	default:
 		return fmt.Errorf("model %q has unknown kind %q", m.Name, m.Kind)
 	}
-	return m.Capabilities.Validate()
+	if err := m.Capabilities.Validate(); err != nil {
+		return err
+	}
+	return m.Limits.Validate()
 }
 
 func decodeSpec(ctx context.Context, raw []byte) (Spec, error) {

--- a/driver/qwen/catalog.go
+++ b/driver/qwen/catalog.go
@@ -37,6 +37,12 @@ type catalogEntry struct {
 	// (最大输入长度) on the per-model pages at
 	// https://www.alibabacloud.com/help/zh/model-studio/models.
 	maxInputTokens int
+	// maxOutputTokens caps the tokens a single response may emit
+	// (thinking plus answer tokens share the budget); zero means
+	// undeclared. Values mirror the published maximum output length
+	// (最大输出长度) on the per-model pages at
+	// https://www.alibabacloud.com/help/zh/model-studio/models.
+	maxOutputTokens int
 }
 
 // qwenMaxPreviewEffortMap is qwen3.8-max-preview's canonical-to-wire map
@@ -71,6 +77,7 @@ var catalog = map[string]catalogEntry{
 		preserveThinking:   true,
 		thinkingStreamOnly: true,
 		maxInputTokens:     983_616,
+		maxOutputTokens:    131_072,
 	},
 	"qwen3.7-max": {
 		kind: kindGenerate,
@@ -80,6 +87,7 @@ var catalog = map[string]catalogEntry{
 		preserveThinking:   true,
 		thinkingStreamOnly: true,
 		maxInputTokens:     991_808,
+		maxOutputTokens:    131_072,
 	},
 	"qwen3.7-plus": {
 		kind: kindGenerate,
@@ -89,6 +97,7 @@ var catalog = map[string]catalogEntry{
 		preserveThinking:   true,
 		thinkingStreamOnly: true,
 		maxInputTokens:     991_808,
+		maxOutputTokens:    131_072,
 	},
 	"qwen3.7-flash": {
 		kind: kindGenerate,
@@ -98,6 +107,7 @@ var catalog = map[string]catalogEntry{
 		preserveThinking:   true,
 		thinkingStreamOnly: true,
 		maxInputTokens:     991_808,
+		maxOutputTokens:    131_072,
 	},
 	"qwen3-vl-plus": {
 		kind: kindGenerate,
@@ -106,6 +116,7 @@ var catalog = map[string]catalogEntry{
 			WithReasoning(inference.ReasoningToggle),
 		thinkingStreamOnly: true,
 		maxInputTokens:     260_096,
+		maxOutputTokens:    32_768,
 	},
 	"qwen3-vl-flash": {
 		kind: kindGenerate,
@@ -114,12 +125,13 @@ var catalog = map[string]catalogEntry{
 			WithReasoning(inference.ReasoningToggle),
 		thinkingStreamOnly: true,
 		maxInputTokens:     260_096,
+		maxOutputTokens:    32_768,
 	},
 
-	"qwen-plus":  {kind: kindGenerate, capabilities: generateChatCapabilities(), maxInputTokens: 997_952},
-	"qwen-turbo": {kind: kindGenerate, capabilities: generateChatCapabilities(), maxInputTokens: 98_304},
-	"qwen-flash": {kind: kindGenerate, capabilities: generateChatCapabilities(), maxInputTokens: 997_952},
-	"qwen-max":   {kind: kindGenerate, capabilities: generateChatCapabilities(), maxInputTokens: 30_720},
+	"qwen-plus":  {kind: kindGenerate, capabilities: generateChatCapabilities(), maxInputTokens: 997_952, maxOutputTokens: 32_768},
+	"qwen-turbo": {kind: kindGenerate, capabilities: generateChatCapabilities(), maxInputTokens: 98_304, maxOutputTokens: 16_384},
+	"qwen-flash": {kind: kindGenerate, capabilities: generateChatCapabilities(), maxInputTokens: 997_952, maxOutputTokens: 32_768},
+	"qwen-max":   {kind: kindGenerate, capabilities: generateChatCapabilities(), maxInputTokens: 30_720, maxOutputTokens: 8_192},
 
 	// Embeddings. The multimodal model is served in the Beijing region
 	// only; text-embedding-v4 batches at most 10 rows per request.
@@ -218,6 +230,12 @@ func mergedCatalog(spec Spec) (map[string]catalogEntry, error) {
 			entry.capabilities.HostedWebSearch || model.Capabilities.HostedWebSearch
 		if model.Capabilities.Reasoning.Kind != inference.ReasoningNone {
 			entry.capabilities.Reasoning = model.Capabilities.Reasoning
+		}
+		if model.Limits.MaxInputTokens != nil {
+			entry.maxInputTokens = *model.Limits.MaxInputTokens
+		}
+		if model.Limits.MaxOutputTokens != nil {
+			entry.maxOutputTokens = *model.Limits.MaxOutputTokens
 		}
 		if err := entry.validate(); err != nil {
 			return nil, fmt.Errorf("model %q: %w", model.Name, err)

--- a/driver/qwen/catalog_test.go
+++ b/driver/qwen/catalog_test.go
@@ -169,3 +169,25 @@ func TestMergedCatalogOverlaysDeclaredLimits(t *testing.T) {
 			entry.maxInputTokens, entry.maxOutputTokens)
 	}
 }
+
+func TestMergedCatalogOverridesDeclaredInputLimit(t *testing.T) {
+	spec, err := decodeSpec(context.Background(), []byte(`{
+		"models": [{
+			"name": "qwen3.7-flash",
+			"capabilities": {"inputs":["text"],"outputs":["text"]},
+			"limits": {"max_input_tokens": 65536}
+		}]
+	}`))
+	if err != nil {
+		t.Fatalf("decodeSpec: %v", err)
+	}
+	models, err := mergedCatalog(spec)
+	if err != nil {
+		t.Fatalf("mergedCatalog: %v", err)
+	}
+	entry := models["qwen3.7-flash"]
+	if entry.maxInputTokens != 65_536 || entry.maxOutputTokens != 131_072 {
+		t.Fatalf("declared input limits = %d/%d, want 65536/131072",
+			entry.maxInputTokens, entry.maxOutputTokens)
+	}
+}

--- a/driver/qwen/catalog_test.go
+++ b/driver/qwen/catalog_test.go
@@ -46,6 +46,46 @@ func TestCatalogDeclaresMaxInputTokens(t *testing.T) {
 	}
 }
 
+func TestCatalogDeclaresMaxOutputTokens(t *testing.T) {
+	provider, err := buildProvider(context.Background(), ResourceSettings{ID: "qwen"}, nil)
+	if err != nil {
+		t.Fatalf("buildProvider: %v", err)
+	}
+	descriptors := make(map[string]inference.ModelDescriptor, len(provider.Models))
+	for _, model := range provider.Models {
+		descriptors[model.Descriptor.ID.Name] = model.Descriptor
+	}
+	for name, entry := range catalog {
+		if entry.kind != kindGenerate {
+			continue
+		}
+		if entry.maxOutputTokens <= 0 {
+			t.Errorf("model %q: max output tokens not declared", name)
+		}
+		descriptor := descriptors[name]
+		if descriptor.Limits.MaxOutputTokens == nil ||
+			*descriptor.Limits.MaxOutputTokens != entry.maxOutputTokens {
+			t.Errorf("model %q: descriptor limit = %v, want %d",
+				name, descriptor.Limits.MaxOutputTokens, entry.maxOutputTokens)
+		}
+	}
+	checks := map[string]int{
+		"qwen3.8-max-preview": 131_072,
+		"qwen3.7-flash":       131_072,
+		"qwen3-vl-flash":      32_768,
+		"qwen-turbo":          16_384,
+		"qwen-max":            8_192,
+	}
+	for name, want := range checks {
+		descriptor := descriptors[name]
+		if descriptor.Limits.MaxOutputTokens == nil ||
+			*descriptor.Limits.MaxOutputTokens != want {
+			t.Errorf("model %q: max output tokens = %v, want %d",
+				name, descriptor.Limits.MaxOutputTokens, want)
+		}
+	}
+}
+
 func TestCatalogPublishesCapabilities(t *testing.T) {
 	provider, err := buildProvider(context.Background(), ResourceSettings{ID: "qwen"}, nil)
 	if err != nil {
@@ -86,5 +126,46 @@ func TestMergedCatalogRejectsEmbedReasoning(t *testing.T) {
 	}
 	if _, err := mergedCatalog(spec); err == nil {
 		t.Fatal("mergedCatalog unexpectedly accepted an embed model with reasoning")
+	}
+}
+
+func TestMergedCatalogOverlaysDeclaredLimits(t *testing.T) {
+	spec, err := decodeSpec(context.Background(), []byte(`{
+		"models": [{
+			"name": "qwen3.7-flash",
+			"capabilities": {"inputs":["text"],"outputs":["text"]}
+		}]
+	}`))
+	if err != nil {
+		t.Fatalf("decodeSpec: %v", err)
+	}
+	models, err := mergedCatalog(spec)
+	if err != nil {
+		t.Fatalf("mergedCatalog: %v", err)
+	}
+	entry := models["qwen3.7-flash"]
+	if entry.maxInputTokens != 991_808 || entry.maxOutputTokens != 131_072 {
+		t.Fatalf("redeclared limits = %d/%d, want catalog 991808/131072",
+			entry.maxInputTokens, entry.maxOutputTokens)
+	}
+
+	spec, err = decodeSpec(context.Background(), []byte(`{
+		"models": [{
+			"name": "qwen3.7-flash",
+			"capabilities": {"inputs":["text"],"outputs":["text"]},
+			"limits": {"max_output_tokens": 4096}
+		}]
+	}`))
+	if err != nil {
+		t.Fatalf("decodeSpec: %v", err)
+	}
+	models, err = mergedCatalog(spec)
+	if err != nil {
+		t.Fatalf("mergedCatalog: %v", err)
+	}
+	entry = models["qwen3.7-flash"]
+	if entry.maxInputTokens != 991_808 || entry.maxOutputTokens != 4096 {
+		t.Fatalf("overridden limits = %d/%d, want 991808/4096",
+			entry.maxInputTokens, entry.maxOutputTokens)
 	}
 }

--- a/driver/qwen/resource.go
+++ b/driver/qwen/resource.go
@@ -104,6 +104,9 @@ func buildProvider(ctx context.Context, settings ResourceSettings, secrets *reso
 		if entry.maxInputTokens > 0 {
 			descriptor.Limits.MaxInputTokens = &entry.maxInputTokens
 		}
+		if entry.maxOutputTokens > 0 {
+			descriptor.Limits.MaxOutputTokens = &entry.maxOutputTokens
+		}
 		provider.Models = append(provider.Models, inference.ModelImplementation{
 			Descriptor: descriptor,
 			Openers:    openersFor(spec, entry, profiles, id),

--- a/driver/qwen/spec.go
+++ b/driver/qwen/spec.go
@@ -43,6 +43,10 @@ type ModelSpec struct {
 	// reasoning control capability. Spec declarations overlay catalog
 	// entries additively (inputs/outputs union, reasoning overrides).
 	Capabilities inference.ModelCapabilities `json:"capabilities,omitempty"`
+	// Limits declares numeric capacity limits for the model. Overriding a
+	// built-in catalog entry by name keeps the catalog limit for any field
+	// left nil; declaring a value replaces it.
+	Limits inference.ModelLimits `json:"limits,omitempty"`
 }
 
 // ProfileSpec carries per-profile overrides; currently empty.
@@ -59,7 +63,10 @@ func (m ModelSpec) Validate() error {
 	default:
 		return fmt.Errorf("model %q declares unsupported kind %q", m.Name, m.Kind)
 	}
-	return m.Capabilities.Validate()
+	if err := m.Capabilities.Validate(); err != nil {
+		return err
+	}
+	return m.Limits.Validate()
 }
 
 func (s Spec) Validate() error {


### PR DESCRIPTION
## Summary

Model descriptors now declare the maximum output a model may emit in a single response (`limits.max_output_tokens`), alongside the existing `max_input_tokens`.

- **core**: add `ModelLimits.MaxOutputTokens` with JSON round-trip, `Clone`, and positive-value validation coverage ([model.go](core/inference/model.go)); bridge round-trip test now asserts the field.
- **drivers** (anthropic, azure, bytedance, deepseek, kimi, minimax, openai, qwen): `ModelSpec` accepts an optional `limits` overlay validated against `ModelLimits.Validate()`; catalog entries carry provider-documented max-output values that are published on generated descriptors.
- **merge semantics**: redeclaring a built-in catalog model keeps its numeric limits unless the spec sets them explicitly; azure copies spec pointers so descriptors never alias the declaration.

## Notes

- Limits are informational today (model list / bridge preflight), mirroring how `max_input_tokens` is consumed; no request-side capping is added.
- Max-output values are transcribed from the provider docs linked in each catalog comment.
- No `.release/` changesets added — no module tag is planned in this PR.

## Verification

- `make ci` passed (all modules)
- `make lint` passed (0 issues, CI-gated modules)
- `make release-check` passed (no pending releases)
- `git diff --check` clean
