### PR TITLE
Bump core to v0.2.6 in drivers and export built-in catalogs

### DIFF
--- a/driver/anthropic/catalog.go
+++ b/driver/anthropic/catalog.go
@@ -199,3 +199,55 @@ func mergedCatalog(spec Spec) (map[string]catalogEntry, error) {
 	}
 	return models, nil
 }
+
+// descriptorFor lowers one catalog entry into its public discovery
+// descriptor under id. buildProvider and Catalog share this lowering so
+// offline catalog views cannot drift from deployed provider models.
+func descriptorFor(id inference.ModelID, entry catalogEntry) inference.ModelDescriptor {
+	descriptor := inference.ModelDescriptor{
+		ID:           id,
+		Capabilities: entry.capabilities,
+	}
+	if entry.deprecated {
+		descriptor.Lifecycle.Status = inference.ModelStatusDeprecated
+		if entry.replacement != "" {
+			replacement := inference.ModelID{
+				Provider: id.Provider,
+				Name:     entry.replacement,
+			}
+			descriptor.Lifecycle.Replacement = &replacement
+		}
+	}
+	if entry.maxInputTokens > 0 {
+		descriptor.Limits.MaxInputTokens = &entry.maxInputTokens
+	}
+	if entry.maxOutputTokens > 0 {
+		descriptor.Limits.MaxOutputTokens = &entry.maxOutputTokens
+	}
+	return descriptor
+}
+
+// Catalog returns every built-in model descriptor under provider, sorted by
+// model name. Descriptors carry the driver-declared capabilities, limits, and
+// lifecycle; Operations stay empty because the inference assembly derives them
+// from the model's openers after deployment. Provider IDs are a deployment
+// property, so callers supply the identity that appears in each descriptor.
+func Catalog(provider string) ([]inference.ModelDescriptor, error) {
+	if provider == "" {
+		return nil, fmt.Errorf("catalog: provider is required")
+	}
+	names := make([]string, 0, len(catalog))
+	for name := range catalog {
+		names = append(names, name)
+	}
+	slices.Sort(names)
+	descriptors := make([]inference.ModelDescriptor, 0, len(catalog))
+	for _, name := range names {
+		descriptor := descriptorFor(
+			inference.ModelID{Provider: provider, Name: name},
+			catalog[name],
+		)
+		descriptors = append(descriptors, descriptor)
+	}
+	return descriptors, nil
+}

--- a/driver/anthropic/catalog_export_test.go
+++ b/driver/anthropic/catalog_export_test.go
@@ -1,0 +1,28 @@
+package anthropic
+
+import "testing"
+
+func TestCatalogExportsBuiltinModels(t *testing.T) {
+	const provider = "anthropic"
+	descriptors, err := Catalog(provider)
+	if err != nil {
+		t.Fatalf("Catalog: %v", err)
+	}
+	if len(descriptors) != len(catalog) {
+		t.Fatalf("Catalog returned %d descriptors, want %d",
+			len(descriptors), len(catalog))
+	}
+	for i, descriptor := range descriptors {
+		if descriptor.ID.Provider != provider {
+			t.Errorf("descriptor %d provider = %q, want %q",
+				i, descriptor.ID.Provider, provider)
+		}
+		if i > 0 && descriptors[i-1].ID.Name >= descriptor.ID.Name {
+			t.Errorf("descriptors not sorted at %d (%q after %q)",
+				i, descriptor.ID.Name, descriptors[i-1].ID.Name)
+		}
+	}
+	if _, err := Catalog(""); err == nil {
+		t.Fatal(`Catalog("") succeeded, want error`)
+	}
+}

--- a/driver/anthropic/go.mod
+++ b/driver/anthropic/go.mod
@@ -3,7 +3,7 @@ module github.com/GizClaw/flowcraft/driver/anthropic
 go 1.25.0
 
 require (
-	github.com/GizClaw/flowcraft/core v0.2.4
+	github.com/GizClaw/flowcraft/core v0.2.6
 	github.com/anthropics/anthropic-sdk-go v1.61.0
 	go.opentelemetry.io/otel/log v0.19.0
 )

--- a/driver/anthropic/go.sum
+++ b/driver/anthropic/go.sum
@@ -1,5 +1,5 @@
-github.com/GizClaw/flowcraft/core v0.2.4 h1:LnBC7iKyr6v9AJTvbZCgBT5n0ifx4xb2zdNwCvs3mPE=
-github.com/GizClaw/flowcraft/core v0.2.4/go.mod h1:oM890ls+7bEtnG6LfBcDfrmKSm+hQPNzutRpQf3hscI=
+github.com/GizClaw/flowcraft/core v0.2.6 h1:q8rSQRfJoOdy8VJv7oRBXVMsNCZ0Wabg1uNpHMpCS8M=
+github.com/GizClaw/flowcraft/core v0.2.6/go.mod h1:oM890ls+7bEtnG6LfBcDfrmKSm+hQPNzutRpQf3hscI=
 github.com/anthropics/anthropic-sdk-go v1.61.0 h1:JRTnm1tPqn5xo1xd1zfrcFDlcoWXVMvV1K68YmhpZKw=
 github.com/anthropics/anthropic-sdk-go v1.61.0/go.mod h1:3EfIfmFqxH6rbiLcIP4tPFyXL/IHakx2wDG4OU+TIEI=
 github.com/bahlo/generic-list-go v0.2.0 h1:5sz/EEAK+ls5wF+NeqDpk5+iNdMDXrh3z3nPnH1Wvgk=

