### PR TITLE
feat(core/tool): discovery pool with independent byte budget

### DIFF
--- a/core/graph/nodes/inference.go
+++ b/core/graph/nodes/inference.go
@@ -213,7 +213,7 @@ const defaultRecoverFeedbackPrefix = "__recover_feedback."
 // user feedback message when a response names a tool the model was
 // never shown.
 const undefinedToolFeedback = "tool %q is not exposed in this round's tool set; " +
-	"call tool_search to find and select it before calling it again"
+	"call tool_search to find it before calling it again"
 
 // InferenceNodeDeps wires the inference node's collaborators. Runtime
 // serves configs carrying an explicit model; Router serves configs

--- a/core/graph/nodes/inference_test.go
+++ b/core/graph/nodes/inference_test.go
@@ -957,8 +957,10 @@ func (f *fakeVisibleCatalog) Definitions() []message.ToolDefinition {
 func (f *fakeVisibleCatalog) Require(names ...string) {
 	f.required = append(f.required, names...)
 }
-func (f *fakeVisibleCatalog) AdvanceTurn()                { f.advances++ }
-func (f *fakeVisibleCatalog) Select(...string)            {}
+func (f *fakeVisibleCatalog) AdvanceTurn() { f.advances++ }
+func (f *fakeVisibleCatalog) Discover(...string) tool.DiscoverOutcome {
+	return tool.DiscoverOutcome{}
+}
 func (f *fakeVisibleCatalog) RecordCall(message.ToolCall) {}
 func (f *fakeVisibleCatalog) Load(context.Context) error  { return nil }
 func (f *fakeVisibleCatalog) EnsureLoaded(context.Context, ...string) error {

--- a/core/runtime/session/catalog_test.go
+++ b/core/runtime/session/catalog_test.go
@@ -21,8 +21,10 @@ func (f *fakeSessionCatalog) Get(string) (sdktool.Tool, bool) { return nil, fals
 func (f *fakeSessionCatalog) Definitions() []message.ToolDefinition {
 	return f.defs
 }
-func (f *fakeSessionCatalog) Require(...string)           {}
-func (f *fakeSessionCatalog) Select(...string)            {}
+func (f *fakeSessionCatalog) Require(...string) {}
+func (f *fakeSessionCatalog) Discover(...string) sdktool.DiscoverOutcome {
+	return sdktool.DiscoverOutcome{}
+}
 func (f *fakeSessionCatalog) RecordCall(message.ToolCall) {}
 func (f *fakeSessionCatalog) AdvanceTurn()                {}
 func (f *fakeSessionCatalog) Load(context.Context) error  { return nil }

--- a/core/runtime/session/epoch_test.go
+++ b/core/runtime/session/epoch_test.go
@@ -18,9 +18,11 @@ type stubToolSession struct{}
 func (stubToolSession) Get(string) (tool.Tool, bool)          { return nil, false }
 func (stubToolSession) Definitions() []message.ToolDefinition { return nil }
 func (stubToolSession) Require(...string)                     {}
-func (stubToolSession) Select(...string)                      {}
-func (stubToolSession) RecordCall(message.ToolCall)           {}
-func (stubToolSession) AdvanceTurn()                          {}
+func (stubToolSession) Discover(...string) tool.DiscoverOutcome {
+	return tool.DiscoverOutcome{}
+}
+func (stubToolSession) RecordCall(message.ToolCall) {}
+func (stubToolSession) AdvanceTurn()                {}
 func (stubToolSession) Search(context.Context, string, int) ([]tool.SearchHit, error) {
 	return nil, nil
 }

--- a/core/tool/assembly.go
+++ b/core/tool/assembly.go
@@ -85,9 +85,16 @@ func NewAssembly(sources []Source, opts ...AssemblyOption) (*Assembly, error) {
 			attacher.Attach(registry)
 		}
 	}
+	mws := o.middleware
+	if policy != nil {
+		// Dynamic sessions keep their discovery pool fresh on every
+		// executed call. The recorder is a no-op without a session on
+		// the context, so one chain serves static and dynamic hosts.
+		mws = append(append([]Middleware{}, mws...), recordSessionCalls())
+	}
 	return &Assembly{
 		registry: registry,
-		executor: NewExecutor(registry, o.middleware...),
+		executor: NewExecutor(registry, mws...),
 		policy:   policy,
 	}, nil
 }
@@ -98,6 +105,21 @@ type searchToolSource struct{}
 
 func (searchToolSource) Tools() []Tool         { return []Tool{SearchTool{}} }
 func (searchToolSource) LazyTools() []LazyTool { return nil }
+
+// recordSessionCalls feeds every dispatched tool call back into the
+// session found on the execution context so active use refreshes the
+// discovery pool. Without a session on the context it is a no-op.
+func recordSessionCalls() Middleware {
+	return func(next Dispatch) Dispatch {
+		return func(ctx context.Context, call message.ToolCall) message.ToolResult {
+			res := next(ctx, call)
+			if session, ok := SessionFromContext(ctx); ok {
+				session.RecordCall(call)
+			}
+			return res
+		}
+	}
+}
 
 // Catalog returns the aggregated read surface.
 func (a *Assembly) Catalog() Catalog { return a.registry }

--- a/core/tool/assembly_test.go
+++ b/core/tool/assembly_test.go
@@ -50,16 +50,39 @@ func TestAssembly_SearchToolExecutesAgainstSession(t *testing.T) {
 	session := assembly.NewSession()
 	ctx := tool.WithSession(context.Background(), session)
 	search, _ := assembly.Catalog().Get(tool.ToolName)
-	out, err := search.Execute(ctx, `{"query":"web search","select":["web.search"]}`)
+	out, err := search.Execute(ctx, `{"query":"web search"}`)
 	if err != nil {
 		t.Fatalf("Execute tool_search: %v", err)
 	}
-	if !strings.Contains(out, `"web.search"`) {
+	if !strings.Contains(out, `"exposed":["web.search"]`) {
 		t.Fatalf("tool_search output = %s", out)
 	}
 	names := definitionNames(session.Definitions())
 	if !contains(names, "web.search") {
-		t.Fatalf("selected tool not visible next round: %v", names)
+		t.Fatalf("discovered tool not visible next round: %v", names)
+	}
+}
+
+func TestAssembly_SessionRecorderRefreshesDiscovery(t *testing.T) {
+	assembly, err := tool.NewAssembly(
+		[]tool.Source{source{tools: []tool.Tool{funcTool("web.search", "find things")}}},
+		tool.WithDynamic(tool.Policy{Default: tool.ExposureDeferred}),
+	)
+	if err != nil {
+		t.Fatalf("NewAssembly: %v", err)
+	}
+	session := assembly.NewSession()
+	ctx := tool.WithSession(context.Background(), session)
+
+	res := assembly.Execute(ctx, message.ToolCall{
+		ID: "c1", Name: "web.search", Arguments: []byte(`{}`),
+	})
+	if res.IsError {
+		t.Fatalf("Execute = %+v", res)
+	}
+	names := definitionNames(session.Definitions())
+	if !contains(names, "web.search") {
+		t.Fatalf("executed tool not in discovery pool: %v", names)
 	}
 }
 

--- a/core/tool/discovery_test.go
+++ b/core/tool/discovery_test.go
@@ -1,0 +1,292 @@
+package tool_test
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/GizClaw/flowcraft/core/errdefs"
+	"github.com/GizClaw/flowcraft/core/message"
+	"github.com/GizClaw/flowcraft/core/tool"
+	"github.com/GizClaw/flowcraft/core/tool/tooltest"
+)
+
+func TestDynamicSession_DiscoveryPoolEvictsLRU(t *testing.T) {
+	assembly, err := tool.NewAssembly(
+		[]tool.Source{source{tools: []tool.Tool{
+			funcTool("a", "1"), funcTool("b", "2"),
+			funcTool("c", "3"), funcTool("d", "4"),
+		}}},
+		tool.WithDynamic(tool.Policy{
+			Default:   tool.ExposureDeferred,
+			Discovery: tool.DiscoveryPolicy{MaxTools: 2},
+		}),
+	)
+	if err != nil {
+		t.Fatalf("NewAssembly: %v", err)
+	}
+	session := assembly.NewSession()
+
+	outcome := session.Discover("a", "b", "c", "d")
+	if len(outcome.Results) != 4 ||
+		outcome.Results[0].Exposed || outcome.Results[1].Exposed ||
+		!outcome.Results[2].Exposed || !outcome.Results[3].Exposed {
+		t.Fatalf("Discover outcome = %+v, want a/b evicted, c/d exposed", outcome)
+	}
+	if len(outcome.Evicted) != 2 || outcome.Evicted[0] != "a" || outcome.Evicted[1] != "b" {
+		t.Fatalf("evicted = %v, want [a b]", outcome.Evicted)
+	}
+
+	names := definitionNames(session.Definitions())
+	if contains(names, "a") || contains(names, "b") {
+		t.Fatalf("evicted tools still visible: %v", names)
+	}
+	if !contains(names, "c") || !contains(names, "d") || !contains(names, tool.ToolName) {
+		t.Fatalf("Definitions = %v, want c, d and tool_search", names)
+	}
+
+	// Re-discovering an evicted tool refreshes it as MRU and evicts the
+	// least-recently-used survivor instead.
+	outcome = session.Discover("a")
+	if len(outcome.Results) != 1 || !outcome.Results[0].Exposed {
+		t.Fatalf("refresh Discover outcome = %+v", outcome)
+	}
+	if len(outcome.Evicted) != 1 || outcome.Evicted[0] != "c" {
+		t.Fatalf("refresh evicted = %v, want [c]", outcome.Evicted)
+	}
+}
+
+func TestDynamicSession_DiscoveryByteCap(t *testing.T) {
+	assembly, err := tool.NewAssembly(
+		[]tool.Source{source{tools: []tool.Tool{
+			funcTool("a", "a"),
+			tooltest.FuncTool("big", strings.Repeat("x", 4096), func(context.Context, string) (string, error) {
+				return "big", nil
+			}),
+		}}},
+		tool.WithDynamic(tool.Policy{
+			Default: tool.ExposureDeferred,
+			Discovery: tool.DiscoveryPolicy{
+				MaxTools: 4,
+				MaxBytes: 1024,
+			},
+		}),
+	)
+	if err != nil {
+		t.Fatalf("NewAssembly: %v", err)
+	}
+	session := assembly.NewSession()
+
+	outcome := session.Discover("big", "a")
+	if len(outcome.Evicted) == 0 || outcome.Evicted[0] != "big" {
+		t.Fatalf("evicted = %v, want big dropped by byte cap", outcome.Evicted)
+	}
+	if outcome.Results[0].Exposed || outcome.Results[0].Reason != "over_budget" {
+		t.Fatalf("big outcome = %+v, want over_budget", outcome.Results[0])
+	}
+	if !outcome.Results[1].Exposed {
+		t.Fatalf("a outcome = %+v, want exposed", outcome.Results[1])
+	}
+}
+
+func TestDynamicSession_DiscoveryIdleEviction(t *testing.T) {
+	assembly, err := tool.NewAssembly(
+		[]tool.Source{source{tools: []tool.Tool{funcTool("a", "1")}}},
+		tool.WithDynamic(tool.Policy{
+			Default:   tool.ExposureDeferred,
+			Discovery: tool.DiscoveryPolicy{IdleRounds: 1},
+		}),
+	)
+	if err != nil {
+		t.Fatalf("NewAssembly: %v", err)
+	}
+	session := assembly.NewSession()
+
+	session.Discover("a")
+	session.AdvanceTurn()
+	if !contains(definitionNames(session.Definitions()), "a") {
+		t.Fatal("discovered tool must survive one idle round")
+	}
+
+	session.RecordCall(message.ToolCall{ID: "c1", Name: "a", Arguments: []byte(`{}`)})
+	session.AdvanceTurn()
+	if !contains(definitionNames(session.Definitions()), "a") {
+		t.Fatal("used tool must be refreshed past the idle horizon")
+	}
+
+	session.AdvanceTurn()
+	if contains(definitionNames(session.Definitions()), "a") {
+		t.Fatal("unused tool must expire after the idle horizon")
+	}
+}
+
+func TestDynamicSession_DiscoveryIgnoresAlwaysAndHidden(t *testing.T) {
+	assembly, _ := dynamicAssembly(t, "always", "deferred", "hidden")
+	session := assembly.NewSession()
+
+	outcome := session.Discover("always", "hidden", "deferred")
+	if len(outcome.Results) != 3 {
+		t.Fatalf("outcome = %+v", outcome)
+	}
+	if outcome.Results[0].Exposed || outcome.Results[0].Reason != "not_discoverable" {
+		t.Fatalf("always outcome = %+v, want not_discoverable", outcome.Results[0])
+	}
+	if outcome.Results[1].Exposed || outcome.Results[1].Reason != "not_discoverable" {
+		t.Fatalf("hidden outcome = %+v, want not_discoverable", outcome.Results[1])
+	}
+	if !outcome.Results[2].Exposed {
+		t.Fatalf("deferred outcome = %+v, want exposed", outcome.Results[2])
+	}
+	names := definitionNames(session.Definitions())
+	if contains(names, "hidden") {
+		t.Fatalf("hidden tool leaked into Definitions: %v", names)
+	}
+}
+
+func TestDynamicSession_DiscoveryStaleCatalogEntryDropped(t *testing.T) {
+	assembly, err := tool.NewAssembly(
+		[]tool.Source{source{tools: []tool.Tool{funcTool("a", "1")}}},
+		tool.WithDynamic(tool.Policy{Default: tool.ExposureDeferred}),
+	)
+	if err != nil {
+		t.Fatalf("NewAssembly: %v", err)
+	}
+	session := assembly.NewSession()
+	session.Discover("a")
+	if !contains(definitionNames(session.Definitions()), "a") {
+		t.Fatal("tool missing before removal")
+	}
+	assembly.Catalog().(*tool.Registry).Remove("a")
+	if contains(definitionNames(session.Definitions()), "a") {
+		t.Fatal("removed tool still visible")
+	}
+}
+
+func TestDiscoverWithoutSessionContextIsSafe(t *testing.T) {
+	_, err := (&tool.SearchTool{}).Execute(context.Background(), `{"query":"x"}`)
+	if !errdefs.IsNotAvailable(err) {
+		t.Fatalf("Execute without session error = %v, want NotAvailable", err)
+	}
+}
+
+func TestDynamicSession_ToolSearchSurvivesBudgetPruning(t *testing.T) {
+	assembly, err := tool.NewAssembly(
+		[]tool.Source{source{tools: []tool.Tool{
+			funcTool("a", "1"), funcTool("b", "2"), funcTool("c", "3"),
+		}}},
+		tool.WithDynamic(tool.Policy{
+			Default: tool.ExposureAlways,
+			Budget:  tool.Budget{MaxDefinitions: 1},
+		}),
+	)
+	if err != nil {
+		t.Fatalf("NewAssembly: %v", err)
+	}
+	names := definitionNames(assembly.NewSession().Definitions())
+	if len(names) != 1 || names[0] != tool.ToolName {
+		t.Fatalf("Definitions = %v, want only tool_search", names)
+	}
+}
+
+func TestDynamicSession_DiscoveryDirectSurvivesRecencyTie(t *testing.T) {
+	assembly, err := tool.NewAssembly(
+		[]tool.Source{source{tools: []tool.Tool{
+			funcTool("keep", "1"), funcTool("drop", "2"),
+		}}},
+		tool.WithDynamic(tool.Policy{
+			Default: tool.ExposureDeferred,
+			Exposures: map[string]tool.Exposure{
+				"keep": tool.ExposureDirect,
+				"drop": tool.ExposureDeferred,
+			},
+			Discovery: tool.DiscoveryPolicy{MaxTools: 1},
+		}),
+	)
+	if err != nil {
+		t.Fatalf("NewAssembly: %v", err)
+	}
+	outcome := assembly.NewSession().Discover("keep", "drop")
+	if len(outcome.Results) != 2 ||
+		!outcome.Results[0].Exposed || outcome.Results[1].Exposed {
+		t.Fatalf("Discover outcome = %+v, want keep exposed, drop evicted", outcome)
+	}
+	if len(outcome.Evicted) != 1 || outcome.Evicted[0] != "drop" {
+		t.Fatalf("evicted = %v, want [drop]", outcome.Evicted)
+	}
+}
+
+func TestDynamicSession_LegacyRetentionSeedsIdleRounds(t *testing.T) {
+	assembly, err := tool.NewAssembly(
+		[]tool.Source{source{tools: []tool.Tool{funcTool("a", "1")}}},
+		tool.WithDynamic(tool.Policy{
+			Default:           tool.ExposureDeferred,
+			SelectedRetention: 2,
+		}),
+	)
+	if err != nil {
+		t.Fatalf("NewAssembly: %v", err)
+	}
+	session := assembly.NewSession()
+	session.Discover("a")
+	for i := 0; i < 2; i++ {
+		session.AdvanceTurn()
+		if !contains(definitionNames(session.Definitions()), "a") {
+			t.Fatalf("tool vanished after %d idle rounds (legacy retention 2)", i+1)
+		}
+	}
+	session.AdvanceTurn()
+	if contains(definitionNames(session.Definitions()), "a") {
+		t.Fatal("tool must expire after legacy retention rounds")
+	}
+}
+
+func TestDynamicSession_PerRoundBudgetPrefersMRUPoolEntries(t *testing.T) {
+	assembly, err := tool.NewAssembly(
+		[]tool.Source{source{tools: []tool.Tool{
+			funcTool("a", "1"), funcTool("b", "2"),
+		}}},
+		tool.WithDynamic(tool.Policy{
+			Default: tool.ExposureDeferred,
+			Budget:  tool.Budget{MaxDefinitions: 2},
+		}),
+	)
+	if err != nil {
+		t.Fatalf("NewAssembly: %v", err)
+	}
+	session := assembly.NewSession()
+	session.Discover("a")
+	session.Discover("b")
+	names := definitionNames(session.Definitions())
+	if !contains(names, "b") || contains(names, "a") {
+		t.Fatalf("Definitions = %v, want only the MRU pool entry b (plus tool_search)", names)
+	}
+	if !contains(names, tool.ToolName) {
+		t.Fatalf("Definitions = %v, want tool_search", names)
+	}
+}
+
+func TestSearchTool_ReportsLoadFailures(t *testing.T) {
+	assembly, err := tool.NewAssembly(
+		[]tool.Source{tooltest.LazySource(tooltest.LazyTool("broken", func(context.Context) (tool.Tool, error) {
+			return nil, errors.New("load boom")
+		}))},
+		tool.WithDynamic(tool.Policy{Default: tool.ExposureDeferred}),
+	)
+	if err != nil {
+		t.Fatalf("NewAssembly: %v", err)
+	}
+	session := assembly.NewSession()
+	ctx := tool.WithSession(context.Background(), session)
+	search, _ := assembly.Catalog().Get(tool.ToolName)
+	out, err := search.Execute(ctx, `{"query":"broken"}`)
+	if err != nil {
+		t.Fatalf("Execute tool_search: %v", err)
+	}
+	if !strings.Contains(out, `"failed":[{"name":"broken","reason":"load_failed"}]`) {
+		t.Fatalf("tool_search output = %s", out)
+	}
+	if contains(definitionNames(session.Definitions()), "broken") {
+		t.Fatal("failed lazy tool must not be exposed")
+	}
+}

--- a/core/tool/exposure.go
+++ b/core/tool/exposure.go
@@ -16,10 +16,12 @@ const (
 	// turn. Keep this set small; it is the stable baseline.
 	ExposureAlways Exposure = "always"
 	// ExposureDirect marks a tool that appears only when it is
-	// RequiredByName or has been selected/used recently.
+	// RequiredByName or sits in the discovery pool (found via
+	// tool_search or used recently).
 	ExposureDirect Exposure = "direct"
 	// ExposureDeferred marks a tool that is hidden until tool_search
-	// surfaces it; once selected it stays visible for M rounds.
+	// surfaces it; discovered tools stay visible while they are used
+	// and expire after idle rounds or discovery-budget eviction.
 	ExposureDeferred Exposure = "deferred"
 	// ExposureHidden marks a tool that never appears in Definitions
 	// (not even via search). RequiredByName can still surface it, and
@@ -76,6 +78,36 @@ var DefaultBudget = Budget{
 	MaxBytes:       16 * 1024,
 }
 
+// DiscoveryPolicy bounds the session-level discovery pool: tools the
+// model has found via tool_search or used, kept loaded across rounds.
+// The pool budget is independent from the per-round Budget: Budget caps
+// what reaches the model this turn, Discovery caps what the session
+// remembers.
+type DiscoveryPolicy struct {
+	// MaxTools caps the number of pool entries. Zero falls back to
+	// DefaultDiscoveryPolicy.MaxTools.
+	MaxTools int `json:"max_tools,omitempty"`
+	// MaxBytes caps the total serialized definition size across pool
+	// entries, measured with definitionBytes. Zero falls back to the
+	// per-round DefaultBudget.MaxBytes, so the default pool fits the
+	// default visible set.
+	MaxBytes int64 `json:"max_bytes,omitempty"`
+	// IdleRounds evicts an entry that has not been used or refreshed
+	// within this many rounds. Zero falls back to 10.
+	IdleRounds int `json:"idle_rounds,omitempty"`
+}
+
+// DefaultDiscoveryPolicy returns the recommended discovery pool bounds:
+// the same size as the default per-round budget, with a 10-round idle
+// horizon.
+func DefaultDiscoveryPolicy() DiscoveryPolicy {
+	return DiscoveryPolicy{
+		MaxTools:   DefaultBudget.MaxDefinitions,
+		MaxBytes:   DefaultBudget.MaxBytes,
+		IdleRounds: 10,
+	}
+}
+
 // Policy is the host-declared injection policy for one assembly.
 // Zero values mean "use DefaultPolicy" for every field except
 // Exposures, so a partial settings subtree is sufficient.
@@ -85,29 +117,35 @@ type Policy struct {
 	Default Exposure `json:"default,omitempty"`
 	// Exposures maps tool names to explicit exposure levels.
 	Exposures map[string]Exposure `json:"exposures,omitempty"`
-	// SelectedRetention is how many rounds a selected tool stays
-	// visible (M). Zero falls back to 5.
-	SelectedRetention int `json:"selected_retention,omitempty"`
-	// RecentWindow is how many rounds a recently used direct tool stays
-	// visible. Zero falls back to 10.
-	RecentWindow int `json:"recent_window,omitempty"`
 	// Budget caps the visible set. Zero uses DefaultBudget.
 	Budget Budget `json:"budget,omitempty"`
 	// SearchWithLoad makes tool_search load every deferred source
 	// before ranking, so hits are computed over real metadata instead
 	// of placeholder declarations. Default is false (lazy search).
 	SearchWithLoad bool `json:"search_with_load,omitempty"`
+	// Discovery bounds the persistent discovery pool. Zero fields fall
+	// back to DefaultDiscoveryPolicy.
+	Discovery DiscoveryPolicy `json:"discovery,omitempty"`
+
+	// SelectedRetention is deprecated: when Discovery.IdleRounds is
+	// unset it seeds the idle horizon, then it is ignored. Zero means
+	// "unset".
+	SelectedRetention int `json:"selected_retention,omitempty"`
+	// RecentWindow is deprecated: when Discovery.IdleRounds is unset
+	// and SelectedRetention is not set either, it seeds the idle
+	// horizon. It no longer drives a separate recency window. Zero
+	// means "unset".
+	RecentWindow int `json:"recent_window,omitempty"`
 }
 
 // DefaultPolicy returns the recommended policy: everything deferred by
-// default, 5 selected rounds, 10 recent rounds, and the default budget.
+// default, the per-round budget, and the default discovery pool.
 func DefaultPolicy() Policy {
 	return Policy{
-		Default:           ExposureDeferred,
-		Exposures:         map[string]Exposure{},
-		SelectedRetention: 5,
-		RecentWindow:      10,
-		Budget:            DefaultBudget,
+		Default:   ExposureDeferred,
+		Exposures: map[string]Exposure{},
+		Budget:    DefaultBudget,
+		Discovery: DefaultDiscoveryPolicy(),
 	}
 }
 
@@ -118,17 +156,27 @@ func normalizePolicy(p Policy) Policy {
 	if out.Default == "" {
 		out.Default = DefaultPolicy().Default
 	}
-	if out.SelectedRetention <= 0 {
-		out.SelectedRetention = DefaultPolicy().SelectedRetention
-	}
-	if out.RecentWindow <= 0 {
-		out.RecentWindow = DefaultPolicy().RecentWindow
-	}
 	if out.Budget.MaxDefinitions <= 0 {
 		out.Budget.MaxDefinitions = DefaultBudget.MaxDefinitions
 	}
 	if out.Budget.MaxBytes <= 0 {
 		out.Budget.MaxBytes = DefaultBudget.MaxBytes
+	}
+	if out.Discovery.MaxTools <= 0 {
+		out.Discovery.MaxTools = DefaultDiscoveryPolicy().MaxTools
+	}
+	if out.Discovery.MaxBytes <= 0 {
+		out.Discovery.MaxBytes = DefaultDiscoveryPolicy().MaxBytes
+	}
+	if out.Discovery.IdleRounds <= 0 {
+		switch {
+		case out.SelectedRetention > 0:
+			out.Discovery.IdleRounds = out.SelectedRetention
+		case out.RecentWindow > 0:
+			out.Discovery.IdleRounds = out.RecentWindow
+		default:
+			out.Discovery.IdleRounds = DefaultDiscoveryPolicy().IdleRounds
+		}
 	}
 	return out
 }
@@ -148,6 +196,20 @@ func (p Policy) Validate() error {
 			return errdefs.Validationf(
 				"tool: exposure %q for tool %q is invalid", e, name)
 		}
+		if name == ToolName && e != ExposureAlways {
+			return errdefs.Validationf(
+				"tool: %s must be registered with exposure %q; exposure %q disables tool discovery",
+				ToolName, ExposureAlways, e)
+		}
+	}
+	if p.Discovery.MaxTools < 0 {
+		return errdefs.Validationf("tool: discovery max_tools must not be negative")
+	}
+	if p.Discovery.MaxBytes < 0 {
+		return errdefs.Validationf("tool: discovery max_bytes must not be negative")
+	}
+	if p.Discovery.IdleRounds < 0 {
+		return errdefs.Validationf("tool: discovery idle_rounds must not be negative")
 	}
 	return nil
 }

