### PR TITLE
feat(core/runtime): add WithResolver for custom expansion schemes

### DIFF
--- a/core/runtime/builder.go
+++ b/core/runtime/builder.go
@@ -40,6 +40,7 @@ type Builder struct {
 	hostDecorator       HostFactoryDecorator
 	resultHostDecorator ResultHostFactoryDecorator
 	loader              *resource.Loader
+	resolver            *resource.ReferenceResolver
 	externalResources   []ExternalResource
 }
 
@@ -113,6 +114,33 @@ func (b *Builder) WithLoader(loader *resource.Loader) error {
 		return errdefs.Validationf("runtime loader is already set")
 	}
 	b.loader = loader
+	return nil
+}
+
+// WithResolver adds custom expansion schemes for inline ${scheme:ref}
+// strings in every settings subtree (resources, agent engines, agent
+// hooks) before a factory decodes them. The custom schemes are merged
+// on top of the deployment's all-open default resolver (env + home,
+// plus base when a loader with a base directory is installed); a custom
+// scheme of the same name overrides the built-in one, except
+// ${secret:...}, which is assembled after the merge and always wins.
+// It is rejected when nil, when already set, or after Build starts.
+func (b *Builder) WithResolver(resolver *resource.ReferenceResolver) error {
+	if b == nil {
+		return errdefs.Validationf("runtime Builder is nil")
+	}
+	if resolver == nil {
+		return errdefs.Validationf("runtime resolver is nil")
+	}
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if b.used {
+		return ErrBuilderUsed
+	}
+	if b.resolver != nil {
+		return errdefs.Validationf("runtime resolver is already set")
+	}
+	b.resolver = resolver
 	return nil
 }
 
@@ -193,11 +221,13 @@ func (b *Builder) Build(ctx context.Context, doc deploy.Document) (*Runtime, err
 		}
 		deployOptions = append(deployOptions, deploy.WithExternalResources(deployValues))
 	}
-	deployBuilder := deploy.NewBuilder(reg, deployOptions...)
 	if b.loader != nil {
 		deployOptions = append(deployOptions, deploy.WithLoader(b.loader))
-		deployBuilder = deploy.NewBuilder(reg, deployOptions...)
 	}
