### PR TITLE
fix(core/inference): replay reasoning traces only where they can be verified

### DIFF
--- a/core/inference/doc.go
+++ b/core/inference/doc.go
@@ -11,6 +11,8 @@
 //   - Attempt compilation: ledger.go (the shared compile ledger),
 //     generate_ledger.go (the generate part-to-field tables), provider.go
 //     (the compiler/binding pipeline),
+//     reasoning_scope.go (the reasoning provenance rule and the decode
+//     stamping wrappers),
 //     provider_definition.go (ProviderDefinition / Openers),
 //     generate_driver.go, prepared.go (a compiled attempt), binding.go
 //     (opened drivers), binding_cache.go (the host-side reuse cache),

--- a/core/inference/generate_stream_accumulator.go
+++ b/core/inference/generate_stream_accumulator.go
@@ -34,6 +34,7 @@ type generatePartAccumulator struct {
 
 	reasoningSignature string
 	reasoningID        string
+	reasoningSource    string
 }
 
 type decodedGenerateStream[RawEvent any] struct {
@@ -324,6 +325,9 @@ func (p *generatePartAccumulator) add(delta PartDelta) error {
 		if value.ID != "" {
 			p.reasoningID = value.ID
 		}
+		if value.Source != "" {
+			p.reasoningSource = value.Source
+		}
 	default:
 		return fmt.Errorf("unsupported generate part delta %T", delta)
 	}
@@ -461,6 +465,7 @@ func (p *generatePartAccumulator) result() (message.Part, error) {
 			Text:      p.text.String(),
 			Signature: p.reasoningSignature,
 			ID:        p.reasoningID,
+			Source:    p.reasoningSource,
 		}
 		if err := part.Validate(); err != nil {
 			return nil, err

--- a/core/inference/generate_stream_delta.go
+++ b/core/inference/generate_stream_delta.go
@@ -62,16 +62,22 @@ func (ToolCallDelta) inferencePartDelta()          {}
 // last delta for a part carries the opaque verification payload and the
 // provider-issued trace identifier. The accumulator concatenates Text and
 // keeps the latest Signature and ID.
+//
+// Source is the same terminal-only stamp as Signature: the verification scope
+// the driver producing this stream stamps on every reasoning delta (see
+// [ReasoningScope]), which the accumulator carries onto the assembled part.
 type ReasoningDelta struct {
 	Text      string `json:"text,omitempty"`
 	Signature string `json:"signature,omitempty"`
 	ID        string `json:"id,omitempty"`
+	Source    string `json:"source,omitempty"`
 }
 
 func (ReasoningDelta) Kind() message.PartKind { return message.PartReasoning }
 func (d ReasoningDelta) validateGenerateDelta() error {
-	if d.Text == "" && d.Signature == "" && d.ID == "" {
-		return fmt.Errorf("reasoning delta carries neither text, signature, nor id")
+	if d.Text == "" && d.Signature == "" && d.ID == "" && d.Source == "" {
+		return fmt.Errorf(
+			"reasoning delta carries neither text, signature, id, nor source")
 	}
 	return nil
 }

--- a/core/inference/reasoning_scope.go
+++ b/core/inference/reasoning_scope.go
@@ -1,0 +1,103 @@
+package inference
+
+import (
+	"context"
+
+	"github.com/GizClaw/flowcraft/core/message"
+)
+
+// Reasoning provenance. A reasoning trace is signed or encrypted by the
+// provider that produced it, and only that provider — under the same account
+// and address — can verify it again. Replaying a trace to a target that
+// cannot verify it is a hard provider error that no retry and no fallback can
+// repair, because the trace stays in the conversation. Drivers therefore
+// stamp every trace they produce with a verification scope and replay one
+// only when the target's scope matches.
+//
+// The scope is a driver-owned, opaque token on message.ReasoningPart.Source:
+// this package defines how it is composed and copied, never what it means.
+
+// ReasoningScope returns the verification scope of one addressed model: the
+// token a driver stamps on the reasoning traces it produces and compares
+// before replaying a stored one.
+//
+// declared is the deployment's own token (its provider spec), and replaces
+// the derived value entirely: an operator who has verified that a set of
+// models or credentials can verify each other's traces says so once and every
+// model of that deployment shares the scope. Otherwise the scope is the
+// address that produced the trace — provider, model, and credential profile —
+// because a provider rejects a payload another account or model cannot
+// decrypt, and the conservative answer is to replay nothing across them.
+func ReasoningScope(declared, provider, model, profile string) string {
+	if declared != "" {
+		return declared
+	}
+	scope := provider + "/" + model
+	if profile != "" {
+		scope += "/" + profile
+	}
+	return scope
+}
+
+// WithReasoningSource stamps every reasoning part a decoder produced with
+// source, so the attempt that replays the trace can tell whether this target
+// may. It is the decode half of [ReasoningScope]; drivers wrap their decoders
+// with it where the model reference and credential profile are known.
+//
+// A decode that fails passes its error through untouched: a failure has no
+// parts to attribute.
+func WithReasoningSource[Raw any](
+	decode Decoder[Raw, GenerateResponse],
+	source string,
+) Decoder[Raw, GenerateResponse] {
+	if source == "" || decode == nil {
+		return decode
+	}
+	return func(ctx context.Context, raw Raw) (GenerateResponse, error) {
+		response, err := decode(ctx, raw)
+		if err != nil {
+			return response, err
+		}
+		for index, part := range response.Message.Content.Parts {
+			normalized, err := message.NormalizePart(part)
+			if err != nil {
+				continue
+			}
+			reasoning, ok := normalized.(message.ReasoningPart)
+			if !ok {
+				continue
+			}
+			reasoning.Source = source
+			response.Message.Content.Parts[index] = reasoning
+		}
+		return response, nil
+	}
+}
+
+// WithReasoningDeltaSource is [WithReasoningSource] for the streaming path:
+// it stamps the reasoning deltas a stream decoder produced, and the stream
+// accumulator carries the stamp onto the assembled part.
+func WithReasoningDeltaSource[RawEvent any](
+	decode GenerateStreamDecoder[RawEvent],
+	source string,
+) GenerateStreamDecoder[RawEvent] {
+	if source == "" || decode == nil {
+		return decode
+	}
+	return func(ctx context.Context, raw RawEvent) (GenerateStreamEvent, error) {
+		event, err := decode(ctx, raw)
+		if err != nil {
+			return event, err
+		}
+		switch delta := event.Delta.(type) {
+		case ReasoningDelta:
+			delta.Source = source
+			event.Delta = delta
+		case *ReasoningDelta:
+			if delta != nil {
+				delta.Source = source
+			}
+		}
+		return event, nil
+	}
+}

--- a/core/inference/reasoning_scope_test.go
+++ b/core/inference/reasoning_scope_test.go
@@ -1,0 +1,205 @@
+package inference
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/GizClaw/flowcraft/core/message"
+)
+
+// TestReasoningScope pins the composition rule: a declared scope replaces the
+// derived one entirely (that is how an operator says "these models and
+// credentials verify each other"), and otherwise the scope is the address
+// that produced the trace, with the credential profile appended only when the
+// reference names one.
+func TestReasoningScope(t *testing.T) {
+	for _, test := range []struct {
+		name                               string
+		declared, provider, model, profile string
+		want                               string
+	}{
+		{
+			name:     "derived from the address",
+			provider: "openai", model: "gpt-5.6-luna", profile: "work",
+			want: "openai/gpt-5.6-luna/work",
+		},
+		{
+			name:     "no profile in the reference",
+			provider: "kimi", model: "kimi-k3",
+			want: "kimi/kimi-k3",
+		},
+		{
+			name:     "model switch changes the scope",
+			provider: "openai", model: "gpt-5.6-terra", profile: "work",
+			want: "openai/gpt-5.6-terra/work",
+		},
+		{
+			name:     "declared scope replaces the address",
+			declared: "shared-openai-prod", provider: "openai", model: "gpt-5.6-luna",
+			profile: "work",
+			want:    "shared-openai-prod",
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			got := ReasoningScope(
+				test.declared, test.provider, test.model, test.profile)
+			if got != test.want {
+				t.Fatalf("ReasoningScope = %q, want %q", got, test.want)
+			}
+		})
+	}
+}
+
+// TestWithReasoningSourceStampsParts pins the decode half: every reasoning
+// part a decoder produced carries the scope, and nothing else is touched.
+func TestWithReasoningSourceStampsParts(t *testing.T) {
+	response := GenerateResponse{Message: message.Message{
+		Role: message.RoleAssistant,
+		Content: message.Content{Parts: []message.Part{
+			message.TextPart{Text: "answer"},
+			message.ReasoningPart{Text: "thinking", Signature: "sig", ID: "t1"},
+			message.ReasoningPart{Signature: "redacted", Source: "stale"},
+		}},
+	}}
+	decode := WithReasoningSource(
+		func(context.Context, string) (GenerateResponse, error) {
+			return response, nil
+		},
+		"openai/gpt-5.6-luna/work",
+	)
+	got, err := decode(context.Background(), "raw")
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if text := got.Message.Content.Parts[0].(message.TextPart); text.Text != "answer" {
+		t.Fatalf("text part changed: %+v", text)
+	}
+	for _, index := range []int{1, 2} {
+		part, ok := got.Message.Content.Parts[index].(message.ReasoningPart)
+		if !ok {
+			t.Fatalf("part %d = %T, want ReasoningPart", index, got.Message.Content.Parts[index])
+		}
+		if part.Source != "openai/gpt-5.6-luna/work" {
+			t.Fatalf("part %d source = %q, want the deployment scope", index, part.Source)
+		}
+	}
+	if got.Message.Content.Parts[1].(message.ReasoningPart).Signature != "sig" {
+		t.Fatal("stamping rewrote the signature")
+	}
+}
+
+// TestWithReasoningSourcePassesFailureThrough pins the failure path: a
+// decoder error is not an opportunity to rewrite anything.
+func TestWithReasoningSourcePassesFailureThrough(t *testing.T) {
+	want := context.Canceled
+	decode := WithReasoningSource(
+		func(context.Context, string) (GenerateResponse, error) {
+			return GenerateResponse{}, want
+		},
+		"scope",
+	)
+	if _, err := decode(context.Background(), "raw"); err != want {
+		t.Fatalf("err = %v, want %v", err, want)
+	}
+}
+
+// TestWithReasoningDeltaSourceStampsBothForms pins the streaming half with the
+// delta forms a decoder may return.
+func TestWithReasoningDeltaSourceStampsBothForms(t *testing.T) {
+	for _, test := range []struct {
+		name  string
+		delta PartDelta
+		read  func(PartDelta) string
+	}{
+		{
+			name:  "value delta",
+			delta: ReasoningDelta{Text: "think"},
+			read: func(delta PartDelta) string {
+				return delta.(ReasoningDelta).Source
+			},
+		},
+		{
+			name:  "pointer delta",
+			delta: &ReasoningDelta{Text: "think"},
+			read: func(delta PartDelta) string {
+				return delta.(*ReasoningDelta).Source
+			},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			decode := WithReasoningDeltaSource(
+				func(context.Context, string) (GenerateStreamEvent, error) {
+					return GenerateStreamEvent{Delta: test.delta}, nil
+				},
+				"scope",
+			)
+			event, err := decode(context.Background(), "raw")
+			if err != nil {
+				t.Fatalf("decode: %v", err)
+			}
+			if got := test.read(event.Delta); got != "scope" {
+				t.Fatalf("delta source = %q, want the deployment scope", got)
+			}
+		})
+	}
+}
+
+// TestReasoningDeltaAccumulatesSource pins the stream accumulator: the source
+// is sticky like the signature, and the assembled part carries it.
+func TestReasoningDeltaAccumulatesSource(t *testing.T) {
+	accumulator := &generatePartAccumulator{kind: message.PartReasoning}
+	for _, delta := range []ReasoningDelta{
+		{Text: "thin", Source: "openai/gpt-5.6-luna/work"},
+		{Text: "king"},
+		{Signature: "sig", ID: "t1", Source: "openai/gpt-5.6-luna/work"},
+	} {
+		if err := accumulator.add(delta); err != nil {
+			t.Fatalf("add(%+v): %v", delta, err)
+		}
+	}
+	part, err := accumulator.result()
+	if err != nil {
+		t.Fatalf("result: %v", err)
+	}
+	reasoning, ok := part.(message.ReasoningPart)
+	if !ok {
+		t.Fatalf("part = %T, want ReasoningPart", part)
+	}
+	if reasoning.Text != "thinking" ||
+		reasoning.Signature != "sig" ||
+		reasoning.ID != "t1" ||
+		reasoning.Source != "openai/gpt-5.6-luna/work" {
+		t.Fatalf("assembled part = %+v", reasoning)
+	}
+}
+
+// TestReasoningPartSourceRoundTrips pins the wire form: provenance survives a
+// JSON round-trip, so a stored conversation keeps it and a host that rebuilds
+// a request from JSON cannot lose the stamp.
+func TestReasoningPartSourceRoundTrips(t *testing.T) {
+	part := message.ReasoningPart{
+		Text:      "thinking",
+		Signature: "sig",
+		ID:        "t1",
+		Source:    "openai/gpt-5.6-luna/work",
+	}
+	raw, err := message.MarshalPart(part)
+	if err != nil {
+		t.Fatalf("MarshalPart: %v", err)
+	}
+	var wire map[string]any
+	if err := json.Unmarshal(raw, &wire); err != nil {
+		t.Fatalf("wire form is not JSON: %v", err)
+	}
+	if wire["source"] != "openai/gpt-5.6-luna/work" {
+		t.Fatalf("wire source = %v, want the scope", wire["source"])
+	}
+	decoded, err := message.UnmarshalPart(raw)
+	if err != nil {
+		t.Fatalf("UnmarshalPart: %v", err)
+	}
+	if decoded != message.Part(part) {
+		t.Fatalf("round-trip = %#v, want %#v", decoded, part)
+	}
+}

