### PR TITLE
fix: replay assistant context as output messages and name contract violations

### DIFF
--- a/core/inference/decision.go
+++ b/core/inference/decision.go
@@ -244,10 +244,18 @@ func (r CompileReport) ValidateFailure(operation Operation, active []FieldID) er
 }
 
 func contractViolation(operation Operation, field FieldID, message string) error {
-	return NewError(
+	err := NewError(
 		CompilerContractViolation,
 		operation,
 		field,
 		fmt.Errorf("%s", message),
 	)
+	// The message names the exact check that failed, and several checks
+	// share a field path while pointing at different owners (a missing
+	// disposition is a driver bug, an inactive decision is a caller bug).
+	// It is a static stage label, so it belongs in Detail where Error(),
+	// logs, and spans can reach it; the cause keeps the chain for
+	// errors.Is/errors.As.
+	err.Detail = message
+	return err
 }

--- a/core/inference/decision_test.go
+++ b/core/inference/decision_test.go
@@ -1,6 +1,9 @@
 package inference
 
-import "testing"
+import (
+	"errors"
+	"testing"
+)
 
 func TestValidateFailureAllowsDroppedAlongsideRejection(t *testing.T) {
 	active := []FieldID{
@@ -48,5 +51,88 @@ func TestValidateFailureRejectsUnreasonedDrop(t *testing.T) {
 	)
 	if err == nil {
 		t.Fatal("ValidateFailure accepted a dropped field without a reason")
+	}
+}
+
+// Every contract violation names the check that failed: the field path
+// alone cannot tell a driver bug from a caller bug, and production triage
+// reads Error() rather than the cause chain.
+func TestContractViolationNamesTheFailedCheck(t *testing.T) {
+	cases := []struct {
+		name   string
+		report CompileReport
+		active []FieldID
+		want   string
+	}{
+		{
+			name: "active field has no disposition",
+			report: CompileReport{
+				Operation: OperationGenerate,
+				Decisions: []Decision{
+					{Field: FieldGenerateContextText, Disposition: Native},
+				},
+			},
+			active: []FieldID{
+				FieldGenerateContextText,
+				FieldGenerateContextReasoning,
+			},
+			want: "compiler_contract_violation during generate at " +
+				"generate.context.*.content.parts.reasoning: active field has no disposition",
+		},
+		{
+			name: "decision covers an inactive field",
+			report: CompileReport{
+				Operation: OperationGenerate,
+				Decisions: []Decision{
+					{Field: FieldGenerateContextText, Disposition: Native},
+					{Field: FieldGenerateContextReasoning, Disposition: Dropped, Reason: "stale"},
+				},
+			},
+			active: []FieldID{FieldGenerateContextText},
+			want: "compiler_contract_violation during generate at " +
+				"generate.context.*.content.parts.reasoning: decision covers an inactive field",
+		},
+	}
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			err := testCase.report.ValidateSuccess(OperationGenerate, testCase.active)
+			if err == nil {
+				t.Fatal("ValidateSuccess accepted an invalid report")
+			}
+			if got := err.Error(); got != testCase.want {
+				t.Fatalf("Error() = %q, want %q", got, testCase.want)
+			}
+			var inferenceErr *Error
+			if !errors.As(err, &inferenceErr) {
+				t.Fatalf("error = %v, want an inference error", err)
+			}
+			if inferenceErr.Detail != testCase.name {
+				t.Fatalf("Detail = %q, want %q", inferenceErr.Detail, testCase.name)
+			}
+			// The cause keeps the chain for errors.Is/errors.As consumers.
+			if cause := errors.Unwrap(err); cause == nil ||
+				cause.Error() != testCase.name {
+				t.Fatalf("cause = %v, want %q", cause, testCase.name)
+			}
+		})
+	}
+}
+
+// The failure-side validator carries its reason the same way.
+func TestContractViolationOnFailedCompileNamesTheFailedCheck(t *testing.T) {
+	report := CompileReport{
+		Operation: OperationGenerate,
+		Decisions: []Decision{
+			{Field: FieldGenerateInputText, Disposition: Dropped},
+		},
+	}
+	err := report.ValidateFailure(OperationGenerate, []FieldID{FieldGenerateInputText})
+	if err == nil {
+		t.Fatal("ValidateFailure accepted a dropped field without a reason")
+	}
+	want := "compiler_contract_violation during generate at generate.input.content.parts.text: " +
+		"dropped field carries no reason"
+	if got := err.Error(); got != want {
+		t.Fatalf("Error() = %q, want %q", got, want)
 	}
 }

