### PR TITLE
feat(core/inference): unified model capability declarations and reasoning contract

### DIFF
--- a/.release/core-v0.2.7.json
+++ b/.release/core-v0.2.7.json
@@ -1,0 +1,9 @@
+{
+  "summary": "feat(core/inference): unify model capability declarations and tighten the reasoning contract — new CapabilitiesPatch/ReasoningPatch give provider specs leaf-level overlay semantics (written leaves replace, unstated leaves inherit, and the legacy `reasoning: \"toggle\"` string form stays backward compatible and now patches only the kind), ModelCapabilities gains CustomEmbedDimensions as a published per-model capability bit alongside hosted web search, ModelLimits grows WithMaxInputTokens/WithMaxOutputTokens/Values so resolved catalog limits share one type with descriptors, and ReasoningKind semantics are made explicit: a model published as `toggle` must compile reasoning_enabled=false on its provider surface while `always` rejects it, enforced by a shared ReasoningOffProbe conformance helper and conformance tests across every driver; drivers (anthropic, azure, bytedance, deepseek, kimi, minimax, openai, qwen) migrated catalog merges to the shared overlay and limits type and removed driver-private control flags (openai/azure effort_none, per-driver top-level dimensions, deepseek per-model responses), so deployment specs changed accordingly: removed keys are rejected by strict decoding, custom_embed_dimensions lives under capabilities, reasoning off needs no knob, and capability/limits/guard behavior is covered by contract tests",
+  "releases": [
+    {
+      "module": "core",
+      "bump": "patch"
+    }
+  ]
+}

--- a/core/inference/generate_intent.go
+++ b/core/inference/generate_intent.go
@@ -98,11 +98,13 @@ type TextIntent struct {
 	// Sampling controls: temperature in [0, 2], top_p in [0, 1].
 	Temperature *float64 `json:"temperature,omitempty"`
 	TopP        *float64 `json:"top_p,omitempty"`
-	// ReasoningEnabled is the universal reasoning switch — every
-	// provider can turn thinking on or off, so the compiler honors it
-	// exactly (or rejects where a model cannot comply). ReasoningEffort
-	// tunes depth where the platform has levels; platforms whose
-	// thinking is binary quantize it, and the compiler reports the loss.
+	// ReasoningEnabled is the universal reasoning switch. The model's
+	// published ReasoningKind decides how a compiler honors it: "toggle"
+	// models must compile reasoning_enabled=false on the publishing
+	// provider surface, "always" models reject it, and "none" models have
+	// no reasoning to switch. ReasoningEffort tunes depth where the
+	// platform has levels; platforms whose thinking is binary quantize it,
+	// and the compiler reports the loss.
 	ReasoningEnabled *bool           `json:"reasoning_enabled,omitempty"`
 	ReasoningEffort  ReasoningEffort `json:"reasoning_effort,omitempty"`
 }

--- a/core/inference/inferencetest/reasoning_probe.go
+++ b/core/inference/inferencetest/reasoning_probe.go
@@ -1,0 +1,30 @@
+package inferencetest
+
+import (
+	"github.com/GizClaw/flowcraft/core/inference"
+	"github.com/GizClaw/flowcraft/core/message"
+)
+
+// ReasoningOffProbe returns the canonical unary GenerateRequest that driver
+// conformance suites use to verify the reasoning "toggle" contract: a plain
+// text generation with reasoning_enabled=false. A model published with
+// ReasoningToggle must compile this probe successfully; a ReasoningAlways
+// model must reject it on the reasoning_enabled field. Keeping the probe
+// here (instead of in every driver's tests) gives the contract one shared
+// spelling across providers.
+func ReasoningOffProbe() inference.GenerateRequest {
+	request := inference.GenerateRequest{
+		Input: inference.GenerateInput{
+			Role: inference.InputRoleUser,
+			Content: inference.InputContent{
+				Content: message.Content{
+					Parts: []message.Part{message.TextPart{Text: "probe"}},
+				},
+				Intent: inference.Intent{Text: &inference.TextIntent{}},
+			},
+		},
+	}
+	disabled := false
+	request.Input.Content.Intent.Text.ReasoningEnabled = &disabled
+	return request
+}