--- a/driver/anthropic/resource.go
+++ b/driver/anthropic/resource.go
@@ -93,26 +93,7 @@ func buildProvider(ctx context.Context, settings ResourceSettings, secrets *reso
 	for _, name := range names {
 		entry := models[name]
 		id := inference.ModelID{Provider: settings.ID, Name: name}
-		descriptor := inference.ModelDescriptor{
-			ID:           id,
-			Capabilities: entry.capabilities,
-		}
-		if entry.deprecated {
-			descriptor.Lifecycle.Status = inference.ModelStatusDeprecated
-			if entry.replacement != "" {
-				replacement := inference.ModelID{
-					Provider: settings.ID,
-					Name:     entry.replacement,
-				}
-				descriptor.Lifecycle.Replacement = &replacement
-			}
-		}
-		if entry.maxInputTokens > 0 {
-			descriptor.Limits.MaxInputTokens = &entry.maxInputTokens
-		}
-		if entry.maxOutputTokens > 0 {
-			descriptor.Limits.MaxOutputTokens = &entry.maxOutputTokens
-		}
+		descriptor := descriptorFor(id, entry)
 		provider.Models = append(provider.Models, inference.ModelImplementation{
 			Descriptor: descriptor,
 			Openers:    openersFor(spec, entry, profiles, id),

--- a/driver/azure/catalog.go
+++ b/driver/azure/catalog.go
@@ -63,3 +63,13 @@ func (e catalogEntry) validate() error {
 	}
 	return nil
 }
+
+// Catalog returns the built-in model catalog under provider. Azure routes by
+// deployment name and has no built-in lineup: every model is declared in the
+// deployment spec, so Catalog always reports an empty catalog.
+func Catalog(provider string) ([]inference.ModelDescriptor, error) {
+	if provider == "" {
+		return nil, fmt.Errorf("catalog: provider is required")
+	}
+	return []inference.ModelDescriptor{}, nil
+}

--- a/driver/azure/catalog_export_test.go
+++ b/driver/azure/catalog_export_test.go
@@ -1,0 +1,17 @@
+package azure
+
+import "testing"
+
+func TestCatalogHasNoBuiltinModels(t *testing.T) {
+	descriptors, err := Catalog("azure")
+	if err != nil {
+		t.Fatalf("Catalog: %v", err)
+	}
+	if len(descriptors) != 0 {
+		t.Fatalf("Catalog returned %d descriptors, want none",
+			len(descriptors))
+	}
+	if _, err := Catalog(""); err == nil {
+		t.Fatal(`Catalog("") succeeded, want error`)
+	}
+}

--- a/driver/azure/go.mod
+++ b/driver/azure/go.mod
@@ -3,7 +3,7 @@ module github.com/GizClaw/flowcraft/driver/azure
 go 1.25.0
 
 require (
-	github.com/GizClaw/flowcraft/core v0.2.4
+	github.com/GizClaw/flowcraft/core v0.2.6
 	github.com/openai/openai-go/v3 v3.50.0
 	go.opentelemetry.io/otel/log v0.19.0
 )

--- a/driver/azure/go.sum
+++ b/driver/azure/go.sum
@@ -6,8 +6,8 @@ github.com/Azure/azure-sdk-for-go/sdk/internal v1.12.0 h1:fhqpLE3UEXi9lPaBRpQ6Xu
 github.com/Azure/azure-sdk-for-go/sdk/internal v1.12.0/go.mod h1:7dCRMLwisfRH3dBupKeNCioWYUZ4SS09Z14H+7i8ZoY=
 github.com/AzureAD/microsoft-authentication-library-for-go v1.7.2 h1:RHK7bS+HQMslb1sZpAokUt+zTVmue0hKSs2C791hhzU=
 github.com/AzureAD/microsoft-authentication-library-for-go v1.7.2/go.mod h1:HKpQxkWaGLJ+D/5H8QRpyQXA1eKjxkFlOMwck5+33Jk=
-github.com/GizClaw/flowcraft/core v0.2.4 h1:LnBC7iKyr6v9AJTvbZCgBT5n0ifx4xb2zdNwCvs3mPE=
-github.com/GizClaw/flowcraft/core v0.2.4/go.mod h1:oM890ls+7bEtnG6LfBcDfrmKSm+hQPNzutRpQf3hscI=
+github.com/GizClaw/flowcraft/core v0.2.6 h1:q8rSQRfJoOdy8VJv7oRBXVMsNCZ0Wabg1uNpHMpCS8M=
+github.com/GizClaw/flowcraft/core v0.2.6/go.mod h1:oM890ls+7bEtnG6LfBcDfrmKSm+hQPNzutRpQf3hscI=
 github.com/cenkalti/backoff/v5 v5.0.3 h1:ZN+IMa753KfX5hd8vVaMixjnqRZ3y8CuJKRKj1xcsSM=
 github.com/cenkalti/backoff/v5 v5.0.3/go.mod h1:rkhZdG3JZukswDf7f0cwqPNk4K0sa+F97BxZthm/crw=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=

--- a/driver/bytedance/catalog.go
+++ b/driver/bytedance/catalog.go
@@ -509,3 +509,55 @@ func mergedCatalog(spec Spec) (map[string]catalogEntry, error) {
 	}
 	return merged, nil
 }
+
+// descriptorFor lowers one catalog entry into its public discovery
+// descriptor under id. buildProvider and Catalog share this lowering so
+// offline catalog views cannot drift from deployed provider models.
+func descriptorFor(id inference.ModelID, entry catalogEntry) inference.ModelDescriptor {
+	descriptor := inference.ModelDescriptor{
+		ID:           id,
+		Capabilities: entry.capabilities,
+	}
+	if entry.deprecated {
+		descriptor.Lifecycle.Status = inference.ModelStatusDeprecated
+		if entry.replacement != "" {
+			replacement := inference.ModelID{
+				Provider: id.Provider,
+				Name:     entry.replacement,
+			}
+			descriptor.Lifecycle.Replacement = &replacement
+		}
+	}
+	if entry.maxInputTokens > 0 {
+		descriptor.Limits.MaxInputTokens = &entry.maxInputTokens
+	}
+	if entry.maxOutputTokens > 0 {
+		descriptor.Limits.MaxOutputTokens = &entry.maxOutputTokens
+	}
+	return descriptor
+}
+
+// Catalog returns every built-in model descriptor under provider, sorted by
+// model name. Descriptors carry the driver-declared capabilities, limits, and
+// lifecycle; Operations stay empty because the inference assembly derives them
+// from the model's openers after deployment. Provider IDs are a deployment
+// property, so callers supply the identity that appears in each descriptor.
+func Catalog(provider string) ([]inference.ModelDescriptor, error) {
+	if provider == "" {
+		return nil, fmt.Errorf("catalog: provider is required")
+	}
+	names := make([]string, 0, len(catalog))
+	for name := range catalog {
+		names = append(names, name)
+	}
+	slices.Sort(names)
+	descriptors := make([]inference.ModelDescriptor, 0, len(catalog))
+	for _, name := range names {
+		descriptor := descriptorFor(
+			inference.ModelID{Provider: provider, Name: name},
+			catalog[name],
+		)
+		descriptors = append(descriptors, descriptor)
+	}
+	return descriptors, nil
+}

--- a/driver/bytedance/catalog_export_test.go
+++ b/driver/bytedance/catalog_export_test.go
@@ -1,0 +1,28 @@
+package bytedance
+
+import "testing"
+
+func TestCatalogExportsBuiltinModels(t *testing.T) {
+	const provider = "bytedance"
+	descriptors, err := Catalog(provider)
+	if err != nil {
+		t.Fatalf("Catalog: %v", err)
+	}
+	if len(descriptors) != len(catalog) {
+		t.Fatalf("Catalog returned %d descriptors, want %d",
+			len(descriptors), len(catalog))
+	}
+	for i, descriptor := range descriptors {
+		if descriptor.ID.Provider != provider {
+			t.Errorf("descriptor %d provider = %q, want %q",
+				i, descriptor.ID.Provider, provider)
+		}
+		if i > 0 && descriptors[i-1].ID.Name >= descriptor.ID.Name {
+			t.Errorf("descriptors not sorted at %d (%q after %q)",
+				i, descriptor.ID.Name, descriptors[i-1].ID.Name)
+		}
+	}
+	if _, err := Catalog(""); err == nil {
+		t.Fatal(`Catalog("") succeeded, want error`)
+	}
+}

--- a/driver/bytedance/go.mod
+++ b/driver/bytedance/go.mod
@@ -3,7 +3,7 @@ module github.com/GizClaw/flowcraft/driver/bytedance
 go 1.25.0
 
 require (
-	github.com/GizClaw/flowcraft/core v0.2.4
+	github.com/GizClaw/flowcraft/core v0.2.6
 	github.com/volcengine/volcengine-go-sdk v1.2.48
 	go.opentelemetry.io/otel/log v0.19.0
 )

--- a/driver/bytedance/go.sum
+++ b/driver/bytedance/go.sum
@@ -1,7 +1,7 @@
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
-github.com/GizClaw/flowcraft/core v0.2.4 h1:LnBC7iKyr6v9AJTvbZCgBT5n0ifx4xb2zdNwCvs3mPE=
-github.com/GizClaw/flowcraft/core v0.2.4/go.mod h1:oM890ls+7bEtnG6LfBcDfrmKSm+hQPNzutRpQf3hscI=
+github.com/GizClaw/flowcraft/core v0.2.6 h1:q8rSQRfJoOdy8VJv7oRBXVMsNCZ0Wabg1uNpHMpCS8M=
+github.com/GizClaw/flowcraft/core v0.2.6/go.mod h1:oM890ls+7bEtnG6LfBcDfrmKSm+hQPNzutRpQf3hscI=
 github.com/avast/retry-go v3.0.0+incompatible/go.mod h1:XtSnn+n/sHqQIpZ10K1qAevBhOOCWBLXXy3hyiqqBrY=
 github.com/cenkalti/backoff/v5 v5.0.3 h1:ZN+IMa753KfX5hd8vVaMixjnqRZ3y8CuJKRKj1xcsSM=
 github.com/cenkalti/backoff/v5 v5.0.3/go.mod h1:rkhZdG3JZukswDf7f0cwqPNk4K0sa+F97BxZthm/crw=

--- a/driver/bytedance/resource.go
+++ b/driver/bytedance/resource.go
@@ -106,26 +106,7 @@ func buildProvider(ctx context.Context, settings ResourceSettings, secrets *reso
 	for _, name := range names {
 		entry := models[name]
 		id := inference.ModelID{Provider: settings.ID, Name: name}
-		descriptor := inference.ModelDescriptor{
-			ID:           id,
-			Capabilities: entry.capabilities,
-		}
-		if entry.deprecated {
-			descriptor.Lifecycle.Status = inference.ModelStatusDeprecated
-			if entry.replacement != "" {
-				replacement := inference.ModelID{
-					Provider: settings.ID,
-					Name:     entry.replacement,
-				}
-				descriptor.Lifecycle.Replacement = &replacement
-			}
-		}
-		if entry.maxInputTokens > 0 {
-			descriptor.Limits.MaxInputTokens = &entry.maxInputTokens
-		}
-		if entry.maxOutputTokens > 0 {
-			descriptor.Limits.MaxOutputTokens = &entry.maxOutputTokens
-		}
+		descriptor := descriptorFor(id, entry)
 		provider.Models = append(provider.Models, inference.ModelImplementation{
 			Descriptor: descriptor,
 			Openers:    openersFor(spec, entry, profiles, id),

--- a/driver/deepseek/catalog.go
+++ b/driver/deepseek/catalog.go
@@ -203,3 +203,40 @@ func sortedNames(models map[string]catalogEntry) []string {
 	sort.Strings(names)
 	return names
 }
+
+// descriptorFor lowers one catalog entry into its public discovery
+// descriptor under id. buildProvider and Catalog share this lowering so
+// offline catalog views cannot drift from deployed provider models.
+func descriptorFor(id inference.ModelID, entry catalogEntry) inference.ModelDescriptor {
+	descriptor := inference.ModelDescriptor{
+		ID:           id,
+		Capabilities: entry.capabilities,
+	}
+	if entry.maxInputTokens > 0 {
+		descriptor.Limits.MaxInputTokens = &entry.maxInputTokens
+	}
+	if entry.maxOutputTokens > 0 {
+		descriptor.Limits.MaxOutputTokens = &entry.maxOutputTokens
+	}
+	return descriptor
+}
+
+// Catalog returns every built-in model descriptor under provider, sorted by
+// model name. Descriptors carry the driver-declared capabilities, limits, and
+// lifecycle; Operations stay empty because the inference assembly derives them
+// from the model's openers after deployment. Provider IDs are a deployment
+// property, so callers supply the identity that appears in each descriptor.
+func Catalog(provider string) ([]inference.ModelDescriptor, error) {
+	if provider == "" {
+		return nil, fmt.Errorf("catalog: provider is required")
+	}
+	descriptors := make([]inference.ModelDescriptor, 0, len(catalog))
+	for _, name := range sortedNames(catalog) {
+		descriptor := descriptorFor(
+			inference.ModelID{Provider: provider, Name: name},
+			catalog[name],
+		)
+		descriptors = append(descriptors, descriptor)
+	}
+	return descriptors, nil
+}

--- a/driver/deepseek/catalog_export_test.go
+++ b/driver/deepseek/catalog_export_test.go
@@ -1,0 +1,28 @@
+package deepseek
+
+import "testing"
+
+func TestCatalogExportsBuiltinModels(t *testing.T) {
+	const provider = "deepseek"
+	descriptors, err := Catalog(provider)
+	if err != nil {
+		t.Fatalf("Catalog: %v", err)
+	}
+	if len(descriptors) != len(catalog) {
+		t.Fatalf("Catalog returned %d descriptors, want %d",
+			len(descriptors), len(catalog))
+	}
+	for i, descriptor := range descriptors {
+		if descriptor.ID.Provider != provider {
+			t.Errorf("descriptor %d provider = %q, want %q",
+				i, descriptor.ID.Provider, provider)
+		}
+		if i > 0 && descriptors[i-1].ID.Name >= descriptor.ID.Name {
+			t.Errorf("descriptors not sorted at %d (%q after %q)",
+				i, descriptor.ID.Name, descriptors[i-1].ID.Name)
+		}
+	}
+	if _, err := Catalog(""); err == nil {
+		t.Fatal(`Catalog("") succeeded, want error`)
+	}
+}

--- a/driver/deepseek/go.mod
+++ b/driver/deepseek/go.mod
@@ -3,7 +3,7 @@ module github.com/GizClaw/flowcraft/driver/deepseek
 go 1.25.0
 
 require (
-	github.com/GizClaw/flowcraft/core v0.2.4
+	github.com/GizClaw/flowcraft/core v0.2.6
 	github.com/openai/openai-go/v3 v3.50.0
 	go.opentelemetry.io/otel/log v0.19.0
 )

--- a/driver/deepseek/go.sum
+++ b/driver/deepseek/go.sum
@@ -1,5 +1,5 @@
-github.com/GizClaw/flowcraft/core v0.2.4 h1:LnBC7iKyr6v9AJTvbZCgBT5n0ifx4xb2zdNwCvs3mPE=
-github.com/GizClaw/flowcraft/core v0.2.4/go.mod h1:oM890ls+7bEtnG6LfBcDfrmKSm+hQPNzutRpQf3hscI=
+github.com/GizClaw/flowcraft/core v0.2.6 h1:q8rSQRfJoOdy8VJv7oRBXVMsNCZ0Wabg1uNpHMpCS8M=
+github.com/GizClaw/flowcraft/core v0.2.6/go.mod h1:oM890ls+7bEtnG6LfBcDfrmKSm+hQPNzutRpQf3hscI=
 github.com/cenkalti/backoff/v5 v5.0.3 h1:ZN+IMa753KfX5hd8vVaMixjnqRZ3y8CuJKRKj1xcsSM=
 github.com/cenkalti/backoff/v5 v5.0.3/go.mod h1:rkhZdG3JZukswDf7f0cwqPNk4K0sa+F97BxZthm/crw=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=

--- a/driver/deepseek/resource.go
+++ b/driver/deepseek/resource.go
@@ -141,16 +141,7 @@ func buildProvider(ctx context.Context, settings ResourceSettings, secrets *reso
 		entry := models[name]
 		entry.api = spec.apiMode()
 		id := inference.ModelID{Provider: settings.ID, Name: name}
-		descriptor := inference.ModelDescriptor{
-			ID:           id,
-			Capabilities: entry.capabilities,
-		}
-		if entry.maxInputTokens > 0 {
-			descriptor.Limits.MaxInputTokens = &entry.maxInputTokens
-		}
-		if entry.maxOutputTokens > 0 {
-			descriptor.Limits.MaxOutputTokens = &entry.maxOutputTokens
-		}
+		descriptor := descriptorFor(id, entry)
 		provider.Models = append(provider.Models, inference.ModelImplementation{
 			Descriptor: descriptor,
 			Openers:    openersFor(spec, entry, profiles, id),

--- a/driver/kimi/catalog.go
+++ b/driver/kimi/catalog.go
@@ -219,3 +219,40 @@ func sortedNames(models map[string]catalogEntry) []string {
 	sort.Strings(names)
 	return names
 }
+
+// descriptorFor lowers one catalog entry into its public discovery
+// descriptor under id. buildProvider and Catalog share this lowering so
+// offline catalog views cannot drift from deployed provider models.
+func descriptorFor(id inference.ModelID, entry catalogEntry) inference.ModelDescriptor {
+	descriptor := inference.ModelDescriptor{
+		ID:           id,
+		Capabilities: entry.capabilities,
+	}
+	if entry.maxInputTokens > 0 {
+		descriptor.Limits.MaxInputTokens = &entry.maxInputTokens
+	}
+	if entry.maxOutputTokens > 0 {
+		descriptor.Limits.MaxOutputTokens = &entry.maxOutputTokens
+	}
+	return descriptor
+}
+
+// Catalog returns every built-in model descriptor under provider, sorted by
+// model name. Descriptors carry the driver-declared capabilities, limits, and
+// lifecycle; Operations stay empty because the inference assembly derives them
+// from the model's openers after deployment. Provider IDs are a deployment
+// property, so callers supply the identity that appears in each descriptor.
+func Catalog(provider string) ([]inference.ModelDescriptor, error) {
+	if provider == "" {
+		return nil, fmt.Errorf("catalog: provider is required")
+	}
+	descriptors := make([]inference.ModelDescriptor, 0, len(catalog))
+	for _, name := range sortedNames(catalog) {
+		descriptor := descriptorFor(
+			inference.ModelID{Provider: provider, Name: name},
+			catalog[name],
+		)
+		descriptors = append(descriptors, descriptor)
+	}
+	return descriptors, nil
+}

--- a/driver/kimi/catalog_export_test.go
+++ b/driver/kimi/catalog_export_test.go
@@ -1,0 +1,28 @@
+package kimi
+
+import "testing"
+
+func TestCatalogExportsBuiltinModels(t *testing.T) {
+	const provider = "kimi"
+	descriptors, err := Catalog(provider)
+	if err != nil {
+		t.Fatalf("Catalog: %v", err)
+	}
+	if len(descriptors) != len(catalog) {
+		t.Fatalf("Catalog returned %d descriptors, want %d",
+			len(descriptors), len(catalog))
+	}
+	for i, descriptor := range descriptors {
+		if descriptor.ID.Provider != provider {
+			t.Errorf("descriptor %d provider = %q, want %q",
+				i, descriptor.ID.Provider, provider)
+		}
+		if i > 0 && descriptors[i-1].ID.Name >= descriptor.ID.Name {
+			t.Errorf("descriptors not sorted at %d (%q after %q)",
+				i, descriptor.ID.Name, descriptors[i-1].ID.Name)
+		}
+	}
+	if _, err := Catalog(""); err == nil {
+		t.Fatal(`Catalog("") succeeded, want error`)
+	}
+}

--- a/driver/kimi/go.mod
+++ b/driver/kimi/go.mod
@@ -3,7 +3,7 @@ module github.com/GizClaw/flowcraft/driver/kimi
 go 1.25.0
 
 require (
-	github.com/GizClaw/flowcraft/core v0.2.4
+	github.com/GizClaw/flowcraft/core v0.2.6
 	go.opentelemetry.io/otel/log v0.19.0
 )
 

--- a/driver/kimi/go.sum
+++ b/driver/kimi/go.sum
@@ -1,5 +1,5 @@
-github.com/GizClaw/flowcraft/core v0.2.4 h1:LnBC7iKyr6v9AJTvbZCgBT5n0ifx4xb2zdNwCvs3mPE=
-github.com/GizClaw/flowcraft/core v0.2.4/go.mod h1:oM890ls+7bEtnG6LfBcDfrmKSm+hQPNzutRpQf3hscI=
+github.com/GizClaw/flowcraft/core v0.2.6 h1:q8rSQRfJoOdy8VJv7oRBXVMsNCZ0Wabg1uNpHMpCS8M=
+github.com/GizClaw/flowcraft/core v0.2.6/go.mod h1:oM890ls+7bEtnG6LfBcDfrmKSm+hQPNzutRpQf3hscI=
 github.com/cenkalti/backoff/v5 v5.0.3 h1:ZN+IMa753KfX5hd8vVaMixjnqRZ3y8CuJKRKj1xcsSM=
 github.com/cenkalti/backoff/v5 v5.0.3/go.mod h1:rkhZdG3JZukswDf7f0cwqPNk4K0sa+F97BxZthm/crw=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=

--- a/driver/kimi/resource.go
+++ b/driver/kimi/resource.go
@@ -93,16 +93,7 @@ func buildProvider(ctx context.Context, settings ResourceSettings, secrets *reso
 	for _, name := range sortedNames(models) {
 		entry := models[name]
 		id := inference.ModelID{Provider: settings.ID, Name: name}
-		descriptor := inference.ModelDescriptor{
-			ID:           id,
-			Capabilities: entry.capabilities,
-		}
-		if entry.maxInputTokens > 0 {
-			descriptor.Limits.MaxInputTokens = &entry.maxInputTokens
-		}
-		if entry.maxOutputTokens > 0 {
-			descriptor.Limits.MaxOutputTokens = &entry.maxOutputTokens
-		}
+		descriptor := descriptorFor(id, entry)
 		provider.Models = append(provider.Models, inference.ModelImplementation{
 			Descriptor: descriptor,
 			Openers:    openersFor(spec, entry, profiles, id),

--- a/driver/minimax/catalog.go
+++ b/driver/minimax/catalog.go
@@ -396,3 +396,40 @@ func sortedNames(models map[string]catalogEntry) []string {
 	sort.Strings(names)
 	return names
 }
+
+// descriptorFor lowers one catalog entry into its public discovery
+// descriptor under id. buildProvider and Catalog share this lowering so
+// offline catalog views cannot drift from deployed provider models.
+func descriptorFor(id inference.ModelID, entry catalogEntry) inference.ModelDescriptor {
+	descriptor := inference.ModelDescriptor{
+		ID:           id,
+		Capabilities: entry.capabilities,
+	}
+	if entry.maxInputTokens > 0 {
+		descriptor.Limits.MaxInputTokens = &entry.maxInputTokens
+	}
+	if entry.maxOutputTokens > 0 {
+		descriptor.Limits.MaxOutputTokens = &entry.maxOutputTokens
+	}
+	return descriptor
+}
+
+// Catalog returns every built-in model descriptor under provider, sorted by
+// model name. Descriptors carry the driver-declared capabilities, limits, and
+// lifecycle; Operations stay empty because the inference assembly derives them
+// from the model's openers after deployment. Provider IDs are a deployment
+// property, so callers supply the identity that appears in each descriptor.
+func Catalog(provider string) ([]inference.ModelDescriptor, error) {
+	if provider == "" {
+		return nil, fmt.Errorf("catalog: provider is required")
+	}
+	descriptors := make([]inference.ModelDescriptor, 0, len(catalog))
+	for _, name := range sortedNames(catalog) {
+		descriptor := descriptorFor(
+			inference.ModelID{Provider: provider, Name: name},
+			catalog[name],
+		)
+		descriptors = append(descriptors, descriptor)
+	}
+	return descriptors, nil
+}

--- a/driver/minimax/catalog_export_test.go
+++ b/driver/minimax/catalog_export_test.go
@@ -1,0 +1,28 @@
+package minimax
+
+import "testing"
+
+func TestCatalogExportsBuiltinModels(t *testing.T) {
+	const provider = "minimax"
+	descriptors, err := Catalog(provider)
+	if err != nil {
+		t.Fatalf("Catalog: %v", err)
+	}
+	if len(descriptors) != len(catalog) {
+		t.Fatalf("Catalog returned %d descriptors, want %d",
+			len(descriptors), len(catalog))
+	}
+	for i, descriptor := range descriptors {
+		if descriptor.ID.Provider != provider {
+			t.Errorf("descriptor %d provider = %q, want %q",
+				i, descriptor.ID.Provider, provider)
+		}
+		if i > 0 && descriptors[i-1].ID.Name >= descriptor.ID.Name {
+			t.Errorf("descriptors not sorted at %d (%q after %q)",
+				i, descriptor.ID.Name, descriptors[i-1].ID.Name)
+		}
+	}
+	if _, err := Catalog(""); err == nil {
+		t.Fatal(`Catalog("") succeeded, want error`)
+	}
+}

--- a/driver/minimax/go.mod
+++ b/driver/minimax/go.mod
@@ -3,7 +3,7 @@ module github.com/GizClaw/flowcraft/driver/minimax
 go 1.25.0
 
 require (
-	github.com/GizClaw/flowcraft/core v0.2.4
+	github.com/GizClaw/flowcraft/core v0.2.6
 	github.com/anthropics/anthropic-sdk-go v1.61.0
 	go.opentelemetry.io/otel/log v0.19.0
 )

--- a/driver/minimax/go.sum
+++ b/driver/minimax/go.sum
@@ -1,5 +1,5 @@
-github.com/GizClaw/flowcraft/core v0.2.4 h1:LnBC7iKyr6v9AJTvbZCgBT5n0ifx4xb2zdNwCvs3mPE=
-github.com/GizClaw/flowcraft/core v0.2.4/go.mod h1:oM890ls+7bEtnG6LfBcDfrmKSm+hQPNzutRpQf3hscI=
+github.com/GizClaw/flowcraft/core v0.2.6 h1:q8rSQRfJoOdy8VJv7oRBXVMsNCZ0Wabg1uNpHMpCS8M=
+github.com/GizClaw/flowcraft/core v0.2.6/go.mod h1:oM890ls+7bEtnG6LfBcDfrmKSm+hQPNzutRpQf3hscI=
 github.com/anthropics/anthropic-sdk-go v1.61.0 h1:JRTnm1tPqn5xo1xd1zfrcFDlcoWXVMvV1K68YmhpZKw=
 github.com/anthropics/anthropic-sdk-go v1.61.0/go.mod h1:3EfIfmFqxH6rbiLcIP4tPFyXL/IHakx2wDG4OU+TIEI=
 github.com/bahlo/generic-list-go v0.2.0 h1:5sz/EEAK+ls5wF+NeqDpk5+iNdMDXrh3z3nPnH1Wvgk=

--- a/driver/minimax/resource.go
+++ b/driver/minimax/resource.go
@@ -100,16 +100,7 @@ func buildProvider(ctx context.Context, settings ResourceSettings, secrets *reso
 	for _, name := range sortedNames(models) {
 		entry := models[name]
 		id := inference.ModelID{Provider: settings.ID, Name: name}
-		descriptor := inference.ModelDescriptor{
-			ID:           id,
-			Capabilities: entry.capabilities,
-		}
-		if entry.maxInputTokens > 0 {
-			descriptor.Limits.MaxInputTokens = &entry.maxInputTokens
-		}
-		if entry.maxOutputTokens > 0 {
-			descriptor.Limits.MaxOutputTokens = &entry.maxOutputTokens
-		}
+		descriptor := descriptorFor(id, entry)
 		provider.Models = append(provider.Models, inference.ModelImplementation{
 			Descriptor: descriptor,
 			Openers:    openersFor(spec, entry, profiles, id),

--- a/driver/openai/catalog.go
+++ b/driver/openai/catalog.go
@@ -308,3 +308,55 @@ func mergedCatalog(spec Spec) (map[string]catalogEntry, error) {
 	}
 	return models, nil
 }
+
+// descriptorFor lowers one catalog entry into its public discovery
+// descriptor under id. buildProvider and Catalog share this lowering so
+// offline catalog views cannot drift from deployed provider models.
+func descriptorFor(id inference.ModelID, entry catalogEntry) inference.ModelDescriptor {
+	descriptor := inference.ModelDescriptor{
+		ID:           id,
+		Capabilities: entry.capabilities,
+	}
+	if entry.deprecated {
+		descriptor.Lifecycle.Status = inference.ModelStatusDeprecated
+		if entry.replacement != "" {
+			replacement := inference.ModelID{
+				Provider: id.Provider,
+				Name:     entry.replacement,
+			}
+			descriptor.Lifecycle.Replacement = &replacement
+		}
+	}
+	if entry.maxInputTokens > 0 {
+		descriptor.Limits.MaxInputTokens = &entry.maxInputTokens
+	}
+	if entry.maxOutputTokens > 0 {
+		descriptor.Limits.MaxOutputTokens = &entry.maxOutputTokens
+	}
+	return descriptor
+}
+
+// Catalog returns every built-in model descriptor under provider, sorted by
+// model name. Descriptors carry the driver-declared capabilities, limits, and
+// lifecycle; Operations stay empty because the inference assembly derives them
+// from the model's openers after deployment. Provider IDs are a deployment
+// property, so callers supply the identity that appears in each descriptor.
+func Catalog(provider string) ([]inference.ModelDescriptor, error) {
+	if provider == "" {
+		return nil, fmt.Errorf("catalog: provider is required")
+	}
+	names := make([]string, 0, len(catalog))
+	for name := range catalog {
+		names = append(names, name)
+	}
+	slices.Sort(names)
+	descriptors := make([]inference.ModelDescriptor, 0, len(catalog))
+	for _, name := range names {
+		descriptor := descriptorFor(
+			inference.ModelID{Provider: provider, Name: name},
+			catalog[name],
+		)
+		descriptors = append(descriptors, descriptor)
+	}
+	return descriptors, nil
+}

--- a/driver/openai/catalog_export_test.go
+++ b/driver/openai/catalog_export_test.go
@@ -1,0 +1,28 @@
+package openai
+
+import "testing"
+
+func TestCatalogExportsBuiltinModels(t *testing.T) {
+	const provider = "openai"
+	descriptors, err := Catalog(provider)
+	if err != nil {
+		t.Fatalf("Catalog: %v", err)
+	}
+	if len(descriptors) != len(catalog) {
+		t.Fatalf("Catalog returned %d descriptors, want %d",
+			len(descriptors), len(catalog))
+	}
+	for i, descriptor := range descriptors {
+		if descriptor.ID.Provider != provider {
+			t.Errorf("descriptor %d provider = %q, want %q",
+				i, descriptor.ID.Provider, provider)
+		}
+		if i > 0 && descriptors[i-1].ID.Name >= descriptor.ID.Name {
+			t.Errorf("descriptors not sorted at %d (%q after %q)",
+				i, descriptor.ID.Name, descriptors[i-1].ID.Name)
+		}
+	}
+	if _, err := Catalog(""); err == nil {
+		t.Fatal(`Catalog("") succeeded, want error`)
+	}
+}

--- a/driver/openai/go.mod
+++ b/driver/openai/go.mod
@@ -3,7 +3,7 @@ module github.com/GizClaw/flowcraft/driver/openai
 go 1.25.0
 
 require (
-	github.com/GizClaw/flowcraft/core v0.2.4
+	github.com/GizClaw/flowcraft/core v0.2.6
 	github.com/openai/openai-go/v3 v3.50.0
 	go.opentelemetry.io/otel/log v0.19.0
 )

--- a/driver/openai/go.sum
+++ b/driver/openai/go.sum
@@ -1,5 +1,5 @@
-github.com/GizClaw/flowcraft/core v0.2.4 h1:LnBC7iKyr6v9AJTvbZCgBT5n0ifx4xb2zdNwCvs3mPE=
-github.com/GizClaw/flowcraft/core v0.2.4/go.mod h1:oM890ls+7bEtnG6LfBcDfrmKSm+hQPNzutRpQf3hscI=
+github.com/GizClaw/flowcraft/core v0.2.6 h1:q8rSQRfJoOdy8VJv7oRBXVMsNCZ0Wabg1uNpHMpCS8M=
+github.com/GizClaw/flowcraft/core v0.2.6/go.mod h1:oM890ls+7bEtnG6LfBcDfrmKSm+hQPNzutRpQf3hscI=
 github.com/cenkalti/backoff/v5 v5.0.3 h1:ZN+IMa753KfX5hd8vVaMixjnqRZ3y8CuJKRKj1xcsSM=
 github.com/cenkalti/backoff/v5 v5.0.3/go.mod h1:rkhZdG3JZukswDf7f0cwqPNk4K0sa+F97BxZthm/crw=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=

--- a/driver/openai/resource.go
+++ b/driver/openai/resource.go
@@ -119,26 +119,7 @@ func buildProvider(ctx context.Context, settings ResourceSettings, secrets *reso
 		entry := models[name]
 		entry.api = spec.apiMode()
 		id := inference.ModelID{Provider: settings.ID, Name: name}
-		descriptor := inference.ModelDescriptor{
-			ID:           id,
-			Capabilities: entry.capabilities,
-		}
-		if entry.deprecated {
-			descriptor.Lifecycle.Status = inference.ModelStatusDeprecated
-			if entry.replacement != "" {
-				replacement := inference.ModelID{
-					Provider: settings.ID,
-					Name:     entry.replacement,
-				}
-				descriptor.Lifecycle.Replacement = &replacement
-			}
-		}
-		if entry.maxInputTokens > 0 {
-			descriptor.Limits.MaxInputTokens = &entry.maxInputTokens
-		}
-		if entry.maxOutputTokens > 0 {
-			descriptor.Limits.MaxOutputTokens = &entry.maxOutputTokens
-		}
+		descriptor := descriptorFor(id, entry)
 		provider.Models = append(provider.Models, inference.ModelImplementation{
 			Descriptor: descriptor,
 			Openers:    openersFor(spec, entry, profiles, id),

--- a/driver/qwen/catalog.go
+++ b/driver/qwen/catalog.go
@@ -257,3 +257,40 @@ func unionKinds(base, addition []message.PartKind) []message.PartKind {
 	}
 	return result
 }
+
+// descriptorFor lowers one catalog entry into its public discovery
+// descriptor under id. buildProvider and Catalog share this lowering so
+// offline catalog views cannot drift from deployed provider models.
+func descriptorFor(id inference.ModelID, entry catalogEntry) inference.ModelDescriptor {
+	descriptor := inference.ModelDescriptor{
+		ID:           id,
+		Capabilities: entry.capabilities,
+	}
+	if entry.maxInputTokens > 0 {
+		descriptor.Limits.MaxInputTokens = &entry.maxInputTokens
+	}
+	if entry.maxOutputTokens > 0 {
+		descriptor.Limits.MaxOutputTokens = &entry.maxOutputTokens
+	}
+	return descriptor
+}
+
+// Catalog returns every built-in model descriptor under provider, sorted by
+// model name. Descriptors carry the driver-declared capabilities, limits, and
+// lifecycle; Operations stay empty because the inference assembly derives them
+// from the model's openers after deployment. Provider IDs are a deployment
+// property, so callers supply the identity that appears in each descriptor.
+func Catalog(provider string) ([]inference.ModelDescriptor, error) {
+	if provider == "" {
+		return nil, fmt.Errorf("catalog: provider is required")
+	}
+	descriptors := make([]inference.ModelDescriptor, 0, len(catalog))
+	for _, name := range sortedNames(catalog) {
+		descriptor := descriptorFor(
+			inference.ModelID{Provider: provider, Name: name},
+			catalog[name],
+		)
+		descriptors = append(descriptors, descriptor)
+	}
+	return descriptors, nil
+}

--- a/driver/qwen/catalog_export_test.go
+++ b/driver/qwen/catalog_export_test.go
@@ -1,0 +1,28 @@
+package qwen
+
+import "testing"
+
+func TestCatalogExportsBuiltinModels(t *testing.T) {
+	const provider = "qwen"
+	descriptors, err := Catalog(provider)
+	if err != nil {
+		t.Fatalf("Catalog: %v", err)
+	}
+	if len(descriptors) != len(catalog) {
+		t.Fatalf("Catalog returned %d descriptors, want %d",
+			len(descriptors), len(catalog))
+	}
+	for i, descriptor := range descriptors {
+		if descriptor.ID.Provider != provider {
+			t.Errorf("descriptor %d provider = %q, want %q",
+				i, descriptor.ID.Provider, provider)
+		}
+		if i > 0 && descriptors[i-1].ID.Name >= descriptor.ID.Name {
+			t.Errorf("descriptors not sorted at %d (%q after %q)",
+				i, descriptor.ID.Name, descriptors[i-1].ID.Name)
+		}
+	}
+	if _, err := Catalog(""); err == nil {
+		t.Fatal(`Catalog("") succeeded, want error`)
+	}
+}

--- a/driver/qwen/go.mod
+++ b/driver/qwen/go.mod
@@ -3,7 +3,7 @@ module github.com/GizClaw/flowcraft/driver/qwen
 go 1.25.0
 
 require (
-	github.com/GizClaw/flowcraft/core v0.2.4
+	github.com/GizClaw/flowcraft/core v0.2.6
 	go.opentelemetry.io/otel/log v0.19.0
 )
 

--- a/driver/qwen/go.sum
+++ b/driver/qwen/go.sum
@@ -1,5 +1,5 @@
-github.com/GizClaw/flowcraft/core v0.2.4 h1:LnBC7iKyr6v9AJTvbZCgBT5n0ifx4xb2zdNwCvs3mPE=
-github.com/GizClaw/flowcraft/core v0.2.4/go.mod h1:oM890ls+7bEtnG6LfBcDfrmKSm+hQPNzutRpQf3hscI=
+github.com/GizClaw/flowcraft/core v0.2.6 h1:q8rSQRfJoOdy8VJv7oRBXVMsNCZ0Wabg1uNpHMpCS8M=
+github.com/GizClaw/flowcraft/core v0.2.6/go.mod h1:oM890ls+7bEtnG6LfBcDfrmKSm+hQPNzutRpQf3hscI=
 github.com/cenkalti/backoff/v5 v5.0.3 h1:ZN+IMa753KfX5hd8vVaMixjnqRZ3y8CuJKRKj1xcsSM=
 github.com/cenkalti/backoff/v5 v5.0.3/go.mod h1:rkhZdG3JZukswDf7f0cwqPNk4K0sa+F97BxZthm/crw=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=

--- a/driver/qwen/resource.go
+++ b/driver/qwen/resource.go
@@ -97,16 +97,7 @@ func buildProvider(ctx context.Context, settings ResourceSettings, secrets *reso
 	for _, name := range sortedNames(models) {
 		entry := models[name]
 		id := inference.ModelID{Provider: settings.ID, Name: name}
-		descriptor := inference.ModelDescriptor{
-			ID:           id,
-			Capabilities: entry.capabilities,
-		}
-		if entry.maxInputTokens > 0 {
-			descriptor.Limits.MaxInputTokens = &entry.maxInputTokens
-		}
-		if entry.maxOutputTokens > 0 {
-			descriptor.Limits.MaxOutputTokens = &entry.maxOutputTokens
-		}
+		descriptor := descriptorFor(id, entry)
 		provider.Models = append(provider.Models, inference.ModelImplementation{
 			Descriptor: descriptor,
 			Openers:    openersFor(spec, entry, profiles, id),


### PR DESCRIPTION
Two commits:

1. **chore(deps): bump core to v0.2.6 in drivers** — all eight driver modules now pin `core v0.2.6` (the release carrying `ModelLimits.MaxOutputTokens`, which the drivers' catalog/spec code from #505 compiles against).

2. **feat(driver): export built-in model catalogs via Catalog(provider)** — each driver exposes

   ```go
   func Catalog(provider string) ([]inference.ModelDescriptor, error)
   ```

   returning the built-in lineup (capabilities, limits, lifecycle) sorted by name. Descriptor lowering is shared with `buildProvider` via `descriptorFor`, so offline catalog views cannot drift from deployed models. `Operations` stay empty because the inference assembly derives them from openers after deployment. Azure has no built-in lineup (models are deployment-declared), so its `Catalog` reports an empty catalog by design.

Verified locally: `GOWORK=off go test ./... -count=1` and `go vet ./...` pass in all eight driver modules; `git diff --check` clean.