### PR TITLE
feat(core/tool): expose telemetry as a configurable assembly middleware

### DIFF
--- a/core/tool/middleware/middleware_telemetry_test.go
+++ b/core/tool/middleware/middleware_telemetry_test.go
@@ -1,0 +1,102 @@
+package middleware
+
+import (
+	"context"
+	"testing"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/codes"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+
+	"github.com/GizClaw/flowcraft/core/telemetry"
+	"github.com/GizClaw/flowcraft/core/tool"
+)
+
+func TestTelemetry_EmitsExecutionSpan(t *testing.T) {
+	rec := installTelemetryTestTracer(t)
+	exec := tool.NewExecutor(catalogWith(echoTool("echo")), Telemetry())
+	tc := call("echo")
+
+	res := exec.Execute(context.Background(), tc)
+	if res.IsError {
+		t.Fatalf("execute = %q, want success", res.Content)
+	}
+
+	spans := rec.Ended()
+	if len(spans) != 1 {
+		t.Fatalf("ended spans = %d, want 1", len(spans))
+	}
+	span := spans[0]
+	if span.Name() != "echo.execute" {
+		t.Errorf("span name = %q, want %q", span.Name(), "echo.execute")
+	}
+	if span.Status().Code != codes.Ok {
+		t.Errorf("span status = %v, want Ok", span.Status().Code)
+	}
+	attrs := telemetrySpanAttrs(span)
+	if attrs[telemetry.AttrToolName] != "echo" ||
+		attrs[telemetry.AttrToolCallID] != tc.ID {
+		t.Errorf("span attrs = %#v, want tool name/call id", attrs)
+	}
+}
+
+func TestFromSettings_EnablesTelemetry(t *testing.T) {
+	rec := installTelemetryTestTracer(t)
+	mws, err := FromSettings(Settings{
+		Telemetry: &TelemetrySettings{Enabled: true},
+	})
+	if err != nil {
+		t.Fatalf("FromSettings: %v", err)
+	}
+	if len(mws) != 1 {
+		t.Fatalf("middlewares = %d, want 1", len(mws))
+	}
+
+	exec := tool.NewExecutor(catalogWith(echoTool("echo")), mws...)
+	if res := exec.Execute(context.Background(), call("echo")); res.IsError {
+		t.Fatalf("execute = %q, want success", res.Content)
+	}
+	if spans := rec.Ended(); len(spans) != 1 {
+		t.Fatalf("ended spans = %d, want 1", len(spans))
+	}
+}
+
+func TestFromSettings_SkipsDisabledOrAbsentTelemetry(t *testing.T) {
+	for _, settings := range []Settings{
+		{},
+		{Telemetry: &TelemetrySettings{}},
+		{Telemetry: &TelemetrySettings{Enabled: false}},
+	} {
+		mws, err := FromSettings(settings)
+		if err != nil {
+			t.Fatalf("FromSettings(%+v): %v", settings, err)
+		}
+		if len(mws) != 0 {
+			t.Errorf("FromSettings(%+v) returned %d middlewares, want 0", settings, len(mws))
+		}
+	}
+}
+
+// installTelemetryTestTracer installs an in-memory TracerProvider and
+// restores the previous global provider on cleanup.
+func installTelemetryTestTracer(t *testing.T) *tracetest.SpanRecorder {
+	t.Helper()
+	prev := otel.GetTracerProvider()
+	rec := tracetest.NewSpanRecorder()
+	tp := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(rec))
+	otel.SetTracerProvider(tp)
+	t.Cleanup(func() {
+		_ = tp.Shutdown(context.Background())
+		otel.SetTracerProvider(prev)
+	})
+	return rec
+}
+
+func telemetrySpanAttrs(span sdktrace.ReadOnlySpan) map[string]any {
+	attrs := make(map[string]any, len(span.Attributes()))
+	for _, kv := range span.Attributes() {
+		attrs[string(kv.Key)] = kv.Value.AsInterface()
+	}
+	return attrs
+}