--- a/core/inference/model.go
+++ b/core/inference/model.go
@@ -119,6 +119,15 @@ func (l ModelLifecycle) ValidateFor(model ModelID) error {
 // ReasoningKind declares a model's reasoning control capability. Zero is the
 // conservative declaration: a model without a declared reasoning capability
 // has no reasoning channel or reasoning controls.
+//
+// Kind is a promise about the provider surface that publishes it, not just
+// about the physical model: a model published as ReasoningToggle must compile
+// reasoning_enabled=false successfully on that provider instance, and one
+// published as ReasoningAlways may reject it. Providers whose wire cannot
+// express "off" for a model on a given surface (for example Chat Completions
+// for models whose Responses surface accepts reasoning.effort=none) must
+// publish ReasoningAlways on that surface; driver conformance suites verify
+// the promise for every published entry.
 type ReasoningKind string
 
 const (
@@ -137,11 +146,13 @@ func (k ReasoningKind) Validate() error {
 }
 
 // ReasoningCapability declares a model's reasoning control surface. Kind
-// keeps the switch semantics (none / always / toggle); EffortMap declares
-// exactly how the five canonical ReasoningEffort levels map onto this
-// model's own wire levels (for example kimi-k3 maps xhigh to "max"). A
-// non-nil EffortMap must cover all five canonical levels; an empty map on
-// a reasoning model means binary thinking with no depth dial.
+// keeps the switch semantics (none / always / toggle): none has no
+// reasoning channel, always cannot be turned off, and toggle promises that
+// reasoning_enabled=false compiles on the publishing provider surface.
+// EffortMap declares exactly how the five canonical ReasoningEffort levels
+// map onto this model's own wire levels (for example kimi-k3 maps xhigh to
+// "max"). A non-nil EffortMap must cover all five canonical levels; an
+// empty map on a reasoning model means binary thinking with no depth dial.
 type ReasoningCapability struct {
 	Kind ReasoningKind `json:"kind,omitempty"`
 	// EffortMap maps each canonical ReasoningEffort onto the model's wire
@@ -163,11 +174,22 @@ func (r ReasoningCapability) Validate() error {
 	if err := r.Kind.Validate(); err != nil {
 		return err
 	}
-	if len(r.EffortMap) == 0 {
-		return nil
-	}
 	if r.Kind == ReasoningNone {
+		if len(r.EffortMap) == 0 {
+			return nil
+		}
 		return fmt.Errorf("reasoning effort map requires a reasoning capability")
+	}
+	return validateReasoningEffortMap(r.EffortMap)
+}
+
+// validateReasoningEffortMap checks a canonical-to-wire effort map: a
+// non-empty map must cover all five canonical levels with well-formed wire
+// tokens and contain no foreign keys. An empty map is the no-dial
+// declaration.
+func validateReasoningEffortMap(efforts map[ReasoningEffort]string) error {
+	if len(efforts) == 0 {
+		return nil
 	}
 	for _, effort := range []ReasoningEffort{
 		ReasoningMinimal,
@@ -176,7 +198,7 @@ func (r ReasoningCapability) Validate() error {
 		ReasoningHigh,
 		ReasoningXHigh,
 	} {
-		mode, ok := r.EffortMap[effort]
+		mode, ok := efforts[effort]
 		if !ok {
 			return fmt.Errorf(
 				"reasoning effort map misses canonical level %q",
@@ -191,7 +213,7 @@ func (r ReasoningCapability) Validate() error {
 			)
 		}
 	}
-	for effort := range r.EffortMap {
+	for effort := range efforts {
 		switch effort {
 		case ReasoningMinimal, ReasoningLow, ReasoningMedium,
 			ReasoningHigh, ReasoningXHigh:
@@ -297,6 +319,14 @@ type ModelCapabilities struct {
 	// rides on GenerateRequest.Extensions as a provider GenerateOptions
 	// extension.
 	HostedWebSearch bool `json:"hosted_web_search,omitempty"`
+	// CustomEmbedDimensions marks embed models whose API accepts the
+	// optional output-dimensions parameter on EmbedRequest. Like
+	// HostedWebSearch it is discovery metadata: hosts surface the knob from
+	// the descriptor, and compilers reject the field for models without
+	// it. Drivers with exact-size constraints (for example Qwen's embed
+	// whitelist) validate the requested size against their own catalog
+	// facts at compile time.
+	CustomEmbedDimensions bool `json:"custom_embed_dimensions,omitempty"`
 }
 
 // Clone returns a defensive copy of the capabilities: the returned value
@@ -353,29 +383,47 @@ func (c ModelCapabilities) WithHostedWebSearch() ModelCapabilities {
 	return c
 }
 
+// WithCustomEmbedDimensions returns a copy of the capabilities with custom
+// embed output dimensions marked supported.
+func (c ModelCapabilities) WithCustomEmbedDimensions() ModelCapabilities {
+	c.CustomEmbedDimensions = true
+	return c
+}
+
 func (c ModelCapabilities) Validate() error {
 	if err := c.Reasoning.Validate(); err != nil {
 		return err
 	}
-	seenInputs := make(map[message.PartKind]struct{}, len(c.Inputs))
-	for _, kind := range c.Inputs {
-		if err := kind.Validate(); err != nil {
-			return fmt.Errorf("input content kind: %w", err)
-		}
-		if _, ok := seenInputs[kind]; ok {
-			return fmt.Errorf("duplicate input content kind %q", kind)
-		}
-		seenInputs[kind] = struct{}{}
+	if err := validatePartKinds(c.Inputs, true); err != nil {
+		return err
 	}
-	seenOutputs := make(map[message.PartKind]struct{}, len(c.Outputs))
-	for _, kind := range c.Outputs {
-		if !isOutputModality(kind) {
-			return fmt.Errorf("output content kind %q is not a representable output modality", kind)
+	return validatePartKinds(c.Outputs, false)
+}
+
+// validatePartKinds checks one content-kind list: kinds must be valid
+// (inputs) or representable output modalities (outputs) and must not
+// repeat.
+func validatePartKinds(kinds []message.PartKind, inputs bool) error {
+	seen := make(map[message.PartKind]struct{}, len(kinds))
+	for _, kind := range kinds {
+		if inputs {
+			if err := kind.Validate(); err != nil {
+				return fmt.Errorf("input content kind: %w", err)
+			}
+		} else if !isOutputModality(kind) {
+			return fmt.Errorf(
+				"output content kind %q is not a representable output modality",
+				kind,
+			)
 		}
-		if _, ok := seenOutputs[kind]; ok {
-			return fmt.Errorf("duplicate output content kind %q", kind)
+		if _, ok := seen[kind]; ok {
+			word := "input"
+			if !inputs {
+				word = "output"
+			}
+			return fmt.Errorf("duplicate %s content kind %q", word, kind)
 		}
-		seenOutputs[kind] = struct{}{}
+		seen[kind] = struct{}{}
 	}
 	return nil
 }
@@ -410,6 +458,39 @@ func (l ModelLimits) Clone() ModelLimits {
 		MaxInputTokens:  clonePointer(l.MaxInputTokens),
 		MaxOutputTokens: clonePointer(l.MaxOutputTokens),
 	}
+}
+
+// WithMaxInputTokens returns limits declaring the input-context window.
+// Values at or below zero leave the window undeclared (the conservative
+// zero declaration), matching the built-in catalog convention.
+func (l ModelLimits) WithMaxInputTokens(value int) ModelLimits {
+	if value > 0 {
+		l.MaxInputTokens = &value
+	}
+	return l
+}
+
+// WithMaxOutputTokens returns limits declaring the output window. Values at
+// or below zero leave the window undeclared.
+func (l ModelLimits) WithMaxOutputTokens(value int) ModelLimits {
+	if value > 0 {
+		l.MaxOutputTokens = &value
+	}
+	return l
+}
+
+// Values returns the declared windows as plain ints; undeclared windows
+// read as zero. Resolved catalog entries and their tests use it to compare
+// limits without dereferencing pointers.
+func (l ModelLimits) Values() (maxInputTokens, maxOutputTokens int) {
+	maxInputTokens, maxOutputTokens = 0, 0
+	if l.MaxInputTokens != nil {
+		maxInputTokens = *l.MaxInputTokens
+	}
+	if l.MaxOutputTokens != nil {
+		maxOutputTokens = *l.MaxOutputTokens
+	}
+	return maxInputTokens, maxOutputTokens
 }
 
 func (l ModelLimits) Validate() error {

--- a/core/inference/model_patch.go
+++ b/core/inference/model_patch.go
@@ -2,6 +2,7 @@ package inference
 
 import (
 	"encoding/json"
+	"fmt"
 	"maps"
 
 	"github.com/GizClaw/flowcraft/core/message"
@@ -94,7 +95,9 @@ func (p *CapabilitiesPatch) Validate() error {
 type ReasoningPatch struct {
 	// Kind replaces the reasoning kind when present. An explicit empty
 	// string (ReasoningNone) removes reasoning control from a base that
-	// declares it; the legacy `reasoning: ""` string form spells this.
+	// declares it, dropping the inherited effort map with it (a none kind
+	// cannot carry a dial); the legacy `reasoning: ""` string form spells
+	// this.
 	Kind *ReasoningKind `json:"kind,omitempty"`
 	// EffortMap replaces the canonical-to-wire effort map when present. An
 	// empty map clears a base dial, leaving binary thinking with no depth
@@ -118,6 +121,12 @@ func (p *ReasoningPatch) Apply(base ReasoningCapability) ReasoningCapability {
 	if p.EffortMap != nil {
 		out.EffortMap = maps.Clone(*p.EffortMap)
 	}
+	if out.Kind == ReasoningNone && p.EffortMap == nil {
+		// None cannot carry a dial: removing the reasoning capability with
+		// the legacy empty-string kind must also drop any inherited effort
+		// map, or the merged capability fails validation downstream.
+		out.EffortMap = nil
+	}
 	return out
 }
 
@@ -131,6 +140,12 @@ func (p *ReasoningPatch) Validate() error {
 	if p.Kind != nil {
 		if err := p.Kind.Validate(); err != nil {
 			return err
+		}
+		if *p.Kind == ReasoningNone &&
+			p.EffortMap != nil && len(*p.EffortMap) > 0 {
+			return fmt.Errorf(
+				"reasoning kind none cannot declare an effort map",
+			)
 		}
 	}
 	if p.EffortMap != nil {

--- a/core/inference/model_patch.go
+++ b/core/inference/model_patch.go
@@ -1,0 +1,170 @@
+package inference
+
+import (
+	"encoding/json"
+	"maps"
+
+	"github.com/GizClaw/flowcraft/core/message"
+)
+
+// CapabilitiesPatch declares capability changes relative to a base model.
+// Field presence is the contract: an absent field inherits the base value
+// (the built-in catalog entry the declaration overrides); a present field
+// replaces that leaf, so narrowing (a shorter inputs list), removal
+// (hosted_web_search: false, inputs: []), and reasoning sub-edits are all
+// explicit instead of accidental. Applying a patch to a zero base yields the
+// conservative declaration, so drivers without a built-in line-up (Azure)
+// keep requiring every published capability to be stated.
+type CapabilitiesPatch struct {
+	// Inputs replaces the base input content kinds when present. An empty
+	// list is a declaration of no text-channel inputs, distinct from an
+	// absent field that inherits the base list.
+	Inputs *[]message.PartKind `json:"inputs,omitempty"`
+	// Outputs replaces the base output content kinds when present. Empty
+	// means no generate outputs (embed-family declarations).
+	Outputs *[]message.PartKind `json:"outputs,omitempty"`
+	// Reasoning is a sub-patch: absent inherits the base reasoning control
+	// surface wholesale; present overrides only the leaves it names. The
+	// legacy `reasoning: "toggle"` string form overrides just the kind.
+	Reasoning *ReasoningPatch `json:"reasoning,omitempty"`
+	// HostedWebSearch overrides provider-side web search support when
+	// present; false explicitly removes the capability from a base that
+	// declares it.
+	HostedWebSearch *bool `json:"hosted_web_search,omitempty"`
+	// CustomEmbedDimensions overrides custom embed output dimension support
+	// when present; false explicitly removes the capability from a base
+	// that declares it.
+	CustomEmbedDimensions *bool `json:"custom_embed_dimensions,omitempty"`
+}
+
+// Apply returns the effective capabilities: base with every leaf this patch
+// names replaced. A nil patch (the declaration did not include a
+// capabilities block at all) inherits base wholesale.
+func (p *CapabilitiesPatch) Apply(base ModelCapabilities) ModelCapabilities {
+	out := base.Clone()
+	if p == nil {
+		return out
+	}
+	if p.Inputs != nil {
+		out.Inputs = append([]message.PartKind(nil), (*p.Inputs)...)
+	}
+	if p.Outputs != nil {
+		out.Outputs = append([]message.PartKind(nil), (*p.Outputs)...)
+	}
+	if p.Reasoning != nil {
+		out.Reasoning = p.Reasoning.Apply(base.Reasoning)
+	}
+	if p.HostedWebSearch != nil {
+		out.HostedWebSearch = *p.HostedWebSearch
+	}
+	if p.CustomEmbedDimensions != nil {
+		out.CustomEmbedDimensions = *p.CustomEmbedDimensions
+	}
+	return out
+}
+
+// Validate checks the leaves the patch names: content kinds must be valid
+// and unique and a reasoning sub-patch must be coherent. Absent leaves have
+// no declaration to check; the merged result is validated after Apply.
+func (p *CapabilitiesPatch) Validate() error {
+	if p == nil {
+		return nil
+	}
+	if p.Inputs != nil {
+		if err := validatePartKinds(*p.Inputs, true); err != nil {
+			return err
+		}
+	}
+	if p.Outputs != nil {
+		if err := validatePartKinds(*p.Outputs, false); err != nil {
+			return err
+		}
+	}
+	if p.Reasoning != nil {
+		if err := p.Reasoning.Validate(); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// ReasoningPatch is the reasoning leaf of a CapabilitiesPatch. Absent
+// fields inherit the base reasoning capability; present fields replace
+// that leaf only.
+type ReasoningPatch struct {
+	// Kind replaces the reasoning kind when present. An explicit empty
+	// string (ReasoningNone) removes reasoning control from a base that
+	// declares it; the legacy `reasoning: ""` string form spells this.
+	Kind *ReasoningKind `json:"kind,omitempty"`
+	// EffortMap replaces the canonical-to-wire effort map when present. An
+	// empty map clears a base dial, leaving binary thinking with no depth
+	// control.
+	EffortMap *map[ReasoningEffort]string `json:"effort_map,omitempty"`
+}
+
+// Apply returns the base reasoning capability with every named leaf
+// replaced.
+func (p *ReasoningPatch) Apply(base ReasoningCapability) ReasoningCapability {
+	out := base
+	if base.EffortMap != nil {
+		out.EffortMap = maps.Clone(base.EffortMap)
+	}
+	if p == nil {
+		return out
+	}
+	if p.Kind != nil {
+		out.Kind = *p.Kind
+	}
+	if p.EffortMap != nil {
+		out.EffortMap = maps.Clone(*p.EffortMap)
+	}
+	return out
+}
+
+// Validate checks the named leaves: a named kind must be valid and a named
+// effort map, when non-empty, must cover all five canonical levels with
+// well-formed wire tokens.
+func (p *ReasoningPatch) Validate() error {
+	if p == nil {
+		return nil
+	}
+	if p.Kind != nil {
+		if err := p.Kind.Validate(); err != nil {
+			return err
+		}
+	}
+	if p.EffortMap != nil {
+		return validateReasoningEffortMap(*p.EffortMap)
+	}
+	return nil
+}
+
+// UnmarshalJSON accepts both the legacy string form ("toggle", meaning
+// "override the kind only") and the object form so existing deployment
+// specs keep decoding and existing redeclarations keep the base effort map
+// unless the object names one.
+func (p *ReasoningPatch) UnmarshalJSON(data []byte) error {
+	var kind ReasoningKind
+	if err := json.Unmarshal(data, &kind); err == nil {
+		*p = ReasoningPatch{Kind: &kind}
+		return nil
+	}
+	type alias ReasoningPatch
+	var decoded alias
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		return err
+	}
+	*p = ReasoningPatch(decoded)
+	return nil
+}
+
+// MarshalJSON keeps the legacy string form when the patch names only a
+// kind, so a deployment that decoded `reasoning: "toggle"` re-serializes to
+// the same string instead of leaking the object shape.
+func (p ReasoningPatch) MarshalJSON() ([]byte, error) {
+	if p.Kind != nil && p.EffortMap == nil {
+		return json.Marshal(*p.Kind)
+	}
+	type alias ReasoningPatch
+	return json.Marshal(alias(p))
+}

--- a/core/inference/model_patch_test.go
+++ b/core/inference/model_patch_test.go
@@ -1,0 +1,257 @@
+package inference
+
+import (
+	"encoding/json"
+	"maps"
+	"strings"
+	"testing"
+
+	"github.com/GizClaw/flowcraft/core/message"
+)
+
+func reasoningPatchCapabilities() ModelCapabilities {
+	return ModelCapabilities{
+		Inputs: []message.PartKind{
+			message.PartText,
+			message.PartImage,
+			message.PartToolCall,
+			message.PartToolResult,
+		},
+		Outputs: []message.PartKind{message.PartText},
+		Reasoning: ReasoningCapability{
+			Kind: ReasoningToggle,
+			EffortMap: map[ReasoningEffort]string{
+				ReasoningMinimal: "minimal",
+				ReasoningLow:     "low",
+				ReasoningMedium:  "medium",
+				ReasoningHigh:    "high",
+				ReasoningXHigh:   "xhigh",
+			},
+		},
+		HostedWebSearch: true,
+	}
+}
+
+func decodePatch(t *testing.T, raw string) *CapabilitiesPatch {
+	t.Helper()
+	var patch CapabilitiesPatch
+	if err := json.Unmarshal([]byte(raw), &patch); err != nil {
+		t.Fatalf("decode patch: %v", err)
+	}
+	if err := patch.Validate(); err != nil {
+		t.Fatalf("validate patch: %v", err)
+	}
+	return &patch
+}
+
+func decodeReasoningPatch(t *testing.T, raw string) *ReasoningPatch {
+	t.Helper()
+	var patch ReasoningPatch
+	if err := json.Unmarshal([]byte(raw), &patch); err != nil {
+		t.Fatalf("decode reasoning patch: %v", err)
+	}
+	if err := patch.Validate(); err != nil {
+		t.Fatalf("validate reasoning patch: %v", err)
+	}
+	return &patch
+}
+
+func TestCapabilitiesPatchAbsentLeavesInherit(t *testing.T) {
+	patch := decodePatch(t, `{"inputs":["text"],"hosted_web_search":false}`)
+	got := patch.Apply(reasoningPatchCapabilities())
+	if len(got.Inputs) != 1 || got.Inputs[0] != message.PartText {
+		t.Fatalf("inputs = %v, want text only", got.Inputs)
+	}
+	if got.HostedWebSearch {
+		t.Fatal("hosted_web_search: false must replace the base true")
+	}
+	if got.Reasoning.Kind != ReasoningToggle {
+		t.Fatalf("reasoning kind = %q, want inherited toggle", got.Reasoning.Kind)
+	}
+	if len(got.Reasoning.EffortMap) != 5 {
+		t.Fatalf("reasoning effort map must be inherited, got %v", got.Reasoning.EffortMap)
+	}
+	if len(got.Outputs) != 1 || got.Outputs[0] != message.PartText {
+		t.Fatalf("outputs = %v, want inherited text", got.Outputs)
+	}
+}
+
+func TestCapabilitiesPatchWholeDeclarationOverZeroBase(t *testing.T) {
+	patch := decodePatch(t, `{"outputs":["text"],"hosted_web_search":true}`)
+	got := patch.Apply(ModelCapabilities{})
+	if len(got.Inputs) != 0 {
+		t.Fatalf("inputs = %v, want conservative zero", got.Inputs)
+	}
+	if len(got.Outputs) != 1 || got.Outputs[0] != message.PartText {
+		t.Fatalf("outputs = %v, want text", got.Outputs)
+	}
+	if !got.HostedWebSearch {
+		t.Fatal("hosted web search must be declared")
+	}
+	if got.Reasoning.Kind != ReasoningNone {
+		t.Fatalf("reasoning = %q, want conservative none", got.Reasoning.Kind)
+	}
+	if err := got.Validate(); err != nil {
+		t.Fatalf("merged capabilities invalid: %v", err)
+	}
+}
+
+func TestReasoningPatchSubLeavesAndLegacyString(t *testing.T) {
+	base := reasoningPatchCapabilities().Reasoning
+
+	kindOnly := decodeReasoningPatch(t, `"toggle"`)
+	got := kindOnly.Apply(base)
+	if got.Kind != ReasoningToggle || len(got.EffortMap) != 5 {
+		t.Fatalf("legacy string must keep base map, got kind %q map %v", got.Kind, got.EffortMap)
+	}
+
+	mapOnly := decodeReasoningPatch(t, `{"effort_map":{}}`)
+	got = mapOnly.Apply(base)
+	if got.Kind != ReasoningToggle {
+		t.Fatalf("kind = %q, want inherited toggle", got.Kind)
+	}
+	if len(got.EffortMap) != 0 {
+		t.Fatalf("effort_map: {} must clear the base dial, got %v", got.EffortMap)
+	}
+
+	nonePatch := decodeReasoningPatch(t, `""`)
+	if nonePatch.Kind == nil || *nonePatch.Kind != ReasoningNone {
+		t.Fatalf("legacy empty string must mean kind none, got %#v", nonePatch.Kind)
+	}
+	got = nonePatch.Apply(base)
+	if got.Kind != ReasoningNone || len(got.EffortMap) != 5 {
+		t.Fatalf("none patch = %#v, want kind none with inherited map", got)
+	}
+}
+
+func TestCapabilitiesPatchValidation(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		raw  string
+		want string
+	}{
+		{"duplicate inputs", `{"inputs":["text","text"]}`, "duplicate input"},
+		{"invalid output modality", `{"outputs":["tool_call"]}`, "not a representable output modality"},
+		{"invalid kind", `{"reasoning":{"kind":"maybe"}}`, "unknown reasoning kind"},
+		{"map misses level", `{"reasoning":{"kind":"toggle","effort_map":{"low":"low"}}}`, "misses canonical level"},
+		{"non-canonical key", `{"reasoning":{"kind":"toggle","effort_map":{"low":"low","medium":"medium","high":"high","minimal":"minimal","xhigh":"xhigh","none":"none"}}}`, "non-canonical key"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var patch CapabilitiesPatch
+			if err := json.Unmarshal([]byte(tc.raw), &patch); err != nil {
+				t.Fatalf("decode: %v", err)
+			}
+			err := patch.Validate()
+			if err == nil {
+				t.Fatal("patch unexpectedly valid")
+			}
+			if !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("error = %q, want substring %q", err, tc.want)
+			}
+		})
+	}
+}
+
+func TestCapabilitiesPatchEmptyLeafIsExplicit(t *testing.T) {
+	var patch CapabilitiesPatch
+	if err := json.Unmarshal([]byte(`{"inputs":[]}`), &patch); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if patch.Inputs == nil || len(*patch.Inputs) != 0 {
+		t.Fatalf("inputs = %#v, want explicit empty list", patch.Inputs)
+	}
+	got := patch.Apply(reasoningPatchCapabilities())
+	if len(got.Inputs) != 0 {
+		t.Fatalf("inputs = %v, want cleared", got.Inputs)
+	}
+}
+
+func TestCustomEmbedDimensionsLeaf(t *testing.T) {
+	base := reasoningPatchCapabilities()
+	if base.CustomEmbedDimensions {
+		t.Fatal("test base unexpectedly declares custom embed dimensions")
+	}
+	on := decodePatch(t, `{"custom_embed_dimensions":true}`).Apply(base)
+	if !on.CustomEmbedDimensions {
+		t.Fatal("custom_embed_dimensions: true must set the capability")
+	}
+	declared := reasoningPatchCapabilities()
+	declared.CustomEmbedDimensions = true
+	off := decodePatch(t, `{"custom_embed_dimensions":false}`).Apply(declared)
+	if off.CustomEmbedDimensions {
+		t.Fatal("custom_embed_dimensions: false must clear the base capability")
+	}
+	inherited := decodePatch(t, `{"outputs":["text"]}`).Apply(declared)
+	if !inherited.CustomEmbedDimensions {
+		t.Fatal("absent leaf must inherit the base capability")
+	}
+}
+
+func TestReasoningCapabilityEmptyMapSemantics(t *testing.T) {
+	empty := map[ReasoningEffort]string{}
+	for name, capability := range map[string]ReasoningCapability{
+		"none without map":    {Kind: ReasoningNone},
+		"none with empty map": {Kind: ReasoningNone, EffortMap: empty},
+		"toggle with empty map": {
+			Kind:      ReasoningToggle,
+			EffortMap: empty,
+		},
+	} {
+		if err := capability.Validate(); err != nil {
+			t.Fatalf("%s unexpectedly invalid: %v", name, err)
+		}
+	}
+}
+
+func TestModelLimitsBuilders(t *testing.T) {
+	got := (ModelLimits{}).
+		WithMaxInputTokens(1_000_000).
+		WithMaxOutputTokens(128_000)
+	if in, out := got.Values(); in != 1_000_000 || out != 128_000 {
+		t.Fatalf("values = %d/%d, want 1000000/128000", in, out)
+	}
+	if err := got.Validate(); err != nil {
+		t.Fatalf("validate: %v", err)
+	}
+	zero := (ModelLimits{}).WithMaxInputTokens(0)
+	if in, _ := zero.Values(); in != 0 {
+		t.Fatalf("non-positive input must stay undeclared, got %d", in)
+	}
+	one := (ModelLimits{}).WithMaxInputTokens(1)
+	if in, _ := one.Values(); in != 1 {
+		t.Fatalf("positive input must be declared, got %d", in)
+	}
+}
+
+func TestReasoningPatchJSONRoundTrip(t *testing.T) {
+	for _, raw := range []string{
+		`"toggle"`,
+		`"always"`,
+		`{"kind":"toggle","effort_map":{"minimal":"minimal","low":"low","medium":"medium","high":"high","xhigh":"xhigh"}}`,
+	} {
+		var patch ReasoningPatch
+		if err := json.Unmarshal([]byte(raw), &patch); err != nil {
+			t.Fatalf("decode %s: %v", raw, err)
+		}
+		encoded, err := json.Marshal(patch)
+		if err != nil {
+			t.Fatalf("marshal: %v", err)
+		}
+		var decoded ReasoningPatch
+		if err := json.Unmarshal(encoded, &decoded); err != nil {
+			t.Fatalf("re-decode %s: %v", encoded, err)
+		}
+		if (decoded.Kind == nil) != (patch.Kind == nil) ||
+			(decoded.Kind != nil && *decoded.Kind != *patch.Kind) ||
+			!maps.Equal(nonNilMap(decoded.EffortMap), nonNilMap(patch.EffortMap)) {
+			t.Fatalf("round trip %s = %#v, want %#v", raw, decoded, patch)
+		}
+	}
+}
+
+func nonNilMap(m *map[ReasoningEffort]string) map[ReasoningEffort]string {
+	if m == nil {
+		return map[ReasoningEffort]string{}
+	}
+	return *m
+}

--- a/core/inference/model_patch_test.go
+++ b/core/inference/model_patch_test.go
@@ -119,8 +119,11 @@ func TestReasoningPatchSubLeavesAndLegacyString(t *testing.T) {
 		t.Fatalf("legacy empty string must mean kind none, got %#v", nonePatch.Kind)
 	}
 	got = nonePatch.Apply(base)
-	if got.Kind != ReasoningNone || len(got.EffortMap) != 5 {
-		t.Fatalf("none patch = %#v, want kind none with inherited map", got)
+	if got.Kind != ReasoningNone || len(got.EffortMap) != 0 {
+		t.Fatalf("none patch = %#v, want kind none with no effort map", got)
+	}
+	if err := got.Validate(); err != nil {
+		t.Fatalf("removed reasoning must stay valid, got %v", err)
 	}
 }
 
@@ -133,6 +136,7 @@ func TestCapabilitiesPatchValidation(t *testing.T) {
 		{"duplicate inputs", `{"inputs":["text","text"]}`, "duplicate input"},
 		{"invalid output modality", `{"outputs":["tool_call"]}`, "not a representable output modality"},
 		{"invalid kind", `{"reasoning":{"kind":"maybe"}}`, "unknown reasoning kind"},
+		{"none with map", `{"reasoning":{"kind":"","effort_map":{"minimal":"minimal","low":"low","medium":"medium","high":"high","xhigh":"xhigh"}}}`, "cannot declare an effort map"},
 		{"map misses level", `{"reasoning":{"kind":"toggle","effort_map":{"low":"low"}}}`, "misses canonical level"},
 		{"non-canonical key", `{"reasoning":{"kind":"toggle","effort_map":{"low":"low","medium":"medium","high":"high","minimal":"minimal","xhigh":"xhigh","none":"none"}}}`, "non-canonical key"},
 	} {

--- a/docs/guides/inference.md
+++ b/docs/guides/inference.md
@@ -62,12 +62,14 @@ reg.MustRegister(inference.Factory{})
 
 Providers expose built-in model catalogs that deployments extend or
 override through the provider spec's `models` list. Declarations are
-leaf-level patches against the same-named built-in entry (Anthropic,
-Bytedance, DeepSeek, MiniMax, OpenAI): a capability leaf that is written
-replaces that leaf, while unstated capability leaves, numeric limits, and
-driver control facts are inherited — redeclaring a model to tweak one
-channel cannot silently revoke the rest. Qwen and Kimi overlay additively
-(a declaration can widen a built-in surface, never narrow it).
+leaf-level patches against the same-named, same-kind built-in entry: a
+capability leaf that is written replaces that leaf, while unstated
+capability leaves, numeric limits, and driver control facts are inherited —
+redeclaring a model to tweak one channel cannot silently revoke the rest,
+and removal is explicit (`hosted_web_search: false`, an empty inputs or
+outputs list, or reasoning kind `none`). Qwen and Kimi follow the same
+leaf semantics; Qwen's custom embed dimensions additionally stay tied to
+its built-in size whitelist.
 
 Capability declarations are promises validated per provider surface: a
 model published with reasoning kind `toggle` must compile

--- a/docs/guides/inference.md
+++ b/docs/guides/inference.md
@@ -58,6 +58,24 @@ reg.MustRegister(deepseek.NewFactory())
 reg.MustRegister(inference.Factory{})
 ```
 
+## Model declarations
+
+Providers expose built-in model catalogs that deployments extend or
+override through the provider spec's `models` list. Declarations are
+leaf-level patches against the same-named built-in entry (Anthropic,
+Bytedance, DeepSeek, MiniMax, OpenAI): a capability leaf that is written
+replaces that leaf, while unstated capability leaves, numeric limits, and
+driver control facts are inherited — redeclaring a model to tweak one
+channel cannot silently revoke the rest. Qwen and Kimi overlay additively
+(a declaration can widen a built-in surface, never narrow it).
+
+Capability declarations are promises validated per provider surface: a
+model published with reasoning kind `toggle` must compile
+`reasoning_enabled=false` on that surface, and one published as `always`
+rejects it. Discovery bits such as `hosted_web_search` and
+`custom_embed_dimensions` ride on the model descriptor, so hosts can
+surface per-model options without driver-specific knowledge.
+
 ## Routing
 
 Optional target selection is an `inference.Router` resource. It consumes

--- a/driver/anthropic/catalog.go
+++ b/driver/anthropic/catalog.go
@@ -17,15 +17,11 @@ type catalogEntry struct {
 	capabilities inference.ModelCapabilities
 	deprecated   bool
 	replacement  string
-	// maxInputTokens caps the input context (system + messages + tools)
-	// in tokens; zero means undeclared. Values mirror the context window
-	// published on https://platform.claude.com/docs/en/about-claude/models.
-	maxInputTokens int
-	// maxOutputTokens caps the tokens a single response may emit
-	// (thinking plus answer tokens share the budget); zero means
-	// undeclared. Values mirror the maximum output published on
-	// https://platform.claude.com/docs/en/about-claude/models.
-	maxOutputTokens int
+	// limits carries the model's context/output windows in tokens. Nil
+	// leaves are undeclared. Values mirror the context window and maximum
+	// output published on https://platform.claude.com/docs/en/about-claude/
+	// models.
+	limits inference.ModelLimits
 }
 
 // validate enforces the generate family contract: Claude compilers only
@@ -37,7 +33,7 @@ func (e catalogEntry) validate() error {
 	if !slices.Contains(e.capabilities.Outputs, message.PartText) {
 		return fmt.Errorf("generate family must declare text output")
 	}
-	return nil
+	return e.limits.Validate()
 }
 
 // generateChatCapabilities is the common capability declaration for the
@@ -75,8 +71,9 @@ var catalog = map[string]catalogEntry{
 			WithInputs(message.PartImage).
 			WithReasoning(inference.ReasoningAlways).
 			WithReasoningEffortMap(claudeEffortMap),
-		maxInputTokens:  1_000_000,
-		maxOutputTokens: 128_000,
+		limits: inference.ModelLimits{}.
+			WithMaxInputTokens(1_000_000).
+			WithMaxOutputTokens(128_000),
 	},
 	// claude-mythos-5 shares Fable 5's capabilities and always-on adaptive
 	// thinking; it is a limited-release model (Project Glasswing), so
@@ -86,40 +83,45 @@ var catalog = map[string]catalogEntry{
 			WithInputs(message.PartImage).
 			WithReasoning(inference.ReasoningAlways).
 			WithReasoningEffortMap(claudeEffortMap),
-		maxInputTokens:  1_000_000,
-		maxOutputTokens: 128_000,
+		limits: inference.ModelLimits{}.
+			WithMaxInputTokens(1_000_000).
+			WithMaxOutputTokens(128_000),
 	},
 	"claude-opus-5": {
 		capabilities: generateChatCapabilities().
 			WithInputs(message.PartImage).
 			WithReasoning(inference.ReasoningToggle).
 			WithReasoningEffortMap(claudeEffortMap),
-		maxInputTokens:  1_000_000,
-		maxOutputTokens: 128_000,
+		limits: inference.ModelLimits{}.
+			WithMaxInputTokens(1_000_000).
+			WithMaxOutputTokens(128_000),
 	},
 	"claude-sonnet-5": {
 		capabilities: generateChatCapabilities().
 			WithInputs(message.PartImage).
 			WithReasoning(inference.ReasoningToggle).
 			WithReasoningEffortMap(claudeEffortMap),
-		maxInputTokens:  1_000_000,
-		maxOutputTokens: 128_000,
+		limits: inference.ModelLimits{}.
+			WithMaxInputTokens(1_000_000).
+			WithMaxOutputTokens(128_000),
 	},
 	"claude-haiku-4-5": {
 		capabilities: generateChatCapabilities().
 			WithInputs(message.PartImage).
 			WithReasoning(inference.ReasoningToggle).
 			WithReasoningEffortMap(claudeEffortMap),
-		maxInputTokens:  200_000,
-		maxOutputTokens: 64_000,
+		limits: inference.ModelLimits{}.
+			WithMaxInputTokens(200_000).
+			WithMaxOutputTokens(64_000),
 	},
 	"claude-haiku-4-5-20251001": {
 		capabilities: generateChatCapabilities().
 			WithInputs(message.PartImage).
 			WithReasoning(inference.ReasoningToggle).
 			WithReasoningEffortMap(claudeEffortMap),
-		maxInputTokens:  200_000,
-		maxOutputTokens: 64_000,
+		limits: inference.ModelLimits{}.
+			WithMaxInputTokens(200_000).
+			WithMaxOutputTokens(64_000),
 	},
 
 	"claude-opus-4-8": {
@@ -128,8 +130,9 @@ var catalog = map[string]catalogEntry{
 			WithReasoning(inference.ReasoningToggle).
 			WithReasoningEffortMap(claudeEffortMap),
 		deprecated: true, replacement: "claude-opus-5",
-		maxInputTokens:  1_000_000,
-		maxOutputTokens: 128_000,
+		limits: inference.ModelLimits{}.
+			WithMaxInputTokens(1_000_000).
+			WithMaxOutputTokens(128_000),
 	},
 	"claude-opus-4-7": {
 		capabilities: generateChatCapabilities().
@@ -137,8 +140,9 @@ var catalog = map[string]catalogEntry{
 			WithReasoning(inference.ReasoningToggle).
 			WithReasoningEffortMap(claudeEffortMap),
 		deprecated: true, replacement: "claude-opus-5",
-		maxInputTokens:  1_000_000,
-		maxOutputTokens: 128_000,
+		limits: inference.ModelLimits{}.
+			WithMaxInputTokens(1_000_000).
+			WithMaxOutputTokens(128_000),
 	},
 	"claude-sonnet-4-6": {
 		capabilities: generateChatCapabilities().
@@ -146,8 +150,9 @@ var catalog = map[string]catalogEntry{
 			WithReasoning(inference.ReasoningToggle).
 			WithReasoningEffortMap(claudeEffortMap),
 		deprecated: true, replacement: "claude-sonnet-5",
-		maxInputTokens:  1_000_000,
-		maxOutputTokens: 128_000,
+		limits: inference.ModelLimits{}.
+			WithMaxInputTokens(1_000_000).
+			WithMaxOutputTokens(128_000),
 	},
 	"claude-sonnet-4-5": {
 		capabilities: generateChatCapabilities().
@@ -155,8 +160,9 @@ var catalog = map[string]catalogEntry{
 			WithReasoning(inference.ReasoningToggle).
 			WithReasoningEffortMap(claudeEffortMap),
 		deprecated: true, replacement: "claude-sonnet-5",
-		maxInputTokens:  200_000,
-		maxOutputTokens: 64_000,
+		limits: inference.ModelLimits{}.
+			WithMaxInputTokens(200_000).
+			WithMaxOutputTokens(64_000),
 	},
 	"claude-opus-4-1": {
 		capabilities: generateChatCapabilities().
@@ -164,31 +170,38 @@ var catalog = map[string]catalogEntry{
 			WithReasoning(inference.ReasoningToggle).
 			WithReasoningEffortMap(claudeEffortMap),
 		deprecated: true, replacement: "claude-opus-5",
-		maxInputTokens:  200_000,
-		maxOutputTokens: 32_000,
+		limits: inference.ModelLimits{}.
+			WithMaxInputTokens(200_000).
+			WithMaxOutputTokens(32_000),
 	},
 }
 
 // mergedCatalog overlays Spec.Models onto the built-in catalog. A spec
-// entry with a catalog name replaces that entry, except that numeric
-// limits are inherited from the built-in entry and only replaced when the
-// declaration sets them explicitly.
+// entry with a catalog name is a leaf-level patch: capability leaves it
+// names replace the built-in's and everything else is inherited, including
+// numeric limits (only replaced when the declaration sets them explicitly).
+// Unknown names extend the catalog with the declared leaves over the
+// conservative zero base.
 func mergedCatalog(spec Spec) (map[string]catalogEntry, error) {
 	models := make(map[string]catalogEntry, len(catalog)+len(spec.Models))
 	maps.Copy(models, catalog)
 	for _, model := range spec.Models {
-		entry := catalogEntry{
-			capabilities: model.Capabilities,
-		}
+		entry := catalogEntry{}
 		if builtin, exists := models[model.Name]; exists {
-			entry.maxInputTokens = builtin.maxInputTokens
-			entry.maxOutputTokens = builtin.maxOutputTokens
+			entry.capabilities = model.Capabilities.Apply(builtin.capabilities)
+			entry.limits = builtin.limits.Clone()
+		} else {
+			entry.capabilities = model.Capabilities.Apply(
+				inference.ModelCapabilities{},
+			)
 		}
 		if model.Limits.MaxInputTokens != nil {
-			entry.maxInputTokens = *model.Limits.MaxInputTokens
+			value := *model.Limits.MaxInputTokens
+			entry.limits.MaxInputTokens = &value
 		}
 		if model.Limits.MaxOutputTokens != nil {
-			entry.maxOutputTokens = *model.Limits.MaxOutputTokens
+			value := *model.Limits.MaxOutputTokens
+			entry.limits.MaxOutputTokens = &value
 		}
 		models[model.Name] = entry
 	}
@@ -218,12 +231,7 @@ func descriptorFor(id inference.ModelID, entry catalogEntry) inference.ModelDesc
 			descriptor.Lifecycle.Replacement = &replacement
 		}
 	}
-	if entry.maxInputTokens > 0 {
-		descriptor.Limits.MaxInputTokens = &entry.maxInputTokens
-	}
-	if entry.maxOutputTokens > 0 {
-		descriptor.Limits.MaxOutputTokens = &entry.maxOutputTokens
-	}
+	descriptor.Limits = entry.limits.Clone()
 	return descriptor
 }
 

--- a/driver/anthropic/catalog_test.go
+++ b/driver/anthropic/catalog_test.go
@@ -24,7 +24,7 @@ func TestCatalogDeclaresMaxInputTokens(t *testing.T) {
 		if !ok {
 			t.Fatalf("catalog model %q missing from provider", name)
 		}
-		if entry.maxInputTokens <= 0 || descriptor.Limits.MaxInputTokens == nil {
+		if entry.limits.MaxInputTokens == nil || descriptor.Limits.MaxInputTokens == nil {
 			t.Errorf("model %q: max input tokens not declared", name)
 		}
 	}
@@ -61,7 +61,7 @@ func TestCatalogDeclaresMaxOutputTokens(t *testing.T) {
 		if !ok {
 			t.Fatalf("catalog model %q missing from provider", name)
 		}
-		if entry.maxOutputTokens <= 0 || descriptor.Limits.MaxOutputTokens == nil {
+		if entry.limits.MaxOutputTokens == nil || descriptor.Limits.MaxOutputTokens == nil {
 			t.Errorf("model %q: max output tokens not declared", name)
 		}
 	}
@@ -138,9 +138,10 @@ func TestMergedCatalogOverlaysDeclaredLimits(t *testing.T) {
 		t.Fatalf("mergedCatalog: %v", err)
 	}
 	entry := models["claude-sonnet-5"]
-	if entry.maxInputTokens != 1_000_000 || entry.maxOutputTokens != 128_000 {
+	in, out := entry.limits.Values()
+	if in != 1_000_000 || out != 128_000 {
 		t.Fatalf("redeclared limits = %d/%d, want catalog 1000000/128000",
-			entry.maxInputTokens, entry.maxOutputTokens)
+			in, out)
 	}
 
 	spec, err = decodeSpec(context.Background(), []byte(`{
@@ -158,9 +159,10 @@ func TestMergedCatalogOverlaysDeclaredLimits(t *testing.T) {
 		t.Fatalf("mergedCatalog: %v", err)
 	}
 	entry = models["claude-sonnet-5"]
-	if entry.maxInputTokens != 1_000_000 || entry.maxOutputTokens != 4096 {
+	in, out = entry.limits.Values()
+	if in != 1_000_000 || out != 4096 {
 		t.Fatalf("overridden limits = %d/%d, want 1000000/4096",
-			entry.maxInputTokens, entry.maxOutputTokens)
+			in, out)
 	}
 }
 
@@ -181,8 +183,9 @@ func TestMergedCatalogOverridesDeclaredInputLimit(t *testing.T) {
 		t.Fatalf("mergedCatalog: %v", err)
 	}
 	entry := models["claude-sonnet-5"]
-	if entry.maxInputTokens != 65_536 || entry.maxOutputTokens != 128_000 {
+	in, out := entry.limits.Values()
+	if in != 65_536 || out != 128_000 {
 		t.Fatalf("declared input limits = %d/%d, want 65536/128000",
-			entry.maxInputTokens, entry.maxOutputTokens)
+			in, out)
 	}
 }

--- a/driver/anthropic/reasoning_contract_test.go
+++ b/driver/anthropic/reasoning_contract_test.go
@@ -51,6 +51,34 @@ func TestRedeclaredBuiltinKeepsReasoning(t *testing.T) {
 	}
 }
 
+// TestRedeclaredBuiltinRemovesReasoning locks the removal contract: the
+// legacy `reasoning: ""` leaf strips a built-in's reasoning kind and the
+// effort map inherited with it, leaving a coherent none capability that
+// still passes merged-catalog validation.
+func TestRedeclaredBuiltinRemovesReasoning(t *testing.T) {
+	spec, err := decodeSpec(context.Background(), []byte(`{
+		"models": [{
+			"name": "claude-sonnet-5",
+			"capabilities": {"reasoning": ""}
+		}]
+	}`))
+	if err != nil {
+		t.Fatalf("decodeSpec: %v", err)
+	}
+	models, err := mergedCatalog(spec)
+	if err != nil {
+		t.Fatalf("mergedCatalog: %v", err)
+	}
+	entry := models["claude-sonnet-5"]
+	if entry.capabilities.Reasoning.Kind != inference.ReasoningNone {
+		t.Fatalf("reasoning kind = %q, want none", entry.capabilities.Reasoning.Kind)
+	}
+	if len(entry.capabilities.Reasoning.EffortMap) != 0 {
+		t.Fatalf("removed reasoning must drop the inherited effort map, got %v",
+			entry.capabilities.Reasoning.EffortMap)
+	}
+}
+
 // TestPublishedToggleCompilesReasoningOff is the generic conformance
 // contract for every built-in model that publishes toggle.
 func TestPublishedToggleCompilesReasoningOff(t *testing.T) {

--- a/driver/anthropic/reasoning_contract_test.go
+++ b/driver/anthropic/reasoning_contract_test.go
@@ -1,0 +1,100 @@
+package anthropic
+
+import (
+	"context"
+	"testing"
+
+	"github.com/GizClaw/flowcraft/core/inference"
+	"github.com/GizClaw/flowcraft/core/inference/inferencetest"
+)
+
+// TestRedeclaredBuiltinKeepsReasoning locks the delta overlay contract:
+// redeclaring claude-sonnet-5 to tweak one channel must keep the built-in
+// reasoning kind and effort map, so a published toggle still compiles
+// reasoning_enabled=false.
+func TestRedeclaredBuiltinKeepsReasoning(t *testing.T) {
+	spec, err := decodeSpec(context.Background(), []byte(`{
+		"models": [{
+			"name": "claude-sonnet-5",
+			"capabilities": {"outputs": ["text"]}
+		}]
+	}`))
+	if err != nil {
+		t.Fatalf("decodeSpec: %v", err)
+	}
+	models, err := mergedCatalog(spec)
+	if err != nil {
+		t.Fatalf("mergedCatalog: %v", err)
+	}
+	entry := models["claude-sonnet-5"]
+	if entry.capabilities.Reasoning.Kind != inference.ReasoningToggle {
+		t.Fatalf("redeclaration must inherit reasoning toggle, got %q",
+			entry.capabilities.Reasoning.Kind)
+	}
+	if len(entry.capabilities.Reasoning.EffortMap) == 0 {
+		t.Fatal("redeclaration must inherit the built-in effort map")
+	}
+	compiled, err := compileGenerate("claude-sonnet-5", entry)(
+		context.Background(),
+		conformanceModel("claude-sonnet-5"),
+		inferencetest.ReasoningOffProbe(),
+		inference.GenerateExecutionUnary,
+	)
+	if err != nil {
+		t.Fatalf("toggle model rejected reasoning off: %v", err)
+	}
+	if compiled.Wire.thinking == nil || *compiled.Wire.thinking {
+		t.Fatalf("wire thinking = %v, want disabled", compiled.Wire.thinking)
+	}
+	if compiled.Report.Rejects(inference.FieldGenerateIntentReasoningEnabled) {
+		t.Fatal("toggle model rejected on the reasoning_enabled field")
+	}
+}
+
+// TestPublishedToggleCompilesReasoningOff is the generic conformance
+// contract for every built-in model that publishes toggle.
+func TestPublishedToggleCompilesReasoningOff(t *testing.T) {
+	spec, err := decodeSpec(context.Background(), []byte(`{}`))
+	if err != nil {
+		t.Fatalf("decodeSpec: %v", err)
+	}
+	models, err := mergedCatalog(spec)
+	if err != nil {
+		t.Fatalf("mergedCatalog: %v", err)
+	}
+	checked := 0
+	for name, entry := range models {
+		if entry.capabilities.Reasoning.Kind != inference.ReasoningToggle {
+			continue
+		}
+		checked++
+		compiled, err := compileGenerate(name, entry)(
+			context.Background(),
+			conformanceModel(name),
+			inferencetest.ReasoningOffProbe(),
+			inference.GenerateExecutionUnary,
+		)
+		if err != nil {
+			t.Fatalf("toggle model %q rejected reasoning off: %v", name, err)
+		}
+		if compiled.Report.Rejects(inference.FieldGenerateIntentReasoningEnabled) {
+			t.Fatalf("toggle model %q rejected on the reasoning_enabled field", name)
+		}
+	}
+	if checked == 0 {
+		t.Fatal("no toggle model exercised")
+	}
+}
+
+// TestCustomEmbedDimensionsUnsupported guards the capability leaf on a
+// provider that serves text generation only.
+func TestCustomEmbedDimensionsUnsupported(t *testing.T) {
+	if _, err := decodeSpec(context.Background(), []byte(`{
+		"models": [{
+			"name": "m",
+			"capabilities": {"outputs": ["text"], "custom_embed_dimensions": true}
+		}]
+	}`)); err == nil {
+		t.Fatal("custom_embed_dimensions on anthropic unexpectedly accepted")
+	}
+}

--- a/driver/anthropic/spec.go
+++ b/driver/anthropic/spec.go
@@ -20,12 +20,14 @@ type Spec struct {
 	Models []ModelSpec `json:"models,omitempty"`
 }
 
-// ModelSpec declares one catalog overlay entry.
+// ModelSpec declares one catalog overlay entry: a leaf-level patch over the
+// same-named built-in model (or a fresh declaration for unknown names).
+// Capability leaves the entry does not name are inherited from the built-in
+// entry, so tweaking one channel cannot silently revoke the rest.
 type ModelSpec struct {
 	Name string `json:"name"`
-	// Capabilities declares the model's input/output content kinds and the
-	// reasoning control capability.
-	Capabilities inference.ModelCapabilities `json:"capabilities,omitempty"`
+	// Capabilities declares the capability leaves this model changes.
+	Capabilities *inference.CapabilitiesPatch `json:"capabilities,omitempty"`
 	// Limits declares numeric capacity limits for the model. Overriding a
 	// built-in catalog entry by name keeps the catalog limit for any field
 	// left nil; declaring a value replaces it.
@@ -53,6 +55,17 @@ func (s Spec) Validate() error {
 			return fmt.Errorf("anthropic: duplicate model %q", model.Name)
 		}
 		seen[model.Name] = true
+		if err := model.Capabilities.Validate(); err != nil {
+			return fmt.Errorf("anthropic: model %q: %w", model.Name, err)
+		}
+		if model.Capabilities != nil &&
+			model.Capabilities.CustomEmbedDimensions != nil {
+			return fmt.Errorf(
+				"anthropic: model %q: custom_embed_dimensions is unsupported "+
+					"(anthropic serves text generation only)",
+				model.Name,
+			)
+		}
 		if err := model.Limits.Validate(); err != nil {
 			return fmt.Errorf("anthropic: model %q: %w", model.Name, err)
 		}

--- a/driver/azure/catalog.go
+++ b/driver/azure/catalog.go
@@ -12,27 +12,25 @@ import (
 // Azure routes by deployment name, so the spec's models list is the whole
 // catalog: the factory maps each declared deployment onto an entry, and the
 // compiler rejects every channel the entry omits. capabilities is the single
-// capability fact source; dimensions and effortNone are control capabilities
-// that no capability kind expresses and stay separate flags.
+// capability fact source, including custom embed output dimensions.
+// Reasoning off needs no separate flag: Azure OpenAI expresses it as
+// reasoning.effort="none", so a deployment published as ReasoningToggle has
+// an off route by construction.
 type catalogEntry struct {
 	kind         modelKind
 	capabilities inference.ModelCapabilities
-	dimensions   bool
-	// effortNone marks generate deployments whose reasoning.effort accepts
-	// "none" to disable reasoning; without it a disable request rejects.
-	effortNone bool
 	// requestMetadataEnvelope is the provider-level lowering policy for
 	// canonical GenerateRequest.RequestMetadata ("" disables forwarding).
 	requestMetadataEnvelope string
 }
 
-// entryFor lowers one declared deployment into a compiler entry.
+// entryFor lowers one declared deployment into a compiler entry. Azure has
+// no built-in catalog, so capability leaves are applied to the conservative
+// zero base: every published capability must be stated.
 func entryFor(model ModelSpec) catalogEntry {
 	return catalogEntry{
 		kind:         modelKind(model.Kind),
-		capabilities: model.Capabilities,
-		dimensions:   model.Dimensions,
-		effortNone:   model.EffortNone,
+		capabilities: model.Capabilities.Apply(inference.ModelCapabilities{}),
 	}
 }
 

--- a/driver/azure/conformance_test.go
+++ b/driver/azure/conformance_test.go
@@ -170,7 +170,14 @@ func TestConformanceGenerateStreamFailure(t *testing.T) {
 func TestConformanceEmbedUnary(t *testing.T) {
 	calls := &inferencetest.Counter{}
 	deployment := "embed-deploy"
-	entry := entryFor(ModelSpec{Name: deployment, Kind: "embed", Dimensions: true})
+	dimensions := true
+	entry := entryFor(ModelSpec{
+		Name: deployment,
+		Kind: "embed",
+		Capabilities: &inference.CapabilitiesPatch{
+			CustomEmbedDimensions: &dimensions,
+		},
+	})
 	driver := conformanceEmbedDriver(t, compileEmbed(deployment, entry), calls)
 	inferencetest.RunEmbedUnary(t, inferencetest.EmbedUnarySuite{
 		Model: conformanceModel(deployment),

--- a/driver/azure/doc.go
+++ b/driver/azure/doc.go
@@ -16,8 +16,9 @@
 //
 // Deployments are the catalog: Azure routes by deployment name, so every
 // model in spec.models declares one deployment plus the operation kind and
-// optional capability flags (including effort_none for reasoning
-// deployments that accept effort "none" to disable thinking). Credentials
-// live per profile under api_key; the resource endpoint and api-version
-// live on the provider Spec.
+// optional capability flags. Reasoning off needs no separate flag: a
+// deployment published as reasoning kind "toggle" asserts the endpoint
+// honors reasoning.effort="none", and deployments that cannot disable
+// reasoning publish "always". Credentials live per profile under api_key;
+// the resource endpoint and api-version live on the provider Spec.
 package azure

--- a/driver/azure/embed.go
+++ b/driver/azure/embed.go
@@ -53,7 +53,7 @@ func compileEmbed(
 			model:      model,
 			dimensions: request.Dimensions,
 		}
-		if request.Dimensions != nil && !entry.dimensions {
+		if request.Dimensions != nil && !entry.capabilities.CustomEmbedDimensions {
 			ledger.reject(
 				inference.FieldEmbedDimensions,
 				"model does not accept custom dimensions",

--- a/driver/azure/embed_capability_test.go
+++ b/driver/azure/embed_capability_test.go
@@ -1,0 +1,78 @@
+package azure
+
+import (
+	"context"
+	"testing"
+
+	"github.com/GizClaw/flowcraft/core/inference"
+	"github.com/GizClaw/flowcraft/core/message"
+)
+
+func embedDimensionRequest() inference.EmbedRequest {
+	dimensions := 512
+	return inference.EmbedRequest{
+		Items: []inference.EmbedItem{{
+			Content: message.Content{Parts: []message.Part{
+				message.TextPart{Text: "hi"},
+			}},
+		}},
+		Dimensions: &dimensions,
+	}
+}
+
+func embedSpec(leaf *bool) ModelSpec {
+	inputs := []message.PartKind{message.PartText}
+	return ModelSpec{
+		Name: "embed-deploy",
+		Kind: "embed",
+		Capabilities: &inference.CapabilitiesPatch{
+			Inputs:                &inputs,
+			CustomEmbedDimensions: leaf,
+		},
+	}
+}
+
+// TestEmbedDimensionsGate locks the capability-driven gate: deployments
+// without the published capability reject the dimensions field, and ones
+// that publish it compile it through.
+func TestEmbedDimensionsGate(t *testing.T) {
+	compiled, err := compileEmbed("embed-deploy", entryFor(embedSpec(nil)))(
+		context.Background(),
+		conformanceModel("embed-deploy"),
+		embedDimensionRequest(),
+	)
+	if err == nil {
+		t.Fatal("fixed-size deployment unexpectedly accepted custom dimensions")
+	}
+	if !compiled.Report.Rejects(inference.FieldEmbedDimensions) {
+		t.Fatal("dimensions request was not rejected on the dimensions field")
+	}
+
+	enabled := true
+	compiled, err = compileEmbed("embed-deploy", entryFor(embedSpec(&enabled)))(
+		context.Background(),
+		conformanceModel("embed-deploy"),
+		embedDimensionRequest(),
+	)
+	if err != nil {
+		t.Fatalf("dimensions request rejected on a capable deployment: %v", err)
+	}
+	if compiled.Wire.dimensions == nil || *compiled.Wire.dimensions != 512 {
+		t.Fatalf("wire dimensions = %v, want 512", compiled.Wire.dimensions)
+	}
+}
+
+// TestCustomEmbedDimensionsRequiresEmbedKind guards the capability leaf's
+// family contract on the spec side.
+func TestCustomEmbedDimensionsRequiresEmbedKind(t *testing.T) {
+	if _, err := decodeSpec(context.Background(), []byte(`{
+		"endpoint": "https://example.openai.azure.com",
+		"models": [{
+			"name": "m",
+			"kind": "generate",
+			"capabilities": {"outputs": ["text"], "custom_embed_dimensions": true}
+		}]
+	}`)); err == nil {
+		t.Fatal("custom_embed_dimensions on a generate deployment unexpectedly accepted")
+	}
+}

--- a/driver/azure/embed_capability_test.go
+++ b/driver/azure/embed_capability_test.go
@@ -76,3 +76,19 @@ func TestCustomEmbedDimensionsRequiresEmbedKind(t *testing.T) {
 		t.Fatal("custom_embed_dimensions on a generate deployment unexpectedly accepted")
 	}
 }
+
+// TestCustomEmbedDimensionsFalseOnGenerateAccepted guards the leaf
+// contract: an explicit false is the conservative declaration and must be
+// a harmless no-op on deployments that never embed.
+func TestCustomEmbedDimensionsFalseOnGenerateAccepted(t *testing.T) {
+	if _, err := decodeSpec(context.Background(), []byte(`{
+		"endpoint": "https://example.openai.azure.com",
+		"models": [{
+			"name": "m",
+			"kind": "generate",
+			"capabilities": {"outputs": ["text"], "custom_embed_dimensions": false}
+		}]
+	}`)); err != nil {
+		t.Fatalf("explicit false on a generate deployment rejected: %v", err)
+	}
+}

--- a/driver/azure/generate.go
+++ b/driver/azure/generate.go
@@ -621,14 +621,9 @@ func compileIntent(
 			)
 		case entry.capabilities.Reasoning.Kind == inference.ReasoningToggle &&
 			!*text.ReasoningEnabled:
-			if entry.effortNone {
-				wire.reasoning = "none"
-				break
-			}
-			ledger.reject(
-				inference.FieldGenerateIntentReasoningEnabled,
-				"reasoning cannot be disabled through this provider",
-			)
+			// Azure OpenAI expresses reasoning off as effort "none", so a
+			// published toggle always has this off route.
+			wire.reasoning = "none"
 		}
 		// enabled == true is a no-op: reasoning models reason by default.
 	}

--- a/driver/azure/reasoning_contract_test.go
+++ b/driver/azure/reasoning_contract_test.go
@@ -1,0 +1,75 @@
+package azure
+
+import (
+	"context"
+	"testing"
+
+	"github.com/GizClaw/flowcraft/core/inference"
+	"github.com/GizClaw/flowcraft/core/inference/inferencetest"
+)
+
+func decodeDeployment(t *testing.T, raw string) Spec {
+	t.Helper()
+	spec, err := decodeSpec(context.Background(), []byte(`{
+		"endpoint": "https://example.openai.azure.com",
+		"models": [`+raw+`]
+	}`))
+	if err != nil {
+		t.Fatalf("decodeSpec: %v", err)
+	}
+	return spec
+}
+
+// TestSpecToggleCompilesOff locks the toggle contract for Azure: "toggle"
+// on a deployment asserts the endpoint honors reasoning.effort="none", so
+// no extra declaration is needed and the switch must compile.
+func TestSpecToggleCompilesOff(t *testing.T) {
+	spec := decodeDeployment(t, `{
+		"name": "deploy-none",
+		"kind": "generate",
+		"capabilities": {"outputs": ["text"], "reasoning": {"kind": "toggle"}}
+	}`)
+	entry := entryFor(spec.Models[0])
+	if err := entry.validate(); err != nil {
+		t.Fatalf("validate: %v", err)
+	}
+	compiled, err := compileGenerate("deploy-none", entry)(
+		context.Background(),
+		conformanceModel("deploy-none"),
+		inferencetest.ReasoningOffProbe(),
+		inference.GenerateExecutionUnary,
+	)
+	if err != nil {
+		t.Fatalf("toggle deployment rejected reasoning off: %v", err)
+	}
+	if compiled.Wire.reasoning != "none" {
+		t.Fatalf("wire reasoning = %q, want none", compiled.Wire.reasoning)
+	}
+	if compiled.Report.Rejects(inference.FieldGenerateIntentReasoningEnabled) {
+		t.Fatal("toggle deployment rejected on the reasoning_enabled field")
+	}
+}
+
+func TestSpecAlwaysRejectsOff(t *testing.T) {
+	spec := decodeDeployment(t, `{
+		"name": "deploy-always",
+		"kind": "generate",
+		"capabilities": {"outputs": ["text"], "reasoning": {"kind": "always"}}
+	}`)
+	entry := entryFor(spec.Models[0])
+	if err := entry.validate(); err != nil {
+		t.Fatalf("validate: %v", err)
+	}
+	compiled, err := compileGenerate("deploy-always", entry)(
+		context.Background(),
+		conformanceModel("deploy-always"),
+		inferencetest.ReasoningOffProbe(),
+		inference.GenerateExecutionUnary,
+	)
+	if err == nil {
+		t.Fatal("always deployment unexpectedly compiled reasoning_enabled=false")
+	}
+	if !compiled.Report.Rejects(inference.FieldGenerateIntentReasoningEnabled) {
+		t.Fatal("always deployment did not reject on the reasoning_enabled field")
+	}
+}

--- a/driver/azure/reasoning_none_test.go
+++ b/driver/azure/reasoning_none_test.go
@@ -8,14 +8,13 @@ import (
 	"github.com/GizClaw/flowcraft/core/message"
 )
 
-func TestToggleFalseCompilesToEffortNone(t *testing.T) {
+func TestToggleFalseCompilesToWireNone(t *testing.T) {
 	entry := catalogEntry{
 		kind: kindGenerate,
 		capabilities: inference.ModelCapabilities{
 			Outputs:   []message.PartKind{message.PartText},
 			Reasoning: inference.ReasoningCapability{Kind: inference.ReasoningToggle},
 		},
-		effortNone: true,
 	}
 	compile := compileGenerate("deploy-none", entry)
 	request := conformanceTextRequest()
@@ -35,34 +34,7 @@ func TestToggleFalseCompilesToEffortNone(t *testing.T) {
 		t.Fatalf("wire reasoning = %q, want none", compiled.Wire.reasoning)
 	}
 	if compiled.Report.Rejects(inference.FieldGenerateIntentReasoningEnabled) {
-		t.Fatal("disable request unexpectedly rejected on an effort_none deployment")
-	}
-}
-
-func TestToggleFalseRejectsWithoutEffortNone(t *testing.T) {
-	entry := catalogEntry{
-		kind: kindGenerate,
-		capabilities: inference.ModelCapabilities{
-			Outputs:   []message.PartKind{message.PartText},
-			Reasoning: inference.ReasoningCapability{Kind: inference.ReasoningToggle},
-		},
-	}
-	compile := compileGenerate("deploy-legacy", entry)
-	request := conformanceTextRequest()
-	disabled := false
-	request.Input.Content.Intent.Text.ReasoningEnabled = &disabled
-
-	compiled, err := compile(
-		context.Background(),
-		conformanceModel("deploy-legacy"),
-		request,
-		inference.GenerateExecutionUnary,
-	)
-	if err == nil {
-		t.Fatal("disable request unexpectedly accepted without effort_none")
-	}
-	if !compiled.Report.Rejects(inference.FieldGenerateIntentReasoningEnabled) {
-		t.Fatal("disable request was not rejected on the reasoning_enabled field")
+		t.Fatal("disable request unexpectedly rejected on a toggle deployment")
 	}
 }
 

--- a/driver/azure/request_metadata_test.go
+++ b/driver/azure/request_metadata_test.go
@@ -9,12 +9,14 @@ import (
 )
 
 func TestRequestMetadataCompilesAndLoweringOptions(t *testing.T) {
+	inputs := []message.PartKind{message.PartText}
+	outputs := []message.PartKind{message.PartText}
 	entry := entryFor(ModelSpec{
 		Name: "gpt-test",
 		Kind: "generate",
-		Capabilities: inference.ModelCapabilities{
-			Inputs:  []message.PartKind{message.PartText},
-			Outputs: []message.PartKind{message.PartText},
+		Capabilities: &inference.CapabilitiesPatch{
+			Inputs:  &inputs,
+			Outputs: &outputs,
 		},
 	})
 	request := inference.GenerateRequest{

--- a/driver/azure/spec.go
+++ b/driver/azure/spec.go
@@ -52,20 +52,15 @@ func (s RequestMetadataSpec) Validate() error {
 type ModelSpec struct {
 	Name string `json:"name"`
 	Kind string `json:"kind"` // generate | embed | image | tts
-	// Capabilities declares the deployment's input/output content kinds,
-	// hosted web search support, and reasoning control capability, validated
-	// against the kind's compiler contract.
-	Capabilities inference.ModelCapabilities `json:"capabilities,omitempty"`
+	// Capabilities declares the deployment's capability leaves (input/output
+	// content kinds, hosted web search, reasoning control). Azure has no
+	// built-in line-up to inherit from, so every leaf a deployment publishes
+	// must be stated; unstated leaves stay the conservative zero declaration.
+	Capabilities *inference.CapabilitiesPatch `json:"capabilities,omitempty"`
 	// Limits declares numeric capacity limits for the deployment. Azure
 	// routes by deployment name and has no built-in catalog, so limits only
 	// ever come from the declaration.
 	Limits inference.ModelLimits `json:"limits,omitempty"`
-	// Dimensions accepts the embed dimensions knob (embed only).
-	Dimensions bool `json:"dimensions,omitempty"`
-	// EffortNone marks generate deployments whose reasoning.effort accepts
-	// "none" to disable reasoning (gpt-5.1+ deployments); deployments
-	// without it reject a ReasoningEnabled=false request.
-	EffortNone bool `json:"effort_none,omitempty"`
 }
 
 func (s Spec) Validate() error {
@@ -119,12 +114,18 @@ func (s Spec) Validate() error {
 				model.Kind,
 			)
 		}
-		if model.Dimensions && modelKind(model.Kind) != kindEmbed {
+		kind := modelKind(model.Kind)
+		if model.Capabilities != nil &&
+			model.Capabilities.CustomEmbedDimensions != nil &&
+			kind != kindEmbed {
 			return fmt.Errorf(
-				"azure: deployment %q sets dimensions on kind %q",
+				"azure: deployment %q sets custom_embed_dimensions on kind %q",
 				model.Name,
 				model.Kind,
 			)
+		}
+		if err := model.Capabilities.Validate(); err != nil {
+			return fmt.Errorf("azure: deployment %q: %w", model.Name, err)
 		}
 		if err := entryFor(model).validate(); err != nil {
 			return fmt.Errorf("azure: deployment %q: %w", model.Name, err)

--- a/driver/azure/spec.go
+++ b/driver/azure/spec.go
@@ -117,6 +117,7 @@ func (s Spec) Validate() error {
 		kind := modelKind(model.Kind)
 		if model.Capabilities != nil &&
 			model.Capabilities.CustomEmbedDimensions != nil &&
+			*model.Capabilities.CustomEmbedDimensions &&
 			kind != kindEmbed {
 			return fmt.Errorf(
 				"azure: deployment %q sets custom_embed_dimensions on kind %q",

--- a/driver/bytedance/catalog.go
+++ b/driver/bytedance/catalog.go
@@ -22,14 +22,12 @@ const (
 
 // catalogEntry is one model's declared capability set. capabilities is the
 // single capability fact source: input/output content kinds, hosted web
-// search, and the reasoning control capability. dimensions and maxResolution
-// are control capabilities that no capability kind expresses and stay
-// separate flags.
+// search, the reasoning control capability, and custom embed output
+// dimensions. maxResolution is a control capability that no capability kind
+// expresses and stays a separate flag.
 type catalogEntry struct {
 	kind         modelKind
 	capabilities inference.ModelCapabilities
-	// embed: accepts custom output dimensions.
-	dimensions bool
 	// video: highest supported resolution tier ("720p", "1080p", "4k");
 	// empty leaves resolution unconstrained.
 	maxResolution string
@@ -38,20 +36,12 @@ type catalogEntry struct {
 	// lifecycle: deprecated models stay routable but announce a replacement.
 	deprecated  bool
 	replacement string
-	// maxInputTokens caps the input context in tokens; zero means
-	// undeclared. Generate values mirror the family context window on
-	// the Volcengine Ark model detail pages; the official model list
-	// (https://www.volcengine.com/docs/82379/1330310) reports separate
-	// per-version max-input values (typically 224K or 256K, with 1M
-	// long-context tiers), so these entries are the family-level upper
-	// bound. Embedding values mirror the documented per-input limit.
-	maxInputTokens int
-	// maxOutputTokens caps the tokens a single generate response may emit
-	// (thinking plus answer tokens share the budget); zero means
-	// undeclared. Generate values mirror the per-version max-output on the
-	// official model list
-	// (https://www.volcengine.com/docs/82379/1330310).
-	maxOutputTokens int
+	// limits carries the model's context/output windows in tokens. Nil
+	// leaves are undeclared. Generate values mirror the family context
+	// window and per-version max output on the Volcengine Ark model detail
+	// pages (https://www.volcengine.com/docs/82379/1330310); embedding
+	// values mirror the documented per-input limit.
+	limits inference.ModelLimits
 }
 
 // videoParams is the Seedance task-parameter support matrix for one video
@@ -59,9 +49,11 @@ type catalogEntry struct {
 // (https://www.volcengine.com/docs/82379/1520757): each field mirrors one
 // parameter's documented "model support" column, so the compiler can reject
 // parameters the strong-validation endpoint would otherwise fault on.
-// Zero values mean "undeclared": Spec.Models entries keep a zero matrix and
-// compile with syntax-only validation (the deployment declares the
-// capability); built-in entries declare the full matrix.
+// Zero values mean "undeclared": custom Spec.Models entries (names outside
+// the built-in catalog) keep a zero matrix and compile with syntax-only
+// validation (the deployment declares the capability); redeclarations of
+// built-in video models inherit the built-in matrix, exactly like every
+// other control flag.
 type videoParams struct {
 	seed          bool // supports seed
 	cameraFixed   bool // supports camera_fixed
@@ -123,7 +115,7 @@ func (e catalogEntry) validate() error {
 			return fmt.Errorf("%s family declares no generate output", e.kind)
 		}
 	}
-	return nil
+	return e.limits.Validate()
 }
 
 // generateChatCapabilities is the common capability declaration for the Ark
@@ -172,8 +164,9 @@ var catalog = map[string]catalogEntry{
 			WithHostedWebSearch().
 			WithReasoning(inference.ReasoningToggle).
 			WithReasoningEffortMap(arkEffortMap),
-		maxInputTokens:  1_024_000,
-		maxOutputTokens: 256_000,
+		limits: inference.ModelLimits{}.
+			WithMaxInputTokens(1_024_000).
+			WithMaxOutputTokens(256_000),
 	},
 
 	// Seed 2.1 (2026-06) — current flagship tier. The whole Seed 2.x line is
@@ -185,8 +178,9 @@ var catalog = map[string]catalogEntry{
 			WithHostedWebSearch().
 			WithReasoning(inference.ReasoningToggle).
 			WithReasoningEffortMap(arkEffortMap),
-		maxInputTokens:  256_000,
-		maxOutputTokens: 256_000,
+		limits: inference.ModelLimits{}.
+			WithMaxInputTokens(256_000).
+			WithMaxOutputTokens(256_000),
 	},
 	"doubao-seed-2-1-turbo": {
 		kind: kindGenerate,
@@ -195,8 +189,9 @@ var catalog = map[string]catalogEntry{
 			WithHostedWebSearch().
 			WithReasoning(inference.ReasoningToggle).
 			WithReasoningEffortMap(arkEffortMap),
-		maxInputTokens:  256_000,
-		maxOutputTokens: 256_000,
+		limits: inference.ModelLimits{}.
+			WithMaxInputTokens(256_000).
+			WithMaxOutputTokens(256_000),
 	},
 
 	// Seed 2.0 (2026-02) — general agent line plus the code-tuned variant.
@@ -210,8 +205,9 @@ var catalog = map[string]catalogEntry{
 			WithHostedWebSearch().
 			WithReasoning(inference.ReasoningToggle).
 			WithReasoningEffortMap(arkEffortMap),
-		maxInputTokens:  256_000,
-		maxOutputTokens: 128_000,
+		limits: inference.ModelLimits{}.
+			WithMaxInputTokens(256_000).
+			WithMaxOutputTokens(128_000),
 	},
 	"doubao-seed-2-0-lite": {
 		kind: kindGenerate,
@@ -220,8 +216,9 @@ var catalog = map[string]catalogEntry{
 			WithHostedWebSearch().
 			WithReasoning(inference.ReasoningToggle).
 			WithReasoningEffortMap(arkEffortMap),
-		maxInputTokens:  256_000,
-		maxOutputTokens: 128_000,
+		limits: inference.ModelLimits{}.
+			WithMaxInputTokens(256_000).
+			WithMaxOutputTokens(128_000),
 	},
 	"doubao-seed-2-0-mini": {
 		kind: kindGenerate,
@@ -230,8 +227,9 @@ var catalog = map[string]catalogEntry{
 			WithHostedWebSearch().
 			WithReasoning(inference.ReasoningToggle).
 			WithReasoningEffortMap(arkEffortMap),
-		maxInputTokens:  256_000,
-		maxOutputTokens: 128_000,
+		limits: inference.ModelLimits{}.
+			WithMaxInputTokens(256_000).
+			WithMaxOutputTokens(128_000),
 	},
 	"doubao-seed-2-0-code": {
 		kind: kindGenerate,
@@ -240,8 +238,9 @@ var catalog = map[string]catalogEntry{
 			WithHostedWebSearch().
 			WithReasoning(inference.ReasoningToggle).
 			WithReasoningEffortMap(arkEffortMap),
-		maxInputTokens:  256_000,
-		maxOutputTokens: 128_000,
+		limits: inference.ModelLimits{}.
+			WithMaxInputTokens(256_000).
+			WithMaxOutputTokens(128_000),
 	},
 
 	// Seed 1.x — superseded by the 2.x line; kept routable for existing
@@ -254,8 +253,9 @@ var catalog = map[string]catalogEntry{
 			WithReasoning(inference.ReasoningToggle).
 			WithReasoningEffortMap(arkEffortMap),
 		deprecated: true, replacement: "doubao-seed-2-0-lite",
-		maxInputTokens:  256_000,
-		maxOutputTokens: 64_000,
+		limits: inference.ModelLimits{}.
+			WithMaxInputTokens(256_000).
+			WithMaxOutputTokens(64_000),
 	},
 	"doubao-seed-1-6-vision": {
 		kind: kindGenerate,
@@ -265,22 +265,24 @@ var catalog = map[string]catalogEntry{
 			WithReasoning(inference.ReasoningToggle).
 			WithReasoningEffortMap(arkEffortMap),
 		deprecated: true, replacement: "doubao-seed-2-0-lite",
-		maxInputTokens:  256_000,
-		maxOutputTokens: 64_000,
+		limits: inference.ModelLimits{}.
+			WithMaxInputTokens(256_000).
+			WithMaxOutputTokens(64_000),
 	},
 
 	"doubao-embedding-large": {
-		kind:           kindEmbed,
-		capabilities:   inference.ModelCapabilities{}.WithInputs(message.PartText),
-		dimensions:     true,
-		maxInputTokens: 4_095,
+		kind: kindEmbed,
+		capabilities: inference.ModelCapabilities{}.
+			WithInputs(message.PartText).
+			WithCustomEmbedDimensions(),
+		limits: inference.ModelLimits{}.WithMaxInputTokens(4_095),
 	},
 	"doubao-embedding-vision": {
 		kind: kindEmbed,
 		capabilities: inference.ModelCapabilities{}.
-			WithInputs(message.PartText, message.PartImage),
-		dimensions:     true,
-		maxInputTokens: 8_191,
+			WithInputs(message.PartText, message.PartImage).
+			WithCustomEmbedDimensions(),
+		limits: inference.ModelLimits{}.WithMaxInputTokens(8_191),
 	},
 
 	// Seedream image generation; 5.0-pro/5.0/4.5 current, 4.0 superseded.
@@ -477,28 +479,42 @@ var catalog = map[string]catalogEntry{
 }
 
 // mergedCatalog overlays Spec.Models onto the built-in catalog and returns
-// the merged view. Spec entries replace catalog entries by name; numeric
-// limits are inherited from the replaced entry unless the declaration sets
-// them explicitly.
+// the merged view. A spec entry with a built-in name under the same kind is
+// a leaf-level patch: capability leaves it names replace the built-in's and
+// everything else (numeric limits, max resolution, the video parameter
+// matrix) is inherited unless declared explicitly. Video entries
+// intentionally keep a zero parameter matrix (syntax-only validation) when
+// the deployment declares its own capability set; see videoParams.
 func mergedCatalog(spec Spec) (map[string]catalogEntry, error) {
 	merged := make(map[string]catalogEntry, len(catalog)+len(spec.Models))
 	maps.Copy(merged, catalog)
 	for _, model := range spec.Models {
-		entry := catalogEntry{
-			kind:          modelKind(model.Kind),
-			capabilities:  model.Capabilities,
-			dimensions:    model.Dimensions,
-			maxResolution: model.MaxResolution,
-		}
-		if builtin, exists := merged[model.Name]; exists && builtin.kind == entry.kind {
-			entry.maxInputTokens = builtin.maxInputTokens
-			entry.maxOutputTokens = builtin.maxOutputTokens
+		kind := modelKind(model.Kind)
+		builtin, exists := merged[model.Name]
+		entry := catalogEntry{kind: kind}
+		if exists && builtin.kind == kind {
+			entry.capabilities = model.Capabilities.Apply(builtin.capabilities)
+			entry.limits = builtin.limits.Clone()
+			entry.video = builtin.video
+			entry.maxResolution = builtin.maxResolution
+			if model.MaxResolution != nil {
+				entry.maxResolution = *model.MaxResolution
+			}
+		} else {
+			entry.capabilities = model.Capabilities.Apply(
+				inference.ModelCapabilities{},
+			)
+			if model.MaxResolution != nil {
+				entry.maxResolution = *model.MaxResolution
+			}
 		}
 		if model.Limits.MaxInputTokens != nil {
-			entry.maxInputTokens = *model.Limits.MaxInputTokens
+			value := *model.Limits.MaxInputTokens
+			entry.limits.MaxInputTokens = &value
 		}
 		if model.Limits.MaxOutputTokens != nil {
-			entry.maxOutputTokens = *model.Limits.MaxOutputTokens
+			value := *model.Limits.MaxOutputTokens
+			entry.limits.MaxOutputTokens = &value
 		}
 		merged[model.Name] = entry
 	}
@@ -528,12 +544,7 @@ func descriptorFor(id inference.ModelID, entry catalogEntry) inference.ModelDesc
 			descriptor.Lifecycle.Replacement = &replacement
 		}
 	}
-	if entry.maxInputTokens > 0 {
-		descriptor.Limits.MaxInputTokens = &entry.maxInputTokens
-	}
-	if entry.maxOutputTokens > 0 {
-		descriptor.Limits.MaxOutputTokens = &entry.maxOutputTokens
-	}
+	descriptor.Limits = entry.limits.Clone()
 	return descriptor
 }
 

--- a/driver/bytedance/catalog_test.go
+++ b/driver/bytedance/catalog_test.go
@@ -27,7 +27,7 @@ func TestCatalogDeclaresMaxInputTokens(t *testing.T) {
 		if !ok {
 			t.Fatalf("catalog model %q missing from provider", name)
 		}
-		if entry.maxInputTokens <= 0 || descriptor.Limits.MaxInputTokens == nil {
+		if entry.limits.MaxInputTokens == nil || descriptor.Limits.MaxInputTokens == nil {
 			t.Errorf("model %q: max input tokens not declared", name)
 		}
 	}
@@ -68,7 +68,7 @@ func TestCatalogDeclaresMaxOutputTokens(t *testing.T) {
 		if !ok {
 			t.Fatalf("catalog model %q missing from provider", name)
 		}
-		if entry.maxOutputTokens <= 0 || descriptor.Limits.MaxOutputTokens == nil {
+		if entry.limits.MaxOutputTokens == nil || descriptor.Limits.MaxOutputTokens == nil {
 			t.Errorf("model %q: max output tokens not declared", name)
 		}
 	}
@@ -218,9 +218,10 @@ func TestMergedCatalogOverlaysDeclaredLimits(t *testing.T) {
 		t.Fatalf("mergedCatalog: %v", err)
 	}
 	entry := models["doubao-seed-2-1-pro"]
-	if entry.maxInputTokens != 256_000 || entry.maxOutputTokens != 256_000 {
+	in, out := entry.limits.Values()
+	if in != 256_000 || out != 256_000 {
 		t.Fatalf("redeclared limits = %d/%d, want catalog 256000/256000",
-			entry.maxInputTokens, entry.maxOutputTokens)
+			in, out)
 	}
 
 	spec, err = decodeSpec(context.Background(), []byte(`{
@@ -239,9 +240,10 @@ func TestMergedCatalogOverlaysDeclaredLimits(t *testing.T) {
 		t.Fatalf("mergedCatalog: %v", err)
 	}
 	entry = models["doubao-seed-2-1-pro"]
-	if entry.maxInputTokens != 256_000 || entry.maxOutputTokens != 4096 {
+	in, out = entry.limits.Values()
+	if in != 256_000 || out != 4096 {
 		t.Fatalf("overridden limits = %d/%d, want 256000/4096",
-			entry.maxInputTokens, entry.maxOutputTokens)
+			in, out)
 	}
 }
 
@@ -263,8 +265,9 @@ func TestMergedCatalogOverridesDeclaredInputLimit(t *testing.T) {
 		t.Fatalf("mergedCatalog: %v", err)
 	}
 	entry := models["doubao-seed-2-1-pro"]
-	if entry.maxInputTokens != 65_536 || entry.maxOutputTokens != 256_000 {
+	in, out := entry.limits.Values()
+	if in != 65_536 || out != 256_000 {
 		t.Fatalf("declared input limits = %d/%d, want 65536/256000",
-			entry.maxInputTokens, entry.maxOutputTokens)
+			in, out)
 	}
 }

--- a/driver/bytedance/embed.go
+++ b/driver/bytedance/embed.go
@@ -64,7 +64,7 @@ func compileEmbed(
 			multimodal: slices.Contains(entry.capabilities.Inputs, message.PartImage),
 			dimensions: request.Dimensions,
 		}
-		if request.Dimensions != nil && !entry.dimensions {
+		if request.Dimensions != nil && !entry.capabilities.CustomEmbedDimensions {
 			ledger.reject(
 				inference.FieldEmbedDimensions,
 				"model does not accept custom dimensions",

--- a/driver/bytedance/embed_capability_test.go
+++ b/driver/bytedance/embed_capability_test.go
@@ -1,0 +1,71 @@
+package bytedance
+
+import (
+	"context"
+	"testing"
+
+	"github.com/GizClaw/flowcraft/core/inference"
+	"github.com/GizClaw/flowcraft/core/message"
+)
+
+func embedDimensionRequest() inference.EmbedRequest {
+	dimensions := 512
+	return inference.EmbedRequest{
+		Items: []inference.EmbedItem{{
+			Content: message.Content{Parts: []message.Part{
+				message.TextPart{Text: "hi"},
+			}},
+		}},
+		Dimensions: &dimensions,
+	}
+}
+
+// TestEmbedDimensionsGate locks the capability-driven gate: models without
+// the published capability reject the dimensions field, and models that
+// publish it compile it through.
+func TestEmbedDimensionsGate(t *testing.T) {
+	fixed := catalogEntry{
+		kind:         kindEmbed,
+		capabilities: inference.ModelCapabilities{}.WithInputs(message.PartText),
+	}
+	compiled, err := compileEmbed("fixed", fixed)(
+		context.Background(),
+		conformanceModel("fixed"),
+		embedDimensionRequest(),
+	)
+	if err == nil {
+		t.Fatal("fixed-size model unexpectedly accepted custom dimensions")
+	}
+	if !compiled.Report.Rejects(inference.FieldEmbedDimensions) {
+		t.Fatal("dimensions request was not rejected on the dimensions field")
+	}
+
+	compiled, err = compileEmbed(
+		"doubao-embedding-large",
+		catalog["doubao-embedding-large"],
+	)(
+		context.Background(),
+		conformanceModel("doubao-embedding-large"),
+		embedDimensionRequest(),
+	)
+	if err != nil {
+		t.Fatalf("dimensions request rejected on a capable model: %v", err)
+	}
+	if compiled.Wire.dimensions == nil || *compiled.Wire.dimensions != 512 {
+		t.Fatalf("wire dimensions = %v, want 512", compiled.Wire.dimensions)
+	}
+}
+
+// TestCustomEmbedDimensionsRequiresEmbedKind guards the capability leaf's
+// family contract on the spec side.
+func TestCustomEmbedDimensionsRequiresEmbedKind(t *testing.T) {
+	if _, err := decodeSpec(context.Background(), []byte(`{
+		"models": [{
+			"name": "m",
+			"kind": "generate",
+			"capabilities": {"outputs": ["text"], "custom_embed_dimensions": true}
+		}]
+	}`)); err == nil {
+		t.Fatal("custom_embed_dimensions on a generate model unexpectedly accepted")
+	}
+}

--- a/driver/bytedance/embed_capability_test.go
+++ b/driver/bytedance/embed_capability_test.go
@@ -69,3 +69,18 @@ func TestCustomEmbedDimensionsRequiresEmbedKind(t *testing.T) {
 		t.Fatal("custom_embed_dimensions on a generate model unexpectedly accepted")
 	}
 }
+
+// TestCustomEmbedDimensionsFalseOnGenerateAccepted guards the leaf
+// contract: an explicit false is the conservative declaration and must be
+// a harmless no-op on models that never embed.
+func TestCustomEmbedDimensionsFalseOnGenerateAccepted(t *testing.T) {
+	if _, err := decodeSpec(context.Background(), []byte(`{
+		"models": [{
+			"name": "m",
+			"kind": "generate",
+			"capabilities": {"outputs": ["text"], "custom_embed_dimensions": false}
+		}]
+	}`)); err != nil {
+		t.Fatalf("explicit false on a generate model rejected: %v", err)
+	}
+}

--- a/driver/bytedance/reasoning_contract_test.go
+++ b/driver/bytedance/reasoning_contract_test.go
@@ -1,0 +1,120 @@
+package bytedance
+
+import (
+	"context"
+	"testing"
+
+	"github.com/GizClaw/flowcraft/core/inference"
+	"github.com/GizClaw/flowcraft/core/inference/inferencetest"
+)
+
+// TestRedeclaredBuiltinKeepsReasoning locks the delta overlay contract:
+// redeclaring doubao-seed-2-1-pro to tweak one channel must keep the
+// built-in reasoning kind and effort map, so a published toggle still
+// compiles reasoning_enabled=false.
+func TestRedeclaredBuiltinKeepsReasoning(t *testing.T) {
+	spec, err := decodeSpec(context.Background(), []byte(`{
+		"models": [{
+			"name": "doubao-seed-2-1-pro",
+			"kind": "generate",
+			"capabilities": {"outputs": ["text"]}
+		}]
+	}`))
+	if err != nil {
+		t.Fatalf("decodeSpec: %v", err)
+	}
+	models, err := mergedCatalog(spec)
+	if err != nil {
+		t.Fatalf("mergedCatalog: %v", err)
+	}
+	entry := models["doubao-seed-2-1-pro"]
+	if entry.capabilities.Reasoning.Kind != inference.ReasoningToggle {
+		t.Fatalf("redeclaration must inherit reasoning toggle, got %q",
+			entry.capabilities.Reasoning.Kind)
+	}
+	if len(entry.capabilities.Reasoning.EffortMap) == 0 {
+		t.Fatal("redeclaration must inherit the built-in effort map")
+	}
+	compiled, err := compileGenerate("doubao-seed-2-1-pro", entry)(
+		context.Background(),
+		conformanceModel("doubao-seed-2-1-pro"),
+		inferencetest.ReasoningOffProbe(),
+		inference.GenerateExecutionUnary,
+	)
+	if err != nil {
+		t.Fatalf("toggle model rejected reasoning off: %v", err)
+	}
+	if compiled.Report.Rejects(inference.FieldGenerateIntentReasoningEnabled) {
+		t.Fatal("toggle model rejected on the reasoning_enabled field")
+	}
+}
+
+// TestRedeclaredBuiltinKeepsControlFlags locks flag inheritance for embed
+// and video entries (dimensions, max resolution) on same-kind redeclare.
+func TestRedeclaredBuiltinKeepsControlFlags(t *testing.T) {
+	spec, err := decodeSpec(context.Background(), []byte(`{
+		"models": [
+			{"name": "doubao-embedding-large", "kind": "embed"},
+			{"name": "doubao-seedance-2-5", "kind": "video"}
+		]
+	}`))
+	if err != nil {
+		t.Fatalf("decodeSpec: %v", err)
+	}
+	models, err := mergedCatalog(spec)
+	if err != nil {
+		t.Fatalf("mergedCatalog: %v", err)
+	}
+	embed := models["doubao-embedding-large"]
+	in, _ := embed.limits.Values()
+	if !embed.capabilities.CustomEmbedDimensions ||
+		in != 4_095 {
+		t.Fatalf("redeclared embed lost control facts: dims=%v in=%d",
+			embed.capabilities.CustomEmbedDimensions, in)
+	}
+	video := models["doubao-seedance-2-5"]
+	builtin := catalog["doubao-seedance-2-5"]
+	if video.maxResolution != builtin.maxResolution {
+		t.Fatalf("redeclared video max_resolution = %q, want built-in %q",
+			video.maxResolution, builtin.maxResolution)
+	}
+	if video.video != builtin.video {
+		t.Fatal("redeclared video lost the built-in parameter matrix")
+	}
+}
+
+// TestPublishedToggleCompilesReasoningOff is the generic conformance
+// contract for every built-in model that publishes toggle.
+func TestPublishedToggleCompilesReasoningOff(t *testing.T) {
+	spec, err := decodeSpec(context.Background(), []byte(`{}`))
+	if err != nil {
+		t.Fatalf("decodeSpec: %v", err)
+	}
+	models, err := mergedCatalog(spec)
+	if err != nil {
+		t.Fatalf("mergedCatalog: %v", err)
+	}
+	checked := 0
+	for name, entry := range models {
+		if entry.kind != kindGenerate ||
+			entry.capabilities.Reasoning.Kind != inference.ReasoningToggle {
+			continue
+		}
+		checked++
+		compiled, err := compileGenerate(name, entry)(
+			context.Background(),
+			conformanceModel(name),
+			inferencetest.ReasoningOffProbe(),
+			inference.GenerateExecutionUnary,
+		)
+		if err != nil {
+			t.Fatalf("toggle model %q rejected reasoning off: %v", name, err)
+		}
+		if compiled.Report.Rejects(inference.FieldGenerateIntentReasoningEnabled) {
+			t.Fatalf("toggle model %q rejected on the reasoning_enabled field", name)
+		}
+	}
+	if checked == 0 {
+		t.Fatal("no toggle model exercised")
+	}
+}

--- a/driver/bytedance/spec.go
+++ b/driver/bytedance/spec.go
@@ -42,12 +42,13 @@ type Spec struct {
 // ModelSpec declares one model outside the built-in catalog, or a delta over
 // a same-named, same-kind built-in catalog entry. Capabilities is a patch
 // with field-presence semantics: leaves it names replace that leaf of the
-// entry it overrides and leaves it does not name are inherited. Dimensions
-// and max resolution is a control capability that no capability kind
-// expresses and stays a separate flag; nil inherits the overridden built-in
-// value, explicit values override. Addressing a custom model at a
-// deployment endpoint works exactly like catalog models: map its name in
-// Spec.Endpoints.
+// entry it overrides and leaves it does not name are inherited. Custom
+// embed output dimensions live in capabilities.custom_embed_dimensions;
+// max_resolution is a control fact that no capability kind expresses and
+// stays a separate flag — nil inherits the overridden built-in value, an
+// explicit empty string declares resolution unconstrained. Addressing a
+// custom model at a deployment endpoint works exactly like catalog models:
+// map its name in Spec.Endpoints.
 type ModelSpec struct {
 	Name string `json:"name"`
 	Kind string `json:"kind"`
@@ -138,6 +139,7 @@ func (m ModelSpec) Validate() error {
 	kind := modelKind(m.Kind)
 	if m.Capabilities != nil &&
 		m.Capabilities.CustomEmbedDimensions != nil &&
+		*m.Capabilities.CustomEmbedDimensions &&
 		kind != kindEmbed {
 		return fmt.Errorf(
 			"model %q sets custom_embed_dimensions on kind %q",

--- a/driver/bytedance/spec.go
+++ b/driver/bytedance/spec.go
@@ -39,28 +39,28 @@ type Spec struct {
 	Models []ModelSpec `json:"models,omitempty"`
 }
 
-// ModelSpec declares one model outside the built-in catalog. Capabilities
-// mirror the built-in catalog shape: content kinds, hosted web search, and
-// the reasoning control capability (validated against the kind's compiler
-// contract at merge time). Dimensions and max resolution are control
-// capabilities that no capability kind expresses and stay separate flags.
-// Addressing a custom model at a deployment endpoint works exactly like
-// catalog models: map its name in Spec.Endpoints.
+// ModelSpec declares one model outside the built-in catalog, or a delta over
+// a same-named, same-kind built-in catalog entry. Capabilities is a patch
+// with field-presence semantics: leaves it names replace that leaf of the
+// entry it overrides and leaves it does not name are inherited. Dimensions
+// and max resolution is a control capability that no capability kind
+// expresses and stays a separate flag; nil inherits the overridden built-in
+// value, explicit values override. Addressing a custom model at a
+// deployment endpoint works exactly like catalog models: map its name in
+// Spec.Endpoints.
 type ModelSpec struct {
 	Name string `json:"name"`
 	Kind string `json:"kind"`
-	// Capabilities declares the model's input/output content kinds, hosted
-	// web search support, and reasoning control capability.
-	Capabilities inference.ModelCapabilities `json:"capabilities,omitempty"`
+	// Capabilities declares the capability leaves this model changes.
+	Capabilities *inference.CapabilitiesPatch `json:"capabilities,omitempty"`
 	// Limits declares numeric capacity limits for the model. Overriding a
 	// built-in catalog entry by name keeps the catalog limit for any field
 	// left nil; declaring a value replaces it.
 	Limits inference.ModelLimits `json:"limits,omitempty"`
-	// Dimensions (embed) allows custom output dimensions.
-	Dimensions bool `json:"dimensions,omitempty"`
 	// MaxResolution (video) caps the supported resolution tier, e.g. "720p"
-	// or "4k"; empty leaves resolution unconstrained.
-	MaxResolution string `json:"max_resolution,omitempty"`
+	// or "4k". Nil inherits the built-in value; an explicit empty string
+	// declares resolution unconstrained.
+	MaxResolution *string `json:"max_resolution,omitempty"`
 }
 
 // ProfileSpec is the per-credential-profile configuration. Endpoint IDs
@@ -134,6 +134,19 @@ func (m ModelSpec) Validate() error {
 	case kindGenerate, kindEmbed, kindImage, kindVideo:
 	default:
 		return fmt.Errorf("model %q has unknown kind %q", m.Name, m.Kind)
+	}
+	kind := modelKind(m.Kind)
+	if m.Capabilities != nil &&
+		m.Capabilities.CustomEmbedDimensions != nil &&
+		kind != kindEmbed {
+		return fmt.Errorf(
+			"model %q sets custom_embed_dimensions on kind %q",
+			m.Name,
+			m.Kind,
+		)
+	}
+	if m.MaxResolution != nil && kind != kindVideo {
+		return fmt.Errorf("model %q sets max_resolution on kind %q", m.Name, m.Kind)
 	}
 	if err := m.Capabilities.Validate(); err != nil {
 		return err

--- a/driver/deepseek/catalog.go
+++ b/driver/deepseek/catalog.go
@@ -24,28 +24,19 @@ const (
 
 // catalogEntry declares what one catalog model accepts. capabilities is the
 // single capability fact source: input/output content kinds, hosted web
-// search, and the reasoning control capability. api, declared, and responses
-// are wire-surface facts, not content capabilities, and stay separate flags.
+// search, and the reasoning control capability. api is a wire-surface fact,
+// not a content capability, and stays a separate flag: every catalog model
+// is served on the surface Spec.API selects.
 type catalogEntry struct {
 	kind         modelKind
 	capabilities inference.ModelCapabilities
 	// api is the provider-level generate surface selected by Spec.API.
 	api apiMode
-	// declared marks a Spec.Models entry (as opposed to a built-in catalog
-	// model). Responses-mode filtering treats declared entries fail-fast.
-	declared bool
-	// responses accepts the Responses API surface. Chat completions work
-	// for every catalog model; responses is per-model.
-	responses bool
-	// maxInputTokens caps the input context in tokens; zero means
-	// undeclared. Both V4 models carry the 1M context published on
+	// limits carries the model's context/output windows in tokens. Nil
+	// leaves are undeclared. Both V4 models carry the 1M context and 384K
+	// maximum output published on
 	// https://api-docs.deepseek.com/quick_start/pricing.
-	maxInputTokens int
-	// maxOutputTokens caps the tokens a single response may emit
-	// (thinking plus answer tokens share the budget); zero means
-	// undeclared. Values mirror the 384K maximum published on
-	// https://api-docs.deepseek.com/quick_start/pricing.
-	maxOutputTokens int
+	limits inference.ModelLimits
 	// requestMetadataEnvelope is the provider-level lowering policy for
 	// canonical GenerateRequest.RequestMetadata ("" disables forwarding).
 	requestMetadataEnvelope string
@@ -78,7 +69,7 @@ func (e catalogEntry) validate() error {
 	if !slices.Contains(e.capabilities.Outputs, message.PartText) {
 		return fmt.Errorf("generate family must declare text output")
 	}
-	return nil
+	return e.limits.Validate()
 }
 
 // generateChatCapabilities is the capability declaration for the DeepSeek
@@ -119,9 +110,9 @@ var catalog = map[string]catalogEntry{
 			WithHostedWebSearch().
 			WithReasoning(inference.ReasoningToggle).
 			WithReasoningEffortMap(deepseekEffortMap),
-		responses:       true,
-		maxInputTokens:  1_000_000,
-		maxOutputTokens: 384_000,
+		limits: inference.ModelLimits{}.
+			WithMaxInputTokens(1_000_000).
+			WithMaxOutputTokens(384_000),
 	},
 	"deepseek-v4-pro": {
 		kind: kindGenerate,
@@ -129,9 +120,9 @@ var catalog = map[string]catalogEntry{
 			WithHostedWebSearch().
 			WithReasoning(inference.ReasoningToggle).
 			WithReasoningEffortMap(deepseekEffortMap),
-		responses:       true,
-		maxInputTokens:  1_000_000,
-		maxOutputTokens: 384_000,
+		limits: inference.ModelLimits{}.
+			WithMaxInputTokens(1_000_000).
+			WithMaxOutputTokens(384_000),
 	},
 	"deepseek-v4-flash-vision-exp": {
 		kind: kindGenerate,
@@ -140,26 +131,25 @@ var catalog = map[string]catalogEntry{
 			WithHostedWebSearch().
 			WithReasoning(inference.ReasoningToggle).
 			WithReasoningEffortMap(deepseekEffortMap),
-		responses:       true,
-		maxInputTokens:  1_000_000,
-		maxOutputTokens: 384_000,
+		limits: inference.ModelLimits{}.
+			WithMaxInputTokens(1_000_000).
+			WithMaxOutputTokens(384_000),
 	},
 }
 
 // mergedCatalog overlays the built-in catalog with the spec's model
-// declarations: a spec entry with a catalog name replaces that entry, and
-// unknown names extend the catalog. Replacing a built-in keeps its numeric
-// limits unless the declaration sets them explicitly. Models stay fail
-// closed — the factory only exposes what the merged catalog declares.
+// declarations: a spec entry with a catalog name is a leaf-level patch over
+// the built-in entry (capability leaves and numeric limits are inherited
+// unless declared explicitly), and unknown names extend the catalog. Models
+// stay fail closed — the factory only exposes what the merged catalog
+// declares. Every generate model is served on whichever surface Spec.API
+// selects.
 func mergedCatalog(spec Spec) (map[string]catalogEntry, error) {
 	models := make(map[string]catalogEntry, len(catalog)+len(spec.Models))
 	maps.Copy(models, catalog)
 	for _, declared := range spec.Models {
 		entry := catalogEntry{
-			kind:         modelKind(declared.Kind),
-			capabilities: declared.Capabilities,
-			responses:    declared.Responses,
-			declared:     true,
+			kind: modelKind(declared.Kind),
 		}
 		if entry.kind == "" {
 			if existing, exists := models[declared.Name]; exists {
@@ -169,14 +159,22 @@ func mergedCatalog(spec Spec) (map[string]catalogEntry, error) {
 			}
 		}
 		if existing, exists := models[declared.Name]; exists {
-			entry.maxInputTokens = existing.maxInputTokens
-			entry.maxOutputTokens = existing.maxOutputTokens
+			entry.capabilities = declared.Capabilities.Apply(
+				existing.capabilities,
+			)
+			entry.limits = existing.limits.Clone()
+		} else {
+			entry.capabilities = declared.Capabilities.Apply(
+				inference.ModelCapabilities{},
+			)
 		}
 		if declared.Limits.MaxInputTokens != nil {
-			entry.maxInputTokens = *declared.Limits.MaxInputTokens
+			value := *declared.Limits.MaxInputTokens
+			entry.limits.MaxInputTokens = &value
 		}
 		if declared.Limits.MaxOutputTokens != nil {
-			entry.maxOutputTokens = *declared.Limits.MaxOutputTokens
+			value := *declared.Limits.MaxOutputTokens
+			entry.limits.MaxOutputTokens = &value
 		}
 		models[declared.Name] = entry
 	}
@@ -212,12 +210,7 @@ func descriptorFor(id inference.ModelID, entry catalogEntry) inference.ModelDesc
 		ID:           id,
 		Capabilities: entry.capabilities,
 	}
-	if entry.maxInputTokens > 0 {
-		descriptor.Limits.MaxInputTokens = &entry.maxInputTokens
-	}
-	if entry.maxOutputTokens > 0 {
-		descriptor.Limits.MaxOutputTokens = &entry.maxOutputTokens
-	}
+	descriptor.Limits = entry.limits.Clone()
 	return descriptor
 }
 

--- a/driver/deepseek/catalog_test.go
+++ b/driver/deepseek/catalog_test.go
@@ -18,7 +18,7 @@ func TestCatalogDeclaresMaxInputTokens(t *testing.T) {
 	}
 	for _, model := range provider.Models {
 		name := model.Descriptor.ID.Name
-		if catalog[name].maxInputTokens <= 0 {
+		if catalog[name].limits.MaxInputTokens == nil {
 			t.Errorf("model %q: max input tokens not declared", name)
 		}
 		if model.Descriptor.Limits.MaxInputTokens == nil ||
@@ -36,7 +36,7 @@ func TestCatalogDeclaresMaxOutputTokens(t *testing.T) {
 	}
 	for _, model := range provider.Models {
 		name := model.Descriptor.ID.Name
-		if catalog[name].maxOutputTokens <= 0 {
+		if catalog[name].limits.MaxOutputTokens == nil {
 			t.Errorf("model %q: max output tokens not declared", name)
 		}
 		if model.Descriptor.Limits.MaxOutputTokens == nil ||
@@ -125,9 +125,10 @@ func TestMergedCatalogOverlaysDeclaredLimits(t *testing.T) {
 		t.Fatalf("mergedCatalog: %v", err)
 	}
 	entry := models["deepseek-v4-flash"]
-	if entry.maxInputTokens != 1_000_000 || entry.maxOutputTokens != 384_000 {
+	in, out := entry.limits.Values()
+	if in != 1_000_000 || out != 384_000 {
 		t.Fatalf("redeclared limits = %d/%d, want catalog 1000000/384000",
-			entry.maxInputTokens, entry.maxOutputTokens)
+			in, out)
 	}
 
 	spec, err = decodeSpec(context.Background(), []byte(`{
@@ -145,9 +146,10 @@ func TestMergedCatalogOverlaysDeclaredLimits(t *testing.T) {
 		t.Fatalf("mergedCatalog: %v", err)
 	}
 	entry = models["deepseek-v4-flash"]
-	if entry.maxInputTokens != 1_000_000 || entry.maxOutputTokens != 64_000 {
+	in, out = entry.limits.Values()
+	if in != 1_000_000 || out != 64_000 {
 		t.Fatalf("overridden limits = %d/%d, want 1000000/64000",
-			entry.maxInputTokens, entry.maxOutputTokens)
+			in, out)
 	}
 }
 
@@ -168,9 +170,10 @@ func TestMergedCatalogOverridesDeclaredInputLimit(t *testing.T) {
 		t.Fatalf("mergedCatalog: %v", err)
 	}
 	entry := models["deepseek-v4-flash"]
-	if entry.maxInputTokens != 65_536 || entry.maxOutputTokens != 384_000 {
+	in, out := entry.limits.Values()
+	if in != 65_536 || out != 384_000 {
 		t.Fatalf("declared input limits = %d/%d, want 65536/384000",
-			entry.maxInputTokens, entry.maxOutputTokens)
+			in, out)
 	}
 }
 

--- a/driver/deepseek/doc.go
+++ b/driver/deepseek/doc.go
@@ -10,12 +10,11 @@
 //     deepseek-v4-flash-vision-exp model additionally accepts image input
 //     (URL or base64) in user messages on this surface.
 //   - Responses (`api: responses`): OpenAI-compatible Responses API on
-//     https://api.deepseek.com/responses. deepseek-v4-flash,
-//     deepseek-v4-pro, and deepseek-v4-flash-vision-exp support it. The
-//     surface adds json_schema output, hosted web_search, and plain-text
-//     reasoning item round-trips. The vision model carries input_image
-//     parts in user messages here too. `include` is intentionally never
-//     sent: DeepSeek does not support it.
+//     https://api.deepseek.com/responses. Every model in the catalog is
+//     served on this surface when selected. The surface adds json_schema
+//     output, hosted web_search, and plain-text reasoning item round-trips.
+//     The vision model carries input_image parts in user messages here too.
+//     `include` is intentionally never sent: DeepSeek does not support it.
 //
 // Credentials come exclusively from resource profiles: `api_key`
 // authenticates every surface, and secret values may reference the

--- a/driver/deepseek/generate_test.go
+++ b/driver/deepseek/generate_test.go
@@ -108,7 +108,6 @@ func responsesEntry() catalogEntry {
 		kind:         kindGenerate,
 		api:          apiResponses,
 		capabilities: generateChatCapabilities().WithHostedWebSearch().WithReasoning(inference.ReasoningToggle),
-		responses:    true,
 	}
 }
 

--- a/driver/deepseek/reasoning_contract_test.go
+++ b/driver/deepseek/reasoning_contract_test.go
@@ -1,0 +1,119 @@
+package deepseek
+
+import (
+	"context"
+	"testing"
+
+	"github.com/GizClaw/flowcraft/core/inference"
+	"github.com/GizClaw/flowcraft/core/inference/inferencetest"
+)
+
+// TestRedeclaredBuiltinKeepsFacts locks the delta overlay contract:
+// redeclaring deepseek-v4-flash to tweak one channel must keep the built-in
+// reasoning kind and effort map, so the published toggle still compiles
+// reasoning_enabled=false on both surfaces.
+func TestRedeclaredBuiltinKeepsFacts(t *testing.T) {
+	spec, err := decodeSpec(context.Background(), []byte(`{
+		"models": [{
+			"name": "deepseek-v4-flash",
+			"kind": "generate",
+			"capabilities": {"outputs": ["text"]}
+		}]
+	}`))
+	if err != nil {
+		t.Fatalf("decodeSpec: %v", err)
+	}
+	models, err := mergedCatalog(spec)
+	if err != nil {
+		t.Fatalf("mergedCatalog: %v", err)
+	}
+	entry := models["deepseek-v4-flash"]
+	if entry.capabilities.Reasoning.Kind != inference.ReasoningToggle {
+		t.Fatalf("redeclaration must inherit reasoning toggle, got %q",
+			entry.capabilities.Reasoning.Kind)
+	}
+	if len(entry.capabilities.Reasoning.EffortMap) == 0 {
+		t.Fatal("redeclaration must inherit the built-in effort map")
+	}
+	in, _ := entry.limits.Values()
+	if in != 1_000_000 {
+		t.Fatalf("redeclaration must inherit the built-in input limit, got %d", in)
+	}
+	if compiled, err := compileChatGenerate("deepseek-v4-flash", entry)(
+		context.Background(),
+		conformanceModel("deepseek-v4-flash"),
+		inferencetest.ReasoningOffProbe(),
+		inference.GenerateExecutionUnary,
+	); err != nil {
+		t.Fatalf("chat toggle rejected reasoning off: %v", err)
+	} else if compiled.Report.Rejects(
+		inference.FieldGenerateIntentReasoningEnabled,
+	) {
+		t.Fatal("chat toggle rejected on the reasoning_enabled field")
+	}
+	if compiled, err := compileResponsesGenerate("deepseek-v4-flash", entry)(
+		context.Background(),
+		conformanceModel("deepseek-v4-flash"),
+		inferencetest.ReasoningOffProbe(),
+		inference.GenerateExecutionUnary,
+	); err != nil {
+		t.Fatalf("responses toggle rejected reasoning off: %v", err)
+	} else if compiled.Report.Rejects(
+		inference.FieldGenerateIntentReasoningEnabled,
+	) {
+		t.Fatal("responses toggle rejected on the reasoning_enabled field")
+	}
+}
+
+// TestPublishedToggleCompilesReasoningOff is the generic conformance
+// contract for every built-in toggle model on both DeepSeek surfaces.
+func TestPublishedToggleCompilesReasoningOff(t *testing.T) {
+	spec, err := decodeSpec(context.Background(), []byte(`{}`))
+	if err != nil {
+		t.Fatalf("decodeSpec: %v", err)
+	}
+	models, err := mergedCatalog(spec)
+	if err != nil {
+		t.Fatalf("mergedCatalog: %v", err)
+	}
+	checked := 0
+	for name, entry := range models {
+		if entry.capabilities.Reasoning.Kind != inference.ReasoningToggle {
+			continue
+		}
+		checked++
+		if _, err := compileChatGenerate(name, entry)(
+			context.Background(),
+			conformanceModel(name),
+			inferencetest.ReasoningOffProbe(),
+			inference.GenerateExecutionUnary,
+		); err != nil {
+			t.Fatalf("chat toggle model %q rejected reasoning off: %v", name, err)
+		}
+		if _, err := compileResponsesGenerate(name, entry)(
+			context.Background(),
+			conformanceModel(name),
+			inferencetest.ReasoningOffProbe(),
+			inference.GenerateExecutionUnary,
+		); err != nil {
+			t.Fatalf("responses toggle model %q rejected reasoning off: %v", name, err)
+		}
+	}
+	if checked == 0 {
+		t.Fatal("no toggle model exercised")
+	}
+}
+
+// TestCustomEmbedDimensionsUnsupported guards the capability leaf on a
+// provider that serves text generation only.
+func TestCustomEmbedDimensionsUnsupported(t *testing.T) {
+	if _, err := decodeSpec(context.Background(), []byte(`{
+		"models": [{
+			"name": "m",
+			"kind": "generate",
+			"capabilities": {"outputs": ["text"], "custom_embed_dimensions": true}
+		}]
+	}`)); err == nil {
+		t.Fatal("custom_embed_dimensions on deepseek unexpectedly accepted")
+	}
+}

--- a/driver/deepseek/reasoning_contract_test.go
+++ b/driver/deepseek/reasoning_contract_test.go
@@ -117,3 +117,18 @@ func TestCustomEmbedDimensionsUnsupported(t *testing.T) {
 		t.Fatal("custom_embed_dimensions on deepseek unexpectedly accepted")
 	}
 }
+
+// TestCustomEmbedDimensionsFalseAccepted guards the leaf contract: deepseek
+// serves text generation only, so an explicit false is the conservative
+// declaration and must decode without error.
+func TestCustomEmbedDimensionsFalseAccepted(t *testing.T) {
+	if _, err := decodeSpec(context.Background(), []byte(`{
+		"models": [{
+			"name": "m",
+			"kind": "generate",
+			"capabilities": {"outputs": ["text"], "custom_embed_dimensions": false}
+		}]
+	}`)); err != nil {
+		t.Fatalf("explicit false on a generate model rejected: %v", err)
+	}
+}

--- a/driver/deepseek/resource.go
+++ b/driver/deepseek/resource.go
@@ -85,29 +85,6 @@ func buildProvider(ctx context.Context, settings ResourceSettings, secrets *reso
 	if err != nil {
 		return inference.ProviderDefinition{}, err
 	}
-	if spec.apiMode() == apiResponses {
-		for name, entry := range models {
-			if !entry.responses {
-				if entry.declared {
-					return inference.ProviderDefinition{}, fmt.Errorf(
-						"deepseek provider %q: model %q does not support the Responses API",
-						settings.ID,
-						name,
-					)
-				}
-				// Built-in models without the responses capability are
-				// excluded from a Responses provider rather than failing
-				// the whole deployment.
-				delete(models, name)
-			}
-		}
-		if len(models) == 0 {
-			return inference.ProviderDefinition{}, fmt.Errorf(
-				"deepseek provider %q: Responses API requires at least one responses-capable model",
-				settings.ID,
-			)
-		}
-	}
 	profiles := make(map[string]profileMaterial, len(settings.Profiles))
 	for _, profile := range settings.Profiles {
 		material, err := newProfileMaterial(ctx, profile, secrets)

--- a/driver/deepseek/resource_test.go
+++ b/driver/deepseek/resource_test.go
@@ -58,13 +58,21 @@ func TestResourceFactoryRequiresID(t *testing.T) {
 	}
 }
 
-func TestResponsesProviderRejectsUnsupportedModels(t *testing.T) {
-	_, err := Factory().New(context.Background(), resource.Input{
+// TestResponsesProviderServesDeclaredModels locks the surface contract
+// after the per-model responses flag removal: api: responses serves every
+// declared generate model, so custom models no longer need a per-model
+// assertion.
+func TestResponsesProviderServesDeclaredModels(t *testing.T) {
+	value, err := Factory().New(context.Background(), resource.Input{
 		Settings: json.RawMessage(`{
 			"id": "deepseek",
 			"spec": {
 				"api": "responses",
-				"models": [{"name": "my-chat-only-model", "kind": "generate"}]
+				"models": [{
+					"name": "my-model",
+					"kind": "generate",
+					"capabilities": {"outputs": ["text"]}
+				}]
 			},
 			"profiles": [{
 				"id": "default",
@@ -72,8 +80,12 @@ func TestResponsesProviderRejectsUnsupportedModels(t *testing.T) {
 			}]
 		}`),
 	})
-	if err == nil {
-		t.Fatal("responses provider accepted deepseek-v4-pro")
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	provider, ok := value.(inference.ProviderDefinition)
+	if !ok || len(provider.Models) != 4 {
+		t.Fatalf("provider = %+v", provider)
 	}
 }
 
@@ -86,7 +98,6 @@ func TestResponsesProviderAllowsDeclaredOverride(t *testing.T) {
 				"models": [{
 					"name": "deepseek-v4-flash",
 					"kind": "generate",
-					"responses": true,
 					"capabilities": {
 						"outputs": ["text"],
 						"hosted_web_search": true

--- a/driver/deepseek/spec.go
+++ b/driver/deepseek/spec.go
@@ -17,8 +17,9 @@ const SecretAPIKey = "api_key"
 // secrets resolve per profile and never appear here.
 type Spec struct {
 	// API selects the generate surface: "chat" (default) or "responses".
-	// Built-in models without the capability are excluded from a
-	// Responses provider, and declared models without it are rejected.
+	// Every catalog model is served on the selected surface; the official
+	// DeepSeek line-up supports both (see
+	// https://api-docs.deepseek.com/guides/responses_api).
 	API string `json:"api,omitempty"`
 	// BaseURL overrides the API endpoint. Defaults to
 	// https://api.deepseek.com (the OpenAI-compatible surface shared by
@@ -56,23 +57,20 @@ func (s RequestMetadataSpec) Validate() error {
 	return nil
 }
 
-// ModelSpec declares one model the deployment serves. Capabilities mirror
-// the built-in catalog shape: content kinds, hosted web search, and the
-// reasoning control capability. Responses is a wire-surface fact and stays a
-// separate flag.
+// ModelSpec declares one model the deployment serves, or a delta over a
+// same-named built-in catalog entry. Capabilities is a patch with
+// field-presence semantics: leaves it names replace that leaf of the entry
+// it overrides and leaves it does not name are inherited. The generate
+// surface is provider-wide (Spec.API), not per-model.
 type ModelSpec struct {
 	Name string `json:"name"`
 	Kind string `json:"kind"`
-	// Capabilities declares the model's input/output content kinds, hosted
-	// web search support, and reasoning control capability.
-	Capabilities inference.ModelCapabilities `json:"capabilities,omitempty"`
+	// Capabilities declares the capability leaves this model changes.
+	Capabilities *inference.CapabilitiesPatch `json:"capabilities,omitempty"`
 	// Limits declares numeric capacity limits for the model. Overriding a
 	// built-in catalog entry by name keeps the catalog limit for any field
 	// left nil; declaring a value replaces it.
 	Limits inference.ModelLimits `json:"limits,omitempty"`
-	// Responses declares Responses API support (deepseek-v4-flash,
-	// deepseek-v4-pro, and deepseek-v4-flash-vision-exp).
-	Responses bool `json:"responses,omitempty"`
 }
 
 var modelNamePattern = regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9._-]*$`)
@@ -84,6 +82,13 @@ func (m ModelSpec) Validate() error {
 	}
 	if m.Kind != "" && m.Kind != string(kindGenerate) {
 		return fmt.Errorf("model %q declares unsupported kind %q", m.Name, m.Kind)
+	}
+	if m.Capabilities != nil && m.Capabilities.CustomEmbedDimensions != nil {
+		return fmt.Errorf(
+			"model %q declares custom_embed_dimensions, but deepseek "+
+				"serves text generation only",
+			m.Name,
+		)
 	}
 	if err := m.Capabilities.Validate(); err != nil {
 		return err

--- a/driver/deepseek/spec.go
+++ b/driver/deepseek/spec.go
@@ -83,7 +83,9 @@ func (m ModelSpec) Validate() error {
 	if m.Kind != "" && m.Kind != string(kindGenerate) {
 		return fmt.Errorf("model %q declares unsupported kind %q", m.Name, m.Kind)
 	}
-	if m.Capabilities != nil && m.Capabilities.CustomEmbedDimensions != nil {
+	if m.Capabilities != nil &&
+		m.Capabilities.CustomEmbedDimensions != nil &&
+		*m.Capabilities.CustomEmbedDimensions {
 		return fmt.Errorf(
 			"model %q declares custom_embed_dimensions, but deepseek "+
 				"serves text generation only",

--- a/driver/kimi/catalog.go
+++ b/driver/kimi/catalog.go
@@ -32,18 +32,13 @@ type catalogEntry struct {
 	// reasoning (kimi-k3, kimi-k2.7-code): traces round-trip natively and
 	// no knob exists to turn the behaviour off.
 	keepThinkingAlways bool
-	// maxInputTokens caps the input context in tokens; zero means
-	// undeclared. Values mirror the context windows published on
-	// https://platform.kimi.com/docs/models (moonshot-v1 variants state
-	// 8k/32k/128k).
-	maxInputTokens int
-	// maxOutputTokens caps the tokens a single response may emit
-	// (thinking plus answer tokens share the budget); zero means
-	// undeclared. kimi-k3's ceiling comes from the official quickstart
-	// (max_completion_tokens up to 1048576,
-	// https://platform.kimi.com/docs/guide/kimi-k3-quickstart);
-	// kimi-k2.7-code values follow the family's 131072 ceiling.
-	maxOutputTokens int
+	// limits carries the model's context/output windows in tokens. Nil
+	// leaves are undeclared. Values mirror the context windows published
+	// on https://platform.kimi.com/docs/models (moonshot-v1 variants state
+	// 8k/32k/128k); kimi-k3's output ceiling comes from the official
+	// quickstart (max_completion_tokens up to 1048576,
+	// https://platform.kimi.com/docs/guide/kimi-k3-quickstart).
+	limits inference.ModelLimits
 }
 
 // kimiK3EffortMap is kimi-k3's canonical-to-wire effort map per the Kimi
@@ -75,8 +70,9 @@ var catalog = map[string]catalogEntry{
 			WithReasoning(inference.ReasoningAlways).
 			WithReasoningEffortMap(kimiK3EffortMap),
 		keepThinkingAlways: true,
-		maxInputTokens:     1_000_000,
-		maxOutputTokens:    1_048_576,
+		limits: inference.ModelLimits{}.
+			WithMaxInputTokens(1_000_000).
+			WithMaxOutputTokens(1_048_576),
 	},
 	"kimi-k2.7-code": {
 		kind: kindGenerate,
@@ -84,8 +80,9 @@ var catalog = map[string]catalogEntry{
 			WithInputs(message.PartImage, message.PartVideo).
 			WithReasoning(inference.ReasoningAlways),
 		keepThinkingAlways: true,
-		maxInputTokens:     256_000,
-		maxOutputTokens:    131_072,
+		limits: inference.ModelLimits{}.
+			WithMaxInputTokens(256_000).
+			WithMaxOutputTokens(131_072),
 	},
 	"kimi-k2.7-code-highspeed": {
 		kind: kindGenerate,
@@ -93,33 +90,67 @@ var catalog = map[string]catalogEntry{
 			WithInputs(message.PartImage, message.PartVideo).
 			WithReasoning(inference.ReasoningAlways),
 		keepThinkingAlways: true,
-		maxInputTokens:     256_000,
-		maxOutputTokens:    131_072,
+		limits: inference.ModelLimits{}.
+			WithMaxInputTokens(256_000).
+			WithMaxOutputTokens(131_072),
 	},
 	"kimi-k2.6": {
 		kind: kindGenerate,
 		capabilities: generateChatCapabilities().
 			WithInputs(message.PartImage, message.PartVideo).
 			WithReasoning(inference.ReasoningToggle),
-		keepThinking:   true,
-		maxInputTokens: 256_000,
+		keepThinking: true,
+		limits:       inference.ModelLimits{}.WithMaxInputTokens(256_000),
 	},
 	"kimi-k2.5": {
 		kind: kindGenerate,
 		capabilities: generateChatCapabilities().
 			WithInputs(message.PartImage).
 			WithReasoning(inference.ReasoningToggle),
-		maxInputTokens: 256_000,
+		limits: inference.ModelLimits{}.WithMaxInputTokens(256_000),
 	},
 
 	// moonshot-v1: text generation plus vision previews; the only family
 	// with sampling knobs and the only one without thinking.
-	"moonshot-v1-8k":                  {kind: kindGenerate, capabilities: generateChatCapabilities(), sampling: true, maxInputTokens: 8_192},
-	"moonshot-v1-32k":                 {kind: kindGenerate, capabilities: generateChatCapabilities(), sampling: true, maxInputTokens: 32_768},
-	"moonshot-v1-128k":                {kind: kindGenerate, capabilities: generateChatCapabilities(), sampling: true, maxInputTokens: 131_072},
-	"moonshot-v1-8k-vision-preview":   {kind: kindGenerate, capabilities: generateChatCapabilities().WithInputs(message.PartImage), sampling: true, maxInputTokens: 8_192},
-	"moonshot-v1-32k-vision-preview":  {kind: kindGenerate, capabilities: generateChatCapabilities().WithInputs(message.PartImage), sampling: true, maxInputTokens: 32_768},
-	"moonshot-v1-128k-vision-preview": {kind: kindGenerate, capabilities: generateChatCapabilities().WithInputs(message.PartImage), sampling: true, maxInputTokens: 131_072},
+	"moonshot-v1-8k": {
+		kind:         kindGenerate,
+		capabilities: generateChatCapabilities(),
+		sampling:     true,
+		limits:       inference.ModelLimits{}.WithMaxInputTokens(8_192),
+	},
+	"moonshot-v1-32k": {
+		kind:         kindGenerate,
+		capabilities: generateChatCapabilities(),
+		sampling:     true,
+		limits:       inference.ModelLimits{}.WithMaxInputTokens(32_768),
+	},
+	"moonshot-v1-128k": {
+		kind:         kindGenerate,
+		capabilities: generateChatCapabilities(),
+		sampling:     true,
+		limits:       inference.ModelLimits{}.WithMaxInputTokens(131_072),
+	},
+	"moonshot-v1-8k-vision-preview": {
+		kind: kindGenerate,
+		capabilities: generateChatCapabilities().
+			WithInputs(message.PartImage),
+		sampling: true,
+		limits:   inference.ModelLimits{}.WithMaxInputTokens(8_192),
+	},
+	"moonshot-v1-32k-vision-preview": {
+		kind: kindGenerate,
+		capabilities: generateChatCapabilities().
+			WithInputs(message.PartImage),
+		sampling: true,
+		limits:   inference.ModelLimits{}.WithMaxInputTokens(32_768),
+	},
+	"moonshot-v1-128k-vision-preview": {
+		kind: kindGenerate,
+		capabilities: generateChatCapabilities().
+			WithInputs(message.PartImage),
+		sampling: true,
+		limits:   inference.ModelLimits{}.WithMaxInputTokens(131_072),
+	},
 }
 
 func (e catalogEntry) validate() error {
@@ -135,7 +166,7 @@ func (e catalogEntry) validate() error {
 	if e.keepThinkingAlways && e.capabilities.Reasoning.Kind != inference.ReasoningAlways {
 		return fmt.Errorf("always-preserved thinking requires always-on thinking")
 	}
-	return nil
+	return e.limits.Validate()
 }
 
 // generateChatCapabilities is the capability declaration for the Kimi text
@@ -183,10 +214,12 @@ func mergedCatalog(spec Spec) (map[string]catalogEntry, error) {
 			entry.capabilities.Reasoning = declared.Capabilities.Reasoning
 		}
 		if declared.Limits.MaxInputTokens != nil {
-			entry.maxInputTokens = *declared.Limits.MaxInputTokens
+			value := *declared.Limits.MaxInputTokens
+			entry.limits.MaxInputTokens = &value
 		}
 		if declared.Limits.MaxOutputTokens != nil {
-			entry.maxOutputTokens = *declared.Limits.MaxOutputTokens
+			value := *declared.Limits.MaxOutputTokens
+			entry.limits.MaxOutputTokens = &value
 		}
 		if err := entry.validate(); err != nil {
 			return nil, fmt.Errorf("model %q: %w", declared.Name, err)
@@ -228,12 +261,7 @@ func descriptorFor(id inference.ModelID, entry catalogEntry) inference.ModelDesc
 		ID:           id,
 		Capabilities: entry.capabilities,
 	}
-	if entry.maxInputTokens > 0 {
-		descriptor.Limits.MaxInputTokens = &entry.maxInputTokens
-	}
-	if entry.maxOutputTokens > 0 {
-		descriptor.Limits.MaxOutputTokens = &entry.maxOutputTokens
-	}
+	descriptor.Limits = entry.limits.Clone()
 	return descriptor
 }
 

--- a/driver/kimi/catalog.go
+++ b/driver/kimi/catalog.go
@@ -183,36 +183,35 @@ func generateChatCapabilities() inference.ModelCapabilities {
 	}
 }
 
-// mergedCatalog overlays the built-in catalog with the spec's model
-// declarations: capability lists union onto the same-named catalog entry,
-// and unknown names extend the catalog as bare generate models.
+// mergedCatalog overlays the spec's declared models on the built-in
+// catalog: a spec entry that names a catalog entry is a leaf patch over it
+// (capability leaves and numeric limits are inherited unless declared),
+// and unknown names start from the conservative zero declaration. Models
+// stay fail closed — the factory only exposes what the merged catalog
+// declares.
 func mergedCatalog(spec Spec) (map[string]catalogEntry, error) {
 	models := make(map[string]catalogEntry, len(catalog)+len(spec.Models))
 	maps.Copy(models, catalog)
 	for _, declared := range spec.Models {
-		if entry, exists := models[declared.Name]; exists {
-			if declared.Kind != "" && modelKind(declared.Kind) != entry.kind {
-				return nil, fmt.Errorf("model %q kind %q conflicts with catalog %q",
-					declared.Name, declared.Kind, entry.kind)
+		entry := catalogEntry{kind: modelKind(declared.Kind)}
+		base := inference.ModelCapabilities{}
+		if existing, exists := models[declared.Name]; exists {
+			if entry.kind == "" {
+				entry.kind = existing.kind
+			}
+			if entry.kind == existing.kind {
+				// Same-kind redeclarations keep the catalog's driver
+				// control facts and limits; capability leaves the
+				// declaration does not name are inherited too.
+				entry = existing
+				base = existing.capabilities
+			}
+		} else {
+			if entry.kind == "" {
+				entry.kind = kindGenerate
 			}
 		}
-		entry := models[declared.Name]
-		if entry.kind == "" {
-			entry.kind = kindGenerate
-		}
-		entry.capabilities.Inputs = unionKinds(
-			entry.capabilities.Inputs,
-			declared.Capabilities.Inputs,
-		)
-		entry.capabilities.Outputs = unionKinds(
-			entry.capabilities.Outputs,
-			declared.Capabilities.Outputs,
-		)
-		entry.capabilities.HostedWebSearch =
-			entry.capabilities.HostedWebSearch || declared.Capabilities.HostedWebSearch
-		if declared.Capabilities.Reasoning.Kind != inference.ReasoningNone {
-			entry.capabilities.Reasoning = declared.Capabilities.Reasoning
-		}
+		entry.capabilities = declared.Capabilities.Apply(base)
 		if declared.Limits.MaxInputTokens != nil {
 			value := *declared.Limits.MaxInputTokens
 			entry.limits.MaxInputTokens = &value
@@ -227,19 +226,6 @@ func mergedCatalog(spec Spec) (map[string]catalogEntry, error) {
 		models[declared.Name] = entry
 	}
 	return models, nil
-}
-
-// unionKinds appends any kind from addition that is not already present in
-// base, preserving base order. Spec declarations overlay catalog entries
-// additively.
-func unionKinds(base, addition []message.PartKind) []message.PartKind {
-	result := append([]message.PartKind(nil), base...)
-	for _, kind := range addition {
-		if !slices.Contains(result, kind) {
-			result = append(result, kind)
-		}
-	}
-	return result
 }
 
 // sortedNames returns catalog names in deterministic order so factory

--- a/driver/kimi/catalog_test.go
+++ b/driver/kimi/catalog_test.go
@@ -20,14 +20,15 @@ func TestCatalogDeclaresMaxInputTokens(t *testing.T) {
 		descriptors[model.Descriptor.ID.Name] = model.Descriptor
 	}
 	for name, entry := range catalog {
-		if entry.maxInputTokens <= 0 {
+		if entry.limits.MaxInputTokens == nil {
 			t.Errorf("model %q: max input tokens not declared", name)
 		}
 		descriptor := descriptors[name]
-		if descriptor.Limits.MaxInputTokens == nil ||
-			*descriptor.Limits.MaxInputTokens != entry.maxInputTokens {
+		in, _ := entry.limits.Values()
+		din, _ := descriptor.Limits.Values()
+		if din != in {
 			t.Errorf("model %q: descriptor limit = %v, want %d",
-				name, descriptor.Limits.MaxInputTokens, entry.maxInputTokens)
+				name, descriptor.Limits.MaxInputTokens, in)
 		}
 	}
 	checks := map[string]int{
@@ -56,14 +57,15 @@ func TestCatalogDeclaresMaxOutputTokens(t *testing.T) {
 		descriptors[model.Descriptor.ID.Name] = model.Descriptor
 	}
 	for name, entry := range catalog {
-		if entry.maxOutputTokens <= 0 {
+		if entry.limits.MaxOutputTokens == nil {
 			continue // family entries without a documented ceiling stay nil.
 		}
 		descriptor := descriptors[name]
-		if descriptor.Limits.MaxOutputTokens == nil ||
-			*descriptor.Limits.MaxOutputTokens != entry.maxOutputTokens {
+		_, out := entry.limits.Values()
+		_, dout := descriptor.Limits.Values()
+		if dout != out {
 			t.Errorf("model %q: descriptor limit = %v, want %d",
-				name, descriptor.Limits.MaxOutputTokens, entry.maxOutputTokens)
+				name, descriptor.Limits.MaxOutputTokens, out)
 		}
 	}
 	checks := map[string]int{
@@ -145,9 +147,10 @@ func TestMergedCatalogOverlaysDeclaredLimits(t *testing.T) {
 		t.Fatalf("mergedCatalog: %v", err)
 	}
 	entry := models["kimi-k3"]
-	if entry.maxInputTokens != 1_000_000 || entry.maxOutputTokens != 1_048_576 {
+	in, out := entry.limits.Values()
+	if in != 1_000_000 || out != 1_048_576 {
 		t.Fatalf("redeclared limits = %d/%d, want catalog 1000000/1048576",
-			entry.maxInputTokens, entry.maxOutputTokens)
+			in, out)
 	}
 
 	spec, err = decodeSpec(context.Background(), []byte(`{
@@ -165,9 +168,10 @@ func TestMergedCatalogOverlaysDeclaredLimits(t *testing.T) {
 		t.Fatalf("mergedCatalog: %v", err)
 	}
 	entry = models["kimi-k3"]
-	if entry.maxInputTokens != 1_000_000 || entry.maxOutputTokens != 4096 {
+	in, out = entry.limits.Values()
+	if in != 1_000_000 || out != 4096 {
 		t.Fatalf("overridden limits = %d/%d, want 1000000/4096",
-			entry.maxInputTokens, entry.maxOutputTokens)
+			in, out)
 	}
 }
 
@@ -187,8 +191,9 @@ func TestMergedCatalogOverridesDeclaredInputLimit(t *testing.T) {
 		t.Fatalf("mergedCatalog: %v", err)
 	}
 	entry := models["kimi-k3"]
-	if entry.maxInputTokens != 65_536 || entry.maxOutputTokens != 1_048_576 {
+	in, out := entry.limits.Values()
+	if in != 65_536 || out != 1_048_576 {
 		t.Fatalf("declared input limits = %d/%d, want 65536/1048576",
-			entry.maxInputTokens, entry.maxOutputTokens)
+			in, out)
 	}
 }

--- a/driver/kimi/reasoning_contract_test.go
+++ b/driver/kimi/reasoning_contract_test.go
@@ -9,16 +9,15 @@ import (
 	"github.com/GizClaw/flowcraft/core/message"
 )
 
-// TestRedeclaredBuiltinKeepsReasoning locks Kimi's additive overlay
-// contract: a spec declaration can widen a built-in's surface but never
-// drop what the catalog already promises, so redeclaring kimi-k2.6 keeps
-// its reasoning toggle and a published toggle still compiles
+// TestRedeclaredBuiltinKeepsReasoning locks the leaf-patch contract:
+// redeclaring kimi-k2.6 without naming its reasoning leaf keeps the
+// built-in reasoning toggle, and a published toggle still compiles
 // reasoning_enabled=false.
 func TestRedeclaredBuiltinKeepsReasoning(t *testing.T) {
 	spec, err := decodeSpec(context.Background(), []byte(`{
 		"models": [{
 			"name": "kimi-k2.6",
-			"capabilities": {"inputs": ["text"]}
+			"capabilities": {"outputs": ["text"]}
 		}]
 	}`))
 	if err != nil {
@@ -35,7 +34,7 @@ func TestRedeclaredBuiltinKeepsReasoning(t *testing.T) {
 			entry.capabilities.Reasoning.Kind)
 	}
 	if !equalKinds(entry.capabilities.Inputs, builtin.capabilities.Inputs) {
-		t.Fatalf("redeclaration must not narrow built-in inputs: %v vs %v",
+		t.Fatalf("unstated inputs must be inherited: %v vs %v",
 			entry.capabilities.Inputs, builtin.capabilities.Inputs)
 	}
 	if _, err := compileGenerate("kimi-k2.6", entry)(
@@ -45,6 +44,39 @@ func TestRedeclaredBuiltinKeepsReasoning(t *testing.T) {
 		inference.GenerateExecutionUnary,
 	); err != nil {
 		t.Fatalf("toggle model rejected reasoning off: %v", err)
+	}
+}
+
+// TestRedeclaredBuiltinCanNarrow locks the leaf-replacement direction:
+// a written inputs list narrows the built-in surface while unstated
+// reasoning and limits are inherited.
+func TestRedeclaredBuiltinCanNarrow(t *testing.T) {
+	spec, err := decodeSpec(context.Background(), []byte(`{
+		"models": [{
+			"name": "kimi-k2.6",
+			"capabilities": {"inputs": ["text"]}
+		}]
+	}`))
+	if err != nil {
+		t.Fatalf("decodeSpec: %v", err)
+	}
+	models, err := mergedCatalog(spec)
+	if err != nil {
+		t.Fatalf("mergedCatalog: %v", err)
+	}
+	entry := models["kimi-k2.6"]
+	want := []message.PartKind{message.PartText}
+	if !equalKinds(entry.capabilities.Inputs, want) {
+		t.Fatalf("written inputs must replace the built-in list, got %v",
+			entry.capabilities.Inputs)
+	}
+	if entry.capabilities.Reasoning.Kind != inference.ReasoningToggle {
+		t.Fatalf("unstated reasoning must be inherited, got %q",
+			entry.capabilities.Reasoning.Kind)
+	}
+	in, _ := entry.limits.Values()
+	if in != 256_000 {
+		t.Fatalf("unstated limits must be inherited, got %d", in)
 	}
 }
 
@@ -94,6 +126,16 @@ func TestCustomEmbedDimensionsUnsupported(t *testing.T) {
 		}]
 	}`)); err == nil {
 		t.Fatal("custom_embed_dimensions on kimi unexpectedly accepted")
+	}
+
+	if _, err := decodeSpec(context.Background(), []byte(`{
+		"models": [{
+			"name": "m",
+			"kind": "generate",
+			"capabilities": {"outputs": ["text"], "custom_embed_dimensions": false}
+		}]
+	}`)); err != nil {
+		t.Fatalf("explicit false on a generate model rejected: %v", err)
 	}
 }
 

--- a/driver/kimi/reasoning_contract_test.go
+++ b/driver/kimi/reasoning_contract_test.go
@@ -1,0 +1,110 @@
+package kimi
+
+import (
+	"context"
+	"testing"
+
+	"github.com/GizClaw/flowcraft/core/inference"
+	"github.com/GizClaw/flowcraft/core/inference/inferencetest"
+	"github.com/GizClaw/flowcraft/core/message"
+)
+
+// TestRedeclaredBuiltinKeepsReasoning locks Kimi's additive overlay
+// contract: a spec declaration can widen a built-in's surface but never
+// drop what the catalog already promises, so redeclaring kimi-k2.6 keeps
+// its reasoning toggle and a published toggle still compiles
+// reasoning_enabled=false.
+func TestRedeclaredBuiltinKeepsReasoning(t *testing.T) {
+	spec, err := decodeSpec(context.Background(), []byte(`{
+		"models": [{
+			"name": "kimi-k2.6",
+			"capabilities": {"inputs": ["text"]}
+		}]
+	}`))
+	if err != nil {
+		t.Fatalf("decodeSpec: %v", err)
+	}
+	models, err := mergedCatalog(spec)
+	if err != nil {
+		t.Fatalf("mergedCatalog: %v", err)
+	}
+	entry := models["kimi-k2.6"]
+	builtin := catalog["kimi-k2.6"]
+	if entry.capabilities.Reasoning.Kind != inference.ReasoningToggle {
+		t.Fatalf("redeclaration must keep reasoning toggle, got %q",
+			entry.capabilities.Reasoning.Kind)
+	}
+	if !equalKinds(entry.capabilities.Inputs, builtin.capabilities.Inputs) {
+		t.Fatalf("redeclaration must not narrow built-in inputs: %v vs %v",
+			entry.capabilities.Inputs, builtin.capabilities.Inputs)
+	}
+	if _, err := compileGenerate("kimi-k2.6", entry)(
+		context.Background(),
+		conformanceModel("kimi-k2.6"),
+		inferencetest.ReasoningOffProbe(),
+		inference.GenerateExecutionUnary,
+	); err != nil {
+		t.Fatalf("toggle model rejected reasoning off: %v", err)
+	}
+}
+
+// TestPublishedToggleCompilesReasoningOff is the generic conformance
+// contract for every built-in toggle model.
+func TestPublishedToggleCompilesReasoningOff(t *testing.T) {
+	spec, err := decodeSpec(context.Background(), []byte(`{}`))
+	if err != nil {
+		t.Fatalf("decodeSpec: %v", err)
+	}
+	models, err := mergedCatalog(spec)
+	if err != nil {
+		t.Fatalf("mergedCatalog: %v", err)
+	}
+	checked := 0
+	for name, entry := range models {
+		if entry.capabilities.Reasoning.Kind != inference.ReasoningToggle {
+			continue
+		}
+		checked++
+		compiled, err := compileGenerate(name, entry)(
+			context.Background(),
+			conformanceModel(name),
+			inferencetest.ReasoningOffProbe(),
+			inference.GenerateExecutionUnary,
+		)
+		if err != nil {
+			t.Fatalf("toggle model %q rejected reasoning off: %v", name, err)
+		}
+		if compiled.Report.Rejects(inference.FieldGenerateIntentReasoningEnabled) {
+			t.Fatalf("toggle model %q rejected on the reasoning_enabled field", name)
+		}
+	}
+	if checked == 0 {
+		t.Fatal("no toggle model exercised")
+	}
+}
+
+// TestCustomEmbedDimensionsUnsupported guards the capability leaf on a
+// provider that serves text generation only.
+func TestCustomEmbedDimensionsUnsupported(t *testing.T) {
+	if _, err := decodeSpec(context.Background(), []byte(`{
+		"models": [{
+			"name": "m",
+			"kind": "generate",
+			"capabilities": {"outputs": ["text"], "custom_embed_dimensions": true}
+		}]
+	}`)); err == nil {
+		t.Fatal("custom_embed_dimensions on kimi unexpectedly accepted")
+	}
+}
+
+func equalKinds(a, b []message.PartKind) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/driver/kimi/spec.go
+++ b/driver/kimi/spec.go
@@ -25,20 +25,21 @@ type Spec struct {
 	// Router owns the full retry budget; nil keeps the httpkit default.
 	HTTPRetries *resource.Int `json:"http_retries,omitempty"`
 	// Models declares models outside the built-in catalog or extends
-	// catalog entries by name.
+	// catalog entries by name. Same-name entries are leaf-level patches
+	// over the built-in: written leaves replace, unstated leaves inherit.
 	Models []ModelSpec `json:"models,omitempty"`
 }
 
-// ModelSpec declares one model the deployment serves. Capability lists union
-// onto the catalog entry of the same name (or a fresh generate entry for
-// unknown names): a spec model can widen a model's surface, never narrow it
-// below what the catalog already promises.
+// ModelSpec declares one model the deployment serves, or a delta over a
+// same-named built-in catalog entry. Capabilities is a patch with
+// field-presence semantics: leaves it names replace that leaf of the entry
+// it overrides and leaves it does not name are inherited. Kimi serves text
+// generation only.
 type ModelSpec struct {
 	Name string `json:"name"`
 	Kind string `json:"kind"`
-	// Capabilities declares the model's input/output content kinds and the
-	// reasoning control capability.
-	Capabilities inference.ModelCapabilities `json:"capabilities,omitempty"`
+	// Capabilities declares the capability leaves this model changes.
+	Capabilities *inference.CapabilitiesPatch `json:"capabilities,omitempty"`
 	// Limits declares numeric capacity limits for the model. Overriding a
 	// built-in catalog entry by name keeps the catalog limit for any field
 	// left nil; declaring a value replaces it.
@@ -55,7 +56,9 @@ func (m ModelSpec) Validate() error {
 	if m.Kind != "" && m.Kind != string(kindGenerate) {
 		return fmt.Errorf("model %q declares unsupported kind %q", m.Name, m.Kind)
 	}
-	if m.Capabilities.CustomEmbedDimensions {
+	if m.Capabilities != nil &&
+		m.Capabilities.CustomEmbedDimensions != nil &&
+		*m.Capabilities.CustomEmbedDimensions {
 		return fmt.Errorf(
 			"model %q declares custom_embed_dimensions, but kimi serves "+
 				"text generation only",

--- a/driver/kimi/spec.go
+++ b/driver/kimi/spec.go
@@ -55,6 +55,13 @@ func (m ModelSpec) Validate() error {
 	if m.Kind != "" && m.Kind != string(kindGenerate) {
 		return fmt.Errorf("model %q declares unsupported kind %q", m.Name, m.Kind)
 	}
+	if m.Capabilities.CustomEmbedDimensions {
+		return fmt.Errorf(
+			"model %q declares custom_embed_dimensions, but kimi serves "+
+				"text generation only",
+			m.Name,
+		)
+	}
 	if err := m.Capabilities.Validate(); err != nil {
 		return err
 	}

--- a/driver/minimax/catalog.go
+++ b/driver/minimax/catalog.go
@@ -50,16 +50,11 @@ type catalogEntry struct {
 	// a multimodal content array, 768P/2K tiers, 4-15s durations, and
 	// ratio control. The Hailuo 2.x/02 trio rides the flat v1 API.
 	videoV2 bool
-	// maxInputTokens caps the input context in tokens; zero means
-	// undeclared. M3 holds the 1M context and the M2.x series holds
-	// 204,800 per https://platform.minimaxi.com/docs/guides/text-generation.
-	maxInputTokens int
-	// maxOutputTokens caps the tokens a single generate response may emit
-	// (thinking plus answer tokens share the budget); zero means
-	// undeclared. M3's Anthropic-compatible surface caps max_tokens at
-	// 524288 (recommended 131072) per
-	// https://platform.minimaxi.com/docs/guides/text-generation.
-	maxOutputTokens int
+	// limits carries the model's context/output windows in tokens. Nil
+	// leaves are undeclared. M3 holds the 1M context with a 524288
+	// max_tokens cap (recommended 131072); the M2.x series holds 204,800 —
+	// per https://platform.minimaxi.com/docs/guides/text-generation.
+	limits inference.ModelLimits
 }
 
 // validate enforces the family contract: the compiler bound by kind can only
@@ -93,7 +88,7 @@ func (e catalogEntry) validate() error {
 	default:
 		return fmt.Errorf("unsupported kind %q", e.kind)
 	}
-	return nil
+	return e.limits.Validate()
 }
 
 // generateChatCapabilities is the common capability declaration for the
@@ -132,50 +127,51 @@ var catalog = map[string]catalogEntry{
 		capabilities: generateChatCapabilities().
 			WithInputs(message.PartImage, message.PartVideo).
 			WithReasoning(inference.ReasoningToggle),
-		maxInputTokens:  1_000_000,
-		maxOutputTokens: 524_288,
+		limits: inference.ModelLimits{}.
+			WithMaxInputTokens(1_000_000).
+			WithMaxOutputTokens(524_288),
 	},
 	"MiniMax-M2.7": {
 		kind: kindGenerate,
 		capabilities: generateChatCapabilities().
 			WithReasoning(inference.ReasoningAlways),
-		maxInputTokens: 204_800,
+		limits: inference.ModelLimits{}.WithMaxInputTokens(204_800),
 	},
 	"MiniMax-M2.7-highspeed": {
 		kind: kindGenerate,
 		capabilities: generateChatCapabilities().
 			WithReasoning(inference.ReasoningAlways),
-		maxInputTokens: 204_800,
+		limits: inference.ModelLimits{}.WithMaxInputTokens(204_800),
 	},
 	"MiniMax-M2.5": {
 		kind: kindGenerate,
 		capabilities: generateChatCapabilities().
 			WithReasoning(inference.ReasoningAlways),
-		maxInputTokens: 204_800,
+		limits: inference.ModelLimits{}.WithMaxInputTokens(204_800),
 	},
 	"MiniMax-M2.5-highspeed": {
 		kind: kindGenerate,
 		capabilities: generateChatCapabilities().
 			WithReasoning(inference.ReasoningAlways),
-		maxInputTokens: 204_800,
+		limits: inference.ModelLimits{}.WithMaxInputTokens(204_800),
 	},
 	"MiniMax-M2.1": {
 		kind: kindGenerate,
 		capabilities: generateChatCapabilities().
 			WithReasoning(inference.ReasoningAlways),
-		maxInputTokens: 204_800,
+		limits: inference.ModelLimits{}.WithMaxInputTokens(204_800),
 	},
 	"MiniMax-M2.1-highspeed": {
 		kind: kindGenerate,
 		capabilities: generateChatCapabilities().
 			WithReasoning(inference.ReasoningAlways),
-		maxInputTokens: 204_800,
+		limits: inference.ModelLimits{}.WithMaxInputTokens(204_800),
 	},
 	"MiniMax-M2": {
 		kind: kindGenerate,
 		capabilities: generateChatCapabilities().
 			WithReasoning(inference.ReasoningAlways),
-		maxInputTokens: 204_800,
+		limits: inference.ModelLimits{}.WithMaxInputTokens(204_800),
 	},
 
 	// Speech synthesis (t2a_v2): HD and turbo tiers.
@@ -323,28 +319,29 @@ var catalog = map[string]catalogEntry{
 }
 
 // mergedCatalog overlays the built-in catalog with the spec's model
-// declarations: a spec entry with a catalog name replaces that entry, and
-// unknown names extend the catalog. Models stay fail closed — the factory
-// only exposes what the merged catalog declares.
+// declarations: a spec entry with a catalog name is a leaf-level patch over
+// the built-in entry, and unknown names extend the catalog. Models stay
+// fail closed — the factory only exposes what the merged catalog declares.
 func mergedCatalog(spec Spec) (map[string]catalogEntry, error) {
 	models := make(map[string]catalogEntry, len(catalog)+len(spec.Models))
 	maps.Copy(models, catalog)
 	for _, declared := range spec.Models {
 		entry := catalogEntry{
-			kind:         modelKind(declared.Kind),
-			capabilities: declared.Capabilities,
+			kind: modelKind(declared.Kind),
 		}
+		base := inference.ModelCapabilities{}
 		if existing, exists := models[declared.Name]; exists {
 			if entry.kind == "" {
 				entry.kind = existing.kind
 			}
 			if entry.kind == existing.kind {
 				// Redeclaring a built-in model under the same kind keeps
-				// the family's control flags and limits; only capabilities
-				// come from the declaration. Without this, a spec entry for
-				// MiniMax-H3 would silently fall back to the v1 video API
-				// and a redeclared Hailuo model would lose its 10s/1080P
-				// support.
+				// the family's control flags and limits; capability leaves
+				// the declaration does not name are inherited too. Without
+				// this, a spec entry for MiniMax-H3 would silently fall
+				// back to the v1 video API and a redeclared Hailuo model
+				// would lose its 10s/1080P support.
+				base = existing.capabilities
 				entry.wireModel = existing.wireModel
 				entry.video10s = existing.video10s
 				entry.videoHD = existing.videoHD
@@ -352,19 +349,24 @@ func mergedCatalog(spec Spec) (map[string]catalogEntry, error) {
 				entry.videoLastFrame = existing.videoLastFrame
 				entry.videoI2VOnly = existing.videoI2VOnly
 				entry.videoV2 = existing.videoV2
-				entry.maxInputTokens = existing.maxInputTokens
-				entry.maxOutputTokens = existing.maxOutputTokens
+				entry.limits = existing.limits.Clone()
 			}
 		} else {
 			if entry.kind == "" {
 				entry.kind = kindGenerate
 			}
 		}
+		// The declaration's capability leaves always apply; the base is the
+		// built-in entry under the same kind, and the conservative zero
+		// declaration for new names and cross-kind redeclarations.
+		entry.capabilities = declared.Capabilities.Apply(base)
 		if declared.Limits.MaxInputTokens != nil {
-			entry.maxInputTokens = *declared.Limits.MaxInputTokens
+			value := *declared.Limits.MaxInputTokens
+			entry.limits.MaxInputTokens = &value
 		}
 		if declared.Limits.MaxOutputTokens != nil {
-			entry.maxOutputTokens = *declared.Limits.MaxOutputTokens
+			value := *declared.Limits.MaxOutputTokens
+			entry.limits.MaxOutputTokens = &value
 		}
 		models[declared.Name] = entry
 	}
@@ -405,12 +407,7 @@ func descriptorFor(id inference.ModelID, entry catalogEntry) inference.ModelDesc
 		ID:           id,
 		Capabilities: entry.capabilities,
 	}
-	if entry.maxInputTokens > 0 {
-		descriptor.Limits.MaxInputTokens = &entry.maxInputTokens
-	}
-	if entry.maxOutputTokens > 0 {
-		descriptor.Limits.MaxOutputTokens = &entry.maxOutputTokens
-	}
+	descriptor.Limits = entry.limits.Clone()
 	return descriptor
 }
 

--- a/driver/minimax/catalog_test.go
+++ b/driver/minimax/catalog_test.go
@@ -24,7 +24,7 @@ func TestCatalogDeclaresMaxInputTokens(t *testing.T) {
 			continue
 		}
 		descriptor := descriptors[name]
-		if entry.maxInputTokens <= 0 || descriptor.Limits.MaxInputTokens == nil {
+		if entry.limits.MaxInputTokens == nil || descriptor.Limits.MaxInputTokens == nil {
 			t.Errorf("model %q: max input tokens not declared", name)
 		}
 	}
@@ -57,7 +57,7 @@ func TestCatalogDeclaresMaxOutputTokens(t *testing.T) {
 			continue
 		}
 		descriptor := descriptors[name]
-		if entry.maxOutputTokens <= 0 {
+		if entry.limits.MaxOutputTokens == nil {
 			if descriptor.Limits.MaxOutputTokens != nil {
 				t.Errorf("model %q: undeclared max output tokens = %d",
 					name, *descriptor.Limits.MaxOutputTokens)
@@ -218,9 +218,10 @@ func TestMergedCatalogOverlaysDeclaredLimits(t *testing.T) {
 		t.Fatalf("mergedCatalog: %v", err)
 	}
 	entry := models["MiniMax-M3"]
-	if entry.maxInputTokens != 1_000_000 || entry.maxOutputTokens != 524_288 {
+	in, out := entry.limits.Values()
+	if in != 1_000_000 || out != 524_288 {
 		t.Fatalf("redeclared limits = %d/%d, want catalog 1000000/524288",
-			entry.maxInputTokens, entry.maxOutputTokens)
+			in, out)
 	}
 
 	spec, err = decodeSpec(context.Background(), []byte(`{
@@ -239,9 +240,10 @@ func TestMergedCatalogOverlaysDeclaredLimits(t *testing.T) {
 		t.Fatalf("mergedCatalog: %v", err)
 	}
 	entry = models["MiniMax-M3"]
-	if entry.maxInputTokens != 1_000_000 || entry.maxOutputTokens != 4096 {
+	in, out = entry.limits.Values()
+	if in != 1_000_000 || out != 4096 {
 		t.Fatalf("overridden limits = %d/%d, want 1000000/4096",
-			entry.maxInputTokens, entry.maxOutputTokens)
+			in, out)
 	}
 }
 
@@ -262,8 +264,9 @@ func TestMergedCatalogOverridesDeclaredInputLimit(t *testing.T) {
 		t.Fatalf("mergedCatalog: %v", err)
 	}
 	entry := models["MiniMax-M3"]
-	if entry.maxInputTokens != 65_536 || entry.maxOutputTokens != 524_288 {
+	in, out := entry.limits.Values()
+	if in != 65_536 || out != 524_288 {
 		t.Fatalf("declared input limits = %d/%d, want 65536/524288",
-			entry.maxInputTokens, entry.maxOutputTokens)
+			in, out)
 	}
 }

--- a/driver/minimax/reasoning_contract_test.go
+++ b/driver/minimax/reasoning_contract_test.go
@@ -1,0 +1,131 @@
+package minimax
+
+import (
+	"context"
+	"testing"
+
+	"github.com/GizClaw/flowcraft/core/inference"
+	"github.com/GizClaw/flowcraft/core/inference/inferencetest"
+	"github.com/GizClaw/flowcraft/core/message"
+)
+
+// TestRedeclaredBuiltinKeepsReasoning locks the delta overlay contract:
+// redeclaring MiniMax-M3 to tweak one channel must keep the built-in
+// reasoning toggle, so a published toggle still compiles
+// reasoning_enabled=false.
+func TestRedeclaredBuiltinKeepsReasoning(t *testing.T) {
+	spec, err := decodeSpec(context.Background(), []byte(`{
+		"models": [{
+			"name": "MiniMax-M3",
+			"kind": "generate",
+			"capabilities": {"outputs": ["text"]}
+		}]
+	}`))
+	if err != nil {
+		t.Fatalf("decodeSpec: %v", err)
+	}
+	models, err := mergedCatalog(spec)
+	if err != nil {
+		t.Fatalf("mergedCatalog: %v", err)
+	}
+	entry := models["MiniMax-M3"]
+	if entry.capabilities.Reasoning.Kind != inference.ReasoningToggle {
+		t.Fatalf("redeclaration must inherit reasoning toggle, got %q",
+			entry.capabilities.Reasoning.Kind)
+	}
+	compiled, err := compileGenerate("MiniMax-M3", entry)(
+		context.Background(),
+		conformanceModel("MiniMax-M3"),
+		inferencetest.ReasoningOffProbe(),
+		inference.GenerateExecutionUnary,
+	)
+	if err != nil {
+		t.Fatalf("toggle model rejected reasoning off: %v", err)
+	}
+	if compiled.Wire.thinking == nil || *compiled.Wire.thinking {
+		t.Fatalf("wire thinking = %v, want disabled", compiled.Wire.thinking)
+	}
+	if compiled.Report.Rejects(inference.FieldGenerateIntentReasoningEnabled) {
+		t.Fatal("toggle model rejected on the reasoning_enabled field")
+	}
+}
+
+// TestPublishedToggleCompilesReasoningOff is the generic conformance
+// contract for every built-in toggle model.
+func TestPublishedToggleCompilesReasoningOff(t *testing.T) {
+	spec, err := decodeSpec(context.Background(), []byte(`{}`))
+	if err != nil {
+		t.Fatalf("decodeSpec: %v", err)
+	}
+	models, err := mergedCatalog(spec)
+	if err != nil {
+		t.Fatalf("mergedCatalog: %v", err)
+	}
+	checked := 0
+	for name, entry := range models {
+		if entry.kind != kindGenerate ||
+			entry.capabilities.Reasoning.Kind != inference.ReasoningToggle {
+			continue
+		}
+		checked++
+		compiled, err := compileGenerate(name, entry)(
+			context.Background(),
+			conformanceModel(name),
+			inferencetest.ReasoningOffProbe(),
+			inference.GenerateExecutionUnary,
+		)
+		if err != nil {
+			t.Fatalf("toggle model %q rejected reasoning off: %v", name, err)
+		}
+		if compiled.Report.Rejects(inference.FieldGenerateIntentReasoningEnabled) {
+			t.Fatalf("toggle model %q rejected on the reasoning_enabled field", name)
+		}
+	}
+	if checked == 0 {
+		t.Fatal("no toggle model exercised")
+	}
+}
+
+// TestCrossKindRedeclarationAppliesDeclaredCapabilities guards the
+// cross-kind overlay path: a spec entry that redeclares a built-in name
+// under another kind replaces the entry with the declared capability leaves
+// over the conservative zero base (it neither inherits the other family's
+// capabilities nor drops the declaration).
+func TestCrossKindRedeclarationAppliesDeclaredCapabilities(t *testing.T) {
+	spec, err := decodeSpec(context.Background(), []byte(`{
+		"models": [{
+			"name": "MiniMax-M3",
+			"kind": "image",
+			"capabilities": {"outputs": ["image"]}
+		}]
+	}`))
+	if err != nil {
+		t.Fatalf("decodeSpec: %v", err)
+	}
+	models, err := mergedCatalog(spec)
+	if err != nil {
+		t.Fatalf("mergedCatalog: %v", err)
+	}
+	entry := models["MiniMax-M3"]
+	if entry.kind != kindImage {
+		t.Fatalf("kind = %q, want image", entry.kind)
+	}
+	if len(entry.capabilities.Outputs) != 1 ||
+		entry.capabilities.Outputs[0] != message.PartImage {
+		t.Fatalf("outputs = %v, want declared image", entry.capabilities.Outputs)
+	}
+}
+
+// TestCustomEmbedDimensionsUnsupported guards the capability leaf on a
+// provider with no embed family.
+func TestCustomEmbedDimensionsUnsupported(t *testing.T) {
+	if _, err := decodeSpec(context.Background(), []byte(`{
+		"models": [{
+			"name": "m",
+			"kind": "generate",
+			"capabilities": {"outputs": ["text"], "custom_embed_dimensions": true}
+		}]
+	}`)); err == nil {
+		t.Fatal("custom_embed_dimensions on minimax unexpectedly accepted")
+	}
+}

--- a/driver/minimax/spec.go
+++ b/driver/minimax/spec.go
@@ -36,14 +36,17 @@ type Spec struct {
 	Models []ModelSpec `json:"models,omitempty"`
 }
 
-// ModelSpec declares one model the deployment serves.
+// ModelSpec declares one model the deployment serves, or a delta over a
+// same-named, same-kind built-in catalog entry. Capabilities is a patch
+// with field-presence semantics: leaves it names replace that leaf of the
+// entry it overrides and leaves it does not name are inherited, so
+// redeclaring a built-in to tweak one channel keeps every other declared
+// fact.
 type ModelSpec struct {
 	Name string `json:"name"`
 	Kind string `json:"kind"`
-	// Capabilities declares the model's input/output content kinds and the
-	// reasoning control capability, validated against the kind's compiler
-	// contract at merge time.
-	Capabilities inference.ModelCapabilities `json:"capabilities,omitempty"`
+	// Capabilities declares the capability leaves this model changes.
+	Capabilities *inference.CapabilitiesPatch `json:"capabilities,omitempty"`
 	// Limits declares numeric capacity limits for the model. Overriding a
 	// built-in catalog entry by name keeps the catalog limit for any field
 	// left nil; declaring a value replaces it.
@@ -64,6 +67,13 @@ func (m ModelSpec) Validate() error {
 		modelKind(m.Kind) != kindContextIR &&
 		modelKind(m.Kind) != kindMusic {
 		return fmt.Errorf("model %q declares unsupported kind %q", m.Name, m.Kind)
+	}
+	if m.Capabilities != nil && m.Capabilities.CustomEmbedDimensions != nil {
+		return fmt.Errorf(
+			"model %q declares custom_embed_dimensions, but minimax has "+
+				"no embed family",
+			m.Name,
+		)
 	}
 	if err := m.Capabilities.Validate(); err != nil {
 		return err

--- a/driver/openai/catalog.go
+++ b/driver/openai/catalog.go
@@ -33,11 +33,11 @@ const (
 
 // catalogEntry is one model in the built-in catalog. capabilities is the
 // single capability fact source: input/output content kinds, hosted web
-// search, and the reasoning control capability. dimensions and effortNone
-// are control capabilities that no capability kind expresses (embed custom
-// output dimensions, and effort "none" to disable reasoning) and stay
-// separate flags. ModelSpec mirrors this shape so deployment-declared
-// models behave identically.
+// search, the reasoning control capability, and custom embed output
+// dimensions. Reasoning off is not a separate flag: on the Responses
+// surface OpenAI expresses it as reasoning.effort="none", so a model
+// published as ReasoningToggle has an off route by construction (see
+// mergedCatalog for the per-surface resolution).
 type catalogEntry struct {
 	kind         modelKind
 	api          apiMode
@@ -52,25 +52,13 @@ type catalogEntry struct {
 	// (true); false disables stream obfuscation. It only affects generate
 	// entries served by the chat surface.
 	chatStreamIncludeObfuscation *bool
-	// dimensions (embed) allows custom output dimensions. Control
-	// capability, likewise not a content kind.
-	dimensions bool
-	// effortNone marks reasoning models whose reasoning.effort accepts
-	// "none" to disable reasoning (gpt-5.1+ per the OpenAI docs); models
-	// without it reject a disable request.
-	effortNone  bool
-	deprecated  bool
-	replacement string
-	// maxInputTokens caps the input context (prompt plus prior turns) in
-	// tokens; zero means undeclared. Generate values mirror the context
-	// window on https://developers.openai.com/api/docs/models; embedding
-	// values mirror the per-request input limit.
-	maxInputTokens int
-	// maxOutputTokens caps the tokens a single generate response may emit
-	// (reasoning plus answer tokens share the budget); zero means
-	// undeclared. Values mirror the maximum output on
-	// https://developers.openai.com/api/docs/models.
-	maxOutputTokens int
+	deprecated                   bool
+	replacement                  string
+	// limits carries the model's context/output windows in tokens. Nil
+	// leaves are undeclared. Generate values mirror the context window and
+	// maximum output on https://developers.openai.com/api/docs/models;
+	// embedding values mirror the per-request input limit.
+	limits inference.ModelLimits
 	// requestMetadataEnvelope is the provider-level lowering policy for
 	// canonical GenerateRequest.RequestMetadata ("" disables forwarding).
 	requestMetadataEnvelope string
@@ -101,7 +89,7 @@ func (e catalogEntry) validate() error {
 			return fmt.Errorf("embed family declares no generate output")
 		}
 	}
-	return nil
+	return e.limits.Validate()
 }
 
 // includeChatStreamUsage resolves the chat streaming usage policy to the
@@ -148,84 +136,99 @@ var openaiEffortMap = map[inference.ReasoningEffort]string{
 var catalog = map[string]catalogEntry{
 	// Generate — GPT-5.6 flagship family (reasoning + vision).
 	"gpt-5.6-sol": {
-		kind:            kindGenerate,
-		capabilities:    generateChatCapabilities().WithInputs(message.PartImage).WithHostedWebSearch().WithReasoning(inference.ReasoningToggle).WithReasoningEffortMap(openaiEffortMap),
-		effortNone:      true,
-		maxInputTokens:  1_050_000,
-		maxOutputTokens: 128_000,
+		kind:         kindGenerate,
+		capabilities: generateChatCapabilities().WithInputs(message.PartImage).WithHostedWebSearch().WithReasoning(inference.ReasoningToggle).WithReasoningEffortMap(openaiEffortMap),
+		limits: inference.ModelLimits{}.
+			WithMaxInputTokens(1_050_000).
+			WithMaxOutputTokens(128_000),
 	},
 	"gpt-5.6-terra": {
-		kind:            kindGenerate,
-		capabilities:    generateChatCapabilities().WithInputs(message.PartImage).WithHostedWebSearch().WithReasoning(inference.ReasoningToggle).WithReasoningEffortMap(openaiEffortMap),
-		effortNone:      true,
-		maxInputTokens:  1_050_000,
-		maxOutputTokens: 128_000,
+		kind:         kindGenerate,
+		capabilities: generateChatCapabilities().WithInputs(message.PartImage).WithHostedWebSearch().WithReasoning(inference.ReasoningToggle).WithReasoningEffortMap(openaiEffortMap),
+		limits: inference.ModelLimits{}.
+			WithMaxInputTokens(1_050_000).
+			WithMaxOutputTokens(128_000),
 	},
 	"gpt-5.6-luna": {
-		kind:            kindGenerate,
-		capabilities:    generateChatCapabilities().WithInputs(message.PartImage).WithHostedWebSearch().WithReasoning(inference.ReasoningToggle).WithReasoningEffortMap(openaiEffortMap),
-		effortNone:      true,
-		maxInputTokens:  1_050_000,
-		maxOutputTokens: 128_000,
+		kind:         kindGenerate,
+		capabilities: generateChatCapabilities().WithInputs(message.PartImage).WithHostedWebSearch().WithReasoning(inference.ReasoningToggle).WithReasoningEffortMap(openaiEffortMap),
+		limits: inference.ModelLimits{}.
+			WithMaxInputTokens(1_050_000).
+			WithMaxOutputTokens(128_000),
 	},
 	// Generate — previous generations, superseded but available.
 	"gpt-5.5": {
 		kind:         kindGenerate,
 		capabilities: generateChatCapabilities().WithInputs(message.PartImage).WithHostedWebSearch().WithReasoning(inference.ReasoningAlways).WithReasoningEffortMap(openaiEffortMap),
 		deprecated:   true, replacement: "gpt-5.6-sol",
-		maxInputTokens:  1_050_000,
-		maxOutputTokens: 128_000,
+		limits: inference.ModelLimits{}.
+			WithMaxInputTokens(1_050_000).
+			WithMaxOutputTokens(128_000),
 	},
 	"gpt-5.4": {
 		kind:         kindGenerate,
 		capabilities: generateChatCapabilities().WithInputs(message.PartImage).WithHostedWebSearch().WithReasoning(inference.ReasoningAlways).WithReasoningEffortMap(openaiEffortMap),
 		deprecated:   true, replacement: "gpt-5.6-sol",
-		maxInputTokens:  1_050_000,
-		maxOutputTokens: 128_000,
+		limits: inference.ModelLimits{}.
+			WithMaxInputTokens(1_050_000).
+			WithMaxOutputTokens(128_000),
 	},
 	"gpt-5.4-mini": {
 		kind:         kindGenerate,
 		capabilities: generateChatCapabilities().WithInputs(message.PartImage).WithHostedWebSearch().WithReasoning(inference.ReasoningAlways).WithReasoningEffortMap(openaiEffortMap),
 		deprecated:   true, replacement: "gpt-5.6-terra",
-		maxInputTokens:  400_000,
-		maxOutputTokens: 128_000,
+		limits: inference.ModelLimits{}.
+			WithMaxInputTokens(400_000).
+			WithMaxOutputTokens(128_000),
 	},
 	"gpt-5.4-nano": {
 		kind:         kindGenerate,
 		capabilities: generateChatCapabilities().WithInputs(message.PartImage).WithHostedWebSearch().WithReasoning(inference.ReasoningAlways).WithReasoningEffortMap(openaiEffortMap),
 		deprecated:   true, replacement: "gpt-5.6-luna",
-		maxInputTokens:  400_000,
-		maxOutputTokens: 128_000,
+		limits: inference.ModelLimits{}.
+			WithMaxInputTokens(400_000).
+			WithMaxOutputTokens(128_000),
 	},
 	// Generate — GPT-4.1 line: vision without the reasoning control.
 	"gpt-4.1": {
-		kind:            kindGenerate,
-		capabilities:    generateChatCapabilities().WithInputs(message.PartImage).WithHostedWebSearch(),
-		maxInputTokens:  1_047_576,
-		maxOutputTokens: 32_768,
+		kind:         kindGenerate,
+		capabilities: generateChatCapabilities().WithInputs(message.PartImage).WithHostedWebSearch(),
+		limits: inference.ModelLimits{}.
+			WithMaxInputTokens(1_047_576).
+			WithMaxOutputTokens(32_768),
 	},
 	"gpt-4.1-mini": {
-		kind:            kindGenerate,
-		capabilities:    generateChatCapabilities().WithInputs(message.PartImage).WithHostedWebSearch(),
-		maxInputTokens:  1_047_576,
-		maxOutputTokens: 32_768,
+		kind:         kindGenerate,
+		capabilities: generateChatCapabilities().WithInputs(message.PartImage).WithHostedWebSearch(),
+		limits: inference.ModelLimits{}.
+			WithMaxInputTokens(1_047_576).
+			WithMaxOutputTokens(32_768),
 	},
 	// gpt-4.1-nano has no hosted web_search tool.
 	"gpt-4.1-nano": {
 		kind:         kindGenerate,
 		capabilities: generateChatCapabilities().WithInputs(message.PartImage),
 		deprecated:   true, replacement: "gpt-5.6-luna",
-		maxInputTokens:  1_047_576,
-		maxOutputTokens: 32_768,
+		limits: inference.ModelLimits{}.
+			WithMaxInputTokens(1_047_576).
+			WithMaxOutputTokens(32_768),
 	},
 
 	// Embed.
-	"text-embedding-3-small": {kind: kindEmbed, dimensions: true, maxInputTokens: 8_192},
-	"text-embedding-3-large": {kind: kindEmbed, dimensions: true, maxInputTokens: 8_192},
+	"text-embedding-3-small": {
+		kind:         kindEmbed,
+		capabilities: inference.ModelCapabilities{}.WithCustomEmbedDimensions(),
+		limits:       inference.ModelLimits{}.WithMaxInputTokens(8_192),
+	},
+	"text-embedding-3-large": {
+		kind:         kindEmbed,
+		capabilities: inference.ModelCapabilities{}.WithCustomEmbedDimensions(),
+		limits:       inference.ModelLimits{}.WithMaxInputTokens(8_192),
+	},
 	"text-embedding-ada-002": {
 		kind:       kindEmbed,
 		deprecated: true, replacement: "text-embedding-3-small",
-		maxInputTokens: 8_192,
+		limits: inference.ModelLimits{}.WithMaxInputTokens(8_192),
 	},
 
 	// Image.
@@ -266,39 +269,58 @@ var catalog = map[string]catalogEntry{
 	},
 }
 
-// mergedCatalog overlays Spec.Models onto the built-in catalog. A custom
-// entry replaces the same-named built-in entirely, except that numeric
-// limits are inherited from the built-in entry and only replaced when the
-// declaration sets them explicitly.
+// mergedCatalog overlays Spec.Models onto the built-in catalog and resolves
+// every entry to the provider instance's surface. A declaration that names a
+// built-in model under the same kind is a leaf-level patch: capability
+// leaves it names replace the built-in's, everything else (capability
+// leaves, numeric limits) is inherited unless declared explicitly.
+// Reasoning kind "toggle" is then resolved per surface: OpenAI expresses
+// reasoning off as reasoning.effort="none" on Responses only, so a model
+// published as "toggle" there is a deployment assertion that the endpoint
+// honors that route, while the chat surface cannot express off at all and
+// those entries publish "always" instead of promising a switch the
+// compiler would reject.
 func mergedCatalog(spec Spec) (map[string]catalogEntry, error) {
 	models := make(map[string]catalogEntry, len(catalog)+len(spec.Models))
 	maps.Copy(models, catalog)
 	for _, model := range spec.Models {
-		entry := catalogEntry{
-			kind:         modelKind(model.Kind),
-			capabilities: model.Capabilities,
-			dimensions:   model.Dimensions,
-			effortNone:   model.EffortNone,
-		}
-		if builtin, exists := models[model.Name]; exists && builtin.kind == entry.kind {
-			entry.maxInputTokens = builtin.maxInputTokens
-			entry.maxOutputTokens = builtin.maxOutputTokens
+		kind := modelKind(model.Kind)
+		builtin, exists := models[model.Name]
+		entry := catalogEntry{kind: kind}
+		if exists && builtin.kind == kind {
+			// Same-kind redeclarations inherit the built-in capabilities as
+			// the patch base plus the limits below.
+			entry.capabilities = model.Capabilities.Apply(builtin.capabilities)
+			entry.limits = builtin.limits.Clone()
+		} else {
+			entry.capabilities = model.Capabilities.Apply(inference.ModelCapabilities{})
 		}
 		if model.Limits.MaxInputTokens != nil {
-			entry.maxInputTokens = *model.Limits.MaxInputTokens
+			value := *model.Limits.MaxInputTokens
+			entry.limits.MaxInputTokens = &value
 		}
 		if model.Limits.MaxOutputTokens != nil {
-			entry.maxOutputTokens = *model.Limits.MaxOutputTokens
+			value := *model.Limits.MaxOutputTokens
+			entry.limits.MaxOutputTokens = &value
 		}
 		models[model.Name] = entry
 	}
 	envelope := spec.requestMetadataEnvelope()
 	chatStreamIncludeUsage := spec.chatStreamIncludeUsage()
 	chatStreamIncludeObfuscation := spec.chatStreamIncludeObfuscation()
+	api := spec.apiMode()
 	for name, entry := range models {
+		entry.api = api
 		entry.requestMetadataEnvelope = envelope
 		entry.chatStreamIncludeUsage = chatStreamIncludeUsage
 		entry.chatStreamIncludeObfuscation = chatStreamIncludeObfuscation
+		if entry.kind == kindGenerate &&
+			entry.capabilities.Reasoning.Kind == inference.ReasoningToggle &&
+			entry.api == apiChat {
+			// Chat Completions has no way to express reasoning off for any
+			// model, so the truthful per-surface capability is always-on.
+			entry.capabilities.Reasoning.Kind = inference.ReasoningAlways
+		}
 		models[name] = entry
 	}
 	for name, entry := range models {
@@ -327,12 +349,7 @@ func descriptorFor(id inference.ModelID, entry catalogEntry) inference.ModelDesc
 			descriptor.Lifecycle.Replacement = &replacement
 		}
 	}
-	if entry.maxInputTokens > 0 {
-		descriptor.Limits.MaxInputTokens = &entry.maxInputTokens
-	}
-	if entry.maxOutputTokens > 0 {
-		descriptor.Limits.MaxOutputTokens = &entry.maxOutputTokens
-	}
+	descriptor.Limits = entry.limits.Clone()
 	return descriptor
 }
 

--- a/driver/openai/catalog_test.go
+++ b/driver/openai/catalog_test.go
@@ -471,3 +471,18 @@ func TestCustomEmbedDimensionsRequiresEmbedKind(t *testing.T) {
 		t.Fatal("custom_embed_dimensions on a generate model unexpectedly accepted")
 	}
 }
+
+// TestCustomEmbedDimensionsFalseOnGenerateAccepted guards the leaf
+// contract: an explicit false is the conservative declaration and must be
+// a harmless no-op on kinds that never embed.
+func TestCustomEmbedDimensionsFalseOnGenerateAccepted(t *testing.T) {
+	if _, err := decodeSpec(context.Background(), []byte(`{
+		"models": [{
+			"name": "m",
+			"kind": "generate",
+			"capabilities": {"outputs": ["text"], "custom_embed_dimensions": false}
+		}]
+	}`)); err != nil {
+		t.Fatalf("explicit false on a generate model rejected: %v", err)
+	}
+}

--- a/driver/openai/catalog_test.go
+++ b/driver/openai/catalog_test.go
@@ -161,6 +161,12 @@ func TestCatalogPublishesCapabilities(t *testing.T) {
 	if len(embed.Capabilities.Outputs) != 0 {
 		t.Fatalf("embed model outputs = %v, want none", embed.Capabilities.Outputs)
 	}
+	if !descriptors["text-embedding-3-large"].Capabilities.CustomEmbedDimensions {
+		t.Fatal("text-embedding-3-large must publish custom embed dimensions support")
+	}
+	if descriptors["text-embedding-ada-002"].Capabilities.CustomEmbedDimensions {
+		t.Fatal("text-embedding-ada-002 must not publish custom embed dimensions support")
+	}
 }
 
 func TestMergedCatalogRejectsFamilyContractViolation(t *testing.T) {
@@ -249,15 +255,17 @@ func TestMergedCatalogOverlaysDeclaredLimits(t *testing.T) {
 		t.Fatalf("mergedCatalog: %v", err)
 	}
 	custom := models["custom"]
-	if custom.maxInputTokens != 100 || custom.maxOutputTokens != 200 {
+	in, out := custom.limits.Values()
+	if in != 100 || out != 200 {
 		t.Fatalf("custom limits = %d/%d, want 100/200",
-			custom.maxInputTokens, custom.maxOutputTokens)
+			in, out)
 	}
 	// Redeclaring a built-in model without limits keeps the catalog values.
 	builtin := models["gpt-4.1"]
-	if builtin.maxInputTokens != 1_047_576 || builtin.maxOutputTokens != 32_768 {
+	in, out = builtin.limits.Values()
+	if in != 1_047_576 || out != 32_768 {
 		t.Fatalf("gpt-4.1 limits = %d/%d, want catalog 1047576/32768",
-			builtin.maxInputTokens, builtin.maxOutputTokens)
+			in, out)
 	}
 
 	spec, err = decodeSpec(context.Background(), []byte(`{
@@ -276,13 +284,14 @@ func TestMergedCatalogOverlaysDeclaredLimits(t *testing.T) {
 		t.Fatalf("mergedCatalog: %v", err)
 	}
 	overridden := models["gpt-4.1"]
-	if overridden.maxInputTokens != 1_047_576 {
+	in, out = overridden.limits.Values()
+	if in != 1_047_576 {
 		t.Fatalf("gpt-4.1 max input = %d, want built-in 1047576",
-			overridden.maxInputTokens)
+			in)
 	}
-	if overridden.maxOutputTokens != 1000 {
+	if out != 1000 {
 		t.Fatalf("gpt-4.1 max output = %d, want declared 1000",
-			overridden.maxOutputTokens)
+			out)
 	}
 }
 
@@ -304,8 +313,161 @@ func TestMergedCatalogOverridesDeclaredInputLimit(t *testing.T) {
 		t.Fatalf("mergedCatalog: %v", err)
 	}
 	entry := models["gpt-4.1"]
-	if entry.maxInputTokens != 65_536 || entry.maxOutputTokens != 32_768 {
+	in, out := entry.limits.Values()
+	if in != 65_536 || out != 32_768 {
 		t.Fatalf("declared input limits = %d/%d, want 65536/32768",
-			entry.maxInputTokens, entry.maxOutputTokens)
+			in, out)
+	}
+}
+
+func TestMergedCatalogRedeclareKeepsCustomEmbedDimensions(t *testing.T) {
+	spec, err := decodeSpec(context.Background(), []byte(`{
+		"models": [{"name": "text-embedding-3-small", "kind": "embed"}]
+	}`))
+	if err != nil {
+		t.Fatalf("decodeSpec: %v", err)
+	}
+	models, err := mergedCatalog(spec)
+	if err != nil {
+		t.Fatalf("mergedCatalog: %v", err)
+	}
+	entry := models["text-embedding-3-small"]
+	if !entry.capabilities.CustomEmbedDimensions {
+		t.Fatal("redeclaration must inherit the custom embed dimensions capability")
+	}
+	in, _ := entry.limits.Values()
+	if in != 8_192 {
+		t.Fatalf("max input tokens = %d, want built-in 8192", in)
+	}
+
+	spec, err = decodeSpec(context.Background(), []byte(`{
+		"models": [{
+			"name": "text-embedding-3-small",
+			"kind": "embed",
+			"capabilities": {"custom_embed_dimensions": false}
+		}]
+	}`))
+	if err != nil {
+		t.Fatalf("decodeSpec: %v", err)
+	}
+	models, err = mergedCatalog(spec)
+	if err != nil {
+		t.Fatalf("mergedCatalog: %v", err)
+	}
+	if models["text-embedding-3-small"].capabilities.CustomEmbedDimensions {
+		t.Fatal("custom_embed_dimensions: false must clear the built-in capability")
+	}
+}
+
+func TestMergedCatalogLegacyReasoningStringKeepsEffortMap(t *testing.T) {
+	spec, err := decodeSpec(context.Background(), []byte(`{
+		"models": [{
+			"name": "gpt-5.6-sol",
+			"kind": "generate",
+			"capabilities": {
+				"outputs": ["text"],
+				"reasoning": "toggle"
+			}
+		}]
+	}`))
+	if err != nil {
+		t.Fatalf("decodeSpec: %v", err)
+	}
+	models, err := mergedCatalog(spec)
+	if err != nil {
+		t.Fatalf("mergedCatalog: %v", err)
+	}
+	entry := models["gpt-5.6-sol"]
+	if entry.capabilities.Reasoning.Kind != inference.ReasoningToggle {
+		t.Fatalf("reasoning kind = %q, want toggle", entry.capabilities.Reasoning.Kind)
+	}
+	if len(entry.capabilities.Reasoning.EffortMap) != 5 {
+		t.Fatalf("legacy string form must keep the built-in effort map, got %v",
+			entry.capabilities.Reasoning.EffortMap)
+	}
+}
+
+// TestMergedCatalogLeafOverrides locks leaf-level override semantics:
+// explicit leaves replace, absent leaves inherit — hosted web search can be
+// removed with false, and a declared effort map replaces the built-in one
+// while an undeclared kind stays inherited.
+func TestMergedCatalogLeafOverrides(t *testing.T) {
+	// hosted_web_search: false removes the built-in capability while
+	// reasoning and limits stay inherited.
+	spec, err := decodeSpec(context.Background(), []byte(`{
+		"models": [{
+			"name": "gpt-5.6-sol",
+			"kind": "generate",
+			"capabilities": {
+				"outputs": ["text"],
+				"hosted_web_search": false
+			}
+		}]
+	}`))
+	if err != nil {
+		t.Fatalf("decodeSpec: %v", err)
+	}
+	models, err := mergedCatalog(spec)
+	if err != nil {
+		t.Fatalf("mergedCatalog: %v", err)
+	}
+	entry := models["gpt-5.6-sol"]
+	if entry.capabilities.HostedWebSearch {
+		t.Fatal("hosted_web_search: false must remove the built-in capability")
+	}
+	if entry.capabilities.Reasoning.Kind != inference.ReasoningToggle ||
+		len(entry.capabilities.Reasoning.EffortMap) != 5 {
+		t.Fatalf("undeclared reasoning must stay inherited: %+v",
+			entry.capabilities.Reasoning)
+	}
+
+	// A declared effort map replaces the built-in one (minimal folds onto
+	// low here) while the reasoning kind stays inherited.
+	spec, err = decodeSpec(context.Background(), []byte(`{
+		"models": [{
+			"name": "gpt-5.6-sol",
+			"kind": "generate",
+			"capabilities": {
+				"outputs": ["text"],
+				"reasoning": {
+					"effort_map": {
+						"minimal": "low", "low": "low", "medium": "medium",
+						"high": "high", "xhigh": "xhigh"
+					}
+				}
+			}
+		}]
+	}`))
+	if err != nil {
+		t.Fatalf("decodeSpec: %v", err)
+	}
+	models, err = mergedCatalog(spec)
+	if err != nil {
+		t.Fatalf("mergedCatalog: %v", err)
+	}
+	entry = models["gpt-5.6-sol"]
+	if entry.capabilities.Reasoning.Kind != inference.ReasoningToggle {
+		t.Fatalf("reasoning kind = %q, want inherited toggle",
+			entry.capabilities.Reasoning.Kind)
+	}
+	if mode, _ := entry.capabilities.Reasoning.ResolveEffort(
+		inference.ReasoningMinimal,
+	); mode != "low" {
+		t.Fatalf("declared effort map must replace the built-in one, minimal -> %q",
+			mode)
+	}
+}
+
+// TestCustomEmbedDimensionsRequiresEmbedKind guards the capability leaf's
+// family contract on the spec side.
+func TestCustomEmbedDimensionsRequiresEmbedKind(t *testing.T) {
+	if _, err := decodeSpec(context.Background(), []byte(`{
+		"models": [{
+			"name": "m",
+			"kind": "generate",
+			"capabilities": {"outputs": ["text"], "custom_embed_dimensions": true}
+		}]
+	}`)); err == nil {
+		t.Fatal("custom_embed_dimensions on a generate model unexpectedly accepted")
 	}
 }

--- a/driver/openai/doc.go
+++ b/driver/openai/doc.go
@@ -11,10 +11,17 @@
 //     round-trips and rejects the hosted web_search tool at compile time;
 //     the rest of the generate surface (tools, vision, JSON formats,
 //     streaming) is equivalent.
-//     Reasoning_enabled: true is a no-op (the default). False rejects at
-//     compile time unless the model declares effort_none (gpt-5.1+,
-//     per-model via the spec flag): those models compile reasoning_enabled:
-//     false to reasoning.effort: "none" on the Responses surface.
+//     Reasoning_enabled: true is a no-op (the default). False compiles to
+//     reasoning.effort: "none" for every model published as reasoning
+//     "toggle" on the Responses surface (gpt-5.1+ models per the OpenAI
+//     docs) and rejects at compile time for models published as reasoning
+//     "always". Descriptors stay truthful per surface: the chat surface
+//     cannot express reasoning off, so chat catalogs publish reasoning
+//     "always" even for models that toggle on Responses. A spec that
+//     redeclares a built-in model by name and kind is a leaf-level patch:
+//     capability leaves it omits (including custom_embed_dimensions) and
+//     numeric limits are inherited, so redeclaring gpt-5.6-sol to adjust
+//     one channel cannot silently revoke the built-in toggle route.
 //     Reasoning items decode into canonical reasoning parts (summary text,
 //     encrypted payload in the Signature slot, item id) and round-trip
 //     through context when id and payload survive; the request always

--- a/driver/openai/embed.go
+++ b/driver/openai/embed.go
@@ -53,7 +53,7 @@ func compileEmbed(
 			model:      model,
 			dimensions: request.Dimensions,
 		}
-		if request.Dimensions != nil && !entry.dimensions {
+		if request.Dimensions != nil && !entry.capabilities.CustomEmbedDimensions {
 			ledger.reject(
 				inference.FieldEmbedDimensions,
 				"model does not accept custom dimensions",

--- a/driver/openai/generate.go
+++ b/driver/openai/generate.go
@@ -643,7 +643,11 @@ func compileIntent(
 			)
 		case entry.capabilities.Reasoning.Kind == inference.ReasoningToggle &&
 			!*text.ReasoningEnabled:
-			if entry.effortNone && entry.api != apiChat {
+			// Toggle is only published where the surface can express off:
+			// Responses lowers it to reasoning.effort "none", while chat
+			// entries are lowered to always at merge time. The chat guard
+			// stays as compiler-level defense for direct entry misuse.
+			if entry.api != apiChat {
 				wire.reasoning = "none"
 				break
 			}

--- a/driver/openai/reasoning_none_test.go
+++ b/driver/openai/reasoning_none_test.go
@@ -5,9 +5,10 @@ import (
 	"testing"
 
 	"github.com/GizClaw/flowcraft/core/inference"
+	"github.com/GizClaw/flowcraft/core/inference/inferencetest"
 )
 
-func TestToggleFalseCompilesToEffortNone(t *testing.T) {
+func TestToggleFalseCompilesToWireNone(t *testing.T) {
 	compile := compileGenerate("gpt-5.6-sol", catalog["gpt-5.6-sol"])
 	request := simpleTextRequest("hi")
 	disabled := false
@@ -26,32 +27,7 @@ func TestToggleFalseCompilesToEffortNone(t *testing.T) {
 		t.Fatalf("wire reasoning = %q, want none", compiled.Wire.reasoning)
 	}
 	if compiled.Report.Rejects(inference.FieldGenerateIntentReasoningEnabled) {
-		t.Fatal("disable request unexpectedly rejected on an effort_none model")
-	}
-}
-
-func TestToggleFalseRejectsWithoutEffortNone(t *testing.T) {
-	entry := catalogEntry{
-		kind:         kindGenerate,
-		api:          apiResponses,
-		capabilities: generateChatCapabilities().WithReasoning(inference.ReasoningToggle),
-	}
-	compile := compileGenerate("legacy-toggle", entry)
-	request := simpleTextRequest("hi")
-	disabled := false
-	request.Input.Content.Intent.Text.ReasoningEnabled = &disabled
-
-	compiled, err := compile(
-		context.Background(),
-		openaiModel("legacy-toggle"),
-		request,
-		inference.GenerateExecutionUnary,
-	)
-	if err == nil {
-		t.Fatal("disable request unexpectedly accepted without effort_none")
-	}
-	if !compiled.Report.Rejects(inference.FieldGenerateIntentReasoningEnabled) {
-		t.Fatal("disable request was not rejected on the reasoning_enabled field")
+		t.Fatal("disable request unexpectedly rejected on a toggle model")
 	}
 }
 
@@ -60,7 +36,6 @@ func TestChatModeToggleFalseStillRejects(t *testing.T) {
 		kind:         kindGenerate,
 		api:          apiChat,
 		capabilities: generateChatCapabilities().WithReasoning(inference.ReasoningToggle),
-		effortNone:   true,
 	}
 	compile := compileGenerate("chat-toggle", entry)
 	request := simpleTextRequest("hi")
@@ -105,5 +80,277 @@ func TestSpecToggleWithoutMapPassesEffortThrough(t *testing.T) {
 	}
 	if compiled.Report.Dropped(inference.FieldGenerateIntentReasoningEffort) {
 		t.Fatal("legacy spec effort unexpectedly dropped")
+	}
+}
+
+// TestRedeclaredBuiltinKeepsToggleRoute locks the original bug: redeclaring
+// gpt-5.6-sol to tweak one channel must keep the built-in reasoning kind and
+// effort map, so the published toggle keeps compiling
+// reasoning_enabled=false without restating the whole declaration.
+func TestRedeclaredBuiltinKeepsToggleRoute(t *testing.T) {
+	spec, err := decodeSpec(context.Background(), []byte(`{
+		"models": [{
+			"name": "gpt-5.6-sol",
+			"kind": "generate",
+			"capabilities": {
+				"inputs": ["text", "image", "data", "tool_call", "tool_result"],
+				"outputs": ["text"],
+				"hosted_web_search": true,
+				"reasoning": {"kind": "toggle"}
+			}
+		}]
+	}`))
+	if err != nil {
+		t.Fatalf("decodeSpec: %v", err)
+	}
+	models, err := mergedCatalog(spec)
+	if err != nil {
+		t.Fatalf("mergedCatalog: %v", err)
+	}
+	entry := models["gpt-5.6-sol"]
+	if entry.capabilities.Reasoning.Kind != inference.ReasoningToggle {
+		t.Fatalf("reasoning kind = %q, want toggle", entry.capabilities.Reasoning.Kind)
+	}
+	if len(entry.capabilities.Reasoning.EffortMap) != 5 {
+		t.Fatalf("redeclaration must keep the built-in effort map, got %v",
+			entry.capabilities.Reasoning.EffortMap)
+	}
+
+	compiled, err := compileGenerate("gpt-5.6-sol", entry)(
+		context.Background(),
+		openaiModel("gpt-5.6-sol"),
+		inferencetest.ReasoningOffProbe(),
+		inference.GenerateExecutionUnary,
+	)
+	if err != nil {
+		t.Fatalf("disable request rejected after redeclaration: %v", err)
+	}
+	if compiled.Wire.reasoning != "none" {
+		t.Fatalf("wire reasoning = %q, want none", compiled.Wire.reasoning)
+	}
+	if compiled.Report.Rejects(inference.FieldGenerateIntentReasoningEnabled) {
+		t.Fatal("disable request unexpectedly rejected after redeclaration")
+	}
+}
+
+func TestRedeclaredBuiltinWithoutCapabilitiesInheritsWholesale(t *testing.T) {
+	spec, err := decodeSpec(context.Background(), []byte(`{
+		"models": [{"name": "gpt-5.6-sol", "kind": "generate"}]
+	}`))
+	if err != nil {
+		t.Fatalf("decodeSpec: %v", err)
+	}
+	models, err := mergedCatalog(spec)
+	if err != nil {
+		t.Fatalf("mergedCatalog: %v", err)
+	}
+	entry := models["gpt-5.6-sol"]
+	builtin := catalog["gpt-5.6-sol"]
+	in, out := entry.limits.Values()
+	bin, bout := builtin.limits.Values()
+	if in != bin || out != bout {
+		t.Fatalf("limits = %d/%d, want built-in %d/%d",
+			in, out, bin, bout)
+	}
+	if entry.capabilities.Reasoning.Kind != inference.ReasoningToggle ||
+		len(entry.capabilities.Reasoning.EffortMap) != 5 {
+		t.Fatalf("empty capabilities block must inherit reasoning wholesale: %+v",
+			entry.capabilities.Reasoning)
+	}
+}
+
+// TestCustomToggleCompilesReasoningOff locks the contract's custom-model
+// side: on the Responses surface "toggle" means the deployment asserts the
+// endpoint honors reasoning.effort="none", so no separate declaration is
+// needed and the switch must compile.
+func TestCustomToggleCompilesReasoningOff(t *testing.T) {
+	spec, err := decodeSpec(context.Background(), []byte(`{
+		"models": [{
+			"name": "my-toggle",
+			"kind": "generate",
+			"capabilities": {
+				"outputs": ["text"],
+				"reasoning": {"kind": "toggle"}
+			}
+		}]
+	}`))
+	if err != nil {
+		t.Fatalf("decodeSpec: %v", err)
+	}
+	models, err := mergedCatalog(spec)
+	if err != nil {
+		t.Fatalf("mergedCatalog: %v", err)
+	}
+	compiled, err := compileGenerate("my-toggle", models["my-toggle"])(
+		context.Background(),
+		openaiModel("my-toggle"),
+		inferencetest.ReasoningOffProbe(),
+		inference.GenerateExecutionUnary,
+	)
+	if err != nil {
+		t.Fatalf("custom toggle rejected reasoning off: %v", err)
+	}
+	if compiled.Wire.reasoning != "none" {
+		t.Fatalf("wire reasoning = %q, want none", compiled.Wire.reasoning)
+	}
+}
+
+// TestRedeclaredBuiltinAsAlwaysGivesTheMigrationPath: a deployment whose
+// endpoint cannot disable reasoning declares kind always and keeps every
+// other built-in fact without restating it.
+func TestRedeclaredBuiltinAsAlwaysGivesTheMigrationPath(t *testing.T) {
+	spec, err := decodeSpec(context.Background(), []byte(`{
+		"models": [{
+			"name": "gpt-5.6-sol",
+			"kind": "generate",
+			"capabilities": {"outputs": ["text"], "reasoning": {"kind": "always"}}
+		}]
+	}`))
+	if err != nil {
+		t.Fatalf("decodeSpec: %v", err)
+	}
+	models, err := mergedCatalog(spec)
+	if err != nil {
+		t.Fatalf("mergedCatalog: %v", err)
+	}
+	entry := models["gpt-5.6-sol"]
+	if entry.capabilities.Reasoning.Kind != inference.ReasoningAlways {
+		t.Fatalf("reasoning kind = %q, want always", entry.capabilities.Reasoning.Kind)
+	}
+	if len(entry.capabilities.Reasoning.EffortMap) != 5 {
+		t.Fatalf("reasoning effort map must still inherit, got %v",
+			entry.capabilities.Reasoning.EffortMap)
+	}
+	if _, err := compileGenerate("gpt-5.6-sol", entry)(
+		context.Background(),
+		openaiModel("gpt-5.6-sol"),
+		inferencetest.ReasoningOffProbe(),
+		inference.GenerateExecutionUnary,
+	); err == nil {
+		t.Fatal("always model unexpectedly compiled reasoning_enabled=false")
+	}
+}
+
+// TestChatSurfacePublishesAlways locks the per-surface materialization
+// contract: on api: chat no model may publish toggle, because the wire
+// cannot express reasoning off there.
+func TestChatSurfacePublishesAlways(t *testing.T) {
+	spec, err := decodeSpec(context.Background(), []byte(`{"api": "chat"}`))
+	if err != nil {
+		t.Fatalf("decodeSpec: %v", err)
+	}
+	models, err := mergedCatalog(spec)
+	if err != nil {
+		t.Fatalf("mergedCatalog: %v", err)
+	}
+	for name, entry := range models {
+		if entry.kind != kindGenerate || entry.api != apiChat {
+			continue
+		}
+		if entry.capabilities.Reasoning.Kind == inference.ReasoningToggle {
+			t.Fatalf("model %q publishes toggle on the chat surface", name)
+		}
+		if entry.capabilities.Reasoning.Kind != inference.ReasoningAlways {
+			continue
+		}
+		compiled, err := compileGenerate(name, entry)(
+			context.Background(),
+			openaiModel(name),
+			inferencetest.ReasoningOffProbe(),
+			inference.GenerateExecutionUnary,
+		)
+		if err == nil {
+			t.Fatalf("model %q compiled reasoning_enabled=false on chat", name)
+		}
+		if !compiled.Report.Rejects(inference.FieldGenerateIntentReasoningEnabled) {
+			t.Fatalf("model %q did not reject on the reasoning_enabled field", name)
+		}
+	}
+}
+
+// TestPublishedToggleCompilesReasoningOff is the generic conformance
+// contract: every generate model that publishes toggle on the responses
+// surface must compile the shared reasoning-off probe.
+func TestPublishedToggleCompilesReasoningOff(t *testing.T) {
+	spec, err := decodeSpec(context.Background(), []byte(`{}`))
+	if err != nil {
+		t.Fatalf("decodeSpec: %v", err)
+	}
+	models, err := mergedCatalog(spec)
+	if err != nil {
+		t.Fatalf("mergedCatalog: %v", err)
+	}
+	checked := 0
+	for name, entry := range models {
+		if entry.kind != kindGenerate ||
+			entry.capabilities.Reasoning.Kind != inference.ReasoningToggle {
+			continue
+		}
+		checked++
+		if compiled, err := compileGenerate(name, entry)(
+			context.Background(),
+			openaiModel(name),
+			inferencetest.ReasoningOffProbe(),
+			inference.GenerateExecutionUnary,
+		); err != nil {
+			t.Fatalf("toggle model %q rejected reasoning off: %v", name, err)
+		} else if compiled.Report.Rejects(
+			inference.FieldGenerateIntentReasoningEnabled,
+		) {
+			t.Fatalf("toggle model %q rejected on the reasoning_enabled field", name)
+		}
+	}
+	if checked == 0 {
+		t.Fatal("no toggle model exercised")
+	}
+}
+
+// TestLegacyEffortNoneConfigNowRejected documents the effort_none removal:
+// strict spec decoding must surface the key as unknown instead of silently
+// accepting a knob that no longer exists.
+func TestLegacyEffortNoneConfigNowRejected(t *testing.T) {
+	if _, err := decodeSpec(context.Background(), []byte(`{
+		"models": [{
+			"name": "gpt-5.6-sol",
+			"kind": "generate",
+			"capabilities": {"outputs": ["text"], "reasoning": {"kind": "toggle"}},
+			"effort_none": true
+		}]
+	}`)); err == nil {
+		t.Fatal("spec with effort_none unexpectedly accepted")
+	}
+}
+
+// TestChatSurfaceLowersDeclaredToggle guards the per-surface resolution for
+// spec-declared models too: even an explicit toggle declaration on api:
+// chat must publish always, because the wire cannot express reasoning off.
+func TestChatSurfaceLowersDeclaredToggle(t *testing.T) {
+	spec, err := decodeSpec(context.Background(), []byte(`{
+		"api": "chat",
+		"models": [{
+			"name": "gpt-5.6-sol",
+			"kind": "generate",
+			"capabilities": {"outputs": ["text"], "reasoning": {"kind": "toggle"}}
+		}]
+	}`))
+	if err != nil {
+		t.Fatalf("decodeSpec: %v", err)
+	}
+	models, err := mergedCatalog(spec)
+	if err != nil {
+		t.Fatalf("mergedCatalog: %v", err)
+	}
+	entry := models["gpt-5.6-sol"]
+	if entry.capabilities.Reasoning.Kind != inference.ReasoningAlways {
+		t.Fatalf("chat redeclaration reasoning kind = %q, want always",
+			entry.capabilities.Reasoning.Kind)
+	}
+	if _, err := compileGenerate("gpt-5.6-sol", entry)(
+		context.Background(),
+		openaiModel("gpt-5.6-sol"),
+		inferencetest.ReasoningOffProbe(),
+		inference.GenerateExecutionUnary,
+	); err == nil {
+		t.Fatal("chat toggle unexpectedly compiled reasoning_enabled=false")
 	}
 }

--- a/driver/openai/resource.go
+++ b/driver/openai/resource.go
@@ -117,7 +117,6 @@ func buildProvider(ctx context.Context, settings ResourceSettings, secrets *reso
 	slices.Sort(names)
 	for _, name := range names {
 		entry := models[name]
-		entry.api = spec.apiMode()
 		id := inference.ModelID{Provider: settings.ID, Name: name}
 		descriptor := descriptorFor(id, entry)
 		provider.Models = append(provider.Models, inference.ModelImplementation{

--- a/driver/openai/spec.go
+++ b/driver/openai/spec.go
@@ -194,6 +194,7 @@ func (m ModelSpec) Validate() error {
 	}
 	if m.Capabilities != nil &&
 		m.Capabilities.CustomEmbedDimensions != nil &&
+		*m.Capabilities.CustomEmbedDimensions &&
 		kind != kindEmbed {
 		return fmt.Errorf(
 			"model %q sets custom_embed_dimensions on kind %q",

--- a/driver/openai/spec.go
+++ b/driver/openai/spec.go
@@ -82,27 +82,24 @@ func (s RequestMetadataSpec) Validate() error {
 	return nil
 }
 
-// ModelSpec declares one model outside the built-in catalog. Capabilities
-// mirror the built-in catalog shape: content kinds, hosted web search, and
-// the reasoning control capability (validated against the kind's compiler
-// contract at merge time). Dimensions and EffortNone are control
-// capabilities that no capability kind expresses and stay separate flags.
+// ModelSpec declares a model outside the built-in catalog, or a delta over a
+// same-named, same-kind built-in catalog entry. Capabilities is a patch with
+// field-presence semantics: every leaf it names replaces that leaf of the
+// entry it overrides, and leaves it does not name are inherited — so
+// redeclaring a built-in to tweak one channel keeps every other declared
+// fact, including the reasoning effort map and custom embed output
+// dimensions. Reasoning off needs no separate declaration: "toggle" on the
+// Responses surface means this model honors reasoning.effort="none", and
+// models whose endpoint cannot disable reasoning publish "always".
 type ModelSpec struct {
 	Name string `json:"name"`
 	Kind string `json:"kind"`
-	// Capabilities declares the model's input/output content kinds, hosted
-	// web search support, and reasoning control capability.
-	Capabilities inference.ModelCapabilities `json:"capabilities,omitempty"`
+	// Capabilities declares the capability leaves this model changes.
+	Capabilities *inference.CapabilitiesPatch `json:"capabilities,omitempty"`
 	// Limits declares numeric capacity limits for the model. Overriding a
 	// built-in catalog entry by name keeps the catalog limit for any field
 	// left nil; declaring a value replaces it.
 	Limits inference.ModelLimits `json:"limits,omitempty"`
-	// Dimensions (embed) allows custom output dimensions.
-	Dimensions bool `json:"dimensions,omitempty"`
-	// EffortNone marks generate models whose reasoning.effort accepts
-	// "none" to disable reasoning (gpt-5.1+); models without it reject a
-	// ReasoningEnabled=false request.
-	EffortNone bool `json:"effort_none,omitempty"`
 }
 
 // ProfileSpec is the per-credential-profile configuration. OpenAI addresses
@@ -189,10 +186,20 @@ func (m ModelSpec) Validate() error {
 	if !modelNamePattern.MatchString(m.Name) {
 		return fmt.Errorf("invalid model name %q", m.Name)
 	}
-	switch modelKind(m.Kind) {
+	kind := modelKind(m.Kind)
+	switch kind {
 	case kindGenerate, kindEmbed, kindImage, kindTTS:
 	default:
 		return fmt.Errorf("model %q has unknown kind %q", m.Name, m.Kind)
+	}
+	if m.Capabilities != nil &&
+		m.Capabilities.CustomEmbedDimensions != nil &&
+		kind != kindEmbed {
+		return fmt.Errorf(
+			"model %q sets custom_embed_dimensions on kind %q",
+			m.Name,
+			m.Kind,
+		)
 	}
 	if err := m.Capabilities.Validate(); err != nil {
 		return err

--- a/driver/qwen/catalog.go
+++ b/driver/qwen/catalog.go
@@ -200,6 +200,12 @@ func (e catalogEntry) validate() error {
 	if e.kind == kindEmbed && (e.preserveThinking || e.thinkingStreamOnly) {
 		return fmt.Errorf("embed model cannot declare thinking flags")
 	}
+	if e.kind != kindEmbed && e.capabilities.CustomEmbedDimensions {
+		return fmt.Errorf(
+			"kind %q cannot declare custom_embed_dimensions",
+			e.kind,
+		)
+	}
 	if e.kind == kindEmbed &&
 		(len(e.embedDimensions) > 0) != e.capabilities.CustomEmbedDimensions {
 		return fmt.Errorf(
@@ -233,8 +239,11 @@ func (e catalogEntry) multimodal() bool {
 }
 
 // mergedCatalog overlays the spec's declared models on the built-in
-// catalog. Unknown kinds are rejected at build time; custom models get the
-// bare declared surface (fail closed).
+// catalog: a spec entry that names a same-kind catalog entry is a leaf
+// patch over it (capability leaves and numeric limits are inherited unless
+// declared), and unknown or cross-kind names start from the conservative
+// zero declaration. Models stay fail closed — the factory only exposes
+// what the merged catalog declares.
 func mergedCatalog(spec Spec) (map[string]catalogEntry, error) {
 	merged := make(map[string]catalogEntry, len(catalog)+len(spec.Models))
 	for name, entry := range catalog {
@@ -244,32 +253,25 @@ func mergedCatalog(spec Spec) (map[string]catalogEntry, error) {
 		merged[name] = entry
 	}
 	for _, model := range spec.Models {
-		if entry, exists := merged[model.Name]; exists {
-			if model.Kind != "" && modelKind(model.Kind) != entry.kind {
-				return nil, fmt.Errorf("model %q kind %q conflicts with catalog %q",
-					model.Name, model.Kind, entry.kind)
+		entry := catalogEntry{kind: modelKind(model.Kind)}
+		base := inference.ModelCapabilities{}
+		if existing, exists := merged[model.Name]; exists {
+			if entry.kind == "" {
+				entry.kind = existing.kind
 			}
-		}
-		entry := merged[model.Name]
-		if entry.kind == "" {
-			entry.kind = modelKind(model.Kind)
+			if entry.kind == existing.kind {
+				// Same-kind redeclarations keep the catalog's driver
+				// control facts and limits; capability leaves the
+				// declaration does not name are inherited too.
+				entry = existing
+				base = existing.capabilities
+			}
+		} else {
 			if entry.kind == "" {
 				entry.kind = kindGenerate
 			}
 		}
-		entry.capabilities.Inputs = unionKinds(
-			entry.capabilities.Inputs,
-			model.Capabilities.Inputs,
-		)
-		entry.capabilities.Outputs = unionKinds(
-			entry.capabilities.Outputs,
-			model.Capabilities.Outputs,
-		)
-		entry.capabilities.HostedWebSearch =
-			entry.capabilities.HostedWebSearch || model.Capabilities.HostedWebSearch
-		if model.Capabilities.Reasoning.Kind != inference.ReasoningNone {
-			entry.capabilities.Reasoning = model.Capabilities.Reasoning
-		}
+		entry.capabilities = model.Capabilities.Apply(base)
 		if model.Limits.MaxInputTokens != nil {
 			value := *model.Limits.MaxInputTokens
 			entry.limits.MaxInputTokens = &value
@@ -284,19 +286,6 @@ func mergedCatalog(spec Spec) (map[string]catalogEntry, error) {
 		merged[model.Name] = entry
 	}
 	return merged, nil
-}
-
-// unionKinds appends any kind from addition that is not already present in
-// base, preserving base order. Spec declarations overlay catalog entries
-// additively.
-func unionKinds(base, addition []message.PartKind) []message.PartKind {
-	result := append([]message.PartKind(nil), base...)
-	for _, kind := range addition {
-		if !slices.Contains(result, kind) {
-			result = append(result, kind)
-		}
-	}
-	return result
 }
 
 // descriptorFor lowers one catalog entry into its public discovery

--- a/driver/qwen/catalog.go
+++ b/driver/qwen/catalog.go
@@ -16,10 +16,13 @@ const (
 )
 
 // catalogEntry declares what one catalog model accepts. capabilities is the
-// single capability fact source: input/output content kinds and the reasoning
-// control capability (switch kind plus the canonical-to-wire effort map).
-// preserveThinking, thinkingStreamOnly, and embedDimensions are control
-// capabilities that no capability kind expresses and stay separate flags.
+// single capability fact source: input/output content kinds, the reasoning
+// control capability (switch kind plus the canonical-to-wire effort map),
+// and custom embed output dimensions. preserveThinking, thinkingStreamOnly,
+// and embedDimensions are control facts that no capability kind expresses
+// and stay separate fields; embedDimensions additionally carries the exact
+// sizes the published custom_embed_dimensions capability allows and must
+// agree with it (validated in catalogEntry.validate).
 type catalogEntry struct {
 	kind         modelKind
 	capabilities inference.ModelCapabilities
@@ -32,17 +35,12 @@ type catalogEntry struct {
 	// embedDimensions lists the vector sizes an embed model accepts; nil
 	// means the model takes no dimension parameter.
 	embedDimensions []int
-	// maxInputTokens caps the input context in tokens; zero means
-	// undeclared. Values mirror the published maximum input length
-	// (最大输入长度) on the per-model pages at
+	// limits carries the model's context/output windows in tokens. Nil
+	// leaves are undeclared. Values mirror the published maximum input
+	// length (最大输入长度) and output length (最大输出长度) on the
+	// per-model pages at
 	// https://www.alibabacloud.com/help/zh/model-studio/models.
-	maxInputTokens int
-	// maxOutputTokens caps the tokens a single response may emit
-	// (thinking plus answer tokens share the budget); zero means
-	// undeclared. Values mirror the published maximum output length
-	// (最大输出长度) on the per-model pages at
-	// https://www.alibabacloud.com/help/zh/model-studio/models.
-	maxOutputTokens int
+	limits inference.ModelLimits
 }
 
 // qwenMaxPreviewEffortMap is qwen3.8-max-preview's canonical-to-wire map
@@ -76,8 +74,9 @@ var catalog = map[string]catalogEntry{
 			WithReasoningEffortMap(qwenMaxPreviewEffortMap),
 		preserveThinking:   true,
 		thinkingStreamOnly: true,
-		maxInputTokens:     983_616,
-		maxOutputTokens:    131_072,
+		limits: inference.ModelLimits{}.
+			WithMaxInputTokens(983_616).
+			WithMaxOutputTokens(131_072),
 	},
 	"qwen3.7-max": {
 		kind: kindGenerate,
@@ -86,8 +85,9 @@ var catalog = map[string]catalogEntry{
 			WithReasoning(inference.ReasoningToggle),
 		preserveThinking:   true,
 		thinkingStreamOnly: true,
-		maxInputTokens:     991_808,
-		maxOutputTokens:    131_072,
+		limits: inference.ModelLimits{}.
+			WithMaxInputTokens(991_808).
+			WithMaxOutputTokens(131_072),
 	},
 	"qwen3.7-plus": {
 		kind: kindGenerate,
@@ -96,8 +96,9 @@ var catalog = map[string]catalogEntry{
 			WithReasoning(inference.ReasoningToggle),
 		preserveThinking:   true,
 		thinkingStreamOnly: true,
-		maxInputTokens:     991_808,
-		maxOutputTokens:    131_072,
+		limits: inference.ModelLimits{}.
+			WithMaxInputTokens(991_808).
+			WithMaxOutputTokens(131_072),
 	},
 	"qwen3.7-flash": {
 		kind: kindGenerate,
@@ -106,8 +107,9 @@ var catalog = map[string]catalogEntry{
 			WithReasoning(inference.ReasoningToggle),
 		preserveThinking:   true,
 		thinkingStreamOnly: true,
-		maxInputTokens:     991_808,
-		maxOutputTokens:    131_072,
+		limits: inference.ModelLimits{}.
+			WithMaxInputTokens(991_808).
+			WithMaxOutputTokens(131_072),
 	},
 	"qwen3-vl-plus": {
 		kind: kindGenerate,
@@ -115,8 +117,9 @@ var catalog = map[string]catalogEntry{
 			WithInputs(message.PartImage, message.PartVideo).
 			WithReasoning(inference.ReasoningToggle),
 		thinkingStreamOnly: true,
-		maxInputTokens:     260_096,
-		maxOutputTokens:    32_768,
+		limits: inference.ModelLimits{}.
+			WithMaxInputTokens(260_096).
+			WithMaxOutputTokens(32_768),
 	},
 	"qwen3-vl-flash": {
 		kind: kindGenerate,
@@ -124,29 +127,57 @@ var catalog = map[string]catalogEntry{
 			WithInputs(message.PartImage, message.PartVideo).
 			WithReasoning(inference.ReasoningToggle),
 		thinkingStreamOnly: true,
-		maxInputTokens:     260_096,
-		maxOutputTokens:    32_768,
+		limits: inference.ModelLimits{}.
+			WithMaxInputTokens(260_096).
+			WithMaxOutputTokens(32_768),
 	},
 
-	"qwen-plus":  {kind: kindGenerate, capabilities: generateChatCapabilities(), maxInputTokens: 997_952, maxOutputTokens: 32_768},
-	"qwen-turbo": {kind: kindGenerate, capabilities: generateChatCapabilities(), maxInputTokens: 98_304, maxOutputTokens: 16_384},
-	"qwen-flash": {kind: kindGenerate, capabilities: generateChatCapabilities(), maxInputTokens: 997_952, maxOutputTokens: 32_768},
-	"qwen-max":   {kind: kindGenerate, capabilities: generateChatCapabilities(), maxInputTokens: 30_720, maxOutputTokens: 8_192},
+	"qwen-plus": {
+		kind:         kindGenerate,
+		capabilities: generateChatCapabilities(),
+		limits: inference.ModelLimits{}.
+			WithMaxInputTokens(997_952).
+			WithMaxOutputTokens(32_768),
+	},
+	"qwen-turbo": {
+		kind:         kindGenerate,
+		capabilities: generateChatCapabilities(),
+		limits: inference.ModelLimits{}.
+			WithMaxInputTokens(98_304).
+			WithMaxOutputTokens(16_384),
+	},
+	"qwen-flash": {
+		kind:         kindGenerate,
+		capabilities: generateChatCapabilities(),
+		limits: inference.ModelLimits{}.
+			WithMaxInputTokens(997_952).
+			WithMaxOutputTokens(32_768),
+	},
+	"qwen-max": {
+		kind:         kindGenerate,
+		capabilities: generateChatCapabilities(),
+		limits: inference.ModelLimits{}.
+			WithMaxInputTokens(30_720).
+			WithMaxOutputTokens(8_192),
+	},
 
 	// Embeddings. The multimodal model is served in the Beijing region
 	// only; text-embedding-v4 batches at most 10 rows per request.
 	"text-embedding-v4": {
-		kind:            kindEmbed,
-		capabilities:    inference.ModelCapabilities{}.WithInputs(message.PartText),
+		kind: kindEmbed,
+		capabilities: inference.ModelCapabilities{}.
+			WithInputs(message.PartText).
+			WithCustomEmbedDimensions(),
 		embedDimensions: []int{2048, 1536, 1024, 768, 512, 256, 128, 64},
-		maxInputTokens:  8_192,
+		limits:          inference.ModelLimits{}.WithMaxInputTokens(8_192),
 	},
 	"qwen3-vl-embedding": {
 		kind: kindEmbed,
 		capabilities: inference.ModelCapabilities{}.
-			WithInputs(message.PartText, message.PartImage, message.PartVideo),
+			WithInputs(message.PartText, message.PartImage, message.PartVideo).
+			WithCustomEmbedDimensions(),
 		embedDimensions: []int{2560, 2048, 1536, 1024, 768, 512, 256},
-		maxInputTokens:  32_000,
+		limits:          inference.ModelLimits{}.WithMaxInputTokens(32_000),
 	},
 }
 
@@ -169,7 +200,15 @@ func (e catalogEntry) validate() error {
 	if e.kind == kindEmbed && (e.preserveThinking || e.thinkingStreamOnly) {
 		return fmt.Errorf("embed model cannot declare thinking flags")
 	}
-	return nil
+	if e.kind == kindEmbed &&
+		(len(e.embedDimensions) > 0) != e.capabilities.CustomEmbedDimensions {
+		return fmt.Errorf(
+			"embed model custom_embed_dimensions capability must match its "+
+				"dimension whitelist (%d sizes)",
+			len(e.embedDimensions),
+		)
+	}
+	return e.limits.Validate()
 }
 
 // generateChatCapabilities is the capability declaration for the Qwen text
@@ -232,10 +271,12 @@ func mergedCatalog(spec Spec) (map[string]catalogEntry, error) {
 			entry.capabilities.Reasoning = model.Capabilities.Reasoning
 		}
 		if model.Limits.MaxInputTokens != nil {
-			entry.maxInputTokens = *model.Limits.MaxInputTokens
+			value := *model.Limits.MaxInputTokens
+			entry.limits.MaxInputTokens = &value
 		}
 		if model.Limits.MaxOutputTokens != nil {
-			entry.maxOutputTokens = *model.Limits.MaxOutputTokens
+			value := *model.Limits.MaxOutputTokens
+			entry.limits.MaxOutputTokens = &value
 		}
 		if err := entry.validate(); err != nil {
 			return nil, fmt.Errorf("model %q: %w", model.Name, err)
@@ -266,12 +307,7 @@ func descriptorFor(id inference.ModelID, entry catalogEntry) inference.ModelDesc
 		ID:           id,
 		Capabilities: entry.capabilities,
 	}
-	if entry.maxInputTokens > 0 {
-		descriptor.Limits.MaxInputTokens = &entry.maxInputTokens
-	}
-	if entry.maxOutputTokens > 0 {
-		descriptor.Limits.MaxOutputTokens = &entry.maxOutputTokens
-	}
+	descriptor.Limits = entry.limits.Clone()
 	return descriptor
 }
 

--- a/driver/qwen/catalog_test.go
+++ b/driver/qwen/catalog_test.go
@@ -20,14 +20,15 @@ func TestCatalogDeclaresMaxInputTokens(t *testing.T) {
 		descriptors[model.Descriptor.ID.Name] = model.Descriptor
 	}
 	for name, entry := range catalog {
-		if entry.maxInputTokens <= 0 {
+		if entry.limits.MaxInputTokens == nil {
 			t.Errorf("model %q: max input tokens not declared", name)
 		}
 		descriptor := descriptors[name]
-		if descriptor.Limits.MaxInputTokens == nil ||
-			*descriptor.Limits.MaxInputTokens != entry.maxInputTokens {
+		in, _ := entry.limits.Values()
+		din, _ := descriptor.Limits.Values()
+		if din != in {
 			t.Errorf("model %q: descriptor limit = %v, want %d",
-				name, descriptor.Limits.MaxInputTokens, entry.maxInputTokens)
+				name, descriptor.Limits.MaxInputTokens, in)
 		}
 	}
 	checks := map[string]int{
@@ -59,14 +60,15 @@ func TestCatalogDeclaresMaxOutputTokens(t *testing.T) {
 		if entry.kind != kindGenerate {
 			continue
 		}
-		if entry.maxOutputTokens <= 0 {
+		if entry.limits.MaxOutputTokens == nil {
 			t.Errorf("model %q: max output tokens not declared", name)
 		}
 		descriptor := descriptors[name]
-		if descriptor.Limits.MaxOutputTokens == nil ||
-			*descriptor.Limits.MaxOutputTokens != entry.maxOutputTokens {
+		_, out := entry.limits.Values()
+		_, dout := descriptor.Limits.Values()
+		if dout != out {
 			t.Errorf("model %q: descriptor limit = %v, want %d",
-				name, descriptor.Limits.MaxOutputTokens, entry.maxOutputTokens)
+				name, descriptor.Limits.MaxOutputTokens, out)
 		}
 	}
 	checks := map[string]int{
@@ -144,9 +146,10 @@ func TestMergedCatalogOverlaysDeclaredLimits(t *testing.T) {
 		t.Fatalf("mergedCatalog: %v", err)
 	}
 	entry := models["qwen3.7-flash"]
-	if entry.maxInputTokens != 991_808 || entry.maxOutputTokens != 131_072 {
+	in, out := entry.limits.Values()
+	if in != 991_808 || out != 131_072 {
 		t.Fatalf("redeclared limits = %d/%d, want catalog 991808/131072",
-			entry.maxInputTokens, entry.maxOutputTokens)
+			in, out)
 	}
 
 	spec, err = decodeSpec(context.Background(), []byte(`{
@@ -164,9 +167,10 @@ func TestMergedCatalogOverlaysDeclaredLimits(t *testing.T) {
 		t.Fatalf("mergedCatalog: %v", err)
 	}
 	entry = models["qwen3.7-flash"]
-	if entry.maxInputTokens != 991_808 || entry.maxOutputTokens != 4096 {
+	in, out = entry.limits.Values()
+	if in != 991_808 || out != 4096 {
 		t.Fatalf("overridden limits = %d/%d, want 991808/4096",
-			entry.maxInputTokens, entry.maxOutputTokens)
+			in, out)
 	}
 }
 
@@ -186,8 +190,9 @@ func TestMergedCatalogOverridesDeclaredInputLimit(t *testing.T) {
 		t.Fatalf("mergedCatalog: %v", err)
 	}
 	entry := models["qwen3.7-flash"]
-	if entry.maxInputTokens != 65_536 || entry.maxOutputTokens != 131_072 {
+	in, out := entry.limits.Values()
+	if in != 65_536 || out != 131_072 {
 		t.Fatalf("declared input limits = %d/%d, want 65536/131072",
-			entry.maxInputTokens, entry.maxOutputTokens)
+			in, out)
 	}
 }

--- a/driver/qwen/reasoning_contract_test.go
+++ b/driver/qwen/reasoning_contract_test.go
@@ -9,16 +9,15 @@ import (
 	"github.com/GizClaw/flowcraft/core/message"
 )
 
-// TestRedeclaredBuiltinKeepsReasoning locks Qwen's additive overlay
-// contract: a spec declaration can widen a built-in's surface but never
-// drop what the catalog already promises, so redeclaring qwen3.7-max keeps
-// its reasoning toggle and a published toggle still compiles
+// TestRedeclaredBuiltinKeepsReasoning locks the leaf-patch contract:
+// redeclaring qwen3.7-max without naming its reasoning leaf keeps the
+// built-in reasoning toggle, and a published toggle still compiles
 // reasoning_enabled=false.
 func TestRedeclaredBuiltinKeepsReasoning(t *testing.T) {
 	spec, err := decodeSpec(context.Background(), []byte(`{
 		"models": [{
 			"name": "qwen3.7-max",
-			"capabilities": {"inputs": ["text"]}
+			"capabilities": {"outputs": ["text"]}
 		}]
 	}`))
 	if err != nil {
@@ -35,7 +34,7 @@ func TestRedeclaredBuiltinKeepsReasoning(t *testing.T) {
 			entry.capabilities.Reasoning.Kind)
 	}
 	if !equalKinds(entry.capabilities.Inputs, builtin.capabilities.Inputs) {
-		t.Fatalf("redeclaration must not narrow built-in inputs: %v vs %v",
+		t.Fatalf("unstated inputs must be inherited: %v vs %v",
 			entry.capabilities.Inputs, builtin.capabilities.Inputs)
 	}
 	if _, err := compileGenerate("qwen3.7-max", entry)(
@@ -45,6 +44,39 @@ func TestRedeclaredBuiltinKeepsReasoning(t *testing.T) {
 		inference.GenerateExecutionUnary,
 	); err != nil {
 		t.Fatalf("toggle model rejected reasoning off: %v", err)
+	}
+}
+
+// TestRedeclaredBuiltinCanNarrow locks the leaf-replacement direction:
+// a written inputs list narrows the built-in surface while unstated
+// reasoning and limits are inherited.
+func TestRedeclaredBuiltinCanNarrow(t *testing.T) {
+	spec, err := decodeSpec(context.Background(), []byte(`{
+		"models": [{
+			"name": "qwen3.7-max",
+			"capabilities": {"inputs": ["text"]}
+		}]
+	}`))
+	if err != nil {
+		t.Fatalf("decodeSpec: %v", err)
+	}
+	models, err := mergedCatalog(spec)
+	if err != nil {
+		t.Fatalf("mergedCatalog: %v", err)
+	}
+	entry := models["qwen3.7-max"]
+	want := []message.PartKind{message.PartText}
+	if !equalKinds(entry.capabilities.Inputs, want) {
+		t.Fatalf("written inputs must replace the built-in list, got %v",
+			entry.capabilities.Inputs)
+	}
+	if entry.capabilities.Reasoning.Kind != inference.ReasoningToggle {
+		t.Fatalf("unstated reasoning must be inherited, got %q",
+			entry.capabilities.Reasoning.Kind)
+	}
+	in, out := entry.limits.Values()
+	if in != 991_808 || out != 131_072 {
+		t.Fatalf("unstated limits must be inherited, got %d/%d", in, out)
 	}
 }
 
@@ -96,11 +128,43 @@ func equalKinds(a, b []message.PartKind) bool {
 	return true
 }
 
-// TestCustomEmbedDimensionsNotConfigurable guards the capability leaf on
-// Qwen specs: exact sizes come from the built-in whitelist, so a
-// declaration cannot be honored and must fail at decode time.
-func TestCustomEmbedDimensionsNotConfigurable(t *testing.T) {
+// TestCustomEmbedDimensionsFamilyContract guards the capability leaf on
+// Qwen specs: only whitelisted catalog entries carry the capability, so a
+// declaration that tries to grant it to a non-embed model or to a custom
+// embed model fails, while a same-kind redeclaration of a whitelisted
+// entry stays consistent.
+func TestCustomEmbedDimensionsFamilyContract(t *testing.T) {
 	if _, err := decodeSpec(context.Background(), []byte(`{
+		"models": [{
+			"name": "m",
+			"kind": "generate",
+			"capabilities": {
+				"outputs": ["text"],
+				"custom_embed_dimensions": true
+			}
+		}]
+	}`)); err == nil {
+		t.Fatal("custom_embed_dimensions on a generate model unexpectedly accepted")
+	}
+
+	spec, err := decodeSpec(context.Background(), []byte(`{
+		"models": [{
+			"name": "custom-embed",
+			"kind": "embed",
+			"capabilities": {
+				"inputs": ["text"],
+				"custom_embed_dimensions": true
+			}
+		}]
+	}`))
+	if err != nil {
+		t.Fatalf("decodeSpec: %v", err)
+	}
+	if _, err := mergedCatalog(spec); err == nil {
+		t.Fatal("custom embed model without a whitelist unexpectedly accepted")
+	}
+
+	spec, err = decodeSpec(context.Background(), []byte(`{
 		"models": [{
 			"name": "text-embedding-v4",
 			"kind": "embed",
@@ -109,8 +173,16 @@ func TestCustomEmbedDimensionsNotConfigurable(t *testing.T) {
 				"custom_embed_dimensions": true
 			}
 		}]
-	}`)); err == nil {
-		t.Fatal("custom_embed_dimensions on a qwen spec unexpectedly accepted")
+	}`))
+	if err != nil {
+		t.Fatalf("decodeSpec: %v", err)
+	}
+	models, err := mergedCatalog(spec)
+	if err != nil {
+		t.Fatalf("whitelisted redeclaration rejected: %v", err)
+	}
+	if !models["text-embedding-v4"].capabilities.CustomEmbedDimensions {
+		t.Fatal("whitelisted redeclaration lost the custom dimensions capability")
 	}
 }
 

--- a/driver/qwen/reasoning_contract_test.go
+++ b/driver/qwen/reasoning_contract_test.go
@@ -1,0 +1,137 @@
+package qwen
+
+import (
+	"context"
+	"testing"
+
+	"github.com/GizClaw/flowcraft/core/inference"
+	"github.com/GizClaw/flowcraft/core/inference/inferencetest"
+	"github.com/GizClaw/flowcraft/core/message"
+)
+
+// TestRedeclaredBuiltinKeepsReasoning locks Qwen's additive overlay
+// contract: a spec declaration can widen a built-in's surface but never
+// drop what the catalog already promises, so redeclaring qwen3.7-max keeps
+// its reasoning toggle and a published toggle still compiles
+// reasoning_enabled=false.
+func TestRedeclaredBuiltinKeepsReasoning(t *testing.T) {
+	spec, err := decodeSpec(context.Background(), []byte(`{
+		"models": [{
+			"name": "qwen3.7-max",
+			"capabilities": {"inputs": ["text"]}
+		}]
+	}`))
+	if err != nil {
+		t.Fatalf("decodeSpec: %v", err)
+	}
+	models, err := mergedCatalog(spec)
+	if err != nil {
+		t.Fatalf("mergedCatalog: %v", err)
+	}
+	entry := models["qwen3.7-max"]
+	builtin := catalog["qwen3.7-max"]
+	if entry.capabilities.Reasoning.Kind != inference.ReasoningToggle {
+		t.Fatalf("redeclaration must keep reasoning toggle, got %q",
+			entry.capabilities.Reasoning.Kind)
+	}
+	if !equalKinds(entry.capabilities.Inputs, builtin.capabilities.Inputs) {
+		t.Fatalf("redeclaration must not narrow built-in inputs: %v vs %v",
+			entry.capabilities.Inputs, builtin.capabilities.Inputs)
+	}
+	if _, err := compileGenerate("qwen3.7-max", entry)(
+		context.Background(),
+		conformanceModel("qwen3.7-max"),
+		inferencetest.ReasoningOffProbe(),
+		inference.GenerateExecutionUnary,
+	); err != nil {
+		t.Fatalf("toggle model rejected reasoning off: %v", err)
+	}
+}
+
+// TestPublishedToggleCompilesReasoningOff is the generic conformance
+// contract for every built-in toggle model.
+func TestPublishedToggleCompilesReasoningOff(t *testing.T) {
+	spec, err := decodeSpec(context.Background(), []byte(`{}`))
+	if err != nil {
+		t.Fatalf("decodeSpec: %v", err)
+	}
+	models, err := mergedCatalog(spec)
+	if err != nil {
+		t.Fatalf("mergedCatalog: %v", err)
+	}
+	checked := 0
+	for name, entry := range models {
+		if entry.kind != kindGenerate ||
+			entry.capabilities.Reasoning.Kind != inference.ReasoningToggle {
+			continue
+		}
+		checked++
+		compiled, err := compileGenerate(name, entry)(
+			context.Background(),
+			conformanceModel(name),
+			inferencetest.ReasoningOffProbe(),
+			inference.GenerateExecutionUnary,
+		)
+		if err != nil {
+			t.Fatalf("toggle model %q rejected reasoning off: %v", name, err)
+		}
+		if compiled.Report.Rejects(inference.FieldGenerateIntentReasoningEnabled) {
+			t.Fatalf("toggle model %q rejected on the reasoning_enabled field", name)
+		}
+	}
+	if checked == 0 {
+		t.Fatal("no toggle model exercised")
+	}
+}
+
+func equalKinds(a, b []message.PartKind) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+// TestCustomEmbedDimensionsNotConfigurable guards the capability leaf on
+// Qwen specs: exact sizes come from the built-in whitelist, so a
+// declaration cannot be honored and must fail at decode time.
+func TestCustomEmbedDimensionsNotConfigurable(t *testing.T) {
+	if _, err := decodeSpec(context.Background(), []byte(`{
+		"models": [{
+			"name": "text-embedding-v4",
+			"kind": "embed",
+			"capabilities": {
+				"inputs": ["text"],
+				"custom_embed_dimensions": true
+			}
+		}]
+	}`)); err == nil {
+		t.Fatal("custom_embed_dimensions on a qwen spec unexpectedly accepted")
+	}
+}
+
+// TestEmbedWhitelistMatchesPublishedCapability guards the invariant that
+// the published capability and the private size whitelist cannot drift.
+func TestEmbedWhitelistMatchesPublishedCapability(t *testing.T) {
+	base := catalogEntry{
+		kind:         kindEmbed,
+		capabilities: inference.ModelCapabilities{}.WithInputs(message.PartText),
+	}
+	if err := base.validate(); err != nil {
+		t.Fatalf("consistent zero declaration rejected: %v", err)
+	}
+	claimWithoutSizes := base
+	claimWithoutSizes.capabilities.CustomEmbedDimensions = true
+	if err := claimWithoutSizes.validate(); err == nil {
+		t.Fatal("capability without a whitelist unexpectedly accepted")
+	}
+	sizesWithoutClaim := base
+	sizesWithoutClaim.embedDimensions = []int{64}
+	if err := sizesWithoutClaim.validate(); err == nil {
+		t.Fatal("whitelist without the capability unexpectedly accepted")
+	}
+}

--- a/driver/qwen/spec.go
+++ b/driver/qwen/spec.go
@@ -35,14 +35,18 @@ type Spec struct {
 	Models []ModelSpec `json:"models,omitempty"`
 }
 
-// ModelSpec declares one model the deployment serves.
+// ModelSpec declares one model outside the built-in catalog, or a delta
+// over a same-named, same-kind built-in catalog entry. Capabilities is a
+// patch with field-presence semantics: leaves it names replace that leaf
+// of the entry it overrides and leaves it does not name are inherited.
+// Embed dimension sizes stay catalog facts backed by a private whitelist,
+// so a declaration cannot grant custom_embed_dimensions to a model without
+// one.
 type ModelSpec struct {
 	Name string `json:"name"`
 	Kind string `json:"kind"`
-	// Capabilities declares the model's input/output content kinds and the
-	// reasoning control capability. Spec declarations overlay catalog
-	// entries additively (inputs/outputs union, reasoning overrides).
-	Capabilities inference.ModelCapabilities `json:"capabilities,omitempty"`
+	// Capabilities declares the capability leaves this model changes.
+	Capabilities *inference.CapabilitiesPatch `json:"capabilities,omitempty"`
 	// Limits declares numeric capacity limits for the model. Overriding a
 	// built-in catalog entry by name keeps the catalog limit for any field
 	// left nil; declaring a value replaces it.
@@ -63,11 +67,14 @@ func (m ModelSpec) Validate() error {
 	default:
 		return fmt.Errorf("model %q declares unsupported kind %q", m.Name, m.Kind)
 	}
-	if m.Capabilities.CustomEmbedDimensions {
+	if kind := modelKind(m.Kind); kind != "" && kind != kindEmbed &&
+		m.Capabilities != nil &&
+		m.Capabilities.CustomEmbedDimensions != nil &&
+		*m.Capabilities.CustomEmbedDimensions {
 		return fmt.Errorf(
-			"model %q declares custom_embed_dimensions, but qwen embed "+
-				"sizes come from the built-in catalog whitelist",
+			"model %q sets custom_embed_dimensions on kind %q",
 			m.Name,
+			m.Kind,
 		)
 	}
 	if err := m.Capabilities.Validate(); err != nil {

--- a/driver/qwen/spec.go
+++ b/driver/qwen/spec.go
@@ -63,6 +63,13 @@ func (m ModelSpec) Validate() error {
 	default:
 		return fmt.Errorf("model %q declares unsupported kind %q", m.Name, m.Kind)
 	}
+	if m.Capabilities.CustomEmbedDimensions {
+		return fmt.Errorf(
+			"model %q declares custom_embed_dimensions, but qwen embed "+
+				"sizes come from the built-in catalog whitelist",
+			m.Name,
+		)
+	}
 	if err := m.Capabilities.Validate(); err != nil {
 		return err
 	}

--- a/skills/flowcraft-config/references/pitfalls.md
+++ b/skills/flowcraft-config/references/pitfalls.md
@@ -53,6 +53,18 @@ builds the deployment with its own factory registry, or at runtime.
     field is reported `dropped` in the compile report. Inspect
     `response.metadata.decisions` (or `Explain`) when metadata seems
     missing upstream — host build/runtime.
+17. Model declarations are leaf patches: redeclaring a built-in model by
+    name and kind inherits every capability leaf, limit, and driver control
+    fact the declaration does not state. Do not re-state the full catalog
+    entry, and do not assume an omitted leaf is removed — write
+    `hosted_web_search: false` or an explicit list to express removal.
+    Qwen and Kimi declarations are additive only (they cannot narrow) —
+    host build.
+18. `effort_none` (OpenAI/Azure) and the top-level `dimensions:` key
+    (OpenAI/Azure/Bytedance) were removed: strict decoding reports them as
+    unknown fields. OpenAI-family reasoning off is implied by
+    `reasoning: toggle`; embed custom dimensions now live under
+    `capabilities.custom_embed_dimensions` — host build.
 
 ## Error map
 

--- a/skills/flowcraft-config/references/pitfalls.md
+++ b/skills/flowcraft-config/references/pitfalls.md
@@ -58,8 +58,10 @@ builds the deployment with its own factory registry, or at runtime.
     fact the declaration does not state. Do not re-state the full catalog
     entry, and do not assume an omitted leaf is removed — write
     `hosted_web_search: false` or an explicit list to express removal.
-    Qwen and Kimi declarations are additive only (they cannot narrow) —
-    host build.
+    Qwen and Kimi accept the same leaf patches; Qwen embed dimension sizes
+    still come from the built-in whitelist, so `custom_embed_dimensions`
+    can only be restated on those entries, never granted elsewhere — host
+    build.
 18. `effort_none` (OpenAI/Azure) and the top-level `dimensions:` key
     (OpenAI/Azure/Bytedance) were removed: strict decoding reports them as
     unknown fields. OpenAI-family reasoning off is implied by

--- a/skills/flowcraft-config/references/resources.md
+++ b/skills/flowcraft-config/references/resources.md
@@ -46,15 +46,14 @@ application from provider driver modules (outside `core/`).
 ## Model declarations
 
 `spec.models` entries extend a provider's built-in catalog or override an
-entry by name. For drivers with a built-in line-up (Anthropic, Bytedance,
-DeepSeek, MiniMax, OpenAI), an entry that names a built-in model under the
-same kind is a **leaf-level patch**: capability leaves the entry writes
-replace only those leaves, and everything unstated — other capability
-leaves, numeric limits, and driver control facts such as Bytedance's
-`max_resolution` — is inherited from the built-in entry. Unknown names
-start from the conservative zero base, so every published capability must
-be stated. Qwen and Kimi are additive only: a declaration can widen a
-built-in surface but never narrow it.
+entry by name. An entry that names a built-in model under the same kind is
+a **leaf-level patch**: capability leaves the entry writes replace only
+those leaves, and everything unstated — other capability leaves, numeric
+limits, and driver control facts such as Bytedance's `max_resolution` —
+is inherited from the built-in entry. Unknown names start from the
+conservative zero base, so every published capability must be stated.
+Qwen and Kimi follow the same leaf semantics as the catalog-backed
+drivers.
 
 Reasoning kind `toggle` is a promise that `reasoning_enabled=false`
 compiles on that provider surface; models whose wire cannot turn reasoning
@@ -67,7 +66,8 @@ Embed models that accept custom output dimensions declare the capability
 leaf `custom_embed_dimensions` (OpenAI, Azure, Bytedance). The old
 top-level `dimensions:` key is gone, drivers without an embed family reject
 the leaf, and Qwen's accepted sizes come from its built-in catalog
-whitelist rather than the declaration.
+whitelist — a declaration can restate the leaf on a whitelisted entry but
+cannot grant it to a model without one.
 
 Routing prefers targets whose declared outputs cover the request intent
 and skips declared-incompatible tiers.

--- a/skills/flowcraft-config/references/resources.md
+++ b/skills/flowcraft-config/references/resources.md
@@ -17,11 +17,11 @@ spec:
   models:               # optional: declare/override catalog models
     - name: deepseek-v4-flash
       kind: generate
-      capabilities:     # optional: content kinds, hosted web search, reasoning control
+      capabilities:     # optional: capability leaves (see "Model declarations" below)
         inputs: [text, data, tool_call, tool_result]
         outputs: [text]
         reasoning:
-          kind: toggle     # "always" or "toggle"; legacy string "toggle" is still accepted
+          kind: toggle     # "always" or "toggle" (legacy string form accepted); toggle promises reasoning_enabled=false compiles on this surface
           effort_map:      # optional: canonical effort -> model wire level
             minimal: low
             low: low
@@ -29,7 +29,6 @@ spec:
             high: high
             xhigh: max
         hosted_web_search: true
-      responses: true
 profiles:
   - secrets:
       api_key: ${env:DEEPSEEK_API_KEY}
@@ -41,11 +40,37 @@ variable, `${base:rel}` / `~` / `${home:rel}` for paths, `${secret:NAME}`
 or `${secret:store.NAME}` for declared `secret.Store` backends); a missing
 variable fails the build. The deploy builder expands every settings
 subtree with env/home/base enabled by default — literal `${` must be
-escaped as `\${...}`. Model capabilities mirror the built-in catalog shape and are
-validated by the driver; routing prefers targets whose declared outputs
-cover the request intent and skips declared-incompatible tiers. Provider
-drivers are registered by the host application from provider driver
-modules (outside `core/`).
+escaped as `\${...}`. Provider drivers are registered by the host
+application from provider driver modules (outside `core/`).
+
+## Model declarations
+
+`spec.models` entries extend a provider's built-in catalog or override an
+entry by name. For drivers with a built-in line-up (Anthropic, Bytedance,
+DeepSeek, MiniMax, OpenAI), an entry that names a built-in model under the
+same kind is a **leaf-level patch**: capability leaves the entry writes
+replace only those leaves, and everything unstated — other capability
+leaves, numeric limits, and driver control facts such as Bytedance's
+`max_resolution` — is inherited from the built-in entry. Unknown names
+start from the conservative zero base, so every published capability must
+be stated. Qwen and Kimi are additive only: a declaration can widen a
+built-in surface but never narrow it.
+
+Reasoning kind `toggle` is a promise that `reasoning_enabled=false`
+compiles on that provider surface; models whose wire cannot turn reasoning
+off publish `always` instead. OpenAI-family reasoning off is
+`reasoning.effort: "none"` and needs no per-model knob (`effort_none` was
+removed); OpenAI `api: chat` catalogs always publish `always` because the
+chat surface has no off route.
+
+Embed models that accept custom output dimensions declare the capability
+leaf `custom_embed_dimensions` (OpenAI, Azure, Bytedance). The old
+top-level `dimensions:` key is gone, drivers without an embed family reject
+the leaf, and Qwen's accepted sizes come from its built-in catalog
+whitelist rather than the declaration.
+
+Routing prefers targets whose declared outputs cover the request intent
+and skips declared-incompatible tiers.
 
 `request_metadata.envelope` names the top-level body field that receives
 canonical `GenerateRequest.RequestMetadata`. It is supported by the


### PR DESCRIPTION
## Summary

Fixes the class of bugs where a model descriptor promises a capability the compiler cannot honor (e.g. #509: redeclaring a built-in OpenAI model silently dropped its reasoning-off route) by making capability declarations and the reasoning contract explicit and shared.

**Core (`core/inference`)**
- New `CapabilitiesPatch` / `ReasoningPatch` with leaf-presence overlay semantics: leaves a spec writes replace only those leaves; unstated leaves, numeric limits, and driver control facts are inherited. The legacy `reasoning: "toggle"` string form stays backward compatible and now patches only the kind.
- `ModelCapabilities.CustomEmbedDimensions` published as a per-model capability bit (alongside `hosted_web_search`), so descriptors and hosts see embed custom-dimension support without driver-specific knowledge.
- `ModelLimits` gains `WithMaxInputTokens` / `WithMaxOutputTokens` / `Values`; catalog entries now resolve limits through the shared type.
- Reasoning contract tightened: `toggle` promises `reasoning_enabled=false` compiles on the publishing provider surface, `always` rejects it. Added the shared `ReasoningOffProbe` conformance helper plus core tests.

**Drivers (anthropic, azure, bytedance, deepseek, kimi, minimax, openai, qwen)**
- Migrated catalog merges to the leaf-level overlay and resolved `ModelLimits`; removed the duplicated limit conversion code in every `descriptorFor`.
- Removed driver-private control flags: `effort_none` (openai/azure), top-level `dimensions:` (openai/azure/bytedance; now `capabilities.custom_embed_dimensions`), per-model `responses` (deepseek — the line-up fully supports the Responses API, so `api: responses` serves every generate model).
- OpenAI chat catalogs publish reasoning `always` (the chat surface has no off route); spec-declared models are lowered the same way.
- Every driver gained conformance coverage that published `toggle` models compile `reasoning_enabled=false`, plus overlay/limits/guard contract tests.

**Docs**
- `docs/guides/inference.md`, `skills/flowcraft-config/references/resources.md`, and `pitfalls.md` updated for the new model-declaration semantics and removed keys.

## Breaking config migration

Strict decoding now rejects these removed keys — delete them:
- `effort_none` (openai/azure): reasoning off is implied by `reasoning: toggle`; use `reasoning: always` when the model cannot be disabled.
- top-level `dimensions:` (openai/azure/bytedance): move to `capabilities.custom_embed_dimensions`.
- `responses` (deepseek): provider-level `api: responses` now serves every generate model.

## Checks

- `make ci`, `make lint`, `make release-check`, `make release-preflight`, `git diff --check` all pass.
- Core changeset added: `core v0.2.6 -> v0.2.7 (patch)`.

## Follow-up

After core v0.2.7 is tagged, bump the driver modules' `core` requirement to v0.2.7 (the same pattern as #508), since driver releases are not managed by this repo's changesets.

Closes #509