### PR TITLE
chore(release): add core v0.2.8 changeset

### DIFF
--- a/.release/core-v0.2.8.json
+++ b/.release/core-v0.2.8.json
@@ -1,0 +1,9 @@
+{
+  "summary": "feat(core/runtime): add WithResolver for custom expansion schemes (closes #513) — the runtime builder can now register custom ${scheme:ref} expansion schemes via WithResolver, passed through unchanged to deploy.WithResolver so per-workspace configuration sources resolve inside resource, agent-engine, and agent-hook settings subtrees before factories decode them; custom schemes shadow same-named built-ins while ${secret:...} always wins, the built-in env/base/home schemes stay available unless overridden, Reload keeps the resolver across generations, and runtime-layer tests pin engine-settings expansion rather than leaving that contract to deploy-layer tests alone",
+  "releases": [
+    {
+      "module": "core",
+      "bump": "patch"
+    }
+  ]
+}


### PR DESCRIPTION
Adds `.release/core-v0.2.8.json` so the Release modules workflow can tag core v0.2.8 (patch).

**Delta since core/v0.2.7** (single commit): `feat(core/runtime): add WithResolver for custom expansion schemes` (#514, closes #513) — additive runtime API, no breaking change, no dependency drift, so no driver coordination or preflight needed.

`make release-check` and `make release-plan` both confirm: `core: 0.2.7 -> 0.2.8 (patch), tag core/v0.2.8`.