--- a/core/tool/middleware/resource_test.go
+++ b/core/tool/middleware/resource_test.go
@@ -26,7 +26,11 @@ func TestAssemblyFactory(t *testing.T) {
 
 	value, err := factory.New(context.Background(), resource.Input{
 		Settings: []byte(`{
-			"middlewares": {"timeout": {"default": "5ms"}, "recover": {"enabled": true}},
+			"middlewares": {
+				"recover": {"enabled": true},
+				"telemetry": {"enabled": true},
+				"timeout": {"default": "5ms"}
+			},
 			"dynamic": {"default": "deferred"}
 		}`),
 		Deps: map[string]any{

--- a/core/tool/middleware/settings.go
+++ b/core/tool/middleware/settings.go
@@ -13,6 +13,7 @@ type Settings struct {
 	Recover     *RecoverSettings     `json:"recover,omitempty"`
 	Timeout     *TimeoutSettings     `json:"timeout,omitempty"`
 	Concurrency *ConcurrencySettings `json:"concurrency,omitempty"`
+	Telemetry   *TelemetrySettings   `json:"telemetry,omitempty"`
 }
 
 type RecoverSettings struct {
@@ -29,12 +30,22 @@ type ConcurrencySettings struct {
 	Limit int `json:"limit"`
 }
 
+// TelemetrySettings enables the standard per-call observability
+// middleware: one span per execution plus executions/duration/error
+// metrics and a warning log for failed calls.
+type TelemetrySettings struct {
+	Enabled bool `json:"enabled"`
+}
+
 // FromSettings builds the middleware chain declared by s, outermost
 // first.
 func FromSettings(s Settings) ([]tool.Middleware, error) {
 	var mws []tool.Middleware
 	if s.Recover != nil && s.Recover.Enabled {
 		mws = append(mws, Recover())
+	}
+	if s.Telemetry != nil && s.Telemetry.Enabled {
+		mws = append(mws, Telemetry())
 	}
 	if s.Timeout != nil && s.Timeout.Default != "" {
 		d, err := time.ParseDuration(s.Timeout.Default)

--- a/docs/guides/tool.md
+++ b/docs/guides/tool.md
@@ -114,17 +114,19 @@ resources:
     settings:
       middlewares:
         recover: {enabled: true}
+        telemetry: {enabled: true}
         timeout: {default: 30s}
         concurrency: {limit: 8}
 ```
 
 Each entry is optional; absent entries are skipped. `recover` converts a
 panicking tool (or inner middleware) into an `IsError` result instead of
-crashing the caller's goroutine; `timeout.default` bounds each call with a
-Go duration (calls that already carry a deadline pass through);
-`concurrency.limit` caps in-flight executions, with excess callers waiting
-(respecting context cancellation). The plain `memory` impl rejects the
-`middlewares` key.
+crashing the caller's goroutine; `telemetry.enabled` records an
+OpenTelemetry span, executions/duration/error metrics, and a warning log
+for each call; `timeout.default` bounds each call with a Go duration (calls
+that already carry a deadline pass through); `concurrency.limit` caps
+in-flight executions, with excess callers waiting (respecting context
+cancellation). The plain `memory` impl rejects the `middlewares` key.
 
 A model that calls a deferred tool before `tool_search` has exposed it is
 rejected at response validation with a distinguishable `undefined_tool`

--- a/skills/flowcraft-config/references/resources.md
+++ b/skills/flowcraft-config/references/resources.md
@@ -210,15 +210,18 @@ tools:
   settings:
     middlewares:
       recover: {enabled: true}
+      telemetry: {enabled: true}
       timeout: {default: 30s}
       concurrency: {limit: 8}
     dynamic: {default: deferred, exposures: {tool_search: always}}
 ```
 
 Each middleware entry is optional; absent entries are skipped. `recover`
-converts tool panics into error results, `timeout.default` bounds each
-call (calls that already carry a deadline pass through), and
-`concurrency.limit` caps in-flight executions.
+converts tool panics into error results, `telemetry.enabled` records an
+OpenTelemetry span plus executions/duration/error metrics and a warning
+log per call, `timeout.default` bounds each call (calls that already
+carry a deadline pass through), and `concurrency.limit` caps in-flight
+executions.
 
 MCP servers attach as a `tool.Source/mcp` resource; attach is best-effort
 with background reconnection, and `required: true` marks a server the host


### PR DESCRIPTION
Makes `tool.Assembly/middleware` support an optional `telemetry` entry, wiring `middleware.Telemetry()` into the executor chain when `telemetry.enabled` is set.

- `FromSettings` now appends `Telemetry()` (after `recover`) when enabled
- resource factory settings decode accepts `telemetry: {enabled: true}`
- adds span + settings tests for telemetry middleware
- updates `docs/guides/tool.md` and the flowcraft-config resource reference

Verified locally: `make ci`, `make lint`, `make release-check`, `git diff --check` all pass.