### PR TITLE
chore(release): add core v0.3.1 changeset

### DIFF
--- a/.release/core-v0.3.1.json
+++ b/.release/core-v0.3.1.json
@@ -1,0 +1,9 @@
+{
+  "summary": "feat(core/tool): add a per-session discovery pool with an independent byte/count budget — Session.Select becomes Discover with per-name Exposed/Reason and Evicted outcomes, dynamic.discovery gains max_tools/max_bytes/idle_rounds (defaults 32 tools, 16 KiB, 10 rounds) with idle sweep and least-recently-used overflow eviction (Deferred before Direct on recency ties), per-round dynamic.budget still caps what reaches the model with tool_search (Always) surviving pruning, tool_search drops select for query+limit and reports hits/exposed/failed/evicted instead of skipping unknown or unloadable names, and dynamic assemblies auto-record while RecordCalls and selected_retention/recent_window are deprecated; feat(core/tool): expose telemetry as a configurable assembly middleware — FromSettings appends middleware.Telemetry() after recover when telemetry.enabled is set, and the resource factory settings decode accepts the telemetry entry",
+  "releases": [
+    {
+      "module": "core",
+      "bump": "patch"
+    }
+  ]
+}


### PR DESCRIPTION
Adds the pending `.release/core-v0.3.1.json` changeset so the release workflow can tag **core/v0.3.1** (patch) after merging.

## Covered delta since core/v0.3.0

- `feat(core/tool): expose telemetry as a configurable assembly middleware` (#519)
- `feat(core/tool): discovery pool with independent byte budget` (#521)

The summary describes both PRs as the accumulated delta since the previous core tag, per the releasegate convention.

## Release plan

```
core: 0.3.0 -> 0.3.1 (patch), tag core/v0.3.1
```

`make release-check`, `make ci`, `make lint`, and `git diff --check` all pass on this branch.

After this merges, the `Release modules` workflow opens/refreshes the changelog Release PR; merging that PR runs the module gates and creates the `core/v0.3.1` tag.