--- a/core/message/parts.go
+++ b/core/message/parts.go
@@ -155,7 +155,8 @@ func MarshalPart(part Part) ([]byte, error) {
 			Text      string   `json:"text,omitempty"`
 			Signature string   `json:"signature,omitempty"`
 			ID        string   `json:"id,omitempty"`
-		}{PartReasoning, value.Text, value.Signature, value.ID}
+			Source    string   `json:"source,omitempty"`
+		}{PartReasoning, value.Text, value.Signature, value.ID, value.Source}
 	default:
 		return nil, fmt.Errorf("unsupported content part %T", part)
 	}
@@ -262,12 +263,14 @@ func UnmarshalPart(data []byte) (Part, error) {
 			Text      string   `json:"text,omitempty"`
 			Signature string   `json:"signature,omitempty"`
 			ID        string   `json:"id,omitempty"`
+			Source    string   `json:"source,omitempty"`
 		}
 		if err := decodeStrict(data, &item); err != nil {
 			return nil, fmt.Errorf("content part: %w", err)
 		}
 		return ReasoningPart{
 			Text: item.Text, Signature: item.Signature, ID: item.ID,
+			Source: item.Source,
 		}, nil
 	default:
 		return nil, fmt.Errorf("content part has unknown type %q", header.Type)
@@ -411,10 +414,19 @@ func (ToolResultPart) messagePart()      {}
 // provider-issued trace identifier (OpenAI reasoning item ids); providers
 // that address traces by id require it on round-trip, and providers
 // without item ids (Anthropic thinking blocks) leave it empty.
+//
+// Source is opaque provenance: the verification scope the driver that
+// produced the trace stamped on it, naming what can verify it (a deployment,
+// its model, and the credential profile that minted the payload — see the
+// driver's spec). A driver replays a trace only to a target whose own scope
+// matches, because a provider rejects a payload another account or model
+// cannot decrypt or verify; the comparison is the driver's, so the value is
+// never interpreted here.
 type ReasoningPart struct {
 	Text      string `json:"text,omitempty"`
 	Signature string `json:"signature,omitempty"`
 	ID        string `json:"id,omitempty"`
+	Source    string `json:"source,omitempty"`
 }
 
 func (ReasoningPart) Kind() PartKind { return PartReasoning }

--- a/docs/guides/inference.md
+++ b/docs/guides/inference.md
@@ -168,6 +168,55 @@ missing or approximate count would be worse than none. Hosts that own the
 conversation history can read the declared input window from
 `InspectModel` and enforce it where they already trim context.
 
+## Reasoning provenance
+
+Reasoning models return a trace — thinking text plus a signature or an
+encrypted payload — that providers expect back in later turns, and they verify
+it against the model and account that produced it. OpenAI validates a
+reasoning item's id and encrypted content; Anthropic validates a thinking
+block's signature. A payload minted elsewhere is rejected with a provider 400
+that no retry and no fallback repairs, because the trace stays in the
+conversation.
+
+Drivers therefore stamp every trace they produce with a **verification scope**
+(`message.ReasoningPart.Source`) and replay a stored trace only when the
+target's scope matches:
+
+| Trace | Compile outcome |
+| --- | --- |
+| stamped with this target's scope | replayed, subject to the surface's own rules (id + encrypted payload, signature, ...) |
+| stamped with another scope | dropped, with both scopes named in the compile report |
+| unstamped (stored before drivers stamped, or built by hand) | dropped as unattributable |
+
+The derived scope is the address that produced the trace — provider, model,
+and the credential profile when the reference names one:
+
+```
+openai/gpt-5.6-luna/default
+```
+
+Switching models inside one deployment therefore drops the previous model's
+traces. That is what Anthropic requires (a thinking signature is bound to the
+model), and it is what an endpoint that does not document cross-model
+verification cannot be trusted with. A deployment that *has* verified a set of
+models or credentials accept each other's traces declares one shared scope and
+every model of that deployment uses it:
+
+```yaml
+spec:
+  wire:
+    reasoning_scope: openai-prod-shared   # OpenAI and Anthropic drivers
+```
+
+Bytedance uses the same key at the top level of `spec` (`reasoning_scope`),
+because its spec is flat. Ark consumes no reasoning input today, so the stamp
+only keeps its traces attributable when a conversation moves elsewhere.
+
+**Upgrading:** a transcript stored before this rule carries unstamped traces,
+so those traces are dropped instead of replayed. The assistant text is
+untouched — only thinking continuity is lost — and the conversation no longer
+risks a provider rejection it cannot recover from.
+
 ## Routing
 
 Optional target selection is an `inference.Router` resource. It consumes

