### PR TITLE
fix(driver): send the required summary field on replayed reasoning items

### DIFF
--- a/driver/azure/generate_openai.go
+++ b/driver/azure/generate_openai.go
@@ -49,6 +49,12 @@ func wireToParams(wire generateWire) responses.ResponseNewParams {
 			reasoning := responses.ResponseReasoningItemParam{
 				ID:               item.reasoningID,
 				EncryptedContent: param.NewOpt(item.encrypted),
+				// The API requires the summary field on a replayed reasoning
+				// item even when it carries no summary text: summaries are
+				// opt-in via reasoning.summary, so an empty array is the
+				// normal shape. Omitting the field fails the whole request
+				// with missing_required_parameter.
+				Summary: []responses.ResponseReasoningItemSummaryParam{},
 			}
 			if item.summary != "" {
 				reasoning.Summary = []responses.ResponseReasoningItemSummaryParam{

--- a/driver/azure/generate_openai_test.go
+++ b/driver/azure/generate_openai_test.go
@@ -10,6 +10,8 @@ import (
 	"github.com/GizClaw/flowcraft/core/inference"
 	"github.com/GizClaw/flowcraft/core/message"
 	"github.com/GizClaw/flowcraft/core/message/media"
+
+	"github.com/openai/openai-go/v3/responses"
 )
 
 // azureEntry declares one deployment for the compiler tests: text in, text
@@ -35,6 +37,15 @@ func azureModel() inference.ModelRef {
 
 func azureWire(t *testing.T, entry catalogEntry, request inference.GenerateRequest) generateWire {
 	t.Helper()
+	return azureCompiled(t, entry, request).Wire
+}
+
+func azureCompiled(
+	t *testing.T,
+	entry catalogEntry,
+	request inference.GenerateRequest,
+) inference.Compiled[generateWire] {
+	t.Helper()
 	compiled, err := compileGenerate("gpt-test", entry)(
 		context.Background(),
 		azureModel(),
@@ -44,7 +55,7 @@ func azureWire(t *testing.T, entry catalogEntry, request inference.GenerateReque
 	if err != nil {
 		t.Fatalf("compileGenerate: %v", err)
 	}
-	return compiled.Wire
+	return compiled
 }
 
 func azureTextRequest(text string) inference.GenerateRequest {
@@ -58,6 +69,76 @@ func azureTextRequest(text string) inference.GenerateRequest {
 				Intent: inference.Intent{Text: &inference.TextIntent{}},
 			},
 		},
+	}
+}
+
+// Replayed reasoning items must carry the summary field even when they have
+// no summary text: Azure's Responses surface requires it, and the driver
+// never opts into summaries, so an empty array is the normal shape.
+func TestWireToParamsReasoningItemWithoutSummary(t *testing.T) {
+	inputs := []message.PartKind{message.PartText}
+	outputs := []message.PartKind{message.PartText}
+	kind := inference.ReasoningToggle
+	entry := entryFor(ModelSpec{
+		Name: "gpt-test",
+		Kind: "generate",
+		Capabilities: &inference.CapabilitiesPatch{
+			Inputs:    &inputs,
+			Outputs:   &outputs,
+			Reasoning: &inference.ReasoningPatch{Kind: &kind},
+		},
+	})
+	request := azureTextRequest("current")
+	request.Context = []message.Message{{
+		Role: message.RoleAssistant,
+		Content: message.Content{Parts: []message.Part{
+			message.ReasoningPart{Signature: "enc-1", ID: "rs_1"},
+			message.TextPart{Text: "answer"},
+		}},
+	}}
+	compiled := azureCompiled(t, entry, request)
+	for _, decision := range compiled.Report.Decisions {
+		if decision.Field == inference.FieldGenerateContextReasoning &&
+			decision.Disposition != inference.Native {
+			t.Fatalf("summary-less reasoning must still round-trip: %+v", decision)
+		}
+	}
+	items := wireToParams(compiled.Wire).Input.OfInputItemList
+	if len(items) == 0 || items[0].OfReasoning == nil {
+		t.Fatalf("items = %+v, want a reasoning item first", items)
+	}
+	reasoning := items[0].OfReasoning
+	if reasoning.ID != "rs_1" || reasoning.EncryptedContent.Value != "enc-1" {
+		t.Fatalf("reasoning param = %+v", reasoning)
+	}
+	if reasoning.Summary == nil || len(reasoning.Summary) != 0 {
+		t.Fatalf("summary = %#v, want a non-nil empty slice", reasoning.Summary)
+	}
+	assertEmptySummaryField(t, reasoning)
+}
+
+// assertEmptySummaryField asserts a marshaled reasoning item carries the
+// summary field as an empty array. Presence is the contract: the field is
+// required, and only a non-nil slice survives the encoder's omitzero. The
+// item is decoded instead of substring-matched so the assertion does not
+// depend on the encoder's key order or whitespace.
+func assertEmptySummaryField(t *testing.T, reasoning *responses.ResponseReasoningItemParam) {
+	t.Helper()
+	raw, err := json.Marshal(reasoning)
+	if err != nil {
+		t.Fatalf("marshal reasoning: %v", err)
+	}
+	var fields map[string]any
+	if err := json.Unmarshal(raw, &fields); err != nil {
+		t.Fatalf("unmarshal reasoning %s: %v", raw, err)
+	}
+	summary, ok := fields["summary"]
+	if !ok {
+		t.Fatalf("reasoning json = %s, want the summary field present", raw)
+	}
+	entries, ok := summary.([]any)
+	if !ok || len(entries) != 0 {
+		t.Fatalf("summary = %#v, want a serialized empty array", summary)
 	}
 }
 

--- a/driver/deepseek/generate_test.go
+++ b/driver/deepseek/generate_test.go
@@ -602,6 +602,67 @@ func TestResponsesUnaryReasoningAndText(t *testing.T) {
 	}
 }
 
+// DeepSeek's Responses surface round-trips reasoning as plain text merged
+// into the adjacent assistant message: the docs state summary and
+// encrypted_content are not supported, so a replayed item must carry the
+// reasoning_text content and must not copy the OpenAI-only fields.
+func TestResponsesReasoningReplayUsesPlainContent(t *testing.T) {
+	server := newCapturedServer(t, func(w http.ResponseWriter, _ map[string]any) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = fmt.Fprint(w, responsesResponseJSON([]map[string]any{
+			reasoningOutputItem("thinking aloud"),
+			textOutputItem("answer"),
+		}))
+	})
+	cls := testClients(t, server.Server)
+	operations, err := openGenerate(cls, responsesEntry(), deepseekModel("deepseek-v4-flash").ID, "default")
+	if err != nil {
+		t.Fatalf("openGenerate: %v", err)
+	}
+	request := simpleTextRequest("again")
+	request.Context = []message.Message{{
+		Role: message.RoleAssistant,
+		Content: message.Content{Parts: []message.Part{
+			message.ReasoningPart{Text: "thinking aloud", ID: "rs_1"},
+			message.TextPart{Text: "answer"},
+		}},
+	}}
+	if _, err := operations.Unary.Execute(
+		context.Background(),
+		deepseekModel("deepseek-v4-flash"),
+		request,
+	); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+
+	body := server.captured()
+	input, ok := body["input"].([]any)
+	if !ok || len(input) == 0 {
+		t.Fatalf("input = %#v, want the replayed context", body["input"])
+	}
+	reasoning, ok := input[0].(map[string]any)
+	if !ok || reasoning["id"] != "rs_1" {
+		t.Fatalf("item[0] = %#v, want the replayed reasoning item first", input[0])
+	}
+	for _, unsupported := range []string{"summary", "encrypted_content"} {
+		if value, exists := reasoning[unsupported]; exists {
+			t.Fatalf(
+				"item[0] carries %s = %#v, which this surface does not support",
+				unsupported,
+				value,
+			)
+		}
+	}
+	content, ok := reasoning["content"].([]any)
+	if !ok || len(content) != 1 {
+		t.Fatalf("content = %#v, want the replayed reasoning text", reasoning["content"])
+	}
+	part, _ := content[0].(map[string]any)
+	if part["text"] != "thinking aloud" {
+		t.Fatalf("content[0] = %#v, want the reasoning text", content[0])
+	}
+}
+
 func TestResponsesMetadataEnvelopeTypedCompiles(t *testing.T) {
 	compiled, err := compileResponsesGenerate(
 		"deepseek-v4-flash",

--- a/driver/openai/generate_openai.go
+++ b/driver/openai/generate_openai.go
@@ -49,6 +49,12 @@ func wireToParams(wire generateWire) responses.ResponseNewParams {
 			reasoning := responses.ResponseReasoningItemParam{
 				ID:               item.reasoningID,
 				EncryptedContent: param.NewOpt(item.encrypted),
+				// The API requires the summary field on a replayed reasoning
+				// item even when it carries no summary text: summaries are
+				// opt-in via reasoning.summary, so an empty array is the
+				// normal shape. Omitting the field fails the whole request
+				// with missing_required_parameter.
+				Summary: []responses.ResponseReasoningItemSummaryParam{},
 			}
 			if item.summary != "" {
 				reasoning.Summary = []responses.ResponseReasoningItemSummaryParam{

--- a/driver/openai/generate_openai_test.go
+++ b/driver/openai/generate_openai_test.go
@@ -751,6 +751,77 @@ func TestWireToParamsReasoningItem(t *testing.T) {
 	}
 }
 
+// TestWireToParamsReasoningItemWithoutSummary locks the field-presence
+// contract for replayed reasoning items. Summaries are opt-in
+// (reasoning.summary), so an item routinely round-trips with its id and
+// encrypted payload but no summary text; the Responses API still requires the
+// summary field, so it must serialize as an empty array instead of being
+// omitted (omitting it fails the whole request with
+// missing_required_parameter).
+func TestWireToParamsReasoningItemWithoutSummary(t *testing.T) {
+	request := simpleTextRequest("current")
+	request.Context = []message.Message{{
+		Role: message.RoleAssistant,
+		Content: message.Content{Parts: []message.Part{
+			message.ReasoningPart{Signature: "enc-1", ID: "rs_1"},
+			message.TextPart{Text: "answer"},
+		}},
+	}}
+	compiled, err := compileGenerate("gpt-5.6-sol", catalog["gpt-5.6-sol"])(
+		context.Background(),
+		openaiModel("gpt-5.6-sol"),
+		request,
+		inference.GenerateExecutionUnary,
+	)
+	if err != nil {
+		t.Fatalf("compileGenerate: %v", err)
+	}
+	for _, decision := range compiled.Report.Decisions {
+		if decision.Field == inference.FieldGenerateContextReasoning &&
+			decision.Disposition != inference.Native {
+			t.Fatalf("summary-less reasoning must still round-trip: %+v", decision)
+		}
+	}
+
+	items := wireToParams(compiled.Wire).Input.OfInputItemList
+	if len(items) == 0 || items[0].OfReasoning == nil {
+		t.Fatalf("items = %+v, want a reasoning item first", items)
+	}
+	reasoning := items[0].OfReasoning
+	if reasoning.ID != "rs_1" || reasoning.EncryptedContent.Value != "enc-1" {
+		t.Fatalf("reasoning param = %+v", reasoning)
+	}
+	if reasoning.Summary == nil || len(reasoning.Summary) != 0 {
+		t.Fatalf("summary = %#v, want a non-nil empty slice", reasoning.Summary)
+	}
+	assertEmptySummaryField(t, reasoning)
+}
+
+// assertEmptySummaryField asserts a marshaled reasoning item carries the
+// summary field as an empty array. Presence is the contract: the field is
+// required, and only a non-nil slice survives the encoder's omitzero. The
+// item is decoded instead of substring-matched so the assertion does not
+// depend on the encoder's key order or whitespace.
+func assertEmptySummaryField(t *testing.T, reasoning *responses.ResponseReasoningItemParam) {
+	t.Helper()
+	raw, err := json.Marshal(reasoning)
+	if err != nil {
+		t.Fatalf("marshal reasoning: %v", err)
+	}
+	var fields map[string]any
+	if err := json.Unmarshal(raw, &fields); err != nil {
+		t.Fatalf("unmarshal reasoning %s: %v", raw, err)
+	}
+	summary, ok := fields["summary"]
+	if !ok {
+		t.Fatalf("reasoning json = %s, want the summary field present", raw)
+	}
+	entries, ok := summary.([]any)
+	if !ok || len(entries) != 0 {
+		t.Fatalf("summary = %#v, want a serialized empty array", summary)
+	}
+}
+
 func TestCompileReasoningDispositions(t *testing.T) {
 	model := openaiModel("gpt-5.6-sol")
 	compile := compileGenerate("gpt-5.6-sol", catalog["gpt-5.6-sol"])


### PR DESCRIPTION
One production-reported compiler bug, plus the missing coverage that let a neighbouring mistake through review.

## Why

The Responses API requires `summary` on a replayed reasoning item. The openai and azure transports built that item from `ID` + `encrypted_content` and only set `Summary` when the trace carried summary text:

```go
if item.summary != "" {
    reasoning.Summary = []responses.ResponseReasoningItemSummaryParam{{Text: item.summary}}
}
```

Summaries are opt-in via `reasoning.summary`, which neither driver ever sets, so the normal shape — encrypted reasoning with no summary text — was replayed with the field omitted entirely, and the provider rejected the whole body with `400 missing_required_parameter`. Because the inference node replays the channel history on every turn, the conversation failed from the second turn on, in the same way #524 did one field over.

The field is emitted only when the slice is non-nil: the SDK encoder tag is `json:"summary,omitzero"` and an empty-but-non-nil slice survives `omitzero` while a nil slice is dropped. Verified against the real request encoding path (httptest server + `client.Responses.New`), not just `json.Marshal`:

```json
{"input":[{"id":"rs_1","summary":[],"encrypted_content":"enc-1","type":"reasoning"}],"model":"..."}
```

## What changed

- `driver/openai`, `driver/azure`: a replayed reasoning item always carries `summary` — an empty array when the trace has no summary text, one `summary_text` entry when it does. The summary-present path is unchanged.
- `driver/deepseek`: no production change. That surface does not model the OpenAI reasoning fields — DeepSeek's docs state plain-text content is merged into the adjacent assistant message while `summary` and `encrypted_content` are not supported — so the replayed item keeps riding `content` only. The new test locks that contract and drives a real request through a captured server, so copying the OpenAI fields across drivers now fails loudly instead of shipping.
- Tests otherwise: the azure test gains the compile-ledger assertion the openai test already had (the summary-less trace must still compile `Native`), and both replace the raw-JSON substring match with a decode that asserts the field is present and empty, so the check no longer depends on the encoder's key order or whitespace.

## Verification

`make ci`, `make lint`, `make release-check`, and `git diff --check` are clean locally.

The new tests fail against the pre-fix code — verified by temporarily removing the `Summary` assignment in all three drivers, confirming each test fails for the intended reason, then restoring the files byte-identically:

- openai / azure: `summary = []responses.ResponseReasoningItemSummaryParam(nil), want a non-nil empty slice`
- deepseek: the replayed item carries `summary`, which the surface does not support

No `.release/` changesets: per the repo convention they are added when a module is actually tagged for release.