+	if b.resolver != nil {
+		deployOptions = append(deployOptions, deploy.WithResolver(b.resolver))
+	}
+	deployBuilder := deploy.NewBuilder(reg, deployOptions...)
 	result, err := deployBuilder.Deploy(ctx, doc)
 	if err != nil {
 		return nil, fmt.Errorf("runtime build deployment: %w", err)
@@ -320,6 +350,7 @@ func (b *Builder) Build(ctx context.Context, doc deploy.Document) (*Runtime, err
 		liveCatalog:         liveCatalog,
 		resources:           reg,
 		loader:              b.loader,
+		resolver:            b.resolver,
 		bus:                 bus,
 		hostDecorator:       b.hostDecorator,
 		resultHostDecorator: b.resultHostDecorator,

--- a/core/runtime/builder.go
+++ b/core/runtime/builder.go
@@ -117,14 +117,12 @@ func (b *Builder) WithLoader(loader *resource.Loader) error {
 	return nil
 }
 
-// WithResolver adds custom expansion schemes for inline ${scheme:ref}
+// WithResolver registers custom schemes for inline ${scheme:ref}
 // strings in every settings subtree (resources, agent engines, agent
-// hooks) before a factory decodes them. The custom schemes are merged
-// on top of the deployment's all-open default resolver (env + home,
-// plus base when a loader with a base directory is installed); a custom
-// scheme of the same name overrides the built-in one, except
-// ${secret:...}, which is assembled after the merge and always wins.
-// It is rejected when nil, when already set, or after Build starts.
+// hooks) before a factory decodes them. Expansion semantics are
+// identical to deploy.WithResolver, which this option passes through
+// unchanged; see that option for the authoritative merge rules. It is
+// rejected when nil, when already set, or after Build starts.
 func (b *Builder) WithResolver(resolver *resource.ReferenceResolver) error {
 	if b == nil {
 		return errdefs.Validationf("runtime Builder is nil")

--- a/core/runtime/reload.go
+++ b/core/runtime/reload.go
@@ -126,11 +126,13 @@ func (r *Runtime) Reload(
 		}
 		deployOptions = append(deployOptions, deploy.WithExternalResources(deployValues))
 	}
-	deployBuilder := deploy.NewBuilder(r.resources, deployOptions...)
 	if r.loader != nil {
 		deployOptions = append(deployOptions, deploy.WithLoader(r.loader))
-		deployBuilder = deploy.NewBuilder(r.resources, deployOptions...)
 	}
+	if r.resolver != nil {
+		deployOptions = append(deployOptions, deploy.WithResolver(r.resolver))
+	}
+	deployBuilder := deploy.NewBuilder(r.resources, deployOptions...)
 	newResult, err := deployBuilder.Deploy(ctx, doc)
 	if err != nil {
 		return fail(fmt.Errorf("runtime reload build deployment: %w", err))

--- a/core/runtime/resolver_test.go
+++ b/core/runtime/resolver_test.go
@@ -1,0 +1,264 @@
+package runtime
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/GizClaw/flowcraft/core/deploy"
+	"github.com/GizClaw/flowcraft/core/errdefs"
+	"github.com/GizClaw/flowcraft/core/event"
+	"github.com/GizClaw/flowcraft/core/resource"
+)
+
+const (
+	captureKind = "resolver.test"
+	captureImpl = "capture"
+)
+
+// captureEntry is one decoded settings record from a resolver capture
+// resource, so tests can assert what the resolver-merged expansion
+// pass materialized per build generation.
+type captureEntry struct {
+	root string
+	name string
+}
+
+type captureRecorder struct {
+	mu      sync.Mutex
+	entries []captureEntry
+}
+
+func (r *captureRecorder) add(entry captureEntry) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.entries = append(r.entries, entry)
+}
+
+func (r *captureRecorder) got() []captureEntry {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	out := make([]captureEntry, len(r.entries))
+	copy(out, r.entries)
+	return out
+}
+
+// resolverCaptureFactory decodes the expanded settings of one
+// "resolver.test" resource and records what it saw.
+type resolverCaptureFactory struct {
+	records *captureRecorder
+}
+
+func (f resolverCaptureFactory) Spec() resource.Spec {
+	return resource.Spec{Kind: captureKind, Impl: captureImpl}
+}
+
+func (f resolverCaptureFactory) New(_ context.Context, in resource.Input) (any, error) {
+	var settings struct {
+		Root string `json:"root"`
+		Name string `json:"name"`
+	}
+	if err := json.Unmarshal(in.Settings, &settings); err != nil {
+		return nil, err
+	}
+	f.records.add(captureEntry{root: settings.Root, name: settings.Name})
+	return &struct{}{}, nil
+}
+
+// ocwsResolver returns a resolver exposing a single "ocws" scheme that
+// maps reference paths through values, standing in for a consumer's
+// per-workspace configuration source.
+func ocwsResolver(values map[string]string) *resource.ReferenceResolver {
+	return resource.NewResolver(resource.SchemeFunc{
+		SchemeName: "ocws",
+		Fn: func(_ context.Context, ref resource.Reference) (any, error) {
+			value, ok := values[ref.Path]
+			if !ok {
+				return "", errdefs.Validationf("ocws: unknown ref %q", ref.Path)
+			}
+			return value, nil
+		},
+	})
+}
+
+// resolverCaptureDoc returns a reload-shaped runtime doc whose agents
+// use the append engine and whose extra "cap" resource carries the
+// given raw settings JSON, expanded through the runtime's resolver.
+func resolverCaptureDoc(t *testing.T, settings string) deploy.Document {
+	t.Helper()
+	doc := reloadDoc(t, `  bot:
+    card: {name: Bot}
+    engine: {kind: append-engine}
+`, "")
+	doc.Resources["cap"] = resource.Resource{
+		Kind:     captureKind,
+		Impl:     captureImpl,
+		Settings: json.RawMessage(settings),
+	}
+	return doc
+}
+
+func newCaptureRegistry(t *testing.T, records *captureRecorder) *resource.Registry {
+	t.Helper()
+	reg := resource.NewRegistry()
+	reg.MustRegister(resolverCaptureFactory{records: records})
+	reg.MustRegister(event.NewFactory())
+	reg.MustRegister(appendEngineFactory{})
+	return reg
+}
+
+func assertEntries(t *testing.T, got, want []captureEntry) {
+	t.Helper()
+	if len(got) != len(want) {
+		t.Fatalf("captured settings = %+v, want %+v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("captured settings = %+v, want %+v", got, want)
+		}
+	}
+}
+
+func TestWithResolverValidation(t *testing.T) {
+	builder := NewBuilder(resource.NewRegistry())
+	if err := builder.WithResolver(nil); !errdefs.IsValidation(err) {
+		t.Fatalf("nil resolver error = %v, want validation", err)
+	}
+	if err := builder.WithResolver(ocwsResolver(nil)); err != nil {
+		t.Fatalf("first resolver: %v", err)
+	}
+	err := builder.WithResolver(ocwsResolver(nil))
+	if err == nil || !errdefs.IsValidation(err) ||
+		!strings.Contains(err.Error(), "already set") {
+		t.Fatalf("duplicate resolver error = %v, want validation mentioning already set", err)
+	}
+}
+
+func TestBuildExpandsCustomScheme(t *testing.T) {
+	records := &captureRecorder{}
+	builder := NewBuilder(newCaptureRegistry(t, records))
+	if err := builder.WithResolver(ocwsResolver(map[string]string{
+		"root": "/srv/ocws", "name": "alpha",
+	})); err != nil {
+		t.Fatalf("WithResolver: %v", err)
+	}
+	app, err := builder.Build(context.Background(),
+		resolverCaptureDoc(t, `{"root": "${ocws:root}", "name": "${ocws:name}"}`))
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	defer func() { _ = app.Close() }()
+
+	assertEntries(t, records.got(),
+		[]captureEntry{{root: "/srv/ocws", name: "alpha"}})
+	if err := builder.WithResolver(ocwsResolver(nil)); !errors.Is(err, ErrBuilderUsed) {
+		t.Fatalf("WithResolver after Build error = %v, want ErrBuilderUsed", err)
+	}
+}
+
+func TestBuildRejectsUnknownSchemeWithoutResolver(t *testing.T) {
+	records := &captureRecorder{}
+	_, err := NewBuilder(newCaptureRegistry(t, records)).Build(
+		context.Background(), resolverCaptureDoc(t, `{"root": "${ocws:root}"}`))
+	if err == nil || !strings.Contains(err.Error(), `scheme "ocws" is not enabled`) {
+		t.Fatalf("Build error = %v, want unresolved custom scheme error", err)
+	}
+}
+
+func TestWithResolverKeepsBuiltinSchemes(t *testing.T) {
+	t.Setenv("RESOLVER_TEST_ENV", "/from-env")
+	records := &captureRecorder{}
+	builder := NewBuilder(newCaptureRegistry(t, records))
+	if err := builder.WithResolver(ocwsResolver(map[string]string{
+		"name": "cfg",
+	})); err != nil {
+		t.Fatalf("WithResolver: %v", err)
+	}
+	app, err := builder.Build(context.Background(), resolverCaptureDoc(t,
+		`{"root": "${env:RESOLVER_TEST_ENV}", "name": "${ocws:name}"}`))
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	defer func() { _ = app.Close() }()
+
+	assertEntries(t, records.got(),
+		[]captureEntry{{root: "/from-env", name: "cfg"}})
+}
+
+func TestReloadKeepsCustomResolver(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+	records := &captureRecorder{}
+	reg := newCaptureRegistry(t, records)
+	values := map[string]string{"first": "one", "second": "two"}
+	builder := NewBuilder(reg)
+	if err := builder.WithResolver(ocwsResolver(values)); err != nil {
+		t.Fatalf("WithResolver: %v", err)
+	}
+	app, err := builder.Build(ctx,
+		resolverCaptureDoc(t, `{"root": "${ocws:first}", "name": "${ocws:second}"}`))
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	t.Cleanup(func() { _ = app.Close() })
+
+	reloaded, err := app.Reload(ctx,
+		resolverCaptureDoc(t, `{"root": "${ocws:second}", "name": "${ocws:first}"}`))
+	if err != nil {
+		t.Fatalf("Reload: %v", err)
+	}
+	if reloaded == nil {
+		t.Fatal("Reload returned a nil result")
+	}
+	assertEntries(t, records.got(), []captureEntry{
+		{root: "one", name: "two"},
+		{root: "two", name: "one"},
+	})
+}
+
+func TestResolverIsolationAcrossBuilds(t *testing.T) {
+	doc := resolverCaptureDoc(t, `{"root": "${ocws:root}"}`)
+	build := func(values map[string]string) (*Runtime, []captureEntry, error) {
+		records := &captureRecorder{}
+		builder := NewBuilder(newCaptureRegistry(t, records))
+		if err := builder.WithResolver(ocwsResolver(values)); err != nil {
+			return nil, nil, err
+		}
+		app, err := builder.Build(context.Background(), doc)
+		if err != nil {
+			return nil, nil, err
+		}
+		return app, records.got(), nil
+	}
+	var wg sync.WaitGroup
+	apps := make([]*Runtime, 2)
+	entries := make([][]captureEntry, 2)
+	errs := make([]error, 2)
+	for i := range apps {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			if i == 0 {
+				apps[i], entries[i], errs[i] = build(
+					map[string]string{"root": "workspace-a"})
+				return
+			}
+			apps[i], entries[i], errs[i] = build(
+				map[string]string{"root": "workspace-b"})
+		}()
+	}
+	wg.Wait()
+	for i := range apps {
+		if errs[i] != nil {
+			t.Fatalf("build %d: %v", i, errs[i])
+		}
+		app := apps[i]
+		t.Cleanup(func() { _ = app.Close() })
+	}
+	assertEntries(t, entries[0], []captureEntry{{root: "workspace-a"}})
+	assertEntries(t, entries[1], []captureEntry{{root: "workspace-b"}})
+}

--- a/core/runtime/resolver_test.go
+++ b/core/runtime/resolver_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/GizClaw/flowcraft/core/agent"
 	"github.com/GizClaw/flowcraft/core/deploy"
 	"github.com/GizClaw/flowcraft/core/errdefs"
 	"github.com/GizClaw/flowcraft/core/event"
@@ -67,6 +68,37 @@ func (f resolverCaptureFactory) New(_ context.Context, in resource.Input) (any, 
 	}
 	f.records.add(captureEntry{root: settings.Root, name: settings.Name})
 	return &struct{}{}, nil
+}
+
+// resolverCaptureEngineFactory decodes the expanded settings of one
+// agent engine and records what it saw, so tests can assert that the
+// runtime's resolver reaches engine settings subtrees, not only
+// resource settings.
+type resolverCaptureEngineFactory struct {
+	records *captureRecorder
+}
+
+func (resolverCaptureEngineFactory) Spec() resource.Spec {
+	return resource.Spec{Kind: "resolver.test.engine"}
+}
+
+func (f resolverCaptureEngineFactory) New(_ context.Context, in resource.Input) (any, error) {
+	var settings struct {
+		Root string `json:"root"`
+		Name string `json:"name"`
+	}
+	if err := json.Unmarshal(in.Settings, &settings); err != nil {
+		return nil, err
+	}
+	f.records.add(captureEntry{root: settings.Root, name: settings.Name})
+	return agent.EngineFunc(func(
+		_ context.Context,
+		_ agent.Run,
+		_ agent.Host,
+		board *agent.Board,
+	) (*agent.Board, error) {
+		return board, nil
+	}), nil
 }
 
 // ocwsResolver returns a resolver exposing a single "ocws" scheme that