--- a/core/tool/middleware/middleware_recordcalls.go
+++ b/core/tool/middleware/middleware_recordcalls.go
@@ -11,6 +11,12 @@ import (
 // found on the execution context. Without a session on the context the
 // middleware is a no-op, so one chain serves runs with and without
 // dynamic injection.
+//
+// Deprecated: dynamic assemblies already append a built-in session
+// recorder when WithDynamic is enabled (see core/tool assembly.go), so
+// this middleware is redundant for hosts executing through an assembly.
+// Keep it only when constructing a raw tool.Executor without the
+// assembly's recorder.
 func RecordCalls() tool.Middleware {
 	return func(next tool.Dispatch) tool.Dispatch {
 		return func(ctx context.Context, call message.ToolCall) message.ToolResult {

--- a/core/tool/middleware/recordcalls_test.go
+++ b/core/tool/middleware/recordcalls_test.go
@@ -18,6 +18,7 @@ func TestRecordCalls_FeedsSession(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewAssembly: %v", err)
 	}
+	//nolint:staticcheck // standalone deprecated middleware: covered for custom dispatchers
 	exec := tool.NewExecutor(assembly.Catalog(), RecordCalls())
 	session := assembly.NewSession()
 	ctx := tool.WithSession(context.Background(), session)
@@ -43,6 +44,7 @@ func TestRecordCalls_NoSessionIsNoOp(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewAssembly: %v", err)
 	}
+	//nolint:staticcheck // standalone deprecated middleware: covered for custom dispatchers
 	exec := tool.NewExecutor(assembly.Catalog(), RecordCalls())
 	res := exec.Execute(context.Background(), call("direct"))
 	if res.IsError {

--- a/core/tool/registry.go
+++ b/core/tool/registry.go
@@ -271,7 +271,7 @@ func (p *lazyProxy) Execute(ctx context.Context, arguments string) (string, erro
 }
 
 // EnsureLoaded forces the deferred load without executing the tool.
-// It is how tool_search makes a selected tool's real definition
+// It is how tool_search makes a discovered tool's real definition
 // available to the next round.
 func (p *lazyProxy) EnsureLoaded(ctx context.Context) error {
 	_, err := p.load(ctx)

--- a/core/tool/session.go
+++ b/core/tool/session.go
@@ -2,6 +2,7 @@ package tool
 
 import (
 	"context"
+	"sort"
 	"sync"
 
 	"github.com/GizClaw/flowcraft/core/errdefs"
@@ -15,24 +16,29 @@ import (
 //
 // When the assembly was built without dynamic injection, the session
 // is static: Definitions() shows every tool, and the stateful
-// operations (Select/Require/RecordCall/AdvanceTurn) are no-ops while
+// operations (Require/Discover/RecordCall/AdvanceTurn) are no-ops while
 // Search returns NotAvailable.
 type Session interface {
 	Catalog
 
 	// Require adds names to the RequiredByName set. Idempotent.
 	Require(names ...string)
-	// Select marks names as selected for the policy's retention
-	// rounds. Selection carries an implicit load contract: a selected
-	// tool must be loaded before the next Definitions call, otherwise
-	// the model would see its placeholder schema. tool_search enforces
-	// this by loading each name before selecting.
-	Select(names ...string)
+	// Discover adds names to the discovery pool (or refreshes their
+	// recency). The pool is bounded by Policy.Discovery: entries are
+	// evicted least-recently-used when the pool is over budget and
+	// swept after idle rounds. A discovered tool must be loaded before
+	// the next Definitions call, otherwise the model would see its
+	// placeholder schema — tool_search loads each name before
+	// discovering it.
+	Discover(names ...string) DiscoverOutcome
 	// RecordCall records that the model called name this round,
-	// refreshing its Selected and UsedRecently state.
+	// refreshing its discovery-pool recency. Always and Hidden tools
+	// are skipped: the former are always visible, the latter must
+	// never surface through use.
 	RecordCall(call message.ToolCall)
-	// AdvanceTurn moves to the next round, expiring Selected and
-	// UsedRecently entries. Call it once per inference round.
+	// AdvanceTurn moves to the next round, expiring discovery entries
+	// that went idle and dropping names no longer in the catalog. Call
+	// it once per inference round.
 	AdvanceTurn()
 	// Search ranks searchable definitions against query with BM25.
 	// Search never loads deferred tools.
@@ -51,9 +57,25 @@ type Session interface {
 	EnsureLoaded(ctx context.Context, names ...string) error
 }
 
+// DiscoverResult reports one tool's discovery-pool outcome.
+type DiscoverResult struct {
+	Name    string `json:"name"`
+	Exposed bool   `json:"exposed"`
+	Reason  string `json:"reason,omitempty"` // "unknown" | "not_discoverable" | "over_budget"
+}
+
+// DiscoverOutcome summarizes one Discover call.
+type DiscoverOutcome struct {
+	// Results carries one entry per requested name, in input order.
+	Results []DiscoverResult `json:"results"`
+	// Evicted lists pool entries dropped by budget pressure (LRU)
+	// while fitting the newly discovered names.
+	Evicted []string `json:"evicted,omitempty"`
+}
+
 // dynamicSession is the stateful injection view. It reads tools from
 // the shared registry (the execution surface) and applies Exposure /
-// budget / selection purely on the read side.
+// discovery pool / budget purely on the read side.
 type dynamicSession struct {
 	catalog Catalog
 	policy  Policy
@@ -73,19 +95,69 @@ func (s *dynamicSession) Definitions() []message.ToolDefinition {
 	s.mu.Unlock()
 
 	all := s.catalog.Definitions()
+	sizes := make(map[string]int64, len(all))
 	cands := make([]candidate, 0, len(all))
 	for _, def := range all {
+		sizes[def.Name] = definitionBytes(def)
 		cands = append(cands, candidate{
 			name: def.Name,
 			def:  def,
 			exp:  policy.exposureOf(def.Name),
 		})
 	}
+	st = fitDiscoveryPool(st, sizes, policy.Discovery)
+
 	visible := visibleCandidates(cands, st, policy)
 	out := make([]message.ToolDefinition, 0, len(visible))
 	for _, cand := range visible {
 		out = append(out, cand.def)
 	}
+	return out
+}
+
+// fitDiscoveryPool restricts the snapshot's discovered set to the pool
+// budget, measured against the live definitions of the current round.
+// Most-recently-used entries stay first; required tools are unaffected
+// (they live in their own set). The read path never mutates state, so
+// entries trimmed here are evicted for real on the next mutation or
+// AdvanceTurn. Like the per-round budget, at least one entry is kept so
+// an oversized single tool remains discoverable.
+func fitDiscoveryPool(st stateSnapshot, sizes map[string]int64, pool DiscoveryPolicy) stateSnapshot {
+	if len(st.discovered) == 0 {
+		return st
+	}
+	names := make([]string, 0, len(st.discovered))
+	for name := range st.discovered {
+		if _, ok := sizes[name]; ok {
+			names = append(names, name)
+		}
+	}
+	sort.Slice(names, func(i, j int) bool {
+		a, b := st.discovered[names[i]], st.discovered[names[j]]
+		if a.lastUse != b.lastUse {
+			return a.lastUse > b.lastUse
+		}
+		if a.seq != b.seq {
+			return a.seq > b.seq
+		}
+		return names[i] < names[j]
+	})
+
+	var total int64
+	kept := make(map[string]discoveredEntry, len(names))
+	for _, name := range names {
+		if pool.MaxTools > 0 && len(kept) >= pool.MaxTools {
+			break
+		}
+		size := sizes[name]
+		if total+size > pool.MaxBytes && len(kept) > 0 {
+			break
+		}
+		total += size
+		kept[name] = st.discovered[name]
+	}
+	out := st
+	out.discovered = kept
 	return out
 }
 
@@ -95,22 +167,130 @@ func (s *dynamicSession) Require(names ...string) {
 	s.st.require(names...)
 }
 
-func (s *dynamicSession) Select(names ...string) {
+// Discover adds or refreshes discovery entries. Each requested name
+// must already be loaded (call EnsureLoaded first) so the pool measures
+// real definitions; entries are then evicted LRU until the pool fits
+// Policy.Discovery.
+func (s *dynamicSession) Discover(names ...string) DiscoverOutcome {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	s.st.selectNames(names, s.policy.SelectedRetention)
+
+	reasons := make(map[string]string, len(names))
+	changed := false
+	for _, name := range names {
+		t, ok := s.catalog.Get(name)
+		if !ok {
+			reasons[name] = "unknown"
+			continue
+		}
+		switch s.policy.exposureOf(name) {
+		case ExposureDirect, ExposureDeferred:
+		default:
+			reasons[name] = "not_discoverable"
+			continue
+		}
+		s.st.touch(name, definitionBytes(t.Definition()))
+		changed = true
+	}
+
+	var evicted []string
+	if changed {
+		evicted = s.evictForFitLocked()
+	}
+	results := make([]DiscoverResult, 0, len(names))
+	for _, name := range names {
+		_, present := s.st.discovered[name]
+		result := DiscoverResult{Name: name, Exposed: present}
+		if !present {
+			if reason, ok := reasons[name]; ok {
+				result.Reason = reason
+			} else {
+				result.Reason = "over_budget"
+			}
+		}
+		results = append(results, result)
+	}
+	return DiscoverOutcome{Results: results, Evicted: evicted}
+}
+
+// evictForFitLocked removes least-recently-used discovery entries until
+// the pool fits MaxTools and MaxBytes. Between equally recent entries,
+// Deferred tools are evicted before Direct ones; a single oversized
+// entry is kept so discovery cannot dead-end on one big schema. Callers
+// hold mu.
+func (s *dynamicSession) evictForFitLocked() []string {
+	pool := s.policy.Discovery
+	var evicted []string
+	for {
+		tools, total := s.st.discoveredTotals()
+		if tools <= pool.MaxTools && (total <= pool.MaxBytes || tools <= 1) {
+			return evicted
+		}
+		if tools == 0 {
+			return evicted
+		}
+
+		var victim string
+		var victimEntry discoveredEntry
+		victimDeferred := false
+		first := true
+		for name, entry := range s.st.discovered {
+			deferred := s.policy.exposureOf(name) == ExposureDeferred
+			if first || evictsBefore(entry, deferred, victimEntry, victimDeferred) {
+				victim = name
+				victimEntry = entry
+				victimDeferred = deferred
+				first = false
+			}
+		}
+		s.st.removeDiscovered(victim)
+		evicted = append(evicted, victim)
+	}
+}
+
+// evictsBefore reports whether a should be evicted before b: least
+// recently used first; on recency ties Deferred before Direct; then
+// oldest discovery sequence.
+func evictsBefore(a discoveredEntry, aDeferred bool, b discoveredEntry, bDeferred bool) bool {
+	if a.lastUse != b.lastUse {
+		return a.lastUse < b.lastUse
+	}
+	if aDeferred != bDeferred {
+		return aDeferred
+	}
+	return a.seq < b.seq
 }
 
 func (s *dynamicSession) RecordCall(call message.ToolCall) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	s.st.recordCall(call.Name, s.policy.SelectedRetention)
+
+	switch s.policy.exposureOf(call.Name) {
+	case ExposureDirect, ExposureDeferred:
+	default:
+		return
+	}
+	t, ok := s.catalog.Get(call.Name)
+	if !ok {
+		return
+	}
+	s.st.touch(call.Name, definitionBytes(t.Definition()))
+	s.evictForFitLocked()
 }
 
 func (s *dynamicSession) AdvanceTurn() {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	s.st.advanceTurn(s.policy.RecentWindow)
+
+	alive := func(name string) bool {
+		_, ok := s.catalog.Get(name)
+		return ok
+	}
+	s.st.advanceTurn(s.policy.Discovery.IdleRounds, alive)
+	// Definitions() only trims overflow in its read view; re-enforce the
+	// pool cap on state here so entries dropped by the view are really
+	// evicted even when no further Discover/RecordCall happens.
+	s.evictForFitLocked()
 }
 
 func (s *dynamicSession) Search(ctx context.Context, query string, limit int) ([]SearchHit, error) {
@@ -187,8 +367,12 @@ func (s *staticSession) Definitions() []message.ToolDefinition {
 	return s.catalog.Definitions()
 }
 
-func (s *staticSession) Require(...string)           {}
-func (s *staticSession) Select(...string)            {}
+func (s *staticSession) Require(...string) {}
+
+func (s *staticSession) Discover(...string) DiscoverOutcome {
+	return DiscoverOutcome{}
+}
+
 func (s *staticSession) RecordCall(message.ToolCall) {}
 func (s *staticSession) AdvanceTurn()                {}
 func (s *staticSession) Load(context.Context) error  { return nil }
@@ -207,8 +391,8 @@ func (s *staticSession) SearchWithLoad(context.Context, string, int) ([]SearchHi
 }
 
 // SessionFromContext returns the per-run session attached by the
-// engine. Only tool_search and RecordCalls read it; the session is
-// explicit run state, not assembly wiring.
+// engine. Only tool_search and the session recorder read it; the
+// session is explicit run state, not assembly wiring.
 func SessionFromContext(ctx context.Context) (Session, bool) {
 	s, ok := ctx.Value(sessionContextKey{}).(Session)
 	return s, ok

--- a/core/tool/session_test.go
+++ b/core/tool/session_test.go
@@ -51,7 +51,7 @@ func TestDynamicSession_ExposureBaseline(t *testing.T) {
 	}
 }
 
-func TestDynamicSession_RequireSelectRecordAdvance(t *testing.T) {
+func TestDynamicSession_DiscoverRecordAdvance(t *testing.T) {
 	assembly, _ := dynamicAssembly(t, "always", "direct", "deferred", "hidden")
 	session := assembly.NewSession()
 
@@ -61,30 +61,33 @@ func TestDynamicSession_RequireSelectRecordAdvance(t *testing.T) {
 		t.Fatalf("required hidden tool missing: %v", names)
 	}
 
-	session.Select("deferred")
+	outcome := session.Discover("deferred")
+	if len(outcome.Results) != 1 || !outcome.Results[0].Exposed {
+		t.Fatalf("Discover deferred outcome = %+v, want exposed", outcome.Results)
+	}
 	names = definitionNames(session.Definitions())
 	if !contains(names, "deferred") {
-		t.Fatalf("selected deferred tool missing: %v", names)
+		t.Fatalf("discovered deferred tool missing: %v", names)
 	}
 
 	session.RecordCall(message.ToolCall{ID: "c1", Name: "direct", Arguments: []byte(`{}`)})
 	names = definitionNames(session.Definitions())
 	if !contains(names, "direct") {
-		t.Fatalf("recent direct tool missing: %v", names)
+		t.Fatalf("used direct tool missing: %v", names)
 	}
 
 	session.AdvanceTurn()
 	names = definitionNames(session.Definitions())
 	if !contains(names, "direct") || !contains(names, "deferred") {
-		t.Fatalf("recent/selected tools must survive one advance: %v", names)
+		t.Fatalf("used/discovered tools must survive one advance: %v", names)
 	}
-	// recent window is 10, selected retention is 5 — advance past both.
+	// The discovery idle horizon is 10 — advance past it.
 	for i := 0; i < 11; i++ {
 		session.AdvanceTurn()
 	}
 	names = definitionNames(session.Definitions())
 	if contains(names, "direct") || contains(names, "deferred") {
-		t.Fatalf("tools survived retention windows: %v", names)
+		t.Fatalf("idle tools survived the discovery horizon: %v", names)
 	}
 }
 
@@ -146,7 +149,7 @@ func TestStaticSession(t *testing.T) {
 	if len(definitionNames(session.Definitions())) != 2 {
 		t.Fatalf("static session must show every tool")
 	}
-	session.Select("a")
+	session.Discover("a")
 	session.AdvanceTurn()
 	session.RecordCall(message.ToolCall{ID: "c", Name: "a", Arguments: []byte(`{}`)})
 	if _, err := session.Search(context.Background(), "a", 8); !errdefs.IsNotAvailable(err) {

--- a/core/tool/state.go
+++ b/core/tool/state.go
@@ -5,44 +5,48 @@ package tool
 // snapshot, so the visibility computation stays a pure function of
 // (candidates, state, policy).
 type sessionState struct {
-	required map[string]struct{}
-	selected map[string]int
-	recent   map[string]uint64
-	turn     uint64
+	required   map[string]struct{}
+	discovered map[string]discoveredEntry
+	turn       uint64
+	seq        uint64
 }
 
 func newSessionState() *sessionState {
 	return &sessionState{
-		required: make(map[string]struct{}),
-		selected: make(map[string]int),
-		recent:   make(map[string]uint64),
+		required:   make(map[string]struct{}),
+		discovered: make(map[string]discoveredEntry),
 	}
+}
+
+// discoveredEntry tracks one tool in the discovery pool. lastUse is the
+// turn of the latest use/discovery refresh; seq breaks same-turn ties in
+// deterministic MRU order. bytes is the serialized definition size used
+// for budget accounting (re-measured from live definitions each round).
+type discoveredEntry struct {
+	lastUse uint64
+	seq     uint64
+	bytes   int64
 }
 
 func (s *sessionState) snapshot() stateSnapshot {
 	snap := stateSnapshot{
-		required: make(map[string]struct{}, len(s.required)),
-		selected: make(map[string]int, len(s.selected)),
-		recent:   make(map[string]uint64, len(s.recent)),
-		turn:     s.turn,
+		required:   make(map[string]struct{}, len(s.required)),
+		discovered: make(map[string]discoveredEntry, len(s.discovered)),
+		turn:       s.turn,
 	}
 	for name := range s.required {
 		snap.required[name] = struct{}{}
 	}
-	for name, rounds := range s.selected {
-		snap.selected[name] = rounds
-	}
-	for name, at := range s.recent {
-		snap.recent[name] = at
+	for name, entry := range s.discovered {
+		snap.discovered[name] = entry
 	}
 	return snap
 }
 
 type stateSnapshot struct {
-	required map[string]struct{}
-	selected map[string]int
-	recent   map[string]uint64
-	turn     uint64
+	required   map[string]struct{}
+	discovered map[string]discoveredEntry
+	turn       uint64
 }
 
 func (s stateSnapshot) isRequired(name string) bool {
@@ -50,12 +54,9 @@ func (s stateSnapshot) isRequired(name string) bool {
 	return ok
 }
 
-func (s stateSnapshot) isRecent(name string, window int) bool {
-	at, ok := s.recent[name]
-	if !ok || window <= 0 {
-		return false
-	}
-	return s.turn-at <= uint64(window)
+func (s stateSnapshot) isDiscovered(name string) bool {
+	_, ok := s.discovered[name]
+	return ok
 }
 
 func (s *sessionState) require(names ...string) {
@@ -64,29 +65,44 @@ func (s *sessionState) require(names ...string) {
 	}
 }
 
-func (s *sessionState) selectNames(names []string, retention int) {
-	for _, name := range names {
-		s.selected[name] = retention
+// touch inserts or refreshes one discovery pool entry as the most
+// recently used item, recording the current definition size.
+func (s *sessionState) touch(name string, size int64) {
+	s.seq++
+	s.discovered[name] = discoveredEntry{
+		lastUse: s.turn,
+		seq:     s.seq,
+		bytes:   size,
 	}
 }
 
-func (s *sessionState) recordCall(name string, retention int) {
-	s.selected[name] = retention
-	s.recent[name] = s.turn
+func (s *sessionState) removeDiscovered(name string) {
+	delete(s.discovered, name)
 }
 
-func (s *sessionState) advanceTurn(recentWindow int) {
+func (s *sessionState) discoveredTotals() (int, int64) {
+	var total int64
+	for _, entry := range s.discovered {
+		total += entry.bytes
+	}
+	return len(s.discovered), total
+}
+
+// advanceTurn increments the round counter and returns the names whose
+// discovery entries have gone idle (no use for idleRounds rounds) or
+// whose tools are no longer in the catalog. Callers perform the actual
+// removal so the catalog check stays outside the state type.
+func (s *sessionState) advanceTurn(idleRounds int, alive func(string) bool) []string {
 	s.turn++
-	for name, rounds := range s.selected {
-		if rounds <= 1 {
-			delete(s.selected, name)
-			continue
-		}
-		s.selected[name] = rounds - 1
-	}
-	for name, at := range s.recent {
-		if s.turn-at > uint64(recentWindow) {
-			delete(s.recent, name)
+	var stale []string
+	for name, entry := range s.discovered {
+		idle := idleRounds > 0 && s.turn-entry.lastUse > uint64(idleRounds)
+		if idle || !alive(name) {
+			stale = append(stale, name)
 		}
 	}
+	for _, name := range stale {
+		delete(s.discovered, name)
+	}
+	return stale
 }

--- a/core/tool/tool_search.go
+++ b/core/tool/tool_search.go
@@ -27,33 +27,37 @@ func NewSearchTool() SearchTool { return SearchTool{} }
 func (SearchTool) Definition() message.ToolDefinition {
 	return message.DefineSchema(
 		ToolName,
-		"Search the available tool catalog for tools relevant to the current task. "+
-			"Use select to make the named tools visible to the model starting from the next round; "+
-			"selected tools are loaded immediately so the next round sees their real schemas, "+
-			"and remain available for the configured number of rounds.",
+		"Search the tool catalog for tools relevant to the current task. "+
+			"Matching tools are loaded and exposed to the model starting from the next round; "+
+			"exposed tools stay available while they are used and are evicted after idle rounds "+
+			"or when the discovery budget is full.",
 		message.ToolProperty("query", "string",
 			"natural-language or keyword query describing the capability to find"),
 		message.ToolPropertyWithDefault("limit", "integer",
-			"maximum number of hits to return", defaultSearchLimit),
-		message.ToolArrayProperty("select",
-			"tool names from the hits to make visible for upcoming rounds",
-			message.Items("string")),
+			"maximum number of hits to return and expose", defaultSearchLimit),
 	).Required("query").Build()
 }
 
 type searchArgs struct {
-	Query  string   `json:"query"`
-	Limit  int      `json:"limit,omitempty"`
-	Select []string `json:"select,omitempty"`
+	Query string `json:"query"`
+	Limit int    `json:"limit,omitempty"`
 }
 
 type searchResult struct {
-	Query    string      `json:"query"`
-	Hits     []SearchHit `json:"hits"`
-	Selected []string    `json:"selected,omitempty"`
+	Query   string          `json:"query"`
+	Hits    []SearchHit     `json:"hits"`
+	Exposed []string        `json:"exposed,omitempty"`
+	Failed  []searchFailure `json:"failed,omitempty"`
+	Evicted []string        `json:"evicted,omitempty"`
 }
 
-// Execute parses the query, ranks hits, and applies the select list.
+type searchFailure struct {
+	Name   string `json:"name"`
+	Reason string `json:"reason"`
+}
+
+// Execute parses the query, ranks hits, and exposes the top results for
+// the following rounds through the session discovery pool.
 func (SearchTool) Execute(ctx context.Context, arguments string) (string, error) {
 	session, ok := SessionFromContext(ctx)
 	if !ok {
@@ -71,18 +75,36 @@ func (SearchTool) Execute(ctx context.Context, arguments string) (string, error)
 	if err != nil {
 		return "", err
 	}
-	selected := make([]string, 0, len(args.Select))
-	for _, name := range args.Select {
-		// Selected tools must be loaded: round N+1 shows the real
-		// definition, never the LazyTool placeholder. A tool that
-		// cannot load is simply not selected.
-		if err := session.EnsureLoaded(ctx, name); err != nil {
+	loaded := make([]string, 0, len(hits))
+	var failed []searchFailure
+	for _, hit := range hits {
+		// Exposed tools must be loaded: round N+1 shows the real
+		// definition, never the LazyTool placeholder. A hit that
+		// cannot load is reported instead of silently skipped.
+		if err := session.EnsureLoaded(ctx, hit.Name); err != nil {
+			failed = append(failed, searchFailure{Name: hit.Name, Reason: "load_failed"})
 			continue
 		}
-		session.Select(name)
-		selected = append(selected, name)
+		loaded = append(loaded, hit.Name)
 	}
-	return compactJSON(searchResult{Query: args.Query, Hits: hits, Selected: selected})
+	outcome := session.Discover(loaded...)
+	exposed := make([]string, 0, len(outcome.Results))
+	for _, result := range outcome.Results {
+		if result.Exposed {
+			exposed = append(exposed, result.Name)
+			continue
+		}
+		if result.Reason != "" && result.Reason != "unknown" {
+			failed = append(failed, searchFailure{Name: result.Name, Reason: result.Reason})
+		}
+	}
+	return compactJSON(searchResult{
+		Query:   args.Query,
+		Hits:    hits,
+		Exposed: exposed,
+		Failed:  failed,
+		Evicted: outcome.Evicted,
+	})
 }
 
 func compactJSON(v any) (string, error) {

--- a/core/tool/visibility.go
+++ b/core/tool/visibility.go
@@ -28,7 +28,7 @@ func visibleCandidates(cands []candidate, st stateSnapshot, policy Policy) []can
 	}
 
 	// Deterministic pruning order: exposure rank, RequiredByName,
-	// selected rounds, recency, then name.
+	// discovery-pool recency, then name.
 	sort.SliceStable(visible, func(i, j int) bool {
 		return lessPriority(visible[i], visible[j], st)
 	})
@@ -55,15 +55,14 @@ func visibleCandidates(cands []candidate, st stateSnapshot, policy Policy) []can
 
 func include(c candidate, st stateSnapshot, policy Policy) bool {
 	required := st.isRequired(c.name)
-	selected := st.selected[c.name] > 0
-	recent := st.isRecent(c.name, policy.RecentWindow)
+	discovered := st.isDiscovered(c.name)
 	switch c.exp {
 	case ExposureAlways:
 		return true
 	case ExposureDirect:
-		return required || selected || recent
+		return required || discovered
 	case ExposureDeferred:
-		return required || selected
+		return required || discovered
 	case ExposureHidden:
 		return required
 	default:
@@ -78,11 +77,23 @@ func lessPriority(a, b candidate, st stateSnapshot) bool {
 	if ar, br := st.isRequired(a.name), st.isRequired(b.name); ar != br {
 		return ar
 	}
-	if as, bs := st.selected[a.name], st.selected[b.name]; as != bs {
-		return as > bs
+	ad, aOK := st.discovered[a.name]
+	bd, bOK := st.discovered[b.name]
+	if aOK != bOK {
+		return aOK
 	}
-	if ar, br := st.recent[a.name], st.recent[b.name]; ar != br {
-		return ar > br
+	if aOK && bOK {
+		if ad.lastUse != bd.lastUse {
+			return ad.lastUse > bd.lastUse
+		}
+		if ad.seq != bd.seq {
+			return ad.seq > bd.seq
+		}
+	}
+	// tool_search is the discovery escape hatch: among otherwise equal
+	// candidates it always sorts first, so per-round pruning keeps it.
+	if a.name != b.name && (a.name == ToolName || b.name == ToolName) {
+		return a.name == ToolName
 	}
 	return a.name < b.name
 }

--- a/docs/guides/tool.md
+++ b/docs/guides/tool.md
@@ -61,7 +61,31 @@ resources:
         default: deferred
         exposures:
           tool_search: always
+        budget:                   # per-round visible set
+          max_definitions: 32
+          max_bytes: 16384
+        discovery:                # persistent discovery pool
+          max_tools: 32
+          max_bytes: 16384        # independent byte cap
+          idle_rounds: 10
 ```
+
+`tool_search` is the discovery tool: a query plus an optional limit.
+Matching tools are loaded and added to the session's discovery pool
+automatically (no `select` step), and their real schemas become visible
+from the next round. Pool entries stay visible while they are used:
+every executed call refreshes the entry, idle entries are evicted after
+`discovery.idle_rounds`, and the pool never exceeds
+`discovery.max_tools` / `discovery.max_bytes` — the per-round
+`budget` still caps what is actually sent to the model each turn.
+`discovery.max_bytes` is independent of `budget.max_bytes`; raising it
+above the per-round budget keeps lower-priority entries as a loaded
+cache that costs no tokens; they return to the visible set when used or
+re-searched.
+`tool_search` must stay `always`; a different exposure is rejected at
+assembly build time. The legacy `selected_retention` and `recent_window`
+policy keys are deprecated and only seed `discovery.idle_rounds` when it
+is unset.
 
 MCP servers are registered as a `tool.Source/mcp` resource. Attach is
 best-effort: a server that is unreachable at startup is retried in the

--- a/skills/flowcraft-config/references/pitfalls.md
+++ b/skills/flowcraft-config/references/pitfalls.md
@@ -67,6 +67,11 @@ builds the deployment with its own factory registry, or at runtime.
     unknown fields. OpenAI-family reasoning off is implied by
     `reasoning: toggle`; embed custom dimensions now live under
     `capabilities.custom_embed_dimensions` — host build.
+19. With dynamic injection, `tool_search` must be exposed as `always`.
+    Configuring it as `direct`/`deferred`/`hidden` disables discovery and
+    is rejected at host build; omit it from `exposures` (it is forced to
+    `always`) or set it explicitly. `tool_search` no longer accepts a
+    `select` argument — matching tools auto-expose from the query hits.
 
 ## Error map
 
@@ -88,6 +93,7 @@ builds the deployment with its own factory registry, or at runtime.
 | `runtime: agent "x" is a deployed agent` | runtime API | register/remove collides with a document agent | register under a new name, or change the deployment |
 | `dynamic catalog has no default; agent "x" needs WithToolAssembly` | runtime API | runtime registration without a tool mapping | add `WithToolAssembly` or configure `default` |
 | removal `DeadlineExceeded` | runtime API | active turn did not finish in time | wait/retry; the agent is still registered |
+| `tool: tool_search must be registered with exposure "always"` | host build | `tool_search` explicitly set to a non-always exposure | remove it from `exposures` or set `tool_search: always` |
 
 ## Debug order
 

--- a/skills/flowcraft-config/references/resources.md
+++ b/skills/flowcraft-config/references/resources.md
@@ -196,7 +196,28 @@ tools:
       default: deferred
       exposures:
         tool_search: always
+      budget:               # per-round visible set
+        max_definitions: 32
+        max_bytes: 16384
+      discovery:            # persistent discovery pool
+        max_tools: 32
+        max_bytes: 16384    # independent byte cap
+        idle_rounds: 10
 ```
+
+`tool_search` must stay `always`; any other exposure is rejected at host
+build. It takes a `query` and an optional `limit` (default 8): matching
+Direct/Deferred tools are loaded and added to the session discovery pool
+automatically — there is no `select` step (a legacy caller that still
+passes `select` is ignored) — and their real schemas become visible from
+the next round. Executed calls refresh pool recency; entries idle beyond
+`discovery.idle_rounds` (default 10) are evicted, and the pool never
+exceeds `discovery.max_tools` / `discovery.max_bytes` (defaults 32 /
+16 KiB), an independent byte cap. The per-round `budget` still caps what
+the model actually receives each turn; raising `discovery.max_bytes`
+above it keeps extra entries as a no-token loaded cache until they are
+used or re-searched. The legacy `selected_retention` and `recent_window`
+policy keys only seed `discovery.idle_rounds` when it is unset.
 
 The `middleware` impl is the same assembly with a settings-declared
 middleware chain; the `memory` impl rejects the `middlewares` key:
@@ -216,7 +237,9 @@ tools:
     dynamic: {default: deferred, exposures: {tool_search: always}}
 ```
 
-Each middleware entry is optional; absent entries are skipped. `recover`
+The `dynamic` subtree takes the same keys as the memory sample above
+(`budget`, `discovery`, ...). Each middleware entry is optional; absent
+entries are skipped. `recover`
 converts tool panics into error results, `telemetry.enabled` records an
 OpenTelemetry span plus executions/duration/error metrics and a warning
 log per call, `timeout.default` bounds each call (calls that already


### PR DESCRIPTION
Fixes #520

## Summary

Replaces the decaying per-round select/retention exposure model in `core/tool` with a per-session **discovery pool** bounded by an independent, configurable byte/count budget.

- `tool_search` no longer takes `select`: `query` + `limit` only; matching hits are loaded and auto-exposed from the next round.
- New `dynamic.discovery` settings: `max_tools` / `max_bytes` (independent byte cap) / `idle_rounds` (defaults 32 / 16 KiB / 10).
- Pool lifecycle: executed calls refresh recency (built-in session recorder on dynamic assemblies), idle entries are swept, overflow evicts least-recently-used (Deferred before Direct on recency ties).
- Per-round `dynamic.budget` still caps what reaches the model each turn; `tool_search` (Always) survives pruning.
- `tool_search` exposure is validated to stay `always` (other values fail the assembly build instead of silently disabling discovery).
- `tool_search` returns `hits / exposed / failed / evicted` instead of silently skipping unloadable or unknown names.

## Breaking changes

- `Session.Select` renamed to `Discover(...) DiscoverOutcome` (per-name `Exposed`/`Reason` plus `Evicted`).
- `tool_search` schema removes `select` (legacy callers passing it are ignored).
- `selected_retention` / `recent_window` deprecated: they only seed `discovery.idle_rounds` when unset.
- `middleware.RecordCalls` deprecated (dynamic assemblies now auto-record).

## Verification

- `make ci`, `make lint`, `make release-check`, `git diff --check` all pass.
- New tests cover LRU/byte-cap eviction, idle expiry + use refresh, Direct-over-Deferred ties, MRU subset under per-round budget, `tool_search` load-failure reporting, Always/Hidden exclusion, and catalog-removal cleanup.
- `docs/guides/tool.md` and the `flowcraft-config` skill references updated.