--- a/driver/azure/generate.go
+++ b/driver/azure/generate.go
@@ -437,6 +437,17 @@ func compileMessage(
 				ledger.reject(fields[message.PartImage], "model does not accept image input")
 				continue
 			}
+			// Assistant context rides an output-message item, whose content
+			// is output_text/refusal only: an assistant image has no wire
+			// form, so it fails here rather than reaching the provider as an
+			// item the API refuses.
+			if role == "assistant" {
+				ledger.reject(
+					fields[message.PartImage],
+					"assistant context cannot carry image input",
+				)
+				continue
+			}
 			content = append(content, wireContent{
 				kind: wireContentImage,
 				uri:  sourceURI(value.Source),

--- a/driver/azure/generate_openai.go
+++ b/driver/azure/generate_openai.go
@@ -27,12 +27,7 @@ func wireToParams(wire generateWire) responses.ResponseNewParams {
 	for _, item := range wire.items {
 		switch item.kind {
 		case wireItemMessage:
-			items = append(items, responses.ResponseInputItemUnionParam{
-				OfMessage: &responses.EasyInputMessageParam{
-					Role:    responses.EasyInputMessageRole(item.role),
-					Content: messageContent(item.content),
-				},
-			})
+			items = append(items, messageInputItem(item))
 		case wireItemToolCall:
 			items = append(items, responses.ResponseInputItemUnionParam{
 				OfFunctionCall: &responses.ResponseFunctionToolCallParam{
@@ -196,6 +191,52 @@ func messageContent(
 		}
 	}
 	return responses.EasyInputMessageContentUnionParam{OfInputItemContentList: list}
+}
+
+// messageInputItem lowers one compiled message into an input item. Assistant
+// text rides an output-message item: the Responses API accepts output_text
+// and refusal under the assistant role only, and the SDK's
+// EasyInputMessage content union can express neither, so an assistant item
+// built that way carries input_text and the provider rejects the whole
+// request (400 invalid_value). Every other role keeps the message path.
+func messageInputItem(item wireItem) responses.ResponseInputItemUnionParam {
+	if item.role == string(message.RoleAssistant) {
+		return responses.ResponseInputItemUnionParam{
+			OfOutputMessage: &responses.ResponseOutputMessageParam{
+				Content: assistantOutputContent(item.content),
+			},
+		}
+	}
+	return responses.ResponseInputItemUnionParam{
+		OfMessage: &responses.EasyInputMessageParam{
+			Role:    responses.EasyInputMessageRole(item.role),
+			Content: messageContent(item.content),
+		},
+	}
+}
+
+// assistantOutputContent lowers assistant parts to output_text. The compiler
+// rejects media on assistant turns, so text is the only kind that arrives
+// here; anything else is skipped rather than marshalled into a shape the
+// provider would refuse.
+func assistantOutputContent(
+	content []wireContent,
+) []responses.ResponseOutputMessageContentUnionParam {
+	parts := make([]responses.ResponseOutputMessageContentUnionParam, 0, len(content))
+	for _, part := range content {
+		if part.kind != wireContentText {
+			continue
+		}
+		parts = append(parts, responses.ResponseOutputMessageContentUnionParam{
+			OfOutputText: &responses.ResponseOutputTextParam{
+				Text: part.text,
+				// Annotations are declared required on the output-text
+				// shape, and a replayed turn has none to carry.
+				Annotations: []responses.ResponseOutputTextAnnotationUnionParam{},
+			},
+		})
+	}
+	return parts
 }
 
 func textFormatParam(format *wireTextFormat) responses.ResponseTextConfigParam {

--- a/driver/azure/generate_openai_test.go
+++ b/driver/azure/generate_openai_test.go
@@ -1,0 +1,154 @@
+package azure
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/GizClaw/flowcraft/core/inference"
+	"github.com/GizClaw/flowcraft/core/message"
+	"github.com/GizClaw/flowcraft/core/message/media"
+)
+
+// azureEntry declares one deployment for the compiler tests: text in, text
+// out, image input when the test needs vision.
+func azureEntry(inputs []message.PartKind) catalogEntry {
+	outputs := []message.PartKind{message.PartText}
+	return entryFor(ModelSpec{
+		Name: "gpt-test",
+		Kind: "generate",
+		Capabilities: &inference.CapabilitiesPatch{
+			Inputs:  &inputs,
+			Outputs: &outputs,
+		},
+	})
+}
+
+func azureModel() inference.ModelRef {
+	return inference.ModelRef{
+		ID:      inference.ModelID{Provider: "azure", Name: "gpt-test"},
+		Profile: "default",
+	}
+}
+
+func azureWire(t *testing.T, entry catalogEntry, request inference.GenerateRequest) generateWire {
+	t.Helper()
+	compiled, err := compileGenerate("gpt-test", entry)(
+		context.Background(),
+		azureModel(),
+		request,
+		inference.GenerateExecutionUnary,
+	)
+	if err != nil {
+		t.Fatalf("compileGenerate: %v", err)
+	}
+	return compiled.Wire
+}
+
+func azureTextRequest(text string) inference.GenerateRequest {
+	return inference.GenerateRequest{
+		Input: inference.GenerateInput{
+			Role: inference.InputRoleUser,
+			Content: inference.InputContent{
+				Content: message.Content{
+					Parts: []message.Part{message.TextPart{Text: text}},
+				},
+				Intent: inference.Intent{Text: &inference.TextIntent{}},
+			},
+		},
+	}
+}
+
+// Assistant context must ride an output-message item: the Responses API
+// accepts output_text and refusal under the assistant role only, and an
+// input_text part under that role fails the whole request with 400
+// invalid_value. See issue #524.
+func TestWireToParamsAssistantContextUsesOutputText(t *testing.T) {
+	request := azureTextRequest("current")
+	request.Context = []message.Message{
+		{
+			Role: message.RoleUser,
+			Content: message.Content{Parts: []message.Part{
+				message.TextPart{Text: "prior"},
+			}},
+		},
+		{
+			Role: message.RoleAssistant,
+			Content: message.Content{Parts: []message.Part{
+				message.TextPart{Text: "answer"},
+			}},
+		},
+	}
+	entry := azureEntry([]message.PartKind{message.PartText})
+	items := wireToParams(azureWire(t, entry, request)).Input.OfInputItemList
+	if len(items) != 3 {
+		t.Fatalf("items = %d, want 3 (user, assistant, current)", len(items))
+	}
+	assistant := items[1]
+	if assistant.OfOutputMessage == nil {
+		t.Fatalf("assistant item = %+v, want an output-message item", assistant)
+	}
+	content := assistant.OfOutputMessage.Content
+	if len(content) != 1 || content[0].OfOutputText == nil ||
+		content[0].OfOutputText.Text != "answer" {
+		t.Fatalf("assistant content = %+v, want one output_text part", content)
+	}
+	raw, err := json.Marshal(assistant)
+	if err != nil {
+		t.Fatalf("marshal assistant item: %v", err)
+	}
+	if !strings.Contains(string(raw), `"type":"output_text"`) {
+		t.Fatalf("assistant item = %s, want output_text content", raw)
+	}
+	for _, index := range []int{0, 2} {
+		other := items[index]
+		if other.OfMessage == nil {
+			t.Fatalf("item[%d] = %+v, want an easy-message item", index, other)
+		}
+		raw, err := json.Marshal(other)
+		if err != nil {
+			t.Fatalf("marshal item[%d]: %v", index, err)
+		}
+		if !strings.Contains(string(raw), `"type":"input_text"`) {
+			t.Fatalf("item[%d] = %s, want input_text content", index, raw)
+		}
+	}
+}
+
+// The assistant output-message shape carries output_text only, so a media
+// part on an assistant turn has no wire form: the compiler fails it locally
+// instead of emitting a body the provider refuses.
+func TestCompileRejectsAssistantContextImage(t *testing.T) {
+	source, err := media.NewImageURL("https://example.com/cat.png", "image/png")
+	if err != nil {
+		t.Fatalf("NewImageURL: %v", err)
+	}
+	request := azureTextRequest("current")
+	request.Context = []message.Message{
+		{
+			Role: message.RoleAssistant,
+			Content: message.Content{Parts: []message.Part{
+				message.TextPart{Text: "answer"},
+				message.ImagePart{Source: source},
+			}},
+		},
+	}
+	entry := azureEntry([]message.PartKind{message.PartText, message.PartImage})
+	_, err = compileGenerate("gpt-test", entry)(
+		context.Background(),
+		azureModel(),
+		request,
+		inference.GenerateExecutionUnary,
+	)
+	if err == nil {
+		t.Fatal("compiler accepted an image in an assistant turn")
+	}
+	var inferenceErr *inference.Error
+	if !errors.As(err, &inferenceErr) ||
+		inferenceErr.Field != inference.FieldGenerateContextImage {
+		t.Fatalf("compile error = %+v, want rejection of %q",
+			err, inference.FieldGenerateContextImage)
+	}
+}

--- a/driver/deepseek/generate_responses.go
+++ b/driver/deepseek/generate_responses.go
@@ -494,12 +494,7 @@ func wireToResponseParams(wire responseWire) responses.ResponseNewParams {
 	for _, item := range wire.items {
 		switch item.kind {
 		case responseWireItemMessage:
-			items = append(items, responses.ResponseInputItemUnionParam{
-				OfMessage: &responses.EasyInputMessageParam{
-					Role:    responses.EasyInputMessageRole(item.role),
-					Content: responseMessageContent(item.content),
-				},
-			})
+			items = append(items, responseMessageInputItem(item))
 		case responseWireItemToolCall:
 			items = append(items, responses.ResponseInputItemUnionParam{
 				OfFunctionCall: &responses.ResponseFunctionToolCallParam{
@@ -652,6 +647,52 @@ func responseMessageContent(
 		}
 	}
 	return responses.EasyInputMessageContentUnionParam{OfInputItemContentList: list}
+}
+
+// responseMessageInputItem lowers one compiled message into an input item.
+// Assistant text rides an output-message item: the Responses API accepts
+// output_text and refusal under the assistant role only, and the SDK's
+// EasyInputMessage content union can express neither, so an assistant item
+// built that way carries input_text and the provider rejects the whole
+// request (400 invalid_value). Every other role keeps the message path.
+func responseMessageInputItem(item responseWireItem) responses.ResponseInputItemUnionParam {
+	if item.role == string(message.RoleAssistant) {
+		return responses.ResponseInputItemUnionParam{
+			OfOutputMessage: &responses.ResponseOutputMessageParam{
+				Content: responseAssistantContent(item.content),
+			},
+		}
+	}
+	return responses.ResponseInputItemUnionParam{
+		OfMessage: &responses.EasyInputMessageParam{
+			Role:    responses.EasyInputMessageRole(item.role),
+			Content: responseMessageContent(item.content),
+		},
+	}
+}
+
+// responseAssistantContent lowers assistant parts to output_text. The
+// compiler keeps images on user turns and rejects everything else, so text
+// is the only kind that arrives here; anything else is skipped rather than
+// marshalled into a shape the provider would refuse.
+func responseAssistantContent(
+	content []wireContent,
+) []responses.ResponseOutputMessageContentUnionParam {
+	parts := make([]responses.ResponseOutputMessageContentUnionParam, 0, len(content))
+	for _, part := range content {
+		if part.kind != wireContentText {
+			continue
+		}
+		parts = append(parts, responses.ResponseOutputMessageContentUnionParam{
+			OfOutputText: &responses.ResponseOutputTextParam{
+				Text: part.text,
+				// Annotations are declared required on the output-text
+				// shape, and a replayed turn has none to carry.
+				Annotations: []responses.ResponseOutputTextAnnotationUnionParam{},
+			},
+		})
+	}
+	return parts
 }
 
 func responseTextFormatParam(format *wireTextFormat) responses.ResponseTextConfigParam {

--- a/driver/deepseek/generate_test.go
+++ b/driver/deepseek/generate_test.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"sync"
 	"testing"
 
@@ -867,5 +868,72 @@ func TestResponsesJSONSchemaCompiles(t *testing.T) {
 	params := wireToResponseParams(compiled.Wire)
 	if params.Text.Format.OfJSONSchema == nil {
 		t.Fatalf("text format = %+v, want json_schema", params.Text.Format)
+	}
+}
+
+// Assistant context must ride an output-message item: the Responses API
+// accepts output_text and refusal under the assistant role only, and an
+// input_text part under that role fails the whole request with 400
+// invalid_value. See issue #524.
+func TestResponsesAssistantContextUsesOutputText(t *testing.T) {
+	request := simpleTextRequest("current")
+	request.Context = []message.Message{
+		{
+			Role: message.RoleUser,
+			Content: message.Content{Parts: []message.Part{
+				message.TextPart{Text: "prior"},
+			}},
+		},
+		{
+			Role: message.RoleAssistant,
+			Content: message.Content{Parts: []message.Part{
+				message.TextPart{Text: "answer"},
+			}},
+		},
+	}
+	compiled, err := compileResponsesGenerate(
+		"deepseek-v4-flash",
+		responsesEntry(),
+	)(
+		context.Background(),
+		deepseekModel("deepseek-v4-flash"),
+		request,
+		inference.GenerateExecutionUnary,
+	)
+	if err != nil {
+		t.Fatalf("Compile: %v", err)
+	}
+	items := wireToResponseParams(compiled.Wire).Input.OfInputItemList
+	if len(items) != 3 {
+		t.Fatalf("items = %d, want 3 (user, assistant, current)", len(items))
+	}
+	assistant := items[1]
+	if assistant.OfOutputMessage == nil {
+		t.Fatalf("assistant item = %+v, want an output-message item", assistant)
+	}
+	content := assistant.OfOutputMessage.Content
+	if len(content) != 1 || content[0].OfOutputText == nil ||
+		content[0].OfOutputText.Text != "answer" {
+		t.Fatalf("assistant content = %+v, want one output_text part", content)
+	}
+	raw, err := json.Marshal(assistant)
+	if err != nil {
+		t.Fatalf("marshal assistant item: %v", err)
+	}
+	if !strings.Contains(string(raw), `"type":"output_text"`) {
+		t.Fatalf("assistant item = %s, want output_text content", raw)
+	}
+	for _, index := range []int{0, 2} {
+		other := items[index]
+		if other.OfMessage == nil {
+			t.Fatalf("item[%d] = %+v, want an easy-message item", index, other)
+		}
+		raw, err := json.Marshal(other)
+		if err != nil {
+			t.Fatalf("marshal item[%d]: %v", index, err)
+		}
+		if !strings.Contains(string(raw), `"type":"input_text"`) {
+			t.Fatalf("item[%d] = %s, want input_text content", index, raw)
+		}
 	}
 }

--- a/driver/openai/generate.go
+++ b/driver/openai/generate.go
@@ -463,6 +463,18 @@ func compileMessage(
 				ledger.reject(fields[message.PartImage], "model does not accept image input")
 				continue
 			}
+			// Assistant context rides an output-message item, whose content
+			// is output_text/refusal only: an assistant image has no wire
+			// form, so it fails here rather than reaching the provider as an
+			// item the API refuses. Chat completions lowers assistant
+			// content to a plain string and keeps its own behavior.
+			if role == "assistant" && entry.api != apiChat {
+				ledger.reject(
+					fields[message.PartImage],
+					"assistant context cannot carry image input",
+				)
+				continue
+			}
 			content = append(content, wireContent{
 				kind: wireContentImage,
 				uri:  sourceURI(value.Source),

--- a/driver/openai/generate_openai.go
+++ b/driver/openai/generate_openai.go
@@ -27,12 +27,7 @@ func wireToParams(wire generateWire) responses.ResponseNewParams {
 	for _, item := range wire.items {
 		switch item.kind {
 		case wireItemMessage:
-			items = append(items, responses.ResponseInputItemUnionParam{
-				OfMessage: &responses.EasyInputMessageParam{
-					Role:    responses.EasyInputMessageRole(item.role),
-					Content: messageContent(item.content),
-				},
-			})
+			items = append(items, messageInputItem(item))
 		case wireItemToolCall:
 			items = append(items, responses.ResponseInputItemUnionParam{
 				OfFunctionCall: &responses.ResponseFunctionToolCallParam{
@@ -199,6 +194,52 @@ func messageContent(
 		}
 	}
 	return responses.EasyInputMessageContentUnionParam{OfInputItemContentList: list}
+}
+
+// messageInputItem lowers one compiled message into an input item. Assistant
+// text rides an output-message item: the Responses API accepts output_text
+// and refusal under the assistant role only, and the SDK's
+// EasyInputMessage content union can express neither, so an assistant item
+// built that way carries input_text and the provider rejects the whole
+// request (400 invalid_value). Every other role keeps the message path.
+func messageInputItem(item wireItem) responses.ResponseInputItemUnionParam {
+	if item.role == string(message.RoleAssistant) {
+		return responses.ResponseInputItemUnionParam{
+			OfOutputMessage: &responses.ResponseOutputMessageParam{
+				Content: assistantOutputContent(item.content),
+			},
+		}
+	}
+	return responses.ResponseInputItemUnionParam{
+		OfMessage: &responses.EasyInputMessageParam{
+			Role:    responses.EasyInputMessageRole(item.role),
+			Content: messageContent(item.content),
+		},
+	}
+}
+
+// assistantOutputContent lowers assistant parts to output_text. The compiler
+// rejects media on assistant turns, so text is the only kind that arrives
+// here; anything else is skipped rather than marshalled into a shape the
+// provider would refuse.
+func assistantOutputContent(
+	content []wireContent,
+) []responses.ResponseOutputMessageContentUnionParam {
+	parts := make([]responses.ResponseOutputMessageContentUnionParam, 0, len(content))
+	for _, part := range content {
+		if part.kind != wireContentText {
+			continue
+		}
+		parts = append(parts, responses.ResponseOutputMessageContentUnionParam{
+			OfOutputText: &responses.ResponseOutputTextParam{
+				Text: part.text,
+				// Annotations are declared required on the output-text
+				// shape, and a replayed turn has none to carry.
+				Annotations: []responses.ResponseOutputTextAnnotationUnionParam{},
+			},
+		})
+	}
+	return parts
 }
 
 func textFormatParam(format *wireTextFormat) responses.ResponseTextConfigParam {

--- a/driver/openai/generate_openai_test.go
+++ b/driver/openai/generate_openai_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -15,6 +16,7 @@ import (
 	"github.com/GizClaw/flowcraft/core/errdefs"
 	"github.com/GizClaw/flowcraft/core/inference"
 	"github.com/GizClaw/flowcraft/core/message"
+	"github.com/GizClaw/flowcraft/core/message/media"
 	"github.com/GizClaw/flowcraft/core/resource"
 
 	"github.com/openai/openai-go/v3/responses"
@@ -447,6 +449,107 @@ func TestWireToParamsMessages(t *testing.T) {
 	if items[4].OfFunctionCallOutput == nil ||
 		items[4].OfFunctionCallOutput.Output.OfString.Value != "found" {
 		t.Fatalf("tool output item = %+v", items[4])
+	}
+}
+
+// Assistant context must ride an output-message item: the Responses API
+// accepts output_text and refusal under the assistant role only, and an
+// input_text part under that role fails the whole request with 400
+// invalid_value. See issue #524.
+func TestWireToParamsAssistantContextUsesOutputText(t *testing.T) {
+	request := simpleTextRequest("current")
+	request.Context = []message.Message{
+		{
+			Role: message.RoleSystem,
+			Content: message.Content{Parts: []message.Part{
+				message.TextPart{Text: "be terse"},
+			}},
+		},
+		{
+			Role: message.RoleUser,
+			Content: message.Content{Parts: []message.Part{
+				message.TextPart{Text: "prior"},
+			}},
+		},
+		{
+			Role: message.RoleAssistant,
+			Content: message.Content{Parts: []message.Part{
+				message.TextPart{Text: "answer"},
+			}},
+		},
+	}
+	items := wireToParams(compileTextWire(t, request)).Input.OfInputItemList
+	if len(items) != 4 {
+		t.Fatalf("items = %d, want 4 (system, user, assistant, current)", len(items))
+	}
+	assistant := items[2]
+	if assistant.OfOutputMessage == nil {
+		t.Fatalf("assistant item = %+v, want an output-message item", assistant)
+	}
+	if assistant.OfMessage != nil {
+		t.Fatalf("assistant item kept the easy-message shape: %+v", assistant.OfMessage)
+	}
+	content := assistant.OfOutputMessage.Content
+	if len(content) != 1 || content[0].OfOutputText == nil ||
+		content[0].OfOutputText.Text != "answer" {
+		t.Fatalf("assistant content = %+v, want one output_text part", content)
+	}
+	raw, err := json.Marshal(assistant)
+	if err != nil {
+		t.Fatalf("marshal assistant item: %v", err)
+	}
+	if !strings.Contains(string(raw), `"type":"output_text"`) ||
+		!strings.Contains(string(raw), `"annotations":[]`) {
+		t.Fatalf("assistant item = %s, want output_text content", raw)
+	}
+	// Every other role stays on the easy-message path with input_text.
+	for _, index := range []int{0, 1, 3} {
+		other := items[index]
+		if other.OfMessage == nil {
+			t.Fatalf("item[%d] = %+v, want an easy-message item", index, other)
+		}
+		raw, err := json.Marshal(other)
+		if err != nil {
+			t.Fatalf("marshal item[%d]: %v", index, err)
+		}
+		if !strings.Contains(string(raw), `"type":"input_text"`) {
+			t.Fatalf("item[%d] = %s, want input_text content", index, raw)
+		}
+	}
+}
+
+// The assistant output-message shape carries output_text only, so a media
+// part on an assistant turn has no wire form: the responses compiler fails
+// it locally instead of emitting a body the provider refuses.
+func TestCompileRejectsAssistantContextImage(t *testing.T) {
+	source, err := media.NewImageURL("https://example.com/cat.png", "image/png")
+	if err != nil {
+		t.Fatalf("NewImageURL: %v", err)
+	}
+	request := simpleTextRequest("current")
+	request.Context = []message.Message{
+		{
+			Role: message.RoleAssistant,
+			Content: message.Content{Parts: []message.Part{
+				message.TextPart{Text: "answer"},
+				message.ImagePart{Source: source},
+			}},
+		},
+	}
+	_, err = compileGenerate("gpt-5.6-sol", catalog["gpt-5.6-sol"])(
+		context.Background(),
+		openaiModel("gpt-5.6-sol"),
+		request,
+		inference.GenerateExecutionUnary,
+	)
+	if err == nil {
+		t.Fatal("responses compiler accepted an image in an assistant turn")
+	}
+	var inferenceErr *inference.Error
+	if !errors.As(err, &inferenceErr) ||
+		inferenceErr.Field != inference.FieldGenerateContextImage {
+		t.Fatalf("compile error = %+v, want rejection of %q",
+			err, inference.FieldGenerateContextImage)
 	}
 }
 


### PR DESCRIPTION
Two production-reported compiler bugs, fixed in one commit each.

## Why

**#524 — every multi-turn request failed at the provider.** The Responses API accepts `output_text` and `refusal` under the assistant role only, but the openai, azure, and deepseek transports lowered every message item to an `EasyInputMessage` whose text parts are `input_text`. The inference node turns the channel history (everything before the tail) into the request context, so from the second turn on the request carried an assistant reply and the provider rejected the whole body with `400 invalid_value`. Long-term memory extraction jobs, which inject the whole conversation as context, retried and dead-lettered. Single-turn requests and tool-result-only items were unaffected, which is why the driver and mock-LLM suites never caught it.

**#525 — production triage could not tell two different failures apart.** `contractViolation` kept its message in the cause only, and `Error()` deliberately excludes the cause, so every `CompilerContractViolation` rendered as `kind during operation at field`. Several checks share one field path while pointing at different owners: a report missing a disposition is a driver bug, a decision covering an inactive field is a caller bug.

## What changed

- `driver/openai`, `driver/azure`, `driver/deepseek`: assistant message items are lowered to an output-message item whose content parts are `output_text`; `user`/`system`/`developer` keep the previous path. The assistant item marshals as:

```json
{"content":[{"annotations":[],"text":"answer","type":"output_text"}],"role":"assistant","type":"message"}
```

- An assistant turn has no media channel under that shape, so the openai (Responses mode) and azure compilers reject an assistant image with a ledger reason instead of emitting a body the provider refuses. DeepSeek already rejected images outside user turns; openai chat mode is untouched.
- `core/inference`: the contract violation message now also lands in `Error.Detail`, which `Error()`, routine logs, and the `inference.error.detail` span attribute already carry. The cause is unchanged for `errors.Is`/`errors.As`, and `NewError` still leaves `Detail` empty. The production log line becomes:

```
compiler_contract_violation during generate at generate.context.*.content.parts.reasoning: active field has no disposition
```

## Verification

`make ci`, `make lint`, `make release-check`, and `git diff --check` are clean locally.

New tests lock the behavior:

- assistant context marshals as `output_text` while the other roles stay `input_text` (openai, azure, deepseek)
- an assistant image in context is rejected locally as `generate.context.*.content.parts.image` (openai, azure)
- contract violations name the failed check for both `active field has no disposition` and `decision covers an inactive field`, and keep the cause chain for `Unwrap`

No `.release/` changesets: per the repo convention they are added when a module is actually tagged for release.

Closes #524
Closes #525