@@ -136,6 +168,19 @@ func TestWithResolverValidation(t *testing.T) {
 		!strings.Contains(err.Error(), "already set") {
 		t.Fatalf("duplicate resolver error = %v, want validation mentioning already set", err)
 	}
+
+	// A consumed builder rejects any further option set, even when the
+	// Build attempt itself failed.
+	if _, err := builder.Build(context.Background(),
+		reloadDoc(t, `  bot:
+    card: {name: Bot}
+    engine: {kind: append-engine}
+`, "")); err == nil {
+		t.Fatal("Build over an empty registry: want error")
+	}
+	if err := builder.WithResolver(ocwsResolver(nil)); !errors.Is(err, ErrBuilderUsed) {
+		t.Fatalf("WithResolver after Build error = %v, want ErrBuilderUsed", err)
+	}
 }
 
 func TestBuildExpandsCustomScheme(t *testing.T) {
@@ -155,9 +200,42 @@ func TestBuildExpandsCustomScheme(t *testing.T) {
 
 	assertEntries(t, records.got(),
 		[]captureEntry{{root: "/srv/ocws", name: "alpha"}})
-	if err := builder.WithResolver(ocwsResolver(nil)); !errors.Is(err, ErrBuilderUsed) {
-		t.Fatalf("WithResolver after Build error = %v, want ErrBuilderUsed", err)
+}
+
+// TestBuildExpandsEngineSettings pins the pass-through contract at the
+// runtime layer: a custom scheme inside an agent engine's settings
+// subtree expands before the engine factory decodes them, exactly like
+// resource settings. Runtime consumers (per-workspace configuration in
+// engine or hook settings) rely on this path.
+func TestBuildExpandsEngineSettings(t *testing.T) {
+	records := &captureRecorder{}
+	reg := resource.NewRegistry()
+	reg.MustRegister(event.NewFactory())
+	reg.MustRegister(resolverCaptureEngineFactory{records: records})
+
+	doc := reloadDoc(t, `  bot:
+    card: {name: Bot}
+    engine: {kind: resolver.test.engine}
+`, "")
+	bot := doc.Agents["bot"]
+	bot.Engine.Settings = json.RawMessage(
+		`{"root": "${ocws:root}", "name": "${ocws:name}"}`)
+	doc.Agents["bot"] = bot
+
+	builder := NewBuilder(reg)
+	if err := builder.WithResolver(ocwsResolver(map[string]string{
+		"root": "/srv/ocws", "name": "alpha",
+	})); err != nil {
+		t.Fatalf("WithResolver: %v", err)
 	}
+	app, err := builder.Build(context.Background(), doc)
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	defer func() { _ = app.Close() }()
+
+	assertEntries(t, records.got(),
+		[]captureEntry{{root: "/srv/ocws", name: "alpha"}})
 }
 
 func TestBuildRejectsUnknownSchemeWithoutResolver(t *testing.T) {

--- a/core/runtime/runtime.go
+++ b/core/runtime/runtime.go
@@ -33,7 +33,11 @@ type Runtime struct {
 	// resolution as deployment time.
 	resources *resource.Registry
 	loader    *resource.Loader
-	bus       event.Bus
+	// resolver is retained from the Builder (like loader) so a later
+	// Reload rebuilds generations with the same custom expansion
+	// schemes as the initial build.
+	resolver *resource.ReferenceResolver
+	bus      event.Bus
 	// hostDecorator is retained from the Builder so a later Reload can
 	// rebuild a host factory for a new deployment generation with the
 	// exact same decoration policy.


### PR DESCRIPTION
## Summary

Closes #513. Adds `runtime.Builder.WithResolver(*resource.ReferenceResolver)` so runtime-level consumers can register custom `${scheme:ref}` expansion schemes (e.g. a per-workspace config scheme) without writing process-global environment variables.

Mirrors `WithLoader` exactly: nil / duplicate set / use-after-`Build` are all rejected (validation errors / `ErrBuilderUsed`). Semantics are pass-through to `deploy.WithResolver` — custom schemes merge **on top of** the all-open default resolver (env + home + base); a custom scheme shadows built-in ones, except `${secret:...}` which is assembled after the merge and always wins.

## The reload gap

`Runtime.Reload` builds a second, independent deploy builder from values retained on `Runtime`. The resolver is now retained (like `loader`) and wired into the reload path too; otherwise a reload silently dropped custom schemes and documents using them would fail to expand on the next generation.

Also collapses a double `deploy.NewBuilder` construction in `Build` and `Reload` (behavior-preserving cleanup).

## Tests (`core/runtime/resolver_test.go`)

- `TestWithResolverValidation` — nil / duplicate / after-Build tri-state
- `TestBuildExpandsCustomScheme` — custom scheme resolves in resource settings
- `TestBuildRejectsUnknownSchemeWithoutResolver` — regression baseline for today's behavior
- `TestWithResolverKeepsBuiltinSchemes` — merge semantics, not replacement
- `TestReloadKeepsCustomResolver` — regression for the reload gap
- `TestResolverIsolationAcrossBuilds` — same scheme name, per-build values, concurrent under `-race`

## Verification

- New tests pass, incl. `-race`; full `core/runtime` suite passes
- `go vet ./runtime/...`, `gofmt -l` clean, `git diff --check` clean
- `make ci` green across all modules (core, drivers, backends, examples/forge)

No `.release/` changeset in this PR (added at tagging time per repo rule). Note: lazy-bound dynamic agents (`lifecycle.go`) still expand with the default resolver only — pre-existing gap shared with `${secret:...}`, tracked separately.
