### PR TITLE
feat(core): stream truncation diagnostics, synthesized-finish signal, and first-class stream failure policy

### DIFF
--- a/.release/core-v0.3.0.json
+++ b/.release/core-v0.3.0.json
@@ -1,0 +1,9 @@
+{
+  "summary": "feat(core/inference): surface generate-stream truncation and finish integrity to callers — streams that end before a terminal finish classify as ProviderTruncated (NotAvailable/503, never auto-retried by core; attempt-void semantics live at the caller), failures carry stable Error.Detail stage labels plus provider request/response ids captured at stream open via the optional ProviderStreamMetadata contract (x-request-id/apim-request-id headers, envelope/message ids), error spans mirror inference.error.detail and llm ids, and adapter-synthesized chat finishes are marked FinishSynthesized end to end on the generate event and response and mirrored as inference.finish.synthesized on success spans, with core rejecting a synthesized flag that carries no finish reason; feat(core/graph,core/agent): make stream failure handling a first-class inference-node policy — MessageStream gains an explicit Drop terminal, the inference node exposes stream_failure_policy {on_error,on_interrupt} with commit_partial (default) or discard actions classified per termination category (errdefs aborted/interrupted markers), recoverable undefined-tool streams discard partial text at the drain site so recovered rounds keep a clean transcript, partial usage reporting stays policy-independent, and stream-delta events are documented as advisory previews with board channels authoritative",
+  "releases": [
+    {
+      "module": "core",
+      "bump": "minor"
+    }
+  ]
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,13 +10,19 @@ Release PR before their tags are published.
 
 | Module | Latest tag | Notes |
 | --- | --- | --- |
-| `core` | `core/v0.2.8` | Unified platform module: contracts, deploy, runtime, and built-in resources. |
+| `core` | `core/v0.3.0` | Unified platform module: contracts, deploy, runtime, and built-in resources. |
 
 ## [Unreleased]
 
 _No pending changes._
 
 <!-- releasegate:releases -->
+
+## `core/v0.3.0` - 2026-09-08
+
+### Changed
+
+- feat(core/inference): surface generate-stream truncation and finish integrity to callers — streams that end before a terminal finish classify as ProviderTruncated (NotAvailable/503, never auto-retried by core; attempt-void semantics live at the caller), failures carry stable Error.Detail stage labels plus provider request/response ids captured at stream open via the optional ProviderStreamMetadata contract (x-request-id/apim-request-id headers, envelope/message ids), error spans mirror inference.error.detail and llm ids, and adapter-synthesized chat finishes are marked FinishSynthesized end to end on the generate event and response and mirrored as inference.finish.synthesized on success spans, with core rejecting a synthesized flag that carries no finish reason; feat(core/graph,core/agent): make stream failure handling a first-class inference-node policy — MessageStream gains an explicit Drop terminal, the inference node exposes stream_failure_policy {on_error,on_interrupt} with commit_partial (default) or discard actions classified per termination category (errdefs aborted/interrupted markers), recoverable undefined-tool streams discard partial text at the drain site so recovered rounds keep a clean transcript, partial usage reporting stays policy-independent, and stream-delta events are documented as advisory previews with board channels authoritative
 
 ## `core/v0.2.8` - 2026-09-07
 

--- a/core/agent/stream.go
+++ b/core/agent/stream.go
@@ -24,6 +24,13 @@ import (
 // node, a wrapper engine, or a test harness can publish a valid stream
 // delta in a single line:
 //
+// Stream deltas are advisory previews, not durable transcript state: the
+// authoritative content is the board channel message materialized by the
+// producing node, and an attempt may be discarded after its deltas were
+// published (see graph.MessageStream failure policies). Consumers that
+// persist output should key off the board/terminal state instead of
+// accumulating deltas from an attempt that may later be dropped.
+//
 //	// Inside a custom long-running graph node:
 //	engine.EmitStreamToken(ctx, pub, runID, nodeID, "loaded chunk 3/10")
 //

--- a/core/graph/message.go
+++ b/core/graph/message.go
@@ -8,6 +8,22 @@ import (
 	"github.com/GizClaw/flowcraft/core/message"
 )
 
+// StreamFailureAction is the action applied to a MessageStream's buffered
+// text when the operation that produced it terminates without a successful
+// result (a provider failure, run error, or interruption).
+type StreamFailureAction string
+
+const (
+	// StreamFailureCommitPartial commits the buffered text to the board
+	// as one assistant message before the error propagates. It is the
+	// default: partial progress survives a failed node.
+	StreamFailureCommitPartial StreamFailureAction = "commit_partial"
+	// StreamFailureDiscard drops the buffer and leaves the board
+	// untouched, so a caller-level retry can replay the request without
+	// duplicating partial output. Usage reporting is unaffected.
+	StreamFailureDiscard StreamFailureAction = "discard"
+)
+
 // MessageStream accumulates a streaming assistant message for one
 // board channel: each Emit publishes a token stream-delta in real
 // time, and Close appends the accumulated text as a single message.
@@ -15,7 +31,10 @@ import (
 // It exists for message-producing node types (typical: LLM nodes
 // consuming a streaming provider): the board stays clean — one
 // message per response, not one per token — while observers still see
-// output as it happens.
+// output as it happens. Stream-delta events are advisory previews; the
+// board channel is the authoritative state. An operation that fails
+// without a usable result calls Drop instead of Close to leave no
+// board trace.
 //
 //	s := ec.NewMessageStream(cfg.MessagesChannel)
 //	for token := range providerStream {
@@ -28,6 +47,7 @@ type MessageStream struct {
 	mu      sync.Mutex
 	buf     strings.Builder
 
+	abandoned    bool
 	materialized bool
 	message      message.Message
 }
@@ -54,12 +74,12 @@ func (s *MessageStream) Emit(token string) error {
 }
 
 // Close appends the accumulated text as one assistant message to the
-// bound channel and returns the message. Closing an empty stream is a
-// no-op returning an empty message and nil error.
+// bound channel and returns the message. Closing an empty or dropped
+// stream is a no-op returning an empty message and nil error.
 func (s *MessageStream) Close(board *agent.Board) (message.Message, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	if s.materialized {
+	if s.materialized || s.abandoned {
 		return s.message, nil
 	}
 	s.materialized = true
@@ -71,6 +91,16 @@ func (s *MessageStream) Close(board *agent.Board) (message.Message, error) {
 	board.AppendChannelMessage(s.channel, msg)
 	s.message = msg
 	return msg, nil
+}
+
+// Drop abandons the stream: the buffered text is discarded and the board
+// is never written. A later Close is a no-op. Dropping an already closed
+// or already dropped stream is a no-op.
+func (s *MessageStream) Drop() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.abandoned = true
+	s.buf.Reset()
 }
 
 // Channel returns the board channel the stream is bound to.

--- a/core/graph/message_test.go
+++ b/core/graph/message_test.go
@@ -84,3 +84,47 @@ func TestMessageStream_MaterializeIsIdempotent(t *testing.T) {
 		t.Fatalf("repeated empty materialization appended %d messages", len(got))
 	}
 }
+
+func TestMessageStream_DropLeavesBoardClean(t *testing.T) {
+	board := agent.NewBoard()
+	ec := ExecutionContext{Context: context.Background(), Host: agent.NoopHost{}, NodeID: "n1"}
+
+	s := ec.NewMessageStream("")
+	if err := s.Emit("partial"); err != nil {
+		t.Fatal(err)
+	}
+	s.Drop()
+	msg, err := s.Close(board)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if msg.Role != "" || msg.Content.Text() != "" {
+		t.Fatalf("dropped stream Close = %+v, want empty message", msg)
+	}
+	if got := board.Channel(agent.MainChannel); len(got) != 0 {
+		t.Fatalf("dropped stream appended %d messages, want 0", len(got))
+	}
+
+	// Close and Drop after Drop are no-ops.
+	s.Drop()
+	if _, err := s.Close(board); err != nil {
+		t.Fatal(err)
+	}
+	if got := board.Channel(agent.MainChannel); len(got) != 0 {
+		t.Fatalf("second Close after Drop appended %d messages, want 0", len(got))
+	}
+
+	// A committed stream is not undone by a later Drop.
+	s2 := ec.NewMessageStream("other")
+	if err := s2.Emit("kept"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := s2.Close(board); err != nil {
+		t.Fatal(err)
+	}
+	s2.Drop()
+	if got := board.Channel("other"); len(got) != 1 ||
+		got[0].Content.Text() != "kept" {
+		t.Fatalf("Drop after Close removed the committed message: %+v", got)
+	}
+}

--- a/core/graph/nodes/inference.go
+++ b/core/graph/nodes/inference.go
@@ -86,6 +86,14 @@ type InferenceConfig struct {
 	// still receives exactly one assembled message (tool_call parts
 	// included).
 	Stream bool `json:"stream,omitempty"`
+	// StreamFailurePolicy controls what happens to the buffered partial
+	// text when a streamed call terminates without a successful result.
+	// on_error covers provider/run failures; on_interrupt covers user or
+	// run stops (context.Canceled / aborted / interrupted errors).
+	// Absent keys default to commit_partial, preserving the historical
+	// behavior of committing the partial text before the error
+	// propagates.
+	StreamFailurePolicy *StreamFailurePolicy `json:"stream_failure_policy,omitempty"`
 
 	// Tools names the catalog tools the model may call this turn.
 	Tools []string `json:"tools,omitempty"`
@@ -119,6 +127,63 @@ type InferenceConfig struct {
 	// opaque metadata bag. Keys are deployment-defined; core does not
 	// reserve or interpret any key name.
 	RequestMetadata map[string]string `json:"request_metadata,omitempty"`
+}
+
+// StreamFailurePolicy maps a streamed inference's termination category to
+// the action applied to its buffered partial text.
+type StreamFailurePolicy struct {
+	// OnError is the action for provider and run failures (anything that
+	// is not an interrupt). Defaults to commit_partial.
+	OnError graph.StreamFailureAction `json:"on_error,omitempty"`
+	// OnInterrupt is the action for user or run stops: errors classified
+	// aborted or interrupted by errdefs (context.Canceled lands here).
+	// Defaults to commit_partial.
+	OnInterrupt graph.StreamFailureAction `json:"on_interrupt,omitempty"`
+}
+
+func (p *StreamFailurePolicy) validate() error {
+	if p == nil {
+		return nil
+	}
+	check := func(field string, action graph.StreamFailureAction) error {
+		switch action {
+		case "", graph.StreamFailureCommitPartial, graph.StreamFailureDiscard:
+			return nil
+		default:
+			return errdefs.Validationf(
+				"inference node: stream_failure_policy.%s = %q, want %q or %q",
+				field, action, graph.StreamFailureCommitPartial,
+				graph.StreamFailureDiscard)
+		}
+	}
+	if err := check("on_error", p.OnError); err != nil {
+		return err
+	}
+	return check("on_interrupt", p.OnInterrupt)
+}
+
+// action resolves the effective action for an interrupt-classified
+// termination. Nil policy and empty actions fall back to commit_partial.
+func (p *StreamFailurePolicy) action(interrupt bool) graph.StreamFailureAction {
+	var action graph.StreamFailureAction
+	if p != nil {
+		action = p.OnError
+		if interrupt {
+			action = p.OnInterrupt
+		}
+	}
+	if action == "" {
+		return graph.StreamFailureCommitPartial
+	}
+	return action
+}
+
+// isInterruptTermination reports whether err terminates a stream because
+// the user or the run stopped it (context.Canceled classifies as Aborted
+// in errdefs; an explicit Interrupted marker lands here too). Timeouts and
+// provider failures stay in the failure category.
+func isInterruptTermination(err error) bool {
+	return errdefs.IsAborted(err) || errdefs.IsInterrupted(err)
 }
 
 // UndefinedToolRecoveryConfig configures the inference node's
@@ -209,6 +274,9 @@ func runInference(ec graph.ExecutionContext, board *agent.Board, cfg InferenceCo
 		return errdefs.Validationf(
 			"inference node: undefined_tool_recovery requires recover_pending_key and recover_count_key")
 	}
+	if err := cfg.StreamFailurePolicy.validate(); err != nil {
+		return err
+	}
 	req, err := buildGenerateRequest(ec, board, channel, cfg, deps)
 	if err != nil {
 		return err
@@ -216,7 +284,7 @@ func runInference(ec graph.ExecutionContext, board *agent.Board, cfg InferenceCo
 
 	resp, err := executeGenerate(ec, board, cfg, deps, req)
 	if err != nil {
-		return recoverUndefinedTool(ec, board, channel, cfg, err)
+		return recoverUndefinedTool(ec, board, cfg, err)
 	}
 	if cfg.RecoverPendingKey != "" {
 		// A successful round clears the recovery marker so the loop
@@ -308,37 +376,12 @@ func runInference(ec graph.ExecutionContext, board *agent.Board, cfg InferenceCo
 // call would be executed for real. The original error is returned when
 // recovery is disabled, the failure is not an undefined-tool rejection,
 // or the per-run budget is exhausted.
-func recoverUndefinedTool(ec graph.ExecutionContext, board *agent.Board, channel string, cfg InferenceConfig, err error) error {
-	if cfg.UndefinedToolRecovery == nil || !cfg.UndefinedToolRecovery.Enabled {
+func recoverUndefinedTool(ec graph.ExecutionContext, board *agent.Board, cfg InferenceConfig, err error) error {
+	call, recoverable := recoverableUndefinedToolCall(board, cfg, err)
+	if !recoverable {
 		return err
-	}
-	var infErr *inference.Error
-	if !errors.As(err, &infErr) ||
-		infErr.Kind != inference.UndefinedTool ||
-		infErr.UndefinedToolCall == nil {
-		return err
-	}
-	max := cfg.UndefinedToolRecovery.MaxPerRun
-	if max <= 0 {
-		max = defaultUndefinedToolMaxRecoveries
 	}
 	count := recoveryCount(board, cfg)
-	if count >= max {
-		return err
-	}
-	call := *infErr.UndefinedToolCall
-
-	// The failed stream materialized its buffered text on the channel
-	// before the error propagated (see drainGenerateStream). The turn is
-	// being rolled back for a retry, so that rejected text must not stay
-	// in the transcript: the recovered round appends its own complete
-	// message right after it, leaving adjacent assistant messages that
-	// violate provider reasoning round-trip rules on the next request.
-	// Nothing is removed when the tail is not that text-only
-	// materialization (unary failures and streams that buffered no text
-	// never commit one).
-	rollbackFailedTurnText(board, channel)
-
 	board.SetVar(recoverFeedbackKey(ec, cfg), fmt.Sprintf(undefinedToolFeedback, call.Name))
 	if cfg.ToolPendingKey != "" {
 		board.SetVar(cfg.ToolPendingKey, false)
@@ -352,25 +395,34 @@ func recoverUndefinedTool(ec graph.ExecutionContext, board *agent.Board, channel
 	return nil
 }
 
-// rollbackFailedTurnText removes the standalone text-only assistant
-// message a failed stream committed to the channel. It is a no-op when
-// the channel tail is not that exact materialization, so ordinary tails
-// (user, tool, tool result) are never touched.
-func rollbackFailedTurnText(board *agent.Board, channel string) {
-	msgs := board.Channel(channel)
-	if len(msgs) == 0 {
-		return
+// recoverableUndefinedToolCall reports whether err is an undefined-tool
+// rejection this node may convert into recoverable feedback, and returns
+// the rejected call when it is. Streamed attempts that are recoverable
+// discard their partial text before materialization (see
+// drainGenerateStream), so the recovered round never leaves adjacent
+// assistant messages in the transcript.
+func recoverableUndefinedToolCall(
+	board *agent.Board,
+	cfg InferenceConfig,
+	err error,
+) (*message.ToolCall, bool) {
+	if cfg.UndefinedToolRecovery == nil || !cfg.UndefinedToolRecovery.Enabled {
+		return nil, false
 	}
-	last := msgs[len(msgs)-1]
-	if last.Role != message.RoleAssistant {
-		return
+	var infErr *inference.Error
+	if !errors.As(err, &infErr) ||
+		infErr.Kind != inference.UndefinedTool ||
+		infErr.UndefinedToolCall == nil {
+		return nil, false
 	}
-	for _, part := range last.Content.Parts {
-		if _, ok := part.(message.TextPart); !ok {
-			return
-		}
+	max := cfg.UndefinedToolRecovery.MaxPerRun
+	if max <= 0 {
+		max = defaultUndefinedToolMaxRecoveries
 	}
-	board.PopChannelMessage(channel)
+	if recoveryCount(board, cfg) >= max {
+		return nil, false
+	}
+	return infErr.UndefinedToolCall, true
 }
 
 // recoveryCount reads the per-run undefined-tool recovery counter.
@@ -680,13 +732,16 @@ func executeGenerate(ec graph.ExecutionContext, board *agent.Board, cfg Inferenc
 // response (complete message, tool_calls included). On a mid-stream
 // failure — driver error or run interruption — the buffered partial
 // text is committed to the board as one assistant message before the
-// error propagates, so downstream consumers and a host-saved board keep
-// the progress instead of silently losing every token. Partial
-// reasoning is streamed but not committed to the board: an unsigned
-// fragment must not round-trip into a conversation context that
-// requires signed reasoning. The last cumulative usage snapshot seen
-// before the failure is still reported to the host, so budget
-// accounting observes the tokens the provider already billed.
+// error propagates unless the node's StreamFailurePolicy discards it or
+// an undefined-tool recovery is pending (which always discards so the
+// recovered round leaves a clean transcript). Downstream consumers and a
+// host-saved board therefore keep progress by default instead of
+// silently losing every token. Partial reasoning is streamed but not
+// committed to the board: an unsigned fragment must not round-trip
+// into a conversation context that requires signed reasoning. The last
+// cumulative usage snapshot seen before the failure is still reported
+// to the host, so budget accounting observes the tokens the provider
+// already billed — regardless of the failure policy.
 func executeGenerateStream(ec graph.ExecutionContext, board *agent.Board, cfg InferenceConfig, deps InferenceNodeDeps, req inference.GenerateRequest) (inference.GenerateResponse, error) {
 	var stream inference.GenerateStream
 	var err error
@@ -711,10 +766,19 @@ func executeGenerateStream(ec graph.ExecutionContext, board *agent.Board, cfg In
 		}
 	}()
 
-	return drainGenerateStream(ec, board, cfg.MessagesChannel, stream)
+	return drainGenerateStream(ec, board, cfg, stream)
 }
 
-func drainGenerateStream(ec graph.ExecutionContext, board *agent.Board, channel string, stream inference.GenerateStream) (response inference.GenerateResponse, err error) {
+func drainGenerateStream(
+	ec graph.ExecutionContext,
+	board *agent.Board,
+	cfg InferenceConfig,
+	stream inference.GenerateStream,
+) (response inference.GenerateResponse, err error) {
+	channel := cfg.MessagesChannel
+	if channel == "" {
+		channel = agent.MainChannel
+	}
 	s := ec.NewMessageStream(channel)
 	var (
 		lastUsage inference.Usage
@@ -736,6 +800,16 @@ func drainGenerateStream(ec graph.ExecutionContext, board *agent.Board, channel 
 			// failed; surface the last cumulative usage snapshot so
 			// budget accounting still observes the partial spend.
 			reportPartialUsage()
+			// An undefined-tool rejection that will be recovered always
+			// discards: the recovered round must not follow a partial
+			// assistant message in the transcript. Otherwise the node's
+			// configured failure policy decides whether the partial text
+			// is committed (default) or dropped for a clean retry.
+			if _, recoverable := recoverableUndefinedToolCall(board, cfg, err); recoverable ||
+				cfg.StreamFailurePolicy.action(isInterruptTermination(err)) == graph.StreamFailureDiscard {
+				s.Drop()
+				return
+			}
 			// Preserve the original stream error; partial materialization
 			// is best effort, but if Close itself fails the caller should
 			// still see why their partial materialization didn't land.

--- a/core/graph/nodes/inference_test.go
+++ b/core/graph/nodes/inference_test.go
@@ -373,14 +373,14 @@ func TestInferenceNode_UndefinedToolRecovery(t *testing.T) {
 	}
 }
 
-// TestInferenceNode_UndefinedToolRecoveryStreamRollsBackPartial proves
+// TestInferenceNode_UndefinedToolRecoveryStreamDiscardsPartial proves
 // that when a streamed generation is rejected for an undefined tool, the
-// recovery rolls back the text-only assistant message the failed stream
-// materialized on the channel. Without the rollback, the next round's
-// success appends a reasoning + tool-call assistant message right after
+// partial text is discarded before materialization instead of being
+// rolled back after the fact. Committing it would let the next round's
+// success append a reasoning + tool-call assistant message right after
 // it, leaving adjacent assistant messages that violate provider
 // reasoning round-trip rules on the following request.
-func TestInferenceNode_UndefinedToolRecoveryStreamRollsBackPartial(t *testing.T) {
+func TestInferenceNode_UndefinedToolRecoveryStreamDiscardsPartial(t *testing.T) {
 	fake := &inferencetest.GenerateFake{
 		Events: []inference.GenerateStreamEvent{
 			{PartIndex: 0, Delta: inference.ReasoningDelta{Text: "think"}},
@@ -408,11 +408,12 @@ func TestInferenceNode_UndefinedToolRecoveryStreamRollsBackPartial(t *testing.T)
 		t.Fatalf("Execute: %v", err)
 	}
 
-	// The failed stream's partial text was rolled back: the channel
-	// holds only the original user turn, not the rejected text.
+	// The failed stream's partial text was discarded before
+	// materialization: the channel holds only the original user turn,
+	// not the rejected text.
 	msgs := board.Channel(agent.MainChannel)
 	if len(msgs) != 1 {
-		t.Fatalf("channel length = %d (%+v), want 1 (partial rolled back)", len(msgs), msgs)
+		t.Fatalf("channel length = %d (%+v), want 1 (partial discarded)", len(msgs), msgs)
 	}
 	feedback := board.GetVarString("recover_feedback")
 	if !strings.Contains(feedback, "ghost") || !strings.Contains(feedback, "tool_search") {
@@ -427,8 +428,8 @@ func TestInferenceNode_UndefinedToolRecoveryStreamRollsBackPartial(t *testing.T)
 }
 
 // TestInferenceNode_UndefinedToolRecoveryStreamNoTextKeepsTail proves
-// the rollback never touches the tail when the failed stream buffered no
-// text (nothing was committed to roll back).
+// the discard path is a no-op when the failed stream buffered no text:
+// the tail is never touched.
 func TestInferenceNode_UndefinedToolRecoveryStreamNoTextKeepsTail(t *testing.T) {
 	fake := &inferencetest.GenerateFake{
 		Events: []inference.GenerateStreamEvent{
@@ -1886,6 +1887,124 @@ func TestInferenceNode_StreamMidFailureCommitsPartial(t *testing.T) {
 	}
 }
 
+// TestInferenceNode_StreamMidFailureDiscardLeavesChannelClean proves the
+// on_error discard policy leaves the board untouched when a streamed call
+// fails mid-generation, so a caller-level retry can replay without
+// duplicating partial output.
+func TestInferenceNode_StreamMidFailureDiscardLeavesChannelClean(t *testing.T) {
+	fake := &inferencetest.GenerateFake{
+		Events: []inference.GenerateStreamEvent{
+			{PartIndex: 0, Delta: inference.TextPartDelta{Text: "hel"}},
+			{PartIndex: 0, Delta: inference.TextPartDelta{Text: "lo"}},
+		},
+		StreamErr:   errors.New("connection reset"),
+		StreamErrAt: 2, // both deltas delivered, then the stream dies
+	}
+	reg := inferenceRegistry(t, InferenceNodeDeps{Assembly: fake.Assembly(t)})
+	g := singleNodeGraph(t, reg, "inference", InferenceConfig{
+		Model:  ptr(inferencetest.DefaultFakeModel),
+		Stream: true,
+		StreamFailurePolicy: &StreamFailurePolicy{
+			OnError: graph.StreamFailureDiscard,
+		},
+	})
+	board := userBoard()
+	if err := executeGraph(t, g, &captureHost{}, board); err == nil {
+		t.Fatal("mid-stream failure must propagate")
+	}
+
+	msgs := board.Channel(agent.MainChannel)
+	if len(msgs) != 1 {
+		t.Fatalf("channel len = %d, want user only (partial discarded)", len(msgs))
+	}
+	if msgs[0].Role != message.RoleUser {
+		t.Fatalf("channel = %+v, want the original user turn untouched", msgs)
+	}
+}
+
+// TestInferenceNode_StreamInterruptDiscardLeavesChannelClean proves the
+// on_interrupt discard policy applies to aborted (user/run stop)
+// terminations, distinct from the on_error policy.
+func TestInferenceNode_StreamInterruptDiscardLeavesChannelClean(t *testing.T) {
+	fake := &inferencetest.GenerateFake{
+		Events: []inference.GenerateStreamEvent{
+			{PartIndex: 0, Delta: inference.TextPartDelta{Text: "hel"}},
+			{PartIndex: 0, Delta: inference.TextPartDelta{Text: "lo"}},
+		},
+		StreamErr:   errdefs.Aborted(errors.New("user stop")),
+		StreamErrAt: 2,
+	}
+	reg := inferenceRegistry(t, InferenceNodeDeps{Assembly: fake.Assembly(t)})
+	g := singleNodeGraph(t, reg, "inference", InferenceConfig{
+		Model:  ptr(inferencetest.DefaultFakeModel),
+		Stream: true,
+		StreamFailurePolicy: &StreamFailurePolicy{
+			OnError:     graph.StreamFailureCommitPartial,
+			OnInterrupt: graph.StreamFailureDiscard,
+		},
+	})
+	board := userBoard()
+	if err := executeGraph(t, g, &captureHost{}, board); err == nil {
+		t.Fatal("interrupted stream must propagate")
+	}
+
+	msgs := board.Channel(agent.MainChannel)
+	if len(msgs) != 1 {
+		t.Fatalf("channel len = %d, want user only (interrupted partial discarded)", len(msgs))
+	}
+}
+
+// TestInferenceNode_StreamInterruptCommitsPartialByDefault proves the
+// default on_interrupt policy (commit_partial) still commits the partial
+// text for aborted terminations, preserving the historical behavior.
+func TestInferenceNode_StreamInterruptCommitsPartialByDefault(t *testing.T) {
+	fake := &inferencetest.GenerateFake{
+		Events: []inference.GenerateStreamEvent{
+			{PartIndex: 0, Delta: inference.TextPartDelta{Text: "hel"}},
+			{PartIndex: 0, Delta: inference.TextPartDelta{Text: "lo"}},
+		},
+		StreamErr:   errdefs.Aborted(errors.New("user stop")),
+		StreamErrAt: 2,
+	}
+	reg := inferenceRegistry(t, InferenceNodeDeps{Assembly: fake.Assembly(t)})
+	g := singleNodeGraph(t, reg, "inference", InferenceConfig{
+		Model:  ptr(inferencetest.DefaultFakeModel),
+		Stream: true,
+	})
+	board := userBoard()
+	if err := executeGraph(t, g, &captureHost{}, board); err == nil {
+		t.Fatal("interrupted stream must propagate")
+	}
+
+	msgs := board.Channel(agent.MainChannel)
+	if len(msgs) != 2 {
+		t.Fatalf("channel len = %d, want user + partial assistant", len(msgs))
+	}
+	if msgs[1].Role != message.RoleAssistant || msgs[1].Content.Text() != "hello" {
+		t.Fatalf("partial message = %+v, want assistant \"hello\"", msgs[1])
+	}
+}
+
+// TestInferenceNode_RejectsUnknownStreamFailurePolicy proves config
+// validation rejects actions outside the commit_partial/discard
+// vocabulary before any provider call.
+func TestInferenceNode_RejectsUnknownStreamFailurePolicy(t *testing.T) {
+	reg := inferenceRegistry(t, InferenceNodeDeps{
+		Assembly: (&inferencetest.GenerateFake{}).Assembly(t),
+	})
+	g := singleNodeGraph(t, reg, "inference", InferenceConfig{
+		Model:  ptr(inferencetest.DefaultFakeModel),
+		Stream: true,
+		StreamFailurePolicy: &StreamFailurePolicy{
+			OnError: "explode",
+		},
+	})
+	err := executeGraph(t, g, agent.NoopHost{}, userBoard())
+	if err == nil || !strings.Contains(err.Error(), "stream_failure_policy.on_error") {
+		t.Fatalf("Execute error = %v, want stream_failure_policy.on_error rejection", err)
+	}
+}
+
 type resultFailingStream struct {
 	next int
 	err  error
@@ -1913,7 +2032,7 @@ func TestInferenceNode_StreamResultFailureCommitsPartialExactlyOnce(t *testing.T
 	stream := &resultFailingStream{err: errors.New("invalid terminal response")}
 	ec := graph.ExecutionContext{Context: context.Background(), Host: agent.NoopHost{}, NodeID: "n"}
 
-	if _, err := drainGenerateStream(ec, board, "", stream); !errors.Is(err, stream.err) {
+	if _, err := drainGenerateStream(ec, board, InferenceConfig{}, stream); !errors.Is(err, stream.err) {
 		t.Fatalf("drainGenerateStream error = %v, want %v", err, stream.err)
 	}
 	msgs := board.Channel(agent.MainChannel)

--- a/core/inference/errors.go
+++ b/core/inference/errors.go
@@ -24,6 +24,17 @@ const (
 	CompilerContractViolation ErrorKind = "compiler_contract_violation"
 	ProviderFailure           ErrorKind = "provider_failure"
 	InvalidProviderResponse   ErrorKind = "invalid_provider_response"
+	// ProviderTruncated marks a stream that ended before the provider
+	// emitted a terminal finish event. It is distinct from
+	// InvalidProviderResponse so retry/degradation policies can treat it
+	// as transient (the request may simply have been cut off mid-flight)
+	// instead of permanent response corruption.
+	// Contract: core never auto-retries this error. Its NotAvailable/503
+	// classification means "this attempt is void and worth re-initiating
+	// at caller granularity" — partial content may already have been
+	// committed by the inference node before the error propagated, so an
+	// internal mid-stream retry would duplicate output.
+	ProviderTruncated ErrorKind = "provider_truncated"
 	// UndefinedTool marks a response whose tool calls name tools absent
 	// from the request's definitions. It is distinct from
 	// InvalidProviderResponse so callers can offer a recoverable path
@@ -43,6 +54,13 @@ type Error struct {
 	Kind      ErrorKind
 	Operation Operation
 	Field     FieldID
+	// Detail is a stable, redacted stage label identifying where within
+	// the operation the failure was detected (for example
+	// "stream.finish.missing" for a stream that ended without a finish
+	// reason). Unlike cause it never carries provider wire payloads,
+	// prompts, or raw response fragments, so it is safe for Error()
+	// text, routine logs, and API responses.
+	Detail string
 	// RetryAfter is a server-provided backoff hint (Retry-After) when a
 	// provider failure carries one. Zero means no hint. It is diagnostic
 	// metadata, not part of the redacted Error() text.
@@ -53,6 +71,10 @@ type Error struct {
 	WireAttempts int
 	// RequestID is the provider-assigned request identifier attached to
 	// this failure when the provider reported one. Empty otherwise.
+	// Stream failures that end early may carry the provider's response
+	// identifier (chat/message id) instead when the transport-level request
+	// id is unknown, so operators can still correlate the truncated
+	// request with the provider.
 	// Runtime telemetry mirrors it onto error spans and logs as
 	// llm.request.id.
 	RequestID string
@@ -104,6 +126,9 @@ func (e *Error) Error() string {
 	if e.Field != "" {
 		message += " at " + string(e.Field)
 	}
+	if e.Detail != "" {
+		message += ": " + e.Detail
+	}
 	return message
 }
 
@@ -141,6 +166,8 @@ func (kind ErrorKind) classify(cause error) error {
 		return errdefs.Aborted(classified)
 	case CompilerContractViolation, InvalidProviderResponse:
 		return errdefs.Internal(cause)
+	case ProviderTruncated:
+		return errdefs.NotAvailable(cause)
 	case UndefinedTool:
 		// Deterministic response violation: the model referenced a tool
 		// it was never shown. Retrying the same request cannot help, so

--- a/core/inference/generate.go
+++ b/core/inference/generate.go
@@ -356,8 +356,16 @@ func appendGenerateIntentFields(fields []FieldID, intent Intent) []FieldID {
 type GenerateResponse struct {
 	Message      message.Message `json:"message"`
 	FinishReason FinishReason    `json:"finish_reason"`
-	Usage        Usage           `json:"usage"`
-	Metadata     Metadata        `json:"metadata"`
+	// FinishSynthesized marks a finish reason the adapter fabricated
+	// because the provider ended the stream without emitting a terminal
+	// finish event (false for provider-emitted reasons). A synthesized
+	// finish may mean the response was truncated mid-flight; callers that
+	// need to trust the response as complete can use the flag to decide
+	// whether to treat the attempt as void and re-initiate at their own
+	// granularity.
+	FinishSynthesized bool     `json:"finish_synthesized,omitempty"`
+	Usage             Usage    `json:"usage"`
+	Metadata          Metadata `json:"metadata"`
 	// ProviderOutputs carries provider-owned structured output that is not
 	// part of Message. It is never fed back into a model request implicitly;
 	// only Message becomes conversation context.

--- a/core/inference/generate_stream.go
+++ b/core/inference/generate_stream.go
@@ -4,12 +4,14 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"sort"
 	"strings"
 	"time"
 
+	"github.com/GizClaw/flowcraft/core/errdefs"
 	"github.com/GizClaw/flowcraft/core/message"
 	"github.com/GizClaw/flowcraft/core/message/media"
 )
@@ -132,6 +134,13 @@ type GenerateStreamEvent struct {
 	// Usage is a cumulative snapshot and replaces the previous snapshot.
 	Usage        *Usage       `json:"usage,omitempty"`
 	FinishReason FinishReason `json:"finish_reason,omitempty"`
+	// FinishSynthesized marks a finish reason the adapter fabricated
+	// because the provider ended the stream without emitting a terminal
+	// finish event (for example a chat stream that closed cleanly between
+	// frames). It is false for provider-emitted finish reasons. A
+	// synthesized finish may mean the response was truncated mid-flight,
+	// so consumers can treat the result with reduced trust.
+	FinishSynthesized bool `json:"finish_synthesized,omitempty"`
 	// ProviderOutputs carries a cumulative snapshot per provider output
 	// family (citations, search-call status). An entry with the same
 	// provider/extension identity replaces the previous snapshot, matching
@@ -159,6 +168,18 @@ type GenerateStream interface {
 type ProviderStream[RawEvent any] interface {
 	Next(context.Context) (RawEvent, error)
 	Close() error
+}
+
+// ProviderStreamMetadata is an optional capability of ProviderStream.
+// Streams that learn a provider-assigned request or response identifier
+// before their terminal event (the x-request-id header at open, the first
+// chunk id, or response.created) implement it so the runtime can attach the
+// identifier to mid-stream and truncated-stream failures. Without it,
+// identifiers ride only the terminal finish event and are lost when the
+// provider stream ends early.
+type ProviderStreamMetadata interface {
+	RequestID() string
+	ResponseID() string
 }
 
 type generateStreamDriver[Wire, RawEvent any] struct {
@@ -196,18 +217,21 @@ func (d *generateStreamDriver[Wire, RawEvent]) Stream(
 	}
 	raw, err := d.pipeline.transport(ctx, compiled.Wire)
 	if err != nil {
-		return nil, newProviderError(OperationGenerate, model.ID.Provider, err)
+		return nil, streamProviderError(model.ID.Provider, "stream.open", err)
 	}
 	if isNilValue(raw) {
-		return nil, NewError(
-			InvalidProviderResponse,
-			OperationGenerate,
-			"",
+		return nil, newStreamError(
+			"stream.open.nil",
 			fmt.Errorf("provider opened a nil generate stream"),
 		)
 	}
+	var meta ProviderStreamMetadata
+	if ids, ok := raw.(ProviderStreamMetadata); ok {
+		meta = ids
+	}
 	return &decodedGenerateStream[RawEvent]{
 		raw:       raw,
+		meta:      meta,
 		decode:    d.decode,
 		model:     model,
 		request:   request.Clone(),
@@ -237,18 +261,23 @@ type generatePartAccumulator struct {
 }
 
 type decodedGenerateStream[RawEvent any] struct {
-	raw        ProviderStream[RawEvent]
-	decode     GenerateStreamDecoder[RawEvent]
-	model      ModelRef
-	request    GenerateRequest
-	report     CompileReport
-	parts      map[int]*generatePartAccumulator
-	usage      Usage
-	finish     FinishReason
-	requestID  string
-	responseID string
-	outputs    ProviderOutputs
-	startedAt  time.Time
+	raw     ProviderStream[RawEvent]
+	meta    ProviderStreamMetadata
+	decode  GenerateStreamDecoder[RawEvent]
+	model   ModelRef
+	request GenerateRequest
+	report  CompileReport
+	parts   map[int]*generatePartAccumulator
+	usage   Usage
+	finish  FinishReason
+	// finishSynthesized mirrors the terminal event's FinishSynthesized
+	// flag; it is stamped onto the result so a fabricated finish reason
+	// is visible to the caller.
+	finishSynthesized bool
+	requestID         string
+	responseID        string
+	outputs           ProviderOutputs
+	startedAt         time.Time
 
 	done      bool
 	result    GenerateResponse
@@ -271,27 +300,27 @@ func (s *decodedGenerateStream[RawEvent]) Next(
 			return GenerateStreamEvent{}, io.EOF
 		}
 		s.done = true
-		s.resultErr = newProviderError(OperationGenerate, s.model.ID.Provider, err)
+		s.resultErr = s.streamProviderFailure("stream.read", err)
 		return GenerateStreamEvent{}, s.resultErr
 	}
 	event, err := s.decode(ctx, rawEvent)
 	if err != nil {
 		s.done = true
-		s.resultErr = NewError(InvalidProviderResponse, OperationGenerate, "", err)
+		s.resultErr = s.streamError("stream.decode", err)
 		return GenerateStreamEvent{}, s.resultErr
 	}
 	if event.Delta != nil {
 		normalized, err := normalizePartDelta(event.Delta)
 		if err != nil {
 			s.done = true
-			s.resultErr = NewError(InvalidProviderResponse, OperationGenerate, "", err)
+			s.resultErr = s.streamError("stream.normalize", err)
 			return GenerateStreamEvent{}, s.resultErr
 		}
 		event.Delta = normalized
 	}
 	if err := s.accumulate(event); err != nil {
 		s.done = true
-		s.resultErr = NewError(InvalidProviderResponse, OperationGenerate, "", err)
+		s.resultErr = s.streamError(streamAccumulateDetail(err), err)
 		return GenerateStreamEvent{}, s.resultErr
 	}
 	return event, nil
@@ -299,10 +328,8 @@ func (s *decodedGenerateStream[RawEvent]) Next(
 
 func (s *decodedGenerateStream[RawEvent]) Result() (GenerateResponse, error) {
 	if !s.done {
-		return GenerateResponse{}, NewError(
-			InvalidProviderResponse,
-			OperationGenerate,
-			"",
+		return GenerateResponse{}, s.streamError(
+			"stream.result.premature",
 			fmt.Errorf("stream is not complete"),
 		)
 	}
@@ -311,9 +338,103 @@ func (s *decodedGenerateStream[RawEvent]) Result() (GenerateResponse, error) {
 
 func (s *decodedGenerateStream[RawEvent]) Close() error {
 	if err := s.raw.Close(); err != nil {
-		return newProviderError(OperationGenerate, s.model.ID.Provider, err)
+		return s.streamProviderFailure("stream.close", err)
 	}
 	return nil
+}
+
+// newStreamError builds the InvalidProviderResponse error used by the
+// generate stream failure points. detail is a stable, redacted stage label
+// (see Error.Detail) identifying where the failure was detected.
+func newStreamError(detail string, cause error) *Error {
+	out := NewError(InvalidProviderResponse, OperationGenerate, "", cause)
+	out.Detail = detail
+	if requestID, ok := errdefs.RequestID(out); ok {
+		out.RequestID = requestID
+	}
+	return out
+}
+
+// streamProviderError builds a ProviderFailure error for a generate stream
+// transport failure with the same stable stage label as newStreamError.
+func streamProviderError(provider, detail string, cause error) *Error {
+	out := newProviderError(OperationGenerate, provider, cause)
+	out.Detail = detail
+	return out
+}
+
+// providerID returns the provider identifier this stream can still attach
+// when it ends early: the transport-level request id when provider metadata
+// exposed one, otherwise the response id observed before truncation,
+// otherwise an identifier carried by an earlier event.
+func (s *decodedGenerateStream[RawEvent]) providerID() string {
+	if s.meta != nil {
+		if id := s.meta.RequestID(); id != "" {
+			return id
+		}
+		if id := s.meta.ResponseID(); id != "" {
+			return id
+		}
+	}
+	return s.requestID
+}
+
+// withProviderID wraps cause with the stream's provider identifier unless
+// the chain already carries one, so errdefs.RequestID consumers (span
+// attributes, run event payloads) see it on failures raised after the
+// provider stream opened.
+func (s *decodedGenerateStream[RawEvent]) withProviderID(cause error) error {
+	if id := s.providerID(); id != "" {
+		if _, ok := errdefs.RequestID(cause); !ok {
+			cause = errdefs.WithRequestID(cause, id)
+		}
+	}
+	return cause
+}
+
+func (s *decodedGenerateStream[RawEvent]) streamError(
+	detail string,
+	cause error,
+) *Error {
+	return newStreamError(detail, s.withProviderID(cause))
+}
+
+func (s *decodedGenerateStream[RawEvent]) streamProviderFailure(
+	detail string,
+	cause error,
+) *Error {
+	return streamProviderError(s.model.ID.Provider, detail, s.withProviderID(cause))
+}
+
+// truncatedStreamError builds the ProviderTruncated error for a stream that
+// ended without a terminal finish event, attaching any provider identifier
+// the stream still knows.
+func (s *decodedGenerateStream[RawEvent]) truncatedStreamError(cause error) *Error {
+	out := NewError(ProviderTruncated, OperationGenerate, "", s.withProviderID(cause))
+	out.Detail = "stream.finish.missing"
+	if requestID, ok := errdefs.RequestID(out); ok {
+		out.RequestID = requestID
+	}
+	return out
+}
+
+// toolCallConflictError marks an accumulation failure where incremental
+// tool-call fragments contradict each other (a changed id or name). It lets
+// Next attach a distinct Detail without parsing error text.
+type toolCallConflictError struct {
+	err error
+}
+
+func (e *toolCallConflictError) Error() string { return e.err.Error() }
+func (e *toolCallConflictError) Unwrap() error { return e.err }
+
+// streamAccumulateDetail picks the Detail for an accumulate failure.
+func streamAccumulateDetail(err error) string {
+	var conflict *toolCallConflictError
+	if errors.As(err, &conflict) {
+		return "stream.accumulate.tool_call"
+	}
+	return "stream.accumulate"
 }
 
 func (s *decodedGenerateStream[RawEvent]) accumulate(
@@ -328,6 +449,10 @@ func (s *decodedGenerateStream[RawEvent]) accumulate(
 		if err := event.FinishReason.Validate(); err != nil {
 			return err
 		}
+	}
+	if event.FinishSynthesized && event.FinishReason == "" {
+		return fmt.Errorf(
+			"generate stream finish_synthesized requires a finish reason")
 	}
 	if err := event.ProviderOutputs.Validate(); err != nil {
 		return err
@@ -372,6 +497,7 @@ func (s *decodedGenerateStream[RawEvent]) accumulate(
 			return fmt.Errorf("stream emitted multiple finish reasons")
 		}
 		s.finish = event.FinishReason
+		s.finishSynthesized = event.FinishSynthesized
 	}
 	return nil
 }
@@ -383,13 +509,13 @@ func (p *generatePartAccumulator) add(delta PartDelta) error {
 	case ToolCallDelta:
 		if value.ID != "" {
 			if p.toolID != "" && p.toolID != value.ID {
-				return fmt.Errorf("tool call changed id")
+				return &toolCallConflictError{err: fmt.Errorf("tool call changed id")}
 			}
 			p.toolID = value.ID
 		}
 		if value.Name != "" {
 			if p.toolName != "" && p.toolName != value.Name {
-				return fmt.Errorf("tool call changed name")
+				return &toolCallConflictError{err: fmt.Errorf("tool call changed name")}
 			}
 			p.toolName = value.Name
 		}
@@ -431,10 +557,7 @@ func (p *generatePartAccumulator) add(delta PartDelta) error {
 func (s *decodedGenerateStream[RawEvent]) finishResult() {
 	s.done = true
 	if s.finish == "" {
-		s.resultErr = NewError(
-			InvalidProviderResponse,
-			OperationGenerate,
-			"",
+		s.resultErr = s.truncatedStreamError(
 			fmt.Errorf("stream ended without a finish reason"),
 		)
 		return
@@ -448,7 +571,7 @@ func (s *decodedGenerateStream[RawEvent]) finishResult() {
 	for _, index := range indices {
 		part, err := s.parts[index].result()
 		if err != nil {
-			s.resultErr = NewError(InvalidProviderResponse, OperationGenerate, "", err)
+			s.resultErr = s.streamError("stream.finish.part", err)
 			return
 		}
 		parts = append(parts, part)
@@ -458,9 +581,10 @@ func (s *decodedGenerateStream[RawEvent]) finishResult() {
 			Role:    message.RoleAssistant,
 			Content: message.Content{Parts: parts},
 		},
-		FinishReason:    s.finish,
-		Usage:           s.usage,
-		ProviderOutputs: s.outputs.Clone(),
+		FinishReason:      s.finish,
+		FinishSynthesized: s.finishSynthesized,
+		Usage:             s.usage,
+		ProviderOutputs:   s.outputs.Clone(),
 	}
 	metadata := s.report.Metadata(s.model)
 	metadata.RequestID = s.requestID
@@ -473,10 +597,43 @@ func (s *decodedGenerateStream[RawEvent]) finishResult() {
 	response.Usage.Model = s.model
 	response.Usage.LatencyMs = time.Since(s.startedAt).Milliseconds()
 	if err := response.ValidateFor(s.request); err != nil {
-		s.resultErr = newResponseValidationError(OperationGenerate, err)
+		out := newResponseValidationError(OperationGenerate, s.withProviderID(err))
+		out.Detail = terminalValidationDetail(out, response)
+		if requestID, ok := errdefs.RequestID(out); ok {
+			out.RequestID = requestID
+		}
+		s.resultErr = out
 		return
 	}
 	s.result = response
+}
+
+// terminalValidationDetail picks the Detail for a terminal response
+// validation failure. Structurally invalid tool-call parts and
+// finish-reason/tool-call mismatches each get a distinct label (both mean
+// the provider ended cleanly with a corrupt tool payload); undefined-tool
+// calls keep their own label alongside the rejected call; everything else
+// is a generic response validation failure.
+func terminalValidationDetail(out *Error, response GenerateResponse) string {
+	if out.Kind == UndefinedTool {
+		return "stream.finish.undefined_tool"
+	}
+	for _, part := range response.Message.Content.Parts {
+		normalized, err := message.NormalizePart(part)
+		if err != nil {
+			continue
+		}
+		if call, ok := normalized.(message.ToolCallPart); ok {
+			if err := call.Validate(); err != nil {
+				return "stream.finish.tool_call"
+			}
+		}
+	}
+	hasToolCalls := response.Message.HasToolCalls()
+	if (response.FinishReason == FinishToolCalls) != hasToolCalls {
+		return "stream.finish.mismatch"
+	}
+	return "stream.finish.validation"
 }
 
 func (p *generatePartAccumulator) result() (message.Part, error) {

--- a/core/inference/generate_stream_detail_test.go
+++ b/core/inference/generate_stream_detail_test.go
@@ -1,0 +1,295 @@
+package inference
+
+import (
+	"context"
+	"errors"
+	"io"
+	"testing"
+	"time"
+
+	"github.com/GizClaw/flowcraft/core/errdefs"
+	"github.com/GizClaw/flowcraft/core/message"
+)
+
+// streamEventList is a scripted ProviderStream over fully decoded events;
+// the decode stage is the identity function, so failures are produced by
+// the runtime accumulator rather than a driver.
+type streamEventList struct {
+	events []GenerateStreamEvent
+	next   int
+}
+
+func (s *streamEventList) Next(context.Context) (GenerateStreamEvent, error) {
+	if s.next < len(s.events) {
+		event := s.events[s.next]
+		s.next++
+		return event, nil
+	}
+	return GenerateStreamEvent{}, io.EOF
+}
+
+func (*streamEventList) Close() error { return nil }
+
+// metaStreamList carries provider identifiers through the optional
+// ProviderStreamMetadata capability, as driver transports do after
+// capturing x-request-id at stream open.
+type metaStreamList struct {
+	*streamEventList
+	requestID  string
+	responseID string
+}
+
+func (s *metaStreamList) RequestID() string  { return s.requestID }
+func (s *metaStreamList) ResponseID() string { return s.responseID }
+
+func identityGenerateDecoder(
+	_ context.Context,
+	event GenerateStreamEvent,
+) (GenerateStreamEvent, error) {
+	return event, nil
+}
+
+func detailTestStream(events []GenerateStreamEvent, request GenerateRequest) *decodedGenerateStream[GenerateStreamEvent] {
+	return &decodedGenerateStream[GenerateStreamEvent]{
+		raw:       &streamEventList{events: events},
+		decode:    identityGenerateDecoder,
+		model:     ModelRef{ID: ModelID{Provider: "fake", Name: "model-1"}},
+		request:   request,
+		parts:     make(map[int]*generatePartAccumulator),
+		startedAt: time.Now(),
+	}
+}
+
+func detailTestStreamWithMeta(
+	events []GenerateStreamEvent,
+	request GenerateRequest,
+	requestID, responseID string,
+) *decodedGenerateStream[GenerateStreamEvent] {
+	stream := detailTestStream(events, request)
+	stream.raw = &metaStreamList{
+		streamEventList: &streamEventList{events: events},
+		requestID:       requestID,
+		responseID:      responseID,
+	}
+	stream.meta = stream.raw.(ProviderStreamMetadata)
+	return stream
+}
+
+func toolStreamRequest(t *testing.T) GenerateRequest {
+	t.Helper()
+	return GenerateRequest{
+		Input: GenerateInput{
+			Role: InputRoleUser,
+			Content: InputContent{
+				Content: message.Content{Parts: []message.Part{message.TextPart{Text: "hi"}}},
+				Intent: Intent{Text: &TextIntent{
+					Tools: []message.ToolDefinition{
+						message.DefineSchema("known", "a known tool").Build(),
+					},
+				}},
+			},
+		},
+	}
+}
+
+func nextStreamError(t *testing.T, stream GenerateStream) *Error {
+	t.Helper()
+	for {
+		_, err := stream.Next(context.Background())
+		if err == nil {
+			continue
+		}
+		if errors.Is(err, io.EOF) {
+			t.Fatal("stream ended cleanly, want failure")
+		}
+		var out *Error
+		if !errors.As(err, &out) {
+			t.Fatalf("Next error = %v, want *inference.Error", err)
+		}
+		return out
+	}
+}
+
+func TestGenerateStreamMissingFinishDetail(t *testing.T) {
+	stream := detailTestStream(nil, GenerateRequest{})
+	err := nextStreamError(t, stream)
+	if err.Kind != ProviderTruncated {
+		t.Fatalf("kind = %q, want %q", err.Kind, ProviderTruncated)
+	}
+	if err.Detail != "stream.finish.missing" {
+		t.Fatalf("Detail = %q, want stream.finish.missing", err.Detail)
+	}
+	if got := err.Error(); got != "provider_truncated during generate: stream.finish.missing" {
+		t.Fatalf("Error() = %q", got)
+	}
+	if !errdefs.IsNotAvailable(err) {
+		t.Fatalf("provider_truncated must classify as not available, got %v", err)
+	}
+}
+
+func TestGenerateStreamTruncationCarriesProviderRequestID(t *testing.T) {
+	stream := detailTestStreamWithMeta(nil, GenerateRequest{}, "req-openai-1", "resp-1")
+	err := nextStreamError(t, stream)
+	if err.Kind != ProviderTruncated {
+		t.Fatalf("kind = %q, want %q", err.Kind, ProviderTruncated)
+	}
+	if err.RequestID != "req-openai-1" {
+		t.Fatalf("Error.RequestID = %q, want req-openai-1", err.RequestID)
+	}
+	if got, ok := errdefs.RequestID(err); !ok || got != "req-openai-1" {
+		t.Fatalf("errdefs.RequestID(err) = %q/%v, want req-openai-1/true", got, ok)
+	}
+}
+
+func TestGenerateStreamTruncationFallsBackToResponseID(t *testing.T) {
+	stream := detailTestStreamWithMeta(nil, GenerateRequest{}, "", "chatcmpl-1")
+	err := nextStreamError(t, stream)
+	if err.RequestID != "chatcmpl-1" {
+		t.Fatalf("Error.RequestID = %q, want chatcmpl-1 fallback", err.RequestID)
+	}
+}
+
+func TestGenerateStreamToolCallStructureDetail(t *testing.T) {
+	events := []GenerateStreamEvent{
+		{PartIndex: 0, Delta: ToolCallDelta{
+			ID:                "call-1",
+			Name:              "known",
+			ArgumentsFragment: `{"query": "x`,
+		}},
+		{FinishReason: FinishToolCalls},
+	}
+	stream := detailTestStream(events, toolStreamRequest(t))
+	err := nextStreamError(t, stream)
+	if err.Kind != InvalidProviderResponse {
+		t.Fatalf("kind = %q, want %q", err.Kind, InvalidProviderResponse)
+	}
+	if err.Detail != "stream.finish.tool_call" {
+		t.Fatalf("Detail = %q, want stream.finish.tool_call", err.Detail)
+	}
+}
+
+func TestGenerateStreamToolCallConflictDetail(t *testing.T) {
+	events := []GenerateStreamEvent{
+		{PartIndex: 0, Delta: ToolCallDelta{ID: "call-1", Name: "known"}},
+		{PartIndex: 0, Delta: ToolCallDelta{ID: "call-2", Name: "known"}},
+	}
+	stream := detailTestStream(events, toolStreamRequest(t))
+	err := nextStreamError(t, stream)
+	if err.Detail != "stream.accumulate.tool_call" {
+		t.Fatalf("Detail = %q, want stream.accumulate.tool_call", err.Detail)
+	}
+}
+
+func TestGenerateStreamToolCallFinishMismatchDetail(t *testing.T) {
+	events := []GenerateStreamEvent{{FinishReason: FinishToolCalls}}
+	stream := detailTestStream(events, toolStreamRequest(t))
+	err := nextStreamError(t, stream)
+	if err.Detail != "stream.finish.mismatch" {
+		t.Fatalf("Detail = %q, want stream.finish.mismatch", err.Detail)
+	}
+}
+
+func TestGenerateStreamUndefinedToolDetail(t *testing.T) {
+	events := []GenerateStreamEvent{
+		{PartIndex: 0, Delta: ToolCallDelta{
+			ID:                "call-1",
+			Name:              "ghost",
+			ArgumentsFragment: `{}`,
+		}},
+		{FinishReason: FinishToolCalls},
+	}
+	stream := detailTestStream(events, toolStreamRequest(t))
+	err := nextStreamError(t, stream)
+	if err.Kind != UndefinedTool {
+		t.Fatalf("kind = %q, want %q", err.Kind, UndefinedTool)
+	}
+	if err.Detail != "stream.finish.undefined_tool" {
+		t.Fatalf("Detail = %q, want stream.finish.undefined_tool", err.Detail)
+	}
+}
+
+func TestErrorDetailFormatting(t *testing.T) {
+	err := NewError(InvalidProviderResponse, OperationGenerate, "", errors.New("boom"))
+	if err.Detail != "" {
+		t.Fatalf("NewError must leave Detail empty, got %q", err.Detail)
+	}
+	if got := err.Error(); got != "invalid_provider_response during generate" {
+		t.Fatalf("Error() without Detail = %q", got)
+	}
+	err.Detail = "stream.decode"
+	if got := err.Error(); got != "invalid_provider_response during generate: stream.decode" {
+		t.Fatalf("Error() with Detail = %q", got)
+	}
+}
+
+func textStreamRequest(t *testing.T) GenerateRequest {
+	t.Helper()
+	return GenerateRequest{
+		Input: GenerateInput{
+			Role: InputRoleUser,
+			Content: InputContent{
+				Content: message.Content{Parts: []message.Part{
+					message.TextPart{Text: "hi"},
+				}},
+				Intent: Intent{Text: &TextIntent{}},
+			},
+		},
+	}
+}
+
+func drainGenerateStreamResult(t *testing.T, stream GenerateStream) GenerateResponse {
+	t.Helper()
+	for {
+		_, err := stream.Next(context.Background())
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		if err != nil {
+			t.Fatalf("Next: %v", err)
+		}
+	}
+	response, err := stream.Result()
+	if err != nil {
+		t.Fatalf("Result: %v", err)
+	}
+	return response
+}
+
+func TestGenerateStreamFinishSynthesizedFlagPropagates(t *testing.T) {
+	stream := detailTestStream([]GenerateStreamEvent{
+		{PartIndex: 0, Delta: TextPartDelta{Text: "hi"}},
+		{FinishReason: FinishCompleted, FinishSynthesized: true},
+	}, textStreamRequest(t))
+	response := drainGenerateStreamResult(t, stream)
+	if !response.FinishSynthesized {
+		t.Fatal("synthesized finish must surface on the response")
+	}
+	if response.FinishReason != FinishCompleted {
+		t.Fatalf("finish reason = %q, want completed", response.FinishReason)
+	}
+}
+
+func TestGenerateStreamExplicitFinishFlagFalse(t *testing.T) {
+	stream := detailTestStream([]GenerateStreamEvent{
+		{PartIndex: 0, Delta: TextPartDelta{Text: "hi"}},
+		{FinishReason: FinishCompleted},
+	}, textStreamRequest(t))
+	response := drainGenerateStreamResult(t, stream)
+	if response.FinishSynthesized {
+		t.Fatal("provider-emitted finish must not be marked synthesized")
+	}
+}
+
+func TestGenerateStreamFinishSynthesizedRequiresFinishReason(t *testing.T) {
+	stream := detailTestStream([]GenerateStreamEvent{
+		{PartIndex: 0, Delta: TextPartDelta{Text: "hi"}},
+		{FinishSynthesized: true},
+	}, textStreamRequest(t))
+	err := nextStreamError(t, stream)
+	if err.Kind != InvalidProviderResponse {
+		t.Fatalf("kind = %q, want %q", err.Kind, InvalidProviderResponse)
+	}
+	if err.Detail != "stream.accumulate" {
+		t.Fatalf("Detail = %q, want stream.accumulate", err.Detail)
+	}
+}

--- a/core/inference/route/resilience.go
+++ b/core/inference/route/resilience.go
@@ -108,7 +108,10 @@ func (p *RetryPolicy) validate() error {
 
 // DefaultRetryable is the conservative same-target retry predicate: only
 // ProviderFailure classified as rate limit, timeout, or not available, and
-// never after observable output.
+// never after observable output. ProviderTruncated is deliberately not
+// retried here even though it classifies as not available: core never
+// auto-retries truncated streams (attempt-void semantics live at the
+// caller), and partial output may already have been committed.
 var DefaultRetryable = func(_ context.Context, decision RetryDecision) bool {
 	if decision.ObservableOutput || decision.ErrorKind != inference.ProviderFailure {
 		return false

--- a/core/inference/route/resilience.go
+++ b/core/inference/route/resilience.go
@@ -147,6 +147,7 @@ func nonRetryableKind(kind inference.ErrorKind) bool {
 		inference.OperationInterrupted,
 		inference.CompilerContractViolation,
 		inference.InvalidProviderResponse,
+		inference.ProviderTruncated,
 		inference.UndefinedTool:
 		return true
 	default:

--- a/core/inference/route/resilience_test.go
+++ b/core/inference/route/resilience_test.go
@@ -8,12 +8,15 @@ import (
 	"github.com/GizClaw/flowcraft/core/inference"
 )
 
-func TestNonRetryableKindUndefinedTool(t *testing.T) {
+func TestNeverRetriedKinds(t *testing.T) {
 	if !nonRetryableKind(inference.UndefinedTool) {
 		t.Fatal("undefined tool rejections must be non-retryable")
 	}
 	if !nonRetryableKind(inference.InvalidProviderResponse) {
 		t.Fatal("invalid provider responses must stay non-retryable")
+	}
+	if !nonRetryableKind(inference.ProviderTruncated) {
+		t.Fatal("provider truncations must stay non-retryable")
 	}
 	if nonRetryableKind(inference.ProviderFailure) {
 		t.Fatal("provider failures must remain retryable candidates")

--- a/core/inference/route/resilience_test.go
+++ b/core/inference/route/resilience_test.go
@@ -1,6 +1,8 @@
 package route
 
 import (
+	"context"
+	"errors"
 	"testing"
 
 	"github.com/GizClaw/flowcraft/core/inference"
@@ -15,5 +17,35 @@ func TestNonRetryableKindUndefinedTool(t *testing.T) {
 	}
 	if nonRetryableKind(inference.ProviderFailure) {
 		t.Fatal("provider failures must remain retryable candidates")
+	}
+}
+
+// TestProviderTruncatedNeverDefaultRetryable locks in the D1 contract:
+// core never auto-retries a truncated stream, so the default predicate
+// rejects ProviderTruncated even though the error classifies as not
+// available and no output was observed.
+func TestProviderTruncatedNeverDefaultRetryable(t *testing.T) {
+	infErr := inference.NewError(
+		inference.ProviderTruncated, inference.OperationGenerate, "",
+		errors.New("stream ended without a finish reason"))
+	decision := RetryDecision{
+		Operation: inference.OperationGenerate,
+		Phase:     AttemptPhaseExecute,
+		ErrorKind: inference.ProviderTruncated,
+		Err:       infErr,
+		Attempt:   0,
+	}
+	if DefaultRetryable(context.Background(), decision) {
+		t.Fatal("provider_truncated must never be retried by DefaultRetryable")
+	}
+	policy, err := (&RetryPolicyConfig{
+		MaxAttempts: 2,
+		Retryable:   []RetryableClass{RetryableUnavailable},
+	}).policy()
+	if err != nil {
+		t.Fatalf("policy: %v", err)
+	}
+	if retryEligible(context.Background(), policy, decision) {
+		t.Fatal("provider_truncated must not be retried even when retryable_unavailable is configured")
 	}
 }

--- a/core/inference/telemetry.go
+++ b/core/inference/telemetry.go
@@ -139,6 +139,9 @@ func (c inferenceCall) finish(metadata Metadata, usage Usage, err error) {
 	}
 	kind := classifyInferenceError(err)
 	c.span.SetAttributes(attribute.String("inference.error_kind", kind))
+	if detail := inferenceErrorDetail(err); detail != "" {
+		c.span.SetAttributes(attribute.String("inference.error.detail", detail))
+	}
 	inferenceExecCount.Add(c.ctx, 1, c.metricAttrs(attribute.String("status", "error")))
 	inferenceErrorCount.Add(c.ctx, 1, c.metricAttrs(attribute.String("error_kind", kind)))
 	if !c.reuse {
@@ -269,6 +272,17 @@ func classifyInferenceError(err error) string {
 	return "unclassified"
 }
 
+// inferenceErrorDetail returns the redacted stage label carried by
+// Error.Detail when the failure is an inference error; anything else has no
+// detail to mirror.
+func inferenceErrorDetail(err error) string {
+	var inferenceErr *Error
+	if errors.As(err, &inferenceErr) {
+		return inferenceErr.Detail
+	}
+	return ""
+}
+
 // costMicros converts a Money (Units / 10^Scale) into the integer
 // micro-unit representation the AttrLLMCostMicros attribute uses. It
 // reports ok=false when converting would overflow or a sub-micro
@@ -331,6 +345,10 @@ func (s *telemetryGenerateStream) Next(ctx context.Context) (GenerateStreamEvent
 func (s *telemetryGenerateStream) Result() (GenerateResponse, error) {
 	response, err := s.inner.Result()
 	s.tel.stampUsage(&response.Usage)
+	if err == nil && response.FinishSynthesized {
+		s.tel.span.SetAttributes(
+			attribute.Bool("inference.finish.synthesized", true))
+	}
 	s.finish(response.Metadata, response.Usage, err)
 	return response, err
 }

--- a/core/inference/telemetry_test.go
+++ b/core/inference/telemetry_test.go
@@ -275,6 +275,90 @@ func TestTelemetryGenerateStreamRecordsIDsAtResult(t *testing.T) {
 	assertUsageAttrs(t, spans[0])
 }
 
+func TestTelemetryGenerateStreamRecordsSynthesizedFinish(t *testing.T) {
+	rec := installTestTracer(t)
+	_, call := startInferenceCall(
+		context.Background(), OperationGenerate,
+		ModelRef{ID: ModelID{Provider: "fake", Name: "model-1"}},
+	)
+	stream := &telemetryGenerateStream{
+		inner: &telemetryFakeStream{
+			events: []GenerateStreamEvent{
+				{PartIndex: 0, Delta: TextPartDelta{Text: "hi"}},
+			},
+			result: GenerateResponse{
+				FinishSynthesized: true,
+				Usage:             testUsage(),
+			},
+		},
+		tel: call,
+	}
+	_ = drainGenerateStreamResult(t, stream)
+
+	spans := rec.Ended()
+	if len(spans) != 1 {
+		t.Fatalf("ended spans = %d, want 1", len(spans))
+	}
+	got, ok := spanAttr(spans[0], "inference.finish.synthesized")
+	if !ok || !got.AsBool() {
+		t.Fatalf("inference.finish.synthesized = %v/%v, want true", got, ok)
+	}
+}
+
+func TestTelemetryGenerateStreamOmitsSynthesizedForExplicitFinish(t *testing.T) {
+	rec := installTestTracer(t)
+	_, call := startInferenceCall(
+		context.Background(), OperationGenerate,
+		ModelRef{ID: ModelID{Provider: "fake", Name: "model-1"}},
+	)
+	stream := &telemetryGenerateStream{
+		inner: &telemetryFakeStream{
+			events: []GenerateStreamEvent{
+				{PartIndex: 0, Delta: TextPartDelta{Text: "hi"}},
+			},
+			result: GenerateResponse{
+				Usage: testUsage(),
+			},
+		},
+		tel: call,
+	}
+	_ = drainGenerateStreamResult(t, stream)
+
+	spans := rec.Ended()
+	if len(spans) != 1 {
+		t.Fatalf("ended spans = %d, want 1", len(spans))
+	}
+	if _, ok := spanAttr(spans[0], "inference.finish.synthesized"); ok {
+		t.Fatal("explicit finish must not record inference.finish.synthesized")
+	}
+}
+
+func TestTelemetryMirrorsInferenceErrorKindAndDetail(t *testing.T) {
+	rec := installTestTracer(t)
+	_, call := startInferenceCall(
+		context.Background(), OperationGenerate,
+		ModelRef{ID: ModelID{Provider: "fake", Name: "model-1"}},
+	)
+	infErr := NewError(ProviderTruncated, OperationGenerate, "", errors.New("boom"))
+	infErr.Detail = "stream.finish.missing"
+	call.finish(Metadata{}, Usage{}, infErr)
+
+	spans := rec.Ended()
+	if len(spans) != 1 {
+		t.Fatalf("ended spans = %d, want 1", len(spans))
+	}
+	if got, ok := spanAttr(spans[0], "inference.error_kind"); !ok ||
+		got.AsString() != string(ProviderTruncated) {
+		t.Fatalf("inference.error_kind = %q/%v, want %q",
+			got.AsString(), ok, string(ProviderTruncated))
+	}
+	if got, ok := spanAttr(spans[0], "inference.error.detail"); !ok ||
+		got.AsString() != "stream.finish.missing" {
+		t.Fatalf("inference.error.detail = %q/%v, want stream.finish.missing",
+			got.AsString(), ok)
+	}
+}
+
 func TestAssemblyGenerateEmitsUsageMetrics(t *testing.T) {
 	prev := otel.GetMeterProvider()
 	reader := sdkmetric.NewManualReader()

--- a/docs/guides/graph.md
+++ b/docs/guides/graph.md
@@ -141,6 +141,7 @@ onto `tool_pending_key` and the graph routes onward.
 | `recover_count_key`                      | board var receiving the per-run recovery counter (node hard-fails past `max_per_run`)                               |
 | `recover_feedback_key`                   | board var receiving the user-role feedback text for the recovered round; the recovered inference round consumes it as its current input; defaults to the reserved per-node `__recover_feedback.<node id>` var when unset |
 | `stream`                                 | open a `GenerateStream`; text/reasoning deltas stream incrementally, the board still gets one assembled message   |
+| `stream_failure_policy`                  | `{on_error, on_interrupt}` actions (`commit_partial`, default, or `discard`) for what happens to buffered partial text when a streamed call fails or is interrupted; a recoverable undefined-tool rejection always discards |
 | `tools`                                  | named catalog tools the model may call this turn                                                                  |
 | `all_tools`                              | send the catalog's entire visible set; with `tools`, names are declared `RequiredByName` and must exist           |
 | `tool_choice`                            | constrain when/which tools are called                                                                             |
@@ -219,7 +220,11 @@ Behavior:
   recovered.
 - Usage is reported to the host on every call. In stream mode a mid-stream
   failure commits the buffered partial text to the board and reports the
-  last usage snapshot before propagating the error.
+  last usage snapshot before propagating the error — unless
+  `stream_failure_policy` is `discard` for that termination category, or
+  the failure is a recoverable undefined-tool rejection (which never
+  materializes partial text so the recovered round keeps a clean
+  transcript).
 
 ```json
 {

--- a/driver/anthropic/generate_stream.go
+++ b/driver/anthropic/generate_stream.go
@@ -61,6 +61,9 @@ func (s *messagesStream) Close() error {
 	return classifyError(s.stream.Close())
 }
 
+func (s *messagesStream) RequestID() string  { return "" }
+func (s *messagesStream) ResponseID() string { return s.id }
+
 func (s *messagesStream) Next(ctx context.Context) (streamRaw, error) {
 	if err := ctx.Err(); err != nil {
 		return streamRaw{}, errdefs.FromContext(err)

--- a/driver/anthropic/generate_stream_meta_test.go
+++ b/driver/anthropic/generate_stream_meta_test.go
@@ -1,0 +1,19 @@
+package anthropic
+
+import (
+	"testing"
+
+	"github.com/GizClaw/flowcraft/core/inference"
+)
+
+var _ inference.ProviderStreamMetadata = (*messagesStream)(nil)
+
+func TestMessagesStreamMetadataExposesMessageID(t *testing.T) {
+	stream := &messagesStream{id: "msg_01AbC"}
+	if got := stream.ResponseID(); got != "msg_01AbC" {
+		t.Fatalf("ResponseID = %q, want msg_01AbC", got)
+	}
+	if got := stream.RequestID(); got != "" {
+		t.Fatalf("RequestID = %q, want empty", got)
+	}
+}

--- a/driver/azure/generate_stream.go
+++ b/driver/azure/generate_stream.go
@@ -10,6 +10,7 @@ import (
 	"github.com/GizClaw/flowcraft/core/inference"
 
 	"github.com/openai/openai-go/v3"
+	"github.com/openai/openai-go/v3/option"
 	"github.com/openai/openai-go/v3/packages/ssestream"
 	"github.com/openai/openai-go/v3/responses"
 )
@@ -30,6 +31,10 @@ type responsesStream struct {
 	// hosted web_search tool. Stream events replace it as calls and
 	// citations arrive.
 	webSearchOutput WebSearchOutput
+
+	// requestID is the provider x-request-id header captured at stream
+	// open; it survives truncation where the terminal event does not.
+	requestID string
 }
 
 type streamPart struct {
@@ -49,10 +54,13 @@ func transportGenerateStream(
 		ctx context.Context,
 		wire generateWire,
 	) (inference.ProviderStream[streamRaw], error) {
+		var requestID string
+		opts := append([]option.RequestOption(nil), requestMetadataOptions(wire)...)
+		opts = append(opts, captureRequestID(&requestID))
 		stream := client.Responses.NewStreaming(
 			ctx,
 			wireToParams(wire),
-			requestMetadataOptions(wire)...,
+			opts...,
 		)
 		if err := stream.Err(); err != nil {
 			classified := classifyError(err)
@@ -61,11 +69,15 @@ func transportGenerateStream(
 		}
 		logInferenceStream(ctx, "generate", wire.model, nil, "")
 		return &responsesStream{
-			stream: stream,
-			parts:  make(map[int64]*streamPart),
+			stream:    stream,
+			parts:     make(map[int64]*streamPart),
+			requestID: requestID,
 		}, nil
 	}
 }
+
+func (s *responsesStream) RequestID() string  { return s.requestID }
+func (s *responsesStream) ResponseID() string { return "" }
 
 func (s *responsesStream) Close() error {
 	if s.stream == nil {

--- a/driver/azure/generate_stream_meta_test.go
+++ b/driver/azure/generate_stream_meta_test.go
@@ -1,0 +1,82 @@
+package azure
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/GizClaw/flowcraft/core/inference"
+	"github.com/GizClaw/flowcraft/core/resource"
+)
+
+var _ inference.ProviderStreamMetadata = (*responsesStream)(nil)
+var _ inference.ProviderStreamMetadata = (*imageStream)(nil)
+
+func TestResponsesStreamMetadataSurfacesRequestID(t *testing.T) {
+	stream := &responsesStream{requestID: "req_azure_1"}
+	if got := stream.RequestID(); got != "req_azure_1" {
+		t.Fatalf("RequestID = %q, want req_azure_1", got)
+	}
+}
+
+func TestImageStreamMetadataSurfacesRequestID(t *testing.T) {
+	stream := &imageStream{requestID: "req_azure_img_1"}
+	if got := stream.RequestID(); got != "req_azure_img_1" {
+		t.Fatalf("RequestID = %q, want req_azure_img_1", got)
+	}
+}
+
+func TestResponsesStreamTransportCapturesRequestID(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/openai/responses" {
+			t.Errorf("path = %q, want /openai/responses", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.Header().Set("x-request-id", "req_azure_responses_1")
+		_, _ = fmt.Fprint(w, "data: [DONE]\n\n")
+	}))
+	defer server.Close()
+
+	spec, err := decodeSpec(context.Background(), []byte(fmt.Sprintf(`{
+		"endpoint": %q,
+		"models": [{
+			"name": "deploy",
+			"kind": "generate",
+			"capabilities": {"outputs": ["text"]}
+		}]
+	}`, server.URL)))
+	if err != nil {
+		t.Fatalf("decodeSpec: %v", err)
+	}
+	cls, err := profileMaterial{
+		apiKey: resource.LiteralSecret("test-key"),
+	}.newClients(context.Background(), spec)
+	if err != nil {
+		t.Fatalf("newClients: %v", err)
+	}
+
+	compiled, err := compileGenerate("deploy", entryFor(ModelSpec{Name: "deploy", Kind: "generate"}))(
+		context.Background(),
+		conformanceModel("deploy"),
+		conformanceTextRequest(),
+		inference.GenerateExecutionStream,
+	)
+	if err != nil {
+		t.Fatalf("compile responses stream: %v", err)
+	}
+	stream, err := transportGenerateStream(cls.api)(context.Background(), compiled.Wire)
+	if err != nil {
+		t.Fatalf("open stream: %v", err)
+	}
+	defer func() { _ = stream.Close() }()
+
+	meta, ok := stream.(inference.ProviderStreamMetadata)
+	if !ok {
+		t.Fatal("responses stream must expose provider stream metadata")
+	}
+	if got := meta.RequestID(); got != "req_azure_responses_1" {
+		t.Fatalf("stream request id = %q, want req_azure_responses_1", got)
+	}
+}

--- a/driver/azure/image.go
+++ b/driver/azure/image.go
@@ -667,6 +667,9 @@ func (s *imageStream) Close() error {
 	return classifyError(s.sdk.Close())
 }
 
+func (s *imageStream) RequestID() string  { return s.requestID }
+func (s *imageStream) ResponseID() string { return "" }
+
 func transportImageStream(
 	client openai.Client,
 ) inference.Transport[imageWire, inference.ProviderStream[imageStreamRaw]] {

--- a/driver/bytedance/generate_stream.go
+++ b/driver/bytedance/generate_stream.go
@@ -10,6 +10,7 @@ import (
 	"github.com/GizClaw/flowcraft/core/inference"
 
 	"github.com/volcengine/volcengine-go-sdk/service/arkruntime"
+	arkmodel "github.com/volcengine/volcengine-go-sdk/service/arkruntime/model"
 	arkresponses "github.com/volcengine/volcengine-go-sdk/service/arkruntime/model/responses"
 	"github.com/volcengine/volcengine-go-sdk/service/arkruntime/utils"
 )
@@ -20,6 +21,10 @@ import (
 // into deltas, so the decoder function stays pure.
 type responsesStream struct {
 	reader *utils.ResponsesStreamReader
+	// requestID is the provider-echoed X-Client-Request-Id header captured
+	// from the stream response at open; it survives truncation where the
+	// terminal event does not.
+	requestID string
 
 	parts    map[int64]*streamPart // ark output index → canonical part
 	nextPart int
@@ -55,11 +60,15 @@ func transportGenerateStream(
 		}
 		logInferenceStream(ctx, "generate", wire.model, nil, "")
 		return &responsesStream{
-			reader: reader,
-			parts:  make(map[int64]*streamPart),
+			reader:    reader,
+			requestID: reader.Header().Get(arkmodel.ClientRequestHeader),
+			parts:     make(map[int64]*streamPart),
 		}, nil
 	}
 }
+
+func (s *responsesStream) RequestID() string  { return s.requestID }
+func (s *responsesStream) ResponseID() string { return "" }
 
 func (s *responsesStream) Close() error {
 	if s.reader == nil {

--- a/driver/bytedance/generate_stream_meta_test.go
+++ b/driver/bytedance/generate_stream_meta_test.go
@@ -1,0 +1,58 @@
+package bytedance
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/GizClaw/flowcraft/core/inference"
+
+	"github.com/volcengine/volcengine-go-sdk/service/arkruntime"
+	arkmodel "github.com/volcengine/volcengine-go-sdk/service/arkruntime/model"
+)
+
+var _ inference.ProviderStreamMetadata = (*responsesStream)(nil)
+
+func TestResponsesStreamMetadataCapturesRequestID(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		if request.URL.Path != "/responses" {
+			t.Errorf("path = %q, want /responses", request.URL.Path)
+		}
+		writer.Header().Set("Content-Type", "text/event-stream")
+		writer.Header().Set(arkmodel.ClientRequestHeader, "req-ark-1")
+		_, _ = fmt.Fprint(writer, "data: [DONE]\n\n")
+	}))
+	defer server.Close()
+
+	client := arkruntime.NewClientWithApiKey(
+		"test-key",
+		arkruntime.WithBaseUrl(server.URL),
+	)
+	compiled, err := compileGenerate(
+		"doubao-seed-2-0-lite",
+		catalog["doubao-seed-2-0-lite"],
+	)(
+		context.Background(),
+		conformanceModel("doubao-seed-2-0-lite"),
+		conformanceTextRequest(),
+		inference.GenerateExecutionStream,
+	)
+	if err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+	stream, err := transportGenerateStream(client)(context.Background(), compiled.Wire)
+	if err != nil {
+		t.Fatalf("open stream: %v", err)
+	}
+	defer func() { _ = stream.Close() }()
+
+	meta, ok := stream.(inference.ProviderStreamMetadata)
+	if !ok {
+		t.Fatal("responses stream must expose provider stream metadata")
+	}
+	if got := meta.RequestID(); got != "req-ark-1" {
+		t.Fatalf("stream request id = %q, want req-ark-1", got)
+	}
+}

--- a/driver/deepseek/generate.go
+++ b/driver/deepseek/generate.go
@@ -76,13 +76,17 @@ const (
 )
 
 type streamRaw struct {
-	kind            streamRawKind
-	part            int // canonical part index, assigned by the transport
-	text            string
-	responseID      string
-	tool            streamRawTool
-	usage           *rawUsage
-	finish          inference.FinishReason
+	kind       streamRawKind
+	part       int // canonical part index, assigned by the transport
+	text       string
+	responseID string
+	tool       streamRawTool
+	usage      *rawUsage
+	finish     inference.FinishReason
+	// synthesized marks a finish reason fabricated by the adapter when
+	// the stream ended without a provider terminal event (e.g. a clean
+	// EOF between frames). It rides the finish raw to the decoded event.
+	synthesized     bool
 	providerOutputs inference.ProviderOutputs
 	reasoningID     string
 }
@@ -317,9 +321,10 @@ func decodeGenerateStream(
 		}, nil
 	case streamRawFinish:
 		event := inference.GenerateStreamEvent{
-			FinishReason:    raw.finish,
-			ResponseID:      raw.responseID,
-			ProviderOutputs: raw.providerOutputs.Clone(),
+			FinishReason:      raw.finish,
+			FinishSynthesized: raw.synthesized,
+			ResponseID:        raw.responseID,
+			ProviderOutputs:   raw.providerOutputs.Clone(),
 		}
 		logInferenceStreamEnd(ctx, "generate", raw.responseID)
 		if raw.usage != nil {

--- a/driver/deepseek/generate_chat.go
+++ b/driver/deepseek/generate_chat.go
@@ -758,6 +758,13 @@ type chatStream struct {
 	sawTools  bool
 	ended     bool
 	id        string
+
+	// requestID is the provider x-request-id header captured at stream
+	// open; it survives truncation where the terminal event does not.
+	requestID string
+
+	// model identifies the requested model for stream lifecycle warnings.
+	model string
 }
 
 // transportChatGenerateStream opens the streaming request and returns the
@@ -770,6 +777,8 @@ func transportChatGenerateStream(
 		wire chatWire,
 	) (inference.ProviderStream[streamRaw], error) {
 		params, overrides := wireToChatParams(wire)
+		var requestID string
+		overrides = append(overrides, captureRequestID(&requestID))
 		stream := client.Chat.Completions.NewStreaming(ctx, params, overrides...)
 		if stream == nil {
 			return nil, errdefs.NotAvailablef(
@@ -786,9 +795,14 @@ func transportChatGenerateStream(
 			reasoningPart: -1,
 			textPart:      -1,
 			toolParts:     make(map[int64]int),
+			requestID:     requestID,
+			model:         wire.model,
 		}, nil
 	}
 }
+
+func (s *chatStream) RequestID() string  { return s.requestID }
+func (s *chatStream) ResponseID() string { return s.id }
 
 func (s *chatStream) Close() error {
 	if s.stream == nil {
@@ -816,7 +830,10 @@ func (s *chatStream) Next(ctx context.Context) (streamRaw, error) {
 				logInferenceStream(ctx, "generate", "", classified, "")
 				return streamRaw{}, classified
 			}
-			s.end()
+			if synthesized := s.end(); synthesized != "" {
+				logChatFinishSynthesized(
+					ctx, s.model, s.requestID, s.id, synthesized)
+			}
 			continue
 		}
 		s.apply(s.stream.Current())
@@ -889,28 +906,35 @@ func (s *chatStream) apply(chunk openaigo.ChatCompletionChunk) {
 
 // end emits the terminal event exactly once: the recorded finish reason
 // (defaulting to completed, or tool_calls when calls streamed without an
-// explicit reason) plus the usage chunk's accounting.
-func (s *chatStream) end() {
+// explicit reason) plus the usage chunk's accounting. It returns the
+// synthesized reason when the provider never sent an explicit one, so
+// callers can warn that the stream may have been truncated.
+func (s *chatStream) end() string {
 	if s.ended {
-		return
+		return ""
 	}
 	s.ended = true
 	if s.finishErr != nil {
-		return
+		return ""
 	}
+	synthesized := ""
 	finish := s.finish
 	if finish == "" && s.sawTools {
 		finish = inference.FinishToolCalls
+		synthesized = string(finish)
 	}
 	if finish == "" {
 		finish = inference.FinishCompleted
+		synthesized = string(finish)
 	}
 	s.pending = append(s.pending, streamRaw{
-		kind:       streamRawFinish,
-		finish:     finish,
-		usage:      s.usage,
-		responseID: s.id,
+		kind:        streamRawFinish,
+		finish:      finish,
+		usage:       s.usage,
+		responseID:  s.id,
+		synthesized: synthesized != "",
 	})
+	return synthesized
 }
 
 func (s *chatStream) assignPart() int {

--- a/driver/deepseek/generate_responses.go
+++ b/driver/deepseek/generate_responses.go
@@ -918,6 +918,10 @@ type deepseekStream struct {
 	sawTools bool
 
 	webSearchOutput WebSearchOutput
+
+	// requestID is the provider x-request-id header captured at stream
+	// open; it survives truncation where the terminal event does not.
+	requestID string
 }
 
 type deepseekStreamPart struct {
@@ -936,10 +940,13 @@ func transportResponsesGenerateStream(
 		ctx context.Context,
 		wire responseWire,
 	) (inference.ProviderStream[streamRaw], error) {
+		var requestID string
+		opts := append([]option.RequestOption(nil), responseMetadataOptions(wire)...)
+		opts = append(opts, captureRequestID(&requestID))
 		stream := client.Responses.NewStreaming(
 			ctx,
 			wireToResponseParams(wire),
-			responseMetadataOptions(wire)...,
+			opts...,
 		)
 		if err := stream.Err(); err != nil {
 			classified := classifyError(err)
@@ -948,11 +955,15 @@ func transportResponsesGenerateStream(
 		}
 		logInferenceStream(ctx, "generate", wire.model, nil, "")
 		return &deepseekStream{
-			stream: stream,
-			parts:  make(map[int64]*deepseekStreamPart),
+			stream:    stream,
+			parts:     make(map[int64]*deepseekStreamPart),
+			requestID: requestID,
 		}, nil
 	}
 }
+
+func (s *deepseekStream) RequestID() string  { return s.requestID }
+func (s *deepseekStream) ResponseID() string { return "" }
 
 func (s *deepseekStream) Close() error {
 	if s.stream == nil {

--- a/driver/deepseek/generate_test.go
+++ b/driver/deepseek/generate_test.go
@@ -303,6 +303,200 @@ func TestChatClientMetadataForwardedOnUnaryBody(t *testing.T) {
 	}
 }
 
+func TestChatStreamTransportCapturesRequestID(t *testing.T) {
+	server := newCapturedServer(t, func(w http.ResponseWriter, _ map[string]any) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.Header().Set("x-request-id", "req_ds_stream_1")
+		_, _ = fmt.Fprint(w, sseBody(
+			map[string]any{
+				"id": "chatcmpl_ds_1", "object": "chat.completion.chunk",
+				"choices": []any{map[string]any{
+					"index":         0,
+					"delta":         map[string]any{"role": "assistant", "content": "ok"},
+					"finish_reason": nil,
+				}},
+			},
+			map[string]any{
+				"id": "chatcmpl_ds_1", "object": "chat.completion.chunk",
+				"choices": []any{map[string]any{
+					"index": 0, "delta": map[string]any{}, "finish_reason": "stop",
+				}},
+			},
+		))
+	})
+	cls := testClients(t, server.Server)
+
+	compiled, err := compileChatGenerate("deepseek-v4-flash", chatEntry())(
+		context.Background(),
+		deepseekModel("deepseek-v4-flash"),
+		simpleTextRequest("hi"),
+		inference.GenerateExecutionStream,
+	)
+	if err != nil {
+		t.Fatalf("compile chat stream: %v", err)
+	}
+	stream, err := transportChatGenerateStream(cls.api)(
+		context.Background(),
+		compiled.Wire,
+	)
+	if err != nil {
+		t.Fatalf("open stream: %v", err)
+	}
+	defer func() { _ = stream.Close() }()
+
+	meta, ok := stream.(inference.ProviderStreamMetadata)
+	if !ok {
+		t.Fatal("chat stream must expose provider stream metadata")
+	}
+	if got := meta.RequestID(); got != "req_ds_stream_1" {
+		t.Fatalf("stream request id = %q, want req_ds_stream_1", got)
+	}
+	if got := meta.ResponseID(); got != "" {
+		t.Fatalf("stream response id before chunks = %q, want empty", got)
+	}
+}
+
+func TestChatStreamTruncatedEOFSurfacesSynthesizedFinish(t *testing.T) {
+	server := newCapturedServer(t, func(w http.ResponseWriter, _ map[string]any) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		// The provider sends content chunks and then closes the stream
+		// without a terminal finish_reason chunk — the truncation shape a
+		// chat-completions adapter cannot distinguish from a clean EOF.
+		_, _ = fmt.Fprint(w, sseBody(
+			map[string]any{
+				"id": "chatcmpl_ds_1", "object": "chat.completion.chunk",
+				"choices": []any{map[string]any{
+					"index":         0,
+					"delta":         map[string]any{"role": "assistant", "content": "hel"},
+					"finish_reason": nil,
+				}},
+			},
+			map[string]any{
+				"id": "chatcmpl_ds_1", "object": "chat.completion.chunk",
+				"choices": []any{map[string]any{
+					"index": 0, "delta": map[string]any{"content": "lo"},
+					"finish_reason": nil,
+				}},
+			},
+		))
+	})
+	cls := testClients(t, server.Server)
+
+	compiled, err := compileChatGenerate("deepseek-v4-flash", chatEntry())(
+		context.Background(),
+		deepseekModel("deepseek-v4-flash"),
+		simpleTextRequest("hi"),
+		inference.GenerateExecutionStream,
+	)
+	if err != nil {
+		t.Fatalf("compile chat stream: %v", err)
+	}
+	stream, err := transportChatGenerateStream(cls.api)(
+		context.Background(),
+		compiled.Wire,
+	)
+	if err != nil {
+		t.Fatalf("open stream: %v", err)
+	}
+	defer func() { _ = stream.Close() }()
+
+	var text string
+	var finish inference.FinishReason
+	synthesized := false
+	for {
+		raw, err := stream.Next(context.Background())
+		if err != nil {
+			break
+		}
+		event, err := decodeGenerateStream(context.Background(), raw)
+		if err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		if delta, ok := event.Delta.(inference.TextPartDelta); ok {
+			text += delta.Text
+		}
+		if event.FinishReason != "" {
+			finish = event.FinishReason
+			synthesized = event.FinishSynthesized
+		}
+	}
+	if text != "hello" || finish != inference.FinishCompleted || !synthesized {
+		t.Fatalf("truncated stream text=%q finish=%q synthesized=%v, want hello/completed/true",
+			text, finish, synthesized)
+	}
+}
+
+func TestResponsesStreamTransportCapturesRequestID(t *testing.T) {
+	server := newCapturedServer(t, func(w http.ResponseWriter, _ map[string]any) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.Header().Set("x-request-id", "req_ds_responses_1")
+		_, _ = fmt.Fprint(w, "data: [DONE]\n\n")
+	})
+	cls := testClients(t, server.Server)
+
+	compiled, err := compileResponsesGenerate("deepseek-v4-flash", responsesEntry())(
+		context.Background(),
+		deepseekModel("deepseek-v4-flash"),
+		simpleTextRequest("hi"),
+		inference.GenerateExecutionStream,
+	)
+	if err != nil {
+		t.Fatalf("compile responses stream: %v", err)
+	}
+	stream, err := transportResponsesGenerateStream(cls.api)(
+		context.Background(),
+		compiled.Wire,
+	)
+	if err != nil {
+		t.Fatalf("open stream: %v", err)
+	}
+	defer func() { _ = stream.Close() }()
+
+	meta, ok := stream.(inference.ProviderStreamMetadata)
+	if !ok {
+		t.Fatal("responses stream must expose provider stream metadata")
+	}
+	if got := meta.RequestID(); got != "req_ds_responses_1" {
+		t.Fatalf("stream request id = %q, want req_ds_responses_1", got)
+	}
+}
+
+func TestChatStreamEndReportsSynthesizedFinishOnlyWithoutExplicitReason(t *testing.T) {
+	truncated := &chatStream{sawTools: true}
+	if got := truncated.end(); got != string(inference.FinishToolCalls) {
+		t.Fatalf("end() = %q, want synthesized tool_calls", got)
+	}
+	if len(truncated.pending) != 1 ||
+		!truncated.pending[0].synthesized ||
+		truncated.pending[0].finish != inference.FinishToolCalls {
+		t.Fatalf("synthesized finish payload = %+v, want synthesized tool_calls",
+			truncated.pending)
+	}
+	if got := truncated.end(); got != "" {
+		t.Fatalf("second end() = %q, want empty", got)
+	}
+
+	explicit := &chatStream{finish: inference.FinishCompleted}
+	if got := explicit.end(); got != "" {
+		t.Fatalf("end() with explicit finish = %q, want empty", got)
+	}
+	if len(explicit.pending) != 1 ||
+		explicit.pending[0].synthesized ||
+		explicit.pending[0].finish != inference.FinishCompleted {
+		t.Fatalf("explicit finish payload = %+v, want non-synthesized completed",
+			explicit.pending)
+	}
+
+	textOnly := &chatStream{}
+	if got := textOnly.end(); got != string(inference.FinishCompleted) {
+		t.Fatalf("end() without tools/finish = %q, want synthesized completed", got)
+	}
+	if len(textOnly.pending) != 1 ||
+		!textOnly.pending[0].synthesized {
+		t.Fatalf("text-only synthesized payload = %+v, want synthesized", textOnly.pending)
+	}
+}
+
 func TestChatReasoningRoundTrip(t *testing.T) {
 	server := newCapturedServer(t, func(w http.ResponseWriter, _ map[string]any) {
 		w.Header().Set("Content-Type", "application/json")

--- a/driver/deepseek/request_id.go
+++ b/driver/deepseek/request_id.go
@@ -1,0 +1,30 @@
+package deepseek
+
+import (
+	"net/http"
+
+	"github.com/openai/openai-go/v3/option"
+)
+
+// captureRequestID returns a per-call request option whose middleware
+// records the provider's request-id response header. The middleware runs on
+// every HTTP attempt, so the last attempt's header wins. DeepSeek echoes
+// the request identifier as x-request-id; apim-request-id covers
+// Azure-backed deployments of the same protocol.
+func captureRequestID(target *string) option.RequestOption {
+	return option.WithMiddleware(func(
+		req *http.Request,
+		next option.MiddlewareNext,
+	) (*http.Response, error) {
+		response, err := next(req)
+		if err != nil || response == nil {
+			return response, err
+		}
+		if id := response.Header.Get("x-request-id"); id != "" {
+			*target = id
+		} else if id := response.Header.Get("apim-request-id"); id != "" {
+			*target = id
+		}
+		return response, err
+	})
+}

--- a/driver/deepseek/telemetry.go
+++ b/driver/deepseek/telemetry.go
@@ -49,6 +49,22 @@ func logInferenceStreamEnd(ctx context.Context, op, responseID string) {
 		inferenceAttrs(op, "", nil, "", responseID)...)
 }
 
+// logChatFinishSynthesized warns when a chat stream ended cleanly without
+// an explicit finish_reason and the adapter fabricated the terminal
+// reason. The provider (or an intermediary) may have truncated the stream
+// mid-flight, so the synthesized finish must not be silently trusted.
+func logChatFinishSynthesized(
+	ctx context.Context,
+	model, requestID, responseID, synthesized string,
+) {
+	attrs := inferenceAttrs("generate", model, nil, requestID, responseID)
+	attrs = append(attrs,
+		otellog.String("stream.finish.synthesized", synthesized))
+	telemetry.Warn(ctx,
+		"chat stream ended without a finish reason; finish synthesized",
+		attrs...)
+}
+
 func inferenceAttrs(
 	op, model string,
 	err error,

--- a/driver/kimi/chat_finish_test.go
+++ b/driver/kimi/chat_finish_test.go
@@ -1,0 +1,71 @@
+package kimi
+
+import (
+	"context"
+	"testing"
+
+	"github.com/GizClaw/flowcraft/core/inference"
+)
+
+func TestChatStreamEndReportsSynthesizedFinishOnlyWithoutExplicitReason(t *testing.T) {
+	truncated := &chatStream{sawTools: true}
+	if got := truncated.end(); got != string(inference.FinishToolCalls) {
+		t.Fatalf("end() = %q, want synthesized tool_calls", got)
+	}
+	if len(truncated.pending) != 1 ||
+		!truncated.pending[0].synthesized ||
+		truncated.pending[0].finish != inference.FinishToolCalls {
+		t.Fatalf("synthesized finish payload = %+v, want synthesized tool_calls",
+			truncated.pending)
+	}
+	if got := truncated.end(); got != "" {
+		t.Fatalf("second end() = %q, want empty", got)
+	}
+
+	explicit := &chatStream{finish: inference.FinishCompleted}
+	if got := explicit.end(); got != "" {
+		t.Fatalf("end() with explicit finish = %q, want empty", got)
+	}
+	if len(explicit.pending) != 1 ||
+		explicit.pending[0].synthesized ||
+		explicit.pending[0].finish != inference.FinishCompleted {
+		t.Fatalf("explicit finish payload = %+v, want non-synthesized completed",
+			explicit.pending)
+	}
+
+	textOnly := &chatStream{}
+	if got := textOnly.end(); got != string(inference.FinishCompleted) {
+		t.Fatalf("end() without tools/finish = %q, want synthesized completed", got)
+	}
+	if len(textOnly.pending) != 1 ||
+		!textOnly.pending[0].synthesized {
+		t.Fatalf("text-only synthesized payload = %+v, want synthesized", textOnly.pending)
+	}
+}
+
+func TestDecodeGenerateStreamPropagatesSynthesizedFinish(t *testing.T) {
+	synthesized := streamRaw{
+		kind:        streamRawFinish,
+		finish:      inference.FinishCompleted,
+		synthesized: true,
+	}
+	event, err := decodeGenerateStream(context.Background(), synthesized)
+	if err != nil {
+		t.Fatalf("decode synthesized finish: %v", err)
+	}
+	if event.FinishReason != inference.FinishCompleted || !event.FinishSynthesized {
+		t.Fatalf("decoded synthesized finish = %+v", event)
+	}
+
+	explicit := streamRaw{
+		kind:   streamRawFinish,
+		finish: inference.FinishCompleted,
+	}
+	event, err = decodeGenerateStream(context.Background(), explicit)
+	if err != nil {
+		t.Fatalf("decode explicit finish: %v", err)
+	}
+	if event.FinishSynthesized {
+		t.Fatalf("decoded explicit finish must not be synthesized: %+v", event)
+	}
+}

--- a/driver/kimi/generate_stream.go
+++ b/driver/kimi/generate_stream.go
@@ -58,6 +58,10 @@ type streamRaw struct {
 	tool       streamRawTool
 	usage      *rawUsage
 	finish     inference.FinishReason
+	// synthesized marks a finish reason fabricated by the adapter when
+	// the stream ended without a provider terminal event (e.g. a clean
+	// EOF between frames). It rides the finish raw to the decoded event.
+	synthesized bool
 }
 
 type streamRawTool struct {
@@ -87,6 +91,9 @@ type chatStream struct {
 	sawTools bool
 	ended    bool
 	id       string // chat completion id from the stream chunks
+
+	// model identifies the requested model for stream lifecycle warnings.
+	model string
 }
 
 // transportGenerateStream opens the streaming request and returns the
@@ -132,6 +139,7 @@ func transportGenerateStream(client *kimiClient) inference.Transport[generateWir
 			reasoningPart: -1,
 			textPart:      -1,
 			toolParts:     make(map[int64]int),
+			model:         wire.Model,
 		}, nil
 	}
 }
@@ -152,7 +160,10 @@ func (s *chatStream) Next(ctx context.Context) (streamRaw, error) {
 		select {
 		case event, ok := <-s.events:
 			if !ok {
-				s.end()
+				if synthesized := s.end(); synthesized != "" {
+					logChatFinishSynthesized(
+						ctx, s.model, "", s.id, synthesized)
+				}
 				continue
 			}
 			if err := s.apply(event.data); err != nil {
@@ -220,25 +231,32 @@ func (s *chatStream) apply(data []byte) error {
 
 // end emits the terminal event exactly once: the recorded finish reason
 // (defaulting to completed, or tool_calls when calls streamed without an
-// explicit reason) plus the usage chunk's accounting.
-func (s *chatStream) end() {
+// explicit reason) plus the usage chunk's accounting. It returns the
+// synthesized reason when the provider never sent an explicit one, so
+// callers can warn that the stream may have been truncated.
+func (s *chatStream) end() string {
 	if s.ended {
-		return
+		return ""
 	}
 	s.ended = true
+	synthesized := ""
 	finish := s.finish
 	if finish == "" && s.sawTools {
 		finish = inference.FinishToolCalls
+		synthesized = string(finish)
 	}
 	if finish == "" {
 		finish = inference.FinishCompleted
+		synthesized = string(finish)
 	}
 	s.pending = append(s.pending, streamRaw{
-		kind:       streamRawFinish,
-		finish:     finish,
-		usage:      s.usage,
-		responseID: s.id,
+		kind:        streamRawFinish,
+		finish:      finish,
+		usage:       s.usage,
+		responseID:  s.id,
+		synthesized: synthesized != "",
 	})
+	return synthesized
 }
 
 func (s *chatStream) assignPart() int {
@@ -286,8 +304,9 @@ func decodeGenerateStream(ctx context.Context, raw streamRaw) (inference.Generat
 		}, nil
 	case streamRawFinish:
 		event := inference.GenerateStreamEvent{
-			FinishReason: raw.finish,
-			ResponseID:   raw.responseID,
+			FinishReason:      raw.finish,
+			FinishSynthesized: raw.synthesized,
+			ResponseID:        raw.responseID,
 		}
 		logInferenceStreamEnd(ctx, "generate", raw.responseID)
 		if raw.usage != nil {

--- a/driver/kimi/generate_stream.go
+++ b/driver/kimi/generate_stream.go
@@ -92,6 +92,10 @@ type chatStream struct {
 	ended    bool
 	id       string // chat completion id from the stream chunks
 
+	// requestID is the provider x-request-id header captured at stream
+	// open; it survives truncation where the terminal event does not.
+	requestID string
+
 	// model identifies the requested model for stream lifecycle warnings.
 	model string
 }
@@ -139,10 +143,14 @@ func transportGenerateStream(client *kimiClient) inference.Transport[generateWir
 			reasoningPart: -1,
 			textPart:      -1,
 			toolParts:     make(map[int64]int),
+			requestID:     response.Header.Get("x-request-id"),
 			model:         wire.Model,
 		}, nil
 	}
 }
+
+func (s *chatStream) RequestID() string  { return s.requestID }
+func (s *chatStream) ResponseID() string { return s.id }
 
 func (s *chatStream) Close() error {
 	s.cancel()
@@ -162,7 +170,7 @@ func (s *chatStream) Next(ctx context.Context) (streamRaw, error) {
 			if !ok {
 				if synthesized := s.end(); synthesized != "" {
 					logChatFinishSynthesized(
-						ctx, s.model, "", s.id, synthesized)
+						ctx, s.model, s.requestID, s.id, synthesized)
 				}
 				continue
 			}

--- a/driver/kimi/generate_stream_meta_test.go
+++ b/driver/kimi/generate_stream_meta_test.go
@@ -1,0 +1,22 @@
+package kimi
+
+import (
+	"testing"
+
+	"github.com/GizClaw/flowcraft/core/inference"
+)
+
+var _ inference.ProviderStreamMetadata = (*chatStream)(nil)
+
+func TestChatStreamMetadataExposesRequestAndResponseIDs(t *testing.T) {
+	stream := &chatStream{
+		requestID: "req_kimi_1",
+		id:        "chatcmpl_kimi_1",
+	}
+	if got := stream.RequestID(); got != "req_kimi_1" {
+		t.Fatalf("RequestID = %q, want req_kimi_1", got)
+	}
+	if got := stream.ResponseID(); got != "chatcmpl_kimi_1" {
+		t.Fatalf("ResponseID = %q, want chatcmpl_kimi_1", got)
+	}
+}

--- a/driver/kimi/telemetry.go
+++ b/driver/kimi/telemetry.go
@@ -49,6 +49,22 @@ func logInferenceStreamEnd(ctx context.Context, op, responseID string) {
 		inferenceAttrs(op, "", nil, "", responseID)...)
 }
 
+// logChatFinishSynthesized warns when a chat stream ended cleanly without
+// an explicit finish_reason and the adapter fabricated the terminal
+// reason. The provider (or an intermediary) may have truncated the stream
+// mid-flight, so the synthesized finish must not be silently trusted.
+func logChatFinishSynthesized(
+	ctx context.Context,
+	model, requestID, responseID, synthesized string,
+) {
+	attrs := inferenceAttrs("generate", model, nil, requestID, responseID)
+	attrs = append(attrs,
+		otellog.String("stream.finish.synthesized", synthesized))
+	telemetry.Warn(ctx,
+		"chat stream ended without a finish reason; finish synthesized",
+		attrs...)
+}
+
 func inferenceAttrs(
 	op, model string,
 	err error,

--- a/driver/minimax/generate_stream.go
+++ b/driver/minimax/generate_stream.go
@@ -61,6 +61,9 @@ func (s *messagesStream) Close() error {
 	return classifyError(s.stream.Close())
 }
 
+func (s *messagesStream) RequestID() string  { return "" }
+func (s *messagesStream) ResponseID() string { return s.id }
+
 func (s *messagesStream) Next(ctx context.Context) (streamRaw, error) {
 	if err := ctx.Err(); err != nil {
 		return streamRaw{}, errdefs.FromContext(err)

--- a/driver/minimax/generate_stream_meta_test.go
+++ b/driver/minimax/generate_stream_meta_test.go
@@ -1,0 +1,19 @@
+package minimax
+
+import (
+	"testing"
+
+	"github.com/GizClaw/flowcraft/core/inference"
+)
+
+var _ inference.ProviderStreamMetadata = (*messagesStream)(nil)
+
+func TestMessagesStreamMetadataExposesMessageID(t *testing.T) {
+	stream := &messagesStream{id: "msg_01AbC"}
+	if got := stream.ResponseID(); got != "msg_01AbC" {
+		t.Fatalf("ResponseID = %q, want msg_01AbC", got)
+	}
+	if got := stream.RequestID(); got != "" {
+		t.Fatalf("RequestID = %q, want empty", got)
+	}
+}

--- a/driver/openai/generate.go
+++ b/driver/openai/generate.go
@@ -170,15 +170,19 @@ type rawUsage struct {
 // canonical part indices (it is the stateful stage) so the decoder function
 // stays pure and concurrency-safe.
 type streamRaw struct {
-	kind            streamRawKind
-	part            int    // canonical part index (text / tool / reasoning kinds)
-	text            string // text / summary delta
-	signature       string // terminal reasoning encrypted payload
-	id              string // terminal reasoning item id
-	responseID      string // response-level id from the terminal event
-	tool            streamRawTool
-	usage           *rawUsage
-	finish          inference.FinishReason
+	kind       streamRawKind
+	part       int    // canonical part index (text / tool / reasoning kinds)
+	text       string // text / summary delta
+	signature  string // terminal reasoning encrypted payload
+	id         string // terminal reasoning item id
+	responseID string // response-level id from the terminal event
+	tool       streamRawTool
+	usage      *rawUsage
+	finish     inference.FinishReason
+	// synthesized marks a finish reason fabricated by the adapter when
+	// the stream ended without a provider terminal event (e.g. a clean
+	// EOF between frames). It rides the finish raw to the decoded event.
+	synthesized     bool
 	providerOutputs inference.ProviderOutputs
 }
 

--- a/driver/openai/generate_chat.go
+++ b/driver/openai/generate_chat.go
@@ -9,6 +9,7 @@ import (
 	"github.com/GizClaw/flowcraft/core/inference"
 
 	"github.com/openai/openai-go/v3"
+	"github.com/openai/openai-go/v3/option"
 	"github.com/openai/openai-go/v3/packages/param"
 	"github.com/openai/openai-go/v3/packages/ssestream"
 	"github.com/openai/openai-go/v3/shared"
@@ -313,6 +314,13 @@ type chatStream struct {
 	sawTools  bool
 	ended     bool
 	id        string
+
+	// requestID is the provider x-request-id header captured at stream
+	// open; it survives truncation where the terminal event does not.
+	requestID string
+
+	// model identifies the requested model for stream lifecycle warnings.
+	model string
 }
 
 // transportChatGenerateStream opens the streaming chat request.
@@ -323,10 +331,13 @@ func transportChatGenerateStream(
 		ctx context.Context,
 		wire generateWire,
 	) (inference.ProviderStream[streamRaw], error) {
+		var requestID string
+		opts := append([]option.RequestOption(nil), requestMetadataOptions(wire)...)
+		opts = append(opts, captureRequestID(&requestID))
 		stream := client.Chat.Completions.NewStreaming(
 			ctx,
 			wireToChatParams(wire),
-			requestMetadataOptions(wire)...,
+			opts...,
 		)
 		if stream == nil {
 			return nil, errdefs.NotAvailablef(
@@ -342,9 +353,14 @@ func transportChatGenerateStream(
 			stream:    stream,
 			textPart:  -1,
 			toolParts: make(map[int64]int),
+			requestID: requestID,
+			model:     wire.model,
 		}, nil
 	}
 }
+
+func (s *chatStream) RequestID() string  { return s.requestID }
+func (s *chatStream) ResponseID() string { return s.id }
 
 func (s *chatStream) Close() error {
 	if s.stream == nil {
@@ -372,7 +388,10 @@ func (s *chatStream) Next(ctx context.Context) (streamRaw, error) {
 				logInferenceStream(ctx, "generate", "", classified, "")
 				return streamRaw{}, classified
 			}
-			s.end()
+			if synthesized := s.end(); synthesized != "" {
+				logChatFinishSynthesized(
+					ctx, s.model, s.requestID, s.id, synthesized)
+			}
 			continue
 		}
 		s.apply(s.stream.Current())
@@ -432,27 +451,37 @@ func (s *chatStream) apply(chunk openai.ChatCompletionChunk) {
 	}
 }
 
-func (s *chatStream) end() {
+// end emits the terminal event exactly once: the recorded finish reason
+// (defaulting to completed, or tool_calls when calls streamed without an
+// explicit reason) plus the usage chunk's accounting. It returns the
+// synthesized reason when the provider never sent an explicit one, so
+// callers can warn that the stream may have been truncated.
+func (s *chatStream) end() string {
 	if s.ended {
-		return
+		return ""
 	}
 	s.ended = true
 	if s.finishErr != nil {
-		return
+		return ""
 	}
+	synthesized := ""
 	finish := s.finish
 	if finish == "" && s.sawTools {
 		finish = inference.FinishToolCalls
+		synthesized = string(finish)
 	}
 	if finish == "" {
 		finish = inference.FinishCompleted
+		synthesized = string(finish)
 	}
 	s.pending = append(s.pending, streamRaw{
-		kind:       streamRawFinish,
-		finish:     finish,
-		usage:      s.usage,
-		responseID: s.id,
+		kind:        streamRawFinish,
+		finish:      finish,
+		usage:       s.usage,
+		responseID:  s.id,
+		synthesized: synthesized != "",
 	})
+	return synthesized
 }
 
 func (s *chatStream) assignPart() int {

--- a/driver/openai/generate_chat_test.go
+++ b/driver/openai/generate_chat_test.go
@@ -145,6 +145,7 @@ func TestChatUnaryTransportAndDecode(t *testing.T) {
 func TestChatStreamTransportAndDecode(t *testing.T) {
 	server, capture := newCapturedOpenAI(t, func(w http.ResponseWriter, _ *http.Request, _ map[string]any) {
 		w.Header().Set("Content-Type", "text/event-stream")
+		w.Header().Set("x-request-id", "req_chat_stream_1")
 		_, _ = fmt.Fprint(w, strings.Join([]string{
 			`data: {"id":"chatcmpl_1","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"role":"assistant","content":"he"},"finish_reason":null}]}`,
 			`data: {"id":"chatcmpl_1","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"content":"llo"},"finish_reason":null}]}`,
@@ -167,9 +168,17 @@ func TestChatStreamTransportAndDecode(t *testing.T) {
 		t.Fatalf("open stream: %v", err)
 	}
 	defer func() { _ = stream.Close() }()
+	meta, ok := stream.(inference.ProviderStreamMetadata)
+	if !ok {
+		t.Fatal("chat stream must expose provider stream metadata")
+	}
+	if got := meta.RequestID(); got != "req_chat_stream_1" {
+		t.Fatalf("stream request id = %q, want req_chat_stream_1", got)
+	}
 
 	var text string
 	var finish inference.FinishReason
+	var synthesized bool
 	var usage *inference.Usage
 	for {
 		raw, err := stream.Next(context.Background())
@@ -185,13 +194,16 @@ func TestChatStreamTransportAndDecode(t *testing.T) {
 		}
 		if event.FinishReason != "" {
 			finish = event.FinishReason
+			synthesized = event.FinishSynthesized
 		}
 		if event.Usage != nil {
 			usage = event.Usage
 		}
 	}
-	if text != "hello" || finish != inference.FinishCompleted || usage == nil || usage.TotalTokens != 3 {
-		t.Fatalf("stream text=%q finish=%q usage=%+v", text, finish, usage)
+	if text != "hello" || finish != inference.FinishCompleted ||
+		synthesized || usage == nil || usage.TotalTokens != 3 {
+		t.Fatalf("stream text=%q finish=%q synthesized=%v usage=%+v",
+			text, finish, synthesized, usage)
 	}
 	streamOptions, ok := capture.body(0)["stream_options"].(map[string]any)
 	if !ok {
@@ -202,6 +214,58 @@ func TestChatStreamTransportAndDecode(t *testing.T) {
 	}
 	if _, ok := streamOptions["include_obfuscation"]; ok {
 		t.Fatalf("default stream_options must not set include_obfuscation: %v", streamOptions)
+	}
+}
+
+func TestChatStreamTruncatedEOFSurfacesSynthesizedFinish(t *testing.T) {
+	server, _ := newCapturedOpenAI(t, func(w http.ResponseWriter, _ *http.Request, _ map[string]any) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		// The provider sends content chunks and then closes the stream
+		// without a terminal finish_reason chunk — the truncation shape a
+		// chat-completions adapter cannot distinguish from a clean EOF.
+		_, _ = fmt.Fprint(w, strings.Join([]string{
+			`data: {"id":"chatcmpl_1","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"role":"assistant","content":"hel"},"finish_reason":null}]}`,
+			`data: {"id":"chatcmpl_1","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"content":"lo"},"finish_reason":null}]}`,
+		}, "\n\n")+"\n\n")
+	})
+	defer server.Close()
+
+	wire, err := compileGenerate("gpt-5.6-sol", catalogEntry{
+		kind: kindGenerate, api: apiChat,
+	})(context.Background(), openaiModel("gpt-5.6-sol"), simpleTextRequest("hi"), inference.GenerateExecutionStream)
+	if err != nil {
+		t.Fatal(err)
+	}
+	stream, err := transportChatGenerateStream(testClients(t, server).api)(
+		context.Background(), wire.Wire)
+	if err != nil {
+		t.Fatalf("open stream: %v", err)
+	}
+	defer func() { _ = stream.Close() }()
+
+	var text string
+	var finish inference.FinishReason
+	synthesized := false
+	for {
+		raw, err := stream.Next(context.Background())
+		if err != nil {
+			break
+		}
+		event, err := decodeChatGenerateStream(context.Background(), raw)
+		if err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		if delta, ok := event.Delta.(inference.TextPartDelta); ok {
+			text += delta.Text
+		}
+		if event.FinishReason != "" {
+			finish = event.FinishReason
+			synthesized = event.FinishSynthesized
+		}
+	}
+	if text != "hello" || finish != inference.FinishCompleted || !synthesized {
+		t.Fatalf("truncated stream text=%q finish=%q synthesized=%v, want hello/completed/true",
+			text, finish, synthesized)
 	}
 }
 

--- a/driver/openai/generate_stream.go
+++ b/driver/openai/generate_stream.go
@@ -10,6 +10,7 @@ import (
 	"github.com/GizClaw/flowcraft/core/inference"
 
 	"github.com/openai/openai-go/v3"
+	"github.com/openai/openai-go/v3/option"
 	"github.com/openai/openai-go/v3/packages/ssestream"
 	"github.com/openai/openai-go/v3/responses"
 )
@@ -30,6 +31,10 @@ type responsesStream struct {
 	// hosted web_search tool. Stream events replace it as calls and
 	// citations arrive.
 	webSearchOutput WebSearchOutput
+
+	// requestID is the provider x-request-id header captured at stream
+	// open; it survives truncation where the terminal event does not.
+	requestID string
 }
 
 type streamPart struct {
@@ -49,10 +54,13 @@ func transportGenerateStream(
 		ctx context.Context,
 		wire generateWire,
 	) (inference.ProviderStream[streamRaw], error) {
+		var requestID string
+		opts := append([]option.RequestOption(nil), requestMetadataOptions(wire)...)
+		opts = append(opts, captureRequestID(&requestID))
 		stream := client.Responses.NewStreaming(
 			ctx,
 			wireToParams(wire),
-			requestMetadataOptions(wire)...,
+			opts...,
 		)
 		if err := stream.Err(); err != nil {
 			classified := classifyError(err)
@@ -61,11 +69,15 @@ func transportGenerateStream(
 		}
 		logInferenceStream(ctx, "generate", wire.model, nil, "")
 		return &responsesStream{
-			stream: stream,
-			parts:  make(map[int64]*streamPart),
+			stream:    stream,
+			parts:     make(map[int64]*streamPart),
+			requestID: requestID,
 		}, nil
 	}
 }
+
+func (s *responsesStream) RequestID() string  { return s.requestID }
+func (s *responsesStream) ResponseID() string { return "" }
 
 func (s *responsesStream) Close() error {
 	if s.stream == nil {
@@ -403,9 +415,10 @@ func decodeGenerateStream(
 		}, nil
 	case streamRawFinish:
 		event := inference.GenerateStreamEvent{
-			FinishReason:    raw.finish,
-			ResponseID:      raw.responseID,
-			ProviderOutputs: raw.providerOutputs.Clone(),
+			FinishReason:      raw.finish,
+			FinishSynthesized: raw.synthesized,
+			ResponseID:        raw.responseID,
+			ProviderOutputs:   raw.providerOutputs.Clone(),
 		}
 		logInferenceStreamEnd(ctx, "generate", raw.responseID)
 		if raw.usage != nil {

--- a/driver/openai/generate_stream_meta_test.go
+++ b/driver/openai/generate_stream_meta_test.go
@@ -1,0 +1,93 @@
+package openai
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/GizClaw/flowcraft/core/inference"
+)
+
+var _ inference.ProviderStreamMetadata = (*chatStream)(nil)
+var _ inference.ProviderStreamMetadata = (*responsesStream)(nil)
+var _ inference.ProviderStreamMetadata = (*imageStream)(nil)
+
+func TestResponsesStreamTransportCapturesRequestID(t *testing.T) {
+	server, _ := newCapturedOpenAI(t, func(w http.ResponseWriter, r *http.Request, _ map[string]any) {
+		if r.URL.Path != "/responses" {
+			t.Errorf("path = %q, want /responses", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.Header().Set("x-request-id", "req_openai_responses_1")
+		_, _ = fmt.Fprint(w, "data: [DONE]\n\n")
+	})
+	defer server.Close()
+
+	entry := catalogEntry{
+		kind:         kindGenerate,
+		api:          apiResponses,
+		capabilities: generateChatCapabilities().WithReasoning(inference.ReasoningToggle),
+	}
+	compiled, err := compileGenerate("gpt-5.6-sol", entry)(
+		context.Background(),
+		openaiModel("gpt-5.6-sol"),
+		simpleTextRequest("hi"),
+		inference.GenerateExecutionStream,
+	)
+	if err != nil {
+		t.Fatalf("compile responses stream: %v", err)
+	}
+	stream, err := transportGenerateStream(testClients(t, server).api)(
+		context.Background(),
+		compiled.Wire,
+	)
+	if err != nil {
+		t.Fatalf("open stream: %v", err)
+	}
+	defer func() { _ = stream.Close() }()
+
+	meta, ok := stream.(inference.ProviderStreamMetadata)
+	if !ok {
+		t.Fatal("responses stream must expose provider stream metadata")
+	}
+	if got := meta.RequestID(); got != "req_openai_responses_1" {
+		t.Fatalf("stream request id = %q, want req_openai_responses_1", got)
+	}
+}
+
+func TestChatStreamEndReportsSynthesizedFinishOnlyWithoutExplicitReason(t *testing.T) {
+	truncated := &chatStream{sawTools: true}
+	if got := truncated.end(); got != string(inference.FinishToolCalls) {
+		t.Fatalf("end() = %q, want synthesized tool_calls", got)
+	}
+	if len(truncated.pending) != 1 ||
+		!truncated.pending[0].synthesized ||
+		truncated.pending[0].finish != inference.FinishToolCalls {
+		t.Fatalf("synthesized finish payload = %+v, want synthesized tool_calls",
+			truncated.pending)
+	}
+	if got := truncated.end(); got != "" {
+		t.Fatalf("second end() = %q, want empty", got)
+	}
+
+	explicit := &chatStream{finish: inference.FinishCompleted}
+	if got := explicit.end(); got != "" {
+		t.Fatalf("end() with explicit finish = %q, want empty", got)
+	}
+	if len(explicit.pending) != 1 ||
+		explicit.pending[0].synthesized ||
+		explicit.pending[0].finish != inference.FinishCompleted {
+		t.Fatalf("explicit finish payload = %+v, want non-synthesized completed",
+			explicit.pending)
+	}
+
+	textOnly := &chatStream{}
+	if got := textOnly.end(); got != string(inference.FinishCompleted) {
+		t.Fatalf("end() without tools/finish = %q, want synthesized completed", got)
+	}
+	if len(textOnly.pending) != 1 ||
+		!textOnly.pending[0].synthesized {
+		t.Fatalf("text-only synthesized payload = %+v, want synthesized", textOnly.pending)
+	}
+}

--- a/driver/openai/image.go
+++ b/driver/openai/image.go
@@ -623,6 +623,9 @@ func (s *imageStream) Close() error {
 	return classifyError(s.sdk.Close())
 }
 
+func (s *imageStream) RequestID() string  { return s.requestID }
+func (s *imageStream) ResponseID() string { return "" }
+
 func transportImageStream(
 	client openai.Client,
 ) inference.Transport[imageWire, inference.ProviderStream[imageStreamRaw]] {

--- a/driver/openai/telemetry.go
+++ b/driver/openai/telemetry.go
@@ -59,6 +59,22 @@ func logInferenceStreamEnd(ctx context.Context, op, responseID string) {
 		inferenceAttrs(op, "", nil, "", responseID)...)
 }
 
+// logChatFinishSynthesized warns when a chat stream ended cleanly without
+// an explicit finish_reason and the adapter fabricated the terminal
+// reason. The provider (or an intermediary) may have truncated the stream
+// mid-flight, so the synthesized finish must not be silently trusted.
+func logChatFinishSynthesized(
+	ctx context.Context,
+	model, requestID, responseID, synthesized string,
+) {
+	attrs := inferenceAttrs("generate", model, nil, requestID, responseID)
+	attrs = append(attrs,
+		otellog.String("stream.finish.synthesized", synthesized))
+	telemetry.Warn(ctx,
+		"chat stream ended without a finish reason; finish synthesized",
+		attrs...)
+}
+
 func inferenceAttrs(
 	op, model string,
 	err error,

--- a/driver/qwen/generate_stream.go
+++ b/driver/qwen/generate_stream.go
@@ -112,6 +112,10 @@ type sseStream struct {
 	mu        sync.Mutex
 	done      bool
 	closeOnce sync.Once
+	// requestID is the request identifier of the last decoded envelope.
+	// It survives truncation where the terminal finish fragment does not,
+	// so the runtime can attach it to a provider_truncated failure.
+	requestID string
 }
 
 func transportGenerateStream(
@@ -200,8 +204,21 @@ func (s *sseStream) Next(ctx context.Context) (streamFragment, error) {
 	}
 	fragment := s.queue[0]
 	s.queue = s.queue[1:]
+	if fragment.requestID != "" {
+		s.mu.Lock()
+		s.requestID = fragment.requestID
+		s.mu.Unlock()
+	}
 	return fragment, nil
 }
+
+func (s *sseStream) RequestID() string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.requestID
+}
+
+func (*sseStream) ResponseID() string { return "" }
 
 func (s *sseStream) Close() error {
 	s.mu.Lock()

--- a/driver/qwen/generate_stream_meta_test.go
+++ b/driver/qwen/generate_stream_meta_test.go
@@ -1,0 +1,31 @@
+package qwen
+
+import (
+	"context"
+	"testing"
+
+	"github.com/GizClaw/flowcraft/core/inference"
+)
+
+var _ inference.ProviderStreamMetadata = (*sseStream)(nil)
+
+func TestSSEStreamMetadataRetainsEnvelopeRequestID(t *testing.T) {
+	stream := &sseStream{
+		queue: []streamFragment{
+			{kind: fragmentText, text: "x", requestID: "req_qwen_1"},
+		},
+	}
+	fragment, err := stream.Next(context.Background())
+	if err != nil {
+		t.Fatalf("Next: %v", err)
+	}
+	if fragment.requestID != "req_qwen_1" {
+		t.Fatalf("fragment request id = %q, want req_qwen_1", fragment.requestID)
+	}
+	if got := stream.RequestID(); got != "req_qwen_1" {
+		t.Fatalf("stream RequestID = %q, want req_qwen_1", got)
+	}
+	if got := stream.ResponseID(); got != "" {
+		t.Fatalf("ResponseID = %q, want empty", got)
+	}
+}


### PR DESCRIPTION
## Summary

Three related changes land together because the driver markers depend on the core contract, and the failure policy completes the retry semantics:

1. feat(core/inference): streams that end before a terminal finish now classify as ProviderTruncated (NotAvailable/503) with stable Error.Detail stage labels and provider request/response ids captured at stream open via the optional ProviderStreamMetadata contract. Core never auto-retries this error: 503 means attempt-void at caller granularity, and the router predicates/tests lock that in.
2. feat(driver): all eight drivers expose stream request/response ids for mid-stream and truncation failures; the openai/deepseek/kimi chat adapters mark adapter-synthesized finishes and decode them into FinishSynthesized events.
3. feat(core/graph, core/agent): stream failure handling becomes a first-class inference-node policy. MessageStream gains an explicit Drop terminal; the inference node exposes stream_failure_policy {on_error, on_interrupt} with commit_partial (default) or discard actions per termination category; recoverable undefined-tool streams discard partial text at the drain site so recovered rounds keep a clean transcript; stream-delta events are documented as advisory previews with board channels authoritative.

## Release

- Adds .release/core-v0.3.0.json (minor) covering the full core delta since core/v0.2.8, plus CHANGELOG update.
- Driver module go.mod core bumps (v0.2.7 -> v0.3.0) and driver tags are intentionally NOT in this PR: drivers must depend on a published core version, so they follow once core/v0.3.0 is tagged (AGENTS.md release sequencing).

## Checks

- make ci (vet + test across the workspace) passes.
- make release-check passes; make release-plan reports core 0.2.8 -> 0.3.0 (minor), tag core/v0.3.0.
- git diff --check clean.