--- a/driver/anthropic/catalog.go
+++ b/driver/anthropic/catalog.go
@@ -22,9 +22,18 @@ type catalogEntry struct {
 	limits model.ModelLimits
 	// videoInput mirrors Spec.Wire.VideoInput: the endpoint accepts video
 	// blocks. Sending one still requires the model to declare video input.
-	videoInput  bool
-	deprecated  bool
-	replacement string
+	videoInput bool
+	// reasoningScopeDeclared mirrors Spec.Wire.ReasoningScope: the
+	// verification scope this deployment declares for its thinking traces.
+	reasoningScopeDeclared string
+	// reasoningScope is the scope of the opened model: the declared token, or
+	// the address that produced the trace. The opener fills it in (the
+	// credential profile is per reference), and both the compiler and the
+	// decode wrapper read it, which keeps the stamp and the comparison
+	// identical.
+	reasoningScope string
+	deprecated     bool
+	replacement    string
 }
 
 // validate enforces the generate family contract: Claude compilers only
@@ -214,6 +223,7 @@ func mergedCatalog(spec Spec) (map[string]catalogEntry, error) {
 	}
 	for name, entry := range models {
 		entry.videoInput = spec.Wire.VideoInput
+		entry.reasoningScopeDeclared = spec.Wire.ReasoningScope
 		models[name] = entry
 	}
 	for name, entry := range models {

--- a/driver/anthropic/doc.go
+++ b/driver/anthropic/doc.go
@@ -4,4 +4,10 @@
 // text, vision input, tool calling, reasoning with signatures, and
 // JSON-schema output. The provider owns its kernel (compiler, transports,
 // and decoders) and registers itself as an inference.Provider resource.
+//
+// Thinking blocks round-trip only for the model and account that signed them,
+// so every trace the decoder produces carries the deployment's verification
+// scope and the compiler replays a stored trace only when that scope matches;
+// `wire.reasoning_scope` declares a shared scope for a deployment whose
+// models or credentials are known to accept each other's traces.
 package anthropic

--- a/driver/anthropic/generate.go
+++ b/driver/anthropic/generate.go
@@ -327,7 +327,7 @@ func compileMessage(
 				),
 			)
 		case message.ReasoningPart:
-			compileReasoning(params, role, value, fields, ledger)
+			compileReasoning(params, role, value, entry, fields, ledger)
 		}
 	}
 }
@@ -337,16 +337,33 @@ func compileMessage(
 // round-trip, so unsigned reasoning cannot be forwarded honestly and is
 // dropped with the reason on the ledger; redacted traces (empty text)
 // round-trip through the opaque data slot.
+//
+// Provenance is checked first: Anthropic verifies a signature against the
+// model and account that produced it, so a trace another deployment stamped —
+// including an OpenAI encrypted payload, which also carries a signature — is
+// dropped instead of sent as a signature this endpoint would reject.
 func compileReasoning(
 	params *anthropicgo.MessageNewParams,
 	role anthropicgo.MessageParamRole,
 	part message.ReasoningPart,
+	entry catalogEntry,
 	fields func(message.PartKind) inference.FieldID,
 	ledger *inference.Ledger,
 ) {
 	field := fields(message.PartReasoning)
 	if role != anthropicgo.MessageParamRoleAssistant {
 		ledger.Reject(field, "reasoning parts belong to assistant context")
+		return
+	}
+	if part.Source == "" {
+		ledger.Drop(field, "reasoning trace carries no provenance")
+		return
+	}
+	if part.Source != entry.reasoningScope {
+		ledger.Drop(field, fmt.Sprintf(
+			"reasoning trace was verified by scope %q, not %q",
+			part.Source, entry.reasoningScope,
+		))
 		return
 	}
 	if part.Signature == "" {

--- a/driver/anthropic/generate_open.go
+++ b/driver/anthropic/generate_open.go
@@ -14,13 +14,21 @@ func openGenerate(
 	cls *clients,
 	entry catalogEntry,
 	id model.ModelID,
-	_ string,
+	profile string,
 ) (inference.GenerateOperations, error) {
+	// One scope for the whole attempt: the decoder stamps it on the thinking
+	// traces this model produces, and the compiler requires it before
+	// replaying a stored one. Anthropic verifies a thinking signature per
+	// model, so the derived default refuses to cross a model or an account
+	// unless the deployment declared a shared scope.
+	scope := inference.ReasoningScope(
+		entry.reasoningScopeDeclared, id.Provider, id.Name, profile)
+	entry.reasoningScope = scope
 	return inference.BindGenerateOperations(
 		compileGenerate(id.Name, entry),
 		transportGenerate(cls.api),
-		decodeGenerate,
+		inference.WithReasoningSource(decodeGenerate, scope),
 		transportGenerateStream(cls.api),
-		decodeGenerateStream,
+		inference.WithReasoningDeltaSource(decodeGenerateStream, scope),
 	)
 }

--- a/driver/anthropic/reasoning_provenance_test.go
+++ b/driver/anthropic/reasoning_provenance_test.go
@@ -1,0 +1,209 @@
+package anthropic
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/GizClaw/flowcraft/core/inference"
+	"github.com/GizClaw/flowcraft/core/inference/model"
+	"github.com/GizClaw/flowcraft/core/message"
+)
+
+// scopedEntry returns the entry the opener hands to the compiler: the catalog
+// entry with the verification scope of one addressed model filled in.
+func scopedEntry(entry catalogEntry, provider, name, profile string) catalogEntry {
+	entry.reasoningScope = inference.ReasoningScope(
+		entry.reasoningScopeDeclared, provider, name, profile)
+	return entry
+}
+
+// decisionFor returns the report entry for one field.
+func decisionFor(
+	decisions []inference.Decision,
+	field inference.FieldID,
+) (inference.Decision, bool) {
+	for _, decision := range decisions {
+		if decision.Field == field {
+			return decision, true
+		}
+	}
+	return inference.Decision{}, false
+}
+
+// reasoningHistoryRequest puts one reasoning trace in assistant history.
+func reasoningHistoryRequest(trace message.ReasoningPart) inference.GenerateRequest {
+	request := conformanceTextRequest()
+	request.Context = []message.Message{{
+		Role: message.RoleAssistant,
+		Content: message.Content{Parts: []message.Part{
+			trace,
+			message.TextPart{Text: "answer"},
+		}},
+	}}
+	return request
+}
+
+// TestForeignReasoningSignatureIsDroppedNotSent covers the cross-provider
+// failure #527 reports: an OpenAI reasoning item carries a signature slot too,
+// so a shape-only gate forwards the encrypted payload as an Anthropic
+// thinking signature and the endpoint rejects the whole request with a 400
+// that no retry can repair. Provenance turns that into a reported drop.
+func TestForeignReasoningSignatureIsDroppedNotSent(t *testing.T) {
+	entry := scopedEntry(
+		catalog["claude-fable-5"], "minimax", "minimax-m3", "default")
+	compiled, err := compileGenerate("minimax-m3", entry)(
+		context.Background(),
+		model.ModelRef{
+			ID:      model.ModelID{Provider: "minimax", Name: "minimax-m3"},
+			Profile: "default",
+		},
+		reasoningHistoryRequest(message.ReasoningPart{
+			Text:      "openai summary",
+			Signature: "enc-openai",
+			ID:        "rs_openai",
+			Source:    "openai/gpt-5.6-luna/default",
+		}),
+		inference.GenerateExecutionUnary,
+	)
+	if err != nil {
+		t.Fatalf("compileGenerate: %v", err)
+	}
+	decision, ok := decisionFor(
+		compiled.Report.Decisions, inference.FieldGenerateContextReasoning)
+	if !ok {
+		t.Fatalf("no reasoning decision: %+v", compiled.Report.Decisions)
+	}
+	if decision.Disposition != inference.Dropped {
+		t.Fatalf("decision = %+v, want Dropped", decision)
+	}
+	if !strings.Contains(decision.Reason, "openai/gpt-5.6-luna/default") {
+		t.Fatalf("reason = %q, want the producing scope named", decision.Reason)
+	}
+	for _, block := range compiled.Wire.Messages {
+		for _, content := range block.Content {
+			if content.OfThinking != nil || content.OfRedactedThinking != nil {
+				t.Fatalf("foreign reasoning reached the request: %+v", content)
+			}
+		}
+	}
+}
+
+// TestOwnReasoningSignatureIsSent pins the other side: a trace this
+// deployment produced still round-trips as a thinking block.
+func TestOwnReasoningSignatureIsSent(t *testing.T) {
+	entry := scopedEntry(
+		catalog["claude-fable-5"], "anthropic", "claude-fable-5", "default")
+	compiled, err := compileGenerate("claude-fable-5", entry)(
+		context.Background(),
+		model.ModelRef{
+			ID:      model.ModelID{Provider: "anthropic", Name: "claude-fable-5"},
+			Profile: "default",
+		},
+		reasoningHistoryRequest(message.ReasoningPart{
+			Text:      "own thinking",
+			Signature: "sig-own",
+			Source:    "anthropic/claude-fable-5/default",
+		}),
+		inference.GenerateExecutionUnary,
+	)
+	if err != nil {
+		t.Fatalf("compileGenerate: %v", err)
+	}
+	decision, ok := decisionFor(
+		compiled.Report.Decisions, inference.FieldGenerateContextReasoning)
+	if !ok || decision.Disposition != inference.Native {
+		t.Fatalf("decision = %+v, want Native", decision)
+	}
+}
+
+// TestReasoningWithoutProvenanceIsDropped covers transcripts stored before
+// drivers stamped their traces.
+func TestReasoningWithoutProvenanceIsDropped(t *testing.T) {
+	entry := scopedEntry(
+		catalog["claude-fable-5"], "anthropic", "claude-fable-5", "default")
+	compiled, err := compileGenerate("claude-fable-5", entry)(
+		context.Background(),
+		model.ModelRef{
+			ID:      model.ModelID{Provider: "anthropic", Name: "claude-fable-5"},
+			Profile: "default",
+		},
+		reasoningHistoryRequest(message.ReasoningPart{
+			Text:      "legacy thinking",
+			Signature: "sig-legacy",
+		}),
+		inference.GenerateExecutionUnary,
+	)
+	if err != nil {
+		t.Fatalf("compileGenerate: %v", err)
+	}
+	decision, ok := decisionFor(
+		compiled.Report.Decisions, inference.FieldGenerateContextReasoning)
+	if !ok || decision.Disposition != inference.Dropped ||
+		!strings.Contains(decision.Reason, "no provenance") {
+		t.Fatalf("decision = %+v, want a provenance drop", decision)
+	}
+}
+
+// TestDeclaredReasoningScopeSharesTraces pins the escape hatch for a
+// compatible endpoint that verifies the same signatures across models.
+func TestDeclaredReasoningScopeSharesTraces(t *testing.T) {
+	spec, err := decodeSpec(context.Background(), []byte(
+		`{"wire":{"reasoning_scope":"gateway-shared"}}`,
+	))
+	if err != nil {
+		t.Fatalf("decodeSpec: %v", err)
+	}
+	models, err := mergedCatalog(spec)
+	if err != nil {
+		t.Fatalf("mergedCatalog: %v", err)
+	}
+	entry := scopedEntry(models["claude-fable-5"], "gw", "claude-other", "default")
+	if entry.reasoningScope != "gateway-shared" {
+		t.Fatalf("scope = %q, want the declared token", entry.reasoningScope)
+	}
+	compiled, err := compileGenerate("claude-other", entry)(
+		context.Background(),
+		model.ModelRef{
+			ID:      model.ModelID{Provider: "gw", Name: "claude-other"},
+			Profile: "default",
+		},
+		reasoningHistoryRequest(message.ReasoningPart{
+			Text:      "shared thinking",
+			Signature: "sig-shared",
+			Source:    "gateway-shared",
+		}),
+		inference.GenerateExecutionUnary,
+	)
+	if err != nil {
+		t.Fatalf("compileGenerate: %v", err)
+	}
+	decision, ok := decisionFor(
+		compiled.Report.Decisions, inference.FieldGenerateContextReasoning)
+	if !ok || decision.Disposition != inference.Native {
+		t.Fatalf("decision = %+v, want Native under the declared scope", decision)
+	}
+}
+
+// TestReasoningScopeSpecValidation pins the declared token's shape rules.
+func TestReasoningScopeSpecValidation(t *testing.T) {
+	for _, tc := range []struct {
+		raw     string
+		wantErr bool
+	}{
+		{raw: `{}`},
+		{raw: `{"wire":{"reasoning_scope":"prod-eu"}}`},
+		{raw: `{"wire":{"reasoning_scope":" prod"}}`, wantErr: true},
+		{raw: `{"wire":{"reasoning_scope":"prod\neu"}}`, wantErr: true},
+		{raw: `{"wire":{"reasoning_scope":"` + strings.Repeat("x", 129) + `"}}`,
+			wantErr: true},
+	} {
+		_, err := decodeSpec(context.Background(), []byte(tc.raw))
+		if tc.wantErr && err == nil {
+			t.Errorf("decodeSpec(%s) succeeded, want an error", tc.raw)
+		}
+		if !tc.wantErr && err != nil {
+			t.Errorf("decodeSpec(%s): %v", tc.raw, err)
+		}
+	}
+}

--- a/driver/anthropic/spec.go
+++ b/driver/anthropic/spec.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"unicode"
 
 	"github.com/GizClaw/flowcraft/core/inference/model"
 	"github.com/GizClaw/flowcraft/core/resource"
@@ -43,6 +44,14 @@ type WireSpec struct {
 	// VideoInput allows video content blocks, a compatible-endpoint
 	// extension: Anthropic's own schema has no video block.
 	VideoInput bool `json:"video_input,omitempty"`
+	// ReasoningScope declares the verification scope this deployment's
+	// thinking traces belong to. It replaces the derived scope — provider,
+	// model, and credential profile — so an operator who has verified that
+	// several models or credentials accept each other's signed traces says so
+	// once. Unset keeps the conservative derived scope, which never replays a
+	// trace across a model or an account; Anthropic verifies thinking
+	// signatures per model, so that default is what the API requires.
+	ReasoningScope string `json:"reasoning_scope,omitempty"`
 }
 
 // catalogMode selects which model namespace one provider instance serves.
@@ -98,6 +107,9 @@ func (s Spec) Validate() error {
 	if s.HTTPRetries != nil && *s.HTTPRetries < 0 {
 		return fmt.Errorf("anthropic: http_retries must not be negative")
 	}
+	if err := validateReasoningScope(s.Wire.ReasoningScope); err != nil {
+		return err
+	}
 	seen := make(map[string]bool, len(s.Models))
 	for _, model := range s.Models {
 		if model.Name == "" || strings.ContainsAny(model.Name, " /") {
@@ -139,6 +151,36 @@ func (s Spec) Validate() error {
 type ProfileSpec struct{}
 
 func (ProfileSpec) Validate() error { return nil }
+
+// maxReasoningScopeLen bounds the declared scope token: it lands in a
+// compile-report reason, so it stays short and printable.
+const maxReasoningScopeLen = 128
+
+// validateReasoningScope checks the declared verification scope. The token is
+// opaque to the driver, but the comparison is exact, so surrounding
+// whitespace and control characters are rejected rather than normalized.
+func validateReasoningScope(scope string) error {
+	if scope == "" {
+		return nil
+	}
+	if strings.TrimSpace(scope) != scope {
+		return fmt.Errorf(
+			"anthropic: wire.reasoning_scope must not have surrounding whitespace")
+	}
+	if len(scope) > maxReasoningScopeLen {
+		return fmt.Errorf(
+			"anthropic: wire.reasoning_scope is %d bytes, at most %d are allowed",
+			len(scope), maxReasoningScopeLen,
+		)
+	}
+	for _, char := range scope {
+		if unicode.IsControl(char) {
+			return fmt.Errorf(
+				"anthropic: wire.reasoning_scope must not contain control characters")
+		}
+	}
+	return nil
+}
 
 func decodeSpec(ctx context.Context, raw []byte) (Spec, error) {
 	spec, err := resource.DecodeTyped[Spec](ctx, raw)

--- a/driver/bytedance/catalog.go
+++ b/driver/bytedance/catalog.go
@@ -40,8 +40,15 @@ type catalogEntry struct {
 	// video: Seedance task-parameter support matrix (see videoParams).
 	video videoParams
 	// lifecycle: deprecated models stay routable but announce a replacement.
-	deprecated  bool
-	replacement string
+	deprecated bool
+	// reasoningScopeDeclared mirrors Spec.ReasoningScope: the verification
+	// scope this deployment declares for its traces.
+	reasoningScopeDeclared string
+	// reasoningScope is the scope of the opened model: the declared token, or
+	// the address that produced the trace. The opener fills it in; today only
+	// the decode side reads it, because ark consumes no reasoning input.
+	reasoningScope string
+	replacement    string
 }
 
 // videoParams is the Seedance task-parameter support matrix for one video
@@ -517,6 +524,10 @@ func mergedCatalog(spec Spec) (map[string]catalogEntry, error) {
 			entry.limits.MaxOutputTokens = &value
 		}
 		merged[declared.Name] = entry
+	}
+	for name, entry := range merged {
+		entry.reasoningScopeDeclared = spec.ReasoningScope
+		merged[name] = entry
 	}
 	for name, entry := range merged {
 		if err := entry.validate(); err != nil {

--- a/driver/bytedance/doc.go
+++ b/driver/bytedance/doc.go
@@ -9,7 +9,10 @@
 //     tool calling, reasoning effort, JSON/JSON-schema response formats.
 //     Reasoning items decode into canonical reasoning parts (summary text
 //     plus item id); ark signs nothing and consumes no reasoning input, so
-//     traces never round-trip and context compiles them as Dropped.
+//     traces never round-trip and context compiles them as Dropped. They do
+//     carry the deployment's verification scope (`spec.reasoning_scope`, or
+//     the derived provider/model/profile), so a conversation that moves to a
+//     target which replays traces can tell where one came from.
 //     GenerateOptions.WebSearch attaches Ark's hosted web_search tool;
 //     web_search_call items and url_citation annotations surface on
 //     GenerateResponse.ProviderOutputs (never inside Message).

--- a/driver/bytedance/generate_open.go
+++ b/driver/bytedance/generate_open.go
@@ -19,11 +19,18 @@ func openGenerate(
 	if err != nil {
 		return inference.GenerateOperations{}, err
 	}
+	// Ark produces reasoning traces but consumes none, so the stamp keeps
+	// them attributable when a conversation later moves to a target that
+	// would replay one. The scope is the deployment's declared token, or the
+	// address that produced the trace.
+	scope := inference.ReasoningScope(
+		entry.reasoningScopeDeclared, id.Provider, id.Name, profile)
+	entry.reasoningScope = scope
 	return inference.BindGenerateOperations(
 		compileGenerate(cls.endpoint(id.Name), entry),
 		transportGenerate(ark, cls.arkRequestOptions),
-		decodeGenerate,
+		inference.WithReasoningSource(decodeGenerate, scope),
 		transportGenerateStream(ark, cls.arkRequestOptions),
-		decodeGenerateStream,
+		inference.WithReasoningDeltaSource(decodeGenerateStream, scope),
 	)
 }

--- a/driver/bytedance/reasoning_provenance_test.go
+++ b/driver/bytedance/reasoning_provenance_test.go
@@ -1,0 +1,65 @@
+package bytedance
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/GizClaw/flowcraft/core/inference"
+	"github.com/GizClaw/flowcraft/core/message"
+)
+
+// TestDecodeGenerateStampsReasoningScope pins the decode half for this
+// driver: ark emits reasoning traces, and every one leaves the decoder
+// stamped with the verification scope of the model that produced it, so a
+// conversation that later moves to a target which replays traces can tell
+// where the trace came from instead of treating it as its own.
+func TestDecodeGenerateStampsReasoningScope(t *testing.T) {
+	scope := inference.ReasoningScope(
+		"", "doubao", "doubao-seed-2-0-lite", "default")
+	decode := inference.WithReasoningSource(decodeGenerate, scope)
+	response, err := decode(context.Background(), generateRaw{
+		id:     "resp_1",
+		finish: inference.FinishCompleted,
+		reasonings: []rawReasoning{
+			{id: "rs_1", text: "thinking"},
+		},
+		texts: []string{"answer"},
+	})
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	parts := response.Message.Content.Parts
+	if len(parts) != 2 {
+		t.Fatalf("parts = %+v", parts)
+	}
+	reasoning, ok := parts[0].(message.ReasoningPart)
+	if !ok || reasoning.Text != "thinking" || reasoning.ID != "rs_1" {
+		t.Fatalf("reasoning part = %#v", parts[0])
+	}
+	if reasoning.Source != scope {
+		t.Fatalf("reasoning source = %q, want %q", reasoning.Source, scope)
+	}
+}
+
+// TestReasoningScopeSpecValidation pins the declared token's shape rules.
+func TestReasoningScopeSpecValidation(t *testing.T) {
+	for _, tc := range []struct {
+		raw     string
+		wantErr bool
+	}{
+		{raw: `{}`},
+		{raw: `{"reasoning_scope":"prod-eu"}`},
+		{raw: `{"reasoning_scope":" prod"}`, wantErr: true},
+		{raw: `{"reasoning_scope":"prod\neu"}`, wantErr: true},
+		{raw: `{"reasoning_scope":"` + strings.Repeat("x", 129) + `"}`, wantErr: true},
+	} {
+		_, err := decodeSpec(context.Background(), []byte(tc.raw))
+		if tc.wantErr && err == nil {
+			t.Errorf("decodeSpec(%s) succeeded, want an error", tc.raw)
+		}
+		if !tc.wantErr && err != nil {
+			t.Errorf("decodeSpec(%s): %v", tc.raw, err)
+		}
+	}
+}

--- a/driver/bytedance/spec.go
+++ b/driver/bytedance/spec.go
@@ -6,6 +6,7 @@ import (
 	"regexp"
 	"strings"
 	"time"
+	"unicode"
 
 	"github.com/GizClaw/flowcraft/core/inference/model"
 	"github.com/GizClaw/flowcraft/core/resource"
@@ -46,6 +47,13 @@ type Spec struct {
 	// so it lives in the deployment Spec, not in a per-request extension.
 	// Unset defaults to defaultVideoPollInterval.
 	VideoPollIntervalMillis *resource.Int64 `json:"video_poll_interval_millis,omitempty"`
+	// ReasoningScope declares the verification scope this deployment's
+	// reasoning traces belong to. Ark emits traces but consumes none today, so
+	// the scope is what makes a trace attributable when a conversation moves
+	// to a target that would replay one: it replaces the derived scope —
+	// provider, model, and credential profile — and unset keeps that
+	// conservative default.
+	ReasoningScope string `json:"reasoning_scope,omitempty"`
 	// Models declares additional models beyond the built-in catalog or
 	// overrides catalog entries by name.
 	Models []ModelSpec `json:"models,omitempty"`
@@ -115,6 +123,9 @@ func (s Spec) Validate() error {
 	}
 	if s.HTTPRetries != nil && *s.HTTPRetries < 0 {
 		return fmt.Errorf("http_retries must not be negative")
+	}
+	if err := validateReasoningScope(s.ReasoningScope); err != nil {
+		return err
 	}
 	for name, value := range map[string]string{
 		"base_url": s.BaseURL,
@@ -188,4 +199,34 @@ func decodeProfileSpec(ctx context.Context, raw []byte) (ProfileSpec, error) {
 		return ProfileSpec{}, fmt.Errorf("bytedance profile spec: %w", err)
 	}
 	return spec, nil
+}
+
+// maxReasoningScopeLen bounds the declared scope token: it lands in a
+// compile-report reason, so it stays short and printable.
+const maxReasoningScopeLen = 128
+
+// validateReasoningScope checks the declared verification scope. The token is
+// opaque to the driver, but the comparison is exact, so surrounding
+// whitespace and control characters are rejected rather than normalized.
+func validateReasoningScope(scope string) error {
+	if scope == "" {
+		return nil
+	}
+	if strings.TrimSpace(scope) != scope {
+		return fmt.Errorf(
+			"reasoning_scope must not have surrounding whitespace")
+	}
+	if len(scope) > maxReasoningScopeLen {
+		return fmt.Errorf(
+			"reasoning_scope is %d bytes, at most %d are allowed",
+			len(scope), maxReasoningScopeLen,
+		)
+	}
+	for _, char := range scope {
+		if unicode.IsControl(char) {
+			return fmt.Errorf(
+				"reasoning_scope must not contain control characters")
+		}
+	}
+	return nil
 }

--- a/driver/openai/catalog.go
+++ b/driver/openai/catalog.go
@@ -64,6 +64,13 @@ type catalogEntry struct {
 	// entry in one deployment. mergedCatalog stamps it so compilers read the
 	// deployment facts here instead of reaching back into the Spec.
 	dialect dialect
+	// reasoningScope is the verification scope of the model this entry was
+	// opened for: the deployment's declared token when it has one, otherwise
+	// the address that produced the trace. The opener fills it in (the
+	// profile is per reference, so the scope cannot be stamped at merge
+	// time); the compiler and the decode wrapper both read it, which is what
+	// keeps the stamp and the comparison identical.
+	reasoningScope string
 }
 
 // validate enforces the family contract: the compiler bound by kind can only

--- a/driver/openai/dialect.go
+++ b/driver/openai/dialect.go
@@ -103,6 +103,7 @@ type dialect struct {
 	azureDeployment         bool
 	videoInput              bool
 	extraBody               []bodyField
+	reasoningScopeDeclared  string
 	requestMetadataEnvelope string
 	// chatStreamIncludeUsage / Obfuscation carry the explicit chat streaming
 	// policy; nil keeps the OpenAI default.
@@ -122,6 +123,7 @@ func (s Spec) dialect() dialect {
 		azureDeployment:              s.routing() == routingAzureDeployment,
 		videoInput:                   s.Wire.VideoInput,
 		extraBody:                    sortedBodyFields(s.Wire.ExtraBody),
+		reasoningScopeDeclared:       s.Wire.ReasoningScope,
 		requestMetadataEnvelope:      s.requestMetadataEnvelope(),
 		chatStreamIncludeUsage:       s.chatStreamIncludeUsage(),
 		chatStreamIncludeObfuscation: s.chatStreamIncludeObfuscation(),

--- a/driver/openai/doc.go
+++ b/driver/openai/doc.go
@@ -26,6 +26,12 @@
 //     encrypted payload in the Signature slot, item id) and round-trip
 //     through context when id and payload survive; the request always
 //     includes reasoning.encrypted_content so round-trips stay possible.
+//     Every trace the decoder produces is stamped with this deployment's
+//     verification scope, and the compiler replays a stored trace only when
+//     that scope matches: an item another model or account minted cannot be
+//     verified here, so sending it is a provider error no retry repairs.
+//     `wire.reasoning_scope` declares a shared scope when the operator has
+//     verified that several models or credentials accept each other's.
 //     GenerateOptions.WebSearch attaches OpenAI's hosted web_search tool;
 //     web_search_call items and url_citation annotations surface on
 //     GenerateResponse.ProviderOutputs (never inside Message).

--- a/driver/openai/generate.go
+++ b/driver/openai/generate.go
@@ -510,6 +510,12 @@ func compileMessage(
 // compileReasoning lowers an assistant reasoning trace into the round-trip
 // shape the surface speaks. A trace the surface or its channel cannot express
 // drops with the reason on the ledger, never silently.
+//
+// Provenance comes first among the shape checks: a provider rejects a payload
+// another model or account cannot decrypt, and no retry or fallback repairs
+// that while the trace stays in the conversation. A trace this deployment did
+// not produce — or one stored before drivers stamped their traces — is
+// dropped instead of sent.
 func compileReasoning(
 	sink generateSink,
 	role string,
@@ -525,6 +531,17 @@ func compileReasoning(
 	}
 	if entry.capabilities.Reasoning.Kind == model.ReasoningNone {
 		ledger.Drop(field, "model has no reasoning channel")
+		return
+	}
+	if part.Source == "" {
+		ledger.Drop(field, "reasoning trace carries no provenance")
+		return
+	}
+	if part.Source != entry.reasoningScope {
+		ledger.Drop(field, fmt.Sprintf(
+			"reasoning trace was verified by scope %q, not %q",
+			part.Source, entry.reasoningScope,
+		))
 		return
 	}
 	if entry.dialect.api == apiChat {

--- a/driver/openai/generate_open.go
+++ b/driver/openai/generate_open.go
@@ -13,22 +13,29 @@ func openGenerate(
 	cls *clients,
 	entry catalogEntry,
 	id model.ModelID,
-	_ string,
+	profile string,
 ) (inference.GenerateOperations, error) {
+	// One scope for the whole attempt: the decoder stamps it on the traces
+	// this model produces, and the compiler requires it before replaying one,
+	// so a trace never crosses a deployment, a model, or an account unless
+	// the deployment declared a shared scope.
+	scope := inference.ReasoningScope(
+		entry.dialect.reasoningScopeDeclared, id.Provider, id.Name, profile)
+	entry.reasoningScope = scope
 	if entry.dialect.api == apiChat {
 		return inference.BindGenerateOperations(
 			compileChat(id.Name, entry),
 			transportChatGenerate(cls.api),
-			decodeGenerate,
+			inference.WithReasoningSource(decodeGenerate, scope),
 			transportChatGenerateStream(cls.api),
-			decodeChatGenerateStream,
+			inference.WithReasoningDeltaSource(decodeChatGenerateStream, scope),
 		)
 	}
 	return inference.BindGenerateOperations(
 		compileResponses(id.Name, entry),
 		transportGenerate(cls.api),
-		decodeGenerate,
+		inference.WithReasoningSource(decodeGenerate, scope),
 		transportGenerateStream(cls.api),
-		decodeGenerateStream,
+		inference.WithReasoningDeltaSource(decodeGenerateStream, scope),
 	)
 }

--- a/driver/openai/generate_openai_operations_test.go
+++ b/driver/openai/generate_openai_operations_test.go
@@ -1102,6 +1102,14 @@ func TestGenerateUnaryReasoningItem(t *testing.T) {
 		reasoning.ID != "rs_1" {
 		t.Fatalf("reasoning part = %#v", parts[0])
 	}
+	// The decoder stamps what this deployment produced: the scope names the
+	// provider, model, and credential profile the trace belongs to, and it is
+	// what the compiler requires before replaying the part.
+	if want := inference.ReasoningScope(
+		"", providerID, "gpt-5.6-sol", "default",
+	); reasoning.Source != want {
+		t.Fatalf("reasoning source = %q, want %q", reasoning.Source, want)
+	}
 	if text, ok := parts[1].(message.TextPart); !ok || text.Text != "answer" {
 		t.Fatalf("text part = %#v", parts[1])
 	}

--- a/driver/openai/generate_openai_test.go
+++ b/driver/openai/generate_openai_test.go
@@ -98,6 +98,22 @@ func openaiModel(name string) model.ModelRef {
 	}
 }
 
+// reasoningScopeFor is the verification scope the opener derives for one model
+// of this driver addressed with the default profile. Tests that build a
+// catalog entry directly (instead of going through openGenerate) stamp their
+// traces with it, because the compiler requires the scope an opened model
+// carries.
+func reasoningScopeFor(name string) string {
+	return inference.ReasoningScope("", providerID, name, "default")
+}
+
+// scopedEntry returns the entry an opener would hand to the compiler: the
+// same catalog entry with the verification scope filled in.
+func scopedEntry(entry catalogEntry, name string) catalogEntry {
+	entry.reasoningScope = reasoningScopeFor(name)
+	return entry
+}
+
 func simpleTextRequest(text string) inference.GenerateRequest {
 	return inference.GenerateRequest{
 		Input: inference.GenerateInput{
@@ -389,7 +405,9 @@ func compileTextRequest(
 	request inference.GenerateRequest,
 ) *responsesRequest {
 	t.Helper()
-	compiled, err := compileResponses("gpt-5.6-sol", catalog["gpt-5.6-sol"])(
+	compiled, err := compileResponses(
+		"gpt-5.6-sol", scopedEntry(catalog["gpt-5.6-sol"], "gpt-5.6-sol"),
+	)(
 		context.Background(),
 		openaiModel("gpt-5.6-sol"),
 		request,
@@ -716,11 +734,14 @@ func TestCompileResponsesReasoningItem(t *testing.T) {
 				Text:      "joined summary",
 				Signature: "enc-1",
 				ID:        "rs_1",
+				Source:    reasoningScopeFor("gpt-5.6-sol"),
 			},
 			message.TextPart{Text: "answer"},
 		}},
 	}}
-	compiled, err := compileResponses("gpt-5.6-sol", catalog["gpt-5.6-sol"])(
+	compiled, err := compileResponses(
+		"gpt-5.6-sol", scopedEntry(catalog["gpt-5.6-sol"], "gpt-5.6-sol"),
+	)(
 		context.Background(),
 		openaiModel("gpt-5.6-sol"),
 		request,
@@ -767,11 +788,17 @@ func TestCompileResponsesReasoningItemWithoutSummary(t *testing.T) {
 	request.Context = []message.Message{{
 		Role: message.RoleAssistant,
 		Content: message.Content{Parts: []message.Part{
-			message.ReasoningPart{Signature: "enc-1", ID: "rs_1"},
+			message.ReasoningPart{
+				Signature: "enc-1",
+				ID:        "rs_1",
+				Source:    reasoningScopeFor("gpt-5.6-sol"),
+			},
 			message.TextPart{Text: "answer"},
 		}},
 	}}
-	compiled, err := compileResponses("gpt-5.6-sol", catalog["gpt-5.6-sol"])(
+	compiled, err := compileResponses(
+		"gpt-5.6-sol", scopedEntry(catalog["gpt-5.6-sol"], "gpt-5.6-sol"),
+	)(
 		context.Background(),
 		openaiModel("gpt-5.6-sol"),
 		request,
@@ -828,14 +855,20 @@ func assertEmptySummaryField(t *testing.T, reasoning *responses.ResponseReasonin
 
 func TestCompileReasoningDispositions(t *testing.T) {
 	model := openaiModel("gpt-5.6-sol")
-	compile := compileResponses("gpt-5.6-sol", catalog["gpt-5.6-sol"])
+	compile := compileResponses(
+		"gpt-5.6-sol", scopedEntry(catalog["gpt-5.6-sol"], "gpt-5.6-sol"),
+	)
 
 	t.Run("reasoning without id drops with reason", func(t *testing.T) {
 		request := simpleTextRequest("hi")
 		request.Context = []message.Message{{
 			Role: message.RoleAssistant,
 			Content: message.Content{Parts: []message.Part{
-				message.ReasoningPart{Text: "trace", Signature: "enc"},
+				message.ReasoningPart{
+					Text:      "trace",
+					Signature: "enc",
+					Source:    reasoningScopeFor("gpt-5.6-sol"),
+				},
 				message.TextPart{Text: "answer"},
 			}},
 		}}

--- a/driver/openai/reasoning_provenance_test.go
+++ b/driver/openai/reasoning_provenance_test.go
@@ -1,0 +1,207 @@
+package openai
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/GizClaw/flowcraft/core/inference"
+	"github.com/GizClaw/flowcraft/core/message"
+)
+
+// reasoningContextRequest is a request whose assistant history carries one
+// reasoning trace.
+func reasoningContextRequest(part message.ReasoningPart) inference.GenerateRequest {
+	request := simpleTextRequest("current")
+	request.Context = []message.Message{{
+		Role: message.RoleAssistant,
+		Content: message.Content{Parts: []message.Part{
+			part,
+			message.TextPart{Text: "answer"},
+		}},
+	}}
+	return request
+}
+
+// reasoningDecision returns the context-reasoning decision of one compile.
+func reasoningDecision(t *testing.T, report inference.CompileReport) inference.Decision {
+	t.Helper()
+	decision, ok := decisionFor(
+		report.Decisions, inference.FieldGenerateContextReasoning)
+	if !ok {
+		t.Fatalf("no decision for context reasoning: %+v", report.Decisions)
+	}
+	return decision
+}
+
+// TestReasoningFromAnotherScopeIsDroppedNotSent covers the failure this rule
+// exists for: a trace another model, account, or deployment produced passes
+// the shape check (it has an item id and an encrypted payload) but the target
+// cannot verify it, so sending it is a provider error no retry can repair. It
+// is dropped instead.
+func TestReasoningFromAnotherScopeIsDroppedNotSent(t *testing.T) {
+	entry := scopedEntry(catalog["gpt-5.6-sol"], "gpt-5.6-sol")
+	compiled, err := compileResponses("gpt-5.6-sol", entry)(
+		context.Background(),
+		openaiModel("gpt-5.6-sol"),
+		reasoningContextRequest(message.ReasoningPart{
+			Text:      "their thinking",
+			Signature: "enc-foreign",
+			ID:        "rs_foreign",
+			Source:    "openai/gpt-5.6-terra/default",
+		}),
+		inference.GenerateExecutionUnary,
+	)
+	if err != nil {
+		t.Fatalf("compileResponses: %v", err)
+	}
+	decision := reasoningDecision(t, compiled.Report)
+	if decision.Disposition != inference.Dropped {
+		t.Fatalf("decision = %+v, want Dropped", decision)
+	}
+	if !strings.Contains(decision.Reason, "openai/gpt-5.6-terra/default") ||
+		!strings.Contains(decision.Reason, "openai/gpt-5.6-sol/default") {
+		t.Fatalf("reason = %q, want both scopes named", decision.Reason)
+	}
+	assertNoReasoningItem(t, compiled)
+}
+
+// TestReasoningWithoutProvenanceIsDropped covers a transcript stored before
+// drivers stamped their traces: unattributable reasoning is not replayed,
+// because nothing says the target can verify it.
+func TestReasoningWithoutProvenanceIsDropped(t *testing.T) {
+	entry := scopedEntry(catalog["gpt-5.6-sol"], "gpt-5.6-sol")
+	compiled, err := compileResponses("gpt-5.6-sol", entry)(
+		context.Background(),
+		openaiModel("gpt-5.6-sol"),
+		reasoningContextRequest(message.ReasoningPart{
+			Text:      "legacy thinking",
+			Signature: "enc-legacy",
+			ID:        "rs_legacy",
+		}),
+		inference.GenerateExecutionUnary,
+	)
+	if err != nil {
+		t.Fatalf("compileResponses: %v", err)
+	}
+	decision := reasoningDecision(t, compiled.Report)
+	if decision.Disposition != inference.Dropped ||
+		!strings.Contains(decision.Reason, "no provenance") {
+		t.Fatalf("decision = %+v, want a provenance drop", decision)
+	}
+	assertNoReasoningItem(t, compiled)
+}
+
+// TestDeclaredReasoningScopeSharesTraces pins the escape hatch: a deployment
+// that declares a scope claims its models and credentials verify each other's
+// traces, so a trace stamped with that token replays even though its derived
+// address would differ.
+func TestDeclaredReasoningScopeSharesTraces(t *testing.T) {
+	spec, err := decodeSpec(context.Background(), []byte(
+		`{"wire":{"reasoning_scope":"openai-prod-shared"}}`,
+	))
+	if err != nil {
+		t.Fatalf("decodeSpec: %v", err)
+	}
+	entry := catalog["gpt-5.6-sol"]
+	entry.dialect = spec.dialect()
+	entry.reasoningScope = inference.ReasoningScope(
+		entry.dialect.reasoningScopeDeclared,
+		"openai", "gpt-5.6-sol", "default",
+	)
+	if entry.reasoningScope != "openai-prod-shared" {
+		t.Fatalf("scope = %q, want the declared token", entry.reasoningScope)
+	}
+
+	compiled, err := compileResponses("gpt-5.6-sol", entry)(
+		context.Background(),
+		openaiModel("gpt-5.6-sol"),
+		reasoningContextRequest(message.ReasoningPart{
+			Text:      "shared thinking",
+			Signature: "enc-shared",
+			ID:        "rs_shared",
+			Source:    "openai-prod-shared",
+		}),
+		inference.GenerateExecutionUnary,
+	)
+	if err != nil {
+		t.Fatalf("compileResponses: %v", err)
+	}
+	decision := reasoningDecision(t, compiled.Report)
+	if decision.Disposition != inference.Native {
+		t.Fatalf("decision = %+v, want Native", decision)
+	}
+	items := compiled.Wire.params.Input.OfInputItemList
+	if len(items) == 0 || items[0].OfReasoning == nil {
+		t.Fatalf("items = %+v, want the reasoning item first", items)
+	}
+}
+
+// TestReasoningModelSwitchDropsTraces pins the derived default's consequence:
+// switching models inside one deployment changes the scope, so the previous
+// model's traces are dropped rather than replayed — which is what the
+// providers that bind a trace to a model require, and what we cannot verify
+// for the ones that do not document it.
+func TestReasoningModelSwitchDropsTraces(t *testing.T) {
+	trace := message.ReasoningPart{
+		Text:      "luna thinking",
+		Signature: "enc-luna",
+		ID:        "rs_luna",
+		Source:    reasoningScopeFor("gpt-5.6-luna"),
+	}
+	entry := scopedEntry(catalog["gpt-5.6-terra"], "gpt-5.6-terra")
+	compiled, err := compileResponses("gpt-5.6-terra", entry)(
+		context.Background(),
+		openaiModel("gpt-5.6-terra"),
+		reasoningContextRequest(trace),
+		inference.GenerateExecutionUnary,
+	)
+	if err != nil {
+		t.Fatalf("compileResponses: %v", err)
+	}
+	if decision := reasoningDecision(t, compiled.Report); decision.Disposition != inference.Dropped {
+		t.Fatalf("decision = %+v, want Dropped across models", decision)
+	}
+	assertNoReasoningItem(t, compiled)
+}
+
+// TestReasoningScopeSpecValidation pins the declared token's shape rules.
+func TestReasoningScopeSpecValidation(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		raw     string
+		wantErr bool
+	}{
+		{name: "unset", raw: `{}`},
+		{name: "token", raw: `{"wire":{"reasoning_scope":"prod-eu"}}`},
+		{name: "token with a separator",
+			raw: `{"wire":{"reasoning_scope":"openai/gpt-5.6-sol"}}`},
+		{name: "surrounding whitespace",
+			raw: `{"wire":{"reasoning_scope":" prod"}}`, wantErr: true},
+		{name: "control character",
+			raw: `{"wire":{"reasoning_scope":"prod\neu"}}`, wantErr: true},
+		{name: "over the cap",
+			raw:     `{"wire":{"reasoning_scope":"` + strings.Repeat("x", 129) + `"}}`,
+			wantErr: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := decodeSpec(context.Background(), []byte(tc.raw))
+			if tc.wantErr && err == nil {
+				t.Fatal("decodeSpec succeeded, want an error")
+			}
+			if !tc.wantErr && err != nil {
+				t.Fatalf("decodeSpec: %v", err)
+			}
+		})
+	}
+}
+
+// assertNoReasoningItem checks that no reasoning item reached the request.
+func assertNoReasoningItem(t *testing.T, compiled inference.Compiled[*responsesRequest]) {
+	t.Helper()
+	for _, item := range compiled.Wire.params.Input.OfInputItemList {
+		if item.OfReasoning != nil {
+			t.Fatalf("dropped reasoning reached the request: %+v", item)
+		}
+	}
+}

--- a/driver/openai/spec.go
+++ b/driver/openai/spec.go
@@ -7,6 +7,7 @@ import (
 	"regexp"
 	"strings"
 	"time"
+	"unicode"
 
 	"github.com/GizClaw/flowcraft/core/inference/model"
 	"github.com/GizClaw/flowcraft/core/resource"
@@ -98,6 +99,13 @@ type AuthSpec struct {
 // derived default, so the driver cross-checks the combination against the
 // catalog's capability declarations before serving any request.
 type WireSpec struct {
+	// ReasoningScope declares the verification scope this deployment's
+	// reasoning traces belong to. It replaces the derived scope — provider,
+	// model, and credential profile — so an operator who has verified that
+	// several models or credentials decrypt and verify each other's traces
+	// says so once. Unset keeps the conservative derived scope, which never
+	// replays a trace across a model or an account.
+	ReasoningScope string `json:"reasoning_scope,omitempty"`
 	// VideoInput allows video content parts, a compatible-endpoint extension:
 	// OpenAI's own schema has no video content part. Only the Chat
 	// Completions surface lowers it today (as `video_url`), and only when a
@@ -259,6 +267,9 @@ func (s Spec) Validate() error {
 		return fmt.Errorf(
 			"wire.video_input requires api \"chat\": the responses surface has no video input lowering",
 		)
+	}
+	if err := validateReasoningScope(s.Wire.ReasoningScope); err != nil {
+		return err
 	}
 	if err := validateBodyFields("wire.extra_body", s.Wire.ExtraBody); err != nil {
 		return err
@@ -456,6 +467,35 @@ func (s Spec) declaresGenerateModel() bool {
 		}
 	}
 	return false
+}
+
+// maxReasoningScopeLen bounds the declared scope token. The token lands in a
+// compile-report reason, so it stays short and printable.
+const maxReasoningScopeLen = 128
+
+// validateReasoningScope checks the declared verification scope: opaque to
+// the driver, but never surrounding-whitespace sensitive (the comparison is
+// exact), never a control character, and never unbounded.
+func validateReasoningScope(scope string) error {
+	if scope == "" {
+		return nil
+	}
+	if strings.TrimSpace(scope) != scope {
+		return fmt.Errorf("wire.reasoning_scope must not have surrounding whitespace")
+	}
+	if len(scope) > maxReasoningScopeLen {
+		return fmt.Errorf(
+			"wire.reasoning_scope is %d bytes, at most %d are allowed",
+			len(scope), maxReasoningScopeLen,
+		)
+	}
+	for _, char := range scope {
+		if unicode.IsControl(char) {
+			return fmt.Errorf(
+				"wire.reasoning_scope must not contain control characters")
+		}
+	}
+	return nil
 }
 
 func decodeSpec(ctx context.Context, raw []byte) (Spec, error) {

--- a/driver/openai/spec_layers_test.go
+++ b/driver/openai/spec_layers_test.go
@@ -249,15 +249,16 @@ func TestCatalogRejectsUnsupportedInputModalities(t *testing.T) {
 // as reasoning_text content without the encrypted-payload include, and the
 // decoder reads it back.
 func TestReasoningTextChannelRoundTrip(t *testing.T) {
-	entry := catalog["gpt-5.6-sol"]
+	entry := scopedEntry(catalog["gpt-5.6-sol"], "gpt-5.6-sol")
 	entry.dialect.reasoningChannel = channelText
 	entry.dialect.omitReasoningPayload = true
+	scope := entry.reasoningScope
 
 	request := simpleTextRequest("current")
 	request.Context = []message.Message{{
 		Role: message.RoleAssistant,
 		Content: message.Content{Parts: []message.Part{
-			message.ReasoningPart{Text: "plain trace", ID: "rs_1"},
+			message.ReasoningPart{Text: "plain trace", ID: "rs_1", Source: scope},
 			message.TextPart{Text: "answer"},
 		}},
 	}}

--- a/skills/flowcraft-config/references/resources.md
+++ b/skills/flowcraft-config/references/resources.md
@@ -21,6 +21,7 @@ spec:
     scheme: header      # "bearer" (default), "header", or "none" (no credential)
     header: Api-Key
   wire:                 # dialect this endpoint speaks
+    reasoning_scope: openai-prod-shared   # optional: one verification scope for this deployment's reasoning traces
     video_input: true   # requires api: chat; with a model declaring video input, carries video_url parts
     extra_body:         # unmodeled body fields applied to every request (sjson paths, raw JSON)
       thinking: {type: enabled}
@@ -146,6 +147,16 @@ deployment value, a nested path updates the object it wrote. The metadata
 envelope field cannot be written by either, and a `catalog: declared`
 deployment with no generate model is rejected — `extra_body` rides the
 generate surfaces, so it would otherwise never apply.
+
+`wire.reasoning_scope` declares the verification scope of this deployment's
+reasoning traces (the Anthropic driver takes it in `wire` too; Bytedance takes
+`reasoning_scope` at the top level of `spec`, since its spec is flat). Drivers
+stamp every trace they produce and replay a stored one only when the target's
+scope matches; the derived default is `provider/model/profile`, so nothing
+crosses a model or an account by accident. Set the key when you have verified
+that several models or credentials accept each other's traces: reasoning
+payloads are verified against the model and account that minted them, and a
+mismatch is a provider 400 that no retry can repair.
 
 ## inference assembly
 


### PR DESCRIPTION
## Why

A reasoning trace is signed or encrypted by the model and account that
produced it, and providers verify it on round-trip: Anthropic validates a
thinking block's signature, OpenAI validates a reasoning item's id and
encrypted content. Nothing in the canonical trace said who produced it, so
drivers decided whether to replay one from its *shape* — and shape is what
makes a foreign payload look legal. An OpenAI encrypted blob carries a
signature slot too, so the Anthropic driver forwarded it as a thinking
signature and the endpoint rejected the whole request.

That rejection is terminal for the conversation: it classifies as validation,
which is neither retryable nor fallback-eligible, and the trace stays in the
history, so every later turn fails the same way. This is reachable through the
shipped example: chat with `openai/gpt-5.6-luna`, then `/model
minimax/minimax-m3`, and the next turn replays an OpenAI reasoning item to an
Anthropic-compatible endpoint.

## What changed

### 1. `feat(core/inference)`: stamp reasoning traces with a verification scope

Records provenance without changing any request shape:

- `message.ReasoningPart.Source` — an opaque verification-scope token, carried
  through the part's wire form (so stored transcripts keep it).
- `inference.ReasoningScope(declared, provider, model, profile)` — the scope of
  one addressed model: the deployment's declared token when it has one,
  otherwise `provider/model/profile`.
- `inference.WithReasoningSource` / `WithReasoningDeltaSource` — the decode-side
  wrappers that stamp what a driver produced (unary and stream; the stream
  accumulator carries the stamp onto the assembled part).
- All three generate drivers stamp at the model-open site: openai (responses
  and chat), anthropic, bytedance. Declared scope: `wire.reasoning_scope` for
  openai and anthropic, `reasoning_scope` at the top level of bytedance's flat
  spec.

### 2. `fix(core/inference)`: replay only where a trace can be verified

- openai and anthropic check provenance **before** the shape rules. A trace
  another scope minted, and a trace with no provenance at all (stored before
  this rule), are dropped with both scopes named on the compile report instead
  of being sent.
- Same-scope replay is unchanged: responses still needs id + encrypted payload
  (or text on the plain-text channel), anthropic still needs a signature,
  bytedance still consumes no reasoning input.

## Design notes

- **The scope names what can verify the trace, not what produced it nicely.**
  The derived token includes the model because Anthropic binds a thinking
  signature to the model, and because cross-model reuse is undocumented for
  the endpoints we cannot test. Switching models inside one deployment
  therefore drops the previous model's traces by default — the assistant text
  stays, only thinking continuity is lost.
- **A deployment can declare a shared scope** (`wire.reasoning_scope`,
  `reasoning_scope`) once it has verified that several models or credentials
  accept each other's traces; every model of that deployment then shares it.
  The declared token replaces the derived one entirely.
- **Dropping, not rejecting:** the request proceeds with the trace omitted, the
  same "partial context" semantics the drivers already use for parts a surface
  cannot carry.

## Upgrade note

A transcript stored before this change carries traces without a scope, so
those traces are dropped rather than replayed. The assistant text is
untouched — only thinking continuity is lost — and the conversation no longer
risks a provider rejection it cannot recover from. Documented in
`docs/guides/inference.md` under "Reasoning provenance".

## Verification

- `make ci`, `make lint` (0 issues), `make release-check`, `git diff --check`
  green.
- Commit 1 was also verified alone (`core/inference`, `core/message`, and all
  three drivers in an isolated worktree), so it is a genuine no-op.
- Tests cover the motivating case end to end: a foreign signed trace is
  dropped and never reaches the thinking block; the deployment's own trace
  still round-trips; an unstamped trace is dropped; a declared shared scope
  replays; model switches drop; the stream path stamps.

Closes #527.
